### PR TITLE
fix(SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001): defect #10 — S24 go-live emits launch_metrics (gate had no producer)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-24-go-live.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-go-live.js
@@ -53,7 +53,7 @@ export async function analyzeStage24GoLive(params) {
   const channelSource = channelCandidates.find(s => Array.isArray(s?.channels) && s.channels.length > 0) || {};
   const channels = (channelSource.channels || []).filter(c => c.status === 'active' || c.enabled === true);
 
-  return {
+  const result = {
     launch_status: 'ready_to_launch',
     readiness_verdict: verdict,
     chairman_override_applied: allowedHold,
@@ -69,4 +69,30 @@ export async function analyzeStage24GoLive(params) {
     // pending-chairman state until the launch decision stamps real notes.
     launch_notes: 'Pending chairman launch decision (go-live trigger records launched_at + final notes).',
   };
+
+  // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #10): the
+  // S24 EXIT gate (SD-LEO-FEAT-STAGE-LIVE-ANNOUNCE-001 FR-5 verifiers) requires a
+  // current launch_metrics artifact with channels[].status==='activated' — but NO
+  // producer existed anywhere in the pipeline, so 24->25 advance was structurally
+  // impossible for every venture. Witnessed live on DataDistill. Emit the t=0
+  // metrics artifact whenever the launch decision is recorded (chairman go-live
+  // trigger passes launchedAt); honest initial metrics are zeros.
+  const launchedAt = params.launchedAt || params.launched_at;
+  if (launchedAt) {
+    result.launch_status = 'launched';
+    result.launched_at = launchedAt;
+    result.artifacts = [{
+      artifactType: 'launch_metrics',
+      title: 'Launch Metrics (t=0)',
+      payload: {
+        launched_at: launchedAt,
+        channels: channels.map(c => ({ channel: c.channel, status: 'activated', activated_at: launchedAt })),
+        metrics: { signups: 0, impressions: 0, clicks: 0, captured_at: launchedAt },
+      },
+      source: 'stage-24-go-live',
+      metadata: { sd_origin: 'SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001' },
+    }];
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary
The S24 exit gate (SD-LEO-FEAT-STAGE-LIVE-ANNOUNCE-001 FR-5 verifiers in `lib/eva/lifecycle/exit-gate-verifiers.js`) requires a current `launch_metrics` artifact with `channels[].status==='activated'` — but **no producer exists anywhere in the pipeline**, making 24→25 advance structurally impossible for every venture. Witnessed live on DataDistill during the honest-launch campaign; it got through only via a manual typed-artifacts persist.

This ships the durable producer: the go-live analyzer emits the t=0 metrics artifact (channels activated, honest zero metrics) whenever the chairman launch decision supplies `launchedAt`.

The campaign calibration readout already on main documents defect #10 as fixed — **this PR is the code that claim refers to** (it was stranded on the closed PR #4636 branch when the SD completed).

27 LOC, single file, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)