### PR TITLE
feat(SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001): reusable fail-open checkout-freshness guard + 3 advisory wires

### DIFF
--- a/lib/governance/checkout-freshness.js
+++ b/lib/governance/checkout-freshness.js
@@ -16,7 +16,7 @@
  * @module lib/governance/checkout-freshness
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 /** Canonical protocol files whose drift vs the base ref makes the checkout STALE-CRITICAL. */
 export const CRITICAL_PROTOCOL_FILES = Object.freeze([
@@ -37,7 +37,8 @@ export const VERDICT = Object.freeze({ FRESH: 'FRESH', STALE: 'STALE', STALE_CRI
  *   Precedence: STALE-CRITICAL > STALE > FRESH.
  */
 export function evaluateFreshness(state, opts = {}) {
-  const behind = Number.isFinite(state?.behind) ? state.behind : 0;
+  const rawBehind = Number(state?.behind); // coerce numeric strings; clamp negatives
+  const behind = Number.isFinite(rawBehind) ? Math.max(0, rawBehind) : 0;
   const criticalDiff = Array.isArray(state?.criticalDiff) ? state.criticalDiff : [];
   const critN = Number.isFinite(opts.criticalThreshold) ? opts.criticalThreshold : 1;
   if (criticalDiff.length >= critN && criticalDiff.length > 0) {
@@ -54,17 +55,25 @@ export function evaluateFreshness(state, opts = {}) {
  * timeout-bounded. Path quoting uses double-quotes (works on both POSIX shells and Windows cmd).
  */
 export function makeGit({ cwd = process.cwd(), remote = 'origin', timeout = 10000 } = {}) {
-  const run = (cmd) => execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout });
+  // execFileSync (array args, NO shell) => no quoting/injection surface, cross-platform safe.
+  const git = (args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout });
   return {
-    fetch: (baseRef) => run(`git fetch ${remote} ${String(baseRef).replace(`${remote}/`, '')} --quiet`),
+    fetch: (baseRef) => {
+      // anchored strip: 'origin/main' -> 'main' (don't corrupt 'my-origin/main' or 'upstream/main')
+      const branch = baseRef.startsWith(`${remote}/`) ? baseRef.slice(remote.length + 1) : baseRef;
+      git(['fetch', remote, branch, '--quiet']);
+    },
     behindCount: (baseRef) => {
-      const n = parseInt(run(`git rev-list --count HEAD..${baseRef}`).trim(), 10);
+      // one-dot range = commits on base not on HEAD (the "behind" count).
+      const n = parseInt(git(['rev-list', '--count', `HEAD..${baseRef}`]).trim(), 10);
       return Number.isFinite(n) ? n : 0;
     },
     diffPaths: (baseRef, paths) => {
       if (!paths || paths.length === 0) return [];
-      const quoted = paths.map((p) => `"${p}"`).join(' ');
-      const raw = run(`git diff --name-only HEAD...${baseRef} -- ${quoted}`);
+      // TWO-dot diff = direct HEAD-tip vs base-tip content ("is my protocol file != canonical base").
+      // Three-dot (HEAD...base) would diff the merge-base vs base and is BLIND to a local hand-edit at
+      // behind=0 -> it would false-FRESH the exact drift this guard exists to catch (review wokfu8fiu).
+      const raw = git(['diff', '--name-only', `HEAD..${baseRef}`, '--', ...paths]);
       return raw.split('\n').map((s) => s.trim()).filter(Boolean);
     },
   };
@@ -117,7 +126,7 @@ export function freshnessBadge(result) {
   if (result?.error) tail = `git error (${result.error}) — treated FRESH`;
   else if (v === VERDICT.FRESH) tail = `up to date vs ${base}`;
   else if (v === VERDICT.STALE_CRITICAL) tail = `PROTOCOL DRIFT: ${(result.criticalDiff || []).join(', ')} — run \`git pull\` before trusting local rules`;
-  else tail = `behind ${base} by ${result.behind} commit(s) — run \`git pull\``;
+  else tail = `behind ${base} by ${result.behind ?? '?'} commit(s) — run \`git pull\``;
   return `[${icon} ${v}] Checkout freshness — ${tail}`;
 }
 

--- a/lib/governance/checkout-freshness.js
+++ b/lib/governance/checkout-freshness.js
@@ -1,0 +1,124 @@
+/**
+ * Checkout freshness guard — SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001.
+ *
+ * ONE reusable, FAIL-OPEN module that tells a worker/coordinator whether its local checkout is
+ * stale vs the base ref — and crucially whether a PROTOCOL file (CLAUDE*.md) has drifted, which
+ * means it is operating on stale rules. Generalizes the scattered patterns in
+ * scripts/eva/git-freshness.js (behind-count) + lib/governance/check-resolver-freshness.js
+ * (path-scoped diff). (The SD-named memory/adam-staleness-check.mjs does NOT exist — generalized
+ * from the real modules.)
+ *
+ * Design: a PURE verdict fn (evaluateFreshness) + an injectable-IO reader (checkoutFreshness, SYNC
+ * to match the sync callers). Verdict precedence: STALE-CRITICAL (>=1 protocol file drifted) >
+ * STALE (behind > 0) > FRESH. EVERY git error fail-opens to FRESH — a freshness check must NEVER
+ * block startup or an audit. `fetch` is opt-in (default off) so startup stays fast/offline-safe.
+ *
+ * @module lib/governance/checkout-freshness
+ */
+
+import { execSync } from 'node:child_process';
+
+/** Canonical protocol files whose drift vs the base ref makes the checkout STALE-CRITICAL. */
+export const CRITICAL_PROTOCOL_FILES = Object.freeze([
+  'CLAUDE.md',
+  'CLAUDE_CORE.md',
+  'CLAUDE_LEAD.md',
+  'CLAUDE_PLAN.md',
+  'CLAUDE_EXEC.md',
+]);
+
+export const VERDICT = Object.freeze({ FRESH: 'FRESH', STALE: 'STALE', STALE_CRITICAL: 'STALE-CRITICAL' });
+
+/**
+ * PURE verdict — no IO, fully testable from data alone.
+ * @param {{behind?: number, criticalDiff?: string[]}} state
+ * @param {{criticalThreshold?: number}} [opts]
+ * @returns {{verdict: string, behind: number, criticalDiff: string[], reason: string}}
+ *   Precedence: STALE-CRITICAL > STALE > FRESH.
+ */
+export function evaluateFreshness(state, opts = {}) {
+  const behind = Number.isFinite(state?.behind) ? state.behind : 0;
+  const criticalDiff = Array.isArray(state?.criticalDiff) ? state.criticalDiff : [];
+  const critN = Number.isFinite(opts.criticalThreshold) ? opts.criticalThreshold : 1;
+  if (criticalDiff.length >= critN && criticalDiff.length > 0) {
+    return { verdict: VERDICT.STALE_CRITICAL, behind, criticalDiff, reason: `protocol file(s) drifted vs base: ${criticalDiff.join(', ')}` };
+  }
+  if (behind > 0) {
+    return { verdict: VERDICT.STALE, behind, criticalDiff, reason: `behind base by ${behind} commit(s)` };
+  }
+  return { verdict: VERDICT.FRESH, behind, criticalDiff, reason: 'up to date with base' };
+}
+
+/**
+ * Default git runner — the injectable IO seam. SYNC (execSync), stdio piped (no output bleed),
+ * timeout-bounded. Path quoting uses double-quotes (works on both POSIX shells and Windows cmd).
+ */
+export function makeGit({ cwd = process.cwd(), remote = 'origin', timeout = 10000 } = {}) {
+  const run = (cmd) => execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout });
+  return {
+    fetch: (baseRef) => run(`git fetch ${remote} ${String(baseRef).replace(`${remote}/`, '')} --quiet`),
+    behindCount: (baseRef) => {
+      const n = parseInt(run(`git rev-list --count HEAD..${baseRef}`).trim(), 10);
+      return Number.isFinite(n) ? n : 0;
+    },
+    diffPaths: (baseRef, paths) => {
+      if (!paths || paths.length === 0) return [];
+      const quoted = paths.map((p) => `"${p}"`).join(' ');
+      const raw = run(`git diff --name-only HEAD...${baseRef} -- ${quoted}`);
+      return raw.split('\n').map((s) => s.trim()).filter(Boolean);
+    },
+  };
+}
+
+/**
+ * Injectable-IO entry. SYNC. Reads git state then delegates to evaluateFreshness.
+ * FAIL-OPEN: ANY git error returns { verdict:'FRESH', behind:0, criticalDiff:[], error } so it can
+ * never block a caller.
+ *
+ * @param {string} [cwd=process.cwd()] repo root for git commands
+ * @param {object} [config]
+ *   baseRef='origin/main' | remote='origin' | timeout=10000
+ *   criticalPaths=CRITICAL_PROTOCOL_FILES (override e.g. resolver paths)
+ *   fetch=false (opt-in network; default trusts the local origin ref)
+ *   role='fleet' (log context only) | criticalThreshold=1
+ *   git=makeGit(...) (INJECTED SEAM: {fetch, behindCount, diffPaths})
+ * @returns {{verdict, behind, criticalDiff, paths, baseRef, role, checkedAt, error?, reason}}
+ */
+export function checkoutFreshness(cwd = process.cwd(), config = {}) {
+  const baseRef = config.baseRef || 'origin/main';
+  const remote = config.remote || 'origin';
+  const timeout = config.timeout || 10000;
+  const paths = config.criticalPaths || CRITICAL_PROTOCOL_FILES;
+  const role = config.role || 'fleet';
+  const git = config.git || makeGit({ cwd, remote, timeout });
+  const checkedAt = new Date().toISOString();
+  try {
+    if (config.fetch) {
+      try { git.fetch(baseRef); } catch { /* a fetch flake is non-fatal; fall back to the local ref */ }
+    }
+    const behind = git.behindCount(baseRef);
+    const criticalDiff = git.diffPaths(baseRef, paths);
+    const v = evaluateFreshness({ behind, criticalDiff }, config);
+    return { ...v, paths, baseRef, role, checkedAt };
+  } catch (err) {
+    return {
+      verdict: VERDICT.FRESH, behind: 0, criticalDiff: [], paths, baseRef, role, checkedAt,
+      error: err?.message || String(err), reason: 'git error (fail-open -> FRESH)',
+    };
+  }
+}
+
+/** One-line advisory badge for startup banners / audit lines. Never throws. */
+export function freshnessBadge(result) {
+  const v = result?.verdict || VERDICT.FRESH;
+  const icon = v === VERDICT.FRESH ? '✅' : v === VERDICT.STALE_CRITICAL ? '🛑' : '⚠️';
+  const base = result?.baseRef || 'origin/main';
+  let tail;
+  if (result?.error) tail = `git error (${result.error}) — treated FRESH`;
+  else if (v === VERDICT.FRESH) tail = `up to date vs ${base}`;
+  else if (v === VERDICT.STALE_CRITICAL) tail = `PROTOCOL DRIFT: ${(result.criticalDiff || []).join(', ')} — run \`git pull\` before trusting local rules`;
+  else tail = `behind ${base} by ${result.behind} commit(s) — run \`git pull\``;
+  return `[${icon} ${v}] Checkout freshness — ${tail}`;
+}
+
+export default { CRITICAL_PROTOCOL_FILES, VERDICT, evaluateFreshness, makeGit, checkoutFreshness, freshnessBadge };

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -22,6 +22,8 @@ import 'dotenv/config';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+// SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
+import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -130,9 +132,18 @@ export function renderLoops(armed) {
   return lines.join('\n');
 }
 
+/** Advisory checkout-freshness badge (fail-open — never throws, never blocks startup). */
+export function renderFreshness(repoRoot = REPO_ROOT) {
+  try {
+    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'adam' }));
+  } catch (err) {
+    return '═══ CHECKOUT FRESHNESS ═══\n  ✅ freshness check skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   const armed = parseArmedSet(argv, env);
-  return [renderResponsibilities(repoRoot), '', renderLoops(armed)].join('\n');
+  return [renderResponsibilities(repoRoot), '', renderLoops(armed), '', renderFreshness(repoRoot)].join('\n');
 }
 
 // ── Main (fail-open: always exit 0) ──

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -24,6 +24,8 @@ import { createClient } from '@supabase/supabase-js';
 import { getDbNowMs } from '../lib/fleet/db-clock.mjs';
 import { isProcessRunning } from '../lib/heartbeat-manager.mjs';
 import { countActiveWorktrees, MAX_WORKTREE_COUNT, countFilesystemWorktreeDirs } from '../lib/worktree-quota.js';
+// SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness dimension.
+import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-freshness.js';
 import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
@@ -120,6 +122,15 @@ async function main() {
   for (const a of D.dep.anomalies.slice(0, 5)) console.log('      ANOMALY ' + a.sd + ' dep(s) not found: ' + a.unknownDeps.join(','));
   console.log('  DUTY-6 BACKLOG-RANK  : ' + D.rank.detail + flag(D.rank));
   console.log('  QUIET-TICK COMMITTED : ' + D.quiet.detail + flag(D.quiet));
+
+  // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: ADVISORY freshness dimension — fail-open and deliberately
+  // kept OUT of `D`/summarizeViolations, so a stale checkout surfaces a warning but never trips the
+  // hard violation count / exit. STALE-CRITICAL (protocol drift) is the high-value advisory here.
+  try {
+    console.log('  DUTY-FRESHNESS CHECK : ' + freshnessBadge(checkoutFreshness(process.cwd(), { role: 'coordinator' })));
+  } catch (e) {
+    console.log('  DUTY-FRESHNESS CHECK : ✅ freshness check skipped (fail-open): ' + (e?.message || String(e)));
+  }
 
   const summary = summarizeViolations(Object.values(D));
   if (summary.count > 0) {

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -19,6 +19,8 @@ import 'dotenv/config';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+// SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
+import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -219,9 +221,18 @@ export function renderLoops(armed) {
   return lines.join('\n');
 }
 
+/** Advisory checkout-freshness badge (fail-open — never throws, never blocks startup). */
+export function renderFreshness(repoRoot = REPO_ROOT) {
+  try {
+    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'coordinator' }));
+  } catch (err) {
+    return '═══ CHECKOUT FRESHNESS ═══\n  ✅ freshness check skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   const armed = parseArmedSet(argv, env);
-  return [renderResponsibilities(repoRoot), '', renderAdamLane(), '', renderLoops(armed)].join('\n');
+  return [renderResponsibilities(repoRoot), '', renderAdamLane(), '', renderLoops(armed), '', renderFreshness(repoRoot)].join('\n');
 }
 
 // ── Main (fail-open: always exit 0) ──

--- a/tests/integration/checkout-freshness-realgit.test.js
+++ b/tests/integration/checkout-freshness-realgit.test.js
@@ -1,0 +1,77 @@
+/**
+ * checkout-freshness REAL-git integration — SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001.
+ * Exercises the DEFAULT makeGit seam (real git, a throwaway temp repo, NO network) so the actual
+ * two-dot diff syntax is covered — the unit tests inject a fake diffPaths, which is exactly why they
+ * could not catch the three-dot false-FRESH bug (adversarial review wokfu8fiu).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkoutFreshness, VERDICT } from '../../lib/governance/checkout-freshness.js';
+
+const git = (cwd, args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+
+describe('checkout-freshness REAL git (default makeGit, temp repo, no network)', () => {
+  let repo;
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), 'cf-realgit-'));
+    git(repo, ['init', '-q']);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test']);
+    git(repo, ['config', 'commit.gpgsign', 'false']);
+    writeFileSync(join(repo, 'CLAUDE.md'), 'v1 canonical\n');
+    git(repo, ['add', 'CLAUDE.md']);
+    git(repo, ['commit', '-q', '-m', 'v1']);
+    git(repo, ['branch', 'baseline']); // baseline == HEAD (v1)
+  });
+  afterAll(() => { try { rmSync(repo, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+  it('FRESH when HEAD == base (real two-dot diff, behind 0)', () => {
+    const r = checkoutFreshness(repo, { baseRef: 'baseline', criticalPaths: ['CLAUDE.md'] });
+    expect(r.verdict).toBe(VERDICT.FRESH);
+    expect(r.behind).toBe(0);
+  });
+
+  it('STALE-CRITICAL on a LOCAL hand-edit to a protocol file at behind=0 (the three-dot false-FRESH bug)', () => {
+    writeFileSync(join(repo, 'CLAUDE.md'), 'v2 LOCAL HAND EDIT\n');
+    git(repo, ['add', 'CLAUDE.md']);
+    git(repo, ['commit', '-q', '-m', 'local edit']); // HEAD ahead of baseline; baseline unchanged
+    const r = checkoutFreshness(repo, { baseRef: 'baseline', criticalPaths: ['CLAUDE.md'] });
+    expect(r.behind).toBe(0); // baseline has no commits HEAD lacks
+    expect(r.verdict).toBe(VERDICT.STALE_CRITICAL); // two-dot catches the content drift; three-dot would FALSE-FRESH
+    expect(r.criticalDiff).toContain('CLAUDE.md');
+  });
+
+  it('STALE-CRITICAL when base is AHEAD with a protocol-file change (behind>0)', () => {
+    git(repo, ['branch', 'ahead']);
+    git(repo, ['checkout', '-q', 'ahead']);
+    writeFileSync(join(repo, 'CLAUDE.md'), 'v3 BASE AHEAD\n');
+    git(repo, ['add', 'CLAUDE.md']);
+    git(repo, ['commit', '-q', '-m', 'base ahead']);
+    git(repo, ['checkout', '-q', '-']); // back to the prior branch (HEAD now behind 'ahead')
+    const r = checkoutFreshness(repo, { baseRef: 'ahead', criticalPaths: ['CLAUDE.md'] });
+    expect(r.behind).toBeGreaterThan(0);
+    expect(r.verdict).toBe(VERDICT.STALE_CRITICAL);
+  });
+
+  it('STALE (not CRITICAL) when base is ahead but a NON-protocol file changed', () => {
+    // Branch from CURRENT HEAD so CLAUDE.md is identical on both sides; only README diverges on base.
+    git(repo, ['branch', 'readme-ahead']);
+    git(repo, ['checkout', '-q', 'readme-ahead']);
+    writeFileSync(join(repo, 'README.md'), 'unrelated change\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-q', '-m', 'unrelated base change']);
+    git(repo, ['checkout', '-q', '-']);
+    const r = checkoutFreshness(repo, { baseRef: 'readme-ahead', criticalPaths: ['CLAUDE.md'] });
+    expect(r.behind).toBeGreaterThan(0); // behind by the README commit
+    expect(r.verdict).toBe(VERDICT.STALE); // CLAUDE.md identical -> behind but NOT protocol-drift
+  });
+
+  it('FAIL-OPEN FRESH on a bogus base ref (a real git error -> FRESH, never throws)', () => {
+    const r = checkoutFreshness(repo, { baseRef: 'does-not-exist-ref', criticalPaths: ['CLAUDE.md'] });
+    expect(r.verdict).toBe(VERDICT.FRESH);
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/tests/unit/checkout-freshness.test.js
+++ b/tests/unit/checkout-freshness.test.js
@@ -1,0 +1,98 @@
+/**
+ * checkout-freshness unit tests — SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001.
+ * Pure evaluateFreshness + checkoutFreshness via an INJECTED git seam. ZERO real git/network.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  evaluateFreshness, checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES, VERDICT,
+} from '../../lib/governance/checkout-freshness.js';
+
+describe('evaluateFreshness (pure)', () => {
+  it('FRESH when behind 0 and no critical diff', () => {
+    expect(evaluateFreshness({ behind: 0, criticalDiff: [] }).verdict).toBe(VERDICT.FRESH);
+  });
+  it('STALE when behind > 0 and no critical diff', () => {
+    const r = evaluateFreshness({ behind: 3, criticalDiff: [] });
+    expect(r.verdict).toBe(VERDICT.STALE);
+    expect(r.reason).toMatch(/3 commit/);
+  });
+  it('STALE-CRITICAL when a protocol file drifted (precedence over STALE)', () => {
+    const r = evaluateFreshness({ behind: 3, criticalDiff: ['CLAUDE.md'] });
+    expect(r.verdict).toBe(VERDICT.STALE_CRITICAL);
+    expect(r.reason).toContain('CLAUDE.md');
+  });
+  it('STALE-CRITICAL even when behind is 0 (a diff can exist without a behind-count)', () => {
+    expect(evaluateFreshness({ behind: 0, criticalDiff: ['CLAUDE_CORE.md'] }).verdict).toBe(VERDICT.STALE_CRITICAL);
+  });
+  it('honors criticalThreshold (>1 requires that many drifted files)', () => {
+    expect(evaluateFreshness({ behind: 0, criticalDiff: ['CLAUDE.md'] }, { criticalThreshold: 2 }).verdict).toBe(VERDICT.FRESH);
+    expect(evaluateFreshness({ behind: 0, criticalDiff: ['CLAUDE.md', 'CLAUDE_LEAD.md'] }, { criticalThreshold: 2 }).verdict).toBe(VERDICT.STALE_CRITICAL);
+  });
+  it('coerces missing/garbage state to FRESH (defensive)', () => {
+    expect(evaluateFreshness(null).verdict).toBe(VERDICT.FRESH);
+    expect(evaluateFreshness({ behind: 'x', criticalDiff: 'nope' }).verdict).toBe(VERDICT.FRESH);
+  });
+});
+
+function fakeGit({ behind = 0, diff = [], throwOn = null } = {}) {
+  return {
+    fetch: vi.fn(() => { if (throwOn === 'fetch') throw new Error('fetch boom'); }),
+    behindCount: vi.fn(() => { if (throwOn === 'behindCount') throw new Error('rev-list boom'); return behind; }),
+    diffPaths: vi.fn(() => { if (throwOn === 'diffPaths') throw new Error('diff boom'); return diff; }),
+  };
+}
+
+describe('checkoutFreshness (injected git seam, no real git)', () => {
+  it('STALE from a behind-count, FRESH-base diff empty', () => {
+    const git = fakeGit({ behind: 2, diff: [] });
+    const r = checkoutFreshness('/repo', { git });
+    expect(r.verdict).toBe(VERDICT.STALE);
+    expect(r.behind).toBe(2);
+    expect(git.behindCount).toHaveBeenCalledWith('origin/main');
+  });
+  it('STALE-CRITICAL when diffPaths returns a protocol file', () => {
+    const r = checkoutFreshness('/repo', { git: fakeGit({ behind: 5, diff: ['CLAUDE.md'] }) });
+    expect(r.verdict).toBe(VERDICT.STALE_CRITICAL);
+    expect(r.criticalDiff).toEqual(['CLAUDE.md']);
+  });
+  it('FRESH when up to date', () => {
+    expect(checkoutFreshness('/repo', { git: fakeGit({ behind: 0, diff: [] }) }).verdict).toBe(VERDICT.FRESH);
+  });
+  it('FAIL-OPEN: a git error -> FRESH with an error field, never throws', () => {
+    const r = checkoutFreshness('/repo', { git: fakeGit({ throwOn: 'behindCount' }) });
+    expect(r.verdict).toBe(VERDICT.FRESH);
+    expect(r.error).toMatch(/rev-list boom/);
+  });
+  it('fetch is opt-in: not called by default, called when config.fetch=true', () => {
+    const g1 = fakeGit({ behind: 0 });
+    checkoutFreshness('/repo', { git: g1 });
+    expect(g1.fetch).not.toHaveBeenCalled();
+    const g2 = fakeGit({ behind: 0 });
+    checkoutFreshness('/repo', { git: g2, fetch: true });
+    expect(g2.fetch).toHaveBeenCalled();
+  });
+  it('a fetch flake does NOT abort the check (non-fatal)', () => {
+    const r = checkoutFreshness('/repo', { git: fakeGit({ behind: 1, throwOn: 'fetch' }), fetch: true });
+    expect(r.verdict).toBe(VERDICT.STALE); // behindCount/diffPaths still ran
+  });
+  it('criticalPaths override is passed through (e.g. resolver paths)', () => {
+    const git = fakeGit({ behind: 0, diff: ['lib/x.js'] });
+    const r = checkoutFreshness('/repo', { git, criticalPaths: ['lib/x.js'] });
+    expect(r.verdict).toBe(VERDICT.STALE_CRITICAL);
+    expect(git.diffPaths).toHaveBeenCalledWith('origin/main', ['lib/x.js']);
+  });
+});
+
+describe('freshnessBadge + constants', () => {
+  it('renders a badge per verdict (never throws)', () => {
+    expect(freshnessBadge({ verdict: VERDICT.FRESH, baseRef: 'origin/main' })).toMatch(/FRESH/);
+    expect(freshnessBadge({ verdict: VERDICT.STALE, behind: 4, baseRef: 'origin/main' })).toMatch(/behind .* 4/);
+    expect(freshnessBadge({ verdict: VERDICT.STALE_CRITICAL, criticalDiff: ['CLAUDE.md'] })).toMatch(/PROTOCOL DRIFT/);
+    expect(freshnessBadge({ verdict: VERDICT.FRESH, error: 'boom' })).toMatch(/git error/);
+    expect(freshnessBadge(undefined)).toMatch(/FRESH/);
+  });
+  it('CRITICAL_PROTOCOL_FILES lists the CLAUDE protocol files', () => {
+    expect(CRITICAL_PROTOCOL_FILES).toContain('CLAUDE.md');
+    expect(CRITICAL_PROTOCOL_FILES).toContain('CLAUDE_CORE.md');
+  });
+});


### PR DESCRIPTION
Generalizes the fleet's scattered staleness logic into one reusable, **fail-open** module and surfaces a FRESH/STALE/STALE-CRITICAL verdict at adam + coordinator startup and in the charter audit.

## What
- **NEW** `lib/governance/checkout-freshness.js` — PURE `evaluateFreshness({behind,criticalDiff})` + injectable-IO `checkoutFreshness(cwd,config)` (sync, `config.git` seam, `fetch` opt-in) + `makeGit` + `freshnessBadge` + `CRITICAL_PROTOCOL_FILES`. Precedence: **STALE-CRITICAL** (≥1 protocol file/CLAUDE*.md drifted vs base) > **STALE** (behind>0) > **FRESH**. **FAIL-OPEN**: any git error → FRESH (never blocks).
- **WIRE** advisory badge into `adam-startup-check.mjs` + `coordinator-startup-check.mjs` (`renderFreshness` in `buildReport`) + an advisory freshness **dimension** in `coordinator-charter-audit.mjs` kept **out of the violation count** (never trips a hard exit).

## Verify
- 15/15 unit tests (injected git seam — all verdict tiers + fail-open, zero real git).
- Smoke: `adam-startup-check.mjs` prints the badge (caught real `behind origin/main by 2`) and exits 0.

## Note
- The SD-named `memory/adam-staleness-check.mjs` does not exist; generalized from the real `git-freshness.js` + `check-resolver-freshness.js` (flagged).

SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)