### PR TITLE
feat(SD-LEO-INFRA-CLAIM-RPC-HONOR-001): claim_sd honors armed silence window (central arbiter)

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-CLAIM-RPC-HONOR-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-CLAIM-RPC-HONOR-001.json
@@ -1,0 +1,105 @@
+{
+  "executive_summary": "claim_sd is the central claim arbiter (4 callers). Its non-force takeover branches — drift_recovery and auto_stale_takeover — reap a claim holder with zero expected_silence_until awareness, so a parked /loop worker heartbeat-silent >15min but inside its armed (<=30min) silence window gets reaped. cleanup_stale_sessions already exempts such a worker in SQL, gated on chairman_dashboard_config.metadata->>'sweep_respect_inflight_agent' (verified LIVE/ON), so today the sweep and the claim arbiter disagree — a split-brain. This SD migrates claim_sd to honor the SAME flag with the SAME hard-cap model (30 + claim_ttl = 45min), refusing both takeover branches against a holder inside a future silence window with a structured claimed_by_silenced_peer result. --force and expired / beyond-cap windows still take over; fail-open on any config error. Additive guards only; mutually exclusive (drift implies no session-side holder). Shipped only via the guarded prod-deploy path after a dedicated adversarial review of the SQL.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "auto_stale_takeover honors the armed silence window",
+      "description": "In claim_sd, before the auto_stale_takeover assignment (v_existing_session NOT NULL AND v_existing_hb_age >= 900 AND NOT v_takeover), add a guard that RETURNS {success:false, error:'claimed_by_silenced_peer'} when the respect-in-flight flag is ON, p_force_takeover is false, the existing session's expected_silence_until is in the future, and its heartbeat age is within the hard-cap ceiling (v_hardcap_minutes*60). Capture cs.expected_silence_until in the existing prior-session SELECT. Never silently double-claims a silenced holder.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "A >900s-silent holder inside its armed window is REFUSED with claimed_by_silenced_peer and is NOT reaped (net-zero claiming_session_id)",
+        "An expired window still takes over; a window beyond the 45-min hard-cap still takes over (no forever-wedge)",
+        "--force always overrides the window"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "drift_recovery honors the armed silence window",
+      "description": "Before the drift_recovery assignment (v_drift_detected AND NOT v_takeover), add the parallel guard reading the SD-side claimant's expected_silence_until (captured alongside v_sd_claim_hb_age). It RETURNS claimed_by_silenced_peer when the flag is ON, not force, window future, and the claimant's heartbeat within the hard-cap. The guard is mutually exclusive with FR-1 (drift requires v_existing_session IS NULL) and fires AFTER the existing claimed_by_live_peer guard (which already covers hb<900).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "A silenced SD-side claimant (>=900s, drifted session pointer) is REFUSED and not reaped",
+        "Once its window expires the drift takeover still proceeds",
+        "Self-resume (holder re-claims its own SD) is unaffected"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Parity with cleanup_stale_sessions + fail-open",
+      "description": "Read the SAME chairman_dashboard_config flag (sweep_respect_inflight_agent, default FALSE) and claim_ttl_minutes (default 15) cleanup_stale_sessions uses, with v_hardcap_minutes = 30 + GREATEST(COALESCE(ttl,15),0). Any config-read error leaves the flag OFF — identical to today's reap-on-stale behavior. No change to the force / live-foreign / terminal / sd_not_found / conflict / claim-switch / new-claim / audit paths. Idempotent CREATE OR REPLACE preserving SECURITY DEFINER and search_path.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Flag, COALESCE defaults, and hard-cap formula are identical in meaning to cleanup_stale_sessions",
+        "Fail-open: a config error degrades to current behavior (no exception aborts a claim)",
+        "Function signature, return shape, SECURITY DEFINER and search_path are unchanged"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Regression tests (deploy verification)",
+      "description": "tests/database/claim-sd-honor-silence-window.test.js — live-DB integration tests gated on HAS_REAL_DB with hermetic per-run fixtures, asserting: auto_stale refuses-within-window / takes-over-expired / takes-over-beyond-cap / force-overrides; drift refuses-within-window / takes-over-expired; self-resume unaffected. These exercise the deployed claim_sd and serve as the deploy gate.",
+      "priority": "high",
+      "acceptance_criteria": [
+        ">=6 scenario tests covering both branches + expiry + hard-cap + force + self-resume",
+        "Fixtures are hermetic (unique RUN_SUFFIX) and restored net-zero in afterAll",
+        "Tests pass against the deployed migration"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Guarded prod-deploy of a central RPC",
+      "description": "Migration 20260613_claim_sd_honor_armed_silence.sql ships via the guarded prod-deploy path (3 serial guards: @approved-by matches git user.email; --issue-token; --prod-deploy). MCP apply_migration is read-only. A wrong claim_sd = fleet-wide claim outage."
+    },
+    {
+      "id": "TR-2",
+      "title": "Mandated adversarial SQL review before deploy",
+      "description": "A multi-agent adversarial review of the SQL (forever-wedge/DoS, false-refusal/availability, guard ordering/mutual-exclusion, parity/SQL-correctness, under-protection) runs and its confirmed defects are fixed before the prod-deploy."
+    }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Silenced holder within window is refused (both branches)", "type": "integration", "expected": "claimed_by_silenced_peer; holder not reaped" },
+    { "id": "TS-2", "scenario": "Expired / beyond-cap window still reaps; --force overrides", "type": "integration", "expected": "takeover=true" },
+    { "id": "TS-3", "scenario": "Self-resume and flag-OFF fail-open unaffected", "type": "integration", "expected": "claim proceeds as today" }
+  ],
+  "acceptance_criteria": [
+    "claim_sd refuses to reap a holder inside an armed silence window on BOTH drift_recovery and auto_stale_takeover, gated on the same flag as cleanup_stale_sessions",
+    "--force and expired/beyond-cap windows still take over; fail-open preserves current behavior",
+    "Adversarial SQL review confirmed-defects fixed; regression tests pass post-deploy"
+  ],
+  "risks": [
+    { "risk": "A silenced-peer guard wrongly REFUSES a legitimate claim, wedging an SD unclaimable", "mitigation": "Hard-cap (45min) + expected_silence_until>NOW() both required; --force always escapes; mirrors the proven cleanup_stale_sessions model; adversarial review of the false-refusal lens.", "severity": "high" },
+    { "risk": "A claim is wedged open forever (DoS)", "mitigation": "Hard-cap ceiling reaps any holder whose heartbeat exceeds 30+TTL minutes regardless of expected_silence_until; verified by the beyond-cap test.", "severity": "high" },
+    { "risk": "Wrong migration to the central arbiter = fleet-wide claim outage", "mitigation": "Idempotent additive CREATE OR REPLACE, guarded prod-deploy (3 serial guards), mandated adversarial review, coordinator/chairman visibility, fail-open config read.", "severity": "high" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["lib/claim-guard.mjs", "lib/session-conflict-checker.mjs", "scripts/qf-start.js", "scripts/worker-checkin.cjs (all call claim_sd)"],
+    "dependencies": ["chairman_dashboard_config.metadata.sweep_respect_inflight_agent (LIVE/ON)", "claude_sessions.expected_silence_until column", "cleanup_stale_sessions silence model (parity source)"],
+    "data_contracts": ["claim_sd return shape unchanged; new error value 'claimed_by_silenced_peer' added"],
+    "runtime_config": ["sweep_respect_inflight_agent flag governs both the sweep and the arbiter (no split-brain)"],
+    "observability_rollout": ["claimed_by_silenced_peer refusals are visible in claim_sd return + caller logs; takeover audit (session_lifecycle_events) emits only on an actual takeover, unchanged"]
+  },
+  "system_architecture": {
+    "summary": "Two additive silence guards at the claim_sd choke point, mirroring cleanup_stale_sessions, gated on one shared config flag.",
+    "components": [
+      { "name": "database/migrations/20260613_claim_sd_honor_armed_silence.sql", "change": "NEW — CREATE OR REPLACE claim_sd with two claimed_by_silenced_peer guards + config read + 2 SELECT column captures" },
+      { "name": "tests/database/claim-sd-honor-silence-window.test.js", "change": "NEW — live-DB deploy-verification regression tests" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Mirror the cleanup_stale_sessions silence model into claim_sd's two takeover branches; review adversarially; deploy via the guarded path; verify with integration tests.",
+    "steps": [
+      "Capture expected_silence_until in the prior-session and SD-side-claimant SELECTs",
+      "Add the auto_stale and drift silence guards (flag-gated, hard-capped, force-respecting)",
+      "Adversarial SQL review; fix confirmed defects",
+      "Guarded prod-deploy + run the integration tests as the deploy gate"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Review database/migrations/20260613_claim_sd_honor_armed_silence.sql for the two claimed_by_silenced_peer guards + the chairman_dashboard_config read", "expected_outcome": "Both guards present, flag-gated, NOT p_force_takeover, hard-cap bounded" },
+    { "step_number": 2, "instruction": "After the guarded prod-deploy: npx vitest run tests/database/claim-sd-honor-silence-window.test.js", "expected_outcome": "All scenarios pass (refuse-within-window, takeover-expired/beyond-cap, force-overrides, self-resume)" },
+    { "step_number": 3, "instruction": "SELECT pg_get_functiondef('claim_sd'::regproc) and confirm claimed_by_silenced_peer appears twice", "expected_outcome": "Deployed function honors the silence window on both branches" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-CLAIM-RPC-HONOR-001" }
+}

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-FDBK-INFRA-SHARED-FLEET-WORKER-001",
-  "expectedBranch": "feat/SD-FDBK-INFRA-SHARED-FLEET-WORKER-001",
-  "createdAt": "2026-06-13T04:20:25.417Z",
+  "sdKey": "SD-LEO-INFRA-CLAIM-RPC-HONOR-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CLAIM-RPC-HONOR-001",
+  "createdAt": "2026-06-13T09:02:02.315Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260613_claim_sd_honor_armed_silence.sql
+++ b/database/migrations/20260613_claim_sd_honor_armed_silence.sql
@@ -1,0 +1,432 @@
+-- SD-LEO-INFRA-CLAIM-RPC-HONOR-001
+-- claim_sd RPC must honor an armed silence window (auto_stale_takeover / drift_recovery choke-point).
+--
+-- FOLLOW-UP to SD-LEO-INFRA-CLAIM-SILENCE-CONSUME-VERIFY-001 (code-layer seams) and a sibling of
+-- 20260609_claim_sd_refuse_live_foreign_claim.sql.
+--
+-- PROBLEM: claim_sd is the choke point for claim acquisition (4 callers: lib/claim-guard.mjs,
+-- lib/session-conflict-checker.mjs, scripts/qf-start.js, scripts/worker-checkin.cjs). Its two
+-- non-force takeover branches reap a holder with ZERO expected_silence_until awareness:
+--   - drift_recovery     : fires when v_drift_detected AND NOT v_takeover.
+--   - auto_stale_takeover: fires when v_existing_hb_age >= 900 AND NOT v_takeover.
+-- A parked /loop worker that is heartbeat-silent >15min but inside its armed (up-to-30min) silence
+-- window therefore gets its claim reaped. cleanup_stale_sessions ALREADY honors the window in SQL
+-- (gated on chairman_dashboard_config.metadata->>'sweep_respect_inflight_agent', which is LIVE/ON),
+-- so today the sweep and the claim arbiter DISAGREE — a split-brain.
+--
+-- FIX (parity-correct, choke-point): read the SAME respect-in-flight flag cleanup_stale_sessions
+-- uses and, when ON, refuse drift_recovery / auto_stale_takeover against a holder that is inside a
+-- future silence window AND whose heartbeat is within the hard-cap ceiling (30min window + claim TTL
+-- = 45min). FAIL-OPEN: any config error leaves the flag OFF = today's reap-on-stale behavior.
+-- p_force_takeover (--force) and genuinely expired / beyond-cap windows STILL take over. The refusal
+-- is a structured 'claimed_by_silenced_peer' (mirrors the live-foreign-claim guard) so a silenced
+-- holder is never silently double-claimed.
+--
+-- BLAST RADIUS: production migration to the CENTRAL claim arbiter. Idempotent CREATE OR REPLACE;
+-- additive guards only (no change to the force / live-foreign / terminal / conflict / claim paths).
+-- A wrong claim_sd = fleet-wide claim outage — this ships only via the guarded prod-deploy path with
+-- a dedicated adversarial review of the SQL and coordinator/chairman visibility.
+
+CREATE OR REPLACE FUNCTION public.claim_sd(p_sd_id text, p_session_id text, p_track text, p_force_takeover boolean DEFAULT false)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing_session    text;
+  v_existing_hb_age     numeric;
+  v_existing_status     text;
+  v_existing_wt_path    text;
+  v_existing_wt_branch  text;
+  v_sd_claiming_id      text;
+  v_sd_parent_id        text;
+  v_drift_detected      boolean := FALSE;
+  v_takeover            boolean := FALSE;
+  v_takeover_reason     text;
+  v_caller_parent_id    text;
+  v_audit_event_id      uuid;
+  v_conflict            RECORD;
+  v_is_qf               boolean := p_sd_id LIKE 'QF-%';
+  v_sd_status           text;
+  v_qf_status           text;
+  v_sd_claim_hb_age     numeric;
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: armed-silence-window awareness (parity with cleanup_stale_sessions).
+  v_respect_inflight       boolean := FALSE;
+  v_ttl_minutes            integer := 15;
+  v_hardcap_minutes        integer := 45;
+  v_existing_silence_until timestamptz;
+  v_sd_claim_silence_until timestamptz;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: read the SAME respect-in-flight flag cleanup_stale_sessions
+  -- uses, so the sweep and the claim arbiter never disagree about an armed silence window. FAIL-OPEN:
+  -- any error leaves the flag OFF (today's reap-on-stale behavior).
+  BEGIN
+    SELECT
+      COALESCE((metadata->>'sweep_respect_inflight_agent')::boolean, FALSE),
+      COALESCE((metadata->>'claim_ttl_minutes')::integer, 15)
+    INTO v_respect_inflight, v_ttl_minutes
+    FROM chairman_dashboard_config
+    WHERE config_key = 'default'
+    LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_respect_inflight := FALSE;
+    v_ttl_minutes := 15;
+  END;
+  -- Hard-cap ceiling = max in-flight silence window (30 min) + claim TTL margin; beyond this no
+  -- expected_silence_until can wedge a dead claim open forever. Mirrors cleanup_stale_sessions.
+  v_hardcap_minutes := 30 + GREATEST(COALESCE(v_ttl_minutes, 15), 0);
+
+  -- 2a. Capture prior session's worktree state (for audit metadata) under the
+  --     SAME FOR UPDATE row lock as the existing-session check.
+  SELECT cs.session_id, cs.status,
+         EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+         cs.worktree_path, cs.worktree_branch,
+         cs.expected_silence_until
+    INTO v_existing_session, v_existing_status, v_existing_hb_age,
+         v_existing_wt_path, v_existing_wt_branch,
+         v_existing_silence_until
+    FROM claude_sessions cs
+   WHERE cs.sd_key = p_sd_id
+     AND cs.session_id != p_session_id
+     AND cs.status IN ('active', 'idle')
+   ORDER BY cs.heartbeat_at DESC
+   LIMIT 1
+     FOR UPDATE;
+
+  IF NOT v_is_qf THEN
+    SELECT sd.claiming_session_id, sd.parent_sd_id, sd.status
+      INTO v_sd_claiming_id, v_sd_parent_id, v_sd_status
+      FROM strategic_directives_v2 sd
+     WHERE sd.sd_key = p_sd_id
+       FOR UPDATE;
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: reject phantom (non-existent) SD ids instead of
+    -- optimistically returning success. claim_sd was OPTIMISTIC — a typo / stale sd_key used
+    -- to self-claim a non-existent SD and write claude_sessions.sd_key. The existing FOR UPDATE
+    -- SELECT above sets FOUND only when an sd_key row exists, so this is the minimal guard.
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_SD_NOT_FOUND] SD %s does not exist in strategic_directives_v2 — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: terminal-status guard. Refuse to claim an SD whose
+    -- lifecycle has already ended (completed/cancelled/deferred) instead of optimistically
+    -- stomping claiming_session_id. Orthogonal to the sd_not_found guard above; fires BEFORE
+    -- the claim UPDATE so it pre-empts trigger 393's raw P0001 with a clean structured failure
+    -- and additionally covers completed/deferred which that cancelled-only trigger does not.
+    IF v_sd_status IN ('completed', 'cancelled', 'deferred') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_sd_status,
+        'message', format('[CLAIM_SD_TERMINAL] SD %s is in terminal status %s — refusing to claim a finished/cancelled/deferred SD.', p_sd_id, v_sd_status));
+    END IF;
+
+    -- SD-LEO-FIX-CLAIM-RPC-REFUSE-001: capture the SD-side claimant's heartbeat age so the
+    -- live-foreign-claim guard below can refuse to stomp a LIVE peer even when its session-side
+    -- claude_sessions.sd_key pointer has drifted out of sync with the SD-side claiming_session_id.
+    -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: also capture its expected_silence_until for the silence guard.
+    IF v_sd_claiming_id IS NOT NULL AND v_sd_claiming_id != p_session_id THEN
+      SELECT EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)),
+             cs.expected_silence_until
+        INTO v_sd_claim_hb_age,
+             v_sd_claim_silence_until
+        FROM claude_sessions cs
+       WHERE cs.session_id = v_sd_claiming_id
+         AND cs.status IN ('active', 'idle')
+       ORDER BY cs.heartbeat_at DESC
+       LIMIT 1;
+    END IF;
+  ELSE
+    -- SD-FDBK-FIX-CLAIM-RPC-VALIDATE-001: same guard for the QF path (claim_sd resolves QFs
+    -- by quick_fixes.id = p_sd_id, mirrored from the QF UPDATE below).
+    SELECT qf.status INTO v_qf_status FROM quick_fixes qf WHERE qf.id = p_sd_id FOR UPDATE;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_not_found',
+        'message', format('[CLAIM_QF_NOT_FOUND] Quick-fix %s does not exist in quick_fixes — refusing to claim a phantom id.', p_sd_id));
+    END IF;
+    -- SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: QF terminal-status guard. 'escalated' is a one-way
+    -- promotion to a full SD (classify-quick-fix.js never reverts it), so claiming an escalated
+    -- QF resumes superseded work. Mirrors the SD terminal guard; fires before the QF UPDATE.
+    IF v_qf_status IN ('completed', 'cancelled', 'escalated') THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'sd_terminal_status',
+        'status', v_qf_status,
+        'message', format('[CLAIM_QF_TERMINAL] Quick-fix %s is in terminal status %s — refusing to claim a finished/cancelled/escalated quick-fix.', p_sd_id, v_qf_status));
+    END IF;
+  END IF;
+
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_existing_session IS NULL
+  THEN
+    v_drift_detected := TRUE;
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age < 900 THEN
+    IF NOT p_force_takeover THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'already_claimed',
+        'message', format(
+          '[CLAIM_PEER_ACTIVE] SD %s is already claimed by active session %s (heartbeat %ss ago). Use --force to take over or wait for release.',
+          p_sd_id, v_existing_session, ROUND(v_existing_hb_age)),
+        'claimed_by', v_existing_session,
+        'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+      );
+    END IF;
+
+    SELECT cs2.sd_key INTO v_caller_parent_id
+      FROM claude_sessions cs2
+     WHERE cs2.session_id = p_session_id
+       AND cs2.status IN ('active', 'idle')
+     LIMIT 1;
+
+    IF v_existing_hb_age >= 60 THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_heartbeat_threshold';
+    ELSIF v_sd_parent_id IS NOT NULL
+          AND v_caller_parent_id = v_sd_parent_id THEN
+      v_takeover := TRUE;
+      v_takeover_reason := 'force_parent_authority';
+    ELSE
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'unauthorized_force',
+        'message', format(
+          '[CLAIM_FORCE_DENIED] SD %s force-takeover refused: caller session %s lacks authority (prior heartbeat %ss < 60s threshold and no parent SD authority). Use sd:release first or wait.',
+          p_sd_id, p_session_id, ROUND(v_existing_hb_age))
+      );
+    END IF;
+  END IF;
+
+  -- SD-LEO-FIX-CLAIM-RPC-REFUSE-001: refuse to overwrite a claim held by a LIVE foreign session.
+  -- The session-side refusal above only fires when the live peer's claude_sessions.sd_key still
+  -- equals p_sd_id; it misses the case where only the SD-side claim (claiming_session_id) points
+  -- to a still-live session whose session pointer drifted. Without this guard the drift_recovery
+  -- takeover below would silently stomp that live peer. A stale claimant (hb >= 900s) or an absent
+  -- session leaves v_sd_claim_hb_age NULL / >= 900 and still falls through to takeover; --force too.
+  IF v_sd_claiming_id IS NOT NULL
+     AND v_sd_claiming_id != p_session_id
+     AND v_sd_claim_hb_age IS NOT NULL
+     AND v_sd_claim_hb_age < 900
+     AND NOT p_force_takeover
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_live_peer',
+      'message', format(
+        '[CLAIM_LIVE_PEER] SD %s is claimed by LIVE session %s (heartbeat %ss ago) — refusing to overwrite a live peer''s claim. Use --force to take over or wait for release.',
+        p_sd_id, v_sd_claiming_id, ROUND(v_sd_claim_hb_age)),
+      'claimed_by', v_sd_claiming_id,
+      'heartbeat_age_seconds', ROUND(v_sd_claim_hb_age)
+    );
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: drift_recovery choke point. If the SD-side claimant is a
+  -- parked worker inside its armed silence window (flag ON, window in the future, heartbeat within
+  -- the hard-cap ceiling), refuse to reap it. --force and expired / beyond-cap windows still take
+  -- over (this guard requires NOT p_force_takeover and a future window <= hard-cap). Mutually
+  -- exclusive with the auto_stale guard below: v_drift_detected implies v_existing_session IS NULL.
+  IF v_respect_inflight
+     AND v_drift_detected AND NOT v_takeover
+     AND NOT p_force_takeover
+     AND v_sd_claim_silence_until IS NOT NULL
+     AND v_sd_claim_silence_until > NOW()
+     AND v_sd_claim_hb_age IS NOT NULL
+     AND v_sd_claim_hb_age <= (v_hardcap_minutes * 60)
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_silenced_peer',
+      'message', format(
+        '[CLAIM_SILENCED_PEER] SD %s is claimed by session %s parked inside an armed silence window (until %s, heartbeat %ss ago) — refusing to reap a parked worker. Use --force to override.',
+        p_sd_id, v_sd_claiming_id, v_sd_claim_silence_until, ROUND(v_sd_claim_hb_age)),
+      'claimed_by', v_sd_claiming_id,
+      'silence_until', v_sd_claim_silence_until,
+      'heartbeat_age_seconds', ROUND(v_sd_claim_hb_age)
+    );
+  END IF;
+
+  IF v_drift_detected AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'drift_recovery';
+  END IF;
+
+  -- SD-LEO-INFRA-CLAIM-RPC-HONOR-001: auto_stale_takeover choke point. A session silent past 900s
+  -- but inside its armed silence window (flag ON, within the hard-cap ceiling) is a PARKED worker,
+  -- not a dead one — refuse the auto-stale takeover. --force and expired / beyond-cap windows still
+  -- reap (a window beyond the 45-min hard-cap, or already past, falls through to takeover below).
+  IF v_respect_inflight
+     AND v_existing_session IS NOT NULL
+     AND v_existing_hb_age >= 900 AND NOT v_takeover
+     AND NOT p_force_takeover
+     AND v_existing_silence_until IS NOT NULL
+     AND v_existing_silence_until > NOW()
+     AND v_existing_hb_age <= (v_hardcap_minutes * 60)
+  THEN
+    RETURN jsonb_build_object(
+      'success', FALSE,
+      'error', 'claimed_by_silenced_peer',
+      'message', format(
+        '[CLAIM_SILENCED_PEER] SD %s is claimed by parked session %s inside an armed silence window (until %s, heartbeat %ss ago) — refusing auto-stale takeover. Use --force to override.',
+        p_sd_id, v_existing_session, v_existing_silence_until, ROUND(v_existing_hb_age)),
+      'claimed_by', v_existing_session,
+      'silence_until', v_existing_silence_until,
+      'heartbeat_age_seconds', ROUND(v_existing_hb_age)
+    );
+  END IF;
+
+  IF v_existing_session IS NOT NULL AND v_existing_hb_age >= 900 AND NOT v_takeover THEN
+    v_takeover := TRUE;
+    v_takeover_reason := 'auto_stale_takeover';
+  END IF;
+
+  IF NOT v_is_qf AND NOT v_takeover THEN
+    SELECT cm.*, cs_other.sd_key AS active_sd, cs_other.session_id AS active_session
+      INTO v_conflict
+      FROM sd_conflict_matrix cm
+      JOIN claude_sessions cs_other ON (
+        (cm.sd_id_a = p_sd_id AND cm.sd_id_b = cs_other.sd_key) OR
+        (cm.sd_id_b = p_sd_id AND cm.sd_id_a = cs_other.sd_key)
+      )
+     WHERE cm.conflict_severity = 'blocking'
+       AND cm.resolved_at IS NULL
+       AND cs_other.sd_key IS NOT NULL
+       AND cs_other.status IN ('active', 'idle')
+       AND EXTRACT(EPOCH FROM (NOW() - cs_other.heartbeat_at)) < 900
+       AND cs_other.session_id != p_session_id
+     LIMIT 1;
+
+    IF v_conflict IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', FALSE,
+        'error', 'blocking_conflict',
+        'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+        'conflict_type', v_conflict.conflict_type,
+        'conflicting_sd', v_conflict.active_sd,
+        'conflicting_session', v_conflict.active_session
+      );
+    END IF;
+  END IF;
+
+  -- ============================================================================
+  -- TAKEOVER PATH: NULL the prior session's claim AND its worktree state.
+  -- (FR-1 of SD-LEO-INFRA-LEO-INFRA-SESSION-001 — only the worktree_* columns
+  -- are new vs. 20260427.)
+  -- ============================================================================
+  IF v_takeover AND v_existing_session IS NOT NULL THEN
+    UPDATE claude_sessions
+       SET sd_key = NULL,
+           track = NULL,
+           claimed_at = NULL,
+           released_at = NOW(),
+           released_reason = v_takeover_reason,
+           status = 'idle',
+           updated_at = NOW(),
+           worktree_path = NULL,
+           worktree_branch = NULL
+     WHERE session_id = v_existing_session;
+  END IF;
+
+  -- Claim-switch path: caller is releasing some OTHER SD to claim p_sd_id.
+  UPDATE claude_sessions
+     SET sd_key = NULL,
+         track = NULL,
+         claimed_at = NULL,
+         released_at = NOW(),
+         released_reason = 'claim_switch',
+         status = 'idle',
+         worktree_path = NULL,
+         worktree_branch = NULL
+   WHERE session_id = p_session_id
+     AND sd_key IS NOT NULL
+     AND sd_key != p_sd_id
+     AND (v_sd_parent_id IS NULL OR sd_key != v_sd_parent_id);
+
+  -- New-claim UPDATE intentionally does NOT set worktree_path / worktree_branch.
+  -- sd-start.js writes them via lib/lifecycle/worktree-state-writer.mjs after
+  -- createWorktree completes. Keeping them NULL here means the FR-5 CHECK
+  -- constraint is never violated transiently.
+  UPDATE claude_sessions
+     SET sd_key = p_sd_id,
+         track = p_track,
+         claimed_at = NOW(),
+         released_at = NULL,
+         released_reason = NULL,
+         heartbeat_at = NOW(),
+         status = 'active'
+   WHERE session_id = p_session_id;
+
+  IF v_is_qf THEN
+    UPDATE quick_fixes
+       SET claiming_session_id = p_session_id,
+           status = 'in_progress'
+     WHERE id = p_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+       SET claiming_session_id = p_session_id,
+           active_session_id = p_session_id,
+           is_working_on = TRUE
+     WHERE sd_key = p_sd_id;
+  END IF;
+
+  -- ============================================================================
+  -- AUDIT EMISSION: gains worktree_path_before / worktree_branch_before
+  -- per TR-1 risk-mitigation observability addition.
+  -- ============================================================================
+  IF v_takeover THEN
+    INSERT INTO session_lifecycle_events (
+      event_type,
+      session_id,
+      reason,
+      metadata
+    ) VALUES (
+      CASE
+        WHEN v_takeover_reason = 'auto_stale_takeover' THEN 'CLAIM_AUTO_RECLAIM'
+        ELSE 'CLAIM_TAKEOVER'
+      END,
+      p_session_id,
+      v_takeover_reason,
+      jsonb_build_object(
+        'sd_key', p_sd_id,
+        'prior_session_id', v_existing_session,
+        'prior_heartbeat_age_seconds', ROUND(COALESCE(v_existing_hb_age, 0)),
+        'drift_detected', v_drift_detected,
+        'force_authorized_by', CASE
+          WHEN v_takeover_reason LIKE 'force_%' THEN v_takeover_reason
+          ELSE NULL
+        END,
+        'sd_claiming_id_before', v_sd_claiming_id,
+        'worktree_path_before', v_existing_wt_path,
+        'worktree_branch_before', v_existing_wt_branch
+      )
+    )
+    RETURNING id INTO v_audit_event_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', TRUE,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_sd_parent_id IS NOT NULL,
+    'takeover', v_takeover,
+    'takeover_reason', v_takeover_reason,
+    'prior_session_id', v_existing_session,
+    'prior_heartbeat_age_seconds', CASE
+      WHEN v_existing_hb_age IS NOT NULL THEN ROUND(v_existing_hb_age)
+      ELSE NULL
+    END,
+    'drift_detected', v_drift_detected,
+    'audit_event_id', v_audit_event_id
+  );
+END;
+$function$;

--- a/database/migrations/20260613_claim_sd_honor_armed_silence.sql
+++ b/database/migrations/20260613_claim_sd_honor_armed_silence.sql
@@ -26,6 +26,10 @@
 -- additive guards only (no change to the force / live-foreign / terminal / conflict / claim paths).
 -- A wrong claim_sd = fleet-wide claim outage — this ships only via the guarded prod-deploy path with
 -- a dedicated adversarial review of the SQL and coordinator/chairman visibility.
+--
+-- @approved-by: codestreetlabs@gmail.com
+-- Chairman decision 3b8d0499 approved (GO routed via coordinator b887c648, 2026-06-13). Adversarial
+-- SQL review wf_987d8106: 4 lenses clean, 1 out-of-scope sibling finding filed to harness_backlog.
 
 CREATE OR REPLACE FUNCTION public.claim_sd(p_sd_id text, p_session_id text, p_track text, p_force_takeover boolean DEFAULT false)
  RETURNS jsonb

--- a/tests/database/claim-sd-honor-silence-window.test.js
+++ b/tests/database/claim-sd-honor-silence-window.test.js
@@ -1,0 +1,154 @@
+/**
+ * SD-LEO-INFRA-CLAIM-RPC-HONOR-001 — claim_sd must honor an armed silence window.
+ *
+ * Gap: claim_sd's auto_stale_takeover (v_existing_hb_age >= 900) and drift_recovery branches
+ * reaped a holder with ZERO expected_silence_until awareness, so a parked /loop worker that is
+ * heartbeat-silent >15min but inside its armed (<=30min) window got its claim reaped — even though
+ * cleanup_stale_sessions already exempts it (flag sweep_respect_inflight_agent, LIVE/ON). The
+ * migration adds, gated on the SAME flag, a structured {success:false, error:'claimed_by_silenced_peer'}
+ * refusal when the holder's expected_silence_until is in the future AND its heartbeat is within the
+ * hard-cap ceiling (30 + claim_ttl = 45min). --force and expired / beyond-cap windows STILL take over.
+ *
+ * Live-DB integration test (the deploy-verification for the migration): gated on HAS_REAL_DB so CI
+ * skips cleanly without service-role creds. Hermetic per-run fixtures restored net-zero in afterAll.
+ *
+ * NOTE: these assertions exercise the DEPLOYED claim_sd. Before the migration is applied to the DB
+ * they fail (old claim_sd reaps the silenced holder) — that is the intended deploy gate.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const RUN_SUFFIX = `${process.pid}-${Date.now().toString(36)}`;
+const PEER = `test-claim-silence-peer-${RUN_SUFFIX}`;   // the silenced holder
+const CALLER = `test-claim-silence-caller-${RUN_SUFFIX}`; // the reaper-candidate
+
+let targetKey = null;
+let flagOn = false; // captured at beforeAll; the silence guard only activates when the flag is ON
+
+const isoSecsAgo = (s) => new Date(Date.now() - s * 1000).toISOString();
+const isoMinsAhead = (m) => new Date(Date.now() + m * 60 * 1000).toISOString();
+
+// AUTO_STALE scenario: PEER holds the SESSION-SIDE claim (sd_key=targetKey) and is silent.
+async function resetAutoStale({ hbSecsAgo, silenceUntil }) {
+  await supabase.from('claude_sessions').upsert(
+    { session_id: PEER, status: 'active', heartbeat_at: isoSecsAgo(hbSecsAgo), sd_key: targetKey, expected_silence_until: silenceUntil },
+    { onConflict: 'session_id' });
+  await supabase.from('claude_sessions').upsert(
+    { session_id: CALLER, status: 'active', heartbeat_at: isoSecsAgo(5), sd_key: null, expected_silence_until: null },
+    { onConflict: 'session_id' });
+  await supabase.from('strategic_directives_v2')
+    .update({ claiming_session_id: PEER, active_session_id: PEER, is_working_on: true })
+    .eq('sd_key', targetKey);
+}
+
+// DRIFT scenario: PEER holds only the SD-SIDE claim (claiming_session_id), its session-side sd_key
+// drifted to NULL, and it is silent (>=900s so the live-foreign guard does not catch it first).
+async function resetDrift({ hbSecsAgo, silenceUntil }) {
+  await supabase.from('claude_sessions').upsert(
+    { session_id: PEER, status: 'active', heartbeat_at: isoSecsAgo(hbSecsAgo), sd_key: null, expected_silence_until: silenceUntil },
+    { onConflict: 'session_id' });
+  await supabase.from('claude_sessions').upsert(
+    { session_id: CALLER, status: 'active', heartbeat_at: isoSecsAgo(5), sd_key: null, expected_silence_until: null },
+    { onConflict: 'session_id' });
+  await supabase.from('strategic_directives_v2')
+    .update({ claiming_session_id: PEER, active_session_id: null, is_working_on: false })
+    .eq('sd_key', targetKey);
+}
+
+const claim = (session, force = false) =>
+  supabase.rpc('claim_sd', { p_sd_id: targetKey, p_session_id: session, p_track: null, p_force_takeover: force }).then(r => r.data);
+
+const sdClaimant = () =>
+  supabase.from('strategic_directives_v2').select('claiming_session_id').eq('sd_key', targetKey).maybeSingle().then(r => r.data?.claiming_session_id);
+
+describe.skipIf(!HAS_REAL_DB)('claim_sd honors an armed silence window (SD-LEO-INFRA-CLAIM-RPC-HONOR-001)', () => {
+  beforeAll(async () => {
+    const { data: cfg } = await supabase.from('chairman_dashboard_config').select('metadata').eq('config_key', 'default').maybeSingle();
+    flagOn = String(cfg?.metadata?.sweep_respect_inflight_agent) === 'true';
+    const key = `SD-TEST-CLAIM-SILENCE-${RUN_SUFFIX}`.toUpperCase();
+    const { error } = await supabase.from('strategic_directives_v2').insert({
+      sd_key: key, id: key,
+      title: 'TEST FIXTURE: claim_sd silence-window scenario — safe to delete',
+      description: 'Scratch SD created by tests/database/claim-sd-honor-silence-window.test.js; deleted in afterAll.',
+      status: 'draft', sd_type: 'bugfix', category: 'test_fixture', priority: 'low',
+    });
+    if (error) return;
+    targetKey = key;
+  });
+
+  afterAll(async () => {
+    if (targetKey) await supabase.from('strategic_directives_v2').delete().eq('sd_key', targetKey);
+    await supabase.from('claude_sessions').delete().eq('session_id', PEER);
+    await supabase.from('claude_sessions').delete().eq('session_id', CALLER);
+  });
+
+  it('auto_stale: REFUSES (claimed_by_silenced_peer) a >900s-silent holder inside its armed window', async () => {
+    if (!targetKey || !flagOn) return; // guard only active with the flag ON
+    await resetAutoStale({ hbSecsAgo: 1000, silenceUntil: isoMinsAhead(20) });
+    const data = await claim(CALLER);
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('claimed_by_silenced_peer');
+    expect(data?.claimed_by).toBe(PEER);
+    expect(await sdClaimant()).toBe(PEER); // net-zero: holder not reaped
+  });
+
+  it('auto_stale: STILL TAKES OVER when the silence window has EXPIRED', async () => {
+    if (!targetKey) return;
+    await resetAutoStale({ hbSecsAgo: 1000, silenceUntil: isoSecsAgo(60) }); // window already past
+    const data = await claim(CALLER);
+    expect(data?.success).toBe(true);
+    expect(data?.takeover).toBe(true);
+  });
+
+  it('auto_stale: STILL TAKES OVER beyond the hard-cap even with a future window (no forever-wedge)', async () => {
+    if (!targetKey) return;
+    await resetAutoStale({ hbSecsAgo: 3000, silenceUntil: isoMinsAhead(60) }); // hb 50min > 45min cap
+    const data = await claim(CALLER);
+    expect(data?.success).toBe(true);
+    expect(data?.takeover).toBe(true);
+  });
+
+  it('auto_stale: --force ALWAYS overrides an armed silence window', async () => {
+    if (!targetKey) return;
+    await resetAutoStale({ hbSecsAgo: 1000, silenceUntil: isoMinsAhead(20) });
+    const data = await claim(CALLER, true);
+    expect(data?.success).toBe(true);
+    expect(data?.takeover).toBe(true);
+  });
+
+  it('drift_recovery: REFUSES a silenced SD-side claimant (>900s, drifted session pointer)', async () => {
+    if (!targetKey || !flagOn) return;
+    await resetDrift({ hbSecsAgo: 1000, silenceUntil: isoMinsAhead(20) });
+    const data = await claim(CALLER);
+    expect(data?.success).toBe(false);
+    expect(data?.error).toBe('claimed_by_silenced_peer');
+    expect(await sdClaimant()).toBe(PEER); // net-zero
+  });
+
+  it('drift_recovery: STILL TAKES OVER a silenced claimant once the window expires', async () => {
+    if (!targetKey) return;
+    await resetDrift({ hbSecsAgo: 1000, silenceUntil: isoSecsAgo(60) });
+    const data = await claim(CALLER);
+    expect(data?.success).toBe(true);
+    expect(data?.takeover).toBe(true);
+  });
+
+  it('does NOT fire for a self-resume (holder re-claims its own SD)', async () => {
+    if (!targetKey) return;
+    await resetAutoStale({ hbSecsAgo: 1000, silenceUntil: isoMinsAhead(20) });
+    const data = await claim(PEER); // caller == holder
+    expect(data?.success).toBe(true); // guard requires a FOREIGN holder
+  });
+});


### PR DESCRIPTION
## Summary
The central claim arbiter `claim_sd` (4 callers) reaped a holder in its `drift_recovery` + `auto_stale_takeover` branches with zero `expected_silence_until` awareness — so a parked /loop worker heartbeat-silent >15min but inside its armed (≤30min) window got reaped, while `cleanup_stale_sessions` already exempts it (flag `sweep_respect_inflight_agent`, **LIVE/ON**). A sweep-vs-arbiter split-brain. The `claim_sd` choke-point follow-up to CLAIM-SILENCE-CONSUME-VERIFY-001.

## Change
Migration `20260613_claim_sd_honor_armed_silence.sql` adds two flag-gated guards (parity with `cleanup_stale_sessions`) that RETURN `claimed_by_silenced_peer` when the holder's window is in the future and its heartbeat is within the hard-cap (30 + claim_ttl = 45min). `--force` and expired/beyond-cap windows still take over; fail-open on config error; additive, idempotent CREATE OR REPLACE; mutually-exclusive guards.

## Process (high blast radius)
- **Deployed to prod** via the guarded path (3 serial guards: `@approved-by` = git email, single-use token, `--prod-deploy`). `MIGRATION_APPLY_PROD_PASS`, sha256 573b973e.
- **Chairman-approved** (decision 3b8d0499, routed via coordinator) — I refused to self-author the `@approved-by` attestation; added it only after the GO.
- **Adversarial review** (`wf_987d8106`, 8 agents, 5 lenses): migration **clean** (forever-wedge / over-refuse / mutual-exclusion / parity-SQL all clear). 1 confirmed **out-of-scope** finding — a sibling `sd-next → release_sd` reap path lacks silence-awareness — filed to harness_backlog as a follow-up.
- **7/7 integration tests** pass against the deployed function (`tests/database/claim-sd-honor-silence-window.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)