### PR TITLE
fix(SD-PAT-FIX-PLAN-EXEC-REJECTED-001): exclude designed fast-fail rejections from session-retro pattern math

### DIFF
--- a/scripts/modules/learning/session-retrospective.js
+++ b/scripts/modules/learning/session-retrospective.js
@@ -24,6 +24,38 @@ const supabase = createSupabaseServiceClient();
 const MIN_REJECTIONS_FOR_PATTERN = 2;
 
 /**
+ * SD-PAT-FIX-PLAN-EXEC-REJECTED-001: designed fast-fail rejection classes that
+ * must NOT feed pattern math. Their validation_score is 0 BY CONSTRUCTION
+ * (they fail before any gate scoring runs), so counting them produces
+ * alarmist "rejected N times, avg 0%" HIGH patterns from cheap guidance
+ * fails — pattern PAT-RETRO-PLANTOEXEC-3741735a (11 "rejections" = ONE
+ * April SD: 3 prerequisite fast-fails + 4 claim-mechanics fails + 1 real
+ * quality failure) auto-escalated into an SD this way.
+ *
+ * Matched against validation_details.reason AND rejection_reason text:
+ *  - PREREQUISITE_PREFLIGHT_FAILED: pre-pipeline guidance (PRD/stories not
+ *    yet created) — the fast-fail IS the designed remediation surface.
+ *  - ARTIFACT_PREFLIGHT_FAILED: deterministic artifact-shape fast-fail
+ *    (SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-A) — same pre-pipeline class.
+ *  - GATE_CLAIM_VALIDITY: multi-session claim mechanics
+ *    (no_deterministic_identity / foreign_claim), not artifact quality.
+ * Excluded rows are still COUNTED and surfaced via metadata.excluded_fast_fails
+ * when a pattern is created from the remaining genuine failures.
+ */
+export const FAST_FAIL_EXCLUDED_REASONS = [
+  'PREREQUISITE_PREFLIGHT_FAILED',
+  'ARTIFACT_PREFLIGHT_FAILED',
+  'GATE_CLAIM_VALIDITY',
+];
+
+/** True when a rejection row is a designed fast-fail (excluded from pattern math). */
+export function isFastFailRejection(rejection) {
+  const reason = rejection?.validation_details?.reason || '';
+  const text = rejection?.rejection_reason || '';
+  return FAST_FAIL_EXCLUDED_REASONS.some(code => reason.includes(code) || text.includes(code));
+}
+
+/**
  * Analyze all rejections for an SD and create issue_patterns for recurring failures.
  *
  * @param {string} sdId - UUID of the SD
@@ -53,9 +85,34 @@ export async function analyzeSDRejections(sdId, options = {}) {
       return { analyzed: true, patternsCreated: 0, gates: {} };
     }
 
+    // SD-PAT-FIX-PLAN-EXEC-REJECTED-001: segment out designed fast-fails BEFORE
+    // pattern math (see FAST_FAIL_EXCLUDED_REASONS above). They are counted per
+    // gate so a created pattern still surfaces them as metadata, never as
+    // occurrence_count / avg-score signal.
+    const excludedByGate = {};
+    let excludedTotal = 0;
+    const qualityRejections = rejections.filter((rejection) => {
+      if (isFastFailRejection(rejection)) {
+        const gate = rejection.handoff_type;
+        excludedByGate[gate] = (excludedByGate[gate] || 0) + 1;
+        excludedTotal++;
+        return false;
+      }
+      return true;
+    });
+
+    if (excludedTotal > 0) {
+      console.log(`  [session-retro] Excluded ${excludedTotal} designed fast-fail rejection(s) from pattern math (${Object.entries(excludedByGate).map(([g, n]) => `${g}:${n}`).join(', ')})`);
+    }
+
+    if (qualityRejections.length === 0) {
+      console.log('  [session-retro] All rejections were designed fast-fails — no quality signal');
+      return { analyzed: true, patternsCreated: 0, gates: {}, excludedFastFails: excludedTotal };
+    }
+
     // Group rejections by handoff_type (gate)
     const byGate = {};
-    for (const rejection of rejections) {
+    for (const rejection of qualityRejections) {
       const gate = rejection.handoff_type;
       if (!byGate[gate]) {
         byGate[gate] = [];
@@ -63,7 +120,7 @@ export async function analyzeSDRejections(sdId, options = {}) {
       byGate[gate].push(rejection);
     }
 
-    console.log(`  [session-retro] Analyzing ${rejections.length} rejection(s) across ${Object.keys(byGate).length} gate(s)`);
+    console.log(`  [session-retro] Analyzing ${qualityRejections.length} rejection(s) across ${Object.keys(byGate).length} gate(s)`);
 
     let patternsCreated = 0;
 
@@ -116,6 +173,8 @@ export async function analyzeSDRejections(sdId, options = {}) {
             rejection_count: gateRejections.length,
             avg_score: avgScore,
             reasons: reasons.slice(0, 10),
+            // SD-PAT-FIX-PLAN-EXEC-REJECTED-001: fast-fails segmented, not hidden.
+            excluded_fast_fails: excludedByGate[gate] || 0,
             analyzed_at: new Date().toISOString()
           }
         });
@@ -128,11 +187,12 @@ export async function analyzeSDRejections(sdId, options = {}) {
       }
     }
 
-    console.log(`  [session-retro] Analysis complete: ${patternsCreated} pattern(s) created from ${rejections.length} rejection(s)`);
+    console.log(`  [session-retro] Analysis complete: ${patternsCreated} pattern(s) created from ${qualityRejections.length} quality rejection(s) (${excludedTotal} fast-fail(s) excluded)`);
 
     return {
       analyzed: true,
       patternsCreated,
+      excludedFastFails: excludedTotal,
       gates: Object.fromEntries(
         Object.entries(byGate).map(([gate, rejs]) => [gate, rejs.length])
       )

--- a/tests/unit/session-retrospective-fastfail-filter.test.js
+++ b/tests/unit/session-retrospective-fastfail-filter.test.js
@@ -1,0 +1,134 @@
+/**
+ * SD-PAT-FIX-PLAN-EXEC-REJECTED-001 — designed fast-fail rejections must not
+ * feed session-retro pattern math.
+ *
+ * Pattern PAT-RETRO-PLANTOEXEC-3741735a ("rejected 11 times, avg 0%") was
+ * generated from ONE April SD whose rejections were mostly prerequisite
+ * fast-fails + claim-validity mechanics (score 0 by construction). These
+ * tests replay that exact shape and pin: no pattern from fast-fails alone,
+ * genuine quality failures still counted, excluded counts surfaced in
+ * metadata (segmented, not hidden).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  analyzeSDRejections,
+  FAST_FAIL_EXCLUDED_REASONS,
+  isFastFailRejection,
+} from '../../scripts/modules/learning/session-retrospective.js';
+
+function mockSupabase({ rejections, existingPatterns = [] }) {
+  const inserted = [];
+  const sb = {
+    from: vi.fn().mockImplementation((table) => {
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn().mockResolvedValue({ data: rejections, error: null }),
+        };
+      }
+      if (table === 'issue_patterns') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: existingPatterns, error: null }),
+          insert: vi.fn().mockImplementation((row) => {
+            inserted.push(row);
+            return Promise.resolve({ error: null });
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    }),
+  };
+  return { sb, inserted };
+}
+
+const fastFail = (overrides = {}) => ({
+  id: 'r', handoff_type: 'PLAN-TO-EXEC', validation_score: 0,
+  rejection_reason: 'Prerequisite preflight failed: PRD_MISSING, USER_STORIES_MISSING',
+  validation_details: { reason: 'PREREQUISITE_PREFLIGHT_FAILED' },
+  created_at: '2026-04-13T11:06:00Z',
+  ...overrides,
+});
+
+const claimFail = (overrides = {}) => ({
+  id: 'r', handoff_type: 'PLAN-TO-EXEC', validation_score: 0,
+  rejection_reason: 'GATE_CLAIM_VALIDITY validation failed - no_deterministic_identity',
+  validation_details: {},
+  created_at: '2026-04-13T11:17:00Z',
+  ...overrides,
+});
+
+const qualityFail = (overrides = {}) => ({
+  id: 'r', handoff_type: 'PLAN-TO-EXEC', validation_score: 45,
+  rejection_reason: 'PRD does not meet quality standards',
+  validation_details: { reason: 'PRD_QUALITY_FAILED' },
+  created_at: '2026-04-13T12:47:00Z',
+  ...overrides,
+});
+
+describe('isFastFailRejection', () => {
+  it('matches the three designed fast-fail classes (reason code or rejection text)', () => {
+    expect(isFastFailRejection(fastFail())).toBe(true);
+    expect(isFastFailRejection(claimFail())).toBe(true);
+    expect(isFastFailRejection({ rejection_reason: 'Artifact preflight failed: success_metrics', validation_details: { reason: 'ARTIFACT_PREFLIGHT_FAILED' } })).toBe(true);
+    expect(isFastFailRejection(qualityFail())).toBe(false);
+  });
+
+  it('exclusion list is exported with the three classes', () => {
+    expect(FAST_FAIL_EXCLUDED_REASONS).toEqual(
+      expect.arrayContaining(['PREREQUISITE_PREFLIGHT_FAILED', 'ARTIFACT_PREFLIGHT_FAILED', 'GATE_CLAIM_VALIDITY'])
+    );
+  });
+});
+
+describe('analyzeSDRejections fast-fail segmentation', () => {
+  it('April-incident replay: 8 fast-fails + 1 quality rejection -> NO pattern, excluded count returned', async () => {
+    const rejections = [
+      fastFail(), fastFail(), fastFail({ rejection_reason: 'Prerequisite preflight failed: USER_STORIES_MISSING' }),
+      claimFail(), claimFail({ rejection_reason: 'GATE_CLAIM_VALIDITY validation failed - foreign_claim: [claim]' }),
+      claimFail(), claimFail(),
+      fastFail({ validation_details: { reason: 'ARTIFACT_PREFLIGHT_FAILED' }, rejection_reason: 'Artifact preflight failed: success_metrics' }),
+      qualityFail(), // only ONE genuine quality failure — below MIN_REJECTIONS_FOR_PATTERN
+    ];
+    const { sb, inserted } = mockSupabase({ rejections });
+
+    const result = await analyzeSDRejections('3741735a-9d49-4080-bda2-eb3f5dde3f04', { supabaseClient: sb });
+
+    expect(result.analyzed).toBe(true);
+    expect(result.patternsCreated).toBe(0);
+    expect(result.excludedFastFails).toBe(8);
+    expect(inserted).toEqual([]);
+  });
+
+  it('all-fast-fail SD: returns clean with zero patterns', async () => {
+    const { sb, inserted } = mockSupabase({ rejections: [fastFail(), fastFail(), claimFail()] });
+    const result = await analyzeSDRejections('sd-uuid', { supabaseClient: sb });
+    expect(result.patternsCreated).toBe(0);
+    expect(result.excludedFastFails).toBe(3);
+    expect(inserted).toEqual([]);
+  });
+
+  it('genuine repeated quality failures still produce a pattern with correct count/avg + excluded metadata', async () => {
+    const rejections = [
+      fastFail(), // 1 fast-fail on the same gate — must appear ONLY in metadata
+      qualityFail({ validation_score: 40 }),
+      qualityFail({ validation_score: 50 }),
+      qualityFail({ validation_score: 60 }),
+      qualityFail({ validation_score: 50 }),
+    ];
+    const { sb, inserted } = mockSupabase({ rejections });
+
+    const result = await analyzeSDRejections('sd-uuid-2', { supabaseClient: sb });
+
+    expect(result.patternsCreated).toBe(1);
+    expect(inserted).toHaveLength(1);
+    const pattern = inserted[0];
+    expect(pattern.occurrence_count).toBe(4);            // quality failures only
+    expect(pattern.metadata.avg_score).toBe(50);          // not dragged to 0 by fast-fails
+    expect(pattern.metadata.excluded_fast_fails).toBe(1); // segmented, not hidden
+    expect(pattern.severity).toBe('high');                // 4 genuine rejections
+  });
+});


### PR DESCRIPTION
## Summary
Auto-filed pattern SD investigated to root cause: PAT-RETRO-PLANTOEXEC-3741735a ("PLAN-TO-EXEC rejected 11 times, avg 0%", HIGH severity) was generated from **one SD on 2026-04-13** — 3 prerequisite fast-fails (PRD/stories not yet created; designed cheap pre-pipeline guidance whose score is 0 *by construction*), 4 GATE_CLAIM_VALIDITY mechanics failures (since-fixed `no_deterministic_identity` class), 1 real PRD-quality failure — then accepted; the SD completed the same day.

## Fix (the generator, not the symptom)
`analyzeSDRejections` now filters `FAST_FAIL_EXCLUDED_REASONS` (PREREQUISITE_PREFLIGHT_FAILED, ARTIFACT_PREFLIGHT_FAILED, GATE_CLAIM_VALIDITY) before pattern math. Excluded rows are **segmented, not hidden**: counts land in `metadata.excluded_fast_fails` and the return value.

## Tests (5)
- April-incident replay → zero patterns (8 excluded + 1 quality below threshold)
- All-fast-fail SD → clean, excluded count returned
- 4 genuine quality failures → HIGH pattern, occurrence_count=4, **avg 50 (not dragged to 0)**, excluded count in metadata
- Exclusion list + matcher pinned

Originating pattern resolved with investigation notes. SD retargeted feature/ehg → bugfix/EHG_Engineer (governance type_change_reason recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)