### PR TITLE
feat(SD-MAN-INFRA-GATE-BAR-REGIME-001): gate-bar regime — evidence bars observe-only + S10 blocking + S3 grounding

### DIFF
--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -386,6 +386,19 @@ export async function recordGateResult(supabase, opts) {
     throw new Error(`[artifact-persistence-service] recordGateResult failed: ${error.message}`);
   }
 
+  // SD-MAN-INFRA-GATE-BAR-REGIME-001: evidence-existence bars on chairman-gate
+  // stages, OBSERVE-ONLY — evaluated and recorded after every verdict persist.
+  // A bar failure (or recording failure) never blocks the verdict write above.
+  try {
+    const { evaluateGateBars, recordGateBarObservation, CHAIRMAN_GATE_STAGES } = await import('./gate-bars.js');
+    if (CHAIRMAN_GATE_STAGES.has(Number(stageNumber))) {
+      const evaluation = await evaluateGateBars(row);
+      await recordGateBarObservation(supabase, { ventureId, gateRowId: data.id }, evaluation);
+    }
+  } catch (barErr) {
+    console.warn(`[artifact-persistence-service] gate-bar observation skipped (non-blocking): ${barErr.message}`);
+  }
+
   return data.id;
 }
 

--- a/lib/eva/gate-bars.js
+++ b/lib/eva/gate-bars.js
@@ -1,0 +1,218 @@
+/**
+ * Gate-bar regime — evidence-existence bars on chairman-gate stages.
+ * SD-MAN-INFRA-GATE-BAR-REGIME-001 (sitting #1 item 1, GO 2026-06-11T14:49Z).
+ *
+ * DataDistill's first full lifecycle proved chairman-gate stages can emit
+ * passing verdicts on empty criteria and NULL scores (70/70 with no evidence).
+ * This module evaluates every chairman-gate verdict against evidence-existence
+ * bars and RECORDS the result. OBSERVE-ONLY: bar failures are advisory and
+ * never block; flipping GATE_BARS_OBSERVE_ONLY to false is a chairman-gated
+ * reviewed change (no-auto-override doctrine, sitting #1 item 2 — automation
+ * never creates chairman_decisions rows and never converts a bar verdict into
+ * a block).
+ */
+'use strict';
+
+/** The 9 chairman-gate stages named by the sitting #1 ruling. */
+export const CHAIRMAN_GATE_STAGES = Object.freeze(new Set([3, 5, 10, 13, 17, 18, 23, 24, 25]));
+
+/**
+ * Single enforcement-mode seam. Bars stay advisory until the calibration
+ * cohort produces ground truth; the flip to binding is one reviewed,
+ * chairman-gated change at this constant.
+ */
+export const GATE_BARS_OBSERVE_ONLY = true;
+
+const URL_RE = /https?:\/\/[^\s"'<>)\]}]+/g;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+
+/** Extract candidate web-source URLs from a gate row's criteria + notes. */
+export function extractWebSources(row) {
+  const text = `${JSON.stringify(row?.gate_criteria ?? {})} ${row?.notes ?? ''}`;
+  return [...new Set(text.match(URL_RE) || [])];
+}
+
+/** Extract candidate artifact references (UUIDs) from gate_criteria values. */
+export function extractArtifactRefs(row) {
+  const text = JSON.stringify(row?.gate_criteria ?? {});
+  return [...new Set((text.match(UUID_RE) || []).map((u) => u.toLowerCase()))];
+}
+
+/**
+ * PURE: evaluate the evidence-existence bars for one eva_stage_gate_results
+ * row. IO (artifact resolution, URL liveness) is injected so unit tests run
+ * without DB or network; both checks are best-effort and fail-open to an
+ * 'unverified' status — under observe-only a bar can fail loudly but the
+ * evaluation itself must never throw on infrastructure trouble.
+ *
+ * @param {{stage_number:number, gate_type?:string, overall_score?:number|null,
+ *          passed?:boolean, gate_criteria?:object|null, notes?:string|null}} row
+ * @param {Object} [opts]
+ * @param {(ref:string)=>Promise<boolean>} [opts.resolveArtifact] - returns true when the ref exists
+ * @param {(url:string)=>Promise<boolean>} [opts.checkUrl] - returns true when the URL is live
+ * @returns {Promise<{stage_number:number, gate_type:string|null, advisory:boolean,
+ *           in_scope:boolean, all_pass:boolean, bars:Array<{bar:string, pass:boolean|null,
+ *           status:'pass'|'fail'|'unverified'|'not_applicable', detail:string}>}>}
+ */
+export async function evaluateGateBars(row, opts = {}) {
+  const stage = Number(row?.stage_number);
+  const inScope = CHAIRMAN_GATE_STAGES.has(stage);
+  const bars = [];
+
+  if (inScope) {
+    const criteria = row?.gate_criteria;
+    const criteriaPresent =
+      criteria != null && typeof criteria === 'object' && Object.keys(criteria).length > 0;
+    bars.push({
+      bar: 'criteria_present',
+      pass: criteriaPresent,
+      status: criteriaPresent ? 'pass' : 'fail',
+      detail: criteriaPresent
+        ? `${Object.keys(criteria).length} criteria key(s)`
+        : 'gate_criteria empty or missing — verdict cites no criteria',
+    });
+
+    const scorePresent = Number.isFinite(Number(row?.overall_score)) && row?.overall_score !== null;
+    bars.push({
+      bar: 'score_present',
+      pass: scorePresent,
+      status: scorePresent ? 'pass' : 'fail',
+      detail: scorePresent ? `overall_score=${row.overall_score}` : 'overall_score is NULL/non-numeric',
+    });
+
+    const refs = extractArtifactRefs(row);
+    if (refs.length === 0) {
+      bars.push({
+        bar: 'evidence_resolvable',
+        pass: false,
+        status: 'fail',
+        detail: 'no artifact references (UUIDs) found in gate_criteria',
+      });
+    } else if (typeof opts.resolveArtifact !== 'function') {
+      bars.push({
+        bar: 'evidence_resolvable',
+        pass: null,
+        status: 'unverified',
+        detail: `${refs.length} artifact ref(s) found; no resolver injected`,
+      });
+    } else {
+      let resolved = 0;
+      let errored = false;
+      for (const ref of refs) {
+        try {
+          if (await opts.resolveArtifact(ref)) resolved += 1;
+        } catch {
+          errored = true; // fail-open: infrastructure trouble is not evidence absence
+        }
+      }
+      const pass = resolved > 0;
+      bars.push({
+        bar: 'evidence_resolvable',
+        pass: errored && !pass ? null : pass,
+        status: errored && !pass ? 'unverified' : pass ? 'pass' : 'fail',
+        detail: `${resolved}/${refs.length} artifact ref(s) resolved${errored ? ' (resolver errors — unverified)' : ''}`,
+      });
+    }
+
+    // S3 kill-gate web-grounding: the market signal must cite a live web source.
+    if (stage === 3) {
+      const urls = extractWebSources(row);
+      if (urls.length === 0) {
+        bars.push({
+          bar: 's3_web_grounding',
+          pass: false,
+          status: 'fail',
+          detail: 'no web-source URL cited in S3 verdict evidence',
+        });
+      } else if (typeof opts.checkUrl !== 'function') {
+        bars.push({
+          bar: 's3_web_grounding',
+          pass: null,
+          status: 'unverified',
+          detail: `${urls.length} URL(s) cited; no liveness checker injected`,
+        });
+      } else {
+        let live = false;
+        let errored = false;
+        for (const url of urls) {
+          try {
+            if (await opts.checkUrl(url)) { live = true; break; }
+          } catch {
+            errored = true; // network failure → unverified, never a hard fail
+          }
+        }
+        bars.push({
+          bar: 's3_web_grounding',
+          pass: live ? true : errored ? null : false,
+          status: live ? 'pass' : errored ? 'unverified' : 'fail',
+          detail: live
+            ? `live web source cited (${urls.length} URL(s) checked)`
+            : errored
+              ? 'liveness check failed (network) — recorded unverified'
+              : `${urls.length} URL(s) cited but none verified live`,
+        });
+      }
+    }
+  }
+
+  return {
+    stage_number: stage,
+    gate_type: row?.gate_type ?? null,
+    advisory: GATE_BARS_OBSERVE_ONLY,
+    in_scope: inScope,
+    all_pass: inScope ? bars.every((b) => b.status === 'pass') : true,
+    bars,
+  };
+}
+
+/** change_reason marker calibration queries filter on. */
+export const GATE_BAR_OBSERVATION_REASON = 'gate_bar_observation (SD-MAN-INFRA-GATE-BAR-REGIME-001, observe-only)';
+
+/**
+ * Record a bar evaluation observe-only. Writes a governance_audit_log row
+ * (changed_by='gate-bars', change_reason=GATE_BAR_OBSERVATION_REASON,
+ * operation='INSERT' — the table's CHECK constraint allows only DML verbs) so
+ * calibration analytics can query bar verdicts without a schema change while
+ * the regime is advisory. FAIL-SOFT: recording trouble logs and returns null —
+ * observation must never break the gate persist path it rides on.
+ *
+ * Calibration note: consumers MUST filter ventures through
+ * isCalibrationEligibleVenture() (lib/eva/gate-enforcement.js) — scaffold-era
+ * ventures carry no market lessons (QF-20260611-510). Query recipe:
+ *   SELECT new_values FROM governance_audit_log
+ *   WHERE changed_by='gate-bars' AND change_reason LIKE 'gate_bar_observation%';
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ventureId:string, gateRowId?:string|null}} ctx
+ * @param {Awaited<ReturnType<typeof evaluateGateBars>>} evaluation
+ * @returns {Promise<string|null>} audit row id or null
+ */
+export async function recordGateBarObservation(supabase, ctx, evaluation) {
+  if (!evaluation?.in_scope) return null;
+  try {
+    const { data, error } = await supabase
+      .from('governance_audit_log')
+      .insert({
+        table_name: 'eva_stage_gate_results',
+        record_id: ctx?.gateRowId ?? null,
+        operation: 'INSERT',
+        changed_by: 'gate-bars',
+        change_reason: GATE_BAR_OBSERVATION_REASON,
+        new_values: {
+          venture_id: ctx?.ventureId ?? null,
+          stage_number: evaluation.stage_number,
+          gate_type: evaluation.gate_type,
+          advisory: evaluation.advisory,
+          all_pass: evaluation.all_pass,
+          bars: evaluation.bars,
+        },
+      })
+      .select('id')
+      .single();
+    if (error) throw error;
+    return data.id;
+  } catch (err) {
+    console.warn(`[gate-bars] observation record failed (non-blocking): ${err.message}`);
+    return null;
+  }
+}

--- a/scripts/one-off/fix-s10-work-type-decision-gate.mjs
+++ b/scripts/one-off/fix-s10-work-type-decision-gate.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * SD-MAN-INFRA-GATE-BAR-REGIME-001 (FR-2) — fix the S10 work_type mislabel.
+ *
+ * venture_stages stage 10 (Customer & Brand Foundation, gate_type=promotion)
+ * carries work_type='artifact_only', which stage-governance.js excludes from
+ * blockingStages — S10's chairman gate silently never blocks. Sitting #1
+ * item 1 ruled S10 must block like its peer gates. Single-row data fix,
+ * reversible: --rollback restores artifact_only.
+ *
+ * S18 and S25 carry the same artifact_only label but the ruling names S10
+ * only — they are left unchanged and documented for chairman follow-up.
+ *
+ * Usage: node scripts/one-off/fix-s10-work-type-decision-gate.mjs [--rollback]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const rollback = process.argv.includes('--rollback');
+const target = rollback ? 'artifact_only' : 'decision_gate';
+
+const db = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const { data: before, error: readErr } = await db
+  .from('venture_stages')
+  .select('stage_number, stage_name, gate_type, work_type')
+  .eq('stage_number', 10)
+  .single();
+if (readErr) { console.error('read failed:', readErr.message); process.exit(1); }
+console.log('before:', JSON.stringify(before));
+
+if (before.work_type === target) {
+  console.log(`idempotent: work_type already '${target}' — nothing to do.`);
+  process.exit(0);
+}
+
+const { data: updated, error } = await db
+  .from('venture_stages')
+  .update({ work_type: target })
+  .eq('stage_number', 10)
+  .select('stage_number, work_type');
+if (error) { console.error('update failed:', error.message); process.exit(1); }
+if (!updated || updated.length !== 1) { console.error(`expected 1 row, got ${updated?.length}`); process.exit(1); }
+console.log('after:', JSON.stringify(updated[0]));
+console.log(rollback ? 'ROLLBACK complete (artifact_only restored).' : 'FIX complete — S10 now classifies into blockingStages.');

--- a/tests/unit/eva/gate-bar-regime.test.js
+++ b/tests/unit/eva/gate-bar-regime.test.js
@@ -1,0 +1,114 @@
+// SD-MAN-INFRA-GATE-BAR-REGIME-001 — evidence-existence bars (observe-only)
+// on the 9 chairman-gate stages. Pins the DataDistill defect class: a 70/70
+// passing verdict with empty criteria and NULL score must produce failing bar
+// records WITHOUT blocking (advisory under observe-only).
+import { describe, it, expect } from 'vitest';
+import {
+  CHAIRMAN_GATE_STAGES,
+  GATE_BARS_OBSERVE_ONLY,
+  evaluateGateBars,
+  extractWebSources,
+  extractArtifactRefs,
+} from '../../../lib/eva/gate-bars.js';
+import { isCalibrationEligibleVenture } from '../../../lib/eva/gate-enforcement.js';
+
+const UUID = '9c85bf76-ced0-495f-9b68-394ca6fa0615';
+
+describe('gate-bar regime scope and mode', () => {
+  it('covers exactly the 9 sitting-ruled chairman-gate stages', () => {
+    expect([...CHAIRMAN_GATE_STAGES].sort((a, b) => a - b)).toEqual([3, 5, 10, 13, 17, 18, 23, 24, 25]);
+  });
+
+  it('ships OBSERVE-ONLY (flip is a chairman-gated reviewed change)', () => {
+    expect(GATE_BARS_OBSERVE_ONLY).toBe(true);
+  });
+
+  it('out-of-scope stages produce no bars and all_pass=true', async () => {
+    const r = await evaluateGateBars({ stage_number: 7, gate_criteria: {}, overall_score: null });
+    expect(r.in_scope).toBe(false);
+    expect(r.bars).toEqual([]);
+    expect(r.all_pass).toBe(true);
+  });
+});
+
+describe('TS-1: empty-criteria NULL-score passing verdict (the DataDistill class)', () => {
+  it('records failing criteria/score/evidence bars, advisory, never throws', async () => {
+    const r = await evaluateGateBars({
+      stage_number: 5, gate_type: 'kill', passed: true, overall_score: null, gate_criteria: {},
+    });
+    expect(r.in_scope).toBe(true);
+    expect(r.advisory).toBe(true);
+    expect(r.all_pass).toBe(false);
+    const byBar = Object.fromEntries(r.bars.map((b) => [b.bar, b.status]));
+    expect(byBar.criteria_present).toBe('fail');
+    expect(byBar.score_present).toBe('fail');
+    expect(byBar.evidence_resolvable).toBe('fail');
+  });
+
+  it('a real evidenced verdict passes all bars', async () => {
+    const r = await evaluateGateBars(
+      { stage_number: 25, gate_type: 'exit', overall_score: 100, gate_criteria: { review_artifact: UUID, t0_review: true } },
+      { resolveArtifact: async () => true },
+    );
+    expect(r.all_pass).toBe(true);
+  });
+
+  it('resolver errors degrade to unverified, not fail (fail-open)', async () => {
+    const r = await evaluateGateBars(
+      { stage_number: 13, overall_score: 80, gate_criteria: { ref: UUID } },
+      { resolveArtifact: async () => { throw new Error('db down'); } },
+    );
+    expect(r.bars.find((b) => b.bar === 'evidence_resolvable').status).toBe('unverified');
+  });
+});
+
+describe('TS-3: S3 kill-gate web-grounding', () => {
+  const base = { stage_number: 3, gate_type: 'kill', overall_score: 70 };
+
+  it('no web citation → grounding bar fails (advisory)', async () => {
+    const r = await evaluateGateBars({ ...base, gate_criteria: { signal: 'looks great' } });
+    expect(r.bars.find((b) => b.bar === 's3_web_grounding').status).toBe('fail');
+  });
+
+  it('live URL cited → grounding bar passes', async () => {
+    const r = await evaluateGateBars(
+      { ...base, gate_criteria: { source: 'https://example.com/market-report' } },
+      { checkUrl: async () => true },
+    );
+    expect(r.bars.find((b) => b.bar === 's3_web_grounding').status).toBe('pass');
+  });
+
+  it('network failure → unverified, never a hard fail', async () => {
+    const r = await evaluateGateBars(
+      { ...base, notes: 'see https://example.com/x' },
+      { checkUrl: async () => { throw new Error('ETIMEDOUT'); } },
+    );
+    expect(r.bars.find((b) => b.bar === 's3_web_grounding').status).toBe('unverified');
+  });
+
+  it('grounding bar only applies to S3', async () => {
+    const r = await evaluateGateBars({ stage_number: 24, overall_score: 90, gate_criteria: { ok: true } });
+    expect(r.bars.find((b) => b.bar === 's3_web_grounding')).toBeUndefined();
+  });
+});
+
+describe('extractors', () => {
+  it('extracts URLs from criteria and notes, deduped', () => {
+    const urls = extractWebSources({
+      gate_criteria: { a: 'https://x.test/1' },
+      notes: 'cited https://x.test/1 and https://y.test/2',
+    });
+    expect(urls).toEqual(['https://x.test/1', 'https://y.test/2']);
+  });
+
+  it('extracts UUID artifact refs from criteria, case-normalized', () => {
+    expect(extractArtifactRefs({ gate_criteria: { ref: UUID.toUpperCase() } })).toEqual([UUID]);
+  });
+});
+
+describe('TS-4: calibration exclusion (doctrine integration)', () => {
+  it('workflow_scaffold ventures stay excluded via the canonical predicate', () => {
+    expect(isCalibrationEligibleVenture({ metadata: { venture_classification: 'workflow_scaffold' } })).toBe(false);
+    expect(isCalibrationEligibleVenture({ metadata: {} })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements sitting #1 item 1 (GO 2026-06-11T14:49Z). DataDistill's calibration readout proved chairman-gate stages can emit passing verdicts on empty criteria and NULL scores (live example: S3 rows with passed=true, overall_score=null, gate_criteria={}).

- **Evidence-existence bars (observe-only)** — `lib/eva/gate-bars.js`: pure evaluator over the 9 chairman-gate stages (S3,S5,S10,S13,S17,S18,S23,S24,S25): criteria_present, score_present, evidence_resolvable (UUID refs, injected resolver), plus the **S3 web-grounding bar** (market signal must cite a live web source; injected liveness check fails open to `unverified`). Recorded via `governance_audit_log` (changed_by='gate-bars') — no schema change. `GATE_BARS_OBSERVE_ONLY=true` is the single flip seam, chairman-gated per no-auto-override doctrine.
- **Wire** — `recordGateResult` (the verdict-persist choke point) evaluates+records bars after every chairman-gate write, never blocking it.
- **S10 blocking fix** — governed single-row data fix executed: `venture_stages` stage 10 `work_type` artifact_only→decision_gate; `blockingStages` now includes 10 (verified live). S18/S25 share the label but the ruling names S10 only — documented for chairman follow-up. 29 historical failed S10 rows may surface as gate debt by design.
- **Tests** — 13 unit tests incl. the DataDistill defect class, fail-open semantics, S3 grounding, and `isCalibrationEligibleVenture` doctrine integration.

## Verification
- `npx vitest run --project unit tests/unit/eva/gate-bar-regime.test.js` → 13/13
- Live: `getStageGovernance().blockingStages` = {3,5,10,13,16,17,23,24} — S10 present
- Rollback: `--rollback` mode on the fix script; bars module is additive

LOC >100 justified in commit message (single coherent seam per PRD plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)