### PR TITLE
fix(SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001): flag-registry integrity — lifecycle CHECK + review-aware updated_at

### DIFF
--- a/database/migrations/20260610_flag_registry_lifecycle_consistency.sql
+++ b/database/migrations/20260610_flag_registry_lifecycle_consistency.sql
@@ -1,0 +1,117 @@
+-- @approved-by:codestreetlabs@gmail.com
+-- =============================================================================
+-- SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001
+-- leo_feature_flags registry integrity: reconcile is_enabled<->lifecycle_state
+-- contradictions, enforce the coupling with a CHECK, and stop review-only
+-- stamps (last_reviewed_at) from clobbering updated_at.
+--
+-- Live-verified defects (2026-06-10):
+--   (1) 3 of 17 rows read is_enabled=true with lifecycle_state in (draft,disabled)
+--       (COORDINATOR_TWOWAY_V2, COORD_ADAM_REVIEW_V1, FLAG_GOVERNANCE_REVIEW_V1).
+--       lib/feature-flags/evaluator.js gates them OFF at runtime despite
+--       is_enabled=true — the "registry lied" failure mode from the 2026-06-09
+--       dormant-switch audit. All 3 are genuinely live (env/cron side channels),
+--       so the reconcile direction is lifecycle_state -> 'enabled'. NOTE this is
+--       an INTENDED behavioral change: the evaluator will gate them ON post-apply.
+--   (2) ALL 17 rows share ONE updated_at: the daily flag-governance-review stamps
+--       last_reviewed_at on every row, and the generic trigger_set_updated_at
+--       (shared by triggers on FIVE tables) unconditionally bumps updated_at —
+--       destroying change-detection on the registry.
+--
+-- Constraint form is the BICONDITIONAL is_enabled = (lifecycle_state='enabled'),
+-- deliberately stronger than the implication form: getEnabledFlags
+-- (lib/feature-flags/registry.js) filters on is_enabled ALONE, so a
+-- (true, expired) row the weaker form permits would lie to it. The canonical
+-- writer transitionLifecycleState always couples both fields (is_enabled =
+-- newState==='enabled', including false for expired/archived), so no legitimate
+-- writer is blocked. The two formerly-uncoupled writers (registry.js updateFlag,
+-- scripts/eva/activate-rubric-v2.mjs setFlagEnabled) are coupled in the same PR.
+--
+-- NO BEGIN/COMMIT here: scripts/apply-migration.js wraps the whole file in one
+-- transaction. Rollback: 20260610_flag_registry_lifecycle_consistency_rollback.sql
+-- (repoints the trigger back + drops the new fn and CHECK; the data reconcile is
+-- NOT reverted — it matches reality).
+-- =============================================================================
+
+-- ── 1. Reconcile the 3 contradictory rows (must precede the CHECK) ──────────
+-- Assert-guarded: abort if the live state drifted from the verified snapshot.
+DO $$
+DECLARE
+  fixed integer;
+BEGIN
+  UPDATE leo_feature_flags
+     SET lifecycle_state = 'enabled'
+   WHERE is_enabled = true
+     AND lifecycle_state IN ('draft', 'disabled');
+  GET DIAGNOSTICS fixed = ROW_COUNT;
+  IF fixed <> 3 THEN
+    RAISE EXCEPTION 'reconcile expected exactly 3 contradictory rows, found % — live state drifted; re-verify before applying', fixed;
+  END IF;
+END $$;
+
+-- ── 2. Enforce the invariant ─────────────────────────────────────────────────
+-- lifecycle_state is NOT NULL DEFAULT 'enabled' (verified live), so no NULL arm.
+ALTER TABLE leo_feature_flags
+  ADD CONSTRAINT chk_flag_lifecycle_enabled_consistency
+  CHECK (is_enabled = (lifecycle_state = 'enabled'));
+
+COMMENT ON CONSTRAINT chk_flag_lifecycle_enabled_consistency ON leo_feature_flags IS
+  'SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001: is_enabled and lifecycle_state cannot diverge. Biconditional (not implication) because getEnabledFlags filters on is_enabled alone. Writers must couple both fields (see registry.js computeCoupledLifecycleState / transitionLifecycleState).';
+
+-- ── 3. Review-aware updated_at trigger for THIS table only ──────────────────
+-- The generic trigger_set_updated_at() is shared by triggers on 5 tables
+-- (constitutional_amendments, leo_feature_flag_policies, leo_feature_flags,
+-- leo_kill_switches, strategic_themes) and MUST NOT change. This table-specific
+-- function preserves OLD.updated_at when the row delta — excluding updated_at,
+-- last_reviewed_at, and row_version — is empty (a review-only stamp).
+-- row_version MUST be excluded: fn_increment_feature_flag_version (a separate
+-- BEFORE UPDATE trigger) bumps it on every update, so without the exclusion the
+-- delta would never be empty (and exclusion keeps this firing-order-independent).
+-- jsonb - text[] drops the keys and automatically covers future columns.
+CREATE OR REPLACE FUNCTION trigger_set_updated_at_flags_review_aware()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'extensions'
+AS $fn$
+DECLARE
+  excluded text[] := ARRAY['updated_at', 'last_reviewed_at', 'row_version'];
+  old_rest jsonb := to_jsonb(OLD) - excluded;
+  new_rest jsonb := to_jsonb(NEW) - excluded;
+BEGIN
+  IF old_rest IS DISTINCT FROM new_rest THEN
+    NEW.updated_at := now();           -- substantive change: bump as before
+  ELSE
+    NEW.updated_at := OLD.updated_at;  -- review-only stamp: preserve the signal
+  END IF;
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS set_updated_at_leo_feature_flags ON leo_feature_flags;
+CREATE TRIGGER set_updated_at_leo_feature_flags
+  BEFORE UPDATE ON leo_feature_flags
+  FOR EACH ROW
+  EXECUTE FUNCTION trigger_set_updated_at_flags_review_aware();
+
+-- ── 4. Post-conditions (abort the transaction if anything is off) ───────────
+DO $$
+DECLARE
+  violations integer;
+  enabled_three integer;
+BEGIN
+  SELECT count(*) INTO violations
+    FROM leo_feature_flags
+   WHERE is_enabled <> (lifecycle_state = 'enabled');
+  IF violations <> 0 THEN
+    RAISE EXCEPTION 'post-condition failed: % rows still violate the invariant', violations;
+  END IF;
+
+  SELECT count(*) INTO enabled_three
+    FROM leo_feature_flags
+   WHERE flag_key IN ('COORDINATOR_TWOWAY_V2', 'COORD_ADAM_REVIEW_V1', 'FLAG_GOVERNANCE_REVIEW_V1')
+     AND is_enabled = true
+     AND lifecycle_state = 'enabled';
+  IF enabled_three <> 3 THEN
+    RAISE EXCEPTION 'post-condition failed: expected the 3 named flags at (true, enabled), found %', enabled_three;
+  END IF;
+END $$;

--- a/database/migrations/20260610_flag_registry_lifecycle_consistency_rollback.sql
+++ b/database/migrations/20260610_flag_registry_lifecycle_consistency_rollback.sql
@@ -1,0 +1,41 @@
+-- @approved-by:codestreetlabs@gmail.com
+-- =============================================================================
+-- ROLLBACK for 20260610_flag_registry_lifecycle_consistency.sql
+-- (SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001)
+--
+-- Restores the original trigger wiring (generic shared trigger_set_updated_at)
+-- and drops the CHECK + the review-aware function. The 3-row data reconcile is
+-- deliberately NOT reverted: lifecycle_state='enabled' on the three named flags
+-- matches their genuinely-live reality regardless of the schema objects.
+-- NO BEGIN/COMMIT: apply-migration.js wraps the file in one transaction.
+-- =============================================================================
+
+-- 1. Repoint the trigger back to the generic shared function.
+DROP TRIGGER IF EXISTS set_updated_at_leo_feature_flags ON leo_feature_flags;
+CREATE TRIGGER set_updated_at_leo_feature_flags
+  BEFORE UPDATE ON leo_feature_flags
+  FOR EACH ROW
+  EXECUTE FUNCTION trigger_set_updated_at();
+
+-- 2. Drop the review-aware function (no longer referenced).
+DROP FUNCTION IF EXISTS trigger_set_updated_at_flags_review_aware();
+
+-- 3. Drop the consistency CHECK.
+ALTER TABLE leo_feature_flags
+  DROP CONSTRAINT IF EXISTS chk_flag_lifecycle_enabled_consistency;
+
+-- Post-condition: original generic trigger is back in place.
+DO $$
+DECLARE
+  fn name;
+BEGIN
+  SELECT p.proname INTO fn
+    FROM pg_trigger t
+    JOIN pg_proc p ON p.oid = t.tgfoid
+    JOIN pg_class c ON c.oid = t.tgrelid
+   WHERE c.relname = 'leo_feature_flags'
+     AND t.tgname = 'set_updated_at_leo_feature_flags';
+  IF fn IS DISTINCT FROM 'trigger_set_updated_at' THEN
+    RAISE EXCEPTION 'rollback post-condition failed: trigger points at %, expected trigger_set_updated_at', fn;
+  END IF;
+END $$;

--- a/lib/feature-flags/registry.js
+++ b/lib/feature-flags/registry.js
@@ -183,6 +183,23 @@ export async function listFlags({ includeDisabled = true } = {}) {
 }
 
 /**
+ * The lifecycle_state a coupled is_enabled write must carry, mirroring transitionLifecycleState's
+ * mapping (isEnabled = newState === 'enabled'). Enabling always means lifecycle 'enabled';
+ * disabling moves an 'enabled' flag to 'disabled' and leaves any already-non-enabled state
+ * (draft/disabled/expired/archived) untouched — all of those satisfy is_enabled=false under the
+ * chk_flag_lifecycle_enabled_consistency biconditional. Exported for tests.
+ * SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001.
+ * @param {boolean} isEnabled
+ * @param {string|null|undefined} currentLifecycleState
+ * @returns {string}
+ */
+export function computeCoupledLifecycleState(isEnabled, currentLifecycleState) {
+  if (isEnabled) return 'enabled';
+  const current = currentLifecycleState || 'enabled';
+  return current === 'enabled' ? 'disabled' : current;
+}
+
+/**
  * Update a feature flag
  * @param {string} flagKey - Flag key to update
  * @param {Object} updates - Fields to update
@@ -204,7 +221,16 @@ export async function updateFlag(flagKey, updates, changedBy) {
   const updateData = {};
   if (updates.displayName !== undefined) updateData.display_name = updates.displayName;
   if (updates.description !== undefined) updateData.description = updates.description;
-  if (updates.isEnabled !== undefined) updateData.is_enabled = updates.isEnabled;
+  if (updates.isEnabled !== undefined) {
+    updateData.is_enabled = updates.isEnabled;
+    // SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001: is_enabled and lifecycle_state are coupled by
+    // the chk_flag_lifecycle_enabled_consistency CHECK (is_enabled = (lifecycle_state='enabled')).
+    // A lone isEnabled toggle would violate it, so co-set lifecycle_state with the same mapping
+    // transitionLifecycleState uses: true -> 'enabled'; false -> 'disabled' only when leaving
+    // 'enabled' (a flag already in draft/disabled/expired/archived keeps its state — those are
+    // all consistent with is_enabled=false).
+    updateData.lifecycle_state = computeCoupledLifecycleState(updates.isEnabled, currentFlag.lifecycle_state);
+  }
 
   const { data, error } = await supabase
     .from('leo_feature_flags')

--- a/scripts/eva/activate-rubric-v2.mjs
+++ b/scripts/eva/activate-rubric-v2.mjs
@@ -75,7 +75,12 @@ async function setV1Active(active) {
 
 async function setFlagEnabled(isEnabled) {
   // Do NOT pass row_version (trigger auto-bumps it).
-  const { error } = await supabase.from('leo_feature_flags').update({ is_enabled: isEnabled }).eq('flag_key', SUB_FLAG_KEY);
+  // SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001: co-set lifecycle_state — the
+  // chk_flag_lifecycle_enabled_consistency CHECK rejects a lone is_enabled write
+  // (is_enabled must equal (lifecycle_state='enabled')). Activate -> enabled;
+  // rollback -> disabled, matching transitionLifecycleState's coupling.
+  const lifecycle_state = isEnabled ? 'enabled' : 'disabled';
+  const { error } = await supabase.from('leo_feature_flags').update({ is_enabled: isEnabled, lifecycle_state }).eq('flag_key', SUB_FLAG_KEY);
   if (error) throw new Error(`UPDATE sub-flag is_enabled=${isEnabled} failed: ${error.message}`);
 }
 

--- a/tests/unit/flag-lifecycle-coupling.test.js
+++ b/tests/unit/flag-lifecycle-coupling.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001 — is_enabled <-> lifecycle_state coupling.
+ *
+ * The chk_flag_lifecycle_enabled_consistency CHECK enforces the biconditional
+ * is_enabled = (lifecycle_state='enabled'). These tests lock the JS-side coupling so no
+ * legitimate writer can produce a row the constraint rejects:
+ *   - computeCoupledLifecycleState (registry.js updateFlag's mapping, mirrors
+ *     transitionLifecycleState semantics)
+ *   - the activate-rubric-v2 setFlagEnabled coupling (static source pin — the script is a
+ *     top-level-await CLI, not importable without side effects)
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { computeCoupledLifecycleState } from '../../lib/feature-flags/registry.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+/** The CHECK predicate, mirrored exactly. */
+const satisfiesCheck = (isEnabled, lifecycleState) => isEnabled === (lifecycleState === 'enabled');
+
+describe('computeCoupledLifecycleState (registry.js updateFlag coupling)', () => {
+  it('enabling from ANY state lands on lifecycle enabled', () => {
+    for (const from of ['draft', 'disabled', 'enabled', 'expired', 'archived', null, undefined]) {
+      expect(computeCoupledLifecycleState(true, from)).toBe('enabled');
+    }
+  });
+
+  it('disabling an enabled flag moves it to disabled', () => {
+    expect(computeCoupledLifecycleState(false, 'enabled')).toBe('disabled');
+    // null/undefined defaults to 'enabled' (matching the registry's `|| 'enabled'` reads)
+    expect(computeCoupledLifecycleState(false, null)).toBe('disabled');
+    expect(computeCoupledLifecycleState(false, undefined)).toBe('disabled');
+  });
+
+  it('disabling preserves an already-non-enabled state (draft/disabled/expired/archived)', () => {
+    for (const from of ['draft', 'disabled', 'expired', 'archived']) {
+      expect(computeCoupledLifecycleState(false, from)).toBe(from);
+    }
+  });
+
+  it('EVERY (isEnabled, fromState) combination satisfies the CHECK biconditional', () => {
+    for (const isEnabled of [true, false]) {
+      for (const from of ['draft', 'disabled', 'enabled', 'expired', 'archived', null]) {
+        const out = computeCoupledLifecycleState(isEnabled, from);
+        expect(satisfiesCheck(isEnabled, out)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('source pins — uncoupled is_enabled writes are gone', () => {
+  it('registry.js updateFlag co-sets lifecycle_state with isEnabled', () => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'lib', 'feature-flags', 'registry.js'), 'utf8');
+    expect(src).toMatch(/updateData\.lifecycle_state\s*=\s*computeCoupledLifecycleState\(/);
+  });
+
+  it('activate-rubric-v2 setFlagEnabled co-sets lifecycle_state', () => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts', 'eva', 'activate-rubric-v2.mjs'), 'utf8');
+    // the update payload must carry BOTH fields
+    expect(src).toMatch(/update\(\{\s*is_enabled:\s*isEnabled,\s*lifecycle_state\s*\}\)/);
+  });
+
+  it('migration excludes row_version from the review-aware delta (firing-order independence)', () => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'database', 'migrations', '20260610_flag_registry_lifecycle_consistency.sql'), 'utf8');
+    expect(src).toMatch(/ARRAY\['updated_at',\s*'last_reviewed_at',\s*'row_version'\]/);
+    // biconditional CHECK form
+    expect(src).toMatch(/CHECK \(is_enabled = \(lifecycle_state = 'enabled'\)\)/);
+    // shared generic fn must not be redefined here
+    expect(src).not.toMatch(/CREATE OR REPLACE FUNCTION trigger_set_updated_at\(\)/);
+  });
+});


### PR DESCRIPTION
## SD-FDBK-INFRA-RECONCILE-LEO-FEATURE-001 — flag-registry integrity: lifecycle CHECK + review-aware updated_at

**Two live defects (chairman-directed harness review 2026-06-10):**
1. **The registry lied**: 3 of 17 rows read `is_enabled=true` with `lifecycle_state` in (draft, disabled) — `COORDINATOR_TWOWAY_V2`, `COORD_ADAM_REVIEW_V1`, `FLAG_GOVERNANCE_REVIEW_V1`. The evaluator gates on BOTH fields, so they evaluated **OFF** at runtime despite `is_enabled=true` (they only worked via env/cron side channels). Recurrence of the 2026-06-09 dormant-switch-audit failure mode.
2. **Change-detection destroyed**: ALL 17 rows shared ONE `updated_at` — the daily 9am governance review stamps `last_reviewed_at` on every row and the generic shared trigger unconditionally bumps `updated_at`.

**Migration** (`20260610_flag_registry_lifecycle_consistency.sql` — **already applied live** under the 3-factor guard, after a `BEGIN..ROLLBACK` rehearsal of UP+DOWN with byte-identical table fingerprint):
- Assert-guarded reconcile (exactly 3 rows → `lifecycle_state='enabled'`; **intended behavioral change**: they now evaluate ON, matching reality)
- **Biconditional CHECK** `is_enabled = (lifecycle_state='enabled')` — deliberately stronger than the implication form the DATABASE agent offered: `getEnabledFlags` filters on `is_enabled` alone, so a `(true, expired)` row would lie to it; the canonical `transitionLifecycleState` always couples, so no legitimate writer is blocked (deviation documented)
- **Review-aware trigger** for this table only: preserves `OLD.updated_at` when the row delta excluding (`updated_at`, `last_reviewed_at`, `row_version`) is empty. `row_version` exclusion is load-bearing (its own trigger bumps it every update). The generic fn serves 4 other tables — untouched.

**JS coupling fixes** (the 2 writers VALIDATION's full write-site inventory found setting `is_enabled` alone — the CHECK would have rejected them): `registry.js updateFlag` (new exported `computeCoupledLifecycleState`) and `activate-rubric-v2.mjs setFlagEnabled`.

**Verification**: rehearsal proved preserve/bump/reject branches in-txn; post-apply 6-probe sequence all PASS (constraint live, 0 violations, 3 flags (true,enabled), trigger repointed, live behavioral both branches, 4 sibling tables untouched). Tests: 7 new + 16/16 governance-review (no regression). TESTING EXEC `8d50de45` (97), DATABASE prospective `daaddf98` (88).

Organic regression check: tomorrow's 9am flag-review cron — `updated_at` must not re-collapse to a single value.

Gates: LEAD-TO-PLAN 96 · PLAN-TO-EXEC 97 · EXEC-TO-PLAN 93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
