### PR TITLE
fix(QF-20260609-183): stop Windows UV_HANDLE_CLOSING abort in DB-touching Stop hooks

### DIFF
--- a/scripts/hooks/__tests__/stop-hook-uv-handle-closing.test.js
+++ b/scripts/hooks/__tests__/stop-hook-uv-handle-closing.test.js
@@ -1,0 +1,63 @@
+// Regression: Windows libuv UV_HANDLE_CLOSING abort in DB-touching Stop hooks.
+//
+// Symptom (pre-fix): a Stop hook that ran a Supabase query (undici/fetch keep-alive
+// socket) and then called process.exit() aborted on Windows with
+//   "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76"
+// surfaced by Claude Code as "Stop hook error: Failed with non-blocking status code".
+//
+// EMPIRICAL finding (repro before the fix, 6/6 each): the abort fires with a bare
+// process.exit(), with a setImmediate-deferred exit (the folklore "gracefulExit"
+// pattern copied from stop-subagent-enforcement.js), AND even after
+// getGlobalDispatcher().close() if process.exit() is still called. The ONLY reliable
+// avoidance is to NOT call process.exit() in the post-query path: close undici's
+// sockets and let the event loop drain so the process exits on its own.
+//
+// These are STATIC SOURCE-PINS (no DB / no subprocess) so they are deterministic in
+// CI: a behavioral repro needs live Supabase + Windows and would flake. They fail if
+// a future edit reintroduces a post-query process.exit() or the disproven setImmediate
+// pattern, or drops the undici socket close.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const HOOKS = [
+  'stop-loop-wakeup-reminder.cjs',
+  'post-completion-tail-enforcement.cjs',
+];
+
+/** Strip line-comments (`//…`) and jsdoc/star lines so assertions see executable code only. */
+function executableSource(src) {
+  return src
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim();
+      return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'));
+    })
+    .join('\n');
+}
+
+describe.each(HOOKS)('UV_HANDLE_CLOSING contract — %s', (hookFile) => {
+  const src = fs.readFileSync(path.resolve(__dirname, '..', hookFile), 'utf8');
+  const code = executableSource(src);
+
+  it('closes undici keep-alive sockets before exiting (getGlobalDispatcher().close())', () => {
+    expect(code).toMatch(/getGlobalDispatcher\(\)\.close\(\)/);
+  });
+
+  it('does NOT use the disproven setImmediate(() => process.exit(…)) pattern', () => {
+    expect(code).not.toMatch(/setImmediate\(\s*\(\)\s*=>\s*process\.exit/);
+  });
+
+  it('calls process.exit() ONLY from the single unref\'d drain backstop', () => {
+    const exits = code.match(/process\.exit\(/g) || [];
+    expect(exits.length).toBe(1);
+    // …and that one occurrence is the unref'd setTimeout backstop, never an inline exit.
+    expect(code).toMatch(/setTimeout\(\s*\(\)\s*=>\s*process\.exit\(0\)\s*,\s*8000\s*\)\.unref\(\)/);
+  });
+
+  it('routes exits through an async shutdown() helper (close → natural drain)', () => {
+    expect(code).toMatch(/async function shutdown\s*\(/);
+    expect(code).toMatch(/return shutdown\(\)/);
+  });
+});

--- a/scripts/hooks/post-completion-tail-enforcement.cjs
+++ b/scripts/hooks/post-completion-tail-enforcement.cjs
@@ -41,6 +41,28 @@ const STATE_FILE = path.join(ROOT, '.claude', 'post-completion-pending.json');
 // crashed / moved on) and is cleared without nagging forever.
 const MAX_AGE_MS = 6 * 60 * 60 * 1000; // 6h
 
+// ── Clean shutdown — Windows libuv UV_HANDLE_CLOSING avoidance ────────────────
+// When 'learn' is pending, learnRanInDb() opens an undici/fetch keep-alive socket
+// (Supabase). Calling process.exit() afterward aborts on Windows: it forces libuv
+// loop teardown while a socket/threadpool completion calls uv_async_send() on a
+// handle already flagged UV_HANDLE_CLOSING → "Assertion failed: !(handle->flags &
+// UV_HANDLE_CLOSING), file src\\win\\async.c, line 76". EMPIRICALLY this reproduces
+// even after a setImmediate-deferred exit AND after dispatcher.close() if exit() is
+// still called. The only reliable avoidance is to NOT call process.exit(): close
+// undici's sockets, then let the event loop drain so the process exits on its own.
+// Every exit path routes through this so the no-I/O fast paths stay uniform too.
+let _shuttingDown = false;
+async function shutdown() {
+  if (_shuttingDown) return;
+  _shuttingDown = true;
+  // Backstop only: force-exit if the loop somehow fails to drain. unref'd so it
+  // never delays a clean natural exit; if it ever fires (8s, under the hook's 10s
+  // timeout) the sockets are already closed, so this exit can't race a live one.
+  setTimeout(() => process.exit(0), 8000).unref();
+  try { await require('undici').getGlobalDispatcher().close(); } catch { /* undici absent/already closed */ }
+  // Deliberately NO process.exit() — returning lets Node exit once the loop drains.
+}
+
 function readStdin() {
   try {
     return fs.readFileSync(0, 'utf8');
@@ -147,7 +169,7 @@ function clearStateFile() {
 
 async function main() {
   // Cheap common-path no-op: absent file ⇒ nothing pending.
-  if (!fs.existsSync(STATE_FILE)) { process.exit(0); }
+  if (!fs.existsSync(STATE_FILE)) { return shutdown(); }
 
   let payload = {};
   try { payload = JSON.parse(readStdin() || '{}'); } catch {}
@@ -158,24 +180,24 @@ async function main() {
   } catch {
     // Malformed ⇒ drop it (no-op).
     clearStateFile();
-    process.exit(0);
+    return shutdown();
   }
 
   const pending = Array.isArray(state.pending) ? state.pending.slice() : [];
-  if (pending.length === 0) { clearStateFile(); process.exit(0); }
+  if (pending.length === 0) { clearStateFile(); return shutdown(); }
 
   // Safety drain on age.
   const completedMs = state.completed_at ? Date.parse(state.completed_at) : NaN;
   if (!Number.isNaN(completedMs) && (Date.now() - completedMs) > MAX_AGE_MS) {
     clearStateFile();
-    process.exit(0);
+    return shutdown();
   }
 
   // Multi-session safety: only the session that completed the SD should be
   // nudged. If both ids are present and differ, this isn't our obligation.
   const mySession = payload.session_id || process.env.CLAUDE_SESSION_ID || null;
   if (state.session_id && mySession && state.session_id !== mySession) {
-    process.exit(0);
+    return shutdown();
   }
 
   // Clear steps that now have evidence.
@@ -192,7 +214,7 @@ async function main() {
   // Persist the decremented list (or delete when fully satisfied).
   if (remaining.length === 0) {
     clearStateFile();
-    process.exit(0);
+    return shutdown();
   }
   if (remaining.length !== pending.length) {
     try {
@@ -201,7 +223,7 @@ async function main() {
   }
 
   // Only nudge under AUTO-PROCEED (when OFF, continuation already pauses).
-  if (!autoProceedOn()) { process.exit(0); }
+  if (!autoProceedOn()) { return shutdown(); }
 
   const sdLabel = state.sd_key || state.sd_id || 'the just-completed SD';
   const cmds = remaining.map((s) => '/' + s).join(' → ');
@@ -212,7 +234,9 @@ async function main() {
     `(/document updates docs; /learn writes learning_runs/patterns future PRDs query.) ` +
     `Prefer driving completion via /leo complete so the full tail sequences automatically.\n`
   );
-  process.exit(0);
+  return shutdown();
 }
 
-main().catch(() => process.exit(0));
+process.on('uncaughtException', () => shutdown());
+process.on('unhandledRejection', () => shutdown());
+main().catch(() => shutdown());

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -34,6 +34,29 @@
 
 const { LOOP_STATE_ACTIVE } = require('../lib/sessions/loop-state-tracker.cjs');
 
+// ── Clean shutdown — Windows libuv UV_HANDLE_CLOSING avoidance ────────────────
+// The claude_sessions query opens an undici/fetch keep-alive socket. Calling
+// process.exit() afterward aborts on Windows: it forces libuv loop teardown while
+// a socket/threadpool completion calls uv_async_send() on a handle already flagged
+// UV_HANDLE_CLOSING → "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING),
+// file src\\win\\async.c, line 76". EMPIRICALLY this reproduces 100% with a bare
+// exit, with a setImmediate-deferred exit, AND even after dispatcher.close() if
+// process.exit() is still called. The ONLY reliable avoidance is to NOT call
+// process.exit(): close undici's sockets, then let the event loop drain so the
+// process exits on its own. (Folklore — mirror stop-subagent-enforcement.js's
+// setImmediate "gracefulExit" — does NOT work here; verified by repro before fix.)
+let _shuttingDown = false;
+async function shutdown() {
+  if (_shuttingDown) return;
+  _shuttingDown = true;
+  // Backstop only: force-exit if the loop somehow fails to drain. unref'd so it
+  // never delays a clean natural exit; if it ever fires (8s, under the hook's 10s
+  // timeout) the sockets are already closed, so this exit can't race a live one.
+  setTimeout(() => process.exit(0), 8000).unref();
+  try { await require('undici').getGlobalDispatcher().close(); } catch { /* undici absent/already closed */ }
+  // Deliberately NO process.exit() — returning lets Node exit once the loop drains.
+}
+
 /**
  * Pure decision: should the Stop hook block-and-remind this turn?
  * Block ONLY when the reminder is enabled AND this is a /loop worker mid-iteration
@@ -66,17 +89,19 @@ function readStdinPayload(timeoutMs = 2000) {
   return new Promise((resolve) => {
     let data = '';
     let settled = false;
+    let timer = null;
     const finish = () => {
       if (settled) return;
       settled = true;
+      if (timer) clearTimeout(timer);   // don't let the timeout pin the loop open at drain
       try { resolve(JSON.parse(data || '{}')); } catch { resolve({}); }
     };
     try {
       process.stdin.setEncoding('utf8');
       process.stdin.on('data', (c) => { data += c; });
       process.stdin.on('end', finish);
-      process.stdin.on('error', () => { if (!settled) { settled = true; resolve({}); } });
-      setTimeout(finish, timeoutMs);
+      process.stdin.on('error', () => { if (!settled) { settled = true; if (timer) clearTimeout(timer); resolve({}); } });
+      timer = setTimeout(finish, timeoutMs);
     } catch { resolve({}); }
   });
 }
@@ -84,14 +109,14 @@ function readStdinPayload(timeoutMs = 2000) {
 async function main() {
   try {
     const flagEnabled = isFlagEnabled();
-    if (!flagEnabled) { process.exit(0); }            // default-OFF fast path
+    if (!flagEnabled) { return shutdown(); }     // default-OFF fast path
 
     const payload = await readStdinPayload();
     const stopHookActive = payload.stop_hook_active === true;
-    if (stopHookActive) { process.exit(0); }          // already reminded — let it stop
+    if (stopHookActive) { return shutdown(); }   // already reminded — let it stop
 
     const sessionId = payload.session_id || process.env.CLAUDE_SESSION_ID || process.env.SESSION_ID || '';
-    if (!sessionId) { process.exit(0); }              // can't resolve — fail-open
+    if (!sessionId) { return shutdown(); }       // can't resolve — fail-open
 
     const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
     const supabase = createSupabaseServiceClient();
@@ -100,21 +125,26 @@ async function main() {
       .select('loop_state')
       .eq('session_id', sessionId)
       .maybeSingle();
-    if (error) { process.exit(0); }                   // DB error — fail-open
+    if (error) { return shutdown(); }            // DB error — fail-open
 
     const loopState = data ? data.loop_state : null;
     if (shouldRemind({ loopState, stopHookActive, flagEnabled })) {
       process.stdout.write(JSON.stringify({ decision: 'block', reason: REMINDER }));
     }
-    process.exit(0);
+    return shutdown();
   } catch (e) {
     process.stderr.write(`[stop-loop-wakeup-reminder] ${e.message}\n`);
-    process.exit(0);                                  // fail-open: never trap a worker
+    return shutdown();                           // fail-open: never trap a worker
   }
 }
 
 if (require.main === module) {
-  main();
+  // Registered only when run as the hook (never when require()'d by tests, so it
+  // can't swallow a test runner's failures). Absorbs any late JS-level rejection
+  // and routes it through the same deferred exit.
+  process.on('uncaughtException', () => shutdown());
+  process.on('unhandledRejection', () => shutdown());
+  main().catch(() => shutdown());
 }
 
 module.exports = { shouldRemind, isFlagEnabled };


### PR DESCRIPTION
**Quick-Fix:** QF-20260609-183 (Tier 2, bug) — governance linkage for this PR.

## Root cause

Two Stop hooks aborted on Windows with:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

surfaced by Claude Code as `Stop hook error: Failed with non-blocking status code`.

The assertion is libuv's `uv_async_send()` guard "don't signal a handle that is already closing." It fires when a hook runs a **Supabase query** (Node's global `fetch`/undici opens a keep-alive TCP socket + a threadpool DNS `getaddrinfo`) and then calls **`process.exit()`**: exit forces libuv loop teardown while a socket/threadpool completion lands on an internal async handle already flagged `UV_HANDLE_CLOSING`.

- `scripts/hooks/stop-loop-wakeup-reminder.cjs` — the **live** culprit: `LEO_LOOP_WAKEUP_REMINDER=on` fleet-wide, so it queries `claude_sessions` then bare-exits on **every** turn-end.
- `scripts/hooks/post-completion-tail-enforcement.cjs` — same shape on its `learn`-pending path (`learnRanInDb`).
- `stop-subagent-enforcement.js` already does the same I/O but its `setImmediate` "gracefulExit" was assumed to be the cure — see below.

## Why the obvious fix was wrong

I reproduced the abort deterministically and tested exit strategies (6 runs each, real DB, Windows):

| strategy | aborts |
|---|---|
| bare `process.exit()` | 6/6 |
| `setImmediate(() => process.exit())` (the existing "gracefulExit" pattern) | 6/6 |
| `await getGlobalDispatcher().close()` → `process.exit()` | 4/4 |
| `await getGlobalDispatcher().close()` → `setImmediate(exit)` | 4/4 |
| `await getGlobalDispatcher().close()` → **natural drain (no `process.exit`)** | **0/4 ✓** |

**Any `process.exit()` after the query aborts — even after closing the socket pool.** The only reliable avoidance is to not call `process.exit()`.

## The fix

A shared `async shutdown()` in both hooks: close undici's global dispatcher, then **return** and let the event loop drain so the process exits on its own. An `unref`'d 8s backstop force-exits only if the loop fails to drain (sockets already closed by then). Also `clearTimeout` the stdin-read timeout so drain is prompt.

## Verification

- Post-fix smoke (the exact path that aborted 100%): **0/N aborts**, exit 0, prompt drain.
- All existing hook tests pass; added a CI-safe **source-pin** regression test (no DB/subprocess) locking the contract on both hooks. **32 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
