### PR TITLE
feat(SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001): /checkin adopts orphaned in_progress SDs (resume_orphan)

### DIFF
--- a/.claude/commands/checkin.md
+++ b/.claude/commands/checkin.md
@@ -53,6 +53,7 @@ The CLI prints **one JSON object** describing the resolved action. It does the w
 |----------|------------------|------------------|------|
 | `resume` | You already claim `sd` | Run `node scripts/sd-start.js <sd>` to (re)attach the worktree, then continue that SD. | On completion, re-run `/checkin`. |
 | `resume_final` | Re-claimed an SD **stranded** at `pending_approval/LEAD_FINAL` (claim was cleared — one handoff from shipped). | Run `node scripts/sd-start.js <sd>` to re-attach the worktree, then `node scripts/handoff.js execute LEAD-FINAL-APPROVAL <sd>` (Bash `timeout: 300000` — the final gate is slow). If `PR_MERGE_VERIFICATION` blocks, merge the PR first (`gh pr merge <#> --squash --admin`), then re-run. Then run the post-completion tail. **NOT** a full rebuild — the SD is already built, gated, and retro'd; it only needs the final approval handoff. | On completion, re-run `/checkin`. |
+| `resume_orphan` | Adopted an **orphaned** `in_progress` SD (zero active claims — prior session reaped mid-build; worktree/commits likely intact). Orchestrator parents, test fixtures, human-action SDs and live-held SDs are never adopted. | Run `node scripts/sd-start.js <sd>` — it re-attaches the existing worktree (or resumes from the pushed branch) and reads the SD's live `current_phase`. Load that phase's context and **continue the handoff chain from where the prior session left off** (the message names the phase as a hint; sd-start is authoritative). NOT a restart — keep existing commits/PRD/handoffs. | On completion, re-run `/checkin`. |
 | `claimed_assignment` | Claimed the coordinator's assigned `sd` via `claim_sd` | Run `node scripts/sd-start.js <sd>`, load phase context, build it. | On completion, re-run `/checkin`. |
 | `self_claimed` | No assignment, so claimed the top of `sd:next` (`sd`) | Run `node scripts/sd-start.js <sd>`, load phase context, build it. | On completion, re-run `/checkin`. |
 | `self_claimed_qf` | No claimable SD, so self-claimed an open quick-fix (`qf`) from the open-QF queue | Run `node scripts/read-quick-fix.js <qf>`, then the `/quick-fix` workflow (implement ≤50 LOC on branch `qf/<qf>`, run tests, then `node scripts/complete-quick-fix.js <qf>`) — **NOT** `sd-start.js` (it only knows `strategic_directives_v2` and would exit "SD not found" for a QF id). | On completion, re-run `/checkin`. |
@@ -61,7 +62,7 @@ The CLI prints **one JSON object** describing the resolved action. It does the w
 
 This is an autonomous-fleet contract: a `/loop` worker must keep moving. Decide from the JSON, act, and proceed. Never end a check-in by asking the operator what to do (no human watches the loop window).
 
-**The cycle never terminates on its own.** For `resume` / `resume_final` / `claimed_assignment` /
+**The cycle never terminates on its own.** For `resume` / `resume_final` / `resume_orphan` / `claimed_assignment` /
 `self_claimed`: build the SD through completion (for `resume_final`, just run the final
 LEAD-FINAL-APPROVAL handoff + post-completion tail), then **re-run `/checkin`** to pull the next
 one — if you instead just stop after finishing the SD, the loop never fires again and you go

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -310,6 +310,79 @@ async function recoverStrandedFinal(sb, sessionId, base) {
   return null;
 }
 
+// SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001: adopt ORPHANED in_progress SDs (zero active claims).
+// A session reaped mid-build (worktree + commits intact) leaves its SD in_progress with
+// claiming_session_id NULL — invisible to EVERY other tier: step 4 needs claude_sessions.sd_key,
+// step 5.7 only covers pending_approval/LEAD_FINAL, and step 6's isSdInFlight guard skips any SD
+// past LEAD (the exact bug: the orphan IS past LEAD, so checkin idled while sd:next flagged
+// LOCAL_ACTIVITY; recovery was a human-driven manual claim_sd — witnessed 2026-06-10 adopting
+// SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001). This tier mirrors recoverStrandedFinal: age-guarded
+// query, shared eligibility classifier, live-holder probe, claim_sd as the final race arbiter,
+// fail-open, idempotent (a re-strand is re-adopted next checkin).
+//
+// Sweep interaction (validated, do NOT re-introduce a destructive reset): the stale-session
+// sweep's phantom-detect (QF-20260426-SWEEP-PHANTOM-DETECT) targets the same zero-claim
+// in_progress population but RESETS it to draft/LEAD — gated by assertSweepHandoffGate, which
+// SKIPS any SD with an accepted handoff past LEAD. So the mid-build orphans this tier adopts
+// survive the sweep, and LEAD-phase no-commit orphans the sweep resets are picked up by the
+// draft tier (6.25) instead. Disjoint dispositions, no race.
+//
+// NOTE: isSdInFlight is deliberately NOT reused here — its phase!=LEAD leg would veto every
+// orphan by definition; only its live-foreign-holder leg applies (inlined below). claim_sd
+// independently refuses live peers (already_claimed / claimed_by_live_peer) and terminal
+// statuses ({completed,cancelled,deferred} — in_progress is claimable), so the probe is
+// defense-in-depth, not the sole guard.
+const ORPHAN_CANDIDATE_LIMIT = 5;
+// One full claim-TTL window (claimGuard TTL = 15 min): a mid-transition worker whose claim
+// briefly clears is never raced; sweep claim-clears also refresh updated_at, deferring adoption
+// one window past the clear. A genuine orphan sits indefinitely — the delay is safe.
+const ORPHAN_MIN_AGE_MS = 15 * 60 * 1000;
+
+async function adoptOrphanInProgress(sb, sessionId, base) {
+  try {
+    const cutoffIso = new Date(Date.now() - ORPHAN_MIN_AGE_MS).toISOString();
+    const { data: orphans } = await sb
+      .from('strategic_directives_v2')
+      // sd_key/sd_type/metadata feed classifyDispatchIneligibility; current_phase feeds the
+      // resume message (advisory — sd-start reads the live phase authoritatively on attach).
+      .select('sd_key, sd_type, status, current_phase, metadata, updated_at')
+      .eq('status', 'in_progress')
+      .is('claiming_session_id', null)
+      .neq('sd_type', 'orchestrator')         // parents are in_progress/no-claim BY DESIGN while children run
+      .lt('updated_at', cutoffIso)            // parked > one claim-TTL window — not a mid-transition race
+      .order('updated_at', { ascending: true }) // oldest orphan first
+      .limit(ORPHAN_CANDIDATE_LIMIT);
+    for (const sd of (orphans || [])) {
+      // Shared classifier (same predicate as the draft tier + coordinator sweep): orchestrator
+      // (redundant with .neq — harmless), test-fixture keys (SD-DEMO-*/SD-TEST-*), and
+      // metadata.requires_human_action all skip.
+      if (classifyDispatchIneligibility(sd) !== null) continue;
+      // Live-foreign-holder probe (the half-write case: SD-side claim cleared but a LIVE session
+      // still points at it via claude_sessions.sd_key). Fail-open: probe errors don't block.
+      try {
+        const { data: live } = await sb
+          .from('v_active_sessions')
+          .select('session_id')
+          .eq('sd_key', sd.sd_key)
+          .neq('session_id', sessionId)
+          .eq('is_alive', true)
+          .limit(1);
+        if (live && live.length) continue;
+      } catch { /* fail-open: claim_sd still arbitrates */ }
+      const claimed = await tryClaim(sb, sd.sd_key, sessionId);
+      if (claimed.ok) {
+        return {
+          ...base,
+          action: 'resume_orphan',
+          sd: sd.sd_key,
+          message: `Adopted ORPHANED in_progress SD ${sd.sd_key} (zero active claims — prior session reaped mid-build; worktree/commits likely intact). Re-attach + continue: node scripts/sd-start.js ${sd.sd_key} (re-attaches the existing worktree / resumes from the pushed branch), then continue the handoff chain from its live phase (currently ${sd.current_phase || 'unknown'} — sd-start reads the authoritative phase). On completion, re-run /checkin.`,
+        };
+      }
+    }
+  } catch { /* fail-open -> caller continues to normal self-claim */ }
+  return null;
+}
+
 /**
  * Dedup guard: should this SD candidate be SKIPPED by self-claim because it is already
  * being built? v_sd_next_candidates only filters completed/cancelled/deferred and
@@ -440,7 +513,7 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
 
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: actions whose result carries a freshly-held claim — every
 // path where a worker ends a check-in owning work and therefore deserves a name NOW.
-const CLAIMED_CHECKIN_ACTIONS = new Set(['resume', 'resume_final', 'claimed_assignment', 'self_claimed', 'self_claimed_qf']);
+const CLAIMED_CHECKIN_ACTIONS = new Set(['resume', 'resume_final', 'resume_orphan', 'claimed_assignment', 'self_claimed', 'self_claimed_qf']);
 
 // Public check-in entrypoint: resolve the action, then name a freshly-claimed, identity-less worker
 // before returning so the SAME response reports the callsign. Naming is a thin fail-open wrapper over
@@ -556,6 +629,13 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   const recovered = await recoverStrandedFinal(sb, sessionId, base);
   if (recovered) return recovered;
 
+  // 5.8 SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001: adopt an ORPHANED in_progress SD (zero active
+  //     claims, session reaped mid-build) BEFORE self-claiming new work — finishing a
+  //     partially-built SD beats starting fresh, but a one-handoff-from-shipped stranded final
+  //     (5.7) still wins over a mid-build orphan.
+  const adopted = await adoptOrphanInProgress(sb, sessionId, base);
+  if (adopted) return adopted;
+
   // 5.5 SD-FDBK-INFRA-AUTO-MAINTAIN-EXECUTION-001: ensure an active execution baseline exists
   //      BEFORE reading v_sd_next_candidates. With zero active baseline the view returns 0 rows
   //      and self-claim silently idles with a full queue. Fail-open: a failure here degrades to
@@ -620,7 +700,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, isSdInFlight, selfHealStaleClaim, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSdInFlight, selfHealStaleClaim, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
+const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
 
 describe('FR-2: extractSdFromAssignment', () => {
   it('prefers payload.sd_key', () => {
@@ -71,6 +71,18 @@ function makeStub(cfg) {
           if (state.filters.lt_updated_at !== undefined) {
             rows = rows.filter((r) => !r.updated_at || r.updated_at < state.filters.lt_updated_at);
           }
+          return Promise.resolve({ data: rows, error: null });
+        }
+        // adoptOrphanInProgress listing (SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001): a third
+        // STRING discriminant (.eq('status','in_progress')) — placed ABOVE the draft fallthrough.
+        // Honors the .lt('updated_at') age guard and the server-side .neq('sd_type') exclusion.
+        if (state.filters.status === 'in_progress') {
+          if (cfg.orphansThrow) return Promise.reject(new Error('orphan query failed'));
+          let rows = cfg.orphans || [];
+          if (state.filters.lt_updated_at !== undefined) {
+            rows = rows.filter((r) => !r.updated_at || r.updated_at < state.filters.lt_updated_at);
+          }
+          if (state.filters.neq_sd_type !== undefined) rows = rows.filter((r) => r.sd_type !== state.filters.neq_sd_type);
           return Promise.resolve({ data: rows, error: null });
         }
         // un-baselined-draft self-claim listing; honor the server-side `.neq('sd_type', …)` filter
@@ -629,6 +641,130 @@ describe('FIX-RECURRING-2ND: recover stranded pending_approval/LEAD_FINAL SDs', 
     };
     const r = await recoverStrandedFinal(throwingSb, 'sess-1', { ok: true });
     expect(r).toBeNull();
+  });
+});
+
+// SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001: adopt orphaned in_progress SDs (zero active claims,
+// session reaped mid-build). Mirrors the stranded-final block: adoption happy path, every
+// exclusion axis (orchestrator / fixture-key / human-action / live-held / young), tier ordering
+// (stranded > orphan > all new-work tiers), claim-race fallthrough, fail-open, fleet naming.
+describe('ORPHAN-ADOPTION: adopt zero-claim in_progress SDs (resume_orphan)', () => {
+  const sess = { session: { metadata: { callsign: 'Bravo' }, sd_key: null }, messages: [] };
+  const old = '2020-01-01T00:00:00Z'; // safely older than the 15-min age guard
+  const orphan = (sd_key, over = {}) => ({
+    sd_key, status: 'in_progress', sd_type: 'infrastructure', current_phase: 'EXEC',
+    metadata: {}, updated_at: old, ...over,
+  });
+
+  it('adopts an eligible orphan with action=resume_orphan and re-attach instructions', async () => {
+    const sb = makeStub({ ...sess, orphans: [orphan('SD-ORPHAN-001')], candidates: [], claimResults: { 'SD-ORPHAN-001': true } });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_orphan');
+    expect(r.sd).toBe('SD-ORPHAN-001');
+    expect(r.message).toMatch(/sd-start\.js SD-ORPHAN-001/);
+    expect(r.message).toMatch(/EXEC/); // advisory phase context in the message
+  });
+
+  it('excludes an orchestrator parent (in_progress/no-claim BY DESIGN while children run)', async () => {
+    const sb = makeStub({ ...sess, orphans: [orphan('SD-PARENT-001', { sd_type: 'orchestrator' })], candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle'); // server-side .neq filter (honored by the stub) — never adopted
+  });
+
+  it('excludes test-fixture keys and requires_human_action SDs (shared classifier axes)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [
+        orphan('SD-TEST-ORPHAN-001'),                                     // test_fixture_key axis
+        orphan('SD-HUMAN-001', { metadata: { requires_human_action: true } }), // human_action axis
+      ],
+      candidates: [],
+      claimResults: { 'SD-TEST-ORPHAN-001': true, 'SD-HUMAN-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle'); // both classifier-skipped despite being claimable
+  });
+
+  it('skips an orphan a LIVE foreign session still points at (claim half-write)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-HELD-001')],
+      activeSessions: [{ sd_key: 'SD-HELD-001', session_id: 'sess-OTHER', is_alive: true }],
+      candidates: [],
+      claimResults: { 'SD-HELD-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+  });
+
+  it('skips an orphan younger than the age guard (mid-transition worker never raced)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-YOUNG-001', { updated_at: new Date().toISOString() })], // fresher than cutoff
+      candidates: [],
+      claimResults: { 'SD-YOUNG-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+  });
+
+  it('stranded-final recovery (5.7) WINS over orphan adoption (5.8)', async () => {
+    const sb = makeStub({
+      ...sess,
+      stranded: [{ sd_key: 'SD-STRANDED-001', status: 'pending_approval', current_phase: 'LEAD_FINAL', updated_at: old }],
+      orphans: [orphan('SD-ORPHAN-001')],
+      candidates: [],
+      claimResults: { 'SD-STRANDED-001': true, 'SD-ORPHAN-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_final');
+    expect(r.sd).toBe('SD-STRANDED-001');
+  });
+
+  it('orphan adoption WINS over baselined / draft / QF self-claim (5.8 before 6/6.25/6.5)', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-ORPHAN-001')],
+      candidates: [{ sd_id: 'SD-NEWWORK-001', track: 'A' }],
+      drafts: [{ sd_key: 'SD-DRAFT-001', status: 'draft', sd_type: 'feature', priority: 'critical', created_at: '2026-01-01T00:00:00Z', dependencies: [] }],
+      quickFixes: [{ id: 'QF-20260601-001', status: 'open', created_at: new Date().toISOString() }],
+      claimResults: { 'SD-ORPHAN-001': true, 'SD-NEWWORK-001': true, 'SD-DRAFT-001': true, 'QF-20260601-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_orphan');
+    expect(r.sd).toBe('SD-ORPHAN-001');
+  });
+
+  it('falls through to the next candidate when the first orphan loses the claim race', async () => {
+    const sb = makeStub({
+      ...sess,
+      orphans: [orphan('SD-CONTESTED-001'), orphan('SD-ORPHAN-002', { updated_at: '2020-06-01T00:00:00Z' })],
+      candidates: [],
+      claimResults: { 'SD-CONTESTED-001': false, 'SD-ORPHAN-002': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_orphan');
+    expect(r.sd).toBe('SD-ORPHAN-002');
+  });
+
+  it('adoptOrphanInProgress returns null (not throw) on a query error — fail-open', async () => {
+    const sb = makeStub({ ...sess, orphansThrow: true, candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('idle'); // error swallowed; resolver fell through, never action=error
+    const direct = await adoptOrphanInProgress(makeStub({ orphansThrow: true }), 'sess-1', { ok: true });
+    expect(direct).toBeNull();
+  });
+
+  it('runCheckin names an UNNAMED worker on resume_orphan (CLAIMED_CHECKIN_ACTIONS coverage)', async () => {
+    const sb = makeStub({
+      session: { metadata: {}, sd_key: null }, messages: [],
+      orphans: [orphan('SD-ORPHAN-001')], candidates: [],
+      claimResults: { 'SD-ORPHAN-001': true },
+    });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('resume_orphan');
+    expect(r.callsign).toBe('Alpha'); // named at check-in, same response
   });
 });
 


### PR DESCRIPTION
## SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001 — /checkin adopts orphaned in_progress SDs

**The gap:** an `in_progress` SD with **zero active claims** (prior session reaped mid-build; worktree + commits intact) was invisible to every checkin tier — step 4 needs `claude_sessions.sd_key`, 5.7 only covers `pending_approval/LEAD_FINAL`, and step 6's `isSdInFlight` guard skips any SD past LEAD (the exact bug). `/checkin` idled while `sd:next` flagged `LOCAL_ACTIVITY`; recovery was a human-driven manual `claim_sd` (witnessed 2026-06-10: SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001, shipped at 99 after manual adoption).

**The fix:** `adoptOrphanInProgress` tier at step **5.8** (below stranded-final recovery — one-handoff-from-shipped still wins; above all new-work tiers — finishing partially-built work beats starting fresh), mirroring the proven `recoverStrandedFinal` pattern:
- 15-min age guard (one full claim-TTL window — mid-transition workers never raced)
- shared `classifyDispatchIneligibility` (orchestrator parents are in_progress/no-claim **by design** — never adopted; fixtures + human-action skip)
- live-foreign-holder probe via `v_active_sessions` (claim half-write case)
- `claim_sd` RPC as the final race arbiter (independently refuses live peers; `in_progress` claimable per the terminal guard)
- fail-open + idempotent

**Sweep interaction validated** (a5d489fb): the phantom-detect (QF-20260426-SWEEP-PHANTOM-DETECT) resets only LEAD-phase no-handoff orphans; `assertSweepHandoffGate` protects the mid-build population — disjoint dispositions, no race (recorded in the tier comment).

`resume_orphan` joins `CLAIMED_CHECKIN_ACTIONS` (fleet-identity naming) + the `/checkin` skill action table. **Tests: 71/71** (10 new: adoption, all 4 exclusion axes, tier ordering, claim-race fallthrough, fail-open, naming). EXEC TESTING ran a live CLI probe with full claim release + zero residue (656d51d5, 96).

Gates: LEAD-TO-PLAN 96 · PLAN-TO-EXEC 97 · EXEC-TO-PLAN 93 · PLAN-TO-LEAD 96. Retro 96847a10 (90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
