### PR TITLE
fix(QF-20260612-113): self-heal stale QF claims in worker-checkin (terminal check was SD-only)

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -647,6 +647,14 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
         const { data: sdRow } = await sb.from('strategic_directives_v2').select('status').eq('sd_key', mySd).maybeSingle();
         if (sdRow && ['completed', 'cancelled', 'deferred'].includes(sdRow.status)) staleTerminal = true;
       } catch { /* fail-open: leave staleTerminal false -> resume preserved */ }
+    } else {
+      // Quick-fix QF-20260612-113: QF claims land in claude_sessions.sd_key too, but the
+      // terminal self-heal above was SD-only — a completed/cancelled/escalated QF looped
+      // action=resume forever. Apply the same check against quick_fixes.status.
+      try {
+        const { data: qfRow } = await sb.from('quick_fixes').select('status').eq('id', mySd).maybeSingle();
+        if (qfRow && ['completed', 'cancelled', 'escalated'].includes(qfRow.status)) staleTerminal = true;
+      } catch { /* fail-open: leave staleTerminal false -> resume preserved */ }
     }
     if (staleTerminal) {
       await selfHealStaleClaim(sb, sessionId, mySd);


### PR DESCRIPTION
## Summary
`worker-checkin.cjs`'s stale-terminal self-heal (FR-2, SD-LEO-INFRA-CLAIM-LIFECYCLE-HARDENING-002) only ran for SD claims; QF claims (which also live in `claude_sessions.sd_key`) skipped it via the `if (!isQf)` guard. Result: after a self-claimed quick-fix completes, every `/checkin` returns `action=resume` for the finished QF forever — the worker can never pull new work without manual `sd_key` surgery. Hit live by Alpha on QF-20260612-047 today.

Fix mirrors the SD check against `quick_fixes.status` (`completed`/`cancelled`/`escalated`), fail-open on query errors exactly like the SD path. +10 LOC, one file.

## Testing
- `tests/unit/worker-checkin-fleet-identity.test.js` 11/11
- `tests/unit/scripts/claim-lifecycle-hardening.test.js`, `tests/unit/checkin-merged-claim-pool.test.js`, `tests/unit/harness/claim-terminal-status-guard.test.js` — 24/24
- Live repro verified pre-fix (resume loop on completed QF-20260612-047; cleared only by manual sd_key null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)