### PR TITLE
fix(QF-20260609-774): PreToolUse guard for git --no-verify / --no-gpg-sign bypass (ENF-16)

### DIFF
--- a/scripts/hooks/lib/no-verify-guard.cjs
+++ b/scripts/hooks/lib/no-verify-guard.cjs
@@ -1,0 +1,41 @@
+/**
+ * --no-verify / --no-gpg-sign bypass-gate logic for pre-tool-enforce ENF-16 (QF-20260609-774).
+ *
+ * `git push --force` is gated by ENF-15, but --no-verify / --no-gpg-sign had NO programmatic
+ * block — a single flag skips the local pre-commit secret scan (Supabase JWT / OpenAI / Resend
+ * / Gemini key detection) and the CLAUDE.md-edit protection → data-leak exposure.
+ *
+ * Extracted so the matcher + override decision are unit-testable WITHOUT spawning the hook
+ * (which runs main() at load) — mirrors scripts/hooks/lib/force-push-branch.cjs. The hook owns
+ * audit + exit; this owns the pure decision.
+ *
+ * @module scripts/hooks/lib/no-verify-guard
+ */
+
+// Reuse the ENF-15 operative-command boundary: match only when `git` is the OPERATIVE command
+// (start-of-command or after a true shell separator — ; | & ( newline && ||), NOT after a bare
+// space or backtick. The flag must be a whitespace-delimited token (`\s--no-…\b`). This means a
+// quoted/MENTIONED `git … --no-verify` (e.g. inside `echo "…"`) is NOT operative → never blocks.
+const NO_VERIFY_RE = /(?:^|[;&|(\n]|&&|\|\|)\s*git\s+[^\n]*?\s--no-(?:verify|gpg-sign)\b/;
+
+/**
+ * Decide the ENF-16 outcome for a Bash command.
+ *
+ * Override: a single env var LEO_ALLOW_NO_VERIFY whose non-empty VALUE is the audited reason
+ * (mirrors `EMERGENCY_PUSH="critical: reason" git push`). Empty/unset → block.
+ *
+ * @param {string} cmd - the Bash command string
+ * @param {Object} [env=process.env] - environment carrying the LEO_ALLOW_NO_VERIFY override
+ * @returns {{matched: boolean, outcome?: 'block'|'override', reason?: string, flag?: string, overrideReason?: string|null}}
+ */
+function decideNoVerify(cmd, env = process.env) {
+  if (!NO_VERIFY_RE.test(cmd || '')) return { matched: false };
+  const overrideReason = ((env && env.LEO_ALLOW_NO_VERIFY) || '').trim();
+  const flag = /--no-gpg-sign\b/.test(cmd) ? 'no-gpg-sign' : 'no-verify';
+  if (overrideReason.length > 0) {
+    return { matched: true, outcome: 'override', reason: 'override_granted', flag, overrideReason };
+  }
+  return { matched: true, outcome: 'block', reason: 'no_verify_disallowed', flag, overrideReason: null };
+}
+
+module.exports = { NO_VERIFY_RE, decideNoVerify };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1326,6 +1326,32 @@ async function main() {
         }
       }
     }
+
+    // --- ENFORCEMENT 16: --no-verify / --no-gpg-sign Bypass Gate (QF-20260609-774) ---
+    // `git push --force` is gated by ENF-15, but --no-verify / --no-gpg-sign had NO programmatic
+    // block — a single flag skips the local pre-commit secret scan (Supabase JWT / OpenAI /
+    // Resend / Gemini key detection) and the CLAUDE.md-edit protection → data-leak exposure.
+    // Block by default; ONE audited override LEO_ALLOW_NO_VERIFY="<reason>" (single env var whose
+    // non-empty VALUE is the reason, mirroring EMERGENCY_PUSH). Decision logic + the operative-
+    // command regex live in lib/no-verify-guard.cjs (unit-tested); this owns audit + exit. Fail-open.
+    try {
+      const { decideNoVerify } = require('./lib/no-verify-guard.cjs');
+      const d = decideNoVerify(cmd, process.env);
+      if (d.matched) {
+        const meta = { flag: d.flag, decision_path: d.reason, override_reason: d.overrideReason };
+        const auditPromise = auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'ENF-16', 'no-verify/no-gpg-sign bypass gate: blocks pre-commit secret-scan / commit-signing bypass unless LEO_ALLOW_NO_VERIFY="<reason>"', d.outcome, meta);
+        if (d.outcome === 'block') {
+          process.stderr.write(`[ENF-16] BLOCKED --${d.flag} bypasses the pre-commit secret scan (Supabase/OpenAI/Resend/Gemini key detection) + CLAUDE.md-edit protection. Override: LEO_ALLOW_NO_VERIFY="<ticket: reason>" <your git command>\n`);
+          await auditAndExit(auditPromise, 2);
+        }
+        // override path: fire-and-forget audit (don't await); fall through
+      }
+    } catch (noVerifyErr) {
+      // Fail-open: any internal error in ENF-16 must NOT block tool execution.
+      if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+        process.stderr.write(`[pre-tool-enforce] ENF-16 errored (fail-open): ${noVerifyErr.message}\n`);
+      }
+    }
   }
 
   // --- ENFORCEMENT 10: Source-Side Telemetry Writer (SD-LEO-INFRA-WORKER-SOURCE-SIDE-001) ---

--- a/tests/unit/no-verify-guard.test.js
+++ b/tests/unit/no-verify-guard.test.js
@@ -1,0 +1,71 @@
+/**
+ * Tests for the ENF-16 --no-verify / --no-gpg-sign bypass gate (QF-20260609-774).
+ * The gate must block a git command that disables the pre-commit secret scan unless the
+ * audited LEO_ALLOW_NO_VERIFY="<reason>" override is set — and must NOT false-block a mere
+ * MENTION of the flag (e.g. inside an echo/quoted string), reusing the ENF-15 boundary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { decideNoVerify, NO_VERIFY_RE } = require('../../scripts/hooks/lib/no-verify-guard.cjs');
+
+const NO_OVERRIDE = { LEO_ALLOW_NO_VERIFY: '' };
+
+describe('decideNoVerify — blocking (no override)', () => {
+  it('blocks git commit --no-verify', () => {
+    const d = decideNoVerify('git commit -m "x" --no-verify', NO_OVERRIDE);
+    expect(d).toMatchObject({ matched: true, outcome: 'block', reason: 'no_verify_disallowed', flag: 'no-verify' });
+  });
+
+  it('blocks git push --no-verify', () => {
+    expect(decideNoVerify('git push origin main --no-verify', NO_OVERRIDE).outcome).toBe('block');
+  });
+
+  it('blocks git commit --no-gpg-sign and reports the flag', () => {
+    const d = decideNoVerify('git commit --no-gpg-sign -m x', NO_OVERRIDE);
+    expect(d.outcome).toBe('block');
+    expect(d.flag).toBe('no-gpg-sign');
+  });
+
+  it('blocks when git is operative after a shell separator', () => {
+    expect(decideNoVerify('cd repo && git commit --no-verify -m x', NO_OVERRIDE).outcome).toBe('block');
+    expect(decideNoVerify('false; git push --no-verify', NO_OVERRIDE).outcome).toBe('block');
+  });
+});
+
+describe('decideNoVerify — audited override', () => {
+  it('overrides when LEO_ALLOW_NO_VERIFY carries a non-empty reason', () => {
+    const d = decideNoVerify('git commit --no-verify -m x', { LEO_ALLOW_NO_VERIFY: 'QF-123: hook is broken, urgent' });
+    expect(d).toMatchObject({ matched: true, outcome: 'override', reason: 'override_granted' });
+    expect(d.overrideReason).toBe('QF-123: hook is broken, urgent');
+  });
+
+  it('does NOT override when the reason is whitespace-only (blocks)', () => {
+    expect(decideNoVerify('git commit --no-verify', { LEO_ALLOW_NO_VERIFY: '   ' }).outcome).toBe('block');
+  });
+
+  it('does NOT override when the env var is absent (blocks)', () => {
+    expect(decideNoVerify('git commit --no-verify', {}).outcome).toBe('block');
+  });
+});
+
+describe('decideNoVerify — no false-positives (operative-command boundary)', () => {
+  it('does not match a quoted MENTION of the flag (git not operative)', () => {
+    expect(decideNoVerify('echo "git commit --no-verify"', NO_OVERRIDE).matched).toBe(false);
+  });
+
+  it('does not match a non-git command that contains the flag substring', () => {
+    expect(decideNoVerify('grep -- --no-verify scripts/foo.sh', NO_OVERRIDE).matched).toBe(false);
+  });
+
+  it('does not match a plain git command without the flag', () => {
+    expect(decideNoVerify('git commit -m "normal commit"', NO_OVERRIDE).matched).toBe(false);
+    expect(decideNoVerify('git push origin main', NO_OVERRIDE).matched).toBe(false);
+  });
+
+  it('requires the flag to be a whitespace-delimited token (not a glued substring)', () => {
+    expect(decideNoVerify('git log --grep=--no-verifyish', NO_OVERRIDE).matched).toBe(false);
+    expect(NO_VERIFY_RE.test('git commit --no-verify')).toBe(true);
+  });
+});


### PR DESCRIPTION
## QF-20260609-774 — close the `--no-verify` / `--no-gpg-sign` bypass hole

**Symptom:** force-pushing is hard-gated by ENF-15 (`pre-tool-enforce.cjs`), but `--no-verify` / `--no-gpg-sign` had **no** programmatic block. A single flag skips the local pre-commit secret scan (Supabase JWT / OpenAI / Resend / Gemini key detection) and the CLAUDE.md-edit protection → **data-leak exposure**.

### Fix — ENF-16 (mirrors ENF-15)
- **Matcher** reuses the ENF-15 *operative-command boundary* (start-of-command or a true shell separator), and the flag must be a **whitespace-delimited token** — so a quoted/MENTIONED flag (e.g. inside `echo "…"`) never false-blocks.
- **Blocks by default** with ONE audited override: `LEO_ALLOW_NO_VERIFY="<reason>"` — a single env var whose non-empty **value is the reason**, mirroring `EMERGENCY_PUSH`.
- **Fail-open** (any internal error must not block tool execution); audited via `auditPermissionDecision` (`rule_code='ENF-16'`).
- Decision logic + regex extracted to `scripts/hooks/lib/no-verify-guard.cjs` (mirrors `lib/force-push-branch.cjs`) so they're unit-testable without spawning the hook.

### Verification
- **11 unit tests**: block (`commit`/`push`/`--no-gpg-sign`/post-separator) · audited override · whitespace-only-reason → block · unset → block · quoted-mention negative · non-git negative · glued-substring negative.
- **Live hook smoke**: `git commit --no-verify` → `[ENF-16] BLOCKED` exit 2; with `LEO_ALLOW_NO_VERIFY="reason"` → passes through; plain `git commit` → ignored.
- `node --check` clean on both files.

> Incidental: ENF-15 false-positives on a commit message whose line *starts with* `git push … --force` (newline is treated as an operative separator) — hit while committing this PR; flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)