### PR TITLE
fix(SD-LEO-INFRA-FIX-CREATE-REPLACE-001): merge claude_sessions.metadata on session re-init, not replace

### DIFF
--- a/database/migrations/20260614_fix_create_or_replace_session_metadata_merge.sql
+++ b/database/migrations/20260614_fix_create_or_replace_session_metadata_merge.sql
@@ -1,0 +1,156 @@
+-- SD-LEO-INFRA-FIX-CREATE-REPLACE-001
+-- Fix create_or_replace_session to MERGE claude_sessions.metadata instead of REPLACE it.
+--
+-- BUG: the ON CONFLICT (session_id) DO UPDATE branch set `metadata = EXCLUDED.metadata`,
+-- which overwrites the entire metadata JSONB on every session re-init. Any keys the live
+-- session already carried (is_coordinator, claim flags, auto_proceed, etc.) that the re-init
+-- caller did NOT re-pass were silently wiped — demoting a coordinator and dropping claim
+-- state on a routine reconnect.
+--
+-- FIX: shallow-merge the incoming metadata onto the existing row metadata:
+--   metadata = COALESCE(claude_sessions.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb)
+-- The `||` operator keeps every existing top-level key, and lets the caller's new values win
+-- on a key collision (so a re-init can still update a flag it explicitly re-passes). Keys the
+-- caller omits are preserved. The INSERT path is unchanged (a brand-new row has no prior
+-- metadata to preserve). Idempotent: CREATE OR REPLACE, no data migration.
+--
+-- This rebases on the CURRENT live definition (20260509_layer1_claiming_session_id_release_parity.sql:
+-- uses sd_key + clears claiming_session_id; the 20260201 body referenced a since-removed sd_id column),
+-- changing ONLY the ON CONFLICT metadata assignment.
+--
+-- DATA-SAFETY: additive behavior change only. Applying this migration modifies NO rows; it
+-- redefines a function. Reversible by restoring `metadata = EXCLUDED.metadata`.
+
+CREATE OR REPLACE FUNCTION create_or_replace_session(
+  p_session_id TEXT,
+  p_machine_id TEXT,
+  p_terminal_id TEXT,
+  p_tty TEXT,
+  p_pid INTEGER,
+  p_hostname TEXT,
+  p_codebase TEXT,
+  p_metadata JSONB DEFAULT '{}'::JSONB
+) RETURNS JSONB AS $$
+DECLARE
+  v_terminal_identity TEXT;
+  v_previous_session RECORD;
+  v_auto_released BOOLEAN := false;
+  v_previous_session_id TEXT := NULL;
+BEGIN
+  v_terminal_identity := COALESCE(p_machine_id, '') || ':' || COALESCE(p_terminal_id, p_tty, '');
+
+  SELECT session_id, sd_key, status INTO v_previous_session
+  FROM claude_sessions
+  WHERE terminal_identity = v_terminal_identity
+    AND status IN ('active', 'idle')
+    AND session_id != p_session_id
+  FOR UPDATE SKIP LOCKED
+  LIMIT 1;
+
+  IF v_previous_session IS NOT NULL THEN
+    UPDATE claude_sessions
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'AUTO_REPLACED',
+        updated_at = NOW()
+    WHERE session_id = v_previous_session.session_id;
+
+    IF v_previous_session.sd_key IS NOT NULL THEN
+      -- LAYER-SIDE-CLAIMING-001 FR-2: clear claiming_session_id alongside active_session_id.
+      -- (sd_claims table reference removed — table does not exist in current schema.)
+      UPDATE strategic_directives_v2
+      SET active_session_id = NULL, claiming_session_id = NULL, is_working_on = false
+      WHERE active_session_id = v_previous_session.session_id
+         OR claiming_session_id = v_previous_session.session_id;
+    END IF;
+
+    v_auto_released := true;
+    v_previous_session_id := v_previous_session.session_id;
+
+    RAISE NOTICE 'Auto-released previous session % for terminal %',
+      v_previous_session.session_id, v_terminal_identity;
+  END IF;
+
+  INSERT INTO claude_sessions (
+    session_id, machine_id, terminal_id, tty, pid, hostname, codebase,
+    status, heartbeat_at, metadata, created_at, updated_at
+  ) VALUES (
+    p_session_id, p_machine_id, p_terminal_id, p_tty, p_pid, p_hostname, p_codebase,
+    'idle', NOW(), p_metadata, NOW(), NOW()
+  )
+  ON CONFLICT (session_id) DO UPDATE SET
+    machine_id = EXCLUDED.machine_id,
+    terminal_id = EXCLUDED.terminal_id,
+    tty = EXCLUDED.tty,
+    pid = EXCLUDED.pid,
+    hostname = EXCLUDED.hostname,
+    heartbeat_at = NOW(),
+    -- SD-LEO-INFRA-FIX-CREATE-REPLACE-001: merge, do not replace, so a re-init never wipes
+    -- is_coordinator / claim flags the live session already carried.
+    metadata = COALESCE(claude_sessions.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb),
+    status = CASE
+      WHEN claude_sessions.status = 'released' THEN 'idle'
+      ELSE claude_sessions.status
+    END,
+    updated_at = NOW();
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'terminal_identity', v_terminal_identity,
+    'auto_released', v_auto_released,
+    'previous_session_id', v_previous_session_id,
+    'created_at', NOW()
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'terminal_conflict',
+      'message', format('Terminal identity %s already claimed by another session', v_terminal_identity)
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION create_or_replace_session IS
+  'Atomically creates a session, auto-releasing any previous session for the same terminal identity. Layer 1 parity (LAYER-SIDE-CLAIMING-001): clears claiming_session_id alongside active_session_id. Part of FR-1. SD-LEO-INFRA-FIX-CREATE-REPLACE-001: re-init MERGES metadata (|| existing) so is_coordinator/claim flags survive a reconnect.';
+
+-- In-migration self-verification (runs inside apply-migration's transaction; fleet-safe:
+-- unique synthetic session/terminal ids that match no real session, cleaned up before COMMIT).
+-- Proves the merge: a re-init that omits is_coordinator/claim flags MUST preserve them, while
+-- still applying the caller's new keys. Mirrors the DO $verify$ ASSERT pattern used by
+-- 20260530_rescan_stage20_reason.sql (SD-LEO-INFRA-STAGE-RESCAN-STAGE-001).
+DO $verify$
+DECLARE
+  v_meta  JSONB;
+  v_sid   TEXT := 'verify-fix-create-replace-001-' || gen_random_uuid()::text;
+  v_term  TEXT := 'verify-machine-fix-create-replace-001-' || gen_random_uuid()::text;
+  v_tty   TEXT := 'verify-tty-' || gen_random_uuid()::text;
+BEGIN
+  -- Seed: a live session carrying a coordinator flag + a claim flag.
+  PERFORM create_or_replace_session(v_sid, v_term, NULL, v_tty, 999001, 'verify-host', 'verify-codebase',
+    '{"is_coordinator": true, "claim_flag": "held"}'::jsonb);
+  -- Re-init the SAME session with metadata that OMITS those flags (the bug's trigger).
+  PERFORM create_or_replace_session(v_sid, v_term, NULL, v_tty, 999001, 'verify-host', 'verify-codebase',
+    '{"auto_proceed": true}'::jsonb);
+
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+
+  ASSERT v_meta ? 'is_coordinator' AND (v_meta->>'is_coordinator')::boolean = true,
+    'FIX-CREATE-REPLACE: is_coordinator was WIPED on re-init (metadata merge failed)';
+  ASSERT v_meta ? 'claim_flag' AND v_meta->>'claim_flag' = 'held',
+    'FIX-CREATE-REPLACE: claim_flag was WIPED on re-init (metadata merge failed)';
+  ASSERT v_meta ? 'auto_proceed' AND (v_meta->>'auto_proceed')::boolean = true,
+    'FIX-CREATE-REPLACE: new metadata key from re-init was not applied';
+
+  -- Cleanup the synthetic verification session (so nothing leaks past COMMIT).
+  DELETE FROM claude_sessions WHERE session_id = v_sid;
+
+  RAISE NOTICE 'FIX-CREATE-REPLACE verify OK: re-init merged metadata, preserving is_coordinator + claim_flag and applying auto_proceed.';
+END
+$verify$;
+
+-- ROLLBACK: re-apply 20260509_layer1_claiming_session_id_release_parity.sql's definition, i.e. set
+--   metadata = EXCLUDED.metadata
+-- in the ON CONFLICT branch (restores the replace-on-reinit behavior).

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -359,6 +359,20 @@ export async function getOrCreateSession() {
     metadata
   };
 
+  // SD-LEO-INFRA-FIX-CREATE-REPLACE-001: the RPC-failure fallbacks below use a direct
+  // .upsert() whose ON CONFLICT replaces metadata wholesale — the same wipe-on-reinit bug
+  // this SD fixes inside the RPC. Merge against the existing row so is_coordinator / claim
+  // flags survive a fallback re-init too. Best-effort (the fallback path is already degraded;
+  // a fetch-then-upsert race is acceptable here and strictly better than a blind replace).
+  const mergeSessionMetadata = async (newMetadata) => {
+    const { data: existingRow } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    return { ...(existingRow?.metadata || {}), ...newMetadata };
+  };
+
   // SD-LEO-INFRA-ISL-001: Use create_or_replace_session for atomic auto-release
   // NOTE: Local file written AFTER successful DB registration (not before)
   // to prevent ghost sessions where local file exists but DB record doesn't.
@@ -387,7 +401,7 @@ export async function getOrCreateSession() {
         hostname,
         codebase,
         status: 'idle',
-        metadata
+        metadata: await mergeSessionMetadata(metadata)
       }, { onConflict: 'session_id' });
 
     if (upsertError) {
@@ -411,7 +425,7 @@ export async function getOrCreateSession() {
         hostname,
         codebase,
         status: 'idle',
-        metadata
+        metadata: await mergeSessionMetadata(metadata)
       }, { onConflict: 'session_id' });
 
     if (upsertError) {

--- a/tests/db-invariants/create-or-replace-session-metadata-merge.test.js
+++ b/tests/db-invariants/create-or-replace-session-metadata-merge.test.js
@@ -1,0 +1,99 @@
+/**
+ * DB Invariant: create_or_replace_session MERGES claude_sessions.metadata on re-init.
+ *
+ * SD: SD-LEO-INFRA-FIX-CREATE-REPLACE-001
+ *
+ * The ON CONFLICT branch previously set `metadata = EXCLUDED.metadata`, which REPLACED the
+ * whole JSONB on a session re-init — silently wiping is_coordinator / claim flags the live
+ * session already carried. The fix merges instead:
+ *   metadata = COALESCE(claude_sessions.metadata,'{}'::jsonb) || COALESCE(EXCLUDED.metadata,'{}'::jsonb)
+ *
+ * Fleet-safe runtime verification: we apply the CORRECTED migration inside a transaction we
+ * always ROLL BACK, so the test proves the real function's behavior against the live DB schema
+ * WITHOUT any permanent change and independent of whether prod has been upgraded yet. The
+ * migration also self-verifies via its in-file DO $verify$ ASSERT block, so simply applying it
+ * here re-runs that assertion; we additionally seed our own synthetic session and assert the
+ * merge explicitly.
+ *
+ * Skips cleanly without a real Supabase connection (db project / describeDb).
+ */
+
+import { it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describeDb, HAS_REAL_DB } from '../helpers/db-available.js';
+import createDatabaseClient from '../../lib/supabase-connection.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATION = join(
+  __dirname,
+  '../../database/migrations/20260614_fix_create_or_replace_session_metadata_merge.sql'
+);
+
+describeDb('create_or_replace_session metadata merge (SD-LEO-INFRA-FIX-CREATE-REPLACE-001)', () => {
+  let client;
+
+  beforeAll(async () => {
+    if (!HAS_REAL_DB) return;
+    client = await createDatabaseClient('engineer', { verify: false });
+  });
+
+  afterAll(async () => {
+    if (client) await client.end();
+  });
+
+  it('re-init preserves is_coordinator + claim flags and applies new keys (rolled-back txn)', async () => {
+    const sql = readFileSync(MIGRATION, 'utf8');
+    // Random suffix is safe here: every statement runs inside a transaction we ROLL BACK,
+    // so nothing is ever committed or journaled.
+    const rnd = () => Math.random().toString(36).slice(2);
+    const sid = 'vitest-fix-create-replace-' + rnd();
+    const term = 'vitest-machine-fix-create-replace-' + rnd(); // unique machine id; the ROLLBACK is the real safety net
+    const tty = 'vitest-tty-' + rnd();
+
+    await client.query('BEGIN');
+    try {
+      // Apply the corrected function (its in-file DO $verify$ ASSERT block runs here too;
+      // a merge regression would throw at this point).
+      await client.query(sql);
+
+      // Seed a live session carrying coordinator + claim flags.
+      await client.query(
+        `SELECT create_or_replace_session($1,$2,NULL,$3,999002,'vitest-host','vitest-codebase',
+           '{"is_coordinator": true, "claim_flag": "held"}'::jsonb)`,
+        [sid, term, tty]
+      );
+      // Re-init the SAME session with metadata that OMITS those flags.
+      await client.query(
+        `SELECT create_or_replace_session($1,$2,NULL,$3,999002,'vitest-host','vitest-codebase',
+           '{"auto_proceed": true}'::jsonb)`,
+        [sid, term, tty]
+      );
+
+      const { rows } = await client.query(
+        'SELECT metadata FROM claude_sessions WHERE session_id = $1',
+        [sid]
+      );
+      expect(rows).toHaveLength(1);
+      const meta = rows[0].metadata;
+      // Preserved (the bug would have wiped these):
+      expect(meta.is_coordinator).toBe(true);
+      expect(meta.claim_flag).toBe('held');
+      // Applied (the re-init's new key):
+      expect(meta.auto_proceed).toBe(true);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('regression guard: the migration merges and never reverts to a bare replace', () => {
+    const sql = readFileSync(MIGRATION, 'utf8');
+    // The ON CONFLICT branch must merge ...
+    expect(sql).toMatch(
+      /metadata\s*=\s*COALESCE\(\s*claude_sessions\.metadata[\s\S]*\|\|[\s\S]*EXCLUDED\.metadata/
+    );
+    // ... and must NOT contain the old replace assignment.
+    expect(sql).not.toMatch(/metadata\s*=\s*EXCLUDED\.metadata\s*,/);
+  });
+});


### PR DESCRIPTION
## Bug
`create_or_replace_session`'s ON CONFLICT branch set `metadata = EXCLUDED.metadata`, overwriting the whole JSONB on every session re-init — silently wiping `is_coordinator` + claim flags the live session already carried (demoting coordinators / dropping claim state on a routine reconnect).

## Fix
Shallow-merge the metadata: `metadata = COALESCE(claude_sessions.metadata,'{}') || COALESCE(EXCLUDED.metadata,'{}')` so omitted keys survive while a re-init can still update keys it explicitly re-passes.
- Rebased on the **current** live definition (20260509: `sd_key` + `claiming_session_id`), NOT the stale 20260201 body (removed `sd_id` column).
- Also fixes the same replace bug in `lib/session-manager.mjs`'s two RPC-failure fallback upserts (merge against the existing row first).

## Verification
- In-migration `DO $verify$` ASSERT block (deploy-time self-check).
- `tests/db-invariants/create-or-replace-session-metadata-merge.test.js`: applies the corrected function in a **rolled-back transaction** (proves real behavior against the live schema, zero permanent change) + a static regression guard. 2/2 green.
- Adversarial review: 4 findings, all addressed (incl. the in-scope fallback-upsert fix).

Migration is additive/idempotent/reversible. **Prod apply is chairman-gated** (apply-migration token) — routed via the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)