### PR TITLE
feat(SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001): Adam read-only opportunity-scan core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ tests/uat/.auth/
 # LEO LLM cost-check runtime artifacts (regenerable; never commit)
 scripts/ops/llm-cost-check.log
 scripts/ops/LLM-COST-ALERT.txt
+
+# Adam opportunity-scan runtime ledger (SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001)
+.adam-scan-ledger.json

--- a/lib/adam/briefings/harness.js
+++ b/lib/adam/briefings/harness.js
@@ -1,0 +1,46 @@
+/**
+ * Harness briefing — read-only signal scan over EHG_Engineer governance tables.
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001.
+ *
+ * Anchors to the O-GOV objectives/KRs. Sources: feedback(harness_backlog),
+ * retrospectives, gate-tuning recommendations, pending EVA recommendations.
+ * Empty tables are reported as "no signal", never as an error.
+ *
+ * Today there is no programmatic live-KR feed wired here, so the briefing
+ * surfaces SIGNAL COUNTS only and emits NO fabricated candidate — the rationale
+ * bar would (correctly) keep it silent without a cited live KR.
+ */
+export function summarizeHarness({ backlog = [], retros = [], gateRecs = [], evaRecs = [] } = {}) {
+  const signals = {
+    open_harness_backlog: backlog.length,
+    recent_retros: retros.length,
+    gate_tuning_recs: gateRecs.length,
+    pending_eva_recs: evaRecs.length,
+  };
+  return { scope_key: 'harness', signals, candidates: [], gaps: [] };
+}
+
+async function safe(fn) {
+  try {
+    const r = await fn();
+    return Array.isArray(r) ? r : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function briefHarness(supabase) {
+  const backlog = await safe(async () =>
+    (await supabase.from('feedback').select('id').eq('category', 'harness_backlog').eq('status', 'new')).data
+  );
+  const retros = await safe(async () =>
+    (await supabase.from('retrospectives').select('id').order('created_at', { ascending: false }).limit(20)).data
+  );
+  const gateRecs = await safe(async () =>
+    (await supabase.from('v_ai_quality_tuning_recommendations').select('sd_type')).data
+  );
+  const evaRecs = await safe(async () =>
+    (await supabase.from('eva_consultant_recommendations').select('id').eq('status', 'pending').limit(50)).data
+  );
+  return summarizeHarness({ backlog, retros, gateRecs, evaRecs });
+}

--- a/lib/adam/briefings/platform.js
+++ b/lib/adam/briefings/platform.js
@@ -1,0 +1,50 @@
+/**
+ * Platform briefing — read-only signal scan over the EHG 26-stage SSOT and
+ * cross-venture gate-failure / stall clustering. SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001.
+ *
+ * Anchors to O-GOV-3 + the SSOT invariant (there is NO per-stage KR, so the
+ * platform scope never fabricates one). Cross-venture clustering claims are
+ * gated by the liveness guard (class-B): below K=3 live ventures they are
+ * suppressed. Empty tables = "no signal".
+ */
+import { crossVentureAdvisoryAllowed } from '../liveness-guard.js';
+
+export function summarizePlatform({ stages = [], gateFailures = [], blockedWork = [], liveVentureCount = 0 } = {}) {
+  const clusters = {};
+  for (const r of gateFailures) {
+    const k = `stage_${r.stage_number}`;
+    clusters[k] = (clusters[k] || 0) + 1;
+  }
+  const guard = crossVentureAdvisoryAllowed(liveVentureCount);
+  const signals = {
+    ssot_stage_count: stages.length,
+    cross_venture_gate_failures: gateFailures.length,
+    blocked_stage_work: blockedWork.length,
+    failure_clusters: clusters,
+  };
+  // Cross-venture clustering is the only candidate source here, and it is
+  // class-B — suppressed entirely while the live venture corpus is below K.
+  return { scope_key: 'platform', signals, liveness: guard, candidates: [], gaps: [] };
+}
+
+async function safe(fn) {
+  try {
+    const r = await fn();
+    return Array.isArray(r) ? r : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function briefPlatform(supabase, { liveVentureCount = 0 } = {}) {
+  const stages = await safe(async () =>
+    (await supabase.from('venture_stages').select('stage_number')).data
+  );
+  const gateFailures = await safe(async () =>
+    (await supabase.from('eva_stage_gate_results').select('stage_number, gate_type, passed').eq('passed', false).limit(500)).data
+  );
+  const blockedWork = await safe(async () =>
+    (await supabase.from('venture_stage_work').select('lifecycle_stage, stage_status').eq('stage_status', 'blocked')).data
+  );
+  return summarizePlatform({ stages, gateFailures, blockedWork, liveVentureCount });
+}

--- a/lib/adam/briefings/venture.js
+++ b/lib/adam/briefings/venture.js
@@ -1,0 +1,68 @@
+/**
+ * Venture briefing — read-only signal scan over a single live venture.
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001.
+ *
+ * Per-venture anchoring requires a chairman-approved L2 vision + a LIVE metric;
+ * if that is absent, the briefing does NOT fabricate a KR — it surfaces the gap
+ * as a DRAFT-SD proposal to bootstrap the data layer (chairman decision; fix
+ * once, unlock all ventures). Sources: competitors, venture_stage_work
+ * (health + advisory_data), venture_separability_scores, L2 eva_vision_documents.
+ * Empty tables = "no signal", not "missing".
+ */
+export function summarizeVenture({ ventureId, competitors = [], stageWork = [], separability = [], visionDocs = [] } = {}) {
+  const blocked = stageWork.filter((w) => w && (w.stage_status === 'blocked' || w.health_score === 'red'));
+  const hasL2Vision = visionDocs.some((v) => v && v.level === 'L2' && v.chairman_approved);
+  const signals = {
+    competitors: competitors.length,
+    stage_work_rows: stageWork.length,
+    blocked_or_red: blocked.length,
+    separability_scored: separability.length,
+    l2_vision_present: hasL2Vision,
+  };
+
+  // Data-gap DRAFT-SD proposals — surfaced (not fabricated signal) when the pipes are dry.
+  const gaps = [];
+  if (competitors.length === 0) {
+    gaps.push({
+      kind: 'data_gap',
+      area: 'competitive_intel',
+      proposal: `Bootstrap competitor intelligence ingestion for venture ${ventureId} (competitive deltas are dry).`,
+    });
+  }
+  if (!hasL2Vision) {
+    gaps.push({
+      kind: 'data_gap',
+      area: 'l2_vision',
+      proposal: `Author/approve a chairman L2 vision for venture ${ventureId} so per-venture rationale anchoring is possible.`,
+    });
+  }
+
+  // No live KR exists per-venture today, so we never fabricate a scoreable
+  // candidate. The honest output is signals + data-gap proposals -> ADAM_OK.
+  return { scope_key: `venture:${ventureId}`, signals, candidates: [], gaps };
+}
+
+async function safe(fn) {
+  try {
+    const r = await fn();
+    return Array.isArray(r) ? r : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function briefVenture(supabase, ventureId) {
+  const competitors = await safe(async () =>
+    (await supabase.from('competitors').select('id').eq('venture_id', ventureId)).data
+  );
+  const stageWork = await safe(async () =>
+    (await supabase.from('venture_stage_work').select('stage_status, health_score').eq('venture_id', ventureId)).data
+  );
+  const separability = await safe(async () =>
+    (await supabase.from('venture_separability_scores').select('overall_score').eq('venture_id', ventureId).order('scored_at', { ascending: false }).limit(1)).data
+  );
+  const visionDocs = await safe(async () =>
+    (await supabase.from('eva_vision_documents').select('level, chairman_approved').eq('venture_id', ventureId).eq('level', 'L2')).data
+  );
+  return summarizeVenture({ ventureId, competitors, stageWork, separability, visionDocs });
+}

--- a/lib/adam/liveness-guard.js
+++ b/lib/adam/liveness-guard.js
@@ -1,0 +1,46 @@
+/**
+ * Liveness guard — suppress class-B (cross-venture) advisories when the live
+ * venture corpus is too thin to generalize. SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001.
+ *
+ * Today only 2 ventures are active+non-demo; the other ~7 venture-kind apps are
+ * synthetic. A cross-venture pattern claim drawn from fewer than K=3 distinct
+ * live ventures is statistically meaningless, so it is suppressed. The harness
+ * and platform scopes are NEVER gated by this guard (they have their own
+ * O-GOV anchors).
+ */
+export const MIN_LIVE_VENTURES_FOR_CROSS_VENTURE = 3; // K
+
+/**
+ * @param {number} distinctLiveVentures - active non-demo ventures evaluated in window
+ * @returns {{ allowed: boolean, threshold: number, observed: number, reason: string }}
+ */
+export function crossVentureAdvisoryAllowed(distinctLiveVentures) {
+  const n = Number.isFinite(distinctLiveVentures) ? distinctLiveVentures : 0;
+  const allowed = n >= MIN_LIVE_VENTURES_FOR_CROSS_VENTURE;
+  return {
+    allowed,
+    threshold: MIN_LIVE_VENTURES_FOR_CROSS_VENTURE,
+    observed: n,
+    reason: allowed
+      ? `live venture corpus n=${n} >= K=${MIN_LIVE_VENTURES_FOR_CROSS_VENTURE}`
+      : `live venture corpus n=${n} < K=${MIN_LIVE_VENTURES_FOR_CROSS_VENTURE} — cross-venture advisory suppressed`,
+  };
+}
+
+/**
+ * Filter a candidate list, dropping class-B (cross_venture=true) candidates when
+ * the guard is closed. Single-scope (class-A) candidates always pass.
+ * @param {Array} candidates
+ * @param {number} distinctLiveVentures
+ * @returns {{ kept: Array, dropped: Array, guard: object }}
+ */
+export function applyLivenessGuard(candidates, distinctLiveVentures) {
+  const guard = crossVentureAdvisoryAllowed(distinctLiveVentures);
+  const kept = [];
+  const dropped = [];
+  for (const c of candidates || []) {
+    if (c && c.cross_venture && !guard.allowed) dropped.push(c);
+    else kept.push(c);
+  }
+  return { kept, dropped, guard };
+}

--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -1,0 +1,149 @@
+/**
+ * The Adam rationale bar — the hard gate every candidate must clear before it
+ * may surface as an advisory. SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001. PURE +
+ * READ-ONLY (no DB, no I/O — fully unit-testable).
+ *
+ * A candidate clears the bar only if it:
+ *   1. carries the full ordered rationale structure (incl. a REQUIRED counterfactual),
+ *   2. cites a live anchor — an objective/KR, or (per-venture) an L2 vision + live metric,
+ *   3. has non-zero OKR linkage (a 0 score is a missing-OKR GAP, not a valid low priority),
+ *   4. does not duplicate an open SD,
+ *   5. passes the CONST-002 (proposer != approver) + CONST-010 (factual framing) self-check.
+ *
+ * Scoring reuses lib/eva/okr-priority-integrator.js constants (off-track KR x3).
+ * A GLOBAL cap of <=1 advisory per tick is enforced by selectAdvisory().
+ */
+import {
+  getContributionWeights,
+  getKRStatusMultipliers,
+} from '../eva/okr-priority-integrator.js';
+
+export const REQUIRED_RATIONALE_FIELDS = [
+  'opportunity',
+  'evidence',
+  'rationale',
+  'risk',
+  'counterfactual',
+];
+
+// CONST-010: no manipulative/urgent/certainty/emotional framing.
+const MANIPULATIVE_PATTERNS =
+  /\b(urgent(?:ly)?|immediately|act now|act fast|must act|critical(?:ly)?|guaranteed|certainly|definitely|absolutely|you (?:need|have) to|don'?t miss|last chance)\b/i;
+
+/**
+ * Compute an OKR-weighted score for a candidate from the KR it cites.
+ * Returns null when no scoreable KR linkage exists (caller treats that as a GAP).
+ * @param {object} candidate
+ * @returns {number|null}
+ */
+export function scoreCandidate(candidate) {
+  if (!candidate || !candidate.objective_kr || !candidate.objective_kr.kr_status) return null;
+  const w = getContributionWeights();
+  const m = getKRStatusMultipliers();
+  const cw = w[candidate.contribution_type] ?? w.supporting; // unknown -> supporting (0.5)
+  const sm = m[candidate.objective_kr.kr_status] ?? m.on_track; // unknown -> on_track (1.0)
+  return Math.round(cw * sm * 10); // 0..~45
+}
+
+/** CONST-002 + CONST-010 self-check. */
+export function passesConstSelfCheck(candidate) {
+  const violations = [];
+  // CONST-002: a candidate is a PROPOSAL — it must not encode an approve/accept/graduate action.
+  if (candidate.action && /accept|approve|graduate|auto[-_ ]?(accept|approve)/i.test(String(candidate.action))) {
+    violations.push('CONST-002: candidate encodes an approval action (proposer != approver)');
+  }
+  // CONST-010: factual framing only.
+  const text = [candidate.opportunity, candidate.rationale, candidate.risk, candidate.counterfactual]
+    .filter(Boolean)
+    .join(' ');
+  if (MANIPULATIVE_PATTERNS.test(text)) {
+    violations.push('CONST-010: manipulative/urgent/certainty framing detected');
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+/** A candidate must anchor to a live KR, or (per-venture) an L2 vision + live metric. */
+export function hasLiveAnchor(candidate) {
+  const hasKr = Boolean(candidate.objective_kr && candidate.objective_kr.kr);
+  const hasVisionMetric = Boolean(candidate.l2_vision_ref && candidate.live_metric);
+  return hasKr || hasVisionMetric;
+}
+
+/**
+ * Evaluate a single candidate against the bar.
+ * @param {object} candidate
+ * @param {{openSdKeys?: Set<string>|Array<string>}} [opts]
+ * @returns {{ clears: boolean, score: number|null, reasons: string[] }}
+ */
+export function evaluateCandidate(candidate, opts = {}) {
+  const openSdKeys =
+    opts.openSdKeys instanceof Set ? opts.openSdKeys : new Set(opts.openSdKeys || []);
+  if (!candidate || typeof candidate !== 'object') {
+    return { clears: false, score: null, reasons: ['no candidate'] };
+  }
+  const reasons = [];
+
+  // 1. full rationale structure
+  for (const f of REQUIRED_RATIONALE_FIELDS) {
+    if (!candidate[f] || String(candidate[f]).trim().length === 0) reasons.push(`missing ${f}`);
+  }
+  // 2. live anchor — never fabricate
+  if (!hasLiveAnchor(candidate)) reasons.push('no live KR or L2-vision+metric anchor');
+  // 3. OKR linkage score (0 => missing-OKR GAP, only excused when an L2 vision anchor exists)
+  const score = candidate.okr_score != null ? candidate.okr_score : scoreCandidate(candidate);
+  if ((score == null || score <= 0) && !candidate.l2_vision_ref) {
+    reasons.push('zero OKR linkage (missing-OKR GAP, not a valid candidate)');
+  }
+  // 4. dedup vs open SDs
+  if (candidate.dedup_key && openSdKeys.has(candidate.dedup_key)) reasons.push('duplicates an open SD');
+  // 5. CONST self-check
+  const cc = passesConstSelfCheck(candidate);
+  if (!cc.ok) reasons.push(...cc.violations);
+
+  return { clears: reasons.length === 0, score, reasons };
+}
+
+/**
+ * Evaluate all candidates, rank the cleared ones, and apply the GLOBAL <=1
+ * advisory cap. Returns the single advisory to surface (or null => ADAM_OK).
+ * @param {Array} candidates
+ * @param {object} [opts]
+ * @returns {{ surfaced: object|null, verdict: 'ADAM_OK'|'SURFACED', cleared: number, evaluated: Array }}
+ */
+export function selectAdvisory(candidates, opts = {}) {
+  const evaluated = (candidates || []).map((c) => {
+    const e = evaluateCandidate(c, opts);
+    return { candidate: c, ...e };
+  });
+  const cleared = evaluated.filter((x) => x.clears);
+  if (cleared.length === 0) {
+    return { surfaced: null, verdict: 'ADAM_OK', cleared: 0, evaluated };
+  }
+  cleared.sort(
+    (a, b) => (b.score ?? 0) - (a.score ?? 0) || (b.candidate.confidence ?? 0) - (a.candidate.confidence ?? 0)
+  );
+  return {
+    surfaced: { ...cleared[0].candidate, okr_score: cleared[0].score },
+    verdict: 'SURFACED',
+    cleared: cleared.length,
+    evaluated,
+  };
+}
+
+/** Format the surfaced candidate into the ordered advisory body string. */
+export function formatAdvisoryBody(c) {
+  if (!c) return '';
+  const anchor = c.objective_kr && c.objective_kr.kr
+    ? `${c.objective_kr.objective || '(objective)'} / ${c.objective_kr.kr} (off-track delta: ${c.objective_kr.off_track_delta ?? 'n/a'})`
+    : `L2-vision ${c.l2_vision_ref} + live metric ${c.live_metric}`;
+  return [
+    `[ADAM ADVISORY] scope=${c.scope_key}`,
+    `Opportunity: ${c.opportunity}`,
+    `Objective/KR: ${anchor}`,
+    `Evidence: ${c.evidence}`,
+    `Rationale: ${c.rationale}`,
+    `Risk: ${c.risk}`,
+    `Counterfactual: ${c.counterfactual}`,
+    `Confidence: ${c.confidence ?? 'n/a'}`,
+  ].join('\n');
+}

--- a/lib/adam/scope-registry.js
+++ b/lib/adam/scope-registry.js
@@ -1,0 +1,114 @@
+/**
+ * Adam scope registry — enumerate portfolio scopes for the governance heartbeat.
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001. READ-ONLY.
+ *
+ * Classifies scopes from the canonical `applications` table (kind + venture_id)
+ * rather than a hard-coded list, reusing repo-paths semantics for name
+ * normalization. Returns one scope per active portfolio surface:
+ *   - harness        = EHG_Engineer (kind=platform)
+ *   - platform       = EHG          (kind=platform)
+ *   - venture:<id>   = each active non-demo venture that has a live application row
+ *
+ * The `supabase` argument MUST be a @supabase/supabase-js client (query-builder
+ * semantics: .from().select().eq().is()), NOT a raw pg.Client.
+ */
+import { normalizeAppName } from '../repo-paths.js';
+
+export const HARNESS_APP = 'EHG_Engineer';
+export const PLATFORM_APP = 'EHG';
+
+/**
+ * Enumerate the live portfolio scopes.
+ * @param {object} supabase - supabase-js client (service role)
+ * @returns {Promise<Array<{scope_key,kind,app_name,repo_path,venture_id}>>}
+ */
+export async function enumerateScopes(supabase) {
+  const { data: apps, error: appErr } = await supabase
+    .from('applications')
+    .select('id, name, normalized_name, kind, local_path, venture_id')
+    .eq('status', 'active')
+    .is('deleted_at', null);
+  if (appErr) throw new Error(`enumerateScopes: applications query failed: ${appErr.message}`);
+
+  // active, non-demo ventures form the per-venture allowlist
+  const { data: ventures, error: venErr } = await supabase
+    .from('ventures')
+    .select('id, name')
+    .eq('status', 'active')
+    .eq('is_demo', false)
+    .is('deleted_at', null);
+  if (venErr) throw new Error(`enumerateScopes: ventures query failed: ${venErr.message}`);
+  const liveVentureIds = new Set((ventures || []).map((v) => v.id));
+
+  const harnessNorm = normalizeAppName(HARNESS_APP);
+  const scopes = [];
+  for (const app of apps || []) {
+    const kind = String(app.kind || '').toLowerCase();
+    if (kind === 'platform') {
+      const isHarness = normalizeAppName(app.name) === harnessNorm;
+      scopes.push({
+        scope_key: isHarness ? 'harness' : 'platform',
+        kind: 'platform',
+        app_name: app.name,
+        repo_path: app.local_path || null,
+        venture_id: null,
+      });
+    } else if (kind === 'venture') {
+      // per-venture scope ONLY when the app links to a live (active, non-demo) venture
+      if (app.venture_id && liveVentureIds.has(app.venture_id)) {
+        scopes.push({
+          scope_key: `venture:${app.venture_id}`,
+          kind: 'venture',
+          app_name: app.name,
+          repo_path: app.local_path || null,
+          venture_id: app.venture_id,
+        });
+      }
+    }
+  }
+
+  // deterministic order: harness, platform, then ventures by app_name
+  const rank = (s) => (s.scope_key === 'harness' ? 0 : s.scope_key === 'platform' ? 1 : 2);
+  scopes.sort((a, b) => rank(a) - rank(b) || String(a.app_name).localeCompare(String(b.app_name)));
+  return scopes;
+}
+
+/**
+ * Count the distinct live ventures in a scope list (drives the liveness guard).
+ * @param {Array} scopes
+ * @returns {number}
+ */
+export function countLiveVentures(scopes) {
+  return (scopes || []).filter((s) => s.kind === 'venture').length;
+}
+
+/**
+ * Weighted round-robin: pick ONE scope per tick. Deterministic given tickIndex
+ * (no Math.random — the loop must be replayable). harness/platform carry the
+ * live OKRs today, so they get double weight.
+ * @param {Array} scopes
+ * @param {number} tickIndex
+ * @returns {object|null}
+ */
+export function selectScopeForTick(scopes, tickIndex = 0) {
+  if (!Array.isArray(scopes) || scopes.length === 0) return null;
+  const weighted = [];
+  for (const s of scopes) {
+    const w = s.kind === 'platform' ? 2 : 1;
+    for (let i = 0; i < w; i++) weighted.push(s);
+  }
+  const i = Number.isFinite(tickIndex) ? tickIndex : 0;
+  const idx = ((i % weighted.length) + weighted.length) % weighted.length;
+  return weighted[idx];
+}
+
+/**
+ * Resolve an explicit --scope argument against the enumerated scopes.
+ * Accepts: 'harness' | 'platform' | 'venture:<id>' | 'auto'.
+ * @returns {object|null} the matching scope, or null if not found
+ */
+export function resolveScopeArg(scopes, scopeArg, tickIndex = 0) {
+  const arg = String(scopeArg || 'auto').trim();
+  if (arg === 'auto' || arg === '') return selectScopeForTick(scopes, tickIndex);
+  return (scopes || []).find((s) => s.scope_key === arg) || null;
+}

--- a/package.json
+++ b/package.json
@@ -303,6 +303,8 @@
     "adam:register": "node scripts/adam-register.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",
     "adam:retro": "node scripts/adam-retro.cjs",
+    "adam:scan": "node scripts/adam-opportunity-scan.cjs --scan",
+    "adam:briefing": "node scripts/adam-opportunity-scan.cjs --briefing",
     "coordinator:cold-recovery": "node scripts/coordinator-cold-recovery.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Adam opportunity-scan CLI — the read-only proactive governance heartbeat.
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001.
+ *
+ * Rotates through portfolio scopes ONE per tick (weighted round-robin), runs a
+ * per-scope read-only briefing over existing tables, applies the rationale bar,
+ * and either appends ADAM_OK to a local ledger (silence-by-default) or shells a
+ * SINGLE ranked advisory to scripts/adam-advisory.cjs. Writes NOTHING to
+ * strategy tables. Ships INERT behind ADAM_GOVERNANCE_HEARTBEAT_V1 (default OFF):
+ * the advisory shell-out is gated; the read-only briefing/ledger may still run.
+ *
+ * Subcommands:  --briefing | --scan | --ledger
+ * Scope:        --scope harness | platform | venture:<id> | auto   (default: auto)
+ * Tick index:   --tick <n>   (deterministic round-robin selector; default 0)
+ *
+ * ESM/CJS note: lib/adam/* and lib/eva/* are ESM, so this CommonJS CLI loads
+ * them via dynamic import(pathToFileURL(...)) (Windows-safe). The advisory lane
+ * (scripts/adam-advisory.cjs) and the supabase client (lib/supabase-client.cjs)
+ * are CommonJS and are require()d directly.
+ */
+const path = require('path');
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const LEDGER_PATH = path.join(REPO_ROOT, '.adam-scan-ledger.json');
+const ADVISORY_CLI = path.join(__dirname, 'adam-advisory.cjs');
+const LEDGER_MAX_ENTRIES = 500;
+
+/** Feature-flag helper: on|1|true => enabled; everything else (incl. undefined) => OFF. */
+function isFlagEnabled(env = process.env) {
+  const v = String(env.ADAM_GOVERNANCE_HEARTBEAT_V1 || 'off').toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}
+
+/** Parse argv into { mode, scope, tick }. mode is null when no subcommand flag is present. */
+function parseArgs(argv) {
+  let mode = null;
+  if (argv.includes('--briefing')) mode = 'briefing';
+  else if (argv.includes('--ledger')) mode = 'ledger';
+  else if (argv.includes('--scan')) mode = 'scan';
+  const sIdx = argv.indexOf('--scope');
+  const scope = sIdx >= 0 ? String(argv[sIdx + 1] || 'auto') : 'auto';
+  const tIdx = argv.indexOf('--tick');
+  const tick = tIdx >= 0 ? Number(argv[tIdx + 1]) || 0 : 0;
+  return { mode, scope, tick };
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/adam-opportunity-scan.cjs <--briefing|--scan|--ledger> [--scope harness|platform|venture:<id>|auto] [--tick <n>]',
+    '  --briefing   print the read-only per-scope briefing',
+    '  --scan       evaluate the rationale bar; surface <=1 advisory or write ADAM_OK',
+    '  --ledger     print the decision ledger (.adam-scan-ledger.json)',
+  ].join('\n');
+}
+
+/** Append one verdict entry to the local ledger (bounded, best-effort). */
+function appendLedger(entry) {
+  let arr = [];
+  try {
+    if (fs.existsSync(LEDGER_PATH)) {
+      const parsed = JSON.parse(fs.readFileSync(LEDGER_PATH, 'utf8'));
+      if (Array.isArray(parsed)) arr = parsed;
+    }
+  } catch {
+    arr = [];
+  }
+  arr.push(entry);
+  if (arr.length > LEDGER_MAX_ENTRIES) arr = arr.slice(-LEDGER_MAX_ENTRIES);
+  try {
+    fs.writeFileSync(LEDGER_PATH, JSON.stringify(arr, null, 2) + '\n');
+  } catch (e) {
+    process.stderr.write(`[adam-scan] ledger write failed (non-fatal): ${e.message}\n`);
+  }
+  return entry;
+}
+
+function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = null }) {
+  return {
+    ts: new Date().toISOString(),
+    scope: scope ? scope.scope_key : 'none',
+    verdict, // ADAM_OK | SURFACED | SUPPRESSED_FLAG_OFF
+    cleared,
+    flag: flagEnabled ? 'on' : 'off',
+    ...(detail ? { detail } : {}),
+  };
+}
+
+async function esm(rel) {
+  return import(pathToFileURL(path.join(__dirname, rel)).href);
+}
+
+/** Fetch open SD dedup keys (read-only). Defensive: returns an empty Set on any error. */
+async function fetchOpenSdKeys(supabase) {
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key')
+      .in('status', ['draft', 'active', 'in_progress', 'pending_approval']);
+    return new Set((data || []).map((r) => r.sd_key).filter(Boolean));
+  } catch {
+    return new Set();
+  }
+}
+
+async function runBriefing(scope, supabase, liveVentureCount) {
+  const { briefHarness } = await esm('../lib/adam/briefings/harness.js');
+  const { briefPlatform } = await esm('../lib/adam/briefings/platform.js');
+  const { briefVenture } = await esm('../lib/adam/briefings/venture.js');
+  if (scope.scope_key === 'harness') return briefHarness(supabase);
+  if (scope.scope_key === 'platform') return briefPlatform(supabase, { liveVentureCount });
+  return briefVenture(supabase, scope.venture_id);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const { mode, scope: scopeArg, tick } = parseArgs(argv);
+
+  if (!mode) {
+    process.stderr.write(usage() + '\n');
+    process.exit(2);
+  }
+
+  const flagEnabled = isFlagEnabled();
+
+  // --ledger is a pure local read; no DB needed.
+  if (mode === 'ledger') {
+    try {
+      const raw = fs.existsSync(LEDGER_PATH) ? fs.readFileSync(LEDGER_PATH, 'utf8') : '[]';
+      process.stdout.write(raw.endsWith('\n') ? raw : raw + '\n');
+    } catch (e) {
+      process.stdout.write('[]\n');
+      process.stderr.write(`[adam-scan] ledger read failed: ${e.message}\n`);
+    }
+    process.exit(0);
+  }
+
+  // Reads below are flag-independent (read-only). Fail OPEN on any error.
+  try {
+    const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+    const supabase = createSupabaseServiceClient('engineer');
+
+    const { enumerateScopes, resolveScopeArg, countLiveVentures } = await esm('../lib/adam/scope-registry.js');
+    const scopes = await enumerateScopes(supabase);
+    const liveVentureCount = countLiveVentures(scopes);
+    const scope = resolveScopeArg(scopes, scopeArg, tick);
+
+    if (!scope) {
+      process.stderr.write(`[adam-scan] scope '${scopeArg}' did not resolve to a live scope.\n` + usage() + '\n');
+      process.exit(2);
+    }
+
+    const briefing = await runBriefing(scope, supabase, liveVentureCount);
+
+    if (mode === 'briefing') {
+      process.stdout.write(JSON.stringify({ scope: scope.scope_key, ...briefing }, null, 2) + '\n');
+      process.exit(0);
+    }
+
+    // mode === 'scan'
+    const { selectAdvisory, formatAdvisoryBody } = await esm('../lib/adam/rationale-bar.js');
+    const { applyLivenessGuard } = await esm('../lib/adam/liveness-guard.js');
+
+    const guarded = applyLivenessGuard(briefing.candidates || [], liveVentureCount);
+    const openSdKeys = await fetchOpenSdKeys(supabase);
+    const result = selectAdvisory(guarded.kept, { openSdKeys });
+
+    if (!result.surfaced) {
+      const entry = appendLedger(buildLedgerEntry({ scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled }));
+      process.stdout.write(`ADAM_OK scope=${scope.scope_key} (nothing cleared the bar)\n`);
+      process.stdout.write(JSON.stringify(entry) + '\n');
+      process.exit(0);
+    }
+
+    const body = formatAdvisoryBody(result.surfaced);
+    if (!flagEnabled) {
+      // Cleared the bar, but the surfacing path is inert until the flag flips.
+      appendLedger(buildLedgerEntry({ scope, verdict: 'SUPPRESSED_FLAG_OFF', cleared: result.cleared, flagEnabled, detail: result.surfaced.dedup_key || null }));
+      process.stdout.write(`SUPPRESSED_FLAG_OFF scope=${scope.scope_key} (1 cleared; ADAM_GOVERNANCE_HEARTBEAT_V1 is off)\n`);
+      process.exit(0);
+    }
+
+    // flag ON: emit exactly ONE advisory via the existing lane.
+    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled, detail: result.surfaced.dedup_key || null }));
+    const r = spawnSync('node', [ADVISORY_CLI, 'send', body], { stdio: 'inherit' });
+    process.exit(r.status == null ? 0 : r.status);
+  } catch (e) {
+    // FAIL OPEN — never break Adam's tick.
+    process.stderr.write(`[adam-scan] read-only scan degraded to no-signal: ${e.message}\n`);
+    process.exit(0);
+  }
+}
+
+module.exports = { isFlagEnabled, parseArgs, buildLedgerEntry, usage, LEDGER_PATH };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -21,7 +21,6 @@
  */
 const path = require('path');
 const fs = require('fs');
-const { pathToFileURL } = require('url');
 const { spawnSync } = require('child_process');
 
 const REPO_ROOT = path.join(__dirname, '..');
@@ -89,9 +88,10 @@ function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = n
   };
 }
 
-async function esm(rel) {
-  return import(pathToFileURL(path.join(__dirname, rel)).href);
-}
+// NOTE: lib/adam/* and lib/eva/* are ESM; this CommonJS CLI loads them via
+// dynamic import() with STRING-LITERAL relative specifiers — both Windows-safe
+// at runtime and traceable by the WIRE_CHECK static call-graph (a computed
+// specifier would create no edge and false-positive the libs as unreachable).
 
 /** Fetch open SD dedup keys (read-only). Defensive: returns an empty Set on any error. */
 async function fetchOpenSdKeys(supabase) {
@@ -107,9 +107,9 @@ async function fetchOpenSdKeys(supabase) {
 }
 
 async function runBriefing(scope, supabase, liveVentureCount) {
-  const { briefHarness } = await esm('../lib/adam/briefings/harness.js');
-  const { briefPlatform } = await esm('../lib/adam/briefings/platform.js');
-  const { briefVenture } = await esm('../lib/adam/briefings/venture.js');
+  const { briefHarness } = await import('../lib/adam/briefings/harness.js');
+  const { briefPlatform } = await import('../lib/adam/briefings/platform.js');
+  const { briefVenture } = await import('../lib/adam/briefings/venture.js');
   if (scope.scope_key === 'harness') return briefHarness(supabase);
   if (scope.scope_key === 'platform') return briefPlatform(supabase, { liveVentureCount });
   return briefVenture(supabase, scope.venture_id);
@@ -143,7 +143,7 @@ async function main() {
     const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
     const supabase = createSupabaseServiceClient('engineer');
 
-    const { enumerateScopes, resolveScopeArg, countLiveVentures } = await esm('../lib/adam/scope-registry.js');
+    const { enumerateScopes, resolveScopeArg, countLiveVentures } = await import('../lib/adam/scope-registry.js');
     const scopes = await enumerateScopes(supabase);
     const liveVentureCount = countLiveVentures(scopes);
     const scope = resolveScopeArg(scopes, scopeArg, tick);
@@ -161,8 +161,8 @@ async function main() {
     }
 
     // mode === 'scan'
-    const { selectAdvisory, formatAdvisoryBody } = await esm('../lib/adam/rationale-bar.js');
-    const { applyLivenessGuard } = await esm('../lib/adam/liveness-guard.js');
+    const { selectAdvisory, formatAdvisoryBody } = await import('../lib/adam/rationale-bar.js');
+    const { applyLivenessGuard } = await import('../lib/adam/liveness-guard.js');
 
     const guarded = applyLivenessGuard(briefing.candidates || [], liveVentureCount);
     const openSdKeys = await fetchOpenSdKeys(supabase);

--- a/scripts/adam-opportunity-scan.test.js
+++ b/scripts/adam-opportunity-scan.test.js
@@ -1,0 +1,52 @@
+/**
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001 — CLI pure helpers (DB-free).
+ * Mixed ESM-test / CJS-require, like scripts/adam-advisory.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+const { isFlagEnabled, parseArgs, buildLedgerEntry, usage } = require('./adam-opportunity-scan.cjs');
+
+describe('isFlagEnabled (ADAM_GOVERNANCE_HEARTBEAT_V1)', () => {
+  it('is OFF for undefined / off / garbage', () => {
+    expect(isFlagEnabled({})).toBe(false);
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: 'off' })).toBe(false);
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: 'maybe' })).toBe(false);
+  });
+  it('is ON only for on / 1 / true', () => {
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: 'on' })).toBe(true);
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: '1' })).toBe(true);
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: 'TRUE' })).toBe(true);
+  });
+});
+
+describe('parseArgs', () => {
+  it('parses subcommand, scope, and tick', () => {
+    expect(parseArgs(['--scan', '--scope', 'venture:abc', '--tick', '3'])).toEqual({ mode: 'scan', scope: 'venture:abc', tick: 3 });
+    expect(parseArgs(['--briefing'])).toEqual({ mode: 'briefing', scope: 'auto', tick: 0 });
+    expect(parseArgs(['--ledger'])).toEqual({ mode: 'ledger', scope: 'auto', tick: 0 });
+  });
+  it('returns mode=null when no subcommand flag is present', () => {
+    expect(parseArgs([]).mode).toBeNull();
+    expect(parseArgs(['--scope', 'harness']).mode).toBeNull();
+  });
+});
+
+describe('buildLedgerEntry', () => {
+  it('records scope, verdict and flag state with a timestamp', () => {
+    const e = buildLedgerEntry({ scope: { scope_key: 'harness' }, verdict: 'ADAM_OK', cleared: 0, flagEnabled: false });
+    expect(e).toMatchObject({ scope: 'harness', verdict: 'ADAM_OK', cleared: 0, flag: 'off' });
+    expect(typeof e.ts).toBe('string');
+  });
+  it('marks the flag on when enabled', () => {
+    const e = buildLedgerEntry({ scope: { scope_key: 'platform' }, verdict: 'SURFACED', cleared: 1, flagEnabled: true });
+    expect(e.flag).toBe('on');
+  });
+});
+
+describe('usage', () => {
+  it('describes the three subcommands', () => {
+    const u = usage();
+    expect(u).toMatch(/--briefing/);
+    expect(u).toMatch(/--scan/);
+    expect(u).toMatch(/--ledger/);
+  });
+});

--- a/tests/unit/adam/briefings.test.js
+++ b/tests/unit/adam/briefings.test.js
@@ -1,0 +1,60 @@
+/**
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001 — per-scope briefing summarizers
+ * (pure, DB-free).
+ */
+import { describe, it, expect } from 'vitest';
+import { summarizeHarness } from '../../../lib/adam/briefings/harness.js';
+import { summarizePlatform } from '../../../lib/adam/briefings/platform.js';
+import { summarizeVenture } from '../../../lib/adam/briefings/venture.js';
+
+describe('summarizeHarness', () => {
+  it('counts signals and surfaces no fabricated candidate', () => {
+    const r = summarizeHarness({ backlog: [1, 2], retros: [1], gateRecs: [1, 2, 3], evaRecs: [] });
+    expect(r.scope_key).toBe('harness');
+    expect(r.signals).toMatchObject({ open_harness_backlog: 2, recent_retros: 1, gate_tuning_recs: 3, pending_eva_recs: 0 });
+    expect(r.candidates).toEqual([]);
+  });
+  it('treats empty inputs as no signal, not an error', () => {
+    const r = summarizeHarness();
+    expect(r.signals.open_harness_backlog).toBe(0);
+  });
+});
+
+describe('summarizePlatform', () => {
+  it('clusters gate failures by stage and reports the liveness guard', () => {
+    const r = summarizePlatform({
+      stages: new Array(26).fill({}),
+      gateFailures: [{ stage_number: 16 }, { stage_number: 16 }, { stage_number: 19 }],
+      blockedWork: [{ lifecycle_stage: 16 }],
+      liveVentureCount: 2,
+    });
+    expect(r.signals.ssot_stage_count).toBe(26);
+    expect(r.signals.failure_clusters).toEqual({ stage_16: 2, stage_19: 1 });
+    expect(r.liveness.allowed).toBe(false); // 2 < K=3
+    expect(r.candidates).toEqual([]);
+  });
+});
+
+describe('summarizeVenture', () => {
+  it('surfaces data-gap proposals when telemetry is dry (never fabricates a KR)', () => {
+    const r = summarizeVenture({ ventureId: 'V1', competitors: [], stageWork: [], separability: [], visionDocs: [] });
+    expect(r.scope_key).toBe('venture:V1');
+    expect(r.candidates).toEqual([]);
+    const areas = r.gaps.map((g) => g.area);
+    expect(areas).toContain('competitive_intel');
+    expect(areas).toContain('l2_vision');
+  });
+
+  it('reports an L2 vision as present and counts blocked/red stage work', () => {
+    const r = summarizeVenture({
+      ventureId: 'V2',
+      competitors: [{ id: 'c1' }],
+      stageWork: [{ stage_status: 'blocked' }, { health_score: 'red' }, { stage_status: 'completed', health_score: 'green' }],
+      separability: [{ overall_score: 80 }],
+      visionDocs: [{ level: 'L2', chairman_approved: true }],
+    });
+    expect(r.signals.l2_vision_present).toBe(true);
+    expect(r.signals.blocked_or_red).toBe(2);
+    expect(r.gaps.map((g) => g.area)).not.toContain('l2_vision');
+  });
+});

--- a/tests/unit/adam/liveness-guard.test.js
+++ b/tests/unit/adam/liveness-guard.test.js
@@ -1,0 +1,40 @@
+/**
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001 — liveness guard (pure, DB-free).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  crossVentureAdvisoryAllowed,
+  applyLivenessGuard,
+  MIN_LIVE_VENTURES_FOR_CROSS_VENTURE,
+} from '../../../lib/adam/liveness-guard.js';
+
+describe('crossVentureAdvisoryAllowed (K=3)', () => {
+  it('suppresses below K and allows at/above K', () => {
+    expect(MIN_LIVE_VENTURES_FOR_CROSS_VENTURE).toBe(3);
+    expect(crossVentureAdvisoryAllowed(2).allowed).toBe(false);
+    expect(crossVentureAdvisoryAllowed(3).allowed).toBe(true);
+    expect(crossVentureAdvisoryAllowed(undefined).allowed).toBe(false);
+  });
+});
+
+describe('applyLivenessGuard', () => {
+  const classA = { dedup_key: 'a', cross_venture: false };
+  const classB = { dedup_key: 'b', cross_venture: true };
+
+  it('drops class-B (cross-venture) candidates when the corpus is thin', () => {
+    const { kept, dropped } = applyLivenessGuard([classA, classB], 2);
+    expect(kept).toEqual([classA]);
+    expect(dropped).toEqual([classB]);
+  });
+
+  it('keeps class-B candidates once the corpus reaches K', () => {
+    const { kept, dropped } = applyLivenessGuard([classA, classB], 3);
+    expect(kept).toContain(classB);
+    expect(dropped).toEqual([]);
+  });
+
+  it('always keeps class-A (single-scope) candidates', () => {
+    const { kept } = applyLivenessGuard([classA], 0);
+    expect(kept).toEqual([classA]);
+  });
+});

--- a/tests/unit/adam/rationale-bar.test.js
+++ b/tests/unit/adam/rationale-bar.test.js
@@ -1,0 +1,124 @@
+/**
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001 — the rationale bar (pure, DB-free).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateCandidate,
+  scoreCandidate,
+  selectAdvisory,
+  formatAdvisoryBody,
+  passesConstSelfCheck,
+  hasLiveAnchor,
+} from '../../../lib/adam/rationale-bar.js';
+
+const validKrCandidate = () => ({
+  scope_key: 'harness',
+  opportunity: 'Close the off-track gate-pass-rate KR for harness governance.',
+  objective_kr: { objective: 'O-GOV', kr: 'KR-gate-pass-85', kr_status: 'off_track', off_track_delta: -12 },
+  contribution_type: 'direct',
+  evidence: 'leo_gate_reviews shows pass_rate 73% over the last 4 weeks (row id 438).',
+  rationale: 'A targeted gate-tuning SD would lift the pass rate toward the 85% KR.',
+  risk: 'Over-tuning could mask real defects.',
+  counterfactual: 'If left alone, pass rate trends further from target as volume grows.',
+  confidence: 0.7,
+  dedup_key: 'harness-gate-pass-tuning',
+});
+
+describe('evaluateCandidate', () => {
+  it('clears the bar for a fully-formed, live-KR-anchored candidate', () => {
+    const r = evaluateCandidate(validKrCandidate(), { openSdKeys: new Set() });
+    expect(r.clears).toBe(true);
+    expect(r.reasons).toEqual([]);
+  });
+
+  it('rejects a candidate missing the required counterfactual', () => {
+    const c = validKrCandidate();
+    delete c.counterfactual;
+    const r = evaluateCandidate(c);
+    expect(r.clears).toBe(false);
+    expect(r.reasons).toContain('missing counterfactual');
+  });
+
+  it('rejects a candidate with no live KR / L2-vision anchor (never fabricate)', () => {
+    const c = validKrCandidate();
+    c.objective_kr = null;
+    const r = evaluateCandidate(c);
+    expect(r.clears).toBe(false);
+    expect(r.reasons).toContain('no live KR or L2-vision+metric anchor');
+  });
+
+  it('treats zero OKR linkage as a missing-OKR GAP unless an L2 vision anchor exists', () => {
+    const c = validKrCandidate();
+    c.objective_kr = { objective: 'O', kr: 'KR', kr_status: 'completed' }; // 1.5*0.5*10=8 -> ok
+    c.contribution_type = 'supporting';
+    c.okr_score = 0;
+    const r = evaluateCandidate(c);
+    expect(r.clears).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/zero OKR linkage/);
+  });
+
+  it('rejects a candidate that duplicates an open SD', () => {
+    const r = evaluateCandidate(validKrCandidate(), { openSdKeys: new Set(['harness-gate-pass-tuning']) });
+    expect(r.clears).toBe(false);
+    expect(r.reasons).toContain('duplicates an open SD');
+  });
+
+  it('rejects manipulative framing (CONST-010)', () => {
+    const c = validKrCandidate();
+    c.rationale = 'You must act now — this is critically urgent and guaranteed to help.';
+    const r = evaluateCandidate(c);
+    expect(r.clears).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/CONST-010/);
+  });
+
+  it('rejects a self-approval action (CONST-002)', () => {
+    const c = validKrCandidate();
+    c.action = 'auto-accept';
+    expect(passesConstSelfCheck(c).ok).toBe(false);
+    expect(evaluateCandidate(c).clears).toBe(false);
+  });
+});
+
+describe('scoreCandidate', () => {
+  it('weights direct + off_track highest (1.5 * 3.0 * 10 = 45)', () => {
+    expect(scoreCandidate(validKrCandidate())).toBe(45);
+  });
+  it('returns null without a scoreable KR', () => {
+    expect(scoreCandidate({ objective_kr: null })).toBeNull();
+  });
+});
+
+describe('hasLiveAnchor', () => {
+  it('accepts an L2 vision + live metric as a per-venture anchor', () => {
+    expect(hasLiveAnchor({ l2_vision_ref: 'VIS-1', live_metric: 'MRR=1200' })).toBe(true);
+    expect(hasLiveAnchor({})).toBe(false);
+  });
+});
+
+describe('selectAdvisory (global <=1 cap)', () => {
+  it('returns ADAM_OK when nothing clears the bar', () => {
+    const r = selectAdvisory([{ opportunity: 'x' }]);
+    expect(r.verdict).toBe('ADAM_OK');
+    expect(r.surfaced).toBeNull();
+  });
+
+  it('surfaces exactly ONE (top-ranked) advisory even when several clear', () => {
+    const a = validKrCandidate();
+    const b = validKrCandidate();
+    b.dedup_key = 'other';
+    b.objective_kr.kr_status = 'at_risk'; // 1.5*2.0*10 = 30 < 45
+    const r = selectAdvisory([b, a], { openSdKeys: new Set() });
+    expect(r.verdict).toBe('SURFACED');
+    expect(r.cleared).toBe(2);
+    expect(r.surfaced.dedup_key).toBe('harness-gate-pass-tuning'); // the 45-score one
+  });
+});
+
+describe('formatAdvisoryBody', () => {
+  it('emits the full ordered rationale structure incl. Counterfactual', () => {
+    const body = formatAdvisoryBody(validKrCandidate());
+    expect(body).toMatch(/Opportunity:/);
+    expect(body).toMatch(/Counterfactual:/);
+    expect(body).toMatch(/Confidence:/);
+  });
+});

--- a/tests/unit/adam/scope-registry.test.js
+++ b/tests/unit/adam/scope-registry.test.js
@@ -1,0 +1,101 @@
+/**
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001 — scope registry.
+ * DB-free: a tiny thenable mock stands in for the supabase-js query builder.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  enumerateScopes,
+  selectScopeForTick,
+  resolveScopeArg,
+  countLiveVentures,
+} from '../../../lib/adam/scope-registry.js';
+
+function thenable(rows) {
+  return {
+    select() { return this; },
+    eq() { return this; },
+    is() { return this; },
+    order() { return this; },
+    limit() { return this; },
+    then(onF, onR) { return Promise.resolve({ data: rows, error: null }).then(onF, onR); },
+  };
+}
+function mockClient({ apps, ventures }) {
+  return {
+    from(t) {
+      if (t === 'applications') return thenable(apps);
+      if (t === 'ventures') return thenable(ventures);
+      return thenable([]);
+    },
+  };
+}
+
+const APPS = [
+  { id: 'a1', name: 'EHG_Engineer', kind: 'platform', local_path: '/p/eng', venture_id: null },
+  { id: 'a2', name: 'EHG', kind: 'platform', local_path: '/p/ehg', venture_id: null },
+  { id: 'a3', name: 'CronGenius', kind: 'venture', local_path: '/p/cg', venture_id: 'V1' },
+  { id: 'a4', name: 'DataDistill', kind: 'venture', local_path: '/p/dd', venture_id: 'V2' },
+  { id: 'a5', name: 'Synthetic NoVenture', kind: 'venture', local_path: '/p/sn', venture_id: null },
+  { id: 'a6', name: 'LinkedToCancelled', kind: 'venture', local_path: '/p/lc', venture_id: 'V3' },
+];
+const VENTURES = [
+  { id: 'V1', name: 'CronGenius' },
+  { id: 'V2', name: 'DataDistill' },
+]; // V3 is cancelled => not returned by the active+non-demo query
+
+describe('enumerateScopes', () => {
+  it('returns harness + platform + exactly the 2 live ventures', async () => {
+    const scopes = await enumerateScopes(mockClient({ apps: APPS, ventures: VENTURES }));
+    expect(scopes.map((s) => s.scope_key)).toEqual(['harness', 'platform', 'venture:V1', 'venture:V2']);
+  });
+
+  it('excludes a venture-kind app with NULL venture_id and one linked to a non-live venture', async () => {
+    const scopes = await enumerateScopes(mockClient({ apps: APPS, ventures: VENTURES }));
+    const ventureKeys = scopes.filter((s) => s.kind === 'venture').map((s) => s.scope_key);
+    expect(ventureKeys).not.toContain('venture:V3');
+    expect(scopes.some((s) => s.app_name === 'Synthetic NoVenture')).toBe(false);
+  });
+
+  it('classifies EHG_Engineer as harness and EHG as platform', async () => {
+    const scopes = await enumerateScopes(mockClient({ apps: APPS, ventures: VENTURES }));
+    expect(scopes.find((s) => s.scope_key === 'harness').app_name).toBe('EHG_Engineer');
+    expect(scopes.find((s) => s.scope_key === 'platform').app_name).toBe('EHG');
+    expect(countLiveVentures(scopes)).toBe(2);
+  });
+
+  it('throws when the applications query errors', async () => {
+    const bad = { from: () => ({ select() { return this; }, eq() { return this; }, is() { return this; }, then(f) { return Promise.resolve({ data: null, error: { message: 'boom' } }).then(f); } }) };
+    await expect(enumerateScopes(bad)).rejects.toThrow(/applications query failed/);
+  });
+});
+
+describe('selectScopeForTick (weighted round-robin, deterministic)', () => {
+  const scopes = [
+    { scope_key: 'harness', kind: 'platform' },
+    { scope_key: 'platform', kind: 'platform' },
+    { scope_key: 'venture:V1', kind: 'venture' },
+    { scope_key: 'venture:V2', kind: 'venture' },
+  ];
+  it('weights platform scopes double and is replayable by tick index', () => {
+    // weighted slots: [harness,harness,platform,platform,venture:V1,venture:V2]
+    expect(selectScopeForTick(scopes, 0).scope_key).toBe('harness');
+    expect(selectScopeForTick(scopes, 2).scope_key).toBe('platform');
+    expect(selectScopeForTick(scopes, 4).scope_key).toBe('venture:V1');
+    expect(selectScopeForTick(scopes, 6).scope_key).toBe('harness'); // wraps
+  });
+  it('returns null for an empty scope list', () => {
+    expect(selectScopeForTick([], 0)).toBeNull();
+  });
+});
+
+describe('resolveScopeArg', () => {
+  const scopes = [
+    { scope_key: 'harness', kind: 'platform' },
+    { scope_key: 'venture:V1', kind: 'venture', venture_id: 'V1' },
+  ];
+  it('resolves an explicit key, auto, and returns null for an unknown scope', () => {
+    expect(resolveScopeArg(scopes, 'venture:V1').venture_id).toBe('V1');
+    expect(resolveScopeArg(scopes, 'auto', 0)).toBeTruthy();
+    expect(resolveScopeArg(scopes, 'bogus')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the Adam read-only proactive opportunity-scan engine — the governance-heartbeat contract (`leo_protocol_sections` id=601). Ships **INERT** behind `ADAM_GOVERNANCE_HEARTBEAT_V1` (default OFF) and writes **nothing** to strategy tables. Makes Adam propose MORE but execute the SAME (zero).

## What's new
- **`lib/adam/scope-registry.js`** — `enumerateScopes()` classifies portfolio scopes off `applications.kind` + `venture_id` (reuses `repo-paths.js`); weighted round-robin one-scope/tick. Yields harness + platform + the 2 live ventures (CronGenius, DataDistill).
- **`lib/adam/liveness-guard.js`** — suppresses class-B cross-venture advisories below K=3 live ventures (today's 2-venture corpus → suppressed).
- **`lib/adam/rationale-bar.js`** — the hard bar: live-KR / L2-vision+metric anchor, OKR-weighted scoring (off-track ×3 via `okr-priority-integrator` constants), dedup vs open SDs, CONST-002/010 self-check, **required counterfactual**, global ≤1-advisory cap.
- **`lib/adam/briefings/{harness,platform,venture}.js`** — per-scope read-only signal scans over existing tables; empty tables = "no signal"; per-venture data gaps → DRAFT-SD proposals (never fabricate a KR).
- **`scripts/adam-opportunity-scan.cjs`** — flag-gated read-only CLI (`--briefing` / `--scan` / `--ledger` / `--scope`); ADAM_OK silence-by-default ledger; one advisory via `adam-advisory.cjs`.
- **npm aliases** `adam:scan` / `adam:briefing` (WIRE_CHECK entry points).

## Verification
- 36/36 DB-free unit tests pass (scope enum, rationale bar, liveness guard, briefings, CLI helpers).
- TESTING sub-agent **PASS** (confidence 92).
- Verified live **read-only** against prod DB: harness/platform/venture briefings + ADAM_OK ledger write.
- WIRE_CHECK reachability verified with the gate's own `buildCallGraph` + `checkReachability` (0 unreachable) — CLI uses string-literal dynamic-import specifiers so the static analyzer traces `lib/adam/*`.

## Notes
- Read-only + flag-OFF + new-files = low blast radius despite size. PR size (~600 source + ~450 test LOC) is one cohesive Tier-3 subsystem; splitting would orphan lib modules under WIRE_CHECK.
- Depends on (completed) SD-LEO-INFRA-ADAM-GOVERNANCE-HEARTBEAT-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)