### PR TITLE
feat(SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001): codify the subsystem review rotation

### DIFF
--- a/.claude/commands/review-subsystem.md
+++ b/.claude/commands/review-subsystem.md
@@ -1,0 +1,128 @@
+<!-- reasoning_effort: high -->
+
+---
+description: "Run a chairman-grade subsystem review: live ground-truth inventory -> code cross-reference -> hand-verified, evidence-cited SD filings -> coordinator/Adam notification -> chairman digest. Usage: /review-subsystem <harness|protocol|data-layer|eva-pipeline|test-estate|scripts-estate|security|docs>"
+---
+
+<!-- HAND-AUTHORED: codified from the chairman's four hand-driven reviews of 2026-06-10
+     (harness, protocol, data layer, EVA pipeline -> 27 evidenced draft SDs).
+     SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001. -->
+
+# /review-subsystem — chairman-grade subsystem review
+
+You are running a **subsystem review**: a read-heavy audit that converts live
+ground truth into evidenced, actionable draft SDs. The four reviews this recipe
+was distilled from produced 27 SDs in one day — the leverage comes from the
+discipline, not the volume.
+
+**ARGUMENTS**: one subsystem name from the rotation registry
+(`lib/coordinator/subsystem-review-rotation.cjs` SUBSYSTEMS):
+`harness | protocol | data-layer | eva-pipeline | test-estate | scripts-estate | security | docs`
+
+## THE QUALITY BAR (non-negotiable)
+
+1. **Live evidence only.** Every finding cites a live query result, a
+   `file:line`, or a row count. Findings derived from docs/READMEs/memory are
+   FORBIDDEN — docs describe intent; you are auditing reality.
+2. **Hand-verify before filing.** Every claim that reaches an SD is re-checked
+   individually against the live source (DB row, catalog entry, file content).
+   Scan artifacts go stale within hours; re-verify before acting.
+3. **Cross-reference shipped fixes.** Query recent completed SDs/PRs touching the
+   subsystem so findings are NET-NEW. Audit the SIBLINGS of fixed functions —
+   post-incident hardening usually fixed the file touched, not the class.
+4. **Grade severity with evidence** (HIGH/MEDIUM/LOW) and give every clean
+   surface an explicit clean bill — absence of findings must be a statement,
+   not silence.
+
+## RECIPE (in order)
+
+1. **Claim context**: run the review under an SD (create one via
+   `/sd-create` or run inside an assigned review SD). The SD MUST stamp
+   `metadata.subsystem_review = '<subsystem>'` — this is how the rotation
+   knows the review happened (stateless registry).
+2. **Inventory ground truth** using the subsystem playbook below. Prefer:
+   live DB queries (service-role — anon RLS returns false-negatives on
+   `feedback` and peers), pg catalogs via the Supabase MCP `execute_sql` tool
+   (`pg_class`, `pg_trigger`, `pg_proc`, `pg_attribute` — census first, then
+   risk-prioritized detail batches), `validation_audit_log`, and live log/heartbeat rows.
+3. **Cross-reference against code**: grep/Explore the repo for consumers,
+   writers, and contracts of every inventoried surface. Single-repo scans
+   cannot adjudicate a shared DB — check both repos when the surface is shared.
+4. **Hand-verify every candidate finding** (quality bar #2).
+5. **File the outputs**:
+   - The review artifact: `docs/audits/<SD-KEY>.md` (inventory + findings +
+     clean bills + consolidation proposals).
+   - MEDIUM+ findings as `feedback` rows (`source_application`, `source_type`
+     NOT NULL; `metadata.sd_key` + a finding kind) so they survive the session.
+   - Tier-3-shaped fixes as draft SDs via `/sd-create` with the evidence inline.
+6. **Notify**: coordinator inbox row (`session_coordination` INFO,
+   `payload.kind='review_supply_result'`, count + headline) and an Adam
+   grooming note (plain feedback row — Adam's sourceableBacklog drops
+   flag-class rows).
+7. **Digest to the chairman**: a compact summary (subsystem, N findings by
+   severity, top-3 headline items, artifact + SD links) via the established
+   digest channel for the session.
+
+## SUBSYSTEM PLAYBOOKS
+
+### harness
+- **Ground truth**: `validation_audit_log` (gate-FP leaderboard: failures by gate over 7d),
+  `sd_phase_handoffs` rejection reasons, `claude_sessions`/`session_coordination` lifecycle rows,
+  bypass-reason fields (an unmined work queue), hook files in `scripts/hooks/` vs `.claude/settings.json` registration.
+- **Cross-ref**: gate executors under `scripts/modules/handoff/executors/`, claim machinery (`scripts/stale-session-sweep.cjs` release paths vs `evaluateSourceSideSignals`).
+- **Known classes**: gate false-positives, silence-bypass claim releases, stale-host hooks, UV-abort commit loss.
+
+### protocol
+- **Ground truth**: `leo_protocol_sections` (publication_status coverage; `npm run protocol:pub-audit`),
+  generated-file hashes (`verifyFileContentHash`), `leo_feature_flags` truthfulness, protocol version vs section churn.
+- **Cross-ref**: section-file mapping JSONs, generator modules, live by-type/by-id section queries (grep ref-counts LIE — only live queries count).
+- **Known classes**: dark sections, mapping drift, digest staleness, retired-content rot.
+
+### data-layer
+- **Ground truth**: pg catalogs via MCP `execute_sql` — table/view/trigger census, `reltuples` (or PostgREST
+  `{count:'estimated', head:true}`), phantom columns vs `pg_attribute`, orphan FK scans. Reuse the
+  data-layer scan recipe (.claude/data-layer-scan-results.json provenance) and `ROW_GROWTH_SNAPSHOT` series.
+- **Cross-ref**: every `from('<table>')` site in BOTH repos; migration files vs live state (`npm run migration:apply-state`).
+- **Known classes**: phantom-column writes (silent 42703 in fire-and-forget), committed-not-applied migrations, dead tables, unbounded growth, null-unsafe triggers.
+
+### eva-pipeline
+- **Ground truth**: `eva_scheduler_heartbeat` (incl. `build_provenance.git_sha` vs origin/main — stale-host detection),
+  `eva_scheduler_metrics`, `okr_generation_log`, `venture_artifacts` distribution vs `stage_artifact_requirements`, `eva_events` backlog.
+- **Cross-ref**: `lib/eva/eva-master-scheduler.js` job/round registries + observe-gates; stage templates; watcher hosting path.
+- **Known classes**: stale daemon builds (SHIP-vs-FLIP), observe-only bypasses, orphaned scheduler queues, raw-JSON KR titles.
+
+### test-estate
+- **Ground truth**: full-tier run results (counts of red files/tests on origin/main), flaky-intel rows, mock-vs-live column pins, configs census (dual roots).
+- **Cross-ref**: db-guards auditor enforcement; tests attempting live INSERTs into prod tables; twins/duplicated suites.
+- **Known classes**: mock-chain rot, drifted column pins, 0xC0000409 abort class, pre-existing red on main (stash-verify before blaming your change).
+
+### scripts-estate
+- **Ground truth**: scripts census vs `package.json` entries (orphans = no importer AND no npm entry AND no doc invocation), archive lag, scratch-dir sprawl, WIRE_CHECK exemption usage.
+- **Cross-ref**: call-graph reachability (the WIRE_CHECK entry-point model), pre-commit/CI references to scripts.
+- **Known classes**: dead-on-arrival files, unwired guards (built but never registered), superseded jobs still armed.
+
+### security
+- **Ground truth**: SECURITY DEFINER functions census (pg_proc), RLS policy coverage per table (pg_policies), key/env handling in hooks and CLIs, `EMERGENCY_*` bypass usage logs.
+- **Cross-ref**: authz guards on chairman/service paths; anon-vs-service client usage in scripts.
+- **Known classes**: missing internal authz on DEFINER RPCs, anon-key false-negatives masking data, bypass envs left enabled.
+
+### docs
+- **Ground truth**: docs/ tree vs reality — broken links, retired content still authoritative-looking, CHANGELOG coverage of merged PRs, `*_DIGEST` staleness.
+- **Cross-ref**: docs referencing deleted scripts/tables (pair with scripts-estate + data-layer outputs); supersession banners.
+- **Known classes**: doc-derived folklore contradicting live contracts (the reason the evidence bar exists).
+
+## OUTPUT CONTRACT
+
+The review is DONE when: the artifact is merged (docs-only PR), MEDIUM+ findings
+are durable feedback rows, Tier-3 candidates are draft SDs with evidence, the
+coordinator + Adam notifications are posted, the chairman digest is emitted, and
+the review SD completes with `metadata.subsystem_review` stamped (the rotation
+advances off that stamp).
+
+## Metadata
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Last Updated**: 2026-06-10
+- **Tags**: review, audit, rotation, fleet, evidence
+- **Author**: SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001

--- a/lib/coordinator/subsystem-review-rotation.cjs
+++ b/lib/coordinator/subsystem-review-rotation.cjs
@@ -1,0 +1,127 @@
+/**
+ * Subsystem review rotation — SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001.
+ *
+ * The chairman hand-drove four subsystem reviews on 2026-06-10 (harness,
+ * protocol, data layer, EVA pipeline) yielding 27 evidenced draft SDs — the
+ * highest-leverage work of the week, and entirely dependent on being asked.
+ * This module makes the rotation STANDING and STATELESS:
+ *
+ *   - The registry derives from SD history: a review SD carries
+ *     metadata.subsystem_review = '<subsystem>'; last_reviewed = the latest
+ *     completion of such an SD per subsystem. No new table, no state file.
+ *   - pickNextDue selects the least-recently-reviewed subsystem
+ *     (never-reviewed first, registry order as the tiebreak).
+ *   - The weekly tick posts ONE coordinator-inbox review-supply row naming the
+ *     subsystem and the /review-subsystem command. It NEVER auto-creates SDs —
+ *     review SDs are the OUTPUT of a worker running the skill.
+ *
+ * Doctrine matches lib/coordinator/row-growth.cjs: pure decisions over injected
+ * data, thin fail-soft IO at the edges.
+ *
+ * @module lib/coordinator/subsystem-review-rotation
+ */
+'use strict';
+
+/** The standing rotation. Order = cold-start priority (never-reviewed tiebreak). */
+const SUBSYSTEMS = [
+  'harness',        // LEO gates, handoffs, hooks, claim machinery
+  'protocol',       // leo_protocol_sections publication pipeline + CLAUDE files
+  'data-layer',     // tables/views/triggers/columns vs code (phantoms, orphans)
+  'eva-pipeline',   // EVA scheduler, stages, venture artifacts, OKR generation
+  'test-estate',    // unit/e2e tiers, mock rot, flaky intel, CI posture
+  'scripts-estate', // scripts/CLI sprawl, orphans, archive lag, npm wiring
+  'security',       // RLS, SECURITY DEFINER RPCs, key handling, authz guards
+  'docs',           // docs/ tree vs reality, retired content, broken links
+];
+
+/** Weekly cadence with jitter tolerance (~6 days). */
+const ROTATION_DUE_MS = 6 * 24 * 60 * 60 * 1000;
+
+const REVIEW_SUPPLY_KIND = 'review_supply';
+
+/**
+ * PURE: derive the rotation table from completed review-SD rows.
+ * @param {Array<{metadata:object|null, status:string, updated_at:string}>} sdRows
+ *   Rows from strategic_directives_v2 carrying metadata.subsystem_review.
+ * @param {string[]} [subsystems]
+ * @returns {Array<{subsystem:string, last_reviewed:string|null, reviews:number}>}
+ */
+function deriveRotation(sdRows, subsystems = SUBSYSTEMS) {
+  const bySubsystem = new Map(subsystems.map((s) => [s, { subsystem: s, last_reviewed: null, reviews: 0 }]));
+  for (const row of sdRows || []) {
+    const name = row && row.metadata && row.metadata.subsystem_review;
+    if (!name || !bySubsystem.has(name)) continue; // unknown names ignored (registry is canonical)
+    if (row.status !== 'completed') continue;      // only completed reviews count
+    const entry = bySubsystem.get(name);
+    entry.reviews += 1;
+    const ts = row.updated_at || null;
+    if (ts && (!entry.last_reviewed || ts > entry.last_reviewed)) entry.last_reviewed = ts;
+  }
+  return [...bySubsystem.values()];
+}
+
+/**
+ * PURE: pick the next-due subsystem — never-reviewed first (registry order),
+ * else the stalest last_reviewed.
+ * @param {Array<{subsystem:string, last_reviewed:string|null}>} rotation
+ * @returns {{subsystem:string, last_reviewed:string|null}|null}
+ */
+function pickNextDue(rotation) {
+  if (!rotation || !rotation.length) return null;
+  const never = rotation.find((r) => !r.last_reviewed);
+  if (never) return never;
+  return [...rotation].sort((a, b) => String(a.last_reviewed).localeCompare(String(b.last_reviewed)))[0];
+}
+
+/**
+ * PURE: is the weekly tick due? Gate on the latest review-supply post time.
+ * Garbage/absent timestamps fail toward due (a missed week beats a silent stall).
+ * @param {string|null} lastPostedAt
+ * @param {number} nowMs
+ * @param {number} [dueMs]
+ * @returns {boolean}
+ */
+function isRotationDue(lastPostedAt, nowMs, dueMs = ROTATION_DUE_MS) {
+  if (!lastPostedAt) return true;
+  const t = new Date(/Z$|[+-]\d{2}:?\d{2}$/.test(String(lastPostedAt)) ? lastPostedAt : lastPostedAt + 'Z').getTime();
+  if (!Number.isFinite(t)) return true;
+  return nowMs - t >= dueMs;
+}
+
+/** IO (fail-soft): completed review-SD rows. */
+async function readReviewHistory(sb) {
+  try {
+    const { data, error } = await sb
+      .from('strategic_directives_v2')
+      .select('metadata, status, updated_at')
+      .eq('status', 'completed')
+      .not('metadata->>subsystem_review', 'is', null);
+    return error ? [] : (data || []);
+  } catch { return []; }
+}
+
+/** IO (fail-soft): when the rotation last posted a review-supply row. */
+async function readLastSupplyPost(sb) {
+  try {
+    const { data, error } = await sb
+      .from('session_coordination')
+      .select('created_at')
+      .eq('message_type', 'INFO')
+      .eq('payload->>kind', REVIEW_SUPPLY_KIND)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error || !data || !data.length) return null;
+    return data[0].created_at;
+  } catch { return null; }
+}
+
+module.exports = {
+  SUBSYSTEMS,
+  ROTATION_DUE_MS,
+  REVIEW_SUPPLY_KIND,
+  deriveRotation,
+  pickNextDue,
+  isRotationDue,
+  readReviewHistory,
+  readLastSupplyPost,
+};

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -43,7 +43,9 @@ const COORDINATOR_CRONS = [
   // the re-assert bug (does not touch the pointer) but still a coordinator cron teardown must remove.
   { key: 'email',     cadence: '7,22,37,52 * * * *',                         command: 'node scripts/coordinator-email-summary.mjs', re_asserts_pointer: false },
   // SD-LEO-INFRA-STANDING-ROW-GROWTH-001: daily governance row-growth gauge (internally due-gated).
-  { key: 'row-growth', cadence: '30 8 * * *',                                command: 'node scripts/row-growth-snapshot.cjs',      re_asserts_pointer: false }
+  { key: 'row-growth', cadence: '30 8 * * *',                                command: 'node scripts/row-growth-snapshot.cjs',      re_asserts_pointer: false },
+  // SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001: weekly subsystem-review rotation (due-gated internally).
+  { key: 'review-rotation', cadence: '0 9 * * 1',                            command: 'node scripts/subsystem-review-rotation.cjs', re_asserts_pointer: false }
 ];
 
 // Basename markers used to recognise coordinator-owned jobs in a CronList() result. The
@@ -55,7 +57,8 @@ const COORD_SCRIPT_MARKERS = [
   'fleet-dashboard.cjs',
   'assign-fleet-identities.cjs',
   'coordinator-email-summary.mjs',
-  'row-growth-snapshot.cjs'
+  'row-growth-snapshot.cjs',
+  'subsystem-review-rotation.cjs'
 ];
 
 function isEnabled() {

--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -33,13 +33,13 @@ afterEach(() => {
 });
 
 describe('teardown-coordinator: inventory + matcher', () => {
-  it('listCoordinatorCrons enumerates all 6 coordinator crons incl the pointer-re-asserting inbox loop', () => {
+  it('listCoordinatorCrons enumerates all 7 coordinator crons incl the pointer-re-asserting inbox loop', () => {
     const crons = listCoordinatorCrons();
-    expect(crons.length).toBe(6); // +row-growth (SD-LEO-INFRA-STANDING-ROW-GROWTH-001)
+    expect(crons.length).toBe(7); // +row-growth +review-rotation (SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001)
     const inbox = crons.find((c) => c.key === 'inbox');
     expect(inbox).toBeTruthy();
     expect(inbox.re_asserts_pointer).toBe(true); // the crux: missing this cron self-reverses teardown
-    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth']);
+    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation']);
   });
 
   it('TS-6: selectCoordinatorCronJobs matches coordinator crons (incl inbox via fleet-dashboard.cjs marker) and excludes non-coordinator jobs', () => {
@@ -76,7 +76,7 @@ describe('teardown-coordinator: clearCoordinatorPointer', () => {
     expect(res.enabled).toBe(true);
     expect(res.refused).toBe(false);
     expect(res.pointer_cleared).toBe(true);
-    expect(res.crons_to_delete.length).toBe(6); // +row-growth (SD-LEO-INFRA-STANDING-ROW-GROWTH-001)
+    expect(res.crons_to_delete.length).toBe(7); // +row-growth +review-rotation (SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001)
     expect(fs.existsSync(tmpPointer)).toBe(false); // pointer file removed
   });
 

--- a/package.json
+++ b/package.json
@@ -375,6 +375,7 @@
     "prepark-wip": "node scripts/prepark-wip.cjs",
     "protocol:pub-audit": "node scripts/protocol-publication-audit.cjs",
     "sre:row-growth": "node scripts/row-growth-snapshot.cjs",
+    "review:rotation": "node scripts/subsystem-review-rotation.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "engine:demo": "node scripts/auto-exec-engine-demo.mjs",
     "checkout-sync:demo": "node scripts/auto-exec-checkout-sync-demo.mjs",

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -76,6 +76,13 @@ export const STANDARD_LOOPS = [
   // management_reviews-45k / sd_baseline_items-13k class within a day, not by accident.
   { key: 'row-growth',  label: 'Governance row-growth gauge (daily)', script: 'row-growth-snapshot.cjs', cron: '30 8 * * *',
     prompt: 'node scripts/row-growth-snapshot.cjs' },
+  // SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001: weekly subsystem-review rotation.
+  // Stateless (registry = completed SDs stamping metadata.subsystem_review); posts ONE
+  // coordinator-inbox review-supply row naming the next-due subsystem + the
+  // /review-subsystem command. Due-gated ~6 days; extra arms/manual runs are no-ops.
+  // Converts idle-fleet gaps into review supply (4 reviews -> 27 evidenced SDs on 2026-06-10).
+  { key: 'review-rotation', label: 'Subsystem review rotation (weekly)', script: 'subsystem-review-rotation.cjs', cron: '0 9 * * 1',
+    prompt: 'node scripts/subsystem-review-rotation.cjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/scripts/subsystem-review-rotation.cjs
+++ b/scripts/subsystem-review-rotation.cjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Weekly subsystem-review rotation tick — SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001.
+ *
+ *   1. Due-gate (~6 days since the last review-supply post; --force overrides).
+ *   2. Derive the rotation table from completed review-SD history (STATELESS:
+ *      SDs carrying metadata.subsystem_review are the registry — no new table).
+ *   3. Pick the next-due subsystem (never-reviewed first).
+ *   4. Post ONE coordinator-inbox review-supply row naming the subsystem and
+ *      the /review-subsystem command. NEVER auto-creates SDs.
+ *
+ * Scheduling: armed weekly by the coordinator (STANDARD_LOOPS, Monday 09:00).
+ * Ad-hoc: npm run review:rotation [-- --force | --dry-run]
+ * ALWAYS exits 0 on operational paths (supply ticks never break the host loop).
+ */
+'use strict';
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const {
+  deriveRotation,
+  pickNextDue,
+  isRotationDue,
+  readReviewHistory,
+  readLastSupplyPost,
+  REVIEW_SUPPLY_KIND,
+} = require('../lib/coordinator/subsystem-review-rotation.cjs');
+
+async function resolveCoordinatorId(sb) {
+  try {
+    const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+    return await getActiveCoordinatorId(sb);
+  } catch { return null; }
+}
+
+async function main() {
+  const force = process.argv.includes('--force');
+  const dryRun = process.argv.includes('--dry-run');
+  const sb = createSupabaseServiceClient();
+
+  const lastPost = await readLastSupplyPost(sb);
+  if (!force && !dryRun && !isRotationDue(lastPost, Date.now())) {
+    console.log(`[review-rotation] not due (last supply post ${lastPost}) — no-op`);
+    return;
+  }
+
+  const history = await readReviewHistory(sb);
+  const rotation = deriveRotation(history);
+  const pick = pickNextDue(rotation);
+
+  console.log('[review-rotation] rotation table:');
+  for (const r of rotation) {
+    console.log(`   ${r.subsystem.padEnd(16)} last_reviewed=${r.last_reviewed || 'never'}  reviews=${r.reviews}`);
+  }
+  if (!pick) { console.log('[review-rotation] empty rotation — no-op'); return; }
+  console.log(`[review-rotation] next due: ${pick.subsystem} (last_reviewed=${pick.last_reviewed || 'never'})`);
+
+  if (dryRun) { console.log('[review-rotation] --dry-run: not posting'); return; }
+
+  try {
+    const coordinatorId = await resolveCoordinatorId(sb);
+    const { error } = await sb.from('session_coordination').insert({
+      target_session: coordinatorId, // null => broadcast, still visible in inbox scans
+      message_type: 'INFO',
+      subject: `[REVIEW-SUPPLY] Weekly subsystem review due: ${pick.subsystem}`,
+      body: `The subsystem review rotation picked '${pick.subsystem}' (last reviewed: ${pick.last_reviewed || 'never'}).\n` +
+        `Assign an idle worker to run: /review-subsystem ${pick.subsystem}\n` +
+        'The skill encodes the recipe (live ground-truth inventory -> code cross-reference -> hand-verified, ' +
+        'evidence-cited SD filings -> coordinator/Adam notification -> chairman digest). ' +
+        'Review SDs must stamp metadata.subsystem_review so the rotation advances.',
+      payload: { kind: REVIEW_SUPPLY_KIND, subsystem: pick.subsystem, last_reviewed: pick.last_reviewed },
+      sender_type: 'system',
+      expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    if (error) console.warn(`[review-rotation] supply post failed (non-fatal): ${error.message}`);
+    else console.log('[review-rotation] review-supply row posted');
+  } catch (e) { console.warn(`[review-rotation] supply post threw (non-fatal): ${e.message}`); }
+}
+
+if (require.main === module) {
+  // Graceful bounded exit: avoid the Windows UV_HANDLE_CLOSING abort after undici
+  // queries (same primitive as row-growth-snapshot.cjs).
+  main()
+    .catch((e) => { console.warn(`[review-rotation] unexpected error (non-fatal): ${e.message}`); })
+    .finally(async () => {
+      try {
+        const { armCliTeardown } = await import('../lib/cli-graceful-exit.js');
+        await armCliTeardown(0);
+      } catch { process.exitCode = 0; }
+    });
+}
+
+module.exports = { main };

--- a/tests/unit/subsystem-review-rotation.test.js
+++ b/tests/unit/subsystem-review-rotation.test.js
@@ -1,0 +1,93 @@
+// SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001 — stateless rotation semantics.
+// The registry derives from completed SDs stamping metadata.subsystem_review;
+// these pin derivation, next-due picking, and the weekly due-gate.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  SUBSYSTEMS,
+  ROTATION_DUE_MS,
+  deriveRotation,
+  pickNextDue,
+  isRotationDue,
+} = require('../../lib/coordinator/subsystem-review-rotation.cjs');
+
+const sd = (subsystem, updated_at, status = 'completed') => ({
+  metadata: { subsystem_review: subsystem }, status, updated_at,
+});
+
+describe('SUBSYSTEMS registry', () => {
+  it('contains 8 subsystems including the four reviewed on 2026-06-10', () => {
+    expect(SUBSYSTEMS).toHaveLength(8);
+    for (const s of ['harness', 'protocol', 'data-layer', 'eva-pipeline']) {
+      expect(SUBSYSTEMS).toContain(s);
+    }
+  });
+});
+
+describe('deriveRotation (pure)', () => {
+  it('cold start: empty history => all never-reviewed, zero reviews', () => {
+    const rot = deriveRotation([]);
+    expect(rot).toHaveLength(8);
+    expect(rot.every((r) => r.last_reviewed === null && r.reviews === 0)).toBe(true);
+  });
+
+  it('latest completion wins; review counts accumulate', () => {
+    const rot = deriveRotation([
+      sd('harness', '2026-06-01T00:00:00Z'),
+      sd('harness', '2026-06-10T00:00:00Z'),
+      sd('protocol', '2026-06-05T00:00:00Z'),
+    ]);
+    const h = rot.find((r) => r.subsystem === 'harness');
+    expect(h.last_reviewed).toBe('2026-06-10T00:00:00Z');
+    expect(h.reviews).toBe(2);
+    expect(rot.find((r) => r.subsystem === 'protocol').reviews).toBe(1);
+  });
+
+  it('ignores unknown subsystem names and non-completed SDs', () => {
+    const rot = deriveRotation([
+      sd('not-a-subsystem', '2026-06-10T00:00:00Z'),
+      sd('harness', '2026-06-10T00:00:00Z', 'in_progress'),
+      { metadata: null, status: 'completed', updated_at: '2026-06-10T00:00:00Z' },
+    ]);
+    expect(rot.every((r) => r.reviews === 0)).toBe(true);
+  });
+});
+
+describe('pickNextDue (pure)', () => {
+  it('never-reviewed wins, in registry order (harness first on cold start)', () => {
+    expect(pickNextDue(deriveRotation([])).subsystem).toBe('harness');
+  });
+
+  it('with one unreviewed subsystem, picks it over stale reviewed ones', () => {
+    const history = SUBSYSTEMS.filter((s) => s !== 'security')
+      .map((s, i) => sd(s, `2026-06-0${(i % 8) + 1}T00:00:00Z`));
+    expect(pickNextDue(deriveRotation(history)).subsystem).toBe('security');
+  });
+
+  it('with all reviewed, picks the stalest', () => {
+    const history = SUBSYSTEMS.map((s, i) => sd(s, `2026-06-${String(i + 2).padStart(2, '0')}T00:00:00Z`));
+    expect(pickNextDue(deriveRotation(history)).subsystem).toBe(SUBSYSTEMS[0]);
+  });
+
+  it('empty rotation => null', () => {
+    expect(pickNextDue([])).toBeNull();
+  });
+});
+
+describe('isRotationDue (pure)', () => {
+  const now = Date.parse('2026-06-10T12:00:00Z');
+  it('due with no prior post; not due within ~6 days; due after', () => {
+    expect(isRotationDue(null, now)).toBe(true);
+    expect(isRotationDue('2026-06-08T12:00:00Z', now)).toBe(false);
+    expect(isRotationDue('2026-06-01T12:00:00Z', now)).toBe(true);
+  });
+  it('garbage timestamps fail toward due', () => {
+    expect(isRotationDue('not-a-date', now)).toBe(true);
+  });
+  it('cadence constant is ~6 days (weekly cron with jitter tolerance)', () => {
+    expect(ROTATION_DUE_MS).toBe(6 * 24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary
Codifies the chairman's subsystem-review pattern (4 hand-driven reviews on 2026-06-10 → **27 evidenced draft SDs**) into a reusable skill + standing weekly rotation, converting idle-fleet gaps into review supply.

## Changes
- **NEW `.claude/commands/review-subsystem.md`** — the review recipe (live ground-truth inventory → code cross-reference → hand-verify → evidence-cited SD filings → coordinator/Adam notification → chairman digest) with a hard quality bar (every finding cites a query/file:line/row-count; **no doc-derived findings**) and playbooks for all 8 rotation subsystems, encoding today's reusable assets (gate-FP leaderboard, MCP pg-catalog extraction, stale-host detection via `build_provenance`, sibling-of-fixed-function auditing).
- **NEW stateless rotation engine** (`lib/coordinator/subsystem-review-rotation.cjs` + `scripts/subsystem-review-rotation.cjs`, `npm run review:rotation`) — the registry derives from completed SDs stamping `metadata.subsystem_review` (no new table/state file); picks the least-recently-reviewed subsystem and posts **one** coordinator-inbox review-supply row. Never auto-creates SDs; due-gated ~6 days; always exits 0.
- **Loop-family wiring** — STANDARD_LOOPS Monday 09:00 + teardown registry/markers; teardown pins bumped 6→7 (live-count verified per the RISK warning).

## Testing
19/19 tests (derivation/pick/due-gate semantics, registry pins, teardown suite at the new count). Live-smoked: cold-start dry-run picks `harness`; live run posted exactly one supply row; immediate re-run no-ops.

SD: SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
