### PR TITLE
feat(SD-LEO-INFRA-REVIVE-EVA-SCHEDULER-SERVICE-001): one-shot supervisor cron that revives a dead EvaMasterScheduler

### DIFF
--- a/docs/06_deployment/eva-scheduler-watcher-cadence.md
+++ b/docs/06_deployment/eva-scheduler-watcher-cadence.md
@@ -53,12 +53,14 @@ one daemon:
 
 - **MF1 — atomic single-winner claim.** The revive is gated by a conditional UPDATE
   of the singleton row: `UPDATE eva_scheduler_heartbeat SET instance_id=<token>,
-  status='reviving', last_poll_at=now() WHERE id=1 AND (last_poll_at IS NULL OR
-  last_poll_at < now()-STALE)`. PostgreSQL row-locks serialize concurrent updaters;
-  the first sets `last_poll_at=now()` (fresh), so every later watcher's predicate no
-  longer matches and affects **0 rows**. Only the watcher that matched exactly one row
-  spawns. No advisory lock / pg pooler required — the conditional singleton UPDATE is
-  itself the atomic gate.
+  last_poll_at=now() WHERE id=1 AND (last_poll_at IS NULL OR last_poll_at <
+  now()-STALE)`. PostgreSQL row-locks serialize concurrent updaters; the first sets
+  `last_poll_at=now()` (fresh), so every later watcher's predicate no longer matches and
+  affects **0 rows**. Only the watcher that matched exactly one row spawns. No advisory
+  lock / pg pooler required — the conditional singleton UPDATE is itself the atomic gate.
+  The claim stamps only `instance_id` + `last_poll_at`; it does **not** write `status`
+  (that column carries a `CHECK (running|stopping|stopped)` and is owned by the daemon's
+  heartbeat — the daemon sets `running` on start).
 - **MF2 — confirm takeover.** After spawning, the watcher polls the heartbeat (up to
   8s) until `instance_id` moves off its supervisor token — the daemon stamps its own
   `scheduler-<hex>` on start. Confirmed → exit 0; timed out → exit 1 (the claim set

--- a/docs/06_deployment/eva-scheduler-watcher-cadence.md
+++ b/docs/06_deployment/eva-scheduler-watcher-cadence.md
@@ -1,0 +1,90 @@
+# EVA Scheduler Watcher — Cadence Contract & Runbook
+
+- **Category**: Report
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Author**: SD-LEO-INFRA-REVIVE-EVA-SCHEDULER-SERVICE-001
+- **Last Updated**: 2026-06-09
+- **Tags**: eva, scheduler, cron, supervisor, operations
+
+## What it is
+
+`scripts/cron/eva-scheduler-watcher.mjs` is a **one-shot supervisor** for the
+`EvaMasterScheduler` daemon (`lib/eva/eva-master-scheduler.js`, launched by
+`node scripts/eva-scheduler.js start`).
+
+The daemon is a long-lived foreground poller that guards itself only with an
+in-process flag — there is **no cross-process supervisor**. If the daemon process
+dies, its singleton heartbeat row (`eva_scheduler_heartbeat` id=1) freezes:
+`last_poll_at` stops advancing while `status` stays `'running'` (a lie). Nothing
+restarts it. This watcher closes that gap: one pass per invocation, it detects death
+by heartbeat **age** and relaunches the daemon — exactly once across any number of
+concurrent watchers.
+
+## Cadence contract
+
+| Property | Value |
+|---|---|
+| npm script | `npm run eva:scheduler:watch:cron` |
+| Invocation | `node scripts/cron/eva-scheduler-watcher.mjs --once` |
+| Recommended schedule | every **5 minutes** (matches the other `*:cron` watchers) |
+| Daemon poll interval | 60s (`EVA_SCHEDULER_POLL_INTERVAL_SECONDS`, default) |
+| Staleness threshold | 5 min (`EVA_SCHEDULER_STALE_MS`, default `300000`) |
+| Mode | one pass + exit (the cron re-invokes; **no** internal loop) |
+
+**Detection latency**: a dead daemon is revived within roughly
+`EVA_SCHEDULER_STALE_MS + watcher_interval` (≈5–10 min at the defaults). Keep the
+watcher interval **≤ `EVA_SCHEDULER_STALE_MS`** so every death is caught within one
+stale window. The threshold is intentionally ~5× the 60s poll interval so a single
+slow poll never trips a false revive.
+
+## Exit codes
+
+| Code | Meaning | Cron interpretation |
+|---|---|---|
+| `0` | Healthy — scheduler alive, revive confirmed, claim lost to a peer watcher, dry-run, or `EVA_SCHEDULER_ENABLED=false` | success, no alert |
+| `1` | Operational — heartbeat read/claim DB error, spawn error, or revive **unconfirmed** within 8s | transient; next tick retries. Alert only if it persists across consecutive ticks |
+| `2` | Fatal misconfiguration — missing `SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` | page the operator — host is misconfigured and **no** daemon was spawned |
+
+## Single-instance guarantee
+
+Multiple watchers (overlapping cron ticks, multiple hosts) **never** spawn more than
+one daemon:
+
+- **MF1 — atomic single-winner claim.** The revive is gated by a conditional UPDATE
+  of the singleton row: `UPDATE eva_scheduler_heartbeat SET instance_id=<token>,
+  status='reviving', last_poll_at=now() WHERE id=1 AND (last_poll_at IS NULL OR
+  last_poll_at < now()-STALE)`. PostgreSQL row-locks serialize concurrent updaters;
+  the first sets `last_poll_at=now()` (fresh), so every later watcher's predicate no
+  longer matches and affects **0 rows**. Only the watcher that matched exactly one row
+  spawns. No advisory lock / pg pooler required — the conditional singleton UPDATE is
+  itself the atomic gate.
+- **MF2 — confirm takeover.** After spawning, the watcher polls the heartbeat (up to
+  8s) until `instance_id` moves off its supervisor token — the daemon stamps its own
+  `scheduler-<hex>` on start. Confirmed → exit 0; timed out → exit 1 (the claim set
+  `last_poll_at=now`, so the next tick waits one stale window before re-revival).
+- **MF4 — creds guard + detached spawn.** SUPABASE creds are asserted **before** any
+  spawn so a misconfigured host fails fast (exit 2) instead of forking a
+  credential-less crash-loop. The daemon is spawned `detached`, `unref`'d, with
+  `windowsHide` and `stdio: 'ignore'` so it outlives the one-shot watcher cross-platform.
+
+## Environment
+
+| Var | Purpose |
+|---|---|
+| `SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` | required to read the heartbeat and to run the spawned daemon |
+| `EVA_SCHEDULER_STALE_MS` | staleness threshold in ms (default `300000`) |
+| `EVA_SCHEDULER_ENABLED` | `'false'` suppresses revival entirely (mirrors `eva-scheduler.js start`) |
+
+## Operations
+
+- **Manual check** (read-only): `npm run eva:scheduler:status` shows the live heartbeat
+  age and instance.
+- **Manual revive**: `npm run eva:scheduler:watch:cron` (safe to run anytime — no-op if
+  the daemon is alive; single-winner if a peer is also reviving).
+- **Dry run**: `node scripts/cron/eva-scheduler-watcher.mjs --dry-run` detects staleness
+  and performs the atomic claim but **skips the spawn** (note: a dry run still writes the
+  `reviving` claim to the heartbeat, briefly masking staleness for one stale window).
+- **Persistent exit 1**: the daemon is being spawned but never stamps its instance —
+  check the host can run `node scripts/eva-scheduler.js start` (env, dependencies) and
+  that `EVA_SCHEDULER_ENABLED` is not `false`.

--- a/docs/06_deployment/eva-scheduler-watcher-cadence.md
+++ b/docs/06_deployment/eva-scheduler-watcher-cadence.md
@@ -51,24 +51,31 @@ slow poll never trips a false revive.
 Multiple watchers (overlapping cron ticks, multiple hosts) **never** spawn more than
 one daemon:
 
-- **MF1 — atomic single-winner claim.** The revive is gated by a conditional UPDATE
-  of the singleton row: `UPDATE eva_scheduler_heartbeat SET instance_id=<token>,
-  last_poll_at=now() WHERE id=1 AND (last_poll_at IS NULL OR last_poll_at <
-  now()-STALE)`. PostgreSQL row-locks serialize concurrent updaters; the first sets
-  `last_poll_at=now()` (fresh), so every later watcher's predicate no longer matches and
-  affects **0 rows**. Only the watcher that matched exactly one row spawns. No advisory
-  lock / pg pooler required — the conditional singleton UPDATE is itself the atomic gate.
-  The claim stamps only `instance_id` + `last_poll_at`; it does **not** write `status`
-  (that column carries a `CHECK (running|stopping|stopped)` and is owned by the daemon's
-  heartbeat — the daemon sets `running` on start).
-- **MF2 — confirm takeover.** After spawning, the watcher polls the heartbeat (up to
-  8s) until `instance_id` moves off its supervisor token — the daemon stamps its own
-  `scheduler-<hex>` on start. Confirmed → exit 0; timed out → exit 1 (the claim set
-  `last_poll_at=now`, so the next tick waits one stale window before re-revival).
-- **MF4 — creds guard + detached spawn.** SUPABASE creds are asserted **before** any
-  spawn so a misconfigured host fails fast (exit 2) instead of forking a
-  credential-less crash-loop. The daemon is spawned `detached`, `unref`'d, with
-  `windowsHide` and `stdio: 'ignore'` so it outlives the one-shot watcher cross-platform.
+- **MF1 — atomic single-winner claim.** After the age-gate flags the heartbeat stale, the
+  revive is gated by a compare-and-swap on `instance_id`:
+  `UPDATE eva_scheduler_heartbeat SET instance_id=<token> WHERE id=1 AND
+  instance_id=<observed>`. PostgreSQL row-locks serialize concurrent watchers; the first
+  swaps the observed instance to its token, so every later watcher's CAS predicate no longer
+  matches and affects **0 rows**. On a **fresh deployment** (empty table) the claim instead
+  `INSERT`s the singleton (`status='stopped'`) — the primary key rejects the loser, so the
+  single-winner property holds there too. No advisory lock / pg pooler required. The claim
+  writes **only** `instance_id` — never `status` (that column carries a
+  `CHECK (running|stopping|stopped)` and is owned by the daemon, which sets `running` on
+  start), and never `last_poll_at` (see MF2).
+- **MF2 — confirm takeover, no false-"alive" mask.** Because the claim does **not** bump
+  `last_poll_at`, a failed spawn/confirm leaves the row stale so the **very next tick retries
+  immediately** (no 5-minute mask). After spawning, the watcher polls the heartbeat (up to
+  8s) until `instance_id` becomes a value that is **neither** the supervisor token **nor**
+  the pre-claim (observed) instance — the daemon stamps a fresh `scheduler-<hex>` on start.
+  Excluding the observed instance means a hung-but-alive **old** daemon that merely re-stamps
+  its original id does not falsely confirm. Confirmed → exit 0; timed out or the child exited
+  early → exit 1.
+- **MF4 — creds guard + observable detached spawn.** SUPABASE creds are asserted **before**
+  any spawn so a misconfigured host fails fast (exit 2) instead of forking a credential-less
+  crash-loop. The daemon is spawned `detached`, `unref`'d, with `windowsHide`, and its
+  stdout/stderr are redirected to `logs/eva-scheduler-daemon.log` (not discarded) with an
+  `exit` listener, so a startup crash is captured and reported instead of surfacing only as
+  an opaque confirm timeout.
 
 ## Environment
 
@@ -84,9 +91,13 @@ one daemon:
   age and instance.
 - **Manual revive**: `npm run eva:scheduler:watch:cron` (safe to run anytime — no-op if
   the daemon is alive; single-winner if a peer is also reviving).
-- **Dry run**: `node scripts/cron/eva-scheduler-watcher.mjs --dry-run` detects staleness
-  and performs the atomic claim but **skips the spawn** (note: a dry run still writes the
-  `reviving` claim to the heartbeat, briefly masking staleness for one stale window).
-- **Persistent exit 1**: the daemon is being spawned but never stamps its instance —
-  check the host can run `node scripts/eva-scheduler.js start` (env, dependencies) and
-  that `EVA_SCHEDULER_ENABLED` is not `false`.
+- **Dry run**: `node scripts/cron/eva-scheduler-watcher.mjs --dry-run` reports whether it
+  *would* revive — fully **read-only**, it mutates nothing (no claim, no spawn).
+- **Persistent exit 1**: the daemon is being spawned but never stamps a fresh instance —
+  read `logs/eva-scheduler-daemon.log` for the startup error, confirm the host can run
+  `node scripts/eva-scheduler.js start` (env, dependencies), and that `EVA_SCHEDULER_ENABLED`
+  is not `false`.
+- **Known follow-up**: the watcher prevents *concurrent watchers* from double-spawning, but
+  it cannot prevent a hung-but-alive **old daemon** from coexisting with a freshly spawned one
+  (the daemon has no cross-process start lock). True duplicate prevention requires the daemon
+  itself to take a `pg_advisory_lock` on start — tracked as a separate hardening item.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "quality:aggregate:cron": "node scripts/cron/quality-findings-aggregator.mjs",
     "cascade:watch:cron": "node scripts/cron/cascade-watcher.mjs --once",
     "leo:build:start:cron": "node scripts/cron/leo-build-starter.mjs --once",
+    "eva:scheduler:watch:cron": "node scripts/cron/eva-scheduler-watcher.mjs --once",
     "cascade:status": "node scripts/cron/cascade-status.mjs",
     "cascade:snapshot:capture": "node scripts/test-helpers/capture-crongenius-snapshot.mjs",
     "backfill:pr-tracking": "node scripts/backfill-pr-tracking.js",

--- a/scripts/__tests__/eva-scheduler-watcher.test.js
+++ b/scripts/__tests__/eva-scheduler-watcher.test.js
@@ -3,16 +3,18 @@
  *
  * SD: SD-LEO-INFRA-REVIVE-EVA-SCHEDULER-SERVICE-001
  *
- * Hermetic — no real DB, no real process spawn. A stateful singleton-row mock
- * simulates the ATOMIC conditional UPDATE that backs the single-instance guarantee
- * (MF1): claimRevival's `.update().eq().or().select()` applies the patch only when the
- * row still matches the staleness predicate, so a second concurrent claim against the
- * now-fresh row returns 0 rows. spawn is injected (deps.spawn) so the race test proves
- * "exactly one process spawned" without forking. Clock + sleep injected for determinism.
+ * Hermetic — no real DB, no real process spawn. A stateful singleton-row mock simulates
+ * the ATOMIC compare-and-swap that backs the single-instance guarantee (MF1): claimRevival
+ * either CAS-swaps instance_id (existing stale row) or INSERTs the singleton (fresh deploy),
+ * and the mock enforces the real status CHECK plus PK-conflict on a duplicate insert. spawn
+ * is injected so the race tests prove "exactly one process spawned" without forking; clock +
+ * sleep injected for determinism.
  *
- * Covers TS-1 (alive→noop), TS-2 (stale→revive), TS-3 (concurrency race→one spawn),
- * TS-4 (missing creds→exit 2), TS-5 (disabled→noop), TS-6 (dry-run→claim no spawn),
- * TS-7 (confirm via instance_id takeover), TS-8 (unconfirmed→exit 1).
+ * Covers TS-1..TS-12: alive→noop, stale→revive, race→one spawn, missing-creds→exit2,
+ * disabled→noop, dry-run→NO mutation, confirm via fresh instance_id, unconfirmed→exit1,
+ * fresh-deploy bootstrap + bootstrap race (the empty-table deadlock the adversarial review
+ * caught), failed-spawn leaves row stale (no 5-min mask), zombie old-instance exclusion,
+ * daemon early-exit capture.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -26,53 +28,57 @@ import {
 
 const FIXED = Date.parse('2026-06-09T22:00:00.000Z');
 const fixedNow = () => FIXED;
+const advancingNow = (start = FIXED, step = 600) => { let t = start; return () => (t += step); };
 const CREDS = { SUPABASE_URL: 'http://x', SUPABASE_SERVICE_ROLE_KEY: 'k' };
+const STALE_LAST_POLL = new Date(FIXED - 9_000_000).toISOString();
 
-// PostgREST `.or()` predicate evaluator for the single-table mock (last_poll_at.is.null,last_poll_at.lt.<iso>)
-function evalOr(orStr, row) {
-  if (!orStr) return true;
-  return orStr.split(',').some((clause) => {
-    const parts = clause.split('.');
-    const col = parts[0];
-    const op = parts[1];
-    const val = parts.slice(2).join('.'); // ISO timestamps contain dots — rejoin
-    if (op === 'is' && val === 'null') return row[col] == null;
-    if (op === 'lt') return row[col] != null && Date.parse(row[col]) < Date.parse(val);
-    return false;
-  });
-}
+const ALLOWED_STATUS = ['running', 'stopping', 'stopped'];
 
 /**
  * Stateful mock of the eva_scheduler_heartbeat singleton row.
- * @param initial row object or null (no heartbeat yet)
- * @param opts.readError / opts.claimError to simulate DB failures
+ * Simulates: maybeSingle read, CAS update (eq/is on instance_id), INSERT with PK conflict,
+ * and the real status CHECK constraint on both insert and update.
  */
 function makeHeartbeatDB(initial, opts = {}) {
   const state = { row: initial ? { ...initial } : null };
-  const calls = { updates: 0, reads: 0 };
+  const calls = { updates: 0, reads: 0, inserts: 0 };
   function from() {
-    let isUpdate = false; let patch = null; let orStr = null;
+    let op = null; let patch = null; let insertRow = null; let instanceIsNull = false;
+    const eqs = {};
     const builder = {
       select() {
-        if (isUpdate) {
+        if (op === 'update') {
           calls.updates++;
           if (opts.claimError) return Promise.resolve({ data: null, error: { message: 'claim boom' } });
-          // Enforce the REAL eva_scheduler_heartbeat_status_check (running|stopping|stopped).
-          // This is the regression guard for the prod bug live-dogfooding caught: a claim that
-          // sets status='reviving' violates the constraint and can NEVER succeed in production.
-          const ALLOWED_STATUS = ['running', 'stopping', 'stopped'];
           if (patch && patch.status != null && !ALLOWED_STATUS.includes(patch.status)) {
-            return Promise.resolve({ data: null, error: { message: 'new row violates check constraint "eva_scheduler_heartbeat_status_check"' } });
+            return Promise.resolve({ data: null, error: { message: 'violates check constraint "eva_scheduler_heartbeat_status_check"' } });
           }
           let matched = false;
-          if (state.row && evalOr(orStr, state.row)) { Object.assign(state.row, patch); matched = true; }
+          if (state.row && (eqs.id == null || state.row.id === eqs.id)) {
+            const instOk = instanceIsNull
+              ? state.row.instance_id == null
+              : (eqs.instance_id === undefined ? true : state.row.instance_id === eqs.instance_id);
+            if (instOk) { Object.assign(state.row, patch); matched = true; }
+          }
           return Promise.resolve({ data: matched ? [{ ...state.row }] : [], error: null });
+        }
+        if (op === 'insert') {
+          calls.inserts++;
+          if (insertRow && insertRow.status != null && !ALLOWED_STATUS.includes(insertRow.status)) {
+            return Promise.resolve({ data: null, error: { message: 'violates check constraint "eva_scheduler_heartbeat_status_check"' } });
+          }
+          if (state.row) {
+            return Promise.resolve({ data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "eva_scheduler_heartbeat_pkey"' } });
+          }
+          state.row = { ...insertRow };
+          return Promise.resolve({ data: [{ ...state.row }], error: null });
         }
         return builder;
       },
-      eq() { return builder; },
-      or(s) { orStr = s; return builder; },
-      update(p) { isUpdate = true; patch = p; return builder; },
+      eq(col, val) { eqs[col] = val; return builder; },
+      is(col, val) { if (col === 'instance_id' && val === null) instanceIsNull = true; return builder; },
+      update(p) { op = 'update'; patch = p; return builder; },
+      insert(r) { op = 'insert'; insertRow = r; return builder; },
       maybeSingle() {
         calls.reads++;
         if (opts.readError) return Promise.resolve({ data: null, error: { message: 'read boom' } });
@@ -85,9 +91,10 @@ function makeHeartbeatDB(initial, opts = {}) {
 }
 
 const freshRow = (instance = 'scheduler-aaaa1111') => ({ id: 1, instance_id: instance, status: 'running', last_poll_at: new Date(FIXED - 10_000).toISOString(), poll_count: 99 });
-const staleRow = (instance = 'scheduler-dead0000') => ({ id: 1, instance_id: instance, status: 'running', last_poll_at: new Date(FIXED - 9_000_000).toISOString(), poll_count: 533 });
+const staleRow = (instance = 'scheduler-dead0000') => ({ id: 1, instance_id: instance, status: 'running', last_poll_at: STALE_LAST_POLL, poll_count: 533 });
 
-const okSpawn = () => vi.fn(() => ({ pid: 4242, unref: vi.fn() }));
+const okSpawn = () => vi.fn(() => ({ pid: 4242, unref: vi.fn(), on: vi.fn() }));
+const crashSpawn = () => vi.fn(() => ({ pid: 7, unref: vi.fn(), on: (evt, cb) => { if (evt === 'exit') cb(1); } }));
 const silentLogger = { log: () => {}, warn: () => {}, error: () => {} };
 
 describe('parseArgs', () => {
@@ -112,77 +119,103 @@ describe('assertSpawnCreds', () => {
 
 describe('schedulerLiveness', () => {
   it('alive when last_poll_at within staleMs', async () => {
-    const db = makeHeartbeatDB(freshRow());
-    const r = await schedulerLiveness(db, { now: fixedNow, staleMs: 300_000 });
+    const r = await schedulerLiveness(makeHeartbeatDB(freshRow()), { now: fixedNow, staleMs: 300_000 });
     expect(r).toMatchObject({ ok: true, alive: true, exists: true });
     expect(r.ageMs).toBe(10_000);
   });
   it('stale when older than staleMs', async () => {
-    const db = makeHeartbeatDB(staleRow());
-    const r = await schedulerLiveness(db, { now: fixedNow, staleMs: 300_000 });
+    const r = await schedulerLiveness(makeHeartbeatDB(staleRow()), { now: fixedNow, staleMs: 300_000 });
     expect(r).toMatchObject({ ok: true, alive: false, exists: true });
   });
   it('absent (no row) → not alive, exists:false', async () => {
-    const db = makeHeartbeatDB(null);
-    const r = await schedulerLiveness(db, { now: fixedNow });
+    const r = await schedulerLiveness(makeHeartbeatDB(null), { now: fixedNow });
     expect(r).toMatchObject({ ok: true, alive: false, exists: false, ageMs: Infinity });
   });
   it('null last_poll_at → not alive (age Infinity)', async () => {
-    const db = makeHeartbeatDB({ id: 1, instance_id: 'x', last_poll_at: null });
-    const r = await schedulerLiveness(db, { now: fixedNow });
+    const r = await schedulerLiveness(makeHeartbeatDB({ id: 1, instance_id: 'x', last_poll_at: null }), { now: fixedNow });
     expect(r.alive).toBe(false);
     expect(r.ageMs).toBe(Infinity);
   });
   it('DB read error → ok:false', async () => {
-    const db = makeHeartbeatDB(staleRow(), { readError: true });
-    const r = await schedulerLiveness(db, { now: fixedNow });
+    const r = await schedulerLiveness(makeHeartbeatDB(staleRow(), { readError: true }), { now: fixedNow });
     expect(r.ok).toBe(false);
   });
 });
 
-describe('claimRevival (MF1 atomic single-winner)', () => {
-  it('wins on a stale row, stamps instance_id+last_poll_at, leaves status untouched (constraint-safe)', async () => {
-    const db = makeHeartbeatDB(staleRow());
-    const r = await claimRevival(db, { token: 'supervisor-t1', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+describe('claimRevival — MF1 CAS (existing row)', () => {
+  it('wins when observed instance still matches; swaps instance_id; leaves last_poll_at + status UNTOUCHED', async () => {
+    const db = makeHeartbeatDB(staleRow('scheduler-dead0000'));
+    const r = await claimRevival(db, { token: 'supervisor-t1', observedInstanceId: 'scheduler-dead0000', rowExists: true });
     expect(r.won).toBe(true);
     expect(db._state.row.instance_id).toBe('supervisor-t1');
-    expect(db._state.row.last_poll_at).toBe(new Date(FIXED).toISOString());
-    expect(db._state.row.status).toBe('running'); // NOT changed → never trips the status CHECK
+    expect(db._state.row.last_poll_at).toBe(STALE_LAST_POLL); // NOT bumped → immediate retry on failure
+    expect(db._state.row.status).toBe('running');             // never written → never trips the CHECK
   });
-  it('loses when row is already fresh (predicate no longer matches)', async () => {
-    const db = makeHeartbeatDB(freshRow());
-    const r = await claimRevival(db, { token: 'supervisor-t2', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+  it('loses when a peer already swapped the observed instance', async () => {
+    const db = makeHeartbeatDB(staleRow('peer-token'));
+    const r = await claimRevival(db, { token: 'supervisor-t2', observedInstanceId: 'scheduler-dead0000', rowExists: true });
     expect(r.won).toBe(false);
+    expect(db._state.row.instance_id).toBe('peer-token'); // untouched
   });
-  it('second claim against the same row loses after the first wins', async () => {
-    const db = makeHeartbeatDB(staleRow());
-    const a = await claimRevival(db, { token: 'A', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
-    const b = await claimRevival(db, { token: 'B', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+  it('second claim with the same observed loses after the first wins', async () => {
+    const db = makeHeartbeatDB(staleRow('scheduler-dead0000'));
+    const a = await claimRevival(db, { token: 'A', observedInstanceId: 'scheduler-dead0000', rowExists: true });
+    const b = await claimRevival(db, { token: 'B', observedInstanceId: 'scheduler-dead0000', rowExists: true });
     expect(a.won).toBe(true);
     expect(b.won).toBe(false);
     expect(db._state.row.instance_id).toBe('A');
   });
+  it('handles a null observed instance (CAS on instance_id IS NULL)', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: null, status: 'stopped', last_poll_at: STALE_LAST_POLL });
+    const r = await claimRevival(db, { token: 'T', observedInstanceId: null, rowExists: true });
+    expect(r.won).toBe(true);
+    expect(db._state.row.instance_id).toBe('T');
+  });
 });
 
-describe('confirmRevival (MF2)', () => {
-  it('confirmed when instance_id moves off our token', async () => {
-    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'reviving' });
-    // sleep simulates the daemon stamping its own instance on first poll
-    const sleep = vi.fn(async () => { db._state.row.instance_id = 'scheduler-new99'; db._state.row.status = 'running'; });
-    const r = await confirmRevival(db, { token: 'supervisor-t', sleep, now: fixedNow });
-    expect(r).toMatchObject({ confirmed: true, instanceId: 'scheduler-new99', status: 'running' });
+describe('claimRevival — MF1 bootstrap (fresh deploy, empty table)', () => {
+  it('inserts the singleton when no row exists (the fresh-deploy fix)', async () => {
+    const db = makeHeartbeatDB(null);
+    const r = await claimRevival(db, { token: 'boot-1', observedInstanceId: null, rowExists: false });
+    expect(r).toMatchObject({ won: true, bootstrap: true });
+    expect(db._state.row).toMatchObject({ id: 1, instance_id: 'boot-1' });
+    expect(ALLOWED_STATUS).toContain(db._state.row.status); // constraint-safe bootstrap status
   });
-  it('times out (exit-1 path) when instance never changes', async () => {
-    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'reviving' });
-    let t = FIXED;
-    const now = () => (t += 600); // advance 600ms per call → crosses 8s timeout
-    const r = await confirmRevival(db, { token: 'supervisor-t', sleep: async () => {}, now });
+  it('loses on PK conflict when a peer inserted first (no error surfaced)', async () => {
+    const db = makeHeartbeatDB(staleRow()); // row already present → simulates the peer-won race
+    const r = await claimRevival(db, { token: 'boot-2', observedInstanceId: null, rowExists: false });
+    expect(r).toMatchObject({ won: false, bootstrap: true });
+    expect(r.error == null).toBe(true);
+  });
+});
+
+describe('confirmRevival — MF2', () => {
+  it('confirmed when instance_id becomes a fresh value (≠ token, ≠ observed)', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'running' });
+    const sleep = vi.fn(async () => { db._state.row.instance_id = 'scheduler-new99'; db._state.row.status = 'running'; });
+    const r = await confirmRevival(db, { token: 'supervisor-t', excludeInstances: ['scheduler-old'], sleep, now: fixedNow });
+    expect(r).toMatchObject({ confirmed: true, instanceId: 'scheduler-new99' });
+  });
+  it('NOT confirmed when only the excluded (zombie) old instance reappears', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'running' });
+    const sleep = async () => { db._state.row.instance_id = 'scheduler-old'; }; // zombie re-stamps its old id
+    const r = await confirmRevival(db, { token: 'supervisor-t', excludeInstances: ['scheduler-old'], sleep, now: advancingNow() });
     expect(r.confirmed).toBe(false);
+  });
+  it('times out when instance never changes', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'running' });
+    const r = await confirmRevival(db, { token: 'supervisor-t', sleep: async () => {}, now: advancingNow() });
+    expect(r.confirmed).toBe(false);
+  });
+  it('early-returns with childExitCode when the spawned daemon exits during the window', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'running' });
+    const r = await confirmRevival(db, { token: 'supervisor-t', sleep: async () => {}, now: fixedNow, getChildExit: () => ({ exited: true, code: 1 }) });
+    expect(r).toMatchObject({ confirmed: false, childExitCode: 1 });
   });
 });
 
 describe('main — integration', () => {
-  const base = (db, extra = {}) => ({ supabase: db, logger: silentLogger, now: fixedNow, env: CREDS, token: 'supervisor-fixedtok', ...extra });
+  const base = (db, extra = {}) => ({ supabase: db, logger: silentLogger, now: fixedNow, env: CREDS, token: 'supervisor-fixedtok', stdio: 'ignore', ...extra });
 
   it('TS-1: alive scheduler → no action, no spawn', async () => {
     const db = makeHeartbeatDB(freshRow());
@@ -201,39 +234,38 @@ describe('main — integration', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('TS-4: stale but missing creds → exit 2, no spawn, no claim', async () => {
+  it('TS-4: stale but missing creds → exit 2, no claim, no spawn', async () => {
     const db = makeHeartbeatDB(staleRow());
     const spawn = okSpawn();
     const r = await main(['node', 'w', '--once'], base(db, { spawn, env: { SUPABASE_URL: 'u' } }));
     expect(r).toMatchObject({ exitCode: 2, action: 'missing_creds' });
-    expect(db._calls.updates).toBe(0);
+    expect(db._calls.updates + db._calls.inserts).toBe(0);
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('TS-6: dry-run → claims (single-winner) but does NOT spawn', async () => {
+  it('TS-6: dry-run → NO mutation at all, no spawn', async () => {
     const db = makeHeartbeatDB(staleRow());
     const spawn = okSpawn();
     const r = await main(['node', 'w', '--dry-run'], base(db, { spawn }));
     expect(r).toMatchObject({ exitCode: 0, action: 'dry_run' });
-    expect(db._calls.updates).toBe(1);
-    expect(db._state.row.instance_id).toBe('supervisor-fixedtok'); // claim applied
-    expect(db._state.row.status).toBe('running');                 // status untouched (constraint-safe)
+    expect(db._calls.updates + db._calls.inserts).toBe(0); // truly read-only
+    expect(db._state.row.instance_id).toBe('scheduler-dead0000');
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('TS-2/TS-7: stale → wins claim, spawns once, confirms takeover → exit 0 revived', async () => {
+  it('TS-2/TS-7: stale → wins CAS, spawns once, confirms takeover → exit 0 revived', async () => {
     const db = makeHeartbeatDB(staleRow());
     const spawn = okSpawn();
-    const sleep = vi.fn(async () => { db._state.row.instance_id = 'scheduler-live01'; db._state.row.status = 'running'; });
+    const sleep = vi.fn(async () => { db._state.row.instance_id = 'scheduler-live01'; db._state.row.last_poll_at = new Date(FIXED).toISOString(); db._state.row.status = 'running'; });
     const r = await main(['node', 'w', '--once'], base(db, { spawn, sleep }));
     expect(r).toMatchObject({ exitCode: 0, action: 'revived', instanceId: 'scheduler-live01' });
     expect(spawn).toHaveBeenCalledTimes(1);
-    const [cmd, argv, optsArg] = spawn.mock.calls[0];
+    const [, argv, optsArg] = spawn.mock.calls[0];
     expect(argv).toEqual(expect.arrayContaining([expect.stringContaining('eva-scheduler.js'), 'start']));
-    expect(optsArg).toMatchObject({ detached: true, windowsHide: true, stdio: 'ignore' });
+    expect(optsArg).toMatchObject({ detached: true, windowsHide: true });
   });
 
-  it('TS-3: two concurrent watchers → EXACTLY ONE spawns (single-instance)', async () => {
+  it('TS-3: two concurrent watchers (existing stale row) → EXACTLY ONE spawns', async () => {
     const db = makeHeartbeatDB(staleRow());
     const spawn = okSpawn();
     const sleep = async () => { db._state.row.instance_id = 'scheduler-winner'; db._state.row.status = 'running'; };
@@ -241,17 +273,55 @@ describe('main — integration', () => {
       main(['node', 'w', '--once'], base(db, { spawn, sleep, token: 'supervisor-A' })),
       main(['node', 'w', '--once'], base(db, { spawn, sleep, token: 'supervisor-B' })),
     ]);
-    const actions = results.map((r) => r.action).sort();
     expect(spawn).toHaveBeenCalledTimes(1);
-    expect(actions).toEqual(['claim_lost', 'revived']);
-    expect(db._calls.updates).toBe(2); // both attempted the claim; only one matched
+    expect(results.map((r) => r.action).sort()).toEqual(['claim_lost', 'revived']);
+    expect(db._calls.updates).toBe(2); // both attempted the CAS; only one matched
   });
 
-  it('spawn throwing → exit 1 spawn_error', async () => {
+  it('TS-9: fresh deploy (empty table) → bootstraps singleton, spawns, confirms', async () => {
+    const db = makeHeartbeatDB(null);
+    const spawn = okSpawn();
+    const sleep = async () => { db._state.row.instance_id = 'scheduler-fresh'; db._state.row.status = 'running'; };
+    const r = await main(['node', 'w', '--once'], base(db, { spawn, sleep }));
+    expect(r).toMatchObject({ exitCode: 0, action: 'revived', instanceId: 'scheduler-fresh' });
+    expect(db._calls.inserts).toBe(1);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('TS-10: fresh-deploy race → EXACTLY ONE inserts+spawns (PK conflict for the loser)', async () => {
+    const db = makeHeartbeatDB(null);
+    const spawn = okSpawn();
+    const sleep = async () => { db._state.row.instance_id = 'scheduler-fresh'; db._state.row.status = 'running'; };
+    const results = await Promise.all([
+      main(['node', 'w', '--once'], base(db, { spawn, sleep, token: 'supervisor-A' })),
+      main(['node', 'w', '--once'], base(db, { spawn, sleep, token: 'supervisor-B' })),
+    ]);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(results.map((r) => r.action).sort()).toEqual(['claim_lost', 'revived']);
+  });
+
+  it('TS-11: failed spawn leaves last_poll_at STALE (no 5-min mask) → exit 1', async () => {
     const db = makeHeartbeatDB(staleRow());
     const spawn = vi.fn(() => { throw new Error('ENOENT'); });
     const r = await main(['node', 'w', '--once'], base(db, { spawn }));
     expect(r).toMatchObject({ exitCode: 1, action: 'spawn_error' });
+    expect(db._state.row.last_poll_at).toBe(STALE_LAST_POLL); // unchanged → next tick retries immediately
+  });
+
+  it('TS-12: zombie old daemon re-stamps its id → NOT confirmed (excluded) → exit 1', async () => {
+    const db = makeHeartbeatDB(staleRow('scheduler-zombie'));
+    const spawn = okSpawn();
+    const sleep = async () => { db._state.row.instance_id = 'scheduler-zombie'; }; // the OLD instance reappears
+    const r = await main(['node', 'w', '--once'], base(db, { spawn, sleep, now: advancingNow() }));
+    expect(r).toMatchObject({ exitCode: 1, action: 'unconfirmed' });
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('daemon exits early during confirm → exit 1 unconfirmed with childExitCode', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = crashSpawn();
+    const r = await main(['node', 'w', '--once'], base(db, { spawn, sleep: async () => {} }));
+    expect(r).toMatchObject({ exitCode: 1, action: 'unconfirmed', childExitCode: 1 });
   });
 
   it('claim DB error → exit 1 claim_error, no spawn', async () => {

--- a/scripts/__tests__/eva-scheduler-watcher.test.js
+++ b/scripts/__tests__/eva-scheduler-watcher.test.js
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for scripts/cron/eva-scheduler-watcher.mjs
+ *
+ * SD: SD-LEO-INFRA-REVIVE-EVA-SCHEDULER-SERVICE-001
+ *
+ * Hermetic — no real DB, no real process spawn. A stateful singleton-row mock
+ * simulates the ATOMIC conditional UPDATE that backs the single-instance guarantee
+ * (MF1): claimRevival's `.update().eq().or().select()` applies the patch only when the
+ * row still matches the staleness predicate, so a second concurrent claim against the
+ * now-fresh row returns 0 rows. spawn is injected (deps.spawn) so the race test proves
+ * "exactly one process spawned" without forking. Clock + sleep injected for determinism.
+ *
+ * Covers TS-1 (alive→noop), TS-2 (stale→revive), TS-3 (concurrency race→one spawn),
+ * TS-4 (missing creds→exit 2), TS-5 (disabled→noop), TS-6 (dry-run→claim no spawn),
+ * TS-7 (confirm via instance_id takeover), TS-8 (unconfirmed→exit 1).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseArgs,
+  assertSpawnCreds,
+  schedulerLiveness,
+  claimRevival,
+  confirmRevival,
+  main,
+} from '../cron/eva-scheduler-watcher.mjs';
+
+const FIXED = Date.parse('2026-06-09T22:00:00.000Z');
+const fixedNow = () => FIXED;
+const CREDS = { SUPABASE_URL: 'http://x', SUPABASE_SERVICE_ROLE_KEY: 'k' };
+
+// PostgREST `.or()` predicate evaluator for the single-table mock (last_poll_at.is.null,last_poll_at.lt.<iso>)
+function evalOr(orStr, row) {
+  if (!orStr) return true;
+  return orStr.split(',').some((clause) => {
+    const parts = clause.split('.');
+    const col = parts[0];
+    const op = parts[1];
+    const val = parts.slice(2).join('.'); // ISO timestamps contain dots — rejoin
+    if (op === 'is' && val === 'null') return row[col] == null;
+    if (op === 'lt') return row[col] != null && Date.parse(row[col]) < Date.parse(val);
+    return false;
+  });
+}
+
+/**
+ * Stateful mock of the eva_scheduler_heartbeat singleton row.
+ * @param initial row object or null (no heartbeat yet)
+ * @param opts.readError / opts.claimError to simulate DB failures
+ */
+function makeHeartbeatDB(initial, opts = {}) {
+  const state = { row: initial ? { ...initial } : null };
+  const calls = { updates: 0, reads: 0 };
+  function from() {
+    let isUpdate = false; let patch = null; let orStr = null;
+    const builder = {
+      select() {
+        if (isUpdate) {
+          calls.updates++;
+          if (opts.claimError) return Promise.resolve({ data: null, error: { message: 'claim boom' } });
+          let matched = false;
+          if (state.row && evalOr(orStr, state.row)) { Object.assign(state.row, patch); matched = true; }
+          return Promise.resolve({ data: matched ? [{ ...state.row }] : [], error: null });
+        }
+        return builder;
+      },
+      eq() { return builder; },
+      or(s) { orStr = s; return builder; },
+      update(p) { isUpdate = true; patch = p; return builder; },
+      maybeSingle() {
+        calls.reads++;
+        if (opts.readError) return Promise.resolve({ data: null, error: { message: 'read boom' } });
+        return Promise.resolve({ data: state.row ? { ...state.row } : null, error: null });
+      },
+    };
+    return builder;
+  }
+  return { from, _state: state, _calls: calls };
+}
+
+const freshRow = (instance = 'scheduler-aaaa1111') => ({ id: 1, instance_id: instance, status: 'running', last_poll_at: new Date(FIXED - 10_000).toISOString(), poll_count: 99 });
+const staleRow = (instance = 'scheduler-dead0000') => ({ id: 1, instance_id: instance, status: 'running', last_poll_at: new Date(FIXED - 9_000_000).toISOString(), poll_count: 533 });
+
+const okSpawn = () => vi.fn(() => ({ pid: 4242, unref: vi.fn() }));
+const silentLogger = { log: () => {}, warn: () => {}, error: () => {} };
+
+describe('parseArgs', () => {
+  it('parses --once / --dry-run / --help', () => {
+    expect(parseArgs(['node', 'cmd', '--once'])).toMatchObject({ once: true });
+    expect(parseArgs(['node', 'cmd', '--dry-run'])).toMatchObject({ dryRun: true });
+    expect(parseArgs(['node', 'cmd', '--help'])).toMatchObject({ help: true });
+    expect(parseArgs(['node', 'cmd'])).toMatchObject({ once: false, dryRun: false, help: false });
+  });
+});
+
+describe('assertSpawnCreds', () => {
+  it('ok when url+key present (either url alias)', () => {
+    expect(assertSpawnCreds(CREDS).ok).toBe(true);
+    expect(assertSpawnCreds({ NEXT_PUBLIC_SUPABASE_URL: 'u', SUPABASE_SERVICE_ROLE_KEY: 'k' }).ok).toBe(true);
+  });
+  it('reports each missing credential', () => {
+    expect(assertSpawnCreds({}).missing).toEqual(['SUPABASE_URL|NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']);
+    expect(assertSpawnCreds({ SUPABASE_URL: 'u' }).missing).toEqual(['SUPABASE_SERVICE_ROLE_KEY']);
+  });
+});
+
+describe('schedulerLiveness', () => {
+  it('alive when last_poll_at within staleMs', async () => {
+    const db = makeHeartbeatDB(freshRow());
+    const r = await schedulerLiveness(db, { now: fixedNow, staleMs: 300_000 });
+    expect(r).toMatchObject({ ok: true, alive: true, exists: true });
+    expect(r.ageMs).toBe(10_000);
+  });
+  it('stale when older than staleMs', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const r = await schedulerLiveness(db, { now: fixedNow, staleMs: 300_000 });
+    expect(r).toMatchObject({ ok: true, alive: false, exists: true });
+  });
+  it('absent (no row) → not alive, exists:false', async () => {
+    const db = makeHeartbeatDB(null);
+    const r = await schedulerLiveness(db, { now: fixedNow });
+    expect(r).toMatchObject({ ok: true, alive: false, exists: false, ageMs: Infinity });
+  });
+  it('null last_poll_at → not alive (age Infinity)', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'x', last_poll_at: null });
+    const r = await schedulerLiveness(db, { now: fixedNow });
+    expect(r.alive).toBe(false);
+    expect(r.ageMs).toBe(Infinity);
+  });
+  it('DB read error → ok:false', async () => {
+    const db = makeHeartbeatDB(staleRow(), { readError: true });
+    const r = await schedulerLiveness(db, { now: fixedNow });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('claimRevival (MF1 atomic single-winner)', () => {
+  it('wins on a stale row and applies the reviving patch', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const r = await claimRevival(db, { token: 'supervisor-t1', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+    expect(r.won).toBe(true);
+    expect(db._state.row.instance_id).toBe('supervisor-t1');
+    expect(db._state.row.status).toBe('reviving');
+  });
+  it('loses when row is already fresh (predicate no longer matches)', async () => {
+    const db = makeHeartbeatDB(freshRow());
+    const r = await claimRevival(db, { token: 'supervisor-t2', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+    expect(r.won).toBe(false);
+  });
+  it('second claim against the same row loses after the first wins', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const a = await claimRevival(db, { token: 'A', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+    const b = await claimRevival(db, { token: 'B', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
+    expect(a.won).toBe(true);
+    expect(b.won).toBe(false);
+    expect(db._state.row.instance_id).toBe('A');
+  });
+});
+
+describe('confirmRevival (MF2)', () => {
+  it('confirmed when instance_id moves off our token', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'reviving' });
+    // sleep simulates the daemon stamping its own instance on first poll
+    const sleep = vi.fn(async () => { db._state.row.instance_id = 'scheduler-new99'; db._state.row.status = 'running'; });
+    const r = await confirmRevival(db, { token: 'supervisor-t', sleep, now: fixedNow });
+    expect(r).toMatchObject({ confirmed: true, instanceId: 'scheduler-new99', status: 'running' });
+  });
+  it('times out (exit-1 path) when instance never changes', async () => {
+    const db = makeHeartbeatDB({ id: 1, instance_id: 'supervisor-t', status: 'reviving' });
+    let t = FIXED;
+    const now = () => (t += 600); // advance 600ms per call → crosses 8s timeout
+    const r = await confirmRevival(db, { token: 'supervisor-t', sleep: async () => {}, now });
+    expect(r.confirmed).toBe(false);
+  });
+});
+
+describe('main — integration', () => {
+  const base = (db, extra = {}) => ({ supabase: db, logger: silentLogger, now: fixedNow, env: CREDS, token: 'supervisor-fixedtok', ...extra });
+
+  it('TS-1: alive scheduler → no action, no spawn', async () => {
+    const db = makeHeartbeatDB(freshRow());
+    const spawn = okSpawn();
+    const r = await main(['node', 'w', '--once'], base(db, { spawn }));
+    expect(r).toMatchObject({ exitCode: 0, action: 'alive' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('TS-5: EVA_SCHEDULER_ENABLED=false → suppressed, no DB read, no spawn', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = okSpawn();
+    const r = await main(['node', 'w', '--once'], base(db, { spawn, env: { ...CREDS, EVA_SCHEDULER_ENABLED: 'false' } }));
+    expect(r).toMatchObject({ exitCode: 0, action: 'disabled' });
+    expect(db._calls.reads).toBe(0);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('TS-4: stale but missing creds → exit 2, no spawn, no claim', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = okSpawn();
+    const r = await main(['node', 'w', '--once'], base(db, { spawn, env: { SUPABASE_URL: 'u' } }));
+    expect(r).toMatchObject({ exitCode: 2, action: 'missing_creds' });
+    expect(db._calls.updates).toBe(0);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('TS-6: dry-run → claims (single-winner) but does NOT spawn', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = okSpawn();
+    const r = await main(['node', 'w', '--dry-run'], base(db, { spawn }));
+    expect(r).toMatchObject({ exitCode: 0, action: 'dry_run' });
+    expect(db._calls.updates).toBe(1);
+    expect(db._state.row.status).toBe('reviving');
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('TS-2/TS-7: stale → wins claim, spawns once, confirms takeover → exit 0 revived', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = okSpawn();
+    const sleep = vi.fn(async () => { db._state.row.instance_id = 'scheduler-live01'; db._state.row.status = 'running'; });
+    const r = await main(['node', 'w', '--once'], base(db, { spawn, sleep }));
+    expect(r).toMatchObject({ exitCode: 0, action: 'revived', instanceId: 'scheduler-live01' });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [cmd, argv, optsArg] = spawn.mock.calls[0];
+    expect(argv).toEqual(expect.arrayContaining([expect.stringContaining('eva-scheduler.js'), 'start']));
+    expect(optsArg).toMatchObject({ detached: true, windowsHide: true, stdio: 'ignore' });
+  });
+
+  it('TS-3: two concurrent watchers → EXACTLY ONE spawns (single-instance)', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = okSpawn();
+    const sleep = async () => { db._state.row.instance_id = 'scheduler-winner'; db._state.row.status = 'running'; };
+    const results = await Promise.all([
+      main(['node', 'w', '--once'], base(db, { spawn, sleep, token: 'supervisor-A' })),
+      main(['node', 'w', '--once'], base(db, { spawn, sleep, token: 'supervisor-B' })),
+    ]);
+    const actions = results.map((r) => r.action).sort();
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(actions).toEqual(['claim_lost', 'revived']);
+    expect(db._calls.updates).toBe(2); // both attempted the claim; only one matched
+  });
+
+  it('spawn throwing → exit 1 spawn_error', async () => {
+    const db = makeHeartbeatDB(staleRow());
+    const spawn = vi.fn(() => { throw new Error('ENOENT'); });
+    const r = await main(['node', 'w', '--once'], base(db, { spawn }));
+    expect(r).toMatchObject({ exitCode: 1, action: 'spawn_error' });
+  });
+
+  it('claim DB error → exit 1 claim_error, no spawn', async () => {
+    const db = makeHeartbeatDB(staleRow(), { claimError: true });
+    const spawn = okSpawn();
+    const r = await main(['node', 'w', '--once'], base(db, { spawn }));
+    expect(r).toMatchObject({ exitCode: 1, action: 'claim_error' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('heartbeat read error → exit 1 db_error', async () => {
+    const db = makeHeartbeatDB(staleRow(), { readError: true });
+    const r = await main(['node', 'w', '--once'], base(db, { spawn: okSpawn() }));
+    expect(r).toMatchObject({ exitCode: 1, action: 'db_error' });
+  });
+});

--- a/scripts/__tests__/eva-scheduler-watcher.test.js
+++ b/scripts/__tests__/eva-scheduler-watcher.test.js
@@ -57,6 +57,13 @@ function makeHeartbeatDB(initial, opts = {}) {
         if (isUpdate) {
           calls.updates++;
           if (opts.claimError) return Promise.resolve({ data: null, error: { message: 'claim boom' } });
+          // Enforce the REAL eva_scheduler_heartbeat_status_check (running|stopping|stopped).
+          // This is the regression guard for the prod bug live-dogfooding caught: a claim that
+          // sets status='reviving' violates the constraint and can NEVER succeed in production.
+          const ALLOWED_STATUS = ['running', 'stopping', 'stopped'];
+          if (patch && patch.status != null && !ALLOWED_STATUS.includes(patch.status)) {
+            return Promise.resolve({ data: null, error: { message: 'new row violates check constraint "eva_scheduler_heartbeat_status_check"' } });
+          }
           let matched = false;
           if (state.row && evalOr(orStr, state.row)) { Object.assign(state.row, patch); matched = true; }
           return Promise.resolve({ data: matched ? [{ ...state.row }] : [], error: null });
@@ -134,12 +141,13 @@ describe('schedulerLiveness', () => {
 });
 
 describe('claimRevival (MF1 atomic single-winner)', () => {
-  it('wins on a stale row and applies the reviving patch', async () => {
+  it('wins on a stale row, stamps instance_id+last_poll_at, leaves status untouched (constraint-safe)', async () => {
     const db = makeHeartbeatDB(staleRow());
     const r = await claimRevival(db, { token: 'supervisor-t1', nowIso: new Date(FIXED).toISOString(), staleThresholdIso: new Date(FIXED - 300_000).toISOString() });
     expect(r.won).toBe(true);
     expect(db._state.row.instance_id).toBe('supervisor-t1');
-    expect(db._state.row.status).toBe('reviving');
+    expect(db._state.row.last_poll_at).toBe(new Date(FIXED).toISOString());
+    expect(db._state.row.status).toBe('running'); // NOT changed → never trips the status CHECK
   });
   it('loses when row is already fresh (predicate no longer matches)', async () => {
     const db = makeHeartbeatDB(freshRow());
@@ -208,7 +216,8 @@ describe('main — integration', () => {
     const r = await main(['node', 'w', '--dry-run'], base(db, { spawn }));
     expect(r).toMatchObject({ exitCode: 0, action: 'dry_run' });
     expect(db._calls.updates).toBe(1);
-    expect(db._state.row.status).toBe('reviving');
+    expect(db._state.row.instance_id).toBe('supervisor-fixedtok'); // claim applied
+    expect(db._state.row.status).toBe('running');                 // status untouched (constraint-safe)
     expect(spawn).not.toHaveBeenCalled();
   });
 

--- a/scripts/cron/eva-scheduler-watcher.mjs
+++ b/scripts/cron/eva-scheduler-watcher.mjs
@@ -14,20 +14,27 @@
  * across any number of concurrent watchers.
  *
  * Single-instance guarantee (the hard requirement):
- *   MF1 — Atomic single-winner claim. The revive is gated by a CONDITIONAL update of
- *         the singleton heartbeat row: only the watcher whose UPDATE ... WHERE id=1 AND
- *         (last_poll_at IS NULL OR last_poll_at < now()-STALE) matches a row proceeds.
- *         PostgreSQL row-locks serialize concurrent updaters; the first sets
- *         last_poll_at=now() (fresh), so every later watcher's predicate no longer
- *         matches and returns 0 rows. Exactly one watcher spawns. No pg pooler/advisory
- *         lock required — the conditional singleton UPDATE is itself the atomic gate.
- *   MF2 — Confirm takeover. After spawning, poll the heartbeat until instance_id moves
- *         away from our supervisor token (the daemon stamps its own scheduler-<hex> on
- *         start). Confirmed → exit 0; timed-out → exit 1 (next tick retries — the claim
- *         set last_poll_at=now so we wait one STALE window before re-revival).
- *   MF4 — Creds guard + detached spawn. Assert SUPABASE creds BEFORE spawning so we
- *         never fork a credential-less crash-loop; spawn detached/unref'd with
- *         windowsHide so the daemon outlives this one-shot process cross-platform.
+ *   MF1 — Atomic single-winner claim via compare-and-swap on instance_id. After the
+ *         age-gate flags the heartbeat stale, the revive is gated by
+ *         `UPDATE ... SET instance_id=<token> WHERE id=1 AND instance_id=<observed>`:
+ *         PostgreSQL row-locks serialize concurrent watchers; the first swaps the
+ *         observed instance to its token, so every later watcher's CAS predicate no
+ *         longer matches and affects 0 rows. Exactly one watcher spawns. On a FRESH
+ *         deployment (empty table) the claim instead INSERTs the singleton — the PK
+ *         rejects the loser, preserving the single-winner property. The CAS deliberately
+ *         does NOT write last_poll_at, so a failed spawn/confirm leaves the row stale and
+ *         the very next tick retries immediately (no 5-minute false-"alive" mask).
+ *   MF2 — Confirm takeover. After spawning, poll the heartbeat until instance_id becomes
+ *         a value that is NEITHER our supervisor token NOR the pre-claim (observed)
+ *         instance — the daemon stamps a fresh scheduler-<hex> on start. Excluding the
+ *         observed instance means a hung-but-alive OLD daemon that merely re-stamps its
+ *         original id does not falsely confirm. Confirmed → exit 0; timed-out (or the
+ *         child exited early) → exit 1 (next tick retries; the claim left the row stale).
+ *   MF4 — Creds guard + observable detached spawn. Assert SUPABASE creds BEFORE spawning
+ *         so we never fork a credential-less crash-loop; spawn detached/unref'd with
+ *         windowsHide, redirecting the daemon's stdout/stderr to logs/eva-scheduler-daemon.log
+ *         (not /dev/null) and registering an 'exit' listener so an immediate startup crash
+ *         is captured and reported instead of surfacing only as an opaque timeout.
  *
  * Exit codes:
  *   0 — healthy (scheduler alive, revive confirmed, claim lost to a peer, dry-run, or disabled)
@@ -36,7 +43,7 @@
  *
  * Usage:
  *   node scripts/cron/eva-scheduler-watcher.mjs --once      # one pass (canonical cron)
- *   node scripts/cron/eva-scheduler-watcher.mjs --dry-run   # detect + claim, skip spawn
+ *   node scripts/cron/eva-scheduler-watcher.mjs --dry-run   # report intent, NO mutation
  *
  * Env:
  *   EVA_SCHEDULER_STALE_MS   staleness threshold in ms (default 300000 = 5min)
@@ -44,6 +51,7 @@
  *   SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (required to spawn)
  */
 import 'dotenv/config';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'crypto';
@@ -118,54 +126,82 @@ export async function schedulerLiveness(supabase, { now = Date.now, staleMs = DE
 }
 
 /**
- * MF1 — atomic single-winner claim. Conditional UPDATE of the singleton row that only
- * matches when the heartbeat is stale (or has never polled). Returns won=true ONLY for
- * the single watcher whose update affected the row; concurrent watchers get won=false
- * because the winner's last_poll_at=now() invalidates their staleness predicate.
- *
- * The claim ONLY stamps instance_id (the single-winner marker that MF2 watches) and
- * last_poll_at (the freshness that serializes concurrent claimers). It deliberately does
- * NOT touch `status`: that column carries a CHECK (running|stopping|stopped) and is owned
- * by the daemon's own heartbeat — a bogus 'reviving' value would make every claim fail the
- * constraint in production (caught by live dogfooding; the daemon sets 'running' on start).
+ * MF1 — atomic single-winner claim.
+ *   • Existing (stale) row → compare-and-swap on instance_id: only the watcher whose
+ *     observed instance still matches wins; the winner's swap invalidates every peer's
+ *     predicate. Does NOT touch last_poll_at (leaving it stale enables immediate retry
+ *     after a failed spawn — no false-"alive" window).
+ *   • Missing row (fresh deploy) → INSERT the singleton; the PK rejects concurrent losers.
+ * The claim never writes `status` (CHECK running|stopping|stopped; the daemon owns it and
+ * sets 'running' on start — a bogus value would fail the constraint on every revive).
  */
-export async function claimRevival(supabase, { token, nowIso, staleThresholdIso }) {
-  const { data, error } = await supabase
-    .from('eva_scheduler_heartbeat')
-    .update({ instance_id: token, last_poll_at: nowIso })
-    .eq('id', 1)
-    .or(`last_poll_at.is.null,last_poll_at.lt.${staleThresholdIso}`)
-    .select();
+export async function claimRevival(supabase, { token, observedInstanceId, rowExists }) {
+  if (!rowExists) {
+    const { data, error } = await supabase
+      .from('eva_scheduler_heartbeat')
+      .insert({ id: 1, instance_id: token, status: 'stopped' })
+      .select();
+    if (error) {
+      const dup = error.code === '23505' || /duplicate key|unique/i.test(error.message || '');
+      return { won: false, error: dup ? null : error, rows: [], bootstrap: true };
+    }
+    return { won: (data || []).length === 1, rows: data || [], bootstrap: true };
+  }
+  let q = supabase.from('eva_scheduler_heartbeat').update({ instance_id: token }).eq('id', 1);
+  q = observedInstanceId == null ? q.is('instance_id', null) : q.eq('instance_id', observedInstanceId);
+  const { data, error } = await q.select();
   if (error) return { won: false, error, rows: [] };
   return { won: (data || []).length === 1, rows: data || [] };
 }
 
 /**
- * MF2 — confirm the spawned daemon took over by watching instance_id move off our token.
+ * MF2 — confirm the spawned daemon took over: instance_id becomes a value that is neither
+ * our token NOR any excluded (pre-claim / zombie) instance. Early-returns if the child
+ * process exited during the window (startup crash) so the failure is reported, not masked.
  */
 export async function confirmRevival(supabase, {
   token,
+  excludeInstances = [],
   timeoutMs = CONFIRM_TIMEOUT_MS,
   intervalMs = CONFIRM_INTERVAL_MS,
   sleep = defaultSleep,
   now = Date.now,
+  getChildExit,
 } = {}) {
+  const exclude = new Set([token, ...excludeInstances].filter((x) => x != null));
   const deadline = now() + timeoutMs;
   let instanceId = token;
   let status = null;
   while (now() < deadline) {
     await sleep(intervalMs);
+    const childExit = getChildExit ? getChildExit() : null;
+    if (childExit && childExit.exited) {
+      return { confirmed: false, instanceId, status, childExitCode: childExit.code };
+    }
     const { data } = await supabase
       .from('eva_scheduler_heartbeat')
       .select('instance_id, status')
       .eq('id', 1)
       .maybeSingle();
     if (data) { instanceId = data.instance_id; status = data.status; }
-    if (data && data.instance_id && data.instance_id !== token) {
+    if (data && data.instance_id && !exclude.has(data.instance_id)) {
       return { confirmed: true, instanceId: data.instance_id, status: data.status };
     }
   }
   return { confirmed: false, instanceId, status };
+}
+
+/** Open an append handle for the daemon's stdout/stderr so startup output is diagnosable. */
+function openDaemonLog(repoRoot, logger, tag) {
+  try {
+    const dir = path.join(repoRoot, 'logs');
+    fs.mkdirSync(dir, { recursive: true });
+    const fd = fs.openSync(path.join(dir, 'eva-scheduler-daemon.log'), 'a');
+    return ['ignore', fd, fd];
+  } catch (err) {
+    logger.warn?.(`${tag} daemon log unavailable (${err.message}); stdio=ignore`);
+    return 'ignore';
+  }
 }
 
 export async function main(argv = process.argv, deps = {}) {
@@ -203,6 +239,7 @@ export async function main(argv = process.argv, deps = {}) {
     logger.log?.(`${tag} scheduler alive (age ${Math.round(live.ageMs / 1000)}s, instance ${live.row?.instance_id}) — no action`);
     return { exitCode: 0, action: 'alive', ageMs: live.ageMs };
   }
+  const observedInstanceId = live.row?.instance_id ?? null;
   logger.log?.(`${tag} scheduler STALE/ABSENT (${live.exists ? 'age ' + Math.round(live.ageMs / 1000) + 's' : 'no heartbeat row'}, threshold ${staleMs / 1000}s) — attempting revive`);
 
   // 2. MF4 — creds guard BEFORE any spawn.
@@ -212,11 +249,16 @@ export async function main(argv = process.argv, deps = {}) {
     return { exitCode: 2, action: 'missing_creds' };
   }
 
-  // 3. MF1 — atomic single-winner claim.
   const token = deps.token || `supervisor-${randomUUID().slice(0, 8)}`;
-  const nowIso = new Date(now()).toISOString();
-  const staleThresholdIso = new Date(now() - staleMs).toISOString();
-  const claim = await claimRevival(supabase, { token, nowIso, staleThresholdIso });
+
+  // Dry run is fully read-only — report intent, mutate nothing.
+  if (args.dryRun) {
+    logger.log?.(`${tag} DRY RUN — scheduler is ${live.exists ? 'stale' : 'absent'}; would claim + spawn eva-scheduler start (no mutation)`);
+    return { exitCode: 0, action: 'dry_run', token };
+  }
+
+  // 3. MF1 — atomic single-winner claim (CAS on existing row, INSERT on fresh deploy).
+  const claim = await claimRevival(supabase, { token, observedInstanceId, rowExists: live.exists });
   if (claim.error) {
     logger.error?.(`${tag} revive claim failed: ${claim.error.message}`);
     return { exitCode: 1, action: 'claim_error' };
@@ -225,25 +267,23 @@ export async function main(argv = process.argv, deps = {}) {
     logger.log?.(`${tag} another supervisor won the revive claim — standing down`);
     return { exitCode: 0, action: 'claim_lost' };
   }
-  logger.log?.(`${tag} won revive claim (token ${token})`);
+  logger.log?.(`${tag} won revive claim (token ${token}${claim.bootstrap ? ', bootstrapped singleton' : ''})`);
 
-  if (args.dryRun) {
-    logger.log?.(`${tag} DRY RUN — would spawn eva-scheduler start; skipping spawn`);
-    return { exitCode: 0, action: 'dry_run', token };
-  }
-
-  // 4. MF4 — spawn the detached daemon from the MAIN repo root (worktree-safe).
+  // 4. MF4 — spawn the detached daemon from the MAIN repo root, with diagnosable stdio.
   const repoRoot = deps.repoRoot || getRepoRoot();
   const scriptPath = path.join(repoRoot, 'scripts', 'eva-scheduler.js');
+  const stdio = deps.stdio !== undefined ? deps.stdio : openDaemonLog(repoRoot, logger, tag);
+  const childExit = { exited: false, code: null };
   let child;
   try {
     child = spawnFn(process.execPath, [scriptPath, 'start'], {
       cwd: repoRoot,
       env: { ...env },
       detached: true,
-      stdio: 'ignore',
+      stdio,
       windowsHide: true,
     });
+    child?.on?.('exit', (code) => { childExit.exited = true; childExit.code = code; logger.warn?.(`${tag} spawned daemon exited early (code ${code}) — see logs/eva-scheduler-daemon.log`); });
     child?.unref?.();
   } catch (err) {
     logger.error?.(`${tag} spawn failed: ${err.message}`);
@@ -251,14 +291,21 @@ export async function main(argv = process.argv, deps = {}) {
   }
   logger.log?.(`${tag} spawned eva-scheduler (pid ${child?.pid ?? 'n/a'}); confirming takeover...`);
 
-  // 5. MF2 — confirm the daemon stamped its own instance_id over our token.
-  const confirm = await confirmRevival(supabase, { token, sleep, now });
+  // 5. MF2 — confirm the daemon stamped a fresh instance_id (≠ token AND ≠ observed/zombie).
+  const confirm = await confirmRevival(supabase, {
+    token,
+    excludeInstances: [observedInstanceId],
+    sleep,
+    now,
+    getChildExit: () => childExit,
+  });
   if (confirm.confirmed) {
     logger.log?.(`${tag} revive CONFIRMED — scheduler instance ${confirm.instanceId} status=${confirm.status}`);
     return { exitCode: 0, action: 'revived', token, instanceId: confirm.instanceId, pid: child?.pid };
   }
-  logger.warn?.(`${tag} revive UNCONFIRMED within ${CONFIRM_TIMEOUT_MS / 1000}s (instance still ${confirm.instanceId}); next tick retries`);
-  return { exitCode: 1, action: 'unconfirmed', token };
+  const why = confirm.childExitCode != null ? `daemon exited code ${confirm.childExitCode}` : `instance still ${confirm.instanceId}`;
+  logger.warn?.(`${tag} revive UNCONFIRMED within ${CONFIRM_TIMEOUT_MS / 1000}s (${why}); next tick retries`);
+  return { exitCode: 1, action: 'unconfirmed', token, childExitCode: confirm.childExitCode ?? null };
 }
 
 // Canonical "run directly?" check (mirrors scripts/check-git-state.js:218). The `&&`

--- a/scripts/cron/eva-scheduler-watcher.mjs
+++ b/scripts/cron/eva-scheduler-watcher.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * EVA scheduler watcher — one-shot supervisor that revives a dead EvaMasterScheduler.
+ *
+ * SD: SD-LEO-INFRA-REVIVE-EVA-SCHEDULER-SERVICE-001
+ *
+ * The EvaMasterScheduler daemon (lib/eva/eva-master-scheduler.js) is a long-lived
+ * foreground poller launched by `node scripts/eva-scheduler.js start`. It guards
+ * itself only with an in-process flag — there is NO cross-process supervisor, so if
+ * the daemon dies the singleton heartbeat row (eva_scheduler_heartbeat id=1) freezes:
+ * last_poll_at stops advancing while status stays 'running' (a lie). This watcher is
+ * the missing supervisor: one pass per invocation (canonical cron: `--once`), it
+ * detects staleness from the heartbeat AGE and re-launches the daemon — exactly once
+ * across any number of concurrent watchers.
+ *
+ * Single-instance guarantee (the hard requirement):
+ *   MF1 — Atomic single-winner claim. The revive is gated by a CONDITIONAL update of
+ *         the singleton heartbeat row: only the watcher whose UPDATE ... WHERE id=1 AND
+ *         (last_poll_at IS NULL OR last_poll_at < now()-STALE) matches a row proceeds.
+ *         PostgreSQL row-locks serialize concurrent updaters; the first sets
+ *         last_poll_at=now() (fresh), so every later watcher's predicate no longer
+ *         matches and returns 0 rows. Exactly one watcher spawns. No pg pooler/advisory
+ *         lock required — the conditional singleton UPDATE is itself the atomic gate.
+ *   MF2 — Confirm takeover. After spawning, poll the heartbeat until instance_id moves
+ *         away from our supervisor token (the daemon stamps its own scheduler-<hex> on
+ *         start). Confirmed → exit 0; timed-out → exit 1 (next tick retries — the claim
+ *         set last_poll_at=now so we wait one STALE window before re-revival).
+ *   MF4 — Creds guard + detached spawn. Assert SUPABASE creds BEFORE spawning so we
+ *         never fork a credential-less crash-loop; spawn detached/unref'd with
+ *         windowsHide so the daemon outlives this one-shot process cross-platform.
+ *
+ * Exit codes:
+ *   0 — healthy (scheduler alive, revive confirmed, claim lost to a peer, dry-run, or disabled)
+ *   1 — operational issue (heartbeat read/claim DB error, spawn error, revive unconfirmed)
+ *   2 — fatal misconfiguration (missing SUPABASE creds, missing supabase client config)
+ *
+ * Usage:
+ *   node scripts/cron/eva-scheduler-watcher.mjs --once      # one pass (canonical cron)
+ *   node scripts/cron/eva-scheduler-watcher.mjs --dry-run   # detect + claim, skip spawn
+ *
+ * Env:
+ *   EVA_SCHEDULER_STALE_MS   staleness threshold in ms (default 300000 = 5min)
+ *   EVA_SCHEDULER_ENABLED    'false' suppresses revival (matches eva-scheduler.js start)
+ *   SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (required to spawn)
+ */
+import 'dotenv/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { randomUUID } from 'crypto';
+import { spawn as realSpawn } from 'child_process';
+import { createClient } from '@supabase/supabase-js';
+import { getRepoRoot } from '../../lib/repo-paths.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DEFAULT_STALE_MS = 300000;       // 5 minutes — ~5x the daemon's 60s poll interval
+const CONFIRM_TIMEOUT_MS = 8000;       // wait up to 8s for the daemon to stamp its instance
+const CONFIRM_INTERVAL_MS = 500;       // poll the heartbeat every 500ms during confirm
+
+const USAGE = 'eva-scheduler-watcher --once|--dry-run   (revives a dead EvaMasterScheduler)';
+
+function staleMsFromEnv(env) {
+  const raw = parseInt(env.EVA_SCHEDULER_STALE_MS || '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_STALE_MS;
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function parseArgs(argv) {
+  const args = { once: false, dryRun: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--once') args.once = true;
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function buildSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+/**
+ * Assert the env carries credentials the SPAWNED daemon needs. Run BEFORE any spawn
+ * so a misconfigured host fails fast (exit 2) instead of forking a crash-looping daemon.
+ */
+export function assertSpawnCreds(env = process.env) {
+  const url = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = env.SUPABASE_SERVICE_ROLE_KEY;
+  const missing = [];
+  if (!url) missing.push('SUPABASE_URL|NEXT_PUBLIC_SUPABASE_URL');
+  if (!key) missing.push('SUPABASE_SERVICE_ROLE_KEY');
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * Read the singleton heartbeat and classify liveness by AGE (not by the row's self-
+ * reported status, which lies after a crash). alive = (now - last_poll_at) <= staleMs.
+ */
+export async function schedulerLiveness(supabase, { now = Date.now, staleMs = DEFAULT_STALE_MS } = {}) {
+  const { data, error } = await supabase
+    .from('eva_scheduler_heartbeat')
+    .select('id, instance_id, last_poll_at, status, poll_count')
+    .eq('id', 1)
+    .maybeSingle();
+  if (error) return { ok: false, error, alive: false, exists: false, ageMs: Infinity, row: null };
+  if (!data) return { ok: true, alive: false, exists: false, ageMs: Infinity, row: null };
+  const lastPoll = data.last_poll_at ? Date.parse(data.last_poll_at) : NaN;
+  const ageMs = Number.isNaN(lastPoll) ? Infinity : (now() - lastPoll);
+  return { ok: true, alive: ageMs <= staleMs, exists: true, ageMs, row: data };
+}
+
+/**
+ * MF1 — atomic single-winner claim. Conditional UPDATE of the singleton row that only
+ * matches when the heartbeat is stale (or has never polled). Returns won=true ONLY for
+ * the single watcher whose update affected the row; concurrent watchers get won=false
+ * because the winner's last_poll_at=now() invalidates their staleness predicate.
+ */
+export async function claimRevival(supabase, { token, nowIso, staleThresholdIso }) {
+  const { data, error } = await supabase
+    .from('eva_scheduler_heartbeat')
+    .update({ instance_id: token, status: 'reviving', last_poll_at: nowIso })
+    .eq('id', 1)
+    .or(`last_poll_at.is.null,last_poll_at.lt.${staleThresholdIso}`)
+    .select();
+  if (error) return { won: false, error, rows: [] };
+  return { won: (data || []).length === 1, rows: data || [] };
+}
+
+/**
+ * MF2 — confirm the spawned daemon took over by watching instance_id move off our token.
+ */
+export async function confirmRevival(supabase, {
+  token,
+  timeoutMs = CONFIRM_TIMEOUT_MS,
+  intervalMs = CONFIRM_INTERVAL_MS,
+  sleep = defaultSleep,
+  now = Date.now,
+} = {}) {
+  const deadline = now() + timeoutMs;
+  let instanceId = token;
+  let status = null;
+  while (now() < deadline) {
+    await sleep(intervalMs);
+    const { data } = await supabase
+      .from('eva_scheduler_heartbeat')
+      .select('instance_id, status')
+      .eq('id', 1)
+      .maybeSingle();
+    if (data) { instanceId = data.instance_id; status = data.status; }
+    if (data && data.instance_id && data.instance_id !== token) {
+      return { confirmed: true, instanceId: data.instance_id, status: data.status };
+    }
+  }
+  return { confirmed: false, instanceId, status };
+}
+
+export async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  if (args.help) { console.log(USAGE); return { exitCode: 0, action: 'help' }; }
+
+  const logger = deps.logger || console;
+  const now = deps.now || Date.now;
+  const sleep = deps.sleep || defaultSleep;
+  const spawnFn = deps.spawn || realSpawn;
+  const env = deps.env || process.env;
+  const staleMs = deps.staleMs || staleMsFromEnv(env);
+  const tag = '[eva-scheduler-watcher]';
+
+  // A disabled scheduler must never be revived (mirrors eva-scheduler.js start's guard).
+  if (env.EVA_SCHEDULER_ENABLED === 'false') {
+    logger.log?.(`${tag} EVA_SCHEDULER_ENABLED=false — revive suppressed`);
+    return { exitCode: 0, action: 'disabled' };
+  }
+
+  let supabase;
+  try { supabase = deps.supabase || buildSupabase(); }
+  catch (err) {
+    logger.error?.(`${tag} supabase client unavailable: ${err.message}`);
+    return { exitCode: 2, action: 'no_supabase' };
+  }
+
+  // 1. Liveness by heartbeat age.
+  const live = await schedulerLiveness(supabase, { now, staleMs });
+  if (!live.ok) {
+    logger.error?.(`${tag} heartbeat read failed: ${live.error?.message}`);
+    return { exitCode: 1, action: 'db_error' };
+  }
+  if (live.alive) {
+    logger.log?.(`${tag} scheduler alive (age ${Math.round(live.ageMs / 1000)}s, instance ${live.row?.instance_id}) — no action`);
+    return { exitCode: 0, action: 'alive', ageMs: live.ageMs };
+  }
+  logger.log?.(`${tag} scheduler STALE/ABSENT (${live.exists ? 'age ' + Math.round(live.ageMs / 1000) + 's' : 'no heartbeat row'}, threshold ${staleMs / 1000}s) — attempting revive`);
+
+  // 2. MF4 — creds guard BEFORE any spawn.
+  const creds = assertSpawnCreds(env);
+  if (!creds.ok) {
+    logger.error?.(`${tag} cannot revive: missing ${creds.missing.join(', ')}`);
+    return { exitCode: 2, action: 'missing_creds' };
+  }
+
+  // 3. MF1 — atomic single-winner claim.
+  const token = deps.token || `supervisor-${randomUUID().slice(0, 8)}`;
+  const nowIso = new Date(now()).toISOString();
+  const staleThresholdIso = new Date(now() - staleMs).toISOString();
+  const claim = await claimRevival(supabase, { token, nowIso, staleThresholdIso });
+  if (claim.error) {
+    logger.error?.(`${tag} revive claim failed: ${claim.error.message}`);
+    return { exitCode: 1, action: 'claim_error' };
+  }
+  if (!claim.won) {
+    logger.log?.(`${tag} another supervisor won the revive claim — standing down`);
+    return { exitCode: 0, action: 'claim_lost' };
+  }
+  logger.log?.(`${tag} won revive claim (token ${token})`);
+
+  if (args.dryRun) {
+    logger.log?.(`${tag} DRY RUN — would spawn eva-scheduler start; skipping spawn`);
+    return { exitCode: 0, action: 'dry_run', token };
+  }
+
+  // 4. MF4 — spawn the detached daemon from the MAIN repo root (worktree-safe).
+  const repoRoot = deps.repoRoot || getRepoRoot();
+  const scriptPath = path.join(repoRoot, 'scripts', 'eva-scheduler.js');
+  let child;
+  try {
+    child = spawnFn(process.execPath, [scriptPath, 'start'], {
+      cwd: repoRoot,
+      env: { ...env },
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child?.unref?.();
+  } catch (err) {
+    logger.error?.(`${tag} spawn failed: ${err.message}`);
+    return { exitCode: 1, action: 'spawn_error' };
+  }
+  logger.log?.(`${tag} spawned eva-scheduler (pid ${child?.pid ?? 'n/a'}); confirming takeover...`);
+
+  // 5. MF2 — confirm the daemon stamped its own instance_id over our token.
+  const confirm = await confirmRevival(supabase, { token, sleep, now });
+  if (confirm.confirmed) {
+    logger.log?.(`${tag} revive CONFIRMED — scheduler instance ${confirm.instanceId} status=${confirm.status}`);
+    return { exitCode: 0, action: 'revived', token, instanceId: confirm.instanceId, pid: child?.pid };
+  }
+  logger.warn?.(`${tag} revive UNCONFIRMED within ${CONFIRM_TIMEOUT_MS / 1000}s (instance still ${confirm.instanceId}); next tick retries`);
+  return { exitCode: 1, action: 'unconfirmed', token };
+}
+
+const isMain = (() => {
+  try {
+    const here = new URL(import.meta.url).pathname;
+    const argv = process.argv[1] ? process.argv[1].replace(/\\/g, '/') : '';
+    return here.endsWith(argv) || argv.endsWith(here);
+  } catch { return false; }
+})();
+
+if (isMain) {
+  main().then(({ exitCode }) => process.exit(exitCode))
+        .catch((err) => { console.error('eva-scheduler-watcher fatal:', err.message); process.exit(2); });
+}

--- a/scripts/cron/eva-scheduler-watcher.mjs
+++ b/scripts/cron/eva-scheduler-watcher.mjs
@@ -45,7 +45,7 @@
  */
 import 'dotenv/config';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'crypto';
 import { spawn as realSpawn } from 'child_process';
 import { createClient } from '@supabase/supabase-js';
@@ -122,11 +122,17 @@ export async function schedulerLiveness(supabase, { now = Date.now, staleMs = DE
  * matches when the heartbeat is stale (or has never polled). Returns won=true ONLY for
  * the single watcher whose update affected the row; concurrent watchers get won=false
  * because the winner's last_poll_at=now() invalidates their staleness predicate.
+ *
+ * The claim ONLY stamps instance_id (the single-winner marker that MF2 watches) and
+ * last_poll_at (the freshness that serializes concurrent claimers). It deliberately does
+ * NOT touch `status`: that column carries a CHECK (running|stopping|stopped) and is owned
+ * by the daemon's own heartbeat — a bogus 'reviving' value would make every claim fail the
+ * constraint in production (caught by live dogfooding; the daemon sets 'running' on start).
  */
 export async function claimRevival(supabase, { token, nowIso, staleThresholdIso }) {
   const { data, error } = await supabase
     .from('eva_scheduler_heartbeat')
-    .update({ instance_id: token, status: 'reviving', last_poll_at: nowIso })
+    .update({ instance_id: token, last_poll_at: nowIso })
     .eq('id', 1)
     .or(`last_poll_at.is.null,last_poll_at.lt.${staleThresholdIso}`)
     .select();
@@ -255,13 +261,10 @@ export async function main(argv = process.argv, deps = {}) {
   return { exitCode: 1, action: 'unconfirmed', token };
 }
 
-const isMain = (() => {
-  try {
-    const here = new URL(import.meta.url).pathname;
-    const argv = process.argv[1] ? process.argv[1].replace(/\\/g, '/') : '';
-    return here.endsWith(argv) || argv.endsWith(here);
-  } catch { return false; }
-})();
+// Canonical "run directly?" check (mirrors scripts/check-git-state.js:218). The `&&`
+// short-circuits when argv[1] is undefined (node -e / REPL / import), so importing this
+// module — e.g. for an ad-hoc liveness probe — never auto-runs main() against the DB.
+const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMain) {
   main().then(({ exitCode }) => process.exit(exitCode))


### PR DESCRIPTION
## Summary
The `EvaMasterScheduler` daemon has no cross-process supervisor: when it dies, the singleton heartbeat row (`eva_scheduler_heartbeat` id=1) freezes (`last_poll_at` stops; `status` stays `'running'` — a lie) and nothing restarts it. (The live row is ~105 days stale.) This adds `scripts/cron/eva-scheduler-watcher.mjs` + `npm run eva:scheduler:watch:cron` — a one-shot supervisor that detects death by heartbeat **age** and relaunches the daemon **exactly once** across concurrent watchers.

## Single-instance guarantee
- **MF1** — atomic single-winner claim: compare-and-swap on `instance_id` (existing stale row) or `INSERT` of the singleton (fresh deploy; PK rejects losers). The claim writes only `instance_id` — never `status` (CHECK-constrained, daemon-owned) and never `last_poll_at`, so a failed spawn leaves the row stale and the next tick retries immediately (no false-"alive" mask).
- **MF2** — confirm takeover: poll until `instance_id` becomes a value that is neither the supervisor token nor the pre-claim instance (excludes a hung zombie re-stamping its old id); early-return on daemon startup crash.
- **MF4** — creds guard before spawn; detached/`unref`/`windowsHide` spawn with stdio → `logs/eva-scheduler-daemon.log`.

## Verification
- 31 hermetic tests (CAS single-winner, fresh-deploy bootstrap + race, no-staleness-mask, zombie exclusion, daemon early-exit, all exit-code paths). Mock enforces the real `status` CHECK on insert+update and PK-conflict.
- Independent TESTING sub-agent re-verified the final HEAD (PASS 95%, incl. a mutation test of the no-mask guard).
- A 9-agent adversarial review drove the CAS/bootstrap/no-mask/zombie/observable-spawn hardening.
- Read-only validated against the live frozen heartbeat (classified STALE; CAS eq-predicate matches the row / 0 on mismatch).

## Operational
`docs/06_deployment/eva-scheduler-watcher-cadence.md` — cadence contract (run every 5 min), exit codes (0/1/2), env, and the single-instance/duplicate-daemon notes. Enabling the cron is the deploy step; this PR ships the supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)