### PR TITLE
fix(SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001): phase-scope TRANSLATION_FIDELITY for multi-SD architecture plans

### DIFF
--- a/scripts/eva/translation-fidelity-gate.js
+++ b/scripts/eva/translation-fidelity-gate.js
@@ -48,7 +48,13 @@ function buildCacheKey(upstream, downstream, gateType) {
     ? upstream.map(u => u.key || u.id).sort().join('+')
     : (upstream.key || upstream.id);
   const downKey = downstream.key || downstream.id;
-  return `${gateType}:${upKeys}:${downKey}`;
+  // SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001 (FR-2): scoped and unscoped
+  // evaluations must never share a cache entry — fold the scope into the key.
+  const scope = downstream.scope;
+  const scopeDigest = scope
+    ? `:scope[${scope.archPhase || ''}|${(scope.siblings || []).map(s => s.sd_key).sort().join(',')}]`
+    : '';
+  return `${gateType}:${upKeys}:${downKey}${scopeDigest}`;
 }
 
 /**
@@ -128,8 +134,9 @@ export async function evaluateTranslationFidelity(upstream, downstream, gateType
       score: parsed.score,
       maxScore: 100,
       gaps: parsed.gaps || [],
-      issues: parsed.gaps?.filter(g => g.severity === 'critical') || [],
-      warnings: parsed.gaps?.filter(g => g.severity !== 'critical') || [],
+      // FR-3: sibling-covered gaps are informational — they never become issues.
+      issues: parsed.gaps?.filter(g => g.severity === 'critical' && !g.sibling_covered) || [],
+      warnings: parsed.gaps?.filter(g => g.severity !== 'critical' || g.sibling_covered) || [],
       details: {
         gate_type: gateType,
         model_used: client.modelId || 'unknown',
@@ -283,7 +290,18 @@ export async function runVisionToArchitectureGate(visionId, archData) {
 
 // --- Gate 3: Architecture → SD ---
 
-export async function runArchitectureToSDGate(archKey, sdData) {
+/**
+ * @param {string} archKey
+ * @param {Object} sdData
+ * @param {Object} [opts] - SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001 (FR-1): phase scoping
+ *   for multi-SD architecture plans. opts.archPhase (string|null) — the plan slice this
+ *   SD declares via metadata.arch_phase. opts.siblings (Array<{sd_key,title}>) — other
+ *   SDs sharing the same arch_key. When present, the LLM is instructed to score ONLY
+ *   the slice this SD claims and mark sibling-owned content sibling_covered:true so the
+ *   executors can report it as informational instead of failing the gate.
+ *   Omitted/empty → byte-identical legacy behavior.
+ */
+export async function runArchitectureToSDGate(archKey, sdData, opts = {}) {
   // Fetch architecture plan
   const { data: arch, error } = await supabase
     .from('eva_architecture_plans')
@@ -295,6 +313,10 @@ export async function runArchitectureToSDGate(archKey, sdData) {
     console.warn(`   ⚠️  Architecture plan ${archKey} not found, skipping Gate 3`);
     return null;
   }
+
+  const scope = (opts.archPhase || (opts.siblings && opts.siblings.length > 0))
+    ? { archPhase: opts.archPhase || null, siblings: opts.siblings || [] }
+    : null;
 
   const upstreams = [
     {
@@ -337,6 +359,9 @@ export async function runArchitectureToSDGate(archKey, sdData) {
       success_criteria: sdData.success_criteria,
     }),
     dimensions: [],
+    // FR-1: scope rides on the downstream artifact so buildPrompts and
+    // buildCacheKey both see it without changing their signatures.
+    scope,
   };
 
   return runAndPersistGate(upstreams, downstream, 'architecture_to_sd');
@@ -354,7 +379,7 @@ Respond with valid JSON only:
   "score": <integer 0-100>,
   "reasoning": "<brief explanation>",
   "coverage_areas": [{"area": "<topic>", "covered": <boolean>, "notes": "<detail>"}],
-  "gaps": [{"item": "<what was lost>", "source": "<upstream artifact>", "severity": "critical|major|minor"}]
+  "gaps": [{"item": "<what was lost>", "source": "<upstream artifact>", "severity": "critical|major|minor", "sibling_covered": <boolean — true when the item belongs to a sibling SD's slice of a multi-SD plan; omit or false otherwise>}]
 }
 
 Scoring guide:
@@ -383,13 +408,35 @@ Scoring guide:
   const downstreamText = `--- Downstream: ${downstream.type} (${downstream.key}) ---
 ${downstream.dimensions?.length ? `Dimensions: ${sanitizeUnicode(JSON.stringify(downstream.dimensions))}\n` : ''}Content: ${sanitizeUnicode((downstream.content || '').substring(0, 3000))}`;
 
-  const userPrompt = `Gate: ${gateDescriptions[gateType]}
+  // SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001 (FR-1): multi-SD plan scoping.
+  // When the downstream SD declares a plan slice (arch_phase) or shares the
+  // architecture plan with sibling SDs, score ONLY the slice this SD claims —
+  // sibling-owned content is informational, not a translation loss.
+  const scope = downstream.scope;
+  let scopingBlock = '';
+  if (scope && (scope.archPhase || scope.siblings?.length)) {
+    const siblingList = (scope.siblings || [])
+      .slice(0, 40)
+      .map(s => `  - ${s.sd_key}: ${sanitizeUnicode(String(s.title || '').substring(0, 120))}`)
+      .join('\n');
+    scopingBlock = `
+
+MULTI-SD PLAN SCOPING (IMPORTANT):
+This architecture plan is delivered by ${1 + (scope.siblings?.length || 0)} Strategic Directives, NOT by this SD alone.
+This SD claims ONLY ${scope.archPhase ? `the plan slice/phase: "${sanitizeUnicode(scope.archPhase)}"` : 'the slice described by its own title/description/key_changes'}.
+${siblingList ? `The following SIBLING SDs deliver other parts of the plan:\n${siblingList}\n` : ''}Rules:
+- Score fidelity ONLY against the slice this SD claims. Plan content outside that slice must NOT reduce the score.
+- For every gap, set "sibling_covered": true when the missing content falls under a sibling SD's scope (or any plan area outside this SD's claimed slice); such items are informational, not losses.
+- Only content INSIDE this SD's claimed slice that is missing from the SD may be a genuine gap (sibling_covered: false).`;
+  }
+
+  const userPrompt = `Gate: ${gateDescriptions[gateType]}${scopingBlock}
 
 ${upstreamText}
 
 ${downstreamText}
 
-Analyze the translation fidelity. Identify what was preserved and what was lost.`;
+Analyze the translation fidelity. Identify what was preserved and what was lost.${scopingBlock ? ' Remember: score only this SD\'s claimed slice; mark out-of-slice items sibling_covered.' : ''}`;
 
   return { systemPrompt, userPrompt };
 }
@@ -410,6 +457,8 @@ function parseGateResponse(text) {
           item: g.item || 'Unknown',
           source: g.source || 'Unknown',
           severity: ['critical', 'major', 'minor'].includes(g.severity) ? g.severity : 'minor',
+          // FR-2: default false — absent field fails toward current (blocking) behavior.
+          sibling_covered: g.sibling_covered === true,
         })),
       };
     } catch (e) {

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
@@ -92,7 +92,29 @@ export function createTranslationFidelityGate(supabase) {
           success_criteria: sd.success_criteria,
         };
 
-        const result = await runArchitectureToSDGate(archKey, sdData);
+        // SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001 (FR-3): phase-scope multi-SD plans.
+        // Query sibling SDs sharing this arch_key so the engine scores ONLY the slice
+        // this SD claims; sibling-owned plan content comes back sibling_covered and is
+        // reported as informational instead of failing the gate. Fail-toward-current:
+        // a sibling-query error degrades to the unscoped (legacy) evaluation.
+        let siblings = [];
+        try {
+          const { data: sibRows } = await supabase
+            .from('strategic_directives_v2')
+            .select('sd_key, title')
+            .filter('metadata->>arch_key', 'eq', archKey)
+            .neq('sd_key', sdKey)
+            .limit(40);
+          siblings = sibRows || [];
+        } catch (e) {
+          console.log(`   ⚠️  Sibling query failed (running unscoped): ${e.message}`);
+        }
+        const archPhase = sd?.metadata?.arch_phase || null;
+        if (siblings.length > 0 || archPhase) {
+          console.log(`   🔭 Phase-scoped: ${siblings.length} sibling SD(s) share ${archKey}${archPhase ? `; declared slice: ${archPhase}` : ''}`);
+        }
+
+        const result = await runArchitectureToSDGate(archKey, sdData, { archPhase, siblings });
 
         if (!result) {
           console.log('   ⚠️  Translation fidelity gate returned no result — treating as advisory pass');
@@ -102,9 +124,11 @@ export function createTranslationFidelityGate(supabase) {
           });
         }
 
-        // Map engine result to semantic gate result
+        // Map engine result to semantic gate result.
+        // FR-3: sibling-covered gaps are informational — excluded from criticals/issues.
         const gapCount = result.gaps?.length || 0;
-        const criticalGaps = result.gaps?.filter(g => g.severity === 'critical') || [];
+        const siblingCoveredGaps = result.gaps?.filter(g => g.sibling_covered) || [];
+        const criticalGaps = result.gaps?.filter(g => g.severity === 'critical' && !g.sibling_covered) || [];
         const score = result.score ?? 0;
         const sdType = sd?.sd_type || 'feature';
         const passingScore = getPassingScore(sdType);
@@ -115,8 +139,8 @@ export function createTranslationFidelityGate(supabase) {
         if (gapCount > 0) {
           console.log('   Gaps found:');
           for (const gap of result.gaps) {
-            const icon = gap.severity === 'critical' ? '❌' : gap.severity === 'major' ? '⚠️' : 'ℹ️';
-            console.log(`      ${icon} [${gap.severity}] ${gap.item} (source: ${gap.source})`);
+            const icon = gap.sibling_covered ? '🔭' : gap.severity === 'critical' ? '❌' : gap.severity === 'major' ? '⚠️' : 'ℹ️';
+            console.log(`      ${icon} [${gap.sibling_covered ? 'sibling-covered' : gap.severity}] ${gap.item} (source: ${gap.source})`);
           }
         }
 
@@ -136,13 +160,16 @@ export function createTranslationFidelityGate(supabase) {
             ...criticalGaps.map(g => `Critical gap: ${g.item}`)
           ],
           warnings: result.gaps
-            ?.filter(g => g.severity !== 'critical')
-            .map(g => `[${g.severity}] ${g.item}`) || [],
+            ?.filter(g => g.severity !== 'critical' || g.sibling_covered)
+            .map(g => g.sibling_covered ? `[sibling-covered] ${g.item}` : `[${g.severity}] ${g.item}`) || [],
           details: {
             arch_key: archKey,
             gate_type: 'architecture_to_sd',
             gap_count: gapCount,
             critical_gap_count: criticalGaps.length,
+            sibling_covered_count: siblingCoveredGaps.length,
+            sibling_count: siblings.length,
+            arch_phase: archPhase,
             model_used: result.details?.model_used,
             duration_ms: result.details?.duration_ms,
           },

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/translation-fidelity.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/translation-fidelity.js
@@ -87,7 +87,26 @@ export function createTranslationFidelityGate(supabase) {
           success_criteria: sd.success_criteria,
         };
 
-        const result = await runArchitectureToSDGate(archKey, sdData);
+        // SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001 (FR-3): phase-scope multi-SD plans.
+        // Identical twin of the LEAD-TO-PLAN gate change — keep in sync.
+        let siblings = [];
+        try {
+          const { data: sibRows } = await supabase
+            .from('strategic_directives_v2')
+            .select('sd_key, title')
+            .filter('metadata->>arch_key', 'eq', archKey)
+            .neq('sd_key', sdKey)
+            .limit(40);
+          siblings = sibRows || [];
+        } catch (e) {
+          console.log(`   ⚠️  Sibling query failed (running unscoped): ${e.message}`);
+        }
+        const archPhase = sd?.metadata?.arch_phase || null;
+        if (siblings.length > 0 || archPhase) {
+          console.log(`   🔭 Phase-scoped: ${siblings.length} sibling SD(s) share ${archKey}${archPhase ? `; declared slice: ${archPhase}` : ''}`);
+        }
+
+        const result = await runArchitectureToSDGate(archKey, sdData, { archPhase, siblings });
 
         if (!result) {
           console.log('   ⚠️  Translation fidelity gate returned no result — treating as advisory pass');
@@ -97,8 +116,10 @@ export function createTranslationFidelityGate(supabase) {
           });
         }
 
+        // FR-3: sibling-covered gaps are informational — excluded from criticals/issues.
         const gapCount = result.gaps?.length || 0;
-        const criticalGaps = result.gaps?.filter(g => g.severity === 'critical') || [];
+        const siblingCoveredGaps = result.gaps?.filter(g => g.sibling_covered) || [];
+        const criticalGaps = result.gaps?.filter(g => g.severity === 'critical' && !g.sibling_covered) || [];
         const score = result.score ?? 0;
         const sdType = sd?.sd_type || sd?.metadata?.sd_type || 'feature';
         const passingScore = getPassingScore(sdType);
@@ -109,8 +130,8 @@ export function createTranslationFidelityGate(supabase) {
         if (gapCount > 0) {
           console.log('   Gaps found:');
           for (const gap of result.gaps) {
-            const icon = gap.severity === 'critical' ? '❌' : gap.severity === 'major' ? '⚠️' : 'ℹ️';
-            console.log(`      ${icon} [${gap.severity}] ${gap.item} (source: ${gap.source})`);
+            const icon = gap.sibling_covered ? '🔭' : gap.severity === 'critical' ? '❌' : gap.severity === 'major' ? '⚠️' : 'ℹ️';
+            console.log(`      ${icon} [${gap.sibling_covered ? 'sibling-covered' : gap.severity}] ${gap.item} (source: ${gap.source})`);
           }
         }
 
@@ -129,14 +150,17 @@ export function createTranslationFidelityGate(supabase) {
             ...criticalGaps.map(g => `Critical gap: ${g.item}`)
           ],
           warnings: result.gaps
-            ?.filter(g => g.severity !== 'critical')
-            .map(g => `[${g.severity}] ${g.item}`) || [],
+            ?.filter(g => g.severity !== 'critical' || g.sibling_covered)
+            .map(g => g.sibling_covered ? `[sibling-covered] ${g.item}` : `[${g.severity}] ${g.item}`) || [],
           details: {
             arch_key: archKey,
             gate_type: 'architecture_to_sd',
             phase: 'PLAN-TO-EXEC',
             gap_count: gapCount,
             critical_gap_count: criticalGaps.length,
+            sibling_covered_count: siblingCoveredGaps.length,
+            sibling_count: siblings.length,
+            arch_phase: archPhase,
             model_used: result.details?.model_used,
             duration_ms: result.details?.duration_ms,
           },

--- a/tests/unit/eva/translation-fidelity-scoping.test.js
+++ b/tests/unit/eva/translation-fidelity-scoping.test.js
@@ -1,0 +1,185 @@
+/**
+ * SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001 — phase-scope the TRANSLATION_FIDELITY
+ * gate for multi-phase / multi-SD architecture plans.
+ *
+ * Resolves PAT-AUTO-7d4450fb (18x) + PAT-AUTO-fc18634f (11x): the gate compared
+ * the ENTIRE arch plan against ONE SD, so sibling-delivered plan content scored
+ * as lost-in-translation. Now the engine accepts {archPhase, siblings}, the LLM
+ * is instructed to score only the slice this SD claims (sibling-owned content
+ * comes back sibling_covered:true), and the executors demote sibling-covered
+ * gaps to informational warnings — while own-slice losses still fail.
+ *
+ * Mirrors the mock pattern of translation-fidelity-gate.test.js (hermetic).
+ *
+ * DB-guard note (audit-db-test-guards.mjs Stage 1.6): this suite is FULLY
+ * HERMETIC — lib/supabase-client.js (createSupabaseServiceClient) and the LLM
+ * client factory are vi.mock'd below, so no live DB or network is ever touched
+ * and the suite cannot hang against the no-DB sentinel. The describeDb /
+ * HAS_REAL_DB wrappers are intentionally NOT used: they would skip these tests
+ * in no-DB CI, where they must run. The import-signal match on this file is a
+ * false positive on mocked suites (guard improvement flagged to the harness
+ * backlog).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+vi.mock('dotenv/config', () => ({}));
+
+// --- Supabase mock: arch plan fetch + gate persistence ---
+const mockInsert = vi.fn().mockResolvedValue({ error: null });
+const mockSingle = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn((table) => {
+      if (table === 'eva_translation_gates') return { insert: mockInsert };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), single: mockSingle };
+    }),
+  })),
+}));
+
+// lib/supabase-client.js wraps createClient — mock it directly too.
+vi.mock('../../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: vi.fn(() => ({
+    from: vi.fn((table) => {
+      if (table === 'eva_translation_gates') return { insert: mockInsert };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), single: mockSingle };
+    }),
+  })),
+}));
+
+// --- LLM mock: capture prompts, return canned gaps ---
+const mockComplete = vi.fn();
+vi.mock('../../../lib/llm/client-factory.js', () => ({
+  getValidationClient: vi.fn(() => ({ complete: mockComplete, modelId: 'test-model' })),
+}));
+
+const ARCH_ROW = {
+  id: 'arch-1',
+  plan_key: 'ARCH-MULTI-001',
+  content: 'Phase A: governance API. Phase B: chairman UI. Phase C: mobile PWA.',
+  extracted_dimensions: [],
+  vision_id: null,
+  sections: { overview: '...' },
+};
+
+const SIBLINGS = [
+  { sd_key: 'SD-SIB-001', title: 'Phase B: chairman UI shell' },
+  { sd_key: 'SD-SIB-002', title: 'Phase C: mobile PWA wrapper' },
+];
+
+const SD_DATA = {
+  id: 'sd-1',
+  sd_key: 'SD-ME-001',
+  title: 'Phase A: governance API surface',
+  description: 'Implements the governance API surface from the plan',
+  key_changes: [],
+  success_criteria: [],
+};
+
+function llmJson(payload) {
+  return JSON.stringify(payload);
+}
+
+describe('translation-fidelity phase scoping (engine)', () => {
+  let mod;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mod = await import('../../../scripts/eva/translation-fidelity-gate.js');
+    mockSingle.mockResolvedValue({ data: ARCH_ROW, error: null });
+  });
+
+  it('FR-1: scoped run injects the MULTI-SD PLAN SCOPING block with siblings + arch_phase', async () => {
+    mockComplete.mockResolvedValueOnce(llmJson({ score: 95, reasoning: 'ok', gaps: [] }));
+    await mod.runArchitectureToSDGate('ARCH-MULTI-001', SD_DATA, { archPhase: 'Phase A', siblings: SIBLINGS });
+
+    const [, userPrompt] = mockComplete.mock.calls[0];
+    expect(userPrompt).toContain('MULTI-SD PLAN SCOPING');
+    expect(userPrompt).toContain('delivered by 3 Strategic Directives');
+    expect(userPrompt).toContain('"Phase A"');
+    expect(userPrompt).toContain('SD-SIB-001');
+    expect(userPrompt).toContain('SD-SIB-002');
+    expect(userPrompt).toContain('sibling_covered');
+  });
+
+  it('FR-1 backward-compat: no opts produces NO scoping block (legacy prompt)', async () => {
+    mockComplete.mockResolvedValueOnce(llmJson({ score: 95, reasoning: 'ok', gaps: [] }));
+    await mod.runArchitectureToSDGate('ARCH-MULTI-001', SD_DATA);
+
+    const [, userPrompt] = mockComplete.mock.calls[0];
+    expect(userPrompt).not.toContain('MULTI-SD PLAN SCOPING');
+    expect(userPrompt).not.toContain('sibling_covered');
+  });
+
+  it('FR-2: sibling_covered survives parsing and defaults to false when absent', async () => {
+    mockComplete.mockResolvedValueOnce(llmJson({
+      score: 80,
+      reasoning: 'mixed',
+      gaps: [
+        { item: 'chairman UI shell', source: 'plan', severity: 'critical', sibling_covered: true },
+        { item: 'governance rate limiting', source: 'plan', severity: 'critical' },
+      ],
+    }));
+    const result = await mod.runArchitectureToSDGate('ARCH-MULTI-001', SD_DATA, { siblings: SIBLINGS });
+
+    const covered = result.gaps.find(g => g.item === 'chairman UI shell');
+    const own = result.gaps.find(g => g.item === 'governance rate limiting');
+    expect(covered.sibling_covered).toBe(true);
+    expect(own.sibling_covered).toBe(false);
+    // Engine-level demotion: sibling-covered criticals are warnings, not issues.
+    expect(result.issues.map(g => g.item)).toEqual(['governance rate limiting']);
+    expect(result.warnings.map(g => g.item)).toContain('chairman UI shell');
+  });
+
+  it('FR-2: scoped and unscoped evaluations use different cache keys (no cross-contamination)', async () => {
+    mockComplete
+      .mockResolvedValueOnce(llmJson({ score: 95, reasoning: 'scoped', gaps: [] }))
+      .mockResolvedValueOnce(llmJson({ score: 40, reasoning: 'unscoped', gaps: [] }));
+
+    const scoped = await mod.runArchitectureToSDGate('ARCH-MULTI-001', SD_DATA, { siblings: SIBLINGS });
+    const unscoped = await mod.runArchitectureToSDGate('ARCH-MULTI-001', SD_DATA);
+
+    // If the cache leaked, the second call would return the first's result (95).
+    expect(scoped.score).toBe(95);
+    expect(unscoped.score).toBe(40);
+    expect(mockComplete).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('executor twins (source assertions — anti-drift)', () => {
+  const LEAD = path.resolve(process.cwd(), 'scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js');
+  const PLAN = path.resolve(process.cwd(), 'scripts/modules/handoff/executors/plan-to-exec/gates/translation-fidelity.js');
+
+  for (const [name, p] of [['lead-to-plan', LEAD], ['plan-to-exec', PLAN]]) {
+    const src = readFileSync(p, 'utf8');
+
+    it(`${name}: queries siblings sharing arch_key and passes {archPhase, siblings} to the engine`, () => {
+      expect(src).toMatch(/metadata->>arch_key/);
+      expect(src).toMatch(/runArchitectureToSDGate\(archKey, sdData, \{ archPhase, siblings \}\)/);
+    });
+
+    it(`${name}: demotes sibling-covered gaps out of criticalGaps (true positives retained)`, () => {
+      expect(src).toMatch(/g\.severity === 'critical' && !g\.sibling_covered/);
+      expect(src).toMatch(/\[sibling-covered\]/);
+    });
+
+    it(`${name}: fail-toward-current — sibling-query errors degrade to unscoped`, () => {
+      expect(src).toMatch(/Sibling query failed \(running unscoped\)/);
+    });
+  }
+
+  it('twins carry the identical scoping diff (anti-drift)', () => {
+    const a = readFileSync(LEAD, 'utf8');
+    const b = readFileSync(PLAN, 'utf8');
+    for (const marker of [
+      "filter('metadata->>arch_key', 'eq', archKey)",
+      'const archPhase = sd?.metadata?.arch_phase || null;',
+      'sibling_covered_count: siblingCoveredGaps.length',
+    ]) {
+      expect(a).toContain(marker);
+      expect(b).toContain(marker);
+    }
+  });
+});


### PR DESCRIPTION
@
## SD-LEO-FIX-PHASE-SCOPE-TRANSLATION-001

The TRANSLATION_FIDELITY gate (LEAD-TO-PLAN + PLAN-TO-EXEC twins → `scripts/eva/translation-fidelity-gate.js`) compared the **entire** linked architecture plan against **one** SD — so plan content delivered by sibling SDs scored as lost-in-translation. **29 recurrences** (PAT-AUTO-7d4450fb 18×, PAT-AUTO-fc18634f 11×) plus bypass debt naming this exact root cause. Multi-SD plans are the norm (ARCH-CHAIRMAN-UI-001 is shared by **37 SDs**); only ~12/595 arch-linked SDs declare `metadata.arch_phase`, so sibling-awareness is the dominant scoping signal.

### Changes
- **Engine**: `runArchitectureToSDGate(archKey, sdData, opts)` — `opts.archPhase` + `opts.siblings`. Prompt gains a **MULTI-SD PLAN SCOPING** block: score ONLY the slice this SD claims; mark sibling-owned content `sibling_covered:true`. Parser passes the field through (default `false` — fail-toward-current-behavior). Cache key folds in the scope (no scoped/unscoped cross-contamination). Engine `issues` exclude sibling-covered criticals.
- **Both executor twins** (identical diff, anti-drift test-pinned): query up to 40 siblings sharing `metadata.arch_key`, read `metadata.arch_phase`, pass the scope; sibling-covered gaps render as `🔭 [sibling-covered]` **warnings** — visible, never blocking — while own-slice criticals **still fail** (true-positive retention). Sibling-query errors degrade to the unscoped legacy evaluation.
- **11 hermetic tests** (mock LLM + supabase): scoping-block injection, byte-identical legacy prompt without opts, `sibling_covered` parse/default, cache-key separation, engine demotion, twin anti-drift markers.

### Pattern resolution
Both PAT-AUTO patterns carry `assigned_sd_id` = this SD → auto-resolve at LEAD-FINAL.

### Notes
- 4 pre-existing failures in `translation-fidelity-gate.test.js` fail identically at baseline (git-stash verified) — not regressions.
- The interim GatePolicyResolver DISABLE of this gate for `sd_type=infrastructure` is a separate blanket mechanism; this fix is its durable replacement (re-enable recommended as follow-up).
- DB-test guard false-positive on fully-mocked suites flagged to harness backlog (`e7bcca94`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@