### PR TITLE
fix(SD-LEO-FIX-FIX-PHANTOM-COLUMN-002): align EVA writers/readers to live columns + fail-loud audit writes

### DIFF
--- a/lib/agents/venture-ceo/handlers.js
+++ b/lib/agents/venture-ceo/handlers.js
@@ -6,7 +6,15 @@
  * SD-LEO-REFACTOR-VENTURE-CEO-001
  */
 
+import { randomUUID } from 'node:crypto';
 import { STAGE_TO_VP } from './constants.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** eva_event_log.correlation_id is uuid — fall back to a fresh UUID for non-uuid message ids. */
+function toCorrelationId(value) {
+  return (typeof value === 'string' && UUID_RE.test(value)) ? value : randomUUID();
+}
 
 /**
  * Handler: Task Delegation
@@ -317,23 +325,25 @@ export async function handleCEOMissionDraft(context, message) {
     };
   }
 
-  // Emit event for audit trail
+  // Emit event for audit trail (live column is metadata, not payload — SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
   try {
-    await supabase
+    const { error: emitError } = await supabase
       .from('eva_event_log')
       .insert({
         event_type: 'ceo.mission.drafted',
-        payload: {
+        ...(typeof ventureId === 'string' && UUID_RE.test(ventureId) ? { venture_id: ventureId } : {}),
+        metadata: {
           mission_id: draft.id,
           venture_id: ventureId,
           version: draft.version,
           _service: 'venture-ceo'
         },
         trigger_source: 'manual',
-        correlation_id: message.id || `mission-draft-v${draft.version}`,
-        status: 'completed',
+        correlation_id: toCorrelationId(message.id),
+        status: 'succeeded',
         created_at: new Date().toISOString()
       });
+    if (emitError) console.warn(`   Event emit failed (non-blocking): ${emitError.message}`);
   } catch (emitErr) {
     console.warn(`   Event emit failed (non-blocking): ${emitErr.message}`);
   }
@@ -569,21 +579,23 @@ export async function handleCEOMonthlyReport(context, message) {
     };
   }
 
-  // Emit event
+  // Emit event (live column is metadata, not payload — SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
   try {
-    await supabase.from('eva_event_log').insert({
+    const { error: emitError } = await supabase.from('eva_event_log').insert({
       event_type: 'ceo.monthly_report.generated',
-      payload: {
+      ...(typeof ventureId === 'string' && UUID_RE.test(ventureId) ? { venture_id: ventureId } : {}),
+      metadata: {
         report_id: report.id,
         venture_id: ventureId,
         period,
         _service: 'venture-ceo'
       },
       trigger_source: 'manual',
-      correlation_id: message.id || `report-${period}`,
-      status: 'completed',
+      correlation_id: toCorrelationId(message.id),
+      status: 'succeeded',
       created_at: new Date().toISOString()
     });
+    if (emitError) console.warn(`   Event emit failed (non-blocking): ${emitError.message}`);
   } catch { /* non-blocking */ }
 
   console.log(`   Monthly report generated for ${period}: ${report.id}`);

--- a/lib/eva/analysis-history.js
+++ b/lib/eva/analysis-history.js
@@ -15,6 +15,7 @@
  * @module lib/eva/analysis-history
  */
 
+import { randomUUID } from 'node:crypto';
 import { ServiceError } from './shared-services.js';
 
 export const MODULE_VERSION = '1.0.0';
@@ -43,13 +44,19 @@ export async function archiveAnalysisStep(supabase, { ventureId, stageId, analys
   const existingHistory = await getAnalysisHistory(supabase, ventureId, stageId);
   const historyCount = existingHistory.length + 1;
 
+  // Live columns: no severity (folded into metadata); trigger_source/status/correlation_id are
+  // NOT NULL with no defaults; CHECKs: trigger_source in (realtime,cron,manual), status in
+  // (succeeded,failed,suppressed); correlation_id is uuid (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data, error } = await supabase
     .from('eva_event_log')
     .insert({
       venture_id: ventureId,
       event_type: 'ANALYSIS_STEP_ARCHIVED',
-      severity: 'info',
+      trigger_source: 'realtime',
+      status: 'succeeded',
+      correlation_id: randomUUID(),
       metadata: {
+        severity: 'info',
         stage_id: stageId,
         analysis_result: analysisResult,
         archived_at: archivedAt,

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -406,7 +406,7 @@ export async function advanceStage(supabase, opts) {
   const gateResult = await checkExitGates({ supabase, ventureId, fromStage });
   if (!gateResult.allowed) {
     throw new Error(
-      `[artifact-persistence-service] advanceStage blocked by exit-gate enforcer. ` +
+      '[artifact-persistence-service] advanceStage blocked by exit-gate enforcer. ' +
       `Venture: ${ventureId}, From: ${fromStage}, To: ${toStage}. ` +
       `Blocked by: ${gateResult.blocked_by.join('; ')}. ` +
       `Gates checked: [${gateResult.gates_checked.join(', ')}].`
@@ -593,9 +593,9 @@ async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, trig
     .eq('vision_key', visionKey)
     .single();
 
-  // SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001-B: Pre-compute evidence_count for HEAL traceability scoring
-  const evidenceMetadata = { evidence_count: artifacts.length, last_evidence_stage: triggerStage };
-
+  // SD-LEO-FIX-FIX-PHANTOM-COLUMN-002: eva_vision_documents has NO metadata column —
+  // the addendums entries already carry evidence_count/stage_number for HEAL traceability.
+  // The phantom metadata key made every one of these writes fail silently (whole row lost).
   if (existing) {
     const newVersion = (existing.version || 1) + 1;
     const addendums = existing.addendums || [];
@@ -605,15 +605,15 @@ async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, trig
       evidence_count: artifacts.length,
       timestamp: new Date().toISOString(),
     });
-    await supabase.from('eva_vision_documents').update({
+    const { error: updateError } = await supabase.from('eva_vision_documents').update({
       content: synthesized,
       version: newVersion,
       addendums,
-      metadata: evidenceMetadata,
       updated_at: new Date().toISOString(),
     }).eq('vision_key', visionKey);
+    if (updateError) console.warn(`[artifact-persistence-service] eva_vision_documents update failed (${visionKey}): ${updateError.message}`);
   } else {
-    await supabase.from('eva_vision_documents').insert({
+    const { error: insertError } = await supabase.from('eva_vision_documents').insert({
       vision_key: visionKey,
       level: 'L2',
       venture_id: ventureId,
@@ -621,9 +621,9 @@ async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, trig
       version: 1,
       status: 'draft',
       created_by: 'eager-synthesis',
-      metadata: evidenceMetadata,
       addendums: [{ stage_number: triggerStage, artifact_count: artifacts.length, evidence_count: artifacts.length, timestamp: new Date().toISOString() }],
     });
+    if (insertError) console.warn(`[artifact-persistence-service] eva_vision_documents insert failed (${visionKey}): ${insertError.message}`);
   }
 }
 
@@ -642,15 +642,15 @@ async function upsertEvaArchFromArtifacts(supabase, planKey, ventureId, triggerS
 
   const synthesized = synthesizeFromArtifacts(artifacts, 'architecture');
 
-  // SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001-B: Pre-compute evidence_count for HEAL traceability scoring
-  const evidenceMetadata = { evidence_count: artifacts.length, last_evidence_stage: triggerStage };
-
   const { data: existing } = await supabase
     .from('eva_architecture_plans')
     .select('id, version, addendums')
     .eq('plan_key', planKey)
     .single();
 
+  // SD-LEO-FIX-FIX-PHANTOM-COLUMN-002: eva_architecture_plans has NO metadata column —
+  // the addendums entries already carry evidence_count/stage_number for HEAL traceability.
+  // The phantom metadata key made every one of these writes fail silently (whole row lost).
   if (existing) {
     const newVersion = (existing.version || 1) + 1;
     const addendums = existing.addendums || [];
@@ -660,24 +660,24 @@ async function upsertEvaArchFromArtifacts(supabase, planKey, ventureId, triggerS
       evidence_count: artifacts.length,
       timestamp: new Date().toISOString(),
     });
-    await supabase.from('eva_architecture_plans').update({
+    const { error: updateError } = await supabase.from('eva_architecture_plans').update({
       content: synthesized,
       version: newVersion,
       addendums,
-      metadata: evidenceMetadata,
       updated_at: new Date().toISOString(),
     }).eq('plan_key', planKey);
+    if (updateError) console.warn(`[artifact-persistence-service] eva_architecture_plans update failed (${planKey}): ${updateError.message}`);
   } else {
-    await supabase.from('eva_architecture_plans').insert({
+    const { error: insertError } = await supabase.from('eva_architecture_plans').insert({
       plan_key: planKey,
       venture_id: ventureId,
       content: synthesized,
       version: 1,
       status: 'draft',
       created_by: 'eager-synthesis',
-      metadata: evidenceMetadata,
       addendums: [{ stage_number: triggerStage, artifact_count: artifacts.length, evidence_count: artifacts.length, timestamp: new Date().toISOString() }],
     });
+    if (insertError) console.warn(`[artifact-persistence-service] eva_architecture_plans insert failed (${planKey}): ${insertError.message}`);
   }
 }
 

--- a/lib/eva/dfe-gate-escalation-router.js
+++ b/lib/eva/dfe-gate-escalation-router.js
@@ -9,6 +9,8 @@
  * @module lib/eva/dfe-gate-escalation-router
  */
 
+import { randomUUID } from 'node:crypto';
+
 const DEFAULT_PATTERN_THRESHOLD = 3; // Minimum occurrences to detect a pattern
 const DEFAULT_LOOKBACK_DAYS = 14;
 
@@ -62,11 +64,17 @@ export async function routeGateFailure(supabase, params, options = {}) {
       created_at: new Date().toISOString(),
     };
 
+    // Live columns: metadata (not payload); trigger_source/status/correlation_id are NOT NULL
+    // with no defaults; CHECKs: trigger_source in (realtime,cron,manual), status in
+    // (succeeded,failed,suppressed); correlation_id is uuid (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
     const { error: insertError } = await supabase
       .from('eva_event_log')
       .insert({
         event_type: 'gate_failure',
-        payload: failureRecord,
+        trigger_source: 'realtime',
+        status: 'failed',
+        correlation_id: randomUUID(),
+        metadata: failureRecord,
         created_at: failureRecord.created_at,
       });
 
@@ -153,7 +161,7 @@ export async function detectPatterns(supabase, options = {}) {
 
     let query = supabase
       .from('eva_event_log')
-      .select('id, payload, created_at')
+      .select('id, metadata, created_at')
       .eq('event_type', 'gate_failure')
       .gte('created_at', cutoff)
       .order('created_at', { ascending: false });
@@ -169,7 +177,7 @@ export async function detectPatterns(supabase, options = {}) {
 
     // Filter by sdId and gateType if provided
     const filtered = all.filter((e) => {
-      const p = e.payload || {};
+      const p = e.metadata || {};
       if (sdId && p.sd_id !== sdId) return false;
       if (gateType && p.gate_type !== gateType) return false;
       return true;
@@ -178,7 +186,7 @@ export async function detectPatterns(supabase, options = {}) {
     // Group by gate_type + sd_id combination
     const groups = {};
     for (const event of filtered) {
-      const p = event.payload || {};
+      const p = event.metadata || {};
       const key = `${p.gate_type}::${p.sd_id}`;
       if (!groups[key]) groups[key] = [];
       groups[key].push(event);
@@ -192,7 +200,7 @@ export async function detectPatterns(supabase, options = {}) {
           gateType: gt,
           sdId: sid,
           occurrences: events.length,
-          recentScores: events.slice(0, 5).map((e) => e.payload?.score),
+          recentScores: events.slice(0, 5).map((e) => e.metadata?.score),
           firstSeen: events[events.length - 1].created_at,
           lastSeen: events[0].created_at,
         });

--- a/lib/eva/escalation-event-persister.js
+++ b/lib/eva/escalation-event-persister.js
@@ -55,20 +55,24 @@ export async function persistEscalationEvent(supabase, {
   let visionDimensionGaps = null;
   const hasVisionTrigger = (dfeResult.triggers || []).some(t => t.type === 'vision_score_signal');
   if (hasVisionTrigger && sdId) {
-    const { data: gaps } = await supabase
+    // Live columns: dimension_name, dimension_score, severity, corrective_sd_id —
+    // dimension_label/current_score/gap_severity/corrective_sd_key do not exist and
+    // target_score has no live equivalent (dropped). SD-LEO-FIX-FIX-PHANTOM-COLUMN-002.
+    const { data: gaps, error: gapsError } = await supabase
       .from('eva_vision_gaps')
-      .select('dimension_key, dimension_label, current_score, target_score, gap_severity, corrective_sd_key')
+      .select('dimension_key, dimension_name, dimension_score, severity, corrective_sd_id')
       .eq('sd_id', sdId)
-      .order('current_score', { ascending: true });
+      .order('dimension_score', { ascending: true });
 
-    if (gaps && gaps.length > 0) {
+    if (gapsError) {
+      console.warn(`[EscalationPersister] eva_vision_gaps query failed: ${gapsError.message}`);
+    } else if (gaps && gaps.length > 0) {
       visionDimensionGaps = gaps.map(g => ({
         dimensionKey: g.dimension_key,
-        dimensionLabel: g.dimension_label,
-        currentScore: g.current_score,
-        targetScore: g.target_score,
-        gapSeverity: g.gap_severity,
-        correctiveSdKey: g.corrective_sd_key,
+        dimensionLabel: g.dimension_name,
+        currentScore: g.dimension_score,
+        gapSeverity: g.severity,
+        correctiveSdKey: g.corrective_sd_id,
       }));
     }
   }

--- a/lib/eva/event-bus/handlers/_log-eva-audit.js
+++ b/lib/eva/event-bus/handlers/_log-eva-audit.js
@@ -1,0 +1,38 @@
+/**
+ * Shared eva_audit_log writer — fail-loud.
+ * SD-LEO-FIX-FIX-PHANTOM-COLUMN-002 (FR-1)
+ *
+ * Live columns (EHG_Engineer DB, verified 2026-06-10):
+ *   id, eva_venture_id (uuid), action_type (NOT NULL), action_source (default 'system'),
+ *   action_data (jsonb default '{}'), actor_type (default 'system'), actor_id, created_at
+ *
+ * Never write venture_id / details / actor — those columns DO NOT exist; PostgREST
+ * rejects the whole insert and (previously) the discarded error made the audit
+ * trail vanish silently.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} row
+ * @param {string} row.eva_venture_id - Venture UUID (eva_ventures.id)
+ * @param {string} row.action_type - Audit action type (NOT NULL)
+ * @param {object} [row.action_data] - JSONB payload
+ * @param {string} [row.actor_type] - Who acted (e.g. 'event_bus', 'chairman')
+ * @param {string} [row.actor_id] - Optional actor identifier
+ * @param {object} [opts]
+ * @param {string} [opts.handler] - Calling handler name for log context
+ * @returns {Promise<{ok: boolean, error?: object}>}
+ */
+export async function logEvaAudit(supabase, { eva_venture_id, action_type, action_data = {}, actor_type = 'system', actor_id = null }, { handler = 'unknown' } = {}) {
+  const { error } = await supabase.from('eva_audit_log').insert({
+    eva_venture_id,
+    action_type,
+    action_data,
+    actor_type,
+    ...(actor_id ? { actor_id } : {}),
+  });
+
+  if (error) {
+    console.warn(`[EvaAudit:${handler}] eva_audit_log write failed (${action_type}): ${error.message}`);
+    return { ok: false, error };
+  }
+  return { ok: true };
+}

--- a/lib/eva/event-bus/handlers/budget-exceeded.js
+++ b/lib/eva/event-bus/handlers/budget-exceeded.js
@@ -8,6 +8,7 @@
  */
 
 import { getComputePosture } from '../../../governance/compute-posture.js';
+import { logEvaAudit } from './_log-eva-audit.js';
 
 /**
  * Handle a budget.exceeded event.
@@ -28,11 +29,11 @@ export async function handleBudgetExceeded(payload, context) {
   const posture = getComputePosture();
   const enforcing = posture.blockOnExceed;
 
-  // Log to audit trail
-  await supabase.from('eva_audit_log').insert({
-    venture_id: ventureId,
+  // Log to audit trail (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
+    eva_venture_id: ventureId,
     action_type: 'budget_exceeded',
-    details: {
+    action_data: {
       current_budget: currentBudget,
       threshold,
       overage,
@@ -40,8 +41,8 @@ export async function handleBudgetExceeded(payload, context) {
       enforcement_mode: enforcing,
       sd_key: sdKey || null,
     },
-    actor: 'event_bus',
-  });
+    actor_type: 'event_bus',
+  }, { handler: 'BudgetExceeded' });
 
   // Add to chairman decision queue
   try {

--- a/lib/eva/event-bus/handlers/chairman-override.js
+++ b/lib/eva/event-bus/handlers/chairman-override.js
@@ -6,6 +6,8 @@
  * to the venture and log to audit trail.
  */
 
+import { logEvaAudit } from './_log-eva-audit.js';
+
 /**
  * Handle a chairman.override event.
  * @param {object} payload - { ventureId, decisionId, overrideType, value }
@@ -22,17 +24,17 @@ export async function handleChairmanOverride(payload, context) {
     throw err;
   }
 
-  // Log to audit trail
-  await supabase.from('eva_audit_log').insert({
-    venture_id: ventureId,
+  // Log to audit trail (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
+    eva_venture_id: ventureId,
     action_type: 'chairman_override',
-    details: {
+    action_data: {
       decision_id: decisionId,
       override_type: overrideType,
       value,
     },
-    actor: 'chairman',
-  });
+    actor_type: 'chairman',
+  }, { handler: 'ChairmanOverride' });
 
   // Mark decision as applied if decisionId provided
   if (decisionId) {

--- a/lib/eva/event-bus/handlers/gate-evaluated.js
+++ b/lib/eva/event-bus/handlers/gate-evaluated.js
@@ -8,6 +8,8 @@
  * - kill: terminate the venture
  */
 
+import { logEvaAudit } from './_log-eva-audit.js';
+
 /**
  * Handle a gate.evaluated event.
  * @param {object} payload - { ventureId, gateId, outcome, reason? }
@@ -74,8 +76,8 @@ async function handleBlock(supabase, ventureId, gateId, reason) {
     .update({ status: 'blocked' })
     .eq('id', ventureId);
 
-  // Record the block reason in audit log
-  await supabase.from('eva_audit_log').insert({
+  // Record the block reason in audit log (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
     eva_venture_id: ventureId,
     action_type: 'venture_blocked',
     action_data: {
@@ -83,7 +85,8 @@ async function handleBlock(supabase, ventureId, gateId, reason) {
       reason: reason || 'Gate evaluation failed',
       blockedAt: new Date().toISOString(),
     },
-  });
+    actor_type: 'event_bus',
+  }, { handler: 'GateEvaluated' });
 
   console.log(`[GateEvaluated] Gate ${gateId} blocked venture ${ventureId}: ${reason || 'no reason'}`);
   return { outcome: 'block', action: 'blocked', ventureId, gateId, reason: reason || 'Gate evaluation failed' };
@@ -95,8 +98,8 @@ async function handleKill(supabase, ventureId, gateId) {
     .update({ status: 'terminated' })
     .eq('id', ventureId);
 
-  // Record termination in audit log
-  await supabase.from('eva_audit_log').insert({
+  // Record termination in audit log (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
     eva_venture_id: ventureId,
     action_type: 'venture_terminated',
     action_data: {
@@ -104,7 +107,8 @@ async function handleKill(supabase, ventureId, gateId) {
       terminatedAt: new Date().toISOString(),
       trigger: 'gate_evaluation_kill',
     },
-  });
+    actor_type: 'event_bus',
+  }, { handler: 'GateEvaluated' });
 
   console.log(`[GateEvaluated] Gate ${gateId} KILLED venture ${ventureId}`);
   return { outcome: 'kill', action: 'terminated', ventureId, gateId };

--- a/lib/eva/event-bus/handlers/sd-completed.js
+++ b/lib/eva/event-bus/handlers/sd-completed.js
@@ -12,6 +12,8 @@
  * 3. Failed SDs create issues with severity classification
  */
 
+import { logEvaAudit } from './_log-eva-audit.js';
+
 // SD types that trigger HIGH severity when they fail
 const HIGH_SEVERITY_TYPES = ['security', 'fix', 'infrastructure'];
 
@@ -202,8 +204,8 @@ export async function handleSdCompleted(payload, context) {
     throw new Error(`Failed to update Stage 19: ${updateError.message}`);
   }
 
-  // Record in audit log
-  await supabase.from('eva_audit_log').insert({
+  // Record in audit log (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
     eva_venture_id: ventureId,
     action_type: 'sd_completion_synced',
     action_data: {
@@ -216,7 +218,8 @@ export async function handleSdCompleted(payload, context) {
       issueCount: failedSiblings.length,
       syncedAt: new Date().toISOString(),
     },
-  }).then(() => {}).catch(() => {}); // Best-effort audit logging
+    actor_type: 'event_bus',
+  }, { handler: 'SdCompleted' });
 
   console.log(
     `[SdCompleted] Updated Stage 19 for venture ${ventureId}: ` +

--- a/lib/eva/event-bus/handlers/stage-failed.js
+++ b/lib/eva/event-bus/handlers/stage-failed.js
@@ -6,6 +6,8 @@
  * log the failure and escalate if needed.
  */
 
+import { logEvaAudit } from './_log-eva-audit.js';
+
 /**
  * Handle a stage.failed event.
  * @param {object} payload - { ventureId, stageId, reason, failureType }
@@ -22,17 +24,17 @@ export async function handleStageFailed(payload, context) {
     throw err;
   }
 
-  // Log to audit trail
-  await supabase.from('eva_audit_log').insert({
-    venture_id: ventureId,
+  // Log to audit trail (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
+    eva_venture_id: ventureId,
     action_type: 'stage_failed',
-    details: {
+    action_data: {
       stage_id: stageId,
       reason: reason || 'Unknown failure',
       failure_type: failureType || 'error',
     },
-    actor: 'event_bus',
-  });
+    actor_type: 'event_bus',
+  }, { handler: 'StageFailed' });
 
   // If it's a gate rejection, it may need chairman review
   if (failureType === 'gate_rejection') {

--- a/lib/eva/event-bus/handlers/venture-created.js
+++ b/lib/eva/event-bus/handlers/venture-created.js
@@ -6,6 +6,8 @@
  * and log the creation to the audit trail.
  */
 
+import { logEvaAudit } from './_log-eva-audit.js';
+
 /**
  * Handle a venture.created event.
  * @param {object} payload - { ventureId, name, createdBy }
@@ -35,17 +37,17 @@ export async function handleVentureCreated(payload, context) {
     throw err;
   }
 
-  // Log to audit trail
-  await supabase.from('eva_audit_log').insert({
-    venture_id: ventureId,
+  // Log to audit trail (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
+    eva_venture_id: ventureId,
     action_type: 'venture_created',
-    details: {
+    action_data: {
       name: name || venture.name,
       created_by: createdBy || 'system',
       initial_status: venture.status,
     },
-    actor: 'event_bus',
-  });
+    actor_type: 'event_bus',
+  }, { handler: 'VentureCreated' });
 
   return { outcome: 'venture_initialized', ventureId };
 }

--- a/lib/eva/event-bus/handlers/venture-killed.js
+++ b/lib/eva/event-bus/handlers/venture-killed.js
@@ -6,6 +6,8 @@
  * and log the kill decision to the audit trail.
  */
 
+import { logEvaAudit } from './_log-eva-audit.js';
+
 /**
  * Handle a venture.killed event.
  * @param {object} payload - { ventureId, reason, killedBy }
@@ -32,16 +34,16 @@ export async function handleVentureKilled(payload, context) {
     throw new Error(`Failed to update venture status: ${updateError.message}`);
   }
 
-  // Log to audit trail
-  await supabase.from('eva_audit_log').insert({
-    venture_id: ventureId,
+  // Log to audit trail (fail-loud: SD-LEO-FIX-FIX-PHANTOM-COLUMN-002)
+  await logEvaAudit(supabase, {
+    eva_venture_id: ventureId,
     action_type: 'venture_killed',
-    details: {
+    action_data: {
       reason: reason || 'No reason provided',
       killed_by: killedBy || 'system',
     },
-    actor: 'event_bus',
-  });
+    actor_type: 'event_bus',
+  }, { handler: 'VentureKilled' });
 
   return { outcome: 'venture_killed', ventureId, reason };
 }

--- a/lib/eva/event-bus/handlers/vision-corrective-sd-created.js
+++ b/lib/eva/event-bus/handlers/vision-corrective-sd-created.js
@@ -32,15 +32,17 @@ export function registerVisionCorrectiveSdCreatedHandlers() {
     if (!dimensions || dimensions.length === 0) return;
 
     try {
+      // Live columns: corrective_sd_id (text, holds sd_keys) and dimension_key —
+      // corrective_sd_key/dimension_id do not exist (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
       const { error } = await supabase
         .from('eva_vision_gaps')
         .update({
-          corrective_sd_key: correctiveSdKey,
+          corrective_sd_id: correctiveSdKey,
           status: 'in_progress',
           updated_at: new Date().toISOString(),
         })
         .eq('sd_id', originSdKey || '')
-        .in('dimension_id', dimensions)
+        .in('dimension_key', dimensions)
         .eq('status', 'open');
 
       if (error) {

--- a/lib/eva/event-bus/handlers/vision-gap-accepted.js
+++ b/lib/eva/event-bus/handlers/vision-gap-accepted.js
@@ -29,19 +29,22 @@ export function registerVisionGapAcceptedHandlers() {
     if (!supabase) return;
 
     try {
+      // Live columns: acceptance_rationale + accepted_at (resolution_notes/dimension_id
+      // do not exist — SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
       const filter = supabase
         .from('eva_vision_gaps')
         .update({
           status: 'accepted',
-          resolution_notes: reason || 'Accepted via gap_accepted event',
+          acceptance_rationale: reason || 'Accepted via gap_accepted event',
+          accepted_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
         });
 
-      // Match by gapId if available, otherwise by sd_id + dimension_id
+      // Match by gapId if available, otherwise by sd_id + dimension_key
       if (gapId) {
         filter.eq('id', gapId);
       } else if (sdKey && dimensionId) {
-        filter.eq('sd_id', sdKey).eq('dimension_id', dimensionId);
+        filter.eq('sd_id', sdKey).eq('dimension_key', dimensionId);
       } else {
         return; // Cannot identify the gap without identifiers
       }

--- a/lib/eva/event-bus/handlers/vision-gap-detected.js
+++ b/lib/eva/event-bus/handlers/vision-gap-detected.js
@@ -24,22 +24,41 @@ export function registerVisionGapDetectedHandlers() {
     console.log(`[VisionBus] Gap detected: ${sdKey} dimension=${dimension} score=${score} threshold=${threshold}`);
   });
 
-  // Subscriber 2: Write gap to eva_vision_gaps table
-  subscribeVisionEvent(VISION_EVENTS.GAP_DETECTED, async ({ sdKey, dimension, dimId, score, threshold, scoreId, supabase }) => {
+  // Subscriber 2: Write gap to eva_vision_gaps table.
+  // Live columns: dimension_key, dimension_score, vision_score_id — the legacy
+  // names did not exist, and threshold/detection timestamps have no live columns.
+  // eva_vision_gaps has NO unique constraint on (sd_id, dimension_key), so an
+  // on-conflict upsert is invalid — select-then-update-else-insert instead
+  // (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
+  subscribeVisionEvent(VISION_EVENTS.GAP_DETECTED, async ({ sdKey, dimension, dimId, score, threshold: _threshold, scoreId, supabase }) => {
     if (!supabase) return;
     try {
-      const { error } = await supabase
+      const dimensionKey = dimId || dimension;
+      const { data: existing, error: selectError } = await supabase
         .from('eva_vision_gaps')
-        .upsert({
-          sd_id: sdKey,
-          dimension_id: dimId || dimension,
-          dimension_name: dimension,
-          score,
-          threshold,
-          score_id: scoreId || null,
-          status: 'open',
-          detected_at: new Date().toISOString(),
-        }, { onConflict: 'sd_id,dimension_id', ignoreDuplicates: false });
+        .select('id')
+        .eq('sd_id', sdKey)
+        .eq('dimension_key', dimensionKey)
+        .limit(1)
+        .maybeSingle();
+
+      if (selectError) {
+        console.warn(`[VisionBus] Failed to check existing gap: ${selectError.message}`);
+        return;
+      }
+
+      const row = {
+        sd_id: sdKey,
+        dimension_key: dimensionKey,
+        dimension_name: dimension,
+        dimension_score: score,
+        vision_score_id: scoreId || null,
+        status: 'open',
+      };
+
+      const { error } = existing
+        ? await supabase.from('eva_vision_gaps').update({ ...row, updated_at: new Date().toISOString() }).eq('id', existing.id)
+        : await supabase.from('eva_vision_gaps').insert(row);
 
       if (error) {
         console.warn(`[VisionBus] Failed to write gap to eva_vision_gaps: ${error.message}`);

--- a/lib/eva/event-bus/handlers/vision-rescore-completed.js
+++ b/lib/eva/event-bus/handlers/vision-rescore-completed.js
@@ -41,26 +41,28 @@ export function registerVisionRescoreCompletedHandlers() {
     if (!dimensionDelta || Object.keys(dimensionDelta).length === 0) return;
 
     try {
-      // Fetch open gaps for this SD's dimensions
+      // Fetch open gaps for this SD's dimensions.
+      // Live columns: dimension_key + dimension_score — dimension_id/score do not
+      // exist (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
       const dimensionIds = Object.keys(dimensionDelta);
       const { data: gaps, error: fetchError } = await supabase
         .from('eva_vision_gaps')
-        .select('id, dimension_id, score')
+        .select('id, dimension_key, dimension_score')
         .eq('sd_id', sdKey || '')
-        .in('dimension_id', dimensionIds)
+        .in('dimension_key', dimensionIds)
         .in('status', ['open', 'in_progress']);
 
       if (fetchError || !gaps) return;
 
       for (const gap of gaps) {
-        const delta = dimensionDelta[gap.dimension_id] || 0;
-        const newScore = (gap.score || 0) + delta;
-        const newStatus = newScore >= GAP_RESOLUTION_THRESHOLD ? 'closed' : gap.score < GAP_RESOLUTION_THRESHOLD ? 'open' : 'in_progress';
+        const delta = dimensionDelta[gap.dimension_key] || 0;
+        const newScore = (gap.dimension_score || 0) + delta;
+        const newStatus = newScore >= GAP_RESOLUTION_THRESHOLD ? 'closed' : gap.dimension_score < GAP_RESOLUTION_THRESHOLD ? 'open' : 'in_progress';
 
         const { error: updateError } = await supabase
           .from('eva_vision_gaps')
           .update({
-            score: newScore,
+            dimension_score: newScore,
             status: newStatus,
             updated_at: new Date().toISOString(),
           })

--- a/lib/eva/gate-failure-recovery.js
+++ b/lib/eva/gate-failure-recovery.js
@@ -12,6 +12,7 @@
  * @module lib/eva/gate-failure-recovery
  */
 
+import { randomUUID } from 'node:crypto';
 import { REASON_CODES } from './reality-gates.js';
 
 const MAX_RETRIES = 3;
@@ -181,7 +182,7 @@ export async function markKilledAtGate(supabase, ventureId, opts = {}) {
 /**
  * US-004: Route gate outcome by severity.
  * Critical → DFE escalation record.
- * Non-critical → stored in venture metadata for auto-retry on next cycle.
+ * Non-critical → durable gate_retry_context event in eva_event_log for auto-retry on next cycle.
  *
  * @param {string} ventureId - Venture UUID
  * @param {string} severity - 'critical' or 'non-critical'
@@ -230,32 +231,30 @@ export async function routeGateOutcome(ventureId, severity, context, deps) {
     }
   }
 
-  // Non-critical: store in venture metadata for auto-retry
+  // Non-critical: record a durable gate_retry_context event for auto-retry.
+  // eva_ventures has NO metadata column — the old stash failed on every call
+  // (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002). eva_event_log live columns require
+  // trigger_source/status/correlation_id (NOT NULL; CHECK-constrained enums).
   try {
-    const { data: venture } = await supabase
-      .from('eva_ventures')
-      .select('metadata')
-      .eq('id', ventureId)
-      .single();
-
-    const updatedMetadata = {
-      ...(venture?.metadata || {}),
-      gate_retry_context: {
-        fromStage,
-        toStage,
-        reasons,
-        severity: 'non-critical',
-        stored_at: new Date().toISOString(),
-      },
-    };
-
     const { error } = await supabase
-      .from('eva_ventures')
-      .update({ metadata: updatedMetadata })
-      .eq('id', ventureId);
+      .from('eva_event_log')
+      .insert({
+        event_type: 'gate_retry_context',
+        venture_id: ventureId,
+        trigger_source: 'realtime',
+        status: 'failed',
+        correlation_id: randomUUID(),
+        metadata: {
+          fromStage,
+          toStage,
+          reasons,
+          severity: 'non-critical',
+          stored_at: new Date().toISOString(),
+        },
+      });
 
     if (error) {
-      logger.error(`[GateRecovery] Metadata update failed: ${error.message}`);
+      logger.error(`[GateRecovery] Retry-context event write failed: ${error.message}`);
       return { routed: false, path: 'auto_track', error: error.message };
     }
 
@@ -315,12 +314,18 @@ export async function attemptGateRecovery(params, deps) {
 
 async function logRetryEvent(supabase, ventureId, eventData, logger) {
   try {
-    await supabase.from('eva_event_log').insert({
+    // Live columns: metadata (not event_data); trigger_source/status/correlation_id are
+    // NOT NULL with no defaults; CHECK-constrained enums (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
+    const { error } = await supabase.from('eva_event_log').insert({
       venture_id: ventureId,
       event_type: eventData.event,
-      event_data: eventData,
+      trigger_source: 'realtime',
+      status: 'failed',
+      correlation_id: randomUUID(),
+      metadata: eventData,
       created_at: new Date().toISOString(),
     });
+    if (error) logger.warn(`[GateRecovery] Event log failed: ${error.message}`);
   } catch (err) {
     logger.warn(`[GateRecovery] Event log failed: ${err.message}`);
   }

--- a/lib/eva/jobs/okr-monthly-generator.js
+++ b/lib/eva/jobs/okr-monthly-generator.js
@@ -256,29 +256,31 @@ async function gatherTopDownInputs(supabase, visionId, logger) {
     }
   }
 
-  // Source 2: EVA vision gaps table (if exists)
+  // Source 2: EVA vision gaps table.
+  // Live columns: dimension_key + dimension_score — dimension_code/gap_score do not
+  // exist (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data: gapRows } = await supabase
     .from('eva_vision_gaps')
-    .select('dimension_code, dimension_name, gap_score, gap_description')
+    .select('dimension_key, dimension_name, dimension_score, gap_description')
     .eq('status', 'open')
-    .order('gap_score', { ascending: true })
+    .order('dimension_score', { ascending: true })
     .limit(5);
 
   if (gapRows) {
     for (const gap of gapRows) {
       // Avoid duplicates from dimension_scores
-      if (krs.some(kr => kr.vision_dimension_code === gap.dimension_code)) continue;
+      if (krs.some(kr => kr.vision_dimension_code === gap.dimension_key)) continue;
       krs.push({
-        title: `Address gap: ${gap.gap_description?.slice(0, 80) || gap.dimension_name || gap.dimension_code}`,
-        description: `Vision gap in ${gap.dimension_code}: ${gap.gap_description || 'Identified gap'}`,
+        title: `Address gap: ${gap.gap_description?.slice(0, 80) || gap.dimension_name || gap.dimension_key}`,
+        description: `Vision gap in ${gap.dimension_key}: ${gap.gap_description || 'Identified gap'}`,
         metric_type: 'percentage',
-        baseline: gap.gap_score || 0,
-        current: gap.gap_score || 0,
+        baseline: gap.dimension_score || 0,
+        current: gap.dimension_score || 0,
         target: 80,
         unit: '%',
         direction: 'increase',
-        vision_dimension_code: gap.dimension_code,
-        source: { type: 'vision_gap', dimension: gap.dimension_code, gap_score: gap.gap_score },
+        vision_dimension_code: gap.dimension_key,
+        source: { type: 'vision_gap', dimension: gap.dimension_key, gap_score: gap.dimension_score },
       });
     }
   }

--- a/lib/eva/launch-workflow/index.js
+++ b/lib/eva/launch-workflow/index.js
@@ -23,9 +23,11 @@ export async function getLaunchStatus(ventureId, deps = {}) {
   const { supabase } = deps;
   if (!supabase) return { ventureId, status: 'no-client' };
 
+  // Live column is current_lifecycle_stage — eva_ventures has NO current_stage
+  // (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data: venture, error } = await supabase
     .from('eva_ventures')
-    .select('id, name, status, current_stage, created_at, updated_at')
+    .select('id, name, status, current_lifecycle_stage, created_at, updated_at')
     .eq('id', ventureId)
     .maybeSingle();
 
@@ -33,7 +35,7 @@ export async function getLaunchStatus(ventureId, deps = {}) {
     return { ventureId, status: 'not-found', error: error?.message };
   }
 
-  const currentStage = venture.current_stage || 0;
+  const currentStage = venture.current_lifecycle_stage || 0;
   const inLaunchPhase = currentStage >= 23;
 
   // Get latest gate results for launch stages
@@ -148,13 +150,13 @@ export async function getTimeline(ventureId, deps = {}) {
 
   const { data: venture } = await supabase
     .from('eva_ventures')
-    .select('current_stage, created_at')
+    .select('current_lifecycle_stage, created_at')
     .eq('id', ventureId)
     .maybeSingle();
 
   return {
     ventureId,
-    currentStage: venture?.current_stage || 0,
+    currentStage: venture?.current_lifecycle_stage || 0,
     startedAt: venture?.created_at || null,
     events,
     stageCount: events.length,

--- a/lib/eva/operations/domain-handler.js
+++ b/lib/eva/operations/domain-handler.js
@@ -78,16 +78,19 @@ export function registerOperationsHandlers(domainRegistry) {
       total_contracts: (contracts || []).length,
     };
 
+    // Live columns: event_type + metadata (jsonb) — eva_scheduler_metrics has NO
+    // metric_type/metric_value (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
     const snapshot = {
-      metric_type: 'ops_metrics_combined',
-      metric_value: JSON.stringify({
+      event_type: 'ops_metrics_combined',
+      metadata: {
         pipeline: { activeVentures, completedStages6h: completedStages },
         aarrr,
-      }),
-      created_at: new Date().toISOString(),
+      },
+      occurred_at: new Date().toISOString(),
     };
 
-    await supabase.from('eva_scheduler_metrics').insert(snapshot);
+    const { error: insertError } = await supabase.from('eva_scheduler_metrics').insert(snapshot);
+    if (insertError) logger.warn(`[ops_metrics_collect] Metric write failed: ${insertError.message}`);
 
     logger.info(`[ops_metrics_collect] Active: ${activeVentures}, Stages (6h): ${completedStages}, Contracts: ${aarrr.total_contracts}`);
     return snapshot;
@@ -179,12 +182,15 @@ export function registerOperationsHandlers(domainRegistry) {
 
     const status = await getOperationsStatus({ supabase, logger });
 
-    // Persist snapshot to scheduler metrics
-    await supabase.from('eva_scheduler_metrics').insert({
-      metric_type: 'ops_status_snapshot',
-      metric_value: JSON.stringify(status),
-      created_at: status.timestamp,
+    // Persist snapshot to scheduler metrics.
+    // Live columns: event_type + metadata (jsonb) — eva_scheduler_metrics has NO
+    // metric_type/metric_value (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
+    const { error: snapshotError } = await supabase.from('eva_scheduler_metrics').insert({
+      event_type: 'ops_status_snapshot',
+      metadata: status,
+      occurred_at: status.timestamp,
     });
+    if (snapshotError) logger.warn(`[ops_status_snapshot] Metric write failed: ${snapshotError.message}`);
 
     logger.info(`[ops_status_snapshot] Overall: ${status.overall}`);
     return status;

--- a/lib/eva/operations/index.js
+++ b/lib/eva/operations/index.js
@@ -61,9 +61,11 @@ async function getHealthStatus(supabase, logger) {
 async function getMetricsStatus(supabase, logger) {
   if (!supabase) return { subsystem: 'metrics-collector', status: 'no-client' };
 
+  // Live columns: event_type + metadata — eva_scheduler_metrics has NO
+  // metric_type/metric_value (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data, error } = await supabase
     .from('eva_scheduler_metrics')
-    .select('metric_type, metric_value, created_at')
+    .select('event_type, metadata, created_at')
     .order('created_at', { ascending: false })
     .limit(5);
 

--- a/lib/eva/routing-state-machine.js
+++ b/lib/eva/routing-state-machine.js
@@ -14,6 +14,7 @@
  * @module lib/eva/routing-state-machine
  */
 
+import { randomUUID } from 'node:crypto';
 import { ServiceError } from './shared-services.js';
 
 export const MODULE_VERSION = '1.0.0';
@@ -146,13 +147,19 @@ export async function transitionMode(supabase, { ventureId, toMode, triggerReaso
  * @returns {Promise<string>} Event ID
  */
 async function logTransitionEvent(supabase, { ventureId, fromMode, toMode, triggerReason, triggeredBy, isWarning }) {
+  // Live columns: no severity (folded into metadata); trigger_source/status/correlation_id are
+  // NOT NULL with no defaults; CHECKs: trigger_source in (realtime,cron,manual), status in
+  // (succeeded,failed,suppressed); correlation_id is uuid (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data, error } = await supabase
     .from('eva_event_log')
     .insert({
       venture_id: ventureId,
       event_type: 'ROUTING_MODE_TRANSITION',
-      severity: isWarning ? 'warning' : 'info',
+      trigger_source: 'realtime',
+      status: 'succeeded',
+      correlation_id: randomUUID(),
       metadata: {
+        severity: isWarning ? 'warning' : 'info',
         from_mode: fromMode,
         to_mode: toMode,
         trigger_reason: triggerReason,
@@ -186,7 +193,7 @@ async function logTransitionEvent(supabase, { ventureId, fromMode, toMode, trigg
 export async function getTransitionHistory(supabase, ventureId, { limit = 20, mode = null } = {}) {
   let query = supabase
     .from('eva_event_log')
-    .select('id, venture_id, event_type, severity, metadata, created_at')
+    .select('id, venture_id, event_type, metadata, created_at')
     .eq('venture_id', ventureId)
     .eq('event_type', 'ROUTING_MODE_TRANSITION')
     .order('created_at', { ascending: false })

--- a/lib/skunkworks/signal-readers/venture-portfolio.js
+++ b/lib/skunkworks/signal-readers/venture-portfolio.js
@@ -16,10 +16,12 @@ export async function readVenturePortfolioSignals(deps) {
   const signals = [];
 
   try {
-    // Get active ventures with their current stage
+    // Get active ventures with their current stage.
+    // Live columns: current_lifecycle_stage (int) + ai_score — ventures has NO
+    // stage/synthesis_score columns (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
     const { data: ventures, error } = await supabase
       .from('ventures')
-      .select('id, name, status, stage, synthesis_score, updated_at, created_at, metadata')
+      .select('id, name, status, current_lifecycle_stage, ai_score, updated_at, created_at, metadata')
       .in('status', ['active', 'evaluating', 'under_review']);
 
     if (error) {
@@ -46,25 +48,25 @@ export async function readVenturePortfolioSignals(deps) {
           evidence: {
             venture_id: venture.id,
             venture_name: venture.name,
-            stage: venture.stage,
+            stage: venture.current_lifecycle_stage,
             days_inactive: daysSinceUpdate,
             last_updated: venture.updated_at,
-            synthesis_score: venture.synthesis_score,
+            ai_score: venture.ai_score,
           },
           priority: Math.min(85, 40 + daysSinceUpdate),
         });
       }
 
-      // Stuck in early stages (stage <= 2) with low synthesis score
-      if (venture.stage != null && venture.stage <= 2 && venture.synthesis_score != null && venture.synthesis_score < 50) {
+      // Stuck in early stages (stage <= 2) with low AI score
+      if (venture.current_lifecycle_stage != null && venture.current_lifecycle_stage <= 2 && venture.ai_score != null && venture.ai_score < 50) {
         signals.push({
           type: 'venture_portfolio',
           title: `Low-scoring early-stage venture: ${venture.name}`,
           evidence: {
             venture_id: venture.id,
             venture_name: venture.name,
-            stage: venture.stage,
-            synthesis_score: venture.synthesis_score,
+            stage: venture.current_lifecycle_stage,
+            ai_score: venture.ai_score,
           },
           priority: 60,
         });
@@ -74,7 +76,7 @@ export async function readVenturePortfolioSignals(deps) {
     // Portfolio balance check — look for stage concentration
     const stageCounts = {};
     for (const v of ventures) {
-      const s = v.stage || 0;
+      const s = v.current_lifecycle_stage || 0;
       stageCounts[s] = (stageCounts[s] || 0) + 1;
     }
 

--- a/scripts/eva/consultant-analysis-round.mjs
+++ b/scripts/eva/consultant-analysis-round.mjs
@@ -141,12 +141,14 @@ async function analyzeGateCalibration() {
 
 // ─── Domain 3: Capability Delivery Tracking ───────────────────
 async function analyzeCapabilityDelivery() {
+  // Live column is completion_date — strategic_directives_v2 has NO completed_at
+  // (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data: completed } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, sd_type, category, completed_at, key_changes')
+    .select('id, sd_key, title, sd_type, category, completion_date, key_changes')
     .eq('status', 'completed')
-    .gte('completed_at', cutoffDate(60))
-    .order('completed_at', { ascending: false })
+    .gte('completion_date', cutoffDate(60))
+    .order('completion_date', { ascending: false })
     .limit(50);
 
   if (!completed || completed.length === 0) return [];
@@ -180,9 +182,11 @@ async function analyzeCapabilityDelivery() {
 
 // ─── Domain 4: Venture Stage Readiness ────────────────────────
 async function analyzeVentureReadiness() {
+  // Live column is current_lifecycle_stage — ventures has NO current_stage
+  // (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data: ventures } = await supabase
     .from('ventures')
-    .select('id, name, status, current_stage, updated_at')
+    .select('id, name, status, current_lifecycle_stage, updated_at')
     .eq('status', 'active');
 
   if (!ventures || ventures.length === 0) return [];
@@ -195,7 +199,7 @@ async function analyzeVentureReadiness() {
       const daysSinceUpdate = (Date.now() - new Date(v.updated_at).getTime()) / 86400000;
       if (daysSinceUpdate > 30) {
         findings.push({
-          title: `Venture "${v.name}" stalled at stage ${v.current_stage || 'unknown'}`,
+          title: `Venture "${v.name}" stalled at stage ${v.current_lifecycle_stage || 'unknown'}`,
           description: `No progress in ${Math.round(daysSinceUpdate)} days. Consider reviewing blockers or deprioritizing.`,
           dataPoints: 3, // venture + stage + staleness = 3 signals
           domain: 'venture_readiness',
@@ -259,11 +263,12 @@ async function analyzeProtocolHealth() {
 
 // ─── Domain 6: Cross-Venture Capability Reuse Detection ──────
 async function analyzeCrossVentureReuse() {
+  // Live column is completion_date (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data: sds } = await supabase
     .from('strategic_directives_v2')
     .select('id, sd_key, title, key_changes, success_criteria, target_application')
     .eq('status', 'completed')
-    .gte('completed_at', cutoffDate(90))
+    .gte('completion_date', cutoffDate(90))
     .limit(50);
 
   if (!sds || sds.length < 5) return [];

--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -18,6 +18,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
 import { config } from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -446,9 +447,16 @@ export function estimateRetroQualityScore(row = {}) {
 async function logHealLearningFailure(supabase, failing, reason) {
   console.warn(`  ⚠️  Learning capture failed for ${failing.sdKey}: ${reason}`);
   try {
-    await supabase.from('eva_event_log').insert({
+    // Live columns: metadata (not event_data); trigger_source/status/correlation_id are NOT NULL
+    // with no defaults; CHECKs: trigger_source in (realtime,cron,manual), status in
+    // (succeeded,failed,suppressed); correlation_id is uuid (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
+    const { error } = await supabase.from('eva_event_log').insert({
       event_type: 'heal_learning_capture_failed',
-      event_data: {
+      trigger_source: 'manual',
+      status: 'failed',
+      correlation_id: randomUUID(),
+      error_message: String(reason).slice(0, 500),
+      metadata: {
         sd_key: failing.sdKey,
         score_id: failing.scoreId,
         total_score: failing.score,
@@ -456,6 +464,7 @@ async function logHealLearningFailure(supabase, failing, reason) {
         threshold: ACCEPT_THRESHOLD,
       },
     });
+    if (error) console.warn(`  ⚠️  Escalation event write failed: ${error.message}`);
   } catch (_) {
     // Escalation is best-effort; never block.
   }
@@ -554,9 +563,15 @@ async function captureHealLearnings(supabase, failingScores, parsed) {
 
       // 6. Success event (non-blocking telemetry).
       try {
-        await supabase.from('eva_event_log').insert({
+        // Live columns: metadata (not event_data); trigger_source/status/correlation_id are NOT NULL
+        // with no defaults; CHECKs: trigger_source in (realtime,cron,manual), status in
+        // (succeeded,failed,suppressed); correlation_id is uuid (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
+        const { error: emitError } = await supabase.from('eva_event_log').insert({
           event_type: 'heal_learning_captured',
-          event_data: {
+          trigger_source: 'manual',
+          status: 'succeeded',
+          correlation_id: randomUUID(),
+          metadata: {
             sd_key: failing.sdKey,
             total_score: failing.score,
             delta,
@@ -566,6 +581,7 @@ async function captureHealLearnings(supabase, failingScores, parsed) {
             threshold: ACCEPT_THRESHOLD,
           },
         });
+        if (emitError) console.warn(`  ⚠️  Telemetry event write failed: ${emitError.message}`);
       } catch (_) {
         // Never block on telemetry.
       }

--- a/scripts/eva/management-review-round.mjs
+++ b/scripts/eva/management-review-round.mjs
@@ -131,9 +131,11 @@ async function managementReviewHandler(_options = {}) {
   const okrSnapshot = buildOkrSnapshot(objectives, keyResults);
 
   // --- Gather venture data ---
+  // Live column is current_lifecycle_stage — ventures has NO current_stage
+  // (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
   const { data: ventures } = await supabase
     .from('ventures')
-    .select('id, name, status, current_stage')
+    .select('id, name, status, current_lifecycle_stage')
     .eq('status', 'active');
 
   // Table eva_intake_queue does not exist yet
@@ -168,7 +170,7 @@ async function managementReviewHandler(_options = {}) {
 
   lines.push('## Ventures');
   for (const v of ventures || []) {
-    lines.push(`- ${v.name}: Stage ${v.current_stage}`);
+    lines.push(`- ${v.name}: Stage ${v.current_lifecycle_stage}`);
   }
 
   const narrative = lines.join('\n');
@@ -182,7 +184,7 @@ async function managementReviewHandler(_options = {}) {
     planned_sds: baselineData.totalItems || 0,
     actual_sds: completed,
     planned_ventures: (ventures || []).length,
-    actual_ventures: (ventures || []).filter(v => v.current_stage >= 5).length,
+    actual_ventures: (ventures || []).filter(v => v.current_lifecycle_stage >= 5).length,
     okr_snapshot: okrSnapshot,
     pipeline_snapshot: {
       intakePending: (intake || []).length,

--- a/scripts/modules/governance/cascade-validator.js
+++ b/scripts/modules/governance/cascade-validator.js
@@ -15,6 +15,7 @@
  */
 
 
+import { randomUUID } from 'node:crypto';
 import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
 /**
  * Validate cascade alignment for a new SD.
@@ -407,11 +408,17 @@ export async function validateCascadeAtHandoff({
       }
     }
 
-    // Log cascade check to eva_event_log
+    // Log cascade check to eva_event_log.
+    // Live columns: metadata (not event_data); trigger_source/status/correlation_id are NOT NULL
+    // with no defaults; CHECKs: trigger_source in (realtime,cron,manual), status in
+    // (succeeded,failed,suppressed); correlation_id is uuid (SD-LEO-FIX-FIX-PHANTOM-COLUMN-002).
     try {
-      await supabase.from('eva_event_log').insert({
+      const { error: logError } = await supabase.from('eva_event_log').insert({
         event_type: 'cascade_alignment_check',
-        event_data: {
+        trigger_source: 'manual',
+        status: 'succeeded',
+        correlation_id: randomUUID(),
+        metadata: {
           sd_key: sd.sd_key || sd.id,
           parent_sd_key: parent.sd_key,
           handoff_type: handoffType,
@@ -422,6 +429,7 @@ export async function validateCascadeAtHandoff({
         },
         created_at: new Date().toISOString(),
       });
+      if (logError) logger.warn(`[CascadeValidator] Event log failed: ${logError.message}`);
     } catch (logErr) {
       logger.warn(`[CascadeValidator] Event log failed: ${logErr.message}`);
     }

--- a/tests/unit/eva-phantom-column-alignment.test.js
+++ b/tests/unit/eva-phantom-column-alignment.test.js
@@ -1,0 +1,376 @@
+/**
+ * SD-LEO-FIX-FIX-PHANTOM-COLUMN-002 — EVA phantom-column alignment guard.
+ *
+ * TS-1: logEvaAudit writes only live eva_audit_log columns and surfaces errors.
+ * TS-2: static assertions — touched files contain zero phantom column names in
+ *       DB-call context. Live column lists (verified against the EHG_Engineer DB,
+ *       project dedlbzhpgkmetvhbkyzq, 2026-06-10) are embedded as source of truth.
+ * TS-3: vision-gap-detected writes via select-then-insert/update (no onConflict
+ *       upsert — eva_vision_gaps has NO unique constraint on (sd_id, dimension_key)).
+ *
+ * All mocked — NO live writes. The optional live schema smoke is read-only and
+ * runs only when RUN_LIVE_SCHEMA_CHECK=1.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Capture vision-events subscribers so TS-3 can drive the gap-detected writer
+// directly (publishVisionEvent is fire-and-forget). Hoisted by vitest.
+vi.mock('../../lib/eva/event-bus/vision-events.js', () => {
+  const captured = [];
+  return {
+    subscribeVisionEvent: (eventType, handler) => captured.push({ eventType, handler }),
+    VISION_EVENTS: { GAP_DETECTED: 'vision.gap_detected' },
+    __captured: captured,
+  };
+});
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+/**
+ * Read a source file with comments stripped — explanatory comments are allowed
+ * to mention the legacy phantom names; executable code is not.
+ */
+const read = (rel) => readFileSync(path.join(ROOT, rel), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/(^|\s)\/\/.*$/gm, '$1');
+
+// ── Cached live column lists (source of truth, verified 2026-06-10) ──────────
+const LIVE_COLUMNS = {
+  eva_audit_log: ['id', 'eva_venture_id', 'action_type', 'action_source', 'action_data', 'actor_type', 'actor_id', 'created_at'],
+  eva_event_log: ['id', 'event_type', 'trigger_source', 'venture_id', 'correlation_id', 'status', 'error_message', 'job_name', 'scheduled_time', 'metadata', 'created_at'],
+  eva_vision_gaps: ['id', 'vision_score_id', 'sd_id', 'dimension_key', 'dimension_name', 'dimension_score', 'gap_description', 'severity', 'status', 'corrective_sd_id', 'accepted_at', 'accepted_by', 'acceptance_rationale', 'resolved_at', 'resolved_by', 'created_at', 'updated_at'],
+  eva_scheduler_metrics: ['id', 'event_type', 'occurred_at', 'scheduler_instance_id', 'venture_id', 'stage_name', 'outcome', 'failure_reason', 'duration_ms', 'queue_depth', 'dispatched_count', 'paused', 'pause_reason', 'stages_dispatched', 'stages_remaining', 'max_stages_per_cycle', 'metadata', 'created_at'],
+};
+// CHECK-constrained enums on eva_event_log (live):
+const EVENT_LOG_TRIGGER_SOURCES = ['realtime', 'cron', 'manual'];
+const EVENT_LOG_STATUSES = ['succeeded', 'failed', 'suppressed'];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+/** Extract code windows following each `.from('<table>')` call. */
+function fromBlocks(content, table, windowChars = 350) {
+  const needle = `.from('${table}')`;
+  const blocks = [];
+  let idx = content.indexOf(needle);
+  while (idx !== -1) {
+    blocks.push(content.slice(idx, idx + windowChars));
+    idx = content.indexOf(needle, idx + 1);
+  }
+  return blocks;
+}
+
+// ── TS-1: logEvaAudit ─────────────────────────────────────────────────────────
+describe('TS-1: logEvaAudit (eva_audit_log fail-loud writer)', () => {
+  let inserted;
+  const makeClient = (error = null) => ({
+    from(table) {
+      return {
+        insert(row) {
+          inserted = { table, row };
+          return Promise.resolve({ error });
+        },
+      };
+    },
+  });
+
+  beforeEach(() => {
+    inserted = null;
+    vi.restoreAllMocks();
+  });
+
+  it('writes only live eva_audit_log columns', async () => {
+    const { logEvaAudit } = await import('../../lib/eva/event-bus/handlers/_log-eva-audit.js');
+    const result = await logEvaAudit(makeClient(), {
+      eva_venture_id: 'v-1',
+      action_type: 'unit_test',
+      action_data: { a: 1 },
+      actor_type: 'event_bus',
+      actor_id: 'tester',
+    }, { handler: 'UnitTest' });
+
+    expect(result.ok).toBe(true);
+    expect(inserted.table).toBe('eva_audit_log');
+    const keys = Object.keys(inserted.row);
+    for (const key of keys) {
+      expect(LIVE_COLUMNS.eva_audit_log, `phantom column '${key}' written by logEvaAudit`).toContain(key);
+    }
+    // Phantom legacy names must never appear
+    expect(keys).not.toContain('venture_id');
+    expect(keys).not.toContain('details');
+    expect(keys).not.toContain('actor');
+    expect(inserted.row.eva_venture_id).toBe('v-1');
+    expect(inserted.row.action_data).toEqual({ a: 1 });
+    expect(inserted.row.actor_type).toBe('event_bus');
+  });
+
+  it('surfaces insert errors via console.warn and returns ok:false', async () => {
+    const { logEvaAudit } = await import('../../lib/eva/event-bus/handlers/_log-eva-audit.js');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await logEvaAudit(makeClient({ message: 'column does not exist' }), {
+      eva_venture_id: 'v-2',
+      action_type: 'unit_test_fail',
+    }, { handler: 'UnitTest' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error.message).toBe('column does not exist');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('UnitTest');
+    expect(warnSpy.mock.calls[0][0]).toContain('unit_test_fail');
+  });
+});
+
+// ── TS-2: static phantom-column assertions ────────────────────────────────────
+describe('TS-2: no phantom columns in DB-call context (static)', () => {
+  const AUDIT_HANDLER_FILES = [
+    'lib/eva/event-bus/handlers/budget-exceeded.js',
+    'lib/eva/event-bus/handlers/chairman-override.js',
+    'lib/eva/event-bus/handlers/venture-created.js',
+    'lib/eva/event-bus/handlers/stage-failed.js',
+    'lib/eva/event-bus/handlers/venture-killed.js',
+    'lib/eva/event-bus/handlers/gate-evaluated.js',
+    'lib/eva/event-bus/handlers/sd-completed.js',
+  ];
+
+  it('all eva_audit_log writes route through logEvaAudit (no direct inserts)', () => {
+    for (const file of AUDIT_HANDLER_FILES) {
+      const content = read(file);
+      expect(content, `${file} must not call eva_audit_log directly`).not.toContain(".from('eva_audit_log')");
+      expect(content, `${file} must use the logEvaAudit helper`).toContain('logEvaAudit(');
+    }
+    // The helper itself is the single writer and uses only live columns
+    const helper = read('lib/eva/event-bus/handlers/_log-eva-audit.js');
+    expect(helper).toContain("from('eva_audit_log')");
+    expect(helper).toContain('eva_venture_id');
+    expect(helper).toMatch(/if \(error\)/);
+  });
+
+  const EVENT_LOG_FILES = [
+    'scripts/eva/heal-command.mjs',
+    'scripts/modules/governance/cascade-validator.js',
+    'lib/agents/venture-ceo/handlers.js',
+    'lib/eva/dfe-gate-escalation-router.js',
+    'lib/eva/analysis-history.js',
+    'lib/eva/routing-state-machine.js',
+    'lib/eva/gate-failure-recovery.js',
+  ];
+
+  it('eva_event_log writers use metadata + NOT NULL columns, never event_data/payload/severity', () => {
+    for (const file of EVENT_LOG_FILES) {
+      const content = read(file);
+      const blocks = fromBlocks(content, 'eva_event_log', 700);
+      expect(blocks.length, `${file} should reference eva_event_log`).toBeGreaterThan(0);
+
+      for (const block of blocks) {
+        if (block.includes('.insert(')) {
+          // Required NOT NULL columns (no DB defaults)
+          expect(block, `${file}: insert missing trigger_source`).toMatch(/trigger_source:/);
+          expect(block, `${file}: insert missing status`).toMatch(/status:/);
+          expect(block, `${file}: insert missing correlation_id`).toMatch(/correlation_id:/);
+          expect(block, `${file}: insert missing metadata`).toMatch(/metadata:/);
+          // Phantom names must not appear as insert columns before the metadata payload
+          const head = block.slice(0, block.indexOf('metadata:'));
+          expect(head, `${file}: phantom event_data in insert`).not.toMatch(/event_data:/);
+          expect(head, `${file}: phantom payload column in insert`).not.toMatch(/payload:/);
+          expect(head, `${file}: phantom severity column in insert`).not.toMatch(/severity:/);
+          // CHECK-constrained enum literals must be valid
+          const ts = block.match(/trigger_source:\s*'([a-z_]+)'/);
+          if (ts) expect(EVENT_LOG_TRIGGER_SOURCES, `${file}: invalid trigger_source '${ts[1]}'`).toContain(ts[1]);
+          const st = block.match(/status:\s*'([a-z_]+)'/);
+          if (st) expect(EVENT_LOG_STATUSES, `${file}: invalid status '${st[1]}'`).toContain(st[1]);
+        }
+        if (block.includes('.select(')) {
+          const sel = block.match(/\.select\('([^']*)'/);
+          if (sel) {
+            expect(sel[1], `${file}: phantom column in eva_event_log select`).not.toMatch(/payload|event_data|severity/);
+          }
+        }
+      }
+      // No file may reference the phantom event_data column at all
+      expect(content, `${file}: stray event_data reference`).not.toMatch(/\bevent_data\b/);
+    }
+  });
+
+  it('eva_vision_gaps writers/readers use live column names', () => {
+    const checks = [
+      { file: 'lib/eva/event-bus/handlers/vision-gap-detected.js', forbid: [/\bdimension_id\b/, /\bscore_id\b/, /\bdetected_at\b/, /onConflict/, /\.upsert\(/], require: ['dimension_key', 'dimension_score', 'vision_score_id'] },
+      { file: 'lib/eva/event-bus/handlers/vision-corrective-sd-created.js', forbid: [/corrective_sd_key/, /\bdimension_id\b/], require: ['corrective_sd_id', 'dimension_key'] },
+      { file: 'lib/eva/event-bus/handlers/vision-gap-accepted.js', forbid: [/resolution_notes/, /\bdimension_id\b/], require: ['acceptance_rationale', 'accepted_at', 'dimension_key'] },
+      { file: 'lib/eva/event-bus/handlers/vision-rescore-completed.js', forbid: [/\bdimension_id\b/, /corrective_sd_key/], require: ['dimension_key', 'dimension_score'] },
+      { file: 'lib/eva/escalation-event-persister.js', forbid: [/corrective_sd_key/, /dimension_label/, /gap_severity/, /current_score/, /target_score/], require: ['corrective_sd_id', 'dimension_score'] },
+      { file: 'lib/eva/jobs/okr-monthly-generator.js', forbid: [/\bdimension_code\b/, /\.order\('gap_score'/, /select\('[^']*gap_score/], require: ['dimension_key', 'dimension_score'] },
+    ];
+    for (const { file, forbid, require: req } of checks) {
+      const content = read(file);
+      for (const re of forbid) {
+        expect(content, `${file}: phantom pattern ${re}`).not.toMatch(re);
+      }
+      for (const needle of req) {
+        expect(content, `${file}: missing live column ${needle}`).toContain(needle);
+      }
+    }
+  });
+
+  it('eva_scheduler_metrics writers/readers use event_type + metadata', () => {
+    for (const file of ['lib/eva/operations/domain-handler.js', 'lib/eva/operations/index.js']) {
+      const content = read(file);
+      expect(content, `${file}: phantom metric_type`).not.toMatch(/metric_type/);
+      expect(content, `${file}: phantom metric_value`).not.toMatch(/metric_value/);
+    }
+    const dh = read('lib/eva/operations/domain-handler.js');
+    expect(dh).toMatch(/event_type: 'ops_metrics_combined'/);
+    expect(dh).toMatch(/event_type: 'ops_status_snapshot'/);
+  });
+
+  it('strategic_directives_v2 reads use completion_date, ventures reads use current_lifecycle_stage', () => {
+    const car = read('scripts/eva/consultant-analysis-round.mjs');
+    expect(car, 'consultant-analysis-round: phantom completed_at').not.toMatch(/completed_at/);
+    expect(car).toContain('completion_date');
+
+    for (const file of ['scripts/eva/consultant-analysis-round.mjs', 'scripts/eva/management-review-round.mjs', 'lib/eva/launch-workflow/index.js']) {
+      const content = read(file);
+      expect(content, `${file}: phantom current_stage`).not.toMatch(/current_stage\b/);
+      expect(content).toContain('current_lifecycle_stage');
+    }
+
+    const vp = read('lib/skunkworks/signal-readers/venture-portfolio.js');
+    expect(vp, 'venture-portfolio: phantom synthesis_score').not.toMatch(/synthesis_score/);
+    expect(vp, 'venture-portfolio: phantom bare stage select').not.toMatch(/select\('[^']*[, ]stage[, ']/);
+    expect(vp).toContain('current_lifecycle_stage');
+    expect(vp).toContain('ai_score');
+  });
+
+  it('eva_vision_documents / eva_architecture_plans writes carry no phantom metadata key', () => {
+    const content = read('lib/eva/artifact-persistence-service.js');
+    for (const table of ['eva_vision_documents', 'eva_architecture_plans']) {
+      for (const block of fromBlocks(content, table, 420)) {
+        if (block.includes('.insert(') || block.includes('.update(')) {
+          expect(block, `${table} write still carries phantom metadata key`).not.toMatch(/\bmetadata:\s/);
+        }
+      }
+    }
+    // Errors are now captured on all four statements
+    expect(content).toMatch(/eva_vision_documents update failed/);
+    expect(content).toMatch(/eva_vision_documents insert failed/);
+    expect(content).toMatch(/eva_architecture_plans update failed/);
+    expect(content).toMatch(/eva_architecture_plans insert failed/);
+  });
+
+  it('gate-failure-recovery stashes retry context in eva_event_log, not eva_ventures.metadata', () => {
+    const content = read('lib/eva/gate-failure-recovery.js');
+    expect(content).not.toMatch(/eva_ventures'\)[\s\S]{0,80}\.select\('metadata'\)/);
+    expect(content).not.toMatch(/\.update\(\{ metadata/);
+    expect(content).toContain("event_type: 'gate_retry_context'");
+  });
+});
+
+// ── TS-3: vision-gap-detected select-then-insert/update ──────────────────────
+describe('TS-3: vision-gap-detected write path (mocked)', () => {
+  function makeGapClient({ existingId = null } = {}) {
+    const calls = { inserts: [], updates: [], upserts: [], selects: 0 };
+    const client = {
+      from(table) {
+        const ctx = { table, op: null, updateRow: null, eqs: [] };
+        const builder = {
+          select() { ctx.op = 'select'; return builder; },
+          insert(row) { calls.inserts.push({ table, row }); return Promise.resolve({ error: null }); },
+          upsert(row, opts) { calls.upserts.push({ table, row, opts }); return Promise.resolve({ error: null }); },
+          update(row) { ctx.op = 'update'; ctx.updateRow = row; return builder; },
+          eq(col, val) { ctx.eqs.push([col, val]); return builder; },
+          limit() { return builder; },
+          maybeSingle() {
+            calls.selects += 1;
+            return Promise.resolve({ data: existingId ? { id: existingId } : null, error: null });
+          },
+          then(resolve, reject) {
+            if (ctx.op === 'update') calls.updates.push({ table, row: ctx.updateRow, eqs: ctx.eqs });
+            return Promise.resolve({ error: null }).then(resolve, reject);
+          },
+        };
+        return builder;
+      },
+    };
+    return { client, calls };
+  }
+
+  async function getGapWriter() {
+    const visionEvents = await import('../../lib/eva/event-bus/vision-events.js');
+    const mod = await import('../../lib/eva/event-bus/handlers/vision-gap-detected.js');
+    mod._resetVisionGapDetectedHandlers();
+    visionEvents.__captured.length = 0;
+    mod.registerVisionGapDetectedHandlers();
+    // Subscriber 2 is the DB writer (subscriber 1 is the console logger)
+    const writer = visionEvents.__captured[1];
+    expect(writer).toBeDefined();
+    return writer.handler;
+  }
+
+  it('inserts a new gap with live columns when none exists', async () => {
+    const handler = await getGapWriter();
+    const { client, calls } = makeGapClient({ existingId: null });
+
+    await handler({ sdKey: 'SD-X-001', dimension: 'tech_depth', dimId: 'dim_tech', score: 42, threshold: 70, scoreId: null, supabase: client });
+
+    expect(calls.upserts).toHaveLength(0);
+    expect(calls.updates).toHaveLength(0);
+    expect(calls.inserts).toHaveLength(1);
+    const row = calls.inserts[0].row;
+    expect(row).toEqual({
+      sd_id: 'SD-X-001',
+      dimension_key: 'dim_tech',
+      dimension_name: 'tech_depth',
+      dimension_score: 42,
+      vision_score_id: null,
+      status: 'open',
+    });
+    for (const key of Object.keys(row)) {
+      expect(LIVE_COLUMNS.eva_vision_gaps, `phantom column '${key}' in gap insert`).toContain(key);
+    }
+  });
+
+  it('updates the existing gap row when one exists (no onConflict anywhere)', async () => {
+    const handler = await getGapWriter();
+    const { client, calls } = makeGapClient({ existingId: 'gap-1' });
+
+    await handler({ sdKey: 'SD-X-001', dimension: 'tech_depth', dimId: 'dim_tech', score: 55, threshold: 70, scoreId: 'b8a8f1e2-0000-4000-8000-000000000001', supabase: client });
+
+    expect(calls.upserts).toHaveLength(0);
+    expect(calls.inserts).toHaveLength(0);
+    expect(calls.updates).toHaveLength(1);
+    const { row, eqs } = calls.updates[0];
+    expect(eqs).toContainEqual(['id', 'gap-1']);
+    expect(row.dimension_key).toBe('dim_tech');
+    expect(row.dimension_score).toBe(55);
+    expect(row.vision_score_id).toBe('b8a8f1e2-0000-4000-8000-000000000001');
+    expect(row).not.toHaveProperty('dimension_id');
+    expect(row).not.toHaveProperty('score');
+    expect(row).not.toHaveProperty('threshold');
+    expect(row).not.toHaveProperty('detected_at');
+  });
+});
+
+// ── Optional read-only live schema smoke (opt-in) ─────────────────────────────
+describe.skipIf(process.env.RUN_LIVE_SCHEMA_CHECK !== '1')('live schema smoke (read-only, opt-in)', () => {
+  it('verifies the embedded column lists against the live engineer DB', async () => {
+    const { createDatabaseClient } = await import('../../lib/supabase-connection.js');
+    const client = await createDatabaseClient('engineer', { verify: false });
+    try {
+      const tables = Object.keys(LIVE_COLUMNS);
+      const res = await client.query(
+        "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema='public' AND table_name = ANY($1)",
+        [tables],
+      );
+      const live = {};
+      for (const r of res.rows) (live[r.table_name] ||= new Set()).add(r.column_name);
+      for (const [table, columns] of Object.entries(LIVE_COLUMNS)) {
+        for (const column of columns) {
+          expect(live[table]?.has(column), `${table}.${column} missing in live DB`).toBe(true);
+        }
+      }
+    } finally {
+      await client.end();
+    }
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

Live EVA paths wrote/read **columns that do not exist** in the EHG_Engineer DB, silently losing audit trails, event logs, vision-gap records and the entire L2 synthesis persistence (chairman-directed data-layer scan; **every claimed site re-verified against `information_schema` before fixing** — 4 claims refuted, cross-DB caveat resolved: all clients target EHG_Engineer, so every fix is ALIGN/DELETE, zero ROUTE, **zero migrations**).

- **FR-1 `eva_audit_log`** — NEW shared `_log-eva-audit.js` helper writing the real columns (`eva_venture_id`/`action_data`/`actor_type`) and **warning on insert failure**; 7 event-bus handlers routed through it (5 were writing phantom columns silently, 2 gain error capture)
- **FR-2 `eva_event_log`** — `event_data`/`payload`→`metadata`, `severity` folded into metadata, and the **NOT-NULL `trigger_source`/`status`/`correlation_id` now supplied by every writer** (a pure rename was insufficient)
- **FR-3 read paths** — `ventures.stage`/`current_stage`→`current_lifecycle_stage` (the skunkworks portfolio reader was fully dead — its select 42703'd and returned `[]`), `synthesis_score`→`ai_score`, SDv2 `completed_at`→`completion_date`
- **FR-4 `eva_vision_gaps`** — 6 writers aligned (`dimension_key`/`dimension_score`/`corrective_sd_id`/`acceptance_rationale`/`severity`/`dimension_name`); the **invalid upsert** (onConflict on a unique constraint that doesn't exist) replaced with select-then-write
- **FR-5** — scheduler metrics `metric_type`/`metric_value`→`event_type`/`metadata` (writer + route reader); **artifact-persistence phantom `metadata` key deleted from 4 statements — it was silently failing the ENTIRE insert/update, so L2 vision/arch synthesis never persisted**; gate-failure-recovery retry stash redirected from the non-existent `eva_ventures.metadata` to an `eva_event_log` event; launch-workflow stage align

Refuted (untouched): `stage19.js`, stage-21/23 story fixtures, `feedback_weight` (lives on `eva_consultant_trends`), `venture_artifacts.stage_number`. Descoped with rationale: `genesis_deployments` cluster (needs a venture-linkage migration — follow-up SD), `venture-test-flowback.js` (dead + CHECK-violating), `srip/venture-integration.mjs` (unwired).

## Verification

- NEW `tests/unit/eva-phantom-column-alignment.test.js`: 11 pass + 1 graceful live-skip — payload-vs-cached-live-column-list guards, a **static phantom-name guard across all touched files** (fails CI on regression), vision-gap de-upsert both paths
- All 15 touched lib files runtime-import OK
- `vision-event-bus.test.js` 2 failures **pre-exist on base** (stash round-trip verified)

## PR Size

~313 insertions / 183 deletions across 28 files — above the 100-LOC target with justification: a single fix-shape (column alignment + error capture) applied across one defect class; splitting per-table would ship the static guard test piecemeal and leave half the silent-loss sites live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)