### PR TITLE
fix(QF-20260610-863): leo_feature_flags authoritative for ADAM_* governance flags (real kill-switch) + drift detection

### DIFF
--- a/lib/feature-flags/governance-review.js
+++ b/lib/feature-flags/governance-review.js
@@ -32,13 +32,27 @@ function ageDays(ts, now) {
  * Classify a single flag's staleness. Returns null when the flag is healthy.
  * @param {object} flag - a leo_feature_flags row
  * @param {number} now - epoch ms (injected for testability)
- * @returns {{flag_key:string, reasons:string[], recommendation:'enable'|'graduate'|'kill'|'extend'|'review', detail:string}|null}
+ * @param {object} [opts] - { env } — runtime env snapshot for registry-vs-runtime
+ *   drift detection (QF-20260610-863). Injected, never read globally (stays pure).
+ * @returns {{flag_key:string, reasons:string[], recommendation:'enable'|'graduate'|'kill'|'extend'|'review'|'reconcile', detail:string}|null}
  */
-export function classifyFlag(flag, now) {
+export function classifyFlag(flag, now, opts = {}) {
   const reasons = [];
   const lifecycle = flag.lifecycle_state;
   // Terminal states are intentionally settled — never "stale".
   if (lifecycle === 'archived' || lifecycle === 'expired') return null;
+
+  // QF-20260610-863 (W0-3, FR-3): registry-vs-runtime drift. An ADAM_* row whose
+  // registry says off/draft while the runtime env flag is ON means the loop is
+  // live but the registry kill-switch disagrees — previously classified HEALTHY
+  // (verified live for ADAM_GOVERNANCE_HEARTBEAT_V1). Surfaced with a RECONCILE
+  // recommendation: promote the row (or kill the env) so the two agree.
+  const envRaw = opts.env ? String(opts.env[flag.flag_key] || '').toLowerCase() : '';
+  const envOn = envRaw === 'on' || envRaw === '1' || envRaw === 'true';
+  const registryRuntimeDrift =
+    String(flag.flag_key || '').startsWith('ADAM_') &&
+    envOn &&
+    (flag.is_enabled === false || lifecycle === 'draft');
 
   const neverReviewed = !flag.last_reviewed_at;
   const expiry = flag.expiry_at ? new Date(flag.expiry_at).getTime() : null;
@@ -65,6 +79,7 @@ export function classifyFlag(flag, now) {
     lifecycle === 'draft' &&
     ageDays(flag.rolled_out_at, now) >= STALE_PENDING_OFF_DAYS;
 
+  if (registryRuntimeDrift) reasons.push('registry-runtime-drift');
   if (neverReviewed) reasons.push('never-reviewed');
   if (pastExpiry) reasons.push('past-expiry');
   if (disabledAging) reasons.push('disabled-aging');
@@ -77,6 +92,19 @@ export function classifyFlag(flag, now) {
   // enabled-unrolled flag should graduate; an aging-disabled flag should be
   // killed; otherwise it just needs a human review.
   let recommendation;
+  // Registry-vs-runtime drift outranks everything: the registry kill-switch is now
+  // AUTHORITATIVE (QF-20260610-863), so a row disagreeing with the live runtime is
+  // an active safety gap, not mere staleness.
+  if (registryRuntimeDrift) {
+    return {
+      flag_key: flag.flag_key,
+      lifecycle_state: lifecycle,
+      is_enabled: !!flag.is_enabled,
+      reasons,
+      recommendation: 'reconcile',
+      detail: `registry (${lifecycle}/${flag.is_enabled ? 'on' : 'off'}) disagrees with live runtime (env=on) — promote the row or kill the env so the authoritative gate is consistent`
+    };
+  }
   // A forgotten shipped-OFF switch is the most actionable signal — surface ENABLE first so the
   // coordinator/chairman sees the automation that is silently not running (the operator's
   // repeatedly-flagged "turn it off and forget" trap). Flipping it ON stays a deliberate action.
@@ -102,10 +130,10 @@ export function classifyFlag(flag, now) {
  * @param {number} now - epoch ms
  * @returns {{stale: Array, total: number, byRecommendation: Record<string,number>}}
  */
-export function computeStaleFlags(flags, now) {
+export function computeStaleFlags(flags, now, opts = {}) {
   const stale = [];
   for (const f of flags || []) {
-    const c = classifyFlag(f, now);
+    const c = classifyFlag(f, now, opts);
     if (c) stale.push(c);
   }
   const byRecommendation = stale.reduce((acc, s) => {

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -34,6 +34,37 @@ function isFlagEnabled(env = process.env) {
   return v === 'on' || v === '1' || v === 'true';
 }
 
+/**
+ * QF-20260610-863 (W0-3, FR-1/FR-2): conjunctive authoritative gate. The registry
+ * (leo_feature_flags) was dead metadata — consumers read env only, so a registry
+ * is_enabled=false had ZERO effect (proven live). Now BOTH must be ON to run:
+ *   env OFF                      -> { enabled:false, source:'env_off' }        (registry never read)
+ *   env ON + registry false      -> { enabled:false, source:'registry_kill' }  (remote kill-switch, fail-CLOSED)
+ *   env ON + registry true       -> { enabled:true,  source:'env_and_registry_on' }
+ *   env ON + row missing/DB err  -> { enabled:true,  source:'registry_degraded_env_verdict', degraded:true }
+ * Asymmetry is deliberate: the kill direction is reliable (a readable registry
+ * false always kills), but a transient DB blip degrades to the env verdict — it
+ * can never silently flip ON a flag the env had off (env_off short-circuits before
+ * any DB read), and never crashes the tick. Pure-DI (client injected) per FR-5.
+ */
+async function resolveGovernanceFlagGate(supabase, flagKey, envVerdict) {
+  if (!envVerdict) return { enabled: false, source: 'env_off', degraded: false };
+  try {
+    const { data, error } = await supabase
+      .from('leo_feature_flags')
+      .select('is_enabled')
+      .eq('flag_key', flagKey)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return { enabled: true, source: 'registry_degraded_env_verdict', degraded: true, detail: 'no registry row' };
+    return data.is_enabled === true
+      ? { enabled: true, source: 'env_and_registry_on', degraded: false }
+      : { enabled: false, source: 'registry_kill', degraded: false };
+  } catch (e) {
+    return { enabled: true, source: 'registry_degraded_env_verdict', degraded: true, detail: e.message };
+  }
+}
+
 /** Parse argv into { mode, scope, tick }. mode is null when no subcommand flag is present. */
 function parseArgs(argv) {
   let mode = null;
@@ -143,6 +174,14 @@ async function main() {
     const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
     const supabase = createSupabaseServiceClient('engineer');
 
+    // QF-20260610-863: the registry is now AUTHORITATIVE — conjoin it with the env
+    // verdict captured above. A registry is_enabled=false kills the loop live.
+    const gate = await resolveGovernanceFlagGate(supabase, 'ADAM_GOVERNANCE_HEARTBEAT_V1', flagEnabled);
+    if (gate.degraded) {
+      process.stderr.write(`[adam-scan] flag gate degraded to env verdict (${gate.detail || 'registry unreadable'})\n`);
+    }
+    const gateEnabled = gate.enabled;
+
     const { enumerateScopes, resolveScopeArg, countLiveVentures } = await import('../lib/adam/scope-registry.js');
     const scopes = await enumerateScopes(supabase);
     const liveVentureCount = countLiveVentures(scopes);
@@ -169,22 +208,23 @@ async function main() {
     const result = selectAdvisory(guarded.kept, { openSdKeys });
 
     if (!result.surfaced) {
-      const entry = appendLedger(buildLedgerEntry({ scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled }));
+      const entry = appendLedger(buildLedgerEntry({ scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled: gateEnabled }));
       process.stdout.write(`ADAM_OK scope=${scope.scope_key} (nothing cleared the bar)\n`);
       process.stdout.write(JSON.stringify(entry) + '\n');
       process.exit(0);
     }
 
     const body = formatAdvisoryBody(result.surfaced);
-    if (!flagEnabled) {
-      // Cleared the bar, but the surfacing path is inert until the flag flips.
-      appendLedger(buildLedgerEntry({ scope, verdict: 'SUPPRESSED_FLAG_OFF', cleared: result.cleared, flagEnabled, detail: result.surfaced.dedup_key || null }));
-      process.stdout.write(`SUPPRESSED_FLAG_OFF scope=${scope.scope_key} (1 cleared; ADAM_GOVERNANCE_HEARTBEAT_V1 is off)\n`);
+    if (!gateEnabled) {
+      // Cleared the bar, but the surfacing path is inert until the gate clears
+      // (env off, or QF-20260610-863: the authoritative registry killed it).
+      appendLedger(buildLedgerEntry({ scope, verdict: 'SUPPRESSED_FLAG_OFF', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null }));
+      process.stdout.write(`SUPPRESSED_FLAG_OFF scope=${scope.scope_key} (1 cleared; ADAM_GOVERNANCE_HEARTBEAT_V1 gate off: ${gate.source})\n`);
       process.exit(0);
     }
 
-    // flag ON: emit exactly ONE advisory via the existing lane.
-    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled, detail: result.surfaced.dedup_key || null }));
+    // gate ON (env AND registry): emit exactly ONE advisory via the existing lane.
+    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null }));
     const r = spawnSync('node', [ADVISORY_CLI, 'send', body], { stdio: 'inherit' });
     process.exit(r.status == null ? 0 : r.status);
   } catch (e) {
@@ -194,7 +234,7 @@ async function main() {
   }
 }
 
-module.exports = { isFlagEnabled, parseArgs, buildLedgerEntry, usage, LEDGER_PATH };
+module.exports = { isFlagEnabled, resolveGovernanceFlagGate, parseArgs, buildLedgerEntry, usage, LEDGER_PATH };
 
 if (require.main === module) {
   main();

--- a/scripts/flag-governance-review.mjs
+++ b/scripts/flag-governance-review.mjs
@@ -32,7 +32,8 @@ export async function reviewMain({ force = false } = {}) {
   }
 
   // Compute the digest BEFORE stamping so never-reviewed flags surface once.
-  const result = computeStaleFlags(flags || [], Date.now());
+  // env injected for the registry-vs-runtime drift detector (QF-20260610-863).
+  const result = computeStaleFlags(flags || [], Date.now(), { env: process.env });
   console.log(formatDigest(result));
 
   // Stamp last_reviewed_at on every reviewed flag (the automated review touched them this cycle).

--- a/tests/unit/adam-governance-flag-gate.test.js
+++ b/tests/unit/adam-governance-flag-gate.test.js
@@ -1,0 +1,143 @@
+/**
+ * QF-20260610-863 (W0-3): leo_feature_flags is AUTHORITATIVE for ADAM_* governance
+ * flags (real kill-switch) + registry-vs-runtime drift detection.
+ *
+ * Before: consumers read env only — a registry is_enabled=false was dead metadata
+ * (proven live: ADAM_GOVERNANCE_HEARTBEAT_V1 registry=false/draft, env=on, loop ran)
+ * and classifyFlag returned HEALTHY for exactly that drift.
+ *
+ * Pins: the conjunctive gate's full truth table incl. the fail-safe asymmetry
+ * (registry false reliably kills; DB blip degrades to env verdict, never crashes,
+ * never flips ON something env had off), and the drift classifier both directions.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { classifyFlag, computeStaleFlags } from '../../lib/feature-flags/governance-review.js';
+
+const require = createRequire(import.meta.url);
+const { isFlagEnabled, resolveGovernanceFlagGate } = require('../../scripts/adam-opportunity-scan.cjs');
+
+// Minimal chainable stub for the single registry read.
+function sbStub({ row, error, throws } = {}) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => {
+            if (throws) throw new Error('db down');
+            return { data: row ?? null, error: error ?? null };
+          },
+        }),
+      }),
+    }),
+  };
+}
+
+describe('isFlagEnabled (pure env helper preserved — FR-5)', () => {
+  it('on/1/true => true; off/undefined => false', () => {
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: 'on' })).toBe(true);
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: '1' })).toBe(true);
+    expect(isFlagEnabled({ ADAM_GOVERNANCE_HEARTBEAT_V1: 'off' })).toBe(false);
+    expect(isFlagEnabled({})).toBe(false);
+  });
+});
+
+describe('resolveGovernanceFlagGate — conjunctive truth table (FR-1)', () => {
+  it('env OFF short-circuits: gate off, registry NEVER read', async () => {
+    const neverRead = { from: () => { throw new Error('must not be called'); } };
+    const g = await resolveGovernanceFlagGate(neverRead, 'ADAM_GOVERNANCE_HEARTBEAT_V1', false);
+    expect(g).toEqual({ enabled: false, source: 'env_off', degraded: false });
+  });
+
+  it('env ON + registry is_enabled=false => KILLED (the real kill-switch)', async () => {
+    const g = await resolveGovernanceFlagGate(sbStub({ row: { is_enabled: false } }), 'F', true);
+    expect(g.enabled).toBe(false);
+    expect(g.source).toBe('registry_kill');
+    expect(g.degraded).toBe(false);
+  });
+
+  it('env ON + registry is_enabled=true => enabled', async () => {
+    const g = await resolveGovernanceFlagGate(sbStub({ row: { is_enabled: true } }), 'F', true);
+    expect(g).toEqual({ enabled: true, source: 'env_and_registry_on', degraded: false });
+  });
+});
+
+describe('resolveGovernanceFlagGate — fail-safe degradation (FR-2)', () => {
+  it('DB throw degrades to the env verdict (on), flagged degraded, never throws', async () => {
+    const g = await resolveGovernanceFlagGate(sbStub({ throws: true }), 'F', true);
+    expect(g.enabled).toBe(true);
+    expect(g.source).toBe('registry_degraded_env_verdict');
+    expect(g.degraded).toBe(true);
+  });
+
+  it('PostgREST error object degrades the same way', async () => {
+    const g = await resolveGovernanceFlagGate(sbStub({ error: { message: 'timeout' } }), 'F', true);
+    expect(g.degraded).toBe(true);
+    expect(g.enabled).toBe(true);
+  });
+
+  it('missing registry row degrades to env verdict (no row != kill)', async () => {
+    const g = await resolveGovernanceFlagGate(sbStub({ row: null }), 'F', true);
+    expect(g.enabled).toBe(true);
+    expect(g.degraded).toBe(true);
+  });
+
+  it('a DB blip can never flip ON a flag env had OFF (env_off precedes any read)', async () => {
+    const g = await resolveGovernanceFlagGate(sbStub({ throws: true }), 'F', false);
+    expect(g.enabled).toBe(false);
+    expect(g.source).toBe('env_off');
+  });
+});
+
+describe('classifyFlag registry-vs-runtime drift (FR-3)', () => {
+  const NOW = new Date('2026-06-10T00:00:00Z').getTime();
+  const driftedRow = {
+    flag_key: 'ADAM_GOVERNANCE_HEARTBEAT_V1',
+    lifecycle_state: 'draft',
+    is_enabled: false,
+    last_reviewed_at: new Date(NOW - 86400000).toISOString(),
+    rolled_out_at: new Date(NOW - 86400000).toISOString(),
+    created_at: new Date(NOW - 86400000).toISOString(),
+  };
+
+  it('flags an ADAM_* row off/draft while env=on as RECONCILE (was HEALTHY — the live bug)', () => {
+    const c = classifyFlag(driftedRow, NOW, { env: { ADAM_GOVERNANCE_HEARTBEAT_V1: 'on' } });
+    expect(c).not.toBeNull();
+    expect(c.reasons).toContain('registry-runtime-drift');
+    expect(c.recommendation).toBe('reconcile');
+  });
+
+  it('no drift when env is off (registry off matches runtime off)', () => {
+    const c = classifyFlag(driftedRow, NOW, { env: {} });
+    // may still be stale for OTHER reasons, but never drift
+    expect(c?.reasons ?? []).not.toContain('registry-runtime-drift');
+  });
+
+  it('no drift for a consistent enabled row (env=on, registry on)', () => {
+    const c = classifyFlag(
+      { ...driftedRow, lifecycle_state: 'enabled', is_enabled: true },
+      NOW,
+      { env: { ADAM_GOVERNANCE_HEARTBEAT_V1: 'on' } }
+    );
+    expect(c?.reasons ?? []).not.toContain('registry-runtime-drift');
+  });
+
+  it('non-ADAM_* flags are out of drift scope', () => {
+    const c = classifyFlag(
+      { ...driftedRow, flag_key: 'OTHER_FLAG' },
+      NOW,
+      { env: { OTHER_FLAG: 'on' } }
+    );
+    expect(c?.reasons ?? []).not.toContain('registry-runtime-drift');
+  });
+
+  it('computeStaleFlags threads opts.env through to the classifier', () => {
+    const res = computeStaleFlags([driftedRow], NOW, { env: { ADAM_GOVERNANCE_HEARTBEAT_V1: 'on' } });
+    expect(res.byRecommendation.reconcile).toBe(1);
+  });
+
+  it('no-env callers keep legacy behavior byte-identical (classifyFlag 2-arg)', () => {
+    const c = classifyFlag(driftedRow, NOW);
+    expect(c?.reasons ?? []).not.toContain('registry-runtime-drift');
+  });
+});


### PR DESCRIPTION
## QF-20260610-863 — W0-3: leo_feature_flags authoritative for ADAM_* governance flags (real kill-switch) + drift detection

**Type**: bug | **Severity**: high | Parent program: `SD-LEO-ORCH-ADAM-PLAN-KEEPER-001` (W0-3) | Authored by Adam workflow `wf_68eb7c51` per chairman directive; 5-critic critique folded (GOVERNANCE-major: registry must be authoritative, not a passive drift-check)

### Problem (proven live)
The DB kill-switch was FAKE: `isFlagEnabled()` read env only, so `leo_feature_flags.ADAM_GOVERNANCE_HEARTBEAT_V1.is_enabled=false` had ZERO effect while env was `on`. And `classifyFlag` returned HEALTHY for exactly that registry-vs-runtime drift.

### Fix
- **FR-1 (the class)**: conjunctive authoritative gate `resolveGovernanceFlagGate` — env AND registry both on ⇒ run; either off ⇒ fail-safe STOP. Every ADAM_* flag becomes remotely killable mid-session.
- **FR-2**: fail-safe asymmetry documented + pinned — readable registry false always kills; DB-unreachable degrades to the env verdict (logged); `env_off` short-circuits before any DB read so a blip can never flip ON a flag env had off; never crashes the tick.
- **FR-3 (the instance detector)**: `classifyFlag`/`computeStaleFlags` accept injected `opts.env`; ADAM_* rows off/draft while env=on surface as top-priority **RECONCILE** in the stale-flag digest. 2-arg callers byte-identical.
- **FR-4 (reconcile, re-verified live at execution)**: `ADAM_GOVERNANCE_HEARTBEAT_V1` promoted `is_enabled=true` + `lifecycle_state='enabled'` (the check constraint couples the two). `ADAM_SELF_SCORE_CADENCE` verified consistent (env undefined, registry off) — left alone.
- **FR-5**: pure env helper untouched; gate is a separately-exported DI function — 17 unit tests, no Supabase.

### Live post-flip proof (executed in order)
1. **Drift-proof**: `flag-governance-review.mjs --force` pre-reconcile emitted `ADAM_GOVERNANCE_HEARTBEAT_V1 [draft/off] — registry disagrees with live runtime (env=on) → RECONCILE` (previously HEALTHY)
2. **Kill-proof**: scan with env=on + registry false → ledger `{"verdict":"ADAM_OK","flag":"off"}` — **the registry killed the gate while env was ON**
3. **Reconcile** → post-flip scan ledger `"flag":"on"`; review digest **0 stale** (drift line gone)

### Verification
- New suite 17/17 + legacy `feature-flag-governance-review` 13/13 (30/30)
- Smoke 15/15 in pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
