### PR TITLE
fix(eva): make venture stage gates binding — gate-debt enforcement + override recording + scaffolding flag

### DIFF
--- a/database/migrations/20260610_gate_debt_view_and_scaffolding_flag.sql
+++ b/database/migrations/20260610_gate_debt_view_and_scaffolding_flag.sql
@@ -1,0 +1,55 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: ventures.is_scaffolding flag + v_venture_gate_debt view (ADDITIVE ONLY)
+-- SD-LEO-FIX-MAKE-VENTURE-STAGE-001
+--
+-- WHAT: (1) is_scaffolding — first-class marker for development/build-out vehicle
+--       ventures (chairman context 2026-06-10: ventures were DELIBERATELY forced through
+--       failing gates to build out downstream stages; their gate history must be excluded
+--       from threshold calibration and portfolio analytics by default). The migration sets
+--       the flag on NO ventures — which ventures qualify is a chairman data decision.
+--       (2) v_venture_gate_debt — per-venture failed-unresolved BLOCKING gates (the data
+--       contract for the EHG-app chairman cockpit; each eva_stage_gate_results row is the
+--       latest evaluation for its (venture, stage, gate_type) because recordGateResult
+--       upserts on that key). Debt = passed=false on a blocking gate_type ('kill','exit')
+--       with NO approved chairman_decisions row for the venture+stage. Scaffolding/demo
+--       ventures excluded by default.
+--
+-- SAFETY: additive only — ADD COLUMN IF NOT EXISTS with DEFAULT + CREATE OR REPLACE VIEW.
+--   No data rows are inserted/updated/deleted. Reversible via the _DOWN (drops view +
+--   column). No chairman GO required (reserved for irreversible data operations).
+
+ALTER TABLE ventures
+  ADD COLUMN IF NOT EXISTS is_scaffolding boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN ventures.is_scaffolding IS
+  'Development/build-out vehicle (SD-LEO-FIX-MAKE-VENTURE-STAGE-001): gate history excluded from threshold calibration and portfolio analytics by default. Sibling of is_demo. Set only by explicit chairman decision.';
+
+CREATE OR REPLACE VIEW v_venture_gate_debt AS
+SELECT
+  v.id            AS venture_id,
+  v.name          AS venture_name,
+  g.stage_number,
+  g.gate_type,
+  g.overall_score,
+  g.notes,
+  g.evaluated_at,
+  g.evaluated_by,
+  cd.id           AS override_decision_id
+FROM eva_stage_gate_results g
+JOIN ventures v ON v.id = g.venture_id
+LEFT JOIN LATERAL (
+  SELECT id FROM chairman_decisions cd
+  WHERE cd.venture_id = g.venture_id
+    AND cd.lifecycle_stage = g.stage_number
+    AND cd.status = 'approved'
+  ORDER BY cd.created_at DESC
+  LIMIT 1
+) cd ON true
+WHERE g.passed = false
+  AND g.gate_type IN ('kill', 'exit')           -- blocking families (lib/eva/gate-enforcement.js)
+  AND cd.id IS NULL                              -- unresolved: no approved chairman decision
+  AND v.is_scaffolding IS DISTINCT FROM true     -- build-out vehicles excluded
+  AND v.is_demo IS DISTINCT FROM true;           -- test fixtures excluded
+
+COMMENT ON VIEW v_venture_gate_debt IS
+  'Failed-unresolved BLOCKING stage gates per venture (SD-LEO-FIX-MAKE-VENTURE-STAGE-001). Data contract for the EHG-app chairman cockpit. A row disappears when the gate re-evaluates green (upsert overwrites) or an approved chairman_decisions row (incl. decision=override) records the chairman call.';

--- a/database/migrations/20260610_gate_debt_view_and_scaffolding_flag_DOWN.sql
+++ b/database/migrations/20260610_gate_debt_view_and_scaffolding_flag_DOWN.sql
@@ -1,0 +1,10 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- DOWN migration for SD-LEO-FIX-MAKE-VENTURE-STAGE-001 (additive UP: view + flag column).
+--
+-- Drops the gate-debt view and the scaffolding flag. The column drop loses any
+-- chairman-set is_scaffolding=true marks — acceptable for a rollback of the
+-- feature itself; re-applying the UP restores the column at default false.
+
+DROP VIEW IF EXISTS v_venture_gate_debt;
+
+ALTER TABLE ventures DROP COLUMN IF EXISTS is_scaffolding;

--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -26,6 +26,10 @@ import { writeArtifact } from '../../../eva/artifact-persistence-service.js';
 import { ARTIFACT_TYPES } from '../../../eva/artifact-types.js';
 import { randomUUID } from 'crypto';
 import { scoreTasteGate, buildTasteSummary, getTasteRubric, TASTE_VERDICT } from '../../../eva/taste-gate-scorer.js';
+// SD-LEO-FIX-MAKE-VENTURE-STAGE-001: blocking-vs-advisory registry (canonical home
+// lib/eva/gate-enforcement.js — pure module avoiding the import cycle with the
+// persistence service whose advanceStage() runs the binding gate-debt check).
+import { GATE_ENFORCEMENT, classifyGateRow } from '../../../eva/gate-enforcement.js';
 
 // ── Gate Configuration ──────────────────────────────────────────────
 
@@ -996,6 +1000,8 @@ export {
   TASTE_GATE_STAGES,
   GATE_TYPE,
   GATE_STATUS,
+  GATE_ENFORCEMENT,
+  classifyGateRow,
   FILTER_PREFERENCE_KEYS,
 };
 

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -14,6 +14,7 @@
 import { persistADRs } from './adr-extractor.js';
 import { isValidArtifactType } from './artifact-types.js';
 import { checkExitGates } from './lifecycle/exit-gate-enforcer.js';
+import { classifyGateRow } from './gate-enforcement.js';
 
 /**
  * Write a venture artifact with dual-write (content TEXT + artifact_data JSONB).
@@ -335,6 +336,12 @@ export async function recordGateResult(supabase, opts) {
     score = null,
     reasoning = null,
     metadata = null,
+    // SD-LEO-FIX-MAKE-VENTURE-STAGE-001: provenance. All 1,102 historical rows have
+    // evaluated_by NULL — no record of WHAT evaluated a gate. New rows always carry it:
+    // callers pass their identity; fallback chain ends at 'eva-orchestrator' so a row
+    // can never be written with NULL provenance again. Historical NULLs stand (no backfill).
+    evaluatedBy = null,
+    source = null,
   } = opts;
 
   // Map code-level gate types to DB check constraint values ('entry', 'exit', 'kill')
@@ -356,6 +363,7 @@ export async function recordGateResult(supabase, opts) {
     stage_number: stageNumber,
     gate_type: mappedGateType,
     passed,
+    evaluated_by: evaluatedBy || source || 'eva-orchestrator',
   };
 
   if (score !== null) row.overall_score = score;
@@ -387,6 +395,62 @@ export async function recordGateResult(supabase, opts) {
  * @param {string|null} [opts.idempotencyKey] - Idempotency key
  * @returns {Promise<{success: boolean, wasDuplicate: boolean, result: Object}>}
  */
+/**
+ * SD-LEO-FIX-MAKE-VENTURE-STAGE-001: gate-debt check for the binding advance path.
+ *
+ * Reads the (latest — the table upserts per (venture, stage, gate_type)) gate
+ * evaluations for the stage being exited, classifies each via the enforcement
+ * registry, and reports whether any BLOCKING gate is failed AND unresolved
+ * (no approved chairman_decisions row for the venture+stage — an approved row of
+ * ANY decision value, incl. 'override', resolves the debt: it is the auditable
+ * record of the chairman's call).
+ *
+ * Error semantics: fail-OPEN with a loud audit-write-guard log on query errors
+ * (transient DB blips must not strand the pipeline); fail-CLOSED only on
+ * confirmed failed blocking gates.
+ *
+ * @param {object} supabase
+ * @param {{ventureId: string, fromStage: number}} params
+ * @returns {Promise<{blocked: boolean, failedGates: Array<object>}>}
+ */
+export async function checkGateDebt(supabase, { ventureId, fromStage }) {
+  try {
+    const { data: gateRows, error: gateErr } = await supabase
+      .from('eva_stage_gate_results')
+      .select('gate_type, passed, overall_score, notes')
+      .eq('venture_id', ventureId)
+      .eq('stage_number', fromStage);
+    if (gateErr) throw gateErr;
+
+    const failedBlocking = (gateRows || []).filter(
+      (r) => r.passed === false && classifyGateRow(r) === 'blocking'
+    );
+    if (failedBlocking.length === 0) return { blocked: false, failedGates: [] };
+
+    // Failed blocking gate(s) exist — resolved only by an approved chairman decision
+    // for this venture+stage (decision='override' is the deliberate-forcing record).
+    const { data: decisions, error: decErr } = await supabase
+      .from('chairman_decisions')
+      .select('id, decision, status')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', fromStage)
+      .eq('status', 'approved')
+      .limit(1);
+    if (decErr) throw decErr;
+
+    if (decisions && decisions.length > 0) return { blocked: false, failedGates: [] };
+    return { blocked: true, failedGates: failedBlocking };
+  } catch (err) {
+    // Fail-open on uncertainty — but LOUDLY (the phantom-column class taught us
+    // silent catches hide real failures for months).
+    try {
+      const { logAuditWriteFailure } = await import('../audit-write-guard.js');
+      logAuditWriteFailure('artifact-persistence.checkGateDebt', err, { ventureId, fromStage });
+    } catch { /* guard must never break the advance path */ }
+    return { blocked: false, failedGates: [], error: err?.message };
+  }
+}
+
 export async function advanceStage(supabase, opts) {
   const {
     ventureId,
@@ -411,6 +475,34 @@ export async function advanceStage(supabase, opts) {
       `Blocked by: ${gateResult.blocked_by.join('; ')}. ` +
       `Gates checked: [${gateResult.gates_checked.join(', ')}].`
     );
+  }
+
+  // SD-LEO-FIX-MAKE-VENTURE-STAGE-001: BINDING gate-debt check. The gate system
+  // evaluated and logged (1,102 eva_stage_gate_results rows) but a FAILED verdict
+  // never had consequence — DataDistill failed 10 gates and advanced anyway. From
+  // here, a failed BLOCKING evaluation (per lib/eva/gate-enforcement.js) blocks the
+  // RPC until the gate re-evaluates green OR an approved chairman_decisions row
+  // exists for this venture+stage (incl. decision='override' — the one-step,
+  // auditable recording of deliberate chairman build-out forcing; chairman context
+  // 2026-06-10). Each (venture, stage, gate_type) row IS the latest evaluation
+  // (recordGateResult upserts on that key). Fail-CLOSED on confirmed failed
+  // blocking gates; fail-OPEN (loudly) on query errors — a transient DB blip must
+  // not strand every venture in the pipeline.
+  const debt = await checkGateDebt(supabase, { ventureId, fromStage });
+  if (debt.blocked) {
+    const gateList = debt.failedGates
+      .map((g) => `${g.gate_type}(score=${g.overall_score ?? 'n/a'})`)
+      .join(', ');
+    const err = new Error(
+      '[artifact-persistence-service] advanceStage blocked by failed stage gate(s). ' +
+      `Venture: ${ventureId}, Stage: ${fromStage}. Failed blocking gates: [${gateList}]. ` +
+      'Remediation: re-run the stage so the gate re-evaluates green, OR record a chairman ' +
+      "override (INSERT chairman_decisions row: venture_id, lifecycle_stage, decision='override', " +
+      "status='approved', override_reason='<why>') to advance with an auditable forcing record."
+    );
+    err.code = 'GATE_BLOCKED';
+    err.failedGates = debt.failedGates;
+    throw err;
   }
 
   const rpcParams = {

--- a/lib/eva/gate-enforcement.js
+++ b/lib/eva/gate-enforcement.js
@@ -1,0 +1,46 @@
+/**
+ * Gate enforcement registry — SD-LEO-FIX-MAKE-VENTURE-STAGE-001.
+ *
+ * PURE module (no imports, no IO) so BOTH stage-gates.js (which imports the
+ * persistence service) and artifact-persistence-service.js (whose advanceStage
+ * enforces the gate-debt check) can consume it without an import cycle.
+ *
+ * Keyed by eva_stage_gate_results.gate_type — the DB CHECK-constraint values
+ * ('kill' | 'exit' | 'entry') that recordGateResult() maps every code-level
+ * gate family onto:
+ *  - kill  → blocking  (termination checkpoints; S3/S5/S13/S24)
+ *  - exit  → blocking  (stage exit gates incl. the EXISTING artifact gates and
+ *                       the promotion family; NOTE: taste-gate rows also land
+ *                       under 'exit' via recordGateResult's GATE_TYPE_MAP and
+ *                       share the (venture,stage,gate_type) upsert key — the
+ *                       LAST evaluation wins; documented pre-existing collision)
+ *  - entry → advisory  (v1: entry preconditions are enforced upstream by the
+ *                       stage executor; their rows are informational here)
+ *
+ * Consistent with stage_config.gate_type semantics in fn_advance_venture_stage
+ * (kill/promotion additionally require approved chairman_decisions at the RPC).
+ *
+ * A FAILED blocking evaluation blocks advanceStage() until re-evaluated green
+ * OR an approved chairman_decisions row exists for the venture+stage — incl.
+ * decision='override', the first-class recording of deliberate chairman
+ * build-out forcing (chairman context 2026-06-10: the override is the
+ * RECORDING of the practice, not a guardrail against it).
+ */
+'use strict';
+
+export const GATE_ENFORCEMENT = Object.freeze({
+  kill: 'blocking',
+  exit: 'blocking',
+  entry: 'advisory',
+});
+
+/**
+ * PURE: classify an eva_stage_gate_results row as 'blocking' | 'advisory'.
+ * Unknown gate_types default to 'advisory' (fail-open for forward-compat: a
+ * new informational gate type must not silently dam every venture).
+ * @param {{gate_type?: string}} row
+ * @returns {'blocking'|'advisory'}
+ */
+export function classifyGateRow(row) {
+  return GATE_ENFORCEMENT[row?.gate_type] || 'advisory';
+}

--- a/tests/venture-gate-binding.test.js
+++ b/tests/venture-gate-binding.test.js
@@ -1,0 +1,147 @@
+/**
+ * SD-LEO-FIX-MAKE-VENTURE-STAGE-001 — binding venture stage gates.
+ * Offline: enforcement matrix for checkGateDebt/advanceStage, registry pins,
+ * evaluated_by provenance, migration static pins.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const { GATE_ENFORCEMENT, classifyGateRow } = await import('../lib/eva/gate-enforcement.js');
+const { checkGateDebt, recordGateResult } = await import('../lib/eva/artifact-persistence-service.js');
+
+/** Minimal mock: gateRows returned for eva_stage_gate_results, decisions for chairman_decisions. */
+function mockDb({ gateRows = [], decisions = [], gateErr = null } = {}) {
+  return {
+    from(table) {
+      const ctx = {};
+      const b = {
+        select() { return b; },
+        eq() { return b; },
+        limit() { return b; },
+        upsert(row) {
+          ctx.upserted = row;
+          calls.upserts.push({ table, row });
+          return { select: () => ({ single: async () => ({ data: { id: 'row-1' }, error: null }) }) };
+        },
+        then(resolve) {
+          if (table === 'eva_stage_gate_results') return resolve({ data: gateRows, error: gateErr });
+          if (table === 'chairman_decisions') return resolve({ data: decisions, error: null });
+          return resolve({ data: [], error: null });
+        },
+      };
+      return b;
+    },
+  };
+}
+const calls = { upserts: [] };
+
+describe('registry — blocking vs advisory', () => {
+  it('kill and exit are blocking; entry advisory; unknown defaults advisory', () => {
+    expect(GATE_ENFORCEMENT.kill).toBe('blocking');
+    expect(GATE_ENFORCEMENT.exit).toBe('blocking');
+    expect(GATE_ENFORCEMENT.entry).toBe('advisory');
+    expect(classifyGateRow({ gate_type: 'kill' })).toBe('blocking');
+    expect(classifyGateRow({ gate_type: 'entry' })).toBe('advisory');
+    expect(classifyGateRow({ gate_type: 'something_new' })).toBe('advisory');
+    expect(classifyGateRow(null)).toBe('advisory');
+  });
+
+  it('stage-gates.js re-exports the registry (single conventional surface)', async () => {
+    const sg = await import('../lib/agents/modules/venture-state-machine/stage-gates.js');
+    expect(sg.GATE_ENFORCEMENT).toBe(GATE_ENFORCEMENT);
+    expect(sg.classifyGateRow).toBe(classifyGateRow);
+  });
+});
+
+describe('checkGateDebt — enforcement matrix', () => {
+  it('TS-1: failed blocking gate + no decision → blocked, gate named', async () => {
+    const db = mockDb({ gateRows: [{ gate_type: 'kill', passed: false, overall_score: 42 }] });
+    const debt = await checkGateDebt(db, { ventureId: 'v1', fromStage: 5 });
+    expect(debt.blocked).toBe(true);
+    expect(debt.failedGates[0].gate_type).toBe('kill');
+  });
+
+  it('TS-2: failed blocking gate + approved override decision → not blocked', async () => {
+    const db = mockDb({
+      gateRows: [{ gate_type: 'exit', passed: false }],
+      decisions: [{ id: 'd1', decision: 'override', status: 'approved' }],
+    });
+    const debt = await checkGateDebt(db, { ventureId: 'v1', fromStage: 17 });
+    expect(debt.blocked).toBe(false);
+  });
+
+  it('TS-3: failed ADVISORY gate only → not blocked', async () => {
+    const db = mockDb({ gateRows: [{ gate_type: 'entry', passed: false }] });
+    const debt = await checkGateDebt(db, { ventureId: 'v1', fromStage: 9 });
+    expect(debt.blocked).toBe(false);
+  });
+
+  it('TS-4: passed blocking gates → not blocked (latest-evaluation semantics: the row IS the latest via upsert)', async () => {
+    const db = mockDb({ gateRows: [{ gate_type: 'kill', passed: true }, { gate_type: 'exit', passed: true }] });
+    const debt = await checkGateDebt(db, { ventureId: 'v1', fromStage: 5 });
+    expect(debt.blocked).toBe(false);
+  });
+
+  it('TS-5: query error → fail-open (never strands the pipeline) with loud guard log', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const db = mockDb({ gateErr: { code: 'XX000', message: 'transient blip' } });
+    const debt = await checkGateDebt(db, { ventureId: 'v1', fromStage: 5 });
+    expect(debt.blocked).toBe(false);
+    expect(debt.error).toContain('blip');
+    errSpy.mockRestore();
+  });
+
+  it('no gate rows at all → not blocked', async () => {
+    const debt = await checkGateDebt(mockDb(), { ventureId: 'v1', fromStage: 2 });
+    expect(debt.blocked).toBe(false);
+  });
+});
+
+describe('recordGateResult — evaluated_by provenance', () => {
+  it('new rows always carry non-null evaluated_by (explicit, source fallback, default)', async () => {
+    calls.upserts.length = 0;
+    const db = mockDb();
+    await recordGateResult(db, { ventureId: 'v1', stageNumber: 5, gateType: 'kill', passed: true, evaluatedBy: 'worker-7' });
+    await recordGateResult(db, { ventureId: 'v1', stageNumber: 5, gateType: 'exit', passed: true, source: 'stage-21' });
+    await recordGateResult(db, { ventureId: 'v1', stageNumber: 5, gateType: 'entry', passed: true });
+    const evals = calls.upserts.map((u) => u.row.evaluated_by);
+    expect(evals).toEqual(['worker-7', 'stage-21', 'eva-orchestrator']);
+    expect(evals.every(Boolean)).toBe(true);
+  });
+});
+
+describe('advanceStage wiring + migration pins (static)', () => {
+  const svc = fs.readFileSync(path.join(ROOT, 'lib/eva/artifact-persistence-service.js'), 'utf8');
+
+  it('advanceStage runs checkGateDebt before the RPC and throws GATE_BLOCKED with remediation', () => {
+    expect(svc).toMatch(/const debt = await checkGateDebt\(supabase, \{ ventureId, fromStage \}\)/);
+    expect(svc).toMatch(/err\.code = 'GATE_BLOCKED'/);
+    expect(svc).toMatch(/decision='override'/);
+    // debt check appears BEFORE the RPC call
+    expect(svc.indexOf('checkGateDebt(supabase')).toBeLessThan(svc.indexOf("supabase.rpc('fn_advance_venture_stage'"));
+  });
+
+  it('migration is additive-only with scaffolding flag + debt view', () => {
+    const up = fs.readFileSync(path.join(ROOT, 'database/migrations/20260610_gate_debt_view_and_scaffolding_flag.sql'), 'utf8');
+    expect(up).toMatch(/ADD COLUMN IF NOT EXISTS is_scaffolding boolean NOT NULL DEFAULT false/);
+    expect(up).toMatch(/CREATE OR REPLACE VIEW v_venture_gate_debt/);
+    expect(up).toMatch(/gate_type IN \('kill', 'exit'\)/);
+    expect(up).toMatch(/is_scaffolding IS DISTINCT FROM true/);
+    expect(up).toMatch(/is_demo IS DISTINCT FROM true/);
+    // additive only: no destructive statements
+    expect(up).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(up).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(up).not.toMatch(/\bUPDATE\s+ventures\b/i);
+  });
+
+  it('DOWN drops view + column', () => {
+    const down = fs.readFileSync(path.join(ROOT, 'database/migrations/20260610_gate_debt_view_and_scaffolding_flag_DOWN.sql'), 'utf8');
+    expect(down).toMatch(/DROP VIEW IF EXISTS v_venture_gate_debt/);
+    expect(down).toMatch(/DROP COLUMN IF EXISTS is_scaffolding/);
+  });
+});


### PR DESCRIPTION
## SD-LEO-FIX-MAKE-VENTURE-STAGE-001

The venture stage-gate system **logged but never gated**: 1,102 `eva_stage_gate_results` rows (`evaluated_by` NULL on every one), DataDistill failed 10 gates and advanced anyway, the S5 financial kill gate failed 64% of evaluations with zero consequence.

**Chairman context honored** (2026-06-10): forcing ventures through failing gates was *deliberate build-out scaffolding* — so the override here is the **recording** of that practice (a one-step auditable `chairman_decisions` row: who/why/when), not a guardrail against it.

### Change
- **NEW `lib/eva/gate-enforcement.js`** — pure blocking/advisory registry keyed by `gate_type` (kill/exit blocking, entry advisory, unknown→advisory fail-open). Re-exported from `stage-gates.js` (cycle-free).
- **`advanceStage()` is now binding**: `checkGateDebt` runs before the RPC — a failed blocking gate (each row IS the latest evaluation; the table upserts per `(venture,stage,gate_type)`) throws `GATE_BLOCKED` naming the gates + the exact one-step override INSERT, unless an approved `chairman_decisions` row (incl. `decision='override'`) exists. Fail-closed on confirmed failures; fail-open **loudly** on query blips.
- **Provenance**: `recordGateResult` writes `evaluated_by` on every new row (explicit → source → default chain). Historical NULLs stand.
- **Additive migration (applied to prod, round-trip probed first)**: `ventures.is_scaffolding` (set on NO ventures — chairman decision) + **`v_venture_gate_debt`** view — live with **5 real unresolved debt rows** (Canvas AI/CronGenius/CronLinter S15, DataDistill S15+S23). The EHG-app cockpit data contract.
- **12 tests**: enforcement matrix, registry pins, provenance chain, additive-only migration pins. 11 adjacent failures proven pre-existing at merge-base with identical line numbers.

### Descoped with evidence
RPC-level verdict enforcement (279-line canonical live fn — own SD), EHG-app cockpit UI, which ventures get `is_scaffolding` (chairman flags filed).

Gates: 94/92/96/97 · TESTING 92 · retro 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
