### PR TITLE
feat(SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001): Adam machinery consumer-side invariants

### DIFF
--- a/.claude/commands/adam.md
+++ b/.claude/commands/adam.md
@@ -56,16 +56,17 @@ This tags the current session in `claude_sessions.metadata` with `role=adam` and
 node scripts/adam-startup-check.mjs
 ```
 
-`CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Adam's tick is **four loops**, silence-by-default + propose-only (CONST-002):
+`CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Adam's tick is **five loops**, silence-by-default + propose-only (CONST-002):
 1. **governance-scan** (daily) — the read-only opportunity-scan (`node scripts/adam-opportunity-scan.cjs --scan --scope auto`); runs only when `ADAM_GOVERNANCE_HEARTBEAT_V1=on` (else it prints `SUPPRESSED_FLAG_OFF`).
 2. **inbox-monitor** (every 15 min) — drain coordinator replies (`node scripts/adam-advisory.cjs replies`).
 3. **offer-help** (every 2 h) — an agent-judgment tick: offer the coordinator concise analysis when it helps, else stay silent.
 4. **self-adherence** (every 6 h) — Adam audits its OWN role-contract adherence (`node scripts/adam-self-adherence-review.mjs`): probes → `adam_adherence_ledger` → propose-only remediation for the coordinator on drift (never builds — CONST-002). SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001.
+5. **belt-countdown** (every 15 min) — an agent-judgment tick: while the fleet is active, post ONE belt-countdown line (ET 12-hour, rolling ETA to belt-dry from DB rows via `node scripts/fleet-dashboard.cjs`); stay silent when the fleet is idle. The contract-named BELT COUNTDOWN DUTY (durable) — previously session-scoped and died every Adam session. SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001.
 
-**Arm them via `CronCreate` — IDEMPOTENTLY.** Run `CronList`, map each existing cron to its loop KEY (`governance-scan` | `inbox-monitor` | `offer-help` | `self-adherence` — keys are the canonical comma-free tokens; prompts can contain commas and won't survive the CSV split), then re-invoke with the armed keys for an `armed|MISSING` verdict, and arm ONLY the missing loops:
+**Arm them via `CronCreate` — IDEMPOTENTLY.** Run `CronList`, map each existing cron to its loop KEY (`governance-scan` | `inbox-monitor` | `offer-help` | `self-adherence` | `belt-countdown` — keys are the canonical comma-free tokens; prompts can contain commas and won't survive the CSV split), then re-invoke with the armed keys for an `armed|MISSING` verdict, and arm ONLY the missing loops:
 
 ```bash
-node scripts/adam-startup-check.mjs --armed "governance-scan,inbox-monitor,offer-help,self-adherence"
+node scripts/adam-startup-check.mjs --armed "governance-scan,inbox-monitor,offer-help,self-adherence,belt-countdown"
 ```
 
 For each `❌ MISSING` loop, call the emitted `CronCreate({ cron, prompt, recurring: true })`. Skip any already in `CronList` (including any interim hand-armed cron) — this is the durable replacement for hand-arming Adam's tick.
@@ -80,4 +81,4 @@ Going forward, the **active coordinator** runs an hourly responsibilities remind
 
 ## Result
 
-After `/adam`: the role contract has been read in full and **verified** (`contract_read: true` in the register output), the session is tagged `role=adam`/`non_fleet=true` (idempotent), the coordination protocol is established, and Adam's recurring tick (governance-scan + inbox-monitor + offer-help + self-adherence) is armed. Adam is now active as an advisory/analysis session, invisible to fleet accounting.
+After `/adam`: the role contract has been read in full and **verified** (`contract_read: true` in the register output), the session is tagged `role=adam`/`non_fleet=true` (idempotent), the coordination protocol is established, and Adam's recurring tick (governance-scan + inbox-monitor + offer-help + self-adherence + belt-countdown) is armed. Adam is now active as an advisory/analysis session, invisible to fleet accounting.

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -75,6 +75,17 @@ export const ADAM_LOOPS = [
     cron: '0 */6 * * *',
     prompt: 'node scripts/adam-self-adherence-review.mjs',
   },
+  {
+    // SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2): the contract-named BELT COUNTDOWN DUTY
+    // (CLAUDE_ADAM.md "BELT COUNTDOWN DUTY (durable)") previously lived only in session-scoped
+    // crons and DIED with every Adam session (2026-06-11 handoff drill). Arming it here makes it
+    // survive session restarts — closing the contract↔tooling gap the duty-marker parity test enforces.
+    key: 'belt-countdown',
+    label: 'Belt-countdown one-liner (ET 12h, rolling ETA to belt-dry) while the fleet is active',
+    script: null, // agent-prompt tick — depth/burn come from DB rows via fleet-dashboard, never hand-converted ET↔UTC
+    cron: '*/15 * * * *',
+    prompt: 'Adam belt-countdown tick: if the fleet is active, post ONE belt-countdown line via node scripts/adam-advisory.cjs send "<line>" — Eastern time in 12-hour format with a rolling ETA to belt-dry (claimable-SD depth vs current fleet burn; read depth/burn from DB rows via node scripts/fleet-dashboard.cjs, never hand-convert ET↔UTC). If the fleet is idle/empty, STAY SILENT.',
+  },
 ];
 
 // Parse the armed-cron basenames/prompts the agent passes from its CronList output.
@@ -91,6 +102,37 @@ export function parseArmedSet(argv = [], env = {}) {
   const provided = raw.trim().length > 0;
   const set = new Set(raw.split(',').map((s) => s.trim()).filter(Boolean));
   return { provided, set };
+}
+
+// SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2): parse the contract's DURABLE recurring-duty
+// markers from CLAUDE_ADAM.md. A durable duty is bolded as `**<NAME> DUTY (durable)**`; the
+// captured NAME is slugged (lowercase, spaces→hyphens) so it can be matched against an
+// ADAM_LOOPS key. The "(durable)" qualifier is load-bearing: TEMPORARY, self-deleting watchers
+// (e.g. the .PUSHED-lifecycle autonomy-completion-watcher) are NOT marked durable, so they are
+// excluded here and correctly stay session-scoped (NOT required in ADAM_LOOPS). Pure; no I/O.
+// MARKER CONVENTION (keep CLAUDE_ADAM.md authors aware): a durable recurring duty is bolded as
+//   **<NAME> DUTY (durable)**
+// where <NAME> is a human label (letters/digits/spaces/hyphens, any case) and the literal token
+// " DUTY (durable)" follows (case-insensitive on "durable", whitespace-tolerant). The slug is
+// <NAME> lowercased with spaces→hyphens. The regex is deliberately FORGIVING so a stylistic
+// variation (hyphenated name, mixed case, uppercase DURABLE) never SILENTLY drops a duty from
+// enforcement — a false negative here = an unenforced duty, the exact failure this guards.
+export function parseDurableDutyMarkers(markdown) {
+  const slugs = new Set();
+  const re = /\*\*\s*([A-Za-z0-9][A-Za-z0-9 -]*?)\s+DUTY\s*\(\s*durable\s*\)\s*\*\*/gi;
+  let m;
+  while ((m = re.exec(String(markdown || ''))) !== null) {
+    slugs.add(m[1].trim().toLowerCase().replace(/\s+/g, '-'));
+  }
+  return [...slugs];
+}
+
+// FR2: which contract-named durable duties are MISSING from ADAM_LOOPS. [] === parity holds.
+// This is the consumer-side invariant for the loop registry: a duty the contract PROMISES must
+// actually exist in the tooling that arms it, or it silently dies every session.
+export function missingDurableDuties(markdown, loops = ADAM_LOOPS) {
+  const keys = new Set(loops.map((l) => l.key));
+  return parseDurableDutyMarkers(markdown).filter((slug) => !keys.has(slug));
 }
 
 // A loop is "armed" when an armed-set was provided AND it contains the loop's KEY (the
@@ -152,9 +194,29 @@ export function renderFreshness(repoRoot = REPO_ROOT) {
   }
 }
 
+/**
+ * SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2): RUNTIME contract↔tooling parity verdict.
+ * Reads CLAUDE_ADAM.md and FAILS LOUD (a warning line at every /adam startup) when a durable
+ * contract duty is missing from ADAM_LOOPS — so future drift surfaces to the operator, not only
+ * to CI. Fail-open: a read/parse hiccup never throws or blocks startup.
+ */
+export function renderContractParity(repoRoot = REPO_ROOT) {
+  const head = '═══ CONTRACT↔TOOLING PARITY ═══\n  ';
+  try {
+    const md = readFileSync(resolve(repoRoot, ROLE_CONTEXT_DOC), 'utf8');
+    const missing = missingDurableDuties(md, ADAM_LOOPS);
+    if (missing.length === 0) {
+      return head + '✅ all durable CLAUDE_ADAM.md duties present in ADAM_LOOPS';
+    }
+    return head + `⚠️ CONTRACT DRIFT: durable duty(ies) declared in ${ROLE_CONTEXT_DOC} but absent from ADAM_LOOPS: ${missing.join(', ')} — they will DIE every session until armed. Add them to ADAM_LOOPS (scripts/adam-startup-check.mjs).`;
+  } catch (err) {
+    return head + '✅ parity check skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   const armed = parseArmedSet(argv, env);
-  return [renderResponsibilities(repoRoot), '', renderLoops(armed), '', renderFreshness(repoRoot)].join('\n');
+  return [renderResponsibilities(repoRoot), '', renderLoops(armed), '', renderContractParity(repoRoot), '', renderFreshness(repoRoot)].join('\n');
 }
 
 // ── Main (fail-open: always exit 0) ──

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1171,18 +1171,15 @@ async function printAdamInbox() {
     return;
   }
 
-  const { data: advisories, error } = await supabase
-    .from('session_coordination')
-    .select('id, sender_session, sender_type, subject, body, payload, created_at')
-    .eq('target_session', coordinatorId)
-    .eq('payload->>kind', 'adam_advisory')
-    // SD-LEO-INFRA-RESILIENT-SYMMETRIC-ADAM-001 FR-1: re-surface gate is payload.actioned_at
-    // IS NULL (not read_at), mirroring the two-stage ACK in lib/coordinator/adam-action-ack.cjs.
-    // A parked-cron render stamps read_at (DELIVERED) but NEVER actioned_at, so an unactioned
-    // advisory keeps re-surfacing until the coordinator runs coordinator-ack-adam.cjs --advisory.
-    .is('payload->>actioned_at', null)
-    .order('created_at', { ascending: false })
-    .limit(20);
+  // SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR3): drive the SINGLE canonical consumer
+  // selector instead of re-implementing the query here. selectUnactionedAdvisories is the
+  // one place that defines "an unactioned advisory" (payload.kind=adam_advisory +
+  // payload.actioned_at IS NULL, no expires_at filter — the row must physically survive,
+  // which is why FR1 gives it a durable TTL). It also covers the broadcast-coordinator
+  // sentinel, which this inline query previously MISSED. Unifying here removes a
+  // writer/consumer-asymmetry drift surface (PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001).
+  const { selectUnactionedAdvisories } = require('../lib/coordinator/adam-advisory-store.cjs');
+  const { rows: advisories, error } = await selectUnactionedAdvisories(supabase, coordinatorId, { limit: 20 });
 
   if (error) {
     console.log('  (adam inbox query failed: ' + error.message + ')');

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -2,6 +2,9 @@
 // SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001 (FR-1)
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   ADAM_LOOPS,
   RESPONSIBILITIES,
@@ -11,16 +14,79 @@ import {
   renderLoops,
   buildReport,
   ROLE_CONTEXT_DOC,
+  parseDurableDutyMarkers,
+  missingDurableDuties,
+  renderContractParity,
 } from '../../scripts/adam-startup-check.mjs';
 
-test('ADAM_LOOPS has the 4 expected tick loops with the expected keys', () => {
-  // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E).
-  assert.equal(ADAM_LOOPS.length, 4);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence']);
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+test('ADAM_LOOPS has the 5 expected tick loops with the expected keys', () => {
+  // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
+  // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty).
+  assert.equal(ADAM_LOOPS.length, 5);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);
   });
+});
+
+// SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2): the consumer-side invariant for the loop
+// registry — every DURABLE contract-named duty in CLAUDE_ADAM.md must exist in ADAM_LOOPS, or
+// it silently dies every Adam session (the belt-countdown failure mode).
+test('FR2: every CLAUDE_ADAM.md durable duty marker is present in ADAM_LOOPS (contract↔tooling parity)', () => {
+  const contract = readFileSync(resolve(REPO_ROOT, 'CLAUDE_ADAM.md'), 'utf-8');
+  const duties = parseDurableDutyMarkers(contract);
+  assert.ok(duties.includes('belt-countdown'), 'contract declares the BELT COUNTDOWN DUTY (durable)');
+  const missing = missingDurableDuties(contract, ADAM_LOOPS);
+  assert.deepEqual(missing, [], `durable duties missing from ADAM_LOOPS: ${missing.join(', ')}`);
+});
+
+test('FR2: parseDurableDutyMarkers slugs the marker name and EXCLUDES non-durable/temporary duties', () => {
+  const md = [
+    '**BELT COUNTDOWN DUTY (durable)**: post a one-liner.',
+    '**SOME TEMP WATCHER**: a session-scoped watcher (NOT a durable duty).',
+    '**AUTONOMY COMPLETION WATCHER**: temporary, .PUSHED lifecycle (no durable marker).',
+  ].join('\n');
+  assert.deepEqual(parseDurableDutyMarkers(md), ['belt-countdown']);
+  // A durable duty with no ADAM_LOOPS entry must be reported missing (the guard's teeth).
+  assert.deepEqual(missingDurableDuties('**GHOST DUTY (durable)**', ADAM_LOOPS), ['ghost']);
+});
+
+// SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (review fix): the matcher must be FORGIVING so a
+// stylistic variation never SILENTLY drops a durable duty from enforcement (a false negative =
+// an unenforced duty). Hyphenated names, mixed/upper case, and uppercase DURABLE all match.
+test('FR2: parseDurableDutyMarkers is forgiving (hyphens, mixed case, UPPER DURABLE) — no silent false negatives', () => {
+  assert.deepEqual(parseDurableDutyMarkers('**Full-Inbox Sweep DUTY (durable)**'), ['full-inbox-sweep']);
+  assert.deepEqual(parseDurableDutyMarkers('**Belt Countdown DUTY (DURABLE)**'), ['belt-countdown']);
+  assert.deepEqual(parseDurableDutyMarkers('**FOO-BAR DUTY ( durable )**'), ['foo-bar']);
+  // a plain bold heading without the " DUTY (durable)" token is NOT a durable duty
+  assert.deepEqual(parseDurableDutyMarkers('**SOME HEADING**'), []);
+});
+
+// FR2: the parity invariant has RUNTIME teeth — renderContractParity surfaces drift at /adam
+// startup (fail-open), not only in CI.
+test('FR2: renderContractParity reports CLEAN for the real contract and is fail-open', () => {
+  const out = renderContractParity(REPO_ROOT);
+  assert.match(out, /CONTRACT↔TOOLING PARITY/);
+  assert.match(out, /✅ all durable .* duties present/);
+  assert.doesNotThrow(() => renderContractParity('/no/such/path'));
+  assert.match(renderContractParity('/no/such/path'), /fail-open/);
+});
+
+test('FR2: buildReport includes the contract-parity section', () => {
+  const report = buildReport([], {}, REPO_ROOT);
+  assert.match(report, /CONTRACT↔TOOLING PARITY/);
+});
+
+test('FR2: belt-countdown is an agent-prompt 15-min tick (durable, survives session restart)', () => {
+  const belt = ADAM_LOOPS.find((l) => l.key === 'belt-countdown');
+  assert.ok(belt, 'belt-countdown loop exists');
+  assert.equal(belt.script, null, 'agent-prompt tick (no script)');
+  assert.equal(belt.cron, '*/15 * * * *', 'every 15 minutes');
+  assert.match(belt.prompt, /belt-countdown/i);
+  assert.match(belt.prompt, /Eastern time|ET/i);
 });
 
 test('self-adherence loop runs the recurring self-adherence review (propose-only)', () => {
@@ -62,16 +128,16 @@ test('loopStatus: armed on key, prompt or script match, MISSING when provided-bu
   assert.equal(loopStatus(offer, { provided: true, set: new Set([offer.prompt]) }), 'armed');
 });
 
-test('end-to-end CSV verdict: --armed with all 4 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
+test('end-to-end CSV verdict: --armed with all 5 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
   const armed = parseArmedSet(['--armed', ADAM_LOOPS.map((l) => l.key).join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 4 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 5 Adam tick loops armed\. Nothing to arm\./);
   assert.doesNotMatch(out, /MISSING/);
 });
 
 test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent note)', () => {
   const out = renderLoops(parseArmedSet([], {}));
-  assert.match(out, /ADAM RECURRING TICK \(4 loops\)/);
+  assert.match(out, /ADAM RECURRING TICK \(5 loops\)/);
   assert.match(out, /CronCreate\(\{ cron: "0 13 \* \* \*"/); // governance-scan spec emitted
   assert.match(out, /idempotent/i);
 });
@@ -79,7 +145,7 @@ test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent
 test('renderLoops reports "Nothing to arm" when all loops are in the armed set', () => {
   const armedSet = new Set(ADAM_LOOPS.map((l) => l.prompt));
   const out = renderLoops({ provided: true, set: armedSet });
-  assert.match(out, /All 4 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 5 Adam tick loops armed\. Nothing to arm\./);
 });
 
 test('renderResponsibilities is fail-open (bad repoRoot → fallback, never throws)', () => {

--- a/tests/unit/adam/adam-machinery-consumer-invariant.test.js
+++ b/tests/unit/adam/adam-machinery-consumer-invariant.test.js
@@ -1,0 +1,155 @@
+/**
+ * SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 — FR1 + FR3 consumer-side-invariant tests.
+ *
+ * Systemic root cause this SD closes: Adam machinery is verified at the PRODUCER boundary
+ * (the advisory is emitted) but never that the real READER sees it across a coordinator
+ * poll-gap. These tests assert the invariant at the CONSUMER boundary by driving the actual
+ * consumer selector (lib/coordinator/adam-advisory-store.cjs selectUnactionedAdvisories — the
+ * SAME query scripts/fleet-dashboard.cjs printAdamInbox now uses) and the actual producer TTL
+ * (scripts/adam-advisory.cjs advisoryExpiresAt), and by modeling the real sweep
+ * (cleanup_expired_coordination = DELETE FROM session_coordination WHERE expires_at < now()).
+ *
+ * Reusable pattern PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001: every producer ships a
+ * "consumer-reads-it-back against the real reader" assertion; here the reader is the advisory
+ * selector + the sweep that governs row lifetime.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { advisoryExpiresAt, ADVISORY_TTL_MS } = require('../../../scripts/adam-advisory.cjs');
+const { selectUnactionedAdvisories } = require('../../../lib/coordinator/adam-advisory-store.cjs');
+
+// Real-cadence constants (from the live system, cited inline):
+const SWEEP_CADENCE_MS = 5 * 60_000;       // cleanup_expired_coordination runs ~every 5 min (stale-session-sweep.cjs)
+const COORDINATOR_POLL_MS = 15 * 60_000;   // inbox-monitor cron '*/15 * * * *' (adam-startup-check.mjs)
+
+// Minimal thenable supabase stub that records the query chain (mirrors resilient-symmetric-adam.test.js).
+function makeSupabase(result, captured) {
+  const chain = {
+    from(t) { captured.from = t; return chain; },
+    select(s) { captured.select = s; return chain; },
+    eq(k, v) { (captured.eq = captured.eq || []).push([k, v]); return chain; },
+    is(k, v) { (captured.is = captured.is || []).push([k, v]); return chain; },
+    in(k, v) { captured.in = [k, v]; return chain; },
+    lt(k, v) { (captured.lt = captured.lt || []).push([k, v]); return chain; },
+    lte(k, v) { (captured.lte = captured.lte || []).push([k, v]); return chain; },
+    gt(k, v) { (captured.gt = captured.gt || []).push([k, v]); return chain; },
+    gte(k, v) { (captured.gte = captured.gte || []).push([k, v]); return chain; },
+    order() { captured.ordered = true; return chain; },
+    limit(n) { captured.limit = n; return chain; },
+    then(res, rej) { return Promise.resolve(result).then(res, rej); },
+  };
+  return chain;
+}
+
+// The real sweep predicate: cleanup_expired_coordination DELETEs rows where expires_at < now().
+const sweptAway = (row, nowMs) => new Date(row.expires_at).getTime() < nowMs;
+// The real reader gate: selectUnactionedAdvisories returns adam_advisory rows with actioned_at IS NULL.
+const readerReturns = (row, nowMs) =>
+  !sweptAway(row, nowMs) && row.payload?.kind === 'adam_advisory' && row.payload?.actioned_at == null;
+
+describe('FR1: durable advisory TTL (decoupled from the await timeout)', () => {
+  it('ADVISORY_TTL_MS exceeds the coordinator poll interval AND the sweep cadence (>= 1h)', () => {
+    expect(ADVISORY_TTL_MS).toBeGreaterThanOrEqual(60 * 60_000);
+    expect(ADVISORY_TTL_MS).toBeGreaterThan(COORDINATOR_POLL_MS);
+    expect(ADVISORY_TTL_MS).toBeGreaterThan(SWEEP_CADENCE_MS);
+  });
+
+  it('advisoryExpiresAt() is ADVISORY_TTL_MS in the future regardless of any await timeout', () => {
+    const now = 1_000_000_000_000;
+    expect(new Date(advisoryExpiresAt(now)).getTime()).toBe(now + ADVISORY_TTL_MS);
+    // No mode/timeout argument exists anymore — the TTL cannot be shrunk by a short --timeout.
+    expect(advisoryExpiresAt.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('FR3: the real reader does NOT filter on expires_at (so the row must physically survive)', () => {
+  it('selectUnactionedAdvisories gates on actioned_at IS NULL and never adds an expires_at filter', async () => {
+    const captured = {};
+    const sb = makeSupabase({ data: [], error: null }, captured);
+    await selectUnactionedAdvisories(sb, 'coord-uuid', { limit: 20 });
+    expect(captured.is).toContainEqual(['payload->>actioned_at', null]);
+    expect(captured.eq).toContainEqual(['payload->>kind', 'adam_advisory']);
+    // The consumer relies on the row EXISTING — it has no expires_at guard of its own.
+    // Therefore row lifetime (the producer TTL + the sweep) is the real durability invariant.
+    const touchedExpires = []
+      .concat(captured.lt || [], captured.lte || [], captured.gt || [], captured.gte || [], captured.eq || [], captured.is || [])
+      .some(([k]) => String(k).includes('expires_at'));
+    expect(touchedExpires).toBe(false);
+  });
+});
+
+describe('FR1+FR3 round-trip: a sent advisory survives a coordinator poll-gap until actioned', () => {
+  const now0 = 1_000_000_000_000;
+  // Producer writes the row with the REAL TTL helper.
+  const advisory = { id: 'adv-1', expires_at: advisoryExpiresAt(now0), payload: { kind: 'adam_advisory' } };
+
+  it('is NOT swept and IS returned by the reader after a >15min poll-gap', () => {
+    const atPoll = now0 + COORDINATOR_POLL_MS + 1; // coordinator's next poll, just past 15 min
+    expect(sweptAway(advisory, atPoll)).toBe(false);
+    expect(readerReturns(advisory, atPoll)).toBe(true);
+  });
+
+  it('disappears from the reader ONLY after payload.actioned_at is stamped — not on TTL expiry', () => {
+    const atPoll = now0 + COORDINATOR_POLL_MS + 1;
+    const actioned = { ...advisory, payload: { ...advisory.payload, actioned_at: new Date(atPoll).toISOString() } };
+    expect(sweptAway(actioned, atPoll)).toBe(false);     // still not expired
+    expect(readerReturns(actioned, atPoll)).toBe(false); // excluded because actioned, not because swept
+  });
+
+  it('COUNTERFACTUAL: the OLD request-mode TTL (now+timeoutMs+5min) WAS swept before the poll (the bug)', () => {
+    const oldTtlMs = 30_000 + 5 * 60_000; // default timeoutMs(30s) + 5min ≈ 5.5min
+    const oldRow = { id: 'adv-old', expires_at: new Date(now0 + oldTtlMs).toISOString(), payload: { kind: 'adam_advisory' } };
+    const atPoll = now0 + COORDINATOR_POLL_MS + 1;
+    expect(sweptAway(oldRow, atPoll)).toBe(true);       // deleted ~9.5 min before the 15-min poll
+    expect(readerReturns(oldRow, atPoll)).toBe(false);  // gone — the exact loss this SD fixes
+  });
+});
+
+// End-to-end through the REAL selectUnactionedAdvisories return path (not the local model):
+// model the DB response as the real sweep (DELETE WHERE expires_at < now) composed with the
+// real reader gate (kind=adam_advisory AND actioned_at IS NULL), then assert the exported
+// selector passes the survivor set through as {rows}. Closes the "real reader RETURN behavior
+// unproven" gap — the local-model tests above prove the survive/swept logic; this proves the
+// actual function returns exactly the surviving, unactioned advisories.
+describe('FR1+FR3 end-to-end: the REAL selectUnactionedAdvisories returns only surviving, unactioned advisories', () => {
+  const now0 = 1_000_000_000_000;
+  const atPoll = now0 + COORDINATOR_POLL_MS + 1;
+  const seed = [
+    { id: 'fresh', expires_at: advisoryExpiresAt(now0), payload: { kind: 'adam_advisory' } },                                              // durable TTL, unactioned → survives + returned
+    { id: 'actioned', expires_at: advisoryExpiresAt(now0), payload: { kind: 'adam_advisory', actioned_at: new Date(atPoll).toISOString() } }, // durable but actioned → gated out
+    { id: 'old-swept', expires_at: new Date(now0 + 30_000 + 5 * 60_000).toISOString(), payload: { kind: 'adam_advisory' } },                // old short TTL → swept before poll
+  ];
+  // Mock supabase whose terminal result is the seed AFTER the real DB semantics at poll time.
+  function dbAtPoll(captured) {
+    const survivors = seed
+      .filter((r) => !sweptAway(r, atPoll))                  // cleanup_expired_coordination DELETE
+      .filter((r) => r.payload?.actioned_at == null);        // the selector's actioned_at IS NULL gate
+    const result = { data: survivors, error: null };
+    const chain = {
+      from() { return chain; }, select() { return chain; },
+      eq(k, v) { (captured.eq = captured.eq || []).push([k, v]); return chain; },
+      is(k, v) { (captured.is = captured.is || []).push([k, v]); return chain; },
+      in() { return chain; }, order() { return chain; }, limit() { return chain; },
+      then(res, rej) { return Promise.resolve(result).then(res, rej); },
+    };
+    return chain;
+  }
+
+  it('returns the fresh unactioned advisory and excludes the actioned + swept ones', async () => {
+    const captured = {};
+    const { rows, error } = await selectUnactionedAdvisories(dbAtPoll(captured), 'coord-uuid', { limit: 20 });
+    expect(error).toBeNull();
+    expect(rows.map((r) => r.id)).toEqual(['fresh']); // actioned gated, old-swept deleted
+    // and it really did request the actioned_at gate (consumer-boundary contract)
+    expect(captured.is).toContainEqual(['payload->>actioned_at', null]);
+  });
+
+  it('surfaces a DB error as {rows:[], error} (fail-soft passthrough)', async () => {
+    const errChain = { from() { return errChain; }, select() { return errChain; }, eq() { return errChain; }, is() { return errChain; }, in() { return errChain; }, order() { return errChain; }, limit() { return errChain; }, then(res, rej) { return Promise.resolve({ data: null, error: { message: 'boom' } }).then(res, rej); } };
+    const { rows, error } = await selectUnactionedAdvisories(errChain, 'coord-uuid');
+    expect(rows).toEqual([]);
+    expect(error).toEqual({ message: 'boom' });
+  });
+});


### PR DESCRIPTION
## Summary
Harden Adam machinery at the **CONSUMER boundary** (the real reader sees it), not just the producer. Systemic root cause: machinery was verified where it is produced (advisory emitted / field exists / list compiles) but never that the real reader reads it back.

## FRs
- **FR1 (comms-durability)** — `adam-advisory.cjs`: durable advisory TTL (`advisoryExpiresAt`/`ADVISORY_TTL_MS`=24h) for **all** modes. Request mode was ~5.5min (`timeoutMs+5min`); the expiry sweep (`cleanup_expired_coordination`, DELETE WHERE expires_at < now()) runs ~every 5min while the coordinator inbox-monitor polls every 15min — so request advisories were **physically deleted ~9.5min before being read**. `timeoutMs` now bounds only `awaitCoordinatorReply`.
- **FR3 (consumer-query unification)** — `fleet-dashboard.cjs` `printAdamInbox` now calls the single canonical `selectUnactionedAdvisories` instead of re-implementing the query: removes a writer/consumer drift surface and fixes a latent **missed-broadcast-advisories** bug. Registered `PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001`.
- **FR2 (contract-tooling parity)** — arm the contract-named **belt-countdown** duty in `ADAM_LOOPS` (it died every session); `parseDurableDutyMarkers`/`missingDurableDuties` enforce contract-to-tooling parity, surfaced at `/adam` startup via `renderContractParity` (fail-open) **and** in CI.

## Adversarial review (28 agents) — 4 confirmed findings fixed before merge
- **HIGH**: `.claude/commands/adam.md` still said "four loops" / omitted belt-countdown from the `--armed` example (same drift class, in the operator doc) -> updated to five loops.
- **MED**: parity check was test-only -> now runs at `/adam` startup (`renderContractParity` in `buildReport`).
- **MED**: brittle duty-marker regex (silent false negatives on hyphens/case) -> broadened + documented convention.
- **MED**: round-trip asserted against a local model -> added an end-to-end assertion through the real `selectUnactionedAdvisories`.

## Tests
45 green (16 `adam-startup-check` + 29 consumer-invariant/advisory/resilient-symmetric). No schema migration; CONST-014 decomposition evaluated and declined (single SD, ~150 LOC).

SD: SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (infrastructure, [MODE: campaign])

🤖 Generated with [Claude Code](https://claude.com/claude-code)
