### PR TITLE
fix(QF-20260612-437): quiescence-gate the hourly Adam exec-summary email

### DIFF
--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -18,6 +18,24 @@ const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPA
 const t = Date.now();
 const DRY = !!process.env.ADAM_EMAIL_DRYRUN || process.argv.includes('--dry-run');
 const SNAP = resolve('.adam-email-last.json');
+
+// Quick-fix QF-20260612-437: quiescence-gate the hourly send (chairman B13, 2026-06-12).
+// The eva-scheduler-host daemon fires this hourly regardless of fleet state — the chairman
+// received fleet-advisor emails with the fleet fully OFF. Reuse the same gate that silences
+// coordinator hourly reminders; gate fails open to ACTIVE, so a query error never drops a
+// legitimate email. --force (or DRY) bypasses for manual runs.
+const FORCE = process.argv.includes('--force');
+if (!DRY && !FORCE) {
+  try {
+    const { createRequire } = await import('module');
+    const q = createRequire(import.meta.url)('../lib/coordinator/fleet-quiescence.cjs');
+    const verdict = await q.assessFleetActivity(db); // returns {quiescent, reason}; fails open to ACTIVE
+    if (verdict.quiescent) {
+      console.log('ADAM-EMAIL skipped (fleet quiescent): ' + verdict.reason);
+      process.exit(0);
+    }
+  } catch (e) { console.log('quiescence check failed open (sending): ' + (e?.message || e)); }
+}
 const esc = (s) => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 const arrow = (cur, prev) => (typeof prev !== 'number' || cur === prev) ? '' : (cur > prev ? UP : DN);
 let snap = {}; try { snap = JSON.parse(readFileSync(SNAP, 'utf8')); } catch { snap = {}; }


### PR DESCRIPTION
## Summary
Chairman-directed (B13, 2026-06-12): the standalone eva-scheduler daemon sends the hourly "Adam — LEO Fleet Advisor" email unconditionally, including while the fleet is fully off. This gates the send on `lib/coordinator/fleet-quiescence.cjs` — the same quiescence verdict that silences coordinator hourly reminders. Skips with `ADAM-EMAIL skipped (fleet quiescent): <reason>` when 0 live claim-holding workers + 0 in_progress builds + no terminal transition in 20 min; resumes automatically when the fleet is active. Fail-open to ACTIVE (query errors never drop a legitimate email); `--dry-run`/`--force` bypass the gate. +19 LOC, one file.

## Testing
- `--dry-run` produces the normal summary (gate bypassed).
- Live run with fleet active: gate evaluated ACTIVE and sent normally.
- Quiescent path stub-verified: `assessFleetActivity` with 0/0/0 signals returns `quiescent:true` → script exits 0 before any email work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)