### PR TITLE
fix(QF-20260611-123): flush stdout before exit — CI red-merge 103->113 truncated-JSON regression

### DIFF
--- a/scripts/audit-ghost-completed-sds.mjs
+++ b/scripts/audit-ghost-completed-sds.mjs
@@ -60,6 +60,11 @@ async function safeExit(code) {
       }
     }
   } catch { /* fail-open: undici unavailable means no pool to drain */ }
+  // Quick-fix QF-20260611-123: process.exit discards unflushed stdout on async
+  // (Linux pipe) streams — a 317KB --json payload was truncated mid-string in CI.
+  // An empty write's callback fires only after all previously queued writes drain.
+  await new Promise((resolve) => process.stdout.write('', () => resolve()));
+  await new Promise((resolve) => process.stderr.write('', () => resolve()));
   process.exit(code);
 }
 


### PR DESCRIPTION
## Summary
Red-merge detector filed QF-20260611-123 when main failures rose 103→113 at 24c8d9034b. CI artifact diff (runs 27370304935 vs 27357195388 vs tip 27371144047) shows:
- 9/10 new failures were transient live-DB integration flakes (already gone at main tip)
- 1 deterministic regression: `audit-ghost-completed-sds.test.js` --json parse — the script writes ~317KB JSON (1000 ghost-SD rows) then `process.exit()`s, which on Linux discards pipe-buffered stdout → JSON truncated mid-string
- the remaining chairman-decision-api failure is the pre-existing flaky cluster (2/3 already failing at the 103 baseline)

## Fix
Drain stdout/stderr via empty-write callbacks in `safeExit()` before `process.exit`. 5 LOC, one file. Baseline NOT regenerated.

## Verification
- `tests/integration/audit-ghost-completed-sds.test.js` 5/5 pass
- smoke 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)