### PR TITLE
fix(SD-FDBK-INFRA-RCA-FIRST-HARD-001): hard-bound external steps + gate coverage in complete-quick-fix

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -39,7 +39,7 @@ export function prompt(question) {
   if (_nonInteractiveMode) {
     return Promise.reject(new Error(
       `[NON_INTERACTIVE] Refusing to prompt under --non-interactive mode. Question was: ${question.trim()}. ` +
-      `Pass the value explicitly via CLI flag (e.g., --uat-verified yes, --verification-notes "...", --actual-loc <N>, --force-complete --reason "...").`
+      'Pass the value explicitly via CLI flag (e.g., --uat-verified yes, --verification-notes "...", --actual-loc <N>, --force-complete --reason "...").'
     ));
   }
 
@@ -65,7 +65,7 @@ export function prompt(question) {
       if (!answered) {
         reject(new Error(
           `[NON_INTERACTIVE] stdin closed with no answer to: ${question.trim()}. ` +
-          `Pass the value via a CLI flag (--uat-verified yes / --actual-loc <N> / --non-interactive / --force-complete --reason "..."), or pipe an answer.`
+          'Pass the value via a CLI flag (--uat-verified yes / --actual-loc <N> / --non-interactive / --force-complete --reason "..."), or pipe an answer.'
         ));
       }
     });
@@ -95,6 +95,10 @@ export function parseArguments(args) {
       'skip-tests':         { type: 'boolean' },
       'tests-pass':         { type: 'string' },
       'skip-typecheck':     { type: 'boolean' },
+      // SD-FDBK-INFRA-RCA-FIRST-HARD-001 (FR-3): skip the advisory per-file test-coverage
+      // probe loop (verifyTestCoverage). Also auto-skipped under --skip-tests/--force-complete,
+      // a docs-only/empty diff, or filesChanged===0 — this flag is the explicit opt-out.
+      'skip-coverage':      { type: 'boolean' },
       'uat-verified':       { type: 'string' },
       'verification-notes': { type: 'string' },
       'force-complete':     { type: 'boolean' },
@@ -188,6 +192,8 @@ export function parseArguments(args) {
     skipTestRun:       values['skip-tests']       || false,
     testsPass:         values['tests-pass']       != null ? values['tests-pass'].toLowerCase().startsWith('y') : undefined,
     skipTypeCheck:     values['skip-typecheck']   || false,
+    // SD-FDBK-INFRA-RCA-FIRST-HARD-001 (FR-3): explicit opt-out of the coverage probe loop.
+    skipCoverage:      values['skip-coverage']    || false,
     uatVerified:       values['uat-verified']     != null ? values['uat-verified'].toLowerCase().startsWith('y') : undefined,
     verificationNotes: values['verification-notes'],
     forceComplete:     values['force-complete']   || false,
@@ -235,6 +241,9 @@ Options:
   --skip-tests          Skip running tests (trusts CI; testsPass=true by default)
   --tests-pass          Override testsPass explicitly (yes/no); optional with --skip-tests
   --skip-typecheck      Skip TypeScript verification (not recommended)
+  --skip-coverage       Skip the advisory per-file test-coverage probe loop. Also auto-skipped
+                        under --skip-tests / --force-complete / a docs-only or empty diff / when
+                        no files changed. Coverage is advisory (console-only) and never gates.
   --uat-verified        UAT verified (yes/no, will prompt if not provided)
   --verification-notes  Optional notes about verification
   --force-complete      Bypass self-verification + LOC-cap blocks; sets quick_fixes.force_completed=true.

--- a/scripts/modules/complete-quick-fix/constants.js
+++ b/scripts/modules/complete-quick-fix/constants.js
@@ -23,5 +23,23 @@ export const MIN_WARN_SCORE = 70;
 export const TEST_TIMEOUT_UNIT = 120000; // 2 minutes for unit tests
 export const TEST_TIMEOUT_E2E = 300000;  // 5 minutes for E2E tests
 
+// SD-FDBK-INFRA-RCA-FIRST-HARD-001 (FR-1): single shared wall-clock bound for FAST
+// external steps (shell-process spawns + git/gh network RPCs). RCA (single structural
+// root) found these call sites omit a timeout, so an adverse input (gh/git stalling on
+// auth/network, or a per-file `test -f` loop ballooned by a stale origin/main) rides to
+// the external 2m/5m SIGTERM as EXIT 124. Apply this to every shelling-out execSync that
+// lacks a timeout. Intentionally-LONGER steps (tsc, lint, the unit/e2e suites) keep their
+// own explicit timeouts (TEST_TIMEOUT_*, test-runner.js) and are NOT routed through this.
+// Override via env LEO_QF_EXTERNAL_STEP_TIMEOUT_MS=<positive integer ms>.
+function resolveExternalStepTimeoutMs() {
+  const raw = process.env.LEO_QF_EXTERNAL_STEP_TIMEOUT_MS;
+  if (raw !== undefined) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 60000; // 60s default — generous for a fast probe, far under the 2m external kill
+}
+export const EXTERNAL_STEP_TIMEOUT_MS = resolveExternalStepTimeoutMs();
+
 // Repository paths for target application (registry-driven)
 export const REPO_PATHS = getRepoPaths();

--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -11,6 +11,7 @@
 import { execSync, execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { EXTERNAL_STEP_TIMEOUT_MS } from './constants.js';
 
 // QF-20260511-123 / feedback 0930f169: prefer the QF worktree when cwd is inside
 // .worktrees/qf/<qfId>, so Tier-1 docs-QFs don't fall back to the parent repo's
@@ -325,12 +326,20 @@ export function fetchPRMetadata(prNumber, testDir) {
   const fields = 'state,headRefName,mergeCommit,additions,deletions,url,files';
   let raw;
   try {
+    // FR-2: bound the gh network RPC. Without a timeout a gh auth/network stall
+    // blocks indefinitely and rides to the external 2m/5m SIGTERM (the 244a67d3
+    // "no output before kill" class). On ETIMEDOUT, surface a loud message rather
+    // than a silent fallback to CWD HEAD.
     raw = execSync(`gh pr view ${prNumber} --json ${fields}`, {
       cwd: testDir,
       encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe']
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: EXTERNAL_STEP_TIMEOUT_MS
     });
   } catch (e) {
+    if (e.code === 'ETIMEDOUT' || e.signal === 'SIGTERM') {
+      throw new Error(`gh pr view ${prNumber} exceeded ${EXTERNAL_STEP_TIMEOUT_MS}ms (external step timeout). Cannot resolve PR metadata; check gh auth/network or pass --commit-sha/--branch-name/--actual-loc explicitly.`);
+    }
     const code = e.status ?? '?';
     const stderr = (e.stderr ? e.stderr.toString() : '').trim().split('\n')[0];
     throw new Error(`gh pr view ${prNumber} exited ${code}${stderr ? `: ${stderr}` : ''}. Cannot resolve PR metadata; pass --commit-sha/--branch-name/--actual-loc explicitly or fix gh auth.`);
@@ -469,18 +478,20 @@ export function autoDetectGitInfo(testDir, options = {}) {
   // ── Legacy in-worktree path (regression-safe) ──────────────────────────
   try {
     if (!result.commitSha) {
-      result.commitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8', cwd: testDir }).trim();
+      // FR-2: bound the legacy autodetect git calls (the 244a67d3 class — these run
+      // from a worktree whose refs can be gone after removal, blocking with no output).
+      result.commitSha = execSync('git rev-parse HEAD', { encoding: 'utf-8', cwd: testDir, timeout: EXTERNAL_STEP_TIMEOUT_MS }).trim();
       console.log(`🔍 Auto-detected commit SHA: ${result.commitSha.substring(0, 7)}`);
     }
 
     if (!result.branchName) {
-      result.branchName = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8', cwd: testDir }).trim();
+      result.branchName = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8', cwd: testDir, timeout: EXTERNAL_STEP_TIMEOUT_MS }).trim();
       console.log(`🔍 Auto-detected branch: ${result.branchName}`);
     }
 
     if (!result.actualLoc) {
       try {
-        const diffStats = execSync('git diff origin/main --shortstat', { encoding: 'utf-8', cwd: testDir }).trim();
+        const diffStats = execSync('git diff origin/main --shortstat', { encoding: 'utf-8', cwd: testDir, timeout: EXTERNAL_STEP_TIMEOUT_MS }).trim();
         const match = diffStats.match(/(\d+) insertion/);
         if (match) {
           result.actualLoc = parseInt(match[1]);

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -20,7 +20,7 @@ import os from 'os';
 
 import { REPO_PATHS, EHG_ROOT } from './constants.js';
 import { runTests, runTypeScriptCheck, displayTestResults } from './test-runner.js';
-import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff, canSkipTestGate, reconcileDeclaredTypeVsFiles, touchesFrontend, getScopedUnitTestFiles, isEmptyDiff } from './git-operations.js';
+import { autoDetectGitInfo, analyzeGitDiff, commitAndPushChanges, mergeToMain, resolveQFWorktreeFromCwd, isDocsOnlyDiff, canSkipTestGate, reconcileDeclaredTypeVsFiles, touchesFrontend, getScopedUnitTestFiles, isEmptyDiff, fetchPRMetadata } from './git-operations.js';
 import {
   validateLOC,
   validateTests,
@@ -124,6 +124,44 @@ export async function completeQuickFix(qfId, options = {}) {
     console.log('⚠️  This issue was escalated to a full SD');
     console.log(`   Reason: ${qf.escalation_reason}`);
     return qf;
+  }
+
+  // SD-FDBK-INFRA-RCA-FIRST-HARD-001 (FR-4): early already-MERGED probe.
+  // Only status==='completed'/'escalated' short-circuits above, so a /checkin re-run on a
+  // QF whose PR is ALREADY MERGED (the f32a6df5 residual) would otherwise re-run the entire
+  // pipeline — including the now-bounded but still-wasteful external steps. When a PR id is
+  // resolvable (from --pr-url or the persisted qf.pr_url) ask gh for PR state (bounded by
+  // EXTERNAL_STEP_TIMEOUT_MS via fetchPRMetadata); if MERGED, reconcile the QF to terminal
+  // and return so the re-run is a fast idempotent no-op. gh (not local git) is authoritative
+  // here because after a worktree removal the local refs are gone but PR state survives.
+  // Best-effort: any failure/timeout falls through to the normal (now-bounded) pipeline and
+  // never blocks a genuinely-incomplete QF.
+  const probePrUrl = options.prUrl || qf.pr_url;
+  const probePrNumber = probePrUrl && String(probePrUrl).match(/\/pull\/(\d+)/)?.[1];
+  if (probePrNumber) {
+    try {
+      const meta = fetchPRMetadata(probePrNumber, testDir);
+      if (meta && meta.state === 'MERGED') {
+        console.log(`\n✅ PR #${probePrNumber} is already MERGED — reconciling ${qfId} to completed (idempotent re-run short-circuit).\n`);
+        const mergeSha = meta.mergeCommit?.oid || qf.commit_sha || null;
+        const { error: reconcileErr } = await supabase
+          .from('quick_fixes')
+          .update({
+            status: 'completed',
+            pr_url: probePrUrl,
+            commit_sha: mergeSha,
+            completed_at: qf.completed_at || new Date().toISOString()
+          })
+          .eq('id', qfId)
+          .neq('status', 'completed');
+        if (reconcileErr) {
+          console.log(`   ⚠️  Could not reconcile QF record (non-fatal): ${reconcileErr.message}`);
+        }
+        return { ...qf, status: 'completed', pr_url: probePrUrl, commit_sha: mergeSha };
+      }
+    } catch (e) {
+      console.log(`   ℹ️  Already-merged probe skipped (will run normal pipeline): ${e.message}`);
+    }
   }
 
   // Auto-detect git info. autoDetectGitInfo NOW throws on PR-metadata failure
@@ -330,8 +368,17 @@ export async function completeQuickFix(qfId, options = {}) {
   // createAutoPR has filesChanged available and the autoPr branch fires BEFORE
   // the PR-URL prompt. 13th-witness PAT-LEO-INFRA-WRITER-CONSUMER-ASYMMETRY-001.)
 
-  // Test Coverage Verification (uses filesChanged from above)
-  const testCoverage = verifyTestCoverage(filesChanged);
+  // Test Coverage Verification (uses filesChanged from above).
+  // SD-FDBK-INFRA-RCA-FIRST-HARD-001 (FR-3): gate the advisory per-file probe loop so a
+  // ballooned filesChanged (stale origin/main after a worktree removal) can't ride the
+  // unbounded spawn loop to EXIT 124. Skip when the operator opted out, when the test gate
+  // itself was skipped (docs-only / --skip-tests), or under --force-complete. Coverage is
+  // console-only and never gates, so skipping changes no verdict. (verifyTestCoverage also
+  // self-skips on an empty filesChanged and bounds each spawn via EXTERNAL_STEP_TIMEOUT_MS.)
+  const skipCoverage = Boolean(
+    options.skipCoverage || options.skipTestRun || options.forceComplete || skipTestGate
+  );
+  const testCoverage = verifyTestCoverage(filesChanged, { skip: skipCoverage });
 
   // PR verification
   let prUrl = options.prUrl;

--- a/scripts/modules/complete-quick-fix/verification.js
+++ b/scripts/modules/complete-quick-fix/verification.js
@@ -5,6 +5,7 @@
 
 import path from 'path';
 import { execSync } from 'child_process';
+import { EXTERNAL_STEP_TIMEOUT_MS } from './constants.js';
 
 /**
  * Hard cap on QF size. Aligned with CLAUDE.md routing: Tier 1 ≤30,
@@ -231,11 +232,23 @@ export function validatePR(prUrl, qfId, qfTitle) {
 }
 
 /**
- * Verify test coverage for changed files
+ * Verify test coverage for changed files.
+ *
+ * SD-FDBK-INFRA-RCA-FIRST-HARD-001 (FR-3): this step is ADVISORY (console-only,
+ * non-gating) but historically ran UNCONDITIONALLY with an unbounded per-file
+ * `execSync('test -f')` loop. When `filesChanged` balloons (e.g. running from main
+ * after a worktree removal with a stale origin/main), the loop is filesChanged × 4
+ * patterns synchronous spawns and rides to the external 2m/5m SIGTERM (EXIT 124).
+ * Callers now pass `opts.skip` (true when --skip-coverage / --skip-tests /
+ * --force-complete / a docs-only diff / an empty diff) to short-circuit it, and
+ * each spawn is bounded by EXTERNAL_STEP_TIMEOUT_MS (FR-2) as defense-in-depth.
+ *
  * @param {Array} filesChanged - List of changed files
+ * @param {object} [opts] - { skip?: boolean } — when skip is true, return the
+ *   neutral coverage shape without entering the spawn loop.
  * @returns {object} Test coverage info
  */
-export function verifyTestCoverage(filesChanged) {
+export function verifyTestCoverage(filesChanged, opts = {}) {
   console.log('📋 Test Coverage Verification\n');
 
   const testCoverage = {
@@ -243,6 +256,17 @@ export function verifyTestCoverage(filesChanged) {
     e2eTestsExist: false,
     filesWithTests: []
   };
+
+  // FR-3: skip the spawn loop entirely when gated by the caller, or when there is
+  // nothing to check. Coverage is advisory, so skipping changes no gate verdict.
+  if (opts.skip || !Array.isArray(filesChanged) || filesChanged.length === 0) {
+    const reason = opts.skip
+      ? 'skipped (gated by --skip-coverage / --skip-tests / --force-complete / docs-only / empty diff)'
+      : 'skipped (no changed files to check)';
+    console.log(`   ⏭️  Test coverage check ${reason}.\n`);
+    testCoverage.skipped = true;
+    return testCoverage;
+  }
 
   try {
     for (const file of filesChanged) {
@@ -263,11 +287,15 @@ export function verifyTestCoverage(filesChanged) {
 
       for (const testPattern of testPatterns) {
         try {
-          execSync(`test -f "${testPattern}"`, { stdio: 'pipe' });
+          // FR-2: bound the probe so a wedged spawn cannot ride to the external
+          // SIGTERM. `test -f` is a fast POSIX/Git-Bash builtin; the timeout is a
+          // safety net against the loop's aggregate cost, not the per-call latency.
+          execSync(`test -f "${testPattern}"`, { stdio: 'pipe', timeout: EXTERNAL_STEP_TIMEOUT_MS });
           testCoverage.filesWithTests.push(file);
           break;
         } catch {
-          // Test file doesn't exist
+          // Test file doesn't exist (or the bounded probe timed out — treated as
+          // "no coverage found", which is advisory only and never blocks completion).
         }
       }
     }

--- a/tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js
+++ b/tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js
@@ -1,0 +1,157 @@
+/**
+ * SD-FDBK-INFRA-RCA-FIRST-HARD-001 — RCA-first: hard-bound external steps +
+ * gate the coverage step in complete-quick-fix.
+ *
+ * Covers the three residual EXIT-124 hangs that survive the COMPLETE-QUICK-FIX-001/002
+ * prompt-class fixes (RCA verdict: single structural root — external steps not
+ * wall-clock-bounded + verifyTestCoverage ungated):
+ *   FR-1 EXTERNAL_STEP_TIMEOUT_MS constant (+ env override)
+ *   FR-2 every shelling-out execSync at the cited sites carries the timeout
+ *   FR-3 verifyTestCoverage gated (skip) + bounded
+ *   FR-4 early already-MERGED probe makes /checkin re-runs idempotent
+ *
+ * Behavioral where the unit is cleanly importable; source-assertion (mirroring
+ * complete-quick-fix-skip-flags.test.js) for logic embedded in the large
+ * completeQuickFix() function so the test stays hermetic (no real spawns / gh / DB).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+import { EXTERNAL_STEP_TIMEOUT_MS } from '../../../scripts/modules/complete-quick-fix/constants.js';
+import { verifyTestCoverage } from '../../../scripts/modules/complete-quick-fix/verification.js';
+import { parseArguments } from '../../../scripts/modules/complete-quick-fix/cli.js';
+
+const MOD = path.resolve(process.cwd(), 'scripts/modules/complete-quick-fix');
+const CONSTANTS_PATH = path.join(MOD, 'constants.js');
+const VERIF_PATH = path.join(MOD, 'verification.js');
+const GITOPS_PATH = path.join(MOD, 'git-operations.js');
+const ORCH_PATH = path.join(MOD, 'orchestrator.js');
+const CLI_PATH = path.join(MOD, 'cli.js');
+
+// ── FR-1: shared timeout constant + env override ──────────────────────────────
+describe('FR-1 EXTERNAL_STEP_TIMEOUT_MS', () => {
+  it('defaults to a positive 60s bound, well under the 2-minute external SIGTERM', () => {
+    expect(EXTERNAL_STEP_TIMEOUT_MS).toBe(60000);
+    expect(EXTERNAL_STEP_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(EXTERNAL_STEP_TIMEOUT_MS).toBeLessThan(120000);
+  });
+
+  it('honors a valid LEO_QF_EXTERNAL_STEP_TIMEOUT_MS env override (computed at import)', () => {
+    // The constant is resolved at module load, so exercise the override in a child
+    // process rather than mutating this process's already-loaded module.
+    const out = execSync(
+      'node -e "import(\'./scripts/modules/complete-quick-fix/constants.js\').then(m=>console.log(m.EXTERNAL_STEP_TIMEOUT_MS))"',
+      { cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, LEO_QF_EXTERNAL_STEP_TIMEOUT_MS: '12345' }, timeout: 30000 }
+    ).trim();
+    expect(out).toBe('12345');
+  });
+
+  it('falls back to the default on an invalid env override', () => {
+    const out = execSync(
+      'node -e "import(\'./scripts/modules/complete-quick-fix/constants.js\').then(m=>console.log(m.EXTERNAL_STEP_TIMEOUT_MS))"',
+      { cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, LEO_QF_EXTERNAL_STEP_TIMEOUT_MS: 'not-a-number' }, timeout: 30000 }
+    ).trim();
+    expect(out).toBe('60000');
+  });
+});
+
+// ── FR-2: every cited shelling-out execSync carries the timeout ───────────────
+describe('FR-2 external execSync sites are bounded', () => {
+  const verifSrc = readFileSync(VERIF_PATH, 'utf8');
+  const gitopsSrc = readFileSync(GITOPS_PATH, 'utf8');
+
+  it('verification.js imports the shared timeout constant', () => {
+    expect(verifSrc).toMatch(/import\s*\{\s*EXTERNAL_STEP_TIMEOUT_MS\s*\}\s*from\s*'\.\/constants\.js'/);
+  });
+
+  it('the verifyTestCoverage `test -f` probe passes the timeout', () => {
+    expect(verifSrc).toMatch(/execSync\(`test -f[^`]*`,\s*\{[^}]*timeout:\s*EXTERNAL_STEP_TIMEOUT_MS/);
+  });
+
+  it('git-operations.js imports the shared timeout constant', () => {
+    expect(gitopsSrc).toMatch(/import\s*\{\s*EXTERNAL_STEP_TIMEOUT_MS\s*\}\s*from\s*'\.\/constants\.js'/);
+  });
+
+  it('fetchPRMetadata gh pr view passes the timeout and loud-fails on ETIMEDOUT', () => {
+    expect(gitopsSrc).toMatch(/gh pr view[\s\S]{0,200}timeout:\s*EXTERNAL_STEP_TIMEOUT_MS/);
+    expect(gitopsSrc).toMatch(/ETIMEDOUT[\s\S]{0,160}external step timeout/);
+  });
+
+  it('the legacy autodetect git rev-parse / diff calls pass the timeout', () => {
+    expect(gitopsSrc).toMatch(/git rev-parse HEAD',\s*\{[^}]*timeout:\s*EXTERNAL_STEP_TIMEOUT_MS/);
+    expect(gitopsSrc).toMatch(/git rev-parse --abbrev-ref HEAD',\s*\{[^}]*timeout:\s*EXTERNAL_STEP_TIMEOUT_MS/);
+    expect(gitopsSrc).toMatch(/git diff origin\/main --shortstat',\s*\{[^}]*timeout:\s*EXTERNAL_STEP_TIMEOUT_MS/);
+  });
+});
+
+// ── FR-3: verifyTestCoverage is gated (behavioral) ────────────────────────────
+describe('FR-3 verifyTestCoverage gating', () => {
+  it('short-circuits without spawning when opts.skip is true', () => {
+    // 1000 fake files would be 4000 spawns if the loop ran — instead it must return fast.
+    const many = Array.from({ length: 1000 }, (_, i) => `src/file-${i}.ts`);
+    const t0 = Date.now();
+    const res = verifyTestCoverage(many, { skip: true });
+    const elapsed = Date.now() - t0;
+    expect(res.skipped).toBe(true);
+    expect(res.filesWithTests).toEqual([]);
+    expect(elapsed).toBeLessThan(1000); // no spawn loop ran
+  });
+
+  it('short-circuits on an empty / non-array filesChanged', () => {
+    expect(verifyTestCoverage([]).skipped).toBe(true);
+    expect(verifyTestCoverage(undefined).skipped).toBe(true);
+  });
+
+  it('orchestrator computes a skipCoverage gate (skipCoverage|skipTestRun|forceComplete|skipTestGate) and threads it', () => {
+    const orchSrc = readFileSync(ORCH_PATH, 'utf8');
+    expect(orchSrc).toMatch(/skipCoverage[\s\S]{0,200}options\.skipTestRun[\s\S]{0,80}options\.forceComplete[\s\S]{0,80}skipTestGate/);
+    expect(orchSrc).toMatch(/verifyTestCoverage\(filesChanged,\s*\{\s*skip:\s*skipCoverage\s*\}\)/);
+  });
+});
+
+// ── FR-3 (cli): --skip-coverage flag ──────────────────────────────────────────
+describe('FR-3 --skip-coverage CLI flag', () => {
+  it('parses --skip-coverage into options.skipCoverage', () => {
+    const { options } = parseArguments(['QF-20260101-001', '--skip-coverage']);
+    expect(options.skipCoverage).toBe(true);
+  });
+
+  it('defaults skipCoverage to false when the flag is absent', () => {
+    const { options } = parseArguments(['QF-20260101-001']);
+    expect(options.skipCoverage).toBe(false);
+  });
+
+  it('lists --skip-coverage in the help text', () => {
+    const cliSrc = readFileSync(CLI_PATH, 'utf8');
+    expect(cliSrc).toMatch(/--skip-coverage/);
+  });
+});
+
+// ── FR-4: early already-MERGED probe (source-assertion; embedded in completeQuickFix) ─
+describe('FR-4 already-MERGED probe', () => {
+  const orchSrc = readFileSync(ORCH_PATH, 'utf8');
+
+  it('imports fetchPRMetadata for the bounded probe', () => {
+    expect(orchSrc).toMatch(/import\s*\{[^}]*\bfetchPRMetadata\b[^}]*\}\s*from\s*'\.\/git-operations\.js'/);
+  });
+
+  it('resolves a PR number from --pr-url or qf.pr_url and checks MERGED state', () => {
+    expect(orchSrc).toMatch(/options\.prUrl\s*\|\|\s*qf\.pr_url/);
+    expect(orchSrc).toMatch(/meta\.state\s*===\s*'MERGED'/);
+  });
+
+  it('reconciles the QF to completed and returns early on MERGED', () => {
+    expect(orchSrc).toMatch(/status:\s*'completed'[\s\S]{0,200}\.eq\('id',\s*qfId\)[\s\S]{0,80}\.neq\('status',\s*'completed'\)/);
+    // The probe must return BEFORE autoDetectGitInfo (which is the next major step).
+    const probeIdx = orchSrc.indexOf("meta.state === 'MERGED'");
+    const autodetectIdx = orchSrc.indexOf('autoDetectGitInfo(testDir, options)');
+    expect(probeIdx).toBeGreaterThan(-1);
+    expect(autodetectIdx).toBeGreaterThan(probeIdx);
+  });
+
+  it('is best-effort: a probe failure falls through to the normal pipeline', () => {
+    expect(orchSrc).toMatch(/Already-merged probe skipped \(will run normal pipeline\)/);
+  });
+});


### PR DESCRIPTION
@
## SD-FDBK-INFRA-RCA-FIRST-HARD-001 — RCA-first

Closes the **three residual EXIT-124 hangs** in `complete-quick-fix` that survive the prompt-class fixes shipped by COMPLETE-QUICK-FIX-001/002.

**RCA (single structural root** — `sub_agent_execution_results` `c94b21d1`, verdict PASS conf 90): external steps (shell spawns + git/gh RPCs) are not wall-clock-bounded, and `verifyTestCoverage` runs ungated. The fix is a structural primitive, not three point patches. The RCA also refuted the naive ``test -f`` reading — it errors fast on both cmd.exe and Git Bash; the coverage hang is spawn-count × ~41ms when `filesChanged` balloons from a stale `origin/main` after a worktree removal.

### Changes
- **FR-1** `constants.js`: `EXTERNAL_STEP_TIMEOUT_MS` (default 60000, env override `LEO_QF_EXTERNAL_STEP_TIMEOUT_MS`).
- **FR-2** bound the cited unbounded `execSync` sites: `verifyTestCoverage` ``test -f`` loop; `fetchPRMetadata` `gh pr view` (loud-fail on ETIMEDOUT, no silent CWD-HEAD fallback); legacy autodetect `git rev-parse`/`git diff` (the 244a67d3 no-output-before-kill class).
- **FR-3** gate `verifyTestCoverage`: new `--skip-coverage` flag; skip the per-file spawn loop under `skipCoverage|skipTestRun|forceComplete|docs-only|empty filesChanged`; bound each spawn as defense-in-depth. Coverage is advisory (console-only) so this gates nothing.
- **FR-4** early already-MERGED probe (orchestrator): when a PR id resolves, bounded `gh pr view --json state,mergeCommit`; if MERGED, reconcile the QF to completed and return so `/checkin` re-runs on a shipped QF are idempotent (the f32a6df5 residual). Best-effort — any failure falls through to the now-bounded pipeline.
- **FR-5** 18 new unit tests (behavioral + source-assertion).

### Verification
- New tests: 18/18 pass. Full `complete-quick-fix` suite: 215/215, **0 regressions**.
- Runtime import smoke: all 5 modules load, cross-imports resolve, coverage-skip short-circuits.
- `--help` lists `--skip-coverage`.
- Scope-locked to the 5 cited files (`constants/verification/git-operations/cli/orchestrator.js`); the broader module-wide execSync sweep the RCA noted is deliberately out of scope.

Closes feedback `c2e1c9c3-ebd9-4c6d-97ac-fed80bc45c0d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@