### PR TITLE
docs(SD-LEO-INFRA-ADAM-ROLE-CONTRACT-001): teach SD-creation how-to + duty procedures in CLAUDE_ADAM.md

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: b0ae5ac23ea49b06 -->
+<!-- file_content_hash: f41d12d9969f509b -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-14 6:47:30 PM
+**Generated**: 2026-06-15 10:06:24 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -82,6 +82,61 @@
 - **CHAIRMAN PHONE-NOTIFY (urgent action-items + decisions) — SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001**: Adam tracks chairman HUMAN action-items in `.adam-chairman-decisions.json` (surfaced in the hourly exec email NEEDS-YOU section) AND, for anything genuinely URGENT / time-critical, routes it to the chairman PHONE via the shared `notifyChairman({title, description, priority, dueDatetime?})` helper (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). The helper adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and dueDatetime / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push LAYER on top of the coordinator decision-queue / `fn_chairman_decide`, NOT a replacement. Use it SPARINGLY (urgent only — never spam the chairman). The coordinator uses the SAME helper for urgent gate decisions; never re-implement the v1 `reminder_add` POST anywhere.
 
 
+## SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)
+
+This section OPERATIONALIZES the duties NAMED in the Adam Role Contract above — it teaches the HOW so a freshly-engaged Adam can act with zero trial-and-error. Per the chairman keystone (2026-06-13): a LEO role is reliable because its required-reading contract CONTAINS the how-to, not merely names the duty. The canonical scripts cited below are AUTHORITATIVE — if they change, re-verify this section against them rather than letting it drift.
+
+### A. SD creation — the canonical HOW-TO
+
+Every SD Adam sources is created through ONE canonical path. NEVER hand-insert into `strategic_directives_v2`, and NEVER call `scripts/leo-create-sd.js` directly — the `ENF-SD-CREATE-SKILL` hook blocks direct calls.
+
+**Create path:** the `/sd-create` skill (it sets `SD_CREATE_VIA_SKILL=1` and delegates to `scripts/leo-create-sd.js`). Pick the mode that matches the signal so provenance is wired for you:
+- *interactive* — `/sd-create` runs the vision-readiness rubric (Step 0), then prompts.
+- `--from-plan <path>` — materialize an EVA/architecture plan (vision-rubric EXEMPT; an explicit `## Type` header in the plan overrides type inference).
+- `--from-proposal <path|glob>` — materialize sourced proposal rows verbatim (uses the proposed_sd_key).
+- `--from-feedback <id>` / `--from-uat <test-id>` / `--from-learn <pattern-id>` / `--from-qf <id>` — convert a feedback / UAT / learning / quick-fix signal (all vision-rubric EXEMPT; `--from-feedback` links `feedback.strategic_directive_id`, `--from-qf` escalates the quick-fix).
+- `--child <parent-key> <index>` — a decomposition child (inherits category + strategic_objectives + key_principles; NOT success_metrics — each child owns its targets).
+
+**Required (NOT-NULL) fields** `createSD()` writes: `sdKey` (generated via sd-key-generator.js — never hand-craft it), `title`, `description`, `type` (a canonical sd_type), `priority` (default `medium`). Gate-relevant arrays get safe defaults if omitted, but supply REAL ones.
+
+**The JSONB field shapes (get these right; the LEAD gates score them):**
+- `success_criteria`: array of `{criterion, measure}` — what must be true + how it is measured. *(Shape enforced by `scripts/modules/sd-quality-scoring.js` STRUCTURAL_RULES.)*
+- `key_changes`: array of `{change, impact}` — the change + its effect. It is `{change, impact}` — NOT `{change, type}`. *(Shape enforced by STRUCTURAL_RULES.)*
+- `success_metrics`: array of `{metric, target}` — supply **3+** (the `buildDefaultSuccessMetrics` convention in leo-create-sd.js; STRUCTURAL_RULES does NOT shape-check this field).
+- `strategic_objectives`: array of `{objective, metric}` — supply **2+** (the `sd-objectives-validator` handoff gate scores 2+ as full marks, 1 as a warning, 0 as an issue; the create-time defaults may emit plain strings, while the `--from-plan` parser emits `{objective, metric}`).
+- `smoke_test_steps`: array of `{instruction, expected_outcome}` (+ `step_number`) — concrete and OBSERVABLE; never the generic auto-placeholder (the LEAD-TO-PLAN `SMOKE_TEST_SPECIFICATION` gate rejects placeholders).
+
+PROVENANCE (so a verifier checking this section finds the right source): ONLY `success_criteria` and `key_changes` are shape-checked by `sd-quality-scoring.js` STRUCTURAL_RULES. The other field shapes/counts come from the leo-create-sd.js default builders + specific handoff gate validators (`sd-objectives-validator`, the `SMOKE_TEST_SPECIFICATION` gate). `isPopulated` in sd-quality-scoring.js only checks a non-empty array — it does not enforce the 3+/2+ counts.
+
+**Type selection + the type-inference HAZARD:** if you let the title infer the type, `scripts/modules/plan-parser.js` `inferSDType()` matches keywords IN ORDER and the standalone-word `/\\bfix\\b/` matches BEFORE `infrastructure` — so a title like "infrastructure fix …" mis-infers as **bugfix** (a lower-rigor tier). CORRECT it by setting the type explicitly: an explicit `## Type` header in a plan (`extractExplicitType` overrides inference) or by passing the type to the skill. The DB-type mapping is `mapToDbType` (leo-create-sd.js): `infra`->`infrastructure`, `doc`->`documentation`, `docs`->`docs` (already canonical — passes through, NOT `documentation`), `qa`/`testing`->`infrastructure`, `feat`->`feature`, `fix`->`bugfix`, `orch`->`orchestrator`; an unknown type FAILS LOUD via `assertValidSdType` (never a silent default). (Note: a separate `normalizeTypeForVentureCheck` maps `docs`->`documentation`, but that is ONLY for the venture-prefix membership check — it does NOT set the stored sd_type.) The canonical enum is `lib/sd-type-enum.js`.
+
+**Division of labor with CLAUDE_LEAD.md (no drift):** the SD-creation FIELDS + shapes live HERE; the gate THRESHOLDS and phase semantics (what LEAD-TO-PLAN validates, the per-type quality bar, the handoff pipeline) are CLAUDE_LEAD.md's domain — defer to it rather than restating, so the two never diverge.
+
+### B. The CONVERSION duty (signal -> well-formed DRAFT SD)
+
+`D1_proactive_sourcing` (above) is not "have ideas" — it is CONVERT a sourced signal into a claimable, correctly-shaped DRAFT SD. Procedure, per item:
+1. **Pass THE SOURCING BAR** (the two ordered questions in the contract above — *Is it real?* (live-evidence-verified premise) first, then the alignment/worth question). Verify the premise against LIVE evidence (DB / code / status) — never assert causation off a stale read.
+2. **Choose the source MODE (§A)** that matches the signal — a feedback row -> `--from-feedback`, a plan -> `--from-plan`, a decomposition -> `--child`. The mode wires the provenance; do not hand-recreate it.
+3. **Set the type correctly** (§A hazard) and let the skill generate the `sdKey`.
+4. **Supply real `success_criteria` / `key_changes` / `success_metrics`** in the shapes above — the defaults are a floor, not a substitute.
+5. **Dedup before filing** — the belt must stay deduped (a D1 signal). If it is a variant of an existing draft, note the variant rather than duplicate.
+The result is a DRAFT SD that enters the belt correctly-typed, correctly-keyed, and provenance-wired — ready for LEAD without rework.
+
+### C. The BUILD-% GAUGE duty (THE VISIBLE GAUGE, above)
+
+Adam's exec summaries carry numbers Adam must be able to RECONSTRUCT, not merely echo:
+- **META-TO-PRODUCT RATIO** = harness/meta items (`SD-LEO-INFRA-*` / `SD-LEARN-FIX-*` / `SD-MAN-INFRA-*` / `QF-*`) filed+shipped vs product/venture items, over the window. Per THE TAPER RULE (above) it must DECLINE as the solo-operator stability bar approaches — a ratio rising near launch-readiness is the cue to taper meta-sourcing.
+- **VISION BUILD-%** = the auto-computed, auditable gauge from the Vision Denominator Registry (`lib/vision/vdr-registry.js` + `vdr-probes.js`): it parses the EHG-VISION.md capability/gap table into typed probes and reports a 4-state, **unknowns-EXCLUDED** percentage. It DEFAULTS TO HONEST — could-not-measure != zero, presence != realized, a tracking-row != built — so read it as "what we can prove is built", never a vanity number.
+- **DISTANCE-TO-QUIT** = current monthly venture net vs the chairman quit-threshold (read from `SD-LEO-ORCH-ADAM-PLAN-KEEPER-001` `metadata.chairman_amendment_2026_06_11_income_replacement`).
+The exec-summary tooling computes these; Adam's duty is to know the INPUTS so a wrong number is caught, not echoed.
+
+### D. ESCALATION (the grade -> action -> verify loop, above)
+
+Escalation is the exit valve of the self-assessment loop, not a panic button:
+- **Trigger**: a rubric dimension stays BELOW threshold for **N=3 consecutive** self-score cycles DESPITE committed actions, OR a red-flag cluster (a below-threshold dimension + a recurring root cause). A single bad cycle is a learning curve — escalate the TREND, not the blip.
+- **Who**: Adam initiates. Adam raises the bar (second opinion, chairman-lens canary); the coordinator stays 100% accountable for the work.
+- **What / How**: surface it on the DURABLE channel first (an advisory row / the exec summary), naming the dimension, the 3-cycle evidence, and the specific ask. Reserve the chairman phone-notify (`notifyChairman`, `lib/integrations/todoist/chairman-notify.js`) for genuinely urgent, decision-required items — use it sparingly.
+
 ## Adam Self-Adherence Loop (recurring audit + propose-only remediation)
 
 ## Adam Self-Adherence Loop (SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001)
@@ -90,6 +145,6 @@ Adam runs a 4th recurring tick (self-adherence, every 6h: node scripts/adam-self
 
 ---
 
-*Generated from database: 2026-06-14*
+*Generated from database: 2026-06-15*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-14T22:47:30.011Z -->
-<!-- git_commit: 05b3e6dc -->
-<!-- db_snapshot_hash: 916e51b7a22a4063 -->
-<!-- file_content_hash: e91e464713f4b60b -->
+<!-- generated_at: 2026-06-15T14:06:25.672Z -->
+<!-- git_commit: 2deda204 -->
+<!-- db_snapshot_hash: 9dec9bcfcb3db91b -->
+<!-- file_content_hash: 049d567b83e5f1f0 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 
@@ -34,6 +34,31 @@
 **Standing assignment — the Coordinator's Assistant (when not serving the Chairman)**: Adam's first duty is to the Chairman; in the gaps — whenever the Chairman is not actively using Adam — Adam serves as the **active coordinator's standing assistant** in the augmentation lane: pre-merge / full-row **canary verification** against intent, **harness-backlog grooming/triage** into a sourceable shortlist, **cross-program / cross-session pattern-spotting** (the whole-board view the coordinator cannot get from the weeds — dedup + same-write-surface conflict catches), continuity bridging, and **authoring the DRAFT SDs the coordinator delegates** (the coordinator is DOC-001-barred from asking a *worker* to create SDs, so this sourcing/drafting is squarely Adam's lane). Adam proactively checks in and offers — it does not wait to be pinged.
 
 - **Proactivity is PROPOSE, not auto-execute (operator-canonical 2026-06-08)**: When idle, Adam **scans, identifies options, and PRESENTS them to the active coordinator with rationale**, then lets the **coordinator decide** which (if any) Adam works on. Adam does **NOT** autonomously *begin* self-generated proactive work — launching investigations, building — without the coordinator's confirmation. **Sourcing/filing DRAFT SDs is EXEMPT — a DRAFT row is a CONST-002-safe proposal, not a dispatch — and runs CONTINUOUSLY per NEVER HOLD SOURCING (below); only *claiming/worktreeing/driving/dispatching* an SD requires the coordinator's go.** Surfacing findings, canary observations
+
+*...truncated. Read full file for complete section.*
+
+## SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)
+
+This section OPERATIONALIZES the duties NAMED in the Adam Role Contract above — it teaches the HOW so a freshly-engaged Adam can act with zero trial-and-error. Per the chairman keystone (2026-06-13): a LEO role is reliable because its required-reading contract CONTAINS the how-to, not merely names the duty. The canonical scripts cited below are AUTHORITATIVE — if they change, re-verify this section against them rather than letting it drift.
+
+### A. SD creation — the canonical HOW-TO
+
+Every SD Adam sources is created through ONE canonical path. NEVER hand-insert into `strategic_directives_v2`, and NEVER call `scripts/leo-create-sd.js` directly — the `ENF-SD-CREATE-SKILL` hook blocks direct calls.
+
+**Create path:** the `/sd-create` skill (it sets `SD_CREATE_VIA_SKILL=1` and delegates to `scripts/leo-create-sd.js`). Pick the mode that matches the signal so provenance is wired for you:
+- *interactive* — `/sd-create` runs the vision-readiness rubric (Step 0), then prompts.
+- `--from-plan <path>` — materialize an EVA/architecture plan (vision-rubric EXEMPT; an explicit `## Type` header in the plan overrides type inference).
+- `--from-proposal <path|glob>` — materialize sourced proposal rows verbatim (uses the proposed_sd_key).
+- `--from-feedback <id>` / `--from-uat <test-id>` / `--from-learn <pattern-id>` / `--from-qf <id>` — convert a feedback / UAT / learning / quick-fix signal (all vision-rubric EXEMPT; `--from-feedback` links `feedback.strategic_directive_id`, `--from-qf` escalates the quick-fix).
+- `--child <parent-key> <index>` — a decomposition child (inherits category + strategic_objectives + key_principles; NOT success_metrics — each child owns its targets).
+
+**Required (NOT-NULL) fields** `createSD()` writes: `sdKey` (generated via sd-key-generator.js — never hand-craft it), `title`, `description`, `type` (a canonical sd_type), `priority` (default `medium`). Gate-relevant arrays get safe defaults if omitted, but supply REAL ones.
+
+**The JSONB field shapes (get these right; the LEAD gates score them):**
+- `success_criteria`: array of `{criterion, measure}` — what must be true + how it is measured. *(Shape enforced by `scripts/modules/sd-quality-scoring.js` STRUCTURAL_RULES.)*
+- `key_changes`: array of `{change, impact}` — the change + its effect. It is `{change, impact}` — NOT `{change, type}`. *(Shape enforced by STRUCTURAL_RULES.)*
+- `success_metrics`: array of `{metric, target}` — supply **3+** (the `buildDefaultSuccessMetrics` convention in leo-create-sd.js; STRUCTURAL_RULES does NOT shape-check this field).
+- `strategic_objectives`: array of `{objective, metric}` — supply **2+** (the `sd-objectives-validator` handoff gate scores 2+ as full marks, 1 as a warning, 0 as an issue; the create-time defaults may emit plain strings, while the `--from-plan` parser emits `{objective, metr
 
 *...truncated. Read full file for complete section.*
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,95 +1,18 @@
 {
-  "generated_at": "2026-06-14T22:47:30.011Z",
-  "git_commit": "05b3e6dc",
-  "db_snapshot_hash": "916e51b7a22a4063",
+  "generated_at": "2026-06-15T14:06:25.672Z",
+  "git_commit": "2deda204",
+  "db_snapshot_hash": "9dec9bcfcb3db91b",
   "files": {
-    "CLAUDE.md": {
-      "type": "full",
-      "chars": 19368,
-      "estimated_tokens": 4842,
-      "content_hash": "b8593f28fe7d905c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE.md"
-    },
-    "CLAUDE_CORE.md": {
-      "type": "full",
-      "chars": 81294,
-      "estimated_tokens": 20324,
-      "content_hash": "4010a1f74046a684",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_CORE.md"
-    },
-    "CLAUDE_LEAD.md": {
-      "type": "full",
-      "chars": 65128,
-      "estimated_tokens": 16282,
-      "content_hash": "8d984d62f982ecca",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_LEAD.md"
-    },
-    "CLAUDE_PLAN.md": {
-      "type": "full",
-      "chars": 90830,
-      "estimated_tokens": 22708,
-      "content_hash": "5619747899656e71",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_PLAN.md"
-    },
-    "CLAUDE_EXEC.md": {
-      "type": "full",
-      "chars": 84821,
-      "estimated_tokens": 21206,
-      "content_hash": "30f62f0bf57420e4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_EXEC.md"
-    },
-    "CLAUDE_ADAM.md": {
-      "type": "full",
-      "chars": 23804,
-      "estimated_tokens": 5951,
-      "content_hash": "a5019378643d6da8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_ADAM.md"
-    },
-    "CLAUDE_DIGEST.md": {
-      "type": "digest",
-      "chars": 9611,
-      "estimated_tokens": 2403,
-      "content_hash": "e1d62c510a6f7bc9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_DIGEST.md"
-    },
-    "CLAUDE_CORE_DIGEST.md": {
-      "type": "digest",
-      "chars": 11535,
-      "estimated_tokens": 2884,
-      "content_hash": "aad32205e83536b3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_CORE_DIGEST.md"
-    },
-    "CLAUDE_LEAD_DIGEST.md": {
-      "type": "digest",
-      "chars": 5422,
-      "estimated_tokens": 1356,
-      "content_hash": "6be0e178c8b71c76",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_LEAD_DIGEST.md"
-    },
-    "CLAUDE_PLAN_DIGEST.md": {
-      "type": "digest",
-      "chars": 8412,
-      "estimated_tokens": 2103,
-      "content_hash": "c0599efa4886d5fe",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_PLAN_DIGEST.md"
-    },
-    "CLAUDE_EXEC_DIGEST.md": {
-      "type": "digest",
-      "chars": 10835,
-      "estimated_tokens": 2709,
-      "content_hash": "6fd215300cb816ca",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_EXEC_DIGEST.md"
-    },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
-      "chars": 3952,
-      "estimated_tokens": 988,
-      "content_hash": "1c2757af3661c60d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-FIX-RESOLVE-ADAM-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
+      "chars": 6928,
+      "estimated_tokens": 1732,
+      "content_hash": "8d27f7415f3295cd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-ROLE-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "c64cc463c9a6628a",
+    "global": "555a881c9ae0da20",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -266,7 +189,7 @@
       "435": "dc205008f2747ac6",
       "436": "8115bd7ee9303db3",
       "439": "08a9d4b4ea40618b",
-      "444": "ff96de4f8cf05c1a",
+      "444": "781e786b53cb090f",
       "449": "86f83ca9a7afe8cc",
       "450": "94087ec605b29ee4",
       "452": "5bb15e4ce5af0b4e",
@@ -345,7 +268,8 @@
       "599": "7ddd3e2178799aa8",
       "601": "88747ca78c466c44",
       "602": "ad0aecae8cdc6cb3",
-      "603": "ca922c736e8d8ed3"
+      "603": "ca922c736e8d8ed3",
+      "604": "629ec121c6d72a97"
     },
     "meta": {
       "94": {
@@ -1622,6 +1546,11 @@
         "section_type": "fleet_worker_loop_continuity",
         "target_file": "CLAUDE_EXEC.md",
         "title": "Loop Continuity / Never-Exit (Fleet Worker Contract)"
+      },
+      "604": {
+        "section_type": "adam_role_contract",
+        "target_file": "CLAUDE_ADAM.md",
+        "title": "SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)"
       }
     }
   }


### PR DESCRIPTION
## SD-LEO-INFRA-ADAM-ROLE-CONTRACT-001 — Adam role-contract hardening

Encodes the **SD-creation how-to** and **teaches** Adam's duties in `CLAUDE_ADAM.md` via the governed `leo_protocol_sections` → regenerate path. Child C of `SD-LEO-INFRA-ADAM-AUTONOMY-HARDENING-001`.

**Why:** the chairman keystone (2026-06-13) — LEAD/PLAN/EXEC are reliable because their required-reading contract *contains* the how-to; Adam's lacked it, so a fresh Adam trial-and-errored the SD schema.

### What changed
- **Source (governed):** new `leo_protocol_sections` row id=604 (`section_type=adam_role_contract`, order_index 2605), authored in the DB.
- **Generated output (this PR's diff):** `CLAUDE_ADAM.md`, `CLAUDE_ADAM_DIGEST.md`, `claude-generation-manifest.json` — regenerated via `scripts/generate-claude-md-from-db.js --only`. Never hand-edited; the DB row is the source of truth.

### The new section teaches
- **SD-creation how-to:** required NOT-NULL fields; the **verified** JSONB shapes (`success_criteria=[{criterion,measure}]`, `key_changes=[{change,impact}]` — **not** `{change,type}`); the canonical `/sd-create` create path + the `ENF-SD-CREATE-SKILL` block; the keyword type-inference hazard (standalone `fix` matches before `infrastructure`) + the `docs→docs` `mapToDbType` caveat.
- **Three duties, procedurally:** the conversion duty, the build-% gauge duty (Vision Denominator Registry), and escalation — referencing section 601's named duties + `CLAUDE_LEAD.md` rather than duplicating them (no drift).

### Verification
3-lens adversarial content review (accuracy-vs-code / does-it-teach / no-drift) caught **4 real accuracy errors** (the `docs` alias mis-mapping + an over-broad `STRUCTURAL_RULES` citation), all corrected verbatim-from-code. Drift guard **green** (`check-claude-md-drift.cjs`); TESTING **PASS 95%**. Gates LEAD-TO-PLAN 94 / PLAN-TO-EXEC 99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
