### PR TITLE
docs(SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B): CHANGELOG for the system_alerts write-contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## Table of Contents
 
+- [2026-06-13](#2026-06-13)
+  - [Infrastructure](#infrastructure)
+  - [Bugfix](#bugfix)
 - [2026-06-12](#2026-06-12)
   - [Infrastructure](#infrastructure)
   - [Bugfix](#bugfix)
@@ -49,6 +52,11 @@
   - [EHG (Venture App)](#ehg-venture-app)
 
 ## 2026-06-13
+
+### Infrastructure
+- **Every breakage detector now writes alerts through one fail-loud, deduped contract** - PR #4701 (SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B)
+  - **What shipped**: `lib/breakage/alert-writer.cjs` — `recordSystemAlert(supabase, opts)` + pure `buildAlertRow(opts)`: the single write-contract that every breakage detector, the canary (children C/D), and the catch-rate harness (F) use to persist a breakage alert to `system_alerts`. It consumes child A’s frozen taxonomy (`lib/coordinator/break-class-taxonomy.cjs`), maps the precise break-class id into the LIVE `system_alerts_alert_type_check` legal set via `toAlertType()` — **no CHECK widening** (protects the 3 live EVA SECURITY-DEFINER functions) — rides the precise class id in `metadata.break_class`, dedups OPEN alerts on `(source_service, metadata->>break_class)`, and throws fail-loud on any query/insert error. Reuses the 14 existing `system_alerts` columns; no schema migration.
+  - **Verification**: `tests/unit/alert-writer.test.js` 8/8 (fake supabase, zero live writes). `@wire-check-exempt` decomposition-root marker (removed when child C imports the writer). Canonical API doc is the in-module JSDoc contract header (lines 1-25).
 
 ### Bugfix
 - **QF classifier no longer auto-escalates same-generator siblings** - PR #4682 (SD-FDBK-FIX-CLASSIFY-QUICK-FIX-001)


### PR DESCRIPTION
Post-completion documentation follow-up for **SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B** (child B). The feature merged in PR #4701 (sha 97642ad5) without a CHANGELOG entry; for an infrastructure SD the CHANGELOG entry is the primary doc deliverable per the SD-type doc matrix, so this closes that gap.

## What this documents
`lib/breakage/alert-writer.cjs` — `recordSystemAlert(supabase, opts)` + pure `buildAlertRow(opts)`: the single fail-loud, deduped write-contract that every breakage detector, the canary (children C/D), and the catch-rate harness (F) use to persist a breakage alert to `system_alerts`. Highlights captured in the entry:
- consumes child A's frozen taxonomy (`lib/coordinator/break-class-taxonomy.cjs`)
- maps the break class to `alert_type` via `toAlertType()` into the LIVE `system_alerts_alert_type_check` legal set — **no CHECK widening** (protects the 3 live EVA SECURITY-DEFINER functions)
- rides the precise class id in `metadata.break_class`, dedups OPEN alerts on `(source_service, metadata->>break_class)`, throws fail-loud on any query/insert error
- reuses the 14 existing `system_alerts` columns; no schema migration

## Scope
- CHANGELOG.md only: +8 lines (new 2026-06-13 Infrastructure entry + ToC entry). No code change.
- The module's public API is documented canonically by its in-module JSDoc contract header (lines 1-25) plus per-function JSDoc — verified adequate during this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)