### PR TITLE
fix(eva): purge arrested write-storm residue + venture_artifacts under growth watch [EXECUTED under chairman GO]

### DIFF
--- a/database/migrations/20260610_purge_venture_artifact_storm_residue.sql
+++ b/database/migrations/20260610_purge_venture_artifact_storm_residue.sql
@@ -1,0 +1,94 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: Reversible purge of arrested write-storm residue from venture_artifacts
+-- SD-LEO-FIX-REMEDIATE-ARRESTED-VENTURE-001
+--
+-- ⚠ DO NOT run with apply-migration.js --split-statements (named dollar-quoted DO blocks).
+--
+-- WHAT: Arrested write storms (worker re-running stages every ~30s while a precondition stayed
+--       unmet; root cause FIXED by SD-LEO-FIX-FIX-STAGE-SKIP-001 d624465baf on 2026-06-07 — the
+--       day all storms stopped) left ~2,684 stale rows across 3 artifact types:
+--       launch_test_plan (1,229 stale / stage-22), blueprint_sprint_plan (1,044 stale / stage-19),
+--       build_security_audit (411 stale / stage-21) — 91.3% of the 2,940-row table. The batch
+--       writer's mark-stale+INSERT semantics preserved exactly the current rows (is_current=true),
+--       which this purge NEVER touches.
+--
+-- SAFETY (recipe: management_reviews purge, PR #4518, same day):
+--   * REVERSIBLE: venture_artifacts_storm_quarantine_20260610 holds every deleted row; DOWN restores.
+--   * TYPE-SCOPED + CURRENT-ROW TRIPWIRE: predicate is is_current=false AND artifact_type IN the
+--     3 storm types; a pre-assert RAISES if ANY is_current=true row lands in quarantine —
+--     deleting a live current artifact is structurally impossible.
+--   * FK-SAFE (live-verified): venture_capability_scores.artifact_id is ON DELETE SET NULL with
+--     0 non-null refs; venture_artifact_summaries.artifact_id is RESTRICT but 0 of its rows
+--     reference any stale storm row.
+--   * Backup-bound DELETE (quarantine ids) + bounded lock/statement timeouts; counts computed live.
+--   * NO new constraints: stale versions are legitimate versioning semantics; the storm was a rate
+--     problem (root-cause fixed) and detection now belongs to the row-growth gauge (venture_artifacts
+--     added to GOVERNANCE_TABLES in this same SD).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+SELECT pg_advisory_xact_lock(hashtext('venture_artifacts_storm_purge'));
+
+-- 0) One-shot guard: abort if a prior run's quarantine exists.
+DO $storm_guard$
+BEGIN
+  IF to_regclass('public.venture_artifacts_storm_quarantine_20260610') IS NOT NULL THEN
+    RAISE EXCEPTION 'purge aborted: quarantine table already exists — prior run detected, investigate before re-running';
+  END IF;
+END
+$storm_guard$;
+
+-- 1) Quarantine snapshot: exactly the stale rows of the 3 storm types.
+CREATE TABLE venture_artifacts_storm_quarantine_20260610 AS
+SELECT * FROM venture_artifacts
+WHERE is_current = false
+  AND artifact_type IN ('launch_test_plan', 'blueprint_sprint_plan', 'build_security_audit');
+
+-- 2) Pre-asserts: quarantine non-empty, count parity with the live predicate, and the
+--    CURRENT-ROW TRIPWIRE (zero is_current=true rows quarantined).
+DO $storm_pre$
+DECLARE
+  v_quar bigint;
+  v_live bigint;
+  v_current bigint;
+BEGIN
+  SELECT count(*) INTO v_quar FROM venture_artifacts_storm_quarantine_20260610;
+  SELECT count(*) INTO v_live FROM venture_artifacts
+    WHERE is_current = false
+      AND artifact_type IN ('launch_test_plan', 'blueprint_sprint_plan', 'build_security_audit');
+  SELECT count(*) INTO v_current FROM venture_artifacts_storm_quarantine_20260610 WHERE is_current = true;
+
+  IF v_quar = 0 THEN
+    RAISE EXCEPTION 'purge aborted: quarantine is empty (nothing matches the storm predicate)';
+  END IF;
+  IF v_quar <> v_live THEN
+    RAISE EXCEPTION 'purge aborted: quarantine % <> live predicate count % (snapshot incomplete)', v_quar, v_live;
+  END IF;
+  IF v_current <> 0 THEN
+    RAISE EXCEPTION 'purge aborted: % is_current=true row(s) in quarantine — predicate breached, NEVER delete current artifacts', v_current;
+  END IF;
+
+  RAISE NOTICE 'storm purge: quarantined % stale rows (0 current rows — tripwire clean)', v_quar;
+END
+$storm_pre$;
+
+-- 3) Backup-bound DELETE: exactly the quarantined rows, by id.
+DELETE FROM venture_artifacts va
+USING venture_artifacts_storm_quarantine_20260610 q
+WHERE va.id = q.id;
+
+-- 4) Post-assert: no rows matching the storm predicate remain.
+DO $storm_post$
+DECLARE
+  v_remaining bigint;
+BEGIN
+  SELECT count(*) INTO v_remaining FROM venture_artifacts
+    WHERE is_current = false
+      AND artifact_type IN ('launch_test_plan', 'blueprint_sprint_plan', 'build_security_audit');
+  IF v_remaining <> 0 THEN
+    RAISE EXCEPTION 'purge failed: % predicate-matching row(s) still present after delete', v_remaining;
+  END IF;
+  RAISE NOTICE 'storm purge: complete — stale storm residue removed; current rows untouched';
+END
+$storm_post$;

--- a/database/migrations/20260610_purge_venture_artifact_storm_residue_DOWN.sql
+++ b/database/migrations/20260610_purge_venture_artifact_storm_residue_DOWN.sql
@@ -1,0 +1,41 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- DOWN migration for SD-LEO-FIX-REMEDIATE-ARRESTED-VENTURE-001
+--
+-- ⚠ DO NOT run with apply-migration.js --split-statements (named $storm_restore$ DO block).
+--
+-- Restores the purged stale storm rows from the quarantine table. COLUMN-EXPLICIT (all 28
+-- columns in ordinal order) so schema drift during the verification window fails LOUDLY
+-- instead of silently misaligning. ON CONFLICT (id) DO NOTHING is idempotent; the
+-- post-restore assert RAISES if any quarantined id failed to land. No constraint changes
+-- to undo (the UP adds none). Quarantine table retained until the verification window
+-- passes, then may be dropped manually.
+
+INSERT INTO venture_artifacts (
+  id, venture_id, lifecycle_stage, artifact_type, title, content, file_url, version,
+  is_current, metadata, created_at, created_by, updated_at, quality_score,
+  validation_status, validated_at, validated_by, epistemic_classification,
+  epistemic_evidence, artifact_embedding, embedding_model, embedding_updated_at,
+  indexing_status, source, artifact_data, supports_vision_key, supports_plan_key, platform
+)
+SELECT
+  id, venture_id, lifecycle_stage, artifact_type, title, content, file_url, version,
+  is_current, metadata, created_at, created_by, updated_at, quality_score,
+  validation_status, validated_at, validated_by, epistemic_classification,
+  epistemic_evidence, artifact_embedding, embedding_model, embedding_updated_at,
+  indexing_status, source, artifact_data, supports_vision_key, supports_plan_key, platform
+FROM venture_artifacts_storm_quarantine_20260610
+ON CONFLICT (id) DO NOTHING;
+
+DO $storm_restore$
+DECLARE
+  v_missing bigint;
+BEGIN
+  SELECT count(*) INTO v_missing
+  FROM venture_artifacts_storm_quarantine_20260610 q
+  WHERE NOT EXISTS (SELECT 1 FROM venture_artifacts va WHERE va.id = q.id);
+  IF v_missing <> 0 THEN
+    RAISE EXCEPTION 'rollback incomplete: % quarantined row(s) not present after restore — investigate', v_missing;
+  END IF;
+  RAISE NOTICE 'storm purge rollback: complete — all quarantined rows restored';
+END
+$storm_restore$;

--- a/lib/coordinator/row-growth.cjs
+++ b/lib/coordinator/row-growth.cjs
@@ -46,6 +46,7 @@ const GOVERNANCE_TABLES = [
   'session_coordination',
   'coordination_events',
   'management_reviews',
+  'venture_artifacts',
   'objectives',
   'key_results',
   'okr_generation_log',

--- a/tests/venture-artifact-storm.test.js
+++ b/tests/venture-artifact-storm.test.js
@@ -112,7 +112,7 @@ describe('writeArtifactBatch single-current invariant (cleanup-safety mechanism)
             const inserted = arr.map((r) => ({ ...r, id: String(nextId++) }));
             rows.push(...inserted);
             return {
-              select: (cols) => ({
+              select: (_cols) => ({
                 single: async () => ({ data: inserted[0], error: null }),
                 then: (res) => res({ data: inserted.map(r => ({ id: r.id })), error: null }),
               }),

--- a/tests/venture-artifact-storm.test.js
+++ b/tests/venture-artifact-storm.test.js
@@ -1,0 +1,152 @@
+/**
+ * SD-LEO-FIX-REMEDIATE-ARRESTED-VENTURE-001 — storm residue remediation pins.
+ * All offline: migration static pins + gauge membership + writeArtifactBatch
+ * single-current invariant (the mechanism that preserved exactly the current rows
+ * through 1,200+ storm writes — the cleanup predicate's safety depends on it).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const UP = path.join(ROOT, 'database/migrations/20260610_purge_venture_artifact_storm_residue.sql');
+const DOWN = path.join(ROOT, 'database/migrations/20260610_purge_venture_artifact_storm_residue_DOWN.sql');
+const STORM_TYPES = ['launch_test_plan', 'blueprint_sprint_plan', 'build_security_audit'];
+
+describe('purge migration (UP) — safety invariants', () => {
+  const sql = fs.readFileSync(UP, 'utf8');
+
+  it('carries @approved-by + split-statements warning + bounded timeouts', () => {
+    expect(sql).toMatch(/^--\s*@approved-by:\s*\S+@\S+/m);
+    expect(sql).toMatch(/DO NOT run .*--split-statements/i);
+    expect(sql).toMatch(/SET LOCAL lock_timeout/i);
+    expect(sql).toMatch(/SET LOCAL statement_timeout/i);
+  });
+
+  it('quarantine predicate is type-scoped AND stale-only', () => {
+    expect(sql).toMatch(/is_current = false/);
+    for (const t of STORM_TYPES) expect(sql).toContain(`'${t}'`);
+  });
+
+  it('CURRENT-ROW TRIPWIRE: aborts if any is_current=true row lands in quarantine', () => {
+    expect(sql).toMatch(/WHERE is_current = true/);
+    expect(sql).toMatch(/RAISE EXCEPTION 'purge aborted: % is_current=true row\(s\) in quarantine/);
+  });
+
+  it('aborts on pre-existing quarantine; DELETE is quarantine-id-bound; post-assert present', () => {
+    expect(sql).toMatch(/to_regclass\('public\.venture_artifacts_storm_quarantine_20260610'\)\s+IS NOT NULL/i);
+    expect(sql).toMatch(/DELETE FROM venture_artifacts va\s+USING\s+venture_artifacts_storm_quarantine_20260610 q\s+WHERE va\.id = q\.id/i);
+    expect(sql).toMatch(/RAISE EXCEPTION 'purge failed:/);
+  });
+
+  it('adds NO constraints (stale versions are legitimate; detection is the gauge)', () => {
+    expect(sql).not.toMatch(/ADD CONSTRAINT/i);
+  });
+});
+
+describe('purge migration (DOWN) — reversibility', () => {
+  const sql = fs.readFileSync(DOWN, 'utf8');
+
+  it('column-explicit re-insert (28 cols), idempotent, with completeness assert', () => {
+    expect(sql).toMatch(/INSERT INTO venture_artifacts\s*\(/i);
+    expect(sql).not.toMatch(/INSERT INTO venture_artifacts\s+SELECT \*/i);
+    expect(sql).toMatch(/ON CONFLICT \(id\) DO NOTHING/i);
+    expect(sql).toMatch(/RAISE EXCEPTION 'rollback incomplete:/);
+    // all 28 live columns named
+    for (const col of ['artifact_embedding', 'supports_plan_key', 'platform', 'epistemic_evidence']) {
+      expect(sql).toContain(col);
+    }
+  });
+});
+
+describe('gauge coverage — venture_artifacts under standing watch', () => {
+  it('GOVERNANCE_TABLES includes venture_artifacts plus both original incident tables', () => {
+    const { GOVERNANCE_TABLES } = require(path.join(ROOT, 'lib/coordinator/row-growth.cjs'));
+    expect(GOVERNANCE_TABLES).toContain('venture_artifacts');
+    expect(GOVERNANCE_TABLES).toContain('management_reviews');
+    expect(GOVERNANCE_TABLES).toContain('sd_baseline_items');
+  });
+
+  it('observed storm rates would trigger the gauge within one daily tick', () => {
+    const { detectRowGrowthAnomalies } = require(path.join(ROOT, 'lib/coordinator/row-growth.cjs'));
+    // launch_test_plan grew ~1230 rows over 6 days ≈ 205/day on a table of ~250 baseline:
+    const gradual = detectRowGrowthAnomalies(
+      { tables: { venture_artifacts: 256 } },
+      { tables: { venture_artifacts: 461 } } // +205 in one tick
+    );
+    expect(gradual.length).toBe(0); // below abs spike AND below 500-row factor floor...
+    // ...but by day 3 the factor trigger fires:
+    const day3 = detectRowGrowthAnomalies(
+      { tables: { venture_artifacts: 666 } },
+      { tables: { venture_artifacts: 1080 } } // x1.62 above the 500-row floor
+    );
+    expect(day3.length).toBe(1);
+    expect(day3[0].trigger).toBe('growth_factor');
+    // and a full-rate 30s storm (~2880/day) trips abs_spike immediately:
+    const fullRate = detectRowGrowthAnomalies(
+      { tables: { venture_artifacts: 256 } },
+      { tables: { venture_artifacts: 6200 } }
+    );
+    expect(fullRate[0].trigger).toBe('abs_spike');
+  });
+});
+
+describe('writeArtifactBatch single-current invariant (cleanup-safety mechanism)', () => {
+  it('repeated batch persists leave exactly ONE is_current=true row per (venture,stage,type)', async () => {
+    const { writeArtifactBatch } = await import('../lib/eva/artifact-persistence-service.js');
+    // In-memory venture_artifacts emulating mark-stale + insert semantics.
+    const rows = [];
+    let nextId = 1;
+    const mock = {
+      from(table) {
+        expect(table).toBe('venture_artifacts');
+        const ctx = { filters: {} };
+        const b = {
+          update(payload) { ctx.update = payload; return b; },
+          insert(payload) {
+            const arr = Array.isArray(payload) ? payload : [payload];
+            const inserted = arr.map((r) => ({ ...r, id: String(nextId++) }));
+            rows.push(...inserted);
+            return {
+              select: (cols) => ({
+                single: async () => ({ data: inserted[0], error: null }),
+                then: (res) => res({ data: inserted.map(r => ({ id: r.id })), error: null }),
+              }),
+              then: (res) => res({ data: inserted, error: null }),
+            };
+          },
+          select() { return b; },
+          eq(col, val) { ctx.filters[col] = val; return b; },
+          in(col, vals) { ctx.filters[col] = vals; return b; },
+          limit() { return b; },
+          async maybeSingle() { return { data: null, error: null }; },
+          then(resolve) {
+            if (ctx.update) {
+              // apply mark-stale update to matching rows
+              for (const r of rows) {
+                const match = Object.entries(ctx.filters).every(([k, v]) =>
+                  Array.isArray(v) ? v.includes(r[k]) : r[k] === v);
+                if (match) Object.assign(r, ctx.update);
+              }
+              return resolve({ data: null, error: null });
+            }
+            return resolve({ data: rows, error: null });
+          },
+        };
+        return b;
+      },
+    };
+    const batch = [{ artifactType: 'blueprint_sprint_plan', title: 't', payload: { a: 1 } }];
+    await writeArtifactBatch(mock, 'v1', 19, batch);
+    await writeArtifactBatch(mock, 'v1', 19, batch); // storm re-run
+    await writeArtifactBatch(mock, 'v1', 19, batch); // storm re-run
+    const current = rows.filter((r) => r.venture_id === 'v1' && r.artifact_type === 'blueprint_sprint_plan' && r.is_current === true);
+    const stale = rows.filter((r) => r.venture_id === 'v1' && r.artifact_type === 'blueprint_sprint_plan' && r.is_current === false);
+    expect(current.length).toBe(1);   // exactly one current — the invariant the cleanup relies on
+    expect(stale.length).toBe(2);     // N-1 stale — the storm residue shape
+  });
+});


### PR DESCRIPTION
## SD-LEO-FIX-REMEDIATE-ARRESTED-VENTURE-001

Arrested write storms left **2,684 stale rows (91.3%)** in `venture_artifacts` — a worker re-ran stages every ~30s while a precondition stayed unmet (`launch_test_plan` 1,229 / `blueprint_sprint_plan` 1,044 / `build_security_audit` 411). Root cause was **already fixed** by SD-LEO-FIX-FIX-STAGE-SKIP-001 (`d624465baf`, 2026-06-07 — the day all storms stopped).

### Executed on prod (chairman GO, this session)
Reversible purge applied: **2,940 → 256 rows**, quarantine table holds all 2,684, **exactly the 6 current rows survive**. A CURRENT-ROW TRIPWIRE makes deleting an `is_current=true` row structurally impossible. Round-trip proven pre-apply (BEGIN..ROLLBACK: 2,940→256→2,940 byte-identical). FK-safety live-verified. Recoverable via the DOWN until the quarantine table is dropped.

### Change
- Purge migration + column-explicit DOWN (28/28 cols, completeness assert). **No new constraints** — stale versions are legitimate versioning semantics.
- `venture_artifacts` added to the row-growth gauge `GOVERNANCE_TABLES` (23rd table) — detection at the layer that covers **all** writers, incl. the `skipDedup:true` batch path and 8+ direct-insert sites a write-path guard would miss.
- 9 tests: migration pins (tripwire incl.), gauge membership, **threshold realism vs observed storm rates** (creep → growth_factor by day 3; full-rate storm → abs_spike same day), `writeArtifactBatch` single-current invariant.

### LEAD rescope (validation 4bb5bca0)
The originally-prescribed write-rate guard at `writeArtifact` was **descoped with evidence**: root cause already fixed, and the storm path bypasses `writeArtifact` dedup entirely (`writeArtifactBatch` passes `skipDedup:true`) — the guard would have been dead code at the wrong layer.

Gates: 94/94/96/97 · TESTING 95 (9/9 + 14/14 gauge + 15/15 smoke) · retro 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
