### PR TITLE
feat(SD-LEO-INFRA-SILENT-STALL-PREVENTION-001): draft-stall detector + fail-open vision-score trigger

### DIFF
--- a/lib/coordinator/draft-stall-detector.mjs
+++ b/lib/coordinator/draft-stall-detector.mjs
@@ -1,0 +1,112 @@
+// SD-LEO-INFRA-SILENT-STALL-PREVENTION-001 — PURE draft-stall detector (data-in, verdict-out).
+//
+// The silent stall: an SD created when the fire-and-forget scoreSDAtConception (leo-create-sd.js, 15s timeout,
+// errors suppressed) times out or fails lands in `draft` with a NULL vision_score and no eva_vision_scores row.
+// It then blocks at LEAD-TO-PLAN (createVisionScoreGate, "no score found") and sits UNNOTICED — never claimed,
+// never surfaced. This detector flags those stranded drafts so the coordinator can remediate (re-score them).
+//
+// Co-located with charter-audit-detectors.mjs and follows its EXACT contract: a pure function, no DB / IO, that
+// returns { violation:boolean, detail:string, remediation:(string|null), ... } so it drops straight into the
+// charter-audit `D` bundle + summarizeViolations(). The clock is INJECTED (nowMs) — it never calls Date.now()
+// itself (so it is deterministically unit-testable, matching the lib/coordinator/detectors pattern).
+//
+// READ-ONLY: it never mutates state; `remediation` is the NAMED action the coordinator agent performs.
+
+const DAY_MS = 86400000;
+
+/**
+ * The CONCEPTION age of a draft row (now - created_at). A silent stall is fundamentally "conceived long ago,
+ * never scored", so created_at is the robust basis.
+ *
+ * It deliberately does NOT use updated_at as a freshness grace (the obvious GREATEST(created_at, updated_at)).
+ * Verified LIVE: unrelated writes — cascade triggers, coordinator sweeps, metadata bumps — touch
+ * strategic_directives_v2.updated_at constantly, so known-stranded drafts (e.g. YOUTUBE-STRATEGY, the ADAM-*
+ * drafts) show updated_at within hours despite being abandoned. A GREATEST grace would let that noise keep
+ * resetting the staleness clock and MASK every real stall — the detector would essentially never fire. The
+ * threshold itself (default 7d) already protects a freshly-CONCEIVED draft, so no extra updated_at grace is
+ * needed. updated_at is used only as a fallback when created_at is absent (legacy / migrated rows).
+ *
+ * @returns {number} age in ms, or NaN if no timestamp is parseable (cannot prove staleness → fail-open)
+ */
+function draftAgeMs(row, nowMs) {
+  const created = row && row.created_at ? new Date(row.created_at).getTime() : NaN;
+  const updated = row && row.updated_at ? new Date(row.updated_at).getTime() : NaN;
+  const basis = Number.isFinite(created) ? created : updated; // prefer conception time; fall back if absent
+  if (!Number.isFinite(basis)) return NaN; // no parseable timestamp → cannot prove staleness
+  return Math.max(0, nowMs - basis);
+}
+
+/**
+ * A draft is a stall CANDIDATE iff status==='draft' AND it has no AUTHORITATIVE vision score.
+ *
+ * "No authoritative score" is NOT just `strategic_directives_v2.vision_score IS NULL`: that column is essentially
+ * never populated on a successful conception-time score (scoreSD writes only eva_vision_scores; nothing syncs the
+ * column). The hard createVisionScoreGate itself treats an SD as scored if EITHER the column is set OR an
+ * eva_vision_scores row exists (vision-score.js fallback, .eq('sd_id', sdKey) — eva_vision_scores.sd_id holds the
+ * sd_key). So to avoid mislabelling a successfully-scored draft as a silent stall, a draft is a candidate only
+ * when the column is null/undefined AND its sd_key is NOT in `scoredKeys` (the injected set of sd_keys with an
+ * eva_vision_scores row — keeps this function PURE; the charter-audit caller does the one query).
+ *
+ * When `scoredKeys` is absent the check conservatively degrades to the column alone (never throws).
+ * @param {object} row
+ * @param {{has:(k:string)=>boolean}|null} scoredKeys - sd_keys known to have an eva_vision_scores row
+ */
+function isUnscoredDraft(row, scoredKeys) {
+  if (!row || row.status !== 'draft') return false;
+  if (row.vision_score !== null && row.vision_score !== undefined) return false;
+  if (scoredKeys && typeof scoredKeys.has === 'function' && scoredKeys.has(row.sd_key)) return false;
+  return true;
+}
+
+/**
+ * Find draft SDs stranded with a NULL vision_score beyond an age threshold (the silent stall). PURE.
+ *
+ * @param {Array<object>} rows - strategic_directives_v2 rows {sd_key,status,vision_score,created_at,updated_at}
+ * @param {number} nowMs - injected clock (e.g. getDbNowMs(db)); never read internally via Date.now()
+ * @param {object} [opts]
+ * @param {number} [opts.thresholdMs=7d] - minimum age before a null-score draft counts as stalled
+ * @param {number} [opts.sampleLimit=10] - cap on the number of sampled sd_keys returned (oldest-first)
+ * @param {{has:(k:string)=>boolean}} [opts.scoredKeys] - sd_keys with an eva_vision_scores row (excluded as scored)
+ * @returns {{violation:boolean, staleCount:number, samples:Array<{sd_key:string,ageDays:number}>, detail:string, remediation:(string|null)}}
+ */
+export function findStalledDrafts(rows = [], nowMs, opts = {}) {
+  // DSD-2: the signature default only applies to `undefined`; normalize a null/non-object opts to {} so a bad
+  // opts degrades to defaults rather than throwing (symmetric with the rows/nowMs fail-open guard below).
+  const o = (opts && typeof opts === 'object') ? opts : {};
+  const thresholdMs = Number.isFinite(o.thresholdMs) ? o.thresholdMs : 7 * DAY_MS;
+  const sampleLimit = Number.isFinite(o.sampleLimit) ? o.sampleLimit : 10;
+  const scoredKeys = (o.scoredKeys && typeof o.scoredKeys.has === 'function') ? o.scoredKeys : null;
+
+  // Fail-OPEN on malformed input: a non-array (or a bad clock) cannot be evaluated → no violation, never throw.
+  if (!Array.isArray(rows) || !Number.isFinite(nowMs)) {
+    return { violation: false, staleCount: 0, samples: [], detail: 'no evaluable rows (fail-open)', remediation: null };
+  }
+
+  const stalled = [];
+  for (const row of rows) {
+    if (!isUnscoredDraft(row, scoredKeys)) continue;
+    const age = draftAgeMs(row, nowMs);
+    if (!Number.isFinite(age)) continue;   // no parseable timestamp → cannot prove stale (fail-open)
+    if (age < thresholdMs) continue;       // fresh draft within the grace window → not stalled
+    stalled.push({ sd_key: row.sd_key || '(unknown)', ageMs: age });
+  }
+
+  // Oldest-first so the coordinator remediates the most-stranded drafts before the fresher ones.
+  stalled.sort((a, b) => b.ageMs - a.ageMs);
+  const samples = stalled.slice(0, Math.max(0, sampleLimit))
+    .map((s) => ({ sd_key: s.sd_key, ageDays: Math.floor(s.ageMs / DAY_MS) }));
+
+  const violation = stalled.length > 0;
+  const thresholdDays = Math.round(thresholdMs / DAY_MS);
+  return {
+    violation,
+    staleCount: stalled.length,
+    samples,
+    detail: violation
+      ? `${stalled.length} draft SD(s) stranded with NULL vision_score >${thresholdDays}d (silent stall) — oldest: ${samples.slice(0, 3).map((s) => `${s.sd_key}(${s.ageDays}d)`).join(', ')}`
+      : 'none (no draft stranded with a null vision_score past threshold)',
+    remediation: violation
+      ? 'ACTION: re-score the stranded draft(s) — `node scripts/eva/vision-scorer.js --sd <key>` (or re-run leo-create-sd scoring); the conception-time async score silently failed'
+      : null,
+  };
+}

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -31,6 +31,8 @@ import {
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
   extractDepKey, resolveWorktreeCount, computeDispatchBelt,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
+// SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: DUTY-7 silent-stall detector (drafts stranded with null vision_score).
+import { findStalledDrafts } from '../lib/coordinator/draft-stall-detector.mjs';
 
 const require = createRequire(import.meta.url);
 const { isWithinArmedSilenceWindow } = require('../lib/fleet/silence-cap.cjs');
@@ -42,6 +44,10 @@ try { ({ resolveCcPidFromTerminalId } = require('./stale-session-sweep.cjs')); }
 
 const STALE_MS = Number(process.env.COORD_STALE_THRESHOLD_MS) || 5 * 60 * 1000;
 const DISPATCH_RANK_TTL_MS = 60 * 60 * 1000; // mirrors worker-checkin.cjs DISPATCH_RANK_TTL_MS
+// SILENT-STALL-PREVENTION-001 — honor an explicit 0 (Number()||7 would silently swallow it); fall back to 7
+// only on NaN/empty/negative.
+const _draftStallDays = Number(process.env.DRAFT_STALL_DAYS_THRESHOLD);
+const DRAFT_STALL_MS = (Number.isFinite(_draftStallDays) && _draftStallDays >= 0 ? _draftStallDays : 7) * 86400000;
 const TERMINAL = new Set(['completed', 'cancelled', 'archived', 'deferred']);
 const depKeysOf = (s) => (Array.isArray(s.dependencies) ? s.dependencies.map(extractDepKey).filter(Boolean) : []);
 
@@ -52,7 +58,7 @@ async function main() {
 
   // ── FOUNDATIONAL queries — FAIL LOUD (never silent-empty / false all-clean) ──
   const { data: sdRows, error: sdErr } = await db.from('strategic_directives_v2')
-    .select('sd_key,status,current_phase,claiming_session_id,updated_at,dependencies,parent_sd_id,metadata,sd_type')
+    .select('sd_key,status,current_phase,claiming_session_id,updated_at,created_at,vision_score,dependencies,parent_sd_id,metadata,sd_type')
     .not('status', 'in', '(' + [...TERMINAL].join(',') + ')');
   const sdMarker = foundationalQueryError(sdErr, 'strategic_directives_v2');
   if (sdMarker) { console.error(sdMarker); process.exit(1); }
@@ -100,6 +106,20 @@ async function main() {
   // human-action SDs) — so the audit never recommends dispatching an unclaimable PARENT to an idle worker.
   const { unclaimed, claimable } = computeDispatchBelt({ sds, statusByKey, terminalSet: TERMINAL, classifyIneligibility: classifyDispatchIneligibility });
 
+  // SILENT-STALL-PREVENTION-001 (DSD-1): the AUTHORITATIVE scored-signal is an eva_vision_scores row (the same
+  // fallback the hard vision-score gate uses), NOT the strategic_directives_v2.vision_score column (which is
+  // essentially never populated on a successful conception-time score). Build the set of candidate-draft sd_keys
+  // that DO have an eva_vision_scores row so a successfully-scored draft is NOT mislabelled a silent stall. Pure
+  // fail-OPEN: on any error the set stays empty → the detector degrades to the column-only check (current safe
+  // behavior). Bounded: queried only for the unscored-draft candidate keys, not the whole table.
+  const candidateDraftKeys = sds.filter((s) => s.status === 'draft' && (s.vision_score === null || s.vision_score === undefined)).map((s) => s.sd_key);
+  let scoredDraftKeys = new Set();
+  if (candidateDraftKeys.length) {
+    const { data: evaRows, error: evaErr } = await db.from('eva_vision_scores').select('sd_id').in('sd_id', candidateDraftKeys);
+    if (evaErr) console.error('[COORD-CHARTER-AUDIT] WARN: eva_vision_scores query failed (fail-open, column-only): ' + evaErr.message);
+    else scoredDraftKeys = new Set((evaRows || []).map((r) => r.sd_id));
+  }
+
   // QUIET-TICK coordinator_review history (latest 2)
   const { data: reviews, error: revErr } = await db.from('feedback')
     .select('metadata,created_at').eq('category', 'coordinator_review').order('created_at', { ascending: false }).limit(2);
@@ -112,6 +132,10 @@ async function main() {
     dep: detectDependencyHealth({ sds, statusByKey, terminalSet: TERMINAL, nowMs }),
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),
+    // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: drafts stranded with a null vision_score (silent stall).
+    // Advisory remediation count only — summarizeViolations never drives a process.exit (foundational-query
+    // failures are the ONLY hard exits), so a stalled draft surfaces a remediation action, never a hard fail.
+    draft: findStalledDrafts(sds, nowMs, { thresholdMs: DRAFT_STALL_MS, scoredKeys: scoredDraftKeys }),
   };
 
   const flag = (r) => (r.remediation ? '  ⚠ ' + r.remediation : '');
@@ -122,6 +146,7 @@ async function main() {
   for (const a of D.dep.anomalies.slice(0, 5)) console.log('      ANOMALY ' + a.sd + ' dep(s) not found: ' + a.unknownDeps.join(','));
   console.log('  DUTY-6 BACKLOG-RANK  : ' + D.rank.detail + flag(D.rank));
   console.log('  QUIET-TICK COMMITTED : ' + D.quiet.detail + flag(D.quiet));
+  console.log('  DUTY-7 DRAFT-STALL   : ' + D.draft.detail + flag(D.draft)); // SILENT-STALL-PREVENTION-001
 
   // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: ADVISORY freshness dimension — fail-open and deliberately
   // kept OUT of `D`/summarizeViolations, so a stale checkout surfaces a warning but never trips the

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score-async-trigger.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score-async-trigger.js
@@ -1,0 +1,62 @@
+/**
+ * Vision-score async trigger — SD-LEO-INFRA-SILENT-STALL-PREVENTION-001.
+ *
+ * The CONSERVATIVE, FAIL-OPEN, NON-BLOCKING half of silent-stall prevention. When a LEAD-TO-PLAN handoff begins
+ * for an SD whose vision_score is still null (the conception-time async scoreSDAtConception silently timed out /
+ * failed), this fires an OPPORTUNISTIC re-score WITHOUT awaiting it — purely to RAISE the pass-rate of the hard
+ * createVisionScoreGate that runs later in the same handoff (which reads eva_vision_scores via fallback).
+ *
+ * It is NOT a gate and removes NO protection: the hard createVisionScoreGate is unchanged and remains the safety
+ * net. This trigger can NEVER block a LEAD handoff:
+ *   1. the caller wraps the import + call in try/catch (import-guard layer),
+ *   2. it returns SYNCHRONOUSLY and the scoring promise is never awaited (fire-and-forget layer),
+ *   3. the fire-and-forget promise has its own .catch collapsing any timeout/LLM/DB error to a debug log
+ *      (inner fail-open layer) — so a rejection never becomes an unhandled rejection.
+ *
+ * @module scripts/modules/handoff/executors/lead-to-plan/gates/vision-score-async-trigger
+ */
+
+/**
+ * Fire an opportunistic, non-blocking vision-score for an unscored SD. PURE-ISH: returns synchronously; any work
+ * happens on a detached promise. Safe to call unconditionally at LEAD entry for ALL SD types (operator scope).
+ *
+ * @param {object} sd - the SD row (needs sd_key/id + vision_score)
+ * @param {object} supabase - the service-client to hand to scoreSD (so it writes eva_vision_scores)
+ * @param {object} [deps] - injectable seams for testing
+ * @param {Function} [deps.scoreSD] - async ({sdKey,supabase})=>... ; defaults to the real vision-scorer
+ * @param {Function} [deps.onError] - error sink (defaults to console.debug) — never re-throws
+ * @returns {{triggered:boolean, reason:string}}
+ */
+export function triggerAsyncVisionScore(sd, supabase, deps = {}) {
+  const onError = typeof deps.onError === 'function'
+    ? deps.onError
+    : (msg) => { try { console.debug(msg); } catch { /* no-op: logging must never throw */ } };
+
+  // Guard 0: already scored (or no SD) → nothing to do. This is the common case and the cheap exit.
+  if (!sd) return { triggered: false, reason: 'no sd supplied' };
+  if (sd.vision_score !== null && sd.vision_score !== undefined) {
+    return { triggered: false, reason: 'vision_score already present' };
+  }
+
+  const sdKey = sd.sd_key || sd.id;
+  if (!sdKey) return { triggered: false, reason: 'no sd_key/id on sd' };
+
+  // The real scorer is lazy-imported by default so this module has no load-time dependency on the (heavy)
+  // vision-scorer; tests inject deps.scoreSD and never touch the import or the network.
+  const scorer = typeof deps.scoreSD === 'function'
+    ? deps.scoreSD
+    : async (o) => (await import('../../../../../eva/vision-scorer.js')).scoreSD(o);
+
+  // FIRE-AND-FORGET: do NOT await. Wrap the launch itself in try (a synchronous throw from scorer(...) — e.g. a
+  // bad import resolved synchronously — must not propagate) and attach .catch for async rejections (fail-open).
+  try {
+    Promise.resolve()
+      .then(() => scorer({ sdKey, supabase, quiet: true }))
+      .catch((e) => onError(`[vision-score-async-trigger] re-score for ${sdKey} failed (non-blocking): ${e && e.message ? e.message : e}`));
+  } catch (e) {
+    onError(`[vision-score-async-trigger] launch for ${sdKey} threw (non-blocking): ${e && e.message ? e.message : e}`);
+    return { triggered: false, reason: 'launch threw (fail-open)' };
+  }
+
+  return { triggered: true, reason: 'async re-score launched (fire-and-forget)' };
+}

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -84,6 +84,16 @@ export class LeadToPlanExecutor extends BaseExecutor {
     // PAT-HF-LEADTOPLAN-b891d12d: Show translation fidelity gaps BEFORE gates run.
     // Surfaces known gaps from prior failed runs so they can be fixed without a full retry cycle.
     await displayTranslationFidelityPreview(sd, this.supabase);
+
+    // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: opportunistic, FAIL-OPEN, NON-BLOCKING vision-score populate.
+    // If the conception-time async score silently failed, this fires a re-score WITHOUT awaiting it — purely to
+    // raise the pass-rate of the hard createVisionScoreGate below (which is unchanged and remains the safety net).
+    // Import-guarded + fire-and-forget so it can NEVER block this handoff; setup() still returns null regardless.
+    try {
+      const { triggerAsyncVisionScore } = await import('./gates/vision-score-async-trigger.js');
+      triggerAsyncVisionScore(sd, this.supabase);
+    } catch { /* non-blocking: a silent-stall re-score must never affect the LEAD handoff */ }
+
     return null;
   }
 

--- a/tests/unit/draft-stall-detector.test.js
+++ b/tests/unit/draft-stall-detector.test.js
@@ -1,0 +1,145 @@
+/**
+ * Draft-stall detector tests — SD-LEO-INFRA-SILENT-STALL-PREVENTION-001.
+ * PURE unit cases with an INJECTED clock (no DB / IO / Date.now). Covers: all-null, some-null, the
+ * GREATEST(created_at,updated_at) fresh-vs-stale grace, non-draft / scored exclusion, fail-open on bad input,
+ * and threshold/sampleLimit injection.
+ */
+import { describe, it, expect } from 'vitest';
+import { findStalledDrafts } from '../../lib/coordinator/draft-stall-detector.mjs';
+
+const DAY = 86400000;
+// Fixed injected "now" — every timestamp below is expressed relative to it (deterministic, no real clock).
+const NOW = Date.parse('2026-06-15T00:00:00.000Z');
+const daysAgo = (d) => new Date(NOW - d * DAY).toISOString();
+
+// A draft stranded with a null vision_score, created `d` days ago (and not since touched).
+const staleDraft = (sd_key, d) => ({ sd_key, status: 'draft', vision_score: null, created_at: daysAgo(d), updated_at: daysAgo(d) });
+
+describe('findStalledDrafts — core detection', () => {
+  it('flags multiple null-score drafts older than the default 7d threshold, oldest-first', () => {
+    const rows = [staleDraft('SD-A', 10), staleDraft('SD-B', 30), staleDraft('SD-C', 8)];
+    const r = findStalledDrafts(rows, NOW);
+    expect(r.violation).toBe(true);
+    expect(r.staleCount).toBe(3);
+    // oldest-first: B(30) > A(10) > C(8)
+    expect(r.samples.map((s) => s.sd_key)).toEqual(['SD-B', 'SD-A', 'SD-C']);
+    expect(r.samples[0].ageDays).toBe(30);
+    expect(r.remediation).toMatch(/re-score/i);
+  });
+
+  it('flags only the stranded subset when some drafts are scored or fresh (some-null)', () => {
+    const rows = [
+      staleDraft('SD-STALE', 20),
+      { sd_key: 'SD-SCORED', status: 'draft', vision_score: 72, created_at: daysAgo(40), updated_at: daysAgo(40) },
+      { sd_key: 'SD-FRESH', status: 'draft', vision_score: null, created_at: daysAgo(2), updated_at: daysAgo(2) },
+    ];
+    const r = findStalledDrafts(rows, NOW);
+    expect(r.staleCount).toBe(1);
+    expect(r.samples.map((s) => s.sd_key)).toEqual(['SD-STALE']);
+  });
+});
+
+describe('findStalledDrafts — conception-age (created_at) basis, robust to updated_at noise', () => {
+  it('FLAGS an old-conceived draft even when updated_at was bumped recently (the live finding)', () => {
+    // created 40d ago, but unrelated writes (cascade/sweep/metadata) bumped updated_at to 1h ago.
+    // A GREATEST(created,updated) grace would MASK this real stall; the conception-age basis correctly flags it.
+    const row = { sd_key: 'SD-NOISY-UPDATE', status: 'draft', vision_score: null, created_at: daysAgo(40), updated_at: new Date(NOW - 3600000).toISOString() };
+    const r = findStalledDrafts([row], NOW);
+    expect(r.violation).toBe(true);
+    expect(r.staleCount).toBe(1);
+    expect(r.samples[0].ageDays).toBe(40); // age is measured from conception, not last touch
+  });
+
+  it('does NOT flag a freshly-conceived draft (threshold protects new drafts — no updated_at grace needed)', () => {
+    const row = { sd_key: 'SD-NEW', status: 'draft', vision_score: null, created_at: daysAgo(2), updated_at: daysAgo(1) };
+    expect(findStalledDrafts([row], NOW).violation).toBe(false);
+  });
+
+  it('falls back to updated_at as the age basis only when created_at is absent (legacy rows)', () => {
+    const legacy = { sd_key: 'SD-LEGACY', status: 'draft', vision_score: null, created_at: null, updated_at: daysAgo(20) };
+    const r = findStalledDrafts([legacy], NOW);
+    expect(r.violation).toBe(true);
+    expect(r.samples[0].ageDays).toBe(20);
+  });
+});
+
+describe('findStalledDrafts — exclusions', () => {
+  it('excludes non-draft rows even with a null vision_score', () => {
+    const rows = [
+      { sd_key: 'SD-ACTIVE', status: 'in_progress', vision_score: null, created_at: daysAgo(30), updated_at: daysAgo(30) },
+      { sd_key: 'SD-DONE', status: 'completed', vision_score: null, created_at: daysAgo(30), updated_at: daysAgo(30) },
+    ];
+    const r = findStalledDrafts(rows, NOW);
+    expect(r.violation).toBe(false);
+    expect(r.staleCount).toBe(0);
+  });
+
+  it('excludes a scored draft (vision_score = 0 is a real score, not a stall)', () => {
+    const row = { sd_key: 'SD-ZERO', status: 'draft', vision_score: 0, created_at: daysAgo(30), updated_at: daysAgo(30) };
+    const r = findStalledDrafts([row], NOW);
+    expect(r.violation).toBe(false);
+  });
+});
+
+describe('findStalledDrafts — authoritative scored-signal (eva-row, DSD-1)', () => {
+  it('EXCLUDES an old null-column draft whose sd_key has an eva_vision_scores row (scored via eva, not a stall)', () => {
+    // The vision_score column is null even for a SUCCESSFULLY-scored draft (scoreSD writes only eva_vision_scores).
+    // A scoredKeys set membership is the authoritative scored-signal — the same fallback the hard gate uses.
+    const row = staleDraft('SD-SCORED-VIA-EVA', 30);
+    const scoredKeys = new Set(['SD-SCORED-VIA-EVA']);
+    expect(findStalledDrafts([row], NOW, { scoredKeys }).violation).toBe(false);
+  });
+
+  it('FLAGS an old null-column draft NOT present in scoredKeys (genuine silent stall)', () => {
+    const row = staleDraft('SD-NO-EVA', 30);
+    const scoredKeys = new Set(['SD-SOMETHING-ELSE']);
+    const r = findStalledDrafts([row], NOW, { scoredKeys });
+    expect(r.violation).toBe(true);
+    expect(r.samples[0].sd_key).toBe('SD-NO-EVA');
+  });
+
+  it('degrades to the column-only check when scoredKeys is absent (conservative, never throws)', () => {
+    expect(findStalledDrafts([staleDraft('SD-X', 30)], NOW).violation).toBe(true);
+  });
+});
+
+describe('findStalledDrafts — fail-open & injection', () => {
+  it('returns no-violation (never throws) on a non-array, null, or empty input', () => {
+    for (const bad of [undefined, null, 'nope', 42, {}]) {
+      const r = findStalledDrafts(bad, NOW);
+      expect(r.violation).toBe(false);
+      expect(r.staleCount).toBe(0);
+    }
+    expect(findStalledDrafts([], NOW).violation).toBe(false);
+  });
+
+  it('does NOT throw on an explicitly-null opts (DSD-2 — degrades to defaults)', () => {
+    expect(() => findStalledDrafts([staleDraft('SD-A', 30)], NOW, null)).not.toThrow();
+    expect(findStalledDrafts([staleDraft('SD-A', 30)], NOW, null).violation).toBe(true); // default 7d threshold
+    // a non-object opts is likewise tolerated
+    expect(() => findStalledDrafts([], NOW, 'garbage')).not.toThrow();
+  });
+
+  it('returns no-violation when the injected clock is not a finite number (fail-open)', () => {
+    const r = findStalledDrafts([staleDraft('SD-A', 30)], NaN);
+    expect(r.violation).toBe(false);
+  });
+
+  it('does not flag a row that has no parseable timestamp (cannot prove staleness)', () => {
+    const row = { sd_key: 'SD-NOTS', status: 'draft', vision_score: null, created_at: null, updated_at: null };
+    expect(findStalledDrafts([row], NOW).violation).toBe(false);
+  });
+
+  it('honours an injected thresholdMs (1d makes a 2-day draft stale)', () => {
+    const row = { sd_key: 'SD-2D', status: 'draft', vision_score: null, created_at: daysAgo(2), updated_at: daysAgo(2) };
+    expect(findStalledDrafts([row], NOW).violation).toBe(false);            // default 7d → fresh
+    expect(findStalledDrafts([row], NOW, { thresholdMs: DAY }).violation).toBe(true); // 1d → stale
+  });
+
+  it('honours an injected sampleLimit (caps samples but not staleCount)', () => {
+    const rows = Array.from({ length: 12 }, (_, i) => staleDraft(`SD-${i}`, 10 + i));
+    const r = findStalledDrafts(rows, NOW, { sampleLimit: 3 });
+    expect(r.staleCount).toBe(12);
+    expect(r.samples).toHaveLength(3);
+  });
+});

--- a/tests/unit/vision-score-async-trigger.test.js
+++ b/tests/unit/vision-score-async-trigger.test.js
@@ -1,0 +1,81 @@
+/**
+ * Vision-score async-trigger tests — SD-LEO-INFRA-SILENT-STALL-PREVENTION-001.
+ * Proves the trigger is fire-and-forget + FAIL-OPEN: already-scored / no-key → no-op; happy path calls the
+ * injected scoreSD exactly once and returns SYNCHRONOUSLY; an injected scoreSD that REJECTS (or throws
+ * synchronously) never produces an unhandled rejection and never blocks the caller. Fakes only — zero DB / LLM.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { triggerAsyncVisionScore } from '../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score-async-trigger.js';
+
+const fakeSupabase = { __fake: true };
+const flush = () => new Promise((r) => setTimeout(r, 0)); // let detached promises settle
+
+describe('triggerAsyncVisionScore — no-op guards', () => {
+  it('does nothing when the SD already has a vision_score', () => {
+    const scoreSD = vi.fn();
+    const r = triggerAsyncVisionScore({ sd_key: 'SD-X', vision_score: 80 }, fakeSupabase, { scoreSD });
+    expect(r.triggered).toBe(false);
+    expect(scoreSD).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no SD is supplied', () => {
+    const scoreSD = vi.fn();
+    expect(triggerAsyncVisionScore(null, fakeSupabase, { scoreSD }).triggered).toBe(false);
+    expect(scoreSD).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the SD has no sd_key/id', () => {
+    const scoreSD = vi.fn();
+    const r = triggerAsyncVisionScore({ vision_score: null }, fakeSupabase, { scoreSD });
+    expect(r.triggered).toBe(false);
+    expect(scoreSD).not.toHaveBeenCalled();
+  });
+});
+
+describe('triggerAsyncVisionScore — happy path (fire-and-forget)', () => {
+  it('launches the injected scoreSD once with {sdKey,supabase} and returns synchronously', async () => {
+    const scoreSD = vi.fn().mockResolvedValue({ ok: true });
+    const r = triggerAsyncVisionScore({ sd_key: 'SD-NULL', vision_score: null }, fakeSupabase, { scoreSD });
+    // Returns synchronously BEFORE the async score resolves (fire-and-forget).
+    expect(r.triggered).toBe(true);
+    await flush();
+    expect(scoreSD).toHaveBeenCalledTimes(1);
+    expect(scoreSD).toHaveBeenCalledWith(expect.objectContaining({ sdKey: 'SD-NULL', supabase: fakeSupabase }));
+  });
+
+  it('uses sd.id when sd_key is absent', async () => {
+    const scoreSD = vi.fn().mockResolvedValue({});
+    triggerAsyncVisionScore({ id: 'SD-BY-ID', vision_score: undefined }, fakeSupabase, { scoreSD });
+    await flush();
+    expect(scoreSD).toHaveBeenCalledWith(expect.objectContaining({ sdKey: 'SD-BY-ID' }));
+  });
+});
+
+describe('triggerAsyncVisionScore — fail-open', () => {
+  it('a REJECTING scoreSD never blocks the caller and never produces an unhandled rejection', async () => {
+    const onError = vi.fn();
+    const scoreSD = vi.fn().mockRejectedValue(new Error('LLM timeout'));
+    // The call itself must not throw...
+    const r = triggerAsyncVisionScore({ sd_key: 'SD-REJ', vision_score: null }, fakeSupabase, { scoreSD, onError });
+    expect(r.triggered).toBe(true);
+    await flush();
+    // ...and the rejection must be swallowed into the error sink (no unhandled rejection).
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toMatch(/SD-REJ.*non-blocking/i);
+  });
+
+  it('a scoreSD that THROWS synchronously is caught (fail-open, returns gracefully)', () => {
+    const onError = vi.fn();
+    const scoreSD = vi.fn(() => { throw new Error('sync boom'); });
+    // Promise.resolve().then(() => scorer(...)) defers the throw into a rejection, so .triggered is still true
+    // and the throw is routed to onError — never propagated to the caller.
+    const r = triggerAsyncVisionScore({ sd_key: 'SD-THROW', vision_score: null }, fakeSupabase, { scoreSD, onError });
+    expect(r.triggered).toBe(true);
+  });
+
+  it('default error sink (console.debug) does not throw when scoreSD rejects', async () => {
+    const scoreSD = vi.fn().mockRejectedValue(new Error('boom'));
+    expect(() => triggerAsyncVisionScore({ sd_key: 'SD-D', vision_score: null }, fakeSupabase, { scoreSD })).not.toThrow();
+    await flush(); // no unhandled rejection surfaces
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-SILENT-STALL-PREVENTION-001 — additive silent-stall prevention

Prevents the **silent stall**: an SD whose conception-time async vision-scorer fails lands in `draft` with a null `vision_score`, blocks at the hard `createVisionScoreGate`, and sits unnoticed.

### Two additive, fail-open, NON-BLOCKING halves (the hard gate is unchanged — safety net)
1. **`lib/coordinator/draft-stall-detector.mjs`** — PURE `findStalledDrafts`, wired read-only into the coordinator charter-audit cron as **DUTY-7**. "Unscored" matches the gate's authoritative `eva_vision_scores` fallback (injected `scoredKeys` set, so a successfully-scored draft is not mislabelled), and staleness uses **conception age** (`created_at`), robust to unrelated `updated_at` writes.
2. **`vision-score-async-trigger.js`** — fire-and-forget, fail-open re-score at LEAD entry, import-guarded into `LeadToPlanExecutor.setup()`; **can never block the handoff** (3 fail-open layers; setup() returns null regardless).

### Verification
- **24 DB-free unit tests** (injected clock + fakes; zero live DB/LLM)
- **Live-falsification** corrected the staleness basis (`GREATEST(created_at,updated_at)` would be masked by unrelated `updated_at` writes → `created_at`); detector now genuinely fires on real stranded drafts
- **6-agent adversarial review** confirmed 2 LOW findings (eva-row scored-signal precision; null-opts fail-open) — **both fixed + tested**
- TESTING sub-agent: PASS@95

No schema/migration. EHG_Engineer only. Fully additive + reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
