### PR TITLE
feat(SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001): fail-closed migration TIER classifier + handoff-time auto-apply gate

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001.json
@@ -1,0 +1,91 @@
+{
+  "executive_summary": "A FAIL-CLOSED tiered migration risk classifier that lets the fleet stop parking trivially-safe additive migrations on the chairman gate, while keeping every destructive migration fully gated. A PURE allow-list DDL linter (scripts/lib/migration-tier-classifier.mjs) classifies a migration TIER-1 ONLY if every statement is provably additive (CREATE TABLE IF NOT EXISTS / CREATE INDEX / nullable ADD COLUMN with constant-or-no default / CREATE POLICY + ENABLE RLS / bare CREATE FUNCTION|VIEW with a non-destructive body); EVERYTHING else — destructive, multi-statement-ambiguous, unparseable, OR REPLACE, DO-block, unrecognized — defaults to TIER-2. TIER-1 auto-applies via the EXISTING handoff-time apply path (BaseExecutor._checkAndExecutePendingMigrations, env-gated); TIER-2 keeps the unchanged 3-factor @approved-by chairman gate (scripts/lib/migration-guards.js). Per auto-apply we log an audit row (file, classification, verdict, timestamp, inverse/drop rollback). The CLAUDE_CORE migration protocol section (leo_protocol_sections id=444) is updated + regenerated so every worker learns the policy. Built on the design grounding workflow (3-layer split, 16 fail-closed rules, 23-case adversarial corpus).",
+  "business_context": "scripts/lib/migration-guards.js applies one 3-factor chairman gate to EVERY prod migration — a trivial CREATE TABLE IF NOT EXISTS gets the same human gate as a destructive ALTER/DROP. That is friction without added safety and caused fleet-wide parked-migration toil (venture_db_secrets, venture_guardrail_state, etc.). The chairman asked whether workers can auto-apply migrations; the answer (established by SD-LEO-INFRA-MIGRATION-DEPLOY-DRIFT-001) is that BLIND auto-apply is unsafe — a flagged migration can be re-run-harmful or destructive. This SD delivers the safe middle: a strict allow-list prover that auto-applies ONLY provably-additive migrations and routes everything else (default-deny) to the preserved chairman gate. The safety rests entirely on the prover being airtight, so it is allow-list-only, multi-layer, and heavily adversarially tested.",
+  "technical_context": "Reuses (does NOT rebuild): the SQL-splitting + DDL-extraction primitives already in the repo — splitPostgreSQLStatements (scripts/lib/supabase-connection.js) and stripNonDdl/normalizeName/extractDdlFacts (scripts/verify-migration-apply-state.mjs); the auto-apply path BaseExecutor._checkAndExecutePendingMigrations() -> invokeDatabaseSubAgent (env-gated by LEO_MIGRATION_GATE_ENFORCE); the 3-factor guard scripts/lib/migration-guards.js (TIER-2, untouched). Known primitive gap compensated: splitPostgreSQLStatements does not track named dollar tags ($tag$) — the classifier adds a named-tag pre-check + a function-body deep-scan so a destructive body cannot mis-split into a false TIER-1. The CLAUDE_CORE migration section is leo_protocol_sections id=444 (section_type='migration_execution_protocol', target CLAUDE_CORE.md, publication_status='file'); regenerate via `npm run leo:generate` (full, no --only) and verify the [hash] console line.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Pure ALLOW-LIST DDL tier classifier (fail-closed, default-deny)",
+      "description": "CREATE scripts/lib/migration-tier-classifier.mjs exporting a PURE classifyMigration(sql) => {tier:1|2, reason, matched[]}. TIER-1 ONLY when EVERY statement matches an explicit allow rule: (A) CREATE TABLE IF NOT EXISTS (IF NOT EXISTS mandatory); (B) CREATE INDEX (incl CONCURRENTLY/UNIQUE/IF NOT EXISTS); (C) ALTER TABLE with ONLY additive nullable ADD COLUMN actions (no NOT NULL, no PK/UNIQUE/REFERENCES/GENERATED/CONSTRAINT inline, default constant-only); (D) CREATE POLICY or ALTER TABLE ENABLE ROW LEVEL SECURITY (only that ALTER form); (E) bare CREATE FUNCTION/VIEW/MATERIALIZED VIEW (NOT 'OR REPLACE') whose body contains no destructive SQL. Implements all 16 fail-closed rules (parse failure, unrecognized statement, multi-statement/under-split ambiguity, volatile/non-constant default, NOT NULL, DO block, function-body-destructive, OR REPLACE, non-additive ALTER, DROP/TRUNCATE/DELETE/UPDATE/RENAME/GRANT/REVOKE, CREATE TRIGGER, bare CREATE TABLE, empty/comment-only, parser-disagreement, SECURITY DEFINER/system-schema, any exception). 3-layer defense: Layer-1 splitPostgreSQLStatements per-statement allow-match; Layer-2 stripNonDdl whole-file forbidden-token sweep (excluding matched allow-heads); Layer-3 function-body deep-scan. TIER-1 requires ALL layers to agree; the function NEVER throws and NEVER returns tier:1 on an error path. Bound input size to avoid regex catastrophic-backtrack.",
+      "acceptance_criteria": [
+        "classifyMigration returns tier:1 ONLY for the provably-additive allow-list; every one of the 19 adversarial TIER-2 smuggle cases (DO-block DROP, drop-after-create, NOT NULL/volatile default, named-tag body DROP, comment/block-comment-hidden DROP, CREATE OR REPLACE, GRANT, RENAME, ALTER COLUMN TYPE, multi-action ALTER with a bad action, TRUNCATE obfuscated, CREATE TRIGGER, bare CREATE TABLE, DISABLE RLS, under-split blob) classifies tier:2.",
+        "The 4 clean additive cases (CREATE TABLE IF NOT EXISTS, CREATE INDEX CONCURRENTLY, nullable ADD COLUMN constant default, ENABLE RLS + CREATE POLICY, read-only CREATE VIEW) classify tier:1.",
+        "classifyMigration NEVER throws (try/catch => tier:2 on any error) and NEVER returns tier:1 on parse failure / unrecognized / ambiguity / non-string input.",
+        "The classifier is pure (no DB, no live-schema, no I/O) and reuses splitPostgreSQLStatements + stripNonDdl rather than re-rolling SQL parsing."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Gate the EXISTING auto-apply path on tier (reuse, do not rebuild)",
+      "description": "Wire classifyMigration into the existing handoff-time auto-apply path at scripts/modules/handoff/executors/BaseExecutor.js _checkAndExecutePendingMigrations() (and/or pending-migrations-check.js invokeDatabaseSubAgent): a pending migration is auto-applied ONLY when classifyMigration(sql).tier===1; a TIER-2 migration is NOT auto-executed — it is deferred with a clear log instructing `node scripts/apply-migration.js <path> --prod-deploy` (the unchanged 3-factor @approved-by chairman gate). Reuse the existing apply machinery + the LEO_MIGRATION_GATE_ENFORCE env gate; do NOT build new apply machinery and do NOT weaken migration-guards.js.",
+      "acceptance_criteria": [
+        "A TIER-1 pending migration is eligible for auto-apply via the existing path; a TIER-2 one is deferred to the manual --prod-deploy 3-factor gate (never auto-applied).",
+        "scripts/lib/migration-guards.js is unchanged (the TIER-2 3-factor @approved-by guard is preserved exactly).",
+        "No new apply machinery is introduced — the existing BaseExecutor/apply-migration path is reused."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Audit row per auto-applied (TIER-1) migration with rollback",
+      "description": "Every TIER-1 auto-apply logs an audit record: migration file, classification (tier + matched allow rules), the linter verdict/reason, timestamp, and the inverse/rollback statement (the DROP that undoes the additive create) for fast recovery. Reuse the existing audit store (schema_migrations_applied / system audit) where possible; fail-soft (audit failure must not crash the apply, but is logged).",
+      "acceptance_criteria": [
+        "An auto-applied TIER-1 migration produces an audit row capturing file, tier, matched rules, verdict, timestamp, and an inverse/drop rollback hint.",
+        "Audit writing is fail-soft (does not crash the apply path) and reuses an existing store, no new table required unless necessary."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Protocol update so the fleet learns the tiered policy",
+      "description": "Update leo_protocol_sections id=444 (section_type='migration_execution_protocol', CLAUDE_CORE.md) content to document the tiered policy: additive migrations on the TIER-1 allow-list auto-apply post-merge; ONLY destructive/ambiguous migrations carry the @approved-by chairman gate; default-deny when in doubt. Regenerate via `npm run leo:generate` (full) and verify the CLAUDE_CORE.md [hash] re-render. Mirror a concise pointer into the phase rows (LEAD id=449 / PLAN id=450 / EXEC) and the CORE digest mapping so phase- and digest-loading sessions also learn it.",
+      "acceptance_criteria": [
+        "leo_protocol_sections id=444 content documents the tiered policy (TIER-1 allow-list auto-applies; TIER-2 keeps @approved-by; default-deny).",
+        "CLAUDE_CORE.md is regenerated and contains the tiered policy (verified via the generator [hash] line, not skipped).",
+        "Workers reading CORE (and, via a pointer/mirror, the phase files) learn to stop parking provably-additive migrations."
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Tests + activation (the full adversarial corpus)",
+      "description": "CREATE a unit suite running classifyMigration against the full 23-case adversarial corpus (19 TIER-2 smuggle attempts + 4 TIER-1) + per-allow-rule real-splitPostgreSQLStatements integration assertions (mocked-green suites miss real-path edge bytes). Set product_requirements_v2.activation_test_id to the suite so GATE_ACTIVATION_INVARIANT proves a destructive migration cannot classify TIER-1 by default.",
+      "acceptance_criteria": [
+        "All 23 adversarial corpus cases assert the expected tier (every smuggle attempt => tier:2).",
+        "At least one real-splitPostgreSQLStatements integration assertion per allow rule (not just string-shape assertions).",
+        "All tests pass under the vitest unit project; PRD.activation_test_id set and the activation test passes."
+      ]
+    }
+  ],
+  "non_functional_requirements": [
+    {"id": "NFR-1", "title": "Fail-closed by construction", "description": "Allow-list only (never a deny-list); default-deny on any doubt; the classifier never throws and never returns tier:1 on an error/ambiguity path. A false tier:1 on a destructive migration is the catastrophe to prevent."},
+    {"id": "NFR-2", "title": "Preserve the chairman gate", "description": "The TIER-2 3-factor @approved-by prod-deploy guard (migration-guards.js) is unchanged; this SD only adds a tier gate in front of the EXISTING auto-apply path."},
+    {"id": "NFR-3", "title": "Pure + reuse", "description": "The classifier is a pure function reusing the repo's existing SQL-split/strip primitives; no new apply machinery."}
+  ],
+  "test_scenarios": [
+    {"id": "TS-1", "scenario": "classifier: 19 TIER-2 smuggle cases all => tier:2; 4 clean additive => tier:1; never-throws on bad input"},
+    {"id": "TS-2", "scenario": "auto-apply gate: TIER-1 eligible for the existing auto-apply path; TIER-2 deferred to --prod-deploy 3-factor gate"},
+    {"id": "TS-3", "scenario": "protocol: CLAUDE_CORE.md regenerated with the tiered policy ([hash] re-render confirmed)"}
+  ],
+  "acceptance_criteria": [
+    "A pure fail-closed allow-list tier classifier that classifies only provably-additive migrations TIER-1 and defaults everything else to TIER-2 (23-case adversarial corpus green).",
+    "TIER-1 auto-applies via the existing path; TIER-2 keeps the unchanged 3-factor chairman gate.",
+    "Audit row per auto-apply with rollback; CLAUDE_CORE protocol section updated + regenerated so the fleet learns.",
+    "Tests + PRD.activation_test_id set."
+  ],
+  "risks": [
+    {"risk": "A false TIER-1 verdict auto-applies a destructive migration (catastrophic)", "severity": "high", "mitigation": "Allow-list-only + 16 fail-closed rules + 3-layer split agreement + default-deny + a dedicated adversarial-review lens whose only job is to smuggle a destructive migration past the classifier; the full 23-case corpus must be green."},
+    {"risk": "Named dollar-tag function body mis-splits and a fragment matches an allow head", "severity": "high", "mitigation": "Named-tag pre-check (unbalanced => TIER-2) + function-body deep-scan (Rule E / FC-7); preserved as a hard requirement."},
+    {"risk": "Weakening the chairman gate for destructive migrations", "severity": "high", "mitigation": "migration-guards.js untouched; TIER-2 path unchanged; a guard-preserved test locks it."},
+    {"risk": "CLAUDE_CORE regen silently skipped (--only cache trap)", "severity": "medium", "mitigation": "Use full `npm run leo:generate`; verify the [hash] console line + manifest update."}
+  ],
+  "implementation_approach": {
+    "summary": "Build the pure allow-list classifier + its full adversarial test corpus first (the security core), then gate the existing auto-apply path on tier, add the audit row, update + regenerate the protocol section, and run a dedicated adversarial-review lens before shipping.",
+    "steps": [
+      "CREATE scripts/lib/migration-tier-classifier.mjs — pure classifyMigration reusing splitPostgreSQLStatements + stripNonDdl; 5 allow rules + 16 fail-closed rules + 3-layer split; never-throws.",
+      "CREATE the unit suite with the full 23-case adversarial corpus + per-rule real-split integration assertions; set activation_test_id.",
+      "Gate BaseExecutor._checkAndExecutePendingMigrations / pending-migrations-check on classifyMigration: TIER-1 auto-apply via the existing path, TIER-2 defer to --prod-deploy (migration-guards.js untouched).",
+      "Add the FR-3 audit row (file, tier, matched, verdict, ts, inverse/drop) — fail-soft, reuse existing store.",
+      "Update leo_protocol_sections id=444 content with the tiered policy + regenerate CLAUDE_CORE.md (full leo:generate, verify [hash]); mirror a pointer to phase rows + digest mapping.",
+      "Dedicated multi-lens adversarial review (smuggle-a-destructive-migration lens) -> fix-first; then TESTING(+SECURITY) -> handoff chain."
+    ]
+  },
+  "dependencies": ["SD-LEO-INFRA-PRE-MERGE-MIGRATION-001 (auto-apply primitive — reused)", "SD-LEO-INFRA-MIGRATION-DEPLOY-DRIFT-001 (recent-vs-legacy classifier + the migration-autonomy finding)"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 744b39c25600383d -->
+<!-- file_content_hash: eaa455ac49687035 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-14 4:52:50 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-15 8:09:48 AM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: b0ae5ac23ea49b06 -->
+<!-- file_content_hash: 9f05dbe997e6c3fe -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-14 6:47:30 PM
+**Generated**: 2026-06-15 8:09:48 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -90,6 +90,6 @@ Adam runs a 4th recurring tick (self-adherence, every 6h: node scripts/adam-self
 
 ---
 
-*Generated from database: 2026-06-14*
+*Generated from database: 2026-06-15*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T22:47:30.011Z -->
-<!-- git_commit: 05b3e6dc -->
+<!-- generated_at: 2026-06-15T12:09:47.932Z -->
+<!-- git_commit: 325cf649 -->
 <!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: e91e464713f4b60b -->
+<!-- file_content_hash: f1b3297a3764e319 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 728825879b7c1e92 -->
+<!-- file_content_hash: 697282a4ad688cb1 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-14 4:52:50 PM
+**Generated**: 2026-06-15 8:09:48 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -30,6 +30,23 @@ The DATABASE sub-agent handles common blockers automatically:
 Task tool with subagent_type="database-agent":
 "Execute the migration file: database/migrations/YYYYMMDD_name.sql"
 ```
+
+---
+
+## Tiered Auto-Apply Policy (SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001)
+
+Handoff-time migration auto-apply is gated by a **fail-closed, allow-list tier classifier** (`scripts/lib/migration-tier-classifier.mjs`). The classifier is PURE (no DB/IO) and **default-deny**: a migration is auto-apply-eligible **only** when EVERY statement provably matches an additive allow rule.
+
+- **TIER-1 (auto-apply eligible)** — provably additive only: `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX` (incl. CONCURRENTLY / IF NOT EXISTS), nullable `ADD COLUMN` with a constant-only default, `ENABLE ROW LEVEL SECURITY` / `CREATE POLICY`, and bare `CREATE FUNCTION`/`VIEW` (NOT `OR REPLACE`, no `SECURITY DEFINER`, body free of destructive SQL). These flow to the DATABASE sub-agent for execution (the mechanics above are unchanged).
+- **TIER-2 (chairman-gated)** — EVERYTHING ELSE: any `DROP`/`TRUNCATE`/`DELETE`/`UPDATE`/`RENAME`/`GRANT`/`REVOKE`, `ALTER COLUMN ... TYPE`, multi-action ALTER with a non-additive action, volatile or `NOT NULL` defaults, `CREATE OR REPLACE`, `SECURITY DEFINER`, `DO` blocks, named-`$tag$` function bodies hiding destructive SQL, and unparseable/under-split/ambiguous input. These are **never auto-applied** — they require the full 3-factor `@approved-by` chairman gate:
+  ```
+  node scripts/apply-migration.js <path> --prod-deploy
+  ```
+  (`--prod-deploy` + a single-use 1h token + an `-- @approved-by: <email>` header matching `git config user.email` — enforced by `scripts/lib/migration-guards.js`, which the tier classifier NEVER weakens.)
+
+**Default-deny safety contract**: a false TIER-1 verdict on a destructive migration would auto-apply it past the chairman gate, so the classifier is allow-list only, NEVER throws, and NEVER returns TIER-1 on any error/ambiguity path. Both auto-apply vectors are gated — SD-declared migrations AND uncommitted manual-update SQL.
+
+**Rollout**: the gate is opt-in via `LEO_MIGRATION_TIER_GATE=on` (default OFF). When OFF, classification is advisory only (computed, logged, and audited to `audit_log` as `MIGRATION_TIER_CLASSIFICATION`) and the existing auto-apply behavior is unchanged. Every tier decision is recorded fail-soft — an audit failure never blocks a handoff.
 
 ## Cascade Invalidation System
 
@@ -1661,7 +1678,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-14*
+*Generated from database: 2026-06-15*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T20:52:50.248Z -->
-<!-- git_commit: a27b6afe -->
+<!-- generated_at: 2026-06-15T12:09:47.932Z -->
+<!-- git_commit: 325cf649 -->
 <!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: 6833d39df2f87656 -->
+<!-- file_content_hash: 5399e4679a0248a3 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-14 4:52:50 PM*
+*DIGEST generated: 2026-06-15 8:09:48 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T20:52:50.248Z -->
-<!-- git_commit: a27b6afe -->
+<!-- generated_at: 2026-06-15T12:09:47.932Z -->
+<!-- git_commit: 325cf649 -->
 <!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: fc2ea11ab0681505 -->
+<!-- file_content_hash: 692d4357907b8de3 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-14 4:52:50 PM*
+*DIGEST generated: 2026-06-15 8:09:48 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: ddeeef964f10a71a -->
+<!-- file_content_hash: 5735c58b3a5a5b4a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-14 4:52:50 PM
+**Generated**: 2026-06-15 8:09:48 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2116,6 +2116,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-06-14*
+*Generated from database: 2026-06-15*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T20:52:50.248Z -->
-<!-- git_commit: a27b6afe -->
+<!-- generated_at: 2026-06-15T12:09:47.932Z -->
+<!-- git_commit: 325cf649 -->
 <!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: 676a8470c2f3a940 -->
+<!-- file_content_hash: 6dca3818bbb20643 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-14 4:52:50 PM*
+*DIGEST generated: 2026-06-15 8:09:48 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 006bdbc26a6cff47 -->
+<!-- file_content_hash: a20d6fbddc8b73f5 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-14 4:52:50 PM
+**Generated**: 2026-06-15 8:09:48 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1582,6 +1582,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-14*
+*Generated from database: 2026-06-15*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T20:52:50.248Z -->
-<!-- git_commit: a27b6afe -->
+<!-- generated_at: 2026-06-15T12:09:47.932Z -->
+<!-- git_commit: 325cf649 -->
 <!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: 8caf1c737f18c03b -->
+<!-- file_content_hash: 753b9a5587570c83 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-14 4:52:50 PM*
+*DIGEST generated: 2026-06-15 8:09:48 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 927c99b2adf034c8 -->
+<!-- file_content_hash: 607d04e072437593 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-14 4:52:50 PM
+**Generated**: 2026-06-15 8:09:48 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2441,6 +2441,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-14*
+*Generated from database: 2026-06-15*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T20:52:50.248Z -->
-<!-- git_commit: a27b6afe -->
+<!-- generated_at: 2026-06-15T12:09:47.932Z -->
+<!-- git_commit: 325cf649 -->
 <!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: d88ffb8a2f574b78 -->
+<!-- file_content_hash: 621c264f94ab4eb5 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-14 4:52:50 PM*
+*DIGEST generated: 2026-06-15 8:09:48 AM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,95 +1,95 @@
 {
-  "generated_at": "2026-06-14T22:47:30.011Z",
-  "git_commit": "05b3e6dc",
+  "generated_at": "2026-06-15T12:09:47.932Z",
+  "git_commit": "325cf649",
   "db_snapshot_hash": "916e51b7a22a4063",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19368,
       "estimated_tokens": 4842,
-      "content_hash": "b8593f28fe7d905c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE.md"
+      "content_hash": "933f827bf3d79e16",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 81294,
-      "estimated_tokens": 20324,
-      "content_hash": "4010a1f74046a684",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_CORE.md"
+      "chars": 83527,
+      "estimated_tokens": 20882,
+      "content_hash": "f5d60c2034d7bc4a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65128,
       "estimated_tokens": 16282,
-      "content_hash": "8d984d62f982ecca",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_LEAD.md"
+      "content_hash": "15c96ba78b124906",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 90830,
       "estimated_tokens": 22708,
-      "content_hash": "5619747899656e71",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_PLAN.md"
+      "content_hash": "437ecbbfa98cd289",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 84821,
       "estimated_tokens": 21206,
-      "content_hash": "30f62f0bf57420e4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_EXEC.md"
+      "content_hash": "1a5cf425808d4967",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
       "chars": 23804,
       "estimated_tokens": 5951,
-      "content_hash": "a5019378643d6da8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_ADAM.md"
+      "content_hash": "862ead18f8275380",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "e1d62c510a6f7bc9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_DIGEST.md"
+      "content_hash": "a9d6633d9917d606",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11535,
       "estimated_tokens": 2884,
-      "content_hash": "aad32205e83536b3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "08c610abfba0c9b0",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5422,
       "estimated_tokens": 1356,
-      "content_hash": "6be0e178c8b71c76",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "c821dd23439bb687",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8412,
       "estimated_tokens": 2103,
-      "content_hash": "c0599efa4886d5fe",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "ffe41d2cde167293",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10835,
       "estimated_tokens": 2709,
-      "content_hash": "6fd215300cb816ca",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "1ac484330aaef44a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 3952,
       "estimated_tokens": 988,
-      "content_hash": "1c2757af3661c60d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "8397b573c4785854",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001\\CLAUDE_ADAM_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "c64cc463c9a6628a",
+    "global": "6a2cf7210eeb84dc",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -266,7 +266,7 @@
       "435": "dc205008f2747ac6",
       "436": "8115bd7ee9303db3",
       "439": "08a9d4b4ea40618b",
-      "444": "ff96de4f8cf05c1a",
+      "444": "781e786b53cb090f",
       "449": "86f83ca9a7afe8cc",
       "450": "94087ec605b29ee4",
       "452": "5bb15e4ce5af0b4e",

--- a/scripts/lib/migration-tier-classifier.mjs
+++ b/scripts/lib/migration-tier-classifier.mjs
@@ -55,6 +55,11 @@ const APPLY_TIME_OR_COUPLING = /\b(materialized\s+view|partition\s+of|inherits)\
 // DEFAULT nextval + (on a non-empty table) a rewrite — NOT a nullable-additive column.
 const SERIAL_PSEUDOTYPE = /\b(smallserial|bigserial|serial8|serial4|serial2|serial)\b/i;
 
+// Zero-width chars JS \s does NOT match: U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ).
+// Built from char codes so no invisible character lives in this source file (which an
+// editor or git filter could silently strip, disarming the FC-18 normalization).
+const ZERO_WIDTH = new RegExp('[' + String.fromCharCode(0x200b, 0x200c, 0x200d) + ']', 'g');
+
 // Strip SQL line comments (dash-dash to EOL) and block comments, replacing each with a
 // space. Postgres treats comments as whitespace in its token stream, so a destructive or
 // flag token can be split by an INTERIOR comment (the SECURITY DEFINER comment-split
@@ -257,6 +262,12 @@ const RULES = [matchCreateTableINE, matchCreateIndex, matchAdditiveAddColumn, ma
 export function classifyMigration(sql) {
   try {
     if (typeof sql !== 'string') return T2('non_string_input');
+    // FC-18: normalize the zero-width chars that JS \s does NOT match (U+200B/C/D) to
+    // spaces, so an invisible char cannot split a keyword pair (e.g. SECURITY<ZWSP>DEFINER)
+    // past a \s-based check. Postgres rejects these as token delimiters (a real apply would
+    // syntax-error), so normalizing toward TIER-2 removes any doubt. Defense-in-depth.
+    // (regex built from char codes so no invisible chars live in this source file.)
+    sql = sql.replace(ZERO_WIDTH, ' ');
     if (sql.length > MAX_SQL_BYTES) return T2('migration_too_large');
     if (!sql.trim()) return T2('empty_migration');
 

--- a/scripts/lib/migration-tier-classifier.mjs
+++ b/scripts/lib/migration-tier-classifier.mjs
@@ -1,0 +1,243 @@
+/**
+ * Migration TIER classifier — PURE, fail-closed allow-list DDL linter.
+ *
+ * SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001 (FR-1).
+ *
+ * classifyMigration(sql) => { tier: 1 | 2, reason, matched: string[] }
+ *
+ * TIER-1 (auto-apply-eligible) is granted ONLY when EVERY statement in the
+ * migration matches an explicit provably-additive allow rule AND no destructive
+ * token survives a whole-file sweep AND no function body hides destructive SQL.
+ * EVERYTHING ELSE — destructive, ambiguous, unparseable, OR REPLACE, DO-block,
+ * unrecognized — is TIER-2 (keeps the full 3-factor @approved-by chairman gate
+ * in scripts/lib/migration-guards.js, which this module NEVER touches).
+ *
+ * SAFETY CONTRACT: a false TIER-1 verdict on a destructive migration is
+ * catastrophic (it would auto-apply, bypassing the chairman gate). Therefore:
+ *   - ALLOW-LIST only (never a deny-list). Default verdict = TIER-2.
+ *   - The function NEVER throws and NEVER returns tier:1 on any error/ambiguity path.
+ *   - Three independent layers must AGREE for tier:1 (see classifyMigration).
+ *
+ * PURE: no DB, no live-schema, no I/O. Reuses the repo's existing SQL primitives
+ * (splitPostgreSQLStatements, stripNonDdl) rather than re-rolling SQL parsing.
+ *
+ * KNOWN PRIMITIVE GAP COMPENSATED: splitPostgreSQLStatements tracks only bare `$$`
+ * dollar quotes, not named tags `$tag$` (wf_5071dc05). We add a named-tag balance
+ * pre-check + a function-body deep-scan so a destructive named-tag body cannot
+ * mis-split into a false TIER-1.
+ *
+ * @module scripts/lib/migration-tier-classifier
+ */
+
+import { splitPostgreSQLStatements } from './supabase-connection.js';
+import { stripNonDdl } from '../verify-migration-apply-state.mjs';
+
+// Bound input size so a pathological body cannot trigger regex catastrophic
+// backtracking / a DoS hang that could leave the classifier in an undefined state.
+const MAX_SQL_BYTES = 200_000;
+
+// Top-level destructive / permission-altering / non-additive verbs. If any of these
+// survive in the body-stripped, allow-head-stripped residue, the migration is TIER-2.
+const FORBIDDEN_TOPLEVEL = /\b(DROP|TRUNCATE|DELETE|UPDATE|RENAME|GRANT|REVOKE|CLUSTER|REINDEX|REFRESH|VACUUM|ANALYZE|COMMENT|COPY|CALL|LISTEN|NOTIFY|IMPORT|MERGE|LOCK|DO)\b/i;
+
+// Destructive tokens inside a CREATE FUNCTION / VIEW body (Rule E deep-scan).
+const BODY_DESTRUCTIVE = /\b(DROP|TRUNCATE|DELETE\s+FROM|UPDATE\b[\s\S]*?\bSET\b|ALTER\s+(TABLE|VIEW|MATERIALIZED|SEQUENCE|TYPE|SCHEMA|POLICY)|GRANT|REVOKE|CALL|COPY|EXECUTE|\bDO\b|INSERT\s+INTO|MERGE)\b/i;
+
+// A constant-only DEFAULT expression: numeric/string/bool/null literal, or a bare
+// cast of those. Anything with a function call, sub-SELECT, or column ref is rejected.
+const CONST_DEFAULT = /^\s*(?:NULL|TRUE|FALSE|-?\d+(?:\.\d+)?|'(?:[^']|'')*'|"(?:[^"]|"")*")\s*(?:::\s*[A-Za-z_][\w ]*(?:\[\])?\s*)?$/i;
+
+function T2(reason) { return { tier: 2, reason, matched: [] }; }
+
+/** Strip leading line/block comments, lowercase, collapse whitespace — for head matching. */
+function normalizeHead(raw) {
+  let s = String(raw);
+  // strip leading -- line comments and /* */ block comments repeatedly
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/^\s*--[^\n]*\n?/, '');
+    s = s.replace(/^\s*\/\*[\s\S]*?\*\//, '');
+  } while (s !== prev);
+  return s.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Even number of bare $$ and balanced named $tag$ dollar quotes. */
+function dollarQuotesBalanced(sql) {
+  const bare = (sql.match(/\$\$/g) || []).length;
+  if (bare % 2 !== 0) return false;
+  const tags = sql.match(/\$[A-Za-z_]\w*\$/g) || [];
+  const counts = {};
+  for (const t of tags) counts[t] = (counts[t] || 0) + 1;
+  return Object.values(counts).every((n) => n % 2 === 0);
+}
+
+/** Count top-level (not inside a string/comment/dollar body) semicolons in a residue. */
+function countTopLevelSemicolons(residue) {
+  return (residue.match(/;/g) || []).length;
+}
+
+/** Remove balanced parenthesized groups (iteratively, innermost-first) — bounded. */
+function stripParens(s) {
+  let prev;
+  let out = s;
+  let guard = 0;
+  do {
+    prev = out;
+    out = out.replace(/\([^()]*\)/g, ' ');
+  } while (out !== prev && guard++ < 200);
+  return out;
+}
+
+const COMMAND_VERBS = /\b(create|alter|drop|truncate|insert|update|delete|grant|revoke|merge|refresh|cluster|reindex|vacuum|analyze|comment|copy|call|do|lock|reset|listen|notify|import|rename|begin|commit|rollback|savepoint)\b/g;
+
+/**
+ * A single (already-split) statement must contain exactly ONE top-level command
+ * verb. >1 means the splitter under-split (e.g. two CREATEs with no separating ;,
+ * which the prefix-only head match would otherwise false-pass) or a destructive
+ * command was concatenated — fail closed. Parens (incl. type sizes + function
+ * argument lists) are stripped first so they cannot hide or fabricate a verb.
+ */
+function commandVerbCount(head) {
+  return (stripParens(head).match(COMMAND_VERBS) || []).length;
+}
+
+/** Split an ALTER action list on TOP-LEVEL commas (ignoring commas inside parens). */
+function splitTopLevelCommas(s) {
+  const out = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of s) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth = Math.max(0, depth - 1);
+    if (ch === ',' && depth === 0) { out.push(cur); cur = ''; } else cur += ch;
+  }
+  if (cur.trim()) out.push(cur);
+  return out;
+}
+
+// ── Allow-rule matchers (return {token} on match, else null) ──────────────────
+
+// Rule A — CREATE TABLE IF NOT EXISTS (IF NOT EXISTS mandatory; FC-12).
+function matchCreateTableINE(head) {
+  const m = head.match(/^create\s+table\s+if\s+not\s+exists\s+([a-z0-9_."]+)/);
+  return m ? { token: `create_table_if_not_exists:${m[1]}` } : null;
+}
+
+// Rule B — CREATE INDEX (incl UNIQUE / CONCURRENTLY / IF NOT EXISTS).
+function matchCreateIndex(head) {
+  const m = head.match(/^create\s+(?:unique\s+)?index\s+(?:concurrently\s+)?(?:if\s+not\s+exists\s+)?/);
+  return m ? { token: 'create_index' } : null;
+}
+
+// Rule C — ALTER TABLE with ONLY additive nullable ADD COLUMN actions (FC-3/4/5/9).
+function matchAdditiveAddColumn(head) {
+  const m = head.match(/^alter\s+table\s+(?:if\s+exists\s+)?([a-z0-9_."]+)\s+(.+)$/);
+  if (!m) return null;
+  const table = m[1];
+  const actions = splitTopLevelCommas(m[2]);
+  if (!actions.length) return null;
+  const cols = [];
+  for (const a0 of actions) {
+    const a = a0.trim();
+    // must be: add column [if not exists] <col> <type...> [default <expr>]
+    const am = a.match(/^add\s+column\s+(?:if\s+not\s+exists\s+)?([a-z0-9_."]+)\s+(.+)$/);
+    if (!am) return null; // any non-add-column action => not Rule C
+    const col = am[1];
+    let rest = am[2];
+    // forbidden inline qualifiers => TIER-2 (FC-5/FC-9)
+    if (/\b(not\s+null|primary\s+key|unique|references|generated|constraint|check)\b/.test(rest)) return null;
+    // default must be constant-only (FC-4)
+    const dm = rest.match(/\bdefault\b\s+(.+)$/);
+    if (dm) {
+      const expr = dm[1].trim();
+      if (!CONST_DEFAULT.test(expr)) return null; // volatile/expression/subquery default => TIER-2
+    }
+    cols.push(`${table}.${col}`);
+  }
+  return { token: `add_column_nullable:${cols.join(',')}` };
+}
+
+// Rule D — CREATE POLICY, or ALTER TABLE ... ENABLE ROW LEVEL SECURITY (only that form).
+function matchPolicyOrEnableRls(head) {
+  if (/^create\s+policy\b/.test(head)) return { token: 'create_policy' };
+  const m = head.match(/^alter\s+table\s+(?:if\s+exists\s+)?([a-z0-9_."]+)\s+enable\s+row\s+level\s+security$/);
+  return m ? { token: `enable_rls:${m[1]}` } : null;
+}
+
+// Rule E — bare CREATE FUNCTION/VIEW/MATVIEW (NOT 'OR REPLACE'), body free of destructive SQL.
+function matchSafeCreateFnView(head, rawStmt) {
+  if (/^create\s+or\s+replace\b/.test(head)) return null; // FC-8: OR REPLACE => TIER-2
+  if (!/^create\s+(function|view|materialized\s+view)\b/.test(head)) return null;
+  // SECURITY DEFINER privilege-escalation vector => TIER-2 (FC-15)
+  if (/\bsecurity\s+definer\b/i.test(rawStmt)) return null;
+  // deep-scan the FULL raw statement body for destructive tokens (FC-7).
+  if (BODY_DESTRUCTIVE.test(rawStmt)) return null;
+  const kind = head.startsWith('create function') ? 'create_function'
+    : head.startsWith('create materialized view') ? 'create_matview' : 'create_view';
+  return { token: kind };
+}
+
+const RULES = [matchCreateTableINE, matchCreateIndex, matchAdditiveAddColumn, matchPolicyOrEnableRls];
+
+/**
+ * Classify a migration's risk tier. PURE; never throws; default-deny to TIER-2.
+ * @param {string} sql
+ * @returns {{ tier: 1|2, reason: string, matched: string[] }}
+ */
+export function classifyMigration(sql) {
+  try {
+    if (typeof sql !== 'string') return T2('non_string_input');
+    if (sql.length > MAX_SQL_BYTES) return T2('migration_too_large');
+    if (!sql.trim()) return T2('empty_migration');
+
+    // FC-1: structural dollar-quote balance (bare $$ + named $tag$).
+    if (!dollarQuotesBalanced(sql)) return T2('unbalanced_dollar_quote');
+
+    const stmts = splitPostgreSQLStatements(sql);
+    if (!stmts.length) return T2('no_statements'); // FC-13
+
+    const residue = stripNonDdl(sql);
+
+    // FC-3: under-split detection — residue has more top-level ; than statements found.
+    if (countTopLevelSemicolons(residue) > stmts.length) return T2('under_split_ambiguity');
+
+    // FC-6: any top-level DO block anywhere => TIER-2 (anonymous code block, arbitrary side effects).
+    if (/(^|;|\s)do\b/i.test(residue)) return T2('do_block_present');
+
+    const matched = [];
+    for (const raw of stmts) {
+      const head = normalizeHead(raw);
+      if (!head) continue; // comment/whitespace-only fragment between statements
+      if (head.includes(';')) return T2('embedded_semicolon_ambiguity'); // FC-3
+      // FC-3 (under-split): a single statement must carry exactly one command verb.
+      // Catches the no-semicolon blob (two CREATEs) that a prefix-only head match
+      // would false-pass, and any destructive command concatenated to an additive one.
+      if (commandVerbCount(head) > 1) return T2('multiple_commands_in_statement');
+      let r = null;
+      for (const rule of RULES) { r = rule(head); if (r) break; }
+      if (!r) r = matchSafeCreateFnView(head, raw); // Rule E needs the raw body, not just head
+      if (!r) return T2(`unrecognized_or_unsafe_statement: ${head.slice(0, 80)}`); // FC-2
+      matched.push(r.token);
+    }
+    if (!matched.length) return T2('no_ddl_statements'); // FC-13 (comment-only)
+
+    // FC-7/FC-10: whole-file forbidden sweep. stripNonDdl already removed comments +
+    // dollar bodies; a forbidden top-level verb surviving here (not part of an
+    // allow-listed head we matched) means a destructive statement slipped the
+    // per-statement loop or the two parsers disagree on boundaries (FC-14) => TIER-2.
+    // We do NOT trust the per-statement loop alone — both must agree.
+    const residueForbidden = FORBIDDEN_TOPLEVEL.test(residue);
+    if (residueForbidden) {
+      // Allow-listed heads never contain these verbs, so any hit is a real forbidden
+      // token (or a parser disagreement) — fail closed.
+      return T2('forbidden_token_in_residue');
+    }
+
+    return { tier: 1, reason: 'all_statements_provably_additive', matched };
+  } catch (e) {
+    return T2(`classifier_exception: ${e && e.message ? e.message : String(e)}`); // FC-16
+  }
+}
+
+export default { classifyMigration };

--- a/scripts/lib/migration-tier-classifier.mjs
+++ b/scripts/lib/migration-tier-classifier.mjs
@@ -43,6 +43,29 @@ const FORBIDDEN_TOPLEVEL = /\b(DROP|TRUNCATE|DELETE|UPDATE|RENAME|GRANT|REVOKE|C
 // Destructive tokens inside a CREATE FUNCTION / VIEW body (Rule E deep-scan).
 const BODY_DESTRUCTIVE = /\b(DROP|TRUNCATE|DELETE\s+FROM|UPDATE\b[\s\S]*?\bSET\b|ALTER\s+(TABLE|VIEW|MATERIALIZED|SEQUENCE|TYPE|SCHEMA|POLICY)|GRANT|REVOKE|CALL|COPY|EXECUTE|\bDO\b|INSERT\s+INTO|MERGE)\b/i;
 
+// Constructs that EXECUTE a query at apply time or structurally couple to an existing
+// object, and have NO provably-additive allow-listed counterpart — fail closed wherever
+// they appear in the residue (whole-file defense-in-depth, adversarial review SD-LEO-
+// INFRA-MIGRATION-TIER-CLASSIFIER-001). NOTE: CTAS (`... AS SELECT`) and expression
+// indexes are caught at the RULE level (Rule A / Rule B) instead, because a plain
+// CREATE VIEW legitimately uses `AS SELECT` and so cannot be swept whole-file.
+const APPLY_TIME_OR_COUPLING = /\b(materialized\s+view|partition\s+of|inherits)\b/i;
+
+// serial pseudo-types: Postgres expands these to NOT NULL + an implicit sequence +
+// DEFAULT nextval + (on a non-empty table) a rewrite — NOT a nullable-additive column.
+const SERIAL_PSEUDOTYPE = /\b(smallserial|bigserial|serial8|serial4|serial2|serial)\b/i;
+
+// Strip SQL line comments (dash-dash to EOL) and block comments, replacing each with a
+// space. Postgres treats comments as whitespace in its token stream, so a destructive or
+// flag token can be split by an INTERIOR comment (the SECURITY DEFINER comment-split
+// bypass) to evade a \s-based regex. Run the security / body scans over this cleaned form.
+// Over-stripping only makes a scan MORE conservative (errs toward TIER-2), which is safe.
+function stripSqlComments(s) {
+  return String(s)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+    .replace(/--[^\n]*/g, ' ');        // line comments
+}
+
 // A constant-only DEFAULT expression: numeric/string/bool/null literal, or a bare
 // cast of those. Anything with a function call, sub-SELECT, or column ref is rejected.
 const CONST_DEFAULT = /^\s*(?:NULL|TRUE|FALSE|-?\d+(?:\.\d+)?|'(?:[^']|'')*'|"(?:[^"]|"")*")\s*(?:::\s*[A-Za-z_][\w ]*(?:\[\])?\s*)?$/i;
@@ -119,15 +142,44 @@ function splitTopLevelCommas(s) {
 // ── Allow-rule matchers (return {token} on match, else null) ──────────────────
 
 // Rule A — CREATE TABLE IF NOT EXISTS (IF NOT EXISTS mandatory; FC-12).
+// MUST be the canonical column-definition form: the column list '(' immediately follows
+// the table name. Reject the tail forms that EXECUTE a query at apply time or couple to
+// an existing object (adversarial review SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001):
+//   - CTAS  `... AS SELECT|VALUES|...`  → runs the query at apply (data exfil / arbitrary fn)
+//   - PARTITION OF                       → attaches to / locks an existing parent table
+//   - INHERITS                           → couples to an existing parent
+//   - LIKE                               → copies from a template (not a standalone create)
+// (An in-table column DEFAULT — even a volatile one like gen_random_uuid() — is NOT
+//  rejected: for a brand-new empty table the default only fires on later INSERTs, never
+//  at apply, so it stays provably-additive at apply time.)
 function matchCreateTableINE(head) {
-  const m = head.match(/^create\s+table\s+if\s+not\s+exists\s+([a-z0-9_."]+)/);
-  return m ? { token: `create_table_if_not_exists:${m[1]}` } : null;
+  const m = head.match(/^create\s+table\s+if\s+not\s+exists\s+([a-z0-9_."]+)\s*(.*)$/);
+  if (!m) return null;
+  const rest = m[2];
+  if (!rest.startsWith('(')) return null;                       // not a column-list create (CTAS/PARTITION OF/OF type/...)
+  if (/\b(as|partition|inherits|like|execute)\b/.test(rest)) return null; // CTAS / coupling / template forms
+  return { token: `create_table_if_not_exists:${m[1]}` };
 }
 
 // Rule B — CREATE INDEX (incl UNIQUE / CONCURRENTLY / IF NOT EXISTS).
+// MUST be a plain column-list index. An expression / functional index, an INCLUDE(...)
+// or USING method(...) expression, or a partial-index WHERE predicate is EVALUATED per
+// existing row at BUILD time, so a volatile function there executes at apply (adversarial
+// review: nextval/pg_advisory_lock/side-effecting fns). Allow ONLY a bare column list:
+//   - require an `ON <table>` before the column-list parens,
+//   - the column-list parens must contain NO nested '(' or ')' (a function call,
+//     expression, INCLUDE(...), USING(...) or WITH(...) clause), and
+//   - reject any trailing WHERE (partial-index predicates are not provably side-effect-free).
 function matchCreateIndex(head) {
-  const m = head.match(/^create\s+(?:unique\s+)?index\s+(?:concurrently\s+)?(?:if\s+not\s+exists\s+)?/);
-  return m ? { token: 'create_index' } : null;
+  if (!/^create\s+(?:unique\s+)?index\s+(?:concurrently\s+)?(?:if\s+not\s+exists\s+)?/.test(head)) return null;
+  const open = head.indexOf('(');
+  const close = head.lastIndexOf(')');
+  if (open === -1 || close <= open) return null;                       // no column list => unrecognized
+  if (!/\bon\s+[a-z0-9_."]+/.test(head.slice(0, open))) return null;   // require ON <table> before the column list
+  const inner = head.slice(open + 1, close);
+  if (inner.includes('(') || inner.includes(')')) return null;         // function/expr/INCLUDE/USING/WITH => TIER-2
+  if (/\bwhere\b/.test(head.slice(close))) return null;                // partial-index predicate => TIER-2
+  return { token: 'create_index' };
 }
 
 // Rule C — ALTER TABLE with ONLY additive nullable ADD COLUMN actions (FC-3/4/5/9).
@@ -147,6 +199,9 @@ function matchAdditiveAddColumn(head) {
     let rest = am[2];
     // forbidden inline qualifiers => TIER-2 (FC-5/FC-9)
     if (/\b(not\s+null|primary\s+key|unique|references|generated|constraint|check)\b/.test(rest)) return null;
+    // serial pseudo-types imply NOT NULL + an implicit sequence + DEFAULT nextval + a
+    // possible rewrite — not a nullable-additive column (adversarial review).
+    if (SERIAL_PSEUDOTYPE.test(rest)) return null;
     // default must be constant-only (FC-4)
     const dm = rest.match(/\bdefault\b\s+(.+)$/);
     if (dm) {
@@ -165,17 +220,31 @@ function matchPolicyOrEnableRls(head) {
   return m ? { token: `enable_rls:${m[1]}` } : null;
 }
 
-// Rule E — bare CREATE FUNCTION/VIEW/MATVIEW (NOT 'OR REPLACE'), body free of destructive SQL.
+// Rule E — bare CREATE FUNCTION / VIEW (NOT 'OR REPLACE'), body free of destructive SQL.
+// CREATE MATERIALIZED VIEW is EXCLUDED: it is materialized WITH DATA at apply time, so its
+// defining SELECT EXECUTES during the migration (setval/pg_sleep/pg_terminate_backend =>
+// apply-time side effects) — always TIER-2 (adversarial review). A plain VIEW and a bare
+// CREATE FUNCTION are additive at apply (the view is lazy; the function definition is
+// stored, not executed) — but guarded below.
 function matchSafeCreateFnView(head, rawStmt) {
-  if (/^create\s+or\s+replace\b/.test(head)) return null; // FC-8: OR REPLACE => TIER-2
-  if (!/^create\s+(function|view|materialized\s+view)\b/.test(head)) return null;
-  // SECURITY DEFINER privilege-escalation vector => TIER-2 (FC-15)
-  if (/\bsecurity\s+definer\b/i.test(rawStmt)) return null;
-  // deep-scan the FULL raw statement body for destructive tokens (FC-7).
-  if (BODY_DESTRUCTIVE.test(rawStmt)) return null;
-  const kind = head.startsWith('create function') ? 'create_function'
-    : head.startsWith('create materialized view') ? 'create_matview' : 'create_view';
-  return { token: kind };
+  if (/^create\s+or\s+replace\b/.test(head)) return null;            // FC-8: OR REPLACE => TIER-2
+  if (/^create\s+materialized\s+view\b/.test(head)) return null;     // matview executes WITH DATA at apply => TIER-2
+  if (!/^create\s+(function|view)\b/.test(head)) return null;
+  // Postgres treats comments as whitespace, so scan a COMMENT-STRIPPED form — otherwise
+  // `SECURITY/*c*/DEFINER` or `SECURITY --c<nl>DEFINER` parse as DEFINER yet evade \s (FC-15).
+  const clean = stripSqlComments(rawStmt);
+  if (/\bsecurity\s+definer\b/i.test(clean)) return null;            // FC-15 (covers EXTERNAL SECURITY DEFINER)
+  if (BODY_DESTRUCTIVE.test(clean)) return null;                     // FC-7 deep-scan (comment-split safe)
+  if (head.startsWith('create view')) {
+    // A provably-additive VIEW is a pure projection. A function call / sub-expression in
+    // the defining query is an un-provable footgun (runs on every read; cannot prove it
+    // pure), so require the body (everything after the first `AS`) to contain no parens.
+    const am = clean.match(/\bas\b([\s\S]*)$/i);
+    const body = am ? am[1] : clean;
+    if (body.includes('(')) return null;
+    return { token: 'create_view' };
+  }
+  return { token: 'create_function' };
 }
 
 const RULES = [matchCreateTableINE, matchCreateIndex, matchAdditiveAddColumn, matchPolicyOrEnableRls];
@@ -232,6 +301,14 @@ export function classifyMigration(sql) {
       // Allow-listed heads never contain these verbs, so any hit is a real forbidden
       // token (or a parser disagreement) — fail closed.
       return T2('forbidden_token_in_residue');
+    }
+
+    // FC-17: whole-file defense-in-depth for apply-time-executing / object-coupling forms
+    // that carry no destructive VERB token (so the FORBIDDEN_TOPLEVEL sweep is blind to
+    // them) but are caught at the rule level above. Re-check the residue so a future
+    // rule-level regression cannot silently re-open them (matview / PARTITION OF / INHERITS).
+    if (APPLY_TIME_OR_COUPLING.test(residue)) {
+      return T2('apply_time_or_coupling_construct');
     }
 
     return { tier: 1, reason: 'all_statements_provably_additive', matched };

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -209,10 +209,17 @@ export class BaseExecutor {
 
       if (migrationCheckResult && migrationCheckResult.blocking === true) {
         const enforceMode = (process.env.LEO_MIGRATION_GATE_ENFORCE || 'warn').toLowerCase();
-        const pending = [
-          ...(migrationCheckResult.uncommittedManualUpdates || []),
-          ...(migrationCheckResult.pendingMigrations || []).map(m => m.file)
-        ];
+        // When the tier gate (LEO_MIGRATION_TIER_GATE) deferred only TIER-2 files (the
+        // TIER-1 subset already auto-applied), the precise blocking set is tierDeferredFiles
+        // — prefer it so the operator recipe lists only files that actually need the
+        // chairman gate. Falls back to the full pending set when the tier gate is OFF
+        // (tierDeferredFiles undefined), preserving the original message verbatim.
+        const pending = Array.isArray(migrationCheckResult.tierDeferredFiles) && migrationCheckResult.tierDeferredFiles.length
+          ? [...migrationCheckResult.tierDeferredFiles]
+          : [
+              ...(migrationCheckResult.uncommittedManualUpdates || []),
+              ...(migrationCheckResult.pendingMigrations || []).map(m => m.file)
+            ];
         const applyRecipe = pending.map(p => `  node scripts/apply-migration.js "${p}" --prod-deploy --issue-token <token>`).join('\n');
         if (enforceMode === 'block') {
           try { endSpan(rootSpan, { result: 'migration_gate_block' }); persist(traceCtx, { supabase: this.supabase }); } catch (_) { /* telemetry non-fatal */ }

--- a/scripts/modules/handoff/pre-checks/pending-migrations-check.js
+++ b/scripts/modules/handoff/pre-checks/pending-migrations-check.js
@@ -26,6 +26,10 @@ import { parseDeclaredObjects } from '../../../lib/migration-object-parser.js';
 import { captureObjectDefinitions } from '../../../lib/migration-verification.js';
 import { hasBeenApplied } from '../../../../lib/migration-audit-reader.js';
 import { createDatabaseClient } from '../../../lib/supabase-connection.js';
+// SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001 FR-2: tier the pending set so only
+// provably-additive (TIER-1) migrations are eligible for handoff-time auto-apply;
+// TIER-2 (destructive/ambiguous) defer to the unchanged 3-factor @approved-by gate.
+import { classifyMigration } from '../../../lib/migration-tier-classifier.mjs';
 
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
@@ -37,6 +41,72 @@ const PROJECT_ROOT = path.resolve(__dirname, '../../../../');
 // Retry configuration
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
+
+// ── SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001 (FR-2/FR-3) ────────────────────
+
+/** Tier gate is opt-in (reversible rollout). When OFF, behavior is unchanged and
+ *  the tier is only computed/logged (advisory). Flip LEO_MIGRATION_TIER_GATE=on. */
+export function tierGateEnabled() {
+  return String(process.env.LEO_MIGRATION_TIER_GATE || '').toLowerCase() === 'on';
+}
+
+/** Classify each pending migration by reading its SQL. Fail-closed: an unreadable
+ *  file => TIER-2 (default-deny). Returns the objects annotated with tier metadata. */
+export function classifyPendingTiers(pendingMigrations) {
+  return (pendingMigrations || []).map((m) => {
+    let sql = null;
+    try {
+      const abs = path.isAbsolute(m.file) ? m.file : path.join(PROJECT_ROOT, m.file);
+      sql = existsSync(abs) ? readFileSync(abs, 'utf8') : null;
+    } catch { sql = null; }
+    if (sql === null) return { ...m, tier: 2, tierReason: 'unreadable_migration_file', matched: [] };
+    const v = classifyMigration(sql);
+    return { ...m, tier: v.tier, tierReason: v.reason, matched: Array.isArray(v.matched) ? v.matched : [] };
+  });
+}
+
+/** FR-3: a coarse inverse/rollback hint from the matched allow-tokens (advisory). */
+export function inverseHint(matched) {
+  const hints = [];
+  for (const tok of matched || []) {
+    const [kind, arg] = String(tok).split(':');
+    if (kind === 'create_table_if_not_exists' && arg) hints.push(`DROP TABLE IF EXISTS ${arg};`);
+    else if (kind === 'add_column_nullable' && arg) for (const tc of arg.split(',')) hints.push(`ALTER TABLE ${tc.split('.')[0]} DROP COLUMN IF EXISTS ${tc.split('.')[1]};`);
+    else if (kind === 'enable_rls' && arg) hints.push(`ALTER TABLE ${arg} DISABLE ROW LEVEL SECURITY;`);
+    else if (kind === 'create_index') hints.push('DROP INDEX IF EXISTS <index>; -- name from the migration');
+    else if (kind === 'create_policy') hints.push('DROP POLICY <name> ON <table>;');
+    else if (kind === 'create_view') hints.push('DROP VIEW IF EXISTS <view>;');
+    else if (kind === 'create_matview') hints.push('DROP MATERIALIZED VIEW IF EXISTS <matview>;');
+    else if (kind === 'create_function') hints.push('DROP FUNCTION IF EXISTS <function>;');
+  }
+  return hints;
+}
+
+/** FR-3: fail-soft audit of the tier decision per migration. Reuses audit_log if
+ *  present; never throws (an audit failure must not block the handoff). */
+async function recordTierAudit(supabase, sd, classified) {
+  try {
+    const rows = classified.map((m) => ({
+      event_type: 'MIGRATION_TIER_CLASSIFICATION',
+      entity_type: 'migration',
+      entity_id: m.file,
+      severity: m.tier === 2 ? 'warning' : 'info',
+      metadata: {
+        sd_key: sd?.sd_key || sd?.id || null,
+        file: m.file,
+        tier: m.tier,
+        verdict: m.tierReason,
+        matched: m.matched,
+        gate_enabled: String(process.env.LEO_MIGRATION_TIER_GATE || '').toLowerCase() === 'on',
+        inverse_rollback_hint: m.tier === 1 ? inverseHint(m.matched) : null,
+      },
+    }));
+    if (!rows.length) return;
+    await supabase.from('audit_log').insert(rows);
+  } catch (e) {
+    console.log(`   [Tier Audit] ⚠️ non-fatal: ${e?.message || e}`);
+  }
+}
 
 /**
  * Check for pending database migrations before handoff
@@ -87,8 +157,58 @@ export async function checkPendingMigrations(supabase, sd, options = {}) {
       sdPending.forEach(m => console.log(`      • ${m.file} (${m.status})`));
     }
 
-    // Step 3: If we have pending migrations, USE THE DATABASE SUB-AGENT to execute them
-    if (result.hasPendingMigrations && options.autoExecute !== false) {
+    // ── SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001 (FR-2/FR-3): tier the pending set.
+    // ADVISORY ALWAYS (classify + audit + attach to result); GATING OPT-IN via
+    // LEO_MIGRATION_TIER_GATE=on. When the gate is OFF this block changes NOTHING about
+    // which files reach the auto-apply path below — it only computes/logs/audits the tier.
+    // When ON, only provably-additive TIER-1 files are auto-apply-eligible; TIER-2
+    // (destructive/ambiguous/unparseable) defer to the unchanged 3-factor @approved-by
+    // chairman gate (scripts/lib/migration-guards.js, which this SD NEVER touches).
+    // BOTH auto-apply vectors are gated: SD-declared migrations AND uncommitted manual
+    // updates (both flow into executeWithRetry -> invokeDatabaseSubAgent/executeDirect).
+    const gateOn = tierGateEnabled();
+    let tier1Pending = sdPending;            // SD-declared files eligible for auto-apply
+    let tier2Deferred = [];                  // SD-declared files held for @approved-by
+    let uncommittedEligible = uncommitted;   // uncommitted manual-update files eligible
+    let uncommittedDeferred = [];
+    if (sdPending.length > 0 || uncommitted.length > 0) {
+      const classifiedSd = classifyPendingTiers(sdPending);
+      const classifiedUnc = classifyPendingTiers(uncommitted.map(f => ({ file: f, status: 'UNCOMMITTED' })));
+      const allClassified = [...classifiedSd, ...classifiedUnc];
+      result.tierClassification = classifiedSd;
+      result.tierClassificationUncommitted = classifiedUnc;
+      result.tierGateEnabled = gateOn;
+
+      const nT1 = allClassified.filter(m => m.tier === 1).length;
+      const nT2 = allClassified.length - nT1;
+      console.log(`   🔐 TIER CLASSIFICATION (gate ${gateOn ? 'ON' : 'OFF — advisory only'}): ${nT1} TIER-1 additive · ${nT2} TIER-2 destructive/ambiguous`);
+      allClassified.forEach(m => console.log(`      • [TIER-${m.tier}] ${m.file} — ${m.tierReason}`));
+
+      // FR-3: fail-soft audit of EVERY classification decision (never blocks the handoff).
+      await recordTierAudit(supabase, sd, allClassified);
+
+      if (gateOn) {
+        tier1Pending = classifiedSd.filter(m => m.tier === 1);
+        tier2Deferred = classifiedSd.filter(m => m.tier === 2);
+        uncommittedEligible = classifiedUnc.filter(m => m.tier === 1).map(m => m.file);
+        uncommittedDeferred = classifiedUnc.filter(m => m.tier === 2).map(m => m.file);
+        const deferredFiles = [...tier2Deferred.map(m => m.file), ...uncommittedDeferred];
+        if (deferredFiles.length > 0) {
+          console.log('   ⛔ TIER-2 migrations are NOT auto-applied (default-deny). Apply each via the unchanged 3-factor chairman gate:');
+          deferredFiles.forEach(f => console.log(`      node scripts/apply-migration.js ${f} --prod-deploy`));
+        }
+      } else {
+        console.log('   ℹ️  Tier gate OFF — classification is advisory only; auto-apply behavior unchanged. Enable with LEO_MIGRATION_TIER_GATE=on.');
+      }
+    }
+    const hasDeferred = tier2Deferred.length > 0 || uncommittedDeferred.length > 0;
+    const hasAutoApplyEligible = tier1Pending.length > 0 || uncommittedEligible.length > 0;
+
+    // Step 3: If we have pending migrations, USE THE DATABASE SUB-AGENT to execute them.
+    // (When the gate is OFF, hasAutoApplyEligible === hasPendingMigrations and the
+    // tier1Pending/uncommittedEligible sets equal the originals — so this is byte-for-byte
+    // the original behavior. When ON, only TIER-1-eligible files reach executeWithRetry.)
+    if (result.hasPendingMigrations && options.autoExecute !== false && hasAutoApplyEligible) {
       console.log('\n   ╔════════════════════════════════════════════════════════════╗');
       console.log('   ║  🗄️  INVOKING DATABASE SUB-AGENT FOR MIGRATION EXECUTION   ║');
       console.log('   ╚════════════════════════════════════════════════════════════╝');
@@ -99,10 +219,11 @@ export async function checkPendingMigrations(supabase, sd, options = {}) {
 
       result.executionAttempted = true;
 
-      // Execute with retry logic
+      // Execute with retry logic. Only TIER-1-eligible files when the gate is ON;
+      // identical to the original (full) sets when the gate is OFF.
       const execResult = await executeWithRetry(supabase, sd, {
-        uncommittedFiles: uncommitted,
-        pendingMigrations: sdPending
+        uncommittedFiles: uncommittedEligible,
+        pendingMigrations: tier1Pending
       });
 
       result.executionResult = execResult;
@@ -113,7 +234,9 @@ export async function checkPendingMigrations(supabase, sd, options = {}) {
         console.log('   ✅ DATABASE sub-agent successfully executed all migrations');
         // FR-4: re-check via pg introspection (not git status). Includes a
         // settle delay + retries to absorb supabase pooler schema-cache lag.
-        const recheck = await recheckDeclaredObjectsPostApply(sdPending);
+        // Only the auto-applied (TIER-1) set is rechecked; deferred TIER-2 files
+        // are re-asserted as pending below so they keep blocking the handoff.
+        const recheck = await recheckDeclaredObjectsPostApply(tier1Pending);
         if (recheck.allApplied) {
           result.hasPendingMigrations = false;
           console.log('   ✅ Verification passed: All declared objects present in pg after apply');
@@ -142,11 +265,26 @@ export async function checkPendingMigrations(supabase, sd, options = {}) {
         console.log('');
       }
     } else if (result.hasPendingMigrations) {
-      console.log('\n   ℹ️  Pending migrations detected - autoExecute disabled');
-      console.log('   💡 The DATABASE sub-agent should be used to execute these migrations.');
-      console.log('   💡 Run `node scripts/execute-manual-migrations.js` for manual execution');
+      if (gateOn && hasDeferred && !hasAutoApplyEligible) {
+        // Gate ON and every pending migration is TIER-2 — nothing auto-applies (default-deny).
+        console.log('\n   ⛔ All pending migrations are TIER-2 (destructive/ambiguous) — none auto-applied (default-deny).');
+        console.log('   💡 Apply each via the unchanged 3-factor chairman gate:');
+        [...tier2Deferred.map(m => m.file), ...uncommittedDeferred].forEach(f => console.log(`      node scripts/apply-migration.js ${f} --prod-deploy`));
+      } else {
+        console.log('\n   ℹ️  Pending migrations detected - autoExecute disabled');
+        console.log('   💡 The DATABASE sub-agent should be used to execute these migrations.');
+        console.log('   💡 Run `node scripts/execute-manual-migrations.js` for manual execution');
+      }
     } else {
       console.log('   ✅ No pending migrations found - database is in sync');
+    }
+
+    // TIER-2 files that were deferred are still pending — re-assert so they block the
+    // handoff even if the TIER-1 subset applied + rechecked clean. No-op when the gate
+    // is OFF (hasDeferred is always false then), preserving original blocking behavior.
+    if (hasDeferred) {
+      result.hasPendingMigrations = true;
+      result.tierDeferredFiles = [...tier2Deferred.map(m => m.file), ...uncommittedDeferred];
     }
 
     console.log('   ' + '─'.repeat(50));
@@ -154,7 +292,11 @@ export async function checkPendingMigrations(supabase, sd, options = {}) {
     // Blocking enforcement: if migrations remain pending after all attempts, block the handoff
     result.blocking = result.hasPendingMigrations;
     if (result.blocking) {
-      console.log('   🚫 BLOCKING: Pending migrations prevent handoff completion');
+      if (hasDeferred) {
+        console.log(`   🚫 BLOCKING: ${result.tierDeferredFiles.length} TIER-2 migration(s) require the @approved-by chairman gate before handoff`);
+      } else {
+        console.log('   🚫 BLOCKING: Pending migrations prevent handoff completion');
+      }
     }
 
     return result;

--- a/tests/unit/migration-tier-classifier.test.js
+++ b/tests/unit/migration-tier-classifier.test.js
@@ -129,4 +129,15 @@ describe('classifyMigration — invariants', () => {
     expect(r.tier).toBe(1);
     expect(r.matched.length).toBe(2); // both statements independently matched an allow rule
   });
+
+  it('FC-18: a zero-width char (U+200B) cannot split SECURITY..DEFINER past the \\s-based check', () => {
+    // Built from char codes so no invisible char lives in this test source. JS \s does
+    // NOT match U+200B/C/D, so without the FC-18 normalization SECURITY<ZWSP>DEFINER would
+    // evade FC-15 and classify TIER-1. (SECURITY sub-agent finding, adversarial review.)
+    for (const cp of [0x200b, 0x200c, 0x200d]) {
+      const zw = String.fromCharCode(cp);
+      const sql = `CREATE FUNCTION esc() RETURNS void LANGUAGE sql SECURITY${zw}DEFINER AS $b$ SELECT 1 $b$;`;
+      expect(classifyMigration(sql).tier, `U+${cp.toString(16)} split must be TIER-2`).toBe(2);
+    }
+  });
 });

--- a/tests/unit/migration-tier-classifier.test.js
+++ b/tests/unit/migration-tier-classifier.test.js
@@ -37,6 +37,39 @@ const TIER2_CORPUS = [
   ['empty / comment-only', '-- just a comment\n'],
   ['non-string input', 12345],
   ['REFRESH MATERIALIZED VIEW (unrecognized)', 'REFRESH MATERIALIZED VIEW mv_stats;'],
+  // ── Adversarial-review breaks (wf_db7f5a79-892): apply-time-executing CREATE forms,
+  //    expression indexes, serial pseudo-types, and the SECURITY DEFINER comment-split.
+  //    Each of these classified TIER-1 before the fix — they MUST be TIER-2. ──
+  ['matview executes setval at apply (WITH DATA)', "CREATE MATERIALIZED VIEW mv AS SELECT setval('seq', 999999);"],
+  ['matview kills sessions at apply', 'CREATE MATERIALIZED VIEW mv AS SELECT pg_terminate_backend(pid) FROM pg_stat_activity;'],
+  ['matview pg_sleep apply-time DoS', 'CREATE MATERIALIZED VIEW mv AS SELECT pg_sleep(86400);'],
+  ['matview invokes arbitrary fn at apply', 'CREATE MATERIALIZED VIEW mv AS SELECT nuke_tables();'],
+  ['matview IF NOT EXISTS invokes drop_all', 'CREATE MATERIALIZED VIEW IF NOT EXISTS mv AS SELECT drop_all();'],
+  ['matview even WITH NO DATA is TIER-2 (blanket)', 'CREATE MATERIALIZED VIEW mv AS SELECT id FROM users WITH NO DATA;'],
+  ['plain VIEW with side-effecting fn body', 'CREATE VIEW v AS SELECT pg_terminate_backend(pid) FROM pg_stat_activity;'],
+  ['CTAS exfiltrates auth.users at apply', 'CREATE TABLE IF NOT EXISTS leak AS SELECT * FROM auth.users;'],
+  ['CTAS kills sessions at apply', 'CREATE TABLE IF NOT EXISTS kill AS SELECT pg_terminate_backend(pid) FROM pg_stat_activity;'],
+  ['CTAS resets a sequence at apply', "CREATE TABLE IF NOT EXISTS seqdump AS SELECT setval('users_id_seq', 1, false);"],
+  ['CTAS with column-alias list then AS SELECT', 'CREATE TABLE IF NOT EXISTS t (id int) AS SELECT 1;'],
+  ['PARTITION OF couples to existing parent', 'CREATE TABLE IF NOT EXISTS p1 PARTITION OF master FOR VALUES FROM (1) TO (100);'],
+  ['INHERITS couples to existing parent', 'CREATE TABLE IF NOT EXISTS c INHERITS (parent);'],
+  ['LIKE copies from a template table', 'CREATE TABLE IF NOT EXISTS c (LIKE src INCLUDING ALL);'],
+  ['expression index runs nextval per row', "CREATE INDEX idx ON big_table (nextval('seq'));"],
+  ['partial-index WHERE runs advisory lock per row', 'CREATE INDEX idx ON foo (id) WHERE pg_advisory_lock(id) IS NOT NULL;'],
+  ['unique partial-index WHERE calls a fn', 'CREATE UNIQUE INDEX idx ON public.users (id) WHERE public.side_effect();'],
+  ['INCLUDE clause with a fn call', "CREATE INDEX idx ON t (a) INCLUDE (nextval('s'));"],
+  ['USING method with a fn expression', 'CREATE INDEX idx ON t USING gin (side_effect(a));'],
+  ['CONCURRENTLY expression index', 'CREATE INDEX CONCURRENTLY idx ON t (evil(a));'],
+  ['immutable-fn expression index (conservative TIER-2)', 'CREATE INDEX idx_lower ON users (lower(email));'],
+  ['serial pseudo-type ADD COLUMN', 'ALTER TABLE foo ADD COLUMN id serial;'],
+  ['bigserial pseudo-type ADD COLUMN', 'ALTER TABLE foo ADD COLUMN id bigserial;'],
+  ['smallserial pseudo-type ADD COLUMN', 'ALTER TABLE foo ADD COLUMN id smallserial;'],
+  ['serial8 alias ADD COLUMN', 'ALTER TABLE foo ADD COLUMN id serial8;'],
+  ['SECURITY DEFINER block-comment split (FC-15)', 'CREATE FUNCTION esc() RETURNS void LANGUAGE sql SECURITY/*c*/DEFINER AS $b$ SELECT 1 $b$;'],
+  ['SECURITY DEFINER line-comment split (FC-15)', 'CREATE FUNCTION esc() RETURNS void LANGUAGE sql SECURITY --c\nDEFINER AS $b$ SELECT 1 $b$;'],
+  ['EXTERNAL SECURITY DEFINER comment split (FC-15)', 'CREATE FUNCTION esc() RETURNS void LANGUAGE sql EXTERNAL SECURITY/*c*/DEFINER AS $b$ SELECT 1 $b$;'],
+  ['weaponized SECURITY DEFINER auth.users exfil', 'CREATE FUNCTION all_secrets() RETURNS SETOF auth.users LANGUAGE sql SECURITY/*x*/DEFINER AS $b$ SELECT * FROM auth.users $b$;'],
+  ['camouflage: additive ADD COLUMN + CTAS-kill', 'ALTER TABLE foo ADD COLUMN note text;\nCREATE TABLE IF NOT EXISTS k AS SELECT pg_terminate_backend(pid) FROM pg_stat_activity;'],
 ];
 
 // ── Provably-additive: every one of these MUST classify TIER-1 (auto-apply eligible) ──
@@ -47,6 +80,10 @@ const TIER1_CORPUS = [
   ['ENABLE RLS + CREATE POLICY', 'ALTER TABLE notes ENABLE ROW LEVEL SECURITY;\nCREATE POLICY notes_owner ON notes FOR SELECT TO authenticated USING (user_id = auth.uid());'],
   ['read-only CREATE VIEW', 'CREATE VIEW active_users AS SELECT id, email FROM users WHERE deleted_at IS NULL;'],
   ['two nullable ADD COLUMNs in one ALTER', 'ALTER TABLE p ADD COLUMN a text, ADD COLUMN b int DEFAULT 0;'],
+  // ── Non-regression guards: the adversarial-review fix must NOT over-reject these
+  //    genuinely-additive forms (proves the fix is precise, not a blanket ban). ──
+  ['bare CREATE FUNCTION (definition stored, not executed at apply)', 'CREATE FUNCTION add_two(a int, b int) RETURNS int LANGUAGE sql AS $$ SELECT a + b $$;'],
+  ['CREATE TABLE IF NOT EXISTS with in-table volatile DEFAULT (fires on INSERT, not apply)', 'CREATE TABLE IF NOT EXISTS evt (id uuid DEFAULT gen_random_uuid(), at timestamptz DEFAULT now());'],
 ];
 
 describe('classifyMigration — TIER-2 (must never auto-apply)', () => {

--- a/tests/unit/migration-tier-classifier.test.js
+++ b/tests/unit/migration-tier-classifier.test.js
@@ -1,0 +1,95 @@
+/**
+ * SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001 — fail-closed allow-list tier classifier.
+ *
+ * The SECURITY suite: a false TIER-1 on a destructive migration would auto-apply it
+ * past the chairman gate. This runs the FULL adversarial corpus (19 smuggle attempts
+ * that MUST be TIER-2 + the provably-additive cases that MUST be TIER-1) against the
+ * REAL classifyMigration (which uses the real splitPostgreSQLStatements + stripNonDdl —
+ * so every case is an integration assertion, not a string-shape mock).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyMigration } from '../../scripts/lib/migration-tier-classifier.mjs';
+
+// ── Adversarial corpus: every one of these MUST classify TIER-2 (never auto-applied) ──
+const TIER2_CORPUS = [
+  ['DO-block hides a dynamic DROP', 'CREATE TABLE IF NOT EXISTS audit_log (id bigserial primary key);\nDO $$ BEGIN EXECUTE \'DROP TABLE users\'; END $$;'],
+  ['DROP COLUMN after an additive create', 'CREATE TABLE IF NOT EXISTS staging (id int);\nALTER TABLE customers DROP COLUMN ssn;'],
+  ['NOT NULL + volatile default now()', 'ALTER TABLE orders ADD COLUMN created_at timestamptz NOT NULL DEFAULT now();'],
+  ['nullable but volatile default gen_random_uuid()', 'ALTER TABLE orders ADD COLUMN uid uuid DEFAULT gen_random_uuid();'],
+  ['subquery default', 'ALTER TABLE invoices ADD COLUMN rate numeric DEFAULT (SELECT rate FROM config LIMIT 1);'],
+  ['function body mutates (DELETE FROM)', 'CREATE FUNCTION purge_stale() RETURNS void LANGUAGE plpgsql AS $$ BEGIN DELETE FROM sessions WHERE ts < now(); END $$;'],
+  ['named-tag function body hides DROP', 'CREATE FUNCTION reset() RETURNS void LANGUAGE plpgsql AS $reset$ BEGIN DROP TABLE temp_data; END $reset$;'],
+  ['line-comment then a real ; DROP', 'CREATE TABLE IF NOT EXISTS t (id int); -- harmless\n; DROP TABLE t;'],
+  ['block-comment-spanning ; then DROP', 'CREATE TABLE IF NOT EXISTS t (id int); /* note ; */ DROP TABLE t;'],
+  ['CREATE OR REPLACE silent redefinition', 'CREATE OR REPLACE FUNCTION is_admin(uid uuid) RETURNS bool LANGUAGE sql AS $$ SELECT true $$;'],
+  ['GRANT ALL privilege escalation', 'GRANT ALL ON ALL TABLES IN SCHEMA public TO anon;'],
+  ['RENAME column', 'ALTER TABLE accounts RENAME COLUMN balance TO bal;'],
+  ['ALTER COLUMN TYPE rewrite', 'ALTER TABLE metrics ALTER COLUMN value TYPE bigint;'],
+  ['multi-action ALTER, one DROP', 'ALTER TABLE t ADD COLUMN note text, DROP COLUMN legacy;'],
+  ['TRUNCATE obfuscated by case/whitespace', '   tRuNcAtE   TABLE   event_log   ;'],
+  ['CREATE TRIGGER side-effect', 'CREATE TRIGGER trg_audit AFTER INSERT ON orders FOR EACH ROW EXECUTE FUNCTION log_insert();'],
+  ['bare CREATE TABLE (no IF NOT EXISTS)', 'CREATE TABLE users (id uuid primary key);'],
+  ['DISABLE ROW LEVEL SECURITY regression', 'ALTER TABLE secrets DISABLE ROW LEVEL SECURITY;'],
+  ['under-split blob (two CREATEs, no semicolon)', 'CREATE TABLE IF NOT EXISTS a (id int) CREATE TABLE IF NOT EXISTS b (id int)'],
+  // extra fail-closed cases beyond the corpus
+  ['SECURITY DEFINER function', 'CREATE FUNCTION esc() RETURNS void LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;'],
+  ['unbalanced named dollar tag', 'CREATE FUNCTION f() RETURNS void LANGUAGE plpgsql AS $body$ BEGIN PERFORM 1; END;'],
+  ['empty / comment-only', '-- just a comment\n'],
+  ['non-string input', 12345],
+  ['REFRESH MATERIALIZED VIEW (unrecognized)', 'REFRESH MATERIALIZED VIEW mv_stats;'],
+];
+
+// ── Provably-additive: every one of these MUST classify TIER-1 (auto-apply eligible) ──
+const TIER1_CORPUS = [
+  ['idempotent CREATE TABLE with in-table volatile default', 'CREATE TABLE IF NOT EXISTS feature_flags (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), name text, enabled boolean DEFAULT false);'],
+  ['CREATE INDEX CONCURRENTLY IF NOT EXISTS', 'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_created ON orders (created_at);'],
+  ['nullable ADD COLUMN with constant default', 'ALTER TABLE profiles ADD COLUMN IF NOT EXISTS nickname text DEFAULT \'anon\';'],
+  ['ENABLE RLS + CREATE POLICY', 'ALTER TABLE notes ENABLE ROW LEVEL SECURITY;\nCREATE POLICY notes_owner ON notes FOR SELECT TO authenticated USING (user_id = auth.uid());'],
+  ['read-only CREATE VIEW', 'CREATE VIEW active_users AS SELECT id, email FROM users WHERE deleted_at IS NULL;'],
+  ['two nullable ADD COLUMNs in one ALTER', 'ALTER TABLE p ADD COLUMN a text, ADD COLUMN b int DEFAULT 0;'],
+];
+
+describe('classifyMigration — TIER-2 (must never auto-apply)', () => {
+  for (const [name, sql] of TIER2_CORPUS) {
+    it(`TIER-2: ${name}`, () => {
+      const r = classifyMigration(sql);
+      expect(r.tier, `expected TIER-2 (reason=${r.reason})`).toBe(2);
+    });
+  }
+});
+
+describe('classifyMigration — TIER-1 (provably additive)', () => {
+  for (const [name, sql] of TIER1_CORPUS) {
+    it(`TIER-1: ${name}`, () => {
+      const r = classifyMigration(sql);
+      expect(r.tier, `expected TIER-1 (reason=${r.reason})`).toBe(1);
+      expect(Array.isArray(r.matched) && r.matched.length).toBeTruthy();
+    });
+  }
+});
+
+describe('classifyMigration — invariants', () => {
+  it('NEVER throws and ALWAYS returns a {tier, reason, matched} shape', () => {
+    for (const bad of [null, undefined, 0, {}, [], 'CREATE', '$$', 'DO $$', 'x'.repeat(300000)]) {
+      const r = classifyMigration(bad);
+      expect(r).toHaveProperty('tier');
+      expect([1, 2]).toContain(r.tier);
+      expect(typeof r.reason).toBe('string');
+      expect(Array.isArray(r.matched)).toBe(true);
+    }
+  });
+
+  it('default-DENY: anything not provably additive is TIER-2 (the activation invariant)', () => {
+    // A representative destructive migration must NOT classify TIER-1 by default.
+    expect(classifyMigration('DROP TABLE users;').tier).toBe(2);
+    expect(classifyMigration('ALTER TABLE t ALTER COLUMN c TYPE bigint;').tier).toBe(2);
+    // And the canonical safe case IS TIER-1 (the system is live, not stuck-all-TIER-2).
+    expect(classifyMigration('CREATE TABLE IF NOT EXISTS ok (id int);').tier).toBe(1);
+  });
+
+  it('reuses the REAL splitter: a multi-statement additive migration is TIER-1 and reports per-statement matches', () => {
+    const r = classifyMigration('CREATE TABLE IF NOT EXISTS a (id int);\nCREATE INDEX IF NOT EXISTS idx_a ON a (id);');
+    expect(r.tier).toBe(1);
+    expect(r.matched.length).toBe(2); // both statements independently matched an allow rule
+  });
+});

--- a/tests/unit/migration-tier-gate.test.js
+++ b/tests/unit/migration-tier-gate.test.js
@@ -1,0 +1,89 @@
+/**
+ * SD-LEO-INFRA-MIGRATION-TIER-CLASSIFIER-001 — FR-2/FR-3 gating helpers.
+ *
+ * The classifier itself (FR-1) is exhaustively covered by migration-tier-classifier.test.js.
+ * This suite covers the HANDOFF-TIME GATE wiring in pending-migrations-check.js:
+ *   - tierGateEnabled(): opt-in, ONLY the literal 'on' (case-insensitive) enables.
+ *   - classifyPendingTiers(): reads each file's SQL and annotates the tier; an UNREADABLE
+ *     file MUST default-deny to TIER-2 (the catastrophic-false-TIER-1 guard at the gate edge).
+ *   - inverseHint(): coarse DROP rollback hints derived from the matched allow-tokens.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { tierGateEnabled, classifyPendingTiers, inverseHint } from '../../scripts/modules/handoff/pre-checks/pending-migrations-check.js';
+
+const tmp = mkdtempSync(path.join(tmpdir(), 'tier-gate-'));
+const writeSql = (name, sql) => { const p = path.join(tmp, name); writeFileSync(p, sql, 'utf8'); return p; };
+afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ } });
+
+describe('tierGateEnabled — opt-in, default-OFF', () => {
+  const KEY = 'LEO_MIGRATION_TIER_GATE';
+  const orig = process.env[KEY];
+  afterAll(() => { if (orig === undefined) delete process.env[KEY]; else process.env[KEY] = orig; });
+
+  it('is OFF when unset', () => { delete process.env[KEY]; expect(tierGateEnabled()).toBe(false); });
+  it('is ON for "on" (any case)', () => {
+    process.env[KEY] = 'on'; expect(tierGateEnabled()).toBe(true);
+    process.env[KEY] = 'ON'; expect(tierGateEnabled()).toBe(true);
+    process.env[KEY] = ' On '.trim(); expect(tierGateEnabled()).toBe(true);
+  });
+  it('stays OFF for any other truthy-looking value (fail-safe to current behavior)', () => {
+    for (const v of ['off', 'true', '1', 'yes', 'enabled', '']) { process.env[KEY] = v; expect(tierGateEnabled()).toBe(false); }
+  });
+});
+
+describe('classifyPendingTiers — per-file tiering with default-deny', () => {
+  it('annotates a provably-additive file as TIER-1 and preserves original fields', () => {
+    const file = writeSql('add.sql', 'CREATE TABLE IF NOT EXISTS gate_ok (id int);');
+    const [r] = classifyPendingTiers([{ file, status: 'NOT_EXECUTED' }]);
+    expect(r.tier).toBe(1);
+    expect(r.status).toBe('NOT_EXECUTED');      // original field preserved
+    expect(Array.isArray(r.matched) && r.matched.length).toBeTruthy();
+  });
+
+  it('annotates a destructive file as TIER-2', () => {
+    const file = writeSql('drop.sql', 'DROP TABLE users;');
+    const [r] = classifyPendingTiers([{ file }]);
+    expect(r.tier).toBe(2);
+  });
+
+  it('DEFAULT-DENY: an unreadable / missing file is TIER-2, never TIER-1', () => {
+    const [r] = classifyPendingTiers([{ file: path.join(tmp, 'does-not-exist.sql') }]);
+    expect(r.tier).toBe(2);
+    expect(r.tierReason).toBe('unreadable_migration_file');
+    expect(r.matched).toEqual([]);
+  });
+
+  it('handles an empty/missing set', () => {
+    expect(classifyPendingTiers([])).toEqual([]);
+    expect(classifyPendingTiers(undefined)).toEqual([]);
+  });
+
+  it('classifies a mixed batch independently (one TIER-1, one TIER-2)', () => {
+    const ok = writeSql('ok2.sql', 'CREATE INDEX IF NOT EXISTS idx_x ON t (a);');
+    const bad = writeSql('bad2.sql', 'ALTER TABLE t ALTER COLUMN c TYPE bigint;');
+    const out = classifyPendingTiers([{ file: ok }, { file: bad }]);
+    expect(out.map(m => m.tier)).toEqual([1, 2]);
+  });
+});
+
+describe('inverseHint — coarse rollback hints from matched allow-tokens', () => {
+  it('maps create_table_if_not_exists to DROP TABLE', () => {
+    expect(inverseHint(['create_table_if_not_exists:audit_log'])).toContain('DROP TABLE IF EXISTS audit_log;');
+  });
+  it('maps each added column to its own DROP COLUMN', () => {
+    const hints = inverseHint(['add_column_nullable:profiles.nickname,profiles.bio']);
+    expect(hints).toContain('ALTER TABLE profiles DROP COLUMN IF EXISTS nickname;');
+    expect(hints).toContain('ALTER TABLE profiles DROP COLUMN IF EXISTS bio;');
+  });
+  it('maps enable_rls to DISABLE ROW LEVEL SECURITY', () => {
+    expect(inverseHint(['enable_rls:notes'])).toContain('ALTER TABLE notes DISABLE ROW LEVEL SECURITY;');
+  });
+  it('returns [] for empty / unknown tokens', () => {
+    expect(inverseHint([])).toEqual([]);
+    expect(inverseHint(undefined)).toEqual([]);
+    expect(inverseHint(['mystery_token'])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
A **fail-closed, allow-list migration TIER classifier** that decides whether a DB migration may be **auto-applied at handoff time** past the 3-factor `@approved-by` chairman gate. **TIER-1** = provably additive (auto-apply eligible); **everything else** = **TIER-2**, which keeps the unchanged chairman gate (`scripts/lib/migration-guards.js` — never touched). The chairman's migration-autonomy question, answered safely: workers can auto-apply the provably-safe subset while destructive/ambiguous migrations still require explicit approval.

Default-deny by construction: the classifier is allow-list only, **never throws**, and **never returns TIER-1 on any error/ambiguity/unparseable path**.

## Functional Requirements
- **FR-1** — pure `classifyMigration(sql) => {tier, reason, matched}` (`scripts/lib/migration-tier-classifier.mjs`); reuses the repo's `splitPostgreSQLStatements` + `stripNonDdl`; 5 allow rules + 18 fail-closed checks + 3-layer defense.
- **FR-2** — gate the existing handoff-time auto-apply path on tier (`pending-migrations-check.js`). **Opt-in** via `LEO_MIGRATION_TIER_GATE` (default **OFF** → advisory + audited only, behavior byte-identical). When ON, only TIER-1 auto-applies; TIER-2 defers to `apply-migration.js --prod-deploy`. Both vectors gated (SD-declared + uncommitted manual updates).
- **FR-3** — fail-soft `audit_log` trail (`MIGRATION_TIER_CLASSIFICATION`) per decision: tier, verdict, matched allow-tokens, gate state, inverse/DROP rollback hint. Never blocks a handoff.
- **FR-4** — `leo_protocol_sections` id=444 documents the tiered policy; `CLAUDE_CORE.md` regenerated.
- **FR-5** — adversarial test corpus (`migration-tier-classifier.test.js` + `migration-tier-gate.test.js`), **78 tests green**.

## Adversarial review (the heart of this PR)
An 8-agent review (4 smugglers running ~280 evasion candidates through the *real* classifier + gate-bypass / guard-integrity / OFF-path auditors + completeness critic) reproduced **24 cases where DESTRUCTIVE migrations classified TIER-1**, collapsing to **5 root-cause defect classes** — all fixed fix-first, each locked in with regression corpus:
1. **Rule A** head-only → CTAS (`... AS SELECT`), `PARTITION OF`, `INHERITS`, `LIKE` (CTAS executes its SELECT at apply: `auth.users` exfil / `pg_terminate_backend` / `setval`).
2. **Rule E** → blanket-reject `CREATE MATERIALIZED VIEW` (materialized WITH DATA executes its SELECT at apply); reject function-call VIEW bodies.
3. **Rule B** → reject expression / `INCLUDE` / `USING` / partial-index `WHERE` indexes (evaluate per row at build).
4. **Rule C** → reject `serial`/`bigserial`/`smallserial`/`serial2/4/8` (imply NOT NULL + sequence + rewrite).
5. **FC-15 SECURITY DEFINER comment-split** → scan a comment-stripped form (Postgres treats comments as whitespace), defeating `SECURITY/*c*/DEFINER` (most catastrophic: PUBLIC-callable owner-privileged `auth.users` exfil). Plus **FC-18** zero-width (U+200B/C/D) normalization.

Defense-in-depth: new whole-file `APPLY_TIME_OR_COUPLING` sweep so a future rule-level regression can't silently re-open matview/PARTITION OF/INHERITS.

## Safety posture
- `scripts/lib/migration-guards.js` (the 3-factor chairman gate) is **byte-unchanged** (verified `git diff origin/main`).
- OFF-path is **provably inert** (control flow + blocking decision identical when the gate is OFF) — verified by the REGRESSION sub-agent.
- All fixes are **tighten-only** (the allow-list only shrinks; no migration that was blocked becomes auto-applied).

## Verification
TESTING (`activation_invariant_verified=true`), SECURITY, VALIDATION, REGRESSION sub-agents all **PASS**; retrospective PUBLISHED. EXEC-TO-PLAN 93, PLAN-TO-LEAD 96. 78/78 tier tests + 62 adjacent migration/handoff tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)