### PR TITLE
fix(QF-20260611-510): scaffold-era exclusion predicate + no-auto-override doctrine at the gate-enforcement seam

### DIFF
--- a/lib/eva/gate-enforcement.js
+++ b/lib/eva/gate-enforcement.js
@@ -25,8 +25,36 @@
  * decision='override', the first-class recording of deliberate chairman
  * build-out forcing (chairman context 2026-06-10: the override is the
  * RECORDING of the practice, not a guardrail against it).
+ *
+ * NO-AUTO-OVERRIDE DOCTRINE (chairman ruling, sitting #1 item 2, 2026-06-11,
+ * recorded in SD-LEO-ORCH-ADAM-PLAN-KEEPER-001 metadata.sitting_1_record;
+ * stamped here per QF-20260611-510): gate overrides are CHAIRMAN decisions —
+ * no automation may create chairman_decisions rows to unblock a gate. The
+ * mechanical enforcement is the chairman_decisions requirement above
+ * (SD-LEO-FIX-MAKE-VENTURE-STAGE-001); this comment is the doctrine reference.
+ *
+ * SCAFFOLD-ERA DATA EXCLUSION (same ruling): ventures stamped
+ * metadata.venture_classification='workflow_scaffold' (CronLinter, Canvas-AI —
+ * gates deliberately forced during workflow build-out) carry NO market/kill
+ * lessons. Gate-calibration analytics MUST exclude them — use
+ * isCalibrationEligibleVenture() below as the canonical predicate
+ * (SD-MAN-INFRA-GATE-BAR-REGIME-001 queries filter through it).
  */
 'use strict';
+
+// Classification value for ventures whose gate history is build-out noise.
+export const SCAFFOLD_CLASSIFICATION = 'workflow_scaffold';
+
+/**
+ * PURE: should this venture's gate verdicts feed calibration analytics?
+ * Excludes ventures classified as workflow scaffolds (chairman-ratified:
+ * their gate data reflects deliberate forcing, not market reality).
+ * @param {{metadata?: {venture_classification?: string}}} venture - a ventures row (or {metadata})
+ * @returns {boolean}
+ */
+export function isCalibrationEligibleVenture(venture) {
+  return venture?.metadata?.venture_classification !== SCAFFOLD_CLASSIFICATION;
+}
 
 export const GATE_ENFORCEMENT = Object.freeze({
   kill: 'blocking',

--- a/tests/unit/gate-enforcement-calibration-eligibility.test.js
+++ b/tests/unit/gate-enforcement-calibration-eligibility.test.js
@@ -1,0 +1,51 @@
+// QF-20260611-510 (chairman ruling, sitting #1 item 2, 2026-06-11): ventures
+// classified workflow_scaffold (CronLinter, Canvas-AI — gates deliberately
+// forced during build-out) must be excluded from gate-calibration analytics.
+// Pins the canonical predicate at the enforcement seam so the
+// SD-MAN-INFRA-GATE-BAR-REGIME-001 calibration queries have ONE filter to use.
+
+import { describe, it, expect } from 'vitest';
+import {
+  SCAFFOLD_CLASSIFICATION,
+  isCalibrationEligibleVenture,
+  GATE_ENFORCEMENT,
+  classifyGateRow,
+} from '../../lib/eva/gate-enforcement.js';
+
+describe('SCAFFOLD_CLASSIFICATION constant', () => {
+  it('matches the chairman-ratified classification value', () => {
+    expect(SCAFFOLD_CLASSIFICATION).toBe('workflow_scaffold');
+  });
+});
+
+describe('isCalibrationEligibleVenture', () => {
+  it('EXCLUDES a workflow_scaffold venture (the CronLinter/Canvas-AI shape)', () => {
+    expect(isCalibrationEligibleVenture({
+      metadata: { venture_classification: 'workflow_scaffold', classification_basis: 'sitting #1 item 2' },
+    })).toBe(false);
+  });
+
+  it('includes a normal venture (no classification)', () => {
+    expect(isCalibrationEligibleVenture({ metadata: {} })).toBe(true);
+  });
+
+  it('includes a venture with a different classification', () => {
+    expect(isCalibrationEligibleVenture({ metadata: { venture_classification: 'real' } })).toBe(true);
+  });
+
+  it('includes when metadata is missing entirely (fail-open: never silently drops real data)', () => {
+    expect(isCalibrationEligibleVenture({})).toBe(true);
+    expect(isCalibrationEligibleVenture(null)).toBe(true);
+    expect(isCalibrationEligibleVenture(undefined)).toBe(true);
+  });
+});
+
+describe('existing enforcement semantics untouched', () => {
+  it('GATE_ENFORCEMENT mapping unchanged (kill/exit blocking, entry advisory)', () => {
+    expect(GATE_ENFORCEMENT).toEqual({ kill: 'blocking', exit: 'blocking', entry: 'advisory' });
+  });
+
+  it('classifyGateRow defaults unknown types to advisory', () => {
+    expect(classifyGateRow({ gate_type: 'mystery' })).toBe('advisory');
+  });
+});


### PR DESCRIPTION
## QF-20260611-510 — workflow_scaffold stamps + calibration exclusion (sitting #1 item 2)

**Type**: polish | **Severity**: medium | Chairman ruling: sitting #1 item 2, 2026-06-11 (recorded in SD-LEO-ORCH-ADAM-PLAN-KEEPER-001 `metadata.sitting_1_record`)

### What
CronLinter + Canvas-AI are ratified `workflow_scaffold` ventures — gates were deliberately forced during workflow build-out, so their gate history carries no market/kill lessons and must not contaminate calibration analytics (especially now that the FIRST clean calibration cohort exists via the DataDistill honest launch).

1. **Ventures stamped live** (read-modify-merge, verified by select-back): `metadata.venture_classification='workflow_scaffold'` + `classification_basis` on `0e6449d9` (CronLinter) and `4f71b3bd` (Canvas AI).
2. **Canonical exclusion predicate at the enforcement seam**: `SCAFFOLD_CLASSIFICATION` + `isCalibrationEligibleVenture()` in `lib/eva/gate-enforcement.js` (pure, fail-open for unclassified ventures) — the ONE filter SD-MAN-INFRA-GATE-BAR-REGIME-001's calibration queries route through.
3. **No-auto-override doctrine** referenced in the module header (mechanical enforcement already shipped by SD-LEO-FIX-MAKE-VENTURE-STAGE-001).

### Verification
- 7/7 new tests (exclusion both directions, fail-open on missing metadata, existing GATE_ENFORCEMENT semantics pinned unchanged)
- Both venture rows verified stamped in the live DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
