### PR TITLE
fix(SD-FDBK-FIX-STOP-STAMPING-GLOBAL-001): stop stamping global issue_patterns into clean handoff retros

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
@@ -51,27 +51,6 @@ async function getIssuesForSD(supabase, sdId) {
 }
 
 /**
- * Query recent active issues (not SD-specific but recent/high-priority)
- * @param {Object} supabase - Supabase client
- * @returns {Promise<Array>} Array of recent issue patterns
- */
-async function getRecentActiveIssues(supabase) {
-  try {
-    const { data, error } = await supabase
-      .from('issue_patterns')
-      .select('pattern_id, issue_summary, category, severity, proven_solutions')
-      .eq('status', 'active')
-      .order('updated_at', { ascending: false })
-      .limit(5);
-
-    if (error) return [];
-    return data || [];
-  } catch (_err) {
-    return [];
-  }
-}
-
-/**
  * Get git context for the SD (files changed, recent commits)
  * @param {string} sdId - SD ID for branch name detection
  * @returns {Object} { filesChanged, commitMessages, summary }
@@ -142,8 +121,10 @@ export async function createExecToPlanRetrospective(supabase, sdId, sd, handoffR
 
     // Query actual issues from issue_patterns table
     const sdIssues = await getIssuesForSD(supabase, sdId);
-    const recentIssues = sdIssues.length === 0 ? await getRecentActiveIssues(supabase) : [];
-    const allIssues = [...sdIssues, ...recentIssues];
+    // SD-FDBK-FIX-STOP-STAMPING-GLOBAL-001: no global fallback — only SD-linked
+    // patterns belong in this SD's retro. The old unscoped top-5 query stamped the
+    // same 5 PAT-AUTO lines into nearly every clean retro fleet-wide.
+    const allIssues = sdIssues;
 
     if (sdIssues.length > 0) {
       console.log(`   📋 Found ${sdIssues.length} issue(s) linked to this SD`);

--- a/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
@@ -44,30 +44,6 @@ async function getIssuesForSD(supabase, sdId) {
 }
 
 /**
- * Query recent active issues (not SD-specific but recent/high-priority)
- * @param {Object} supabase - Supabase client
- * @returns {Promise<Array>} Array of recent issue patterns
- */
-async function getRecentActiveIssues(supabase) {
-  try {
-    const { data, error } = await supabase
-      .from('issue_patterns')
-      .select('pattern_id, issue_summary, category, severity, proven_solutions')
-      .eq('status', 'active')
-      .order('updated_at', { ascending: false })
-      .limit(5);
-
-    if (error) {
-      return [];
-    }
-
-    return data || [];
-  } catch (_err) {
-    return [];
-  }
-}
-
-/**
  * Create handoff retrospective
  *
  * @param {string} sdId - SD ID
@@ -83,8 +59,10 @@ export async function createHandoffRetrospective(sdId, sd, handoffResult, retros
 
     // Query actual issues from issue_patterns table (PAT-RETRO-BOILERPLATE-001 fix)
     const sdIssues = await getIssuesForSD(supabase, sdId);
-    const recentIssues = sdIssues.length === 0 ? await getRecentActiveIssues(supabase) : [];
-    const allIssues = [...sdIssues, ...recentIssues];
+    // SD-FDBK-FIX-STOP-STAMPING-GLOBAL-001: no global fallback — only SD-linked
+    // patterns belong in this SD's retro. The old unscoped top-5 query stamped the
+    // same 5 PAT-AUTO lines into nearly every clean retro fleet-wide.
+    const allIssues = sdIssues;
 
     if (sdIssues.length > 0) {
       console.log(`   📋 Found ${sdIssues.length} issue(s) linked to this SD`);

--- a/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
@@ -40,30 +40,6 @@ async function getIssuesForSD(supabase, sdId) {
 }
 
 /**
- * Query recent active issues (not SD-specific but recent/high-priority)
- * @param {Object} supabase - Supabase client
- * @returns {Promise<Array>} Array of recent issue patterns
- */
-async function getRecentActiveIssues(supabase) {
-  try {
-    const { data, error } = await supabase
-      .from('issue_patterns')
-      .select('pattern_id, issue_summary, category, severity, proven_solutions')
-      .eq('status', 'active')
-      .order('updated_at', { ascending: false })
-      .limit(5);
-
-    if (error) {
-      return [];
-    }
-
-    return data || [];
-  } catch (_err) {
-    return [];
-  }
-}
-
-/**
  * Create handoff retrospective after successful handoff
  *
  * Uses handoff metrics for quality scoring. Interactive prompts are optional
@@ -83,8 +59,10 @@ export async function createHandoffRetrospective(supabase, sdId, sd, handoffResu
 
     // Query actual issues from issue_patterns table (PAT-RETRO-BOILERPLATE-001 fix)
     const sdIssues = await getIssuesForSD(supabase, sdId);
-    const recentIssues = sdIssues.length === 0 ? await getRecentActiveIssues(supabase) : [];
-    const allIssues = [...sdIssues, ...recentIssues];
+    // SD-FDBK-FIX-STOP-STAMPING-GLOBAL-001: no global fallback — only SD-linked
+    // patterns belong in this SD's retro. The old unscoped top-5 query stamped the
+    // same 5 PAT-AUTO lines into nearly every clean retro fleet-wide.
+    const allIssues = sdIssues;
 
     if (sdIssues.length > 0) {
       console.log(`   📋 Found ${sdIssues.length} issue(s) linked to this SD`);

--- a/tests/unit/retro-no-global-pattern-stamping.test.js
+++ b/tests/unit/retro-no-global-pattern-stamping.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// SD-FDBK-FIX-STOP-STAMPING-GLOBAL-001: handoff retros must build pattern lines
+// ONLY from SD-linked issue_patterns. The old getRecentActiveIssues() fallback
+// stamped the global top-5 (ORDER BY updated_at LIMIT 5) into nearly every clean
+// retro fleet-wide (~150+ of 256 improvement items across 60 retros in 7d).
+
+// Keep the cross-type clobber guard out of the behavioral test (it queries the DB).
+vi.mock('../../scripts/modules/handoff/lib/retro-clobber-guard.js', () => ({
+  isSafeToWriteRetro: vi.fn(async () => ({ safe: true })),
+}));
+
+const EXECUTOR_FILES = [
+  'scripts/modules/handoff/executors/exec-to-plan/retrospective.js',
+  'scripts/modules/handoff/executors/lead-to-plan/retrospective.js',
+  'scripts/modules/handoff/executors/plan-to-exec/retrospective.js',
+];
+
+describe('static guard: no global issue_patterns fallback in any handoff retro executor (TS-1)', () => {
+  for (const file of EXECUTOR_FILES) {
+    it(`${file} has no getRecentActiveIssues and no unscoped top-5 query`, () => {
+      const src = readFileSync(resolve(process.cwd(), file), 'utf8');
+      expect(src).not.toMatch(/getRecentActiveIssues/);
+      // The defect's signature: an issue_patterns query ordered by updated_at with
+      // no SD scoping. getIssuesForSD (the legitimate query) filters by
+      // first_seen_sd_id/last_seen_sd_id and never orders by updated_at.
+      expect(src).not.toMatch(/issue_patterns'[\s\S]{0,300}order\('updated_at'/);
+    });
+  }
+});
+
+/**
+ * Mock supabase that routes by table:
+ * - issue_patterns: resolves the provided linked issues (and records the call
+ *   shape so an unscoped re-introduction would surface as an extra query)
+ * - retrospectives: no existing row; insert captures the retro payload
+ */
+function mockSupabase({ linkedIssues = [] } = {}) {
+  const captured = { inserted: null, patternQueries: 0 };
+  const makeBuilder = (table) => {
+    const builder = {
+      _table: table,
+      select: vi.fn(() => builder),
+      or: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+      insert: vi.fn((row) => { captured.inserted = row; return builder; }),
+      update: vi.fn(() => builder),
+      upsert: vi.fn((row) => { captured.inserted = row; return builder; }),
+      then: (resolveFn) => {
+        if (table === 'issue_patterns') {
+          captured.patternQueries += 1;
+          return resolveFn({ data: linkedIssues, error: null });
+        }
+        return resolveFn({ data: captured.inserted ? [captured.inserted] : [], error: null });
+      },
+    };
+    return builder;
+  };
+  return { client: { from: vi.fn((table) => makeBuilder(table)) }, captured };
+}
+
+const SD = {
+  id: '00000000-0000-0000-0000-000000000001',
+  sd_key: 'SD-TEST-RETRO-001',
+  title: 'Test SD for retro stamping guard',
+  sd_type: 'bugfix',
+};
+
+describe('behavioral: exec-to-plan retro content (TS-2, TS-3)', () => {
+  it('clean SD (no linked issues) produces no [PAT- lines anywhere in the retro row', async () => {
+    const { createExecToPlanRetrospective } = await import(
+      '../../scripts/modules/handoff/executors/exec-to-plan/retrospective.js'
+    );
+    const { client, captured } = mockSupabase({ linkedIssues: [] });
+    await createExecToPlanRetrospective(client, SD.sd_key, SD, { qualityScore: 90 }, {});
+    expect(captured.inserted).toBeTruthy();
+    const flat = JSON.stringify(captured.inserted);
+    expect(flat).not.toMatch(/\[PAT-/);
+    // exactly one issue_patterns query (the SD-scoped one) — the old fallback made two
+    expect(captured.patternQueries).toBe(1);
+  });
+
+  it('SD with a linked issue still surfaces its own pattern line', async () => {
+    const { createExecToPlanRetrospective } = await import(
+      '../../scripts/modules/handoff/executors/exec-to-plan/retrospective.js'
+    );
+    const linked = [{
+      pattern_id: 'PAT-TEST-LINKED-1',
+      issue_summary: 'real linked issue for this SD',
+      category: 'testing',
+      severity: 'medium',
+      proven_solutions: [],
+      prevention_checklist: [],
+    }];
+    const { client, captured } = mockSupabase({ linkedIssues: linked });
+    await createExecToPlanRetrospective(client, SD.sd_key, SD, { qualityScore: 90 }, {});
+    expect(captured.inserted).toBeTruthy();
+    const flat = JSON.stringify(captured.inserted);
+    expect(flat).toMatch(/PAT-TEST-LINKED-1/);
+  });
+});


### PR DESCRIPTION
## Summary

All three handoff retrospective executors (`exec-to-plan`, `lead-to-plan`, `plan-to-exec`) fell back to an **unscoped global top-5** `issue_patterns` query (`status=active ORDER BY updated_at DESC LIMIT 5`) whenever an SD had no linked issues. Because the same 5 PAT-AUTO rows dominate `updated_at` fleet-wide, the identical noise lines were stamped verbatim into nearly every clean retro — **~150+ of 256 improvement items across 60 retros (7d)** — drowning real learnings and polluting /learn distillation.

**Fix (net −63 source LOC):** delete `getRecentActiveIssues` from all three executors; `allIssues` is now `sdIssues` only (the SD-scoped `first_seen_sd_id`/`last_seen_sd_id` query). Clean SDs fall through to the existing `'No specific issues identified - implementation phase was clean'` default; SDs **with** linked issues keep their real pattern lines.

Descoped with rationale: resolving the 5 stale PAT-AUTO rows themselves (data change; the /learn noise filter already quarantines them as LOW_SIGNAL_SOURCE — this PR removes the mechanism that amplified them into retro content).

## Verification

- 5 new tests (`tests/unit/retro-no-global-pattern-stamping.test.js`): static guard per executor (fails if anyone re-adds the fallback) + behavioral via mocked supabase (clean SD ⇒ no `[PAT-` lines and exactly 1 pattern query; linked issue ⇒ its line surfaces)
- Existing retro suites green: `retrospective-enricher` + `rejection-subagent-mapping-retro` 33/33
- Runtime dynamic-import smoke of all three executors passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)