### PR TITLE
fix(QF-20260610-124): strip V-dims for readonly/bugfix/documentation corrective sources

### DIFF
--- a/scripts/eva/corrective-sd-generator.mjs
+++ b/scripts/eva/corrective-sd-generator.mjs
@@ -106,6 +106,42 @@ export const LIFECYCLE_FEATURE_KEYWORDS = [
 // A01-A04 to emit identical noise correctives (see cancelled SDs 040/041/042).
 export const SUPPRESSED_ARCHITECTURAL_DIMS = new Set(['A01', 'A02', 'A03', 'A04', 'A05']);
 
+// QF-20260610-124: classifier verdicts that ALSO strip VISION dims. A narrow
+// readonly/bugfix/documentation source was never scoped to advance vision
+// dimensions, yet V-dim weak scores emitted P1 vision-gap findings against it —
+// all 5 corrective_finding rows ever emitted hit this class and every one was
+// triaged wont_fix/resolved. lifecycle_feature is deliberately EXCLUDED (keeps
+// its A-dims-only strip): feature-type sources may legitimately move V-dims.
+export const VISION_SUPPRESSED_REASONS = new Set(['cli_validation', 'readonly_bugfix', 'documentation']);
+
+/**
+ * QF-20260610-124: pure strip step for the 5b source-class filter (extracted so it
+ * is unit-testable without a Supabase client). For ANY suppression verdict, removes
+ * SUPPRESSED_ARCHITECTURAL_DIMS from every group; when `reason` is one of
+ * VISION_SUPPRESSED_REASONS, also removes V-dims. Mutates `groups` in place and
+ * drops now-empty groups (identical to the prior inline A-dim loop). Other
+ * (non-V/non-A) dims always pass through.
+ *
+ * @param {Array<{dims: Array<{dimId: string}>}>} groups
+ * @param {string|null} reason - classifySourceSD verdict
+ * @returns {{ suppressedArch: string[], suppressedVision: string[] }} sorted dim ids removed
+ */
+export function _stripSuppressedDims(groups, reason) {
+  const stripVision = VISION_SUPPRESSED_REASONS.has(reason);
+  const hit = (d) => SUPPRESSED_ARCHITECTURAL_DIMS.has(d.dimId) || (stripVision && d.dimId.startsWith('V'));
+  const suppressedArch = new Set();
+  const suppressedVision = new Set();
+  for (let i = groups.length - 1; i >= 0; i--) {
+    for (const d of groups[i].dims) {
+      if (!hit(d)) continue;
+      (d.dimId.startsWith('V') ? suppressedVision : suppressedArch).add(d.dimId);
+    }
+    groups[i].dims = groups[i].dims.filter(d => !hit(d));
+    if (groups[i].dims.length === 0) groups.splice(i, 1);
+  }
+  return { suppressedArch: [...suppressedArch].sort(), suppressedVision: [...suppressedVision].sort() };
+}
+
 /**
  * Lightweight classifier: inspect SD shape and return reason if architectural
  * correctives should be suppressed. Returns null when no suppression match.
@@ -657,36 +693,37 @@ export async function generateCorrectiveSD(scoreId, options = {}) {
     });
   }
 
-  // 5b. Architectural source-class filter (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001
-  // shipped A05-only; SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001 extends to A01-A05).
-  // For source SDs classified as read-only/CLI/documentation/lifecycle-feature, the
-  // entire architectural row (A01-A05) is noise because the SD does not change
-  // architecture. Strip all A-dims from each group; V-dims pass through. Drop empty
-  // groups. Other dimensions still emit normally for non-suppressed sources.
+  // 5b. Source-class filter (SD-LEO-INFRA-FILTER-CORRECTIVE-GENERATOR-001 shipped
+  // A05-only; SD-LEO-INFRA-EXTEND-CORRECTIVE-GENERATOR-001 extends to A01-A05;
+  // QF-20260610-124 extends readonly/bugfix/documentation verdicts to V-dims too).
+  // For suppressed sources the architectural row (A01-A05) is noise because the SD
+  // does not change architecture; for the readonly verdict subset the V-dims are
+  // equally noise (the SD never scoped vision-relevant behavior). lifecycle_feature
+  // keeps V-dims. Drop empty groups. Other dims still emit for non-suppressed sources.
   if (score.sd_id) {
     const verdict = await isSourceSDA05Suppressed(score.sd_id, supabase);
     if (verdict.suppress) {
-      let suppressedAny = false;
-      const suppressedDims = new Set();
-      for (let i = groups.length - 1; i >= 0; i--) {
-        const beforeLen = groups[i].dims.length;
-        for (const d of groups[i].dims) {
-          if (SUPPRESSED_ARCHITECTURAL_DIMS.has(d.dimId)) suppressedDims.add(d.dimId);
-        }
-        groups[i].dims = groups[i].dims.filter(d => !SUPPRESSED_ARCHITECTURAL_DIMS.has(d.dimId));
-        if (groups[i].dims.length < beforeLen) suppressedAny = true;
-        if (groups[i].dims.length === 0) groups.splice(i, 1);
-      }
-      if (suppressedAny) {
+      const { suppressedArch, suppressedVision } = _stripSuppressedDims(groups, verdict.reason);
+      if (suppressedArch.length > 0) {
         const eventType = verdict.reason === 'lifecycle_feature'
           ? 'skipped_lifecycle_feature_class'
           : 'skipped_a05_source_class';
-        const dimsList = [...suppressedDims].sort().join(',');
-        console.log(`[corrective-sd-generator] eva.corrective.${eventType} source_sd_id=${verdict.sourceSdKey} reason=${verdict.reason} dims=${dimsList} total_score=${score.total_score ?? '?'}`);
+        console.log(`[corrective-sd-generator] eva.corrective.${eventType} source_sd_id=${verdict.sourceSdKey} reason=${verdict.reason} dims=${suppressedArch.join(',')} total_score=${score.total_score ?? '?'}`);
         await _logAudit(supabase, scoreId, eventType, null, score.vision_id, {
           source_sd_id: verdict.sourceSdKey,
           reason: verdict.reason,
-          suppressed_dims: [...suppressedDims].sort(),
+          suppressed_dims: suppressedArch,
+        });
+      }
+      // QF-20260610-124 (FR-3): distinct event so the V-dim strip is observable in
+      // the brainstorm_sessions audit, mirroring the skipped_a05_source_class shape.
+      if (suppressedVision.length > 0) {
+        const eventType = 'skipped_vision_dim_readonly_source';
+        console.log(`[corrective-sd-generator] eva.corrective.${eventType} source_sd_id=${verdict.sourceSdKey} reason=${verdict.reason} dims=${suppressedVision.join(',')} total_score=${score.total_score ?? '?'}`);
+        await _logAudit(supabase, scoreId, eventType, null, score.vision_id, {
+          source_sd_id: verdict.sourceSdKey,
+          reason: verdict.reason,
+          suppressed_dims: suppressedVision,
         });
       }
     }

--- a/tests/unit/eva/corrective-sd-generator-vision-dim-filter.test.js
+++ b/tests/unit/eva/corrective-sd-generator-vision-dim-filter.test.js
@@ -1,0 +1,97 @@
+/**
+ * QF-20260610-124: V-dim strip for readonly/bugfix/documentation sources.
+ *
+ * The 5b source-class filter stripped A01-A05 for suppressed sources but let
+ * V-dims pass, so narrow bugfix/infra SDs emitted P1 vision-gap findings (all 5
+ * corrective_finding rows ever emitted hit this class; all triaged wont_fix).
+ * These pin the pure strip helper both directions: readonly verdicts strip V+A,
+ * lifecycle_feature stays A-only, genuine write sources classify to null (never
+ * reach the strip at all), and non-V/non-A dims always pass through.
+ */
+
+import { describe, it, expect } from 'vitest';
+// NOTE: no supabase-js mock needed — every export under test is pure, and the
+// generator module only constructs its client lazily inside _getSupabase()
+// (never at import time), so this suite is genuinely DB-free (Stage-1.6 clean).
+import {
+  classifySourceSD,
+  _stripSuppressedDims,
+  VISION_SUPPRESSED_REASONS,
+} from '../../../scripts/eva/corrective-sd-generator.mjs';
+
+const dim = (dimId) => ({ dimId, dimensionName: `dim ${dimId}`, score: 1 });
+const group = (...dimIds) => ({ dims: dimIds.map(dim), sdType: 'corrective', category: 'corrective', label: 'Vision' });
+
+describe('VISION_SUPPRESSED_REASONS membership (FR-1/FR-5)', () => {
+  it('contains exactly the readonly verdicts — lifecycle_feature excluded', () => {
+    expect([...VISION_SUPPRESSED_REASONS].sort()).toEqual(['cli_validation', 'documentation', 'readonly_bugfix']);
+  });
+});
+
+describe('_stripSuppressedDims — readonly verdicts strip V-dims (FR-1)', () => {
+  it('(a) bugfix source with a weak V-dim: finding suppressed (STAGE-RENDERER V04 regression)', () => {
+    const groups = [group('V04')];
+    const out = _stripSuppressedDims(groups, 'readonly_bugfix');
+    expect(out.suppressedVision).toEqual(['V04']);
+    expect(groups).toHaveLength(0); // empty group dropped -> nothing emits
+  });
+
+  it('(b) cli/infra source with V04/V06: both suppressed (COMPLETION-FLAG-HARNESS regression)', () => {
+    const groups = [group('V04', 'V06')];
+    const out = _stripSuppressedDims(groups, 'cli_validation');
+    expect(out.suppressedVision).toEqual(['V04', 'V06']);
+    expect(groups).toHaveLength(0);
+  });
+
+  it('(d) mixed V+A groups on a readonly source: both stripped, empty groups dropped', () => {
+    const groups = [group('V03'), group('A04', 'A05')];
+    const out = _stripSuppressedDims(groups, 'readonly_bugfix');
+    expect(out.suppressedVision).toEqual(['V03']);
+    expect(out.suppressedArch).toEqual(['A04', 'A05']);
+    expect(groups).toHaveLength(0);
+  });
+
+  it('documentation verdict also strips V-dims', () => {
+    const groups = [group('V01')];
+    expect(_stripSuppressedDims(groups, 'documentation').suppressedVision).toEqual(['V01']);
+    expect(groups).toHaveLength(0);
+  });
+
+  it('non-V/non-A dims always pass through (group kept, V/A removed from it)', () => {
+    const groups = [{ ...group('V02', 'X01'), label: 'Vision' }];
+    const out = _stripSuppressedDims(groups, 'cli_validation');
+    expect(out.suppressedVision).toEqual(['V02']);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].dims.map(d => d.dimId)).toEqual(['X01']);
+  });
+});
+
+describe('_stripSuppressedDims — conservative defaults preserved (FR-2)', () => {
+  it('lifecycle_feature keeps V-dims (A-dims-only strip, prior behavior byte-identical)', () => {
+    const groups = [group('V04'), group('A05')];
+    const out = _stripSuppressedDims(groups, 'lifecycle_feature');
+    expect(out.suppressedVision).toEqual([]);
+    expect(out.suppressedArch).toEqual(['A05']);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].dims.map(d => d.dimId)).toEqual(['V04']);
+  });
+
+  it('(c) genuine write/feature source classifies to null — never reaches the strip (PROVISIONING-PARITY regression)', () => {
+    // SD-LEO-FIX-VENTURE-PROVISIONING-PARITY-001 shape: write keywords >= 2 -> null verdict
+    const sd = {
+      sd_type: 'bugfix',
+      title: 'Fix venture provisioning parity',
+      description: 'persist provisioning rows and emit lifecycle events; insert missing records',
+      scope: 'provisioning insert/update paths',
+      key_changes: [{ change: 'persist + publish parity events', impact: 'rows inserted' }],
+    };
+    expect(classifySourceSD(sd)).toBeNull(); // suppress=false -> V- AND A-dims both still emit
+  });
+
+  it('null reason strips nothing vision-side (defensive: stripVision is verdict-gated)', () => {
+    const groups = [group('V04')];
+    const out = _stripSuppressedDims(groups, null);
+    expect(out.suppressedVision).toEqual([]);
+    expect(groups).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## QF-20260610-124 — Strip V-dims for readonly/bugfix/documentation corrective sources

**Type**: bug | **Severity**: medium | **Tier**: 2 (Standard QF) | Source feedback: `ecda4798` (Adam sweep `wf_229accdd`, residual_after_shipped)

### Problem
The 5b source-class filter (FILTER → EXTEND family) strips A01-A05 for readonly/bugfix/documentation sources but deliberately let VISION dims pass — so narrow fix/harness SDs emitted P1 vision-gap findings they were never scoped to address. **Live proof: all 5 `corrective_finding` rows ever emitted target this class; every one was triaged wont_fix/resolved** (V04 on FIX-STAGE-RENDERER, V04/V06 on COMPLETION-FLAG-HARNESS, V03+A04/A05 on VENTURE-PROVISIONING-PARITY, A02-A04 on DATADISTILL-H1).

### Fix (FR-1..FR-5)
- **FR-1**: `VISION_SUPPRESSED_REASONS = {cli_validation, readonly_bugfix, documentation}`; the 5b strip (extracted to pure exported `_stripSuppressedDims`) removes V-dims in addition to A01-A05 for those verdicts. `lifecycle_feature` deliberately excluded — keeps its A-dims-only strip.
- **FR-2**: conservative default preserved — `classifySourceSD` null verdicts (write≥2) never reach the strip; both V- and A-dims still emit (PROVISIONING-PARITY non-regression pinned).
- **FR-3**: distinct `skipped_vision_dim_readonly_source` audit event mirroring the `skipped_a05_source_class` shape (source_sd_id, reason, suppressed_dims); the legacy event keeps its exact prior shape for A-dims.
- **FR-4**: 9 new unit tests (both live regressions, lifecycle V-passthrough, mixed V+A group drop, other-dim passthrough, exact reason-set membership). Suite is mock-free — the generator's client is lazy, so no supabase-js import fakery (Stage-1.6 clean).
- **FR-5**: gates on the classifier verdict only — no new sd_type literals.

### Verification
- New suite 9/9; **all 8 corrective-generator suites 136/136** (pre-existing A-only paths byte-identical)
- Behavior parity: when only A-dims are suppressed, the emitted event/dims are unchanged from before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
