### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DECISION-DELIVERY-001): triage rationale for the non-technical chairman

### DIFF
--- a/lib/chairman/decision-layman.mjs
+++ b/lib/chairman/decision-layman.mjs
@@ -94,12 +94,14 @@ function ventureName(row) {
 }
 
 /**
- * Render ONE item into a plain action line. The free-text types show the title AS RECEIVED.
+ * Render ONE item's BODY (no triage note) into a plain action line. The free-text types show
+ * the title AS RECEIVED. Wrapped by renderItem(), which appends the triage rationale before the
+ * trailing ref token. Kept as the unmodified base so the per-type lines + ref contract are stable.
  * @param {object} item - from buildDecisionItems
  * @param {Date} now
  * @returns {string}
  */
-export function renderItem(item, now = new Date()) {
+function renderItemBase(item, now = new Date()) {
   const rows = item.rows;
   const ref = refTag(rows);
 
@@ -155,6 +157,59 @@ export function renderItem(item, now = new Date()) {
 
   // unknown type — present the title as received.
   return `${cleanText(row.title, 200)} (${age}). ${ref}`;
+}
+
+/**
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-DELIVERY-001 — the TRIAGE RATIONALE for a non-technical chairman.
+ * The chairman_pending_decisions view silently REORDERS/ELEVATES decisions (age_escalated past 72h bumps a
+ * priority class; blocking sorts first), but the email never says WHY an item jumped the queue. This PURE helper
+ * renders that already-decided rationale in plain language — it does NOT re-derive the escalation rule (it only
+ * reads the view's age_escalated flag + blocking). Returns '' when nothing elevated the item (no spurious note).
+ *
+ * Accepts a render-item ({type, rows}), an array of rows, or a single row (flexible for callers + tests).
+ * @returns {string} e.g. "(moved up — waiting 9d)", "(blocking a venture)", "" — paren-wrapped or empty.
+ */
+export function triageNote(itemOrRows, now = new Date()) {
+  const rows = Array.isArray(itemOrRows?.rows) ? itemOrRows.rows
+    : Array.isArray(itemOrRows) ? itemOrRows
+    : itemOrRows ? [itemOrRows] : [];
+  const type = itemOrRows && !Array.isArray(itemOrRows) ? itemOrRows.type : undefined;
+  const parts = [];
+
+  // Age-escalation: reuse the view's authoritative age_escalated flag (do NOT recompute the 72h rule).
+  const escalated = rows.filter((r) => r && r.age_escalated === true);
+  if (escalated.length) {
+    const ts = (r) => new Date(r.created_at || now).getTime();
+    const oldest = escalated.reduce((a, b) => (ts(a) <= ts(b) ? a : b)); // smallest ts = oldest
+    parts.push(`moved up — waiting ${formatAge(oldest.created_at, now)}`);
+  }
+
+  // Blocking: gate_decision already states blocking inline in renderItemBase, so only annotate it for
+  // OTHER types (avoid a redundant double-mention on gate lines). The gate suppression keys on the render-item
+  // `type`; the production caller (renderItem) always passes the full item, so a raw-row/array call (tests only)
+  // would not suppress — harmless since renderItem is the sole production path.
+  if (type !== 'gate_decision') {
+    const nBlocking = rows.filter((r) => r && r.blocking).length;
+    if (nBlocking) parts.push(nBlocking > 1 ? `${nBlocking} blocking a venture` : 'blocking a venture');
+  }
+
+  return parts.length ? `(${parts.join('; ')})` : '';
+}
+
+/**
+ * Render ONE item: the base action line plus the triage rationale, INSERTED BEFORE the trailing ref token so
+ * the `[ref(s) decision_type:id]` handle the chairman-decisions CLI parses stays at the end, byte-identical.
+ * @param {object} item
+ * @param {Date} now
+ * @returns {string}
+ */
+export function renderItem(item, now = new Date()) {
+  const line = renderItemBase(item, now);
+  const note = triageNote(item, now);
+  if (!note) return line;
+  const ref = refTag(item.rows);
+  // Keep the ref trailing: splice the note in just before it (fallback: append, never drop the note).
+  return line.endsWith(ref) ? `${line.slice(0, -ref.length).trimEnd()} ${note} ${ref}` : `${line} ${note}`;
 }
 
 /** Full render: rows -> { count, lines }. Sorts (priority/age), groups, and renders each item. */

--- a/tests/unit/decision-triage-note.test.js
+++ b/tests/unit/decision-triage-note.test.js
@@ -1,0 +1,101 @@
+/**
+ * Triage-rationale tests — SD-LEO-INFRA-CHAIRMAN-DECISION-DELIVERY-001.
+ * PURE: synthetic decision rows + injected `now`, zero live DB. Proves triageNote surfaces the view's
+ * already-computed age-escalation / blocking rationale, and that renderItem appends it WITHOUT disturbing
+ * the trailing `[ref(s) decision_type:id]` handle the chairman-decisions CLI depends on (TR-2).
+ */
+import { describe, it, expect } from 'vitest';
+import { triageNote, renderItem, renderDecisionLines, refTag, buildDecisionItems } from '../../lib/chairman/decision-layman.mjs';
+
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+const daysAgo = (d) => new Date(NOW.getTime() - d * 86400000).toISOString();
+
+const row = (over = {}) => ({
+  id: over.id || 'd1',
+  decision_type: over.decision_type || 'flag_review',
+  title: over.title || 'A flagged issue',
+  priority: over.priority || 'high',
+  effective_priority: over.effective_priority || over.priority || 'high',
+  age_escalated: over.age_escalated || false,
+  blocking: over.blocking || false,
+  created_at: over.created_at || daysAgo(1),
+  ...over,
+});
+
+describe('triageNote — surfaces the view rationale', () => {
+  it('age_escalated row → a plain "moved up — waiting ..." reason', () => {
+    const note = triageNote(row({ age_escalated: true, created_at: daysAgo(9) }), NOW);
+    expect(note).toMatch(/moved up — waiting/i);
+    expect(note.startsWith('(') && note.endsWith(')')).toBe(true);
+  });
+
+  it('blocking NON-gate row → notes it is blocking', () => {
+    const note = triageNote(row({ decision_type: 'chairman_approval', blocking: true }), NOW);
+    expect(note).toMatch(/blocking a venture/i);
+  });
+
+  it('both escalated AND blocking → combined', () => {
+    const note = triageNote(row({ decision_type: 'chairman_approval', age_escalated: true, created_at: daysAgo(4), blocking: true }), NOW);
+    expect(note).toMatch(/moved up/i);
+    expect(note).toMatch(/blocking/i);
+  });
+
+  it('neither escalated nor blocking → empty string (no spurious note)', () => {
+    expect(triageNote(row({ age_escalated: false, blocking: false }), NOW)).toBe('');
+  });
+
+  it('gate_decision blocking → does NOT add a redundant blocking note (renderItemBase states it inline)', () => {
+    // gate_decision item: blocking is shown inline by the base renderer, so triageNote suppresses it.
+    const note = triageNote({ type: 'gate_decision', kind: 'single', rows: [row({ decision_type: 'gate_decision', blocking: true })] }, NOW);
+    expect(note).toBe('');
+  });
+
+  it('gate_decision that is ALSO age-escalated still gets the escalation reason (only blocking is suppressed)', () => {
+    const note = triageNote({ type: 'gate_decision', kind: 'single', rows: [row({ decision_type: 'gate_decision', blocking: true, age_escalated: true, created_at: daysAgo(5) })] }, NOW);
+    expect(note).toMatch(/moved up/i);
+    expect(note).not.toMatch(/blocking a venture/i);
+  });
+
+  it('fail-safe: missing/garbage input never throws → empty', () => {
+    expect(triageNote(null, NOW)).toBe('');
+    expect(triageNote({ rows: [{}] }, NOW)).toBe('');
+    expect(() => triageNote(undefined, NOW)).not.toThrow();
+  });
+
+  it('grouped rows: counts multiple blocking members', () => {
+    const note = triageNote({ type: 'chairman_approval', kind: 'group', rows: [row({ blocking: true }), row({ id: 'd2', blocking: true })] }, NOW);
+    expect(note).toMatch(/2 blocking a venture/i);
+  });
+});
+
+describe('renderItem — appends the rationale, preserves the ref contract (TR-2)', () => {
+  it('the rendered line still ENDS WITH the exact ref token (CLI handle preserved)', () => {
+    const item = { type: 'flag_review', kind: 'single', rows: [row({ age_escalated: true, created_at: daysAgo(9) })] };
+    const line = renderItem(item, NOW);
+    const ref = refTag(item.rows);
+    expect(line.endsWith(ref)).toBe(true);     // ref stays trailing, byte-identical
+    expect(line).toMatch(/moved up — waiting/i); // rationale present, before the ref
+    expect(line.indexOf('moved up')).toBeLessThan(line.indexOf(ref));
+  });
+
+  it('a non-elevated line is unchanged (no note injected, ref still trailing)', () => {
+    const item = { type: 'flag_review', kind: 'single', rows: [row()] };
+    const line = renderItem(item, NOW);
+    expect(line.endsWith(refTag(item.rows))).toBe(true);
+    expect(line).not.toMatch(/moved up|blocking a venture/i);
+  });
+});
+
+describe('renderDecisionLines — count + grouping preserved', () => {
+  it('the decision COUNT is unchanged by the rationale (every underlying row still counted)', () => {
+    const rows = [
+      row({ id: 'a', decision_type: 'chairman_approval', age_escalated: true, created_at: daysAgo(8) }),
+      row({ id: 'b', decision_type: 'chairman_approval' }),
+      row({ id: 'c', decision_type: 'flag_review', blocking: true }),
+    ];
+    const out = renderDecisionLines(rows, NOW);
+    expect(out.count).toBe(3);                 // grouping collapses lines but count reflects all rows
+    // every line still carries resolvable ref token(s)
+    expect(out.lines.every((l) => /\[refs? /.test(l))).toBe(true);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-CHAIRMAN-DECISION-DELIVERY-001 — triage rationale for the non-technical chairman

The chairman decision delivery layer is **already live** (cross-store `chairman_unified_decisions` view, the `chairman_pending_decisions` filtered/age-escalated surface, the hourly Adam exec-email push, the plain-language render, and `routeDecision` route-back — all via the chairman_decision_queue work, migration 20260611).

**The gap this closes:** the surface silently reorders/elevates decisions (age-escalated past 72h bumps a priority class; blocking sorts first) but never told the chairman *why* an item jumped the queue — opaque for a non-technical reader. Verified live: a `flag_review` row sits at `effective_priority=critical` (escalated from `high`, ~8d old) shown with no rationale.

### Change (pure, additive — only `decision-layman.mjs` + tests)
- NEW pure `triageNote(itemOrRows, now)` renders the view's **already-computed** `age_escalated`/`blocking` rationale (`(moved up — waiting Nd)` / `(blocking a venture)`). Reuses the view flag — does **not** re-derive the 72h rule.
- `renderItem` wrapper splices the note in **before** the trailing `[ref(s) decision_type:id]` token, so the chairman-decisions CLI handle stays byte-identical + trailing. Suppresses the blocking clause for `gate_decision` (base renderer states it inline); returns `''` when nothing elevated the item.

### Verification
- **11 new pure tests + 46 existing layman/queue tests pass** (no regression to the render/ref-token contract).
- **Live render** confirmed the rationale appears on a real age-escalated decision; non-escalated lines unchanged; count + ref tokens preserved.
- **Consolidated adversarial review: ship** — ref-token contract verified safe across all branches, escalation logic matches the view SQL, no silent blocking drop, pure/fail-safe.
- TESTING sub-agent: PASS@95.

Zero changes to the consolidation views, the email push, or routing. The chairman web-UI vision (chairman-web-ui-architecture-v2.md) is a **separate, deferred initiative**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
