### PR TITLE
fix(SD-LEO-FIX-SWITCH-CLAIM-RPC-001): switch_sd_claim existence + terminal-status guards

### DIFF
--- a/database/migrations/20260609_switch_sd_claim_existence_terminal_guards.sql
+++ b/database/migrations/20260609_switch_sd_claim_existence_terminal_guards.sql
@@ -1,0 +1,154 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-FIX-SWITCH-CLAIM-RPC-001
+-- switch_sd_claim RPC: existence + terminal-status guards for the NEW claim target.
+--
+-- Bug (PAT-OPTIMISTIC-RPC): switch_sd_claim took a free-form p_new_sd_id like claim_sd p_sd_id
+-- but had NO existence guard and NO terminal-status guard. Its SD-side UPDATE keyed
+-- WHERE sd_key=p_new_sd_id with no NOT FOUND check (a phantom/typo id matched zero SD rows
+-- yet the claude_sessions UPDATE still wrote sd_key=p_new_sd_id), and no terminal check (a
+-- claim could be switched onto a completed/cancelled/deferred SD). This adds, BEFORE any
+-- UPDATE, the same two guards that landed on the sibling claim_sd RPC this session
+-- (SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 existence + SD-LEO-FIX-CLAIM-RPC-TERMINAL-001 terminal),
+-- using identical error codes (sd_not_found / sd_terminal_status) and terminal sets
+-- (SD={completed,cancelled,deferred}; QF={completed,cancelled,escalated}).
+--
+-- The ENTIRE live function body is carried BYTE-VERBATIM (proven: reversing the 2 inserts
+-- reproduces pg_get_functiondef exactly). Function-only CREATE OR REPLACE with the unchanged
+-- switch_sd_claim(text,text,text,text) signature, SECURITY DEFINER + search_path preserved,
+-- so EXECUTE grants (postgres, service_role) are preserved.
+
+CREATE OR REPLACE FUNCTION public.switch_sd_claim(p_session_id text, p_old_sd_id text, p_new_sd_id text, p_new_track text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_session RECORD;
+  v_conflict RECORD;
+  v_new_is_qf boolean := p_new_sd_id LIKE 'QF-%';
+  v_new_sd_status text;
+  v_new_qf_status text;
+BEGIN
+  SELECT * INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id
+    AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Session not found or not active'
+    );
+  END IF;
+
+  IF v_session.sd_key IS DISTINCT FROM p_old_sd_id THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Session does not hold claim on %s (current: %s)', p_old_sd_id, COALESCE(v_session.sd_key, 'none'))
+    );
+  END IF;
+
+  SELECT session_id, sd_key INTO v_conflict
+  FROM claude_sessions
+  WHERE sd_key = p_new_sd_id
+    AND status IN ('active', 'idle')
+    AND session_id != p_session_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('SD %s is already claimed by session %s', p_new_sd_id, v_conflict.session_id),
+      'conflict_session_id', v_conflict.session_id
+    );
+  END IF;
+
+  -- SD-LEO-FIX-SWITCH-CLAIM-RPC-001: existence + terminal-status guards for the NEW target.
+  -- switch_sd_claim was OPTIMISTIC (PAT-OPTIMISTIC-RPC) -- a phantom/typo p_new_sd_id matched zero
+  -- SD rows in the SD-side UPDATE below, yet the claude_sessions UPDATE still wrote sd_key=p_new_sd_id;
+  -- and a claim could be switched onto a completed/cancelled/deferred SD. These guards fire BEFORE any
+  -- UPDATE. Mirrors claim_sd (SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 + SD-LEO-FIX-CLAIM-RPC-TERMINAL-001):
+  -- same error codes (sd_not_found / sd_terminal_status) and same terminal sets.
+  IF NOT v_new_is_qf THEN
+    SELECT sd.status INTO v_new_sd_status
+      FROM strategic_directives_v2 sd
+     WHERE sd.sd_key = p_new_sd_id
+       FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[SWITCH_SD_NOT_FOUND] SD %s does not exist in strategic_directives_v2 -- refusing to switch a claim onto a phantom id.', p_new_sd_id));
+    END IF;
+    IF v_new_sd_status IN ('completed', 'cancelled', 'deferred') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_new_sd_status,
+        'message', format('[SWITCH_SD_TERMINAL] SD %s is in terminal status %s -- refusing to switch a claim onto a finished/cancelled/deferred SD.', p_new_sd_id, v_new_sd_status));
+    END IF;
+  ELSE
+    SELECT qf.status INTO v_new_qf_status FROM quick_fixes qf WHERE qf.id = p_new_sd_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[SWITCH_QF_NOT_FOUND] Quick-fix %s does not exist in quick_fixes -- refusing to switch a claim onto a phantom id.', p_new_sd_id));
+    END IF;
+    IF v_new_qf_status IN ('completed', 'cancelled', 'escalated') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_new_qf_status,
+        'message', format('[SWITCH_QF_TERMINAL] Quick-fix %s is in terminal status %s -- refusing to switch a claim onto a finished/cancelled/escalated quick-fix.', p_new_sd_id, v_new_qf_status));
+    END IF;
+  END IF;
+
+  IF p_old_sd_id LIKE 'QF-%' THEN
+    UPDATE quick_fixes
+    SET claiming_session_id = NULL
+    WHERE id = p_old_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+    SET claiming_session_id = NULL,
+        active_session_id = NULL,
+        is_working_on = false
+    WHERE sd_key = p_old_sd_id
+      AND (active_session_id = p_session_id OR claiming_session_id = p_session_id);
+  END IF;
+
+  UPDATE claude_sessions
+  SET
+    sd_key = p_new_sd_id,
+    track = COALESCE(p_new_track, track),
+    claimed_at = NOW(),
+    heartbeat_at = NOW(),
+    updated_at = NOW(),
+    worktree_path = NULL,
+    worktree_branch = NULL
+  WHERE session_id = p_session_id;
+
+  IF p_new_sd_id LIKE 'QF-%' THEN
+    UPDATE quick_fixes
+    SET claiming_session_id = p_session_id,
+        status = 'in_progress'
+    WHERE id = p_new_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+    SET active_session_id = p_session_id,
+        claiming_session_id = p_session_id,
+        is_working_on = true
+    WHERE sd_key = p_new_sd_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'old_sd_id', p_old_sd_id,
+    'new_sd_id', p_new_sd_id,
+    'switched_at', NOW()::TEXT
+  );
+END;
+$function$;

--- a/tests/database/switch-sd-claim-guards.test.js
+++ b/tests/database/switch-sd-claim-guards.test.js
@@ -1,0 +1,161 @@
+/**
+ * SD-LEO-FIX-SWITCH-CLAIM-RPC-001 — switch_sd_claim must reject phantom / terminal NEW targets.
+ *
+ * switch_sd_claim took a free-form p_new_sd_id like claim_sd but had NO existence guard and
+ * NO terminal-status guard. Its SD-side UPDATE keyed WHERE sd_key=p_new_sd_id with no NOT FOUND
+ * check (a phantom/typo id matched zero SD rows, yet the claude_sessions UPDATE still wrote
+ * sd_key=p_new_sd_id — a phantom self-switch), and no terminal check (a claim could be switched
+ * onto a completed/cancelled/deferred SD). The fix mirrors the sibling claim_sd guards
+ * (SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001 existence + SD-LEO-FIX-CLAIM-RPC-TERMINAL-001 terminal):
+ * the existence (sd_not_found) and terminal (sd_terminal_status) guards fire BEFORE any UPDATE,
+ * so the phantom/terminal probes are inherently net-zero (asserted explicitly).
+ *
+ * Live-DB integration test, gated like the other tests/database suites so CI skips cleanly
+ * without service-role creds. Net-zero: the probe session row is inserted in beforeAll and
+ * hard-deleted in afterAll; the only real-SD writes (the valid happy-path switch) are restored
+ * to their captured pre-state.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const PROBE_SESSION = 'test-switch-claim-guards-session';
+// A fixed phantom key the probe session "holds" as its old claim. switch_sd_claim only reads
+// claude_sessions for the old side (the old-side UPDATE is a no-op WHERE clause for this key),
+// so using a phantom old id keeps the old side net-zero without touching any real SD.
+const OLD_PHANTOM = 'SD-SWITCH-OLD-PROBE-000';
+
+async function firstSdWithStatus(status) {
+  const { data } = await supabase.from('strategic_directives_v2')
+    .select('sd_key').eq('status', status).limit(1);
+  return data && data[0] ? data[0].sd_key : null;
+}
+
+describe.skipIf(!HAS_REAL_DB)('switch_sd_claim rejects phantom/terminal NEW targets (SD-LEO-FIX-SWITCH-CLAIM-RPC-001)', () => {
+  beforeAll(async () => {
+    // Insert a dedicated probe session already holding the (phantom) old claim, status=active.
+    await supabase.from('claude_sessions').delete().eq('session_id', PROBE_SESSION);
+    await supabase.from('claude_sessions').insert({
+      session_id: PROBE_SESSION,
+      sd_key: OLD_PHANTOM,
+      status: 'active',
+      track: 'C',
+    });
+  });
+
+  afterAll(async () => {
+    // Hard-delete the probe session row → net-zero (we created it).
+    await supabase.from('claude_sessions').delete().eq('session_id', PROBE_SESSION);
+  });
+
+  async function switchTo(newId) {
+    return supabase.rpc('switch_sd_claim', {
+      p_session_id: PROBE_SESSION,
+      p_old_sd_id: OLD_PHANTOM,
+      p_new_sd_id: newId,
+      p_new_track: null,
+    });
+  }
+
+  it('returns sd_not_found for a phantom NEW SD id and does NOT write sd_key onto the session', async () => {
+    const { data, error } = await switchTo('SD-FAKE-SWITCH-TARGET-000');
+    expect(error).toBeNull();
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_not_found');
+    // CRITICAL: the phantom-self-switch bug — session.sd_key must still be the OLD claim, never the phantom NEW id.
+    const { data: sess } = await supabase.from('claude_sessions')
+      .select('sd_key').eq('session_id', PROBE_SESSION).maybeSingle();
+    expect(sess?.sd_key).toBe(OLD_PHANTOM);
+    expect(sess?.sd_key).not.toBe('SD-FAKE-SWITCH-TARGET-000');
+  });
+
+  it('returns sd_not_found for a phantom NEW QF id', async () => {
+    const { data, error } = await switchTo('QF-00000000-switch');
+    expect(error).toBeNull();
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_not_found');
+    const { data: sess } = await supabase.from('claude_sessions')
+      .select('sd_key').eq('session_id', PROBE_SESSION).maybeSingle();
+    expect(sess?.sd_key).toBe(OLD_PHANTOM);
+  });
+
+  it('rejects a completed NEW SD with sd_terminal_status and does NOT switch the claim', async () => {
+    const key = await firstSdWithStatus('completed');
+    if (!key) return; // env-dependent
+    // capture target claim state to prove net-zero
+    const { data: before } = await supabase.from('strategic_directives_v2')
+      .select('claiming_session_id, active_session_id, is_working_on').eq('sd_key', key).maybeSingle();
+    const { data, error } = await switchTo(key);
+    expect(error).toBeNull();
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('completed');
+    // net-zero: the terminal target's claim columns are unchanged (guard fired before any UPDATE)
+    const { data: after } = await supabase.from('strategic_directives_v2')
+      .select('claiming_session_id, active_session_id, is_working_on').eq('sd_key', key).maybeSingle();
+    expect(after?.claiming_session_id ?? null).toBe(before?.claiming_session_id ?? null);
+    expect(after?.active_session_id ?? null).toBe(before?.active_session_id ?? null);
+    expect(after?.is_working_on ?? null).toBe(before?.is_working_on ?? null);
+    // and the session still holds the OLD claim
+    const { data: sess } = await supabase.from('claude_sessions')
+      .select('sd_key').eq('session_id', PROBE_SESSION).maybeSingle();
+    expect(sess?.sd_key).toBe(OLD_PHANTOM);
+  });
+
+  it('rejects a cancelled NEW SD with clean sd_terminal_status JSON (skipped if none exist)', async () => {
+    const key = await firstSdWithStatus('cancelled');
+    if (!key) return;
+    const { data, error } = await switchTo(key);
+    expect(error).toBeNull();
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('cancelled');
+  });
+
+  it('rejects a deferred NEW SD with sd_terminal_status (skipped if none exist)', async () => {
+    const key = await firstSdWithStatus('deferred');
+    if (!key) return;
+    const { data } = await switchTo(key);
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('sd_terminal_status');
+    expect(data?.status).toBe('deferred');
+  });
+
+  it('still switches onto a real unclaimed draft/active SD (guards do not break the happy path)', async () => {
+    const { data: cand } = await supabase.from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id, active_session_id, is_working_on')
+      .is('claiming_session_id', null).in('status', ['draft', 'active']).limit(1);
+    if (!cand || !cand[0]) return; // env-dependent
+    const key = cand[0].sd_key;
+    const { data, error } = await switchTo(key);
+    expect(error).toBeNull();
+    expect(data?.success).toBe(true);
+    expect(data?.new_sd_id).toBe(key);
+    // session now holds the NEW claim
+    const { data: sess } = await supabase.from('claude_sessions')
+      .select('sd_key').eq('session_id', PROBE_SESSION).maybeSingle();
+    expect(sess?.sd_key).toBe(key);
+
+    // ---- restore (net-zero) ----
+    // 1) reset the NEW SD's claim columns to their captured pre-state
+    await supabase.from('strategic_directives_v2').update({
+      claiming_session_id: cand[0].claiming_session_id,
+      active_session_id: cand[0].active_session_id,
+      is_working_on: cand[0].is_working_on,
+    }).eq('sd_key', key);
+    // 2) put the probe session back onto the phantom OLD claim for any subsequent assertions/teardown
+    await supabase.from('claude_sessions').update({ sd_key: OLD_PHANTOM })
+      .eq('session_id', PROBE_SESSION);
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors `claim_sd`'s existence + terminal-status guards onto its sibling RPC **`switch_sd_claim`** (PAT-OPTIMISTIC-RPC).

**Gap:** `switch_sd_claim` took a free-form `p_new_sd_id` exactly like `claim_sd`'s `p_sd_id` but had **no existence guard** (a phantom/typo id matched zero SD rows yet `UPDATE claude_sessions SET sd_key = p_new_sd_id` still wrote the phantom key) and **no terminal-status guard** (a claim could be switched onto a completed/cancelled/deferred SD).

**Fix:** function-only CREATE OR REPLACE adding, **before the SD-side UPDATE**: existence guard (`sd_not_found`) + terminal-status guard (`sd_terminal_status`; SD `{completed,cancelled,deferred}`, QF `{completed,cancelled,escalated}`). Same error codes/terminal-sets as `claim_sd`.

## Verification
- **Applied to prod + verified byte-identical** by the DATABASE sub-agent (live-sourced from `pg_get_functiondef`; base byte-verbatim via reverse-diff; signature/grants preserved).
- **6/6** net-zero behavioral tests against the live function (phantom→`sd_not_found` + no-write, terminal→`sd_terminal_status`, valid→success); **23/23** sibling `claim_sd` suites non-regression.
- Completes the claim-RPC guard family (validate-exists + terminal + refuse-live-foreign on `claim_sd`, now mirrored to `switch_sd_claim`). Follow-up: PAT-OPTIMISTIC-RPC sweep of `release_sd`/assignment RPCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)