### PR TITLE
fix(QF-20260610-551): surface prior-lessons advisory on the executeHandoff path

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.execute-lessons.test.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.execute-lessons.test.js
@@ -1,0 +1,116 @@
+/**
+ * QF-20260610-551: executeHandoff surfaces the prior-lessons advisory (parity with
+ * precheckHandoff from QF-457). Autonomous /loop workers call executeHandoff directly
+ * and never run precheck, so the advisory must live on the execute path too.
+ *
+ * Asserts: (a) fail-open — the verdict is unchanged when surfacePriorLessons throws;
+ * (b) the advisory is skipped entirely when LEO_SURFACE_LESSONS==='off';
+ * (c) the advisory runs post-verdict with the SD's category feeding the search.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const surfacePriorLessonsMock = vi.fn();
+const formatPriorLessonsMock = vi.fn().mockReturnValue('LESSONS-BLOCK');
+const resolvePhaseStrategyMock = vi.fn().mockReturnValue('strategy');
+
+vi.mock('../../../lib/learning/surface-prior-lessons.js', () => ({
+  surfacePriorLessons: surfacePriorLessonsMock,
+  formatPriorLessons: formatPriorLessonsMock,
+  resolvePhaseStrategy: resolvePhaseStrategyMock,
+}));
+vi.mock('../../../lib/learning/issue-knowledge-base.js', () => ({
+  IssueKnowledgeBase: class {},
+}));
+vi.mock('./auto-proceed-resolver.js', () => ({
+  resolveAutoProceed: vi.fn().mockResolvedValue({ autoProceed: true, source: 'test', sessionId: 's-1' }),
+  createHandoffMetadata: vi.fn().mockReturnValue({}),
+}));
+vi.mock('../../../lib/flywheel/capture.js', () => ({
+  captureHandoffGate: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./pre-checks/prerequisite-preflight.js', () => ({
+  runPrerequisitePreflight: vi.fn().mockResolvedValue({ passed: true, issues: [] }),
+}));
+vi.mock('../../../lib/supabase-client.js', () => ({ createSupabaseServiceClient: () => ({}) }));
+
+const { HandoffOrchestrator } = await import('./HandoffOrchestrator.js');
+
+const SD_ROW = { id: 'uuid-1', sd_key: 'SD-X-001', title: 'A title', category: 'infrastructure', sd_type: 'infrastructure' };
+
+function makeOrchestrator(executeResult) {
+  const orchestrator = new HandoffOrchestrator({
+    supabase: { mock: true },
+    sdRepo: { verifyExists: vi.fn().mockResolvedValue(SD_ROW) },
+    handoffRepo: { loadTemplate: vi.fn().mockResolvedValue({}) },
+    recorder: {
+      recordSuccess: vi.fn().mockResolvedValue(undefined),
+      recordFailure: vi.fn().mockResolvedValue(undefined),
+      recordSystemError: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+  // Bypass lazy executor loading.
+  orchestrator._executors = {
+    'PLAN-TO-LEAD': { execute: vi.fn().mockResolvedValue(executeResult) },
+  };
+  return orchestrator;
+}
+
+beforeEach(() => {
+  surfacePriorLessonsMock.mockReset().mockResolvedValue({ patterns: [{ p: 1 }], retrospectives: [] });
+  formatPriorLessonsMock.mockClear();
+  delete process.env.LEO_SURFACE_LESSONS;
+});
+
+afterEach(() => {
+  delete process.env.LEO_SURFACE_LESSONS;
+});
+
+describe('QF-551 executeHandoff prior-lessons advisory', () => {
+  it('surfaces lessons post-verdict using the SD category, verdict unchanged', async () => {
+    const orchestrator = makeOrchestrator({ success: true, score: 95 });
+    const result = await orchestrator.executeHandoff('PLAN-TO-LEAD', 'SD-X-001');
+
+    expect(result.success).toBe(true);
+    expect(result.score).toBe(95);
+    expect(surfacePriorLessonsMock).toHaveBeenCalledTimes(1);
+    const args = surfacePriorLessonsMock.mock.calls[0][0];
+    expect(args.sdCategory).toBe('infrastructure'); // sd.category from verifyExists row
+    expect(args.limit).toBe(3);
+    expect(resolvePhaseStrategyMock).toHaveBeenCalledWith('PLAN-TO-LEAD');
+    expect(formatPriorLessonsMock).toHaveBeenCalled();
+  });
+
+  it('FAIL-OPEN: verdict unchanged and no throw when surfacePriorLessons rejects', async () => {
+    surfacePriorLessonsMock.mockRejectedValue(new Error('DB down'));
+    const orchestrator = makeOrchestrator({ success: true, score: 88 });
+
+    const result = await orchestrator.executeHandoff('PLAN-TO-LEAD', 'SD-X-001');
+
+    expect(result.success).toBe(true);
+    expect(result.score).toBe(88);
+    expect(result.systemError).toBeUndefined(); // never escalates to the catch-all
+    expect(orchestrator.recorder.recordSystemError).not.toHaveBeenCalled();
+  });
+
+  it('SKIPPED entirely when LEO_SURFACE_LESSONS=off', async () => {
+    process.env.LEO_SURFACE_LESSONS = 'off';
+    const orchestrator = makeOrchestrator({ success: true, score: 90 });
+
+    const result = await orchestrator.executeHandoff('PLAN-TO-LEAD', 'SD-X-001');
+
+    expect(result.success).toBe(true);
+    expect(surfacePriorLessonsMock).not.toHaveBeenCalled();
+  });
+
+  it('also surfaces (and stays fail-open) on a FAILED verdict', async () => {
+    const orchestrator = makeOrchestrator({ success: false, reason: 'GATE_FAILED' });
+
+    const result = await orchestrator.executeHandoff('PLAN-TO-LEAD', 'SD-X-001');
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toBe('GATE_FAILED');
+    expect(surfacePriorLessonsMock).toHaveBeenCalledTimes(1);
+    expect(orchestrator.recorder.recordFailure).toHaveBeenCalled();
+  });
+});

--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -119,7 +119,9 @@ export class HandoffOrchestrator {
       console.log('Options:', { ...options, autoProceed: autoProceedResult.autoProceed });
       console.log('');
       // MANDATORY: Verify SD exists in database
-      await this.sdRepo.verifyExists(sdId);
+      // QF-20260610-551: capture the returned SD row (verifyExists selects category/title)
+      // — it feeds the prior-lessons advisory below without a redundant DB round-trip.
+      const sd = await this.sdRepo.verifyExists(sdId);
 
       // Validate handoff type
       if (!this.supportedHandoffs.includes(normalizedType)) {
@@ -211,6 +213,34 @@ export class HandoffOrchestrator {
         }
       } else if (!result.systemError) {
         await this.recorder.recordFailure(normalizedType, sdId, result, template);
+      }
+
+      // QF-20260610-551: prior-lessons advisory on the EXECUTE path. QF-457 wired this
+      // into precheckHandoff only, but autonomous /loop workers call executeHandoff
+      // directly (scripts/handoff.js execute → cli-main.js → here) and never run
+      // precheck — so the captured lessons never reached the workers they were meant
+      // for. Mirrors the precheck block: ADVISORY ONLY, fail-open (any error swallowed
+      // with a non-blocking warn), surfaced POST-VERDICT so the gate run and the
+      // recorded result are never delayed or altered. Default-on; LEO_SURFACE_LESSONS=off
+      // disables it.
+      if (process.env.LEO_SURFACE_LESSONS !== 'off') {
+        try {
+          const { surfacePriorLessons, formatPriorLessons, resolvePhaseStrategy } =
+            await import('../../../lib/learning/surface-prior-lessons.js');
+          const { IssueKnowledgeBase } = await import('../../../lib/learning/issue-knowledge-base.js');
+          const { patterns, retrospectives } = await surfacePriorLessons({
+            kb: new IssueKnowledgeBase(),
+            supabase: this.supabase,
+            sdCategory: (sd && (sd.category || sd.title)) || sdId,
+            phaseStrategy: resolvePhaseStrategy(normalizedType),
+            limit: 3
+          });
+          console.log('');
+          console.log(formatPriorLessons(patterns, retrospectives));
+          console.log('');
+        } catch (e) {
+          console.warn(`   [execute] prior-lessons surfacing skipped (advisory, non-blocking): ${e.message}`);
+        }
       }
 
       // SD-LEO-FEAT-DATA-FLYWHEEL-001: Fire-and-forget capture to eva_interactions


### PR DESCRIPTION
Closes feedback ff36b8f8. QF-457 wired the prior-lessons advisory into `precheckHandoff` only, but autonomous /loop workers invoke `handoff.js execute` → `executeHandoff` directly and never run precheck — the captured lessons never reached the workers the QF was meant to serve.

Mirrors the precheck block into `executeHandoff`: SD row captured from the existing `verifyExists` return (no extra round-trip), surfaced **post-verdict** (gate run + recorded result never delayed/altered), advisory-only + fail-open, same default-on `LEO_SURFACE_LESSONS` switch. ~30 LOC + 4 tests (8/8 with the precheck suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)