### PR TITLE
feat(SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001): CLAUDE_*.md DB-to-file drift guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,6 +62,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/scratch-sweep-sessionstart.cjs",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-doc-drift-warn.cjs",
+            "timeout": 12
           }
         ]
       },

--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -1,0 +1,79 @@
+name: CLAUDE.md Drift Check
+
+# SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-4a): enforced backstop. The generated
+# CLAUDE_*.md family is produced from leo_protocol_sections; this job red-flags any PR whose
+# committed docs have drifted from the live DB (a section content edit not regenerated). Unlike
+# the local pre-commit gate (FR-2), CI cannot be bypassed with --no-verify, so it is the
+# authoritative change-time enforcement point.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'CLAUDE*.md'
+      - 'claude-generation-manifest.json'
+      - 'scripts/generate-claude-md-from-db.js'
+      - 'scripts/check-claude-md-drift.cjs'
+      - 'scripts/modules/claude-md-generator/**'
+      - 'scripts/section-file-mapping*.json'
+      - '.github/workflows/claude-md-drift.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'CLAUDE*.md'
+      - 'claude-generation-manifest.json'
+      - 'scripts/generate-claude-md-from-db.js'
+      - 'scripts/check-claude-md-drift.cjs'
+      - 'scripts/modules/claude-md-generator/**'
+      - 'scripts/section-file-mapping*.json'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift-check:
+    name: Generated docs match leo_protocol_sections
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Check CLAUDE_*.md drift vs leo_protocol_sections
+        shell: bash
+        run: |
+          set +e
+          node scripts/check-claude-md-drift.cjs
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
+            echo "::notice::CLAUDE_*.md are in sync with leo_protocol_sections"
+            exit 0
+          elif [ "$code" -eq 1 ]; then
+            echo "::error::CLAUDE_*.md have drifted from leo_protocol_sections. Run 'node scripts/generate-claude-md-from-db.js' and commit the regenerated files."
+            exit 1
+          else
+            # Exit 2 = internal/infra error (e.g. missing DB secrets). Fail-open in CI so a
+            # transient DB blip or unconfigured fork PR does not red-flag an unrelated change.
+            echo "::warning::Drift check could not run (exit $code) — skipping (infra/secret issue, not a content drift)."
+            exit 0
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ scripts/check-*.cjs
 # Production check-* scripts (must be committed) — add an explicit negation below
 !scripts/check-migration-readiness.mjs
 !scripts/check-activation-catalog.mjs
+# SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1): the drift-check primitive is a
+# permanent, shared script (used by FR-2 pre-commit, FR-3 SessionStart, FR-4a CI).
+!scripts/check-claude-md-drift.cjs
 scripts/cleanup-*.js
 !scripts/cleanup-phantom-worktrees.js
 scripts/complete-*.mjs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -808,5 +808,15 @@ else
   echo "✅ Root temp file check passed ($ROOT_TOTAL files)"
 fi
 
+# ============================================================================
+# STAGE 10: CLAUDE_*.md Drift Gate (BLOCKING when generated-doc family is staged)
+# ============================================================================
+# SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-2): if this commit stages CLAUDE_*.md, the
+# manifest, the generator, or the section mapping, ensure the committed docs are not stale vs
+# leo_protocol_sections. Scoped + fail-open (skips silently on unrelated commits / no DB creds).
+echo ""
+echo "📐 Checking CLAUDE_*.md drift vs leo_protocol_sections..."
+node scripts/hooks/pre-commit-claude-md-drift.cjs || exit 1
+
 echo ""
 echo "✅ Pre-commit checks passed. Proceeding with commit."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
-<!-- file_content_hash: 4241b7ff70952603 -->
+<!-- file_content_hash: 744b39c25600383d -->
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
 ## Prime Directive
@@ -198,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-11 9:56:07 AM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-14 4:52:50 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,7 +1,8 @@
-<!-- file_content_hash: 569a7a2581969535 -->
+<!-- file_content_hash: 9cb31c181e51796a -->
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-14 10:27:42 PM
+**Generated**: 2026-06-14 4:52:50 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -80,6 +81,12 @@
 
 - **CHAIRMAN PHONE-NOTIFY (urgent action-items + decisions) — SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001**: Adam tracks chairman HUMAN action-items in `.adam-chairman-decisions.json` (surfaced in the hourly exec email NEEDS-YOU section) AND, for anything genuinely URGENT / time-critical, routes it to the chairman PHONE via the shared `notifyChairman({title, description, priority, dueDatetime?})` helper (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). The helper adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and dueDatetime / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push LAYER on top of the coordinator decision-queue / `fn_chairman_decide`, NOT a replacement. Use it SPARINGLY (urgent only — never spam the chairman). The coordinator uses the SAME helper for urgent gate decisions; never re-implement the v1 `reminder_add` POST anywhere.
 
+
+## Adam Self-Adherence Loop (recurring audit + propose-only remediation)
+
+## Adam Self-Adherence Loop (SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001)
+
+Adam runs a 4th recurring tick (self-adherence, every 6h: node scripts/adam-self-adherence-review.mjs) that audits Adam's OWN role-contract adherence. Pure role-derived probes (lib/adam/adherence-probes.js: sourcing-cadence, vision-monitoring, friction-signaling, propose-only/never-build) emit pass|fail|unknown — FAIL-LOUD: an un-runnable probe is unknown, NEVER a silent pass. Each verdict is written (one row per probe per run) to the adam_adherence_ledger table. On drift (any fail) the loop SOURCES a propose-only remediation — a feedback flag (category=adam_adherence_drift) for the coordinator to triage into a gap-closing SD — and NEVER builds the fix itself (CONST-002). This is the self-improving governance loop: Adam's own adherence is measured and remediated, not assumed.
 
 ---
 

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,8 +1,9 @@
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-11T13:56:07.378Z -->
-<!-- git_commit: 3dc541dd -->
-<!-- db_snapshot_hash: 565fa3f04d144dd0 -->
-<!-- file_content_hash: 580d155538f70558 -->
+<!-- generated_at: 2026-06-14T20:52:50.248Z -->
+<!-- git_commit: a27b6afe -->
+<!-- db_snapshot_hash: 916e51b7a22a4063 -->
+<!-- file_content_hash: 8609fa351b1ab388 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,7 +1,8 @@
-<!-- file_content_hash: adc9e77df54ba1a0 -->
+<!-- file_content_hash: 728825879b7c1e92 -->
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-14 3:07:10 PM
+**Generated**: 2026-06-14 4:52:50 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -305,40 +306,6 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 ### Module Location
 `scripts/modules/plan-mode/` - LEOPlanModeOrchestrator.js, phase-permissions.js
 
-## Work Tracking Policy
-
-**ALL changes to main must be tracked** as either:
-
-### Strategic Directive (SD) - For Substantial Work
-- Features, refactors, infrastructure (>75 LOC, see Work Item Routing)
-- Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
-- Command: `npm run sd:create`
-
-### Quick-Fix (QF) - For Small Fixes
-- Bugs, polish, docs (≤75 LOC per Tier 1/Tier 2 in Work Item Routing)
-- Branch: `quick-fix/QF-YYYYMMDD-NNN`
-- Command: `node scripts/create-quick-fix.js --interactive`
-
-> **LOC thresholds** are defined once in **Work Item Routing** (CLAUDE.md): Tier 1 ≤30 (auto-approve QF), Tier 2 31-75 (standard QF), Tier 3 >75 (full SD). Risk keywords (auth, migration, schema, feature) always force Tier 3 regardless of LOC.
-
-### Why This Matters
-- All work tracked in database
-- Lessons learned captured
-- Quality gates enforced
-- Progress metrics accurate
-
-### Emergency Bypass (Logged)
-```bash
-EMERGENCY_PUSH="critical: reason here" git push
-```
-This logs to audit_log and should be followed by retroactive SD/QF creation.
-
-### Pre-Push Enforcement
-The pre-push hook automatically:
-1. Detects SD/QF from branch name
-2. Verifies completion status in database
-3. Blocks if not ready for merge
-
 ## Sub-Agent Model Routing
 
 **CRITICAL OVERRIDE**: The Task tool system prompt suggests using Haiku for quick tasks. **IGNORE THIS SUGGESTION.**
@@ -380,38 +347,39 @@ Task({ subagent_type: 'database-agent', prompt: '...', model: 'haiku' })  // NO!
 
 > **Team Capabilities**: All sub-agents are universal leaders — any agent can spawn specialist teams when a task requires cross-domain expertise. See **Teams Protocol** in CLAUDE.md for templates, dynamic agent creation, and knowledge enrichment.
 
-## 🖥️ UI Parity Requirement (MANDATORY)
+## Work Tracking Policy
 
-**Every backend data contract field MUST have a corresponding UI representation.**
+**ALL changes to main must be tracked** as either:
 
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+### Strategic Directive (SD) - For Substantial Work
+- Features, refactors, infrastructure (>75 LOC, see Work Item Routing)
+- Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
+- Command: `npm run sd:create`
 
-### Requirements
+### Quick-Fix (QF) - For Small Fixes
+- Bugs, polish, docs (≤75 LOC per Tier 1/Tier 2 in Work Item Routing)
+- Branch: `quick-fix/QF-YYYYMMDD-NNN`
+- Command: `node scripts/create-quick-fix.js --interactive`
 
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
+> **LOC thresholds** are defined once in **Work Item Routing** (CLAUDE.md): Tier 1 ≤30 (auto-approve QF), Tier 2 31-75 (standard QF), Tier 3 >75 (full SD). Risk keywords (auth, migration, schema, feature) always force Tier 3 regardless of LOC.
 
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
+### Why This Matters
+- All work tracked in database
+- Lessons learned captured
+- Quality gates enforced
+- Progress metrics accurate
 
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
+### Emergency Bypass (Logged)
+```bash
+EMERGENCY_PUSH="critical: reason here" git push
+```
+This logs to audit_log and should be followed by retroactive SD/QF creation.
 
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
+### Pre-Push Enforcement
+The pre-push hook automatically:
+1. Detects SD/QF from branch name
+2. Verifies completion status in database
+3. Blocks if not ready for merge
 
 ## Execution Philosophy
 
@@ -449,6 +417,39 @@ Before marking any stage/feature as complete:
 - Skip LEAD approval for child SDs
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
+
+## 🖥️ UI Parity Requirement (MANDATORY)
+
+**Every backend data contract field MUST have a corresponding UI representation.**
+
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+
+### Requirements
+
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
+
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
+
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## QF Lifecycle Reconciliation
 
@@ -665,38 +666,6 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
-
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -737,6 +706,38 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 **Why**: SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001 revealed that the S17 doc-gen hook failed silently on every run since it was shipped (wrong column name in query). Because the error was caught as non-fatal, the pipeline continued without vision/architecture docs, and S19 generated an unvalidated sprint plan.
 
 **Rule**: "Non-fatal" means the hook threw an unexpected exception. "Hook ran but wrote zero rows to its target table" is a **data integrity failure** that must surface.
+
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
 
 ## 🔄 Git Commit Guidelines
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,8 +1,9 @@
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-11T13:56:07.378Z -->
-<!-- git_commit: 3dc541dd -->
-<!-- db_snapshot_hash: 565fa3f04d144dd0 -->
-<!-- file_content_hash: bcd9612d1ddb9641 -->
+<!-- generated_at: 2026-06-14T20:52:50.248Z -->
+<!-- git_commit: a27b6afe -->
+<!-- db_snapshot_hash: 916e51b7a22a4063 -->
+<!-- file_content_hash: 6833d39df2f87656 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -269,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-11 9:56:07 AM*
+*DIGEST generated: 2026-06-14 4:52:50 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,8 +1,9 @@
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-11T13:56:07.378Z -->
-<!-- git_commit: 3dc541dd -->
-<!-- db_snapshot_hash: 565fa3f04d144dd0 -->
-<!-- file_content_hash: 3ebe26a656f07e20 -->
+<!-- generated_at: 2026-06-14T20:52:50.248Z -->
+<!-- git_commit: a27b6afe -->
+<!-- db_snapshot_hash: 916e51b7a22a4063 -->
+<!-- file_content_hash: fc2ea11ab0681505 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-11 9:56:07 AM*
+*DIGEST generated: 2026-06-14 4:52:50 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,7 +1,8 @@
-<!-- file_content_hash: 9235b7450bea731e -->
+<!-- file_content_hash: ddeeef964f10a71a -->
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-14 3:07:10 PM
+**Generated**: 2026-06-14 4:52:50 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -200,70 +201,6 @@ See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for c
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
 
 
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-# Branch was auto-created at LEAD-TO-PLAN handoff
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
-
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
 
 **Source**: Analysis of 175 high-quality retrospectives (score ≥60)
@@ -351,6 +288,70 @@ If `research_confidence_score = 0.00`, you skipped this step.
 | Simulate sub-agents | 15% quality loss | Execute actual tools |
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
+
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+# Branch was auto-created at LEAD-TO-PLAN handoff
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
 
 ## Vision/Architecture Doc Pre-Check
 
@@ -441,41 +442,6 @@ Required sub-agents for a handoff MUST be invoked CONCURRENTLY — one message c
 Script-path equivalent: `npm run subagents:collect -- --sd <SD-KEY> --phase <HANDOFF>` launches all required agents for the handoff in parallel and waits for all evidence rows (one command replaces N serial invocations).
 *Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
 
-## Migration Script Pattern (MANDATORY)
-
-**Issue Pattern**: PAT-DB-MIGRATION-001
-
-When writing migration scripts, you MUST use the established pattern:
-
-### Correct Pattern
-```javascript
-import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
-import { readFileSync } from 'fs';
-
-const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
-const client = await createDatabaseClient('engineer', { verify: true });
-const statements = splitPostgreSQLStatements(migrationSQL);
-
-for (const statement of statements) {
-  await client.query(statement);
-}
-
-await client.end();
-```
-
-### NEVER Use This Pattern
-```javascript
-// WRONG - exec_sql RPC does not exist
-import { createClient } from '@supabase/supabase-js';
-const supabase = createClient(url, key);
-await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
-```
-
-### Before Writing Migration Scripts
-1. Search for existing patterns: `Glob *migration*.js`
-2. Read `scripts/run-sql-migration.js` as canonical template
-3. Use `lib/supabase-connection.js` utilities
-
 ## 📚 Skill Integration (EXEC Phase)
 
 ## Skill Integration During EXEC
@@ -555,6 +521,41 @@ Both are valid in EXEC — use them for different purposes:
 Skills are for **creative guidance** (how to build).
 Sub-agents act as **first responders** on domain-specific errors AND as **formal validators** before EXEC-TO-PLAN.
 Use both during EXEC — the distinction is about *purpose*, not *phase*.
+
+## Migration Script Pattern (MANDATORY)
+
+**Issue Pattern**: PAT-DB-MIGRATION-001
+
+When writing migration scripts, you MUST use the established pattern:
+
+### Correct Pattern
+```javascript
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+import { readFileSync } from 'fs';
+
+const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
+const client = await createDatabaseClient('engineer', { verify: true });
+const statements = splitPostgreSQLStatements(migrationSQL);
+
+for (const statement of statements) {
+  await client.query(statement);
+}
+
+await client.end();
+```
+
+### NEVER Use This Pattern
+```javascript
+// WRONG - exec_sql RPC does not exist
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(url, key);
+await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
+```
+
+### Before Writing Migration Scripts
+1. Search for existing patterns: `Glob *migration*.js`
+2. Read `scripts/run-sql-migration.js` as canonical template
+3. Use `lib/supabase-connection.js` utilities
 
 ## Validation Rules (SD-LEARN-008)
 
@@ -753,6 +754,24 @@ EXEC→PLAN handoffs now have **intelligent verification**:
 | **300-600** | ✅ **OPTIMAL** | Sweet spot |
 | **>800** | **MUST split** | Too complex |
 
+## TODO Comment Standard
+
+## TODO Comment Standard (When Deferring Work)
+
+**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
+
+### Standard TODO Format
+
+```typescript
+// TODO (SD-ID): Action required
+// Requires: Dependencies, prerequisites
+// Estimated effort: X-Y hours
+// Current state: Mock/temporary/placeholder
+```
+
+**Success Pattern** (SD-UAT-003):
+> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
+
 ## Human-Like E2E Testing Fixtures
 
 ### Human-Like E2E Testing Enhancements (LEO v4.4)
@@ -836,24 +855,6 @@ All human-like test results are automatically included in the LEO evidence pack:
 - `test_results.attachments.accessibility` - axe-core violations
 - `test_results.attachments.chaos` - resilience test results
 - `test_results.attachments.llm_ux` - LLM evaluation scores
-
-## TODO Comment Standard
-
-## TODO Comment Standard (When Deferring Work)
-
-**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
-
-### Standard TODO Format
-
-```typescript
-// TODO (SD-ID): Action required
-// Requires: Dependencies, prerequisites
-// Estimated effort: X-Y hours
-// Current state: Mock/temporary/placeholder
-```
-
-**Success Pattern** (SD-UAT-003):
-> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
 
 ## EXEC Dual Test Requirement
 
@@ -1464,6 +1465,77 @@ The ACCEPTANCE_CRITERIA_VALIDATION gate scores stories as follows:
 
 Threshold: overall score >= 60 AND no story scores 0.
 
+## Playwright MCP Integration
+
+## 🎭 Playwright MCP Integration
+
+**Status**: ✅ READY (Installed 2025-10-12)
+
+### Overview
+Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
+
+### Installed Components
+- **Chrome**: Google Chrome browser for MCP operations
+- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
+- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
+- **System Dependencies**: All required Linux libraries installed
+
+### Available MCP Tools
+
+#### Navigation
+- `mcp__playwright__browser_navigate` - Navigate to URL
+- `mcp__playwright__browser_navigate_back` - Go back to previous page
+
+#### Interaction
+- `mcp__playwright__browser_click` - Click elements
+- `mcp__playwright__browser_fill` - Fill form fields
+- `mcp__playwright__browser_select` - Select dropdown options
+- `mcp__playwright__browser_hover` - Hover over elements
+- `mcp__playwright__browser_type` - Type text into elements
+
+#### Verification
+- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
+- `mcp__playwright__browser_take_screenshot` - Take screenshots
+- `mcp__playwright__browser_evaluate` - Execute JavaScript
+
+#### Management
+- `mcp__playwright__browser_close` - Close browser
+- `mcp__playwright__browser_tabs` - Manage tabs
+
+### Testing Integration
+
+**When to Use Playwright MCP**:
+1. ✅ Visual regression testing
+2. ✅ UI component verification
+3. ✅ Screenshot capture for evidence
+4. ✅ Accessibility tree validation
+5. ✅ Cross-browser testing
+
+**When to Use Standard Playwright**:
+1. ✅ E2E test suites (`npm run test:e2e`)
+2. ✅ CI/CD pipeline tests
+3. ✅ Automated test runs
+4. ✅ User story validation
+
+### Usage Example
+
+```javascript
+// Using Playwright MCP for visual verification
+await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
+await mcp__playwright__browser_snapshot(); // Get accessibility tree
+await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
+await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
+```
+
+### QA Director Integration
+
+The QA Engineering Director sub-agent now has access to:
+- Playwright MCP for visual testing
+- Standard Playwright for E2E automation
+- Both Chrome (MCP) and Chromium (tests) browsers
+
+**Complete Guide**: See `docs/reference/playwright-mcp-guide.md` *(retired — no longer in the tree)*
+
 ## Triangulated Runtime Audit Protocol
 
 ### Purpose
@@ -1681,77 +1753,6 @@ See: `/runtime-audit` skill for full template
 - `codebase-search` - Finding code references
 - `schema-design` - Database schema issues
 
-
-## Playwright MCP Integration
-
-## 🎭 Playwright MCP Integration
-
-**Status**: ✅ READY (Installed 2025-10-12)
-
-### Overview
-Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
-
-### Installed Components
-- **Chrome**: Google Chrome browser for MCP operations
-- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
-- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
-- **System Dependencies**: All required Linux libraries installed
-
-### Available MCP Tools
-
-#### Navigation
-- `mcp__playwright__browser_navigate` - Navigate to URL
-- `mcp__playwright__browser_navigate_back` - Go back to previous page
-
-#### Interaction
-- `mcp__playwright__browser_click` - Click elements
-- `mcp__playwright__browser_fill` - Fill form fields
-- `mcp__playwright__browser_select` - Select dropdown options
-- `mcp__playwright__browser_hover` - Hover over elements
-- `mcp__playwright__browser_type` - Type text into elements
-
-#### Verification
-- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
-- `mcp__playwright__browser_take_screenshot` - Take screenshots
-- `mcp__playwright__browser_evaluate` - Execute JavaScript
-
-#### Management
-- `mcp__playwright__browser_close` - Close browser
-- `mcp__playwright__browser_tabs` - Manage tabs
-
-### Testing Integration
-
-**When to Use Playwright MCP**:
-1. ✅ Visual regression testing
-2. ✅ UI component verification
-3. ✅ Screenshot capture for evidence
-4. ✅ Accessibility tree validation
-5. ✅ Cross-browser testing
-
-**When to Use Standard Playwright**:
-1. ✅ E2E test suites (`npm run test:e2e`)
-2. ✅ CI/CD pipeline tests
-3. ✅ Automated test runs
-4. ✅ User story validation
-
-### Usage Example
-
-```javascript
-// Using Playwright MCP for visual verification
-await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
-await mcp__playwright__browser_snapshot(); // Get accessibility tree
-await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
-await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
-```
-
-### QA Director Integration
-
-The QA Engineering Director sub-agent now has access to:
-- Playwright MCP for visual testing
-- Standard Playwright for E2E automation
-- Both Chrome (MCP) and Chromium (tests) browsers
-
-**Complete Guide**: See `docs/reference/playwright-mcp-guide.md` *(retired — no longer in the tree)*
 
 ## Loop Continuity / Never-Exit (Fleet Worker Contract)
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,8 +1,9 @@
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-11T13:56:07.378Z -->
-<!-- git_commit: 3dc541dd -->
-<!-- db_snapshot_hash: 565fa3f04d144dd0 -->
-<!-- file_content_hash: b7343da787190e3e -->
+<!-- generated_at: 2026-06-14T20:52:50.248Z -->
+<!-- git_commit: a27b6afe -->
+<!-- db_snapshot_hash: 916e51b7a22a4063 -->
+<!-- file_content_hash: 676a8470c2f3a940 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -216,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-11 9:56:07 AM*
+*DIGEST generated: 2026-06-14 4:52:50 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,7 +1,8 @@
-<!-- file_content_hash: 4a9b62fff1ff3a2a -->
+<!-- file_content_hash: 006bdbc26a6cff47 -->
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-11 9:56:07 AM
+**Generated**: 2026-06-14 4:52:50 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1581,6 +1582,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-11*
+*Generated from database: 2026-06-14*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,8 +1,9 @@
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-11T13:56:07.378Z -->
-<!-- git_commit: 3dc541dd -->
-<!-- db_snapshot_hash: 565fa3f04d144dd0 -->
-<!-- file_content_hash: 28c8b8ab038aeae3 -->
+<!-- generated_at: 2026-06-14T20:52:50.248Z -->
+<!-- git_commit: a27b6afe -->
+<!-- db_snapshot_hash: 916e51b7a22a4063 -->
+<!-- file_content_hash: 8caf1c737f18c03b -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -131,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-11 9:56:07 AM*
+*DIGEST generated: 2026-06-14 4:52:50 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,7 +1,8 @@
-<!-- file_content_hash: 7580d7a8250b555d -->
+<!-- file_content_hash: 927c99b2adf034c8 -->
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-11 10:37:45 PM
+**Generated**: 2026-06-14 4:52:50 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -205,6 +206,30 @@ LEAD Phase                    PLAN Phase                   EXEC Phase
 ```
 
 
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
+
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -242,30 +267,6 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
-
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
 
 ## Phase-Specific Sub-Agent Guidance: PLAN
 
@@ -460,6 +461,23 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 | "DESIGN sub-agent not executed" | Didn't run design-agent | Use Task tool with design-agent |
 | "DATABASE sub-agent not executed" | Didn't run database-agent | Use Task tool with database-agent |
 
+## Enhanced QA Engineering Director v2.0 - Testing-First Edition
+
+**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
+
+**Core Capabilities:**
+1. Professional test case generation from user stories
+2. Pre-test build validation (saves 2-3 hours)
+3. Database migration verification (prevents 1-2 hours debugging)
+4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
+5. Test infrastructure discovery and reuse
+
+**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
+
+**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
+
+**Full Guide**: See `docs/reference/qa-director-guide.md`
+
 ## ✅ Scope Verification with Explore (PLAN_VERIFY)
 
 ## Scope Verification with Explore
@@ -530,23 +548,6 @@ This change [describe]. Options:
 
 Which do you prefer?"
 ```
-
-## Enhanced QA Engineering Director v2.0 - Testing-First Edition
-
-**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
-
-**Core Capabilities:**
-1. Professional test case generation from user stories
-2. Pre-test build validation (saves 2-3 hours)
-3. Database migration verification (prevents 1-2 hours debugging)
-4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
-5. Test infrastructure discovery and reuse
-
-**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
-
-**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
-
-**Full Guide**: See `docs/reference/qa-director-guide.md`
 
 ## PLAN Pre-EXEC Checklist
 
@@ -708,6 +709,33 @@ When a pipeline has cascading failures, the architecture plan MUST:
 
 **Detection**: The gate checks architecture plan content for failure chain diagrams and upstream-first child ordering language.
 
+## 🔬 BMAD Method Enhancements
+
+## BMAD Enhancements
+
+### 6 Key Improvements
+1. **Unified Handoff System** - All handoffs via `handoff.js`
+2. **Database-First PRDs** - PRDs stored in database, not markdown
+3. **Validation Gates** - 4-gate validation before EXEC
+4. **Progress Tracking** - Automatic progress % calculation
+5. **Context Management** - Proactive monitoring, compression strategies
+6. **Sub-Agent Compression** - 3-tier output reduction
+
+### Using Handoff System
+```bash
+node scripts/handoff.js create "{message}"
+```
+
+### PRD Creation
+```bash
+node scripts/add-prd-to-database.js {SD-ID}
+```
+
+### Never Bypass
+- ⚠️ Always use process scripts
+- ⚠️ Never create PRDs as markdown files
+- ⚠️ Never skip validation gates
+
 ## Research Lookup Before PRD Creation
 
 ## Research Lookup Before PRD Creation (MANDATORY)
@@ -805,33 +833,6 @@ node scripts/add-prd-to-database.js SD-RESEARCH-106
 # → PRD includes research findings in technical_approach
 ```
 
-
-## 🔬 BMAD Method Enhancements
-
-## BMAD Enhancements
-
-### 6 Key Improvements
-1. **Unified Handoff System** - All handoffs via `handoff.js`
-2. **Database-First PRDs** - PRDs stored in database, not markdown
-3. **Validation Gates** - 4-gate validation before EXEC
-4. **Progress Tracking** - Automatic progress % calculation
-5. **Context Management** - Proactive monitoring, compression strategies
-6. **Sub-Agent Compression** - 3-tier output reduction
-
-### Using Handoff System
-```bash
-node scripts/handoff.js create "{message}"
-```
-
-### PRD Creation
-```bash
-node scripts/add-prd-to-database.js {SD-ID}
-```
-
-### Never Bypass
-- ⚠️ Always use process scripts
-- ⚠️ Never create PRDs as markdown files
-- ⚠️ Never skip validation gates
 
 ## CI/CD Pipeline Verification
 
@@ -1676,34 +1677,6 @@ for (const childId of childIds) {
 
 > **Team Capabilities**: When planning complex SDs, consider whether team spawning (any agent leading specialists) could parallelize cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
-
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1744,6 +1717,34 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
+
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
 
 ## Quality Assessment Integration in Handoffs
 
@@ -2440,6 +2441,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-11*
+*Generated from database: 2026-06-14*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,8 +1,9 @@
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-11T13:56:07.378Z -->
-<!-- git_commit: 3dc541dd -->
-<!-- db_snapshot_hash: 565fa3f04d144dd0 -->
-<!-- file_content_hash: b8ddaefca33c4118 -->
+<!-- generated_at: 2026-06-14T20:52:50.248Z -->
+<!-- git_commit: a27b6afe -->
+<!-- db_snapshot_hash: 916e51b7a22a4063 -->
+<!-- file_content_hash: d88ffb8a2f574b78 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -162,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-11 9:56:07 AM*
+*DIGEST generated: 2026-06-14 4:52:50 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,14 +1,1628 @@
 {
-  "generated_at": "2026-06-14T02:27:42.375Z",
-  "git_commit": "50078d88",
-  "db_snapshot_hash": "15cdd0a6da83d8c4",
+  "generated_at": "2026-06-14T20:52:50.248Z",
+  "git_commit": "a27b6afe",
+  "db_snapshot_hash": "916e51b7a22a4063",
   "files": {
+    "CLAUDE.md": {
+      "type": "full",
+      "chars": 19368,
+      "estimated_tokens": 4842,
+      "content_hash": "c5007233675348b6",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE.md"
+    },
+    "CLAUDE_CORE.md": {
+      "type": "full",
+      "chars": 81294,
+      "estimated_tokens": 20324,
+      "content_hash": "7dbce519976e4041",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_CORE.md"
+    },
+    "CLAUDE_LEAD.md": {
+      "type": "full",
+      "chars": 65128,
+      "estimated_tokens": 16282,
+      "content_hash": "377a216774c9d0e9",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_LEAD.md"
+    },
+    "CLAUDE_PLAN.md": {
+      "type": "full",
+      "chars": 90830,
+      "estimated_tokens": 22708,
+      "content_hash": "6137f9f96a38f147",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_PLAN.md"
+    },
+    "CLAUDE_EXEC.md": {
+      "type": "full",
+      "chars": 84821,
+      "estimated_tokens": 21206,
+      "content_hash": "a9e5d91c4acc6a3f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_EXEC.md"
+    },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 22138,
-      "estimated_tokens": 5535,
-      "content_hash": "93a7e9653f6217c5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001\\CLAUDE_ADAM.md"
+      "chars": 23273,
+      "estimated_tokens": 5819,
+      "content_hash": "cadc2cb0aac709d5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_ADAM.md"
+    },
+    "CLAUDE_DIGEST.md": {
+      "type": "digest",
+      "chars": 9611,
+      "estimated_tokens": 2403,
+      "content_hash": "f96a690df17c166a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_DIGEST.md"
+    },
+    "CLAUDE_CORE_DIGEST.md": {
+      "type": "digest",
+      "chars": 11535,
+      "estimated_tokens": 2884,
+      "content_hash": "6d2c7dfef7e12585",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_CORE_DIGEST.md"
+    },
+    "CLAUDE_LEAD_DIGEST.md": {
+      "type": "digest",
+      "chars": 5422,
+      "estimated_tokens": 1356,
+      "content_hash": "702dfdb250295933",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_LEAD_DIGEST.md"
+    },
+    "CLAUDE_PLAN_DIGEST.md": {
+      "type": "digest",
+      "chars": 8412,
+      "estimated_tokens": 2103,
+      "content_hash": "30b3e1bb8b461c41",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_PLAN_DIGEST.md"
+    },
+    "CLAUDE_EXEC_DIGEST.md": {
+      "type": "digest",
+      "chars": 10835,
+      "estimated_tokens": 2709,
+      "content_hash": "77519577a04610ad",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_EXEC_DIGEST.md"
+    },
+    "CLAUDE_ADAM_DIGEST.md": {
+      "type": "digest",
+      "chars": 3952,
+      "estimated_tokens": 988,
+      "content_hash": "d0083005c27b3873",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001\\CLAUDE_ADAM_DIGEST.md"
+    }
+  },
+  "section_digests": {
+    "global": "3d962834f9e80992",
+    "byId": {
+      "94": "ef2f1e7ed617b5e0",
+      "189": "6398659126897bbb",
+      "190": "10f2475eae8afd22",
+      "191": "22bfa253c667b537",
+      "192": "47bb75dc50f88454",
+      "193": "b08aee786e136af8",
+      "194": "18d2d52d4afd5c6c",
+      "196": "415854485180c1ba",
+      "197": "3ca6b6673aceedc3",
+      "198": "92cca3364de0bc34",
+      "199": "a9facc33a2d2b4ec",
+      "201": "28796aa3a9ca8661",
+      "202": "fdb3c89e8348f61d",
+      "203": "00b10a9e35bf0e59",
+      "204": "faff41fb18dd6a2c",
+      "205": "e1261146fada8c22",
+      "206": "630e37f49e96fd34",
+      "207": "e445b9976ac071e4",
+      "208": "a7d1a5ecfdf8499c",
+      "209": "36c316bc964a6cfe",
+      "210": "f2ad58fdc48f49a2",
+      "211": "5d137550e1e954b7",
+      "212": "53916ba04560d9cf",
+      "213": "05620e243a2c48a1",
+      "214": "9a1bc63221a289d3",
+      "215": "74abef4df87e4fbf",
+      "216": "07a5aa99e8763a1a",
+      "217": "fc247f263fc764e7",
+      "218": "07846ee9a13b2745",
+      "219": "84474842daa1743b",
+      "220": "c5d729a254d975b7",
+      "222": "80f96bc1e28c9059",
+      "225": "138f5e1820aa2ea9",
+      "226": "43e95d9812289214",
+      "227": "1284797091b7cb8c",
+      "228": "a2254594a872302b",
+      "230": "0a7f087d552a0d96",
+      "231": "f88ee38333c1f53b",
+      "232": "884be0b20a5b9183",
+      "233": "4d0d7baf850ac007",
+      "234": "8755dce3bed36c63",
+      "240": "b7056a9a915c7931",
+      "245": "6cc258fd0010cb4e",
+      "246": "5fd6159fed4be823",
+      "247": "9aa71821dd77b214",
+      "248": "e03238bf8a9d8635",
+      "249": "9d02322b78e81385",
+      "250": "14f743b7a91a8d79",
+      "251": "593b3b10a8a47c83",
+      "252": "c052fcbf28a24544",
+      "254": "f1ea45d423dc8c4c",
+      "255": "f305b58f7b0dfd1f",
+      "256": "aee0db021da60e56",
+      "257": "f72613a96f171e1c",
+      "258": "0c2e7546195bf5b4",
+      "259": "146327422ab6adc9",
+      "262": "c8f9dd74bec589b1",
+      "263": "87494b8d3831ebb4",
+      "264": "47834c25c1940b74",
+      "265": "171d12c6afd3a7cc",
+      "266": "8b93d6ac1d446420",
+      "267": "976ed19065d9e1e7",
+      "269": "d127f90f556f59c3",
+      "270": "1bb7d913d65e2386",
+      "271": "51446290af3288ac",
+      "272": "b6ef6bf5e5e47205",
+      "273": "0fce9ec10a892325",
+      "274": "e7a098480995413c",
+      "275": "8a1c47b19d98488b",
+      "276": "5bf34816e9d52cc5",
+      "277": "904074ab992a9409",
+      "278": "501f54098bf25aed",
+      "279": "c279d5b5a31fb8c7",
+      "280": "b74fa08ccc3ba6ac",
+      "281": "53f5ab89a2f5e19a",
+      "282": "87fd6e852562a3a2",
+      "284": "1c9f5a99ff118036",
+      "286": "887ca730108ffa29",
+      "287": "9cd7f602ff4fecd8",
+      "288": "c7f7324a8090c87e",
+      "289": "38e17ba9d7a8d144",
+      "290": "ecc81495351e7611",
+      "291": "12e28b9bffda36db",
+      "292": "3af0fb5d3a3e5774",
+      "293": "8a5a7eb0b9a694f9",
+      "294": "9bfc656114c59db0",
+      "295": "447331e1e6f386f3",
+      "296": "c6ccef265c848ffd",
+      "297": "458e28fd2a9a81df",
+      "299": "ee0885ebefc14f26",
+      "300": "87e4aa2892c00fd2",
+      "301": "cec5f28b18b461a4",
+      "303": "9ccb23f56cde7b93",
+      "305": "e1a835721684425e",
+      "306": "0c43eb6c7b16f82d",
+      "307": "4a5e9b832ae9c14e",
+      "308": "a02867048d9feb1f",
+      "309": "a1aa83f4ff4bfa3a",
+      "310": "c1efcb6577442b08",
+      "311": "a5bd1792e7f8dfb9",
+      "312": "47a97e7ca854a28e",
+      "315": "85757a0fe109468e",
+      "316": "e0eb178d0a81ac28",
+      "317": "7f5c188709ac7334",
+      "318": "0ec59de5577d5fd8",
+      "320": "b24e3e2f4b075d53",
+      "321": "82d6263d718533f0",
+      "322": "9f9e5e6bdf49868b",
+      "323": "574a443c18466c7e",
+      "324": "aa06eb6069e082b9",
+      "325": "6daf416a2d333242",
+      "329": "27dbea1143f8be69",
+      "334": "ad19b97845f7d155",
+      "335": "19226e238cf2a19a",
+      "336": "175b688bb9e15d76",
+      "337": "89098d5ae399de8c",
+      "338": "251bf7a761ac46e3",
+      "340": "a39ffe7c0c8cb1c4",
+      "341": "a63ae4ddb330324d",
+      "342": "711a605f28c687d0",
+      "344": "dd1a643fe3c9a1a7",
+      "345": "ba1f3253e0734f19",
+      "347": "e64c2ad11f63001f",
+      "349": "511d3e1346215f92",
+      "351": "1263b944c16bc45a",
+      "360": "f2d25d7d352c5e3f",
+      "361": "676eb8472b459dde",
+      "362": "973ecfa886452ba4",
+      "363": "49dae90de190bf06",
+      "364": "6f412b7f8aa9c9eb",
+      "365": "d0f3fd2281b7fb22",
+      "366": "9201b170e0f90729",
+      "369": "999bfb4d0c2ec34f",
+      "370": "2d2f62f10a40d590",
+      "371": "70ef0843cca84b6a",
+      "372": "b22dee3afacbd3ce",
+      "375": "8b08cc11ab858a95",
+      "376": "2d6c6ac7b6c7a00f",
+      "377": "3ccae6ca7a8ca946",
+      "378": "8cef93059452a0d8",
+      "384": "8544beddce1568f1",
+      "388": "dc79234b779a4c8e",
+      "389": "c40ddf9d5d7f7253",
+      "390": "a99a83cab43a7eee",
+      "391": "29f13662c0a42f86",
+      "394": "61ae563931eb8e87",
+      "396": "001d779e71a61bfa",
+      "398": "19e1fc396913f973",
+      "399": "33cd544e54561eab",
+      "400": "c35fa7bcd622f945",
+      "401": "c98dbc8b1ecd0597",
+      "402": "70f35a8617d0c379",
+      "403": "dcd6ef2d05643688",
+      "404": "3c0a8c33301e8019",
+      "405": "dff2041f598544f0",
+      "406": "775ef3684d8c8d2a",
+      "407": "7fd77a4b1ab7b2a1",
+      "408": "e718266c938598fd",
+      "409": "082a7a428676eb6e",
+      "410": "ef523472690082c7",
+      "414": "6169151951624c25",
+      "415": "7180712fdb003725",
+      "416": "5111a5863e908b5e",
+      "417": "7a52daa48bb5f7e0",
+      "419": "f1ee3672581052af",
+      "420": "3758794f6943f4c8",
+      "423": "39276248fee9a4c1",
+      "424": "14a9b10a48a20de1",
+      "425": "966640ccb77eabed",
+      "428": "b4f817b4d03aaff3",
+      "431": "5cfbef3d6872768b",
+      "434": "5188b26b9528594d",
+      "435": "dc205008f2747ac6",
+      "436": "8115bd7ee9303db3",
+      "439": "08a9d4b4ea40618b",
+      "444": "ff96de4f8cf05c1a",
+      "449": "86f83ca9a7afe8cc",
+      "450": "94087ec605b29ee4",
+      "452": "5bb15e4ce5af0b4e",
+      "459": "ed8de7b4fcf8ece3",
+      "460": "a24d3ead26a7e88b",
+      "461": "92a304282379c1be",
+      "462": "0e2fea90fdb631ac",
+      "463": "6b87118dd098a71c",
+      "469": "eac9aaedca6ccab4",
+      "470": "d3f1f4686a774290",
+      "471": "d186e84c659f0140",
+      "472": "2f19f3d58680c855",
+      "473": "1dbd94cbba0db507",
+      "483": "21b66fe1b527b196",
+      "484": "8b550827f1b37ff5",
+      "485": "5c1a012b3d30cf06",
+      "486": "46b4cf97f5415c69",
+      "492": "842c875ef688dff7",
+      "493": "27caa3d6ece1e129",
+      "494": "355f84ac069b7d1c",
+      "495": "5290901da4072c8d",
+      "496": "6445ce3caa83071c",
+      "497": "30ed2c0762b07d8b",
+      "498": "c8a8b32c2e5048de",
+      "499": "cd4f7fd863c14843",
+      "500": "5bbc37016edfa158",
+      "501": "b571649ae0a1ee01",
+      "508": "1a68c498faab183d",
+      "509": "04b0c66269a5d830",
+      "510": "95e58f07e9d0edfd",
+      "513": "cfc7186bd2334d0b",
+      "514": "411fc58da048166f",
+      "517": "869202c848cc1cec",
+      "518": "01595b7ba313e82d",
+      "519": "b598db22d6c48b60",
+      "520": "8997c803f49046a7",
+      "521": "3a41c86e6d321678",
+      "522": "f6c3d5c2a90a4eb1",
+      "524": "0b517bbcc30ec9ff",
+      "525": "d553f3c1dceb8887",
+      "526": "a6ad4a059caf827b",
+      "529": "2d15257e180cc154",
+      "531": "32a4a018ec71ab0f",
+      "538": "97573d76a94e5f98",
+      "539": "b539a095719b2087",
+      "540": "2559404924b120a1",
+      "541": "a2ec8a812765018a",
+      "544": "2a7694d82dc5756b",
+      "545": "1d2551641b2c4f81",
+      "549": "8a5f3735df0d8557",
+      "550": "e089fb954b1d73c8",
+      "555": "9555caf0ac7f81cc",
+      "556": "dde11ace1ff56a1f",
+      "557": "44d4738331e23bef",
+      "558": "f0d604ad0512c6bc",
+      "562": "0200a46bd76ad848",
+      "563": "1ff455c3f40da523",
+      "565": "355d48a91fc08a8f",
+      "567": "64f2b952b04863ae",
+      "570": "a3899d3f9b3a5824",
+      "573": "f16e2c959d262928",
+      "574": "08e2c1be8c49e95f",
+      "575": "9f3c912d460ffcb2",
+      "576": "1bb168991a70140f",
+      "577": "90708c21ba1f683f",
+      "580": "4232fb5222f35163",
+      "584": "768510d24242f194",
+      "589": "34719a2e3fd508a7",
+      "590": "b44b6d41eabcb2d8",
+      "592": "775e8922b58033b1",
+      "593": "5aa3c836ecc1752c",
+      "594": "ac4c90927e1cff29",
+      "595": "b99d7c14d039c4be",
+      "596": "bf95e6419e99aee7",
+      "597": "8220a84f943767a6",
+      "599": "7ddd3e2178799aa8",
+      "601": "eb219777e1887ecd",
+      "602": "ad0aecae8cdc6cb3",
+      "603": "ca922c736e8d8ed3"
+    },
+    "meta": {
+      "94": {
+        "section_type": "session_verification_quick_start",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "🚀 Session Verification & Quick Start (MANDATORY)"
+      },
+      "189": {
+        "section_type": "multi_application_testing_architecture",
+        "target_file": null,
+        "title": "Multi-Application Testing Architecture"
+      },
+      "190": {
+        "section_type": "exec_dual_test_requirement",
+        "target_file": null,
+        "title": "EXEC Dual Test Requirement"
+      },
+      "191": {
+        "section_type": "development_workflow",
+        "target_file": null,
+        "title": "🔧 CRITICAL DEVELOPMENT WORKFLOW"
+      },
+      "192": {
+        "section_type": "trigger-disable-pattern",
+        "target_file": null,
+        "title": "Database Trigger Management for Special Cases"
+      },
+      "193": {
+        "section_type": "context_monitoring",
+        "target_file": null,
+        "title": "Proactive Context Monitoring"
+      },
+      "194": {
+        "section_type": "database_query_best_practices",
+        "target_file": null,
+        "title": "Database Query Best Practices"
+      },
+      "196": {
+        "section_type": "PHASE_4_VERIFICATION",
+        "target_file": null,
+        "title": "Stubbed/Mocked Code Detection"
+      },
+      "197": {
+        "section_type": "parallel_execution",
+        "target_file": null,
+        "title": "Parallel Execution"
+      },
+      "198": {
+        "section_type": "retrospective-schema-reference",
+        "target_file": null,
+        "title": "Retrospective Table Schema Reference"
+      },
+      "199": {
+        "section_type": "file_warning",
+        "target_file": null,
+        "title": "⚠️ DO NOT EDIT THIS FILE DIRECTLY"
+      },
+      "201": {
+        "section_type": "subagent_parallel_execution",
+        "target_file": null,
+        "title": "Sub-Agent Parallel Execution"
+      },
+      "202": {
+        "section_type": "schema_documentation_access",
+        "target_file": null,
+        "title": "Database Schema Documentation Access"
+      },
+      "203": {
+        "section_type": "schema_documentation_reference",
+        "target_file": null,
+        "title": "Database Schema Documentation"
+      },
+      "204": {
+        "section_type": "exec_component_sizing_guidelines",
+        "target_file": null,
+        "title": "Component Sizing Guidelines"
+      },
+      "205": {
+        "section_type": "simplicity_first_enforcement",
+        "target_file": null,
+        "title": "Quality Validation Examples"
+      },
+      "206": {
+        "section_type": "exec_todo_comment_standard",
+        "target_file": null,
+        "title": "TODO Comment Standard"
+      },
+      "207": {
+        "section_type": "plan_cicd_verification",
+        "target_file": null,
+        "title": "CI/CD Pipeline Verification"
+      },
+      "208": {
+        "section_type": "lead_code_review_requirement",
+        "target_file": null,
+        "title": "LEAD Code Review for UI/UX SDs"
+      },
+      "209": {
+        "section_type": "session_prologue",
+        "target_file": null,
+        "title": "Session Prologue (Short)"
+      },
+      "210": {
+        "section_type": "exec_implementation_requirements",
+        "target_file": null,
+        "title": "🚨 EXEC Agent Implementation Requirements"
+      },
+      "211": {
+        "section_type": "git_commit_guidelines",
+        "target_file": null,
+        "title": "🔄 Git Commit Guidelines"
+      },
+      "212": {
+        "section_type": "lead_pre_approval_simplicity_gate",
+        "target_file": null,
+        "title": "🛡️ LEAD Pre-Approval Strategic Validation Gate"
+      },
+      "213": {
+        "section_type": "test_section",
+        "target_file": null,
+        "title": "Test Section"
+      },
+      "214": {
+        "section_type": "communication_context",
+        "target_file": null,
+        "title": "📊 Communication & Context"
+      },
+      "215": {
+        "section_type": "directive_submission_review",
+        "target_file": null,
+        "title": "📋 Directive Submission Review Process"
+      },
+      "216": {
+        "section_type": "unified_handoff_system",
+        "target_file": null,
+        "title": "🔄 Unified Handoff System (Database-First)"
+      },
+      "217": {
+        "section_type": "database_schema_overview",
+        "target_file": null,
+        "title": "Database Schema Overview"
+      },
+      "218": {
+        "section_type": "design_database_validation_gates",
+        "target_file": null,
+        "title": "DESIGN→DATABASE Validation Gates"
+      },
+      "219": {
+        "section_type": "database_first_enforcement_expanded",
+        "target_file": null,
+        "title": "Database-First Enforcement - Expanded"
+      },
+      "220": {
+        "section_type": "database",
+        "target_file": null,
+        "title": "Database Operations - One Table at a Time"
+      },
+      "222": {
+        "section_type": "planning_pattern",
+        "target_file": null,
+        "title": "Child SD Pattern: When to Break into Child Strategic Directives"
+      },
+      "225": {
+        "section_type": "documentation_platform",
+        "target_file": null,
+        "title": "📚 Documentation Platform Integration"
+      },
+      "226": {
+        "section_type": "e2e_testing_mode_configuration",
+        "target_file": null,
+        "title": "E2E Testing: Dev Mode vs Preview Mode"
+      },
+      "227": {
+        "section_type": "sub_agent_compression",
+        "target_file": null,
+        "title": "Sub-Agent Report Compression System"
+      },
+      "228": {
+        "section_type": "guide",
+        "target_file": null,
+        "title": "Database Migration Pre-Flight Checklist"
+      },
+      "230": {
+        "section_type": "plan_pre_exec_checklist",
+        "target_file": null,
+        "title": "PLAN Pre-EXEC Checklist"
+      },
+      "231": {
+        "section_type": "execution_philosophy",
+        "target_file": null,
+        "title": "Execution Philosophy"
+      },
+      "232": {
+        "section_type": "five_phase_workflow",
+        "target_file": null,
+        "title": "5-Phase Strategic Directive Workflow"
+      },
+      "233": {
+        "section_type": "testing_tools",
+        "target_file": null,
+        "title": "Playwright MCP Integration"
+      },
+      "234": {
+        "section_type": "sub_agents",
+        "target_file": null,
+        "title": "Native Claude Code Sub-Agent Integration"
+      },
+      "240": {
+        "section_type": "quick_reference",
+        "target_file": null,
+        "title": "Knowledge Retrieval Commands"
+      },
+      "245": {
+        "section_type": "application_architecture",
+        "target_file": null,
+        "title": "🏗️ Application Architecture - UNIFIED FRONTEND"
+      },
+      "246": {
+        "section_type": "strategic_directive_execution_protocol",
+        "target_file": null,
+        "title": "Strategic Directive Execution Protocol"
+      },
+      "247": {
+        "section_type": "context_management_upfront",
+        "target_file": null,
+        "title": "Context Management Throughout Execution"
+      },
+      "248": {
+        "section_type": "bmad_enhancements",
+        "target_file": null,
+        "title": "🔬 BMAD Method Enhancements"
+      },
+      "249": {
+        "section_type": "best_practices",
+        "target_file": null,
+        "title": "Database Migration Validation - Two-Phase Approach"
+      },
+      "250": {
+        "section_type": "pr_size_guidelines",
+        "target_file": null,
+        "title": "PR Size Guidelines"
+      },
+      "251": {
+        "section_type": "sd_evaluation",
+        "target_file": null,
+        "title": "6-Step SD Evaluation Checklist"
+      },
+      "252": {
+        "section_type": "process",
+        "target_file": null,
+        "title": "LEAD Over-Engineering Evaluation Process"
+      },
+      "254": {
+        "section_type": "qa_engineering_enhanced",
+        "target_file": null,
+        "title": "Enhanced QA Engineering Director v2.0 - Testing-First Edition"
+      },
+      "255": {
+        "section_type": "testing_tier_strategy",
+        "target_file": null,
+        "title": "Testing Tier Strategy"
+      },
+      "256": {
+        "section_type": "handoff-rls-bypass-pattern",
+        "target_file": null,
+        "title": "Handoff Creation: RLS Bypass Pattern"
+      },
+      "257": {
+        "section_type": "smart_router",
+        "target_file": null,
+        "title": "Context Router & Loading Strategy"
+      },
+      "258": {
+        "section_type": "supabase_operations",
+        "target_file": null,
+        "title": "🗄️ Supabase Database Operations"
+      },
+      "259": {
+        "section_type": "testing_tier_strategy_updated",
+        "target_file": null,
+        "title": "Testing Tier Strategy (Updated)"
+      },
+      "262": {
+        "section_type": "quick-reference",
+        "target_file": null,
+        "title": "Database Workaround Anti-Patterns (NEVER DO THIS)"
+      },
+      "263": {
+        "section_type": "plan_presentation_template",
+        "target_file": null,
+        "title": "Pre-Implementation Plan Presentation Template"
+      },
+      "264": {
+        "section_type": "PHASE_2_PLANNING",
+        "target_file": null,
+        "title": "Deferred Work Management"
+      },
+      "265": {
+        "section_type": "guideline",
+        "target_file": null,
+        "title": "⚠️ Mandatory Process Scripts"
+      },
+      "266": {
+        "section_type": "exec_edge_case_testing_checklist",
+        "target_file": null,
+        "title": "Edge Case Testing Checklist"
+      },
+      "267": {
+        "section_type": "plan_visual_documentation_examples",
+        "target_file": null,
+        "title": "Visual Documentation Best Practices"
+      },
+      "269": {
+        "section_type": "knowledge_retrieval",
+        "target_file": null,
+        "title": "📚 Automated PRD Enrichment (MANDATORY)"
+      },
+      "270": {
+        "section_type": "execution_pattern",
+        "target_file": null,
+        "title": "Working with Child SDs (Execution Phase)"
+      },
+      "271": {
+        "section_type": "quick_fix_workflow",
+        "target_file": null,
+        "title": "🎯 LEO Quick-Fix Workflow"
+      },
+      "272": {
+        "section_type": "best_practice",
+        "target_file": null,
+        "title": "Scripts as Documentation-by-Example: Schema Validation"
+      },
+      "273": {
+        "section_type": "session_verification",
+        "target_file": null,
+        "title": "🔍 Session Start Verification (MANDATORY)"
+      },
+      "274": {
+        "section_type": "database_column_reference",
+        "target_file": null,
+        "title": "📊 Database Column Quick Reference"
+      },
+      "275": {
+        "section_type": "exec_requirement",
+        "target_file": null,
+        "title": "📦 Database-First Progress Tracking (MANDATORY)"
+      },
+      "276": {
+        "section_type": "lead_operations",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "SD to Quick Fix Reverse Rubric (LEO v4.3.3)"
+      },
+      "277": {
+        "section_type": "pattern_search_guide",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "🔍 Issue Pattern Search (Knowledge Base)"
+      },
+      "278": {
+        "section_type": "ui_parity_requirement",
+        "target_file": null,
+        "title": "🖥️ UI Parity Requirement (MANDATORY)"
+      },
+      "279": {
+        "section_type": "lead_strategic_validation_q7",
+        "target_file": null,
+        "title": "🔍 Strategic Validation Question 7: UI Inspectability"
+      },
+      "280": {
+        "section_type": "gate_2_5_human_inspectability",
+        "target_file": null,
+        "title": "🚪 Gate 2.5: Human Inspectability Validation"
+      },
+      "281": {
+        "section_type": "exec_ui_parity_verification",
+        "target_file": null,
+        "title": "✅ EXEC UI Parity Verification Checklist"
+      },
+      "282": {
+        "section_type": "stage_7_hard_block",
+        "target_file": null,
+        "title": "🚫 Stage 7 Hard Block: UI Coverage Prerequisite"
+      },
+      "284": {
+        "section_type": "branch_hygiene_gate",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "🌿 Branch Hygiene Gate (MANDATORY)"
+      },
+      "286": {
+        "section_type": "exec_completion_merge_requirement",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "🔀 SD/Quick-Fix Completion: Commit, Push, Merge"
+      },
+      "287": {
+        "section_type": "prd_research_lookup",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Research Lookup Before PRD Creation"
+      },
+      "288": {
+        "section_type": "skill_integration",
+        "target_file": null,
+        "title": "🎯 Skill Integration (Claude Code Skills)"
+      },
+      "289": {
+        "section_type": "builtin_agent_integration",
+        "target_file": null,
+        "title": "🤖 Built-in Agent Integration"
+      },
+      "290": {
+        "section_type": "lead_explore_integration",
+        "target_file": null,
+        "title": "🔍 Explore Before Validation (LEAD Phase)"
+      },
+      "291": {
+        "section_type": "plan_multi_perspective",
+        "target_file": null,
+        "title": "🎯 Multi-Perspective Planning"
+      },
+      "292": {
+        "section_type": "plan_verify_explore",
+        "target_file": null,
+        "title": "✅ Scope Verification with Explore (PLAN_VERIFY)"
+      },
+      "293": {
+        "section_type": "exec_skill_integration",
+        "target_file": null,
+        "title": "📚 Skill Integration (EXEC Phase)"
+      },
+      "294": {
+        "section_type": "common_commands",
+        "target_file": null,
+        "title": "Common Commands"
+      },
+      "295": {
+        "section_type": "parent_child_sd_governance",
+        "target_file": null,
+        "title": "Parent-Child SD Phase Governance"
+      },
+      "296": {
+        "section_type": "plan_test_infrastructure_gate",
+        "target_file": null,
+        "title": "🧪 Test Infrastructure Readiness Gate (Before PLAN→EXEC)"
+      },
+      "297": {
+        "section_type": "exec_retrospective_anti_patterns",
+        "target_file": null,
+        "title": "❌ Anti-Patterns from Retrospectives (EXEC Phase)"
+      },
+      "299": {
+        "section_type": "session_init",
+        "target_file": "CLAUDE.md",
+        "title": "Session Initialization - SD Selection"
+      },
+      "300": {
+        "section_type": "lead_operations",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "SD Orchestration & Baseline Management"
+      },
+      "301": {
+        "section_type": "multi_track_parallel_execution",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Multi-Track Parallel Execution"
+      },
+      "303": {
+        "section_type": "model_routing_guidance",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Sub-Agent Model Routing"
+      },
+      "305": {
+        "section_type": "multi_instance_coordination",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Multi-Instance Coordination (MANDATORY)"
+      },
+      "306": {
+        "section_type": "auto_merge_workflow",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Auto-Merge Workflow for SD Completion"
+      },
+      "307": {
+        "section_type": "mandatory_phase_transitions",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "🚫 MANDATORY: Phase Transition Commands (BLOCKING)"
+      },
+      "308": {
+        "section_type": "mandatory_phase_transitions_lead",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "🚫 MANDATORY: Phase Transition Commands (BLOCKING)"
+      },
+      "309": {
+        "section_type": "mandatory_phase_transitions_plan",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "🚫 MANDATORY: Phase Transition Commands (BLOCKING)"
+      },
+      "310": {
+        "section_type": "mandatory_phase_transitions_exec",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "🚫 MANDATORY: Phase Transition Commands (BLOCKING)"
+      },
+      "311": {
+        "section_type": "ai_quality_russian_judge",
+        "target_file": null,
+        "title": "AI-Powered Russian Judge Quality Assessment"
+      },
+      "312": {
+        "section_type": "handoff_quality_gates",
+        "target_file": null,
+        "title": "Quality Assessment Integration in Handoffs"
+      },
+      "315": {
+        "section_type": "parent_child_exec",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Working with Child SDs During EXEC"
+      },
+      "316": {
+        "section_type": "parent_child_lead",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Parent-Child Decomposition Approval"
+      },
+      "317": {
+        "section_type": "parent_child_overview",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Parent-Child SD Hierarchy"
+      },
+      "318": {
+        "section_type": "parent_child_plan",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Child SD Pattern: When to Decompose"
+      },
+      "320": {
+        "section_type": "handoffs",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Handoff Retrospectives"
+      },
+      "321": {
+        "section_type": "handoff_chain_diagram",
+        "target_file": null,
+        "title": "Mandatory 4-Step Handoff Chain"
+      },
+      "322": {
+        "section_type": "lesson_learned_capture",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Lesson Learned Capture (MANDATORY)"
+      },
+      "323": {
+        "section_type": "vision_v2_lead",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Vision V2 SD Handling (SD-VISION-V2-*)"
+      },
+      "324": {
+        "section_type": "vision_v2_plan",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Vision V2 PRD Requirements (SD-VISION-V2-*)"
+      },
+      "325": {
+        "section_type": "vision_v2_exec",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Vision V2 Implementation Requirements (SD-VISION-V2-*)"
+      },
+      "329": {
+        "section_type": "parent_child_validation",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Child SD Field Requirements for LEAD Evaluation"
+      },
+      "334": {
+        "section_type": "negative_constraints_global",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Global Negative Constraints"
+      },
+      "335": {
+        "section_type": "negative_constraints_plan",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "PLAN Phase Negative Constraints"
+      },
+      "336": {
+        "section_type": "negative_constraints_exec",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "EXEC Phase Negative Constraints"
+      },
+      "337": {
+        "section_type": "prd_template_scaffold",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "PRD Template Scaffolding"
+      },
+      "338": {
+        "section_type": "sd_type_workflow_paths",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "SD Type-Aware Workflow Paths"
+      },
+      "340": {
+        "section_type": "plan_to_exec_checklist",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "PLAN-TO-EXEC Checklist (MANDATORY)"
+      },
+      "341": {
+        "section_type": "negative_constraints_global",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Background Task Output Retrieval"
+      },
+      "342": {
+        "section_type": "quality_intelligence",
+        "target_file": null,
+        "title": "Quality Intelligence System (v4.3.4)"
+      },
+      "344": {
+        "section_type": "lead_operations",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Baseline Issues Management"
+      },
+      "345": {
+        "section_type": "docs-info-architecture",
+        "target_file": null,
+        "title": "Documentation Information Architecture"
+      },
+      "347": {
+        "section_type": "human_like_testing",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Human-Like E2E Testing Fixtures"
+      },
+      "349": {
+        "section_type": "work_tracking_policy",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Work Tracking Policy"
+      },
+      "351": {
+        "section_type": "mandatory_agent_invocation",
+        "target_file": "CLAUDE.md",
+        "title": "Mandatory Agent Invocation Rules"
+      },
+      "360": {
+        "section_type": "workflow",
+        "target_file": null,
+        "title": "Triangulated Runtime Audit Protocol"
+      },
+      "361": {
+        "section_type": "lead_refactor_evaluation",
+        "target_file": null,
+        "title": "Refactoring SD Evaluation"
+      },
+      "362": {
+        "section_type": "plan_refactor_brief_guide",
+        "target_file": null,
+        "title": "Refactor Brief Documentation"
+      },
+      "363": {
+        "section_type": "template",
+        "target_file": null,
+        "title": "Refactor Brief Template"
+      },
+      "364": {
+        "section_type": "genesis_codebase",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Genesis Codebase Locations"
+      },
+      "365": {
+        "section_type": "lead_strategic_validation_q9",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "🎯 Strategic Validation Question 9: Human-Verifiable Outcome"
+      },
+      "366": {
+        "section_type": "sustainable_issue_resolution",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Sustainable Issue Resolution Philosophy"
+      },
+      "369": {
+        "section_type": "workflow",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Branch Creation (Automated at LEAD-TO-PLAN)"
+      },
+      "370": {
+        "section_type": "workflow",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Branch Should Already Exist (LEO v4.4.1)"
+      },
+      "371": {
+        "section_type": "handoff_checklist",
+        "target_file": null,
+        "title": "Checklist Item 1"
+      },
+      "372": {
+        "section_type": "sub_agent_workflow",
+        "target_file": null,
+        "title": "Sub-Agent Trigger Guidance"
+      },
+      "375": {
+        "section_type": "reference",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Validation Rules (SD-LEARN-008)"
+      },
+      "376": {
+        "section_type": "plan_streams",
+        "target_file": null,
+        "title": "PLAN Phase Design & Architecture Streams"
+      },
+      "377": {
+        "section_type": "critical_term_definitions",
+        "target_file": null,
+        "title": "Critical Term Definitions"
+      },
+      "378": {
+        "section_type": "child_sd_preflight_validation",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Child SD Pre-Work Validation (MANDATORY)"
+      },
+      "384": {
+        "section_type": "infrastructure",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Claude Code Plan Mode Integration"
+      },
+      "388": {
+        "section_type": "sd_creation_process",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Strategic Directive Creation Process"
+      },
+      "389": {
+        "section_type": "sd_type_validation_requirements_deprecated",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "SD Type-Specific Validation Requirements"
+      },
+      "390": {
+        "section_type": "sd_creation_errors",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Common SD Creation Errors and Solutions"
+      },
+      "391": {
+        "section_type": "skill_intent_detection",
+        "target_file": "CLAUDE.md",
+        "title": "Skill Intent Detection (Proactive Invocation)"
+      },
+      "394": {
+        "section_type": "conditional_handoffs_deprecated",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "⚠️ Conditional Handoffs by SD Type (CRITICAL)"
+      },
+      "396": {
+        "section_type": "guidance",
+        "target_file": "CLAUDE.md",
+        "title": "Sub-Agent Database Recording"
+      },
+      "398": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-001: Human Approval Required"
+      },
+      "399": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-002: No Self-Approval"
+      },
+      "400": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-003: Audit Trail"
+      },
+      "401": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-004: Rollback Capability"
+      },
+      "402": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-005: Database First"
+      },
+      "403": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-006: Complexity Conservation"
+      },
+      "404": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-007: Velocity Limit"
+      },
+      "405": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-008: Chesterton's Fence"
+      },
+      "406": {
+        "section_type": "constitution",
+        "target_file": null,
+        "title": "CONST-009: Emergency Freeze"
+      },
+      "407": {
+        "section_type": "sd_creation_anti_pattern",
+        "target_file": null,
+        "title": "SD Creation Anti-Pattern (PROHIBITED)"
+      },
+      "408": {
+        "section_type": "prd_creation_anti_pattern",
+        "target_file": null,
+        "title": "PRD Creation Anti-Pattern (PROHIBITED)"
+      },
+      "409": {
+        "section_type": "script_anti_patterns",
+        "target_file": null,
+        "title": "Script Creation Anti-Patterns"
+      },
+      "410": {
+        "section_type": "sub_agent_config",
+        "target_file": "CLAUDE.md",
+        "title": "Database Sub-Agent Auto-Invocation"
+      },
+      "414": {
+        "section_type": "compaction_instructions",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Compaction Instructions (CRITICAL)"
+      },
+      "415": {
+        "section_type": "weighted_keyword_scoring",
+        "target_file": null,
+        "title": "Weighted Keyword Scoring System"
+      },
+      "416": {
+        "section_type": "auto_proceed_mode",
+        "target_file": null,
+        "title": "AUTO-PROCEED Mode"
+      },
+      "417": {
+        "section_type": "child_sd_context_loading",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Child SD Context Loading (MANDATORY)"
+      },
+      "419": {
+        "section_type": "strunkian_writing_standards",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Strunkian Writing Standards"
+      },
+      "420": {
+        "section_type": "orchestrator_chaining",
+        "target_file": "CLAUDE.md",
+        "title": "Orchestrator Chaining Mode"
+      },
+      "423": {
+        "section_type": "migration_script_pattern",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Migration Script Pattern (MANDATORY)"
+      },
+      "424": {
+        "section_type": "rca_issue_resolution_mandate",
+        "target_file": null,
+        "title": "RCA Issue Resolution Mandate"
+      },
+      "425": {
+        "section_type": "rca_multi_expert_protocol",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "RCA Multi-Expert Collaboration Protocol"
+      },
+      "428": {
+        "section_type": "work_item_routing",
+        "target_file": "CLAUDE.md",
+        "title": "Work Item Creation Routing"
+      },
+      "431": {
+        "section_type": "feature_documentation",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Feedback Quality Layer"
+      },
+      "434": {
+        "section_type": "migration_execution_delegation",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Migration Execution - DATABASE Sub-Agent Delegation"
+      },
+      "435": {
+        "section_type": "proposals",
+        "target_file": null,
+        "title": "Protocol Improvement Proposals"
+      },
+      "436": {
+        "section_type": "vetting",
+        "target_file": null,
+        "title": "Vetting Rules and Rubrics"
+      },
+      "439": {
+        "section_type": "sd_continuation_truth_table",
+        "target_file": "CLAUDE.md",
+        "title": "SD Continuation Truth Table"
+      },
+      "444": {
+        "section_type": "migration_execution_protocol",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Migration Execution Protocol"
+      },
+      "449": {
+        "section_type": "migration_execution_protocol_lead",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Migration Execution Protocol"
+      },
+      "450": {
+        "section_type": "migration_execution_protocol_plan",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Migration Execution Protocol"
+      },
+      "452": {
+        "section_type": "sd_recovery_protocol",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "SD Recovery Protocol (Limbo State Detection)"
+      },
+      "459": {
+        "section_type": "jsonb_validation_guidance",
+        "target_file": null,
+        "title": "JSONB Field Validation Guidance"
+      },
+      "460": {
+        "section_type": "infrastructure_exec_skip",
+        "target_file": null,
+        "title": "Infrastructure SD: EXEC-TO-PLAN Skip Conditions"
+      },
+      "461": {
+        "section_type": "enum_consistency_validation",
+        "target_file": null,
+        "title": "Enum Value Consistency Validation"
+      },
+      "462": {
+        "section_type": "env_var_migration_validation",
+        "target_file": null,
+        "title": "Environment Variable Validation for Migration Scripts"
+      },
+      "463": {
+        "section_type": "postgresql_immutability_constraints",
+        "target_file": null,
+        "title": "PostgreSQL Function Immutability Constraints for Index Creation"
+      },
+      "469": {
+        "section_type": "gate_exemption_visibility",
+        "target_file": null,
+        "title": "Gate Exemption Visibility During LEAD Approval"
+      },
+      "470": {
+        "section_type": "retroactive_compliance_procedure",
+        "target_file": null,
+        "title": "Retroactive LEO Protocol Compliance Procedure"
+      },
+      "471": {
+        "section_type": "jest_esm_testing_patterns",
+        "target_file": null,
+        "title": "Vitest ESM Testing Patterns Guide"
+      },
+      "472": {
+        "section_type": "branch_auto_checkout_guidance",
+        "target_file": null,
+        "title": "Branch Auto-Checkout After Creation in PLAN-TO-EXEC"
+      },
+      "473": {
+        "section_type": "prd_grounding_validation_guidance",
+        "target_file": null,
+        "title": "PRD Grounding Validation as Mandatory Pipeline Step"
+      },
+      "483": {
+        "section_type": "handoff_error_field_paths",
+        "target_file": null,
+        "title": "Handoff Validation Error Messages: Field Path Requirements"
+      },
+      "484": {
+        "section_type": "documentation_standards_validation",
+        "target_file": null,
+        "title": "Documentation Standards Compliance Gate"
+      },
+      "485": {
+        "section_type": "anti_pattern_impl_before_docs",
+        "target_file": null,
+        "title": "Anti-Pattern: Implementation Before Documentation"
+      },
+      "486": {
+        "section_type": "gate_bypass_audit_requirements",
+        "target_file": null,
+        "title": "Gate Bypass Audit Trail Requirements"
+      },
+      "492": {
+        "section_type": "stop_hook_context_awareness",
+        "target_file": null,
+        "title": "Stop Hook Context Awareness for Ad-Hoc Work"
+      },
+      "493": {
+        "section_type": "infrastructure_config_persistence",
+        "target_file": null,
+        "title": "Infrastructure Config File Persistence Through Hooks"
+      },
+      "494": {
+        "section_type": "sd_context_persistence_handoffs",
+        "target_file": null,
+        "title": "SD Context Persistence Across Handoff Boundaries"
+      },
+      "495": {
+        "section_type": "schema_validation_helper",
+        "target_file": null,
+        "title": "Schema Validation Helper for Database Queries"
+      },
+      "496": {
+        "section_type": "precommit_hook_edge_case_checklist",
+        "target_file": null,
+        "title": "Pre-commit Hook Edge Case Testing Checklist"
+      },
+      "497": {
+        "section_type": "sd_type_detection_keywords",
+        "target_file": null,
+        "title": "SD Type Detection - Extended Infrastructure Keywords"
+      },
+      "498": {
+        "section_type": "debate_circuit_breaker",
+        "target_file": null,
+        "title": "Debate Circuit Breaker Protocol"
+      },
+      "499": {
+        "section_type": "feature_flag_governance",
+        "target_file": null,
+        "title": "Feature Flag Governance Pattern"
+      },
+      "500": {
+        "section_type": "audit_logging_standards_mutations",
+        "target_file": null,
+        "title": "Audit Logging Standards for Database Mutations"
+      },
+      "501": {
+        "section_type": "judge_sub_agent_capabilities",
+        "target_file": null,
+        "title": "JUDGE Sub-Agent Capabilities"
+      },
+      "508": {
+        "section_type": "test_coverage_quality_gate",
+        "target_file": null,
+        "title": "Test Coverage Quality Gate (EXEC-TO-PLAN)"
+      },
+      "509": {
+        "section_type": "integration_test_requirement_gate",
+        "target_file": null,
+        "title": "Integration Test Requirement Gate (EXEC-TO-PLAN)"
+      },
+      "510": {
+        "section_type": "documentation_link_validation_gate",
+        "target_file": null,
+        "title": "Documentation Link Validation Gate (PLAN-TO-LEAD)"
+      },
+      "513": {
+        "section_type": "teams_protocol",
+        "target_file": "CLAUDE.md",
+        "title": "Teams Protocol"
+      },
+      "514": {
+        "section_type": "sub_agent_prompt_quality",
+        "target_file": null,
+        "title": "Sub-Agent Invocation Quality Standard"
+      },
+      "517": {
+        "section_type": "vision_heal_loop",
+        "target_file": null,
+        "title": "Vision Heal Loop (Auto-Continue)"
+      },
+      "518": {
+        "section_type": "governance_strategic_hierarchy",
+        "target_file": null,
+        "title": "Strategic Governance Hierarchy"
+      },
+      "519": {
+        "section_type": "governance_chairman_ceo_roles",
+        "target_file": null,
+        "title": "Chairman and CEO Governance Roles"
+      },
+      "520": {
+        "section_type": "governance_okr_alignment_lead",
+        "target_file": null,
+        "title": "OKR Alignment in LEAD Evaluation"
+      },
+      "521": {
+        "section_type": "governance_kr_linkage_plan",
+        "target_file": null,
+        "title": "KR Linkage in PRD Creation"
+      },
+      "522": {
+        "section_type": "governance_kr_progress_exec",
+        "target_file": null,
+        "title": "KR Progress Tracking in EXEC"
+      },
+      "524": {
+        "section_type": "reference",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "/batch Command Reference"
+      },
+      "525": {
+        "section_type": "plan_smoke_test_requirement",
+        "target_file": null,
+        "title": "Smoke Test Evidence Requirement (Pipeline/Integration SDs)"
+      },
+      "526": {
+        "section_type": "plan_failure_chain_ordering",
+        "target_file": null,
+        "title": "First-Failure-First Ordering (Pipeline Orchestrator SDs)"
+      },
+      "529": {
+        "section_type": "exec_acceptance_criteria_verification",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "User Story Acceptance Criteria Verification (MANDATORY)"
+      },
+      "531": {
+        "section_type": "ui_design_evaluation_process",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "UI Design Evaluation Process"
+      },
+      "538": {
+        "section_type": "sub_agent_routing_reference",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Sub-Agent Routing Reference"
+      },
+      "539": {
+        "section_type": "sub_agent_phase_guidance_lead",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Phase-Specific Sub-Agent Guidance: LEAD"
+      },
+      "540": {
+        "section_type": "sub_agent_phase_guidance_plan",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Phase-Specific Sub-Agent Guidance: PLAN"
+      },
+      "541": {
+        "section_type": "sub_agent_phase_guidance_exec",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Phase-Specific Sub-Agent Guidance: EXEC"
+      },
+      "544": {
+        "section_type": "handoff_precheck",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Handoff Precheck Command"
+      },
+      "545": {
+        "section_type": "handoff_precheck",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Handoff Precheck Command"
+      },
+      "549": {
+        "section_type": "cascade_invalidation_system",
+        "target_file": null,
+        "title": "Cascade Invalidation System"
+      },
+      "550": {
+        "section_type": "cascade_invalidation_plan",
+        "target_file": null,
+        "title": "Cascade Invalidation — PLAN Phase Guidance"
+      },
+      "555": {
+        "section_type": "db_ops_protocol",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "DB Ops Protocol (Common Pitfalls)"
+      },
+      "556": {
+        "section_type": "gate_failure_protocol",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Gate Failure Protocol"
+      },
+      "557": {
+        "section_type": "vision_arch_doc_check",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Vision/Architecture Doc Pre-Check"
+      },
+      "558": {
+        "section_type": "pipeline_debugging_protocol",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Pipeline Debugging Protocol"
+      },
+      "562": {
+        "section_type": "skill",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "LEO Settings Skill"
+      },
+      "563": {
+        "section_type": "skill",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "LEO Resume Skill"
+      },
+      "565": {
+        "section_type": "multi_repo_sd_verification",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Multi-Repo SD Verification"
+      },
+      "567": {
+        "section_type": "auto_proceed_router",
+        "target_file": "CLAUDE.md",
+        "title": "AUTO-PROCEED Mode"
+      },
+      "570": {
+        "section_type": "prd_creation_anti_pattern",
+        "target_file": "CLAUDE.md",
+        "title": "PRD Creation — Inline Mode is the Default for Claude Code"
+      },
+      "573": {
+        "section_type": "directive",
+        "target_file": "CLAUDE.md",
+        "title": "HANDOFF_POST_ACTION Directive Parsing"
+      },
+      "574": {
+        "section_type": "claim_heartbeat_protocol",
+        "target_file": null,
+        "title": "Claim Heartbeat Protocol"
+      },
+      "575": {
+        "section_type": "code_quality_pre_commit",
+        "target_file": null,
+        "title": "Code Quality Pre-Commit Check"
+      },
+      "576": {
+        "section_type": "protocol_lint_tooling",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Protocol Consistency Linter"
+      },
+      "577": {
+        "section_type": "qf_lifecycle_reconciliation",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "QF Lifecycle Reconciliation"
+      },
+      "580": {
+        "section_type": "gate_retrospective_invariants",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Retrospective-Gate Invariants"
+      },
+      "584": {
+        "section_type": "lead_anti_pattern_confirmation_fishing",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Anti-Pattern: Confirmation-Fishing at Scope-Lock"
+      },
+      "589": {
+        "section_type": "queue_ranking_unified",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Queue Ranking and QF Track Inference"
+      },
+      "590": {
+        "section_type": "reference",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "PRD metadata.db_content_assertions field guide"
+      },
+      "592": {
+        "section_type": "signaling_friction",
+        "target_file": "CLAUDE_CORE.md",
+        "title": "Signaling friction to the coordinator"
+      },
+      "593": {
+        "section_type": "lead_testing_agent_harness_fix_cadence",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Default Sub-Agent Invocation Cadence for Harness-Fix SDs"
+      },
+      "594": {
+        "section_type": "plan_keyword_list_substring_audit",
+        "target_file": "CLAUDE_PLAN.md",
+        "title": "Substring-Redundancy Audit for Keyword-List Expansions"
+      },
+      "595": {
+        "section_type": "exec_atomic_insert_writer_consumer_pattern",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Atomic INSERT Pattern for Writer/Consumer Asymmetry Fixes"
+      },
+      "596": {
+        "section_type": "signaling_friction_pointer_phase",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Friction signaling"
+      },
+      "597": {
+        "section_type": "signaling_friction_pointer_digest",
+        "target_file": "CLAUDE_CORE_DIGEST.md",
+        "title": "Friction signaling"
+      },
+      "599": {
+        "section_type": "venture_lifecycle_pipeline",
+        "target_file": "CLAUDE_LEAD.md",
+        "title": "Venture Lifecycle Pipeline"
+      },
+      "601": {
+        "section_type": "adam_role_contract",
+        "target_file": "CLAUDE_ADAM.md",
+        "title": "Adam Role Contract — Chairman-Attached Advisory/Analysis Session"
+      },
+      "602": {
+        "section_type": "adam_self_adherence_loop",
+        "target_file": "CLAUDE_ADAM.md",
+        "title": "Adam Self-Adherence Loop (recurring audit + propose-only remediation)"
+      },
+      "603": {
+        "section_type": "fleet_worker_loop_continuity",
+        "target_file": "CLAUDE_EXEC.md",
+        "title": "Loop Continuity / Never-Exit (Fleet Worker Contract)"
+      }
     }
   }
 }

--- a/scripts/__tests__/check-claude-md-drift.test.js
+++ b/scripts/__tests__/check-claude-md-drift.test.js
@@ -1,0 +1,148 @@
+// SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-6): tests for the drift guard.
+// Unit tier (no DB): exercises the PURE pieces — computeSectionDigests (the content-aware
+// digest), diffSectionDigests (the comparison), renderFileContent (FR-5 banner), and the
+// getFileSpecs single-source file list. The live-DB path (computeDrift) is covered by the
+// SD's smoke_test_steps.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  CLAUDEMDGeneratorV3,
+  KNOWN_GENERATED_FILES,
+  computeSectionDigests,
+  GENERATED_BANNER,
+} from '../modules/claude-md-generator/index.js';
+
+const require = createRequire(import.meta.url);
+const { diffSectionDigests } = require(path.resolve(__dirname, '../check-claude-md-drift.cjs'));
+
+const SECTIONS = [
+  { id: 1, section_type: 'core_a', title: 'Core A', content: 'alpha', order_index: 1, target_file: 'CLAUDE_CORE.md', context_tier: 'CORE', updated_at: '2026-01-01' },
+  { id: 2, section_type: 'lead_b', title: 'Lead B', content: 'beta', order_index: 2, target_file: 'CLAUDE_LEAD.md', context_tier: 'PHASE_LEAD', updated_at: '2026-01-01' },
+];
+
+describe('computeSectionDigests (FR-1 — content-aware, churn-immune)', () => {
+  it('is deterministic for identical input (no false positive on re-run / timestamp churn)', () => {
+    expect(computeSectionDigests(SECTIONS)).toEqual(computeSectionDigests(SECTIONS));
+  });
+
+  it('changes the per-section hash when section CONTENT changes (caught — unlike the coarse count hash)', () => {
+    const a = computeSectionDigests(SECTIONS);
+    const edited = SECTIONS.map((s) => (s.id === 1 ? { ...s, content: 'ALPHA-edited' } : s));
+    const b = computeSectionDigests(edited);
+    expect(b.byId['1']).not.toBe(a.byId['1']);
+    expect(b.byId['2']).toBe(a.byId['2']); // untouched section stays stable
+    expect(b.global).not.toBe(a.global);
+  });
+
+  it('IGNORES non-rendered fields (updated_at/created_at/context_tier/target_file column) — no false-positive drift', () => {
+    // context_tier and the target_file COLUMN are not rendered (placement is keyed off
+    // section_type via the mapping), so changing them must NOT register as drift.
+    const a = computeSectionDigests(SECTIONS);
+    const churned = SECTIONS.map((s) => ({ ...s, updated_at: '2099-12-31', created_at: 'whenever', context_tier: 'TOTALLY-DIFFERENT', target_file: 'CLAUDE_ELSEWHERE.md' }));
+    const b = computeSectionDigests(churned);
+    expect(b.byId).toEqual(a.byId); // content digests unchanged
+    expect(b.global).toBe(a.global); // render-order signature unchanged
+  });
+
+  it('DOES change the per-section hash when order_index changes (order is rendered)', () => {
+    const a = computeSectionDigests(SECTIONS);
+    const b = computeSectionDigests(SECTIONS.map((s) => (s.id === 1 ? { ...s, order_index: 99 } : s)));
+    expect(b.byId['1']).not.toBe(a.byId['1']);
+  });
+
+  it('flips the global hash on a PURE REORDER (same content, swapped render order)', () => {
+    const a = computeSectionDigests(SECTIONS); // order [1,2]
+    const b = computeSectionDigests([SECTIONS[1], SECTIONS[0]]); // order [2,1], identical content
+    expect(b.byId).toEqual(a.byId); // per-section content unchanged
+    expect(b.global).not.toBe(a.global); // but the render-order signature changed
+  });
+
+  it('records target_file + title in meta for stale-file attribution', () => {
+    const d = computeSectionDigests(SECTIONS);
+    expect(d.meta['1'].target_file).toBe('CLAUDE_CORE.md');
+    expect(d.meta['1'].title).toBe('Core A');
+  });
+
+  it('handles empty / null sections without throwing', () => {
+    expect(() => computeSectionDigests([])).not.toThrow();
+    expect(() => computeSectionDigests(null)).not.toThrow();
+    expect(computeSectionDigests([]).byId).toEqual({});
+  });
+});
+
+describe('diffSectionDigests (FR-1 — pure comparison)', () => {
+  it('reports NO drift when live === stored (clean)', () => {
+    const d = computeSectionDigests(SECTIONS);
+    const r = diffSectionDigests(d, d);
+    expect(r.drift).toBe(false);
+    expect(r.changed).toHaveLength(0);
+    expect(r.added).toHaveLength(0);
+    expect(r.removed).toHaveLength(0);
+    expect(r.globalMatch).toBe(true);
+  });
+
+  it('flags a PURE REORDER as drift via globalMatch (the FR-1 false-negative the review caught)', () => {
+    const stored = computeSectionDigests(SECTIONS); // order [1,2]
+    const live = computeSectionDigests([SECTIONS[1], SECTIONS[0]]); // order [2,1], same content
+    const r = diffSectionDigests(live, stored);
+    expect(r.changed).toHaveLength(0);
+    expect(r.added).toHaveLength(0);
+    expect(r.removed).toHaveLength(0);
+    expect(r.globalMatch).toBe(false);
+    expect(r.orderChanged).toBe(true);
+    expect(r.drift).toBe(true); // reorder IS drift
+  });
+
+  it('detects changed + added + removed and names the stale files', () => {
+    const stored = computeSectionDigests(SECTIONS);
+    const live = computeSectionDigests([
+      { ...SECTIONS[0], content: 'edited' }, // #1 changed
+      // #2 dropped -> removed
+      { id: 3, section_type: 'exec_c', title: 'Exec C', content: 'gamma', order_index: 3, target_file: 'CLAUDE_EXEC.md', context_tier: 'PHASE_EXEC' }, // #3 added
+    ]);
+    const r = diffSectionDigests(live, stored);
+    expect(r.drift).toBe(true);
+    expect(r.changed.map((c) => c.id)).toEqual(['1']);
+    expect(r.added.map((c) => c.id)).toEqual(['3']);
+    expect(r.removed.map((c) => c.id)).toEqual(['2']);
+    expect(r.staleFiles).toEqual(expect.arrayContaining(['CLAUDE_CORE.md', 'CLAUDE_EXEC.md', 'CLAUDE_LEAD.md']));
+  });
+});
+
+describe('CLAUDEMDGeneratorV3.renderFileContent (FR-5 banner + FR-1b shared render path)', () => {
+  const gen = new CLAUDEMDGeneratorV3(null, '/tmp', '/tmp/section-file-mapping.json', {});
+
+  it('injects the GENERATED DO-NOT-EDIT banner and a real file_content_hash', () => {
+    const out = gen.renderFileContent(() => '# Heading\nbody', {});
+    expect(out).toContain('GENERATED FILE - DO NOT EDIT DIRECTLY');
+    expect(out).toMatch(/<!-- file_content_hash: [0-9a-f]{16} -->/);
+  });
+
+  it('does NOT double the banner when content already starts with it (idempotent)', () => {
+    const out = gen.renderFileContent(() => `${GENERATED_BANNER}\n# Heading\nbody`, {});
+    const count = (out.match(/GENERATED FILE - DO NOT EDIT DIRECTLY/g) || []).length;
+    expect(count).toBe(1);
+  });
+
+  it('is deterministic for identical content (no timestamp in the render path => no drift false-positive)', () => {
+    const fn = () => '# Heading\nstable body';
+    expect(gen.renderFileContent(fn, {})).toBe(gen.renderFileContent(fn, {}));
+  });
+});
+
+describe('getFileSpecs single-source list (FR-1b — write path == render path coverage)', () => {
+  it('returns EXACTLY KNOWN_GENERATED_FILES when digests enabled (guards a forgotten file)', () => {
+    const gen = new CLAUDEMDGeneratorV3(null, '/tmp', '/tmp/section-file-mapping.json', { generateDigest: true });
+    const names = gen.getFileSpecs({}).map(([f]) => f);
+    expect(new Set(names)).toEqual(new Set(KNOWN_GENERATED_FILES));
+    expect(names).toHaveLength(KNOWN_GENERATED_FILES.length);
+  });
+
+  it('omits digest files when generateDigest is false', () => {
+    const gen = new CLAUDEMDGeneratorV3(null, '/tmp', '/tmp/section-file-mapping.json', { generateDigest: false });
+    const names = gen.getFileSpecs({}).map(([f]) => f);
+    expect(names.every((n) => !n.includes('DIGEST'))).toBe(true);
+    expect(names).toContain('CLAUDE.md');
+  });
+});

--- a/scripts/check-claude-md-drift.cjs
+++ b/scripts/check-claude-md-drift.cjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 — FR-1: deterministic CLAUDE_*.md drift-check
+ * primitive (content-aware per-section digest).
+ *
+ * The generated CLAUDE_*.md family is produced from the leo_protocol_sections DB table by
+ * scripts/generate-claude-md-from-db.js. Nothing detected when a section's CONTENT changed in
+ * the DB but the files were not regenerated+committed, so every session could silently load
+ * stale protocol prose.
+ *
+ * WHY A SECTION DIGEST (not a render-diff, not the db_snapshot_hash):
+ *  - The generator's db_snapshot_hash hashes section COUNT (+ subagent count + telemetry
+ *    hashes), NOT section content — a content edit to an existing section is invisible to it.
+ *  - The rendered CLAUDE_*.md files embed VOLATILE live telemetry (hotPatterns, gateHealth,
+ *    recentRetrospectives, pendingProposals, frictionPoints, visionGaps) + Generated
+ *    timestamps, which churn independently of protocol content — so a regenerate-and-diff of
+ *    the rendered files is false-positive-prone (it would report "drift" every time a gate
+ *    runs). Verified live 2026-06-14.
+ *  - The actionable drift is: a leo_protocol_sections row's CONTENT changed but the docs were
+ *    not regenerated. computeSectionDigests() (in the generator module, the SINGLE source of
+ *    the hashing logic) hashes only the stable rendering fields and is written to the manifest
+ *    at generation time. This primitive recomputes it from the live DB and compares.
+ *
+ * Exit codes: 0 = clean, 1 = DRIFT (stale sections/files named), 2 = internal error (callers
+ * should fail-open on 2 — a DB/infra blip must never block a commit or a session).
+ *
+ * Reused by: FR-2 pre-commit gate, FR-3 SessionStart warning, FR-4a CI PR check.
+ */
+const path = require('path');
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+
+// Best-effort env load (cwd .env). In worker sessions / CI the env is already injected;
+// if SUPABASE creds are absent computeDrift() throws and the caller fail-opens (exit 2).
+try { require('dotenv').config(); } catch { /* dotenv optional */ }
+
+const SCRIPTS_DIR = __dirname;
+const REPO_ROOT = path.join(__dirname, '..');
+const GENERATOR_URL = pathToFileURL(path.join(SCRIPTS_DIR, 'modules', 'claude-md-generator', 'index.js')).href;
+const DBQ_URL = pathToFileURL(path.join(SCRIPTS_DIR, 'modules', 'claude-md-generator', 'db-queries.js')).href;
+const manifestPathFor = (baseDir) => path.join(baseDir, 'claude-generation-manifest.json');
+
+/**
+ * Pure comparison of two section-digest maps (live DB vs manifest). No I/O, no DB —
+ * unit-testable in isolation.
+ * @param {{ byId:Object, meta?:Object, global?:string }} live
+ * @param {{ byId:Object, meta?:Object, global?:string }} stored
+ * @returns {{ drift:boolean, changed:Array, added:Array, removed:Array, staleFiles:string[], globalMatch:boolean }}
+ */
+function diffSectionDigests(live, stored) {
+  const liveSet = new Set(Object.keys(live.byId || {}));
+  const storedSet = new Set(Object.keys(stored.byId || {}));
+  const changed = [];
+  const added = [];
+  const removed = [];
+  for (const id of liveSet) {
+    if (!storedSet.has(id)) added.push(id);
+    else if (live.byId[id] !== stored.byId[id]) changed.push(id);
+  }
+  for (const id of storedSet) if (!liveSet.has(id)) removed.push(id);
+
+  const staleFiles = new Set();
+  const describe = (id, metaSource) => {
+    const m = (metaSource && metaSource[id]) || {};
+    if (m.target_file) staleFiles.add(m.target_file);
+    return { id, section_type: m.section_type || null, target_file: m.target_file || null, title: m.title || null };
+  };
+  const changedD = changed.map((id) => describe(id, live.meta));
+  const addedD = added.map((id) => describe(id, live.meta));
+  const removedD = removed.map((id) => describe(id, stored.meta));
+  const globalMatch = (live.global || null) === (stored.global || null);
+  const contentDrift = changed.length + added.length + removed.length > 0;
+  // A pure REORDER (same sections + content, different render order) leaves byId untouched but
+  // flips the render-order `global` hash — still real drift (the rendered bytes differ).
+  const orderChanged = !globalMatch && !contentDrift;
+  return {
+    drift: contentDrift || !globalMatch,
+    changed: changedD,
+    added: addedD,
+    removed: removedD,
+    staleFiles: [...staleFiles],
+    globalMatch,
+    orderChanged,
+  };
+}
+
+/**
+ * Compare the live leo_protocol_sections content digests against the digests stored in
+ * claude-generation-manifest.json at the last generation.
+ * @param {{ baseDir?: string }} [opts] baseDir defaults to the repo root that owns this script.
+ * @returns {Promise<{ status:string, drift:boolean, changed:Array, added:Array, removed:Array, staleFiles:string[], note?:string }>}
+ */
+async function computeDrift({ baseDir = REPO_ROOT } = {}) {
+  const { createClient } = require('@supabase/supabase-js');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — cannot read leo_protocol_sections');
+  }
+  const supabase = createClient(url, key);
+
+  const { computeSectionDigests } = await import(GENERATOR_URL);
+  const { getActiveProtocol } = await import(DBQ_URL);
+
+  const protocol = await getActiveProtocol(supabase);
+  const live = computeSectionDigests(protocol.sections);
+
+  const manifestPath = manifestPathFor(baseDir);
+  if (!fs.existsSync(manifestPath)) {
+    return { status: 'no_manifest', drift: true, changed: [], added: [], removed: [], staleFiles: [], note: 'claude-generation-manifest.json missing — run the generator' };
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch {
+    return { status: 'bad_manifest', drift: true, changed: [], added: [], removed: [], staleFiles: [], note: 'manifest unparseable — regenerate' };
+  }
+
+  const stored = manifest.section_digests;
+  if (!stored || !stored.byId) {
+    return { status: 'no_section_digests', drift: true, changed: [], added: [], removed: [], staleFiles: [], note: 'manifest predates the drift guard (no section_digests) — regenerate to enable drift tracking' };
+  }
+
+  return { status: 'ok', ...diffSectionDigests(live, stored) };
+}
+
+async function main() {
+  try {
+    const r = await computeDrift();
+    if (!r.drift) {
+      console.log('OK no drift — generated CLAUDE_*.md match leo_protocol_sections (section digests aligned)');
+      process.exit(0);
+    }
+    console.error('DRIFT generated protocol docs are STALE vs leo_protocol_sections.');
+    if (r.note) console.error('   ' + r.note);
+    const fmt = (d) => `${d.title || d.section_type || d.id}${d.target_file ? ' -> ' + d.target_file : ''}`;
+    if (r.changed.length) { console.error(`   Changed sections (${r.changed.length}):`); r.changed.forEach((d) => console.error('     ~ ' + fmt(d))); }
+    if (r.added.length) { console.error(`   New sections (${r.added.length}):`); r.added.forEach((d) => console.error('     + ' + fmt(d))); }
+    if (r.removed.length) { console.error(`   Removed sections (${r.removed.length}):`); r.removed.forEach((d) => console.error('     - ' + fmt(d))); }
+    if (r.orderChanged) console.error('   Section ORDER changed (same content, different render order) — rendered output differs.');
+    if (r.staleFiles.length) console.error('   Stale files: ' + r.staleFiles.join(', '));
+    console.error('\n   Fix: node scripts/generate-claude-md-from-db.js   (then commit the regenerated files)');
+    process.exit(1);
+  } catch (err) {
+    console.error(`check-claude-md-drift: INTERNAL ERROR (fail-open) — ${err && err.message}`);
+    process.exit(2);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { computeDrift, diffSectionDigests };

--- a/scripts/hooks/pre-commit-claude-md-drift.cjs
+++ b/scripts/hooks/pre-commit-claude-md-drift.cjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-2): pre-commit source gate.
+ *
+ * Blocks a commit that STAGES changes to the generated-doc family (CLAUDE_*.md, the manifest,
+ * the generator, or the section mapping) while those committed docs have drifted from the live
+ * leo_protocol_sections DB — i.e. a partial / stale regeneration. This stops drift from reaching
+ * main at the change. CI (FR-4a) is the un-bypassable backstop; this is the fast local catch.
+ *
+ * Scoped: only runs the (DB-touching) drift check when the commit actually touches the
+ * generated-doc family, so unrelated commits pay no cost and are never blocked by ambient drift.
+ * Fail-open: any inability to determine drift (no DB creds, transient error, missing primitive)
+ * exits 0. Override with LEO_DOC_DRIFT_GATE=off.
+ *
+ * Exit: 0 = allow, 1 = block (real drift on a doc-family commit).
+ */
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+
+const TRIGGER = [
+  /^CLAUDE[^/]*\.md$/,
+  /^claude-generation-manifest\.json$/,
+  /^scripts\/generate-claude-md-from-db\.js$/,
+  /^scripts\/check-claude-md-drift\.cjs$/,
+  /^scripts\/modules\/claude-md-generator\//,
+  /^scripts\/section-file-mapping.*\.json$/,
+];
+
+async function run() {
+  if (String(process.env.LEO_DOC_DRIFT_GATE || '').toLowerCase() === 'off') return 0;
+
+  let staged = [];
+  try {
+    staged = execSync('git diff --cached --name-only', { encoding: 'utf8' }).split(/\r?\n/).filter(Boolean);
+  } catch {
+    return 0; // cannot list staged files → fail-open
+  }
+  const relevant = staged.some((f) => TRIGGER.some((re) => re.test(f)));
+  if (!relevant) return 0; // commit does not touch the generated-doc family — skip (no DB call)
+
+  let computeDrift;
+  try {
+    ({ computeDrift } = require(path.join(__dirname, '..', 'check-claude-md-drift.cjs')));
+  } catch {
+    return 0; // drift primitive unavailable → fail-open
+  }
+
+  let r;
+  try {
+    r = await computeDrift();
+  } catch {
+    return 0; // DB / infra error → fail-open (never block a commit on infra)
+  }
+
+  if (r && r.drift) {
+    const n = (r.changed?.length || 0) + (r.added?.length || 0) + (r.removed?.length || 0);
+    const files = (r.staleFiles || []).filter(Boolean).join(', ');
+    console.error('');
+    console.error('BLOCKED: CLAUDE_*.md drift vs leo_protocol_sections (FR-2 source gate)');
+    console.error(`   ${n} section change(s) not regenerated${files ? ` — stale: ${files}` : ''}.`);
+    console.error('   Fix: node scripts/generate-claude-md-from-db.js   (then stage the regenerated files + recommit)');
+    console.error('   Override (rare/infra): LEO_DOC_DRIFT_GATE=off git commit ...');
+    console.error('');
+    return 1;
+  }
+  return 0;
+}
+
+run()
+  .then((code) => process.exit(code))
+  .catch(() => process.exit(0)); // belt-and-suspenders fail-open

--- a/scripts/hooks/session-doc-drift-warn.cjs
+++ b/scripts/hooks/session-doc-drift-warn.cjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-3): SessionStart stale-docs warning.
+ *
+ * Warns (does NOT block) when the generated CLAUDE_*.md family is stale vs the
+ * leo_protocol_sections DB — turning the CLAUDE.md "version check / if stale, regenerate"
+ * step into a real, automated detector. Silent when clean.
+ *
+ * Hard contract: FAIL-OPEN. This hook must never block, hang, or pollute session start —
+ * any error (missing DB creds, transient failure, timeout) is swallowed and it exits 0.
+ * Gated by LEO_DOC_DRIFT_WARN (default ON; set to 'off' to silence).
+ */
+const path = require('node:path');
+
+async function run() {
+  if (String(process.env.LEO_DOC_DRIFT_WARN || '').toLowerCase() === 'off') return;
+
+  const projectDir = process.env.CLAUDE_PROJECT_DIR || path.join(__dirname, '..', '..');
+  const { computeDrift } = require(path.join(projectDir, 'scripts', 'check-claude-md-drift.cjs'));
+
+  // Time-box the DB round-trip so a slow/hanging query never delays session start.
+  const withTimeout = (p, ms) => Promise.race([
+    p,
+    new Promise((_, reject) => { const t = setTimeout(() => reject(new Error('drift-check timeout')), ms); if (t.unref) t.unref(); }),
+  ]);
+
+  const r = await withTimeout(computeDrift({ baseDir: projectDir }), 8000);
+  if (r && r.drift) {
+    const n = (r.changed?.length || 0) + (r.added?.length || 0) + (r.removed?.length || 0);
+    const files = (r.staleFiles || []).filter(Boolean).join(', ');
+    console.log(
+      `[PROTOCOL DRIFT] ${n} leo_protocol_sections change(s) not regenerated — generated CLAUDE_*.md are STALE` +
+      `${files ? ` (${files})` : ''}. Fix: node scripts/generate-claude-md-from-db.js`
+    );
+  }
+}
+
+run()
+  .catch(() => { /* fail-open: a drift-check failure must never disrupt session start */ })
+  .finally(() => process.exit(0));

--- a/scripts/modules/claude-md-generator/db-queries.js
+++ b/scripts/modules/claude-md-generator/db-queries.js
@@ -23,7 +23,14 @@ async function getActiveProtocol(supabase) {
     .from('leo_protocol_sections')
     .select('*')
     .eq('protocol_id', data.id)
-    .order('order_index');
+    // SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1): deterministic secondary sort.
+    // Without an `id` tiebreak, Postgres returns rows that share an order_index in an
+    // UNSPECIFIED order, so the rendered CLAUDE_*.md byte-order for a tied group could
+    // shuffle (table rewrite / VACUUM / plan change) with no DB content change — making the
+    // generated docs non-deterministic AND invisible to the per-section drift digest. The
+    // tiebreak pins a stable render order so the digest faithfully tracks rendered output.
+    .order('order_index')
+    .order('id');
 
   data.sections = sections || [];
   return data;

--- a/scripts/modules/claude-md-generator/index.js
+++ b/scripts/modules/claude-md-generator/index.js
@@ -46,6 +46,12 @@ import {
   generateAdamDigest
 } from './digest-generators.js';
 
+// SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-5): every generated file carries a
+// prominent DO-NOT-edit banner. It is DETERMINISTIC (no timestamp), so it is identically
+// present in both the in-memory render and the on-disk file and never causes a drift
+// false-positive. Pure ASCII to keep the byte-comparison encoding-stable.
+export const GENERATED_BANNER = '<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->';
+
 /**
  * CLAUDE.md Generator V3 - Modular Architecture with Dual Generation
  *
@@ -147,6 +153,144 @@ class CLAUDEMDGeneratorV3 {
   }
 
   /**
+   * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1b): the single ordered list of every
+   * generated file and its generator fn. generate() (write path) and renderAll() (the
+   * drift-check render path) BOTH iterate this — ONE source of truth, never a divergent
+   * re-derivation. Digest files are included only when generateDigest is enabled.
+   * @param {Object} digestMetadata - { generatedAt, gitCommit, dbSnapshotHash }
+   * @returns {Array<[string, Function, string]>} [filename, generatorFn, type]
+   */
+  getFileSpecs(digestMetadata) {
+    const specs = [
+      ['CLAUDE.md', (d) => generateRouter(d, this.fileMapping), 'full'],
+      ['CLAUDE_CORE.md', (d) => generateCore(d, this.fileMapping), 'full'],
+      ['CLAUDE_LEAD.md', (d) => generateLead(d, this.fileMapping), 'full'],
+      ['CLAUDE_PLAN.md', (d) => generatePlan(d, this.fileMapping), 'full'],
+      ['CLAUDE_EXEC.md', (d) => generateExec(d, this.fileMapping), 'full'],
+      ['CLAUDE_ADAM.md', (d) => generateAdam(d, this.fileMapping), 'full'],
+    ];
+    if (this.options.generateDigest) {
+      specs.push(
+        ['CLAUDE_DIGEST.md', (d) => generateRouterDigest(d, this.digestMapping, digestMetadata), 'digest'],
+        ['CLAUDE_CORE_DIGEST.md', (d) => generateCoreDigest(d, this.digestMapping, digestMetadata), 'digest'],
+        ['CLAUDE_LEAD_DIGEST.md', (d) => generateLeadDigest(d, this.digestMapping, digestMetadata), 'digest'],
+        ['CLAUDE_PLAN_DIGEST.md', (d) => generatePlanDigest(d, this.digestMapping, digestMetadata), 'digest'],
+        ['CLAUDE_EXEC_DIGEST.md', (d) => generateExecDigest(d, this.digestMapping, digestMetadata), 'digest'],
+        ['CLAUDE_ADAM_DIGEST.md', (d) => generateAdamDigest(d, this.digestMapping, digestMetadata), 'digest'],
+      );
+    }
+    return specs;
+  }
+
+  /**
+   * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1b): load every DB input + init the
+   * manifest header (generated_at / git_commit / db_snapshot_hash) and the digest metadata.
+   * Extracted from generate() so renderAll() (the drift check) consumes IDENTICAL inputs
+   * without re-deriving the fetches.
+   * @returns {Promise<{ data: Object, digestMetadata: Object, protocol: Object }>}
+   */
+  async loadData() {
+    this.loadMappings();
+
+    // Fetch all data from database
+    const protocol = await getActiveProtocol(this.supabase);
+    const agents = await getAgents(this.supabase);
+    const subAgents = await getSubAgents(this.supabase);
+    const handoffTemplates = await getHandoffTemplates(this.supabase);
+    const validationRules = await getValidationRules(this.supabase);
+    const schemaConstraints = await getSchemaConstraints(this.supabase);
+    const processScripts = await getProcessScripts(this.supabase);
+    const hotPatterns = await getHotPatterns(this.supabase, 5);
+    // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-4b: known friction points from worker /signal aggregation
+    const knownFrictionPoints = await getKnownFrictionPoints(this.supabase, 5);
+    const recentRetrospectives = await getRecentRetrospectives(this.supabase, 30, 5);
+    const gateHealth = await getGateHealth(this.supabase);
+    const pendingProposals = await getPendingProposals(this.supabase, 5);
+    const autonomousDirectives = await getAutonomousDirectives(this.supabase);
+    // SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001: live VGAP data for protocol injection
+    const visionGapInsights = await getVisionGapInsights(this.supabase, 3);
+
+    const data = {
+      protocol,
+      agents,
+      subAgents,
+      handoffTemplates,
+      validationRules,
+      schemaConstraints,
+      processScripts,
+      hotPatterns,
+      knownFrictionPoints,
+      recentRetrospectives,
+      gateHealth,
+      pendingProposals,
+      autonomousDirectives,
+      visionGapInsights
+    };
+
+    // Initialize manifest header
+    this.manifest.generated_at = new Date().toISOString();
+    this.manifest.git_commit = this.getGitCommit();
+    this.manifest.db_snapshot_hash = this.computeDbSnapshotHash(data);
+    // SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1): persist per-section content digests
+    // so the drift check can detect a section CONTENT edit (which the coarse db_snapshot_hash,
+    // a count-only hash, misses) WITHOUT false positives from rendered-file telemetry/timestamps.
+    this.manifest.section_digests = computeSectionDigests(protocol.sections);
+
+    // Metadata for digest headers
+    const digestMetadata = {
+      generatedAt: this.manifest.generated_at,
+      gitCommit: this.manifest.git_commit,
+      dbSnapshotHash: this.manifest.db_snapshot_hash
+    };
+
+    return { data, digestMetadata, protocol };
+  }
+
+  /**
+   * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1b): pure render of one file's FINAL
+   * content (FR-5 banner + file_content_hash injected), with NO disk write and NO manifest
+   * mutation. generateFile() calls this then writes; renderAll() calls this and compares.
+   * One render path => the drift check can never diverge from what is actually written.
+   * @returns {string} final content, identical to what generateFile() writes
+   */
+  renderFileContent(generatorFn, data) {
+    let content = generatorFn(data);
+
+    // FR-5: prepend the deterministic GENERATED banner (idempotent).
+    if (!content.startsWith(GENERATED_BANNER)) {
+      content = `${GENERATED_BANNER}\n${content}`;
+    }
+
+    // file_content_hash: body = content minus the hash line; header = sha256(body)[:16].
+    const HASH_LINE_RE = /^<!-- file_content_hash: [^>]*-->\r?\n/m;
+    if (HASH_LINE_RE.test(content)) {
+      const body = content.replace(HASH_LINE_RE, '');
+      const bodyHash = this.computeHash(body);
+      content = content.replace(HASH_LINE_RE, `<!-- file_content_hash: ${bodyHash} -->\n`);
+    } else {
+      const bodyHash = this.computeHash(content);
+      content = `<!-- file_content_hash: ${bodyHash} -->\n${content}`;
+    }
+    return content;
+  }
+
+  /**
+   * SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1b): render every generated file in
+   * memory from the live DB and return { filename: content } WITHOUT writing to disk or
+   * mutating the manifest. This is the render half of the drift-check primitive
+   * (scripts/check-claude-md-drift.cjs).
+   * @returns {Promise<Object<string,string>>}
+   */
+  async renderAll() {
+    const { data, digestMetadata } = await this.loadData();
+    const rendered = {};
+    for (const [filename, generatorFn] of this.getFileSpecs(digestMetadata)) {
+      rendered[filename] = this.renderFileContent(generatorFn, data);
+    }
+    return rendered;
+  }
+
+  /**
    * Generate all CLAUDE files (FULL + DIGEST)
    * @returns {Object} Generation manifest
    */
@@ -154,99 +298,22 @@ class CLAUDEMDGeneratorV3 {
     console.log('Generating modular CLAUDE files from database (V3.1 - Dual Generation)...\n');
 
     try {
-      this.loadMappings();
+      const { data, digestMetadata, protocol } = await this.loadData();
 
-      // Fetch all data from database
-      const protocol = await getActiveProtocol(this.supabase);
-      const agents = await getAgents(this.supabase);
-      const subAgents = await getSubAgents(this.supabase);
-      const handoffTemplates = await getHandoffTemplates(this.supabase);
-      const validationRules = await getValidationRules(this.supabase);
-      const schemaConstraints = await getSchemaConstraints(this.supabase);
-      const processScripts = await getProcessScripts(this.supabase);
-      const hotPatterns = await getHotPatterns(this.supabase, 5);
-      // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-4b: known friction points from worker /signal aggregation
-      const knownFrictionPoints = await getKnownFrictionPoints(this.supabase, 5);
-      const recentRetrospectives = await getRecentRetrospectives(this.supabase, 30, 5);
-      const gateHealth = await getGateHealth(this.supabase);
-      const pendingProposals = await getPendingProposals(this.supabase, 5);
-      const autonomousDirectives = await getAutonomousDirectives(this.supabase);
-      // SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001: live VGAP data for protocol injection
-      const visionGapInsights = await getVisionGapInsights(this.supabase, 3);
+      console.log('=== GENERATING FILES (FULL + DIGEST) ===\n');
+      // SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1b): iterate the single getFileSpecs()
+      // list so the write path and the drift-check render path never diverge.
+      for (const [filename, generatorFn, type] of this.getFileSpecs(digestMetadata)) {
+        this.generateFile(filename, data, generatorFn, type);
+      }
 
-      const data = {
-        protocol,
-        agents,
-        subAgents,
-        handoffTemplates,
-        validationRules,
-        schemaConstraints,
-        processScripts,
-        hotPatterns,
-        knownFrictionPoints,
-        recentRetrospectives,
-        gateHealth,
-        pendingProposals,
-        autonomousDirectives,
-        visionGapInsights
-      };
-
-      // Initialize manifest
-      this.manifest.generated_at = new Date().toISOString();
-      this.manifest.git_commit = this.getGitCommit();
-      this.manifest.db_snapshot_hash = this.computeDbSnapshotHash(data);
-
-      // Metadata for digest headers
-      const digestMetadata = {
-        generatedAt: this.manifest.generated_at,
-        gitCommit: this.manifest.git_commit,
-        dbSnapshotHash: this.manifest.db_snapshot_hash
-      };
-
-      console.log('=== FULL FILES ===\n');
-
-      // Generate FULL files
-      this.generateFile('CLAUDE.md', data, (d) => generateRouter(d, this.fileMapping), 'full');
-      this.generateFile('CLAUDE_CORE.md', data, (d) => generateCore(d, this.fileMapping), 'full');
-      this.generateFile('CLAUDE_LEAD.md', data, (d) => generateLead(d, this.fileMapping), 'full');
-      this.generateFile('CLAUDE_PLAN.md', data, (d) => generatePlan(d, this.fileMapping), 'full');
-      this.generateFile('CLAUDE_EXEC.md', data, (d) => generateExec(d, this.fileMapping), 'full');
-      // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-C: Adam role contract (database-first)
-      this.generateFile('CLAUDE_ADAM.md', data, (d) => generateAdam(d, this.fileMapping), 'full');
-
-      // Calculate FULL totals
+      // Totals + token-budget enforcement (computed from the populated manifest).
       const fullFiles = Object.entries(this.manifest.files).filter(([_, f]) => f.type === 'full');
-      const fullTotalChars = fullFiles.reduce((sum, [_, f]) => sum + f.chars, 0);
+      const digestFiles = Object.entries(this.manifest.files).filter(([_, f]) => f.type === 'digest');
       const fullTotalTokens = fullFiles.reduce((sum, [_, f]) => sum + f.estimated_tokens, 0);
+      const digestTotalTokens = digestFiles.reduce((sum, [_, f]) => sum + f.estimated_tokens, 0);
 
-      console.log(`\n   FULL Total: ${(fullTotalChars / 1024).toFixed(1)} KB (~${fullTotalTokens} tokens)`);
-
-      // Generate DIGEST files if enabled
-      if (this.options.generateDigest) {
-        console.log('\n=== DIGEST FILES ===\n');
-
-        this.generateFile('CLAUDE_DIGEST.md', data,
-          (d) => generateRouterDigest(d, this.digestMapping, digestMetadata), 'digest');
-        this.generateFile('CLAUDE_CORE_DIGEST.md', data,
-          (d) => generateCoreDigest(d, this.digestMapping, digestMetadata), 'digest');
-        this.generateFile('CLAUDE_LEAD_DIGEST.md', data,
-          (d) => generateLeadDigest(d, this.digestMapping, digestMetadata), 'digest');
-        this.generateFile('CLAUDE_PLAN_DIGEST.md', data,
-          (d) => generatePlanDigest(d, this.digestMapping, digestMetadata), 'digest');
-        this.generateFile('CLAUDE_EXEC_DIGEST.md', data,
-          (d) => generateExecDigest(d, this.digestMapping, digestMetadata), 'digest');
-        // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-C: Adam role contract digest
-        this.generateFile('CLAUDE_ADAM_DIGEST.md', data,
-          (d) => generateAdamDigest(d, this.digestMapping, digestMetadata), 'digest');
-
-        // Calculate DIGEST totals
-        const digestFiles = Object.entries(this.manifest.files).filter(([_, f]) => f.type === 'digest');
-        const digestTotalChars = digestFiles.reduce((sum, [_, f]) => sum + f.chars, 0);
-        const digestTotalTokens = digestFiles.reduce((sum, [_, f]) => sum + f.estimated_tokens, 0);
-
-        console.log(`\n   DIGEST Total: ${(digestTotalChars / 1024).toFixed(1)} KB (~${digestTotalTokens} tokens)`);
-
-        // Check token budget
+      if (this.options.generateDigest && digestFiles.length > 0) {
         if (digestTotalTokens > this.options.tokenBudget) {
           console.error(`\n   TOKEN BUDGET EXCEEDED: ${digestTotalTokens} > ${this.options.tokenBudget}`);
           console.error('   Per-file breakdown:');
@@ -254,14 +321,11 @@ class CLAUDEMDGeneratorV3 {
             console.error(`     ${name}: ${f.estimated_tokens} tokens`);
           });
           throw new Error(`DIGEST token budget exceeded: ${digestTotalTokens} > ${this.options.tokenBudget}`);
-        } else {
-          console.log(`   Token budget OK: ${digestTotalTokens}/${this.options.tokenBudget} (${Math.round(digestTotalTokens / this.options.tokenBudget * 100)}%)`);
         }
-
-        // Calculate savings (skip under --only scoping where full totals may be 0)
+        console.log(`   Token budget OK: ${digestTotalTokens}/${this.options.tokenBudget} (${Math.round(digestTotalTokens / this.options.tokenBudget * 100)}%)`);
         if (fullTotalTokens > 0) {
           const savingsPercent = Math.round((1 - digestTotalTokens / fullTotalTokens) * 100);
-          console.log(`\n   Token Savings: ${savingsPercent}% (${fullTotalTokens - digestTotalTokens} tokens saved)`);
+          console.log(`   Token Savings: ${savingsPercent}% (${fullTotalTokens - digestTotalTokens} tokens saved)`);
         }
       }
 
@@ -301,25 +365,10 @@ class CLAUDEMDGeneratorV3 {
     }
 
     const filePath = path.join(this.baseDir, filename);
-    let content = generatorFn(data);
-
-    // SD-LEO-INFRA-PROTOCOL-PUBLICATION-PIPELINE-001 (FR-3): real content hash in the
-    // header. The digest header templates emit `file_content_hash: pending` INSIDE the
-    // body, but the hash is only computable AFTER rendering (chicken-and-egg) — every
-    // live header showed 'pending'. Contract: body = file content with the hash LINE
-    // removed; header value = sha256(body)[:16]. FULL files (no template header) get a
-    // single prepended stamp line so staleness checks cover all generated files.
-    // Verify anywhere via verifyFileContentHash() below.
-    const HASH_LINE_RE = /^<!-- file_content_hash: [^>]*-->\r?\n/m;
-    if (HASH_LINE_RE.test(content)) {
-      const body = content.replace(HASH_LINE_RE, '');
-      const bodyHash = this.computeHash(body);
-      content = content.replace(HASH_LINE_RE, `<!-- file_content_hash: ${bodyHash} -->\n`);
-    } else {
-      const bodyHash = this.computeHash(content);
-      content = `<!-- file_content_hash: ${bodyHash} -->\n${content}`;
-    }
-
+    // SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1b): single shared render path
+    // (FR-5 banner + file_content_hash injection) — byte-identical to renderAll()'s
+    // output, so the drift check can never diverge from what is written here.
+    const content = this.renderFileContent(generatorFn, data);
     const contentHash = this.computeHash(content);
 
     writeFileAtomic(filePath, content);
@@ -364,6 +413,48 @@ export const KNOWN_GENERATED_FILES = [
 // the single `<!-- file_content_hash: ... -->` line removed; expected = sha256(body)[:16].
 // Returns { ok, expected, actual } — ok=false with actual=null when no hash line exists
 // (pre-FR-3 file or hand-edited header), making staleness/tamper checks one call.
+// SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1): content-aware per-section digest of
+// leo_protocol_sections — the SOURCE prose that determines the generated docs, and the only
+// sound drift signal. (The coarse db_snapshot_hash hashes section COUNT, not content; the
+// rendered files additionally embed volatile live telemetry — hotPatterns/gateHealth/retros —
+// so neither a count hash nor a render-diff is a reliable drift detector.) Hashes ONLY the
+// stable rendering-relevant fields, never volatile row metadata (updated_at/created_at).
+// Single source of the hashing logic — imported by scripts/check-claude-md-drift.cjs so the
+// writer (manifest) and the consumer (drift check) can never diverge.
+// @param {Array<Object>} sections - leo_protocol_sections rows for the active protocol
+// @returns {{ global: string, byId: Object<string,string>, meta: Object<string,Object> }}
+export function computeSectionDigests(sections) {
+  const byId = {};
+  const meta = {};
+  const seq = [];
+  // Iterate in the PASSED (render) order — callers pass protocol.sections exactly as
+  // getActiveProtocol returns them (deterministic via the order_index,id sort), so the
+  // `global` hash below faithfully reflects rendered section order. Do NOT re-sort here, or
+  // the digest would decouple from the renderer (the false-negative this guard exists to avoid).
+  for (const s of (sections || [])) {
+    const id = String(s.id);
+    // Hash ONLY fields that flow into rendered output: section_type (controls file membership
+    // via section-file-mapping), title + content (the body), and order_index (controls section
+    // ORDER). context_tier and the target_file COLUMN are intentionally excluded — neither is
+    // rendered (placement is keyed off section_type via the mapping), so hashing them produced
+    // false-positive "drift" on edits that change no rendered byte.
+    const payload = JSON.stringify({
+      section_type: s.section_type ?? null,
+      title: s.title ?? null,
+      content: s.content ?? null,
+      order_index: s.order_index ?? null,
+    });
+    const h = crypto.createHash('sha256').update(payload).digest('hex').substring(0, 16);
+    byId[id] = h;
+    meta[id] = { section_type: s.section_type ?? null, target_file: s.target_file ?? null, title: s.title ?? null };
+    seq.push(`${id}:${h}`);
+  }
+  // global = hash over the render-order sequence, so a pure REORDERING (no per-section content
+  // change) still flips global and is caught by diffSectionDigests (which consults globalMatch).
+  const global = crypto.createHash('sha256').update(seq.join('|')).digest('hex').substring(0, 16);
+  return { global, byId, meta };
+}
+
 export function verifyFileContentHash(filePath) {
   const content = fs.readFileSync(filePath, 'utf-8');
   const m = content.match(/^<!-- file_content_hash: ([0-9a-f]{16}) -->\r?\n/m);


### PR DESCRIPTION
## Summary
Defense-in-depth so generated `CLAUDE_*.md` can never silently lag `leo_protocol_sections` (the DB source of truth). Verified live 2026-06-14: origin/main's generated docs lagged the DB by ~570 lines with no detector behind the CLAUDE.md "version check / if stale, regenerate" step.

## What changed
- **FR-1** `scripts/check-claude-md-drift.cjs` — deterministic drift-check primitive. Compares a **content-aware per-section digest** (live DB vs `claude-generation-manifest.json` `section_digests`). Chosen over a render-diff (rendered files embed volatile live telemetry — gateHealth/retros/patterns/timestamps — so a render-diff cry-wolfs) and over the generator's coarse `db_snapshot_hash` (count-only, content-blind). Exit 0 clean / 1 drift / 2 infra (fail-open).
- **FR-1b** generator render-only mode (`loadData`/`getFileSpecs`/`renderFileContent`/`renderAll` — single shared file list & render path so the manifest writer and the drift consumer can never diverge). Behavior-preserving (generator regression 23/23).
- **FR-2** scoped, fail-open pre-commit source gate (`.husky/pre-commit` STAGE 10).
- **FR-3** SessionStart stale-docs warning (fail-open, 8s timeout, silent-when-clean).
- **FR-4a** CI PR drift check (`.github/workflows/claude-md-drift.yml`).
- **FR-5** deterministic GENERATED do-not-edit banner on every file.
- **FR-6** 15 unit tests.
- **FR-4b** (continuous coordinator-tick/cron sweep) deferred + documented — FR-2 + FR-3 + FR-4a already cover change-time, load-time, and CI.

## Adversarial review (37-agent workflow) — fixed before merge
- **HIGH false-negative**: sections sharing an `order_index` rendered in Postgres's unspecified row order (11 same-file ties live) → a shuffle changed rendered bytes but left per-id hashes unchanged. Fix: `.order('id')` deterministic tiebreak + `global` hash over render order + `globalMatch` consulted (a pure reorder is now flagged).
- **MEDIUM/LOW false-positives**: `context_tier` + `target_file` column were hashed but neither is rendered → dropped from the hashed payload.

## Test plan
- 15 FR-6 unit tests pass; generator regression 23/23.
- Live: drift-check detects a seeded section change/add/remove/reorder and is clean (exit 0) after regeneration — no timestamp/telemetry false-positive.

SD: SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (infrastructure, [MODE: campaign])

🤖 Generated with [Claude Code](https://claude.com/claude-code)