### PR TITLE
feat(SD-LEO-INFRA-SIZE-TIER-AWARE-001): tier-aware PRD exec_checklist seeding so fast SDs do not start sub-threshold

### DIFF
--- a/scripts/modules/handoff/extract-deliverables-from-prd.js
+++ b/scripts/modules/handoff/extract-deliverables-from-prd.js
@@ -14,6 +14,24 @@
  * - Enables bi-directional sync between stories and deliverables
  */
 
+// SD-LEO-INFRA-SIZE-TIER-AWARE-001: tier-aware deliverable seeding. The PRD exec_checklist is a
+// fixed 6-item definition-of-done; for a small/fast SD (a 2-file bugfix) the size-irrelevant
+// items ("Development environment setup", "Integration tests completed") stay 'pending' and sink
+// the SCOPE_AUDIT coverage (4/6=67% < 80%), forcing every fast SD to manually flip them. Drop
+// those size-irrelevant items for small SD types so the seeded denominator matches the actual
+// scope. Fail-open: an unknown/large type keeps the full checklist (no behavior change for
+// feature/infrastructure SDs).
+export const SMALL_SD_TYPES = new Set(['fix', 'bugfix', 'hotfix', 'documentation']);
+export const SIZE_IRRELEVANT_DELIVERABLES = new Set([
+  'Development environment setup',
+  'Integration tests completed',
+]);
+
+export function filterChecklistForTier(checklist, sdType) {
+  if (!Array.isArray(checklist) || !SMALL_SD_TYPES.has(sdType)) return checklist;
+  return checklist.filter((item) => !SIZE_IRRELEVANT_DELIVERABLES.has(((item && item.text) || '').trim()));
+}
+
 /**
  * Extract deliverables from PRD and populate sd_scope_deliverables table
  *
@@ -66,11 +84,19 @@ export async function extractAndPopulateDeliverables(sdId, prd, supabase, option
       userStories.forEach(s => storyKeyToId.set(s.story_key, s.id));
     }
 
+    // SD-LEO-INFRA-SIZE-TIER-AWARE-001: drop size-irrelevant boilerplate for small SD types.
+    let sdTypeForTier = null;
+    try {
+      const { data: sdRow } = await supabase.from('strategic_directives_v2').select('sd_type').eq('id', sdId).single();
+      sdTypeForTier = sdRow?.sd_type ?? null;
+    } catch { /* fail-open: no SD type -> full checklist (no filtering) */ }
+    const execChecklist = filterChecklistForTier(prd.exec_checklist, sdTypeForTier);
+
     // PRIORITY: Extract from exec_checklist with user_story_ids (SD-DELIVERABLES-V2-001 Phase 2)
-    if (prd.exec_checklist && Array.isArray(prd.exec_checklist)) {
+    if (execChecklist && Array.isArray(execChecklist)) {
       let linkedCount = 0;
 
-      prd.exec_checklist.forEach((item, index) => {
+      execChecklist.forEach((item, index) => {
         // Resolve user_story_id from user_story_ids array
         let userStoryId = null;
         if (item.user_story_ids && Array.isArray(item.user_story_ids) && item.user_story_ids.length > 0) {

--- a/scripts/prd/prd-creator.js
+++ b/scripts/prd/prd-creator.js
@@ -39,6 +39,65 @@ export function truncateGoalSummary(text, limit = 300) {
   return truncated;
 }
 
+// SD-LEO-INFRA-SIZE-TIER-AWARE-001: the PRD exec_checklist seeds sd_scope_deliverables (via
+// extract-deliverables-from-prd at PLAN-TO-EXEC). A FIXED 6-item list put fast/small SDs at
+// 4/6 = 67% under the 80% SCOPE_AUDIT gate at PLAN-TO-LEAD, because items like "Development
+// environment setup" / "Integration tests completed" / a separate "Documentation updated"
+// deliverable simply do not apply to a focused 2-file bugfix — they sit `pending` and drag the
+// denominator. Size/tier-aware seeding makes the denominator match the actual work so a fast SD
+// that completes its real deliverables clears the gate without manual flip-the-boilerplate tax.
+const FULL_EXEC_CHECKLIST = [
+  'Development environment setup',
+  'Core functionality implemented',
+  'Unit tests written',
+  'Integration tests completed',
+  'Code review completed',
+  'Documentation updated',
+];
+// Fast/small SD types (bugfix/fix — where escalated QFs land) deliver a focused change: only the
+// genuinely-applicable subset is seeded.
+const FAST_EXEC_CHECKLIST = [
+  'Core functionality implemented',
+  'Unit tests written',
+  'Code review completed',
+];
+const FAST_SD_TYPES = new Set(['bugfix', 'fix']);
+
+/**
+ * Build the tier-aware PRD exec_checklist (deliverable denominator) for an SD type.
+ * Fast types (bugfix/fix) get the focused 3-item subset; everything else gets the full 6.
+ * Unknown/empty type falls back to the full list (no regression).
+ * @param {string} sdType
+ * @returns {Array<{text:string, checked:boolean}>}
+ */
+export function buildExecChecklist(sdType) {
+  const items = FAST_SD_TYPES.has(String(sdType || '').toLowerCase())
+    ? FAST_EXEC_CHECKLIST
+    : FULL_EXEC_CHECKLIST;
+  return items.map((text) => ({ text, checked: false }));
+}
+
+/**
+ * Resolve the SD's sd_type (best-effort) and build the tier-aware exec_checklist.
+ * Fail-safe: any lookup error degrades to the full checklist (current behavior).
+ * @param {Object} supabase
+ * @param {string} sdIdValue - SD primary key (UUID) or sd_key
+ * @returns {Promise<Array<{text:string, checked:boolean}>>}
+ */
+export async function resolveExecChecklist(supabase, sdIdValue) {
+  let sdType = null;
+  try {
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(sdIdValue || ''));
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_type')
+      .eq(isUuid ? 'id' : 'sd_key', sdIdValue)
+      .maybeSingle();
+    sdType = data?.sd_type || null;
+  } catch { /* fail-safe: fall through to full checklist */ }
+  return buildExecChecklist(sdType);
+}
+
 /**
  * Create initial PRD entry in database
  * @param {Object} supabase - Supabase client
@@ -105,14 +164,7 @@ export async function createPRDEntry(supabase, prdId, sdId, sdIdValue, prdTitle,
         { text: 'Timeline and milestones set', checked: false },
         { text: 'Risk assessment completed', checked: false }
       ],
-      exec_checklist: [
-        { text: 'Development environment setup', checked: false },
-        { text: 'Core functionality implemented', checked: false },
-        { text: 'Unit tests written', checked: false },
-        { text: 'Integration tests completed', checked: false },
-        { text: 'Code review completed', checked: false },
-        { text: 'Documentation updated', checked: false }
-      ],
+      exec_checklist: await resolveExecChecklist(supabase, sdIdValue),
       validation_checklist: [
         { text: 'All acceptance criteria met', checked: false },
         { text: 'Performance requirements validated', checked: false },
@@ -325,14 +377,7 @@ export async function createPRDWithValidatedContent(
       phase: 'planning',
       created_by: 'PLAN',
       plan_checklist: planChecklist,
-      exec_checklist: [
-        { text: 'Development environment setup', checked: false },
-        { text: 'Core functionality implemented', checked: false },
-        { text: 'Unit tests written', checked: false },
-        { text: 'Integration tests completed', checked: false },
-        { text: 'Code review completed', checked: false },
-        { text: 'Documentation updated', checked: false }
-      ],
+      exec_checklist: await resolveExecChecklist(supabase, sdIdValue),
       validation_checklist: [
         { text: 'All acceptance criteria met', checked: false },
         { text: 'Performance requirements validated', checked: false },

--- a/tests/unit/handoff/tier-aware-deliverables.test.js
+++ b/tests/unit/handoff/tier-aware-deliverables.test.js
@@ -1,0 +1,63 @@
+// SD-LEO-INFRA-SIZE-TIER-AWARE-001 — tier-aware deliverable seeding.
+// A small/fast SD's seeded sd_scope_deliverables must not include the size-irrelevant
+// boilerplate ("Development environment setup", "Integration tests completed") that stays
+// pending and sinks SCOPE_AUDIT coverage to 4/6=67%. filterChecklistForTier drops those for
+// small SD types and is a no-op for large types (feature/infrastructure) — fail-open.
+import { describe, it, expect } from 'vitest';
+import { filterChecklistForTier, SMALL_SD_TYPES, SIZE_IRRELEVANT_DELIVERABLES }
+  from '../../../scripts/modules/handoff/extract-deliverables-from-prd.js';
+
+const FULL_EXEC_CHECKLIST = [
+  { text: 'Development environment setup', checked: false },
+  { text: 'Core functionality implemented', checked: false },
+  { text: 'Unit tests written', checked: false },
+  { text: 'Integration tests completed', checked: false },
+  { text: 'Code review completed', checked: false },
+  { text: 'Documentation updated', checked: false },
+];
+
+describe('filterChecklistForTier (SD-LEO-INFRA-SIZE-TIER-AWARE-001)', () => {
+  it('drops size-irrelevant boilerplate for small SD types (4/4 instead of 4/6)', () => {
+    for (const type of ['fix', 'bugfix', 'hotfix', 'documentation']) {
+      const out = filterChecklistForTier(FULL_EXEC_CHECKLIST, type);
+      expect(out).toHaveLength(4);
+      const names = out.map((i) => i.text);
+      expect(names).not.toContain('Development environment setup');
+      expect(names).not.toContain('Integration tests completed');
+      // the real-scope items survive
+      expect(names).toContain('Core functionality implemented');
+      expect(names).toContain('Unit tests written');
+      expect(names).toContain('Code review completed');
+      expect(names).toContain('Documentation updated');
+    }
+  });
+
+  it('is a no-op for large SD types (feature/infrastructure keep the full DoD)', () => {
+    for (const type of ['feature', 'infrastructure', 'security', 'enhancement']) {
+      expect(filterChecklistForTier(FULL_EXEC_CHECKLIST, type)).toHaveLength(6);
+    }
+  });
+
+  it('fail-open: unknown/null/undefined type keeps the full checklist', () => {
+    expect(filterChecklistForTier(FULL_EXEC_CHECKLIST, null)).toHaveLength(6);
+    expect(filterChecklistForTier(FULL_EXEC_CHECKLIST, undefined)).toHaveLength(6);
+    expect(filterChecklistForTier(FULL_EXEC_CHECKLIST, 'totally-unknown-type')).toHaveLength(6);
+  });
+
+  it('non-array / empty input returned unchanged (no throw)', () => {
+    expect(filterChecklistForTier(null, 'bugfix')).toBe(null);
+    expect(filterChecklistForTier(undefined, 'bugfix')).toBe(undefined);
+    expect(filterChecklistForTier([], 'bugfix')).toEqual([]);
+  });
+
+  it('a custom (non-boilerplate) exec_checklist is untouched even for a small type', () => {
+    const custom = [{ text: 'Migrate claim_sd RPC', checked: true }, { text: 'Run regression', checked: true }];
+    expect(filterChecklistForTier(custom, 'bugfix')).toEqual(custom);
+  });
+
+  it('exported sets are sane', () => {
+    expect(SMALL_SD_TYPES.has('bugfix')).toBe(true);
+    expect(SMALL_SD_TYPES.has('feature')).toBe(false);
+    expect(SIZE_IRRELEVANT_DELIVERABLES.has('Development environment setup')).toBe(true);
+  });
+});

--- a/tests/unit/prd/prd-creator-exec-checklist.test.js
+++ b/tests/unit/prd/prd-creator-exec-checklist.test.js
@@ -1,0 +1,88 @@
+/**
+ * SD-LEO-INFRA-SIZE-TIER-AWARE-001 — tier-aware PRD exec_checklist seeding.
+ *
+ * The PRD exec_checklist becomes the sd_scope_deliverables denominator (via
+ * extract-deliverables-from-prd at PLAN-TO-EXEC). A fixed 6-item list put fast/small SDs at
+ * 4/6 = 67% under the 80% SCOPE_AUDIT gate. buildExecChecklist() makes the denominator
+ * size/tier-aware: fast types (bugfix/fix) get the focused 3-item subset; everything else gets
+ * the full 6. resolveExecChecklist() fetches sd_type and is fail-safe (errors -> full list).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { buildExecChecklist, resolveExecChecklist } from '../../../scripts/prd/prd-creator.js';
+
+const texts = (list) => list.map((i) => i.text);
+
+describe('buildExecChecklist — tier-aware deliverable denominator', () => {
+  it('bugfix → focused 3-item subset (no env-setup / integration-suite / separate-docs)', () => {
+    const list = buildExecChecklist('bugfix');
+    expect(texts(list)).toEqual(['Core functionality implemented', 'Unit tests written', 'Code review completed']);
+    expect(texts(list)).not.toContain('Development environment setup');
+    expect(texts(list)).not.toContain('Integration tests completed');
+    expect(texts(list)).not.toContain('Documentation updated');
+  });
+
+  it("fix → same focused 3-item subset (escalated QFs land as 'fix')", () => {
+    expect(texts(buildExecChecklist('fix'))).toHaveLength(3);
+  });
+
+  it('is case-insensitive (BUGFIX → fast)', () => {
+    expect(texts(buildExecChecklist('BUGFIX'))).toHaveLength(3);
+  });
+
+  it('feature → full 6-item checklist', () => {
+    const list = buildExecChecklist('feature');
+    expect(list).toHaveLength(6);
+    expect(texts(list)).toContain('Development environment setup');
+    expect(texts(list)).toContain('Integration tests completed');
+  });
+
+  it('infrastructure / security / database → full 6-item checklist', () => {
+    for (const t of ['infrastructure', 'security', 'database', 'refactor', 'enhancement']) {
+      expect(buildExecChecklist(t)).toHaveLength(6);
+    }
+  });
+
+  it('unknown / null / undefined type → full checklist (no regression)', () => {
+    expect(buildExecChecklist(null)).toHaveLength(6);
+    expect(buildExecChecklist(undefined)).toHaveLength(6);
+    expect(buildExecChecklist('')).toHaveLength(6);
+    expect(buildExecChecklist('totally-unknown-type')).toHaveLength(6);
+  });
+
+  it('every item has the {text, checked:false} shape', () => {
+    for (const item of buildExecChecklist('bugfix').concat(buildExecChecklist('feature'))) {
+      expect(item).toEqual({ text: expect.any(String), checked: false });
+    }
+  });
+});
+
+describe('resolveExecChecklist — sd_type lookup + fail-safe', () => {
+  const mockSb = (result) => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => result) })),
+      })),
+    })),
+  });
+
+  it('resolves a bugfix SD to the fast 3-item checklist', async () => {
+    const list = await resolveExecChecklist(mockSb({ data: { sd_type: 'bugfix' } }), '0d2216ca-50ac-48d1-9850-58926a3e53ed');
+    expect(list).toHaveLength(3);
+  });
+
+  it('resolves a feature SD to the full 6-item checklist', async () => {
+    const list = await resolveExecChecklist(mockSb({ data: { sd_type: 'feature' } }), 'SD-SOME-KEY-001');
+    expect(list).toHaveLength(6);
+  });
+
+  it('fail-safe: a lookup error degrades to the full checklist (no regression)', async () => {
+    const throwingSb = { from: vi.fn(() => { throw new Error('db down'); }) };
+    const list = await resolveExecChecklist(throwingSb, 'whatever');
+    expect(list).toHaveLength(6);
+  });
+
+  it('fail-safe: no matching SD (null data) degrades to the full checklist', async () => {
+    const list = await resolveExecChecklist(mockSb({ data: null }), 'SD-MISSING-001');
+    expect(list).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Problem
The PRD `exec_checklist` (scripts/prd/prd-creator.js) becomes the `sd_scope_deliverables` denominator (via extract-deliverables-from-prd at PLAN-TO-EXEC). It was a **fixed 6-item list** regardless of SD size, so a focused 2-file bugfix had inapplicable boilerplate ('Development environment setup', 'Integration tests completed', a separate 'Documentation updated') sitting `pending` → **4/6 = 67% < 80% SCOPE_AUDIT** at PLAN-TO-LEAD. Every fast SD/QF paid this tax manually (the single most recurrent harness-backlog friction, clears 7 reports).

## Fix
- `buildExecChecklist(sdType)`: fast types (`bugfix`/`fix`, where escalated QFs land) → focused 3-item subset [Core functionality / Unit tests / Code review]; all other types → full 6. Case-insensitive; unknown/null → full (no regression).
- `resolveExecChecklist(supabase, sdIdValue)`: fetches sd_type (UUID-or-sd_key aware), **fail-safe** (any lookup error degrades to the full list).
- Both call sites (`createPRDEntry` + `createPRDWithValidatedContent`) now seed via the resolver — no caller signature changes.

A fast bugfix now seeds 3 deliverables → completing its real work scores 3/3 = 100% and clears SCOPE_AUDIT.

## Grounding & tests
Grounded in live data (inspected `sd_scope_deliverables` on shipped fast SDs: the friction set is `extracted_from='prd'`, `priority='required'`, traced to prd-creator.js — a 4-agent mapping Workflow confirmed the full subsystem first). +11 unit tests (tier mapping, case-insensitivity, null/unknown fallback, resolver lookup + fail-safe); existing prd-creator-prevalidation suite green (5/5); TESTING evidence 16/16, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)