### PR TITLE
feat(SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001): tri-party verify-step enforcement primitive + fleet-retro restore (scope-locked core)

### DIFF
--- a/lib/fleet/verify-score-contract.mjs
+++ b/lib/fleet/verify-score-contract.mjs
@@ -1,0 +1,136 @@
+/**
+ * Verify-score contract validator — the tri-party self-improvement loop's "verify it stuck" step.
+ * SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (FR-3, the named core fix).
+ *
+ * Pure + dependency-injected (NO DB I/O — the caller fetches the rows). Enforces the contract
+ * canonicalized in leo_protocol_sections id=601 / .claude/commands/coordinator.md:
+ *   1. A self-score with a below-threshold dimension but ZERO committed_actions is INVALID
+ *      (the dormant-review / vanity-measurement failure mode).
+ *   2. A self-score that does NOT verify the prior cycle's committed_actions (prior_action_outcomes
+ *      empty when the prior cycle committed actions) is INVALID — this is the missing VERIFY step.
+ *   3. A dimension that stays below-threshold for N consecutive cycles despite committed actions
+ *      ESCALATES to the operator.
+ * Missing/unparseable metrics yield INCONCLUSIVE (never INVALID) so a data outage can't fabricate
+ * a failure or cascade an infinite invalid loop.
+ *
+ * Score-row shape (the `description` JSON of a feedback row, category=coordinator_review /
+ * adam_self_assessment):
+ *   { overall, session, dimensions: { name: number, ... },
+ *     below_threshold?: string[], committed_actions: object[], prior_action_outcomes?: object[] }
+ *
+ * @module lib/fleet/verify-score-contract
+ */
+
+/** Default: a dimension scoring at/below this is "below-threshold" (matches the contract's ≤2). */
+export const DEFAULT_BELOW_THRESHOLD_AT = 2;
+
+/** Default: escalate after this many consecutive below-threshold cycles despite committed actions. */
+export const DEFAULT_ESCALATE_AFTER_N = 3;
+
+/**
+ * Parse a feedback row into a score object. Accepts a row ({description}), a JSON string, or an
+ * already-parsed object. Returns null when it is not a score row (no numeric `dimensions` map) —
+ * so callers can filter capture rows (raw signal text) from actual self-score rows.
+ *
+ * @param {Object|string} rowOrDescription
+ * @returns {Object|null}
+ */
+export function parseScore(rowOrDescription) {
+  if (!rowOrDescription) return null;
+  let obj = rowOrDescription;
+  if (typeof obj === 'object' && 'description' in obj && !('dimensions' in obj)) obj = obj.description;
+  if (typeof obj === 'string') {
+    try { obj = JSON.parse(obj); } catch { return null; }
+  }
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+  if (!obj.dimensions || typeof obj.dimensions !== 'object' || Array.isArray(obj.dimensions)) return null;
+  return obj;
+}
+
+/**
+ * Partition a dimensions map into below-threshold vs inconclusive (non-numeric) names.
+ *
+ * @param {Object} dimensions - { name: number, ... }
+ * @param {number} belowThresholdAt
+ * @returns {{ below: string[], inconclusive: string[] }}
+ */
+export function classifyDimensions(dimensions, belowThresholdAt = DEFAULT_BELOW_THRESHOLD_AT) {
+  const below = [];
+  const inconclusive = [];
+  for (const [name, score] of Object.entries(dimensions || {})) {
+    if (typeof score !== 'number' || Number.isNaN(score)) { inconclusive.push(name); continue; }
+    if (score <= belowThresholdAt) below.push(name);
+  }
+  return { below, inconclusive };
+}
+
+const isNonEmptyArray = (v) => Array.isArray(v) && v.length > 0;
+
+/**
+ * Validate a proposed self-score against the verify-step contract.
+ *
+ * @param {Object} args
+ * @param {Object|string} args.current - the proposed/latest score row or its description
+ * @param {Object|string|null} [args.prior] - the previous cycle's score row (null if first cycle)
+ * @param {number} [args.priorStreak=0] - consecutive below-threshold cycles carried from before
+ * @param {number} [args.belowThresholdAt]
+ * @param {number} [args.escalateAfterN]
+ * @returns {{ valid: boolean|null, inconclusive: boolean, violations: string[],
+ *   belowThreshold: string[], inconclusiveDims: string[],
+ *   escalation: { triggered: boolean, streak: number, dimensions: string[] } }}
+ *   valid=null means INCONCLUSIVE (could not parse the current score).
+ */
+export function validateScoreContract({
+  current,
+  prior = null,
+  priorStreak = 0,
+  belowThresholdAt = DEFAULT_BELOW_THRESHOLD_AT,
+  escalateAfterN = DEFAULT_ESCALATE_AFTER_N,
+} = {}) {
+  const cur = parseScore(current);
+  if (!cur) {
+    return {
+      valid: null, inconclusive: true,
+      violations: ['INCONCLUSIVE: current score row has no parseable numeric dimensions'],
+      belowThreshold: [], inconclusiveDims: [],
+      escalation: { triggered: false, streak: priorStreak, dimensions: [] },
+    };
+  }
+
+  const { below, inconclusive } = classifyDimensions(cur.dimensions, belowThresholdAt);
+  const violations = [];
+
+  // Rule 1: below-threshold dimension(s) with zero committed_actions => INVALID.
+  if (below.length > 0 && !isNonEmptyArray(cur.committed_actions)) {
+    violations.push(
+      `INVALID: below-threshold dimension(s) [${below.join(', ')}] with no committed_actions ` +
+      `(a self-score that names a gap but commits no action is a vanity measurement)`);
+  }
+
+  // Rule 2: skipped the verify step => INVALID. The prior cycle committed actions but this score
+  // did not record their outcomes (did each land? did the dimension move?).
+  const priorScore = parseScore(prior);
+  if (priorScore && isNonEmptyArray(priorScore.committed_actions) && !isNonEmptyArray(cur.prior_action_outcomes)) {
+    violations.push(
+      `INVALID: did not verify the prior cycle's ${priorScore.committed_actions.length} committed_actions ` +
+      `(prior_action_outcomes is empty) — grade→commit→act→VERIFY, the verify step was skipped`);
+  }
+
+  // Rule 3: escalation — consecutive below-threshold cycles despite committed actions.
+  const streak = below.length > 0 ? (priorStreak + 1) : 0;
+  const escalationTriggered = streak >= escalateAfterN;
+  if (escalationTriggered) {
+    violations.push(
+      `ESCALATE: ${streak} consecutive below-threshold cycle(s) (≥ ${escalateAfterN}) despite committed actions ` +
+      `— dimension(s) [${below.join(', ')}] are not moving; surface to the operator`);
+  }
+
+  return {
+    valid: violations.length === 0,
+    inconclusive: false,
+    violations,
+    belowThreshold: below,
+    inconclusiveDims: inconclusive,
+    escalation: { triggered: escalationTriggered, streak, dimensions: escalationTriggered ? below : [] },
+  };
+}

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -123,6 +123,36 @@ export async function selfReviewMain() {
     for (const r of (all || []).slice(0, 12)) console.log('  ' + (r.created_at || '').slice(5, 16) + ' | ' + String(r.description || '').replace(/\s+/g, ' ').slice(0, 160));
     console.log('[ACTION] Coordinator: cluster -> ADJUST + source concrete coordinator-tooling fixes as SDs; surface a digest to the operator.');
   }
+
+  // SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (FR-3): ENFORCE the verify step. Validate the latest
+  // coordinator self-score against the prior cycle and surface INVALID/escalation LOUDLY so the
+  // loop is grade->commit->act->VERIFY, not a vanity metric. DEFAULT-OFF (TRI_PARTY_VERIFY_V1) ->
+  // byte-identical when off; FAIL-OPEN; ARTIFACT-ONLY (prints + records the streak; NEVER blocks
+  // an SD handoff). The score rows are the JSON-`description` coordinator_review rows in `all`.
+  if (process.env.TRI_PARTY_VERIFY_V1 === 'on') {
+    try {
+      const { validateScoreContract, parseScore } = await import('../lib/fleet/verify-score-contract.mjs');
+      const scores = (all || []).map(r => parseScore(r)).filter(Boolean); // newest-first; capture rows drop out
+      if (scores.length) {
+        const priorStreak = (typeof state.belowThresholdStreak === 'number') ? state.belowThresholdStreak : 0;
+        const v = validateScoreContract({ current: scores[0], prior: scores[1] || null, priorStreak });
+        if (v.inconclusive) {
+          console.log('[VERIFY-STEP] INCONCLUSIVE — latest coordinator score row had no parseable dimensions; skipping (no penalty).');
+        } else {
+          try { const cur = JSON.parse(readFileSync(STATE, 'utf8')); writeFileSync(STATE, JSON.stringify({ ...cur, belowThresholdStreak: v.escalation.streak })); } catch {}
+          if (v.valid) {
+            console.log('[VERIFY-STEP] OK — latest self-score satisfies the grade->commit->act->VERIFY contract' + (scores[1] ? ' (prior cycle verified)' : ' (first cycle)') + '; below-threshold streak=' + v.escalation.streak + '.');
+          } else {
+            console.log('[VERIFY-STEP INVALID] the latest coordinator self-score violates the verify contract:');
+            for (const msg of v.violations) console.log('   x ' + msg);
+            console.log('[ACTION] Re-author the self-score: add committed_actions for every below-threshold dimension AND prior_action_outcomes verifying last cycle' + (v.escalation.triggered ? '; and ESCALATE the stuck dimension(s) to the operator' : '') + '. (Review-artifact only — no SD handoff is blocked.)');
+          }
+        }
+      }
+    } catch (verifyErr) {
+      console.log('[VERIFY-STEP] skipped (fail-open): ' + verifyErr.message);
+    }
+  }
 }
 
 // Main-guard: run only when invoked directly (the cron path), not on import (tests).

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -62,6 +62,12 @@ export const STANDARD_LOOPS = [
   // fires the coordinator<->workers<->Adam review only when due. SD-LEO-INFRA-ARM-CANONICALIZE-WORK-001.
   { key: 'self-review', label: 'Coordinator self-review (work-triggered tri-party)', script: 'coordinator-self-review.mjs', cron: '*/5 * * * *',
     prompt: 'node scripts/coordinator-self-review.mjs' },
+  // SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (FR-2a): restore the worker fleet-retro to a schedule
+  // (it had drifted to manual — last ran ~2.5d ago). Re-arms the existing, idempotent capture/
+  // synthesis script (reuses the feedback/issue_patterns pipeline; dedups on metadata.retro_key).
+  // Cheap read+insert; */30 captures session_coordination FLEET-RETRO signals before they are swept.
+  { key: 'fleet-retro',  label: 'Worker fleet-retro (periodic capture/synthesis)', script: 'coordinator-fleet-retro.mjs', cron: '*/30 * * * *',
+    prompt: 'node scripts/coordinator-fleet-retro.mjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/tests/unit/verify-score-contract.test.js
+++ b/tests/unit/verify-score-contract.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for the tri-party verify-step contract validator (SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 FR-3).
+ * Enforces: below-threshold-with-no-committed_actions => INVALID; skipped-verify => INVALID;
+ * N consecutive below-threshold => ESCALATE; missing metrics => INCONCLUSIVE (never INVALID).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseScore,
+  classifyDimensions,
+  validateScoreContract,
+  DEFAULT_ESCALATE_AFTER_N,
+} from '../../lib/fleet/verify-score-contract.mjs';
+
+const scoreRow = (dims, extra = {}) => ({
+  description: JSON.stringify({ overall: 'x', session: 's', dimensions: dims, ...extra }),
+});
+
+describe('parseScore', () => {
+  it('parses a feedback row whose description is a JSON score', () => {
+    const s = parseScore(scoreRow({ a: 4, b: 2 }, { committed_actions: [{ gap: 'g' }] }));
+    expect(s.dimensions).toEqual({ a: 4, b: 2 });
+    expect(s.committed_actions).toHaveLength(1);
+  });
+  it('parses an already-parsed object', () => {
+    expect(parseScore({ dimensions: { a: 3 } }).dimensions).toEqual({ a: 3 });
+  });
+  it('returns null for a capture row (raw signal text, not a score)', () => {
+    expect(parseScore({ description: 'FLEET-RETRO: worker X says Y' })).toBeNull();
+    expect(parseScore('not json')).toBeNull();
+    expect(parseScore(null)).toBeNull();
+  });
+  it('returns null when dimensions is missing or not a numeric map', () => {
+    expect(parseScore({ description: JSON.stringify({ overall: 'x' }) })).toBeNull();
+    expect(parseScore({ description: JSON.stringify({ dimensions: [1, 2] }) })).toBeNull();
+  });
+});
+
+describe('classifyDimensions', () => {
+  it('partitions below-threshold (≤2) and inconclusive (non-numeric)', () => {
+    const r = classifyDimensions({ good: 4, weak: 2, bad: 1, unknown: null, missing: 'n/a' });
+    expect(r.below.sort()).toEqual(['bad', 'weak']);
+    expect(r.inconclusive.sort()).toEqual(['missing', 'unknown']);
+  });
+});
+
+describe('validateScoreContract — Rule 1 (below-threshold needs committed_actions)', () => {
+  it('INVALID when a below-threshold dim has zero committed_actions', () => {
+    const r = validateScoreContract({ current: scoreRow({ a: 4, b: 2 }, { committed_actions: [] }) });
+    expect(r.valid).toBe(false);
+    expect(r.belowThreshold).toEqual(['b']);
+    expect(r.violations.join(' ')).toMatch(/no committed_actions/);
+  });
+  it('VALID when below-threshold dims all carry committed_actions (first cycle, no prior)', () => {
+    const r = validateScoreContract({ current: scoreRow({ a: 4, b: 2 }, { committed_actions: [{ gap: 'b', action: 'fix' }] }) });
+    expect(r.valid).toBe(true);
+    expect(r.violations).toEqual([]);
+  });
+  it('VALID when nothing is below-threshold (no actions required)', () => {
+    const r = validateScoreContract({ current: scoreRow({ a: 4, b: 5 }, { committed_actions: [] }) });
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe('validateScoreContract — Rule 2 (verify the prior cycle)', () => {
+  const prior = scoreRow({ a: 2 }, { committed_actions: [{ gap: 'a', action: 'do x' }] });
+  it('INVALID when the prior cycle committed actions but this score has empty prior_action_outcomes', () => {
+    const r = validateScoreContract({
+      current: scoreRow({ a: 4 }, { committed_actions: [] }),
+      prior,
+    });
+    expect(r.valid).toBe(false);
+    expect(r.violations.join(' ')).toMatch(/verify the prior cycle|verify step was skipped/i);
+  });
+  it('VALID when the prior cycle is verified (prior_action_outcomes populated)', () => {
+    const r = validateScoreContract({
+      current: scoreRow({ a: 4 }, { committed_actions: [], prior_action_outcomes: [{ action: 'do x', landed: true, moved: true }] }),
+      prior,
+    });
+    expect(r.valid).toBe(true);
+  });
+  it('no Rule-2 violation on the first cycle (prior is null)', () => {
+    const r = validateScoreContract({ current: scoreRow({ a: 4 }, { committed_actions: [] }), prior: null });
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe('validateScoreContract — Rule 3 (escalation) + INCONCLUSIVE', () => {
+  it('ESCALATES after N consecutive below-threshold cycles despite committed actions', () => {
+    const r = validateScoreContract({
+      current: scoreRow({ a: 2 }, { committed_actions: [{ gap: 'a', action: 'x' }], prior_action_outcomes: [{ landed: true }] }),
+      prior: scoreRow({ a: 2 }, { committed_actions: [{ gap: 'a' }] }),
+      priorStreak: DEFAULT_ESCALATE_AFTER_N - 1,
+    });
+    expect(r.escalation.triggered).toBe(true);
+    expect(r.escalation.streak).toBe(DEFAULT_ESCALATE_AFTER_N);
+    expect(r.valid).toBe(false);
+    expect(r.violations.join(' ')).toMatch(/ESCALATE/);
+  });
+  it('resets the streak to 0 when nothing is below-threshold', () => {
+    const r = validateScoreContract({ current: scoreRow({ a: 5 }, { committed_actions: [] }), priorStreak: 5 });
+    expect(r.escalation.streak).toBe(0);
+    expect(r.escalation.triggered).toBe(false);
+  });
+  it('INCONCLUSIVE (valid=null) when the current score row cannot be parsed', () => {
+    const r = validateScoreContract({ current: { description: 'just a comment, no dimensions' } });
+    expect(r.valid).toBeNull();
+    expect(r.inconclusive).toBe(true);
+    expect(r.violations.join(' ')).toMatch(/INCONCLUSIVE/);
+  });
+  it('treats a non-numeric dimension as inconclusive, NOT below-threshold (no false INVALID)', () => {
+    const r = validateScoreContract({ current: scoreRow({ a: 5, b: 'n/a' }, { committed_actions: [] }) });
+    expect(r.belowThreshold).toEqual([]);
+    expect(r.inconclusiveDims).toEqual(['b']);
+    expect(r.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 — the "verify it stuck" enforcement primitive

LEAD circuit-breaker **scope-lock** of a 4-FR SD, informed by a 5-subsystem exploration. Ships the additive, low-risk core; defers the live-behavior change + the large net-new surface to filed follow-up SDs.

### FR-3 (the named core fix) — verify-step enforcement
- **NEW `lib/fleet/verify-score-contract.mjs`** — a pure, DI validator for the tri-party self-improvement contract (id=601 / coordinator.md): a below-threshold dimension with **zero `committed_actions`** is INVALID; a score that doesn't **verify the prior cycle** (empty `prior_action_outcomes` when the prior committed actions) is INVALID — the missing VERIFY step; **N consecutive** below-threshold cycles ESCALATE; missing/unparseable metrics are **INCONCLUSIVE** (never INVALID, so a data outage can't fabricate failure or cascade an infinite invalid loop). **15 unit tests.**
- Wired into the one scheduled path (`coordinator-self-review.mjs` DUE step): validates the latest coordinator self-score (the JSON-`description` `feedback` rows, category=coordinator_review) vs the prior and surfaces INVALID/escalation loudly. **Additive, fail-open, behind a default-OFF flag `TRI_PARTY_VERIFY_V1`** (byte-identical when off), **artifact-only** (prints + a guarded streak write; never blocks an SD handoff).

### FR-2a — restore the worker fleet-retro to a schedule
One `STANDARD_LOOPS` entry in `coordinator-startup-check.mjs` arming the existing, idempotent `coordinator-fleet-retro.mjs` (*/30; reuses the feedback/issue_patterns pipeline; zero logic change).

### Deferred (filed as draft SDs)
- **SD-LEO-INFRA-ADAM-SELF-ASSESSMENT-001** — the ~250-400 LOC net-new Adam self-assessment writer + turn-counter (reuses this validator).
- **SD-LEO-INFRA-ENABLE-TRI-PARTY-001** — flip the cadence flags ON (the only true live multi-session behavior change), sequenced LAST with conservative N.

### Verification
- 15/15 unit tests; `node --check` clean; validation-agent **PASS (95)** (net-new, premises confirmed, scope-lock sound, risk low); vision 93/proceed; retro quality **100**. ~172 source LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)