### PR TITLE
feat(SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A): artifact pre-flight in handoff execute before the gate pipeline

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.artifact-preflight.test.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.artifact-preflight.test.js
@@ -1,0 +1,120 @@
+/**
+ * SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A — executeHandoff artifact-preflight wiring.
+ *
+ * Asserts: (a) HARD_FAIL stops PRE-PIPELINE — the executor is never invoked,
+ * the failure is recorded with ARTIFACT_PREFLIGHT_FAILED and the violations
+ * are attached; (b) clean payloads pass through byte-identical (executor
+ * called with identical args, verdict unchanged); (c) a preflight module
+ * exception falls OPEN (pipeline runs normally); (d) prevented-bounce
+ * telemetry fires on HARD_FAIL (fail-soft).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const executeArtifactPreflightMock = vi.fn();
+const logPreventedBounceMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./artifact-preflight.js', () => ({
+  executeArtifactPreflight: executeArtifactPreflightMock,
+  logPreventedBounce: logPreventedBounceMock,
+  formatViolations: (vs) => vs.map(v => `${v.field}: expected ${v.expected}, got ${v.got}`).join('\n'),
+}));
+vi.mock('./auto-proceed-resolver.js', () => ({
+  resolveAutoProceed: vi.fn().mockResolvedValue({ autoProceed: true, source: 'test', sessionId: 's-1' }),
+  createHandoffMetadata: vi.fn().mockReturnValue({}),
+}));
+vi.mock('../../../lib/flywheel/capture.js', () => ({
+  captureHandoffGate: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./pre-checks/prerequisite-preflight.js', () => ({
+  runPrerequisitePreflight: vi.fn().mockResolvedValue({ passed: true, issues: [] }),
+}));
+vi.mock('../../../lib/learning/surface-prior-lessons.js', () => ({
+  surfacePriorLessons: vi.fn().mockResolvedValue({ patterns: [], retrospectives: [] }),
+  formatPriorLessons: vi.fn().mockReturnValue(''),
+  resolvePhaseStrategy: vi.fn().mockReturnValue('strategy'),
+}));
+vi.mock('../../../lib/learning/issue-knowledge-base.js', () => ({ IssueKnowledgeBase: class {} }));
+vi.mock('../../../lib/supabase-client.js', () => ({ createSupabaseServiceClient: () => ({}) }));
+
+const { HandoffOrchestrator } = await import('./HandoffOrchestrator.js');
+
+const SD_ROW = { id: 'uuid-1', sd_key: 'SD-X-001', title: 'T', category: 'infrastructure', sd_type: 'infrastructure' };
+
+function makeOrchestrator(executeResult) {
+  const executorExecute = vi.fn().mockResolvedValue(executeResult);
+  const recorder = {
+    recordSuccess: vi.fn().mockResolvedValue(undefined),
+    recordFailure: vi.fn().mockResolvedValue(undefined),
+    recordSystemError: vi.fn().mockResolvedValue(undefined),
+  };
+  const orchestrator = new HandoffOrchestrator({
+    supabase: { mock: true },
+    sdRepo: { verifyExists: vi.fn().mockResolvedValue(SD_ROW), getById: vi.fn().mockResolvedValue(SD_ROW) },
+    handoffRepo: { loadTemplate: vi.fn().mockResolvedValue({}) },
+    recorder,
+  });
+  orchestrator._executors = { 'LEAD-TO-PLAN': { execute: executorExecute } };
+  return { orchestrator, executorExecute, recorder };
+}
+
+beforeEach(() => {
+  executeArtifactPreflightMock.mockReset();
+  logPreventedBounceMock.mockClear().mockResolvedValue(undefined);
+});
+
+describe('executeHandoff artifact-preflight wiring', () => {
+  it('HARD_FAIL stops pre-pipeline: executor never invoked, ARTIFACT_PREFLIGHT_FAILED recorded with violations', async () => {
+    executeArtifactPreflightMock.mockResolvedValue({
+      verdict: 'HARD_FAIL',
+      violations: [{ field: 'success_metrics', expected: '>=3 UNIQUE', got: '1 unique of 1', hint: 'h' }],
+      advisories: [],
+    });
+    const { orchestrator, executorExecute, recorder } = makeOrchestrator({ success: true });
+
+    const result = await orchestrator.executeHandoff('LEAD-TO-PLAN', 'SD-X-001');
+
+    expect(executorExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.reasonCode).toBe('ARTIFACT_PREFLIGHT_FAILED');
+    expect(result.preflightViolations[0].field).toBe('success_metrics');
+    expect(recorder.recordFailure).toHaveBeenCalledTimes(1);
+    expect(logPreventedBounceMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sdKey: 'SD-X-001', handoffType: 'LEAD-TO-PLAN', trapFields: ['success_metrics'] })
+    );
+  });
+
+  it('PASS verdict: pipeline runs byte-identical (executor called once, verdict unchanged)', async () => {
+    executeArtifactPreflightMock.mockResolvedValue({ verdict: 'PASS', violations: [], advisories: [] });
+    const { orchestrator, executorExecute, recorder } = makeOrchestrator({ success: true });
+
+    const result = await orchestrator.executeHandoff('LEAD-TO-PLAN', 'SD-X-001');
+
+    expect(executorExecute).toHaveBeenCalledTimes(1);
+    expect(executorExecute).toHaveBeenCalledWith('SD-X-001', expect.objectContaining({ autoProceed: true }));
+    expect(result.success).toBe(true);
+    expect(recorder.recordSuccess).toHaveBeenCalledTimes(1);
+    expect(logPreventedBounceMock).not.toHaveBeenCalled();
+  });
+
+  it('preflight module throw falls OPEN: pipeline runs normally', async () => {
+    executeArtifactPreflightMock.mockRejectedValue(new Error('module exploded'));
+    const { orchestrator, executorExecute } = makeOrchestrator({ success: true });
+
+    const result = await orchestrator.executeHandoff('LEAD-TO-PLAN', 'SD-X-001');
+
+    expect(executorExecute).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('ERROR verdict (wrapper-internal failure) falls OPEN: pipeline runs normally', async () => {
+    executeArtifactPreflightMock.mockResolvedValue({ verdict: 'ERROR', violations: [], advisories: [], error: 'db down' });
+    const { orchestrator, executorExecute } = makeOrchestrator({ success: true });
+
+    const result = await orchestrator.executeHandoff('LEAD-TO-PLAN', 'SD-X-001');
+
+    expect(executorExecute).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+});

--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -909,9 +909,13 @@ export class HandoffOrchestrator {
         elapsed += pollIntervalMs;
 
         try {
+          // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A (drive-by, caught by schema-reference
+          // lint): 'prd_id' is a phantom column (live 42703) — the PK is 'id'. The phantom
+          // select errored into the catch below on EVERY poll, so PRD-creation verification
+          // always timed out silently.
           const { data } = await this.supabase
             .from('product_requirements_v2')
-            .select('prd_id')
+            .select('id')
             .eq('sd_id', sdId)
             .limit(1);
 

--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -181,6 +181,53 @@ export class HandoffOrchestrator {
         return preflightResult;
       }
 
+      // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A (program L1): artifact pre-flight.
+      // Known deterministic gate-reject shapes fail FAST with the SHAPE_VIOLATION
+      // remediation list and skip the gate pipeline entirely; advisory shape issues
+      // are printed but never block; any internal preflight error FAILS OPEN.
+      try {
+        const { executeArtifactPreflight, formatViolations, logPreventedBounce } =
+          await import('./artifact-preflight.js');
+        const artifact = await executeArtifactPreflight({
+          sdRepo: this.sdRepo,
+          prdRepo: this.prdRepo,
+          handoffType: normalizedType,
+          sdId,
+        });
+        if (artifact.verdict === 'HARD_FAIL') {
+          console.log('');
+          console.log('🚫 ARTIFACT PRE-FLIGHT FAILED (gate pipeline NOT run — known deterministic reject)');
+          console.log('─'.repeat(50));
+          console.log(formatViolations(artifact.violations));
+          console.log('─'.repeat(50));
+          console.log('   Fix the artifact shape above, then retry the handoff.');
+          console.log('');
+          const rejected = ResultBuilder.rejected(
+            'ARTIFACT_PREFLIGHT_FAILED',
+            `Artifact preflight failed: ${artifact.violations.map(v => v.field).join(', ')}`
+          );
+          rejected.preflightViolations = artifact.violations;
+          await this.recorder.recordFailure(normalizedType, sdId, rejected, null);
+          logPreventedBounce(this.supabase, {
+            sdKey: (sd && sd.sd_key) || sdId,
+            handoffType: normalizedType,
+            trapFields: artifact.violations.map(v => v.field),
+          }).catch(() => {});
+          return rejected;
+        }
+        if (artifact.advisories && artifact.advisories.length > 0) {
+          console.log(`   ℹ️  [artifact-preflight] ${artifact.advisories.length} advisory shape issue(s) (non-blocking):`);
+          for (const a of artifact.advisories.slice(0, 5)) {
+            console.log(`      - ${a.field}: expected ${a.expected}, got ${a.got}`);
+          }
+        }
+        if (artifact.verdict === 'ERROR') {
+          console.warn(`   [artifact-preflight] skipped (fail-open): ${artifact.error}`);
+        }
+      } catch (preflightErr) {
+        console.warn(`   [artifact-preflight] skipped (fail-open): ${preflightErr.message}`);
+      }
+
       // Execute the handoff with AUTO-PROCEED metadata
       const result = await executor.execute(sdId, enhancedOptions);
 

--- a/scripts/modules/handoff/artifact-preflight.js
+++ b/scripts/modules/handoff/artifact-preflight.js
@@ -1,0 +1,177 @@
+/**
+ * Artifact Pre-Flight — SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A (program L1)
+ *
+ * Runs artifact-shape checks inside the handoff EXECUTE path BEFORE the gate
+ * pipeline burns a full evaluation. ~60% of parseable handoff rejections
+ * (2026-06-07..10) are artifact-shape traps the shipped tooling already
+ * detects offline, but /loop workers call executeHandoff directly
+ * (scripts/handoff.js execute → cli-main.js → HandoffOrchestrator) and never
+ * run the optional precheckHandoff advisory path.
+ *
+ * DESIGN CONTRACT (FR-2):
+ *  - HARD_FAIL is reserved for shapes the gates DETERMINISTICALLY reject —
+ *    today that is exactly one check: GATE_SD_METRICS_SUFFICIENCY at
+ *    LEAD-TO-PLAN, mirrored here by calling the gate's own
+ *    validateMetricsSufficiency() on the same SD row (parity by construction,
+ *    zero re-encoding). The gate is BLOCKING and unconditionally registered
+ *    (executors/lead-to-plan/index.js getRequiredGates — no orchestrator-child
+ *    reduced set at LEAD-TO-PLAN).
+ *  - Everything else is ADVISORY ONLY. Verified non-deterministic at gate
+ *    time, so a pre-pipeline block would false-positive:
+ *      • PLAN-TO-LEAD empty/pending metric actuals — the consolidated
+ *        SUCCESS_METRICS gate AUTO-POPULATES empty actuals from accepted
+ *        handoffs / completed stories before scoring
+ *        (success-metrics-gate.js:202-260), and evidence-bound metrics
+ *        ({evidence:{kind,ref}}) are resolved from machine evidence with the
+ *        actual text ignored.
+ *      • lib/artifact-contracts shape mode on the SD row — "no SD gate
+ *        counterpart today" (lib/artifact-contracts/index.js), and on the PRD
+ *        row — shape mode mirrors add-prd's creation-time checks, not a
+ *        PLAN-TO-EXEC gate.
+ *  - Any internal error FAILS OPEN to the normal pipeline (verdict ERROR;
+ *    the caller proceeds). Never block on tooling.
+ *
+ * Violations reuse the SHAPE_VIOLATION rendering contract:
+ *   { field, expected, got, hint }  →  formatViolations()
+ */
+
+import { validateMetricsSufficiency } from './verifiers/lead-to-plan/sd-validation.js';
+import { validateArtifact, formatViolations } from '../../../lib/artifact-contracts/index.js';
+
+export { formatViolations };
+
+const PENDING_PATTERN = /^(pending|tbd|to\s*be\s*determined|not\s*yet|awaiting|[\d.]+%?\s*-?\s*pending.*)$/i;
+const isEmptyOrPending = (val) =>
+  val == null || String(val).trim() === '' || PENDING_PATTERN.test(String(val).trim());
+
+function normalizeType(handoffType) {
+  return String(handoffType || '').toUpperCase().replace(/_/g, '-');
+}
+
+/**
+ * Pure preflight core — no DB, no I/O.
+ *
+ * @param {object} input
+ * @param {string} input.handoffType — e.g. 'LEAD-TO-PLAN' (underscores accepted)
+ * @param {object|null} input.sd — full strategic_directives_v2 row
+ * @param {object|null} input.prd — product_requirements_v2 row (PLAN-TO-EXEC only; may be null)
+ * @returns {{ verdict: 'PASS'|'HARD_FAIL'|'ERROR',
+ *             violations: Array<{field:string,expected:string,got:string,hint:string}>,
+ *             advisories: Array<{field:string,expected:string,got:string,hint:string}> }}
+ */
+export function runArtifactPreflight({ handoffType, sd, prd } = {}) {
+  const type = normalizeType(handoffType);
+  const violations = [];
+  const advisories = [];
+
+  if (!sd || typeof sd !== 'object') {
+    // No SD row available — nothing deterministic to assert; let the pipeline
+    // (which has its own SD-existence handling) own the failure.
+    return { verdict: 'PASS', violations, advisories };
+  }
+
+  if (type === 'LEAD-TO-PLAN') {
+    // ── HARD-FAIL: GATE_SD_METRICS_SUFFICIENCY mirror (exact gate function) ──
+    const sufficiency = validateMetricsSufficiency(sd);
+    if (!sufficiency.pass) {
+      violations.push({
+        field: 'success_metrics',
+        expected: '>=3 UNIQUE metrics (success_criteria accepted as fallback source)',
+        got: `${sufficiency.uniqueCount} unique of ${sufficiency.originalCount} (${sufficiency.issues.join('; ') || 'insufficient'})`,
+        hint: 'GATE_SD_METRICS_SUFFICIENCY (BLOCKING at LEAD-TO-PLAN) dedups by text — padding with duplicates fails. Populate strategic_directives_v2.success_metrics with >=3 distinct measurable outcomes. Pre-validate payloads with: npm run contract:check -- sd <file>',
+      });
+    }
+
+    // ── ADVISORY: SD contract shape (no SD gate counterpart today) ──
+    try {
+      const sdShape = validateArtifact('sd', sd, { mode: 'shape' });
+      advisories.push(...sdShape.violations);
+    } catch { /* advisory only */ }
+  }
+
+  if (type === 'PLAN-TO-EXEC' && prd && typeof prd === 'object') {
+    // ── ADVISORY: PRD contract shape (mirrors add-prd creation checks, not a gate) ──
+    try {
+      const prdShape = validateArtifact('prd', prd, { mode: 'shape' });
+      advisories.push(...prdShape.violations);
+    } catch { /* advisory only */ }
+  }
+
+  if (type === 'PLAN-TO-LEAD') {
+    // ── ADVISORY: empty/pending metric actuals. NOT a hard-fail — the
+    // SUCCESS_METRICS gate auto-populates from accepted-handoff/story evidence
+    // and evidence-bound metrics resolve from machine evidence. Surfacing the
+    // remediation early still saves the round-trip when auto-population has
+    // nothing to draw on.
+    const raw = Array.isArray(sd.success_metrics) ? sd.success_metrics : [];
+    raw.forEach((m, i) => {
+      const metric = typeof m === 'string' ? { name: m, actual: null } : (m || {});
+      if (metric.evidence) return; // evidence-bound — gate resolves from evidence
+      if (isEmptyOrPending(metric.actual)) {
+        advisories.push({
+          field: `success_metrics[${i}].actual`,
+          expected: 'achieved-state actual LEADING WITH A NUMBER (e.g. "8/8 — all FRs verified", "100% — 6 of 6")',
+          got: metric.actual == null ? 'null' : `"${String(metric.actual)}"`,
+          hint: 'The SUCCESS_METRICS gate attempts auto-population from accepted handoffs/stories, but a recorded numeric-leading actual is deterministic. Update strategic_directives_v2.success_metrics[].actual before PLAN-TO-LEAD.',
+        });
+      }
+    });
+  }
+
+  return {
+    verdict: violations.length > 0 ? 'HARD_FAIL' : 'PASS',
+    violations,
+    advisories,
+  };
+}
+
+/**
+ * Async wrapper used by HandoffOrchestrator.executeHandoff — gathers the rows,
+ * runs the pure core, and NEVER throws (any internal failure → verdict ERROR,
+ * caller falls open to the normal pipeline).
+ *
+ * @param {object} deps
+ * @param {object} deps.sdRepo — SDRepository (getById)
+ * @param {object} deps.prdRepo — PRDRepository (getBySdId)
+ * @param {string} deps.handoffType
+ * @param {string} deps.sdId — sd_key or UUID
+ */
+export async function executeArtifactPreflight({ sdRepo, prdRepo, handoffType, sdId }) {
+  try {
+    const type = normalizeType(handoffType);
+    const sd = await sdRepo.getById(sdId);
+    if (!sd) return { verdict: 'PASS', violations: [], advisories: [] };
+
+    let prd = null;
+    if (type === 'PLAN-TO-EXEC' && prdRepo && typeof prdRepo.getBySdId === 'function') {
+      try { prd = await prdRepo.getBySdId(sd.id || sdId); } catch { /* no PRD is the prerequisite preflight's problem */ }
+    }
+
+    return runArtifactPreflight({ handoffType: type, sd, prd });
+  } catch (e) {
+    return { verdict: 'ERROR', violations: [], advisories: [], error: (e && e.message) || String(e) };
+  }
+}
+
+/**
+ * FR-3 telemetry: fire-and-forget prevented-bounce event on the EXISTING
+ * coordination_events table (no new tables). Failure never affects the
+ * handoff result.
+ */
+export async function logPreventedBounce(supabase, { sdKey, handoffType, trapFields }) {
+  try {
+    const { error } = await supabase.from('coordination_events').insert({
+      event_type: 'HANDOFF_PREVENTED_BOUNCE',
+      severity: 'info',
+      payload: {
+        sd_key: sdKey,
+        handoff_type: normalizeType(handoffType),
+        trap_fields: trapFields || [],
+        source: 'artifact-preflight',
+      },
+    });
+    if (error) console.warn(`   [artifact-preflight] telemetry write failed (non-fatal): ${error.message}`);
+  } catch (e) {
+    console.warn(`   [artifact-preflight] telemetry threw (non-fatal): ${(e && e.message) || e}`);
+  }
+}

--- a/scripts/modules/handoff/artifact-preflight.test.js
+++ b/scripts/modules/handoff/artifact-preflight.test.js
@@ -1,0 +1,118 @@
+/**
+ * SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A (program L1) — artifact pre-flight.
+ *
+ * Pins the FR-2 design contract:
+ *  - HARD_FAIL only on shapes the gates deterministically reject
+ *    (GATE_SD_METRICS_SUFFICIENCY mirror at LEAD-TO-PLAN, exact gate function);
+ *  - everything else advisory (PLAN-TO-LEAD empty actuals — the gate
+ *    auto-populates, so blocking would false-positive);
+ *  - any internal error fails OPEN (verdict ERROR, never throws);
+ *  - executeHandoff wiring: HARD_FAIL stops pre-pipeline with the remediation
+ *    list, clean payloads pass through byte-identical, exceptions fall open.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runArtifactPreflight, executeArtifactPreflight } from './artifact-preflight.js';
+
+const THREE_METRICS = [
+  { metric: 'A', target: '>=1', actual: '1 — done' },
+  { metric: 'B', target: '>=2', actual: '2 — done' },
+  { metric: 'C', target: '>=3', actual: '3 — done' },
+];
+
+describe('runArtifactPreflight (pure core)', () => {
+  it('LEAD-TO-PLAN: insufficient success_metrics (no criteria fallback) → HARD_FAIL naming success_metrics', () => {
+    const r = runArtifactPreflight({
+      handoffType: 'LEAD-TO-PLAN',
+      sd: { sd_key: 'SD-T-001', success_metrics: [{ metric: 'only one', target: 'x' }] },
+    });
+    expect(r.verdict).toBe('HARD_FAIL');
+    expect(r.violations.length).toBeGreaterThanOrEqual(1);
+    expect(r.violations[0].field).toBe('success_metrics');
+    expect(r.violations[0].hint).toContain('GATE_SD_METRICS_SUFFICIENCY');
+  });
+
+  it('LEAD-TO-PLAN: >=3 unique metrics → PASS (no deterministic reject)', () => {
+    const r = runArtifactPreflight({
+      handoffType: 'LEAD-TO-PLAN',
+      sd: { sd_key: 'SD-T-002', success_metrics: THREE_METRICS },
+    });
+    expect(r.verdict).toBe('PASS');
+    expect(r.violations).toEqual([]);
+  });
+
+  it('LEAD-TO-PLAN: duplicate-padded metrics dedup to insufficient → HARD_FAIL (gate parity)', () => {
+    const dup = { metric: 'same text', target: 'x' };
+    const r = runArtifactPreflight({
+      handoffType: 'LEAD_TO_PLAN', // underscore form accepted
+      sd: { sd_key: 'SD-T-003', success_metrics: [dup, { ...dup }, { ...dup }] },
+    });
+    expect(r.verdict).toBe('HARD_FAIL');
+  });
+
+  it('PLAN-TO-LEAD: empty metric actuals are ADVISORY ONLY (gate auto-populates — never block)', () => {
+    const r = runArtifactPreflight({
+      handoffType: 'PLAN-TO-LEAD',
+      sd: { sd_key: 'SD-T-004', success_metrics: [{ metric: 'M1', target: '>=1', actual: '' }, { metric: 'M2', target: '>=1' }] },
+    });
+    expect(r.verdict).toBe('PASS');
+    expect(r.advisories.length).toBe(2);
+    expect(r.advisories[0].field).toBe('success_metrics[0].actual');
+    expect(r.advisories[0].expected).toContain('LEADING WITH A NUMBER');
+  });
+
+  it('PLAN-TO-LEAD: evidence-bound metrics with empty actuals get NO advisory (gate resolves from evidence)', () => {
+    const r = runArtifactPreflight({
+      handoffType: 'PLAN-TO-LEAD',
+      sd: {
+        sd_key: 'SD-T-005',
+        success_metrics: [{ metric: 'M1', target: '>=85', actual: '', evidence: { kind: 'gate_score', ref: { handoff: 'EXEC-TO-PLAN', expect: '>=85' } } }],
+      },
+    });
+    expect(r.verdict).toBe('PASS');
+    expect(r.advisories).toEqual([]);
+  });
+
+  it('LEAD-TO-PLAN with no PRD: no PRD-scoped checks run (per-handoff-type scoping)', () => {
+    const r = runArtifactPreflight({
+      handoffType: 'LEAD-TO-PLAN',
+      sd: { sd_key: 'SD-T-006', success_metrics: THREE_METRICS },
+      prd: null,
+    });
+    expect(r.verdict).toBe('PASS');
+    expect(r.violations.every(v => !String(v.field).startsWith('prd'))).toBe(true);
+  });
+
+  it('missing SD row → PASS (pipeline owns SD-existence failures)', () => {
+    expect(runArtifactPreflight({ handoffType: 'PLAN-TO-LEAD', sd: null }).verdict).toBe('PASS');
+  });
+
+  it('EXEC-TO-PLAN: no deterministic checks today → PASS pass-through', () => {
+    const r = runArtifactPreflight({ handoffType: 'EXEC-TO-PLAN', sd: { sd_key: 'SD-T-007' } });
+    expect(r.verdict).toBe('PASS');
+    expect(r.violations).toEqual([]);
+  });
+});
+
+describe('executeArtifactPreflight (fail-open wrapper)', () => {
+  it('repo throw → verdict ERROR, never rejects', async () => {
+    const r = await executeArtifactPreflight({
+      sdRepo: { getById: vi.fn().mockRejectedValue(new Error('db down')) },
+      prdRepo: null,
+      handoffType: 'LEAD-TO-PLAN',
+      sdId: 'SD-T-008',
+    });
+    expect(r.verdict).toBe('ERROR');
+    expect(r.error).toContain('db down');
+    expect(r.violations).toEqual([]);
+  });
+
+  it('fetches PRD only for PLAN-TO-EXEC', async () => {
+    const getBySdId = vi.fn().mockResolvedValue({ id: 'prd-1' });
+    const sdRepo = { getById: vi.fn().mockResolvedValue({ id: 'uuid-1', sd_key: 'SD-T-009', success_metrics: THREE_METRICS }) };
+    await executeArtifactPreflight({ sdRepo, prdRepo: { getBySdId }, handoffType: 'LEAD-TO-PLAN', sdId: 'SD-T-009' });
+    expect(getBySdId).not.toHaveBeenCalled();
+    await executeArtifactPreflight({ sdRepo, prdRepo: { getBySdId }, handoffType: 'PLAN-TO-EXEC', sdId: 'SD-T-009' });
+    expect(getBySdId).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Program L1 (pure waste removal, Adam-authored, chairman program 2026-06-11): /loop workers call `executeHandoff` directly and never run the optional precheck — paying the 26% PLAN-TO-LEAD bounce on artifact-shape traps the shipped tooling already detects offline (~60% of parseable handoff rejections 2026-06-07..10).

## What shipped
**New `scripts/modules/handoff/artifact-preflight.js`:**
- `runArtifactPreflight` (pure): **HARD_FAIL reserved for shapes the gates deterministically reject** — exactly the GATE_SD_METRICS_SUFFICIENCY mirror at LEAD-TO-PLAN, via the gate's own `validateMetricsSufficiency` (parity by construction, zero re-encoding).
- Build verification found PLAN-TO-LEAD empty actuals are **NOT** deterministic — the SUCCESS_METRICS gate auto-populates from accepted handoffs/stories and resolves evidence-bound metrics from machine evidence — so those are **advisory only**, as are SD/PRD contract shape-mode findings (no gate counterpart / creation-time mirror).
- `executeArtifactPreflight`: never throws; internal failure → verdict ERROR → caller falls OPEN to the normal pipeline.
- `logPreventedBounce`: fire-and-forget HANDOFF_PREVENTED_BOUNCE on coordination_events (sd_key, handoff_type, trap_fields — no new tables) so the program metric (26% → 13% bounce) is measurable.

**`HandoffOrchestrator.executeHandoff` wiring:** after prerequisite preflight, before `executor.execute`. HARD_FAIL prints the SHAPE_VIOLATION remediation list (field/expected/got/hint), records ARTIFACT_PREFLIGHT_FAILED, logs telemetry, skips the pipeline.

## Tests
- 10 pure-core + 4 wiring (executor-never-invoked on HARD_FAIL; byte-identical pass-through; module-throw and ERROR-verdict fall open)
- Existing execute-lessons + precheck-policy suites green — 22/22 total; smoke 15/15
- Live probes: LEAD-TO-PLAN 1-metric → HARD_FAIL(1); PLAN-TO-LEAD empty actual → PASS + 1 advisory

OUT of scope (per SD): gate-strictness changes, precheck CLI, verdict caching (sibling -B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)