### PR TITLE
chore(SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001): register coordinator ranker/forecaster as npm entry points (WIRE_CHECK)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-MAN-INFRA-STAGE-REVIVAL-PLUMBING-001",
-  "expectedBranch": "feat/SD-MAN-INFRA-STAGE-REVIVAL-PLUMBING-001",
-  "createdAt": "2026-06-11T15:06:24.452Z",
+  "sdKey": "SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001",
+  "expectedBranch": "feat/SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001",
+  "createdAt": "2026-06-13T02:46:05.729Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/coordinator/sd-exclusion.mjs
+++ b/lib/coordinator/sd-exclusion.mjs
@@ -1,0 +1,106 @@
+/**
+ * sd-exclusion.mjs — shared SD classifiers for the coordinator dispatch surfaces
+ * (SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001).
+ *
+ * Two witnessed defects in the ranker/forecaster:
+ *   1. BARE_SHELL: SD-MAN-INFRA-GATE-BAR-REGIME-001 ranked #3 fleet-wide while its
+ *      description was just its title — a stub that cannot pass LEAD-TO-PLAN, so a
+ *      self-claiming worker burns LEAD cycles on it.
+ *   2. FIXTURE leak (feedback b5f21465): UAT test-run fixtures with epoch-stamped keys
+ *      (SD-UAT-FIX-TEST-E2E-1781186358703-001) ranked #1/#2 because the old FIXTURE_RE
+ *      only matched the legacy SD-LEO-FEAT-TEST-E2E- prefix.
+ *
+ * These are PURE classifiers. Both are FAIL-OPEN AGAINST CRASHES: malformed input makes
+ * them return false (the SD is treated as a normal item) so a classifier error can never
+ * THROW and kill the ranker. They must ALSO avoid the opposite failure — never exclude
+ * REAL work — which is why the epoch-stamped key pattern is anchored to a key-segment
+ * boundary (see FIXTURE_RE) so it cannot collide mid-word (e.g. the "TEST" tail of
+ * LATEST/FASTEST). The DURABLE fixture signal is the metadata.is_fixture marker; the
+ * key-shape regex is a secondary heuristic for legacy un-stamped rows.
+ *
+ * RESERVED FIXTURE PREFIXES: SD-(TEST|DEMO|SWITCH-OLD)-* are reserved for fixtures and
+ * MUST NOT be used by real ventures (a real SD keyed SD-DEMO-* is intentionally demoted).
+ * SD keys are UPPERCASE by DB convention; the regex is case-sensitive by design.
+ */
+
+// Anchored legacy prefixes + a BOUNDARY-ANCHORED epoch-stamped TEST-E2E segment.
+// The third alternative is bounded by (?:^|-) on the left and (?:-|$) on the right so it
+// fires only on a STANDALONE "TEST-E2E-<10+ digits>" key segment — NOT as the tail of a
+// longer word (LATEST/FASTEST/GREATEST-E2E-…) nor mid-key. The 10+ digit floor additionally
+// avoids matching a hypothetical real "TEST-E2E-2" feature token. (Adversarial-review fix,
+// SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: the original unanchored \bTEST-E2E-\d{10,}\b
+// over-excluded real keys whose preceding segment ended in "TEST".)
+export const FIXTURE_RE = /^SD-(TEST|DEMO|SWITCH-OLD)\b|^SD-LEO-FEAT-TEST-E2E-|(?:^|-)TEST-E2E-\d{10,}(?:-|$)/;
+
+/**
+ * Fixture SDs are seeded by test/UAT runners and must never be dispatched or counted as
+ * belt. Matches, in order of preference:
+ *   - an explicit metadata.is_fixture === true marker (durable; what UAT runners should
+ *     stamp — strict === true so a coincidentally-truthy value never demotes real work), OR
+ *   - a fixture KEY SHAPE per FIXTURE_RE (legacy prefixes or a standalone epoch-stamped
+ *     TEST-E2E-<epoch> segment, covering the new SD-UAT-FIX-TEST-E2E-<epoch>- keys).
+ *
+ * @param {string} sdKey
+ * @param {object} [metadata]
+ * @returns {boolean}
+ */
+export function isFixtureSd(sdKey, metadata) {
+  try {
+    if (metadata && typeof metadata === 'object' && metadata.is_fixture === true) return true;
+    if (typeof sdKey !== 'string' || !sdKey) return false;
+    return FIXTURE_RE.test(sdKey);
+  } catch {
+    return false; // fail-open: never let a classifier error exclude real work
+  }
+}
+
+/**
+ * A bare-shell SD has no real strategic content: its description is empty/whitespace or
+ * is just a copy of the title. Such a stub cannot pass LEAD-TO-PLAN, so the ranker must
+ * demote it below every authored SD and the forecaster must not count it as belt.
+ *
+ * @param {{description?: string, title?: string}} sd
+ * @returns {boolean}
+ */
+export function isBareShell(sd) {
+  try {
+    if (!sd || typeof sd !== 'object') return false;
+    const desc = typeof sd.description === 'string' ? sd.description.trim() : '';
+    if (desc === '') return true;
+    const title = typeof sd.title === 'string' ? sd.title.trim() : '';
+    if (title !== '' && desc === title) return true;
+    return false;
+  } catch {
+    return false; // fail-open: a classifier error ranks the SD normally
+  }
+}
+
+/**
+ * Belt-depth / dispatchability predicate shared by the capacity forecaster: an SD is NOT
+ * real, distributable belt if it is a fixture OR a bare-shell stub (neither can pass
+ * LEAD-TO-PLAN, so counting them over-reports capacity and masks a forecast deficit).
+ * The scripts CALL this exported function so tests exercise the real exclusion logic
+ * rather than a re-implementation.
+ *
+ * @param {{sd_key?: string, metadata?: object, description?: string, title?: string}} sd
+ * @returns {boolean} true when the SD must be excluded from belt depth
+ */
+export function isExcludedFromBelt(sd) {
+  if (!sd || typeof sd !== 'object') return false; // fail-open
+  return isFixtureSd(sd.sd_key, sd.metadata) || isBareShell(sd);
+}
+
+/**
+ * Dominant ranking comparator key used by coordinator-backlog-rank.mjs: bare-shell SDs
+ * sort AFTER every authored SD (returns >0 when only `a` is bare-shell). Exported and
+ * called by the ranker so a test of this function exercises the real demotion logic.
+ * Returns 0 when both sides have equal bare-shell status (caller falls through to its
+ * secondary keys: quarantine → unlock → priority → age).
+ *
+ * @returns {number} -1 | 0 | 1
+ */
+export function bareShellLastCompare(a, b) {
+  const ba = isBareShell(a) ? 1 : 0;
+  const bb = isBareShell(b) ? 1 : 0;
+  return ba - bb; // authored (0) before bare-shell (1)
+}

--- a/package.json
+++ b/package.json
@@ -322,6 +322,8 @@
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",
     "coordinator:self-review": "node scripts/coordinator-self-review.mjs",
     "coordinator:audit": "node scripts/coordinator-audit.mjs",
+    "coordinator:backlog-rank": "node scripts/coordinator-backlog-rank.mjs",
+    "coordinator:capacity-forecast": "node scripts/coordinator-capacity-forecast.mjs",
     "sd:start": "node scripts/sd-start.js",
     "sd:drain": "node scripts/sd-drain.mjs",
     "sd:recover": "node scripts/sd-recover.js",

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -25,10 +25,15 @@
  */
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+// SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: shared fail-open classifiers so the
+// ranker and the capacity forecaster exclude the same fixtures, and the ranker
+// demotes bare-shell stubs. FIXTURE_RE catches epoch-stamped TEST-E2E keys; the
+// bare-shell demotion uses the shared bareShellLastCompare so the test suite
+// exercises the real comparator, not a re-implementation.
+import { isFixtureSd, isBareShell, bareShellLastCompare } from '../lib/coordinator/sd-exclusion.mjs';
 
 const DRY = process.argv.includes('--dry-run');
 const PRIORITY_W = { critical: 3, high: 2, medium: 1, med: 1, low: 0 };
-const FIXTURE_RE = /^SD-(TEST|DEMO|SWITCH-OLD)\b|^SD-LEO-FEAT-TEST-E2E-/;
 
 // Dependencies appear in TWO shapes in live data: [{sd_id:'SD-…'}] (add-prd convention) and
 // raw string arrays ['SD-…'] (plan-keeper/Adam authoring). Reading only x.sd_id made this
@@ -43,7 +48,8 @@ const sb = createClient(
 
 async function main() {
   const { data: sds, error } = await sb.from('strategic_directives_v2')
-    .select('sd_key, status, sd_type, priority, created_at, claiming_session_id, dependencies, metadata')
+    // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + title, description to classify bare-shell stubs.
+    .select('sd_key, title, description, status, sd_type, priority, created_at, claiming_session_id, dependencies, metadata')
     .not('status', 'in', '("completed","cancelled","deferred")');
   if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return; }
 
@@ -81,14 +87,28 @@ async function main() {
 
   // ── claimable leaves ──
   const claimable = [];
+  let fixtureSkips = 0;
   for (const d of (sds || [])) {
     if (d.claiming_session_id) continue;
     if (d.sd_type === 'orchestrator') continue;          // parents are never dispatched
-    if (FIXTURE_RE.test(d.sd_key)) continue;             // test fixtures are never ranked
+    // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: fixtures (epoch-stamped TEST-E2E keys or
+    // metadata.is_fixture) are never ranked — they get no dispatch_rank at all.
+    if (isFixtureSd(d.sd_key, d.metadata)) {             // test fixtures are never ranked
+      fixtureSkips++;
+      console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
+      continue;
+    }
     const unmet = (d.dependencies || []).map(depId)
       .filter(k => k && (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
     if (unmet.length) continue;
     claimable.push(d);
+  }
+  if (fixtureSkips) console.log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
+  // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs (empty/title-only description)
+  // cannot pass LEAD-TO-PLAN; log them so the demote-to-last below is auditable. The sort
+  // below (bareShellLastCompare as the dominant key) is what actually places them last.
+  for (const d of claimable) {
+    if (isBareShell(d)) console.log(`  [demote] BARE_SHELL will sort below all authored SDs (description empty or equal to title): ${d.sd_key}`);
   }
 
   // ── rank ──
@@ -103,6 +123,12 @@ async function main() {
     return m.auto_generated === true && !m.triaged_by;
   };
   claimable.sort((a, b) => {
+    // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs sort below EVERY
+    // authored SD (rank-last), so a worker never self-claims a stub that cannot pass
+    // LEAD-TO-PLAN. This precedes quarantine/unlock so it dominates the ordering.
+    // Uses the shared comparator so the demotion is unit-tested against real code.
+    const bs = bareShellLastCompare(a, b);
+    if (bs !== 0) return bs;                                // authored (non-bare-shell) first
     const qa = quarantined(a) ? 1 : 0, qb = quarantined(b) ? 1 : 0;
     if (qa !== qb) return qa - qb;                          // human-authored first
     const ua = unlockScore(a.sd_key), ub = unlockScore(b.sd_key);

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -28,6 +28,10 @@ import { createRequire } from 'module';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+// SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: shared belt-exclusion predicate so test/UAT
+// fixtures AND bare-shell stubs (neither can pass LEAD-TO-PLAN) never inflate belt depth —
+// counting them as claimable over-reports capacity and suppresses the deficit/Adam alert.
+import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
 
 const require = createRequire(import.meta.url);
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
@@ -79,7 +83,9 @@ async function main() {
       .select('session_id, terminal_id, sd_key, heartbeat_at, loop_state, metadata')
       .gte('heartbeat_at', liveCutoff),
     sb.from('strategic_directives_v2')
-      .select('sd_key, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies')
+      // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + metadata (is_fixture marker) and
+      // title/description (bare-shell detection) so excluded rows do not inflate belt depth.
+      .select('sd_key, title, description, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies, metadata')
       .not('status', 'in', '("completed","cancelled","deferred")'),
     // Open QFs are claimable belt too (a worker can claim a QF) — counting only SDs
     // under-reports belt depth and over-reports deficit (workers self-claim QFs).
@@ -99,15 +105,21 @@ async function main() {
   }
   const claimable = [];
   const claimsBySession = {};
+  let beltExcludes = 0;
   for (const d of (sds || [])) {
     if (d.claiming_session_id) {
       (claimsBySession[d.claiming_session_id] ||= []).push(d);
       continue;
     }
     if (d.sd_type === 'orchestrator') continue; // parents auto-complete; never dispatch
+    // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: fixtures and bare-shell stubs are not real
+    // belt — neither can pass LEAD-TO-PLAN. Excluding them keeps beltDepth honest so a
+    // forecast deficit (and the proactive Adam reach-out) is not masked by non-distributable rows.
+    if (isExcludedFromBelt(d)) { beltExcludes++; continue; }
     const unmet = (d.dependencies || []).map(depId).filter(k => k && depStatus[k] !== 'completed');
     if (unmet.length === 0) claimable.push(d);
   }
+  if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell) excluded from belt depth`);
 
   // ── classify live workers (exclude coordinator + adam) ──
   const workers = (sessions || []).filter(s => {

--- a/tests/unit/coordinator-sd-exclusion.test.js
+++ b/tests/unit/coordinator-sd-exclusion.test.js
@@ -1,0 +1,184 @@
+/**
+ * SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001 — backlog-rank exclusion hardening.
+ *
+ * Pins the shared classifiers AND the production-used predicates that the ranker
+ * (coordinator-backlog-rank.mjs) and the forecaster (coordinator-capacity-forecast.mjs)
+ * call, so a regression that reverts the regex, removes the bare-shell sort key, or
+ * deletes a forecaster exclusion is caught:
+ *   - isFixtureSd: epoch-stamped UAT keys + metadata.is_fixture, no mid-word over-match
+ *   - isBareShell: stub SDs (description empty or equal to title)
+ *   - isExcludedFromBelt / bareShellLastCompare: the REAL functions the scripts call
+ * Hardened after adversarial review (the unanchored regex over-excluded LATEST/FASTEST keys,
+ * and the prior ranking test re-implemented the sort locally).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  isFixtureSd,
+  isBareShell,
+  isExcludedFromBelt,
+  bareShellLastCompare,
+  FIXTURE_RE,
+} from '../../lib/coordinator/sd-exclusion.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RANKER = resolve(__dirname, '../../scripts/coordinator-backlog-rank.mjs');
+const FORECASTER = resolve(__dirname, '../../scripts/coordinator-capacity-forecast.mjs');
+
+describe('isFixtureSd — fixture inclusion', () => {
+  it('excludes the witnessed epoch-stamped UAT fixture keys (the b5f21465 gap)', () => {
+    expect(isFixtureSd('SD-UAT-FIX-TEST-E2E-1781186358703-001')).toBe(true);
+    expect(isFixtureSd('SD-UAT-FIX-TEST-E2E-1781186358703-002')).toBe(true);
+  });
+
+  it('still excludes the legacy fixture prefixes', () => {
+    expect(isFixtureSd('SD-LEO-FEAT-TEST-E2E-foo')).toBe(true);
+    expect(isFixtureSd('SD-TEST-SOMETHING')).toBe(true);
+    expect(isFixtureSd('SD-DEMO-X')).toBe(true);
+    expect(isFixtureSd('SD-SWITCH-OLD-1')).toBe(true);
+  });
+
+  it('honors a STRICT metadata.is_fixture === true marker only', () => {
+    expect(isFixtureSd('SD-MAN-INFRA-WHATEVER-001', { is_fixture: true })).toBe(true);
+    expect(isFixtureSd('SD-MAN-INFRA-WHATEVER-001', { is_fixture: false })).toBe(false);
+    // strict === true is load-bearing: a coincidentally-truthy value must NOT demote real work
+    expect(isFixtureSd('SD-MAN-INFRA-WHATEVER-001', { is_fixture: 'true' })).toBe(false);
+    expect(isFixtureSd('SD-MAN-INFRA-WHATEVER-001', { is_fixture: 1 })).toBe(false);
+    expect(isFixtureSd('SD-MAN-INFRA-WHATEVER-001', { is_fixture: {} })).toBe(false);
+  });
+});
+
+describe('isFixtureSd — no over-exclusion of real work (adversarial-review hardening)', () => {
+  it('does NOT exclude normally-authored SDs', () => {
+    expect(isFixtureSd('SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001')).toBe(false);
+    expect(isFixtureSd('SD-MAN-INFRA-GATE-BAR-REGIME-001')).toBe(false);
+    expect(isFixtureSd('SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-D')).toBe(false);
+  });
+
+  it('does NOT match mid-word: a segment ending in TEST followed by E2E-<epoch>', () => {
+    // The original unanchored /TEST-E2E-\d{10,}/ wrongly matched the "TEST" tail of these.
+    expect(isFixtureSd('SD-FEAT-LATEST-E2E-1718000000')).toBe(false);
+    expect(isFixtureSd('SD-PERF-FASTEST-E2E-2026010100')).toBe(false);
+    expect(isFixtureSd('SD-FEAT-GREATEST-E2E-1234567890')).toBe(false);
+    expect(isFixtureSd('SD-QA-PROTEST-E2E-9999999999')).toBe(false);
+    expect(isFixtureSd('SD-QA-CONTEST-E2E-1000000000')).toBe(false);
+  });
+
+  it('still matches a STANDALONE epoch-stamped TEST-E2E segment regardless of prefix', () => {
+    expect(isFixtureSd('SD-ANYPREFIX-TEST-E2E-1781186358703-001')).toBe(true);
+  });
+
+  it('pins the 10-digit epoch floor at the 9/10 seam', () => {
+    expect(FIXTURE_RE.test('SD-FEAT-TEST-E2E-2')).toBe(false);              // 1 digit
+    expect(isFixtureSd('SD-FEAT-TEST-E2E-123456789-001')).toBe(false);     // 9 digits — below floor
+    expect(isFixtureSd('SD-FEAT-TEST-E2E-1234567890-001')).toBe(true);     // 10 digits — at floor
+  });
+
+  it('documents the reserved-prefix + case-sensitivity contract', () => {
+    // SD-(TEST|DEMO|SWITCH-OLD)-* are RESERVED for fixtures; a real venture must not use them.
+    expect(isFixtureSd('SD-DEMO-GRAPH-FEATURE-001')).toBe(true);
+    // keys are UPPERCASE by DB convention; the regex is intentionally case-sensitive.
+    expect(isFixtureSd('sd-uat-fix-test-e2e-1781186358703-001')).toBe(false);
+  });
+
+  it('fails open on malformed input (never excludes real work on a quirk)', () => {
+    expect(isFixtureSd(null)).toBe(false);
+    expect(isFixtureSd(undefined)).toBe(false);
+    expect(isFixtureSd(12345)).toBe(false);
+    expect(isFixtureSd('')).toBe(false);
+    expect(isFixtureSd('SD-X', null)).toBe(false);
+    expect(isFixtureSd('SD-X', 'not-an-object')).toBe(false);
+    expect(isFixtureSd('SD-X', 42)).toBe(false);
+  });
+});
+
+describe('isBareShell', () => {
+  it('flags a description equal to the title (the GATE-BAR-REGIME witness)', () => {
+    const title = 'backlog-rank exclusion hardening: bare-shell demotion';
+    expect(isBareShell({ title, description: title })).toBe(true);
+    expect(isBareShell({ title, description: `  ${title}  ` })).toBe(true); // whitespace-only diff
+  });
+
+  it('flags an empty or whitespace-only description', () => {
+    expect(isBareShell({ title: 'X', description: '' })).toBe(true);
+    expect(isBareShell({ title: 'X', description: '   \n\t ' })).toBe(true);
+    expect(isBareShell({ title: 'X', description: null })).toBe(true);
+    expect(isBareShell({ title: 'X' })).toBe(true);
+  });
+
+  it('does NOT flag a genuinely authored SD', () => {
+    expect(isBareShell({ title: 'Short title', description: 'A real, distinct, multi-sentence strategic description that is clearly not the title.' })).toBe(false);
+  });
+
+  it('fails open on malformed input', () => {
+    expect(isBareShell(null)).toBe(false);
+    expect(isBareShell(undefined)).toBe(false);
+    expect(isBareShell('not an object')).toBe(false);
+    expect(isBareShell(42)).toBe(false);
+  });
+});
+
+describe('bareShellLastCompare — the REAL ranker comparator key', () => {
+  const authored = { sd_key: 'SD-A', title: 'A', description: 'A real description.' };
+  const shell = { sd_key: 'SD-B', title: 'B', description: 'B' };
+
+  it('sorts a bare-shell SD after an authored SD', () => {
+    expect(bareShellLastCompare(authored, shell)).toBeLessThan(0);
+    expect(bareShellLastCompare(shell, authored)).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when both sides have equal bare-shell status (caller falls through)', () => {
+    expect(bareShellLastCompare(authored, { sd_key: 'SD-C', title: 'C', description: 'Another real one.' })).toBe(0);
+    expect(bareShellLastCompare(shell, { sd_key: 'SD-D', title: 'D', description: 'D' })).toBe(0);
+  });
+
+  it('used as the dominant key, a bare-shell never ranks above an authored SD', () => {
+    const ranked = [shell, authored].sort(bareShellLastCompare);
+    expect(ranked.map(s => s.sd_key)).toEqual(['SD-A', 'SD-B']);
+  });
+});
+
+describe('isExcludedFromBelt — the REAL forecaster belt predicate', () => {
+  it('excludes fixtures (epoch key or metadata.is_fixture) from belt', () => {
+    expect(isExcludedFromBelt({ sd_key: 'SD-UAT-FIX-TEST-E2E-1781186358703-001', metadata: {} })).toBe(true);
+    expect(isExcludedFromBelt({ sd_key: 'SD-REAL-001', metadata: { is_fixture: true } })).toBe(true);
+  });
+
+  it('excludes bare-shell stubs from belt (they cannot pass LEAD-TO-PLAN)', () => {
+    expect(isExcludedFromBelt({ sd_key: 'SD-STUB-001', title: 'Stub', description: 'Stub', metadata: {} })).toBe(true);
+    expect(isExcludedFromBelt({ sd_key: 'SD-STUB-002', title: 'Stub', description: '', metadata: {} })).toBe(true);
+  });
+
+  it('keeps a real authored, non-fixture SD in belt', () => {
+    expect(isExcludedFromBelt({ sd_key: 'SD-REAL-001', title: 'Real', description: 'A genuine description distinct from the title.', metadata: {} })).toBe(false);
+  });
+
+  it('fails open on malformed input', () => {
+    expect(isExcludedFromBelt(null)).toBe(false);
+    expect(isExcludedFromBelt('x')).toBe(false);
+  });
+});
+
+describe('production wiring guards (catch call-site deletion)', () => {
+  const rankerSrc = readFileSync(RANKER, 'utf8');
+  const forecasterSrc = readFileSync(FORECASTER, 'utf8');
+
+  it('the ranker imports and applies the fixture skip + bare-shell comparator', () => {
+    expect(rankerSrc).toMatch(/from '\.\.\/lib\/coordinator\/sd-exclusion\.mjs'/);
+    expect(rankerSrc).toContain('isFixtureSd(d.sd_key, d.metadata)');
+    expect(rankerSrc).toContain('bareShellLastCompare(a, b)');
+  });
+
+  it('the forecaster imports and applies the belt exclusion', () => {
+    expect(forecasterSrc).toMatch(/from '\.\.\/lib\/coordinator\/sd-exclusion\.mjs'/);
+    expect(forecasterSrc).toContain('isExcludedFromBelt(d)');
+  });
+
+  it('both scripts SELECT the columns their classifiers read', () => {
+    // bare-shell needs title+description; is_fixture needs metadata.
+    expect(rankerSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
+    expect(forecasterSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
+  });
+});


### PR DESCRIPTION
Follow-up to #4683. The armed-cron coordinator scripts were invoked only via prose string prompts, so WIRE_CHECK could not reach the new lib/coordinator/sd-exclusion.mjs through them. Registers coordinator:backlog-rank / coordinator:capacity-forecast npm scripts (the gate's prescribed mechanism), wiring the shared classifier and improving discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)