### PR TITLE
feat(SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-C): canonical-vision content consolidation — L1 identity-only + standalone lifecycle spec

### DIFF
--- a/docs/vision/ehg-mission-vision-canonical.md
+++ b/docs/vision/ehg-mission-vision-canonical.md
@@ -1,0 +1,33 @@
+# ExecHoldings Global (EHG) — Mission & Vision
+
+> Chairman-approved 2026-06-09. CANONICAL. Supersedes the divergent vision statements in strategic_vision (EHG-2028) and the companies record; the venture-lifecycle specification remains a SEPARATE operating document. The public/external narrative is maintained SEPARATELY as a go-to-market positioning note, not as part of the canonical vision.
+
+## Mission
+Systematically create, validate, and scale AI-governed ventures — transforming ideas into self-operating businesses with a single human leader overseeing an ecosystem of AI agents.
+
+## Vision
+ExecHoldings Global is an AI-governed holding company where one Chairman orchestrates an ecosystem of AI agents to ideate, validate, build, and operate a portfolio of software ventures — each one a real business that earns its customers' trust and, in the building of it, compounds the system's ability to make better decisions, faster, than it could the venture before.
+
+The end state: EHG runs a handful (3–5) of self-operating, self-sustaining businesses concurrently, with the Chairman in pure strategic oversight — a target the system is built to reach as fast as capability allows, not on a fixed timeline.
+
+## What EHG Is
+EHG looks like a disciplined micro-holding company — and it genuinely is one: its output is durable software businesses that earn their customers' trust and stand on their own economics. What makes it different is underneath — a capability-compounding, self-improving machine whose accumulated decision-making leverage lets one person build better businesses, faster, than any competitor can.
+- Ventures are real businesses — and vessels. Every venture must stand on its own (real customers, real economics) AND make the whole system smarter — adding a reusable capability, sharpening judgment, or hardening governance. A business that teaches the system nothing is a distraction; a capability the market doesn't want is a science project. A venture must do both.
+- Always self-improving. The system gets measurably better every cycle — each venture, decision, and retrospective sharpens the next, automatically and without human intervention.
+- The moat is learning speed. EHG starts every venture from a higher baseline, kills bad ideas earlier with more confidence, and reaches truth faster — an advantage that compounds and is hard to copy.
+- Competitively vigilant. The system continuously watches the field, anticipates competitor moves, and reprioritizes to stay ahead — the edge is both internal (compounding capability) and external (out-maneuvering rivals).
+- Expertise on demand — and combinatorial. EHG summons expert-level AI specialists in any discipline or vertical industry, instantiated dynamically as the work requires and grounded in that field's best practices. The deeper advantage is COMBINING them — many expert perspectives brought to bear on a single problem produce cross-disciplinary insight no individual specialist could reach alone. The bench is unlimited, always current, and its power compounds in combination.
+- One human, by design. The Chairman is the only person in the system; all analysis, building, and operations are performed by AI agents.
+
+## How EHG Operates
+(principles — the full venture lifecycle lives in its own spec, referenced not embedded)
+1. AI-only execution; maximum automation, minimum intervention. Every step runs autonomously and only escalates when human judgment is genuinely required.
+2. The Chairman governs by exception. Override authority, not approval authority. Reviews decisions, never enters data. Mandatory touchpoints are deliberately few; ultimate kill authority is absolute and never times out.
+3. Expertise is instantiated and combined, not hired. For any decision or task, the system spins up the right domain and vertical-industry experts on the fly — at the level of a leading practitioner, grounded in best practices — and combines their perspectives to out-think any single specialist, then reuses or retires them.
+4. Compute is not a constraint. The system optimizes for decision quality and learning speed, not token thrift.
+5. Engineering is delegated to the LEO Harness. The venture lifecycle decides what to build; LEO decides how and ships it.
+6. Stay ahead of the field. Continuously monitor competitors and reprioritize venture work to preserve and extend the edge — a competitor's move is a signal to act, not merely to note.
+7. Everything compounds and self-improves. Calibration, patterns, capabilities, and lessons transfer automatically across ventures, and the system sharpens its own methods every cycle — getting smarter without the Chairman's involvement.
+
+## The North Star
+A handful of self-sustaining software businesses running concurrently — each serving real customers and standing on its own economics — with the Chairman spending time almost entirely on strategic oversight and capability direction, demonstrating that one person plus a governed AI ecosystem can build and operate a real portfolio. Deliberately not timeboxed: development is accelerating — each new model generation moves us faster — and the system is built to reach this as soon as capability allows, possibly very soon.

--- a/scripts/eva/seed-l1-vision.js
+++ b/scripts/eva/seed-l1-vision.js
@@ -36,7 +36,11 @@ const REPO_ROOT = resolve(__dirname, '../../');
 // ============================================================================
 
 const SOURCE_FILES = {
-  vision: 'docs/plans/archived/eva-venture-lifecycle-vision.md',
+  // SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-C (A1c): the L1 vision is seeded from the
+  // chairman-approved canonical identity/strategy text — NOT from the lifecycle
+  // spec. The lifecycle spec seeds its OWN document row (LIFECYCLE_SPEC_KEY).
+  canonical: 'docs/vision/ehg-mission-vision-canonical.md',
+  lifecycle: 'docs/plans/archived/eva-venture-lifecycle-vision.md',
   architecture: 'docs/plans/archived/eva-platform-architecture.md',
   doctrine: 'brainstorm/topic-5-ehg-vision.md',
 };
@@ -47,6 +51,9 @@ const SOURCE_FILES = {
 
 const VISION_KEY = 'VISION-EHG-L1-001';
 const ARCH_KEY = 'ARCH-EHG-L1-001';
+// A1c: the venture-lifecycle spec is a standalone operating document, cross-linked
+// from L1 — never fused into the identity vision again.
+const LIFECYCLE_SPEC_KEY = 'SPEC-EVA-VENTURE-LIFECYCLE-001';
 
 // Max chars to send to LLM for dimension extraction (avoid context overflow)
 const MAX_LLM_CONTENT_CHARS = 8000;
@@ -152,12 +159,19 @@ export async function main() {
 
   // ── 1. Read source files ──────────────────────────────────────────────────
   console.log('📂 Reading source files...');
-  const visionContent = readSourceFile(SOURCE_FILES.vision);
+  const canonicalContent = readSourceFile(SOURCE_FILES.canonical);
+  const lifecycleContent = readSourceFile(SOURCE_FILES.lifecycle);
   const architectureContent = readSourceFile(SOURCE_FILES.architecture);
   const doctrineContent = readSourceFile(SOURCE_FILES.doctrine);
 
-  // Combine vision + doctrine for L1 vision record
-  const combinedVisionContent = `${visionContent}\n\n---\n\n# EHG Capability Doctrine\n\n${doctrineContent}`;
+  // SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-C (A1c): L1 = IDENTITY/STRATEGY ONLY — the
+  // chairman-approved canonical text + the Capability Doctrine identity block +
+  // a cross-link to the standalone lifecycle spec. The previous structure
+  // concatenated the 60k-char lifecycle spec AHEAD of the identity content,
+  // making the L1 apex masquerade as a lifecycle document (H1 was the lifecycle
+  // title; 73% of the content was stage spec). The lifecycle spec now seeds its
+  // OWN row (LIFECYCLE_SPEC_KEY below) — structurally separate, never re-fused.
+  const combinedVisionContent = `${canonicalContent}\n\n---\n\n> Operating specification: the venture-lifecycle spec is maintained as a SEPARATE document — see eva_vision_documents '${LIFECYCLE_SPEC_KEY}'.\n\n---\n\n# EHG Capability Doctrine\n\n${doctrineContent}`;
 
   // ── 2. Extract dimensions via LLM ─────────────────────────────────────────
   console.log('\n🤖 Extracting vision scoring dimensions via LLM...');
@@ -192,7 +206,7 @@ export async function main() {
     version: 1,
     status: 'draft',
     chairman_approved: false,
-    source_file_path: SOURCE_FILES.vision,
+    source_file_path: SOURCE_FILES.canonical,
     created_by: 'seed-l1-vision',
   };
 
@@ -209,6 +223,33 @@ export async function main() {
 
   console.log(`   ✅ ${visionData.vision_key} (id: ${visionData.id})`);
   const visionId = visionData.id;
+
+  // ── 3b. Upsert the standalone lifecycle-spec document (A1c) ───────────────
+  // Seeded non-active: eva_vision_documents_active_rich_check requires
+  // extracted_dimensions for active rows, and spec activation is an operational
+  // decision, not a seed side-effect. parent_vision_id cross-links back to L1.
+  console.log('\n📝 Upserting standalone lifecycle-spec document...');
+  const lifecycleRecord = {
+    vision_key: LIFECYCLE_SPEC_KEY,
+    level: 'L2',
+    content: lifecycleContent,
+    parent_vision_id: visionId,
+    version: 1,
+    status: 'draft',
+    chairman_approved: false,
+    source_file_path: SOURCE_FILES.lifecycle,
+    created_by: 'seed-l1-vision',
+  };
+  const { data: lifecycleData, error: lifecycleError } = await supabase
+    .from('eva_vision_documents')
+    .upsert(lifecycleRecord, { onConflict: 'vision_key' })
+    .select('id, vision_key, level, status')
+    .single();
+  if (lifecycleError) {
+    console.error(`❌ Failed to upsert lifecycle spec: ${lifecycleError.message}`);
+    process.exit(1);
+  }
+  console.log(`   ✅ ${lifecycleData.vision_key} (id: ${lifecycleData.id}, parent: ${visionId})`);
 
   // ── 4. Upsert eva_architecture_plans ─────────────────────────────────────
   console.log('\n📝 Upserting eva_architecture_plans...');

--- a/tests/unit/eva/seed-l1-vision-structure.test.js
+++ b/tests/unit/eva/seed-l1-vision-structure.test.js
@@ -1,0 +1,58 @@
+/**
+ * SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-C (A1c) — seed fusion-structure fix + canonical file.
+ *
+ * The L1 apex doc previously seeded as lifecycle-spec + doctrine CONCATENATED
+ * (combinedVisionContent = `${visionContent}...# EHG Capability Doctrine...`),
+ * making the identity vision masquerade as a 26-stage lifecycle document. These
+ * tests pin the two-document structure so a re-provision can never re-fuse them.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const SEED = readFileSync(resolve(REPO_ROOT, 'scripts/eva/seed-l1-vision.js'), 'utf8');
+const CANONICAL = readFileSync(resolve(REPO_ROOT, 'docs/vision/ehg-mission-vision-canonical.md'), 'utf8');
+
+describe('canonical vision file (the L1 seed source)', () => {
+  it('exists with the chairman-approved H1 and supersession header', () => {
+    expect(CANONICAL.split('\n')[0]).toBe('# ExecHoldings Global (EHG) — Mission & Vision');
+    expect(CANONICAL).toMatch(/Chairman-approved 2026-06-09\. CANONICAL\./);
+    expect(CANONICAL).toMatch(/venture-lifecycle specification remains a SEPARATE operating document/);
+  });
+
+  it('is identity/strategy only — no lifecycle spec markers', () => {
+    expect(CANONICAL).not.toMatch(/## 5\. Stage Inventory/);
+    expect(CANONICAL).not.toMatch(/Appendix A/);
+    // identity docs mention stages only in passing; the spec had 295 mentions
+    expect((CANONICAL.match(/stage/gi) || []).length).toBeLessThan(10);
+  });
+});
+
+describe('seed two-document structure (no re-fusion)', () => {
+  it('L1 seeds from the canonical file, not the lifecycle spec', () => {
+    expect(SEED).toMatch(/canonical:\s*'docs\/vision\/ehg-mission-vision-canonical\.md'/);
+    expect(SEED).toMatch(/const canonicalContent = readSourceFile\(SOURCE_FILES\.canonical\)/);
+    // the old fusion: combinedVisionContent starting from the lifecycle visionContent
+    expect(SEED).not.toMatch(/combinedVisionContent = `\$\{visionContent\}/);
+    // new structure: canonical leads the L1 content
+    expect(SEED).toMatch(/combinedVisionContent = `\$\{canonicalContent\}/);
+  });
+
+  it('the lifecycle spec seeds its OWN row with a cross-link parent', () => {
+    expect(SEED).toMatch(/LIFECYCLE_SPEC_KEY = 'SPEC-EVA-VENTURE-LIFECYCLE-001'/);
+    expect(SEED).toMatch(/vision_key: LIFECYCLE_SPEC_KEY/);
+    expect(SEED).toMatch(/content: lifecycleContent/);
+    expect(SEED).toMatch(/parent_vision_id: visionId/);
+  });
+
+  it('L1 content cross-links to the lifecycle spec document', () => {
+    expect(SEED).toMatch(/SEPARATE document — see eva_vision_documents '\$\{LIFECYCLE_SPEC_KEY\}'/);
+  });
+
+  it('the doctrine identity block is preserved in L1 (below the canonical text)', () => {
+    expect(SEED).toMatch(/# EHG Capability Doctrine\\n\\n\$\{doctrineContent\}/);
+  });
+});


### PR DESCRIPTION
## Summary
A1c of the Plan-Keeper program. The L1 apex doc `VISION-EHG-L1-001` carried 83,242 chars whose H1 was the **lifecycle spec title** — 73% stage spec fused ahead of identity content by the seed concat at `seed-l1-vision.js:160`.

**Repo side (this PR):**
- NEW `docs/vision/ehg-mission-vision-canonical.md` — the chairman-approved (2026-06-09) canonical Mission & Vision, verbatim from the BACKBONE SD metadata (5,219 chars), as the durable seed source
- Seed restructure: L1 = canonical + cross-link + Capability Doctrine; the lifecycle spec seeds its **own** row (`SPEC-EVA-VENTURE-LIFECYCLE-001`, L2, parent→L1) — no re-fusion possible
- 6 structure tests

**Live flip (already executed, insert-verify-update-verify):** SPEC row inserted active with the lossless-split 60,580-char lifecycle body + the **full byte-exact 83,242-char original backed up in its addendums** BEFORE the L1 update; L1 content-only UPDATE (status/approved/version/sections untouched — trigger-safe, optimistic version guard). Post-flip: canonical H1 live, stage mentions 295→3, `v_okr_hierarchy.vision_title` = the canonical title, sections takeaway key intact.

**DOCMON note:** pre-push flagged 'leverage' + passive voice **inside the chairman-locked verbatim text** — pushed with the documented `SKIP_DOCMON=1`; editing the chairman's approved wording to satisfy a style linter would be wrong.

TESTING PASS 96 (6/6 + 25/25). Gates: 93/97/94/95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)