### PR TITLE
chore(SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001): wire adam-startup-check via npm script (WIRE_CHECK parity)

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,6 +310,7 @@
     "adam:self-score": "node scripts/adam-self-assessment-writer.cjs",
     "coordinator:cold-recovery": "node scripts/coordinator-cold-recovery.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
+    "adam:startup-check": "node scripts/adam-startup-check.mjs",
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",
     "test:cold-recovery": "vitest run tests/unit/coordinator-cold-recovery.test.js --project unit",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",


### PR DESCRIPTION
## Summary

Follow-up to #4514. `scripts/adam-startup-check.mjs` is a doc-invoked CLI (adam.md Step 4), so it had no literal-import edge and `WIRE_CHECK_GATE` flagged it unreachable at LEAD-FINAL-APPROVAL. Exact parity fix with its template: `coordinator-startup-check.mjs` is reachable via the `coordinator:startup-check` npm script — this adds the identical `adam:startup-check` entry (1 LOC).

Verified prospectively with the gate's own `discoverEntryPoints`: the script now appears in the entry set (269 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)