### PR TITLE
feat(SD-MAN-INFRA-RETENTION-OPS-FINISHER-001): arm weekly retention loop durably + changed_at index + quarantine-drop schedule

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001",
-  "expectedBranch": "feat/SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001",
-  "createdAt": "2026-06-11T11:16:52.397Z",
+  "sdKey": "SD-MAN-INFRA-RETENTION-OPS-FINISHER-001",
+  "expectedBranch": "feat/SD-MAN-INFRA-RETENTION-OPS-FINISHER-001",
+  "createdAt": "2026-06-11T13:55:14.778Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260611_governance_audit_log_changed_at_idx.sql
+++ b/database/migrations/20260611_governance_audit_log_changed_at_idx.sql
@@ -1,0 +1,15 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-MAN-INFRA-RETENTION-OPS-FINISHER-001 (FR-4, closes flag d2c40522).
+-- Chairman context: retention machinery + 90d windows GO'd 2026-06-10
+-- (SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001); this index was emitted as the
+-- needs_decision completion flag d2c40522 of that approved SD. LEAD decision +
+-- RISK PASS-88 (row 3c7f4545): additive index only, no data change.
+-- Retention sorts on governance_audit_log (~484k rows, ~1 insert/sec) order by
+-- changed_at and hit intermittent statement timeouts (absorbed fail-soft by the
+-- retention CLI — zero data loss, but weekly convergence stalls). Plain CREATE
+-- INDEX accepted at LEAD: the SHARE lock blocks writes only for the build
+-- (low tens of seconds at this size); inserts queue, not fail. CONCURRENTLY is
+-- deliberately NOT used — it cannot run inside apply-migration's transaction
+-- wrapper. Idempotent via IF NOT EXISTS.
+CREATE INDEX IF NOT EXISTS idx_governance_audit_log_changed_at
+  ON governance_audit_log (changed_at);

--- a/lib/coordinator/teardown-coordinator.cjs
+++ b/lib/coordinator/teardown-coordinator.cjs
@@ -47,7 +47,9 @@ const COORDINATOR_CRONS = [
   // SD-LEO-INFRA-CODIFY-SUBSYSTEM-REVIEW-001: weekly subsystem-review rotation (due-gated internally).
   { key: 'review-rotation', cadence: '0 9 * * 1',                            command: 'node scripts/subsystem-review-rotation.cjs', re_asserts_pointer: false },
   // SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001: weekly scripts-estate reachability gauge (due-gated internally).
-  { key: 'scripts-reachability', cadence: '40 9 * * 1',                       command: 'node scripts/scripts-reachability-gauge.mjs', re_asserts_pointer: false }
+  { key: 'scripts-reachability', cadence: '40 9 * * 1',                       command: 'node scripts/scripts-reachability-gauge.mjs', re_asserts_pointer: false },
+  // SD-MAN-INFRA-RETENTION-OPS-FINISHER-001: weekly archive-not-delete retention enforcement.
+  { key: 'retention', cadence: '0 3 * * 0',                                   command: 'npm run retention:apply',                    re_asserts_pointer: false }
 ];
 
 // Basename markers used to recognise coordinator-owned jobs in a CronList() result. The
@@ -60,7 +62,14 @@ const COORD_SCRIPT_MARKERS = [
   'assign-fleet-identities.cjs',
   'coordinator-email-summary.mjs',
   'row-growth-snapshot.cjs',
-  'subsystem-review-rotation.cjs'
+  'subsystem-review-rotation.cjs',
+  // Drive-by (SD-MAN-INFRA-RETENTION-OPS-FINISHER-001): scripts-reachability was added to
+  // COORDINATOR_CRONS without a marker — its cron was unmatched at teardown (orphan-cron gap).
+  'scripts-reachability-gauge.mjs',
+  'retention-enforce.js',
+  // retention:apply resolves to retention-enforce.js; the npm alias is also matched directly
+  // so a CronList entry created with the alias prompt is still recognised for teardown.
+  'retention:apply'
 ];
 
 function isEnabled() {

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -112,6 +112,13 @@ export const STANDARD_LOOPS = [
   // so an extra arm or manual run is a cheap no-op. Advisory — never CI-blocking.
   { key: 'scripts-reachability', label: 'Scripts-estate reachability gauge (weekly)', script: 'scripts-reachability-gauge.mjs', cron: '40 9 * * 1',
     prompt: 'node scripts/scripts-reachability-gauge.mjs' },
+  // SD-MAN-INFRA-RETENTION-OPS-FINISHER-001: weekly archive-not-delete retention enforcement
+  // (machinery shipped + chairman-GO'd by SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001; 196k rows
+  // archived in the first live soak). Prompt mirrors scripts/retention-enforce.js --arming-spec.
+  // Batch-clamped + per-table fail-soft, so a re-arm or manual run is safe; backlog convergence
+  // (~513k workflow_trace_log + ~484k governance_audit_log) only progresses while this is armed.
+  { key: 'retention', label: 'Weekly retention enforcement (archive-not-delete)', script: 'retention-enforce.js', cron: '0 3 * * 0',
+    prompt: 'Run `npm run retention:apply` in EHG_Engineer and report the per-table archived/deleted counts; if the command exits non-zero or `npm run retention:check -- --liveness` reports STALE, surface to the coordinator.' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/tests/unit/retention-loop-parity.test.js
+++ b/tests/unit/retention-loop-parity.test.js
@@ -1,0 +1,66 @@
+// SD-MAN-INFRA-RETENTION-OPS-FINISHER-001: creation-teardown parity for the weekly
+// retention-enforce loop (the chairman-GO'd archive-not-delete machinery from
+// SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001, finally armed). Convention mirrors
+// the row-growth / review-rotation / scripts-reachability parity pins: the loop must
+// exist in STANDARD_LOOPS (creation), COORDINATOR_CRONS (teardown inventory), and
+// COORD_SCRIPT_MARKERS (CronList matcher) — a miss at any site = orphan-cron risk.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { STANDARD_LOOPS } from '../../scripts/coordinator-startup-check.mjs';
+
+const require = createRequire(import.meta.url);
+const { COORDINATOR_CRONS, COORD_SCRIPT_MARKERS, selectCoordinatorCronJobs } =
+  require('../../lib/coordinator/teardown-coordinator.cjs');
+
+describe('retention loop — creation site (STANDARD_LOOPS)', () => {
+  const loop = STANDARD_LOOPS.find((l) => l.key === 'retention');
+
+  it('exists with the weekly Sunday 03:00 cadence', () => {
+    expect(loop).toBeTruthy();
+    expect(loop.cron).toBe('0 3 * * 0');
+    expect(loop.script).toBe('retention-enforce.js');
+  });
+
+  it('prompt mirrors the emitted arming spec (apply + report + STALE surfacing)', () => {
+    expect(loop.prompt).toMatch(/retention:apply/);
+    expect(loop.prompt).toMatch(/per-table archived\/deleted counts/);
+    expect(loop.prompt).toMatch(/STALE/);
+    expect(loop.prompt).toMatch(/coordinator/);
+  });
+});
+
+describe('retention loop — teardown parity', () => {
+  it('COORDINATOR_CRONS carries the matching entry (same cadence, non-pointer-asserting)', () => {
+    const cron = COORDINATOR_CRONS.find((c) => c.key === 'retention');
+    expect(cron).toBeTruthy();
+    expect(cron.cadence).toBe('0 3 * * 0');
+    expect(cron.re_asserts_pointer).toBe(false);
+  });
+
+  it('COORD_SCRIPT_MARKERS matches BOTH the script basename and the npm alias', () => {
+    expect(COORD_SCRIPT_MARKERS).toContain('retention-enforce.js');
+    expect(COORD_SCRIPT_MARKERS).toContain('retention:apply');
+  });
+
+  it('selectCoordinatorCronJobs recognises a CronList row created from the arming-spec prompt', () => {
+    const picked = selectCoordinatorCronJobs([
+      { id: 'x1', prompt: 'Run `npm run retention:apply` in EHG_Engineer and report the per-table archived/deleted counts' },
+      { id: 'x2', prompt: 'something unrelated' },
+    ]);
+    expect(picked.map((j) => j.id)).toEqual(['x1']);
+  });
+});
+
+describe('drive-by: scripts-reachability marker parity (pre-existing gap closed)', () => {
+  it('scripts-reachability-gauge.mjs is now in COORD_SCRIPT_MARKERS', () => {
+    expect(COORD_SCRIPT_MARKERS).toContain('scripts-reachability-gauge.mjs');
+  });
+
+  it('every COORDINATOR_CRONS entry is matchable by at least one marker (full-inventory parity)', () => {
+    for (const c of COORDINATOR_CRONS) {
+      const matched = COORD_SCRIPT_MARKERS.some((m) => String(c.command).includes(m));
+      expect(matched, `${c.key} (${c.command}) has no matching marker`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## SD-MAN-INFRA-RETENTION-OPS-FINISHER-001 — retention ops finisher trio

**Type**: infrastructure | **Priority**: medium | Gates: LEAD-TO-PLAN ✅, PLAN-TO-EXEC ✅ | RISK PASS-88 (row 3c7f4545)

Finishes the operational tail of the chairman-GO'd retention machinery (SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001):

### 1. Weekly retention loop ARMED durably (flags 7a3713ea → resolved)
- `STANDARD_LOOPS` key=`retention` (`0 3 * * 0`), prompt mirrors `retention-enforce.js --arming-spec`
- Teardown parity: `COORDINATOR_CRONS` entry + markers for **both** the script basename and the `retention:apply` npm alias (CronList rows created from the spec prompt are matchable)
- **7-test parity pin** incl. a full-inventory every-cron-has-a-marker sweep
- **Drive-by**: `scripts-reachability-gauge.mjs` was in COORDINATOR_CRONS with **no marker** (orphan-cron gap since ship) — closed + pinned
- Until armed, backlog convergence was paused: ~109k workflow_trace_log + ~76k governance_audit_log rows currently >90d eligible

### 2. `idx_governance_audit_log_changed_at` — APPLIED LIVE (flag d2c40522 → resolved)
`MIGRATION_APPLY_PROD_PASS` (sha 80396c6f), pre-checked zero long transactions; plain `CREATE INDEX` per LEAD decision (inserts queue not fail at ~1 write/sec; CONCURRENTLY incompatible with the apply-migration tx wrapper). **`retention:check` now runs clean on the 484k-row table** (was intermittent statement timeouts).

### 3. Quarantine drop scheduled (manual + chairman-gated)
Coordinator-inbox reminder posted: `management_reviews_quarantine_20260610` (45,015 rows) eligible **2026-06-24** — drop stays manual and chairman-reviewed; the weekly loop reports it every run. No automated drop built.

### Verification
- Parity suite 7/7; smoke 15/15; index verified via pg_indexes; retention:check live-run clean post-index

🤖 Generated with [Claude Code](https://claude.com/claude-code)
