### PR TITLE
fix(SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001): fail-soft sweep + SD-TEST fixture exclusion

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -215,9 +215,34 @@ async function isSweepResetAllowed(sdKey, targetResetPhase, contextLabel) {
       );
       return false;
     }
-    // Unexpected error — re-throw to caller (sweep aborts loudly rather
-    // than silently overriding state).
-    throw err;
+    // SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001 (FR-1): a vanished SD (TOCTOU — a
+    // concurrent test suite DELETEd an SD-TEST-* fixture between the sweep's
+    // snapshot and this handoff-gate lookup) makes assertSweepHandoffGate throw
+    // ExecContextError code=SD_NOT_FOUND. That is NOT a fault to abort the whole
+    // sweep on (it previously propagated to the top-level catch → process.exit(1),
+    // killing all fleet protection for the tick — live evidence fa7dc41e). Treat
+    // it as a per-item skip: the SD is gone, so there is nothing to reset. Do NOT
+    // swallow SCHEMA_ERROR (a genuine, permanent fault that must surface).
+    if (err && err.code === 'SD_NOT_FOUND') {
+      console.log(
+        '  SKIP_RESET: ' + sdKey + ' — ' + contextLabel +
+        ' — SD vanished before handoff-gate lookup (TOCTOU); skipping reset (non-fatal)'
+      );
+      return false;
+    }
+    // SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001 (FR-2): any other unexpected error
+    // (e.g. SCHEMA_ERROR) is contained at the item boundary, not re-thrown. This
+    // is the single fail-soft containment point for the QA reset gate — returning
+    // false ("reset not allowed") is the SAFE default: it does NOT override SD
+    // state, it simply skips this one item. Previously this re-threw and bubbled
+    // to the top-level catch → process.exit(1), killing ALL fleet protection for
+    // the tick over a single bad row. The fault is still surfaced via a WARN line
+    // emitted every tick until resolved (visible, but non-catastrophic).
+    console.warn(
+      '  WARN_RESET_GATE_ERROR: ' + sdKey + ' — ' + contextLabel + ' — ' +
+      (err && err.message ? err.message : err) + ' (skipping reset, non-fatal)'
+    );
+    return false;
   }
 }
 
@@ -240,6 +265,14 @@ const PHASE_RESET_MAP = {
 };
 
 async function resetSdPhaseOnRelease(sdKey, reason) {
+  // SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001 (FR-2): per-item fail-soft. This is the
+  // dominant throw source in the QA loops (it calls isSweepResetAllowed, which
+  // re-throws genuinely-unexpected errors such as SCHEMA_ERROR). A throw here used
+  // to bubble to the top-level catch → process.exit(1), aborting the whole sweep
+  // tick for ONE item. Contain it: log a warning and return so the remaining items
+  // still process. (FR-1 already neutralizes the common SD_NOT_FOUND case inside
+  // isSweepResetAllowed; this catch covers any other unexpected per-item fault.)
+  try {
   const { data: sd } = await supabase
     .from('strategic_directives_v2')
     .select('sd_key, current_phase, status')
@@ -264,6 +297,10 @@ async function resetSdPhaseOnRelease(sdKey, reason) {
       .eq('sd_key', sdKey);
     console.log('  PHASE_RESET: ' + sdKey + ' ' + sd.current_phase + ' → ' + resetTo + ' (' + reason + ')');
   }
+  } catch (err) {
+    // FR-2: contain a per-item reset fault; never abort the whole sweep tick.
+    console.warn('  WARN_RESET_SKIPPED: ' + sdKey + ' (' + reason + ') — ' + (err && err.message ? err.message : err));
+  }
 }
 
 function isProcessRunning(pid) {
@@ -281,6 +318,19 @@ function isProcessRunning(pid) {
 function bar(pct, width = 20) {
   const filled = Math.round((pct / 100) * width);
   return '\u2588'.repeat(filled) + '\u2591'.repeat(width - filled);
+}
+
+// SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001 (FR-3): `SD-TEST-` is a RESERVED sd_key
+// namespace for ephemeral test fixtures that concurrent test suites INSERT and
+// DELETE within a single run. The sweep's QA reset/mutation paths must never
+// iterate or mutate these \u2014 doing so (a) churns phantom resets every tick
+// (witnessed SD-TEST-MQ7XBNBM-ORCH-001 reset in_progress/EXEC/100% \u2192 draft) and
+// (b) is the TOCTOU source of the FR-1 fatal (a fixture deleted mid-sweep). Real
+// SDs use source prefixes (SD-LEO-/SD-FDBK-/etc.), never SD-TEST-. Single source
+// of truth, applied at every QA mutation site. SQL form: .not('sd_key','like','SD-TEST-%').
+const TEST_FIXTURE_SD_KEY_LIKE = 'SD-TEST-%';
+function isTestFixtureSdKey(sdKey) {
+  return typeof sdKey === 'string' && /^SD-TEST-/.test(sdKey);
 }
 
 // --- Layer 1: Terminal Identity Collision Detection ---
@@ -846,10 +896,13 @@ async function main() {
   const { data: allPendingApproval } = await supabase
     .from('strategic_directives_v2')
     .select('id, sd_key, status, current_phase, progress_percentage, completion_date')
-    .eq('status', 'pending_approval');
+    .eq('status', 'pending_approval')
+    // FR-3: never QA-reset ephemeral SD-TEST-* fixtures.
+    .not('sd_key', 'like', TEST_FIXTURE_SD_KEY_LIKE);
 
   const activeClaimSdIds = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_key));
-  const stuckApproval = (allPendingApproval || []).filter(sd => !activeClaimSdIds.has(sd.sd_key));
+  // FR-3 (defense-in-depth): also drop any fixture that slipped past the query filter.
+  const stuckApproval = (allPendingApproval || []).filter(sd => !activeClaimSdIds.has(sd.sd_key) && !isTestFixtureSdKey(sd.sd_key));
 
   // QF-20260423-909: Guard against resetting SDs that legitimately completed
   // PLAN-TO-LEAD and are resting in pending_approval awaiting LEAD-FINAL-APPROVAL.
@@ -922,7 +975,9 @@ async function main() {
     .from('strategic_directives_v2')
     .select('sd_key, status, claiming_session_id, is_working_on')
     .in('status', ['completed', 'cancelled'])
-    .not('claiming_session_id', 'is', null);
+    .not('claiming_session_id', 'is', null)
+    // FR-3: never touch ephemeral SD-TEST-* fixtures.
+    .not('sd_key', 'like', TEST_FIXTURE_SD_KEY_LIKE);
 
   for (const sd of (terminalWithClaims || [])) {
     const { error } = await supabase
@@ -951,7 +1006,10 @@ async function main() {
     .from('strategic_directives_v2')
     .select('sd_key, current_phase, progress_percentage')
     .eq('status', 'in_progress')
-    .is('claiming_session_id', null);
+    .is('claiming_session_id', null)
+    // FR-3: never reset ephemeral SD-TEST-* fixtures (witnessed phantom churn of
+    // SD-TEST-MQ7XBNBM-ORCH-001 reset in_progress/EXEC/100% → draft every tick).
+    .not('sd_key', 'like', TEST_FIXTURE_SD_KEY_LIKE);
 
   for (const sd of (phantomInProgress || [])) {
     // SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001 (FR-3, AC-4/AC-5): generalized
@@ -982,7 +1040,9 @@ async function main() {
     .from('strategic_directives_v2')
     .select('sd_key, title, description, scope')
     .in('status', ['draft', 'ready'])
-    .not('sd_key', 'like', '%ORCH-STAGE-VENTURE-WORKFLOW-001-%');
+    .not('sd_key', 'like', '%ORCH-STAGE-VENTURE-WORKFLOW-001-%')
+    // FR-3: never enrich ephemeral SD-TEST-* fixtures.
+    .not('sd_key', 'like', TEST_FIXTURE_SD_KEY_LIKE);
   const bareShellSDs = (pendingSDs || []).filter(sd => {
     if (sd.description && sd.description.startsWith('Child SD of')) return false;
     return !sd.description || sd.description === sd.title || (sd.description.length < 100 && sd.scope === sd.title);
@@ -2049,3 +2109,14 @@ module.exports.detectCrossSessionCollisions = detectCrossSessionCollisions;
 module.exports.loadRecentIntents = loadRecentIntents;
 module.exports.INTENT_WINDOW_MIN = INTENT_WINDOW_MIN;
 module.exports.INTENT_PAYLOAD_KEYS = INTENT_PAYLOAD_KEYS;
+
+// SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001 — claim-safety exports.
+// FR-3 predicate (pure): the reserved SD-TEST- fixture namespace check.
+module.exports.isTestFixtureSdKey = isTestFixtureSdKey;
+module.exports.TEST_FIXTURE_SD_KEY_LIKE = TEST_FIXTURE_SD_KEY_LIKE;
+// FR-1/FR-2: the fail-soft reset gate + a test-only seam to seed the lazily-imported
+// exec-context-guard cache (so tests can inject a mock assertSweepHandoffGate without
+// touching the live ESM module). Seeding the cache is exactly what the first real call
+// does — no production behavior change.
+module.exports.isSweepResetAllowed = isSweepResetAllowed;
+module.exports.__setExecContextGuardForTest = (mock) => { _execContextGuardCache = mock; };

--- a/tests/unit/scripts/stale-session-sweep-claim-safety.test.js
+++ b/tests/unit/scripts/stale-session-sweep-claim-safety.test.js
@@ -1,0 +1,164 @@
+/**
+ * SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001 — claim-safety + fail-soft hardening.
+ *
+ * The stale-session-sweep is the fleet's every-5-min supervisor. Two LEAD-verified
+ * defects (live evidence 2026-06-10):
+ *   FR-1: a vanished SD (TOCTOU — a concurrent test suite DELETEs an SD-TEST-* fixture
+ *         mid-sweep) made the handoff-gate lookup throw SD_NOT_FOUND, which bubbled to the
+ *         top-level catch → process.exit(1), killing ALL fleet protection for the tick
+ *         (evidence fa7dc41e: "SWEEP FATAL: SD not found for sd_key=SD-TEST-MQ7XOM7D-ORCH-001
+ *         during handoff-gate lookup").
+ *   FR-2: any per-item reset-gate fault (e.g. SCHEMA_ERROR) must be contained at the item
+ *         boundary, never aborting the whole sweep.
+ *   FR-3: the QA reset/mutation paths must never iterate or mutate ephemeral SD-TEST-*
+ *         fixtures (they churn phantom resets every tick AND are the FR-1 TOCTOU source).
+ *
+ * Combines behavioral tests (the core safety property — does the gate contain faults
+ * instead of throwing?) with static source-invariant tests (the file's established
+ * convention — every QA mutation query applies the SD-TEST exclusion).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const SOURCE_PATH = resolve(REPO_ROOT, 'scripts/stale-session-sweep.cjs');
+const SOURCE = readFileSync(SOURCE_PATH, 'utf8');
+
+const require = createRequire(import.meta.url);
+const sweep = require(SOURCE_PATH);
+
+// Helper: a code-tagged error mirroring lib/exec-context-guard.mjs::ExecContextError shape.
+function guardError(code, message) {
+  const e = new Error(message || code);
+  e.code = code;
+  return e;
+}
+
+describe('FR-3 — isTestFixtureSdKey predicate (pure)', () => {
+  it('matches the reserved SD-TEST- namespace', () => {
+    expect(sweep.isTestFixtureSdKey('SD-TEST-MQ7XOM7D-ORCH-001')).toBe(true);
+    expect(sweep.isTestFixtureSdKey('SD-TEST-MQ7XBNBM-ORCH-001')).toBe(true);
+    expect(sweep.isTestFixtureSdKey('SD-TEST-001')).toBe(true);
+  });
+
+  it('does NOT match real SD source prefixes or QF keys', () => {
+    expect(sweep.isTestFixtureSdKey('SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001')).toBe(false);
+    expect(sweep.isTestFixtureSdKey('SD-FDBK-FIX-STAGE-TEMPLATE-FIXES-001')).toBe(false);
+    expect(sweep.isTestFixtureSdKey('QF-20260610-001')).toBe(false);
+    // anchored: SD-TEST must be a prefix, not a substring
+    expect(sweep.isTestFixtureSdKey('SD-LEO-TEST-HARNESS-001')).toBe(false);
+  });
+
+  it('is null/undefined/non-string safe', () => {
+    expect(sweep.isTestFixtureSdKey(null)).toBe(false);
+    expect(sweep.isTestFixtureSdKey(undefined)).toBe(false);
+    expect(sweep.isTestFixtureSdKey(123)).toBe(false);
+    expect(sweep.isTestFixtureSdKey('')).toBe(false);
+  });
+
+  it('exposes the SQL LIKE pattern used at the query sites', () => {
+    expect(sweep.TEST_FIXTURE_SD_KEY_LIKE).toBe('SD-TEST-%');
+  });
+});
+
+describe('FR-1/FR-2 — isSweepResetAllowed fail-soft containment', () => {
+  // NB: `await`-ing the call directly IS the "does not throw" assertion — if the gate
+  // re-threw (the pre-fix process-exit-causing behavior), the await would reject and the
+  // test would fail. Reaching the `expect(result)` line at all proves containment.
+  it('FR-1: a vanished SD (SD_NOT_FOUND) returns false and does NOT throw', async () => {
+    sweep.__setExecContextGuardForTest({
+      assertSweepHandoffGate: vi.fn(async () => { throw guardError('SD_NOT_FOUND', 'SD not found for sd_key=SD-TEST-X during handoff-gate lookup'); }),
+    });
+    const result = await sweep.isSweepResetAllowed('SD-TEST-X', 'LEAD', 'unit');
+    expect(result).toBe(false);
+  });
+
+  it('FR-2: an unexpected fault (SCHEMA_ERROR) is contained — returns false, does NOT throw', async () => {
+    sweep.__setExecContextGuardForTest({
+      assertSweepHandoffGate: vi.fn(async () => { throw guardError('SCHEMA_ERROR', 'Schema error during sd_key→UUID lookup'); }),
+    });
+    const result = await sweep.isSweepResetAllowed('SD-REAL-001', 'LEAD', 'unit');
+    expect(result).toBe(false);
+  });
+
+  it('FR-2: even a generic (uncoded) throw is contained — returns false, does NOT throw', async () => {
+    sweep.__setExecContextGuardForTest({
+      assertSweepHandoffGate: vi.fn(async () => { throw new Error('boom: unexpected'); }),
+    });
+    const result = await sweep.isSweepResetAllowed('SD-REAL-002', 'LEAD', 'unit');
+    expect(result).toBe(false);
+  });
+
+  it('preserves existing ACCEPTED_HANDOFF_OVERRIDE behavior (skip reset, no throw)', async () => {
+    sweep.__setExecContextGuardForTest({
+      assertSweepHandoffGate: vi.fn(async () => { throw guardError('ACCEPTED_HANDOFF_OVERRIDE', 'accepted handoff past target'); }),
+    });
+    const result = await sweep.isSweepResetAllowed('SD-REAL-003', 'LEAD', 'unit');
+    expect(result).toBe(false);
+  });
+
+  it('allows the reset on the normal path (guard resolves without throwing)', async () => {
+    sweep.__setExecContextGuardForTest({
+      assertSweepHandoffGate: vi.fn(async () => ({ ok: true })),
+    });
+    const result = await sweep.isSweepResetAllowed('SD-REAL-004', 'LEAD', 'unit');
+    expect(result).toBe(true);
+  });
+});
+
+describe('FR-3 — SD-TEST exclusion applied at every QA mutation query site (static)', () => {
+  it('the top-level fatal handler still exists (the thing FR-1/FR-2 protect against)', () => {
+    // Regression anchor: if this disappears, the containment tests above lose their meaning.
+    expect(SOURCE).toMatch(/SWEEP FATAL:/);
+  });
+
+  it('every QA strategic_directives_v2 mutation scan excludes SD-TEST-% (pending_approval, terminal-claims, phantom in_progress, bare-shell)', () => {
+    // Each of these QA scans must carry a .not('sd_key','like', SD-TEST pattern). We assert the
+    // status-keyed query anchors are each followed (within a window) by the exclusion.
+    const anchors = [
+      { name: 'pending_approval scan', re: /\.eq\(\s*['"]status['"]\s*,\s*['"]pending_approval['"]\s*\)/ },
+      { name: 'terminal-claims clear', re: /\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]completed['"]\s*,\s*['"]cancelled['"]\s*\]\s*\)/ },
+      { name: 'phantom in_progress scan', re: /\.eq\(\s*['"]status['"]\s*,\s*['"]in_progress['"]\s*\)/ },
+      { name: 'bare-shell enrich scan', re: /\.in\(\s*['"]status['"]\s*,\s*\[\s*['"]draft['"]\s*,\s*['"]ready['"]\s*\]\s*\)/ },
+    ];
+    for (const a of anchors) {
+      const m = SOURCE.match(a.re);
+      expect(m, `${a.name}: status anchor not found`).toBeTruthy();
+      const window = SOURCE.slice(m.index, m.index + 400);
+      expect(window, `${a.name}: missing SD-TEST-% exclusion within query window`)
+        .toMatch(/\.not\(\s*['"]sd_key['"]\s*,\s*['"]like['"]\s*,\s*TEST_FIXTURE_SD_KEY_LIKE\s*\)/);
+    }
+  });
+
+  it('the shared predicate + LIKE constant are defined exactly once (single source of truth)', () => {
+    expect((SOURCE.match(/function isTestFixtureSdKey\(/g) || []).length).toBe(1);
+    expect((SOURCE.match(/const TEST_FIXTURE_SD_KEY_LIKE\s*=/g) || []).length).toBe(1);
+  });
+});
+
+describe('FR-1/FR-2 — no bare re-throw in the reset gate; reset helper is wrapped (static)', () => {
+  it('isSweepResetAllowed handles SD_NOT_FOUND explicitly (FR-1)', () => {
+    expect(SOURCE).toMatch(/err\.code === 'SD_NOT_FOUND'/);
+  });
+
+  it('isSweepResetAllowed no longer ends its catch with a bare `throw err`', () => {
+    // The catch must contain the fail-soft WARN + `return false`, not re-throw.
+    const fnStart = SOURCE.indexOf('async function isSweepResetAllowed');
+    const fnEnd = SOURCE.indexOf('\n}', fnStart);
+    const fnBody = SOURCE.slice(fnStart, fnEnd);
+    expect(fnBody).toMatch(/WARN_RESET_GATE_ERROR/);
+    expect(fnBody).not.toMatch(/\n\s*throw err;/);
+  });
+
+  it('resetSdPhaseOnRelease wraps its body in try/catch (FR-2 per-item containment)', () => {
+    const fnStart = SOURCE.indexOf('async function resetSdPhaseOnRelease');
+    const fnBody = SOURCE.slice(fnStart, fnStart + 2500);
+    expect(fnBody).toMatch(/try\s*\{/);
+    expect(fnBody).toMatch(/WARN_RESET_SKIPPED/);
+  });
+});


### PR DESCRIPTION
## Summary
Hardens `scripts/stale-session-sweep.cjs` (the fleet's every-5-min supervisor) against two LEAD-verified claim-safety defects. Scope was LEAD-locked from 4 FRs to 2 after verifying claims against source: FR-3 (SD-aware classifier) was already fixed by `a681fc28ea` ~18h before this SD existed, and FR-4 (fresh-tick guard) is already implemented via the `process_alive_at` source-side signal.

## Changes
- **FR-1 fail-soft iteration** (live evidence `fa7dc41e`): a vanished SD (TOCTOU — a concurrent test suite DELETEs an `SD-TEST-*` fixture mid-sweep) made `assertSweepHandoffGate` throw `SD_NOT_FOUND`, which bubbled to the top-level catch → `process.exit(1)`, killing ALL fleet protection for that tick. `isSweepResetAllowed` now contains `SD_NOT_FOUND` (and any other unexpected gate error e.g. `SCHEMA_ERROR`) as a per-item skip — logs a WARN, returns `false` (the safe "don't override state" default). `resetSdPhaseOnRelease` wraps its body in try/catch as defense-in-depth.
- **FR-3 test-fixture exclusion**: the four QA reset/mutation scans (pending_approval, terminal-claim clear, phantom in_progress, bare-shell enrich) now exclude the reserved `SD-TEST-%` namespace via a single shared `isTestFixtureSdKey` predicate — stops phantom churn and removes the FR-1 TOCTOU trigger at its source.

## Tests
- 15 new (behavioral containment via injected mock guard + static query-site coverage)
- 28 existing sweep tests still green (no regression)
- Smoke: the exact `fa7dc41e` fatal now logs `SKIP_RESET` and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)