### PR TITLE
feat(eva): reversible purge of management_reviews pollution + durable UNIQUE/upsert guard [CHAIRMAN-GATED]

### DIFF
--- a/database/migrations/20260610_purge_management_reviews_pollution.sql
+++ b/database/migrations/20260610_purge_management_reviews_pollution.sql
@@ -1,0 +1,96 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: Reversible purge of ALL test-pollution rows from management_reviews + durable UNIQUE guard
+-- SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 — FR-1 (child of SD-LEO-INFRA-REVIVE-EVA-MASTER-001)
+--
+-- WHAT: management_reviews held ~44,883 rows (live-verified 2026-06-10, growing per-second), ALL of
+--       them test pollution: every row review_type='weekly', ZERO chairman_notes, ZERO
+--       chairman_approved_proposals. Two bare .insert writers
+--       (scripts/eva/management-review-round.mjs:199 and scripts/pipeline/management-review-generator.js:343)
+--       let any test/fleet invocation append a row, drowning the chairman Reviews surface that the
+--       EVA Master Scheduler revival is about to make live again.
+--       Chairman keep-predicate (confirmed 2026-06-09): DELETE ALL rows, quarantine-first. No keep rows exist.
+--
+-- SAFETY (recipe: SD-LEO-INFRA-BULK-PURGE-LIVE-001 / PR #4497):
+--   * REVERSIBLE: management_reviews_quarantine_20260610 holds EVERY deleted row; the DOWN migration
+--     drops the new constraint and re-inserts them.
+--   * RACE-SAFE: pollution arrives per-second. LOCK TABLE ... ACCESS EXCLUSIVE blocks all concurrent
+--     management_reviews writers for the whole transaction, so (a) the quarantine snapshot == the
+--     deleted set, and (b) no same-day duplicate (review_date, review_type) can sneak in between the
+--     DELETE and the ADD CONSTRAINT (which would otherwise abort the constraint add).
+--   * GUARDED: pre-assert (quarantine count == live count AND zero chairman-touched rows) and
+--     post-assert (live count == 0) RAISE EXCEPTION on mismatch — aborting the whole transaction
+--     before/after the irreversible DELETE. Counts are computed LIVE; nothing is hardcoded.
+--   * apply-migration.js wraps this in BEGIN/COMMIT with path + global advisory locks and runs prior
+--     setup queries in the same tx (so SET TRANSACTION ISOLATION LEVEL is unavailable — the
+--     ACCESS EXCLUSIVE lock is the isolation mechanism here).
+--
+-- BOUNDARIES: management_reviews only. Adds UNIQUE(review_date, review_type). Does NOT touch any other
+--   table and does NOT modify the writer code (that is a separate code change in the same SD).
+
+SELECT pg_advisory_xact_lock(hashtext('management_reviews_pollution_purge'));
+
+-- 0) Hard lock: block ALL concurrent management_reviews writers for the duration of this transaction.
+--    Mandatory — rows arrive per-second; without this the snapshot/delete/constraint sequence races
+--    and a late same-day insert would abort the UNIQUE add after the DELETE already ran.
+LOCK TABLE management_reviews IN ACCESS EXCLUSIVE MODE;
+
+-- 1) Full quarantine snapshot (reversibility source for the DOWN migration).
+--    DDL is transactional in Postgres: if any assertion below fails, this CREATE rolls back too.
+CREATE TABLE IF NOT EXISTS management_reviews_quarantine_20260610 AS
+SELECT * FROM management_reviews;
+
+-- 2) Pre-assertions: quarantine non-empty, holds EVERY live row (count parity proves a full snapshot),
+--    and the chairman keep-predicate STILL holds (zero chairman-touched rows). The chairman check is a
+--    live tripwire: if the cadence was revived early and a genuine review landed, abort and escalate
+--    rather than delete a real review.
+DO $purge_pre$
+DECLARE
+  v_live     bigint;
+  v_quar     bigint;
+  v_chairman bigint;
+BEGIN
+  SELECT count(*) INTO v_live FROM management_reviews;
+  SELECT count(*) INTO v_quar FROM management_reviews_quarantine_20260610;
+  SELECT count(*) INTO v_chairman FROM management_reviews
+    WHERE chairman_notes IS NOT NULL OR chairman_approved_proposals IS NOT NULL;
+
+  IF v_quar = 0 THEN
+    RAISE EXCEPTION 'purge aborted: quarantine is empty (nothing to purge)';
+  END IF;
+  IF v_quar <> v_live THEN
+    RAISE EXCEPTION 'purge aborted: quarantine % <> live % (snapshot is not a full copy)', v_quar, v_live;
+  END IF;
+  IF v_chairman <> 0 THEN
+    RAISE EXCEPTION 'purge aborted: % chairman-touched row(s) present — keep-predicate (DELETE ALL) no longer valid, escalate to chairman', v_chairman;
+  END IF;
+
+  RAISE NOTICE 'purge: quarantined % rows (all pollution, 0 chairman-touched)', v_quar;
+END
+$purge_pre$;
+
+-- 3) Backup-bound DELETE: remove exactly the quarantined rows, by id. Equivalent to a full delete here
+--    (all rows are pollution) but the bound form proves deleted-set == quarantined-set, making the DOWN
+--    migration a perfect inverse.
+DELETE FROM management_reviews mr
+USING management_reviews_quarantine_20260610 q
+WHERE mr.id = q.id;
+
+-- 4) Post-assertion: the table is empty (every row was pollution and every row is now gone).
+DO $purge_post$
+DECLARE
+  v_remaining bigint;
+BEGIN
+  SELECT count(*) INTO v_remaining FROM management_reviews;
+  IF v_remaining <> 0 THEN
+    RAISE EXCEPTION 'purge failed: % row(s) still present after delete', v_remaining;
+  END IF;
+  RAISE NOTICE 'purge: complete — management_reviews emptied';
+END
+$purge_post$;
+
+-- 5) Durable anti-recurrence guard: at most ONE row per (review_date, review_type) forever after.
+--    Safe to add now — the table is empty, so no existing duplicate can block it. Paired with the
+--    upsert(onConflict 'review_date,review_type') code change so legitimate same-day re-runs update
+--    in place instead of throwing 23505.
+ALTER TABLE management_reviews
+  ADD CONSTRAINT management_reviews_review_date_type_key UNIQUE (review_date, review_type);

--- a/database/migrations/20260610_purge_management_reviews_pollution.sql
+++ b/database/migrations/20260610_purge_management_reviews_pollution.sql
@@ -2,57 +2,94 @@
 -- Migration: Reversible purge of ALL test-pollution rows from management_reviews + durable UNIQUE guard
 -- SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 — FR-1 (child of SD-LEO-INFRA-REVIVE-EVA-MASTER-001)
 --
--- WHAT: management_reviews held ~44,883 rows (live-verified 2026-06-10, growing per-second), ALL of
---       them test pollution: every row review_type='weekly', ZERO chairman_notes, ZERO
---       chairman_approved_proposals. Two bare .insert writers
---       (scripts/eva/management-review-round.mjs:199 and scripts/pipeline/management-review-generator.js:343)
---       let any test/fleet invocation append a row, drowning the chairman Reviews surface that the
---       EVA Master Scheduler revival is about to make live again.
---       Chairman keep-predicate (confirmed 2026-06-09): DELETE ALL rows, quarantine-first. No keep rows exist.
+-- ⚠ DO NOT run this file with apply-migration.js --split-statements. The named dollar-quoted DO
+--   blocks ($purge_pre$ / $purge_post$) are only safe on the DEFAULT single-query path;
+--   splitPostgreSQLStatements recognizes bare $$ but not named $tag$ and would shred the DO blocks.
 --
--- SAFETY (recipe: SD-LEO-INFRA-BULK-PURGE-LIVE-001 / PR #4497):
+-- WHAT: management_reviews held ~44,964 rows (live-verified 2026-06-10), ALL of them test pollution:
+--       every row review_type='weekly', and ZERO rows carry any human-decision signal (chairman_notes,
+--       chairman_approved_proposals, overall_score, eva_proposals, decisions, actions — all empty).
+--       Two bare .insert writers (scripts/eva/management-review-round.mjs:199 and
+--       scripts/pipeline/management-review-generator.js:343) let any test/fleet invocation append a row,
+--       drowning the chairman Reviews surface that the EVA Master Scheduler revival is about to make live.
+--       Chairman keep-predicate (confirmed 2026-06-09): DELETE ALL rows, quarantine-first. No keep rows.
+--
+-- DEPLOY ORDERING (operational, enforced outside this file): the paired writer change converts both
+--   writers to .upsert(onConflict 'review_date,review_type'), which REQUIRES this UNIQUE constraint to
+--   exist or it throws 42P10. Therefore APPLY THIS MIGRATION FIRST, verify the constraint exists, THEN
+--   merge/deploy the writer code. Migration and writer code ship on ONE branch; only the apply-order
+--   matters. (Adversarial verification wf_5071dc05 — the only true blocker was this ordering.)
+--
+-- SAFETY (recipe: SD-LEO-INFRA-BULK-PURGE-LIVE-001 / PR #4497; hardened per wf_5071dc05):
 --   * REVERSIBLE: management_reviews_quarantine_20260610 holds EVERY deleted row; the DOWN migration
---     drops the new constraint and re-inserts them.
---   * RACE-SAFE: pollution arrives per-second. LOCK TABLE ... ACCESS EXCLUSIVE blocks all concurrent
---     management_reviews writers for the whole transaction, so (a) the quarantine snapshot == the
---     deleted set, and (b) no same-day duplicate (review_date, review_type) can sneak in between the
---     DELETE and the ADD CONSTRAINT (which would otherwise abort the constraint add).
---   * GUARDED: pre-assert (quarantine count == live count AND zero chairman-touched rows) and
---     post-assert (live count == 0) RAISE EXCEPTION on mismatch — aborting the whole transaction
---     before/after the irreversible DELETE. Counts are computed LIVE; nothing is hardcoded.
+--     drops the new constraint and re-inserts them (with a post-restore completeness assertion).
+--   * RACE-SAFE: LOCK TABLE ... ACCESS EXCLUSIVE blocks all concurrent management_reviews writers for
+--     the whole transaction, so the snapshot == the deleted set and no same-day duplicate can sneak in
+--     between the DELETE and the ADD CONSTRAINT. lock_timeout/statement_timeout bound the wait so a
+--     contended apply aborts cleanly instead of stalling the live table.
+--   * FRESH SNAPSHOT: aborts if the quarantine table already exists (a prior run) rather than reusing a
+--     stale snapshot or clobbering an existing backup.
+--   * SAFE-BY-CONSTRUCTION KEEP-PREDICATE: the pre-assert aborts if ANY human-decision column is
+--     populated (not just the 2 chairman columns), so a future genuine review can never be silently
+--     deleted. Verified live: this broadened predicate currently matches 0 rows.
+--   * GUARDED: pre-assert (quarantine count == live count) and post-assert (live count == 0) RAISE
+--     EXCEPTION on mismatch — aborting the whole transaction. Counts are computed LIVE; nothing hardcoded.
 --   * apply-migration.js wraps this in BEGIN/COMMIT with path + global advisory locks and runs prior
---     setup queries in the same tx (so SET TRANSACTION ISOLATION LEVEL is unavailable — the
---     ACCESS EXCLUSIVE lock is the isolation mechanism here).
+--     setup queries in the same tx (SET TRANSACTION ISOLATION LEVEL unavailable — the ACCESS EXCLUSIVE
+--     lock is the isolation mechanism here).
 --
 -- BOUNDARIES: management_reviews only. Adds UNIQUE(review_date, review_type). Does NOT touch any other
---   table and does NOT modify the writer code (that is a separate code change in the same SD).
+--   table and does NOT modify the writer code (that is the paired code change in the same SD/branch).
+
+-- Bound the lock acquisition and total statement time so a contended apply fails clean rather than
+-- stalling the live table indefinitely (no global timeout is set by apply-migration.js).
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
 
 SELECT pg_advisory_xact_lock(hashtext('management_reviews_pollution_purge'));
 
--- 0) Hard lock: block ALL concurrent management_reviews writers for the duration of this transaction.
---    Mandatory — rows arrive per-second; without this the snapshot/delete/constraint sequence races
---    and a late same-day insert would abort the UNIQUE add after the DELETE already ran.
+-- 0a) One-shot guard: this purge must start from a clean slate. If the quarantine table already exists,
+--     a prior run happened — abort rather than risk a stale snapshot or clobbering an existing backup.
+--     (On a transactional rollback of a failed apply the CREATE below rolls back too, so a legit retry
+--     still finds no table.)
+DO $purge_guard$
+BEGIN
+  IF to_regclass('public.management_reviews_quarantine_20260610') IS NOT NULL THEN
+    RAISE EXCEPTION 'purge aborted: quarantine table management_reviews_quarantine_20260610 already exists — prior run detected, investigate before re-running';
+  END IF;
+END
+$purge_guard$;
+
+-- 0b) Hard lock: block ALL concurrent management_reviews writers for the duration of this transaction.
 LOCK TABLE management_reviews IN ACCESS EXCLUSIVE MODE;
 
--- 1) Full quarantine snapshot (reversibility source for the DOWN migration).
---    DDL is transactional in Postgres: if any assertion below fails, this CREATE rolls back too.
-CREATE TABLE IF NOT EXISTS management_reviews_quarantine_20260610 AS
+-- 1) Full quarantine snapshot (reversibility source for the DOWN migration). Plain CREATE TABLE (not
+--    IF NOT EXISTS) — the 0a guard already proved the table is absent, and DDL is transactional so a
+--    failed apply rolls this back.
+CREATE TABLE management_reviews_quarantine_20260610 AS
 SELECT * FROM management_reviews;
 
 -- 2) Pre-assertions: quarantine non-empty, holds EVERY live row (count parity proves a full snapshot),
---    and the chairman keep-predicate STILL holds (zero chairman-touched rows). The chairman check is a
---    live tripwire: if the cadence was revived early and a genuine review landed, abort and escalate
---    rather than delete a real review.
+--    and the keep-predicate STILL holds — abort if ANY human-decision signal exists in any column.
+--    The human-signal check is a live tripwire: if the cadence was revived early and a genuine review
+--    landed (chairman notes, an overall_score, recorded decisions/actions, or EVA proposals), abort and
+--    escalate rather than delete a real review.
 DO $purge_pre$
 DECLARE
-  v_live     bigint;
-  v_quar     bigint;
-  v_chairman bigint;
+  v_live  bigint;
+  v_quar  bigint;
+  v_human bigint;
 BEGIN
   SELECT count(*) INTO v_live FROM management_reviews;
   SELECT count(*) INTO v_quar FROM management_reviews_quarantine_20260610;
-  SELECT count(*) INTO v_chairman FROM management_reviews
-    WHERE chairman_notes IS NOT NULL OR chairman_approved_proposals IS NOT NULL;
+  SELECT count(*) INTO v_human FROM management_reviews
+    WHERE chairman_notes IS NOT NULL
+       OR chairman_approved_proposals IS NOT NULL
+       OR overall_score IS NOT NULL
+       OR (jsonb_typeof(eva_proposals) = 'array'  AND jsonb_array_length(eva_proposals) > 0)
+       OR (jsonb_typeof(eva_proposals) = 'object' AND eva_proposals <> '{}'::jsonb)
+       OR (jsonb_typeof(decisions) = 'array' AND jsonb_array_length(decisions) > 0)
+       OR (jsonb_typeof(actions)   = 'array' AND jsonb_array_length(actions)   > 0);
 
   IF v_quar = 0 THEN
     RAISE EXCEPTION 'purge aborted: quarantine is empty (nothing to purge)';
@@ -60,11 +97,11 @@ BEGIN
   IF v_quar <> v_live THEN
     RAISE EXCEPTION 'purge aborted: quarantine % <> live % (snapshot is not a full copy)', v_quar, v_live;
   END IF;
-  IF v_chairman <> 0 THEN
-    RAISE EXCEPTION 'purge aborted: % chairman-touched row(s) present — keep-predicate (DELETE ALL) no longer valid, escalate to chairman', v_chairman;
+  IF v_human <> 0 THEN
+    RAISE EXCEPTION 'purge aborted: % row(s) carry a human-decision signal — keep-predicate (DELETE ALL) no longer valid, escalate to chairman', v_human;
   END IF;
 
-  RAISE NOTICE 'purge: quarantined % rows (all pollution, 0 chairman-touched)', v_quar;
+  RAISE NOTICE 'purge: quarantined % rows (all pollution, 0 human-decision rows)', v_quar;
 END
 $purge_pre$;
 

--- a/database/migrations/20260610_purge_management_reviews_pollution_DOWN.sql
+++ b/database/migrations/20260610_purge_management_reviews_pollution_DOWN.sql
@@ -1,23 +1,62 @@
 -- @approved-by: codestreetlabs@gmail.com
 -- DOWN migration for SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 — FR-1
 --
+-- ⚠ DO NOT run with apply-migration.js --split-statements (named $restore_post$ DO block).
+--
 -- Rolls back the purge by restoring management_reviews to its pre-purge state.
 --
 -- ORDER MATTERS: the UNIQUE(review_date, review_type) guard MUST be dropped FIRST. The quarantine
--- table contains ~44,883 rows that all share review_type='weekly' with many duplicate review_date
+-- table contains ~44,964 rows that all share review_type='weekly' with many duplicate review_date
 -- values, so re-inserting them while the constraint exists would violate it (23505) and fail the
 -- rollback. Dropping the constraint first returns the table to exactly its original (unconstrained)
 -- shape, then the rows are restored.
 --
--- ON CONFLICT (id) DO NOTHING makes the re-insert idempotent and safe if some rows were already
--- restored or re-created by the (now upserting) writers. Apply ONLY to undo the purge, via:
+-- COLUMN-EXPLICIT insert (not SELECT *) so that if a column was ADDED to management_reviews during the
+-- verification window before this DOWN runs, the restore fails LOUDLY (column count mismatch) instead
+-- of silently misaligning positional values.
+--
+-- ON CONFLICT (id) DO NOTHING makes the re-insert idempotent if some rows were already restored or
+-- re-created by the (now upserting) writers; a post-restore assertion then RAISES if any quarantined id
+-- failed to land, turning a silent drop into a loud, transactional abort.
+--
+-- Apply ONLY to undo the purge, via:
 --   node scripts/apply-migration.js database/migrations/20260610_purge_management_reviews_pollution_DOWN.sql --prod-deploy
--- (issue a fresh single-use token first). The quarantine table is retained until a verification
--- window passes, then may be dropped manually.
+-- (issue a fresh single-use token first). The quarantine table is retained until a verification window
+-- passes, then may be dropped manually.
 
 ALTER TABLE management_reviews
   DROP CONSTRAINT IF EXISTS management_reviews_review_date_type_key;
 
-INSERT INTO management_reviews
-SELECT * FROM management_reviews_quarantine_20260610
+INSERT INTO management_reviews (
+  id, review_date, review_type, baseline_version_from, baseline_version_to,
+  planned_capabilities, actual_capabilities, planned_ventures, actual_ventures,
+  planned_sds, actual_sds, okr_snapshot, risk_snapshot, strategy_health,
+  decisions, actions, pipeline_snapshot, eva_narrative, eva_proposals,
+  chairman_notes, chairman_approved_proposals, overall_score, created_at
+)
+SELECT
+  id, review_date, review_type, baseline_version_from, baseline_version_to,
+  planned_capabilities, actual_capabilities, planned_ventures, actual_ventures,
+  planned_sds, actual_sds, okr_snapshot, risk_snapshot, strategy_health,
+  decisions, actions, pipeline_snapshot, eva_narrative, eva_proposals,
+  chairman_notes, chairman_approved_proposals, overall_score, created_at
+FROM management_reviews_quarantine_20260610
 ON CONFLICT (id) DO NOTHING;
+
+-- Post-restore assertion: every quarantined id must now be present in the live table. If a writer
+-- re-created an id-colliding row during the verification window, ON CONFLICT (id) DO NOTHING would have
+-- silently kept the live row and dropped the quarantine copy — fail loudly so that is investigated
+-- rather than silently losing the original.
+DO $restore_post$
+DECLARE
+  v_missing bigint;
+BEGIN
+  SELECT count(*) INTO v_missing
+  FROM management_reviews_quarantine_20260610 q
+  WHERE NOT EXISTS (SELECT 1 FROM management_reviews mr WHERE mr.id = q.id);
+  IF v_missing <> 0 THEN
+    RAISE EXCEPTION 'rollback incomplete: % quarantined row(s) are not present after restore (id collision drop) — investigate', v_missing;
+  END IF;
+  RAISE NOTICE 'rollback: complete — all quarantined rows restored';
+END
+$restore_post$;

--- a/database/migrations/20260610_purge_management_reviews_pollution_DOWN.sql
+++ b/database/migrations/20260610_purge_management_reviews_pollution_DOWN.sql
@@ -1,0 +1,23 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- DOWN migration for SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 — FR-1
+--
+-- Rolls back the purge by restoring management_reviews to its pre-purge state.
+--
+-- ORDER MATTERS: the UNIQUE(review_date, review_type) guard MUST be dropped FIRST. The quarantine
+-- table contains ~44,883 rows that all share review_type='weekly' with many duplicate review_date
+-- values, so re-inserting them while the constraint exists would violate it (23505) and fail the
+-- rollback. Dropping the constraint first returns the table to exactly its original (unconstrained)
+-- shape, then the rows are restored.
+--
+-- ON CONFLICT (id) DO NOTHING makes the re-insert idempotent and safe if some rows were already
+-- restored or re-created by the (now upserting) writers. Apply ONLY to undo the purge, via:
+--   node scripts/apply-migration.js database/migrations/20260610_purge_management_reviews_pollution_DOWN.sql --prod-deploy
+-- (issue a fresh single-use token first). The quarantine table is retained until a verification
+-- window passes, then may be dropped manually.
+
+ALTER TABLE management_reviews
+  DROP CONSTRAINT IF EXISTS management_reviews_review_date_type_key;
+
+INSERT INTO management_reviews
+SELECT * FROM management_reviews_quarantine_20260610
+ON CONFLICT (id) DO NOTHING;

--- a/scripts/eva/management-review-round.mjs
+++ b/scripts/eva/management-review-round.mjs
@@ -194,9 +194,13 @@ async function managementReviewHandler(_options = {}) {
     eva_narrative: narrative,
   };
 
+  // Upsert (not insert) so a legitimate same-day re-run of the review round updates the existing
+  // row in place instead of appending a duplicate. Paired with the UNIQUE(review_date, review_type)
+  // constraint (migration 20260610_purge_management_reviews_pollution.sql) that makes scale
+  // re-pollution impossible — SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 FR-2.
   const { data: reviewData, error: reviewError } = await supabase
     .from('management_reviews')
-    .insert(review)
+    .upsert(review, { onConflict: 'review_date,review_type' })
     .select('id')
     .single();
 

--- a/scripts/pipeline/management-review-generator.js
+++ b/scripts/pipeline/management-review-generator.js
@@ -338,9 +338,13 @@ async function generateReview() {
     eva_proposals: null,
   };
 
+  // Upsert (not insert) so a same-day re-run updates the existing row in place rather than appending
+  // a duplicate that would violate the UNIQUE(review_date, review_type) guard
+  // (migration 20260610_purge_management_reviews_pollution.sql) with a 23505 —
+  // SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 FR-2 (second writer site).
   const { data, error } = await supabase
     .from('management_reviews')
-    .insert(review)
+    .upsert(review, { onConflict: 'review_date,review_type' })
     .select('id')
     .single();
 

--- a/scripts/probe-purge-migration.mjs
+++ b/scripts/probe-purge-migration.mjs
@@ -10,39 +10,55 @@ import { createDatabaseClient } from './lib/supabase-connection.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UP = path.resolve(__dirname, '..', 'database', 'migrations', '20260610_purge_management_reviews_pollution.sql');
-const sql = fs.readFileSync(UP, 'utf8');
+const DOWN = path.resolve(__dirname, '..', 'database', 'migrations', '20260610_purge_management_reviews_pollution_DOWN.sql');
+const upSql = fs.readFileSync(UP, 'utf8');
+const downSql = fs.readFileSync(DOWN, 'utf8');
+
+const constraintQ = `
+  SELECT 1 FROM pg_constraint
+  WHERE conname = 'management_reviews_review_date_type_key'
+    AND conrelid = 'management_reviews'::regclass`;
+// Order-independent full-content fingerprint of the table, to prove the DOWN restores it exactly.
+const fingerprintQ = `
+  SELECT md5(coalesce(string_agg(t.row_md5, '' ORDER BY t.row_md5), '')) AS fp
+  FROM (SELECT md5(management_reviews::text) AS row_md5 FROM management_reviews) t`;
 
 const client = await createDatabaseClient('ehg');
 let ok = false;
 try {
-  await client.query('SET statement_timeout = 60000');
   await client.query('BEGIN');
 
   const before = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+  const fpBefore = await client.query(fingerprintQ);
   console.log('live count before (in-tx):', before.rows[0].n);
 
-  // Run the whole migration as one multi-statement query (matches apply-migration.js single-tx model).
-  await client.query(sql);
+  // --- UP: run the whole migration as one multi-statement query (matches apply-migration.js model) ---
+  await client.query(upSql);
 
   const after = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
   const quar = await client.query('SELECT count(*)::bigint AS n FROM management_reviews_quarantine_20260610');
-  const con = await client.query(`
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'management_reviews_review_date_type_key'
-      AND conrelid = 'management_reviews'::regclass`);
+  const conUp = await client.query(constraintQ);
+  console.log('after UP  — live:', after.rows[0].n, '(expect 0) | quarantine:', quar.rows[0].n, '(expect == before) | UNIQUE present:', conUp.rowCount === 1 ? 'YES' : 'NO');
 
-  console.log('live count after delete (in-tx):', after.rows[0].n, '(expect 0)');
-  console.log('quarantine count (in-tx):', quar.rows[0].n, '(expect == before)');
-  console.log('UNIQUE constraint present (in-tx):', con.rowCount === 1 ? 'YES' : 'NO');
+  // --- DOWN: roll the purge back inside the same tx and prove byte-identical restoration ---
+  await client.query(downSql);
+
+  const restored = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+  const fpAfter = await client.query(fingerprintQ);
+  const conDown = await client.query(constraintQ);
+  console.log('after DOWN — live:', restored.rows[0].n, '(expect == before) | UNIQUE present:', conDown.rowCount === 1 ? 'YES' : 'NO', '(expect NO) | fingerprint match:', fpBefore.rows[0].fp === fpAfter.rows[0].fp ? 'YES' : 'NO');
 
   const pass =
     after.rows[0].n === '0' &&
     quar.rows[0].n === before.rows[0].n &&
-    con.rowCount === 1;
+    conUp.rowCount === 1 &&
+    restored.rows[0].n === before.rows[0].n &&
+    conDown.rowCount === 0 &&
+    fpBefore.rows[0].fp === fpAfter.rows[0].fp;
 
   if (!pass) throw new Error('PROBE ASSERTIONS FAILED');
   ok = true;
-  console.log('\n✅ PROBE PASS — migration executes correctly (asserts pass, table empties, constraint adds).');
+  console.log('\n✅ PROBE PASS — UP purges + constrains, DOWN restores byte-identical (fingerprint match), all rolled back.');
 } catch (e) {
   console.error('\n❌ PROBE FAIL:', e.message);
 } finally {

--- a/scripts/probe-purge-migration.mjs
+++ b/scripts/probe-purge-migration.mjs
@@ -1,0 +1,52 @@
+// Prospective validation for SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001.
+// Runs the purge migration inside a self-managed BEGIN ... ROLLBACK so it touches NO committed data
+// but proves end-to-end that: the asserts pass, the DELETE empties the table, and the UNIQUE guard
+// adds cleanly. (apply-migration.js --dry-run does NOT execute SQL — BULK-PURGE-LIVE-001 lesson.)
+// NOTE: holds ACCESS EXCLUSIVE on management_reviews for the (sub-second) probe, then rolls back.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const UP = path.resolve(__dirname, '..', 'database', 'migrations', '20260610_purge_management_reviews_pollution.sql');
+const sql = fs.readFileSync(UP, 'utf8');
+
+const client = await createDatabaseClient('ehg');
+let ok = false;
+try {
+  await client.query('SET statement_timeout = 60000');
+  await client.query('BEGIN');
+
+  const before = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+  console.log('live count before (in-tx):', before.rows[0].n);
+
+  // Run the whole migration as one multi-statement query (matches apply-migration.js single-tx model).
+  await client.query(sql);
+
+  const after = await client.query('SELECT count(*)::bigint AS n FROM management_reviews');
+  const quar = await client.query('SELECT count(*)::bigint AS n FROM management_reviews_quarantine_20260610');
+  const con = await client.query(`
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'management_reviews_review_date_type_key'
+      AND conrelid = 'management_reviews'::regclass`);
+
+  console.log('live count after delete (in-tx):', after.rows[0].n, '(expect 0)');
+  console.log('quarantine count (in-tx):', quar.rows[0].n, '(expect == before)');
+  console.log('UNIQUE constraint present (in-tx):', con.rowCount === 1 ? 'YES' : 'NO');
+
+  const pass =
+    after.rows[0].n === '0' &&
+    quar.rows[0].n === before.rows[0].n &&
+    con.rowCount === 1;
+
+  if (!pass) throw new Error('PROBE ASSERTIONS FAILED');
+  ok = true;
+  console.log('\n✅ PROBE PASS — migration executes correctly (asserts pass, table empties, constraint adds).');
+} catch (e) {
+  console.error('\n❌ PROBE FAIL:', e.message);
+} finally {
+  try { await client.query('ROLLBACK'); console.log('rolled back — no committed change'); } catch {}
+  await client.end();
+  process.exitCode = ok ? 0 : 1;
+}

--- a/tests/management-reviews-purge.test.js
+++ b/tests/management-reviews-purge.test.js
@@ -4,7 +4,8 @@
 // live-DB or subprocess tests. Rationale (QF-20260609-547 lesson): migration/hook tests that spawn
 // subprocesses or require a live DB flake in CI; pinning the on-disk artifact is deterministic and
 // still catches every regression that matters here (a writer reverting to bare .insert, a missing
-// safety clause in the irreversible migration).
+// safety clause in the irreversible migration). The invariants pinned below were each hardened in
+// response to the adversarial verification workflow wf_5071dc05.
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -27,6 +28,20 @@ describe('purge migration (UP) — irreversible-safe invariants', () => {
     expect(sql).toMatch(/^--\s*@approved-by:\s*\S+@\S+/m);
   });
 
+  it('warns against --split-statements (named dollar-quoted DO blocks)', () => {
+    expect(sql).toMatch(/DO NOT run .*--split-statements/i);
+  });
+
+  it('bounds lock + statement time so a contended apply fails clean (no live stall)', () => {
+    expect(sql).toMatch(/SET LOCAL lock_timeout\s*=\s*'5s'/i);
+    expect(sql).toMatch(/SET LOCAL statement_timeout\s*=/i);
+  });
+
+  it('aborts if a stale quarantine table already exists (fresh-snapshot-or-fail)', () => {
+    expect(sql).toMatch(/to_regclass\('public\.management_reviews_quarantine_20260610'\)\s+IS NOT NULL/i);
+    expect(sql).toMatch(/RAISE EXCEPTION 'purge aborted: quarantine table[^']*already exists/i);
+  });
+
   it('takes an ACCESS EXCLUSIVE lock BEFORE any DML (race guard against per-second pollution)', () => {
     expect(sql).toMatch(/LOCK TABLE\s+management_reviews\s+IN\s+ACCESS EXCLUSIVE MODE/i);
     const lockIdx = sql.search(/LOCK TABLE\s+management_reviews\s+IN\s+ACCESS EXCLUSIVE MODE/i);
@@ -37,12 +52,22 @@ describe('purge migration (UP) — irreversible-safe invariants', () => {
   });
 
   it('quarantines the full table before deleting (reversibility source)', () => {
-    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS\s+management_reviews_quarantine_20260610\s+AS\s+SELECT \* FROM management_reviews/i);
+    expect(sql).toMatch(/CREATE TABLE\s+management_reviews_quarantine_20260610\s+AS\s+SELECT \* FROM management_reviews/i);
+    // plain CREATE TABLE (not IF NOT EXISTS) — the pre-existence guard handles idempotency safely
+    expect(sql).not.toMatch(/CREATE TABLE IF NOT EXISTS\s+management_reviews_quarantine_20260610/i);
   });
 
-  it('pre-asserts quarantine==live count AND zero chairman-touched rows (keep-predicate tripwire)', () => {
-    expect(sql).toMatch(/v_quar\s*<>\s*v_live/);            // snapshot completeness
-    expect(sql).toMatch(/chairman_notes IS NOT NULL OR chairman_approved_proposals IS NOT NULL/i);
+  it('pre-asserts quarantine==live count (snapshot completeness)', () => {
+    expect(sql).toMatch(/v_quar\s*<>\s*v_live/);
+  });
+
+  it('keep-predicate is safe-by-construction: aborts on ANY human-decision signal, not just chairman cols', () => {
+    expect(sql).toMatch(/chairman_notes IS NOT NULL/i);
+    expect(sql).toMatch(/chairman_approved_proposals IS NOT NULL/i);
+    expect(sql).toMatch(/overall_score IS NOT NULL/i);
+    expect(sql).toMatch(/eva_proposals/i);
+    expect(sql).toMatch(/jsonb_array_length\(decisions\)/i);
+    expect(sql).toMatch(/jsonb_array_length\(actions\)/i);
     expect(sql).toMatch(/RAISE EXCEPTION 'purge aborted:[^']*keep-predicate/i);
   });
 
@@ -86,8 +111,16 @@ describe('purge migration (DOWN) — reversibility', () => {
     expect(dropIdx).toBeLessThan(insertIdx); // drop before re-insert, else 23505
   });
 
-  it('re-inserts every quarantined row idempotently (ON CONFLICT (id) DO NOTHING)', () => {
-    expect(sql).toMatch(/INSERT INTO management_reviews\s+SELECT \* FROM management_reviews_quarantine_20260610\s+ON CONFLICT \(id\) DO NOTHING/i);
+  it('re-inserts COLUMN-EXPLICITLY (not SELECT *) so schema drift fails loud, idempotent on id', () => {
+    expect(sql).toMatch(/INSERT INTO management_reviews\s*\(/i);     // explicit column list
+    expect(sql).not.toMatch(/INSERT INTO management_reviews\s+SELECT \*/i);
+    expect(sql).toMatch(/ON CONFLICT \(id\) DO NOTHING/i);
+    expect(sql).toMatch(/FROM management_reviews_quarantine_20260610/i);
+  });
+
+  it('post-asserts every quarantined row landed (loud on silent id-collision drop)', () => {
+    expect(sql).toMatch(/v_missing\s*<>\s*0/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'rollback incomplete:/i);
   });
 });
 
@@ -95,7 +128,6 @@ describe('management_reviews writers — upsert, not insert', () => {
   it('management-review-round.mjs upserts with the correct conflict target', () => {
     const src = read(ROUND_WRITER);
     expect(src).toMatch(/\.from\(['"]management_reviews['"]\)\s*\.upsert\(\s*review\s*,\s*\{\s*onConflict:\s*['"]review_date,review_type['"]\s*\}\s*\)/);
-    // and must NOT regress to a bare insert into management_reviews
     expect(src).not.toMatch(/\.from\(['"]management_reviews['"]\)\s*\.insert\(/);
   });
 

--- a/tests/management-reviews-purge.test.js
+++ b/tests/management-reviews-purge.test.js
@@ -1,0 +1,115 @@
+// SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 — static source-pin tests.
+//
+// These tests are deliberately STATIC source-pins (read the files, assert invariants) rather than
+// live-DB or subprocess tests. Rationale (QF-20260609-547 lesson): migration/hook tests that spawn
+// subprocesses or require a live DB flake in CI; pinning the on-disk artifact is deterministic and
+// still catches every regression that matters here (a writer reverting to bare .insert, a missing
+// safety clause in the irreversible migration).
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const UP_SQL = path.join(ROOT, 'database', 'migrations', '20260610_purge_management_reviews_pollution.sql');
+const DOWN_SQL = path.join(ROOT, 'database', 'migrations', '20260610_purge_management_reviews_pollution_DOWN.sql');
+const ROUND_WRITER = path.join(ROOT, 'scripts', 'eva', 'management-review-round.mjs');
+const GEN_WRITER = path.join(ROOT, 'scripts', 'pipeline', 'management-review-generator.js');
+
+const read = (p) => fs.readFileSync(p, 'utf8');
+
+describe('purge migration (UP) — irreversible-safe invariants', () => {
+  const sql = read(UP_SQL);
+
+  it('exists and carries the @approved-by header (apply-migration.js 3-factor guard)', () => {
+    expect(sql).toMatch(/^--\s*@approved-by:\s*\S+@\S+/m);
+  });
+
+  it('takes an ACCESS EXCLUSIVE lock BEFORE any DML (race guard against per-second pollution)', () => {
+    expect(sql).toMatch(/LOCK TABLE\s+management_reviews\s+IN\s+ACCESS EXCLUSIVE MODE/i);
+    const lockIdx = sql.search(/LOCK TABLE\s+management_reviews\s+IN\s+ACCESS EXCLUSIVE MODE/i);
+    const deleteIdx = sql.search(/DELETE FROM management_reviews/i);
+    expect(lockIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeGreaterThan(-1);
+    expect(lockIdx).toBeLessThan(deleteIdx); // lock comes first
+  });
+
+  it('quarantines the full table before deleting (reversibility source)', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS\s+management_reviews_quarantine_20260610\s+AS\s+SELECT \* FROM management_reviews/i);
+  });
+
+  it('pre-asserts quarantine==live count AND zero chairman-touched rows (keep-predicate tripwire)', () => {
+    expect(sql).toMatch(/v_quar\s*<>\s*v_live/);            // snapshot completeness
+    expect(sql).toMatch(/chairman_notes IS NOT NULL OR chairman_approved_proposals IS NOT NULL/i);
+    expect(sql).toMatch(/RAISE EXCEPTION 'purge aborted:[^']*keep-predicate/i);
+  });
+
+  it('DELETE is backup-bound (WHERE mr.id = q.id against the quarantine), not a bare predicate', () => {
+    expect(sql).toMatch(/DELETE FROM management_reviews mr\s+USING\s+management_reviews_quarantine_20260610 q\s+WHERE mr\.id = q\.id/i);
+  });
+
+  it('post-asserts the table is empty before declaring success', () => {
+    expect(sql).toMatch(/v_remaining\s*<>\s*0/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'purge failed:/i);
+  });
+
+  it('adds the durable UNIQUE(review_date, review_type) guard AFTER the purge', () => {
+    expect(sql).toMatch(/ADD CONSTRAINT\s+management_reviews_review_date_type_key\s+UNIQUE\s*\(review_date,\s*review_type\)/i);
+    const deleteIdx = sql.search(/DELETE FROM management_reviews/i);
+    const constraintIdx = sql.search(/ADD CONSTRAINT\s+management_reviews_review_date_type_key/i);
+    expect(deleteIdx).toBeLessThan(constraintIdx); // constraint added on the now-empty table
+  });
+
+  it('does not hardcode the row count in executable logic (counts computed live)', () => {
+    // Strip SQL line-comments — the header legitimately documents the live-verified figure;
+    // what must never happen is a hardcoded count in the DELETE/assert logic.
+    const executable = sql.replace(/--.*$/gm, '');
+    expect(executable).not.toMatch(/\b44[,_]?\d{3}\b/);
+  });
+});
+
+describe('purge migration (DOWN) — reversibility', () => {
+  const sql = read(DOWN_SQL);
+
+  it('exists and carries the @approved-by header', () => {
+    expect(sql).toMatch(/^--\s*@approved-by:\s*\S+@\S+/m);
+  });
+
+  it('drops the UNIQUE constraint FIRST (quarantine holds duplicate date/type pairs)', () => {
+    expect(sql).toMatch(/DROP CONSTRAINT IF EXISTS\s+management_reviews_review_date_type_key/i);
+    const dropIdx = sql.search(/DROP CONSTRAINT/i);
+    const insertIdx = sql.search(/INSERT INTO management_reviews/i);
+    expect(dropIdx).toBeGreaterThan(-1);
+    expect(insertIdx).toBeGreaterThan(-1);
+    expect(dropIdx).toBeLessThan(insertIdx); // drop before re-insert, else 23505
+  });
+
+  it('re-inserts every quarantined row idempotently (ON CONFLICT (id) DO NOTHING)', () => {
+    expect(sql).toMatch(/INSERT INTO management_reviews\s+SELECT \* FROM management_reviews_quarantine_20260610\s+ON CONFLICT \(id\) DO NOTHING/i);
+  });
+});
+
+describe('management_reviews writers — upsert, not insert', () => {
+  it('management-review-round.mjs upserts with the correct conflict target', () => {
+    const src = read(ROUND_WRITER);
+    expect(src).toMatch(/\.from\(['"]management_reviews['"]\)\s*\.upsert\(\s*review\s*,\s*\{\s*onConflict:\s*['"]review_date,review_type['"]\s*\}\s*\)/);
+    // and must NOT regress to a bare insert into management_reviews
+    expect(src).not.toMatch(/\.from\(['"]management_reviews['"]\)\s*\.insert\(/);
+  });
+
+  it('management-review-generator.js upserts with the correct conflict target', () => {
+    const src = read(GEN_WRITER);
+    expect(src).toMatch(/\.from\(['"]management_reviews['"]\)\s*\.upsert\(\s*review\s*,\s*\{\s*onConflict:\s*['"]review_date,review_type['"]\s*\}\s*\)/);
+    expect(src).not.toMatch(/\.from\(['"]management_reviews['"]\)\s*\.insert\(/);
+  });
+
+  it('regression sweep: neither writer contains a bare .insert into management_reviews', () => {
+    for (const f of [ROUND_WRITER, GEN_WRITER]) {
+      const src = read(f);
+      const bareInsert = /management_reviews['"]\)\s*\.insert\(/.test(src);
+      expect(bareInsert, `${path.basename(f)} still has a bare .insert into management_reviews`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
@
## SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 (FR-3 of REVIVE-EVA-MASTER-001)

**⚠️ DO NOT MERGE before the migration is applied to prod.** This is a chairman-gated, irreversible purge. See Deploy Order below.

### Problem
`management_reviews` holds **44,964 rows** (live-verified 2026-06-10, was growing), **all test pollution** — every row `review_type=weekly`, zero human-decision signal (chairman_notes / chairman_approved_proposals / overall_score / eva_proposals / decisions / actions all empty). Two bare `.insert(review)` writers let any test/fleet run append a row, drowning the chairman Reviews surface that the EVA Master Scheduler revival is about to make live.

### Change
- **New reversible migration** (`20260610_purge_management_reviews_pollution.sql`): `SET LOCAL lock_timeout/statement_timeout` → advisory + `ACCESS EXCLUSIVE` lock → abort-if-quarantine-exists guard → full quarantine snapshot → pre-assert (count parity + **broadened keep-predicate tripwire**: aborts on ANY human-decision column) → backup-bound DELETE → empty post-assert → `ADD CONSTRAINT UNIQUE(review_date, review_type)`.
- **DOWN**: drop-constraint-first → column-explicit re-insert (`ON CONFLICT (id) DO NOTHING`) → post-restore completeness assertion.
- **Both writers** → `.upsert(review, { onConflict: review_date,review_type })` so legitimate same-day re-runs update in place.
- **19 static-pin tests** + a live `BEGIN..ROLLBACK` round-trip probe.

### Verification
- Adversarial verification workflow (`wf_5071dc05`, 6 agents, 5 lenses): **GO-WITH-FIXES** — all recommended additive fixes folded in; the only "blocker" was deploy-ordering (below).
- **Live round-trip probe**: UP purges + constrains, DOWN restores **byte-identical** (table fingerprint match), all rolled back — zero committed change.
- TESTING sub-agent PASS (92) · DATABASE sub-agent PASS (96) · handoffs LEAD-TO-PLAN 96 / PLAN-TO-EXEC 99 / EXEC-TO-PLAN 97 / PLAN-TO-LEAD 100.

### Deploy Order (MANDATORY — the one real operational constraint)
The upsert writers REQUIRE the UNIQUE constraint or they throw `42P10`. So:
1. Confirm the weekly-review writer cadence is dead/paused (currently quiescent; EVA scheduler down).
2. **Apply the UP migration to prod** (`apply-migration.js --prod-deploy`, fresh single-use token) — purges + adds constraint.
3. Verify constraint exists + table empty.
4. **Then merge this PR** (writers become upsert, now backed by the constraint).

### Chairman gate
Keep-predicate confirmed 2026-06-09 (`DELETE_ALL` quarantine-first). The irreversible prod DELETE is **NOT executed** — awaiting explicit chairman GO-to-execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@