### PR TITLE
feat(SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001): site-diversity class escalation + gate the FP corrective auto-finding path

### DIFF
--- a/lib/learning/class-escalation.js
+++ b/lib/learning/class-escalation.js
@@ -1,0 +1,187 @@
+/**
+ * Class-level pattern escalation by SITE DIVERSITY
+ * (SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001).
+ *
+ * Recurring incident CLASSES were promoted to class-level fixes only when a
+ * human noticed ("third artifact-type mismatch this month"). occurrence_count
+ * counts repeats but cannot distinguish "the same site failing five times"
+ * (one fix) from "five DIFFERENT sites failing the same way" (a structural
+ * class). This module records a per-pattern site ledger in
+ * issue_patterns.metadata.sites[] (additive JSONB — no migration) and, when a
+ * pattern accumulates >= N DISTINCT sites (default 3), drafts ONE propose-only
+ * class-fix SD through the normal LEAD gate (createSD inserts status='draft'
+ * by construction — CONST-002 compliant, nothing auto-executes).
+ *
+ * Precision tuned on the known-good historical classes (each should have
+ * escalated at the 3rd distinct site): artifact-type mismatches
+ * (S21/S22/S23 family), phantom-column writes (30 file sites), and
+ * process.exit-after-Supabase hangs (4+ CLIs). The failed corrective-sd
+ * -generator path (5/5 vision-tier false positives — single-doc complaints,
+ * zero site diversity) is gated default-OFF at its score-command call site.
+ *
+ * Every DB-write path here is FAIL-SOFT: escalation problems log and return
+ * null — they never throw into the host recording seam (RCA capture and
+ * knowledge-base writes are more important than escalation).
+ */
+
+export const DEFAULT_MIN_SITES = 3;
+export const MIN_SITES_FLOOR = 2;
+export const SITES_CAP = 50;
+
+/** Effective threshold (env-tunable, floor-clamped). */
+export function minSites(env = process.env) {
+  const raw = Number(env.CLASS_ESCALATION_MIN_SITES);
+  if (!Number.isFinite(raw)) return DEFAULT_MIN_SITES;
+  return Math.max(MIN_SITES_FLOOR, Math.floor(raw));
+}
+
+/**
+ * Canonical site key. Precedence: file > gate > stage > sd_id — the most
+ * location-specific signal wins so "same file, different SDs" stays ONE site
+ * while "different files via the same SD" counts as distinct sites.
+ * Returns null when the occurrence carries no usable site signal.
+ */
+export function siteKeyFrom(site = {}) {
+  const norm = (s) => String(s).trim().replace(/\\/g, '/').toLowerCase();
+  if (site.file) return `file:${norm(site.file)}`;
+  if (site.gate) return `gate:${norm(site.gate)}`;
+  if (site.stage !== undefined && site.stage !== null && site.stage !== '') return `stage:${norm(site.stage)}`;
+  if (site.sd_id) return `sd:${norm(site.sd_id)}`;
+  return null;
+}
+
+/**
+ * Merge a site into a pattern's metadata (pure — returns a NEW metadata object).
+ * @returns {{metadata: object, distinctCount: number, added: boolean}}
+ */
+export function mergeSite(metadata, site, now = new Date()) {
+  const md = { ...(metadata || {}) };
+  const key = siteKeyFrom(site);
+  const sites = Array.isArray(md.sites) ? [...md.sites] : [];
+  if (!key) return { metadata: md, distinctCount: sites.length, added: false };
+  const exists = sites.some((s) => s && s.key === key);
+  if (!exists) {
+    sites.push({
+      key,
+      ...(site.file ? { file: site.file } : {}),
+      ...(site.gate ? { gate: site.gate } : {}),
+      ...(site.stage !== undefined && site.stage !== null && site.stage !== '' ? { stage: site.stage } : {}),
+      ...(site.sd_id ? { sd_id: site.sd_id } : {}),
+      first_seen: now.toISOString(),
+    });
+    while (sites.length > SITES_CAP) sites.shift();
+  }
+  md.sites = sites;
+  return { metadata: md, distinctCount: sites.length, added: !exists };
+}
+
+/**
+ * Escalation predicate. Pure.
+ * @param {object} pattern — issue_patterns row (status, data_quality_status, metadata)
+ */
+export function shouldEscalate(pattern, { threshold, env = process.env } = {}) {
+  const n = threshold ?? minSites(env);
+  if (!pattern) return false;
+  if (pattern.status !== 'active') return false;
+  if (pattern.data_quality_status === 'noise') return false;
+  const md = pattern.metadata || {};
+  if (md.class_escalation && md.class_escalation.sd_key) return false; // exactly once
+  const sites = Array.isArray(md.sites) ? md.sites : [];
+  return sites.length >= n;
+}
+
+/** Build the class-fix SD draft payload (pure — for tests + the drafter). */
+export function buildClassSdInput(pattern) {
+  const md = pattern.metadata || {};
+  const sites = Array.isArray(md.sites) ? md.sites : [];
+  const head = String(pattern.issue_summary || 'recurring issue').slice(0, 80).replace(/\s+/g, ' ').trim();
+  const siteLines = sites.map((s) => `- ${s.key}${s.first_seen ? ` (first seen ${s.first_seen.slice(0, 10)})` : ''}`).join('\n');
+  return {
+    title: `Class fix: ${pattern.category || 'uncategorized'}: ${head}`,
+    description:
+      'CLASS-LEVEL ESCALATION (auto-drafted, propose-only — SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001): ' +
+      `pattern ${pattern.pattern_id} ("${head}") has recurred across ${sites.length} DISTINCT sites — this is a structural class, not an instance. ` +
+      'Each site below failed the same way; instance-level fixes have not stopped the class. ' +
+      'Deliverable: ONE structural fix addressing the class at its shared root (registry/lint/contract/sweep as appropriate), not another per-site patch.\n\n' +
+      `Sites (${sites.length}):\n${siteLines}\n\n` +
+      `Evidence: issue_patterns.pattern_id=${pattern.pattern_id}, occurrence_count=${pattern.occurrence_count}, category=${pattern.category}, severity=${pattern.severity}. ` +
+      'This draft enters the NORMAL LEAD gate — verify the class premise against the live tree before approving (sites may have been fixed since recording).',
+    type: 'infrastructure',
+    priority: pattern.severity === 'critical' ? 'high' : 'medium',
+    source: 'class_escalation',
+  };
+}
+
+/**
+ * Draft the class SD + stamp the pattern. FAIL-SOFT: returns the created
+ * sd_key, or null on any failure (logged, never thrown).
+ */
+export async function escalateToClassSd(supabase, pattern, { now = new Date() } = {}) {
+  try {
+    // Lazy import: scripts/leo-create-sd.js is the proven programmatic draft
+    // path (corrective-triage precedent); its CLI entry is isMainModule-guarded
+    // so importing is side-effect-free. createSD inserts status='draft'.
+    const { createSD } = await import('../../scripts/leo-create-sd.js');
+    const input = buildClassSdInput(pattern);
+    const created = await createSD(input);
+    const sdKey = created?.sd_key || created?.sdKey || created?.id;
+    if (!sdKey) {
+      console.warn(`[class-escalation] createSD returned no key for ${pattern.pattern_id} — not stamping`);
+      return null;
+    }
+    const md = { ...(pattern.metadata || {}) };
+    md.class_escalation = {
+      sd_key: sdKey,
+      escalated_at: now.toISOString(),
+      sites_at_escalation: (md.sites || []).map((s) => s.key),
+    };
+    const { error } = await supabase
+      .from('issue_patterns')
+      .update({ metadata: md, assigned_sd_id: sdKey, assignment_date: now.toISOString() })
+      .eq('id', pattern.id);
+    if (error) {
+      console.warn(`[class-escalation] stamp failed for ${pattern.pattern_id}: ${error.message} (SD ${sdKey} exists — manual stamp ok)`);
+    }
+    console.log(`[class-escalation] CLASS ESCALATED: ${pattern.pattern_id} (${(md.sites || []).length} sites) -> ${sdKey} (draft, LEAD gate)`);
+    return sdKey;
+  } catch (err) {
+    console.warn(`[class-escalation] escalation failed (non-fatal): ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * The seam entry: record a site occurrence on a pattern row and escalate when
+ * the diversity threshold is crossed. FAIL-SOFT end to end — the host write
+ * (RCA capture / knowledge-base) must never be harmed by this path.
+ *
+ * @param {object} supabase  service client
+ * @param {object} pattern   the freshly-read issue_patterns row (id, pattern_id, status, metadata, ...)
+ * @param {object} site      {file?, gate?, stage?, sd_id?}
+ * @returns {Promise<{distinctCount: number, escalatedSdKey: string|null}>}
+ */
+export async function recordSiteAndMaybeEscalate(supabase, pattern, site, opts = {}) {
+  try {
+    if (!pattern || !pattern.id) return { distinctCount: 0, escalatedSdKey: null };
+    const { metadata, distinctCount, added } = mergeSite(pattern.metadata, site, opts.now || new Date());
+    if (added) {
+      const { error } = await supabase
+        .from('issue_patterns')
+        .update({ metadata })
+        .eq('id', pattern.id);
+      if (error) {
+        console.warn(`[class-escalation] site record failed for ${pattern.pattern_id}: ${error.message}`);
+        return { distinctCount, escalatedSdKey: null };
+      }
+    }
+    const candidate = { ...pattern, metadata };
+    if (shouldEscalate(candidate, opts)) {
+      const sdKey = await escalateToClassSd(supabase, candidate, opts);
+      return { distinctCount, escalatedSdKey: sdKey };
+    }
+    return { distinctCount, escalatedSdKey: null };
+  } catch (err) {
+    console.warn(`[class-escalation] recordSiteAndMaybeEscalate failed (non-fatal): ${err.message}`);
+    return { distinctCount: 0, escalatedSdKey: null };
+  }
+}

--- a/lib/learning/issue-knowledge-base.js
+++ b/lib/learning/issue-knowledge-base.js
@@ -221,6 +221,17 @@ export class IssueKnowledgeBase {
     }
 
     console.log(`  ✅ Updated pattern ${pattern_id}: ${newCount} total occurrences`);
+
+    // SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001: record SITE DIVERSITY (sd-level site
+    // at this seam) and escalate a structural class at >=N distinct sites.
+    // FAIL-SOFT by contract — never harms the occurrence write above.
+    try {
+      const { recordSiteAndMaybeEscalate } = await import('./class-escalation.js');
+      await recordSiteAndMaybeEscalate(supabase, updated, { sd_id });
+    } catch (escErr) {
+      console.warn(`  ⚠ class-escalation skipped (non-fatal): ${escErr.message}`);
+    }
+
     return updated;
   }
 

--- a/lib/rca/rca-orchestrator.js
+++ b/lib/rca/rca-orchestrator.js
@@ -262,6 +262,27 @@ async function upsertIssuePattern(supabase, triggerEvent, rcrId, log, resolvedSd
 
     if (!error) {
       log(`[RCA-Orchestrator] Updated issue pattern: ${existing.pattern_id} (count: ${(existing.occurrence_count || 0) + 1})`);
+      // SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001: record SITE DIVERSITY and escalate
+      // a structural class when >=N DISTINCT sites have hit the same pattern.
+      // FAIL-SOFT by contract — never harms the RCA capture above.
+      try {
+        const { recordSiteAndMaybeEscalate } = await import('../learning/class-escalation.js');
+        const { data: fullRow } = await supabase
+          .from('issue_patterns')
+          .select('id, pattern_id, status, data_quality_status, category, severity, issue_summary, occurrence_count, metadata')
+          .eq('pattern_id', existing.pattern_id)
+          .maybeSingle();
+        if (fullRow) {
+          await recordSiteAndMaybeEscalate(supabase, fullRow, {
+            sd_id: resolvedSdId,
+            gate: triggerEvent.gate_name || triggerEvent.validator_name || null,
+            file: triggerEvent.file || null,
+            stage: triggerEvent.stage || null,
+          });
+        }
+      } catch (escErr) {
+        log(`[RCA-Orchestrator] class-escalation skipped (non-fatal): ${escErr.message}`);
+      }
       return existing.pattern_id;
     }
   }
@@ -305,6 +326,26 @@ async function upsertIssuePattern(supabase, triggerEvent, rcrId, log, resolvedSd
   }
 
   log(`[RCA-Orchestrator] Created issue pattern: ${patternId}`);
+  // SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001: record the FIRST site on creation so the
+  // diversity ledger starts at occurrence #1. Fail-soft — never harms the insert.
+  try {
+    const { recordSiteAndMaybeEscalate } = await import('../learning/class-escalation.js');
+    const { data: fullRow } = await supabase
+      .from('issue_patterns')
+      .select('id, pattern_id, status, data_quality_status, category, severity, issue_summary, occurrence_count, metadata')
+      .eq('pattern_id', patternId)
+      .maybeSingle();
+    if (fullRow) {
+      await recordSiteAndMaybeEscalate(supabase, fullRow, {
+        sd_id: resolvedSdId,
+        gate: triggerEvent.gate_name || triggerEvent.validator_name || null,
+        file: triggerEvent.file || null,
+        stage: triggerEvent.stage || null,
+      });
+    }
+  } catch (escErr) {
+    log(`[RCA-Orchestrator] class-escalation skipped (non-fatal): ${escErr.message}`);
+  }
   return patternId;
 }
 

--- a/scripts/eva/score-command.mjs
+++ b/scripts/eva/score-command.mjs
@@ -93,10 +93,21 @@ export async function runScore(options = {}) {
   const score = await scoreSD({ sdKey, visionKey, archKey, scope, dryRun });
 
   // Step 2: Generate corrective SD (only when score has a DB record)
+  // SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001: gated DEFAULT-OFF. This per-score
+  // auto-finding path produced 5/5 false positives (2026-06-10 triage —
+  // vision-tier complaints about single docs, zero site diversity). Class-level
+  // escalation now lives in lib/learning/class-escalation.js (site-diversity
+  // keyed, propose-only). NARROW gate: only this call site — the weekly
+  // eva-master-scheduler corrective round, heal-command, and corrective-triage
+  // promote flows are untouched. Re-enable with CORRECTIVE_AUTO_FINDINGS=on.
   let corrective = null;
   if (!dryRun && score.id) {
-    const generateCorrectiveSD = await getGenerateCorrectiveSD();
-    corrective = await generateCorrectiveSD(score.id);
+    if (process.env.CORRECTIVE_AUTO_FINDINGS === 'on') {
+      const generateCorrectiveSD = await getGenerateCorrectiveSD();
+      corrective = await generateCorrectiveSD(score.id);
+    } else {
+      console.log('  [score-command] corrective auto-finding skipped (CORRECTIVE_AUTO_FINDINGS!=on; class escalation handles multi-site patterns — SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001)');
+    }
   }
 
   return { score, corrective, visionKey, archKey };

--- a/tests/unit/learning/class-escalation.test.js
+++ b/tests/unit/learning/class-escalation.test.js
@@ -1,0 +1,177 @@
+/**
+ * SD-LEO-INFRA-CLASS-LEVEL-PATTERN-001 — site-diversity class escalation.
+ *
+ * Precision backtest on the three known-good historical classes (each should
+ * have escalated at the 3rd DISTINCT site) + false-positive negatives modeled
+ * on the corrective-sd-generator failures (single-doc, zero site diversity).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  siteKeyFrom, mergeSite, shouldEscalate, buildClassSdInput,
+  recordSiteAndMaybeEscalate, minSites, DEFAULT_MIN_SITES, MIN_SITES_FLOOR, SITES_CAP,
+} from '../../../lib/learning/class-escalation.js';
+
+const basePattern = (over = {}) => ({
+  id: 'uuid-1', pattern_id: 'PAT-AUTO-test1234', status: 'active',
+  data_quality_status: null, category: 'infrastructure', severity: 'high',
+  issue_summary: 'artifact type mismatch on persist', occurrence_count: 1, metadata: {},
+  ...over,
+});
+
+describe('siteKeyFrom — canonical site keys', () => {
+  it('precedence: file > gate > stage > sd', () => {
+    expect(siteKeyFrom({ file: 'lib/a.js', gate: 'G', stage: 21, sd_id: 'SD-1' })).toBe('file:lib/a.js');
+    expect(siteKeyFrom({ gate: 'WIRE_CHECK', sd_id: 'SD-1' })).toBe('gate:wire_check');
+    expect(siteKeyFrom({ stage: 21, sd_id: 'SD-1' })).toBe('stage:21');
+    expect(siteKeyFrom({ sd_id: 'SD-ABC-001' })).toBe('sd:sd-abc-001');
+  });
+  it('path normalization: backslashes + case collapse to one site', () => {
+    expect(siteKeyFrom({ file: 'lib\\eva\\Handler.js' })).toBe(siteKeyFrom({ file: 'lib/eva/handler.js' }));
+  });
+  it('no usable signal -> null', () => {
+    expect(siteKeyFrom({})).toBeNull();
+    expect(siteKeyFrom({ stage: '' })).toBeNull();
+  });
+});
+
+describe('mergeSite — diversity ledger', () => {
+  it('dedupes by canonical key; counts distinct sites', () => {
+    let md = {};
+    ({ metadata: md } = mergeSite(md, { file: 'a.js' }));
+    ({ metadata: md } = mergeSite(md, { file: 'A.js' })); // same site (case)
+    const r = mergeSite(md, { file: 'b.js' });
+    expect(r.distinctCount).toBe(2);
+    expect(r.added).toBe(true);
+  });
+  it('caps the ledger at SITES_CAP (FIFO)', () => {
+    let md = {};
+    for (let i = 0; i < SITES_CAP + 5; i++) ({ metadata: md } = mergeSite(md, { file: `f${i}.js` }));
+    expect(md.sites.length).toBe(SITES_CAP);
+  });
+  it('signal-less site is a no-op', () => {
+    const r = mergeSite({}, {});
+    expect(r.added).toBe(false);
+    expect(r.distinctCount).toBe(0);
+  });
+});
+
+describe('minSites — threshold config', () => {
+  it('default 3; env override; floor 2', () => {
+    expect(minSites({})).toBe(DEFAULT_MIN_SITES);
+    expect(minSites({ CLASS_ESCALATION_MIN_SITES: '5' })).toBe(5);
+    expect(minSites({ CLASS_ESCALATION_MIN_SITES: '1' })).toBe(MIN_SITES_FLOOR);
+  });
+});
+
+// ─── Historical backtest (the SD's named known-good classes) ───
+const escalatesAtThirdSite = (sites) => {
+  let md = {};
+  const verdicts = [];
+  for (const s of sites) {
+    ({ metadata: md } = mergeSite(md, s));
+    verdicts.push(shouldEscalate(basePattern({ metadata: md }), { env: {} }));
+  }
+  return verdicts;
+};
+
+describe('historical backtest — each class escalates at EXACTLY the 3rd distinct site', () => {
+  it('artifact-type mismatches (S21/S22/S23 family -> contract registry)', () => {
+    const v = escalatesAtThirdSite([
+      { stage: 21, sd_id: 'SD-A' }, { stage: 22, sd_id: 'SD-B' }, { stage: 23, sd_id: 'SD-C' },
+    ]);
+    expect(v).toEqual([false, false, true]);
+  });
+  it('phantom-column writes (30 file sites -> schema lint)', () => {
+    const v = escalatesAtThirdSite([
+      { file: 'scripts/eva/srip/quality-checker.mjs' },
+      { file: 'scripts/eva/srip/venture-integration.mjs' },
+      { file: 'server/routes/stage24.js' },
+    ]);
+    expect(v).toEqual([false, false, true]);
+  });
+  it('process.exit-after-Supabase hangs (4+ CLIs -> exit-hang sweep)', () => {
+    const v = escalatesAtThirdSite([
+      { file: 'scripts/create-quick-fix.js' },
+      { file: 'scripts/complete-quick-fix.js' },
+      { file: 'scripts/worker-checkin.cjs' },
+    ]);
+    expect(v).toEqual([false, false, true]);
+  });
+});
+
+describe('false-positive negatives (modeled on the 5/5-FP corrective findings)', () => {
+  it('single-site repeated 5x never escalates (the corrective-FP shape)', () => {
+    let md = {};
+    for (let i = 0; i < 5; i++) ({ metadata: md } = mergeSite(md, { file: 'docs/some-vision-doc.md' }));
+    expect(shouldEscalate(basePattern({ metadata: md, occurrence_count: 5 }), { env: {} })).toBe(false);
+  });
+  it('noise-flagged multi-site pattern never escalates', () => {
+    let md = {};
+    for (const f of ['a.js', 'b.js', 'c.js']) ({ metadata: md } = mergeSite(md, { file: f }));
+    expect(shouldEscalate(basePattern({ metadata: md, data_quality_status: 'noise' }), { env: {} })).toBe(false);
+  });
+  it('non-active (resolved) pattern never escalates', () => {
+    let md = {};
+    for (const f of ['a.js', 'b.js', 'c.js']) ({ metadata: md } = mergeSite(md, { file: f }));
+    expect(shouldEscalate(basePattern({ metadata: md, status: 'resolved' }), { env: {} })).toBe(false);
+  });
+  it('already-escalated pattern never re-escalates (exactly once)', () => {
+    let md = { class_escalation: { sd_key: 'SD-CLASS-001' } };
+    for (const f of ['a.js', 'b.js', 'c.js', 'd.js']) ({ metadata: md } = mergeSite(md, { file: f }));
+    expect(shouldEscalate(basePattern({ metadata: md }), { env: {} })).toBe(false);
+  });
+});
+
+describe('class-SD draft payload (propose-only)', () => {
+  it('links every site + frames the structural fix + carries evidence', () => {
+    let md = {};
+    for (const f of ['lib/a.js', 'lib/b.js', 'lib/c.js']) ({ metadata: md } = mergeSite(md, { file: f }));
+    const input = buildClassSdInput(basePattern({ metadata: md }));
+    expect(input.title).toMatch(/^Class fix: infrastructure:/);
+    expect(input.description).toMatch(/3 DISTINCT sites/);
+    expect(input.description).toMatch(/file:lib\/a\.js/);
+    expect(input.description).toMatch(/NORMAL LEAD gate/);
+    expect(input.source).toBe('class_escalation');
+  });
+});
+
+describe('recordSiteAndMaybeEscalate — seam contract (fail-soft)', () => {
+  const mockSb = (updateError = null) => ({
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({ eq: vi.fn(async () => ({ error: updateError })) })),
+    })),
+  });
+
+  it('records the site and returns no escalation below threshold', async () => {
+    const sb = mockSb();
+    const r = await recordSiteAndMaybeEscalate(sb, basePattern(), { file: 'a.js' }, { env: {} });
+    expect(r.distinctCount).toBe(1);
+    expect(r.escalatedSdKey).toBeNull();
+  });
+
+  it('a failing site write is contained (no throw, no escalation)', async () => {
+    const sb = mockSb({ message: 'boom' });
+    const r = await recordSiteAndMaybeEscalate(sb, basePattern(), { file: 'a.js' }, { env: {} });
+    expect(r.escalatedSdKey).toBeNull();
+  });
+
+  it('a null/invalid pattern is a safe no-op', async () => {
+    const r = await recordSiteAndMaybeEscalate(mockSb(), null, { file: 'a.js' }, { env: {} });
+    expect(r).toEqual({ distinctCount: 0, escalatedSdKey: null });
+  });
+});
+
+describe('score-command gate (FR-3 static)', () => {
+  it('the auto-finding call is gated behind CORRECTIVE_AUTO_FINDINGS (default off)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, resolve } = await import('node:path');
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../../');
+    const src = readFileSync(resolve(root, 'scripts/eva/score-command.mjs'), 'utf8');
+    expect(src).toMatch(/CORRECTIVE_AUTO_FINDINGS === 'on'/);
+    expect(src).toMatch(/corrective auto-finding skipped/);
+    // the generator module itself is untouched (narrow gate)
+    const gen = readFileSync(resolve(root, 'scripts/eva/corrective-sd-generator.mjs'), 'utf8');
+    expect(gen).not.toMatch(/CORRECTIVE_AUTO_FINDINGS/);
+  });
+});


### PR DESCRIPTION
## Summary
Recurring incident CLASSES escalated only when a human noticed — `occurrence_count` can't distinguish one site failing 5x (one fix) from 5 DIFFERENT sites failing identically (a structural class). The corrective-sd-generator built for auto-drafting produced **5/5 false positives**.

- **NEW `lib/learning/class-escalation.js`**: canonical site keys (file>gate>stage>sd), `metadata.sites[]` diversity ledger (JSONB, no migration), escalation at **>=3 distinct sites** drafting ONE propose-only class-fix SD via `createSD` (status draft → normal LEAD gate, CONST-002), exactly-once stamp, all fail-soft.
- **Both live seams wired** (rca-orchestrator `upsertIssuePattern` update+insert, issue-knowledge-base `recordOccurrence`) — escalation runs AFTER the host write in try/catch, never harms capture. Dormant pattern-detection-engine untouched.
- **The 5/5-FP path gated default-OFF**: `score-command.mjs`'s per-score auto-finding call behind `CORRECTIVE_AUTO_FINDINGS` — narrow (generator untouched; weekly scheduler round + heal/triage flows unaffected; pinned by a static test).

## Verification
**Historical backtest**: artifact-type mismatch (S21/22/23), phantom-column, and exit-hang classes each escalate at EXACTLY the 3rd distinct site; FP negatives (single-site 5x, noise, resolved, re-escalation) all hold. 19 new tests, 37/37 learning suites. TESTING PASS 96, VALIDATION PASS 92. Gates: 93/97/91/96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)