### PR TITLE
fix(SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001): wire the dead-on-arrival EXEC-TO-PLAN FR gate; retire 2 unwired/superseded modules

### DIFF
--- a/.worktree-nm-mode
+++ b/.worktree-nm-mode
@@ -1,1 +1,1 @@
-junction
+isolated

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-FIX-PERSIST-KILL-GATE-001",
-  "expectedBranch": "feat/SD-LEO-FIX-PERSIST-KILL-GATE-001",
-  "createdAt": "2026-06-10T23:31:54.073Z",
+  "sdKey": "SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001",
+  "expectedBranch": "feat/SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001",
+  "createdAt": "2026-06-11T11:16:52.397Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/_deprecated/feature-flag-expiry-checker.js
+++ b/scripts/_deprecated/feature-flag-expiry-checker.js
@@ -1,5 +1,18 @@
 #!/usr/bin/env node
 /**
+ * RETIRED 2026-06-11 (SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001).
+ * Zero references anywhere (package.json, .github, hooks, crons) - the recommended
+ * 15-minute cron was NEVER armed, so this job never ran in production.
+ * SUPERSEDED by the flag-governance machinery (2026-06-09): lib/feature-flags/
+ * governance-review.js consumes expiry_at and surfaces past-expiry flags in the
+ * weekly stale-flag digest with an extend/kill recommendation
+ * (scripts/flag-governance-review.mjs, FLAG_GOVERNANCE_REVIEW_V1).
+ * SEMANTIC DELTA (documented deliberately): this job AUTO-TRANSITIONED
+ * lifecycle_state='expired'; the new machinery RECOMMENDS to a human instead -
+ * consistent with the deliberate-flip governance design (no automated lifecycle
+ * mutations). Since the job never ran, no behavior actually changed at retirement.
+ */
+/**
  * Feature Flag Expiry Checker
  * SD-LEO-SELF-IMPROVE-001K - Phase 6: Feature Flag Governance
  *

--- a/scripts/_deprecated/pre-commit-secret-scan.sh
+++ b/scripts/_deprecated/pre-commit-secret-scan.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# RETIRED 2026-06-11 (SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001).
+# This script was NEVER wired into any .husky hook (zero references since ship by
+# SD-LEO-ORCH-SECURITY-AUDIT-REMEDIATION-001-A) - a secret scanner that never ran.
+# The LIVE pre-commit secret scan is INLINE in .husky/pre-commit (~lines 228-300,
+# SD-SEC-CREDENTIAL-ROTATION-001) and is a strict pattern SUPERSET of this file
+# (adds Anthropic keys, AWS access/secret keys, private-key blocks, connection
+# strings, generic api_key/secret_key patterns) and runs on every commit.
+# Decision: retire rather than wire (redundant). Flagged to the security-posture
+# review via the durable feedback channel. Do not re-wire without diffing patterns
+# against the inline scan first.
 # Pre-commit hook: Block commits containing hardcoded secrets
 # Installed by SD-LEO-ORCH-SECURITY-AUDIT-REMEDIATION-001-A
 #

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -47,6 +47,11 @@ import { createProtocolFileReadGate } from '../../gates/protocol-file-read-gate.
 // Scope Completion Verification Gate (SD-LEO-INFRA-COMPLETION-SCOPE-VERIFICATION-001)
 import { createScopeCompletionGate } from '../../gates/scope-completion-gate.js';
 
+// FR Delivery Traceability (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001, built for THIS boundary;
+// wired by SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001 — was dead-on-arrival with zero importers).
+// Warn-only by default (LEO_FR_TRACEABILITY_ENFORCE unset) + fail-open on classifier errors.
+import { createFrDeliveryTraceabilityGate } from '../../gates/fr-delivery-traceability-gate.js';
+
 // Parent Orchestrator Detection (SD-LEO-INFRA-ORCH-PARENT-LIFECYCLE-001 FR-1, FR-2)
 import { isParentOrchestrator as isParentOrchestratorAsync } from '../../../../../lib/handoff/parent-detection.js';
 import { getParentOrchestratorExecToPlanGates } from './parent-orchestrator.js';
@@ -263,6 +268,10 @@ export class ExecToPlanExecutor extends BaseExecutor {
       // Scope Completion Verification (applies to children too)
       gates.push(createScopeCompletionGate());
 
+      // FR Delivery Traceability — children were the original gap this gate closes
+      // (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001); warn-only default, fail-open.
+      gates.push(createFrDeliveryTraceabilityGate(this.supabase));
+
       return gates;
     }
 
@@ -308,6 +317,11 @@ export class ExecToPlanExecutor extends BaseExecutor {
     // Integration contract gate (SD-LEO-INFRA-INTEGRATION-AWARE-PRD-001 FR-2)
     // Verifies integration_contract items from PRD metadata are present in codebase
     gates.push(createIntegrationContractGate(this.supabase));
+
+    // FR Delivery Traceability (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001, built for this
+    // boundary; wired by SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001). Warn-only by default
+    // (LEO_FR_TRACEABILITY_ENFORCE unset) + fail-open on classifier errors.
+    gates.push(createFrDeliveryTraceabilityGate(this.supabase));
 
     // Story auto-validation (SD-LEO-FIX-STORIES-SUB-AGENT-001)
     // Validates user stories after EXEC completion

--- a/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
+++ b/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
@@ -1,53 +1,77 @@
 /**
  * FR Delivery Traceability gate for the EXEC-TO-PLAN completion boundary.
- * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001.
+ * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001 (built) / SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001 (wired).
  *
  * Closes the gap where orchestrator CHILDREN (and normal SDs) reached EXEC-TO-PLAN with only
  * proxy gates and FR delivery was never checked until LEAD-FINAL (and even then via an
  * any-story proxy). Reuses the SAME shared per-FR classifier as the LEAD-FINAL gate, so the
  * logic cannot drift between boundaries. Enforcement gated by LEO_FR_TRACEABILITY_ENFORCE
  * (default OFF = warn-only -> zero blast radius).
+ *
+ * Shipped 2026-06-08 but never imported by any executor (dead on arrival — WIRE_CHECK did not
+ * flag the exported-no-caller factory). Wired into exec-to-plan/index.js (both the
+ * orchestrator-child path and the normal path) by SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001.
  */
 import { classifyFrDelivery, projectGateResult, isFrTraceabilityEnforced } from './fr-delivery-classifier.js';
+
+/** The real validation body — separated so the fail-open wrapper below stays trivial. */
+async function runFrDeliveryTraceability(supabase, ctx) {
+  console.log('\n🔒 GATE: FR Delivery Traceability (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001)');
+  console.log('-'.repeat(50));
+  const sd = ctx.sd || {};
+  // Orchestrator PARENTS delegate FR delivery to their children — skip here.
+  const { data: children } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq('parent_sd_id', sd.id);
+  if (children && children.length > 0) {
+    console.log('   ℹ️  Orchestrator parent — FR delivery delegated to children');
+    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator parent — FR delivery delegated to children'], required: false };
+  }
+
+  const classification = await classifyFrDelivery(supabase, {
+    sdId: sd.id,
+    // product_requirements_v2.directive_id stores the sd_key, not the UUID — pass it so
+    // the PRD/FR lookup resolves at this boundary (UUID-only would vacuously find 0 FRs).
+    directiveId: sd.sd_key || sd.id,
+    sdMetadata: sd.metadata || {},
+    requesterSessionId: ctx.sessionId || ctx.session_id || null,
+  });
+
+  if (classification.total === 0) {
+    console.log('   ℹ️  No functional requirements in PRD (or no PRD) — nothing to verify');
+    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No functional requirements found for FR delivery traceability'], required: false };
+  }
+
+  for (const f of classification.frs) {
+    const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
+    console.log(`   ${mark} ${f.id} [${f.status}]`);
+  }
+  const enforced = isFrTraceabilityEnforced();
+  console.log(`   📊 ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
+  return projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_TRACEABILITY' });
+}
 
 export function createFrDeliveryTraceabilityGate(supabase) {
   return {
     name: 'FR_DELIVERY_TRACEABILITY',
     validator: async (ctx) => {
-      console.log('\n🔒 GATE: FR Delivery Traceability (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001)');
-      console.log('-'.repeat(50));
-      const sd = ctx.sd || {};
-      // Orchestrator PARENTS delegate FR delivery to their children — skip here.
-      const { data: children } = await supabase
-        .from('strategic_directives_v2')
-        .select('id')
-        .eq('parent_sd_id', sd.id);
-      if (children && children.length > 0) {
-        console.log('   ℹ️  Orchestrator parent — FR delivery delegated to children');
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator parent — FR delivery delegated to children'], required: false };
+      // SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001 (FR-2): fail-open in non-enforced mode.
+      // ValidationOrchestrator blocks on the STATIC gate.required=true whenever a
+      // validator THROWS — so a transient classifier DB error (3 live round-trips)
+      // would hard-fail every EXEC-TO-PLAN even though the gate is warn-only by
+      // default. Off => thrown errors resolve to a passing warn result; ON => strict.
+      try {
+        return await runFrDeliveryTraceability(supabase, ctx);
+      } catch (err) {
+        if (isFrTraceabilityEnforced()) throw err;
+        console.log(`   ⚠️  FR traceability errored in warn-only mode (fail-open): ${err.message}`);
+        return {
+          passed: true, score: 100, max_score: 100, issues: [],
+          warnings: [`FR delivery traceability errored (warn-only, fail-open): ${err.message}`],
+          required: false
+        };
       }
-
-      const classification = await classifyFrDelivery(supabase, {
-        sdId: sd.id,
-        // product_requirements_v2.directive_id stores the sd_key, not the UUID — pass it so
-        // the PRD/FR lookup resolves at this boundary (UUID-only would vacuously find 0 FRs).
-        directiveId: sd.sd_key || sd.id,
-        sdMetadata: sd.metadata || {},
-        requesterSessionId: ctx.sessionId || ctx.session_id || null,
-      });
-
-      if (classification.total === 0) {
-        console.log('   ℹ️  No functional requirements in PRD (or no PRD) — nothing to verify');
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No functional requirements found for FR delivery traceability'], required: false };
-      }
-
-      for (const f of classification.frs) {
-        const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
-        console.log(`   ${mark} ${f.id} [${f.status}]`);
-      }
-      const enforced = isFrTraceabilityEnforced();
-      console.log(`   📊 ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
-      return projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_TRACEABILITY' });
     },
     required: true
   };

--- a/tests/unit/fr-delivery-traceability-wiring.test.js
+++ b/tests/unit/fr-delivery-traceability-wiring.test.js
@@ -1,0 +1,82 @@
+// SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001: the FR_DELIVERY_TRACEABILITY gate shipped
+// 2026-06-08 for the EXEC-TO-PLAN boundary with ZERO importers (dead on arrival;
+// WIRE_CHECK missed the exported-no-caller factory). Pins: (1) the gate is wired
+// into BOTH exec-to-plan gate paths; (2) the FR-2 fail-open contract — a thrown
+// classifier in warn-only mode resolves to a passing warn result instead of
+// hard-failing the handoff via ValidationOrchestrator's static-required block;
+// (3) the two reconciled dead files are gone from live paths.
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const EXEC_TO_PLAN = path.resolve(__dirname, '../../scripts/modules/handoff/executors/exec-to-plan/index.js');
+const src = readFileSync(EXEC_TO_PLAN, 'utf8');
+
+describe('FR-1: gate wired into exec-to-plan', () => {
+  it('imports createFrDeliveryTraceabilityGate from the gates module', () => {
+    expect(src).toMatch(/import \{ createFrDeliveryTraceabilityGate \} from '\.\.\/\.\.\/gates\/fr-delivery-traceability-gate\.js'/);
+  });
+
+  it('pushes the gate in BOTH the orchestrator-child path and the normal path (2 sites)', () => {
+    const pushes = src.match(/gates\.push\(createFrDeliveryTraceabilityGate\(this\.supabase\)\)/g) || [];
+    expect(pushes).toHaveLength(2);
+  });
+
+  it('the child-path push sits inside the child branch (between scope-completion and the early return)', () => {
+    const childStart = src.indexOf('Scope Completion Verification (applies to children too)');
+    const childReturn = src.indexOf('return gates;', childStart);
+    expect(childStart).toBeGreaterThan(0);
+    const childBlock = src.slice(childStart, childReturn);
+    expect(childBlock).toMatch(/createFrDeliveryTraceabilityGate\(this\.supabase\)/);
+  });
+});
+
+describe('FR-2: fail-open contract in warn-only mode', async () => {
+  // Stub the classifier module so the gate factory can be exercised hermetically.
+  vi.mock('../../scripts/modules/handoff/gates/fr-delivery-classifier.js', () => ({
+    classifyFrDelivery: vi.fn(),
+    projectGateResult: vi.fn(() => ({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] })),
+    isFrTraceabilityEnforced: vi.fn(() => process.env.LEO_FR_TRACEABILITY_ENFORCE === 'true'),
+  }));
+  const { createFrDeliveryTraceabilityGate } = await import('../../scripts/modules/handoff/gates/fr-delivery-traceability-gate.js');
+
+  function throwingSupabase() {
+    return { from: () => { throw new Error('transient db error'); } };
+  }
+
+  it('thrown classifier path with enforcement OFF => passing warn result (never blocks)', async () => {
+    delete process.env.LEO_FR_TRACEABILITY_ENFORCE;
+    const gate = createFrDeliveryTraceabilityGate(throwingSupabase());
+    const result = await gate.validator({ sd: { id: 'x', sd_key: 'SD-X' } });
+    expect(result.passed).toBe(true);
+    expect(result.required).toBe(false);
+    expect(result.warnings.join(' ')).toMatch(/fail-open/);
+  });
+
+  it('thrown classifier path with enforcement ON => error propagates (strict)', async () => {
+    process.env.LEO_FR_TRACEABILITY_ENFORCE = 'true';
+    try {
+      const gate = createFrDeliveryTraceabilityGate(throwingSupabase());
+      await expect(gate.validator({ sd: { id: 'x', sd_key: 'SD-X' } })).rejects.toThrow('transient db error');
+    } finally {
+      delete process.env.LEO_FR_TRACEABILITY_ENFORCE;
+    }
+  });
+});
+
+describe('FR-3/FR-4: dead files retired from live paths', () => {
+  const ROOT = path.resolve(__dirname, '../..');
+  it('pre-commit-secret-scan.sh moved to _deprecated (inline husky scan is the live one)', () => {
+    expect(existsSync(path.join(ROOT, 'scripts/hooks/pre-commit-secret-scan.sh'))).toBe(false);
+    expect(existsSync(path.join(ROOT, 'scripts/_deprecated/pre-commit-secret-scan.sh'))).toBe(true);
+  });
+  it('feature-flag-expiry-checker.js moved to _deprecated (governance digest covers expiry_at)', () => {
+    expect(existsSync(path.join(ROOT, 'scripts/jobs/feature-flag-expiry-checker.js'))).toBe(false);
+    expect(existsSync(path.join(ROOT, 'scripts/_deprecated/feature-flag-expiry-checker.js'))).toBe(true);
+  });
+  it('the inline husky secret scan is still present', () => {
+    const husky = readFileSync(path.join(ROOT, '.husky/pre-commit'), 'utf8');
+    expect(husky).toMatch(/secret detection scan/i);
+  });
+});


### PR DESCRIPTION
## SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001 — reconcile three dead-on-arrival modules

**Type**: bugfix | **Priority**: medium | Gates: LEAD-TO-PLAN 93, PLAN-TO-EXEC 94 | RISK PASS-88 (row f8cd27df)

### 1. WIRED — FR_DELIVERY_TRACEABILITY at EXEC-TO-PLAN
`fr-delivery-traceability-gate.js` was built *for* this boundary (SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001, 2026-06-08) and shipped with **zero importers**. Now pushed in both exec-to-plan gate paths (orchestrator-child + normal), warn-only by default.

**RISK mitigation built in (the load-bearing finding)**: `ValidationOrchestrator` blocks on the *static* `gate.required=true` when a validator throws — a transient classifier DB error would have hard-failed every EXEC-TO-PLAN fleet-wide even in warn-only mode. Thrown errors now resolve to a passing warn result unless `LEO_FR_TRACEABILITY_ENFORCE` is on (strict propagation preserved + unit-pinned both directions).

### 2. RETIRED — `pre-commit-secret-scan.sh` → `_deprecated/`
Never referenced by any `.husky` hook (false comfort since ship). The inline husky scan (SD-SEC-CREDENTIAL-ROTATION-001) is a **strict pattern superset** (Anthropic/AWS keys, private-key blocks, connection strings, generics) and runs on every commit. Decision flagged to the security-posture review (feedback filed).

### 3. ARCHIVED — `feature-flag-expiry-checker.js` → `_deprecated/`
Zero references; its recommended cron was never armed. Superseded by the flag-governance digest (`governance-review.js` consumes `expiry_at`: past-expiry ⇒ extend/kill recommendation). Semantic delta documented in the archive header: auto-transition → human recommendation (deliberate-flip design). Nothing ran before, so zero behavior change.

### Plus: WIRE_CHECK false-negative ledger entry
Exported-no-caller factory passes the reachability walk; the same PR's inline `gates.js` contained matching FR_DELIVERY strings so string-level probes matched the *feature*, not the *file*. Filed with a hardening suggestion (flag new gate/executor files whose exports have zero import sites in the same PR).

### Verification
- 8 new wiring/fail-open/retirement pins + classifier suite **27/27**
- exec-to-plan index import-smoked clean
- Gate witnessed executing warn-only in a live `handoff.js precheck EXEC-TO-PLAN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
