### PR TITLE
feat(SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B): recordSystemAlert write-contract

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B.json
+++ b/.prd-payloads/SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B.json
@@ -1,0 +1,31 @@
+{
+  "executive_summary": "Child B of the BREAKAGE-DETECTOR orchestrator: the single fail-loud write-contract recordSystemAlert() that every breakage detector + the canary (children C/D) and the catch-rate harness (F) use to persist alerts to system_alerts. Consumes child A's frozen taxonomy contract (COMPLETED + merged): alert_type via toAlertType() stays in the LIVE system_alerts_alert_type_check set (circuit_breaker/threshold_breach/system_health/eva_error); the precise class id rides in metadata.break_class (the harness read-back key); severity from BREAK_CLASS_SPEC.defaultSeverity (or a legal caller override). Reuses the 14 existing system_alerts columns — NO alert_type CHECK widening (protects the 3 live EVA SECURITY-DEFINER functions). Fail-loud on write failure; dedup of duplicate OPEN alerts (+ optional dedup index) so a recurring breakage does not flood the table. ~130 LOC, EHG_Engineer only. Unit-tested with a fake supabase so tests never write to live system_alerts.",
+  "functional_requirements": [
+    { "id": "FR-1", "title": "lib/breakage/alert-writer.cjs recordSystemAlert()", "description": "CommonJS module exporting async recordSystemAlert(supabase, { breakClass, source, severity?, message?, metadata? }). Imports lib/coordinator/break-class-taxonomy.cjs. Builds a system_alerts row: alert_type = toAlertType(breakClass) (legal CHECK value); severity = severity || BREAK_CLASS_SPEC[breakClass].defaultSeverity (validated against LEGAL_SEVERITIES, default 'warning' if illegal); metadata = { ...callerMetadata, break_class: breakClass, source }. Reuses the 14 existing columns only. Validates breakClass is in BREAK_CLASSES (loud reject otherwise). Returns the inserted row id." },
+    { "id": "FR-2", "title": "Open-alert dedup + fail-loud", "description": "Before inserting, suppress a duplicate OPEN alert for the same (metadata.break_class + source) — query for an existing unresolved system_alerts row matching that pair; if found, skip the insert (return the existing id + deduped:true) rather than flooding. Fail-loud: any insert/query error throws (or logs loud + rethrows) — never a silent swallow. Optional: a dedup index recommendation (no non-index schema migration in scope)." },
+    { "id": "FR-3", "title": "Regression tests (fake supabase, no live writes)", "description": "tests/unit pins with a fake supabase client (no live DB): (a) recordSystemAlert builds alert_type via toAlertType() in the legal set, metadata.break_class = the class, severity in LEGAL_SEVERITIES; (b) an unknown breakClass is loud-rejected; (c) a duplicate OPEN alert (fake returns an existing row) is deduped (no second insert); (d) a write error throws fail-loud. Tests must NOT write to the real system_alerts." }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "description": "Import the contract from lib/coordinator/break-class-taxonomy.cjs (child A, merged) — toAlertType, BREAK_CLASSES, BREAK_CLASS_SPEC, LEGAL_SEVERITIES. Do NOT re-declare the class list / severity / encoding (single source of truth)." },
+    { "id": "TR-2", "description": "Reuse the 14 existing system_alerts columns; alert_type/severity must satisfy the LIVE CHECK constraints. NO alert_type CHECK widening; no non-index schema migration. Class id lives ONLY in metadata.break_class." },
+    { "id": "TR-3", "description": "Fail-loud (throw on write/query failure). EHG_Engineer only. Tests use a fake supabase — zero live system_alerts writes. No hand-rolled inserts elsewhere (call sites in child C use THIS writer)." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "recordSystemAlert(supabase, {breakClass:'schema-drift', source:'x'})", "expected": "inserts row: alert_type=toAlertType('schema-drift') (legal), metadata.break_class='schema-drift', severity legal" },
+    { "id": "TS-2", "scenario": "recordSystemAlert with breakClass not in BREAK_CLASSES", "expected": "loud reject (throws) — never an illegal write" },
+    { "id": "TS-3", "scenario": "duplicate OPEN alert for same (break_class, source)", "expected": "deduped — no second insert, returns existing id + deduped:true" },
+    { "id": "TS-4", "scenario": "supabase insert returns an error", "expected": "fail-loud (throws/logs+rethrows), not silently swallowed" }
+  ],
+  "acceptance_criteria": [
+    "lib/breakage/alert-writer.cjs recordSystemAlert() exists, imports the child-A taxonomy, and writes legal system_alerts rows (alert_type via toAlertType, metadata.break_class, legal severity) reusing the 14 existing columns",
+    "Duplicate OPEN alerts are deduped; write failures fail loud",
+    "NO alert_type CHECK widening; no non-index schema migration",
+    "Tests pin the row shape + dedup + fail-loud with a fake supabase (no live system_alerts writes); children C/D/F can import this single writer"
+  ],
+  "risks": [
+    { "risk": "Tests pollute live system_alerts", "mitigation": "Unit tests use a fake supabase client; zero live writes (TR-3)" },
+    { "risk": "Illegal alert_type/severity trips the live CHECK", "mitigation": "alert_type via toAlertType() (child A guarantees legal); severity validated against LEGAL_SEVERITIES with a legal default" },
+    { "risk": "Dedup misses or over-suppresses", "mitigation": "Dedup keys on (metadata.break_class + source) for OPEN alerts only; resolved alerts re-alert; pinned by TS-3" }
+  ],
+  "metadata": { "estimated_loc": 130, "target_application": "EHG_Engineer", "parent_sd": "SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001", "child": "B", "depends_on": "A" }
+}

--- a/lib/breakage/alert-writer.cjs
+++ b/lib/breakage/alert-writer.cjs
@@ -1,0 +1,94 @@
+/**
+ * system_alerts write-contract — SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B (child B).
+ *
+ * The SINGLE fail-loud writer that every breakage detector + the canary (children C/D) and the
+ * catch-rate harness (F) use to persist a breakage alert to system_alerts. Consumes child A's
+ * frozen taxonomy (lib/coordinator/break-class-taxonomy.cjs): the precise break-class id rides in
+ * system_alerts.metadata.break_class (the harness read-back key); alert_type is written via
+ * toAlertType() to a value the LIVE system_alerts_alert_type_check admits
+ * (circuit_breaker/threshold_breach/system_health/eva_error) — NO alert_type CHECK widening
+ * (protects the 3 live EVA SECURITY-DEFINER functions). Severity stays in the live
+ * {info,warning,critical} set. Reuses the 14 existing system_alerts columns; no schema migration.
+ *
+ * NOT-NULL columns supplied: alert_type, severity, title, message, source_service.
+ * Dedup: an OPEN alert (resolved_at IS NULL) for the same (metadata.break_class, source_service)
+ * is suppressed so a recurring breakage does not flood the table. Fail-loud: any query/insert error
+ * throws — never a silent swallow. Pure builder logic is unit-tested with a fake supabase (no live
+ * writes); call sites in child C must use THIS writer (no hand-rolled inserts).
+ *
+ * @module lib/breakage/alert-writer
+ */
+'use strict';
+
+const {
+  BREAK_CLASSES,
+  BREAK_CLASS_SPEC,
+  LEGAL_SEVERITIES,
+  toAlertType,
+} = require('../coordinator/break-class-taxonomy.cjs');
+
+/**
+ * Build the canonical system_alerts row for a break class (pure — no IO). Exposed for testing +
+ * for callers that want the row without writing.
+ * @param {object} opts
+ * @returns {object} a system_alerts insert payload (all NOT-NULL columns populated)
+ */
+function buildAlertRow(opts = {}) {
+  const { breakClass, sourceService, severity, title, message, sourceEntityId, metadata } = opts;
+  if (!BREAK_CLASSES.includes(breakClass)) {
+    throw new Error(
+      `[recordSystemAlert] unknown break class "${breakClass}" — must be one of: ${BREAK_CLASSES.join(', ')}`
+    );
+  }
+  if (!sourceService || typeof sourceService !== 'string') {
+    throw new Error('[recordSystemAlert] sourceService (NOT NULL) is required');
+  }
+  const spec = BREAK_CLASS_SPEC[breakClass];
+  const sev = severity && LEGAL_SEVERITIES.includes(severity) ? severity : spec.defaultSeverity;
+  return {
+    alert_type: toAlertType(breakClass), // guaranteed in the legal CHECK set by child A
+    severity: sev,
+    title: title || `Breakage: ${spec.label}`,
+    message: message || `${spec.label} detected by the breakage detector`,
+    source_service: sourceService,
+    source_entity_id: sourceEntityId || null,
+    metadata: { ...(metadata && typeof metadata === 'object' ? metadata : {}), break_class: breakClass },
+  };
+}
+
+/**
+ * Persist a breakage alert to system_alerts — the single fail-loud, deduped write-contract.
+ * @param {object} supabase - Supabase client
+ * @param {object} opts - { breakClass (required, in BREAK_CLASSES), sourceService (required), severity?, title?, message?, sourceEntityId?, metadata? }
+ * @returns {Promise<{id: string, deduped: boolean}>}
+ */
+async function recordSystemAlert(supabase, opts = {}) {
+  const row = buildAlertRow(opts); // loud reject on bad class / missing source before any IO
+
+  // Dedup: skip if an OPEN (unresolved) alert for the same break_class + source already exists.
+  const { data: existing, error: dedupErr } = await supabase
+    .from('system_alerts')
+    .select('id')
+    .eq('source_service', row.source_service)
+    .eq('metadata->>break_class', row.metadata.break_class)
+    .is('resolved_at', null)
+    .limit(1);
+  if (dedupErr) {
+    throw new Error(`[recordSystemAlert] dedup query failed (fail-loud): ${dedupErr.message}`);
+  }
+  if (Array.isArray(existing) && existing.length > 0) {
+    return { id: existing[0].id, deduped: true };
+  }
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from('system_alerts')
+    .insert(row)
+    .select('id')
+    .single();
+  if (insertErr) {
+    throw new Error(`[recordSystemAlert] insert failed (fail-loud): ${insertErr.message}`);
+  }
+  return { id: inserted.id, deduped: false };
+}
+
+module.exports = { recordSystemAlert, buildAlertRow };

--- a/lib/breakage/alert-writer.cjs
+++ b/lib/breakage/alert-writer.cjs
@@ -18,6 +18,11 @@
  *
  * @module lib/breakage/alert-writer
  */
+// @wire-check-exempt: write-contract for the BREAKAGE-DETECTOR decomposition; consumers are sibling
+// children C (detector wiring) / D (canary) / F (harness) which are not yet built. Correctly
+// unreferenced until child C imports recordSystemAlert — NOT dead code. REMOVE this marker when a
+// sibling imports it (then it is genuinely reachable and must be wire-checked). Coordinator-
+// sanctioned exemption pattern for a decomposition-root module (same as child A's taxonomy).
 'use strict';
 
 const {

--- a/tests/unit/alert-writer.test.js
+++ b/tests/unit/alert-writer.test.js
@@ -1,0 +1,97 @@
+/**
+ * SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B — recordSystemAlert write-contract pins.
+ * Uses a FAKE supabase — zero live system_alerts writes. Verifies: legal alert_type (via the
+ * child-A toAlertType) + metadata.break_class + legal severity + all NOT-NULL columns; unknown
+ * break-class loud reject; OPEN-alert dedup; fail-loud on query/insert error.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { recordSystemAlert, buildAlertRow } = require('../../lib/breakage/alert-writer.cjs');
+const { BREAK_CLASSES, LEGAL_SEVERITIES, LEGAL_ALERT_TYPES } = require('../../lib/coordinator/break-class-taxonomy.cjs');
+
+// Fake supabase: dedup path (from().select().eq().eq().is().limit()) resolves `existing`;
+// insert path (from().insert(row).select().single()) captures the row + resolves `insertResult`.
+function fakeSupabase({ existing = [], dedupError = null, insertError = null, onInsert } = {}) {
+  const dedupChain = {
+    select() { return dedupChain; },
+    eq() { return dedupChain; },
+    is() { return dedupChain; },
+    limit() { return Promise.resolve({ data: existing, error: dedupError }); },
+  };
+  return {
+    from() {
+      return {
+        select: dedupChain.select,
+        eq: dedupChain.eq,
+        is: dedupChain.is,
+        limit: dedupChain.limit,
+        insert(row) {
+          if (onInsert) onInsert(row);
+          return { select() { return { single() {
+            return Promise.resolve({ data: insertError ? null : { id: 'new-alert-id' }, error: insertError });
+          } }; } };
+        },
+      };
+    },
+  };
+}
+
+describe('recordSystemAlert — canonical system_alerts write-contract (child B)', () => {
+  it('builds a legal row: alert_type via toAlertType, metadata.break_class, legal severity, all NOT-NULL cols', async () => {
+    let row = null;
+    const sb = fakeSupabase({ existing: [], onInsert: (r) => { row = r; } });
+    const res = await recordSystemAlert(sb, { breakClass: 'schema-drift', sourceService: 'schema-lint' });
+    expect(res).toEqual({ id: 'new-alert-id', deduped: false });
+    expect(LEGAL_ALERT_TYPES).toContain(row.alert_type);
+    expect(LEGAL_SEVERITIES).toContain(row.severity);
+    expect(row.metadata.break_class).toBe('schema-drift');
+    expect(row.source_service).toBe('schema-lint');
+    // NOT-NULL columns all present + truthy
+    for (const col of ['alert_type', 'severity', 'title', 'message', 'source_service']) {
+      expect(row[col]).toBeTruthy();
+    }
+  });
+
+  it('every break class produces a legal alert_type + severity (buildAlertRow, pure)', () => {
+    for (const bc of BREAK_CLASSES) {
+      const r = buildAlertRow({ breakClass: bc, sourceService: 'x' });
+      expect(LEGAL_ALERT_TYPES).toContain(r.alert_type);
+      expect(LEGAL_SEVERITIES).toContain(r.severity);
+      expect(r.metadata.break_class).toBe(bc);
+    }
+  });
+
+  it('an illegal caller severity falls back to a legal default', () => {
+    const r = buildAlertRow({ breakClass: 'row-growth-anomaly', sourceService: 'x', severity: 'CATASTROPHIC' });
+    expect(LEGAL_SEVERITIES).toContain(r.severity);
+  });
+
+  it('unknown break class → loud reject (throws), no IO', async () => {
+    const sb = fakeSupabase({});
+    await expect(recordSystemAlert(sb, { breakClass: 'not-a-class', sourceService: 'x' })).rejects.toThrow(/unknown break class/i);
+  });
+
+  it('missing sourceService (NOT NULL) → loud reject', async () => {
+    const sb = fakeSupabase({});
+    await expect(recordSystemAlert(sb, { breakClass: 'schema-drift' })).rejects.toThrow(/sourceService/i);
+  });
+
+  it('duplicate OPEN alert (same break_class + source) → deduped, no second insert', async () => {
+    let inserted = false;
+    const sb = fakeSupabase({ existing: [{ id: 'existing-open' }], onInsert: () => { inserted = true; } });
+    const res = await recordSystemAlert(sb, { breakClass: 'gate-pipeline-down', sourceService: 'canary' });
+    expect(res).toEqual({ id: 'existing-open', deduped: true });
+    expect(inserted).toBe(false);
+  });
+
+  it('dedup query error → fail-loud (throws)', async () => {
+    const sb = fakeSupabase({ dedupError: { message: 'conn lost' } });
+    await expect(recordSystemAlert(sb, { breakClass: 'schema-drift', sourceService: 'x' })).rejects.toThrow(/dedup query failed/i);
+  });
+
+  it('insert error → fail-loud (throws, not swallowed)', async () => {
+    const sb = fakeSupabase({ existing: [], insertError: { message: 'check violation' } });
+    await expect(recordSystemAlert(sb, { breakClass: 'schema-drift', sourceService: 'x' })).rejects.toThrow(/insert failed/i);
+  });
+});


### PR DESCRIPTION
## Child B — the system_alerts write-contract

Second leaf of the BREAKAGE-DETECTOR orchestrator (depends on child A #4698, merged). `lib/breakage/alert-writer.cjs` `recordSystemAlert()` is the single fail-loud, deduped writer that children C/D (detectors/canary) + F (catch-rate harness) use to persist alerts to `system_alerts`.

- Consumes child A's frozen taxonomy: `alert_type` via `toAlertType()` (legal CHECK set), class id in `metadata.break_class` (harness read-back key), severity in `{info,warning,critical}`.
- Reuses the 14 existing `system_alerts` columns (verified live schema — `alert_type`/`severity`/`title`/`message`/`source_service` NOT NULL). **NO alert_type CHECK widening** (protects the 3 live EVA SECURITY-DEFINER fns).
- **Dedup:** an OPEN alert (`resolved_at IS NULL`) for the same `(metadata.break_class, source_service)` is suppressed.
- **Fail-loud:** dedup/insert errors throw — never silently swallowed.

## Tests (8/8, fake supabase — zero live writes)
Legal `alert_type`/severity for all 7 classes, illegal-severity fallback, unknown-class loud reject, missing-source reject, OPEN-alert dedup, dedup-error + insert-error fail-loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)