### PR TITLE
fix(SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001): handoff claim gate + session attribution

### DIFF
--- a/scripts/handoff.js
+++ b/scripts/handoff.js
@@ -103,11 +103,20 @@ const sdIdArg = args[2]; // e.g., node handoff.js execute LEAD-TO-PLAN <SD-ID>
 if (args[0] === 'execute' && sdIdArg) {
   try {
     const result = await claimGuard(sdIdArg, null, { autoFallback: true });
-    if (!result.success && !result.fallback) {
-      console.error(`[handoff.js] Claim check failed for ${sdIdArg}: ${result.error}`);
+    // SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001 FR-1: fallback=true means an ACTIVE (or
+    // stale-but-alive) foreign session owns the claim — that must never drive
+    // `execute` (2026-06-12: a parallel driver produced a ghost completion this way).
+    // Documented bypass (--bypass-validation, reason recorded downstream) still works.
+    const { decideExecuteClaimGate } = await import('./modules/handoff/claim-gate-decision.js');
+    const verdict = decideExecuteClaimGate(result, args.includes('--bypass-validation'));
+    if (verdict.action === 'proceed_bypassed') {
+      console.warn(`[handoff.js] ⚠️  ${verdict.label} bypassed via --bypass-validation for ${sdIdArg} (owner: ${result.owner?.session_id || 'unknown'})`);
+    } else if (verdict.action === 'exit') {
+      console.error(`[handoff.js] ❌ ${verdict.label} for ${sdIdArg}: ${result.error}`);
       if (result.owner) {
         console.error(`   Owner: ${result.owner.session_id} (${result.owner.heartbeat_age_human})`);
       }
+      console.error('   Only the claim-holding session may run handoff execute. Acquire the claim first (node scripts/sd-start.js <SD-KEY>) or have the owner finish/release.');
       process.exit(1);
     }
   } catch (e) {

--- a/scripts/modules/handoff/claim-gate-decision.js
+++ b/scripts/modules/handoff/claim-gate-decision.js
@@ -1,0 +1,40 @@
+/**
+ * SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001 — pure decision seams for the handoff claim gate.
+ *
+ * Witnessed 2026-06-12: a second session drove the full handoff pipeline interleaved
+ * with the claim holder (duplicate LEAD-TO-PLAN .. double LEAD-FINAL-APPROVAL),
+ * producing a ghost completion. Two soft seams allowed it:
+ *   1. scripts/handoff.js treated claimGuard fallback=true (ACTIVE foreign owner)
+ *      as a pass for `execute`.
+ *   2. BaseExecutor discarded assertValidClaim's return, so ownership='unclaimed'
+ *      (NULL claim or orphan auto-release) proceeded into the gate pipeline.
+ * Both decisions live here as pure functions so they are directly testable.
+ */
+
+/**
+ * Decide the pre-delegate verdict in scripts/handoff.js for `execute`.
+ * @param {{success:boolean, fallback?:boolean, error?:string, owner?:object}} guardResult result of claimGuard(..., {autoFallback:true})
+ * @param {boolean} bypassRequested --bypass-validation present (reason recorded downstream)
+ * @returns {{action:'proceed'|'proceed_bypassed'|'exit', label?:string}}
+ */
+export function decideExecuteClaimGate(guardResult, bypassRequested) {
+  if (guardResult?.success) return { action: 'proceed' };
+  if (guardResult?.fallback && bypassRequested) return { action: 'proceed_bypassed', label: 'FOREIGN_CLAIM' };
+  return { action: 'exit', label: guardResult?.fallback ? 'FOREIGN_CLAIM' : 'CLAIM_CHECK_FAILED' };
+}
+
+/**
+ * Decide whether BaseExecutor Step 1.3 must hard-fail on the assertValidClaim return.
+ * Handoffs are claim-holder-only: an unclaimed SD (NULL claim, or a claim the gate
+ * just auto-released from a stale owner) requires explicit re-claim via sd-start.
+ * @param {{ownership?:string, reason?:string, released_owner_session?:string}|null} claimCheck
+ * @param {string} sdKey
+ * @returns {{block:boolean, detail?:string}}
+ */
+export function evaluateClaimCheckForHandoff(claimCheck, sdKey) {
+  if (!claimCheck || claimCheck.ownership !== 'unclaimed') return { block: false };
+  const detail = claimCheck.released_owner_session
+    ? `claim was auto-released from stale owner ${claimCheck.released_owner_session} (reason=${claimCheck.reason}) — explicit re-claim required`
+    : 'no session holds the claim';
+  return { block: true, detail: `${detail}. Run: node scripts/sd-start.js ${sdKey}` };
+}

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -148,9 +148,10 @@ export class BaseExecutor {
         // latency to the happy path (retry fires only on failure).
         let attempt = 0;
         const maxAttempts = 2;
+        let claimCheck = null;
         while (true) {
           try {
-            await assertValidClaim(this.supabase, sdKeyForGate, {
+            claimCheck = await assertValidClaim(this.supabase, sdKeyForGate, {
               operation: `handoff_${this.handoffType}`,
               allowMainRepoForAcquisition: isOrchestrator
             });
@@ -164,6 +165,23 @@ export class BaseExecutor {
             console.warn(`[claim-validity] no_deterministic_identity on attempt ${attempt} — waiting 250ms for marker-file to settle, then retrying once.`);
             await new Promise(r => setTimeout(r, 250));
           }
+        }
+        // SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001 FR-2: assertValidClaim returns
+        // ownership='unclaimed' both for claiming_session_id=NULL and after its
+        // orphan auto-release path. Handoffs are claim-holder-only operations —
+        // an unclaimed SD must be explicitly claimed (sd-start) before any
+        // session may drive the pipeline (2026-06-12 parallel-driver incident).
+        const { evaluateClaimCheckForHandoff } = await import('../claim-gate-decision.js');
+        const noClaim = evaluateClaimCheckForHandoff(claimCheck, sdKeyForGate);
+        if (noClaim.block) {
+          console.error(`❌ NO_CLAIM: ${noClaim.detail}`);
+          try { endSpan(rootSpan, { result: 'claim_validity_gate_blocked' }); persist(traceCtx, { supabase: this.supabase }); } catch (_) { /* telemetry non-fatal */ }
+          return ResultBuilder.gateFailure('GATE_CLAIM_VALIDITY', {
+            issues: [`NO_CLAIM: handoff_${this.handoffType} attempted on unclaimed SD ${sdKeyForGate} — ${noClaim.detail}`],
+            score: 0,
+            max_score: 100,
+            warnings: [`Acquire the claim first: node scripts/sd-start.js ${sdKeyForGate}`]
+          }, `NO_CLAIM: ${sdKeyForGate} is unclaimed — handoffs require the claim-holding session`);
         }
       } catch (e) {
         if (e?.name === 'ClaimIdentityError') {

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -20,6 +20,7 @@ import {
 } from './helpers.js';
 import { getRemediation } from './remediations.js';
 import { clearState as clearAutoProceedState } from '../../auto-proceed-state.js';
+import { recorderIdentity, recorderIdentities } from '../../recording/HandoffRecorder.js';
 import { recordSdCompleted } from '../../../../../lib/learning/outcome-tracker.js';
 // SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3: completion-boundary instrumentation
 import { stampCompletion, stampExecutionContext } from '../../../../../lib/fleet/claim-stamp.cjs';
@@ -374,7 +375,7 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       validation_score: normalizedScore,
       validation_passed: !usePendingPath, // pending_acceptance hasn't validated yet
       validation_details: insertValidationDetails,
-      created_by: 'UNIFIED-HANDOFF-SYSTEM'
+      created_by: recorderIdentity()
     };
     if (insertStatus === 'accepted') {
       insertPayload.accepted_at = new Date().toISOString();
@@ -723,7 +724,7 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
         .eq('sd_id', sdId)
         .eq('handoff_type', 'LEAD-FINAL-APPROVAL')
         .eq('status', 'pending_acceptance')
-        .eq('created_by', 'UNIFIED-HANDOFF-SYSTEM');
+        .in('created_by', recorderIdentities());
       if (error) {
         console.warn(`   ⚠️  [LFA_PENDING_CLEANUP_FAILED] sd_id=${sdId} reason=${error.message}`);
       }

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -42,6 +42,21 @@ function isCompletionAction(handoffType) {
   return COMPLETION_ACTIONS.includes(handoffType.toUpperCase());
 }
 
+/**
+ * SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001 FR-4: session attribution on every recorded row.
+ * The legacy constant carried zero session identity, so a parallel pipeline driver
+ * could not be attributed after the fact (2026-06-12 incident). Lookups that
+ * previously keyed on the constant must match BOTH values (see recorderIdentities).
+ */
+export const HANDOFF_SYSTEM_TAG = 'UNIFIED-HANDOFF-SYSTEM';
+export function recorderIdentity() {
+  return process.env.CLAUDE_SESSION_ID || HANDOFF_SYSTEM_TAG;
+}
+export function recorderIdentities() {
+  const id = recorderIdentity();
+  return id === HANDOFF_SYSTEM_TAG ? [HANDOFF_SYSTEM_TAG] : [HANDOFF_SYSTEM_TAG, id];
+}
+
 export class HandoffRecorder {
   constructor(supabase, options = {}) {
     if (!supabase) {
@@ -161,7 +176,7 @@ export class HandoffRecorder {
         verifier: 'unified-handoff-system.js'
       },
       accepted_at: new Date().toISOString(),
-      created_by: 'UNIFIED-HANDOFF-SYSTEM'
+      created_by: recorderIdentity()
     };
 
     try {
@@ -187,7 +202,7 @@ export class HandoffRecorder {
           .eq('sd_id', sdUuid)
           .eq('handoff_type', 'LEAD-FINAL-APPROVAL')
           .eq('status', 'pending_acceptance')
-          .eq('created_by', 'UNIFIED-HANDOFF-SYSTEM')
+          .in('created_by', recorderIdentities())
           .limit(2);
         if (lookupError) {
           console.warn(`   [LFA-PENDING-UPSERT] lookup failed: ${lookupError.message} — falling back to INSERT`);
@@ -367,7 +382,7 @@ export class HandoffRecorder {
         message: result.message
       },
       rejection_reason: enrichedRejectionReason,
-      created_by: 'UNIFIED-HANDOFF-SYSTEM'
+      created_by: recorderIdentity()
     };
 
     // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (L5): persist per-gate verdicts on
@@ -482,7 +497,7 @@ export class HandoffRecorder {
           : {})
       },
       rejection_reason: result.message,
-      created_by: 'UNIFIED-HANDOFF-SYSTEM'
+      created_by: recorderIdentity()
     };
 
     try {
@@ -589,7 +604,7 @@ export class HandoffRecorder {
         wait_attempts: Number(result.waitMetadata?.wait_attempts) || 0,
         first_wait_at: result.waitMetadata?.first_wait_at || new Date().toISOString()
       },
-      created_by: 'UNIFIED-HANDOFF-SYSTEM'
+      created_by: recorderIdentity()
     };
 
     try {
@@ -646,7 +661,7 @@ export class HandoffRecorder {
         error: errorMessage,
         occurred_at: new Date().toISOString()
       },
-      created_by: 'UNIFIED-HANDOFF-SYSTEM'
+      created_by: recorderIdentity()
     };
 
     try {
@@ -854,7 +869,7 @@ export class HandoffRecorder {
         validation_passed: result.success !== false,
         validation_details: result.validation || {},
         metadata,
-        created_by: 'UNIFIED-HANDOFF-SYSTEM'
+        created_by: recorderIdentity()
       };
 
       // Log elements for debugging

--- a/tests/unit/handoff-claim-gate.test.js
+++ b/tests/unit/handoff-claim-gate.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests: SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001 — handoff claim gate + session attribution.
+ * Covers: foreign-claim rejected, unclaimed rejected (incl. orphan auto-release),
+ * claim-holder passes, bypass honored, created_by identity + LFA lookup coherence.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { decideExecuteClaimGate, evaluateClaimCheckForHandoff } from '../../scripts/modules/handoff/claim-gate-decision.js';
+import { recorderIdentity, recorderIdentities, HANDOFF_SYSTEM_TAG } from '../../scripts/modules/handoff/recording/HandoffRecorder.js';
+
+const ORIGINAL_SID = process.env.CLAUDE_SESSION_ID;
+afterEach(() => {
+  if (ORIGINAL_SID === undefined) delete process.env.CLAUDE_SESSION_ID;
+  else process.env.CLAUDE_SESSION_ID = ORIGINAL_SID;
+});
+
+describe('decideExecuteClaimGate (handoff.js pre-delegate seam)', () => {
+  it('claim-holder passes unchanged', () => {
+    expect(decideExecuteClaimGate({ success: true }, false)).toEqual({ action: 'proceed' });
+  });
+
+  it('foreign ACTIVE owner (fallback=true) is rejected — no longer a pass for execute', () => {
+    const v = decideExecuteClaimGate(
+      { success: false, fallback: true, error: 'claimed_by_active_session', owner: { session_id: 'peer-1' } },
+      false
+    );
+    expect(v.action).toBe('exit');
+    expect(v.label).toBe('FOREIGN_CLAIM');
+  });
+
+  it('stale-but-alive foreign owner is also FOREIGN_CLAIM', () => {
+    const v = decideExecuteClaimGate({ success: false, fallback: true, error: 'claimed_by_stale_but_alive_session' }, false);
+    expect(v).toEqual({ action: 'exit', label: 'FOREIGN_CLAIM' });
+  });
+
+  it('non-fallback failure keeps the legacy hard-fail label', () => {
+    const v = decideExecuteClaimGate({ success: false, error: 'db_error' }, false);
+    expect(v).toEqual({ action: 'exit', label: 'CLAIM_CHECK_FAILED' });
+  });
+
+  it('documented bypass flag proceeds with the bypass surfaced', () => {
+    const v = decideExecuteClaimGate({ success: false, fallback: true }, true);
+    expect(v).toEqual({ action: 'proceed_bypassed', label: 'FOREIGN_CLAIM' });
+  });
+
+  it('bypass does NOT rescue non-fallback failures', () => {
+    const v = decideExecuteClaimGate({ success: false }, true);
+    expect(v.action).toBe('exit');
+  });
+});
+
+describe('evaluateClaimCheckForHandoff (BaseExecutor Step 1.3 seam)', () => {
+  it('claim-holder (ownership=mine) passes', () => {
+    expect(evaluateClaimCheckForHandoff({ ownership: 'mine' }, 'SD-X')).toEqual({ block: false });
+  });
+
+  it('null claimCheck does not block (fail-open parity with prior behavior on missing return)', () => {
+    expect(evaluateClaimCheckForHandoff(null, 'SD-X')).toEqual({ block: false });
+  });
+
+  it('NULL claim (ownership=unclaimed) is rejected with sd-start direction', () => {
+    const v = evaluateClaimCheckForHandoff({ ownership: 'unclaimed' }, 'SD-X');
+    expect(v.block).toBe(true);
+    expect(v.detail).toContain('no session holds the claim');
+    expect(v.detail).toContain('sd-start.js SD-X');
+  });
+
+  it('orphan auto-release no longer silently proceeds — explicit re-claim required', () => {
+    const v = evaluateClaimCheckForHandoff(
+      { ownership: 'unclaimed', reason: 'stale', released_owner_session: 'dead-session-1' },
+      'SD-Y'
+    );
+    expect(v.block).toBe(true);
+    expect(v.detail).toContain('dead-session-1');
+    expect(v.detail).toContain('explicit re-claim required');
+  });
+});
+
+describe('recorder session attribution (FR-4)', () => {
+  it('created_by carries CLAUDE_SESSION_ID when set', () => {
+    process.env.CLAUDE_SESSION_ID = 'session-abc';
+    expect(recorderIdentity()).toBe('session-abc');
+  });
+
+  it('falls back to the legacy system tag when no session identity exists', () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    expect(recorderIdentity()).toBe(HANDOFF_SYSTEM_TAG);
+  });
+
+  it('LFA pending-upsert lookup matches BOTH the legacy tag and the session identity', () => {
+    process.env.CLAUDE_SESSION_ID = 'session-abc';
+    expect(recorderIdentities()).toEqual([HANDOFF_SYSTEM_TAG, 'session-abc']);
+    delete process.env.CLAUDE_SESSION_ID;
+    expect(recorderIdentities()).toEqual([HANDOFF_SYSTEM_TAG]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the unclaimed/foreign parallel-driver hole in the handoff pipeline (incident 2026-06-12: a second session ran the full pipeline interleaved with the claim holder — duplicate handoffs, double LEAD-FINAL-APPROVAL, ghost completion).

- **Seam 1 (`scripts/handoff.js`)**: `claimGuard` `fallback=true` (active or stale-but-alive foreign owner) no longer passes `execute` — hard `FOREIGN_CLAIM` error naming the owner. Documented `--bypass-validation` proceeds with the bypass surfaced (reason recorded downstream).
- **Seam 2 (`BaseExecutor` Step 1.3)**: consumes the `assertValidClaim` return; `ownership=unclaimed` (NULL claim or orphan auto-release) is rejected with `NO_CLAIM` directing to `sd-start`. Orphan auto-release no longer silently proceeds for handoffs.
- **Seam 3 (attribution)**: every `leo_handoff_executions` insert stamps `created_by = CLAUDE_SESSION_ID` (fallback: legacy `UNIFIED-HANDOFF-SYSTEM`); the LFA pending-upsert and cleanup lookups dual-match both identities so the pending→accepted flip stays coherent.

Decision logic extracted to pure `scripts/modules/handoff/claim-gate-decision.js` for direct testability.

## Testing
- `tests/unit/handoff-claim-gate.test.js` — 13/13: foreign rejected (active + stale-alive), unclaimed rejected, orphan-release rejected, holder passes, bypass honored (and not over-honored), identity stamp + dual-match lookup.
- LFA executor import smoke OK; the SD's own EXEC-TO-PLAN → LFA handoffs self-host the claim-holder path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)