### PR TITLE
fix(SD-FDBK-FIX-LFA-ACCEPT-CANONICAL-001): accepted LFA persists canonically to sd_phase_handoffs

### DIFF
--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -4,15 +4,14 @@
  *
  * Manages recording of successful/failed handoffs and creates artifacts.
  *
- * IMPORTANT DISTINCTION (Root Cause Fix - SD-VENTURE-STAGE0-UI-001):
- * - Phase TRANSITIONS (LEAD-TO-PLAN, PLAN-TO-EXEC, etc.) create artifacts in sd_phase_handoffs
- *   because they transfer work from one phase to another with from_phase → to_phase
- * - COMPLETION actions (LEAD-FINAL-APPROVAL) only record in leo_handoff_executions
- *   because they don't transfer work - they complete the SD lifecycle
- *
- * The sd_phase_handoffs table has a constraint: to_phase IN ('LEAD', 'PLAN', 'EXEC')
- * LEAD-FINAL-APPROVAL would parse to to_phase='APPROVAL' which violates this constraint.
- * Instead of forcing it, we recognize that completion actions are fundamentally different.
+ * IMPORTANT DISTINCTION (revised by SD-FDBK-FIX-LFA-ACCEPT-CANONICAL-001):
+ * - Phase TRANSITIONS (LEAD-TO-PLAN, PLAN-TO-EXEC, etc.) create artifacts in sd_phase_handoffs.
+ * - COMPLETION actions (LEAD-FINAL-APPROVAL) record in leo_handoff_executions AND now also
+ *   persist an accepted sd_phase_handoffs row with to_phase coerced 'APPROVAL'->'LEAD'
+ *   (parity with recordFailure, which always wrote rejected LFA rows that way).
+ *   The original skip (SD-VENTURE-STAGE0-UI-001, citing the to_phase CHECK) made every
+ *   recorder-path completion read as a ghost in v_sd_completion_integrity, which treats
+ *   an accepted sd_phase_handoffs LFA row as the canonical completion evidence.
  */
 
 import { randomUUID } from 'crypto';
@@ -268,14 +267,28 @@ export class HandoffRecorder {
         failedGate: result.failedGate || null
       });
 
-      // Create handoff artifact ONLY for phase transitions, not completion actions
-      // Root Cause Fix (SD-VENTURE-STAGE0-UI-001):
-      // - Completion actions (LEAD-FINAL-APPROVAL) don't have a valid to_phase
-      // - sd_phase_handoffs requires to_phase IN ('LEAD', 'PLAN', 'EXEC')
-      // - Completion actions end the lifecycle, they don't transition to another phase
+      // SD-FDBK-FIX-LFA-ACCEPT-CANONICAL-001 FR-1/FR-2: completion actions now ALSO
+      // persist to sd_phase_handoffs (to_phase coerced 'APPROVAL'->'LEAD', parity with
+      // recordFailure). The prior skip (SD-VENTURE-STAGE0-UI-001) made every recorder-path
+      // completion a ghost: v_sd_completion_integrity treats sd_phase_handoffs as canonical
+      // and saw only rejected LFA rows. createArtifact THROWS on write failure (fail-loud) —
+      // an SD is never marked completed on the executions-table write alone.
       if (isCompletionAction(handoffType)) {
-        console.log(`ℹ️  ${handoffType} is a completion action - skipping sd_phase_handoffs artifact`);
-        console.log(`   (Completion recorded in leo_handoff_executions: ${executionId})`);
+        // Idempotency: a clean re-run after a prior accept must not duplicate the canonical row.
+        const { data: existingAccept } = await this.supabase
+          .from('sd_phase_handoffs')
+          .select('id')
+          .eq('sd_id', sdUuid)
+          .eq('handoff_type', handoffType)
+          .eq('status', 'accepted')
+          .limit(1)
+          .maybeSingle();
+        if (existingAccept) {
+          console.log(`ℹ️  ${handoffType} canonical row already accepted (${existingAccept.id}) — skipping duplicate insert`);
+        } else {
+          await this.createArtifact(handoffType, sdId, result, executionId);
+          console.log(`   (Completion also recorded in leo_handoff_executions: ${executionId})`);
+        }
       } else {
         await this.createArtifact(handoffType, sdId, result, executionId);
       }
@@ -722,7 +735,12 @@ export class HandoffRecorder {
         .limit(10);
 
       // Build content
-      const [fromPhase, , toPhase] = handoffType.split('-');
+      // SD-FDBK-FIX-LFA-ACCEPT-CANONICAL-001 FR-1: coerce 'APPROVAL'->'LEAD' exactly as
+      // recordFailure already does, so accepted LEAD-FINAL-APPROVAL rows satisfy the
+      // sd_phase_handoffs to_phase CHECK ('LEAD','PLAN','EXEC'). The old skip made every
+      // recorder-path completion a ghost in v_sd_completion_integrity (275/291 since 06-01).
+      const [fromPhase, , rawToPhase] = handoffType.split('-');
+      const toPhase = rawToPhase === 'APPROVAL' ? 'LEAD' : rawToPhase;
       const handoffContent = this.contentBuilder.build(handoffType, sd, result, subAgentResults);
 
       // Use normalizedScore (weighted average) if available, otherwise calculate from totalScore/maxScore

--- a/tests/unit/handoff-recorder-lfa-canonical.test.js
+++ b/tests/unit/handoff-recorder-lfa-canonical.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests: SD-FDBK-FIX-LFA-ACCEPT-CANONICAL-001 — accepted LEAD-FINAL-APPROVAL must
+ * persist to sd_phase_handoffs (to_phase coerced APPROVAL->LEAD), fail-loud, idempotent.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { HandoffRecorder } from '../../scripts/modules/handoff/recording/HandoffRecorder.js';
+
+const SD_UUID = 'sd-uuid-1';
+
+/** Minimal supabase stub recording inserts/updates per table. */
+function makeSupabaseStub({ sphInsertError = null, existingAcceptedLfa = null } = {}) {
+  const writes = { inserts: {}, updates: {} };
+  const stub = {
+    writes,
+    from(table) {
+      const q = {
+        _table: table,
+        _filters: {},
+        select() { return q; },
+        eq(col, val) { q._filters[col] = val; return q; },
+        or() { return q; },
+        in() { return q; },
+        order() { return q; },
+        limit() { return q; },
+        not() { return q; },
+        gte() { return q; },
+        insert(row) {
+          (writes.inserts[table] ||= []).push(row);
+          const error = table === 'sd_phase_handoffs' ? sphInsertError : null;
+          const resolved = { data: row, error };
+          return { select: () => Promise.resolve(resolved), then: (r) => Promise.resolve(resolved).then(r) };
+        },
+        update(patch) {
+          (writes.updates[table] ||= []).push(patch);
+          return q._thenable({ data: null, error: null });
+        },
+        delete() { return q._thenable({ data: null, error: null }); },
+        maybeSingle() {
+          if (table === 'sd_phase_handoffs' && q._filters.status === 'accepted') {
+            return Promise.resolve({ data: existingAcceptedLfa, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        single() {
+          if (table === 'strategic_directives_v2') {
+            return Promise.resolve({ data: { id: SD_UUID, sd_key: 'SD-TEST-001', title: 'T' }, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        _thenable(resolved) {
+          return { eq: () => q._thenable(resolved), then: (r) => Promise.resolve(resolved).then(r) };
+        },
+        then(resolve) {
+          // awaited query without terminal method (e.g. sub_agent_execution_results list)
+          return Promise.resolve({ data: [], error: null }).then(resolve);
+        },
+      };
+      return q;
+    },
+  };
+  return stub;
+}
+
+const stubContentBuilder = {
+  build: () => ({ executive_summary: 's', deliverables_manifest: {}, key_decisions: [], known_issues: [], resource_utilization: {}, action_items: [], completeness_report: {} }),
+  buildRejection: () => ({}),
+  logElements: () => {},
+};
+const stubValidator = { preValidateData: async () => ({ valid: true }) };
+
+function makeRecorder(supabase) {
+  return new HandoffRecorder(supabase, { contentBuilder: stubContentBuilder, validationOrchestrator: stubValidator });
+}
+
+const okResult = { passed: true, normalizedScore: 95, gateCount: 5, issues: [], warnings: [], gateResults: {} };
+
+describe('LFA accepted canonical persistence', () => {
+  let supabase;
+  beforeEach(() => { supabase = makeSupabaseStub(); });
+
+  it('recordSuccess(LEAD-FINAL-APPROVAL) writes BOTH leo_handoff_executions and sd_phase_handoffs', async () => {
+    const recorder = makeRecorder(supabase);
+    await recorder.recordSuccess('LEAD-FINAL-APPROVAL', SD_UUID, okResult);
+    expect(supabase.writes.inserts['leo_handoff_executions']?.length).toBe(1);
+    const sph = supabase.writes.inserts['sd_phase_handoffs'];
+    expect(sph?.length).toBe(1);
+    expect(sph[0].handoff_type).toBe('LEAD-FINAL-APPROVAL');
+  });
+
+  it('coerces to_phase APPROVAL->LEAD on the canonical row (parity with recordFailure)', async () => {
+    const recorder = makeRecorder(supabase);
+    await recorder.recordSuccess('LEAD-FINAL-APPROVAL', SD_UUID, okResult);
+    const row = supabase.writes.inserts['sd_phase_handoffs'][0];
+    expect(row.to_phase).toBe('LEAD');
+    expect(row.from_phase).toBe('LEAD');
+  });
+
+  it('FAIL-LOUD: throws when the sd_phase_handoffs write fails (never completed-on-executions-alone)', async () => {
+    supabase = makeSupabaseStub({ sphInsertError: { message: 'CHECK violation' } });
+    const recorder = makeRecorder(supabase);
+    await expect(recorder.recordSuccess('LEAD-FINAL-APPROVAL', SD_UUID, okResult)).rejects.toThrow();
+  });
+
+  it('idempotent: existing accepted LFA row skips a duplicate canonical insert', async () => {
+    supabase = makeSupabaseStub({ existingAcceptedLfa: { id: 'prior-accept' } });
+    const recorder = makeRecorder(supabase);
+    await recorder.recordSuccess('LEAD-FINAL-APPROVAL', SD_UUID, okResult);
+    expect(supabase.writes.inserts['sd_phase_handoffs']).toBeUndefined();
+    expect(supabase.writes.inserts['leo_handoff_executions']?.length).toBe(1);
+  });
+
+  it('phase transitions unchanged: LEAD-TO-PLAN writes sd_phase_handoffs with natural to_phase', async () => {
+    const recorder = makeRecorder(supabase);
+    await recorder.recordSuccess('LEAD-TO-PLAN', SD_UUID, okResult);
+    const row = supabase.writes.inserts['sd_phase_handoffs'][0];
+    expect(row.to_phase).toBe('PLAN');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the ghost-completion split-brain: 275/291 SDs completed since 2026-06-01 read `is_ghost_completed=true` because `recordSuccess` deliberately skipped the `sd_phase_handoffs` write for LEAD-FINAL-APPROVAL while `v_sd_completion_integrity` treats an accepted `sd_phase_handoffs` LFA row as canonical. `recordFailure` already coerced `APPROVAL→LEAD` and wrote rejected rows — so ghosts showed only their rejected attempts.

- Completion actions now route through `createArtifact` with the same `APPROVAL→LEAD` coercion (CHECK-safe, parity with the reject path).
- **Fail-loud**: `createArtifact` throws on write failure — an SD is never marked completed on the executions write alone.
- **Idempotent**: an existing accepted LFA row skips the duplicate insert (clean re-runs).
- `leo_handoff_executions` write, LFA pending-upsert flip, and progress-trigger UNION path untouched.

## Testing
- `tests/unit/handoff-recorder-lfa-canonical.test.js` — 5/5 (both-tables write, coercion, fail-loud, idempotency, transitions unchanged).
- Adjacent suites green: recorder-rejection-enrichment + pending-upsert (20), handoff-claim-gate + gate-verdict-cache (30).
- Live proof: this SD's own LEAD-FINAL-APPROVAL (run post-merge) should read non-ghost without reconciliation — 4 SDs today needed manual ADMIN_OVERRIDE reconciliation under the old behavior.

Historical backfill of the ~275 existing ghosts is intentionally out of scope (separate governed data pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)