### PR TITLE
feat(fleet): converge SD-dispatch eligibility on one shared classifier (fixture + human-action guards)

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -12,8 +12,38 @@
  *
  * Eligibility rules (an SD is INELIGIBLE for worker dispatch when):
  *   - sd_type === 'orchestrator' (a parent — auto-completes on its children; never worker-built), OR
+ *   - sd_key is a test-fixture key (SD-DEMO-* / SD-TEST-* — phantoms that surface transiently during
+ *     test runs and must never be routed onto a real worker), OR
+ *   - metadata.requires_human_action is truthy (a POSTGRES-001-class SD that a human must action), OR
  *   - any referenced dependency is not status='completed' (dep-blocked).
+ *
+ * The first three axes are DB-FREE (decidable from an already-loaded SD row), so they live in the pure
+ * synchronous classifyDispatchIneligibility() below and are shared by every dispatch consumer WITHOUT
+ * adding per-SD queries (SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001). Dependency satisfaction is the
+ * only DB-backed axis and remains path-specific (the sweep uses a local completedKeys set; the
+ * self_claim/evaluate paths use draftDepsSatisfied).
  */
+
+/** Test-fixture key families that must never be dispatched onto a worker. Word-boundary anchored so
+ *  real keys that merely START with these letters (SD-TESTABLE-*, SD-DEMONSTRATE-*) are NOT excluded. */
+const TEST_FIXTURE_KEY_RE = /^SD-(DEMO|TEST)\b/;
+
+/**
+ * PURE, synchronous, DB-free dispatch-ineligibility classifier for the non-dependency axes.
+ * Returns null when the SD is eligible on these axes, or a reason string when it is ineligible.
+ * Shared by evaluateDispatchEligibility (after its fetch), the sweep available-set filter, and the
+ * worker self_claim draft path — one source of truth so the classes cannot drift apart again.
+ *
+ * @param {{ sd_key?: string, sd_type?: string, metadata?: object }} sdRow  an already-loaded SD row
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required'}
+ */
+function classifyDispatchIneligibility(sdRow) {
+  const row = sdRow || {};
+  if (row.sd_type === 'orchestrator') return 'orchestrator_parent';
+  if (typeof row.sd_key === 'string' && TEST_FIXTURE_KEY_RE.test(row.sd_key)) return 'test_fixture_key';
+  if (row.metadata && row.metadata.requires_human_action) return 'human_action_required';
+  return null;
+}
 
 /**
  * Are ALL of this SD's dependencies satisfied (each referenced SD completed)?
@@ -65,12 +95,15 @@ async function draftDepsSatisfied(sb, sd, { throwOnError = false } = {}) {
 async function evaluateDispatchEligibility(sb, sdKey) {
   const { data, error } = await sb
     .from('strategic_directives_v2')
-    .select('sd_type, dependencies')
+    .select('sd_key, sd_type, dependencies, metadata')
     .eq('sd_key', sdKey)
     .maybeSingle();
   if (error) throw error;                                       // uncertain -> caller decides
   if (!data) return { eligible: false, reason: 'sd_not_found' }; // can't verify -> not dispatchable
-  if (data.sd_type === 'orchestrator') return { eligible: false, reason: 'orchestrator_parent' };
+  // Shared DB-free axes (orchestrator-parent, test-fixture, human-action). data carries sd_key from
+  // the query above so the fixture check resolves even though the caller passed sdKey separately.
+  const ineligible = classifyDispatchIneligibility({ ...data, sd_key: data.sd_key || sdKey });
+  if (ineligible) return { eligible: false, reason: ineligible };
   const depsOk = await draftDepsSatisfied(sb, data, { throwOnError: true }); // propagate dep-query errors
   return depsOk ? { eligible: true } : { eligible: false, reason: 'dep_blocked' };
 }
@@ -87,4 +120,4 @@ async function baselinedCandidateEligible(sb, sdKey) {
   }
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible };
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE };

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -28,7 +28,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
-const { evaluateDispatchEligibility } = require('../lib/fleet/claim-eligibility.cjs');
+const { evaluateDispatchEligibility, classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): single shared definition of which
 // classified session statuses count as "currently holding the SD claim" — used
 // by BOTH the available-to-claim filter and the worker-render filter below so
@@ -1297,12 +1297,14 @@ async function main() {
   const [childRes, standaloneRes] = await Promise.all([
     supabase
       .from('strategic_directives_v2')
-      .select('sd_key, title, status, current_phase, progress_percentage, dependencies')
+      // sd_type + metadata feed the shared classifyDispatchIneligibility gate below
+      // (SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001) with no extra round-trips.
+      .select('sd_key, title, status, current_phase, progress_percentage, dependencies, sd_type, metadata')
       .like('sd_key', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-%')
       .order('sd_key', { ascending: true }),
     supabase
       .from('strategic_directives_v2')
-      .select('sd_key, title, status, current_phase, progress_percentage, dependencies, priority')
+      .select('sd_key, title, status, current_phase, progress_percentage, dependencies, priority, sd_type, metadata')
       .in('status', ['draft', 'in_progress', 'ready', 'pending_approval'])
       .not('sd_key', 'like', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001%')
       .limit(20)
@@ -1324,6 +1326,14 @@ async function main() {
     .filter(c => {
       if (c.status === 'completed') return false;
       if (claimedByActive.has(c.sd_key)) return false;
+      // SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001: route the coordinator/sweep PUSH path through the
+      // SAME shared eligibility classifier the worker self_claim PULL path uses, so a test-fixture
+      // phantom (SD-DEMO-*/SD-TEST-*), an orchestrator PARENT, or a requires_human_action SD can never
+      // be advertised available or emitted as a WORK_ASSIGNMENT. Pure + synchronous on already-loaded
+      // rows (no N+1). Fail-soft per SD: a malformed row that throws is dropped, never aborts the sweep.
+      try {
+        if (classifyDispatchIneligibility(c) !== null) return false;
+      } catch { return false; }
       // QF-20260525-542: canonical SD-key blocker rule (was completedKeys.has(dep) on
       // raw elements — object-shaped placeholders never matched → false BLOCKED).
       const depKeys = parseSdDependencies(c.dependencies);

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -30,7 +30,7 @@ const ws = require('../lib/fleet/worker-status.cjs');
 const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cjs');
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
-const { draftDepsSatisfied, baselinedCandidateEligible } = require('../lib/fleet/claim-eligibility.cjs');
+const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
 const { NATO, COLORS, nextAvailable, isTestSessionId } = require('./assign-fleet-identities.cjs');
@@ -232,7 +232,9 @@ async function selfClaimDraftSd(sb, sessionId, base) {
   try {
     const { data: drafts } = await sb
       .from('strategic_directives_v2')
-      .select('sd_key, status, sd_type, priority, created_at, dependencies')
+      // metadata feeds the shared classifyDispatchIneligibility gate (the requires_human_action axis);
+      // sd_type already selected for the existing orchestrator exclusion.
+      .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata')
       .in('status', ['draft', 'active'])
       .is('claiming_session_id', null)
       .neq('sd_type', 'orchestrator')
@@ -243,6 +245,11 @@ async function selfClaimDraftSd(sb, sessionId, base) {
       (a, b) => (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9)
     );
     for (const d of ordered) {
+      // SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001: same shared classifier the baselined candidate-view
+      // tier (step 6) and the coordinator/sweep PUSH path use — the un-baselined draft tier must not
+      // self-claim a test-fixture phantom (SD-DEMO-*/SD-TEST-*) or a requires_human_action SD. (The
+      // orchestrator axis is also covered here, redundant with the .neq query filter above — harmless.)
+      if (classifyDispatchIneligibility(d) !== null) continue;
       if (!(await draftDepsSatisfied(sb, d))) continue; // skip dependency-blocked
       if (await isSdInFlight(sb, d.sd_key, sessionId)) continue; // dedup: skip SDs already started or live-foreign-held
       const claimed = await tryClaim(sb, d.sd_key, sessionId);

--- a/tests/dispatch-eligibility-convergence.test.js
+++ b/tests/dispatch-eligibility-convergence.test.js
@@ -1,0 +1,126 @@
+// SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001 — converge SD-dispatch eligibility onto one predicate.
+//
+// Coverage:
+//  (A) classifyDispatchIneligibility — the PURE shared gate all three dispatch consumers call
+//      (every reason + the eligible/null case + word-boundary false-positives).
+//  (B) evaluateDispatchEligibility delegates its non-dep checks to the pure gate (mock client) —
+//      proves the baselined PULL path + the sweep CLAIM_FIX path inherit the new reasons.
+//  (C) Static wiring pins: the sweep available-set filter and the worker-checkin draft self_claim
+//      path both invoke classifyDispatchIneligibility — proves FR-2/FR-3 are wired (cheap, deterministic,
+//      avoids fragile full-sweep mocking; the gate's own behavior is covered by (A)/(B)).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const { classifyDispatchIneligibility, evaluateDispatchEligibility, TEST_FIXTURE_KEY_RE } =
+  require(path.join(ROOT, 'lib', 'fleet', 'claim-eligibility.cjs'));
+
+describe('(A) classifyDispatchIneligibility — pure shared gate', () => {
+  it('returns null for an ordinary eligible SD', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-INFRA-X', sd_type: 'infrastructure' })).toBe(null);
+  });
+
+  it("flags orchestrator parents as 'orchestrator_parent'", () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-LEO-ORCH-Y', sd_type: 'orchestrator' })).toBe('orchestrator_parent');
+  });
+
+  it("flags test-fixture keys (SD-DEMO-* / SD-TEST-*) as 'test_fixture_key'", () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-DEMO-RACE' })).toBe('test_fixture_key');
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-TEST-FOO' })).toBe('test_fixture_key');
+  });
+
+  it('does NOT flag real keys that merely START with TEST/DEMO letters (word-boundary anchor)', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-TESTABLE-REAL' })).toBe(null);
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-DEMONSTRATE-VALUE' })).toBe(null);
+    // sanity: the exported regex itself encodes the boundary
+    expect(TEST_FIXTURE_KEY_RE.test('SD-TEST-X')).toBe(true);
+    expect(TEST_FIXTURE_KEY_RE.test('SD-TESTABLE-X')).toBe(false);
+  });
+
+  it("flags requires_human_action SDs as 'human_action_required'", () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: { requires_human_action: true } })).toBe('human_action_required');
+  });
+
+  it('treats absent/falsey requires_human_action as eligible', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: {} })).toBe(null);
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: { requires_human_action: false } })).toBe(null);
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X' })).toBe(null);
+  });
+
+  it('is null-safe on a missing/empty row', () => {
+    expect(classifyDispatchIneligibility(undefined)).toBe(null);
+    expect(classifyDispatchIneligibility({})).toBe(null);
+  });
+
+  it('orchestrator takes precedence, then fixture, then human-action (deterministic order)', () => {
+    // an orchestrator that is also a fixture key reports orchestrator first
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-TEST-ORCH', sd_type: 'orchestrator' })).toBe('orchestrator_parent');
+  });
+});
+
+// Minimal chainable mock of the supabase query builder used by evaluateDispatchEligibility:
+//   sb.from(t).select(c).eq('sd_key', k).maybeSingle()  and  .in('sd_key', keys) for deps.
+function mockClient(rowsByKey) {
+  return {
+    from() {
+      const ctx = { _eqKey: null, _inKeys: null };
+      const builder = {
+        select() { return builder; },
+        eq(_col, val) { ctx._eqKey = val; return builder; },
+        in(_col, vals) { ctx._inKeys = vals; return builder; },
+        async maybeSingle() { return { data: rowsByKey[ctx._eqKey] || null, error: null }; },
+        then(resolve) { // the dep query awaits the builder directly (.in(...))
+          const data = (ctx._inKeys || []).map(k => rowsByKey[k]).filter(Boolean).map(r => ({ sd_key: r.sd_key, status: r.status }));
+          return resolve({ data, error: null });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('(B) evaluateDispatchEligibility delegates non-dep checks to the shared gate', () => {
+  it('returns sd_not_found for an absent SD', async () => {
+    const sb = mockClient({});
+    expect(await evaluateDispatchEligibility(sb, 'SD-MISSING')).toEqual({ eligible: false, reason: 'sd_not_found' });
+  });
+
+  it('inherits test_fixture_key from the pure gate', async () => {
+    const sb = mockClient({ 'SD-DEMO-RACE': { sd_key: 'SD-DEMO-RACE', sd_type: 'infrastructure', dependencies: [] } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-DEMO-RACE')).toEqual({ eligible: false, reason: 'test_fixture_key' });
+  });
+
+  it('inherits human_action_required from the pure gate', async () => {
+    const sb = mockClient({ 'SD-H': { sd_key: 'SD-H', sd_type: 'infrastructure', dependencies: [], metadata: { requires_human_action: true } } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-H')).toEqual({ eligible: false, reason: 'human_action_required' });
+  });
+
+  it('still reports orchestrator_parent and eligible:true correctly', async () => {
+    const orch = mockClient({ 'SD-O': { sd_key: 'SD-O', sd_type: 'orchestrator', dependencies: [] } });
+    expect(await evaluateDispatchEligibility(orch, 'SD-O')).toEqual({ eligible: false, reason: 'orchestrator_parent' });
+    const ok = mockClient({ 'SD-OK': { sd_key: 'SD-OK', sd_type: 'infrastructure', dependencies: [] } });
+    expect(await evaluateDispatchEligibility(ok, 'SD-OK')).toEqual({ eligible: true });
+  });
+});
+
+describe('(C) wiring pins — all push/pull consumers call the shared gate', () => {
+  it('sweep available-set filter invokes classifyDispatchIneligibility (fail-soft)', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'scripts', 'stale-session-sweep.cjs'), 'utf8');
+    expect(src).toMatch(/classifyDispatchIneligibility/);
+    // imported from the shared module, not re-implemented
+    expect(src).toMatch(/require\(['"]\.\.\/lib\/fleet\/claim-eligibility\.cjs['"]\)/);
+    // the available batch query was enriched so the synchronous gate has sd_type + metadata
+    expect(src).toMatch(/sd_type, metadata/);
+  });
+
+  it('worker-checkin draft self_claim path invokes classifyDispatchIneligibility', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'scripts', 'worker-checkin.cjs'), 'utf8');
+    expect(src).toMatch(/classifyDispatchIneligibility\(d\)\s*!==\s*null/);
+  });
+});


### PR DESCRIPTION
@
## SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001

Three SD-dispatch consumers diverged on what counts as a dispatchable SD, and the coordinator/sweep WORK_ASSIGNMENT **push** path enforced no SD-eligibility predicate at all. This converges them onto one **pure** classifier and adds two ineligibility classes the queue can surface.

### Change
- **`lib/fleet/claim-eligibility.cjs`**: new pure, synchronous `classifyDispatchIneligibility(sdRow)` → `null | orchestrator_parent | test_fixture_key (/^SD-(DEMO|TEST)\b/, word-boundary anchored) | human_action_required (metadata.requires_human_action)`. `evaluateDispatchEligibility` delegates its non-dep checks to it — existing reason strings + signatures **byte-stable**.
- **`stale-session-sweep.cjs`**: available-set + WORK_ASSIGNMENT insert (derives from available) + children path gated on the shared classifier. Batch queries enriched with `sd_type, metadata` so the gate is synchronous on already-loaded rows — **no N+1**. Fail-soft per SD.
- **`worker-checkin.cjs`**: `selfClaimDraftSd` gated on the shared classifier (draft tier now matches the baselined candidate-view tier, which inherits the new reasons via `evaluateDispatchEligibility`).
- **14 tests**: all 4 reasons + word-boundary false-positives (`SD-TESTABLE-`/`SD-DEMONSTRATE-` NOT excluded) + delegation (mock client) + sweep/draft wiring pins. 29/29 incl. smoke.

### Framing
Preventive drift-hardening — verified **0 live dispatchable targets today** (all `SD-DEMO`/`SD-TEST` fixture keys terminal; the single `requires_human_action` SD is deferred). Value = preventing the writer/consumer asymmetry (`PAT-WRITER-CONSUMER-ASYMMETRY`) that already leaked an orchestrator **parent** once from recurring for the fixture + human-action classes.

### Coordination
Same-file sibling **SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001** (in_progress) edits **disjoint functions** in `stale-session-sweep.cjs`; it rebases onto this smaller, merged change. Align its `SD-TEST-%` filter to this shared classifier as a follow-up.

### Gates
LEAD-TO-PLAN 96 · PLAN-TO-EXEC 98 · EXEC-TO-PLAN 94 · PLAN-TO-LEAD 97 · TESTING 29/29 · retro 90 · heal 97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@