### PR TITLE
feat(SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001): live cloud-cap feeder + detectFromDb repoint+guard

### DIFF
--- a/database/migrations/20260614_llm_cloud_health.sql
+++ b/database/migrations/20260614_llm_cloud_health.sql
@@ -38,3 +38,14 @@ ON CONFLICT (id) DO NOTHING;
 
 COMMENT ON TABLE llm_cloud_health IS
   'Singleton live cloud-health signal for the chairman-away degradation ladder (SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001). Sole writer: scripts/continuity/cloud-cap-feeder.mjs. Read by llm-degradation-detector.mjs::detectFromDb. Distinct from llm_canary_state (local-model rollout).';
+
+-- RLS: parity with the sibling continuity tables (llm_canary_state/_transitions/_metrics) and the
+-- repo standard (SD-SEC-DB-LINTER-001 — every public table must have RLS enabled). The feeder +
+-- detectFromDb use the service-role client (RLS-bypass), so this is additive/zero-functional-risk;
+-- without it the security-linter sentinel (rls_disabled_in_public) goes red and the writable health
+-- row is exposed to anon/authenticated via PostgREST.
+ALTER TABLE llm_cloud_health ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON llm_cloud_health FROM anon, authenticated;
+GRANT ALL ON llm_cloud_health TO service_role;
+CREATE POLICY service_role_full_access ON llm_cloud_health
+  FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/database/migrations/20260614_llm_cloud_health.sql
+++ b/database/migrations/20260614_llm_cloud_health.sql
@@ -1,0 +1,40 @@
+-- SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001 — dedicated cloud-health substrate for the
+-- chairman-away PAUSE ladder. Coordinator spec-fork ruling 3e11be61: fork2 =
+-- dedicated-table-additive-migration (clean separation; do NOT overload the local-model
+-- rollout llm_canary_state row or its advance_canary_stage/get_canary_state RPCs).
+--
+-- ADDITIVE ONLY: CREATE TABLE + seed one singleton row. No ALTER/DROP of any existing
+-- object. Columns mirror EXACTLY the health-signal shape the source-agnostic pure
+-- evaluator scripts/continuity/llm-degradation-detector.mjs::evaluateDegradationRung reads,
+-- so detectFromDb can repoint here with no evaluator change. The cloud-cap feeder
+-- (scripts/continuity/cloud-cap-feeder.mjs) is the SOLE writer of this row.
+
+CREATE TABLE IF NOT EXISTS llm_cloud_health (
+  -- Enforced singleton: exactly one row, addressed by id='singleton'.
+  id TEXT PRIMARY KEY DEFAULT 'singleton' CHECK (id = 'singleton'),
+
+  -- Lifecycle: 'rolling' while the feeder is actively probing (arms the PAUSE trigger in
+  -- the evaluator), 'paused' between probe batches (disarms false-PAUSE on a quiescent fleet).
+  status TEXT NOT NULL DEFAULT 'paused' CHECK (status IN ('rolling', 'paused')),
+
+  -- Live cloud-cap signal (stamped by the feeder from real Anthropic 429/5xx/overloaded/timeout outcomes).
+  current_error_rate DECIMAL(5,4),                                    -- failures / total probes in the batch
+  error_rate_threshold DECIMAL(5,4) NOT NULL DEFAULT 0.05,           -- MODEL_FALLBACK if current > this
+  current_latency_p95_ms INTEGER,                                    -- p95 latency over the probe batch
+  baseline_latency_p95_ms INTEGER,                                   -- stamped once on first healthy batch
+  latency_multiplier_threshold DECIMAL(4,2) NOT NULL DEFAULT 2.0,    -- SINGLE_SESSION if p95 > mult * baseline
+  consecutive_failures INTEGER NOT NULL DEFAULT 0,                   -- incremented on a bad batch, reset on healthy
+  failures_before_rollback INTEGER NOT NULL DEFAULT 3,              -- PAUSE_AND_SURFACE if >= this AND status='rolling'
+  last_quality_check_at TIMESTAMPTZ,                                 -- when the feeder last probed (liveness)
+
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the singleton (idempotent). Default status='paused' => evaluator reads NORMAL until
+-- the feeder first probes, which is the correct fail-open posture for a fresh substrate.
+INSERT INTO llm_cloud_health (id, status)
+VALUES ('singleton', 'paused')
+ON CONFLICT (id) DO NOTHING;
+
+COMMENT ON TABLE llm_cloud_health IS
+  'Singleton live cloud-health signal for the chairman-away degradation ladder (SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001). Sole writer: scripts/continuity/cloud-cap-feeder.mjs. Read by llm-degradation-detector.mjs::detectFromDb. Distinct from llm_canary_state (local-model rollout).';

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "skill:audit:body": "node scripts/pocock/audit-skill-bodies.mjs",
     "prio:top3": "node scripts/wsjf-priority-fetcher.js",
     "continuity:spike-rehearsal": "node scripts/continuity/spike-rehearsal.mjs",
+    "continuity:cloud-cap-feeder": "node scripts/continuity/cloud-cap-feeder.mjs",
     "glide:add-income-dimension": "node scripts/glide-path/add-income-dimension.mjs",
     "qf:link": "node scripts/qf-link-resolution.mjs",
     "session:prologue": "node scripts/generate-session-prologue.js",

--- a/scripts/continuity/cloud-cap-feeder.mjs
+++ b/scripts/continuity/cloud-cap-feeder.mjs
@@ -1,0 +1,188 @@
+// @wire-check-exempt: opt-in continuity CLI (npm: continuity:cloud-cap-feeder) + unit test;
+// it is the sole writer of llm_cloud_health, read by llm-degradation-detector.mjs::detectFromDb.
+/**
+ * Cloud-cap live feeder — SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001.
+ *
+ * The deferred "cloud-health feeder" named in llm-degradation-detector.mjs. It actively probes
+ * the Anthropic API (cheap models.list calls — no token spend), categorizes real outcomes
+ * (429 rate_limit / 5xx server / overloaded_error / timeout), and stamps the dedicated
+ * `llm_cloud_health` singleton (coordinator spec-fork ruling 3e11be61: a dedicated table, NOT an
+ * overload of the local-rollout llm_canary_state row) that the pure source-agnostic evaluator
+ * (evaluateDegradationRung) reads via detectFromDb.
+ *
+ * LIFECYCLE (single UPDATE per run): a batch whose error_rate exceeds error_rate_threshold is a
+ * "failure batch" -> status='rolling' (arms the evaluator's PAUSE trigger) + consecutive_failures++.
+ * A healthy batch -> status='paused' (disarms PAUSE) + consecutive_failures=0. baseline_latency_p95_ms
+ * is stamped once on the first healthy batch. last_quality_check_at is refreshed every run (liveness).
+ *
+ * SAFETY: opt-in CLI (no background spend); only writer of these columns. Stale-rolling (feeder
+ * stopped mid-degradation) is contained by detectFromDb's Layer-2 quiescent-fleet guard (0 live
+ * workers -> NORMAL) plus the evaluator's liveness rung. Injectable client/clock/supabase => tests
+ * make ZERO live Anthropic calls or DB writes.
+ *
+ * @module scripts/continuity/cloud-cap-feeder
+ */
+
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { createAnthropicClient } from '../eva-support/_internal/anthropic-client.js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+/** Error categories that count as a cloud-cap failure (vs operator/config errors like 401/400). */
+export const CAP_FAILURE_CATEGORIES = Object.freeze(new Set(['rate_limit', 'overloaded', 'server', 'timeout']));
+
+export const DEFAULT_PROBE_COUNT = 5;
+export const SINGLETON_ID = 'singleton';
+
+/**
+ * Categorize an Anthropic SDK error into a cloud-cap signal. PURE.
+ * @param {any} err
+ * @returns {'rate_limit'|'overloaded'|'server'|'timeout'|'other'}
+ */
+export function categorizeProbeError(err) {
+  if (!err) return 'other';
+  const status = typeof err.status === 'number' ? err.status : null;
+  const type = err.error?.type || err.type || null;
+  const name = err.name || '';
+  const msg = err.message || '';
+  if (status === 429) return 'rate_limit';
+  if (status === 529 || type === 'overloaded_error') return 'overloaded';
+  if (status != null && status >= 500) return 'server';
+  if (/timeout/i.test(name) || /timeout/i.test(msg) || err.code === 'ETIMEDOUT') return 'timeout';
+  return 'other';
+}
+
+/** p95 of a latency array (ms). PURE. Returns null for an empty array. */
+export function computeP95(latencies) {
+  const arr = (latencies || []).filter((n) => Number.isFinite(n)).sort((a, b) => a - b);
+  if (arr.length === 0) return null;
+  const idx = Math.min(arr.length - 1, Math.ceil(0.95 * arr.length) - 1);
+  return arr[Math.max(0, idx)];
+}
+
+/**
+ * Summarize a probe batch. PURE.
+ * @param {Array<{ok:boolean, latencyMs?:number, category?:string}>} results
+ * @returns {{total:number, capFailures:number, otherErrors:number, errorRate:number|null, p95LatencyMs:number|null}}
+ */
+export function summarizeBatch(results) {
+  const list = Array.isArray(results) ? results : [];
+  const total = list.length;
+  let capFailures = 0, otherErrors = 0;
+  const okLatencies = [];
+  for (const r of list) {
+    if (r.ok) { if (Number.isFinite(r.latencyMs)) okLatencies.push(r.latencyMs); continue; }
+    if (CAP_FAILURE_CATEGORIES.has(r.category)) capFailures++;
+    else otherErrors++;
+  }
+  return {
+    total,
+    capFailures,
+    otherErrors,
+    errorRate: total > 0 ? Number((capFailures / total).toFixed(4)) : null,
+    p95LatencyMs: computeP95(okLatencies),
+  };
+}
+
+/**
+ * Compute the next llm_cloud_health column values from the prior row + a batch summary. PURE.
+ * Failure batch (errorRate > threshold) -> status='rolling' + consecutive_failures++; else healthy ->
+ * status='paused' + reset to 0. Baseline stamped once on the first healthy batch that has a p95.
+ * @param {object} prev - prior row (or null)
+ * @param {object} summary - from summarizeBatch
+ * @returns {{status:string, consecutive_failures:number, current_error_rate:number|null, current_latency_p95_ms:number|null, baseline_latency_p95_ms:number|null}}
+ */
+export function computeNextHealthState(prev, summary) {
+  const p = prev && typeof prev === 'object' ? prev : {};
+  // null-aware: Number(null) === 0 (finite), so guard null/undefined BEFORE coercing — else a
+  // null baseline reads as 0 and never gets stamped, and a null threshold reads as 0 (always-bad).
+  const num = (v) => (v == null || !Number.isFinite(Number(v)) ? null : Number(v));
+  const threshold = num(p.error_rate_threshold) ?? 0.05;
+  const prevFailures = num(p.consecutive_failures) ?? 0;
+  const prevBaseline = num(p.baseline_latency_p95_ms);
+
+  const batchBad = summary.errorRate != null && summary.errorRate > threshold;
+  const status = batchBad ? 'rolling' : 'paused';
+  const consecutive_failures = batchBad ? prevFailures + 1 : 0;
+  // Stamp baseline once, on the first healthy batch that produced a latency sample.
+  const baseline_latency_p95_ms = prevBaseline != null
+    ? prevBaseline
+    : (!batchBad && summary.p95LatencyMs != null ? summary.p95LatencyMs : null);
+
+  return {
+    status,
+    consecutive_failures,
+    current_error_rate: summary.errorRate,
+    current_latency_p95_ms: summary.p95LatencyMs,
+    baseline_latency_p95_ms,
+  };
+}
+
+/**
+ * Run a batch of cheap probes against the injected Anthropic client. IO (but client is injected).
+ * Uses models.list() — no token spend — as the health probe.
+ * @param {object} args
+ * @param {object} args.client - Anthropic SDK client (injected; fake in tests)
+ * @param {number} [args.count=DEFAULT_PROBE_COUNT]
+ * @param {() => number} [args.nowFn=Date.now]
+ * @returns {Promise<Array<{ok:boolean, latencyMs?:number, category?:string}>>}
+ */
+export async function runProbeBatch({ client, count = DEFAULT_PROBE_COUNT, nowFn = Date.now } = {}) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    const t0 = nowFn();
+    try {
+      await client.models.list();
+      results.push({ ok: true, latencyMs: Math.max(0, nowFn() - t0) });
+    } catch (err) {
+      results.push({ ok: false, category: categorizeProbeError(err) });
+    }
+  }
+  return results;
+}
+
+/**
+ * Probe the cloud + stamp the llm_cloud_health singleton. The SOLE writer of these columns.
+ * @param {object} args
+ * @param {object} args.supabase
+ * @param {object} args.client - Anthropic SDK client (injected)
+ * @param {() => number} [args.nowFn=Date.now]
+ * @param {() => string} [args.nowIso] - ISO timestamp provider (inject for tests)
+ * @param {number} [args.probeCount=DEFAULT_PROBE_COUNT]
+ * @returns {Promise<{summary:object, update:object}>}
+ */
+export async function feedCloudHealth({ supabase, client, nowFn = Date.now, nowIso, probeCount = DEFAULT_PROBE_COUNT } = {}) {
+  const isoFn = nowIso || (() => new Date(nowFn()).toISOString());
+  const { data: prev, error: readErr } = await supabase
+    .from('llm_cloud_health')
+    .select('error_rate_threshold, consecutive_failures, baseline_latency_p95_ms')
+    .eq('id', SINGLETON_ID)
+    .maybeSingle();
+  if (readErr) throw new Error(`[cloud-cap-feeder] read failed (fail-loud): ${readErr.message}`);
+
+  const results = await runProbeBatch({ client, count: probeCount, nowFn });
+  const summary = summarizeBatch(results);
+  const next = computeNextHealthState(prev, summary);
+
+  const update = { ...next, last_quality_check_at: isoFn(), updated_at: isoFn() };
+  const { error: writeErr } = await supabase
+    .from('llm_cloud_health')
+    .update(update)
+    .eq('id', SINGLETON_ID);
+  if (writeErr) throw new Error(`[cloud-cap-feeder] write failed (fail-loud): ${writeErr.message}`);
+
+  return { summary, update };
+}
+
+// CLI entry — opt-in (npm run continuity:cloud-cap-feeder). Real client + supabase; no background daemon.
+if (isMainModule(import.meta.url)) {
+  (async () => {
+    const supabase = createSupabaseServiceClient();
+    const client = createAnthropicClient();
+    const { summary, update } = await feedCloudHealth({ supabase, client });
+    console.log(`[cloud-cap-feeder] probes=${summary.total} cap_failures=${summary.capFailures} error_rate=${summary.errorRate} p95=${summary.p95LatencyMs}ms -> status=${update.status} consecutive_failures=${update.consecutive_failures}`);
+    process.exit(0);
+  })().catch((e) => {
+    console.error(`[cloud-cap-feeder] ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/continuity/cloud-cap-feeder.mjs
+++ b/scripts/continuity/cloud-cap-feeder.mjs
@@ -15,10 +15,11 @@
  * A healthy batch -> status='paused' (disarms PAUSE) + consecutive_failures=0. baseline_latency_p95_ms
  * is stamped once on the first healthy batch. last_quality_check_at is refreshed every run (liveness).
  *
- * SAFETY: opt-in CLI (no background spend); only writer of these columns. Stale-rolling (feeder
- * stopped mid-degradation) is contained by detectFromDb's Layer-2 quiescent-fleet guard (0 live
- * workers -> NORMAL) plus the evaluator's liveness rung. Injectable client/clock/supabase => tests
- * make ZERO live Anthropic calls or DB writes.
+ * SAFETY: opt-in CLI (no background spend); only writer of these columns. A STOPPED feeder cannot pin
+ * a degraded rung on live workers — detectFromDb suppresses any degraded signal whose
+ * last_quality_check_at is stale beyond the liveness window (feeder not actively probing -> NORMAL),
+ * with the 0-live-workers guard as a second layer. probeCount is clamped (only real-spend surface).
+ * Injectable client/clock/supabase => tests make ZERO live Anthropic calls or DB writes.
  *
  * @module scripts/continuity/cloud-cap-feeder
  */
@@ -31,6 +32,7 @@ import { isMainModule } from '../../lib/utils/is-main-module.js';
 export const CAP_FAILURE_CATEGORIES = Object.freeze(new Set(['rate_limit', 'overloaded', 'server', 'timeout']));
 
 export const DEFAULT_PROBE_COUNT = 5;
+export const MAX_PROBE_COUNT = 20; // clamp the only real-spend surface against a fat-finger invocation
 export const SINGLETON_ID = 'singleton';
 
 /**
@@ -41,13 +43,22 @@ export const SINGLETON_ID = 'singleton';
 export function categorizeProbeError(err) {
   if (!err) return 'other';
   const status = typeof err.status === 'number' ? err.status : null;
-  const type = err.error?.type || err.type || null;
+  // The real @anthropic-ai/sdk overloaded error exposes the discriminator on err.type; err.error.type
+  // reads the response ENVELOPE (not the inner error), so check both.
+  const type = err.type || err.error?.type || err.error?.error?.type || null;
   const name = err.name || '';
+  const ctorName = err.constructor?.name || '';
   const msg = err.message || '';
+  // Real Anthropic.APIConnectionTimeoutError: name==='Error', message==='Request timed out.', no code —
+  // identify by constructor name, a "timed out"/"timeout" message, or the undici cause code.
+  const causeCode = err.cause?.code || '';
+  const isTimeout = ctorName === 'APIConnectionTimeoutError'
+    || /timed?\s*out|timeout/i.test(name) || /timed?\s*out|timeout/i.test(msg)
+    || err.code === 'ETIMEDOUT' || causeCode === 'UND_ERR_CONNECT_TIMEOUT' || causeCode === 'ETIMEDOUT';
   if (status === 429) return 'rate_limit';
   if (status === 529 || type === 'overloaded_error') return 'overloaded';
   if (status != null && status >= 500) return 'server';
-  if (/timeout/i.test(name) || /timeout/i.test(msg) || err.code === 'ETIMEDOUT') return 'timeout';
+  if (isTimeout) return 'timeout';
   return 'other';
 }
 
@@ -159,7 +170,8 @@ export async function feedCloudHealth({ supabase, client, nowFn = Date.now, nowI
     .maybeSingle();
   if (readErr) throw new Error(`[cloud-cap-feeder] read failed (fail-loud): ${readErr.message}`);
 
-  const results = await runProbeBatch({ client, count: probeCount, nowFn });
+  const safeCount = Math.max(1, Math.min(MAX_PROBE_COUNT, Math.floor(Number(probeCount)) || DEFAULT_PROBE_COUNT));
+  const results = await runProbeBatch({ client, count: safeCount, nowFn });
   const summary = summarizeBatch(results);
   const next = computeNextHealthState(prev, summary);
 

--- a/scripts/continuity/llm-degradation-detector.mjs
+++ b/scripts/continuity/llm-degradation-detector.mjs
@@ -102,8 +102,15 @@ export function isDegradedSafeMode(rung) {
   return rung === RUNG.PAUSE_AND_SURFACE;
 }
 
-/** Live-worker window (ms): a degraded signal is suppressed if no worker heartbeat is this fresh. */
-export const DEFAULT_LIVE_WORKER_WINDOW_MS = 5 * 60 * 1000; // 5 min (claim-guard TTL parity)
+/**
+ * Live-worker window (ms): a degraded signal is suppressed only if NO worker heartbeat is this fresh.
+ * 15 min for parity with the main-worker TTL — pure-heartbeat liveness has a known false-stale rate,
+ * and the wrong-suppression risk is worst exactly when a cap blocks workers mid-tool-call, so a
+ * generous window avoids reading a busy fleet as quiescent.
+ * NOTE: countLiveWorkers MUST be passed a SERVICE-ROLE supabase client — an anon/RLS-restricted client
+ * silently reads count=0 (no error) and would wrongly suppress a real degradation as 'quiescent'.
+ */
+export const DEFAULT_LIVE_WORKER_WINDOW_MS = 15 * 60 * 1000; // 15 min (main-worker TTL parity)
 
 /**
  * Count workers with a fresh heartbeat (the authoritative "is work flowing right now" signal).
@@ -145,6 +152,19 @@ export async function detectFromDb(supabase, nowMs, opts = {}) {
     if (error) return { rung: RUNG.NORMAL, reason: `cloud-health read error (fail-open): ${error.message}`, signals: {} };
     const verdict = evaluateDegradationRung(data, nowMs, opts);
     if (verdict.rung === RUNG.NORMAL) return verdict;
+    // Stale-signal guard: a degraded row whose last probe is older than the liveness window means the
+    // feeder STOPPED (it is the sole writer + an opt-in CLI, not a daemon). A degraded rung — especially
+    // PAUSE, which out-ranks the evaluator's own liveness-stale rung and so would otherwise pin PAUSE on
+    // hours-old data — assumes an actively-probing source; once stale that assumption is violated. Treat
+    // a stale degraded signal as NORMAL (fail-open: stale == no current signal), so a stopped feeder can
+    // never pin a degraded rung on live workers. A running feeder refreshes last_quality_check_at each
+    // cadence, so this only fires when the feeder is genuinely not running.
+    const livenessStaleMs = numOrNull(opts.livenessStaleMs) ?? DEFAULT_LIVENESS_STALE_MS;
+    const lastCheckMs = data?.last_quality_check_at ? Date.parse(data.last_quality_check_at) : null;
+    const signalStale = Number.isFinite(lastCheckMs) && Number.isFinite(nowMs) && (nowMs - lastCheckMs) > livenessStaleMs;
+    if (signalStale) {
+      return { rung: RUNG.NORMAL, reason: `stale cloud-health signal (feeder not actively probing) — suppress ${verdict.rung}`, signals: { ...verdict.signals, signalStale: true } };
+    }
     const liveWorkers = await countLiveWorkers(supabase, nowMs, liveWorkerWindowMs);
     if (liveWorkers === 0) {
       return { rung: RUNG.NORMAL, reason: `quiescent fleet (0 live workers) — suppress ${verdict.rung}`, signals: { ...verdict.signals, liveWorkers } };

--- a/scripts/continuity/llm-degradation-detector.mjs
+++ b/scripts/continuity/llm-degradation-detector.mjs
@@ -11,16 +11,15 @@
  * It is PURE (no I/O, no DB write, no chairman-reserved mutation), fully unit-testable, and can never
  * itself cause a regression. See docs/03_protocols_and_standards/anthropic-cap-contingency.md.
  *
- * SIGNAL-SOURCE CAVEAT (read before wiring this live): detectFromDb currently reads the existing
- * `llm_canary_state` row (migration 20260206_llm_canary_routing.sql). That row is the LOCAL-MODEL
- * rollout canary — its quality columns measure a local model against the Anthropic cloud CONTROL, it
- * is dormant (paused, stage 0, NULL columns) with NO writer, and its `status='rolled_back'` means
- * "local leg abandoned → back to the HEALTHY Anthropic cloud" — the INVERSE of a cloud-cap event.
- * So as-wired against that substrate the detector reads NORMAL in production. The validated FR-3
- * deliverable is the evaluator + the documented ladder + the rehearsal; LIVE production detection is
- * a NAMED, DEFERRED follow-up: a cloud-health feeder that stamps current_error_rate /
- * current_latency_p95_ms / last_quality_check_at (and increments consecutive_failures) from REAL
- * Anthropic API outcomes (429 / 5xx) onto a row this evaluator reads.
+ * SIGNAL SOURCE (live as of SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001): detectFromDb reads the
+ * DEDICATED `llm_cloud_health` singleton (migration 20260614_llm_cloud_health.sql), stamped by the
+ * cloud-cap feeder (scripts/continuity/cloud-cap-feeder.mjs) from REAL Anthropic API outcomes
+ * (429 / 5xx / overloaded / timeout). This REPLACES the earlier placeholder wiring to
+ * `llm_canary_state` — that row is the LOCAL-MODEL rollout canary (its `status='rolled_back'` means
+ * "back to the HEALTHY Anthropic cloud", the INVERSE of a cap), kept cleanly separate per the
+ * coordinator spec-fork ruling (dedicated table, no row overload). detectFromDb also applies a
+ * Layer-2 quiescent-fleet guard (0 live workers → NORMAL) so a stale degraded row can never PAUSE
+ * an idle fleet.
  *
  * Fail-direction: an ALL-UNKNOWN row (never probed) returns NORMAL — we do not pause a healthy fleet
  * on missing data. Only definite signals from an ACTIVELY-PROBING source degrade.
@@ -103,27 +102,55 @@ export function isDegradedSafeMode(rung) {
   return rung === RUNG.PAUSE_AND_SURFACE;
 }
 
+/** Live-worker window (ms): a degraded signal is suppressed if no worker heartbeat is this fresh. */
+export const DEFAULT_LIVE_WORKER_WINDOW_MS = 5 * 60 * 1000; // 5 min (claim-guard TTL parity)
+
 /**
- * Read-only DB wrapper: load the singleton llm_canary_state row and evaluate the rung.
- * Does NOT write (no chairman-reserved mutation; it records NO transition row). Returns NORMAL if the
- * substrate is absent/unreadable (fail-open).
+ * Count workers with a fresh heartbeat (the authoritative "is work flowing right now" signal).
+ * Returns null on read error/unknown — the caller treats unknown as "do not suppress" (a definite
+ * degraded signal is only suppressed by DEFINITE evidence of a quiescent fleet, liveWorkers===0).
+ */
+async function countLiveWorkers(supabase, nowMs, windowMs) {
+  const base = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const since = new Date(base - windowMs).toISOString();
+  const { count, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id', { count: 'exact', head: true })
+    .eq('status', 'active')
+    .gt('heartbeat_at', since);
+  if (error) return null;
+  return typeof count === 'number' ? count : null;
+}
+
+/**
+ * Read-only DB wrapper: load the singleton `llm_cloud_health` row (stamped by the cloud-cap feeder)
+ * and evaluate the rung, then apply the Layer-2 quiescent-fleet guard. Does NOT write. Fail-open:
+ * absent/unreadable substrate → NORMAL.
  *
- * NOTE: reading `llm_canary_state` is PLACEHOLDER wiring (see the SIGNAL-SOURCE CAVEAT at the top of
- * this file) — that row is the dormant local-rollout canary, so this returns NORMAL in production
- * today. Repoint at the cloud-health feeder row when that DEFERRED follow-up lands.
+ * Layer 1 (in the pure evaluator): PAUSE arms only on status='rolling'. Layer 2 (here): even a
+ * genuinely degraded row is suppressed to NORMAL when 0 workers have a fresh heartbeat — a degraded
+ * cloud only matters if work is flowing, and this contains a stale 'rolling' row from a feeder that
+ * stopped mid-degradation. Unknown liveness (query error) does NOT suppress (surface the signal).
  * @param {object} supabase
  * @param {number} nowMs
  */
 export async function detectFromDb(supabase, nowMs, opts = {}) {
+  const liveWorkerWindowMs = numOrNull(opts.liveWorkerWindowMs) ?? DEFAULT_LIVE_WORKER_WINDOW_MS;
   try {
     const { data, error } = await supabase
-      .from('llm_canary_state')
+      .from('llm_cloud_health')
       .select('status, current_error_rate, error_rate_threshold, current_latency_p95_ms, baseline_latency_p95_ms, latency_multiplier_threshold, consecutive_failures, failures_before_rollback, last_quality_check_at')
       .limit(1)
       .maybeSingle();
-    if (error) return { rung: RUNG.NORMAL, reason: `canary read error (fail-open): ${error.message}`, signals: {} };
-    return evaluateDegradationRung(data, nowMs, opts);
+    if (error) return { rung: RUNG.NORMAL, reason: `cloud-health read error (fail-open): ${error.message}`, signals: {} };
+    const verdict = evaluateDegradationRung(data, nowMs, opts);
+    if (verdict.rung === RUNG.NORMAL) return verdict;
+    const liveWorkers = await countLiveWorkers(supabase, nowMs, liveWorkerWindowMs);
+    if (liveWorkers === 0) {
+      return { rung: RUNG.NORMAL, reason: `quiescent fleet (0 live workers) — suppress ${verdict.rung}`, signals: { ...verdict.signals, liveWorkers } };
+    }
+    return { ...verdict, signals: { ...verdict.signals, liveWorkers } };
   } catch (e) {
-    return { rung: RUNG.NORMAL, reason: `canary read threw (fail-open): ${e.message}`, signals: {} };
+    return { rung: RUNG.NORMAL, reason: `cloud-health read threw (fail-open): ${e.message}`, signals: {} };
   }
 }

--- a/tests/unit/cloud-cap-feeder.test.js
+++ b/tests/unit/cloud-cap-feeder.test.js
@@ -13,13 +13,18 @@ const errWith = (props) => Object.assign(new Error(props.message || 'probe error
 
 describe('categorizeProbeError', () => {
   it('429 -> rate_limit', () => expect(categorizeProbeError(errWith({ status: 429 }))).toBe('rate_limit'));
-  it('529 / overloaded_error -> overloaded', () => {
+  it('529 / overloaded_error -> overloaded (status + the SDK err.type discriminator)', () => {
     expect(categorizeProbeError(errWith({ status: 529 }))).toBe('overloaded');
-    expect(categorizeProbeError(errWith({ error: { type: 'overloaded_error' } }))).toBe('overloaded');
+    expect(categorizeProbeError(errWith({ type: 'overloaded_error' }))).toBe('overloaded');
   });
   it('5xx -> server', () => expect(categorizeProbeError(errWith({ status: 503 }))).toBe('server'));
-  it('timeout name/code -> timeout', () => {
-    expect(categorizeProbeError(errWith({ name: 'APIConnectionTimeoutError' }))).toBe('timeout');
+  it('REAL Anthropic timeout shapes -> timeout (constructor.name, "Request timed out." message, undici cause)', () => {
+    // The real Anthropic.APIConnectionTimeoutError has err.name==='Error', message==='Request timed out.',
+    // and no .code — only the CONSTRUCTOR name is distinctive. Cover all three real discriminators.
+    class APIConnectionTimeoutError extends Error {}
+    expect(categorizeProbeError(new APIConnectionTimeoutError('boom'))).toBe('timeout'); // constructor.name path
+    expect(categorizeProbeError(Object.assign(new Error('Request timed out.'), { name: 'Error' }))).toBe('timeout'); // real message ("timed out")
+    expect(categorizeProbeError(Object.assign(new Error('x'), { cause: { code: 'UND_ERR_CONNECT_TIMEOUT' } }))).toBe('timeout'); // undici connect-timeout cause
     expect(categorizeProbeError(errWith({ code: 'ETIMEDOUT' }))).toBe('timeout');
   });
   it('4xx config (401/400) -> other (NOT a cap signal — never false-PAUSE on a bad key)', () => {

--- a/tests/unit/cloud-cap-feeder.test.js
+++ b/tests/unit/cloud-cap-feeder.test.js
@@ -1,0 +1,132 @@
+/**
+ * cloud-cap feeder unit tests — SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001.
+ * Pure helpers + feedCloudHealth via INJECTED fake Anthropic client + fake supabase.
+ * ZERO live Anthropic calls, ZERO live DB writes.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  categorizeProbeError, computeP95, summarizeBatch, computeNextHealthState,
+  runProbeBatch, feedCloudHealth,
+} from '../../scripts/continuity/cloud-cap-feeder.mjs';
+
+const errWith = (props) => Object.assign(new Error(props.message || 'probe error'), props);
+
+describe('categorizeProbeError', () => {
+  it('429 -> rate_limit', () => expect(categorizeProbeError(errWith({ status: 429 }))).toBe('rate_limit'));
+  it('529 / overloaded_error -> overloaded', () => {
+    expect(categorizeProbeError(errWith({ status: 529 }))).toBe('overloaded');
+    expect(categorizeProbeError(errWith({ error: { type: 'overloaded_error' } }))).toBe('overloaded');
+  });
+  it('5xx -> server', () => expect(categorizeProbeError(errWith({ status: 503 }))).toBe('server'));
+  it('timeout name/code -> timeout', () => {
+    expect(categorizeProbeError(errWith({ name: 'APIConnectionTimeoutError' }))).toBe('timeout');
+    expect(categorizeProbeError(errWith({ code: 'ETIMEDOUT' }))).toBe('timeout');
+  });
+  it('4xx config (401/400) -> other (NOT a cap signal — never false-PAUSE on a bad key)', () => {
+    expect(categorizeProbeError(errWith({ status: 401 }))).toBe('other');
+    expect(categorizeProbeError(errWith({ status: 400 }))).toBe('other');
+  });
+});
+
+describe('computeP95', () => {
+  it('null on empty', () => expect(computeP95([])).toBeNull());
+  it('p95 of 10 sorted values', () => expect(computeP95([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])).toBe(100));
+  it('single value', () => expect(computeP95([42])).toBe(42));
+});
+
+describe('summarizeBatch', () => {
+  it('counts cap failures vs other; error_rate over total; p95 over ok latencies', () => {
+    const s = summarizeBatch([
+      { ok: true, latencyMs: 100 }, { ok: false, category: 'rate_limit' }, { ok: false, category: 'server' },
+      { ok: false, category: 'other' }, { ok: true, latencyMs: 200 },
+    ]);
+    expect(s.total).toBe(5);
+    expect(s.capFailures).toBe(2);
+    expect(s.otherErrors).toBe(1);
+    expect(s.errorRate).toBe(0.4);
+    expect(s.p95LatencyMs).toBe(200);
+  });
+  it('all healthy -> error_rate 0', () => expect(summarizeBatch([{ ok: true, latencyMs: 50 }]).errorRate).toBe(0));
+  it('empty -> null error_rate', () => expect(summarizeBatch([]).errorRate).toBeNull());
+});
+
+describe('computeNextHealthState', () => {
+  it('bad batch -> rolling + consecutive_failures++ (baseline untouched)', () => {
+    const n = computeNextHealthState({ error_rate_threshold: 0.05, consecutive_failures: 2, baseline_latency_p95_ms: 100 }, { errorRate: 0.4, p95LatencyMs: 300 });
+    expect(n.status).toBe('rolling');
+    expect(n.consecutive_failures).toBe(3);
+    expect(n.current_error_rate).toBe(0.4);
+    expect(n.baseline_latency_p95_ms).toBe(100);
+  });
+  it('healthy batch -> paused + reset; stamps baseline once when null', () => {
+    const n = computeNextHealthState({ error_rate_threshold: 0.05, consecutive_failures: 5, baseline_latency_p95_ms: null }, { errorRate: 0, p95LatencyMs: 120 });
+    expect(n.status).toBe('paused');
+    expect(n.consecutive_failures).toBe(0);
+    expect(n.baseline_latency_p95_ms).toBe(120);
+  });
+  it('never overwrites an existing baseline', () => {
+    expect(computeNextHealthState({ baseline_latency_p95_ms: 90 }, { errorRate: 0, p95LatencyMs: 500 }).baseline_latency_p95_ms).toBe(90);
+  });
+  it('null prev -> defaults (threshold 0.05); bad batch rolling+1', () => {
+    const n = computeNextHealthState(null, { errorRate: 0.9, p95LatencyMs: null });
+    expect(n.status).toBe('rolling');
+    expect(n.consecutive_failures).toBe(1);
+  });
+});
+
+describe('runProbeBatch (injected fake client; no real calls)', () => {
+  it('records ok/latency, categorizes failures, calls list() per probe', async () => {
+    let i = 0;
+    const client = { models: { list: vi.fn(async () => { i++; if (i === 2) throw errWith({ status: 429 }); return { data: [] }; }) } };
+    let t = 0; const nowFn = () => (t += 50);
+    const results = await runProbeBatch({ client, count: 3, nowFn });
+    expect(results).toHaveLength(3);
+    expect(results[0].ok).toBe(true);
+    expect(results[1]).toEqual({ ok: false, category: 'rate_limit' });
+    expect(results[2].ok).toBe(true);
+    expect(client.models.list).toHaveBeenCalledTimes(3);
+  });
+});
+
+function fakeSupabase(prev, { writeError = null } = {}) {
+  let captured = null;
+  const api = {
+    from() { return api; },
+    select() { return api; },
+    eq() { return api; },
+    maybeSingle: async () => ({ data: prev, error: null }),
+    update(payload) { captured = payload; return { eq: async () => ({ error: writeError }) }; },
+    captured: () => captured,
+  };
+  return api;
+}
+
+describe('feedCloudHealth (fake client + fake supabase, ZERO live calls/writes)', () => {
+  it('mixed-429 batch -> error_rate>0, status rolling, consecutive_failures++', async () => {
+    const sb = fakeSupabase({ error_rate_threshold: 0.05, consecutive_failures: 0, baseline_latency_p95_ms: null });
+    let i = 0;
+    const client = { models: { list: async () => { i++; if (i % 2 === 0) throw errWith({ status: 429 }); return { data: [] }; } } };
+    let t = 0;
+    const { summary, update } = await feedCloudHealth({ supabase: sb, client, nowFn: () => (t += 10), nowIso: () => '2026-06-14T00:00:00Z', probeCount: 4 });
+    expect(summary.capFailures).toBe(2);
+    expect(update.status).toBe('rolling');
+    expect(update.consecutive_failures).toBe(1);
+    expect(update.current_error_rate).toBe(0.5);
+    expect(update.last_quality_check_at).toBe('2026-06-14T00:00:00Z');
+    expect(sb.captured().status).toBe('rolling');
+  });
+  it('all-healthy batch -> status paused, consecutive_failures reset to 0', async () => {
+    const sb = fakeSupabase({ error_rate_threshold: 0.05, consecutive_failures: 3, baseline_latency_p95_ms: null });
+    const client = { models: { list: async () => ({ data: [] }) } };
+    let t = 0;
+    const { update } = await feedCloudHealth({ supabase: sb, client, nowFn: () => (t += 10), nowIso: () => 'T', probeCount: 3 });
+    expect(update.status).toBe('paused');
+    expect(update.consecutive_failures).toBe(0);
+  });
+  it('read error -> fail-loud throw (no probe, no write)', async () => {
+    const list = vi.fn(async () => ({ data: [] }));
+    const sb = { from() { return sb; }, select() { return sb; }, eq() { return sb; }, maybeSingle: async () => ({ data: null, error: { message: 'boom' } }) };
+    await expect(feedCloudHealth({ supabase: sb, client: { models: { list } } })).rejects.toThrow(/read failed/i);
+    expect(list).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/llm-degradation-detector.test.js
+++ b/tests/unit/llm-degradation-detector.test.js
@@ -127,6 +127,16 @@ describe('detectFromDb — repoint + Layer-2 quiescent-fleet guard (SD-LEO-INFRA
     expect((await detectFromDb(fakeDb({ healthRow: pausing, liveCount: 1 }), NOW2)).rung).toBe(RUNG.PAUSE_AND_SURFACE);
   });
 
+  it('STALE degraded row (feeder stopped) -> NORMAL even with live workers (stale-signal suppress)', async () => {
+    const staleIso = new Date(NOW2 - (40 * 60 * 1000)).toISOString(); // 40 min old (> 30min liveness window)
+    const stalePause = { ...pausing, last_quality_check_at: staleIso };
+    const r1 = await detectFromDb(fakeDb({ healthRow: stalePause, liveCount: 5 }), NOW2);
+    expect(r1.rung).toBe(RUNG.NORMAL);
+    expect(r1.reason).toMatch(/stale/i);
+    const staleFallback = { ...degraded, last_quality_check_at: staleIso };
+    expect((await detectFromDb(fakeDb({ healthRow: staleFallback, liveCount: 5 }), NOW2)).rung).toBe(RUNG.NORMAL);
+  });
+
   it('degraded row + UNKNOWN liveness (query error) -> NOT suppressed (surface the real signal)', async () => {
     const r = await detectFromDb(fakeDb({ healthRow: degraded, liveError: { message: 'liveness q failed' } }), NOW2);
     expect(r.rung).toBe(RUNG.MODEL_FALLBACK);

--- a/tests/unit/llm-degradation-detector.test.js
+++ b/tests/unit/llm-degradation-detector.test.js
@@ -3,7 +3,7 @@
  * Pins each rung boundary, precedence, recovery, and the fail-open direction.
  */
 import { describe, it, expect } from 'vitest';
-import { evaluateDegradationRung, isDegradedSafeMode, RUNG, DEFAULT_LIVENESS_STALE_MS } from '../../scripts/continuity/llm-degradation-detector.mjs';
+import { evaluateDegradationRung, isDegradedSafeMode, RUNG, DEFAULT_LIVENESS_STALE_MS, detectFromDb } from '../../scripts/continuity/llm-degradation-detector.mjs';
 
 const NOW = 1_000_000_000_000;
 const isoAgo = (ms) => new Date(NOW - ms).toISOString();
@@ -77,5 +77,68 @@ describe('evaluateDegradationRung — precedence + recovery + fail-safe', () => 
     expect(isDegradedSafeMode(RUNG.PAUSE_AND_SURFACE)).toBe(true);
     expect(isDegradedSafeMode(RUNG.MODEL_FALLBACK)).toBe(false);
     expect(isDegradedSafeMode(RUNG.NORMAL)).toBe(false);
+  });
+});
+
+describe('detectFromDb — repoint + Layer-2 quiescent-fleet guard (SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001)', () => {
+  const NOW2 = 1_000_000_000_000;
+  const freshIso = new Date(NOW2 - 60_000).toISOString();
+  const degraded = { status: 'rolling', current_error_rate: 0.06, error_rate_threshold: 0.05, current_latency_p95_ms: 1000, baseline_latency_p95_ms: 1000, latency_multiplier_threshold: 2.0, consecutive_failures: 0, failures_before_rollback: 3, last_quality_check_at: freshIso };
+  const pausing = { ...degraded, current_error_rate: 0.9, consecutive_failures: 3 };
+
+  function fakeDb({ healthRow, liveCount = null, liveError = null, healthError = null }) {
+    return {
+      from(table) {
+        if (table === 'llm_cloud_health') {
+          const api = { select() { return api; }, limit() { return api; }, maybeSingle: async () => ({ data: healthRow, error: healthError }) };
+          return api;
+        }
+        if (table === 'claude_sessions') {
+          const api = { select() { return api; }, eq() { return api; }, gt: async () => ({ count: liveCount, error: liveError }) };
+          return api;
+        }
+        throw new Error('unexpected table ' + table);
+      },
+    };
+  }
+
+  it('reads llm_cloud_health (live feeder substrate), NOT the old llm_canary_state placeholder', async () => {
+    const tables = [];
+    const db = { from(t) { tables.push(t); const api = { select() { return api; }, limit() { return api; }, eq() { return api; }, maybeSingle: async () => ({ data: null, error: null }), gt: async () => ({ count: 0, error: null }) }; return api; } };
+    await detectFromDb(db, NOW2);
+    expect(tables).toContain('llm_cloud_health');
+    expect(tables).not.toContain('llm_canary_state');
+  });
+
+  it('degraded row + 0 live workers -> NORMAL (quiescent guard suppresses)', async () => {
+    const r = await detectFromDb(fakeDb({ healthRow: degraded, liveCount: 0 }), NOW2);
+    expect(r.rung).toBe(RUNG.NORMAL);
+    expect(r.reason).toMatch(/quiescent/i);
+  });
+
+  it('degraded row + >=1 live worker -> the degraded rung (not suppressed)', async () => {
+    const r = await detectFromDb(fakeDb({ healthRow: degraded, liveCount: 2 }), NOW2);
+    expect(r.rung).toBe(RUNG.MODEL_FALLBACK);
+    expect(r.signals.liveWorkers).toBe(2);
+  });
+
+  it('PAUSE candidate + 0 live workers -> NORMAL; + 1 live worker -> PAUSE_AND_SURFACE', async () => {
+    expect((await detectFromDb(fakeDb({ healthRow: pausing, liveCount: 0 }), NOW2)).rung).toBe(RUNG.NORMAL);
+    expect((await detectFromDb(fakeDb({ healthRow: pausing, liveCount: 1 }), NOW2)).rung).toBe(RUNG.PAUSE_AND_SURFACE);
+  });
+
+  it('degraded row + UNKNOWN liveness (query error) -> NOT suppressed (surface the real signal)', async () => {
+    const r = await detectFromDb(fakeDb({ healthRow: degraded, liveError: { message: 'liveness q failed' } }), NOW2);
+    expect(r.rung).toBe(RUNG.MODEL_FALLBACK);
+  });
+
+  it('healthy row -> NORMAL (evaluator returns early; guard not consulted)', async () => {
+    const r = await detectFromDb(fakeDb({ healthRow: { ...degraded, status: 'paused', current_error_rate: 0.0, consecutive_failures: 0 }, liveCount: 0 }), NOW2);
+    expect(r.rung).toBe(RUNG.NORMAL);
+  });
+
+  it('cloud-health read error -> NORMAL (fail-open)', async () => {
+    const r = await detectFromDb(fakeDb({ healthRow: null, healthError: { message: 'down' } }), NOW2);
+    expect(r.rung).toBe(RUNG.NORMAL);
   });
 });


### PR DESCRIPTION
Wires the chairman-away PAUSE ladder to LIVE Anthropic cloud-health signal (closes the 'decorative G4' gap). Coordinator spec-fork ruling 3e11be61: **fork1=active-probe, fork2=dedicated-table-additive-migration**.

## What
- **NEW** `database/migrations/20260614_llm_cloud_health.sql` — additive singleton table mirroring the evaluator's read shape; `llm_canary_state` + its rollout RPCs untouched (clean separation, not row overload).
- **NEW** `scripts/continuity/cloud-cap-feeder.mjs` — opt-in active-probe feeder (injectable Anthropic client; cheap `models.list` batch; categorizes 429/5xx/overloaded/timeout → `current_error_rate` + p95; `status='rolling'` on a bad batch / `paused`+reset on healthy; sole writer).
- **EDIT** `scripts/continuity/llm-degradation-detector.mjs` — `detectFromDb` repoint to `llm_cloud_health` + **Layer-2 quiescent-fleet guard** (0 live worker heartbeats → NORMAL; unknown liveness surfaces) + refreshed comments. `evaluateDegradationRung` byte-unchanged.

## Verify
- 38/38 unit tests (12 existing evaluator green + feeder + guard), fake Anthropic + fake supabase, **zero live calls/writes**.

## Notes
- Migration is **additive**; prod-apply is gated (staged, not self-approved).
- Full SDK-call-path instrumentation named as a follow-up.

SD-LEO-INFRA-CLOUD-CAP-LIVE-FEEDER-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)