### PR TITLE
docs(SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001): CHANGELOG for --from-proposal ingest mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ## 2026-06-13
 
 ### Infrastructure
+- **`leo-create-sd.js --from-proposal <path|glob> [--dry-run]` now materializes `.prd-payloads/PROPOSAL-*.json` files into DRAFT SDs in one command (verbatim key from `proposed_sd_key`, fail-loud bracket-tokenized validation, idempotent via key-exists, `--dry-run` = zero writes)** - PR #4710 (SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001)
 - **Every breakage detector now writes alerts through one fail-loud, deduped contract** - PR #4701 (SD-LEO-INFRA-BREAKAGE-DETECTOR-SURFACE-001-B)
   - **What shipped**: `lib/breakage/alert-writer.cjs` — `recordSystemAlert(supabase, opts)` + pure `buildAlertRow(opts)`: the single write-contract that every breakage detector, the canary (children C/D), and the catch-rate harness (F) use to persist a breakage alert to `system_alerts`. It consumes child A’s frozen taxonomy (`lib/coordinator/break-class-taxonomy.cjs`), maps the precise break-class id into the LIVE `system_alerts_alert_type_check` legal set via `toAlertType()` — **no CHECK widening** (protects the 3 live EVA SECURITY-DEFINER functions) — rides the precise class id in `metadata.break_class`, dedups OPEN alerts on `(source_service, metadata->>break_class)`, and throws fail-loud on any query/insert error. Reuses the 14 existing `system_alerts` columns; no schema migration.
   - **Verification**: `tests/unit/alert-writer.test.js` 8/8 (fake supabase, zero live writes). `@wire-check-exempt` decomposition-root marker (removed when child C imports the writer). Canonical API doc is the in-module JSDoc contract header (lines 1-25).


### PR DESCRIPTION
Post-completion documentation follow-up for **SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001** (code shipped in #4710, already merged).

## What this adds
A single benefit-led CHANGELOG entry under the existing **2026-06-13 → Infrastructure** heading documenting the `leo-create-sd.js --from-proposal <path|glob> [--dry-run]` ingest mode that materializes `.prd-payloads/PROPOSAL-*.json` files into DRAFT SDs (verbatim key from `proposed_sd_key`, fail-loud bracket-tokenized validation, idempotent via key-exists, `--dry-run` = zero writes).

## Scope
- CHANGELOG.md: +1 line, no other changes.
- Branched directly off `origin/main` (which already contains #4710) to avoid the squash-ancestry trap — this PR re-introduces **zero** already-merged code; `git diff --stat origin/main..HEAD` = `CHANGELOG.md | 1 +`.
- TOC unchanged: the 2026-06-13 Infrastructure anchor already exists.

The in-module JSDoc (section header at the `--from-proposal ingest` block, plus JSDoc on `validateProposalShape` and `createFromProposal`) and the `--help` text (usage line + scoped `--dry-run` flag entry) were already shipped in #4710 and adequately document the mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)