### PR TITLE
fix(patterns): break the cancel→regenerate loop for SD-PAT-FIX SDs (QF-20260611-851)

### DIFF
--- a/scripts/pattern-alert-sd-creator.js
+++ b/scripts/pattern-alert-sd-creator.js
@@ -93,24 +93,70 @@ const CONFIG = {
 };
 
 /**
- * Check if a pattern already has an associated SD
+ * Check if a pattern already has an associated SD.
+ *
+ * QF-20260611-851: cancelled SDs now COUNT as existing unless the pattern has
+ * genuinely NEW occurrences after the cancellation. Pre-fix, `.neq('status',
+ * 'cancelled')` made a cancelled SD-PAT-FIX draft invisible here, so the
+ * generator re-created the same SD on its next cycle — a bulk triage cancelled
+ * 14 drafts at 13:31Z 2026-06-11 and 10 regenerated within ~25 minutes.
+ * Disposition semantics: pattern.updated_at <= SD cancellation time means no
+ * new evidence since a human said no — skip and stamp
+ * issue_patterns.metadata.disposition (auditable, implicit backfill). New
+ * occurrences AFTER the cancellation re-escalate legitimately.
+ *
+ * @param {string} patternId
+ * @param {object|null} pattern - the issue_patterns row (recency vs cancellation)
  */
-async function hasExistingSD(patternId) {
-  // Check for existing SD with pattern ID in title or description
+export async function hasExistingSD(patternId, pattern = null) {
   const { data, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, status')
+    .select('id, sd_key, status, updated_at')
     .or(`title.ilike.%${patternId}%,description.ilike.%${patternId}%`)
     .neq('status', 'completed')
-    .neq('status', 'cancelled')
-    .limit(1);
+    .order('updated_at', { ascending: false })
+    .limit(5);
 
   if (error) {
     console.error(`  Error checking existing SD: ${error.message}`);
     return false;
   }
 
-  return data && data.length > 0 ? data[0] : null;
+  const rows = data || [];
+  const live = rows.find(r => r.status !== 'cancelled');
+  if (live) return live;
+
+  const cancelled = rows.find(r => r.status === 'cancelled');
+  if (cancelled) {
+    const cancelledAt = cancelled.updated_at ? new Date(cancelled.updated_at) : null;
+    const lastActivity = pattern?.updated_at ? new Date(pattern.updated_at) : null;
+    const hasNewOccurrences = cancelledAt && lastActivity && lastActivity > cancelledAt;
+    if (!hasNewOccurrences) {
+      // Stamp the disposition on the pattern (fail-soft: a stamp failure must
+      // not break the alert cycle).
+      try {
+        await supabase
+          .from('issue_patterns')
+          .update({
+            metadata: {
+              ...(pattern?.metadata || {}),
+              disposition: {
+                kind: 'sd_cancelled_no_new_occurrences',
+                cancelled_sd: cancelled.sd_key,
+                cancelled_at: cancelled.updated_at,
+                stamped_at: new Date().toISOString(),
+                stamped_by: 'pattern-alert-sd-creator (QF-20260611-851)'
+              }
+            }
+          })
+          .eq('pattern_id', patternId);
+      } catch { /* fail-soft */ }
+      return { ...cancelled, disposition: 'cancelled_no_new_occurrences' };
+    }
+    console.log(`  Prior SD ${cancelled.sd_key} cancelled but pattern has NEW occurrences since — regeneration allowed`);
+  }
+
+  return null;
 }
 
 /**
@@ -324,7 +370,7 @@ ${suggestedTeam}
  */
 export async function createSDForPattern(pattern) {
   // Check for existing SD first
-  const existingSD = await hasExistingSD(pattern.pattern_id);
+  const existingSD = await hasExistingSD(pattern.pattern_id, pattern);
   if (existingSD) {
     console.log(`  SD already exists: ${existingSD.sd_key} (${existingSD.status})`);
     return { skipped: true, existing: existingSD };

--- a/tests/unit/pattern-alert-cancelled-disposition.test.js
+++ b/tests/unit/pattern-alert-cancelled-disposition.test.js
@@ -1,0 +1,104 @@
+/**
+ * QF-20260611-851 — cancelled SD-PAT-FIX SDs must not regenerate.
+ *
+ * Pre-fix, hasExistingSD excluded cancelled SDs, so a bulk-cancelled draft was
+ * invisible and the generator re-created it next cycle (14 cancelled at 13:31Z
+ * 2026-06-11; 10 regenerated within ~25 min). Now: a cancelled SD counts as
+ * existing unless the pattern has NEW occurrences after the cancellation.
+ *
+ * TEST_REQUIRES_DB: false — @supabase/supabase-js is vi.mock'd below; the env
+ * values set before import only satisfy the module's construction guard.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const queries = [];
+let sdRows = [];
+const patternUpdates = [];
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: (table) => {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: () => ({
+            or: () => ({
+              neq: () => ({
+                order: () => ({
+                  limit: () => {
+                    queries.push(table);
+                    return Promise.resolve({ data: sdRows, error: null });
+                  },
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'issue_patterns') {
+        return {
+          update: (payload) => ({
+            eq: (col, val) => {
+              patternUpdates.push({ payload, col, val });
+              return Promise.resolve({ data: null, error: null });
+            },
+          }),
+        };
+      }
+      return {};
+    },
+  }),
+}));
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://fake.local';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'fake-key';
+
+const { hasExistingSD } = await import('../../scripts/pattern-alert-sd-creator.js');
+
+const T0 = '2026-06-11T13:00:00Z'; // pattern last activity
+const T_CANCEL = '2026-06-11T13:31:00Z'; // bulk-cancel time (after T0)
+
+beforeEach(() => {
+  queries.length = 0;
+  sdRows = [];
+  patternUpdates.length = 0;
+});
+
+describe('QF-20260611-851: hasExistingSD cancelled-disposition', () => {
+  it('live (non-cancelled) SD still short-circuits as before', async () => {
+    sdRows = [{ id: '1', sd_key: 'SD-PAT-X-001', status: 'draft', updated_at: T_CANCEL }];
+    const r = await hasExistingSD('PAT-X', { updated_at: T0 });
+    expect(r.sd_key).toBe('SD-PAT-X-001');
+    expect(r.disposition).toBeUndefined();
+  });
+
+  it('cancelled SD with NO new occurrences blocks regeneration and stamps disposition', async () => {
+    sdRows = [{ id: '1', sd_key: 'SD-PAT-X-001', status: 'cancelled', updated_at: T_CANCEL }];
+    const r = await hasExistingSD('PAT-X', { updated_at: T0, metadata: { keep: true } });
+    expect(r.disposition).toBe('cancelled_no_new_occurrences');
+    expect(patternUpdates).toHaveLength(1);
+    const d = patternUpdates[0].payload.metadata.disposition;
+    expect(d.kind).toBe('sd_cancelled_no_new_occurrences');
+    expect(d.cancelled_sd).toBe('SD-PAT-X-001');
+    expect(patternUpdates[0].payload.metadata.keep).toBe(true); // merge, not clobber
+    expect(patternUpdates[0].val).toBe('PAT-X');
+  });
+
+  it('cancelled SD but pattern has NEW occurrences after cancel → regeneration allowed (returns null)', async () => {
+    sdRows = [{ id: '1', sd_key: 'SD-PAT-X-001', status: 'cancelled', updated_at: T_CANCEL }];
+    const r = await hasExistingSD('PAT-X', { updated_at: '2026-06-11T14:00:00Z' });
+    expect(r).toBeNull();
+    expect(patternUpdates).toHaveLength(0);
+  });
+
+  it('no SDs at all → null (creation proceeds)', async () => {
+    const r = await hasExistingSD('PAT-X', { updated_at: T0 });
+    expect(r).toBeNull();
+  });
+
+  it('missing pattern timestamps fail SAFE (treated as no new occurrences — skip)', async () => {
+    sdRows = [{ id: '1', sd_key: 'SD-PAT-X-001', status: 'cancelled', updated_at: T_CANCEL }];
+    const r = await hasExistingSD('PAT-X', null);
+    expect(r.disposition).toBe('cancelled_no_new_occurrences');
+  });
+});


### PR DESCRIPTION
## Summary
Bulk-cancelling 14 SD-PAT-FIX drafts at 13:31Z today produced **10 regenerated drafts within ~25 minutes**: `hasExistingSD` excluded `cancelled` SDs, so a cancelled pattern SD was invisible to the generator's dedup.

- Cancelled SD now counts as existing **unless** the pattern's `updated_at` moves past the cancellation time (new occurrences ⇒ legitimate re-escalation stays alive)
- Skip stamps `issue_patterns.metadata.disposition` (auditable; implicit backfill on next cycle — no separate backfill script)
- Fail-safe: missing timestamps ⇒ skip (don't regenerate)

## Verification
- 5 new unit tests + pattern-sd-completeness suite green (10/10)
- Live `--dry-run`: 18 patterns checked, **0 created**, 0 errors

Coordinator may unpause the generator after merge (corr patfix-wave2-1781186906).

🤖 Generated with [Claude Code](https://claude.com/claude-code)