### PR TITLE
feat(SD-LEO-INFRA-MAKE-FEATURE-FLAGS-001): stale-OFF nag + retroactive enrollment of forgotten flags

### DIFF
--- a/lib/feature-flags/governance-review.js
+++ b/lib/feature-flags/governance-review.js
@@ -14,6 +14,13 @@ export const DISABLED_AGING_DAYS = 30;
 // An enabled flag that was never marked rolled_out is a graduation candidate
 // once it has been enabled at least this long.
 export const ENABLED_UNROLLED_DAYS = 14;
+// SD-LEO-INFRA-MAKE-FEATURE-FLAGS-001: a flag shipped default-OFF (rolled_out_at set) that is
+// STILL disabled and not yet decided (lifecycle_state='draft') this long after rollout is a
+// FORGOTTEN switch — the "ship-it-off-and-forget" trap: automation that silently never runs.
+// The review job must ESCALATE it (recommend ENABLE), not let it sit silently. We key on
+// lifecycle='draft' (undecided) — a flag the operator has explicitly moved to 'disabled' is a
+// deliberate decision handled by the disabled-aging → KILL path, not a forgotten one.
+export const STALE_PENDING_OFF_DAYS = 7;
 const DAY_MS = 24 * 3600 * 1000;
 
 function ageDays(ts, now) {
@@ -25,7 +32,7 @@ function ageDays(ts, now) {
  * Classify a single flag's staleness. Returns null when the flag is healthy.
  * @param {object} flag - a leo_feature_flags row
  * @param {number} now - epoch ms (injected for testability)
- * @returns {{flag_key:string, reasons:string[], recommendation:'graduate'|'kill'|'extend'|'review', detail:string}|null}
+ * @returns {{flag_key:string, reasons:string[], recommendation:'enable'|'graduate'|'kill'|'extend'|'review', detail:string}|null}
  */
 export function classifyFlag(flag, now) {
   const reasons = [];
@@ -49,11 +56,20 @@ export function classifyFlag(flag, now) {
     flag.is_enabled === true &&
     !flag.rolled_out_at &&
     age >= ENABLED_UNROLLED_DAYS;
+  // Forgotten switch: shipped default-OFF (rolled_out_at set) but still disabled and still
+  // undecided (lifecycle='draft') past the staleness window. Age is measured from rolled_out_at
+  // (when the OFF rollout shipped), not created_at — the clock starts when it went live OFF.
+  const staleOffPending =
+    flag.is_enabled === false &&
+    !!flag.rolled_out_at &&
+    lifecycle === 'draft' &&
+    ageDays(flag.rolled_out_at, now) >= STALE_PENDING_OFF_DAYS;
 
   if (neverReviewed) reasons.push('never-reviewed');
   if (pastExpiry) reasons.push('past-expiry');
   if (disabledAging) reasons.push('disabled-aging');
   if (enabledNeverRolledOut) reasons.push('enabled-never-rolled-out');
+  if (staleOffPending) reasons.push('stale-off-pending');
 
   if (reasons.length === 0) return null;
 
@@ -61,7 +77,11 @@ export function classifyFlag(flag, now) {
   // enabled-unrolled flag should graduate; an aging-disabled flag should be
   // killed; otherwise it just needs a human review.
   let recommendation;
-  if (pastExpiry) recommendation = 'extend'; // operator extends expiry_at or kills explicitly
+  // A forgotten shipped-OFF switch is the most actionable signal — surface ENABLE first so the
+  // coordinator/chairman sees the automation that is silently not running (the operator's
+  // repeatedly-flagged "turn it off and forget" trap). Flipping it ON stays a deliberate action.
+  if (staleOffPending) recommendation = 'enable';
+  else if (pastExpiry) recommendation = 'extend'; // operator extends expiry_at or kills explicitly
   else if (disabledAging) recommendation = 'kill';
   else if (enabledNeverRolledOut) recommendation = 'graduate';
   else recommendation = 'review';

--- a/scripts/one-off/_enroll-forgotten-flags-make-feature-flags-001.mjs
+++ b/scripts/one-off/_enroll-forgotten-flags-make-feature-flags-001.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-MAKE-FEATURE-FLAGS-001 / FR-2 — retroactive enrollment of the forgotten flags.
+ *
+ * The operator's repeatedly-flagged "ship-it-off-and-forget" trap: three flags are sitting OFF
+ * and untracked (2026-06-09). This enrolls them into the governed registry so the new stale-OFF
+ * escalation (lib/feature-flags/governance-review.js classifyFlag 'stale-off-pending') can SEE
+ * them and nag once they go stale:
+ *   - ADAM_GOVERNANCE_HEARTBEAT_V1 — NOT registered anywhere → register (draft, off).
+ *   - ADAM_SELF_SCORE_CADENCE, COORD_REVIEW_EVERY — registered but rolled_out_at IS NULL, so the
+ *     "shipped default-OFF, pending enablement" clock never started → stamp rolled_out_at.
+ *
+ * Stamping rolled_out_at = created_at marks "this default-OFF rollout shipped at creation"; the
+ * stale clock then runs from there (STALE_PENDING_OFF_DAYS=7). NEVER flips is_enabled — turning a
+ * flag ON stays a deliberate SD/operator action (plan risk note). Fully idempotent.
+ */
+
+import 'dotenv/config';
+import { createFlag, getFlag } from '../../lib/feature-flags/registry.js';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+
+const NEW_FLAG = 'ADAM_GOVERNANCE_HEARTBEAT_V1';
+const STAMP_ROLLED_OUT = ['ADAM_SELF_SCORE_CADENCE', 'COORD_REVIEW_EVERY', NEW_FLAG];
+
+(async () => {
+  const sb = createSupabaseServiceClient();
+
+  // 1) Register the net-new orphan flag (idempotent).
+  const existing = await getFlag(NEW_FLAG).catch(() => null);
+  if (existing) {
+    console.log(`• ${NEW_FLAG} already registered — skipping create.`);
+  } else {
+    await createFlag({
+      flagKey: NEW_FLAG,
+      displayName: 'Adam governance heartbeat (proactive multi-scope scan)',
+      description: 'Gates whether Adam runs the proactive governance-heartbeat scan (scope rotation: harness/platform/per-venture; one-advisory-per-tick cap) defined in the Adam Role Contract (leo_protocol_sections id=601, SD-LEO-INFRA-ADAM-GOVERNANCE-HEARTBEAT-001). Shipped default-OFF; enrolled here so it cannot be silently forgotten.',
+      isEnabled: false,
+      changedBy: 'SD-LEO-INFRA-MAKE-FEATURE-FLAGS-001',
+      ownerType: 'team',
+      ownerId: 'adam',
+      riskTier: 'low',
+      isTemporary: false,
+    });
+    console.log(`• Registered ${NEW_FLAG} (draft, is_enabled=false, owner=team:adam).`);
+  }
+
+  // 2) Stamp rolled_out_at on any of the three that lack it (only where NULL — idempotent), using
+  //    created_at as the rollout timestamp. enablement_criteria backfilled when empty so the
+  //    review digest can show WHY the flag is OFF.
+  for (const key of STAMP_ROLLED_OUT) {
+    const { data: row, error: selErr } = await sb
+      .from('leo_feature_flags')
+      .select('flag_key, is_enabled, lifecycle_state, rolled_out_at, created_at, enablement_criteria')
+      .eq('flag_key', key)
+      .maybeSingle();
+    if (selErr || !row) { console.log(`• ${key}: not found (${selErr?.message || 'no row'}) — skipping.`); continue; }
+    const patch = {};
+    if (!row.rolled_out_at) patch.rolled_out_at = row.created_at || new Date().toISOString();
+    if (!row.enablement_criteria) {
+      patch.enablement_criteria = 'Intended steady-state: ON. Enable when its consuming automation is wired and stable. Until then this is a tracked pending-enablement flag (stale-OFF nag escalates past STALE_PENDING_OFF_DAYS).';
+    }
+    if (Object.keys(patch).length === 0) { console.log(`• ${key}: already enrolled (rolled_out_at + criteria set) — no-op.`); continue; }
+    const { error: updErr } = await sb.from('leo_feature_flags').update(patch).eq('flag_key', key);
+    console.log(updErr
+      ? `• ${key}: UPDATE failed: ${updErr.message}`
+      : `• ${key}: stamped {${Object.keys(patch).join(', ')}} (is_enabled left ${row.is_enabled} — no auto-flip).`);
+  }
+
+  console.log('Retroactive enrollment complete. The stale-OFF nag will escalate these once past STALE_PENDING_OFF_DAYS.');
+})().catch((e) => { console.error('enrollment failed:', e.message); process.exit(1); });

--- a/tests/unit/feature-flag-governance-review.test.js
+++ b/tests/unit/feature-flag-governance-review.test.js
@@ -8,7 +8,8 @@ import {
   computeStaleFlags,
   formatDigest,
   DISABLED_AGING_DAYS,
-  ENABLED_UNROLLED_DAYS
+  ENABLED_UNROLLED_DAYS,
+  STALE_PENDING_OFF_DAYS
 } from '../../lib/feature-flags/governance-review.js';
 
 const NOW = new Date('2026-06-08T00:00:00Z').getTime();
@@ -53,6 +54,33 @@ describe('classifyFlag', () => {
 
   it('does not flag a freshly enabled un-rolled flag (within grace window)', () => {
     expect(classifyFlag({ flag_key: 'NEW', lifecycle_state: 'enabled', is_enabled: true, last_reviewed_at: daysAgo(1), rolled_out_at: null, created_at: daysAgo(1) }, NOW)).toBeNull();
+  });
+
+  // SD-LEO-INFRA-MAKE-FEATURE-FLAGS-001: stale-off-pending (the forgotten-switch escalation).
+  it('flags a forgotten shipped-OFF draft flag (rolled out, still off, past window) as stale-off-pending → enable', () => {
+    const c = classifyFlag({ flag_key: 'FORGOTTEN', lifecycle_state: 'draft', is_enabled: false, last_reviewed_at: daysAgo(1), rolled_out_at: daysAgo(STALE_PENDING_OFF_DAYS + 2) }, NOW);
+    expect(c.reasons).toContain('stale-off-pending');
+    expect(c.recommendation).toBe('enable');
+  });
+
+  it('does NOT flag a shipped-OFF draft flag still within the staleness window', () => {
+    expect(classifyFlag({ flag_key: 'FRESH_OFF', lifecycle_state: 'draft', is_enabled: false, last_reviewed_at: daysAgo(1), rolled_out_at: daysAgo(STALE_PENDING_OFF_DAYS - 2) }, NOW)).toBeNull();
+  });
+
+  it('does NOT flag a never-rolled-out (rolled_out_at=null) draft-off flag as stale-off (no ship signal)', () => {
+    expect(classifyFlag({ flag_key: 'NEVER_SHIPPED', lifecycle_state: 'draft', is_enabled: false, last_reviewed_at: daysAgo(1), rolled_out_at: null }, NOW)).toBeNull();
+  });
+
+  it('stale-off ENABLE takes precedence over a co-occurring never-reviewed', () => {
+    const c = classifyFlag({ flag_key: 'BOTH', lifecycle_state: 'draft', is_enabled: false, last_reviewed_at: null, rolled_out_at: daysAgo(STALE_PENDING_OFF_DAYS + 5) }, NOW);
+    expect(c.reasons).toEqual(expect.arrayContaining(['never-reviewed', 'stale-off-pending']));
+    expect(c.recommendation).toBe('enable');
+  });
+
+  it('a deliberately disabled (not draft) aging OFF flag stays KILL, not stale-off (a decision, not a forgotten switch)', () => {
+    const c = classifyFlag({ flag_key: 'KILLED', lifecycle_state: 'disabled', is_enabled: false, last_reviewed_at: daysAgo(1), rolled_out_at: daysAgo(STALE_PENDING_OFF_DAYS + 5), created_at: daysAgo(DISABLED_AGING_DAYS + 5) }, NOW);
+    expect(c.reasons).not.toContain('stale-off-pending');
+    expect(c.recommendation).toBe('kill');
   });
 });
 


### PR DESCRIPTION
## Problem
We ship automation behind off-by-default flags (safe rollout) but **forget to turn them back on** — the automation silently never runs. Live proof: ADAM_SELF_SCORE_CADENCE, COORD_REVIEW_EVERY, ADAM_GOVERNANCE_HEARTBEAT_V1 sitting OFF and forgotten. The 2026-06-08 feature-flag governance (leo_feature_flags + review job + /flags) had no escalation for forgotten OFF flags, and these three weren't fully tracked.

## Fix (reuse-first — extends the shipped governance, no parallel system, no schema migration)
- **FR-1 stale-OFF nag** — `lib/feature-flags/governance-review.js classifyFlag` escalates a flag that shipped default-OFF (`rolled_out_at` set) but is still disabled and still undecided (`lifecycle='draft'`) past `STALE_PENDING_OFF_DAYS=7`: new reason `stale-off-pending` → recommendation **`enable`** (highest precedence). Keyed on `draft` so a deliberately `disabled` flag stays on the disabled-aging→KILL path.
- **FR-2 retroactive enrollment** — idempotent script registers the missing ADAM_GOVERNANCE_HEARTBEAT_V1 and stamps `rolled_out_at` + intended-state criteria on the other two (which had `rolled_out_at` NULL). **Never flips `is_enabled`** (turning ON stays deliberate). Run live; all 3 verified enrolled, off.
- **FR-3 surfacing** — automatic: the existing review job + /flags render `stale-off-pending → ENABLE` via `formatDigest`/`computeStaleFlags`.

+5 unit tests; governance-review suite **16/16**; TESTING evidence verified the 3 flags live.

The mandatory-enrollment **CI-blocking** gate is a scoped follow-up (the plan specifies flipping the advisory lint to blocking only after the flag baseline is triaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)