### PR TITLE
feat(SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D): single publish() orchestration — dry-run-default + fail-closed post-publish gates

### DIFF
--- a/.prd-payloads/SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D.json
+++ b/.prd-payloads/SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D.json
@@ -1,0 +1,91 @@
+{
+  "executive_summary": "Child D (the integration capstone) of the CONST-014 decomposition of SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001 (Cloudflare venture-publish retarget). Ties children A (stack descriptor), B (DB provisioning/routing) and C (spend-guardrails) into a SINGLE publish() action plus post-publish verifiers. publish() is DRY-RUN by default — it plans the Cloudflare Pages/Workers-or-Cloud-Run deploy + D1/Neon DB + R2 + production migrations and emits a reviewable evidence object WITHOUT executing anything, unless explicitly told dryRun:false and the venture passes every readiness check (guardrails active, DB connection provisioned). All external CLIs (wrangler/gcloud/neonctl/git) go through an injected, mockable cli-adapters layer so the whole orchestration is testable with no real CLIs. Non-overlapping with A/B/C/E; the only shared-file edit is a single family-aware line in build-tasks-writer.",
+  "business_context": "Today 'publish a venture' is a hand-run sequence of CLI steps with no single safe entry point and no machine-checkable proof the deploy succeeded. That is error-prone and blocks autonomous venture launch. D makes publishing one reviewable, fail-safe step: dry-run-by-default so an operator can see exactly what WOULD happen, human-gated for the real run, refusing to publish a venture whose guardrails (C) or DB connection (B) are not ready, and backed by post-publish verifiers that prove the Pages URL / compute / DB / storage actually came up. This is the capstone that makes the Cloudflare retarget usable end-to-end.",
+  "technical_context": "Reuses (does NOT modify): C's lib/venture-deploy/spend-guardrails.js (evaluateGuardrails, GUARDRAIL_NAMES, persistGuardrailDecisions) + the 'spend guardrails ready' verifier; B's stakes-router + the stack_descriptor.connection {provider, secret_ref} written by the provisioner + B's 'stack descriptor valid' / 'deployment target provisioned' verifiers; A's lib/venture-deploy/stack-descriptor.js (validateStackDescriptor, deployTargetFamily). build-tasks-writer.js already dispatches on deployTargetFamily and has a computed `family`; only its Child-3 line 3.5 (currently hardcoded 'Replit hosting') needs to become family-aware. New gate strings MUST be distinct from B ('stack descriptor valid','deployment target provisioned') and C ('spend guardrails ready').",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Single publish() orchestration action — dry-run-default, human-gated, fail-safe",
+      "description": "CREATE lib/venture-deploy/publish.js exporting async publish(ventureId, supabase, deployCfg, deps). DRY-RUN by DEFAULT (deployCfg.dryRun !== false). It (a) reads the venture's stack_descriptor + connection (B) and resolves deployTargetFamily; (b) checks readiness — guardrails active via C's evaluateGuardrails/the recorded venture_guardrail_state, and DB connection provisioned (stack_descriptor.connection.provider+secret_ref); (c) plans the ordered deploy steps (Pages build + Workers/Cloud-Run deploy + D1/Neon ensure + R2 + prod migrations) via the cli-adapters; (d) in dry-run, executes NOTHING and returns evidence of the planned actions; in real-run (dryRun:false) it refuses with a blocked status naming the first failing readiness check, else runs the steps through the adapters. Emits { status: 'planned'|'published'|'blocked', deploymentUrl, databaseReady, guardrailsActive, evidence: { plannedActions[], adapterCalls[] } }. Fail-loud on a missing/invalid descriptor.",
+      "acceptance_criteria": [
+        "Calling publish() with no dryRun override for a ready venture returns status 'planned' with a populated evidence.plannedActions and executes ZERO real adapter side-effects — an operator can read exactly what a real publish would do.",
+        "Calling publish() with dryRun:false for a venture whose guardrails are not active OR whose DB connection is missing returns status 'blocked' naming the failing check, and performs no partial deploy.",
+        "Calling publish() with dryRun:false for a fully-ready venture invokes the cli-adapters in order and returns status 'published' with deploymentUrl/databaseReady/guardrailsActive set.",
+        "publish() fails loud on a missing or invalid stack_descriptor (never a silent no-op deploy)."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Injected, mockable CLI adapters",
+      "description": "CREATE lib/venture-deploy/cli-adapters.js wrapping the external deploy CLIs (wrangler pages/deploy, gcloud run deploy, neonctl, git/CI trigger) behind a small typed interface { deployPages, deployWorkers, deployCloudRun, ensureD1, ensureNeon, ensureR2, runMigrations }. Each adapter is a thin execFile wrapper; the module exports a default real-adapter set AND accepts dependency injection so publish() can be driven with fakes. Real adapters are NEVER invoked in dry-run.",
+      "acceptance_criteria": [
+        "publish() consumes cli-adapters via injection (deps.adapters), so unit tests pass in fakes and need no real wrangler/gcloud/neonctl installed.",
+        "The default real adapters are thin execFile wrappers with no business logic.",
+        "In dry-run, no adapter's execute path is called — only its planned-action descriptor is recorded in evidence."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Fail-closed post-publish verifiers",
+      "description": "UPDATE lib/eva/lifecycle/exit-gate-verifiers.js: register post-publish verifiers under gate strings DISTINCT from B/C — 'pages url live' (deploymentUrl recorded for cloudflare/cloud-run ventures), 'compute deployed' (Workers/Cloud Run service recorded), and 'publish evidence recorded' (a publish evidence artifact/record exists for the venture). All FAIL-CLOSED: query error / missing record => satisfied:false. Registered = enforced once a stage wires the string into gates.exit.",
+      "acceptance_criteria": [
+        "The post-publish verifiers return satisfied:false when the venture has no recorded deployment URL / compute / publish evidence (fail-closed).",
+        "They return satisfied:true only when the corresponding publish record is present.",
+        "The new gate strings are substring-distinct from B's and C's gate strings (no resolveVerifier collision)."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Family-aware Child-3 deploy build-task line",
+      "description": "UPDATE lib/eva/bridge/build-tasks-writer.js — the single Child-3 line 3.5 (currently hardcoded 'Replit hosting (autoscale)') becomes family-aware using the already-computed `family`: replit => existing Replit prose (byte-identical for replit ventures); cloudflare => Cloudflare Pages/Workers via `wrangler`; cloud-run => `gcloud run deploy`. One line only — disjoint from A.",
+      "acceptance_criteria": [
+        "A replit-family venture's generated build tasks contain the byte-identical original '3.5 Deploy — Replit hosting' line (no regression).",
+        "A cloudflare-family venture's 3.5 line references Cloudflare Pages/Workers + wrangler.",
+        "A cloud-run-family venture's 3.5 line references gcloud run deploy."
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Tests + activation",
+      "description": "CREATE tests/unit/venture-publish.test.js covering publish() dry-run-default (no side-effects + evidence shape), real-run blocked-on-failed-readiness, real-run published-with-fakes, fail-loud on bad descriptor; the post-publish verifiers fail-closed/pass; and the family-aware build-task line for all 3 families. Set product_requirements_v2.activation_test_id to this test.",
+      "acceptance_criteria": [
+        "Unit tests cover publish() dry-run/blocked/published/fail-loud with mocked cli-adapters (no real CLIs).",
+        "Tests assert the post-publish verifiers are fail-closed and the build-task line is family-aware for replit/cloudflare/cloud-run.",
+        "All tests pass green under the vitest unit project; PRD.activation_test_id is set and the activation test passes."
+      ]
+    }
+  ],
+  "non_functional_requirements": [
+    {"id": "NFR-1", "title": "Safe-by-default", "description": "publish() is dry-run by default and human-gated; it never executes a real deploy without an explicit dryRun:false AND passing every readiness check."},
+    {"id": "NFR-2", "title": "Testable without real infra", "description": "All external CLIs are behind injected, mockable adapters so the orchestration is fully unit-testable with no wrangler/gcloud/neonctl installed."},
+    {"id": "NFR-3", "title": "No regression / non-overlapping", "description": "Reuses A/B/C modules read-only; the only shared-file change is one family-aware line in build-tasks-writer, preserving byte-identical output for replit ventures."}
+  ],
+  "test_scenarios": [
+    {"id": "TS-1", "scenario": "publish() dry-run default: zero side-effects, evidence.plannedActions populated"},
+    {"id": "TS-2", "scenario": "publish() real-run: blocked when guardrails inactive / DB connection missing; published when ready (fakes)"},
+    {"id": "TS-3", "scenario": "post-publish verifiers fail-closed + pass; family-aware build-task line for replit/cloudflare/cloud-run"}
+  ],
+  "acceptance_criteria": [
+    "Single publish() action orchestrates the venture deploy, dry-run by default, human-gated, refusing on failed readiness checks, reusing A/B/C.",
+    "All external CLIs behind injected mockable adapters; no real CLI invoked in dry-run or tests.",
+    "Fail-closed post-publish verifiers registered with gate strings distinct from B/C.",
+    "Child-3 deploy build-task line is family-aware (replit byte-identical, cloudflare/cloud-run cloud prose).",
+    "Tests green; PRD.activation_test_id set."
+  ],
+  "risks": [
+    {"risk": "publish() accidentally executes a real deploy in dry-run", "severity": "high", "mitigation": "dry-run is the DEFAULT; real adapters are only reachable via injected execute path gated on dryRun:false; a test asserts zero adapter side-effects in dry-run."},
+    {"risk": "build-tasks-writer edit regresses replit ventures", "severity": "medium", "mitigation": "keep the replit branch byte-identical; test asserts the original line for replit family."},
+    {"risk": "post-publish gate strings collide with B/C", "severity": "low", "mitigation": "choose substring-distinct strings; test asserts resolveVerifier maps them to the new verifiers, not B/C."}
+  ],
+  "implementation_approach": {
+    "summary": "Build the mockable cli-adapters first, then the dry-run-default publish() orchestration that reuses A/B/C, then the fail-closed post-publish verifiers and the one family-aware build-task line, then tests + adversarial review.",
+    "steps": [
+      "CREATE lib/venture-deploy/cli-adapters.js — injected, mockable wrappers (wrangler/gcloud/neonctl/CI).",
+      "CREATE lib/venture-deploy/publish.js — dry-run-default, human-gated publish() reusing C's guardrails + B's connection; emits {status, deploymentUrl, databaseReady, guardrailsActive, evidence}.",
+      "UPDATE lib/eva/lifecycle/exit-gate-verifiers.js — fail-closed post-publish verifiers, gate strings distinct from B/C.",
+      "UPDATE lib/eva/bridge/build-tasks-writer.js — single family-aware Child-3 deploy line (replit byte-identical).",
+      "CREATE tests/unit/venture-publish.test.js + set PRD.activation_test_id; rewrite auto-stories to INVEST; adversarial review; TESTING evidence; handoffs."
+    ]
+  },
+  "dependencies": ["SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-A (COMPLETED)", "SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-B (COMPLETED)", "SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-C (COMPLETED)"]
+}

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-B",
-  "expectedBranch": "feat/SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-B",
-  "createdAt": "2026-06-14T20:40:02.596Z",
+  "sdKey": "SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D",
+  "expectedBranch": "feat/SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D",
+  "createdAt": "2026-06-14T21:48:20.163Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/bridge/build-tasks-writer.js
+++ b/lib/eva/bridge/build-tasks-writer.js
@@ -162,6 +162,15 @@ ${grandchildren}`;
   child2 += `
 - [ ] **Feedback page (required in every venture)** — build the \`/feedback\` page following \`docs/design-prompts.md\` **Prompt 5**; wire the landing footer "Feedback" link to it.`;
 
+  // SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D FR-4: family-aware deploy line.
+  // replit => byte-identical original (no regression); cloudflare => Pages/Workers via
+  // wrangler; cloud-run => gcloud run deploy. `family`/`isCloudflare` already in scope.
+  const deployLine = family === 'replit'
+    ? '- [ ] **3.5 Deploy** — Replit hosting (autoscale); confirm the run command + port in \`.replit\`.'
+    : isCloudflare
+      ? '- [ ] **3.5 Deploy** — Cloudflare Pages (frontend) + Workers (compute) via \`wrangler pages deploy\` / \`wrangler deploy\`.'
+      : '- [ ] **3.5 Deploy** — GCP Cloud Run via \`gcloud run deploy\` (containerized; listen on the injected PORT).';
+
   const child3 = `
 
 ### Child 3 — Monitoring, polish & deploy
@@ -169,7 +178,7 @@ ${grandchildren}`;
 - [ ] **3.2 AI images (if applicable)** — Google Gemini image editing via \`GEMINI_API_KEY\`; honest fallback when unconfigured.
 - [ ] **3.3 Polish** — responsive/mobile-first, a11y (semantic HTML + ARIA).
 ${line34}
-- [ ] **3.5 Deploy** — Replit hosting (autoscale); confirm the run command + port in \`.replit\`.
+${deployLine}
 `;
 
   return header + child2 + child3;

--- a/lib/eva/lifecycle/exit-gate-verifiers.js
+++ b/lib/eva/lifecycle/exit-gate-verifiers.js
@@ -22,6 +22,9 @@ import { normalizeBuildTaskCompletion } from '../bridge/repo-readiness.js';
 import { GUARDRAIL_NAMES } from '../../venture-deploy/spend-guardrails.js';
 // SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-B FR-3: stack-descriptor validation.
 import { validateStackDescriptor } from '../../venture-deploy/stack-descriptor.js';
+// SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D FR-3: post-publish verifiers read
+// the publish record written by lib/venture-deploy/publish.js into
+// ventures.stack_descriptor.publish. (No extra import needed — read inline.)
 
 /**
  * @typedef {Object} VerifierResult
@@ -371,6 +374,50 @@ async function verifyDeploymentTargetProvisioned({ supabase, ventureId }) {
 }
 
 /**
+ * SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D FR-3: fail-closed post-publish gates.
+ *
+ * All read ventures.stack_descriptor.publish (written by publish() on a real
+ * 'published' run). FAIL-CLOSED — query error, missing venture row, or missing
+ * publish record yields satisfied:false. Gate strings are distinct from B/C.
+ */
+
+/** Verifier: a deployment URL was recorded by publish(). Backs 'pages url live'. */
+async function verifyPagesUrlLive({ supabase, ventureId }) {
+  const { data, error } = await supabase
+    .from('ventures').select('stack_descriptor').eq('id', ventureId).maybeSingle();
+  if (error) return { satisfied: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
+  const url = data?.stack_descriptor?.publish?.deploymentUrl;
+  if (typeof url !== 'string' || url.length === 0) {
+    return { satisfied: false, reason: 'no deployment URL recorded by publish() → fail-closed' };
+  }
+  return { satisfied: true, reason: '' };
+}
+
+/** Verifier: publish() reported status 'published'. Backs 'compute deployed'. */
+async function verifyComputeDeployed({ supabase, ventureId }) {
+  const { data, error } = await supabase
+    .from('ventures').select('stack_descriptor').eq('id', ventureId).maybeSingle();
+  if (error) return { satisfied: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
+  const status = data?.stack_descriptor?.publish?.status;
+  if (status !== 'published') {
+    return { satisfied: false, reason: `publish status is '${status ?? 'none'}' (not 'published') → fail-closed` };
+  }
+  return { satisfied: true, reason: '' };
+}
+
+/** Verifier: a publish evidence record exists. Backs 'publish evidence recorded'. */
+async function verifyPublishEvidenceRecorded({ supabase, ventureId }) {
+  const { data, error } = await supabase
+    .from('ventures').select('stack_descriptor').eq('id', ventureId).maybeSingle();
+  if (error) return { satisfied: false, reason: `ventures query failed: ${error.message} (fail-closed)` };
+  const evidence = data?.stack_descriptor?.publish?.evidence;
+  if (!evidence || !Array.isArray(evidence.plannedActions) || evidence.plannedActions.length === 0) {
+    return { satisfied: false, reason: 'no publish evidence (plannedActions) recorded → fail-closed' };
+  }
+  return { satisfied: true, reason: '' };
+}
+
+/**
  * Verifier registry: gate-string-substring → verifier function.
  * Lookup is case-insensitive substring match (gate strings are author-prose so
  * exact-string equality is too brittle).
@@ -397,6 +444,10 @@ export const GATE_VERIFIERS = Object.freeze([
   // SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-B FR-3 — fail-closed descriptor + provisioning gates.
   { match: 'stack descriptor valid', verifier: verifyStackDescriptorValid },
   { match: 'deployment target provisioned', verifier: verifyDeploymentTargetProvisioned },
+  // SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D FR-3 — fail-closed post-publish gates.
+  { match: 'pages url live', verifier: verifyPagesUrlLive },
+  { match: 'compute deployed', verifier: verifyComputeDeployed },
+  { match: 'publish evidence recorded', verifier: verifyPublishEvidenceRecorded },
 ]);
 
 /**

--- a/lib/venture-deploy/cli-adapters.js
+++ b/lib/venture-deploy/cli-adapters.js
@@ -1,0 +1,57 @@
+/**
+ * CLI adapters for venture publish — thin, injectable, mockable wrappers around
+ * the external deploy CLIs (wrangler / gcloud / neonctl / CI trigger).
+ *
+ * SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D (FR-2).
+ *
+ * Each adapter is a THIN execFile wrapper with NO business logic — the
+ * orchestration lives in publish.js. publish() takes an adapter set via
+ * dependency injection (deps.adapters), so unit tests pass fakes and need no
+ * real wrangler/gcloud/neonctl installed. The real adapters are NEVER invoked
+ * in a dry-run (publish() only records their planned-action descriptors).
+ *
+ * @module lib/venture-deploy/cli-adapters
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Build a thin execFile-backed adapter. The returned fn runs `bin args...` and
+ * resolves { stdout, stderr }. No parsing / no business logic.
+ * @param {string} bin
+ */
+function cmd(bin) {
+  return async (args = [], opts = {}) => {
+    const { stdout, stderr } = await execFileAsync(bin, args, { ...opts });
+    return { bin, args, stdout, stderr };
+  };
+}
+
+/**
+ * The default REAL adapter set. Each entry is a thin CLI wrapper.
+ * @typedef {Object} CliAdapters
+ * @property {(args?:string[])=>Promise<any>} deployPages    — `wrangler pages deploy`
+ * @property {(args?:string[])=>Promise<any>} deployWorkers  — `wrangler deploy`
+ * @property {(args?:string[])=>Promise<any>} deployCloudRun — `gcloud run deploy`
+ * @property {(args?:string[])=>Promise<any>} ensureD1       — `wrangler d1`
+ * @property {(args?:string[])=>Promise<any>} ensureNeon     — `neonctl`
+ * @property {(args?:string[])=>Promise<any>} ensureR2       — `wrangler r2`
+ * @property {(args?:string[])=>Promise<any>} runMigrations  — project migration applier
+ */
+export const realAdapters = Object.freeze({
+  deployPages: cmd('wrangler'),    // wrangler pages deploy ...
+  deployWorkers: cmd('wrangler'),  // wrangler deploy ...
+  deployCloudRun: cmd('gcloud'),   // gcloud run deploy ...
+  ensureD1: cmd('wrangler'),       // wrangler d1 ...
+  ensureNeon: cmd('neonctl'),      // neonctl ...
+  ensureR2: cmd('wrangler'),       // wrangler r2 ...
+  runMigrations: cmd('node'),      // node scripts/apply-migration.js ... (real prod apply stays chairman-gated elsewhere)
+});
+
+/** Canonical adapter keys, in stable order — used to validate an injected set. */
+export const ADAPTER_KEYS = Object.freeze(Object.keys(realAdapters));
+
+export default { realAdapters, ADAPTER_KEYS };

--- a/lib/venture-deploy/publish.js
+++ b/lib/venture-deploy/publish.js
@@ -1,0 +1,178 @@
+/**
+ * Single venture publish() orchestration — the integration capstone.
+ *
+ * SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D (FR-1).
+ *
+ * Ties children A (stack descriptor), B (DB provisioning/routing) and C
+ * (spend-guardrails) into ONE action that plans — and, only when explicitly told
+ * AND every readiness check passes, executes — the Cloudflare Pages/Workers or
+ * Cloud Run deploy + D1/Neon + R2 + production migrations.
+ *
+ * SAFE BY DEFAULT:
+ *   - DRY-RUN is the default (deployCfg.dryRun !== false). A dry-run executes NO
+ *     real adapter side-effects; it only records the ordered planned actions in
+ *     `evidence` so an operator can review exactly what a real publish would do.
+ *   - A real run (dryRun:false) REFUSES (status 'blocked') unless the venture's
+ *     spend guardrails (C) are active AND its DB connection (B) is provisioned.
+ *   - All external CLIs go through injected, mockable adapters (FR-2) — real
+ *     adapters are never reached in dry-run or in tests.
+ *
+ * @module lib/venture-deploy/publish
+ */
+
+import { deployTargetFamily, validateStackDescriptor } from './stack-descriptor.js';
+import { GUARDRAIL_NAMES } from './spend-guardrails.js';
+import { realAdapters } from './cli-adapters.js';
+
+/**
+ * @typedef {Object} PublishResult
+ * @property {'planned'|'published'|'blocked'} status
+ * @property {string|null} deploymentUrl
+ * @property {boolean} databaseReady
+ * @property {boolean} guardrailsActive
+ * @property {{plannedActions: object[], adapterCalls: object[], blockedReason?: string}} evidence
+ */
+
+/** Read whether all 8 spend guardrails are recorded 'allow' with no open kill-switch (reuses C's state). */
+async function readGuardrailsActive(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('venture_guardrail_state')
+    .select('guardrail, decision, killswitch_open')
+    .eq('venture_id', ventureId);
+  if (error) return { active: false, reason: `guardrail-state query failed: ${error.message}` };
+  const rows = data || [];
+  const recorded = new Set(rows.map((r) => r.guardrail));
+  const missing = GUARDRAIL_NAMES.filter((n) => !recorded.has(n));
+  if (missing.length > 0) return { active: false, reason: `guardrails not recorded: ${missing.join(', ')}` };
+  const bad = rows.filter((r) => r.decision !== 'allow' || r.killswitch_open === true);
+  if (bad.length > 0) return { active: false, reason: `guardrails unmet/halted: ${bad.map((r) => r.guardrail).join(', ')}` };
+  return { active: true, reason: '' };
+}
+
+/** Build the ordered list of planned deploy actions for a venture's deployment family. */
+function planActions(family, descriptor) {
+  const actions = [];
+  const dbProvider = descriptor?.connection?.provider || descriptor?.db_provider || 'unknown';
+  if (family === 'cloudflare') {
+    actions.push({ adapter: 'deployPages', desc: 'wrangler pages deploy (Cloudflare Pages frontend)' });
+    actions.push({ adapter: 'deployWorkers', desc: 'wrangler deploy (Cloudflare Workers compute)' });
+    if (dbProvider === 'd1') actions.push({ adapter: 'ensureD1', desc: 'wrangler d1 (provision/verify D1)' });
+    if (dbProvider === 'neon') actions.push({ adapter: 'ensureNeon', desc: 'neonctl (provision/verify Neon)' });
+    actions.push({ adapter: 'ensureR2', desc: 'wrangler r2 (object storage)' });
+  } else if (family === 'cloud-run') {
+    actions.push({ adapter: 'deployPages', desc: 'wrangler pages deploy (Cloudflare Pages frontend)' });
+    actions.push({ adapter: 'deployCloudRun', desc: 'gcloud run deploy (Cloud Run compute)' });
+    actions.push({ adapter: 'ensureNeon', desc: 'neonctl (provision/verify Neon)' });
+    actions.push({ adapter: 'ensureR2', desc: 'wrangler r2 (object storage)' });
+  } else {
+    // replit family — the legacy path is hosted on Replit; publish() plans no cloud steps.
+    actions.push({ adapter: null, desc: 'Replit hosting (autoscale) — no cloud publish steps' });
+  }
+  actions.push({ adapter: 'runMigrations', desc: 'apply production migrations (chairman-gated for prod-deploy)' });
+  return actions;
+}
+
+/**
+ * Orchestrate a venture publish.
+ *
+ * @param {string} ventureId
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ dryRun?: boolean }} [deployCfg] — dryRun defaults to TRUE (safe)
+ * @param {{ adapters?: object }} [deps] — inject fake adapters for testing
+ * @returns {Promise<PublishResult>}
+ */
+export async function publish(ventureId, supabase, deployCfg = {}, deps = {}) {
+  if (!ventureId) throw new Error('publish: ventureId is required');
+  if (!supabase) throw new Error('publish: supabase client is required');
+  const dryRun = deployCfg.dryRun !== false; // DEFAULT TRUE (safe)
+  const adapters = deps.adapters || realAdapters;
+
+  // Read the venture's stack descriptor (A) + resolved connection (B).
+  const { data: vRow, error: vErr } = await supabase
+    .from('ventures')
+    .select('stack_descriptor')
+    .eq('id', ventureId)
+    .maybeSingle();
+  if (vErr) throw new Error(`publish: cannot read ventures.stack_descriptor: ${vErr.message}`);
+  const descriptor = vRow?.stack_descriptor;
+  const { valid, errors } = validateStackDescriptor(descriptor);
+  if (!valid) {
+    // fail-loud: never silently no-op a publish on a bad descriptor.
+    throw new Error(`publish: invalid/missing stack_descriptor — refusing: ${errors.join('; ')}`);
+  }
+
+  const family = deployTargetFamily(descriptor);
+  const connection = descriptor.connection || null;
+  const databaseReady = !!(connection && connection.provider && connection.secret_ref);
+  const guard = await readGuardrailsActive(supabase, ventureId);
+  const guardrailsActive = guard.active;
+
+  const plannedActions = planActions(family, descriptor);
+  const evidence = { plannedActions, adapterCalls: [] };
+
+  // DRY-RUN (default): plan only, execute NOTHING.
+  if (dryRun) {
+    return {
+      status: 'planned',
+      deploymentUrl: null,
+      databaseReady,
+      guardrailsActive,
+      evidence,
+    };
+  }
+
+  // REAL RUN: refuse unless every readiness check passes (fail-safe, no partial deploy).
+  if (!guardrailsActive || !databaseReady) {
+    const blockedReason = !guardrailsActive
+      ? `spend guardrails not active: ${guard.reason}`
+      : 'database connection not provisioned (stack_descriptor.connection missing provider/secret_ref)';
+    return {
+      status: 'blocked',
+      deploymentUrl: null,
+      databaseReady,
+      guardrailsActive,
+      evidence: { ...evidence, blockedReason },
+    };
+  }
+
+  // Execute each planned action through the (injected) adapters.
+  let deploymentUrl = null;
+  for (const action of plannedActions) {
+    if (!action.adapter || typeof adapters[action.adapter] !== 'function') {
+      evidence.adapterCalls.push({ adapter: action.adapter, skipped: true, desc: action.desc });
+      continue;
+    }
+    const result = await adapters[action.adapter]([], { ventureId });
+    evidence.adapterCalls.push({ adapter: action.adapter, desc: action.desc, ran: true });
+    // First Pages/Workers/Cloud-Run deploy result that yields a URL becomes the deploymentUrl.
+    if (!deploymentUrl && result && typeof result.deploymentUrl === 'string') {
+      deploymentUrl = result.deploymentUrl;
+    }
+  }
+
+  // Persist the publish record so the fail-closed post-publish verifiers (FR-3)
+  // have evidence to read. Written under stack_descriptor.publish (additive;
+  // never touches B's connection or A's descriptor fields). Fail-loud on write error.
+  const publishRecord = {
+    status: 'published',
+    deploymentUrl,
+    family,
+    publishedAt: new Date().toISOString(),
+    evidence: { plannedActions: evidence.plannedActions, adapterCalls: evidence.adapterCalls },
+  };
+  const { error: upErr } = await supabase
+    .from('ventures')
+    .update({ stack_descriptor: { ...descriptor, publish: publishRecord } })
+    .eq('id', ventureId);
+  if (upErr) throw new Error(`publish: failed to record publish evidence: ${upErr.message}`);
+
+  return {
+    status: 'published',
+    deploymentUrl,
+    databaseReady,
+    guardrailsActive,
+    evidence,
+  };
+}
+
+export default { publish };

--- a/tests/unit/venture-publish.test.js
+++ b/tests/unit/venture-publish.test.js
@@ -1,0 +1,197 @@
+/**
+ * SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D — single publish() orchestration.
+ *
+ * Pure, no-DB / no-real-CLI unit + activation suite:
+ *  - FR-1/FR-2: publish() dry-run-default (zero side-effects + evidence), real-run
+ *    blocked-on-failed-readiness, real-run published (injected fake adapters),
+ *    fail-loud on a bad descriptor.
+ *  - FR-3: the 3 fail-closed post-publish verifiers + gate-string distinctness.
+ *  - FR-4: the family-aware Child-3 build-task deploy line (replit byte-identical).
+ *  - Activation invariant: safe-publish path is live (dry-run never deploys).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { publish } from '../../lib/venture-deploy/publish.js';
+import { GUARDRAIL_NAMES } from '../../lib/venture-deploy/spend-guardrails.js';
+import { GATE_VERIFIERS, resolveVerifier } from '../../lib/eva/lifecycle/exit-gate-verifiers.js';
+import { buildBuildTasks } from '../../lib/eva/bridge/build-tasks-writer.js';
+
+const VENTURE = 'venture-ddd-444';
+const ALL_ALLOW = GUARDRAIL_NAMES.map((g) => ({ guardrail: g, decision: 'allow', killswitch_open: false }));
+const READY_DESCRIPTOR = {
+  db_provider: 'd1',
+  deployment_target: 'cloudflare-workers',
+  connection: { provider: 'd1', secret_ref: `venture_db_secrets:${VENTURE}` },
+};
+
+// Spy adapter set: records calls; real CLIs never touched.
+function fakeAdapters(returns = {}) {
+  const calls = [];
+  const a = {};
+  for (const k of ['deployPages', 'deployWorkers', 'deployCloudRun', 'ensureD1', 'ensureNeon', 'ensureR2', 'runMigrations']) {
+    a[k] = (args, opts) => { calls.push({ name: k, args, opts }); return Promise.resolve(returns[k] || {}); };
+  }
+  a._calls = calls;
+  return a;
+}
+
+// Fake supabase: ventures select->maybeSingle, venture_guardrail_state select->eq (awaited),
+// ventures update->eq. onUpdate captures the persisted publish record.
+function fakeSupabase({ venture = null, ventureError = null, guardrails = [], guardrailsError = null, updateError = null, onUpdate = null } = {}) {
+  return {
+    from(table) {
+      const result = table === 'ventures'
+        ? { data: venture, error: ventureError }
+        : { data: guardrails, error: guardrailsError };
+      const selChain = {
+        eq() { return selChain; },
+        maybeSingle() { return Promise.resolve(result); },
+        then(res, rej) { return Promise.resolve(result).then(res, rej); }, // awaitable for guardrail read
+      };
+      return {
+        select() { return selChain; },
+        update(payload) {
+          return { eq() { if (onUpdate) onUpdate(payload); return Promise.resolve({ error: updateError }); } };
+        },
+      };
+    },
+  };
+}
+
+describe('FR-1/FR-2: publish() orchestration', () => {
+  it('DRY-RUN by default: status planned, evidence populated, ZERO adapter side-effects', async () => {
+    const adapters = fakeAdapters();
+    const sb = fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR }, guardrails: ALL_ALLOW });
+    const r = await publish(VENTURE, sb, {}, { adapters });
+    expect(r.status).toBe('planned');
+    expect(r.evidence.plannedActions.length).toBeGreaterThan(0);
+    expect(adapters._calls).toHaveLength(0); // nothing executed
+    expect(r.databaseReady).toBe(true);
+    expect(r.guardrailsActive).toBe(true);
+    expect(r.deploymentUrl).toBeNull();
+  });
+
+  it('DRY-RUN never deploys even for an UNREADY venture', async () => {
+    const adapters = fakeAdapters();
+    const sb = fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR }, guardrails: [] }); // no guardrails
+    const r = await publish(VENTURE, sb, { dryRun: true }, { adapters });
+    expect(r.status).toBe('planned');
+    expect(r.guardrailsActive).toBe(false);
+    expect(adapters._calls).toHaveLength(0);
+  });
+
+  it('REAL-RUN BLOCKED when guardrails are not active (names the failing check, no deploy)', async () => {
+    const adapters = fakeAdapters();
+    const sb = fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR }, guardrails: [] });
+    const r = await publish(VENTURE, sb, { dryRun: false }, { adapters });
+    expect(r.status).toBe('blocked');
+    expect(r.evidence.blockedReason).toContain('guardrails');
+    expect(adapters._calls).toHaveLength(0);
+  });
+
+  it('REAL-RUN BLOCKED when the DB connection is missing', async () => {
+    const adapters = fakeAdapters();
+    const noConn = { db_provider: 'd1', deployment_target: 'cloudflare-workers' }; // no connection
+    const sb = fakeSupabase({ venture: { stack_descriptor: noConn }, guardrails: ALL_ALLOW });
+    const r = await publish(VENTURE, sb, { dryRun: false }, { adapters });
+    expect(r.status).toBe('blocked');
+    expect(r.evidence.blockedReason).toContain('database');
+    expect(adapters._calls).toHaveLength(0);
+  });
+
+  it('REAL-RUN PUBLISHED for a ready venture: adapters run, deploymentUrl set, evidence persisted', async () => {
+    const adapters = fakeAdapters({ deployPages: { deploymentUrl: 'https://acme.pages.dev' } });
+    let persisted = null;
+    const sb = fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR }, guardrails: ALL_ALLOW, onUpdate: (p) => { persisted = p; } });
+    const r = await publish(VENTURE, sb, { dryRun: false }, { adapters });
+    expect(r.status).toBe('published');
+    expect(r.deploymentUrl).toBe('https://acme.pages.dev');
+    expect(adapters._calls.length).toBeGreaterThan(0);
+    // publish evidence persisted under stack_descriptor.publish (additive — connection preserved)
+    expect(persisted.stack_descriptor.publish.status).toBe('published');
+    expect(persisted.stack_descriptor.connection).toEqual(READY_DESCRIPTOR.connection);
+  });
+
+  it('FAIL-LOUD on a missing/invalid stack descriptor (never a silent no-op)', async () => {
+    const sb = fakeSupabase({ venture: { stack_descriptor: null }, guardrails: ALL_ALLOW });
+    await expect(publish(VENTURE, sb, { dryRun: false }, { adapters: fakeAdapters() })).rejects.toThrow(/invalid\/missing stack_descriptor/);
+  });
+
+  it('requires ventureId and supabase (fail-loud)', async () => {
+    await expect(publish(null, fakeSupabase())).rejects.toThrow(/ventureId/);
+    await expect(publish(VENTURE, null)).rejects.toThrow(/supabase/);
+  });
+});
+
+describe('FR-3: fail-closed post-publish verifiers', () => {
+  const PUBLISHED = {
+    ...READY_DESCRIPTOR,
+    publish: { status: 'published', deploymentUrl: 'https://acme.pages.dev', evidence: { plannedActions: [{ adapter: 'deployPages' }] } },
+  };
+
+  it('registers all 3 gate strings, distinct from B/C', () => {
+    for (const g of ['pages url live', 'compute deployed', 'publish evidence recorded']) {
+      expect(typeof resolveVerifier(g)).toBe('function');
+      expect(GATE_VERIFIERS.some((v) => v.match === g)).toBe(true);
+    }
+    // distinct from sibling B/C gates
+    const c = resolveVerifier('spend guardrails ready');
+    const b = resolveVerifier('stack descriptor valid');
+    expect(resolveVerifier('compute deployed')).not.toBe(c);
+    expect(resolveVerifier('compute deployed')).not.toBe(b);
+    // 'compute deployed' must NOT collide with the pre-existing 'application deployed'
+    expect(resolveVerifier('compute deployed')).not.toBe(resolveVerifier('application deployed'));
+  });
+
+  it('pages-url-live: PASS when recorded, fail-closed when absent / on error', async () => {
+    const v = resolveVerifier('pages url live');
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: PUBLISHED } }), ventureId: VENTURE })).satisfied).toBe(true);
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR } }), ventureId: VENTURE })).satisfied).toBe(false);
+    expect((await v({ supabase: fakeSupabase({ ventureError: { message: 'boom' } }), ventureId: VENTURE })).satisfied).toBe(false);
+  });
+
+  it('compute-deployed: PASS only when status published, fail-closed otherwise', async () => {
+    const v = resolveVerifier('compute deployed');
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: PUBLISHED } }), ventureId: VENTURE })).satisfied).toBe(true);
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR } }), ventureId: VENTURE })).satisfied).toBe(false);
+  });
+
+  it('publish-evidence-recorded: PASS when evidence present, fail-closed otherwise', async () => {
+    const v = resolveVerifier('publish evidence recorded');
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: PUBLISHED } }), ventureId: VENTURE })).satisfied).toBe(true);
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR } }), ventureId: VENTURE })).satisfied).toBe(false);
+  });
+});
+
+describe('FR-4: family-aware Child-3 deploy build-task line', () => {
+  it('replit family (no descriptor) keeps the byte-identical Replit line', () => {
+    const md = buildBuildTasks({ name: 'Acme', stackDescriptor: null });
+    expect(md).toContain('**3.5 Deploy** — Replit hosting (autoscale); confirm the run command + port in `.replit`.');
+  });
+
+  it('cloudflare family references Cloudflare Pages/Workers via wrangler', () => {
+    const md = buildBuildTasks({ name: 'Acme', stackDescriptor: { db_provider: 'd1', deployment_target: 'cloudflare-workers' } });
+    expect(md).toContain('**3.5 Deploy** — Cloudflare Pages');
+    expect(md).toContain('wrangler');
+    expect(md).not.toContain('Replit hosting (autoscale)');
+  });
+
+  it('cloud-run family references gcloud run deploy', () => {
+    const md = buildBuildTasks({ name: 'Acme', stackDescriptor: { db_provider: 'neon', deployment_target: 'cloud-run' } });
+    expect(md).toContain('gcloud run deploy');
+    expect(md).not.toContain('Replit hosting (autoscale)');
+  });
+});
+
+describe('Activation invariant (GATE_ACTIVATION_INVARIANT)', () => {
+  it('safe-publish path is live: dry-run default deploys nothing; post-publish gates fail-closed by default', async () => {
+    const adapters = fakeAdapters();
+    const sb = fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR }, guardrails: ALL_ALLOW });
+    const r = await publish(VENTURE, sb, {}, { adapters });
+    expect(r.status).toBe('planned');
+    expect(adapters._calls).toHaveLength(0);
+    // a venture that never published is not allowed to advance
+    const v = resolveVerifier('compute deployed');
+    expect((await v({ supabase: fakeSupabase({ venture: { stack_descriptor: READY_DESCRIPTOR } }), ventureId: 'fresh' })).satisfied).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D (child of AUTOMATED-RESILIENT-VENTURE-001)

The **integration capstone**: ties children A (descriptor), B (DB provisioning) and C (spend-guardrails) into one safe `publish()` action. Completes the Cloudflare venture-publish retarget (4/5 children; only E remains).

### What shipped (5 FRs)
- **FR-1** `lib/venture-deploy/publish.js` — `publish(ventureId, supabase, deployCfg, deps)`. **DRY-RUN by default** (executes nothing, returns `evidence.plannedActions`). A real run (`dryRun:false`) **refuses** with `status:'blocked'` unless spend guardrails are active (C) **and** the DB connection is provisioned (B); on success it runs the family-appropriate steps via injected adapters, records `deploymentUrl`, and persists `stack_descriptor.publish`. **Fail-loud** on a bad descriptor.
- **FR-2** `lib/venture-deploy/cli-adapters.js` — thin, **injectable, mockable** wrappers (wrangler/gcloud/neonctl/CI). Real adapters never run in dry-run or tests.
- **FR-3** Three **fail-closed** post-publish verifiers (`pages url live` / `compute deployed` / `publish evidence recorded`) — gate strings distinct from B/C; query error / missing record ⇒ `satisfied:false`.
- **FR-4** `build-tasks-writer.js` Child-3 deploy line is now **family-aware** (replit byte-identical / cloudflare wrangler / cloud-run gcloud) — one line.
- **FR-5** `tests/unit/venture-publish.test.js` — 15 tests. `PRD.activation_test_id` set.

### Evidence
- TESTING (EXEC): 15/15, `activation_invariant_verified=true`.
- VALIDATION (PLAN_VERIFICATION): PASS, all 5 FRs.
- Adversarial review: verdict **ship** — every safety contract verified by execution (dry-run never deploys, real-run fail-safe, fail-closed verifiers, no gate collision, no regression to the replit build-task path).
- Retrospective: 90/100.

### Follow-ups (tracked, deliberate scope boundary)
- Real-run adapter CLI-argument wiring is a downstream activation follow-up (D ships the safe dry-run skeleton + mockable adapters); pair with a live integration test.
- The 3 post-publish verifiers (and B/C's) are registered-but-dormant until a lifecycle stage wires their gate strings into `gates.exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
