### PR TITLE
fix(QF-20260610-473): leo-create-sd --child: derive child suffix from max existing suffix (collision + falsy-zero index fix)

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -20,6 +20,7 @@ import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import {
   generateSDKey,
   generateChildKey,
+  deriveChildIndex,
   SD_SOURCES,
   SD_TYPES,
   normalizeVenturePrefix
@@ -624,7 +625,7 @@ async function createFromQF(qfId) {
  * @param {string} overrides.type - Child SD type (default: 'feature', never inherits 'orchestrator')
  * @param {string} overrides.title - Child title override
  */
-async function createChild(parentKey, index = 0, overrides = {}) {
+async function createChild(parentKey, index = null, overrides = {}) {
   console.log(`\n📋 Creating child SD for: ${parentKey}`);
 
   // Fetch parent SD
@@ -639,16 +640,29 @@ async function createChild(parentKey, index = 0, overrides = {}) {
     process.exit(1);
   }
 
-  // Count existing children to determine index
+  // QF-20260610-473: derive index from MAX existing suffix (not count — count
+  // collides forever on non-contiguous children: {-B} -> count=1 -> proposes -B),
+  // honor an explicit index of 0 (nullish check, not ||), and self-heal residual
+  // collisions by bumping to the next free letter. Policy: derived default is
+  // max(taken)+1, so {-B} -> -C and {-A,-C} -> -D.
   const { data: existingChildren } = await supabase
     .from('strategic_directives_v2')
-    .select('id')
+    .select('sd_key')
     .eq('parent_sd_id', parent.id);
 
-  const childIndex = index || (existingChildren?.length || 0);
+  const parentSdKey = parent.sd_key || parentKey;
+  const derivation = deriveChildIndex(
+    parentSdKey,
+    (existingChildren || []).map((c) => c.sd_key),
+    Number.isInteger(index) ? index : null
+  );
+  const childIndex = derivation.index;
+  if (derivation.bumped) {
+    console.log(`   ℹ️  Suffix collision — bumped to next free index ${childIndex} (taken: ${derivation.takenIndexes.join(',')})`);
+  }
 
   // Generate child key
-  const sdKey = generateChildKey(parent.sd_key || parentKey, childIndex);
+  const sdKey = generateChildKey(parentSdKey, childIndex);
 
   // Inherit strategic fields from parent (SD-LEO-FIX-METADATA-001)
   const inheritedFields = inheritStrategicFields(parent);
@@ -2270,7 +2284,9 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const childIndexArg = args.find((a, i) =>
         i >= 2 && !a.startsWith('-') && !flagValuePositionsChild.has(i) && i !== childTypeIdx + 1 && i !== childTitleIdx + 1
       );
-      await createChild(childParentKey, parseInt(childIndexArg || '0', 10), childOverrides);
+      // QF-20260610-473: pass null when no explicit index (so an EXPLICIT 0 is honored
+      // and the absent case derives from max existing suffix instead of count).
+      await createChild(childParentKey, childIndexArg != null ? parseInt(childIndexArg, 10) : null, childOverrides);
     } else {
       // Direct creation: <source> <type> "<title>"
       // Detect unknown flags to prevent silent corruption (SD-LEO-FIX-CREATE-ARGS-001)

--- a/scripts/modules/sd-key-generator.js
+++ b/scripts/modules/sd-key-generator.js
@@ -825,6 +825,42 @@ export function generateChildKey(parentKey, childIndex) {
 }
 
 /**
+ * Derive the child index to use for a new child SD (QF-20260610-473).
+ *
+ * Fixes two coupled defects in the old count-based fallback:
+ *  - non-contiguous children (e.g. only -B exists) made count=1 propose -B
+ *    forever (duplicate-key, no self-heal). Policy: default = MAX existing
+ *    suffix + 1 (so {-B} -> -C, {-A,-C} -> -D).
+ *  - an EXPLICIT index of 0 was swallowed by `index || count` (0 is falsy),
+ *    so `--child <parent> 0` could never create -A.
+ *
+ * Collisions self-heal: if the chosen index (explicit or derived) is already
+ * taken, bump to the next free letter (bounded at Z).
+ *
+ * @param {string} parentKey - Parent SD key (e.g. "SD-X-001")
+ * @param {string[]} existingChildKeys - sd_keys of existing children
+ * @param {number|null} explicitIndex - Explicit 0-based index, or null to derive
+ * @returns {{index: number, bumped: boolean, takenIndexes: number[]}}
+ */
+export function deriveChildIndex(parentKey, existingChildKeys, explicitIndex = null) {
+  const taken = new Set();
+  for (const key of existingChildKeys || []) {
+    if (typeof key !== 'string' || !key.startsWith(`${parentKey}-`)) continue;
+    const m = key.slice(parentKey.length).match(/^-([A-Z])$/);
+    if (m) taken.add(m[1].charCodeAt(0) - 65);
+  }
+  let index = Number.isInteger(explicitIndex)
+    ? explicitIndex
+    : (taken.size > 0 ? Math.max(...taken) + 1 : 0);
+  let bumped = false;
+  while (taken.has(index) && index < 26) {
+    index += 1;
+    bumped = true;
+  }
+  return { index, bumped, takenIndexes: [...taken].sort((a, b) => a - b) };
+}
+
+/**
  * Generate a grandchild SD key
  *
  * @param {string} parentKey - Parent (child) SD key (e.g., "SD-FIX-NAV-001-A")

--- a/tests/unit/derive-child-index.test.js
+++ b/tests/unit/derive-child-index.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { deriveChildIndex, generateChildKey } from '../../scripts/modules/sd-key-generator.js';
+
+// QF-20260610-473: --child suffix derivation — max-existing-suffix+1 (not count),
+// explicit 0 honored, collisions self-heal by bumping to the next free letter.
+
+const P = 'SD-TEST-PARENT-001';
+
+describe('deriveChildIndex (QF-20260610-473)', () => {
+  it('no existing children -> index 0 (-A)', () => {
+    const r = deriveChildIndex(P, [], null);
+    expect(r.index).toBe(0);
+    expect(r.bumped).toBe(false);
+    expect(generateChildKey(P, r.index)).toBe(`${P}-A`);
+  });
+
+  it('non-contiguous: only -B exists -> derives -C (max+1 policy), NOT the old colliding -B', () => {
+    const r = deriveChildIndex(P, [`${P}-B`], null);
+    expect(r.index).toBe(2); // -C
+    expect(generateChildKey(P, r.index)).toBe(`${P}-C`);
+    expect(r.takenIndexes).toEqual([1]);
+  });
+
+  it('contiguous -A..-C -> derives -D', () => {
+    const r = deriveChildIndex(P, [`${P}-A`, `${P}-B`, `${P}-C`], null);
+    expect(generateChildKey(P, r.index)).toBe(`${P}-D`);
+  });
+
+  it('gapped {-A, -C} -> derives -D (max+1, gaps are not refilled by default)', () => {
+    const r = deriveChildIndex(P, [`${P}-A`, `${P}-C`], null);
+    expect(generateChildKey(P, r.index)).toBe(`${P}-D`);
+  });
+
+  it('explicit 0 is HONORED (the old `index || count` swallowed it)', () => {
+    const r = deriveChildIndex(P, [`${P}-B`], 0);
+    expect(r.index).toBe(0); // -A is free
+    expect(r.bumped).toBe(false);
+    expect(generateChildKey(P, r.index)).toBe(`${P}-A`);
+  });
+
+  it('explicit index that collides self-heals to the next free letter', () => {
+    const r = deriveChildIndex(P, [`${P}-A`, `${P}-B`], 0);
+    expect(r.index).toBe(2); // -A,-B taken -> -C
+    expect(r.bumped).toBe(true);
+  });
+
+  it('derived collision chain self-heals across consecutive taken letters', () => {
+    // taken {-A,-B,-C}: derived = 3 (-D, free); explicit 1 bumps over -B,-C to -D
+    const r = deriveChildIndex(P, [`${P}-A`, `${P}-B`, `${P}-C`], 1);
+    expect(generateChildKey(P, r.index)).toBe(`${P}-D`);
+    expect(r.bumped).toBe(true);
+  });
+
+  it('ignores non-child keys (grandchildren, other parents, malformed)', () => {
+    const keys = [`${P}-A1`, 'SD-OTHER-001-A', `${P}-AB`, `${P}-a`, null, 42];
+    const r = deriveChildIndex(P, keys, null);
+    expect(r.index).toBe(0);
+    expect(r.takenIndexes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260610-473

**Type:** bug
**Severity:** medium

### Issue Description
Two coupled defects in the leo-create-sd.js --child path (hit live 2026-06-10 authoring Plan-Keeper Wave-1 children; feedback b872dfbb): (1) scripts/leo-create-sd.js:648  — the COUNT-based fallback proposes a suffix that collides whenever existing children are non-contiguous: 1 existing child at -B -> count=1 -> generateChildKey proposes -B -> duplicate-key error, FOREVER (no retry/skip). Same collision class the Plan-Keeper 5-critic critique flagged in promoteWaveToSDs (per-run counter vs max-existing-suffix). (2) The || makes an EXPLICIT index 0 falsy, silently falling back to the colliding count path — so --child <parent> 0 can never create an -A child.

FIX: (FR-1) derive the default childIndex from MAX existing suffix + 1 (parse existing child keys via the existing parseSDKey/getHierarchySuffix helpers in scripts/modules/sd-key-generator.js), not count; (FR-2) honor an explicit index of 0 (nullish check / Number.isInteger parse instead of ||); (FR-3) on residual duplicate-key error, retry with next free suffix (bounded, e.g. 3 attempts) instead of hard-failing; (FR-4) unit tests: non-contiguous children (-B only) -> next key is -A or -C (per chosen policy, document it), explicit 0 -> -A, contiguous -A..-C -> -D, collision retry path. RECURRENCE PATH: Wave 2/3 Plan-Keeper child authoring (post sitting #1) creates more children under the same parent and will re-hit this. Workaround in use: explicit indexes skipping taken letters.


### Expected Behavior
--child works against non-contiguous children; explicit index 0 honored; collisions self-heal

### Actual Behavior
Count-based suffix collides forever on non-contiguous children (-B exists -> proposes -B); index 0 silently ignored

### Changes
- **Files Changed:** 3
  - scripts/leo-create-sd.js
  - scripts/modules/sd-key-generator.js
  - tests/unit/derive-child-index.test.js
- **LOC:** 45 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol