### PR TITLE
feat(SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001): artifact-contract single source of truth (v1)

### DIFF
--- a/lib/artifact-contracts/index.js
+++ b/lib/artifact-contracts/index.js
@@ -1,0 +1,156 @@
+/**
+ * Artifact-contract single source of truth (SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001).
+ *
+ * validateArtifact(klass, payload, {mode}) — pure, synchronous, no DB.
+ *   mode 'shape'     — gate parity: exactly the checks add-prd's
+ *                      validateContentPayloadShape enforces (type/shape of
+ *                      keys WHEN PRESENT). This is what the gate imports.
+ *   mode 'authoring' — strict: shape + required keys + minItems + exactKeys.
+ *                      This is what `npm run contract:check` runs so authors
+ *                      see the FULL contract before any gate does.
+ *
+ * Violations are self-describing: {field, expected, got, hint}.
+ */
+import { PRD_FIELD_SPECS, scaffoldPrd } from './prd-contract.js';
+import { SD_FIELD_SPECS, scaffoldSd, validateSdExtras } from './sd-contract.js';
+
+export { PRD_FIELD_SPECS, SD_FIELD_SPECS };
+
+const SPECS = { prd: PRD_FIELD_SPECS, sd: SD_FIELD_SPECS };
+const SCAFFOLDS = { prd: scaffoldPrd, sd: scaffoldSd };
+
+const typeOf = (v) => (Array.isArray(v) ? 'array' : v === null ? 'null' : typeof v);
+
+/**
+ * Generic shape check for one spec entry. Returns violations ({field, expected, got, hint}).
+ * 'shape' mode checks ONLY keys present in the payload (gate parity);
+ * 'authoring' mode additionally enforces required/minItems/exactKeys.
+ */
+function checkField(spec, payload, mode) {
+  const violations = [];
+  const present = spec.field in payload;
+
+  if (!present) {
+    if (mode === 'authoring' && spec.required) {
+      violations.push({ field: spec.field, expected: `${spec.shape} (required)`, got: 'missing', hint: spec.hint });
+    }
+    return violations;
+  }
+
+  const v = payload[spec.field];
+  switch (spec.shape) {
+    case 'array':
+      if (!Array.isArray(v)) violations.push({ field: spec.field, expected: 'array', got: typeOf(v), hint: spec.hint });
+      break;
+    case 'object':
+      if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+        violations.push({ field: spec.field, expected: 'object', got: typeOf(v), hint: spec.hint });
+      }
+      break;
+    case 'arrayOfObjects':
+      if (!Array.isArray(v)) {
+        violations.push({ field: spec.field, expected: 'array', got: typeOf(v), hint: spec.hint });
+      } else {
+        v.forEach((item, idx) => {
+          if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+            violations.push({ field: `${spec.field}[${idx}]`, expected: 'object', got: typeOf(item), hint: spec.hint });
+          }
+        });
+      }
+      break;
+    case 'string':
+      // Gate parity: add-prd does not type-check string fields — authoring mode only.
+      if (mode === 'authoring' && typeof v !== 'string') {
+        violations.push({ field: spec.field, expected: 'string', got: typeOf(v), hint: spec.hint });
+      }
+      break;
+    default:
+      break;
+  }
+
+  // Nested shape checks (e.g. system_architecture.components must be an array)
+  // are part of the GATE behavior (add-prd recursion) — both modes.
+  if (spec.nested && typeof v === 'object' && v !== null && !Array.isArray(v)) {
+    for (const n of spec.nested) {
+      if (n.path in v && n.shape === 'array' && !Array.isArray(v[n.path])) {
+        violations.push({
+          field: `${spec.field}.${n.path}`, expected: 'array', got: typeOf(v[n.path]), hint: spec.hint,
+        });
+      }
+    }
+  }
+
+  if (mode === 'authoring') {
+    if (spec.minItems && Array.isArray(v) && v.length < spec.minItems) {
+      violations.push({ field: spec.field, expected: `>=${spec.minItems} items`, got: `${v.length} items`, hint: spec.hint });
+    }
+    if (spec.exactKeys && typeof v === 'object' && v !== null && !Array.isArray(v)) {
+      const keys = Object.keys(v).sort();
+      const want = [...spec.exactKeys].sort();
+      if (JSON.stringify(keys) !== JSON.stringify(want)) {
+        violations.push({
+          field: spec.field,
+          expected: `object with exactly the keys: ${spec.exactKeys.join(', ')}`,
+          got: `keys: ${keys.join(', ') || '(none)'}`,
+          hint: spec.hint,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Validate a payload against an artifact contract.
+ *
+ * @param {'sd'|'prd'} klass
+ * @param {object} payload
+ * @param {{mode?: 'shape'|'authoring'}} [opts]
+ * @returns {{valid: boolean, violations: Array, warnings: Array}}
+ */
+export function validateArtifact(klass, payload, opts = {}) {
+  const mode = opts.mode || 'authoring';
+  const specs = SPECS[klass];
+  if (!specs) throw new Error(`Unknown artifact class: ${klass} (expected 'sd' or 'prd')`);
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return {
+      valid: false,
+      violations: [{ field: '(top-level)', expected: 'object', got: typeOf(payload), hint: 'The artifact payload must be a JSON object.' }],
+      warnings: [],
+    };
+  }
+
+  const violations = [];
+  let warnings = [];
+  for (const spec of specs) violations.push(...checkField(spec, payload, mode));
+
+  // SD-specific extras (canonical metrics delegation + boilerplate-smoke advisory)
+  // run in authoring mode only — shape mode mirrors add-prd's PRD checks and has
+  // no SD gate counterpart today.
+  if (klass === 'sd' && mode === 'authoring') {
+    const extras = validateSdExtras(payload);
+    violations.push(...extras.violations);
+    warnings = extras.warnings;
+  }
+
+  return { valid: violations.length === 0, violations, warnings };
+}
+
+/**
+ * Render violations as the multi-line, field-level message used in
+ * CONTENT_SHAPE_VIOLATION errors and the contract:check CLI.
+ */
+export function formatViolations(violations) {
+  return violations
+    .map((v) => `  - .${v.field.replace(/^\./, '')}: expected ${v.expected}, got ${v.got}${v.hint ? `\n      hint: ${v.hint}` : ''}`)
+    .join('\n');
+}
+
+/** Return a valid authoring skeleton for the class (passes its own validation). */
+export function scaffold(klass) {
+  const fn = SCAFFOLDS[klass];
+  if (!fn) throw new Error(`Unknown artifact class: ${klass} (expected 'sd' or 'prd')`);
+  return fn();
+}

--- a/lib/artifact-contracts/prd-contract.js
+++ b/lib/artifact-contracts/prd-contract.js
@@ -1,0 +1,156 @@
+/**
+ * PRD artifact contract — the single declarative shape-spec source for PRD
+ * authoring payloads (SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001).
+ *
+ * Two consumption modes:
+ *   - 'shape' (gate parity): EXACTLY what scripts/add-prd-to-database.js
+ *     validateContentPayloadShape enforces today — type/shape of keys WHEN
+ *     PRESENT. add-prd derives its checks from this table (the v1 gate-source
+ *     inversion); behavior-identical by parity test.
+ *   - 'authoring' (strict): everything 'shape' checks PLUS required keys,
+ *     minimum counts, and exact-key sets that downstream quality gates
+ *     (scripts/prd/quality-validator.js, grounding scorer) enforce later.
+ *     Used by `npm run contract:check` so authors discover the full contract
+ *     BEFORE burning sub-agent orchestration — not by failing gates one at
+ *     a time.
+ *
+ * Every spec entry carries a `hint` quoting the folklore lesson that used to
+ * live only in validator code + session memories.
+ */
+
+/**
+ * @typedef {Object} FieldSpec
+ * @property {string} field        top-level payload key
+ * @property {'array'|'object'|'arrayOfObjects'|'string'} shape
+ * @property {boolean} [required]      enforced in authoring mode only
+ * @property {number}  [minItems]      enforced in authoring mode only
+ * @property {string[]} [exactKeys]    enforced in authoring mode only
+ * @property {string[]} [itemKeys]     advisory: expected keys per item (scaffold + hints)
+ * @property {{path:string, shape:string}[]} [nested]  nested shape checks (shape mode)
+ * @property {string}  hint
+ * @property {string}  gate            which gate/validator enforces this downstream
+ */
+
+/** @type {FieldSpec[]} */
+export const PRD_FIELD_SPECS = [
+  {
+    field: 'executive_summary', shape: 'string', required: true,
+    hint: 'Required by the PRD quality gate; 2-5 sentences grounding the SD intent.',
+    gate: 'scripts/prd/quality-validator.js',
+  },
+  {
+    field: 'functional_requirements', shape: 'arrayOfObjects', required: true, minItems: 3,
+    itemKeys: ['id', 'title', 'description', 'priority', 'acceptance_criteria'],
+    hint: 'Array of OBJECTS (strings fail SHAPE_VIOLATION). >=3 required by the DB functional_requirements_min_count. The grounding validator scores title + requirement + description (deduped) — write the rich SD-vocabulary body in any of those fields (SD-FDBK-FIX-FIX-PRD-GROUNDING-001).',
+    gate: 'add-prd shape + quality-validator + lib/prd-grounding-validator.js',
+  },
+  {
+    field: 'technical_requirements', shape: 'arrayOfObjects',
+    itemKeys: ['id', 'title', 'description'],
+    hint: 'Array of objects when present.',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'test_scenarios', shape: 'arrayOfObjects',
+    itemKeys: ['id', 'scenario', 'type', 'expected'],
+    hint: 'Array of objects when present.',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'risks', shape: 'arrayOfObjects',
+    itemKeys: ['risk', 'mitigation', 'severity'],
+    hint: 'Array of objects ({} instead of [] fails SHAPE_VIOLATION).',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'smoke_test_steps', shape: 'arrayOfObjects',
+    itemKeys: ['step_number', 'instruction', 'expected_outcome'],
+    hint: 'Array of {step_number, instruction, expected_outcome}. Write CONCRETE observable steps — boilerplate like "Run the modified script" fails SMOKE_TEST_SPECIFICATION at LEAD-TO-PLAN. NOTE: the gate reads the SD-level TOP-LEVEL smoke_test_steps column (not PRD metadata).',
+    gate: 'add-prd shape + SMOKE_TEST_SPECIFICATION (SD-level)',
+  },
+  {
+    field: 'acceptance_criteria', shape: 'array',
+    hint: 'Loose array (item shape varies).',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'strategic_objectives', shape: 'array',
+    hint: 'Loose array.',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'key_changes', shape: 'array',
+    hint: 'Loose array at the PRD layer. (The SD-level key_changes column is stricter: array of {change, type} objects — see the SD contract.)',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'integration_operationalization', shape: 'object', required: true,
+    exactKeys: ['consumers', 'dependencies', 'data_contracts', 'runtime_config', 'observability_rollout'],
+    hint: 'An OBJECT (an array here is the classic trap), with EXACTLY these keys: consumers, dependencies, data_contracts, runtime_config, observability_rollout. The GATE_INTEGRATION_SECTION_VALIDATION gate at PLAN-TO-EXEC expects this exact key set.',
+    gate: 'add-prd shape + GATE_INTEGRATION_SECTION_VALIDATION',
+  },
+  {
+    field: 'metadata', shape: 'object',
+    hint: 'Object when present.',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'system_architecture', shape: 'object',
+    nested: [{ path: 'components', shape: 'array' }],
+    hint: 'Object with a components ARRAY — a non-array components crashes scripts/prd/formatters.js downstream (SD-LEO-INFRA-HARDEN-ADD-PRD-001).',
+    gate: 'add-prd shape (nested components check)',
+  },
+  {
+    field: 'implementation_approach', shape: 'object',
+    hint: 'Object when present (string fails SHAPE_VIOLATION).',
+    gate: 'add-prd shape',
+  },
+  {
+    field: 'activation_test_id', shape: 'string',
+    hint: 'ADVISORY (not shape-enforced): code-producing SDs FAIL GATE_ACTIVATION_INVARIANT at LEAD-FINAL-APPROVAL unless product_requirements_v2.activation_test_id holds a relative test path that exists on disk AND the TESTING evidence row carries metadata.activation_invariant_verified=true. Set it at PRD authoring time.',
+    gate: 'GATE_ACTIVATION_INVARIANT (LEAD-FINAL-APPROVAL)',
+  },
+];
+
+/** A minimal valid PRD authoring payload (passes authoring-mode validation). */
+export function scaffoldPrd() {
+  return {
+    executive_summary: 'One-paragraph summary: the problem, the delivered change, and the verification story, grounded in the SD vocabulary.',
+    functional_requirements: [
+      { id: 'FR-1', title: 'First functional requirement', description: 'Rich SD-vocabulary description of the behavior delivered (this field is grounding-scored).', priority: 'critical', acceptance_criteria: ['Observable criterion 1'] },
+      { id: 'FR-2', title: 'Second functional requirement', description: 'Description with concrete file paths / behaviors.', priority: 'high', acceptance_criteria: ['Observable criterion 2'] },
+      { id: 'FR-3', title: 'Third functional requirement', description: 'At least 3 FRs are required by the DB constraint.', priority: 'medium', acceptance_criteria: ['Observable criterion 3'] },
+    ],
+    technical_requirements: [
+      { id: 'TR-1', title: 'Technical constraint', description: 'e.g. single-file, additive, no schema change.' },
+    ],
+    test_scenarios: [
+      { id: 'TS-1', scenario: 'Core behavior', type: 'unit', expected: 'Observable expected outcome' },
+    ],
+    acceptance_criteria: ['Top-level acceptance criterion'],
+    risks: [
+      { risk: 'Primary risk', mitigation: 'How it is contained', severity: 'low' },
+    ],
+    integration_operationalization: {
+      consumers: ['Who/what consumes this change'],
+      dependencies: ['What this change depends on'],
+      data_contracts: ['Schema/data contracts touched or "none"'],
+      runtime_config: ['Env vars/flags or "none"'],
+      observability_rollout: ['How rollout is observed/verified'],
+    },
+    system_architecture: {
+      summary: 'One-line architecture summary.',
+      components: [{ name: 'path/to/component', change: 'NEW or what changes' }],
+    },
+    implementation_approach: {
+      summary: 'One-line approach.',
+      steps: ['Step 1', 'Step 2'],
+    },
+    smoke_test_steps: [
+      { step_number: 1, instruction: 'Concrete command or user action', expected_outcome: 'Concrete observable outcome' },
+      { step_number: 2, instruction: 'Second concrete step', expected_outcome: 'Second observable outcome' },
+      { step_number: 3, instruction: 'Third concrete step', expected_outcome: 'Third observable outcome' },
+    ],
+    metadata: { sd_key: 'SD-XXX-001' },
+  };
+}

--- a/lib/artifact-contracts/sd-contract.js
+++ b/lib/artifact-contracts/sd-contract.js
@@ -1,0 +1,146 @@
+/**
+ * SD artifact contract — declarative field specs for Strategic Directive
+ * authoring payloads (SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001).
+ *
+ * The metrics-sufficiency rule is NOT re-implemented here: validateSdArtifact
+ * DELEGATES to the canonical validateMetricsSufficiency in
+ * scripts/modules/handoff/verifiers/lead-to-plan/sd-validation.js (the same
+ * pure function the GATE_SD_METRICS_SUFFICIENCY gate and the LEAD-TO-PLAN
+ * verifier already share) — one source, zero drift.
+ *
+ * Field hints quote the documented folklore traps so authors discover the
+ * contract from `npm run contract:check -- sd <file>` instead of by failing
+ * gates one at a time.
+ */
+import { validateMetricsSufficiency } from '../../scripts/modules/handoff/verifiers/lead-to-plan/sd-validation.js';
+
+/** Boilerplate smoke-step phrases the SMOKE_TEST_SPECIFICATION gate rejects.
+ *  Advisory (warning) in the contract — the gate itself is the enforcement. */
+export const BOILERPLATE_SMOKE_PATTERNS = [
+  /run the modified script/i,
+  /verify output matches expected behavior/i,
+  /confirm no regressions in related workflows/i,
+  /script executes without errors/i,
+  /output is correct and complete/i,
+  /existing functionality unchanged/i,
+];
+
+/** @type {import('./prd-contract.js').FieldSpec[]} */
+export const SD_FIELD_SPECS = [
+  {
+    field: 'success_metrics', shape: 'arrayOfObjects',
+    itemKeys: ['metric', 'target', 'actual'],
+    hint: '>=3 UNIQUE entries required (GATE_SD_METRICS_SUFFICIENCY dedups by text — padding with duplicates fails). Achievement scoring parses `actual` LEADING WITH A NUMBER (e.g. "8/8 — ..." or "0 — ..."); operator-prefixed targets (">=3", "<=0", unicode >=/<=) are supported post SD-FDBK-FIX-FIX-SUCCESS-METRICS-001. Validation DELEGATES to the canonical validateMetricsSufficiency.',
+    gate: 'GATE_SD_METRICS_SUFFICIENCY (LEAD-TO-PLAN; also fires at PLAN-TO-LEAD)',
+  },
+  {
+    field: 'success_criteria', shape: 'arrayOfObjects',
+    itemKeys: ['criterion', 'measure'],
+    hint: 'Alternative to success_metrics — at least ONE of the two must be populated with valid structure or LEAD-TO-PLAN fails GATE_SD_TRANSITION_READINESS.',
+    gate: 'GATE_SD_TRANSITION_READINESS',
+  },
+  {
+    field: 'smoke_test_steps', shape: 'arrayOfObjects',
+    itemKeys: ['step_number', 'instruction', 'expected_outcome'],
+    hint: 'The SMOKE_TEST_SPECIFICATION gate reads this TOP-LEVEL SD column (a metadata-located copy is only recovered via the auto-hoist fallback from SD-FDBK-FIX-FIX-SMOKE-TEST-001). Code-producing infrastructure SDs REQUIRE it. Steps must be CONCRETE + observable — auto-seeded boilerplate ("Run the modified script...") FAILS the gate.',
+    gate: 'SMOKE_TEST_SPECIFICATION (LEAD-TO-PLAN)',
+  },
+  {
+    field: 'key_changes', shape: 'arrayOfObjects',
+    itemKeys: ['change', 'type'],
+    hint: 'DB CHECK constraint key_changes_is_array requires an array of OBJECTS with change+type keys — an array of strings violates the constraint at insert time.',
+    gate: 'strategic_directives_v2 CHECK key_changes_is_array',
+  },
+  {
+    field: 'key_principles', shape: 'array', minItems: 1,
+    hint: 'DB CHECK key_principles_not_empty: when provided, must be a NON-EMPTY string array — [] violates the constraint. Omit entirely if none.',
+    gate: 'strategic_directives_v2 CHECK key_principles_not_empty',
+  },
+  {
+    field: 'delivers_capabilities', shape: 'array',
+    hint: 'Empty array [] is VALID and preferred for SDs with no formal capability rows (folklore that rows are mandatory is retired — fail-soft per SD-FDBK-FIX-ROOT-FIX-TRG-001). Capability completion writes are fail-soft.',
+    gate: 'fn_handle_capability_lifecycle (fail-soft)',
+  },
+  {
+    field: 'strategic_objectives', shape: 'array',
+    hint: 'String array; auto-seeded boilerplate is flagged (warning) by GATE_PLACEHOLDER_CONTENT_DETECTION — enrich before PLAN.',
+    gate: 'GATE_PLACEHOLDER_CONTENT_DETECTION (advisory)',
+  },
+  {
+    field: 'risks', shape: 'arrayOfObjects',
+    itemKeys: ['risk', 'mitigation'],
+    hint: 'Array of {risk, mitigation} objects when present.',
+    gate: 'SD quality validation',
+  },
+];
+
+/** A minimal valid SD authoring payload (passes authoring-mode validation). */
+export function scaffoldSd() {
+  return {
+    title: 'Short imperative title',
+    description: 'What is broken/missing, the evidence, and what this SD delivers — concrete and grounded.',
+    rationale: 'Why this matters now (business/operational justification).',
+    scope: 'IN: the bounded deliverables. OUT: explicitly excluded adjacent work.',
+    sd_type: 'infrastructure',
+    category: 'infrastructure',
+    priority: 'medium',
+    target_application: 'EHG_Engineer',
+    success_metrics: [
+      { metric: 'Primary observable outcome', target: '>=1 concrete threshold', actual: '0 — pre-build baseline (lead actual with a number)' },
+      { metric: 'Second unique metric', target: '<=0 regressions', actual: '0 — measured post-build' },
+      { metric: 'Third unique metric', target: '100% of N items', actual: '0 of N — updated at completion' },
+    ],
+    key_changes: [
+      { change: 'First concrete change', type: 'fix' },
+    ],
+    key_principles: ['Additive and reversible'],
+    smoke_test_steps: [
+      { step_number: 1, instruction: 'Concrete command or user action', expected_outcome: 'Concrete observable outcome' },
+      { step_number: 2, instruction: 'Second concrete step', expected_outcome: 'Second observable outcome' },
+      { step_number: 3, instruction: 'Third concrete step', expected_outcome: 'Third observable outcome' },
+    ],
+    delivers_capabilities: [],
+  };
+}
+
+/**
+ * SD-specific validation beyond generic shape checks.
+ * Returns extra violations/warnings arrays in the same {field, expected, got, hint}
+ * format used by validateArtifact.
+ */
+export function validateSdExtras(payload) {
+  const violations = [];
+  const warnings = [];
+
+  // Metrics sufficiency — DELEGATED to the canonical gate-shared implementation.
+  const metricsResult = validateMetricsSufficiency(payload);
+  if (!metricsResult.pass) {
+    for (const issue of metricsResult.issues || []) {
+      violations.push({
+        field: 'success_metrics',
+        expected: '>=3 unique success_metrics entries (or valid success_criteria)',
+        got: issue,
+        hint: 'Canonical check: validateMetricsSufficiency (gate-shared). Dedup is by text — pad-with-duplicates fails.',
+      });
+    }
+  }
+  for (const w of metricsResult.warnings || []) {
+    warnings.push({ field: 'success_metrics', expected: '', got: w, hint: 'Canonical metrics warning.' });
+  }
+
+  // Boilerplate smoke-step heuristic — ADVISORY in v1 (the gate enforces).
+  const steps = Array.isArray(payload.smoke_test_steps) ? payload.smoke_test_steps : [];
+  for (const [i, step] of steps.entries()) {
+    const text = `${step?.instruction || ''} ${step?.expected_outcome || ''}`;
+    if (BOILERPLATE_SMOKE_PATTERNS.some((re) => re.test(text))) {
+      warnings.push({
+        field: `smoke_test_steps[${i}]`,
+        expected: 'concrete, observable instruction + outcome',
+        got: (step?.instruction || '').slice(0, 60),
+        hint: 'Auto-seeded boilerplate fails SMOKE_TEST_SPECIFICATION at LEAD-TO-PLAN — replace with a real command/action and its observable result.',
+      });
+    }
+  }
+
+  return { violations, warnings };
+}

--- a/package.json
+++ b/package.json
@@ -303,6 +303,8 @@
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
+    "contract:scaffold": "node scripts/artifact-contract.js scaffold",
+    "contract:check": "node scripts/artifact-contract.js check",
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",

--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -50,6 +50,9 @@ import fs from 'node:fs';
 import { addPRDToDatabase } from './prd/index.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 import { startHeartbeat, stopHeartbeat } from '../lib/heartbeat-manager.mjs';
+// SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001: shape checks derive from the PRD
+// artifact contract (single spec source shared with contract:scaffold/check).
+import { validateArtifact, formatViolations } from '../lib/artifact-contracts/index.js';
 
 // SD-FDBK-INFRA-ADD-PRD-DATABASE-001: --content flag closes the INLINE-mode Catch-22.
 // 2MB cap prevents parse-bomb / memory-exhaustion on file or stdin input (R4 mitigation).
@@ -124,79 +127,24 @@ export function loadContentPayload(rawValue) {
  * @throws {Error} with code 'CONTENT_SHAPE_VIOLATION' if any key has the wrong type
  */
 export function validateContentPayloadShape(payload) {
+  // SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001 (gate-source inversion): the field
+  // list and shapes now come from the PRD artifact contract — the same spec that
+  // powers `npm run contract:scaffold/check` — so spec and enforcement cannot
+  // drift. mode:'shape' is BEHAVIOR-IDENTICAL to the previous hand-rolled checks
+  // (type/shape of keys WHEN PRESENT; required-key and minimum-count enforcement
+  // remain downstream in scripts/prd/quality-validator.js). Parity pinned by
+  // tests/unit/artifact-contracts/. Historical trap notes (grounding field-name
+  // trap e8008b14, integration_operationalization-as-array, the
+  // system_architecture.components formatter crash) now live as `hint` strings
+  // in lib/artifact-contracts/prd-contract.js and are rendered in the error.
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     const e = new Error(`--content: SHAPE_VIOLATION (top-level): expected object, got ${Array.isArray(payload) ? 'array' : payload === null ? 'null' : typeof payload}`);
     e.code = 'CONTENT_SHAPE_VIOLATION';
     throw e;
   }
-  const errors = [];
-  const typeOf = (v) => Array.isArray(v) ? 'array' : v === null ? 'null' : typeof v;
-  const expectArray = (key) => {
-    if (!(key in payload)) return;
-    if (!Array.isArray(payload[key])) {
-      errors.push(`.${key}: expected array, got ${typeOf(payload[key])}`);
-    }
-  };
-  const expectObject = (key) => {
-    if (!(key in payload)) return;
-    const v = payload[key];
-    if (typeof v !== 'object' || v === null || Array.isArray(v)) {
-      errors.push(`.${key}: expected object, got ${typeOf(v)}`);
-    }
-  };
-  const expectArrayOfObjects = (key) => {
-    if (!(key in payload)) return;
-    if (!Array.isArray(payload[key])) {
-      errors.push(`.${key}: expected array, got ${typeOf(payload[key])}`);
-      return;
-    }
-    payload[key].forEach((item, idx) => {
-      if (typeof item !== 'object' || item === null || Array.isArray(item)) {
-        errors.push(`.${key}[${idx}]: expected object, got ${typeOf(item)}`);
-      }
-    });
-  };
-  // Array-of-object PRD fields (rubric requires per-item structure)
-  //
-  // Functional-requirement field shape (SD-FDBK-FIX-FIX-PRD-GROUNDING-001):
-  //   { id, title?, requirement?, description?, priority, acceptance_criteria }
-  // ALL THREE text fields (title / requirement / description) are scored by the
-  // PRD-grounding validator — write the rich SD-vocabulary body in whichever field
-  // fits; the field-name choice no longer changes the grounding verdict. `title`
-  // (falling back to `requirement`) is also used as the display label in reports.
-  // Historical trap: the validator used to drop the `requirement` body whenever a
-  // title was present, scoring the FR on the short label alone (~1-2% Jaccard) and
-  // failing the quality gate (witnessed e8008b14 / SD-LEO-INFRA-ADAM-EVA-SEAM-001).
-  expectArrayOfObjects('functional_requirements');
-  expectArrayOfObjects('technical_requirements');
-  expectArrayOfObjects('test_scenarios');
-  expectArrayOfObjects('risks');
-  expectArrayOfObjects('smoke_test_steps');
-  // Loose-array fields (item shape varies; just enforce top-level type)
-  expectArray('acceptance_criteria');
-  expectArray('strategic_objectives');
-  expectArray('key_changes');
-  // Object fields (the integration_operationalization typo bit me directly here)
-  expectObject('integration_operationalization');
-  expectObject('metadata');
-  expectObject('system_architecture');
-  expectObject('implementation_approach');
-
-  // SD-LEO-INFRA-HARDEN-ADD-PRD-001: recurse into system_architecture.components — a string/object
-  // value passes expectObject('system_architecture') but then crashes downstream at
-  // scripts/prd/formatters.js (arch.components.forEach is not a function). Assert it's an array when present.
-  if (
-    payload.system_architecture &&
-    typeof payload.system_architecture === 'object' &&
-    !Array.isArray(payload.system_architecture) &&
-    'components' in payload.system_architecture &&
-    !Array.isArray(payload.system_architecture.components)
-  ) {
-    errors.push(`.system_architecture.components: expected array, got ${typeOf(payload.system_architecture.components)}`);
-  }
-
-  if (errors.length > 0) {
-    const e = new Error(`--content: SHAPE_VIOLATIONS (${errors.length}):\n  - ${errors.join('\n  - ')}`);
+  const { violations } = validateArtifact('prd', payload, { mode: 'shape' });
+  if (violations.length > 0) {
+    const e = new Error(`--content: SHAPE_VIOLATIONS (${violations.length}):\n${formatViolations(violations)}\n\n  Pre-check payloads with: npm run contract:check -- prd <file> (scaffold: npm run contract:scaffold -- prd)`);
     e.code = 'CONTENT_SHAPE_VIOLATION';
     throw e;
   }

--- a/scripts/artifact-contract.js
+++ b/scripts/artifact-contract.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * artifact-contract.js — author-side contract tooling
+ * (SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001).
+ *
+ * Usage:
+ *   node scripts/artifact-contract.js scaffold <sd|prd>          # print a valid skeleton
+ *   node scripts/artifact-contract.js check <sd|prd> <file|->    # validate a JSON payload
+ *
+ * npm entries: contract:scaffold / contract:check
+ *
+ * `check` runs AUTHORING mode (strict: required keys, min counts, exact keys,
+ * canonical metrics delegation, boilerplate-smoke advisories) so authors see
+ * the FULL contract before any gate does. The gates themselves consume the
+ * same spec in 'shape' mode (see scripts/add-prd-to-database.js).
+ *
+ * Exit codes: 0 valid, 1 violations, 2 usage error.
+ */
+import fs from 'node:fs';
+import { validateArtifact, formatViolations, scaffold } from '../lib/artifact-contracts/index.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+const VALID_CLASSES = ['sd', 'prd'];
+
+export function runCli(argv) {
+  const [cmd, klass, file] = argv;
+
+  if (!cmd || !['scaffold', 'check'].includes(cmd) || !VALID_CLASSES.includes(klass)) {
+    console.error('Usage: node scripts/artifact-contract.js scaffold <sd|prd>');
+    console.error('       node scripts/artifact-contract.js check <sd|prd> <file|->');
+    return 2;
+  }
+
+  if (cmd === 'scaffold') {
+    console.log(JSON.stringify(scaffold(klass), null, 2));
+    return 0;
+  }
+
+  // check
+  if (!file) {
+    console.error('check: missing <file|-> argument (use - for stdin)');
+    return 2;
+  }
+  let raw;
+  try {
+    raw = file === '-' ? fs.readFileSync(0, 'utf8') : fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    console.error(`check: cannot read ${file}: ${e.message}`);
+    return 2;
+  }
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (e) {
+    console.error(`check: INVALID_JSON: ${e.message}`);
+    return 1;
+  }
+
+  const { valid, violations, warnings } = validateArtifact(klass, payload, { mode: 'authoring' });
+
+  if (warnings.length > 0) {
+    console.log(`⚠ ${warnings.length} warning(s):`);
+    console.log(formatViolations(warnings));
+    console.log('');
+  }
+  if (!valid) {
+    console.error(`✗ ${klass.toUpperCase()} contract: ${violations.length} violation(s):`);
+    console.error(formatViolations(violations));
+    return 1;
+  }
+  console.log(`✓ ${klass.toUpperCase()} contract: payload valid (${warnings.length} warning(s))`);
+  return 0;
+}
+
+if (isMainModule(import.meta.url)) {
+  process.exitCode = runCli(process.argv.slice(2));
+}

--- a/tests/unit/artifact-contracts/contract-gate-parity.test.js
+++ b/tests/unit/artifact-contracts/contract-gate-parity.test.js
@@ -1,0 +1,196 @@
+/**
+ * SD-LEO-INFRA-ARTIFACT-CONTRACT-SINGLE-001 — contract<->gate parity + scaffolds + errors.
+ *
+ * The load-bearing property: after the gate-source inversion, add-prd's
+ * validateContentPayloadShape (now contract-derived, mode:'shape') accepts and
+ * rejects EXACTLY what the previous hand-rolled implementation did. The legacy
+ * behavior is pinned here as a reference implementation (copied verbatim from
+ * the pre-inversion function) and both are run over a corpus of valid payloads
+ * + one payload per documented trap.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateArtifact, formatViolations, scaffold, PRD_FIELD_SPECS, SD_FIELD_SPECS } from '../../../lib/artifact-contracts/index.js';
+import { validateContentPayloadShape } from '../../../scripts/add-prd-to-database.js';
+import { validateMetricsSufficiency } from '../../../scripts/modules/handoff/verifiers/lead-to-plan/sd-validation.js';
+
+// ─── Legacy reference implementation (pre-inversion, verbatim semantics) ───
+function legacyShapeErrors(payload) {
+  const errors = [];
+  const typeOf = (v) => Array.isArray(v) ? 'array' : v === null ? 'null' : typeof v;
+  const expectArray = (key) => {
+    if (!(key in payload)) return;
+    if (!Array.isArray(payload[key])) errors.push(key);
+  };
+  const expectObject = (key) => {
+    if (!(key in payload)) return;
+    const v = payload[key];
+    if (typeof v !== 'object' || v === null || Array.isArray(v)) errors.push(key);
+  };
+  const expectArrayOfObjects = (key) => {
+    if (!(key in payload)) return;
+    if (!Array.isArray(payload[key])) { errors.push(key); return; }
+    payload[key].forEach((item, idx) => {
+      if (typeof item !== 'object' || item === null || Array.isArray(item)) errors.push(`${key}[${idx}]`);
+    });
+  };
+  expectArrayOfObjects('functional_requirements');
+  expectArrayOfObjects('technical_requirements');
+  expectArrayOfObjects('test_scenarios');
+  expectArrayOfObjects('risks');
+  expectArrayOfObjects('smoke_test_steps');
+  expectArray('acceptance_criteria');
+  expectArray('strategic_objectives');
+  expectArray('key_changes');
+  expectObject('integration_operationalization');
+  expectObject('metadata');
+  expectObject('system_architecture');
+  expectObject('implementation_approach');
+  if (
+    payload.system_architecture && typeof payload.system_architecture === 'object' &&
+    !Array.isArray(payload.system_architecture) &&
+    'components' in payload.system_architecture &&
+    !Array.isArray(payload.system_architecture.components)
+  ) {
+    errors.push('system_architecture.components');
+  }
+  return errors;
+}
+
+// ─── Corpus: valid payloads + one per documented trap ───
+const CORPUS = {
+  valid_full: scaffold('prd'),
+  valid_minimal: { executive_summary: 'x' },
+  valid_empty: {},
+  trap_io_as_array: { integration_operationalization: [] },
+  trap_fr_as_strings: { functional_requirements: ['just a string'] },
+  trap_risks_as_object: { risks: {} },
+  trap_arch_components_string: { system_architecture: { components: 'not-an-array' } },
+  trap_impl_approach_string: { implementation_approach: 'a string' },
+  trap_smoke_steps_object: { smoke_test_steps: { step_number: 1 } },
+  trap_key_changes_object: { key_changes: {} },
+  trap_metadata_array: { metadata: [] },
+  trap_fr_nested_array_item: { functional_requirements: [{ id: 'FR-1' }, ['nested-array']] },
+};
+
+describe('contract<->gate parity (mode:shape vs legacy implementation)', () => {
+  for (const [name, payload] of Object.entries(CORPUS)) {
+    it(`parity: ${name}`, () => {
+      const legacy = legacyShapeErrors(payload);
+      const { violations } = validateArtifact('prd', payload, { mode: 'shape' });
+      const contractFields = violations.map((v) => v.field).sort();
+      const legacyFields = legacy.map((k) => k).sort();
+      expect(contractFields, `field sets must match legacy for ${name}`).toEqual(legacyFields);
+    });
+  }
+
+  it('the WIRED gate (validateContentPayloadShape) rejects traps with CONTENT_SHAPE_VIOLATION + hints', () => {
+    let threw = null;
+    try { validateContentPayloadShape(CORPUS.trap_io_as_array); } catch (e) { threw = e; }
+    expect(threw).toBeTruthy();
+    expect(threw.code).toBe('CONTENT_SHAPE_VIOLATION');
+    expect(threw.message).toMatch(/integration_operationalization/);
+    expect(threw.message).toMatch(/expected object, got array/);
+    expect(threw.message).toMatch(/hint:/);                 // self-describing (FR-3)
+    expect(threw.message).toMatch(/contract:check/);        // points authors at the tooling
+  });
+
+  it('the WIRED gate still accepts valid payloads (no behavior change)', () => {
+    expect(() => validateContentPayloadShape(CORPUS.valid_full)).not.toThrow();
+    expect(() => validateContentPayloadShape(CORPUS.valid_minimal)).not.toThrow();
+    expect(() => validateContentPayloadShape(CORPUS.valid_empty)).not.toThrow();
+  });
+
+  it('shape mode does NOT enforce authoring-only rules (required keys, minItems, exactKeys)', () => {
+    // {} has none of the required fields and io with wrong keys is absent — shape mode passes.
+    expect(validateArtifact('prd', {}, { mode: 'shape' }).valid).toBe(true);
+    // exactKeys not enforced in shape mode (gate parity: legacy only checked object-ness)
+    const partialIo = { integration_operationalization: { consumers: [] } };
+    expect(validateArtifact('prd', partialIo, { mode: 'shape' }).valid).toBe(true);
+  });
+});
+
+describe('authoring mode (strict, what contract:check runs)', () => {
+  it('scaffold(prd) passes its own authoring validation', () => {
+    const r = validateArtifact('prd', scaffold('prd'), { mode: 'authoring' });
+    expect(r.violations).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+
+  it('scaffold(sd) passes its own authoring validation with zero violations', () => {
+    const r = validateArtifact('sd', scaffold('sd'), { mode: 'authoring' });
+    expect(r.violations).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+
+  it('authoring mode enforces integration_operationalization EXACT keys', () => {
+    const payload = { ...scaffold('prd'), integration_operationalization: { consumers: [], wrong_key: [] } };
+    const r = validateArtifact('prd', payload, { mode: 'authoring' });
+    const v = r.violations.find((x) => x.field === 'integration_operationalization');
+    expect(v).toBeTruthy();
+    expect(v.expected).toMatch(/consumers, dependencies, data_contracts, runtime_config, observability_rollout/);
+  });
+
+  it('authoring mode enforces functional_requirements >=3', () => {
+    const payload = { ...scaffold('prd'), functional_requirements: [{ id: 'FR-1', title: 't', description: 'd' }] };
+    const r = validateArtifact('prd', payload, { mode: 'authoring' });
+    expect(r.violations.some((x) => x.field === 'functional_requirements' && /(>=|≥)3/.test(x.expected))).toBe(true);
+  });
+
+  it('SD metrics validation DELEGATES to the canonical validateMetricsSufficiency', () => {
+    const sd = { ...scaffold('sd'), success_metrics: [{ metric: 'only one', target: '>=1', actual: '0' }], success_criteria: undefined };
+    delete sd.success_criteria;
+    const canonical = validateMetricsSufficiency(sd);
+    const r = validateArtifact('sd', sd, { mode: 'authoring' });
+    // contract verdict mirrors the canonical function
+    expect(r.violations.some((x) => x.field === 'success_metrics')).toBe(!canonical.pass);
+  });
+
+  it('SD duplicate metrics fail (canonical dedup) — padding does not help', () => {
+    const m = { metric: 'same text', target: '>=1', actual: '0' };
+    const sd = { ...scaffold('sd'), success_metrics: [m, { ...m }, { ...m }] };
+    const r = validateArtifact('sd', sd, { mode: 'authoring' });
+    expect(r.violations.some((x) => x.field === 'success_metrics')).toBe(true);
+  });
+
+  it('boilerplate smoke steps produce ADVISORY warnings, not violations', () => {
+    const sd = {
+      ...scaffold('sd'),
+      smoke_test_steps: [{ step_number: 1, instruction: 'Run the modified script/gate for: X', expected_outcome: 'Script executes without errors' }],
+    };
+    const r = validateArtifact('sd', sd, { mode: 'authoring' });
+    expect(r.warnings.some((w) => w.field.startsWith('smoke_test_steps'))).toBe(true);
+    expect(r.violations.some((v) => v.field.startsWith('smoke_test_steps['))).toBe(false);
+  });
+
+  it('SD key_changes as strings violates (DB CHECK key_changes_is_array shape)', () => {
+    const sd = { ...scaffold('sd'), key_changes: ['a string change'] };
+    const r = validateArtifact('sd', sd, { mode: 'authoring' });
+    expect(r.violations.some((x) => x.field === 'key_changes[0]')).toBe(true);
+  });
+});
+
+describe('self-describing errors + spec completeness', () => {
+  it('violations carry field/expected/got/hint', () => {
+    const { violations } = validateArtifact('prd', CORPUS.trap_io_as_array, { mode: 'shape' });
+    expect(violations.length).toBe(1);
+    const v = violations[0];
+    expect(v.field).toBe('integration_operationalization');
+    expect(v.expected).toBe('object');
+    expect(v.got).toBe('array');
+    expect(v.hint).toMatch(/exact/i);
+  });
+
+  it('formatViolations renders field + expected + hint lines', () => {
+    const { violations } = validateArtifact('prd', CORPUS.trap_io_as_array, { mode: 'shape' });
+    const out = formatViolations(violations);
+    expect(out).toMatch(/\.integration_operationalization: expected object, got array/);
+    expect(out).toMatch(/hint:/);
+  });
+
+  it('every spec entry has a non-empty hint and gate attribution', () => {
+    for (const spec of [...PRD_FIELD_SPECS, ...SD_FIELD_SPECS]) {
+      expect(spec.hint, `${spec.field} missing hint`).toBeTruthy();
+      expect(spec.gate, `${spec.field} missing gate attribution`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Structural fix for the artifact-shape-mismatch class — judgment-boundary handoffs ran **77-79% vs the 85% target** because gates enforce shapes authors could only discover by failing the gate (contracts lived in validator code + session folklore).

- **NEW `lib/artifact-contracts/`** (pure, no DB): declarative FIELD_SPECS for the SD + PRD classes encoding every documented trap field, each with a hint quoting the folklore lesson + the enforcing gate. Two modes: `shape` (gate parity) vs `authoring` (strict author pre-check).
- **Gate-source inversion** (behavior-identical): `add-prd` `validateContentPayloadShape` derives from the PRD contract; parity pinned by a verbatim legacy reference implementation over a 12-payload corpus. SD metrics **delegates** to the canonical `validateMetricsSufficiency`.
- **Self-describing errors**: `CONTENT_SHAPE_VIOLATION` now renders `{field, expected, got, hint}` + points at `contract:check`.
- **Author CLI**: `npm run contract:scaffold -- <sd|prd>` / `npm run contract:check -- <sd|prd> <file|->` — scaffolds pass their own validation.

## Tests
26 new (parity corpus, scaffold self-validation, authoring strictness, metrics delegation, error shape) + **48/48 existing add-prd tests green** (behavior-identical proof). TESTING agent PASS 97 (74/74).

Deferred (flags at completion): CLAUDE-guidance rendering, handoff-payload class, smoke-gate/grounding-scorer inversions (freshly fixed today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)