### PR TITLE
feat(SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001): ground SUCCESS_METRICS in machine-checkable evidence

### DIFF
--- a/scripts/lib/metric-evidence-resolver.js
+++ b/scripts/lib/metric-evidence-resolver.js
@@ -95,8 +95,15 @@ async function resolveTest(ref, ctx) {
   const rel = ref.trim();
   const abs = join(ctx.repoRoot, rel);
   if (!existsSync(abs)) return unresolvable(`test file not found: ${rel}`);
+  // Spawn node directly on vitest's JS entry — NOT `npx`: execFileSync('npx') ENOENTs on
+  // Windows (npx is npx.cmd, and .cmd spawns without a shell are blocked on patched Node),
+  // and shell:true would open a quoting/injection surface on the author-controlled ref.
+  // Found live by this SD's own self-hosted PLAN-TO-LEAD run (fail-open held: the binding
+  // degraded to advisory instead of failing the gate).
+  const vitestEntry = join(ctx.repoRoot, 'node_modules', 'vitest', 'vitest.mjs');
+  if (!existsSync(vitestEntry)) return unresolvable('vitest not installed at node_modules/vitest/vitest.mjs');
   try {
-    ctx.exec('npx', ['vitest', 'run', rel], { cwd: ctx.repoRoot, timeout: TEST_RUN_TIMEOUT_MS });
+    ctx.exec(process.execPath, [vitestEntry, 'run', rel], { cwd: ctx.repoRoot, timeout: TEST_RUN_TIMEOUT_MS });
     return resolvedAs(true, `test green: ${rel}`);
   } catch (err) {
     // Distinguish "ran and failed" (a real contradiction) from "could not run" (fail-open).

--- a/scripts/lib/metric-evidence-resolver.js
+++ b/scripts/lib/metric-evidence-resolver.js
@@ -1,0 +1,232 @@
+/**
+ * Metric Evidence Resolver — grounds SUCCESS_METRICS achievement in machine-checkable
+ * evidence instead of self-reported free text. SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001.
+ *
+ * Each success_metrics entry may carry an OPT-IN binding:
+ *   { evidence: { kind: 'test'|'git'|'db_probe'|'gate_score', ref } }
+ *
+ * Kinds:
+ *   test       ref = test file path. VERIFIED iff the file exists AND a single bounded
+ *              vitest run on that file exits 0. Spawn failure / timeout = UNRESOLVABLE
+ *              (never a contradiction — infrastructure flake must not fabricate failure).
+ *   git        ref = 'PR#123' | '#123' | {pr:123} | <40-hex sha> | {commit:sha}.
+ *              PR: VERIFIED iff `gh pr view` reports state MERGED.
+ *              Commit: VERIFIED iff `git merge-base --is-ancestor <sha> origin/main` exits 0.
+ *   db_probe   ref = { table, match: {col: val, ...}, expect: '<op><num>' } — DECLARATIVE
+ *              ONLY (no raw SQL, ever). Resolved as a supabase head-count with eq filters,
+ *              compared against expect.
+ *   gate_score ref = { handoff: 'EXEC-TO-PLAN', expect: '>=85' }. VERIFIED iff the latest
+ *              ACCEPTED sd_phase_handoffs row of that type for this SD has a
+ *              validation_score meeting expect. A missing accepted row is UNRESOLVABLE
+ *              (the SD's own in-flight handoff is never self-referenced).
+ *
+ * Outcomes (the resolver NEVER throws into the gate):
+ *   { bound: true, resolved: true,  verified: boolean, detail: string }
+ *   { bound: true, resolved: false, reason: string }            // fail-open → advisory
+ *   { bound: false }                                            // no binding on the metric
+ *
+ * Dependency-injected for hermetic tests: ctx = { supabase, sdUuid, repoRoot, exec }.
+ * `exec(file, args, opts)` defaults to child_process.execFileSync with stdio:'pipe' and a
+ * hard timeout — unit tests inject a fake and never spawn real processes.
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+/** Hard timeout for the in-gate vitest run (test kind). Bindings are opt-in and rare. */
+export const TEST_RUN_TIMEOUT_MS = 180_000;
+/** Hard timeout for git/gh executions. */
+const VCS_TIMEOUT_MS = 15_000;
+
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+const PR_RE = /^(?:PR)?#?(\d+)$/i;
+const EXPECT_RE = /^\s*(>=|<=|>|<|==?|≥|≤)?\s*([\d.]+)\s*$/;
+
+/** Compare a number against an '<op><num>' expectation string (default op >=). */
+export function compareExpect(value, expect) {
+  if (value == null || expect == null) return null;
+  const m = String(expect).match(EXPECT_RE);
+  if (!m) return null;
+  const op = m[1] === '≥' ? '>=' : m[1] === '≤' ? '<=' : (m[1] || '>=');
+  const num = parseFloat(m[2]);
+  if (Number.isNaN(num)) return null;
+  switch (op) {
+    case '>=': return value >= num;
+    case '>':  return value > num;
+    case '<=': return value <= num;
+    case '<':  return value < num;
+    case '=':
+    case '==': return value === num;
+    default:   return value >= num;
+  }
+}
+
+/** Normalize a git ref into {pr} | {commit} | null. Exported for tests. */
+export function parseGitRef(ref) {
+  if (ref == null) return null;
+  if (typeof ref === 'object') {
+    if (ref.pr != null && /^\d+$/.test(String(ref.pr))) return { pr: Number(ref.pr) };
+    if (typeof ref.commit === 'string' && SHA_RE.test(ref.commit.trim())) return { commit: ref.commit.trim() };
+    return null;
+  }
+  const s = String(ref).trim();
+  const pr = s.match(PR_RE);
+  if (pr) return { pr: Number(pr[1]) };
+  if (SHA_RE.test(s)) return { commit: s };
+  return null;
+}
+
+function defaultExec(file, args, opts = {}) {
+  return execFileSync(file, args, {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: opts.timeout ?? VCS_TIMEOUT_MS,
+    cwd: opts.cwd,
+    windowsHide: true,
+  });
+}
+
+const unresolvable = (reason) => ({ bound: true, resolved: false, reason });
+const resolvedAs = (verified, detail) => ({ bound: true, resolved: true, verified, detail });
+
+async function resolveTest(ref, ctx) {
+  if (typeof ref !== 'string' || !ref.trim()) return unresolvable('test ref must be a file path string');
+  const rel = ref.trim();
+  const abs = join(ctx.repoRoot, rel);
+  if (!existsSync(abs)) return unresolvable(`test file not found: ${rel}`);
+  try {
+    ctx.exec('npx', ['vitest', 'run', rel], { cwd: ctx.repoRoot, timeout: TEST_RUN_TIMEOUT_MS });
+    return resolvedAs(true, `test green: ${rel}`);
+  } catch (err) {
+    // Distinguish "ran and failed" (a real contradiction) from "could not run" (fail-open).
+    // execFileSync sets err.status for a non-zero exit; timeouts/spawn errors carry
+    // err.signal / ENOENT-style codes with status null/undefined.
+    if (err && typeof err.status === 'number' && err.status > 0 && !err.signal) {
+      return resolvedAs(false, `test FAILED (exit ${err.status}): ${rel}`);
+    }
+    return unresolvable(`test runner unavailable (${err?.signal || err?.code || err?.message || 'unknown'}): ${rel}`);
+  }
+}
+
+async function resolveGit(ref, ctx) {
+  const parsed = parseGitRef(ref);
+  if (!parsed) return unresolvable(`unrecognized git ref: ${JSON.stringify(ref)}`);
+  if (parsed.pr != null) {
+    try {
+      const out = ctx.exec('gh', ['pr', 'view', String(parsed.pr), '--json', 'state'], { cwd: ctx.repoRoot });
+      const state = JSON.parse(out || '{}').state;
+      if (state === 'MERGED') return resolvedAs(true, `PR #${parsed.pr} MERGED`);
+      return resolvedAs(false, `PR #${parsed.pr} state=${state || 'unknown'} (not MERGED)`);
+    } catch (err) {
+      return unresolvable(`gh unavailable for PR #${parsed.pr} (${err?.code || err?.message || 'error'})`);
+    }
+  }
+  try {
+    ctx.exec('git', ['merge-base', '--is-ancestor', parsed.commit, 'origin/main'], { cwd: ctx.repoRoot });
+    return resolvedAs(true, `commit ${parsed.commit.slice(0, 10)} is on origin/main`);
+  } catch (err) {
+    // exit 1 = definitively NOT an ancestor (a contradiction); anything else = can't tell.
+    if (err && err.status === 1 && !err.signal) {
+      return resolvedAs(false, `commit ${parsed.commit.slice(0, 10)} is NOT on origin/main`);
+    }
+    return unresolvable(`git unavailable for commit check (${err?.code || err?.message || 'error'})`);
+  }
+}
+
+async function resolveDbProbe(ref, ctx) {
+  if (!ref || typeof ref !== 'object' || Array.isArray(ref)) return unresolvable('db_probe ref must be {table, match, expect}');
+  const { table, match, expect } = ref;
+  if (typeof table !== 'string' || !table) return unresolvable('db_probe: table required');
+  if (typeof expect !== 'string' || !EXPECT_RE.test(expect)) return unresolvable('db_probe: expect must be "<op><num>"');
+  if (match != null && (typeof match !== 'object' || Array.isArray(match))) return unresolvable('db_probe: match must be a {col: val} map');
+  if (!ctx.supabase) return unresolvable('db_probe: no supabase client in ctx');
+  try {
+    let q = ctx.supabase.from(table).select('*', { count: 'exact', head: true });
+    for (const [col, val] of Object.entries(match || {})) q = q.eq(col, val);
+    const { count, error } = await q;
+    if (error) return unresolvable(`db_probe query error: ${error.message}`);
+    const met = compareExpect(count ?? 0, expect);
+    if (met == null) return unresolvable(`db_probe: cannot compare count ${count} vs "${expect}"`);
+    return resolvedAs(met, `db_probe ${table} count=${count ?? 0} vs ${expect}`);
+  } catch (err) {
+    return unresolvable(`db_probe failed: ${err?.message || 'error'}`);
+  }
+}
+
+async function resolveGateScore(ref, ctx) {
+  if (!ref || typeof ref !== 'object' || typeof ref.handoff !== 'string' || !ref.handoff) {
+    return unresolvable('gate_score ref must be {handoff, expect}');
+  }
+  if (typeof ref.expect !== 'string' || !EXPECT_RE.test(ref.expect)) return unresolvable('gate_score: expect must be "<op><num>"');
+  if (!ctx.supabase || !ctx.sdUuid) return unresolvable('gate_score: supabase + sdUuid required in ctx');
+  try {
+    const { data, error } = await ctx.supabase
+      .from('sd_phase_handoffs')
+      .select('validation_score, accepted_at')
+      .eq('sd_id', ctx.sdUuid)
+      .eq('handoff_type', ref.handoff)
+      .eq('status', 'accepted')          // ACCEPTED only — never the SD's own in-flight row
+      .order('accepted_at', { ascending: false })
+      .limit(1);
+    if (error) return unresolvable(`gate_score query error: ${error.message}`);
+    const row = data && data[0];
+    if (!row || row.validation_score == null) return unresolvable(`gate_score: no accepted ${ref.handoff} handoff with a score`);
+    const met = compareExpect(Number(row.validation_score), ref.expect);
+    if (met == null) return unresolvable(`gate_score: cannot compare ${row.validation_score} vs "${ref.expect}"`);
+    return resolvedAs(met, `gate_score ${ref.handoff}=${row.validation_score} vs ${ref.expect}`);
+  } catch (err) {
+    return unresolvable(`gate_score failed: ${err?.message || 'error'}`);
+  }
+}
+
+const KIND_RESOLVERS = {
+  test: resolveTest,
+  git: resolveGit,
+  db_probe: resolveDbProbe,
+  gate_score: resolveGateScore,
+};
+
+/**
+ * Resolve one evidence binding. Never throws.
+ * @param {{kind: string, ref: any}|null|undefined} evidence
+ * @param {{supabase?: object, sdUuid?: string, repoRoot: string, exec?: Function}} ctx
+ */
+export async function resolveEvidenceBinding(evidence, ctx) {
+  if (evidence == null) return { bound: false };
+  if (typeof evidence !== 'object' || Array.isArray(evidence)) return unresolvable('evidence must be {kind, ref}');
+  const resolver = KIND_RESOLVERS[evidence.kind];
+  if (!resolver) return unresolvable(`unknown evidence kind: ${JSON.stringify(evidence.kind)}`);
+  const fullCtx = { exec: defaultExec, ...ctx };
+  try {
+    return await resolver(evidence.ref, fullCtx);
+  } catch (err) {
+    return unresolvable(`resolver error (${evidence.kind}): ${err?.message || 'unknown'}`);
+  }
+}
+
+/**
+ * Resolve bindings for a metrics array. Returns a Map of metric index → outcome for
+ * BOUND metrics only (unbound metrics are absent, keeping their path untouched).
+ * @param {Array} metrics - normalized success_metrics entries
+ * @param {object} ctx
+ * @returns {Promise<Map<number, object>>}
+ */
+export async function resolveAllBindings(metrics, ctx) {
+  const out = new Map();
+  if (!Array.isArray(metrics)) return out;
+  for (let i = 0; i < metrics.length; i++) {
+    const evidence = metrics[i] && metrics[i].evidence;
+    if (evidence == null) continue;
+    out.set(i, await resolveEvidenceBinding(evidence, ctx));
+  }
+  return out;
+}
+
+/** One concrete example per kind — printed by the gate's self-documenting advisory. */
+export const BINDING_EXAMPLES = Object.freeze([
+  '{"evidence":{"kind":"git","ref":"PR#4553"}}                                — verified iff the PR is MERGED',
+  '{"evidence":{"kind":"test","ref":"tests/unit/foo.test.js"}}                — verified iff that test file runs green',
+  '{"evidence":{"kind":"db_probe","ref":{"table":"t","match":{"col":"v"},"expect":">=1"}}} — verified iff the row count meets expect',
+  '{"evidence":{"kind":"gate_score","ref":{"handoff":"EXEC-TO-PLAN","expect":">=85"}}}     — verified iff the accepted handoff score meets expect',
+]);

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/gate-reason-codes.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/gate-reason-codes.js
@@ -11,6 +11,11 @@
 export const GATE_REASON_CODES = Object.freeze({
   SUCCESS_METRICS_EMPTY_ACTUAL: 'SUCCESS_METRICS_EMPTY_ACTUAL',
   SUCCESS_METRICS_PLACEHOLDER_VALUE: 'SUCCESS_METRICS_PLACEHOLDER_VALUE',
+  // SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001: an opt-in evidence binding RESOLVED and the
+  // evidence CONTRADICTS the claimed achievement (bound PR not merged, bound test red,
+  // bound gate score below expect, ...). Distinct from EMPTY/PLACEHOLDER: the author
+  // asserted a machine-checkable claim and the machine check failed.
+  SUCCESS_METRICS_EVIDENCE_CONTRADICTED: 'SUCCESS_METRICS_EVIDENCE_CONTRADICTED',
   HEAL_BELOW_THRESHOLD: 'HEAL_BELOW_THRESHOLD',
   HEAL_EXHAUSTED: 'HEAL_EXHAUSTED',
 });

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-evidence.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-evidence.test.js
@@ -1,0 +1,222 @@
+/**
+ * Evidence-binding integration tests for the consolidated SUCCESS_METRICS gate
+ * (SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001).
+ *
+ * Covers: bound+verified=100 (evidence-backed), bound+contradicted=0 with the structured
+ * SUCCESS_METRICS_EVIDENCE_CONTRADICTED reason code (gate hard-fails), bound+unresolvable
+ * advisory fallback to self-report, the auto-populate interaction (bound metrics never get
+ * speculative actuals — neither mutated nor persisted), the verification-result override,
+ * the evidence_summary counts, and the UNBOUND byte-identical regression lock.
+ *
+ * The heuristic verifier is mocked to a deterministic per-metric self_reported result so the
+ * override path is observable; bindings use db_probe/gate_score kinds only (stub supabase —
+ * no process is ever spawned).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createSuccessMetricsGate } from './success-metrics-gate.js';
+import { GATE_REASON_CODES } from './gate-reason-codes.js';
+
+vi.mock('../../../../../lib/metric-auto-verifier.js', () => ({
+  verifyAllMetrics: (metrics) => ({
+    results: (metrics || []).map(m => ({
+      metric: m.metric || m.name || 'Unnamed',
+      reportedValue: String(m.actual ?? ''),
+      measuredValue: null,
+      score: 65,
+      status: 'self_reported',
+      issue: null,
+    })),
+    overallScore: 65,
+  }),
+}));
+
+/**
+ * Routed supabase stub covering every chain the gate + resolver use:
+ *  - strategic_directives_v2: children select / parent check / success_metrics fetch / update
+ *  - sd_phase_handoffs: auto-populate evidence (select.eq.eq → then) AND gate_score
+ *    (select.eq.eq.eq.order.limit → promise)
+ *  - user_stories: auto-populate evidence
+ *  - any other table: db_probe count head ({count} from cfg.counts)
+ */
+function makeSupabase(cfg = {}) {
+  const updates = [];
+  const handoffRows = cfg.gateScoreHandoffs || [];
+  function from(table) {
+    if (table === 'strategic_directives_v2') {
+      const chain = {
+        _select: null, _update: null,
+        select(f) { this._select = f; return this; },
+        eq() { return this; },
+        update(payload) { this._update = payload; updates.push(payload); return this; },
+        async single() {
+          if (this._select && this._select.includes('parent_sd_id')) return { data: { parent_sd_id: null }, error: null };
+          if (this._select && this._select.includes('success_metrics')) return { data: { success_metrics: cfg.successMetrics }, error: null };
+          return { data: null, error: null };
+        },
+        then(resolve) {
+          if (this._select === 'id') return Promise.resolve({ data: [], error: null }).then(resolve); // no children
+          if (this._update) return Promise.resolve({ data: null, error: null }).then(resolve);
+          return Promise.resolve({ data: null, error: null }).then(resolve);
+        },
+      };
+      return chain;
+    }
+    if (table === 'sd_phase_handoffs') {
+      const filters = {};
+      const chain = {
+        select() { return chain; },
+        eq(col, val) { filters[col] = val; return chain; },
+        order() { return chain; },
+        limit() {
+          const rows = handoffRows.filter(h => h.handoff_type === filters.handoff_type && h.status === filters.status);
+          return Promise.resolve({ data: rows, error: null });
+        },
+        then(resolve) { return Promise.resolve({ data: cfg.acceptedHandoffs || [], error: null }).then(resolve); },
+      };
+      return chain;
+    }
+    if (table === 'user_stories') {
+      return { select() { return this; }, eq() { return this; }, then(resolve) { return Promise.resolve({ data: cfg.stories || [], error: null }).then(resolve); } };
+    }
+    // db_probe target tables
+    return {
+      select() { return this; }, eq() { return this; },
+      then(resolve) {
+        if (cfg.probeError) return resolve({ count: null, error: { message: cfg.probeError } });
+        return resolve({ count: (cfg.counts || {})[table] ?? 0, error: null });
+      },
+    };
+  }
+  return { from, _updates: updates };
+}
+
+const run = async (sb, sdType = 'feature') => {
+  const gate = createSuccessMetricsGate(sb);
+  return gate.validator({ sd: { id: 'uuid-1', sd_type: sdType }, sdId: 'uuid-1' });
+};
+
+describe('evidence-bound achievement', () => {
+  it('bound+VERIFIED scores 100 from the machine check, not the actual text', async () => {
+    const sb = makeSupabase({
+      counts: { widgets: 5 },
+      successMetrics: [
+        { metric: 'Rows present', target: 'descriptive prose target', actual: 'descriptive prose actual',
+          evidence: { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } } },
+      ],
+    });
+    const r = await run(sb);
+    const ms = r.details.achievement.metric_scores[0];
+    expect(ms.score).toBe(100);
+    expect(ms.evidence_backed).toBe(true);
+    expect(ms.reason).toMatch(/Evidence verified/);
+    expect(r.details.evidence_summary).toMatchObject({ bound: 1, evidence_backed: 1, self_reported: 0 });
+    expect(r.passed).toBe(true);
+  });
+
+  it('bound+CONTRADICTED scores 0 with the structured reason code and hard-fails the gate', async () => {
+    const sb = makeSupabase({
+      gateScoreHandoffs: [{ handoff_type: 'EXEC-TO-PLAN', status: 'accepted', validation_score: 60, accepted_at: 'x' }],
+      successMetrics: [
+        { metric: 'Gate quality', target: '>=99', actual: '100% — definitely met',
+          evidence: { kind: 'gate_score', ref: { handoff: 'EXEC-TO-PLAN', expect: '>=99' } } },
+      ],
+    });
+    const r = await run(sb);
+    const ms = r.details.achievement.metric_scores[0];
+    expect(ms.score).toBe(0);
+    expect(ms.reason_code).toBe(GATE_REASON_CODES.SUCCESS_METRICS_EVIDENCE_CONTRADICTED);
+    expect(r.passed).toBe(false);
+    expect(r.issues.some(i => i.includes('SUCCESS_METRICS_EVIDENCE_CONTRADICTED'))).toBe(true);
+  });
+
+  it('bound+UNRESOLVABLE falls back to self-report scoring (advisory, not a failure)', async () => {
+    const sb = makeSupabase({
+      probeError: 'permission denied',
+      successMetrics: [
+        { metric: 'Rows present', target: '>=1', actual: '3',
+          evidence: { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } } },
+      ],
+    });
+    const r = await run(sb);
+    const ms = r.details.achievement.metric_scores[0];
+    expect(ms.score).toBe(100); // self-report path: 3 >= 1
+    expect(ms.evidence_backed).toBeUndefined();
+    expect(r.details.evidence_summary).toMatchObject({ bound: 1, evidence_backed: 0, unresolvable: 1 });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe('auto-populate interaction (evidence precedence over speculation)', () => {
+  it('a bound metric with an EMPTY actual is scored by evidence and never auto-populated', async () => {
+    const sb = makeSupabase({
+      counts: { widgets: 5 },
+      acceptedHandoffs: [{ handoff_type: 'EXEC-TO-PLAN', status: 'accepted', validation_score: 90 }],
+      stories: [{ status: 'completed' }],
+      successMetrics: [
+        { metric: 'Rows present', target: '>=1', actual: '',
+          evidence: { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } } },
+      ],
+    });
+    const r = await run(sb);
+    expect(r.details.achievement.metric_scores[0]).toMatchObject({ score: 100, evidence_backed: true });
+    // hasEmptyActuals excludes evidence-resolved metrics → auto-populate block never ran
+    expect(sb._updates.length).toBe(0);
+    expect(r.passed).toBe(true);
+  });
+
+  it('mixed: the unbound empty metric is auto-populated; the bound one is left untouched', async () => {
+    const sb = makeSupabase({
+      counts: { widgets: 5 },
+      acceptedHandoffs: [{ handoff_type: 'EXEC-TO-PLAN', status: 'accepted', validation_score: 90 }],
+      stories: [{ status: 'completed' }, { status: 'completed' }],
+      successMetrics: [
+        { metric: 'Rows present', target: '>=1', actual: '',
+          evidence: { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } } },
+        { metric: 'Implementation completeness', target: '100%', actual: '' },
+      ],
+    });
+    const r = await run(sb);
+    expect(r.details.achievement.metric_scores[0]).toMatchObject({ score: 100, evidence_backed: true });
+    // auto-populate persisted once, and the BOUND metric inside the payload is untouched
+    expect(sb._updates.length).toBe(1);
+    const persisted = sb._updates[0].success_metrics;
+    expect(persisted[0]._auto_populated).toBeUndefined();
+    expect(persisted[0].actual).toBe('');
+    expect(persisted[1]._auto_populated).toBe(true);
+  });
+});
+
+describe('verification override + summary surfaces', () => {
+  it('evidence-resolved metrics override the heuristic verifier result', async () => {
+    const sb = makeSupabase({
+      counts: { widgets: 5 },
+      successMetrics: [
+        { metric: 'Rows present', target: '>=1', actual: 'prose',
+          evidence: { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } } },
+        { metric: 'Unbound thing', target: '>=1', actual: '2' },
+      ],
+    });
+    const r = await run(sb);
+    const vr = r.details.verification.results;
+    expect(vr[0]).toMatchObject({ status: 'verified', score: 100, evidence_backed: true });
+    expect(vr[1]).toMatchObject({ status: 'self_reported', score: 65 }); // heuristic untouched
+  });
+
+  it('UNBOUND-ONLY metrics behave exactly as before (regression lock)', async () => {
+    const sb = makeSupabase({
+      successMetrics: [
+        { metric: 'A', target: '>=1', actual: '2' },     // met → 100
+        { metric: 'B', target: '>=5', actual: '3' },     // not met → 50
+        { metric: 'C', target: 'N/A', actual: 'prose words' }, // non-numeric → 75
+      ],
+    });
+    const r = await run(sb);
+    const scores = r.details.achievement.metric_scores.map(m => m.score);
+    expect(scores).toEqual([100, 50, 75]);
+    expect(r.details.achievement.score).toBe(75); // round((100+50+75)/3)
+    expect(r.details.evidence_summary).toMatchObject({ bound: 0, self_reported: 3 });
+    // no metric carries evidence flags on the unbound path
+    expect(r.details.achievement.metric_scores.every(m => m.evidence_backed === undefined)).toBe(true);
+    expect(sb._updates.length).toBe(0); // no auto-populate (all actuals present)
+  });
+});

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
@@ -15,6 +15,7 @@
  */
 
 import { verifyAllMetrics } from '../../../../../lib/metric-auto-verifier.js';
+import { resolveAllBindings, BINDING_EXAMPLES } from '../../../../../lib/metric-evidence-resolver.js';
 import { GATE_REASON_CODES, isPlaceholderActual } from './gate-reason-codes.js';
 
 // ── Achievement helpers (from success-metrics-achievement.js) ──
@@ -174,13 +175,40 @@ export function createSuccessMetricsGate(supabase) {
         typeof m === 'string' ? { name: m, target: 'N/A', actual: null } : m
       );
 
+      // ── SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001: resolve opt-in evidence bindings FIRST ──
+      // Bound metrics ({evidence:{kind,ref}}) get their achievement from MACHINE-CHECKABLE
+      // evidence, not from the self-reported actual text (the Goodhart fix). Resolution runs
+      // BEFORE auto-populate so a bound metric is never given a speculative auto-populated
+      // actual (evidence takes precedence over speculation). Fail-open: an unresolvable
+      // binding degrades to the existing self-report path with an advisory warning.
+      let evidenceOutcomes = new Map();
+      try {
+        evidenceOutcomes = await resolveAllBindings(metrics, {
+          supabase,
+          sdUuid,
+          repoRoot: process.cwd(),
+        });
+      } catch (evErr) {
+        console.log(`   ⚠️  Evidence resolution failed (${evErr.message}) — all metrics fall back to self-report`);
+      }
+      const isEvidenceResolved = (idx) => {
+        const o = evidenceOutcomes.get(idx);
+        return !!(o && o.bound && o.resolved);
+      };
+      if (evidenceOutcomes.size > 0) {
+        console.log(`   🔗 Evidence bindings: ${evidenceOutcomes.size} bound metric(s)`);
+      }
+
       // SD-LEARN-FIX-ADDRESS-PAT-AUTO-074: Auto-populate missing actual values
       // from handoff evidence to prevent 0/100 scores on SDs that completed work
       // but didn't manually fill in success_metrics.actual
       // SD-LEARN-FIX-ADDRESS-PAT-AUTO-080: Also treat 'pending'/'tbd' as empty
+      // SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001: evidence-RESOLVED metrics are excluded —
+      // their verdict comes from evidence, so they must not receive a speculative actual
+      // (neither the in-place mutation nor the persisted write-back below).
       const PENDING_PATTERN = /^(pending|tbd|to\s*be\s*determined|not\s*yet|awaiting|[\d.]+%?\s*-?\s*pending.*)$/i;
       const isEmptyOrPending = (val) => val == null || String(val).trim() === '' || PENDING_PATTERN.test(String(val).trim());
-      const hasEmptyActuals = metrics.some(m => isEmptyOrPending(m.actual));
+      const hasEmptyActuals = metrics.some((m, i) => !isEvidenceResolved(i) && isEmptyOrPending(m.actual));
       if (hasEmptyActuals) {
         try {
           // Query evidence: accepted handoffs, user story completion, PR merge status
@@ -201,12 +229,13 @@ export function createSuccessMetricsGate(supabase) {
           const completedStories = stories?.filter(s => EVIDENCE_STATUSES.has(s.status))?.length || 0;
 
           // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-080: Show auto-population status per metric
-          const emptyMetrics = metrics.filter(m => isEmptyOrPending(m.actual));
+          const emptyMetrics = metrics.filter((m, i) => !isEvidenceResolved(i) && isEmptyOrPending(m.actual));
           console.log(`   📋 Auto-population check: ${emptyMetrics.length} metric(s) missing actual values`);
           if (acceptedCount > 0 || completedStories > 0) {
             console.log(`   🔄 Auto-populating from evidence: ${acceptedCount} handoff(s), ${completedStories}/${totalStories} stories`);
             console.log(`      Source: ${acceptedCount > 0 ? 'handoff evidence' : ''}${acceptedCount > 0 && completedStories > 0 ? ' + ' : ''}${completedStories > 0 ? 'story completion' : ''}`);
-            for (const metric of metrics) {
+            for (const [mIdx, metric] of metrics.entries()) {
+              if (isEvidenceResolved(mIdx)) continue; // evidence verdict owns this metric — no speculation
               if (!isEmptyOrPending(metric.actual)) continue;
               const name = (metric.metric || metric.name || '').toLowerCase();
               const targetStr = String(metric.target || '').toLowerCase();
@@ -253,11 +282,37 @@ export function createSuccessMetricsGate(supabase) {
       // ═══════════════════════════════════════════
       console.log('   ── Achievement Check ──');
       const metricScores = [];
-      for (const metric of metrics) {
+      for (const [mIdx, metric] of metrics.entries()) {
         const name = metric.metric || metric.name || 'Unnamed metric';
         const actual = metric.actual;
         const target = metric.target;
         const hasActual = actual != null && String(actual).trim() !== '';
+
+        // SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001: evidence verdict takes precedence over
+        // free-text parsing for bound metrics. verified=100 (the claim is machine-checked);
+        // contradicted=0 with a structured reason code (the author asserted a checkable claim
+        // and the check failed — harder than 'target not met' BY DESIGN; bindings are opt-in
+        // so no existing SD is affected). Unresolvable falls through to self-report scoring
+        // below with an advisory warning.
+        const outcome = evidenceOutcomes.get(mIdx);
+        if (outcome && outcome.bound && outcome.resolved) {
+          if (outcome.verified) {
+            metricScores.push({ name, score: 100, reason: `Evidence verified — ${outcome.detail}`, target, actual, evidence_backed: true });
+            console.log(`   ✅ ${name}: EVIDENCE VERIFIED (${outcome.detail})`);
+          } else {
+            metricScores.push({
+              name, score: 0,
+              reason: `Evidence CONTRADICTS claim — ${outcome.detail}`,
+              reason_code: GATE_REASON_CODES.SUCCESS_METRICS_EVIDENCE_CONTRADICTED,
+              target, actual, evidence_backed: true,
+            });
+            console.log(`   ❌ ${name}: EVIDENCE CONTRADICTED (${outcome.detail})`);
+          }
+          continue;
+        }
+        if (outcome && outcome.bound && !outcome.resolved) {
+          console.log(`   ⚠️  ${name}: evidence unresolvable (${outcome.reason}) — scoring from self-report (advisory)`);
+        }
 
         if (!hasActual) {
           metricScores.push({ name, score: 0, reason: 'No actual value recorded', reason_code: GATE_REASON_CODES.SUCCESS_METRICS_EMPTY_ACTUAL, target, actual });
@@ -320,7 +375,25 @@ export function createSuccessMetricsGate(supabase) {
       console.log(`   Mode: ${isVerificationAdvisory ? 'ADVISORY' : 'REQUIRED'}`);
 
       const repoRoot = process.cwd();
-      const { results: verifyResults, overallScore: verificationScore } = verifyAllMetrics(metrics, repoRoot);
+      const { results: verifyResults } = verifyAllMetrics(metrics, repoRoot);
+
+      // SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001: evidence-resolved metrics override the
+      // heuristic verifier result (single source of truth per metric; verifyAllMetrics has
+      // no consumer outside this gate). Unbound/unresolvable metrics keep the heuristic.
+      for (const [mIdx, outcome] of evidenceOutcomes.entries()) {
+        if (!outcome.resolved || !verifyResults[mIdx]) continue;
+        verifyResults[mIdx] = {
+          ...verifyResults[mIdx],
+          measuredValue: outcome.detail,
+          score: outcome.verified ? 100 : 0,
+          status: outcome.verified ? 'verified' : 'mismatch',
+          issue: outcome.verified ? null : `Evidence contradicts claim: ${outcome.detail}`,
+          evidence_backed: true,
+        };
+      }
+      const verificationScore = verifyResults.length > 0
+        ? Math.round(verifyResults.reduce((sum, r) => sum + r.score, 0) / verifyResults.length)
+        : 100;
 
       for (const r of verifyResults) {
         const icon = r.status === 'verified' ? '✅' : r.status === 'mismatch' ? '❌' : 'ℹ️ ';
@@ -339,6 +412,22 @@ export function createSuccessMetricsGate(supabase) {
       // ═══════════════════════════════════════════
       const combinedScore = Math.round((achievementScore + verificationScore) / 2);
       const passed = achievementPassed && verificationPassed;
+
+      // SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001: evidence adoption summary + self-documenting
+      // binding advisory. The gate teaches its own grounding mechanism at the moment of
+      // friction — remediation lives in gate output, not retros.
+      const evidenceSummary = {
+        bound: evidenceOutcomes.size,
+        evidence_backed: [...evidenceOutcomes.values()].filter(o => o.resolved).length,
+        unresolvable: [...evidenceOutcomes.values()].filter(o => o.bound && !o.resolved).length,
+        self_reported: metrics.length - evidenceOutcomes.size,
+      };
+      console.log(`\n   🔗 Evidence: ${evidenceSummary.evidence_backed} evidence-backed, ${evidenceSummary.unresolvable} unresolvable, ${evidenceSummary.self_reported} self-reported (of ${metrics.length})`);
+      if (evidenceSummary.self_reported > 0) {
+        console.log('   💡 Self-reported metrics can be GROUNDED with an opt-in evidence binding on the metric object:');
+        for (const ex of BINDING_EXAMPLES) console.log(`      ${ex}`);
+        console.log('      Bound metrics are scored from the machine check, not the actual text.');
+      }
 
       const issues = [
         ...metricScores.filter(m => m.score === 0).map(m =>
@@ -387,6 +476,7 @@ export function createSuccessMetricsGate(supabase) {
         }),
         details: {
           metrics_count: metrics.length,
+          evidence_summary: evidenceSummary,
           achievement: {
             score: achievementScore,
             threshold: ACHIEVEMENT_THRESHOLD,

--- a/tests/unit/metric-evidence-resolver.test.js
+++ b/tests/unit/metric-evidence-resolver.test.js
@@ -1,0 +1,293 @@
+/**
+ * Hermetic tests for scripts/lib/metric-evidence-resolver.js
+ * (SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001).
+ *
+ * Full matrix: 4 kinds x {verified, contradicted, unresolvable} + malformed bindings,
+ * unknown kinds, executor timeouts (fail-open), and the resolveAllBindings index map.
+ * exec is injected — no real process is ever spawned; supabase is a chainable stub.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveEvidenceBinding,
+  resolveAllBindings,
+  parseGitRef,
+  compareExpect,
+  BINDING_EXAMPLES,
+} from '../../scripts/lib/metric-evidence-resolver.js';
+
+const REPO = process.cwd(); // tests run from the repo/worktree root — real files exist here
+
+/** exec stub factory: route by binary, throw structured errors like execFileSync. */
+function makeExec(routes) {
+  return vi.fn((file, args) => {
+    const handler = routes[file];
+    if (!handler) { const e = new Error(`ENOENT ${file}`); e.code = 'ENOENT'; throw e; }
+    return handler(args);
+  });
+}
+const exitErr = (status, signal = null) => { const e = new Error(`exit ${status}`); e.status = status; e.signal = signal; return e; };
+
+/** Chainable supabase stub for db_probe (count head) and gate_score (handoff rows). */
+function makeSupabase({ counts = {}, handoffs = [], probeError = null } = {}) {
+  return {
+    from(table) {
+      const filters = {};
+      const chain = {
+        select(_cols, opts) { chain._head = !!(opts && opts.head); return chain; },
+        eq(col, val) { filters[col] = val; return chain; },
+        order() { return chain; },
+        limit() {
+          // gate_score terminal: ordered accepted handoffs
+          const rows = handoffs.filter(h =>
+            h.sd_id === filters.sd_id && h.handoff_type === filters.handoff_type && h.status === filters.status);
+          return Promise.resolve({ data: rows, error: null });
+        },
+        then(resolve) {
+          // db_probe terminal: count head
+          if (probeError) return resolve({ count: null, error: { message: probeError } });
+          const key = `${table}:${JSON.stringify(filters)}`;
+          return resolve({ count: counts[key] ?? counts[table] ?? 0, error: null });
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+// ── pure helpers ──────────────────────────────────────────────────────────────
+
+describe('parseGitRef', () => {
+  it('parses PR forms', () => {
+    expect(parseGitRef('PR#4553')).toEqual({ pr: 4553 });
+    expect(parseGitRef('#123')).toEqual({ pr: 123 });
+    expect(parseGitRef('123')).toEqual({ pr: 123 });
+    expect(parseGitRef({ pr: 7 })).toEqual({ pr: 7 });
+  });
+  it('parses commit forms', () => {
+    expect(parseGitRef('77ac38a6e622e45b2bbbb4222d6dd257a66299e4')).toEqual({ commit: '77ac38a6e622e45b2bbbb4222d6dd257a66299e4' });
+    expect(parseGitRef({ commit: 'abcdef1' })).toEqual({ commit: 'abcdef1' });
+  });
+  it('rejects garbage', () => {
+    expect(parseGitRef('not-a-ref!')).toBeNull();
+    expect(parseGitRef({})).toBeNull();
+    expect(parseGitRef(null)).toBeNull();
+  });
+});
+
+describe('compareExpect', () => {
+  it('handles operators incl. unicode and default >=', () => {
+    expect(compareExpect(85, '>=85')).toBe(true);
+    expect(compareExpect(84, '>=85')).toBe(false);
+    expect(compareExpect(1, '≥1')).toBe(true);
+    expect(compareExpect(3, '<=2')).toBe(false);
+    expect(compareExpect(2, '≤2')).toBe(true);
+    expect(compareExpect(5, '5')).toBe(true);   // default >=
+    expect(compareExpect(0, '==0')).toBe(true);
+  });
+  it('returns null on unparseable expectations', () => {
+    expect(compareExpect(5, 'lots')).toBeNull();
+    expect(compareExpect(null, '>=1')).toBeNull();
+  });
+});
+
+// ── git kind ──────────────────────────────────────────────────────────────────
+
+describe('git kind', () => {
+  const ctxWith = (routes) => ({ repoRoot: REPO, exec: makeExec(routes) });
+
+  it('VERIFIED: merged PR', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: 'PR#42' },
+      ctxWith({ gh: () => JSON.stringify({ state: 'MERGED' }) }));
+    expect(r).toMatchObject({ bound: true, resolved: true, verified: true });
+    expect(r.detail).toMatch(/PR #42 MERGED/);
+  });
+
+  it('CONTRADICTED: open PR', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: { pr: 42 } },
+      ctxWith({ gh: () => JSON.stringify({ state: 'OPEN' }) }));
+    expect(r).toMatchObject({ resolved: true, verified: false });
+  });
+
+  it('UNRESOLVABLE: gh unavailable (fail-open, never contradicted)', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: 'PR#42' }, ctxWith({}));
+    expect(r).toMatchObject({ bound: true, resolved: false });
+    expect(r.reason).toMatch(/gh unavailable/);
+  });
+
+  it('VERIFIED: commit is ancestor of origin/main', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: 'a'.repeat(40) },
+      ctxWith({ git: () => '' }));
+    expect(r).toMatchObject({ resolved: true, verified: true });
+  });
+
+  it('CONTRADICTED: commit not an ancestor (exit 1)', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: { commit: 'b'.repeat(40) } },
+      ctxWith({ git: () => { throw exitErr(1); } }));
+    expect(r).toMatchObject({ resolved: true, verified: false });
+  });
+
+  it('UNRESOLVABLE: git timeout (signal) — cannot tell', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: { commit: 'c'.repeat(40) } },
+      ctxWith({ git: () => { throw exitErr(null, 'SIGTERM'); } }));
+    expect(r).toMatchObject({ resolved: false });
+  });
+
+  it('UNRESOLVABLE: unrecognized ref shape', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'git', ref: { branch: 'main' } }, ctxWith({}));
+    expect(r).toMatchObject({ resolved: false });
+  });
+});
+
+// ── test kind ─────────────────────────────────────────────────────────────────
+
+describe('test kind', () => {
+  it('VERIFIED: existing test file runs green (exec exit 0)', async () => {
+    const exec = makeExec({ npx: () => '' });
+    const r = await resolveEvidenceBinding(
+      { kind: 'test', ref: 'tests/unit/metric-evidence-resolver.test.js' },
+      { repoRoot: REPO, exec });
+    expect(r).toMatchObject({ resolved: true, verified: true });
+    expect(exec).toHaveBeenCalledWith('npx', ['vitest', 'run', 'tests/unit/metric-evidence-resolver.test.js'], expect.anything());
+  });
+
+  it('CONTRADICTED: test file runs red (clean non-zero exit)', async () => {
+    const r = await resolveEvidenceBinding(
+      { kind: 'test', ref: 'tests/unit/metric-evidence-resolver.test.js' },
+      { repoRoot: REPO, exec: makeExec({ npx: () => { throw exitErr(1); } }) });
+    expect(r).toMatchObject({ resolved: true, verified: false });
+    expect(r.detail).toMatch(/FAILED/);
+  });
+
+  it('UNRESOLVABLE: runner timeout (signal) — infrastructure flake never contradicts', async () => {
+    const r = await resolveEvidenceBinding(
+      { kind: 'test', ref: 'tests/unit/metric-evidence-resolver.test.js' },
+      { repoRoot: REPO, exec: makeExec({ npx: () => { throw exitErr(null, 'SIGTERM'); } }) });
+    expect(r).toMatchObject({ resolved: false });
+  });
+
+  it('UNRESOLVABLE: file does not exist', async () => {
+    const r = await resolveEvidenceBinding(
+      { kind: 'test', ref: 'tests/does-not-exist.test.js' },
+      { repoRoot: REPO, exec: makeExec({ npx: () => '' }) });
+    expect(r).toMatchObject({ resolved: false });
+    expect(r.reason).toMatch(/not found/);
+  });
+
+  it('UNRESOLVABLE: non-string ref', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'test', ref: { file: 'x' } }, { repoRoot: REPO, exec: makeExec({}) });
+    expect(r).toMatchObject({ resolved: false });
+  });
+});
+
+// ── db_probe kind ─────────────────────────────────────────────────────────────
+
+describe('db_probe kind', () => {
+  it('VERIFIED: count meets expect', async () => {
+    const supabase = makeSupabase({ counts: { widgets: 3 } });
+    const r = await resolveEvidenceBinding(
+      { kind: 'db_probe', ref: { table: 'widgets', match: { status: 'live' }, expect: '>=1' } },
+      { repoRoot: REPO, supabase });
+    expect(r).toMatchObject({ resolved: true, verified: true });
+    expect(r.detail).toMatch(/count=3/);
+  });
+
+  it('CONTRADICTED: count misses expect', async () => {
+    const supabase = makeSupabase({ counts: { widgets: 0 } });
+    const r = await resolveEvidenceBinding(
+      { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } },
+      { repoRoot: REPO, supabase });
+    expect(r).toMatchObject({ resolved: true, verified: false });
+  });
+
+  it('UNRESOLVABLE: query error (fail-open)', async () => {
+    const supabase = makeSupabase({ probeError: 'permission denied' });
+    const r = await resolveEvidenceBinding(
+      { kind: 'db_probe', ref: { table: 'widgets', expect: '>=1' } },
+      { repoRoot: REPO, supabase });
+    expect(r).toMatchObject({ resolved: false });
+  });
+
+  it('UNRESOLVABLE: declarative-shape violations (no raw SQL channel)', async () => {
+    const supabase = makeSupabase({});
+    for (const bad of [
+      'SELECT 1',                                  // not an object
+      { table: 'w' },                              // missing expect
+      { table: 'w', expect: 'DROP TABLE x' },      // non-numeric expect
+      { table: 'w', match: ['a'], expect: '>=1' }, // match not a map
+      { expect: '>=1' },                           // missing table
+    ]) {
+      const r = await resolveEvidenceBinding({ kind: 'db_probe', ref: bad }, { repoRoot: REPO, supabase });
+      expect(r.resolved, JSON.stringify(bad)).toBe(false);
+    }
+  });
+});
+
+// ── gate_score kind ───────────────────────────────────────────────────────────
+
+describe('gate_score kind', () => {
+  const SD = 'uuid-1';
+  const accepted = (type, score) => ({ sd_id: SD, handoff_type: type, status: 'accepted', validation_score: score, accepted_at: '2026-06-10' });
+
+  it('VERIFIED: accepted handoff score meets expect', async () => {
+    const supabase = makeSupabase({ handoffs: [accepted('EXEC-TO-PLAN', 93)] });
+    const r = await resolveEvidenceBinding(
+      { kind: 'gate_score', ref: { handoff: 'EXEC-TO-PLAN', expect: '>=85' } },
+      { repoRoot: REPO, supabase, sdUuid: SD });
+    expect(r).toMatchObject({ resolved: true, verified: true });
+  });
+
+  it('CONTRADICTED: score below expect', async () => {
+    const supabase = makeSupabase({ handoffs: [accepted('EXEC-TO-PLAN', 60)] });
+    const r = await resolveEvidenceBinding(
+      { kind: 'gate_score', ref: { handoff: 'EXEC-TO-PLAN', expect: '>=85' } },
+      { repoRoot: REPO, supabase, sdUuid: SD });
+    expect(r).toMatchObject({ resolved: true, verified: false });
+  });
+
+  it('UNRESOLVABLE: no accepted handoff of that type (never self-references the in-flight row)', async () => {
+    const supabase = makeSupabase({ handoffs: [] });
+    const r = await resolveEvidenceBinding(
+      { kind: 'gate_score', ref: { handoff: 'PLAN-TO-LEAD', expect: '>=85' } },
+      { repoRoot: REPO, supabase, sdUuid: SD });
+    expect(r).toMatchObject({ resolved: false });
+  });
+
+  it('UNRESOLVABLE: malformed ref', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'gate_score', ref: 'EXEC-TO-PLAN' }, { repoRoot: REPO, supabase: makeSupabase({}), sdUuid: SD });
+    expect(r).toMatchObject({ resolved: false });
+  });
+});
+
+// ── binding-level edge cases + resolveAllBindings ─────────────────────────────
+
+describe('binding edge cases', () => {
+  it('unknown kind → unresolvable, never throws', async () => {
+    const r = await resolveEvidenceBinding({ kind: 'vibes', ref: 'trust me' }, { repoRoot: REPO });
+    expect(r).toMatchObject({ bound: true, resolved: false });
+    expect(r.reason).toMatch(/unknown evidence kind/);
+  });
+
+  it('non-object evidence → unresolvable; null/undefined → unbound', async () => {
+    expect(await resolveEvidenceBinding('PR#1', { repoRoot: REPO })).toMatchObject({ resolved: false });
+    expect(await resolveEvidenceBinding(null, { repoRoot: REPO })).toEqual({ bound: false });
+    expect(await resolveEvidenceBinding(undefined, { repoRoot: REPO })).toEqual({ bound: false });
+  });
+
+  it('resolveAllBindings maps ONLY bound metric indexes (unbound untouched)', async () => {
+    const supabase = makeSupabase({ counts: { t: 2 } });
+    const metrics = [
+      { metric: 'no binding', actual: '100%' },
+      { metric: 'bound', evidence: { kind: 'db_probe', ref: { table: 't', expect: '>=1' } } },
+      { metric: 'also unbound', actual: '5' },
+    ];
+    const map = await resolveAllBindings(metrics, { repoRoot: REPO, supabase });
+    expect([...map.keys()]).toEqual([1]);
+    expect(map.get(1)).toMatchObject({ resolved: true, verified: true });
+  });
+
+  it('resolveAllBindings on non-array → empty map; BINDING_EXAMPLES covers all 4 kinds', async () => {
+    expect((await resolveAllBindings(null, { repoRoot: REPO })).size).toBe(0);
+    const joined = BINDING_EXAMPLES.join('\n');
+    for (const kind of ['git', 'test', 'db_probe', 'gate_score']) expect(joined).toContain(`"${kind}"`);
+  });
+});

--- a/tests/unit/metric-evidence-resolver.test.js
+++ b/tests/unit/metric-evidence-resolver.test.js
@@ -141,19 +141,26 @@ describe('git kind', () => {
 // ── test kind ─────────────────────────────────────────────────────────────────
 
 describe('test kind', () => {
-  it('VERIFIED: existing test file runs green (exec exit 0)', async () => {
-    const exec = makeExec({ npx: () => '' });
+  // The runner is spawned as `node <repo>/node_modules/vitest/vitest.mjs run <ref>` — NOT npx
+  // (npx ENOENTs on Windows; shell:true would open injection on the author-controlled ref).
+  const NODE = process.execPath;
+
+  it('VERIFIED: existing test file runs green (exec exit 0), spawned via node + vitest entry', async () => {
+    const exec = makeExec({ [NODE]: () => '' });
     const r = await resolveEvidenceBinding(
       { kind: 'test', ref: 'tests/unit/metric-evidence-resolver.test.js' },
       { repoRoot: REPO, exec });
     expect(r).toMatchObject({ resolved: true, verified: true });
-    expect(exec).toHaveBeenCalledWith('npx', ['vitest', 'run', 'tests/unit/metric-evidence-resolver.test.js'], expect.anything());
+    const [file, args] = exec.mock.calls[0];
+    expect(file).toBe(NODE);
+    expect(args[0]).toMatch(/node_modules[\\/]vitest[\\/]vitest\.mjs$/);
+    expect(args.slice(1)).toEqual(['run', 'tests/unit/metric-evidence-resolver.test.js']);
   });
 
   it('CONTRADICTED: test file runs red (clean non-zero exit)', async () => {
     const r = await resolveEvidenceBinding(
       { kind: 'test', ref: 'tests/unit/metric-evidence-resolver.test.js' },
-      { repoRoot: REPO, exec: makeExec({ npx: () => { throw exitErr(1); } }) });
+      { repoRoot: REPO, exec: makeExec({ [NODE]: () => { throw exitErr(1); } }) });
     expect(r).toMatchObject({ resolved: true, verified: false });
     expect(r.detail).toMatch(/FAILED/);
   });
@@ -161,14 +168,14 @@ describe('test kind', () => {
   it('UNRESOLVABLE: runner timeout (signal) — infrastructure flake never contradicts', async () => {
     const r = await resolveEvidenceBinding(
       { kind: 'test', ref: 'tests/unit/metric-evidence-resolver.test.js' },
-      { repoRoot: REPO, exec: makeExec({ npx: () => { throw exitErr(null, 'SIGTERM'); } }) });
+      { repoRoot: REPO, exec: makeExec({ [NODE]: () => { throw exitErr(null, 'SIGTERM'); } }) });
     expect(r).toMatchObject({ resolved: false });
   });
 
   it('UNRESOLVABLE: file does not exist', async () => {
     const r = await resolveEvidenceBinding(
       { kind: 'test', ref: 'tests/does-not-exist.test.js' },
-      { repoRoot: REPO, exec: makeExec({ npx: () => '' }) });
+      { repoRoot: REPO, exec: makeExec({ [NODE]: () => '' }) });
     expect(r).toMatchObject({ resolved: false });
     expect(r.reason).toMatch(/not found/);
   });


### PR DESCRIPTION
## SD-LEO-INFRA-GROUND-SUCCESS-METRICS-001 — ground SUCCESS_METRICS in machine-checkable evidence

**The Goodhart problem:** the SUCCESS_METRICS gate hard-gates ≥70% achievement on self-reported free-text `actual` values hand-set by the same agent being gated. The known recipe is leading the actual with a number — the gate verified **formatting, not achievement**.

**The fix — opt-in evidence bindings** (`{evidence:{kind,ref}}` on `success_metrics` entries; the jsonb survives the full round-trip, live-verified):

| kind | verified iff | contradicted iff | unresolvable (advisory) |
|---|---|---|---|
| `test` | named test file runs green (node→vitest entry, bounded) | clean non-zero exit | timeout/spawn error/missing vitest |
| `git` | `PR#N` MERGED / commit ancestor of origin/main | not merged / exit 1 | gh/git unavailable |
| `db_probe` | declarative `{table,match,expect}` count meets expect | count misses | query error (**no raw-SQL channel**) |
| `gate_score` | latest ACCEPTED handoff `validation_score` meets expect | below expect | no accepted row (never self-references) |

**Gate integration:** bindings resolve **before** auto-populate (bound metrics excluded from speculative actuals — both the mutation and the persist); achievement: verified=100, **contradicted=0 with new structured `SUCCESS_METRICS_EVIDENCE_CONTRADICTED`** (opt-in ⇒ no existing SD affected), unresolvable=advisory fallback; verification sub-check overridden for evidence-resolved metrics; `details.evidence_summary` adoption counts; **self-documenting advisory** prints the binding shape whenever self-reported metrics exist. Unbound metrics are **byte-identical** (regression-locked exact scores).

**Self-hosted live demonstration:** this SD's own metrics carry 3 bindings. Its PLAN-TO-LEAD (PASS 96) produced the **first production evidence-verified metric** — `EVIDENCE VERIFIED (gate_score EXEC-TO-PLAN=92 vs >=85)` — and the run itself caught a real Windows bug (`npx` ENOENT) which the **fail-open design absorbed live** (bindings degraded to advisory, gate unharmed); fixed in the follow-up commit (node→vitest entry spawn, injection-safe) and re-proven live (`test green`).

Tests: 29 resolver matrix + 7 gate integration; **174/174 across 13 touching suites** (3 pre-existing failures in unrelated gates confirmed on base via stash). Evidence: VALIDATION `64da589e` (96), prospective TESTING `1d2824e3`, EXEC TESTING `b03fe365` (98, live read-only prod probes). Gates: 95/94/92/96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
