### PR TITLE
feat(SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001): DUTY-8 progress-stall detector

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -145,6 +145,72 @@ export function detectQuietTickUnverified({ coordinatorReviews = [] } = {}) {
 }
 
 /**
+ * DUTY-8 PROGRESS-STALL (SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001) — surface claim-holders that are
+ * heartbeat-ALIVE but whose claimed SD is FROZEN (no progress). PURE; the canonical staleness predicate
+ * (detectStuckWorker from lib/coordinator/detectors.cjs) and the armed-silence check are INJECTED.
+ *
+ * Why not feed detectStuckWorker the real heartbeat: its progress proxy is MAX(heartbeat_at, sd_updated_at),
+ * so a FRESH heartbeat masks the stall — it would never fire on a live worker (the very class we want). So the
+ * claim-builder here establishes liveness itself (ACTIVELY heartbeating within `freshMs` AND not inside an
+ * armed-silence window) and then passes heartbeat_at:null into the canonical predicate so it keys PURELY on SD
+ * progress (sd_updated_at staleness). This reuses the canonical staleness math (no re-derivation / no drift
+ * with the sweep) while correctly capturing the alive-but-frozen class.
+ *
+ * FALSE-POSITIVE GUARD — the THRESHOLD is primary, not armed-silence: strategic_directives_v2.updated_at only
+ * advances on an actual SD-row UPDATE (handoffs / phase writes / progress-tick), NOT during ordinary EXEC work,
+ * and an expected_silence_until window is hard-capped at ~30min (well below a sane threshold). So the conservative
+ * caller threshold (default 4h — far longer than any normal phase) is what keeps this a rare high-signal advisory;
+ * the armed-silence exclusion below is only a secondary early-out for a worker that is explicitly parked RIGHT NOW.
+ *
+ * @param {object} p
+ * @param {Array<object>} p.liveSessions - charter-audit live sessions {session_id, sd_key, heartbeat_at, expected_silence_until}
+ * @param {Array<object>} p.sds - non-terminal SDs {sd_key, updated_at, current_phase}
+ * @param {number} p.nowMs - injected clock
+ * @param {number} [p.thresholdMs] - SD-progress staleness threshold passed to the canonical predicate
+ * @param {number} [p.freshMs=5m] - heartbeat-freshness window that defines "actively alive"
+ * @param {(until:any, now:number)=>boolean} [p.isWithinArmedSilence] - canonical armed-silence check (excludes parked workers)
+ * @param {(data:object)=>{matched:boolean,reason:string,evidence:object}} p.detectStuck - canonical detectStuckWorker
+ * @returns {{violation:boolean, stalledCount:number, samples:Array, detail:string, remediation:(string|null)}}
+ */
+export function detectProgressStall({ liveSessions = [], sds = [], nowMs, thresholdMs, freshMs, isWithinArmedSilence, detectStuck } = {}) {
+  if (typeof detectStuck !== 'function' || !Array.isArray(liveSessions) || !Array.isArray(sds) || !Number.isFinite(nowMs)) {
+    return { violation: false, stalledCount: 0, samples: [], detail: 'progress-stall not evaluable (fail-open)', remediation: null };
+  }
+  const fresh = Number.isFinite(freshMs) ? freshMs : 5 * 60 * 1000;
+  const sdByKey = new Map(sds.filter((s) => s && s.sd_key).map((s) => [s.sd_key, s]));
+  const claims = [];
+  for (const s of liveSessions) {
+    if (!s || !s.sd_key) continue;                                  // no claim → not this detector's class
+    const sd = sdByKey.get(s.sd_key);
+    if (!sd) continue;                                              // claimed SD terminal/absent → excluded
+    const hb = s.heartbeat_at ? new Date(s.heartbeat_at).getTime() : NaN;
+    if (!Number.isFinite(hb) || (nowMs - hb) >= fresh) continue;    // require ACTIVELY heartbeating (alive)
+    if (isWithinArmedSilence && isWithinArmedSilence(s.expected_silence_until, nowMs)) continue; // legit parked
+    // Liveness established above → pass heartbeat_at:null so the canonical predicate keys PURELY on SD progress.
+    claims.push({ sd_key: s.sd_key, session_id: s.session_id, heartbeat_at: null, sd_updated_at: sd.updated_at, current_phase: sd.current_phase });
+  }
+  let res;
+  try { res = detectStuck({ claims, now: nowMs, thresholdMs }); }
+  catch { return { violation: false, stalledCount: 0, samples: [], detail: 'progress-stall predicate threw (fail-open)', remediation: null }; }
+  const matched = !!(res && res.matched);
+  const ev = (res && res.evidence) || {};
+  const samples = Array.isArray(ev.samples)
+    ? ev.samples.slice(0, 10).map((x) => ({ sd_key: x.sd_key, phase: x.phase ?? null, ageHours: Number.isFinite(x.age_ms) ? Math.round(x.age_ms / 3600000) : null }))
+    : [];
+  return {
+    violation: matched,
+    stalledCount: matched ? (ev.stuck_count ?? samples.length) : 0,
+    samples,
+    detail: matched
+      ? `${ev.stuck_count ?? samples.length} worker(s) heartbeat-alive but claimed SD frozen (no SD update past threshold; not in armed-silence) — ${samples.slice(0, 3).map((x) => `${x.sd_key}(${x.phase || '?'},${x.ageHours}h)`).join(', ')}`
+      : 'none (claimed SDs progressing, or live workers parked in armed-silence)',
+    remediation: matched
+      ? 'ACTION: checkpoint the heartbeat-alive worker(s) on the named SD(s) — actively heartbeating but the claimed SD has not advanced and not in an armed-silence window (possible mid-phase loop / phase-reset / silent block); wake/prompt or verify progress'
+      : null,
+  };
+}
+
+/**
  * Resolve the authoritative worktree count, detecting countActiveWorktrees's SILENT git-failure: that helper
  * swallows a git-CLI error and returns 0 (it never throws), which would read as a false-clean 0/20. If git
  * reports 0 but the filesystem shows worktree directories, git failed -> return -1 (the fail-loud sentinel

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -29,7 +29,7 @@ import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-fr
 import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
-  extractDepKey, resolveWorktreeCount, computeDispatchBelt,
+  extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectProgressStall,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
 // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: DUTY-7 silent-stall detector (drafts stranded with null vision_score).
 import { findStalledDrafts } from '../lib/coordinator/draft-stall-detector.mjs';
@@ -37,6 +37,12 @@ import { findStalledDrafts } from '../lib/coordinator/draft-stall-detector.mjs';
 const require = createRequire(import.meta.url);
 const { isWithinArmedSilenceWindow } = require('../lib/fleet/silence-cap.cjs');
 const { classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
+// SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001: reuse the CANONICAL stuck-worker staleness predicate for DUTY-8
+// (no re-derived staleness math → no drift with the stale-session-sweep). GUARDED like the PID resolver above:
+// a missing/broken detectors.cjs degrades detectStuckWorker to null → detectProgressStall fail-opens to a
+// no-violation no-op (DUTY-8 is strictly additive and must never crash the audit at import time).
+let detectStuckWorker = null;
+try { ({ detectStuckWorker } = require('../lib/coordinator/detectors.cjs')); } catch { /* DUTY-8 fail-open if unavailable */ }
 // Reuse the sweep's authoritative PID resolver (import-safe — main() is require.main-guarded). Optional: a
 // failed import degrades the PID signal to a no-op (armed-silence + heartbeat still drive liveness).
 let resolveCcPidFromTerminalId = () => null;
@@ -48,6 +54,16 @@ const DISPATCH_RANK_TTL_MS = 60 * 60 * 1000; // mirrors worker-checkin.cjs DISPA
 // only on NaN/empty/negative.
 const _draftStallDays = Number(process.env.DRAFT_STALL_DAYS_THRESHOLD);
 const DRAFT_STALL_MS = (Number.isFinite(_draftStallDays) && _draftStallDays >= 0 ? _draftStallDays : 7) * 86400000;
+// SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001 — DUTY-8 threshold: a claimed SD whose updated_at is stale beyond
+// this (while the worker is fresh-heartbeating + NOT in armed-silence) is a progress-stall. Honor an explicit 0.
+// Default 4h is DELIBERATELY conservative and is the PRIMARY false-positive guard: strategic_directives_v2.updated_at
+// only advances on an actual SD-row UPDATE (handoffs / phase writes / progress-tick), NOT during ordinary EXEC work
+// (editing code, running tests). A worker can also only arm an expected_silence_until window for ~30min (silence
+// hard cap, well below this threshold), so armed-silence is merely a secondary early-out for an explicitly-parked
+// worker — the 4h threshold (far longer than any normal phase) is what keeps DUTY-8 a rare, high-signal advisory
+// rather than nagging every healthy long-EXEC worker. Env-tunable via PROGRESS_STALL_HOURS_THRESHOLD.
+const _progressStallHrs = Number(process.env.PROGRESS_STALL_HOURS_THRESHOLD);
+const PROGRESS_STALL_MS = (Number.isFinite(_progressStallHrs) && _progressStallHrs >= 0 ? _progressStallHrs : 4) * 3600000;
 const TERMINAL = new Set(['completed', 'cancelled', 'archived', 'deferred']);
 const depKeysOf = (s) => (Array.isArray(s.dependencies) ? s.dependencies.map(extractDepKey).filter(Boolean) : []);
 
@@ -136,6 +152,9 @@ async function main() {
     // Advisory remediation count only — summarizeViolations never drives a process.exit (foundational-query
     // failures are the ONLY hard exits), so a stalled draft surfaces a remediation action, never a hard fail.
     draft: findStalledDrafts(sds, nowMs, { thresholdMs: DRAFT_STALL_MS, scoredKeys: scoredDraftKeys }),
+    // SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001: DUTY-8 — claim-holders heartbeat-ALIVE but claimed SD FROZEN.
+    // Reuses the canonical detectStuckWorker predicate (injected); advisory remediation count only (no new exit).
+    progress: detectProgressStall({ liveSessions: live, sds, nowMs, thresholdMs: PROGRESS_STALL_MS, isWithinArmedSilence: isWithinArmedSilenceWindow, detectStuck: detectStuckWorker }),
   };
 
   const flag = (r) => (r.remediation ? '  ⚠ ' + r.remediation : '');
@@ -147,6 +166,7 @@ async function main() {
   console.log('  DUTY-6 BACKLOG-RANK  : ' + D.rank.detail + flag(D.rank));
   console.log('  QUIET-TICK COMMITTED : ' + D.quiet.detail + flag(D.quiet));
   console.log('  DUTY-7 DRAFT-STALL   : ' + D.draft.detail + flag(D.draft)); // SILENT-STALL-PREVENTION-001
+  console.log('  DUTY-8 PROGRESS-STALL: ' + D.progress.detail + flag(D.progress)); // PROGRESS-STALL-DETECTION-001
 
   // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: ADVISORY freshness dimension — fail-open and deliberately
   // kept OUT of `D`/summarizeViolations, so a stale checkout surfaces a warning but never trips the

--- a/tests/unit/progress-stall-detector.test.js
+++ b/tests/unit/progress-stall-detector.test.js
@@ -1,0 +1,113 @@
+/**
+ * Progress-stall detector (DUTY-8) tests — SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001.
+ * PURE: injected clock + injected canonical predicate (real detectStuckWorker for genuine integration; a stub
+ * to prove the INJECTED predicate is what decides) + injected armed-silence check. Zero live DB.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { detectProgressStall } from '../../lib/coordinator/charter-audit-detectors.mjs';
+import detectorsPkg from '../../lib/coordinator/detectors.cjs';
+import silenceCap from '../../lib/fleet/silence-cap.cjs';
+const { detectStuckWorker } = detectorsPkg;
+// Use the REAL canonical armed-silence check (NOT a loose inline stub) — it is hard-capped at ~30min, so tests
+// exercise the production behavior, including that armed-silence canNOT cover a multi-hour stall threshold.
+const { isWithinArmedSilenceWindow: isWithinArmedSilence } = silenceCap;
+
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const NOW = Date.parse('2026-06-15T12:00:00.000Z');
+const ago = (ms) => new Date(NOW - ms).toISOString();
+
+const baseOpts = (over = {}) => ({
+  nowMs: NOW,
+  thresholdMs: HOUR,
+  isWithinArmedSilence,
+  detectStuck: detectStuckWorker,
+  ...over,
+});
+
+// A live (fresh-heartbeat) session holding sd_key, not in armed-silence.
+const liveSession = (sd_key, over = {}) => ({ session_id: 's-' + sd_key, sd_key, heartbeat_at: ago(1 * MIN), expected_silence_until: null, ...over });
+const sd = (sd_key, updatedMsAgo, phase = 'EXEC') => ({ sd_key, updated_at: ago(updatedMsAgo), current_phase: phase });
+
+describe('detectProgressStall — fires on alive-but-frozen', () => {
+  it('flags a fresh-heartbeat worker whose claimed SD is stale beyond threshold', () => {
+    const r = detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 2 * HOUR)] }));
+    expect(r.violation).toBe(true);
+    expect(r.stalledCount).toBe(1);
+    expect(r.samples[0].sd_key).toBe('SD-A');
+    expect(r.samples[0].phase).toBe('EXEC');
+    expect(r.samples[0].ageHours).toBe(2);
+    expect(r.remediation).toMatch(/checkpoint/i);
+  });
+});
+
+describe('detectProgressStall — does NOT fire', () => {
+  it('SD updated recently (within threshold) → progressing', () => {
+    const r = detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 10 * MIN)] }));
+    expect(r.violation).toBe(false);
+  });
+  it('worker in a CURRENT armed-silence window (within the ~30min cap) is excluded even if SD is stale', () => {
+    const parked = liveSession('SD-A', { expected_silence_until: new Date(NOW + 20 * MIN).toISOString() });
+    expect(detectProgressStall(baseOpts({ liveSessions: [parked], sds: [sd('SD-A', 5 * HOUR)] })).violation).toBe(false);
+  });
+  it('PS-1: an EXPIRED armed-silence window does NOT protect a long stall (silence cap < threshold) → fires', () => {
+    // armed-silence only covers the window duration (hard-capped ~30min); once expired it cannot shield a multi-hour
+    // stall — so the conservative THRESHOLD (not armed-silence) is the real guard. A worker whose window lapsed and
+    // whose SD has been frozen 5h is correctly flagged.
+    const lapsed = liveSession('SD-A', { expected_silence_until: new Date(NOW - 10 * MIN).toISOString() });
+    expect(detectProgressStall(baseOpts({ liveSessions: [lapsed], sds: [sd('SD-A', 5 * HOUR)] })).violation).toBe(true);
+  });
+  it('worker not ACTIVELY heartbeating (heartbeat older than freshMs) is excluded', () => {
+    const stale = liveSession('SD-A', { heartbeat_at: ago(30 * MIN) });
+    expect(detectProgressStall(baseOpts({ liveSessions: [stale], sds: [sd('SD-A', 5 * HOUR)] })).violation).toBe(false);
+  });
+  it('session with no sd_key, or claimed SD absent/terminal (not in sds), is excluded', () => {
+    const noClaim = { session_id: 's-x', heartbeat_at: ago(1 * MIN) };
+    expect(detectProgressStall(baseOpts({ liveSessions: [noClaim], sds: [sd('SD-A', 5 * HOUR)] })).violation).toBe(false);
+    // claims SD-GONE but it is not in sds (terminal/absent) → excluded
+    expect(detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-GONE')], sds: [sd('SD-A', 5 * HOUR)] })).violation).toBe(false);
+  });
+});
+
+describe('detectProgressStall — reuses the INJECTED canonical predicate (no re-derivation)', () => {
+  it('an injected predicate returning matched:false suppresses the violation despite stale timestamps', () => {
+    const stub = vi.fn(() => ({ matched: false, reason: 'stub', evidence: {} }));
+    const r = detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 9 * HOUR)], detectStuck: stub }));
+    expect(stub).toHaveBeenCalledTimes(1);
+    // the claim fed to the predicate carries heartbeat_at:null so the predicate keys purely on SD progress
+    expect(stub.mock.calls[0][0].claims[0]).toMatchObject({ sd_key: 'SD-A', heartbeat_at: null });
+    expect(r.violation).toBe(false);
+  });
+  it('PS-3: pins the relied-on detectStuckWorker contract — a heartbeat_at:null claim keys PURELY on sd_updated_at', () => {
+    // The whole reuse trick depends on this: with heartbeat nulled, MAX(heartbeat,sd_updated) collapses to
+    // sd_updated, so a STALE sd_updated_at matches and a FRESH one does not — regardless of any heartbeat.
+    const stale = detectStuckWorker({ claims: [{ sd_key: 'SD-A', session_id: 's1', heartbeat_at: null, sd_updated_at: ago(3 * HOUR), current_phase: 'EXEC' }], now: NOW, thresholdMs: HOUR });
+    expect(stale.matched).toBe(true);
+    const fresh = detectStuckWorker({ claims: [{ sd_key: 'SD-A', session_id: 's1', heartbeat_at: null, sd_updated_at: ago(10 * MIN), current_phase: 'EXEC' }], now: NOW, thresholdMs: HOUR });
+    expect(fresh.matched).toBe(false);
+  });
+  it('an injected predicate returning matched:true drives the violation (adapter maps evidence)', () => {
+    const stub = vi.fn(() => ({ matched: true, reason: 'x', evidence: { stuck_count: 1, samples: [{ sd_key: 'SD-A', phase: 'EXEC', age_ms: 3 * HOUR }] } }));
+    const r = detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 3 * HOUR)], detectStuck: stub }));
+    expect(r.violation).toBe(true);
+    expect(r.samples[0]).toMatchObject({ sd_key: 'SD-A', ageHours: 3 });
+  });
+});
+
+describe('detectProgressStall — fail-open', () => {
+  it('no detectStuck predicate → no violation, never throws', () => {
+    expect(detectProgressStall({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 5 * HOUR)], nowMs: NOW }).violation).toBe(false);
+  });
+  it('non-array sessions / NaN clock → no violation', () => {
+    expect(detectProgressStall(baseOpts({ liveSessions: 'nope', sds: [] })).violation).toBe(false);
+    expect(detectProgressStall(baseOpts({ liveSessions: [], sds: [], nowMs: NaN })).violation).toBe(false);
+  });
+  it('a predicate that THROWS is caught (fail-open)', () => {
+    const boom = () => { throw new Error('predicate boom'); };
+    expect(() => detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 5 * HOUR)], detectStuck: boom }))).not.toThrow();
+    expect(detectProgressStall(baseOpts({ liveSessions: [liveSession('SD-A')], sds: [sd('SD-A', 5 * HOUR)], detectStuck: boom })).violation).toBe(false);
+  });
+  it('empty inputs → no violation', () => {
+    expect(detectProgressStall(baseOpts({ liveSessions: [], sds: [] })).violation).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001 — DUTY-8 progress-stall detector

Surfaces claim-holders that are **heartbeat-ALIVE but whose claimed SD is FROZEN** (no progress) as a new read-only **DUTY-8** in the coordinator charter-audit self-audit — a class the durable self-audit was previously blind to (the stale-session-sweep acts on it, but the coordinator's own duty dashboard did not surface it).

### Design
- **`lib/coordinator/charter-audit-detectors.mjs`** — NEW pure `detectProgressStall(...)`. Establishes liveness itself (fresh heartbeat + NOT in armed-silence), then **REUSES the canonical `detectStuckWorker`** (injected) keyed on SD progress via `heartbeat_at:null` — no re-derived staleness math, no drift with the sweep. Pure, clock-injected, fail-open.
- **`scripts/coordinator-charter-audit.mjs`** — wires DUTY-8 (GUARDED require; advisory, **no new hard exit**). `PROGRESS_STALL_HOURS_THRESHOLD` default **4h** is the primary false-positive guard (`sd.updated_at` only advances at handoffs; armed-silence caps at ~30min).
- **`tests/unit/progress-stall-detector.test.js`** — 13 pure tests (injected clock + REAL `detectStuckWorker` + REAL `isWithinArmedSilenceWindow` + a stub proving injection decides).

### Verification
- **13 DB-free unit tests** pass.
- **Live-validated**: at the 4h default, DUTY-8 surfaced exactly one **genuine** 9h-frozen alive worker (not noise), EXIT=0.
- **Consolidated adversarial review**: PS-1/PS-2 (cry-wolf at 1h) → fixed via the 4h threshold + corrected comment; PS-3/PS-4 + test false-confidence fixed; Dimension-C (no-new-exit/fail-open/purity) clean.
- TESTING sub-agent: PASS@96.

**Deferred** (follow-ups): cross-sweep phase-fingerprint persistence + a BLOCKED_ON_PROMPT worker signal. No schema. EHG_Engineer only. Additive + reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
