### PR TITLE
fix(tests): claim-guard mock missing .maybeSingle — stops BASELINE_REGRESSION on every PR (QF-20260610-366)

### DIFF
--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -35,6 +35,14 @@ vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => mockSupabase)
 }));
 
+// QF-20260610-366: mock the db-clock (SD-FDBK-INFRA-NODE-CLOCK-SKEW-001). claimGuard's
+// staleness math reads ONE v_active_sessions row purely for a clock-skew-safe "now";
+// stubbing it keeps the "never queries v_active_sessions for CLAIMS" assertion valid
+// and makes staleness tests deterministic on the node clock.
+vi.mock('./fleet/db-clock.mjs', () => ({
+  getDbNowMs: vi.fn(async () => Date.now())
+}));
+
 /**
  * Helper: Build a Supabase query chain mock for claude_sessions initial claim check.
  * Query pattern: .from('claude_sessions').select(...).eq('sd_key', key).in('status', ['active', 'idle'])
@@ -124,7 +132,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
     });
 
     await claimGuard('SD-TEST-001', 'session-1');
@@ -157,7 +165,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
     });
 
     await claimGuard('SD-TEST-001', 'session-1');
@@ -195,7 +203,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }), update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }) };
     });
 
     const result = await claimGuard('SD-TEST-001', 'session-1');
@@ -243,7 +251,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await claimGuard('SD-TEST-001', 'session-1');
@@ -303,12 +311,18 @@ describe('claimGuard', () => {
       }
       if (table === 'strategic_directives_v2') {
         return {
+          // QF-20260610-366: status pre-check (.select().eq().maybeSingle()) — null row = fail-open
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+            })
+          }),
           update: vi.fn().mockReturnValue({
             eq: vi.fn().mockResolvedValue({ data: null, error: null })
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     mockRpc.mockImplementation((funcName) => {
@@ -357,12 +371,18 @@ describe('claimGuard', () => {
       }
       if (table === 'strategic_directives_v2') {
         return {
+          // QF-20260610-366: status pre-check (.select().eq().maybeSingle()) — null row = fail-open
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+            })
+          }),
           update: vi.fn().mockReturnValue({
             eq: vi.fn().mockResolvedValue({ data: null, error: null })
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     mockRpc.mockResolvedValue({
@@ -382,7 +402,7 @@ describe('claimGuard', () => {
       if (table === 'claude_sessions') {
         return mockClaudeSessionsClaimQuery(null, { message: 'Connection refused' });
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     await expect(claimGuard('SD-TEST-001', 'session-1'))
@@ -412,7 +432,7 @@ describe('claimGuard', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     mockRpc.mockResolvedValue({
@@ -457,7 +477,7 @@ describe('verifyClaimOwnership', () => {
           session_id: 'session-1', sd_key: 'SD-TEST-001', status: 'active'
         }]);
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
@@ -473,7 +493,7 @@ describe('verifyClaimOwnership', () => {
           session_id: 'other-session', sd_key: 'SD-TEST-001', status: 'active'
         }]);
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
@@ -488,7 +508,7 @@ describe('verifyClaimOwnership', () => {
       if (table === 'claude_sessions') {
         return mockClaudeSessionsClaimQuery([]);
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
@@ -505,7 +525,7 @@ describe('verifyClaimOwnership', () => {
           { session_id: 'session-2', sd_key: 'SD-TEST-001', status: 'idle' }
         ]);
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
@@ -519,7 +539,7 @@ describe('verifyClaimOwnership', () => {
       if (table === 'claude_sessions') {
         return mockClaudeSessionsClaimQuery(null, { message: 'timeout' });
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
@@ -589,7 +609,7 @@ describe('claimGuard - stale PID liveness check', () => {
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     const result = await claimGuard('SD-TEST-001', 'session-1');
@@ -651,12 +671,18 @@ describe('claimGuard - stale PID liveness check', () => {
       }
       if (table === 'strategic_directives_v2') {
         return {
+          // QF-20260610-366: status pre-check (.select().eq().maybeSingle()) — null row = fail-open
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+            })
+          }),
           update: vi.fn().mockReturnValue({
             eq: vi.fn().mockResolvedValue({ data: null, error: null })
           })
         };
       }
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
 
     mockRpc.mockImplementation((funcName) => {
@@ -865,7 +891,7 @@ describe('resolveClaimTtlSeconds - FR19 sd_type-aware TTL', () => {
       if (table === 'chairman_dashboard_config') return mockConfigQuery(metadata);
       if (table === 'strategic_directives_v2') return mockTypeQuery(sdRow, { throws: sdThrows });
       if (table === 'quick_fixes') return mockTypeQuery(qfRow);
-      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
     });
   }
 

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -43,14 +43,6 @@
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
     {
-      "file": "lib/claim-guard.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: supabase.from(...).select(...).eq(...).maybeSingle is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "lib/eva/__tests__/lifecycle-terminal-orchestrator.test.js",
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected { handled: true, …(2) } to deeply equal { Object (handled, completed, ...) }",


### PR DESCRIPTION
## Summary
Every PR since 083d335230 (#4605) failed Test Coverage Enforcement with the same new failure: `supabase.from(...).select(...).eq(...).maybeSingle is not a function` at lib/claim-guard.mjs:300 (witnessed on runs 27319083708 / 27318731588).

- extend all 16 fallback mock chains + the 3 `strategic_directives_v2` table mocks with `.maybeSingle` (fail-open `{data:null}`) for the SD-status pre-check
- `vi.mock` the db-clock helper (its `v_active_sessions` read is the clock-skew fix, not a claim query — keeps the 'never queries v_active_sessions for claims' assertion honest and staleness tests deterministic)
- de-quarantine `lib/claim-guard.test.js` (quarantined earlier today for this exact signature)

## Verification
- 41/41 green under the unit project (was 41/41 failing on import, then 4 failing after the first mock pass)
- Ratchet snapshot NOT regenerated (per QF directive — fix, don't absorb)

Quick-fix QF-20260610-366 (severity high). 🤖 Generated with [Claude Code](https://claude.com/claude-code)