### PR TITLE
feat(SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B): gate-verdict caching on handoff retry — opt-in declared-input hashing, PASS-only reuse

### DIFF
--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -935,11 +935,16 @@ export async function handleExecuteCommand(handoffType, sdId, args) {
     }
   }
 
+  // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (L5): --no-cache forces a full gate
+  // re-run (gate-verdict cache bypassed entirely — audit/debug path).
+  const noCache = args.includes('--no-cache');
+
   // Execute handoff
   const result = await system.executeHandoff(handoffType, sdId, {
     prdId,
     bypassValidation,
-    bypassReason
+    bypassReason,
+    noCache
   });
 
   // Display results

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -323,6 +323,36 @@ export class BaseExecutor {
       validationContext._traceCtx = traceCtx;
       validationContext._parentSpan = step3Span;
 
+      // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (L5): gate-verdict cache setup.
+      // PASS-only reuse for declared-input gates across retries of the same
+      // handoff. LEAD-FINAL-APPROVAL is hard-excluded (final bar); --no-cache
+      // (options.noCache) forces a full re-run. Fail-open: loader errors → no cache.
+      let verdictCacheModule = null;
+      try {
+        verdictCacheModule = await import('../gate-verdict-cache.js');
+        const cacheEnabled = verdictCacheModule.isCacheAllowed({
+          noCache: options.noCache,
+          handoffType: this.handoffType,
+        });
+        let priorResults = null;
+        if (cacheEnabled) {
+          priorResults = await verdictCacheModule.loadPriorGateResults(
+            this.supabase, sd?.id || sdId, this.handoffType
+          );
+        }
+        validationContext._verdictCache = {
+          enabled: cacheEnabled && !!priorResults,
+          prior: priorResults || {},
+          _allowed: cacheEnabled,
+        };
+        if (validationContext._verdictCache.enabled) {
+          console.log(`   ♻️  Gate-verdict cache armed (${Object.keys(priorResults).length} prior gate result(s) with input hashes)`);
+        }
+      } catch (cacheErr) {
+        validationContext._verdictCache = { enabled: false, prior: {}, _allowed: false };
+        console.warn(`   [gate-verdict-cache] disabled (fail-open): ${cacheErr.message}`);
+      }
+
       // SD-MAN-GEN-CORRECTIVE-VISION-GAP-013 (V02): Gate retry loop — auto-retry transient failures
       let gateResults;
       let currentRetryCount = options._retryCount || 0;
@@ -330,6 +360,18 @@ export class BaseExecutor {
 
       for (let attempt = 0; attempt <= maxGateRetries; attempt++) {
         gateResults = await this.validationOrchestrator.validateGates(gates, validationContext);
+
+        // L5: fold this attempt's hash-bearing PASS verdicts into the cache so the
+        // in-process retry below reuses them too (same PASS-only semantics).
+        if (verdictCacheModule && validationContext._verdictCache && validationContext._verdictCache._allowed) {
+          try {
+            validationContext._verdictCache.prior = verdictCacheModule.mergePassResults(
+              validationContext._verdictCache.prior, gateResults.gateResults
+            );
+            validationContext._verdictCache.enabled =
+              Object.keys(validationContext._verdictCache.prior).length > 0;
+          } catch { /* fail-open */ }
+        }
 
         if (gateResults.passed) break; // Gates passed — exit retry loop
 
@@ -353,6 +395,22 @@ export class BaseExecutor {
       }
 
       try { endSpan(step3Span, { result: gateResults.passed ? 'pass' : 'fail' }); } catch (e) { console.debug('[BaseExecutor] telemetry suppressed:', e?.message || e); }
+
+      // L5 telemetry: cache-hit counts per run (fail-soft, fire-and-forget).
+      try {
+        const allEntries = Object.entries(gateResults.gateResults || {});
+        const hitNames = allEntries.filter(([, r]) => r && r.cache_hit === true).map(([n]) => n);
+        if (hitNames.length > 0 && verdictCacheModule) {
+          console.log(`   ♻️  Gate-verdict cache: ${hitNames.length} reused, ${allEntries.length - hitNames.length} evaluated (${hitNames.join(', ')})`);
+          verdictCacheModule.logCacheTelemetry(this.supabase, {
+            sdKey: sd?.sd_key || sdId,
+            handoffType: this.handoffType,
+            hits: hitNames.length,
+            reran: allEntries.length - hitNames.length,
+            gates: hitNames,
+          }).catch(() => {});
+        }
+      } catch { /* telemetry never affects the verdict */ }
 
       // SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 FR-5: WAIT verdict short-circuit.
       // A WAIT verdict means the handoff is correctly blocked (e.g. parent orchestrator
@@ -461,13 +519,18 @@ export class BaseExecutor {
           }
 
           try { endSpan(rootSpan, { result: 'gate_failure' }); persist(traceCtx, { supabase: this.supabase }); } catch (e) { console.debug('[BaseExecutor] telemetry suppressed:', e?.message || e); }
-          return ResultBuilder.gateFailure(gateResults.failedGate, {
+          const gateFailureResult = ResultBuilder.gateFailure(gateResults.failedGate, {
             issues: gateResults.issues,
             score: gateResults.totalScore,
             max_score: gateResults.totalMaxScore,
             warnings: gateResults.warnings,
             details: gateResults.gateResults
           }, remediation);
+          // L5 (SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B): surface per-gate results
+          // top-level so recordFailure persists them — retries follow rejections, so
+          // without this the cache has nothing to reuse.
+          gateFailureResult.gateResults = gateResults.gateResults;
+          return gateFailureResult;
         }
       }
 

--- a/scripts/modules/handoff/gate-verdict-cache.js
+++ b/scripts/modules/handoff/gate-verdict-cache.js
@@ -1,0 +1,184 @@
+/**
+ * Gate-Verdict Cache — SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (program L5)
+ *
+ * Reuses per-gate PASS verdicts across handoff retries when the declared
+ * inputs of a gate are byte-identical. 177 rejections in 4 days each re-ran
+ * the ENTIRE pipeline, duplicating evaluations of gates whose inputs had not
+ * changed.
+ *
+ * ZERO QUALITY LOSS BY CONSTRUCTION:
+ *  - Caching is OPT-IN per gate via a declared input extractor. Live seam
+ *    verification showed most gates self-query the DB (inputs invisible at
+ *    the loop), so ONLY gates whose validator is a pure function of declared
+ *    ctx fields are registered. Undeclared gates ALWAYS re-run.
+ *  - Reuse requires: identical sha256 over the stable-stringified extracted
+ *    inputs AND prior verdict passed===true. FAIL/CONDITIONAL/WAIT verdicts
+ *    are NEVER reused.
+ *  - LEAD-FINAL-APPROVAL is hard-excluded (final bar). --no-cache forces a
+ *    full re-run. Any doubt (extractor throw, missing prior row, version
+ *    mismatch) means re-evaluate.
+ *
+ * Initial registry (verified pure — validator(ctx) delegates to a pure
+ * function of ctx.sd, 0 supabase references in gate or delegate):
+ *  - GATE_SD_METRICS_SUFFICIENCY  → validateMetricsSufficiency(ctx.sd)
+ *  - GATE_SD_QUALITY              → validateSdQuality(ctx.sd)
+ *  - GATE_PLACEHOLDER_CONTENT_DETECTION → validatePlaceholderContent(ctx.sd)
+ * All three share one OVER-INCLUSIVE extractor: the union of every SD field
+ * any of them evaluates. Over-inclusion is SAFE — an unrelated content-field
+ * change only costs a cache miss, never a stale reuse.
+ */
+
+import crypto from 'node:crypto';
+
+export const GATE_RESULTS_VERSION_HASHED = 2;
+
+/** Union of every SD field evaluated by the registered pure gates
+ * (sd-quality-scoring.js JSONB_FIELDS + description/scope/sd_type +
+ * sd-validation.js metrics-sufficiency reads). */
+export const SD_CONTENT_FIELDS = [
+  'title',
+  'description',
+  'sd_type',
+  'scope',
+  'strategic_objectives',
+  'dependencies',
+  'implementation_guidelines',
+  'success_criteria',
+  'success_metrics',
+  'key_changes',
+  'key_principles',
+  'risks',
+  'target_application',
+];
+
+function extractSdContent(ctx) {
+  const sd = ctx && ctx.sd;
+  if (!sd || typeof sd !== 'object') return null; // unhashable
+  const out = {};
+  for (const f of SD_CONTENT_FIELDS) out[f] = sd[f] ?? null;
+  return out;
+}
+
+/** Opt-in registry: gate name → input extractor (ctx) => object|null. */
+export const GATE_INPUT_EXTRACTORS = {
+  GATE_SD_METRICS_SUFFICIENCY: extractSdContent,
+  GATE_SD_QUALITY: extractSdContent,
+  GATE_PLACEHOLDER_CONTENT_DETECTION: extractSdContent,
+};
+
+/** Deterministic stringify — recursive sorted keys, stable across key order. */
+export function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+  const keys = Object.keys(value).sort();
+  return '{' + keys.map(k => JSON.stringify(k) + ':' + stableStringify(value[k])).join(',') + '}';
+}
+
+export function computeInputHash(inputs) {
+  return crypto.createHash('sha256').update(stableStringify(inputs)).digest('hex');
+}
+
+/**
+ * FR-4 policy: is caching allowed for this run at all?
+ * LEAD-FINAL-APPROVAL is hard-excluded (final bar, cheap insurance);
+ * --no-cache (options.noCache) and LEO_GATE_VERDICT_CACHE=off disable it.
+ */
+export function isCacheAllowed({ noCache, handoffType, env = process.env }) {
+  if (noCache) return false;
+  if (String(handoffType || '').toUpperCase().replace(/_/g, '-') === 'LEAD-FINAL-APPROVAL') return false;
+  if (env.LEO_GATE_VERDICT_CACHE === 'off') return false;
+  return true;
+}
+
+/**
+ * Probe the cache for one gate. Pure decision — no I/O.
+ *
+ * @param {string} gateName
+ * @param {object} context — validation context (ctx.sd etc.)
+ * @param {object|null} cacheCfg — context._verdictCache: { enabled, prior: {gateName: priorResult} }
+ * @returns {{ hit: boolean, priorResult?: object, inputHash: string|null }}
+ */
+export function probeVerdictCache(gateName, context, cacheCfg) {
+  let inputHash = null;
+  const extractor = GATE_INPUT_EXTRACTORS[gateName];
+  if (extractor) {
+    try {
+      const inputs = extractor(context);
+      if (inputs != null) inputHash = computeInputHash(inputs);
+    } catch {
+      inputHash = null; // extractor failure → unhashable this run (fail-open)
+    }
+  }
+
+  if (!cacheCfg || !cacheCfg.enabled || !inputHash) return { hit: false, inputHash };
+
+  const prior = cacheCfg.prior && cacheCfg.prior[gateName];
+  if (!prior) return { hit: false, inputHash };
+  // PASS-only reuse; identical declared-input hash required.
+  if (prior.passed !== true) return { hit: false, inputHash };
+  if (prior.input_hash !== inputHash) return { hit: false, inputHash };
+  // Never reuse skipped/wait shapes even if marked passed.
+  if (prior.wait === true || prior.skipReason) return { hit: false, inputHash };
+
+  return { hit: true, priorResult: prior, inputHash };
+}
+
+/**
+ * Load the most recent prior gate_results (version >= 2, i.e. hash-bearing)
+ * for the same SD + handoff type from sd_phase_handoffs — any status:
+ * rejected rows are the whole point (retries follow rejections), and
+ * recordFailure persists per-gate results as of this SD.
+ *
+ * Fail-open: any error → null (cache disabled for the run).
+ */
+export async function loadPriorGateResults(supabase, sdUuid, handoffType) {
+  try {
+    const { data, error } = await supabase
+      .from('sd_phase_handoffs')
+      .select('id, metadata, created_at')
+      .eq('sd_id', sdUuid)
+      .eq('handoff_type', handoffType)
+      .order('created_at', { ascending: false })
+      .limit(3);
+    if (error || !data) return null;
+    for (const row of data) {
+      const md = row.metadata;
+      if (md && md.gate_results && (md.gate_results_version || 0) >= GATE_RESULTS_VERSION_HASHED) {
+        return md.gate_results;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * FR-5 telemetry — fire-and-forget GATE_VERDICT_CACHE event on the existing
+ * coordination_events table. Never affects the handoff verdict.
+ */
+export async function logCacheTelemetry(supabase, { sdKey, handoffType, hits, reran, gates }) {
+  try {
+    const { error } = await supabase.from('coordination_events').insert({
+      event_type: 'GATE_VERDICT_CACHE',
+      severity: 'info',
+      payload: { sd_key: sdKey, handoff_type: handoffType, hits, reran, gates, source: 'gate-verdict-cache' },
+    });
+    if (error) console.warn(`   [gate-verdict-cache] telemetry write failed (non-fatal): ${error.message}`);
+  } catch (e) {
+    console.warn(`   [gate-verdict-cache] telemetry threw (non-fatal): ${(e && e.message) || e}`);
+  }
+}
+
+/**
+ * Merge a finished attempt's PASS results into the prior map so the
+ * in-process gate retry loop (BaseExecutor attempt 0..N) also reuses
+ * verdicts. Same PASS-only + hash-bearing rules.
+ */
+export function mergePassResults(prior, gateResults) {
+  const merged = { ...(prior || {}) };
+  for (const [name, r] of Object.entries(gateResults || {})) {
+    if (r && r.passed === true && r.input_hash && !r.wait && !r.skipReason) merged[name] = r;
+  }
+  return merged;
+}

--- a/scripts/modules/handoff/gate-verdict-cache.test.js
+++ b/scripts/modules/handoff/gate-verdict-cache.test.js
@@ -1,0 +1,223 @@
+/**
+ * SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (program L5) — gate-verdict cache.
+ *
+ * Pins the zero-quality-loss contract:
+ *  - reuse requires byte-identical declared-input hash AND prior PASS;
+ *  - FAIL/CONDITIONAL/WAIT/skipped verdicts are NEVER reused;
+ *  - changed input invalidates exactly the affected gate;
+ *  - undeclared gates never hash, never hit;
+ *  - extractor throw → unhashable this run (fail-open);
+ *  - --no-cache and LEAD-FINAL-APPROVAL disable caching (isCacheAllowed);
+ *  - recordFailure persists per-gate gate_results (version 2) on rejected rows;
+ *  - validateGates end-to-end: cached gate's validator is NOT invoked and the
+ *    pipeline verdict equals a control full run.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  stableStringify,
+  computeInputHash,
+  probeVerdictCache,
+  isCacheAllowed,
+  mergePassResults,
+  loadPriorGateResults,
+  GATE_INPUT_EXTRACTORS,
+  SD_CONTENT_FIELDS,
+} from './gate-verdict-cache.js';
+
+const SD = {
+  title: 'T', description: 'D', sd_type: 'infrastructure', scope: 'S',
+  strategic_objectives: ['o1'], dependencies: [], implementation_guidelines: [],
+  success_criteria: [{ criterion: 'c', measure: 'm' }],
+  success_metrics: [{ metric: 'a' }, { metric: 'b' }, { metric: 'c' }],
+  key_changes: [{ change: 'k' }], key_principles: ['p'], risks: [{ risk: 'r' }],
+  target_application: 'EHG_Engineer',
+};
+
+function priorPass(ctx) {
+  const hash = computeInputHash(
+    Object.fromEntries(SD_CONTENT_FIELDS.map(f => [f, (ctx.sd[f] ?? null)]))
+  );
+  return { passed: true, score: 100, maxScore: 100, issues: [], warnings: [], input_hash: hash };
+}
+
+describe('stableStringify / computeInputHash', () => {
+  it('key order does not affect the hash', () => {
+    expect(computeInputHash({ b: 2, a: 1 })).toBe(computeInputHash({ a: 1, b: 2 }));
+    expect(stableStringify({ x: [1, { z: 1, y: 2 }] })).toBe(stableStringify({ x: [1, { y: 2, z: 1 }] }));
+  });
+  it('different content yields a different hash', () => {
+    expect(computeInputHash({ a: 1 })).not.toBe(computeInputHash({ a: 2 }));
+  });
+});
+
+describe('probeVerdictCache', () => {
+  const ctx = { sd: SD };
+
+  it('identical inputs + prior PASS → hit with prior result', () => {
+    const prior = { GATE_SD_METRICS_SUFFICIENCY: priorPass(ctx) };
+    const probe = probeVerdictCache('GATE_SD_METRICS_SUFFICIENCY', ctx, { enabled: true, prior });
+    expect(probe.hit).toBe(true);
+    expect(probe.priorResult.score).toBe(100);
+  });
+
+  it('changed declared input invalidates exactly that gate', () => {
+    const prior = {
+      GATE_SD_METRICS_SUFFICIENCY: priorPass(ctx),
+      GATE_SD_QUALITY: priorPass(ctx),
+    };
+    const changedCtx = { sd: { ...SD, success_metrics: [{ metric: 'CHANGED' }] } };
+    // Shared extractor: BOTH gates see the changed SD content — both miss…
+    expect(probeVerdictCache('GATE_SD_METRICS_SUFFICIENCY', changedCtx, { enabled: true, prior }).hit).toBe(false);
+    // …while the unchanged SD still hits (per-gate invalidation is hash-driven).
+    expect(probeVerdictCache('GATE_SD_QUALITY', ctx, { enabled: true, prior }).hit).toBe(true);
+  });
+
+  it('prior FAIL is NEVER reused even with identical hash', () => {
+    const failed = { ...priorPass(ctx), passed: false, score: 40 };
+    const probe = probeVerdictCache('GATE_SD_QUALITY', ctx, { enabled: true, prior: { GATE_SD_QUALITY: failed } });
+    expect(probe.hit).toBe(false);
+  });
+
+  it('wait/skipped prior shapes are never reused', () => {
+    const waiting = { ...priorPass(ctx), wait: true };
+    const skipped = { ...priorPass(ctx), skipReason: 'SD_TYPE' };
+    expect(probeVerdictCache('GATE_SD_QUALITY', ctx, { enabled: true, prior: { GATE_SD_QUALITY: waiting } }).hit).toBe(false);
+    expect(probeVerdictCache('GATE_SD_QUALITY', ctx, { enabled: true, prior: { GATE_SD_QUALITY: skipped } }).hit).toBe(false);
+  });
+
+  it('undeclared gate: no hash, no hit', () => {
+    const probe = probeVerdictCache('RCA_GATE', ctx, { enabled: true, prior: { RCA_GATE: priorPass(ctx) } });
+    expect(probe.inputHash).toBeNull();
+    expect(probe.hit).toBe(false);
+  });
+
+  it('cache disabled: hash still computed (for persistence) but no hit', () => {
+    const prior = { GATE_SD_QUALITY: priorPass(ctx) };
+    const probe = probeVerdictCache('GATE_SD_QUALITY', ctx, { enabled: false, prior });
+    expect(probe.hit).toBe(false);
+    expect(probe.inputHash).toBeTruthy();
+  });
+
+  it('extractor throw → unhashable this run (fail-open)', () => {
+    GATE_INPUT_EXTRACTORS.__THROWY__ = () => { throw new Error('boom'); };
+    try {
+      const probe = probeVerdictCache('__THROWY__', ctx, { enabled: true, prior: { __THROWY__: priorPass(ctx) } });
+      expect(probe.hit).toBe(false);
+      expect(probe.inputHash).toBeNull();
+    } finally {
+      delete GATE_INPUT_EXTRACTORS.__THROWY__;
+    }
+  });
+});
+
+describe('isCacheAllowed (FR-4 policy)', () => {
+  it('--no-cache disables', () => {
+    expect(isCacheAllowed({ noCache: true, handoffType: 'PLAN-TO-LEAD' })).toBe(false);
+  });
+  it('LEAD-FINAL-APPROVAL hard-excluded (both separator forms)', () => {
+    expect(isCacheAllowed({ noCache: false, handoffType: 'LEAD-FINAL-APPROVAL' })).toBe(false);
+    expect(isCacheAllowed({ noCache: false, handoffType: 'LEAD_FINAL_APPROVAL' })).toBe(false);
+  });
+  it('env kill-switch disables; default allows', () => {
+    expect(isCacheAllowed({ noCache: false, handoffType: 'PLAN-TO-LEAD', env: { LEO_GATE_VERDICT_CACHE: 'off' } })).toBe(false);
+    expect(isCacheAllowed({ noCache: false, handoffType: 'PLAN-TO-LEAD', env: {} })).toBe(true);
+  });
+});
+
+describe('mergePassResults (in-process retry reuse)', () => {
+  it('folds only hash-bearing PASS results', () => {
+    const merged = mergePassResults({}, {
+      A: { passed: true, input_hash: 'h1' },
+      B: { passed: false, input_hash: 'h2' },
+      C: { passed: true },                       // no hash
+      D: { passed: true, input_hash: 'h4', wait: true },
+    });
+    expect(Object.keys(merged)).toEqual(['A']);
+  });
+});
+
+describe('loadPriorGateResults', () => {
+  function mockSupabase(rows, error = null) {
+    const chain = {
+      select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue({ data: rows, error }),
+    };
+    return { from: vi.fn().mockReturnValue(chain) };
+  }
+
+  it('returns the newest version>=2 gate_results; skips version-1 rows', async () => {
+    const rows = [
+      { metadata: { gate_results: { OLD: {} }, gate_results_version: 1 } },
+      { metadata: { gate_results: { NEW: { passed: true } }, gate_results_version: 2 } },
+    ];
+    const out = await loadPriorGateResults(mockSupabase(rows), 'uuid', 'PLAN-TO-LEAD');
+    expect(out).toEqual({ NEW: { passed: true } });
+  });
+
+  it('fail-open: query error → null', async () => {
+    expect(await loadPriorGateResults(mockSupabase(null, { message: 'down' }), 'u', 'T')).toBeNull();
+  });
+});
+
+describe('validateGates end-to-end reuse (TS-1 control parity)', () => {
+  it('cached gate validator NOT invoked; pipeline verdict equals control run', async () => {
+    const { ValidationOrchestrator } = await import('./validation/ValidationOrchestrator.js');
+    const orchestrator = new ValidationOrchestrator({ supabase: {} });
+    // Avoid DB-dependent preloading in this offline test.
+    orchestrator.preloadGateContexts = async () => {};
+
+    const validator = vi.fn().mockResolvedValue({ passed: true, score: 100, maxScore: 100, issues: [], warnings: [] });
+    const gates = [{ name: 'GATE_SD_QUALITY', validator, weight: 1 }];
+    const ctx = { sd: SD };
+
+    // Control: full run, no cache.
+    const control = await orchestrator.validateGates(gates, { ...ctx });
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(control.gateResults.GATE_SD_QUALITY.input_hash).toBeTruthy();
+
+    // Retry with cache armed from the control run's results.
+    const prior = mergePassResults({}, control.gateResults);
+    const retry = await orchestrator.validateGates(gates, { ...ctx, _verdictCache: { enabled: true, prior } });
+    expect(validator).toHaveBeenCalledTimes(1); // NOT invoked again
+    expect(retry.gateResults.GATE_SD_QUALITY.cache_hit).toBe(true);
+    expect(retry.passed).toBe(control.passed);
+    expect(retry.gateResults.GATE_SD_QUALITY.score).toBe(control.gateResults.GATE_SD_QUALITY.score);
+  });
+});
+
+describe('recordFailure persists per-gate verdicts (TS-6)', () => {
+  it('rejected row metadata carries gate_results version 2', async () => {
+    const { HandoffRecorder } = await import('./recording/HandoffRecorder.js');
+    let inserted = null;
+    const supabase = {
+      from: vi.fn().mockImplementation((table) => ({
+        insert: vi.fn().mockImplementation((row) => {
+          if (table === 'sd_phase_handoffs') inserted = row; // only the rejection row
+          return { select: vi.fn().mockResolvedValue({ data: [row], error: null }) };
+        }),
+        update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+        select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      })),
+      rpc: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const recorder = new HandoffRecorder(supabase, {
+      contentBuilder: { buildRejection: () => ({ executive_summary: 'x' }) },
+      validationOrchestrator: { preValidateData: async () => ({ valid: true, errors: [] }) },
+    });
+    // _resolveToUUID hits the DB — stub it for the offline test.
+    recorder._resolveToUUID = async () => '00000000-0000-0000-0000-000000000001';
+
+    const gateResults = { GATE_SD_QUALITY: { passed: true, score: 100, input_hash: 'abc' } };
+    await recorder.recordFailure('PLAN-TO-LEAD', 'SD-T-001', {
+      message: 'failed', reasonCode: 'GATE_FAILED', gateCount: 1, issues: [], warnings: [],
+      gateResults,
+    });
+
+    expect(inserted).toBeTruthy();
+    expect(inserted.metadata.gate_results).toEqual(gateResults);
+    expect(inserted.metadata.gate_results_version).toBe(2);
+  });
+});

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -333,6 +333,19 @@ export class HandoffRecorder {
       created_by: 'UNIFIED-HANDOFF-SYSTEM'
     };
 
+    // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (L5): persist per-gate verdicts on
+    // REJECTED rows too (previously summary-only). Retries follow rejections, so
+    // this is the storage the gate-verdict cache reads back — entries carry
+    // input_hash where the gate has a declared extractor. Version 2 = hash-bearing.
+    const perGateResults = result.gateResults || result.details?.details || null;
+    if (perGateResults && typeof perGateResults === 'object' && Object.keys(perGateResults).length > 0) {
+      execution.metadata = {
+        ...(execution.metadata || {}),
+        gate_results: perGateResults,
+        gate_results_version: 2,
+      };
+    }
+
     try {
       // Pre-validate - for rejections, try to fix common issues
       const preValidation = await this.validationOrchestrator.preValidateData('sd_phase_handoffs', execution);
@@ -692,9 +705,12 @@ export class HandoffRecorder {
             console.warn('   ⚠️  WARNING: GATE3_TRACEABILITY not found in gateResults');
           }
         }
-        // Store all gate results for comprehensive audit trail
+        // Store all gate results for comprehensive audit trail.
+        // L5 (SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B): version 2 when any entry
+        // carries an input_hash (hash-bearing shape the gate-verdict cache reads).
         metadata.gate_results = result.gateResults;
-        metadata.gate_results_version = 1;
+        metadata.gate_results_version =
+          Object.values(result.gateResults).some(r => r && r.input_hash) ? 2 : 1;
       } else {
         console.warn('   ⚠️  No gateResults in result object - cross-handoff traceability compromised');
       }

--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -36,6 +36,10 @@ import { OIVGate, OIV_GATE_WEIGHT } from './oiv/index.js';
 // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Gate context preloader
 import { preloadGateContext, getGateNumberForRule } from './validator-registry/gate-context-preloader.js';
 
+// SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (program L5): gate-verdict cache —
+// PASS-only reuse across handoff retries for gates with declared pure inputs.
+import { probeVerdictCache } from '../gate-verdict-cache.js';
+
 // SD-LEO-INFRA-EXTEND-WAIT-VERDICT-001 (FR-5/TR-4): max-wait ceiling guard.
 // Escalates a perpetually-WAITing gate to FAIL after N consecutive waits OR a
 // wall-clock timeout, protecting ALL wait-returning gates (incl. PR #4021
@@ -291,12 +295,31 @@ export class ValidationOrchestrator {
 
       if (eligibleGates.length === 0) continue;
 
-      // Execute all gates within this tier concurrently
+      // Execute all gates within this tier concurrently.
+      // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (L5): consult the gate-verdict
+      // cache first — a declared-input gate whose inputs are byte-identical to a
+      // prior PASS verdict is reused without re-evaluation (cache_hit). FAIL/
+      // CONDITIONAL/WAIT verdicts are never reused; undeclared or unhashable
+      // gates always run; any probe error falls open to a normal run.
       const tierResults = await Promise.all(
-        eligibleGates.map(gate =>
-          this.validateGate(gate.name, gate.validator, context)
-            .then(gateResult => ({ gate, gateResult }))
-        )
+        eligibleGates.map(gate => {
+          let probe = { hit: false, inputHash: null };
+          try {
+            probe = probeVerdictCache(gate.name, context, context._verdictCache);
+          } catch { /* fail-open */ }
+          if (probe.hit) {
+            console.log(`   ♻️  ${gate.name}: reused prior PASS verdict (cache_hit, identical declared inputs)`);
+            const gateResult = { ...probe.priorResult, cache_hit: true, input_hash: probe.inputHash };
+            return Promise.resolve({ gate, gateResult });
+          }
+          return this.validateGate(gate.name, gate.validator, context)
+            .then(gateResult => {
+              if (probe.inputHash && gateResult && typeof gateResult === 'object') {
+                gateResult.input_hash = probe.inputHash;
+              }
+              return { gate, gateResult };
+            });
+        })
       );
 
       // Process results from this tier


### PR DESCRIPTION
## Summary
Program L5 (pure waste removal, sibling of #4609/L1): 177 handoff rejections in 4 days each re-ran the **entire** gate pipeline on retry. This caches per-gate PASS verdicts and reuses them when a gate's declared inputs are byte-identical.

## Premise corrections from live seam verification
1. `recordFailure` persisted only a summary — **rejected rows carried no per-gate verdicts**, making retry reuse structurally impossible (retries follow rejections). Now fixed: rejected rows persist `metadata.gate_results` (version 2).
2. Most gates **self-query the DB** (inputs invisible at the loop) — so caching is **opt-in per gate** via a declared input extractor. Undeclared gates always re-run.

## Zero quality loss by construction
- Reuse requires byte-identical sha256 over stable-stringified declared inputs **AND** prior `passed===true`; FAIL/CONDITIONAL/WAIT/skipped never reused.
- Initial registry: 3 live-verified pure-ctx gates (GATE_SD_METRICS_SUFFICIENCY, GATE_SD_QUALITY, GATE_PLACEHOLDER_CONTENT_DETECTION — validator(ctx) → pure fn of ctx.sd, 0 supabase refs) sharing one **over-inclusive** extractor (union of every evaluated SD field — over-inclusion only costs a miss, never a stale reuse).
- `--no-cache` flag; **LEAD-FINAL-APPROVAL hard-excluded**; `LEO_GATE_VERDICT_CACHE=off` kill-switch; every cache-machinery error falls open to a full run.
- Telemetry: GATE_VERDICT_CACHE events on coordination_events make the ~44 duplicate-runs/day baseline measurable.

## Wiring
ValidationOrchestrator probes per gate pre-validator (cache_hit reuse / input_hash stamping); BaseExecutor arms the cache, folds each attempt's PASS results for in-process retries, logs hits; HandoffRecorder persists per-gate results on failures + version-bumps; cli-main parses --no-cache.

## Tests
17/17 new (hash stability, PASS-only, per-gate invalidation, negative shapes, policy matrix, loader fail-open, **validateGates control-parity with validator-not-invoked**, recordFailure persistence); smoke 15/15. Pre-existing failures in 5 sibling files verified identical on unmodified base (17=17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)