### PR TITLE
fix(SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001): sd-next + child-selector auto-release honors armed silence

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001.json
@@ -1,0 +1,55 @@
+{
+  "executive_summary": "The 3rd/last armed-silence reaper seam. RCA-confirmed live recurrence: during a multi-tick /loop SD build, the worker process EXITS between ticks (re-invoked by ScheduleWakeup) so its PID looks dead and the heartbeat ages; the sd-next auto-release path (scripts/modules/sd-next/claim-analysis.js analyzeClaimRelationship -> autoReleaseStaleDeadClaim -> release_sd RPC) then classifies the PARKED-but-claimed SD as stale_dead (canAutoRelease=true) and reaps it, and the phase rolls back to draft/LEAD — so the next tick Gate-0 pre-commit blocks 'SD is in DRAFT status' until a manual service-client reconcile (the 790368e7 workaround run every tick this session). The claim_sd arbiter (CLAIM-RPC-HONOR-001) + the peer-release seams (CLAIM-SILENCE-CONSUME-VERIFY-001) already honor the armed-silence window via the ONE shared predicate lib/fleet/silence-cap.cjs isWithinArmedSilenceWindow(expectedSilenceUntil, nowMs); this SD extends the SAME predicate to the sd-next/release_sd path: a claim whose holder's claude_sessions.expected_silence_until is within the armed-silence window is PARKED (intentionally silent, coming back) — NOT dead — so it is NOT auto-released or phase-reset. The fail-safe is preserved: an expired / over-SILENCE_HARD_CAP_MS / absent window falls through to the normal stale_dead classification and is still reaped.",
+  "functional_requirements": [
+    { "id": "FR-1", "title": "Gate the sd-next auto-release on the shared armed-silence predicate", "description": "In scripts/modules/sd-next/claim-analysis.js analyzeClaimRelationship, add a guard (after the same_conversation check, BEFORE the status/heartbeat stale classification): if isWithinArmedSilenceWindow(claimingSession.expected_silence_until, Date.now()) return { relationship:'parked_armed_silence', canAutoRelease:false, displayLabel:'PARKED (armed silence)' }. REUSE the ONE shared predicate from lib/fleet/silence-cap.cjs — do NOT add a 4th copy. This makes a parked /loop worker (PID dead between ticks) NOT reapable while its armed-silence window is live.", "priority": "high", "acceptance_criteria": ["a claim whose holder's expected_silence_until is within the armed-silence window -> canAutoRelease=false (not reaped)", "the shared isWithinArmedSilenceWindow predicate is imported + reused (no 4th copy)", "the guard precedes the stale_inactive/stale_dead classification"] },
+    { "id": "FR-2", "title": "Carry expected_silence_until into the claim analysis", "description": "Ensure the activeSessions fetch that builds claimingSession includes claude_sessions.expected_silence_until (so analyzeClaimRelationship can read it). Add the column to the select if missing; null/absent is handled (predicate returns false -> normal classification).", "priority": "high", "acceptance_criteria": ["claimingSession includes expected_silence_until from the activeSessions source", "a missing/null expected_silence_until falls through to normal classification (fail-safe)"] },
+    { "id": "FR-3", "title": "Fail-safe: genuinely-stale claims still reap", "description": "An EXPIRED window (now >= expected_silence_until), an OVER-CAP window (delta > SILENCE_HARD_CAP_MS), or an ABSENT window must NOT block the reap — the predicate returns false and the existing stale_dead/stale_inactive path still auto-releases. No claim-stuck-forever. A foreign live worker (fresh heartbeat) is already other_active (not reaped). Pin this.", "priority": "high", "acceptance_criteria": ["expired window -> not within -> normal classification (stale_dead still reaps)", "over-SILENCE_HARD_CAP_MS window -> not within -> reaps", "absent window -> not within -> reaps; no regression to the other relationships"] },
+    { "id": "FR-4", "title": "sd-start re-affirm restores current_phase (belt-and-suspenders)", "description": "If a parked claim was nonetheless phase-reset (e.g. by a path this SD does not gate), sd-start re-affirm should restore current_phase for a self-held resumed claim, not just the claim — so a worker is never left at draft/LEAD with WIP. (Only if a cheap, safe restore exists; otherwise document the primary FR-1 fix is sufficient and this is covered by the worker's tick-reconcile.)", "priority": "medium", "acceptance_criteria": ["a self-held resumed claim is not left phase-reset when a prior phase existed", "the restore is bounded/safe (does not fabricate a phase)"] },
+    { "id": "FR-5", "title": "Regression test", "description": "Unit test for analyzeClaimRelationship: within-window expected_silence_until -> parked_armed_silence/canAutoRelease=false even when status=idle or PID dead; expired/over-cap/absent window -> the prior classification (stale_dead reaps) is unchanged; same_conversation + other_active unaffected.", "priority": "high", "acceptance_criteria": ["within-window -> not reaped (pinned)", "expired/over-cap/absent -> still reaps (pinned)", "no regression to same_conversation/other_active/stale_remote"] }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Reuse the ONE predicate", "description": "Import isWithinArmedSilenceWindow + SILENCE_HARD_CAP_MS from lib/fleet/silence-cap.cjs (CJS) into claim-analysis.js (ESM) via interop/createRequire — never duplicate. Parity with claim-guard.mjs / claim-validity-gate.js / coordinator-cold-recovery.cjs." },
+    { "id": "TR-2", "title": "Fail-safe direction", "description": "The guard only SUPPRESSES a reap when definitely within an armed-silence window; any ambiguity (null/expired/over-cap/parse-fail) falls through to the existing classification -> reaps. Never strand a genuinely-dead claim." },
+    { "id": "TR-3", "title": "Out of scope", "description": "Do NOT change the claim_sd arbiter (CLAIM-RPC-HONOR-001) or the peer-release/sweep seams (CLAIM-SILENCE-CONSUME-VERIFY-001); no schema change; no new predicate copy." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "parked worker within armed-silence window (PID dead) -> not reaped", "type": "unit", "expected": "canAutoRelease=false, relationship=parked_armed_silence" },
+    { "id": "TS-2", "scenario": "expired / over-cap / absent window -> stale_dead still reaps", "type": "unit", "expected": "canAutoRelease=true (unchanged)" },
+    { "id": "TS-3", "scenario": "same_conversation + other_active unaffected", "type": "unit", "expected": "canAutoRelease=false (yours / active)" }
+  ],
+  "acceptance_criteria": [
+    "The sd-next/release_sd auto-release path honors the armed-silence window via the shared isWithinArmedSilenceWindow predicate (no 4th copy): a parked-but-claimed multi-tick SD within its window is NOT reaped or phase-reset",
+    "The fail-safe holds: expired/over-cap/absent window + foreign live claims still reap (no claim-stuck-forever)",
+    "Regression test pins within-window-skip + outside-window/expired-still-reap; adversarial review of predicate parity + fail-safe + no-regression clean"
+  ],
+  "risks": [
+    { "risk": "Claim-stuck-forever if a genuinely-dead claim is mis-treated as parked", "mitigation": "isWithinArmedSilenceWindow returns false for null/expired/over-SILENCE_HARD_CAP_MS, so an abandoned claim (no fresh arming) reaps once the window lapses; the hard cap bounds the max suppression. TS-2 pins it.", "severity": "high" },
+    { "risk": "A 4th predicate copy drifts from the canonical one", "mitigation": "Import lib/fleet/silence-cap.cjs; adversarial review asserts byte-parity reuse.", "severity": "medium" },
+    { "risk": "expected_silence_until not present in claimingSession", "mitigation": "FR-2 adds it to the activeSessions select; absent -> false -> normal classification (fail-safe).", "severity": "medium" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["the /loop fleet worker (multi-tick builds no longer phase-reset between ticks)", "sd-next display/recommendation paths"],
+    "dependencies": ["lib/fleet/silence-cap.cjs (isWithinArmedSilenceWindow + SILENCE_HARD_CAP_MS)", "scripts/modules/sd-next/claim-analysis.js (analyzeClaimRelationship + autoReleaseStaleDeadClaim)", "the activeSessions source (claude_sessions.expected_silence_until)"],
+    "data_contracts": ["read claude_sessions.expected_silence_until; no writes beyond the existing release path; NO schema change"],
+    "runtime_config": ["SILENCE_HARD_CAP_MS bounds the max suppression window"],
+    "observability_rollout": ["a parked claim shows 'PARKED (armed silence)' instead of being reaped; unit pins"]
+  },
+  "system_architecture": {
+    "summary": "A single guard in the sd-next reap-decision function (analyzeClaimRelationship) using the shared armed-silence predicate, plus carrying expected_silence_until into the claim analysis, with a strict fail-safe direction.",
+    "components": [
+      { "name": "scripts/modules/sd-next/claim-analysis.js", "change": "MODIFY: import + apply isWithinArmedSilenceWindow guard in analyzeClaimRelationship (FR-1)" },
+      { "name": "the activeSessions fetch (sd-next)", "change": "MODIFY: add expected_silence_until to the select (FR-2)" },
+      { "name": "tests/unit/...-armed-silence.test.js", "change": "NEW: FR-5 regression pins" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Reuse the ONE shared armed-silence predicate; add a parked-armed-silence guard before the stale classification in the sd-next reap decision; carry expected_silence_until into claimingSession; keep a strict fail-safe (only suppress within a live, bounded window); pin with unit tests; adversarially review parity + fail-safe before merge.",
+    "steps": ["import + guard in analyzeClaimRelationship", "add expected_silence_until to the activeSessions select", "unit tests (within-skip / expired-reap)", "PRD->adversarial review->PR->full chain->LFA"]
+  },
+  "smoke_test_steps": [
+    { "instruction": "npx vitest run the new release_sd/sd-next armed-silence regression test", "expected_outcome": "the auto-release path SKIPS reaping a parked-but-claimed SD whose claim is within its armed-silence window (isWithinArmedSilenceWindow) and does NOT phase-reset it; outside-window/expired/over-cap claims still reap" },
+    { "instruction": "Simulate a parked multi-tick SD (claiming_session_id=self, is_working_on=true, expected_silence_until in the future) and run the sd-next/release_sd reap path", "expected_outcome": "the SD is NOT released and current_phase is NOT reset to draft/LEAD (no Gate-0 DRAFT block next tick); the worker commits WIP without a manual service-client reconcile" },
+    { "instruction": "Confirm the SHARED isWithinArmedSilenceWindow predicate is REUSED (not a 4th copy) and the hard cap still reaps a genuinely-stale claim", "expected_outcome": "ONE predicate imported (byte-parity with the claim_sd + peer-release seams); SILENCE_HARD_CAP_MS bounds the window; expired/forced/over-cap claims still reap (fail-safe)" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001" }
+}

--- a/scripts/modules/handoff/child-sd-selector.js
+++ b/scripts/modules/handoff/child-sd-selector.js
@@ -15,6 +15,10 @@ import { sortByUrgency, scoreToBand } from '../auto-proceed/urgency-scorer.js';
 import { buildDependencyDAG, detectCycles, computeRunnableSet } from '../../../lib/orchestrator/dependency-dag.js';
 import { computeGateState } from '../../../lib/cadence/pre-claim-gate.mjs';
 import { isLeadDecisionPaused } from '../sd-next/status-helpers.js';
+// SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001: route the child-path stale-claim reap through the SAME
+// gated helper the sd-next reaper uses, so a PARKED /loop worker on a CHILD SD (armed silence, PID dead
+// between ticks) is NOT reaped/phase-reset while its window is live. Reuses the ONE shared predicate.
+import { autoReleaseStaleDeadClaim } from '../sd-next/claim-analysis.js';
 
 /**
  * Check if an SD is a child (has a parent)
@@ -143,9 +147,17 @@ export async function getNextReadyChild(supabase, parentSdId, excludeCompletedId
           continue;
         }
         if (hbAge > 900) {
-          // Stale claim (> 15min) — auto-release and return this child
-          console.log(`   [child-sd-selector] Auto-releasing stale claim on ${candidate.sd_key} (${Math.round(hbAge)}s stale)`);
-          await supabase.rpc('release_sd', { p_session_id: candidate.claiming_session_id, p_reason: 'stale_child_auto_release' }).catch(() => {});
+          // Stale claim (> 15min) — auto-release via the GATED helper so a parked /loop worker within its
+          // armed-silence window (SILENCE_HARD_CAP 30min > this 15min trigger) is NOT reaped/phase-reset.
+          // autoReleaseStaleDeadClaim fetches expected_silence_until + applies isWithinArmedSilenceWindow
+          // (fail-open: expired/over-cap/absent/error still reaps). false = parked (or release failed) →
+          // leave the claim and skip this sibling to be safe (no double-claim hand-out).
+          const released = await autoReleaseStaleDeadClaim(supabase, candidate.claiming_session_id, 'stale_child_auto_release');
+          if (!released) {
+            console.log(`   [child-sd-selector] Skipping ${candidate.sd_key} — claim parked (armed silence) or release failed`);
+            continue;
+          }
+          console.log(`   [child-sd-selector] Auto-released stale claim on ${candidate.sd_key} (${Math.round(hbAge)}s stale)`);
           return { sd: candidate, allComplete: false, reason: 'Stale claim released, child available' };
         }
         // Between 5-15min — ambiguous, skip to be safe

--- a/scripts/modules/sd-next/claim-analysis.js
+++ b/scripts/modules/sd-next/claim-analysis.js
@@ -11,6 +11,10 @@ import os from 'os';
 import { isSameConversation } from '../../../lib/claim-guard.mjs';
 import { isProcessRunning } from '../../../lib/heartbeat-manager.mjs';
 import { getStaleThresholdSeconds } from '../../../lib/claim/stale-threshold.js';
+// SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001 (3rd/last reaper seam): the ONE shared armed-silence
+// predicate — same import claim-guard.mjs uses; do NOT duplicate. Parity with claim_sd (CLAIM-RPC-HONOR-001)
+// + the peer-release seams (CLAIM-SILENCE-CONSUME-VERIFY-001) + the stale-session-sweep (already honors it).
+import { isWithinArmedSilenceWindow } from '../../../lib/fleet/silence-cap.cjs';
 
 /**
  * Analyze the relationship between the current session and a claiming session.
@@ -60,6 +64,23 @@ export function analyzeClaimRelationship({ claimingSessionId: _claimingSessionId
         pid: claimPid
       };
     }
+  }
+
+  // SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001: a PARKED /loop worker arms expected_silence_until and
+  // EXITS between ticks (so its PID looks dead + heartbeat ages), but it is intentionally silent and COMING
+  // BACK — not dead. While its armed-silence window is live, do NOT mark the claim auto-releasable (parity
+  // with claim_sd + the sweep + the peer-release seams; reuse the ONE predicate). Fail-safe: an expired /
+  // over-SILENCE_HARD_CAP_MS / absent window returns false here and falls through to normal classification,
+  // so a genuinely-dead claim still reaps. (Defensive: the v_active_sessions view does not expose this field
+  // today, so in the display path this is a no-op until the session is enriched; the AUTHORITATIVE gate is
+  // at the release choke point autoReleaseStaleDeadClaim below, which fetches the field from claude_sessions.)
+  if (isWithinArmedSilenceWindow(claimingSession?.expected_silence_until, Date.now())) {
+    return {
+      relationship: 'parked_armed_silence',
+      canAutoRelease: false,
+      displayLabel: 'PARKED (armed silence)',
+      pid: claimPid,
+    };
   }
 
   // Session explicitly released/stale/idle → safe to auto-release regardless of heartbeat
@@ -237,6 +258,23 @@ export function checkEnrichmentSignal({ sd, activeSessions, recencyMinutes } = {
  * @returns {Promise<boolean>} true if released successfully
  */
 export async function autoReleaseStaleDeadClaim(supabase, sessionId) {
+  // SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001 (the AUTHORITATIVE gate — DB truth lives here, not in
+  // the pure display function): a parked /loop worker exits between ticks (PID dead) but is coming back
+  // while its armed-silence window is live. Honor it via the ONE shared predicate (parity with claim_sd +
+  // the peer-release seams + the sweep). Skipping the release_sd RPC prevents BOTH the claim clear AND the
+  // phase-reset that follows it (the 790368e7 Gate-0 DRAFT block). FAIL-OPEN: any fetch error / null /
+  // expired / over-cap window proceeds to release, so a genuinely-dead claim still reaps (no stuck-forever).
+  try {
+    const { data: sess } = await supabase
+      .from('claude_sessions')
+      .select('expected_silence_until')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (sess && isWithinArmedSilenceWindow(sess.expected_silence_until, Date.now())) {
+      return false; // parked within the armed-silence window — do NOT auto-release / phase-reset
+    }
+  } catch { /* fail-open: proceed to release a genuinely-stale claim */ }
+
   const { error: rpcError } = await supabase.rpc('release_sd', {
     p_session_id: sessionId,
     p_reason: 'auto_release_dead_pid'

--- a/scripts/modules/sd-next/claim-analysis.js
+++ b/scripts/modules/sd-next/claim-analysis.js
@@ -255,9 +255,10 @@ export function checkEnrichmentSignal({ sd, activeSessions, recencyMinutes } = {
  *
  * @param {Object} supabase - Supabase client
  * @param {string} sessionId - The claiming session to release
+ * @param {string} [reason='auto_release_dead_pid'] - Audit reason recorded on release_sd / the fallback update
  * @returns {Promise<boolean>} true if released successfully
  */
-export async function autoReleaseStaleDeadClaim(supabase, sessionId) {
+export async function autoReleaseStaleDeadClaim(supabase, sessionId, reason = 'auto_release_dead_pid') {
   // SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001 (the AUTHORITATIVE gate — DB truth lives here, not in
   // the pure display function): a parked /loop worker exits between ticks (PID dead) but is coming back
   // while its armed-silence window is live. Honor it via the ONE shared predicate (parity with claim_sd +
@@ -277,7 +278,7 @@ export async function autoReleaseStaleDeadClaim(supabase, sessionId) {
 
   const { error: rpcError } = await supabase.rpc('release_sd', {
     p_session_id: sessionId,
-    p_reason: 'auto_release_dead_pid'
+    p_reason: reason
   });
 
   if (!rpcError) return true;
@@ -288,7 +289,7 @@ export async function autoReleaseStaleDeadClaim(supabase, sessionId) {
     .update({
       sd_key: null,
       released_at: new Date().toISOString(),
-      released_reason: 'auto_release_dead_pid',
+      released_reason: reason,
       status: 'idle'
     })
     .eq('session_id', sessionId);

--- a/tests/unit/release-sd-honor-armed-silence.test.js
+++ b/tests/unit/release-sd-honor-armed-silence.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001 — the 3rd/last armed-silence reaper seam.
+ * Pins: the sd-next auto-release path honors a parked worker's armed-silence window (within-window ->
+ * NOT reaped/phase-reset) while preserving the fail-safe (expired / over-cap / absent window -> still reaps).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { analyzeClaimRelationship, autoReleaseStaleDeadClaim } from '../../scripts/modules/sd-next/claim-analysis.js';
+const require = createRequire(import.meta.url);
+const { SILENCE_HARD_CAP_MS } = require('../../lib/fleet/silence-cap.cjs');
+
+const NOW = Date.now();
+const iso = (deltaMs) => new Date(NOW + deltaMs).toISOString();
+// A claiming session that the STATUS path would auto-release (status=idle), with a dead-looking PID +
+// stale heartbeat — so any 'not reaped' result is solely due to the armed-silence guard firing first.
+const reapableSession = (overrides = {}) => ({ status: 'idle', heartbeat_age_seconds: 99999, pid: null, hostname: 'h', ...overrides });
+
+describe('analyzeClaimRelationship — armed-silence guard (FR-1/FR-3)', () => {
+  it('within the armed-silence window -> parked_armed_silence, NOT auto-releasable (even when status=idle)', () => {
+    const r = analyzeClaimRelationship({ claimingSession: reapableSession({ expected_silence_until: iso(5 * 60 * 1000) }), currentSession: null });
+    expect(r.relationship).toBe('parked_armed_silence');
+    expect(r.canAutoRelease).toBe(false);
+  });
+
+  it('FAIL-SAFE: an EXPIRED window falls through -> stale_inactive, still auto-releasable', () => {
+    const r = analyzeClaimRelationship({ claimingSession: reapableSession({ expected_silence_until: iso(-5 * 60 * 1000) }), currentSession: null });
+    expect(r.relationship).toBe('stale_inactive');
+    expect(r.canAutoRelease).toBe(true);
+  });
+
+  it('FAIL-SAFE: an OVER-CAP window (> SILENCE_HARD_CAP_MS) falls through -> still auto-releasable', () => {
+    const r = analyzeClaimRelationship({ claimingSession: reapableSession({ expected_silence_until: iso(SILENCE_HARD_CAP_MS + 60 * 1000) }), currentSession: null });
+    expect(r.canAutoRelease).toBe(true);
+  });
+
+  it('FAIL-SAFE: an ABSENT window falls through -> still auto-releasable', () => {
+    const r = analyzeClaimRelationship({ claimingSession: reapableSession(), currentSession: null });
+    expect(r.canAutoRelease).toBe(true);
+  });
+
+  it('a fresh-heartbeat foreign claim with no window is other_active (unaffected)', () => {
+    const r = analyzeClaimRelationship({ claimingSession: { status: 'active', heartbeat_age_seconds: 1, pid: null, hostname: 'h' }, currentSession: null });
+    expect(r.relationship).toBe('other_active');
+    expect(r.canAutoRelease).toBe(false);
+  });
+});
+
+// Fake supabase that records whether release_sd was invoked.
+function fakeSb({ expectedSilenceUntil = null } = {}) {
+  const calls = { rpc: [] };
+  return {
+    calls,
+    from() {
+      return { select() { return this; }, eq() { return this; }, maybeSingle: () => Promise.resolve({ data: { expected_silence_until: expectedSilenceUntil }, error: null }), update() { return { eq: () => Promise.resolve({ error: null }) }; } };
+    },
+    rpc(name, args) { calls.rpc.push({ name, args }); return Promise.resolve({ error: null }); },
+  };
+}
+
+describe('autoReleaseStaleDeadClaim — authoritative DB-backed armed-silence gate (FR-1/FR-2/FR-3)', () => {
+  it('within the armed-silence window -> SKIPS release_sd (returns false, no reap/phase-reset)', async () => {
+    const sb = fakeSb({ expectedSilenceUntil: iso(5 * 60 * 1000) });
+    const released = await autoReleaseStaleDeadClaim(sb, 'sess-parked');
+    expect(released).toBe(false);
+    expect(sb.calls.rpc.find((c) => c.name === 'release_sd')).toBeUndefined(); // never released
+  });
+
+  it('FAIL-SAFE: expired window -> release_sd IS called (genuinely-dead claim still reaps)', async () => {
+    const sb = fakeSb({ expectedSilenceUntil: iso(-5 * 60 * 1000) });
+    const released = await autoReleaseStaleDeadClaim(sb, 'sess-dead');
+    expect(released).toBe(true);
+    expect(sb.calls.rpc.find((c) => c.name === 'release_sd')).toBeDefined();
+  });
+
+  it('FAIL-SAFE: absent window -> release_sd IS called', async () => {
+    const sb = fakeSb({ expectedSilenceUntil: null });
+    const released = await autoReleaseStaleDeadClaim(sb, 'sess-dead');
+    expect(released).toBe(true);
+    expect(sb.calls.rpc.find((c) => c.name === 'release_sd')).toBeDefined();
+  });
+});

--- a/tests/unit/release-sd-honor-armed-silence.test.js
+++ b/tests/unit/release-sd-honor-armed-silence.test.js
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 import { analyzeClaimRelationship, autoReleaseStaleDeadClaim } from '../../scripts/modules/sd-next/claim-analysis.js';
+import { getNextReadyChild } from '../../scripts/modules/handoff/child-sd-selector.js';
 const require = createRequire(import.meta.url);
 const { SILENCE_HARD_CAP_MS } = require('../../lib/fleet/silence-cap.cjs');
 
@@ -77,5 +78,58 @@ describe('autoReleaseStaleDeadClaim — authoritative DB-backed armed-silence ga
     const released = await autoReleaseStaleDeadClaim(sb, 'sess-dead');
     expect(released).toBe(true);
     expect(sb.calls.rpc.find((c) => c.name === 'release_sd')).toBeDefined();
+  });
+});
+
+// Child-path coverage: the orchestrator child selector reaps a stale CHILD claim (>15min heartbeat). It must
+// route through the SAME gated helper so a parked /loop worker on a child SD (armed-silence, PID dead between
+// ticks) is NOT reaped/phase-reset — closing the sibling seam the adversarial review surfaced.
+function childSelectorSb({ claimerHbAge = 1000, sess = { expected_silence_until: null }, child } = {}) {
+  const calls = { rpc: [] };
+  const candidate = child || { id: 'child-1', sd_key: 'SD-CHILD-001', status: 'active', metadata: {}, governance_metadata: {}, created_at: '2026-06-13T00:00:00Z', claiming_session_id: 'sess-x', sd_type: 'feature' };
+  const sb = {
+    calls,
+    from(table) {
+      const b = { _table: table, _select: null };
+      b.select = (cols) => { b._select = cols; return b; };
+      b.eq = () => b;
+      b.neq = () => b;
+      b.in = () => b;
+      b.maybeSingle = () => {
+        if (table === 'v_active_sessions') return Promise.resolve({ data: { session_id: candidate.claiming_session_id, heartbeat_age_seconds: claimerHbAge, computed_status: 'stale' }, error: null });
+        if (table === 'claude_sessions') return Promise.resolve({ data: sess, error: null });
+        return Promise.resolve({ data: null, error: null });
+      };
+      // thenable: distinguish the two strategic_directives_v2 queries by their select columns
+      b.then = (resolve) => {
+        if (table === 'strategic_directives_v2') {
+          if (b._select && b._select.includes('claiming_session_id')) return resolve({ data: [candidate], error: null });
+          return resolve({ data: [{ id: candidate.id, status: candidate.status }], error: null }); // allChildren
+        }
+        return resolve({ data: null, error: null });
+      };
+      return b;
+    },
+    rpc(name, args) { calls.rpc.push({ name, args }); return Promise.resolve({ error: null }); },
+  };
+  return sb;
+}
+
+describe('getNextReadyChild — child-path armed-silence (sibling seam)', () => {
+  it('a stale CHILD claim within the armed-silence window is NOT reaped (no release_sd) and the child is NOT handed out', async () => {
+    const sb = childSelectorSb({ claimerHbAge: 1000, sess: { expected_silence_until: iso(5 * 60 * 1000) } });
+    const res = await getNextReadyChild(sb, 'parent-1');
+    expect(res.sd).toBeNull(); // parked child skipped -> falls through to "no ready children"
+    expect(sb.calls.rpc.find((c) => c.name === 'release_sd')).toBeUndefined();
+  });
+
+  it('FAIL-SAFE: a stale CHILD claim with an expired/absent window IS reaped (release_sd, child-specific reason) and the child is returned', async () => {
+    const sb = childSelectorSb({ claimerHbAge: 1000, sess: { expected_silence_until: null } });
+    const res = await getNextReadyChild(sb, 'parent-1');
+    expect(res.sd).not.toBeNull();
+    expect(res.sd.sd_key).toBe('SD-CHILD-001');
+    const rel = sb.calls.rpc.find((c) => c.name === 'release_sd');
+    expect(rel).toBeDefined();
+    expect(rel.args.p_reason).toBe('stale_child_auto_release'); // audit reason preserved through the gated helper
   });
 });


### PR DESCRIPTION
## Summary
The 3rd/last **armed-silence** reaper seam. RCA-confirmed live recurrence: during a multi-tick `/loop` SD build the worker process EXITS between ticks (re-invoked by ScheduleWakeup) so its PID looks dead and the heartbeat ages; the sd-next auto-release path then classifies the PARKED-but-claimed SD as stale_dead and reaps it, and the phase rolls back to draft/LEAD — so the next tick Gate-0 blocks 'SD is in DRAFT status' until a manual service-client reconcile (the 790368e7 workaround I ran every tick this session).

This extends the **ONE shared** armed-silence predicate (`lib/fleet/silence-cap.cjs isWithinArmedSilenceWindow`) — already honored by `claim_sd` (CLAIM-RPC-HONOR-001), the peer-release seams (CLAIM-SILENCE-CONSUME-VERIFY-001), and the stale-session-sweep — to the sd-next/release_sd path. A claim whose holder's `claude_sessions.expected_silence_until` is within the window is PARKED (intentionally silent, coming back), not dead, so it is NOT auto-released or phase-reset.

**Fail-safe preserved**: an expired / over-`SILENCE_HARD_CAP_MS` (30min) / absent / parse-fail / fetch-error window falls through and STILL reaps — no claim-stuck-forever.

## Changes
- `scripts/modules/sd-next/claim-analysis.js`:
  - `autoReleaseStaleDeadClaim` (the AUTHORITATIVE choke point, fetches `expected_silence_until` from `claude_sessions`) skips `release_sd` (returns false) when within the window; **fail-open** on any error/null/expired/over-cap. Optional `reason` param (default unchanged).
  - `analyzeClaimRelationship` defensive pure guard returns `parked_armed_silence`/`canAutoRelease=false` (no-op in the display path until `v_active_sessions` is enriched; the choke point is authoritative — documented inline).
- `scripts/modules/handoff/child-sd-selector.js` **(found by adversarial review)**: the child-path stale-claim reap was a direct `release_sd` RPC firing at hbAge>900s/15min with no armed-silence check — a parked worker on a CHILD SD could still be reaped. Now routed through the gated `autoReleaseStaleDeadClaim` (reuses the ONE predicate; child-specific audit reason preserved; false→skip sibling).
- `tests/unit/release-sd-honor-armed-silence.test.js`: 10 pins (within-window→parked/not-reaped; expired/over-cap/absent→still reaps; child-path parked→no release_sd; child-path expired→reaped+returned+reason).

## Verification
- 21 unit tests pass (8 armed-silence + 2 child-path + 11 existing claim-analysis); 23 existing child-sd-selector tests pass (no regression). Smoke + Gate 0 green.
- Adversarial-review Workflow (4 lenses) — 1 confirmed major defect (the child-selector seam above), now fixed; no claim-stuck-forever, no regression to the other seams.

## Residual (out of scope, follow-up)
child-sd-selector still reaps on heartbeat-age alone with no PID-liveness check — a busy-but-stale child worker (PID alive, no armed silence) could be reaped. Tracked as a completion follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)