### PR TITLE
fix(SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001): FR-2 — make sd-next parked_armed_silence display guard live

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -344,6 +344,28 @@ export class SDNextSelector {
     try {
       this.activeSessions = await this.sessionManager.getActiveSessions();
 
+      // SD-LEO-INFRA-RELEASE-SD-HONOR-ARMED-SILENCE-001 (FR-2): v_active_sessions does NOT expose
+      // expected_silence_until, so the parked_armed_silence guard in analyzeClaimRelationship would
+      // never fire on the display path. Enrich each active session with the field via ONE batch query
+      // against claude_sessions so the "PARKED (armed silence)" badge renders. No schema change (read
+      // only); the AUTHORITATIVE reap gate (autoReleaseStaleDeadClaim) re-fetches the field itself, so
+      // this is display-only. Fail-safe: absent/null -> predicate returns false -> normal classification.
+      try {
+        const sessionIds = this.activeSessions.map((s) => s.session_id).filter(Boolean);
+        if (sessionIds.length > 0) {
+          const { data: silenceRows } = await this.supabase
+            .from('claude_sessions')
+            .select('session_id, expected_silence_until')
+            .in('session_id', sessionIds);
+          if (silenceRows) {
+            const byId = new Map(silenceRows.map((r) => [r.session_id, r.expected_silence_until]));
+            for (const session of this.activeSessions) {
+              if (byId.has(session.session_id)) session.expected_silence_until = byId.get(session.session_id);
+            }
+          }
+        }
+      } catch { /* non-fatal: absent field -> normal classification (fail-safe) */ }
+
       for (const session of this.activeSessions) {
         if (session.sd_id) {
           this.claimedSDs.set(session.sd_id, session.session_id);

--- a/scripts/modules/sd-next/claim-analysis.js
+++ b/scripts/modules/sd-next/claim-analysis.js
@@ -71,9 +71,10 @@ export function analyzeClaimRelationship({ claimingSessionId: _claimingSessionId
   // BACK — not dead. While its armed-silence window is live, do NOT mark the claim auto-releasable (parity
   // with claim_sd + the sweep + the peer-release seams; reuse the ONE predicate). Fail-safe: an expired /
   // over-SILENCE_HARD_CAP_MS / absent window returns false here and falls through to normal classification,
-  // so a genuinely-dead claim still reaps. (Defensive: the v_active_sessions view does not expose this field
-  // today, so in the display path this is a no-op until the session is enriched; the AUTHORITATIVE gate is
-  // at the release choke point autoReleaseStaleDeadClaim below, which fetches the field from claude_sessions.)
+  // so a genuinely-dead claim still reaps. (v_active_sessions does not expose this field, so the sd-next
+  // display path enriches each session with expected_silence_until from claude_sessions — FR-2,
+  // SDNextSelector.loadActiveSessions — before calling this; the AUTHORITATIVE gate at the release choke
+  // point autoReleaseStaleDeadClaim below re-fetches the field from claude_sessions regardless.)
   if (isWithinArmedSilenceWindow(claimingSession?.expected_silence_until, Date.now())) {
     return {
       relationship: 'parked_armed_silence',


### PR DESCRIPTION
Follow-up to PR #4708 (which shipped the SD's core: FR-1/FR-3/FR-5 + child-path seam). #4708 did not include FR-2.

**Problem (found by adversarial review):** the display-path `parked_armed_silence` guard in `analyzeClaimRelationship` was dead code — `v_active_sessions` does not expose `expected_silence_until`, so the guard never fired and the `PARKED (armed silence)` badge never rendered. FR-2 acceptance criterion was unmet.

**Fix:** `SDNextSelector.loadActiveSessions()` now batch-fetches `expected_silence_until` from `claude_sessions` (one `.in(session_ids)` read) and maps it onto the active session objects that feed `analyzeClaimRelationship`. Synced the `claim-analysis.js` comment to reflect the enrichment is live.

- No schema change (read-only query; honors TR-3)
- Fail-safe: absent/null/query-error → predicate false → normal classification
- Display-only — the authoritative reap gate (`autoReleaseStaleDeadClaim`) re-fetches the field itself, so this cannot affect reap correctness

**Validation:** 10/10 unit + 15/15 smoke green; VALIDATION (92) + REGRESSION (95) PASS on the full SD; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)