### PR TITLE
feat(SD-LEO-INFRA-ADAM-SELF-ASSESSMENT-001): Adam self-assessment writer + turn-counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,6 @@ scripts/ops/LLM-COST-ALERT.txt
 
 # Adam opportunity-scan runtime ledger (SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001)
 .adam-scan-ledger.json
+
+# Adam self-assessment turn-counter state (SD-LEO-INFRA-ADAM-SELF-ASSESSMENT-001)
+.adam-self-assessment-state.json

--- a/lib/adam/self-assessment.cjs
+++ b/lib/adam/self-assessment.cjs
@@ -1,0 +1,215 @@
+/**
+ * Adam self-assessment — pure, dependency-injected core.
+ * SD-LEO-INFRA-ADAM-SELF-ASSESSMENT-001. NO DB/FS I/O (the CLI does that).
+ *
+ * Scores Adam on the canonical 8 dimensions (leo_protocol_sections id=601) from
+ * OBSERVABLE SIGNALS only. A dimension with no signal is emitted as INCONCLUSIVE
+ * (omitted from the numeric `dimensions` map / null) — never a fabricated number.
+ * The score object matches the schema the verify-score-contract + adam-exec-summary
+ * already consume: { overall, session, cycle, threshold, dimensions, below_threshold,
+ * committed_actions, prior_action_outcomes, review_key }.
+ */
+
+const DEFAULT_EVERY_TURNS = 10;
+const BELOW_THRESHOLD_AT = 2; // matches lib/fleet/verify-score-contract.mjs DEFAULT_BELOW_THRESHOLD_AT
+const TARGET = 4; // aspirational per-dimension target (stored as `threshold`, like the existing rows)
+
+const DIMENSIONS = [
+  'D1_proactive_sourcing',
+  'D2_propose_first',
+  'D3_reviewer_not_safetynet',
+  'D4_verify_before_certainty',
+  'D5_vision_alignment',
+  'D6_close_loops_ack',
+  'D7_sd_quality',
+  'D8_interface_clarity',
+];
+
+const ACTION_HINTS = {
+  D1_proactive_sourcing: 'source more belt candidates and dedup before idling',
+  D2_propose_first: 'never claim or build — surface options and decline build-routes',
+  D3_reviewer_not_safetynet: 'let the coordinator run without intervening; catch by decline',
+  D4_verify_before_certainty: 'verify every claim against live code/DB before asserting',
+  D5_vision_alignment: 'cite a live objective/KR row (or L2 vision + metric) in every advisory',
+  D6_close_loops_ack: 'post terminal-action check-ins and ack directives within SLA',
+  D7_sd_quality: 'ground SD drafts in file:line, right tier, dedup-cited',
+  D8_interface_clarity: 'clear advisories, correct lane/target, <=1 per tick',
+};
+
+// ---------------------------------------------------------------------------
+// Turn-counter
+// ---------------------------------------------------------------------------
+
+/** Fire only when at least `everyTurns` turns have elapsed since the last fire. */
+function shouldFire(state, currentTurn, everyTurns = DEFAULT_EVERY_TURNS) {
+  const last = state && Number.isFinite(state.last_fired_turn) ? state.last_fired_turn : -Infinity;
+  return currentTurn - last >= everyTurns;
+}
+
+/** Default fresh state (a missing/corrupt state file degrades to this, never a crash). */
+function freshState() {
+  return { invocations: 0, last_fired_turn: -Infinity, cycle: 0, streak: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Dimension scorers (observable signal -> 1..5, or null = inconclusive)
+// ---------------------------------------------------------------------------
+
+const SCORERS = {
+  // belt depth: more unclaimed workable SDs surfaced/available = better proactive sourcing
+  D1_proactive_sourcing: (s) => {
+    if (s.belt_depth == null) return { score: null, provenance: 'no belt_depth signal (inconclusive)' };
+    const d = s.belt_depth;
+    const score = d >= 8 ? 5 : d >= 5 ? 4 : d >= 3 ? 3 : d >= 1 ? 2 : 1;
+    return { score, signal: `belt_depth=${d}`, provenance: 'unclaimed workable SD count' };
+  },
+  // Adam must NEVER claim/build — 0 claims is the only passing state; any claim is a red-flag.
+  D2_propose_first: (s) => {
+    if (s.adam_claim_count == null) return { score: null, provenance: 'no adam_claim_count signal (inconclusive)' };
+    const n = s.adam_claim_count;
+    return {
+      score: n === 0 ? 5 : 1,
+      signal: `adam_claim_count=${n}`,
+      provenance: 'claude_sessions Adam-role rows with a non-null sd_key',
+      red_flag: n > 0,
+    };
+  },
+  // coordinator can run without Adam — hard to measure directly; inconclusive unless supplied
+  D3_reviewer_not_safetynet: (s) => {
+    if (s.coordinator_autonomy_rate == null) return { score: null, provenance: 'no coordinator_autonomy signal (inconclusive)' };
+    const r = s.coordinator_autonomy_rate;
+    const score = r >= 0.95 ? 5 : r >= 0.8 ? 4 : r >= 0.6 ? 3 : r >= 0.4 ? 2 : 1;
+    return { score, signal: `coordinator_autonomy_rate=${r}`, provenance: 'coordinator review cycles run without Adam intervention' };
+  },
+  // verify-before-certainty: fewer contradicted/false claims = better
+  D4_verify_before_certainty: (s) => {
+    if (s.false_claim_rate == null) return { score: null, provenance: 'no false_claim_rate signal (inconclusive)' };
+    const r = s.false_claim_rate;
+    const score = r <= 0.02 ? 5 : r <= 0.05 ? 4 : r <= 0.1 ? 3 : r <= 0.2 ? 2 : 1;
+    return { score, signal: `false_claim_rate=${r}`, provenance: 'dropped-on-verify / live-contradicted claims' };
+  },
+  // vision alignment: share of advisories citing a live objective/KR/vision row
+  D5_vision_alignment: (s) => {
+    if (s.advisory_citation_rate == null) return { score: null, provenance: 'no advisory_citation_rate signal (inconclusive)' };
+    const r = s.advisory_citation_rate;
+    const score = r >= 0.95 ? 5 : r >= 0.8 ? 4 : r >= 0.6 ? 3 : r >= 0.3 ? 2 : 1;
+    return { score, signal: `advisory_citation_rate=${r}`, provenance: 'advisories citing objectives/key_results/eva_vision_documents' };
+  },
+  // close loops: lower ack latency (minutes) on Adam-targeted coordination rows = better
+  D6_close_loops_ack: (s) => {
+    if (s.ack_latency_min == null) return { score: null, provenance: 'no ack_latency_min signal (inconclusive)' };
+    const m = s.ack_latency_min;
+    const score = m <= 15 ? 5 : m <= 60 ? 4 : m <= 240 ? 3 : m <= 1440 ? 2 : 1;
+    return { score, signal: `ack_latency_min=${m}`, provenance: 'session_coordination read_at/actioned_at median latency' };
+  },
+  // sd quality: gate pass-rate of Adam-authored draft SDs
+  D7_sd_quality: (s) => {
+    if (s.adam_sd_pass_rate == null) return { score: null, provenance: 'no adam_sd_pass_rate signal (inconclusive)' };
+    const r = s.adam_sd_pass_rate;
+    const score = r >= 0.95 ? 5 : r >= 0.85 ? 4 : r >= 0.7 ? 3 : r >= 0.5 ? 2 : 1;
+    return { score, signal: `adam_sd_pass_rate=${r}`, provenance: 'gate pass-rate of Adam-authored SD drafts' };
+  },
+  // interface clarity: advisory deliverability (delivered / total)
+  D8_interface_clarity: (s) => {
+    if (s.advisory_deliverability == null) return { score: null, provenance: 'no advisory_deliverability signal (inconclusive)' };
+    const r = s.advisory_deliverability;
+    const score = r >= 0.98 ? 5 : r >= 0.9 ? 4 : r >= 0.75 ? 3 : r >= 0.5 ? 2 : 1;
+    return { score, signal: `advisory_deliverability=${r}`, provenance: 'advisories delivered vs dead-lettered' };
+  },
+};
+
+/**
+ * Score all 8 dimensions from a signals object.
+ * @returns {{ dimensions: Object<string,number>, provenance: Object, inconclusive: string[] }}
+ */
+function scoreDimensions(signals) {
+  const s = signals || {};
+  const dimensions = {};
+  const provenance = {};
+  const inconclusive = [];
+  for (const dim of DIMENSIONS) {
+    const r = SCORERS[dim](s);
+    provenance[dim] = { signal: r.signal || null, basis: r.provenance, ...(r.red_flag ? { red_flag: true } : {}) };
+    if (typeof r.score === 'number') dimensions[dim] = r.score;
+    else inconclusive.push(dim);
+  }
+  return { dimensions, provenance, inconclusive };
+}
+
+/** Below-threshold = numeric dimension scoring at/below the cutoff (default 2). */
+function classifyBelowThreshold(dimensions, belowAt = BELOW_THRESHOLD_AT) {
+  return Object.entries(dimensions || {})
+    .filter(([, v]) => typeof v === 'number' && v <= belowAt)
+    .map(([k]) => k);
+}
+
+/**
+ * Verify the prior cycle's committed_actions: a dimension "moved" when its current
+ * score exceeds the prior score. Populates prior_action_outcomes (required by the
+ * contract's Rule 2 whenever the prior cycle committed actions).
+ */
+function derivePriorOutcomes(priorScore, currentDimensions) {
+  if (!priorScore || !Array.isArray(priorScore.committed_actions)) return [];
+  const cur = currentDimensions || {};
+  const priorDims = priorScore.dimensions || {};
+  return priorScore.committed_actions.map((ca) => {
+    const dim = ca.gap;
+    const priorV = priorDims[dim];
+    const curV = cur[dim];
+    const moved = typeof priorV === 'number' && typeof curV === 'number' ? curV > priorV : false;
+    const outcome = typeof curV !== 'number' ? 'INCONCLUSIVE' : moved ? 'LANDED' : 'NOT_MOVED';
+    return { action: ca.action, gap: dim, outcome, moved };
+  });
+}
+
+/** Generate one committed_action per below-threshold dimension (Rule 1). */
+function generateCommittedActions(belowThreshold, provenance = {}) {
+  return (belowThreshold || []).map((dim) => ({
+    gap: dim,
+    type: 'behavior',
+    action: `Improve ${dim}: ${ACTION_HINTS[dim] || 'address the below-threshold signal'} (${provenance[dim]?.signal || 'signal'}).`,
+    verify_next: `Next cycle ${dim} score should exceed this cycle.`,
+  }));
+}
+
+/** "sum/max (avg/5)" over the numeric dimensions only. */
+function overallString(dimensions) {
+  const vals = Object.values(dimensions || {}).filter((v) => typeof v === 'number');
+  const sum = vals.reduce((a, b) => a + b, 0);
+  const avg = vals.length ? sum / vals.length : 0;
+  return `${sum}/${vals.length * 5} (${avg.toFixed(1)}/5)`;
+}
+
+/** Assemble the canonical score object (the metadata.score payload). */
+function assembleScore({ dimensions, cycle, session, committedActions, priorOutcomes, provenance, belowThreshold, date }) {
+  return {
+    cycle,
+    session,
+    threshold: TARGET,
+    overall: overallString(dimensions),
+    dimensions,
+    below_threshold: belowThreshold || classifyBelowThreshold(dimensions),
+    committed_actions: committedActions || [],
+    prior_action_outcomes: priorOutcomes || [],
+    review_key: `adam:cycle${cycle}:${date}`,
+    provenance: provenance || {},
+    generated_by: 'adam-self-assessment-writer',
+  };
+}
+
+module.exports = {
+  DIMENSIONS,
+  DEFAULT_EVERY_TURNS,
+  BELOW_THRESHOLD_AT,
+  TARGET,
+  ACTION_HINTS,
+  SCORERS,
+  shouldFire,
+  freshState,
+  scoreDimensions,
+  classifyBelowThreshold,
+  derivePriorOutcomes,
+  generateCommittedActions,
+  overallString,
+  assembleScore,
+};

--- a/package.json
+++ b/package.json
@@ -306,6 +306,7 @@
     "adam:retro": "node scripts/adam-retro.cjs",
     "adam:scan": "node scripts/adam-opportunity-scan.cjs --scan",
     "adam:briefing": "node scripts/adam-opportunity-scan.cjs --briefing",
+    "adam:self-score": "node scripts/adam-self-assessment-writer.cjs",
     "coordinator:cold-recovery": "node scripts/coordinator-cold-recovery.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",

--- a/scripts/adam-self-assessment-writer.cjs
+++ b/scripts/adam-self-assessment-writer.cjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * Adam self-assessment writer — the programmatic per-dimension self-score.
+ * SD-LEO-INFRA-ADAM-SELF-ASSESSMENT-001.
+ *
+ * Flag-gated (ADAM_SELF_SCORE_CADENCE, default OFF — ships INERT; the live-enablement
+ * child flips it). On a ~ADAM_SELF_SCORE_EVERY_TURNS cadence it: gathers observable
+ * signals, scores the 8 dimensions (numeric where a signal exists, inconclusive
+ * otherwise — never fabricated), verifies the prior cycle + validates via the shipped
+ * lib/fleet/verify-score-contract.mjs, and persists ONE feedback row
+ * (category=adam_self_assessment) with the common score schema, idempotent on review_key.
+ * Fail-OPEN on every error so it can never break Adam's tick.
+ *
+ * Flags: --dry-run (compute + print, write nothing) | --force (ignore flag + cadence gate).
+ *
+ * ESM note: the pure core (lib/adam/self-assessment.cjs) is required directly (CJS); the
+ * only ESM dep (verify-score-contract.mjs) is loaded via a string-LITERAL dynamic import
+ * so the WIRE_CHECK static call-graph can trace it.
+ */
+const path = require('path');
+const fs = require('fs');
+const core = require('../lib/adam/self-assessment.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const STATE_PATH = path.join(REPO_ROOT, '.adam-self-assessment-state.json');
+
+/** on|1|true => enabled; everything else (incl. undefined) => OFF. */
+function isFlagEnabled(env = process.env) {
+  const v = String(env.ADAM_SELF_SCORE_CADENCE || 'off').toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}
+
+function readState() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+    if (parsed && typeof parsed === 'object') return { ...core.freshState(), ...parsed };
+  } catch {
+    /* missing/corrupt => fresh */
+  }
+  return core.freshState();
+}
+
+function writeState(state) {
+  try {
+    fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2) + '\n');
+  } catch (e) {
+    process.stderr.write(`[adam-self-score] state write failed (non-fatal): ${e.message}\n`);
+  }
+}
+
+/** Gather observable signals (read-only, defensive: each failure => null = inconclusive). */
+async function gatherSignals(sb) {
+  const signals = {};
+  const safeCount = async (fn) => {
+    try {
+      const { count, error } = await fn();
+      return error ? null : count;
+    } catch {
+      return null;
+    }
+  };
+
+  // D1: belt depth = unclaimed workable (draft) SDs
+  signals.belt_depth = await safeCount(() =>
+    sb.from('strategic_directives_v2').select('id', { count: 'exact', head: true }).eq('status', 'draft').is('claiming_session_id', null)
+  );
+
+  // D2: Adam-role sessions holding a non-null sd_key (should be 0 — Adam never claims)
+  signals.adam_claim_count = await (async () => {
+    try {
+      const { data, error } = await sb
+        .from('claude_sessions')
+        .select('id, sd_key, callsign, metadata')
+        .not('sd_key', 'is', null);
+      if (error || !Array.isArray(data)) return null;
+      return data.filter((r) => {
+        const cs = String(r.callsign || '').toLowerCase();
+        const role = String((r.metadata && r.metadata.role) || '').toLowerCase();
+        return cs === 'adam' || role === 'adam';
+      }).length;
+    } catch {
+      return null;
+    }
+  })();
+
+  // D8: advisory deliverability = adam_advisory rows read / total (last 7d)
+  signals.advisory_deliverability = await (async () => {
+    try {
+      const { data, error } = await sb
+        .from('session_coordination')
+        .select('read_at, payload')
+        .eq('sender_type', 'adam')
+        .limit(500);
+      if (error || !Array.isArray(data) || data.length === 0) return null;
+      const adv = data.filter((r) => r.payload && r.payload.kind === 'adam_advisory');
+      if (adv.length === 0) return null;
+      const delivered = adv.filter((r) => r.read_at != null).length;
+      return delivered / adv.length;
+    } catch {
+      return null;
+    }
+  })();
+
+  // The remaining signals (D3 coordinator_autonomy_rate, D4 false_claim_rate,
+  // D5 advisory_citation_rate, D6 ack_latency_min, D7 adam_sd_pass_rate) have no
+  // reliable live source yet — left undefined so the scorers emit INCONCLUSIVE
+  // rather than a fabricated number.
+  return signals;
+}
+
+function printScore(score, verdict) {
+  process.stdout.write(JSON.stringify({ score, verdict }, null, 2) + '\n');
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const force = argv.includes('--force');
+
+  if (!isFlagEnabled() && !force) {
+    process.stdout.write('adam-self-assessment: ADAM_SELF_SCORE_CADENCE off — no-op\n');
+    process.exit(0);
+  }
+
+  try {
+    const everyTurns = Number(process.env.ADAM_SELF_SCORE_EVERY_TURNS) || core.DEFAULT_EVERY_TURNS;
+    const state = readState();
+    const invocations = (Number.isFinite(state.invocations) ? state.invocations : 0) + 1;
+
+    if (!core.shouldFire({ last_fired_turn: state.last_fired_turn }, invocations, everyTurns) && !force) {
+      writeState({ ...state, invocations });
+      const due = (Number.isFinite(state.last_fired_turn) ? state.last_fired_turn : 0) + everyTurns;
+      process.stdout.write(`adam-self-assessment: turn ${invocations}/${due} — not due, skip\n`);
+      process.exit(0);
+    }
+
+    const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+    const sb = createSupabaseServiceClient('engineer');
+    const sessionId = process.env.CLAUDE_SESSION_ID || 'adam';
+    const date = new Date().toISOString().slice(0, 10);
+    const newCycle = (state.cycle || 0) + 1;
+
+    const signals = await gatherSignals(sb);
+    const { dimensions, provenance } = core.scoreDimensions(signals);
+    const belowThreshold = core.classifyBelowThreshold(dimensions);
+
+    // prior cycle (most recent self-assessment row)
+    let priorScore = null;
+    try {
+      const { data: priorRows } = await sb
+        .from('feedback')
+        .select('metadata')
+        .eq('category', 'adam_self_assessment')
+        .order('created_at', { ascending: false })
+        .limit(1);
+      priorScore = priorRows && priorRows[0] && priorRows[0].metadata ? priorRows[0].metadata.score : null;
+    } catch {
+      priorScore = null;
+    }
+
+    const priorOutcomes = core.derivePriorOutcomes(priorScore, dimensions);
+    const committedActions = core.generateCommittedActions(belowThreshold, provenance);
+    const score = core.assembleScore({
+      dimensions, cycle: newCycle, session: sessionId, committedActions, priorOutcomes, provenance, belowThreshold, date,
+    });
+
+    // validate via the shipped contract (literal dynamic import — WIRE_CHECK-traceable)
+    const { validateScoreContract } = await import('../lib/fleet/verify-score-contract.mjs');
+    const verdict = validateScoreContract({ current: score, prior: priorScore, priorStreak: state.streak || 0 });
+    score.verify_verdict = { valid: verdict.valid, inconclusive: verdict.inconclusive, violations: verdict.violations, escalation: verdict.escalation };
+
+    if (dryRun) {
+      printScore(score, verdict);
+      process.exit(0);
+    }
+
+    // idempotent dedup on review_key
+    try {
+      const { data: existing } = await sb
+        .from('feedback')
+        .select('id')
+        .eq('category', 'adam_self_assessment')
+        .filter('metadata->>review_key', 'eq', score.review_key)
+        .limit(1);
+      if (existing && existing.length) {
+        process.stdout.write(`adam-self-assessment: cycle row ${score.review_key} already exists — skip\n`);
+        writeState({ ...state, invocations, last_fired_turn: invocations });
+        process.exit(0);
+      }
+    } catch {
+      /* dedup check failed — proceed (a duplicate is a tolerable additive row) */
+    }
+
+    const description = JSON.stringify({ overall: score.overall, below_threshold: belowThreshold });
+    const { error: insErr } = await sb.from('feedback').insert({
+      category: 'adam_self_assessment',
+      status: 'new',
+      description,
+      metadata: { score, review_key: score.review_key, sender_session: sessionId },
+    });
+    if (insErr) throw new Error(`feedback insert failed: ${insErr.message}`);
+
+    writeState({ invocations, last_fired_turn: invocations, cycle: newCycle, streak: verdict.escalation ? verdict.escalation.streak : 0 });
+    process.stdout.write(`adam-self-assessment: wrote cycle ${newCycle} (${score.overall}) review_key=${score.review_key}${verdict.escalation && verdict.escalation.triggered ? ' [ESCALATE]' : ''}\n`);
+    process.exit(0);
+  } catch (e) {
+    // FAIL OPEN — never break Adam's tick.
+    process.stderr.write(`[adam-self-score] degraded to no-op: ${e.message}\n`);
+    process.exit(0);
+  }
+}
+
+module.exports = { isFlagEnabled, readState, writeState, gatherSignals, STATE_PATH };
+
+if (require.main === module) {
+  main();
+}

--- a/tests/unit/adam/self-assessment.test.js
+++ b/tests/unit/adam/self-assessment.test.js
@@ -1,0 +1,128 @@
+/**
+ * SD-LEO-INFRA-ADAM-SELF-ASSESSMENT-001 — pure core + CLI flag helper (DB-free).
+ */
+import { describe, it, expect } from 'vitest';
+import { validateScoreContract } from '../../../lib/fleet/verify-score-contract.mjs';
+const core = require('../../../lib/adam/self-assessment.cjs');
+const { isFlagEnabled } = require('../../../scripts/adam-self-assessment-writer.cjs');
+
+describe('shouldFire (turn-counter)', () => {
+  it('does not fire before the cadence elapses, fires once it does', () => {
+    const state = { last_fired_turn: 5 };
+    expect(core.shouldFire(state, 10, 10)).toBe(false); // 10-5=5 < 10
+    expect(core.shouldFire(state, 15, 10)).toBe(true); // 10 >= 10
+    expect(core.shouldFire(state, 16, 10)).toBe(true);
+  });
+  it('fires on a fresh state (last_fired_turn = -Infinity)', () => {
+    expect(core.shouldFire(core.freshState(), 1, 10)).toBe(true);
+  });
+});
+
+describe('scoreDimensions', () => {
+  it('scores numeric where a signal exists and inconclusive (omitted) where absent', () => {
+    const { dimensions, inconclusive } = core.scoreDimensions({ belt_depth: 6, adam_claim_count: 0 });
+    expect(dimensions.D1_proactive_sourcing).toBe(4); // belt 6 -> 4
+    expect(dimensions.D2_propose_first).toBe(5); // 0 claims -> 5
+    expect('D5_vision_alignment' in dimensions).toBe(false); // no signal -> inconclusive
+    expect(inconclusive).toContain('D5_vision_alignment');
+  });
+  it('flags D2 as a red-flag and scores 1 when Adam has claimed an SD', () => {
+    const { dimensions, provenance } = core.scoreDimensions({ adam_claim_count: 1 });
+    expect(dimensions.D2_propose_first).toBe(1);
+    expect(provenance.D2_propose_first.red_flag).toBe(true);
+  });
+  it('never fabricates: an all-empty signals object yields zero numeric dimensions', () => {
+    const { dimensions, inconclusive } = core.scoreDimensions({});
+    expect(Object.keys(dimensions).length).toBe(0);
+    expect(inconclusive.length).toBe(core.DIMENSIONS.length);
+  });
+});
+
+describe('classifyBelowThreshold', () => {
+  it('marks only dimensions scoring <=2 and excludes inconclusive (absent) dims', () => {
+    const below = core.classifyBelowThreshold({ D6_close_loops_ack: 2, D1_proactive_sourcing: 4, D8_interface_clarity: 1 });
+    expect(below.sort()).toEqual(['D6_close_loops_ack', 'D8_interface_clarity']);
+  });
+});
+
+describe('derivePriorOutcomes', () => {
+  const prior = {
+    dimensions: { D6_close_loops_ack: 2 },
+    committed_actions: [{ gap: 'D6_close_loops_ack', action: 'ack faster' }],
+  };
+  it('marks moved=true (LANDED) when the dimension improved', () => {
+    const out = core.derivePriorOutcomes(prior, { D6_close_loops_ack: 4 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ gap: 'D6_close_loops_ack', outcome: 'LANDED', moved: true });
+  });
+  it('marks NOT_MOVED when the dimension did not improve, INCONCLUSIVE when now unscored', () => {
+    expect(core.derivePriorOutcomes(prior, { D6_close_loops_ack: 2 })[0].outcome).toBe('NOT_MOVED');
+    expect(core.derivePriorOutcomes(prior, {})[0].outcome).toBe('INCONCLUSIVE');
+  });
+  it('returns [] when the prior cycle committed no actions', () => {
+    expect(core.derivePriorOutcomes({ dimensions: {}, committed_actions: [] }, {})).toEqual([]);
+  });
+});
+
+describe('generateCommittedActions', () => {
+  it('produces exactly one action per below-threshold dimension', () => {
+    const acts = core.generateCommittedActions(['D6_close_loops_ack', 'D8_interface_clarity'], {});
+    expect(acts).toHaveLength(2);
+    expect(acts[0]).toMatchObject({ gap: 'D6_close_loops_ack', type: 'behavior' });
+    expect(acts[0].action.length).toBeGreaterThan(10);
+  });
+});
+
+describe('assembleScore + overallString', () => {
+  it('assembles the canonical schema with overall computed from numeric dims', () => {
+    const score = core.assembleScore({
+      dimensions: { D1_proactive_sourcing: 4, D2_propose_first: 5 },
+      cycle: 3, session: 'sess-1', committedActions: [], priorOutcomes: [], provenance: {}, belowThreshold: [], date: '2026-06-09',
+    });
+    expect(score).toMatchObject({ cycle: 3, session: 'sess-1', threshold: 4, review_key: 'adam:cycle3:2026-06-09' });
+    expect(score.overall).toBe('9/10 (4.5/5)');
+    expect(Array.isArray(score.committed_actions)).toBe(true);
+    expect(Array.isArray(score.prior_action_outcomes)).toBe(true);
+  });
+});
+
+describe('validateScoreContract integration (valid by construction)', () => {
+  it('a writer-assembled score with below-threshold dims passes (actions + prior outcomes present)', () => {
+    const prior = { dimensions: { D6_close_loops_ack: 2 }, committed_actions: [{ gap: 'D6_close_loops_ack', action: 'ack faster' }] };
+    const dimensions = { D6_close_loops_ack: 2, D1_proactive_sourcing: 4 };
+    const below = core.classifyBelowThreshold(dimensions); // [D6]
+    const score = core.assembleScore({
+      dimensions, cycle: 2, session: 's', date: '2026-06-09',
+      belowThreshold: below,
+      committedActions: core.generateCommittedActions(below, {}),
+      priorOutcomes: core.derivePriorOutcomes(prior, dimensions),
+    });
+    const verdict = validateScoreContract({ current: score, prior, priorStreak: 0 });
+    expect(verdict.valid).toBe(true);
+    expect(verdict.violations).toEqual([]);
+  });
+
+  it('escalates after N consecutive below-threshold cycles', () => {
+    const dimensions = { D6_close_loops_ack: 2 };
+    const score = core.assembleScore({
+      dimensions, cycle: 5, session: 's', date: '2026-06-09',
+      belowThreshold: ['D6_close_loops_ack'],
+      committedActions: core.generateCommittedActions(['D6_close_loops_ack'], {}),
+      priorOutcomes: [],
+    });
+    const verdict = validateScoreContract({ current: score, prior: null, priorStreak: 2 });
+    expect(verdict.escalation.triggered).toBe(true);
+    expect(verdict.escalation.streak).toBe(3);
+  });
+});
+
+describe('isFlagEnabled (ADAM_SELF_SCORE_CADENCE)', () => {
+  it('is OFF for unset/off/garbage, ON only for on/1/true', () => {
+    expect(isFlagEnabled({})).toBe(false);
+    expect(isFlagEnabled({ ADAM_SELF_SCORE_CADENCE: 'off' })).toBe(false);
+    expect(isFlagEnabled({ ADAM_SELF_SCORE_CADENCE: 'maybe' })).toBe(false);
+    expect(isFlagEnabled({ ADAM_SELF_SCORE_CADENCE: 'on' })).toBe(true);
+    expect(isFlagEnabled({ ADAM_SELF_SCORE_CADENCE: '1' })).toBe(true);
+    expect(isFlagEnabled({ ADAM_SELF_SCORE_CADENCE: 'TRUE' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The programmatic per-dimension self-score Adam was missing. Previously the `adam_self_assessment` rows were hand-authored and `ADAM_SELF_SCORE_CADENCE` had **zero runtime consumer**. This ships the writer **INERT** behind `ADAM_SELF_SCORE_CADENCE` (default OFF — the downstream live-enablement child flips it). Consumes the shipped `lib/fleet/verify-score-contract.mjs`.

## What's new
- **`lib/adam/self-assessment.cjs`** (pure/DI core): turn-counter (`shouldFire`), 8 dimension scorers (observable-signal → 1-5, or **null = inconclusive** — never fabricated), `classifyBelowThreshold` (≤2), `derivePriorOutcomes` (a dimension "moved" when current > prior), `generateCommittedActions`, `assembleScore` (canonical schema).
- **`scripts/adam-self-assessment-writer.cjs`** (CLI): flag gate + turn-counter state file, gather live signals, **reuse** `verify-score-contract.mjs` to validate (literal dynamic import), persist **one** `feedback` row (`category=adam_self_assessment`, `metadata.score`) idempotent on `review_key`, `--dry-run`/`--force`, **fail-OPEN**.
- **npm alias** `adam:self-score`; `.adam-self-assessment-state.json` gitignored.

## Verification
- 14/14 DB-free unit tests pass.
- TESTING sub-agent **PASS** (92): never-fabricate + read-only-except-one-flagged-insert invariants empirically proven.
- Live `--force --dry-run` computed a real signal-grounded score (D1=4 from belt_depth, D8=2 from advisory_deliverability, D2-D7 inconclusive), derived `prior_action_outcomes` from the prior cycle, validated `valid=true`, wrote nothing.
- WIRE_CHECK reachability verified with the gate's own `buildCallGraph`+`checkReachability` (0 unreachable, once committed).

## Notes
- Read-only except the single flag-gated `feedback` insert; ships inert (flag OFF). Activation is the downstream child SD.
- Depends on (completed) SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (PR #4503), which shipped the verify-score-contract primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)