### PR TITLE
fix(QF-20260610-545): Adam surface-not-drain for ALL directed rows — drop sender_type allowlist

### DIFF
--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -104,14 +104,18 @@ function classifyInboxMessage(msg, opts = {}) {
   // through to the :105 carve-out below (surfaces, read_at left NULL) so a reply arriving after
   // a sync await times out is recovered by adam-advisory.cjs's durable `replies` reader.
   if (twoWayOn && isInfo && p.kind === 'coordinator_reply' && !amAdam) return { skip: true };
-  // Adam session: do NOT auto-drain a coordinator-originated directive of ANY message_type —
-  // leave read_at NULL so the Adam inbox monitor (read_at IS NULL) keeps surfacing it until Adam
-  // acts on it. QF-20260610-623: this carve-out was gated on isInfo, so a NON-INFO coordinator->Adam
-  // directive (e.g. COACHING — a live type per lib/coordinator/adam-action-ack.cjs:291 +
-  // scripts/coordinator-comms-check.mjs:84) fell through to the default drain (markRead/markAck:true)
-  // and was auto-acked on the next PostToolUse poll before Adam read it. Drop the isInfo gate so the
-  // carve-out fires for every message_type; INFO behavior is unchanged (it already matched here).
-  if (amAdam && (msg.sender_type === 'orchestrator' || msg.sender_type === 'coordinator')) {
+  // Adam session: NEVER auto-drain ANY inbound row — surface-not-drain, unconditionally.
+  // QF-20260610-623 dropped the isInfo gate but kept a sender_type ALLOWLIST
+  // (orchestrator|coordinator), so sender_type=chairman directives (a live, exercised value —
+  // 5 chairman messages auto-acked unseen 2026-06-10, harness-bug 43c2dee2, directive
+  // dq-inbox-rca-20260610) fell through to the default drain below. Compounding: Adam manual
+  // polls filter acknowledged_at IS NULL, so a drained row is invisible forever.
+  // QF-20260610-545 (chairman-specified shape): the poll path must never stamp read/ack on a
+  // row not actually routed to the agent — for amAdam, EVERY non-skip directed row surfaces
+  // with read_at/acknowledged_at left NULL; Adam stamps ack on genuine processing. Cost: pure
+  // notifications re-surface until acked — acceptable for an advisory session whose duty is
+  // never missing a directive. Non-Adam (worker/coordinator) drain behavior is untouched.
+  if (amAdam) {
     return { skip: false, markRead: false, markAck: false };
   }
   // Actionable idle rows — surface but do NOT mark read/ack on poll; re-surface until the agent

--- a/tests/unit/coordination-inbox-read-ack-split.test.js
+++ b/tests/unit/coordination-inbox-read-ack-split.test.js
@@ -78,4 +78,45 @@ describe('classifyInboxMessage', () => {
     // a NON-Adam session still drains the same COACHING row on display (byte-identical legacy behavior)
     expect(classifyInboxMessage(coaching, { amAdam: false })).toEqual({ skip: false, markRead: true, markAck: true });
   });
+
+  // QF-20260610-545: residual after QF-623 — the carve-out kept a sender_type ALLOWLIST
+  // (orchestrator|coordinator), so sender_type=chairman directives fell through to the default
+  // drain and 5 chairman messages were auto-acked unseen (harness-bug 43c2dee2). The fix replaces
+  // the allowlist with unconditional surface-not-drain for ALL amAdam non-skip rows.
+  it('QF-545: a chairman INFO coordinator_request to Adam stays UNREAD (no sender_type allowlist)', () => {
+    const chairmanReq = { message_type: 'INFO', payload: { kind: 'coordinator_request' }, sender_type: 'chairman' };
+    expect(classifyInboxMessage(chairmanReq, { amAdam: true })).toEqual({ skip: false, markRead: false, markAck: false });
+    // expects_reply variant, same protection
+    const expectsReply = { message_type: 'INFO', payload: { expects_reply: true }, sender_type: 'chairman' };
+    expect(classifyInboxMessage(expectsReply, { amAdam: true })).toEqual({ skip: false, markRead: false, markAck: false });
+  });
+
+  it('QF-545: NO amAdam row ever returns markAck:true from the poll path (exhaustive sweep)', () => {
+    const senders = ['chairman', 'coordinator', 'orchestrator', 'worker', 'system', undefined];
+    const types = ['INFO', 'COACHING', 'WORK_ASSIGNMENT', 'PRIORITY_CHANGE', 'TASK'];
+    const payloads = [{}, { kind: 'coordinator_request' }, { expects_reply: true }, { kind: 'coordinator_reply' }];
+    for (const sender_type of senders) {
+      for (const message_type of types) {
+        for (const payload of payloads) {
+          for (const isIdle of [true, false]) {
+            for (const twoWayOn of [true, false]) {
+              const v = classifyInboxMessage({ message_type, payload, sender_type }, { isIdle, twoWayOn, amAdam: true });
+              // skip rows are fine (coordinator-exclusive); any surfaced row must not be stamped
+              if (!v.skip) {
+                expect(v.markAck, `sender=${sender_type} type=${message_type} payload=${JSON.stringify(payload)}`).toBe(false);
+                expect(v.markRead).toBe(false);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it('QF-545: non-Adam (worker) drain behavior is byte-identical — plain INFO and busy non-actionable still drain', () => {
+    expect(classifyInboxMessage({ message_type: 'INFO', payload: {}, sender_type: 'chairman' }, { amAdam: false }))
+      .toEqual({ skip: false, markRead: true, markAck: true });
+    expect(classifyInboxMessage({ message_type: 'PRIORITY_CHANGE', payload: {}, sender_type: 'chairman' }, { isIdle: false, amAdam: false }))
+      .toEqual({ skip: false, markRead: true, markAck: true });
+  });
 });


### PR DESCRIPTION
## Summary
Residual after QF-20260610-623: the Adam carve-out in `classifyInboxMessage` kept a **sender_type allowlist** (orchestrator|coordinator), so `sender_type=chairman` directives fell through to the default poll drain and **5 chairman messages were auto-acked unseen** 2026-06-10 (harness-bug 43c2dee2, chairman directive dq-inbox-rca-20260610). Adam manual polls filter `acknowledged_at IS NULL`, so once drained the rows were invisible forever.

## Fix (chairman-specified shape)
For `amAdam` sessions, **every** non-skip row surfaces with `read_at`/`acknowledged_at` left NULL — the poll path never stamps a row not actually routed to the agent. Adam stamps ack on genuine processing. Cost: pure notifications re-surface until acked — acceptable for an advisory session whose duty is never missing a directive. Non-Adam (worker/coordinator) drain behavior is byte-identical (pinned by test).

## Tests
- chairman INFO + `coordinator_request` and `expects_reply` variants → `markRead:false/markAck:false`
- exhaustive sweep (6 senders × 5 types × 4 payloads × idle × twoWay): **no amAdam row ever returns markAck:true** from the poll path
- worker drain parity pinned
- 12/12 file, 17/17 inbox suite, smoke 15/15

QF-20260610-545 · ≤50 LOC (+53/−8, mostly comments/tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)