### PR TITLE
fix(handoff): end the LEAD-TO-PLAN guaranteed-rejection class for auto-generated SDs (SD-PAT-FIX-LEAD-PLAN-REJECTED-004)

### DIFF
--- a/lib/sub-agents/performance.js
+++ b/lib/sub-agents/performance.js
@@ -688,7 +688,13 @@ async function auditBarrelImports(repoPath) {
       `cd "${repoPath}" && grep -rl "export \\* from" --include="*.js" --include="*.ts" src lib scripts 2>/dev/null || echo ""`
     );
 
-    const detectedBarrels = barrelFiles.trim().split('\n').filter(Boolean);
+    // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 drive-by: on Windows the `|| echo ""`
+    // no-match fallback prints a LITERAL `""` (cmd does not strip quotes),
+    // which survived filter(Boolean) and was counted as 1 new barrel —
+    // blocking EXEC-TO-PLAN with violations:[`""`] despite zero real barrels.
+    const detectedBarrels = barrelFiles.trim().split('\n')
+      .map(f => f.trim())
+      .filter(f => f && f !== '""' && f !== "''");
 
     // Normalize paths for comparison
     const normalizedBaseline = new Set(baseline.files.map(f => f.replace(/^\.\//, '')));

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -177,6 +177,87 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
 }
 
 /**
+ * True when a JSONB-ish field already holds content (array with items,
+ * object with keys, or non-empty string).
+ */
+function isPopulated(val) {
+  if (!val) return false;
+  if (Array.isArray(val)) return val.length > 0;
+  if (typeof val === 'string') return val.trim().length > 0;
+  return Object.keys(val).length > 0;
+}
+
+/**
+ * Derive strategic_objectives from author-provided title + rationale + scope.
+ * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-1): derivation restructures content
+ * the SD author already wrote — it never invents facts. String form requires
+ * >= 100 chars to satisfy verify-l2p's strategic-objectives scoring.
+ *
+ * @param {Object} sd - Strategic Directive record
+ * @returns {string|null} derived objectives text, or null when not derivable
+ */
+export function deriveStrategicObjectives(sd) {
+  if (!sd || isPopulated(sd.strategic_objectives)) return null;
+  const parts = [sd.title, sd.rationale, sd.scope]
+    .filter(p => typeof p === 'string' && p.trim().length > 0)
+    .map(p => p.trim());
+  if (parts.length === 0) return null;
+  const text = parts.join(' — ');
+  if (text.length < 100) return null;
+  return text;
+}
+
+/**
+ * Derive success_criteria from a numbered/bulleted "Acceptance Criteria"
+ * (or "Success Criteria") section in the SD description.
+ * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-1). Shape follows
+ * STRUCTURAL_RULES.success_criteria: [{criterion, measure}].
+ *
+ * @param {Object} sd - Strategic Directive record
+ * @returns {Array<{criterion: string, measure: string}>|null}
+ */
+export function deriveSuccessCriteria(sd) {
+  if (!sd || isPopulated(sd.success_criteria)) return null;
+  const desc = typeof sd.description === 'string' ? sd.description : '';
+  const section = desc.match(/#+\s*(?:acceptance|success)\s+criteria\s*\n([\s\S]*?)(?=\n#+\s|\n---|$)/i);
+  if (!section) return null;
+  const items = section[1]
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => /^(\d+[.)]|[-*])\s+/.test(l))
+    .map(l => l.replace(/^(\d+[.)]|[-*])\s+/, '').replace(/^\[ \]\s*/, '').trim())
+    .filter(Boolean);
+  if (items.length === 0) return null;
+  return items.map(criterion => ({
+    criterion,
+    measure: 'Verified during PLAN/EXEC validation against the original pattern occurrences'
+  }));
+}
+
+/**
+ * Derive success_metrics by mirroring existing or just-derived success
+ * criteria into [{metric, target}] shape. Only runs when criteria exist —
+ * never fabricates measurables. SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-1).
+ *
+ * @param {Object} sd - Strategic Directive record
+ * @param {Array|null} derivedCriteria - output of deriveSuccessCriteria (may be null)
+ * @returns {Array<{metric: string, target: string}>|null}
+ */
+export function deriveSuccessMetrics(sd, derivedCriteria = null) {
+  if (!sd || isPopulated(sd.success_metrics)) return null;
+  const source = isPopulated(sd.success_criteria) ? sd.success_criteria : derivedCriteria;
+  if (!Array.isArray(source) || source.length === 0) return null;
+  const metrics = source
+    .map(c => {
+      const metric = typeof c === 'string' ? c : (c?.criterion || '');
+      const target = (typeof c === 'object' && c?.measure) ? c.measure : 'Criterion met and verified';
+      return metric ? { metric, target } : null;
+    })
+    .filter(Boolean);
+  return metrics.length > 0 ? metrics : null;
+}
+
+/**
  * Auto-fix common SD deficiencies that cause gate failures.
  * Only fixes structural gaps (missing fields), never overrides existing content.
  * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-122
@@ -213,6 +294,27 @@ async function autoFixDeficiencies(supabase, sd) {
     if (!sd.dependencies || !Array.isArray(sd.dependencies) || sd.dependencies.length === 0) {
       fixes.dependencies = [];
       fixed.push('dependencies');
+    }
+
+    // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-1): content-derivation for the
+    // fields the legacy autofix could never fill. Derivation only restructures
+    // author-provided content (title/rationale/scope, description Acceptance
+    // Criteria lists) — when the source content is absent, the field stays
+    // empty and the preflight still rejects, so the gate is not eroded.
+    const derivedObjectives = deriveStrategicObjectives(sd);
+    if (derivedObjectives) {
+      fixes.strategic_objectives = derivedObjectives;
+      fixed.push('strategic_objectives');
+    }
+    const derivedCriteria = deriveSuccessCriteria(sd);
+    if (derivedCriteria) {
+      fixes.success_criteria = derivedCriteria;
+      fixed.push('success_criteria');
+    }
+    const derivedMetrics = deriveSuccessMetrics(sd, derivedCriteria);
+    if (derivedMetrics) {
+      fixes.success_metrics = derivedMetrics;
+      fixed.push('success_metrics');
     }
   }
 

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -303,6 +303,27 @@ export class HandoffRecorder {
     const rawScore = result.actualScore || 0;
     const normalizedScore = this._normalizeValidationScore(rawScore);
 
+    // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-3): persist per-field deficits in
+    // the row workers actually read. Before this, the rejected sd_phase_handoffs
+    // row carried only the generic message ("Strategic Directive does not meet
+    // completeness standards") while the actionable error list lived in console
+    // output + leo_handoff_rejections — producing blind retry loops (7x on SD
+    // e756f97d, 2026-05-16).
+    const requiredImprovements = (Array.isArray(result.improvements?.required) && result.improvements.required.length > 0)
+      ? result.improvements.required
+      : (Array.isArray(result.details?.sdValidation?.errors) && result.details.sdValidation.errors.length > 0)
+        ? result.details.sdValidation.errors
+        : null;
+    const actualScore = result.details?.actualScore ?? result.actualScore ?? null;
+    const requiredScore = result.details?.requiredScore ?? result.requiredScore ?? null;
+    let enrichedRejectionReason = result.message;
+    if (requiredImprovements) {
+      const scoreSuffix = (actualScore != null && requiredScore != null)
+        ? ` (score ${actualScore}%, required ${requiredScore}%)`
+        : '';
+      enrichedRejectionReason = `${result.message} | deficits: ${requiredImprovements.join('; ')}${scoreSuffix}`.slice(0, 1000);
+    }
+
     // SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001 (FR-1): completion actions record
     // failures to leo_handoff_executions — PARITY with recordSuccess, which skips
     // sd_phase_handoffs for completion actions (no valid to_phase). Before this fix,
@@ -335,13 +356,17 @@ export class HandoffRecorder {
           gate_count: result.gateCount,
           failed_gate: result.failedGate || null,
           issue_count: (result.issues || []).length,
-          warning_count: (result.warnings || []).length
+          warning_count: (result.warnings || []).length,
+          // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-3): full per-field error
+          // list + required score, queryable without joining leo_handoff_rejections.
+          ...(requiredImprovements ? { required_improvements: requiredImprovements } : {}),
+          ...(requiredScore != null ? { required_score: requiredScore } : {})
         },
         rejected_at: new Date().toISOString(),
         reason: result.reasonCode,
         message: result.message
       },
-      rejection_reason: result.message,
+      rejection_reason: enrichedRejectionReason,
       created_by: 'UNIFIED-HANDOFF-SYSTEM'
     };
 

--- a/scripts/pattern-alert-sd-creator.js
+++ b/scripts/pattern-alert-sd-creator.js
@@ -32,6 +32,7 @@ import {
   fetchAssignedSdStatuses,
   fetchPatternSourceSDStatuses,
 } from './modules/learning/filter.mjs';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 dotenv.config();
 
@@ -190,18 +191,11 @@ async function generateSDKey(pattern) {
 }
 
 /**
- * Create Strategic Directive for pattern
+ * Build the full SD insert payload for a pattern — pure, no DB access.
+ * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): exported so tests can pin the
+ * completeness contract (output passes LEAD-TO-PLAN validators untouched).
  */
-async function createSDForPattern(pattern) {
-  // Check for existing SD first
-  const existingSD = await hasExistingSD(pattern.pattern_id);
-  if (existingSD) {
-    console.log(`  SD already exists: ${existingSD.sd_key} (${existingSD.status})`);
-    return { skipped: true, existing: existingSD };
-  }
-
-  // SD-LEO-SDKEY-001: Pass full pattern for semantic key generation
-  const sdKey = await generateSDKey(pattern);
+function buildSdDataForPattern(pattern, sdKey) {
   const suggestedTeam = CONFIG.CATEGORY_TEAMS[pattern.category] || 'engineering';
   const sdCategory = CONFIG.PATTERN_TO_SD_CATEGORY[pattern.category] || 'Technical Debt';
 
@@ -213,6 +207,17 @@ async function createSDForPattern(pattern) {
   const preventionSummary = pattern.prevention_checklist?.length > 0
     ? pattern.prevention_checklist.map(p => `- [ ] ${p}`).join('\n')
     : 'No prevention checklist available.';
+
+  // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): single source for the acceptance
+  // criteria — written into BOTH the description and success_criteria so the
+  // created SD passes LEAD-TO-PLAN completeness without manual backfill.
+  const acceptanceCriteria = [
+    'Root cause identified and documented',
+    'Permanent fix implemented',
+    'Pattern occurrence count stabilizes or decreases',
+    'Prevention checklist updated with new learnings',
+    `Pattern marked as resolved: \`npm run pattern:resolve ${pattern.pattern_id} "Resolution notes"\``
+  ];
 
   const sdData = {
     id: uuidv4(),
@@ -244,11 +249,7 @@ ${provenSolutionsSummary}
 ${preventionSummary}
 
 ### Acceptance Criteria
-1. Root cause identified and documented
-2. Permanent fix implemented
-3. Pattern occurrence count stabilizes or decreases
-4. Prevention checklist updated with new learnings
-5. Pattern marked as resolved: \`npm run pattern:resolve ${pattern.pattern_id} "Resolution notes"\`
+${acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join('\n')}
 
 ### Suggested Team
 ${suggestedTeam}
@@ -260,7 +261,50 @@ ${suggestedTeam}
     status: CONFIG.SD_STATUS,
     priority: CONFIG.SD_PRIORITY,
     rationale: `This pattern has occurred ${pattern.occurrence_count} times with ${pattern.severity} severity. Recurring issues indicate a systemic problem requiring root cause resolution.`,
-    scope: `Pattern Category: ${pattern.category}`,
+    scope: `Resolve the root cause of recurring pattern ${pattern.pattern_id} (category: ${pattern.category}). In scope: root-cause analysis of the recorded occurrences, a permanent fix, and prevention-checklist updates. Out of scope: unrelated refactors beyond the pattern's blast radius.`,
+    // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): emit a COMPLETE SD. Before
+    // this, pattern SDs inserted 0 of the 8 completeness JSONB fields while
+    // defaulting to sd_type=feature (8/8 bar) — mathematically guaranteeing a
+    // JSONB_FIELDS_INCOMPLETE rejection at LEAD-TO-PLAN for every created SD.
+    sd_type: 'bugfix', // root-cause defect work, not a feature (honest 4-field bar)
+    // Patterns originate from LEO harness retrospectives/RCA — the fix lands
+    // in EHG_Engineer tooling, not the EHG product app.
+    target_application: 'EHG_Engineer',
+    strategic_objectives: `Resolve the recurring "${pattern.issue_summary}" pattern (${pattern.pattern_id}: ${pattern.severity} severity, ${pattern.occurrence_count} occurrences, trend ${pattern.trend}) by identifying and permanently fixing its root cause, so the pattern stops recurring across SD lifecycles and the prevention checklist captures the learning.`,
+    success_criteria: acceptanceCriteria.map(criterion => ({
+      criterion,
+      measure: 'Verified against the pattern record and its recorded occurrences'
+    })),
+    success_metrics: [
+      { metric: `Pattern ${pattern.pattern_id} occurrence count`, baseline: String(pattern.occurrence_count), target: 'Stabilized or decreasing post-fix' },
+      { metric: `Pattern ${pattern.pattern_id} status`, baseline: 'active', target: 'resolved' },
+      { metric: 'Prevention checklist entries capturing this root cause', baseline: String(pattern.prevention_checklist?.length || 0), target: 'At least one new entry documenting the fix' }
+    ],
+    key_changes: [
+      { change: `Implement a permanent fix for the root cause behind: ${pattern.issue_summary.substring(0, 160)}`, impact: `Eliminates recurrence of ${pattern.pattern_id} (${pattern.occurrence_count} occurrences to date)` }
+    ],
+    key_principles: [
+      'Fix root cause, not symptoms',
+      'Validate the fix against the original pattern occurrences',
+      'Preserve existing behavior for passing cases'
+    ],
+    risks: [
+      { risk: 'Fix may not cover all occurrence variants of the pattern', mitigation: 'Verify against the recorded occurrence list before marking the pattern resolved' }
+    ],
+    implementation_guidelines: pattern.prevention_checklist?.length > 0
+      ? pattern.prevention_checklist.slice(0, 5)
+      : ['Read the pattern occurrence records before modifying code', 'Add tests for the specific failure pattern'],
+    dependencies: [],
+    smoke_test_steps: [
+      {
+        instruction: `Reproduce the failure described in pattern ${pattern.pattern_id}, apply the fix, then re-run the originally failing scenario`,
+        expected_outcome: 'The original failure no longer reproduces'
+      },
+      {
+        instruction: `npm run pattern:resolve ${pattern.pattern_id} "<resolution notes>"`,
+        expected_outcome: 'Pattern status transitions to resolved'
+      }
+    ],
     created_at: new Date().toISOString(),
     metadata: {
       source: 'pattern-alert-sd-creator',
@@ -271,6 +315,24 @@ ${suggestedTeam}
       auto_generated: true
     }
   };
+
+  return sdData;
+}
+
+/**
+ * Create Strategic Directive for pattern
+ */
+async function createSDForPattern(pattern) {
+  // Check for existing SD first
+  const existingSD = await hasExistingSD(pattern.pattern_id);
+  if (existingSD) {
+    console.log(`  SD already exists: ${existingSD.sd_key} (${existingSD.status})`);
+    return { skipped: true, existing: existingSD };
+  }
+
+  // SD-LEO-SDKEY-001: Pass full pattern for semantic key generation
+  const sdKey = await generateSDKey(pattern);
+  const sdData = buildSdDataForPattern(pattern, sdKey);
 
   if (DRY_RUN) {
     console.log(`  [DRY RUN] Would create SD: ${sdKey}`);
@@ -360,12 +422,19 @@ async function checkPatternsAndCreateSDs() {
   return stats;
 }
 
-// Run
-checkPatternsAndCreateSDs()
-  .then((stats) => {
-    process.exit(stats.errors > 0 ? 1 : 0);
-  })
-  .catch((error) => {
-    console.error(' Fatal error:', error);
-    process.exit(1);
-  });
+// SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): exported for unit testing —
+// the completeness contract (created SDs pass LEAD-TO-PLAN validators with
+// zero manual backfill) is pinned by tests/unit/handoff/pattern-sd-completeness.test.js.
+export { createSDForPattern, buildSdDataForPattern, checkPatternsAndCreateSDs };
+
+// Run only when invoked directly (not when imported by tests)
+if (isMainModule(import.meta.url)) {
+  checkPatternsAndCreateSDs()
+    .then((stats) => {
+      process.exit(stats.errors > 0 ? 1 : 0);
+    })
+    .catch((error) => {
+      console.error(' Fatal error:', error);
+      process.exit(1);
+    });
+}

--- a/scripts/pattern-alert-sd-creator.js
+++ b/scripts/pattern-alert-sd-creator.js
@@ -195,7 +195,7 @@ async function generateSDKey(pattern) {
  * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): exported so tests can pin the
  * completeness contract (output passes LEAD-TO-PLAN validators untouched).
  */
-function buildSdDataForPattern(pattern, sdKey) {
+export function buildSdDataForPattern(pattern, sdKey) {
   const suggestedTeam = CONFIG.CATEGORY_TEAMS[pattern.category] || 'engineering';
   const sdCategory = CONFIG.PATTERN_TO_SD_CATEGORY[pattern.category] || 'Technical Debt';
 
@@ -322,7 +322,7 @@ ${suggestedTeam}
 /**
  * Create Strategic Directive for pattern
  */
-async function createSDForPattern(pattern) {
+export async function createSDForPattern(pattern) {
   // Check for existing SD first
   const existingSD = await hasExistingSD(pattern.pattern_id);
   if (existingSD) {
@@ -359,7 +359,7 @@ async function createSDForPattern(pattern) {
 /**
  * Main alert check and SD creation
  */
-async function checkPatternsAndCreateSDs() {
+export async function checkPatternsAndCreateSDs() {
   console.log('\n PATTERN ALERT SD CREATOR');
   console.log('═'.repeat(60));
   console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
@@ -421,11 +421,6 @@ async function checkPatternsAndCreateSDs() {
 
   return stats;
 }
-
-// SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): exported for unit testing —
-// the completeness contract (created SDs pass LEAD-TO-PLAN validators with
-// zero manual backfill) is pinned by tests/unit/handoff/pattern-sd-completeness.test.js.
-export { createSDForPattern, buildSdDataForPattern, checkPatternsAndCreateSDs };
 
 // Run only when invoked directly (not when imported by tests)
 if (isMainModule(import.meta.url)) {

--- a/scripts/verify-l2p/handoff-execution.js
+++ b/scripts/verify-l2p/handoff-execution.js
@@ -107,7 +107,11 @@ export async function rejectHandoff(supabase, sdId, reasonCode, message, details
     reasonCode,
     message,
     rejectionId: rejection.id,
-    improvements
+    improvements,
+    // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-3): surface the rejection details
+    // (sdValidation errors, actualScore/requiredScore) to the recorder so the
+    // persisted sd_phase_handoffs row carries per-field remediation.
+    details
   };
 }
 

--- a/tests/unit/handoff/pattern-sd-completeness.test.js
+++ b/tests/unit/handoff/pattern-sd-completeness.test.js
@@ -1,0 +1,63 @@
+/**
+ * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): pattern-alert-sd-creator emits
+ * COMPLETE SDs — output passes both LEAD-TO-PLAN validators with zero manual
+ * backfill. Before this fix, pattern SDs inserted 0 of the 8 completeness
+ * JSONB fields while defaulting to sd_type=feature (8/8 bar), guaranteeing a
+ * JSONB_FIELDS_INCOMPLETE rejection for every created SD (incl. the SD that
+ * shipped this fix, claimed with success_criteria=null).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSdDataForPattern } from '../../../scripts/pattern-alert-sd-creator.js';
+import { checkLeadToPlanPrereqs } from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+import { validateStrategicDirective } from '../../../scripts/verify-l2p/sd-validation.js';
+import { SD_TYPE_OVERRIDES } from '../../../scripts/verify-l2p/constants.js';
+
+const PATTERN_FIXTURE = {
+  pattern_id: 'PAT-RETRO-LEADTOPLAN-e756f97d',
+  category: 'session_retrospective',
+  severity: 'high',
+  occurrence_count: 7,
+  trend: 'stable',
+  issue_summary: 'LEAD-TO-PLAN rejected 7 times during SD lifecycle. Avg score: 0%. Common reasons: Prerequisite preflight failed: JSONB_FIELDS_INCOMPLETE',
+  proven_solutions: [],
+  prevention_checklist: ['Populate completeness fields before running the handoff'],
+  first_seen_sd_id: 'e756f97d-c748-4dc2-aec0-6a60de837844',
+  last_seen_sd_id: 'e756f97d-c748-4dc2-aec0-6a60de837844'
+};
+
+describe('FR-2: pattern SD completeness contract', () => {
+  const sdData = buildSdDataForPattern(PATTERN_FIXTURE, 'SD-PAT-FIX-TEST-CONTRACT-001');
+
+  it('classifies as bugfix targeting EHG_Engineer', () => {
+    expect(sdData.sd_type).toBe('bugfix');
+    expect(sdData.target_application).toBe('EHG_Engineer');
+  });
+
+  it('passes the prerequisite preflight with zero blocking issues', () => {
+    const issues = checkLeadToPlanPrereqs(sdData);
+    const blocking = issues.filter(i => i && i.severity !== 'info');
+    expect(blocking).toEqual([]);
+  });
+
+  it('passes validateStrategicDirective at the effective threshold for its type', () => {
+    const validation = validateStrategicDirective(sdData);
+    const minScore = SD_TYPE_OVERRIDES[sdData.sd_type]?.minimumScore ?? 85;
+    expect(validation.percentage).toBeGreaterThanOrEqual(minScore);
+    expect(validation.errors).toEqual([]);
+  });
+
+  it('keeps acceptance criteria in sync between description and success_criteria', () => {
+    for (const entry of sdData.success_criteria) {
+      // each structured criterion also appears in the human-readable description
+      expect(sdData.description).toContain(entry.criterion.replace(/\\`/g, '`').slice(0, 40));
+    }
+  });
+
+  it('carries valid smoke_test_steps in canonical shape', () => {
+    expect(sdData.smoke_test_steps.length).toBeGreaterThan(0);
+    for (const step of sdData.smoke_test_steps) {
+      expect(step.instruction).toBeTruthy();
+      expect(step.expected_outcome).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/handoff/preflight-derivation.test.js
+++ b/tests/unit/handoff/preflight-derivation.test.js
@@ -1,0 +1,140 @@
+/**
+ * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 — LEAD-TO-PLAN rejection class fix.
+ *
+ * FR-1: content-derivation helpers in prerequisite-preflight.js derive
+ *       strategic_objectives / success_criteria / success_metrics from
+ *       author-provided content only — never invent.
+ * FR-2: pattern-alert-sd-creator emits SDs that pass both LEAD-TO-PLAN
+ *       validators with zero manual backfill.
+ * FR-3: HandoffRecorder.recordFailure persists per-field deficits into the
+ *       rejected sd_phase_handoffs row (the 7x-loop fix).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  deriveStrategicObjectives,
+  deriveSuccessCriteria,
+  deriveSuccessMetrics,
+  checkLeadToPlanPrereqs
+} from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+import { STRUCTURAL_RULES } from '../../../scripts/modules/sd-quality-scoring.js';
+
+/** Fixture shaped like a pattern-alert auto-generated SD (the e756f97d class). */
+function patternSdFixture(overrides = {}) {
+  return {
+    sd_key: 'SD-PAT-FIX-TEST-001',
+    sd_type: 'bugfix',
+    title: '[PAT-TEST-1234] Resolve Root Cause: handoff rejected repeatedly during SD lifecycle',
+    rationale: 'This pattern has occurred 7 times with high severity. Recurring issues indicate a systemic problem requiring root cause resolution.',
+    scope: 'Resolve the root cause of recurring pattern PAT-TEST-1234 (category: session_retrospective).',
+    description: [
+      '## Auto-Generated from Issue Pattern',
+      '',
+      '### Issue Summary',
+      'LEAD-TO-PLAN rejected 7 times during SD lifecycle.',
+      '',
+      '### Acceptance Criteria',
+      '1. Root cause identified and documented',
+      '2. Permanent fix implemented',
+      '3. Pattern occurrence count stabilizes or decreases',
+      '',
+      '### Suggested Team',
+      'engineering'
+    ].join('\n'),
+    strategic_objectives: null,
+    success_criteria: null,
+    success_metrics: null,
+    ...overrides
+  };
+}
+
+describe('FR-1: deriveStrategicObjectives', () => {
+  it('derives from title + rationale + scope when combined >= 100 chars', () => {
+    const out = deriveStrategicObjectives(patternSdFixture());
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThanOrEqual(100);
+    expect(out).toContain('Resolve Root Cause');
+    expect(out).toContain('systemic problem');
+  });
+
+  it('returns null when the field is already populated (never overwrites)', () => {
+    expect(deriveStrategicObjectives(patternSdFixture({ strategic_objectives: 'Existing objectives text' }))).toBeNull();
+    expect(deriveStrategicObjectives(patternSdFixture({ strategic_objectives: [{ title: 'x' }] }))).toBeNull();
+  });
+
+  it('returns null when source content is too thin (< 100 chars)', () => {
+    expect(deriveStrategicObjectives({ title: 'Short', rationale: '', scope: '' })).toBeNull();
+  });
+});
+
+describe('FR-1: deriveSuccessCriteria', () => {
+  it('parses a numbered Acceptance Criteria section into {criterion, measure}', () => {
+    const out = deriveSuccessCriteria(patternSdFixture());
+    expect(Array.isArray(out)).toBe(true);
+    expect(out).toHaveLength(3);
+    expect(out[0].criterion).toBe('Root cause identified and documented');
+    // shape matches STRUCTURAL_RULES.success_criteria
+    for (const entry of out) {
+      for (const key of STRUCTURAL_RULES.success_criteria.expectedKeys) {
+        expect(entry[key]).toBeTruthy();
+      }
+    }
+  });
+
+  it('parses bulleted/checkbox lists too', () => {
+    const sd = patternSdFixture({
+      description: '### Success Criteria\n- [ ] First thing works\n- Second thing verified\n\n### Next\nother'
+    });
+    const out = deriveSuccessCriteria(sd);
+    expect(out.map(c => c.criterion)).toEqual(['First thing works', 'Second thing verified']);
+  });
+
+  it('returns null when there is no criteria section (never invents)', () => {
+    expect(deriveSuccessCriteria(patternSdFixture({ description: 'A bare description with no list sections at all.' }))).toBeNull();
+  });
+
+  it('returns null when already populated', () => {
+    expect(deriveSuccessCriteria(patternSdFixture({ success_criteria: [{ criterion: 'x', measure: 'y' }] }))).toBeNull();
+  });
+});
+
+describe('FR-1: deriveSuccessMetrics', () => {
+  it('mirrors derived criteria into {metric, target}', () => {
+    const criteria = deriveSuccessCriteria(patternSdFixture());
+    const out = deriveSuccessMetrics(patternSdFixture(), criteria);
+    expect(out).toHaveLength(3);
+    expect(out[0].metric).toBe(criteria[0].criterion);
+    expect(out[0].target).toBeTruthy();
+  });
+
+  it('uses existing success_criteria when present on the SD', () => {
+    const sd = patternSdFixture({ success_criteria: [{ criterion: 'Existing crit', measure: 'Existing measure' }] });
+    const out = deriveSuccessMetrics(sd, null);
+    expect(out).toEqual([{ metric: 'Existing crit', target: 'Existing measure' }]);
+  });
+
+  it('returns null with no criteria source (never fabricates measurables)', () => {
+    expect(deriveSuccessMetrics(patternSdFixture(), null)).toBeNull();
+  });
+
+  it('returns null when success_metrics already populated', () => {
+    const sd = patternSdFixture({ success_metrics: [{ metric: 'm', target: 't' }] });
+    expect(deriveSuccessMetrics(sd, [{ criterion: 'c', measure: 'm' }])).toBeNull();
+  });
+});
+
+describe('FR-1: gate not eroded for bare SDs', () => {
+  it('a bare-content SD derives nothing and still rejects via checkLeadToPlanPrereqs', () => {
+    const bare = {
+      sd_key: 'SD-BARE-001',
+      sd_type: 'bugfix',
+      title: 'Tiny',
+      description: 'Too short.',
+      smoke_test_steps: null
+    };
+    expect(deriveStrategicObjectives(bare)).toBeNull();
+    expect(deriveSuccessCriteria(bare)).toBeNull();
+    expect(deriveSuccessMetrics(bare, null)).toBeNull();
+    const issues = checkLeadToPlanPrereqs(bare);
+    expect(issues.some(i => i.code === 'JSONB_FIELDS_INCOMPLETE')).toBe(true);
+  });
+});

--- a/tests/unit/handoff/recorder-rejection-enrichment.test.js
+++ b/tests/unit/handoff/recorder-rejection-enrichment.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-3): recordFailure persists per-field
+ * deficits into the rejected sd_phase_handoffs row.
+ *
+ * Before: rejection_reason = generic message only ("Strategic Directive does
+ * not meet completeness standards"); the actionable error list lived in
+ * console output + leo_handoff_rejections, producing blind retry loops
+ * (7 rejections on SD e756f97d in 8 minutes, 2026-05-16).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { HandoffRecorder } from '../../../scripts/modules/handoff/recording/HandoffRecorder.js';
+
+function buildRecorder(captured) {
+  const supabase = {
+    from: vi.fn(() => ({
+      insert: vi.fn((row) => {
+        captured.push(row);
+        return { select: vi.fn(async () => ({ data: [row], error: null })) };
+      }),
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(async () => ({ data: { id: 'sd-uuid-1' }, error: null })),
+          limit: vi.fn(async () => ({ data: [{ id: 'sd-uuid-1' }], error: null }))
+        })),
+        or: vi.fn(() => ({
+          limit: vi.fn(async () => ({ data: [{ id: 'sd-uuid-1' }], error: null })),
+          single: vi.fn(async () => ({ data: { id: 'sd-uuid-1' }, error: null }))
+        }))
+      }))
+    }))
+  };
+  const recorder = new HandoffRecorder(supabase, {
+    contentBuilder: { buildRejection: () => ({ executive_summary: 'rejected' }) },
+    validationOrchestrator: { preValidateData: async () => ({ valid: true, errors: [] }) }
+  });
+  // Bypass the DB lookup inside _resolveToUUID — unit scope is row shaping.
+  recorder._resolveToUUID = async (id) => id;
+  return recorder;
+}
+
+const SD_INCOMPLETE_RESULT = {
+  success: false,
+  rejected: true,
+  reasonCode: 'SD_INCOMPLETE',
+  message: 'Strategic Directive does not meet completeness standards',
+  improvements: {
+    required: [
+      'Missing required field: scope',
+      'Insufficient strategic objectives: 0/3',
+      'Missing success_metrics or success_criteria'
+    ],
+    actions: [],
+    timeEstimate: '2-3 hours',
+    instructions: ''
+  },
+  details: {
+    sdValidation: { errors: ['Missing required field: scope'] },
+    actualScore: 0,
+    requiredScore: 85
+  }
+};
+
+describe('FR-3: recordFailure rejection enrichment', () => {
+  it('persists per-field deficits + scores in rejection_reason and validation_details', async () => {
+    const captured = [];
+    const recorder = buildRecorder(captured);
+    await recorder.recordFailure('LEAD-TO-PLAN', 'SD-TEST-001', SD_INCOMPLETE_RESULT);
+
+    const row = captured.find(r => r.status === 'rejected');
+    expect(row).toBeTruthy();
+    expect(row.rejection_reason).toContain('does not meet completeness standards');
+    expect(row.rejection_reason).toContain('deficits:');
+    expect(row.rejection_reason).toContain('Insufficient strategic objectives: 0/3');
+    expect(row.rejection_reason).toContain('(score 0%, required 85%)');
+    expect(row.rejection_reason.length).toBeLessThanOrEqual(1000);
+    expect(row.validation_details.summary.required_improvements).toHaveLength(3);
+    expect(row.validation_details.summary.required_score).toBe(85);
+  });
+
+  it('caps rejection_reason at 1000 chars', async () => {
+    const captured = [];
+    const recorder = buildRecorder(captured);
+    const longResult = {
+      ...SD_INCOMPLETE_RESULT,
+      improvements: { required: Array.from({ length: 50 }, (_, i) => `Missing very long descriptive field number ${i} with extra explanatory text`) }
+    };
+    await recorder.recordFailure('LEAD-TO-PLAN', 'SD-TEST-001', longResult);
+    const row = captured.find(r => r.status === 'rejected');
+    expect(row.rejection_reason.length).toBeLessThanOrEqual(1000);
+  });
+
+  it('legacy result shape (no improvements/details) persists exactly the prior message', async () => {
+    const captured = [];
+    const recorder = buildRecorder(captured);
+    await recorder.recordFailure('LEAD-TO-PLAN', 'SD-TEST-001', {
+      success: false,
+      reasonCode: 'ENV_NOT_READY',
+      message: 'Development environment not ready for planning phase'
+    });
+    const row = captured.find(r => r.status === 'rejected');
+    expect(row.rejection_reason).toBe('Development environment not ready for planning phase');
+    expect(row.validation_details.summary.required_improvements).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes pattern PAT-RETRO-LEADTOPLAN-e756f97d (7 occurrences, high): LEAD-TO-PLAN rejections with JSONB_FIELDS_INCOMPLETE / "does not meet completeness standards" — 15+ rejections across ~15 SDs from 2026-05-04 to 2026-06-11, including a 7x blind retry loop on one SD.

**Root cause (3 layers):**
1. Auto-generators (pattern-alert-sd-creator) insert 0 of the 8 completeness JSONB fields while defaulting to sd_type=feature (8/8 bar) — guaranteed rejection.
2. The preflight autofix could only fill 4 filler fields, never the 4 that verify-l2p scores 40/100 points on.
3. The persisted rejection row carried only a generic message; per-field errors went to console + leo_handoff_rejections (unread), so remediation never converged.

**Fixes:**
- **FR-1** prerequisite-preflight: derive strategic_objectives / success_criteria / success_metrics from author-provided content only (title+rationale+scope, description Acceptance Criteria lists). Bare SDs still reject — gate not eroded.
- **FR-2** pattern-alert-sd-creator: emits complete SDs (all JSONB fields + smoke_test_steps, sd_type=bugfix, target_application=EHG_Engineer); buildSdDataForPattern extracted pure + isMainModule guard.
- **FR-3** HandoffRecorder.recordFailure: rejected rows carry per-field deficits + scores in rejection_reason (capped 1000) and validation_details.summary.

## Test plan
- 20 new tests across 3 files (derivation, recorder enrichment, creator completeness contract pinned against BOTH live validators)
- tests/unit/handoff: 69 files / 715 tests green
- Unit-tier: 2 failures pre-existing (proven by stash round-trip): quarantine-manifest disk-state, heal-vision worktree-ROOT
- Live proof: this SD itself (a specimen of the bug, claimed with success_criteria=null) passed LEAD-TO-PLAN at 95 on first attempt after population

🤖 Generated with [Claude Code](https://claude.com/claude-code)