### PR TITLE
fix(QF-20260610-234): multi-root-cause scope-discovery advisory in QF triage LOC estimation

### DIFF
--- a/lib/ai-loc-estimator.js
+++ b/lib/ai-loc-estimator.js
@@ -6,6 +6,62 @@
  * Created: 2025-11-17
  */
 
+// QF-20260610-234: lexical signals of probable multi-root-cause coupling. A factually-
+// singular bug report ("X fails") can mask several coupled defects (QF-20260609-493:
+// filed as one root cause, shipped 152 LOC / 4 defects, needed --force-complete).
+// Pure/synchronous — stays on the hot triage path, no LLM call.
+const FAILURE_VERB_RE = /\b(fail(?:s|ed|ing)?|crash(?:es|ed)?|throw(?:s|n)?|hang(?:s)?|block(?:s|ed)?|time(?:s)?\s*out|reject(?:s|ed)?|miss(?:es|ing)?|broken|break(?:s)?|leak(?:s|ed)?|corrupt(?:s|ed)?|ignore(?:s|d)?|drop(?:s|ped)?|mismatch(?:es)?|stuck|silently|no-?op(?:s)?)\b/g;
+const CONJOINED_RE = /\b(and also|as well as|plus|additionally|; also|, also)\b/;
+const ENUMERATED_RE = /(?:^|\s)\(?\d+[.)]\s/g; // "1. " / "2) " style symptom lists
+const FILE_REF_RE = /\b[\w./-]+\.(?:c|m)?[jt]sx?\b|\b[\w./-]+\.(?:sql|py|cjs|mjs|json)\b/g;
+const FUNC_REF_RE = /\b\w+\(\)/g;
+const COMPOUNDING_PHRASES = [
+  'no json found', 'cascade', 'chained', 'which then', 'in turn',
+  'downstream', 'root causes', 'coupled', 'compounding',
+];
+
+/**
+ * QF-20260610-234 (FR-1): detect probable multi-defect coupling in symptom text.
+ * Conservative: requires >=2 DISTINCT signal categories so a single keyword never
+ * flags a genuinely singular typo/null-access/single-file fix.
+ *
+ * @param {Object} params - { title, description, type, file, consoleError }
+ * @returns {{ likelyMultiDefect: boolean, signals: string[], suggestedLocFloor: number|null }}
+ */
+export function detectMultiDefectScope(params) {
+  const none = { likelyMultiDefect: false, signals: [], suggestedLocFloor: null };
+  if (!params || typeof params !== 'object') return none;
+  const { title = '', description = '', consoleError = '', file = '' } = params;
+  const combined = [title, description, consoleError]
+    .filter(v => typeof v === 'string')
+    .join(' ')
+    .toLowerCase();
+  if (!combined.trim()) return none;
+
+  const signals = [];
+  const verbs = new Set((combined.match(FAILURE_VERB_RE) || []).map(v => v.replace(/(s|ed|ing|es|n|ped)$/, '')));
+  if (verbs.size >= 2) signals.push(`multiple_failure_verbs(${verbs.size})`);
+  if (CONJOINED_RE.test(combined) || (combined.match(ENUMERATED_RE) || []).length >= 2) {
+    signals.push('conjoined_or_enumerated_symptoms');
+  }
+  const refs = new Set([
+    ...(combined.match(FILE_REF_RE) || []),
+    ...(typeof file === 'string' && file ? [file.toLowerCase()] : []),
+    ...(combined.match(FUNC_REF_RE) || []),
+  ]);
+  if (refs.size >= 2) signals.push(`multiple_code_references(${refs.size})`);
+  if (COMPOUNDING_PHRASES.some(p => combined.includes(p))) signals.push('compounding_error_phrase');
+
+  const likelyMultiDefect = signals.length >= 2;
+  return {
+    likelyMultiDefect,
+    signals,
+    // Floor lands the estimate in Tier 2 (31-75) so a would-be Tier-1 auto-approve
+    // gets a second look; never enough to force Tier 3 on its own (advisory only).
+    suggestedLocFloor: likelyMultiDefect ? 40 : null,
+  };
+}
+
 /**
  * Estimate LOC based on issue description, error type, and context
  * @param {Object} params - Estimation parameters
@@ -116,6 +172,17 @@ export function estimateLOC(params) {
     // Has line number in stack trace
     confidence = Math.max(confidence, 85);
     reasoning.push('Stack trace with line number provided - high confidence');
+  }
+
+  // Pattern 7 (QF-20260610-234): multi-defect scope-discovery soft floor. The
+  // first-match break (Pattern 1) sizes off ONE error pattern, so a singular-sounding
+  // report masking coupled defects under-estimates. The floor only ever RAISES the
+  // estimate (Math.max — FR-3) and adds a reasoning line; it never lowers or replaces.
+  const scope = detectMultiDefectScope(params);
+  if (scope.likelyMultiDefect && scope.suggestedLocFloor > estimatedLoc) {
+    estimatedLoc = scope.suggestedLocFloor;
+    confidence = Math.max(confidence - 15, 40);
+    reasoning.push(`Scope-discovery: probable multi-defect coupling (${scope.signals.join(', ')}) — floored estimate at ${scope.suggestedLocFloor} LOC; consider re-estimating / full SD`);
   }
 
   // Cap at reasonable values

--- a/scripts/modules/triage-gate.js
+++ b/scripts/modules/triage-gate.js
@@ -12,7 +12,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
-import { estimateLOC } from '../../lib/ai-loc-estimator.js';
+import { estimateLOC, detectMultiDefectScope } from '../../lib/ai-loc-estimator.js';
 import { routeWorkItem } from '../../lib/utils/work-item-router.js';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
 
@@ -178,6 +178,18 @@ export async function runTriageGate(input, supabaseClient) {
     supabaseClient
   );
 
+  // Step 2.5 (QF-20260610-234, FR-2): scope-discovery advisory. estimateLOC already
+  // applies the soft floor internally; this surfaces the pre-claim recommendation on
+  // the TriageResult for a would-be Tier 1/2 item. Fail-soft: advisory text only —
+  // never blocks, never forces an error, never lowers a tier.
+  let scopeAdvisory = null;
+  try {
+    const scope = detectMultiDefectScope({ title, description: combinedDescription, type });
+    if (scope.likelyMultiDefect && routingDecision.tier <= 2) {
+      scopeAdvisory = `scope-discovery: symptom shows probable multi-defect coupling (${scope.signals.join(', ')}) — re-estimate LOC before claim; consider a full SD if multiple root causes confirm`;
+    }
+  } catch { /* fail-soft: advisory must never break triage */ }
+
   // Step 3: Determine if we should gate
   const shouldGate = routingDecision.tier <= 2 && isHardGateSource(lowerSource);
 
@@ -190,6 +202,9 @@ export async function runTriageGate(input, supabaseClient) {
       title,
       type
     );
+    if (scopeAdvisory && askUserQuestionPayload?.questions?.[0]) {
+      askUserQuestionPayload.questions[0].question += ` ⚠️ ${scopeAdvisory}`;
+    }
   }
 
   return {
@@ -199,8 +214,9 @@ export async function runTriageGate(input, supabaseClient) {
     workItemType: routingDecision.workItemType,
     estimatedLoc: locResult.estimatedLoc,
     confidence: locResult.confidence,
-    reasoning: locResult.reasoning,
+    reasoning: scopeAdvisory ? `${locResult.reasoning}; ${scopeAdvisory}` : locResult.reasoning,
     escalationReason: routingDecision.escalationReason,
+    scopeDiscoveryAdvisory: scopeAdvisory,
     askUserQuestionPayload,
     routingDecision,
   };

--- a/tests/unit/ai-loc-estimator-multidefect.test.js
+++ b/tests/unit/ai-loc-estimator-multidefect.test.js
@@ -1,0 +1,111 @@
+/**
+ * QF-20260610-234: multi-root-cause scope-discovery advisory in QF triage.
+ *
+ * The LOC estimator sizes off the FIRST matching error pattern only, so a
+ * singular-sounding symptom masking coupled defects under-tiers (QF-20260609-493:
+ * filed as one root cause, shipped 152 LOC / 4 defects, needed --force-complete).
+ * Pins detectMultiDefectScope (pure), the estimateLOC soft floor (raise-only),
+ * and the triage-gate advisory surfacing — plus the no-false-positive direction.
+ */
+import { describe, it, expect } from 'vitest';
+import { estimateLOC, detectMultiDefectScope } from '../../lib/ai-loc-estimator.js';
+import { runTriageGate } from '../../scripts/modules/triage-gate.js';
+
+// QF-493-shaped symptom: singular framing, multiple coupled defects underneath.
+const QF493_STYLE = {
+  title: 'Quick-fix completion fails',
+  description:
+    'complete-quick-fix.js throws No JSON found when parsing PR metadata, and also the ' +
+    'branch detection in git-operations.js silently drops the worktree path, plus the ' +
+    'LOC counter ignores test files. Each failure then blocks the next step in turn.',
+  type: 'bug',
+};
+
+describe('detectMultiDefectScope (FR-1)', () => {
+  it('(a) flags a QF-493-style singular-symptom/multi-defect report', () => {
+    const out = detectMultiDefectScope(QF493_STYLE);
+    expect(out.likelyMultiDefect).toBe(true);
+    expect(out.signals.length).toBeGreaterThanOrEqual(2);
+    expect(out.suggestedLocFloor).toBe(40);
+  });
+
+  it('(b) does NOT flag a genuinely singular typo fix', () => {
+    const out = detectMultiDefectScope({
+      title: 'Typo in dashboard heading',
+      description: 'The heading says "Vetures" instead of "Ventures". Single text change.',
+      type: 'typo',
+    });
+    expect(out).toEqual({ likelyMultiDefect: false, signals: [], suggestedLocFloor: null });
+  });
+
+  it('(b) does NOT flag a singular null-access single-file fix', () => {
+    const out = detectMultiDefectScope({
+      title: 'Cannot read property name of undefined in VentureCard',
+      description: 'Null access when venture has no owner. Add a guard.',
+      type: 'bug',
+      file: 'src/components/VentureCard.tsx',
+    });
+    expect(out.likelyMultiDefect).toBe(false);
+    expect(out.suggestedLocFloor).toBeNull();
+  });
+
+  it('(c) empty/garbage/non-string input returns false without throwing', () => {
+    expect(detectMultiDefectScope({}).likelyMultiDefect).toBe(false);
+    expect(detectMultiDefectScope(null).likelyMultiDefect).toBe(false);
+    expect(detectMultiDefectScope(undefined).likelyMultiDefect).toBe(false);
+    expect(detectMultiDefectScope({ title: 42, description: {} }).likelyMultiDefect).toBe(false);
+    expect(detectMultiDefectScope({ description: '   ' }).likelyMultiDefect).toBe(false);
+  });
+});
+
+describe('estimateLOC soft floor (FR-3: raise-only, reasoning preserved)', () => {
+  it('floors a multi-defect symptom to 40 LOC with a scope-discovery reasoning line', () => {
+    const out = estimateLOC(QF493_STYLE);
+    expect(out.estimatedLoc).toBeGreaterThanOrEqual(40);
+    expect(out.reasoning).toMatch(/Scope-discovery: probable multi-defect coupling/);
+  });
+
+  it('never lowers an estimate already above the floor', () => {
+    // 'api call' base (15) x 'entire' multiplier (3.0) = 45 > the 40 floor.
+    // (no 'across'/'multiple' words — the complexity loop breaks on first match)
+    const out = estimateLOC({
+      title: 'Rewrite entire api call layer',
+      description:
+        'fetch fails and also crashes in helper.js and parser.js; cascade of errors',
+      type: 'bug',
+    });
+    expect(out.estimatedLoc).toBe(45); // floor (40) did not pull it DOWN
+    expect(out.reasoning).not.toMatch(/floored estimate/);
+  });
+
+  it('leaves a singular fix estimate untouched (output contract preserved)', () => {
+    const out = estimateLOC({ title: 'Fix typo in heading', description: 'single word change', type: 'typo' });
+    expect(out.estimatedLoc).toBeLessThanOrEqual(3);
+    expect(out.reasoning).not.toMatch(/Scope-discovery/);
+    expect(typeof out.confidence).toBe('number');
+  });
+});
+
+describe('runTriageGate advisory (FR-2: fail-soft, advisory only)', () => {
+  it('(a) surfaces the scope-discovery advisory and lands >= Tier 2 for a QF-493-style item', async () => {
+    const res = await runTriageGate({ ...QF493_STYLE, source: 'interactive' });
+    expect(res.tier).toBeGreaterThanOrEqual(2);
+    expect(res.scopeDiscoveryAdvisory).toMatch(/scope-discovery/);
+    expect(res.reasoning).toMatch(/re-estimate LOC before claim/);
+    if (res.askUserQuestionPayload) {
+      expect(res.askUserQuestionPayload.questions[0].question).toMatch(/scope-discovery/);
+    }
+  });
+
+  it('(b) no advisory for a genuinely singular fix — routing unchanged', async () => {
+    const res = await runTriageGate({
+      title: 'Fix typo in heading',
+      description: 'single word change',
+      type: 'typo',
+      source: 'interactive',
+    });
+    expect(res.scopeDiscoveryAdvisory).toBeNull();
+    expect(res.reasoning).not.toMatch(/scope-discovery/);
+    expect(res.tier).toBe(1);
+  });
+});


### PR DESCRIPTION
## QF-20260610-234 — Multi-root-cause scope-discovery advisory in QF triage LOC estimation

**Type**: bug | **Severity**: low | **Tier**: 2 (Standard QF) | Source feedback: `78733e87` (Adam sweep `wf_229accdd`, net_new)

### Problem
`estimateLOC` sizes off the FIRST matching error pattern (loop break) and inflates only on generic complexity keywords (`multiple`/`several`/`across`), so a factually-singular symptom masking several coupled defects routes as Tier 1/2 — exactly how QF-20260609-493 was filed as one root cause, shipped 152 LOC (4 coupled defects), and needed an audited `--force-complete` past the Tier-2 cap.

### Fix (FR-1..FR-4, additive + fail-soft)
- **FR-1**: new exported pure `detectMultiDefectScope()` (`lib/ai-loc-estimator.js`) — lexical coupling signals: ≥2 distinct failure verbs, conjoined/enumerated symptom lists, ≥2 distinct file/function references, compounding-error phrases ('No JSON found', cascade/chained). Conservative: requires **≥2 distinct signal categories**, so singular typo/null/single-file fixes never flag.
- **FR-3**: wired into `estimateLOC` as a **raise-only** soft floor (`Math.max` to 40 LOC = Tier-2 territory) + additive reasoning line; existing output contract preserved.
- **FR-2**: `runTriageGate` surfaces a fail-soft `scope-discovery` advisory (new `scopeDiscoveryAdvisory` field, appended to `reasoning`, appended to the AskUserQuestion text for hard-gate sources). Never blocks, never errors, never lowers a tier.
- **FR-4**: 9 unit tests — QF-493-style flagged + lands ≥Tier 2; typo + null-access single-file NOT flagged; empty/garbage/non-string safe; floor raise-only (45-LOC estimate untouched); advisory both directions through `runTriageGate`.

### Out of scope honored
No tier-threshold change, no LLM call (pure/synchronous on the hot path), recurrence detector and complete-quick-fix cap logic untouched.

### Verification
- New suite 9/9; `work-item-router` 28/28 + `leo-create-sd-vision-prescreen` green unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
