### PR TITLE
fix(env): quiet dotenv v17 stdout banner contaminating --json CLIs (QF-20260611-017)

### DIFF
--- a/lib/supabase-client.js
+++ b/lib/supabase-client.js
@@ -23,7 +23,10 @@ import path from 'path';
   while (dir !== path.dirname(dir)) {
     const envFile = path.join(dir, '.env');
     if (fs.existsSync(envFile)) {
-      dotenv.config({ path: envFile });
+      // QF-20260611-017: quiet=true — dotenv v17 prints its "injected env" banner
+      // to STDOUT by default, contaminating --json CLI output (red merge 102->103:
+      // audit-ghost-completed-sds --json failed JSON.parse on the banner).
+      dotenv.config({ path: envFile, quiet: true });
       return;
     }
     dir = path.dirname(dir);


### PR DESCRIPTION
## Summary
**Red-merge detector catch #2**: merge 948b19b395 (#4635) surfaced a new failure — `audit-ghost-completed-sds --json` output fails `JSON.parse` because **dotenv v17 prints its 'injected env' banner to STDOUT by default**, and lib/supabase-client.js loads env on import for every CLI.

- `dotenv.config({ path, quiet: true })` — suppresses the banner repo-wide at the single seam; older dotenv versions ignore the option
- Fixes the failing integration test (5/5 green locally); baseline NOT regenerated

Auto-filed QF (FR-3 detector, SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001). 🤖 Generated with [Claude Code](https://claude.com/claude-code)