### PR TITLE
feat(SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001): consolidate stage I/O contracts onto the venture_stages SSOT + connectivity solver in CI

### DIFF
--- a/.github/workflows/stage-contract-connectivity.yml
+++ b/.github/workflows/stage-contract-connectivity.yml
@@ -1,0 +1,60 @@
+name: Stage Contract Connectivity
+
+# SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-4.
+# Runs the stage-contract connectivity solver
+# (scripts/validate-stage-contract-connectivity.mjs): asserts venture_stages
+# required artifacts have declared producers (C1), boundary configs are
+# coherent (C2), S18 consumes are satisfiable (C3), no deprecated alias sits
+# in a live registry (C4), the legacy stage_artifact_requirements table
+# mirrors the SSOT (C5), and the STAGE_CONTRACTS Map has no duplicate stage
+# keys (C7). Prevents the drift class behind the S21/S22 mislabeled-artifact
+# incidents (412 + 1,230 junk venture_artifacts rows from stale exit-gate
+# types feeding the orchestrator's generic fallback).
+#
+# Cloned from boundary-config-coherence.yml (which stays as-is; this solver's
+# C2 supersets its check — fold-in is a follow-up once this workflow soaks).
+
+on:
+  pull_request:
+    paths:
+      - 'lib/eva/artifact-types.js'
+      - 'lib/eva/contracts/**'
+      - 'lib/eva/stage-templates/upstream-artifact-types.js'
+      - 'database/migrations/*venture_stages*.sql'
+      - 'database/migrations/*stage_artifact_requirements*.sql'
+      - 'database/migrations/*gate_boundary_config*.sql'
+      - 'scripts/validate-stage-contract-connectivity.mjs'
+      - '.github/workflows/stage-contract-connectivity.yml'
+  schedule:
+    # Nightly drift sweep — table edits bypass PRs, so path filters alone
+    # cannot catch registry drift (precedent: gate-health-weekly.yml).
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  stage-contract-connectivity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: stage-contract-connectivity-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Assert secrets present
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          [ -n "$SUPABASE_URL" ] || { echo "[STAGE_CONTRACT_INFRA_ERROR] SUPABASE_URL missing"; exit 2; }
+          [ -n "$SUPABASE_SERVICE_ROLE_KEY" ] || { echo "[STAGE_CONTRACT_INFRA_ERROR] SUPABASE_SERVICE_ROLE_KEY missing"; exit 2; }
+      - run: npm ci --no-audit --no-fund
+      - name: Run stage-contract connectivity solver
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npm run stage-contracts:check

--- a/database/migrations/20260610_sync_stage_artifact_requirements_to_ssot.sql
+++ b/database/migrations/20260610_sync_stage_artifact_requirements_to_ssot.sql
@@ -1,0 +1,101 @@
+-- Migration: Sync stage_artifact_requirements to the venture_stages SSOT
+--            + deprecate the legacy stage-contract tables.
+-- SD: SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 (FR-2)
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- Pure DML + COMMENT — no DDL. Idempotent: re-running converges to the same
+-- state (the INSERT is derived live from venture_stages at apply time).
+-- No DO blocks / no dollar-quoted bodies (single-statement friendly).
+--
+-- WHY:
+--   stage_artifact_requirements was hand-seeded 2026-04-06/07 against the
+--   pre-redesign pipeline and never updated. Confirmed stale rows (live audit
+--   2026-06-10, scripts/validate-stage-contract-connectivity.mjs pre-fix run —
+--   41 LEGACY_PARITY failures):
+--     S15 blueprint_wireframes        -> wireframe_screens
+--     S16 blueprint_api_contract      -> blueprint_financial_projection
+--     S17 stage_17_analysis           -> system_devils_advocate_review
+--     S18 build_system_prompt         -> 9 marketing_* types (never produced;
+--                                        fallback mislabeling class: 412 rows
+--                                        at S21 + 1,230 rows at S22)
+--     S19 blueprint_sprint_plan       -> build_mvp_build
+--     S20 build_mvp_build             -> code_quality_report
+--     S21 build_security_audit        -> distribution_channel_config + distribution_ad_copy
+--     S22 launch_test_plan            -> visual_device_screenshots + visual_social_graphics
+--     S23 launch_uat_report           -> launch_readiness_checklist
+--     S24 launch_deployment_runbook   -> launch_metrics
+--     S25 launch_marketing_checklist  -> postlaunch_assumptions_vs_reality + postlaunch_user_feedback_summary
+--     S26 launch_optimization_roadmap -> growth_playbook + growth_optimization_roadmap
+--   plus missing multi-artifact rows at S12 (identity_brand_guidelines) and
+--   S14 (data_model / erd_diagram / api_contract / schema_spec).
+--
+--   venture_stages.required_artifacts (text[]) is the established SSOT
+--   (SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001; fn_advance_venture_stage reads it
+--   canonical-first since 20260504/20260529). This migration makes the legacy
+--   table a faithful mirror so the fn_advance legacy-fallback path and any
+--   residual reader can no longer disagree with the SSOT. Parity is enforced
+--   going forward by the LEGACY_PARITY (C5) check in
+--   scripts/validate-stage-contract-connectivity.mjs (CI: stage-contract-connectivity.yml).
+--
+-- PRE-IMAGE (2026-06-10, for manual rollback reference — data lines, not SQL):
+--   1:truth_idea_brief 2:truth_ai_critique 3:truth_validation_decision
+--   4:truth_competitive_analysis 5:truth_financial_model 6:engine_risk_matrix
+--   7:engine_pricing_model 8:engine_business_model_canvas 9:engine_exit_strategy
+--   10:identity_persona_brand 11:identity_naming_visual 12:identity_gtm_sales_strategy
+--   13:blueprint_product_roadmap 14:blueprint_technical_architecture
+--   15:blueprint_wireframes 16:blueprint_api_contract 17:stage_17_analysis
+--   18:build_system_prompt 19:blueprint_sprint_plan 20:build_mvp_build
+--   21:build_security_audit 22:launch_test_plan 23:launch_uat_report
+--   24:launch_deployment_runbook 25:launch_marketing_checklist
+--   26:launch_optimization_roadmap
+--   (all rows: required_status='completed', is_blocking=true, timeout_hours=null)
+
+BEGIN;
+
+-- 1. Replace the legacy table content with rows derived from the SSOT.
+--    DELETE+INSERT keeps this idempotent and review-simple; nothing references
+--    stage_artifact_requirements.id (no FKs; ai_gen_provenance references the
+--    table NAME in a CHECK constraint, not rows).
+DELETE FROM stage_artifact_requirements;
+
+INSERT INTO stage_artifact_requirements (stage_number, artifact_type, required_status, is_blocking, description)
+SELECT
+  vs.stage_number,
+  t.artifact_type,
+  'completed',
+  true,
+  t.artifact_type || ' required before leaving Stage ' || vs.stage_number || ' (' || vs.stage_name
+    || ') — synced from venture_stages.required_artifacts (SSOT) by SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001'
+FROM venture_stages vs
+CROSS JOIN LATERAL unnest(vs.required_artifacts) AS t(artifact_type)
+WHERE vs.required_artifacts IS NOT NULL
+ORDER BY vs.stage_number, t.artifact_type;
+
+-- 2. Deprecate the legacy table (kept only as the fn_advance_venture_stage
+--    legacy-fallback path; the eva-orchestrator read was repointed to
+--    venture_stages in the same SD).
+COMMENT ON TABLE stage_artifact_requirements IS
+  'DEPRECATED (SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001, 2026-06-10): superseded by venture_stages.required_artifacts (SSOT). Retained ONLY as the fn_advance_venture_stage legacy-fallback path. Do not hand-edit; content is a derived mirror of venture_stages and parity is enforced by the LEGACY_PARITY check in scripts/validate-stage-contract-connectivity.mjs. DROP candidate via the quarantine recipe in a follow-up SD.';
+
+-- 3. Retire stage_data_contracts (2 rows from the dead 40-stage model,
+--    Dec 2025; zero code readers — verified 2026-06-10).
+UPDATE stage_data_contracts SET is_active = false, updated_at = now() WHERE is_active = true;
+
+COMMENT ON TABLE stage_data_contracts IS
+  'ABANDONED (SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001, 2026-06-10): 2 rows reference the retired 40-stage workflow model; zero code readers. Stage I/O contracts live in venture_stages.required_artifacts (SSOT) + lib/eva/contracts/stage-contracts.js. DROP candidate via the quarantine recipe in a follow-up SD.';
+
+COMMIT;
+
+-- VERIFY (run after apply):
+--   SELECT count(*) FROM stage_artifact_requirements;            -- expect 43 (26 stages, multi-artifact stages expanded; matches live venture_stages 2026-06-10)
+--   SELECT count(*) FROM stage_artifact_requirements sar
+--     JOIN venture_stages vs ON vs.stage_number = sar.stage_number
+--    WHERE sar.artifact_type <> ALL (vs.required_artifacts);     -- expect 0
+--   SELECT count(*) FROM stage_data_contracts WHERE is_active;   -- expect 0
+--   node scripts/validate-stage-contract-connectivity.mjs        -- LEGACY_PARITY (C5) green
+--
+-- Rollback (manual): restore the 26 pre-image rows listed above with
+--   required_status='completed', is_blocking=true, and re-set
+--   stage_data_contracts.is_active=true for the 2 rows; then restore the
+--   previous COMMENT ON TABLE texts (see git history of
+--   database/migrations/20260406_create_stage_artifact_requirements.sql).

--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -95,6 +95,21 @@ export const ARTIFACT_TYPES = Object.freeze({
   BUILD_SECURITY_AUDIT: 'build_security_audit',
   BUILD_MVP_BUILD: 'build_mvp_build',
   BUILD_TEST_COVERAGE_REPORT: 'build_test_coverage_report',
+  // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-1: S20 Code Quality Gate output
+  // (venture_stages.required_artifacts[20]; written by the S20 analyzer per
+  // SD-LEO-FEAT-STAGE-CODE-QUALITY-001). String predates this constant — it
+  // already exists in venture_stages and repo migrations.
+  BUILD_CODE_QUALITY_REPORT: 'code_quality_report',
+  // S21 Distribution Setup outputs (stage-22-distribution-setup.js analyzer —
+  // file named for the pre-swap numbering; writes lifecycle_stage 21).
+  // SD-LEO-FEAT-STAGE-DISTRIBUTION-SETUP-001.
+  DISTRIBUTION_CHANNEL_CONFIG: 'distribution_channel_config',
+  DISTRIBUTION_AD_COPY: 'distribution_ad_copy',
+  // S22 Visual Assets outputs (stage-21-visual-assets.js analyzer — file named
+  // for the pre-swap numbering; writes lifecycle_stage 22).
+  // SD-LEO-FEAT-CONVERT-STAGE-VISUAL-001.
+  VISUAL_DEVICE_SCREENSHOTS: 'visual_device_screenshots',
+  VISUAL_SOCIAL_GRAPHICS: 'visual_social_graphics',
 
   // Stage 18 — Marketing Copy Studio (SD-LEO-FEAT-STAGE-MARKETING-COPY-001).
   // One artifact per COPY_SECTIONS entry; these marketing_<section> strings are
@@ -270,6 +285,24 @@ export const OLD_TO_NEW_MAP = Object.freeze({
   marketing_manifest: ARTIFACT_TYPES.IDENTITY_PERSONA_BRAND,
 });
 
+// ── Deprecated alias → canonical replacement ─────────────────────────
+// SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-1: machine-readable form of the
+// @deprecated JSDoc annotations above. Consumed by:
+//   - scripts/validate-stage-contract-connectivity.mjs (C4 RENAME_ATOMICITY:
+//     no live-enforced DB registry may reference a deprecated alias)
+//   - lib/eva/contracts/describe-artifact-gap.js (alias-aware nearest-match)
+// Keep in sync with the @deprecated constants in ARTIFACT_TYPES.
+export const DEPRECATED_TO_CANONICAL = Object.freeze({
+  [ARTIFACT_TYPES.ENGINE_RISK_ASSESSMENT]: ARTIFACT_TYPES.ENGINE_RISK_MATRIX,
+  [ARTIFACT_TYPES.ENGINE_REVENUE_MODEL]: ARTIFACT_TYPES.ENGINE_PRICING_MODEL,
+  [ARTIFACT_TYPES.LAUNCH_MARKETING_CHECKLIST]: ARTIFACT_TYPES.LAUNCH_READINESS_CHECKLIST,
+  [ARTIFACT_TYPES.LAUNCH_OPTIMIZATION_ROADMAP]: ARTIFACT_TYPES.GROWTH_OPTIMIZATION_ROADMAP,
+  [ARTIFACT_TYPES.LAUNCH_LAUNCH_METRICS]: ARTIFACT_TYPES.LAUNCH_METRICS,
+});
+
+/** Deprecated artifact_type strings (keys of DEPRECATED_TO_CANONICAL). */
+export const DEPRECATED_ARTIFACT_TYPES = Object.freeze(Object.keys(DEPRECATED_TO_CANONICAL));
+
 // ── Artifact types by stage ──────────────────────────────────────────
 // SD-RCA-PREEMPTIVE-S26: Added Stage 26 entry (was missing).
 export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
@@ -357,11 +390,37 @@ export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
   // (no other stage entry references it), so reverse-lookup
   // _STAGE_BY_ARTIFACT_TYPE resolves 'build_mvp_build' to 19 deterministically.
   19: [ARTIFACT_TYPES.BLUEPRINT_SPRINT_PLAN, ARTIFACT_TYPES.BUILD_MVP_BUILD],
-  20: [ARTIFACT_TYPES.BUILD_SECURITY_AUDIT],
-  21: [ARTIFACT_TYPES.LAUNCH_TEST_PLAN, ARTIFACT_TYPES.LAUNCH_UAT_REPORT],
-  22: [ARTIFACT_TYPES.LAUNCH_DEPLOYMENT_RUNBOOK],
-  23: [ARTIFACT_TYPES.LAUNCH_MARKETING_CHECKLIST],
+  // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-1: stages 20-24 realigned with
+  // venture_stages.required_artifacts (SSOT) after the S18-S26 pipeline redesign
+  // + the 21<->22 swap (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A). Convention:
+  // canonical (SSOT-required) types FIRST — index [0] is the orchestrator's
+  // generic-fallback label — historical/legacy types retained at the TAIL so
+  // getStageForArtifactType keeps resolving pre-redesign rows (412 live
+  // build_security_audit rows at S21, 1,230 launch_test_plan rows at S22, etc.).
+  // S20 = Code Quality Gate.
+  20: [ARTIFACT_TYPES.BUILD_CODE_QUALITY_REPORT, ARTIFACT_TYPES.BUILD_SECURITY_AUDIT],
+  // S21 = Distribution Setup (post-swap).
+  21: [
+    ARTIFACT_TYPES.DISTRIBUTION_CHANNEL_CONFIG,
+    ARTIFACT_TYPES.DISTRIBUTION_AD_COPY,
+    ARTIFACT_TYPES.LAUNCH_TEST_PLAN,
+    ARTIFACT_TYPES.LAUNCH_UAT_REPORT,
+  ],
+  // S22 = Visual Assets (post-swap).
+  22: [
+    ARTIFACT_TYPES.VISUAL_DEVICE_SCREENSHOTS,
+    ARTIFACT_TYPES.VISUAL_SOCIAL_GRAPHICS,
+    ARTIFACT_TYPES.LAUNCH_DEPLOYMENT_RUNBOOK,
+  ],
+  // S23 = Launch Readiness: canonical launch_readiness_checklist first
+  // (SD-LEO-FEAT-STAGE-LAUNCH-READINESS-001 FR-1); deprecated alias retained
+  // at tail for read-back only.
+  23: [ARTIFACT_TYPES.LAUNCH_READINESS_CHECKLIST, ARTIFACT_TYPES.LAUNCH_MARKETING_CHECKLIST],
+  // S24 = Go Live & Announce: canonical launch_metrics first
+  // (SD-LEO-FEAT-STAGE-LIVE-ANNOUNCE-001 FR-1); historical S24 ops artifacts
+  // retained at tail for reverse-lookup parity.
   24: [
+    ARTIFACT_TYPES.LAUNCH_METRICS,
     ARTIFACT_TYPES.LAUNCH_ANALYTICS_DASHBOARD,
     ARTIFACT_TYPES.LAUNCH_HEALTH_SCORING,
     ARTIFACT_TYPES.LAUNCH_CHURN_TRIGGERS,

--- a/lib/eva/contracts/describe-artifact-gap.js
+++ b/lib/eva/contracts/describe-artifact-gap.js
@@ -1,0 +1,194 @@
+/**
+ * Self-describing artifact-gap diagnostics.
+ *
+ * SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5.
+ *
+ * When a stage precondition / reality gate / fallback-labeling path cannot find
+ * a required artifact_type, the failure historically named ONLY the missing
+ * type — leaving operators to manually diff the registry against what the
+ * venture actually produced (the S21/S22 incident ran 6+ days because
+ * 'build_security_audit' was demanded while the venture had distribution_* /
+ * visual_* artifacts). This helper turns those failures self-describing:
+ *
+ *   required type  +  the venture's ACTUAL artifact types at that stage
+ *                  +  a nearest-match diff (rename-alias-aware first,
+ *                     Levenshtein second).
+ *
+ * One injected query, fail-soft: any DB error returns a degraded-but-usable
+ * result instead of throwing (callers are failure paths already).
+ *
+ * @module lib/eva/contracts/describe-artifact-gap
+ */
+
+import {
+  ARTIFACT_TYPES,
+  OLD_TO_NEW_MAP,
+  DEPRECATED_TO_CANONICAL,
+} from '../artifact-types.js';
+
+/** Plain dynamic-programming Levenshtein distance. */
+export function levenshtein(a, b) {
+  if (a === b) return 0;
+  if (!a) return b.length;
+  if (!b) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      curr[j] = Math.min(
+        prev[j] + 1,
+        curr[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+/**
+ * Find the closest match for `required` within `candidates`.
+ *
+ * Resolution order (alias maps consulted BEFORE string distance, so a
+ * half-finished rename is reported as a rename, not a typo):
+ *   1. required is a deprecated alias whose canonical replacement is present
+ *      -> { kind: 'renamed_to' }
+ *   2. required is an OLD_TO_NEW_MAP legacy key whose new name is present
+ *      -> { kind: 'renamed_to' }
+ *   3. some candidate is an alias/legacy key whose canonical form IS required
+ *      -> { kind: 'renamed_from' }
+ *   4. minimum Levenshtein distance -> { kind: 'levenshtein', distance }
+ *
+ * @param {string} required
+ * @param {string[]} candidates
+ * @returns {{ match: string, kind: string, distance: number } | null}
+ */
+export function nearestMatch(required, candidates) {
+  if (!required || !Array.isArray(candidates) || candidates.length === 0) return null;
+  const candidateSet = new Set(candidates);
+
+  const canonicalOfRequired = DEPRECATED_TO_CANONICAL[required] ?? OLD_TO_NEW_MAP[required];
+  if (canonicalOfRequired && candidateSet.has(canonicalOfRequired)) {
+    return { match: canonicalOfRequired, kind: 'renamed_to', distance: 0 };
+  }
+
+  for (const c of candidates) {
+    if ((DEPRECATED_TO_CANONICAL[c] ?? OLD_TO_NEW_MAP[c]) === required) {
+      return { match: c, kind: 'renamed_from', distance: 0 };
+    }
+  }
+
+  let best = null;
+  for (const c of candidates) {
+    if (c === required) continue;
+    const d = levenshtein(required, c);
+    if (!best || d < best.distance) best = { match: c, kind: 'levenshtein', distance: d };
+  }
+  return best;
+}
+
+function isArtifactTypeName(t) {
+  // Resource-style requirements (e.g. 'venture_resources.deployment_url') are
+  // not venture_artifacts types — exclude them from artifact diffs.
+  return typeof t === 'string' && t.length > 0 && !t.includes('.');
+}
+
+/**
+ * Describe the gap between required artifact types and what the venture
+ * actually has.
+ *
+ * @param {Object} args
+ * @param {Object} args.supabase - Supabase client (injected).
+ * @param {string} args.ventureId
+ * @param {number} args.stage - The stage whose requirement failed.
+ * @param {string[]} args.requiredTypes - The missing/required artifact types.
+ * @param {Object} [args.logger]
+ * @returns {Promise<{
+ *   stage: number,
+ *   required: string[],
+ *   actual_at_stage: string[],
+ *   actual_by_stage: Object<string, string[]>,
+ *   matches: Array<{ required: string, match: string|null, kind: string|null, distance: number|null }>,
+ *   rendered: string,
+ *   degraded: boolean,
+ * }>}
+ */
+export async function describeArtifactGap({ supabase, ventureId, stage, requiredTypes = [], logger = console }) {
+  const required = (requiredTypes || []).filter(isArtifactTypeName);
+  const result = {
+    stage,
+    required,
+    actual_at_stage: [],
+    actual_by_stage: {},
+    matches: [],
+    rendered: '',
+    degraded: false,
+  };
+
+  let rows = [];
+  try {
+    if (!supabase || !ventureId) throw new Error('supabase client and ventureId are required');
+    const { data, error } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_type, lifecycle_stage')
+      .eq('venture_id', ventureId)
+      .eq('is_current', true);
+    if (error) throw error;
+    rows = data || [];
+  } catch (err) {
+    result.degraded = true;
+    logger?.warn?.(`[describe-artifact-gap] venture_artifacts read failed (degraded output): ${err.message}`);
+  }
+
+  const byStage = new Map();
+  for (const r of rows) {
+    if (!r?.artifact_type) continue;
+    const s = r.lifecycle_stage;
+    if (!byStage.has(s)) byStage.set(s, new Set());
+    byStage.get(s).add(r.artifact_type);
+  }
+  for (const [s, set] of [...byStage.entries()].sort((a, b) => a[0] - b[0])) {
+    result.actual_by_stage[s] = [...set].sort();
+  }
+  result.actual_at_stage = result.actual_by_stage[stage] || [];
+
+  // Nearest-match candidates: everything the venture actually has, plus the
+  // canonical type registry (so a stale requirement still maps to its rename
+  // even when the venture produced nothing yet).
+  const allActual = [...new Set(rows.map(r => r.artifact_type).filter(Boolean))];
+  const candidatePool = [...new Set([...allActual, ...Object.values(ARTIFACT_TYPES)])];
+  for (const t of required) {
+    const m = nearestMatch(t, candidatePool);
+    result.matches.push({
+      required: t,
+      match: m?.match ?? null,
+      kind: m?.kind ?? null,
+      distance: m?.distance ?? null,
+    });
+  }
+
+  const lines = [];
+  lines.push(`required at stage ${stage}: ${required.join(', ') || '(none)'}`);
+  lines.push(
+    result.actual_at_stage.length > 0
+      ? `venture has at stage ${stage}: ${result.actual_at_stage.join(', ')}`
+      : `venture has NO current artifacts at stage ${stage}${result.degraded ? ' (lookup degraded)' : ''}`,
+  );
+  for (const m of result.matches) {
+    if (!m.match) continue;
+    if (m.kind === 'renamed_to') {
+      lines.push(`'${m.required}' was RENAMED to '${m.match}' — the requirement source is stale; check venture_stages.required_artifacts`);
+    } else if (m.kind === 'renamed_from') {
+      lines.push(`venture has '${m.match}', the legacy name of required '${m.required}'`);
+    } else {
+      lines.push(`nearest match for '${m.required}': ${m.match} (levenshtein ${m.distance})`);
+    }
+  }
+  const stagesPresent = Object.entries(result.actual_by_stage)
+    .map(([s, types]) => `${s}(${types.length})`)
+    .join(', ');
+  if (stagesPresent) lines.push(`artifact stages present: ${stagesPresent}`);
+  result.rendered = lines.join('\n');
+
+  return result;
+}

--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -342,24 +342,14 @@ const STAGE_CONTRACTS = new Map([
     },
   }],
 
-  [20, {
-    consumes: [
-      { stage: 18, fields: {
-        buildReadiness: { type: 'object', required: false },
-      }},
-      { stage: 19, fields: {
-        items: { type: 'array' },
-      }},
-    ],
-    produces: {
-      tasks: { type: 'array', minItems: 1 },
-      total_tasks: { type: 'number' },
-      completed_tasks: { type: 'number' },
-    },
-  }],
-
   // 2026-04-22: S20 redesigned from Build Execution to Code Quality Gate
-  // (SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-C)
+  // (SD-REDESIGN-S18S26-MARKETINGFIRST-POSTBUILD-ORCH-001-C).
+  // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-1: the pre-redesign Build
+  // Execution entry (consumes 18.buildReadiness/19.items, produces tasks/
+  // total_tasks/completed_tasks) was a DUPLICATE [20, ...] Map key above this
+  // one — the Map constructor silently discarded it, so deleting it is
+  // behavior-identical. Duplicate keys are now linted by CONTRACT_MAP_LINT in
+  // scripts/validate-stage-contract-connectivity.mjs.
   [20, {
     consumes: [
       { stage: 19, fields: { content: { type: 'object', required: false } }},  // GitHub repo URL

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -36,6 +36,7 @@ import { validateStageGate } from '../agents/modules/venture-state-machine/stage
 import { retrieveKnowledge } from './utils/knowledge-retriever.js';
 import { getTemplate } from './stage-templates/index.js';
 import { getContract, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
+import { describeArtifactGap } from './contracts/describe-artifact-gap.js';
 import { recordTokenUsage, checkBudget, buildTokenSummary } from './utils/token-tracker.js';
 import { runRealityTracking } from './utils/assumption-reality-tracker.js';
 import { scoreTasteGate, buildTasteSummary, TASTE_VERDICT } from './taste-gate-scorer.js';
@@ -243,18 +244,23 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     logger.warn(`[Eva] EVA key resolution failed (non-fatal): ${evaKeyErr.message}`);
   }
 
-  // ── 2c. Load required artifact types from stage_artifact_requirements ──
-  // SD-ARTIFACT-SYSTEM-RECONCILIATION-MULTIARTIFACT-ORCH-001-B: migrated from
-  // lifecycle_stage_config.required_artifacts to stage_artifact_requirements table
-  // (single source of truth, seeded by SD-UNIFIED-STAGE-GATE-ARTIFACTPRECONDITION-ORCH-001)
+  // ── 2c. Load required artifact types from venture_stages (SSOT) ──
+  // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-1: repointed from the legacy
+  // stage_artifact_requirements table (hand-seeded 2026-04, stale for S14-S26 —
+  // its stale exit-gate types fed the :453 generic fallback and mislabeled
+  // 412 S21 + 1,230 S22 artifacts) to venture_stages.required_artifacts, the
+  // established SSOT (SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001; fn_advance_venture_stage
+  // reads it canonical-first since 20260504). venture_stages stores the types as
+  // a text[] on ONE row per stage (vs one-row-per-type in the legacy table).
   let requiredArtifacts = [];
   try {
-    const { data: artReqs } = await supabase
-      .from('stage_artifact_requirements')
-      .select('artifact_type')
-      .eq('stage_number', resolvedStage); // QF-20260525-570: stage_artifact_requirements uses stage_number (no lifecycle_stage col); QF-20260420-405 wrongly renamed this query, swallowed error left reality gate silently passing
-    if (artReqs?.length > 0) {
-      requiredArtifacts = artReqs.map(r => r.artifact_type);
+    const { data: vsRows } = await supabase
+      .from('venture_stages')
+      .select('required_artifacts')
+      .eq('stage_number', resolvedStage); // venture_stages keys on stage_number (unique), not lifecycle_stage
+    const ssotTypes = Array.isArray(vsRows) && vsRows[0] ? vsRows[0].required_artifacts : null;
+    if (Array.isArray(ssotTypes) && ssotTypes.length > 0) {
+      requiredArtifacts = [...ssotTypes];
       logger.log(`[Eva] Stage ${resolvedStage} requires artifacts: ${requiredArtifacts.join(', ')}`);
     }
   } catch {
@@ -449,8 +455,20 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
           // applies to every stage that returns a skip; normal (non-skip) writes unaffected.
           logger.info?.(`[Eva] Stage ${resolvedStage} step returned _skip (reason=${stepResult.skip_reason || 'unknown'}); skip marker owned by the stage — no generic fallback artifact persisted.`);
         } else {
+          const fallbackType = stepResult.artifactType || step.artifactType || requiredArtifacts[0] || (ARTIFACT_TYPE_BY_STAGE[resolvedStage]?.[0]);
+          if (!fallbackType) {
+            // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5: self-describing
+            // failure — name the required types AND what the venture actually
+            // has (+ nearest-match diff) instead of just "not configured".
+            let gapNote = '';
+            try {
+              const gap = await describeArtifactGap({ supabase, ventureId, stage: resolvedStage, requiredTypes: requiredArtifacts, logger });
+              if (gap?.rendered) gapNote = `\n${gap.rendered}`;
+            } catch { /* fail-soft: diagnostics must not mask the real error */ }
+            throw new Error(`No artifact type configured for stage ${resolvedStage} — check venture_stages.required_artifacts (SSOT) and ARTIFACT_TYPE_BY_STAGE.${gapNote}`);
+          }
           artifacts.push({
-            artifactType: stepResult.artifactType || step.artifactType || requiredArtifacts[0] || (ARTIFACT_TYPE_BY_STAGE[resolvedStage]?.[0]) || (() => { throw new Error(`No artifact type configured for stage ${resolvedStage} — check stage_artifact_requirements and ARTIFACT_TYPE_BY_STAGE`); })(),
+            artifactType: fallbackType,
             stageId: resolvedStage,
             createdAt: new Date().toISOString(),
             payload: stepResult.payload || stepResult,
@@ -694,7 +712,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     } else {
       // L0 manual — run gate.
       // SD-LEO-INFRA-REALITY-GATE-ARTIFACT-001 FR-4: requiredArtifacts (sourced from
-      // stage_artifact_requirements for the from_stage) is the PER-STAGE check.
+      // venture_stages.required_artifacts for the from_stage — SSOT, repointed by
+      // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001) is the PER-STAGE check.
       // When empty, evaluateRealityGate falls to its internal DB lookup against
       // public.gate_boundary_config (FR-2) for the boundary-spanning requirements.
       // The hardcoded BOUNDARY_CONFIG inside reality-gates.js is now a last-resort

--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -15,6 +15,7 @@
  */
 
 import { ARTIFACT_TYPES } from './artifact-types.js';
+import { describeArtifactGap } from './contracts/describe-artifact-gap.js';
 
 const MODULE_VERSION = '1.0.0';
 
@@ -378,6 +379,39 @@ async function evaluateRealityGate(params, deps = {}) {
     } else if (req.url_verification_required && simulationMode) {
       logger.info(`Reality Gate: skipping URL verification for '${req.artifact_type}' (simulation mode)`);
     }
+  }
+
+  // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5: self-describing
+  // ARTIFACT_MISSING — one extra query enriches every missing-artifact reason
+  // with the venture's ACTUAL types at the from_stage and a rename-aware
+  // nearest-match hint. Fail-soft: diagnostics never change gate outcome.
+  const missingReasons = result.reasons.filter(r => r.code === REASON_CODES.ARTIFACT_MISSING);
+  if (missingReasons.length > 0) {
+    try {
+      const gap = await describeArtifactGap({
+        supabase,
+        ventureId,
+        stage: effectiveFromStage,
+        requiredTypes: missingReasons.map(r => r.artifact_type),
+        logger,
+      });
+      if (gap) {
+        result.gap_detail = gap.rendered;
+        for (const reason of missingReasons) {
+          const m = gap.matches.find(x => x.required === reason.artifact_type);
+          if (!m?.match) continue;
+          reason.nearest_match = m.match;
+          reason.match_kind = m.kind;
+          if (m.kind === 'renamed_to') {
+            reason.message += `; '${reason.artifact_type}' was RENAMED to '${m.match}' — requirement source is stale`;
+          } else if (m.kind === 'renamed_from') {
+            reason.message += `; venture has '${m.match}', the legacy name of this artifact`;
+          } else {
+            reason.message += `; nearest match: ${m.match}`;
+          }
+        }
+      }
+    } catch { /* fail-soft */ }
   }
 
   // Set final status — BLOCKED instead of FAIL (Chairman decides venture fate)

--- a/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-visual-assets.js
@@ -23,6 +23,7 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { describeArtifactGap } from '../../contracts/describe-artifact-gap.js';
 
 const DEVICE_FRAMES = ['iphone_15', 'macbook_pro', 'ipad', 'android_phone'];
 
@@ -364,6 +365,21 @@ async function persistSkipMarker(supabase, ventureId, missing, logger) {
       attempted_at: new Date().toISOString(),
       required_upstream: REQUIRED_UPSTREAM,
     };
+    // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5: self-describing skip —
+    // record what the venture ACTUALLY has (+ nearest-match / rename diff)
+    // alongside what is missing. Fail-soft: diagnostics never block the marker.
+    try {
+      const gap = await describeArtifactGap({
+        supabase, ventureId, stage: 22,
+        requiredTypes: missing.map(m => m.artifact_type),
+        logger,
+      });
+      if (gap) {
+        artifactData.gap_detail = gap.rendered;
+        artifactData.gap_matches = gap.matches;
+        logger?.warn?.(`[S21-VisualAssets] artifact gap detail:\n${gap.rendered}`);
+      }
+    } catch { /* fail-soft */ }
     const { data: existing } = await supabase
       .from('venture_artifacts')
       .select('id')

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -20,6 +20,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-D (FR-004): pre-launch Growth Playbook co-output.
 import { runPrelaunchGrowthCoOutput } from './prelaunch-growth-playbook.js';
+import { describeArtifactGap } from '../../contracts/describe-artifact-gap.js';
 
 const CHANNELS = ['app_store', 'google_ads', 'facebook_instagram', 'twitter_x', 'email', 'blog_seo'];
 
@@ -277,7 +278,7 @@ export async function persistCanonicalPair(supabase, ventureId, channelConfig, a
         artifact_type: w.artifact_type,
         title: w.title,
         is_current: true,
-        source: `worker_sd_leo_feat_stage_distribution_setup_001`,
+        source: 'worker_sd_leo_feat_stage_distribution_setup_001',
         artifact_data: w.artifact_data,
       });
     if (e2) {
@@ -292,6 +293,26 @@ export async function persistCanonicalPair(supabase, ventureId, channelConfig, a
 export async function persistSkipMarker(supabase, ventureId, missing, logger) {
   if (!supabase || !ventureId) return { persisted: false };
   try {
+    const artifactData = {
+      precondition_missing: missing.map(m => m.artifact_type),
+      attempted_at: new Date().toISOString(),
+      required_upstream: REQUIRED_UPSTREAM,
+    };
+    // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5: self-describing skip —
+    // record what the venture ACTUALLY has (+ nearest-match / rename diff)
+    // alongside what is missing. Fail-soft: diagnostics never block the marker.
+    try {
+      const gap = await describeArtifactGap({
+        supabase, ventureId, stage: 21,
+        requiredTypes: missing.map(m => m.artifact_type),
+        logger,
+      });
+      if (gap) {
+        artifactData.gap_detail = gap.rendered;
+        artifactData.gap_matches = gap.matches;
+        logger?.warn?.(`[S22-Distribution] artifact gap detail:\n${gap.rendered}`);
+      }
+    } catch { /* fail-soft */ }
     const { error } = await supabase
       .from('venture_artifacts')
       .insert({
@@ -301,11 +322,7 @@ export async function persistSkipMarker(supabase, ventureId, missing, logger) {
         title: 'Distribution skipped',  // venture_artifacts.title is NOT NULL (FR-4)
         is_current: true,
         source: 'worker_sd_leo_feat_stage_distribution_setup_001',
-        artifact_data: {
-          precondition_missing: missing.map(m => m.artifact_type),
-          attempted_at: new Date().toISOString(),
-          required_upstream: REQUIRED_UPSTREAM,
-        },
+        artifact_data: artifactData,
       });
     if (error) {
       logger?.warn?.(`[S22-Distribution] SKIP marker persist error: ${error.message}`);
@@ -451,7 +468,7 @@ function buildFallback(ventureName) {
         skip_reason: isActive ? null : 'Awaiting GTM data — fallback skip',
         reason: ch === 'app_store' ? 'Primary distribution' : 'Awaiting GTM data',
         ad_copy: isActive
-          ? { headline: `Try ${ventureName}`, body: `[Fallback — regenerate with GTM data]`, cta: 'Get Started' }
+          ? { headline: `Try ${ventureName}`, body: '[Fallback — regenerate with GTM data]', cta: 'Get Started' }
           : null,
         targeting: isActive
           ? { audience: 'Target audience', demographics: 'specified-by-EXEC from persona data', keywords: [ventureName?.toLowerCase() || 'product'] }

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
     "checkin": "node scripts/worker-checkin.cjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",
+    "stage-contracts:check": "node scripts/validate-stage-contract-connectivity.mjs",
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",

--- a/scripts/validate-stage-contract-connectivity.mjs
+++ b/scripts/validate-stage-contract-connectivity.mjs
@@ -1,0 +1,543 @@
+#!/usr/bin/env node
+/**
+ * scripts/validate-stage-contract-connectivity.mjs
+ *
+ * SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-3: stage-contract connectivity
+ * solver. Extends the validate-boundary-config-coherence.mjs recipe (pure
+ * exported check functions + thin main) to the full stage I/O contract estate:
+ *
+ *   C1 REQUIRED_HAS_PRODUCER  (hard)     every venture_stages.required_artifacts[N]
+ *                                        type has a declared producer at some stage
+ *                                        <= N in ARTIFACT_TYPE_BY_STAGE (or is a
+ *                                        cross-cutting gate artifact).
+ *   C2 BOUNDARY_COHERENCE     (hard)     every gate_boundary_config required type
+ *                                        is producible at some stage <= from_stage.
+ *   C3 CONSUMES_SATISFIABLE   (hard)     S18 UPSTREAM_ARTIFACT_TYPES/STAGE_MAP are
+ *                                        internally consistent and each consumed type
+ *                                        has a declared producer at its mapped stage.
+ *                             (advisory) STAGE_CONTRACTS consumes + CROSS_STAGE_DEPS
+ *                                        reference only earlier stages.
+ *   C4 RENAME_ATOMICITY       (hard)     no deprecated/legacy artifact_type alias
+ *                                        appears in a live-enforced DB registry
+ *                                        (venture_stages, gate_boundary_config).
+ *   C5 LEGACY_PARITY          (hard)     stage_artifact_requirements (legacy table,
+ *                                        still the fn_advance fallback) matches
+ *                                        venture_stages.required_artifacts per stage.
+ *                                        Expected RED until the FR-2 sync migration
+ *                                        (20260610_sync_stage_artifact_requirements_
+ *                                        to_ssot.sql) is applied.
+ *   C6 OBSERVED_PRODUCER      (advisory) required types never observed in
+ *                                        venture_artifacts despite ventures having
+ *                                        traversed that stage.
+ *   C7 CONTRACT_MAP_LINT      (hard)     no duplicate stage keys in the
+ *                                        STAGE_CONTRACTS Map source (a duplicate key
+ *                                        silently discards the first entry).
+ *
+ * Exit codes (bracket-tokenized markers per LEO convention):
+ *   0 + [STAGE_CONTRACT_OK]          — all hard checks green
+ *   1 + [STAGE_CONTRACT_DRIFT]       — at least one hard failure
+ *   2 + [STAGE_CONTRACT_INFRA_ERROR] — missing env vars / DB unreachable
+ *
+ * --json: machine-readable JSON on stdout; markers go to stderr so the JSON
+ * stream stays parseable (stderr-marker pattern).
+ *
+ * Failure shape: { check, stage, artifact_type, expected, got, nearest_match }
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import * as artifactTypesMod from '../lib/eva/artifact-types.js';
+import { UPSTREAM_ARTIFACT_TYPES, STAGE_MAP } from '../lib/eva/stage-templates/upstream-artifact-types.js';
+import { STAGE_CONTRACTS, CROSS_STAGE_DEPS } from '../lib/eva/contracts/stage-contracts.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STAGE_CONTRACTS_SOURCE_PATH = path.resolve(__dirname, '..', 'lib', 'eva', 'contracts', 'stage-contracts.js');
+
+// Local-run convenience: load repo .env when present (no-op in CI, where env
+// comes from workflow secrets). Same precedent as scripts/generate-stage-config.cjs.
+try {
+  const { default: dotenv } = await import('dotenv');
+  dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+} catch { /* dotenv unavailable — rely on process env */ }
+
+const { ARTIFACT_TYPES, ARTIFACT_TYPE_BY_STAGE, OLD_TO_NEW_MAP } = artifactTypesMod;
+
+// Defensive: DEPRECATED_ARTIFACT_TYPES is added by FR-1 of this SD; fall back to
+// the known alias list so the solver also runs against pre-FR-1 trees (used to
+// capture the pre-fix evidence run).
+const FALLBACK_DEPRECATED = Object.freeze([
+  'engine_risk_assessment',
+  'engine_revenue_model',
+  'launch_marketing_checklist',
+  'launch_optimization_roadmap',
+  'launch_launch_metrics',
+]);
+const DEPRECATED_TYPES = artifactTypesMod.DEPRECATED_ARTIFACT_TYPES ?? FALLBACK_DEPRECATED;
+
+// Cross-cutting gate artifacts: produced by gate machinery (Devil's Advocate,
+// value-multiplier, lifecycle bridge) at multiple stages, not by a single stage
+// analyzer — treated as universally producible.
+export const CROSS_CUTTING_TYPES = Object.freeze(new Set([
+  ARTIFACT_TYPES.SYSTEM_DEVILS_ADVOCATE_REVIEW,
+  ARTIFACT_TYPES.VALUE_MULTIPLIER_ASSESSMENT,
+  ARTIFACT_TYPES.ECONOMIC_LENS,
+  ARTIFACT_TYPES.LIFECYCLE_SD_BRIDGE,
+  ARTIFACT_TYPES.POST_LIFECYCLE_DECISION,
+]));
+
+export const CHECK_IDS = Object.freeze({
+  C1: 'REQUIRED_HAS_PRODUCER',
+  C2: 'BOUNDARY_COHERENCE',
+  C3: 'CONSUMES_SATISFIABLE',
+  C4: 'RENAME_ATOMICITY',
+  C5: 'LEGACY_PARITY',
+  C6: 'OBSERVED_PRODUCER',
+  C7: 'CONTRACT_MAP_LINT',
+});
+
+// ── shared helpers ───────────────────────────────────────────────────
+
+/** Plain dynamic-programming Levenshtein distance. */
+export function levenshtein(a, b) {
+  if (a === b) return 0;
+  if (!a) return b.length;
+  if (!b) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      curr[j] = Math.min(
+        prev[j] + 1,
+        curr[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+/** Nearest candidate by Levenshtein distance. Returns null for empty candidates. */
+export function nearestType(name, candidates) {
+  let best = null;
+  for (const c of candidates) {
+    if (c === name) continue;
+    const d = levenshtein(name, c);
+    if (!best || d < best.distance) best = { match: c, distance: d };
+  }
+  return best;
+}
+
+function failure({ check, stage = null, artifact_type = null, expected = null, got = null, nearest_match = null }) {
+  return { check, stage, artifact_type, expected, got, nearest_match };
+}
+
+/** Set of types declared producible at any stage <= maxStage. */
+export function producibleAtOrBefore(maxStage, artifactTypeByStage, extraByStage = null) {
+  const set = new Set();
+  for (const [stage, types] of Object.entries(artifactTypeByStage)) {
+    if (Number(stage) > maxStage) continue;
+    for (const t of types || []) set.add(t);
+  }
+  if (extraByStage) {
+    for (const row of extraByStage) {
+      if (row.stage_number > maxStage) continue;
+      for (const t of row.required_artifacts || []) set.add(t);
+    }
+  }
+  return set;
+}
+
+// ── C1 REQUIRED_HAS_PRODUCER ─────────────────────────────────────────
+
+export function checkRequiredHasProducer(ventureStages, artifactTypeByStage, { crossCutting = CROSS_CUTTING_TYPES } = {}) {
+  const failures = [];
+  const allDeclared = producibleAtOrBefore(Infinity, artifactTypeByStage);
+  for (const row of ventureStages) {
+    const producible = producibleAtOrBefore(row.stage_number, artifactTypeByStage);
+    for (const t of row.required_artifacts || []) {
+      if (producible.has(t) || crossCutting.has(t)) continue;
+      failures.push(failure({
+        check: CHECK_IDS.C1,
+        stage: row.stage_number,
+        artifact_type: t,
+        expected: `declared producer at stage <= ${row.stage_number} in ARTIFACT_TYPE_BY_STAGE`,
+        got: allDeclared.has(t) ? 'declared only at a LATER stage' : 'no declared producer at any stage',
+        nearest_match: nearestType(t, [...allDeclared])?.match ?? null,
+      }));
+    }
+  }
+  return failures;
+}
+
+// ── C2 BOUNDARY_COHERENCE ────────────────────────────────────────────
+
+export function checkBoundaryCoherence(boundaries, ventureStages, artifactTypeByStage, { crossCutting = CROSS_CUTTING_TYPES } = {}) {
+  const failures = [];
+  for (const b of boundaries) {
+    const producible = producibleAtOrBefore(b.from_stage, artifactTypeByStage, ventureStages);
+    for (const t of b.required_artifacts || []) {
+      if (producible.has(t) || crossCutting.has(t)) continue;
+      failures.push(failure({
+        check: CHECK_IDS.C2,
+        stage: b.from_stage,
+        artifact_type: t,
+        expected: `producer at stage <= ${b.from_stage} (boundary ${b.from_stage}->${b.to_stage})`,
+        got: 'no upstream producer',
+        nearest_match: nearestType(t, [...producible])?.match ?? null,
+      }));
+    }
+  }
+  return failures;
+}
+
+// ── C3 CONSUMES_SATISFIABLE ──────────────────────────────────────────
+
+export function checkConsumesSatisfiable({
+  upstreamTypes = UPSTREAM_ARTIFACT_TYPES,
+  stageMap = STAGE_MAP,
+  consumerStage = 18,
+  artifactTypeByStage = ARTIFACT_TYPE_BY_STAGE,
+  stageContracts = STAGE_CONTRACTS,
+  crossStageDeps = CROSS_STAGE_DEPS,
+  crossCutting = CROSS_CUTTING_TYPES,
+} = {}) {
+  const failures = [];
+  const advisories = [];
+
+  // Hard: STAGE_MAP and UPSTREAM_ARTIFACT_TYPES must be the same set.
+  const upstreamSet = new Set(upstreamTypes);
+  for (const t of upstreamTypes) {
+    if (!(t in stageMap)) {
+      failures.push(failure({
+        check: CHECK_IDS.C3, stage: consumerStage, artifact_type: t,
+        expected: 'entry in STAGE_MAP', got: 'missing',
+        nearest_match: nearestType(t, Object.keys(stageMap))?.match ?? null,
+      }));
+    }
+  }
+  for (const t of Object.keys(stageMap)) {
+    if (!upstreamSet.has(t)) {
+      failures.push(failure({
+        check: CHECK_IDS.C3, stage: consumerStage, artifact_type: t,
+        expected: 'entry in UPSTREAM_ARTIFACT_TYPES', got: 'STAGE_MAP-only entry',
+        nearest_match: null,
+      }));
+    }
+  }
+
+  // Hard: each consumed type producible at its mapped stage, which must precede the consumer.
+  for (const t of upstreamTypes) {
+    const srcStage = stageMap[t];
+    if (srcStage === undefined) continue; // already failed above
+    if (!(srcStage < consumerStage)) {
+      failures.push(failure({
+        check: CHECK_IDS.C3, stage: srcStage, artifact_type: t,
+        expected: `source stage < ${consumerStage}`, got: `source stage ${srcStage}`,
+        nearest_match: null,
+      }));
+      continue;
+    }
+    const producible = producibleAtOrBefore(srcStage, artifactTypeByStage);
+    if (!producible.has(t) && !crossCutting.has(t)) {
+      failures.push(failure({
+        check: CHECK_IDS.C3, stage: srcStage, artifact_type: t,
+        expected: `declared producer at stage <= ${srcStage}`, got: 'no declared producer',
+        nearest_match: nearestType(t, [...producibleAtOrBefore(Infinity, artifactTypeByStage)])?.match ?? null,
+      }));
+    }
+  }
+
+  // Advisory: STAGE_CONTRACTS consumes must reference earlier stages only.
+  for (const [stageNum, contract] of stageContracts.entries()) {
+    for (const dep of contract.consumes || []) {
+      if (!(dep.stage < stageNum)) {
+        advisories.push(failure({
+          check: CHECK_IDS.C3, stage: stageNum, artifact_type: null,
+          expected: `consumes stage < ${stageNum}`, got: `consumes stage ${dep.stage}`,
+          nearest_match: null,
+        }));
+      }
+    }
+  }
+
+  // Advisory: CROSS_STAGE_DEPS must reference earlier stages only.
+  for (const [stage, deps] of Object.entries(crossStageDeps)) {
+    for (const d of deps || []) {
+      if (!(d < Number(stage))) {
+        advisories.push(failure({
+          check: CHECK_IDS.C3, stage: Number(stage), artifact_type: null,
+          expected: `dependency stage < ${stage}`, got: `dependency stage ${d}`,
+          nearest_match: null,
+        }));
+      }
+    }
+  }
+
+  return { failures, advisories };
+}
+
+// ── C4 RENAME_ATOMICITY ──────────────────────────────────────────────
+
+/**
+ * Live-enforced registries must not reference deprecated aliases or legacy
+ * (pre-rename) names. The legacy stage_artifact_requirements table is NOT
+ * checked here — its entire content is compared by C5 (single-owner reporting).
+ */
+export function checkRenameAtomicity({
+  deprecatedTypes = DEPRECATED_TYPES,
+  oldToNewMap = OLD_TO_NEW_MAP,
+  canonicalValues = new Set(Object.values(ARTIFACT_TYPES)),
+  registries,
+}) {
+  const failures = [];
+  const deprecatedSet = new Set(deprecatedTypes);
+  const deprecatedToCanonical = artifactTypesMod.DEPRECATED_TO_CANONICAL ?? {};
+  for (const reg of registries) {
+    for (const entry of reg.entries) {
+      for (const t of entry.types || []) {
+        const isDeprecated = deprecatedSet.has(t);
+        const isLegacyKey = (t in oldToNewMap) && !canonicalValues.has(t);
+        if (!isDeprecated && !isLegacyKey) continue;
+        const canonical = deprecatedToCanonical[t] ?? oldToNewMap[t] ?? null;
+        failures.push(failure({
+          check: CHECK_IDS.C4,
+          stage: entry.stage ?? null,
+          artifact_type: t,
+          expected: canonical ? `canonical type '${canonical}'` : 'a canonical (non-deprecated) type',
+          got: `${isDeprecated ? 'deprecated alias' : 'legacy pre-rename name'} in ${reg.name}`,
+          nearest_match: canonical,
+        }));
+      }
+    }
+  }
+  return failures;
+}
+
+// ── C5 LEGACY_PARITY ─────────────────────────────────────────────────
+
+export function checkLegacyParity(legacyRows, ventureStages) {
+  const failures = [];
+  const legacyByStage = new Map();
+  for (const r of legacyRows) {
+    if (!legacyByStage.has(r.stage_number)) legacyByStage.set(r.stage_number, new Set());
+    legacyByStage.get(r.stage_number).add(r.artifact_type);
+  }
+  for (const row of ventureStages) {
+    const ssot = new Set(row.required_artifacts || []);
+    const legacy = legacyByStage.get(row.stage_number) || new Set();
+    for (const t of ssot) {
+      if (!legacy.has(t)) {
+        failures.push(failure({
+          check: CHECK_IDS.C5, stage: row.stage_number, artifact_type: t,
+          expected: `row in stage_artifact_requirements (SSOT requires '${t}')`,
+          got: 'missing from legacy table',
+          nearest_match: nearestType(t, [...legacy])?.match ?? null,
+        }));
+      }
+    }
+    for (const t of legacy) {
+      if (!ssot.has(t)) {
+        failures.push(failure({
+          check: CHECK_IDS.C5, stage: row.stage_number, artifact_type: t,
+          expected: `absent (SSOT requires: ${[...ssot].join(', ') || 'none'})`,
+          got: 'stale legacy row',
+          nearest_match: nearestType(t, [...ssot])?.match ?? null,
+        }));
+      }
+    }
+  }
+  return failures;
+}
+
+// ── C6 OBSERVED_PRODUCER (advisory) ──────────────────────────────────
+
+export function checkObservedProducer(ventureStages, observedTypes, maxTraversedStage) {
+  const advisories = [];
+  for (const row of ventureStages) {
+    if (row.stage_number > maxTraversedStage) continue;
+    for (const t of row.required_artifacts || []) {
+      if (observedTypes.has(t)) continue;
+      advisories.push(failure({
+        check: CHECK_IDS.C6, stage: row.stage_number, artifact_type: t,
+        expected: 'at least one venture_artifacts row of this type',
+        got: `never observed (ventures have reached stage ${maxTraversedStage})`,
+        nearest_match: nearestType(t, [...observedTypes])?.match ?? null,
+      }));
+    }
+  }
+  return advisories;
+}
+
+// ── C7 CONTRACT_MAP_LINT ─────────────────────────────────────────────
+
+export function checkContractMapLint(sourceText) {
+  const failures = [];
+  const counts = new Map();
+  for (const line of sourceText.split('\n')) {
+    const m = line.match(/^\s*\[\s*(\d+)\s*,\s*\{/);
+    if (m) counts.set(Number(m[1]), (counts.get(Number(m[1])) || 0) + 1);
+  }
+  for (const [stage, n] of counts) {
+    if (n > 1) {
+      failures.push(failure({
+        check: CHECK_IDS.C7, stage, artifact_type: null,
+        expected: 'unique STAGE_CONTRACTS Map key',
+        got: `${n} entries for stage ${stage} (Map silently keeps only the last)`,
+        nearest_match: null,
+      }));
+    }
+  }
+  return failures;
+}
+
+// ── aggregation ──────────────────────────────────────────────────────
+
+export function runAllChecks({ ventureStages, boundaries, legacyRows, observedTypes, maxTraversedStage, stageContractsSource }) {
+  const failures = [];
+  const advisories = [];
+
+  failures.push(...checkRequiredHasProducer(ventureStages, ARTIFACT_TYPE_BY_STAGE));
+  failures.push(...checkBoundaryCoherence(boundaries, ventureStages, ARTIFACT_TYPE_BY_STAGE));
+
+  const c3 = checkConsumesSatisfiable({});
+  failures.push(...c3.failures);
+  advisories.push(...c3.advisories);
+
+  failures.push(...checkRenameAtomicity({
+    registries: [
+      { name: 'venture_stages.required_artifacts', entries: ventureStages.map(r => ({ stage: r.stage_number, types: r.required_artifacts })) },
+      { name: 'gate_boundary_config.required_artifacts', entries: boundaries.map(b => ({ stage: b.from_stage, types: b.required_artifacts })) },
+    ],
+  }));
+
+  failures.push(...checkLegacyParity(legacyRows, ventureStages));
+  advisories.push(...checkObservedProducer(ventureStages, observedTypes, maxTraversedStage));
+  failures.push(...checkContractMapLint(stageContractsSource));
+
+  const perCheck = {};
+  for (const f of failures) perCheck[f.check] = (perCheck[f.check] || 0) + 1;
+  const perAdvisory = {};
+  for (const a of advisories) perAdvisory[a.check] = (perAdvisory[a.check] || 0) + 1;
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    advisories,
+    summary: failures.length === 0
+      ? `OK: ${ventureStages.length} stages, ${boundaries.length} boundaries, ${legacyRows.length} legacy rows — all hard checks green (${advisories.length} advisories)`
+      : `DRIFT: ${failures.length} hard failure(s) [${Object.entries(perCheck).map(([k, v]) => `${k}:${v}`).join(', ')}], ${advisories.length} advisory(ies)${Object.keys(perAdvisory).length ? ` [${Object.entries(perAdvisory).map(([k, v]) => `${k}:${v}`).join(', ')}]` : ''}`,
+  };
+}
+
+// ── thin main ────────────────────────────────────────────────────────
+
+function renderFailureLine(f) {
+  const nm = f.nearest_match ? ` (nearest: ${f.nearest_match})` : '';
+  const st = f.stage !== null && f.stage !== undefined ? `stage ${f.stage}` : 'global';
+  const at = f.artifact_type ? ` '${f.artifact_type}'` : '';
+  return `  - [${f.check}] ${st}${at}: expected ${f.expected}; got ${f.got}${nm}`;
+}
+
+async function loadObserved(supabase) {
+  const observedTypes = new Set();
+  let maxTraversedStage = -1;
+  const PAGE = 1000;
+  for (let page = 0; page < 60; page++) {
+    const { data, error } = await supabase
+      .from('venture_artifacts')
+      .select('lifecycle_stage, artifact_type')
+      .range(page * PAGE, page * PAGE + PAGE - 1);
+    if (error) throw error;
+    for (const r of data || []) {
+      if (r.artifact_type) observedTypes.add(r.artifact_type);
+      if (typeof r.lifecycle_stage === 'number' && r.lifecycle_stage > maxTraversedStage) {
+        maxTraversedStage = r.lifecycle_stage;
+      }
+    }
+    if (!data || data.length < PAGE) break;
+  }
+  return { observedTypes, maxTraversedStage };
+}
+
+async function main() {
+  const jsonMode = process.argv.includes('--json');
+  const out = jsonMode ? console.error : console.log; // human lines; in --json mode everything human goes to stderr
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[STAGE_CONTRACT_INFRA_ERROR] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(2);
+  }
+
+  const supabase = createClient(url, key, { auth: { persistSession: false } });
+
+  let ventureStages;
+  let boundaries;
+  let legacyRows;
+  let observed;
+  let stageContractsSource;
+  try {
+    const [vsRes, gbRes, legacyRes] = await Promise.all([
+      supabase.from('venture_stages').select('stage_number, stage_name, required_artifacts').order('stage_number'),
+      supabase.from('gate_boundary_config').select('from_stage, to_stage, required_artifacts'),
+      supabase.from('stage_artifact_requirements').select('stage_number, artifact_type'),
+    ]);
+    for (const r of [vsRes, gbRes, legacyRes]) {
+      if (r.error) throw r.error;
+    }
+    ventureStages = vsRes.data || [];
+    boundaries = gbRes.data || [];
+    legacyRows = legacyRes.data || [];
+    observed = await loadObserved(supabase);
+    stageContractsSource = fs.readFileSync(STAGE_CONTRACTS_SOURCE_PATH, 'utf8');
+  } catch (err) {
+    console.error(`[STAGE_CONTRACT_INFRA_ERROR] data load failed: ${err.message || err}`);
+    process.exit(2);
+  }
+
+  const result = runAllChecks({
+    ventureStages,
+    boundaries,
+    legacyRows,
+    observedTypes: observed.observedTypes,
+    maxTraversedStage: observed.maxTraversedStage,
+    stageContractsSource,
+  });
+
+  if (jsonMode) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    if (result.failures.length > 0) {
+      out('Hard failures:');
+      for (const f of result.failures) out(renderFailureLine(f));
+    }
+    if (result.advisories.length > 0) {
+      out('Advisories (non-blocking):');
+      for (const a of result.advisories) out(renderFailureLine(a));
+    }
+  }
+
+  if (!result.ok) {
+    console.error('[STAGE_CONTRACT_DRIFT]', result.summary);
+    process.exit(1);
+  }
+  // OK marker: stdout normally (boundary-script parity); stderr in --json mode
+  // so stdout stays pure JSON.
+  (jsonMode ? console.error : console.log)('[STAGE_CONTRACT_OK]', result.summary);
+  process.exit(0);
+}
+
+// Only run main when executed directly (not when imported by tests).
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  // libuv-safe exit pattern (QF-20260511-469): await main, catch unhandled,
+  // then explicit exit.
+  main().catch((err) => {
+    console.error(`[STAGE_CONTRACT_INFRA_ERROR] Unhandled: ${err?.message || err}`);
+    process.exit(2);
+  });
+}

--- a/tests/integration/artifact-gate.test.js
+++ b/tests/integration/artifact-gate.test.js
@@ -3,7 +3,17 @@
  * SD: SD-UNIFIED-STAGE-GATE-ARTIFACTPRECONDITION-ORCH-001-C
  *
  * Tests the artifact gate logic by calling the RPC with various artifact states.
- * Requires: stage_artifact_requirements table populated via seed script.
+ *
+ * SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001: requirements now come from
+ * venture_stages.required_artifacts (SSOT; the fn reads it canonical-first
+ * since 20260504, and the legacy stage_artifact_requirements table is a
+ * derived mirror after the 20260610 sync migration). Stage-15 expectations
+ * updated blueprint_wireframes -> wireframe_screens accordingly.
+ *
+ * KNOWN PRE-EXISTING FAILURE (2026-06-10, predates SD-LEO-INFRA-STAGE-
+ * CONTRACT-REGISTRY-001): all 6 tests fail with "invalid input syntax for
+ * type json" from the live RPC — an fn_advance_venture_stage call-signature /
+ * overload drift, NOT an artifact-gate logic regression. Needs its own fix SD.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -133,7 +143,8 @@ describe.skipIf(!HAS_REAL_DB)('fn_advance_venture_stage artifact precondition ga
     expect(data.stage).toBe(15);
     expect(data.missing).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ artifact_type: 'blueprint_wireframes' })
+        // SSOT (venture_stages) S15 requirement — was blueprint_wireframes pre-redesign.
+        expect.objectContaining({ artifact_type: 'wireframe_screens' })
       ])
     );
   });
@@ -141,7 +152,7 @@ describe.skipIf(!HAS_REAL_DB)('fn_advance_venture_stage artifact precondition ga
   it('should allow Stage 15 advancement after wireframe artifact inserted', async () => {
     const { error: insertErr } = await supabase.from('venture_artifacts').insert({
       venture_id: testVentureId,
-      artifact_type: 'blueprint_wireframes',
+      artifact_type: 'wireframe_screens',
       lifecycle_stage: 15,
       title: 'Test wireframe screens',
       content: 'Test'

--- a/tests/unit/eva/describe-artifact-gap.test.js
+++ b/tests/unit/eva/describe-artifact-gap.test.js
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the self-describing artifact-gap helper.
+ * SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-5.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  levenshtein,
+  nearestMatch,
+  describeArtifactGap,
+} from '../../../lib/eva/contracts/describe-artifact-gap.js';
+
+function mockSupabaseRows(rows, error = null) {
+  const result = Promise.resolve({ data: rows, error });
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    then: (...args) => result.then(...args),
+  };
+  return { from: vi.fn(() => builder) };
+}
+
+const silentLogger = { warn: vi.fn(), log: vi.fn(), error: vi.fn() };
+
+describe('nearestMatch', () => {
+  it('resolves a deprecated alias to its canonical replacement FIRST (alias hit beats string distance)', () => {
+    const m = nearestMatch('launch_marketing_checklist', ['launch_readiness_checklist', 'launch_test_plan']);
+    expect(m).toEqual({ match: 'launch_readiness_checklist', kind: 'renamed_to', distance: 0 });
+  });
+
+  it('resolves OLD_TO_NEW_MAP legacy keys', () => {
+    const m = nearestMatch('uat_report', ['launch_uat_report']);
+    expect(m).toEqual({ match: 'launch_uat_report', kind: 'renamed_to', distance: 0 });
+  });
+
+  it('detects renamed_from: a candidate that is the legacy name of the required type', () => {
+    const m = nearestMatch('launch_readiness_checklist', ['launch_marketing_checklist']);
+    expect(m).toEqual({ match: 'launch_marketing_checklist', kind: 'renamed_from', distance: 0 });
+  });
+
+  it('falls back to Levenshtein nearest', () => {
+    const m = nearestMatch('marketing_taglin', ['marketing_tagline', 'marketing_seo_meta']);
+    expect(m.kind).toBe('levenshtein');
+    expect(m.match).toBe('marketing_tagline');
+    expect(m.distance).toBe(1);
+  });
+
+  it('returns null for empty inputs', () => {
+    expect(nearestMatch('x', [])).toBeNull();
+    expect(nearestMatch('', ['a'])).toBeNull();
+  });
+
+  it('levenshtein basics', () => {
+    expect(levenshtein('abc', 'abc')).toBe(0);
+    expect(levenshtein('abc', 'axc')).toBe(1);
+  });
+});
+
+describe('describeArtifactGap', () => {
+  it('reports the venture actual types at the failing stage + rename-aware nearest match', async () => {
+    const supabase = mockSupabaseRows([
+      { artifact_type: 'launch_readiness_checklist', lifecycle_stage: 23 },
+      { artifact_type: 'system_devils_advocate_review', lifecycle_stage: 23 },
+      { artifact_type: 'marketing_tagline', lifecycle_stage: 18 },
+    ]);
+
+    const gap = await describeArtifactGap({
+      supabase, ventureId: 'v-1', stage: 23,
+      requiredTypes: ['launch_uat_report'],
+      logger: silentLogger,
+    });
+
+    expect(gap.degraded).toBe(false);
+    expect(gap.required).toEqual(['launch_uat_report']);
+    expect(gap.actual_at_stage).toEqual(['launch_readiness_checklist', 'system_devils_advocate_review']);
+    expect(gap.actual_by_stage['18']).toEqual(['marketing_tagline']);
+    expect(gap.matches[0].required).toBe('launch_uat_report');
+    expect(gap.matches[0].match).toBeTruthy();
+    expect(gap.rendered).toContain('required at stage 23: launch_uat_report');
+    expect(gap.rendered).toContain('venture has at stage 23: launch_readiness_checklist');
+    expect(gap.rendered).toContain('artifact stages present: 18(1), 23(2)');
+  });
+
+  it('reports an alias hit as a RENAME, naming the stale requirement source', async () => {
+    const supabase = mockSupabaseRows([
+      { artifact_type: 'launch_readiness_checklist', lifecycle_stage: 23 },
+    ]);
+
+    const gap = await describeArtifactGap({
+      supabase, ventureId: 'v-1', stage: 25,
+      requiredTypes: ['launch_marketing_checklist'],
+      logger: silentLogger,
+    });
+
+    expect(gap.matches[0]).toMatchObject({
+      required: 'launch_marketing_checklist',
+      match: 'launch_readiness_checklist',
+      kind: 'renamed_to',
+    });
+    expect(gap.rendered).toContain("RENAMED to 'launch_readiness_checklist'");
+    expect(gap.rendered).toContain('venture has NO current artifacts at stage 25');
+  });
+
+  it('handles an empty venture (no artifacts at all)', async () => {
+    const supabase = mockSupabaseRows([]);
+    const gap = await describeArtifactGap({
+      supabase, ventureId: 'v-1', stage: 21,
+      requiredTypes: ['distribution_channel_config'],
+      logger: silentLogger,
+    });
+    expect(gap.actual_at_stage).toEqual([]);
+    expect(gap.actual_by_stage).toEqual({});
+    // Canonical registry still feeds nearest-match even with zero venture rows.
+    expect(gap.matches[0].match).toBeTruthy();
+    expect(gap.rendered).toContain('venture has NO current artifacts at stage 21');
+  });
+
+  it('filters resource-style requirements (venture_resources.deployment_url) out of artifact diffs', async () => {
+    const supabase = mockSupabaseRows([]);
+    const gap = await describeArtifactGap({
+      supabase, ventureId: 'v-1', stage: 22,
+      requiredTypes: ['venture_resources.deployment_url', 'visual_device_screenshots'],
+      logger: silentLogger,
+    });
+    expect(gap.required).toEqual(['visual_device_screenshots']);
+  });
+
+  it('degrades gracefully (no throw) on DB error', async () => {
+    const supabase = mockSupabaseRows(null, new Error('boom'));
+    const gap = await describeArtifactGap({
+      supabase, ventureId: 'v-1', stage: 22,
+      requiredTypes: ['visual_device_screenshots'],
+      logger: silentLogger,
+    });
+    expect(gap.degraded).toBe(true);
+    expect(gap.rendered).toContain('lookup degraded');
+    expect(silentLogger.warn).toHaveBeenCalled();
+  });
+
+  it('degrades gracefully when supabase/ventureId missing', async () => {
+    const gap = await describeArtifactGap({
+      supabase: null, ventureId: null, stage: 1,
+      requiredTypes: ['truth_idea_brief'],
+      logger: silentLogger,
+    });
+    expect(gap.degraded).toBe(true);
+    expect(gap.rendered).toContain('required at stage 1: truth_idea_brief');
+  });
+});

--- a/tests/unit/eva/eva-orchestrator.test.js
+++ b/tests/unit/eva/eva-orchestrator.test.js
@@ -149,13 +149,14 @@ describe('EvaOrchestrator', () => {
     });
   });
 
-  describe('processStage - artifact requirements query (regression for QF-20260525-570)', () => {
-    it('queries stage_artifact_requirements by stage_number, never lifecycle_stage', async () => {
-      // Regression guard: stage_artifact_requirements has a `stage_number` column and
-      // NO `lifecycle_stage` column. QF-20260420-405 wrongly used `lifecycle_stage` here;
-      // the thrown PostgREST error was swallowed by the surrounding catch{}, silently
-      // leaving requiredArtifacts empty so the reality-gate never enforced them. Fixed in
-      // QF-20260525-570; this test prevents the column name from regressing again.
+  describe('processStage - artifact requirements query (SSOT repoint, SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001)', () => {
+    it('queries venture_stages (SSOT) by stage_number and never reads legacy stage_artifact_requirements', async () => {
+      // SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-1: requiredArtifacts is
+      // sourced from venture_stages.required_artifacts (SSOT) — the legacy
+      // stage_artifact_requirements table (stale for S14-S26; fed the
+      // S21/S22 mislabeled-artifact incidents through the generic fallback)
+      // must no longer be queried here. Also preserves the QF-20260525-570
+      // regression guard: key on `stage_number`, never `lifecycle_stage`.
       const eqCalls = [];
       const ventureRow = {
         id: 'v-1', name: 'Test Venture', status: 'active',
@@ -188,9 +189,59 @@ describe('EvaOrchestrator', () => {
         },
       );
 
-      const sarCalls = eqCalls.filter((c) => c.table === 'stage_artifact_requirements');
-      expect(sarCalls.some((c) => c.col === 'stage_number')).toBe(true);
-      expect(sarCalls.some((c) => c.col === 'lifecycle_stage')).toBe(false);
+      const vsCalls = eqCalls.filter((c) => c.table === 'venture_stages');
+      expect(vsCalls.some((c) => c.col === 'stage_number')).toBe(true);
+      expect(vsCalls.some((c) => c.col === 'lifecycle_stage')).toBe(false);
+      // Legacy table must never be touched by the orchestrator anymore.
+      expect(eqCalls.some((c) => c.table === 'stage_artifact_requirements')).toBe(false);
+      expect(mockSupabase.from.mock.calls.some(([table]) => table === 'stage_artifact_requirements')).toBe(false);
+    });
+
+    it('adopts venture_stages.required_artifacts as requiredArtifacts (text[] on one row per stage)', async () => {
+      // venture_stages stores types as a text[] on ONE row per stage (vs
+      // one-row-per-type in the legacy table) — guard the shape translation.
+      const ventureRow = {
+        id: 'v-1', name: 'Test Venture', status: 'active',
+        current_lifecycle_stage: 1, archetype: 'saas',
+        created_at: '2026-01-01', autonomy_level: 'L0',
+      };
+      function makeBuilder(table) {
+        const builder = {
+          select: vi.fn(() => builder),
+          in: vi.fn(() => builder),
+          is: vi.fn(() => builder),
+          single: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+          insert: vi.fn(() => builder),
+          update: vi.fn(() => builder),
+        };
+        builder.eq = vi.fn(() => {
+          if (table === 'venture_stages') {
+            // Awaiting the builder after .eq() must resolve to the SSOT row.
+            return Promise.resolve({ data: [{ required_artifacts: ['truth_idea_brief'] }], error: null });
+          }
+          return builder;
+        });
+        return builder;
+      }
+      const mockSupabase = { from: vi.fn((table) => makeBuilder(table)) };
+      const realityGateFn = vi.fn().mockResolvedValue({ passed: true, status: 'PASS' });
+
+      await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+          evaluateRealityGateFn: realityGateFn,
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      // The per-stage reality gate receives the SSOT-derived requiredArtifacts.
+      expect(realityGateFn).toHaveBeenCalled();
+      const gateArgs = realityGateFn.mock.calls[0][0];
+      expect(gateArgs.requiredArtifacts).toEqual(['truth_idea_brief']);
     });
   });
 

--- a/tests/unit/eva/stage-contract-connectivity.test.js
+++ b/tests/unit/eva/stage-contract-connectivity.test.js
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for the stage-contract connectivity solver (pure checks).
+ * SD-LEO-INFRA-STAGE-CONTRACT-REGISTRY-001 FR-3.
+ *
+ * Each check is exercised with a passing fixture AND a failing fixture.
+ * Network-free: only the exported pure functions are imported; main() guards
+ * on direct execution.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CHECK_IDS,
+  CROSS_CUTTING_TYPES,
+  levenshtein,
+  nearestType,
+  producibleAtOrBefore,
+  checkRequiredHasProducer,
+  checkBoundaryCoherence,
+  checkConsumesSatisfiable,
+  checkRenameAtomicity,
+  checkLegacyParity,
+  checkObservedProducer,
+  checkContractMapLint,
+  runAllChecks,
+} from '../../../scripts/validate-stage-contract-connectivity.mjs';
+import { ARTIFACT_TYPE_BY_STAGE } from '../../../lib/eva/artifact-types.js';
+
+const ATBS_FIXTURE = {
+  1: ['truth_idea_brief'],
+  2: ['truth_ai_critique'],
+  3: ['truth_validation_decision'],
+};
+
+describe('levenshtein / nearestType', () => {
+  it('computes exact distances', () => {
+    expect(levenshtein('abc', 'abc')).toBe(0);
+    expect(levenshtein('abc', 'abd')).toBe(1);
+    expect(levenshtein('', 'ab')).toBe(2);
+    expect(levenshtein('launch_uat_report', 'launch_test_plan')).toBeGreaterThan(0);
+  });
+
+  it('nearestType picks the closest candidate and skips identity', () => {
+    const n = nearestType('truth_idea_brie', ['truth_idea_brief', 'truth_ai_critique']);
+    expect(n.match).toBe('truth_idea_brief');
+    expect(n.distance).toBe(1);
+    expect(nearestType('x', [])).toBeNull();
+  });
+});
+
+describe('producibleAtOrBefore', () => {
+  it('unions declared types up to and including the stage', () => {
+    const set = producibleAtOrBefore(2, ATBS_FIXTURE);
+    expect(set.has('truth_idea_brief')).toBe(true);
+    expect(set.has('truth_ai_critique')).toBe(true);
+    expect(set.has('truth_validation_decision')).toBe(false);
+  });
+
+  it('folds in extraByStage rows (venture_stages requirement side)', () => {
+    const set = producibleAtOrBefore(2, ATBS_FIXTURE, [
+      { stage_number: 1, required_artifacts: ['extra_type'] },
+      { stage_number: 5, required_artifacts: ['too_late'] },
+    ]);
+    expect(set.has('extra_type')).toBe(true);
+    expect(set.has('too_late')).toBe(false);
+  });
+});
+
+describe('C1 REQUIRED_HAS_PRODUCER', () => {
+  it('passes when every required type has a producer at stage <= N', () => {
+    const vs = [
+      { stage_number: 1, required_artifacts: ['truth_idea_brief'] },
+      { stage_number: 3, required_artifacts: ['truth_idea_brief', 'truth_validation_decision'] },
+    ];
+    expect(checkRequiredHasProducer(vs, ATBS_FIXTURE)).toEqual([]);
+  });
+
+  it('passes for cross-cutting gate artifacts at any stage', () => {
+    const vs = [{ stage_number: 17, required_artifacts: ['system_devils_advocate_review'] }];
+    expect(checkRequiredHasProducer(vs, ATBS_FIXTURE)).toEqual([]);
+  });
+
+  it('fails with later-stage-only and no-producer diagnostics + nearest match', () => {
+    const vs = [
+      { stage_number: 1, required_artifacts: ['truth_validation_decision'] }, // declared at 3 (later)
+      { stage_number: 2, required_artifacts: ['totally_unknown_type'] },
+    ];
+    const failures = checkRequiredHasProducer(vs, ATBS_FIXTURE);
+    expect(failures).toHaveLength(2);
+    expect(failures[0]).toMatchObject({
+      check: CHECK_IDS.C1,
+      stage: 1,
+      artifact_type: 'truth_validation_decision',
+      got: 'declared only at a LATER stage',
+    });
+    expect(failures[1].got).toBe('no declared producer at any stage');
+    expect(failures[1].nearest_match).toBeTruthy();
+  });
+
+  it('REGRESSION (live shape): post-FR-1 ARTIFACT_TYPE_BY_STAGE covers the SSOT S20-S26 requirements', () => {
+    const vs = [
+      { stage_number: 20, required_artifacts: ['code_quality_report'] },
+      { stage_number: 21, required_artifacts: ['distribution_channel_config', 'distribution_ad_copy'] },
+      { stage_number: 22, required_artifacts: ['visual_device_screenshots', 'visual_social_graphics'] },
+      { stage_number: 23, required_artifacts: ['launch_readiness_checklist'] },
+      { stage_number: 24, required_artifacts: ['launch_metrics'] },
+      { stage_number: 25, required_artifacts: ['postlaunch_assumptions_vs_reality', 'postlaunch_user_feedback_summary'] },
+      { stage_number: 26, required_artifacts: ['growth_playbook', 'growth_optimization_roadmap'] },
+    ];
+    expect(checkRequiredHasProducer(vs, ARTIFACT_TYPE_BY_STAGE)).toEqual([]);
+  });
+});
+
+describe('C2 BOUNDARY_COHERENCE', () => {
+  const vs = [{ stage_number: 2, required_artifacts: ['from_vs_only'] }];
+
+  it('passes when boundary requirements are producible upstream (ATBS or venture_stages or cross-cutting)', () => {
+    const boundaries = [
+      { from_stage: 3, to_stage: 4, required_artifacts: ['truth_idea_brief', 'from_vs_only', 'system_devils_advocate_review'] },
+    ];
+    expect(checkBoundaryCoherence(boundaries, vs, ATBS_FIXTURE)).toEqual([]);
+  });
+
+  it('fails for orphan boundary types', () => {
+    const boundaries = [{ from_stage: 2, to_stage: 3, required_artifacts: ['truth_validation_decision'] }];
+    const failures = checkBoundaryCoherence(boundaries, vs, ATBS_FIXTURE);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      check: CHECK_IDS.C2,
+      stage: 2,
+      artifact_type: 'truth_validation_decision',
+    });
+  });
+});
+
+describe('C3 CONSUMES_SATISFIABLE', () => {
+  it('passes for an internally consistent consumes spec', () => {
+    const r = checkConsumesSatisfiable({
+      upstreamTypes: ['truth_idea_brief'],
+      stageMap: { truth_idea_brief: 1 },
+      consumerStage: 18,
+      artifactTypeByStage: ATBS_FIXTURE,
+      stageContracts: new Map([[2, { consumes: [{ stage: 1, fields: {} }] }]]),
+      crossStageDeps: { 2: [1] },
+    });
+    expect(r.failures).toEqual([]);
+    expect(r.advisories).toEqual([]);
+  });
+
+  it('fails hard on STAGE_MAP/UPSTREAM set mismatch and unproducible consumed types', () => {
+    const r = checkConsumesSatisfiable({
+      upstreamTypes: ['truth_idea_brief', 'no_map_entry'],
+      stageMap: { truth_idea_brief: 1, map_only_entry: 4, unproducible: 2 },
+      consumerStage: 18,
+      artifactTypeByStage: ATBS_FIXTURE,
+      stageContracts: new Map(),
+      crossStageDeps: {},
+    });
+    const kinds = r.failures.map(f => `${f.artifact_type}:${f.got}`);
+    expect(r.failures.length).toBeGreaterThanOrEqual(2);
+    expect(kinds.some(k => k.startsWith('no_map_entry:'))).toBe(true);
+    expect(kinds.some(k => k.startsWith('map_only_entry:'))).toBe(true);
+  });
+
+  it('flags non-causal consumes/deps as advisories (not hard failures)', () => {
+    const r = checkConsumesSatisfiable({
+      upstreamTypes: [],
+      stageMap: {},
+      artifactTypeByStage: ATBS_FIXTURE,
+      stageContracts: new Map([[2, { consumes: [{ stage: 5, fields: {} }] }]]),
+      crossStageDeps: { 3: [3] },
+    });
+    expect(r.failures).toEqual([]);
+    expect(r.advisories).toHaveLength(2);
+    expect(r.advisories.every(a => a.check === CHECK_IDS.C3)).toBe(true);
+  });
+
+  it('REGRESSION (live shape): the real S18 UPSTREAM_ARTIFACT_TYPES spec is satisfiable', () => {
+    const r = checkConsumesSatisfiable({});
+    expect(r.failures).toEqual([]);
+  });
+});
+
+describe('C4 RENAME_ATOMICITY', () => {
+  it('passes for canonical-only registries', () => {
+    const failures = checkRenameAtomicity({
+      registries: [
+        { name: 'venture_stages.required_artifacts', entries: [{ stage: 23, types: ['launch_readiness_checklist'] }] },
+      ],
+    });
+    expect(failures).toEqual([]);
+  });
+
+  it('flags deprecated aliases with their canonical replacement', () => {
+    const failures = checkRenameAtomicity({
+      registries: [
+        { name: 'venture_stages.required_artifacts', entries: [{ stage: 25, types: ['launch_marketing_checklist'] }] },
+      ],
+    });
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      check: CHECK_IDS.C4,
+      stage: 25,
+      artifact_type: 'launch_marketing_checklist',
+      nearest_match: 'launch_readiness_checklist',
+    });
+  });
+
+  it('flags legacy pre-rename keys (OLD_TO_NEW_MAP keys that are not canonical values)', () => {
+    const failures = checkRenameAtomicity({
+      registries: [
+        { name: 'gate_boundary_config.required_artifacts', entries: [{ stage: 9, types: ['risk_matrix'] }] },
+      ],
+    });
+    expect(failures).toHaveLength(1);
+    expect(failures[0].nearest_match).toBe('engine_risk_matrix');
+  });
+});
+
+describe('C5 LEGACY_PARITY', () => {
+  const vs = [
+    { stage_number: 18, required_artifacts: ['marketing_tagline', 'marketing_seo_meta'] },
+    { stage_number: 23, required_artifacts: ['launch_readiness_checklist'] },
+  ];
+
+  it('passes when the legacy table mirrors the SSOT', () => {
+    const legacy = [
+      { stage_number: 18, artifact_type: 'marketing_tagline' },
+      { stage_number: 18, artifact_type: 'marketing_seo_meta' },
+      { stage_number: 23, artifact_type: 'launch_readiness_checklist' },
+    ];
+    expect(checkLegacyParity(legacy, vs)).toEqual([]);
+  });
+
+  it('reports both missing-from-legacy and stale-legacy rows (the S18/S23 drift class)', () => {
+    const legacy = [
+      { stage_number: 18, artifact_type: 'build_system_prompt' },   // stale (never produced)
+      { stage_number: 23, artifact_type: 'launch_uat_report' },     // stale (renamed away)
+    ];
+    const failures = checkLegacyParity(legacy, vs);
+    const missing = failures.filter(f => f.got === 'missing from legacy table');
+    const stale = failures.filter(f => f.got === 'stale legacy row');
+    expect(missing.map(f => f.artifact_type).sort()).toEqual(['launch_readiness_checklist', 'marketing_seo_meta', 'marketing_tagline']);
+    expect(stale.map(f => f.artifact_type).sort()).toEqual(['build_system_prompt', 'launch_uat_report']);
+    // Nearest-match guides the operator from the stale name to the canonical one.
+    expect(stale.find(f => f.artifact_type === 'launch_uat_report').nearest_match).toBe('launch_readiness_checklist');
+  });
+});
+
+describe('C6 OBSERVED_PRODUCER (advisory)', () => {
+  const vs = [
+    { stage_number: 1, required_artifacts: ['truth_idea_brief'] },
+    { stage_number: 20, required_artifacts: ['code_quality_report'] },
+    { stage_number: 26, required_artifacts: ['growth_playbook'] },
+  ];
+
+  it('only flags never-observed types at stages ventures have actually traversed', () => {
+    const advisories = checkObservedProducer(vs, new Set(['truth_idea_brief']), 23);
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toMatchObject({
+      check: CHECK_IDS.C6,
+      stage: 20,
+      artifact_type: 'code_quality_report',
+    });
+    // stage 26 > maxTraversed 23 -> not flagged; truth_idea_brief observed -> not flagged.
+  });
+
+  it('flags nothing when no venture has traversed any stage', () => {
+    expect(checkObservedProducer(vs, new Set(), -1)).toEqual([]);
+  });
+});
+
+describe('C7 CONTRACT_MAP_LINT', () => {
+  it('passes on unique Map keys', () => {
+    const src = 'const M = new Map([\n  [1, {\n  }],\n  [2, {\n  }],\n]);';
+    expect(checkContractMapLint(src)).toEqual([]);
+  });
+
+  it('flags duplicate Map keys (the silent-discard bug class)', () => {
+    const src = 'const M = new Map([\n  [20, {\n  }],\n  [20, {\n  }],\n  [21, {\n  }],\n]);';
+    const failures = checkContractMapLint(src);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ check: CHECK_IDS.C7, stage: 20 });
+  });
+
+  it('ignores numeric arrays that are not Map entries (CROSS_STAGE_DEPS style)', () => {
+    const src = 'const DEPS = {\n  14: [1, 13],\n  15: [1, 6, 10],\n};';
+    expect(checkContractMapLint(src)).toEqual([]);
+  });
+});
+
+describe('runAllChecks aggregation', () => {
+  it('aggregates failures + advisories with a per-check summary and ok flag', () => {
+    const result = runAllChecks({
+      ventureStages: [{ stage_number: 18, required_artifacts: ['marketing_tagline'] }],
+      boundaries: [],
+      legacyRows: [{ stage_number: 18, artifact_type: 'build_system_prompt' }],
+      observedTypes: new Set(['marketing_tagline']),
+      maxTraversedStage: 23,
+      stageContractsSource: 'new Map([\n  [20, {\n  }],\n  [20, {\n  }],\n]);',
+    });
+    expect(result.ok).toBe(false);
+    // C5: marketing_tagline missing from legacy + build_system_prompt stale; C7: dup 20.
+    expect(result.failures.filter(f => f.check === CHECK_IDS.C5)).toHaveLength(2);
+    expect(result.failures.filter(f => f.check === CHECK_IDS.C7)).toHaveLength(1);
+    expect(result.summary).toContain('DRIFT');
+    expect(result.summary).toContain('LEGACY_PARITY');
+  });
+
+  it('reports ok with a green summary when everything lines up', () => {
+    const result = runAllChecks({
+      ventureStages: [{ stage_number: 18, required_artifacts: ['marketing_tagline'] }],
+      boundaries: [],
+      legacyRows: [{ stage_number: 18, artifact_type: 'marketing_tagline' }],
+      observedTypes: new Set(['marketing_tagline']),
+      maxTraversedStage: 23,
+      stageContractsSource: 'new Map([\n  [20, {\n  }],\n]);',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.summary).toContain('OK');
+  });
+});
+
+describe('CROSS_CUTTING_TYPES', () => {
+  it('covers the gate-machinery artifacts', () => {
+    expect(CROSS_CUTTING_TYPES.has('system_devils_advocate_review')).toBe(true);
+    expect(CROSS_CUTTING_TYPES.has('value_multiplier_assessment')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The venture pipeline's stage I/O contracts drifted across 5+ sources, and the stale `stage_artifact_requirements` registry fed the orchestrator's generic fallback — mislabeling **412 S21 + 1,230 S22 + 2 S16 artifacts** (the S21 incident class, now fully mapped). PLAN ground-truthing corrected the premise: **`venture_stages.required_artifacts` is already the chairman-approved SSOT** (SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-D) and is current — so this consolidates onto it instead of building anything new.

- **FR-1**: orchestrator artifact-requirements read repointed from the stale table to `venture_stages` (text[]-one-row shape handled); `ARTIFACT_TYPE_BY_STAGE[20-24]` aligned canonical-first with legacy tails preserved (historical mislabeled rows keep resolving via `getStageForArtifactType`); dead duplicate `[20]` Map key removed from STAGE_CONTRACTS
- **FR-2**: DML-only migration syncing the legacy registry to the SSOT (26→43 one-type-per-row) + deprecation COMMENTs + `stage_data_contracts` deactivated — **APPLIED to prod via the 3-factor path (`MIGRATION_APPLY_PROD_PASS` sha 6bfe8457)**
- **FR-3**: NEW `scripts/validate-stage-contract-connectivity.mjs` — 7 named checks (REQUIRED_HAS_PRODUCER, BOUNDARY_COHERENCE, CONSUMES_SATISFIABLE, RENAME_ATOMICITY, LEGACY_PARITY, OBSERVED_PRODUCER advisory, CONTRACT_MAP_LINT), structured failures with nearest-match hints, `--json`, npm `stage-contracts:check`
- **FR-4**: NEW CI workflow — contract-relevant PR paths + nightly cron + dispatch
- **FR-5**: NEW `describe-artifact-gap.js` — every NO_PRECONDITION-class failure now self-describes (required type + venture's actual types + alias/Levenshtein nearest match), wired at S21/S22 skip markers, the orchestrator throw, and reality-gate reasons

## Verification

- **Solver pre-fix evidence**: 49 hard failures + 5 advisories on the pre-fix state (named exactly the S18 `build_system_prompt` / S23 `launch_uat_report` / S25 / S26 drift + dup key) — **post-fix + post-apply: `[STAGE_CONTRACT_OK]`, all hard checks green**
- 39/39 new tests; ~165 tests green across the touched estate; pre-existing failures stash-attributed (legacy twin suites + `artifact-gate.test.js` 6/6 — live RPC signature drift, pre-existing, flagged for follow-up)
- Follow-up flags: live `venture_artifacts` CHECK constraint missing `code_quality_report` (a committed-not-deployed migration family); ~2,690 junk rows data-hygiene SD; legacy table DROP via quarantine recipe

## PR Size

+1,627/−53 across 15 files. Justification: ~480 LOC is the solver (single new script), ~480 LOC is tests; the live-code delta is ~220 LOC across 7 files — one defect class, independently reviewed FR groups, sequential-PR alternative would ship the solver without the drift it proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)