### PR TITLE
fix(hooks): creds-free AskUserQuestion worker-block (stops live worker /loop hangs)

### DIFF
--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -182,6 +182,14 @@ const _SESSION_ID = _stdinPayload.session_id ||
   process.env.LEO_SESSION_ID ||
   'unknown';
 
+// SD-FDBK-INFRA-CREDS-FREE-ASKUSER-001: the PreToolUse stdin payload carries the
+// session's `cwd` (the directory the Claude Code session is running from). This is
+// a CREDS-FREE worker signal used by ENFORCEMENT 12: fleet workers run with cwd
+// INSIDE .worktrees/<SD>/, while the coordinator/Adam/operator run from the repo
+// ROOT. Falls back to process.cwd() only if the payload omitted it. May be ''/undefined
+// in degenerate cases — every consumer guards against that and fail-safes to ALLOW.
+const _CWD = (typeof _stdinPayload.cwd === 'string' && _stdinPayload.cwd) || process.cwd() || '';
+
 // QF-20260504-932: test-only mode — print resolved variables and exit before
 // any enforcement runs. Tests use this to verify stdin/env resolution without
 // triggering side-effects (audit writes, exit-2 blocks). Production hooks
@@ -566,13 +574,56 @@ async function main() {
   // coordinator/Adam/non_fleet); operator/chairman/coordinator/Adam and any unresolved
   // session are EXEMPT. The metadata lookup runs ONLY for this (rare) tool, and fail-OPEN
   // (any resolution error → meta=null → not blockable) so it can never wedge a tool call.
+  //
+  // SD-FDBK-INFRA-CREDS-FREE-ASKUSER-001: the DB lookup needs Supabase creds, which the
+  // live worker hooks currently LACK, so it silently fail-opened and workers hung their
+  // /loop. A CREDS-FREE fallback (cwd inside .worktrees/ → worker) now also blocks, while
+  // never false-blocking a RESOLVED coordinator/Adam (exemptByMeta). DB path stays
+  // authoritative; cwd only adds coverage when creds are absent. See block below.
   if (TOOL_NAME === 'AskUserQuestion') {
     const { metadata: meta, loopState } = await resolveSessionContext(_SESSION_ID);
-    if (isBlockableWorker(meta, loopState)) {
+
+    // SD-FDBK-INFRA-CREDS-FREE-ASKUSER-001: CREDS-FREE worker fallback.
+    // resolveSessionContext reads SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY from the
+    // inherited env and fail-OPENS (meta=null, loopState=null) when those creds are
+    // absent — which they currently are for live worker hooks (collateral from a
+    // shared-root `git clean -fdx`). With meta=null, isBlockableWorker returns false
+    // and the worker successfully calls AskUserQuestion, hanging its /loop forever
+    // (the #1 attrition cause). To close that hole we add a creds-free, metadata-
+    // wipe-proof signal: the session cwd. Fleet WORKERS run with cwd inside
+    // .worktrees/<SD>/; the coordinator, Adam, and the operator/chairman run from the
+    // repo ROOT (never inside .worktrees/), so a worktree cwd alone is a clean WORKER
+    // signal that excludes those privileged sessions. The DB path stays AUTHORITATIVE
+    // when creds are present (isBlockableWorker); the cwd predicate only adds coverage
+    // when it is not. Wrapped in try/catch — ANY error → not-worktree → fall through
+    // to the existing DB-only behavior; this can NEVER throw or wedge a tool call.
+    let isWorktreeWorker = false;
+    try {
+      isWorktreeWorker = typeof _CWD === 'string' && _CWD.length > 0 && WORKTREE_PATH_RE.test(_CWD);
+    } catch {
+      isWorktreeWorker = false; // fail-safe: treat as not-worktree → existing behavior
+    }
+    // exemptByMeta is true ONLY when metadata was ACTUALLY resolved AND says this is a
+    // privileged session (coordinator / Adam / non_fleet). When meta is null (credless),
+    // exemptByMeta is false, so a worktree cwd alone blocks. This guarantees we never
+    // false-block a RESOLVED coordinator/Adam that happens to run inside a worktree.
+    const exemptByMeta = Boolean(
+      meta && typeof meta === 'object' &&
+      (meta.is_coordinator === true || meta.role === 'adam' || meta.non_fleet === true)
+    );
+
+    const blockByDb = isBlockableWorker(meta, loopState);
+    const blockByCwd = isWorktreeWorker && !exemptByMeta;
+
+    if (blockByDb || blockByCwd) {
+      const detectedVia = blockByDb ? 'db' : 'cwd_worktree';
       const auditPromise = auditPermissionDecision(
         _SESSION_ID, TOOL_NAME, 'ENF-NO-ASKUSER-WORKER',
         'AskUserQuestion blocked for autonomous fleet worker', 'block',
-        { callsign: (meta.fleet_identity && meta.fleet_identity.callsign) || meta.callsign || null }
+        {
+          callsign: (meta && ((meta.fleet_identity && meta.fleet_identity.callsign) || meta.callsign)) || null,
+          detected_via: detectedVia
+        }
       );
       process.stderr.write(ASKUSER_DENY_MESSAGE + '\n');
       await auditAndExit(auditPromise, 2, 800);

--- a/tests/unit/pre-tool-enforce-askuser.db.test.js
+++ b/tests/unit/pre-tool-enforce-askuser.db.test.js
@@ -1,0 +1,215 @@
+/**
+ * SD-FDBK-INFRA-CREDS-FREE-ASKUSER-001 — CREDS-FREE fallback for the AskUserQuestion
+ * worker-block (ENFORCEMENT 12 in scripts/hooks/pre-tool-enforce.cjs).
+ *
+ * BUG: resolveSessionContext() reads SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY and fail-OPENS
+ * (meta=null) when creds are absent. Live worker hooks currently run WITHOUT those creds,
+ * so the DB-only guard fail-opened and workers successfully called AskUserQuestion, hanging
+ * their /loop (the #1 attrition cause).
+ *
+ * FIX: a creds-free worker signal — cwd inside .worktrees/ — blocks EVEN WHEN meta=null,
+ * while the DB path stays authoritative when creds ARE present, and a RESOLVED
+ * coordinator/Adam is never false-blocked even inside a worktree.
+ *
+ * These spawn the REAL hook subprocess feeding the PreToolUse stdin payload (which carries
+ * `cwd`). Cases that need a resolved metadata row stand up a tiny local HTTP server that
+ * mimics the Supabase REST claude_sessions endpoint and point SUPABASE_URL at it.
+ *
+ * NOTE: each case uses a UNIQUE session_id and (where Bash) a UNIQUE command so the
+ * stateful RCA repeat-blocker (ENFORCEMENT 11) can never pollute a control case.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn } from 'child_process';
+import { resolve } from 'path';
+import http from 'http';
+
+const HOOK_PATH = resolve(process.cwd(), 'scripts/hooks/pre-tool-enforce.cjs');
+
+// A fabricated worktree cwd (fleet WORKER signal) and a repo-root cwd (privileged sessions).
+const WORKTREE_CWD = resolve(process.cwd(), '.worktrees', 'SD-TEST-CREDS-FREE-001');
+const ROOT_CWD = process.cwd();
+
+let _servers = [];
+afterEach(() => {
+  for (const s of _servers) { try { s.close(); } catch { /* ignore */ } }
+  _servers = [];
+});
+
+/**
+ * Spawn the hook ASYNCHRONOUSLY with a PreToolUse stdin payload. Returns a promise of
+ * { status, stdout, stderr }.
+ *
+ * MUST be async (not spawnSync): the DB-path cases stand up an in-process HTTP mock server
+ * in THIS Node process, so the parent event loop must stay free to serve the child's fetch
+ * while the hook runs — spawnSync would block the loop and the mock would never answer.
+ *
+ * env overrides are merged onto a CLEANED base that strips any inherited Supabase creds so
+ * "credless" cases are genuinely credless regardless of the runner's environment.
+ */
+function runHook({ payload, env = {} }) {
+  return new Promise((resolveP) => {
+    const baseEnv = { ...process.env };
+    delete baseEnv.SUPABASE_URL;
+    delete baseEnv.SUPABASE_SERVICE_ROLE_KEY;
+    // Disable the RCA tiered enforcement so it can never interfere with control cases.
+    baseEnv.LEO_RCA_ENFORCEMENT = 'off';
+    const child = spawn(process.execPath, [HOOK_PATH], {
+      env: { ...baseEnv, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    const killer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* ignore */ } }, 15000);
+    child.on('close', (status) => {
+      clearTimeout(killer);
+      resolveP({ status, stdout, stderr });
+    });
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+/**
+ * Stand up a local HTTP server that mimics the Supabase REST API the hook calls:
+ *  - GET  /rest/v1/claude_sessions?...  → returns [metadataRow] (or [] for none)
+ *  - POST /rest/v1/permission_audit_log → 201 (audit sink; body ignored)
+ * Returns { url } and registers it for afterEach teardown.
+ */
+function startSupabaseMock({ metadataRow }) {
+  return new Promise((resolveP) => {
+    const server = http.createServer((req, res) => {
+      if (req.method === 'GET' && req.url.includes('/rest/v1/claude_sessions')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(metadataRow ? [metadataRow] : []));
+        return;
+      }
+      // Drain & accept everything else (audit POSTs, etc.)
+      req.resume();
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end('{}');
+    });
+    server.listen(0, '127.0.0.1', () => {
+      _servers.push(server);
+      const { port } = server.address();
+      resolveP({ url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+describe('ENFORCEMENT 12 — CREDS-FREE AskUserQuestion worker block (SD-FDBK-INFRA-CREDS-FREE-ASKUSER-001)', () => {
+  // (a) THE KEY NEW CASE: worker cwd in .worktrees/ + meta=null (credless) → BLOCK (exit 2)
+  it('(a) BLOCKS a credless worker whose cwd is inside .worktrees/ (exit 2)', async () => {
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-a-worker',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'a-unique?', options: ['X'] }] },
+        hook_event_name: 'PreToolUse',
+        cwd: WORKTREE_CWD,
+      },
+      // intentionally NO SUPABASE creds → resolveSessionContext returns meta=null
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+
+  // (b) coordinator cwd in repo root + meta=null (credless) → ALLOW (exit 0)
+  it('(b) ALLOWS a credless session whose cwd is the repo root (exit 0)', async () => {
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-b-root',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'b-unique?', options: ['X'] }] },
+        hook_event_name: 'PreToolUse',
+        cwd: ROOT_CWD,
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+
+  // (c) cwd in .worktrees/ but meta RESOLVES is_coordinator:true → ALLOW (exit 0)
+  //     edge: never false-block a RESOLVED coordinator even when it runs inside a worktree
+  it('(c) ALLOWS a RESOLVED coordinator even with a .worktrees/ cwd (exit 0)', async () => {
+    const { url } = await startSupabaseMock({
+      metadataRow: { metadata: { is_coordinator: true }, loop_state: 'active' },
+    });
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-c-coordinator',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'c-unique?', options: ['X'] }] },
+        hook_event_name: 'PreToolUse',
+        cwd: WORKTREE_CWD,
+      },
+      env: { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: 'test-key' },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+
+  // (d) existing DB path still blocks a worker WITH creds (loop_state=active, no callsign)
+  it('(d) DB path still BLOCKS a resolved /loop worker with creds (exit 2)', async () => {
+    const { url } = await startSupabaseMock({
+      metadataRow: { metadata: { source: 'startup' }, loop_state: 'active' },
+    });
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-d-dbworker',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'd-unique?', options: ['X'] }] },
+        hook_event_name: 'PreToolUse',
+        // cwd at ROOT so the ONLY block signal is the DB path, proving it still works
+        cwd: ROOT_CWD,
+      },
+      env: { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: 'test-key' },
+    });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+
+  // (e) worker cwd in .worktrees/ + a non-AskUserQuestion tool (Bash) → ALLOW (untouched)
+  it('(e) does NOT touch a non-AskUserQuestion tool (Bash) from a worktree cwd (exit 0)', async () => {
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-e-bash',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo creds-free-test-e-unique-command' },
+        hook_event_name: 'PreToolUse',
+        cwd: WORKTREE_CWD,
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+
+  // (f) cwd undefined / garbage → no throw, ALLOW (fail-safe)
+  it('(f) cwd undefined → no throw, ALLOW (fail-safe, exit 0)', async () => {
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-f-nocwd',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'f-unique?', options: ['X'] }] },
+        hook_event_name: 'PreToolUse',
+        // cwd intentionally OMITTED → _CWD falls back to process.cwd() (repo root) → not worktree
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+
+  it('(f2) garbage non-string cwd → no throw, ALLOW (fail-safe, exit 0)', async () => {
+    const r = await runHook({
+      payload: {
+        session_id: 'creds-free-test-f2-garbage',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'f2-unique?', options: ['X'] }] },
+        hook_event_name: 'PreToolUse',
+        cwd: { not: 'a-string' }, // non-string → guarded → falls back to process.cwd()
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toMatch(/ENF-NO-ASKUSER-WORKER/);
+  });
+});


### PR DESCRIPTION
## Problem (chairman-reported 2026-06-14)
Fleet workers are STILL calling AskUserQuestion and hanging their /loop (the #1 attrition cause) despite the enforcement that's supposed to block it.

## Root cause (diagnosed + proven)
`ENF-NO-ASKUSER-WORKER` (PR #4430) blocks AskUserQuestion for fleet workers via `resolveSessionContext`, which reads `SUPABASE_*` from inherited env and **fail-opens when creds are absent**. Today's live worker hooks are running **credless** (collateral from the 3× shared-root `git clean -fdx` env disruption), so the guard silently fail-opens → workers call AskUserQuestion → /loop hangs.

**Evidence:** `permission_audit_log` shows real worker blocks on 2026-06-09/10 but **ZERO on 2026-06-14** despite live workers calling it. Proven empirically: with creds a live worker → exit 2 BLOCK; without creds → exit 0 ALLOW.

## Fix
Creds-free fallback in ENFORCEMENT 12: a session whose `cwd` is inside `.worktrees/<SD>/` is a fleet worker (coordinator/Adam/operator run from the repo root), so it blocks **even when the DB read fails**. The DB path stays authoritative; `cwd` only adds coverage when creds are absent; `exemptByMeta` still exempts a *resolved* coordinator/Adam even inside a worktree. Audit records `detected_via` (db|cwd_worktree).

## Verification
- Adversarially verified **3/3** (no-false-block, fail-safe, effectiveness+test-validity).
- Cannot false-block coordinator/Adam/operator (they run from the root; regex never matches; resolved privileged sessions exempt via `exemptByMeta`).
- Fail-safe: any error / undefined cwd → ALLOW (never wedges a tool).
- 7-case integration test (incl. the key credless-worker case) + regression pass; `node --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)