### PR TITLE
feat(SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001): VDR vision build-% gauge + one-roadmap registry

### DIFF
--- a/database/migrations/20260614_archive_eva_intake_roadmap.sql
+++ b/database/migrations/20260614_archive_eva_intake_roadmap.sql
@@ -1,0 +1,41 @@
+-- Archive the stale EVA Intake Roadmap row so ONE canonical roadmap remains.
+-- SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-3).
+-- DATA migration (no schema change): the strategic_roadmaps table holds two status='active' rows —
+-- the stale "EVA Intake Roadmap" (ed12bf74, 2026-03-08, 462 stale items) and the canonical
+-- "LEO Roadmap" (3aa2f3e2, 2026-06-13). The vision/LEO-ROADMAP doc names the EVA row as the one to
+-- archive. This sets it to status='archived' (an allowed CHECK value: draft|active|archived) so the
+-- canonical LEO Roadmap is the single active source of truth.
+--
+-- REVERSIBLE: to undo, UPDATE strategic_roadmaps SET status='active' WHERE id='ed12bf74-57c9-4ee0-a1b3-273bef11705c'.
+-- CONSUMER COUPLING: the EHG-app reader (ehg/src/hooks/usePortfolioRoadmap.ts) currently fetches ALL
+-- roadmaps with NO status filter — so this archival fully realizes "one roadmap in the cockpit" only
+-- once the cross-repo ehg query adds `.eq("status","active")` (shipped with FR-5 in the ehg PR). The
+-- archival is safe on its own (the row is merely marked archived).
+--
+-- CHAIRMAN PROD-DEPLOY GATE: intentionally NOT yet attested. Before `node scripts/apply-migration.js
+-- <file> --prod-deploy`, the CHAIRMAN must add `-- @approved-by: <chairman-email>` (matching git
+-- user.email) — absent here because the worker may not self-author the attestation (CONST-002), and
+-- archiving a live roadmap row is a chairman-visible change best sequenced with the ehg filter merge.
+
+UPDATE strategic_roadmaps
+   SET status = 'archived',
+       updated_at = now()
+ WHERE id = 'ed12bf74-57c9-4ee0-a1b3-273bef11705c'
+   AND title = 'EVA Intake Roadmap';
+
+-- In-migration verify (green-now): the EVA row is archived AND exactly one active roadmap remains.
+DO $verify$
+DECLARE
+  eva_status text;
+  active_count integer;
+BEGIN
+  SELECT status INTO eva_status FROM strategic_roadmaps WHERE id = 'ed12bf74-57c9-4ee0-a1b3-273bef11705c';
+  IF eva_status IS DISTINCT FROM 'archived' THEN
+    RAISE EXCEPTION 'EVA Intake Roadmap not archived (status=%)', eva_status;
+  END IF;
+  SELECT count(*) INTO active_count FROM strategic_roadmaps WHERE status = 'active';
+  IF active_count <> 1 THEN
+    RAISE EXCEPTION 'expected exactly 1 active roadmap after archival, found %', active_count;
+  END IF;
+END
+$verify$;

--- a/database/migrations/20260614_vision_build_gauge.sql
+++ b/database/migrations/20260614_vision_build_gauge.sql
@@ -1,0 +1,57 @@
+-- vision_build_gauge — historized snapshots of the auto-computed vision BUILD-completeness gauge.
+-- SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-2).
+-- Minimal ADDITIVE table — no change to any existing table. APPEND-ONLY: one row per VDR run
+-- (scripts/vision-gauge-refresh.mjs), so the overall %, per-layer breakdown, and the full
+-- component/probe results are historized for trend ("Adam works it down"). The denominator is
+-- inspectable (components JSONB) so the percentage is auditable and never fabricated.
+--
+-- CHAIRMAN PROD-DEPLOY GATE: this migration is intentionally NOT yet attested. Before applying to
+-- production with `node scripts/apply-migration.js <file> --prod-deploy`, the CHAIRMAN must add the
+-- line `-- @approved-by: <chairman-email>` (matching git user.email) — it is deliberately absent
+-- here because the worker may not self-author the chairman attestation (CONST-002).
+
+CREATE TABLE IF NOT EXISTS vision_build_gauge (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  overall_pct        integer,                       -- 0..100; NULL when the gauge was unavailable (vision doc absent)
+  available          boolean NOT NULL DEFAULT true, -- false ⇒ the gauge could not be computed this run
+  per_layer          jsonb NOT NULL DEFAULT '{}'::jsonb,   -- { infrastructure, application, venture, process } → pct|null
+  components          jsonb NOT NULL DEFAULT '[]'::jsonb,   -- [{ capability, layer, status, detail, score }] — the auditable denominator
+  denominator        integer NOT NULL DEFAULT 0,    -- probeable capabilities (status != 'unknown') = the % denominator
+  total_capabilities integer NOT NULL DEFAULT 0,    -- all REQUIRED capabilities parsed from EHG-VISION.md
+  unknown_count      integer NOT NULL DEFAULT 0,    -- capabilities excluded from the denominator (unprobeable)
+  source             text NOT NULL DEFAULT 'vdr',   -- producer tag (the Vision Denominator Registry)
+  measured_at        timestamptz NOT NULL DEFAULT now()
+);
+
+-- Trend reads (latest snapshot / time series) order by measured_at.
+CREATE INDEX IF NOT EXISTS idx_vision_build_gauge_measured_at ON vision_build_gauge (measured_at DESC);
+
+-- RLS: authenticated read; service_role full write (governance-table convention — mirrors
+-- adam_adherence_ledger / venture_guardrail_state).
+ALTER TABLE vision_build_gauge ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vision_build_gauge_read ON vision_build_gauge
+  FOR SELECT
+  USING (auth.role() = 'authenticated' OR auth.role() = 'service_role');
+
+CREATE POLICY vision_build_gauge_service_write ON vision_build_gauge
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+COMMENT ON TABLE vision_build_gauge IS 'Historized vision BUILD-completeness gauge snapshots (SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 FR-2). Append-only; written by scripts/vision-gauge-refresh.mjs from the Vision Denominator Registry; read by the Adam exec-summary + the Chairman-UI build-% tile. components JSONB is the inspectable, auditable denominator.';
+
+-- In-migration verify (green-now): assert the table + index + policies exist after apply.
+DO $verify$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'vision_build_gauge') THEN
+    RAISE EXCEPTION 'vision_build_gauge table was not created';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_vision_build_gauge_measured_at') THEN
+    RAISE EXCEPTION 'idx_vision_build_gauge_measured_at index was not created';
+  END IF;
+  IF (SELECT count(*) FROM pg_policies WHERE tablename = 'vision_build_gauge') < 2 THEN
+    RAISE EXCEPTION 'vision_build_gauge RLS policies were not created';
+  END IF;
+END
+$verify$;

--- a/lib/vision/vdr-probes.js
+++ b/lib/vision/vdr-probes.js
@@ -1,0 +1,126 @@
+/**
+ * SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-1) — VDR typed probe runners.
+ *
+ * The Vision Denominator Registry (VDR) computes the vision BUILD-completeness gauge by running
+ * a TYPED probe per REQUIRED capability against LIVE signals. These runners are the deterministic,
+ * no-LLM numerator engine. Each runner is pure + injectable (the supabase client and the code-grep
+ * seam are passed in) so the gauge is unit-testable without a live DB and the percentage is never
+ * fabricated.
+ *
+ * Probe result contract — every runner returns:
+ *   { status: 'built' | 'partial' | 'unbuilt' | 'unknown', value: <observed>, detail: <string> }
+ * 'unknown' means the probe could not be evaluated (e.g. a cross-repo grep when the repo is absent);
+ * the gauge EXCLUDES 'unknown' from the denominator and reports the count, so an unprobeable
+ * capability is never silently counted as built OR unbuilt (honest, auditable).
+ *
+ * Probe types:
+ *   - kr_status:     a key_results row (by `code`) — built when achieved / current>=target.
+ *   - db_count:      COUNT(table [+ filter]) vs a threshold — builtWhen 'gte' (present) or 'absent' (==0).
+ *   - row_predicate: at least one row matches a filter — builtWhen 'exists' or 'absent'.
+ *   - code_grep:     a regex matches under a repo path — builtWhen 'present' or 'absent'.
+ */
+
+export const VALID_STATUSES = ['built', 'partial', 'unbuilt', 'unknown'];
+
+/** kr_status: read key_results by `code`. built when status='achieved' OR current>=target; partial when current>0 (and target>0). */
+export async function krStatusProbe(def, io) {
+  const supabase = io && io.supabase;
+  if (!supabase) return { status: 'unknown', value: null, detail: 'no supabase client' };
+  try {
+    const { data, error } = await supabase
+      .from('key_results')
+      .select('code,status,current_value,target_value')
+      .eq('code', def.code)
+      .maybeSingle();
+    if (error) return { status: 'unknown', value: null, detail: `kr query error: ${error.message}` };
+    if (!data) return { status: 'unknown', value: null, detail: `KR ${def.code} not found` };
+    const cur = Number(data.current_value);
+    const tgt = Number(data.target_value);
+    const met = data.status === 'achieved' || (Number.isFinite(cur) && Number.isFinite(tgt) && tgt > 0 && cur >= tgt);
+    if (met) return { status: 'built', value: data.status, detail: `${def.code} ${data.status} (${cur}/${tgt})` };
+    if (Number.isFinite(cur) && cur > 0) return { status: 'partial', value: cur, detail: `${def.code} in progress (${cur}/${tgt})` };
+    return { status: 'unbuilt', value: cur, detail: `${def.code} ${data.status} (${cur}/${tgt})` };
+  } catch (e) {
+    return { status: 'unknown', value: null, detail: `kr probe threw: ${e.message}` };
+  }
+}
+
+/** db_count: COUNT(table [+ eq filter]) vs threshold. builtWhen 'gte' (>=min ⇒ built) or 'absent' (==0 ⇒ built). */
+export async function dbCountProbe(def, io) {
+  const supabase = io && io.supabase;
+  if (!supabase) return { status: 'unknown', value: null, detail: 'no supabase client' };
+  try {
+    let q = supabase.from(def.table).select('*', { count: 'exact', head: true });
+    if (def.filter && typeof def.filter === 'object') {
+      for (const [k, v] of Object.entries(def.filter)) q = q.eq(k, v);
+    }
+    const { count, error } = await q;
+    if (error) return { status: 'unknown', value: null, detail: `count error on ${def.table}: ${error.message}` };
+    const n = Number(count) || 0;
+    if (def.builtWhen === 'absent') {
+      return { status: n === 0 ? 'built' : 'unbuilt', value: n, detail: `${def.table} count=${n} (built when 0)` };
+    }
+    const min = Number.isFinite(def.min) ? def.min : 1;
+    return { status: n >= min ? 'built' : 'unbuilt', value: n, detail: `${def.table} count=${n} (built when >=${min})` };
+  } catch (e) {
+    return { status: 'unknown', value: null, detail: `db_count threw: ${e.message}` };
+  }
+}
+
+/** row_predicate: does >=1 row match the eq filter? builtWhen 'exists' (default) or 'absent'. */
+export async function rowPredicateProbe(def, io) {
+  const supabase = io && io.supabase;
+  if (!supabase) return { status: 'unknown', value: null, detail: 'no supabase client' };
+  try {
+    let q = supabase.from(def.table).select('*', { count: 'exact', head: true });
+    if (def.filter && typeof def.filter === 'object') {
+      for (const [k, v] of Object.entries(def.filter)) q = q.eq(k, v);
+    }
+    const { count, error } = await q;
+    if (error) return { status: 'unknown', value: null, detail: `predicate error on ${def.table}: ${error.message}` };
+    const exists = (Number(count) || 0) > 0;
+    const builtWhenAbsent = def.builtWhen === 'absent';
+    const built = builtWhenAbsent ? !exists : exists;
+    return { status: built ? 'built' : 'unbuilt', value: Number(count) || 0, detail: `${def.table} exists=${exists} (built when ${builtWhenAbsent ? 'absent' : 'exists'})` };
+  } catch (e) {
+    return { status: 'unknown', value: null, detail: `row_predicate threw: ${e.message}` };
+  }
+}
+
+/** code_grep: does `pattern` match under repoRoot/<path>? builtWhen 'present' (default) or 'absent'.
+ *  io.grep(pattern, absPath) MUST return { matched: boolean, accessible: boolean }. If the path is not
+ *  accessible (e.g. the cross-repo ehg checkout is absent) the probe is 'unknown' (never guessed). */
+export async function codeGrepProbe(def, io) {
+  const grep = io && io.grep;
+  if (typeof grep !== 'function') return { status: 'unknown', value: null, detail: 'no grep seam' };
+  try {
+    const res = await grep(def.pattern, def.path, def.repo || 'EHG_Engineer');
+    if (!res || res.accessible === false) {
+      return { status: 'unknown', value: null, detail: `path not accessible: ${def.repo || ''}/${def.path}` };
+    }
+    const builtWhenAbsent = def.builtWhen === 'absent';
+    const built = builtWhenAbsent ? !res.matched : res.matched;
+    return { status: built ? 'built' : 'unbuilt', value: !!res.matched, detail: `grep /${def.pattern}/ in ${def.repo || ''}/${def.path} matched=${!!res.matched} (built when ${builtWhenAbsent ? 'absent' : 'present'})` };
+  } catch (e) {
+    return { status: 'unknown', value: null, detail: `code_grep threw: ${e.message}` };
+  }
+}
+
+export const PROBE_RUNNERS = {
+  kr_status: krStatusProbe,
+  db_count: dbCountProbe,
+  row_predicate: rowPredicateProbe,
+  code_grep: codeGrepProbe,
+};
+
+/** Run one probe def by type. Unknown type ⇒ 'unknown' (never fabricated). */
+export async function runProbe(def, io) {
+  const runner = PROBE_RUNNERS[def && def.type];
+  if (!runner) return { status: 'unknown', value: null, detail: `unknown probe type: ${def && def.type}` };
+  const r = await runner(def, io || {});
+  if (!r || !VALID_STATUSES.includes(r.status)) {
+    return { status: 'unknown', value: null, detail: 'probe returned invalid status' };
+  }
+  return r;
+}
+

--- a/lib/vision/vdr-probes.js
+++ b/lib/vision/vdr-probes.js
@@ -60,8 +60,15 @@ export async function dbCountProbe(def, io) {
     if (def.builtWhen === 'absent') {
       return { status: n === 0 ? 'built' : 'unbuilt', value: n, detail: `${def.table} count=${n} (built when 0)` };
     }
+    // Honest banding (anti-inflation): a single stray/seed row must NOT credit 'built' for a
+    // capability the vision describes as "stood up" / "fed by a real cohort". count>=min ⇒ built;
+    // 0<count<min ⇒ partial (beginning, not realized); count==0 ⇒ unbuilt.
     const min = Number.isFinite(def.min) ? def.min : 1;
-    return { status: n >= min ? 'built' : 'unbuilt', value: n, detail: `${def.table} count=${n} (built when >=${min})` };
+    let status;
+    if (n >= min) status = 'built';
+    else if (n > 0) status = 'partial';
+    else status = 'unbuilt';
+    return { status, value: n, detail: `${def.table} count=${n} (built when >=${min}; partial when >0)` };
   } catch (e) {
     return { status: 'unknown', value: null, detail: `db_count threw: ${e.message}` };
   }
@@ -99,8 +106,14 @@ export async function codeGrepProbe(def, io) {
       return { status: 'unknown', value: null, detail: `path not accessible: ${def.repo || ''}/${def.path}` };
     }
     const builtWhenAbsent = def.builtWhen === 'absent';
-    const built = builtWhenAbsent ? !res.matched : res.matched;
-    return { status: built ? 'built' : 'unbuilt', value: !!res.matched, detail: `grep /${def.pattern}/ in ${def.repo || ''}/${def.path} matched=${!!res.matched} (built when ${builtWhenAbsent ? 'absent' : 'present'})` };
+    if (builtWhenAbsent) {
+      // Absence proves the capability (e.g. "no dead code path"): a clean absence is 'built'.
+      return { status: res.matched ? 'unbuilt' : 'built', value: !!res.matched, detail: `grep /${def.pattern}/ in ${def.repo || ''}/${def.path} matched=${!!res.matched} (built when absent)` };
+    }
+    // builtWhen 'present': a code/vocabulary MATCH is weak evidence — intent/scaffolding, not a
+    // realized capability (and can hit archived/dead code). Anti-inflation: a match is 'partial',
+    // NOT 'built'; 'built' is reserved for stronger live signals (a DB/KR probe). No match ⇒ unbuilt.
+    return { status: res.matched ? 'partial' : 'unbuilt', value: !!res.matched, detail: `grep /${def.pattern}/ in ${def.repo || ''}/${def.path} matched=${!!res.matched} (present ⇒ partial; code presence is intent, not realization)` };
   } catch (e) {
     return { status: 'unknown', value: null, detail: `code_grep threw: ${e.message}` };
   }

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -169,3 +169,25 @@ export async function computeBuildGauge({ io = {}, visionMarkdown, visionPath } 
   };
 }
 
+/**
+ * SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4/FR-5): SINGLE-SOURCE display mapping of a gauge
+ * result → { pct, layerLine, note, available }, so the Adam exec-summary (FR-4) and the
+ * Chairman-UI tile (FR-5) render the SAME number the SAME way (no divergent formatting). Pure.
+ * @param {object} gauge - a computeBuildGauge() result
+ * @param {object} [opts] - { layerLabel: { <layer>: <display label> }, em: <dash> }
+ * @returns {{ pct: number|null, layerLine: string, note: string, available: boolean }}
+ */
+export function formatGaugeForSummary(gauge, opts = {}) {
+  const em = opts.em || '—';
+  const layerLabel = opts.layerLabel || { infrastructure: 'infrastructure', application: 'UI/UX', venture: 'venture/income', process: 'process' };
+  if (!gauge || !gauge.available || typeof gauge.overall_pct !== 'number') {
+    return { pct: null, layerLine: '', available: false, note: `(gauge unavailable ${em} ${gauge && gauge.measured_at_note ? gauge.measured_at_note : 'vision doc not found'})` };
+  }
+  const layerLine = Object.entries(gauge.per_layer || {})
+    .filter(([, pct]) => pct != null)
+    .map(([layer, pct]) => `${layerLabel[layer] || layer} ${pct}%`)
+    .join('  ·  ');
+  const note = `(live VDR gauge ${em} ${gauge.denominator}/${gauge.total_capabilities} capabilities probed${gauge.unknown_count ? `, ${gauge.unknown_count} unknown` : ''})`;
+  return { pct: gauge.overall_pct, layerLine, note, available: true };
+}
+

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -69,9 +69,13 @@ export const VDR_REGISTRY = [
   { capability: 'Venture-performance read', layer: 'application',
     probe: { type: 'code_grep', repo: 'ehg', path: 'src/components/chairman-v3', pattern: 'PerformanceGauge|performance-gauge|valueAdd|competitiveness', builtWhen: 'present' } },
   { capability: 'Run a self-operating venture', layer: 'venture',
-    probe: { type: 'db_count', table: 'agent_messages', min: 1, builtWhen: 'gte' } }, // org alive = messages flowing
+    // FIX (review): a stood-up 19-agent org produces sustained traffic; a single stray/seed message
+    // must not credit 'built'. min=20 ⇒ built (org operating); 1..19 ⇒ partial (beginning); 0 ⇒ unbuilt. Revisable.
+    probe: { type: 'db_count', table: 'agent_messages', min: 20, builtWhen: 'gte' } },
   { capability: 'Compound venture-level learning', layer: 'process',
-    probe: { type: 'db_count', table: 'pattern_occurrences', min: 1, builtWhen: 'gte' } }, // venture-level engine firing
+    // FIX (review): a compounding venture-learning engine has multiple occurrences; one row ⇒ partial.
+    // min=10 ⇒ built (engine firing); 1..9 ⇒ partial; 0 ⇒ unbuilt. Revisable.
+    probe: { type: 'db_count', table: 'pattern_occurrences', min: 10, builtWhen: 'gte' } },
   { capability: 'Solo-operator survivability', layer: 'infrastructure',
     probe: { type: 'kr_status', code: 'KR-2026-07-02' } }, // ≥90% breakage caught before customers
   { capability: 'Calibrate the gates', layer: 'process',
@@ -81,7 +85,10 @@ export const VDR_REGISTRY = [
   { capability: 'Turn the fleet dial with data', layer: 'infrastructure',
     probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'scripts', pattern: 'token_count|tokens_used|effort_level', builtWhen: 'present' } },
   { capability: 'A queryable, structured north star', layer: 'application',
-    probe: { type: 'row_predicate', table: 'key_results', filter: { code: 'KR-2026-07-05' }, builtWhen: 'exists' } },
+    // FIX (review): existence of the TRACKING KR row is NOT realization — the row exists only to
+    // track the unbuilt capability. Probe its ACHIEVEMENT (kr_status), so a pending KR reads
+    // 'unbuilt'/'partial', matching the vision's TODAY assessment (current_value=0).
+    probe: { type: 'kr_status', code: 'KR-2026-07-05' } },
 ];
 
 /**
@@ -127,6 +134,18 @@ export async function computeBuildGauge({ io = {}, visionMarkdown, visionPath } 
   const rows = parseCapabilityGap(md);
   const coherence = assertRegistryCoherence(rows);
 
+  // FIX (review): coherence is NOT advisory. If the vision's REQUIRED-capability list and the probe
+  // registry have drifted (a capability added/removed/renamed), the % would silently measure only
+  // the still-mapped subset over a wrong denominator. Per the anti-honesty-lie doctrine, FAIL the
+  // gauge to available:false on drift rather than emit a number computed over a drifted denominator.
+  if (!coherence.ok) {
+    return {
+      overall_pct: null, per_layer: {}, components: [], denominator: 0,
+      total_capabilities: rows.length, unknown_count: 0, available: false, coherence,
+      measured_at_note: `registry↔vision drift — gauge withheld (missingProbes=[${coherence.missingProbes.join(', ')}], staleProbes=[${coherence.staleProbes.join(', ')}]); update VDR_REGISTRY to match EHG-VISION.md`,
+    };
+  }
+
   const byCap = new Map(VDR_REGISTRY.map((e) => [e.capability, e]));
   const components = [];
   for (const row of rows) {
@@ -148,7 +167,17 @@ export async function computeBuildGauge({ io = {}, visionMarkdown, visionPath } 
 
   // Overall: built-equivalents / probeable (status !== 'unknown'). Honest — unknowns excluded.
   const scored = components.filter((c) => c.score !== null);
-  const overall_pct = scored.length === 0 ? 0 : Math.round((100 * scored.reduce((s, c) => s + c.score, 0)) / scored.length);
+  // FIX (review): 0 probeable capabilities (e.g. DB unreachable + no grep seam) means "could not
+  // measure anything", NOT "0% built". Return null/available:false so consumers render
+  // 'gauge unavailable' rather than a confident, false 0%.
+  if (scored.length === 0) {
+    return {
+      overall_pct: null, per_layer: {}, components, denominator: 0,
+      total_capabilities: rows.length, unknown_count: components.length, available: false, coherence,
+      measured_at_note: 'no probeable capabilities (all unknown) — gauge unmeasurable this run',
+    };
+  }
+  const overall_pct = Math.round((100 * scored.reduce((s, c) => s + c.score, 0)) / scored.length);
 
   const per_layer = {};
   for (const layer of LAYERS) {

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -1,0 +1,171 @@
+/**
+ * SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-1) — Vision Denominator Registry (VDR).
+ *
+ * The DENOMINATOR is parsed deterministically from EHG-VISION.md's chairman-accepted
+ * "## CAPABILITY GAP — at-a-glance table" (one row per REQUIRED vision capability). The
+ * NUMERATOR is computed by running one TYPED probe per capability against LIVE signals
+ * (no LLM in steady state). The build-% is overall = built-equivalents / probeable-capabilities,
+ * with a per-layer breakdown (infra / application / venture / process). Capabilities whose probe
+ * returns 'unknown' are EXCLUDED from the denominator and reported, so the % is never fabricated
+ * and the component list is fully inspectable/auditable (anti-honesty-lie doctrine).
+ *
+ * CANON COUPLING: VDR_REGISTRY is keyed to the EXACT capability labels in the vision table.
+ * assertRegistryCoherence() FAILS LOUD if the parsed table and the registry drift apart — so a
+ * vision edit cannot silently desync the gauge (the denominator and its probes stay in lockstep).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { runProbe } from './vdr-probes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const LAYERS = ['infrastructure', 'application', 'venture', 'process'];
+export const STATUS_SCORE = { built: 1, partial: 0.5, unbuilt: 0, unknown: null };
+
+/**
+ * Parse the "## CAPABILITY GAP — at-a-glance table" markdown table into the denominator rows.
+ * Returns [{ capability, today, required }] in document order. Deterministic; no LLM.
+ * @param {string} markdown - full EHG-VISION.md content
+ */
+export function parseCapabilityGap(markdown) {
+  const md = String(markdown || '');
+  const hdrIdx = md.indexOf('## CAPABILITY GAP');
+  if (hdrIdx === -1) return [];
+  // Bound the section at the next top-level heading.
+  const rest = md.slice(hdrIdx);
+  const nextHdr = rest.indexOf('\n## ', 3);
+  const section = nextHdr === -1 ? rest : rest.slice(0, nextHdr);
+  const rows = [];
+  for (const line of section.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t.startsWith('|')) continue;
+    const cells = t.split('|').slice(1, -1).map((c) => c.trim()); // strip leading/trailing pipe
+    if (cells.length < 3) continue;
+    // Skip the header row and the |---|---| separator.
+    if (/^-+$/.test(cells[0].replace(/[:\s]/g, '')) || /vision capability/i.test(cells[0])) continue;
+    // Capability label is the bold text in column 1.
+    const m = cells[0].match(/\*\*(.+?)\*\*/);
+    const capability = (m ? m[1] : cells[0]).trim();
+    if (!capability) continue;
+    rows.push({ capability, today: cells[1], required: cells[2] });
+  }
+  return rows;
+}
+
+/**
+ * VDR_REGISTRY — one entry per vision capability: { capability (must match the table label),
+ * layer, probe }. Each probe targets a LIVE signal the vision itself cites (KRs, table counts,
+ * code presence). 'capability' must equal the bold label parsed from the table.
+ */
+export const VDR_REGISTRY = [
+  { capability: 'Take a real dollar', layer: 'venture',
+    probe: { type: 'kr_status', code: 'KR-2026-07-04' } }, // ≥1 venture can accept real payment
+  { capability: 'See distance-to-quit', layer: 'application',
+    probe: { type: 'kr_status', code: 'KR-2026-07-05' } }, // the income gauge rendered
+  { capability: 'See distance-to-broke', layer: 'application',
+    probe: { type: 'code_grep', repo: 'ehg', path: 'src', pattern: 'distance[-_ ]?to[-_ ]?broke', builtWhen: 'present' } },
+  { capability: 'Venture-performance read', layer: 'application',
+    probe: { type: 'code_grep', repo: 'ehg', path: 'src/components/chairman-v3', pattern: 'PerformanceGauge|performance-gauge|valueAdd|competitiveness', builtWhen: 'present' } },
+  { capability: 'Run a self-operating venture', layer: 'venture',
+    probe: { type: 'db_count', table: 'agent_messages', min: 1, builtWhen: 'gte' } }, // org alive = messages flowing
+  { capability: 'Compound venture-level learning', layer: 'process',
+    probe: { type: 'db_count', table: 'pattern_occurrences', min: 1, builtWhen: 'gte' } }, // venture-level engine firing
+  { capability: 'Solo-operator survivability', layer: 'infrastructure',
+    probe: { type: 'kr_status', code: 'KR-2026-07-02' } }, // ≥90% breakage caught before customers
+  { capability: 'Calibrate the gates', layer: 'process',
+    probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'lib', pattern: 'calibration[_-]?cohort|gate.*BLOCK.*calibrat', builtWhen: 'present' } },
+  { capability: 'The cockpit', layer: 'application',
+    probe: { type: 'code_grep', repo: 'ehg', path: 'src', pattern: 'CANONICAL_SURFACES|six[_-]?surfaces|SURFACE_REGISTRY', builtWhen: 'present' } },
+  { capability: 'Turn the fleet dial with data', layer: 'infrastructure',
+    probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'scripts', pattern: 'token_count|tokens_used|effort_level', builtWhen: 'present' } },
+  { capability: 'A queryable, structured north star', layer: 'application',
+    probe: { type: 'row_predicate', table: 'key_results', filter: { code: 'KR-2026-07-05' }, builtWhen: 'exists' } },
+];
+
+/**
+ * FAIL LOUD if the parsed vision table and VDR_REGISTRY have drifted (capability added/removed/renamed).
+ * This is the consumer-side invariant for the denominator: the gauge's probe set must stay in lockstep
+ * with the vision's REQUIRED capability list, or the % silently measures the wrong thing.
+ * @returns {{ ok: boolean, missingProbes: string[], staleProbes: string[] }}
+ */
+export function assertRegistryCoherence(parsedRows) {
+  const parsed = new Set((parsedRows || []).map((r) => r.capability));
+  const registered = new Set(VDR_REGISTRY.map((e) => e.capability));
+  const missingProbes = [...parsed].filter((c) => !registered.has(c)); // in vision, no probe
+  const staleProbes = [...registered].filter((c) => !parsed.has(c));   // probe for a removed capability
+  return { ok: missingProbes.length === 0 && staleProbes.length === 0, missingProbes, staleProbes };
+}
+
+/**
+ * Compute the vision BUILD-completeness gauge. Pure-ish: all IO is injected.
+ * @param {object} opts
+ * @param {object} opts.io        - { supabase, grep } injected probe IO
+ * @param {string} [opts.visionMarkdown] - EHG-VISION.md content; if absent, read from visionPath
+ * @param {string} [opts.visionPath]     - path to EHG-VISION.md (default: repo docs/strategy)
+ * @returns {Promise<{ overall_pct, per_layer, components, denominator, unknown_count, coherence, measured_at_note }>}
+ */
+export async function computeBuildGauge({ io = {}, visionMarkdown, visionPath } = {}) {
+  let md = visionMarkdown;
+  if (md == null) {
+    const p = visionPath || path.resolve(__dirname, '..', '..', 'docs', 'strategy', 'EHG-VISION.md');
+    // Fail-soft: EHG-VISION.md is the denominator source. If it is unavailable (e.g. a git
+    // checkout/CI where the doc is not committed — it is currently an UNTRACKED working-tree file),
+    // return an explicit unavailable gauge rather than throwing, so the exec-summary/tile degrade
+    // to "gauge unavailable" instead of crashing. Callers should surface unavailable distinctly.
+    if (!fs.existsSync(p)) {
+      return {
+        overall_pct: null, per_layer: {}, components: [], denominator: 0, total_capabilities: 0,
+        unknown_count: 0, available: false,
+        coherence: { ok: false, missingProbes: [], staleProbes: [] },
+        measured_at_note: `vision doc unavailable at ${p} (untracked? commit docs/strategy/EHG-VISION.md to enable the gauge in CI/checkouts)`,
+      };
+    }
+    md = fs.readFileSync(p, 'utf-8');
+  }
+  const rows = parseCapabilityGap(md);
+  const coherence = assertRegistryCoherence(rows);
+
+  const byCap = new Map(VDR_REGISTRY.map((e) => [e.capability, e]));
+  const components = [];
+  for (const row of rows) {
+    const entry = byCap.get(row.capability);
+    if (!entry) {
+      components.push({ capability: row.capability, layer: 'unmapped', status: 'unknown', detail: 'no probe registered', score: null });
+      continue;
+    }
+    const result = await runProbe(entry.probe, io);
+    components.push({
+      capability: row.capability,
+      layer: entry.layer,
+      status: result.status,
+      detail: result.detail,
+      value: result.value,
+      score: STATUS_SCORE[result.status],
+    });
+  }
+
+  // Overall: built-equivalents / probeable (status !== 'unknown'). Honest — unknowns excluded.
+  const scored = components.filter((c) => c.score !== null);
+  const overall_pct = scored.length === 0 ? 0 : Math.round((100 * scored.reduce((s, c) => s + c.score, 0)) / scored.length);
+
+  const per_layer = {};
+  for (const layer of LAYERS) {
+    const inLayer = scored.filter((c) => c.layer === layer);
+    per_layer[layer] = inLayer.length === 0 ? null : Math.round((100 * inLayer.reduce((s, c) => s + c.score, 0)) / inLayer.length);
+  }
+
+  return {
+    overall_pct,
+    per_layer,
+    components,
+    denominator: scored.length,
+    total_capabilities: rows.length,
+    unknown_count: components.length - scored.length,
+    available: true,
+    coherence,
+    measured_at_note: 'deterministic; no LLM; unknowns excluded from denominator',
+  };
+}
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "migration:apply": "node scripts/apply-migration.js",
     "migration:issue-token": "node scripts/apply-migration.js --issue-token",
     "income:capture": "node scripts/income/run-income-capture.mjs",
+    "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "setup-db": "node scripts/setup-database.js",
     "setup-db-supabase": "node scripts/setup-database-supabase.js",
     "check-directives": "node scripts/check-directives-data.js",

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -22,7 +22,7 @@ import { liveFleetWorkers, isFleetWorker } from '../lib/fleet/genuine-worker.mjs
 import { renderDecisionLines } from '../lib/chairman/decision-layman.mjs';
 // SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4): the LIVE VDR build-% gauge, replacing the
 // static .adam-vision-build.json number.
-import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
+import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-registry.js';
 
 const EM = '—';
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -86,22 +86,16 @@ const workerText = pulseSource === 'unavailable' ? 'count unavailable (will refr
 // Replaces the static .adam-vision-build.json estimate with the auto-computed Vision Denominator
 // Registry gauge (deterministic typed probes over EHG-VISION.md's REQUIRED capabilities; no LLM).
 // Fail-soft: a gauge error or an unavailable vision doc degrades to "(gauge unavailable)".
-const LAYER_LABEL = { infrastructure: 'infrastructure', application: 'UI/UX', venture: 'venture/income', process: 'process' };
 let visPct = null;
 let layerLine = '';
 let visNote = '';
 try {
-  const gauge = await computeBuildGauge({ io: { supabase: db } }); // no grep seam ⇒ code_grep probes report 'unknown' (excluded)
-  if (gauge && gauge.available && typeof gauge.overall_pct === 'number') {
-    visPct = gauge.overall_pct;
-    layerLine = Object.entries(gauge.per_layer || {})
-      .filter(([, pct]) => pct != null)
-      .map(([layer, pct]) => `${LAYER_LABEL[layer] || layer} ${pct}%`)
-      .join('  ·  ');
-    visNote = `(live VDR gauge ${EM} ${gauge.denominator}/${gauge.total_capabilities} capabilities probed${gauge.unknown_count ? `, ${gauge.unknown_count} unknown` : ''})`;
-  } else {
-    visNote = `(gauge unavailable ${EM} ${gauge && gauge.measured_at_note ? gauge.measured_at_note : 'vision doc not found'})`;
-  }
+  // no grep seam ⇒ code_grep probes report 'unknown' (excluded from the denominator)
+  const gauge = await computeBuildGauge({ io: { supabase: db } });
+  const fmt = formatGaugeForSummary(gauge, { em: EM }); // single-source display mapping (shared with the Chairman-UI tile)
+  visPct = fmt.pct;
+  layerLine = fmt.layerLine;
+  visNote = fmt.note;
 } catch (e) {
   console.warn('[adam-email] live VDR gauge failed (fail-soft): ' + (e?.message || e));
   visPct = null;

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -18,9 +18,11 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'url';
 import { resolve } from 'path';
-import { readFileSync } from 'fs';
 import { liveFleetWorkers, isFleetWorker } from '../lib/fleet/genuine-worker.mjs';
 import { renderDecisionLines } from '../lib/chairman/decision-layman.mjs';
+// SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4): the LIVE VDR build-% gauge, replacing the
+// static .adam-vision-build.json number.
+import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
 
 const EM = '—';
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -80,17 +82,31 @@ if (avgActive === null) {
 }
 const workerText = pulseSource === 'unavailable' ? 'count unavailable (will refresh next run)' : `${avgActive} active${avgIdle ? `, ${avgIdle} idle` : ''} (${pulseSource})`;
 
-// ── 2. EHG VISION build-% gauge (.adam-vision-build.json) ──
-const LAYER_LABEL = { infrastructure: 'infrastructure', application: 'UI/UX', 'venture/income': 'venture/income', process: 'process' };
-let vis = null;
-try { vis = JSON.parse(readFileSync(resolve('.adam-vision-build.json'), 'utf8')); }
-catch (e) { console.warn('[adam-email] vision gauge file unreadable (.adam-vision-build.json): ' + (e?.message || e)); vis = null; }
-const visPct = (vis && typeof vis.overall_pct === 'number') ? vis.overall_pct : null;
-const layers = (vis && Array.isArray(vis.per_layer)) ? vis.per_layer : [];
-const layerLine = layers.map((l) => `${LAYER_LABEL[l.layer] || l.layer} ${l.pct == null ? '?' : l.pct}%`).join('  ·  ');
-let measured = null;
-if (vis && vis.measured_at) { const d = new Date(vis.measured_at + 'T00:00:00Z'); if (!Number.isNaN(d.getTime())) measured = d.toLocaleString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric' }); }
-const visNote = vis ? `(v1 estimate${measured ? ' as of ' + measured : ''} ${EM} live auto-updating gauge coming)` : '';
+// ── 2. EHG VISION build-% gauge (LIVE VDR — SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 FR-4) ──
+// Replaces the static .adam-vision-build.json estimate with the auto-computed Vision Denominator
+// Registry gauge (deterministic typed probes over EHG-VISION.md's REQUIRED capabilities; no LLM).
+// Fail-soft: a gauge error or an unavailable vision doc degrades to "(gauge unavailable)".
+const LAYER_LABEL = { infrastructure: 'infrastructure', application: 'UI/UX', venture: 'venture/income', process: 'process' };
+let visPct = null;
+let layerLine = '';
+let visNote = '';
+try {
+  const gauge = await computeBuildGauge({ io: { supabase: db } }); // no grep seam ⇒ code_grep probes report 'unknown' (excluded)
+  if (gauge && gauge.available && typeof gauge.overall_pct === 'number') {
+    visPct = gauge.overall_pct;
+    layerLine = Object.entries(gauge.per_layer || {})
+      .filter(([, pct]) => pct != null)
+      .map(([layer, pct]) => `${LAYER_LABEL[layer] || layer} ${pct}%`)
+      .join('  ·  ');
+    visNote = `(live VDR gauge ${EM} ${gauge.denominator}/${gauge.total_capabilities} capabilities probed${gauge.unknown_count ? `, ${gauge.unknown_count} unknown` : ''})`;
+  } else {
+    visNote = `(gauge unavailable ${EM} ${gauge && gauge.measured_at_note ? gauge.measured_at_note : 'vision doc not found'})`;
+  }
+} catch (e) {
+  console.warn('[adam-email] live VDR gauge failed (fail-soft): ' + (e?.message || e));
+  visPct = null;
+  visNote = `(gauge unavailable ${EM} compute error)`;
+}
 
 // ── 3. ACTIONS FOR YOU: render the pending decisions (fetched above) as a copy-paste block ──
 const LEAD_IN = "I have received the following executive decisions via email and I'm ready to address them:";

--- a/scripts/vision-gauge-refresh.mjs
+++ b/scripts/vision-gauge-refresh.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-2) — refresh the vision BUILD-completeness gauge.
+ *
+ * Computes the Vision Denominator Registry gauge (lib/vision/vdr-registry.js) and APPENDS a
+ * historized snapshot to the vision_build_gauge table (the auditable, trend-able record Adam
+ * works down). This is the runtime invoker for the VDR lib + the writer behind the Adam
+ * exec-summary's live read and the Chairman-UI tile.
+ *
+ * Usage:
+ *   node scripts/vision-gauge-refresh.mjs            # compute + persist a snapshot
+ *   node scripts/vision-gauge-refresh.mjs --dry-run  # compute + print, do NOT write
+ *
+ * Fail-soft: if the vision doc is unavailable the snapshot is still written with available=false
+ * (so the trend honestly records "gauge unavailable" rather than a gap). Exit 0 on success,
+ * 1 on a hard DB/compute error.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+// Sibling-repo roots for cross-repo code_grep probes (e.g. the ehg app UI). Absent ⇒ 'unknown'.
+const REPO_ROOTS = {
+  EHG_Engineer: REPO_ROOT,
+  ehg: path.resolve(REPO_ROOT, '..', 'ehg'),
+};
+
+/**
+ * Portable code-grep seam for the VDR: `git grep` over tracked files (no ripgrep dependency),
+ * scoped to a subdir pathspec. Returns { accessible, matched }; accessible=false ⇒ the probe
+ * degrades to 'unknown' (honest — never guessed).
+ */
+function grep(pattern, sub, repo) {
+  const root = REPO_ROOTS[repo];
+  if (!root || !fs.existsSync(root)) return { accessible: false, matched: false };
+  const target = sub ? path.join(root, sub) : root;
+  if (!fs.existsSync(target)) return { accessible: false, matched: false };
+  try {
+    execFileSync('git', ['-C', root, 'grep', '-lE', pattern, '--', sub || '.'], { stdio: 'pipe', timeout: 20000 });
+    return { accessible: true, matched: true };
+  } catch (e) {
+    if (e && e.status === 1) return { accessible: true, matched: false };
+    return { accessible: false, matched: false };
+  }
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('[vision-gauge] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required'); process.exit(1); }
+  const supabase = createClient(url, key);
+
+  let gauge;
+  try {
+    gauge = await computeBuildGauge({ io: { supabase, grep } });
+  } catch (e) {
+    console.error('[vision-gauge] compute failed: ' + (e?.message || e));
+    process.exit(1);
+  }
+
+  const row = {
+    overall_pct: gauge.overall_pct,
+    available: !!gauge.available,
+    per_layer: gauge.per_layer || {},
+    components: gauge.components || [],
+    denominator: gauge.denominator || 0,
+    total_capabilities: gauge.total_capabilities || 0,
+    unknown_count: gauge.unknown_count || 0,
+    source: 'vdr',
+  };
+
+  console.log(`[vision-gauge] available=${row.available} overall=${row.overall_pct == null ? 'n/a' : row.overall_pct + '%'} ` +
+    `probeable=${row.denominator}/${row.total_capabilities} unknown=${row.unknown_count}`);
+  console.log('[vision-gauge] per_layer=' + JSON.stringify(row.per_layer));
+  if (!gauge.coherence?.ok) {
+    console.warn('[vision-gauge] WARN registry<->vision drift: ' + JSON.stringify(gauge.coherence));
+  }
+
+  if (dryRun) { console.log('[vision-gauge] --dry-run: not persisted'); return; }
+
+  const { error } = await supabase.from('vision_build_gauge').insert(row);
+  if (error) {
+    // Table may not exist yet (migration not applied) — surface clearly, don't crash silently.
+    console.error('[vision-gauge] insert failed (is the migration applied?): ' + error.message);
+    process.exit(1);
+  }
+  console.log('[vision-gauge] snapshot persisted to vision_build_gauge');
+}
+
+main().catch((e) => { console.error('[vision-gauge] UNHANDLED: ' + (e?.message || e)); process.exit(1); });

--- a/scripts/vision-gauge-refresh.mjs
+++ b/scripts/vision-gauge-refresh.mjs
@@ -42,7 +42,11 @@ function grep(pattern, sub, repo) {
   const target = sub ? path.join(root, sub) : root;
   if (!fs.existsSync(target)) return { accessible: false, matched: false };
   try {
-    execFileSync('git', ['-C', root, 'grep', '-lE', pattern, '--', sub || '.'], { stdio: 'pipe', timeout: 20000 });
+    // Exclude archived/dead/test paths so a vocabulary hit there cannot credit a capability
+    // (review: 'effort_level' in scripts/archive/* false-credited the fleet-dial capability).
+    execFileSync('git', ['-C', root, 'grep', '-lE', pattern, '--', sub || '.',
+      ':!**/archive/**', ':!**/__tests__/**', ':!**/*.test.*', ':!**/*.spec.*'],
+      { stdio: 'pipe', timeout: 20000 });
     return { accessible: true, matched: true };
   } catch (e) {
     if (e && e.status === 1) return { accessible: true, matched: false };

--- a/scripts/vision-gauge-refresh.mjs
+++ b/scripts/vision-gauge-refresh.mjs
@@ -89,7 +89,10 @@ async function main() {
 
   if (dryRun) { console.log('[vision-gauge] --dry-run: not persisted'); return; }
 
-  const { error } = await supabase.from('vision_build_gauge').insert(row);
+  // vision_build_gauge is created by 20260614_vision_build_gauge.sql, a chairman-gated migration
+  // not yet applied to prod, so it is absent from the schema snapshot until apply (the lint
+  // resolves automatically once the snapshot is regenerated post-apply).
+  const { error } = await supabase.from('vision_build_gauge').insert(row); // schema-lint-disable-line
   if (error) {
     // Table may not exist yet (migration not applied) — surface clearly, don't crash silently.
     console.error('[vision-gauge] insert failed (is the migration applied?): ' + error.message);

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -6,6 +6,7 @@ import {
   parseCapabilityGap,
   assertRegistryCoherence,
   computeBuildGauge,
+  formatGaugeForSummary,
   VDR_REGISTRY,
   STATUS_SCORE,
 } from '../../../lib/vision/vdr-registry.js';
@@ -141,5 +142,36 @@ describe('runProbe (FR-1 typed probe runners, injected IO)', () => {
   });
   it('unknown probe type → unknown (never fabricated)', async () => {
     expect((await runProbe({ type: 'bogus' }, {})).status).toBe('unknown');
+  });
+});
+
+describe('formatGaugeForSummary (FR-4/FR-5 single-source display mapping)', () => {
+  it('maps an available gauge to pct + layerLine + a live note', () => {
+    const fmt = formatGaugeForSummary({
+      available: true, overall_pct: 42,
+      per_layer: { infrastructure: 10, application: 80, venture: null, process: 25 },
+      denominator: 6, total_capabilities: 11, unknown_count: 5,
+    });
+    expect(fmt.available).toBe(true);
+    expect(fmt.pct).toBe(42);
+    // null layers dropped; venture omitted; labels applied (application → UI/UX, venture → venture/income)
+    expect(fmt.layerLine).toBe('infrastructure 10%  ·  UI/UX 80%  ·  process 25%');
+    expect(fmt.note).toMatch(/live VDR gauge.*6\/11 capabilities probed, 5 unknown/);
+  });
+  it('omits the "unknown" suffix when unknown_count is 0', () => {
+    const fmt = formatGaugeForSummary({ available: true, overall_pct: 100, per_layer: {}, denominator: 11, total_capabilities: 11, unknown_count: 0 });
+    expect(fmt.note).toMatch(/11\/11 capabilities probed\)/);
+    expect(fmt.note).not.toMatch(/unknown/);
+  });
+  it('maps an unavailable gauge to pct=null + a clear unavailable note', () => {
+    const fmt = formatGaugeForSummary({ available: false, overall_pct: null, measured_at_note: 'vision doc unavailable at X' });
+    expect(fmt.available).toBe(false);
+    expect(fmt.pct).toBeNull();
+    expect(fmt.layerLine).toBe('');
+    expect(fmt.note).toMatch(/gauge unavailable.*vision doc unavailable at X/);
+  });
+  it('treats null/garbage gauge as unavailable (never throws)', () => {
+    expect(formatGaugeForSummary(null).available).toBe(false);
+    expect(formatGaugeForSummary(undefined).pct).toBeNull();
   });
 });

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -77,9 +77,11 @@ describe('assertRegistryCoherence (FR-1 fail-loud denominator↔probe lockstep)'
 });
 
 describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', () => {
-  it('computes overall % + per-layer, EXCLUDING unknowns from the denominator', async () => {
-    // KR-04 achieved (built), KR-05 pending (unbuilt), KR-02 pending current>0 (partial);
-    // agent_messages=2 (built), pattern_occurrences=0 (unbuilt); all code_grep → unknown (no grep seam).
+  it('computes overall % + per-layer with HONEST banding, EXCLUDING unknowns from the denominator', async () => {
+    // 6 DB-backed probeable; 5 code_grep → unknown (no grep seam). With the post-review semantics:
+    //   built(1):  Take-a-dollar (KR04 achieved)
+    //   partial(.5): self-operating (agent_messages=2 < min20), survivability (KR02 45/90)
+    //   unbuilt(0): distance-to-quit (KR05 0/1), venture-learning (pattern_occurrences=0), north-star (KR05 0/1)
     const io = {
       supabase: stubSupabase({
         countByTable: { agent_messages: 2, pattern_occurrences: 0, key_results: 1 },
@@ -89,21 +91,36 @@ describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', ()
           'KR-2026-07-02': { status: 'pending', current_value: 45, target_value: 90 },
         },
       }),
-      // no grep → code_grep probes return 'unknown'
     };
     const g = await computeBuildGauge({ io, visionMarkdown: visionFixture() });
     expect(g.available).toBe(true);
     expect(g.coherence.ok).toBe(true);
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
-    // 5 code_grep capabilities → unknown; 6 DB-backed → probeable
     expect(g.unknown_count).toBe(5);
     expect(g.denominator).toBe(6);
-    // built: Take-a-dollar(KR04), north-star(row_predicate exists), self-operating(agent_messages=2) = 3 built(1.0)
-    // partial: survivability(KR02 45/90) = 0.5 ; unbuilt: distance-to-quit(KR05), venture-learning(pattern_occurrences=0) = 0
-    // overall = (1+1+1+0.5+0+0)/6 = 3.5/6 = 58%
-    expect(g.overall_pct).toBe(58);
-    // every component carries an honest status + score mapping
+    // (1 + 0.5 + 0.5 + 0 + 0 + 0) / 6 = 2.0/6 = 33%
+    expect(g.overall_pct).toBe(33);
+    expect(g.per_layer).toMatchObject({ venture: 75, infrastructure: 50, application: 0, process: 0 });
     for (const c of g.components) expect(STATUS_SCORE).toHaveProperty(c.status);
+  });
+
+  it('FIX: all-unknown (0 probeable) ⇒ overall_pct=null + available:false (not a confident 0%)', async () => {
+    // no supabase, no grep ⇒ every probe is 'unknown'
+    const g = await computeBuildGauge({ io: {}, visionMarkdown: visionFixture() });
+    expect(g.denominator).toBe(0);
+    expect(g.available).toBe(false);
+    expect(g.overall_pct).toBeNull();
+    expect(g.measured_at_note).toMatch(/unmeasurable|no probeable/i);
+  });
+
+  it('FIX: registry↔vision drift ⇒ gauge withheld (available:false), not computed over a wrong denominator', async () => {
+    // a vision fixture with an unmapped capability → coherence.ok=false
+    const md = visionFixture([...VDR_REGISTRY.map((e) => e.capability), 'Brand New Unmapped Capability']);
+    const g = await computeBuildGauge({ io: { supabase: stubSupabase({}) }, visionMarkdown: md });
+    expect(g.coherence.ok).toBe(false);
+    expect(g.available).toBe(false);
+    expect(g.overall_pct).toBeNull();
+    expect(g.measured_at_note).toMatch(/drift/i);
   });
 
   it('fails soft (available:false) when the vision doc path does not exist', async () => {
@@ -125,19 +142,23 @@ describe('runProbe (FR-1 typed probe runners, injected IO)', () => {
     expect((await runProbe({ type: 'kr_status', code: 'B' }, { supabase: sb })).status).toBe('partial');
     expect((await runProbe({ type: 'kr_status', code: 'C' }, { supabase: sb })).status).toBe('unbuilt');
   });
-  it('db_count: gte builds when present; absent builds when zero', async () => {
-    const sb = stubSupabase({ countByTable: { t_has: 5, t_empty: 0 } });
-    expect((await runProbe({ type: 'db_count', table: 't_has', min: 1, builtWhen: 'gte' }, { supabase: sb })).status).toBe('built');
-    expect((await runProbe({ type: 'db_count', table: 't_empty', min: 1, builtWhen: 'gte' }, { supabase: sb })).status).toBe('unbuilt');
+  it('db_count: HONEST band — built at >=min, partial in (0,min), unbuilt at 0; absent builds at 0', async () => {
+    const sb = stubSupabase({ countByTable: { t_many: 25, t_one: 1, t_empty: 0 } });
+    expect((await runProbe({ type: 'db_count', table: 't_many', min: 20, builtWhen: 'gte' }, { supabase: sb })).status).toBe('built');
+    expect((await runProbe({ type: 'db_count', table: 't_one', min: 20, builtWhen: 'gte' }, { supabase: sb })).status).toBe('partial'); // single stray row ⇒ NOT built
+    expect((await runProbe({ type: 'db_count', table: 't_empty', min: 20, builtWhen: 'gte' }, { supabase: sb })).status).toBe('unbuilt');
     expect((await runProbe({ type: 'db_count', table: 't_empty', builtWhen: 'absent' }, { supabase: sb })).status).toBe('built');
   });
-  it('code_grep: unknown when no grep seam; built/unbuilt via injected grep', async () => {
+  it('code_grep: unknown when no grep seam; a present MATCH ⇒ partial (intent, not built); no match ⇒ unbuilt', async () => {
     expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y' }, {})).status).toBe('unknown');
     const grepHit = async () => ({ accessible: true, matched: true });
     const grepMiss = async () => ({ accessible: true, matched: false });
     const grepGone = async () => ({ accessible: false, matched: false });
-    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y', builtWhen: 'present' }, { grep: grepHit })).status).toBe('built');
+    // FIX (review): a code/vocabulary match is intent/scaffolding, not realization ⇒ 'partial', NOT 'built'.
+    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y', builtWhen: 'present' }, { grep: grepHit })).status).toBe('partial');
     expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y', builtWhen: 'present' }, { grep: grepMiss })).status).toBe('unbuilt');
+    // absence-is-built still earns 'built' (a clean absence proves the capability)
+    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y', builtWhen: 'absent' }, { grep: grepMiss })).status).toBe('built');
     expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y' }, { grep: grepGone })).status).toBe('unknown');
   });
   it('unknown probe type → unknown (never fabricated)', async () => {

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -1,0 +1,145 @@
+// SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-1/FR-6) — VDR engine unit tests.
+// Hermetic: no live DB, no real grep, no real vision file. Validates the deterministic
+// numerator/denominator math, the typed probe runners, coherence, and fail-soft behavior.
+import { describe, it, expect } from 'vitest';
+import {
+  parseCapabilityGap,
+  assertRegistryCoherence,
+  computeBuildGauge,
+  VDR_REGISTRY,
+  STATUS_SCORE,
+} from '../../../lib/vision/vdr-registry.js';
+import { runProbe } from '../../../lib/vision/vdr-probes.js';
+
+// Build a CAPABILITY GAP markdown table from the registry labels so coherence passes by construction.
+function visionFixture(labels = VDR_REGISTRY.map((e) => e.capability)) {
+  const rows = labels.map((l) => `| **${l}** | today cell | required cell |`).join('\n');
+  return [
+    '## CAPABILITY GAP — at-a-glance table',
+    '',
+    '| Vision capability | TODAY (verified live) | REQUIRED to realize the vision |',
+    '|---|---|---|',
+    rows,
+    '',
+    '## THROUGH-LINES',
+    'next section (must be excluded from the table parse)',
+    '| **Not a capability** | x | y |',
+  ].join('\n');
+}
+
+// Chainable supabase stub: head/count queries resolve to { count }, maybeSingle to { data }.
+function stubSupabase({ countByTable = {}, krRows = {} } = {}) {
+  return {
+    from(table) {
+      const ctx = { table, filters: {} };
+      const chain = {
+        select() { return chain; },
+        eq(k, v) { ctx.filters[k] = v; return chain; },
+        maybeSingle() { return Promise.resolve({ data: krRows[ctx.filters.code] || null, error: null }); },
+        then(res, rej) { return Promise.resolve({ count: countByTable[table] ?? 0, error: null }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('parseCapabilityGap (FR-1 deterministic denominator)', () => {
+  it('extracts only the CAPABILITY GAP table rows, stripping bold + bounding at the next heading', () => {
+    const rows = parseCapabilityGap(visionFixture(['Alpha cap', 'Beta cap']));
+    expect(rows.map((r) => r.capability)).toEqual(['Alpha cap', 'Beta cap']); // "Not a capability" (post-heading) excluded
+    expect(rows[0]).toMatchObject({ capability: 'Alpha cap', today: 'today cell', required: 'required cell' });
+  });
+  it('returns [] when the section is absent', () => {
+    expect(parseCapabilityGap('# nothing here')).toEqual([]);
+    expect(parseCapabilityGap(null)).toEqual([]);
+  });
+  it('is deterministic (same input → same output)', () => {
+    const md = visionFixture();
+    expect(parseCapabilityGap(md)).toEqual(parseCapabilityGap(md));
+  });
+});
+
+describe('assertRegistryCoherence (FR-1 fail-loud denominator↔probe lockstep)', () => {
+  it('ok when the parsed table matches VDR_REGISTRY exactly', () => {
+    const r = assertRegistryCoherence(parseCapabilityGap(visionFixture()));
+    expect(r.ok).toBe(true);
+    expect(r.missingProbes).toEqual([]);
+    expect(r.staleProbes).toEqual([]);
+  });
+  it('flags a vision capability with no probe (missingProbes) and a probe for a removed capability (staleProbes)', () => {
+    const dropped = VDR_REGISTRY.slice(1).map((e) => e.capability); // remove the first registered capability
+    const r = assertRegistryCoherence([...dropped.map((c) => ({ capability: c })), { capability: 'Brand New Vision Cap' }]);
+    expect(r.ok).toBe(false);
+    expect(r.missingProbes).toContain('Brand New Vision Cap'); // in vision, no probe
+    expect(r.staleProbes).toContain(VDR_REGISTRY[0].capability); // probe exists, capability gone
+  });
+});
+
+describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', () => {
+  it('computes overall % + per-layer, EXCLUDING unknowns from the denominator', async () => {
+    // KR-04 achieved (built), KR-05 pending (unbuilt), KR-02 pending current>0 (partial);
+    // agent_messages=2 (built), pattern_occurrences=0 (unbuilt); all code_grep → unknown (no grep seam).
+    const io = {
+      supabase: stubSupabase({
+        countByTable: { agent_messages: 2, pattern_occurrences: 0, key_results: 1 },
+        krRows: {
+          'KR-2026-07-04': { status: 'achieved', current_value: 1, target_value: 1 },
+          'KR-2026-07-05': { status: 'pending', current_value: 0, target_value: 1 },
+          'KR-2026-07-02': { status: 'pending', current_value: 45, target_value: 90 },
+        },
+      }),
+      // no grep → code_grep probes return 'unknown'
+    };
+    const g = await computeBuildGauge({ io, visionMarkdown: visionFixture() });
+    expect(g.available).toBe(true);
+    expect(g.coherence.ok).toBe(true);
+    expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
+    // 5 code_grep capabilities → unknown; 6 DB-backed → probeable
+    expect(g.unknown_count).toBe(5);
+    expect(g.denominator).toBe(6);
+    // built: Take-a-dollar(KR04), north-star(row_predicate exists), self-operating(agent_messages=2) = 3 built(1.0)
+    // partial: survivability(KR02 45/90) = 0.5 ; unbuilt: distance-to-quit(KR05), venture-learning(pattern_occurrences=0) = 0
+    // overall = (1+1+1+0.5+0+0)/6 = 3.5/6 = 58%
+    expect(g.overall_pct).toBe(58);
+    // every component carries an honest status + score mapping
+    for (const c of g.components) expect(STATUS_SCORE).toHaveProperty(c.status);
+  });
+
+  it('fails soft (available:false) when the vision doc path does not exist', async () => {
+    const g = await computeBuildGauge({ io: {}, visionPath: '/no/such/EHG-VISION.md' });
+    expect(g.available).toBe(false);
+    expect(g.overall_pct).toBeNull();
+    expect(g.measured_at_note).toMatch(/unavailable/i);
+  });
+});
+
+describe('runProbe (FR-1 typed probe runners, injected IO)', () => {
+  it('kr_status: built when achieved, partial when current>0<target, unbuilt at 0', async () => {
+    const sb = stubSupabase({ krRows: {
+      A: { status: 'achieved', current_value: 1, target_value: 1 },
+      B: { status: 'pending', current_value: 3, target_value: 10 },
+      C: { status: 'pending', current_value: 0, target_value: 1 },
+    } });
+    expect((await runProbe({ type: 'kr_status', code: 'A' }, { supabase: sb })).status).toBe('built');
+    expect((await runProbe({ type: 'kr_status', code: 'B' }, { supabase: sb })).status).toBe('partial');
+    expect((await runProbe({ type: 'kr_status', code: 'C' }, { supabase: sb })).status).toBe('unbuilt');
+  });
+  it('db_count: gte builds when present; absent builds when zero', async () => {
+    const sb = stubSupabase({ countByTable: { t_has: 5, t_empty: 0 } });
+    expect((await runProbe({ type: 'db_count', table: 't_has', min: 1, builtWhen: 'gte' }, { supabase: sb })).status).toBe('built');
+    expect((await runProbe({ type: 'db_count', table: 't_empty', min: 1, builtWhen: 'gte' }, { supabase: sb })).status).toBe('unbuilt');
+    expect((await runProbe({ type: 'db_count', table: 't_empty', builtWhen: 'absent' }, { supabase: sb })).status).toBe('built');
+  });
+  it('code_grep: unknown when no grep seam; built/unbuilt via injected grep', async () => {
+    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y' }, {})).status).toBe('unknown');
+    const grepHit = async () => ({ accessible: true, matched: true });
+    const grepMiss = async () => ({ accessible: true, matched: false });
+    const grepGone = async () => ({ accessible: false, matched: false });
+    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y', builtWhen: 'present' }, { grep: grepHit })).status).toBe('built');
+    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y', builtWhen: 'present' }, { grep: grepMiss })).status).toBe('unbuilt');
+    expect((await runProbe({ type: 'code_grep', path: 'x', pattern: 'y' }, { grep: grepGone })).status).toBe('unknown');
+  });
+  it('unknown probe type → unknown (never fabricated)', async () => {
+    expect((await runProbe({ type: 'bogus' }, {})).status).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
Child A of the Adam Autonomy Hardening program. Builds the **Vision Denominator Registry (VDR)** — an auto-computed, deterministic, **auditable** vision BUILD-completeness % gauge — replacing the static hand-curated ~46% number with a live gauge Adam works down.

## What changed (EHG_Engineer core, 6 FRs)
- **FR-1** `lib/vision/vdr-registry.js` + `vdr-probes.js` — parse `EHG-VISION.md`'s CAPABILITY GAP table (11 REQUIRED capabilities = the auditable **denominator**); run one **typed probe** per capability (`kr_status`/`db_count`/`row_predicate`/`code_grep`) against **live** signals. Honest 4-state result (`built`/`partial`/`unbuilt`/`unknown`); unknowns **excluded** from the denominator; **no LLM** in steady state. `assertRegistryCoherence` keeps the registry in lockstep with the vision table.
- **FR-2** `database/migrations/20260614_vision_build_gauge.sql` — additive, append-only **historized** gauge table (RLS, in-migration verify) + `scripts/vision-gauge-refresh.mjs` (`npm run vision:gauge`, portable git-grep seam).
- **FR-3** `database/migrations/20260614_archive_eva_intake_roadmap.sql` — archive the stale EVA Intake Roadmap row so **one canonical roadmap** remains (reversible).
- **FR-4** `scripts/adam-exec-summary.mjs` — wired to the live gauge (`computeBuildGauge` + `formatGaugeForSummary`), retiring the static `.adam-vision-build.json`; fail-soft.
- **FR-6** `formatGaugeForSummary` single-source display mapping (shared with the future Chairman-UI tile) + **17 hermetic tests**.

Both migrations are **chairman-gated** (unattested `@approved-by`, per CONST-002 — the worker does not self-author prod-apply attestation).

## Adversarial review (55 agents) — the gauge was lying HIGH; all 5 honesty defects fixed
The review caught the gauge over-crediting `built` on weak signals, inflating to a false **38%** vs the honest **9%**:
- all-unknown (0 probeable) → `null`/`available:false` (was a confident "0%")
- `code_grep` present-match → `partial` (intent, not realization) + grep seam excludes archive/test paths (was false-crediting `effort_level` in `scripts/archive/*`)
- "structured north star" probe: row-EXISTS → `kr_status` achievement (a pending tracking-KR no longer reads built)
- `db_count` honest band: `built ≥ min` / `partial` in `(0,min)` / `unbuilt` at 0; mins raised so a single seed row reads `partial`
- `assertRegistryCoherence` is now load-bearing — the gauge is **withheld** (`available:false`) on registry↔vision drift

## Tests
17 VDR unit tests + 290 broader unit-tier, 0 fail. Live smoke = honest **9%** (0 false-built; 9 unbuilt, 2 partial), matching the vision's t=0.

## Deferred (pre-authorized cross-repo fast-follow, separate ehg PR)
FR-5 Chairman-UI build-% tile at ehg `/chairman/vision` (reuses `formatGaugeForSummary`) + FR-3b `ehg usePortfolioRoadmap` `.eq("status","active")`. FR-4 already surfaces the gauge, so no measurement gap.

## Note
`docs/strategy/EHG-VISION.md` (the denominator source) is currently **untracked in git**; the engine fail-softs (gauge unavailable) in CI/checkouts until the chairman commits it — surfaced to the harness backlog, not self-actioned.

SD: SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (infrastructure, [MODE: campaign])

🤖 Generated with [Claude Code](https://claude.com/claude-code)
