### PR TITLE
feat(SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B): build-provenance stamp + observe-gate pin

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -672,7 +672,11 @@ fi
 # Extract SD identifier pattern from commit message or branch name
 # Matches: SD-LEO-GATE0-001, SD-FEATURE-001, SD-LEO-REFACTOR-LARGE-FILES-002
 # Also matches multi-segment: SD-LEO-SELF-IMPROVE-AIJUDGE-001
-SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z0-9]+(-[A-Z0-9]+)*-[0-9]+' | head -1)
+# SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B: also match the CHILD letter suffix
+# (leo-create-sd --child emits -B/-C/...). Without it the key truncates to the
+# PARENT orchestrator (often legitimately draft while children run), falsely
+# blocking every child commit with "SD is in DRAFT status".
+SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z0-9]+(-[A-Z0-9]+)*-[0-9]+(-[A-Z])?' | head -1)
 
 if [ ! -z "$SD_ID" ]; then
   echo "   Found SD reference: $SD_ID"

--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -11,8 +11,33 @@
  */
 
 import { randomUUID } from 'crypto';
+import { execSync } from 'child_process';
 import { ServiceRegistry } from './service-registry.js';
 import { TTLMap } from '../utils/ttl-map.js';
+
+// SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B (FR-1): build provenance, computed ONCE at
+// construction and merged into every heartbeat metadata write. The 2026-06-10 OKR
+// bypass happened because the live daemon ran a stale pre-fix build and NOTHING
+// recorded which build/env the process actually had — staleness was only inferred
+// post-incident from behavior. Fail-open: any probe error yields nulls and never
+// blocks construction or heartbeats. The env fingerprint records EFFECTIVE
+// booleans only — never raw env values.
+export function computeBuildProvenance({ exec = execSync, env = process.env, cwd = process.cwd() } = {}) {
+  let gitSha = null;
+  try {
+    gitSha = String(exec('git rev-parse HEAD', { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10000 })).trim() || null;
+  } catch { /* fail-open */ }
+  return {
+    git_sha: gitSha,
+    started_from: cwd,
+    node_version: process.version,
+    env: {
+      okr_require_acceptance: String(env.OKR_REQUIRE_ACCEPTANCE ?? 'true').toLowerCase() !== 'false',
+      eva_scheduler_observe_only: env.EVA_SCHEDULER_OBSERVE_ONLY === 'true',
+    },
+    stamped_at: new Date().toISOString(),
+  };
+}
 
 // SD-MAN-GEN-CORRECTIVE-VISION-GAP-012 (A03): Domain handlers registered via service registry
 // instead of direct imports. Each handler is lazy-loaded on first dispatch.
@@ -137,6 +162,10 @@ export class EvaMasterScheduler {
     this.observeOnly = cfg.observeOnly
       ?? (process.env.EVA_SCHEDULER_OBSERVE_ONLY === 'true')
       ?? false;
+
+    // SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B (FR-1): computed once, cached for the
+    // process lifetime, merged into every heartbeat write (no per-poll exec).
+    this._buildProvenance = computeBuildProvenance(cfg.provenanceProbe || {});
     this.statusTopN = cfg.statusTopN
       || parseInt(process.env.EVA_SCHEDULER_STATUS_TOP_N || '10', 10)
       || DEFAULT_STATUS_TOP_N;
@@ -1360,6 +1389,9 @@ export class EvaMasterScheduler {
           updated_at: new Date().toISOString(),
           metadata: {
             observe_only: this.observeOnly,
+            // SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B (FR-1): which build/env this
+            // process ACTUALLY runs — makes a stale daemon detectable in one query.
+            build_provenance: this._buildProvenance,
             metrics_write_failures: this._metricsWriteFailures,
             round_execution_count: this._totalRoundExecutions,
             round_error_count: this._totalRoundErrors,

--- a/tests/unit/eva-master-scheduler.test.js
+++ b/tests/unit/eva-master-scheduler.test.js
@@ -19,7 +19,7 @@ vi.mock('../../lib/eva/eva-orchestrator.js', () => ({
   processStage: vi.fn(),
 }));
 
-import { EvaMasterScheduler } from '../../lib/eva/eva-master-scheduler.js';
+import { EvaMasterScheduler, computeBuildProvenance } from '../../lib/eva/eva-master-scheduler.js';
 import { processStage } from '../../lib/eva/eva-orchestrator.js';
 
 // ── Mock Factories ──────────────────────────────────────────────
@@ -1702,5 +1702,101 @@ describe('EvaMasterScheduler', () => {
       expect(status.circuit_breaker_state).toBe('UNKNOWN');
       expect(status.queue_depth).toBe(0);
     });
+  });
+});
+
+// ── SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B ──────────────────────────
+// FR-1: build-provenance stamp (computed once, fail-open, merged into heartbeat).
+// FR-2: regression pin on the _runDueJobs observe gate (PR #4522) — the 2026-06-10
+// OKR bypass ran okr-monthly-generate under observe_only because the live daemon
+// predated that gate; these tests fail if the gate is ever removed.
+
+describe('SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B: build provenance (FR-1)', () => {
+  test('computeBuildProvenance returns trimmed git sha + env fingerprint booleans', () => {
+    const p = computeBuildProvenance({
+      exec: () => 'abc123def456\n',
+      env: { OKR_REQUIRE_ACCEPTANCE: 'true', EVA_SCHEDULER_OBSERVE_ONLY: 'true' },
+      cwd: '/repo',
+    });
+    expect(p.git_sha).toBe('abc123def456');
+    expect(p.started_from).toBe('/repo');
+    expect(p.node_version).toBe(process.version);
+    expect(p.env).toEqual({ okr_require_acceptance: true, eva_scheduler_observe_only: true });
+    expect(typeof p.stamped_at).toBe('string');
+  });
+
+  test('fail-open: git probe throwing yields git_sha=null (never throws)', () => {
+    const p = computeBuildProvenance({ exec: () => { throw new Error('git unavailable'); }, env: {} });
+    expect(p.git_sha).toBeNull();
+    // requireAcceptance defaults TRUE when env var absent (mirrors okr-monthly-generator.js)
+    expect(p.env.okr_require_acceptance).toBe(true);
+    expect(p.env.eva_scheduler_observe_only).toBe(false);
+  });
+
+  test('OKR_REQUIRE_ACCEPTANCE=false is fingerprinted as false', () => {
+    const p = computeBuildProvenance({ exec: () => 'sha\n', env: { OKR_REQUIRE_ACCEPTANCE: 'false' } });
+    expect(p.env.okr_require_acceptance).toBe(false);
+  });
+
+  test('heartbeat upsert payload carries metadata.build_provenance (computed once at construction)', async () => {
+    const mockSupabase = createMockSupabase();
+    const mockLogger = createMockLogger();
+    const exec = vi.fn(() => 'deadbeef\n');
+    const scheduler = new EvaMasterScheduler({
+      supabase: mockSupabase,
+      logger: mockLogger,
+      config: { provenanceProbe: { exec, env: { OKR_REQUIRE_ACCEPTANCE: 'true' }, cwd: '/host/repo' } },
+    });
+    expect(exec).toHaveBeenCalledTimes(1); // cached at construction — no per-poll exec
+
+    await scheduler._updateHeartbeat('running');
+    const upsertArg = mockSupabase.upsert.mock.calls.at(-1)[0];
+    expect(upsertArg.metadata.build_provenance).toMatchObject({
+      git_sha: 'deadbeef',
+      started_from: '/host/repo',
+      env: { okr_require_acceptance: true },
+    });
+    expect(exec).toHaveBeenCalledTimes(1); // still once after a heartbeat write
+  });
+});
+
+describe('SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B: _runDueJobs observe gate pin (FR-2)', () => {
+  test('observeOnly=true: due job handler NOT invoked, OBSERVE log emitted, cadence clock advanced', async () => {
+    const mockSupabase = createMockSupabase();
+    const mockLogger = createMockLogger();
+    const scheduler = new EvaMasterScheduler({
+      supabase: mockSupabase,
+      logger: mockLogger,
+      config: { observeOnly: true },
+    });
+    const handler = vi.fn();
+    scheduler.registerJob({ name: 'pin-test-job', handler, cadenceDays: 30 });
+    // No prior run -> due immediately.
+
+    await scheduler._runDueJobs();
+
+    expect(handler).not.toHaveBeenCalled(); // THE pin: gate removal fails here
+    const observeLogs = mockLogger.log.mock.calls.filter(
+      (c) => c[0] && c[0].includes('OBSERVE: Would run job pin-test-job'),
+    );
+    expect(observeLogs.length).toBe(1);
+    // Cadence clock advanced so observe-mode doesn't cause a thundering catch-up at flip.
+    expect(scheduler._jobLastRunAt.get('pin-test-job')).toBeGreaterThan(0);
+  });
+
+  test('observeOnly=false: the same due job handler IS invoked (gate is mode-scoped, not a blanket skip)', async () => {
+    const mockSupabase = createMockSupabase();
+    const mockLogger = createMockLogger();
+    const scheduler = new EvaMasterScheduler({
+      supabase: mockSupabase,
+      logger: mockLogger,
+      config: { observeOnly: false },
+    });
+    const handler = vi.fn().mockResolvedValue(undefined);
+    scheduler.registerJob({ name: 'pin-test-live-job', handler, cadenceDays: 30 });
+
+    await scheduler._runDueJobs();
+
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
Wave-0 of the Adam Plan-Keeper program (deadline before the 2026-07-01 monthly generation). The live EVA scheduler daemon executed the 2026-06 OKR generation at 2026-06-10T11:42Z **while `observe_only=true`**, bypassing the chairman-acceptance seam — because the process runs a stale pre-#4507/#4522 build, and nothing recorded which build/env the daemon actually had.

## Changes
- **FR-1 — provenance**: `computeBuildProvenance()` (exported, injectable probe) — git SHA + effective-boolean env fingerprint (`OKR_REQUIRE_ACCEPTANCE`, `EVA_SCHEDULER_OBSERVE_ONLY`; never raw values) + `node_version` + `started_from`, computed **once** at construction (fail-open → nulls) and merged into every `eva_scheduler_heartbeat.metadata` write. A stale daemon is now detectable in one query.
- **FR-2 — gate pin**: regression tests on the shipped `_runDueJobs` observe gate (PR #4522): due-job handler NOT invoked under observeOnly + OBSERVE log + cadence clock advanced; live-mode counterpart proves the gate is mode-scoped.
- **Inline harness fix (campaign)**: Gate 0's SD-key regex in `.husky/pre-commit` now matches the child letter suffix (`-B`/`-C`). It truncated child keys to the PARENT orchestrator key, falsely blocking child commits whenever the parent is legitimately draft while children run (hit live by this SD).

## Testing
6 new tests pass. The 2 pre-existing failures in this suite (TS-1 dispatch-args shape + error-count) reproduce identically WITHOUT this change (stash-verified) — unrelated.

## Follow-through (this SD, post-merge)
Live re-host of daemon `scheduler-454e4a66` onto current main via the #4524 hosting path, observe-only drill (zero OKR-table writes with jobs forced due), and the durable bypass audit.

SD: SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
