### PR TITLE
fix(gates): parse operator-prefixed quantified metric values in SUCCESS_METRICS gate

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
@@ -26,7 +26,8 @@ function isNotApplicable(value) {
   return NA_PATTERN.test(String(value).trim());
 }
 
-function parseMetricValue(value) {
+// Exported for unit tests (SD-FDBK-FIX-FIX-SUCCESS-METRICS-001) — pure, no side effects.
+export function parseMetricValue(value) {
   if (value == null) return null;
   const str = String(value).trim();
   if (!str) return null;
@@ -42,17 +43,34 @@ function parseMetricValue(value) {
   if (ofMatch && parseFloat(ofMatch[2]) > 0) return (parseFloat(ofMatch[1]) / parseFloat(ofMatch[2])) * 100;
   const inlineFracMatch = str.match(/\b(\d+)\s*\/\s*(\d+)\b/);
   if (inlineFracMatch && parseFloat(inlineFracMatch[2]) > 0) return (parseFloat(inlineFracMatch[1]) / parseFloat(inlineFracMatch[2])) * 100;
+  // SD-FDBK-FIX-FIX-SUCCESS-METRICS-001: operator-prefixed quantified values (">=1 finding",
+  // "<5 errors", "≥3 dimensions") fell through to the parseFloat fallback below, which returns NaN
+  // on the leading operator → null → the metric scored the non-numeric 75 even when genuinely met.
+  // Strip a leading comparison operator (ASCII + unicode) and parse the remainder. Comparison
+  // integrity is preserved: meetsTarget() extracts the operator from the RAW target string before
+  // any parsing, so an unmet operator-prefixed goal still fails (scores 50). This also fixes
+  // operator-prefixed TARGETS (">=1"), which nulled out via the same fallback. Placed after all
+  // existing branches so no currently-parsing form changes.
+  const opStripped = str.match(/^(?:[<>=]+|≥|≤)\s*([\d.]+)/);
+  if (opStripped) {
+    const opNum = parseFloat(opStripped[1]);
+    if (!isNaN(opNum)) return opNum;
+  }
   const num = parseFloat(str);
   if (!isNaN(num)) return num;
   return null;
 }
 
-function meetsTarget(actual, target) {
+// Exported for unit tests (SD-FDBK-FIX-FIX-SUCCESS-METRICS-001) — pure, no side effects.
+export function meetsTarget(actual, target) {
   if (actual == null || target == null) return null;
   const actualNum = parseMetricValue(String(actual));
   const targetStr = String(target).trim();
-  const opMatch = targetStr.match(/^([<>=]+)/);
-  const operator = opMatch ? opMatch[1] : '>=';
+  // SD-FDBK-FIX-FIX-SUCCESS-METRICS-001: also extract unicode operators (≥ → >=, ≤ → <=). Without
+  // this, a now-parsing "≤2" target would fall back to the default '>=' and INVERT the comparison
+  // into a false pass — the parse fix and this extraction must land together.
+  const opMatch = targetStr.match(/^([<>=]+|≥|≤)/);
+  const operator = opMatch ? (opMatch[1] === '≥' ? '>=' : opMatch[1] === '≤' ? '<=' : opMatch[1]) : '>=';
   const targetNum = parseMetricValue(targetStr);
   if (actualNum == null || targetNum == null) return null;
   switch (operator) {
@@ -220,8 +238,8 @@ export function createSuccessMetricsGate(supabase) {
               .eq('id', sdUuid);
           } else {
             // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Explain why auto-population skipped
-            console.log(`   ⚠️  No evidence found for auto-population (0 handoffs, 0 completed stories)`);
-            console.log(`      💡 Complete user stories or handoffs to provide evidence for metric actuals`);
+            console.log('   ⚠️  No evidence found for auto-population (0 handoffs, 0 completed stories)');
+            console.log('      💡 Complete user stories or handoffs to provide evidence for metric actuals');
           }
         } catch (autoPopErr) {
           console.log(`   ⚠️  Auto-populate failed: ${autoPopErr.message} (continuing with manual values)`);

--- a/tests/unit/gates/success-metrics-gate-parser.test.js
+++ b/tests/unit/gates/success-metrics-gate-parser.test.js
@@ -1,0 +1,81 @@
+/**
+ * SUCCESS_METRICS gate parser — operator-prefixed quantified values.
+ * SD-FDBK-FIX-FIX-SUCCESS-METRICS-001
+ *
+ * Tests the ACTIVE consolidated gate's pure helpers (success-metrics-gate.js), NOT the legacy
+ * success-metrics-achievement.js copy (dead for gate purposes; its parser is divergent).
+ *
+ * Defect fixed: parseMetricValue fell through to parseFloat on operator-prefixed values
+ * (">=1 finding", "<5 errors", "≥3 dimensions"), returning NaN→null, so a genuinely-met goal
+ * scored the non-numeric 75 instead of comparing. The fix strips a leading comparison operator
+ * (ASCII + unicode) before the parseFloat fallback. Comparison INTEGRITY must hold: meetsTarget
+ * extracts the operator from the raw target independently, so unmet goals still fail — including
+ * unicode ≤ targets, whose operator extraction was extended in the same change (otherwise a
+ * now-parsing "≤2" target would default to '>=' and invert the comparison).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseMetricValue, meetsTarget } from '../../../scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js';
+
+describe('parseMetricValue — operator-prefixed quantified values (the fix)', () => {
+  it('parses ASCII operator-prefixed values that previously returned null', () => {
+    expect(parseMetricValue('>=1 finding')).toBe(1);
+    expect(parseMetricValue('<5 errors')).toBe(5);
+    expect(parseMetricValue('<= 2 issues')).toBe(2);   // space after operator tolerated
+    expect(parseMetricValue('> 10 items')).toBe(10);
+  });
+
+  it('parses unicode operator-prefixed values (≥ / ≤)', () => {
+    expect(parseMetricValue('≥3 dimensions')).toBe(3);
+    expect(parseMetricValue('≤2 regressions')).toBe(2);
+  });
+
+  it('still returns null for genuinely-prose values (75-tier semantics preserved)', () => {
+    expect(parseMetricValue('all gates green')).toBe(null);
+    expect(parseMetricValue('verified manually')).toBe(null);
+    expect(parseMetricValue('')).toBe(null);
+    expect(parseMetricValue(null)).toBe(null);
+  });
+
+  it('regression-pins every previously-parsing form (unchanged results)', () => {
+    expect(parseMetricValue('95%')).toBe(95);
+    expect(parseMetricValue('>=90%')).toBe(90);        // pct branch already handled operators
+    expect(parseMetricValue('3/5')).toBe(60);
+    expect(parseMetricValue('6 of 6')).toBe(100);
+    expect(parseMetricValue('6/6 FRs implemented')).toBe(100);
+    expect(parseMetricValue('100% — 6 of 6')).toBe(100); // pct wins over "of"
+    expect(parseMetricValue('95')).toBe(95);
+    expect(parseMetricValue('3 findings')).toBe(3);
+    expect(parseMetricValue('100ms')).toBe(100);
+  });
+});
+
+describe('meetsTarget — comparison integrity with operator-prefixed forms', () => {
+  it('met goal now compares true (was null → 75)', () => {
+    expect(meetsTarget('3 findings', '>=1 finding')).toBe(true);
+    expect(meetsTarget('3 findings', '≥1 finding')).toBe(true);
+  });
+
+  it('INTEGRITY: unmet goal still fails — never a false pass', () => {
+    expect(meetsTarget('2 found', '>=5 findings')).toBe(false);
+    expect(meetsTarget('0 found', '≥1 finding')).toBe(false);
+  });
+
+  it('direction preserved for less-than targets (ASCII and unicode)', () => {
+    expect(meetsTarget('7 errors', '<5 errors')).toBe(false);
+    expect(meetsTarget('2 errors', '<5 errors')).toBe(true);
+    // unicode ≤: without the operator-extraction fix this would default to '>=' and INVERT
+    expect(meetsTarget('5 regressions', '≤2 regressions')).toBe(false);
+    expect(meetsTarget('1 regression', '≤2 regressions')).toBe(true);
+  });
+
+  it('operator-prefixed ACTUALS parse too (both sides share the parser)', () => {
+    // an actual recorded as ">=3 dimensions scored" parses to 3 and compares
+    expect(meetsTarget('>=3 dimensions scored', '>=3')).toBe(true);
+  });
+
+  it('prose values still yield null (non-numeric 75 tier), not a comparison', () => {
+    expect(meetsTarget('all gates green', '>=1 finding')).toBe(null);
+    expect(meetsTarget('3 findings', 'qualitative goal')).toBe(null);
+  });
+});


### PR DESCRIPTION
@
## SD-FDBK-FIX-FIX-SUCCESS-METRICS-001

Fixes an integrity-preserving false-positive in the SUCCESS_METRICS achievement gate (PLAN-TO-LEAD, hard-gates at 70 — the fleet's top-offending gate).

### Defect
`parseMetricValue` fell through to `parseFloat` on operator-prefixed quantified values (`">=1 finding"`, `"<5 errors"`, `"≥3 dimensions"`), returning NaN → null, so a genuinely-met goal scored the non-numeric **75** instead of comparing to 100. Because `meetsTarget` runs the parser on **both** sides, operator-prefixed **targets** (the majority of live occurrences: `"<=0"`, `">=12 (...)"`, `"<=150 LOC"`) also nulled out — so even clean numeric actuals couldn't compare against them.

### Fix (b28691e36f, +105/-6)
- `parseMetricValue`: operator-strip branch (ASCII `>= > <= < =` + unicode `≥ ≤`) **before** the parseFloat fallback, **after** all existing branches — no currently-parsing form changes.
- `meetsTarget`: operator extraction extended to unicode (`≥`→`>=`, `≤`→`<=`). Required for integrity: a now-parsing `"≤2"` target would otherwise default to `">="` and **invert** the comparison into a false pass.
- Pure helpers exported for direct unit testing; 12 new cases incl. integrity pins (unmet goals still score 50 in both directions) + regression pins for every prior parse form.

### Evidence
- **Live replay (FR-3)**: 13 operator-prefixed strings found in live `strategic_directives_v2`; **12/12 went null→number, 0 already-parsing values changed**. 4/4 directional integrity checks correct (recorded in SD `metadata.fix_verification`).
- **LEAD rescope note**: the SD's broad "gate shape false-positives" premise was unverifiable (gate telemetry empty) and one observed failure was a true positive — scope was narrowed to this one empirically-confirmed defect; `GATE_SD_METRICS_SUFFICIENCY` verified defect-free and dropped.
- Suites: 19/19 success-metrics tests, 15/15 smoke; 3 unrelated failures in other gate suites proven identical on unmodified main (pre-existing).
- Gates: LEAD-TO-PLAN 94 · PLAN-TO-EXEC 94 · EXEC-TO-PLAN 97 · PLAN-TO-LEAD 98 · TESTING PASS · retro 100.

### Follow-up flagged
Legacy `success-metrics-achievement.js` is a dead, divergent parser copy (missing QF-746 + this fix) still imported by its old test file — cleanup tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@