### PR TITLE
fix(SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001): register check:external-status npm entry (WIRE_CHECK)

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,6 +500,7 @@
     "okr:sync": "node scripts/okr-priority-sync.js",
     "check:migration-readiness": "node scripts/check-migration-readiness.mjs",
     "check:ghosts": "node scripts/ghost-completion-check.mjs",
+    "check:external-status": "node scripts/check-external-status.mjs",
     "validate:capability-trigger": "node scripts/validate-capability-lifecycle-trigger.mjs --live",
     "qf:create": "node scripts/create-quick-fix.js",
     "migration:apply-state": "node scripts/verify-migration-apply-state.mjs",


### PR DESCRIPTION
Follow-up to #4774. The WIRE_CHECK gate discovers entry points from package.json scripts; the CLI scripts/check-external-status.mjs is prose-invoked (not statically imported), so it + the lib it imports were unreachable → WIRE_CHECK_GATE_FAILED at LEAD-FINAL. Adding the `check:external-status` npm script makes the CLI a discovered entry point, so both files are reachable. 1-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)