### PR TITLE
feat(SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001): scripts-reachability gauge + scratch-sweep extension + liveness norm (PR-A)

### DIFF
--- a/docs/03_protocols_and_standards/scripts-estate-liveness.md
+++ b/docs/03_protocols_and_standards/scripts-estate-liveness.md
@@ -1,0 +1,57 @@
+---
+category: protocol
+status: active
+version: 1.0.0
+author: SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001
+last_updated: 2026-06-11
+tags: [protocol, scripts, liveness, hygiene]
+---
+# Scripts-Estate Liveness Norm
+
+## The norm
+
+**Every script kept under `scripts/` (outside `scripts/archive/`) MUST be reachable from
+at least one liveness anchor:**
+
+1. a `package.json` npm alias,
+2. a git hook (`.husky/**`) or Claude Code hook (`.claude/settings*.json`),
+3. a GitHub workflow (`.github/**`),
+4. a skill/command/agent definition (`.claude/commands/**`, `.claude/agents/**`),
+5. a cron registry (`STANDARD_LOOPS` in `scripts/coordinator-startup-check.mjs` /
+   `COORDINATOR_CRONS` in `lib/coordinator/teardown-coordinator.cjs`),
+6. another reachable script/module, or a doc that tells humans/agents to run it
+   (`docs/**`, `CLAUDE*.md`, `templates/**`).
+
+A script nothing reaches is an **orphan**. Orphans are not kept "just in case":
+
+- **Throwaway work** goes in `scripts/tmp/` or `scripts/temp/` — these are sweepable
+  (auto-pruned by `scripts/maintenance/sweep-worker-scratch.mjs` once untracked files
+  are older than 7 days) — or in `scripts/one-off/` when it must be tracked.
+- **Superseded/dead work** is moved to `scripts/archive/` via `git mv`
+  (see `scripts/archive/README.md` for the convention).
+
+**Preferred liveness anchor: an npm alias.** If a script is worth keeping, it is worth
+one line in `package.json` — that line is what makes it discoverable, greppable, and
+provably alive (WIRE_CHECK and the reachability gauge both treat `package.json` as an
+entry-point source).
+
+## Enforcement seams (both advisory-first, neither CI-blocking)
+
+| Direction | Tool | When it runs |
+|---|---|---|
+| Forward — "which scripts does NOTHING reference?" | `npm run sre:scripts-reachability` (`scripts/scripts-reachability-gauge.mjs`) | Weekly coordinator cron (`40 9 * * 1`); persists a `coordination_events` `SCRIPTS_REACHABILITY_SNAPSHOT` baseline series; alerts the coordinator inbox only on orphan growth (+>=10/week) or broken npm aliases |
+| Reverse — "does every reference point at a real file?" | `scripts/validate-script-references.js` | Pre-commit (`.husky/pre-commit`, `--staged`); blocks deleting/moving a script something still references |
+
+## Known blind spots (why the gauge is advisory)
+
+The gauge matches basenames against a filesystem haystack. It cannot see references
+stored only in the database (cron prompt strings, `leo_protocol_sections`), dynamically
+constructed paths, or references from the EHG sibling repo. **An orphan flag is a triage
+candidate, never a deletion warrant** — archive in verified batches, with the pre-commit
+reverse check as the safety net.
+
+## Provenance
+
+SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001, productizing the chairman's 2026-06-10
+scripts-sprawl review (4,562 files; 717/2,091 live candidates orphaned; scratch dirs
+accumulating ~600 files with no lifecycle).

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -45,7 +45,9 @@ const COORDINATOR_CRONS = [
   // SD-LEO-INFRA-STANDING-ROW-GROWTH-001: daily governance row-growth gauge (internally due-gated).
   { key: 'row-growth', cadence: '30 8 * * *',                                command: 'node scripts/row-growth-snapshot.cjs',      re_asserts_pointer: false },
   // SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001: weekly subsystem-review rotation (due-gated internally).
-  { key: 'review-rotation', cadence: '0 9 * * 1',                            command: 'node scripts/subsystem-review-rotation.cjs', re_asserts_pointer: false }
+  { key: 'review-rotation', cadence: '0 9 * * 1',                            command: 'node scripts/subsystem-review-rotation.cjs', re_asserts_pointer: false },
+  // SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001: weekly scripts-estate reachability gauge (due-gated internally).
+  { key: 'scripts-reachability', cadence: '40 9 * * 1',                       command: 'node scripts/scripts-reachability-gauge.mjs', re_asserts_pointer: false }
 ];
 
 // Basename markers used to recognise coordinator-owned jobs in a CronList() result. The

--- a/package.json
+++ b/package.json
@@ -378,6 +378,7 @@
     "prepark-wip": "node scripts/prepark-wip.cjs",
     "protocol:pub-audit": "node scripts/protocol-publication-audit.cjs",
     "sre:row-growth": "node scripts/row-growth-snapshot.cjs",
+    "sre:scripts-reachability": "node scripts/scripts-reachability-gauge.mjs",
     "subagents:collect": "node scripts/collect-subagent-evidence.js",
     "effort:readout": "node scripts/effort-experiment/readout.mjs",
     "effort:set-arm": "node scripts/effort-experiment/set-arm.mjs",

--- a/scripts/archive/README.md
+++ b/scripts/archive/README.md
@@ -1,0 +1,24 @@
+# scripts/archive — dead-script cold storage
+
+Scripts that are superseded, one-shot-completed, or verified-unreachable live here so
+the active `scripts/` estate stays navigable. Archived files are EXCLUDED from the
+reachability gauge's candidate set (`npm run sre:scripts-reachability`) and from npm
+alias resolution — landing here is what takes a script out of the liveness ledger.
+
+## Convention
+
+- **`git mv` only — never copy, never delete.** History stays attached; restoration is
+  `git mv` back (plus re-adding a liveness anchor, e.g. an npm alias).
+- **Reachability-sweep batches** go in a dated subdir preserving the original subpath:
+  `scripts/archive/<yyyymm>-reachability-sweep/<original/sub/path>` — so a restore is a
+  mechanical reverse move and provenance (which sweep, which scan) is the dirname.
+- **Category dirs** (pre-existing): `codex-integration/`, `handoffs/`, `migrations/`,
+  `one-time/`, `prd-scripts/`, `sd-scripts/`, `timeline-attempts/` — use these for
+  topic-driven archiving outside a sweep batch.
+- **Before archiving**, verify nothing references the file: the pre-commit hook runs
+  `scripts/validate-script-references.js --staged` and blocks moves that would break a
+  live reference — but also screen the blind spots it can't see (DB-stored cron prompt
+  strings, dynamically built paths, the EHG sibling repo).
+
+See `docs/03_protocols_and_standards/scripts-estate-liveness.md` for the liveness norm
+(SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001).

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -104,6 +104,14 @@ export const STANDARD_LOOPS = [
   // Converts idle-fleet gaps into review supply (4 reviews -> 27 evidenced SDs on 2026-06-10).
   { key: 'review-rotation', label: 'Subsystem review rotation (weekly)', script: 'subsystem-review-rotation.cjs', cron: '0 9 * * 1',
     prompt: 'node scripts/subsystem-review-rotation.cjs' },
+  // SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-1): weekly scripts-estate reachability
+  // gauge. Scans scripts/** against the reference haystack (package.json, .github, .husky,
+  // hooks/skills configs, docs, code, CLAUDE*.md), persists a coordination_events baseline
+  // series (SCRIPTS_REACHABILITY_SNAPSHOT) and alerts the coordinator inbox ONLY on growth
+  // (orphan_count +>=10 week-over-week) or broken npm aliases. Internally due-gated (~6d),
+  // so an extra arm or manual run is a cheap no-op. Advisory — never CI-blocking.
+  { key: 'scripts-reachability', label: 'Scripts-estate reachability gauge (weekly)', script: 'scripts-reachability-gauge.mjs', cron: '40 9 * * 1',
+    prompt: 'node scripts/scripts-reachability-gauge.mjs' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/scripts/maintenance/sweep-worker-scratch.mjs
+++ b/scripts/maintenance/sweep-worker-scratch.mjs
@@ -22,6 +22,9 @@
  *   node scripts/maintenance/sweep-worker-scratch.mjs --execute --older-than-hours 0   # delete all matched
  *   node scripts/maintenance/sweep-worker-scratch.mjs --auto           # hook mode: execute, throttled, silent, 24h gate
  *
+ *   scripts/tmp + scripts/temp candidates (SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 FR-2)
+ *   carry their own 7-day minimum age gate that --older-than-hours can NOT lower.
+ *
  * Exit codes: 0 always in --auto (fail-open so it can never block a session). In manual
  * mode, 0 on success, 1 on an unexpected error (so a human notices).
  */
@@ -62,6 +65,16 @@ const NEVER_DELETE_BASENAMES = new Set([
   '.coord-email-last.json', '.coord-review-last.json',
   '.adam-scan-ledger.json', 'docmon-report.json',
 ]);
+
+// Scripts scratch dirs (SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 FR-2): scripts/tmp
+// and scripts/temp are throwaway-by-convention but nothing pruned them (150 + 159 files,
+// ~0-1 tracked, by the 2026-06-10 sprawl scan). Swept recursively, UNTRACKED-ONLY (the
+// trackedSet invariant in main() covers these candidates like any other) and with their
+// own 7-DAY minimum age gate — these are bigger artifacts than session scratch, and the
+// per-candidate gate cannot be lowered by --older-than-hours (Math.max in main()).
+// scripts/one-off stays EXCLUDED (179+ tracked deliverables + live-cron scripts mix in).
+const SCRIPTS_SCRATCH_ROOTS = ['scripts/tmp', 'scripts/temp'];
+const SCRIPTS_SCRATCH_MIN_AGE_HOURS = 7 * 24;
 
 const ROOT_SCRATCH_RE = /^_.+\.(mjs|cjs|json|diff|txt|sh|sql)$/; // root-level ad-hoc scratch
 const MONITOR_PID_RE = /^\.monitor-.+\.pid$/;      // stale monitor PID files (scoped; NOT *.pid)
@@ -113,7 +126,8 @@ function dirSizeBytes(absPath) {
  */
 function findCandidates(root) {
   const out = [];
-  const add = (rel, bucket, isDir = false) => out.push({ rel, abs: path.join(root, rel), bucket, isDir });
+  const add = (rel, bucket, isDir = false, minAgeHours = 0) =>
+    out.push({ rel, abs: path.join(root, rel), bucket, isDir, minAgeHours });
 
   // 1) repo-root files: _*.mjs/_*.cjs probes, .monitor-*.pid, the stray artifact
   for (const name of fs.readdirSync(root)) {
@@ -145,6 +159,26 @@ function findCandidates(root) {
   for (const name of ROOT_BACKUP_DIRS) {
     const abs = path.join(root, name);
     if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) add(name, 'backup-dir', true);
+  }
+
+  // 4) scripts scratch dirs (recursive, files only — never the dirs themselves, so a
+  //    tracked file deep in a subtree can never be collateral). Untracked-only via the
+  //    trackedSet check in main(); 7-day per-candidate minimum age gate.
+  for (const scratchRoot of SCRIPTS_SCRATCH_ROOTS) {
+    const base = path.join(root, scratchRoot);
+    if (!fs.existsSync(base)) continue;
+    const stack = [base];
+    while (stack.length) {
+      const dir = stack.pop();
+      let entries = [];
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+      for (const entry of entries) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) { stack.push(abs); continue; }
+        const rel = path.relative(root, abs).replace(/\\/g, '/');
+        add(rel, 'scripts-scratch', false, SCRIPTS_SCRATCH_MIN_AGE_HOURS);
+      }
+    }
   }
 
   return out;
@@ -217,7 +251,10 @@ function main() {
     }
     let age;
     try { age = ageHours(c.abs); } catch { skipped.push({ ...c, why: 'stat-failed' }); continue; }
-    if (age < args.olderThanHours) { skipped.push({ ...c, why: `too-new(${age.toFixed(1)}h)` }); continue; }
+    // Per-candidate minimum age (scripts-scratch = 7d) can never be lowered by
+    // --older-than-hours: a global "0" must not turn the scripts dirs into a hair trigger.
+    const gateHours = Math.max(args.olderThanHours, c.minAgeHours || 0);
+    if (age < gateHours) { skipped.push({ ...c, why: `too-new(${age.toFixed(1)}h<${gateHours}h)` }); continue; }
     let bytes = 0;
     try { bytes = c.isDir ? dirSizeBytes(c.abs) : fs.statSync(c.abs).size; } catch { /* ignore */ }
     planned.push({ ...c, ageH: age, bytes });

--- a/scripts/scripts-reachability-gauge.mjs
+++ b/scripts/scripts-reachability-gauge.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * Scripts-estate reachability gauge — SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-1).
+ *
+ * Weekly standing SRE gauge over the scripts/ estate (productized from the
+ * chairman's 2026-06-10 sprawl scan, which found 717 of 2,091 live candidates
+ * referenced by nothing). Forward direction of the script-liveness norm:
+ *   - reverse direction (reference -> file exists) is scripts/validate-script-references.js
+ *     in the pre-commit hook;
+ *   - this gauge answers "which scripts does NOTHING reference?" and tracks the
+ *     trend so orphan growth is caught weekly, not by accident.
+ *
+ * What it does (mirrors scripts/row-growth-snapshot.cjs):
+ *   1. Due-gate: skip unless the latest SCRIPTS_REACHABILITY_SNAPSHOT coordination
+ *      event is older than ~6 days (or --force).
+ *   2. Scan: inventory scripts/**, build a reference haystack (package.json scripts,
+ *      .github, .husky, .claude/commands|agents|settings*, docs, scripts, lib, src,
+ *      server, api, templates, CLAUDE*.md) and classify candidates reachable/orphan.
+ *      .husky is included deliberately — its omission from the original scan made
+ *      live pre-commit hooks look orphaned (known false-positive class).
+ *   3. Persist ONE coordination_events row (the baseline series, fail-soft).
+ *   4. Alert leg ONLY on growth: orphan_count +>=10 vs prev snapshot, or any broken
+ *      npm alias -> coordinator inbox row (session_coordination INFO), same
+ *      mechanism as row-growth.
+ *
+ * KNOWN BLIND SPOTS (advisory gauge — never a kill list, never CI-blocking):
+ *   - references stored only in the DB (cron prompt strings, leo_protocol_sections),
+ *   - dynamically constructed paths, references from the EHG sibling repo.
+ *   An "orphan" here is a triage candidate. Archive via verified batches (FR-4 recipe).
+ *
+ * Scheduling: armed weekly by the coordinator (coordinator-startup-check.mjs
+ * STANDARD_LOOPS, cron '40 9 * * 1'). Ad-hoc: npm run sre:scripts-reachability [-- --force]
+ * ALWAYS exits 0 on operational paths (a gauge must never break its host loop).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+
+export const SNAPSHOT_EVENT_TYPE = 'SCRIPTS_REACHABILITY_SNAPSHOT';
+export const GAUGE_DUE_MS = 6 * 24 * 60 * 60 * 1000; // ~6d => weekly cron tick, tolerant of jitter
+export const ORPHAN_GROWTH_ALERT_THRESHOLD = 10;     // alert when orphan_count grows by >= this vs prev
+export const LIST_CAP = 50;                          // cap new/resolved lists in payload + alert body
+
+const SKIP_DIRS = new Set(['node_modules', '.git']);
+const SCRIPT_EXT_RE = /\.(js|cjs|mjs|ts|sh|ps1|py)$/;
+const REF_EXT_RE = /\.(js|cjs|mjs|ts|yml|yaml|json|md|sh|ps1)$/;
+const TEST_RE = /\.(test|spec)\.[jt]sx?$/;
+
+function* walk(dir) {
+  let entries = [];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+const isTest = (f) => TEST_RE.test(f) || f.includes('__tests__');
+
+/**
+ * Full estate scan (filesystem-only, no DB). Pure given a repo root + clock.
+ * @param {string} root repo root
+ * @param {number} [nowMs]
+ * @returns {{captured_at:string,total:number,candidates:number,reachable:number,orphan_count:number,
+ *            by_dir:Object<string,number>,age_buckets:Object<string,number>,
+ *            broken_npm_aliases:Array<{alias:string,file:string}>,orphans_full:string[]}}
+ */
+export function scanScriptsEstate(root, nowMs = Date.now()) {
+  const rel = (p) => path.relative(root, p).replace(/\\/g, '/');
+
+  // ---- inventory ----
+  const scriptFiles = [];
+  for (const f of walk(path.join(root, 'scripts'))) {
+    if (SCRIPT_EXT_RE.test(f)) scriptFiles.push(rel(f));
+  }
+
+  // ---- npm alias health ----
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+  const broken_npm_aliases = [];
+  for (const [name, cmd] of Object.entries(pkg.scripts || {})) {
+    const matches = [...cmd.matchAll(/(?:node|node --test|tsx)\s+(?:--[^\s]+\s+)*((?:scripts|lib|src|dist|tools)\/[^\s'"&|;]+\.(?:js|cjs|mjs|ts))/g)];
+    for (const m of matches) {
+      if (!fs.existsSync(path.join(root, m[1]))) broken_npm_aliases.push({ alias: name, file: m[1] });
+    }
+  }
+
+  // ---- reference haystack ----
+  // .husky added vs the original scratch scan (its hooks are extensionless shell
+  // files — read EVERY file there, the extension filter would skip them all).
+  const refDirs = ['.github', '.husky', '.claude/commands', '.claude/agents', 'docs', 'scripts', 'lib', 'src', 'server', 'api', 'templates'];
+  const refFiles = [];
+  for (const d of refDirs) {
+    const abs = path.join(root, d);
+    if (!fs.existsSync(abs)) continue;
+    const readAll = d === '.husky';
+    for (const f of walk(abs)) {
+      if (readAll || REF_EXT_RE.test(f)) refFiles.push(f);
+    }
+  }
+  for (const cfg of ['.claude/settings.json', '.claude/settings.local.json', 'CLAUDE.md', 'CLAUDE_CORE.md', 'CLAUDE_LEAD.md', 'CLAUDE_PLAN.md', 'CLAUDE_EXEC.md', 'CLAUDE_ADAM.md']) {
+    const abs = path.join(root, cfg);
+    if (fs.existsSync(abs)) refFiles.push(abs);
+  }
+  let haystack = JSON.stringify(pkg.scripts || {});
+  for (const f of refFiles) {
+    try { haystack += '\n' + fs.readFileSync(f, 'utf8'); } catch { /* skip unreadable */ }
+  }
+
+  // ---- reachability (basename match, self-reference excluded) ----
+  const candidates = scriptFiles.filter((f) => !isTest(f) && !f.startsWith('scripts/archive/'));
+  const orphans = [];
+  let reachableCount = 0;
+  for (const f of candidates) {
+    const base = path.basename(f);
+    let own = '';
+    try { own = fs.readFileSync(path.join(root, f), 'utf8'); } catch { /* treat as empty */ }
+    const globalCount = haystack.split(base).length - 1;
+    const ownCount = own.split(base).length - 1;
+    if (globalCount - ownCount > 0) reachableCount++;
+    else orphans.push(f);
+  }
+
+  // ---- orphan profile ----
+  const by_dir = {};
+  const age_buckets = { '<30d': 0, '30-90d': 0, '90-180d': 0, '>180d': 0 };
+  for (const f of orphans) {
+    const parts = f.split('/');
+    const key = parts.length > 2 ? parts.slice(0, 2).join('/') : 'scripts/(top)';
+    by_dir[key] = (by_dir[key] || 0) + 1;
+    let mtime = 0;
+    try { mtime = fs.statSync(path.join(root, f)).mtimeMs; } catch { /* bucket as oldest */ }
+    const ageDays = (nowMs - mtime) / 86_400_000;
+    if (ageDays < 30) age_buckets['<30d']++;
+    else if (ageDays < 90) age_buckets['30-90d']++;
+    else if (ageDays < 180) age_buckets['90-180d']++;
+    else age_buckets['>180d']++;
+  }
+
+  return {
+    captured_at: new Date(nowMs).toISOString(),
+    total: scriptFiles.length,
+    candidates: candidates.length,
+    reachable: reachableCount,
+    orphan_count: orphans.length,
+    by_dir,
+    age_buckets,
+    broken_npm_aliases,
+    orphans_full: orphans.sort(),
+  };
+}
+
+/**
+ * PURE: deltas vs the previous snapshot payload (null-safe — first baseline has no prev).
+ * @param {{orphan_count?:number, orphans_full?:string[]}|null} prev
+ * @param {{orphan_count:number, orphans_full:string[]}} curr
+ */
+export function computeDeltas(prev, curr) {
+  if (!prev || !Array.isArray(prev.orphans_full)) {
+    return { orphan_delta: null, new_orphans: [], resolved_orphans: [], new_orphans_total: 0, resolved_orphans_total: 0 };
+  }
+  const prevSet = new Set(prev.orphans_full);
+  const currSet = new Set(curr.orphans_full);
+  const newOrphans = curr.orphans_full.filter((f) => !prevSet.has(f));
+  const resolved = prev.orphans_full.filter((f) => !currSet.has(f));
+  return {
+    orphan_delta: curr.orphan_count - (prev.orphan_count ?? prev.orphans_full.length),
+    new_orphans: newOrphans.slice(0, LIST_CAP),
+    resolved_orphans: resolved.slice(0, LIST_CAP),
+    new_orphans_total: newOrphans.length,
+    resolved_orphans_total: resolved.length,
+  };
+}
+
+/**
+ * PURE: alert decision — ONLY on growth (orphan_delta >= threshold) or broken npm aliases.
+ * Shrinkage and steady state never alert; first baseline (orphan_delta null) never
+ * growth-alerts (broken aliases still do — they are point-in-time defects).
+ * @param {{orphan_delta:number|null}} deltas
+ * @param {{broken_npm_aliases:Array}} scan
+ * @returns {{alert:boolean, reasons:string[]}}
+ */
+export function shouldAlert(deltas, scan, threshold = ORPHAN_GROWTH_ALERT_THRESHOLD) {
+  const reasons = [];
+  if (Number.isFinite(deltas.orphan_delta) && deltas.orphan_delta >= threshold) {
+    reasons.push(`orphan_count grew by ${deltas.orphan_delta} since the previous snapshot (threshold ${threshold})`);
+  }
+  if (Array.isArray(scan.broken_npm_aliases) && scan.broken_npm_aliases.length > 0) {
+    reasons.push(`${scan.broken_npm_aliases.length} npm alias(es) point at missing files: ${scan.broken_npm_aliases.map((b) => b.alias).join(', ')}`);
+  }
+  return { alert: reasons.length > 0, reasons };
+}
+
+/** PURE: is a new snapshot due? (same shape as lib/coordinator/row-growth.cjs) */
+export function isSnapshotDue(lastCapturedAt, nowMs, dueMs = GAUGE_DUE_MS) {
+  if (!lastCapturedAt) return true;
+  const t = new Date(/Z$|[+-]\d{2}:?\d{2}$/.test(String(lastCapturedAt)) ? lastCapturedAt : lastCapturedAt + 'Z').getTime();
+  if (!Number.isFinite(t)) return true;
+  return nowMs - t >= dueMs;
+}
+
+/** IO (fail-soft): latest persisted snapshot payload, or null. */
+export async function readLatestSnapshot(sb) {
+  try {
+    const { data, error } = await sb
+      .from('coordination_events')
+      .select('payload, created_at')
+      .eq('event_type', SNAPSHOT_EVENT_TYPE)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error || !data || !data.length) return null;
+    const p = data[0].payload || {};
+    if (!Array.isArray(p.orphans_full)) return null;
+    return { ...p, captured_at: p.captured_at || data[0].created_at };
+  } catch { return null; }
+}
+
+async function resolveCoordinatorId(sb) {
+  try {
+    const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+    return await getActiveCoordinatorId(sb);
+  } catch { return null; }
+}
+
+export async function main() {
+  const force = process.argv.includes('--force');
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1')), '..');
+  const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+  const sb = createSupabaseServiceClient();
+
+  const prev = await readLatestSnapshot(sb);
+  if (!force && prev && !isSnapshotDue(prev.captured_at, Date.now())) {
+    console.log(`[scripts-reachability] not due (last snapshot ${prev.captured_at}) — no-op`);
+    return;
+  }
+
+  const scan = scanScriptsEstate(root);
+  const deltas = computeDeltas(prev, scan);
+  const payload = { ...scan, ...deltas };
+
+  // Persist the baseline point (non-fatal on failure — next run retries).
+  try {
+    const { error } = await sb.from('coordination_events').insert({
+      event_type: SNAPSHOT_EVENT_TYPE,
+      severity: 'info',
+      payload,
+    });
+    if (error) console.warn(`[scripts-reachability] snapshot persist failed (non-fatal): ${error.message}`);
+  } catch (e) { console.warn(`[scripts-reachability] snapshot persist threw (non-fatal): ${e.message}`); }
+
+  const { orphans_full, ...summary } = payload;
+  console.log(`[scripts-reachability] ${JSON.stringify(summary, null, 1)}`);
+  console.log(`[scripts-reachability] snapshot captured @ ${scan.captured_at}${prev ? ` (prev ${prev.captured_at})` : ' (first baseline — no growth check)'}`);
+
+  const verdict = shouldAlert(deltas, scan);
+  if (!verdict.alert) {
+    console.log('[scripts-reachability] no growth / no broken aliases — no alert');
+    return;
+  }
+
+  console.log(`[scripts-reachability] ⚠️  alert: ${verdict.reasons.join(' | ')}`);
+  // Alert leg: coordinator inbox row (same mechanism as row-growth-snapshot.cjs).
+  try {
+    const coordinatorId = await resolveCoordinatorId(sb);
+    await sb.from('session_coordination').insert({
+      target_session: coordinatorId, // null => broadcast row, still visible in inbox scans
+      message_type: 'INFO',
+      subject: `[SCRIPTS_REACHABILITY] ${verdict.reasons[0]}`,
+      body: [
+        ...verdict.reasons,
+        '',
+        `orphan_count: ${scan.orphan_count} (delta ${deltas.orphan_delta ?? 'n/a'})`,
+        deltas.new_orphans.length ? `new orphans (first ${deltas.new_orphans.length} of ${deltas.new_orphans_total}):\n${deltas.new_orphans.map((f) => `  - ${f}`).join('\n')}` : '',
+        scan.broken_npm_aliases.length ? `broken aliases:\n${scan.broken_npm_aliases.map((b) => `  - ${b.alias} -> ${b.file}`).join('\n')}` : '',
+        '',
+        'Advisory gauge — orphans are triage candidates (DB-stored refs / dynamic paths are blind spots).',
+        'Recipe: verify, then git mv to scripts/archive/<yyyymm>-reachability-sweep/ (see scripts/archive/README.md).',
+      ].filter(Boolean).join('\n'),
+      payload: { kind: 'scripts_reachability_alert', reasons: verdict.reasons, orphan_count: scan.orphan_count, orphan_delta: deltas.orphan_delta, broken_npm_aliases: scan.broken_npm_aliases },
+      sender_type: 'system',
+      expires_at: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(),
+    });
+  } catch (e) { console.warn(`[scripts-reachability] inbox alert failed (non-fatal): ${e.message}`); }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  // Graceful bounded exit (same primitive as row-growth-snapshot.cjs): direct
+  // process.exit() after Supabase/undici queries UV-aborts on Windows; armCliTeardown
+  // drains naturally with an unref'd backstop. Exit code always 0 — a gauge never
+  // breaks its host loop.
+  main()
+    .catch((e) => { console.warn(`[scripts-reachability] unexpected error (non-fatal): ${e.message}`); })
+    .finally(async () => {
+      try {
+        const { armCliTeardown } = await import('../lib/cli-graceful-exit.js');
+        await armCliTeardown(0);
+      } catch { process.exitCode = 0; /* helper missing — natural drain */ }
+    });
+}

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -20,9 +20,12 @@ test('STANDARD_LOOPS has the expected standard loops with the expected keys', ()
   // the one chairman-facing email is the Adam exec-summary GHA (adam-exec-email-cron.yml).
   // Operator 2026-06-10 added the predictive capacity-forecast loop (worker utilization + belt dry-out)
   // and the backlog-prioritization pass (dispatch_rank for self-claim ordering — SRE duty 6).
-  assert.equal(STANDARD_LOOPS.length, 11);
+  // SD-LEO-INFRA-STANDING-ROW-GROWTH-001 added row-growth; SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001
+  // added review-rotation (this pin had drifted to 11 while both shipped — fixed here).
+  // SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-1) added the weekly scripts-reachability gauge.
+  assert.equal(STANDARD_LOOPS.length, 14);
   const keys = STANDARD_LOOPS.map((l) => l.key);
-  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'fleet-retro']);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability']);
 });
 
 test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
@@ -90,7 +93,7 @@ test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboa
 test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
   const none = parseArmedSet([], {});
   const out = renderLoops(none);
-  assert.match(out, /STANDARD CRON LOOPS \(11\)/);
+  assert.match(out, /STANDARD CRON LOOPS \(14\)/);
   // All prompts emitted as CronCreate specs when nothing is armed
   for (const loop of STANDARD_LOOPS) {
     assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
@@ -102,7 +105,7 @@ test('renderLoops reports all-armed cleanly when every loop is armed', () => {
   const allPrompts = STANDARD_LOOPS.map((l) => l.prompt).join(',');
   const armed = parseArmedSet(['--armed', allPrompts], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 11 standard loops armed/);
+  assert.match(out, /All 14 standard loops armed/);
 });
 
 test('buildReport combines responsibilities + loop sections', () => {

--- a/tests/unit/scripts-reachability-gauge.test.js
+++ b/tests/unit/scripts-reachability-gauge.test.js
@@ -1,0 +1,102 @@
+// SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-1) — pure-core tests for the
+// weekly scripts-estate reachability gauge. No DB, no network: the delta/alert
+// decisions are tested with mocked snapshot rows; cron wiring parity is pinned
+// statically against STANDARD_LOOPS and the teardown inventory.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import {
+  computeDeltas,
+  shouldAlert,
+  isSnapshotDue,
+  SNAPSHOT_EVENT_TYPE,
+  GAUGE_DUE_MS,
+  ORPHAN_GROWTH_ALERT_THRESHOLD,
+  LIST_CAP,
+} from '../../scripts/scripts-reachability-gauge.mjs';
+import { STANDARD_LOOPS } from '../../scripts/coordinator-startup-check.mjs';
+
+const require = createRequire(import.meta.url);
+
+describe('computeDeltas', () => {
+  it('first baseline (no prev) yields null delta and empty lists', () => {
+    const d = computeDeltas(null, { orphan_count: 700, orphans_full: ['a.js'] });
+    expect(d.orphan_delta).toBeNull();
+    expect(d.new_orphans).toEqual([]);
+    expect(d.resolved_orphans).toEqual([]);
+  });
+
+  it('computes new/resolved orphans and the count delta', () => {
+    const prev = { orphan_count: 3, orphans_full: ['scripts/a.js', 'scripts/b.js', 'scripts/c.js'] };
+    const curr = { orphan_count: 4, orphans_full: ['scripts/b.js', 'scripts/c.js', 'scripts/d.js', 'scripts/e.js'] };
+    const d = computeDeltas(prev, curr);
+    expect(d.orphan_delta).toBe(1);
+    expect(d.new_orphans).toEqual(['scripts/d.js', 'scripts/e.js']);
+    expect(d.resolved_orphans).toEqual(['scripts/a.js']);
+    expect(d.new_orphans_total).toBe(2);
+    expect(d.resolved_orphans_total).toBe(1);
+  });
+
+  it('caps the new/resolved lists at LIST_CAP but keeps the true totals', () => {
+    const curr = {
+      orphan_count: LIST_CAP + 20,
+      orphans_full: Array.from({ length: LIST_CAP + 20 }, (_, i) => `scripts/n${i}.js`),
+    };
+    const d = computeDeltas({ orphan_count: 0, orphans_full: [] }, curr);
+    expect(d.new_orphans).toHaveLength(LIST_CAP);
+    expect(d.new_orphans_total).toBe(LIST_CAP + 20);
+  });
+});
+
+describe('shouldAlert — growth-only alerting', () => {
+  const clean = { broken_npm_aliases: [] };
+
+  it(`alerts at orphan growth >= ${ORPHAN_GROWTH_ALERT_THRESHOLD}`, () => {
+    expect(shouldAlert({ orphan_delta: ORPHAN_GROWTH_ALERT_THRESHOLD }, clean).alert).toBe(true);
+  });
+
+  it('does NOT alert below the growth threshold, on shrink, or on first baseline', () => {
+    expect(shouldAlert({ orphan_delta: ORPHAN_GROWTH_ALERT_THRESHOLD - 1 }, clean).alert).toBe(false);
+    expect(shouldAlert({ orphan_delta: -200 }, clean).alert).toBe(false);
+    expect(shouldAlert({ orphan_delta: null }, clean).alert).toBe(false);
+  });
+
+  it('alerts on any broken npm alias regardless of growth', () => {
+    const v = shouldAlert({ orphan_delta: null }, { broken_npm_aliases: [{ alias: 'x', file: 'scripts/x.mjs' }] });
+    expect(v.alert).toBe(true);
+    expect(v.reasons.join(' ')).toContain('npm alias');
+  });
+});
+
+describe('isSnapshotDue (weekly cadence)', () => {
+  const now = Date.parse('2026-06-11T12:00:00Z');
+  it('due with no prior snapshot or unparseable timestamp', () => {
+    expect(isSnapshotDue(null, now)).toBe(true);
+    expect(isSnapshotDue('not-a-date', now)).toBe(true);
+  });
+  it('not due within the ~6d window; due after it', () => {
+    expect(isSnapshotDue(new Date(now - GAUGE_DUE_MS + 60_000).toISOString(), now)).toBe(false);
+    expect(isSnapshotDue(new Date(now - GAUGE_DUE_MS - 60_000).toISOString(), now)).toBe(true);
+  });
+});
+
+describe('cron wiring parity (arm + teardown both know the gauge)', () => {
+  it('STANDARD_LOOPS arms the weekly gauge with the canonical prompt', () => {
+    const loop = STANDARD_LOOPS.find((l) => l.key === 'scripts-reachability');
+    expect(loop).toBeDefined();
+    expect(loop.cron).toBe('40 9 * * 1');
+    expect(loop.prompt).toBe('node scripts/scripts-reachability-gauge.mjs');
+  });
+
+  it('teardown inventory lists the same cron (cadence + command parity)', () => {
+    const { COORDINATOR_CRONS } = require('../../lib/coordinator/teardown-coordinator.cjs');
+    const cron = COORDINATOR_CRONS.find((c) => c.key === 'scripts-reachability');
+    expect(cron).toBeDefined();
+    expect(cron.cadence).toBe('40 9 * * 1');
+    expect(cron.command).toBe('node scripts/scripts-reachability-gauge.mjs');
+    expect(cron.re_asserts_pointer).toBe(false);
+  });
+
+  it('event type is the canonical series name', () => {
+    expect(SNAPSHOT_EVENT_TYPE).toBe('SCRIPTS_REACHABILITY_SNAPSHOT');
+  });
+});

--- a/tests/unit/sweep-worker-scratch-scripts-roots.test.js
+++ b/tests/unit/sweep-worker-scratch-scripts-roots.test.js
@@ -1,0 +1,83 @@
+// SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-2) — scripts/tmp + scripts/temp
+// scratch roots in sweep-worker-scratch.mjs. Hermetic: spawns the real CLI inside a
+// throwaway git repo fixture (the script resolves its root via `git rev-parse`), and
+// asserts the three contract points:
+//   1. untracked files older than 7d are sweep candidates,
+//   2. the 7-day minimum age gate holds even with --older-than-hours 0,
+//   3. git-tracked files in those dirs are NEVER candidates (safety invariant).
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SWEEP = path.resolve(HERE, '../../scripts/maintenance/sweep-worker-scratch.mjs');
+
+let fixture;
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function runSweep(args, cwd) {
+  return execFileSync(process.execPath, [SWEEP, ...args], { cwd, encoding: 'utf8' });
+}
+
+function writeAged(rel, ageDays) {
+  const abs = path.join(fixture, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, `// fixture ${rel}\n`);
+  const t = new Date(Date.now() - ageDays * 86_400_000);
+  fs.utimesSync(abs, t, t);
+  return abs;
+}
+
+beforeAll(() => {
+  fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'sweep-scratch-fix-'));
+  git(['init', '-q'], fixture);
+  git(['config', 'user.email', 'fixture@test'], fixture);
+  git(['config', 'user.name', 'fixture'], fixture);
+
+  writeAged('scripts/tmp/old-probe.mjs', 8);          // candidate: untracked, > 7d
+  writeAged('scripts/tmp/nested/old-deep.sql', 9);    // candidate: recursive walk
+  writeAged('scripts/tmp/fresh-probe.mjs', 1);        // protected: under the 7d gate
+  const tracked = writeAged('scripts/temp/tracked-old.cjs', 30); // protected: tracked
+  git(['add', path.relative(fixture, tracked).replace(/\\/g, '/')], fixture);
+  git(['commit', '-q', '-m', 'fixture tracked file'], fixture);
+  writeAged('scripts/one-off/old-deliverable.mjs', 30); // protected: excluded dir
+});
+
+afterAll(() => {
+  try { fs.rmSync(fixture, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('sweep-worker-scratch scripts/tmp + scripts/temp roots', () => {
+  it('dry-run plans only untracked >7d files under the scratch roots', () => {
+    const out = runSweep(['--verbose'], fixture);
+    expect(out).toContain('scripts/tmp/old-probe.mjs');
+    expect(out).toContain('scripts/tmp/nested/old-deep.sql');
+    expect(out).not.toContain('fresh-probe.mjs');       // 7d gate
+    expect(out).not.toContain('tracked-old.cjs');       // tracked invariant
+    expect(out).not.toContain('old-deliverable.mjs');   // one-off stays excluded
+    expect(out).toContain('dry-run');                   // default is never destructive
+    // Nothing deleted by a dry-run.
+    expect(fs.existsSync(path.join(fixture, 'scripts/tmp/old-probe.mjs'))).toBe(true);
+  });
+
+  it('--older-than-hours 0 cannot lower the 7-day scripts-scratch gate', () => {
+    const out = runSweep(['--older-than-hours', '0', '--verbose'], fixture);
+    expect(out).toContain('scripts/tmp/old-probe.mjs'); // still old enough
+    expect(out).not.toContain('fresh-probe.mjs');       // per-candidate Math.max gate held
+  });
+
+  it('--execute removes the aged untracked files and spares everything else', () => {
+    runSweep(['--execute'], fixture);
+    expect(fs.existsSync(path.join(fixture, 'scripts/tmp/old-probe.mjs'))).toBe(false);
+    expect(fs.existsSync(path.join(fixture, 'scripts/tmp/nested/old-deep.sql'))).toBe(false);
+    expect(fs.existsSync(path.join(fixture, 'scripts/tmp/fresh-probe.mjs'))).toBe(true);
+    expect(fs.existsSync(path.join(fixture, 'scripts/temp/tracked-old.cjs'))).toBe(true);
+    expect(fs.existsSync(path.join(fixture, 'scripts/one-off/old-deliverable.mjs'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The scripts estate (4,562 files) had 717 orphans (34% of live candidates) with archiving lagging ~6 months, and no recurring visibility. PLAN ground-truthing corrected two stale premises: the broken `validate:schema-sync` aliases were **already retired by #4575** (target file never existed on main), and the scratch-lifecycle core **already landed via #4599** — so this ships the remaining gaps.

- **FR-1**: NEW `scripts/scripts-reachability-gauge.mjs` (`npm run sre:scripts-reachability`) — weekly orphan-count gauge mirroring the row-growth pattern: `coordination_events` snapshot series + deltas (`new_orphans`/`resolved_orphans`), growth-only alert leg (≥10 WoW or any broken npm alias), ~6d due-gate, `armCliTeardown`. **Fixes the known FP class**: `.husky` added to the reference haystack (two LIVE pre-commit hooks were flagged orphan by the original scan). STANDARD_LOOPS weekly entry + teardown parity.
- **FR-2**: `sweep-worker-scratch.mjs` extended with `scripts/tmp|temp` untracked-only roots (hard 7d age floor; tracked-set invariant protects the 1 tracked file; `one-off` stays excluded). Live dry-run: **278 files / 4.5 MB** eligible.
- **FR-3**: `docs/03_protocols_and_standards/scripts-estate-liveness.md` (alias-as-liveness norm, both enforcement seams) + `scripts/archive/README.md` (dated-sweep git-mv recipe).

FR-4 (proof-of-recipe archive batch) follows as a separate moves-only PR. Drive-by: the STANDARD_LOOPS count-pin test was already broken on main (pinned 11, main had 13) — fixed to 14 with drift documented.

## Verification

Live gauge runs ×3 (baseline snapshot persisted, delta run, due-gate no-op); FP fix verified (both .husky-wired scripts now reachable); sweep dry-run contract points + hermetic git-fixture tests; 24/24 new+updated tests green; schema lint 0.

## PR Size

+627/−7 across 10 files: ~300 LOC is the gauge (lifted from the chairman's proven scan), ~170 tests, rest docs/wiring. Infra justification per tiered guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)