### PR TITLE
fix(cli): bounded graceful teardown for create-quick-fix (exit-hang class)

### DIFF
--- a/lib/cli-graceful-exit.js
+++ b/lib/cli-graceful-exit.js
@@ -1,0 +1,60 @@
+/**
+ * Shared CLI graceful-teardown primitive — the exit-hang / UV_HANDLE_CLOSING class.
+ * SD-FDBK-INFRA-SWEEP-CLI-EXIT-001 (recipe proven in PR #4505:
+ * scripts/hooks/post-completion-tail-enforcement.cjs shutdown(), lines 54-64).
+ *
+ * The class has two failure modes, both cured here:
+ *  (a) HANG: a CLI whose success path never exits relies on natural event-loop drain; any
+ *      lingering handle (keep-alive socket, stray interval, child pipe) keeps the process
+ *      alive until the CALLER's timeout SIGTERMs it (exit-143). Live consequence: the
+ *      quick_fixes row was already inserted, the caller saw "failure" and blind-retried,
+ *      creating a duplicate QF (QF-20260610-541 / QF-20260610-221).
+ *  (b) ABORT: calling process.exit() right after a Supabase/undici query aborts on Windows —
+ *      libuv loop teardown races a socket/threadpool uv_async_send() on a handle already
+ *      flagged UV_HANDLE_CLOSING ("Assertion failed: !(handle->flags & UV_HANDLE_CLOSING),
+ *      src\\win\\async.c:76"). Empirically this reproduces even after a setImmediate-deferred
+ *      exit AND after dispatcher.close() if exit() is still called.
+ *
+ * The only reliable shape (proven): do NOT call process.exit() — set process.exitCode for
+ * errors, close undici's idle sockets to accelerate drain, and arm an UNREF'D backstop timer
+ * that force-exits only if the loop somehow fails to drain. The backstop is safe: it is unref'd
+ * (never delays/holds a clean natural exit), and by the time it could fire the sockets are
+ * already closed, so its exit cannot race a live handle.
+ *
+ * ⚠ Arm AFTER your CLI's work fully settles (promise resolve/reject) — never before: the
+ * backstop would kill legitimately-slow steps (npm provisioning can run minutes).
+ *
+ * ESM on purpose: the ~8 prior implementations of this recipe are hand-rolled cjs/mjs copies;
+ * ESM CLIs (like create-quick-fix.js) had nothing importable. Follow-up flagged to converge
+ * the hand-rolled sites onto this helper.
+ */
+
+let armed = false;
+
+/**
+ * Arm the graceful teardown. Idempotent — only the first call takes effect.
+ *
+ * @param {number} [exitCode=0]   process exit code; non-zero is set via process.exitCode
+ *                                (never a direct process.exit — that is failure mode (b)).
+ * @param {object} [opts]
+ * @param {number} [opts.backstopMs=8000]  last-resort force-exit delay; unref'd.
+ * @returns {Promise<void>} resolves after the dispatcher close attempt (awaitable in tests;
+ *                          production callers may fire-and-return).
+ */
+export async function armCliTeardown(exitCode = 0, { backstopMs = 8000 } = {}) {
+  if (armed) return;
+  armed = true;
+  if (exitCode) process.exitCode = exitCode;
+  // Backstop ONLY — unref'd so it never delays a clean natural exit; if it ever fires the
+  // sockets are already closed, so this exit can't race a live one.
+  setTimeout(() => process.exit(exitCode), backstopMs).unref();
+  try {
+    const { getGlobalDispatcher } = await import('undici');
+    await getGlobalDispatcher().close();
+  } catch { /* undici absent or already closed — natural drain still applies */ }
+  // Deliberately NO process.exit() — returning lets Node exit once the loop drains.
+}
+
+/** Test hook: report/reset the armed latch (idempotency assertions). Not for production use. */
+export function _isArmed() { return armed; }
+export function _resetForTests() { armed = false; }

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -26,6 +26,7 @@ import { routeWorkItem } from '../lib/utils/work-item-router.js';
 import { getRepoPaths, ENGINEER_ROOT } from '../lib/repo-paths.js';
 import { preclaimFeedbackRows, resolveFeedbackIds, findFeedbackRefConflicts } from '../lib/feedback/preclaim-feedback-rows.js';
 import { releasePreclaim } from '../lib/feedback/release-preclaim.js';
+import { armCliTeardown } from '../lib/cli-graceful-exit.js';
 
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
 const __filename = fileURLToPath(import.meta.url);
@@ -674,8 +675,17 @@ Tiered Routing:
   }
 }
 
-// Run
-createQuickFix(options).catch((err) => {
-  console.error('❌ Error:', err.message);
-  process.exit(1);
-});
+// Run — both paths route through the shared graceful teardown, armed only AFTER the work
+// settles (worktree creation / npm provisioning can legitimately run minutes; a pre-armed
+// backstop would kill them mid-work). Success: no process.exit — natural drain, bounded by
+// the helper's unref'd backstop, so this CLI can never again hang to the caller's Bash
+// timeout (SIGTERM/143) after the quick_fixes row was already inserted — the failure that
+// caused the blind-retry duplicate QF-20260610-541/QF-20260610-221. Errors: exitCode=1 via
+// the helper (a direct process.exit after Supabase queries aborts on Windows with
+// UV_HANDLE_CLOSING). SD-FDBK-INFRA-SWEEP-CLI-EXIT-001.
+createQuickFix(options)
+  .then(() => armCliTeardown(0))
+  .catch((err) => {
+    console.error('❌ Error:', err.message);
+    return armCliTeardown(1);
+  });

--- a/tests/cli-graceful-exit.test.js
+++ b/tests/cli-graceful-exit.test.js
@@ -1,0 +1,84 @@
+/**
+ * SD-FDBK-INFRA-SWEEP-CLI-EXIT-001 — shared CLI graceful-teardown primitive.
+ *
+ * Subprocess-based (offline, no live DB): each scenario runs a tiny child node process so we
+ * can observe REAL exit codes and REAL event-loop drain — the things the helper exists to fix.
+ * Plus a static pin that create-quick-fix.js's entry point routes through the helper.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const HELPER = path.join(ROOT, 'lib', 'cli-graceful-exit.js').replace(/\\/g, '/');
+
+function runChild(script, timeoutMs = 15000) {
+  const t0 = Date.now();
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    encoding: 'utf8', timeout: timeoutMs, cwd: ROOT,
+  });
+  return { ...r, elapsedMs: Date.now() - t0 };
+}
+
+describe('armCliTeardown — child-process contract', () => {
+  it('natural drain: exits 0 well under the backstop with NO process.exit call', () => {
+    const r = runChild(`
+      const { armCliTeardown } = await import('file://${HELPER}');
+      await armCliTeardown(0, { backstopMs: 10000 });
+      // no lingering handles -> loop drains; if the backstop were the exit path this would take 10s
+    `);
+    expect(r.status).toBe(0);
+    expect(r.elapsedMs).toBeLessThan(5000); // drained naturally, nowhere near the 10s backstop
+  });
+
+  it('error path: exitCode 1 via process.exitCode (no direct exit)', () => {
+    const r = runChild(`
+      const { armCliTeardown } = await import('file://${HELPER}');
+      await armCliTeardown(1, { backstopMs: 10000 });
+    `);
+    expect(r.status).toBe(1);
+    expect(r.elapsedMs).toBeLessThan(5000);
+  });
+
+  it('backstop rescue: a stuck loop (ref-d interval) is force-exited at ~backstopMs', () => {
+    const r = runChild(`
+      const { armCliTeardown } = await import('file://${HELPER}');
+      setInterval(() => {}, 1000); // ref'd handle — loop can never drain naturally
+      await armCliTeardown(0, { backstopMs: 1500 });
+    `);
+    expect(r.status).toBe(0);
+    expect(r.elapsedMs).toBeGreaterThanOrEqual(1400); // waited for the backstop...
+    expect(r.elapsedMs).toBeLessThan(8000);           // ...but did NOT hang to the caller timeout
+  });
+
+  it('idempotent: second call is a no-op (single backstop, first exitCode wins)', () => {
+    const r = runChild(`
+      const { armCliTeardown, _isArmed } = await import('file://${HELPER}');
+      await armCliTeardown(0, { backstopMs: 10000 });
+      await armCliTeardown(1, { backstopMs: 50 }); // must be ignored — would exit 1 fast if not
+      if (!_isArmed()) process.exitCode = 99;
+    `);
+    expect(r.status).toBe(0); // second call's exitCode/backstop ignored
+  });
+});
+
+describe('create-quick-fix.js entry-point wiring (static pin)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'scripts', 'create-quick-fix.js'), 'utf8');
+
+  it('imports the shared helper', () => {
+    expect(src).toMatch(/import \{ armCliTeardown \} from '\.\.\/lib\/cli-graceful-exit\.js'/);
+  });
+
+  it('resolve path routes through armCliTeardown(0); reject path through armCliTeardown(1)', () => {
+    expect(src).toMatch(/\.then\(\(\) => armCliTeardown\(0\)\)/);
+    expect(src).toMatch(/return armCliTeardown\(1\);/);
+  });
+
+  it('entry point has no bare process.exit (teardown owns the exit)', () => {
+    const entry = src.slice(src.lastIndexOf('createQuickFix(options)'));
+    expect(entry).not.toMatch(/process\.exit\(/);
+  });
+});


### PR DESCRIPTION
@
## SD-FDBK-INFRA-SWEEP-CLI-EXIT-001

Fixes the CLI exit-hang class for `create-quick-fix.js`: the entry point had **no success-path exit**, so any lingering handle after the post-create steps hung the process until the caller's 120s Bash timeout SIGTERM'd it (exit-143) — *after* the `quick_fixes` row was inserted. A blind caller retry then created a live duplicate (QF-20260610-541 / QF-20260610-221).

### Change (+159/-5)
- **New shared ESM `lib/cli-graceful-exit.js`** — `armCliTeardown(exitCode, {backstopMs=8000})`: unref'd backstop timer + `undici getGlobalDispatcher().close()` + **no** `process.exit` on success (natural drain); errors set `process.exitCode` (a direct exit after Supabase queries aborts on Windows: `UV_HANDLE_CLOSING`). Recipe proven in PR #4505; first importable ESM form (~8 hand-rolled cjs/mjs copies exist — convergence flagged as follow-up).
- **`create-quick-fix.js` entry point**: resolve → `armCliTeardown(0)`, reject → log + `armCliTeardown(1)`, armed **only after** `createQuickFix` settles — legitimately-slow worktree/npm provisioning is never killed mid-work (statically pinned).
- **7 tests**: 4 real-subprocess (natural drain <1s with a 10s backstop; stuck ref'd-interval loop rescued at ~1.5s; exitCode propagation; idempotency) + 3 static wiring pins.

### LEAD premise corrections
`restartLeoStack` does not appear in the file (SD hypothesis dropped); the QF id already prints before the worktree steps; a drain-profile probe showed the import set + a live select drains in ~1ms — the cure is the bounded teardown, not the SD's original fix menu.

Gates: LEAD-TO-PLAN 94 · PLAN-TO-EXEC 97 · EXEC-TO-PLAN 97 · PLAN-TO-LEAD 96 · TESTING PASS · retro 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@