### PR TITLE
fix(SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001): pattern-alert closed-loop suppression (cancel-aware, incident-aware, storm-capped)

### DIFF
--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -98,14 +98,20 @@ async function cancelSD(sd, reason) {
   // SD-LEO-INFRA-CLOSE-ISSUE-PATTERN-001 (FR-2): report the closure-loop reset that the
   // trg_reset_patterns_on_sd_cancel trigger performs on this cancel. Read-only count;
   // the trigger does the actual issue_patterns reset (assigned -> active).
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (b): capture the linked pattern ROWS
+  // BEFORE the cancel — trg_reset_patterns_on_sd_cancel nulls assigned_sd_id
+  // during the cancel UPDATE, so a post-cancel lookup by assigned_sd_id finds
+  // nothing and the suppression would silently no-op.
   let assignedPatternCount = 0;
+  let linkedPatterns = [];
   try {
-    const { count } = await supabase
+    const { data: linkedRows } = await supabase
       .from('issue_patterns')
-      .select('id', { count: 'exact', head: true })
+      .select('id, pattern_id, metadata')
       .eq('status', 'assigned')
       .in('assigned_sd_id', [sd.id, sd.sd_key].filter(Boolean));
-    assignedPatternCount = count || 0;
+    linkedPatterns = linkedRows || [];
+    assignedPatternCount = linkedPatterns.length;
   } catch { /* non-fatal: reporting only */ }
 
   const updates = {
@@ -153,6 +159,48 @@ async function cancelSD(sd, reason) {
   // SD-LEO-INFRA-CLOSE-ISSUE-PATTERN-001 (FR-2): surface the closure-loop reset.
   if (assignedPatternCount > 0) {
     console.log(`✓ closure-loop: ${assignedPatternCount} assigned issue_pattern(s) reset to active by trg_reset_patterns_on_sd_cancel`);
+  }
+
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (a/b): cancel-sd ALWAYS records a reason
+  // (this CLI requires one) — that reason IS the evidence-cancelled marker. The
+  // trigger's assigned->active reset RE-ARMS the alert creator (cancel -> active ->
+  // threshold -> re-file: two PAT-FIX storms on 2026-06-12). Override the reset:
+  // resolve linked pattern(s) with an auditable disposition so the family never
+  // re-files. Genuinely NEW post-cancel occurrences still re-escalate via the
+  // creator's recency check against the disposition timestamp.
+  if (assignedPatternCount > 0) {
+    try {
+      // Use the PRE-cancel snapshot (linkedPatterns): the trigger already
+      // nulled assigned_sd_id, so re-querying by it would return nothing.
+      const linked = linkedPatterns;
+      let suppressed = 0;
+      for (const p of linked || []) {
+        // Re-read metadata by id (id survives the trigger reset) so the
+        // trigger's last_cancelled_assignment breadcrumb is preserved.
+        const { data: freshRow } = await supabase
+          .from('issue_patterns').select('metadata').eq('id', p.id).single();
+        const { error: supErr } = await supabase
+          .from('issue_patterns')
+          .update({
+            status: 'resolved',
+            metadata: {
+              ...((freshRow || p).metadata || {}),
+              disposition: {
+                kind: 'evidence_cancelled_suppressed',
+                cancelled_sd: sd.sd_key,
+                cancellation_reason: String(reason).slice(0, 500),
+                stamped_at: new Date().toISOString(),
+                stamped_by: 'cancel-sd.js (SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001)'
+              }
+            }
+          })
+          .eq('id', p.id);
+        if (!supErr) suppressed++;
+      }
+      console.log(`✓ closure-loop: ${suppressed} linked pattern(s) resolved with evidence_cancelled_suppressed disposition (no re-file)`);
+    } catch (e) {
+      console.warn(`⚠️  pattern suppression failed (non-fatal — reconcile sweep is the backstop): ${e.message}`);
+    }
   }
 
   // Release the holder's claude_sessions row, if any.

--- a/scripts/modules/learning/filter.mjs
+++ b/scripts/modules/learning/filter.mjs
@@ -47,6 +47,11 @@ export const REJECT_REASONS = Object.freeze({
   HANDOFF_FAILURE_NEEDS_MULTI_SD: 'HANDOFF_FAILURE_NEEDS_MULTI_SD',
   EMPTY_PROVEN_LOW_OCCURRENCE: 'EMPTY_PROVEN_LOW_OCCURRENCE',
   FINGERPRINT_STEM_DUP: 'FINGERPRINT_STEM_DUP',
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (b): an assigned SD cancelled WITH a
+  // cancellation_reason is an evidence-backed human "no" — drop the pattern
+  // instead of passing it back to the creator (the old cancelled-passthrough
+  // re-armed the refile loop).
+  EVIDENCE_CANCELLED_ASSIGNED_SD: 'EVIDENCE_CANCELLED_ASSIGNED_SD',
 });
 
 const REASON_SEVERITY = {
@@ -60,6 +65,7 @@ const REASON_SEVERITY = {
   [REJECT_REASONS.HANDOFF_FAILURE_NEEDS_MULTI_SD]: 'INFO',
   [REJECT_REASONS.EMPTY_PROVEN_LOW_OCCURRENCE]: 'INFO',
   [REJECT_REASONS.FINGERPRINT_STEM_DUP]: 'INFO',
+  [REJECT_REASONS.EVIDENCE_CANCELLED_ASSIGNED_SD]: 'INFO',
 };
 
 function checkSource(pattern, allowSources) {
@@ -85,6 +91,11 @@ function checkAssignedSd(pattern, sdStatusMap, blockStatuses) {
   if (!sdId) return null;
   const status = sdStatusMap.get(sdId);
   if (status === undefined) return REJECT_REASONS.ALREADY_ASSIGNED_OPEN_SD;
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (b): 'cancelled_with_evidence' is the
+  // sentinel fetchAssignedSdStatuses emits for a cancel that carries a recorded
+  // cancellation_reason — a human said no with evidence; suppress the pattern.
+  // Bare 'cancelled' keeps the legacy passthrough (requeue allowed).
+  if (status === 'cancelled_with_evidence') return REJECT_REASONS.EVIDENCE_CANCELLED_ASSIGNED_SD;
   if (status === 'cancelled') return null;
   if (blockStatuses.has(status)) return REJECT_REASONS.ALREADY_ASSIGNED_OPEN_SD;
   return null;
@@ -409,17 +420,27 @@ export async function fetchAssignedSdStatuses(supabase, patterns) {
 
   if (ids.length === 0) return new Map();
 
-  const { data, error } = await supabase
-    .from('strategic_directives_v2')
-    .select('id, status')
-    .in('id', ids);
-
-  if (error) {
-    throw new Error(`fetchAssignedSdStatuses failed: ${error.message}`);
+  // Batched .in() — same oversized-URL guard as fetchPatternSourceSDStatuses.
+  const data = [];
+  for (let i = 0; i < ids.length; i += 100) {
+    const { data: page, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, status, cancellation_reason')
+      .in('id', ids.slice(i, i + 100));
+    if (error) {
+      throw new Error(`fetchAssignedSdStatuses failed: ${error.message}`);
+    }
+    data.push(...(page || []));
   }
 
   const map = new Map();
-  for (const row of data || []) map.set(row.id, row.status);
+  for (const row of data || []) {
+    // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (b): cancelled WITH a recorded reason is
+    // an evidence-cancel — encode as a distinct sentinel so checkAssignedSd can
+    // suppress instead of requeue. Plain cancels keep the legacy 'cancelled' value.
+    const evidenceCancelled = row.status === 'cancelled' && row.cancellation_reason && String(row.cancellation_reason).trim().length > 0;
+    map.set(row.id, evidenceCancelled ? 'cancelled_with_evidence' : row.status);
+  }
   return map;
 }
 
@@ -446,17 +467,22 @@ export async function fetchPatternSourceSDStatuses(supabase, patterns) {
 
   if (ids.size === 0) return new Map();
 
-  const { data, error } = await supabase
-    .from('strategic_directives_v2')
-    .select('id, status')
-    .in('id', [...ids]);
-
-  if (error) {
-    throw new Error(`fetchPatternSourceSDStatuses failed: ${error.message}`);
-  }
-
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001: batch the .in() — 400+ source ids
+  // build a ~15KB GET URL and the fetch fails outright. Under the old fail-open
+  // posture that meant the noise filter NEVER ran on real pattern volumes
+  // (silent contributor to the PAT-FIX storms).
   const map = new Map();
-  for (const row of data || []) map.set(row.id, row.status);
+  const all = [...ids];
+  for (let i = 0; i < all.length; i += 100) {
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, status')
+      .in('id', all.slice(i, i + 100));
+    if (error) {
+      throw new Error(`fetchPatternSourceSDStatuses failed: ${error.message}`);
+    }
+    for (const row of data || []) map.set(row.id, row.status);
+  }
   return map;
 }
 

--- a/scripts/pattern-alert-sd-creator.js
+++ b/scripts/pattern-alert-sd-creator.js
@@ -197,30 +197,62 @@ async function getAlertablePatterns() {
       console.log(`  Noise filter: ${result.rejected.length} pattern(s) suppressed before threshold check`);
     }
   } catch (filterErr) {
-    // Fail-open: a filter error must not block legitimate alerting; matches
-    // the context-builder.js fail-open posture at line 469.
-    console.warn(`[noise-filter] skipped due to error: ${filterErr.message}`);
+    // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (5): FAIL-CLOSED. The fail-open posture
+    // meant a single filter error filed EVERYTHING (one input to the 2026-06-12
+    // 13-SD storm). An auto-SD-creating path must skip a cycle, not file unfiltered.
+    console.error(`[noise-filter] FAIL-CLOSED: filter error — skipping this alert cycle: ${filterErr.message}`);
+    return [];
   }
 
   // Filter patterns that meet threshold criteria
   return surviving.filter(p => {
+    // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (d): incident-window discount.
+    // Occurrence growth attributable to a flagged incident (e.g. one SD's
+    // parallel-driver reconcile churn) is recorded on the pattern as
+    // metadata.incident_discount (count) and must not push the pattern over
+    // CRITICAL/HIGH/INCREASING thresholds.
+    const effectiveCount = effectiveOccurrences(p);
+    if (effectiveCount !== p.occurrence_count) {
+      console.log(`  [incident-discount] ${p.pattern_id}: ${p.occurrence_count} raw -> ${effectiveCount} effective`);
+    }
+
     // Critical severity with 5+ occurrences
-    if (p.severity === 'critical' && p.occurrence_count >= CONFIG.CRITICAL_SEVERITY_THRESHOLD) {
+    if (p.severity === 'critical' && effectiveCount >= CONFIG.CRITICAL_SEVERITY_THRESHOLD) {
       return true;
     }
 
     // High severity with 7+ occurrences
-    if (p.severity === 'high' && p.occurrence_count >= CONFIG.HIGH_SEVERITY_THRESHOLD) {
+    if (p.severity === 'high' && effectiveCount >= CONFIG.HIGH_SEVERITY_THRESHOLD) {
       return true;
     }
 
     // Increasing trend with 4+ occurrences (regardless of severity)
-    if (p.trend === 'increasing' && p.occurrence_count >= CONFIG.INCREASING_TREND_THRESHOLD) {
+    if (p.trend === 'increasing' && effectiveCount >= CONFIG.INCREASING_TREND_THRESHOLD) {
       return true;
     }
 
     return false;
   });
+}
+
+/**
+ * SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (c): per-run storm cap. The 2026-06-12
+ * storm filed 13 SDs in one 2-second burst. Cap auto-filing (default 3); the
+ * remainder becomes a logged drop-list + loud signal so a genuine multi-class
+ * outbreak gets human triage, not blanket-filed SDs. Pure — exported for tests.
+ */
+export function stormCapLimit(envValue) {
+  const n = parseInt(envValue || '3', 10);
+  return Number.isFinite(n) && n > 0 ? n : 3;
+}
+
+/**
+ * SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (d): effective occurrence count after the
+ * incident-window discount (metadata.incident_discount). Pure — exported for tests.
+ */
+export function effectiveOccurrences(pattern) {
+  const discount = Number(pattern?.metadata?.incident_discount || 0);
+  return Math.max(0, (pattern?.occurrence_count || 0) - (Number.isFinite(discount) ? discount : 0));
 }
 
 /**
@@ -398,6 +430,19 @@ export async function createSDForPattern(pattern) {
     return { error };
   }
 
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (a): stamp the closure-loop linkage at
+  // creation time. Without assigned_sd_id + status='assigned', the cancel-side
+  // machinery (trg_reset_patterns_on_sd_cancel, reconcile sweep, checkAssignedSd)
+  // has zero rows to act on and the pattern re-files forever.
+  try {
+    const { error: linkErr } = await supabase
+      .from('issue_patterns')
+      .update({ assigned_sd_id: data.id, status: 'assigned', assignment_date: new Date().toISOString() })
+      .eq('pattern_id', pattern.pattern_id);
+    if (linkErr) console.warn(`  ⚠️  linkage stamp failed for ${pattern.pattern_id}: ${linkErr.message}`);
+    else console.log(`  ✓ pattern ${pattern.pattern_id} linked (assigned_sd_id=${data.id})`);
+  } catch (e) { console.warn(`  ⚠️  linkage stamp failed: ${e.message}`); }
+
   console.log(`  Created SD: ${data.sd_key}`);
   return { success: true, sd: data };
 }
@@ -427,10 +472,17 @@ export async function checkPatternsAndCreateSDs() {
   const stats = {
     created: 0,
     skipped: 0,
-    errors: 0
+    errors: 0,
+    dropped: []
   };
 
+  const MAX_SDS_PER_RUN = stormCapLimit(process.env.PATTERN_ALERT_MAX_SDS_PER_RUN);
+
   for (const pattern of patterns) {
+    if (stats.created >= MAX_SDS_PER_RUN) {
+      stats.dropped.push(pattern.pattern_id);
+      continue;
+    }
     console.log(`\n${pattern.pattern_id} (${pattern.category}/${pattern.severity})`);
     console.log(`   Occurrences: ${pattern.occurrence_count}, Trend: ${pattern.trend}`);
     console.log(`   "${pattern.issue_summary.substring(0, 50)}..."`);
@@ -444,6 +496,23 @@ export async function checkPatternsAndCreateSDs() {
     } else if (result.error) {
       stats.errors++;
     }
+  }
+
+  if (stats.dropped.length > 0) {
+    console.error(`\n🚨 STORM CAP HIT: ${stats.created} SD(s) filed (cap ${MAX_SDS_PER_RUN}); ${stats.dropped.length} alertable pattern(s) DROPPED this run: ${stats.dropped.join(', ')}`);
+    // Durable loud signal: a feedback row the coordinator/inbox surfaces.
+    try {
+      await supabase.from('feedback').insert({
+        type: 'issue',
+        category: 'harness_backlog',
+        priority: 'P1',
+        status: 'new',
+        title: `pattern-alert storm cap hit: ${stats.dropped.length} pattern(s) dropped`,
+        description: `checkPatternsAndCreateSDs filed ${stats.created}/${MAX_SDS_PER_RUN} SDs and dropped ${stats.dropped.length} alertable patterns this run (SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 storm cap). Dropped pattern ids: ${stats.dropped.join(', ')}. Triage whether this is a genuine multi-class outbreak or threshold churn.`,
+        source_type: 'pattern-alert-sd-creator',
+        metadata: { dropped_pattern_ids: stats.dropped, cap: MAX_SDS_PER_RUN, created: stats.created }
+      });
+    } catch (e) { console.warn(`  ⚠️  storm-cap signal write failed: ${e.message}`); }
   }
 
   // Summary

--- a/scripts/reconcile-cancelled-sd-patterns.mjs
+++ b/scripts/reconcile-cancelled-sd-patterns.mjs
@@ -53,19 +53,27 @@ async function loadCancelledSdKeysAndIds() {
   // Paginate cancelled SDs; build a set of BOTH their id (uuid) and sd_key so we
   // can match assigned_sd_id stored in either form.
   const set = new Set();
+  // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (b): evidence map — cancelled SDs with a
+  // recorded cancellation_reason are evidence-cancels; their patterns get RESOLVED
+  // (suppressed) instead of reset to active (the reset re-armed the alert creator).
+  const evidence = new Map();
   const pageSize = 1000;
   for (let start = 0; start < 50000; start += pageSize) {
     const { data, error } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key')
+      .select('id, sd_key, cancellation_reason')
       .eq('status', 'cancelled')
       .range(start, start + pageSize - 1);
     if (error) throw new Error(`cancelled SD query failed: ${error.message}`);
     if (!data || data.length === 0) break;
-    for (const r of data) { if (r.id) set.add(r.id); if (r.sd_key) set.add(r.sd_key); }
+    for (const r of data) {
+      const hasReason = !!(r.cancellation_reason && String(r.cancellation_reason).trim().length > 0);
+      if (r.id) { set.add(r.id); evidence.set(r.id, hasReason); }
+      if (r.sd_key) { set.add(r.sd_key); evidence.set(r.sd_key, hasReason); }
+    }
     if (data.length < pageSize) break;
   }
-  return set;
+  return { set, evidence };
 }
 
 async function loadAssignedPatterns() {
@@ -87,7 +95,7 @@ async function loadAssignedPatterns() {
 
 async function main() {
   console.log(`mode=${EXECUTE ? 'EXECUTE' : 'DRY-RUN'}`);
-  const cancelled = await loadCancelledSdKeysAndIds();
+  const { set: cancelled, evidence } = await loadCancelledSdKeysAndIds();
   const assigned = await loadAssignedPatterns();
   console.log(`cancelled SDs (id+sd_key tokens): ${cancelled.size} | status='assigned' patterns: ${assigned.length}`);
 
@@ -107,16 +115,27 @@ async function main() {
   }
 
   for (const p of danglers) {
+    // SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 (b): resolve-or-suppress vs requeue.
+    // Evidence-cancel (SD has a recorded cancellation_reason) -> status='resolved'
+    // with disposition so the alert creator never re-files. Plain cancel -> legacy
+    // reset to active (legitimate requeue).
+    const isEvidence = evidence.get(p.assigned_sd_id) === true;
     const prior = { sd_key: p.assigned_sd_id, prior_assignment_date: p.assignment_date || null, reset_at: new Date().toISOString() };
-    const metadata = { ...(p.metadata || {}), last_cancelled_assignment: prior };
+    const metadata = isEvidence
+      ? { ...(p.metadata || {}), last_cancelled_assignment: prior, disposition: { kind: 'evidence_cancelled_suppressed', cancelled_sd: p.assigned_sd_id, stamped_at: prior.reset_at, stamped_by: 'reconcile-cancelled-sd-patterns.mjs' } }
+      : { ...(p.metadata || {}), last_cancelled_assignment: prior };
+    const patch = isEvidence
+      ? { status: 'resolved', metadata }
+      : { status: 'active', assigned_sd_id: null, assignment_date: null, metadata };
     try {
       const { error } = await supabase
         .from('issue_patterns')
-        .update({ status: 'active', assigned_sd_id: null, assignment_date: null, metadata })
+        .update(patch)
         .eq('id', p.id)
         .eq('status', 'assigned'); // idempotency guard: only flip rows still assigned
       if (error) { console.log(`  ✗ ${p.pattern_id || p.id}: ${error.message}`); tally.failed++; continue; }
       tally.reset++;
+      if (isEvidence) console.log(`  ✓ ${p.pattern_id || p.id}: resolved (evidence-cancelled, suppressed)`);
     } catch (e) {
       console.log(`  ✗ ${p.pattern_id || p.id}: ${e?.message || e}`);
       tally.failed++;

--- a/tests/unit/pattern-alert-closed-loop.test.js
+++ b/tests/unit/pattern-alert-closed-loop.test.js
@@ -1,0 +1,77 @@
+// SD-FDBK-FIX-PATTERN-ALERT-CREATOR-001 — closed-loop suppression regression.
+// Pins the cancel->no-refile loop at the filter seam: an assigned SD cancelled
+// WITH evidence drops the pattern; a bare cancel keeps the legacy requeue.
+import { describe, it, expect } from 'vitest';
+import {
+  filterPatternsForLearning,
+  fetchAssignedSdStatuses,
+  REJECT_REASONS,
+} from '../../scripts/modules/learning/filter.mjs';
+
+const basePattern = (over = {}) => ({
+  pattern_id: 'PAT-TEST-1',
+  source: 'retrospective',
+  category: 'protocol',
+  severity: 'high',
+  occurrence_count: 9,
+  trend: 'stable',
+  issue_summary: 'test pattern',
+  proven_solutions: [{ solution: 'x' }],
+  metadata: {},
+  ...over,
+});
+
+describe('checkAssignedSd evidence-cancelled suppression (b)', () => {
+  it('drops a pattern whose assigned SD was cancelled WITH evidence', () => {
+    const p = basePattern({ assigned_sd_id: 'sd-1' });
+    const result = filterPatternsForLearning([p], {
+      sdStatusMap: new Map([['sd-1', 'cancelled_with_evidence']]),
+      sourceSdStatusMap: new Map(),
+    });
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe(REJECT_REASONS.EVIDENCE_CANCELLED_ASSIGNED_SD);
+  });
+
+  it('keeps a pattern whose assigned SD had a bare cancel (requeue allowed)', () => {
+    const p = basePattern({ assigned_sd_id: 'sd-2' });
+    const result = filterPatternsForLearning([p], {
+      sdStatusMap: new Map([['sd-2', 'cancelled']]),
+      sourceSdStatusMap: new Map(),
+    });
+    expect(result.kept).toHaveLength(1);
+  });
+
+  it('still rejects patterns assigned to open SDs', () => {
+    const p = basePattern({ assigned_sd_id: 'sd-3' });
+    const result = filterPatternsForLearning([p], {
+      sdStatusMap: new Map([['sd-3', 'draft']]),
+      sourceSdStatusMap: new Map(),
+    });
+    expect(result.kept).toHaveLength(0);
+    expect(result.rejected[0].reason).toBe(REJECT_REASONS.ALREADY_ASSIGNED_OPEN_SD);
+  });
+});
+
+describe('fetchAssignedSdStatuses sentinel mapping (b)', () => {
+  const mockSupabase = (rows) => ({
+    from: () => ({
+      select: () => ({
+        in: async () => ({ data: rows, error: null }),
+      }),
+    }),
+  });
+
+  it('maps cancelled+reason to cancelled_with_evidence, bare cancel stays cancelled', async () => {
+    const map = await fetchAssignedSdStatuses(
+      mockSupabase([
+        { id: 'sd-a', status: 'cancelled', cancellation_reason: 'superseded by #4640 with live evidence' },
+        { id: 'sd-b', status: 'cancelled', cancellation_reason: '   ' },
+        { id: 'sd-c', status: 'in_progress', cancellation_reason: null },
+      ]),
+      [{ assigned_sd_id: 'sd-a' }, { assigned_sd_id: 'sd-b' }, { assigned_sd_id: 'sd-c' }],
+    );
+    expect(map.get('sd-a')).toBe('cancelled_with_evidence');
+    expect(map.get('sd-b')).toBe('cancelled');
+    expect(map.get('sd-c')).toBe('in_progress');
+  });
+});


### PR DESCRIPTION
## Summary
Closes the pattern-alert regeneration loop that produced two PAT-FIX SD storms on 2026-06-12 (13 duplicate SDs in a 2-second burst, all for families a worker had evidence-cancelled the same day).

- **(a) Linkage at creation**: `createSDForPattern` stamps `assigned_sd_id` + `status='assigned'` so the cancel-side closure machinery has rows to act on.
- **(b) Evidence-cancel suppresses, bare cancel requeues**: `cancel-sd.js` resolves linked patterns with an `evidence_cancelled_suppressed` disposition (captured pre-cancel — the reset trigger nulls `assigned_sd_id` during the cancel UPDATE); the reconcile sweep resolve-or-resets on the same evidence test; the noise filter emits a `cancelled_with_evidence` sentinel and rejects with `EVIDENCE_CANCELLED_ASSIGNED_SD`.
- **(c) Storm cap**: max 3 auto-filed SDs/run (`PATTERN_ALERT_MAX_SDS_PER_RUN`), remainder logged as a drop-list + durable P1 feedback signal — never 13 in one burst.
- **(d) Incident-window discount**: `metadata.incident_discount` subtracts incident-attributed churn before CRITICAL/HIGH/INCREASING thresholds.
- **(e) Fail-closed filter**: a noise-filter error now skips the alert cycle instead of filing unfiltered.

## Testing
66/66 across `pattern-alert-closed-loop` (new), `pattern-alert-cancelled-disposition`, `pattern-sd-completeness`, and the learn filter suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)