### PR TITLE
fix(SD-FDBK-FIX-FIX-SMOKE-TEST-001): smoke gate metadata fallback + auto-hoist + column-naming messages

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
@@ -15,13 +15,75 @@ import { isLightweightSDType, detectCodeProduction } from '../../../validation/s
 import { safeTruncate } from '../../../../../../lib/utils/safe-truncate.js';
 import { isAllPlaceholderSmokeSteps } from '../../../smoke-test-defaults.js';
 
+/** Parse a smoke_test_steps value that may be a JSONB array or a TEXT-column JSON string. */
+function parseStepsValue(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try { const parsed = JSON.parse(value); return Array.isArray(parsed) ? parsed : []; }
+    catch (e) { console.debug('[SmokeTestSpec] JSON parse suppressed:', e?.message || e); return []; }
+  }
+  return [];
+}
+
+/**
+ * Resolve smoke test steps with a metadata fallback.
+ *
+ * SD-FDBK-FIX-FIX-SMOKE-TEST-001: the canonical location is the TOP-LEVEL
+ * strategic_directives_v2.smoke_test_steps column, but workers remediating a
+ * gate failure historically wrote metadata.smoke_test_steps (the failure
+ * message never named the column — ~20 gate fails/7d). Prefer top-level;
+ * fall back to metadata and report the source so the caller can warn + hoist.
+ *
+ * @param {Object} sd - Strategic Directive
+ * @returns {{steps: Array, source: 'top_level'|'metadata'|'none'}}
+ */
+export function resolveSmokeTestSteps(sd) {
+  const topLevel = parseStepsValue(sd.smoke_test_steps);
+  if (topLevel.length > 0) return { steps: topLevel, source: 'top_level' };
+  const fromMetadata = parseStepsValue(sd.metadata?.smoke_test_steps);
+  if (fromMetadata.length > 0) return { steps: fromMetadata, source: 'metadata' };
+  return { steps: [], source: 'none' };
+}
+
+/**
+ * Hoist metadata-stranded steps into the canonical top-level column.
+ * Idempotent and guarded: pre-reads the live row and writes ONLY when the
+ * live top-level column is still empty. Fail-open — a write error never
+ * blocks validation (the steps already validated from the fallback read).
+ */
+async function hoistStepsToTopLevel(supabase, sd, steps) {
+  const filterCol = sd.id ? 'id' : 'sd_key';
+  const filterVal = sd.id || sd.sd_key;
+  if (!filterVal) return { hoisted: false, reason: 'no id/sd_key on SD object' };
+  try {
+    const { data: live, error: readErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('smoke_test_steps')
+      .eq(filterCol, filterVal)
+      .maybeSingle();
+    if (readErr) return { hoisted: false, reason: readErr.message };
+    if (parseStepsValue(live?.smoke_test_steps).length > 0) {
+      return { hoisted: false, reason: 'live top-level column already populated' };
+    }
+    const { error: writeErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({ smoke_test_steps: steps })
+      .eq(filterCol, filterVal);
+    if (writeErr) return { hoisted: false, reason: writeErr.message };
+    return { hoisted: true };
+  } catch (e) {
+    return { hoisted: false, reason: e?.message || String(e) };
+  }
+}
+
 /**
  * Validate smoke test specification
  *
  * @param {Object} sd - Strategic Directive
+ * @param {Object} [supabase] - Optional client enabling the metadata→top-level hoist
  * @returns {Object} Validation result
  */
-export async function validateSmokeTestSpecification(sd) {
+export async function validateSmokeTestSpecification(sd, supabase) {
   const sdType = (sd.sd_type || 'feature').toLowerCase();
 
   // SD-LEO-FIX-COMPLETION-WORKFLOW-001: Use centralized SD type policy
@@ -34,16 +96,16 @@ export async function validateSmokeTestSpecification(sd) {
       console.log(`   ℹ️  Reason: ${detection.reason}`);
 
       if (detection.producesCode) {
-        console.log(`   ⚠️  Code-producing infrastructure SD — smoke test specification REQUIRED`);
+        console.log('   ⚠️  Code-producing infrastructure SD — smoke test specification REQUIRED');
         // Fall through to the normal validation below (do NOT return early)
       } else {
-        console.log(`   ℹ️  Non-code infrastructure SD — smoke test specification not required`);
+        console.log('   ℹ️  Non-code infrastructure SD — smoke test specification not required');
         return {
           pass: true,
           score: 100,
           max_score: 100,
           issues: [],
-          warnings: [`Smoke test skipped for non-code infrastructure SD`],
+          warnings: ['Smoke test skipped for non-code infrastructure SD'],
           details: { skipped: true, reason: 'non-code infrastructure SD exempt', codeDetection: detection }
         };
       }
@@ -62,22 +124,38 @@ export async function validateSmokeTestSpecification(sd) {
 
   console.log(`   SD Type: ${sdType} - smoke test specification REQUIRED`);
 
-  // Check if smoke_test_steps exists and is valid
-  // Handle TEXT column returning JSON string (not pre-parsed JSONB)
-  let smokeTestSteps = sd.smoke_test_steps || [];
-  if (typeof smokeTestSteps === 'string') {
-    try { smokeTestSteps = JSON.parse(smokeTestSteps); } catch (e) { console.debug('[SmokeTestSpec] JSON parse suppressed:', e?.message || e); smokeTestSteps = []; }
-  }
-  const isArray = Array.isArray(smokeTestSteps);
-  const stepCount = isArray ? smokeTestSteps.length : 0;
+  // Check if smoke_test_steps exists and is valid.
+  // SD-FDBK-FIX-FIX-SMOKE-TEST-001: resolve with metadata fallback — the gate
+  // reads the TOP-LEVEL column, but steps stranded in metadata.smoke_test_steps
+  // are recovered (warn + hoist) instead of failing generically.
+  const { steps: smokeTestSteps, source: stepsSource } = resolveSmokeTestSteps(sd);
+  const stepCount = smokeTestSteps.length;
 
-  console.log(`   Smoke test steps: ${stepCount} defined`);
+  console.log(`   Smoke test steps: ${stepCount} defined${stepsSource === 'metadata' ? ' (in metadata.smoke_test_steps — see warning)' : ''}`);
+
+  const sourceWarnings = [];
+  if (stepsSource === 'metadata') {
+    console.log('   ⚠️  Steps found in metadata.smoke_test_steps — the canonical location is the TOP-LEVEL strategic_directives_v2.smoke_test_steps column.');
+    if (supabase) {
+      const hoist = await hoistStepsToTopLevel(supabase, sd, smokeTestSteps);
+      if (hoist.hoisted) {
+        console.log('   ✅ Auto-hoisted steps into the top-level strategic_directives_v2.smoke_test_steps column.');
+        sourceWarnings.push('smoke_test_steps were auto-hoisted from metadata.smoke_test_steps into the canonical top-level column');
+      } else {
+        console.log(`   ⚠️  Auto-hoist skipped (${hoist.reason}) — move them manually to the top-level column.`);
+        sourceWarnings.push(`smoke_test_steps read from metadata.smoke_test_steps (hoist skipped: ${hoist.reason}) — write future steps to the top-level strategic_directives_v2.smoke_test_steps column`);
+      }
+    } else {
+      sourceWarnings.push('smoke_test_steps read from metadata.smoke_test_steps — move them to the top-level strategic_directives_v2.smoke_test_steps column (no DB client available for auto-hoist)');
+    }
+  }
 
   if (stepCount === 0) {
     console.log('   ❌ BLOCKING: No smoke test steps defined');
     console.log('\n   LEAD Question 9: "Describe the 30-second demo that proves this SD delivered value."');
     console.log('   If you cannot answer this question, the SD is too vague.\n');
-    console.log('   Required: Add smoke_test_steps array with 3-5 user-observable steps');
+    console.log('   Required: Add smoke_test_steps (3-5 user-observable steps) to the TOP-LEVEL');
+    console.log('   strategic_directives_v2.smoke_test_steps column — NOT metadata.smoke_test_steps.');
     console.log('   Example:');
     console.log('   [');
     console.log('     { "step_number": 1, "instruction": "Navigate to /dashboard", "expected_outcome": "Dashboard loads with venture list" },');
@@ -90,17 +168,17 @@ export async function validateSmokeTestSpecification(sd) {
       score: 0,
       max_score: 100,
       issues: [
-        'BLOCKING: Feature SD requires smoke_test_steps for LEAD approval',
+        'BLOCKING: Feature SD requires smoke_test_steps for LEAD approval — write them to the top-level strategic_directives_v2.smoke_test_steps column (NOT metadata.smoke_test_steps)',
         'Answer LEAD Q9: "Describe the 30-second demo that proves this SD delivered value"'
       ],
       warnings: [],
-      remediation: 'Add smoke_test_steps JSONB array with 3-5 user-observable verification steps'
+      remediation: 'Add a smoke_test_steps JSONB array with 3-5 user-observable verification steps to the top-level strategic_directives_v2.smoke_test_steps column (NOT metadata.smoke_test_steps)'
     };
   }
 
   // Validate step quality
   const issues = [];
-  const warnings = [];
+  const warnings = [...sourceWarnings];
 
   if (stepCount < 3) {
     warnings.push(`Only ${stepCount} smoke test steps - recommend 3-5 for comprehensive verification`);
@@ -160,6 +238,7 @@ export async function validateSmokeTestSpecification(sd) {
     details: {
       stepCount,
       validSteps,
+      stepsSource,
       aiValidation: aiValidation?.isConcreteEnough ?? null
     }
   };
@@ -168,17 +247,19 @@ export async function validateSmokeTestSpecification(sd) {
 /**
  * Create the smoke test specification gate
  *
+ * @param {Object} [supabase] - Optional client enabling the metadata→top-level
+ *   auto-hoist (SD-FDBK-FIX-FIX-SMOKE-TEST-001). Omitted => pure validation.
  * @returns {Object} Gate configuration
  */
-export function createSmokeTestSpecificationGate() {
+export function createSmokeTestSpecificationGate(supabase) {
   return {
     name: 'SMOKE_TEST_SPECIFICATION',
     validator: async (ctx) => {
       console.log('\n👤 GATE: Smoke Test Specification (LEO v4.4.0)');
       console.log('-'.repeat(50));
-      return validateSmokeTestSpecification(ctx.sd);
+      return validateSmokeTestSpecification(ctx.sd, supabase);
     },
     required: true,
-    remediation: 'Add smoke_test_steps array with 3-5 user-observable verification steps. Example: [{step_number: 1, instruction: "Navigate to /dashboard", expected_outcome: "Dashboard loads with venture list visible"}]'
+    remediation: 'Add a smoke_test_steps array with 3-5 user-observable verification steps to the TOP-LEVEL strategic_directives_v2.smoke_test_steps column (NOT metadata.smoke_test_steps). Example: [{step_number: 1, instruction: "Navigate to /dashboard", expected_outcome: "Dashboard loads with venture list visible"}]'
   };
 }

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -115,7 +115,9 @@ export class LeadToPlanExecutor extends BaseExecutor {
     gates.push(createBaselineDebtGate(this.supabase));
 
     // Smoke Test Specification Gate (LEO v4.4.0)
-    gates.push(createSmokeTestSpecificationGate());
+    // SD-FDBK-FIX-FIX-SMOKE-TEST-001: inject supabase so metadata-stranded
+    // smoke_test_steps auto-hoist into the canonical top-level column.
+    gates.push(createSmokeTestSpecificationGate(this.supabase));
 
     // Placeholder Content Detection Gate (SD-LEO-INFRA-PROTOCOL-FILE-STATE-001)
     // Warning-only: detects default template text from leo-create-sd.js

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -261,7 +261,7 @@ async function autoFixDeficiencies(supabase, sd) {
  * LEAD-TO-PLAN: Check SD JSONB field completeness
  * Catches: PAT-HF-LEADTOPLAN (SD does not meet completeness standards)
  */
-function checkLeadToPlanPrereqs(sd) {
+export function checkLeadToPlanPrereqs(sd) {
   const issues = [];
   const sdType = sd.sd_type || 'default';
   const threshold = SD_TYPE_THRESHOLDS[sdType] || DEFAULT_THRESHOLD;
@@ -324,13 +324,37 @@ function checkLeadToPlanPrereqs(sd) {
       remediation: 'No action required — informational entry only.'
     });
   } else {
-    const smokeSteps = sd.smoke_test_steps;
+    // SD-FDBK-FIX-FIX-SMOKE-TEST-001: tolerate a TEXT column returning a JSON string.
+    let smokeSteps = sd.smoke_test_steps;
+    if (typeof smokeSteps === 'string') {
+      try { smokeSteps = JSON.parse(smokeSteps); } catch { smokeSteps = null; }
+    }
     if (!smokeSteps || !Array.isArray(smokeSteps) || smokeSteps.length === 0) {
-      issues.push({
-        code: 'SMOKE_TEST_MISSING',
-        message: 'No smoke_test_steps defined',
-        remediation: 'Add smoke_test_steps: [{instruction: "...", expected_outcome: "..."}]'
-      });
+      // SD-FDBK-FIX-FIX-SMOKE-TEST-001: distinguish stranded-in-metadata from
+      // truly-missing — the SMOKE_TEST_SPECIFICATION gate reads the TOP-LEVEL
+      // strategic_directives_v2.smoke_test_steps column, but workers remediating
+      // a failure historically wrote metadata.smoke_test_steps.
+      let metaSteps = sd.metadata?.smoke_test_steps;
+      if (typeof metaSteps === 'string') {
+        try { metaSteps = JSON.parse(metaSteps); } catch { metaSteps = null; }
+      }
+      if (Array.isArray(metaSteps) && metaSteps.length > 0) {
+        const sdKey = sd.sd_key || sd.id || 'SD-XXX-001';
+        issues.push({
+          code: 'SMOKE_TEST_IN_METADATA',
+          message: `Found ${metaSteps.length} smoke_test_steps in metadata.smoke_test_steps — the SMOKE_TEST_SPECIFICATION gate reads the TOP-LEVEL strategic_directives_v2.smoke_test_steps column`,
+          remediation: [
+            'Hoist the steps into the top-level column (the gate also auto-hoists at execute time):',
+            `  node -e "require('dotenv').config(); const {createClient}=require('@supabase/supabase-js'); const s=createClient(process.env.SUPABASE_URL||process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY); s.from('strategic_directives_v2').select('metadata').eq('sd_key','${sdKey}').single().then(({data})=>s.from('strategic_directives_v2').update({smoke_test_steps:data.metadata.smoke_test_steps}).eq('sd_key','${sdKey}')).then(r=>console.log(r.error||'Hoisted'));"`
+          ].join('\n')
+        });
+      } else {
+        issues.push({
+          code: 'SMOKE_TEST_MISSING',
+          message: 'No smoke_test_steps defined',
+          remediation: 'Add smoke_test_steps: [{instruction: "...", expected_outcome: "..."}] to the TOP-LEVEL strategic_directives_v2.smoke_test_steps column (NOT metadata.smoke_test_steps)'
+        });
+      }
     } else {
       const canonicalized = smokeSteps.map(canonicalizeSmokeStep);
       const validSteps = canonicalized.filter(s => s.instruction && s.expected_outcome);

--- a/tests/unit/smoke-test-specification-metadata-fallback.test.js
+++ b/tests/unit/smoke-test-specification-metadata-fallback.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Keep the gate's optional AI validator out of the unit test (no LLM call).
+vi.mock('../../scripts/modules/handoff/human-verification-validator.js', () => ({}));
+
+import {
+  resolveSmokeTestSteps,
+  validateSmokeTestSpecification,
+  createSmokeTestSpecificationGate,
+} from '../../scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js';
+import { checkLeadToPlanPrereqs } from '../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+// SD-FDBK-FIX-FIX-SMOKE-TEST-001: the gate reads the TOP-LEVEL
+// strategic_directives_v2.smoke_test_steps column; steps stranded in
+// metadata.smoke_test_steps must be recovered (fallback + hoist), and every
+// failure message must name the column.
+
+const REAL_STEPS = [
+  { step_number: 1, instruction: 'Open /chairman/ventures', expected_outcome: 'Venture list renders with live telemetry badges' },
+  { step_number: 2, instruction: 'Click the CronGenius row', expected_outcome: 'Detail pane shows stage history' },
+  { step_number: 3, instruction: 'Run node scripts/example-probe.js', expected_outcome: 'PROBE_OK printed with a non-zero count' },
+];
+
+/** Mock supabase capturing the hoist read+write chain. */
+function mockSupabase({ liveTopLevel = null, readError = null, writeError = null } = {}) {
+  const calls = { updates: [], filters: [] };
+  const chain = (result) => ({
+    select: vi.fn().mockReturnThis(),
+    update: vi.fn(function (payload) { calls.updates.push(payload); return this; }),
+    eq: vi.fn(function (col, val) { calls.filters.push([col, val]); return this; }),
+    maybeSingle: vi.fn(async () => result),
+  });
+  const client = {
+    from: vi.fn(() => chain({ data: readError ? null : { smoke_test_steps: liveTopLevel }, error: readError })),
+  };
+  // update path resolves like supabase-js: awaiting the builder returns {error}
+  const origFrom = client.from;
+  client.from = vi.fn(() => {
+    const c = origFrom();
+    // make the update().eq() chain awaitable
+    c.eq = vi.fn(function (col, val) {
+      calls.filters.push([col, val]);
+      const self = this;
+      return Object.assign(Object.create(Object.getPrototypeOf(self)), self, {
+        eq: c.eq,
+        maybeSingle: c.maybeSingle,
+        then: (resolve) => resolve({ error: writeError }),
+      });
+    });
+    return c;
+  });
+  return { client, calls };
+}
+
+describe('resolveSmokeTestSteps', () => {
+  it('prefers the top-level column', () => {
+    const sd = { smoke_test_steps: REAL_STEPS, metadata: { smoke_test_steps: [{ instruction: 'x', expected_outcome: 'y' }] } };
+    const { steps, source } = resolveSmokeTestSteps(sd);
+    expect(source).toBe('top_level');
+    expect(steps).toHaveLength(3);
+  });
+
+  it('falls back to metadata.smoke_test_steps when top-level is empty', () => {
+    const sd = { smoke_test_steps: null, metadata: { smoke_test_steps: REAL_STEPS } };
+    const { steps, source } = resolveSmokeTestSteps(sd);
+    expect(source).toBe('metadata');
+    expect(steps).toHaveLength(3);
+  });
+
+  it('parses string-JSON in both locations; malformed metadata JSON -> none', () => {
+    expect(resolveSmokeTestSteps({ smoke_test_steps: JSON.stringify(REAL_STEPS) }).source).toBe('top_level');
+    const meta = { smoke_test_steps: null, metadata: { smoke_test_steps: JSON.stringify(REAL_STEPS) } };
+    expect(resolveSmokeTestSteps(meta).source).toBe('metadata');
+    expect(resolveSmokeTestSteps({ smoke_test_steps: '{not json', metadata: { smoke_test_steps: '[broken' } }).source).toBe('none');
+  });
+});
+
+describe('validateSmokeTestSpecification — metadata fallback (TS-1, TS-2, TS-3, TS-6)', () => {
+  it('TS-1: passes via fallback and hoists into the empty top-level column', async () => {
+    const { client, calls } = mockSupabase({ liveTopLevel: null });
+    const sd = { sd_type: 'feature', sd_key: 'SD-TEST-001', smoke_test_steps: null, metadata: { smoke_test_steps: REAL_STEPS } };
+    const result = await validateSmokeTestSpecification(sd, client);
+    expect(result.pass).toBe(true);
+    expect(result.details.stepsSource).toBe('metadata');
+    expect(result.warnings.join(' ')).toMatch(/auto-hoisted|top-level/i);
+    expect(calls.updates).toHaveLength(1);
+    expect(calls.updates[0].smoke_test_steps).toEqual(REAL_STEPS);
+  });
+
+  it('TS-2: passes via fallback without a client (manual-hoist warning, no throw)', async () => {
+    const sd = { sd_type: 'feature', sd_key: 'SD-TEST-002', smoke_test_steps: null, metadata: { smoke_test_steps: REAL_STEPS } };
+    const result = await validateSmokeTestSpecification(sd);
+    expect(result.pass).toBe(true);
+    expect(result.warnings.join(' ')).toMatch(/top-level strategic_directives_v2\.smoke_test_steps/);
+  });
+
+  it('TS-1b: hoist is skipped when the live top-level column is already populated', async () => {
+    const { client, calls } = mockSupabase({ liveTopLevel: REAL_STEPS });
+    const sd = { sd_type: 'feature', sd_key: 'SD-TEST-003', smoke_test_steps: null, metadata: { smoke_test_steps: REAL_STEPS } };
+    const result = await validateSmokeTestSpecification(sd, client);
+    expect(result.pass).toBe(true);
+    expect(calls.updates).toHaveLength(0);
+    expect(result.warnings.join(' ')).toMatch(/hoist skipped/i);
+  });
+
+  it('TS-3: top-level wins — no hoist, no fallback warning', async () => {
+    const { client, calls } = mockSupabase({});
+    const sd = { sd_type: 'feature', sd_key: 'SD-TEST-004', smoke_test_steps: REAL_STEPS, metadata: { smoke_test_steps: [{ instruction: 'junk', expected_outcome: 'junk' }] } };
+    const result = await validateSmokeTestSpecification(sd, client);
+    expect(result.pass).toBe(true);
+    expect(result.details.stepsSource).toBe('top_level');
+    expect(calls.updates).toHaveLength(0);
+    expect(result.warnings.join(' ')).not.toMatch(/metadata\.smoke_test_steps/);
+  });
+
+  it('TS-6: malformed metadata string-JSON falls through to the zero-steps failure', async () => {
+    const sd = { sd_type: 'feature', sd_key: 'SD-TEST-005', smoke_test_steps: null, metadata: { smoke_test_steps: '[broken json' } };
+    const result = await validateSmokeTestSpecification(sd);
+    expect(result.pass).toBe(false);
+  });
+});
+
+describe('zero-steps failure names the exact column (TS-4)', () => {
+  it('issues and remediation cite top-level and NOT metadata.smoke_test_steps', async () => {
+    const sd = { sd_type: 'feature', sd_key: 'SD-TEST-006', smoke_test_steps: null, metadata: {} };
+    const result = await validateSmokeTestSpecification(sd);
+    expect(result.pass).toBe(false);
+    const text = result.issues.join(' ') + ' ' + result.remediation;
+    expect(text).toMatch(/top-level strategic_directives_v2\.smoke_test_steps/);
+    expect(text).toMatch(/NOT metadata\.smoke_test_steps/);
+  });
+
+  it('gate factory remediation names the column location', () => {
+    const gate = createSmokeTestSpecificationGate();
+    expect(gate.remediation).toMatch(/TOP-LEVEL strategic_directives_v2\.smoke_test_steps/);
+    expect(gate.remediation).toMatch(/NOT metadata\.smoke_test_steps/);
+  });
+});
+
+describe('lightweight skip unchanged (TS-7)', () => {
+  it('bugfix-type SD with no steps still skips at 100', async () => {
+    const result = await validateSmokeTestSpecification({ sd_type: 'bugfix', smoke_test_steps: null, metadata: {} });
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.details.skipped).toBe(true);
+  });
+});
+
+describe('prerequisite-preflight SMOKE_TEST_IN_METADATA (TS-5)', () => {
+  const baseSd = {
+    sd_key: 'SD-TEST-007',
+    sd_type: 'feature',
+    description: Array(60).fill('word').join(' '),
+    success_criteria: [{ criterion: 'c', measure: 'm' }],
+    key_changes: [{ change: 'c' }],
+    risks: [{ risk: 'r', mitigation: 'm' }],
+    strategic_objectives: ['o1'],
+    success_metrics: [{ metric: 'm', target: 't' }],
+  };
+
+  it('metadata-only steps => SMOKE_TEST_IN_METADATA with a hoist one-liner (not SMOKE_TEST_MISSING)', () => {
+    const issues = checkLeadToPlanPrereqs({ ...baseSd, smoke_test_steps: null, metadata: { smoke_test_steps: REAL_STEPS } });
+    const codes = issues.map(i => i.code);
+    expect(codes).toContain('SMOKE_TEST_IN_METADATA');
+    expect(codes).not.toContain('SMOKE_TEST_MISSING');
+    const issue = issues.find(i => i.code === 'SMOKE_TEST_IN_METADATA');
+    expect(issue.message).toMatch(/TOP-LEVEL strategic_directives_v2\.smoke_test_steps/);
+    expect(issue.remediation).toMatch(/SD-TEST-007/);
+  });
+
+  it('no steps anywhere => SMOKE_TEST_MISSING naming the top-level column', () => {
+    const issues = checkLeadToPlanPrereqs({ ...baseSd, smoke_test_steps: null, metadata: {} });
+    const issue = issues.find(i => i.code === 'SMOKE_TEST_MISSING');
+    expect(issue).toBeTruthy();
+    expect(issue.remediation).toMatch(/TOP-LEVEL strategic_directives_v2\.smoke_test_steps/);
+  });
+
+  it('valid top-level steps (including string-JSON) => no smoke issue', () => {
+    const a = checkLeadToPlanPrereqs({ ...baseSd, smoke_test_steps: REAL_STEPS, metadata: {} });
+    expect(a.find(i => String(i.code).startsWith('SMOKE_TEST_') && i.code !== 'SMOKE_TEST_BYPASSED')).toBeFalsy();
+    const b = checkLeadToPlanPrereqs({ ...baseSd, smoke_test_steps: JSON.stringify(REAL_STEPS), metadata: {} });
+    expect(b.find(i => String(i.code).startsWith('SMOKE_TEST_') && i.code !== 'SMOKE_TEST_BYPASSED')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

The LEAD-TO-PLAN `SMOKE_TEST_SPECIFICATION` gate reads only the top-level `strategic_directives_v2.smoke_test_steps` column, while workers remediating a gate failure naturally write `metadata.smoke_test_steps` — the failure message never named the column. Cost: ~20 fleet-wide gate failures in 7 days, 2+ burned handoff attempts per SD, 3 historically stranded SDs.

- **FR-1** — `resolveSmokeTestSteps()`: prefer top-level, fall back to `metadata.smoke_test_steps` (string-JSON tolerant both ways); on fallback, warn + **auto-hoist** the steps into the canonical column (guarded: only when the live top-level is empty; fail-open write) so downstream consumers (heal, UAT, SMOKE_TEST_GATE) still see them
- **FR-2** — every failure/remediation string names the exact column: "top-level strategic_directives_v2.smoke_test_steps (NOT metadata.smoke_test_steps)"
- **FR-3** — `prerequisite-preflight` emits a precise `SMOKE_TEST_IN_METADATA` issue (with a copy-pasteable hoist one-liner) instead of the generic `SMOKE_TEST_MISSING` when steps are stranded in metadata
- **FR-4** — executor injects `this.supabase` into the gate factory (optional param; pure validation unchanged without it)

## Verification

- 14 new tests (`tests/unit/smoke-test-specification-metadata-fallback.test.js`): fallback, hoist, hoist-skip when live column populated, top-level-wins, string-JSON parse, column-naming messages, lightweight skip, preflight branch
- Existing `smoke-test-placeholder-rejection.test.js` 7/7 green
- `preflight-autofix.test.js` failures are pre-existing on base (verified via stash round-trip)

## PR Size

~90 source LOC + ~190 test LOC. No schema changes, no flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)