### PR TITLE
fix(QF-20260610-623): Adam inbound-directive auto-ack residual: non-INFO coordinator directives drained on poll + no two-stage monitor

### DIFF
--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -104,9 +104,14 @@ function classifyInboxMessage(msg, opts = {}) {
   // through to the :105 carve-out below (surfaces, read_at left NULL) so a reply arriving after
   // a sync await times out is recovered by adam-advisory.cjs's durable `replies` reader.
   if (twoWayOn && isInfo && p.kind === 'coordinator_reply' && !amAdam) return { skip: true };
-  // Adam session: do NOT auto-drain a coordinator-originated INFO directive — leave read_at NULL
-  // so the Adam inbox monitor (read_at IS NULL) keeps surfacing it until Adam acts on it.
-  if (amAdam && isInfo && (msg.sender_type === 'orchestrator' || msg.sender_type === 'coordinator')) {
+  // Adam session: do NOT auto-drain a coordinator-originated directive of ANY message_type —
+  // leave read_at NULL so the Adam inbox monitor (read_at IS NULL) keeps surfacing it until Adam
+  // acts on it. QF-20260610-623: this carve-out was gated on isInfo, so a NON-INFO coordinator->Adam
+  // directive (e.g. COACHING — a live type per lib/coordinator/adam-action-ack.cjs:291 +
+  // scripts/coordinator-comms-check.mjs:84) fell through to the default drain (markRead/markAck:true)
+  // and was auto-acked on the next PostToolUse poll before Adam read it. Drop the isInfo gate so the
+  // carve-out fires for every message_type; INFO behavior is unchanged (it already matched here).
+  if (amAdam && (msg.sender_type === 'orchestrator' || msg.sender_type === 'coordinator')) {
     return { skip: false, markRead: false, markAck: false };
   }
   // Actionable idle rows — surface but do NOT mark read/ack on poll; re-surface until the agent

--- a/scripts/read-adam-directives.cjs
+++ b/scripts/read-adam-directives.cjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * read-adam-directives.cjs — read-only, two-stage peek at coordinator/orchestrator
+ * directives sent TO Adam that are not yet acknowledged.
+ * QF-20260610-623 (FR-3).
+ *
+ * The inbox hook + adam-advisory drainReplies only surface rows with read_at IS NULL, so
+ * once read_at is stamped a directive is hidden permanently even if Adam never ACTED on it.
+ * This monitor closes that gap: it surfaces session_coordination rows targeting the Adam
+ * session from a coordinator/orchestrator sender where acknowledged_at IS NULL — i.e. the
+ * READ-but-UNACKNOWLEDGED tier — so a directive whose read_at got stamped (by any poll) is
+ * still recoverable until Adam genuinely acknowledges it. Stamps NOTHING (neither read_at
+ * nor acknowledged_at); re-running shows the same rows until they are acked. Mirrors the
+ * non-mutating read-adam-advisories.cjs.
+ *
+ * Usage: node scripts/read-adam-directives.cjs
+ */
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+
+const DIRECTIVE_SENDERS = ['coordinator', 'orchestrator'];
+
+// Resolve the Adam session id: prefer CLAUDE_SESSION_ID when it is the Adam session, else fall
+// back to the most-recent active session tagged metadata.role='adam'. Returns null if none.
+async function resolveAdamSessionId(supabase) {
+  const envId = process.env.CLAUDE_SESSION_ID;
+  if (envId) {
+    const { data } = await supabase
+      .from('claude_sessions').select('session_id, metadata').eq('session_id', envId).single();
+    if (data && data.metadata && data.metadata.role === 'adam') return envId;
+  }
+  const { data: rows } = await supabase
+    .from('claude_sessions')
+    .select('session_id, status, updated_at, metadata')
+    .eq('metadata->>role', 'adam')
+    .order('updated_at', { ascending: false })
+    .limit(1);
+  return rows && rows.length ? rows[0].session_id : null;
+}
+
+async function main() {
+  let supabase;
+  try { supabase = createSupabaseServiceClient(); }
+  catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+
+  const adamId = await resolveAdamSessionId(supabase);
+  if (!adamId) { console.log('ADAM DIRECTIVE PEEK: no active Adam session found — nothing to surface.'); return; }
+
+  const { data: rows, error } = await supabase
+    .from('session_coordination')
+    .select('id, message_type, subject, body, payload, sender_type, sender_session, created_at, read_at, acknowledged_at')
+    .eq('target_session', adamId)
+    .in('sender_type', DIRECTIVE_SENDERS)
+    .is('acknowledged_at', null)
+    .order('created_at', { ascending: true })
+    .limit(20);
+  if (error) { console.error('ERROR: directive query failed:', error.message); process.exit(1); }
+
+  console.log('ADAM DIRECTIVE PEEK — read-but-unacknowledged (read-only — stamps nothing)');
+  console.log('─'.repeat(60));
+  if (!rows || !rows.length) { console.log('  (no unacknowledged coordinator/orchestrator directives to Adam)'); return; }
+
+  console.log(`  ${rows.length} unacknowledged directive(s):`);
+  for (const r of rows) {
+    const stage = r.read_at ? 'READ-unacked' : 'unread';
+    const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    const body = (r.body || (r.payload && r.payload.body) || r.subject || '').replace(/\n/g, ' ');
+    console.log(`  • ${r.id}`);
+    console.log(`      ${r.sender_type} | ${r.message_type} | ${stage} | ${ageStr} ago`);
+    console.log(`      ${body}`);
+  }
+  console.log('');
+  console.log('  These rows stay visible until acknowledged_at is stamped (genuine Adam action).');
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}
+
+module.exports = { resolveAdamSessionId, DIRECTIVE_SENDERS };

--- a/tests/unit/coordination-inbox-read-ack-split.test.js
+++ b/tests/unit/coordination-inbox-read-ack-split.test.js
@@ -64,4 +64,18 @@ describe('classifyInboxMessage', () => {
     const v = classifyInboxMessage({ message_type: 'PRIORITY_CHANGE', payload: {}, sender_type: 'orchestrator' }, { isIdle: false });
     expect(v).toEqual({ skip: false, markRead: true, markAck: true });
   });
+
+  // QF-20260610-623: a NON-INFO coordinator->Adam directive (COACHING is a live type) must NOT be
+  // auto-drained by the poll. Before the fix the Adam carve-out was isInfo-gated, so a COACHING
+  // directive fell through to the default drain (markRead/markAck:true) and was acked before Adam
+  // read it. After the fix it stays UNREAD (read_at NULL) like the INFO case.
+  it('QF-623: a COACHING (non-INFO) coordinator->Adam directive stays UNREAD for Adam', () => {
+    const coaching = { message_type: 'COACHING', payload: { kind: 'comms_check' }, sender_type: 'coordinator' };
+    expect(classifyInboxMessage(coaching, { amAdam: true })).toEqual({ skip: false, markRead: false, markAck: false });
+    // orchestrator sender, same protection
+    const orchDirective = { message_type: 'COACHING', payload: {}, sender_type: 'orchestrator' };
+    expect(classifyInboxMessage(orchDirective, { amAdam: true })).toEqual({ skip: false, markRead: false, markAck: false });
+    // a NON-Adam session still drains the same COACHING row on display (byte-identical legacy behavior)
+    expect(classifyInboxMessage(coaching, { amAdam: false })).toEqual({ skip: false, markRead: true, markAck: true });
+  });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260610-623

**Type:** bug
**Severity:** high

### Issue Description
Residual after SD-LEO-FIX-FIX-COORDINATION-INBOX-001 (feedback b9c4946f; verified live by Adam workflow wf_d63768fe-5f7). The Adam carve-out in scripts/hooks/coordination-inbox.cjs classifyInboxMessage (line ~109) is gated on isInfo, so a coordinator->Adam directive with a NON-INFO message_type (e.g. COACHING — a LIVE type per lib/coordinator/adam-action-ack.cjs:291 + scripts/coordinator-comms-check.mjs:84) falls through to the default branch (lines 117-118) returning {markRead:true,markAck:true} and is auto-acked on the next PostToolUse poll before Adam reads it. RESIDUAL B: drainReplies (adam-advisory.cjs:115-123) surfaces ONLY coordinator_reply with read_at IS NULL; there is no two-stage READ-but-UNACKNOWLEDGED inbound monitor, so any read_at stamp hides the directive permanently. FIX: (FR-1) make the amAdam + sender_type in {orchestrator,coordinator} carve-out fire for ALL message_types (return markRead:false/markAck:false), INFO behavior unchanged; (FR-2) add a non-INFO (COACHING) test case to tests/unit/coordination-inbox-read-ack-split.test.js; (FR-3) add a read-only inbound monitor surfacing coordinator/orchestrator->Adam rows where acknowledged_at IS NULL (two-stage, stamps nothing), mirroring read-adam-advisories.cjs. Additive, fail-soft, NO schema change (read_at/acknowledged_at already exist). Worker (non-Adam) drain behavior must stay byte-identical. Source feedback id: b9c4946f-e9c2-4a36-9adc-b366bb1d4c55.


### Expected Behavior
Coordinator directives to Adam (any message_type) stay unread/unacked until Adam genuinely actions them; a two-stage monitor recovers read-but-unacked directives

### Actual Behavior
Non-INFO coordinator->Adam directives auto-acked on poll; Adam's UNREAD-only monitor shows 0; directives silently missed (operator had to verbally relay this session)

### Changes
- **Files Changed:** 3
  - scripts/hooks/coordination-inbox.cjs
  - scripts/read-adam-directives.cjs
  - tests/unit/coordination-inbox-read-ack-split.test.js
- **LOC:** 121 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol