### PR TITLE
feat(SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): coordinator↔Adam comms resilience — correlation echo, receipts, no-auto-ack allowlist, dead-letter sweep

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -753,6 +753,24 @@ Selector: `payload->>kind='adam_advisory' AND payload->>actioned_at IS NULL AND 
 A peek/render NEVER retires an advisory — only `coordinator-ack-adam.cjs --advisory` does. The
 `--reply`/reply legs need `COORDINATOR_TWOWAY_V2=on`.
 
+### NO hand-rolled inserts (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001)
+
+**NEVER write `session_coordination` rows via ad-hoc `node -e` inserts.** Live 7-day evidence:
+158/166 `coordinator_reply` rows lacked `payload.reply_to` (hand-rolled), so awaiting senders
+never matched them — plus invented kinds (`coordinator_to_adam`) leaked into the lane. Always
+route through the canonical writers:
+
+| Intent | Canonical path |
+|--------|----------------|
+| Reply to a worker request | `node scripts/coordinator-reply.cjs --to <session> --correlation <id> "<body>"` (echoes the correlation under BOTH `reply_to` + `correlation_id`) |
+| Reply to an Adam advisory | `node scripts/coordinator-reply.cjs --advisory <id> "<body>"` or `coordinator-ack-adam.cjs --advisory <id> --reply "<body>"` |
+| Any other directive row | `lib/coordinator/dispatch.cjs insertCoordinationRow` with a kind from `PAYLOAD_KINDS`/`DIRECTIVE_KINDS` (`lib/fleet/worker-status.cjs`) — never an invented `payload.kind` |
+
+Receipt contract (all directive kinds): `read_at` = DELIVERED, `acknowledged_at` /
+`payload.actioned_at` = ACTIONED. Check `node scripts/fleet-dashboard.cjs inbox` —
+'UNDELIVERED OUTBOUND' lists your rows sitting unread at live targets; 'DEAD-LETTERED (24h)'
+lists rows the sweep dead-lettered (re-send to the successor session if still relevant).
+
 ---
 
 ## Same-SD Parallel Worker Assignment (FR-4)

--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -93,3 +93,42 @@ node scripts/coordinator-ack-adam.cjs --advisory <id> --reply "sourcing now" # r
 # Adam
 node scripts/adam-advisory.cjs replies                                       # drains the reply
 ```
+
+## Receipt contract — ALL directive kinds (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001)
+
+The two-stage ACK above is not advisory-specific. For **every** directive kind
+(`coordinator_request`, `work_assignment`, `adam_action_required`, `coordinator_reminder`,
+`coordinator_to_adam` — the canonical list is `DIRECTIVE_KINDS` in
+`lib/fleet/worker-status.cjs`, **import it, never duplicate it**), in **both** directions:
+
+| Marker | Meaning | Who stamps it |
+|--------|---------|---------------|
+| `read_at` | **DELIVERED** — a render/poll surfaced the row to the target | any poll/render (inbox hook, dashboard) |
+| `acknowledged_at` / `payload.actioned_at` | **ACTIONED** — the agent genuinely processed it | ONLY the agent that actioned the row |
+
+No poll/drain path may ever stamp `acknowledged_at` on a directive kind (FR-3 —
+the inbox hook's kind-allowlist enforces this; the sender-type allowlist that auto-acked
+5 chairman directives unseen is dead, per QF-20260610-545).
+
+**Sender-side receipts:** an outbound row unread (`read_at IS NULL`) at a **live** target
+for 10+ minutes is UNDELIVERED — surfaced by `node scripts/fleet-dashboard.cjs inbox`
+('UNDELIVERED OUTBOUND') and the hourly review. Pure selector:
+`lib/coordinator/receipts.cjs findUndelivered`.
+
+## Correlation echo — replies carry BOTH keys
+
+Every reply writer echoes the request's correlation under **both** `payload.reply_to`
+(canonical) **and** `payload.correlation_id`, and await matchers accept either key
+(forgiving matcher, kind-filtered). Adam answers an inbound `coordinator_request` with
+`node scripts/adam-advisory.cjs send "<answer>" --reply-to <correlation_or_row_id>` —
+the echo overrides the advisory's fresh correlation. Live evidence behind this rule:
+158/166 `coordinator_reply` rows in one week lacked `reply_to` (hand-rolled inserts),
+so awaiting senders never matched them.
+
+## Dead letters — never silently deleted
+
+The stale-session sweep no longer hard-DELETEs unread rows targeting dead/gone sessions.
+It stamps `payload.dead_letter=true` (+ `dead_letter_at`, `dead_letter_reason`,
+`original_target`), stamps `read_at` (drain marker), and backfills `expires_at = now+7d`
+when NULL so the audit trail is reaped after a week. Surfaced by the coordinator inbox
+section 'DEAD-LETTERED (24h)' — re-send to the successor session if still relevant.

--- a/lib/coordinator/receipts.cjs
+++ b/lib/coordinator/receipts.cjs
@@ -1,0 +1,90 @@
+/**
+ * Coordinator comms receipts — FR-2 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001).
+ *
+ * Uniform receipt contract for coordination directives (both directions):
+ *   read_at              = DELIVERED  — any render/poll that surfaced the row to the target
+ *   payload.actioned_at /
+ *   acknowledged_at      = ACTIONED   — only the agent that genuinely processed the row
+ *
+ * This module closes the SENDER-side gap: live evidence (2026-06-10) showed
+ * coordinator->Adam GO messages (payload.kind=coordinator_request) sitting UNREAD
+ * 24-29 minutes — and one reply 4.4h — while the target was heartbeat-alive, with
+ * nothing surfacing it to the sender. findUndelivered() is the pure selector behind
+ * the 'UNDELIVERED OUTBOUND' section in scripts/fleet-dashboard.cjs and the hourly
+ * check in scripts/coordinator-hourly-review.cjs.
+ *
+ * PURE — zero IO. Callers fetch the candidate rows + sessions and inject them
+ * (mocked-client testable; template: lib/coordinator/adam-action-ack.cjs).
+ *
+ * @module lib/coordinator/receipts
+ */
+
+'use strict';
+
+/** A target is "live" when its heartbeat is fresher than this (mirrors
+ *  lib/fleet/worker-status.cjs FLEET_ACTIVE_WINDOW_MS). */
+const DEFAULT_HEARTBEAT_FRESH_MS = 15 * 60 * 1000;
+
+/** An unread outbound row older than this counts as UNDELIVERED (10 min ≈ 2
+ *  coordinator cron cycles — same rationale as adam-action-ack DEFAULT_SLA_MS). */
+const DEFAULT_UNDELIVERED_AGE_MS = 10 * 60 * 1000;
+
+/** Dead-letter surfacing window for the dashboard section. */
+const DEFAULT_DEAD_LETTER_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function toMs(ts) {
+  const ms = ts ? Date.parse(ts) : NaN;
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * Pure: select the caller's outbound rows that are UNDELIVERED at a LIVE target —
+ * i.e. read_at IS NULL, older than ageMs, and the target session has a fresh
+ * heartbeat (a dead/gone target is the dead-letter sweep's lane, not this one).
+ *
+ * @param {Array<object>} rows      session_coordination rows (sender = caller; any read state — filtered here)
+ * @param {Array<object>} sessions  claude_sessions rows ({ session_id, heartbeat_at })
+ * @param {object}        [opts]    { now=Date.now(), ageMs, heartbeatFreshMs }
+ * @returns {Array<object>} the undelivered rows, oldest first, each annotated with ageMs
+ */
+function findUndelivered(rows, sessions, opts = {}) {
+  const {
+    now = Date.now(),
+    ageMs = DEFAULT_UNDELIVERED_AGE_MS,
+    heartbeatFreshMs = DEFAULT_HEARTBEAT_FRESH_MS,
+  } = opts;
+
+  const liveIds = new Set(
+    (sessions || [])
+      .filter((s) => s && s.session_id && (now - toMs(s.heartbeat_at)) < heartbeatFreshMs)
+      .map((s) => s.session_id)
+  );
+
+  return (rows || [])
+    .filter((r) => r && !r.read_at)
+    .filter((r) => !(r.payload && r.payload.dead_letter === true)) // dead-lettered rows have their own section
+    .filter((r) => liveIds.has(r.target_session))
+    .filter((r) => (now - toMs(r.created_at)) >= ageMs)
+    .map((r) => ({ ...r, ageMs: now - toMs(r.created_at) }))
+    .sort((a, b) => b.ageMs - a.ageMs);
+}
+
+/**
+ * Pure: select rows dead-lettered (FR-4 sweep: payload.dead_letter=true) within
+ * the window — the 'DEAD-LETTERED (24h)' dashboard section.
+ */
+function selectRecentDeadLetters(rows, opts = {}) {
+  const { now = Date.now(), windowMs = DEFAULT_DEAD_LETTER_WINDOW_MS } = opts;
+  return (rows || [])
+    .filter((r) => r && r.payload && r.payload.dead_letter === true)
+    .filter((r) => (now - toMs(r.payload.dead_letter_at)) <= windowMs)
+    .sort((a, b) => toMs(b.payload.dead_letter_at) - toMs(a.payload.dead_letter_at));
+}
+
+module.exports = {
+  findUndelivered,
+  selectRecentDeadLetters,
+  DEFAULT_UNDELIVERED_AGE_MS,
+  DEFAULT_HEARTBEAT_FRESH_MS,
+  DEFAULT_DEAD_LETTER_WINDOW_MS,
+};

--- a/lib/coordinator/worker-signal.request.test.js
+++ b/lib/coordinator/worker-signal.request.test.js
@@ -52,13 +52,18 @@ describe('FR-1: request payload contract', () => {
 });
 
 describe('FR-1: awaitCoordinatorReply round-trip', () => {
-  // Minimal supabase stub: session_coordination.select(...).eq().eq().order().limit()
-  // resolves to whatever rows we queue.
+  // Minimal supabase stub: session_coordination.select(...).eq().or().in().order().limit()
+  // resolves to whatever rows we queue. (.or/.in added by FR-1
+  // SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001 — the forgiving dual-key matcher;
+  // without them the old stub threw inside the poll's try/catch and the frozen-clock
+  // test looped forever.)
   function buildSupabaseStub(rowsSequence) {
     let call = 0;
     const chain = {
       select: vi.fn(() => chain),
       eq: vi.fn(() => chain),
+      or: vi.fn(() => chain),
+      in: vi.fn(() => chain),
       order: vi.fn(() => chain),
       limit: vi.fn(() => {
         const rows = rowsSequence[Math.min(call, rowsSequence.length - 1)];

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -64,6 +64,23 @@ const PAYLOAD_KINDS = Object.freeze({
   ADAM_ADVISORY: 'adam_advisory',     // SD-...-001-B: Adam advisory clean lane (off friction router)
 });
 
+// FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): payload.kind values that are
+// DIRECTIVES — rows that require genuine agent action. NO poll/drain path may ever
+// stamp acknowledged_at on these (read_at = DELIVERED is allowed; acknowledged_at /
+// payload.actioned_at = ACTIONED is reserved for the agent that actually processed
+// the row). This is the ALLOWLIST shape the QF-20260610-545 lesson demands: classify
+// the KIND of the row, never the sender_type (the sender allowlist missed `chairman`
+// and auto-acked 5 live directives unseen — harness-bug 43c2dee2). Consumers MUST
+// import this list — never duplicate it (source-pinned by
+// tests/unit/coord-adam-comms-resilient.test.js).
+const DIRECTIVE_KINDS = Object.freeze([
+  'coordinator_request',
+  'work_assignment',
+  'adam_action_required',
+  'coordinator_reminder',
+  'coordinator_to_adam',
+]);
+
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;
 
 /**
@@ -124,6 +141,7 @@ module.exports = {
   SESSION_COORDINATION_COLUMNS,
   CLAUDE_SESSIONS_COLUMNS,
   PAYLOAD_KINDS,
+  DIRECTIVE_KINDS,
   FLEET_ACTIVE_WINDOW_MS,
   getServiceClient,
   getReadClient,

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -45,7 +45,7 @@ const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
  * request mode. Conflating them made every fire-and-forget send falsely advertise
  * Reply?=yes in printAdamInbox.
  */
-function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes }) {
+function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo }) {
   const payload = {
     kind: PAYLOAD_KINDS.ADAM_ADVISORY,
     sender_callsign: senderCallsign || null,
@@ -67,6 +67,14 @@ function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expec
   }
   if (correlationId) payload.correlation_id = correlationId; // replyable (always)
   if (expectsReply) payload.expects_reply = true;            // awaiting a sync reply (request mode only)
+  // FR-1 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): when this advisory ANSWERS an inbound
+  // coordinator_request, echo that request's correlation under BOTH keys (reply_to +
+  // correlation_id) so the awaiting side's forgiving matcher pairs it. The echo OVERRIDES the
+  // fresh correlation_id above — a reply correlates to its request, not to itself.
+  if (replyTo) {
+    payload.reply_to = replyTo;
+    payload.correlation_id = replyTo;
+  }
   // INVARIANT: no signal_type, no intent_action.
   return payload;
 }
@@ -96,6 +104,37 @@ async function resolveScopeForSend(supabase, repoPath) {
   } catch {
     return {};
   }
+}
+
+/**
+ * FR-1 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001) — resolve `--reply-to <value>` to the
+ * correlation to echo. The value may be EITHER a session_coordination row id (the inbound
+ * coordinator_request row — we echo ITS payload.correlation_id) or a bare correlation id
+ * (echoed as-is). Row lookup is best-effort: if no row matches, the value is treated as the
+ * correlation itself. Throws only when a matching ROW exists but carries no correlation_id
+ * (not replyable — surfacing that beats silently inventing a correlation). Exported for tests.
+ */
+async function resolveReplyToCorrelation(supabase, value) {
+  if (!value) return null;
+  let row = null;
+  try {
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, payload')
+      .eq('id', value)
+      .maybeSingle();
+    row = data || null;
+  } catch { row = null; /* not a row id (or lookup failed) -> treat as correlation */ }
+  if (row) {
+    const corr = row.payload && row.payload.correlation_id;
+    if (!corr) {
+      const e = new Error(`row ${value} carries no payload.correlation_id (not replyable)`);
+      e.code = 'REPLY_TO_NOT_REPLYABLE';
+      throw e;
+    }
+    return corr;
+  }
+  return value;
 }
 
 async function snapshotSender(supabase, sessionId) {
@@ -145,7 +184,7 @@ async function main() {
   const argv = process.argv.slice(2);
   const mode = argv[0];
   if (mode !== 'send' && mode !== 'request' && mode !== 'replies') {
-    console.error('Usage: node scripts/adam-advisory.cjs send "<body>"  |  request "<question>" [--timeout <ms>]  |  replies');
+    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>]  |  request "<question>" [--timeout <ms>]  |  replies');
     process.exit(2);
   }
 
@@ -164,7 +203,12 @@ async function main() {
 
   const tIdx = argv.indexOf('--timeout');
   const timeoutMs = tIdx >= 0 ? Number(argv[tIdx + 1]) || 30000 : 30000;
-  const body = argv.slice(1).filter((a, i) => !(a === '--timeout' || argv[i] === '--timeout')).join(' ').trim();
+  // FR-1 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): `send --reply-to <correlation_or_row_id>`
+  // — answer an inbound coordinator_request, echoing its correlation (resolved below).
+  const rIdx = argv.indexOf('--reply-to');
+  const replyToArg = rIdx >= 0 ? argv[rIdx + 1] || null : null;
+  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1].filter(i => i >= 0));
+  const body = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
   if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
 
   const coordinatorId = await getActiveCoordinatorId(supabase);
@@ -180,9 +224,16 @@ async function main() {
   // sets expects_reply (it synchronously awaits).
   const correlationId = crypto.randomUUID();
   const expectsReply = mode === 'request';
+  // FR-1 (COORD-ADAM-COMMS-RESILIENT): resolve --reply-to (row id OR correlation) to the
+  // correlation to echo. Send-mode only; a hard failure here is surfaced, not swallowed.
+  let replyTo = null;
+  if (replyToArg && mode === 'send') {
+    try { replyTo = await resolveReplyToCorrelation(supabase, replyToArg); }
+    catch (e) { console.error(`ERROR: --reply-to ${replyToArg} — ${e.message}`); process.exit(2); }
+  }
   // FR-1: scope-tag the advisory from the sending repo (reuse-first, fail-soft).
   const { scopeKey, reuseClass, appliesToScopes } = await resolveScopeForSend(supabase, process.cwd());
-  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes });
+  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo });
   const subject = `[ADAM_ADVISORY] ${payload.body.slice(0, 80)}`;
   const expiresAt = new Date(Date.now() + (mode === 'request' ? timeoutMs + 5 * 60_000 : 24 * 60 * 60_000)).toISOString();
 
@@ -208,7 +259,8 @@ async function main() {
   console.log('✓ Adam advisory sent');
   console.log('  advisory_id:', inserted.id);
   console.log('  target:', target);
-  console.log('  correlation_id:', correlationId, '(replyable)');
+  console.log('  correlation_id:', payload.correlation_id, replyTo ? '(echoed from --reply-to)' : '(replyable)');
+  if (replyTo) console.log('  reply_to:', replyTo);
   console.log('  callsign:', senderCallsign || '(none)');
 
   if (mode === 'request') {
@@ -221,7 +273,7 @@ async function main() {
   }
 }
 
-module.exports = { buildAdvisoryPayload, resolveScopeForSend, drainReplies };
+module.exports = { buildAdvisoryPayload, resolveScopeForSend, resolveReplyToCorrelation, drainReplies };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -105,6 +105,38 @@ async function main() {
   } catch (e) {
     console.log('[HOURLY-REVIEW] Adam reminder skipped (non-fatal): ' + e.message);
   }
+
+  // FR-2 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): hourly UNDELIVERED-receipt check.
+  // Surfaces this coordinator's outbound rows sitting UNREAD at a LIVE target (read_at =
+  // DELIVERED; the live 35-min-unread-GO incident class). Read-only + fail-open.
+  try {
+    const myId = process.env.CLAUDE_SESSION_ID;
+    if (myId) {
+      const { findUndelivered } = require('../lib/coordinator/receipts.cjs');
+      const sinceIso = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+      const { data: outbound } = await sb.from('session_coordination')
+        .select('id, target_session, message_type, subject, payload, created_at, read_at')
+        .eq('sender_session', myId)
+        .is('read_at', null)
+        .gte('created_at', sinceIso)
+        .limit(100);
+      const { data: sessions } = await sb.from('claude_sessions')
+        .select('session_id, heartbeat_at')
+        .gte('heartbeat_at', new Date(Date.now() - 15 * 60 * 1000).toISOString())
+        .limit(200);
+      const undelivered = findUndelivered(outbound || [], sessions || []);
+      if (undelivered.length > 0) {
+        console.log('\n[HOURLY-REVIEW] UNDELIVERED OUTBOUND — ' + undelivered.length + ' row(s) unread at a LIVE target (re-send or nudge):');
+        undelivered.slice(0, 10).forEach(function (r) {
+          const kind = (r.payload && r.payload.kind) || r.message_type || '?';
+          console.log('  • [' + String(r.id).slice(0, 8) + '] → ' + String(r.target_session).slice(0, 8)
+            + ' | ' + kind + ' | unread ' + Math.floor(r.ageMs / 60000) + 'm | ' + (r.subject || '').slice(0, 40));
+        });
+      }
+    }
+  } catch (e) {
+    console.log('[HOURLY-REVIEW] undelivered-receipt check skipped (non-fatal): ' + e.message);
+  }
 }
 
 main().catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });

--- a/scripts/coordinator-reply.cjs
+++ b/scripts/coordinator-reply.cjs
@@ -25,10 +25,15 @@ const { redact, BODY_HARD_CAP } = require('./worker-signal.cjs');
 const REPLY_DEFAULT_TTL_MS = 60 * 60_000;
 
 // Pure + exported (TS): the exact reply payload written to session_coordination.payload.
+// FR-1 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): echo the correlation under BOTH keys
+// (reply_to AND correlation_id) so any await matcher — legacy (reply_to-only) or forgiving
+// (either key) — pairs the reply with its request. Live 7d evidence: 158/166
+// coordinator_reply rows lacked reply_to and were never matched by an await.
 function buildReplyPayload({ correlationId, body, coordinatorSession }) {
   const payload = {
     kind: 'coordinator_reply',
     reply_to: correlationId,
+    correlation_id: correlationId,
     sender: coordinatorSession || null
   };
   if (body) payload.body = redact(String(body)).slice(0, BODY_HARD_CAP);

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1206,6 +1206,103 @@ async function printAdamInbox() {
   console.log('');
 }
 
+// ── Section: Undelivered outbound + dead letters (FR-2/FR-4, SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001) ──
+// Receipt contract: read_at = DELIVERED, payload.actioned_at / acknowledged_at = ACTIONED.
+// This section closes the SENDER-side gap: outbound rows sitting UNREAD at a LIVE target
+// (live: GO messages sat unread 24-29 min while Adam was heartbeat-alive). Read-only —
+// stamps NOTHING (stamping read_at here would forge a DELIVERED receipt).
+async function printUndeliveredOutbound() {
+  const { findUndelivered } = require('../lib/coordinator/receipts.cjs');
+
+  console.log('UNDELIVERED OUTBOUND');
+  console.log('─'.repeat(72));
+
+  const coordinatorId = await _getActiveCoordinatorIdForInbox(supabase);
+  if (!coordinatorId) {
+    console.log('  (no active coordinator detected — run /coordinator start first)');
+    console.log('');
+    return;
+  }
+
+  const sinceIso = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+  const { data: outbound, error } = await supabase
+    .from('session_coordination')
+    .select('id, target_session, message_type, subject, payload, created_at, read_at')
+    .eq('sender_session', coordinatorId)
+    .is('read_at', null)
+    .gte('created_at', sinceIso)
+    .order('created_at', { ascending: true })
+    .limit(100);
+  if (error) {
+    console.log('  (outbound query failed: ' + error.message + ')');
+    console.log('');
+    return;
+  }
+
+  const { data: sessions } = await supabase
+    .from('claude_sessions')
+    .select('session_id, heartbeat_at')
+    .gte('heartbeat_at', new Date(Date.now() - 15 * 60 * 1000).toISOString())
+    .limit(200);
+
+  const undelivered = findUndelivered(outbound, sessions || []);
+  if (undelivered.length === 0) {
+    console.log('  (no undelivered outbound rows at live targets)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + undelivered.length + ' outbound row(s) UNREAD at a LIVE target — consider re-sending or nudging:');
+  for (const r of undelivered) {
+    const kind = (r.payload && r.payload.kind) || r.message_type || '?';
+    const ageMin = Math.floor(r.ageMs / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    console.log('  • [' + String(r.id).slice(0, 8) + '] → ' + String(r.target_session).slice(0, 8)
+      + ' | ' + kind + ' | unread ' + ageStr + ' | ' + (r.subject || '').slice(0, 40));
+  }
+  console.log('');
+}
+
+// FR-4 surfacing: rows the stale-session sweep dead-lettered (payload.dead_letter=true)
+// in the last 24h — undelivered traffic no longer vanishes tracelessly; the coordinator
+// can re-send to the successor session. Read-only.
+async function printDeadLetters() {
+  const { selectRecentDeadLetters } = require('../lib/coordinator/receipts.cjs');
+
+  console.log('DEAD-LETTERED (24h)');
+  console.log('─'.repeat(72));
+
+  const sinceIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: rows, error } = await supabase
+    .from('session_coordination')
+    .select('id, target_session, message_type, subject, payload, created_at')
+    .eq('payload->>dead_letter', 'true')
+    .gte('created_at', sinceIso)
+    .order('created_at', { ascending: false })
+    .limit(50);
+  if (error) {
+    console.log('  (dead-letter query failed: ' + error.message + ')');
+    console.log('');
+    return;
+  }
+
+  const recent = selectRecentDeadLetters(rows || []);
+  if (recent.length === 0) {
+    console.log('  (no dead-lettered coordination rows in the last 24h)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + recent.length + ' row(s) dead-lettered (target dead/gone) — re-send if still relevant:');
+  for (const r of recent) {
+    const kind = (r.payload && r.payload.kind) || r.message_type || '?';
+    const orig = (r.payload && r.payload.original_target) || r.target_session || '?';
+    console.log('  • [' + String(r.id).slice(0, 8) + '] was → ' + String(orig).slice(0, 8)
+      + ' | ' + kind + ' | ' + (r.subject || '').slice(0, 44));
+  }
+  console.log('');
+}
+
 // ── Section: Feedback work-store (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001) ──
 // READ-ONLY / additive: surfaces the feedback table (untriaged feedback + harness
 // backlog) on the coordinator single-pane view so pending feedback work is never
@@ -1304,7 +1401,12 @@ async function main() {
     forecast:      async () => await printForecast(d),
     predictions:   async () => await printPredictions(d),
     drain:         () => printDrainAgents(d),
-    inbox:         async () => await printInbox(),
+    inbox:         async () => {
+      await printInbox();
+      // FR-2/FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): sender-side receipts.
+      await printUndeliveredOutbound();
+      await printDeadLetters();
+    },
     adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
     feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
@@ -1319,6 +1421,8 @@ async function main() {
       printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
       await printInbox(); // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a
+      await printUndeliveredOutbound(); // FR-2 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
+      await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
       await printFeedback(d); // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001 — feedback work-store
       await printCoaching(d);

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -78,6 +78,16 @@ const CHECK_INTERVAL_MS = parseInt(process.env.COORDINATION_CHECK_INTERVAL_MS, 1
 const HEARTBEAT_INTERVAL_MS = 30_000; // Update heartbeat every 30 seconds
 const ACTIONABLE_TYPES = ['WORK_ASSIGNMENT', 'CLAIM_RELEASED', 'CLAIM_REMINDER'];
 
+// FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): the canonical directive-kind
+// allowlist lives in lib/fleet/worker-status.cjs — IMPORTED, never duplicated (the
+// QF-20260610-545 lesson: classify the row KIND, not the sender). Guarded require:
+// if the lib is unavailable the list is empty and behavior degrades to today's
+// drain (fail-toward-current), never a hook crash.
+let DIRECTIVE_KINDS = [];
+try {
+  ({ DIRECTIVE_KINDS } = require(path.resolve(__dirname, '../../lib/fleet/worker-status.cjs')));
+} catch { /* fail-open: ack-withholding disabled, hook still runs */ }
+
 // SD-LEO-FIX-FIX-COORDINATION-INBOX-001: pure, per-message inbox decision.
 // Returns { skip, markRead, markAck }. The bug this fixes: this PostToolUse hook (fires on
 // every tool call in every session) stamped read_at on poll for actionable rows AND only
@@ -122,6 +132,14 @@ function classifyInboxMessage(msg, opts = {}) {
   // genuinely actions them (worker-checkin ackMessage stamps both on claim).
   if (isIdle && ACTIONABLE_TYPES.includes(msg && msg.message_type)) {
     return { skip: false, markRead: false, markAck: false };
+  }
+  // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): DIRECTIVE kinds never receive
+  // acknowledged_at from a poll, for ANY role/sender — read-only drain (read_at = DELIVERED,
+  // so they don't re-render forever; ACK is withheld so delivered vs actioned stays
+  // distinguishable; genuine actioning stamps acknowledged_at / payload.actioned_at later).
+  // Kind-allowlist shape per QF-20260610-545 — never a sender_type allow/denylist.
+  if (p.kind && DIRECTIVE_KINDS.includes(p.kind)) {
+    return { skip: false, markRead: true, markAck: false };
   }
   // Default — a pure notification with no follow-up action; drain on display (legacy behavior).
   return { skip: false, markRead: true, markAck: true };

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1555,37 +1555,37 @@ async function main() {
   // Clean up expired messages first
   try { await supabase.rpc('cleanup_expired_coordination'); } catch { /* ignore */ }
 
-  // FIX #3: Clean up coordination messages targeting dead/stale sessions
-  // These accumulate because target sessions exit without reading them
-  // QF-20260426-SWEEP-MSG-NUKE: previously also deleted unexpired broadcasts
-  // (target_session='broadcast' is never in classified-set) and COACHING messages
-  // to STALE-but-claim-holding sessions (workers read on next sd-start chained run).
-  // Now: only delete unread messages where (a) target is a real session_id (UUID-shaped),
-  // (b) target is DEAD (claim released), and (c) message is past its expires_at if set.
+  // FIX #3 — REWORKED by FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): coordination
+  // messages targeting dead/gone sessions are DEAD-LETTERED, never hard-DELETEd. The old
+  // delete made undelivered traffic vanish tracelessly (the 'CLEANUP: deleted N unread...'
+  // path). Now (mirroring the :WORK_ASSIGNMENT read_at-drain precedent below): stamp
+  // payload.dead_letter=true + dead_letter_at/reason/original_target, stamp read_at (drops
+  // the row out of every unread selector), and backfill expires_at=now+7d when NULL so the
+  // cleanup_expired_coordination RPC reaps the audit trail after a week. Surfaced by the
+  // coordinator inbox 'DEAD-LETTERED (24h)' section (scripts/fleet-dashboard.cjs).
+  // Eligibility is unchanged from QF-20260426-SWEEP-MSG-NUKE: (a) UUID-shaped target,
+  // (b) target DEAD or gone, (c) past expires_at if set. Selection is the pure
+  // planDeadLetters() (exported for tests).
   const allSessionIds = new Set(classified.map(s => s.session_id));
   const deadIds = new Set(classified.filter(s => s.status === 'DEAD').map(s => s.session_id));
   const nowMs = Date.now();
-  const isUuidLike = (s) => typeof s === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(s);
-  const isExpired = (m) => !m.expires_at || new Date(m.expires_at).getTime() <= nowMs;
 
   const { data: unreadMsgs } = await supabase
     .from('session_coordination')
-    .select('id, target_session, message_type, expires_at')
+    .select('id, target_session, message_type, payload, expires_at')
     .is('acknowledged_at', null)
     .is('read_at', null);
 
-  const allDeadMsgIds = (unreadMsgs || [])
-    .filter(m => isUuidLike(m.target_session))
-    .filter(m => !allSessionIds.has(m.target_session) || deadIds.has(m.target_session))
-    .filter(isExpired)
-    .map(m => m.id);
-  if (allDeadMsgIds.length > 0) {
-    // Delete in batches of 50
-    for (let i = 0; i < allDeadMsgIds.length; i += 50) {
-      const batch = allDeadMsgIds.slice(i, i + 50);
-      await supabase.from('session_coordination').delete().in('id', batch);
+  const deadLetterPlan = planDeadLetters(unreadMsgs, { allSessionIds, deadIds }, nowMs);
+  if (deadLetterPlan.length > 0) {
+    // Per-row UPDATE (payload merge differs per row); chunked pacing of 50 retained.
+    for (let i = 0; i < deadLetterPlan.length; i += 50) {
+      const batch = deadLetterPlan.slice(i, i + 50);
+      for (const dl of batch) {
+        await supabase.from('session_coordination').update(dl.update).eq('id', dl.id);
+      }
     }
-    actions.push('CLEANUP: deleted ' + allDeadMsgIds.length + ' unread coordination messages targeting dead/gone sessions');
+    actions.push('CLEANUP: dead-lettered ' + deadLetterPlan.length + ' unread coordination messages targeting dead/gone sessions (payload.dead_letter=true, audit retained)');
   }
 
   // FR-1 (SD-LEO-FIX-STALE-SESSION-SWEEP-001): drain WORK_ASSIGNMENT rows whose target SD/QF has
@@ -2105,6 +2105,42 @@ async function main() {
   return { actions, warnings, collisions: collisionsDetected };
 }
 
+// FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001) — pure dead-letter planner.
+// Replaces the hard-DELETE of unread rows targeting dead/gone sessions: the same
+// eligibility predicates (UUID-shaped target; target DEAD or absent from the classified
+// set; past expires_at when set — a NULL expires_at counts as eligible, matching the old
+// behavior), but the output is an UPDATE plan, never a delete:
+//   read_at        = drain marker (drops out of every unread selector; audit preserved)
+//   payload        = merged with { dead_letter, dead_letter_at, dead_letter_reason,
+//                    original_target } so the coordinator audit/inbox can surface + re-send
+//   expires_at     = backfilled to now+DEAD_LETTER_TTL_MS ONLY when NULL, so the
+//                    cleanup_expired_coordination RPC reaps the audit trail after 7d
+// Idempotent: rows already stamped payload.dead_letter are excluded. ZERO IO.
+const DEAD_LETTER_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+function planDeadLetters(unreadMsgs, { allSessionIds, deadIds }, nowMs) {
+  const isUuidLike = (s) => typeof s === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(s);
+  const nowIso = new Date(nowMs).toISOString();
+  return (unreadMsgs || [])
+    .filter(m => isUuidLike(m.target_session))
+    .filter(m => !allSessionIds.has(m.target_session) || deadIds.has(m.target_session))
+    .filter(m => !m.expires_at || new Date(m.expires_at).getTime() <= nowMs)
+    .filter(m => !(m.payload && m.payload.dead_letter === true))
+    .map(m => ({
+      id: m.id,
+      update: {
+        read_at: nowIso,
+        ...(m.expires_at ? {} : { expires_at: new Date(nowMs + DEAD_LETTER_TTL_MS).toISOString() }),
+        payload: {
+          ...(m.payload || {}),
+          dead_letter: true,
+          dead_letter_at: nowIso,
+          dead_letter_reason: 'target_dead',
+          original_target: m.target_session,
+        },
+      },
+    }));
+}
+
 // SD-FDBK-INFRA-CROSS-SESSION-CONFLICTION-001 / FR-2: guard auto-run so the pure
 // collision functions can be imported by unit tests without main() hitting the DB.
 if (require.main === module) {
@@ -2113,6 +2149,10 @@ if (require.main === module) {
     process.exit(1);
   });
 }
+
+// FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001) exports — pure dead-letter planner.
+module.exports.planDeadLetters = planDeadLetters;
+module.exports.DEAD_LETTER_TTL_MS = DEAD_LETTER_TTL_MS;
 
 // FR-2 exports — pure collision detector + intent loader (unit-testable in isolation).
 module.exports.detectCrossSessionCollisions = detectCrossSessionCollisions;

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -137,9 +137,20 @@ async function registerRollCall(sb, { sessionId, coordinatorId, callsign, mySd }
   }
 }
 
-async function ackMessage(sb, id) {
+async function ackMessage(sb, id, opts = {}) {
   try {
     const now = new Date().toISOString();
+    // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): an ADAM-role session must never
+    // auto-ack a DIRECTIVE kind from the checkin path — stamp read_at only (DELIVERED) and
+    // leave acknowledged_at for genuine Adam processing. Kind-allowlist (imported
+    // ws.DIRECTIVE_KINDS, never duplicated) per the QF-20260610-545 lesson; WORK_ASSIGNMENT
+    // message_type counts as a directive even without payload.kind.
+    const { role = null, kind = null, messageType = null } = opts;
+    const isDirective = (kind && ws.DIRECTIVE_KINDS.includes(kind)) || messageType === 'WORK_ASSIGNMENT';
+    if (role === 'adam' && isDirective) {
+      await sb.from('session_coordination').update({ read_at: now }).eq('id', id);
+      return;
+    }
     await sb.from('session_coordination').update({ read_at: now, acknowledged_at: now }).eq('id', id);
   } catch { /* best-effort */ }
 }
@@ -600,12 +611,15 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   try { coordinatorId = await getCoordinator(sb); } catch { coordinatorId = null; }
 
   // 2. confirm callsign + current claim
-  let callsign = null, mySd = null;
+  let callsign = null, mySd = null, sessionRole = null;
   try {
     const { data } = await sb.from('claude_sessions').select('metadata, sd_key').eq('session_id', sessionId).maybeSingle();
     if (data) {
       callsign = (data.metadata && (data.metadata.fleet_identity?.callsign || data.metadata.callsign)) || null;
       mySd = data.sd_key || null;
+      // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): role feeds the ackMessage
+      // Adam-directive guard (Adam sessions never auto-ack directive kinds via checkin).
+      sessionRole = (data.metadata && data.metadata.role) || null;
     }
   } catch { /* fail-open */ }
 
@@ -665,12 +679,12 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
         if (tgt && ['completed', 'cancelled', 'deferred'].includes(tgt.status)) terminalStatus = tgt.status;
       } catch { /* fail-open: leave terminalStatus null, attempt the claim below */ }
       if (terminalStatus) {
-        await ackMessage(sb, assignment.id);
+        await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
         base.stale_assignment_purged = { sd: sdKey, status: terminalStatus };
       } else {
         const claimed = await tryClaim(sb, sdKey, sessionId);
         if (claimed.ok) {
-          await ackMessage(sb, assignment.id);
+          await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
           return { ...base, action: 'claimed_assignment', sd: sdKey, message: `Claimed assigned ${sdKey} via claim_sd. Run: node scripts/sd-start.js ${sdKey}` };
         }
         // could not claim the assigned SD -> fall through to self-claim
@@ -777,7 +791,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSdInFlight, selfHealStaleClaim, orderByRankMap, sortByDispatchRank, DISPATCH_RANK_TTL_MS, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
+module.exports = { extractSdFromAssignment, tryClaim, registerRollCall, ackMessage, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSdInFlight, selfHealStaleClaim, orderByRankMap, sortByDispatchRank, DISPATCH_RANK_TTL_MS, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-signal.cjs
+++ b/scripts/worker-signal.cjs
@@ -281,11 +281,17 @@ async function awaitCoordinatorReply(supabase, opts = {}) {
   for (;;) {
     let row = null;
     try {
+      // FR-1 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): FORGIVING matcher — accept the
+      // correlation echoed as payload.reply_to (canonical) OR payload.correlation_id
+      // (echo convention). Kind-filtered to reply-capable kinds (coordinator_reply, or an
+      // adam_advisory carrying a --reply-to echo) so an unrelated row reusing the
+      // correlation — e.g. a relayed copy of the original request — never satisfies the await.
       const { data } = await supabase
         .from('session_coordination')
         .select('id, payload, body, sender_session, created_at')
         .eq('target_session', sessionId)
-        .eq('payload->>reply_to', correlationId)
+        .or(`payload->>reply_to.eq.${correlationId},payload->>correlation_id.eq.${correlationId}`)
+        .in('payload->>kind', ['coordinator_reply', 'adam_advisory'])
         .order('created_at', { ascending: false })
         .limit(1);
       row = Array.isArray(data) && data.length ? data[0] : null;

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -1,0 +1,371 @@
+/**
+ * Unit tests — SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
+ * Coordinator↔Adam comms resilience: 4 FRs matching the 4 live-confirmed defects.
+ *   FR-1 correlation echo (dual-key replies + forgiving await matcher + --reply-to echo)
+ *   FR-2 receipt contract (findUndelivered / selectRecentDeadLetters pure selectors)
+ *   FR-3 directive-kind no-auto-ack allowlist (DIRECTIVE_KINDS imported, never duplicated)
+ *   FR-4 dead-letter instead of delete (planDeadLetters pure planner + no-delete source pin)
+ * Mocked clients + source pins only — no live DB writes.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+const require = createRequire(import.meta.url);
+
+const ROOT = path.resolve(__dirname, '../..');
+const src = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+const ws = require('../../lib/fleet/worker-status.cjs');
+const { classifyInboxMessage } = require('../../scripts/hooks/coordination-inbox.cjs');
+const { ackMessage } = require('../../scripts/worker-checkin.cjs');
+const { buildReplyPayload } = require('../../scripts/coordinator-reply.cjs');
+const { awaitCoordinatorReply, buildRequestPayload } = require('../../scripts/worker-signal.cjs');
+const { buildAdvisoryPayload, resolveReplyToCorrelation } = require('../../scripts/adam-advisory.cjs');
+const sweep = require('../../scripts/stale-session-sweep.cjs');
+const receipts = require('../../lib/coordinator/receipts.cjs');
+
+const NOW = Date.parse('2026-06-10T12:00:00Z');
+const MIN = 60_000;
+const iso = (ms) => new Date(ms).toISOString();
+const UUID_A = '11111111-2222-4333-8444-555555555555';
+const UUID_B = '99999999-8888-4777-8666-555555555555';
+
+// ───────────────────────────── FR-3 — directive-kind ACK withholding ─────────────────────────────
+
+describe('FR-3: DIRECTIVE_KINDS allowlist', () => {
+  it('exports the exact frozen directive-kind list', () => {
+    expect(ws.DIRECTIVE_KINDS).toEqual([
+      'coordinator_request',
+      'work_assignment',
+      'adam_action_required',
+      'coordinator_reminder',
+      'coordinator_to_adam',
+    ]);
+    expect(Object.isFrozen(ws.DIRECTIVE_KINDS)).toBe(true);
+  });
+
+  it('SOURCE PIN: every consumer IMPORTS the list — never duplicates it', () => {
+    const consumers = [
+      'scripts/hooks/coordination-inbox.cjs',
+      'scripts/worker-checkin.cjs',
+    ];
+    for (const file of consumers) {
+      const text = src(file);
+      expect(text, `${file} must reference DIRECTIVE_KINDS`).toMatch(/DIRECTIVE_KINDS/);
+      expect(text, `${file} must require lib/fleet/worker-status.cjs`).toMatch(/lib[/\\]fleet[/\\]worker-status\.cjs/);
+      // duplication tripwire: no consumer may carry the kind literals themselves
+      expect(text, `${file} must not duplicate the kind literals`).not.toMatch(/adam_action_required/);
+    }
+    // the canonical definition lives in exactly one place
+    expect(src('lib/fleet/worker-status.cjs')).toMatch(/adam_action_required/);
+  });
+
+  it('kinds × roles matrix: NO directive kind ever gets markAck from the poll classifier', () => {
+    const types = ['INFO', 'COACHING', 'WORK_ASSIGNMENT', 'PRIORITY_CHANGE'];
+    for (const kind of ws.DIRECTIVE_KINDS) {
+      for (const message_type of types) {
+        for (const sender_type of ['chairman', 'coordinator', 'orchestrator', 'worker', undefined]) {
+          for (const amAdam of [true, false]) {
+            for (const isIdle of [true, false]) {
+              for (const twoWayOn of [true, false]) {
+                const v = classifyInboxMessage(
+                  { message_type, payload: { kind }, sender_type },
+                  { isIdle, twoWayOn, amAdam }
+                );
+                if (!v.skip) {
+                  expect(v.markAck, `kind=${kind} type=${message_type} sender=${sender_type} amAdam=${amAdam}`).toBe(false);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it('directive kinds get read-only drain for non-Adam sessions (markRead, never markAck)', () => {
+    const v = classifyInboxMessage(
+      { message_type: 'INFO', payload: { kind: 'coordinator_request' }, sender_type: 'coordinator' },
+      { amAdam: false }
+    );
+    expect(v).toEqual({ skip: false, markRead: true, markAck: false });
+  });
+
+  it('pure notification kinds keep the legacy read+ack drain (byte-identical)', () => {
+    expect(classifyInboxMessage({ message_type: 'INFO', payload: {} }, { amAdam: false }))
+      .toEqual({ skip: false, markRead: true, markAck: true });
+    expect(classifyInboxMessage({ message_type: 'INFO', payload: { kind: 'roll_call' } }, { amAdam: false }))
+      .toEqual({ skip: false, markRead: true, markAck: true });
+  });
+});
+
+describe('FR-3: worker-checkin ackMessage Adam-role guard', () => {
+  function mockSb(updates) {
+    return {
+      from() {
+        return {
+          update(u) {
+            updates.push(u);
+            return { eq: async () => ({}) };
+          },
+        };
+      },
+    };
+  }
+
+  it('adam role + directive kind → read_at ONLY (no acknowledged_at)', async () => {
+    const updates = [];
+    await ackMessage(mockSb(updates), 'id-1', { role: 'adam', kind: 'coordinator_request' });
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toHaveProperty('read_at');
+    expect(updates[0]).not.toHaveProperty('acknowledged_at');
+  });
+
+  it('adam role + WORK_ASSIGNMENT message_type (no payload.kind) → read_at ONLY', async () => {
+    const updates = [];
+    await ackMessage(mockSb(updates), 'id-2', { role: 'adam', kind: null, messageType: 'WORK_ASSIGNMENT' });
+    expect(updates[0]).toHaveProperty('read_at');
+    expect(updates[0]).not.toHaveProperty('acknowledged_at');
+  });
+
+  it('worker (role null) genuine claim still stamps BOTH (legacy behavior)', async () => {
+    const updates = [];
+    await ackMessage(mockSb(updates), 'id-3', { role: null, kind: 'work_assignment', messageType: 'WORK_ASSIGNMENT' });
+    expect(updates[0]).toHaveProperty('read_at');
+    expect(updates[0]).toHaveProperty('acknowledged_at');
+  });
+
+  it('adam role + NON-directive kind still stamps both', async () => {
+    const updates = [];
+    await ackMessage(mockSb(updates), 'id-4', { role: 'adam', kind: 'roll_call' });
+    expect(updates[0]).toHaveProperty('acknowledged_at');
+  });
+
+  it('no opts (legacy call shape) stamps both — backward compatible', async () => {
+    const updates = [];
+    await ackMessage(mockSb(updates), 'id-5');
+    expect(updates[0]).toHaveProperty('read_at');
+    expect(updates[0]).toHaveProperty('acknowledged_at');
+  });
+});
+
+// ───────────────────────────── FR-1 — correlation echo ─────────────────────────────
+
+describe('FR-1: dual-key reply payload + forgiving await matcher', () => {
+  it('buildReplyPayload echoes the correlation under BOTH reply_to and correlation_id', () => {
+    const p = buildReplyPayload({ correlationId: 'corr-123', body: 'hi', coordinatorSession: UUID_A });
+    expect(p.kind).toBe('coordinator_reply');
+    expect(p.reply_to).toBe('corr-123');
+    expect(p.correlation_id).toBe('corr-123');
+    expect(p.signal_type).toBeUndefined();
+    expect(p.intent_action).toBeUndefined();
+  });
+
+  function mockAwaitSb(replyRow, calls) {
+    const chain = {
+      from(t) { calls.push(['from', t]); return chain; },
+      select(c) { calls.push(['select', c]); return chain; },
+      eq(k, v) { calls.push(['eq', k, v]); return chain; },
+      or(expr) { calls.push(['or', expr]); return chain; },
+      in(k, v) { calls.push(['in', k, v]); return chain; },
+      order() { return chain; },
+      limit() { return Promise.resolve({ data: replyRow ? [replyRow] : [] }); },
+    };
+    return chain;
+  }
+
+  it('awaitCoordinatorReply matches on EITHER reply_to OR correlation_id, kind-filtered', async () => {
+    const calls = [];
+    const reply = { id: 'r1', payload: { kind: 'coordinator_reply', correlation_id: 'C-1' } };
+    const res = await awaitCoordinatorReply(mockAwaitSb(reply, calls), {
+      sessionId: UUID_A, correlationId: 'C-1', timeoutMs: 50, pollMs: 1, sleep: async () => {},
+    });
+    expect(res.ok).toBe(true);
+    expect(res.reply.id).toBe('r1');
+    const orCall = calls.find((c) => c[0] === 'or');
+    expect(orCall[1]).toContain('payload->>reply_to.eq.C-1');
+    expect(orCall[1]).toContain('payload->>correlation_id.eq.C-1');
+    const inCall = calls.find((c) => c[0] === 'in');
+    expect(inCall[1]).toBe('payload->>kind');
+    expect(inCall[2]).toEqual(['coordinator_reply', 'adam_advisory']);
+  });
+
+  it('awaitCoordinatorReply times out cleanly when nothing matches', async () => {
+    const res = await awaitCoordinatorReply(mockAwaitSb(null, []), {
+      sessionId: UUID_A, correlationId: 'C-2', timeoutMs: 5, pollMs: 1, sleep: async () => {},
+    });
+    expect(res).toEqual({ ok: false, reply: null, timedOut: true });
+  });
+
+  it('request payload still carries correlation_id + expects_reply (unchanged contract)', () => {
+    const p = buildRequestPayload({ correlationId: 'C-3', body: 'q', senderCallsign: 'alpha' });
+    expect(p.kind).toBe('coordinator_request');
+    expect(p.correlation_id).toBe('C-3');
+    expect(p.expects_reply).toBe(true);
+  });
+});
+
+describe('FR-1: adam-advisory --reply-to echo', () => {
+  it('buildAdvisoryPayload({replyTo}) echoes under BOTH keys, overriding the fresh correlation', () => {
+    const p = buildAdvisoryPayload({ body: 'answer', correlationId: 'fresh-uuid', replyTo: 'inbound-corr' });
+    expect(p.kind).toBe('adam_advisory');
+    expect(p.reply_to).toBe('inbound-corr');
+    expect(p.correlation_id).toBe('inbound-corr'); // echo wins — a reply correlates to its request
+  });
+
+  it('without replyTo the payload is unchanged (fresh correlation, no reply_to)', () => {
+    const p = buildAdvisoryPayload({ body: 'fyi', correlationId: 'fresh-uuid' });
+    expect(p.correlation_id).toBe('fresh-uuid');
+    expect(p.reply_to).toBeUndefined();
+  });
+
+  function mockRowSb(row) {
+    return {
+      from() {
+        return {
+          select() {
+            return { eq() { return { maybeSingle: async () => ({ data: row }) }; } };
+          },
+        };
+      },
+    };
+  }
+
+  it('resolveReplyToCorrelation: row id → echoes the ROW\'s correlation_id', async () => {
+    const corr = await resolveReplyToCorrelation(mockRowSb({ id: 'row-1', payload: { correlation_id: 'C-9' } }), 'row-1');
+    expect(corr).toBe('C-9');
+  });
+
+  it('resolveReplyToCorrelation: no matching row → value treated as the correlation itself', async () => {
+    const corr = await resolveReplyToCorrelation(mockRowSb(null), 'bare-corr');
+    expect(corr).toBe('bare-corr');
+  });
+
+  it('resolveReplyToCorrelation: matching row WITHOUT correlation_id → throws REPLY_TO_NOT_REPLYABLE', async () => {
+    await expect(resolveReplyToCorrelation(mockRowSb({ id: 'row-2', payload: {} }), 'row-2'))
+      .rejects.toMatchObject({ code: 'REPLY_TO_NOT_REPLYABLE' });
+  });
+});
+
+// ───────────────────────────── FR-4 — dead-letter instead of delete ─────────────────────────────
+
+describe('FR-4: planDeadLetters (pure)', () => {
+  const sets = () => ({
+    allSessionIds: new Set([UUID_A]),     // UUID_A is known (alive unless in deadIds)
+    deadIds: new Set([UUID_B]),           // UUID_B classified DEAD
+  });
+  const row = (over = {}) => ({
+    id: 'm1', target_session: 'cccccccc-dddd-4eee-8fff-000000000000',
+    message_type: 'INFO', payload: { kind: 'coordinator_request', body: 'go' }, expires_at: null,
+    ...over,
+  });
+
+  it('eligible row (uuid target, gone, NULL expires) → dead-letter update, never a delete', () => {
+    const plan = sweep.planDeadLetters([row()], sets(), NOW);
+    expect(plan).toHaveLength(1);
+    const u = plan[0].update;
+    expect(u.read_at).toBe(iso(NOW));                       // drain marker
+    expect(u.expires_at).toBe(iso(NOW + sweep.DEAD_LETTER_TTL_MS)); // 7d backfill (was NULL)
+    expect(u.payload.dead_letter).toBe(true);
+    expect(u.payload.dead_letter_at).toBe(iso(NOW));
+    expect(u.payload.dead_letter_reason).toBe('target_dead');
+    expect(u.payload.original_target).toBe('cccccccc-dddd-4eee-8fff-000000000000');
+    expect(u.payload.kind).toBe('coordinator_request');     // original payload preserved
+    expect(u.payload.body).toBe('go');
+  });
+
+  it('row with a PAST expires_at keeps it (no backfill — only NULL is backfilled)', () => {
+    const plan = sweep.planDeadLetters([row({ expires_at: iso(NOW - MIN) })], sets(), NOW);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].update.expires_at).toBeUndefined();
+  });
+
+  it('exclusions: future-expiry, non-uuid target, LIVE target, already dead-lettered', () => {
+    const cases = [
+      row({ expires_at: iso(NOW + 60 * MIN) }),                          // not yet expired
+      row({ target_session: 'broadcast-coordinator' }),                  // not UUID-shaped
+      row({ target_session: UUID_A }),                                   // known + not dead
+      row({ payload: { dead_letter: true } }),                           // idempotency
+    ];
+    expect(sweep.planDeadLetters(cases, sets(), NOW)).toHaveLength(0);
+  });
+
+  it('a DEAD (classified) target IS dead-lettered even though it is in the classified set', () => {
+    expect(sweep.planDeadLetters([row({ target_session: UUID_B })], sets(), NOW)).toHaveLength(1);
+  });
+
+  it('SOURCE PIN: the dead/gone-session cleanup section contains NO .delete() on session_coordination', () => {
+    const text = src('scripts/stale-session-sweep.cjs');
+    const start = text.indexOf('FIX #3');
+    const end = text.indexOf('SD-LEO-FIX-STALE-SESSION-SWEEP-001', start); // next section AFTER FIX #3
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const section = text.slice(start, end);
+    expect(section).not.toContain('.delete()');
+    expect(section).toContain('planDeadLetters');
+  });
+});
+
+// ───────────────────────────── FR-2 — receipt contract ─────────────────────────────
+
+describe('FR-2: findUndelivered (pure)', () => {
+  const sessions = [
+    { session_id: UUID_A, heartbeat_at: iso(NOW - 2 * MIN) },   // live
+    { session_id: UUID_B, heartbeat_at: iso(NOW - 60 * MIN) },  // stale heartbeat
+  ];
+  const out = (over = {}) => ({
+    id: 'o1', target_session: UUID_A, read_at: null,
+    created_at: iso(NOW - 30 * MIN), payload: { kind: 'coordinator_request' }, subject: 'GO',
+    ...over,
+  });
+
+  it('flags an unread 30m-old row at a LIVE target, annotated with ageMs', () => {
+    const r = receipts.findUndelivered([out()], sessions, { now: NOW });
+    expect(r).toHaveLength(1);
+    expect(r[0].id).toBe('o1');
+    expect(r[0].ageMs).toBe(30 * MIN);
+  });
+
+  it('exclusions: already read, young, dead/stale target, unknown target, dead-lettered', () => {
+    const cases = [
+      out({ read_at: iso(NOW - MIN) }),                                  // delivered
+      out({ created_at: iso(NOW - 5 * MIN) }),                           // younger than 10m default
+      out({ target_session: UUID_B }),                                   // stale heartbeat — sweep's lane
+      out({ target_session: 'cccccccc-dddd-4eee-8fff-000000000000' }),   // not in sessions
+      out({ payload: { kind: 'coordinator_request', dead_letter: true } }), // dead-lettered
+    ];
+    expect(receipts.findUndelivered(cases, sessions, { now: NOW })).toHaveLength(0);
+  });
+
+  it('sorts oldest (largest age) first', () => {
+    const r = receipts.findUndelivered(
+      [out({ id: 'young', created_at: iso(NOW - 11 * MIN) }), out({ id: 'old', created_at: iso(NOW - 90 * MIN) })],
+      sessions, { now: NOW }
+    );
+    expect(r.map((x) => x.id)).toEqual(['old', 'young']);
+  });
+
+  it('thresholds are injectable (ageMs / heartbeatFreshMs)', () => {
+    const r = receipts.findUndelivered([out({ created_at: iso(NOW - 5 * MIN) })], sessions, { now: NOW, ageMs: 4 * MIN });
+    expect(r).toHaveLength(1);
+    const r2 = receipts.findUndelivered([out({ target_session: UUID_B })], sessions, { now: NOW, heartbeatFreshMs: 120 * MIN });
+    expect(r2).toHaveLength(1); // 60m-old heartbeat counts as live under a 120m window
+  });
+});
+
+describe('FR-2: selectRecentDeadLetters (pure)', () => {
+  const dl = (at, over = {}) => ({
+    id: 'd1', payload: { dead_letter: true, dead_letter_at: at, original_target: UUID_A }, ...over,
+  });
+
+  it('keeps rows dead-lettered within the 24h window, newest first; drops older + non-dead-letter rows', () => {
+    const r = receipts.selectRecentDeadLetters([
+      dl(iso(NOW - 60 * MIN), { id: 'recent' }),
+      dl(iso(NOW - 2 * MIN), { id: 'newest' }),
+      dl(iso(NOW - 48 * 60 * MIN), { id: 'too-old' }),
+      { id: 'not-dl', payload: { kind: 'coordinator_request' } },
+    ], { now: NOW });
+    expect(r.map((x) => x.id)).toEqual(['newest', 'recent']);
+  });
+});


### PR DESCRIPTION
## Summary

Coordinator↔Adam coordination messaging lost traffic 4 confirmed ways (live evidence: **95% of replies missing `reply_to`** — 158/166 over 7d; GO directives unread 24-29 min at a heartbeat-alive Adam with zero sender-side visibility; `read_at`==`acknowledged_at` on 23/23 stamped rows; the sweep hard-deleting unread rows to dead/gone targets — with the `!expires_at`-counts-as-expired footgun).

- **FR-3** structural no-auto-ack: frozen `DIRECTIVE_KINDS` exported beside `PAYLOAD_KINDS`; the inbox-hook drain returns `markAck:false` for any directive kind, any role/sender (drain-by-allowlist replaces the deny-by-sender shape that broke twice: b9c4946f, 43c2dee2); Adam-role checkin ack guard
- **FR-1** dual-key correlation echo: replies carry BOTH `reply_to` + `correlation_id`; forgiving await matcher (`.or` both keys + kind filter incl. Adam's `--reply-to` echo lane); `adam-advisory send --reply-to` echoes inbound correlations
- **FR-4** dead-letter, never delete: pure `planDeadLetters` + per-row UPDATE (`payload.dead_letter`/reason/original_target + `read_at` drain + 7d `expires_at` backfill), mirroring the WORK_ASSIGNMENT drain precedent; "DEAD-LETTERED (24h)" surfaced in the coordinator inbox
- **FR-2** uniform receipts: NEW `lib/coordinator/receipts.cjs` (`findUndelivered`: unread ≥10m at live target); "UNDELIVERED OUTBOUND" sections in fleet-dashboard inbox/all + hourly review; receipt contract (read=DELIVERED / `payload.actioned_at`=ACTIONED) documented in the comms protocol; "no hand-rolled inserts" rule added to coordinator.md

No new tables, no migrations, no flags.

## Verification

- NEW 29-test suite (kinds×roles matrix, import-not-duplicate source pins, ack-guard matrix, dual-key + matcher capture, `--reply-to` branches, dead-letter planner + no-`.delete()` pin, receipts matrices) — 29/29
- Existing comms estate 73/73 green (incl. the QF-545 exhaustive sweep); pre-commit smoke 15/15
- One defective pre-existing test stub fixed in-SD (mock lacked `.or`/`.in` → infinite loop under the new matcher; fix-breaks-stale-sibling class, commented)

Note: the inbox-hook change activates from the main tree on merge (`core.hooksPath`).

## PR Size

+848/−36 across 14 files: ~270 product LOC across 4 independent FRs (4-defect resilience cluster), remainder tests + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)