### PR TITLE
feat(SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001): A1a vision-spine FK substrate (additive, reversible)

### DIFF
--- a/database/migrations/20260610_initiative_backbone_a1a.sql
+++ b/database/migrations/20260610_initiative_backbone_a1a.sql
@@ -1,0 +1,144 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: Initiative backbone A1a — vision-spine FK substrate (additive, reversible)
+-- SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001 (the Plan-Keeper program's A1a schema slot;
+-- program child SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-E declares a dependency on this SD)
+--
+-- WHAT (5 nullable FK columns + 3 key-resolved backfills + 1 naming fix; NOTHING dropped/repointed):
+--   1. objectives.eva_vision_id          -> eva_vision_documents(id)   + backfill to the canonical L1
+--   2. okr_generation_log.eva_vision_id  -> eva_vision_documents(id)   + backfill to the canonical L1
+--   3. eva_vision_documents.mission_id   -> missions(id)               + backfill ONLY the active L1 doc
+--   4. strategic_directives_v2.initiative_id -> objectives(id)         (no backfill; forward-looking)
+--   5. roadmap_waves.initiative_id           -> objectives(id)         (no backfill; forward-looking)
+--   6. companies naming-drift fix: 'Executive Holdings Global' -> 'ExecHoldings Global' (id-anchored)
+--
+-- SAFETY / BOUNDARIES:
+--   * ADDITIVE ONLY. The legacy objectives.vision_id / okr_generation_log.vision_id columns and
+--     their hard FKs to strategic_vision(id) are UNTOUCHED — they stay authoritative for old
+--     readers until the program's A1b read-repoints (-001-E) and A1d soft-retire (-001-D).
+--   * okr_generation_log.eva_vision_id exists precisely BECAUSE okr_generation_log.vision_id has a
+--     hard FK to strategic_vision(id) (20260220_okr_monthly_system.sql L48): canonical
+--     eva_vision_documents ids MUST be written to the NEW columns, never the legacy ones.
+--   * Backfills resolve ids by STABLE KEYS at runtime (vision_key + status; venture_id IS NULL),
+--     never hardcoded row ids; pre-flight asserts abort loudly if cardinality drifts.
+--   * Idempotent: ADD COLUMN IF NOT EXISTS; backfills guard on IS NULL; the companies UPDATE is
+--     id-anchored + name-guarded (cannot touch the separate 'EHG' record d73aac88).
+--   * Reversible: column-explicit DOWN at database/migrations/20260610_initiative_backbone_a1a_DOWN.sql.
+--   * apply-migration.js wraps this whole file in its own BEGIN/COMMIT (single query, advisory
+--     locks); no SET TRANSACTION ISOLATION in-file by design.
+
+SELECT pg_advisory_xact_lock(hashtext('initiative_backbone_a1a'));
+
+-- 0) Pre-flight asserts: the stable keys must resolve to exactly one row each.
+DO $a1a_pre$
+DECLARE
+  v_l1      int;
+  v_mission int;
+  v_legacy  int;
+BEGIN
+  SELECT count(*) INTO v_l1
+    FROM eva_vision_documents
+   WHERE vision_key = 'VISION-EHG-L1-001' AND status = 'active' AND chairman_approved = true;
+  IF v_l1 <> 1 THEN
+    RAISE EXCEPTION 'A1a aborted: expected exactly 1 active+approved VISION-EHG-L1-001, found %', v_l1;
+  END IF;
+
+  SELECT count(*) INTO v_mission FROM missions WHERE venture_id IS NULL;
+  IF v_mission <> 1 THEN
+    RAISE EXCEPTION 'A1a aborted: expected exactly 1 portfolio mission (venture_id IS NULL), found %', v_mission;
+  END IF;
+
+  -- strategic_vision is the legacy single-row root; >1 row means the world changed under us.
+  SELECT count(*) INTO v_legacy FROM strategic_vision;
+  IF v_legacy > 1 THEN
+    RAISE EXCEPTION 'A1a aborted: strategic_vision has % rows (expected <=1) — re-verify backfill predicate', v_legacy;
+  END IF;
+END;
+$a1a_pre$;
+
+-- 1) Vision-spine FK substrate (the A1b consumer contract columns).
+ALTER TABLE objectives
+  ADD COLUMN IF NOT EXISTS eva_vision_id UUID REFERENCES eva_vision_documents(id);
+ALTER TABLE okr_generation_log
+  ADD COLUMN IF NOT EXISTS eva_vision_id UUID REFERENCES eva_vision_documents(id);
+
+-- 2) Mission foundation: the vision spine CITES the mission (peer anchor, not a new apex).
+ALTER TABLE eva_vision_documents
+  ADD COLUMN IF NOT EXISTS mission_id UUID REFERENCES missions(id);
+
+-- 3) Initiative grain: OKR objectives ARE the Initiative (no new entity).
+ALTER TABLE strategic_directives_v2
+  ADD COLUMN IF NOT EXISTS initiative_id UUID REFERENCES objectives(id);
+ALTER TABLE roadmap_waves
+  ADD COLUMN IF NOT EXISTS initiative_id UUID REFERENCES objectives(id);
+
+-- 4) Backfills (key-resolved, IS NULL-guarded => idempotent).
+UPDATE objectives o
+   SET eva_vision_id = (SELECT id FROM eva_vision_documents
+                         WHERE vision_key = 'VISION-EHG-L1-001' AND status = 'active')
+ WHERE o.eva_vision_id IS NULL
+   AND o.vision_id IN (SELECT id FROM strategic_vision);
+
+UPDATE okr_generation_log g
+   SET eva_vision_id = (SELECT id FROM eva_vision_documents
+                         WHERE vision_key = 'VISION-EHG-L1-001' AND status = 'active')
+ WHERE g.eva_vision_id IS NULL
+   AND g.vision_id IN (SELECT id FROM strategic_vision);
+
+UPDATE eva_vision_documents d
+   SET mission_id = (SELECT id FROM missions WHERE venture_id IS NULL)
+ WHERE d.vision_key = 'VISION-EHG-L1-001' AND d.status = 'active'
+   AND d.mission_id IS NULL;
+
+-- 5) Companies naming-drift fix (chairman-locked; id-anchored + name-guarded).
+UPDATE companies
+   SET name = 'ExecHoldings Global'
+ WHERE id = 'b933ecb0-a9d4-47b0-a4cb-ec21a6031475'
+   AND name = 'Executive Holdings Global';
+
+-- 6) Post-asserts: backfills landed exactly where intended.
+DO $a1a_post$
+DECLARE
+  v_obj_pending int;
+  v_log_pending int;
+  v_l1_mission  int;
+  v_old_name    int;
+BEGIN
+  SELECT count(*) INTO v_obj_pending
+    FROM objectives
+   WHERE vision_id IN (SELECT id FROM strategic_vision) AND eva_vision_id IS NULL;
+  IF v_obj_pending <> 0 THEN
+    RAISE EXCEPTION 'A1a post-assert failed: % objectives on the legacy root still lack eva_vision_id', v_obj_pending;
+  END IF;
+
+  SELECT count(*) INTO v_log_pending
+    FROM okr_generation_log
+   WHERE vision_id IN (SELECT id FROM strategic_vision) AND eva_vision_id IS NULL;
+  IF v_log_pending <> 0 THEN
+    RAISE EXCEPTION 'A1a post-assert failed: % okr_generation_log rows on the legacy root still lack eva_vision_id', v_log_pending;
+  END IF;
+
+  SELECT count(*) INTO v_l1_mission
+    FROM eva_vision_documents
+   WHERE mission_id IS NOT NULL;
+  IF v_l1_mission <> 1 THEN
+    RAISE EXCEPTION 'A1a post-assert failed: expected exactly 1 mission-cited vision doc (the L1), found %', v_l1_mission;
+  END IF;
+
+  SELECT count(*) INTO v_old_name FROM companies WHERE name = 'Executive Holdings Global';
+  IF v_old_name <> 0 THEN
+    RAISE EXCEPTION 'A1a post-assert failed: % companies rows still carry the drifted name', v_old_name;
+  END IF;
+END;
+$a1a_post$;
+
+-- 7) Contract documentation on the columns themselves.
+COMMENT ON COLUMN objectives.eva_vision_id IS
+  'Canonical vision spine FK (eva_vision_documents). A1b/-001-E threads THIS column for canonical ids — never legacy vision_id (hard FK to strategic_vision). SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001.';
+COMMENT ON COLUMN okr_generation_log.eva_vision_id IS
+  'Canonical vision spine FK (eva_vision_documents). A1b/-001-E threads THIS column — legacy vision_id keeps its strategic_vision FK until A1d. SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001.';
+COMMENT ON COLUMN eva_vision_documents.mission_id IS
+  'Mission foundation up-FK (missions). Portfolio mission (venture_id NULL) <-> L1; per-venture mission <-> that venture''s L2; consumers COALESCE to portfolio. Only the L1 doc is backfilled. SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001.';
+COMMENT ON COLUMN strategic_directives_v2.initiative_id IS
+  'Initiative grain: the OKR objective this (orchestrator) SD advances. Nullable; forward-looking adoption. SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001.';
+COMMENT ON COLUMN roadmap_waves.initiative_id IS
+  'Initiative grain: the OKR objective this wave advances (single-FK complement to okr_objective_ids JSONB). Nullable; forward-looking adoption. SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001.';

--- a/database/migrations/20260610_initiative_backbone_a1a_DOWN.sql
+++ b/database/migrations/20260610_initiative_backbone_a1a_DOWN.sql
@@ -1,0 +1,49 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- DOWN migration for SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001 (Initiative backbone A1a)
+--
+-- Column-explicit revert of the additive A1a substrate: drops exactly the 5 new nullable FK
+-- columns and restores the companies name. Backfilled values live only in the dropped columns,
+-- so no separate data restore is needed. Apply via:
+--   node scripts/apply-migration.js database/migrations/20260610_initiative_backbone_a1a_DOWN.sql
+--
+-- WARNING: only run BEFORE program child -001-E (A1b) starts writing eva_vision_id — after that,
+-- dropping the columns discards A1b's writes (coordinate with the Plan-Keeper program first).
+
+SELECT pg_advisory_xact_lock(hashtext('initiative_backbone_a1a'));
+
+ALTER TABLE objectives              DROP COLUMN IF EXISTS eva_vision_id;
+ALTER TABLE okr_generation_log      DROP COLUMN IF EXISTS eva_vision_id;
+ALTER TABLE eva_vision_documents    DROP COLUMN IF EXISTS mission_id;
+ALTER TABLE strategic_directives_v2 DROP COLUMN IF EXISTS initiative_id;
+ALTER TABLE roadmap_waves           DROP COLUMN IF EXISTS initiative_id;
+
+UPDATE companies
+   SET name = 'Executive Holdings Global'
+ WHERE id = 'b933ecb0-a9d4-47b0-a4cb-ec21a6031475'
+   AND name = 'ExecHoldings Global';
+
+-- Post-restore asserts: columns gone, name restored.
+DO $a1a_down_post$
+DECLARE
+  v_cols int;
+  v_name int;
+BEGIN
+  SELECT count(*) INTO v_cols
+    FROM information_schema.columns
+   WHERE (table_name = 'objectives'              AND column_name = 'eva_vision_id')
+      OR (table_name = 'okr_generation_log'      AND column_name = 'eva_vision_id')
+      OR (table_name = 'eva_vision_documents'    AND column_name = 'mission_id')
+      OR (table_name = 'strategic_directives_v2' AND column_name = 'initiative_id')
+      OR (table_name = 'roadmap_waves'           AND column_name = 'initiative_id');
+  IF v_cols <> 0 THEN
+    RAISE EXCEPTION 'A1a DOWN post-assert failed: % A1a columns still present', v_cols;
+  END IF;
+
+  SELECT count(*) INTO v_name
+    FROM companies
+   WHERE id = 'b933ecb0-a9d4-47b0-a4cb-ec21a6031475' AND name = 'Executive Holdings Global';
+  IF v_name <> 1 THEN
+    RAISE EXCEPTION 'A1a DOWN post-assert failed: companies name not restored (found % matching rows)', v_name;
+  END IF;
+END;
+$a1a_down_post$;

--- a/tests/integration/initiative-backbone-a1a-migration.test.js
+++ b/tests/integration/initiative-backbone-a1a-migration.test.js
@@ -1,0 +1,150 @@
+/**
+ * SD-LEO-INFRA-INITIATIVE-BACKBONE-CANONICAL-001 — A1a migration round-trip proof.
+ *
+ * Runs the FULL UP migration inside a self-managed BEGIN..ROLLBACK against the live DB
+ * (apply-migration.js dry-run does NOT execute SQL, so this probe is the real validation —
+ * established recipe from SD-LEO-INFRA-BULK-PURGE-LIVE-001 / REVIVE-EVA-PURGE-MGMT-REVIEWS-001):
+ *   - schema fingerprint (information_schema.columns over the 5 touched tables) before == after
+ *   - in-transaction asserts: backfill exactness, legacy columns untouched, naming fix scoped
+ *
+ * IDEMPOTENT BY DESIGN: the UP uses ADD COLUMN IF NOT EXISTS + IS NULL-guarded backfills +
+ * name-guarded UPDATE, so this test passes identically BEFORE and AFTER the live apply.
+ *
+ * Static UP/DOWN parity tests run regardless of DB availability.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../');
+const UP_PATH = resolve(REPO_ROOT, 'database/migrations/20260610_initiative_backbone_a1a.sql');
+const DOWN_PATH = resolve(REPO_ROOT, 'database/migrations/20260610_initiative_backbone_a1a_DOWN.sql');
+const UP_SQL = readFileSync(UP_PATH, 'utf8');
+const DOWN_SQL = readFileSync(DOWN_PATH, 'utf8');
+
+const A1A_COLUMNS = [
+  ['objectives', 'eva_vision_id'],
+  ['okr_generation_log', 'eva_vision_id'],
+  ['eva_vision_documents', 'mission_id'],
+  ['strategic_directives_v2', 'initiative_id'],
+  ['roadmap_waves', 'initiative_id'],
+];
+
+describe('A1a migration — static UP/DOWN parity', () => {
+  it('UP adds exactly the 5 contract columns (ADD COLUMN IF NOT EXISTS)', () => {
+    for (const [table, col] of A1A_COLUMNS) {
+      const re = new RegExp(`ALTER TABLE ${table}\\s+ADD COLUMN IF NOT EXISTS ${col}\\b`);
+      expect(UP_SQL, `UP missing ${table}.${col}`).toMatch(re);
+    }
+    // count STATEMENTS (the safety comment block also mentions the phrase, so anchor on ALTER TABLE)
+    expect((UP_SQL.match(/ALTER TABLE \w+\s+ADD COLUMN IF NOT EXISTS/g) || []).length).toBe(5);
+  });
+
+  it('DOWN drops exactly the same 5 columns (column-explicit) and restores the companies name', () => {
+    for (const [table, col] of A1A_COLUMNS) {
+      const re = new RegExp(`ALTER TABLE ${table}\\s+DROP COLUMN IF EXISTS ${col}\\b`);
+      expect(DOWN_SQL, `DOWN missing ${table}.${col}`).toMatch(re);
+    }
+    expect((DOWN_SQL.match(/DROP COLUMN IF EXISTS/g) || []).length).toBe(5);
+    expect(DOWN_SQL).toMatch(/SET name = 'Executive Holdings Global'/);
+    expect(DOWN_SQL).toMatch(/AND name = 'ExecHoldings Global'/);
+  });
+
+  it('UP never touches the legacy vision_id columns or strategic_vision data', () => {
+    // The ONLY strategic_vision references must be read-side (IN (SELECT id FROM strategic_vision))
+    // and the pre-flight count assert — never UPDATE/ALTER/DROP against it.
+    expect(UP_SQL).not.toMatch(/UPDATE\s+strategic_vision/i);
+    expect(UP_SQL).not.toMatch(/ALTER\s+TABLE\s+strategic_vision/i);
+    expect(UP_SQL).not.toMatch(/DROP\s+/i);
+    // legacy columns: never assigned
+    expect(UP_SQL).not.toMatch(/SET\s+vision_id\s*=/i);
+  });
+
+  it('UP backfills are idempotent (IS NULL-guarded) and key-resolved (no hardcoded vision/mission ids)', () => {
+    // 2 backfill guards (WHERE x.eva_vision_id IS NULL) + 2 post-assert checks reuse the phrase
+    expect((UP_SQL.match(/\.eva_vision_id IS NULL/g) || []).length).toBe(2);
+    expect((UP_SQL.match(/eva_vision_id IS NULL/g) || []).length).toBe(4);
+    expect(UP_SQL).toMatch(/mission_id IS NULL/);
+    expect(UP_SQL).toMatch(/vision_key = 'VISION-EHG-L1-001'/);
+    expect(UP_SQL).toMatch(/venture_id IS NULL/);
+    // the only hardcoded UUID allowed is the id-anchored companies row
+    const uuids = UP_SQL.match(/'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'/g) || [];
+    expect(uuids.every(u => u === "'b933ecb0-a9d4-47b0-a4cb-ec21a6031475'"), 'unexpected hardcoded UUID in UP').toBe(true);
+  });
+});
+
+const POOLER = process.env.SUPABASE_POOLER_URL;
+
+describe.skipIf(!POOLER)('A1a migration — live BEGIN..ROLLBACK round-trip', () => {
+  let client;
+  const FINGERPRINT_SQL = `
+    SELECT md5(string_agg(table_name || '.' || column_name || ':' || data_type || ':' || is_nullable, ',' ORDER BY table_name, ordinal_position)) AS fp
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name IN ('objectives','okr_generation_log','eva_vision_documents','strategic_directives_v2','roadmap_waves','companies','strategic_vision')`;
+
+  beforeAll(async () => {
+    const { Client } = await import('pg');
+    client = new Client({ connectionString: POOLER });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  it('full UP executes in a transaction, asserts pass in-txn, and rollback restores the schema byte-identically', async () => {
+    const before = (await client.query(FINGERPRINT_SQL)).rows[0].fp;
+    const legacyBefore = (await client.query('SELECT count(*)::int AS n, count(vision_id)::int AS v FROM objectives')).rows[0];
+
+    await client.query('BEGIN');
+    try {
+      await client.query(UP_SQL); // multi-statement simple-query — runs the whole UP incl. asserts
+
+      // In-txn backfill exactness (TS-2)
+      const obj = (await client.query(
+        `SELECT count(*)::int AS n FROM objectives
+          WHERE vision_id IN (SELECT id FROM strategic_vision) AND eva_vision_id IS NOT NULL`)).rows[0].n;
+      const objPending = (await client.query(
+        `SELECT count(*)::int AS n FROM objectives
+          WHERE vision_id IN (SELECT id FROM strategic_vision) AND eva_vision_id IS NULL`)).rows[0].n;
+      expect(objPending).toBe(0);
+      expect(obj).toBeGreaterThanOrEqual(8); // 8 at authoring; >= guards against new legacy-rooted objectives
+
+      const log = (await client.query(
+        `SELECT count(*)::int AS n FROM okr_generation_log
+          WHERE vision_id IN (SELECT id FROM strategic_vision) AND eva_vision_id IS NULL`)).rows[0].n;
+      expect(log).toBe(0);
+
+      const l1Mission = (await client.query(
+        'SELECT count(*)::int AS n FROM eva_vision_documents WHERE mission_id IS NOT NULL')).rows[0].n;
+      expect(l1Mission).toBe(1);
+
+      const initiativeRows = (await client.query(
+        `SELECT (SELECT count(initiative_id)::int FROM strategic_directives_v2) +
+                (SELECT count(initiative_id)::int FROM roadmap_waves) AS n`)).rows[0].n;
+      expect(initiativeRows).toBe(0); // forward-looking: nothing populated (TS-2)
+
+      // Naming fix scoped (TS-4): old name gone, EHG record untouched
+      const oldName = (await client.query(
+        'SELECT count(*)::int AS n FROM companies WHERE name = \'Executive Holdings Global\'')).rows[0].n;
+      expect(oldName).toBe(0);
+      const ehgRec = (await client.query(
+        'SELECT name FROM companies WHERE id = \'d73aac88-9dd1-402d-9f9f-ca21c2f8f89b\'')).rows[0];
+      expect(ehgRec.name).toBe('EHG');
+
+      // Legacy untouched in-txn (TS-3): same row/vision_id counts, strategic_vision row intact
+      const legacyIn = (await client.query('SELECT count(*)::int AS n, count(vision_id)::int AS v FROM objectives')).rows[0];
+      expect(legacyIn).toEqual(legacyBefore);
+      const sv = (await client.query('SELECT count(*)::int AS n FROM strategic_vision')).rows[0].n;
+      expect(sv).toBe(1);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+
+    const after = (await client.query(FINGERPRINT_SQL)).rows[0].fp;
+    expect(after, 'schema fingerprint changed across BEGIN..ROLLBACK').toBe(before); // TS-1
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary
The Plan-Keeper program's **A1a schema slot** (child `-001-E` declares a dependency on this SD). One additive, reversible migration delivering the Initiative-backbone FK substrate:

- `objectives.eva_vision_id` + `okr_generation_log.eva_vision_id` (nullable FKs → `eva_vision_documents`), backfilled to the canonical apex `VISION-EHG-L1-001` — the log column exists because its legacy `vision_id` carries a **hard FK to `strategic_vision(id)`** that `-001-E`'s canonical-id writes would otherwise violate
- `eva_vision_documents.mission_id` (nullable FK → `missions`), only the active L1 doc backfilled to the portfolio mission
- `initiative_id` (nullable FK → `objectives`) on `strategic_directives_v2` + `roadmap_waves` (Initiative grain = OKR objectives; forward-looking)
- companies naming-drift fix (`Executive Holdings Global` → `ExecHoldings Global`, id-anchored + name-guarded; chairman-locked content)

**Nothing repointed/retired/rewritten** — read-repoints belong to `-001-E`, canonical content to `-001-C`, the chairman-gated `strategic_vision` soft-retire to `-001-D`. Legacy `vision_id` columns + FKs untouched.

## Proof
- Live `BEGIN..ROLLBACK` round-trip executed the **full UP** against the live DB: in-txn backfill exactness (8 objectives / 2 log rows / 1 mission-cited L1 / 0 initiative rows), post-rollback schema fingerprint **byte-identical**. 5/5 tests.
- DATABASE sub-agent PASS (94): all 7 design constraints validated incl. apply-migration.js compatibility, no-table-rewrite nullable adds, trigger no-op on the backfills. TESTING PASS (95).

## Gates
LEAD-TO-PLAN 93 · PLAN-TO-EXEC 97 · EXEC-TO-PLAN 96 · PLAN-TO-LEAD 97 · retro quality 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)