### PR TITLE
fix(SD-LEO-INFRA-BULK-PURGE-LIVE-001): reversibly purge 12,932 dead-orphan sd_baseline_items + stop the leak

### DIFF
--- a/database/migrations/20260609_bulk_purge_orphan_sd_baseline_items.sql
+++ b/database/migrations/20260609_bulk_purge_orphan_sd_baseline_items.sql
@@ -1,0 +1,95 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: Reversible bulk purge of dead-orphan sd_baseline_items
+-- SD-LEO-INFRA-BULK-PURGE-LIVE-001 — FR-1
+--
+-- WHAT: Delete sd_baseline_items rows whose sd_id joins to NO real strategic_directives_v2,
+--       using the DUAL-column predicate (sd.sd_key = bi.sd_id OR sd.id::text = bi.sd_id).
+--       ~86% of the table is dead orphans (test-fixture leak: no FK / ON DELETE CASCADE),
+--       which degrades the v_sd_next_candidates self-claim queue fleet-wide.
+--
+-- SAFETY (DATABASE + prospective evidence ee1d3194 / 6fb46651):
+--   * DUAL-column predicate is MANDATORY. A sd_key-only predicate would false-orphan ~1,134
+--     LIVE legacy rows keyed off id (historical NEW.id trigger) = irreversible data loss +
+--     would re-break v_sd_next_candidates. orphan-set ∩ live-set = 0 was proven.
+--   * REVERSIBLE: a full backup table holds every purged row; the DOWN migration re-inserts.
+--   * CONCURRENCY-SAFE under READ COMMITTED (apply-migration.js runs prior queries in the tx,
+--     so SET TRANSACTION ISOLATION LEVEL is unavailable): the DELETE is bound to the backup
+--     snapshot AND re-checks orphan-hood at delete time — an orphan "rescued" by a concurrent
+--     SD insert is skipped, never lost. apply-migration.js wraps this in BEGIN/COMMIT with
+--     path + global advisory locks; the named lock below is additional defense.
+--   * Counts are computed LIVE; nothing is hardcoded.
+--
+-- BOUNDARIES: sd_baseline_items only. Does NOT touch strategic_directives_v2 SD rows and does
+--   NOT modify fn_sync_sd_to_baseline (it is already correct; the id-keyed rows are legacy data
+--   the dual-join predicate handles).
+
+SELECT pg_advisory_xact_lock(hashtext('sd_baseline_items_bulk_purge'));
+
+-- 1) Full backup of the dual-join orphans (reversibility source for the DOWN migration).
+--    DDL is transactional in Postgres: if any assertion below fails, this CREATE rolls back too.
+CREATE TABLE IF NOT EXISTS sd_baseline_items_purge_backup_20260609 AS
+SELECT bi.*
+FROM sd_baseline_items bi
+WHERE NOT EXISTS (
+  SELECT 1 FROM strategic_directives_v2 sd
+  WHERE sd.sd_key = bi.sd_id OR sd.id::text = bi.sd_id
+);
+
+-- 2) Pre-assertions: backup non-empty, within the 95% ceiling, and every backed-up row is
+--    genuinely an orphan (guards a mis-scoped or runaway predicate before any delete).
+DO $purge_pre$
+DECLARE
+  v_total  int;
+  v_backup int;
+BEGIN
+  SELECT count(*) INTO v_total  FROM sd_baseline_items;
+  SELECT count(*) INTO v_backup FROM sd_baseline_items_purge_backup_20260609;
+
+  IF v_backup = 0 THEN
+    RAISE EXCEPTION 'purge aborted: backup is empty (no orphans to purge)';
+  END IF;
+  IF v_backup > v_total * 0.95 THEN
+    RAISE EXCEPTION 'purge aborted: backup % exceeds 95%% ceiling of total %', v_backup, v_total;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM sd_baseline_items_purge_backup_20260609 b
+    WHERE EXISTS (
+      SELECT 1 FROM strategic_directives_v2 sd
+      WHERE sd.sd_key = b.sd_id OR sd.id::text = b.sd_id
+    )
+  ) THEN
+    RAISE EXCEPTION 'purge aborted: backup contains a row joined to a live SD (predicate mis-scoped)';
+  END IF;
+
+  RAISE NOTICE 'purge: backing up % orphans of % total rows', v_backup, v_total;
+END
+$purge_pre$;
+
+-- 3) Delete ONLY backup rows that are STILL orphans at delete time (snapshot-precise +
+--    concurrency-safe — a row rescued by a concurrent SD insert is left untouched).
+DELETE FROM sd_baseline_items bi
+USING sd_baseline_items_purge_backup_20260609 b
+WHERE bi.id = b.id
+  AND NOT EXISTS (
+    SELECT 1 FROM strategic_directives_v2 sd
+    WHERE sd.sd_key = bi.sd_id OR sd.id::text = bi.sd_id
+  );
+
+-- 4) Post-assertion: no backed-up row that is still an orphan remains in the live table.
+DO $purge_post$
+DECLARE
+  v_remaining int;
+BEGIN
+  SELECT count(*) INTO v_remaining
+  FROM sd_baseline_items bi
+  JOIN sd_baseline_items_purge_backup_20260609 b ON b.id = bi.id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM strategic_directives_v2 sd
+    WHERE sd.sd_key = bi.sd_id OR sd.id::text = bi.sd_id
+  );
+  IF v_remaining <> 0 THEN
+    RAISE EXCEPTION 'purge failed: % backed-up orphans still present after delete', v_remaining;
+  END IF;
+  RAISE NOTICE 'purge: complete — all still-orphan backed-up rows removed';
+END
+$purge_post$;

--- a/database/migrations/20260609_bulk_purge_orphan_sd_baseline_items_DOWN.sql
+++ b/database/migrations/20260609_bulk_purge_orphan_sd_baseline_items_DOWN.sql
@@ -1,0 +1,13 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- DOWN migration for SD-LEO-INFRA-BULK-PURGE-LIVE-001 — FR-1
+--
+-- Rolls back the bulk purge by re-inserting every purged row from the backup table.
+-- ON CONFLICT (id) DO NOTHING makes it idempotent and safe if some rows were already
+-- restored or re-created. Apply ONLY to undo the purge, via:
+--   node scripts/apply-migration.js database/migrations/20260609_bulk_purge_orphan_sd_baseline_items_DOWN.sql --prod-deploy
+-- (issue a fresh single-use token first). The backup table is retained until a
+-- verification window passes, then may be dropped manually.
+
+INSERT INTO sd_baseline_items
+SELECT * FROM sd_baseline_items_purge_backup_20260609
+ON CONFLICT (id) DO NOTHING;

--- a/tests/helpers/database-helpers.js
+++ b/tests/helpers/database-helpers.js
@@ -183,6 +183,22 @@ export async function createTestPRD(directiveId, data = {}) {
 export async function deleteTestDirective(directiveId) {
   const supabase = getSupabaseClient();
 
+  // SD-LEO-INFRA-BULK-PURGE-LIVE-001 FR-2: the fn_sync_sd_to_baseline trigger writes a
+  // sd_baseline_items row (sd_id = NEW.sd_key today, or NEW.id on legacy paths) when an SD is
+  // inserted, and sd_baseline_items has NO FK / ON DELETE CASCADE — so deleting only the SD leaks
+  // a dead baseline orphan (the leak this SD eliminates). Delete the baseline row(s) FIRST, keyed
+  // by BOTH the SD id and its sd_key so the current sd_key-write and the legacy id-write are both
+  // covered. Best-effort (test cleanup): a lookup miss falls back to deleting by id only.
+  let sdKey = null;
+  try {
+    const { data } = await supabase.from('strategic_directives_v2').select('sd_key').eq('id', directiveId).maybeSingle();
+    sdKey = data?.sd_key || null;
+  } catch { /* best-effort */ }
+  const baselineKeys = [directiveId, sdKey].filter(Boolean);
+  if (baselineKeys.length > 0) {
+    await supabase.from('sd_baseline_items').delete().in('sd_id', baselineKeys);
+  }
+
   // Delete in order (respecting foreign key constraints)
   // Table 'deliverables' does not exist — skip
   await supabase.from('user_stories').delete().eq('strategic_directive_id', directiveId);

--- a/tests/integration/baseline-leak-guard.test.js
+++ b/tests/integration/baseline-leak-guard.test.js
@@ -1,0 +1,130 @@
+/**
+ * Integration Test: sd_baseline_items leak guard (behavioral net-zero)
+ * SD: SD-LEO-INFRA-BULK-PURGE-LIVE-001 — FR-3
+ *
+ * WHY THIS EXISTS
+ * sd_baseline_items has NO foreign key / ON DELETE CASCADE to strategic_directives_v2.
+ * The fn_sync_sd_to_baseline AFTER-INSERT trigger writes one sd_baseline_items row
+ * (sd_id = NEW.sd_key) whenever an SD is inserted and an active baseline exists. So any
+ * test that inserts a real SD and later deletes ONLY the SD leaves a dead baseline orphan.
+ * Those orphans accumulated to ~86% of the table and degraded the v_sd_next_candidates
+ * self-claim queue fleet-wide. FR-2 fixed the leak at the shared cleanup sinks; this guard
+ * makes the fix durable by FAILING if the shared sink ever stops deleting the baseline row.
+ *
+ * DESIGN — net-zero by FIXTURE FOOTPRINT, not global count.
+ * This suite runs against the LIVE database alongside up to ~6 other fleet sessions that
+ * insert/complete SDs concurrently, so a global COUNT(*) before/after would be racy. Instead
+ * we assert the fixture's OWN footprint returns to zero (rows for its sd_key: 0 -> 1 -> 0).
+ * That is a true net-zero for this fixture, immune to concurrent peers, and still fails the
+ * instant the shared-sink cleanup omits the baseline delete (a leftover row -> assertion fail).
+ *
+ * The cleanup path under guard is the shared sink deleteTestDirective() (tests/helpers).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'crypto';
+import { getSupabaseClient, deleteTestDirective } from '../helpers/database-helpers.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// Mirrors the proven-good insert shape from sd-completed-handler.test.js so the row passes
+// the BEFORE-INSERT governance/content-quality triggers on strategic_directives_v2.
+const SD_DEFAULTS = {
+  rationale: 'Fixture SD for the baseline-leak-guard net-zero regression test',
+  scope: 'Test scope',
+  description: 'Test description',
+  status: 'draft',
+  category: 'infrastructure',
+  priority: 'low',
+  current_phase: 'EXEC',
+  target_application: 'EHG_Engineer',
+  created_by: 'test-harness',
+  key_principles: ['Test principle'],
+  success_criteria: [{ criterion: 'Baseline row is cleaned on SD delete', met: false }],
+  key_changes: [{ change: 'leak guard fixture', type: 'test' }],
+  strategic_objectives: ['Guard against sd_baseline_items re-leak'],
+  success_metrics: [{ metric: 'Net-zero baseline footprint', target: '0', actual: 'TBD' }],
+  smoke_test_steps: ['Insert fixture SD, clean via shared sink, assert net-zero'],
+  risks: [{ risk: 'None', mitigation: 'N/A' }],
+  governance_metadata: { automation_context: 'test-harness' },
+};
+
+const credsPresent = !!(
+  process.env.SUPABASE_SERVICE_ROLE_KEY &&
+  (process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL)
+);
+
+/** Count sd_baseline_items rows belonging to a specific fixture sd_key (the fixture footprint). */
+async function footprint(supabase, sdKey) {
+  const { count, error } = await supabase
+    .from('sd_baseline_items')
+    .select('id', { count: 'exact', head: true })
+    .eq('sd_id', sdKey);
+  if (error) throw new Error(`footprint count failed: ${error.message}`);
+  return count ?? 0;
+}
+
+async function hasActiveBaseline(supabase) {
+  const { data, error } = await supabase
+    .from('sd_execution_baselines')
+    .select('id')
+    .eq('is_active', true)
+    .limit(1);
+  if (error) throw new Error(`active-baseline check failed: ${error.message}`);
+  return !!(data && data.length);
+}
+
+describe('sd_baseline_items leak guard (FR-3, behavioral net-zero)', () => {
+  it.skipIf(!credsPresent)(
+    'fixture baseline footprint returns to zero after shared-sink cleanup',
+    async () => {
+      const supabase = getSupabaseClient();
+
+      // fn_sync_sd_to_baseline only writes a row when an active baseline exists. Without one
+      // the trigger is inert, so the guard cannot demonstrate the leak — skip rather than
+      // pass vacuously.
+      if (!(await hasActiveBaseline(supabase))) {
+        console.warn('[baseline-leak-guard] no active baseline present — trigger inert, skipping');
+        return;
+      }
+
+      const uuid = randomUUID();
+      const sdKey = `SD-LEAKGUARD-${Date.now().toString(36).toUpperCase()}-${uuid.slice(0, 8)}`;
+
+      // Footprint must start clean (unique sd_key).
+      expect(await footprint(supabase, sdKey)).toBe(0);
+
+      try {
+        // Insert through the standard path → fires fn_sync_sd_to_baseline (writes sd_id = sd_key).
+        const { error: insErr } = await supabase
+          .from('strategic_directives_v2')
+          .insert({ id: uuid, sd_key: sdKey, title: 'Baseline Leak Guard Fixture', sd_type: 'infrastructure', ...SD_DEFAULTS })
+          .select('id, sd_key')
+          .single();
+        expect(insErr?.message ?? null, insErr?.message).toBeNull();
+
+        // Precondition: the trigger created exactly one baseline orphan source for this sd_key.
+        expect(
+          await footprint(supabase, sdKey),
+          'fn_sync_sd_to_baseline should have written exactly one baseline row keyed by sd_key',
+        ).toBe(1);
+
+        // Clean via the SHARED sink — the consumer this guard protects. It must delete the
+        // baseline row (by id and sd_key) BEFORE the SD, leaving no orphan.
+        await deleteTestDirective(uuid);
+
+        // The net-zero assertion: the fixture's baseline footprint is back to zero. If a future
+        // change drops the baseline delete from the shared sink, a row remains here and this fails.
+        expect(
+          await footprint(supabase, sdKey),
+          'shared-sink cleanup must leave the fixture sd_baseline_items footprint net-zero (no orphan)',
+        ).toBe(0);
+      } finally {
+        // Defensive teardown: never leak even if an assertion above threw mid-flight.
+        await supabase.from('sd_baseline_items').delete().eq('sd_id', sdKey);
+        await supabase.from('strategic_directives_v2').delete().eq('id', uuid);
+      }
+    },
+  );
+});

--- a/tests/integration/sd-completed-handler.test.js
+++ b/tests/integration/sd-completed-handler.test.js
@@ -211,6 +211,12 @@ describe.skipIf(!HAS_REAL_DB)('sd.completed Handler (Return Path)', () => {
       .eq('venture_id', testVentureId)
       .eq('lifecycle_stage', 19);
 
+    // SD-LEO-INFRA-BULK-PURGE-LIVE-001 FR-2: fn_sync_sd_to_baseline writes a sd_baseline_items row keyed
+    // by NEW.sd_key when an active baseline exists, and sd_baseline_items has NO FK / ON DELETE CASCADE —
+    // so deleting only the SD leaks a dead baseline orphan. Every fixture sd_key is `SD-${PREFIX}-...`, so
+    // one prefix-scoped delete cleans the parent + all children (incl. replaceChild re-inserts) FIRST.
+    await supabase.from('sd_baseline_items').delete().ilike('sd_id', `SD-${PREFIX}-%`);
+
     // Delete children first (FK on parent_sd_id)
     for (const uuid of childSdUuids) {
       await supabase.from('strategic_directives_v2').delete().eq('id', uuid);

--- a/tests/integration/sd-creation/fixtures/supabase-seed.js
+++ b/tests/integration/sd-creation/fixtures/supabase-seed.js
@@ -140,6 +140,12 @@ export async function cleanup(testRunId) {
   // uat_test_results: id is a UUID (not testRunId-prefixed), so we clean by
   // error_message which always contains testRunId.
   const strategies = [
+    // SD-LEO-INFRA-BULK-PURGE-LIVE-001 FR-2: the fn_sync_sd_to_baseline trigger writes a
+    // sd_baseline_items row (sd_id = the testRunId-prefixed sd_key, or id on legacy paths) when these
+    // fixtures insert an SD, and sd_baseline_items has NO FK / ON DELETE CASCADE — so it must be
+    // cleaned explicitly or it leaks a dead baseline orphan. Delete it FIRST, keyed by the
+    // testRunId-prefixed sd_id (covers both the sd_key-write and the id-write).
+    { name: 'sd_baseline_items', col: 'sd_id', filter: `${testRunId}%` },
     { name: 'strategic_directives_v2', col: 'sd_key', filter: `${testRunId}%` },
     { name: 'strategic_directives_v2', col: 'id', filter: `${testRunId}%` },
     { name: 'strategic_directives_v2', col: 'title', filter: `${testRunId}%` },


### PR DESCRIPTION
## Summary
`sd_baseline_items` has no FK / `ON DELETE CASCADE` to `strategic_directives_v2`, so every test that inserted a real SD and deleted only the SD leaked a dead baseline row. Orphans reached **~86% of the table (14,916 rows)** and degraded the `v_sd_next_candidates` self-claim queue fleet-wide.

## Changes
**FR-1 — reversible bulk purge (applied LIVE via `apply-migration.js --prod-deploy` → `MIGRATION_APPLY_PROD_PASS`)**
- DUAL-column orphan predicate (`sd.sd_key = bi.sd_id OR sd.id::text = bi.sd_id`). A `sd_key`-only predicate would have false-orphaned **~1,134 LIVE legacy id-keyed rows** = irreversible data loss + re-breaks the queue. Those 1,134 rows are correctly preserved.
- Full backup table `sd_baseline_items_purge_backup_20260609` (12,932 rows) + pre/post assertions + 95% ceiling + named advisory lock; snapshot-precise, concurrency-safe `DELETE` (re-checks orphan-hood at delete time). `..._DOWN.sql` restores from the backup.
- **Live result: 14,916 → 1,984 total; dual-join orphans 12,932 → 0; queue unbroken.**

**FR-2 — stop the leak at the SHARED cleanup sinks** (PAT-WRITER-CONSUMER-ASYMMETRY)
- `tests/helpers/database-helpers.js` `deleteTestDirective()` — delete the baseline row by both `id` and `sd_key` before the SD delete.
- `tests/integration/sd-creation/fixtures/supabase-seed.js` `cleanup()` — add a `sd_baseline_items` delete strategy.
- `tests/integration/sd-completed-handler.test.js` `afterAll` — prefix-scoped baseline cleanup.

**FR-3 — durable regression guard**
- `tests/integration/baseline-leak-guard.test.js` — behavioral net-zero guard (fixture baseline footprint 0→1→0), scoped to the fixture footprint to stay non-flaky under concurrent fleet sessions.

## Verification
- Migration validated end-to-end against live data in a ROLLBACK'd transaction before the real apply.
- Post-apply live verification: dual-join orphans = 0; backup = 12,932; `v_sd_next_candidates` healthy.
- Tests: FR-3 guard **1/1**, sd-creation **31/31**, sd-completed-handler **9/10** (the 1 failure is a pre-existing `trg_require_cancellation_reason` drift in `setStatus`, unrelated to this change).

## Reversibility
Run `..._DOWN.sql` to re-insert from `sd_baseline_items_purge_backup_20260609` (`ON CONFLICT (id) DO NOTHING`).

SD: SD-LEO-INFRA-BULK-PURGE-LIVE-001 | Gates: EXEC-TO-PLAN 93, PLAN-TO-LEAD 97 | Retro 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)