### PR TITLE
feat(cost): Factory P&L — per-SD/per-phase cost visibility + waste ledger (SD-LEO-INFRA-FACTORY-COST-UNIT-001)

### DIFF
--- a/docs/audits/factory-waste-ledger-2026-06.json
+++ b/docs/audits/factory-waste-ledger-2026-06.json
@@ -1,0 +1,45 @@
+{
+  "generated_at": "2026-06-11T01:45:42.993Z",
+  "caveat": "ESTIMATE: programmatic LLM calls only — Claude Code main-session tokens (the dominant factory cost) are NOT captured; pricing is a static snapshot.",
+  "classes": [
+    {
+      "class": "venture_artifacts_storm",
+      "status": "QUANTIFIED",
+      "method": "quarantined duplicate-regeneration rows (2026-06-10 purge); content chars/4 ≈ output tokens, 1:1 input assumption, gemini-2.5-flash pricing; lower bound (thinking/orchestration overhead unmodeled)",
+      "rows": 2684,
+      "est_input_tokens": 3222732,
+      "est_output_tokens": 3222732,
+      "est_usd": 9.02,
+      "by_artifact_type": {
+        "blueprint_sprint_plan": {
+          "rows": 1044,
+          "est_usd": 8.23
+        },
+        "build_security_audit": {
+          "rows": 411,
+          "est_usd": 0.38
+        },
+        "launch_test_plan": {
+          "rows": 1229,
+          "est_usd": 0.41
+        }
+      },
+      "root_cause_fix": "eva-orchestrator generic fallback re-persist — fixed d624465baf 2026-06-07 (SD-LEO-FIX-FIX-STAGE-SKIP-001)"
+    },
+    {
+      "class": "retry_threshold_hits",
+      "status": "UNQUANTIFIABLE",
+      "reason": "retry-state-manager stores per-session counters in ephemeral .claude/retry-state-*.json files (deleted with sessions); no durable record of how many retries reached the gate, and retried tool calls are not LLM-token events in model_usage_log"
+    },
+    {
+      "class": "exit_hang_duplicate_runs",
+      "status": "UNQUANTIFIABLE",
+      "reason": "UV-abort/exit-hang reruns are indistinguishable from legitimate runs in model_usage_log (no rerun marker); quantification would require a dedup fingerprint the logger does not record"
+    },
+    {
+      "class": "main_session_tokens",
+      "status": "UNQUANTIFIABLE",
+      "reason": "Claude Code main-session tokens (the dominant factory cost) are not captured in model_usage_log at all — out of scope for v1 (LEAD decision); revisit if a harness-level usage export becomes available"
+    }
+  ]
+}

--- a/docs/audits/factory-waste-ledger-2026-06.md
+++ b/docs/audits/factory-waste-ledger-2026-06.md
@@ -1,0 +1,39 @@
+# Factory Waste Ledger — June 2026 (v1)
+
+**SD**: SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-4)
+**Generated**: 2026-06-10 · rerun anytime with `node scripts/cost-waste-ledger.mjs [--json]`
+**Caveat**: ESTIMATE — programmatic LLM calls only; Claude Code main-session tokens (the dominant factory cost) are NOT captured; pricing is a static snapshot.
+
+## Quantified classes
+
+### venture_artifacts storm — **≈ $9.02** (2,684 rows, ~6.4M tokens)
+
+| artifact_type | rows | est USD |
+|---|---:|---:|
+| blueprint_sprint_plan | 1,044 | $8.23 |
+| launch_test_plan | 1,229 | $0.41 |
+| build_security_audit | 411 | $0.38 |
+
+**Method**: each row in `venture_artifacts_storm_quarantine_20260610` (the 2026-06-10 purge, SD-LEO-FIX-REMEDIATE-ARRESTED-VENTURE-001) was one duplicate LLM regeneration of an already-existing artifact. Tokens estimated as `content chars / 4` output, 1:1 input assumption, priced at the gemini-2.5-flash tier (EVA artifact writers run the flash family). **Lower bound** — thinking tokens and orchestration overhead unmodeled.
+
+**Root cause**: eva-orchestrator generic fallback re-persisting every ~30s with a stale exit-gate type — fixed `d624465baf` 2026-06-07 (SD-LEO-FIX-FIX-STAGE-SKIP-001); all three storms stopped the same day.
+
+**Reading**: the famous "1,230× test plan" storm burned ≈ $0.41 — the real cost of storms is table bloat, scan noise, and remediation labor, not direct token spend. The blueprint storm dominated dollar-wise (longer artifacts).
+
+## Unquantifiable classes (stated, not guessed)
+
+| class | why |
+|---|---|
+| retry_threshold_hits | retry-state-manager counters live in ephemeral per-session `.claude/retry-state-*.json`; no durable record, and retried tool calls are not token events in model_usage_log |
+| exit_hang_duplicate_runs | UV-abort reruns are indistinguishable from legitimate runs (no rerun marker / dedup fingerprint in the logger) |
+| main_session_tokens | not captured in model_usage_log at all — out of scope v1 (LEAD decision); revisit if a harness-level usage export lands |
+
+## ops-cost-governance decision (FR-6)
+
+**RETIRED.** `lib/eva/services/ops-cost-governance.js` had zero live importers ever, and its tables (`ops_cost_budgets`/`ops_cost_events`/`ops_cost_overrides`/`ops_revenue_metrics`) were never provisioned (table-estate matrix 2026-06-10 RETIRE_MODULE; re-verified by this SD's VALIDATION agent). Factory cost visibility now lives in `lib/cost/*` + `npm run cost:report` — direct consumers of data that actually exists.
+
+## Attribution baseline (the gauge for FR-3)
+
+Last 7d at ship time: 6,609 calls, **6.7% with sd_id**, 93% with tokens. The usage-logger fallback (FR-3) now stamps `sd_id` from the session's active claim — verified live in-session. Watch `cost:report --by-sd` coverage % climb; that is the FR-3 success gauge.
+
+Machine-readable snapshot: [factory-waste-ledger-2026-06.json](factory-waste-ledger-2026-06.json)

--- a/lib/cost/email-cost-panel.js
+++ b/lib/cost/email-cost-panel.js
@@ -1,0 +1,95 @@
+/**
+ * Coordinator-email LLM cost panel.
+ * SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-5) — window spend + trailing 24h vs the
+ * trailing 7-day daily average, top models by cost. Pure render given fetched rows;
+ * the single exported entry fetches (paginated, limit<=1000) then renders.
+ *
+ * Fail-soft contract: callers wrap in try/catch and omit the panel on any error.
+ *
+ * @module lib/cost/email-cost-panel
+ */
+
+import { rowCost, COST_CAVEAT } from './llm-pricing.js';
+
+const DAY_MS = 86_400_000;
+const PAGE = 1000; // PostgREST max-rows clamp — never request more per page
+
+/** Fetch model_usage_log rows since a timestamp via supabase-js, paginated. */
+async function fetchRows(db, sinceISO) {
+  const all = [];
+  for (let offset = 0; ; offset += PAGE) {
+    const { data, error } = await db
+      .from('model_usage_log')
+      .select('reported_model_name,metadata,captured_at')
+      .gte('captured_at', sinceISO)
+      .order('captured_at', { ascending: true })
+      .range(offset, offset + PAGE - 1);
+    if (error) throw new Error(`model_usage_log read failed: ${error.message}`);
+    all.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+    if (offset > 100_000) break; // safety
+  }
+  return all;
+}
+
+/**
+ * Pure aggregation for the panel (exported for unit tests).
+ * @param {Array<object>} rows rows since (now - 8d)
+ * @param {{sinceTs: number|null, now: number}} opts window start (last email) + now
+ */
+export function computeCostPanel(rows, { sinceTs, now }) {
+  let windowUsd = 0, windowCalls = 0;
+  let dayUsd = 0;
+  const byModel = {};
+  const dailyUsd = {}; // yyyy-mm-dd -> usd, for the trailing-7d average
+  const dayStart = now - DAY_MS;
+
+  for (const r of rows) {
+    const ts = new Date(r.captured_at).getTime();
+    const c = rowCost(r);
+    const d = String(r.captured_at || '').slice(0, 10);
+    dailyUsd[d] = (dailyUsd[d] || 0) + c.usd;
+    if (ts >= dayStart) {
+      dayUsd += c.usd;
+      const k = r.reported_model_name || 'unknown';
+      if (!byModel[k]) byModel[k] = 0;
+      byModel[k] += c.usd;
+    }
+    if (sinceTs != null && ts >= sinceTs) { windowUsd += c.usd; windowCalls++; }
+  }
+
+  // trailing 7 complete days BEFORE today
+  const today = new Date(now).toISOString().slice(0, 10);
+  const completeDays = Object.keys(dailyUsd).filter((d) => d < today).sort().slice(-7);
+  const avgDailyUsd = completeDays.length
+    ? completeDays.reduce((a, d) => a + dailyUsd[d], 0) / completeDays.length
+    : 0;
+  const topModels = Object.entries(byModel).sort((a, b) => b[1] - a[1]).slice(0, 3);
+  const trend = avgDailyUsd > 0 ? dayUsd / avgDailyUsd : null;
+
+  return { windowUsd, windowCalls, dayUsd, avgDailyUsd, topModels, trend };
+}
+
+/** Render html+text panel strings from the computed aggregates (exported for tests). */
+export function formatCostPanel(p) {
+  const usd = (n) => '$' + n.toFixed(2);
+  const trendTxt = p.trend == null ? '' : p.trend > 1.5 ? ` (⚠ ${p.trend.toFixed(1)}x the 7-day avg ${usd(p.avgDailyUsd)})` : ` (7-day avg ${usd(p.avgDailyUsd)}/day)`;
+  const models = p.topModels.map(([m, v]) => `${m} ${usd(v)}`).join(' · ') || 'none';
+  const winTxt = p.windowCalls ? `${usd(p.windowUsd)} since last email · ` : '';
+  const html = `<p style="font-size:13px;color:#777;margin:0 0 6px">💸 LLM est: ${winTxt}<b>${usd(p.dayUsd)}</b> last 24h${trendTxt}<br><span style="font-size:12px">top: ${models}</span><br><span style="font-size:11px;color:#aaa">${COST_CAVEAT}</span></p>`;
+  const text = `LLM est: ${winTxt}${usd(p.dayUsd)} last 24h${trendTxt} — top: ${models}\n(${COST_CAVEAT})`;
+  return { html, text };
+}
+
+/**
+ * Fetch + compute + render. The one call sites use.
+ * @param {object} db supabase client
+ * @param {{sinceTs: number|null, now?: number}} opts
+ */
+export async function renderCostPanel(db, { sinceTs = null, now = Date.now() } = {}) {
+  const sinceISO = new Date(now - 8 * DAY_MS).toISOString();
+  const rows = await fetchRows(db, sinceISO);
+  return formatCostPanel(computeCostPanel(rows, { sinceTs, now }));
+}
+
+export default { renderCostPanel, computeCostPanel, formatCostPanel };

--- a/lib/cost/llm-pricing.js
+++ b/lib/cost/llm-pricing.js
@@ -1,0 +1,71 @@
+/**
+ * Shared LLM pricing snapshot + model-name resolver.
+ * SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-1) — extracted from scripts/llm-cost-report.mjs
+ * so the cost report CLI, the coordinator email cost panel, and tests share ONE source.
+ *
+ * IMPORTANT: these are static ESTIMATE rates (USD per 1M tokens, snapshot 2026-06).
+ * Cache discounts and provider billing nuances are NOT modeled — label every derived
+ * figure an ESTIMATE. No pricing DB table in v1 (LEAD scope decision).
+ *
+ * @module lib/cost/llm-pricing
+ */
+
+// input, output per 1M tokens (USD). Cached input handled separately (cache_hit rows
+// cost ~0 here because the logger records 0 tokens for response-cache hits).
+export const PRICING = {
+  'gemini-2.5-pro':            { in: 1.25, out: 10.00 },
+  'gemini-2.5-flash':          { in: 0.30, out: 2.50 },
+  'gemini-2.5-flash-lite':     { in: 0.10, out: 0.40 },
+  'gemini-embedding-001':      { in: 0.15, out: 0.00 },
+  'gpt-5.5':                   { in: 5.00, out: 30.00 },
+  'gpt-5.4':                   { in: 2.50, out: 15.00 },
+  'gpt-5.4-mini':              { in: 0.75, out: 4.50 },
+  'gpt-5.4-nano':              { in: 0.20, out: 1.25 },
+  'claude-opus':               { in: 15.00, out: 75.00 },
+  'claude-sonnet':             { in: 3.00, out: 15.00 },
+  'claude-haiku':              { in: 1.00, out: 5.00 },
+  'local':                     { in: 0.00, out: 0.00 },
+};
+
+/**
+ * Fuzzy-resolve a reported model name to a pricing tier.
+ * Mirrors the original llm-cost-report.mjs matcher exactly (behavior-identical).
+ * @param {string} modelName e.g. 'gemini-2.5-flash', 'Opus 4.8 (1M context)', 'qwen3-coder:30b'
+ * @returns {{in: number, out: number}|null} null = unknown model (counted in tokens, $0 estimate)
+ */
+export function priceFor(modelName) {
+  if (!modelName) return null;
+  const m = String(modelName).toLowerCase();
+  if (m.includes('qwen') || m.includes('ollama') || m.includes('llama') || m.includes('local')) return PRICING.local;
+  if (m.includes('flash-lite')) return PRICING['gemini-2.5-flash-lite'];
+  if (m.includes('gemini') && m.includes('flash')) return PRICING['gemini-2.5-flash'];
+  if (m.includes('gemini') && m.includes('pro')) return PRICING['gemini-2.5-pro'];
+  if (m.includes('embedding')) return PRICING['gemini-embedding-001'];
+  if (m.includes('gpt-5.5')) return PRICING['gpt-5.5'];
+  if (m.includes('nano')) return PRICING['gpt-5.4-nano'];
+  if (m.includes('mini')) return PRICING['gpt-5.4-mini'];
+  if (m.includes('gpt-5.4') || m.includes('gpt-5')) return PRICING['gpt-5.4'];
+  if (m.includes('opus')) return PRICING['claude-opus'];
+  if (m.includes('sonnet')) return PRICING['claude-sonnet'];
+  if (m.includes('haiku')) return PRICING['claude-haiku'];
+  return null; // unknown → counted in tokens, $0 estimate
+}
+
+/**
+ * Estimate the USD cost of one model_usage_log row.
+ * @param {{reported_model_name?: string, metadata?: {input_tokens?: number, output_tokens?: number}}} r
+ * @returns {{usd: number, inT: number, outT: number, known: boolean}}
+ */
+export function rowCost(r) {
+  const p = priceFor(r?.reported_model_name);
+  const inT = Number(r?.metadata?.input_tokens || 0);
+  const outT = Number(r?.metadata?.output_tokens || 0);
+  if (!p) return { usd: 0, inT, outT, known: false };
+  return { usd: (inT / 1e6) * p.in + (outT / 1e6) * p.out, inT, outT, known: true };
+}
+
+/** Hard-coded caveat line — every cost surface must print/render this. */
+export const COST_CAVEAT =
+  'ESTIMATE: programmatic LLM calls only — Claude Code main-session tokens (the dominant factory cost) are NOT captured; pricing is a static snapshot.';
+
+export default { PRICING, priceFor, rowCost, COST_CAVEAT };

--- a/lib/cost/usage-rollup.js
+++ b/lib/cost/usage-rollup.js
@@ -1,0 +1,65 @@
+/**
+ * Pure per-SD / per-phase cost rollup over model_usage_log rows.
+ * SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-2) — rows in, aggregates out; no DB access,
+ * so the CLI, the coordinator email panel, and tests share one implementation.
+ *
+ * @module lib/cost/usage-rollup
+ */
+
+import { rowCost } from './llm-pricing.js';
+
+const UNATTRIBUTED = 'UNATTRIBUTED';
+
+function bump(map, key, c, r) {
+  if (!map[key]) map[key] = { calls: 0, inT: 0, outT: 0, usd: 0, cacheHits: 0 };
+  const e = map[key];
+  e.calls++; e.inT += c.inT; e.outT += c.outT; e.usd += c.usd;
+  if (r?.metadata?.cache_hit) e.cacheHits++;
+}
+
+/**
+ * Roll model_usage_log rows up by SD, by phase, and by SD+phase.
+ * Rows with null/empty sd_id land in the UNATTRIBUTED bucket (never dropped).
+ *
+ * @param {Array<object>} rows model_usage_log rows ({sd_id, phase, reported_model_name, metadata})
+ * @returns {{
+ *   bySd: Record<string, {calls:number,inT:number,outT:number,usd:number,cacheHits:number}>,
+ *   byPhase: Record<string, object>,
+ *   bySdPhase: Record<string, object>,
+ *   totals: {calls:number,inT:number,outT:number,usd:number},
+ *   coverage: {attributedCalls:number, totalCalls:number, pct:number}
+ * }}
+ */
+export function rollup(rows = []) {
+  const bySd = {};
+  const byPhase = {};
+  const bySdPhase = {};
+  const totals = { calls: 0, inT: 0, outT: 0, usd: 0 };
+  let attributedCalls = 0;
+
+  for (const r of rows) {
+    const c = rowCost(r);
+    const sd = r?.sd_id || UNATTRIBUTED;
+    const phase = r?.phase || 'UNKNOWN';
+    if (sd !== UNATTRIBUTED) attributedCalls++;
+    bump(bySd, sd, c, r);
+    bump(byPhase, phase, c, r);
+    bump(bySdPhase, `${sd}|${phase}`, c, r);
+    totals.calls++; totals.inT += c.inT; totals.outT += c.outT; totals.usd += c.usd;
+  }
+
+  return {
+    bySd,
+    byPhase,
+    bySdPhase,
+    totals,
+    coverage: {
+      attributedCalls,
+      totalCalls: totals.calls,
+      pct: totals.calls ? Number(((attributedCalls / totals.calls) * 100).toFixed(1)) : 0,
+    },
+  };
+}
+
+export { UNATTRIBUTED };
+export default { rollup, UNATTRIBUTED };

--- a/lib/eva/services/index.js
+++ b/lib/eva/services/index.js
@@ -134,19 +134,10 @@ export {
   DEFAULT_AT_RISK_THRESHOLD,
 } from './ops-customer-health.js';
 
-// Operations Cost Governance (SD-LEO-INFRA-OPERATIONS-COST-GOVERNANCE-001)
-export {
-  upsertBudget,
-  getBudget,
-  recordCostEvent,
-  getCurrentSpend,
-  checkThreshold,
-  checkAllThresholds,
-  recordOverride,
-  calculateMargin,
-  COST_CATEGORIES,
-  THRESHOLDS,
-} from './ops-cost-governance.js';
+// Operations Cost Governance: RETIRED by SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-6).
+// Zero live importers ever existed and its tables (ops_cost_budgets/events/overrides)
+// were never provisioned (table-estate matrix 2026-06-10 RETIRE_MODULE). Factory cost
+// visibility now lives in lib/cost/* + scripts/llm-cost-report.mjs (npm run cost:report).
 
 // Design Reference Library (SD-MAN-INFRA-AWWWARDS-CURATED-DESIGN-001)
 export {

--- a/lib/llm/usage-logger.js
+++ b/lib/llm/usage-logger.js
@@ -24,6 +24,35 @@ function getSupabase() {
   return supabase;
 }
 
+// SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-3): sd_id attribution fallback.
+// Only ~7% of rows carried sd_id because most callsites never pass it. When the
+// caller omits sdId, fall back to (a) LEO_SD_KEY env, else (b) a one-time cached
+// lookup of this session's active claim (claude_sessions.sd_key). The lookup is
+// lazy, cached for process lifetime (including null results), and fail-soft —
+// it can never throw or block the fire-and-forget logging path.
+let claimSdPromise = null;
+
+function resolveFallbackSdId(db) {
+  if (process.env.LEO_SD_KEY) return Promise.resolve(process.env.LEO_SD_KEY);
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId || !db) return Promise.resolve(null);
+  if (!claimSdPromise) {
+    claimSdPromise = db
+      .from('claude_sessions')
+      .select('sd_key')
+      .eq('session_id', sessionId)
+      .maybeSingle()
+      .then(({ data }) => data?.sd_key || null)
+      .catch(() => null);
+  }
+  return claimSdPromise;
+}
+
+/** Test-only: reset the cached claim lookup between cases. */
+export function _resetClaimCacheForTest() {
+  claimSdPromise = null;
+}
+
 /**
  * Log an LLM call to model_usage_log (fire-and-forget).
  *
@@ -52,12 +81,12 @@ export function logUsage({
   const db = getSupabase();
   if (!db) return;
 
-  const row = {
+  const buildRow = (resolvedSdId) => ({
     id: randomUUID(),
     reported_model_name: model || 'unknown',
     reported_model_id: model || 'unknown',
     session_id: process.env.CLAUDE_SESSION_ID || null,
-    sd_id: sdId || null,
+    sd_id: sdId || resolvedSdId || null,
     phase: phase || 'UNKNOWN',
     subagent_type: purpose || null,
     metadata: {
@@ -69,11 +98,14 @@ export function logUsage({
       cache_hit: cacheHit,
       logged_at: new Date().toISOString()
     }
-  };
+  });
 
-  // Fire-and-forget: don't await, don't throw
-  db.from('model_usage_log')
-    .insert(row)
+  // Fire-and-forget: don't await, don't throw. FR-3 fallback resolves sd_id
+  // (explicit sdId short-circuits; env/claim fallback otherwise; null on failure).
+  const sdResolution = sdId ? Promise.resolve(sdId) : resolveFallbackSdId(db);
+  sdResolution
+    .catch(() => null)
+    .then((resolvedSdId) => db.from('model_usage_log').insert(buildRow(resolvedSdId)))
     .then(({ error }) => {
       if (error) {
         // Silent failure - logging should never break LLM calls

--- a/package.json
+++ b/package.json
@@ -378,6 +378,7 @@
     "prepark-wip": "node scripts/prepark-wip.cjs",
     "protocol:pub-audit": "node scripts/protocol-publication-audit.cjs",
     "sre:row-growth": "node scripts/row-growth-snapshot.cjs",
+    "cost:report": "node scripts/llm-cost-report.mjs",
     "review:rotation": "node scripts/subsystem-review-rotation.cjs",
     "policy:check": "node scripts/auto-exec-policy-check.mjs",
     "engine:demo": "node scripts/auto-exec-engine-demo.mjs",

--- a/scripts/coordinator-email-summary.mjs
+++ b/scripts/coordinator-email-summary.mjs
@@ -142,6 +142,17 @@ const recentSeen = (sessRaw || []).filter(s => isFleetWorker(s, me) && s.heartbe
 const incognito = Math.max(0, recentSeen.length - liveWorkers);   // provisioned but quiet >15m = incognito (needs a wake re-paste)
 const totalWorkers = liveWorkers + incognito;                     // TRUE provisioned headcount the operator stood up
 
+// ── cost panel (SD-LEO-INFRA-FACTORY-COST-UNIT-001 FR-5) — fail-soft: a cost query
+//    failure must NEVER block the fleet email; the panel is simply omitted. ──
+let costHtml = '', costText = '';
+try {
+  const { renderCostPanel } = await import(pathToFileURL(resolve('lib/cost/email-cost-panel.js')).href);
+  const panel = await renderCostPanel(db, { sinceTs: typeof snap.ts === 'number' ? snap.ts : null, now: t });
+  costHtml = panel.html; costText = panel.text;
+} catch (e) {
+  console.warn('[coordinator-email] cost panel skipped:', e.message);
+}
+
 // ── render ──
 const dot = { red: '🔴', yellow: '🟡', green: '🟢' }[overall];
 const word = { red: 'RED', yellow: 'YELLOW', green: 'GREEN' }[overall];
@@ -170,10 +181,10 @@ const liveHtml = incognito ? `<p style="font-size:14px;margin:0 0 8px;padding:8p
 const html = `<p style="font-size:17px;margin:0 0 10px"><b>${dot} ${word}</b> — ${meaning} <span style="color:#777;font-size:14px">(${trendWord} ${trendArrow})</span></p>
 ${qHtml}${liveHtml}<p style="font-size:14px;margin:0 0 6px"><b>Active workers:</b> ${gauge}${workable ? ` · ${workable} item${workable > 1 ? 's' : ''} in play` : ''}</p>
 <p style="font-size:13px;color:#777;margin:0 0 6px">📦 Since last email: <b>+${shippedSince}</b> shipped</p>
-<p style="font-size:11px;color:#999;margin:14px 0 0">${when} ET</p>`;
+${costHtml}<p style="font-size:11px;color:#999;margin:14px 0 0">${when} ET</p>`;
 const qText = qN ? `❓ ${qN} question${qN > 1 ? 's' : ''} need${qN > 1 ? '' : 's'} your input:\n${questions.map(q => { const l = qLabel(q); return `  • ${l.text} — ${l.who}${l.sd}`; }).join('\n')}\n\n` : '';
 const liveText = incognito ? `🔔 Needs you: ${incognito} worker${incognito > 1 ? 's' : ''} went incognito — a wake re-paste/relaunch refills the fleet.\n\n` : '';
-const text = `${dot} ${word} — ${meaning} (${trendWord} ${trendArrow})\n\n${qText}${liveText}Active workers: ${gauge}${workable ? ` · ${workable} item(s) in play` : ''}\nSince last email: +${shippedSince} shipped\n\n${when} ET`;
+const text = `${dot} ${word} — ${meaning} (${trendWord} ${trendArrow})\n\n${qText}${liveText}Active workers: ${gauge}${workable ? ` · ${workable} item(s) in play` : ''}\nSince last email: +${shippedSince} shipped\n${costText}\n${when} ET`;
 
 // QF-20260609-738: skip-if-unchanged + max-staleness heartbeat. The */30 cron used to
 // send EVERY run even when nothing material changed (the chairman is usually away), so the

--- a/scripts/cost-waste-ledger.mjs
+++ b/scripts/cost-waste-ledger.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Factory waste ledger — retroactive quantification of known waste classes.
+ * SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-4)
+ *
+ * Report-first v1 (no DB table until a consumer exists). Quantifies each known
+ * waste class from existing data where attribution holds; classes that cannot be
+ * honestly quantified are listed UNQUANTIFIABLE with the reason — never guessed.
+ *
+ * USAGE
+ *   node scripts/cost-waste-ledger.mjs            # human report
+ *   node scripts/cost-waste-ledger.mjs --json     # machine-readable
+ *
+ * METHOD (storm class): the 2026-06-10 venture_artifacts purge quarantined 2,684
+ * duplicate-regeneration rows into venture_artifacts_storm_quarantine_20260610
+ * (SD-LEO-FIX-REMEDIATE-ARRESTED-VENTURE-001; root cause fixed 2026-06-07 by
+ * d624465baf). Each quarantined row was one LLM regeneration of an artifact that
+ * already existed. Token estimate: content chars / 4 ≈ output tokens (standard
+ * heuristic), input assumed >= output for generation prompts (conservative 1:1).
+ * Priced at the gemini-2.5-flash tier (EVA artifact writers run the flash family).
+ * These are lower-bound ESTIMATES — thinking tokens and orchestration overhead
+ * are not modeled.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { PRICING, COST_CAVEAT } from '../lib/cost/llm-pricing.js';
+
+const STORM_QUARANTINE = 'venture_artifacts_storm_quarantine_20260610';
+const PAGE = 1000; // PostgREST max-rows clamp
+
+const db = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/** Estimate tokens/USD for one storm row (pure; exported shape for tests via --json). */
+export function stormRowEstimate(contentLen) {
+  const outT = Math.round((contentLen || 0) / 4);
+  const inT = outT; // conservative 1:1 prompt assumption, stated in METHOD
+  const p = PRICING['gemini-2.5-flash'];
+  return { inT, outT, usd: (inT / 1e6) * p.in + (outT / 1e6) * p.out };
+}
+
+async function quantifyStormClass() {
+  const byType = {};
+  let rows = 0, inT = 0, outT = 0, usd = 0;
+  for (let offset = 0; ; offset += PAGE) {
+    const { data, error } = await db
+      .from(STORM_QUARANTINE)
+      .select('artifact_type,content')
+      .range(offset, offset + PAGE - 1);
+    if (error) return { error: error.message };
+    for (const r of data || []) {
+      const e = stormRowEstimate((r.content || '').length);
+      rows++; inT += e.inT; outT += e.outT; usd += e.usd;
+      const k = r.artifact_type || 'unknown';
+      if (!byType[k]) byType[k] = { rows: 0, usd: 0 };
+      byType[k].rows++; byType[k].usd += e.usd;
+    }
+    if (!data || data.length < PAGE) break;
+  }
+  return { rows, inT, outT, usd, byType };
+}
+
+async function main() {
+  const json = process.argv.includes('--json');
+  const storm = await quantifyStormClass();
+
+  const ledger = {
+    generated_at: new Date().toISOString(),
+    caveat: COST_CAVEAT,
+    classes: [
+      storm.error
+        ? { class: 'venture_artifacts_storm', status: 'UNQUANTIFIABLE', reason: `quarantine table read failed: ${storm.error} (table may have been dropped after the reversibility window)` }
+        : {
+            class: 'venture_artifacts_storm',
+            status: 'QUANTIFIED',
+            method: 'quarantined duplicate-regeneration rows (2026-06-10 purge); content chars/4 ≈ output tokens, 1:1 input assumption, gemini-2.5-flash pricing; lower bound (thinking/orchestration overhead unmodeled)',
+            rows: storm.rows,
+            est_input_tokens: storm.inT,
+            est_output_tokens: storm.outT,
+            est_usd: Number(storm.usd.toFixed(2)),
+            by_artifact_type: Object.fromEntries(Object.entries(storm.byType || {}).map(([k, v]) => [k, { rows: v.rows, est_usd: Number(v.usd.toFixed(2)) }])),
+            root_cause_fix: 'eva-orchestrator generic fallback re-persist — fixed d624465baf 2026-06-07 (SD-LEO-FIX-FIX-STAGE-SKIP-001)',
+          },
+      {
+        class: 'retry_threshold_hits',
+        status: 'UNQUANTIFIABLE',
+        reason: 'retry-state-manager stores per-session counters in ephemeral .claude/retry-state-*.json files (deleted with sessions); no durable record of how many retries reached the gate, and retried tool calls are not LLM-token events in model_usage_log',
+      },
+      {
+        class: 'exit_hang_duplicate_runs',
+        status: 'UNQUANTIFIABLE',
+        reason: 'UV-abort/exit-hang reruns are indistinguishable from legitimate runs in model_usage_log (no rerun marker); quantification would require a dedup fingerprint the logger does not record',
+      },
+      {
+        class: 'main_session_tokens',
+        status: 'UNQUANTIFIABLE',
+        reason: 'Claude Code main-session tokens (the dominant factory cost) are not captured in model_usage_log at all — out of scope for v1 (LEAD decision); revisit if a harness-level usage export becomes available',
+      },
+    ],
+  };
+
+  if (json) {
+    console.log(JSON.stringify(ledger, null, 2));
+    return;
+  }
+
+  console.log('\n=== FACTORY WASTE LEDGER ===');
+  console.log(ledger.caveat + '\n');
+  for (const c of ledger.classes) {
+    console.log(`— ${c.class}: ${c.status}`);
+    if (c.status === 'QUANTIFIED') {
+      console.log(`   rows=${c.rows}  est tokens in/out=${c.est_input_tokens}/${c.est_output_tokens}  est $${c.est_usd}`);
+      for (const [k, v] of Object.entries(c.by_artifact_type)) console.log(`     ${k}: ${v.rows} rows ≈ $${v.est_usd}`);
+      console.log(`   method: ${c.method}`);
+      console.log(`   root cause fix: ${c.root_cause_fix}`);
+    } else {
+      console.log(`   reason: ${c.reason}`);
+    }
+    console.log('');
+  }
+}
+
+main().catch((e) => { console.error('[cost-waste-ledger] ERROR', e.message); process.exit(1); });

--- a/scripts/llm-cost-report.mjs
+++ b/scripts/llm-cost-report.mjs
@@ -28,45 +28,13 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-
-// --- Pricing per 1M tokens (USD), current as of 2026-06 ----------------------
-// input, output. Cached input handled separately (cache_hit rows cost ~0 here
-// because the logger records 0 tokens for response-cache hits).
-const PRICING = {
-  'gemini-2.5-pro':            { in: 1.25, out: 10.00 },
-  'gemini-2.5-flash':          { in: 0.30, out: 2.50 },
-  'gemini-2.5-flash-lite':     { in: 0.10, out: 0.40 },
-  'gemini-embedding-001':      { in: 0.15, out: 0.00 },
-  'gpt-5.5':                   { in: 5.00, out: 30.00 },
-  'gpt-5.4':                   { in: 2.50, out: 15.00 },
-  'gpt-5.4-mini':              { in: 0.75, out: 4.50 },
-  'gpt-5.4-nano':              { in: 0.20, out: 1.25 },
-  'claude-opus':               { in: 15.00, out: 75.00 },
-  'claude-sonnet':             { in: 3.00, out: 15.00 },
-  'claude-haiku':              { in: 1.00, out: 5.00 },
-  'local':                     { in: 0.00, out: 0.00 },
-};
-
-function priceFor(modelName) {
-  if (!modelName) return null;
-  const m = String(modelName).toLowerCase();
-  if (m.includes('qwen') || m.includes('ollama') || m.includes('llama') || m.includes('local')) return PRICING.local;
-  if (m.includes('flash-lite')) return PRICING['gemini-2.5-flash-lite'];
-  if (m.includes('gemini') && m.includes('flash')) return PRICING['gemini-2.5-flash'];
-  if (m.includes('gemini') && m.includes('pro')) return PRICING['gemini-2.5-pro'];
-  if (m.includes('embedding')) return PRICING['gemini-embedding-001'];
-  if (m.includes('gpt-5.5')) return PRICING['gpt-5.5'];
-  if (m.includes('nano')) return PRICING['gpt-5.4-nano'];
-  if (m.includes('mini')) return PRICING['gpt-5.4-mini'];
-  if (m.includes('gpt-5.4') || m.includes('gpt-5')) return PRICING['gpt-5.4'];
-  if (m.includes('opus')) return PRICING['claude-opus'];
-  if (m.includes('sonnet')) return PRICING['claude-sonnet'];
-  if (m.includes('haiku')) return PRICING['claude-haiku'];
-  return null; // unknown → counted in tokens, $0 estimate
-}
+// SD-LEO-INFRA-FACTORY-COST-UNIT-001: pricing + per-SD rollup extracted to shared lib
+// (behavior-identical) so the email cost panel and tests share one implementation.
+import { rowCost as libRowCost, COST_CAVEAT } from '../lib/cost/llm-pricing.js';
+import { rollup, UNATTRIBUTED } from '../lib/cost/usage-rollup.js';
 
 function parseArgs(argv) {
-  const a = { days: 7, since: null, check: false, json: false,
+  const a = { days: 7, since: null, check: false, json: false, bySd: false,
     maxDailyUsd: 12, maxDailyCalls: 3000, spike: 2.0 };
   for (let i = 2; i < argv.length; i++) {
     const k = argv[i];
@@ -74,6 +42,7 @@ function parseArgs(argv) {
     else if (k === '--since') a.since = argv[++i];
     else if (k === '--check') a.check = true;
     else if (k === '--json') a.json = true;
+    else if (k === '--by-sd') a.bySd = true;
     else if (k === '--max-daily-usd') a.maxDailyUsd = parseFloat(argv[++i]);
     else if (k === '--max-daily-calls') a.maxDailyCalls = parseInt(argv[++i], 10);
     else if (k === '--spike') a.spike = parseFloat(argv[++i]);
@@ -120,13 +89,7 @@ async function pullRows(url, key, sinceISO) {
   return all;
 }
 
-function rowCost(r) {
-  const p = priceFor(r.reported_model_name);
-  const inT = Number(r.metadata?.input_tokens || 0);
-  const outT = Number(r.metadata?.output_tokens || 0);
-  if (!p) return { usd: 0, inT, outT };
-  return { usd: (inT / 1e6) * p.in + (outT / 1e6) * p.out, inT, outT };
-}
+const rowCost = libRowCost;
 
 function aggregate(rows, keyFn) {
   const m = {};
@@ -191,12 +154,40 @@ async function main() {
   }
 
   if (args.json) {
-    console.log(JSON.stringify({
+    const out = {
       window: { sinceISO, rows: rows.length, totalUsd: Number(totalUsd.toFixed(2)) },
+      caveat: COST_CAVEAT,
       byModel: aggregate(rows, r => r.reported_model_name),
       byPurpose: aggregate(rows, r => r.subagent_type),
       byDay,
-    }, null, 2));
+    };
+    if (args.bySd) {
+      const r = rollup(rows);
+      out.bySd = r.bySd;
+      out.byPhase = r.byPhase;
+      out.coverage = r.coverage;
+    }
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  if (args.bySd) {
+    // SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-2): per-SD / per-phase factory P&L view.
+    const r = rollup(rows);
+    console.log(`\n=== FACTORY COST BY SD — since ${sinceISO.slice(0, 10)} (${rows.length} calls) ===`);
+    console.log(`${COST_CAVEAT}`);
+    console.log(`Attribution coverage: ${r.coverage.pct}% of calls carry sd_id (${r.coverage.attributedCalls}/${r.coverage.totalCalls})\n`);
+
+    const sdRows = Object.entries(r.bySd).sort((a, b) => b[1].usd - a[1].usd).slice(0, 25);
+    console.log(`${pad('sd_id', 44)} ${padN('calls', 7)} ${padN('inTok', 11)} ${padN('outTok', 11)} ${padN('est$', 9)}`);
+    for (const [k, v] of sdRows)
+      console.log(`${pad(k === UNATTRIBUTED ? `${UNATTRIBUTED} (null sd_id)` : k, 44)} ${padN(v.calls, 7)} ${padN(v.inT, 11)} ${padN(v.outT, 11)} ${padN(fmtUsd(v.usd), 9)}`);
+
+    console.log('\n--- BY PHASE ---');
+    console.log(`${pad('phase', 16)} ${padN('calls', 7)} ${padN('est$', 9)}`);
+    for (const [k, v] of Object.entries(r.byPhase).sort((a, b) => b[1].usd - a[1].usd))
+      console.log(`${pad(k, 16)} ${padN(v.calls, 7)} ${padN(fmtUsd(v.usd), 9)}`);
+    console.log('');
     return;
   }
 

--- a/tests/unit/lib/cost-rollup.test.js
+++ b/tests/unit/lib/cost-rollup.test.js
@@ -1,0 +1,139 @@
+/**
+ * SD-LEO-INFRA-FACTORY-COST-UNIT-001 — pricing, rollup, and email-panel units.
+ * Pure-lib tests: no DB access.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PRICING, priceFor, rowCost, COST_CAVEAT } from '../../../lib/cost/llm-pricing.js';
+import { rollup, UNATTRIBUTED } from '../../../lib/cost/usage-rollup.js';
+import { computeCostPanel, formatCostPanel } from '../../../lib/cost/email-cost-panel.js';
+
+// ── FR-1: pricing resolver covers the live model-name families ────────────────
+describe('priceFor — live model name families (TS-1)', () => {
+  it.each([
+    ['gemini-2.5-flash', PRICING['gemini-2.5-flash']],
+    ['gemini-2.5-flash-lite', PRICING['gemini-2.5-flash-lite']],
+    ['gemini-2.5-pro', PRICING['gemini-2.5-pro']],
+    ['gemini-embedding-001', PRICING['gemini-embedding-001']],
+    ['Opus 4.8', PRICING['claude-opus']],
+    ['Opus 4.8 (1M context)', PRICING['claude-opus']],
+    ['claude-opus-4-8[1m]', PRICING['claude-opus']],
+    ['claude-sonnet-4-6', PRICING['claude-sonnet']],
+    ['claude-haiku-4-5-20251001', PRICING['claude-haiku']],
+    ['qwen3-coder:30b', PRICING.local],
+    ['ollama/llama3', PRICING.local],
+    ['gpt-5.5', PRICING['gpt-5.5']],
+    ['gpt-5.4-mini', PRICING['gpt-5.4-mini']],
+    ['gpt-5.4-nano', PRICING['gpt-5.4-nano']],
+    ['gpt-5.4', PRICING['gpt-5.4']],
+  ])('%s → expected tier', (name, tier) => {
+    expect(priceFor(name)).toBe(tier);
+  });
+
+  it('unknown model → null (counted in tokens, $0 estimate)', () => {
+    expect(priceFor('mystery-model-9000')).toBeNull();
+    expect(priceFor(null)).toBeNull();
+    expect(priceFor('')).toBeNull();
+  });
+});
+
+describe('rowCost', () => {
+  it('prices a known-model row from metadata tokens', () => {
+    const r = { reported_model_name: 'gemini-2.5-flash', metadata: { input_tokens: 1_000_000, output_tokens: 1_000_000 } };
+    const c = rowCost(r);
+    expect(c.known).toBe(true);
+    expect(c.usd).toBeCloseTo(0.30 + 2.50, 6);
+  });
+
+  it('unknown model → $0 but tokens still counted', () => {
+    const c = rowCost({ reported_model_name: 'mystery', metadata: { input_tokens: 5, output_tokens: 7 } });
+    expect(c).toMatchObject({ usd: 0, inT: 5, outT: 7, known: false });
+  });
+
+  it('tolerates missing metadata', () => {
+    expect(rowCost({ reported_model_name: 'gemini-2.5-flash' }).usd).toBe(0);
+    expect(rowCost(null).usd).toBe(0);
+  });
+});
+
+// ── FR-2: pure rollup (TS-2) ──────────────────────────────────────────────────
+describe('rollup — bySd/byPhase/coverage (TS-2)', () => {
+  const flash = (sd, phase, inT, outT, extra = {}) => ({
+    sd_id: sd, phase, reported_model_name: 'gemini-2.5-flash',
+    metadata: { input_tokens: inT, output_tokens: outT, ...extra },
+  });
+
+  it('aggregates by SD with null sd_id in UNATTRIBUTED (never dropped)', () => {
+    const r = rollup([
+      flash('SD-A', 'EXEC', 1_000_000, 0),
+      flash('SD-A', 'LEAD', 0, 1_000_000),
+      flash(null, 'EXEC', 2_000_000, 0),
+    ]);
+    expect(r.bySd['SD-A'].calls).toBe(2);
+    expect(r.bySd['SD-A'].usd).toBeCloseTo(0.30 + 2.50, 6);
+    expect(r.bySd[UNATTRIBUTED].calls).toBe(1);
+    expect(r.bySd[UNATTRIBUTED].usd).toBeCloseTo(0.60, 6);
+    expect(r.totals.calls).toBe(3);
+    expect(r.totals.usd).toBeCloseTo(0.30 + 2.50 + 0.60, 6);
+  });
+
+  it('aggregates by phase and by sd|phase', () => {
+    const r = rollup([flash('SD-A', 'EXEC', 1_000_000, 0), flash('SD-B', 'EXEC', 1_000_000, 0)]);
+    expect(r.byPhase.EXEC.calls).toBe(2);
+    expect(r.bySdPhase['SD-A|EXEC'].calls).toBe(1);
+    expect(r.bySdPhase['SD-B|EXEC'].calls).toBe(1);
+  });
+
+  it('coverage % = attributed / total', () => {
+    const r = rollup([flash('SD-A', 'EXEC', 0, 0), flash(null, 'EXEC', 0, 0), flash(null, 'EXEC', 0, 0), flash(null, 'EXEC', 0, 0)]);
+    expect(r.coverage).toMatchObject({ attributedCalls: 1, totalCalls: 4, pct: 25 });
+  });
+
+  it('counts cache hits and handles empty input', () => {
+    const r = rollup([flash('SD-A', 'EXEC', 0, 0, { cache_hit: true })]);
+    expect(r.bySd['SD-A'].cacheHits).toBe(1);
+    expect(rollup([]).coverage.pct).toBe(0);
+    expect(rollup().totals.calls).toBe(0);
+  });
+});
+
+// ── FR-5: email cost panel (TS-4) ─────────────────────────────────────────────
+describe('email cost panel (TS-4)', () => {
+  const NOW = new Date('2026-06-10T12:00:00Z').getTime();
+  const at = (iso, usdTokens = 1_000_000) => ({
+    reported_model_name: 'gemini-2.5-flash',
+    captured_at: iso,
+    metadata: { input_tokens: 0, output_tokens: usdTokens }, // 1M out = $2.50 flash
+  });
+
+  it('computes last-24h spend, trailing avg, window spend, top models', () => {
+    const rows = [
+      at('2026-06-03T12:00:00Z'), // complete day, in trailing avg
+      at('2026-06-09T13:00:00Z'), // complete day + ALSO within last 24h of NOW (>= 06-09T12:00Z)
+      at('2026-06-10T11:00:00Z'), // today, within last 24h
+    ];
+    const p = computeCostPanel(rows, { sinceTs: new Date('2026-06-10T00:00:00Z').getTime(), now: NOW });
+    expect(p.dayUsd).toBeCloseTo(5.0, 6);          // 2 rows in 24h window
+    expect(p.windowUsd).toBeCloseTo(2.5, 6);       // 1 row since last email
+    expect(p.windowCalls).toBe(1);
+    expect(p.avgDailyUsd).toBeGreaterThan(0);
+    expect(p.topModels[0][0]).toBe('gemini-2.5-flash');
+  });
+
+  it('renders html+text with the hard-coded caveat', () => {
+    const out = formatCostPanel({ windowUsd: 1.5, windowCalls: 3, dayUsd: 4.2, avgDailyUsd: 2.0, topModels: [['m1', 4.2]], trend: 2.1 });
+    expect(out.html).toContain('$4.20');
+    expect(out.html).toContain(COST_CAVEAT);
+    expect(out.html).toContain('⚠ 2.1x');
+    expect(out.text).toContain('$4.20');
+    expect(out.text).toContain(COST_CAVEAT);
+  });
+
+  it('handles empty rows (no trend, $0)', () => {
+    const p = computeCostPanel([], { sinceTs: null, now: NOW });
+    expect(p.dayUsd).toBe(0);
+    expect(p.trend).toBeNull();
+    const out = formatCostPanel(p);
+    expect(out.text).toContain('$0.00');
+  });
+});

--- a/tests/unit/lib/usage-logger-sd-fallback.test.js
+++ b/tests/unit/lib/usage-logger-sd-fallback.test.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-FACTORY-COST-UNIT-001 (FR-3 / TS-3) — usage-logger sd_id fallback.
+ * Mocks @supabase/supabase-js; asserts the fallback chain
+ * (explicit sdId > LEO_SD_KEY env > cached active-claim lookup > null)
+ * and that the fire-and-forget path never throws.
+ *
+ * TEST_REQUIRES_DB: false — @supabase/supabase-js is vi.mock'd below and the
+ * SUPABASE_* env values set in beforeEach are fakes that only satisfy the
+ * logger's `if (url && key)` construction gate; no network/DB access occurs.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const inserted = [];
+let claimResult = { data: { sd_key: 'SD-CLAIMED-001' }, error: null };
+let claimLookups = 0;
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: (table) => {
+      if (table === 'claude_sessions') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => {
+                claimLookups++;
+                return Promise.resolve(claimResult);
+              },
+            }),
+          }),
+        };
+      }
+      return {
+        insert: (row) => {
+          inserted.push(row);
+          return Promise.resolve({ error: null });
+        },
+      };
+    },
+  }),
+}));
+
+const ENV_KEYS = ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'CLAUDE_SESSION_ID', 'LEO_SD_KEY'];
+const saved = {};
+
+async function freshLogger() {
+  vi.resetModules();
+  const mod = await import('../../../lib/llm/usage-logger.js');
+  mod._resetClaimCacheForTest();
+  return mod;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.SUPABASE_URL = 'http://fake.local';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'fake-key';
+  process.env.CLAUDE_SESSION_ID = 'sess-test-1';
+  delete process.env.LEO_SD_KEY;
+  inserted.length = 0;
+  claimLookups = 0;
+  claimResult = { data: { sd_key: 'SD-CLAIMED-001' }, error: null };
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('usage-logger sd_id fallback (FR-3)', () => {
+  it('explicit sdId short-circuits (no claim lookup)', async () => {
+    const { logUsage } = await freshLogger();
+    logUsage({ model: 'gemini-2.5-flash', sdId: 'SD-EXPLICIT-001' });
+    await flush();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].sd_id).toBe('SD-EXPLICIT-001');
+    expect(claimLookups).toBe(0);
+  });
+
+  it('falls back to LEO_SD_KEY env before the claim lookup', async () => {
+    process.env.LEO_SD_KEY = 'SD-FROM-ENV-001';
+    const { logUsage } = await freshLogger();
+    logUsage({ model: 'gemini-2.5-flash' });
+    await flush();
+    expect(inserted[0].sd_id).toBe('SD-FROM-ENV-001');
+    expect(claimLookups).toBe(0);
+  });
+
+  it('falls back to the active claim and caches the lookup', async () => {
+    const { logUsage } = await freshLogger();
+    logUsage({ model: 'gemini-2.5-flash' });
+    logUsage({ model: 'gemini-2.5-flash' });
+    await flush();
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0].sd_id).toBe('SD-CLAIMED-001');
+    expect(inserted[1].sd_id).toBe('SD-CLAIMED-001');
+    expect(claimLookups).toBe(1); // cached after first resolution
+  });
+
+  it('lookup failure → logs with sd_id null and never throws', async () => {
+    // Rejecting thenable: adopted on resolution, so the logger's .catch absorbs it.
+    claimResult = { then: (_, rej) => rej(new Error('db down')) };
+    const { logUsage } = await freshLogger();
+    expect(() => logUsage({ model: 'gemini-2.5-flash' })).not.toThrow();
+    await flush();
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].sd_id).toBeNull();
+  });
+
+  it('no session row → sd_id null', async () => {
+    claimResult = { data: null, error: null };
+    const { logUsage } = await freshLogger();
+    logUsage({ model: 'gemini-2.5-flash' });
+    await flush();
+    expect(inserted[0].sd_id).toBeNull();
+  });
+
+  it('no CLAUDE_SESSION_ID → sd_id null without lookup', async () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const { logUsage } = await freshLogger();
+    logUsage({ model: 'gemini-2.5-flash' });
+    await flush();
+    expect(inserted[0].sd_id).toBeNull();
+    expect(claimLookups).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Gives the factory the economic scrutiny it applies to ventures (chairman top-3 strategic pick, 2026-06-10).

- **lib/cost/llm-pricing.js + usage-rollup.js** — pricing/rollup extracted to a shared pure lib (CLI + email + tests share one impl)
- **npm run cost:report -- --by-sd** — per-SD/per-phase USD estimates with UNATTRIBUTED bucket + attribution coverage %
- **FR-3 attribution fix**: usage-logger sd_id fallback (explicit > LEO_SD_KEY > cached active-claim > null), fail-soft, fire-and-forget path can never throw — **verified live** (probe row carried sd_id with no caller change; baseline coverage was 6.7%)
- **FR-4 waste ledger**: storm class QUANTIFIED — 2,684 quarantined regenerations ≈ **$9.02** / 6.4M tokens (the famous 1,230× test-plan storm ≈ $0.41 — real storm cost is bloat + remediation labor, not tokens); 3 classes honestly UNQUANTIFIABLE with stated reasons. Report: docs/audits/factory-waste-ledger-2026-06.md
- **FR-5 email cost panel**: coordinator email gains fail-soft LLM spend panel (last 24h vs 7-day avg, top models) — rendered live in dry-run
- **FR-6**: ops-cost-governance RETIRED (zero live importers ever; tables never provisioned — table-estate 2026-06-10 + re-verified)

**Honest limitation on every surface**: model_usage_log captures programmatic LLM calls only — main-session Claude Code tokens (the dominant cost) are not captured; all figures are labeled ESTIMATE.

## Verification
- 32 new unit tests green (pricing families incl. live model names, rollup, fallback chain, email panel)
- 6 pre-existing failures on base confirmed unrelated via stash run (6F/275P without diff → 6F/307P with)
- Live smokes: cost:report --by-sd against 2,602 live rows; waste ledger against live quarantine; email dry-run rendered panel; FR-3 live probe

Gates: LEAD-TO-PLAN 93, PLAN-TO-EXEC 97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)