### PR TITLE
feat(sre): standing row-growth anomaly gauge for governance tables

### DIFF
--- a/lib/coordinator/row-growth.cjs
+++ b/lib/coordinator/row-growth.cjs
@@ -1,0 +1,158 @@
+/**
+ * Standing row-growth anomaly detection — SD-LEO-INFRA-STANDING-ROW-GROWTH-001.
+ *
+ * Runaway table growth was discovered by accident: management_reviews reached
+ * 45k duplicate rows and sd_baseline_items 13k orphans before anyone noticed.
+ * This module gives the coordinator's detector family a standing gauge:
+ * a daily snapshot of estimated row counts for the governance tables, persisted
+ * as a coordination_events series, with pure anomaly predicates over consecutive
+ * snapshots (growth factor and absolute-spike thresholds).
+ *
+ * Doctrine matches lib/coordinator/detectors.cjs: detection logic is PURE over
+ * injected data; the thin IO helpers here do only PostgREST reads/writes and are
+ * fail-open. Counts use PostgREST estimated head counts (pg statistics — the
+ * same source as pg_class.reltuples) so a snapshot costs one cheap HEAD request
+ * per table, never COUNT(*).
+ *
+ * @module lib/coordinator/row-growth
+ */
+'use strict';
+
+/** Snapshot cadence gate: due when the last snapshot is older than this. */
+const SNAPSHOT_DUE_MS = 22 * 60 * 60 * 1000; // 22h => once per daily cron tick, tolerant of jitter
+
+/** coordination_events event types written by this gauge. */
+const SNAPSHOT_EVENT_TYPE = 'ROW_GROWTH_SNAPSHOT';
+const ANOMALY_EVENT_TYPE = 'ROW_GROWTH_ANOMALY';
+
+/**
+ * Curated governance-table set (the SD's titled scope). Both motivating
+ * incidents (management_reviews 45k, sd_baseline_items 13k) are members.
+ * Extend freely — unknown tables fail-soft to a null estimate and are skipped.
+ */
+const GOVERNANCE_TABLES = [
+  'strategic_directives_v2',
+  'product_requirements_v2',
+  'user_stories',
+  'sd_phase_handoffs',
+  'sd_baseline_items',
+  'sd_backlog_map',
+  'sub_agent_execution_results',
+  'retrospectives',
+  'feedback',
+  'issue_patterns',
+  'quick_fixes',
+  'claude_sessions',
+  'session_coordination',
+  'coordination_events',
+  'management_reviews',
+  'objectives',
+  'key_results',
+  'okr_generation_log',
+  'leo_protocol_sections',
+  'validation_audit_log',
+  'eva_scheduler_metrics',
+  'learning_decisions',
+];
+
+/** Default anomaly thresholds. */
+const DEFAULT_OPTS = Object.freeze({
+  growthFactor: 1.5,   // matched when current >= prev * growthFactor ...
+  minRowsForFactor: 500, // ...but only once a table is big enough that factors mean something
+  absSpike: 5000,      // OR matched when current - prev >= absSpike regardless of factor
+});
+
+/**
+ * PURE: detect per-table growth anomalies between two snapshots.
+ * A snapshot is { captured_at: ISO string, tables: { [name]: number } }.
+ * Negative growth (cleanup) never matches. Tables absent from either snapshot
+ * are skipped (new/removed tables are inventory changes, not growth anomalies).
+ *
+ * @param {{captured_at?:string, tables:Object<string,number>}|null} prev
+ * @param {{captured_at?:string, tables:Object<string,number>}} curr
+ * @param {{growthFactor?:number, minRowsForFactor?:number, absSpike?:number}} [opts]
+ * @returns {Array<{table:string, prev:number, curr:number, delta:number, factor:number|null, trigger:'growth_factor'|'abs_spike'}>}
+ */
+function detectRowGrowthAnomalies(prev, curr, opts = {}) {
+  const o = { ...DEFAULT_OPTS, ...opts };
+  const anomalies = [];
+  if (!prev || !prev.tables || !curr || !curr.tables) return anomalies;
+  for (const [table, currRaw] of Object.entries(curr.tables)) {
+    const prevRaw = prev.tables[table];
+    if (!Number.isFinite(prevRaw) || !Number.isFinite(currRaw)) continue;
+    const delta = currRaw - prevRaw;
+    if (delta <= 0) continue; // shrink/steady is never an anomaly here
+    const factor = prevRaw > 0 ? currRaw / prevRaw : null;
+    if (delta >= o.absSpike) {
+      anomalies.push({ table, prev: prevRaw, curr: currRaw, delta, factor, trigger: 'abs_spike' });
+    } else if (prevRaw >= o.minRowsForFactor && factor !== null && factor >= o.growthFactor) {
+      anomalies.push({ table, prev: prevRaw, curr: currRaw, delta, factor, trigger: 'growth_factor' });
+    }
+  }
+  return anomalies.sort((a, b) => b.delta - a.delta);
+}
+
+/**
+ * PURE: is a new snapshot due?
+ * @param {string|null} lastCapturedAt - ISO timestamp of the latest snapshot (or null)
+ * @param {number} nowMs
+ * @param {number} [dueMs]
+ * @returns {boolean}
+ */
+function isSnapshotDue(lastCapturedAt, nowMs, dueMs = SNAPSHOT_DUE_MS) {
+  if (!lastCapturedAt) return true;
+  const t = new Date(/Z$|[+-]\d{2}:?\d{2}$/.test(String(lastCapturedAt)) ? lastCapturedAt : lastCapturedAt + 'Z').getTime();
+  if (!Number.isFinite(t)) return true;
+  return nowMs - t >= dueMs;
+}
+
+/**
+ * IO (fail-soft): estimated row counts for a table list via PostgREST
+ * head+estimated (pg statistics, no COUNT(*) scan). A table that errors
+ * (missing, RLS) is skipped — never throws.
+ * @param {object} sb - supabase client
+ * @param {string[]} [tables]
+ * @returns {Promise<Object<string, number>>}
+ */
+async function readTableEstimates(sb, tables = GOVERNANCE_TABLES) {
+  const out = {};
+  for (const t of tables) {
+    try {
+      const { count, error } = await sb.from(t).select('*', { count: 'estimated', head: true });
+      if (!error && Number.isFinite(count)) out[t] = count;
+    } catch { /* fail-soft: skip table */ }
+  }
+  return out;
+}
+
+/**
+ * IO (fail-soft): latest persisted snapshot event, or null.
+ * @param {object} sb
+ * @returns {Promise<{captured_at:string, tables:Object<string,number>}|null>}
+ */
+async function readLatestSnapshot(sb) {
+  try {
+    const { data, error } = await sb
+      .from('coordination_events')
+      .select('payload, created_at')
+      .eq('event_type', SNAPSHOT_EVENT_TYPE)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error || !data || !data.length) return null;
+    const p = data[0].payload || {};
+    if (!p.tables) return null;
+    return { captured_at: p.captured_at || data[0].created_at, tables: p.tables };
+  } catch { return null; }
+}
+
+module.exports = {
+  GOVERNANCE_TABLES,
+  DEFAULT_OPTS,
+  SNAPSHOT_DUE_MS,
+  SNAPSHOT_EVENT_TYPE,
+  ANOMALY_EVENT_TYPE,
+  detectRowGrowthAnomalies,
+  isSnapshotDue,
+  readTableEstimates,
+  readLatestSnapshot,
+};

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -41,7 +41,9 @@ const COORDINATOR_CRONS = [
   { key: 'inbox',     cadence: '*/2 * * * *',                                command: 'node scripts/fleet-dashboard.cjs inbox',  re_asserts_pointer: true },
   // email: coordinator-confirmed command (coordinator signal 2026-06-06 01:42). Non-critical for
   // the re-assert bug (does not touch the pointer) but still a coordinator cron teardown must remove.
-  { key: 'email',     cadence: '7,22,37,52 * * * *',                         command: 'node scripts/coordinator-email-summary.mjs', re_asserts_pointer: false }
+  { key: 'email',     cadence: '7,22,37,52 * * * *',                         command: 'node scripts/coordinator-email-summary.mjs', re_asserts_pointer: false },
+  // SD-LEO-INFRA-STANDING-ROW-GROWTH-001: daily governance row-growth gauge (internally due-gated).
+  { key: 'row-growth', cadence: '30 8 * * *',                                command: 'node scripts/row-growth-snapshot.cjs',      re_asserts_pointer: false }
 ];
 
 // Basename markers used to recognise coordinator-owned jobs in a CronList() result. The
@@ -52,7 +54,8 @@ const COORD_SCRIPT_MARKERS = [
   'stale-session-sweep.cjs',
   'fleet-dashboard.cjs',
   'assign-fleet-identities.cjs',
-  'coordinator-email-summary.mjs'
+  'coordinator-email-summary.mjs',
+  'row-growth-snapshot.cjs'
 ];
 
 function isEnabled() {

--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -33,13 +33,13 @@ afterEach(() => {
 });
 
 describe('teardown-coordinator: inventory + matcher', () => {
-  it('listCoordinatorCrons enumerates all 5 coordinator crons incl the pointer-re-asserting inbox loop', () => {
+  it('listCoordinatorCrons enumerates all 6 coordinator crons incl the pointer-re-asserting inbox loop', () => {
     const crons = listCoordinatorCrons();
-    expect(crons.length).toBe(5);
+    expect(crons.length).toBe(6); // +row-growth (SD-LEO-INFRA-STANDING-ROW-GROWTH-001)
     const inbox = crons.find((c) => c.key === 'inbox');
     expect(inbox).toBeTruthy();
     expect(inbox.re_asserts_pointer).toBe(true); // the crux: missing this cron self-reverses teardown
-    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email']);
+    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth']);
   });
 
   it('TS-6: selectCoordinatorCronJobs matches coordinator crons (incl inbox via fleet-dashboard.cjs marker) and excludes non-coordinator jobs', () => {
@@ -76,7 +76,7 @@ describe('teardown-coordinator: clearCoordinatorPointer', () => {
     expect(res.enabled).toBe(true);
     expect(res.refused).toBe(false);
     expect(res.pointer_cleared).toBe(true);
-    expect(res.crons_to_delete.length).toBe(5);
+    expect(res.crons_to_delete.length).toBe(6); // +row-growth (SD-LEO-INFRA-STANDING-ROW-GROWTH-001)
     expect(fs.existsSync(tmpPointer)).toBe(false); // pointer file removed
   });
 

--- a/package.json
+++ b/package.json
@@ -374,6 +374,7 @@
     "session:park": "node scripts/park-worker.cjs",
     "prepark-wip": "node scripts/prepark-wip.cjs",
     "protocol:pub-audit": "node scripts/protocol-publication-audit.cjs",
+    "sre:row-growth": "node scripts/row-growth-snapshot.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "engine:demo": "node scripts/auto-exec-engine-demo.mjs",
     "checkout-sync:demo": "node scripts/auto-exec-checkout-sync-demo.mjs",

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -68,6 +68,14 @@ export const STANDARD_LOOPS = [
   // Cheap read+insert; */30 captures session_coordination FLEET-RETRO signals before they are swept.
   { key: 'fleet-retro',  label: 'Worker fleet-retro (periodic capture/synthesis)', script: 'coordinator-fleet-retro.mjs', cron: '*/30 * * * *',
     prompt: 'node scripts/coordinator-fleet-retro.mjs' },
+  // SD-LEO-INFRA-STANDING-ROW-GROWTH-001: daily governance-table row-growth gauge.
+  // Snapshots estimated row counts (PostgREST head+estimated — pg statistics, no COUNT(*))
+  // into a coordination_events baseline series and alerts the coordinator inbox on
+  // growth-factor / absolute-spike anomalies between consecutive snapshots. Internally
+  // due-gated (~22h), so an extra arm or manual run is a cheap no-op. Catches the
+  // management_reviews-45k / sd_baseline_items-13k class within a day, not by accident.
+  { key: 'row-growth',  label: 'Governance row-growth gauge (daily)', script: 'row-growth-snapshot.cjs', cron: '30 8 * * *',
+    prompt: 'node scripts/row-growth-snapshot.cjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/scripts/row-growth-snapshot.cjs
+++ b/scripts/row-growth-snapshot.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Row-growth snapshot + anomaly gauge CLI — SD-LEO-INFRA-STANDING-ROW-GROWTH-001.
+ *
+ * Daily standing SRE gauge for the governance tables:
+ *   1. Due-gate: skip unless the latest ROW_GROWTH_SNAPSHOT coordination event
+ *      is older than ~22h (or --force).
+ *   2. Snapshot estimated row counts (PostgREST head+estimated — pg statistics,
+ *      no COUNT(*)) for lib/coordinator/row-growth.cjs GOVERNANCE_TABLES.
+ *   3. Persist the snapshot as a coordination_events row (the baseline series).
+ *   4. Run the pure anomaly detector vs the previous snapshot; on anomalies,
+ *      write a ROW_GROWTH_ANOMALY event AND a coordinator-inbox row
+ *      (session_coordination INFO) so the alert lands where the coordinator looks.
+ *
+ * Scheduling: armed daily by the coordinator (see coordinator-startup-check.mjs
+ * cron specs). Safe to run ad-hoc: npm run sre:row-growth [-- --force]
+ * ALWAYS exits 0 on operational paths (a gauge must never break its host loop).
+ */
+'use strict';
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const {
+  GOVERNANCE_TABLES,
+  SNAPSHOT_EVENT_TYPE,
+  ANOMALY_EVENT_TYPE,
+  detectRowGrowthAnomalies,
+  isSnapshotDue,
+  readTableEstimates,
+  readLatestSnapshot,
+} = require('../lib/coordinator/row-growth.cjs');
+
+async function resolveCoordinatorId(sb) {
+  try {
+    const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+    return await getActiveCoordinatorId(sb);
+  } catch { return null; }
+}
+
+async function main() {
+  const force = process.argv.includes('--force');
+  const sb = createSupabaseServiceClient();
+
+  const prev = await readLatestSnapshot(sb);
+  if (!force && prev && !isSnapshotDue(prev.captured_at, Date.now())) {
+    console.log(`[row-growth] not due (last snapshot ${prev.captured_at}) — no-op`);
+    return;
+  }
+
+  const tables = await readTableEstimates(sb, GOVERNANCE_TABLES);
+  const tableCount = Object.keys(tables).length;
+  if (tableCount === 0) {
+    console.warn('[row-growth] no table estimates readable — skipping (fail-open)');
+    return;
+  }
+  const captured_at = new Date().toISOString();
+  const snapshot = { captured_at, tables };
+
+  // Persist the baseline point (non-fatal on failure — next run retries).
+  try {
+    const { error } = await sb.from('coordination_events').insert({
+      event_type: SNAPSHOT_EVENT_TYPE,
+      severity: 'info',
+      payload: snapshot,
+    });
+    if (error) console.warn(`[row-growth] snapshot persist failed (non-fatal): ${error.message}`);
+  } catch (e) { console.warn(`[row-growth] snapshot persist threw (non-fatal): ${e.message}`); }
+
+  console.log(`[row-growth] snapshot captured: ${tableCount} tables @ ${captured_at}${prev ? ` (prev ${prev.captured_at})` : ' (first baseline — no anomaly check)'}`);
+
+  if (!prev) return;
+
+  const anomalies = detectRowGrowthAnomalies(prev, snapshot);
+  if (anomalies.length === 0) {
+    console.log('[row-growth] no growth anomalies');
+    return;
+  }
+
+  console.log(`[row-growth] ⚠️  ${anomalies.length} growth anomalie(s):`);
+  for (const a of anomalies) {
+    console.log(`   - ${a.table}: ${a.prev} -> ${a.curr} (+${a.delta}${a.factor ? `, x${a.factor.toFixed(2)}` : ''}) [${a.trigger}]`);
+  }
+
+  // Alert leg 1: durable detector event.
+  try {
+    await sb.from('coordination_events').insert({
+      event_type: ANOMALY_EVENT_TYPE,
+      severity: 'warning',
+      payload: { captured_at, anomalies, window: { prev: prev.captured_at, curr: captured_at } },
+    });
+  } catch (e) { console.warn(`[row-growth] anomaly event failed (non-fatal): ${e.message}`); }
+
+  // Alert leg 2: coordinator inbox row (where the fleet actually looks).
+  try {
+    const coordinatorId = await resolveCoordinatorId(sb);
+    const top = anomalies[0];
+    await sb.from('session_coordination').insert({
+      target_session: coordinatorId, // null => broadcast row, still visible in inbox scans
+      message_type: 'INFO',
+      subject: `[ROW_GROWTH] ${anomalies.length} table(s) growing abnormally — top: ${top.table} +${top.delta}`,
+      body: anomalies.map((a) => `${a.table}: ${a.prev} -> ${a.curr} (+${a.delta}${a.factor ? `, x${a.factor.toFixed(2)}` : ''}) [${a.trigger}]`).join('\n'),
+      payload: { kind: 'row_growth_anomaly', anomalies },
+      sender_type: 'system',
+      expires_at: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(),
+    });
+  } catch (e) { console.warn(`[row-growth] inbox alert failed (non-fatal): ${e.message}`); }
+}
+
+if (require.main === module) {
+  // Graceful bounded exit (SD-FDBK-INFRA-SWEEP-CLI-EXIT-001 primitive): a direct
+  // process.exit() after Supabase/undici queries aborts on Windows (UV_HANDLE_CLOSING),
+  // and no exit at all risks hanging to the caller's timeout. armCliTeardown closes idle
+  // sockets and lets the loop drain naturally, with an unref'd 8s backstop. Exit code is
+  // always 0 — a gauge never breaks its host loop.
+  main()
+    .catch((e) => { console.warn(`[row-growth] unexpected error (non-fatal): ${e.message}`); })
+    .finally(async () => {
+      try {
+        const { armCliTeardown } = await import('../lib/cli-graceful-exit.js');
+        await armCliTeardown(0);
+      } catch { process.exitCode = 0; /* helper missing — natural drain */ }
+    });
+}
+
+module.exports = { main };

--- a/tests/unit/row-growth-detector.test.js
+++ b/tests/unit/row-growth-detector.test.js
@@ -1,0 +1,117 @@
+// SD-LEO-INFRA-STANDING-ROW-GROWTH-001 — pure row-growth anomaly detection.
+// Motivating incidents: management_reviews hit 45k duplicate rows and
+// sd_baseline_items 13k orphans before anyone noticed. These pin the detector
+// semantics: growth-factor + absolute-spike triggers, shrink never matches,
+// small tables exempt from factor noise, due-gating ~22h.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  detectRowGrowthAnomalies,
+  isSnapshotDue,
+  GOVERNANCE_TABLES,
+  DEFAULT_OPTS,
+  SNAPSHOT_DUE_MS,
+} = require('../../lib/coordinator/row-growth.cjs');
+
+const snap = (tables, captured_at = '2026-06-10T00:00:00Z') => ({ captured_at, tables });
+
+describe('detectRowGrowthAnomalies (pure)', () => {
+  it('flags an absolute spike regardless of factor (the management_reviews-45k class)', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ management_reviews: 1000 }),
+      snap({ management_reviews: 46000 })
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ table: 'management_reviews', delta: 45000, trigger: 'abs_spike' });
+  });
+
+  it('flags a growth factor on a table above minRowsForFactor (the sd_baseline_items class)', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ sd_baseline_items: 2000 }),
+      snap({ sd_baseline_items: 3500 }) // x1.75 >= 1.5, delta 1500 < absSpike
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ table: 'sd_baseline_items', trigger: 'growth_factor' });
+    expect(out[0].factor).toBeCloseTo(1.75);
+  });
+
+  it('does NOT flag factor noise on small tables (below minRowsForFactor)', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ tiny_table: 10 }),
+      snap({ tiny_table: 100 }) // x10 but tiny — daily churn, not an anomaly
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('never flags shrink or steady state (cleanups are not anomalies)', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ a: 45000, b: 500 }),
+      snap({ a: 1, b: 500 })
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('skips tables absent from either snapshot (inventory changes are not growth)', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ old_table: 100 }),
+      snap({ new_table: 99999 })
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it('returns [] with no previous snapshot (first baseline)', () => {
+    expect(detectRowGrowthAnomalies(null, snap({ a: 1 }))).toEqual([]);
+  });
+
+  it('sorts multiple anomalies by delta descending', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ a: 1000, b: 1000 }),
+      snap({ a: 7000, b: 90000 })
+    );
+    expect(out.map((x) => x.table)).toEqual(['b', 'a']);
+  });
+
+  it('threshold overrides are honored', () => {
+    const out = detectRowGrowthAnomalies(
+      snap({ a: 1000 }),
+      snap({ a: 1200 }),
+      { growthFactor: 1.1, minRowsForFactor: 100 }
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].trigger).toBe('growth_factor');
+  });
+});
+
+describe('isSnapshotDue (pure)', () => {
+  const now = Date.parse('2026-06-10T12:00:00Z');
+  it('due when no prior snapshot', () => {
+    expect(isSnapshotDue(null, now)).toBe(true);
+  });
+  it('not due within the window; due after it', () => {
+    expect(isSnapshotDue('2026-06-10T11:00:00Z', now)).toBe(false);
+    expect(isSnapshotDue('2026-06-09T10:00:00Z', now)).toBe(true);
+  });
+  it('treats naive timestamps as UTC and garbage as due (fail-toward-snapshot)', () => {
+    expect(isSnapshotDue('2026-06-09 10:00:00', now)).toBe(true);
+    expect(isSnapshotDue('not-a-date', now)).toBe(true);
+  });
+  it('window constant is ~22h (daily cron with jitter tolerance)', () => {
+    expect(SNAPSHOT_DUE_MS).toBe(22 * 60 * 60 * 1000);
+  });
+});
+
+describe('GOVERNANCE_TABLES inventory', () => {
+  it('covers both motivating-incident tables and the core governance set', () => {
+    expect(GOVERNANCE_TABLES).toContain('management_reviews');
+    expect(GOVERNANCE_TABLES).toContain('sd_baseline_items');
+    expect(GOVERNANCE_TABLES).toContain('strategic_directives_v2');
+    expect(GOVERNANCE_TABLES).toContain('session_coordination');
+    expect(GOVERNANCE_TABLES.length).toBeGreaterThanOrEqual(20);
+  });
+  it('default thresholds are the documented ones', () => {
+    expect(DEFAULT_OPTS).toMatchObject({ growthFactor: 1.5, minRowsForFactor: 500, absSpike: 5000 });
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-STANDING-ROW-GROWTH-001

Runaway table growth has been discovered by accident: `management_reviews` hit **45k duplicate rows** and `sd_baseline_items` **13k orphans** before anyone noticed — both needed chairman-gated cleanup SDs. This ships the standing daily gauge that catches the class within one tick.

### What it does
- **`lib/coordinator/row-growth.cjs`** — pure anomaly predicates over consecutive snapshots (growth factor ≥1.5 once a table exceeds 500 rows, OR absolute spike ≥5000; negative growth never matches) + fail-soft IO. 22-table governance watch list incl. both incident tables. Counts via PostgREST `head+estimated` (planner statistics — **no COUNT(*) scans**).
- **`scripts/row-growth-snapshot.cjs`** — 22h due-gated daily CLI; persists the baseline series as `ROW_GROWTH_SNAPSHOT` `coordination_events` rows (**no new tables** — existing `(event_type, detected_at)` index serves it); on anomalies, dual alert legs: durable `ROW_GROWTH_ANOMALY` event + `session_coordination` coordinator-inbox row (72h expiry). Always exits 0 via `armCliTeardown` — a gauge never breaks its host loop.
- **Cron lifecycle** — `STANDARD_LOOPS` arm (daily 08:30) + `teardown-coordinator` registration/markers (armed-and-torn-down parity verified) + `npm run sre:row-growth`.

### Orphaned-WIP recovery (verify-then-finish)
The implementation was inherited **staged-but-uncommitted** from a prior worker session (zero branch commits; the prior worker even ran it live — 2 valid baseline snapshots exist). Every diff reviewed line-by-line, all 22 inherited tests run, live baselines validated — and **one real defect found and fixed**: direct `process.exit(0)` after Supabase queries (the UV_HANDLE_CLOSING abort class) replaced with the shared `armCliTeardown` primitive shipped earlier today (#4545).

### Verification
22/22 unit + 15/15 smoke green · live due-gate no-op verified (exit 0, prompt) · validation-agent: no duplicate, RETENTION-POLICY complementary, estimated-counts equivalent-and-more-portable than direct `reltuples` SQL. Gates: 96/94/96/96 · TESTING 96 · retro 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
