### PR TITLE
fix(QF-20260612-405): VALIDATION CONDITIONAL_PASS now satisfies check_conditions_required

### DIFF
--- a/lib/sub-agents/validation.js
+++ b/lib/sub-agents/validation.js
@@ -302,6 +302,17 @@ export async function execute(sdId, subAgent, options = {}) {
     } else if (results.critical_issues.length > 0 || results.warnings.length > 0) {
       // Has discovery warnings but no blocking issues = proceed with caution
       results.verdict = 'CONDITIONAL_PASS';
+      // Quick-fix QF-20260612-405: sub_agent_execution_results enforces
+      // check_conditions_required (non-empty conditions array) and
+      // check_justification_required (justification >= 50 chars) on every
+      // CONDITIONAL_PASS row — populate both from the discovery findings.
+      const issues = [...results.critical_issues, ...results.warnings];
+      results.conditions = issues.map(w => w.recommendation || w.issue).filter(Boolean);
+      if (results.conditions.length === 0) results.conditions = ['Review discovery warnings before EXEC'];
+      results.justification = (
+        `CONDITIONAL_PASS: ${issues.length} non-blocking discovery finding(s) — ` +
+        issues.map(w => w.issue).filter(Boolean).join('; ')
+      ).slice(0, 1000).padEnd(50, '.');
     } else {
       results.verdict = 'PASS';
     }


### PR DESCRIPTION
## Summary
`collect-subagent-evidence.js` aborted with Postgres 23514 (`check_conditions_required`) whenever VALIDATION resolved CONDITIONAL_PASS: the producer (`lib/sub-agents/validation.js`) never populated `conditions`/`justification`, which the DB contract requires on every CONDITIONAL_PASS row. Fix at the producer: derive `conditions` from discovery findings (guaranteed non-empty) and synthesize a ≥50-char `justification`.

## Verification
- Re-ran `collect-subagent-evidence.js --sd SD-UAT-FIX-TEST-E2E-1781186358703-001 --phase LEAD-TO-PLAN`: VALIDATION rows now insert (previously hard-aborted the whole collection).
- RCA agent traced both constraints' definitions (migration 20251115114444) and confirmed producer-side fix as the prescribed option; PASS-downgrade and constraint-drop options rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)