### PR TITLE
fix(SD-FDBK-FIX-GATE-PIPELINE-GATE1-001): GATE1 key drift + remove premature GATE4 at PLAN-TO-LEAD

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -50,6 +50,14 @@ export { createCrossSdFileOverlapTemporalShipGate };
 import { createActivationInvariantGate } from './gates/activation-invariant-gate.js';
 export { createActivationInvariantGate };
 
+// SD-FDBK-FIX-GATE-PIPELINE-GATE1-001: GATE4_WORKFLOW_ROI is NOT pushed here as an executor gate.
+// It is ALREADY evaluated at LEAD-FINAL-APPROVAL via the DB-driven validator-registry rules
+// (leo_validation_rules gate='4' handoff_type='LEAD-FINAL-APPROVAL': valueDelivered,
+// patternEffectiveness, executiveValidation, processAdherence — all resolve to
+// validateGate4LeadFinal via the gate-4 preloader). Adding an executor-level push would run the
+// git-shelling + multi-DB-round-trip GATE4 computation a SECOND time per handoff (dedup keys on
+// rule name, which differs). The (A) fix is simply removing the PREMATURE PLAN-TO-LEAD execution.
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -1212,6 +1220,11 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   // works against real data. Closes 26th writer-consumer asymmetry witness.
   // (SD-LEO-INFRA-REQUIRE-END-END-001 FR-2)
   gates.push(createActivationInvariantGate(supabase, prdRepo));
+
+  // SD-FDBK-FIX-GATE-PIPELINE-GATE1-001: GATE4_WORKFLOW_ROI is intentionally NOT pushed here —
+  // it already runs at LEAD-FINAL via the validator-registry DB rules (see header note). The (A)
+  // fix is the PLAN-TO-LEAD removal + the (B) gate1 key-drift fix so the LFA computation scores
+  // correctly. Adding a push here would double-run validateGate4LeadFinal.
 
   return gates;
 }

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -36,7 +36,7 @@ import {
   createRetrospectiveQualityGate,
   createGitCommitEnforcementGate,
   createTraceabilityGate,
-  createWorkflowROIGate,
+  // createWorkflowROIGate removed — GATE4 moved to LEAD-FINAL-APPROVAL (SD-FDBK-FIX-GATE-PIPELINE-GATE1-001)
   createUserStoryExistenceGate,
   createDocumentationLinkValidationGate,
   createHealBeforeCompleteGate,
@@ -293,8 +293,13 @@ export class PlanToLeadExecutor extends BaseExecutor {
     const isBugfixSD = sdType === 'bugfix' || sdType === 'bug_fix';
 
     if (!isNonCodeSD && !isBugfixSD) {
-      gates.push(createTraceabilityGate(this.supabase));
-      gates.push(createWorkflowROIGate(this.supabase));
+      gates.push(createTraceabilityGate(this.supabase)); // GATE3 — legitimately scored at PLAN-TO-LEAD
+      // SD-FDBK-FIX-GATE-PIPELINE-GATE1-001: createWorkflowROIGate (GATE4_WORKFLOW_ROI) is a
+      // LEAD-FINAL computation ("X/3 gates cleared", reads the PLAN-TO-LEAD acceptance + gate3).
+      // At PLAN-TO-LEAD the PLAN-TO-LEAD handoff is not yet accepted, so the gate3 acceptance and
+      // the N/3 rollup are structurally unscoreable — it ran one phase too early and forced a
+      // --bypass-validation on passing security SDs. Moved to LEAD-FINAL-APPROVAL (getRequiredGates),
+      // where the PLAN-TO-LEAD handoff is accepted and the rollup is sound.
     }
 
     // User story existence gate

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -842,12 +842,19 @@ export class HandoffRecorder {
           }
         }
         // PLAN-TO-EXEC: Store Gate 1 results for LEAD-FINAL-APPROVAL
+        // SD-FDBK-FIX-GATE-PIPELINE-GATE1-001: gateResults is keyed by gate.name, and the live
+        // PLAN-TO-EXEC gate is GATE1_DESIGN_DATABASE — the legacy GATE1_PRD_QUALITY key is never
+        // produced, so gate1 was never mirrored to metadata.gate1_validation and GATE4 at
+        // LEAD-FINAL never found it (undercounting C1, forcing a bypass on passing security SDs).
+        // Recognize the live key with GATE1_PRD_QUALITY back-compat. (The full map is also stored
+        // at metadata.gate_results below, so the GATE4 reader can read the canonical name too.)
         if (handoffType === 'PLAN-TO-EXEC') {
-          if (result.gateResults.GATE1_PRD_QUALITY) {
-            metadata.gate1_validation = result.gateResults.GATE1_PRD_QUALITY;
-            console.log('   ✅ Gate 1 PRD quality saved to metadata.gate1_validation');
+          const gate1 = result.gateResults.GATE1_DESIGN_DATABASE || result.gateResults.GATE1_PRD_QUALITY;
+          if (gate1) {
+            metadata.gate1_validation = gate1;
+            console.log('   ✅ Gate 1 (DESIGN→DATABASE) saved to metadata.gate1_validation');
           } else {
-            console.warn('   ⚠️  WARNING: GATE1_PRD_QUALITY not found in gateResults');
+            console.warn('   ⚠️  WARNING: GATE1 (GATE1_DESIGN_DATABASE / GATE1_PRD_QUALITY) not found in gateResults');
           }
         }
         // PLAN-TO-LEAD: Store Gate 3 results for LEAD-FINAL-APPROVAL Gate 4

--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -38,6 +38,65 @@ const execAsync = promisify(exec);
  * @param {Object} allGateResults - Results from Gates 1-3 (optional)
  * @returns {Promise<Object>} Validation result
  */
+
+/**
+ * Credit gate1/gate2/gate3 results + acceptance from a handoff-history list, mutating the
+ * passed accumulators. Behavior-preserving extraction of the per-handoff loop so the gate-key
+ * recognition (notably the live GATE1_DESIGN_DATABASE name) is directly unit-testable.
+ * PURE over its inputs except for the accumulator mutation. SD-FDBK-FIX-GATE-PIPELINE-GATE1-001.
+ *
+ * @param {Array<{handoff_type:string, status:string, metadata?:object}>} handoffs
+ * @param {{gateResults:object, acceptedHandoffs:object, gateDataSources:object}} acc
+ */
+export function creditGatesFromHandoffs(handoffs, { gateResults, acceptedHandoffs, gateDataSources }) {
+  for (const handoff of (handoffs || [])) {
+    // PLAN-TO-EXEC: Gate 1 (PRD Quality / DESIGN→DATABASE)
+    if (handoff.handoff_type === 'PLAN-TO-EXEC') {
+      if (handoff.status === 'accepted') acceptedHandoffs.gate1 = true;
+      if (!gateResults.gate1) {
+        // gate_results is keyed by gate.name; the live PLAN-TO-EXEC gate is GATE1_DESIGN_DATABASE —
+        // GATE1_PRD_QUALITY is never emitted. Check the live key first, then the legacy canonical
+        // name, then the legacy gate1_validation mirror.
+        const canon = handoff.metadata?.gate_results?.GATE1_DESIGN_DATABASE
+          || handoff.metadata?.gate_results?.GATE1_PRD_QUALITY;
+        if (canon) {
+          gateResults.gate1 = canon;
+          gateDataSources.gate1 = 'canonical';
+        } else if (handoff.metadata?.gate1_validation) {
+          gateResults.gate1 = handoff.metadata.gate1_validation;
+          gateDataSources.gate1 = 'legacy';
+        }
+      }
+    }
+    // EXEC-TO-PLAN: Gate 2 (Implementation Fidelity)
+    if (handoff.handoff_type === 'EXEC-TO-PLAN') {
+      if (handoff.status === 'accepted') acceptedHandoffs.gate2 = true;
+      if (!gateResults.gate2) {
+        if (handoff.metadata?.gate_results?.GATE2_IMPLEMENTATION_FIDELITY) {
+          gateResults.gate2 = handoff.metadata.gate_results.GATE2_IMPLEMENTATION_FIDELITY;
+          gateDataSources.gate2 = 'canonical';
+        } else if (handoff.metadata?.gate2_validation) {
+          gateResults.gate2 = handoff.metadata.gate2_validation;
+          gateDataSources.gate2 = 'legacy';
+        }
+      }
+    }
+    // PLAN-TO-LEAD: Gate 3 (Traceability)
+    if (handoff.handoff_type === 'PLAN-TO-LEAD') {
+      if (handoff.status === 'accepted') acceptedHandoffs.gate3 = true;
+      if (!gateResults.gate3) {
+        if (handoff.metadata?.gate_results?.GATE3_TRACEABILITY) {
+          gateResults.gate3 = handoff.metadata.gate_results.GATE3_TRACEABILITY;
+          gateDataSources.gate3 = 'canonical';
+        } else if (handoff.metadata?.gate3_validation) {
+          gateResults.gate3 = handoff.metadata.gate3_validation;
+          gateDataSources.gate3 = 'legacy';
+        }
+      }
+    }
+  }
+}
+
 export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {}, options = {}) {
   console.log('\n🚪 GATE 4: Workflow ROI & Pattern Effectiveness (LEAD Final)');
   console.log('='.repeat(60));
@@ -168,51 +227,7 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
         .order('created_at', { ascending: false })).data;
 
       if (handoffs) {
-        for (const handoff of handoffs) {
-          // PLAN-TO-EXEC: Gate 1 (PRD Quality)
-          // Read canonical gate_results first, fall back to legacy key. Acceptance is
-          // credited regardless of whether the gate value is already present.
-          if (handoff.handoff_type === 'PLAN-TO-EXEC') {
-            if (handoff.status === 'accepted') acceptedHandoffs.gate1 = true;
-            if (!gateResults.gate1) {
-              if (handoff.metadata?.gate_results?.GATE1_PRD_QUALITY) {
-                gateResults.gate1 = handoff.metadata.gate_results.GATE1_PRD_QUALITY;
-                gateDataSources.gate1 = 'canonical';
-              } else if (handoff.metadata?.gate1_validation) {
-                gateResults.gate1 = handoff.metadata.gate1_validation;
-                gateDataSources.gate1 = 'legacy';
-              }
-            }
-          }
-          // EXEC-TO-PLAN: Gate 2 (Implementation Fidelity)
-          if (handoff.handoff_type === 'EXEC-TO-PLAN') {
-            if (handoff.status === 'accepted') acceptedHandoffs.gate2 = true;
-            if (!gateResults.gate2) {
-              if (handoff.metadata?.gate_results?.GATE2_IMPLEMENTATION_FIDELITY) {
-                gateResults.gate2 = handoff.metadata.gate_results.GATE2_IMPLEMENTATION_FIDELITY;
-                gateDataSources.gate2 = 'canonical';
-              } else if (handoff.metadata?.gate2_validation) {
-                gateResults.gate2 = handoff.metadata.gate2_validation;
-                gateDataSources.gate2 = 'legacy';
-              }
-            }
-          }
-          // PLAN-TO-LEAD: Gate 3 (Traceability)
-          // SD-LEARN-FIX-ADDRESS-PAT-AUTO-002: Check canonical, then legacy gate3_validation,
-          // then nested gate_results.GATE3_TRACEABILITY
-          if (handoff.handoff_type === 'PLAN-TO-LEAD') {
-            if (handoff.status === 'accepted') acceptedHandoffs.gate3 = true;
-            if (!gateResults.gate3) {
-              if (handoff.metadata?.gate_results?.GATE3_TRACEABILITY) {
-                gateResults.gate3 = handoff.metadata.gate_results.GATE3_TRACEABILITY;
-                gateDataSources.gate3 = 'canonical';
-              } else if (handoff.metadata?.gate3_validation) {
-                gateResults.gate3 = handoff.metadata.gate3_validation;
-                gateDataSources.gate3 = 'legacy';
-              }
-            }
-          }
-        }
+        creditGatesFromHandoffs(handoffs, { gateResults, acceptedHandoffs, gateDataSources });
       }
     }
     // SD-LEO-INFRA-HARDEN-LEO-HANDOFF-001 FR-1: deterministic precheck == execute.

--- a/tests/unit/gate-pipeline-gate1-placement.test.js
+++ b/tests/unit/gate-pipeline-gate1-placement.test.js
@@ -1,0 +1,144 @@
+/**
+ * SD-FDBK-FIX-GATE-PIPELINE-GATE1-001 — gate-pipeline GATE1 key-drift + GATE4 placement.
+ *
+ * (B) GATE1 KEY DRIFT: the live PLAN-TO-EXEC gate is GATE1_DESIGN_DATABASE (gate_results keyed by
+ *     gate.name); GATE1_PRD_QUALITY was never emitted, so GATE4's reader never found gate1.
+ *     creditGatesFromHandoffs (reader) + HandoffRecorder (writer) now recognize the live key.
+ * (A) GATE4 MISPLACEMENT: createWorkflowROIGate (GATE4_WORKFLOW_ROI) ran as a BLOCKING executor
+ *     gate at PLAN-TO-LEAD (one phase too early). It is REMOVED from PLAN-TO-LEAD. GATE4 already
+ *     runs at LEAD-FINAL via the validator-registry DB rules (leo_validation_rules gate='4',
+ *     handoff_type='LEAD-FINAL-APPROVAL') — so the LFA executor must NOT push it again (double-run).
+ *
+ * Tests bind to the REAL exported functions; the adversarial review of this diff caught a
+ * double-run (the original draft pushed GATE4 at LFA on top of the registry) — these tests pin
+ * the corrected behavior.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { creditGatesFromHandoffs } from '../../scripts/modules/workflow-roi-validation.js';
+import { getRequiredGates } from '../../scripts/modules/handoff/executors/lead-final-approval/gates.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PLAN_TO_LEAD = resolve(__dirname, '../../scripts/modules/handoff/executors/plan-to-lead/index.js');
+const HANDOFF_RECORDER = resolve(__dirname, '../../scripts/modules/handoff/recording/HandoffRecorder.js');
+
+const freshAcc = () => ({ gateResults: {}, acceptedHandoffs: {}, gateDataSources: {} });
+
+describe('(B) GATE1 key drift — creditGatesFromHandoffs (reader)', () => {
+  it('credits gate1 from the LIVE GATE1_DESIGN_DATABASE key (the drift fix)', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate_results: { GATE1_DESIGN_DATABASE: { score: 92, passed: true } } } },
+    ], acc);
+    expect(acc.gateResults.gate1).toEqual({ score: 92, passed: true });
+    expect(acc.gateDataSources.gate1).toBe('canonical');
+    expect(acc.acceptedHandoffs.gate1).toBe(true);
+  });
+
+  it('still credits gate1 from the legacy GATE1_PRD_QUALITY canonical key (back-compat)', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate_results: { GATE1_PRD_QUALITY: { score: 88 } } } },
+    ], acc);
+    expect(acc.gateResults.gate1).toEqual({ score: 88 });
+    expect(acc.gateDataSources.gate1).toBe('canonical');
+  });
+
+  it('still credits gate1 from the legacy gate1_validation mirror', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate1_validation: { score: 77 } } },
+    ], acc);
+    expect(acc.gateResults.gate1).toEqual({ score: 77 });
+    expect(acc.gateDataSources.gate1).toBe('legacy');
+  });
+
+  it('does NOT credit gate1 from an UNRECOGNIZED gate_results key (recognition-set guard)', () => {
+    // The exact bug class the SD remediates: an unknown key must surface as an undercount
+    // (gate1 undefined) loudly, not be silently mis-credited.
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate_results: { GATE1_SOME_FUTURE_RENAME: { score: 91 } } } },
+    ], acc);
+    expect(acc.gateResults.gate1).toBeUndefined();
+    expect(acc.gateDataSources.gate1).toBeUndefined();
+    expect(acc.acceptedHandoffs.gate1).toBe(true); // acceptance still credited; score not mis-credited
+  });
+
+  it('does NOT credit acceptance for a non-accepted handoff (status guard)', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'PLAN-TO-EXEC', status: 'rejected', metadata: { gate_results: { GATE1_DESIGN_DATABASE: { score: 90 } } } },
+    ], acc);
+    expect(acc.acceptedHandoffs.gate1).toBeFalsy();
+    expect(acc.gateResults.gate1).toEqual({ score: 90 }); // value credit is status-independent
+  });
+
+  it('first matching handoff in the list wins the gate1 value (caller passes newest first)', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate_results: { GATE1_DESIGN_DATABASE: { score: 99 } } } },
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate_results: { GATE1_DESIGN_DATABASE: { score: 11 } } } },
+    ], acc);
+    expect(acc.gateResults.gate1).toEqual({ score: 99 });
+  });
+
+  it('credits gate2 and gate3 from their canonical keys (behavior preserved)', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([
+      { handoff_type: 'EXEC-TO-PLAN', status: 'accepted', metadata: { gate_results: { GATE2_IMPLEMENTATION_FIDELITY: { score: 95 } } } },
+      { handoff_type: 'PLAN-TO-LEAD', status: 'accepted', metadata: { gate_results: { GATE3_TRACEABILITY: { score: 100 } } } },
+    ], acc);
+    expect(acc.gateResults.gate2).toEqual({ score: 95 });
+    expect(acc.gateResults.gate3).toEqual({ score: 100 });
+    expect(acc.acceptedHandoffs.gate2).toBe(true);
+    expect(acc.acceptedHandoffs.gate3).toBe(true);
+  });
+
+  it('credits acceptance when the gate value is absent, and tolerates an empty/undefined list', () => {
+    const acc = freshAcc();
+    creditGatesFromHandoffs([{ handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: {} }], acc);
+    expect(acc.acceptedHandoffs.gate1).toBe(true);
+    expect(acc.gateResults.gate1).toBeUndefined();
+    expect(() => creditGatesFromHandoffs(undefined, freshAcc())).not.toThrow();
+  });
+});
+
+describe('(A) GATE4 placement — PLAN-TO-LEAD removal + no LFA double-push (wiring guards)', () => {
+  const p2lSrc = readFileSync(PLAN_TO_LEAD, 'utf8');
+  const stubSupabase = {};
+  const stubPrdRepo = {};
+
+  it('the PLAN-TO-LEAD executor no longer pushes createWorkflowROIGate (GATE4 removed)', () => {
+    expect(p2lSrc).not.toMatch(/^\s*gates\.push\(createWorkflowROIGate/m);
+  });
+
+  it('the PLAN-TO-LEAD executor still pushes the GATE3 traceability gate', () => {
+    expect(p2lSrc).toMatch(/gates\.push\(createTraceabilityGate/);
+  });
+
+  it('LEAD-FINAL getRequiredGates does NOT push GATE4_WORKFLOW_ROI (registry already runs it — no double-run)', () => {
+    for (const sd of [{ sd_key: 'SD-SEC-001', sd_type: 'feature' }, { sd_key: 'SD-FIX-001', sd_type: 'bugfix' }, null]) {
+      const names = getRequiredGates(stubSupabase, stubPrdRepo, sd).map(g => g.name);
+      expect(names).not.toContain('GATE4_WORKFLOW_ROI');
+    }
+  });
+});
+
+describe('(B) GATE1 key drift — HandoffRecorder writer mirror', () => {
+  // The recorder's PLAN-TO-EXEC block mirrors gate1 into metadata.gate1_validation (the legacy
+  // fallback the GATE4 reader uses). Source-pin that it recognizes the live key + back-compat,
+  // so a revert to GATE1_PRD_QUALITY-only is caught.
+  const recSrc = readFileSync(HANDOFF_RECORDER, 'utf8');
+
+  it('the writer recognizes the live GATE1_DESIGN_DATABASE key with GATE1_PRD_QUALITY back-compat', () => {
+    expect(recSrc).toMatch(/result\.gateResults\.GATE1_DESIGN_DATABASE\s*\|\|\s*result\.gateResults\.GATE1_PRD_QUALITY/);
+    expect(recSrc).toMatch(/metadata\.gate1_validation\s*=\s*gate1/);
+  });
+
+  it('the writer still persists the full gate_results map (the GATE4 reader canonical path)', () => {
+    expect(recSrc).toMatch(/metadata\.gate_results\s*=\s*result\.gateResults/);
+  });
+});


### PR DESCRIPTION
## Summary
Two gate-pipeline defects forced a `--bypass-validation` on a passing security SD (SD-LEO-GEN-SCOPE-ANON-KEY-001):

- **(A) Misplacement**: `createWorkflowROIGate` (GATE4_WORKFLOW_ROI) ran as a BLOCKING executor gate at PLAN-TO-LEAD — a LEAD-Final computation one phase too early (the PLAN-TO-LEAD handoff isn't accepted yet, so the gate3-acceptance + N/3 rollup are structurally unscoreable). **Removed from PLAN-TO-LEAD.** GATE4 already runs at LEAD-FINAL via the validator-registry DB rules (`leo_validation_rules` gate='4' / LEAD-FINAL-APPROVAL — verified live), so the executor must not push it again.
- **(B) GATE1 key drift**: the reader/writer keyed on `GATE1_PRD_QUALITY`, but the live PLAN-TO-EXEC gate emits `GATE1_DESIGN_DATABASE` — that key is never produced, so gate1 was never found at GATE4 (undercounting C1). Reader (`creditGatesFromHandoffs`, extracted for testability) + writer (HandoffRecorder mirror) now recognize the live key with back-compat.

## Adversarial review caught a double-run pre-merge
A 22-agent review (with live DB access) found my original draft — which pushed GATE4 into LFA `getRequiredGates` — would have **double-run** the git-shelling + multi-DB-round-trip `validateGate4LeadFinal` (the registry already evaluates it at LFA). My static grep had wrongly concluded the registry path was "dormant" (it's DB-rule-driven, not statically imported). Corrected to a pure PLAN-TO-LEAD removal. Verified independently: 4 active gate='4' registry rules at LFA, 0 at PLAN-TO-LEAD.

## Testing
`tests/unit/gate-pipeline-gate1-placement.test.js` — 13/13 bound to real exported functions: live-key recognition, legacy/mirror back-compat, unrecognized-key + non-accepted-status + duplicate-precedence guards, PLAN-TO-LEAD removal + no-LFA-double-push wiring guards, writer source-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)