### PR TITLE
feat(governance): chairman decision queue — unified view + /decisions triage + email digest (SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001)

### DIFF
--- a/.claude/commands/decisions.md
+++ b/.claude/commands/decisions.md
@@ -1,0 +1,57 @@
+<!-- reasoning_effort: medium -->
+
+---
+description: "Chairman decision queue — list every pending decision (escalations, gate decisions, chairman approvals, critical/high feedback, idle draft flags, OKR acceptances) and walk the chairman through deciding each via AskUserQuestion. Nothing auto-decides. SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001."
+---
+
+# /decisions — Chairman Decision Queue
+
+**Constitutional rule**: NOTHING in this flow auto-decides. Recommendations are
+display-only defaults; silence escalates VISIBILITY (sort order) only. Every
+decision requires an explicit chairman answer, and each answer produces exactly
+ONE source write (the CLI prints what was written).
+
+## Steps
+
+1. **List the queue**:
+   ```bash
+   node scripts/chairman-decisions.mjs list --json
+   ```
+   Each row carries `decision_type`, `id`, `title`, `priority`,
+   `effective_priority` (+`age_escalated` marker when pending > 72h),
+   `blocking`, `recommendation`, and `details` (context pack).
+
+2. **Present each pending decision via AskUserQuestion** (one at a time, queue
+   order — blocking first, then effective priority, oldest first):
+   - Question: the row's title + a 1-2 sentence context summary from `details`
+     (age, source, venture if any).
+   - Options, in this order:
+     1. The row's `recommendation` (or `approve` if none) — label it
+        **(Recommended)**. This is a DISPLAY default only; never select it on
+        the chairman's behalf.
+     2. The alternatives (`reject`, plus any source-specific custom action the
+        details suggest).
+     3. `defer` — records the deferral durably; the item stays pending.
+
+3. **Execute the chairman's answer** with the CLI (one call per decision):
+   ```bash
+   node scripts/chairman-decisions.mjs decide <decision_type:id> <approve|reject|defer|custom> --rationale "<the chairman's words or your faithful summary>"
+   ```
+   Routing (exactly one source write each):
+   - `chairman_approval` → `fn_chairman_decide` RPC on `chairman_decisions`
+   - `flag_review` → resolves the `feedback` row (status + resolution note)
+   - `flag_enablement` → records the call as a `feedback` row (the flag itself
+     is NOT toggled — enacting it is the flag tooling's job)
+   - `okr_acceptance` → `acceptPendingOkrGeneration` (approve) / generation-log
+     reject
+   - `escalation` / `gate_decision` → read-only here; tell the chairman to use
+     the coordinator inbox / venture gate flow.
+
+4. **Report**: after the pass, summarize what was decided, deferred, and what
+   remains pending. Do not loop automatically — one pass per invocation.
+
+## Notes
+
+- If the chairman gives an answer not in the options, pass it through as the
+  custom decision verbatim (where the source supports it) — never coerce.
+- `decide` without an explicit decision argument exits 1 by design.

--- a/database/migrations/20260611_chairman_decision_queue.sql
+++ b/database/migrations/20260611_chairman_decision_queue.sql
@@ -1,0 +1,302 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- approval context: chairman top-3 strategic pick 2026-06-10 (SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001)
+-- Migration: Chairman Decision Queue — extend the unified decision union-view stack
+-- SD: SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001
+-- Date: 2026-06-11
+--
+-- WHAT THIS DOES
+--   1. CREATE OR REPLACE chairman_unified_decisions:
+--      - The 4 existing branches (agent_messages escalations, venture_decisions
+--        pending, venture_decisions decided, chairman_decisions) are kept
+--        BYTE-COMPATIBLE: their 16 output columns carry the exact same
+--        expressions/types as the live definition (source: 20260327 migration,
+--        verified against pg_get_viewdef on the live DB 2026-06-11).
+--      - Adds 3 new UNION ALL branches (governance sources):
+--          (a) feedback           -> decision_type 'flag_review'
+--          (b) leo_feature_flags  -> decision_type 'flag_enablement'
+--          (c) okr_generation_log -> decision_type 'okr_acceptance'
+--      - Adds ONE trailing column `blocking boolean` to every branch (trailing
+--        column addition is the CREATE OR REPLACE-safe shape; the existing 16
+--        columns are unchanged). Needed by the pending view's ordering.
+--   2. CREATE OR REPLACE chairman_pending_decisions:
+--      - pending filter + ordering = blocking DESC, effective priority class,
+--        created_at ASC. AGE ESCALATION: a row pending > 72h sorts ONE priority
+--        class higher (computed `effective_priority`; `age_escalated` marker).
+--      - CONSTITUTIONAL: nothing here decides anything. Age escalation changes
+--        VISIBILITY (sort order) only. Defaults/recommendations are display-only.
+--   3. ALTER chairman_decisions.venture_id DROP NOT NULL — required by FR-4
+--      (recordPendingDecision proxy for ventureless session questions, e.g.
+--      coordinator operator-question escalations). Non-breaking for existing
+--      writers (they always supply venture_id).
+--
+-- POSTURE: both views carry security_invoker=on on the live DB (20260602
+-- re-assert). Re-asserted here via WITH (security_invoker = on) so CREATE OR
+-- REPLACE does not drop the option. No new grants (CREATE OR REPLACE preserves
+-- existing ACLs).
+--
+-- Source-table columns verified live 2026-06-11 (information_schema.columns):
+--   feedback: id uuid, title varchar NOT NULL, description text, severity varchar,
+--             status varchar default 'new', category varchar, metadata jsonb,
+--             resolved_at timestamptz, venture_id uuid, created_at timestamptz
+--   leo_feature_flags: id uuid, flag_key text NOT NULL, display_name text NOT NULL,
+--             description text, is_enabled bool NOT NULL, lifecycle_state
+--             feature_flag_lifecycle_state NOT NULL, risk_tier enum, created_at timestamptz NOT NULL
+--   okr_generation_log: id uuid, generation_date date NOT NULL, period text NOT NULL,
+--             status text default 'completed', total_krs_generated int NOT NULL,
+--             created_at timestamptz
+--
+-- Rollback: database/migrations/20260611_chairman_decision_queue_DOWN.sql
+
+-- ============================================================
+-- Step 1: chairman_decisions.venture_id nullable (FR-4 proxy rows)
+-- ============================================================
+ALTER TABLE chairman_decisions ALTER COLUMN venture_id DROP NOT NULL;
+
+-- ============================================================
+-- Step 2: chairman_unified_decisions — 4 existing branches verbatim
+--         + trailing `blocking` column + 3 new governance branches
+-- ============================================================
+CREATE OR REPLACE VIEW chairman_unified_decisions WITH (security_invoker = on) AS
+  -- Source 1: Agent escalations (pending only)
+  SELECT am.id,
+    'escalation'::text AS decision_type,
+    am.subject AS title,
+    (COALESCE(am.priority, 'normal'::character varying))::text AS priority,
+    'pending'::text AS status,
+    ar.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULL::text AS recommendation,
+    am.response_deadline,
+    am.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    ar.display_name AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('message_type', am.message_type, 'body', am.body, 'from_agent_id', am.from_agent_id) AS details,
+    false AS blocking
+  FROM agent_messages am
+    LEFT JOIN agent_registry ar ON ar.id = am.from_agent_id
+    LEFT JOIN ventures v ON v.id = ar.venture_id
+  WHERE am.message_type::text = 'escalation'::text
+    AND am.status::text = 'pending'::text
+
+UNION ALL
+  -- Source 2: Venture gate decisions (pending - no decision yet)
+  SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+    CASE
+      WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+      WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+      ELSE 'normal'::text
+    END AS priority,
+    'pending'::text AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details,
+    (vd.gate_type = 'hard_gate'::text) AS blocking
+  FROM venture_decisions vd
+    LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NULL
+
+UNION ALL
+  -- Source 3: Venture gate decisions (decided)
+  SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+    CASE
+      WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+      WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+      ELSE 'normal'::text
+    END AS priority,
+    CASE
+      WHEN vd.decision = 'proceed'::text THEN 'approved'::text
+      WHEN vd.decision = ANY (ARRAY['kill'::text, 'pause'::text]) THEN 'rejected'::text
+      ELSE 'decided'::text
+    END AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    vd.decided_at,
+    vd.decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'decision', vd.decision, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details,
+    (vd.gate_type = 'hard_gate'::text) AS blocking
+  FROM venture_decisions vd
+    LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NOT NULL
+
+UNION ALL
+  -- Source 4: Chairman decisions (decision='pending' -> status='pending')
+  SELECT cd.id,
+    'chairman_approval'::text AS decision_type,
+    concat('Stage ', cd.lifecycle_stage, ' Chairman Approval') AS title,
+    'critical'::text AS priority,
+    CASE
+      WHEN cd.status = 'pending'::text THEN 'pending'::text
+      WHEN cd.decision::text = 'proceed'::text THEN 'approved'::text
+      WHEN cd.decision::text = ANY (ARRAY['kill'::character varying, 'pause'::character varying]::text[]) THEN 'rejected'::text
+      WHEN cd.decision::text = 'pivot'::text THEN 'pivot'::text
+      WHEN cd.decision::text = 'fix'::text THEN 'fix'::text
+      WHEN cd.decision::text = 'override'::text THEN 'override'::text
+      ELSE 'decided'::text
+    END AS status,
+    cd.venture_id,
+    cd.lifecycle_stage AS stage,
+    NULL::text AS gate_type,
+    cd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    cd.created_at,
+    cd.created_at AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('health_score', cd.health_score, 'override_reason', cd.override_reason, 'risks_acknowledged', cd.risks_acknowledged, 'quick_fixes_applied', cd.quick_fixes_applied) AS details,
+    COALESCE(cd.blocking, false) AS blocking
+  FROM chairman_decisions cd
+    LEFT JOIN ventures v ON v.id = cd.venture_id
+
+UNION ALL
+  -- Source 5 (NEW): Unresolved critical/high feedback -> flag_review
+  SELECT f.id,
+    'flag_review'::text AS decision_type,
+    (f.title)::text AS title,
+    CASE
+      WHEN f.severity::text = 'critical'::text THEN 'critical'::text
+      ELSE 'high'::text
+    END AS priority,
+    'pending'::text AS status,
+    f.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULLIF(f.metadata ->> 'recommendation', '') AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    f.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('id', f.id, 'category', f.category, 'severity', f.severity, 'body', left(COALESCE(f.description, ''::text), 280)) AS details,
+    (f.severity::text = 'critical'::text) AS blocking
+  FROM feedback f
+    LEFT JOIN ventures v ON v.id = f.venture_id
+  WHERE f.severity::text = ANY (ARRAY['critical'::text, 'high'::text])
+    AND f.resolved_at IS NULL
+    AND COALESCE(f.status, 'new'::character varying)::text <> ALL (ARRAY['resolved'::text, 'wont_fix'::text])
+
+UNION ALL
+  -- Source 6 (NEW): Draft feature flags idle > 7 days -> flag_enablement
+  SELECT ff.id,
+    'flag_enablement'::text AS decision_type,
+    concat('Feature flag: ', ff.flag_key) AS title,
+    'normal'::text AS priority,
+    'pending'::text AS status,
+    NULL::uuid AS venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    'Review for enablement or kill'::text AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    ff.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    NULL::character varying(255) AS venture_name,
+    jsonb_build_object('flag_key', ff.flag_key, 'display_name', ff.display_name, 'description', ff.description, 'risk_tier', ff.risk_tier::text) AS details,
+    false AS blocking
+  FROM leo_feature_flags ff
+  WHERE ff.is_enabled = false
+    AND ff.lifecycle_state::text = 'draft'::text
+    AND ff.created_at < (now() - interval '7 days')
+
+UNION ALL
+  -- Source 7 (NEW): OKR generations awaiting chairman acceptance -> okr_acceptance
+  SELECT ogl.id,
+    'okr_acceptance'::text AS decision_type,
+    concat('Accept OKR generation — ', ogl.period, ' (', ogl.generation_date, ')') AS title,
+    'high'::text AS priority,
+    'pending'::text AS status,
+    NULL::uuid AS venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    'Review and accept or reject this OKR generation'::text AS recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    ogl.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    NULL::character varying(255) AS venture_name,
+    jsonb_build_object('generation_id', ogl.id, 'period', ogl.period, 'generation_date', ogl.generation_date, 'total_krs_generated', ogl.total_krs_generated) AS details,
+    false AS blocking
+  FROM okr_generation_log ogl
+  WHERE ogl.status = 'pending_chairman_acceptance'::text;
+
+-- ============================================================
+-- Step 3: chairman_pending_decisions — pending filter + ordering:
+--         blocking DESC, effective priority class (72h age escalation,
+--         visibility only), created_at ASC
+-- ============================================================
+CREATE OR REPLACE VIEW chairman_pending_decisions WITH (security_invoker = on) AS
+  SELECT id,
+    decision_type,
+    title,
+    priority,
+    status,
+    venture_id,
+    stage,
+    gate_type,
+    recommendation,
+    response_deadline,
+    created_at,
+    decided_at,
+    decided_by,
+    requestor_name,
+    venture_name,
+    details,
+    blocking,
+    CASE effective_rank
+      WHEN 1 THEN 'critical'::text
+      WHEN 2 THEN 'high'::text
+      WHEN 3 THEN 'normal'::text
+      ELSE 'low'::text
+    END AS effective_priority,
+    (effective_rank < priority_rank) AS age_escalated
+  FROM (
+    SELECT u.*,
+      CASE u.priority
+        WHEN 'critical' THEN 1
+        WHEN 'high' THEN 2
+        WHEN 'normal' THEN 3
+        WHEN 'low' THEN 4
+        ELSE 5
+      END AS priority_rank,
+      GREATEST(1,
+        CASE u.priority
+          WHEN 'critical' THEN 1
+          WHEN 'high' THEN 2
+          WHEN 'normal' THEN 3
+          WHEN 'low' THEN 4
+          ELSE 5
+        END
+        - CASE WHEN (now() - u.created_at) > interval '72 hours' THEN 1 ELSE 0 END
+      ) AS effective_rank
+    FROM chairman_unified_decisions u
+    WHERE u.status = 'pending'::text
+  ) ranked
+  ORDER BY blocking DESC, effective_rank, created_at ASC;
+
+-- No new grants: CREATE OR REPLACE preserves the existing ACLs
+-- (SELECT to authenticated + service_role, per 20260327) and the
+-- WITH (security_invoker = on) clause preserves the invoker posture (20260602).

--- a/database/migrations/20260611_chairman_decision_queue_DOWN.sql
+++ b/database/migrations/20260611_chairman_decision_queue_DOWN.sql
@@ -1,0 +1,166 @@
+-- DOWN migration for 20260611_chairman_decision_queue.sql
+-- Restores the pre-migration definitions VERBATIM (live defs verified via
+-- pg_get_viewdef 2026-06-11; textual source: 20260327 migration + 20260602
+-- security_invoker re-assert + 20260327 grants).
+--
+-- DROP + recreate is required (not CREATE OR REPLACE) because the UP migration
+-- appended trailing columns, which CREATE OR REPLACE cannot remove.
+
+-- ============================================================
+-- Step 1: restore chairman_decisions.venture_id NOT NULL (guarded)
+-- ============================================================
+DO $$
+DECLARE
+  v_null_rows integer;
+BEGIN
+  SELECT count(*) INTO v_null_rows FROM chairman_decisions WHERE venture_id IS NULL;
+  IF v_null_rows > 0 THEN
+    RAISE EXCEPTION 'DOWN blocked: % chairman_decisions rows have venture_id IS NULL (session_question proxy rows). Delete or re-home them before restoring NOT NULL.', v_null_rows;
+  END IF;
+  ALTER TABLE chairman_decisions ALTER COLUMN venture_id SET NOT NULL;
+END $$;
+
+-- ============================================================
+-- Step 2: drop the extended views (dependent first)
+-- ============================================================
+DROP VIEW IF EXISTS chairman_pending_decisions;
+
+DROP VIEW IF EXISTS chairman_unified_decisions;
+
+-- ============================================================
+-- Step 3: recreate chairman_unified_decisions (pre-migration definition)
+-- ============================================================
+CREATE OR REPLACE VIEW chairman_unified_decisions WITH (security_invoker = on) AS
+  -- Source 1: Agent escalations (pending only)
+  SELECT am.id,
+    'escalation'::text AS decision_type,
+    am.subject AS title,
+    (COALESCE(am.priority, 'normal'::character varying))::text AS priority,
+    'pending'::text AS status,
+    ar.venture_id,
+    NULL::integer AS stage,
+    NULL::text AS gate_type,
+    NULL::text AS recommendation,
+    am.response_deadline,
+    am.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    ar.display_name AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('message_type', am.message_type, 'body', am.body, 'from_agent_id', am.from_agent_id) AS details
+  FROM agent_messages am
+    LEFT JOIN agent_registry ar ON ar.id = am.from_agent_id
+    LEFT JOIN ventures v ON v.id = ar.venture_id
+  WHERE am.message_type::text = 'escalation'::text
+    AND am.status::text = 'pending'::text
+
+UNION ALL
+  -- Source 2: Venture gate decisions (pending - no decision yet)
+  SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+    CASE
+      WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+      WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+      ELSE 'normal'::text
+    END AS priority,
+    'pending'::text AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    NULL::timestamp with time zone AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details
+  FROM venture_decisions vd
+    LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NULL
+
+UNION ALL
+  -- Source 3: Venture gate decisions (decided)
+  SELECT vd.id,
+    'gate_decision'::text AS decision_type,
+    concat('Stage ', vd.stage, ' Gate Decision') AS title,
+    CASE
+      WHEN vd.gate_type = 'hard_gate'::text THEN 'critical'::text
+      WHEN vd.gate_type = 'advisory_checkpoint'::text THEN 'high'::text
+      ELSE 'normal'::text
+    END AS priority,
+    CASE
+      WHEN vd.decision = 'proceed'::text THEN 'approved'::text
+      WHEN vd.decision = ANY (ARRAY['kill'::text, 'pause'::text]) THEN 'rejected'::text
+      ELSE 'decided'::text
+    END AS status,
+    vd.venture_id,
+    vd.stage,
+    vd.gate_type,
+    vd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    vd.created_at,
+    vd.decided_at,
+    vd.decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('notes', vd.notes, 'decision', vd.decision, 'current_stage', v.current_lifecycle_stage, 'health_score', v.health_score) AS details
+  FROM venture_decisions vd
+    LEFT JOIN ventures v ON v.id = vd.venture_id
+  WHERE vd.decision IS NOT NULL
+
+UNION ALL
+  -- Source 4: Chairman decisions (handle decision='pending' -> status='pending')
+  SELECT cd.id,
+    'chairman_approval'::text AS decision_type,
+    concat('Stage ', cd.lifecycle_stage, ' Chairman Approval') AS title,
+    'critical'::text AS priority,
+    CASE
+      WHEN cd.status = 'pending'::text THEN 'pending'::text
+      WHEN cd.decision::text = 'proceed'::text THEN 'approved'::text
+      WHEN cd.decision::text = ANY (ARRAY['kill'::character varying, 'pause'::character varying]::text[]) THEN 'rejected'::text
+      WHEN cd.decision::text = 'pivot'::text THEN 'pivot'::text
+      WHEN cd.decision::text = 'fix'::text THEN 'fix'::text
+      WHEN cd.decision::text = 'override'::text THEN 'override'::text
+      ELSE 'decided'::text
+    END AS status,
+    cd.venture_id,
+    cd.lifecycle_stage AS stage,
+    NULL::text AS gate_type,
+    cd.recommendation,
+    NULL::timestamp with time zone AS response_deadline,
+    cd.created_at,
+    cd.created_at AS decided_at,
+    NULL::uuid AS decided_by,
+    NULL::text AS requestor_name,
+    v.name AS venture_name,
+    jsonb_build_object('health_score', cd.health_score, 'override_reason', cd.override_reason, 'risks_acknowledged', cd.risks_acknowledged, 'quick_fixes_applied', cd.quick_fixes_applied) AS details
+  FROM chairman_decisions cd
+    LEFT JOIN ventures v ON v.id = cd.venture_id;
+
+-- ============================================================
+-- Step 4: recreate chairman_pending_decisions (pre-migration definition)
+-- ============================================================
+CREATE OR REPLACE VIEW chairman_pending_decisions WITH (security_invoker = on) AS
+  SELECT * FROM chairman_unified_decisions
+  WHERE status = 'pending'
+  ORDER BY
+    CASE priority
+      WHEN 'critical' THEN 1
+      WHEN 'high' THEN 2
+      WHEN 'normal' THEN 3
+      WHEN 'low' THEN 4
+      ELSE 5
+    END, created_at;
+
+-- ============================================================
+-- Step 5: restore grants (DROP discarded the ACLs; 20260327 set)
+-- ============================================================
+GRANT SELECT ON chairman_unified_decisions TO authenticated;
+
+GRANT SELECT ON chairman_unified_decisions TO service_role;
+
+GRANT SELECT ON chairman_pending_decisions TO authenticated;
+
+GRANT SELECT ON chairman_pending_decisions TO service_role;

--- a/docs/governance/chairman-decision-surfaces.md
+++ b/docs/governance/chairman-decision-surfaces.md
@@ -1,0 +1,39 @@
+# Chairman Decision Surfaces — Inventory
+
+> SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001 · 2026-06-11
+>
+> The 10 places a "the chairman needs to decide something" can live, and which
+> are covered by the unified queue (`chairman_unified_decisions` /
+> `chairman_pending_decisions`, extended by
+> `database/migrations/20260611_chairman_decision_queue.sql`).
+>
+> **Constitutional rule**: the queue NEVER decides anything. Recommendations
+> are display-only defaults; pending-too-long (>72h) escalates *visibility*
+> (sort order) only. Every decision is an explicit chairman act producing
+> exactly one source write (`scripts/chairman-decisions.mjs decide`).
+
+| # | Surface | Mechanism | Writers | Pending shape | Queue coverage |
+|---|---------|-----------|---------|---------------|----------------|
+| 1 | `chairman_decisions` | Table; atomic decide via `fn_chairman_decide` RPC (the name `decide_chairman_decision` does not exist on the live DB) | Venture stage-gate machinery (stage_gate/review/promotion_gate rows), `lib/chairman/record-pending-decision.mjs` proxy (session_question rows) | `status='pending'` (`decision='pending'`) | **Covered** — branch 4 (`chairman_approval`) |
+| 2 | `venture_decisions` | Table; gate decisions per venture stage | Venture gate flow | `decision IS NULL` | **Covered** — branches 2/3 (`gate_decision`) |
+| 3 | `agent_messages` escalations | Table; agent→chairman escalation messages | Agent fleet (`message_type='escalation'`) | `status='pending'` | **Covered** — branch 1 (`escalation`) |
+| 4 | `feedback` (critical/high) | Table; durable flag/issue channel | `/signal`, `log-harness-bug.js`, sub-agents, captures, retros | `severity IN ('critical','high') AND resolved_at IS NULL AND status NOT IN ('resolved','wont_fix')` | **Covered (new)** — branch 5 (`flag_review`) |
+| 5 | `okr_generation_log` | Table; monthly OKR generator parks generations for acceptance | `lib/eva/jobs/okr-monthly-generator.js` (with `OKR_REQUIRE_ACCEPTANCE`); accept path `lib/eva/jobs/okr-accept-generation.js` | `status='pending_chairman_acceptance'` | **Covered (new)** — branch 7 (`okr_acceptance`) |
+| 6 | `leo_feature_flags` | Table; flags shipped OFF awaiting an enable-or-kill call | SDs shipping gated features (`lifecycle_state='draft'`, `is_enabled=false`) | draft + disabled + idle > 7 days | **Covered (new)** — branch 6 (`flag_enablement`); the queue records the call only — toggling stays in the flag tooling |
+| 7 | CHAIRMAN-PENDING markers | Convention: feedback rows / memory flags / doc markers tagged "CHAIRMAN-PENDING" (e.g. DR entitlement flag 9715c003) | Workers/retros ad hoc | free-text marker, no uniform shape | **Uncovered** — no machine-readable pending predicate; severity-tagged ones surface via branch 5; full coverage needs a marker convention SD |
+| 8 | AskUserQuestion (ephemeral) | In-session prompt; vanishes with the session | Any interactive session | none (ephemeral) | **Uncovered by reading** (nothing durable to read); **proxied on write** via `recordPendingDecision()` → surface 1. Reference wiring: `scripts/coordinator-escalate-question.mjs` |
+| 9 | `session_coordination` | Table; coordinator↔worker message lane (questions, advisories, directives) | Coordinator/worker fleet | `payload->>kind` various; no uniform "awaiting chairman" kind | **Uncovered** — lane is agent-to-agent; genuinely-human questions are escalated via `coordinator-escalate-question.mjs`, which now lands in surfaces 1+4 (both covered) |
+| 10 | Todoist (external) | Chairman's personal task system (MCP) | Chairman/assistants externally | external API, not in our DB | **Uncovered** — external system of record; out of scope by design (the queue must not write to or mirror an external personal tool) |
+
+## Consumers (de-orphaning)
+
+- `scripts/chairman-decisions.mjs list|decide` — CLI (+ `/decisions` skill in
+  `.claude/commands/decisions.md` for the AskUserQuestion walk-through).
+- `scripts/adam-exec-summary.mjs` — daily chairman email ("Decisions awaiting
+  you", top 10 with age + one-line recommendation; GitHub-Actions cron
+  `adam-exec-email-cron.yml`). This is the ≥1-live-consumer validation condition.
+
+## Ordering semantics (`chairman_pending_decisions`)
+
+`blocking DESC` → `effective_priority` class (base priority bumped one class
+after 72h pending — visibility only) → `created_at ASC` (oldest first).

--- a/lib/chairman/decision-queue.mjs
+++ b/lib/chairman/decision-queue.mjs
@@ -1,0 +1,159 @@
+/**
+ * lib/chairman/decision-queue.mjs — pure helpers for the chairman decision queue.
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001.
+ *
+ * CONSTITUTIONAL RULE: nothing in this module (or its callers) auto-decides.
+ * Recommendations/defaults are display-only; age escalation changes VISIBILITY
+ * (sort order) only. Every decision requires an explicit human-supplied
+ * decision argument and results in exactly ONE source write.
+ *
+ * Deliberately dependency-free (no supabase import): the CLI injects writers,
+ * so the unit tier can test routing/sorting without any DB plumbing.
+ */
+
+export const PRIORITY_RANK = { critical: 1, high: 2, normal: 3, low: 4 };
+const RANK_LABEL = { 1: 'critical', 2: 'high', 3: 'normal', 4: 'low', 5: 'low' };
+export const AGE_ESCALATION_HOURS = 72;
+
+/** Map a priority label to its sort rank (unknown -> 5, sorts last). */
+export function priorityRank(priority) {
+  return PRIORITY_RANK[priority] ?? 5;
+}
+
+/**
+ * Compute the effective priority of a pending row: pending > 72h sorts ONE
+ * priority class higher. Mirrors the SQL in chairman_pending_decisions
+ * (20260611_chairman_decision_queue.sql) so pre-migration rows render the same.
+ * @param {{priority?: string, created_at?: string|Date}} row
+ * @param {Date} [now]
+ * @returns {{rank: number, label: string, escalated: boolean}}
+ */
+export function effectivePriority(row, now = new Date()) {
+  const baseRank = priorityRank(row?.priority);
+  const created = row?.created_at ? new Date(row.created_at) : null;
+  const ageMs = created && !Number.isNaN(created.getTime()) ? now.getTime() - created.getTime() : 0;
+  const bump = ageMs > AGE_ESCALATION_HOURS * 3600 * 1000 ? 1 : 0;
+  const rank = Math.max(1, baseRank - bump);
+  return { rank, label: RANK_LABEL[rank] || 'low', escalated: rank < baseRank };
+}
+
+/**
+ * Sort pending rows: blocking DESC, effective priority rank ASC, created_at ASC.
+ * Pure; does not mutate the input.
+ */
+export function sortPending(rows, now = new Date()) {
+  return [...(rows || [])].sort((a, b) => {
+    const ab = a?.blocking ? 1 : 0, bb = b?.blocking ? 1 : 0;
+    if (ab !== bb) return bb - ab;
+    const ar = effectivePriority(a, now).rank, br = effectivePriority(b, now).rank;
+    if (ar !== br) return ar - br;
+    return new Date(a?.created_at || 0) - new Date(b?.created_at || 0);
+  });
+}
+
+/** Render an age like '3d' / '7h' / '12m'. */
+export function formatAge(createdAt, now = new Date()) {
+  const ms = Math.max(0, now - new Date(createdAt || now));
+  const h = ms / 3600000;
+  if (h >= 48) return Math.floor(h / 24) + 'd';
+  if (h >= 1) return Math.floor(h) + 'h';
+  return Math.floor(ms / 60000) + 'm';
+}
+
+export const USAGE = `Usage:
+  node scripts/chairman-decisions.mjs list [--json]
+  node scripts/chairman-decisions.mjs decide <decision_type:id> <approve|reject|defer|custom...> --rationale "..."
+
+decision_type routes the single source write:
+  chairman_approval  -> fn_chairman_decide RPC on chairman_decisions
+  flag_review        -> resolve the feedback row (status + resolution note)
+  flag_enablement    -> record the chairman call as a feedback row (flag NOT toggled)
+  okr_acceptance     -> acceptPendingOkrGeneration / reject the generation log row
+  (escalation / gate_decision are read-only here — decide them in their own tooling)
+
+NO decision is ever taken without an explicit decision argument.`;
+
+/**
+ * Parse CLI argv (after `node script`). Returns either a command object or
+ * { error } — never throws. decide WITHOUT an explicit decision is an error
+ * (TS-3 never-auto-decide).
+ */
+export function parseArgs(argv) {
+  const args = [...(argv || [])];
+  const cmd = args.shift();
+  if (cmd === 'list') {
+    return { command: 'list', json: args.includes('--json') };
+  }
+  if (cmd === 'decide') {
+    let rationale = null;
+    const ri = args.indexOf('--rationale');
+    if (ri !== -1) { rationale = args[ri + 1] ?? null; args.splice(ri, 2); }
+    const target = args.shift();
+    const decision = args.shift();
+    if (!target || !target.includes(':')) return { error: 'decide requires <decision_type:id>', usage: USAGE };
+    if (!decision) return { error: 'decide requires an explicit decision (approve|reject|defer|custom). Nothing auto-decides.', usage: USAGE };
+    const sep = target.indexOf(':');
+    return {
+      command: 'decide',
+      decisionType: target.slice(0, sep),
+      id: target.slice(sep + 1),
+      decision,
+      rationale,
+    };
+  }
+  return { error: 'unknown command: ' + (cmd || '(none)'), usage: USAGE };
+}
+
+/**
+ * Route a decision to EXACTLY ONE injected writer. Pure routing — the writers
+ * do the IO. Returns { writer, result } or { error }.
+ *
+ * @param {{decisionType: string, id: string, decision: string, rationale?: string}} d
+ * @param {{
+ *   chairmanDecide: (id, action, rationale) => any,        // fn_chairman_decide RPC
+ *   resolveFeedback: (id, status, note) => any,            // feedback row resolve
+ *   recordFlagCall: (id, decision, rationale) => any,      // feedback row recording flag call
+ *   okrAccept: (id) => any,                                // acceptPendingOkrGeneration
+ *   okrReject: (id, rationale) => any,                     // okr_generation_log -> rejected
+ *   recordDeferral: (d) => any,                            // feedback row recording deferral
+ * }} writers
+ */
+export async function routeDecision(d, writers) {
+  const { decisionType, id, decision, rationale } = d || {};
+  if (!decisionType || !id) return { error: 'missing decision_type:id target' };
+  if (!decision) return { error: 'missing explicit decision — nothing auto-decides' };
+
+  // defer is uniform across sources: record the deferral durably (one write);
+  // the item REMAINS pending — deferral is a visibility/audit act, not a decision.
+  if (decision === 'defer') {
+    return { writer: 'recordDeferral', result: await writers.recordDeferral(d) };
+  }
+
+  switch (decisionType) {
+    case 'chairman_approval': {
+      if (decision !== 'approve' && decision !== 'reject') {
+        return { error: "chairman_approval supports approve|reject|defer (fn_chairman_decide RPC accepts 'approved'/'rejected')" };
+      }
+      const action = decision === 'approve' ? 'approved' : 'rejected';
+      return { writer: 'chairmanDecide', result: await writers.chairmanDecide(id, action, rationale) };
+    }
+    case 'flag_review': {
+      const status = decision === 'reject' ? 'wont_fix' : 'resolved';
+      const note = `[chairman:${decision}] ${rationale || '(no rationale provided)'}`;
+      return { writer: 'resolveFeedback', result: await writers.resolveFeedback(id, status, note) };
+    }
+    case 'flag_enablement':
+      // Record the chairman call ONLY — toggling the flag is the flag tooling's job.
+      return { writer: 'recordFlagCall', result: await writers.recordFlagCall(id, decision, rationale) };
+    case 'okr_acceptance': {
+      if (decision === 'approve') return { writer: 'okrAccept', result: await writers.okrAccept(id) };
+      if (decision === 'reject') return { writer: 'okrReject', result: await writers.okrReject(id, rationale) };
+      return { error: 'okr_acceptance supports approve|reject|defer' };
+    }
+    case 'escalation':
+    case 'gate_decision':
+      return { error: decisionType + ' is read-only in this CLI — decide it via its own tooling (coordinator inbox / venture gate flow)' };
+    default:
+      return { error: 'unknown decision_type: ' + decisionType };
+  }
+}

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -1,0 +1,75 @@
+/**
+ * lib/chairman/record-pending-decision.mjs — durable proxy for ephemeral
+ * chairman questions. SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001 FR-4.
+ *
+ * Inserts a chairman_decisions row (status='pending') so a question that today
+ * only lives in an AskUserQuestion prompt / coordinator escalation also lands
+ * in the unified decision queue (chairman_unified_decisions branch 4).
+ *
+ * CONSTITUTIONAL: this RECORDS a pending decision; it never decides one.
+ *
+ * Schema notes (probed live 2026-06-11):
+ *   NOT NULL without default: lifecycle_stage (int), decision, decision_type,
+ *     status (default 'pending'). venture_id becomes nullable with the
+ *     20260611_chairman_decision_queue migration (session questions are
+ *     ventureless) — pre-migration, pass options.ventureId or the insert fails.
+ *   CHECK constraints: decision must be in the allowed list ('pending' is
+ *     valid); recommendation column only allows proceed/pivot/fix/kill/pause —
+ *     free-text recommendations therefore go into brief_data, and the column is
+ *     only set when the value is one of the allowed enums.
+ */
+
+const COLUMN_RECOMMENDATIONS = new Set(['proceed', 'pivot', 'fix', 'kill', 'pause']);
+
+/**
+ * Record a pending chairman decision.
+ * @param {Object} supabase - supabase client (service role)
+ * @param {Object} opts
+ * @param {string} opts.title - short question/title (stored in summary + brief_data.title)
+ * @param {string} [opts.decisionType='session_question']
+ * @param {Object|string} [opts.context] - context pack, stored as brief_data
+ * @param {string} [opts.recommendation] - display-only default answer
+ * @param {boolean} [opts.blocking=false]
+ * @param {string} [opts.ventureId] - optional; session questions are ventureless
+ * @param {number} [opts.lifecycleStage=0] - 0 = not a venture lifecycle decision
+ * @returns {Promise<{recorded: boolean, id?: string, error?: string}>}
+ */
+export async function recordPendingDecision(supabase, {
+  title,
+  decisionType = 'session_question',
+  context,
+  recommendation,
+  blocking = false,
+  ventureId = null,
+  lifecycleStage = 0,
+} = {}) {
+  if (!supabase) return { recorded: false, error: 'supabase client is required' };
+  if (!title) return { recorded: false, error: 'title is required' };
+
+  const briefData = {
+    title,
+    ...(recommendation ? { recommendation } : {}),
+    context: context ?? null,
+    recorded_via: 'record-pending-decision',
+  };
+
+  const row = {
+    venture_id: ventureId,
+    lifecycle_stage: lifecycleStage,
+    decision: 'pending',           // NOT NULL; 'pending' is in the CHECK list
+    decision_type: decisionType,   // NOT NULL, no CHECK — free text
+    status: 'pending',
+    summary: title,
+    brief_data: briefData,
+    blocking: !!blocking,
+  };
+  if (recommendation && COLUMN_RECOMMENDATIONS.has(recommendation)) {
+    row.recommendation = recommendation; // column CHECK only allows these five
+  }
+
+  const res = await supabase.from('chairman_decisions').insert(row).select('id');
+  if (res.error) {
+    return { recorded: false, error: res.error.message };
+  }
+  return { recorded: true, id: res.data?.[0]?.id };
+}

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -42,6 +42,21 @@ const northStar = 'Pilot DataDistill S' + pilotStage + '/26' + (arrow(pilotStage
 
 let needs = []; try { needs = JSON.parse(readFileSync(resolve('.adam-chairman-decisions.json'), 'utf8')) || []; } catch {}
 
+// SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001: 'Decisions awaiting you' — top 10 from the
+// chairman_pending_decisions union view (escalations, gate decisions, chairman approvals,
+// critical/high feedback, idle draft flags, OKR acceptances). Display-only (nothing
+// auto-decides); fail-soft so a view/DB error never blocks the chairman email.
+let pendingDecisions = [];
+try {
+  // select('*'): tolerant of pre/post-migration column sets (blocking/effective_priority are new).
+  const { data } = await db.from('chairman_pending_decisions').select('*').limit(50);
+  pendingDecisions = data || [];
+  try { const { sortPending } = await import(pathToFileURL(resolve('lib/chairman/decision-queue.mjs')).href); pendingDecisions = sortPending(pendingDecisions); } catch {}
+  pendingDecisions = pendingDecisions.slice(0, 10);
+} catch {}
+const decAge = (c) => { const h = Math.max(0, (t - new Date(c).getTime()) / 3600000); return h >= 48 ? Math.floor(h / 24) + 'd' : Math.floor(h) + 'h'; };
+const decLine = (d) => '[' + decAge(d.created_at) + '] [' + d.decision_type + (d.blocking ? '/BLOCKING' : '') + '] ' + d.title + (d.recommendation ? ' ' + EM + ' ' + d.recommendation : '');
+
 // FR-2: per-scope roll-up — count recent Adam advisories per scope (reuses FR-1's scope_key),
 // fail-soft so a scope/DB error never blocks the chairman email.
 let scopeRollup = [], perScope = {};
@@ -97,6 +112,7 @@ const text = [
   'STRATEGIC ' + EM + ' chairman lens (two focuses: drive the pilot + improve the venture process)', '',
   'NORTH STAR: ' + northStar, '',
   'NEEDS YOU (' + needs.length + '):', ...needs.map(d => '  - [' + d.priority + '] ' + needsLabel(d)), '',
+  'DECISIONS AWAITING YOU (' + pendingDecisions.length + '):', ...(pendingDecisions.length ? pendingDecisions.map(d => '  - ' + decLine(d)) : ['  (none pending)']), '',
   'PER-SCOPE (advisories, last 24h): ' + scopeRollupLine, '',
   'VALUE DELIVERED (last 24h, ' + shippedN + ' SDs):',
   '  Capabilities added (' + buckets.cap.length + '): ' + bucketLine(buckets.cap, 3),
@@ -107,6 +123,7 @@ const text = [
   '--- FLEET HEALTH ---', cardText
 ].join('\n');
 const needsHtml = needs.length ? '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' + needs.map(d => '<li style="margin:0 0 3px"><b>[' + esc(d.priority) + ']</b> ' + esc(needsLabel(d)) + '</li>').join('') + '</ul>' : '<span style="font-size:13px">nothing pending</span>';
+const decisionsHtml = pendingDecisions.length ? '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' + pendingDecisions.map(d => '<li style="margin:0 0 3px"><b>[' + esc(decAge(d.created_at)) + ' · ' + esc(d.decision_type) + (d.blocking ? ' · BLOCKING' : '') + ']</b> ' + esc(d.title) + (d.recommendation ? ' ' + EM + ' <i>' + esc(d.recommendation) + '</i>' : '') + '</li>').join('') + '</ul>' : '<span style="font-size:13px">nothing pending</span>';
 const scopeRollupHtml = '<span style="font-size:13px">' + esc(scopeRollupLine) + '</span>';
 const valHtml = '<ul style="margin:2px 0 0;padding-left:16px;font-size:13px">' +
   '<li style="margin:0 0 3px"><b>Capabilities added (' + buckets.cap.length + '):</b> ' + esc(bucketLine(buckets.cap, 3)) + '</li>' +
@@ -117,6 +134,7 @@ const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px
   '<p style="font-size:12px;color:#777;margin:0 0 10px">Two focuses: drive the pilot (issue-discovery vehicle) + improve the venture-management process</p>' +
   '<p style="font-size:14px;margin:0 0 8px">' + I.star + ' <b>North star:</b> ' + esc(northStar) + '</p>' +
   '<p style="font-size:14px;margin:0 0 2px">' + I.flag + ' <b>Needs you (' + needs.length + '):</b></p>' + needsHtml +
+  '<p style="font-size:14px;margin:10px 0 2px"><b>Decisions awaiting you (' + pendingDecisions.length + '):</b></p>' + decisionsHtml +
   '<p style="font-size:14px;margin:10px 0 2px"><b>Per-scope (advisories, last 24h):</b> ' + scopeRollupHtml + '</p>' +
   '<p style="font-size:14px;margin:10px 0 2px">' + I.tools + ' <b>Value delivered (last 24h, ' + shippedN + ' SDs):</b></p>' + valHtml +
   '<p style="font-size:14px;margin:10px 0 2px">' + I.loop + ' <b>Self-improvement:</b> ' + esc(selfLine) + '</p>' +

--- a/scripts/chairman-decisions.mjs
+++ b/scripts/chairman-decisions.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// chairman-decisions.mjs — chairman decision queue CLI.
+// SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001.
+//
+//   list [--json]                                          render the pending queue
+//   decide <decision_type:id> <approve|reject|defer|...> --rationale "..."
+//
+// CONSTITUTIONAL: nothing auto-decides. `decide` without an explicit decision
+// argument exits 1 with usage. Every decide performs EXACTLY ONE source write
+// and prints what was written. Interactive tool — errors are loud, no fail-soft.
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import {
+  parseArgs, routeDecision, sortPending, effectivePriority, formatAge, USAGE,
+} from '../lib/chairman/decision-queue.mjs';
+import { armCliTeardown } from '../lib/cli-graceful-exit.js';
+
+const parsed = parseArgs(process.argv.slice(2));
+if (parsed.error) {
+  console.error('ERROR: ' + parsed.error + '\n\n' + (parsed.usage || USAGE));
+  process.exit(1);
+}
+
+const db = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+const DECIDED_BY = process.env.CHAIRMAN_DECIDED_BY || 'chairman-cli';
+
+if (parsed.command === 'list') {
+  const { data, error } = await db.from('chairman_pending_decisions').select('*').limit(200);
+  if (error) {
+    console.error('LIST_ERR ' + error.message);
+    await armCliTeardown(1); // graceful drain — never process.exit() after a query (UV abort class)
+  } else {
+    // Sort client-side with the same semantics as the view (also covers a
+    // pre-migration view that lacks blocking/effective_priority columns).
+    const rows = sortPending(data || []);
+    if (parsed.json) {
+      console.log(JSON.stringify(rows.map((r) => ({
+        ...r,
+        effective_priority: r.effective_priority ?? effectivePriority(r).label,
+        age_escalated: r.age_escalated ?? effectivePriority(r).escalated,
+      })), null, 2));
+    } else {
+      if (!rows.length) console.log('No pending chairman decisions.');
+      for (const r of rows) {
+        const ep = effectivePriority(r);
+        const pri = (r.effective_priority ?? ep.label) + ((r.age_escalated ?? ep.escalated) ? '^ (age-escalated)' : '');
+        const block = r.blocking ? ' BLOCKING' : '';
+        console.log(`[${formatAge(r.created_at)}] [${r.decision_type}:${r.id}] [${pri}${block}] ${r.title}` +
+          (r.recommendation ? ' — ' + r.recommendation : ''));
+      }
+      console.log('\n' + rows.length + ' pending. Decide: node scripts/chairman-decisions.mjs decide <decision_type:id> <approve|reject|defer> --rationale "..."');
+    }
+    await armCliTeardown(0);
+  }
+}
+
+// ---- decide: exactly ONE source write, routed by decision_type ----
+const writers = {
+  // chairman_decisions rows — the existing atomic RPC (fn_chairman_decide; the
+  // planned name decide_chairman_decision does not exist on the live DB).
+  chairmanDecide: async (id, action, rationale) => {
+    const { data, error } = await db.rpc('fn_chairman_decide', {
+      p_decision_id: id, p_action: action, p_decided_by: DECIDED_BY, p_rationale: rationale,
+    });
+    if (error) throw new Error('fn_chairman_decide: ' + error.message);
+    if (data && data.success === false) throw new Error('fn_chairman_decide refused: ' + (data.error || data.code));
+    return { table: 'chairman_decisions', via: 'fn_chairman_decide RPC', id, action, data };
+  },
+  // feedback rows — resolve with a resolution note.
+  resolveFeedback: async (id, status, note) => {
+    const { data, error } = await db.from('feedback')
+      .update({ status, resolved_at: new Date().toISOString(), resolution_notes: note, resolution_type: 'chairman_decision' })
+      .eq('id', id).select('id,status');
+    if (error) throw new Error('feedback update: ' + error.message);
+    if (!data?.length) throw new Error('feedback row ' + id + ' not found');
+    return { table: 'feedback', id, status, note };
+  },
+  // flag rows — record the chairman call as a feedback row; do NOT toggle the flag.
+  recordFlagCall: async (id, decision, rationale) => {
+    const { data: flag } = await db.from('leo_feature_flags').select('flag_key').eq('id', id).maybeSingle();
+    const { data, error } = await db.from('feedback').insert({
+      type: 'improvement', source_application: 'EHG_Engineer', source_type: 'auto_capture',
+      category: 'chairman_flag_decision', status: 'new', severity: 'low',
+      title: `Chairman call on flag ${flag?.flag_key || id}: ${decision}`,
+      description: rationale || '(no rationale provided)',
+      metadata: { flag_id: id, flag_key: flag?.flag_key || null, decision, decided_by: DECIDED_BY, decided_at: new Date().toISOString() },
+    }).select('id');
+    if (error) throw new Error('flag-call feedback insert: ' + error.message);
+    return { table: 'feedback', recorded_decision: decision, flag_id: id, feedback_id: data?.[0]?.id, note: 'flag NOT toggled — use the flag tooling to enact' };
+  },
+  // okr rows — the existing accept path / reject the generation log row.
+  okrAccept: async (id) => {
+    const { acceptPendingOkrGeneration } = await import('../lib/eva/jobs/okr-accept-generation.js');
+    const r = await acceptPendingOkrGeneration({ supabase: db, generationId: id });
+    return { table: 'okr_generation_log (+objectives/key_results)', via: 'acceptPendingOkrGeneration', ...r };
+  },
+  okrReject: async (id, rationale) => {
+    const { data, error } = await db.from('okr_generation_log')
+      .update({ status: 'rejected', error_message: '[chairman:reject] ' + (rationale || '(no rationale provided)') })
+      .eq('id', id).eq('status', 'pending_chairman_acceptance').select('id,status');
+    if (error) throw new Error('okr_generation_log update: ' + error.message);
+    if (!data?.length) throw new Error('okr generation ' + id + ' not found or not pending');
+    return { table: 'okr_generation_log', id, status: 'rejected' };
+  },
+  // deferral — durable audit row; the item stays pending (visibility act, not a decision).
+  recordDeferral: async (d) => {
+    const { data, error } = await db.from('feedback').insert({
+      type: 'improvement', source_application: 'EHG_Engineer', source_type: 'auto_capture',
+      category: 'chairman_decision_deferred', status: 'new', severity: 'low',
+      title: `Chairman deferred ${d.decisionType}:${d.id}`,
+      description: d.rationale || '(no rationale provided)',
+      metadata: { decision_type: d.decisionType, target_id: d.id, decided_by: DECIDED_BY, deferred_at: new Date().toISOString() },
+    }).select('id');
+    if (error) throw new Error('deferral feedback insert: ' + error.message);
+    return { table: 'feedback', feedback_id: data?.[0]?.id, note: 'item remains pending' };
+  },
+};
+
+if (parsed.command === 'decide') {
+  try {
+    const out = await routeDecision(parsed, writers);
+    if (out.error) {
+      console.error('ERROR: ' + out.error + '\n\n' + USAGE);
+      await armCliTeardown(1);
+    } else {
+      console.log('DECIDED ' + parsed.decisionType + ':' + parsed.id + ' -> ' + parsed.decision);
+      console.log('WROTE (' + out.writer + '): ' + JSON.stringify(out.result));
+      await armCliTeardown(0);
+    }
+  } catch (e) {
+    console.error('DECIDE_ERR: ' + e.message);
+    await armCliTeardown(1);
+  }
+}

--- a/scripts/coordinator-escalate-question.mjs
+++ b/scripts/coordinator-escalate-question.mjs
@@ -41,6 +41,22 @@ const { data: dup } = await db.from('feedback')
 if (dup && dup.length) {
   console.log('ALREADY_OPEN id=' + dup[0].id + ' — surfaced in the next executive email');
 } else {
+  // SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001 FR-4: also record the question as a pending
+  // chairman_decisions row so it appears in the unified decision queue (chairman_pending_decisions
+  // + the /decisions skill + the chairman email). Fail-soft — the feedback lane below stays primary.
+  // When the chairman answers (via /decisions or the dashboard), the decision is recorded through
+  // the fn_chairman_decide RPC; this script is fire-and-forget and never receives the answer itself.
+  try {
+    const { recordPendingDecision } = await import(pathToFileURL(resolve('lib/chairman/record-pending-decision.mjs')).href);
+    const rec = await recordPendingDecision(db, {
+      title: 'Worker question — ' + worker + (sd ? ' (' + sd + ')' : ''),
+      decisionType: 'session_question',
+      context: { question: q, worker, sd_key: sd || null, sender_session: session || null },
+      recommendation: recommended || undefined,
+      blocking: questionCategory === 'critical',
+    });
+    console.log(rec.recorded ? 'DECISION_QUEUED chairman_decisions id=' + rec.id : 'DECISION_QUEUE_SKIP ' + rec.error);
+  } catch (e) { console.log('DECISION_QUEUE_SKIP ' + e.message); }
   const { data, error } = await db.from('feedback').insert({
     type: 'issue', source_application: 'EHG_Engineer', source_type: 'auto_capture',
     category: 'operator_question', status: 'new', severity: 'medium',

--- a/tests/unit/chairman-decision-queue.test.js
+++ b/tests/unit/chairman-decision-queue.test.js
@@ -1,0 +1,188 @@
+/**
+ * tests/unit/chairman-decision-queue.test.js
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-001 — unit tier, fully mocked.
+ *
+ * No supabase import anywhere in this file or in lib/chairman/decision-queue.mjs
+ * (the lib is dependency-free by design; writers are injected), so the db-guards
+ * auditor has nothing to flag.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseArgs, routeDecision, effectivePriority, sortPending, priorityRank,
+} from '../../lib/chairman/decision-queue.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MIGRATION = join(REPO_ROOT, 'database', 'migrations', '20260611_chairman_decision_queue.sql');
+
+const mockWriters = () => ({
+  chairmanDecide: vi.fn(async () => ({ ok: true })),
+  resolveFeedback: vi.fn(async () => ({ ok: true })),
+  recordFlagCall: vi.fn(async () => ({ ok: true })),
+  okrAccept: vi.fn(async () => ({ ok: true })),
+  okrReject: vi.fn(async () => ({ ok: true })),
+  recordDeferral: vi.fn(async () => ({ ok: true })),
+});
+const writeCount = (w) => Object.values(w).reduce((n, fn) => n + fn.mock.calls.length, 0);
+
+describe('TS-3 never-auto-decide', () => {
+  it('decide without an explicit decision argument is a parse error (CLI exits 1 on it)', () => {
+    const p = parseArgs(['decide', 'flag_review:abc-123']);
+    expect(p.error).toMatch(/explicit decision/i);
+    expect(p.command).toBeUndefined();
+  });
+
+  it('decide with only --rationale (still no decision) is a parse error', () => {
+    const p = parseArgs(['decide', 'flag_review:abc-123', '--rationale', 'because']);
+    expect(p.error).toMatch(/explicit decision/i);
+  });
+
+  it('routeDecision with no decision performs zero writes', async () => {
+    const w = mockWriters();
+    const out = await routeDecision({ decisionType: 'flag_review', id: 'x', decision: undefined }, w);
+    expect(out.error).toBeTruthy();
+    expect(writeCount(w)).toBe(0);
+  });
+
+  it('read-only sources (escalation/gate_decision) route to zero writes', async () => {
+    const w = mockWriters();
+    for (const t of ['escalation', 'gate_decision']) {
+      const out = await routeDecision({ decisionType: t, id: 'x', decision: 'approve' }, w);
+      expect(out.error).toMatch(/read-only/i);
+    }
+    expect(writeCount(w)).toBe(0);
+  });
+
+  it('parseArgs round-trips a valid decide with rationale', () => {
+    const p = parseArgs(['decide', 'okr_acceptance:gen-1', 'approve', '--rationale', 'looks right']);
+    expect(p).toMatchObject({ command: 'decide', decisionType: 'okr_acceptance', id: 'gen-1', decision: 'approve', rationale: 'looks right' });
+  });
+});
+
+describe('TS-4 age escalation (visibility only)', () => {
+  const now = new Date('2026-06-11T12:00:00Z');
+  const hoursAgo = (h) => new Date(now.getTime() - h * 3600 * 1000).toISOString();
+
+  it('bumps a >72h pending row exactly one class higher', () => {
+    expect(effectivePriority({ priority: 'normal', created_at: hoursAgo(73) }, now))
+      .toEqual({ rank: 2, label: 'high', escalated: true });
+    expect(effectivePriority({ priority: 'high', created_at: hoursAgo(100) }, now))
+      .toEqual({ rank: 1, label: 'critical', escalated: true });
+  });
+
+  it('does not bump at or under 72h', () => {
+    expect(effectivePriority({ priority: 'normal', created_at: hoursAgo(72) }, now).escalated).toBe(false);
+    expect(effectivePriority({ priority: 'normal', created_at: hoursAgo(1) }, now))
+      .toEqual({ rank: 3, label: 'normal', escalated: false });
+  });
+
+  it('critical cannot escalate past critical', () => {
+    expect(effectivePriority({ priority: 'critical', created_at: hoursAgo(500) }, now))
+      .toEqual({ rank: 1, label: 'critical', escalated: false });
+  });
+
+  it('sortPending orders blocking DESC, effective class, then created_at ASC', () => {
+    const rows = [
+      { id: 'old-normal', priority: 'normal', created_at: hoursAgo(80) },   // escalates to high
+      { id: 'fresh-high', priority: 'high', created_at: hoursAgo(1) },
+      { id: 'blocking-low', priority: 'low', created_at: hoursAgo(2), blocking: true },
+      { id: 'fresh-normal', priority: 'normal', created_at: hoursAgo(3) },
+    ];
+    const sorted = sortPending(rows, now).map((r) => r.id);
+    expect(sorted[0]).toBe('blocking-low'); // blocking always first
+    expect(sorted.indexOf('old-normal')).toBeLessThan(sorted.indexOf('fresh-high')); // same class, older first
+    expect(sorted.indexOf('fresh-high')).toBeLessThan(sorted.indexOf('fresh-normal'));
+  });
+
+  it('unknown priority ranks last', () => {
+    expect(priorityRank('bogus')).toBe(5);
+  });
+});
+
+describe('schema contract — migration view branches pin the normalized columns', () => {
+  const sql = readFileSync(MIGRATION, 'utf8');
+  // Isolate the unified-view body, then split into UNION ALL branches.
+  const viewBody = sql.split(/CREATE OR REPLACE VIEW chairman_unified_decisions[^]*?AS/)[1]
+    .split(/CREATE OR REPLACE VIEW chairman_pending_decisions/)[0];
+  const branches = viewBody.split(/UNION ALL/);
+  const PINNED = ['decision_type', 'title', 'priority', 'status', 'recommendation', 'created_at', 'details'];
+
+  it('has exactly 7 branches (4 legacy + feedback + flags + okr)', () => {
+    expect(branches.length).toBe(7);
+  });
+
+  it.each(PINNED)('every branch selects %s', (col) => {
+    for (const b of branches) {
+      expect(b, 'branch missing ' + col + ':\n' + b.slice(0, 200)).toMatch(new RegExp('\\b' + col + '\\b'));
+    }
+  });
+
+  it('every branch carries the trailing blocking column', () => {
+    for (const b of branches) expect(b).toMatch(/AS blocking/);
+  });
+
+  it('new branches target the probed source tables with the agreed pending predicates', () => {
+    expect(sql).toMatch(/FROM feedback f/);
+    expect(sql).toMatch(/resolved_at IS NULL/);
+    expect(sql).toMatch(/FROM leo_feature_flags ff/);
+    expect(sql).toMatch(/interval '7 days'/);
+    expect(sql).toMatch(/FROM okr_generation_log ogl/);
+    expect(sql).toMatch(/pending_chairman_acceptance/);
+  });
+
+  it('pending view implements 72h age escalation and the blocking-first ordering', () => {
+    const pending = sql.split(/CREATE OR REPLACE VIEW chairman_pending_decisions/)[1];
+    expect(pending).toMatch(/interval '72 hours'/);
+    expect(pending).toMatch(/ORDER BY blocking DESC, effective_rank, created_at ASC/);
+  });
+
+  it('preserves the security_invoker posture on both views', () => {
+    expect(sql.match(/VIEW chairman_\w+ WITH \(security_invoker = on\)/g)?.length).toBe(2);
+  });
+});
+
+describe('routing — each decision_type maps to exactly one writer', () => {
+  const cases = [
+    [{ decisionType: 'chairman_approval', id: 'a', decision: 'approve', rationale: 'r' }, 'chairmanDecide'],
+    [{ decisionType: 'chairman_approval', id: 'a', decision: 'reject' }, 'chairmanDecide'],
+    [{ decisionType: 'flag_review', id: 'b', decision: 'approve' }, 'resolveFeedback'],
+    [{ decisionType: 'flag_review', id: 'b', decision: 'reject' }, 'resolveFeedback'],
+    [{ decisionType: 'flag_enablement', id: 'c', decision: 'enable' }, 'recordFlagCall'],
+    [{ decisionType: 'okr_acceptance', id: 'd', decision: 'approve' }, 'okrAccept'],
+    [{ decisionType: 'okr_acceptance', id: 'd', decision: 'reject' }, 'okrReject'],
+    [{ decisionType: 'flag_review', id: 'b', decision: 'defer' }, 'recordDeferral'],
+    [{ decisionType: 'chairman_approval', id: 'a', decision: 'defer' }, 'recordDeferral'],
+  ];
+
+  it.each(cases)('%o -> %s (single write)', async (d, writer) => {
+    const w = mockWriters();
+    const out = await routeDecision(d, w);
+    expect(out.error).toBeUndefined();
+    expect(out.writer).toBe(writer);
+    expect(w[writer]).toHaveBeenCalledTimes(1);
+    expect(writeCount(w)).toBe(1);
+  });
+
+  it('chairman_approval RPC actions are approved/rejected', async () => {
+    const w = mockWriters();
+    await routeDecision({ decisionType: 'chairman_approval', id: 'a', decision: 'approve' }, w);
+    expect(w.chairmanDecide).toHaveBeenCalledWith('a', 'approved', undefined);
+  });
+
+  it('flag_review reject maps to wont_fix; approve maps to resolved', async () => {
+    const w = mockWriters();
+    await routeDecision({ decisionType: 'flag_review', id: 'b', decision: 'reject', rationale: 'noise' }, w);
+    expect(w.resolveFeedback).toHaveBeenCalledWith('b', 'wont_fix', expect.stringContaining('noise'));
+    await routeDecision({ decisionType: 'flag_review', id: 'b', decision: 'approve' }, w);
+    expect(w.resolveFeedback).toHaveBeenLastCalledWith('b', 'resolved', expect.any(String));
+  });
+
+  it('unknown decision_type routes to zero writes', async () => {
+    const w = mockWriters();
+    const out = await routeDecision({ decisionType: 'mystery', id: 'z', decision: 'approve' }, w);
+    expect(out.error).toMatch(/unknown decision_type/);
+    expect(writeCount(w)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
One truthful prioritized surface for every decision awaiting the chairman (chairman top-3 strategic pick, 2026-06-10).

- **Reuse over rebuild**: the orphaned `chairman_unified_decisions` stack (4 venture branches + `fn_chairman_decide` one-shot RPC) extended with 3 governance branches — feedback crit/high flag_review, feature-flags pending-enablement (>7d), OKR pending acceptance. Legacy branches byte-compatible; `security_invoker` preserved. **Migration applied to prod** (3-factor, round-trip probe PASS).
- **Ordering = the constitution**: blocking first, then 72h age-escalated effective_priority, then age — *silence escalates visibility, never assumes consent*. Nothing auto-decides (static test pin); defaults are display-only recommendations.
- **Consumers (de-orphaned)**: `/decisions` skill + `scripts/chairman-decisions.mjs` (list with context packs; decide routes exactly ONE write to the source system) + 'Decisions awaiting you' section in the daily chairman email.
- **Ephemeral surfaces become durable**: `record-pending-decision` proxy helper, reference-wired into coordinator-escalate-question. 10-surface inventory doc.

## Live verification
6 pending decisions unioned from 2+ source systems, age-escalation marker rendering, blocking item first. 34 unit tests; db-guards exit 0; schema-reference lint clean.

## Note for the chairman
Queue shape/ordering shipped as the validation-recommended default — it's your workflow; adjustments are cheap view edits (completion flag filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)