### PR TITLE
feat(SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B): single-writer mutation guard for coordinator duties

### DIFF
--- a/lib/coordinator-mutation-guard.mjs
+++ b/lib/coordinator-mutation-guard.mjs
@@ -1,0 +1,123 @@
+/**
+ * coordinator-mutation-guard.mjs — SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-1+FR-2
+ *
+ * Single-writer mutation guard for coordinator-owned duties.
+ * A lingering NON-canonical coordinator session must not double-act on
+ * mutating coordinator duties. Call assertCanonicalCoordinator (or the
+ * convenience wrapper guardMutation) at the top of any mutating coordinator
+ * duty daemon before writing.
+ *
+ * Posture:
+ *   - Fail-CLOSED only when the resolver returns a DIFFERENT, non-empty session_id.
+ *   - Fail-OPEN on throw / null / no session_id — never brick the only live coordinator.
+ *   - Guard is READ-ONLY (zero writes of its own).
+ */
+
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const require = createRequire(import.meta.url);
+const { getActiveCoordinatorId } = require('./coordinator/resolve.cjs');
+
+// The on-disk session pointer the coordinator already maintains. Absolute, resolved
+// from this module's location so it is stable regardless of the daemon's cwd.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SESSION_ID_FILE = path.resolve(__dirname, '../.claude/session-id.json');
+
+/**
+ * resolveOwnSessionId — best-effort resolution of THIS process's session id.
+ *
+ * Order: process.env.CLAUDE_SESSION_ID (set inside a live coordinator session)
+ *        → .claude/session-id.json `.session_id` (read fail-safe; the on-disk pointer
+ *          the coordinator already maintains, reliable when a daemon/cron runs out-of-band
+ *          with an empty env var)
+ *        → null (guard then fail-opens on a missing id — see assertCanonicalCoordinator).
+ *
+ * Finding 1 (SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B): a bare
+ * process.env.CLAUDE_SESSION_ID can be empty when a script runs out-of-band, which would
+ * silently fail-open and let a rogue OLD coordinator's daemon keep mutating. The disk
+ * pointer recovers the real id so the guard can correctly BLOCK the rogue.
+ *
+ * @param {string} [file]  Pointer file path (test injectability; defaults to SESSION_ID_FILE)
+ * @returns {string|null}
+ */
+export function resolveOwnSessionId(file = SESSION_ID_FILE) {
+  const fromEnv = process.env.CLAUDE_SESSION_ID;
+  if (fromEnv) return fromEnv;
+  try {
+    if (!fs.existsSync(file)) return null;
+    const raw = fs.readFileSync(file, 'utf8');
+    const data = JSON.parse(raw);
+    if (data && typeof data.session_id === 'string' && data.session_id) return data.session_id;
+    return null;
+  } catch {
+    return null; // fail-safe: any read/parse error → null (guard fail-opens, never throws)
+  }
+}
+
+/**
+ * assertCanonicalCoordinator — check whether `sessionId` is the canonical coordinator.
+ *
+ * @param {object} supabase    Supabase client (may be null — triggers fail-open)
+ * @param {string|null} sessionId  The running session's id (process.env.CLAUDE_SESSION_ID)
+ * @param {object} [opts]      Options; opts._getCanonicalId injects a test resolver seam
+ * @returns {Promise<{allowed: boolean, canonical_session_id: string|null, reason: string}>}
+ */
+export async function assertCanonicalCoordinator(supabase, sessionId, opts = {}) {
+  // No session_id → cannot identify ourselves → fail-open (don't block what we can't identity-check)
+  if (!sessionId) {
+    return { allowed: true, canonical_session_id: null, reason: 'no_session_id_fail_open' };
+  }
+
+  // opts._getCanonicalId is a test seam: inject a stub to avoid real CJS require resolution in tests.
+  const resolverFn = (opts && typeof opts._getCanonicalId === 'function')
+    ? opts._getCanonicalId
+    : getActiveCoordinatorId;
+
+  let canonical;
+  try {
+    canonical = await resolverFn(supabase);
+  } catch {
+    // Resolver threw → fail-open (never brick the only live coordinator on an error)
+    return { allowed: true, canonical_session_id: null, reason: 'resolver_error_fail_open' };
+  }
+
+  // Resolver returned null/falsy (transient blip, no canonical found) → fail-open
+  if (!canonical) {
+    return { allowed: true, canonical_session_id: null, reason: 'resolver_null_fail_open' };
+  }
+
+  // This session IS the canonical coordinator → allow
+  if (canonical === sessionId) {
+    return { allowed: true, canonical_session_id: canonical, reason: 'canonical' };
+  }
+
+  // A DIFFERENT, non-empty canonical session was found → block this rogue session
+  return { allowed: false, canonical_session_id: canonical, reason: 'not_canonical' };
+}
+
+/**
+ * guardMutation — convenience wrapper for daemon entry points.
+ *
+ * Calls assertCanonicalCoordinator; when the verdict is !allowed, emits a
+ * structured console.warn so operators can audit rogue-session skips, then
+ * returns the verdict. The daemon should early-return on !allowed.
+ *
+ * @param {object} supabase
+ * @param {string|null} sessionId
+ * @param {string} dutyLabel   Human-readable label for the duty being guarded (logged on block)
+ * @param {object} [opts]
+ * @returns {Promise<{allowed: boolean, canonical_session_id: string|null, reason: string}>}
+ */
+export async function guardMutation(supabase, sessionId, dutyLabel, opts = {}) {
+  const verdict = await assertCanonicalCoordinator(supabase, sessionId, opts);
+  if (!verdict.allowed) {
+    console.warn(
+      `[COORD_MUTATION_BLOCKED] ${dutyLabel}: ` +
+      `this session ${sessionId} is not the canonical coordinator ` +
+      `(${verdict.canonical_session_id}); skipping mutation`
+    );
+  }
+  return verdict;
+}

--- a/lib/coordinator-mutation-guard.test.js
+++ b/lib/coordinator-mutation-guard.test.js
@@ -1,0 +1,383 @@
+/**
+ * coordinator-mutation-guard.test.js — SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-3
+ *
+ * Tests for lib/coordinator-mutation-guard.mjs:
+ *   MG-1: canonical session → allowed
+ *   MG-2: different canonical → fail-closed (block)
+ *   MG-3: resolver throws → fail-open
+ *   MG-4: resolver returns null/falsy → fail-open
+ *   MG-5: no sessionId → fail-open (resolver NOT called)
+ *   MG-6: guardMutation convenience wrapper — logs warn on block, returns verdict
+ *   MG-7: daemon-wiring (coordinator-self-review seam) — guard blocks vs. allows
+ *   MG-8: daemon-wiring (coordinator-backlog-rank seam) — guard blocks vs. allows
+ *   MG-9:  resolveOwnSessionId — env-first, .claude/session-id.json fallback, null (Finding 1)
+ *   MG-10: stale-session-sweep WORK_ASSIGNMENT dispatch — gated by !allowed (Finding 3 HIGH)
+ *
+ * Uses opts._getCanonicalId injection seam (no vi.mock required — avoids CJS/ESM
+ * boundary issues with createRequire-based imports).
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { assertCanonicalCoordinator, guardMutation, resolveOwnSessionId } from './coordinator-mutation-guard.mjs';
+
+// dispatchWorkAssignmentsIfAllowed is the guarded dispatch helper extracted from
+// scripts/stale-session-sweep.cjs (CJS); require it via createRequire.
+const _require = createRequire(import.meta.url);
+const { dispatchWorkAssignmentsIfAllowed } = _require('../scripts/stale-session-sweep.cjs');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Seam helpers ─────────────────────────────────────────────────────────────
+// opts._getCanonicalId: injectable resolver seam that bypasses the real CJS require.
+const resolverReturns = (val) => ({ _getCanonicalId: async () => val });
+const resolverThrows = (msg) => ({ _getCanonicalId: async () => { throw new Error(msg); } });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-1: canonical session → allowed
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-1: canonical session → allowed', () => {
+  it('returns allowed:true and reason:canonical when sessionId matches canonical', async () => {
+    const result = await assertCanonicalCoordinator({}, 'session-abc', resolverReturns('session-abc'));
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('canonical');
+    expect(result.canonical_session_id).toBe('session-abc');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-2: different canonical → fail-closed
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-2: different canonical → fail-closed', () => {
+  it('returns allowed:false and canonical_session_id of the real coordinator', async () => {
+    const result = await assertCanonicalCoordinator({}, 'rogue-session', resolverReturns('the-real-coordinator'));
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('not_canonical');
+    expect(result.canonical_session_id).toBe('the-real-coordinator');
+  });
+
+  it('blocked verdict contains the canonical id (not the caller id)', async () => {
+    const result = await assertCanonicalCoordinator({}, 'other-session', resolverReturns('canonical-id-xyz'));
+    expect(result.canonical_session_id).toBe('canonical-id-xyz');
+    expect(result.canonical_session_id).not.toBe('other-session');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-3: resolver throws → fail-open
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-3: resolver throws → fail-open', () => {
+  it('returns allowed:true and reason:resolver_error_fail_open when resolver throws', async () => {
+    const result = await assertCanonicalCoordinator({}, 'some-session', resolverThrows('DB is down'));
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('resolver_error_fail_open');
+    expect(result.canonical_session_id).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-4: resolver returns null/falsy → fail-open
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-4: resolver returns null/falsy → fail-open', () => {
+  it('returns allowed:true and reason:resolver_null_fail_open when resolver returns null', async () => {
+    const result = await assertCanonicalCoordinator({}, 'some-session', resolverReturns(null));
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('resolver_null_fail_open');
+    expect(result.canonical_session_id).toBeNull();
+  });
+
+  it('returns fail-open when resolver returns empty string (falsy)', async () => {
+    const result = await assertCanonicalCoordinator({}, 'some-session', resolverReturns(''));
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('resolver_null_fail_open');
+  });
+
+  it('returns fail-open when resolver returns undefined', async () => {
+    const result = await assertCanonicalCoordinator({}, 'some-session', resolverReturns(undefined));
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('resolver_null_fail_open');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-5: no sessionId → fail-open (resolver NOT called)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-5: no sessionId → fail-open', () => {
+  it('returns allowed:true and reason:no_session_id_fail_open when sessionId is null', async () => {
+    const resolverSpy = vi.fn(async () => 'canonical');
+    const result = await assertCanonicalCoordinator({}, null, { _getCanonicalId: resolverSpy });
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('no_session_id_fail_open');
+    expect(result.canonical_session_id).toBeNull();
+    // Resolver must NOT be called when sessionId is absent — no unnecessary DB round-trip
+    expect(resolverSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns fail-open when sessionId is undefined', async () => {
+    const resolverSpy = vi.fn(async () => 'canonical');
+    const result = await assertCanonicalCoordinator({}, undefined, { _getCanonicalId: resolverSpy });
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('no_session_id_fail_open');
+    expect(resolverSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns fail-open when sessionId is empty string', async () => {
+    const resolverSpy = vi.fn(async () => 'canonical');
+    const result = await assertCanonicalCoordinator({}, '', { _getCanonicalId: resolverSpy });
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('no_session_id_fail_open');
+    expect(resolverSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-6: guardMutation convenience wrapper
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-6: guardMutation convenience wrapper', () => {
+  it('returns the verdict from assertCanonicalCoordinator (allowed case)', async () => {
+    const result = await guardMutation({}, 'my-session', 'test-duty', resolverReturns('my-session'));
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe('canonical');
+  });
+
+  it('emits a structured console.warn when blocked and returns the verdict', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await guardMutation({}, 'rogue-session', 'some-duty-label', resolverReturns('canonical-session'));
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('not_canonical');
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const warnMsg = warnSpy.mock.calls[0][0];
+    expect(warnMsg).toContain('[COORD_MUTATION_BLOCKED]');
+    expect(warnMsg).toContain('some-duty-label');
+    expect(warnMsg).toContain('rogue-session');
+    expect(warnMsg).toContain('canonical-session');
+  });
+
+  it('does NOT emit console.warn when allowed', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await guardMutation({}, 'my-session', 'test-duty', resolverReturns('my-session'));
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit console.warn on fail-open cases (no block noise when uncertain)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await guardMutation({}, 'some-session', 'test-duty', resolverReturns(null));
+    expect(result.allowed).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit console.warn when resolver throws (fail-open, no block)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await guardMutation({}, 'some-session', 'test-duty', resolverThrows('boom'));
+    expect(result.allowed).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-7: daemon-wiring seam (coordinator-self-review)
+// Tests the guard contract that selfReviewMain enforces:
+//   - When guardMutation returns !allowed → early return (no DB writes happen)
+//   - When guardMutation returns allowed → execution continues
+// We test via the guard directly with the same calling convention the daemon uses.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-7: coordinator-self-review daemon wiring (seam test)', () => {
+  it('guard blocks and returns !allowed when running as non-canonical session', async () => {
+    const guardResult = await guardMutation(
+      {},
+      'rogue-session',
+      'coordinator-self-review',
+      resolverReturns('canonical-coordinator')
+    );
+    expect(guardResult.allowed).toBe(false);
+    expect(guardResult.reason).toBe('not_canonical');
+    expect(guardResult.canonical_session_id).toBe('canonical-coordinator');
+    // The daemon: if (!_guardVerdict.allowed) return _guardVerdict;
+    // Confirmed: early-return path is triggered by this verdict shape.
+  });
+
+  it('guard allows when this session IS the canonical coordinator', async () => {
+    const guardResult = await guardMutation(
+      {},
+      'canonical-coordinator',
+      'coordinator-self-review',
+      resolverReturns('canonical-coordinator')
+    );
+    expect(guardResult.allowed).toBe(true);
+    expect(guardResult.reason).toBe('canonical');
+  });
+
+  it('guard is fail-open when resolver throws (daemon proceeds normally)', async () => {
+    const guardResult = await guardMutation(
+      {},
+      'any-session',
+      'coordinator-self-review',
+      resolverThrows('transient DB error')
+    );
+    expect(guardResult.allowed).toBe(true);
+    expect(guardResult.reason).toBe('resolver_error_fail_open');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-8: daemon-wiring seam (coordinator-backlog-rank)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-8: coordinator-backlog-rank daemon wiring (seam test)', () => {
+  it('guard blocks writes when running as non-canonical session', async () => {
+    const verdict = await guardMutation(
+      {},
+      'non-coordinator-session',
+      'coordinator-backlog-rank',
+      resolverReturns('real-coordinator')
+    );
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.canonical_session_id).toBe('real-coordinator');
+  });
+
+  it('guard allows writes when running as canonical coordinator', async () => {
+    const verdict = await guardMutation(
+      {},
+      'coord-session-123',
+      'coordinator-backlog-rank',
+      resolverReturns('coord-session-123')
+    );
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.reason).toBe('canonical');
+  });
+
+  it('guard is fail-open when resolver returns null (transient blip — writes proceed)', async () => {
+    const verdict = await guardMutation(
+      {},
+      'some-session',
+      'coordinator-backlog-rank',
+      resolverReturns(null)
+    );
+    // fail-open: writes proceed when we cannot determine the canonical
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.reason).toBe('resolver_null_fail_open');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-9: resolveOwnSessionId — env-first, on-disk pointer fallback, null (Finding 1)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-9: resolveOwnSessionId (Finding 1 — disk-pointer fallback)', () => {
+  const origEnv = process.env.CLAUDE_SESSION_ID;
+  let tmpFile;
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.CLAUDE_SESSION_ID;
+    else process.env.CLAUDE_SESSION_ID = origEnv;
+    if (tmpFile) { try { fs.unlinkSync(tmpFile); } catch { /* ignore */ } tmpFile = null; }
+  });
+
+  it('returns process.env.CLAUDE_SESSION_ID when set (env wins over disk)', () => {
+    process.env.CLAUDE_SESSION_ID = 'env-session-id';
+    // Write a DIFFERENT id to disk to prove env takes precedence.
+    tmpFile = path.join(os.tmpdir(), `sid-env-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({ session_id: 'disk-session-id' }));
+    expect(resolveOwnSessionId(tmpFile)).toBe('env-session-id');
+  });
+
+  it('falls back to .session_id from the disk pointer when env is empty', () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    tmpFile = path.join(os.tmpdir(), `sid-disk-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({ session_id: 'disk-recovered-id', host: 'h' }));
+    expect(resolveOwnSessionId(tmpFile)).toBe('disk-recovered-id');
+  });
+
+  it('returns null when env empty AND pointer file is absent (guard then fail-opens)', () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    const missing = path.join(os.tmpdir(), `sid-missing-${Date.now()}-${Math.random()}.json`);
+    expect(resolveOwnSessionId(missing)).toBeNull();
+  });
+
+  it('returns null fail-safe when the pointer file is malformed JSON', () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    tmpFile = path.join(os.tmpdir(), `sid-bad-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, '{ this is not valid json');
+    expect(resolveOwnSessionId(tmpFile)).toBeNull();
+  });
+
+  it('returns null when the pointer file has no usable session_id', () => {
+    delete process.env.CLAUDE_SESSION_ID;
+    tmpFile = path.join(os.tmpdir(), `sid-nokey-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({ host: 'h', session_id: '' }));
+    expect(resolveOwnSessionId(tmpFile)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MG-10: stale-session-sweep WORK_ASSIGNMENT dispatch gating (Finding 3 — HIGH)
+// The whole point of the SD: a lingering NON-canonical coordinator's sweep must NOT
+// re-dispatch WORK_ASSIGNMENT (sender_type:'sweep') rows. Asserts NO insert when !allowed,
+// and that the insert DOES happen when allowed.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('MG-10: sweep WORK_ASSIGNMENT dispatch is gated by the single-writer verdict', () => {
+  // Minimal supabase mock: records inserts; .select()… chain returns no existing rows
+  // so the "don't spam" check passes and a fresh insert would fire when allowed.
+  function makeSweepSb(inserts) {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      is: () => chain,
+      limit: () => Promise.resolve({ data: [], error: null }), // no existing unacked assignment
+      insert: (row) => { inserts.push(row); return Promise.resolve({ data: null, error: null }); },
+    };
+    return { from: () => chain };
+  }
+
+  const activeSessions = [
+    { session_id: 'worker-1', sd_key: 'SD-FOO-BAR-001' },
+    { session_id: 'worker-2', sd_key: 'SD-BAZ-QUX-002' },
+  ];
+
+  it('does NOT insert ANY WORK_ASSIGNMENT (sender_type:sweep) when !allowed', async () => {
+    const inserts = [];
+    const sb = makeSweepSb(inserts);
+    const result = await dispatchWorkAssignmentsIfAllowed(sb, activeSessions, ['SD-NEXT-001'], /* allowed */ false);
+
+    // The harmful double-act is fully suppressed.
+    expect(inserts.length).toBe(0);
+    expect(result.blocked).toBe(true);
+    expect(result.dispatched).toBe(0);
+    expect(result.skipped).toBe(activeSessions.length);
+    // Belt-and-suspenders: no row carrying sender_type:'sweep' WORK_ASSIGNMENT escaped.
+    expect(inserts.some(r => r.message_type === 'WORK_ASSIGNMENT' && r.sender_type === 'sweep')).toBe(false);
+  });
+
+  it('DOES insert WORK_ASSIGNMENT (sender_type:sweep) for each active session when allowed', async () => {
+    const inserts = [];
+    const sb = makeSweepSb(inserts);
+    const result = await dispatchWorkAssignmentsIfAllowed(sb, activeSessions, ['SD-NEXT-001'], /* allowed */ true);
+
+    expect(result.blocked).toBe(false);
+    expect(result.dispatched).toBe(activeSessions.length);
+    expect(inserts.length).toBe(activeSessions.length);
+    // Every inserted row is the canonical sweep WORK_ASSIGNMENT shape.
+    for (const r of inserts) {
+      expect(r.message_type).toBe('WORK_ASSIGNMENT');
+      expect(r.sender_type).toBe('sweep');
+    }
+    expect(inserts.map(r => r.target_session).sort()).toEqual(['worker-1', 'worker-2']);
+  });
+
+  it('dispatches to ZERO sessions safely when activeSessions is empty (allowed)', async () => {
+    const inserts = [];
+    const sb = makeSweepSb(inserts);
+    const result = await dispatchWorkAssignmentsIfAllowed(sb, [], [], true);
+    expect(inserts.length).toBe(0);
+    expect(result.dispatched).toBe(0);
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -143,6 +143,18 @@ async function main() {
   const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
   const supabase = createSupabaseServiceClient();
 
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: single-writer mutation guard.
+  // Dynamic import of .mjs guard from .cjs context; async context already established.
+  // Finding 1: resolveOwnSessionId resolves env-first with .claude/session-id.json fallback,
+  // so an out-of-band cron run with an empty env var still resolves the real id and can block a rogue.
+  const { guardMutation: _guardMutation, resolveOwnSessionId: _resolveOwnSessionId } = await import('../lib/coordinator-mutation-guard.mjs');
+  const _mySessionId = _resolveOwnSessionId();
+  const _fleetGuard = await _guardMutation(supabase, _mySessionId, 'assign-fleet-identities');
+  if (!_fleetGuard.allowed) {
+    console.log('[FLEET-IDENTITY] mutation blocked by coordinator guard — not the canonical coordinator; skipping assignment.');
+    return;
+  }
+
   // Parse flags
   const args = process.argv.slice(2);
   const forceReassign = args.includes('--force');

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -25,6 +25,8 @@
  */
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+// SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: single-writer mutation guard.
+import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-guard.mjs';
 // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: shared fail-open classifiers so the
 // ranker and the capacity forecaster exclude the same fixtures, and the ranker
 // demotes bare-shell stubs. FIXTURE_RE catches epoch-stamped TEST-E2E keys; the
@@ -153,6 +155,20 @@ async function main() {
 
   const now = new Date().toISOString();
   console.log(`[BACKLOG-RANK] ${now}${DRY ? ' (dry-run)' : ''} — ${claimable.length} claimable leaf SD(s) ranked`);
+
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: guard rank WRITES only
+  // (the SELECT/ranking reads above are always allowed). Skip the write if this session
+  // is not the canonical coordinator. Fail-open on resolver error / no session_id.
+  // Finding 1: env-first with disk-pointer fallback so an out-of-band run still resolves.
+  const me = resolveOwnSessionId();
+  if (!DRY) {
+    const _rankGuard = await guardMutation(sb, me, 'coordinator-backlog-rank');
+    if (!_rankGuard.allowed) {
+      console.log('[BACKLOG-RANK] mutation blocked by coordinator guard — not the canonical coordinator; skipping writes.');
+      return;
+    }
+  }
+
   let writes = 0, clears = 0;
   for (let i = 0; i < claimable.length; i++) {
     const d = claimable[i];

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -12,6 +12,8 @@ import { resolve } from 'path';
 import { createRequire } from 'module';
 // SD-LEO-INFRA-COORDINATOR-DISPATCH-TARGET-001: validated dispatch guard.
 const { insertCoordinationRow, isFullUuid } = createRequire(import.meta.url)('../lib/coordinator/dispatch.cjs');
+// SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: single-writer mutation guard.
+import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-guard.mjs';
 
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 const me = process.env.CLAUDE_SESSION_ID;
@@ -43,6 +45,14 @@ export function partitionParticipants(sess, me, adamReviewOn) {
 // SD-...-001-D: wrapped in a named fn + main-guard so partitionParticipants is
 // importable by tests without executing this DB-touching body on import.
 export async function selfReviewMain() {
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: guard — block if this session
+  // is not the canonical coordinator (fail-open on resolver error / no session_id).
+  // Finding 1: resolve our id env-first, disk-pointer fallback (works out-of-band).
+  // Finding 2: return; (void) on block like the other 3 consumers — guardMutation already
+  // logged the [COORD_MUTATION_BLOCKED] warn, so the block stays observable.
+  const _guardVerdict = await guardMutation(db, resolveOwnSessionId(), 'coordinator-self-review');
+  if (!_guardVerdict.allowed) return;
+
   // 1) ALWAYS capture responses -> durable feedback (cheap; dedup by metadata.review_key)
   const since = new Date(t - 24 * 3600 * 1000).toISOString();
   const { data: sigs } = await db.from('session_coordination').select('id,sender_session,payload,created_at')

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -570,6 +570,47 @@ async function clearStaleQfClaims(supabase, now, actions, warnings) {
   }
 }
 
+// SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): guarded WORK_ASSIGNMENT
+// dispatch, extracted from main() so the single-writer gate is unit-testable in isolation.
+// When `allowed` is false (this sweep is running as a NON-canonical coordinator), NO
+// WORK_ASSIGNMENT (sender_type:'sweep') insert happens — preventing a lingering OLD coordinator
+// from re-dispatching to every worker every 5 min (the double-dispatch FR-2 names first).
+// When `allowed` is true, dispatch proceeds exactly as before (skip workers that already have an
+// unacknowledged WORK_ASSIGNMENT to avoid spam). Returns { dispatched, skipped } for observability.
+async function dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, available, allowed) {
+  if (!allowed) {
+    console.log('[SWEEP] WORK_ASSIGNMENT dispatch SKIPPED for ' + (activeSessions || []).length + ' active session(s) — not the canonical coordinator (double-dispatch guard).');
+    return { dispatched: 0, skipped: (activeSessions || []).length, blocked: true };
+  }
+  let dispatched = 0;
+  for (const s of activeSessions || []) {
+    // Check if we already have an unacknowledged message for this session
+    const { data: existing } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', s.session_id)
+      .eq('message_type', 'WORK_ASSIGNMENT')
+      .is('acknowledged_at', null)
+      .limit(1);
+
+    if (existing && existing.length > 0) continue; // Don't spam
+
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: s.session_id,
+        target_sd: s.sd_key,
+        message_type: 'WORK_ASSIGNMENT',
+        subject: 'Next work available when ' + s.sd_key.split('-').pop() + ' completes',
+        body: 'When you complete ' + s.sd_key + ', pick up the next unclaimed child.\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
+        payload: { available_sds: available, current_sd: s.sd_key },
+        sender_type: 'sweep'
+      });
+    dispatched++;
+  }
+  return { dispatched, skipped: 0, blocked: false };
+}
+
 async function main() {
   const now = new Date();
   const actions = [];
@@ -1484,6 +1525,30 @@ async function main() {
   // third claim-holding status, ALIVE_SOURCE_SIDE.
   const activeSessions = classified.filter(s => CLAIM_HOLDING_STATUSES.has(s.status));
 
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): single-writer guard.
+  // The sweep cron fires INSIDE the coordinator's live session, so process.env.CLAUDE_SESSION_ID
+  // (env-first, .claude/session-id.json fallback) IS the coordinator id. A lingering OLD
+  // coordinator's sweep would otherwise keep re-dispatching WORK_ASSIGNMENT rows + re-asserting
+  // claims every 5 min (the double-dispatch FR-2 exists to stop). Compute the verdict ONCE and
+  // gate ONLY the harmful coordinator double-act mutations below:
+  //   - CLAIM_FIX re-assert (claiming_session_id / is_working_on writes)
+  //   - WORK_ASSIGNMENT terminal-drain (read_at stamp)
+  //   - WORK_ASSIGNMENT dispatch (sender_type:'sweep' inserts)
+  //   - is_coordinator stale-flag clear (existing guard, now sharing this verdict)
+  // DEAD-session cleanup / bilateral claim releases stay UNGATED — idempotent hygiene that is
+  // safe to run from any session and must not be blocked. Fail-OPEN: any guard error → allowed
+  // (never brick the only live coordinator; the sweep is coordinator-invoked).
+  let _coordMutationAllowed = true;
+  try {
+    const { guardMutation: _sweepGuardFn, resolveOwnSessionId: _sweepResolveId } =
+      await import('../lib/coordinator-mutation-guard.mjs');
+    const _sweepVerdict = await _sweepGuardFn(supabase, _sweepResolveId(), 'stale-session-sweep:coordinator-mutations');
+    _coordMutationAllowed = _sweepVerdict.allowed;
+    if (!_coordMutationAllowed) {
+      console.log('[SWEEP] coordinator-mutation guard: NOT the canonical coordinator — WORK_ASSIGNMENT dispatch/drain + CLAIM_FIX re-assert + is_coordinator-clear will be SKIPPED this run (dead-session cleanup still runs).');
+    }
+  } catch { /* fail-open — guard error must not suppress sweep coordinator duties */ }
+
   // 6b. QA — Claim Integrity: detect idle sessions with no SD claim and nudge them
   const { data: idleSessions } = await supabase
     .from('v_active_sessions')
@@ -1629,7 +1694,13 @@ async function main() {
         continue;
       }
       // Eligible -> existing re-assert behavior (unchanged).
-      if (sd.claiming_session_id !== s.session_id) {
+      // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): the re-assert is a
+      // harmful coordinator double-act (a rogue OLD coordinator re-stamping claiming_session_id /
+      // is_working_on every 5 min). Skip it when not the canonical coordinator. The bilateral
+      // CLEARS above (ineligible/terminal/fixture) are idempotent hygiene and stay UNGATED.
+      if (!_coordMutationAllowed) {
+        warnings.push('CLAIM_FIX: re-assert SKIPPED for ' + s.sd_key + ' — not the canonical coordinator (rogue double-act guard)');
+      } else if (sd.claiming_session_id !== s.session_id) {
         await supabase
           .from('strategic_directives_v2')
           .update({ claiming_session_id: s.session_id, is_working_on: true })
@@ -1694,7 +1765,11 @@ async function main() {
   // sweep interval (assignment-age floor) so a transient terminal read can't drop a mid-transition
   // in-flight assignment. Terminal sets BRANCH by target shape: SD → {completed,cancelled,deferred};
   // QF → {completed,cancelled,escalated} (escalated is QF-only; deferred is SD-only). Fail-open.
-  try {
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): the drain is a
+  // WORK_ASSIGNMENT-table coordinator mutation — skip it when not the canonical coordinator.
+  if (!_coordMutationAllowed) {
+    console.log('[SWEEP] WORK_ASSIGNMENT terminal-drain SKIPPED — not the canonical coordinator.');
+  } else try {
     const SWEEP_INTERVAL_MS = 5 * 60_000;
     const assignAgeCutoff = new Date(nowMs - SWEEP_INTERVAL_MS).toISOString();
     const { data: openAssignments } = await supabase
@@ -1728,30 +1803,13 @@ async function main() {
     warnings.push('WORK_ASSIGNMENT_TERMINAL_DRAIN: skipped due to error: ' + (e && e.message ? e.message : e));
   }
 
-  for (const s of activeSessions) {
-    // Check if we already have an unacknowledged message for this session
-    const { data: existing } = await supabase
-      .from('session_coordination')
-      .select('id')
-      .eq('target_session', s.session_id)
-      .eq('message_type', 'WORK_ASSIGNMENT')
-      .is('acknowledged_at', null)
-      .limit(1);
-
-    if (existing && existing.length > 0) continue; // Don't spam
-
-    await supabase
-      .from('session_coordination')
-      .insert({
-        target_session: s.session_id,
-        target_sd: s.sd_key,
-        message_type: 'WORK_ASSIGNMENT',
-        subject: 'Next work available when ' + s.sd_key.split('-').pop() + ' completes',
-        body: 'When you complete ' + s.sd_key + ', pick up the next unclaimed child.\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
-        payload: { available_sds: available, current_sd: s.sd_key },
-        sender_type: 'sweep'
-      });
-  }
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): the WORK_ASSIGNMENT
+  // dispatch is the EXACT double-dispatch FR-2 names first — a lingering OLD coordinator's
+  // sweep would re-insert a WORK_ASSIGNMENT (sender_type:'sweep') to every active worker every
+  // 5 min. Extracted to a guarded, exported helper so the gate is unit-testable in isolation.
+  // (Dead-session cleanup / claim releases above already ran ungated — only this rogue double-act
+  // is blocked.)
+  await dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, available, _coordMutationAllowed);
 
   // Send CLAIM_RELEASED ONLY for sessions whose release write actually succeeded
   // (QF-20260611-162 — previously iterated the raw `dead` list, announcing held/failed releases
@@ -2008,26 +2066,33 @@ async function main() {
   // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-1 — clear is_coordinator flag on
   // sessions whose heartbeat is older than 10 minutes. Logged as
   // COORDINATOR_FLAG_CLEARED. Best-effort — failure does not abort sweep.
+  // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: guard this coordinator-mutation
+  // entry point — only the canonical coordinator session should clear stale flags. Reuses the
+  // single shared _coordMutationAllowed verdict computed once at the top of main() (Finding 3).
   try {
-    const cutoff = new Date(Date.now() - 10 * 60_000).toISOString();
-    const { data: stale } = await supabase
-      .from('claude_sessions')
-      .select('session_id, metadata, heartbeat_at')
-      .filter('metadata->>is_coordinator', 'eq', 'true')
-      .lt('heartbeat_at', cutoff);
-    let cleared = 0;
-    for (const s of stale || []) {
-      const next = { ...(s.metadata || {}) };
-      delete next.is_coordinator;
-      delete next.coordinator_since;
-      await supabase
+    if (!_coordMutationAllowed) {
+      console.log('[SWEEP] coordinator-flag-clear SKIPPED — not the canonical coordinator.');
+    } else {
+      const cutoff = new Date(Date.now() - 10 * 60_000).toISOString();
+      const { data: stale } = await supabase
         .from('claude_sessions')
-        .update({ metadata: next })
-        .eq('session_id', s.session_id);
-      cleared++;
-      console.log('  COORDINATOR_FLAG_CLEARED: session=' + s.session_id + ' heartbeat=' + s.heartbeat_at);
+        .select('session_id, metadata, heartbeat_at')
+        .filter('metadata->>is_coordinator', 'eq', 'true')
+        .lt('heartbeat_at', cutoff);
+      let cleared = 0;
+      for (const s of stale || []) {
+        const next = { ...(s.metadata || {}) };
+        delete next.is_coordinator;
+        delete next.coordinator_since;
+        await supabase
+          .from('claude_sessions')
+          .update({ metadata: next })
+          .eq('session_id', s.session_id);
+        cleared++;
+        console.log('  COORDINATOR_FLAG_CLEARED: session=' + s.session_id + ' heartbeat=' + s.heartbeat_at);
+      }
+      if (cleared > 0) console.log('STALE COORDINATOR FLAGS CLEARED: ' + cleared);
     }
-    if (cleared > 0) console.log('STALE COORDINATOR FLAGS CLEARED: ' + cleared);
   } catch (coordErr) {
     console.log('COORDINATOR FLAG CLEANUP: ' + (coordErr && coordErr.message ? coordErr.message : 'unknown'));
   }
@@ -2305,3 +2370,8 @@ module.exports.TEST_FIXTURE_SD_KEY_LIKE = TEST_FIXTURE_SD_KEY_LIKE;
 // does — no production behavior change.
 module.exports.isSweepResetAllowed = isSweepResetAllowed;
 module.exports.__setExecContextGuardForTest = (mock) => { _execContextGuardCache = mock; };
+
+// SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): export the guarded
+// WORK_ASSIGNMENT dispatch so the single-writer gate is unit-testable (assert NO sender_type:'sweep'
+// insert happens when !allowed; insert happens when allowed).
+module.exports.dispatchWorkAssignmentsIfAllowed = dispatchWorkAssignmentsIfAllowed;


### PR DESCRIPTION
## Child B — single-writer guard

A lingering NON-canonical coordinator session can no longer double-act on mutating coordinator duties.

- **NEW lib/coordinator-mutation-guard.mjs**: `assertCanonicalCoordinator` (FAIL-CLOSED on a confirmed different-canonical verdict, FAIL-OPEN on resolver throw/null/no-session) + `guardMutation` + `resolveOwnSessionId` (env → .claude/session-id.json fallback).
- Wired into the 4 mutating duty daemons (self-review, backlog-rank, fleet-identities, stale-sweep). In the sweep, gates ONLY the harmful coordinator double-acts (WORK_ASSIGNMENT dispatch + drain, CLAIM re-assert, is_coordinator-clear) while leaving DEAD-session cleanup UNGATED (idempotent hygiene). Read-only paths unguarded.

### Review
Adversarial review caught a real **HIGH** gap — the WORK_ASSIGNMENT dispatch (FR-2's first-named duty) was initially left unguarded on a self-contradictory rationale — plus 2 LOW. All fixed. `lib/coordinator/` + guard = **196/196**.

Depends on child A (merged). 🤖 Generated with [Claude Code](https://claude.com/claude-code)