### PR TITLE
fix(SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001): write canonical LFA row BEFORE the completion reconcile

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -413,6 +413,68 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       console.warn(`   ⚠️  Migration verification check failed (non-blocking): ${migCheckError.message}`);
     }
 
+    // SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001: write the CANONICAL accepted LFA row
+    // BEFORE the completion reconcile below. The reconcile sets is_working_on=false,
+    // after which the enforce_is_working_on_for_handoffs BEFORE-INSERT trigger on
+    // sd_phase_handoffs rejects the recorder's post-return createArtifact insert
+    // ("Cannot create handoff for SD without active session claim") — every
+    // recorder-path LFA ghosted on first attempt post-#4674 (4x on 2026-06-12/13).
+    // Writing here, while the claim is live, passes the trigger; HandoffRecorder's
+    // #4674 idempotency check (existing accepted LFA row -> skip) makes the later
+    // recorder call a no-op. FAIL-LOUD AND FAIL-EARLY: if this canonical write
+    // fails, the SD is NEVER flipped to completed — stronger than #4674's post-hoc throw.
+    try {
+      const { HANDOFF_SYSTEM_TAG } = await import('../../recording/HandoffRecorder.js');
+      const { data: existingLfa } = await this.supabase
+        .from('sd_phase_handoffs')
+        .select('id')
+        .eq('sd_id', sd.id)
+        .eq('handoff_type', 'LEAD-FINAL-APPROVAL')
+        .eq('status', 'accepted')
+        .limit(1)
+        .maybeSingle();
+      if (!existingLfa) {
+        const { error: canonErr } = await this.supabase
+          .from('sd_phase_handoffs')
+          .insert({
+            sd_id: sd.id,
+            from_phase: 'LEAD',
+            to_phase: 'LEAD', // APPROVAL->LEAD coercion (sd_phase_handoffs to_phase CHECK), parity with recordFailure
+            handoff_type: 'LEAD-FINAL-APPROVAL',
+            status: 'accepted',
+            executive_summary: `LEAD-FINAL-APPROVAL accepted for ${sd.sd_key || sd.id} (score ${normalizedScore}). Canonical row written pre-completion while the session claim is live (SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001); full validation detail on the leo_handoff_executions row.`,
+            deliverables_manifest: { items: [{ name: 'final approval accepted', status: 'completed' }] },
+            key_decisions: [{ decision: `Final approval granted (validation score ${normalizedScore})` }],
+            known_issues: [{ issue: 'None at approval time' }],
+            resource_utilization: { execution_table: 'leo_handoff_executions' },
+            action_items: [{ item: 'None — SD lifecycle complete; post-completion tail follows' }],
+            completeness_report: { validation_score: normalizedScore },
+            validation_score: normalizedScore,
+            validation_passed: true,
+            validation_details: { written_by: 'LeadFinalApprovalExecutor pre-completion canonical write' },
+            accepted_at: new Date().toISOString(),
+            created_by: HANDOFF_SYSTEM_TAG,
+            metadata: { canonical_pre_completion_write: true, sd_ref: 'SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001' }
+          });
+        if (canonErr) {
+          console.log(`   ❌ Canonical LFA write failed (SD NOT completed): ${canonErr.message}`);
+          await this._cleanupPendingPreInsert(sd.id, usePendingPath);
+          return ResultBuilder.rejected(
+            'CANONICAL_LFA_WRITE_FAILED',
+            `Canonical sd_phase_handoffs LFA write failed before completion: ${canonErr.message}. SD left at pending_approval — fix the cause and re-run LEAD-FINAL-APPROVAL.`,
+            { trigger_hint: 'enforce_is_working_on_for_handoffs (if claim-related)' }
+          );
+        }
+        console.log('   ✅ Canonical accepted LFA row written pre-completion (sd_phase_handoffs)');
+      } else {
+        console.log(`   ℹ️  Canonical accepted LFA row already exists (${existingLfa.id})`);
+      }
+    } catch (canonEx) {
+      console.log(`   ❌ Canonical LFA write errored (SD NOT completed): ${canonEx.message}`);
+      await this._cleanupPendingPreInsert(sd.id, usePendingPath);
+      return ResultBuilder.rejected('CANONICAL_LFA_WRITE_FAILED', `Canonical LFA write errored: ${canonEx.message}`);
+    }
+
     // Transition SD to completed status
     // SD-MAN-INFRA-SAME-TURN-NEXT-001 FR-3: capture the completing session id
     // BEFORE the update below nulls active_session_id.

--- a/tests/unit/lfa-accept-ordering.test.js
+++ b/tests/unit/lfa-accept-ordering.test.js
@@ -1,0 +1,60 @@
+/**
+ * SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001 — pins the post-#4674 re-ghosting fix.
+ *
+ * Shape (reproduced 4x 2026-06-12/13): LeadFinalApprovalExecutor reconciled the SD
+ * to completed (is_working_on=false) BEFORE HandoffRecorder.createArtifact inserted
+ * the canonical accepted LFA row; the enforce_is_working_on_for_handoffs trigger
+ * then rejected the insert ("Cannot create handoff for SD without active session
+ * claim") and every recorder-path LFA ghosted on first attempt.
+ *
+ * Fix under pin: the executor writes the canonical accepted row PRE-completion
+ * (claim still live), fails EARLY (SD never flipped to completed on write failure),
+ * and is idempotent so the recorder's later createArtifact call no-ops via the
+ * #4674 existing-accepted-row check.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(
+  resolve(__dirname, '../../scripts/modules/handoff/executors/lead-final-approval/index.js'),
+  'utf8'
+);
+
+describe('LFA canonical write ordering (source-contract pin)', () => {
+  it('the canonical sd_phase_handoffs insert precedes the status=completed reconcile', () => {
+    const canonicalIdx = SRC.indexOf('canonical_pre_completion_write');
+    const completedIdx = SRC.indexOf('progress_percentage: 100');
+    expect(canonicalIdx).toBeGreaterThan(-1);
+    expect(completedIdx).toBeGreaterThan(-1);
+    expect(canonicalIdx).toBeLessThan(completedIdx);
+  });
+
+  it('fails EARLY: a rejected canonical write returns CANONICAL_LFA_WRITE_FAILED before completion', () => {
+    expect(SRC).toContain('CANONICAL_LFA_WRITE_FAILED');
+    // The rejection must occur before the completed update in source order.
+    expect(SRC.indexOf('CANONICAL_LFA_WRITE_FAILED')).toBeLessThan(SRC.indexOf('progress_percentage: 100'));
+  });
+
+  it('is idempotent: an existing accepted LFA row short-circuits the insert', () => {
+    const idx = SRC.indexOf('Canonical accepted LFA row already exists');
+    expect(idx).toBeGreaterThan(-1);
+    expect(idx).toBeLessThan(SRC.indexOf('progress_percentage: 100'));
+  });
+
+  it('coerces to_phase APPROVAL->LEAD (CHECK-safe) and uses the allowlisted system tag', () => {
+    const block = SRC.slice(SRC.indexOf('canonical_pre_completion_write') - 3000, SRC.indexOf('canonical_pre_completion_write'));
+    expect(block).toContain("to_phase: 'LEAD'");
+    expect(block).toContain('HANDOFF_SYSTEM_TAG');
+  });
+
+  it('recorder idempotency partner (#4674) still present so the later createArtifact no-ops', () => {
+    const recorder = readFileSync(
+      resolve(__dirname, '../../scripts/modules/handoff/recording/HandoffRecorder.js'),
+      'utf8'
+    );
+    expect(recorder).toContain('canonical row already accepted');
+  });
+});


### PR DESCRIPTION
## Summary
Stops the post-#4674 re-ghosting: the executor's completion reconcile cleared `is_working_on` before the recorder's canonical `sd_phase_handoffs` insert, so the `enforce_is_working_on_for_handoffs` trigger rejected every recorder-path LFA canonical write (4x reproduced 2026-06-12/13; GHOST_COMPLETION sweep alarming continuously).

- Canonical accepted LFA row now written **pre-completion** (claim live) inside `LeadFinalApprovalExecutor`.
- **Fail-early**: a rejected canonical write returns `CANONICAL_LFA_WRITE_FAILED` and the SD is never flipped to completed.
- Idempotent both ways: existing accepted row short-circuits the executor write AND the recorder's later `createArtifact` (#4674 check).
- The trigger itself is untouched — non-completion handoff inserts for unclaimed SDs are still rejected.

## Testing
- `tests/unit/lfa-accept-ordering.test.js` — 5/5 source-contract pins (ordering, fail-early, idempotency, coercion + system tag, recorder partner) + `handoff-recorder-lfa-canonical` 5/5 still green.
- Live proof: this SD's own LEAD-FINAL-APPROVAL (run post-merge) must complete non-ghost on first attempt.
- Inter-fix ghost window re-repaired via the backfill tool after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)