### PR TITLE
feat(SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001): archive-not-delete retention for 6 unbounded audit/trace tables

### DIFF
--- a/database/migrations/20260610_retention_substrate.sql
+++ b/database/migrations/20260610_retention_substrate.sql
@@ -1,0 +1,69 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: Retention substrate — cold JSONB archive + age-keyed run stamps (additive, reversible)
+-- SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001
+--
+-- WHAT: two NEW tables, nothing else touched.
+--   1. retention_archive — single cold store for rows aged out of the unbounded audit/trace
+--      tables (workflow_trace_log 607k, governance_audit_log 605k, audit_log 143k,
+--      validation_audit_log 59k, model_usage_log 52k, permission_audit_log 41k at authoring).
+--      ARCHIVE-NOT-DELETE: the enforcement CLI copies each row to row_data (jsonb) BEFORE
+--      deleting it from the hot table; restore = re-insert row_data filtered by
+--      source_table/run_id.
+--   2. retention_runs — one stamp per enforcement run (including dry runs). Observability is
+--      the AGE of max(ran_at) — never self-reported status (the dormant-daemon lesson:
+--      eva_scheduler_heartbeat said status=running for ~105 days while dead).
+--
+-- SAFETY: additive only; no triggers/FKs on the six source tables (verified: none exist);
+-- enforcement itself is a separate chairman-gated CLI (dry-run by default). Reversible via
+-- the column-explicit DOWN (20260610_retention_substrate_DOWN.sql).
+
+SELECT pg_advisory_xact_lock(hashtext('retention_substrate_20260610'));
+
+CREATE TABLE IF NOT EXISTS retention_archive (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_table  text NOT NULL,
+  source_id     text,
+  row_data      jsonb NOT NULL,
+  row_timestamp timestamptz,
+  archived_at   timestamptz NOT NULL DEFAULT now(),
+  archived_by   text,
+  run_id        uuid
+);
+
+CREATE INDEX IF NOT EXISTS idx_retention_archive_source_ts
+  ON retention_archive (source_table, row_timestamp);
+CREATE INDEX IF NOT EXISTS idx_retention_archive_archived_at
+  ON retention_archive (archived_at);
+CREATE INDEX IF NOT EXISTS idx_retention_archive_run
+  ON retention_archive (run_id);
+
+CREATE TABLE IF NOT EXISTS retention_runs (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  ran_at      timestamptz NOT NULL DEFAULT now(),
+  mode        text NOT NULL,
+  caps        jsonb,
+  per_table   jsonb,
+  duration_ms integer,
+  ran_by      text
+);
+
+CREATE INDEX IF NOT EXISTS idx_retention_runs_ran_at
+  ON retention_runs (ran_at DESC);
+
+COMMENT ON TABLE retention_archive IS
+  'Cold JSONB archive for rows aged out of unbounded audit/trace tables. Restore = re-insert row_data (filter by source_table/run_id). Writer: scripts/retention-enforce.js (archive-before-delete invariant). SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001.';
+COMMENT ON TABLE retention_runs IS
+  'Age-keyed liveness stamps for retention enforcement: alarm on AGE of max(ran_at), never on self-reported status. One row per run incl. dry runs. SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001.';
+
+-- Post-asserts: both tables queryable.
+DO $retention_post$
+DECLARE
+  v_cnt int;
+BEGIN
+  SELECT count(*) INTO v_cnt FROM information_schema.tables
+   WHERE table_schema='public' AND table_name IN ('retention_archive','retention_runs');
+  IF v_cnt <> 2 THEN
+    RAISE EXCEPTION 'retention substrate post-assert failed: % of 2 tables present', v_cnt;
+  END IF;
+END;
+$retention_post$;

--- a/database/migrations/20260610_retention_substrate_DOWN.sql
+++ b/database/migrations/20260610_retention_substrate_DOWN.sql
@@ -1,0 +1,25 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- DOWN migration for SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001 (retention substrate)
+--
+-- Column-explicit revert: drops exactly the two new tables (and their indexes with them).
+-- WARNING: dropping retention_archive discards any ARCHIVED rows — restore them to their
+-- source tables FIRST if any enforcement --apply has run (SELECT row_data FROM
+-- retention_archive WHERE source_table='...' → re-insert), or accept the loss explicitly.
+-- Apply via: node scripts/apply-migration.js database/migrations/20260610_retention_substrate_DOWN.sql
+
+SELECT pg_advisory_xact_lock(hashtext('retention_substrate_20260610'));
+
+DROP TABLE IF EXISTS retention_archive;
+DROP TABLE IF EXISTS retention_runs;
+
+DO $retention_down_post$
+DECLARE
+  v_cnt int;
+BEGIN
+  SELECT count(*) INTO v_cnt FROM information_schema.tables
+   WHERE table_schema='public' AND table_name IN ('retention_archive','retention_runs');
+  IF v_cnt <> 0 THEN
+    RAISE EXCEPTION 'retention substrate DOWN post-assert failed: % tables still present', v_cnt;
+  END IF;
+END;
+$retention_down_post$;

--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -1,0 +1,81 @@
+/**
+ * Declarative retention-policy registry (SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001).
+ *
+ * Pure module — no DB access. scripts/retention-enforce.js is the only executor.
+ *
+ * KEYING: age of each table's OWN timestamp column (created_at / changed_at /
+ * captured_at — verified per-table against the live schema), NEVER row status —
+ * the sd_id-scoped gate readers (learning-or-bypass-resolved, Aegis bypass
+ * completeness) read only the current in-flight SD's recent rows, so an
+ * age-keyed archiver can never strand them (validation-agent c081fe53).
+ *
+ * WINDOW FLOOR: the longest enforced automated consumer lookback found by the
+ * validation sweep is 30 days (validation_audit_log false-positive leaderboard;
+ * governance_audit_log queryBypassPatterns). MIN_HOT_DAYS = 45 gives margin;
+ * the default 90-day window is 3x the longest consumer. Policies below the
+ * floor REFUSE to run.
+ *
+ * Chairman governance: hotDays values are chairman-approved (SD deliverable).
+ * Env overrides RETENTION_HOT_DAYS_<TABLE_UPPER> allow tuning without code
+ * change, still floor-clamped.
+ */
+
+export const MIN_HOT_DAYS = 45;
+export const DEFAULT_HOT_DAYS = 90;
+export const DEFAULT_PER_RUN_CAP = 20000;
+export const BATCH_SIZE = 2000;
+export const DELETE_CHUNK = 200;
+export const LIVENESS_MAX_AGE_DAYS = 8;
+
+/** Verified per-table timestamp columns (live schema, 2026-06-10). */
+export const RETENTION_POLICIES = [
+  { table: 'workflow_trace_log',   timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  { table: 'governance_audit_log', timestampColumn: 'changed_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  { table: 'audit_log',            timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  { table: 'validation_audit_log', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  { table: 'model_usage_log',      timestampColumn: 'captured_at', hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  { table: 'permission_audit_log', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+];
+
+/**
+ * REPORT-ONLY entries: surfaced by the CLI, never executed by it.
+ * management_reviews_quarantine_20260610 is the reversibility backup from the
+ * SD-LEO-INFRA-REVIVE-EVA-PURGE-MGMT-REVIEWS-001 purge — eligible for a manual
+ * chairman-reviewed drop after its verification soak window.
+ */
+export const SOAK_ENTRIES = [
+  {
+    table: 'management_reviews_quarantine_20260610',
+    mode: 'soak_until',
+    eligibleAfter: '2026-06-24',
+    action: 'manual chairman-reviewed drop after the purge verification window (45,015 backup rows)',
+  },
+];
+
+/**
+ * Resolve a policy's effective hot window (env override, floor-clamped).
+ * @param {{table: string, hotDays: number}} policy
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number} effective hotDays (>= MIN_HOT_DAYS)
+ */
+export function effectiveHotDays(policy, env = process.env) {
+  const key = `RETENTION_HOT_DAYS_${policy.table.toUpperCase()}`;
+  const raw = env[key];
+  const requested = raw !== undefined && raw !== '' ? Number(raw) : policy.hotDays;
+  if (!Number.isFinite(requested)) {
+    throw new Error(`${key}: not a number (${raw})`);
+  }
+  if (requested < MIN_HOT_DAYS) {
+    throw new Error(
+      `Retention window for ${policy.table} is ${requested}d — below the MIN_HOT_DAYS floor of ${MIN_HOT_DAYS}d ` +
+      '(longest enforced consumer lookback is 30d; the floor protects readers). Refusing to run.'
+    );
+  }
+  return requested;
+}
+
+/** Cutoff ISO timestamp for a policy as of `now`. */
+export function cutoffIso(policy, now = new Date(), env = process.env) {
+  const days = effectiveHotDays(policy, env);
+  return new Date(now.getTime() - days * 86_400_000).toISOString();
+}

--- a/package.json
+++ b/package.json
@@ -471,7 +471,9 @@
     "check:migration-readiness": "node scripts/check-migration-readiness.mjs",
     "validate:capability-trigger": "node scripts/validate-capability-lifecycle-trigger.mjs --live",
     "qf:create": "node scripts/create-quick-fix.js",
-    "migration:apply-state": "node scripts/verify-migration-apply-state.mjs"
+    "migration:apply-state": "node scripts/verify-migration-apply-state.mjs",
+    "retention:check": "node scripts/retention-enforce.js",
+    "retention:apply": "node scripts/retention-enforce.js --apply"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.85.0",

--- a/scripts/retention-enforce.js
+++ b/scripts/retention-enforce.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * retention-enforce.js — archive-not-delete retention for unbounded audit/trace
+ * tables (SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001).
+ *
+ * DRY-RUN BY DEFAULT. `--apply` executes (chairman-gated: do not arm or apply
+ * without the approved windows — see the SD's FR-6).
+ *
+ * Per policy table:
+ *   dry: count rows older than the cutoff, report.
+ *   apply: loop batches — SELECT (id + row) LIMIT BATCH_SIZE → INSERT jsonb
+ *          copies into retention_archive (archive-BEFORE-delete; a failed
+ *          archive aborts the table's run with NO delete) → DELETE by id in
+ *          chunks — until the per-run cap or no rows remain. Fail-soft per
+ *          table: one table's error never aborts the others.
+ *
+ * Every run (incl. dry) stamps retention_runs — observability is the AGE of
+ * max(ran_at), never self-reported status (`--liveness` exits 1 when stale).
+ * `--arming-spec` prints the CronCreate spec for the weekly apply (harness
+ * pattern: the script never self-arms).
+ *
+ * Also rotates logs/eva-scheduler-daemon.log when >25MB (2 generations,
+ * fail-soft).
+ *
+ * Usage:
+ *   node scripts/retention-enforce.js                  # dry-run (npm run retention:check)
+ *   node scripts/retention-enforce.js --apply          # enforce (npm run retention:apply)
+ *   node scripts/retention-enforce.js --liveness       # exit 1 if last run > LIVENESS_MAX_AGE_DAYS
+ *   node scripts/retention-enforce.js --arming-spec    # print the CronCreate spec
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import dotenv from 'dotenv';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import {
+  RETENTION_POLICIES, SOAK_ENTRIES, effectiveHotDays, cutoffIso,
+  BATCH_SIZE, DELETE_CHUNK, LIVENESS_MAX_AGE_DAYS,
+} from '../lib/retention/policies.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+dotenv.config();
+
+const ROTATE_LOG = 'logs/eva-scheduler-daemon.log';
+const ROTATE_MAX_BYTES = 25 * 1024 * 1024;
+const ROTATE_GENERATIONS = 2;
+
+function chunk(arr, n) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+  return out;
+}
+
+/** Size-based log rotation, fail-soft (FR-5). */
+export function rotateDaemonLog(repoRoot = process.cwd()) {
+  try {
+    const p = path.resolve(repoRoot, ROTATE_LOG);
+    if (!fs.existsSync(p)) return { rotated: false, reason: 'absent' };
+    const size = fs.statSync(p).size;
+    if (size <= ROTATE_MAX_BYTES) return { rotated: false, reason: 'under-threshold', size };
+    for (let g = ROTATE_GENERATIONS - 1; g >= 1; g--) {
+      const from = `${p}.${g}`;
+      const to = `${p}.${g + 1}`;
+      if (fs.existsSync(from)) fs.renameSync(from, to);
+    }
+    fs.renameSync(p, `${p}.1`);
+    return { rotated: true, size };
+  } catch (err) {
+    console.warn(`   ⚠ log rotation failed (non-fatal): ${err.message}`);
+    return { rotated: false, reason: 'error', error: err.message };
+  }
+}
+
+/**
+ * Enforce one policy. Returns { table, eligible, archived, deleted, error }.
+ * apply=false → count only. Archive-before-delete invariant: the DELETE for a
+ * batch is only issued after the archive INSERT for that batch is confirmed.
+ */
+export async function enforcePolicy(supabase, policy, { apply = false, runId = null, now = new Date(), env = process.env } = {}) {
+  const cutoff = cutoffIso(policy, now, env);
+  const result = { table: policy.table, hotDays: effectiveHotDays(policy, env), cutoff, eligible: 0, archived: 0, deleted: 0, error: null };
+  try {
+    const { count, error: cntErr } = await supabase
+      .from(policy.table).select('*', { count: 'exact', head: true })
+      .lt(policy.timestampColumn, cutoff);
+    if (cntErr) throw new Error(`count failed: ${cntErr.message}`);
+    result.eligible = count || 0;
+    if (!apply || result.eligible === 0) return result;
+
+    while (result.archived < policy.perRunCap) {
+      const batchLimit = Math.min(BATCH_SIZE, policy.perRunCap - result.archived);
+      const { data: rows, error: selErr } = await supabase
+        .from(policy.table).select('*')
+        .lt(policy.timestampColumn, cutoff)
+        .order(policy.timestampColumn, { ascending: true })
+        .limit(batchLimit);
+      if (selErr) throw new Error(`select failed: ${selErr.message}`);
+      if (!rows || rows.length === 0) break;
+
+      // 1) ARCHIVE — must succeed before any delete (TR-1).
+      const archiveRows = rows.map((r) => ({
+        source_table: policy.table,
+        source_id: r.id != null ? String(r.id) : null,
+        row_data: r,
+        row_timestamp: r[policy.timestampColumn] || null,
+        archived_by: 'retention-enforce',
+        run_id: runId,
+      }));
+      const { error: insErr, count: insCount } = await supabase
+        .from('retention_archive')
+        .insert(archiveRows, { count: 'exact' });
+      if (insErr) throw new Error(`archive insert failed (NO rows deleted this batch): ${insErr.message}`);
+      if ((insCount ?? archiveRows.length) !== archiveRows.length) {
+        throw new Error(`archive insert count mismatch (${insCount} != ${archiveRows.length}) — aborting before delete`);
+      }
+      result.archived += rows.length;
+
+      // 2) DELETE the archived ids (chunked — URL-length safe).
+      const ids = rows.map((r) => r.id);
+      for (const ch of chunk(ids, DELETE_CHUNK)) {
+        const { error: delErr } = await supabase.from(policy.table).delete().in('id', ch);
+        if (delErr) throw new Error(`delete failed after archive (rows ARE archived; rerun converges): ${delErr.message}`);
+        result.deleted += ch.length;
+      }
+
+      if (rows.length < batchLimit) break; // backlog drained
+    }
+    return result;
+  } catch (err) {
+    result.error = err.message;
+    return result;
+  }
+}
+
+export async function runEnforcement({ apply = false } = {}) {
+  const supabase = createSupabaseServiceClient();
+  const started = Date.now();
+  const runId = globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : undefined;
+  const mode = apply ? 'apply' : 'dry_run';
+  console.log(`\n— retention-enforce (${mode}) —`);
+
+  const perTable = [];
+  let anyError = false;
+  for (const policy of RETENTION_POLICIES) {
+    const r = await enforcePolicy(supabase, policy, { apply, runId });
+    perTable.push(r);
+    anyError = anyError || Boolean(r.error);
+    const tail = r.error ? `ERROR: ${r.error}` : apply ? `archived ${r.archived}, deleted ${r.deleted}` : 'dry';
+    console.log(`  ${r.table.padEnd(26)} >${r.hotDays}d: ${String(r.eligible).padStart(7)} eligible | ${tail}`);
+  }
+
+  for (const s of SOAK_ENTRIES) {
+    const eligible = new Date() >= new Date(s.eligibleAfter);
+    console.log(`  ${s.table.padEnd(26)} SOAK (report-only): ${eligible ? 'ELIGIBLE for' : 'not yet eligible until ' + s.eligibleAfter + ' for'} ${s.action}`);
+  }
+
+  const rotation = rotateDaemonLog();
+  if (rotation.rotated) console.log(`  rotated ${ROTATE_LOG} (${rotation.size} bytes)`);
+
+  // Age-keyed liveness stamp — written for EVERY run including dry.
+  const { error: stampErr } = await supabase.from('retention_runs').insert({
+    mode,
+    caps: { batch: BATCH_SIZE, deleteChunk: DELETE_CHUNK, perRunCaps: Object.fromEntries(RETENTION_POLICIES.map((p) => [p.table, p.perRunCap])) },
+    per_table: perTable,
+    duration_ms: Date.now() - started,
+    ran_by: process.env.CLAUDE_SESSION_ID || 'cli',
+  });
+  if (stampErr) {
+    console.warn(`  ⚠ retention_runs stamp failed: ${stampErr.message}`);
+    anyError = true;
+  } else {
+    console.log('  ✓ retention_runs stamp written');
+  }
+  return anyError ? 1 : 0;
+}
+
+export async function checkLiveness() {
+  const supabase = createSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from('retention_runs').select('ran_at').order('ran_at', { ascending: false }).limit(1);
+  if (error) { console.error(`liveness: query failed: ${error.message}`); return 1; }
+  if (!data || data.length === 0) { console.error('liveness: NO retention runs recorded — job never ran'); return 1; }
+  const ageDays = (Date.now() - new Date(data[0].ran_at).getTime()) / 86_400_000;
+  const stale = ageDays > LIVENESS_MAX_AGE_DAYS;
+  console.log(`liveness: last run ${ageDays.toFixed(1)}d ago (max ${LIVENESS_MAX_AGE_DAYS}d) — ${stale ? 'STALE' : 'fresh'}`);
+  return stale ? 1 : 0;
+}
+
+export function printArmingSpec() {
+  console.log(JSON.stringify({
+    tool: 'CronCreate',
+    name: 'retention-enforce-weekly',
+    schedule: 'weekly (e.g. Sunday 03:00 local)',
+    prompt: 'Run `npm run retention:apply` in EHG_Engineer and report the per-table archived/deleted counts; if the command exits non-zero or `npm run retention:check -- --liveness` reports STALE, surface to the coordinator.',
+    note: 'Arm only after the chairman approves windows + first apply (SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001 FR-6). The script never self-arms.',
+  }, null, 2));
+}
+
+if (isMainModule(import.meta.url)) {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--arming-spec')) {
+    printArmingSpec();
+  } else if (argv.includes('--liveness')) {
+    checkLiveness().then((code) => { process.exitCode = code; });
+  } else {
+    runEnforcement({ apply: argv.includes('--apply') }).then((code) => { process.exitCode = code; });
+  }
+}

--- a/tests/unit/retention/retention-policy.test.js
+++ b/tests/unit/retention/retention-policy.test.js
@@ -1,0 +1,171 @@
+/**
+ * SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001 — policy registry + enforcement invariants.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  RETENTION_POLICIES, SOAK_ENTRIES, effectiveHotDays, cutoffIso,
+  MIN_HOT_DAYS, DEFAULT_HOT_DAYS,
+} from '../../../lib/retention/policies.js';
+import { enforcePolicy, rotateDaemonLog } from '../../../scripts/retention-enforce.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+
+describe('policy registry (TS-1)', () => {
+  it('registers all 6 unbounded tables with the VERIFIED timestamp columns', () => {
+    const m = Object.fromEntries(RETENTION_POLICIES.map((p) => [p.table, p.timestampColumn]));
+    expect(m).toEqual({
+      workflow_trace_log: 'created_at',
+      governance_audit_log: 'changed_at',
+      audit_log: 'created_at',
+      validation_audit_log: 'created_at',
+      model_usage_log: 'captured_at',
+      permission_audit_log: 'created_at',
+    });
+  });
+
+  it('default window is 90d (3x the 30d longest consumer lookback)', () => {
+    expect(DEFAULT_HOT_DAYS).toBe(90);
+    for (const p of RETENTION_POLICIES) expect(effectiveHotDays(p, {})).toBe(90);
+  });
+
+  it('floor assert: a window below MIN_HOT_DAYS refuses to run', () => {
+    const p = RETENTION_POLICIES[0];
+    expect(() => effectiveHotDays(p, { [`RETENTION_HOT_DAYS_${p.table.toUpperCase()}`]: '30' }))
+      .toThrow(/below the MIN_HOT_DAYS floor/);
+    expect(MIN_HOT_DAYS).toBeGreaterThan(30); // must exceed the longest consumer lookback
+  });
+
+  it('env override above the floor is honored', () => {
+    const p = RETENTION_POLICIES[0];
+    expect(effectiveHotDays(p, { [`RETENTION_HOT_DAYS_${p.table.toUpperCase()}`]: '120' })).toBe(120);
+  });
+
+  it('cutoff math: 90d before now', () => {
+    const now = new Date('2026-06-10T00:00:00Z');
+    const iso = cutoffIso(RETENTION_POLICIES[0], now, {});
+    expect(iso).toBe(new Date(now.getTime() - 90 * 86_400_000).toISOString());
+  });
+
+  it('the quarantine soak entry is report-only (no archive mode)', () => {
+    expect(SOAK_ENTRIES).toHaveLength(1);
+    expect(SOAK_ENTRIES[0].table).toBe('management_reviews_quarantine_20260610');
+    expect(SOAK_ENTRIES[0].mode).toBe('soak_until');
+    // and it is NOT in the executable policy list
+    expect(RETENTION_POLICIES.some((p) => p.table === SOAK_ENTRIES[0].table)).toBe(false);
+  });
+});
+
+// ── mock supabase builder helper ──
+function mockSupabase({ eligible = 5, rows = null, insertError = null, deleteError = null } = {}) {
+  const calls = { inserts: 0, deletes: 0 };
+  const sampleRows = rows || Array.from({ length: eligible }, (_, i) => ({ id: `id-${i}`, created_at: '2026-01-01T00:00:00Z' }));
+  const from = vi.fn((table) => {
+    if (table === 'retention_archive') {
+      return {
+        insert: vi.fn(async (rowsIn) => {
+          calls.inserts += 1;
+          if (insertError) return { error: { message: insertError }, count: null };
+          return { error: null, count: rowsIn.length };
+        }),
+      };
+    }
+    // source table builder — chainable
+    const builder = {
+      select: vi.fn(() => builder),
+      lt: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      limit: vi.fn(async () => ({ data: sampleRows, error: null })),
+      delete: vi.fn(() => ({
+        in: vi.fn(async () => {
+          calls.deletes += 1;
+          if (deleteError) return { error: { message: deleteError } };
+          return { error: null };
+        }),
+      })),
+    };
+    // count query: select(head:true) path resolves via then on builder — emulate with a thenable
+    builder.then = undefined;
+    builder.select = vi.fn((sel, opts) => {
+      if (opts && opts.head) {
+        return { lt: vi.fn(async () => ({ count: eligible, error: null })) };
+      }
+      return builder;
+    });
+    return builder;
+  });
+  return { supabase: { from }, calls };
+}
+
+describe('enforcement invariants (TS-3/TS-4)', () => {
+  const policy = { table: 'audit_log', timestampColumn: 'created_at', hotDays: 90, mode: 'archive', perRunCap: 10 };
+
+  it('dry-run counts but never selects/inserts/deletes rows', async () => {
+    const { supabase, calls } = mockSupabase({ eligible: 7 });
+    const r = await enforcePolicy(supabase, policy, { apply: false, env: {} });
+    expect(r.eligible).toBe(7);
+    expect(r.archived).toBe(0);
+    expect(r.deleted).toBe(0);
+    expect(calls.inserts).toBe(0);
+    expect(calls.deletes).toBe(0);
+  });
+
+  it('apply archives THEN deletes; counts reconcile', async () => {
+    const { supabase, calls } = mockSupabase({ eligible: 5 });
+    const r = await enforcePolicy(supabase, policy, { apply: true, env: {} });
+    expect(r.error).toBeNull();
+    expect(r.archived).toBe(5);
+    expect(r.deleted).toBe(5);
+    expect(calls.inserts).toBeGreaterThan(0);
+    expect(calls.deletes).toBeGreaterThan(0);
+  });
+
+  it('TS-4: a FAILED archive insert issues ZERO deletes (archive-before-delete invariant)', async () => {
+    const { supabase, calls } = mockSupabase({ eligible: 5, insertError: 'boom' });
+    const r = await enforcePolicy(supabase, policy, { apply: true, env: {} });
+    expect(r.error).toMatch(/archive insert failed/);
+    expect(r.deleted).toBe(0);
+    expect(calls.deletes).toBe(0);
+  });
+
+  it('a failed delete AFTER archive reports the rows as archived (rerun converges)', async () => {
+    const { supabase } = mockSupabase({ eligible: 5, deleteError: 'net blip' });
+    const r = await enforcePolicy(supabase, policy, { apply: true, env: {} });
+    expect(r.error).toMatch(/delete failed after archive/);
+    expect(r.archived).toBe(5);
+  });
+
+  it('per-table fail-soft: enforcePolicy returns the error rather than throwing', async () => {
+    const supabase = { from: vi.fn(() => ({ select: vi.fn(() => ({ lt: vi.fn(async () => ({ count: null, error: { message: 'table gone' } })) })) })) };
+    const r = await enforcePolicy(supabase, policy, { apply: false, env: {} });
+    expect(r.error).toMatch(/count failed/);
+  });
+});
+
+describe('migration parity (TS-2 static)', () => {
+  const UP = readFileSync(resolve(REPO_ROOT, 'database/migrations/20260610_retention_substrate.sql'), 'utf8');
+  const DOWN = readFileSync(resolve(REPO_ROOT, 'database/migrations/20260610_retention_substrate_DOWN.sql'), 'utf8');
+
+  it('UP creates exactly the two substrate tables; DOWN drops exactly those two', () => {
+    expect((UP.match(/CREATE TABLE IF NOT EXISTS (retention_archive|retention_runs)/g) || []).length).toBe(2);
+    expect((DOWN.match(/DROP TABLE IF EXISTS (retention_archive|retention_runs)/g) || []).length).toBe(2);
+    expect(UP).not.toMatch(/ALTER TABLE (workflow_trace_log|governance_audit_log|audit_log|validation_audit_log|model_usage_log|permission_audit_log)/);
+    // anchor on the STATEMENT form — the safety comments legitimately mention "delete"
+    expect(UP).not.toMatch(/DELETE\s+FROM/i);
+    expect(UP).not.toMatch(/TRUNCATE/i);
+  });
+
+  it('liveness contract documented at the table (age-keyed, not status)', () => {
+    expect(UP).toMatch(/alarm on AGE of max\(ran_at\), never on self-reported status/);
+  });
+});
+
+describe('log rotation (FR-5)', () => {
+  it('absent log file is a no-op', () => {
+    const r = rotateDaemonLog('/nonexistent/repo/root');
+    expect(r.rotated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Six audit/trace tables grow unbounded (1.5M+ rows total). Ships ARCHIVE-NOT-DELETE retention machinery — **nothing destructive runs from this PR alone** (chairman-gated activation per the SD deliverable).

- **Migration** (reversible): `retention_archive` cold JSONB store (restore = re-insert `row_data`) + `retention_runs` age-keyed liveness stamps. Live `BEGIN..ROLLBACK` round-trip proven.
- **Policy registry**: verified per-table timestamp columns; 90d default = 3x the longest enforced consumer lookback (30d); `MIN_HOT_DAYS=45` floor refuses to run below it; the mgmt-reviews quarantine table tracked as report-only soak.
- **Enforcement CLI**: dry-run default; `--apply` = batched **archive-before-delete** (failed archive ⇒ zero deletes) under per-run caps; per-table fail-soft; `--liveness`; `--arming-spec` (never self-arms); daemon-log rotation. npm `retention:check`/`retention:apply`.
- 14 tests incl. the archive-before-delete invariant.

VALIDATION PASS 92 (consumer-lookback sweep, zero FKs/triggers on targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)