### PR TITLE
fix(QF-20260610-626): allowlist canonical coordinator cron loops in RCA tiered-enforcement counter

### DIFF
--- a/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
@@ -1,0 +1,103 @@
+// QF-20260610-626 — exempt the remaining canonical coordinator cron loops from the
+// RCA tiered-enforcement counter. The loops exit 0 by design on fixed intervals; the
+// consecutive-attempt counter misread the cron cadence as a stuck retry loop because
+// the exit-0 exemption's single per-session lastOutcome file is clobbered under
+// interleaved loops (residual after SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001).
+// Closes feedback ids d89abebc + c86d5027.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const MODULE_PATH = path.resolve(__dirname, '../retry-state-manager.cjs');
+
+function loadFresh() {
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+// FR-1/2/3 — the full canonical coordinator-loop command set.
+const LOOP_COMMANDS = [
+  'node scripts/coordinator-self-review.mjs',                                  // loop 8, */5
+  'node scripts/coordinator-audit.mjs',                                        // loop 5, */15
+  'node scripts/coordinator-email-summary.mjs',                                // loop 6, */30
+  'node scripts/coordinator-startup-check.mjs',                                // startup probe
+  // Step-0 keepalive: node -e inline (no script path) — matched on stable tokens.
+  'node -e "const { setActiveCoordinator } = require(\'./lib/coordinator/resolve.cjs\'); setActiveCoordinator(process.env.CLAUDE_SESSION_ID).then(...)"',
+  'node -e "require(\'./lib/coordinator/resolve.cjs\').setActiveCoordinator(id)"',
+];
+
+describe('QF-626 isExempt: canonical coordinator cron loops', () => {
+  const { isExempt } = loadFresh();
+
+  for (const cmd of LOOP_COMMANDS) {
+    it(`exempts: ${cmd.slice(0, 60)}`, () => {
+      expect(isExempt(cmd)).toBe(true);
+    });
+  }
+
+  it('still exempts with ./ prefix and windows separators', () => {
+    expect(isExempt('node ./scripts/coordinator-self-review.mjs')).toBe(true);
+    expect(isExempt('node scripts\\coordinator-audit.mjs')).toBe(true);
+  });
+
+  // FR-5 — anchoring: unrelated coordinator-* scripts stay RCA-gated.
+  it('does NOT exempt arbitrary or unrelated coordinator-* commands', () => {
+    expect(isExempt('node scripts/leo-create-sd.js')).toBe(false);
+    expect(isExempt('node scripts/coordinator-revive.cjs')).toBe(false);
+    expect(isExempt('node scripts/coordinator-self-review-helper.mjs')).toBe(false);
+  });
+
+  // FR-5 — fail-open input handling preserved.
+  it('returns false for non-string/empty input', () => {
+    expect(isExempt(null)).toBe(false);
+    expect(isExempt(undefined)).toBe(false);
+    expect(isExempt('')).toBe(false);
+  });
+});
+
+describe('QF-626 recordAndCount: loop commands never accumulate attempts', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf626-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    delete process.env.LEO_RETRY_STATE_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  for (const cmd of LOOP_COMMANDS.slice(0, 4)) {
+    it(`attempts stays 0 across 4 consecutive runs: ${cmd.slice(5, 50)}`, async () => {
+      const { recordAndCount } = loadFresh();
+      const opts = { rcaCheck: async () => null };
+      for (let i = 0; i < 4; i++) {
+        const r = await recordAndCount('qf626-sess', null, 'Bash', { command: cmd }, opts);
+        expect(r.attempts).toBe(0);
+      }
+    });
+  }
+
+  it('the Step-0 keepalive inline command also stays at 0', async () => {
+    const { recordAndCount } = loadFresh();
+    const opts = { rcaCheck: async () => null };
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount('qf626-sess', null, 'Bash', { command: LOOP_COMMANDS[4] }, opts);
+      expect(r.attempts).toBe(0);
+    }
+  });
+
+  it('non-loop command still accumulates 1..4 (3-strikes machinery untouched)', async () => {
+    const { recordAndCount } = loadFresh();
+    const opts = { rcaCheck: async () => null };
+    const counts = [];
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount('qf626-throttle', null, 'Bash', { command: 'node scripts/some-retry-loop.js' }, opts);
+      counts.push(r.attempts);
+    }
+    expect(counts).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -44,6 +44,20 @@ const EXEMPT_PATTERNS = [
   /\bscripts[/\\]fleet-dashboard\.cjs\b/,
   /\bscripts[/\\]assign-fleet-identities\.cjs\b/,
   /[/\\]?\.claude[/\\]tmp[/\\]coord-[\w-]+\.(?:cjs|mjs)\b/,
+  // QF-20260610-626 — the remaining canonical coordinator cron loops (coordinator.md
+  // Step 0/5). All exit 0 by design on a fixed interval; the consecutive-attempt counter
+  // misreads the cron cadence as a stuck retry loop (the SD-FDBK-FIX-RCA-TIERED-
+  // ENFORCEMENT-001 exit-0 exemption keys on a single per-session lastOutcome file that
+  // interleaved loops clobber, so it never matches for them). Each pattern is anchored
+  // to the specific script basename — unrelated coordinator-* scripts stay RCA-gated.
+  /\bscripts[/\\]coordinator-self-review\.mjs\b/,           // loop 8, */5
+  /\bscripts[/\\]coordinator-audit\.mjs\b/,                 // loop 5, */15
+  /\bscripts[/\\]coordinator-email-summary\.mjs\b/,         // loop 6, */30
+  /\bscripts[/\\]coordinator-startup-check\.mjs\b/,         // startup probe
+  // Step-0 keepalive: a `node -e` inline script (no script path) that re-asserts the
+  // active coordinator ~every 2 min — match its stable tokens, not a path.
+  /\bsetActiveCoordinator\b/,
+  /\bcoordinator[/\\]resolve\.cjs\b/,
 ];
 
 /**


### PR DESCRIPTION
Closes feedback d89abebc + c86d5027. The RCA tiered-enforcement consecutive-attempt counter treated fixed-interval coordinator cron ticks as stuck retry loops, throttling the coordinator heartbeat. The shipped exit-0 exemption keys on a single per-session lastOutcome file that interleaved loops clobber, so it never matched for these.

Fix per the QF-20260504-830 pattern: extend `EXEMPT_PATTERNS` in `scripts/hooks/retry-state-manager.cjs` with the remaining canonical coordinator loops (self-review */5, audit */15, email-summary */30, startup-check) + the Step-0 `node -e` keepalive (matched on `setActiveCoordinator` / `coordinator/resolve.cjs` tokens). Anchored to basenames — unrelated coordinator-* scripts stay RCA-gated.

15 new hermetic tests; 25/25 with the existing suite. The one outcome-mix TS-5 failure pre-exists on clean main (confirmed via checkout, unrelated content-digest signature change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)