### PR TITLE
fix(QF-20260610-541): ENF-15 stops false-positiving on documentary force-push mentions

### DIFF
--- a/scripts/hooks/lib/force-push-operative.cjs
+++ b/scripts/hooks/lib/force-push-operative.cjs
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * ENF-15 operative force-push detection (QF-20260610-541, feedback 00934869).
+ *
+ * FORCE_PUSH_RE keeps a literal newline in its boundary class (QF-20260525-345 verified
+ * that dropping it false-negatives a real `git push --force` on its own line of a
+ * multi-line block). But that same newline made a line INSIDE a `git commit -m` quoted
+ * body or a heredoc body look like an operative command — a commit message that merely
+ * DOCUMENTS a force-push was blocked with reason=bare_force_disallowed.
+ *
+ * Fix: strip documentary content BEFORE matching, leave the regex untouched:
+ *   - quoted strings attached to message-bearing flags (-m/-F/-c + long forms / --body),
+ *     including multi-line quoted bodies;
+ *   - heredoc bodies — UNLESS the heredoc start line mentions a shell interpreter
+ *     (`bash <<EOF`, `cat <<EOF | sh`), whose body IS executed and must keep matching.
+ * Pure module (mirrors supabase-operative.cjs) so it is unit-testable — the hook runs
+ * main() at load.
+ */
+
+// Verbatim ENF-15 regex from pre-tool-enforce.cjs (QF-20260525-345 boundary class:
+// start-of-command or true shell separator; no bare space, no backtick; newline KEPT).
+const FORCE_PUSH_RE = /(?:^|[;&|(\n]|&&|\|\|)\s*git\s+push\b[^\n]*--force\b/;
+
+// Quoted payloads of message/content flags. Double-quoted bodies may span newlines and
+// contain escaped quotes; single-quoted bodies span newlines (POSIX). Replaced with "".
+const FLAG_STRING_RE = /(\s(?:-m|-F|-c|--message|--file|--body)(?:=|\s+))("(?:[^"\\]|\\[\s\S])*"|'[^']*')/g;
+
+const HEREDOC_START_RE = /<<(-)?\s*(["']?)([A-Za-z_][A-Za-z0-9_]*)\2/;
+// A shell interpreter anywhere on the heredoc start line means the body is EXECUTED
+// (`bash <<EOF`, `cat <<EOF | sh`) — fail toward keeping the gate: do not strip it.
+const SHELL_RUNNER_RE = /(?:^|[\s;&|(])(?:bash|sh|zsh|dash|ksh|pwsh|powershell)(?:\.exe)?\b/i;
+
+function stripFlagStrings(text) {
+  return text.replace(FLAG_STRING_RE, '$1""');
+}
+
+function stripHeredocBodies(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let term = null;
+  let allowIndent = false;
+  for (const line of lines) {
+    if (term !== null) {
+      const probe = (allowIndent ? line.replace(/^\t+/, '') : line).replace(/\r$/, '');
+      if (probe === term) term = null;
+      continue; // body + terminator dropped
+    }
+    const m = line.match(HEREDOC_START_RE);
+    if (m && !SHELL_RUNNER_RE.test(line)) {
+      term = m[3];
+      allowIndent = m[1] === '-';
+    }
+    out.push(line); // the start line itself stays (it is the operative part)
+  }
+  return out.join('\n');
+}
+
+/** `cmd` with documentary content removed; what ENF-15 should actually match against. */
+function stripDocumentaryContent(cmd) {
+  return stripHeredocBodies(stripFlagStrings(cmd));
+}
+
+/** True when `cmd` contains an OPERATIVE `git push … --force` (not a quoted mention). */
+function isOperativeForcePush(cmd) {
+  if (typeof cmd !== 'string' || cmd.length === 0) return false;
+  return FORCE_PUSH_RE.test(stripDocumentaryContent(cmd));
+}
+
+module.exports = { FORCE_PUSH_RE, stripDocumentaryContent, isOperativeForcePush };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1235,18 +1235,20 @@ async function main() {
   // module-level mocking does not apply).
   if (TOOL_NAME === 'Bash') {
     const cmd = (input && input.command || '').trim();
-    // QF-20260525-345 (RCA 6188492f): match `git push … --force` only when it is the
-    // OPERATIVE command — at start-of-command or after a true shell separator
-    // (; | & ( newline, && ||) — NOT after a bare space or a backtick. The previous
-    // boundary class `[\s;&|`]` admitted a space AND a backtick, so any command that
-    // merely MENTIONED the phrase inside a quoted argument false-positived: gh pr/issue
-    // `--body "… `git push --force-with-lease` …"` (markdown code-span → backtick),
-    // `git commit -m "… git push --force …"`, `echo`, `grep`. Same class QF-484 fixed
-    // for ENF-SD-CREATE-SKILL. Dropping backtick forgoes catching a `` `git push --force` ``
-    // command-substitution — not a real force-push vector (substitution captures stdout);
-    // all realistic vectors (bare, ; && || | & (, leading-ws, flag-after-positional) still block.
-    const FORCE_PUSH_RE = /(?:^|[;&|(\n]|&&|\|\|)\s*git\s+push\b[^\n]*--force\b/;
-    if (FORCE_PUSH_RE.test(cmd) && !/--help/.test(cmd)) {
+    // QF-20260525-345 (RCA 6188492f) matched `git push … --force` only at start-of-command
+    // or after a true shell separator (incl. newline — deliberately KEPT so an operative
+    // push on its own line of a multi-line block still blocks). QF-20260610-541 (feedback
+    // 00934869): that newline made a commit-message/heredoc body LINE starting `git push
+    // --force` look operative too. lib/force-push-operative.cjs strips documentary content
+    // (-m/-F/-c quoted strings + heredoc bodies not fed to a shell) BEFORE the same match.
+    // Fail-open to the verbatim legacy regex if the lib errs — the gate stays intact.
+    let forcePushDetected;
+    try {
+      forcePushDetected = require('./lib/force-push-operative.cjs').isOperativeForcePush(cmd);
+    } catch {
+      forcePushDetected = /(?:^|[;&|(\n]|&&|\|\|)\s*git\s+push\b[^\n]*--force\b/.test(cmd);
+    }
+    if (forcePushDetected && !/--help/.test(cmd)) {
       try {
         const { execSync } = require('child_process');
         const HAS_WITH_LEASE = /--force-with-lease\b/.test(cmd);

--- a/tests/unit/force-push-operative.test.js
+++ b/tests/unit/force-push-operative.test.js
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for ENF-15 operative force-push detection (QF-20260610-541, feedback 00934869).
+ *
+ * Pins both directions of the documentary-content fix:
+ *  - a `git push --force` line INSIDE a commit-message body (-m/-F) or a heredoc body is
+ *    documentary => no match (the live false-positive: hook blocked a commit whose MESSAGE
+ *    documented a force-push, reason=bare_force_disallowed);
+ *  - a real operative push (bare, post-&&, on its own line of a multi-line block, or in a
+ *    heredoc body fed to a shell) still matches (QF-20260525-345 verified that simply
+ *    dropping newline from the boundary class false-negatives the multi-line case).
+ */
+import { describe, it, expect } from 'vitest';
+import pkg from '../../scripts/hooks/lib/force-push-operative.cjs';
+const { FORCE_PUSH_RE, stripDocumentaryContent, isOperativeForcePush } = pkg;
+
+describe('documentary mentions => no match', () => {
+  it('commit -m body line documenting a force-push (the live ENF-15 false positive)', () => {
+    const cmd = 'git commit -m "docs: recovery notes\n\ngit push --force origin main is forbidden; use --force-with-lease"';
+    expect(isOperativeForcePush(cmd)).toBe(false);
+  });
+
+  it('heredoc body documenting a force-push (git commit -F - <<EOF)', () => {
+    const cmd = "git commit -F - <<'EOF'\nchore: update hook docs\n\nNote: the hook even blocked\ngit push --force in a body line.\nEOF";
+    expect(isOperativeForcePush(cmd)).toBe(false);
+  });
+
+  it('single-line -m mention (QF-20260525-345 regression pin)', () => {
+    expect(isOperativeForcePush('git commit -m "see git push --force docs"')).toBe(false);
+  });
+
+  it('multi-line gh pr --body mention', () => {
+    const cmd = 'gh pr create --title "fix" --body "Steps:\ngit push --force was previously required"';
+    expect(isOperativeForcePush(cmd)).toBe(false);
+  });
+
+  it('single-quoted multi-line -m body', () => {
+    expect(isOperativeForcePush("git commit -m 'note\ngit push --force is documented here'")).toBe(false);
+  });
+
+  it('escaped quotes inside a double-quoted -m body', () => {
+    expect(isOperativeForcePush('git commit -m "say \\"hi\\"\ngit push --force note"')).toBe(false);
+  });
+
+  it('non-string / empty input', () => {
+    expect(isOperativeForcePush('')).toBe(false);
+    expect(isOperativeForcePush(undefined)).toBe(false);
+    expect(isOperativeForcePush(null)).toBe(false);
+  });
+});
+
+describe('operative pushes => match', () => {
+  it('bare force push', () => {
+    expect(isOperativeForcePush('git push --force origin feat/SD-X')).toBe(true);
+  });
+
+  it('post-&& force push', () => {
+    expect(isOperativeForcePush('cd repo && git push --force-with-lease origin feat/SD-X')).toBe(true);
+  });
+
+  it('own line of a multi-line block (QF-345 false-negative pin: newline boundary must stay)', () => {
+    expect(isOperativeForcePush('git fetch origin\ngit push --force-with-lease origin feat/SD-X')).toBe(true);
+  });
+
+  it('operative push AFTER a heredoc terminator still matches', () => {
+    const cmd = "git commit -F - <<'EOF'\nmsg body\nEOF\ngit push --force origin feat/SD-X";
+    expect(isOperativeForcePush(cmd)).toBe(true);
+  });
+
+  it('heredoc body fed to a shell IS executed => still matches (bash <<EOF)', () => {
+    expect(isOperativeForcePush("bash <<'EOF'\ngit push --force origin main\nEOF")).toBe(true);
+  });
+
+  it('documentary -m on the SAME command as an operative push still matches', () => {
+    expect(isOperativeForcePush('git commit -m "x" && git push --force origin feat/SD-X')).toBe(true);
+  });
+});
+
+describe('exported pieces', () => {
+  it('FORCE_PUSH_RE is the verbatim ENF-15 boundary-class regex (newline kept)', () => {
+    expect(FORCE_PUSH_RE.source).toBe('(?:^|[;&|(\\n]|&&|\\|\\|)\\s*git\\s+push\\b[^\\n]*--force\\b');
+  });
+
+  it('stripDocumentaryContent removes the -m payload but keeps the command skeleton', () => {
+    const out = stripDocumentaryContent('git commit -m "a\nb" && git status');
+    expect(out).toContain('git commit -m ""');
+    expect(out).toContain('git status');
+  });
+});


### PR DESCRIPTION
## QF-20260610-541 — ENF-15 force-push gate false-positives on documentary mentions

**Type**: bug | **Severity**: low | **Tier**: 2 (Standard QF) | Source feedback: `00934869` (LIVE-reproduced by Adam workflow `wf_d63768fe` — the hook blocked the verifying agent's own repro command)

### Problem
`FORCE_PUSH_RE`'s boundary class includes a literal newline (deliberately kept by QF-20260525-345: an operative push on its own line of a multi-line block must match). But a newline INSIDE a `git commit -m` quoted body or heredoc body is treated as a top-level separator, so a message body line starting with a force-push mention matched and was blocked with `reason=bare_force_disallowed` — even though no push executes.

### Fix (per the QF spec, FR-1..FR-3)
- **FR-1**: new pure lib `scripts/hooks/lib/force-push-operative.cjs` — `isOperativeForcePush(cmd)` strips documentary content first: `-m/-F/-c/--message/--file/--body` quoted strings (incl. multi-line) + heredoc bodies **not** fed to a shell interpreter (`bash <<EOF` bodies are executed and still match). The ENF-15 regex itself is verbatim-unchanged.
- **FR-2**: `pre-tool-enforce.cjs:1248` rewired to the lib inside a fail-open try/catch falling back to the legacy inline regex — the gate is never weakened by a lib error. Downstream 5-condition decision logic (lines 1267-1320) untouched.
- **FR-3**: 17 unit tests pin both directions (documentary no-match incl. QF-345 single-line regression pin; bare / post-`&&` / multi-line / shell-heredoc operative pushes still match) + regex-source parity.

### Verification
- `vitest run tests/unit/force-push-operative.test.js tests/unit/force-push-branch.test.js` → **31/31 pass**
- Live hook subprocess smoke: documentary `-m` body → exit 0; documentary heredoc → exit 0; operative bare → `BLOCKED reason=bare_force_disallowed`; operative multi-line lease → `BLOCKED reason=env_var_unset` (gate intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
