### PR TITLE
fix: phantom gate_threshold column in BaseExecutor SD-type note

### DIFF
--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -753,16 +753,20 @@ export class BaseExecutor {
     const sdType = sd?.sd_type || 'feature';
     let typeNote = '';
     try {
+      // Drive-by (caught by schema-reference diff lint): 'gate_threshold' was a
+      // phantom column (live 42703) — the whole select errored into the catch on
+      // every call, so the type note NEVER rendered. 'prd_minimum_score' is the
+      // real threshold-style column on sd_type_validation_profiles.
       const { data: profile } = await this.supabase
         .from('sd_type_validation_profiles')
-        .select('requires_prd, requires_user_stories, gate_threshold')
+        .select('requires_prd, requires_user_stories, prd_minimum_score')
         .eq('sd_type', sdType)
         .single();
       if (profile) {
         const notes = [];
         if (!profile.requires_prd) notes.push('PRD not required for this SD type');
         if (!profile.requires_user_stories) notes.push('User stories not required for this SD type');
-        if (profile.gate_threshold) notes.push(`Gate threshold: ${profile.gate_threshold}%`);
+        if (profile.prd_minimum_score) notes.push(`PRD minimum score: ${profile.prd_minimum_score}`);
         if (notes.length > 0) typeNote = `\n   SD type '${sdType}': ${notes.join(', ')}`;
       }
     } catch (e) {


### PR DESCRIPTION
Drive-by from PR #4617's schema-reference lint catch: `sd_type_validation_profiles.gate_threshold` does not exist (live 42703) — the select errored into the fail-soft catch on every call, so the SD-type advisory note never rendered, and the lint will block every future PR touching BaseExecutor until fixed. Swapped to the real `prd_minimum_score` column. Same phantom-column class as the `prd_id` fix in #4609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)