### PR TITLE
fix(tests): derive teardown cron count from key list — stops the count-pin breakage class (QF-20260611-101)

### DIFF
--- a/lib/coordinator/teardown-coordinator.test.js
+++ b/lib/coordinator/teardown-coordinator.test.js
@@ -33,13 +33,17 @@ afterEach(() => {
 });
 
 describe('teardown-coordinator: inventory + matcher', () => {
-  it('listCoordinatorCrons enumerates all 8 coordinator crons incl the pointer-re-asserting inbox loop', () => {
+  // QF-20260611-101: the cron inventory grows ~weekly and the magic-number pin
+  // broke main twice in one day (7->8 #4626, 8->9 #4645). The key LIST is the
+  // single pin now; the count derives from it. Adding a cron = add ONE key here.
+  const EXPECTED_CRON_KEYS = ['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention'];
+
+  it('listCoordinatorCrons enumerates exactly the expected coordinator crons incl the pointer-re-asserting inbox loop', () => {
     const crons = listCoordinatorCrons();
-    expect(crons.length).toBe(8); // +scripts-reachability (SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001, QF-20260611-405 pin bump)
+    expect(crons.map((c) => c.key)).toEqual(EXPECTED_CRON_KEYS);
     const inbox = crons.find((c) => c.key === 'inbox');
     expect(inbox).toBeTruthy();
     expect(inbox.re_asserts_pointer).toBe(true); // the crux: missing this cron self-reverses teardown
-    expect(crons.map((c) => c.key)).toEqual(['sweep', 'dashboard', 'identity', 'inbox', 'email', 'row-growth', 'review-rotation', 'scripts-reachability']);
   });
 
   it('TS-6: selectCoordinatorCronJobs matches coordinator crons (incl inbox via fleet-dashboard.cjs marker) and excludes non-coordinator jobs', () => {
@@ -76,7 +80,8 @@ describe('teardown-coordinator: clearCoordinatorPointer', () => {
     expect(res.enabled).toBe(true);
     expect(res.refused).toBe(false);
     expect(res.pointer_cleared).toBe(true);
-    expect(res.crons_to_delete.length).toBe(8); // +scripts-reachability (SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001, QF-20260611-405 pin bump)
+    // QF-20260611-101: derive from the live inventory — the count pin broke main twice in a day
+    expect(res.crons_to_delete.length).toBe(listCoordinatorCrons().length);
     expect(fs.existsSync(tmpPointer)).toBe(false); // pointer file removed
   });
 


### PR DESCRIPTION
## Summary
**Red-merge detector catch #3** (103→105 at 13fa5b152b): #4645 added the 9th coordinator cron (retention) and the teardown count-pin broke main — for the **second time today** (7→8 by #4626 this morning).

- The key LIST is now the single pin (adding a cron = adding ONE key, with exact order still asserted)
- `crons_to_delete.length` derives from the live inventory
- `retention` key added

8/8 green; baseline NOT regenerated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)