### PR TITLE
feat(SD-FDBK-INFRA-SHARED-FLEET-WORKER-001): shared is-fleet-worker/is-fixture-session predicate — consolidate capacity/ranking/identity/sweep

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-FDBK-FIX-CLASSIFY-QUICK-FIX-001",
-  "expectedBranch": "feat/SD-FDBK-FIX-CLASSIFY-QUICK-FIX-001",
-  "createdAt": "2026-06-13T01:51:38.260Z",
+  "sdKey": "SD-FDBK-INFRA-SHARED-FLEET-WORKER-001",
+  "expectedBranch": "feat/SD-FDBK-INFRA-SHARED-FLEET-WORKER-001",
+  "createdAt": "2026-06-13T04:20:25.417Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/coordinator/sd-exclusion.mjs
+++ b/lib/coordinator/sd-exclusion.mjs
@@ -91,6 +91,31 @@ export function isExcludedFromBelt(sd) {
 }
 
 /**
+ * An SD is "started / in-flight" once it has advanced past the initial LEAD draft
+ * (current_phase is set AND not 'LEAD'). current_phase only advances on an ACCEPTED handoff,
+ * so this avoids the rejected-first-handoff false positive that raw handoff-row presence has.
+ * The ranker must NOT surface a started SD as a FRESH dispatch candidate: a mid-build SD —
+ * even one momentarily unclaimed after a session reap — is resumed via the orphan-adopt path
+ * in worker-checkin.cjs (resume_orphan), not re-claimed from the backlog, so ranking it #1
+ * invites a fresh worker to duplicate in-flight work. This consolidates the (a) branch of
+ * worker-checkin's isSdInFlight started-guard (SD-FDBK-FIX-SELF-CLAIM-DEDUP-001) as the shared
+ * classifier (SD-FDBK-INFRA-SHARED-FLEET-WORKER-001, bug d5e59236). FAIL-OPEN: malformed input
+ * returns false (rank normally) so a classifier error never drops a real fresh leaf.
+ *
+ * @param {{current_phase?: string}} sd
+ * @returns {boolean} true when the SD is past LEAD (in-flight) and must not be fresh-ranked
+ */
+export function isStartedSd(sd) {
+  try {
+    if (!sd || typeof sd !== 'object') return false; // fail-open: rank normally
+    const phase = typeof sd.current_phase === 'string' ? sd.current_phase.trim() : '';
+    return phase !== '' && phase !== 'LEAD';
+  } catch {
+    return false; // fail-open: a classifier error ranks the SD normally
+  }
+}
+
+/**
  * Dominant ranking comparator key used by coordinator-backlog-rank.mjs: bare-shell SDs
  * sort AFTER every authored SD (returns >0 when only `a` is bare-shell). Exported and
  * called by the ranker so a test of this function exercises the real demotion logic.

--- a/lib/fleet/session-predicates.mjs
+++ b/lib/fleet/session-predicates.mjs
@@ -76,3 +76,33 @@ export function isFixtureSession(idOrSession) {
 export function isGenuineCountableWorker(session, coordinatorId) {
   return !isFixtureSession(session) && isFleetWorker(session, coordinatorId);
 }
+
+/**
+ * Identity/role-level fleet membership: is this session a dispatchable fleet MEMBER — i.e.
+ * NOT the coordinator, NOT adam (metadata.role==='adam'), NOT non_fleet, NOT a fixture id?
+ *
+ * Unlike isFleetWorker / isGenuineCountableWorker this deliberately does NOT require everClaimed
+ * or an active/idle status. A genuine worker that just FINISHED an SD is released with sd_key AND
+ * claimed_at nulled (lib/session-manager.mjs releaseSD), and v_active_sessions exposes neither
+ * worktree_path nor continuous_sds_completed — so everClaimed would read false and wrongly drop
+ * the very workers that are most "idle and available". A freshly-spawned worker likewise has not
+ * claimed yet. Use THIS predicate for the idle / available-capacity panel where the only thing to
+ * exclude is the role/identity polluters (the witnessed bug 623eb17d: adam/non_fleet counted as
+ * idle workers). FAILS toward "member" on garbage so a quirk never hides a real idle worker.
+ *
+ * @param {object} session - claude_sessions / v_active_sessions row (reads session_id, metadata)
+ * @param {string} coordinatorId - the active coordinator's session_id (excluded)
+ * @returns {boolean}
+ */
+export function isDispatchableFleetMember(session, coordinatorId) {
+  try {
+    if (!session || typeof session !== 'object') return false;
+    if (session.session_id && coordinatorId && session.session_id === coordinatorId) return false;
+    if (session.metadata?.role === 'adam') return false;
+    if (session.metadata?.non_fleet) return false;
+    if (isFixtureSession(session)) return false;
+    return true;
+  } catch {
+    return true; // fail toward "member" — never hide a real idle worker from capacity math
+  }
+}

--- a/lib/fleet/session-predicates.mjs
+++ b/lib/fleet/session-predicates.mjs
@@ -1,0 +1,78 @@
+// SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 — ONE shared session-level classification predicate
+// consumed by every capacity / ranking / sweep path, so they never disagree on "is this a real
+// fleet worker" vs "is this a test/fixture/non_fleet session".
+//
+// Mirrors the isCalibrationEligibleVenture canonical-predicate precedent: divergent ad-hoc
+// inline checks caused four verified-live bugs (capacity pollution from adam/non_fleet sessions,
+// a fixture id restored onto a real SD by the sweep, *-probe-*/QF-TEST- fixtures consuming
+// callsigns, a started SD ranked #1). This module is the single source of truth.
+//
+// isFleetWorker / liveFleetWorkers / everClaimed are RE-EXPORTED verbatim from the existing SoT
+// (lib/fleet/genuine-worker.mjs, SD-FDBK-FIX-COORDINATOR-AUDIT-MJS-001); isFixtureSession is new.
+
+import { everClaimed, isFleetWorker, liveFleetWorkers } from './genuine-worker.mjs';
+export { everClaimed, isFleetWorker, liveFleetWorkers };
+
+/** A real Claude session id is a UUID. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * A legitimate NON-UUID session id shape produced by lib/session-manager.mjs when no birth-cert
+ * UUID is available: `session_<hex8>_<tty>_<pid>`. These are REAL sessions, not fixtures — the
+ * "non-UUID" fixture heuristic must not flag them.
+ */
+const LEGIT_SESSION_SHAPE_RE = /^session_[0-9a-f]{8}_/i;
+
+/**
+ * Known fixture / test / probe session-id markers. Covers the witnessed offenders:
+ *   - the legacy ghost prefixes (drain_test_ / test_execute_ / test-session- / test_session_),
+ *   - test-switch-claim-guards-session (the sweep CLAIM_FIX victim, fd018627),
+ *   - qf-route-probe-A/B and any *-probe-* (assign-fleet-identities miss, 7b59dac8),
+ *   - QF-TEST-* work/session ids.
+ * Anchored or boundary-delimited so a real id containing "test" as a substring of a word
+ * (e.g. a UUID, or "latest") is not falsely flagged.
+ */
+const FIXTURE_SESSION_RE = new RegExp(
+  [
+    '^drain_test_', '^test_execute_', '^test-session-', '^test_session_',
+    '^test-',                 // test-switch-claim-guards-session, test-* fixtures
+    '(^|[-_])probe([-_]|$)',  // *-probe-* (qf-route-probe-A)
+    '^qf-?test',              // QF-TEST-* / qftest-*
+    '(^|[-_])fixture([-_]|$)',
+  ].join('|'),
+  'i',
+);
+
+/**
+ * Is this session a TEST / FIXTURE / synthetic session (never a genuine fleet worker)?
+ * Accepts a session_id string or a claude_sessions row. Returns true when the id carries a
+ * fixture marker, OR is a non-UUID id that is NOT the legitimate `session_<hex>_<tty>_<pid>`
+ * shape (a bare synthetic id). FAIL-CLOSED toward "not a fixture" on empty/garbage input so a
+ * classification quirk never excludes a real worker from capacity/claims.
+ *
+ * @param {string|{session_id?: string, metadata?: object}} idOrSession
+ * @returns {boolean}
+ */
+export function isFixtureSession(idOrSession) {
+  try {
+    const id = typeof idOrSession === 'string' ? idOrSession : idOrSession?.session_id;
+    if (typeof id !== 'string' || !id) return false; // unknown -> treat as real (never false-exclude)
+    if (FIXTURE_SESSION_RE.test(id)) return true;
+    // A real id is either a UUID or the legit session_<hex>_<tty>_<pid> shape; anything else is synthetic.
+    if (UUID_RE.test(id) || LEGIT_SESSION_SHAPE_RE.test(id)) return false;
+    return true;
+  } catch {
+    return false; // fail toward "real" — never let a quirk drop a genuine worker
+  }
+}
+
+/**
+ * Convenience: a session is a dispatchable/capacity-countable genuine worker only if it is a
+ * fleet worker AND not a fixture. (isFleetWorker already excludes coordinator/adam/non_fleet and
+ * requires everClaimed; this layers the fixture-id guard for the sweep/ranking paths.)
+ * @param {object} session - claude_sessions row
+ * @param {string} coordinatorId
+ */
+export function isGenuineCountableWorker(session, coordinatorId) {
+  return !isFixtureSession(session) && isFleetWorker(session, coordinatorId);
+}

--- a/lib/fleet/session-predicates.mjs
+++ b/lib/fleet/session-predicates.mjs
@@ -13,16 +13,6 @@
 import { everClaimed, isFleetWorker, liveFleetWorkers } from './genuine-worker.mjs';
 export { everClaimed, isFleetWorker, liveFleetWorkers };
 
-/** A real Claude session id is a UUID. */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * A legitimate NON-UUID session id shape produced by lib/session-manager.mjs when no birth-cert
- * UUID is available: `session_<hex8>_<tty>_<pid>`. These are REAL sessions, not fixtures — the
- * "non-UUID" fixture heuristic must not flag them.
- */
-const LEGIT_SESSION_SHAPE_RE = /^session_[0-9a-f]{8}_/i;
-
 /**
  * Known fixture / test / probe session-id markers. Covers the witnessed offenders:
  *   - the legacy ghost prefixes (drain_test_ / test_execute_ / test-session- / test_session_),
@@ -44,11 +34,17 @@ const FIXTURE_SESSION_RE = new RegExp(
 );
 
 /**
- * Is this session a TEST / FIXTURE / synthetic session (never a genuine fleet worker)?
- * Accepts a session_id string or a claude_sessions row. Returns true when the id carries a
- * fixture marker, OR is a non-UUID id that is NOT the legitimate `session_<hex>_<tty>_<pid>`
- * shape (a bare synthetic id). FAIL-CLOSED toward "not a fixture" on empty/garbage input so a
- * classification quirk never excludes a real worker from capacity/claims.
+ * Is this session a TEST / FIXTURE session (never a genuine fleet worker)? Accepts a session_id
+ * string or a claude_sessions row. Returns true ONLY when the id carries an EXPLICIT fixture marker
+ * (FIXTURE_SESSION_RE).
+ *
+ * An unknown / non-UUID id shape is NOT treated as a fixture. An earlier "synthetic catch-all"
+ * branch (return true for any id that was neither a UUID nor `session_<hex8>_…`) over-released
+ * GENUINE claim-holding workers in the sweep CLAIM_FIX path: the codebase mints many legitimate
+ * non-UUID worker/session ids (session_<epoch>, session_<epoch>_<pid>, leo-assist-<epoch>,
+ * coordinator-<uuid>, qf-<n>-<epoch>, bare ids) — verified live across all five callsigns
+ * (adversarial review, SD-FDBK-INFRA-SHARED-FLEET-WORKER-001). FAIL TOWARD "not a fixture" on every
+ * unknown/empty/garbage input so a classification quirk never excludes or releases a real worker.
  *
  * @param {string|{session_id?: string, metadata?: object}} idOrSession
  * @returns {boolean}
@@ -57,10 +53,7 @@ export function isFixtureSession(idOrSession) {
   try {
     const id = typeof idOrSession === 'string' ? idOrSession : idOrSession?.session_id;
     if (typeof id !== 'string' || !id) return false; // unknown -> treat as real (never false-exclude)
-    if (FIXTURE_SESSION_RE.test(id)) return true;
-    // A real id is either a UUID or the legit session_<hex>_<tty>_<pid> shape; anything else is synthetic.
-    if (UUID_RE.test(id) || LEGIT_SESSION_SHAPE_RE.test(id)) return false;
-    return true;
+    return FIXTURE_SESSION_RE.test(id);              // POSITIVE markers ONLY — no synthetic catch-all
   } catch {
     return false; // fail toward "real" — never let a quirk drop a genuine worker
   }

--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -53,6 +53,11 @@ function filterOutCoordinators(rows) {
 // `claimedSessionIds` — Set of session_ids that currently hold an SD claim (kept
 // DB-free so this stays a pure, unit-testable function). Pass an empty Set to rely
 // on per-row signals (sd_key / fleet_identity) only.
+// SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: DEFENSIVE FALLBACK ONLY. The canonical fixture check is
+// the shared lib/fleet/session-predicates.mjs isFixtureSession (a strict superset that also catches
+// *-probe-* and QF-TEST-* — bug 7b59dac8, where qf-route-probe-A/B consumed callsign Charlie).
+// main() dynamic-imports that predicate and injects it into filterOutGhostSessions; this local list
+// only runs if the function is called WITHOUT an injected predicate (never in production).
 const GHOST_SESSION_ID_PREFIXES = ['drain_test_', 'test_execute_', 'test-session-', 'test_session_'];
 
 function isTestSessionId(sessionId) {
@@ -60,12 +65,14 @@ function isTestSessionId(sessionId) {
   return GHOST_SESSION_ID_PREFIXES.some(p => sessionId.startsWith(p));
 }
 
-function filterOutGhostSessions(rows, claimedSessionIds = new Set()) {
+function filterOutGhostSessions(rows, claimedSessionIds = new Set(), isFixture = isTestSessionId) {
   const claimed = claimedSessionIds instanceof Set ? claimedSessionIds : new Set(claimedSessionIds || []);
+  const fixtureCheck = typeof isFixture === 'function' ? isFixture : isTestSessionId;
   return (rows || []).filter(w => {
     if (!w) return false;
-    // Genuine test/ghost session_ids never get a callsign, even if otherwise active.
-    if (isTestSessionId(w.session_id)) return false;
+    // Fixture/test/probe session_ids never get a callsign, even if otherwise active. The shared
+    // isFixtureSession (injected by main) catches *-probe-*/QF-TEST-* the local prefix list missed.
+    if (fixtureCheck(w.session_id)) return false;
     // Currently claiming an SD → real worker.
     if (w.sd_key) return true;
     // Between SDs but in the canonical claim cohort → real worker, momentarily idle.
@@ -183,7 +190,10 @@ async function main() {
   const claimedSessionIds = new Set(
     (rawWorkers || []).filter(w => w && w.sd_key).map(w => w.session_id)
   );
-  const workers = filterOutGhostSessions(nonCoordinators, claimedSessionIds);
+  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug 7b59dac8): inject the SHARED fixture predicate so
+  // *-probe-* / QF-TEST-* fixtures never consume a callsign. Dynamic import: .cjs reading the .mjs SoT.
+  const { isFixtureSession } = await import('../lib/fleet/session-predicates.mjs');
+  const workers = filterOutGhostSessions(nonCoordinators, claimedSessionIds, isFixtureSession);
 
   if (!workers || workers.length === 0) {
     console.log('No active workers found.');

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -30,7 +30,7 @@ import { createClient } from '@supabase/supabase-js';
 // demotes bare-shell stubs. FIXTURE_RE catches epoch-stamped TEST-E2E keys; the
 // bare-shell demotion uses the shared bareShellLastCompare so the test suite
 // exercises the real comparator, not a re-implementation.
-import { isFixtureSd, isBareShell, bareShellLastCompare } from '../lib/coordinator/sd-exclusion.mjs';
+import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd } from '../lib/coordinator/sd-exclusion.mjs';
 
 const DRY = process.argv.includes('--dry-run');
 const PRIORITY_W = { critical: 3, high: 2, medium: 1, med: 1, low: 0 };
@@ -49,7 +49,8 @@ const sb = createClient(
 async function main() {
   const { data: sds, error } = await sb.from('strategic_directives_v2')
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + title, description to classify bare-shell stubs.
-    .select('sd_key, title, description, status, sd_type, priority, created_at, claiming_session_id, dependencies, metadata')
+    // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + current_phase for the in-flight (started) guard.
+    .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata')
     .not('status', 'in', '("completed","cancelled","deferred")');
   if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return; }
 
@@ -88,9 +89,19 @@ async function main() {
   // ── claimable leaves ──
   const claimable = [];
   let fixtureSkips = 0;
+  let inFlightSkips = 0;
   for (const d of (sds || [])) {
     if (d.claiming_session_id) continue;
     if (d.sd_type === 'orchestrator') continue;          // parents are never dispatched
+    // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug d5e59236): a started/mid-build SD past the
+    // initial LEAD draft (current_phase != 'LEAD') must NOT be ranked for FRESH dispatch even
+    // when momentarily unclaimed (e.g. reaped mid-build) — it is resumed via worker-checkin's
+    // resume_orphan path, not re-claimed from the backlog. Mirrors isSdInFlight's (a) branch.
+    if (isStartedSd(d)) {                                 // in-flight SD is resumed, never fresh-ranked
+      inFlightSkips++;
+      console.log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
+      continue;
+    }
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: fixtures (epoch-stamped TEST-E2E keys or
     // metadata.is_fixture) are never ranked — they get no dispatch_rank at all.
     if (isFixtureSd(d.sd_key, d.metadata)) {             // test fixtures are never ranked
@@ -104,6 +115,7 @@ async function main() {
     claimable.push(d);
   }
   if (fixtureSkips) console.log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
+  if (inFlightSkips) console.log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
   // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs (empty/title-only description)
   // cannot pass LEAD-TO-PLAN; log them so the demote-to-last below is auditable. The sort
   // below (bareShellLastCompare as the dominant key) is what actually places them last.

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -128,7 +128,9 @@ async function loadData() {
       .order('heartbeat_age_seconds', { ascending: true }),
     supabase
       .from('v_active_sessions')
-      .select('session_id, sd_key, computed_status, tty, heartbeat_age_seconds, heartbeat_age_human')
+      // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + metadata so the idle filter can apply
+      // isDispatchableFleetMember (excludes coordinator/adam/non_fleet/fixture).
+      .select('session_id, sd_key, computed_status, metadata, tty, heartbeat_age_seconds, heartbeat_age_human')
       .order('heartbeat_age_seconds', { ascending: true }),
     supabase
       .from('strategic_directives_v2')
@@ -184,6 +186,17 @@ async function loadData() {
   const workable = workRes.data || [];
   const coordMessages = coordRes.data || [];
   const rawSessions = rawSessRes.data || [];
+
+  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug 623eb17d): the idle "available worker" list (and the
+  // belt-countdown capacity math fed from it) must exclude role/identity polluters. Load the shared
+  // predicate + active coordinator id once so the idle filter below drops adam/non_fleet/coordinator/
+  // fixture sessions. isDispatchableFleetMember (NOT isGenuineCountableWorker) is used on purpose: a
+  // just-finished worker is released with claimed_at nulled, so an everClaimed-based predicate would
+  // under-count real idle capacity. Dynamic import: this is a .cjs reading an .mjs SoT.
+  const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+  const { isDispatchableFleetMember } = await import('../lib/fleet/session-predicates.mjs');
+  let _dashCoordinatorId = null;
+  try { _dashCoordinatorId = await getActiveCoordinatorId(supabase); } catch { _dashCoordinatorId = null; }
 
   const claimedSdIds = new Set(sessions.map(s => s.sd_key));
   // Cross-reference heartbeat age with PID marker liveness:
@@ -245,7 +258,14 @@ async function loadData() {
     !hasExpectedSilence(s)
   );
   const DEAD_THRESHOLD = STALE_THRESHOLD * 3; // 15min
-  const idleSessions = allSessions.filter(s => !s.sd_key && s.heartbeat_age_seconds < DEAD_THRESHOLD);
+  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: only dispatchable fleet MEMBERS count as idle/available —
+  // exclude adam/non_fleet/coordinator/fixture (isDispatchableFleetMember fails toward "member" on
+  // garbage, so a classification quirk never hides a true idle worker).
+  const idleSessions = allSessions.filter(s =>
+    !s.sd_key &&
+    s.heartbeat_age_seconds < DEAD_THRESHOLD &&
+    isDispatchableFleetMember(s, _dashCoordinatorId)
+  );
 
   const completedChildren = children.filter(c => c.status === 'completed').length;
   const totalChildren = children.length;

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1521,6 +1521,8 @@ async function main() {
   }
 
   // Also check: sessions with sd_id but SD's claiming_session_id doesn't match (broken claim)
+  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: shared fixture-session predicate (.cjs → .mjs SoT).
+  const { isFixtureSession } = await import('../lib/fleet/session-predicates.mjs');
   for (const s of classified.filter(c => c.status === 'ACTIVE' && c.sd_key)) {
     const { data: sd } = await supabase
       .from('strategic_directives_v2')
@@ -1529,6 +1531,38 @@ async function main() {
       .single();
 
     if (!sd) continue;
+
+    // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug fd018627): a FIXTURE/test session id (e.g.
+    // test-switch-claim-guards-session, replayed from claim_history) must NEVER drive a CLAIM_FIX
+    // re-assert onto a real SD. Bilaterally release the fixture's stale sd_key; if the SD itself
+    // still points at the fixture, clear that too so it becomes claimable. isFixtureSession FAILS
+    // TOWARD "not a fixture" (UUIDs + the legit session_<hex>_<tty>_<pid> shape return false), so a
+    // real worker is never wrongly released. Guards ALL downstream branches (terminal / eligibility
+    // / re-assert) in one place.
+    if (isFixtureSession(s.session_id)) {
+      await supabase
+        .from('claude_sessions')
+        .update({
+          sd_key: null,
+          status: s.status === 'ACTIVE' ? 'idle' : 'released',
+          released_at: now.toISOString(),
+          released_reason: 'SWEEP_FIXTURE_SESSION_CLAIM_FIX',
+          worktree_path: null,
+          worktree_branch: null,
+          current_branch: null,
+        })
+        .eq('session_id', s.session_id)
+        .eq('sd_key', s.sd_key); // race guard: only clear if still pointing at this SD
+      if (sd.claiming_session_id === s.session_id) {
+        await supabase
+          .from('strategic_directives_v2')
+          .update({ claiming_session_id: null, is_working_on: false })
+          .eq('sd_key', s.sd_key)
+          .eq('claiming_session_id', s.session_id); // race guard: only clear if still the fixture
+      }
+      actions.push('CLAIM_FIX: released FIXTURE session ' + s.session_id.substring(0, 20) + ' (never re-assert onto ' + s.sd_key + ')');
+      continue;
+    }
 
     // QF-20260525-211 (B1): never re-assert a claim on a terminal SD. FIX #2 above cleared
     // claiming_session_id on completed/cancelled SDs; without this guard CLAIM_FIX would

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -758,8 +758,15 @@ async function main() {
   }
 
   // 3. Detect conflicts (multiple sessions claiming same SD)
+  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (adversarial review): exclude FIXTURE sessions from conflict
+  // keeper selection. The conflict loop picks the freshest-heartbeat session as keeper and EVICTS the
+  // rest; without this, a fixture sharing an sd_key with a real worker (the fd018627 condition) could
+  // win keeper and bounce the real worker BEFORE the CLAIM_FIX fixture guard (further below) releases
+  // the fixture. Fixtures never participate in keeper selection; they are bilaterally released later.
+  const { isFixtureSession } = await import('../lib/fleet/session-predicates.mjs');
   const bySD = {};
   classified.forEach(s => {
+    if (isFixtureSession(s.session_id)) return; // fixture: never a conflict keeper/evictor
     if (!bySD[s.sd_key]) bySD[s.sd_key] = [];
     bySD[s.sd_key].push(s);
   });
@@ -1521,8 +1528,7 @@ async function main() {
   }
 
   // Also check: sessions with sd_id but SD's claiming_session_id doesn't match (broken claim)
-  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: shared fixture-session predicate (.cjs → .mjs SoT).
-  const { isFixtureSession } = await import('../lib/fleet/session-predicates.mjs');
+  // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: isFixtureSession is imported once above (conflict build).
   for (const s of classified.filter(c => c.status === 'ACTIVE' && c.sd_key)) {
     const { data: sd } = await supabase
       .from('strategic_directives_v2')

--- a/tests/unit/assign-fleet-identities-coordinator-filter.test.js
+++ b/tests/unit/assign-fleet-identities-coordinator-filter.test.js
@@ -7,6 +7,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isFixtureSession } from '../../lib/fleet/session-predicates.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -16,6 +20,9 @@ const {
   dedupeAssignedCallsigns,
   reserveParkedIdentities
 } = require('../../scripts/assign-fleet-identities.cjs');
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ASSIGNER = resolve(__dirname, '../../scripts/assign-fleet-identities.cjs');
 
 describe('filterOutCoordinators (QF-20260508-648)', () => {
   it('excludes a coordinator row (metadata.is_coordinator=true)', () => {
@@ -285,5 +292,50 @@ describe('reserveParkedIdentities (SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001)', 
     reserveParkedIdentities(usedCallsigns, usedColors, [sess('p', 'Golf', 'green')], new Set());
     expect([...usedCallsigns].sort()).toEqual(['Alpha', 'Golf']);
     expect([...usedColors].sort()).toEqual(['green', 'red']);
+  });
+});
+
+// SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug 7b59dac8): the production path injects the SHARED
+// isFixtureSession into filterOutGhostSessions so *-probe-* / QF-TEST-* fixtures never consume a
+// callsign — the gap the local 4-prefix list missed.
+describe('filterOutGhostSessions + shared isFixtureSession (SD-FDBK-INFRA-SHARED-FLEET-WORKER-001)', () => {
+  it('the LOCAL prefix fallback lets a CLAIMING *-probe-* survive (the witnessed bug)', () => {
+    // The bug: a probe that holds a claim (sd_key) or a prior fleet_identity SURVIVES the local
+    // 4-prefix filter (which does not match *-probe-*/QF-TEST-) and consumes a callsign (Charlie).
+    const rows = [
+      { session_id: 'qf-route-probe-A', sd_key: 'SD-Z' },                            // claiming probe
+      { session_id: 'QF-TEST-001', metadata: { fleet_identity: { callsign: 'Echo' } } }, // pre-assigned probe
+    ];
+    expect(filterOutGhostSessions(rows).map(r => r.session_id))
+      .toEqual(['qf-route-probe-A', 'QF-TEST-001']); // both wrongly survive under the local fallback
+  });
+
+  it('injecting the shared isFixtureSession DROPS the claiming/pre-assigned probe + legacy ghosts', () => {
+    const rows = [
+      { session_id: 'qf-route-probe-A', sd_key: 'SD-Z' },                            // would-survive probe
+      { session_id: 'qf-route-probe-B' },
+      { session_id: 'QF-TEST-001', metadata: { fleet_identity: { callsign: 'Echo' } } },
+      { session_id: 'drain_test_legacy' },
+    ];
+    const out = filterOutGhostSessions(rows, new Set(), isFixtureSession);
+    expect(out).toEqual([]); // the shared fixture check fires FIRST, before the claim/identity rescue
+  });
+
+  it('a REAL claiming worker (UUID/session_ id) is NEVER dropped by the shared predicate', () => {
+    const rows = [
+      { session_id: '65d08634-9ded-4c8f-96e8-2f4cfd991a2a', sd_key: 'SD-X' }, // claiming UUID worker
+      { session_id: 'session_a1b2c3d4_tty1_12345', sd_key: 'SD-Y' },          // legit session_ shape
+      { session_id: 'qf-route-probe-A' },                                      // fixture, no claim
+    ];
+    const out = filterOutGhostSessions(rows, new Set(), isFixtureSession).map(r => r.session_id);
+    expect(out).toContain('65d08634-9ded-4c8f-96e8-2f4cfd991a2a');
+    expect(out).toContain('session_a1b2c3d4_tty1_12345');
+    expect(out).not.toContain('qf-route-probe-A');
+  });
+
+  it('the assigner main() injects the shared predicate (call-site guard)', () => {
+    const src = readFileSync(ASSIGNER, 'utf8');
+    expect(src).toMatch(/from '\.\.\/lib\/fleet\/session-predicates\.mjs'|session-predicates\.mjs/);
+    expect(src).toContain('filterOutGhostSessions(nonCoordinators, claimedSessionIds, isFixtureSession)');
   });
 });

--- a/tests/unit/coordinator-sd-exclusion.test.js
+++ b/tests/unit/coordinator-sd-exclusion.test.js
@@ -20,6 +20,7 @@ import {
   isBareShell,
   isExcludedFromBelt,
   bareShellLastCompare,
+  isStartedSd,
   FIXTURE_RE,
 } from '../../lib/coordinator/sd-exclusion.mjs';
 
@@ -161,6 +162,31 @@ describe('isExcludedFromBelt — the REAL forecaster belt predicate', () => {
   });
 });
 
+// SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug d5e59236): in-flight (started) guard.
+describe('isStartedSd — the REAL ranker in-flight guard', () => {
+  it('flags an SD past the initial LEAD draft as started (must not be fresh-ranked)', () => {
+    expect(isStartedSd({ current_phase: 'PLAN_PRD' })).toBe(true);
+    expect(isStartedSd({ current_phase: 'EXEC' })).toBe(true);
+    expect(isStartedSd({ current_phase: 'PLAN_VERIFICATION' })).toBe(true);
+    expect(isStartedSd({ current_phase: 'LEAD_FINAL' })).toBe(true);
+    expect(isStartedSd({ current_phase: ' EXEC ' })).toBe(true); // trimmed
+  });
+
+  it('does NOT flag a fresh LEAD-draft (or unset phase) SD — these stay fresh-rankable', () => {
+    expect(isStartedSd({ current_phase: 'LEAD' })).toBe(false);
+    expect(isStartedSd({ current_phase: '' })).toBe(false);
+    expect(isStartedSd({ current_phase: '   ' })).toBe(false);
+    expect(isStartedSd({})).toBe(false); // phase column absent → treat as fresh
+  });
+
+  it('fails OPEN on garbage input (never drops a real fresh leaf)', () => {
+    expect(isStartedSd(null)).toBe(false);
+    expect(isStartedSd(undefined)).toBe(false);
+    expect(isStartedSd('LEAD')).toBe(false);
+    expect(isStartedSd({ current_phase: 42 })).toBe(false);
+  });
+});
+
 describe('production wiring guards (catch call-site deletion)', () => {
   const rankerSrc = readFileSync(RANKER, 'utf8');
   const forecasterSrc = readFileSync(FORECASTER, 'utf8');
@@ -169,6 +195,11 @@ describe('production wiring guards (catch call-site deletion)', () => {
     expect(rankerSrc).toMatch(/from '\.\.\/lib\/coordinator\/sd-exclusion\.mjs'/);
     expect(rankerSrc).toContain('isFixtureSd(d.sd_key, d.metadata)');
     expect(rankerSrc).toContain('bareShellLastCompare(a, b)');
+  });
+
+  it('the ranker imports and applies the in-flight (started) guard', () => {
+    expect(rankerSrc).toContain('isStartedSd');
+    expect(rankerSrc).toContain('isStartedSd(d)');
   });
 
   it('the forecaster imports and applies the belt exclusion', () => {
@@ -180,5 +211,9 @@ describe('production wiring guards (catch call-site deletion)', () => {
     // bare-shell needs title+description; is_fixture needs metadata.
     expect(rankerSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
     expect(forecasterSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
+  });
+
+  it('the ranker SELECTs current_phase for the in-flight guard', () => {
+    expect(rankerSrc).toMatch(/select\([^)]*current_phase/s);
   });
 });

--- a/tests/unit/session-predicates.test.js
+++ b/tests/unit/session-predicates.test.js
@@ -4,13 +4,20 @@
  * boundary, and confirms the genuine-worker SoT is re-exported (single source of truth).
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   isFixtureSession,
   isFleetWorker,
   liveFleetWorkers,
   everClaimed,
   isGenuineCountableWorker,
+  isDispatchableFleetMember,
 } from '../../lib/fleet/session-predicates.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DASHBOARD = resolve(__dirname, '../../scripts/fleet-dashboard.cjs');
 
 describe('isFixtureSession — fixture/probe/test id detection', () => {
   it('flags the witnessed fixture ids (the four cited bugs)', () => {
@@ -77,5 +84,49 @@ describe('genuine-worker SoT re-export (single source of truth)', () => {
     // adam/non_fleet excluded by isFleetWorker even with a real id
     const adam = { session_id: 'aaaaaaaa-0000-4000-8000-000000000000', status: 'active', metadata: { role: 'adam' }, sd_key: 'SD-Z' };
     expect(isGenuineCountableWorker(adam, coordId)).toBe(false);
+  });
+});
+
+describe('isDispatchableFleetMember — idle/capacity panel role guard (no everClaimed)', () => {
+  const coordId = 'cccccccc-0000-4000-8000-000000000000';
+
+  it('counts a JUST-FINISHED worker (released: sd_key+claimed_at nulled) as a member', () => {
+    // This is the regression isGenuineCountableWorker would cause: everClaimed=false here.
+    const justFinished = { session_id: '65d08634-9ded-4c8f-96e8-2f4cfd991a2a', status: 'idle', metadata: {}, sd_key: null, claimed_at: null };
+    expect(isDispatchableFleetMember(justFinished, coordId)).toBe(true);
+    // contrast: the everClaimed-based predicate drops it
+    expect(isGenuineCountableWorker(justFinished, coordId)).toBe(false);
+  });
+
+  it('counts a freshly-spawned not-yet-claimed worker as a member', () => {
+    const fresh = { session_id: 'b887c648-e65a-447f-a46c-bb672f42b089', status: 'active', metadata: {}, sd_key: null };
+    expect(isDispatchableFleetMember(fresh, coordId)).toBe(true);
+  });
+
+  it('EXCLUDES the witnessed polluters: coordinator, adam, non_fleet, fixture', () => {
+    expect(isDispatchableFleetMember({ session_id: coordId, metadata: {} }, coordId)).toBe(false);
+    expect(isDispatchableFleetMember({ session_id: 'aaaaaaaa-0000-4000-8000-000000000000', metadata: { role: 'adam' } }, coordId)).toBe(false);
+    expect(isDispatchableFleetMember({ session_id: 'dddddddd-0000-4000-8000-000000000000', metadata: { non_fleet: true } }, coordId)).toBe(false);
+    expect(isDispatchableFleetMember({ session_id: 'qf-route-probe-A', metadata: {} }, coordId)).toBe(false);
+  });
+
+  it('fails toward "member" on garbage but excludes a null session', () => {
+    expect(isDispatchableFleetMember(null, coordId)).toBe(false);
+    expect(isDispatchableFleetMember(undefined, coordId)).toBe(false);
+    expect(isDispatchableFleetMember({}, coordId)).toBe(true);   // unknown role → counted (same as legacy)
+  });
+});
+
+describe('production wiring guard (catch idle-filter call-site deletion)', () => {
+  const dashSrc = readFileSync(DASHBOARD, 'utf8');
+
+  it('the dashboard imports + applies isDispatchableFleetMember on the idle filter', () => {
+    expect(dashSrc).toMatch(/from '\.\.\/lib\/fleet\/session-predicates\.mjs'|session-predicates\.mjs/);
+    expect(dashSrc).toContain('isDispatchableFleetMember(s, _dashCoordinatorId)');
+  });
+
+  it('the dashboard SELECTs metadata so the role guard can read it', () => {
+    // the allSessions query (idle source) must include metadata for the role/non_fleet checks
+    expect(dashSrc).toMatch(/select\([^)]*metadata/s);
   });
 });

--- a/tests/unit/session-predicates.test.js
+++ b/tests/unit/session-predicates.test.js
@@ -46,8 +46,17 @@ describe('isFixtureSession — fixture/probe/test id detection', () => {
     expect(isFixtureSession('session_a1b2c3d4_tty1_12345')).toBe(false);
   });
 
-  it('flags a bare non-UUID synthetic id', () => {
-    expect(isFixtureSession('some-random-synthetic-id')).toBe(true);
+  it('does NOT flag an unknown non-marker id as a fixture (over-release fix: positive markers ONLY)', () => {
+    // Adversarial review (SD-FDBK-INFRA-SHARED-FLEET-WORKER-001) proved the old "synthetic catch-all"
+    // over-released GENUINE workers whose ids are legit non-UUID shapes. Only explicit fixture markers
+    // (FIXTURE_SESSION_RE) count; every other shape is treated as REAL.
+    expect(isFixtureSession('some-random-synthetic-id')).toBe(false);
+    expect(isFixtureSession('session_1776019751948')).toBe(false);        // epoch worker id (live: Bravo)
+    expect(isFixtureSession('session_1774443726642_4821')).toBe(false);   // epoch_pid worker id
+    expect(isFixtureSession('leo-assist-1778504351303')).toBe(false);     // /leo assist worker id (live: Echo)
+    expect(isFixtureSession('coordinator-65d08634-9ded-4c8f-96e8-2f4cfd991a2a')).toBe(false);
+    expect(isFixtureSession('qf-876-1778500000000')).toBe(false);         // qf-<n>-<epoch> (NOT qf-test)
+    expect(isFixtureSession('51362')).toBe(false);                        // bare numeric id
   });
 
   it('does not flag a real UUID, and the probe/test markers are delimiter-anchored (no mid-word match)', () => {

--- a/tests/unit/session-predicates.test.js
+++ b/tests/unit/session-predicates.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 — shared session classification predicate.
+ * Pins isFixtureSession against the witnessed offenders + the legit-session-shape false-positive
+ * boundary, and confirms the genuine-worker SoT is re-exported (single source of truth).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isFixtureSession,
+  isFleetWorker,
+  liveFleetWorkers,
+  everClaimed,
+  isGenuineCountableWorker,
+} from '../../lib/fleet/session-predicates.mjs';
+
+describe('isFixtureSession — fixture/probe/test id detection', () => {
+  it('flags the witnessed fixture ids (the four cited bugs)', () => {
+    expect(isFixtureSession('test-switch-claim-guards-session')).toBe(true); // sweep CLAIM_FIX victim (fd018627)
+    expect(isFixtureSession('qf-route-probe-A')).toBe(true);                 // callsign-stealing probe (7b59dac8)
+    expect(isFixtureSession('qf-route-probe-B')).toBe(true);
+    expect(isFixtureSession('QF-TEST-001')).toBe(true);
+    expect(isFixtureSession('drain_test_abc')).toBe(true);                   // legacy ghost prefixes
+    expect(isFixtureSession('test_execute_x')).toBe(true);
+    expect(isFixtureSession('test-session-1')).toBe(true);
+    expect(isFixtureSession('test_session_2')).toBe(true);
+  });
+
+  it('accepts a session row object (reads .session_id)', () => {
+    expect(isFixtureSession({ session_id: 'qf-route-probe-A' })).toBe(true);
+    expect(isFixtureSession({ session_id: '65d08634-9ded-4c8f-96e8-2f4cfd991a2a' })).toBe(false);
+  });
+
+  it('does NOT flag a real UUID session', () => {
+    expect(isFixtureSession('65d08634-9ded-4c8f-96e8-2f4cfd991a2a')).toBe(false);
+    expect(isFixtureSession('b887c648-e65a-447f-a46c-bb672f42b089')).toBe(false);
+  });
+
+  it('does NOT flag the legitimate session_<hex>_<tty>_<pid> shape (false-positive boundary)', () => {
+    // lib/session-manager.mjs produces these for real sessions without a birth-cert UUID.
+    expect(isFixtureSession('session_a1b2c3d4_tty1_12345')).toBe(false);
+  });
+
+  it('flags a bare non-UUID synthetic id', () => {
+    expect(isFixtureSession('some-random-synthetic-id')).toBe(true);
+  });
+
+  it('does not flag a real UUID, and the probe/test markers are delimiter-anchored (no mid-word match)', () => {
+    // A valid hex UUID is never a fixture even if a hex run coincidentally reads like a word.
+    expect(isFixtureSession('deadbeef-0000-4000-8000-cabfaceb00de')).toBe(false);
+    // 'probe' only matches at a (^|[-_]) boundary: a session id embedding 'probe' mid-token,
+    // when it is otherwise the legit session_<hex> shape, is not a fixture.
+    expect(isFixtureSession('session_deadbeef_probeless_99')).toBe(false);
+  });
+
+  it('fails toward "not a fixture" on empty/garbage input (never false-excludes a real worker)', () => {
+    expect(isFixtureSession(null)).toBe(false);
+    expect(isFixtureSession(undefined)).toBe(false);
+    expect(isFixtureSession('')).toBe(false);
+    expect(isFixtureSession(12345)).toBe(false);
+    expect(isFixtureSession({})).toBe(false);
+  });
+});
+
+describe('genuine-worker SoT re-export (single source of truth)', () => {
+  it('re-exports isFleetWorker / liveFleetWorkers / everClaimed', () => {
+    expect(typeof isFleetWorker).toBe('function');
+    expect(typeof liveFleetWorkers).toBe('function');
+    expect(typeof everClaimed).toBe('function');
+  });
+
+  it('isGenuineCountableWorker = fleet worker AND not a fixture', () => {
+    const coordId = 'coord-uuid';
+    const realWorker = { session_id: '65d08634-9ded-4c8f-96e8-2f4cfd991a2a', status: 'active', metadata: {}, sd_key: 'SD-X' };
+    expect(isGenuineCountableWorker(realWorker, coordId)).toBe(true);
+    // a fixture-id session that otherwise looks like a worker is excluded
+    const fixtureWorker = { session_id: 'qf-route-probe-A', status: 'active', metadata: {}, sd_key: 'SD-Y' };
+    expect(isGenuineCountableWorker(fixtureWorker, coordId)).toBe(false);
+    // adam/non_fleet excluded by isFleetWorker even with a real id
+    const adam = { session_id: 'aaaaaaaa-0000-4000-8000-000000000000', status: 'active', metadata: { role: 'adam' }, sd_key: 'SD-Z' };
+    expect(isGenuineCountableWorker(adam, coordId)).toBe(false);
+  });
+});

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -40,6 +40,37 @@ describe('QF-20260525-211 (B1): CLAIM_FIX terminal-status guard', () => {
   });
 });
 
+describe('SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: CLAIM_FIX fixture-session guard (bug fd018627)', () => {
+  it('imports the SHARED isFixtureSession predicate (SoT, not a local re-impl)', () => {
+    expect(src).toMatch(/await import\(['"]\.\.\/lib\/fleet\/session-predicates\.mjs['"]\)/);
+    expect(src).toContain('isFixtureSession');
+  });
+
+  it('guards the broken-claim loop on isFixtureSession(s.session_id)', () => {
+    expect(src).toMatch(/if\s*\(\s*isFixtureSession\(s\.session_id\)\s*\)/);
+  });
+
+  it('bilaterally releases the fixture session — clears sd_key with a race guard', () => {
+    const idx = src.indexOf("released_reason: 'SWEEP_FIXTURE_SESSION_CLAIM_FIX'");
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx - 400, idx + 600);
+    expect(block).toMatch(/sd_key:\s*null/);
+    expect(block).toMatch(/\.eq\(['"]sd_key['"],\s*s\.sd_key\)/); // race guard on the session clear
+  });
+
+  it('clears the SD claim ONLY if it still points at the fixture (race guard), then continues', () => {
+    const idx = src.indexOf('SWEEP_FIXTURE_SESSION_CLAIM_FIX');
+    const block = src.slice(idx, idx + 800);
+    expect(block).toMatch(/claiming_session_id:\s*null/);
+    expect(block).toMatch(/\.eq\(['"]claiming_session_id['"],\s*s\.session_id\)/); // race guard on the SD clear
+    expect(block).toMatch(/continue;/);
+  });
+
+  it('the fixture guard PRECEDES the terminal-status guard (covers all downstream branches)', () => {
+    expect(src.indexOf('SWEEP_FIXTURE_SESSION_CLAIM_FIX')).toBeLessThan(src.indexOf('SWEEP_SD_TERMINAL_CLAIM_FIX'));
+  });
+});
+
 describe('QF-20260525-211 (B2): workingOnCompleted covers cancelled', () => {
   it('workingOnCompleted filter matches completed OR cancelled', () => {
     const idx = src.indexOf('const workingOnCompleted');

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -69,6 +69,22 @@ describe('SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: CLAIM_FIX fixture-session guard
   it('the fixture guard PRECEDES the terminal-status guard (covers all downstream branches)', () => {
     expect(src.indexOf('SWEEP_FIXTURE_SESSION_CLAIM_FIX')).toBeLessThan(src.indexOf('SWEEP_SD_TERMINAL_CLAIM_FIX'));
   });
+
+  // Adversarial-review fix (Defect 2): a fixture must not win conflict-keeper selection and evict a
+  // real worker before the CLAIM_FIX fixture guard runs ~166 lines later.
+  it('excludes fixtures from the conflict bySD build (keeper selection)', () => {
+    const idx = src.indexOf('const bySD = {}');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 260);
+    expect(block).toMatch(/if\s*\(\s*isFixtureSession\(s\.session_id\)\s*\)\s*return;/);
+  });
+
+  it('imports isFixtureSession ABOVE the conflict build (not only in the broken-claim loop)', () => {
+    const importIdx = src.indexOf("import('../lib/fleet/session-predicates.mjs')");
+    const conflictIdx = src.indexOf('const bySD = {}');
+    expect(importIdx).toBeGreaterThan(0);
+    expect(importIdx).toBeLessThan(conflictIdx); // hoisted before conflict detection
+  });
 });
 
 describe('QF-20260525-211 (B2): workingOnCompleted covers cancelled', () => {


### PR DESCRIPTION
## Summary
Consolidates ONE shared session-classification predicate set consumed by all four fleet dispatch/capacity/identity/sweep paths, so they can never again disagree on "real fleet worker vs test/fixture session" (mirrors the isCalibrationEligibleVenture canonical-predicate precedent). Closes 4 verified-live bugs.

**Shared SoT:** `lib/fleet/session-predicates.mjs` (re-exports genuine-worker SoT; adds `isFixtureSession`, `isGenuineCountableWorker`, `isDispatchableFleetMember`) + `lib/coordinator/sd-exclusion.mjs` (`isStartedSd`).

**Consumer wirings (each + regression test bound to real exports + static call-site guard):**
- **FR-1** `fleet-dashboard.cjs` idle/capacity filter → `isDispatchableFleetMember` (excludes coordinator/adam/non_fleet/fixture; NOT `everClaimed`, so just-finished workers still count). bug 623eb17d
- **FR-2** `stale-session-sweep.cjs` CLAIM_FIX never re-asserts onto a fixture (bilateral, race-guarded) + fixtures excluded from conflict-keeper selection. bug fd018627
- **FR-3** `assign-fleet-identities.cjs` injects the shared `isFixtureSession` so \*-probe-\*/QF-TEST-\* never consume a callsign. bug 7b59dac8
- **FR-4** `coordinator-backlog-rank.mjs` in-flight guard (`isStartedSd`: current_phase != LEAD). bug d5e59236

## Adversarial review (high blast radius — fleet-claim mutation)
A multi-agent adversarial review of FR-2 found + fixed **2 real, live-verified defects**:
1. **Over-release** — `isFixtureSession`'s synthetic catch-all misclassified genuine non-UUID worker ids (`session_<epoch>`, `leo-assist-<epoch>`, `coordinator-<uuid>`, `qf-<n>-<epoch>`, bare ids; verified across all 5 callsigns, Bravo `session_1776019751948` held a real claim). Narrowed to **positive FIXTURE_SESSION_RE markers only** (fail toward not-a-fixture).
2. **Conflict keeper** — the conflict loop could let a fixture evict a real worker before the CLAIM_FIX guard ran. Fixtures now excluded from conflict-keeper selection.

## Verification
- 92 tests across the 4 affected files (bound to real exports + static call-site/SELECT guards)
- TESTING sub-agent PASS (row 02e0ca87); VALIDATION sub-agent PASS (row fb23610d, conf 95)
- Gates: LEAD-TO-PLAN 95, PLAN-TO-EXEC 97, EXEC-TO-PLAN 92, PLAN-TO-LEAD 95
- Read-only column additions only (current_phase, metadata); no schema change/migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)