### PR TITLE
chore(SD-FDBK-INFRA-AUTO-PUSH-WIP-001): add npm prepark-wip entry (WIRE_CHECK reachability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,6 +370,7 @@
     "session:worktree": "node scripts/session-worktree.js",
     "session:check-concurrency": "node scripts/session-check-concurrency.js",
     "session:park": "node scripts/park-worker.cjs",
+    "prepark-wip": "node scripts/prepark-wip.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "engine:demo": "node scripts/auto-exec-engine-demo.mjs",
     "checkout-sync:demo": "node scripts/auto-exec-checkout-sync-demo.mjs",


### PR DESCRIPTION
Follow-up to #4531. `scripts/prepark-wip.cjs` is invoked from the loop directive + role-hook prose (not static call-graph edges), so WIRE_CHECK at LEAD-FINAL flagged it and its `lib/fleet/prepark-wip.cjs` + `branch-ahead.cjs` requires as unreachable. This adds a `package.json` script target — the gate treats package.json scripts as entry points — making `npm run prepark-wip` a first-class, discoverable command and restoring reachability.

One line. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
