### PR TITLE
fix(QF-20260611-162): CLAIM_RELEASED announces only write-verified releases (kills the 5-min phantom-announce loop)

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1102,6 +1102,14 @@ async function main() {
 
   // 4. Auto-release dead sessions (with WIP guard + MC liveness gate)
   const dead = classified.filter(s => s.status === 'DEAD');
+  // QF-20260611-162: announce-vs-write split. The CLAIM_RELEASED announce loop
+  // (step 6) used to iterate ALL of `dead`, but this release loop `continue`s on
+  // four hold guards (WIP, MC, hardcap-pid-alive, cross-signal) and the UPDATE
+  // can fail — so held/failed sessions were announced as released every ~5min
+  // forever while claiming_session_id persisted (7+ phantom announces across 2
+  // SDs, 2026-06-11). Track what ACTUALLY released vs failed; announce only those.
+  const releasedDead = [];
+  const releaseFailedDead = [];
 
   // SD-LEO-INFRA-FLEET-LIVENESS-MONTE-001 (US-005): Pre-fetch the latest MC
   // estimate per dead-classified session (single query, then index). An
@@ -1227,7 +1235,9 @@ async function main() {
 
     if (error) {
       actions.push('FAILED to release ' + s.session_id + ' (' + s.sd_key + '): ' + error.message);
+      releaseFailedDead.push({ ...s, release_error: error.message }); // QF-20260611-162
     } else {
+      releasedDead.push(s); // QF-20260611-162: write checked — only these announce CLAIM_RELEASED
       if (s.sd_key) {
         await resetSdPhaseOnRelease(s.sd_key, releaseReason);
         // Clear claiming_session_id on the SD so the next worker can claim it
@@ -1653,8 +1663,21 @@ async function main() {
       });
   }
 
-  // Also send CLAIM_RELEASED messages for any sessions we evicted (dead)
-  for (const d of dead) {
+  // Send CLAIM_RELEASED ONLY for sessions whose release write actually succeeded
+  // (QF-20260611-162 — previously iterated the raw `dead` list, announcing held/failed releases
+  // as released every ~5min forever). Dedup: skip if an identical announce for the
+  // same session+SD landed within the last 30 minutes.
+  const ANNOUNCE_DEDUP_MIN = 30;
+  const dedupSinceIso = new Date(Date.now() - ANNOUNCE_DEDUP_MIN * 60000).toISOString();
+  for (const d of releasedDead) {
+    const { data: dupes } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', d.session_id)
+      .eq('message_type', 'CLAIM_RELEASED')
+      .gte('created_at', dedupSinceIso)
+      .limit(1);
+    if (dupes && dupes.length > 0) continue;
     await supabase
       .from('session_coordination')
       .insert({
@@ -1664,6 +1687,28 @@ async function main() {
         subject: 'Claim on ' + (d.sd_key || 'unknown') + ' was released (PID dead)',
         body: 'Your session was detected as dead (PID ' + d.pid + '). Claim released. Available: ' + available.join(', '),
         payload: { released_sd: d.sd_key, reason: 'PID_DEAD', available_sds: available },
+        sender_type: 'sweep'
+      });
+  }
+  // Failed release writes announce the FAILURE with the error — never a phantom release.
+  for (const d of releaseFailedDead) {
+    const { data: dupes } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', d.session_id)
+      .eq('message_type', 'RELEASE_FAILED')
+      .gte('created_at', dedupSinceIso)
+      .limit(1);
+    if (dupes && dupes.length > 0) continue;
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: d.session_id,
+        target_sd: d.sd_key,
+        message_type: 'RELEASE_FAILED',
+        subject: 'Release of ' + (d.sd_key || 'unknown') + ' FAILED (PID dead, write rejected)',
+        body: 'Sweep detected this session dead (PID ' + d.pid + ') but the release UPDATE failed: ' + d.release_error,
+        payload: { released_sd: d.sd_key, reason: 'PID_DEAD_RELEASE_FAILED', error: d.release_error },
         sender_type: 'sweep'
       });
   }

--- a/tests/unit/stale-sweep-qf162-release-announce.test.js
+++ b/tests/unit/stale-sweep-qf162-release-announce.test.js
@@ -1,0 +1,77 @@
+// QF-20260611-162: CLAIM_RELEASED announce-vs-write split.
+// Before: the announce loop iterated ALL `dead` sessions, but the release loop
+// `continue`s on four hold guards (WIP, MC, hardcap-pid-alive, cross-signal) and
+// the UPDATE can fail — so held/failed releases were announced as CLAIM_RELEASED
+// every ~5min forever while claiming_session_id persisted (7+ phantom announces
+// across 2 SDs on 2026-06-11). After: only write-verified releases announce
+// CLAIM_RELEASED; failed writes announce RELEASE_FAILED with the error; both are
+// deduped to once per session per 30 minutes.
+// Static source assertions per the project convention for this monolithic script
+// (see stale-sweep-qf211-claim-guards.test.js).
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/stale-session-sweep.cjs');
+const src = readFileSync(SCRIPT, 'utf8');
+
+describe('QF-20260611-162: write-checked release tracking', () => {
+  it('declares releasedDead and releaseFailedDead trackers next to the dead classification', () => {
+    expect(src).toMatch(/const releasedDead = \[\];/);
+    expect(src).toMatch(/const releaseFailedDead = \[\];/);
+  });
+
+  it('pushes to releasedDead ONLY on the success branch of the release UPDATE', () => {
+    const idx = src.indexOf('releasedDead.push(s)');
+    expect(idx).toBeGreaterThan(0);
+    // the push must sit in the else of `if (error)` — i.e. after the FAILED action line
+    const before = src.slice(idx - 400, idx);
+    expect(before).toMatch(/if \(error\) \{/);
+    expect(before).toMatch(/FAILED to release/);
+  });
+
+  it('pushes failed releases (with the error) to releaseFailedDead', () => {
+    expect(src).toMatch(/releaseFailedDead\.push\(\{ \.\.\.s, release_error: error\.message \}\)/);
+  });
+});
+
+describe('QF-20260611-162: announce loop iterates verified releases, not raw dead', () => {
+  it('the PID-dead CLAIM_RELEASED announce iterates releasedDead', () => {
+    expect(src).toMatch(/for \(const d of releasedDead\)/);
+  });
+
+  it('the legacy `for (const d of dead)` announce loop is GONE', () => {
+    // `dead` is still used for classification/release, but never as the announce iterator
+    expect(src).not.toMatch(/for \(const d of dead\)/);
+  });
+
+  it('failed writes announce RELEASE_FAILED carrying the error, never CLAIM_RELEASED', () => {
+    const idx = src.indexOf("message_type: 'RELEASE_FAILED'");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx - 600, idx + 600);
+    expect(block).toMatch(/for \(const d of releaseFailedDead\)/);
+    expect(block).toMatch(/PID_DEAD_RELEASE_FAILED/);
+    expect(block).toMatch(/error: d\.release_error/);
+  });
+});
+
+describe('QF-20260611-162: 30-minute announce dedup', () => {
+  it('defines a 30-minute dedup window', () => {
+    expect(src).toMatch(/const ANNOUNCE_DEDUP_MIN = 30;/);
+  });
+
+  it('both announce loops check for a recent same-type message to the same session before inserting', () => {
+    // two dedup probes: one for CLAIM_RELEASED, one for RELEASE_FAILED
+    const claimDedup = src.match(/\.eq\('message_type', 'CLAIM_RELEASED'\)\s*\n\s*\.gte\('created_at', dedupSinceIso\)/);
+    const failDedup = src.match(/\.eq\('message_type', 'RELEASE_FAILED'\)\s*\n\s*\.gte\('created_at', dedupSinceIso\)/);
+    expect(claimDedup).toBeTruthy();
+    expect(failDedup).toBeTruthy();
+  });
+
+  it('dedup skips with continue (no insert) when a recent announce exists', () => {
+    const idx = src.indexOf('const ANNOUNCE_DEDUP_MIN');
+    const after = src.slice(idx, idx + 2500);
+    expect(after).toMatch(/if \(dupes && dupes\.length > 0\) continue;/);
+  });
+});


### PR DESCRIPTION
## QF-20260611-162 — CLAIM_RELEASED announces only write-verified releases

**Type**: bug | **Severity**: high | **Tier**: 2 (Standard QF)

### Problem (7+ live events, 2026-06-11)
The sweep's PID-dead announce loop iterated **all** dead-classified sessions, but the release loop `continue`s on four hold guards (WIP, MC, hardcap-pid-alive, cross-signal) and the `claude_sessions` UPDATE can fail — so held/failed releases were announced as `CLAIM_RELEASED` every ~5 minutes **forever** while `claiming_session_id` persisted (MAKE-VENTURE-STAGE 4×, GREEN-MAIN-TRIAGE 3×; the SD rows' `updated_at` predated every announce).

### Fix (announce-after-write, per the QF spec)
- `releasedDead[]` / `releaseFailedDead[]`: a session is announced as released **only after the release UPDATE succeeded**; failures carry the error
- Failed writes announce `RELEASE_FAILED` with the error — never a phantom `CLAIM_RELEASED`
- 30-min dedup on both announce types (same session+type within window → skip)
- Held sessions (guards) announce **nothing** — they were never released
- Manual claim-nulling deliberately NOT done (the bug is the unchecked write path)

### Verification
- 9 new static-source regression tests (project convention for the monolithic sweep, mirrors `stale-sweep-qf211-claim-guards`); all 4 sweep suites **33/33**
- Live sweep run clean (no errors, no phantom announces)
- `session_coordination` has no message_type check constraint — `RELEASE_FAILED` verified insertable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
