### PR TITLE
feat(SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001): synthetic canary venture probe — scheduled isolated pipeline health check

### DIFF
--- a/.github/workflows/canary-venture-probe.yml
+++ b/.github/workflows/canary-venture-probe.yml
@@ -1,0 +1,61 @@
+# Synthetic canary venture probe — weekly scheduled pipeline health check.
+# SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001.
+#
+# Drives THE isolated is_demo canary venture through the real stage machinery
+# and classifies every stage; failures file deduped canary_probe_alert rows.
+#
+# FLAG-GATED (cannot become a dormant switch): the job checks
+# leo_feature_flags.CANARY_VENTURE_PROBE_V1 FIRST and exits 0 quietly when
+# disabled (the flag ships OFF; enable via the standard registry flow after the
+# first supervised incremental run). Pattern: adam-exec-email-cron.
+name: Canary Venture Probe
+
+on:
+  schedule:
+    - cron: '17 6 * * 0'   # Sundays 06:17 UTC (dodges top-of-hour congestion)
+  workflow_dispatch:
+    inputs:
+      max_stages:
+        description: 'Bound the run (--max-stages)'
+        required: false
+        default: '26'
+
+concurrency:
+  group: canary-venture-probe
+  cancel-in-progress: false
+
+jobs:
+  canary-probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci --omit=dev --ignore-scripts
+
+      - name: Run canary probe (flag-gated)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set +e
+          node scripts/canary/run-canary-probe.mjs --max-stages "${{ github.event.inputs.max_stages || '26' }}" --teardown | tee probe-output.txt
+          code=${PIPESTATUS[0]}
+          {
+            echo "## Canary Venture Probe"
+            echo ""
+            echo '```'
+            tail -50 probe-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Exit 2 = flag disabled (quiet success); exit 1 = probe FAIL (red).
+          if [ "$code" = "2" ]; then
+            echo "flag disabled — quiet exit" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          exit $code

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -308,7 +308,8 @@ echo "✅ No secrets detected in staged files"
 echo ""
 echo "🔍 Running artifact persistence service enforcement..."
 
-STAGED_JS_FOR_PERSIST=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|ts|mjs|cjs)$' | grep -v 'artifact-persistence-service' | grep -v '__tests__' | grep -v 'test/' | grep -v 'tests/' | grep -v 'backfill-artifact-data' | grep -v 'stage-execution-worker' || true)
+# run-canary-probe: the canary probe resets ITS OWN isolated is_demo fixture venture BACKWARD to stage 1 for deterministic full passes — advanceStage() only moves forward through exit gates (SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001).
+STAGED_JS_FOR_PERSIST=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|ts|mjs|cjs)$' | grep -v 'artifact-persistence-service' | grep -v '__tests__' | grep -v 'test/' | grep -v 'tests/' | grep -v 'backfill-artifact-data' | grep -v 'stage-execution-worker' | grep -v 'run-canary-probe' || true)
 
 if [ ! -z "$STAGED_JS_FOR_PERSIST" ]; then
   PERSIST_VIOLATIONS=""

--- a/package.json
+++ b/package.json
@@ -475,7 +475,8 @@
     "retention:apply": "node scripts/retention-enforce.js --apply",
     "schema:lint": "node scripts/lint/schema-reference-lint.mjs --diff",
     "schema:lint:all": "node scripts/lint/schema-reference-lint.mjs --all",
-    "schema:snapshot:lint": "node scripts/lint/schema-reference-snapshot.mjs"
+    "schema:snapshot:lint": "node scripts/lint/schema-reference-snapshot.mjs",
+    "canary:probe": "node scripts/canary/run-canary-probe.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.85.0",

--- a/scripts/canary/canary-core.mjs
+++ b/scripts/canary/canary-core.mjs
@@ -1,0 +1,142 @@
+/**
+ * Canary probe core — PURE helpers (no fs/DB/network/clock).
+ * SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001.
+ *
+ * The synthetic canary venture probe drives an isolated is_demo venture
+ * through the venture-factory stage machinery and classifies every stage so
+ * regressions (config drift, RPC failures, renderer crashes, contract
+ * mismatches) surface BEFORE a real venture hits them.
+ */
+
+/** Stable identity marker for THE canary venture (idempotent find-or-create). */
+export const CANARY_KEY = 'CANARY-VENTURE-PROBE-001';
+
+/** The feature flag gating scheduled probe runs. */
+export const CANARY_FLAG = 'CANARY_VENTURE_PROBE_V1';
+
+/**
+ * Stages with HARD external dependencies (GitHub repo/Replit provisioning,
+ * live deployment, launch comms, analytics) — confirmed in code during LEAD
+ * validation (stage-execution-worker S18 buildReadiness / S19 build gate,
+ * stage 23-26 launch/metrics surfaces). The probe never attempts these; they
+ * are reported as external_skip so coverage stays honest.
+ */
+export const EXTERNAL_DEP_STAGES = new Set([18, 19, 23, 24, 25, 26]);
+
+/** Probe result statuses. */
+export const STAGE_STATUS = Object.freeze({
+  PASS: 'pass',
+  FAIL: 'fail',
+  BLOCKED: 'blocked',
+  EXTERNAL_SKIP: 'external_skip',
+  NOT_REACHED: 'not_reached',
+});
+
+/**
+ * Build the probe run id. Clock injected for testability (no Date.now here).
+ * @param {Date} now
+ * @param {string} shortId - short random suffix supplied by the runner
+ */
+export function buildRunId(now, shortId) {
+  return `canary-${now.toISOString().slice(0, 10)}-${shortId}`;
+}
+
+/**
+ * Alert dedup key: ONE alert per stage per UTC-day window. A same-day re-run
+ * that fails the same stage must not duplicate the alert.
+ * @param {number} stage
+ * @param {Date} now
+ */
+export function alertDedupKey(stage, now) {
+  return `canary_probe_alert:stage-${stage}:${now.toISOString().slice(0, 10)}`;
+}
+
+/**
+ * Classify a stage_executions row into a probe stage result.
+ * @param {{lifecycle_stage:number, status:string, started_at?:string, completed_at?:string, error_message?:string}} row
+ */
+export function classifyExecutionRow(row) {
+  const duration =
+    row.started_at && row.completed_at
+      ? Date.parse(row.completed_at) - Date.parse(row.started_at)
+      : null;
+  const base = { stage: row.lifecycle_stage, duration_ms: duration };
+  const s = String(row.status || '').toLowerCase();
+  // 'succeeded' is the live stage_executions value (witnessed in the first
+  // canary run); the others are defensive aliases.
+  if (s === 'succeeded' || s === 'completed' || s === 'success' || s === 'passed') {
+    return { ...base, status: STAGE_STATUS.PASS };
+  }
+  if (s === 'failed' || s === 'error') {
+    return { ...base, status: STAGE_STATUS.FAIL, error: row.error_message || 'stage execution failed' };
+  }
+  // running/pending/blocked/anything-else at probe end = blocked
+  return { ...base, status: STAGE_STATUS.BLOCKED, error: row.error_message || `terminal status: ${row.status}` };
+}
+
+/**
+ * Shape the final run report from observed per-stage results.
+ *
+ * @param {Object} opts
+ * @param {string} opts.runId
+ * @param {Date} opts.startedAt
+ * @param {Date} opts.endedAt
+ * @param {number} opts.startStage - venture stage at run start
+ * @param {number} opts.endStage - venture stage at run end
+ * @param {Array} opts.stageResults - classified results (classifyExecutionRow output)
+ * @param {number} opts.maxStage - run bound (--max-stages or the external-dep frontier)
+ * @param {Object} [opts.rowDelta] - net-zero audit {table: countDelta}
+ */
+export function buildRunReport({ runId, startedAt, endedAt, startStage, endStage, stageResults, maxStage, rowDelta }) {
+  const attempted = stageResults.filter(r => r.status !== STAGE_STATUS.EXTERNAL_SKIP);
+  const failures = stageResults.filter(r => r.status === STAGE_STATUS.FAIL);
+  const blocked = stageResults.filter(r => r.status === STAGE_STATUS.BLOCKED);
+  // External-skip frontier: anything in EXTERNAL_DEP_STAGES within the bound
+  // that the venture reached but the probe refused to attempt.
+  return {
+    run_id: runId,
+    started_at: startedAt.toISOString(),
+    ended_at: endedAt.toISOString(),
+    duration_ms: endedAt - startedAt,
+    start_stage: startStage,
+    end_stage: endStage,
+    max_stage: maxStage,
+    stages: stageResults,
+    summary: {
+      attempted: attempted.length,
+      passed: stageResults.filter(r => r.status === STAGE_STATUS.PASS).length,
+      failed: failures.length,
+      blocked: blocked.length,
+      external_skipped: stageResults.filter(r => r.status === STAGE_STATUS.EXTERNAL_SKIP).length,
+    },
+    outcome: failures.length > 0 ? 'FAIL' : blocked.length > 0 ? 'BLOCKED' : 'PASS',
+    row_delta: rowDelta || null,
+  };
+}
+
+/**
+ * Decide whether the probe may run.
+ * @param {{flagEnabled:boolean, forceLocal:boolean}} opts
+ * @returns {{allowed:boolean, reason:string}}
+ */
+export function probeAdmission({ flagEnabled, forceLocal }) {
+  if (flagEnabled) return { allowed: true, reason: 'flag_enabled' };
+  if (forceLocal) return { allowed: true, reason: 'force_local_override' };
+  return {
+    allowed: false,
+    reason: `flag ${CANARY_FLAG} is disabled — enable it (standard registry flow) or pass --force-local for a local verification run`,
+  };
+}
+
+/**
+ * The next stage the probe should drive toward, honoring the external-dep
+ * frontier and the --max-stages bound.
+ * @param {number} currentStage
+ * @param {number} maxStage
+ * @returns {{action:'drive'|'external_skip'|'done', stage:number}}
+ */
+export function nextAction(currentStage, maxStage) {
+  if (currentStage > maxStage) return { action: 'done', stage: currentStage };
+  if (EXTERNAL_DEP_STAGES.has(currentStage)) return { action: 'external_skip', stage: currentStage };
+  return { action: 'drive', stage: currentStage };
+}

--- a/scripts/canary/run-canary-probe.mjs
+++ b/scripts/canary/run-canary-probe.mjs
@@ -1,0 +1,329 @@
+/**
+ * Synthetic canary venture probe runner.
+ * SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001.
+ *
+ * Drives THE permanently-flagged isolated canary venture (is_demo=true —
+ * excluded from Adam scope-registry, eva_ventures sync, fixture dispatch)
+ * through the REAL stage machinery (StageExecutionWorker) and classifies every
+ * stage, so config drift / RPC regressions / renderer crashes / contract
+ * mismatches surface before a real venture hits them.
+ *
+ * Chairman gates are auto-approved under a RECORDED canary policy (rationale
+ * 'canary-auto-policy' through the existing chairman_decisions flow — the
+ * probe tests the MACHINE, not the judgment; override = recording, never a
+ * silent bypass). Stages with hard external deps (18,19,23-26) are reported
+ * external_skip, never attempted.
+ *
+ * Usage:
+ *   node scripts/canary/run-canary-probe.mjs [--max-stages N] [--teardown|--keep]
+ *        [--force-local] [--json]
+ *   npm run canary:probe        (flag-gated; quiet refusal when disabled)
+ *
+ * Gated by leo_feature_flags CANARY_VENTURE_PROBE_V1 (ships OFF). The weekly
+ * cron workflow checks the flag and exits 0 quietly when disabled.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'node:crypto';
+import { config } from 'dotenv';
+import { armCliTeardown } from '../../lib/cli-graceful-exit.js';
+import {
+  CANARY_KEY, CANARY_FLAG, EXTERNAL_DEP_STAGES, STAGE_STATUS,
+  buildRunId, alertDedupKey, classifyExecutionRow, buildRunReport,
+  probeAdmission, nextAction,
+} from './canary-core.mjs';
+
+config();
+
+const args = process.argv.slice(2);
+const argVal = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i !== -1 && args[i + 1] ? args[i + 1] : dflt;
+};
+const MAX_STAGES = parseInt(argVal('--max-stages', '26'), 10);
+const TEARDOWN = args.includes('--teardown') || !args.includes('--keep');
+const FORCE_LOCAL = args.includes('--force-local');
+const AS_JSON = args.includes('--json');
+const STAGE_TIMEOUT_MS = parseInt(process.env.CANARY_STAGE_TIMEOUT_MS || '120000', 10);
+/** Bound on drive iterations — each iteration advances >=1 stage or stops. */
+const MAX_ITERATIONS = 40;
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const log = (...a) => { if (!AS_JSON) console.log(...a); };
+
+async function flagEnabled() {
+  const { data } = await supabase
+    .from('leo_feature_flags')
+    .select('is_enabled')
+    .eq('flag_key', CANARY_FLAG)
+    .maybeSingle();
+  return data?.is_enabled === true;
+}
+
+/** Idempotent find-or-create of THE canary venture. */
+async function provisionCanary() {
+  const { data: existing } = await supabase
+    .from('ventures')
+    .select('id, name, current_lifecycle_stage, is_demo')
+    .eq('is_demo', true)
+    .filter('metadata->>canary_key', 'eq', CANARY_KEY)
+    .maybeSingle();
+  if (existing) return { venture: existing, created: false };
+
+  const { data: created, error } = await supabase
+    .from('ventures')
+    .insert({
+      name: 'Canary Venture Probe',
+      problem_statement: 'Synthetic SRE canary: scheduled isolated pipeline probe (SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001). Not a real venture.',
+      origin_type: 'manual',
+      is_demo: true,
+      metadata: {
+        canary: true,
+        canary_key: CANARY_KEY,
+        created_by_sd: 'SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001',
+        // Stage 1 hydrates from ventures.metadata.stage_zero (the orchestrator's
+        // documented fallback when no Stage 0 artifact exists). The canary gets
+        // a fixed synthetic synthesis so Stage 1 onward exercises the REAL
+        // machinery deterministically.
+        stage_zero: {
+          intent: 'Probe the venture-factory stage machinery end to end on a schedule.',
+          reframed_problem: 'Stage pipeline regressions (config drift, RPC failures, renderer crashes, contract mismatches) are discovered reactively by real ventures instead of proactively by synthetic monitoring.',
+          synthesis: 'A synthetic, permanently-isolated canary venture is driven through every feasible lifecycle stage weekly. Each stage transition is a probe assertion; failures alert the coordinator before any real venture encounters the regression.',
+          target_user: 'EHG platform operators and the fleet coordinator',
+          value_hypothesis: 'Proactive detection of stage-machinery regressions reduces venture-blocking incidents to near zero.',
+          constraints: ['fully isolated (is_demo)', 'net-zero artifacts per run', 'no external service calls (stages 18/19/23-26 skipped)'],
+          source: 'synthetic-canary-fixture',
+        },
+      },
+    })
+    .select('id, name, current_lifecycle_stage, is_demo')
+    .single();
+  if (error) throw new Error(`canary provisioning failed: ${error.message}`);
+  return { venture: created, created: true };
+}
+
+/** Approve pending canary decisions through the EXISTING flow, recorded. */
+async function approveCanaryDecisions(ventureId) {
+  const { data: pending } = await supabase
+    .from('chairman_decisions')
+    .select('id, lifecycle_stage')
+    .eq('venture_id', ventureId)
+    .eq('status', 'pending');
+  let approved = 0;
+  for (const d of pending || []) {
+    const { error } = await supabase
+      .from('chairman_decisions')
+      .update({
+        status: 'approved',
+        decision: 'continue',
+        rationale: 'canary-auto-policy: probe tests the machine, not the judgment (SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001; recorded override, excludable via ventures.is_demo join)',
+        decided_by: 'canary-probe',
+      })
+      .eq('id', d.id)
+      .eq('status', 'pending');
+    if (!error) approved++;
+  }
+  return approved;
+}
+
+/** Count rows tied to the canary venture in run-affected tables (net-zero audit). */
+async function countCanaryRows(ventureId) {
+  const counts = {};
+  for (const table of ['stage_executions', 'venture_artifacts', 'chairman_decisions']) {
+    const { count } = await supabase
+      .from(table)
+      .select('id', { count: 'exact', head: true })
+      .eq('venture_id', ventureId);
+    counts[table] = count ?? 0;
+  }
+  return counts;
+}
+
+/** Reap rows created during this run (the venture itself always persists). */
+async function teardownRunRows(ventureId, sinceIso) {
+  const reaped = {};
+  for (const table of ['stage_executions', 'venture_artifacts', 'chairman_decisions']) {
+    const { data, error } = await supabase
+      .from(table)
+      .delete()
+      .eq('venture_id', ventureId)
+      .gte('created_at', sinceIso)
+      .select('id');
+    reaped[table] = error ? `error: ${error.message}` : (data?.length ?? 0);
+  }
+  return reaped;
+}
+
+/** File ONE deduped alert per failed stage per UTC day. */
+async function fileAlert(stageResult, runId, ventureId, now) {
+  const dedup = alertDedupKey(stageResult.stage, now);
+  const { data: existing } = await supabase
+    .from('session_coordination')
+    .select('id')
+    .filter('payload->>dedup_key', 'eq', dedup)
+    .limit(1);
+  if (existing && existing.length > 0) return { filed: false, dedup };
+
+  const { error } = await supabase.from('session_coordination').insert({
+    message_type: 'INFO',
+    payload: {
+      kind: 'canary_probe_alert',
+      dedup_key: dedup,
+      stage: stageResult.stage,
+      run_id: runId,
+      venture_id: ventureId,
+      error: String(stageResult.error || '').slice(0, 500),
+      sd: 'SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001',
+    },
+  });
+  return { filed: !error, dedup, error: error?.message };
+}
+
+async function currentStage(ventureId) {
+  const { data } = await supabase
+    .from('ventures')
+    .select('current_lifecycle_stage')
+    .eq('id', ventureId)
+    .single();
+  return data?.current_lifecycle_stage ?? 0;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+const startedAt = new Date();
+const runId = buildRunId(startedAt, randomUUID().slice(0, 8));
+
+const admission = probeAdmission({ flagEnabled: await flagEnabled(), forceLocal: FORCE_LOCAL });
+if (!admission.allowed) {
+  console.error(`canary-probe: refused — ${admission.reason}`);
+  await armCliTeardown(2); // SWEEP-CLI-EXIT-001 pattern: drain or backstop, never hang
+} else {
+  log(`🐤 canary probe ${runId} (admission: ${admission.reason}; max-stages ${MAX_STAGES}; ${TEARDOWN ? 'teardown' : 'keep'})`);
+
+  const { venture, created } = await provisionCanary();
+  log(`   venture ${venture.id} (${created ? 'created' : 'reused'}; is_demo=${venture.is_demo}; stage ${venture.current_lifecycle_stage ?? 0})`);
+
+  // Self-heal the orchestrator state at run start: the canary venture is
+  // exclusively probe-driven, so any non-idle state is residue from a prior
+  // (killed/failed) run — reset it so acquireProcessingLock can succeed.
+  const { data: pre } = await supabase
+    .from('ventures').select('orchestrator_state').eq('id', venture.id).single();
+  if (pre?.orchestrator_state && pre.orchestrator_state !== 'idle') {
+    log(`   self-heal: orchestrator_state '${pre.orchestrator_state}' → 'idle' (probe owns this venture exclusively)`);
+    await supabase.from('ventures')
+      .update({ orchestrator_state: 'idle', orchestrator_lock_id: null, orchestrator_lock_acquired_at: null })
+      .eq('id', venture.id);
+  }
+
+  // Full-pass determinism: each run starts from stage 1 (the venture persists
+  // across runs but its progress does not — every scheduled run is a complete
+  // probe of the feasible range). --no-reset continues from the current stage.
+  if (!args.includes('--no-reset') && (venture.current_lifecycle_stage ?? 0) > 1) {
+    log(`   reset: stage ${venture.current_lifecycle_stage} → 1 (deterministic full pass; --no-reset to continue instead)`);
+    await supabase.from('ventures')
+      .update({ current_lifecycle_stage: 1 })
+      .eq('id', venture.id);
+  }
+
+  const preCounts = await countCanaryRows(venture.id);
+  const startStage = await currentStage(venture.id);
+  const stageResults = [];
+  const seenStages = new Set();
+
+  const { StageExecutionWorker } = await import('../../lib/eva/stage-execution-worker.js');
+  const worker = new StageExecutionWorker({
+    supabase,
+    logger: AS_JSON ? { log() {}, warn() {}, error() {} } : console,
+    maxRetries: 1,
+    gateTimeoutMs: 5000, // never hang on a gate — the probe approves then re-drives
+  });
+
+  let stage = startStage;
+  for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+    const act = nextAction(Math.max(stage, 1), MAX_STAGES);
+    if (act.action === 'done') break;
+    if (act.action === 'external_skip') {
+      stageResults.push({ stage: act.stage, status: STAGE_STATUS.EXTERNAL_SKIP, duration_ms: null });
+      log(`   stage ${act.stage}: external_skip (hard external dependency)`);
+      break; // frontier reached — later stages are unreachable without it
+    }
+
+    // Drive (bounded): the worker advances until a boundary/block/fail.
+    const driveStart = new Date().toISOString();
+    try {
+      await Promise.race([
+        worker.processOneStage(venture.id),
+        new Promise((_, rej) => setTimeout(() => rej(new Error(`stage drive exceeded ${STAGE_TIMEOUT_MS}ms`)), STAGE_TIMEOUT_MS).unref?.()),
+      ]);
+    } catch (e) {
+      stageResults.push({ stage, status: STAGE_STATUS.FAIL, duration_ms: null, error: e.message });
+      log(`   stage ${stage}: FAIL (${e.message})`);
+      break;
+    }
+
+    // Classify what the machinery recorded since this drive.
+    const { data: execRows } = await supabase
+      .from('stage_executions')
+      .select('lifecycle_stage, status, started_at, completed_at, error_message')
+      .eq('venture_id', venture.id)
+      .gte('created_at', driveStart)
+      .order('lifecycle_stage', { ascending: true });
+    for (const row of execRows || []) {
+      if (seenStages.has(row.lifecycle_stage)) continue;
+      seenStages.add(row.lifecycle_stage);
+      const result = classifyExecutionRow(row);
+      stageResults.push(result);
+      log(`   stage ${result.stage}: ${result.status}${result.error ? ` (${result.error})` : ''}${result.duration_ms != null ? ` ${result.duration_ms}ms` : ''}`);
+    }
+
+    // Approve any canary decisions the drive created, then continue.
+    const approved = await approveCanaryDecisions(venture.id);
+    if (approved > 0) log(`   approved ${approved} canary decision(s) under the recorded policy`);
+
+    const newStage = await currentStage(venture.id);
+    const hardFail = stageResults.some(r => r.status === STAGE_STATUS.FAIL);
+    if (hardFail) break;
+    if (newStage === stage && approved === 0) {
+      // No progress and nothing to approve — blocked.
+      if (!seenStages.has(newStage)) {
+        stageResults.push({ stage: newStage, status: STAGE_STATUS.BLOCKED, duration_ms: null, error: 'no progress (worker boundary or unresolved gate)' });
+      }
+      break;
+    }
+    stage = newStage;
+  }
+
+  // Alerts for failures (deduped per stage per day).
+  const alerts = [];
+  for (const r of stageResults.filter(x => x.status === STAGE_STATUS.FAIL)) {
+    alerts.push(await fileAlert(r, runId, venture.id, new Date()));
+  }
+
+  // Net-zero teardown (default) — the venture itself persists.
+  let rowDelta = null;
+  if (TEARDOWN) {
+    const reaped = await teardownRunRows(venture.id, startedAt.toISOString());
+    const postCounts = await countCanaryRows(venture.id);
+    rowDelta = {};
+    for (const t of Object.keys(preCounts)) rowDelta[t] = (postCounts[t] ?? 0) - (preCounts[t] ?? 0);
+    log(`   teardown: reaped ${JSON.stringify(reaped)} | row delta vs pre-run ${JSON.stringify(rowDelta)}`);
+  }
+
+  const endStage = await currentStage(venture.id);
+  const report = buildRunReport({
+    runId, startedAt, endedAt: new Date(), startStage, endStage,
+    stageResults, maxStage: MAX_STAGES, rowDelta,
+  });
+  report.alerts = alerts;
+
+  if (AS_JSON) console.log(JSON.stringify(report, null, 1));
+  else {
+    log(`\n🐤 canary probe ${report.outcome}: ${report.summary.passed} pass / ${report.summary.failed} fail / ${report.summary.blocked} blocked / ${report.summary.external_skipped} external_skip (stages ${startStage}→${endStage})`);
+  }
+  // The StageExecutionWorker holds heartbeats/subscriptions that block a
+  // natural drain — arm the SWEEP-CLI-EXIT-001 teardown (undici close +
+  // unref'd backstop) so the probe can never ride to an external SIGTERM.
+  await armCliTeardown(report.outcome === 'FAIL' ? 1 : 0);
+}

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -42,11 +42,19 @@ function aggregateTeardownResults(results) {
 }
 
 // Get all ventures
+// SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001 (FR-5c): demo/canary ventures
+// (is_demo=true — e.g. the synthetic canary probe venture) are excluded from
+// the list by default so they never surface in chairman dashboards/rollups.
+// Opt in with ?include_demo=1.
 router.get('/', asyncHandler(async (req, res) => {
-  const { data, error } = await dbLoader.supabase
+  let query = dbLoader.supabase
     .from('ventures')
     .select('*')
     .order('created_at', { ascending: false });
+  if (req.query.include_demo !== '1') {
+    query = query.or('is_demo.is.null,is_demo.eq.false');
+  }
+  const { data, error } = await query;
 
   if (error) {
     console.error('Error fetching ventures:', error);

--- a/tests/unit/canary/canary-core.test.js
+++ b/tests/unit/canary/canary-core.test.js
@@ -1,0 +1,124 @@
+/**
+ * SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001 (FR-6) — hermetic tests for the
+ * pure canary core. No fs/DB/network/clock: dates injected, fixtures inline.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  CANARY_FLAG, EXTERNAL_DEP_STAGES, STAGE_STATUS,
+  buildRunId, alertDedupKey, classifyExecutionRow, buildRunReport,
+  probeAdmission, nextAction,
+} from '../../../scripts/canary/canary-core.mjs';
+
+const T = new Date('2026-06-10T12:00:00Z');
+
+describe('run identity + alert dedup', () => {
+  it('run id embeds the UTC date and the injected suffix', () => {
+    expect(buildRunId(T, 'abc12345')).toBe('canary-2026-06-10-abc12345');
+  });
+
+  it('dedup key is stable per stage per UTC day (same-day re-run dedupes)', () => {
+    const a = alertDedupKey(7, new Date('2026-06-10T01:00:00Z'));
+    const b = alertDedupKey(7, new Date('2026-06-10T23:59:00Z'));
+    const c = alertDedupKey(7, new Date('2026-06-11T00:01:00Z'));
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(alertDedupKey(8, T)).not.toBe(alertDedupKey(7, T));
+  });
+});
+
+describe('classifyExecutionRow', () => {
+  it('succeeded (live stage_executions value) maps to pass', () => {
+    const r = classifyExecutionRow({ lifecycle_stage: 2, status: 'succeeded' });
+    expect(r.status).toBe(STAGE_STATUS.PASS);
+  });
+
+  it('completed → pass with duration', () => {
+    const r = classifyExecutionRow({
+      lifecycle_stage: 4, status: 'completed',
+      started_at: '2026-06-10T12:00:00Z', completed_at: '2026-06-10T12:00:30Z',
+    });
+    expect(r).toMatchObject({ stage: 4, status: STAGE_STATUS.PASS, duration_ms: 30000 });
+  });
+
+  it('failed → fail with the error message', () => {
+    const r = classifyExecutionRow({ lifecycle_stage: 7, status: 'failed', error_message: 'renderer crashed' });
+    expect(r).toMatchObject({ stage: 7, status: STAGE_STATUS.FAIL, error: 'renderer crashed' });
+  });
+
+  it('anything non-terminal → blocked (never silently pass)', () => {
+    const r = classifyExecutionRow({ lifecycle_stage: 9, status: 'running' });
+    expect(r.status).toBe(STAGE_STATUS.BLOCKED);
+  });
+});
+
+describe('external-dep frontier + bounds (nextAction)', () => {
+  it('drives normal stages within the bound', () => {
+    expect(nextAction(5, 26)).toEqual({ action: 'drive', stage: 5 });
+  });
+
+  it('external_skip exactly the hard-dependency stages', () => {
+    for (const s of [18, 19, 23, 24, 25, 26]) {
+      expect(EXTERNAL_DEP_STAGES.has(s)).toBe(true);
+      expect(nextAction(s, 26).action).toBe('external_skip');
+    }
+    for (const s of [17, 20, 21, 22]) {
+      expect(EXTERNAL_DEP_STAGES.has(s)).toBe(false);
+    }
+  });
+
+  it('honors --max-stages', () => {
+    expect(nextAction(4, 3).action).toBe('done');
+  });
+});
+
+describe('probeAdmission (flag gating)', () => {
+  it('allows when the flag is enabled', () => {
+    expect(probeAdmission({ flagEnabled: true, forceLocal: false }).allowed).toBe(true);
+  });
+  it('allows --force-local for verification runs', () => {
+    const a = probeAdmission({ flagEnabled: false, forceLocal: true });
+    expect(a).toMatchObject({ allowed: true, reason: 'force_local_override' });
+  });
+  it('refuses otherwise, naming the flag', () => {
+    const a = probeAdmission({ flagEnabled: false, forceLocal: false });
+    expect(a.allowed).toBe(false);
+    expect(a.reason).toContain(CANARY_FLAG);
+  });
+});
+
+describe('buildRunReport', () => {
+  const stages = [
+    { stage: 1, status: STAGE_STATUS.PASS, duration_ms: 100 },
+    { stage: 2, status: STAGE_STATUS.PASS, duration_ms: 150 },
+    { stage: 3, status: STAGE_STATUS.FAIL, duration_ms: 50, error: 'rpc missing' },
+    { stage: 18, status: STAGE_STATUS.EXTERNAL_SKIP, duration_ms: null },
+  ];
+
+  it('summarizes counts and outcome FAIL when any stage failed', () => {
+    const rep = buildRunReport({
+      runId: 'canary-2026-06-10-x', startedAt: T, endedAt: new Date(T.getTime() + 5000),
+      startStage: 1, endStage: 3, stageResults: stages, maxStage: 26,
+    });
+    expect(rep.summary).toMatchObject({ passed: 2, failed: 1, blocked: 0, external_skipped: 1 });
+    expect(rep.outcome).toBe('FAIL');
+    expect(rep.duration_ms).toBe(5000);
+  });
+
+  it('outcome PASS when no failures or blocks', () => {
+    const rep = buildRunReport({
+      runId: 'r', startedAt: T, endedAt: T, startStage: 1, endStage: 2,
+      stageResults: stages.filter(s => s.status === STAGE_STATUS.PASS), maxStage: 26,
+    });
+    expect(rep.outcome).toBe('PASS');
+  });
+
+  it('outcome BLOCKED when blocked but not failed; carries the net-zero row delta', () => {
+    const rep = buildRunReport({
+      runId: 'r', startedAt: T, endedAt: T, startStage: 1, endStage: 1,
+      stageResults: [{ stage: 5, status: STAGE_STATUS.BLOCKED, duration_ms: null }],
+      maxStage: 26, rowDelta: { stage_executions: 0, venture_artifacts: 0 },
+    });
+    expect(rep.outcome).toBe('BLOCKED');
+    expect(rep.row_delta).toEqual({ stage_executions: 0, venture_artifacts: 0 });
+  });
+});


### PR DESCRIPTION
@
## SD-LEO-INFRA-SYNTHETIC-CANARY-VENTURE-001

**SRE synthetic monitoring for the venture factory**: one permanently-flagged isolated canary venture (`is_demo=true`) driven through the **real** stage machinery on a weekly schedule, classifying every stage so regressions (config drift, RPC failures, renderer crashes, contract mismatches) surface **before** a real venture hits them — the Stage 2/7/20/21/22 incident family of the past week was all discovered reactively. Pairs with STAGE-CONTRACT-REGISTRY-001 (static solver): this is the runtime proof.

### Design
- **Isolation for free**: `is_demo=true` already excludes the canary from Adam scope-registry, the `eva_ventures` sync triggers, and fixture dispatch; this PR also closes the VALIDATION-flagged gap by filtering it from `GET /ventures` (opt-in `?include_demo=1`).
- **Recorded policy, never silent bypass**: chairman gates are auto-approved **through the existing `chairman_decisions` flow** with the `canary-auto-policy` rationale (override = recording; excludable from DQ calibration via the `is_demo` join).
- **Honest coverage**: stages 18/19/23–26 (GitHub/Replit/launch/analytics — hard external deps confirmed in code) are `external_skip`, never fake-passed.
- **Deterministic full passes**: run-start self-heal of `orchestrator_state` + backward stage reset (probe owns its fixture exclusively; `.husky` named exemption with justification at site — `advanceStage()` only moves forward through exit gates).
- **Net-zero**: run rows reaped at teardown (`--keep` to retain); the venture is the only persistent artifact. One **deduped** `canary_probe_alert` per failed stage per UTC day.
- **Cannot become a dormant switch**: `CANARY_VENTURE_PROBE_V1` enrolled via the standard registry (team owner, low risk-tier, audit `af15dfd9`), ships **OFF**; the Sunday 06:17 UTC workflow checks the flag first and exits 0 quietly when disabled.

### Live verification (supervised, `--force-local --max-stages 2 --teardown`)
- Stages **1→3 driven green through real LLM analysis** (6.7s / 31s / 25s)
- S3 gate decision created and approved under the recorded policy
- Teardown row-delta **0/0/0** (stage_executions / venture_artifacts / chairman_decisions)
- 15/15 hermetic unit tests; iterative hardening during the live runs: `succeeded` status mapping, stale-lock self-heal, `metadata.stage_zero` synthesis hydration, `armCliTeardown` drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@