### PR TITLE
fix(SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001): payload-first tool-name guard so park signals actually write

### DIFF
--- a/scripts/hooks/__tests__/migration-execution-reminder.test.js
+++ b/scripts/hooks/__tests__/migration-execution-reminder.test.js
@@ -1,0 +1,77 @@
+// SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001 (class fix): the migration reminder
+// hook read tool_name/tool_input from CLAUDE_TOOL_* env vars the harness never sets
+// (RCA #2 2026-05-04) — dead since ship. Pins payload-first resolution with the env
+// vars ABSENT, plus the env fallback for manual invocations.
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+
+const HOOK_PATH = path.resolve(__dirname, '../migration-execution-reminder.cjs');
+
+function spawnHook(stdinPayload, env = {}) {
+  const { spawn } = require('node:child_process');
+  const spawnEnv = { ...process.env, ...env };
+  for (const k of ['CLAUDE_TOOL_NAME', 'CLAUDE_TOOL_INPUT', 'CLAUDE_TOOL_OUTPUT']) {
+    if (!(k in env)) delete spawnEnv[k];
+  }
+  const probe = spawn('node', [HOOK_PATH], { stdio: ['pipe', 'pipe', 'pipe'], env: spawnEnv });
+  if (stdinPayload === null) probe.stdin.end();
+  else probe.stdin.end(stdinPayload);
+  return new Promise((resolve) => {
+    let stdout = ''; let stderr = '';
+    probe.stdout.on('data', c => { stdout += c; });
+    probe.stderr.on('data', c => { stderr += c; });
+    probe.on('close', code => resolve({ stdout, stderr, code }));
+  });
+}
+
+const MIGRATION_WRITE = {
+  session_id: 'mig-payload-1',
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Write',
+  tool_input: {
+    file_path: 'database/migrations/20260611_test_migration.sql',
+    content: '-- SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001\nCREATE TABLE x();'
+  }
+};
+
+describe('MIG-PAYLOAD: harness-shaped invocation (env vars absent)', () => {
+  it('emits the reminder for a migration Write delivered via stdin payload', async () => {
+    const r = await spawnHook(JSON.stringify(MIGRATION_WRITE));
+    expect(r.stdout).toContain('MIGRATION FILE CREATED');
+    expect(r.stdout).toContain('20260611_test_migration.sql');
+    expect(r.code).toBe(0);
+  });
+
+  it('silent for a non-Write payload', async () => {
+    const r = await spawnHook(JSON.stringify({ ...MIGRATION_WRITE, tool_name: 'Bash' }));
+    expect(r.stdout).not.toContain('MIGRATION FILE CREATED');
+    expect(r.code).toBe(0);
+  });
+
+  it('silent for a Write to a non-migration path', async () => {
+    const r = await spawnHook(JSON.stringify({
+      ...MIGRATION_WRITE,
+      tool_input: { file_path: 'src/components/Foo.tsx', content: 'x' }
+    }));
+    expect(r.stdout).not.toContain('MIGRATION FILE CREATED');
+    expect(r.code).toBe(0);
+  });
+
+  it('silent + exit 0 with no stdin and no env (fail-open)', async () => {
+    const r = await spawnHook(null);
+    expect(r.stdout).not.toContain('MIGRATION FILE CREATED');
+    expect(r.code).toBe(0);
+  });
+});
+
+describe('MIG-ENV-FALLBACK: manual invocations still work via env', () => {
+  it('emits the reminder when tool name/input arrive ONLY via env', async () => {
+    const r = await spawnHook(null, {
+      CLAUDE_TOOL_NAME: 'Write',
+      CLAUDE_TOOL_INPUT: JSON.stringify(MIGRATION_WRITE.tool_input)
+    });
+    expect(r.stdout).toContain('MIGRATION FILE CREATED');
+    expect(r.code).toBe(0);
+  });
+});

--- a/scripts/hooks/__tests__/post-tool-loop-state.test.js
+++ b/scripts/hooks/__tests__/post-tool-loop-state.test.js
@@ -25,12 +25,18 @@ function spawnHook(stdinPayload, env = {}) {
     };
     require('${HOOK_PATH}');
   `;
+  // SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001: spawn HARNESS-SHAPED by default —
+  // CLAUDE_TOOL_NAME deliberately ABSENT (Claude Code never sets it for hooks; the
+  // legacy default of injecting it here is exactly why the dead env-only guard
+  // shipped undetected fleet-wide). Tests exercising the env FALLBACK set it via `env`.
+  const spawnEnv = { ...process.env, LEO_PARK_SILENCE_ARM: 'off', ...env };
+  if (!('CLAUDE_TOOL_NAME' in env)) delete spawnEnv.CLAUDE_TOOL_NAME;
   const probe = spawn('node', ['-e', code], {
     stdio: ['pipe', 'pipe', 'pipe'],
     // These cases assert ONLY the loop_state resolution path. Disable the FR-2
     // silence-arm (SD-FDBK-INFRA-AUTO-PUSH-WIP-001) so they stay hermetic — the
     // arm is covered separately by spawnHookSilence below.
-    env: { ...process.env, CLAUDE_TOOL_NAME: 'ScheduleWakeup', LEO_PARK_SILENCE_ARM: 'off', ...env }
+    env: spawnEnv
   });
   if (stdinPayload === null) {
     probe.stdin.end();
@@ -106,9 +112,12 @@ function spawnHookSilence(stdinPayload, env = {}) {
     }};
     require('${HOOK_PATH}');
   `;
+  // Harness-shaped: CLAUDE_TOOL_NAME absent (the payloads carry tool_name) — see spawnHook.
+  const spawnEnvS = { ...process.env, ...env };
+  if (!('CLAUDE_TOOL_NAME' in env)) delete spawnEnvS.CLAUDE_TOOL_NAME;
   const probe = spawn('node', ['-e', code], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, CLAUDE_TOOL_NAME: 'ScheduleWakeup', ...env }
+    env: spawnEnvS
   });
   probe.stdin.end(stdinPayload);
   return new Promise((resolve) => {
@@ -150,5 +159,43 @@ describe('PTL-SILENCE-1: ScheduleWakeup hook arms a capped expected_silence_unti
     }), { LEO_PARK_SILENCE_ARM: 'off' });
     expect(r.stdout).not.toContain('SILENCE:');
     expect(r.code).toBe(0);
+  });
+});
+
+// SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001: payload-first tool-name resolution.
+// The harness delivers tool_name in the stdin JSON and NEVER sets CLAUDE_TOOL_NAME
+// (RCA #2 2026-05-04). The previous env-only guard exited silently on every real
+// invocation — loop_state read 'unknown' fleet-wide. These pin both directions
+// with the env var ABSENT (the legacy suite injected it and masked the bug).
+describe('PTL-PAYLOAD-TOOLNAME: tool name resolves payload-first with env fallback', () => {
+  it('HARNESS SHAPE: payload tool_name=ScheduleWakeup, env var absent => writes', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'ptl-payload-1', hook_event_name: 'PostToolUse',
+      tool_name: 'ScheduleWakeup', tool_input: { delaySeconds: 1200 }
+    }));
+    expect(r.stdout).toBe('CALLED:ptl-payload-1:awaiting_tick');
+    expect(r.code).toBe(0);
+  });
+
+  it('payload tool_name=Bash, env var absent => excluded (no write)', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'ptl-payload-2', hook_event_name: 'PostToolUse', tool_name: 'Bash'
+    }));
+    expect(r.stdout).not.toContain('CALLED:');
+    expect(r.code).toBe(0);
+  });
+
+  it('env-only fallback still honored (manual invocations): no payload tool_name, env=ScheduleWakeup', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'ptl-payload-3'
+    }), { CLAUDE_TOOL_NAME: 'ScheduleWakeup' });
+    expect(r.stdout).toBe('CALLED:ptl-payload-3:awaiting_tick');
+  });
+
+  it('payload tool_name WINS over a conflicting env value', async () => {
+    const r = await spawnHook(JSON.stringify({
+      session_id: 'ptl-payload-4', tool_name: 'Bash'
+    }), { CLAUDE_TOOL_NAME: 'ScheduleWakeup' });
+    expect(r.stdout).not.toContain('CALLED:');
   });
 });

--- a/scripts/hooks/migration-execution-reminder.cjs
+++ b/scripts/hooks/migration-execution-reminder.cjs
@@ -59,21 +59,28 @@ function extractSDId(filePath, content) {
  * Main hook execution
  */
 async function main() {
-  // Get tool output from environment
-  const toolOutput = process.env.CLAUDE_TOOL_OUTPUT || '';
-  const toolInput = process.env.CLAUDE_TOOL_INPUT || '';
-  const toolName = process.env.CLAUDE_TOOL_NAME || '';
+  // SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001 (class fix, RCA #2 2026-05-04):
+  // Claude Code does NOT set CLAUDE_TOOL_NAME / CLAUDE_TOOL_INPUT for hooks —
+  // the payload arrives as JSON on stdin. The previous env-only reads meant
+  // this hook exited at the Write guard on EVERY harness invocation (dead
+  // since ship). Payload-first, env fallback (manual/test invocations).
+  const { readHookStdinPayload } = require('../../lib/hooks/session-id.cjs');
+  let payload = null;
+  try { payload = await readHookStdinPayload(); } catch { /* fall back to env */ }
+
+  const toolName = (payload && payload.tool_name) || process.env.CLAUDE_TOOL_NAME || '';
 
   // Only check for Write tool
   if (toolName !== 'Write') {
     process.exit(0);
   }
 
-  // Parse file path from tool input
+  // Tool input: payload object first; env JSON string fallback.
   let filePath = '';
   let content = '';
   try {
-    const input = JSON.parse(toolInput);
+    const input = (payload && typeof payload.tool_input === 'object' && payload.tool_input)
+      || JSON.parse(process.env.CLAUDE_TOOL_INPUT || '');
     filePath = input.file_path || '';
     content = input.content || '';
   } catch (_e) {

--- a/scripts/hooks/post-tool-loop-state.cjs
+++ b/scripts/hooks/post-tool-loop-state.cjs
@@ -7,9 +7,15 @@
  *
  * Hook contract:
  *   - matcher: "ScheduleWakeup" (set in .claude/settings.json) restricts firing
- *     to the right tool. We still verify CLAUDE_TOOL_NAME defensively in case
- *     the matcher is missing or the hook is invoked from a different settings
- *     entry.
+ *     to the right tool. We still verify the tool name defensively in case the
+ *     matcher is missing or the hook is invoked from a different settings entry.
+ *     SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001: the tool name MUST be read
+ *     from the stdin payload (payload.tool_name) with CLAUDE_TOOL_NAME as a
+ *     fallback only — Claude Code does NOT set CLAUDE_TOOL_NAME for hooks (RCA
+ *     #2 2026-05-04, same class pre-tool-enforce.cjs fixed), so the previous
+ *     env-only guard exited silently on EVERY harness invocation. That single
+ *     guard is why claude_sessions.loop_state read 'unknown' fleet-wide all day
+ *     2026-06-10 and parked workers were indistinguishable from stalled ones.
  *   - Always exit 0 — observability writes MUST NOT block the tool call. Any
  *     failure is logged to stderr by the tracker module.
  *   - Feature-flag gate: setting LEO_LOOP_STATE_SIGNAL=off short-circuits the
@@ -27,8 +33,6 @@
  * LEO_PARK_SILENCE_ARM and fully best-effort (its own try/catch).
  */
 
-const TOOL_NAME = process.env.CLAUDE_TOOL_NAME || '';
-
 function isOff(v) {
   const f = String(v == null ? 'on' : v).toLowerCase();
   return f === 'off' || f === '0' || f === 'false';
@@ -36,13 +40,17 @@ function isOff(v) {
 
 (async () => {
   try {
-    if (TOOL_NAME !== 'ScheduleWakeup') return;
     if (isOff(process.env.LEO_LOOP_STATE_SIGNAL)) return;
 
-    // FR-2: read the FULL stdin payload ONCE — we need session_id AND
-    // tool_input.delaySeconds, and stdin can only be consumed once.
+    // Read the FULL stdin payload ONCE — we need tool_name, session_id AND
+    // tool_input.delaySeconds, and stdin can only be consumed once. The tool
+    // guard runs AFTER this read: payload-first, env fallback (the env var is
+    // not set by the harness — see header).
     const sidLib = require('../../lib/hooks/session-id.cjs');
     const payload = await sidLib.readHookStdinPayload();
+
+    const toolName = (payload && payload.tool_name) || process.env.CLAUDE_TOOL_NAME || '';
+    if (toolName !== 'ScheduleWakeup') return;
 
     let sessionId = payload && sidLib.isValidSessionId(payload.session_id) ? payload.session_id : '';
     if (!sessionId && sidLib.isValidSessionId(process.env.CLAUDE_SESSION_ID)) sessionId = process.env.CLAUDE_SESSION_ID;


### PR DESCRIPTION
## SD-LEO-INFRA-PARK-VISIBILITY-LOOP-STATE-001 — park signals actually write (payload-first tool-name guard)

**Type**: infrastructure | **Priority**: high | Gates: LEAD-TO-PLAN 93, PLAN-TO-EXEC 94 | RISK PASS-90 (row 33749a39)

### Problem (witnessed fleet-wide 2026-06-10)
`claude_sessions.loop_state` read `unknown` for EVERY session all day and `expected_silence_until` stayed stale during parks — a parked /loop worker was indistinguishable from a stalled one, so operators manually jump-started healthy workers (Delta re-invoked at ~14:04 with a wakeup armed for 14:19).

### Root cause (LEAD investigation refuted the SD's worktree hypothesis)
A manual main-tree run wrote both signals fine. The actual defect: the PostToolUse hook guarded on `process.env.CLAUDE_TOOL_NAME`, **which Claude Code never sets for hooks** (tool_name arrives in the stdin JSON — RCA #2 2026-05-04, the class `pre-tool-enforce.cjs` fixed long ago). The guard exited silently on every harness invocation.

### Fix
- `post-tool-loop-state.cjs`: stdin payload read first; ScheduleWakeup guard now checks `payload.tool_name` (env fallback for manual runs). Both park signals (`loop_state=awaiting_tick` + capped `expected_silence_until`) fire on real invocations.
- `migration-execution-reminder.cjs` (class fix): was 100% env-dependent → dead since ship; now payload-first. `post-tool-rca-outcome.cjs` audited — already payload-aware, untouched.
- Tests: the legacy suite injected `CLAUDE_TOOL_NAME` on every spawn — exactly why the bug shipped undetected. Spawns are now harness-shaped (env var deleted by default); +4 payload-first pins +5-test migration suite. **25/25 green.**

### Live smoke (worktree, env var absent)
- ScheduleWakeup payload → `loop_state=awaiting_tick` + future `expected_silence_until` written for a real session ✅
- Bash payload → zero writes ✅

### Consumers unlocked (FR-5, post-merge)
stale-session-sweep parked-worker protection (30-min hard-cap bounded), capacity forecaster IDLE-vs-STALLED, stop-loop-wakeup-reminder — all move from claim-based fallbacks to real signals. Rollback stays env-gated (`LEO_LOOP_STATE_SIGNAL=off`, `LEO_PARK_SILENCE_ARM=off`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
