### PR TITLE
feat(SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001): --from-proposal ingest mode

### DIFF
--- a/.claude/commands/sd-create.md
+++ b/.claude/commands/sd-create.md
@@ -22,6 +22,9 @@ SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-uat <test-id>
 SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-learn <pattern-id>
 SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-feedback <id>
 SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-plan [path]
+# Materialize sourced proposal(s) into DRAFT SD(s); --dry-run validates with zero writes
+# (SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001 — key taken verbatim from proposed_sd_key)
+SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --from-proposal <path|glob> [--dry-run]
 node scripts/modules/sd-key-generator.js --child <parent-key> <index>
 
 # Cross-repo SDs — set metadata.target_repos[] at creation time

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -16,11 +16,14 @@
  */
 
 import { randomUUID, createHash } from 'crypto';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, basename, join as joinPath } from 'node:path';
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import {
   generateSDKey,
   generateChildKey,
   deriveChildIndex,
+  keyExists,
   SD_SOURCES,
   SD_TYPES,
   normalizeVenturePrefix
@@ -2020,6 +2023,175 @@ export function formatDependencyForDisplay(dep) {
   return dep.dependency ?? dep.sd_key ?? dep.sd_id ?? dep.id ?? JSON.stringify(dep);
 }
 
+// ============================================================================
+// --from-proposal ingest (SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001)
+// Materialize .prd-payloads/PROPOSAL-*.json into DRAFT SDs via the EXISTING
+// createSD() path. Critical divergence from --from-plan: the key is taken
+// VERBATIM from proposed_sd_key (no generateSDKey / archive / content-hash).
+// validateProposalShape + mapProposalToCreateArgs are PURE + exported so unit
+// tests exercise them with zero DB access; createFromProposal accepts injected
+// deps {keyExists, createSD, readFile, resolveFiles} so dry-run + idempotency
+// are testable without the (non-injectable, module-singleton) live supabase.
+// ============================================================================
+
+const VALID_PROPOSAL_PRIORITIES = ['critical', 'high', 'medium', 'low'];
+
+/**
+ * Validate a parsed proposal object fail-loud. Required: proposed_sd_key, title,
+ * sd_type, priority (+ PROPOSAL===true, status_intended==='draft' when present).
+ * sd_type is validated by reusing mapToDbType() (canonical 15-value enum, throws);
+ * priority is lowercased + checked against the 4-value set. On any failure: a
+ * bracket-tokenized console.error + process.exit(1). Returns the normalized core.
+ * @param {object} proposal
+ * @param {string} filePath
+ * @returns {{sdKey:string,title:string,type:string,priority:string,rawType:string}}
+ */
+export function validateProposalShape(proposal, filePath) {
+  const where = filePath || '<proposal>';
+  if (!proposal || typeof proposal !== 'object' || Array.isArray(proposal)) {
+    console.error(`[INVALID_PROPOSAL] ${where}: payload must be a JSON object`);
+    process.exit(1);
+  }
+  if (proposal.PROPOSAL !== true) {
+    console.error(`[INVALID_PROPOSAL] ${where}: not a proposal (expected "PROPOSAL": true)`);
+    process.exit(1);
+  }
+  if (proposal.status_intended != null && proposal.status_intended !== 'draft') {
+    console.error(`[INVALID_PROPOSAL] ${where}: status_intended must be "draft" (got ${JSON.stringify(proposal.status_intended)})`);
+    process.exit(1);
+  }
+  for (const field of ['proposed_sd_key', 'title', 'sd_type', 'priority']) {
+    const v = proposal[field];
+    if (v === undefined || v === null || (typeof v === 'string' && v.trim() === '')) {
+      console.error(`[INVALID_PROPOSAL] ${where}: missing required field "${field}"`);
+      process.exit(1);
+    }
+  }
+  let type;
+  try {
+    type = mapToDbType(proposal.sd_type); // reuses canonical enum; throws on invalid
+  } catch (e) {
+    console.error(`[INVALID_PROPOSAL_SD_TYPE] ${where}: ${e.message}`);
+    process.exit(1);
+  }
+  const priority = String(proposal.priority).toLowerCase();
+  if (!VALID_PROPOSAL_PRIORITIES.includes(priority)) {
+    console.error(`[INVALID_PROPOSAL_PRIORITY] ${where}: "${proposal.priority}". Valid: ${VALID_PROPOSAL_PRIORITIES.join(', ')}`);
+    process.exit(1);
+  }
+  return { sdKey: proposal.proposed_sd_key, title: proposal.title, type, priority, rawType: proposal.sd_type };
+}
+
+/**
+ * Map a validated proposal to createSD() args. Key is verbatim; description falls
+ * back rationale -> scope -> title; metadata.source='proposal' + provenance.
+ * No vision_key/arch_key (avoids enrichFromVisionArch orphan-FK), no parentId,
+ * no orchestrator auto-routing. PURE.
+ */
+export function mapProposalToCreateArgs(normalized, proposal, filePath) {
+  return {
+    sdKey: normalized.sdKey,
+    title: normalized.title,
+    type: normalized.type,
+    priority: normalized.priority,
+    description: proposal.rationale || proposal.scope || proposal.title,
+    scope: proposal.scope || null,
+    success_criteria: Array.isArray(proposal.success_criteria) ? proposal.success_criteria : null,
+    metadata: {
+      source: 'proposal',
+      proposal_file_path: filePath || null,
+      proposal_provenance: proposal.provenance || null,
+      roadmap_phase: proposal.roadmap_phase || null,
+      tier_hint: proposal.tier_hint || null,
+      gold_origin: proposal.gold_origin || null,
+      necessity: proposal.necessity || null,
+      dedup_note: proposal.dedup_note || null,
+    },
+  };
+}
+
+/**
+ * Resolve a path or simple glob (basename may contain '*') to a sorted file list.
+ * Fail-loud if nothing matches / the file is missing.
+ */
+function resolveProposalFiles(pathOrGlob) {
+  if (!pathOrGlob || typeof pathOrGlob !== 'string') {
+    console.error('[INVALID_PROPOSAL] --from-proposal requires a file path or glob (e.g. .prd-payloads/PROPOSAL-*.json)');
+    process.exit(1);
+  }
+  if (pathOrGlob.includes('*')) {
+    const dir = dirname(pathOrGlob);
+    const pat = basename(pathOrGlob);
+    const rx = new RegExp('^' + pat.split('*').map(s => s.replace(/[.+?^${}()|[\]\\]/g, '\\$&')).join('.*') + '$');
+    let entries;
+    try { entries = readdirSync(dir); } catch (e) {
+      console.error(`[INVALID_PROPOSAL] cannot read directory "${dir}": ${e.message}`);
+      process.exit(1);
+    }
+    const matched = entries.filter(f => rx.test(f)).sort().map(f => joinPath(dir, f));
+    if (matched.length === 0) {
+      console.error(`[INVALID_PROPOSAL] no files match glob "${pathOrGlob}"`);
+      process.exit(1);
+    }
+    return matched;
+  }
+  if (!existsSync(pathOrGlob)) {
+    console.error(`[INVALID_PROPOSAL] file not found: "${pathOrGlob}"`);
+    process.exit(1);
+  }
+  return [pathOrGlob];
+}
+
+/**
+ * --from-proposal ingest: read PROPOSAL-*.json file(s), validate, and create a
+ * DRAFT SD per file via the existing createSD() path (verbatim key). Idempotent
+ * (skips an already-materialized key). --dry-run validates + reports, zero writes.
+ * @param {string} pathOrGlob
+ * @param {{dryRun?:boolean, deps?:{keyExists?:Function, createSD?:Function, readFile?:Function, resolveFiles?:Function}}} options
+ */
+export async function createFromProposal(pathOrGlob, options = {}) {
+  const { dryRun = false, deps = {} } = options;
+  const _keyExists = deps.keyExists || keyExists;
+  const _createSD = deps.createSD || createSD;
+  const _readFile = deps.readFile || readFileSync;
+  const _resolveFiles = deps.resolveFiles || resolveProposalFiles;
+
+  const files = _resolveFiles(pathOrGlob);
+  const results = [];
+  for (const file of files) {
+    let raw, proposal;
+    try {
+      raw = _readFile(file, 'utf8');
+    } catch (e) {
+      console.error(`[INVALID_PROPOSAL] ${file}: cannot read file: ${e.message}`);
+      process.exit(1);
+    }
+    try {
+      proposal = JSON.parse(raw);
+    } catch (e) {
+      console.error(`[INVALID_PROPOSAL] ${file}: invalid JSON: ${e.message}`);
+      process.exit(1);
+    }
+    const normalized = validateProposalShape(proposal, file);
+    const exists = await _keyExists(normalized.sdKey);
+    if (exists) {
+      console.log(`⏭️  ${normalized.sdKey} already exists, skipping (${file})`);
+      results.push({ sdKey: normalized.sdKey, file, action: 'skipped' });
+      continue;
+    }
+    const args = mapProposalToCreateArgs(normalized, proposal, file);
+    if (dryRun) {
+      console.log(`🔎 [dry-run] would create ${args.sdKey} (${args.type}/${args.priority}) — ${args.title}`);
+      results.push({ sdKey: normalized.sdKey, file, action: 'dry-run' });
+      continue;
+    }
+    await _createSD(args);
+    console.log(`✅ Created DRAFT SD ${args.sdKey} from ${file}`);
+    results.push({ sdKey: normalized.sdKey, file, action: 'created' });
+  }
+  return results;
+}
+
 // Export for programmatic use (e.g., corrective-sd-generator)
 // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-4): export buildDefaultSmokeTestSteps for unit-test access.
 export { createSD, buildDefaultSmokeTestSteps };
@@ -2040,6 +2212,7 @@ Usage:
   node scripts/leo-create-sd.js --from-learn <pattern-id>
   node scripts/leo-create-sd.js --from-feedback <feedback-id>
   node scripts/leo-create-sd.js --from-qf <QF-ID>
+  node scripts/leo-create-sd.js --from-proposal <path|glob> [--dry-run]
   node scripts/leo-create-sd.js --from-plan [path] [--type <type>] [--title "<title>"]
   node scripts/leo-create-sd.js --child <parent-key> [index] [--type <type>] [--title "<title>"]
   node scripts/leo-create-sd.js <source> <type> "<title>"
@@ -2073,6 +2246,7 @@ Flags:
                         Pairs with computeReposForSD() at lead-final-approval/gates.js
                         (SD-LEO-INFRA-CROSS-REPO-MERGE-001). Supported in all 3 modes:
                         direct LEO, --from-plan, --child.
+  --dry-run          (--from-proposal only) Validate + report would-create SDs; ZERO database writes.
   --help             Show this help message
 
 Dependency Field Guide:
@@ -2143,6 +2317,13 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       });
     } else if (args[0] === '--from-qf') {
       await createFromQF(args[1]);
+    } else if (args[0] === '--from-proposal') {
+      // SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001: materialize PROPOSAL-*.json into DRAFT SDs.
+      // path/glob = first non-flag positional after --from-proposal; --dry-run = no writes.
+      const dryRun = args.includes('--dry-run');
+      const fpKnownFlags = new Set(['--from-proposal', '--dry-run']);
+      const proposalArg = args.find((a, i) => i > 0 && !a.startsWith('-') && !fpKnownFlags.has(a)) || args[1];
+      await createFromProposal(proposalArg, { dryRun });
     } else if (args[0] === '--from-plan') {
       // Check for --yes flag (skip confirmation for auto-detect)
       const hasYesFlag = args.includes('--yes') || args.includes('-y');

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2060,21 +2060,27 @@ export function validateProposalShape(proposal, filePath) {
     console.error(`[INVALID_PROPOSAL] ${where}: status_intended must be "draft" (got ${JSON.stringify(proposal.status_intended)})`);
     process.exit(1);
   }
+  // Required fields must be non-empty STRINGS. The typeof check is load-bearing:
+  // without it a number/boolean/array/object (e.g. title:[] or proposed_sd_key:42)
+  // would pass and flow verbatim into createSD -> a corrupt INSERT or an uncaught
+  // TypeError at sdKey.startsWith. (adversarial review w2b0qjnoa, 2 HIGH findings)
   for (const field of ['proposed_sd_key', 'title', 'sd_type', 'priority']) {
     const v = proposal[field];
-    if (v === undefined || v === null || (typeof v === 'string' && v.trim() === '')) {
-      console.error(`[INVALID_PROPOSAL] ${where}: missing required field "${field}"`);
+    if (v === undefined || v === null || typeof v !== 'string' || v.trim() === '') {
+      console.error(`[INVALID_PROPOSAL] ${where}: required field "${field}" must be a non-empty string`);
       process.exit(1);
     }
   }
   let type;
   try {
-    type = mapToDbType(proposal.sd_type); // reuses canonical enum; throws on invalid
+    type = mapToDbType(proposal.sd_type); // reuses canonical enum; throws on invalid (now guaranteed a string)
   } catch (e) {
     console.error(`[INVALID_PROPOSAL_SD_TYPE] ${where}: ${e.message}`);
     process.exit(1);
   }
-  const priority = String(proposal.priority).toLowerCase();
+  // priority is guaranteed a non-empty string by the loop above, so a single-element
+  // array like ['high'] can no longer String()-coerce through this check.
+  const priority = proposal.priority.toLowerCase();
   if (!VALID_PROPOSAL_PRIORITIES.includes(priority)) {
     console.error(`[INVALID_PROPOSAL_PRIORITY] ${where}: "${proposal.priority}". Valid: ${VALID_PROPOSAL_PRIORITIES.join(', ')}`);
     process.exit(1);
@@ -2095,6 +2101,9 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath) {
     type: normalized.type,
     priority: normalized.priority,
     description: proposal.rationale || proposal.scope || proposal.title,
+    // Sibling parity: UAT/learn/feedback/QF/plan/child all set an explicit rationale
+    // (used by the LEAD evaluator). Fall back to a provenance line when absent.
+    rationale: proposal.rationale || `Materialized from proposal ${filePath || 'unknown'}`,
     scope: proposal.scope || null,
     success_criteria: Array.isArray(proposal.success_criteria) ? proposal.success_criteria : null,
     metadata: {

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -1,0 +1,163 @@
+/**
+ * --from-proposal ingest unit tests — SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001
+ *
+ * Exercises the EXPORTED pure helpers (validateProposalShape, mapProposalToCreateArgs)
+ * and createFromProposal's dry-run + idempotency via INJECTED deps. ZERO live DB access:
+ * createSD uses a module-level supabase singleton that is not injectable, so no test
+ * calls the real createSD/keyExists — they are faked through opts.deps.
+ *
+ * Pattern mirrors tests/unit/leo-create-sd-target-repos.test.js: process.exit is
+ * mocked to THROW so fail-loud paths are assertable, console.error/log are spied.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  validateProposalShape,
+  mapProposalToCreateArgs,
+  createFromProposal,
+} from '../../scripts/leo-create-sd.js';
+
+function validProposal(overrides = {}) {
+  return {
+    PROPOSAL: true,
+    status_intended: 'draft',
+    proposed_sd_key: 'SD-LEO-INFRA-EXAMPLE-001',
+    title: 'Example proposal',
+    sd_type: 'infrastructure',
+    priority: 'high',
+    rationale: 'because the belt needs refilling',
+    scope: 'DOES: x. DOES NOT: y.',
+    success_criteria: ['criterion a'],
+    provenance: 'coordinator-go',
+    roadmap_phase: 'phase-1',
+    ...overrides,
+  };
+}
+
+describe('validateProposalShape (SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001)', () => {
+  let exitSpy, errorSpy;
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit(${code})`); });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => { exitSpy.mockRestore(); errorSpy.mockRestore(); });
+
+  it('valid proposal → normalized {sdKey verbatim, mapped type, lowercased priority}', () => {
+    const n = validateProposalShape(validProposal(), 'p.json');
+    expect(n).toEqual({
+      sdKey: 'SD-LEO-INFRA-EXAMPLE-001', title: 'Example proposal',
+      type: 'infrastructure', priority: 'high', rawType: 'infrastructure',
+    });
+  });
+
+  it("sd_type alias 'infra' maps to canonical 'infrastructure'", () => {
+    expect(validateProposalShape(validProposal({ sd_type: 'infra' }), 'p.json').type).toBe('infrastructure');
+  });
+
+  it('uppercase priority is lowercased', () => {
+    expect(validateProposalShape(validProposal({ priority: 'HIGH' }), 'p.json').priority).toBe('high');
+  });
+
+  it.each(['proposed_sd_key', 'title', 'sd_type', 'priority'])('missing required field "%s" → [INVALID_PROPOSAL] + exit 1', (field) => {
+    const p = validProposal(); delete p[field];
+    expect(() => validateProposalShape(p, 'p.json')).toThrow('process.exit(1)');
+    const msg = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(msg).toContain('[INVALID_PROPOSAL]');
+    expect(msg).toContain(field);
+  });
+
+  it('invalid sd_type → [INVALID_PROPOSAL_SD_TYPE] listing valid values + the bad value', () => {
+    expect(() => validateProposalShape(validProposal({ sd_type: 'widget' }), 'p.json')).toThrow('process.exit(1)');
+    const msg = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(msg).toContain('[INVALID_PROPOSAL_SD_TYPE]');
+    expect(msg).toContain('widget');
+    expect(msg).toContain('infrastructure'); // valid values are listed by assertValidSdType
+  });
+
+  it('invalid priority → [INVALID_PROPOSAL_PRIORITY] + exit 1', () => {
+    expect(() => validateProposalShape(validProposal({ priority: 'urgent' }), 'p.json')).toThrow('process.exit(1)');
+    const msg = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(msg).toContain('[INVALID_PROPOSAL_PRIORITY]');
+    expect(msg).toContain('urgent');
+  });
+
+  it('non-proposal object (PROPOSAL!==true) → [INVALID_PROPOSAL] + exit 1', () => {
+    const p = validProposal(); delete p.PROPOSAL;
+    expect(() => validateProposalShape(p, 'p.json')).toThrow('process.exit(1)');
+    expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('[INVALID_PROPOSAL]');
+  });
+
+  it('status_intended other than draft → [INVALID_PROPOSAL] + exit 1', () => {
+    expect(() => validateProposalShape(validProposal({ status_intended: 'active' }), 'p.json')).toThrow('process.exit(1)');
+    expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('[INVALID_PROPOSAL]');
+  });
+});
+
+describe('mapProposalToCreateArgs (pure field mapping)', () => {
+  const normalized = { sdKey: 'SD-LEO-INFRA-EXAMPLE-001', title: 'Example proposal', type: 'infrastructure', priority: 'high', rawType: 'infrastructure' };
+
+  it('maps key verbatim, stamps metadata.source=proposal, no vision/arch/parent', () => {
+    const args = mapProposalToCreateArgs(normalized, validProposal(), 'p.json');
+    expect(args.sdKey).toBe('SD-LEO-INFRA-EXAMPLE-001');
+    expect(args.type).toBe('infrastructure');
+    expect(args.priority).toBe('high');
+    expect(args.metadata.source).toBe('proposal');
+    expect(args.metadata.proposal_file_path).toBe('p.json');
+    expect(args.metadata.roadmap_phase).toBe('phase-1');
+    expect(args.metadata.vision_key).toBeUndefined();
+    expect(args.metadata.arch_key).toBeUndefined();
+    expect(args.parentId).toBeUndefined();
+    expect(args.success_criteria).toEqual(['criterion a']);
+  });
+
+  it('description falls back rationale -> scope -> title', () => {
+    expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined }), 'p.json').description).toBe('DOES: x. DOES NOT: y.');
+    expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined, scope: undefined }), 'p.json').description).toBe('Example proposal');
+  });
+});
+
+describe('createFromProposal (dry-run + idempotency, injected deps, zero DB/FS)', () => {
+  let logSpy;
+  beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+  afterEach(() => { logSpy.mockRestore(); });
+
+  const baseDeps = (over = {}) => ({
+    resolveFiles: () => ['fake.json'],
+    readFile: () => JSON.stringify(validProposal()),
+    keyExists: vi.fn(async () => false),
+    createSD: vi.fn(async () => ({ id: 'x' })),
+    ...over,
+  });
+
+  it('--dry-run validates + reports but never calls createSD', async () => {
+    const deps = baseDeps();
+    const res = await createFromProposal('fake.json', { dryRun: true, deps });
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(deps.keyExists).toHaveBeenCalledWith('SD-LEO-INFRA-EXAMPLE-001');
+    expect(res).toEqual([{ sdKey: 'SD-LEO-INFRA-EXAMPLE-001', file: 'fake.json', action: 'dry-run' }]);
+  });
+
+  it('idempotent: existing key is skipped, createSD not called', async () => {
+    const deps = baseDeps({ keyExists: vi.fn(async () => true) });
+    const res = await createFromProposal('fake.json', { deps });
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(res[0].action).toBe('skipped');
+  });
+
+  it('create path: new key → createSD called once with the verbatim key', async () => {
+    const deps = baseDeps();
+    const res = await createFromProposal('fake.json', { deps });
+    expect(deps.createSD).toHaveBeenCalledTimes(1);
+    expect(deps.createSD.mock.calls[0][0].sdKey).toBe('SD-LEO-INFRA-EXAMPLE-001');
+    expect(res[0].action).toBe('created');
+  });
+
+  it('multi-file: each resolved file is processed independently', async () => {
+    const deps = baseDeps({
+      resolveFiles: () => ['a.json', 'b.json'],
+      keyExists: vi.fn(async (k) => false),
+    });
+    const res = await createFromProposal('.prd-payloads/PROPOSAL-*.json', { dryRun: true, deps });
+    expect(res).toHaveLength(2);
+    expect(res.every(r => r.action === 'dry-run')).toBe(true);
+  });
+});

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -90,6 +90,25 @@ describe('validateProposalShape (SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001)', () => 
     expect(() => validateProposalShape(validProposal({ status_intended: 'active' }), 'p.json')).toThrow('process.exit(1)');
     expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('[INVALID_PROPOSAL]');
   });
+
+  // Adversarial review w2b0qjnoa (2 HIGH): type-laxness — non-string required fields
+  // and array-wrapped priority must NOT coerce through into createSD.
+  it.each([
+    ['title', []],
+    ['title', 42],
+    ['title', {}],
+    ['title', ['Some Title']],
+    ['proposed_sd_key', 42],
+    ['proposed_sd_key', ['SD-X-2']],
+    ['sd_type', 42],
+    ['priority', ['high']], // single-element array previously String()-coerced to 'high'
+    ['priority', 5],
+  ])('non-string %s = %j → [INVALID_PROPOSAL] non-empty-string + exit 1 (no coercion)', (field, badValue) => {
+    expect(() => validateProposalShape(validProposal({ [field]: badValue }), 'p.json')).toThrow('process.exit(1)');
+    const msg = errorSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(msg).toContain('[INVALID_PROPOSAL]');
+    expect(msg).toContain(field);
+  });
 });
 
 describe('mapProposalToCreateArgs (pure field mapping)', () => {
@@ -112,6 +131,30 @@ describe('mapProposalToCreateArgs (pure field mapping)', () => {
   it('description falls back rationale -> scope -> title', () => {
     expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined }), 'p.json').description).toBe('DOES: x. DOES NOT: y.');
     expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined, scope: undefined }), 'p.json').description).toBe('Example proposal');
+  });
+
+  it('sets a rationale (sibling parity): proposal rationale, else a provenance fallback', () => {
+    expect(mapProposalToCreateArgs(normalized, validProposal(), 'p.json').rationale).toBe('because the belt needs refilling');
+    expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined }), 'p.json').rationale).toContain('Materialized from proposal');
+  });
+
+  // Adversarial review w2b0qjnoa (invariant regression guard): a DIRTY proposal carrying
+  // vision_key/arch_key/parent_id (top-level AND nested in metadata) must NOT leak those
+  // into the mapped createSD args — else enrichFromVisionArch / orchestrator-routing /
+  // parent-FK could silently re-activate. The closed whitelist is the protection.
+  it('dirty proposal: vision_key/arch_key/parent_id never leak into mapped args', () => {
+    const dirty = validProposal({
+      vision_key: 'VIS-EVIL-001', arch_key: 'ARCH-EVIL-001', parent_id: 'SD-PARENT-001',
+      parentId: 'SD-PARENT-002', metadata: { vision_key: 'VIS-NESTED-001', arch_key: 'ARCH-NESTED-001' },
+    });
+    const args = mapProposalToCreateArgs(normalized, dirty, 'p.json');
+    expect(args.metadata.vision_key).toBeUndefined();
+    expect(args.metadata.arch_key).toBeUndefined();
+    expect(args.metadata.parent_id).toBeUndefined();
+    expect(args.parentId).toBeUndefined();
+    expect(args.vision_key).toBeUndefined();
+    expect(args.arch_key).toBeUndefined();
+    expect(args.metadata.source).toBe('proposal'); // only the closed whitelist survives
   });
 });
 


### PR DESCRIPTION
Adds a `--from-proposal <path|glob>` mode to scripts/leo-create-sd.js that materializes .prd-payloads/PROPOSAL-*.json into DRAFT SDs via the existing createSD() path.

## What
- **createFromProposal(pathOrGlob, {dryRun, deps})** — reads proposal file(s), validates, creates DRAFT SDs. Key taken **verbatim** from `proposed_sd_key` (critical divergence from --from-plan: no generateSDKey/archive/content-hash).
- **validateProposalShape() / mapProposalToCreateArgs()** — exported PURE helpers. Fail-loud, bracket-tokenized ([INVALID_PROPOSAL], [INVALID_PROPOSAL_SD_TYPE], [INVALID_PROPOSAL_PRIORITY]); reuses mapToDbType (canonical 15-value enum) + the 4-value priority set.
- **Idempotent** via keyExists() (skips already-materialized keys); **--dry-run** validates + reports with ZERO writes.
- Dependency-injected {keyExists, createSD, readFile, resolveFiles} so the 17 unit tests touch **zero live DB**.

## Verify
- 17/17 unit tests (tests/unit/leo-create-sd-from-proposal.test.js)
- Real --dry-run: idempotency-skip on the existing key; fail-loud on a real proposal missing priority

SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001 (coordinator-GO'd, advisory lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)