### PR TITLE
fix(QF-20260609-493): make programmatic vision-scorer persist robust (score-only + JS persist)

### DIFF
--- a/lib/programmatic/vision-score-row.js
+++ b/lib/programmatic/vision-score-row.js
@@ -1,0 +1,73 @@
+/**
+ * Vision-score row builder for the programmatic (tool-loop) scorer.
+ * QF-20260609-493: extracted so the persist logic is unit-testable without the CLI.
+ *
+ * Root cause it serves: scripts/programmatic/vision-scorer.js used to ask the LLM to
+ * supabase_upsert AND then echo the score JSON in its final message. On the Gemini
+ * fallback the final message frequently omitted the JSON, so the caller saw
+ * "No JSON found in scorer output" and wrote nothing — even though --dry-run returned a
+ * valid score. The fix scores the model in score-only mode (final message = the JSON) and
+ * persists the row in JS via buildVisionScoreRow().
+ *
+ * @module lib/programmatic/vision-score-row
+ */
+
+/** Allowed values for eva_vision_scores.threshold_action (DB CHECK constraint). */
+export const THRESHOLD_ACTIONS = ['accept', 'minor_sd', 'gap_closure_sd', 'escalate'];
+
+/**
+ * Map the programmatic rubric's action (proceed/minor_sd/corrective_sd/block) onto the
+ * eva_vision_scores.threshold_action CHECK vocab. Already-canonical values pass through;
+ * anything unrecognised fails safe to 'escalate' (most conservative — never a constraint
+ * violation, which is what silently dropped the row before).
+ *
+ * @param {string} action
+ * @returns {string} one of THRESHOLD_ACTIONS
+ */
+export function mapThresholdAction(action) {
+  const MAP = { proceed: 'accept', minor_sd: 'minor_sd', corrective_sd: 'gap_closure_sd', block: 'escalate' };
+  if (MAP[action]) return MAP[action];
+  return THRESHOLD_ACTIONS.includes(action) ? action : 'escalate';
+}
+
+/**
+ * Extract and parse the score JSON object from a model's final text message.
+ * Returns null when no JSON object is present or it does not parse, so the caller can
+ * retry / fail loudly instead of throwing.
+ *
+ * @param {string} text
+ * @returns {Object|null}
+ */
+export function extractScoreJson(text) {
+  const m = (text || '').match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try {
+    return JSON.parse(m[0]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a fully-populated eva_vision_scores row. Supplies every NOT-NULL column that has
+ * no DB default (vision_id, total_score, dimension_scores, threshold_action,
+ * rubric_snapshot) — the model's old upsert omitted vision_id/rubric_snapshot, which is
+ * why valid scores failed to persist. iteration/scored_at/metadata fall back to their
+ * column defaults (metadata carries scoring_method, which is NOT a real column).
+ *
+ * @param {{scoreData: Object, visionId: string, archPlanId?: string|null, sdId: string}} args
+ * @returns {Object} insertable eva_vision_scores row
+ */
+export function buildVisionScoreRow({ scoreData, visionId, archPlanId, sdId }) {
+  return {
+    vision_id: visionId,
+    arch_plan_id: archPlanId ?? null,
+    sd_id: sdId,
+    total_score: scoreData.total_score,
+    dimension_scores: scoreData.dimension_scores ?? {},
+    threshold_action: mapThresholdAction(scoreData.action),
+    rubric_snapshot: { rubric: 'eva-5dim-v1', source: 'vision-scorer-programmatic' },
+    created_by: 'vision-scorer-programmatic',
+    metadata: { scoring_method: 'programmatic-ollama' },
+  };
+}

--- a/scripts/programmatic/vision-scorer.js
+++ b/scripts/programmatic/vision-scorer.js
@@ -16,8 +16,9 @@ import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import 'dotenv/config';
 import { parseArgs } from 'node:util';
 import { runProgrammaticTask } from '../../lib/programmatic/tool-loop.js';
-import { createSupabaseTool, createSupabaseUpsertTool } from '../../lib/programmatic/tools/supabase-tool.js';
+import { createSupabaseTool } from '../../lib/programmatic/tools/supabase-tool.js';
 import { createOllamaTool } from '../../lib/programmatic/tools/ollama-tool.js';
+import { extractScoreJson, buildVisionScoreRow } from '../../lib/programmatic/vision-score-row.js';
 
 const { values: args } = parseArgs({
   options: {
@@ -29,6 +30,13 @@ const { values: args } = parseArgs({
 const sdId = args['sd-id'];
 const dryRun = args['dry-run'];
 
+// QF-20260609-493: resolve the EHG portfolio vision/arch by KEY. eva_vision_documents has
+// NO is_active column, so the old `WHERE is_active = true LIMIT 1` matched nothing (or a
+// random venture vision) — a second reason the score never persisted. Default to the L1
+// portfolio docs; honour the same env overrides the LEAD-TO-PLAN vision gate uses.
+const VISION_KEY = process.env.LEO_VISION_KEY_OVERRIDE || 'VISION-EHG-L1-001';
+const ARCH_KEY = process.env.LEO_ARCH_KEY_OVERRIDE || 'ARCH-EHG-L1-001';
+
 if (!sdId) {
   console.error('Usage: node scripts/programmatic/vision-scorer.js --sd-id SD-XXX-001 [--dry-run]');
   process.exit(1);
@@ -38,7 +46,9 @@ const supabase = createSupabaseServiceClient();
 
 const tools = [
   createSupabaseTool(supabase),
-  createSupabaseUpsertTool(supabase),
+  // QF-20260609-493: NO upsert tool — the model scores only; the caller persists the row in
+  // JS (buildVisionScoreRow) so the model's final message is reliably the score JSON (the
+  // upsert tool round-trip is what made the Gemini fallback drop the JSON → "No JSON found").
   // SD-FDBK-FIX-VISION-SCORER-DETERMINISM-001 (FR-4): pin sampling on the LIVE
   // programmatic scoring path (seed matches the cloud-path VISION_SCORE_SEED=1729).
   createOllamaTool({ temperature: 0, seed: 1729 }),
@@ -51,7 +61,7 @@ const SYSTEM_PROMPT = `You are an EVA vision alignment scorer. Your task is to:
 4. Build a scoring prompt from the SD and dimensions
 5. Call call_local_llm with the scoring system prompt and built prompt
 6. Parse the score JSON from the response
-7. Persist the score using supabase_upsert on eva_vision_scores
+7. Do NOT call any upsert/persist tool — the caller persists the score row
 8. Output ONLY the final JSON: {"total_score": N, "action": "...", "dimension_scores": {...}}
 
 The score JSON from the LLM must have: total_score (0-100), action (one of: proceed, minor_sd, corrective_sd, block), dimension_scores (object).
@@ -72,32 +82,59 @@ const USER_PROMPT = `Score SD "${sdId}" against the EVA vision.
 
 Steps:
 1. Query strategic_directives_v2 WHERE sd_key = '${sdId}', select: title, description, strategic_objectives, key_changes, sd_type
-2. Query eva_vision_documents WHERE is_active = true, select: id, extracted_dimensions, vision_key, limit 1
-3. Query eva_architecture_plans WHERE is_active = true, select: id, extracted_dimensions, limit 1
+2. Query eva_vision_documents WHERE vision_key = '${VISION_KEY}', select: id, extracted_dimensions, vision_key, limit 1
+3. Query eva_architecture_plans WHERE plan_key = '${ARCH_KEY}', select: id, extracted_dimensions, limit 1
 4. Build scoring prompt using SD data + vision/arch dimensions
 5. Call call_local_llm with the EVA scoring rubric system prompt and your built prompt
 6. Parse JSON from the response (strip markdown fences if present)
-7. If dry_run flag detected, do NOT call supabase_upsert — just return the score
-8. Otherwise, upsert into eva_vision_scores: { sd_id: '${sdId}', total_score, dimension_scores, threshold_action: action, scoring_method: 'programmatic-ollama', created_by: 'vision-scorer-programmatic' }
-9. Output final JSON
+7. Do NOT call any upsert/persist tool — the caller persists the score row. Just return the score.
+8. Output ONLY the final score JSON`;
 
-${dryRun ? 'DRY RUN MODE: Skip the supabase_upsert call. Add dry_run: true to output.' : ''}`;
+// QF-20260609-493: score-only model + JS persist. Retry on an empty/non-JSON final
+// message (flaky Gemini fallback), then write the row ourselves — never silent-empty.
+const MAX_SCORE_ATTEMPTS = 3;
 
 try {
-  const result = await runProgrammaticTask(USER_PROMPT, tools, {
-    systemPrompt: SYSTEM_PROMPT,
-    dryRun,
-  });
-
-  // Extract JSON from result
-  const jsonMatch = result.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) {
-    console.error('No JSON found in scorer output:', result.substring(0, 200));
-    process.exit(1);
+  let scoreData = null;
+  let lastPreview = '';
+  for (let attempt = 1; attempt <= MAX_SCORE_ATTEMPTS; attempt++) {
+    const result = await runProgrammaticTask(USER_PROMPT, tools, { systemPrompt: SYSTEM_PROMPT, dryRun });
+    const parsed = extractScoreJson(result);
+    if (parsed && typeof parsed.total_score === 'number') { scoreData = parsed; break; }
+    lastPreview = (result || '').substring(0, 200);
+    if (attempt < MAX_SCORE_ATTEMPTS) await new Promise((r) => setTimeout(r, 1000 * attempt));
   }
 
-  const scoreData = JSON.parse(jsonMatch[0]);
-  if (dryRun) scoreData.dry_run = true;
+  // Fail LOUDLY (non-zero exit + structured error) so the caller can tell a scorer outage
+  // apart from a legitimate low score — never silent-empty (the old "No JSON found" bug).
+  if (!scoreData) {
+    console.error(JSON.stringify({
+      error: 'SCORER_NO_JSON', sd_id: sdId, attempts: MAX_SCORE_ATTEMPTS,
+      message: `vision-scorer produced no parseable score after ${MAX_SCORE_ATTEMPTS} attempts; no row written.`,
+      last_output_preview: lastPreview,
+    }));
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    scoreData.dry_run = true;
+  } else {
+    const { data: vis } = await supabase.from('eva_vision_documents').select('id').eq('vision_key', VISION_KEY).limit(1);
+    const visionId = vis?.[0]?.id;
+    if (!visionId) {
+      console.error(JSON.stringify({ error: 'SCORER_NO_ACTIVE_VISION', sd_id: sdId, vision_key: VISION_KEY,
+        message: `Vision document '${VISION_KEY}' not found; cannot persist vision score.` }));
+      process.exit(3);
+    }
+    const { data: arch } = await supabase.from('eva_architecture_plans').select('id').eq('plan_key', ARCH_KEY).limit(1);
+    const { error: insErr } = await supabase
+      .from('eva_vision_scores')
+      .insert(buildVisionScoreRow({ scoreData, visionId, archPlanId: arch?.[0]?.id, sdId }));
+    if (insErr) {
+      console.error(JSON.stringify({ error: 'SCORER_PERSIST_FAILED', sd_id: sdId, message: insErr.message }));
+      process.exit(4);
+    }
+  }
 
   console.log(JSON.stringify(scoreData));
   process.exit(0);

--- a/tests/unit/programmatic/vision-score-row.test.js
+++ b/tests/unit/programmatic/vision-score-row.test.js
@@ -1,0 +1,82 @@
+/**
+ * Tests for the programmatic vision-scorer persist helpers.
+ * QF-20260609-493 — the persist path must write a complete, constraint-valid row OR fail
+ * explicitly; it must never silently emit empty / drop the score.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  THRESHOLD_ACTIONS,
+  mapThresholdAction,
+  extractScoreJson,
+  buildVisionScoreRow,
+} from '../../../lib/programmatic/vision-score-row.js';
+
+describe('mapThresholdAction', () => {
+  it('maps the programmatic rubric vocab onto the DB CHECK vocab', () => {
+    expect(mapThresholdAction('proceed')).toBe('accept');
+    expect(mapThresholdAction('minor_sd')).toBe('minor_sd');
+    expect(mapThresholdAction('corrective_sd')).toBe('gap_closure_sd');
+    expect(mapThresholdAction('block')).toBe('escalate');
+  });
+
+  it('passes through already-canonical values', () => {
+    for (const a of THRESHOLD_ACTIONS) expect(mapThresholdAction(a)).toBe(a);
+  });
+
+  it('fails safe to escalate for unknown/undefined actions (never a constraint violation)', () => {
+    expect(mapThresholdAction('nonsense')).toBe('escalate');
+    expect(mapThresholdAction(undefined)).toBe('escalate');
+    expect(THRESHOLD_ACTIONS).toContain(mapThresholdAction('whatever'));
+  });
+});
+
+describe('extractScoreJson', () => {
+  it('parses the JSON object embedded in a model message', () => {
+    const text = 'Here is the score:\n```json\n{"total_score": 86, "action": "proceed"}\n```\nDone.';
+    expect(extractScoreJson(text)).toEqual({ total_score: 86, action: 'proceed' });
+  });
+
+  it('returns null when no JSON object is present (the empty-fallback case)', () => {
+    expect(extractScoreJson('Score persisted successfully. Nothing else to add.')).toBeNull();
+    expect(extractScoreJson('')).toBeNull();
+    expect(extractScoreJson(null)).toBeNull();
+  });
+
+  it('returns null on malformed JSON rather than throwing', () => {
+    expect(extractScoreJson('{ total_score: 86, ')).toBeNull();
+  });
+});
+
+describe('buildVisionScoreRow', () => {
+  const base = {
+    scoreData: { total_score: 86, action: 'proceed', dimension_scores: { innovation: 15 } },
+    visionId: 'vision-uuid',
+    archPlanId: 'arch-uuid',
+    sdId: 'SD-LEO-INFRA-SIZE-TIER-AWARE-001',
+  };
+
+  it('supplies every NOT-NULL column that has no DB default', () => {
+    const row = buildVisionScoreRow(base);
+    // vision_id + rubric_snapshot were the columns the old model upsert omitted.
+    for (const col of ['vision_id', 'total_score', 'dimension_scores', 'threshold_action', 'rubric_snapshot']) {
+      expect(row[col]).toBeDefined();
+      expect(row[col]).not.toBeNull();
+    }
+    expect(row.vision_id).toBe('vision-uuid');
+    expect(row.sd_id).toBe(base.sdId);
+    expect(row.total_score).toBe(86);
+  });
+
+  it('maps the action to a constraint-valid threshold_action', () => {
+    expect(buildVisionScoreRow(base).threshold_action).toBe('accept');
+    expect(THRESHOLD_ACTIONS).toContain(buildVisionScoreRow(base).threshold_action);
+  });
+
+  it('defaults arch_plan_id to null and dimension_scores to {} when absent', () => {
+    const row = buildVisionScoreRow({ ...base, archPlanId: undefined, scoreData: { total_score: 50, action: 'block' } });
+    expect(row.arch_plan_id).toBeNull();
+    expect(row.dimension_scores).toEqual({});
+    expect(row.threshold_action).toBe('escalate');
+  });
+});


### PR DESCRIPTION
## QF-20260609-493 — vision-scorer persist returns empty (blocks infra SD vision scoring)

**Symptom:** `scripts/programmatic/vision-scorer.js --dry-run` returned a valid score, but the real persist run consistently returned *"No JSON found in scorer output"* and wrote no `eva_vision_scores` row — permanently blocking infra SDs at the LEAD-TO-PLAN Vision Score Gate (witnessed on SD-LEO-INFRA-SIZE-TIER-AWARE-001).

### Four coupled root causes (filed QF estimated only #1)
1. **JSON-loss** — persist mode made a `supabase_upsert` tool round-trip; the model's final message (esp. the Gemini fallback) often omitted the score JSON → regex miss → silent-empty exit.
2. **Missing NOT NULL columns** — the model's upsert omitted `vision_id` and `rubric_snapshot` (both NOT NULL, no default).
3. **Action-vocab mismatch** — rubric emits `proceed/minor_sd/corrective_sd/block`; the `threshold_action` CHECK only allows `accept/minor_sd/gap_closure_sd/escalate`.
4. **Broken vision resolution** — prompt queried `eva_vision_documents WHERE is_active = true`, but that column doesn't exist (flag is `status='active'`; doc keyed by `vision_key`).

### Fix
- Model scores **only** (upsert tool removed → final message reliably the score JSON).
- Caller persists in JS via `buildVisionScoreRow()` — supplies every required column, **maps the action** onto the CHECK vocab, resolves vision/arch **by key** (`VISION-EHG-L1-001` / `ARCH-EHG-L1-001`, env-overridable).
- **Retries** up to 3× on an empty/non-JSON response, then **fails LOUDLY** (structured error + non-zero exit) — never silent-empty.
- Logic extracted to `lib/programmatic/vision-score-row.js` for unit testing.

### Verification
- **9 unit tests** pass (action mapping incl. fail-safe; JSON extraction incl. null/malformed; row-completeness).
- **Live-DB round-trip**: built row is constraint-valid, lands, and is found by the gate's read query (`sd_id` / latest `scored_at`); net-zero cleanup.
- `node --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)