### PR TITLE
fix(tests): teardown-coordinator cron pins 7->8 (QF-20260611-405 — first auto-filed red-merge QF)

### DIFF
--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -33,13 +33,13 @@ afterEach(() => {
 });
 
 describe('teardown-coordinator: inventory + matcher', () => {
-  it('listCoordinatorCrons enumerates all 7 coordinator crons incl the pointer-re-asserting inbox loop', () => {
+  it('listCoordinatorCrons enumerates all 8 coordinator crons incl the pointer-re-asserting inbox loop', () => {
     const crons = listCoordinatorCrons();
-    expect(crons.length).toBe(7); // +row-growth +review-rotation (SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001)
+    expect(crons.length).toBe(8); // +scripts-reachability (SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001, QF-20260611-405 pin bump)
     const inbox = crons.find((c) => c.key === 'inbox');
     expect(inbox).toBeTruthy();
     expect(inbox.re_asserts_pointer).toBe(true); // the crux: missing this cron self-reverses teardown
-    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation']);
+    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation', 'scripts-reachability']);
   });
 
   it('TS-6: selectCoordinatorCronJobs matches coordinator crons (incl inbox via fleet-dashboard.cjs marker) and excludes non-coordinator jobs', () => {
@@ -76,7 +76,7 @@ describe('teardown-coordinator: clearCoordinatorPointer', () => {
     expect(res.enabled).toBe(true);
     expect(res.refused).toBe(false);
     expect(res.pointer_cleared).toBe(true);
-    expect(res.crons_to_delete.length).toBe(7); // +row-growth +review-rotation (SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001)
+    expect(res.crons_to_delete.length).toBe(8); // +scripts-reachability (SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001, QF-20260611-405 pin bump)
     expect(fs.existsSync(tmpPointer)).toBe(false); // pointer file removed
   });
 


### PR DESCRIPTION
## Summary
**This QF was auto-filed by the FR-3 red-merge detector on its first live firing** (shipped ~30 min earlier in #4627): merge 4a3095acca (#4626) added the 8th coordinator cron (scripts-reachability) to teardown-coordinator.cjs without bumping the count-pin tests — main rose 106→108 failures.

- pins bumped 7→8 in both tests; new `scripts-reachability` key asserted in the inventory order
- baseline NOT regenerated (fix, don't absorb)

## Verification
- 8/8 green locally (was 2 failing on clean main)
- New-failure delta confirmed via artifact diff of main runs 27344953528 → 27345625651 (exactly these 2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)