### PR TITLE
feat(SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001): EVA scheduler staleness detector + SRE gauge

### DIFF
--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -43,6 +43,8 @@ function resolveThresholds(env) {
     // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: warn at 6 days (7-day hard-expiry looms); "looks alive" = 10 min.
     loopExpiryWarnMs: (Number(env.COORD_LOOP_EXPIRY_WARN_MIN) || 8640) * 60 * 1000,
     stalledLoopFreshMs: (Number(env.COORD_STALLED_LOOP_FRESH_MIN) || 10) * 60 * 1000,
+    // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001: EVA scheduler down if last_poll_at older than 15 min (~15 missed ~60s polls).
+    evaSchedulerStaleMs: (Number(env.COORD_EVA_SCHEDULER_STALE_MIN) || 15) * 60 * 1000,
   };
 }
 
@@ -170,6 +172,16 @@ async function gatherDetectorInputs(supabase, opts) {
     bundle.signals = data || [];
   } catch (_) { bundle.signals = []; }
 
+  // 5) eva_scheduler_heartbeat — the EVA dispatch scheduler's liveness row(s) for EVA_SCHEDULER_STALE
+  // (SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001). last_poll_at is the trustworthy anchor; status is
+  // intentionally NOT relied on (it freezes on the last value when the process dies). Fail-open → null.
+  try {
+    const { data } = await supabase
+      .from('eva_scheduler_heartbeat')
+      .select('id, instance_id, last_poll_at, status');
+    bundle.evaSchedulerHeartbeat = data || null;
+  } catch (_) { bundle.evaSchedulerHeartbeat = null; }
+
   return bundle;
 }
 
@@ -226,6 +238,8 @@ async function runAndLogDetectors(supabase, data, opts) {
       // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001
       loopExpiryWarnMs: thresholds.loopExpiryWarnMs,
       stalledLoopFreshMs: thresholds.stalledLoopFreshMs,
+      // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001
+      evaSchedulerStaleMs: thresholds.evaSchedulerStaleMs,
     });
   } catch (e) {
     console.warn(`   ⚠️  [COORD_DETECTORS_THREW] ${(e && e.message) || e} (non-fatal)`);

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -334,7 +334,7 @@ function detectStalledLoop(data) {
 /**
  * Run all detectors over an injected data bundle. PURE — no I/O.
  * @param {object} data
- * @param {object} [opts] - { now, replyStarvationMs, stuckWorkerMs, priorPhases, deployGapMs, loopExpiryWarnMs, stalledLoopFreshMs }
+ * @param {object} [opts] - { now, replyStarvationMs, stuckWorkerMs, priorPhases, deployGapMs, loopExpiryWarnMs, stalledLoopFreshMs, evaSchedulerStaleMs }
  * @returns {Array<{ event_type: string, severity: string, reason: string, evidence: object }>}
  */
 function runDetectors(data, opts) {
@@ -352,6 +352,8 @@ function runDetectors(data, opts) {
     // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: loop-liveness detectors (warning; advisory observability).
     { event_type: 'LOOP_EXPIRY_WARNING', severity: 'warning', res: detectLoopExpiry({ sessions: data && data.sessions, now }, { warnMs: opts.loopExpiryWarnMs }) },
     { event_type: 'STALLED_LOOP', severity: 'warning', res: detectStalledLoop({ sessions: data && data.sessions, unclaimedItems: data && data.unclaimedItems, now, freshMs: opts.stalledLoopFreshMs }) },
+    // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001: EVA scheduler staleness (warning; keyed on last_poll_at age, ignores the status lie).
+    { event_type: 'EVA_SCHEDULER_STALE', severity: 'warning', res: detectEvaSchedulerStale({ heartbeat: data && data.evaSchedulerHeartbeat, now }, { staleMs: opts.evaSchedulerStaleMs }) },
   ];
   return results
     .filter((r) => r.res.matched)
@@ -393,6 +395,55 @@ function detectInertWorkerRevival(data) {
   return { matched: false, reason: 'no_inert_spawn_requests', evidence: { threshold_ms: thresholdMs } };
 }
 
+// SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001: a read-only alarm for the EVA dispatch
+// scheduler going dark — the heartbeat row's status column freezes on its last value when
+// the process dies, so age (not status) is the only trustworthy liveness signal.
+/** Default EVA_SCHEDULER_STALE threshold (ms): 15 min. The scheduler polls every ~60s, so a
+ *  last_poll_at older than 15 min is ~15 missed polls — down, not a transient hiccup. */
+const DEFAULT_EVA_SCHEDULER_STALE_MS = 15 * 60 * 1000;
+
+/**
+ * EVA_SCHEDULER_STALE — the EVA dispatch scheduler (eva_scheduler_heartbeat) has stopped
+ * polling. Keyed PURELY on last_poll_at AGE, deliberately IGNORING the status column: a
+ * crashed scheduler leaves status='running' frozen (a stale lie) while last_poll_at stops
+ * advancing, so trusting status would mask the outage entirely. Flags when (now -
+ * last_poll_at) exceeds an env-tunable threshold (~15 min ≈ 15 missed ~60s polls). Modeled
+ * on detectDeployGap (a timestamp anchor). PURE — no I/O. Fail-open: a row with no usable
+ * last_poll_at, or no heartbeat row at all, is SKIPPED (never a false flag — a scheduler
+ * that was never deployed has nothing to alarm on). Accepts a single row, an array of rows,
+ * or nothing.
+ * @param {{ heartbeat?: (object|Array), now?: number }} data
+ * @param {{ staleMs?: number }} [opts]
+ * @returns {{ matched: boolean, reason: string, evidence: object }}
+ */
+function detectEvaSchedulerStale(data, opts) {
+  opts = opts || {};
+  const now = (data && data.now) ?? Date.now();
+  const staleMs = opts.staleMs ?? DEFAULT_EVA_SCHEDULER_STALE_MS;
+  const raw = data && data.heartbeat;
+  const rows = Array.isArray(raw) ? raw : (raw ? [raw] : []); // normalize row | rows | none
+  const stale = [];
+  for (const hb of rows) {
+    if (!hb) continue;
+    const pollMs = toMs(hb.last_poll_at);
+    if (!pollMs) continue;                 // unknown/unparseable last_poll_at → skip (fail-open)
+    const ageMs = now - pollMs;
+    if (ageMs <= staleMs) continue;        // polling recently → healthy (regardless of status)
+    if (stale.length < 10) {
+      stale.push({ instance_id: hb.instance_id ?? hb.id ?? null, last_poll_at: hb.last_poll_at, age_ms: ageMs, reported_status: hb.status ?? null });
+    }
+  }
+  if (stale.length === 0) {
+    return { matched: false, reason: 'eva_scheduler_polling_within_window', evidence: { threshold_ms: staleMs } };
+  }
+  const maxAge = stale.reduce((m, e) => Math.max(m, e.age_ms), 0);
+  return {
+    matched: true,
+    reason: 'eva_scheduler_heartbeat_stale',
+    evidence: { stale_count: stale.length, max_age_ms: maxAge, threshold_ms: staleMs, samples: stale, advisory: 'EVA dispatch scheduler has stopped polling (the status column may falsely read "running"); restart the scheduler process' },
+  };
+}
+
 module.exports = {
   DEFAULT_COORDINATOR_FRESH_MS,
   DEFAULT_REPLY_STARVATION_MS,
@@ -416,4 +467,7 @@ module.exports = {
   LOOP_ACTIVE_STATES,
   DEFAULT_LOOP_EXPIRY_WARN_MS,
   DEFAULT_STALLED_LOOP_FRESH_MS,
+  // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001
+  detectEvaSchedulerStale,
+  DEFAULT_EVA_SCHEDULER_STALE_MS,
 };

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -18,7 +18,8 @@ import { sourceableBacklog } from './lib/sourceable-backlog.mjs';
 import { readFileSync } from 'node:fs';
 import { computeReviewHealth } from '../lib/fleet/review-health.mjs';
 // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: reuse the pure detectors as the single source for the gauges.
-import { detectLoopExpiry, detectStalledLoop } from '../lib/coordinator/detectors.cjs';
+// SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001: + the EVA scheduler staleness detector.
+import { detectLoopExpiry, detectStalledLoop, detectEvaSchedulerStale } from '../lib/coordinator/detectors.cjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -159,6 +160,18 @@ try {
     : 'none (' + unclaimed.length + ' unclaimed)';
 } catch (e) { stalledLoopLine = 'unavailable (' + e.message + ')'; }
 
+// (d3) LIVENESS — EVA dispatch scheduler heartbeat (SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001).
+// Reuse the pure detector; keyed on last_poll_at AGE, ignoring the status column (it freezes
+// 'running' when the process dies). Fail-open per gauge.
+let evaSchedulerLine;
+try {
+  const { data: hb } = await db.from('eva_scheduler_heartbeat').select('id, instance_id, last_poll_at, status');
+  const ev = detectEvaSchedulerStale({ heartbeat: hb, now: t });
+  evaSchedulerLine = ev.matched
+    ? ev.evidence.stale_count + ' scheduler instance(s) DARK ⚠ last poll ' + ageStr(ev.evidence.max_age_ms) + ' ago — restart (status may falsely read "running")'
+    : ((hb && hb.length) ? 'polling (within ' + Math.round((Number(process.env.COORD_EVA_SCHEDULER_STALE_MIN) || 15)) + 'm window)' : 'no heartbeat row (scheduler not deployed)');
+} catch (e) { evaSchedulerLine = 'unavailable (' + e.message + ')'; }
+
 // (e) DEPENDENCY / CRITICAL-PATH — blocked vs ready, plus stale-blocked anomalies
 let depLine, depStale = [];
 try {
@@ -189,6 +202,7 @@ console.log('  FLOW (idle/work): ' + idleWorkLine);
 console.log('  LIVENESS (loop) : ' + loopLine + '  (live workers)');
 console.log('  LIVENESS (expiry): ' + loopExpiryLine);
 console.log('  LIVENESS (stall): ' + stalledLoopLine);
+console.log('  LIVENESS (eva)  : ' + evaSchedulerLine);
 console.log('  DEPENDENCY      : ' + depLine);
 for (const k of depStale.slice(0, 5)) console.log('      stale-blocked: ' + k);
 

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -14,6 +14,7 @@ import {
   detectClaimHalfWrite,
   detectLoopExpiry,
   detectStalledLoop,
+  detectEvaSchedulerStale,
   runDetectors,
 } from '../../../lib/coordinator/detectors.cjs';
 import {
@@ -157,6 +158,40 @@ describe('detectStalledLoop', () => {
   });
 });
 
+describe('detectEvaSchedulerStale', () => {
+  const fresh = { id: 1, instance_id: 'eva-1', last_poll_at: minsAgo(1), status: 'running' };
+  it('is quiet when the scheduler polled within the window (accepts a single row)', () => {
+    const r = detectEvaSchedulerStale({ heartbeat: fresh, now: NOW });
+    expect(r.matched).toBe(false);
+    expect(r.reason).toBe('eva_scheduler_polling_within_window');
+  });
+  it('fires when last_poll_at is older than the threshold', () => {
+    const aged = { id: 1, instance_id: 'eva-1', last_poll_at: minsAgo(45), status: 'running' };
+    const r = detectEvaSchedulerStale({ heartbeat: aged, now: NOW });
+    expect(r.matched).toBe(true);
+    expect(r.reason).toBe('eva_scheduler_heartbeat_stale');
+    expect(r.evidence.stale_count).toBe(1);
+    expect(r.evidence.samples[0].instance_id).toBe('eva-1');
+  });
+  it('IGNORES the status="running" lie — a crashed scheduler freezes status but stops polling', () => {
+    // The whole point: status reads "running" yet last_poll_at is 2h stale → MUST fire.
+    const lying = { id: 1, instance_id: 'eva-1', last_poll_at: minsAgo(120), status: 'running' };
+    const r = detectEvaSchedulerStale({ heartbeat: lying, now: NOW });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.samples[0].reported_status).toBe('running'); // captured for the operator, not trusted
+  });
+  it('fail-open: no heartbeat row, or an unparseable last_poll_at, never flags', () => {
+    expect(detectEvaSchedulerStale({ heartbeat: null, now: NOW }).matched).toBe(false);
+    expect(detectEvaSchedulerStale({ heartbeat: [], now: NOW }).matched).toBe(false);
+    expect(detectEvaSchedulerStale({ heartbeat: { id: 1, last_poll_at: null }, now: NOW }).matched).toBe(false);
+  });
+  it('accepts an array of rows and is env-tunable via opts.staleMs', () => {
+    const rows = [{ id: 1, instance_id: 'eva-1', last_poll_at: minsAgo(8), status: 'running' }];
+    expect(detectEvaSchedulerStale({ heartbeat: rows, now: NOW }).matched).toBe(false);                       // default 15m → no
+    expect(detectEvaSchedulerStale({ heartbeat: rows, now: NOW }, { staleMs: 5 * 60 * 1000 }).matched).toBe(true); // 5m → yes
+  });
+});
+
 describe('runDetectors', () => {
   it('returns only matched detectors with event_type + severity', () => {
     const data = {
@@ -180,6 +215,16 @@ describe('runDetectors', () => {
     expect(byType.LOOP_EXPIRY_WARNING?.severity).toBe('warning');
     expect(byType.STALLED_LOOP?.severity).toBe('warning');
   });
+  it('surfaces EVA_SCHEDULER_STALE (severity warning) when the heartbeat is dark', () => {
+    const data = {
+      coordinatorCount: 0, idleWorkers: 0, unclaimedItems: 0,
+      signals: [], claims: [], sdClaims: [], sessions: [],
+      evaSchedulerHeartbeat: { id: 1, instance_id: 'eva-1', last_poll_at: daysAgo(2), status: 'running' },
+    };
+    const byType = Object.fromEntries(runDetectors(data, { now: NOW }).map((m) => [m.event_type, m]));
+    expect(byType.EVA_SCHEDULER_STALE?.severity).toBe('warning');
+    expect(byType.EVA_SCHEDULER_STALE?.reason).toBe('eva_scheduler_heartbeat_stale');
+  });
 });
 
 describe('coordDetectorsEnabled', () => {
@@ -196,6 +241,9 @@ describe('coordDetectorsEnabled', () => {
     expect(resolveThresholds({}).stalledLoopFreshMs).toBe(10 * 60 * 1000);
     expect(resolveThresholds({ COORD_LOOP_EXPIRY_WARN_MIN: '120' }).loopExpiryWarnMs).toBe(120 * 60 * 1000);
     expect(resolveThresholds({ COORD_STALLED_LOOP_FRESH_MIN: '5' }).stalledLoopFreshMs).toBe(5 * 60 * 1000);
+    // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001: 15-min EVA scheduler staleness default, env-tunable.
+    expect(resolveThresholds({}).evaSchedulerStaleMs).toBe(15 * 60 * 1000);
+    expect(resolveThresholds({ COORD_EVA_SCHEDULER_STALE_MIN: '30' }).evaSchedulerStaleMs).toBe(30 * 60 * 1000);
   });
 });
 


### PR DESCRIPTION
## What

Adds a pure, read-only, fail-open `detectEvaSchedulerStale` detector keyed on `eva_scheduler_heartbeat.last_poll_at` AGE — deliberately ignoring the `status` column, because a crashed scheduler freezes `status='running'` while polls stop. The live row was dead **105 days** (since 2026-02-24) yet still read `status='running'` with no alarm.

## Changes
- **lib/coordinator/detectors.cjs**: `detectEvaSchedulerStale` + `DEFAULT_EVA_SCHEDULER_STALE_MS` (15m), registered in `runDetectors` as `EVA_SCHEDULER_STALE` (severity `warning`), exported.
- **lib/coordinator/coordination-events.cjs**: `resolveThresholds.evaSchedulerStaleMs` (env `COORD_EVA_SCHEDULER_STALE_MIN`, default 15) + `gatherDetectorInputs` SELECT + `runAndLogDetectors` passthrough.
- **scripts/coordinator-audit.mjs**: `LIVENESS (eva)` SRE gauge.
- **tests/unit/coordinator/detectors.test.js**: +6 cases (30 total) incl. the explicit `status='running'` lie case and fail-open paths.

## Verification
- 30/30 focused + 47/47 coordinator regression (TESTING sub-agent, evidence 69f440ee).
- Pure + fail-open: null/empty/unparseable inputs all return `matched:false`, never throw.
- Child of SD-LEO-INFRA-REVIVE-EVA-MASTER-001 — reuse-first, no new daemon, zero production blast radius (read-only/advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)