### PR TITLE
feat(SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001): auto-check external status before attributing a fleet anomaly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ scripts/check-*.cjs
 # SD-LEO-INFRA-PROTOCOL-DOC-DRIFT-GUARD-001 (FR-1): the drift-check primitive is a
 # permanent, shared script (used by FR-2 pre-commit, FR-3 SessionStart, FR-4a CI).
 !scripts/check-claude-md-drift.cjs
+# SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001: the external-status attribution-guard CLI is a permanent,
+# shared script (the runtime consumer of lib/fleet/external-status-check.mjs) — must be committed.
+!scripts/check-external-status.mjs
 scripts/cleanup-*.js
 !scripts/cleanup-phantom-worktrees.js
 scripts/complete-*.mjs

--- a/lib/fleet/external-status-check.mjs
+++ b/lib/fleet/external-status-check.mjs
@@ -1,0 +1,125 @@
+// SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001 — auto-check external Anthropic/Claude status on a fleet-wide anomaly
+// BEFORE attributing it to a code or fleet gap.
+//
+// Real failure this prevents: a live Opus-4.8 incident caused mass rate-limits / heartbeat-loss that were
+// nearly mis-attributed to a worker-resilience / fleet gap (D4 self-lesson; it also tripped this session's
+// review workflows). When the fleet shows a cohort anomaly (see lib/fleet/freeze-detector.cjs), the coordinator
+// /Adam should FIRST check whether Anthropic is having an incident, and only attribute to internal code/fleet
+// if the external service is healthy.
+//
+// Split for testability:
+//   - checkAnthropicStatus(): injectable-IO + FAIL-OPEN fetch of the Statuspage status.json. Never throws.
+//   - classifyAnomalyAttribution(): PURE (data-in / verdict-out). The fail-open posture is load-bearing — a
+//     fetch failure yields indicator='unknown' and a LOW-confidence "check manually" verdict, NEVER a confident
+//     internal/external claim (so the guard against mis-attribution can itself never cause a mis-attribution).
+
+// status.anthropic.com 302-redirects to status.claude.com; global fetch follows the redirect. (Verified
+// reachable 2026-06-15: status.indicator='none', "All Systems Operational".)
+export const DEFAULT_STATUS_URL = process.env.EXTERNAL_STATUS_URL || 'https://status.claude.com/api/v2/status.json';
+export const DEFAULT_TIMEOUT_MS = Number(process.env.EXTERNAL_STATUS_TIMEOUT_MS) || 8000;
+
+// Statuspage indicators that denote an ACTIVE incident (vs 'none' = operational).
+export const INCIDENT_INDICATORS = new Set(['minor', 'major', 'critical']);
+
+function failOpen(error) {
+  return { ok: false, indicator: 'unknown', description: null, updatedAt: null, ageMs: null, error };
+}
+
+/**
+ * Default IO seam — a node global-fetch GET with an AbortController timeout. Follows redirects.
+ * Returns { ok:boolean, json:()=>Promise<any> }. Overridden in tests via opts.fetchImpl.
+ */
+async function defaultFetch(url, { timeoutMs } = {}) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs || DEFAULT_TIMEOUT_MS);
+  try {
+    const r = await fetch(url, { signal: ac.signal, redirect: 'follow', headers: { 'User-Agent': 'leo-fleet-health/1.0 (+external-status-check)' } });
+    return { ok: r.ok, json: () => r.json() };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch the external service status. INJECTABLE-IO + FAIL-OPEN — never throws.
+ * @param {object} [opts]
+ * @param {(url:string, o:object)=>Promise<{ok:boolean, json:()=>Promise<any>}>} [opts.fetchImpl] - IO seam (tests mock it)
+ * @param {number} [opts.nowMs] - injected clock (for deterministic ageMs)
+ * @param {string} [opts.url]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{ok:boolean, indicator:string, description:(string|null), updatedAt:(string|null), ageMs:(number|null), error:(string|null)}>}
+ */
+export async function checkAnthropicStatus({ fetchImpl, nowMs, url = DEFAULT_STATUS_URL, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const doFetch = typeof fetchImpl === 'function' ? fetchImpl : defaultFetch;
+  try {
+    const res = await doFetch(url, { timeoutMs });
+    if (!res || !res.ok) return failOpen('non-200 or empty response');
+    const body = typeof res.json === 'function' ? await res.json() : res.body;
+    const indicator = body && body.status && body.status.indicator;
+    if (!indicator || typeof indicator !== 'string') return failOpen('no status.indicator in response body');
+    const updatedAt = (body.page && body.page.updated_at) || null;
+    // Guard an unparseable updated_at: new Date('garbage').getTime() is NaN → keep ageMs null (the JSDoc
+    // promises number|null), so a downstream `ageMs > threshold` can never silently compare against NaN.
+    const updatedTs = updatedAt ? new Date(updatedAt).getTime() : NaN;
+    const ageMs = Number.isFinite(updatedTs) ? Math.max(0, now - updatedTs) : null;
+    return { ok: true, indicator, description: (body.status && body.status.description) || null, updatedAt, ageMs, error: null };
+  } catch (e) {
+    return failOpen(e && e.message ? e.message : String(e));
+  }
+}
+
+/**
+ * Attribute a fleet-wide anomaly to a likely EXTERNAL incident vs an internal code/fleet gap. PURE.
+ * @param {object} [p]
+ * @param {object|string} [p.anomaly] - the fleet-anomaly summary (e.g. from freeze-detector)
+ * @param {object} [p.status] - a checkAnthropicStatus() result
+ * @returns {{likely_external:(boolean|null), indicator:string, confidence:('high'|'medium'|'low'), reason:string, recommendation:string}}
+ */
+export function classifyAnomalyAttribution({ anomaly, status } = {}) {
+  const indicator = (status && typeof status.indicator === 'string') ? status.indicator : 'unknown';
+  const anomalyDesc = (anomaly && (anomaly.summary || anomaly.kind)) || (typeof anomaly === 'string' && anomaly) || 'this fleet-wide anomaly';
+
+  // FAIL-OPEN: status unreachable → never make a confident claim; recommend a manual check.
+  if (indicator === 'unknown') {
+    return {
+      likely_external: null,
+      indicator,
+      confidence: 'low',
+      reason: `Could not determine external status (${(status && status.error) || 'no status result'}).`,
+      recommendation: `Check https://status.claude.com MANUALLY before attributing ${anomalyDesc} to a code/fleet gap — the external status could not be read, so neither cause can be ruled out.`,
+    };
+  }
+
+  if (INCIDENT_INDICATORS.has(indicator)) {
+    const desc = (status && status.description) ? `: ${status.description}` : '';
+    return {
+      likely_external: true,
+      indicator,
+      confidence: (indicator === 'major' || indicator === 'critical') ? 'high' : 'medium',
+      reason: `Anthropic/Claude status reports an ACTIVE incident (indicator='${indicator}'${desc}).`,
+      recommendation: `Treat ${anomalyDesc} as likely EXTERNAL — wait/retry per the incident. Do NOT attribute it to a code/fleet gap or file a remediation SD until the external status clears.`,
+    };
+  }
+
+  if (indicator === 'none') {
+    return {
+      likely_external: false,
+      indicator,
+      confidence: 'medium',
+      reason: `Anthropic/Claude status is operational (indicator='none').`,
+      recommendation: `No known external incident — investigate ${anomalyDesc} as a possible code/fleet gap.`,
+    };
+  }
+
+  // UNRECOGNIZED indicator (not none/minor/major/critical, and not the 'unknown' fetch-failure sentinel — e.g.
+  // a 'maintenance' or future Statuspage value). It is NOT provably operational, so — true to the SD's
+  // anti-mis-attribution mission — do NOT confidently steer to an internal investigation; treat it like unknown.
+  return {
+    likely_external: null,
+    indicator,
+    confidence: 'low',
+    reason: `Unrecognized external status indicator '${indicator}'.`,
+    recommendation: `Check https://status.claude.com MANUALLY before attributing ${anomalyDesc} — the status indicator was not recognized, so neither an external incident nor a code/fleet gap can be ruled out.`,
+  };
+}

--- a/scripts/check-external-status.mjs
+++ b/scripts/check-external-status.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001 — CLI consumer of lib/fleet/external-status-check.mjs.
+//
+// Run this when a FLEET-WIDE anomaly is observed (cohort heartbeat-loss / mass rate-limits / widespread tool
+// errors) to check whether Anthropic/Claude is having an incident BEFORE attributing the anomaly to a code or
+// fleet gap. Advisory + fail-open: always exits 0 (a status-check failure must never block incident handling).
+//
+// Usage: node scripts/check-external-status.mjs ["<anomaly summary>"]   (or ANOMALY_SUMMARY env)
+import { checkAnthropicStatus, classifyAnomalyAttribution } from '../lib/fleet/external-status-check.mjs';
+
+const anomalySummary = process.argv.slice(2).join(' ').trim() || process.env.ANOMALY_SUMMARY || null;
+
+const status = await checkAnthropicStatus({});
+const verdict = classifyAnomalyAttribution({ anomaly: anomalySummary ? { summary: anomalySummary } : null, status });
+
+const head = `[external-status-check] indicator=${status.indicator}` +
+  (status.description ? ` (${status.description})` : '') +
+  (status.ok ? '' : ` [fetch failed: ${status.error}]`) +
+  (status.updatedAt ? ` | status page updated ${status.updatedAt}` : '');
+console.log(head);
+console.log(`  likely_external: ${verdict.likely_external} (confidence: ${verdict.confidence})`);
+console.log(`  reason: ${verdict.reason}`);
+console.log(`  ACTION: ${verdict.recommendation}`);
+console.log(`EXTERNAL_STATUS_INDICATOR=${status.indicator} LIKELY_EXTERNAL=${verdict.likely_external}`);
+
+// Advisory only — never fail the caller. Set exitCode (don't process.exit()) so the event loop drains
+// cleanly; an explicit process.exit() while undici's fetch/AbortController handle is mid-close trips a benign
+// libuv UV_HANDLE_CLOSING assertion on Windows. Everything above is fail-open, so a clean drain always exits 0.
+process.exitCode = 0;

--- a/tests/unit/external-status-check.test.js
+++ b/tests/unit/external-status-check.test.js
@@ -1,0 +1,89 @@
+/**
+ * External-status attribution guard tests — SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001.
+ * PURE classifier + injected-fetch fetcher. ZERO live network (fetchImpl is always mocked).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { checkAnthropicStatus, classifyAnomalyAttribution } from '../../lib/fleet/external-status-check.mjs';
+
+// A mock fetchImpl that resolves to a Statuspage-shaped body.
+const okFetch = (body) => vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(body) });
+const sp = (indicator, description = '', updated_at = '2026-06-15T12:00:00.000Z') => ({ status: { indicator, description }, page: { updated_at } });
+
+describe('classifyAnomalyAttribution (pure)', () => {
+  it('active incident (critical) → likely_external=true, high confidence, do-not-attribute-internally', () => {
+    const v = classifyAnomalyAttribution({ anomaly: { summary: 'mass heartbeat loss' }, status: { indicator: 'critical', description: 'Elevated errors' } });
+    expect(v.likely_external).toBe(true);
+    expect(v.confidence).toBe('high');
+    expect(v.recommendation).toMatch(/do NOT attribute/i);
+  });
+  it('minor incident → likely_external=true, medium confidence', () => {
+    expect(classifyAnomalyAttribution({ status: { indicator: 'minor' } })).toMatchObject({ likely_external: true, confidence: 'medium' });
+  });
+  it('operational (none) → likely_external=false, investigate internally', () => {
+    const v = classifyAnomalyAttribution({ anomaly: 'rate-limit spike', status: { indicator: 'none' } });
+    expect(v.likely_external).toBe(false);
+    expect(v.recommendation).toMatch(/code\/fleet gap/i);
+  });
+  it('unknown (fetch failed) → likely_external=null, low confidence, check manually (no false attribution)', () => {
+    const v = classifyAnomalyAttribution({ status: { indicator: 'unknown', error: 'timeout' } });
+    expect(v.likely_external).toBeNull();
+    expect(v.confidence).toBe('low');
+    expect(v.recommendation).toMatch(/manually/i);
+  });
+  it('missing/partial input never throws → treated as unknown', () => {
+    expect(() => classifyAnomalyAttribution()).not.toThrow();
+    expect(classifyAnomalyAttribution({}).indicator).toBe('unknown');
+    expect(classifyAnomalyAttribution({ status: {} }).likely_external).toBeNull();
+  });
+  it('F2: an UNRECOGNIZED indicator (e.g. maintenance/future value) is NOT confidently operational → low-confidence manual-check', () => {
+    const v = classifyAnomalyAttribution({ anomaly: 'odd anomaly', status: { indicator: 'maintenance' } });
+    expect(v.likely_external).toBeNull();            // NOT false ("investigate internally")
+    expect(v.confidence).toBe('low');
+    expect(v.reason).toMatch(/Unrecognized.*maintenance/i); // names the real indicator, not 'none'
+    expect(v.recommendation).toMatch(/manually/i);
+  });
+});
+
+describe('checkAnthropicStatus (injectable-IO, fail-open)', () => {
+  it('valid JSON body → {ok:true, indicator, description, updatedAt, ageMs}', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: okFetch(sp('none', 'All Systems Operational')), nowMs: Date.parse('2026-06-15T13:00:00.000Z') });
+    expect(r).toMatchObject({ ok: true, indicator: 'none', description: 'All Systems Operational' });
+    expect(r.ageMs).toBe(60 * 60 * 1000); // 1h after the page updated_at
+  });
+  it('maps an active incident indicator', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: okFetch(sp('major', 'Degraded')) });
+    expect(r).toMatchObject({ ok: true, indicator: 'major', description: 'Degraded' });
+  });
+  it('fetchImpl that THROWS → fail-open {ok:false, indicator:unknown}, never throws', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: vi.fn().mockRejectedValue(new Error('ECONNRESET')) });
+    expect(r).toMatchObject({ ok: false, indicator: 'unknown' });
+    expect(r.error).toMatch(/ECONNRESET/);
+  });
+  it('non-200 response → fail-open', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }) });
+    expect(r).toMatchObject({ ok: false, indicator: 'unknown' });
+  });
+  it('F1: present but UNPARSEABLE updated_at → ageMs is null (not NaN), per the JSDoc contract', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: okFetch({ status: { indicator: 'none' }, page: { updated_at: 'not-a-real-date' } }), nowMs: Date.parse('2026-06-15T13:00:00.000Z') });
+    expect(r.ok).toBe(true);
+    expect(r.ageMs).toBeNull();           // NOT NaN
+    expect(Number.isNaN(r.ageMs)).toBe(false);
+  });
+  it('200 but body missing status.indicator → fail-open', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: okFetch({ page: { updated_at: '2026-06-15T12:00:00.000Z' } }) });
+    expect(r).toMatchObject({ ok: false, indicator: 'unknown' });
+  });
+  it('json() that throws (unparseable body) → fail-open', async () => {
+    const r = await checkAnthropicStatus({ fetchImpl: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.reject(new Error('bad json')) }) });
+    expect(r).toMatchObject({ ok: false, indicator: 'unknown' });
+  });
+});
+
+describe('end-to-end (mocked fetch) — incident detected gates internal attribution', () => {
+  it('fetch reports critical → classifier says likely_external (do not attribute to code/fleet)', async () => {
+    const status = await checkAnthropicStatus({ fetchImpl: okFetch(sp('critical', 'Major outage')) });
+    const v = classifyAnomalyAttribution({ anomaly: { summary: 'fleet-wide tool errors' }, status });
+    expect(v.likely_external).toBe(true);
+    expect(v.recommendation).toMatch(/EXTERNAL/);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001 — auto-check external status before attributing a fleet anomaly

When the fleet shows a cohort anomaly (mass heartbeat-loss / rate-limits / widespread tool errors), the coordinator/Adam can mis-attribute it to a code/fleet gap when the real cause is an **external Anthropic/Claude incident** — a real, recently-experienced failure (a live Opus-4.8 incident). This adds an auto-check of the external status **before** attribution.

### Design (additive, EHG_Engineer only, no schema)
- **`lib/fleet/external-status-check.mjs`** (NEW): `checkAnthropicStatus()` — injectable-IO, **FAIL-OPEN** fetch of `status.claude.com /api/v2/status.json` (any error/timeout/non-200/missing-indicator/bad-body → `{ok:false, indicator:'unknown'}`, never throws); `classifyAnomalyAttribution()` — **PURE**: incident→`likely_external=true` (don't attribute internally), `none`→false (investigate code/fleet), unknown **or unrecognized**→null low-confidence "check manually". The fail-open posture is load-bearing: a status-check failure can never itself cause a confident (mis-)attribution.
- **`scripts/check-external-status.mjs`** (NEW): thin CLI consumer (the runtime consumer; clean `exitCode=0` drain). + a `.gitignore` negation so the `scripts/check-*` rule doesn't silently drop it.

### Verification
- **14 pure tests** (mocked fetchImpl, zero live network), incl. regressions for the 3 adversarial findings (F1 ageMs-null-not-NaN; F2 unrecognized-indicator→manual-check; F3 reason interpolates the real indicator).
- **Live-smoked** against `status.claude.com` (indicator 'none' → investigate internally; bad-endpoint → fail-open manual-check; both exit 0).
- **Consolidated adversarial review**: no release-blockers; the FAIL-OPEN invariant holds on every failure path; F1/F2/F3 fixed + regression-tested.
- TESTING sub-agent: PASS.

Reuses the existing fleet-anomaly signal (`lib/fleet/freeze-detector.cjs`). The broader codebase-health-scoring vision is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
