### PR TITLE
fix(SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001): 9 first-contact defects from driving the first venture through stages 20-24 live

### DIFF
--- a/database/migrations/20260611_add_code_quality_report_artifact_type.sql
+++ b/database/migrations/20260611_add_code_quality_report_artifact_type.sql
@@ -1,0 +1,54 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Approval context: chairman (Rick Felix) — SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001
+--   honest-launch campaign, chairman-approved top-3 strategic pick 2026-06-10;
+--   fix-forward of first-contact defects is explicit campaign scope. Additive
+--   CHECK widening only (one new allowed value), zero rows touched, reversible
+--   by re-adding the prior constraint (definition preserved below verbatim
+--   minus the one addition).
+-- SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #6)
+-- venture_artifacts_artifact_type_check omits 'code_quality_report' — the type
+-- ARTIFACT_TYPES.BUILD_CODE_QUALITY_REPORT declares canonical for Stage 20 and
+-- the Stage 23 launch-readiness FR-4 preflight REQUIRES (anyOf
+-- code_quality_report|build_quality_score, BOTH absent from the CHECK).
+-- Consequence: no venture could ever satisfy S23's code_quality category —
+-- every launch-readiness evaluation degraded to SKIPPED. Witnessed live on
+-- DataDistill (510177ba) during the honest-launch campaign.
+--
+-- ADDITIVE ONLY: widens the allowlist by one value; no rows touched.
+ALTER TABLE venture_artifacts
+  DROP CONSTRAINT venture_artifacts_artifact_type_check;
+
+ALTER TABLE venture_artifacts
+  ADD CONSTRAINT venture_artifacts_artifact_type_check CHECK ((artifact_type)::text = ANY (ARRAY[
+    'blueprint_api_contract','blueprint_data_model','blueprint_erd_diagram','blueprint_financial_projection',
+    'blueprint_launch_readiness','blueprint_positioning_brief','blueprint_product_roadmap','blueprint_project_plan',
+    'blueprint_promotion_gate','blueprint_review_summary','blueprint_risk_register','blueprint_schema_spec',
+    'blueprint_sprint_plan','blueprint_technical_architecture','blueprint_token_manifest','blueprint_user_story_pack',
+    'blueprint_wireframes','build_cicd_config','build_mvp_build','build_security_audit','build_system_prompt',
+    'build_test_coverage_report','code_quality_report','design_token_manifest','distribution_ad_copy',
+    'distribution_channel_config','distribution_skip_marker','economic_lens','engine_business_model_canvas',
+    'engine_exit_strategy','engine_pricing_model','engine_revenue_model','engine_risk_assessment','engine_risk_matrix',
+    'growth_optimization_roadmap','growth_playbook','identity_brand_guidelines','identity_brand_name',
+    'identity_gtm_sales_strategy','identity_logo_image','identity_naming_visual','identity_persona_brand',
+    'intake_venture_analysis','launch_analytics_dashboard','launch_assumptions_vs_reality','launch_churn_triggers',
+    'launch_deployment_runbook','launch_health_scoring','launch_launch_metrics','launch_marketing_checklist',
+    'launch_metrics','launch_optimization_roadmap','launch_production_app','launch_readiness_checklist',
+    'launch_retention_playbook','launch_test_plan','launch_uat_report','launch_user_feedback_summary',
+    'lifecycle_sd_bridge','marketing_app_store_desc','marketing_blog_draft','marketing_email_onboarding',
+    'marketing_email_reengagement','marketing_email_welcome','marketing_landing_hero','marketing_seo_meta',
+    'marketing_social_posts','marketing_tagline','post_lifecycle_decision','postlaunch_analytics_dashboard',
+    'postlaunch_assumptions_vs_reality','postlaunch_user_feedback_summary','s17_approved','s17_approved_png',
+    's17_archetypes','s17_design_system','s17_fill_screen','s17_preview','s17_qa_report','s17_session_state',
+    's17_strategy_recommendation','s17_strategy_stats','s17_variant_scores','s17_variant_wip',
+    'stage_0_analysis','stage_10_analysis','stage_11_analysis','stage_12_analysis','stage_13_analysis',
+    'stage_14_analysis','stage_15_analysis','stage_16_analysis','stage_17_analysis','stage_18_analysis',
+    'stage_19_analysis','stage_1_analysis','stage_20_analysis','stage_21_analysis','stage_22_analysis',
+    'stage_23_analysis','stage_24_analysis','stage_25_analysis','stage_26_analysis','stage_2_analysis',
+    'stage_3_analysis','stage_4_analysis','stage_5_analysis','stage_6_analysis','stage_7_analysis',
+    'stage_8_analysis','stage_9_analysis','stitch_budget','stitch_curation','stitch_design_export',
+    'stitch_project','stitch_qa_report','system_devils_advocate_review','truth_ai_critique',
+    'truth_competitive_analysis','truth_financial_model','truth_idea_brief','truth_problem_statement',
+    'truth_target_market_analysis','truth_validation_decision','truth_value_proposition',
+    'value_multiplier_assessment','visual_assets_skipped','visual_device_screenshots','visual_final_assets',
+    'visual_social_graphics','wireframe_screens'
+  ]));

--- a/database/migrations/20260611_fix_advance_stage_required_artifacts_cast.sql
+++ b/database/migrations/20260611_fix_advance_stage_required_artifacts_cast.sql
@@ -1,0 +1,206 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Approval context: chairman (Rick Felix) — SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001
+--   honest-launch campaign fix-forward (first-contact defect #8).
+--
+-- DEFECT: fn_advance_venture_stage declares v_canonical_required JSONB but
+-- SELECTs venture_stages.required_artifacts (a text[] column) INTO it. The
+-- implicit text[]->jsonb coercion throws 'invalid input syntax for type json'
+-- for ANY stage whose required_artifacts is populated (e.g. stage 23
+-- '{launch_readiness_checklist}'), caught by EXCEPTION WHEN OTHERS into a
+-- generic {success:false}. Consequence: stage advancement was IMPOSSIBLE from
+-- any artifact-gated stage. Witnessed live on DataDistill 23->24 (the first
+-- venture ever to attempt it). The UNIFY-VENTURE-STAGE-001-C comment assumed
+-- 'IDENTICAL _text type' — true of the column swap, but the function variable
+-- was jsonb from the lifecycle_stage_config era.
+--
+-- FIX (minimal): read the text[] column directly into the text[] variable;
+-- drop the jsonb intermediary + conversion. No other logic touched.
+CREATE OR REPLACE FUNCTION fn_advance_venture_stage(
+  p_venture_id uuid, p_from_stage integer, p_to_stage integer,
+  p_handoff_data jsonb DEFAULT '{}'::jsonb, p_idempotency_key uuid DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  v_gate_result JSONB;
+  v_user_id UUID;
+  v_idem_key UUID;
+  v_missing_artifacts JSONB;
+  v_gate_type TEXT;
+  v_review_mode TEXT;
+  v_canonical_array text[];
+  v_legacy_array text[];
+  v_required_artifacts text[];
+  v_s22_flag_enabled boolean;
+  v_legacy_skipped boolean;
+  v_artifact_source text;
+BEGIN
+  SELECT current_lifecycle_stage, name INTO v_current_stage, v_venture_name
+  FROM ventures WHERE id = p_venture_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture not found', 'venture_id', p_venture_id);
+  END IF;
+
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Stage mismatch', 'current_stage', v_current_stage, 'from_stage', p_from_stage);
+  END IF;
+
+  IF p_to_stage < 1 OR p_to_stage > 26 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid to_stage', 'to_stage', p_to_stage);
+  END IF;
+
+  IF p_idempotency_key IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM venture_stage_transitions WHERE idempotency_key = p_idempotency_key) THEN
+      RETURN jsonb_build_object('success', true, 'was_duplicate', true, 'venture_id', p_venture_id);
+    END IF;
+  END IF;
+
+  SELECT COALESCE(sc.gate_type, 'none'), COALESCE(sc.review_mode, 'review')
+  INTO v_gate_type, v_review_mode
+  FROM venture_stages sc
+  WHERE sc.stage_number = p_from_stage
+  FOR SHARE;
+
+  IF NOT FOUND THEN
+    v_gate_type := 'none';
+    v_review_mode := 'review';
+  END IF;
+
+  IF v_review_mode = 'review' THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = p_from_stage
+        AND status = 'approved'
+    ) THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'review_gate_blocked',
+        'message', format('Stage %s requires chairman review approval', p_from_stage),
+        'venture_id', p_venture_id,
+        'stage', p_from_stage,
+        'gate_type', v_gate_type,
+        'review_mode', v_review_mode
+      );
+    END IF;
+  END IF;
+
+  IF v_gate_type IN ('kill', 'promotion') THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = p_from_stage
+        AND status = 'approved'
+    ) THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'gate_blocked',
+        'message', format('Stage %s has %s gate requiring approval', p_from_stage, v_gate_type),
+        'venture_id', p_venture_id,
+        'stage', p_from_stage,
+        'gate_type', v_gate_type,
+        'review_mode', v_review_mode
+      );
+    END IF;
+  END IF;
+
+  SELECT is_enabled INTO v_s22_flag_enabled
+  FROM leo_feature_flags WHERE flag_key = 'LEO_S22_GATES_ENABLED';
+  v_s22_flag_enabled := COALESCE(v_s22_flag_enabled, false);
+
+  SELECT COALESCE((metadata->>'s22_legacy_skipped')::boolean, false)
+  INTO v_legacy_skipped
+  FROM ventures WHERE id = p_venture_id;
+
+  -- SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 defect #8 fix: required_artifacts
+  -- is text[]; read it directly (was: SELECT INTO a jsonb var -> cast exception).
+  SELECT required_artifacts INTO v_canonical_array
+  FROM venture_stages
+  WHERE stage_number = p_from_stage;
+  v_canonical_array := COALESCE(v_canonical_array, ARRAY[]::text[]);
+
+  SELECT array_agg(artifact_type) INTO v_legacy_array
+  FROM stage_artifact_requirements
+  WHERE stage_number = p_from_stage AND is_blocking = true;
+  v_legacy_array := COALESCE(v_legacy_array, ARRAY[]::text[]);
+
+  IF v_legacy_skipped AND p_from_stage = 22 THEN
+    v_required_artifacts := ARRAY[]::text[];
+    v_artifact_source := 'bypass_s22_legacy_skipped';
+  ELSIF v_s22_flag_enabled THEN
+    v_required_artifacts := v_canonical_array;
+    v_artifact_source := 'canonical';
+  ELSIF array_length(v_canonical_array, 1) IS NOT NULL THEN
+    v_required_artifacts := v_canonical_array;
+    v_artifact_source := 'canonical_with_fallback_available';
+  ELSE
+    v_required_artifacts := v_legacy_array;
+    v_artifact_source := 'legacy_fallback';
+  END IF;
+
+  IF array_length(v_required_artifacts, 1) IS NOT NULL THEN
+    SELECT jsonb_agg(jsonb_build_object('artifact_type', a))
+    INTO v_missing_artifacts
+    FROM unnest(v_required_artifacts) a
+    WHERE NOT EXISTS (
+      SELECT 1 FROM venture_artifacts va
+      WHERE va.venture_id = p_venture_id
+        AND va.artifact_type = a
+        AND va.is_current = true
+    );
+
+    IF v_missing_artifacts IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'artifact_precondition_unmet',
+        'missing', v_missing_artifacts,
+        'venture_id', p_venture_id,
+        'stage', p_from_stage,
+        'source', v_artifact_source,
+        'flag_enabled', v_s22_flag_enabled
+      );
+    END IF;
+  END IF;
+
+  IF p_from_stage = 21 AND p_to_stage = 22 THEN
+    v_user_id := (p_handoff_data->>'user_id')::UUID;
+    v_gate_result := evaluate_stage20_compliance_gate(p_venture_id, v_user_id);
+    IF NOT (v_gate_result->>'success')::BOOLEAN THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Compliance gate failed', 'gate_result', v_gate_result);
+    END IF;
+    IF (v_gate_result->>'outcome') = 'FAIL' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Compliance gate blocked', 'gate_status', 'BLOCKED', 'gate_result', v_gate_result);
+    END IF;
+    PERFORM record_compliance_gate_passed(p_venture_id, v_user_id);
+  END IF;
+
+  UPDATE ventures SET current_lifecycle_stage = p_to_stage, updated_at = NOW() WHERE id = p_venture_id;
+
+  UPDATE venture_stage_work SET stage_status = 'completed', completed_at = NOW()
+  WHERE venture_id = p_venture_id AND lifecycle_stage = p_from_stage;
+
+  v_idem_key := COALESCE(p_idempotency_key, gen_random_uuid());
+
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, 'normal',
+    COALESCE(p_handoff_data->>'ceo_agent_id', 'system'), p_handoff_data, v_idem_key
+  ) ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true, 'venture_id', p_venture_id, 'venture_name', v_venture_name,
+    'from_stage', p_from_stage, 'to_stage', p_to_stage,
+    'transitioned_at', NOW(),
+    'idempotency_key', v_idem_key,
+    'artifact_source', v_artifact_source,
+    'flag_enabled', v_s22_flag_enabled
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM, 'venture_id', p_venture_id);
+END;
+$$;

--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -362,118 +362,103 @@ const STAGE_CONTRACTS = new Map([
     },
   }],
 
+  // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #2):
+  // contracts 21-26 below were PRE-REDESIGN stale — 21 demanded QA outputs
+  // (test_suites/overall_pass_rate), 22 demanded release_items/promotion_gate,
+  // 23-26 consumed those phantom products. The live SSOT (venture_stages) and
+  // shipped v3.x templates are: 21=Distribution Setup, 22=Visual Assets,
+  // 23=Launch Readiness Kill Gate, 24=Go Live & Announce, 25=Post-Launch
+  // Review, 26=Growth Playbook. Discovered live when DataDistill's S23
+  // re-evaluation (chairman-directed) hard-blocked on the phantom
+  // 'stage-22.promotion_gate'. Produces now mirror each template's schema
+  // (non-derived fields); consumes are OPTIONAL (the S23 analyzer does its own
+  // FR-4 any-of upstream verification with a SKIP fallback — the contract
+  // layer must not double-block on a stricter phantom shape).
   [21, {
     consumes: [
-      { stage: 19, fields: {
-        items: { type: 'array' },
-      }},
-      { stage: 20, fields: {
-        verdict: { type: 'string' },
-        findings: { type: 'array' },
+      { stage: 18, fields: {
+        readiness_pct: { type: 'number', required: false },
       }},
     ],
     produces: {
-      test_suites: { type: 'array', minItems: 1 },
-      overall_pass_rate: { type: 'number' },
-      quality_gate_passed: { type: 'boolean' },
+      channels: { type: 'array' },
+      email_sequences: { type: 'array', required: false },
+      budget_allocation: { type: 'object', required: false },
     },
   }],
 
   [22, {
     consumes: [
-      { stage: 17, fields: {
-        decision: { type: 'string' },
-      }},
       { stage: 18, fields: {
-        readiness_pct: { type: 'number' },
-      }},
-      { stage: 19, fields: {
-        items: { type: 'array', minItems: 1 },
-      }},
-      { stage: 20, fields: {
-        tasks: { type: 'array' },
-      }},
-      { stage: 21, fields: {
-        test_suites: { type: 'array' },
-        quality_gate_passed: { type: 'boolean', required: false },
+        readiness_pct: { type: 'number', required: false },
       }},
     ],
     produces: {
-      release_items: { type: 'array', minItems: 1 },
-      release_notes: { type: 'string', minLength: 10 },
-      promotion_gate: { type: 'object' },
+      device_screenshots: { type: 'array' },
+      social_graphics: { type: 'array', required: false },
+      video_storyboard: { type: 'array', required: false },
     },
   }],
 
   [23, {
     consumes: [
+      { stage: 20, fields: {
+        verdict: { type: 'string', required: false },
+      }},
+      { stage: 21, fields: {
+        channels: { type: 'array', required: false },
+      }},
       { stage: 22, fields: {
-        promotion_gate: { type: 'object' },
-        releaseDecision: { type: 'object', required: false },
+        device_screenshots: { type: 'array', required: false },
       }},
     ],
     produces: {
-      marketing_items: { type: 'array', minItems: 3 },
-      sd_bridge_payloads: { type: 'array' },
-      marketing_strategy_summary: { type: 'string', minLength: 10 },
+      // minItems 0: the S23 analyzer's FR-4 SKIPPED verdict (upstream missing)
+      // legitimately returns an EMPTY checklist — a designed non-blocking shape
+      // the contract must not reject (validateArray defaults minItems to 1).
+      checklist: { type: 'array', minItems: 0 },
+      verdict: { type: 'string' },
     },
   }],
 
   [24, {
     consumes: [
-      { stage: 22, fields: {
-        promotion_gate: { type: 'object' },
-        releaseDecision: { type: 'object', required: false },
-      }},
       { stage: 23, fields: {
-        marketing_items: { type: 'array' },
-        marketing_readiness_pct: { type: 'number', required: false },
+        checklist: { type: 'array', required: false },
+        verdict: { type: 'string', required: false },
       }},
     ],
     produces: {
-      readiness_checklist: { type: 'object' },
-      go_no_go_decision: { type: 'string' },
-      readiness_score: { type: 'number' },
+      launch_status: { type: 'string' },
+      channels_to_activate: { type: 'array' },
+      launch_notes: { type: 'string', required: false },
     },
   }],
 
-  // Stage 25: Launch Readiness (Chairman Gate)
-  // Consumes release readiness + marketing data, produces readiness checklist with chairman gate.
-  // SD-RCA-PREEMPTIVE-S26: Fixed consumes to reference correct upstream stages.
   [25, {
     consumes: [
-      { stage: 23, fields: {
-        release_items: { type: 'array', required: false },
-        releaseDecision: { type: 'object', required: false },
-      }},
       { stage: 24, fields: {
-        marketing_items: { type: 'array', required: false },
+        launch_status: { type: 'string', required: false },
       }},
     ],
     produces: {
-      readiness_checklist: { type: 'object' },
-      go_no_go_decision: { type: 'string' },
-      readiness_score: { type: 'number' },
-      chairmanGate: { type: 'object' },
+      metrics: { type: 'object' },
+      key_learnings: { type: 'array', required: false },
+      data_collection_status: { type: 'string' },
     },
   }],
 
-  // Stage 26: Launch Execution (Pipeline Terminus)
-  // Consumes Stage 25 chairman gate approval and upstream launch data.
-  // SD-RCA-PREEMPTIVE-S26: Added missing contract for pipeline terminus.
+  // Stage 26: Growth Playbook (pipeline terminus per venture_stages SSOT)
   [26, {
     consumes: [
       { stage: 25, fields: {
-        chairmanGate: { type: 'object' },
-        go_no_go_decision: { type: 'string' },
-        readiness_score: { type: 'number' },
+        key_learnings: { type: 'array', required: false },
       }},
     ],
     produces: {
-      distribution_channels: { type: 'array', minItems: 1 },
-      operations_handoff: { type: 'object' },
-      launch_summary: { type: 'string', minLength: 10 },
-      pipeline_terminus: { type: 'boolean' },
+      growth_experiments: { type: 'array' },
+      scaling_priorities: { type: 'array', required: false },
+      operations_handoff: { type: 'object', required: false },
     },
   }],
 ]);
@@ -633,7 +618,10 @@ export const CROSS_STAGE_DEPS = {
   23: [1, 18, 19, 20, 21, 22], // Release readiness: idea + full build loop stages
 
   // Phase 6: LAUNCH & LEARN (Stages 24-26)
-  24: [1, 22, 23],            // Marketing preparation: idea + build review + release readiness
+  // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 defect #9: stage 21 (Distribution
+  // Setup post-resequence) added — Go Live activates the distribution channels,
+  // but stage21Data was never fetched so channels_to_activate was always empty.
+  24: [1, 21, 22, 23],        // Go Live: idea + distribution channels + visual assets + launch readiness
   25: [23, 24],              // Launch readiness (chairman gate): release + marketing
   26: [23, 24, 25],          // Launch execution (pipeline terminus): release + marketing + chairman approval
 };

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -392,7 +392,21 @@ export async function analyzeStage22Distribution(params) {
     result = buildFallback(ventureName);
   }
 
-  const channels = Array.isArray(result.channels) ? result.channels : [];
+  // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #5): the LLM
+  // proposes off-spec channels despite the prompt enum (witnessed live: "linkedin"
+  // for a B2B DevOps venture — a *reasonable* suggestion), and validateChannelCoverage
+  // hard-throws on ANY unrecognized name, converting the whole stage to SKIP. An
+  // EXTRA channel must not kill coverage of the 6 spec'd ones: filter extras out
+  // (preserved under extra_channels for the calibration record) and validate the
+  // recognized set. Missing/malformed SPEC'D channels still throw → SKIP unchanged.
+  const rawChannels = Array.isArray(result.channels) ? result.channels : [];
+  const isOffSpec = (c) => c && typeof c === 'object' && (c.channel || c.channel_name) && !CHANNELS.includes(c.channel || c.channel_name);
+  const extraChannels = rawChannels.filter(isOffSpec);
+  if (extraChannels.length > 0) {
+    logger.warn?.(`[S22-Distribution] dropping ${extraChannels.length} off-spec channel(s): ${extraChannels.map(c => c.channel || c.channel_name).join(', ')} (kept under extra_channels)`);
+    result.extra_channels = extraChannels;
+  }
+  const channels = rawChannels.filter(c => !isOffSpec(c));
   const activeChannels = channels.filter(c => (typeof c.enabled === 'boolean' ? c.enabled : c.status === 'active'));
 
   const fullResult = {

--- a/lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-launch-readiness.js
@@ -172,12 +172,24 @@ export async function analyzeStage23LaunchReadiness(params) {
         else if (stage20Data?.verdict === 'FAIL') { status = 'fail'; detail = `${stage20Data?.summary?.by_severity?.critical || 0} critical issues`; }
         else if (stage20Data?.verdict === 'WARN') { status = 'warn'; detail = 'Warnings present but no critical issues'; }
         break;
-      case 'marketing_assets':
-        if (stage21Data?.total_assets > 0) { status = 'pass'; detail = `${stage21Data.total_assets} assets generated`; }
+      // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #7):
+      // post-resequence positional swap — Distribution runs at stage 21 and
+      // Visual Assets at stage 22 (SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-A
+      // option-ii; venture_stages SSOT), but this scorer still read the
+      // pre-resequence positions, so distribution_channels could NEVER pass
+      // (witnessed live: DataDistill NOT_READY/pending despite an active
+      // distribution_channel_config). Read BOTH positions (any-of) so the
+      // scorer is robust to either era's data.
+      case 'marketing_assets': {
+        const assets = (stage22Data?.total_assets ?? 0) || (stage21Data?.total_assets ?? 0);
+        if (assets > 0) { status = 'pass'; detail = `${assets} assets generated`; }
         break;
-      case 'distribution_channels':
-        if (stage22Data?.active_channels > 0) { status = 'pass'; detail = `${stage22Data.active_channels} channels active`; }
+      }
+      case 'distribution_channels': {
+        const active = (stage21Data?.active_channels ?? 0) || (stage22Data?.active_channels ?? 0);
+        if (active > 0) { status = 'pass'; detail = `${active} channels active`; }
         break;
+      }
       // FR-005: the growth categories are present here ONLY when the flag is ON (REQUIRED).
       // Score them from is_current artifact presence (robust to post-resequence positional-
       // param ambiguity); absence is `pending` => verdict NOT_READY (blocks launch).

--- a/lib/eva/stage-templates/analysis-steps/stage-24-go-live.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-go-live.js
@@ -20,7 +20,7 @@
 const SUCCESS_VERDICTS = new Set(['PASS', 'READY']);
 
 export async function analyzeStage24GoLive(params) {
-  const { stage23Data, stage22Data, ventureName, logger = console } = params;
+  const { stage23Data, stage22Data, stage21Data, ventureName, logger = console } = params;
 
   logger.info?.(`[S24-GoLive] Processing go-live for ${ventureName || 'unknown'}`);
 
@@ -36,7 +36,22 @@ export async function analyzeStage24GoLive(params) {
     );
   }
 
-  const channels = (stage22Data?.channels || []).filter(c => c.status === 'active');
+  // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #9, same
+  // positional-swap class as the S23 scorer): Distribution runs at stage 21
+  // post-resequence (venture_stages SSOT), so channels live in stage21Data —
+  // reading only stage22Data yielded ZERO channels_to_activate on first live
+  // contact. Read both positions (any-of), preferring the SSOT position.
+  // Prefer the lossless __byType accessor — the merged stageNNData is
+  // last-writer-wins across ALL the stage's artifacts, so a later co-output
+  // (growth_playbook / launch_deployment_runbook) shadows the channels field.
+  const channelCandidates = [
+    stage21Data?.__byType?.distribution_channel_config,
+    stage22Data?.__byType?.distribution_channel_config,
+    stage21Data,
+    stage22Data,
+  ];
+  const channelSource = channelCandidates.find(s => Array.isArray(s?.channels) && s.channels.length > 0) || {};
+  const channels = (channelSource.channels || []).filter(c => c.status === 'active' || c.enabled === true);
 
   return {
     launch_status: 'ready_to_launch',
@@ -50,6 +65,8 @@ export async function analyzeStage24GoLive(params) {
     })),
     total_channels: channels.length,
     launched_at: null, // Set by chairman decision
-    launch_notes: '',
+    // Non-empty by contract (launch_notes minLength 1 when present): records the
+    // pending-chairman state until the launch decision stamps real notes.
+    launch_notes: 'Pending chairman launch decision (go-live trigger records launched_at + final notes).',
   };
 }

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -19,6 +19,7 @@ import { validateString, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage20CodeQuality, VERDICT_OPTIONS } from './analysis-steps/stage-20-code-quality.js';
 import { FINDING_CATEGORIES } from '../quality-findings/finding-shape.js';
+import { ARTIFACT_TYPES } from '../artifact-types.js';
 
 const TEMPLATE = {
   id: 'stage-20',
@@ -74,7 +75,28 @@ const TEMPLATE = {
 };
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
-TEMPLATE.analysisStep = analyzeStage20CodeQuality;
+// SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #3): the bare
+// analysisStep persisted as generic 'stage_20_analysis', but Stage 23's FR-4
+// canonical-upstream preflight requires artifact_type='code_quality_report'
+// (ARTIFACT_TYPES.BUILD_CODE_QUALITY_REPORT, canonical per lifecycle_stage_config)
+// — so every venture reached S23 as SKIPPED. Mirror the stage-23 wrapper pattern:
+// typed-artifacts contract, bare fields preserved at the result root.
+TEMPLATE.analysisStep = async function stage20CodeQualityAnalysisStep(params) {
+  const result = await analyzeStage20CodeQuality(params);
+  return {
+    ...result,
+    artifacts: [{
+      artifactType: ARTIFACT_TYPES.BUILD_CODE_QUALITY_REPORT,
+      title: 'Code Quality Report',
+      payload: result,
+      source: 'stage-20-code-quality',
+      metadata: {
+        sd_origin: 'SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001',
+        canonical_artifact_type: ARTIFACT_TYPES.BUILD_CODE_QUALITY_REPORT,
+      },
+    }],
+  };
+};
 ensureOutputSchema(TEMPLATE);
 
 export default TEMPLATE;

--- a/tests/unit/eva/stage-contracts.test.js
+++ b/tests/unit/eva/stage-contracts.test.js
@@ -36,12 +36,15 @@ describe('stage-contracts', () => {
     });
 
     it('returns contract for stage 26 (pipeline terminus)', () => {
+      // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001: contracts 21-26 repointed to
+      // the live SSOT (26 = Growth Playbook); the old assertions pinned the
+      // pre-redesign phantom shape (distribution_channels/pipeline_terminus).
       const c = getContract(26);
       expect(c).not.toBeNull();
       expect(c.consumes).toHaveLength(1);
       expect(c.consumes[0].stage).toBe(25);
-      expect(c.produces).toHaveProperty('distribution_channels');
-      expect(c.produces).toHaveProperty('pipeline_terminus');
+      expect(c.produces).toHaveProperty('growth_experiments');
+      expect(c.produces).toHaveProperty('scaling_priorities');
     });
 
     it('returns null for invalid stage', () => {
@@ -123,10 +126,12 @@ describe('stage-contracts', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('fails stage 26 pre-stage when stage 25 data missing', () => {
+    it('passes stage 26 pre-stage when stage 25 data missing (consumes now optional)', () => {
+      // Repointed contract: S26 consumes only optional key_learnings from S25 —
+      // the S25 analyzer does its own upstream verification; the contract layer
+      // must not double-block on a stricter phantom shape (warnings, not errors).
       const result = validatePreStage(26, new Map(), { logger: silentLogger });
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toMatch(/stage-25 data missing/);
+      expect(result.valid).toBe(true);
     });
 
     it('passes stage 25 pre-stage when upstream stages absent (all optional)', () => {
@@ -206,23 +211,22 @@ describe('stage-contracts', () => {
       expect(result.valid).toBe(false);
     });
 
-    it('validates stage 26 post-stage output (pipeline terminus)', () => {
+    it('validates stage 26 post-stage output (Growth Playbook terminus)', () => {
+      // Repointed contract: S26 = Growth Playbook (growth_experiments required;
+      // scaling_priorities / operations_handoff optional).
       const output = {
-        distribution_channels: [{ name: 'Web', type: 'web', status: 'active' }],
+        growth_experiments: [{ name: 'SEO content sprint', hypothesis: 'organic signups +20%' }],
+        scaling_priorities: ['blog_seo'],
         operations_handoff: { monitoring: {}, escalation: {} },
-        launch_summary: 'CronRead launch: all items approved, pipeline complete.',
-        pipeline_terminus: true,
       };
       const result = validatePostStage(26, output, { logger: silentLogger });
       expect(result.valid).toBe(true);
     });
 
-    it('rejects stage 26 output with empty distribution_channels', () => {
+    it('rejects stage 26 output missing growth_experiments', () => {
       const output = {
-        distribution_channels: [],
+        scaling_priorities: [],
         operations_handoff: {},
-        launch_summary: 'CronRead launch complete.',
-        pipeline_terminus: true,
       };
       const result = validatePostStage(26, output, { logger: silentLogger });
       expect(result.valid).toBe(false);


### PR DESCRIPTION
## Summary
DataDistill honest-launch campaign (chairman-approved top-3 pick): stages 24-26 had never executed against a real venture. Driving DataDistill live through S20→S24 with binding gates surfaced **9 first-contact defects**, all fixed forward (FR-3):

| # | Defect | Fix |
|---|--------|-----|
| 2 | stage-contracts 21-26 pre-redesign stale (21=QA, 22=release/promotion_gate) vs venture_stages SSOT | Repointed to live template schemas; consumes optional |
| 3 | S20 persisted generic `stage_20_analysis`; S23 requires canonical `code_quality_report` | Typed-artifacts wrapper (stage-23 pattern) |
| 4 | Contract blocked S23's designed SKIPPED shape (empty checklist; validateArray default minItems 1) | `minItems: 0` |
| 5 | Off-spec LLM channel ('linkedin') hard-killed the distribution stage | Filter + preserve under `extra_channels` |
| 6 | DB CHECK constraint omitted `code_quality_report` — S23 code_quality **structurally unsatisfiable fleet-wide** | Additive allowlist migration (applied) |
| 7 | S23 scorer read distribution from stage22Data post-resequence | Any-of both positions |
| 8 | `fn_advance_venture_stage`: text[] → jsonb cast exception — **advancement impossible from any artifact-gated stage** | Function migration (applied) |
| 9 | S24 go-live: channels from wrong stage + CROSS_STAGE_DEPS[24] missing 21 + merge shadowing | `__byType` accessor + deps fix (RCA 4ef74cda) |

(#1 = stranded S15/S23 gate debt — resolved DB-side via recorded chairman override + honest re-evaluation.)

## Live outcome so far
S23 honest verdict **READY 100%** (earned, not forced) · gate debt zero · DataDistill advanced 23→24 via real `advanceStage` (**first venture ever in stage 24**) · S24 `ready_to_launch` with 3 channels · launch decision routed to the chairman via coordinator.

Contract solver green; stage-contracts tests 24/24; eva unit estate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)