### PR TITLE
hotfix(SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001): scope session stamp to leo_handoff_executions only

### DIFF
--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -382,7 +382,7 @@ export class HandoffRecorder {
         message: result.message
       },
       rejection_reason: enrichedRejectionReason,
-      created_by: recorderIdentity()
+      created_by: HANDOFF_SYSTEM_TAG // sd_phase_handoffs DB guard allowlists the system tag; session identity lives on leo_handoff_executions.created_by
     };
 
     // SD-MAN-ORCH-LEO-HARNESS-EFFICIENCY-001-B (L5): persist per-gate verdicts on
@@ -604,7 +604,7 @@ export class HandoffRecorder {
         wait_attempts: Number(result.waitMetadata?.wait_attempts) || 0,
         first_wait_at: result.waitMetadata?.first_wait_at || new Date().toISOString()
       },
-      created_by: recorderIdentity()
+      created_by: HANDOFF_SYSTEM_TAG // sd_phase_handoffs DB guard allowlists the system tag; session identity lives on leo_handoff_executions.created_by
     };
 
     try {
@@ -661,7 +661,7 @@ export class HandoffRecorder {
         error: errorMessage,
         occurred_at: new Date().toISOString()
       },
-      created_by: recorderIdentity()
+      created_by: HANDOFF_SYSTEM_TAG // sd_phase_handoffs DB guard allowlists the system tag; session identity lives on leo_handoff_executions.created_by
     };
 
     try {
@@ -869,7 +869,7 @@ export class HandoffRecorder {
         validation_passed: result.success !== false,
         validation_details: result.validation || {},
         metadata,
-        created_by: recorderIdentity()
+        created_by: HANDOFF_SYSTEM_TAG // sd_phase_handoffs DB guard allowlists the system tag; session identity lives on leo_handoff_executions.created_by
       };
 
       // Log elements for debugging


### PR DESCRIPTION
URGENT follow-up to #4668: the auto-merge fired before the scoping commit pushed, so main stamps created_by=CLAUDE_SESSION_ID on sd_phase_handoffs inserts, which the HANDOFF_BYPASS_BLOCKED DB guard rejects — EVERY phase-transition handoff recording fails for any session with CLAUDE_SESSION_ID set. This cherry-picks the scoping fix (session identity on leo_handoff_executions only; allowlisted tag on sd_phase_handoffs). Verified by self-hosting EXEC-TO-PLAN (94) and PLAN-TO-LEAD (96) on the SD branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)