### PR TITLE
fix(SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001): clamp BATCH_SIZE to the PostgREST max-rows cap

### DIFF
--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -23,7 +23,12 @@
 export const MIN_HOT_DAYS = 45;
 export const DEFAULT_HOT_DAYS = 90;
 export const DEFAULT_PER_RUN_CAP = 20000;
-export const BATCH_SIZE = 2000;
+// PostgREST silently caps SELECTs at max-rows=1000 — a larger .limit() returns
+// 1000 rows anyway, which made the enforcement loop's `rows.length < batchLimit`
+// convergence check misread "truncated" as "drained" and stop after ONE batch
+// (witnessed on the first live apply 2026-06-10: exactly 1000/table). Keep
+// BATCH_SIZE at the PostgREST cap so the check stays truthful.
+export const BATCH_SIZE = 1000;
 export const DELETE_CHUNK = 200;
 export const LIVENESS_MAX_AGE_DAYS = 8;
 


### PR DESCRIPTION
First live apply archived exactly 1000 rows/table despite BATCH_SIZE=2000 — PostgREST caps SELECTs at max-rows=1000, so the loop's `rows.length < batchLimit` convergence check misread truncation as a drained backlog and stopped after one batch. Clamp to 1000 so runs drain up to the 20k/table per-run cap as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)