### PR TITLE
feat(SD-LEO-INFRA-ADAM-PREFERENCE-LEARNING-001): scope-tagged advisories + scheduled per-scope chairman exec email

### DIFF
--- a/.github/workflows/adam-exec-email-cron.yml
+++ b/.github/workflows/adam-exec-email-cron.yml
@@ -1,0 +1,67 @@
+name: "Adam chairman exec email (cron)"
+
+# SD: SD-LEO-INFRA-ADAM-PREFERENCE-LEARNING-001 (FR-3)
+#
+# Schedules the Adam chairman executive summary (scripts/adam-exec-summary.mjs) — the
+# chairman-chosen proactive channel — which previously had NO schedule (manual only, not
+# in package.json, no cron). Per the cadence contract this MUST be GitHub-Actions cron, NOT
+# pg_cron (no migration).
+#
+# OBSERVE-ONLY BRING-UP: the scheduled run sends a REAL email ONLY when the repo variable
+# ADAM_EMAIL_LIVE == 'true'. Until the operator sets that variable (and the RESEND_API_KEY /
+# CLAUDE_NOTIFY_EMAIL secrets), every run is --dry-run (logs the summary, sends nothing) — so
+# merging this workflow cannot email anyone unconfigured. The workflow_dispatch dry_run input
+# forces a dry-run even when ADAM_EMAIL_LIVE is set (for safe manual testing).
+
+on:
+  schedule:
+    # Daily 13:00 UTC (~9am ET) — the always-on proactive chairman artifact.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Force dry-run (no send) even if ADAM_EMAIL_LIVE is set"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  exec-email:
+    name: Send chairman exec email
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      CLAUDE_NOTIFY_EMAIL: ${{ secrets.CLAUDE_NOTIFY_EMAIL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Send chairman exec email (observe-only until ADAM_EMAIL_LIVE repo var = true)
+        run: |
+          ARGS="--dry-run"
+          if [ "${{ vars.ADAM_EMAIL_LIVE }}" = "true" ] && [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+            ARGS=""
+          fi
+          echo "Running adam:exec:email:cron ${ARGS:-(LIVE send)}"
+          npm run adam:exec:email:cron -- $ARGS

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cascade:watch:cron": "node scripts/cron/cascade-watcher.mjs --once",
     "leo:build:start:cron": "node scripts/cron/leo-build-starter.mjs --once",
     "eva:scheduler:watch:cron": "node scripts/cron/eva-scheduler-watcher.mjs --once",
+    "adam:exec:email:cron": "node scripts/adam-exec-summary.mjs",
     "cascade:status": "node scripts/cron/cascade-status.mjs",
     "cascade:snapshot:capture": "node scripts/test-helpers/capture-crongenius-snapshot.mjs",
     "backfill:pr-tracking": "node scripts/backfill-pr-tracking.js",

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -45,17 +45,57 @@ const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
  * request mode. Conflating them made every fire-and-forget send falsely advertise
  * Reply?=yes in printAdamInbox.
  */
-function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply }) {
+function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes }) {
   const payload = {
     kind: PAYLOAD_KINDS.ADAM_ADVISORY,
     sender_callsign: senderCallsign || null,
     repo: repo || null,
   };
-  if (body) payload.body = redact(String(body)).slice(0, BODY_HARD_CAP);
+  // FR-1 (SD-LEO-INFRA-ADAM-PREFERENCE-LEARNING-001) — scope-tagged surfacing. ADDITIVE
+  // routing fields (no migration); scope_key reuses the lib/adam/scope-registry.js
+  // vocabulary (harness | platform | venture:<id>). reuse_class classifies applicability
+  // (scope_local | cross_scope); applies_to_scopes lists the scopes a cross-scope advisory
+  // covers. The two-stage actioned_at ACK is unchanged.
+  if (scopeKey) payload.scope_key = scopeKey;
+  if (reuseClass) payload.reuse_class = reuseClass;
+  if (Array.isArray(appliesToScopes) && appliesToScopes.length) payload.applies_to_scopes = appliesToScopes;
+  if (body) {
+    // Prefix the body with [<scope_key>] so a delivered-but-ignored advisory stays
+    // scannable by scope. Prefix BEFORE redact/slice so the tag survives the hard cap.
+    const tagged = scopeKey ? `[${scopeKey}] ${String(body)}` : String(body);
+    payload.body = redact(tagged).slice(0, BODY_HARD_CAP);
+  }
   if (correlationId) payload.correlation_id = correlationId; // replyable (always)
   if (expectsReply) payload.expects_reply = true;            // awaiting a sync reply (request mode only)
   // INVARIANT: no signal_type, no intent_action.
   return payload;
+}
+
+/**
+ * FR-1 — resolve the scope_key for an outgoing advisory from the SENDING repo, REUSING the
+ * lib/adam/scope-registry.js vocabulary (harness | platform | venture:<id>) instead of
+ * re-inventing it. The ESM registry is loaded via a string-LITERAL dynamic import (the
+ * CJS->ESM WIRE_CHECK-safe form). Fail-soft: any resolution error returns {} so the advisory
+ * still sends untagged (backward-compatible). Exported for tests.
+ * @returns {Promise<{scopeKey?:string, reuseClass?:string, appliesToScopes?:string[]}>}
+ */
+async function resolveScopeForSend(supabase, repoPath) {
+  try {
+    const { enumerateScopes } = await import('../lib/adam/scope-registry.js');
+    const scopes = await enumerateScopes(supabase);
+    if (!Array.isArray(scopes) || scopes.length === 0) return {};
+    // Canonicalize (forward-slash + strip any .worktrees/<sd> suffix) so a worker's worktree
+    // cwd matches the registry's main-root repo_path. Mirrors lib/repo-paths toCanonicalRepoPath.
+    const canon = (p) => String(p || '').replace(/\\/g, '/').replace(/\/\.worktrees\/[^/]+/, '').replace(/\/+$/, '');
+    const here = canon(repoPath);
+    const mine = scopes.find((s) => canon(s.repo_path) === here)
+      || scopes.find((s) => s.scope_key === 'platform')
+      || null;
+    if (!mine) return {};
+    return { scopeKey: mine.scope_key, reuseClass: 'scope_local', appliesToScopes: [mine.scope_key] };
+  } catch {
+    return {};
+  }
 }
 
 async function snapshotSender(supabase, sessionId) {
@@ -140,7 +180,9 @@ async function main() {
   // sets expects_reply (it synchronously awaits).
   const correlationId = crypto.randomUUID();
   const expectsReply = mode === 'request';
-  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply });
+  // FR-1: scope-tag the advisory from the sending repo (reuse-first, fail-soft).
+  const { scopeKey, reuseClass, appliesToScopes } = await resolveScopeForSend(supabase, process.cwd());
+  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes });
   const subject = `[ADAM_ADVISORY] ${payload.body.slice(0, 80)}`;
   const expiresAt = new Date(Date.now() + (mode === 'request' ? timeoutMs + 5 * 60_000 : 24 * 60 * 60_000)).toISOString();
 
@@ -179,7 +221,7 @@ async function main() {
   }
 }
 
-module.exports = { buildAdvisoryPayload, drainReplies };
+module.exports = { buildAdvisoryPayload, resolveScopeForSend, drainReplies };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -88,9 +88,9 @@ async function resolveScopeForSend(supabase, repoPath) {
     // cwd matches the registry's main-root repo_path. Mirrors lib/repo-paths toCanonicalRepoPath.
     const canon = (p) => String(p || '').replace(/\\/g, '/').replace(/\/\.worktrees\/[^/]+/, '').replace(/\/+$/, '');
     const here = canon(repoPath);
-    const mine = scopes.find((s) => canon(s.repo_path) === here)
-      || scopes.find((s) => s.scope_key === 'platform')
-      || null;
+    // No 'platform' fallback: a repo that matches no enumerated scope stays UNTAGGED (honest)
+    // rather than mislabeled — scope_key only appears when we can actually identify the scope.
+    const mine = scopes.find((s) => canon(s.repo_path) === here) || null;
     if (!mine) return {};
     return { scopeKey: mine.scope_key, reuseClass: 'scope_local', appliesToScopes: [mine.scope_key] };
   } catch {

--- a/scripts/adam-advisory.test.js
+++ b/scripts/adam-advisory.test.js
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-const { buildAdvisoryPayload, drainReplies } = require('./adam-advisory.cjs');
+const { buildAdvisoryPayload, drainReplies, resolveScopeForSend } = require('./adam-advisory.cjs');
 const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
 
 describe('FR-2: PAYLOAD_KINDS registry', () => {
@@ -51,5 +51,43 @@ describe('buildAdvisoryPayload', () => {
 describe('FR-4: durable reply reader export', () => {
   it('exports drainReplies for the persistent coordinator_reply reader', () => {
     expect(typeof drainReplies).toBe('function');
+  });
+});
+
+// SD-LEO-INFRA-ADAM-PREFERENCE-LEARNING-001 FR-1 — scope-tagged surfacing.
+describe('FR-1: scope-tagged advisory payload', () => {
+  it('emits scope_key / reuse_class / applies_to_scopes when provided', () => {
+    const p = buildAdvisoryPayload({ body: 'stale heartbeat', senderCallsign: 'Adam', repo: '/r', scopeKey: 'harness', reuseClass: 'scope_local', appliesToScopes: ['harness'] });
+    expect(p.scope_key).toBe('harness');
+    expect(p.reuse_class).toBe('scope_local');
+    expect(p.applies_to_scopes).toEqual(['harness']);
+  });
+
+  it('prefixes the body with [<scope_key>] when a scope is present', () => {
+    const p = buildAdvisoryPayload({ body: 'venture X stalled at S17', senderCallsign: 'Adam', repo: '/r', scopeKey: 'venture:abc-123' });
+    expect(p.body).toBe('[venture:abc-123] venture X stalled at S17');
+  });
+
+  it('is fully backward-compatible: NO scope fields and NO body prefix when scope is absent', () => {
+    const p = buildAdvisoryPayload({ body: 'plain advisory', senderCallsign: 'Adam', repo: '/r' });
+    expect(p.scope_key).toBeUndefined();
+    expect(p.reuse_class).toBeUndefined();
+    expect(p.applies_to_scopes).toBeUndefined();
+    expect(p.body).toBe('plain advisory'); // unchanged
+  });
+
+  it('omits applies_to_scopes when given an empty array (additive, no empty keys)', () => {
+    const p = buildAdvisoryPayload({ body: 'x', scopeKey: 'platform', appliesToScopes: [] });
+    expect(p.scope_key).toBe('platform');
+    expect(p.applies_to_scopes).toBeUndefined();
+  });
+
+  it('exports resolveScopeForSend and it is fail-soft (returns {} when scope enumeration throws)', async () => {
+    expect(typeof resolveScopeForSend).toBe('function');
+    // A supabase stub whose query path throws — resolveScopeForSend must swallow it and
+    // return {} so the advisory still sends untagged (never blocks a send on scope failure).
+    const throwingSupabase = { from() { throw new Error('db down'); } };
+    const r = await resolveScopeForSend(throwingSupabase, '/some/repo');
+    expect(r).toEqual({});
   });
 });

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -1,0 +1,109 @@
+// adam-exec-summary v2 — chairman-lens exec summary (Adam-owned). Dual focus (chairman 2026-06-08): pilot
+// (DataDistill, issue-discovery VEHICLE) + venture-process improvement (the real deliverable). Pilot pace =
+// "advancing as the process fixes land", not "stalled". Value section classifies shipped SDs into
+// capabilities / enablers / problems-solved. Trends on every line. Reuses coordinator fleet card verbatim.
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { execSync } from 'child_process';
+import { pathToFileURL } from 'url';
+import { resolve } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+
+const EM = '—', UP = ' ↑', DN = ' ↓';
+const I = { star: '\u{1F3AF}', flag: '⛳', tools: '\u{1F6E0}', loop: '\u{1F501}', siren: '\u{1F6A8}' };
+const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const t = Date.now();
+const DRY = !!process.env.ADAM_EMAIL_DRYRUN;
+const SNAP = resolve('.adam-email-last.json');
+const esc = (s) => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const arrow = (cur, prev) => (typeof prev !== 'number' || cur === prev) ? '' : (cur > prev ? UP : DN);
+let snap = {}; try { snap = JSON.parse(readFileSync(SNAP, 'utf8')); } catch { snap = {}; }
+const TERMINAL = "(completed,cancelled,archived,deferred)";
+const PROCESS_RX = /LIFECYCLE|STAGE|VENTURE|GROWTH|LAUNCH|DISTRIBUTION|OPERATIONS|POST-BUILD|S2[0-6]|VISUAL|PLAYBOOK/i;
+
+let cardText = '(fleet card unavailable)', cardSubject = 'Fleet';
+try {
+  const out = execSync('node --env-file=.env scripts/coordinator-email-summary.mjs', { encoding: 'utf8', env: { ...process.env, COORD_EMAIL_DRYRUN: '1' } });
+  const sm = out.match(/SUBJECT:\s*(.+)/); if (sm) cardSubject = sm[1].trim();
+  const parts = out.split('---'); if (parts.length >= 2) cardText = parts[1].trim();
+} catch (e) { cardText = '(fleet card error)'; }
+
+let pilotStage = 0;
+try {
+  const { data: v } = await db.from('ventures').select('id').ilike('name', '%datadistill%').limit(1);
+  if (v && v[0]) { const { data: a } = await db.from('venture_artifacts').select('lifecycle_stage').eq('venture_id', v[0].id).order('lifecycle_stage', { ascending: false }).limit(1); pilotStage = (a && a[0]) ? (a[0].lifecycle_stage || 0) : 0; }
+} catch {}
+let procInFlight = 0;
+try { const { data: open } = await db.from('strategic_directives_v2').select('sd_key,scope,title').not('status', 'in', TERMINAL); procInFlight = (open || []).filter(r => PROCESS_RX.test(String(r.sd_key) + ' ' + String(r.title) + ' ' + String(r.scope))).length; } catch {}
+const northStar = 'Pilot DataDistill S' + pilotStage + '/26' + (arrow(pilotStage, snap.pilotStage) || ' (steady)') + ' ' + EM + ' advancing as the process fixes it surfaced land. ' + procInFlight + ' process SDs in flight (stages 20-26 + ops).';
+
+let needs = []; try { needs = JSON.parse(readFileSync(resolve('.adam-chairman-decisions.json'), 'utf8')) || []; } catch {}
+
+const since = new Date(t - 24 * 3600 * 1000).toISOString(); // value section = rolling 24h (substantive), not the 30-min cadence
+let buckets = { cap: [], enab: [], prob: [] }, shippedN = 0, completedNow = snap.completedCount;
+try {
+  const r = await db.from('strategic_directives_v2').select('sd_key', { count: 'exact', head: true }).eq('status', 'completed'); completedNow = r.count;
+  const { data: done } = await db.from('strategic_directives_v2').select('sd_key,title,sd_type').eq('status', 'completed').gte('updated_at', since).order('updated_at', { ascending: false }).limit(40);
+  shippedN = (done || []).length;
+  const clean = (s) => String(s || '').replace(/^(SD-[A-Z0-9-]+:?\s*)/i, '').replace(/\s+/g, ' ').trim();
+  const trunc = (s, n) => { s = clean(s); if (s.length <= n) return s; const cut = s.slice(0, n); const sp = cut.lastIndexOf(' '); return (sp > n * 0.6 ? cut.slice(0, sp) : cut).replace(/[\s,.:;—-]+$/, '') + '…'; };
+  for (const r2 of (done || [])) {
+    const k = String(r2.sd_key || '').toUpperCase(); const ty = String(r2.sd_type || '').toLowerCase();
+    const label = trunc(r2.title, 50);
+    if (ty === 'bugfix' || ty === 'fix' || /\b(FIX|GUARD|BUG|HANG|DRIFT|REPAIR|RESIDUAL|VALIDATE)\b/.test(k)) buckets.prob.push(label);
+    else if (ty === 'feature' || /(FEAT|GATE|LIFECYCLE|CONVERT|HARDEN)/.test(k)) buckets.cap.push(label);
+    else buckets.enab.push(label);
+  }
+} catch {}
+const bucketLine = (arr, n) => arr.length ? (arr.slice(0, n).join(' · ') + (arr.length > n ? ' · +' + (arr.length - n) + ' more' : '')) : 'none';
+
+let selfLabel = 'pending', selfScore = snap.selfScore, coordRev = 'pending';
+try {
+  const { data: a } = await db.from('feedback').select('description').eq('category', 'adam_self_assessment').order('created_at', { ascending: false }).limit(1);
+  const { data: c } = await db.from('feedback').select('description').eq('category', 'coordinator_review').order('created_at', { ascending: false }).limit(1);
+  try { const o = JSON.parse((a && a[0] && a[0].description) || '{}'); selfLabel = o.overall || 'pending'; const m = String(selfLabel).match(/(\d+)\s*\/\s*40/); if (m) selfScore = parseInt(m[1], 10); } catch {}
+  try { const co = JSON.parse((c && c[0] && c[0].description) || '{}'); coordRev = co.overall || ((c && c[0]) ? 'on file' : 'pending'); } catch { coordRev = (c && c[0]) ? 'on file' : 'pending'; }
+} catch {}
+const selfLine = 'Adam self-score ' + selfLabel + arrow(selfScore, snap.selfScore) + '; coordinator self-score ' + coordRev;
+
+let canaryN = 0; try { const r = await db.from('feedback').select('id', { count: 'exact', head: true }).eq('status', 'new').eq('severity', 'high').in('category', ['harness_backlog', 'ci_failure', 'corrective_finding']); canaryN = r.count || 0; } catch {}
+const canaryLine = canaryN ? (canaryN + ' high-sev open' + (arrow(canaryN, snap.canaryCount) || ' (steady)')) : 'no high-sev flags';
+
+const when = new Date(t).toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
+const subject = '[Chairman] Pilot S' + pilotStage + '/26 ' + EM + ' ' + needs.length + ' need you ' + EM + ' ' + procInFlight + ' process SDs ' + EM + ' ' + cardSubject;
+const text = [
+  'STRATEGIC ' + EM + ' chairman lens (two focuses: drive the pilot + improve the venture process)', '',
+  'NORTH STAR: ' + northStar, '',
+  'NEEDS YOU (' + needs.length + '):', ...needs.map(d => '  - [' + d.priority + '] ' + d.label), '',
+  'VALUE DELIVERED (last 24h, ' + shippedN + ' SDs):',
+  '  Capabilities added (' + buckets.cap.length + '): ' + bucketLine(buckets.cap, 3),
+  '  Enablers added (' + buckets.enab.length + '): ' + bucketLine(buckets.enab, 3),
+  '  Problems solved (' + buckets.prob.length + '): ' + bucketLine(buckets.prob, 3), '',
+  'SELF-IMPROVEMENT (tri-party): ' + selfLine, '',
+  'CANARY: ' + canaryLine, '',
+  '--- FLEET HEALTH ---', cardText
+].join('\n');
+const needsHtml = needs.length ? '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' + needs.map(d => '<li style="margin:0 0 3px"><b>[' + esc(d.priority) + ']</b> ' + esc(d.label) + '</li>').join('') + '</ul>' : '<span style="font-size:13px">nothing pending</span>';
+const valHtml = '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' +
+  '<li style="margin:0 0 3px"><b>Capabilities added (' + buckets.cap.length + '):</b> ' + esc(bucketLine(buckets.cap, 3)) + '</li>' +
+  '<li style="margin:0 0 3px"><b>Enablers added (' + buckets.enab.length + '):</b> ' + esc(bucketLine(buckets.enab, 3)) + '</li>' +
+  '<li style="margin:0 0 3px"><b>Problems solved (' + buckets.prob.length + '):</b> ' + esc(bucketLine(buckets.prob, 3)) + '</li></ul>';
+const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
+  '<p style="font-size:16px;font-weight:600;margin:0 0 2px">Strategic ' + EM + ' chairman lens</p>' +
+  '<p style="font-size:12px;color:#777;margin:0 0 10px">Two focuses: drive the pilot (issue-discovery vehicle) + improve the venture-management process</p>' +
+  '<p style="font-size:14px;margin:0 0 8px">' + I.star + ' <b>North star:</b> ' + esc(northStar) + '</p>' +
+  '<p style="font-size:14px;margin:0 0 2px">' + I.flag + ' <b>Needs you (' + needs.length + '):</b></p>' + needsHtml +
+  '<p style="font-size:14px;margin:10px 0 2px">' + I.tools + ' <b>Value delivered (last 24h, ' + shippedN + ' SDs):</b></p>' + valHtml +
+  '<p style="font-size:14px;margin:10px 0 2px">' + I.loop + ' <b>Self-improvement:</b> ' + esc(selfLine) + '</p>' +
+  '<p style="font-size:14px;margin:0 0 12px">' + I.siren + ' <b>Canary:</b> ' + esc(canaryLine) + '</p>' +
+  '<p style="font-size:13px;font-weight:600;color:#555;margin:0 0 4px">Fleet health</p>' +
+  '<pre style="font-size:13px;background:#f6f8fa;border-radius:4px;padding:10px;white-space:pre-wrap;margin:0">' + esc(cardText) + '</pre>' +
+  '<p style="font-size:11px;color:#999;margin:12px 0 0">' + when + ' ET ' + EM + ' Adam ' + EM + ' LEO Fleet Advisor</p></div>';
+
+if (DRY) { console.log('=== [ADAM DRY RUN] no email sent ===\nSUBJECT: ' + subject + '\n---\n' + text + '\n---'); }
+else {
+  const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
+  const r = await mod.sendEmail({ from: 'Adam ' + EM + ' LEO Fleet Advisor <onboarding@resend.dev>', to: process.env.CLAUDE_NOTIFY_EMAIL, subject, html, text });
+  console.log('ADAM-EMAIL', JSON.stringify(r));
+  try { writeFileSync(SNAP, JSON.stringify({ lastTs: t, pilotStage, completedCount: completedNow, selfScore, canaryCount: canaryN })); } catch {}
+}

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -8,12 +8,15 @@ import { execSync } from 'child_process';
 import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { readFileSync, writeFileSync } from 'fs';
+// FR-2 (SD-LEO-INFRA-ADAM-PREFERENCE-LEARNING-001): per-scope roll-up reuses the existing
+// scope vocabulary instead of re-inventing it (scan-core delivered enumerateScopes).
+import { enumerateScopes } from '../lib/adam/scope-registry.js';
 
 const EM = '—', UP = ' ↑', DN = ' ↓';
 const I = { star: '\u{1F3AF}', flag: '⛳', tools: '\u{1F6E0}', loop: '\u{1F501}', siren: '\u{1F6A8}' };
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const t = Date.now();
-const DRY = !!process.env.ADAM_EMAIL_DRYRUN;
+const DRY = !!process.env.ADAM_EMAIL_DRYRUN || process.argv.includes('--dry-run');
 const SNAP = resolve('.adam-email-last.json');
 const esc = (s) => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 const arrow = (cur, prev) => (typeof prev !== 'number' || cur === prev) ? '' : (cur > prev ? UP : DN);
@@ -38,6 +41,25 @@ try { const { data: open } = await db.from('strategic_directives_v2').select('sd
 const northStar = 'Pilot DataDistill S' + pilotStage + '/26' + (arrow(pilotStage, snap.pilotStage) || ' (steady)') + ' ' + EM + ' advancing as the process fixes it surfaced land. ' + procInFlight + ' process SDs in flight (stages 20-26 + ops).';
 
 let needs = []; try { needs = JSON.parse(readFileSync(resolve('.adam-chairman-decisions.json'), 'utf8')) || []; } catch {}
+
+// FR-2: per-scope roll-up — count recent Adam advisories per scope (reuses FR-1's scope_key),
+// fail-soft so a scope/DB error never blocks the chairman email.
+let scopeRollup = [], perScope = {};
+try {
+  const scopes = await enumerateScopes(db);
+  const advSince = new Date(t - 24 * 3600 * 1000).toISOString();
+  let advs = [];
+  try {
+    const { data } = await db.from('session_coordination').select('payload').gte('created_at', advSince).filter('payload->>kind', 'eq', 'adam_advisory').limit(2000);
+    advs = data || [];
+  } catch {}
+  for (const a of advs) { const sk = a.payload && a.payload.scope_key; if (sk) perScope[sk] = (perScope[sk] || 0) + 1; }
+  const prev = snap.perScope || {};
+  scopeRollup = (scopes || []).map((s) => ({ scope: s.scope_key, n: perScope[s.scope_key] || 0, arrow: arrow(perScope[s.scope_key] || 0, prev[s.scope_key]) }));
+} catch {}
+const scopeRollupLine = scopeRollup.length ? scopeRollup.map((r) => r.scope + ': ' + r.n + (r.arrow || '')).join('  ·  ') : '(scope roll-up unavailable)';
+// FR-2: scope-tag a needs item label (forward-compatible — only when the item carries a scope).
+const needsLabel = (d) => (d && (d.scope_key || d.scope) ? '[' + (d.scope_key || d.scope) + '] ' : '') + (d ? d.label : '');
 
 const since = new Date(t - 24 * 3600 * 1000).toISOString(); // value section = rolling 24h (substantive), not the 30-min cadence
 let buckets = { cap: [], enab: [], prob: [] }, shippedN = 0, completedNow = snap.completedCount;
@@ -74,7 +96,8 @@ const subject = '[Chairman] Pilot S' + pilotStage + '/26 ' + EM + ' ' + needs.le
 const text = [
   'STRATEGIC ' + EM + ' chairman lens (two focuses: drive the pilot + improve the venture process)', '',
   'NORTH STAR: ' + northStar, '',
-  'NEEDS YOU (' + needs.length + '):', ...needs.map(d => '  - [' + d.priority + '] ' + d.label), '',
+  'NEEDS YOU (' + needs.length + '):', ...needs.map(d => '  - [' + d.priority + '] ' + needsLabel(d)), '',
+  'PER-SCOPE (advisories, last 24h): ' + scopeRollupLine, '',
   'VALUE DELIVERED (last 24h, ' + shippedN + ' SDs):',
   '  Capabilities added (' + buckets.cap.length + '): ' + bucketLine(buckets.cap, 3),
   '  Enablers added (' + buckets.enab.length + '): ' + bucketLine(buckets.enab, 3),
@@ -83,7 +106,8 @@ const text = [
   'CANARY: ' + canaryLine, '',
   '--- FLEET HEALTH ---', cardText
 ].join('\n');
-const needsHtml = needs.length ? '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' + needs.map(d => '<li style="margin:0 0 3px"><b>[' + esc(d.priority) + ']</b> ' + esc(d.label) + '</li>').join('') + '</ul>' : '<span style="font-size:13px">nothing pending</span>';
+const needsHtml = needs.length ? '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' + needs.map(d => '<li style="margin:0 0 3px"><b>[' + esc(d.priority) + ']</b> ' + esc(needsLabel(d)) + '</li>').join('') + '</ul>' : '<span style="font-size:13px">nothing pending</span>';
+const scopeRollupHtml = '<span style="font-size:13px">' + esc(scopeRollupLine) + '</span>';
 const valHtml = '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' +
   '<li style="margin:0 0 3px"><b>Capabilities added (' + buckets.cap.length + '):</b> ' + esc(bucketLine(buckets.cap, 3)) + '</li>' +
   '<li style="margin:0 0 3px"><b>Enablers added (' + buckets.enab.length + '):</b> ' + esc(bucketLine(buckets.enab, 3)) + '</li>' +
@@ -93,6 +117,7 @@ const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px
   '<p style="font-size:12px;color:#777;margin:0 0 10px">Two focuses: drive the pilot (issue-discovery vehicle) + improve the venture-management process</p>' +
   '<p style="font-size:14px;margin:0 0 8px">' + I.star + ' <b>North star:</b> ' + esc(northStar) + '</p>' +
   '<p style="font-size:14px;margin:0 0 2px">' + I.flag + ' <b>Needs you (' + needs.length + '):</b></p>' + needsHtml +
+  '<p style="font-size:14px;margin:10px 0 2px"><b>Per-scope (advisories, last 24h):</b> ' + scopeRollupHtml + '</p>' +
   '<p style="font-size:14px;margin:10px 0 2px">' + I.tools + ' <b>Value delivered (last 24h, ' + shippedN + ' SDs):</b></p>' + valHtml +
   '<p style="font-size:14px;margin:10px 0 2px">' + I.loop + ' <b>Self-improvement:</b> ' + esc(selfLine) + '</p>' +
   '<p style="font-size:14px;margin:0 0 12px">' + I.siren + ' <b>Canary:</b> ' + esc(canaryLine) + '</p>' +
@@ -105,5 +130,5 @@ else {
   const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
   const r = await mod.sendEmail({ from: 'Adam ' + EM + ' LEO Fleet Advisor <onboarding@resend.dev>', to: process.env.CLAUDE_NOTIFY_EMAIL, subject, html, text });
   console.log('ADAM-EMAIL', JSON.stringify(r));
-  try { writeFileSync(SNAP, JSON.stringify({ lastTs: t, pilotStage, completedCount: completedNow, selfScore, canaryCount: canaryN })); } catch {}
+  try { writeFileSync(SNAP, JSON.stringify({ lastTs: t, pilotStage, completedCount: completedNow, selfScore, canaryCount: canaryN, perScope })); } catch {}
 }


### PR DESCRIPTION
## Summary
Closes Adam's surfacing loop with three additive, reuse-first, fail-soft changes (no migration, no schema/security change). Speculative preference-learning / self-improvement / cross-scope compounding (FR-3/4/5 of the original plan) were LEAD-deferred to a follow-up to keep this a shippable ≤400 LOC unit.

- **FR-1 — scope-tagged advisories**: `buildAdvisoryPayload` emits additive `scope_key`/`reuse_class`/`applies_to_scopes` + a `[<scope_key>]` body prefix. `resolveScopeForSend()` resolves the sending repo's scope by **reusing** `lib/adam/scope-registry.js` `enumerateScopes` (harness | platform | venture:<id>) — loaded via a string-literal CJS→ESM dynamic import (WIRE_CHECK-safe), fail-soft. Unmatched repos stay honestly untagged.
- **FR-2 — per-scope chairman email roll-up**: `adam-exec-summary.mjs` gains a per-scope advisory roll-up (via FR-1's `scope_key`), trend arrows from new per-scope counters in `.adam-email-last.json`, scope-tagged needs labels, and a `--dry-run` flag.
- **FR-3 — scheduling gap closed**: `adam:exec:email:cron` npm script + a GitHub-Actions cron workflow (not pg_cron). **Observe-only**: the schedule only sends a real email when the `ADAM_EMAIL_LIVE` repo variable is `true`, so merging emails no one until the operator opts in (+ sets `RESEND_API_KEY`/`CLAUDE_NOTIFY_EMAIL`).

The untracked `adam-exec-summary.mjs` baseline (flagged prospectively by VALIDATION) was committed into the branch before generalization.

## Verification
- 11/11 unit tests (5 new FR-1); dry-run renders the per-scope roll-up across all enumerated scopes.
- Independent TESTING sub-agent: PASS (90%) — fail-soft guarantees and the observe-only gate verified; its one flagged nit (platform-fallback mislabel) was fixed.
- Prospective VALIDATION confirmed reuse-first (the scope vocabulary already existed in scan-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)