### PR TITLE
feat(SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001): working_context standing-context + full-lane reply reader

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001.json
@@ -1,0 +1,133 @@
+{
+  "executive_summary": "Adam<->coordinator interface hardening, child D of SD-LEO-INFRA-ADAM-AUTONOMY-HARDENING-001. LEAD VALIDATION (row 459dc65f) found that the SD's original auto-ack and two-stage-ACK goals are ALREADY DELIVERED: QF-20260610-623 (PR #4533, commit b7dfd42) shipped the amAdam all-message-types auto-ack carve-out (coordination-inbox.cjs:141-143), the read-but-unacknowledged monitor (read-adam-directives.cjs), and the COACHING test; and the read_at->actioned_at two-stage ACK already exists as the payload.actioned_at JSONB contract (coordinator-ack-adam.cjs:65-71, adam-action-ack.cjs hasBeenActioned, read-adam-advisories.cjs gate). This PRD therefore VERIFIES (does not rebuild) those, and delivers the genuine remaining work: the chairman-directed working_context standing-context substrate (a continuously-current, mutually-readable list of each operator's concurrent workstreams on claude_sessions.metadata.working_context, with waiting-on-the-other-party as the highest-value signal), a narrowed reply-reader full-lane fix, and a regression test that locks the delivery contract. The verification story: a hermetic working-context library unit suite + a fleet-dashboard dual-render + a live CLI demo against the existing manual blob on session f808779a.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "working_context canonical-thread library (lib/coordinator/working-context.cjs)",
+      "description": "A pure, injectable, CJS library that models each operator session's working_context as a LIST of concurrent workstreams (not a single focus). Canonical thread lifecycle states are active|waiting|blocked|done|cancelled with an optional waiting_on field (coordinator|chairman|adam|<party>) so a waiting-on-the-other-party thread is first-class. normalizeThread/normalizeWorkingContext map the live hand-maintained free-form vocabulary on claude_sessions.metadata.working_context (session f808779a: states like 'waiting-on-coordinator', 'monitoring', 'done-7/7') onto the canonical shape so the library auto-maintains the existing data rather than clobbering it. pruneThreads transitions done|cancelled threads out of the live list into recently_closed and ages recently_closed entries past a TTL out. isStale flags a context whose top-level updated_at is older than the 30-minute staleness threshold (a stale context MISLEADS, worse than none). deriveThreadState maps a thread to a live signal (SD status / advisory ack / claim state) and returns the derived canonical state where mappable, null otherwise, so the context self-maintains instead of relying on manual upkeep that rots. formatWorkingContext is the single-source display mapping (reused by the CLI and the fleet-dashboard) that renders threads with state badges, HIGHLIGHTS waiting-on-other, and labels staleness.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "normalizeThread maps 'waiting-on-coordinator' -> {state:'waiting', waiting_on:'coordinator'}, 'monitoring' -> {state:'active'}, 'done-7/7' -> {state:'done'}; unknown states resolve to a documented honest default and never throw.",
+        "pruneThreads moves done|cancelled threads into recently_closed and removes recently_closed entries older than the TTL; the live threads list contains only open (active|waiting|blocked) threads.",
+        "isStale returns true when updated_at is missing or older than the 30-minute threshold (configurable), false otherwise.",
+        "deriveThreadState returns the canonical state derived from an injected live signal when the thread maps to one, and null when no mapping applies.",
+        "formatWorkingContext is pure, never throws on null/garbage input, and visibly highlights waiting-on-<other-party> threads and a STALE banner."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Atomic JSONB write path + chairman-gated RPC migration + CLI",
+      "description": "Writes to working_context go through an atomic JSONB merge, NEVER a JS whole-object read-modify-write (the lost-update lesson: a select->mutate->write of claude_sessions.metadata clobbers concurrent writers of other metadata keys — is_coordinator, claim, fleet_identity). A new chairman-gated, additive, reversible migration creates a SECURITY DEFINER RPC set_session_working_context(p_session_id text, p_wc jsonb) that runs UPDATE claude_sessions SET metadata = COALESCE(metadata,'{}'::jsonb) || jsonb_build_object('working_context', p_wc) with an in-migration DO $verify$ ASSERT. The JS store (getWorkingContext/writeWorkingContext) calls the RPC and FAIL-SOFTS (warns 'persistence pending migration apply', returns persisted:false) when the function is absent (migration not yet applied) rather than falling back to the dangerous RMW. A CLI scripts/working-context.cjs exposes show / set / done / cancel / prune / refresh (refresh = auto-derive + prune + write, the per-tick self-maintenance path).",
+      "priority": "high",
+      "acceptance_criteria": [
+        "writeWorkingContext invokes supabase.rpc('set_session_working_context', ...) and never issues a full-object .update({metadata}) read-modify-write.",
+        "When the RPC is absent the writer returns {persisted:false, reason} and prints a clear 'migration unapplied' warning — it does not crash and does not perform an unsafe RMW.",
+        "The migration is additive, reversible, carries an in-migration verify, and has NO -- @approved-by attestation (chairman-gated, dormant until applied).",
+        "scripts/working-context.cjs set/done/prune mutate the in-memory context via the FR-1 library then persist via the writer."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "fleet-dashboard dual-render of both operators' working_context",
+      "description": "scripts/fleet-dashboard.cjs gains a working-context section that reads the Adam session's and the coordinator session's metadata.working_context and renders both via the FR-1 formatWorkingContext single-source mapping, with a per-context freshness indicator (FRESH/STALE by the 30-minute rule) and waiting-on-the-other-party threads highlighted, so neither operator mistakes the other's heads-down silence for being ignored and both have standing CONTEXT alongside the point-to-point advisories.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "The dashboard renders Adam's and the coordinator's working_context side-by-side using formatWorkingContext (no duplicated display logic).",
+        "A context older than 30 minutes renders a visible STALE/unreliable indicator.",
+        "waiting-on-<other-party> threads are visually distinguished from active/blocked threads."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Narrowed reply-reader full-lane (adam-advisory.cjs replies)",
+      "description": "The `node scripts/adam-advisory.cjs replies` drain command currently filters payload->>kind = 'coordinator_reply' ONLY (drainReplies, line ~168), so a reply to an Adam advisory that is not tagged coordinator_reply is hidden. (Inbound coordinator directives of all kinds are already covered by read-adam-directives.cjs + the amAdam inbox carve-out + the DIRECTIVE_KINDS allowlist, so this is a CLI-convenience gap, not a delivery-reliability gap.) Broaden the drain to surface every reply targeting the Adam session — coordinator_reply OR any row carrying a payload.reply_to (a correlated reply to an Adam advisory) — while preserving the advisory-vs-friction lane separation and the exactly-once read_at consume.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "drainReplies surfaces coordinator_reply rows AND rows with a payload.reply_to that are not coordinator_reply, for the Adam session, where read_at IS NULL.",
+        "Each surfaced reply is consumed exactly once (read_at stamped only on rows still NULL).",
+        "No friction-router or deconfliction regression: rows without a reply correlation are not scooped."
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Regression tests + verified-not-rebuilt contract documentation",
+      "description": "A hermetic vitest suite tests/unit/coordination/working-context.test.js covers the FR-1 library (normalize, prune, stale, derive, format) and the FR-2 writer fail-soft (RPC-absent path via an injected supabase stub) and the FR-4 full-lane drain. The PRD and a code comment document that success criteria #1 (auto-ack cannot hide a directed row) and #3 (two-stage read->actioned ACK) are VERIFIED as already delivered by QF-20260610-623 + the payload.actioned_at contract, citing files, and are NOT rebuilt — closing the SD's 'Delivery is TESTED' criterion against the genuine remaining surface.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "working-context.test.js is hermetic (no live DB / no real time via injected nowMs) and green.",
+        "A test exercises the RPC-absent fail-soft path and asserts no RMW is attempted.",
+        "A test asserts drainReplies surfaces a non-coordinator_reply reply (payload.reply_to set).",
+        "The PRD records the verified-not-rebuilt items with file:line + PR#/commit evidence."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Additive; no new table/column", "description": "working_context lives on the EXISTING claude_sessions.metadata JSONB. The only schema artifact is the chairman-gated set_session_working_context RPC migration. The redundant '(new)_two_stage_ack.sql' from the SD scope is DROPPED — session_coordination uses read_at + acknowledged_at + payload.actioned_at by design (VALIDATION finding)." },
+    { "id": "TR-2", "title": "Atomic JSONB writes only — never JS RMW", "description": "Per the singleton/metadata atomic-jsonb lesson, working_context is written via metadata || jsonb_build_object through a SECURITY DEFINER RPC; the JS path fail-softs when the RPC is absent rather than performing a lost-update-prone whole-object read-modify-write." },
+    { "id": "TR-3", "title": "Backward-compatible + lane separation preserved", "description": "The library normalizes (never clobbers) the live working_context blob shape {mode, threads:[{what,state}], updated_at, staleness_rule, recently_closed}. adam-advisory lane invariants (payload.kind=adam_advisory, NO signal_type / intent_action) are preserved by FR-4. Modules are CJS (.cjs) because the repo is type:module." },
+    { "id": "TR-4", "title": "Do not rebuild already-delivered work", "description": "No changes to the QF-20260610-623 auto-ack carve-out, read-adam-directives.cjs, or the payload.actioned_at two-stage ACK contract beyond verification + tests." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "normalize live free-form states to canonical lifecycle", "type": "unit", "expected": "waiting-on-coordinator/monitoring/done-7/7 map to {waiting,waiting_on:coordinator}/{active}/{done}; canonical shape out." },
+    { "id": "TS-2", "scenario": "prune done|cancelled into recently_closed + age out", "type": "unit", "expected": "live threads contain only open threads; recently_closed older than TTL removed." },
+    { "id": "TS-3", "scenario": "staleness detection", "type": "unit", "expected": "isStale true when updated_at missing or >30min old." },
+    { "id": "TS-4", "scenario": "auto-derive thread state from injected live signal", "type": "unit", "expected": "derived canonical state when mapped, null otherwise." },
+    { "id": "TS-5", "scenario": "writer fail-soft when RPC absent", "type": "unit", "expected": "returns persisted:false + warning; no full-object metadata update issued." },
+    { "id": "TS-6", "scenario": "drainReplies full-lane", "type": "unit", "expected": "surfaces a payload.reply_to reply that is not coordinator_reply; consumes exactly once." }
+  ],
+  "acceptance_criteria": [
+    "working_context is a continuously-current, mutually-readable LIST of concurrent threads per operator with waiting-on-other surfaced (SD criterion: standing context, currency over staleness).",
+    "All writes are atomic JSONB (no JS RMW); the RPC migration is chairman-gated and the JS path fail-softs when unapplied.",
+    "fleet-dashboard renders both operators' contexts with freshness + waiting-on-other highlighting via a single-source formatter.",
+    "The reply-only drainReplies blindspot is closed for the Adam session (narrowed FR-4).",
+    "SD criteria #1 (auto-ack cannot hide a directed row) and #3 (two-stage read->actioned ACK) are VERIFIED already-delivered (QF-20260610-623 + payload.actioned_at contract) and locked by regression, not rebuilt.",
+    "Advisory lane separation (adam_advisory kind, no signal_type) is preserved."
+  ],
+  "risks": [
+    { "risk": "JS read-modify-write of claude_sessions.metadata would reintroduce the lost-update race (clobbers concurrent metadata writers).", "mitigation": "Atomic metadata || jsonb_build_object via SECURITY DEFINER RPC; JS path fail-softs (never RMW) when the RPC is absent.", "severity": "high" },
+    { "risk": "Stale working_context actively misleads (worse than none).", "mitigation": "Top-level updated_at + 30-min isStale rule surfaced in every render; auto-derive + prune keep it current; manual threads still get the freshness backstop.", "severity": "medium" },
+    { "risk": "Chairman-gated migration is unapplied at ship, so persistence is dormant.", "mitigation": "Reads work against the existing manual blob; writer fail-softs with a clear notice; in-migration verify proves correctness on apply; captured as a completion flag.", "severity": "low" },
+    { "risk": "Re-deriving/rebuilding work already shipped by QF-20260610-623 or the payload.actioned_at contract.", "mitigation": "VALIDATION (row 459dc65f) enumerated already-delivered items with evidence; this PRD verifies + tests them only.", "severity": "medium" },
+    { "risk": "Broadening drainReplies could scoop non-reply rows or break lane separation.", "mitigation": "Filter strictly to coordinator_reply OR rows with a payload.reply_to correlation; preserve exactly-once read_at consume; unit-tested.", "severity": "low" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["The Adam operator session", "The coordinator operator session", "scripts/fleet-dashboard.cjs", "scripts/working-context.cjs CLI"],
+    "dependencies": ["claude_sessions.metadata (existing JSONB column)", "set_session_working_context RPC (new chairman-gated migration)", "lib/coordinator/working-context.cjs (new library)"],
+    "data_contracts": ["claude_sessions.metadata.working_context = {mode, threads:[{what,state,waiting_on?,since}], updated_at, staleness_rule?, recently_closed:[{at,what,state}]}", "RPC set_session_working_context(p_session_id text, p_wc jsonb)"],
+    "runtime_config": ["none (no new env var/flag); persistence activates when the chairman applies the RPC migration"],
+    "observability_rollout": ["working-context.test.js unit suite", "node scripts/working-context.cjs show (live render)", "fleet-dashboard working-context section", "the 5 smoke_test_steps"]
+  },
+  "system_architecture": {
+    "summary": "A pure working_context lifecycle library + an atomic JSONB write path (RPC) + dual-render, layered over the existing claude_sessions.metadata and the already-delivered ACK/inbox contracts.",
+    "components": [
+      { "name": "lib/coordinator/working-context.cjs", "change": "NEW — canonical thread model, normalize, prune, isStale, deriveThreadState, formatWorkingContext" },
+      { "name": "lib/coordinator/working-context-store.cjs", "change": "NEW — getWorkingContext/writeWorkingContext (RPC + fail-soft)" },
+      { "name": "scripts/working-context.cjs", "change": "NEW — show/set/done/cancel/prune/refresh CLI" },
+      { "name": "database/migrations/20260615_set_session_working_context.sql", "change": "NEW — chairman-gated atomic-merge RPC + verify" },
+      { "name": "scripts/fleet-dashboard.cjs", "change": "UPDATE — working-context dual-render section" },
+      { "name": "scripts/adam-advisory.cjs", "change": "UPDATE — drainReplies full-lane (narrowed FR-4)" },
+      { "name": "tests/unit/coordination/working-context.test.js", "change": "NEW — hermetic regression suite" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the pure library first, layer the atomic store + migration, then wire CLI + dashboard, narrow FR-4, and lock with hermetic tests.",
+    "steps": [
+      "Write lib/coordinator/working-context.cjs (pure model + normalize/prune/isStale/deriveThreadState/formatWorkingContext) and its hermetic test suite.",
+      "Write lib/coordinator/working-context-store.cjs (RPC writer + fail-soft) and the chairman-gated set_session_working_context migration with in-migration verify.",
+      "Write scripts/working-context.cjs CLI (show/set/done/cancel/prune/refresh).",
+      "Wire the dual-render working-context section into scripts/fleet-dashboard.cjs via formatWorkingContext.",
+      "Narrow FR-4: broaden drainReplies to the full reply lane (coordinator_reply OR payload.reply_to).",
+      "Run the suite + a live `working-context.cjs show` smoke against session f808779a; document verified-not-rebuilt items."
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run the working-context library unit tests: npx vitest run tests/unit/coordination/working-context.test.js", "expected_outcome": "All green. normalizeThread maps live free-form states; pruneThreads moves done|cancelled into recently_closed and ages the list out; isStale flags >30min-old contexts." },
+    { "step_number": 2, "instruction": "Show the rendered working context: node scripts/working-context.cjs show", "expected_outcome": "Renders the Adam and coordinator working_context as canonical parallel threads; waiting-on-<other party> threads are HIGHLIGHTED; a stale context is labelled STALE/unreliable." },
+    { "step_number": 3, "instruction": "Set + close a thread: node scripts/working-context.cjs set \"CronGenius refresh\" --state waiting-on-coordinator ; then node scripts/working-context.cjs done \"CronGenius refresh\"", "expected_outcome": "Thread upserted then transitioned to done and pruned into recently_closed; updated_at bumped; write goes through the atomic RPC (or fail-soft warns when the chairman-gated migration is unapplied) — never a whole-object JS RMW." },
+    { "step_number": 4, "instruction": "Render the fleet dashboard: node scripts/fleet-dashboard.cjs (working-context section)", "expected_outcome": "Both operators' working_context render with a freshness indicator; waiting-on-the-other-party threads surfaced." },
+    { "step_number": 5, "instruction": "Drain the full directive lane: node scripts/adam-advisory.cjs replies", "expected_outcome": "The replies reader surfaces all directed reply kinds for the Adam session, not coordinator_reply only — the reply-only blindspot at adam-advisory.cjs:168 is closed." }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001"
+  }
+}

--- a/database/migrations/20260615_set_session_working_context.sql
+++ b/database/migrations/20260615_set_session_working_context.sql
@@ -1,0 +1,92 @@
+-- SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-2) — atomic working_context write RPC.
+--
+-- The chairman-directed working_context (a per-operator-session LIST of concurrent workstreams)
+-- lives on claude_sessions.metadata.working_context. Writing it from JS by SELECT metadata →
+-- merge in JS → write the WHOLE object is the lost-update race FIX-CREATE-REPLACE-001 and the
+-- atomic coordinator-flag RPCs already fixed for the same table: a concurrent writer of a sibling
+-- metadata key (is_coordinator, claim flags, fleet_identity, heartbeat) gets clobbered.
+--
+-- FIX: one SECURITY DEFINER RPC that performs an ATOMIC jsonb mutation in a single UPDATE
+--   statement (Postgres row-lock serializes concurrent mutations of the same row; `||` operates
+--   on the LIVE row value, never a stale JS snapshot):
+--     set_session_working_context(p_session_id, p_wc)
+--        → metadata = COALESCE(metadata,'{}') || jsonb_build_object('working_context', p_wc)
+--   working_context is a SINGLE managed key, so a whole-key replace is correct (the application
+--   builds the next working_context value via lib/coordinator/working-context.cjs and persists it
+--   wholesale); sibling metadata keys are preserved because `||` merges onto the live row.
+--   Create-if-absent mirrors the established set_coordinator_flag path so a session whose row does
+--   not yet exist still persists its context.
+--
+-- DATA-SAFETY: additive. Applying this migration creates ONE function and modifies NO real rows
+--   (the DO $verify$ block seeds + deletes a synthetic session inside the transaction). Reversible
+--   via DROP FUNCTION. Chairman-gated for prod-apply (no -- @approved-by attestation): the JS
+--   writer (lib/coordinator/working-context-store.cjs) FAIL-SOFTS when this function is absent, so
+--   the feature is dormant-but-safe until the chairman applies the migration.
+
+CREATE OR REPLACE FUNCTION set_session_working_context(p_session_id TEXT, p_wc JSONB)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO claude_sessions (session_id, metadata, heartbeat_at, status, created_at, updated_at)
+  VALUES (
+    p_session_id,
+    jsonb_build_object('working_context', p_wc),
+    now(),
+    'active',
+    now(),
+    now()
+  )
+  ON CONFLICT (session_id) DO UPDATE SET
+    metadata = COALESCE(claude_sessions.metadata, '{}'::jsonb)
+               || jsonb_build_object('working_context', p_wc),
+    updated_at = now();
+END;
+$$;
+
+COMMENT ON FUNCTION set_session_working_context(TEXT, JSONB) IS
+  'SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001: atomically set metadata.working_context for one session (jsonb `||`), preserving all sibling metadata keys. Race-safe replacement for a JS read-modify-write. Create-if-absent mirrors set_coordinator_flag.';
+
+-- ── In-migration self-verification (runs inside the apply transaction; aborts on any ASSERT) ──
+DO $verify$
+DECLARE
+  v_sid  TEXT := 'verify-working-ctx-' || md5(clock_timestamp()::text);
+  v_meta JSONB;
+  v_wc1  JSONB := jsonb_build_object('mode','support','threads', jsonb_build_array(jsonb_build_object('what','t1','state','active')),'updated_at','2026-06-15T12:00:00Z');
+  v_wc2  JSONB := jsonb_build_object('mode','build','threads', jsonb_build_array(jsonb_build_object('what','t2','state','waiting','waiting_on','coordinator')),'updated_at','2026-06-15T12:05:00Z');
+BEGIN
+  -- Seed an existing session carrying a sibling metadata key that MUST survive the write.
+  INSERT INTO claude_sessions (session_id, metadata, heartbeat_at, status, created_at, updated_at)
+  VALUES (v_sid, jsonb_build_object('is_coordinator', true, 'claim_flag', 'held'), now(), 'active', now(), now());
+
+  -- set on an EXISTING row: working_context stored, sibling keys preserved.
+  PERFORM set_session_working_context(v_sid, v_wc1);
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+  ASSERT v_meta ? 'working_context', 'WORKING-CTX: working_context not set';
+  ASSERT (v_meta->'working_context'->'threads'->0->>'what') = 't1', 'WORKING-CTX: thread payload not stored';
+  ASSERT v_meta ? 'is_coordinator' AND (v_meta->>'is_coordinator')::boolean = true, 'WORKING-CTX: clobbered sibling is_coordinator';
+  ASSERT v_meta->>'claim_flag' = 'held', 'WORKING-CTX: clobbered sibling claim_flag';
+
+  -- a second set REPLACES the working_context value wholesale (single managed key), siblings intact.
+  PERFORM set_session_working_context(v_sid, v_wc2);
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+  ASSERT (v_meta->'working_context'->'threads'->0->>'what') = 't2', 'WORKING-CTX: second set did not replace';
+  ASSERT (v_meta->'working_context'->'threads'->0->>'waiting_on') = 'coordinator', 'WORKING-CTX: waiting_on not persisted';
+  ASSERT v_meta->>'claim_flag' = 'held', 'WORKING-CTX: second set clobbered sibling';
+
+  -- create-if-absent: set on a NON-EXISTENT session registers a fresh row.
+  DELETE FROM claude_sessions WHERE session_id = v_sid;
+  PERFORM set_session_working_context(v_sid, v_wc1);
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+  ASSERT v_meta ? 'working_context', 'WORKING-CTX: create-if-absent failed';
+
+  -- Cleanup so nothing leaks past COMMIT.
+  DELETE FROM claude_sessions WHERE session_id = v_sid;
+  RAISE NOTICE 'WORKING-CTX verify OK: atomic set preserves siblings, replaces the managed key, and create-if-absent works.';
+END
+$verify$;
+
+-- ROLLBACK: DROP FUNCTION set_session_working_context(TEXT, JSONB);
+-- Additive + fully reversible — no data migration to undo.

--- a/lib/coordinator/working-context-store.cjs
+++ b/lib/coordinator/working-context-store.cjs
@@ -1,0 +1,73 @@
+/**
+ * working-context-store.cjs — SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-2)
+ *
+ * The persistence seam for working_context. Reads are a plain SELECT of
+ * claude_sessions.metadata.working_context (normalized through the pure library). Writes go
+ * EXCLUSIVELY through the atomic set_session_working_context RPC (metadata || jsonb_build_object)
+ * — NEVER a JS read-modify-write of the whole metadata object, which is the lost-update race the
+ * atomic coordinator-flag RPCs already fixed for this table.
+ *
+ * FAIL-SOFT: when the RPC is absent (the chairman-gated migration is not yet applied) the writer
+ * returns { persisted:false, reason:'rpc_absent' } and warns — it does NOT fall back to a
+ * dangerous RMW and it does not crash. The feature is dormant-but-safe until apply.
+ *
+ * Injectable: the supabase client is passed in so the store is unit-testable with a stub.
+ */
+
+const wcLib = require('./working-context.cjs');
+
+// Postgres/PostgREST signals that the RPC function is not defined (migration unapplied).
+function isMissingFunctionError(error) {
+  if (!error) return false;
+  const code = error.code || '';
+  if (code === '42883' || code === 'PGRST202') return true; // undefined_function / PostgREST not-found
+  const msg = String(error.message || error.hint || '').toLowerCase();
+  return /could not find the function|function .*does not exist|set_session_working_context/.test(msg) && /not (found|exist)/.test(msg);
+}
+
+/** Read + normalize a session's working_context. Returns a normalized context (empty if absent). */
+async function getWorkingContext(supabase, sessionId) {
+  if (!supabase || !sessionId) return wcLib.normalizeWorkingContext(null);
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) return wcLib.normalizeWorkingContext(null);
+    return wcLib.normalizeWorkingContext(data && data.metadata ? data.metadata.working_context : null);
+  } catch {
+    return wcLib.normalizeWorkingContext(null);
+  }
+}
+
+/**
+ * Persist a working_context value atomically via the RPC. Returns:
+ *   { persisted:true }                                 on success
+ *   { persisted:false, reason:'rpc_absent', warn }     when the migration is not applied (fail-soft)
+ *   { persisted:false, reason:'error', error }         on any other DB error
+ * NEVER performs a JS read-modify-write fallback (lost-update safety).
+ */
+async function writeWorkingContext(supabase, sessionId, wc) {
+  if (!supabase || !sessionId) return { persisted: false, reason: 'no_client_or_session' };
+  let res;
+  try {
+    res = await supabase.rpc('set_session_working_context', { p_session_id: sessionId, p_wc: wc });
+  } catch (e) {
+    if (isMissingFunctionError(e)) return rpcAbsent();
+    return { persisted: false, reason: 'error', error: e && e.message ? e.message : String(e) };
+  }
+  const error = res && res.error;
+  if (error) {
+    if (isMissingFunctionError(error)) return rpcAbsent();
+    return { persisted: false, reason: 'error', error: error.message || String(error) };
+  }
+  return { persisted: true };
+}
+
+function rpcAbsent() {
+  const warn = '[working-context] persistence pending: set_session_working_context RPC is not applied (chairman-gated migration). Context not persisted (no unsafe RMW fallback).';
+  return { persisted: false, reason: 'rpc_absent', warn };
+}
+
+module.exports = { getWorkingContext, writeWorkingContext, isMissingFunctionError };

--- a/lib/coordinator/working-context.cjs
+++ b/lib/coordinator/working-context.cjs
@@ -1,0 +1,219 @@
+/**
+ * working-context.cjs — SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-1)
+ *
+ * The chairman-directed standing-context substrate for the Adam<->coordinator interface.
+ * Each operator session keeps, on claude_sessions.metadata.working_context, a LIST of its
+ * concurrent workstreams (NOT a single focus — a single-focus field would hide the other live
+ * threads and MISLEAD). The reader sees the full parallel picture and, most importantly, which
+ * threads are waiting-on-the-other-party (the highest-value signal: e.g. Adam waiting-on-coordinator).
+ *
+ * CURRENCY is the core requirement: a stale working_context actively misleads (worse than none).
+ * So this library (1) normalizes threads to a canonical lifecycle, (2) prunes completed/cancelled
+ * threads, (3) detects staleness (updated_at drift), and (4) AUTO-DERIVES thread state from live
+ * signals (SD status / advisory ack / claim state) where a thread maps to one, so the context
+ * self-maintains instead of relying on manual upkeep that rots.
+ *
+ * PURE + injectable (no DB, no I/O, time passed in) so it is unit-testable. The atomic persistence
+ * path lives in working-context-store.cjs. This module is CJS because the repo is type:module.
+ *
+ * Canonical shape:
+ *   { mode, threads: [{ what, state, waiting_on?, since }], recently_closed: [{ at, what, state }], updated_at }
+ * Canonical thread states: active | waiting | blocked | done | cancelled.
+ * Backward-compatible: normalizes the live hand-maintained blob (free-form states like
+ * 'waiting-on-coordinator', 'monitoring', 'done-7/7') rather than clobbering it.
+ */
+
+const CANONICAL_STATES = Object.freeze(['active', 'waiting', 'blocked', 'done', 'cancelled']);
+const OPEN_STATES = Object.freeze(['active', 'waiting', 'blocked']);
+const CLOSED_STATES = Object.freeze(['done', 'cancelled']);
+const STALE_THRESHOLD_MS = 30 * 60_000;          // 30 min — a context older than this is treated as unreliable.
+const RECENTLY_CLOSED_TTL_MS = 24 * 60 * 60_000; // 24 h — closed threads age out of recently_closed after this.
+
+function isoNow(nowMs) {
+  return new Date(Number.isFinite(nowMs) ? nowMs : Date.now()).toISOString();
+}
+
+/**
+ * Map a free-form state string onto the canonical lifecycle, extracting the waiting-on party.
+ * Returns { state, waiting_on? }. Unknown states resolve to the honest default 'active' (keeps an
+ * unrecognized thread VISIBLE — never silently coerced to done/pruned).
+ */
+function normalizeState(raw) {
+  const s = String(raw == null ? '' : raw).trim().toLowerCase();
+  if (!s) return { state: 'active' };
+  const m = s.match(/^(waiting|blocked)[-_\s]+on[-_\s]+(.+)$/);
+  if (m) return { state: m[1], waiting_on: m[2].trim() };
+  if (s === 'waiting' || s === 'awaiting' || s === 'pending') return { state: 'waiting' };
+  if (s === 'blocked' || s === 'stuck') return { state: 'blocked' };
+  if (s === 'monitoring' || s === 'watching' || s === 'active' || s === 'in-progress' || s === 'in_progress' || s === 'wip') return { state: 'active' };
+  if (s.startsWith('done') || s === 'complete' || s === 'completed' || s === 'shipped' || s === 'merged') return { state: 'done' };
+  if (s === 'cancelled' || s === 'canceled' || s === 'dropped' || s === 'abandoned') return { state: 'cancelled' };
+  return { state: 'active' };
+}
+
+/** Normalize one thread to the canonical shape, or null if it has no usable `what`. Does NOT fabricate `since`. */
+function normalizeThread(t) {
+  if (!t || typeof t !== 'object') return null;
+  const what = typeof t.what === 'string' ? t.what.trim() : (typeof t.thread === 'string' ? t.thread.trim() : '');
+  if (!what) return null;
+  const norm = normalizeState(t.state);
+  const out = { what, state: norm.state };
+  const waitingOn = norm.waiting_on || (typeof t.waiting_on === 'string' ? t.waiting_on.trim() : null);
+  if (waitingOn && (out.state === 'waiting' || out.state === 'blocked')) out.waiting_on = waitingOn;
+  out.since = typeof t.since === 'string' ? t.since : null;
+  return out;
+}
+
+/** Normalize a whole working_context blob. Never throws; tolerates null/garbage. */
+function normalizeWorkingContext(wc) {
+  const base = (wc && typeof wc === 'object' && !Array.isArray(wc)) ? wc : {};
+  const threads = Array.isArray(base.threads) ? base.threads.map(normalizeThread).filter(Boolean) : [];
+  const recently_closed = Array.isArray(base.recently_closed)
+    ? base.recently_closed.filter((r) => r && typeof r === 'object' && typeof r.what === 'string') : [];
+  return {
+    mode: typeof base.mode === 'string' ? base.mode : null,
+    threads,
+    recently_closed,
+    updated_at: typeof base.updated_at === 'string' ? base.updated_at : null,
+  };
+}
+
+/** A context is stale (unreliable) when updated_at is missing/garbage or older than the threshold. */
+function isStale(wc, nowMs, thresholdMs = STALE_THRESHOLD_MS) {
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const ts = wc && typeof wc.updated_at === 'string' ? Date.parse(wc.updated_at) : NaN;
+  if (!Number.isFinite(ts)) return true;
+  return (now - ts) > thresholdMs;
+}
+
+/** Upsert a thread (match by `what`); bumps updated_at. Immutable — returns a new normalized context. */
+function upsertThread(wc, threadInput, nowMs) {
+  const now = isoNow(nowMs);
+  const norm = normalizeWorkingContext(wc);
+  const t = normalizeThread(threadInput);
+  if (!t) return { ...norm, updated_at: norm.updated_at };
+  const idx = norm.threads.findIndex((x) => x.what === t.what);
+  if (idx >= 0) {
+    const since = norm.threads[idx].since || t.since || now;
+    norm.threads[idx] = { ...t, since };
+  } else {
+    norm.threads.push({ ...t, since: t.since || now });
+  }
+  norm.updated_at = now;
+  return norm;
+}
+
+/** Transition an existing thread to a new state (upserts if absent); bumps updated_at. Immutable. */
+function setThreadState(wc, what, rawState, nowMs) {
+  const now = isoNow(nowMs);
+  const key = String(what == null ? '' : what).trim();
+  const norm = normalizeWorkingContext(wc);
+  const idx = norm.threads.findIndex((x) => x.what === key);
+  if (idx < 0) return upsertThread(norm, { what: key, state: rawState }, nowMs);
+  const ns = normalizeState(rawState);
+  const updated = { ...norm.threads[idx], state: ns.state };
+  if ((ns.state === 'waiting' || ns.state === 'blocked') && ns.waiting_on) updated.waiting_on = ns.waiting_on;
+  else delete updated.waiting_on;
+  norm.threads[idx] = updated;
+  norm.updated_at = now;
+  return norm;
+}
+
+/**
+ * Prune: move done|cancelled threads out of the live list into recently_closed, and age out
+ * recently_closed entries older than the TTL. updated_at bumps ONLY when a real state change
+ * happened (a thread was closed) — pure age-out must not lie about freshness. Immutable.
+ */
+function pruneThreads(wc, nowMs, opts = {}) {
+  const ttl = Number.isFinite(opts.recentlyClosedTtlMs) ? opts.recentlyClosedTtlMs : RECENTLY_CLOSED_TTL_MS;
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const nowIsoStr = new Date(now).toISOString();
+  const norm = normalizeWorkingContext(wc);
+  const open = [];
+  const newlyClosed = [];
+  for (const t of norm.threads) {
+    if (CLOSED_STATES.includes(t.state)) newlyClosed.push({ at: nowIsoStr, what: t.what, state: t.state });
+    else open.push(t);
+  }
+  const recently_closed = [...norm.recently_closed, ...newlyClosed].filter((r) => {
+    const ts = r && r.at ? Date.parse(r.at) : NaN;
+    if (!Number.isFinite(ts)) return false;
+    return (now - ts) <= ttl;
+  });
+  return {
+    ...norm,
+    threads: open,
+    recently_closed,
+    updated_at: newlyClosed.length > 0 ? nowIsoStr : norm.updated_at,
+  };
+}
+
+/**
+ * Auto-derive a thread's canonical state from live signals when it maps to one; null otherwise
+ * (so manual-only threads are left untouched and keep their freshness backstop).
+ *   signals: { sdStatus?, advisoryAcked?, claimActive? } — any subset.
+ */
+function deriveThreadState(thread, signals) {
+  if (!thread || !signals || typeof signals !== 'object') return null;
+  if (typeof signals.sdStatus === 'string') {
+    const st = signals.sdStatus.trim().toLowerCase();
+    if (st === 'completed' || st === 'complete') return 'done';
+    if (st === 'cancelled' || st === 'canceled' || st === 'deferred') return 'cancelled';
+    if (st === 'blocked') return 'blocked';
+    if (st === 'in_progress' || st === 'active' || st === 'draft' || st === 'pending_approval') return 'active';
+  }
+  if (signals.advisoryAcked === true) return 'active';
+  if (signals.claimActive === false && (thread.state === 'active' || thread.state === 'waiting')) return 'done';
+  return null;
+}
+
+/**
+ * Single-source display mapping (reused by the CLI + fleet-dashboard). Pure; never throws.
+ * waiting-on-<other-party> threads are highlighted (the highest-value signal) and a STALE
+ * banner is shown when the context has drifted past the threshold. opts.em is an optional
+ * emphasis function (e.g. a chalk colorizer) applied to highlighted lines.
+ */
+function formatWorkingContext(wc, opts = {}) {
+  const now = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+  const label = opts.label || 'working context';
+  const em = typeof opts.em === 'function' ? opts.em : (s) => s;
+  if (!wc || typeof wc !== 'object' || Array.isArray(wc)) return `  ${label}: (none)`;
+  const norm = normalizeWorkingContext(wc);
+  const ts = norm.updated_at ? Date.parse(norm.updated_at) : NaN;
+  const ageMin = Number.isFinite(ts) ? Math.floor((now - ts) / 60_000) : null;
+  const stale = isStale(norm, now, opts.thresholdMs);
+  const freshTag = stale
+    ? `STALE${ageMin != null ? ` (${ageMin}m old — re-derive before trusting)` : ' (no timestamp)'}`
+    : `fresh${ageMin != null ? ` (${ageMin}m)` : ''}`;
+  const lines = [`  ${label} — ${norm.threads.length} open thread(s) · ${stale ? em(freshTag) : freshTag}`];
+  if (!norm.threads.length) lines.push('    (no open threads)');
+  for (const t of norm.threads) {
+    const waitingOnOther = (t.state === 'waiting' || t.state === 'blocked') && t.waiting_on;
+    const badge = waitingOnOther ? `${t.state}-on-${t.waiting_on}` : t.state;
+    const mark = waitingOnOther ? '>>' : (t.state === 'blocked' ? '!!' : '·');
+    const line = `    ${mark} [${badge}] ${t.what}`;
+    lines.push(waitingOnOther ? em(line) : line);
+  }
+  if (norm.recently_closed.length) {
+    const recent = norm.recently_closed.slice(-3).map((r) => r.what).join('; ');
+    lines.push(`    recently closed: ${recent}`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  CANONICAL_STATES,
+  OPEN_STATES,
+  CLOSED_STATES,
+  STALE_THRESHOLD_MS,
+  RECENTLY_CLOSED_TTL_MS,
+  normalizeState,
+  normalizeThread,
+  normalizeWorkingContext,
+  isStale,
+  upsertThread,
+  setThreadState,
+  pruneThreads,
+  deriveThreadState,
+  formatWorkingContext,
+};

--- a/lib/coordinator/working-context.cjs
+++ b/lib/coordinator/working-context.cjs
@@ -28,9 +28,23 @@ const OPEN_STATES = Object.freeze(['active', 'waiting', 'blocked']);
 const CLOSED_STATES = Object.freeze(['done', 'cancelled']);
 const STALE_THRESHOLD_MS = 30 * 60_000;          // 30 min — a context older than this is treated as unreliable.
 const RECENTLY_CLOSED_TTL_MS = 24 * 60 * 60_000; // 24 h — closed threads age out of recently_closed after this.
+const CLOCK_SKEW_TOLERANCE_MS = 5 * 60_000;      // 5 min — a future-dated context beyond this is unreliable (honesty).
 
 function isoNow(nowMs) {
   return new Date(Number.isFinite(nowMs) ? nowMs : Date.now()).toISOString();
+}
+
+/** Trim-or-empty a candidate string field (helper for the `what` fallback chain). */
+function pickStr(v) { return typeof v === 'string' ? v.trim() : ''; }
+
+/** Coerce a `since` value to an ISO string without LOSING it: strings pass through, numbers/Dates
+ *  convert, anything else is null. (Review: a strict typeof==='string' guard silently dropped
+ *  numeric/Date timestamps — data loss on the normalize-persist cycle.) */
+function coerceSince(v) {
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' && Number.isFinite(v)) return new Date(v).toISOString();
+  if (v instanceof Date && !isNaN(v.getTime())) return v.toISOString();
+  return null;
 }
 
 /**
@@ -48,29 +62,39 @@ function normalizeState(raw) {
   if (s === 'monitoring' || s === 'watching' || s === 'active' || s === 'in-progress' || s === 'in_progress' || s === 'wip') return { state: 'active' };
   if (s.startsWith('done') || s === 'complete' || s === 'completed' || s === 'shipped' || s === 'merged') return { state: 'done' };
   if (s === 'cancelled' || s === 'canceled' || s === 'dropped' || s === 'abandoned') return { state: 'cancelled' };
-  return { state: 'active' };
+  // Unrecognized non-empty state: default to 'active' (keep VISIBLE) but PRESERVE the original
+  // string (raw_state) so the operator's intent is never silently lost (honesty / audit).
+  return { state: 'active', raw_state: String(raw == null ? '' : raw).trim() };
 }
 
 /** Normalize one thread to the canonical shape, or null if it has no usable `what`. Does NOT fabricate `since`. */
 function normalizeThread(t) {
   if (!t || typeof t !== 'object') return null;
-  const what = typeof t.what === 'string' ? t.what.trim() : (typeof t.thread === 'string' ? t.thread.trim() : '');
+  // Accept several alternate name fields before dropping a thread (reduces silent loss from a
+  // hand-edited blob that used a different key for the thread label).
+  const what = pickStr(t.what) || pickStr(t.thread) || pickStr(t.description) || pickStr(t.title) || pickStr(t.name);
   if (!what) return null;
   const norm = normalizeState(t.state);
   const out = { what, state: norm.state };
   const waitingOn = norm.waiting_on || (typeof t.waiting_on === 'string' ? t.waiting_on.trim() : null);
   if (waitingOn && (out.state === 'waiting' || out.state === 'blocked')) out.waiting_on = waitingOn;
-  out.since = typeof t.since === 'string' ? t.since : null;
+  if (norm.raw_state) out.raw_state = norm.raw_state; // carry the unrecognized original through for audit
+  out.since = coerceSince(t.since);
   return out;
 }
 
-/** Normalize a whole working_context blob. Never throws; tolerates null/garbage. */
+/** Normalize a whole working_context blob. Never throws; tolerates null/garbage. Preserves unknown
+ *  top-level keys (e.g. staleness_rule) so a normalize-persist cycle does not silently drop them. */
 function normalizeWorkingContext(wc) {
   const base = (wc && typeof wc === 'object' && !Array.isArray(wc)) ? wc : {};
   const threads = Array.isArray(base.threads) ? base.threads.map(normalizeThread).filter(Boolean) : [];
   const recently_closed = Array.isArray(base.recently_closed)
-    ? base.recently_closed.filter((r) => r && typeof r === 'object' && typeof r.what === 'string') : [];
+    // Keep an entry that has EITHER a usable `what` OR a timestamp `at` (don't silently drop a
+    // dated closed-record just because its label is non-string).
+    ? base.recently_closed.filter((r) => r && typeof r === 'object' && (typeof r.what === 'string' || typeof r.at === 'string'))
+    : [];
   return {
+    ...base, // passthrough: unknown top-level keys (staleness_rule, future fields) survive the cycle
     mode: typeof base.mode === 'string' ? base.mode : null,
     threads,
     recently_closed,
@@ -78,12 +102,17 @@ function normalizeWorkingContext(wc) {
   };
 }
 
-/** A context is stale (unreliable) when updated_at is missing/garbage or older than the threshold. */
+/** A context is stale (unreliable) when updated_at is missing/garbage, older than the threshold,
+ *  OR future-dated beyond the clock-skew tolerance (a future timestamp signals corruption/skew and
+ *  must NOT read as fresh — honesty: a temporal anomaly is treated as unreliable, not trustworthy). */
 function isStale(wc, nowMs, thresholdMs = STALE_THRESHOLD_MS) {
   const now = Number.isFinite(nowMs) ? nowMs : Date.now();
   const ts = wc && typeof wc.updated_at === 'string' ? Date.parse(wc.updated_at) : NaN;
   if (!Number.isFinite(ts)) return true;
-  return (now - ts) > thresholdMs;
+  const delta = now - ts;
+  if (delta > thresholdMs) return true;                  // too old
+  if (delta < -CLOCK_SKEW_TOLERANCE_MS) return true;     // future-dated beyond tolerance => unreliable
+  return false;
 }
 
 /** Upsert a thread (match by `what`); bumps updated_at. Immutable — returns a new normalized context. */
@@ -191,7 +220,8 @@ function formatWorkingContext(wc, opts = {}) {
     const waitingOnOther = (t.state === 'waiting' || t.state === 'blocked') && t.waiting_on;
     const badge = waitingOnOther ? `${t.state}-on-${t.waiting_on}` : t.state;
     const mark = waitingOnOther ? '>>' : (t.state === 'blocked' ? '!!' : '·');
-    const line = `    ${mark} [${badge}] ${t.what}`;
+    const rawNote = t.raw_state ? ` (raw: "${t.raw_state}")` : ''; // surface unrecognized intent, never hide it
+    const line = `    ${mark} [${badge}] ${t.what}${rawNote}`;
     lines.push(waitingOnOther ? em(line) : line);
   }
   if (norm.recently_closed.length) {
@@ -207,6 +237,7 @@ module.exports = {
   CLOSED_STATES,
   STALE_THRESHOLD_MS,
   RECENTLY_CLOSED_TTL_MS,
+  CLOCK_SKEW_TOLERANCE_MS,
   normalizeState,
   normalizeThread,
   normalizeWorkingContext,

--- a/package.json
+++ b/package.json
@@ -320,6 +320,7 @@
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",
+    "working-context": "node scripts/working-context.cjs",
     "chairman:notify": "node lib/integrations/todoist/chairman-notify.js",
     "adam:retro": "node scripts/adam-retro.cjs",
     "adam:scan": "node scripts/adam-opportunity-scan.cjs --scan",

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -162,23 +162,33 @@ async function snapshotSender(supabase, sessionId) {
  *
  * SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-4) — FULL-LANE reader. This previously surfaced
  * ONLY payload.kind='coordinator_reply', so a reply to an Adam advisory that carries a correlation
- * (payload.reply_to) under any other kind was hidden — the reply-only blindspot. Broaden to:
- * coordinator_reply OR any row carrying a payload.reply_to. Lane separation is preserved: a
- * non-reply row (no reply_to and not a coordinator_reply) is never scooped, and the exactly-once
- * read_at consume is unchanged. (Inbound coordinator DIRECTIVES of all kinds remain covered by
- * scripts/read-adam-directives.cjs + the amAdam inbox carve-out; this closes the `replies` lane.)
+ * (payload.reply_to) under any other kind was hidden — the reply-only blindspot. The fix fetches
+ * this session's UNREAD rows with AND-only filters (target_session + read_at IS NULL) and selects
+ * the reply lane IN JS: coordinator_reply OR any row carrying a payload.reply_to correlation. This
+ * deliberately avoids a PostgREST .or() over a jsonb ->> extraction (the `not.is.null` form inside
+ * .or() is brittle) and sidesteps any .or()+.eq() boolean-precedence question — lane separation is
+ * GUARANTEED by the AND-only query (every returned row is scoped to THIS target_session). A
+ * non-reply row is never surfaced, and the exactly-once read_at consume is unchanged. (Inbound
+ * coordinator DIRECTIVES of all kinds remain covered by scripts/read-adam-directives.cjs + the
+ * amAdam inbox carve-out; this closes the `replies` lane.)
  */
+function isReplyRow(r) {
+  const p = r && r.payload;
+  if (!p) return false;
+  return p.kind === 'coordinator_reply' || (p.reply_to != null && p.reply_to !== '');
+}
+
 async function drainReplies(supabase, sessionId) {
-  const { data: rows, error } = await supabase
+  const { data: allRows, error } = await supabase
     .from('session_coordination')
     .select('id, sender_session, subject, body, payload, created_at')
     .eq('target_session', sessionId)
-    .or('payload->>kind.eq.coordinator_reply,payload->>reply_to.not.is.null')
     .is('read_at', null)
     .order('created_at', { ascending: true })
-    .limit(50);
+    .limit(100);
   if (error) { console.error('ERROR: replies query failed:', error.message); process.exit(1); }
-  if (!rows || rows.length === 0) { console.log('(no unread directed replies)'); return; }
+  const rows = (allRows || []).filter(isReplyRow);
+  if (rows.length === 0) { console.log('(no unread directed replies)'); return; }
 
   console.log(`${rows.length} directed repl${rows.length === 1 ? 'y' : 'ies'}:`);
   const ids = [];
@@ -296,7 +306,7 @@ async function main() {
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -154,25 +154,33 @@ async function snapshotSender(supabase, sessionId) {
 }
 
 /**
- * FR-4 — durable reader: drain coordinator replies targeting THIS Adam session that
- * were not consumed by an in-flight sync await (read_at IS NULL). These are replies
- * that arrived after `request` mode's await timed out, or replies to fire-and-forget
- * `send` advisories. Gates on read_at IS NULL (same gate the inbox hook leaves NULL
- * for an Adam session) so each reply is consumed EXACTLY once. Stamps read_at to consume.
+ * FR-4 — durable reader: drain replies targeting THIS Adam session that were not consumed by an
+ * in-flight sync await (read_at IS NULL). These are replies that arrived after `request` mode's
+ * await timed out, or replies to fire-and-forget `send` advisories. Gates on read_at IS NULL
+ * (same gate the inbox hook leaves NULL for an Adam session) so each reply is consumed EXACTLY
+ * once. Stamps read_at to consume.
+ *
+ * SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-4) — FULL-LANE reader. This previously surfaced
+ * ONLY payload.kind='coordinator_reply', so a reply to an Adam advisory that carries a correlation
+ * (payload.reply_to) under any other kind was hidden — the reply-only blindspot. Broaden to:
+ * coordinator_reply OR any row carrying a payload.reply_to. Lane separation is preserved: a
+ * non-reply row (no reply_to and not a coordinator_reply) is never scooped, and the exactly-once
+ * read_at consume is unchanged. (Inbound coordinator DIRECTIVES of all kinds remain covered by
+ * scripts/read-adam-directives.cjs + the amAdam inbox carve-out; this closes the `replies` lane.)
  */
 async function drainReplies(supabase, sessionId) {
   const { data: rows, error } = await supabase
     .from('session_coordination')
     .select('id, sender_session, subject, body, payload, created_at')
     .eq('target_session', sessionId)
-    .eq('payload->>kind', 'coordinator_reply')
+    .or('payload->>kind.eq.coordinator_reply,payload->>reply_to.not.is.null')
     .is('read_at', null)
     .order('created_at', { ascending: true })
     .limit(50);
   if (error) { console.error('ERROR: replies query failed:', error.message); process.exit(1); }
-  if (!rows || rows.length === 0) { console.log('(no unread coordinator replies)'); return; }
+  if (!rows || rows.length === 0) { console.log('(no unread directed replies)'); return; }
 
-  console.log(`${rows.length} coordinator repl${rows.length === 1 ? 'y' : 'ies'}:`);
+  console.log(`${rows.length} directed repl${rows.length === 1 ? 'y' : 'ies'}:`);
   const ids = [];
   for (const r of rows) {
     const replyTo = (r.payload && r.payload.reply_to) || '?';

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -19,7 +19,11 @@ function saveDashState(s) { try { fs.mkdirSync(path.dirname(DASH_STATE_FILE), { 
 function normalizeRender(s) {
   return s.replace(/\[[0-9;]*m/g, '').replace(/\d+s ago/g, '_s_').replace(/\d+m ago/g, '_m_')
     .replace(/\d+:\d+:\d+ [AP]M/g, '_T_').replace(/\d+:\d+ [AP]M/g, '_t_').replace(/uptime \d+h\d+m/gi, '_U_')
-    .replace(/[\d.]+h ago/g, '_H_').replace(/\d{4,}m/g, '_W_');
+    .replace(/[\d.]+h ago/g, '_H_').replace(/\d{4,}m/g, '_W_')
+    // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3): working_context age indicators tick every
+    // minute ("STALE (98m old …)" / "fresh (1m)") — normalize them so the steady-state suppress hash
+    // does not change every minute and the dashboard can still reach its identical-render threshold.
+    .replace(/-?\d+m old/g, '_m_old').replace(/\(-?\d+m\)/g, '(_m_)');
 }
 // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B (Phase 2)
 const teamBanner = require('../lib/execute/team-banner.cjs');

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1223,6 +1223,36 @@ async function printAdamInbox() {
   console.log('');
 }
 
+// ── Section: Working context (FR-3, SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001) ──
+// Dual-render of both operators' standing working_context (claude_sessions.metadata.working_context)
+// so neither Adam nor the coordinator mistakes the other's heads-down silence for being ignored.
+// waiting-on-the-other-party threads are highlighted (the highest-value signal) and a context older
+// than the staleness threshold is flagged so a stale (misleading) context is never trusted blindly.
+// Read-only — renders via the single-source formatWorkingContext; stamps nothing.
+async function printWorkingContext() {
+  const getActiveCoordinatorId = _getActiveCoordinatorIdForInbox;
+  const store = require('../lib/coordinator/working-context-store.cjs');
+  const wcLib = require('../lib/coordinator/working-context.cjs');
+  let resolveAdamSessionId = null;
+  try { ({ resolveAdamSessionId } = require('./read-adam-directives.cjs')); } catch { resolveAdamSessionId = null; }
+
+  console.log('WORKING CONTEXT (Adam <-> Coordinator standing threads)');
+  console.log('─'.repeat(72));
+
+  let adamId = null, coordId = null;
+  try { adamId = resolveAdamSessionId ? await resolveAdamSessionId(supabase) : null; } catch { adamId = null; }
+  try { coordId = await getActiveCoordinatorId(supabase); } catch { coordId = null; }
+
+  const adam = adamId ? await store.getWorkingContext(supabase, adamId) : null;
+  const coord = coordId ? await store.getWorkingContext(supabase, coordId) : null;
+  const em = (s) => '\x1b[33m' + s + '\x1b[0m'; // yellow = waiting-on-other / STALE
+
+  console.log(wcLib.formatWorkingContext(adam, { label: 'Adam' + (adamId ? '' : ' (no session)'), em }));
+  console.log('');
+  console.log(wcLib.formatWorkingContext(coord, { label: 'Coordinator' + (coordId ? '' : ' (no session)'), em }));
+  console.log('');
+}
+
 // ── Section: Undelivered outbound + dead letters (FR-2/FR-4, SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001) ──
 // Receipt contract: read_at = DELIVERED, payload.actioned_at / acknowledged_at = ACTIONED.
 // This section closes the SENDER-side gap: outbound rows sitting UNREAD at a LIVE target
@@ -1425,6 +1455,7 @@ async function main() {
       await printDeadLetters();
     },
     adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
+    context:       async () => await printWorkingContext(), // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3)
     feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
     all:           async () => {
@@ -1441,6 +1472,7 @@ async function main() {
       await printUndeliveredOutbound(); // FR-2 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
+      await printWorkingContext(); // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3) — standing context dual-render
       await printFeedback(d); // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001 — feedback work-store
       await printCoaching(d);
       printHealth(d);
@@ -1453,7 +1485,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, feedback, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, context, feedback, team, all');
     process.exit(1);
   }
 

--- a/scripts/working-context.cjs
+++ b/scripts/working-context.cjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * working-context.cjs — SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-2)
+ *
+ * CLI for an operator session (Adam or coordinator) to maintain its standing working_context —
+ * the continuously-current LIST of its concurrent workstreams that the OTHER operator reads, so
+ * neither mistakes heads-down silence for being ignored. Mutations build the next context via the
+ * pure lib/coordinator/working-context.cjs and persist it through the atomic RPC writer
+ * (lib/coordinator/working-context-store.cjs) — never a JS read-modify-write.
+ *
+ * Usage:
+ *   node scripts/working-context.cjs show [--all]                  # render self (or both operators)
+ *   node scripts/working-context.cjs set "<what>" --state <state>  # upsert a thread (self)
+ *   node scripts/working-context.cjs done "<what>"                 # mark a thread done + prune (self)
+ *   node scripts/working-context.cjs cancel "<what>"               # mark a thread cancelled + prune (self)
+ *   node scripts/working-context.cjs prune                         # prune closed/aged threads (self)
+ *   node scripts/working-context.cjs refresh                       # prune + re-stamp freshness (self)
+ *
+ * State strings accept the live free-form vocabulary (active | monitoring | waiting-on-coordinator |
+ * blocked-on-chairman | done | cancelled, ...); the library normalizes them to the canonical lifecycle.
+ */
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
+const store = require('../lib/coordinator/working-context-store.cjs');
+const wc = require('../lib/coordinator/working-context.cjs');
+
+function emHighlight(s) { return '\x1b[33m' + s + '\x1b[0m'; } // yellow = waiting-on-other / STALE
+
+function arg(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? (process.argv[i + 1] || null) : null;
+}
+
+async function loadAndWrite(supabase, sessionId, mutate) {
+  const current = await store.getWorkingContext(supabase, sessionId);
+  const next = mutate(current);
+  const res = await store.writeWorkingContext(supabase, sessionId, next);
+  if (!res.persisted) console.warn(res.warn || `[working-context] not persisted: ${res.reason}${res.error ? ' — ' + res.error : ''}`);
+  else console.log('[working-context] persisted.');
+  console.log(wc.formatWorkingContext(next, { label: 'working context (you)', em: emHighlight }));
+  return res;
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  let supabase;
+  try { supabase = createSupabaseServiceClient(); }
+  catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+
+  if (cmd === 'show') {
+    const all = process.argv.includes('--all');
+    if (all) {
+      const adamId = await resolveAdamSessionId(supabase).catch(() => null);
+      const coordId = await getActiveCoordinatorId(supabase).catch(() => null);
+      const adam = adamId ? await store.getWorkingContext(supabase, adamId) : null;
+      const coord = coordId ? await store.getWorkingContext(supabase, coordId) : null;
+      console.log(wc.formatWorkingContext(adam, { label: `Adam (${adamId || 'no session'})`, em: emHighlight }));
+      console.log('');
+      console.log(wc.formatWorkingContext(coord, { label: `Coordinator (${coordId || 'no session'})`, em: emHighlight }));
+      return;
+    }
+    const sessionId = process.env.CLAUDE_SESSION_ID;
+    if (!sessionId) { console.error('ERROR: CLAUDE_SESSION_ID required for self show (use --all to view both operators).'); process.exit(1); }
+    const ctx = await store.getWorkingContext(supabase, sessionId);
+    console.log(wc.formatWorkingContext(ctx, { label: 'working context (you)', em: emHighlight }));
+    return;
+  }
+
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) { console.error('ERROR: CLAUDE_SESSION_ID required (mutations write your own session).'); process.exit(1); }
+
+  if (cmd === 'set') {
+    const what = process.argv[3];
+    const state = arg('--state') || 'active';
+    if (!what || what.startsWith('--')) { console.error('Usage: working-context.cjs set "<what>" --state <state>'); process.exit(2); }
+    await loadAndWrite(supabase, sessionId, (cur) => wc.upsertThread(cur, { what, state }));
+    return;
+  }
+  if (cmd === 'done' || cmd === 'cancel') {
+    const what = process.argv[3];
+    if (!what) { console.error(`Usage: working-context.cjs ${cmd} "<what>"`); process.exit(2); }
+    await loadAndWrite(supabase, sessionId, (cur) => wc.pruneThreads(wc.setThreadState(cur, what, cmd === 'done' ? 'done' : 'cancelled')));
+    return;
+  }
+  if (cmd === 'prune' || cmd === 'refresh') {
+    await loadAndWrite(supabase, sessionId, (cur) => {
+      const pruned = wc.pruneThreads(cur);
+      if (cmd === 'refresh') pruned.updated_at = new Date().toISOString(); // re-stamp freshness on the tick
+      return pruned;
+    });
+    return;
+  }
+
+  console.error('Usage: working-context.cjs show [--all] | set "<what>" --state <s> | done "<what>" | cancel "<what>" | prune | refresh');
+  process.exit(2);
+}
+
+if (require.main === module) {
+  main().catch((e) => { console.error('UNHANDLED:', e && e.message ? e.message : e); process.exit(1); });
+}
+
+module.exports = { main };

--- a/scripts/working-context.cjs
+++ b/scripts/working-context.cjs
@@ -85,11 +85,10 @@ async function main() {
     return;
   }
   if (cmd === 'prune' || cmd === 'refresh') {
-    await loadAndWrite(supabase, sessionId, (cur) => {
-      const pruned = wc.pruneThreads(cur);
-      if (cmd === 'refresh') pruned.updated_at = new Date().toISOString(); // re-stamp freshness on the tick
-      return pruned;
-    });
+    // Both prune closed/aged threads. updated_at is bumped by pruneThreads ONLY when a real change
+    // occurred (a thread was actually closed) — neither command force-stamps freshness, so a tick
+    // with no real change never advertises false currency (a stale context misleads worse than none).
+    await loadAndWrite(supabase, sessionId, (cur) => wc.pruneThreads(cur));
     return;
   }
 

--- a/tests/unit/coordination/adam-advisory-full-lane.test.js
+++ b/tests/unit/coordination/adam-advisory-full-lane.test.js
@@ -1,0 +1,62 @@
+// SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-4/FR-5) — drainReplies full-lane reader.
+// Hermetic: stubs the supabase query/update chain. Proves the reader queries the FULL reply lane
+// (coordinator_reply OR any payload.reply_to) and consumes every surfaced row exactly once.
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { drainReplies } = require('../../../scripts/adam-advisory.cjs');
+
+function stub(rows) {
+  const captured = { orArg: null, updatedIds: null };
+  const selectChain = {
+    select() { return selectChain; },
+    eq() { return selectChain; },
+    or(expr) { captured.orArg = expr; return selectChain; },
+    is() { return selectChain; },
+    order() { return selectChain; },
+    limit() { return Promise.resolve({ data: rows, error: null }); },
+  };
+  const updateChain = {
+    update() { return updateChain; },
+    in(_col, ids) { captured.updatedIds = ids; return updateChain; },
+    is() { return Promise.resolve({ error: null }); },
+  };
+  const supabase = {
+    from() {
+      // First call in drainReplies is the SELECT; the second is the UPDATE. Distinguish by
+      // returning a proxy that supports both shapes (select* and update*).
+      return new Proxy({}, {
+        get(_t, prop) {
+          if (prop in selectChain) return selectChain[prop];
+          if (prop in updateChain) return updateChain[prop];
+          return undefined;
+        },
+      });
+    },
+  };
+  return { supabase, captured };
+}
+
+describe('drainReplies (FR-4 full-lane)', () => {
+  it('queries coordinator_reply OR any payload.reply_to, and consumes every surfaced row once', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const rows = [
+      { id: 'r1', payload: { kind: 'coordinator_reply', reply_to: 'corr-1', body: 'classic reply' }, created_at: new Date().toISOString() },
+      { id: 'r2', payload: { kind: 'chairman_directive', reply_to: 'corr-2', body: 'reply under a different kind' }, created_at: new Date().toISOString() },
+    ];
+    const { supabase, captured } = stub(rows);
+    await drainReplies(supabase, 'adam-session');
+    expect(captured.orArg).toBe('payload->>kind.eq.coordinator_reply,payload->>reply_to.not.is.null');
+    expect(captured.updatedIds).toEqual(['r1', 'r2']); // both surfaced rows consumed
+    logSpy.mockRestore();
+  });
+
+  it('reports cleanly when there are no unread directed replies', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { supabase, captured } = stub([]);
+    await drainReplies(supabase, 'adam-session');
+    expect(captured.updatedIds).toBeNull(); // nothing consumed
+    expect(logSpy).toHaveBeenCalledWith('(no unread directed replies)');
+    logSpy.mockRestore();
+  });
+});

--- a/tests/unit/coordination/adam-advisory-full-lane.test.js
+++ b/tests/unit/coordination/adam-advisory-full-lane.test.js
@@ -1,18 +1,38 @@
 // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-4/FR-5) — drainReplies full-lane reader.
-// Hermetic: stubs the supabase query/update chain. Proves the reader queries the FULL reply lane
-// (coordinator_reply OR any payload.reply_to) and consumes every surfaced row exactly once.
+// The reader fetches THIS session's unread rows with AND-only filters (target_session + read_at
+// IS NULL) and selects the reply lane IN JS via isReplyRow. These tests exercise the REAL filter
+// logic (isReplyRow) + the fetch/consume flow — not a brittle PostgREST .or() string (the prior
+// version stubbed an .or() that never executed, which let an invalid query pass green).
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { drainReplies } = require('../../../scripts/adam-advisory.cjs');
+const { drainReplies, isReplyRow } = require('../../../scripts/adam-advisory.cjs');
 
+describe('isReplyRow (FR-4 reply-lane predicate)', () => {
+  it('matches coordinator_reply and any row carrying a payload.reply_to correlation', () => {
+    expect(isReplyRow({ payload: { kind: 'coordinator_reply' } })).toBe(true);
+    expect(isReplyRow({ payload: { kind: 'chairman_directive', reply_to: 'corr-2' } })).toBe(true);
+    expect(isReplyRow({ payload: { kind: 'coordinator_request', reply_to: 'corr-3' } })).toBe(true);
+  });
+  it('does NOT match non-reply rows (lane separation)', () => {
+    expect(isReplyRow({ payload: { kind: 'adam_advisory' } })).toBe(false);          // an outbound advisory shape
+    expect(isReplyRow({ payload: { kind: 'work_assignment' } })).toBe(false);        // a directive, not a reply
+    expect(isReplyRow({ payload: { kind: 'coordinator_request', reply_to: '' } })).toBe(false); // empty correlation
+    expect(isReplyRow({ payload: {} })).toBe(false);
+    expect(isReplyRow({})).toBe(false);
+    expect(isReplyRow(null)).toBe(false);
+  });
+});
+
+// Stub the supabase query/update chain. The SELECT uses AND-only filters (NO .or()), and the
+// chain captures the eq/is filters so we can PROVE lane scoping is applied, plus the consumed ids.
 function stub(rows) {
-  const captured = { orArg: null, updatedIds: null };
+  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false };
   const selectChain = {
     select() { return selectChain; },
-    eq() { return selectChain; },
-    or(expr) { captured.orArg = expr; return selectChain; },
-    is() { return selectChain; },
+    eq(col, val) { captured.eq[col] = val; return selectChain; },
+    or() { captured.usedOr = true; return selectChain; },
+    is(col) { captured.isNull.push(col); return selectChain; },
     order() { return selectChain; },
     limit() { return Promise.resolve({ data: rows, error: null }); },
   };
@@ -23,8 +43,6 @@ function stub(rows) {
   };
   const supabase = {
     from() {
-      // First call in drainReplies is the SELECT; the second is the UPDATE. Distinguish by
-      // returning a proxy that supports both shapes (select* and update*).
       return new Proxy({}, {
         get(_t, prop) {
           if (prop in selectChain) return selectChain[prop];
@@ -37,25 +55,28 @@ function stub(rows) {
   return { supabase, captured };
 }
 
-describe('drainReplies (FR-4 full-lane)', () => {
-  it('queries coordinator_reply OR any payload.reply_to, and consumes every surfaced row once', async () => {
+describe('drainReplies (FR-4 full-lane, AND-only query + JS filter)', () => {
+  it('scopes to target_session + read_at IS NULL, surfaces only reply rows, consumes them once', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const rows = [
       { id: 'r1', payload: { kind: 'coordinator_reply', reply_to: 'corr-1', body: 'classic reply' }, created_at: new Date().toISOString() },
-      { id: 'r2', payload: { kind: 'chairman_directive', reply_to: 'corr-2', body: 'reply under a different kind' }, created_at: new Date().toISOString() },
+      { id: 'r2', payload: { kind: 'chairman_directive', reply_to: 'corr-2', body: 'reply under another kind' }, created_at: new Date().toISOString() },
+      { id: 'r3', payload: { kind: 'work_assignment', body: 'a directive, NOT a reply' }, created_at: new Date().toISOString() },
     ];
     const { supabase, captured } = stub(rows);
     await drainReplies(supabase, 'adam-session');
-    expect(captured.orArg).toBe('payload->>kind.eq.coordinator_reply,payload->>reply_to.not.is.null');
-    expect(captured.updatedIds).toEqual(['r1', 'r2']); // both surfaced rows consumed
+    expect(captured.eq.target_session).toBe('adam-session'); // lane scoped by the AND-only query
+    expect(captured.isNull).toContain('read_at');
+    expect(captured.usedOr).toBe(false);                      // no brittle PostgREST .or()
+    expect(captured.updatedIds).toEqual(['r1', 'r2']);        // only the two reply rows consumed; r3 left alone
     logSpy.mockRestore();
   });
 
   it('reports cleanly when there are no unread directed replies', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const { supabase, captured } = stub([]);
+    const { supabase, captured } = stub([{ id: 'x', payload: { kind: 'work_assignment' }, created_at: new Date().toISOString() }]);
     await drainReplies(supabase, 'adam-session');
-    expect(captured.updatedIds).toBeNull(); // nothing consumed
+    expect(captured.updatedIds).toBeNull(); // nothing reply-shaped -> nothing consumed
     expect(logSpy).toHaveBeenCalledWith('(no unread directed replies)');
     logSpy.mockRestore();
   });

--- a/tests/unit/coordination/working-context.test.js
+++ b/tests/unit/coordination/working-context.test.js
@@ -45,8 +45,10 @@ describe('normalizeState (canonical lifecycle + waiting-on party)', () => {
     expect(normalizeState('cancelled')).toEqual({ state: 'cancelled' });
     expect(normalizeState('active')).toEqual({ state: 'active' });
   });
-  it('honest default: unknown/empty states resolve to active (kept VISIBLE, never auto-pruned)', () => {
-    expect(normalizeState('something weird')).toEqual({ state: 'active' });
+  it('honest default: unknown states resolve to active but PRESERVE the original (raw_state) for audit', () => {
+    expect(normalizeState('something weird')).toEqual({ state: 'active', raw_state: 'something weird' });
+    expect(normalizeState('  Paused  ')).toEqual({ state: 'active', raw_state: 'Paused' }); // original case kept
+    // empty/null/undefined carry NO raw_state (nothing to preserve)
     expect(normalizeState('')).toEqual({ state: 'active' });
     expect(normalizeState(null)).toEqual({ state: 'active' });
     expect(normalizeState(undefined)).toEqual({ state: 'active' });
@@ -77,6 +79,26 @@ describe('normalizeThread / normalizeWorkingContext (backward-compatible, never 
     const t = normalizeThread({ what: 'x', state: 'active', waiting_on: 'coordinator' });
     expect(t.waiting_on).toBeUndefined();
   });
+  it('accepts alternate name fields before dropping a thread (reduces silent loss)', () => {
+    expect(normalizeThread({ description: 'desc-named', state: 'active' }).what).toBe('desc-named');
+    expect(normalizeThread({ title: 'title-named' }).what).toBe('title-named');
+    expect(normalizeThread({ name: 'name-named' }).what).toBe('name-named');
+  });
+  it('coerceSince: preserves string, converts number/Date to ISO, never silently drops a timestamp', () => {
+    const ms = Date.parse('2026-06-15T10:00:00.000Z');
+    expect(normalizeThread({ what: 'a', since: '2026-06-15T10:00:00.000Z' }).since).toBe('2026-06-15T10:00:00.000Z');
+    expect(normalizeThread({ what: 'a', since: ms }).since).toBe('2026-06-15T10:00:00.000Z');
+    expect(normalizeThread({ what: 'a', since: new Date(ms) }).since).toBe('2026-06-15T10:00:00.000Z');
+    expect(normalizeThread({ what: 'a' }).since).toBeNull(); // genuinely absent -> null (not fabricated)
+  });
+  it('preserves unknown top-level keys (staleness_rule) across the normalize cycle', () => {
+    const norm = normalizeWorkingContext(liveBlob());
+    expect(norm.staleness_rule).toBe('if updated_at > ~30min old, treat as STALE'); // not dropped
+  });
+  it('keeps a recently_closed entry that has `at` even if `what` is non-string', () => {
+    const norm = normalizeWorkingContext({ recently_closed: [{ at: new Date(T0).toISOString(), state: 'done' }, { foo: 'bar' }] });
+    expect(norm.recently_closed).toHaveLength(1); // the dated one survives; the shapeless one is dropped
+  });
 });
 
 describe('isStale (currency-over-staleness)', () => {
@@ -84,6 +106,15 @@ describe('isStale (currency-over-staleness)', () => {
     const wc = { updated_at: new Date(T0).toISOString() };
     expect(isStale(wc, T0 + STALE_THRESHOLD_MS - 1)).toBe(false);
     expect(isStale(wc, T0 + STALE_THRESHOLD_MS + 1)).toBe(true);
+  });
+  it('boundary: exactly at the threshold is still fresh (> not >=)', () => {
+    const wc = { updated_at: new Date(T0).toISOString() };
+    expect(isStale(wc, T0 + STALE_THRESHOLD_MS)).toBe(false);
+    expect(isStale(wc, T0 + STALE_THRESHOLD_MS + 1)).toBe(true);
+  });
+  it('future-dated beyond clock-skew tolerance => stale (a future timestamp must NOT read as fresh)', () => {
+    expect(isStale({ updated_at: new Date(T0 + 60_000).toISOString() }, T0)).toBe(false); // 1m future within tolerance
+    expect(isStale({ updated_at: new Date(T0 + 60 * 60_000).toISOString() }, T0)).toBe(true); // 1h future => unreliable
   });
   it('missing/garbage updated_at => stale (treat as unreliable)', () => {
     expect(isStale({}, T0)).toBe(true);
@@ -179,6 +210,11 @@ describe('formatWorkingContext (single-source display)', () => {
   it('shows a STALE banner past the threshold', () => {
     const out = formatWorkingContext(liveBlob(), { nowMs: T0 + STALE_THRESHOLD_MS + 60_000 });
     expect(out).toMatch(/STALE \(\d+m old — re-derive before trusting\)/);
+  });
+  it('surfaces an unrecognized raw state (never hides intent)', () => {
+    const wc = { threads: [{ what: 'odd thread', state: 'paused-indefinitely' }], updated_at: new Date(T0).toISOString() };
+    const out = formatWorkingContext(wc, { nowMs: T0 });
+    expect(out).toMatch(/\[active\] odd thread \(raw: "paused-indefinitely"\)/);
   });
   it('never throws on null/garbage', () => {
     expect(formatWorkingContext(null)).toMatch(/\(none\)/);

--- a/tests/unit/coordination/working-context.test.js
+++ b/tests/unit/coordination/working-context.test.js
@@ -1,0 +1,246 @@
+// SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-1/FR-5) — working_context library tests.
+// Hermetic: no live DB, no real time (nowMs injected). Validates the canonical-lifecycle
+// normalization (backward-compatible with the live hand-maintained blob), pruning, staleness,
+// auto-derivation, and the single-source display formatter.
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_STATES,
+  STALE_THRESHOLD_MS,
+  RECENTLY_CLOSED_TTL_MS,
+  normalizeState,
+  normalizeThread,
+  normalizeWorkingContext,
+  isStale,
+  upsertThread,
+  setThreadState,
+  pruneThreads,
+  deriveThreadState,
+  formatWorkingContext,
+} from '../../../lib/coordinator/working-context.cjs';
+import { getWorkingContext, writeWorkingContext, isMissingFunctionError } from '../../../lib/coordinator/working-context-store.cjs';
+
+const T0 = Date.parse('2026-06-15T12:00:00.000Z');
+
+// Mirrors the live blob on session f808779a (free-form states the library must normalize).
+function liveBlob() {
+  return {
+    mode: 'support',
+    threads: [
+      { what: 'recurring ticks', state: 'active' },
+      { what: 'CronGenius Stage-19 refresh', state: 'waiting-on-coordinator' },
+      { what: 'session-sourced SDs tracking', state: 'monitoring' },
+    ],
+    updated_at: new Date(T0).toISOString(),
+    staleness_rule: 'if updated_at > ~30min old, treat as STALE',
+    recently_closed: [{ at: new Date(T0 - 60_000).toISOString(), what: 'migration canary', state: 'done-7/7' }],
+  };
+}
+
+describe('normalizeState (canonical lifecycle + waiting-on party)', () => {
+  it('maps the live free-form vocabulary onto canonical states', () => {
+    expect(normalizeState('waiting-on-coordinator')).toEqual({ state: 'waiting', waiting_on: 'coordinator' });
+    expect(normalizeState('blocked-on-chairman')).toEqual({ state: 'blocked', waiting_on: 'chairman' });
+    expect(normalizeState('monitoring')).toEqual({ state: 'active' });
+    expect(normalizeState('done-7/7')).toEqual({ state: 'done' });
+    expect(normalizeState('cancelled')).toEqual({ state: 'cancelled' });
+    expect(normalizeState('active')).toEqual({ state: 'active' });
+  });
+  it('honest default: unknown/empty states resolve to active (kept VISIBLE, never auto-pruned)', () => {
+    expect(normalizeState('something weird')).toEqual({ state: 'active' });
+    expect(normalizeState('')).toEqual({ state: 'active' });
+    expect(normalizeState(null)).toEqual({ state: 'active' });
+    expect(normalizeState(undefined)).toEqual({ state: 'active' });
+  });
+  it('every produced state is in the canonical set', () => {
+    for (const raw of ['waiting-on-x', 'blocked', 'done', 'cancelled', 'wip', 'garbage']) {
+      expect(CANONICAL_STATES).toContain(normalizeState(raw).state);
+    }
+  });
+});
+
+describe('normalizeThread / normalizeWorkingContext (backward-compatible, never throws)', () => {
+  it('normalizes the live blob without clobbering it', () => {
+    const norm = normalizeWorkingContext(liveBlob());
+    expect(norm.threads).toHaveLength(3);
+    expect(norm.threads[1]).toMatchObject({ what: 'CronGenius Stage-19 refresh', state: 'waiting', waiting_on: 'coordinator' });
+    expect(norm.threads[2]).toMatchObject({ what: 'session-sourced SDs tracking', state: 'active' }); // monitoring -> active
+    expect(norm.mode).toBe('support');
+    expect(norm.recently_closed).toHaveLength(1);
+  });
+  it('drops threads with no usable `what` and tolerates garbage input', () => {
+    expect(normalizeThread({ state: 'active' })).toBeNull();
+    expect(normalizeThread(null)).toBeNull();
+    expect(normalizeWorkingContext(null)).toEqual({ mode: null, threads: [], recently_closed: [], updated_at: null });
+    expect(normalizeWorkingContext([1, 2, 3]).threads).toEqual([]);
+  });
+  it('waiting_on is only attached to waiting/blocked states', () => {
+    const t = normalizeThread({ what: 'x', state: 'active', waiting_on: 'coordinator' });
+    expect(t.waiting_on).toBeUndefined();
+  });
+});
+
+describe('isStale (currency-over-staleness)', () => {
+  it('false within threshold, true past it', () => {
+    const wc = { updated_at: new Date(T0).toISOString() };
+    expect(isStale(wc, T0 + STALE_THRESHOLD_MS - 1)).toBe(false);
+    expect(isStale(wc, T0 + STALE_THRESHOLD_MS + 1)).toBe(true);
+  });
+  it('missing/garbage updated_at => stale (treat as unreliable)', () => {
+    expect(isStale({}, T0)).toBe(true);
+    expect(isStale({ updated_at: 'not-a-date' }, T0)).toBe(true);
+    expect(isStale(null, T0)).toBe(true);
+  });
+});
+
+describe('upsertThread / setThreadState (immutable, bumps updated_at)', () => {
+  it('upserts a new thread with since=now and bumps updated_at', () => {
+    const wc = upsertThread(liveBlob(), { what: 'new thread', state: 'active' }, T0 + 1000);
+    expect(wc.threads.find((t) => t.what === 'new thread')).toMatchObject({ state: 'active', since: new Date(T0 + 1000).toISOString() });
+    expect(wc.updated_at).toBe(new Date(T0 + 1000).toISOString());
+  });
+  it('upsert of an existing thread updates state, preserves original since', () => {
+    const base = upsertThread({}, { what: 'a', state: 'active', since: new Date(T0).toISOString() }, T0);
+    const wc = upsertThread(base, { what: 'a', state: 'blocked' }, T0 + 5000);
+    const t = wc.threads.find((x) => x.what === 'a');
+    expect(t.state).toBe('blocked');
+    expect(t.since).toBe(new Date(T0).toISOString());
+  });
+  it('setThreadState transitions state and clears waiting_on when leaving a waiting state', () => {
+    const base = upsertThread({}, { what: 'a', state: 'waiting-on-coordinator' }, T0);
+    expect(base.threads[0].waiting_on).toBe('coordinator');
+    const done = setThreadState(base, 'a', 'done', T0 + 1000);
+    expect(done.threads[0].state).toBe('done');
+    expect(done.threads[0].waiting_on).toBeUndefined();
+  });
+  it('setThreadState upserts when the thread is absent', () => {
+    const wc = setThreadState({}, 'brand new', 'waiting-on-chairman', T0);
+    expect(wc.threads[0]).toMatchObject({ what: 'brand new', state: 'waiting', waiting_on: 'chairman' });
+  });
+});
+
+describe('pruneThreads (close + age-out, honest freshness)', () => {
+  it('moves done|cancelled threads into recently_closed and keeps only open threads', () => {
+    let wc = upsertThread({}, { what: 'open', state: 'active' }, T0);
+    wc = upsertThread(wc, { what: 'finished', state: 'done' }, T0);
+    wc = upsertThread(wc, { what: 'dropped', state: 'cancelled' }, T0);
+    const pruned = pruneThreads(wc, T0 + 2000);
+    expect(pruned.threads.map((t) => t.what)).toEqual(['open']);
+    expect(pruned.recently_closed.map((r) => r.what).sort()).toEqual(['dropped', 'finished']);
+    expect(pruned.updated_at).toBe(new Date(T0 + 2000).toISOString()); // real change bumps freshness
+  });
+  it('ages out recently_closed entries older than the TTL', () => {
+    const wc = {
+      threads: [],
+      recently_closed: [
+        { at: new Date(T0 - RECENTLY_CLOSED_TTL_MS - 1000).toISOString(), what: 'old', state: 'done' },
+        { at: new Date(T0 - 1000).toISOString(), what: 'recent', state: 'done' },
+      ],
+      updated_at: new Date(T0).toISOString(),
+    };
+    const pruned = pruneThreads(wc, T0);
+    expect(pruned.recently_closed.map((r) => r.what)).toEqual(['recent']);
+  });
+  it('pure age-out (no thread closed) does NOT bump updated_at (no false freshness)', () => {
+    const wc = { threads: [{ what: 'open', state: 'active' }], recently_closed: [], updated_at: new Date(T0).toISOString() };
+    const pruned = pruneThreads(wc, T0 + 999_999);
+    expect(pruned.updated_at).toBe(new Date(T0).toISOString());
+  });
+});
+
+describe('deriveThreadState (auto-derive from live signals)', () => {
+  it('derives from SD status', () => {
+    const t = { what: 'x', state: 'active' };
+    expect(deriveThreadState(t, { sdStatus: 'completed' })).toBe('done');
+    expect(deriveThreadState(t, { sdStatus: 'blocked' })).toBe('blocked');
+    expect(deriveThreadState(t, { sdStatus: 'in_progress' })).toBe('active');
+    expect(deriveThreadState(t, { sdStatus: 'deferred' })).toBe('cancelled');
+  });
+  it('derives from advisory ack and claim state', () => {
+    expect(deriveThreadState({ what: 'x', state: 'waiting' }, { advisoryAcked: true })).toBe('active');
+    expect(deriveThreadState({ what: 'x', state: 'active' }, { claimActive: false })).toBe('done');
+  });
+  it('returns null when no signal maps (manual thread left untouched)', () => {
+    expect(deriveThreadState({ what: 'x', state: 'active' }, {})).toBeNull();
+    expect(deriveThreadState({ what: 'x', state: 'active' }, { sdStatus: 'mystery' })).toBeNull();
+    expect(deriveThreadState(null, { sdStatus: 'completed' })).toBeNull();
+  });
+});
+
+describe('formatWorkingContext (single-source display)', () => {
+  it('renders threads, highlights waiting-on-other, marks fresh', () => {
+    const marks = [];
+    const out = formatWorkingContext(liveBlob(), { nowMs: T0 + 60_000, label: 'Adam', em: (s) => { marks.push(s); return `*${s}*`; } });
+    expect(out).toMatch(/Adam — 3 open thread/);
+    expect(out).toMatch(/fresh \(1m\)/);
+    expect(out).toMatch(/\[waiting-on-coordinator\] CronGenius/);
+    // the waiting-on-other line was passed through the emphasis fn
+    expect(marks.some((m) => /waiting-on-coordinator/.test(m))).toBe(true);
+  });
+  it('shows a STALE banner past the threshold', () => {
+    const out = formatWorkingContext(liveBlob(), { nowMs: T0 + STALE_THRESHOLD_MS + 60_000 });
+    expect(out).toMatch(/STALE \(\d+m old — re-derive before trusting\)/);
+  });
+  it('never throws on null/garbage', () => {
+    expect(formatWorkingContext(null)).toMatch(/\(none\)/);
+    expect(formatWorkingContext([1, 2])).toMatch(/\(none\)/);
+    expect(() => formatWorkingContext({ threads: 'bad' }, { nowMs: T0 })).not.toThrow();
+  });
+});
+
+// FR-2 store: atomic-RPC writer with fail-soft. The stub records every call so we can PROVE
+// the writer never performs a JS read-modify-write (.from().update()) fallback.
+function storeStub({ rpcResult } = {}) {
+  const calls = { rpc: [], from: [], update: 0 };
+  return {
+    calls,
+    rpc(fn, args) { calls.rpc.push({ fn, args }); return Promise.resolve(rpcResult || { error: null }); },
+    from(table) {
+      calls.from.push(table);
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        maybeSingle() { return Promise.resolve({ data: { metadata: { working_context: { mode: 'support', threads: [{ what: 'x', state: 'monitoring' }], updated_at: new Date(T0).toISOString() } } }, error: null }); },
+        update() { calls.update += 1; return chain; },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('working-context-store (FR-2 atomic writer, fail-soft, NO RMW)', () => {
+  it('writeWorkingContext persists via the RPC and never issues a metadata update (RMW)', async () => {
+    const sb = storeStub({ rpcResult: { error: null } });
+    const r = await writeWorkingContext(sb, 'sess-1', { threads: [], updated_at: new Date(T0).toISOString() });
+    expect(r.persisted).toBe(true);
+    expect(sb.calls.rpc).toHaveLength(1);
+    expect(sb.calls.rpc[0].fn).toBe('set_session_working_context');
+    expect(sb.calls.rpc[0].args).toMatchObject({ p_session_id: 'sess-1' });
+    expect(sb.calls.update).toBe(0); // NEVER a read-modify-write
+  });
+  it('fail-softs (rpc_absent) when the migration is unapplied — still no RMW', async () => {
+    const sb = storeStub({ rpcResult: { error: { code: 'PGRST202', message: 'Could not find the function set_session_working_context' } } });
+    const r = await writeWorkingContext(sb, 'sess-1', {});
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toBe('rpc_absent');
+    expect(r.warn).toMatch(/persistence pending/i);
+    expect(sb.calls.update).toBe(0);
+  });
+  it('surfaces other DB errors without crashing or RMW', async () => {
+    const sb = storeStub({ rpcResult: { error: { code: '500', message: 'boom' } } });
+    const r = await writeWorkingContext(sb, 'sess-1', {});
+    expect(r.persisted).toBe(false);
+    expect(r.reason).toBe('error');
+    expect(sb.calls.update).toBe(0);
+  });
+  it('getWorkingContext reads + normalizes metadata.working_context', async () => {
+    const sb = storeStub();
+    const wc = await getWorkingContext(sb, 'sess-1');
+    expect(wc.threads[0]).toMatchObject({ what: 'x', state: 'active' }); // monitoring -> active
+  });
+  it('isMissingFunctionError recognizes 42883 and PGRST202', () => {
+    expect(isMissingFunctionError({ code: '42883' })).toBe(true);
+    expect(isMissingFunctionError({ code: 'PGRST202' })).toBe(true);
+    expect(isMissingFunctionError({ code: '23505' })).toBe(false);
+    expect(isMissingFunctionError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 — Adam↔coordinator interface hardening

Child D of SD-LEO-INFRA-ADAM-AUTONOMY-HARDENING-001 (D6 close-loops/ACK dimension).

### Re-scope after LEAD VALIDATION (convergent-work guard)
A LEAD VALIDATION pass (`sub_agent_execution_results` row `459dc65f`) found the SD's **original** auto-ack + two-stage-ACK goals were **already delivered** and must not be rebuilt:
- **QF-20260610-623** (PR #4533, commit `b7dfd42`): the `amAdam` all-message-types auto-ack carve-out (`coordination-inbox.cjs:141-143`), the read-but-unacked monitor (`read-adam-directives.cjs`), and a COACHING test.
- The read→actioned two-stage ACK already exists as the **`payload.actioned_at` JSONB contract** (`coordinator-ack-adam.cjs`, `adam-action-ack.cjs`, `read-adam-advisories.cjs`).

So this PR **verifies (does not rebuild)** those and ships the genuine remaining work; the redundant `(new)_two_stage_ack.sql` from the SD scope was dropped (`actioned_at` is JSONB by design).

### What ships
- **FR-1** `lib/coordinator/working-context.cjs` — pure canonical thread-lifecycle library for the chairman-directed `working_context` standing context: states `active|waiting|blocked|done|cancelled` + `waiting_on` (the highest-value "waiting-on-the-other-party" signal); normalizes the live hand-maintained blob; prunes done/cancelled → `recently_closed` + age-out; `isStale` (>30 min, and future-skew); `deriveThreadState` (SD status / advisory ack / claim); single-source `formatWorkingContext`.
- **FR-2** atomic write path — `database/migrations/20260615_set_session_working_context.sql` (chairman-gated SECURITY DEFINER RPC, `metadata || jsonb_build_object`, in-migration verify) + `working-context-store.cjs` (RPC writer, **fail-soft** when unapplied, never a JS read-modify-write) + `scripts/working-context.cjs` CLI.
- **FR-3** `scripts/fleet-dashboard.cjs` — dual-render of both operators' `working_context` (`context` section + in `all`), waiting-on-other highlighted, staleness flagged.
- **FR-4** (narrowed) `scripts/adam-advisory.cjs` `drainReplies` — full reply lane (coordinator_reply OR any `payload.reply_to`); closes the reply-only blindspot.
- **FR-5** 37 hermetic tests.

### Adversarial review
A 55-agent review (20 findings) caught a **CRITICAL the 28 original green tests missed**: an invalid/ambiguous PostgREST `.or('…reply_to.not.is.null')` (the hermetic stub never executed it). Rewritten to an AND-only unread fetch + JS `isReplyRow` filter (guarantees lane separation, moots the precedence question, and is now genuinely test-exercised). Also fixed: `isStale` future-skew honesty, `refresh` false-freshness, `since`/`staleness_rule`/`recently_closed` data-loss on normalize, and the dashboard suppress-hash regression from per-minute age strings.

### Verification
- 96/96 tests green (37 new + 59 regression); `schema:lint` 0 violations; TESTING evidence row `ad6befd1` (PASS, confidence 98).
- Live read-only smoke: Adam's real blob (session `f808779a`) renders normalized, `waiting-on-coordinator` highlighted, STALE flagged.

### Chairman-gated / deferred
- `20260615_set_session_working_context.sql` is **not applied** (no `@approved-by`); the writer fail-softs until the chairman applies it (persistence dormant-but-safe). Reads work against the existing blob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
