### PR TITLE
chore(adam): exec email cadence daily -> hourly (chairman-chosen)

### DIFF
--- a/.github/workflows/adam-exec-email-cron.yml
+++ b/.github/workflows/adam-exec-email-cron.yml
@@ -15,8 +15,11 @@ name: "Adam chairman exec email (cron)"
 
 on:
   schedule:
-    # Daily 13:00 UTC (~9am ET) — the always-on proactive chairman artifact.
-    - cron: '0 13 * * *'
+    # Hourly (chairman-chosen cadence 2026-06-10, 24/day) — the always-on proactive
+    # chairman artifact. Fires at :17 past the hour (NOT :00) to dodge GitHub Actions'
+    # top-of-hour scheduling congestion, where queued runs are routinely delayed or
+    # dropped — so the hourly email actually lands. Count is unchanged (24/day).
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary
Chairman directive 2026-06-10: the Adam executive email was shipped at **once-daily** (`0 13 * * *`), but the intended/expected cadence is **hourly**. The originating spec (SD-LEO-INFRA-ADAM-PREFERENCE-LEARNING-001 FR-3) said only 'wire it onto a cadence' — it never specified a number, so the implementer defaulted to daily. This reconciles the shipped cadence to the chairman's choice.

- `.github/workflows/adam-exec-email-cron.yml`: `cron: '0 13 * * *'` → `cron: '17 * * * *'` (hourly, 24/day).
- Fires at **:17 past the hour, not :00**, to dodge GitHub Actions' top-of-hour scheduling congestion (queued scheduled runs at :00 are routinely delayed or dropped). Count is unchanged — 24/day — just more reliable delivery.

## Notes
- The email still only sends when repo var `ADAM_EMAIL_LIVE=true` (already set 2026-06-10) — observe-only otherwise.
- Scheduled workflows only run from the default branch, so this must merge to `main` to take effect.
- Caveat surfaced to the chairman: GitHub Actions cron is not precise sub-hourly/at-load; if reliably-exact hourly timing is later required, a dedicated scheduler (not GHA cron) would be the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)