### PR TITLE
fix(SD-FDBK-FIX-HANDOFF-EPIPE-GUARD-001): EPIPE guard on handoff.js stdout/stderr

### DIFF
--- a/lib/utils/ignore-epipe.mjs
+++ b/lib/utils/ignore-epipe.mjs
@@ -1,0 +1,34 @@
+/**
+ * ignore-epipe.mjs — shared EPIPE-tolerant stream-'error' handler
+ * (SD-FDBK-FIX-HANDOFF-EPIPE-GUARD-001).
+ *
+ * Long-running CLIs that emit heavy console output AROUND async DB writes (handoff.js,
+ * add-prd-to-database.js) crash if their stdout/stderr read end closes early (a pipe to
+ * head/grep): the next console.log raises an unhandled 'error' (EPIPE) that aborts the
+ * process BEFORE persistence completes on POSIX/CI (Windows git-bash masks it), leaving a
+ * partially-written / non-recorded row. Attach this handler to process.stdout AND
+ * process.stderr so a closed pipe is swallowed while any OTHER stream error still throws.
+ *
+ *   import { attachIgnoreEpipe } from '../lib/utils/ignore-epipe.mjs';
+ *   attachIgnoreEpipe();  // call once, early, before heavy output
+ */
+
+/**
+ * Stream 'error' listener: swallow EPIPE (and the falsy/no-error edge), rethrow anything
+ * else so real stream faults are never hidden. Pure — exported for direct unit testing.
+ * @param {(NodeJS.ErrnoException|undefined|null)} err
+ */
+export function ignoreEpipe(err) {
+  if (!err || err.code === 'EPIPE') return;
+  throw err;
+}
+
+/**
+ * Attach {@link ignoreEpipe} to the given streams (default: process stdout+stderr).
+ * Idempotent enough for a single early call; pass streams in tests.
+ * @param {{stdout?: NodeJS.WriteStream, stderr?: NodeJS.WriteStream}} [streams]
+ */
+export function attachIgnoreEpipe(streams = process) {
+  if (streams.stdout && typeof streams.stdout.on === 'function') streams.stdout.on('error', ignoreEpipe);
+  if (streams.stderr && typeof streams.stderr.on === 'function') streams.stderr.on('error', ignoreEpipe);
+}

--- a/scripts/handoff.js
+++ b/scripts/handoff.js
@@ -64,6 +64,19 @@ if (_reexecPlan.reexec) {
 // If cwd is still broken (no_valid_main_root / sentinel set), the loud STALE_CWD
 // guard below preserves the original exit(1) failure (never silently swallowed).
 
+// SD-FDBK-FIX-HANDOFF-EPIPE-GUARD-001: EPIPE-tolerant stdout/stderr. handoff.js is the
+// canonical SD-V2 phase/status writer and emits heavy interleaved gate output AROUND the
+// executors' DB .update/.insert writes. Piping it through head/grep closes the read end,
+// and the next console.log would raise an unhandled 'error' (EPIPE) that crashes the
+// process BEFORE persistence completes on POSIX/CI (Windows git-bash masks it), producing
+// a partially-written / non-recorded handoff. Swallow EPIPE on both streams so a closed
+// pipe never aborts a mid-persistence run. Shared util ported from the inline guard in
+// scripts/add-prd-to-database.js (SD-LEO-INFRA-HARDEN-ADD-PRD-001 / PR #4477). Attached
+// HERE — after the re-exec early-exit, before any heavy output — so it covers the entire
+// gate+persist pipeline. Builtin-free import keeps it safe before the heavy graph loads.
+const { attachIgnoreEpipe } = await import('../lib/utils/ignore-epipe.mjs');
+attachIgnoreEpipe();
+
 // Heavy graph: dynamic imports deferred until cwd is known-good (or re-exec'd).
 const { main } = await import('./modules/handoff/cli/index.js');
 const { claimGuard } = await import('../lib/claim-guard.mjs');

--- a/tests/unit/ignore-epipe.test.js
+++ b/tests/unit/ignore-epipe.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-FDBK-FIX-HANDOFF-EPIPE-GUARD-001 — EPIPE-tolerant stream guard.
+ *
+ * Pins the shared handler that handoff.js (and add-prd-to-database.js) attach so a closed
+ * read-end pipe never crashes the process mid-DB-persistence: EPIPE (and the no-error edge)
+ * is swallowed, every other stream error still throws, and a static guard confirms
+ * handoff.js actually attaches it.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { EventEmitter } from 'node:events';
+import { ignoreEpipe, attachIgnoreEpipe } from '../../lib/utils/ignore-epipe.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HANDOFF = resolve(__dirname, '../../scripts/handoff.js');
+
+describe('ignoreEpipe predicate', () => {
+  it('swallows an EPIPE error (does not throw)', () => {
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    expect(() => ignoreEpipe(epipe)).not.toThrow();
+  });
+
+  it('swallows the falsy/no-error edge', () => {
+    expect(() => ignoreEpipe(null)).not.toThrow();
+    expect(() => ignoreEpipe(undefined)).not.toThrow();
+  });
+
+  it('RETHROWS any non-EPIPE stream error (never hides a real fault)', () => {
+    const econnreset = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    expect(() => ignoreEpipe(econnreset)).toThrow(/socket hang up/);
+    const generic = new Error('boom'); // no .code
+    expect(() => ignoreEpipe(generic)).toThrow(/boom/);
+  });
+});
+
+describe('attachIgnoreEpipe', () => {
+  it('registers the handler on both streams so a closed pipe is swallowed end-to-end', () => {
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    attachIgnoreEpipe({ stdout, stderr });
+    // Emitting an EPIPE 'error' on an EventEmitter WITH a listener does not throw;
+    // WITHOUT the listener Node would throw "Unhandled error". So a non-throw proves attach.
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    expect(() => stdout.emit('error', epipe)).not.toThrow();
+    expect(() => stderr.emit('error', epipe)).not.toThrow();
+  });
+
+  it('the attached handler still surfaces a non-EPIPE error', () => {
+    const stdout = new EventEmitter();
+    attachIgnoreEpipe({ stdout });
+    const real = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+    expect(() => stdout.emit('error', real)).toThrow(/disk full/);
+  });
+
+  it('tolerates streams missing .on (no throw)', () => {
+    expect(() => attachIgnoreEpipe({ stdout: {}, stderr: undefined })).not.toThrow();
+  });
+});
+
+describe('production wiring guard', () => {
+  it('handoff.js imports and attaches the shared EPIPE guard before the heavy graph', () => {
+    const src = readFileSync(HANDOFF, 'utf8');
+    // Dynamic import by design: it must load AFTER the re-exec preflight (builtin-only
+    // module top), so assert the specifier appears in any import form.
+    expect(src).toContain("'../lib/utils/ignore-epipe.mjs'");
+    expect(src).toContain('attachIgnoreEpipe()');
+    // It must be attached BEFORE the heavy main import (which begins the gate+persist output).
+    expect(src.indexOf('attachIgnoreEpipe()')).toBeLessThan(src.indexOf("import('./modules/handoff/cli/index.js')"));
+  });
+});


### PR DESCRIPTION
## Summary
`handoff.js` (canonical SD-V2 phase/status writer) registered no EPIPE handler. It emits heavy gate output around the executors' DB writes; piping through head/grep closes the read end and the next console.log raises an unhandled 'error' (EPIPE) that crashes the process before persistence completes on POSIX/CI (Windows masks it) — a partially-written handoff. The worker rule "never pipe handoff.js" was a fragile workaround. The guard already shipped inline in add-prd-to-database.js (PR #4477) but was never propagated.

Extracted to a shared, tested util lib/utils/ignore-epipe.mjs (swallow EPIPE + no-error edge, rethrow every other stream error) and attached in handoff.js after the re-exec early-exit, before the heavy graph.

## Testing
tests/unit/ignore-epipe.test.js — 7/7. node scripts/handoff.js | head exits 0 (was 141). Follow-up: add-prd-to-database.js can adopt the shared util.

🤖 Generated with [Claude Code](https://claude.com/claude-code)