### PR TITLE
feat(SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001): atomic QF claim on every routing surface

### DIFF
--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -90,6 +90,12 @@ This validates:
 
 If qualified for quick-fix:
 
+0. **CLAIM FIRST (atomic — never skip):**
+   ```bash
+   node scripts/qf-start.js QF-YYYYMMDD-NNN
+   ```
+   This takes the atomic claim via the QF-aware `claim_sd` RPC (sets `quick_fixes.claiming_session_id` + `status=in_progress` + your session's `sd_key`). If it exits non-zero the QF is held by a live peer — pick a different one; never duplicate in-flight work (SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001: two unclaimed workers produced duplicate fixes for QF-20260611-123).
+
 1. **Read details:**
    ```bash
    node scripts/read-quick-fix.js QF-YYYYMMDD-NNN

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -749,7 +749,7 @@ export class SDNextSelector {
       const sdUUIDs = filteredSDs.map(sd => sd.id);
       const { data: krAlignments } = await this.supabase
         .from('sd_key_result_alignment')
-        .select('sd_id, key_result_id, contribution_type, contribution_weight, key_results!inner(id, status, code, title)')
+        .select('sd_id, key_result_id, contribution_type, contribution_weight, key_results!inner(id, status, code, title)') // schema-lint-disable-line — embedded key_results!inner columns mis-attributed to sd_key_result_alignment by the lint parser; pre-existing query, table+embed verified live (SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001)
         .in('sd_id', sdUUIDs);
 
       if (krAlignments && krAlignments.length > 0) {

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -231,7 +231,10 @@ export class SDNextSelector {
       this.displayHarnessBacklog();
       displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
       if (qfSummaryNoBaseline?.topStartableQF) {
-        return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available` };
+        // SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001: qf_start consumers MUST take the
+        // atomic claim before working — claim_cmd is the contract (two unclaimed
+        // workers duplicated QF-20260611-123 on 2026-06-12).
+        return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, claim_cmd: `node scripts/qf-start.js ${qfSummaryNoBaseline.topStartableQF.id}`, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available — CLAIM FIRST via claim_cmd` };
       }
       return { action: 'none', sd_id: null, reason: 'No active baseline found' };
     }
@@ -251,7 +254,7 @@ export class SDNextSelector {
       this.displayHarnessBacklog();
       displayWorktreeIsolationReminder(this.activeSessions, this.currentSession);
       if (qfSummaryExhausted?.topStartableQF) {
-        return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available` };
+        return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, claim_cmd: `node scripts/qf-start.js ${qfSummaryExhausted.topStartableQF.id}`, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available — CLAIM FIRST via claim_cmd` };
       }
       return { action: 'none', sd_id: null, reason: 'Baseline exhausted - all items completed' };
     }

--- a/scripts/qf-start.js
+++ b/scripts/qf-start.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * QF Start — atomically claim a quick-fix and begin work.
+ * SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001
+ *
+ * The QF counterpart of sd-start.js. Routes through the existing QF-aware
+ * claim_sd RPC (advisory xact lock; sets quick_fixes.claiming_session_id +
+ * status=in_progress + claude_sessions.sd_key=<QF-ID> in one transaction), so:
+ *   - two sessions can never be routed to the same QF (the 2026-06-12
+ *     QF-20260611-123 duplicate-fix incident class), and
+ *   - a QF-holding worker is visible as BUSY to fleet-dashboard /
+ *     capacity-forecast / the sweep (their idle test is claude_sessions.sd_key).
+ *
+ * Usage: CLAUDE_SESSION_ID=<id> node scripts/qf-start.js <QF-ID>
+ * Exit codes: 0 claimed; 2 usage; 3 claim refused (holder info printed); 1 error.
+ */
+
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { spawnSync } from 'node:child_process';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * Drain undici's keep-alive socket pool before process.exit — without this,
+ * Windows libuv asserts (src\win\async.c:76) when exit races socket teardown
+ * and the process dies 127 instead of the intended code (QF-20260510-170 class).
+ */
+async function safeExit(code) {
+  try {
+    const undici = await import('undici');
+    const d = undici.getGlobalDispatcher?.();
+    if (d?.destroy) await Promise.race([d.destroy(), new Promise((r) => setTimeout(r, 200))]).catch(() => {});
+  } catch { /* no pool to drain */ }
+  process.exit(code);
+}
+
+async function main() {
+  const qfId = process.argv.slice(2).find((a) => !a.startsWith('--'));
+  if (!qfId || !/^QF-/i.test(qfId)) {
+    console.error('Usage: node scripts/qf-start.js <QF-ID>   (id must start with QF-)');
+    process.exit(2);
+  }
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) {
+    console.error('CLAUDE_SESSION_ID env var required (set by the SessionStart hook).');
+    process.exit(2);
+  }
+
+  const supabase = createSupabaseServiceClient();
+  const { data, error } = await supabase.rpc('claim_sd', {
+    p_sd_id: qfId,
+    p_session_id: sessionId,
+    p_track: null,
+  });
+  if (error) {
+    console.error(`claim_sd failed: ${error.message}`);
+    await safeExit(1);
+  }
+  if (!data?.success) {
+    console.error(`✗ Quick-fix ${qfId} NOT claimed: ${data?.error || 'unknown'}`);
+    if (data?.claimed_by) {
+      console.error(`  Held by session ${data.claimed_by}` +
+        (data.heartbeat_age_seconds != null ? ` (heartbeat ${data.heartbeat_age_seconds}s ago)` : ''));
+      console.error('  Pick a different QF — never duplicate in-flight work.');
+    }
+    if (data?.message) console.error(`  ${data.message}`);
+    await safeExit(3);
+  }
+
+  console.log(`✓ Quick-fix ${qfId} claimed (session ${sessionId})`);
+  console.log(`  Branch convention: qf/${qfId}`);
+  console.log(`  Complete with: node scripts/complete-quick-fix.js ${qfId} --pr-url <url>`);
+  console.log('');
+
+  // Delegate the details display to the existing canonical reader.
+  const out = spawnSync(process.execPath, ['scripts/read-quick-fix.js', qfId], {
+    encoding: 'utf8',
+    stdio: 'inherit',
+  });
+  await safeExit(0); // claim succeeded; display failure is non-fatal
+}
+
+main().catch(async (e) => { console.error(e?.message || e); await safeExit(1); });

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -709,6 +709,18 @@ async function main() {
     process.exit(1);
   }
 
+  // SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001: QF ids are not SDs — route them
+  // to the atomic QF claim path instead of querying strategic_directives_v2 and
+  // crashing with 'Cannot coerce the result to a single JSON object'
+  // (witnessed 2026-06-12 on QF-20260611-123).
+  if (/^QF-/i.test(sdId)) {
+    console.log(`${colors.yellow}${sdId} is a quick-fix, not an SD.${colors.reset}`);
+    console.log(`Routing to the atomic QF claim: ${colors.cyan}node scripts/qf-start.js ${sdId}${colors.reset}\n`);
+    const { spawnSync } = await import('node:child_process');
+    const out = spawnSync(process.execPath, ['scripts/qf-start.js', sdId], { stdio: 'inherit' });
+    process.exit(out.status ?? 1);
+  }
+
   // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR5 enhancement B):
   // Fail fast if this command is running from inside the .worktrees/ subtree.
   // Otherwise `git rev-parse --show-toplevel` (historically used downstream)

--- a/tests/unit/qf-claim-routing.test.js
+++ b/tests/unit/qf-claim-routing.test.js
@@ -1,0 +1,75 @@
+/**
+ * SD-FDBK-INFRA-CLAIM-VISIBILITY-ATOMIC-001 — QF claim/routing pins.
+ * Pure unit: source-level contracts + the startability predicate
+ * (live-peer-held exclusion lives in classifyQuickFixes — pinned here against
+ * regression since it is the consumer-side half of the atomic claim).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { classifyQuickFixes } from '../../scripts/modules/sd-next/display/quick-fixes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = (rel) => fs.readFileSync(path.resolve(__dirname, '../..', rel), 'utf8');
+
+describe('qf_start action contract (SDNextSelector)', () => {
+  it('every qf_start action carries claim_cmd pointing at qf-start.js', () => {
+    const src = read('scripts/modules/sd-next/SDNextSelector.js');
+    const qfStartReturns = src.match(/action: 'qf_start'[^}]+/g) || [];
+    expect(qfStartReturns.length).toBeGreaterThan(0);
+    for (const r of qfStartReturns) {
+      expect(r).toContain('claim_cmd');
+      expect(r).toContain('scripts/qf-start.js');
+    }
+  });
+});
+
+describe('sd-start.js QF-id routing (crash fix)', () => {
+  it('detects ^QF- ids before any strategic_directives_v2 query and delegates to qf-start.js', () => {
+    const src = read('scripts/sd-start.js');
+    const routeIdx = src.indexOf('/^QF-/i.test(sdId)');
+    expect(routeIdx).toBeGreaterThan(-1);
+    expect(src.slice(routeIdx, routeIdx + 600)).toContain('scripts/qf-start.js');
+  });
+});
+
+describe('qf-start.js claim CLI', () => {
+  it('claims via the canonical claim_sd RPC and surfaces holder info on refusal', () => {
+    const src = read('scripts/qf-start.js');
+    expect(src).toContain("rpc('claim_sd'");
+    expect(src).toContain('claimed_by');
+    expect(src).toContain('process.exit(3)');
+  });
+});
+
+describe('live-peer-held QFs are excluded from topStartableQF (consumer half)', () => {
+  const baseQf = {
+    id: 'QF-20260612-TEST', title: 'x', type: 'bug', severity: 'high',
+    status: 'open', created_at: new Date().toISOString(),
+  };
+  const me = { session_id: 'me' };
+
+  it('a QF held by a LIVE peer is not startable', () => {
+    const { summary } = classifyQuickFixes(
+      [{ ...baseQf, claiming_session_id: 'peer' }],
+      new Map(),
+      { currentSession: me, activeSessions: [{ session_id: 'peer', heartbeat_age_seconds: 30 }] },
+    );
+    expect(summary.topStartableQF).toBeNull();
+  });
+
+  it('a QF held by a STALE (>=900s) peer remains startable (claim_sd takeover handles the race)', () => {
+    const { summary } = classifyQuickFixes(
+      [{ ...baseQf, claiming_session_id: 'peer' }],
+      new Map(),
+      { currentSession: me, activeSessions: [{ session_id: 'peer', heartbeat_age_seconds: 5000 }] },
+    );
+    expect(summary.topStartableQF?.id).toBe(baseQf.id);
+  });
+
+  it('an unclaimed fresh open QF is startable', () => {
+    const { summary } = classifyQuickFixes([{ ...baseQf }], new Map(), { currentSession: me, activeSessions: [] });
+    expect(summary.topStartableQF?.id).toBe(baseQf.id);
+  });
+});

--- a/tests/unit/qf-claim-routing.test.js
+++ b/tests/unit/qf-claim-routing.test.js
@@ -39,7 +39,7 @@ describe('qf-start.js claim CLI', () => {
     const src = read('scripts/qf-start.js');
     expect(src).toContain("rpc('claim_sd'");
     expect(src).toContain('claimed_by');
-    expect(src).toContain('process.exit(3)');
+    expect(src).toContain('safeExit(3)');
   });
 });
 


### PR DESCRIPTION
## Summary
Two unclaimed workers duplicated **QF-20260611-123** on 2026-06-12, and QF-working sessions read *idle-no-claim* on the fleet dashboard. Verified at LEAD: `claim_sd` is already fully QF-aware (locks quick_fixes, sets `claiming_session_id` + `in_progress` + `claude_sessions.sd_key` atomically) and the sd:next selector already excludes live-peer-held QFs — the defect was routing surfaces that never **took** the claim, so there was nothing to exclude and nothing for idle-detection to see.

- **NEW `scripts/qf-start.js`** — atomic claim via `claim_sd` + QF details; on refusal prints holder + heartbeat age and exits 3 (autonomous loops fall through to the next candidate). Undici-drain `safeExit` prevents the Windows libuv async.c assert from corrupting exit codes.
- **`scripts/sd-start.js`** — `^QF-` ids route to qf-start instead of crashing (`Cannot coerce the result to a single JSON object`).
- **`SDNextSelector`** — both `qf_start` actions now carry `claim_cmd` and a CLAIM FIRST reason.
- **`/quick-fix` skill** — step 0: claim before implementing.
- **6 contract pins** (`tests/unit/qf-claim-routing.test.js`) incl. live-peer-held exclusion + stale-holder adoptability.

## Verification
- Live race: probe A claims (claiming_session_id set, in_progress); probe B refused with `already_claimed` + holder + heartbeat, exit 3
- `sd-start QF-…` routes cleanly with guidance (no crash)
- 6/6 new tests green; no schema/RPC changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)