### PR TITLE
fix(SD-LEO-INFRA-PAYMENT-RAIL-FOUNDATION-001): wire-check reachability (follow-up to #4709)

### DIFF
--- a/lib/payments/analytics-bridge.js
+++ b/lib/payments/analytics-bridge.js
@@ -1,3 +1,4 @@
+// @wire-check-exempt: Phase-2 forward-only analytics bridge (FR-5 deferred until ops-revenue-collector enum/status reconciliation); intentionally not wired in Phase-1.
 /**
  * Analytics bridge: ops_payment_events -> capital_transactions.
  * SD-LEO-INFRA-PAYMENT-RAIL-FOUNDATION-001  (FR-5, Phase-1 re-scope)

--- a/lib/test-helpers/stripe-signature.js
+++ b/lib/test-helpers/stripe-signature.js
@@ -1,3 +1,4 @@
+// @wire-check-exempt: test-only helper (Stripe signed-payload builder) used by tests/unit|integration/payments and the FR-4 proof; not production-wired.
 /**
  * Deterministic Stripe-signature test helper.
  * SD-LEO-INFRA-PAYMENT-RAIL-FOUNDATION-001

--- a/package.json
+++ b/package.json
@@ -308,6 +308,8 @@
     "checkin": "node scripts/worker-checkin.cjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",
+    "payments:test-charge": "node scripts/payments/test-charge-harness.mjs",
+    "llc:track": "node scripts/legal/track-llc-formation.mjs",
     "stage-contracts:check": "node scripts/validate-stage-contract-connectivity.mjs",
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",


### PR DESCRIPTION
Resolves LEAD-FINAL WIRE_CHECK for the merged payment rail (#4709): package.json script entries (payments:test-charge, llc:track — also wires stripe-client.js via the harness import) + @wire-check-exempt on the Phase-2 forward-only analytics bridge and the test-only signature helper. Cherry-picked clean onto main (the feat branch conflicted post-squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)