### PR TITLE
fix(QF-20260612-416): scope distill Todoist sync to the for-processing project (configurable)

### DIFF
--- a/lib/integrations/todoist/todoist-sync.js
+++ b/lib/integrations/todoist/todoist-sync.js
@@ -12,7 +12,21 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const TARGET_PROJECTS = ['EVA', 'EVA Next Steps'];
+// Quick-fix QF-20260612-416 (chairman-directed 2026-06-12): the formal distill
+// process pulls ONLY the dedicated for-processing project by default
+// (https://app.todoist.com/app/project/for-processing-6gfJpjh9Ghvv8fFq).
+// Override per-run via TODOIST_INTAKE_PROJECTS (comma-separated project ids,
+// name fallback) — e.g. the chairman's ONE-TIME pass over the personal eva
+// project sets the env var for a single run; eva must NOT join this default.
+const DEFAULT_INTAKE_PROJECTS = ['6gfJpjh9Ghvv8fFq'];
+
+export function getTargetProjects(env = process.env) {
+  const raw = env.TODOIST_INTAKE_PROJECTS;
+  if (typeof raw === 'string' && raw.trim()) {
+    return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return [...DEFAULT_INTAKE_PROJECTS];
+}
 
 /**
  * Create a configured Todoist API client
@@ -42,7 +56,9 @@ function createSupabaseClient() {
 async function findTargetProjects(api) {
   const response = await api.getProjects();
   const projects = response.results || response;
-  return projects.filter(p => TARGET_PROJECTS.includes(p.name));
+  const targets = getTargetProjects();
+  // Match by project id first (stable), project name as fallback.
+  return projects.filter(p => targets.includes(p.id) || targets.includes(p.name));
 }
 
 /**
@@ -248,7 +264,7 @@ export async function syncTodoist(options = {}) {
   const projects = await findTargetProjects(api);
 
   if (projects.length === 0) {
-    console.log('  No matching Todoist projects found. Expected:', TARGET_PROJECTS.join(', '));
+    console.log('  No matching Todoist projects found. Expected:', getTargetProjects().join(', '));
     return results;
   }
 
@@ -331,4 +347,4 @@ export async function syncTodoist(options = {}) {
   return results;
 }
 
-export default { syncTodoist, createTodoistClient, TARGET_PROJECTS };
+export default { syncTodoist, createTodoistClient, getTargetProjects };

--- a/tests/unit/todoist-intake-projects.test.js
+++ b/tests/unit/todoist-intake-projects.test.js
@@ -1,0 +1,33 @@
+/**
+ * Quick-fix QF-20260612-416: distill Todoist sync scoped to the dedicated
+ * for-processing project by default; env-configurable per run.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTargetProjects } from '../../lib/integrations/todoist/todoist-sync.js';
+
+describe('getTargetProjects (QF-20260612-416)', () => {
+  it('defaults to ONLY the for-processing project id', () => {
+    expect(getTargetProjects({})).toEqual(['6gfJpjh9Ghvv8fFq']);
+  });
+
+  it('does not include the legacy EVA projects in the default', () => {
+    const defaults = getTargetProjects({});
+    expect(defaults).not.toContain('EVA');
+    expect(defaults).not.toContain('EVA Next Steps');
+  });
+
+  it('TODOIST_INTAKE_PROJECTS env overrides the default (comma-separated, trimmed)', () => {
+    expect(getTargetProjects({ TODOIST_INTAKE_PROJECTS: '6Wrq3gHw2j3gC2Gw, someName' }))
+      .toEqual(['6Wrq3gHw2j3gC2Gw', 'someName']);
+  });
+
+  it('blank/whitespace env falls back to the default', () => {
+    expect(getTargetProjects({ TODOIST_INTAKE_PROJECTS: '   ' })).toEqual(['6gfJpjh9Ghvv8fFq']);
+  });
+
+  it('returns a fresh array (no shared-mutation of the default)', () => {
+    const a = getTargetProjects({});
+    a.push('mutated');
+    expect(getTargetProjects({})).toEqual(['6gfJpjh9Ghvv8fFq']);
+  });
+});


### PR DESCRIPTION
Chairman-directed 2026-06-12. `lib/integrations/todoist/todoist-sync.js` hard-coded `TARGET_PROJECTS=['EVA','EVA Next Steps']`; the designated for-processing project was never pulled.

- Default target = ONLY the for-processing project id `6gfJpjh9Ghvv8fFq` (match by project id, name fallback)
- `TODOIST_INTAKE_PROJECTS` env (comma-separated) overrides per run — enables the one-time personal-notes pass without touching the default or the distill code
- Legacy EVA projects removed from default; no external consumers of the old export (grep-verified)
- 5 unit tests pin default, exclusion, override, blank-env fallback, no-mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)