### PR TITLE
feat(SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001): publication-status inventory + hash stamping + scoped regen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- file_content_hash: 554e5acb03aefd5d -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
 ## Prime Directive
@@ -197,4 +198,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-10 12:15:59 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-10 2:53:04 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,6 +1,7 @@
+<!-- file_content_hash: e9311797bc2ecab2 -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-10 12:15:59 PM
+**Generated**: 2026-06-10 2:53:04 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,8 +1,8 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-10T16:15:59.602Z -->
-<!-- git_commit: 11a75297 -->
-<!-- db_snapshot_hash: 4c260fddb7740f6c -->
-<!-- file_content_hash: pending -->
+<!-- generated_at: 2026-06-10T18:53:04.116Z -->
+<!-- git_commit: afd81f04 -->
+<!-- db_snapshot_hash: 1c0d92b1433aad31 -->
+<!-- file_content_hash: 3da908f1f2907dbc -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,7 @@
+<!-- file_content_hash: 36efd797b7771305 -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-10 12:15:59 PM
+**Generated**: 2026-06-10 2:53:04 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -87,41 +88,6 @@ Task tool with subagent_type="database-agent":
 bash scripts/leo-stack.sh restart   # All 3 servers
 ```
 
-## 🔍 Session Start Verification (MANDATORY)
-
-**Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
-
-### Before Starting ANY SD Work:
-```
-[ ] Query database to confirm SD exists
-[ ] Verify SD status and current_phase  
-[ ] Check for existing PRD if phase > LEAD
-[ ] Check for existing handoffs
-[ ] Document: "Verified SD [title] exists, status=[X], phase=[Y]"
-```
-
-### Verification Queries:
-```sql
--- Find SD by title
-SELECT legacy_id, title, status, current_phase, progress 
-FROM strategic_directives_v2 
-WHERE title ILIKE '%[keyword]%' AND is_active = true;
-
--- Check PRD exists
-SELECT prd_id, status FROM product_requirements_v2 WHERE sd_id = '[SD-ID]';
-
--- Check handoffs exist
-SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID]';
-```
-
-### Why This Matters:
-- Session summaries describe *context*, not *state*
-- AI can hallucinate successful database operations
-- Database is the ONLY source of truth
-- If records don't exist, CREATE them before proceeding
-
-**Pattern Reference**: PAT-SESS-VER-001
-
 ## 🚀 Session Verification & Quick Start (MANDATORY)
 
 ## Session Start Checklist
@@ -163,6 +129,41 @@ SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID
 | `npm run prio:top3` | Top priority SDs |
 | `git status` | Working tree status |
 | `npm run handoff:latest` | Latest handoff |
+
+## 🔍 Session Start Verification (MANDATORY)
+
+**Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
+
+### Before Starting ANY SD Work:
+```
+[ ] Query database to confirm SD exists
+[ ] Verify SD status and current_phase  
+[ ] Check for existing PRD if phase > LEAD
+[ ] Check for existing handoffs
+[ ] Document: "Verified SD [title] exists, status=[X], phase=[Y]"
+```
+
+### Verification Queries:
+```sql
+-- Find SD by title
+SELECT legacy_id, title, status, current_phase, progress 
+FROM strategic_directives_v2 
+WHERE title ILIKE '%[keyword]%' AND is_active = true;
+
+-- Check PRD exists
+SELECT prd_id, status FROM product_requirements_v2 WHERE sd_id = '[SD-ID]';
+
+-- Check handoffs exist
+SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID]';
+```
+
+### Why This Matters:
+- Session summaries describe *context*, not *state*
+- AI can hallucinate successful database operations
+- Database is the ONLY source of truth
+- If records don't exist, CREATE them before proceeding
+
+**Pattern Reference**: PAT-SESS-VER-001
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -219,6 +220,48 @@ npm run handoff:compliance SD-ID
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
+## 🤖 Built-in Agent Integration
+
+## Built-in Agent Integration
+
+### Three-Layer Agent Architecture
+
+LEO Protocol uses three complementary agent layers:
+
+| Layer | Source | Agents | Purpose |
+|-------|--------|--------|---------|
+| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
+| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
+| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
+
+### Integration Principle
+
+> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
+
+Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
+
+### When to Use Each Layer
+
+| Task | Use | Example |
+|------|-----|---------|
+| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
+| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
+| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
+| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
+| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
+
+### Parallel Execution
+
+Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
+
+```
+Task(subagent_type="Explore", prompt="Search for existing implementations")
+Task(subagent_type="Explore", prompt="Find related patterns")
+Task(subagent_type="Explore", prompt="Identify affected areas")
+```
+
+This is faster than sequential exploration and provides comprehensive coverage.
+
 ## Claude Code Plan Mode Integration
 
 **Status**: ACTIVE | **Version**: 1.0.0
@@ -261,48 +304,6 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 
 ### Module Location
 `scripts/modules/plan-mode/` - LEOPlanModeOrchestrator.js, phase-permissions.js
-
-## 🤖 Built-in Agent Integration
-
-## Built-in Agent Integration
-
-### Three-Layer Agent Architecture
-
-LEO Protocol uses three complementary agent layers:
-
-| Layer | Source | Agents | Purpose |
-|-------|--------|--------|---------|
-| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
-| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
-| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
-
-### Integration Principle
-
-> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
-
-Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
-
-### When to Use Each Layer
-
-| Task | Use | Example |
-|------|-----|---------|
-| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
-| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
-| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
-| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
-| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
-
-### Parallel Execution
-
-Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
-
-```
-Task(subagent_type="Explore", prompt="Search for existing implementations")
-Task(subagent_type="Explore", prompt="Find related patterns")
-Task(subagent_type="Explore", prompt="Identify affected areas")
-```
-
-This is faster than sequential exploration and provides comprehensive coverage.
 
 ## Sub-Agent Model Routing
 
@@ -379,6 +380,71 @@ The pre-push hook automatically:
 2. Verifies completion status in database
 3. Blocks if not ready for merge
 
+## QF Lifecycle Reconciliation
+
+**Problem**: quick_fixes rows stay `status=open` after a PR is merged via direct `gh pr merge` (any path that skips complete-quick-fix.js). sd:next then recommends phantom work. Root cause documented in feedback memory `feedback_qf_db_stale_after_merge.md`.
+
+**Solution**: Two complementary reconciliation layers — pre-merge filter + post-merge sweep. Both are idempotent and safe to run on any schedule.
+
+### Layer 1 — Pre-Merge Filter (sd:next data loader)
+`scripts/modules/sd-next/data-loaders.js` exposes two functions:
+- `loadOpenQuickFixes()` — returns rows where `pr_url IS NULL` AND `commit_sha IS NULL`. Filters out QFs with in-flight PRs so sd:next does not restart work a parallel session is already merging (QF-380 merge-race fix).
+- `loadReadyToMergeQuickFixes()` — queries the inverse pool (`pr_url IS NOT NULL`), cross-checks each PR state via `gh api` with a 60-second in-memory cache, returns only OPEN + all-checks-green rows tagged `ready_to_merge=true`. Lets the sd:next dispatcher emit a `qf_merge` action for adoption-ready work instead of `qf_start`.
+
+> Why the cache: sd:next runs many times per session. Without the 60s dedup, each invocation hits the GitHub API for every open QF — rate limits bite within minutes.
+
+### Layer 2 — Post-Merge Sweep (orphan-qf-reaper)
+`scripts/orphan-qf-reaper.mjs` sweeps rows where `status IN (open, in_progress)` AND `pr_url` points to a MERGED PR, and flips them to `status=completed`. Protections:
+- **Idempotency**: `.eq(status, current)` guard on the update — a concurrent complete-quick-fix.js flip wins without erroring.
+- **5-minute safety window**: skips rows whose `pr_url` was set within the last 5 minutes, giving complete-quick-fix.js time to finish its own flip.
+- **Structured JSON logging**: one line per row evaluated, durable artifact for debugging races.
+
+### Scheduled Execution
+`.github/workflows/orphan-qf-reaper.yml` runs Layer 2 every 15 minutes on cron plus `workflow_dispatch`, with a `dry-run` input, a concurrency group to prevent overlap, and a per-run `reaper.log` artifact.
+
+### When to Reach For This
+- **`sd:next` recommends a QF you know was merged**: check `loadOpenQuickFixes` is filtering on `pr_url IS NULL`; inspect that QF's `pr_url` / `commit_sha` columns. If they're set, the reaper will close it on its next cron; for immediate cleanup, run `node scripts/orphan-qf-reaper.mjs`.
+- **Two sessions on the same QF**: verify `loadReadyToMergeQuickFixes` is wired into the dispatcher and emitting `qf_merge` for rows with open PRs.
+- **QF with open PR but sd:next ignores it**: the PR's checks are not all green — expected. Layer 1 only surfaces merge-ready work.
+
+### Anti-Pattern
+Do **not** replace these layers with a blanket "close all QFs with any pr_url set". The 5-minute window and merged-state check prevent closing a QF whose PR is still under review.
+
+> Background: This section is FR5 of SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001. Layer 1 first shipped as QF-20260423-380; Layer 2 + scheduled sweep ship with this SD.
+
+## 🖥️ UI Parity Requirement (MANDATORY)
+
+**Every backend data contract field MUST have a corresponding UI representation.**
+
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+
+### Requirements
+
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
+
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
+
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
+
 ## Execution Philosophy
 
 ### Quality-First (PARAMOUNT)
@@ -415,71 +481,6 @@ The pre-push hook automatically:
 - Skip LEAD approval for child SDs
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
-
-## 🖥️ UI Parity Requirement (MANDATORY)
-
-**Every backend data contract field MUST have a corresponding UI representation.**
-
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
-
-### Requirements
-
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
-
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
-
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
-
-## QF Lifecycle Reconciliation
-
-**Problem**: quick_fixes rows stay `status=open` after a PR is merged via direct `gh pr merge` (any path that skips complete-quick-fix.js). sd:next then recommends phantom work. Root cause documented in feedback memory `feedback_qf_db_stale_after_merge.md`.
-
-**Solution**: Two complementary reconciliation layers — pre-merge filter + post-merge sweep. Both are idempotent and safe to run on any schedule.
-
-### Layer 1 — Pre-Merge Filter (sd:next data loader)
-`scripts/modules/sd-next/data-loaders.js` exposes two functions:
-- `loadOpenQuickFixes()` — returns rows where `pr_url IS NULL` AND `commit_sha IS NULL`. Filters out QFs with in-flight PRs so sd:next does not restart work a parallel session is already merging (QF-380 merge-race fix).
-- `loadReadyToMergeQuickFixes()` — queries the inverse pool (`pr_url IS NOT NULL`), cross-checks each PR state via `gh api` with a 60-second in-memory cache, returns only OPEN + all-checks-green rows tagged `ready_to_merge=true`. Lets the sd:next dispatcher emit a `qf_merge` action for adoption-ready work instead of `qf_start`.
-
-> Why the cache: sd:next runs many times per session. Without the 60s dedup, each invocation hits the GitHub API for every open QF — rate limits bite within minutes.
-
-### Layer 2 — Post-Merge Sweep (orphan-qf-reaper)
-`scripts/orphan-qf-reaper.mjs` sweeps rows where `status IN (open, in_progress)` AND `pr_url` points to a MERGED PR, and flips them to `status=completed`. Protections:
-- **Idempotency**: `.eq(status, current)` guard on the update — a concurrent complete-quick-fix.js flip wins without erroring.
-- **5-minute safety window**: skips rows whose `pr_url` was set within the last 5 minutes, giving complete-quick-fix.js time to finish its own flip.
-- **Structured JSON logging**: one line per row evaluated, durable artifact for debugging races.
-
-### Scheduled Execution
-`.github/workflows/orphan-qf-reaper.yml` runs Layer 2 every 15 minutes on cron plus `workflow_dispatch`, with a `dry-run` input, a concurrency group to prevent overlap, and a per-run `reaper.log` artifact.
-
-### When to Reach For This
-- **`sd:next` recommends a QF you know was merged**: check `loadOpenQuickFixes` is filtering on `pr_url IS NULL`; inspect that QF's `pr_url` / `commit_sha` columns. If they're set, the reaper will close it on its next cron; for immediate cleanup, run `node scripts/orphan-qf-reaper.mjs`.
-- **Two sessions on the same QF**: verify `loadReadyToMergeQuickFixes` is wired into the dispatcher and emitting `qf_merge` for rows with open PRs.
-- **QF with open PR but sd:next ignores it**: the PR's checks are not all green — expected. Layer 1 only surfaces merge-ready work.
-
-### Anti-Pattern
-Do **not** replace these layers with a blanket "close all QFs with any pr_url set". The 5-minute window and merged-state check prevent closing a QF whose PR is still under review.
-
-> Background: This section is FR5 of SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001. Layer 1 first shipped as QF-20260423-380; Layer 2 + scheduled sweep ship with this SD.
 
 ## Queue Ranking and QF Track Inference
 
@@ -1520,60 +1521,60 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. Retrospective — SD-LEO-REFAC-GATE-PATTERN-UNIFICATION-001 — Gate UI Pattern Unification (Trilogy Closer at the UI Render Layer) [QUALITY]
-**Category**: APPLICATION_ISSUE | **Date**: 5/12/2026 | **Score**: 100
+### 1. SD-FDBK-ENH-RETROSPECTIVES-AUTO-VALIDATE-001: Symmetric + idempotent missing_protocol_improvements quality-warning lifecycle (PR #4285) [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
-- Mock paths for lazy stage components in tests required cross-referencing src/data/venture-workflow.t...
-- useVentureWorkflow currentStage takes precedence over modeInfo.currentStage inside VentureActionBar....
+- The two quality_issues-writing triggers should arguably be unified so a single function owns quality...
+- A missing_protocol_improvements warning still does not survive a content-change INSERT because auto_...
 
 **Action Items**:
-- [ ] Add an ESLint or AST-based structural check that flags any new Stage*.tsx compon...
-- [ ] Build a test-scaffold generator that reads src/data/venture-workflow.ts and emit...
+- [ ] Add a lint/static check that flags any trigger reading or writing a column that ...
+- [ ] Open a follow-up SD to unify retrospectives quality_issues ownership into a sing...
 
-### 2. LEAD_TO_PLAN Handoff Retrospective: Gate Status Authority Unification — worker-state-driven UI labels for gate stages [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 5/12/2026 | **Score**: 100
+### 2. SD-LEO-FIX-SHOW-WHICH-STAGE-001: Show which stage is being viewed when browsing venture stage history — SD Completion Retrospective [QUALITY]
+**Category**: USER_EXPERIENCE | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
-- [PAT-RETRO-EXECTOPLAN-934968a4] EXEC-TO-PLAN rejected 2 times during SD lifecycle. Avg score: 0%. Co...
-- [PAT-RETRO-PLANTOEXEC-934968a4] PLAN-TO-EXEC rejected 3 times during SD lifecycle. Avg score: 0%. Co...
+- The SD's named target files were wrong for the actual defect. Root cause (5 Whys): (1) header showed...
+- add-prd --content failed once because the integration_operationalization key whitelist is exact: the...
 
 **Action Items**:
-- [ ] Verify: VentureActionBar branches on stageWork.stage_status BEFORE the gate-fall...
-- [ ] Validate: 15 gate stages render "Analyzing stage..." with spinner during worker ...
+- [ ] Update the testing-agent so that when it maps a passing test to a user story it ...
+- [ ] Document the add-prd --content integration_operationalization key whitelist (the...
 
-### 3. Retrospective: SD-LEO-INFRA-CANONICAL-SCRIPTS-APPLY-001 — Canonical scripts/apply-migration.js + audit table [QUALITY]
-**Category**: DATABASE_SCHEMA | **Date**: 5/11/2026 | **Score**: 100
+### 3. SD-LEO-INFRA-ATOMIC-FLEET-WORK-001: Atomic fleet work-leasing — the swept-twice bug was a deploy gap, not a code gap [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 6/5/2026 | **Score**: 100
 
 **Key Improvements**:
-- sd-start.js reported "install skipped: lockfile hash match" while node_modules was empty (symlink-ta...
-- Prior session let PLAN-TO-EXEC pass @ 91 without TS-7 (PRD explicitly states TS-7 "gates PLAN-TO-EXE...
+- Migration deploy automation and auditing: committed does not equal applied, and there is currently n...
+- The "completed" definition for migration-bearing SDs should require a deploy gate; otherwise a write...
 
 **Action Items**:
-- [ ] File QF for sd-start.js to add a node_modules liveness check (count entries > 10...
-- [ ] Add a PRD validator that enforces test-set gating: if PRD names a test ID as gat...
+- [ ] In a fresh session, apply 20260605_atomic_lease_sweep_respect_inflight.sql via s...
+- [ ] Fix the false "check-readiness CI applies it" comment across migration templates...
 
-### 4. SD-LEO-INFRA-VENTURE-GATE-UNIFICATION-001 SD-Completion Retrospective — Venture Gate Unification across all 26 stages [QUALITY]
-**Category**: DATABASE_SCHEMA | **Date**: 5/12/2026 | **Score**: 100
+### 4. SD-LEO-INFRA-ENABLE-CLAIM-SWEEP-001 Retrospective [QUALITY]
+**Category**: DATABASE_SCHEMA | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
-- The MIGRATION_READINESS_INFRA_ERROR CI infra bug (missing SUPABASE_DB_PASSWORD GH Actions secret) fo...
-- The 2 retry tests in tests/unit/eva/stage-execution-worker.test.js were skipped rather than rewritte...
+- The initial verify step queried the wrong column (schema_migrations_applied.migration_name instead o...
+- My own session claim was swept during the ~18-minute database-agent run (re-affirmed via sd-start) —...
 
 **Action Items**:
-- [ ] Rewrite the 2 skipped retry tests in tests/unit/eva/stage-execution-worker.test....
-- [ ] File harness SD/QF for the pre-existing MIGRATION_READINESS_INFRA_ERROR root cau...
+- [ ] DEPLOY: update the main checkout's .claude/settings.json (or reload settings) so...
+- [ ] POST-DEPLOY VERIFY: confirm the fleet-wide claim-sweep-mid-sub-agent dormancy is...
 
-### 5. Retrospective: SD-LEO-REFAC-GATE-STATUS-AUTHORITY-001 — Pentalogy-Closing Worker-State UI Authority [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 5/12/2026 | **Score**: 100
+### 5. SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001 SD Completion Retrospective [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 6/6/2026 | **Score**: 100
 
 **Key Improvements**:
-- sub_agent_code case-asymmetry: 21st+ witness of the writer/consumer asymmetry pattern at the protoco...
-- CI workflow gap in EHG repo was deeper than expected: prior to SD-AUTO-ADVANCE-001 there was NO unit...
+- {"area":"EHG app listVentures() applies neither an is_demo nor a deleted_at predicate","prevention":...
+- {"area":"The pre-existing chairman_decisions parity assertion fails on the unmodified baseline","pre...
 
 **Action Items**:
-- [ ] 21st+ witness of writer/consumer asymmetry — exact pattern this pentalogy was su...
-- [ ] AUTO-ADVANCE SD added the first unit-test CI workflow; STATUS-AUTHORITY (this SD...
+- [ ] Open a follow-up QF to add is_demo=false and deleted_at IS NULL predicates to th...
+- [ ] Track and fix the pre-existing chairman_decisions parity assertion that fails on...
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,8 +1,8 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-10T16:15:59.602Z -->
-<!-- git_commit: 11a75297 -->
-<!-- db_snapshot_hash: 4c260fddb7740f6c -->
-<!-- file_content_hash: pending -->
+<!-- generated_at: 2026-06-10T18:53:04.116Z -->
+<!-- git_commit: afd81f04 -->
+<!-- db_snapshot_hash: 1c0d92b1433aad31 -->
+<!-- file_content_hash: 58fb61ebe21c160d -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -269,5 +269,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-10 12:15:59 PM*
+*DIGEST generated: 2026-06-10 2:53:04 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,8 +1,8 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-10T16:15:59.602Z -->
-<!-- git_commit: 11a75297 -->
-<!-- db_snapshot_hash: 4c260fddb7740f6c -->
-<!-- file_content_hash: pending -->
+<!-- generated_at: 2026-06-10T18:53:04.116Z -->
+<!-- git_commit: afd81f04 -->
+<!-- db_snapshot_hash: 1c0d92b1433aad31 -->
+<!-- file_content_hash: ae144aab1c432a75 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +159,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-10 12:15:59 PM*
+*DIGEST generated: 2026-06-10 2:53:04 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,7 @@
+<!-- file_content_hash: d8f8a79262051607 -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-10 12:15:59 PM
+**Generated**: 2026-06-10 2:53:04 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -199,6 +200,70 @@ See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for c
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
 
 
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+# Branch was auto-created at LEAD-TO-PLAN handoff
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
+
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
 
 **Source**: Analysis of 175 high-quality retrospectives (score ≥60)
@@ -287,70 +352,6 @@ If `research_confidence_score = 0.00`, you skipped this step.
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
 
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-# Branch was auto-created at LEAD-TO-PLAN handoff
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
-
 ## Vision/Architecture Doc Pre-Check
 
 ## Vision/Architecture Doc Pre-Check (Step 0.25)
@@ -435,6 +436,41 @@ Sub-agents are FIRST RESPONDERS in EXEC phase. When you encounter a problem that
 
 *Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
 
+## Migration Script Pattern (MANDATORY)
+
+**Issue Pattern**: PAT-DB-MIGRATION-001
+
+When writing migration scripts, you MUST use the established pattern:
+
+### Correct Pattern
+```javascript
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+import { readFileSync } from 'fs';
+
+const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
+const client = await createDatabaseClient('engineer', { verify: true });
+const statements = splitPostgreSQLStatements(migrationSQL);
+
+for (const statement of statements) {
+  await client.query(statement);
+}
+
+await client.end();
+```
+
+### NEVER Use This Pattern
+```javascript
+// WRONG - exec_sql RPC does not exist
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(url, key);
+await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
+```
+
+### Before Writing Migration Scripts
+1. Search for existing patterns: `Glob *migration*.js`
+2. Read `scripts/run-sql-migration.js` as canonical template
+3. Use `lib/supabase-connection.js` utilities
+
 ## 📚 Skill Integration (EXEC Phase)
 
 ## Skill Integration During EXEC
@@ -514,41 +550,6 @@ Both are valid in EXEC — use them for different purposes:
 Skills are for **creative guidance** (how to build).
 Sub-agents act as **first responders** on domain-specific errors AND as **formal validators** before EXEC-TO-PLAN.
 Use both during EXEC — the distinction is about *purpose*, not *phase*.
-
-## Migration Script Pattern (MANDATORY)
-
-**Issue Pattern**: PAT-DB-MIGRATION-001
-
-When writing migration scripts, you MUST use the established pattern:
-
-### Correct Pattern
-```javascript
-import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
-import { readFileSync } from 'fs';
-
-const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
-const client = await createDatabaseClient('engineer', { verify: true });
-const statements = splitPostgreSQLStatements(migrationSQL);
-
-for (const statement of statements) {
-  await client.query(statement);
-}
-
-await client.end();
-```
-
-### NEVER Use This Pattern
-```javascript
-// WRONG - exec_sql RPC does not exist
-import { createClient } from '@supabase/supabase-js';
-const supabase = createClient(url, key);
-await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
-```
-
-### Before Writing Migration Scripts
-1. Search for existing patterns: `Glob *migration*.js`
-2. Read `scripts/run-sql-migration.js` as canonical template
-3. Use `lib/supabase-connection.js` utilities
 
 ## Validation Rules (SD-LEARN-008)
 
@@ -747,24 +748,6 @@ EXEC→PLAN handoffs now have **intelligent verification**:
 | **300-600** | ✅ **OPTIMAL** | Sweet spot |
 | **>800** | **MUST split** | Too complex |
 
-## TODO Comment Standard
-
-## TODO Comment Standard (When Deferring Work)
-
-**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
-
-### Standard TODO Format
-
-```typescript
-// TODO (SD-ID): Action required
-// Requires: Dependencies, prerequisites
-// Estimated effort: X-Y hours
-// Current state: Mock/temporary/placeholder
-```
-
-**Success Pattern** (SD-UAT-003):
-> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
-
 ## Human-Like E2E Testing Fixtures
 
 ### Human-Like E2E Testing Enhancements (LEO v4.4)
@@ -848,6 +831,24 @@ All human-like test results are automatically included in the LEO evidence pack:
 - `test_results.attachments.accessibility` - axe-core violations
 - `test_results.attachments.chaos` - resilience test results
 - `test_results.attachments.llm_ux` - LLM evaluation scores
+
+## TODO Comment Standard
+
+## TODO Comment Standard (When Deferring Work)
+
+**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
+
+### Standard TODO Format
+
+```typescript
+// TODO (SD-ID): Action required
+// Requires: Dependencies, prerequisites
+// Estimated effort: X-Y hours
+// Current state: Mock/temporary/placeholder
+```
+
+**Success Pattern** (SD-UAT-003):
+> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
 
 ## EXEC Dual Test Requirement
 
@@ -965,86 +966,6 @@ UI Parity Status:
 - Gate 2.5 Status: PASS/FAIL
 ```
 
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
-
-**Every completed Strategic Directive and Quick-Fix MUST end with:**
-
-1. **Commit** - All changes committed with proper message format
-2. **Push** - Branch pushed to remote
-3. **Merge to Main** - Feature branch merged into main
-
-### For Quick-Fixes
-
-The `complete-quick-fix.js` script handles this automatically:
-
-```bash
-node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
-```
-
-The script will:
-1. Verify tests pass and UAT completed
-2. Commit and push changes
-3. **Prompt to merge PR to main** (or local merge if no PR)
-4. Delete the feature branch
-
-### For Strategic Directives
-
-After LEAD approval, execute the following:
-
-```bash
-# 1. Ensure all changes committed
-git add .
-git commit -m "feat(SD-YYYY-XXX): [description]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
-
-# 2. Push to remote
-git push origin feature/SD-YYYY-XXX
-
-# 3. Create PR if not exists
-gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
-
-# 4. Merge PR (preferred method)
-gh pr merge --merge --delete-branch
-
-# OR local merge fallback
-git checkout main
-git pull origin main
-git merge --no-ff feature/SD-YYYY-XXX
-git push origin main
-git branch -d feature/SD-YYYY-XXX
-git push origin --delete feature/SD-YYYY-XXX
-```
-
-### Merge Checklist
-
-Before merging, verify:
-- [ ] All tests passing (unit + E2E)
-- [ ] CI/CD pipeline green
-- [ ] Code review completed (if required)
-- [ ] No merge conflicts
-- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
-
-### Anti-Patterns
-
-❌ **NEVER** leave feature branches unmerged after completion
-❌ **NEVER** skip the push step
-❌ **NEVER** merge without verifying tests pass
-❌ **NEVER** force push to main
-
-### Verification
-
-After merge, confirm:
-```bash
-git checkout main
-git pull origin main
-git log --oneline -5  # Should show your merge commit
-```
-
 ## 🌿 Branch Hygiene Gate (MANDATORY)
 
 ## Branch Hygiene Gate (MANDATORY)
@@ -1137,6 +1058,86 @@ When starting implementation:
 3. If multiple SDs detected → split branches
 4. If >100 files changed → assess scope creep
 5. Document branch health in handoff notes
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
+
+**Every completed Strategic Directive and Quick-Fix MUST end with:**
+
+1. **Commit** - All changes committed with proper message format
+2. **Push** - Branch pushed to remote
+3. **Merge to Main** - Feature branch merged into main
+
+### For Quick-Fixes
+
+The `complete-quick-fix.js` script handles this automatically:
+
+```bash
+node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
+```
+
+The script will:
+1. Verify tests pass and UAT completed
+2. Commit and push changes
+3. **Prompt to merge PR to main** (or local merge if no PR)
+4. Delete the feature branch
+
+### For Strategic Directives
+
+After LEAD approval, execute the following:
+
+```bash
+# 1. Ensure all changes committed
+git add .
+git commit -m "feat(SD-YYYY-XXX): [description]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# 2. Push to remote
+git push origin feature/SD-YYYY-XXX
+
+# 3. Create PR if not exists
+gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
+
+# 4. Merge PR (preferred method)
+gh pr merge --merge --delete-branch
+
+# OR local merge fallback
+git checkout main
+git pull origin main
+git merge --no-ff feature/SD-YYYY-XXX
+git push origin main
+git branch -d feature/SD-YYYY-XXX
+git push origin --delete feature/SD-YYYY-XXX
+```
+
+### Merge Checklist
+
+Before merging, verify:
+- [ ] All tests passing (unit + E2E)
+- [ ] CI/CD pipeline green
+- [ ] Code review completed (if required)
+- [ ] No merge conflicts
+- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
+
+### Anti-Patterns
+
+❌ **NEVER** leave feature branches unmerged after completion
+❌ **NEVER** skip the push step
+❌ **NEVER** merge without verifying tests pass
+❌ **NEVER** force push to main
+
+### Verification
+
+After merge, confirm:
+```bash
+git checkout main
+git pull origin main
+git log --oneline -5  # Should show your merge commit
+```
 
 ## Auto-Merge Workflow for SD Completion
 
@@ -1458,6 +1459,77 @@ The ACCEPTANCE_CRITERIA_VALIDATION gate scores stories as follows:
 
 Threshold: overall score >= 60 AND no story scores 0.
 
+## Playwright MCP Integration
+
+## 🎭 Playwright MCP Integration
+
+**Status**: ✅ READY (Installed 2025-10-12)
+
+### Overview
+Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
+
+### Installed Components
+- **Chrome**: Google Chrome browser for MCP operations
+- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
+- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
+- **System Dependencies**: All required Linux libraries installed
+
+### Available MCP Tools
+
+#### Navigation
+- `mcp__playwright__browser_navigate` - Navigate to URL
+- `mcp__playwright__browser_navigate_back` - Go back to previous page
+
+#### Interaction
+- `mcp__playwright__browser_click` - Click elements
+- `mcp__playwright__browser_fill` - Fill form fields
+- `mcp__playwright__browser_select` - Select dropdown options
+- `mcp__playwright__browser_hover` - Hover over elements
+- `mcp__playwright__browser_type` - Type text into elements
+
+#### Verification
+- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
+- `mcp__playwright__browser_take_screenshot` - Take screenshots
+- `mcp__playwright__browser_evaluate` - Execute JavaScript
+
+#### Management
+- `mcp__playwright__browser_close` - Close browser
+- `mcp__playwright__browser_tabs` - Manage tabs
+
+### Testing Integration
+
+**When to Use Playwright MCP**:
+1. ✅ Visual regression testing
+2. ✅ UI component verification
+3. ✅ Screenshot capture for evidence
+4. ✅ Accessibility tree validation
+5. ✅ Cross-browser testing
+
+**When to Use Standard Playwright**:
+1. ✅ E2E test suites (`npm run test:e2e`)
+2. ✅ CI/CD pipeline tests
+3. ✅ Automated test runs
+4. ✅ User story validation
+
+### Usage Example
+
+```javascript
+// Using Playwright MCP for visual verification
+await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
+await mcp__playwright__browser_snapshot(); // Get accessibility tree
+await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
+await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
+```
+
+### QA Director Integration
+
+The QA Engineering Director sub-agent now has access to:
+- Playwright MCP for visual testing
+- Standard Playwright for E2E automation
+- Both Chrome (MCP) and Chromium (tests) browsers
+
+**Complete Guide**: See `docs/reference/playwright-mcp-guide.md`
+
 ## Triangulated Runtime Audit Protocol
 
 ### Purpose
@@ -1675,77 +1747,6 @@ See: `/runtime-audit` skill for full template
 - `codebase-search` - Finding code references
 - `schema-design` - Database schema issues
 
-
-## Playwright MCP Integration
-
-## 🎭 Playwright MCP Integration
-
-**Status**: ✅ READY (Installed 2025-10-12)
-
-### Overview
-Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
-
-### Installed Components
-- **Chrome**: Google Chrome browser for MCP operations
-- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
-- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
-- **System Dependencies**: All required Linux libraries installed
-
-### Available MCP Tools
-
-#### Navigation
-- `mcp__playwright__browser_navigate` - Navigate to URL
-- `mcp__playwright__browser_navigate_back` - Go back to previous page
-
-#### Interaction
-- `mcp__playwright__browser_click` - Click elements
-- `mcp__playwright__browser_fill` - Fill form fields
-- `mcp__playwright__browser_select` - Select dropdown options
-- `mcp__playwright__browser_hover` - Hover over elements
-- `mcp__playwright__browser_type` - Type text into elements
-
-#### Verification
-- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
-- `mcp__playwright__browser_take_screenshot` - Take screenshots
-- `mcp__playwright__browser_evaluate` - Execute JavaScript
-
-#### Management
-- `mcp__playwright__browser_close` - Close browser
-- `mcp__playwright__browser_tabs` - Manage tabs
-
-### Testing Integration
-
-**When to Use Playwright MCP**:
-1. ✅ Visual regression testing
-2. ✅ UI component verification
-3. ✅ Screenshot capture for evidence
-4. ✅ Accessibility tree validation
-5. ✅ Cross-browser testing
-
-**When to Use Standard Playwright**:
-1. ✅ E2E test suites (`npm run test:e2e`)
-2. ✅ CI/CD pipeline tests
-3. ✅ Automated test runs
-4. ✅ User story validation
-
-### Usage Example
-
-```javascript
-// Using Playwright MCP for visual verification
-await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
-await mcp__playwright__browser_snapshot(); // Get accessibility tree
-await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
-await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
-```
-
-### QA Director Integration
-
-The QA Engineering Director sub-agent now has access to:
-- Playwright MCP for visual testing
-- Standard Playwright for E2E automation
-- Both Chrome (MCP) and Chromium (tests) browsers
-
-**Complete Guide**: See `docs/reference/playwright-mcp-guide.md`
 
 ## Edge Case Testing Checklist
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,8 +1,8 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-10T16:15:59.602Z -->
-<!-- git_commit: 11a75297 -->
-<!-- db_snapshot_hash: 4c260fddb7740f6c -->
-<!-- file_content_hash: pending -->
+<!-- generated_at: 2026-06-10T18:53:04.116Z -->
+<!-- git_commit: afd81f04 -->
+<!-- db_snapshot_hash: 1c0d92b1433aad31 -->
+<!-- file_content_hash: 2c519e8eb95c34b0 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -216,5 +216,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-10 12:15:59 PM*
+*DIGEST generated: 2026-06-10 2:53:04 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,7 @@
+<!-- file_content_hash: 908223b3b886c765 -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-10 12:15:59 PM
+**Generated**: 2026-06-10 2:53:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -503,81 +504,6 @@ node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 - **Process Scripts**: `scripts/add-sd-to-database.js`, `scripts/handoff.js`, `scripts/leo-create-sd.js`
 - **Plan-Aware Creation**: `docs/reference/sd-key-generator-guide.md` (--from-plan section)
 
-## Child SD Context Loading (MANDATORY)
-
-**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
-
-### Why This Applies to Children
-
-Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
-- Has its own PRD
-- Has its own handoffs
-- Has its own retrospective
-- Must meet its own gate thresholds
-
-**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
-
-### Required Context Loading Sequence
-
-Before starting ANY work on a child SD:
-
-1. **Run child preflight validation**:
-   ```bash
-   node scripts/child-sd-preflight.js SD-XXX-001
-   ```
-
-2. **Read CLAUDE_CORE.md** (provides SD type requirements):
-   ```
-   Read tool: CLAUDE_CORE.md
-   ```
-
-3. **Read phase-specific file** based on current_phase:
-   | Phase | File |
-   |-------|------|
-   | LEAD_APPROVAL | CLAUDE_LEAD.md |
-   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
-   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
-
-### What CLAUDE_CORE.md Provides
-
-- SD type definitions (feature, bugfix, infrastructure, etc.)
-- Gate pass thresholds per SD type
-- Required handoff counts
-- Required sub-agents per SD type
-- Global negative constraints
-
-### Consequences of Skipping Context Loading
-
-Without loading CLAUDE_CORE.md before child SD work:
-- **Unknown requirements**: May not know PRD is required
-- **Wrong thresholds**: May target 70% when 85% is required
-- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
-- **Incomplete handoffs**: May not execute full chain
-
-### Enforcement
-
-The `child-sd-preflight.js` script now displays a reminder:
-```
-⚠️  CONTEXT LOADING REMINDER:
-   Before starting work, you MUST read:
-   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
-   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
-```
-
-**This reminder is advisory.** The actual context loading must be performed by reading the files.
-
-### Quick Reference
-
-| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
-|---------------|----------------|--------------|--------------|
-| feature | 85% | 5 | YES |
-| bugfix | 85% | 5 | YES |
-| infrastructure | 80% | 4 | YES |
-| documentation | 60% | 4 | NO |
-| refactor | 75-90% | 5 | Brief |
-
-*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
-
 ## Common SD Creation Errors and Solutions
 
 ### Database Constraint Errors
@@ -851,6 +777,81 @@ const sdKey = await generateSDKey({ source, type, title });
 4. `scripts/create-sd.js`
 5. `scripts/modules/learning/executor.js`
 
+
+## Child SD Context Loading (MANDATORY)
+
+**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
+
+### Why This Applies to Children
+
+Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
+- Has its own PRD
+- Has its own handoffs
+- Has its own retrospective
+- Must meet its own gate thresholds
+
+**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
+
+### Required Context Loading Sequence
+
+Before starting ANY work on a child SD:
+
+1. **Run child preflight validation**:
+   ```bash
+   node scripts/child-sd-preflight.js SD-XXX-001
+   ```
+
+2. **Read CLAUDE_CORE.md** (provides SD type requirements):
+   ```
+   Read tool: CLAUDE_CORE.md
+   ```
+
+3. **Read phase-specific file** based on current_phase:
+   | Phase | File |
+   |-------|------|
+   | LEAD_APPROVAL | CLAUDE_LEAD.md |
+   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
+   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
+
+### What CLAUDE_CORE.md Provides
+
+- SD type definitions (feature, bugfix, infrastructure, etc.)
+- Gate pass thresholds per SD type
+- Required handoff counts
+- Required sub-agents per SD type
+- Global negative constraints
+
+### Consequences of Skipping Context Loading
+
+Without loading CLAUDE_CORE.md before child SD work:
+- **Unknown requirements**: May not know PRD is required
+- **Wrong thresholds**: May target 70% when 85% is required
+- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
+- **Incomplete handoffs**: May not execute full chain
+
+### Enforcement
+
+The `child-sd-preflight.js` script now displays a reminder:
+```
+⚠️  CONTEXT LOADING REMINDER:
+   Before starting work, you MUST read:
+   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
+   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
+```
+
+**This reminder is advisory.** The actual context loading must be performed by reading the files.
+
+### Quick Reference
+
+| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
+|---------------|----------------|--------------|--------------|
+| feature | 85% | 5 | YES |
+| bugfix | 85% | 5 | YES |
+| infrastructure | 80% | 4 | YES |
+| documentation | 60% | 4 | NO |
+| refactor | 75-90% | 5 | Brief |
+
+*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
 
 ## Phase-Specific Sub-Agent Guidance: LEAD
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,8 +1,8 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-10T16:15:59.602Z -->
-<!-- git_commit: 11a75297 -->
-<!-- db_snapshot_hash: 4c260fddb7740f6c -->
-<!-- file_content_hash: pending -->
+<!-- generated_at: 2026-06-10T18:53:04.116Z -->
+<!-- git_commit: afd81f04 -->
+<!-- db_snapshot_hash: 1c0d92b1433aad31 -->
+<!-- file_content_hash: cf6e3000f355e775 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -131,5 +131,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-10 12:15:59 PM*
+*DIGEST generated: 2026-06-10 2:53:04 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,7 @@
+<!-- file_content_hash: 5c7e213ca2350361 -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-10 12:15:59 PM
+**Generated**: 2026-06-10 2:53:04 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -204,6 +205,30 @@ LEAD Phase                    PLAN Phase                   EXEC Phase
 ```
 
 
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
+
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -241,30 +266,6 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
-
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
 
 ## Phase-Specific Sub-Agent Guidance: PLAN
 
@@ -454,23 +455,6 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 | "DESIGN sub-agent not executed" | Didn't run design-agent | Use Task tool with design-agent |
 | "DATABASE sub-agent not executed" | Didn't run database-agent | Use Task tool with database-agent |
 
-## Enhanced QA Engineering Director v2.0 - Testing-First Edition
-
-**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
-
-**Core Capabilities:**
-1. Professional test case generation from user stories
-2. Pre-test build validation (saves 2-3 hours)
-3. Database migration verification (prevents 1-2 hours debugging)
-4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
-5. Test infrastructure discovery and reuse
-
-**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
-
-**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
-
-**Full Guide**: See `docs/reference/qa-director-guide.md`
-
 ## ✅ Scope Verification with Explore (PLAN_VERIFY)
 
 ## Scope Verification with Explore
@@ -541,6 +525,23 @@ This change [describe]. Options:
 
 Which do you prefer?"
 ```
+
+## Enhanced QA Engineering Director v2.0 - Testing-First Edition
+
+**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
+
+**Core Capabilities:**
+1. Professional test case generation from user stories
+2. Pre-test build validation (saves 2-3 hours)
+3. Database migration verification (prevents 1-2 hours debugging)
+4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
+5. Test infrastructure discovery and reuse
+
+**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
+
+**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
+
+**Full Guide**: See `docs/reference/qa-director-guide.md`
 
 ## PLAN Pre-EXEC Checklist
 
@@ -827,6 +828,21 @@ node scripts/add-prd-to-database.js {SD-ID}
 - ⚠️ Never create PRDs as markdown files
 - ⚠️ Never skip validation gates
 
+## CI/CD Pipeline Verification
+
+## CI/CD Pipeline Verification (MANDATORY)
+
+**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
+
+### Verification Process
+
+**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
+
+1. Wait 2-3 minutes for GitHub Actions to complete
+2. Trigger DevOps sub-agent to verify pipeline status
+3. Document CI/CD status in PLAN→LEAD handoff
+4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
+
 ## DESIGN→DATABASE Validation Gates
 
 **4 mandatory gates ensuring sub-agent execution and implementation fidelity.**
@@ -878,21 +894,6 @@ Retroactive audit at SD closure:
 
 **Reference**: `scripts/modules/design-database-gates-validation.js`
 
-
-## CI/CD Pipeline Verification
-
-## CI/CD Pipeline Verification (MANDATORY)
-
-**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
-
-### Verification Process
-
-**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
-
-1. Wait 2-3 minutes for GitHub Actions to complete
-2. Trigger DevOps sub-agent to verify pipeline status
-3. Document CI/CD status in PLAN→LEAD handoff
-4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
 
 ## 🚪 Gate 2.5: Human Inspectability Validation
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,8 +1,8 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-10T16:15:59.602Z -->
-<!-- git_commit: 11a75297 -->
-<!-- db_snapshot_hash: 4c260fddb7740f6c -->
-<!-- file_content_hash: pending -->
+<!-- generated_at: 2026-06-10T18:53:04.116Z -->
+<!-- git_commit: afd81f04 -->
+<!-- db_snapshot_hash: 1c0d92b1433aad31 -->
+<!-- file_content_hash: b02c31f6b5dd3ba1 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -162,5 +162,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-10 12:15:59 PM*
+*DIGEST generated: 2026-06-10 2:53:04 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,91 +1,14 @@
 {
-  "generated_at": "2026-06-10T16:15:59.602Z",
-  "git_commit": "11a75297",
-  "db_snapshot_hash": "4c260fddb7740f6c",
+  "generated_at": "2026-06-10T18:53:32.650Z",
+  "git_commit": "afd81f04",
+  "db_snapshot_hash": "1c0d92b1433aad31",
   "files": {
-    "CLAUDE.md": {
-      "type": "full",
-      "chars": 19123,
-      "estimated_tokens": 4781,
-      "content_hash": "71e38744ddf89fba",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE.md"
-    },
-    "CLAUDE_CORE.md": {
-      "type": "full",
-      "chars": 78656,
-      "estimated_tokens": 19664,
-      "content_hash": "2b4d064b8f4fdd2f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_CORE.md"
-    },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 64883,
-      "estimated_tokens": 16221,
-      "content_hash": "030102cf1f6b5615",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_LEAD.md"
-    },
-    "CLAUDE_PLAN.md": {
-      "type": "full",
-      "chars": 89642,
-      "estimated_tokens": 22411,
-      "content_hash": "36a6afcce30d29ec",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_PLAN.md"
-    },
-    "CLAUDE_EXEC.md": {
-      "type": "full",
-      "chars": 81225,
-      "estimated_tokens": 20307,
-      "content_hash": "cd243f71e4b8eeb0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_EXEC.md"
-    },
-    "CLAUDE_ADAM.md": {
-      "type": "full",
-      "chars": 17842,
-      "estimated_tokens": 4461,
-      "content_hash": "d48765afc3ec8ca6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_ADAM.md"
-    },
-    "CLAUDE_DIGEST.md": {
-      "type": "digest",
-      "chars": 9402,
-      "estimated_tokens": 2351,
-      "content_hash": "07bfa82d3f52f9e6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_DIGEST.md"
-    },
-    "CLAUDE_CORE_DIGEST.md": {
-      "type": "digest",
-      "chars": 11326,
-      "estimated_tokens": 2832,
-      "content_hash": "3c2a07c9937e27d8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_CORE_DIGEST.md"
-    },
-    "CLAUDE_LEAD_DIGEST.md": {
-      "type": "digest",
-      "chars": 5213,
-      "estimated_tokens": 1304,
-      "content_hash": "62de3e23aacf0863",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_LEAD_DIGEST.md"
-    },
-    "CLAUDE_PLAN_DIGEST.md": {
-      "type": "digest",
-      "chars": 8203,
-      "estimated_tokens": 2051,
-      "content_hash": "acb696ef0597e44c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_PLAN_DIGEST.md"
-    },
-    "CLAUDE_EXEC_DIGEST.md": {
-      "type": "digest",
-      "chars": 10626,
-      "estimated_tokens": 2657,
-      "content_hash": "0cf2d71a326769d1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_EXEC_DIGEST.md"
-    },
-    "CLAUDE_ADAM_DIGEST.md": {
-      "type": "digest",
-      "chars": 3742,
-      "estimated_tokens": 936,
-      "content_hash": "ab92f7489a0ec2a3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-CONSISTENCY-DOC-001\\CLAUDE_ADAM_DIGEST.md"
+      "chars": 64927,
+      "estimated_tokens": 16232,
+      "content_hash": "ef8033fe1f36149b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001\\CLAUDE_LEAD.md"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
     "session:check-concurrency": "node scripts/session-check-concurrency.js",
     "session:park": "node scripts/park-worker.cjs",
     "prepark-wip": "node scripts/prepark-wip.cjs",
+    "protocol:pub-audit": "node scripts/protocol-publication-audit.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "engine:demo": "node scripts/auto-exec-engine-demo.mjs",
     "checkout-sync:demo": "node scripts/auto-exec-checkout-sync-demo.mjs",

--- a/scripts/generate-claude-md-from-db.js
+++ b/scripts/generate-claude-md-from-db.js
@@ -12,9 +12,27 @@ import path from 'path';
 import { createClient } from '@supabase/supabase-js';
 import { fileURLToPath } from 'url';
 
-import { CLAUDEMDGeneratorV3 } from './modules/claude-md-generator/index.js';
+import { CLAUDEMDGeneratorV3, KNOWN_GENERATED_FILES } from './modules/claude-md-generator/index.js';
 import { getActiveProtocol } from './modules/claude-md-generator/db-queries.js';
 import { runRegenLintHook } from './protocol-lint/regen-hook.mjs';
+
+// SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-4): parse --only <FILE[,FILE...]>
+// into a validated file list. Unknown names fail loud listing valid targets. Exported
+// (pure) for unit tests. Returns null when no --only flag is present (full regen).
+export function parseOnlyFlag(argv, known = KNOWN_GENERATED_FILES) {
+  const idx = argv.indexOf('--only');
+  if (idx === -1) return null;
+  const value = argv[idx + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`--only requires a value. Valid targets: ${known.join(', ')}`);
+  }
+  const files = value.split(',').map((f) => f.trim()).filter(Boolean);
+  const unknown = files.filter((f) => !known.includes(f));
+  if (unknown.length) {
+    throw new Error(`--only: unknown file(s) ${unknown.join(', ')}. Valid targets: ${known.join(', ')}`);
+  }
+  return files;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -54,7 +72,17 @@ if (import.meta.url === `file:///${normalizedArgv}`) {
       process.exit(1);
     }
 
-    const generator = new CLAUDEMDGeneratorV3(supabase, baseDir, mappingPath);
+    // FR-4: scoped regeneration — validate the target list before any work.
+    let only = null;
+    try {
+      only = parseOnlyFlag(process.argv);
+    } catch (e) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    if (only) console.log(`Scoped regeneration (--only): ${only.join(', ')}\n`);
+
+    const generator = new CLAUDEMDGeneratorV3(supabase, baseDir, mappingPath, only ? { only } : {});
     await generator.generate();
   }
 

--- a/scripts/modules/claude-md-generator/index.js
+++ b/scripts/modules/claude-md-generator/index.js
@@ -258,9 +258,11 @@ class CLAUDEMDGeneratorV3 {
           console.log(`   Token budget OK: ${digestTotalTokens}/${this.options.tokenBudget} (${Math.round(digestTotalTokens / this.options.tokenBudget * 100)}%)`);
         }
 
-        // Calculate savings
-        const savingsPercent = Math.round((1 - digestTotalTokens / fullTotalTokens) * 100);
-        console.log(`\n   Token Savings: ${savingsPercent}% (${fullTotalTokens - digestTotalTokens} tokens saved)`);
+        // Calculate savings (skip under --only scoping where full totals may be 0)
+        if (fullTotalTokens > 0) {
+          const savingsPercent = Math.round((1 - digestTotalTokens / fullTotalTokens) * 100);
+          console.log(`\n   Token Savings: ${savingsPercent}% (${fullTotalTokens - digestTotalTokens} tokens saved)`);
+        }
       }
 
       // Write manifest
@@ -289,8 +291,35 @@ class CLAUDEMDGeneratorV3 {
    * @param {string} type - File type ('full' or 'digest')
    */
   generateFile(filename, data, generatorFn, type = 'full') {
+    // SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-4): --only scoped regen.
+    // options.only = array of filenames; anything else is skipped (not rendered,
+    // not written, not in the manifest) so untouched files stay byte-identical.
+    if (Array.isArray(this.options.only) && this.options.only.length > 0 &&
+        !this.options.only.includes(filename)) {
+      console.log(`   ${filename.padEnd(25)} skipped (--only)`);
+      return;
+    }
+
     const filePath = path.join(this.baseDir, filename);
-    const content = generatorFn(data);
+    let content = generatorFn(data);
+
+    // SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-3): real content hash in the
+    // header. The digest header templates emit `file_content_hash: pending` INSIDE the
+    // body, but the hash is only computable AFTER rendering (chicken-and-egg) — every
+    // live header showed 'pending'. Contract: body = file content with the hash LINE
+    // removed; header value = sha256(body)[:16]. FULL files (no template header) get a
+    // single prepended stamp line so staleness checks cover all generated files.
+    // Verify anywhere via verifyFileContentHash() below.
+    const HASH_LINE_RE = /^<!-- file_content_hash: [^>]*-->\r?\n/m;
+    if (HASH_LINE_RE.test(content)) {
+      const body = content.replace(HASH_LINE_RE, '');
+      const bodyHash = this.computeHash(body);
+      content = content.replace(HASH_LINE_RE, `<!-- file_content_hash: ${bodyHash} -->\n`);
+    } else {
+      const bodyHash = this.computeHash(content);
+      content = `<!-- file_content_hash: ${bodyHash} -->\n${content}`;
+    }
+
     const contentHash = this.computeHash(content);
 
     writeFileAtomic(filePath, content);
@@ -322,6 +351,27 @@ class CLAUDEMDGeneratorV3 {
 }
 
 export { CLAUDEMDGeneratorV3 };
+
+// SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-4): the complete generated-file
+// set, used to validate --only targets (unknown names fail loud listing these).
+export const KNOWN_GENERATED_FILES = [
+  'CLAUDE.md', 'CLAUDE_CORE.md', 'CLAUDE_LEAD.md', 'CLAUDE_PLAN.md', 'CLAUDE_EXEC.md', 'CLAUDE_ADAM.md',
+  'CLAUDE_DIGEST.md', 'CLAUDE_CORE_DIGEST.md', 'CLAUDE_LEAD_DIGEST.md', 'CLAUDE_PLAN_DIGEST.md', 'CLAUDE_EXEC_DIGEST.md', 'CLAUDE_ADAM_DIGEST.md',
+];
+
+// SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-3): verify a generated file's
+// header hash against its body. Contract (mirrors generateFile): body = content with
+// the single `<!-- file_content_hash: ... -->` line removed; expected = sha256(body)[:16].
+// Returns { ok, expected, actual } — ok=false with actual=null when no hash line exists
+// (pre-FR-3 file or hand-edited header), making staleness/tamper checks one call.
+export function verifyFileContentHash(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const m = content.match(/^<!-- file_content_hash: ([0-9a-f]{16}) -->\r?\n/m);
+  if (!m) return { ok: false, expected: null, actual: null };
+  const body = content.replace(/^<!-- file_content_hash: [^>]*-->\r?\n/m, '');
+  const expected = crypto.createHash('sha256').update(body).digest('hex').substring(0, 16);
+  return { ok: expected === m[1], expected, actual: m[1] };
+}
 
 export {
   getActiveProtocol,

--- a/scripts/one-off/_classify-protocol-sections.cjs
+++ b/scripts/one-off/_classify-protocol-sections.cjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-1): one-time classification batch.
+// Writes metadata.publication_status (+ publication_note) to every leo_protocol_sections row
+// via read-modify-merge of ONLY those two keys. CLASSIFICATION IS ADVISORY — nothing acts on it.
+// Bulk rule: section_type mapped in either section-file-mapping JSON OR target_file set => 'file'.
+// Dark sections (59) classified per the evidence-grounded DECISIONS table below.
+// Audit afterwards: npm run protocol:pub-audit (scripts/protocol-publication-audit.cjs).
+'use strict';
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+
+// Evidence-grounded per-id decisions for TRUE-dark sections (no target_file, type unmapped).
+// runtime = a live consumer queries the section (by id or section_type) outside the generator.
+// retired = zero live consumers AND superseded by another live source (advisory flag only).
+// file    = unrendered content that plausibly belongs in a context file — chairman routing review.
+const DECISIONS = {
+  345: { status: 'runtime', note: 'Queried by id 345 from the /document skill (.claude/commands/document.md:30,186) — Documentation Information Architecture is loaded at runtime.' },
+  372: { status: 'runtime', note: "Live consumer: scripts/modules/learning/improvement-appliers.js creates/updates sections with section_type='sub_agent_workflow'." },
+  398: { status: 'retired', note: 'CONST-001 copy superseded by the protocol_constitution table (14 rows) which live code (risk-classifier, governance) reads; this sections-table copy has zero live consumers.' },
+  399: { status: 'retired', note: 'CONST-002 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  400: { status: 'retired', note: 'CONST-003 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  401: { status: 'retired', note: 'CONST-004 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  402: { status: 'retired', note: 'CONST-005 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  403: { status: 'retired', note: 'CONST-006 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  404: { status: 'retired', note: 'CONST-007 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  405: { status: 'retired', note: 'CONST-008 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  406: { status: 'retired', note: 'CONST-009 copy superseded by protocol_constitution table; zero live consumers of the sections copy.' },
+  416: { status: 'retired', note: "auto_proceed_mode full text superseded: section-file-mapping.json _removed_sections_note records it was deliberately removed; the router generator hardcodes the condensed AUTO-PROCEED summary and CLAUDE.md carries the canonical pause-point list from other sections." },
+};
+const DEFAULT_DARK = { status: 'file', note: 'No live runtime consumer found (git grep lib/scripts/server excluding archive/one-off/generator); content is unrendered — candidate for chairman routing review. Classified 2026-06-10 (SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001).' };
+
+async function main() {
+  const sb = createSupabaseServiceClient();
+  const repoRoot = path.resolve(__dirname, '../..');
+  const mapping = JSON.parse(fs.readFileSync(path.join(repoRoot, 'scripts/section-file-mapping.json'), 'utf8'));
+  const digestMapping = JSON.parse(fs.readFileSync(path.join(repoRoot, 'scripts/section-file-mapping-digest.json'), 'utf8'));
+  const mapped = new Set();
+  for (const f of Object.values(mapping)) (f.sections || []).forEach((s) => mapped.add(s));
+  for (const f of Object.values(digestMapping)) (f.sections || []).forEach((s) => mapped.add(s));
+
+  const { data: rows, error } = await sb.from('leo_protocol_sections').select('id, section_type, target_file, title, metadata');
+  if (error) throw new Error(error.message);
+  console.log(`sections: ${rows.length}`);
+
+  const report = { file_bulk: 0, runtime: [], retired: [], file_dark: [], errors: [] };
+  for (const r of rows) {
+    const isMapped = mapped.has(r.section_type) || !!r.target_file;
+    let verdict;
+    if (isMapped) {
+      verdict = { status: 'file', note: r.target_file ? `Routed via target_file=${r.target_file}.` : 'Routed via section-file-mapping by section_type.' };
+      report.file_bulk++;
+    } else {
+      verdict = DECISIONS[r.id] || DEFAULT_DARK;
+      report[verdict.status === 'file' ? 'file_dark' : verdict.status].push(`${r.id} ${r.section_type} — ${(r.title || '').slice(0, 60)}`);
+    }
+    // Surgical read-modify-merge: only the two publication keys change.
+    const metadata = { ...(r.metadata || {}), publication_status: verdict.status, publication_note: verdict.note };
+    const { error: upErr } = await sb.from('leo_protocol_sections').update({ metadata }).eq('id', r.id);
+    if (upErr) report.errors.push(`${r.id}: ${upErr.message}`);
+  }
+
+  console.log(JSON.stringify({
+    bulk_file: report.file_bulk,
+    runtime: report.runtime,
+    retired: report.retired,
+    dark_as_file: report.file_dark.length,
+    errors: report.errors,
+  }, null, 2));
+  if (report.errors.length) process.exitCode = 1;
+}
+
+main().catch((e) => { console.error(e.message); process.exitCode = 1; });

--- a/scripts/protocol-publication-audit.cjs
+++ b/scripts/protocol-publication-audit.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Protocol publication audit — SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-1).
+ *
+ * Asserts the publication-pipeline integrity invariants:
+ *   1. COMPLETENESS — every leo_protocol_sections row carries an explicit
+ *      metadata.publication_status in {runtime, file, retired} (0 ambiguous).
+ *   2. MAPPING INTEGRITY — every section_type referenced by the two
+ *      section-file-mapping JSONs exists in the DB (drift detection), and
+ *      every dark section (unmapped + no target_file) is explicitly classified.
+ *
+ * Exit codes: 0 = all invariants hold; 1 = violations (listed on stdout).
+ * Usage: npm run protocol:pub-audit   |   node scripts/protocol-publication-audit.cjs [--json]
+ */
+'use strict';
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+
+const VALID_STATUSES = new Set(['runtime', 'file', 'retired']);
+
+/**
+ * Pure invariant evaluation (exported for unit tests — no DB/IO).
+ * @param {Array<{id:number,section_type:string,target_file:string|null,metadata:object|null}>} rows
+ * @param {Set<string>} mappedTypes - section_types referenced by either mapping JSON
+ * @returns {{unclassified:Array, invalidStatus:Array, mappingDrift:string[], darkUnreviewed:Array, counts:Object, ok:boolean}}
+ */
+function evaluatePublicationInvariants(rows, mappedTypes) {
+  const unclassified = [];
+  const invalidStatus = [];
+  const darkUnreviewed = [];
+  const counts = { runtime: 0, file: 0, retired: 0 };
+  const dbTypes = new Set();
+
+  for (const r of rows) {
+    dbTypes.add(r.section_type);
+    const status = r.metadata && r.metadata.publication_status;
+    if (!status) {
+      unclassified.push({ id: r.id, section_type: r.section_type });
+      continue;
+    }
+    if (!VALID_STATUSES.has(status)) {
+      invalidStatus.push({ id: r.id, status });
+      continue;
+    }
+    counts[status]++;
+    const isDark = !r.target_file && !mappedTypes.has(r.section_type);
+    if (isDark && status === 'file' && !(r.metadata.publication_note || '').length) {
+      darkUnreviewed.push({ id: r.id, section_type: r.section_type });
+    }
+  }
+
+  const mappingDrift = [...mappedTypes].filter((t) => !dbTypes.has(t));
+  const ok = unclassified.length === 0 && invalidStatus.length === 0 && mappingDrift.length === 0;
+  return { unclassified, invalidStatus, mappingDrift, darkUnreviewed, counts, ok };
+}
+
+function loadMappedTypes(repoRoot) {
+  const mapped = new Set();
+  for (const file of ['scripts/section-file-mapping.json', 'scripts/section-file-mapping-digest.json']) {
+    const m = JSON.parse(fs.readFileSync(path.join(repoRoot, file), 'utf8'));
+    for (const f of Object.values(m)) (f.sections || []).forEach((s) => mapped.add(s));
+  }
+  return mapped;
+}
+
+async function main() {
+  const asJson = process.argv.includes('--json');
+  const sb = createSupabaseServiceClient();
+  const repoRoot = path.resolve(__dirname, '..');
+  const mappedTypes = loadMappedTypes(repoRoot);
+
+  const { data: rows, error } = await sb
+    .from('leo_protocol_sections')
+    .select('id, section_type, target_file, metadata');
+  if (error) throw new Error(`leo_protocol_sections read failed: ${error.message}`);
+
+  const result = evaluatePublicationInvariants(rows, mappedTypes);
+
+  if (asJson) {
+    console.log(JSON.stringify({ total: rows.length, ...result }, null, 2));
+  } else {
+    console.log(`Protocol publication audit — ${rows.length} sections`);
+    console.log(`  runtime: ${result.counts.runtime}  file: ${result.counts.file}  retired: ${result.counts.retired}`);
+    if (result.unclassified.length) {
+      console.log(`  ❌ UNCLASSIFIED (${result.unclassified.length}):`);
+      result.unclassified.forEach((u) => console.log(`     - id=${u.id} ${u.section_type}`));
+    }
+    if (result.invalidStatus.length) {
+      console.log(`  ❌ INVALID STATUS (${result.invalidStatus.length}):`);
+      result.invalidStatus.forEach((u) => console.log(`     - id=${u.id} status=${u.status}`));
+    }
+    if (result.mappingDrift.length) {
+      console.log(`  ❌ MAPPING DRIFT — mapped section_types absent from DB (${result.mappingDrift.length}):`);
+      result.mappingDrift.forEach((t) => console.log(`     - ${t}`));
+    }
+    if (result.darkUnreviewed.length) {
+      console.log(`  ⚠️  dark 'file' sections missing a publication_note (${result.darkUnreviewed.length}) — advisory`);
+    }
+    console.log(result.ok ? '  ✅ all invariants hold' : '  ❌ violations found');
+  }
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+module.exports = { evaluatePublicationInvariants, VALID_STATUSES, loadMappedTypes };
+
+if (require.main === module) {
+  main().catch((e) => { console.error(e.message); process.exitCode = 1; });
+}

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -101,7 +101,6 @@
       "plan_to_exec_checklist",
       "plan_test_infrastructure_gate",
       "testing_tier_strategy_updated",
-      "test_evidence_architecture",
       "plan_cicd_verification",
       "plan_presentation_template",
       "plan_refactor_brief_guide",

--- a/tests/unit/protocol-publication-pipeline.test.js
+++ b/tests/unit/protocol-publication-pipeline.test.js
@@ -1,0 +1,142 @@
+// SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 — publication pipeline integrity.
+// FR-1: evaluatePublicationInvariants (pure audit core).
+// FR-3: body-hash header contract (verifyFileContentHash + generateFile injection).
+// FR-4: parseOnlyFlag validation + generateFile --only skip.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { createRequire } from 'node:module';
+
+import { CLAUDEMDGeneratorV3, KNOWN_GENERATED_FILES, verifyFileContentHash } from '../../scripts/modules/claude-md-generator/index.js';
+import { parseOnlyFlag } from '../../scripts/generate-claude-md-from-db.js';
+
+const require = createRequire(import.meta.url);
+const { evaluatePublicationInvariants } = require('../../scripts/protocol-publication-audit.cjs');
+
+const sha16 = (s) => crypto.createHash('sha256').update(s).digest('hex').substring(0, 16);
+
+describe('FR-1: evaluatePublicationInvariants (pure)', () => {
+  const row = (id, type, status, target_file = null, note = 'evidence') => ({
+    id, section_type: type, target_file, metadata: status ? { publication_status: status, publication_note: note } : {},
+  });
+
+  it('all classified + no drift => ok with correct counts', () => {
+    const rows = [row(1, 'a', 'file'), row(2, 'b', 'runtime'), row(3, 'c', 'retired')];
+    const r = evaluatePublicationInvariants(rows, new Set(['a']));
+    expect(r.ok).toBe(true);
+    expect(r.counts).toEqual({ runtime: 1, file: 1, retired: 1 });
+  });
+
+  it('missing publication_status => unclassified, not ok', () => {
+    const r = evaluatePublicationInvariants([row(1, 'a', null)], new Set());
+    expect(r.ok).toBe(false);
+    expect(r.unclassified).toEqual([{ id: 1, section_type: 'a' }]);
+  });
+
+  it('invalid status value => flagged, not ok', () => {
+    const r = evaluatePublicationInvariants([row(1, 'a', 'bogus')], new Set());
+    expect(r.ok).toBe(false);
+    expect(r.invalidStatus).toEqual([{ id: 1, status: 'bogus' }]);
+  });
+
+  it('mapped type absent from DB => mapping drift, not ok', () => {
+    const r = evaluatePublicationInvariants([row(1, 'a', 'file')], new Set(['a', 'ghost_type']));
+    expect(r.ok).toBe(false);
+    expect(r.mappingDrift).toEqual(['ghost_type']);
+  });
+
+  it('dark file-status section without a note => advisory darkUnreviewed (still ok)', () => {
+    const rows = [{ id: 9, section_type: 'dark', target_file: null, metadata: { publication_status: 'file', publication_note: '' } }];
+    const r = evaluatePublicationInvariants(rows, new Set());
+    expect(r.ok).toBe(true);
+    expect(r.darkUnreviewed).toEqual([{ id: 9, section_type: 'dark' }]);
+  });
+});
+
+describe('FR-3: content-hash header contract', () => {
+  it('generateFile replaces a template "pending" hash line with the real body hash', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pubpipe-'));
+    try {
+      const gen = new CLAUDEMDGeneratorV3({}, dir, path.join(dir, 'nope.json'));
+      const rendered = '<!-- DIGEST FILE -->\n<!-- file_content_hash: pending -->\n# Body\ncontent here\n';
+      gen.generateFile('CLAUDE_TEST_DIGEST.md', {}, () => rendered, 'digest');
+      const written = fs.readFileSync(path.join(dir, 'CLAUDE_TEST_DIGEST.md'), 'utf-8');
+      expect(written).not.toContain('pending');
+      const v = verifyFileContentHash(path.join(dir, 'CLAUDE_TEST_DIGEST.md'));
+      expect(v.ok).toBe(true);
+      expect(v.actual).toMatch(/^[0-9a-f]{16}$/);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('generateFile prepends a stamp to files with no header (FULL files)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pubpipe-'));
+    try {
+      const gen = new CLAUDEMDGeneratorV3({}, dir, path.join(dir, 'nope.json'));
+      gen.generateFile('CLAUDE_TEST.md', {}, () => '# Full file\nbody\n', 'full');
+      const v = verifyFileContentHash(path.join(dir, 'CLAUDE_TEST.md'));
+      expect(v.ok).toBe(true);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('verifyFileContentHash detects a mutated body (staleness/tamper)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pubpipe-'));
+    try {
+      const body = '# Body\noriginal\n';
+      const file = path.join(dir, 'f.md');
+      fs.writeFileSync(file, `<!-- file_content_hash: ${sha16(body)} -->\n${body}`);
+      expect(verifyFileContentHash(file).ok).toBe(true);
+      fs.writeFileSync(file, `<!-- file_content_hash: ${sha16(body)} -->\n# Body\nMUTATED\n`);
+      expect(verifyFileContentHash(file).ok).toBe(false);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('verifyFileContentHash on a pre-FR-3 file (no hash line) => ok:false, actual:null', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pubpipe-'));
+    try {
+      const file = path.join(dir, 'old.md');
+      fs.writeFileSync(file, '# Old generated file\n');
+      expect(verifyFileContentHash(file)).toEqual({ ok: false, expected: null, actual: null });
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe('FR-4: --only scoped regeneration', () => {
+  it('parseOnlyFlag: absent => null (full regen)', () => {
+    expect(parseOnlyFlag(['node', 'gen.js'])).toBeNull();
+  });
+
+  it('parseOnlyFlag: valid single + comma list', () => {
+    expect(parseOnlyFlag(['node', 'gen.js', '--only', 'CLAUDE_LEAD.md'])).toEqual(['CLAUDE_LEAD.md']);
+    expect(parseOnlyFlag(['node', 'gen.js', '--only', 'CLAUDE.md,CLAUDE_CORE_DIGEST.md']))
+      .toEqual(['CLAUDE.md', 'CLAUDE_CORE_DIGEST.md']);
+  });
+
+  it('parseOnlyFlag: unknown target fails loud listing valid files', () => {
+    expect(() => parseOnlyFlag(['node', 'gen.js', '--only', 'NOPE.md'])).toThrow(/unknown file\(s\) NOPE\.md.*CLAUDE\.md/s);
+  });
+
+  it('parseOnlyFlag: missing value fails loud', () => {
+    expect(() => parseOnlyFlag(['node', 'gen.js', '--only'])).toThrow(/--only requires a value/);
+  });
+
+  it('generateFile skips files outside options.only (no write, no manifest entry)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pubpipe-'));
+    try {
+      const gen = new CLAUDEMDGeneratorV3({}, dir, path.join(dir, 'nope.json'), { only: ['CLAUDE_KEEP.md'] });
+      gen.generateFile('CLAUDE_SKIP.md', {}, () => 'skip me', 'full');
+      gen.generateFile('CLAUDE_KEEP.md', {}, () => 'keep me', 'full');
+      expect(fs.existsSync(path.join(dir, 'CLAUDE_SKIP.md'))).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'CLAUDE_KEEP.md'))).toBe(true);
+      expect(Object.keys(gen.manifest.files)).toEqual(['CLAUDE_KEEP.md']);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('KNOWN_GENERATED_FILES covers the 12 generated files', () => {
+    expect(KNOWN_GENERATED_FILES).toHaveLength(12);
+    expect(KNOWN_GENERATED_FILES).toContain('CLAUDE.md');
+    expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_ADAM_DIGEST.md');
+  });
+});


### PR DESCRIPTION
## Summary
Protocol publication pipeline integrity. The DB (262 sections / ~520k chars) publishes to 12 generated files, with three gaps: **59 dark sections** (~105k chars) had no explicit publication path; generated headers all showed `file_content_hash: pending` (render-order chicken-and-egg) so staleness checks compared nothing real; and any edit forced regenerating all 12 files.

LEAD ground truth corrected the filed premise: routing is by `section_type` via the mapping JSONs (not `target_file` — true dark is 59/262, not the filed 53%), and digests are **already** DB-sourced (FR-2 descoped, 45% scope cut recorded).

## Changes
- **FR-1 — publication-status inventory**: all 262 sections now carry `metadata.publication_status` (2 runtime / 250 file / 10 retired) with evidence notes, via an audited one-off classifier (decision table in source; constitution ×9 retired — superseded by the `protocol_constitution` table live code reads). NEW durable audit `npm run protocol:pub-audit` asserts completeness + mapping integrity — and **immediately caught real drift** (`test_evidence_architecture` mapped but absent from the DB; dead reference removed). Classification is advisory metadata only — no content moves.
- **FR-3 — real hash stamping**: `generateFile` injects `sha256(body)[:16]` into the header post-render; FULL files gain a prepended stamp. NEW `verifyFileContentHash()` makes staleness/tamper checks one call. Live: **12/12 generated files verify; a deliberately mutated copy is detected**.
- **FR-4 — scoped regen**: `--only <FILE[,FILE]>` validated against `KNOWN_GENERATED_FILES` (unknown names fail loud). Live: `--only CLAUDE_LEAD.md` skips 11 files; others untouched by mtime.
- 15 new unit tests; includes the stamped regeneration of the 12 generated files + manifest.

SD: SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
