### PR TITLE
feat(SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001): unify intake pools into one conversion ledger

### DIFF
--- a/database/migrations/20260614_conversion_ledger.sql
+++ b/database/migrations/20260614_conversion_ledger.sql
@@ -1,0 +1,55 @@
+-- Migration: 20260614_conversion_ledger.sql
+-- SD: SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001 (FR-1)
+-- Purpose: ONE conversion ledger normalizing the 3 disconnected intake pools
+--          (eva_consultant_recommendations, sd_proposals, .prd-payloads/PROPOSAL-*.json)
+--          so every signal reaches a terminal disposition. Backlog depth =
+--          a single query (disposition IS NULL). Source rows are NEVER deleted —
+--          the drain only STATUS-UPDATES them.
+-- Idempotency: UNIQUE(source_pool, source_id).
+
+CREATE TABLE IF NOT EXISTS conversion_ledger (
+  id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_pool            TEXT NOT NULL CHECK (source_pool IN ('eva_consultant_rec','sd_proposal','prd_payload_file')),
+  source_id              TEXT NOT NULL,                  -- uuid (DB pools) or filename (file pool)
+  source_external_id     TEXT,                           -- e.g. trend_id / proposed_sd_key
+  title                  TEXT NOT NULL,
+  description            TEXT,
+  normalized_priority    TEXT CHECK (normalized_priority IN ('critical','high','medium','low')),
+  intake_status          TEXT NOT NULL DEFAULT 'registered' CHECK (intake_status IN ('registered','triaged')),
+  disposition            TEXT CHECK (disposition IN ('converted','dismissed','merged_duplicate','deferred')), -- NULL = still in backlog
+  triage_verdict         TEXT,
+  dedup_match_sd_key     TEXT,
+  dedup_score            NUMERIC(4,3),
+  dismiss_reason         TEXT,
+  linked_sd_key          TEXT,                           -- the SD this converted into
+  promoted_proposal_path TEXT,                           -- .prd-payloads/PROPOSAL-*.json written on promote
+  triaged_at             TIMESTAMPTZ,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (source_pool, source_id)
+);
+
+-- Backlog depth + drain-source lookups
+CREATE INDEX IF NOT EXISTS idx_conversion_ledger_backlog     ON conversion_ledger (created_at) WHERE disposition IS NULL;
+CREATE INDEX IF NOT EXISTS idx_conversion_ledger_disposition ON conversion_ledger (disposition);
+CREATE INDEX IF NOT EXISTS idx_conversion_ledger_source_pool ON conversion_ledger (source_pool);
+
+-- RLS: intake metadata (no PII). Service-role writes (drain); authenticated reads
+-- (backlog visibility). No anon/authenticated writes.
+ALTER TABLE conversion_ledger ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='conversion_ledger' AND policyname='conversion_ledger_select') THEN
+    CREATE POLICY conversion_ledger_select ON conversion_ledger FOR SELECT TO authenticated USING (true);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='conversion_ledger' AND policyname='conversion_ledger_service') THEN
+    CREATE POLICY conversion_ledger_service ON conversion_ledger FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+COMMENT ON TABLE conversion_ledger IS 'Unified intake conversion ledger (SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001). Normalizes 3 pools; backlog = disposition IS NULL; source rows never deleted.';
+
+-- ============================================================================
+-- ROLLBACK (manual):  DROP TABLE IF EXISTS conversion_ledger;
+-- ============================================================================

--- a/lib/intake/conversion-ledger.js
+++ b/lib/intake/conversion-ledger.js
@@ -1,0 +1,117 @@
+/**
+ * Conversion Ledger — service-role intake ledger.
+ * SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001 (FR-2)
+ *
+ * One ledger normalizing the 3 intake pools. registerItem is idempotent on
+ * (source_pool, source_id); setDisposition moves an item to a terminal state;
+ * backlogDepth is a single query (disposition IS NULL). Source rows in the
+ * origin pools are NEVER deleted — the drain only status-updates them.
+ *
+ * The supabase client is injectable so the unit tests run with a mock.
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+let _defaultClient = null;
+function defaultClient() {
+  if (!_defaultClient) _defaultClient = createSupabaseServiceClient();
+  return _defaultClient;
+}
+
+const VALID_POOLS = new Set(['eva_consultant_rec', 'sd_proposal', 'prd_payload_file']);
+const VALID_PRIORITIES = new Set(['critical', 'high', 'medium', 'low']);
+const VALID_DISPOSITIONS = new Set(['converted', 'dismissed', 'merged_duplicate', 'deferred']);
+
+/**
+ * Idempotently register a normalized intake item. Re-registering the same
+ * (source_pool, source_id) does NOT overwrite an existing disposition — it
+ * returns the existing row. Returns the ledger row.
+ *
+ * @param {Object} item - {source_pool, source_id, source_external_id?, title, description?, normalized_priority?}
+ * @param {Object} [opts] - {client}
+ */
+export async function registerItem(item, opts = {}) {
+  const db = opts.client || defaultClient();
+  if (!item || !VALID_POOLS.has(item.source_pool)) {
+    throw new Error(`registerItem: invalid source_pool: ${item && item.source_pool}`);
+  }
+  if (item.source_id == null || String(item.source_id).length === 0) {
+    throw new Error('registerItem: source_id is required');
+  }
+  if (!item.title) throw new Error('registerItem: title is required');
+  if (item.normalized_priority != null && !VALID_PRIORITIES.has(item.normalized_priority)) {
+    throw new Error(`registerItem: invalid normalized_priority: ${item.normalized_priority}`);
+  }
+
+  const row = {
+    source_pool: item.source_pool,
+    source_id: String(item.source_id),
+    source_external_id: item.source_external_id ?? null,
+    title: item.title,
+    description: item.description ?? null,
+    normalized_priority: item.normalized_priority ?? null,
+    intake_status: 'registered',
+  };
+
+  // Idempotent: insert; on (source_pool, source_id) conflict do nothing.
+  const ins = await db.from('conversion_ledger')
+    .upsert(row, { onConflict: 'source_pool,source_id', ignoreDuplicates: true })
+    .select('*');
+  if (ins.error) throw new Error(`registerItem upsert failed: ${ins.error.message}`);
+
+  if (Array.isArray(ins.data) && ins.data.length > 0) return ins.data[0]; // freshly inserted
+
+  // Already existed — return the existing row (disposition preserved).
+  const sel = await db.from('conversion_ledger')
+    .select('*')
+    .eq('source_pool', item.source_pool)
+    .eq('source_id', String(item.source_id))
+    .maybeSingle();
+  if (sel.error) throw new Error(`registerItem reselect failed: ${sel.error.message}`);
+  return sel.data;
+}
+
+/**
+ * Move a ledger item to a terminal disposition (idempotent re-apply is safe).
+ * @param {string} id - conversion_ledger.id
+ * @param {Object} verdict - {disposition, triage_verdict?, dedup_match_sd_key?, dedup_score?, dismiss_reason?, linked_sd_key?, promoted_proposal_path?}
+ * @param {Object} [opts] - {client}
+ */
+export async function setDisposition(id, verdict, opts = {}) {
+  const db = opts.client || defaultClient();
+  if (!id) throw new Error('setDisposition: id is required');
+  if (!verdict || !VALID_DISPOSITIONS.has(verdict.disposition)) {
+    throw new Error(`setDisposition: invalid disposition: ${verdict && verdict.disposition}`);
+  }
+  const patch = {
+    disposition: verdict.disposition,
+    triage_verdict: verdict.triage_verdict ?? null,
+    dedup_match_sd_key: verdict.dedup_match_sd_key ?? null,
+    dedup_score: verdict.dedup_score ?? null,
+    dismiss_reason: verdict.dismiss_reason ?? null,
+    linked_sd_key: verdict.linked_sd_key ?? null,
+    promoted_proposal_path: verdict.promoted_proposal_path ?? null,
+    intake_status: 'triaged',
+    triaged_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error } = await db.from('conversion_ledger').update(patch).eq('id', id).select('*').maybeSingle();
+  if (error) throw new Error(`setDisposition failed: ${error.message}`);
+  return data;
+}
+
+/**
+ * Backlog depth — items with no terminal disposition yet.
+ * @param {Object} [opts] - {client}
+ * @returns {Promise<number>}
+ */
+export async function backlogDepth(opts = {}) {
+  const db = opts.client || defaultClient();
+  const { count, error } = await db.from('conversion_ledger')
+    .select('id', { count: 'exact', head: true })
+    .is('disposition', null);
+  if (error) throw new Error(`backlogDepth failed: ${error.message}`);
+  return count || 0;
+}
+
+export const _internals = { VALID_POOLS, VALID_PRIORITIES, VALID_DISPOSITIONS };

--- a/lib/intake/conversion-ledger.js
+++ b/lib/intake/conversion-ledger.js
@@ -68,6 +68,7 @@ export async function registerItem(item, opts = {}) {
     .eq('source_id', String(item.source_id))
     .maybeSingle();
   if (sel.error) throw new Error(`registerItem reselect failed: ${sel.error.message}`);
+  if (!sel.data) throw new Error(`registerItem: upsert inserted no row AND reselect found none for ${item.source_pool}:${item.source_id} (unexpected)`);
   return sel.data;
 }
 

--- a/lib/intake/triage-classifier.js
+++ b/lib/intake/triage-classifier.js
@@ -86,12 +86,12 @@ export function classify(item, ctx = {}) {
   // (d) CONSERVATIVE guard — a generic/low-signal title that weakly matches many SDs
   // is NOT auto-promoted and NOT mass-dismissed; it is deferred for human eyes.
   if (itemKws.size <= GENERIC_KEYWORD_MAX && weakMatches >= AMBIGUOUS_MIN_WEAK_MATCHES) {
-    return { ...base, disposition: 'deferred', triage_verdict: 'ambiguous_generic', dedup_score: best.score ? Number(best.score.toFixed(3)) : null };
+    return { ...base, disposition: 'deferred', triage_verdict: 'ambiguous_generic', dedup_score: best.key != null ? Number(best.score.toFixed(3)) : null };
   }
 
   // (e) Novel + aligned -> promote. Disposition 'converted' is the INTENDED terminal
   // state; the drain only writes it after the SD is actually materialized.
-  return { ...base, disposition: 'converted', triage_verdict: 'novel_promote', promote: true, dedup_score: best.score ? Number(best.score.toFixed(3)) : null };
+  return { ...base, disposition: 'converted', triage_verdict: 'novel_promote', promote: true, dedup_score: best.key != null ? Number(best.score.toFixed(3)) : null };
 }
 
 export const _thresholds = { JACCARD_DUP_THRESHOLD, CAPABILITY_COVER_THRESHOLD, WEAK_MATCH_THRESHOLD, GENERIC_KEYWORD_MAX, AMBIGUOUS_MIN_WEAK_MATCHES };

--- a/lib/intake/triage-classifier.js
+++ b/lib/intake/triage-classifier.js
@@ -1,0 +1,97 @@
+/**
+ * Triage Classifier — PURE, rule-based, idempotent.
+ * SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001 (FR-3)
+ *
+ * classify(normalizedItem, { existingSds, capabilities }) -> verdict. No DB, no
+ * I/O, no content judgment — only deterministic rules. Reuses the existing
+ * scope-similarity dedup (Jaccard >= 0.5). Same input -> same output (idempotent).
+ *
+ * Disposition semantics:
+ *   dismissed        — advisory/research or already covered (NOT an SD candidate)
+ *   merged_duplicate — exact or Jaccard match to an existing SD
+ *   deferred         — ambiguous/generic; needs human eyes (never auto-promoted)
+ *   converted        — novel + aligned; promote=true (the drain materializes the SD)
+ */
+
+import { extractKeywords, calculateSimilarity, extractSDKeywords } from '../../scripts/modules/handoff/validation/scope-similarity.js';
+
+const JACCARD_DUP_THRESHOLD = 0.5;       // >= this vs an SD => duplicate
+const CAPABILITY_COVER_THRESHOLD = 0.5;  // >= this vs a capability => already covered
+const WEAK_MATCH_THRESHOLD = 0.3;        // counts toward "matches many" for the guard
+const GENERIC_KEYWORD_MAX = 2;           // <= this many keywords => "generic" title
+const AMBIGUOUS_MIN_WEAK_MATCHES = 4;    // generic + this many weak matches => deferred
+
+function normTitle(t) {
+  return String(t || '').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * @param {Object} item - normalized intake item {title, description, action_type?, ...}
+ * @param {Object} ctx
+ * @param {Array}  ctx.existingSds  - [{sd_key, title, scope, description, key_changes}]
+ * @param {Array} [ctx.capabilities] - [{name, description}]
+ * @returns {{disposition:string, triage_verdict:string, dedup_match_sd_key:?string, dedup_score:?number, dismiss_reason:?string, promote:boolean}}
+ */
+export function classify(item, ctx = {}) {
+  const existingSds = Array.isArray(ctx.existingSds) ? ctx.existingSds : [];
+  const capabilities = Array.isArray(ctx.capabilities) ? ctx.capabilities : [];
+  const existingSdKeys = ctx.existingSdKeys instanceof Set
+    ? ctx.existingSdKeys
+    : new Set(Array.isArray(ctx.existingSdKeys) ? ctx.existingSdKeys : []);
+  const base = { disposition: null, triage_verdict: null, dedup_match_sd_key: null, dedup_score: null, dismiss_reason: null, promote: false };
+
+  // (0) Key dedup — an item whose proposed/source key is ALREADY an SD is already
+  // materialized (e.g. a PROPOSAL-*.json whose SD shipped). Runs first; Pool-1
+  // source_external_id is a trend_id (uuid) and will not collide with sd_keys.
+  const extKey = item.source_external_id;
+  if (extKey && existingSdKeys.has(extKey)) {
+    return { ...base, disposition: 'merged_duplicate', triage_verdict: 'already_materialized', dedup_match_sd_key: extKey, dedup_score: 1.0 };
+  }
+
+  // (a) Action-type advisory filters (Pool-1). These are deterministic non-SD classes.
+  const action = (item.action_type || '').toLowerCase();
+  if (action === 'review') {
+    return { ...base, disposition: 'dismissed', triage_verdict: 'advisory_review', dismiss_reason: 'advisory_review_not_sd_candidate' };
+  }
+  if (action === 'research') {
+    return { ...base, disposition: 'dismissed', triage_verdict: 'research_directive', dismiss_reason: 'research_directive_not_sd_candidate' };
+  }
+
+  // (b) Dedup vs existing SDs — exact title, then Jaccard.
+  const itemTitleNorm = normTitle(item.title);
+  const itemKws = extractKeywords(`${item.title || ''} ${item.description || ''}`);
+
+  let best = { key: null, score: 0 };
+  let weakMatches = 0;
+  for (const sd of existingSds) {
+    if (sd && normTitle(sd.title) === itemTitleNorm && itemTitleNorm.length > 0) {
+      return { ...base, disposition: 'merged_duplicate', triage_verdict: 'exact_duplicate', dedup_match_sd_key: sd.sd_key, dedup_score: 1.0 };
+    }
+    const score = calculateSimilarity(itemKws, extractSDKeywords(sd || {}));
+    if (score > best.score) best = { key: sd && sd.sd_key, score };
+    if (score >= WEAK_MATCH_THRESHOLD) weakMatches++;
+  }
+  if (best.score >= JACCARD_DUP_THRESHOLD) {
+    return { ...base, disposition: 'merged_duplicate', triage_verdict: 'jaccard_duplicate', dedup_match_sd_key: best.key, dedup_score: Number(best.score.toFixed(3)) };
+  }
+
+  // (c) Capability coverage (soft) — already solved by an existing capability.
+  for (const cap of capabilities) {
+    const capKws = extractKeywords(`${cap.name || ''} ${cap.description || ''}`);
+    if (calculateSimilarity(itemKws, capKws) >= CAPABILITY_COVER_THRESHOLD) {
+      return { ...base, disposition: 'dismissed', triage_verdict: 'covered_by_capability', dismiss_reason: 'already_covered_by_capability' };
+    }
+  }
+
+  // (d) CONSERVATIVE guard — a generic/low-signal title that weakly matches many SDs
+  // is NOT auto-promoted and NOT mass-dismissed; it is deferred for human eyes.
+  if (itemKws.size <= GENERIC_KEYWORD_MAX && weakMatches >= AMBIGUOUS_MIN_WEAK_MATCHES) {
+    return { ...base, disposition: 'deferred', triage_verdict: 'ambiguous_generic', dedup_score: best.score ? Number(best.score.toFixed(3)) : null };
+  }
+
+  // (e) Novel + aligned -> promote. Disposition 'converted' is the INTENDED terminal
+  // state; the drain only writes it after the SD is actually materialized.
+  return { ...base, disposition: 'converted', triage_verdict: 'novel_promote', promote: true, dedup_score: best.score ? Number(best.score.toFixed(3)) : null };
+}
+
+export const _thresholds = { JACCARD_DUP_THRESHOLD, CAPABILITY_COVER_THRESHOLD, WEAK_MATCH_THRESHOLD, GENERIC_KEYWORD_MAX, AMBIGUOUS_MIN_WEAK_MATCHES };

--- a/package.json
+++ b/package.json
@@ -311,6 +311,7 @@
     "contract:check": "node scripts/artifact-contract.js check",
     "payments:test-charge": "node scripts/payments/test-charge-harness.mjs",
     "llc:track": "node scripts/legal/track-llc-formation.mjs",
+    "intake:drain": "node scripts/intake/drain-intake.mjs",
     "stage-contracts:check": "node scripts/validate-stage-contract-connectivity.mjs",
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",

--- a/scripts/intake/drain-intake.mjs
+++ b/scripts/intake/drain-intake.mjs
@@ -29,7 +29,12 @@ import { registerItem, setDisposition, backlogDepth } from '../../lib/intake/con
 const APPLY = process.argv.includes('--apply');
 const DRY_RUN = !APPLY; // dry-run is the default
 const limIdx = process.argv.indexOf('--limit');
-const LIMIT = limIdx !== -1 ? parseInt(process.argv[limIdx + 1], 10) : null;
+const _rawLimit = limIdx !== -1 ? parseInt(process.argv[limIdx + 1], 10) : null;
+if (_rawLimit !== null && (!Number.isInteger(_rawLimit) || _rawLimit <= 0)) {
+  console.error(`--limit must be a positive integer (got "${process.argv[limIdx + 1]}")`);
+  process.exit(1);
+}
+const LIMIT = _rawLimit; // applied UNIFORMLY across the combined batch (not just Pool-1)
 const PROPOSALS_DIR = path.resolve('.prd-payloads');
 
 /** D1: priority_score (numeric, 0-1 or 0-100) -> normalized_priority. */
@@ -72,11 +77,9 @@ async function loadCapabilities(sb) {
 
 /** Pool 1: eva_consultant_recommendations (live source). */
 async function loadPool1(sb) {
-  let q = sb.from('eva_consultant_recommendations')
+  const { data, error } = await sb.from('eva_consultant_recommendations')
     .select('id, trend_id, title, description, priority_score, action_type, status')
     .order('created_at', { ascending: true });
-  if (LIMIT) q = q.limit(LIMIT);
-  const { data, error } = await q;
   if (error) throw new Error(`loadPool1: ${error.message}`);
   return (data || []).map(r => ({
     source_pool: 'eva_consultant_rec',
@@ -133,7 +136,8 @@ async function main() {
     loadPool1(sb), loadPool2(sb), loadExistingSds(sb), loadCapabilities(sb),
   ]);
   const pool3 = loadPool3();
-  const items = [...pool1, ...pool2, ...pool3];
+  let items = [...pool1, ...pool2, ...pool3];
+  if (LIMIT) items = items.slice(0, LIMIT); // uniform cap across all pools
   const existingSdKeys = new Set(existingSds.map(s => s.sd_key).filter(Boolean));
   console.log(`   pools: eva_consultant_rec=${pool1.length}, sd_proposal=${pool2.length}, prd_payload_file=${pool3.length} | total=${items.length}`);
   console.log(`   existing SDs (dedup corpus)=${existingSds.length}, capabilities=${capabilities.length}`);
@@ -158,18 +162,33 @@ async function main() {
         source_external_id: item.source_external_id, title: item.title,
         description: item.description, normalized_priority: item.normalized_priority,
       }, { client: sb });
-      if (row && row.disposition) { skipped++; continue; } // already triaged (idempotent)
+      if (row && row.disposition) {
+        // Already triaged (idempotent). IDEMP-3: still reconcile the SOURCE status
+        // in case a prior run dispositioned the ledger but failed the source update.
+        if (item.source_pool === 'eva_consultant_rec') {
+          await sb.from('eva_consultant_recommendations').update({ status: 'triaged' }).eq('id', item.source_id);
+        }
+        skipped++; continue;
+      }
 
       let linked_sd_key = null, promoted_proposal_path = null, disposition = verdict.disposition;
       if (verdict.promote) {
         // Promote novel items via the EXISTING --from-proposal ingest (no fork).
         const proposalPath = item._proposalPath || await writeProposalForItem(item);
         promoted_proposal_path = proposalPath;
-        const { createFromProposal } = await import('../leo-create-sd.js');
         process.env.SDKEY_SKIP_PROTOCOL_READ = '1';
+        const { createFromProposal } = await import('../leo-create-sd.js');
         const created = await createFromProposal(proposalPath, { dryRun: false });
-        linked_sd_key = (created && (created.sd_key || created[0]?.sd_key)) || null;
+        // createFromProposal returns [{sdKey, file, action}] (camelCase).
+        const linked = Array.isArray(created) ? (created.find(r => r && r.sdKey) || created[0]) : created;
+        linked_sd_key = (linked && (linked.sdKey || linked.sd_key)) || null;
         disposition = 'converted';
+        // DEDUP-03: add the just-promoted SD to the in-run corpus so subsequent
+        // items in THIS batch dedup against it (prevents intra-batch duplicates).
+        if (linked_sd_key) {
+          existingSds.push({ sd_key: linked_sd_key, title: item.title, scope: '', description: item.description || '', key_changes: [] });
+          existingSdKeys.add(linked_sd_key);
+        }
       }
       await setDisposition(row.id, {
         disposition,
@@ -209,15 +228,23 @@ async function main() {
   }
 }
 
-/** Write a PROPOSAL-*.json for a promote item that has no source file (Pool-1 create_sd). */
+/**
+ * Write a PROPOSAL-*.json for a promote item that has no source file (Pool-1 create_sd).
+ * The proposed_sd_key + filename are DETERMINISTIC per source item, so a re-run
+ * reuses the same key — createFromProposal's keyExists guard then makes promotion
+ * idempotent (no duplicate SD on crash-then-rerun). proposed_sd_key is REQUIRED by
+ * validateProposalShape (a non-empty string) — omitting it process.exit(1)s the run.
+ */
 async function writeProposalForItem(item) {
   const { writeFileSync, mkdirSync } = await import('fs');
   mkdirSync(PROPOSALS_DIR, { recursive: true });
-  const slug = String(item.title).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
-  const fname = `PROPOSAL-INTAKE-${slug || 'item'}-${String(item.source_id).slice(0, 8)}.json`;
-  const fpath = path.join(PROPOSALS_DIR, fname);
+  const shortId = String(item.source_id).replace(/[^a-zA-Z0-9]/g, '').slice(0, 10).toUpperCase() || 'ITEM';
+  const proposedKey = `SD-LEO-INTAKE-${shortId}`;
+  const fpath = path.join(PROPOSALS_DIR, `PROPOSAL-${proposedKey}.json`);
   writeFileSync(fpath, JSON.stringify({
     PROPOSAL: true,
+    proposed_sd_key: proposedKey,
+    status_intended: 'draft',
     title: item.title,
     sd_type: 'infrastructure',
     priority: item.normalized_priority || 'medium',

--- a/scripts/intake/drain-intake.mjs
+++ b/scripts/intake/drain-intake.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * drain-intake.mjs — unify + drain the intake pools into the conversion ledger.
+ * SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001 (FR-4 / FR-5)
+ *
+ * Reads the 3 pools, normalizes each to the ledger schema, registers them in the
+ * conversion_ledger, runs the PURE rule-based triage classifier, and applies a
+ * terminal disposition to each. Novel items are promoted via the EXISTING
+ * leo-create-sd.js --from-proposal ingest (no fork). Source rows are STATUS-UPDATED,
+ * NEVER deleted.
+ *
+ *   DEFAULT = --dry-run: zero writes; reports the full disposition plan.
+ *   --apply : registers items, applies dispositions, promotes novel items,
+ *             and status-updates source rows (idempotent + reversible).
+ *
+ * Usage:
+ *   node scripts/intake/drain-intake.mjs              # dry-run (default)
+ *   node scripts/intake/drain-intake.mjs --apply
+ *   node scripts/intake/drain-intake.mjs --dry-run --limit 50
+ */
+import dotenv from 'dotenv';
+dotenv.config({ path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.env', override: true });
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { classify } from '../../lib/intake/triage-classifier.js';
+import { registerItem, setDisposition, backlogDepth } from '../../lib/intake/conversion-ledger.js';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY; // dry-run is the default
+const limIdx = process.argv.indexOf('--limit');
+const LIMIT = limIdx !== -1 ? parseInt(process.argv[limIdx + 1], 10) : null;
+const PROPOSALS_DIR = path.resolve('.prd-payloads');
+
+/** D1: priority_score (numeric, 0-1 or 0-100) -> normalized_priority. */
+function normalizePriorityScore(score) {
+  if (score == null || Number.isNaN(Number(score))) return 'medium';
+  let s = Number(score);
+  if (s > 1) s = s / 100; // accept a 0-100 scale
+  if (s >= 0.8) return 'critical';
+  if (s >= 0.6) return 'high';
+  if (s >= 0.4) return 'medium';
+  return 'low';
+}
+
+function normalizePriorityText(p) {
+  return ['critical', 'high', 'medium', 'low'].includes(p) ? p : 'medium';
+}
+
+async function loadExistingSds(sb) {
+  // Paginate — PostgREST caps a single select at 1000 rows; the dedup corpus
+  // MUST be the full SD set or already-shipped work gets misclassified as novel.
+  const all = [];
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await sb.from('strategic_directives_v2')
+      .select('sd_key, title, scope, description, key_changes')
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(`loadExistingSds: ${error.message}`);
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < pageSize) break;
+  }
+  return all;
+}
+
+async function loadCapabilities(sb) {
+  const { data, error } = await sb.from('sd_capabilities').select('name, description');
+  if (error) return []; // table optional; coverage check just no-ops
+  return data || [];
+}
+
+/** Pool 1: eva_consultant_recommendations (live source). */
+async function loadPool1(sb) {
+  let q = sb.from('eva_consultant_recommendations')
+    .select('id, trend_id, title, description, priority_score, action_type, status')
+    .order('created_at', { ascending: true });
+  if (LIMIT) q = q.limit(LIMIT);
+  const { data, error } = await q;
+  if (error) throw new Error(`loadPool1: ${error.message}`);
+  return (data || []).map(r => ({
+    source_pool: 'eva_consultant_rec',
+    source_id: r.id,
+    source_external_id: r.trend_id || null,
+    title: r.title || '(untitled)',
+    description: r.description || null,
+    normalized_priority: normalizePriorityScore(r.priority_score),
+    action_type: r.action_type,
+    _source: r,
+  }));
+}
+
+/** Pool 2: sd_proposals — D4: schema-reserved, SKIPPED while empty. */
+async function loadPool2(sb) {
+  const { count } = await sb.from('sd_proposals').select('id', { count: 'exact', head: true });
+  if (!count) return [];
+  // Non-empty path intentionally deferred (D4): fn_create_sd_from_proposal mints
+  // non-canonical keys. When Pool-2 gains rows, wire normalization here.
+  console.warn(`   ⚠️  Pool-2 (sd_proposals) has ${count} rows — D4 deferral: skipping (not yet wired).`);
+  return [];
+}
+
+/** Pool 3: .prd-payloads/PROPOSAL-*.json files (proposal residue awaiting materialization). */
+function loadPool3() {
+  let files = [];
+  try { files = readdirSync(PROPOSALS_DIR).filter(f => /^PROPOSAL-.*\.json$/.test(f)); }
+  catch { return []; }
+  const items = [];
+  for (const f of files) {
+    try {
+      const j = JSON.parse(readFileSync(path.join(PROPOSALS_DIR, f), 'utf8'));
+      items.push({
+        source_pool: 'prd_payload_file',
+        source_id: f,
+        source_external_id: j.proposed_sd_key || j.sd_key || null,
+        title: j.title || f,
+        description: j.rationale || j.description || null,
+        normalized_priority: normalizePriorityText(j.priority),
+        action_type: 'create_sd', // proposals are SD candidates by construction
+        _proposalPath: path.join(PROPOSALS_DIR, f),
+        _json: j,
+      });
+    } catch (e) { console.warn(`   ⚠️  skipping unparseable ${f}: ${e.message}`); }
+  }
+  return items;
+}
+
+async function main() {
+  const sb = createSupabaseServiceClient();
+  console.log(`\n=== intake drain (${DRY_RUN ? 'DRY-RUN — zero writes' : 'APPLY'}) ===`);
+
+  const [pool1, pool2, existingSds, capabilities] = await Promise.all([
+    loadPool1(sb), loadPool2(sb), loadExistingSds(sb), loadCapabilities(sb),
+  ]);
+  const pool3 = loadPool3();
+  const items = [...pool1, ...pool2, ...pool3];
+  const existingSdKeys = new Set(existingSds.map(s => s.sd_key).filter(Boolean));
+  console.log(`   pools: eva_consultant_rec=${pool1.length}, sd_proposal=${pool2.length}, prd_payload_file=${pool3.length} | total=${items.length}`);
+  console.log(`   existing SDs (dedup corpus)=${existingSds.length}, capabilities=${capabilities.length}`);
+
+  const tally = { dismissed: 0, merged_duplicate: 0, deferred: 0, converted: 0 };
+  const byVerdict = {};
+  const promoted = [];
+  let applied = 0, skipped = 0;
+
+  for (const item of items) {
+    const verdict = classify(item, { existingSds, capabilities, existingSdKeys });
+    const d = verdict.disposition || 'deferred';
+    tally[d] = (tally[d] || 0) + 1;
+    byVerdict[verdict.triage_verdict] = (byVerdict[verdict.triage_verdict] || 0) + 1;
+
+    if (DRY_RUN) continue;
+
+    // --- APPLY (idempotent, status-update-only, never delete) ---
+    try {
+      const row = await registerItem({
+        source_pool: item.source_pool, source_id: item.source_id,
+        source_external_id: item.source_external_id, title: item.title,
+        description: item.description, normalized_priority: item.normalized_priority,
+      }, { client: sb });
+      if (row && row.disposition) { skipped++; continue; } // already triaged (idempotent)
+
+      let linked_sd_key = null, promoted_proposal_path = null, disposition = verdict.disposition;
+      if (verdict.promote) {
+        // Promote novel items via the EXISTING --from-proposal ingest (no fork).
+        const proposalPath = item._proposalPath || await writeProposalForItem(item);
+        promoted_proposal_path = proposalPath;
+        const { createFromProposal } = await import('../leo-create-sd.js');
+        process.env.SDKEY_SKIP_PROTOCOL_READ = '1';
+        const created = await createFromProposal(proposalPath, { dryRun: false });
+        linked_sd_key = (created && (created.sd_key || created[0]?.sd_key)) || null;
+        disposition = 'converted';
+      }
+      await setDisposition(row.id, {
+        disposition,
+        triage_verdict: verdict.triage_verdict,
+        dedup_match_sd_key: verdict.dedup_match_sd_key,
+        dedup_score: verdict.dedup_score,
+        dismiss_reason: verdict.dismiss_reason,
+        linked_sd_key, promoted_proposal_path,
+      }, { client: sb });
+
+      // Status-update the SOURCE row (never delete). Defensive: non-fatal on CHECK conflicts.
+      if (item.source_pool === 'eva_consultant_rec') {
+        const { error: upErr } = await sb.from('eva_consultant_recommendations')
+          .update({ status: 'triaged' }).eq('id', item.source_id);
+        if (upErr) console.warn(`   ⚠️  source status-update skipped for ${item.source_id}: ${upErr.message}`);
+      }
+      if (verdict.promote) promoted.push(linked_sd_key || promoted_proposal_path);
+      applied++;
+    } catch (e) {
+      console.error(`   ❌ apply failed for ${item.source_pool}:${item.source_id}: ${e.message}`);
+    }
+  }
+
+  console.log('\n--- disposition plan ---');
+  console.log(`   dismissed       : ${tally.dismissed || 0}`);
+  console.log(`   merged_duplicate: ${tally.merged_duplicate || 0}`);
+  console.log(`   deferred        : ${tally.deferred || 0}`);
+  console.log(`   converted       : ${tally.converted || 0}  (promote candidates)`);
+  console.log('   by verdict      :', JSON.stringify(byVerdict));
+
+  if (DRY_RUN) {
+    console.log('\n   DRY-RUN: zero writes. Re-run with --apply to register + disposition + promote.');
+  } else {
+    const depth = await backlogDepth({ client: sb });
+    console.log(`\n   APPLIED: ${applied} dispositioned, ${skipped} already-triaged (idempotent), ${promoted.length} promoted.`);
+    console.log(`   backlog depth now (disposition IS NULL): ${depth}`);
+  }
+}
+
+/** Write a PROPOSAL-*.json for a promote item that has no source file (Pool-1 create_sd). */
+async function writeProposalForItem(item) {
+  const { writeFileSync, mkdirSync } = await import('fs');
+  mkdirSync(PROPOSALS_DIR, { recursive: true });
+  const slug = String(item.title).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+  const fname = `PROPOSAL-INTAKE-${slug || 'item'}-${String(item.source_id).slice(0, 8)}.json`;
+  const fpath = path.join(PROPOSALS_DIR, fname);
+  writeFileSync(fpath, JSON.stringify({
+    PROPOSAL: true,
+    title: item.title,
+    sd_type: 'infrastructure',
+    priority: item.normalized_priority || 'medium',
+    rationale: item.description || `Promoted from intake (${item.source_pool}:${item.source_id})`,
+    provenance: { source: 'drain-intake', source_pool: item.source_pool, source_id: item.source_id },
+  }, null, 2));
+  return fpath;
+}
+
+main().catch(e => { console.error('drain-intake FAILED:', e?.stack || e); process.exit(1); });

--- a/tests/unit/intake/conversion-ledger.test.js
+++ b/tests/unit/intake/conversion-ledger.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { registerItem, setDisposition, backlogDepth } from '../../../lib/intake/conversion-ledger.js';
+
+// Minimal mock matching the exact Supabase chains the ledger lib uses.
+function makeClient({ upsertResult, reselectResult, updateResult, countResult } = {}) {
+  return {
+    from() {
+      return {
+        upsert: () => ({ select: () => Promise.resolve(upsertResult) }),
+        update: () => ({ eq: () => ({ select: () => ({ maybeSingle: () => Promise.resolve(updateResult) }) }) }),
+        select: (cols, opts) => {
+          if (opts && opts.head) return { is: () => Promise.resolve(countResult) };
+          return { eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve(reselectResult) }) }) };
+        },
+      };
+    },
+  };
+}
+
+const validItem = { source_pool: 'eva_consultant_rec', source_id: 'rec-1', title: 'Some signal', normalized_priority: 'high' };
+
+describe('conversion-ledger lib', () => {
+  it('registerItem returns the freshly-inserted row', async () => {
+    const client = makeClient({ upsertResult: { data: [{ id: 'L1', ...validItem, disposition: null }], error: null } });
+    const row = await registerItem(validItem, { client });
+    expect(row.id).toBe('L1');
+    expect(row.disposition).toBeNull();
+  });
+
+  it('registerItem is idempotent — returns the EXISTING row (disposition preserved) on conflict', async () => {
+    const client = makeClient({
+      upsertResult: { data: [], error: null }, // conflict -> nothing inserted
+      reselectResult: { data: { id: 'L9', source_pool: 'eva_consultant_rec', source_id: 'rec-1', disposition: 'dismissed' }, error: null },
+    });
+    const row = await registerItem(validItem, { client });
+    expect(row.id).toBe('L9');
+    expect(row.disposition).toBe('dismissed'); // not overwritten
+  });
+
+  it('registerItem rejects an invalid source_pool', async () => {
+    const client = makeClient({});
+    await expect(registerItem({ ...validItem, source_pool: 'bogus' }, { client })).rejects.toThrow(/source_pool/);
+  });
+
+  it('registerItem rejects a missing title', async () => {
+    const client = makeClient({});
+    await expect(registerItem({ source_pool: 'eva_consultant_rec', source_id: 'x' }, { client })).rejects.toThrow(/title/);
+  });
+
+  it('setDisposition writes a terminal disposition', async () => {
+    const client = makeClient({ updateResult: { data: { id: 'L1', disposition: 'converted', intake_status: 'triaged' }, error: null } });
+    const row = await setDisposition('L1', { disposition: 'converted', linked_sd_key: 'SD-NEW-001' }, { client });
+    expect(row.disposition).toBe('converted');
+  });
+
+  it('setDisposition rejects an invalid disposition', async () => {
+    const client = makeClient({});
+    await expect(setDisposition('L1', { disposition: 'bogus' }, { client })).rejects.toThrow(/disposition/);
+  });
+
+  it('backlogDepth returns the count of un-dispositioned items', async () => {
+    const client = makeClient({ countResult: { count: 7, error: null } });
+    expect(await backlogDepth({ client })).toBe(7);
+  });
+});

--- a/tests/unit/intake/triage-classifier.test.js
+++ b/tests/unit/intake/triage-classifier.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { classify } from '../../../lib/intake/triage-classifier.js';
+
+const sd = (sd_key, title, extra = {}) => ({ sd_key, title, scope: '', description: '', key_changes: [], ...extra });
+
+describe('triage-classifier (pure, rule-based) — every verdict path', () => {
+  it('action_type review -> dismissed/advisory_review', () => {
+    const v = classify({ title: 'Look into X', action_type: 'review' }, { existingSds: [] });
+    expect(v.disposition).toBe('dismissed');
+    expect(v.triage_verdict).toBe('advisory_review');
+    expect(v.dismiss_reason).toBe('advisory_review_not_sd_candidate');
+    expect(v.promote).toBe(false);
+  });
+
+  it('action_type research -> dismissed/research_directive', () => {
+    const v = classify({ title: 'Research Y', action_type: 'research' }, { existingSds: [] });
+    expect(v.disposition).toBe('dismissed');
+    expect(v.triage_verdict).toBe('research_directive');
+  });
+
+  it('proposed key already materialized -> merged_duplicate/already_materialized (runs before action_type)', () => {
+    const v = classify(
+      { title: 'whatever', action_type: 'create_sd', source_external_id: 'SD-LEO-X-001' },
+      { existingSds: [], existingSdKeys: new Set(['SD-LEO-X-001']) }
+    );
+    expect(v.disposition).toBe('merged_duplicate');
+    expect(v.triage_verdict).toBe('already_materialized');
+    expect(v.dedup_match_sd_key).toBe('SD-LEO-X-001');
+    expect(v.dedup_score).toBe(1.0);
+  });
+
+  it('exact title match -> merged_duplicate/exact_duplicate score 1.0', () => {
+    const v = classify(
+      { title: 'Unify intake pools', action_type: 'create_sd' },
+      { existingSds: [sd('SD-DUP-001', 'Unify intake pools')] }
+    );
+    expect(v.disposition).toBe('merged_duplicate');
+    expect(v.triage_verdict).toBe('exact_duplicate');
+    expect(v.dedup_match_sd_key).toBe('SD-DUP-001');
+    expect(v.dedup_score).toBe(1.0);
+  });
+
+  it('Jaccard >= 0.5 -> merged_duplicate/jaccard_duplicate', () => {
+    const v = classify(
+      { title: 'payment webhook signature verification idempotent', action_type: 'create_sd' },
+      { existingSds: [sd('SD-JAC-001', 'payment webhook signature verification idempotent capture')] }
+    );
+    expect(v.disposition).toBe('merged_duplicate');
+    expect(v.triage_verdict).toBe('jaccard_duplicate');
+    expect(v.dedup_match_sd_key).toBe('SD-JAC-001');
+    expect(v.dedup_score).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('capability coverage -> dismissed/covered_by_capability', () => {
+    const v = classify(
+      { title: 'conversion ledger backlog metric query', action_type: 'create_sd' },
+      { existingSds: [], capabilities: [{ name: 'conversion ledger backlog metric', description: 'query' }] }
+    );
+    expect(v.disposition).toBe('dismissed');
+    expect(v.triage_verdict).toBe('covered_by_capability');
+  });
+
+  it('generic title weakly matching many SDs -> deferred/ambiguous_generic (conservative guard)', () => {
+    const existingSds = [
+      sd('SD-A', 'alpha charlie'), sd('SD-B', 'alpha delta'),
+      sd('SD-C', 'alpha echo'), sd('SD-D', 'alpha foxtrot'),
+    ];
+    const v = classify({ title: 'alpha bravo', action_type: 'create_sd' }, { existingSds });
+    expect(v.disposition).toBe('deferred');
+    expect(v.triage_verdict).toBe('ambiguous_generic');
+    expect(v.promote).toBe(false);
+  });
+
+  it('novel + create_sd -> promote (converted intended)', () => {
+    const v = classify(
+      { title: 'Quantum flux capacitor orchestration subsystem', action_type: 'create_sd' },
+      { existingSds: [sd('SD-OTHER', 'completely unrelated payroll module')] }
+    );
+    expect(v.promote).toBe(true);
+    expect(v.disposition).toBe('converted');
+    expect(v.triage_verdict).toBe('novel_promote');
+  });
+
+  it('is idempotent — same input yields same verdict', () => {
+    const item = { title: 'payment webhook signature verification idempotent', action_type: 'create_sd' };
+    const ctx = { existingSds: [sd('SD-JAC-001', 'payment webhook signature verification idempotent capture')] };
+    expect(classify(item, ctx)).toEqual(classify(item, ctx));
+  });
+});


### PR DESCRIPTION
## Summary
Unify the 3 disconnected intake pools (eva_consultant_recommendations, sd_proposals, .prd-payloads/PROPOSAL-*.json) into ONE conversion_ledger with automated, data-safe rule-based triage.

- `conversion_ledger` table (migration applied): normalized schema, backlog = one query (disposition IS NULL), UNIQUE(source_pool,source_id), RLS service-write/auth-read. **Source rows are status-updated, NEVER deleted.**
- `lib/intake/conversion-ledger.js`: idempotent registerItem / setDisposition / backlogDepth.
- `lib/intake/triage-classifier.js`: PURE rule-based classify reusing scope-similarity (Jaccard ≥0.5) + proposed_sd_key dedup + conservative ambiguous-generic guard.
- `scripts/intake/drain-intake.mjs`: **dry-run DEFAULT** (zero writes); --apply registers/dispositions/promotes novel items via the existing `--from-proposal` ingest (no fork) + status-updates sources.

## Verification
- **FR-5 dry-run over live 568**: 542 dismissed (541 advisory + 1 research), 12 merged-duplicate (11 already-materialized + 1 exact), 14 novel-promote, 0 deferred.
- 16 unit tests passing (classifier every verdict path + ledger idempotency).
- **44-agent adversarial review** (dedup/idempotency/data-safety/edge): 20 findings, 11 confirmed, all fixed pre-merge — incl. a CRITICAL --apply crash (missing proposed_sd_key), the linked_sd_key camelCase bug, intra-batch dedup, and source reconciliation.
- Mid-build I also fixed two dedup-correctness gaps (1000-row corpus cap → full pagination; proposed_sd_key→existing-key dedup).

## Migration
`20260614_conversion_ledger.sql` (applied to shared DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)