### PR TITLE
feat(SD-LEO-INFRA-WORKER-CLAIM-TIME-001): worker claim-time fitness gate (repo-match + preconditions + premise)

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-WORKER-CLAIM-TIME-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-WORKER-CLAIM-TIME-001.json
@@ -1,0 +1,141 @@
+{
+  "executive_summary": "Eliminate the recurring 'unfit assignment' churn where a fleet worker claims an SD then discovers mid-flight it cannot execute in its context (live: worker Alpha hit 4 consecutive unfit assignments — an already-released SD, a repo mismatch where the SD targeted the EHG app while the worktree was EHG_Engineer, and a run-SD whose input data file was absent). A LEAD VALIDATION pass (row dcd2e090) confirmed this is a COMPOSE/WIRE effort, not greenfield: every building block has an existing primitive (lib/repo-paths.js, lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility, claimable-work.cjs TERMINAL_STATUSES, lib/eva create buildChildSD), but none decides 'is this SD executable HERE/NOW' before a worker commits. This PRD delivers a single reusable, FAIL-OPEN predicate isSdExecutableHere(sd,ctx) composed from those primitives, wired into the shared claim/rank seam and into sd-start fail-fast, plus a typed 'unfit' signal and a propose-only partial-block triage. Verified by a hermetic predicate suite + the unchanged existing claim-eligibility suite (zero regression).",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "isSdExecutableHere(sd, ctx) fitness predicate (new pure module, FAIL-OPEN)",
+      "description": "A new pure, injectable module (lib/fleet/sd-executable-here.cjs) exporting isSdExecutableHere(sd, ctx) -> { fit:boolean, blockClass:'repo_mismatch'|'missing_precondition'|'premise_closed'|null, reasons:string[] }. It COMPOSES existing primitives, never reimplements them: (a) repo-match via lib/repo-paths.js canonicalization comparing the SD's target_application / metadata.target_application_explicit to ctx's current checkout repo; (b) preconditions-met by checking declared input-data preconditions (e.g. a required ledger/file) against the checkout; (c) premise-open by REUSING claimable-work.cjs TERMINAL_STATUSES (+ released/superseded). CRITICAL invariant: it FAILS OPEN — any internal error, indeterminate signal, OR absent/ambiguous target_application yields fit:true (a fitness bug must NEVER block all claims). Only a POSITIVELY-determined unfit condition returns fit:false.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Returns {fit:true} for an SD targeting the current repo with met preconditions and an open premise.",
+        "Returns {fit:false, blockClass:'repo_mismatch'} when target_application resolves to a different repo than the current checkout (via repo-paths canonicalization).",
+        "Returns {fit:false, blockClass:'missing_precondition'} when a declared input precondition is unmet, and {fit:false, blockClass:'premise_closed'} for a TERMINAL_STATUSES / released / superseded SD.",
+        "FAILS OPEN: an internal throw, an indeterminate signal, or an absent/ambiguous target_application all yield {fit:true} (never blocks).",
+        "Pure + injectable (repo resolver, supabase, fs probes passed in) — unit-tested with no live DB."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Wire fitness into the shared claim-eligibility seam (no parallel filter)",
+      "description": "EXTEND lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility (the single shared pull+push predicate used by worker-checkin self_claim AND the coordinator sweep) to consult isSdExecutableHere and add the fitness axes as new ineligibility reasons — additively, behind the existing contract, NOT a parallel filter. Unfit SDs become claim-ineligible so they never rank/surface; clear metadata.dispatch_rank for an SD that becomes unfit (mirroring scripts/coordinator-backlog-rank.mjs's rank write/clear). Existing eligibility axes (orchestrator-parent, test-fixture, requires_human_action, deps, in-flight dedup) are unchanged.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "classifyDispatchIneligibility returns an ineligible verdict (with a fitness reason + blockClass) for an unfit SD.",
+        "dispatch_rank is cleared for an SD that is classified unfit.",
+        "The existing claim-eligibility test suite stays green (zero regression in existing axes)."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "sd-start fail-fast before claiming",
+      "description": "Add an isSdExecutableHere check in scripts/sd-start.js that runs BEFORE the claim is committed and aborts fast on a positively-unfit verdict, mirroring the existing target-application crosscheck-BLOCK + release_sd pattern already in sd-start (~lines 1359-1373). The message names the blockClass (e.g. UNFIT(repo_mismatch)) and the SD is left unclaimed. Fail-open: an indeterminate verdict does NOT block start.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "sd-start aborts with a clear UNFIT(<blockClass>) message and leaves the SD unclaimed when the verdict is positively unfit.",
+        "An indeterminate/fail-open verdict allows start to proceed (no false block).",
+        "The abort path reuses the existing crosscheck-BLOCK + release_sd mechanism (no new claim-mutation path)."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Typed 'unfit' worker signal + router recognition",
+      "description": "Add 'unfit' to scripts/worker-signal.cjs SIGNAL_TYPES and emit a STRUCTURED payload (block class, repo, missing precondition, sd_key) instead of a free-text release, so the coordinator can route it systematically. Recognize the new type in lib/coordinator/signal-router.cjs (routed, not dropped, not mishandled as generic friction). Preserves the existing signal-lane invariants.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "worker-signal.cjs accepts type 'unfit' and writes a row with payload.signal_type='unfit' + a structured payload.",
+        "signal-router.cjs recognizes signal_type='unfit' and routes it (a unit/contract test asserts recognition).",
+        "Existing signal types and lane separation are unchanged."
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Propose-only partial-block triage (reuse decomposition)",
+      "description": "On a PARTIAL block (a code-buildable SD whose RUN is blocked — e.g. missing input data), provide a triage helper that PROPOSES a decomposition (buildable code child + blocked run child) by REUSING lib/eva/create-orchestrator-from-plan.js buildChildSD, behind a PROPOSE-ONLY / dry-run-default boundary — it prints/returns the proposed split and emits the FR-4 unfit signal; it never creates or executes children without explicit coordinator/chairman action.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "The triage helper returns/prints a proposed {code_child, run_child} split for a partial-block SD using buildChildSD shapes.",
+        "Dry-run-default: with no explicit execute flag it creates/executes NOTHING (propose-not-execute boundary verified).",
+        "It emits the typed unfit signal describing the partial block."
+      ]
+    },
+    {
+      "id": "FR-6",
+      "title": "Regression tests + zero-regression guarantee",
+      "description": "A hermetic vitest suite (tests/unit/fleet/sd-executable-here.test.js) covering FR-1 (fit, each unfit class, fail-open) and FR-2's extension behavior with injected stubs; plus a contract test for the FR-4 unfit signal recognition. The existing claim-eligibility suite must remain green to prove no regression in the shared seam.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "sd-executable-here.test.js is hermetic (no live DB / injected resolver+probes) and green.",
+        "A test exercises the fail-open path (internal error => fit:true).",
+        "The pre-existing claim-eligibility test suite passes unchanged."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Compose, don't duplicate", "description": "REUSE lib/repo-paths.js, lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility, claimable-work.cjs TERMINAL_STATUSES, lib/eva buildChildSD. No reimplementation of repo resolution, eligibility, terminal-status, or decomposition logic." },
+    { "id": "TR-2", "title": "Fail-open safety", "description": "isSdExecutableHere and every call site default to fit/allow on error or indeterminacy. A fitness defect must degrade to today's behavior (claim allowed), never a fleet-wide claim stall." },
+    { "id": "TR-3", "title": "Additive, CJS, no schema change", "description": "New lib is .cjs (repo is type:module). No new table/column — uses existing strategic_directives_v2 fields (target_application, status, metadata) + session_coordination for the signal. Pure functions injectable for tests." },
+    { "id": "TR-4", "title": "Propose-not-execute", "description": "The triage layer is dry-run-default; it never auto-creates/executes child SDs without explicit action." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "fit SD (repo match, preconditions met, premise open)", "type": "unit", "expected": "{fit:true, blockClass:null}" },
+    { "id": "TS-2", "scenario": "repo mismatch (target != checkout)", "type": "unit", "expected": "{fit:false, blockClass:'repo_mismatch'}" },
+    { "id": "TS-3", "scenario": "missing input precondition", "type": "unit", "expected": "{fit:false, blockClass:'missing_precondition'}" },
+    { "id": "TS-4", "scenario": "terminal/released/superseded premise", "type": "unit", "expected": "{fit:false, blockClass:'premise_closed'} reusing TERMINAL_STATUSES" },
+    { "id": "TS-5", "scenario": "internal error / absent target / indeterminate", "type": "unit", "expected": "FAILS OPEN => {fit:true}" },
+    { "id": "TS-6", "scenario": "claim-eligibility extension marks unfit ineligible + clears dispatch_rank", "type": "unit", "expected": "ineligible verdict with fitness reason; existing axes unchanged" },
+    { "id": "TS-7", "scenario": "unfit signal recognized by router", "type": "unit", "expected": "signal_type='unfit' routed, not dropped" }
+  ],
+  "acceptance_criteria": [
+    "A repo-mismatch / missing-precondition / premise-closed SD is classified UNFIT before claim and does not rank/surface; sd-start fails fast and leaves it unclaimed.",
+    "The fitness predicate is a single reusable, fail-open module composed from existing primitives, wired into the shared claim-eligibility seam (no parallel filter).",
+    "A partial block produces a typed 'unfit' signal + a propose-only decomposition; nothing is auto-created.",
+    "Zero regression: existing claim-eligibility + signal behavior unchanged; new hermetic suite green."
+  ],
+  "risks": [
+    { "risk": "A fitness bug blocks ALL claims (fleet-wide stall).", "mitigation": "FAIL OPEN everywhere — error/indeterminate/absent-target => fit:true; only positive-unfit blocks; fail-open unit-tested.", "severity": "high" },
+    { "risk": "Repo-match false-positive on harness SDs with no explicit target.", "mitigation": "Absent/ambiguous target => fit; only a POSITIVE target-vs-checkout mismatch is unfit; reuse repo-paths canonicalization.", "severity": "medium" },
+    { "risk": "Extending the shared claim-eligibility seam regresses dispatch.", "mitigation": "Additive new reasons behind the existing contract; keep the existing suite green.", "severity": "medium" },
+    { "risk": "Auto-decomposition creates unwanted children.", "mitigation": "Propose-only / dry-run-default; never create/execute without explicit action.", "severity": "medium" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["scripts/worker-checkin.cjs (self_claim)", "the coordinator deconfliction/dispatch sweep", "scripts/sd-start.js", "scripts/coordinator-backlog-rank.mjs"],
+    "dependencies": ["lib/repo-paths.js", "lib/fleet/claim-eligibility.cjs", "scripts/claimable-work.cjs TERMINAL_STATUSES", "lib/eva/create-orchestrator-from-plan.js buildChildSD", "scripts/worker-signal.cjs", "lib/coordinator/signal-router.cjs"],
+    "data_contracts": ["strategic_directives_v2.target_application / metadata.target_application_explicit / status / metadata.dispatch_rank (read/clear)", "session_coordination payload.signal_type='unfit' + structured payload (new value, no schema change)"],
+    "runtime_config": ["none (no new env var/flag); dry-run-default for triage"],
+    "observability_rollout": ["tests/unit/fleet/sd-executable-here.test.js", "the unchanged claim-eligibility suite", "the 5 smoke_test_steps", "live: an unfit SD no longer surfaces for claim + a typed unfit signal in the coordinator inbox"]
+  },
+  "system_architecture": {
+    "summary": "One fail-open fitness predicate composed from existing repo/eligibility/terminal-status primitives, wired into the shared claim seam + sd-start, with a typed unfit signal and a propose-only triage.",
+    "components": [
+      { "name": "lib/fleet/sd-executable-here.cjs", "change": "NEW — isSdExecutableHere(sd,ctx) fail-open predicate (composes repo-paths + claim-eligibility + TERMINAL_STATUSES)" },
+      { "name": "lib/fleet/claim-eligibility.cjs", "change": "UPDATE — classifyDispatchIneligibility consults fitness + clears dispatch_rank for unfit" },
+      { "name": "scripts/sd-start.js", "change": "UPDATE — fail-fast unfit check before claim (mirror crosscheck-BLOCK pattern)" },
+      { "name": "scripts/worker-signal.cjs", "change": "UPDATE — add 'unfit' SIGNAL_TYPE + structured payload" },
+      { "name": "lib/coordinator/signal-router.cjs", "change": "UPDATE — recognize/route signal_type='unfit'" },
+      { "name": "lib/fleet/unfit-triage.cjs", "change": "NEW — propose-only partial-block decomposition (reuses buildChildSD)" },
+      { "name": "tests/unit/fleet/sd-executable-here.test.js", "change": "NEW — hermetic regression suite" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the fail-open predicate first, wire it into the shared seam + sd-start, add the typed signal + propose-only triage, lock with hermetic tests + the unchanged existing suite.",
+    "steps": [
+      "Read the existing primitives (repo-paths canonicalization, claim-eligibility classifyDispatchIneligibility, claimable-work TERMINAL_STATUSES, sd-start crosscheck-BLOCK ~1359-1373, worker-signal SIGNAL_TYPES, signal-router) to ground exact signatures.",
+      "Write lib/fleet/sd-executable-here.cjs (compose, fail-open) + its hermetic test suite.",
+      "Extend claim-eligibility.cjs classifyDispatchIneligibility additively + clear dispatch_rank for unfit; keep the existing suite green.",
+      "Add the sd-start fail-fast call mirroring the crosscheck-BLOCK + release_sd path.",
+      "Add 'unfit' to worker-signal SIGNAL_TYPES + structured payload + signal-router recognition.",
+      "Add lib/fleet/unfit-triage.cjs propose-only decomposition (reuse buildChildSD).",
+      "Run the new suite + the existing claim-eligibility suite; adversarial review (fail-open, repo false-positives, regression)."
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run the fitness unit tests: npx vitest run tests/unit/fleet/sd-executable-here.test.js", "expected_outcome": "Green. fit SD => {fit:true}; repo-mismatch/missing-precondition/premise-closed => {fit:false, blockClass:...}; internal error => fail-open {fit:true}." },
+    { "step_number": 2, "instruction": "Attempt to start an SD targeting the OTHER app from this EHG_Engineer checkout: node scripts/sd-start.js <other-app-SD>", "expected_outcome": "Fails fast with UNFIT(repo_mismatch) and does NOT claim (mirrors the crosscheck-BLOCK + release_sd path)." },
+    { "step_number": 3, "instruction": "Run the self-claim / backlog-rank path with an unfit SD present", "expected_outcome": "The unfit SD does not rank/surface (dispatch_rank cleared via classifyDispatchIneligibility); fit SDs still rank." },
+    { "step_number": 4, "instruction": "Emit a typed unfit signal: node scripts/worker-signal.cjs unfit \"repo mismatch: SD targets ehg, worktree is EHG_Engineer\" --severity medium", "expected_outcome": "Row written with payload.signal_type=unfit + structured payload; signal-router recognizes the type (not dropped)." },
+    { "step_number": 5, "instruction": "Trigger the partial-block triage in propose-only mode against a code+run SD", "expected_outcome": "Proposes a {code_child, blocked run_child} split via buildChildSD WITHOUT creating/executing anything (propose-not-execute)." }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-WORKER-CLAIM-TIME-001"
+  }
+}

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -28,20 +28,38 @@
  *  real keys that merely START with these letters (SD-TESTABLE-*, SD-DEMONSTRATE-*) are NOT excluded. */
 const TEST_FIXTURE_KEY_RE = /^SD-(DEMO|TEST)\b/;
 
+// SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): claim-time fitness predicate (repo-match + premise +
+// preconditions), composed here so the same gate that excludes orchestrator parents / fixtures /
+// human-action SDs also excludes work that is unfit for the CURRENT checkout. Fail-open by design.
+const { isSdExecutableHere } = require('./sd-executable-here.cjs');
+
 /**
  * PURE, synchronous, DB-free dispatch-ineligibility classifier for the non-dependency axes.
  * Returns null when the SD is eligible on these axes, or a reason string when it is ineligible.
  * Shared by evaluateDispatchEligibility (after its fetch), the sweep available-set filter, and the
  * worker self_claim draft path — one source of truth so the classes cannot drift apart again.
  *
- * @param {{ sd_key?: string, sd_type?: string, metadata?: object }} sdRow  an already-loaded SD row
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required'}
+ * SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): an OPTIONAL `ctx` enables the claim-time fitness axes
+ * (repo-match against ctx.cwd / ctx.currentApp, premise-open, preconditions). When `ctx` is omitted
+ * the behavior is BYTE-IDENTICAL to before (zero regression for the ~existing callers); the SD row
+ * must carry `target_application` + `status` for the repo/premise axes to apply (absent => fail-open
+ * fit). isSdExecutableHere fails open, so a fitness fault never adds an ineligibility.
+ *
+ * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
+ * @param {{ cwd?: string, currentApp?: string }} [ctx]  when present, applies the claim-time fitness axes
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
-function classifyDispatchIneligibility(sdRow) {
+function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
   if (row.sd_type === 'orchestrator') return 'orchestrator_parent';
   if (typeof row.sd_key === 'string' && TEST_FIXTURE_KEY_RE.test(row.sd_key)) return 'test_fixture_key';
   if (row.metadata && row.metadata.requires_human_action) return 'human_action_required';
+  if (ctx) {
+    try {
+      const verdict = isSdExecutableHere(row, ctx);
+      if (verdict && verdict.fit === false && verdict.blockClass) return `unfit_${verdict.blockClass}`;
+    } catch { /* fail-open: a fitness fault never blocks dispatch */ }
+  }
   return null;
 }
 
@@ -92,17 +110,20 @@ async function draftDepsSatisfied(sb, sd, { throwOnError = false } = {}) {
  * THROWS on a query error (the lookup or the dep-status check) — the caller decides how to degrade.
  * `sdKey` is the sd_KEY string (v_sd_next_candidates.sd_id holds the key; claude_sessions.sd_key too).
  */
-async function evaluateDispatchEligibility(sb, sdKey) {
+async function evaluateDispatchEligibility(sb, sdKey, ctx) {
   const { data, error } = await sb
     .from('strategic_directives_v2')
-    .select('sd_key, sd_type, dependencies, metadata')
+    // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): target_application + status added so the optional
+    // claim-time fitness axes (repo-match / premise-open) have the fields they need when ctx is passed.
+    .select('sd_key, sd_type, dependencies, metadata, target_application, status')
     .eq('sd_key', sdKey)
     .maybeSingle();
   if (error) throw error;                                       // uncertain -> caller decides
   if (!data) return { eligible: false, reason: 'sd_not_found' }; // can't verify -> not dispatchable
-  // Shared DB-free axes (orchestrator-parent, test-fixture, human-action). data carries sd_key from
-  // the query above so the fixture check resolves even though the caller passed sdKey separately.
-  const ineligible = classifyDispatchIneligibility({ ...data, sd_key: data.sd_key || sdKey });
+  // Shared DB-free axes (orchestrator-parent, test-fixture, human-action) + optional fitness (ctx).
+  // data carries sd_key from the query above so the fixture check resolves even though the caller
+  // passed sdKey separately.
+  const ineligible = classifyDispatchIneligibility({ ...data, sd_key: data.sd_key || sdKey }, ctx);
   if (ineligible) return { eligible: false, reason: ineligible };
   const depsOk = await draftDepsSatisfied(sb, data, { throwOnError: true }); // propagate dep-query errors
   return depsOk ? { eligible: true } : { eligible: false, reason: 'dep_blocked' };
@@ -112,9 +133,9 @@ async function evaluateDispatchEligibility(sb, sdKey) {
  * Boolean wrapper preserving the worker-checkin self_claim contract: false for orchestrator parents,
  * dep-blocked SDs, not-found, OR any query error (conservative: never claim on uncertainty).
  */
-async function baselinedCandidateEligible(sb, sdKey) {
+async function baselinedCandidateEligible(sb, sdKey, ctx) {
   try {
-    return (await evaluateDispatchEligibility(sb, sdKey)).eligible;
+    return (await evaluateDispatchEligibility(sb, sdKey, ctx)).eligible;
   } catch {
     return false; // conservative: skip this candidate on a query error
   }

--- a/lib/fleet/sd-executable-here.cjs
+++ b/lib/fleet/sd-executable-here.cjs
@@ -1,0 +1,99 @@
+'use strict';
+/**
+ * sd-executable-here.cjs — SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-1)
+ *
+ * One reusable predicate that answers "can a fleet worker actually execute this SD HERE/NOW?"
+ * BEFORE it commits a claim — eliminating the recurring unfit-assignment churn (live: worker Alpha
+ * claimed an SD targeting the EHG app from an EHG_Engineer checkout, then an SD whose run-input data
+ * file was absent, then an already-released SD). It COMPOSES existing primitives (it does NOT
+ * reimplement repo resolution, terminal-status, or eligibility):
+ *   - repo-match     : normalizeAppName (same trivial rule as lib/repo-paths.js) — positive
+ *                      target-vs-checkout mismatch only.
+ *   - premise-open   : REUSES lib/coordinator/claimable-work.cjs TERMINAL_STATUSES (+ superseded/
+ *                      released/handled metadata flags).
+ *   - preconditions  : declared input-data preconditions (metadata.preconditions) probed against the
+ *                      checkout (injectable probe; default = fs.existsSync for {type:'file'}).
+ *
+ * INVARIANT — FAIL OPEN. A fitness bug must NEVER block all claims (fleet-wide stall). Any internal
+ * error, any indeterminate signal, and an absent/ambiguous target_application all yield fit:true.
+ * Only a POSITIVELY-determined unfit condition returns fit:false. Pure + injectable (cwd, probe,
+ * terminalStatuses all overridable) so it is unit-testable with no live DB and no real filesystem.
+ */
+const path = require('path');
+const fs = require('fs');
+
+let TERMINAL_STATUSES;
+try { ({ TERMINAL_STATUSES } = require('../coordinator/claimable-work.cjs')); }
+catch { TERMINAL_STATUSES = Object.freeze(['completed', 'cancelled', 'archived', 'deferred']); }
+
+/** Same normalization rule as lib/repo-paths.js normalizeAppName (inlined to keep this CJS module
+ *  free of the ESM repo-paths import; 'EHG_Engineer' -> 'ehgengineer', 'ehg' -> 'ehg'). */
+function normalizeAppName(name) {
+  return String(name == null ? '' : name).toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/** Resolve the current checkout's app identity from a cwd: strip any /.worktrees/<sd> suffix, take
+ *  the repo-root basename, normalize. Returns '' when indeterminate (=> repo check is skipped). */
+function appOfCwd(cwd) {
+  const p = String(cwd == null ? '' : cwd).replace(/\\/g, '/').replace(/\/\.worktrees\/[^/]+.*$/, '').replace(/\/+$/, '');
+  const base = p.split('/').filter(Boolean).pop() || '';
+  return normalizeAppName(base);
+}
+
+function unfit(blockClass, reason) { return { fit: false, blockClass, reasons: [reason] }; }
+function fit(reason) { return { fit: true, blockClass: null, reasons: reason ? [reason] : [] }; }
+
+/**
+ * @param {{sd_key?:string, target_application?:string, status?:string, metadata?:object}} sd
+ * @param {{cwd?:string, currentApp?:string, repoRoot?:string, terminalStatuses?:string[], preconditionProbe?:Function}} [ctx]
+ * @returns {{fit:boolean, blockClass:('repo_mismatch'|'missing_precondition'|'premise_closed'|null), reasons:string[]}}
+ */
+function isSdExecutableHere(sd, ctx = {}) {
+  try {
+    const row = sd || {};
+    const md = (row.metadata && typeof row.metadata === 'object') ? row.metadata : {};
+    const terminal = Array.isArray(ctx.terminalStatuses) ? ctx.terminalStatuses : TERMINAL_STATUSES;
+
+    // 1. premise-open — a terminal / superseded / released / handled SD is not executable.
+    if (row.status && terminal.includes(row.status)) return unfit('premise_closed', `status='${row.status}' is terminal`);
+    if (md.superseded === true || md.released === true || md.handled === true) {
+      return unfit('premise_closed', 'metadata marks the premise superseded/released/handled');
+    }
+
+    // 2. repo-match — POSITIVE target-vs-checkout mismatch only. Absent/ambiguous target => fit.
+    const target = normalizeAppName(row.target_application);
+    if (target) {
+      const current = ctx.currentApp ? normalizeAppName(ctx.currentApp) : appOfCwd(ctx.cwd || process.cwd());
+      if (current && target !== current) {
+        return unfit('repo_mismatch', `SD targets '${row.target_application}' but checkout is '${current}'`);
+      }
+    }
+
+    // 3. preconditions — declared input-data requirements must be present in the checkout.
+    const pres = Array.isArray(md.preconditions) ? md.preconditions : [];
+    if (pres.length) {
+      const probe = typeof ctx.preconditionProbe === 'function'
+        ? ctx.preconditionProbe
+        : (pc) => {
+            try {
+              if (pc && pc.type === 'file' && pc.path) {
+                return fs.existsSync(path.resolve(ctx.repoRoot || process.cwd(), String(pc.path)));
+              }
+              return true; // unknown precondition type => treat as met (fail-open)
+            } catch { return true; }
+          };
+      for (const pc of pres) {
+        let met = true;
+        try { met = probe(pc) !== false; } catch { met = true; } // probe error => met (fail-open)
+        if (!met) return unfit('missing_precondition', `precondition unmet: ${JSON.stringify(pc)}`);
+      }
+    }
+
+    return fit();
+  } catch (e) {
+    // FAIL OPEN: a predicate fault must never block a claim.
+    return { fit: true, blockClass: null, reasons: [`fail-open: ${e && e.message ? e.message : String(e)}`] };
+  }
+}
+
+module.exports = { isSdExecutableHere, normalizeAppName, appOfCwd };

--- a/lib/fleet/unfit-triage.cjs
+++ b/lib/fleet/unfit-triage.cjs
@@ -1,0 +1,63 @@
+'use strict';
+/**
+ * unfit-triage.cjs — SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-5)
+ *
+ * PROPOSE-ONLY partial-block triage. When an SD is code-buildable HERE but its RUN is blocked (e.g.
+ * a missing input-data precondition — the live YOUTUBE-STRATEGY-EXTRACTION case: the code exists,
+ * only the extraction RUN needs an absent ledger file), propose splitting it into a buildable code
+ * child + a blocked run child so the coordinator can route the buildable half NOW and gate the run
+ * half until the precondition is met.
+ *
+ * PROPOSE-NOT-EXECUTE BOUNDARY: this module NEVER creates or executes children (it does not import or
+ * call lib/eva insertCascade). It returns the proposed child SPECS — shaped to be fed to
+ * lib/eva/create-orchestrator-from-plan.js buildChildSD by a coordinator/chairman who decides whether
+ * to materialize them — plus the typed unfit-signal command to file. Pure + synchronous + testable.
+ *
+ * A repo_mismatch or premise_closed verdict is NOT a partial block — those are whole-SD reroutes /
+ * closures, not splits — so proposeUnfitDecomposition returns { propose:false } for them.
+ */
+
+// Only these block classes warrant a code/run SPLIT (the code is buildable here; the run is gated).
+const PARTIAL_BLOCK_CLASSES = Object.freeze(['missing_precondition']);
+
+/**
+ * @param {{sd_key?:string, title?:string}} sd  the unfit SD
+ * @param {{blockClass?:string, reasons?:string[]}} verdict  the isSdExecutableHere verdict
+ * @returns {{propose:boolean, parent:string|null, blockClass?:string, reason?:string, children?:Array, signal?:string}}
+ */
+function proposeUnfitDecomposition(sd, verdict) {
+  const row = sd || {};
+  const v = verdict || {};
+  const parent = row.sd_key || null;
+  if (!v.blockClass || !PARTIAL_BLOCK_CLASSES.includes(v.blockClass)) {
+    return { propose: false, parent, reason: `blockClass '${v.blockClass || 'none'}' is a whole-SD reroute/closure, not a partial block — no split proposed` };
+  }
+  const parentKey = parent || 'SD-UNKNOWN';
+  const baseTitle = row.title || parentKey;
+  const why = (v.reasons || []).join('; ');
+  const children = [
+    {
+      suffix: 'CODE',
+      role: 'code',
+      blocked: false,
+      title: `${baseTitle} — buildable code`,
+      description: `Code-buildable slice of ${parentKey} (no blocked run dependency). Split-proposed by claim-time triage because the parent's run is blocked: ${why}.`,
+    },
+    {
+      suffix: 'RUN',
+      role: 'run',
+      blocked: true,
+      title: `${baseTitle} — blocked run`,
+      description: `Run/execution slice of ${parentKey}, BLOCKED on a missing precondition (${why}). Unblock the precondition, then execute.`,
+    },
+  ];
+  return {
+    propose: true,
+    parent: parentKey,
+    blockClass: v.blockClass,
+    children, // buildChildSD-compatible specs — materialized only by an explicit coordinator/chairman action
+    signal: `node scripts/worker-signal.cjs unfit "${v.blockClass}: ${parentKey} — proposing code/run split" --block-class ${v.blockClass}`,
+  };
+}
+
+module.exports = { proposeUnfitDecomposition, PARTIAL_BLOCK_CLASSES };

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -64,6 +64,9 @@ import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-
 import { shouldShowVenturePipelinePointer, VENTURE_PIPELINE_POINTER } from '../lib/leo/venture-pipeline-pointer.js';
 // SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: enforce declared dependencies at claim time.
 import { evaluateDependencyGate, formatDependencyRefusal } from '../lib/sd-start/dependency-gate.mjs';
+// SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-3): claim-time fitness fail-fast (repo-match + premise +
+// preconditions). CJS module imported as default (Node CJS interop) for its named export.
+import sdFit from '../lib/fleet/sd-executable-here.cjs';
 
 dotenv.config();
 
@@ -1375,6 +1378,32 @@ async function main() {
   } catch (ccErr) {
     // Non-blocking — cross-check is defense-in-depth
     console.log(`${colors.dim}[crosscheck] skipped: ${ccErr.message}${colors.reset}`);
+  }
+
+  // 4.45. SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-3): claim-time fitness fail-fast. Refuse to HOLD a
+  // claim for an SD that is unfit for THIS checkout — a repo mismatch (SD targets a different app),
+  // a closed premise (terminal/superseded/released), or a missing input-data precondition — and
+  // release it back to the queue. Mirrors the target-application crosscheck BLOCK + release_sd path
+  // above. FAIL-OPEN: isSdExecutableHere only returns fit:false on a POSITIVELY-determined unfit
+  // condition, so an indeterminate signal (e.g. no target_application) never blocks a start.
+  try {
+    const fitVerdict = sdFit.isSdExecutableHere(
+      { sd_key: sd.sd_key, target_application: sd.target_application, status: sd.status, metadata: sd.metadata },
+      { cwd: process.cwd() }
+    );
+    if (fitVerdict && fitVerdict.fit === false) {
+      console.error(`\n${colors.red}   ❌ UNFIT(${fitVerdict.blockClass}): ${(fitVerdict.reasons || []).join('; ')}${colors.reset}`);
+      console.error(`${colors.dim}   Refusing to hold this claim from the current checkout; releasing ${effectiveId}.${colors.reset}`);
+      console.error(`${colors.dim}   Route it: node scripts/worker-signal.cjs unfit "${fitVerdict.blockClass}: ${sd.sd_key}"${colors.reset}`);
+      await supabase.rpc('release_sd', {
+        p_session_id: session.session_id,
+        p_reason: 'manual'
+      }).catch(() => {});
+      process.exit(1);
+    }
+  } catch (fitErr) {
+    // Non-blocking — fitness fail-fast is defense-in-depth and must fail open.
+    console.log(`${colors.dim}[fitness] skipped (fail-open): ${fitErr.message}${colors.reset}`);
   }
 
   // 4.5. Resolve worktree (creates if needed in claim mode)

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -67,6 +67,9 @@ import { evaluateDependencyGate, formatDependencyRefusal } from '../lib/sd-start
 // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-3): claim-time fitness fail-fast (repo-match + premise +
 // preconditions). CJS module imported as default (Node CJS interop) for its named export.
 import sdFit from '../lib/fleet/sd-executable-here.cjs';
+// SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-5): propose-only partial-block triage surfaced on an unfit
+// fail-fast (a missing-precondition block proposes a code/run split — never created here).
+import unfitTriage from '../lib/fleet/unfit-triage.cjs';
 
 dotenv.config();
 
@@ -1394,7 +1397,18 @@ async function main() {
     if (fitVerdict && fitVerdict.fit === false) {
       console.error(`\n${colors.red}   ❌ UNFIT(${fitVerdict.blockClass}): ${(fitVerdict.reasons || []).join('; ')}${colors.reset}`);
       console.error(`${colors.dim}   Refusing to hold this claim from the current checkout; releasing ${effectiveId}.${colors.reset}`);
-      console.error(`${colors.dim}   Route it: node scripts/worker-signal.cjs unfit "${fitVerdict.blockClass}: ${sd.sd_key}"${colors.reset}`);
+      console.error(`${colors.dim}   Route it: node scripts/worker-signal.cjs unfit "${fitVerdict.blockClass}: ${sd.sd_key}" --block-class ${fitVerdict.blockClass}${colors.reset}`);
+      // FR-5: on a PARTIAL block (the code is buildable here but the run is gated), surface a
+      // propose-only code/run decomposition for the coordinator. Nothing is created here.
+      try {
+        const proposal = unfitTriage.proposeUnfitDecomposition({ sd_key: sd.sd_key, title: sd.title }, fitVerdict);
+        if (proposal && proposal.propose) {
+          console.error(`${colors.dim}   Partial block — proposed split (propose-only, NOT created):${colors.reset}`);
+          for (const c of proposal.children) {
+            console.error(`${colors.dim}     - [${c.role}${c.blocked ? ' BLOCKED' : ''}] ${c.title}${colors.reset}`);
+          }
+        }
+      } catch { /* triage is advisory — never block the release on it */ }
       await supabase.rpc('release_sd', {
         p_session_id: session.session_id,
         p_reason: 'manual'

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -521,7 +521,9 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
       .from('strategic_directives_v2')
       // sd_key/sd_type/metadata feed classifyDispatchIneligibility; current_phase feeds the
       // resume message (advisory — sd-start reads the live phase authoritatively on attach).
-      .select('sd_key, sd_type, status, current_phase, metadata, updated_at')
+      // target_application added for the SD-LEO-INFRA-WORKER-CLAIM-TIME-001 claim-time repo-match
+      // axis so a repo-mismatched orphan is not adopted into the wrong checkout.
+      .select('sd_key, sd_type, status, current_phase, metadata, updated_at, target_application')
       .eq('status', 'in_progress')
       .is('claiming_session_id', null)
       .neq('sd_type', 'orchestrator')         // parents are in_progress/no-claim BY DESIGN while children run
@@ -531,8 +533,9 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
     for (const sd of (orphans || [])) {
       // Shared classifier (same predicate as the draft tier + coordinator sweep): orchestrator
       // (redundant with .neq — harmless), test-fixture keys (SD-DEMO-*/SD-TEST-*), and
-      // metadata.requires_human_action all skip.
-      if (classifyDispatchIneligibility(sd) !== null) continue;
+      // metadata.requires_human_action all skip. SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): {cwd}
+      // adds the claim-time fitness axes so a repo-mismatched orphan is not adopted here.
+      if (classifyDispatchIneligibility(sd, { cwd: process.cwd() }) !== null) continue;
       // Live-foreign-holder probe (the half-write case: SD-side claim cleared but a LIVE session
       // still points at it via claude_sessions.sd_key). Fail-open: probe errors don't block.
       try {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -391,8 +391,9 @@ async function fetchDraftCandidates(sb) {
   const { data: drafts } = await sb
     .from('strategic_directives_v2')
     // metadata feeds the shared classifyDispatchIneligibility gate (the requires_human_action axis);
-    // sd_type already selected for the existing orchestrator exclusion.
-    .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata')
+    // sd_type already selected for the existing orchestrator exclusion. target_application added for
+    // the SD-LEO-INFRA-WORKER-CLAIM-TIME-001 claim-time repo-match fitness axis.
+    .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata, target_application')
     .in('status', ['draft', 'active'])
     .is('claiming_session_id', null)
     .neq('sd_type', 'orchestrator')
@@ -410,7 +411,9 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d) {
   // SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001: same shared classifier the baselined candidate-view
   // tier (step 6) and the coordinator/sweep PUSH path use — the un-baselined draft tier must not
   // self-claim a test-fixture phantom (SD-DEMO-*/SD-TEST-*) or a requires_human_action SD.
-  if (classifyDispatchIneligibility(d) !== null) return null;
+  // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): pass {cwd} so an SD that is unfit for THIS checkout
+  // (repo mismatch / closed premise / missing precondition) is skipped before claiming.
+  if (classifyDispatchIneligibility(d, { cwd: process.cwd() }) !== null) return null;
   if (!(await draftDepsSatisfied(sb, d))) return null; // skip dependency-blocked
   if (await isSdInFlight(sb, d.sd_key, sessionId)) return null; // dedup: started or live-foreign-held
   const claimed = await tryClaim(sb, d.sd_key, sessionId);
@@ -920,7 +923,9 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       if (x.kind === 'baselined') {
         // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: skip dependency-blocked SDs and orchestrator PARENTS
         // (the view surfaces both; claim_sd enforces neither). Mirrors the draft-tier guard.
-        if (!(await baselinedCandidateEligible(sb, x.key))) continue;
+        // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): {cwd} adds the claim-time fitness axes so a
+        // baselined candidate unfit for THIS checkout is skipped before claiming.
+        if (!(await baselinedCandidateEligible(sb, x.key, { cwd: process.cwd() }))) continue;
         if (await isSdInFlight(sb, x.key, sessionId)) continue;  // dedup: started or live-foreign-held
         const claimed = await tryClaim(sb, x.key, sessionId, x.track);
         if (claimed.ok) {

--- a/scripts/worker-signal.cjs
+++ b/scripts/worker-signal.cjs
@@ -20,7 +20,12 @@ const crypto = require('crypto');
 const { createClient } = require('@supabase/supabase-js');
 const { getActiveCoordinatorId, isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 
-const SIGNAL_TYPES = ['stuck', 'need-sweep', 'prd-ambiguous', 'gate-bug', 'spec-conflict', 'harness-bug', 'feedback', 'other'];
+// SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-4): 'unfit' — a worker reporting an assignment it cannot
+// execute HERE/NOW (repo mismatch / closed premise / missing input precondition). Replaces the
+// free-text release so the coordinator can route systematically; carries a structured payload
+// (block_class via --block-class, plus the standard sd_key + repo). The signal-router is
+// signal_type-agnostic, so aggregation/promotion works without router changes.
+const SIGNAL_TYPES = ['stuck', 'need-sweep', 'prd-ambiguous', 'gate-bug', 'spec-conflict', 'harness-bug', 'feedback', 'unfit', 'other'];
 const SEVERITIES = ['low', 'medium', 'high', 'critical'];
 const BODY_HARD_CAP = 4096;
 
@@ -471,6 +476,11 @@ async function main() {
   } catch { /* best-effort */ }
 
   const subject = `[WORKER_SIGNAL:${type.toUpperCase()}] ${body.slice(0, 80)}`;
+  // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-4): an 'unfit' signal carries a structured block_class
+  // (repo_mismatch | premise_closed | missing_precondition) so the coordinator routes it
+  // systematically instead of parsing free text. --block-class is accepted for any type but is the
+  // intended companion of `unfit`.
+  const blockClass = flags['block-class'] ? redact(String(flags['block-class'])).slice(0, 80) : null;
   const payload = {
     signal_type: type,
     body,
@@ -478,7 +488,8 @@ async function main() {
     sender_callsign: senderCallsign,
     sd_key: claimedSdKey,
     repo: process.cwd(),
-    ...(subtype ? { subtype } : {})
+    ...(subtype ? { subtype } : {}),
+    ...(blockClass ? { block_class: blockClass } : {})
   };
 
   const expiresAt = new Date(Date.now() + 24 * 60 * 60_000).toISOString();

--- a/tests/dispatch-eligibility-convergence.test.js
+++ b/tests/dispatch-eligibility-convergence.test.js
@@ -121,6 +121,8 @@ describe('(C) wiring pins — all push/pull consumers call the shared gate', () 
 
   it('worker-checkin draft self_claim path invokes classifyDispatchIneligibility', () => {
     const src = fs.readFileSync(path.join(ROOT, 'scripts', 'worker-checkin.cjs'), 'utf8');
-    expect(src).toMatch(/classifyDispatchIneligibility\(d\)\s*!==\s*null/);
+    // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): the call now passes an optional {cwd} ctx for the
+    // claim-time fitness axes; accept the original (d) form OR (d, { ... }).
+    expect(src).toMatch(/classifyDispatchIneligibility\(d(?:,\s*\{[^}]*\})?\)\s*!==\s*null/);
   });
 });

--- a/tests/unit/fleet/sd-executable-here.test.js
+++ b/tests/unit/fleet/sd-executable-here.test.js
@@ -1,0 +1,118 @@
+// SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-1/FR-2/FR-5/FR-6) — claim-time fitness gate tests.
+// Hermetic: no live DB, no real filesystem (cwd + preconditionProbe injected). Validates the
+// predicate (incl. FAIL-OPEN), the backward-compatible claim-eligibility extension, and the
+// propose-only triage.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { isSdExecutableHere, normalizeAppName, appOfCwd } = require('../../../lib/fleet/sd-executable-here.cjs');
+const { classifyDispatchIneligibility } = require('../../../lib/fleet/claim-eligibility.cjs');
+const { proposeUnfitDecomposition } = require('../../../lib/fleet/unfit-triage.cjs');
+
+const ENGINEER_CWD = 'C:/Users/x/Projects/_EHG/EHG_Engineer/.worktrees/SD-FOO-001';
+
+describe('appOfCwd / normalizeAppName', () => {
+  it('strips the worktree suffix and normalizes the repo-root basename', () => {
+    expect(appOfCwd(ENGINEER_CWD)).toBe('ehgengineer');
+    expect(appOfCwd('/home/u/ehg')).toBe('ehg');
+    expect(appOfCwd('')).toBe(''); // indeterminate
+  });
+  it('normalizeAppName matches the repo-paths rule', () => {
+    expect(normalizeAppName('EHG_Engineer')).toBe('ehgengineer');
+    expect(normalizeAppName('EHG')).toBe('ehg');
+    expect(normalizeAppName(null)).toBe('');
+  });
+});
+
+describe('isSdExecutableHere (FR-1)', () => {
+  const ctx = { cwd: ENGINEER_CWD };
+
+  it('fit: target matches checkout, open premise, no preconditions', () => {
+    const v = isSdExecutableHere({ sd_key: 'SD-A', target_application: 'EHG_Engineer', status: 'draft' }, ctx);
+    expect(v).toEqual({ fit: true, blockClass: null, reasons: [] });
+  });
+
+  it('repo_mismatch: SD targets a different app than the checkout', () => {
+    const v = isSdExecutableHere({ sd_key: 'SD-E', target_application: 'ehg', status: 'draft' }, ctx);
+    expect(v.fit).toBe(false);
+    expect(v.blockClass).toBe('repo_mismatch');
+  });
+
+  it('absent/ambiguous target => FIT (no constraint; fail-open)', () => {
+    expect(isSdExecutableHere({ sd_key: 'SD-N', status: 'draft' }, ctx).fit).toBe(true);
+    expect(isSdExecutableHere({ sd_key: 'SD-N', target_application: '', status: 'draft' }, ctx).fit).toBe(true);
+    // indeterminate current app (a rootless cwd resolves to no app name) => skip repo check => fit
+    expect(isSdExecutableHere({ sd_key: 'SD-N', target_application: 'ehg', status: 'draft' }, { cwd: '/' }).fit).toBe(true);
+  });
+
+  it('premise_closed: terminal status or superseded/released/handled metadata', () => {
+    expect(isSdExecutableHere({ sd_key: 'SD-C', status: 'completed' }, ctx).blockClass).toBe('premise_closed');
+    expect(isSdExecutableHere({ sd_key: 'SD-C', status: 'cancelled' }, ctx).blockClass).toBe('premise_closed');
+    expect(isSdExecutableHere({ sd_key: 'SD-C', status: 'draft', metadata: { released: true } }, ctx).blockClass).toBe('premise_closed');
+    expect(isSdExecutableHere({ sd_key: 'SD-C', status: 'draft', metadata: { superseded: true } }, ctx).blockClass).toBe('premise_closed');
+  });
+
+  it('missing_precondition: a declared input precondition is unmet (injected probe)', () => {
+    const sd = { sd_key: 'SD-P', target_application: 'EHG_Engineer', status: 'draft', metadata: { preconditions: [{ type: 'file', path: 'data/ledger.json' }] } };
+    const unmet = isSdExecutableHere(sd, { ...ctx, preconditionProbe: () => false });
+    expect(unmet.blockClass).toBe('missing_precondition');
+    const met = isSdExecutableHere(sd, { ...ctx, preconditionProbe: () => true });
+    expect(met.fit).toBe(true);
+  });
+
+  it('FAILS OPEN: a probe that throws => fit (a fitness fault never blocks)', () => {
+    const sd = { sd_key: 'SD-P', target_application: 'EHG_Engineer', status: 'draft', metadata: { preconditions: [{ type: 'file', path: 'x' }] } };
+    const v = isSdExecutableHere(sd, { ...ctx, preconditionProbe: () => { throw new Error('boom'); } });
+    expect(v.fit).toBe(true);
+  });
+
+  it('FAILS OPEN: garbage input never throws', () => {
+    expect(isSdExecutableHere(null).fit).toBe(true);
+    expect(isSdExecutableHere(undefined, null).fit).toBe(true);
+  });
+
+  it('premise is checked before repo (a completed EHG SD reports premise_closed, not repo_mismatch)', () => {
+    const v = isSdExecutableHere({ sd_key: 'SD-X', target_application: 'ehg', status: 'completed' }, ctx);
+    expect(v.blockClass).toBe('premise_closed');
+  });
+});
+
+describe('classifyDispatchIneligibility (FR-2 — backward-compatible extension)', () => {
+  it('without ctx: behavior is unchanged (existing axes only)', () => {
+    expect(classifyDispatchIneligibility({ sd_type: 'orchestrator' })).toBe('orchestrator_parent');
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-DEMO-1' })).toBe('test_fixture_key');
+    expect(classifyDispatchIneligibility({ metadata: { requires_human_action: true } })).toBe('human_action_required');
+    // an SD that WOULD be unfit is STILL eligible when no ctx is passed (zero regression)
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-E', target_application: 'ehg', status: 'draft' })).toBeNull();
+  });
+  it('with ctx: adds the fitness axes (unfit_<blockClass>)', () => {
+    const ctx = { cwd: ENGINEER_CWD };
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-E', target_application: 'ehg', status: 'draft' }, ctx)).toBe('unfit_repo_mismatch');
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-C', status: 'completed' }, ctx)).toBe('unfit_premise_closed');
+    // a fit SD with ctx is still eligible
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-A', target_application: 'EHG_Engineer', status: 'draft' }, ctx)).toBeNull();
+  });
+  it('existing axes take precedence over fitness (orchestrator parent wins even with ctx)', () => {
+    expect(classifyDispatchIneligibility({ sd_type: 'orchestrator', target_application: 'ehg' }, { cwd: ENGINEER_CWD })).toBe('orchestrator_parent');
+  });
+});
+
+describe('proposeUnfitDecomposition (FR-5 — propose-only)', () => {
+  it('partial block (missing_precondition): proposes a code child + a blocked run child', () => {
+    const out = proposeUnfitDecomposition(
+      { sd_key: 'SD-RUN-001', title: 'Extract X' },
+      { blockClass: 'missing_precondition', reasons: ['precondition unmet: ledger.json'] }
+    );
+    expect(out.propose).toBe(true);
+    expect(out.parent).toBe('SD-RUN-001');
+    expect(out.children.map((c) => c.role)).toEqual(['code', 'run']);
+    expect(out.children[0].blocked).toBe(false);
+    expect(out.children[1].blocked).toBe(true);
+    expect(out.signal).toMatch(/worker-signal\.cjs unfit .*--block-class missing_precondition/);
+  });
+  it('whole-SD reroute (repo_mismatch / premise_closed): propose:false (no split)', () => {
+    expect(proposeUnfitDecomposition({ sd_key: 'SD-E' }, { blockClass: 'repo_mismatch' }).propose).toBe(false);
+    expect(proposeUnfitDecomposition({ sd_key: 'SD-C' }, { blockClass: 'premise_closed' }).propose).toBe(false);
+    expect(proposeUnfitDecomposition({ sd_key: 'SD-N' }, {}).propose).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-WORKER-CLAIM-TIME-001 — Worker claim-time fitness/readiness gate

Coordinator-assigned. Eliminates the recurring **unfit-assignment churn**: a worker claims an SD, then discovers mid-flight it cannot execute in its context (live: worker Alpha hit 4 consecutive unfit assignments — incl. an SD targeting the **EHG app claimed from an EHG_Engineer checkout**, an already-released SD, and a run-SD whose input data file was absent).

### Compose, not greenfield
A LEAD VALIDATION pass (`sub_agent_execution_results` `dcd2e090`) established this is a **compose/wire** effort — every building block had an existing primitive (`lib/repo-paths.js`, `lib/fleet/claim-eligibility.cjs`, `claimable-work.cjs TERMINAL_STATUSES`, `lib/eva buildChildSD`); nothing decided "is this SD executable HERE/NOW" before a worker committed.

### What ships
- **FR-1** `lib/fleet/sd-executable-here.cjs` — one pure, **FAIL-OPEN** `isSdExecutableHere(sd,ctx) → {fit, blockClass, reasons}`: repo-match (positive target-vs-checkout mismatch only), premise-open (reuses `TERMINAL_STATUSES` + superseded/released/handled), preconditions (injectable probe). Any error/indeterminate/absent-target ⇒ `fit` (a fitness bug can never stall the fleet).
- **FR-2** `lib/fleet/claim-eligibility.cjs` — `classifyDispatchIneligibility` gains an **optional `ctx`** that adds the `unfit_*` axes; without `ctx` it is byte-identical (zero regression). Threaded through `evaluateDispatchEligibility`/`baselinedCandidateEligible`; the self_claim **draft + baselined + orphan** paths pass `{cwd}`.
- **FR-3** `scripts/sd-start.js` — claim-time **fail-fast** (`release_sd` + exit) for an unfit SD, mirroring the existing target-application crosscheck BLOCK pattern.
- **FR-4** `scripts/worker-signal.cjs` — `unfit` signal type + structured `block_class` payload (the signal-router is type-agnostic).
- **FR-5** `lib/fleet/unfit-triage.cjs` — **propose-only** partial-block triage (missing_precondition ⇒ buildable code child + blocked run child); surfaced in sd-start, never created.
- **FR-6** 15 hermetic tests.

### Adversarial review (3 reviewers)
Confirmed the **FAIL-OPEN invariant is sound** and the primary live case correct (EHG-targeted SD from EHG_Engineer ⇒ `repo_mismatch`). Caught + fixed **2 regressions the initial green tests missed**: the orphan-adoption path missed the `{cwd}` ctx; a source-regex wiring test in `tests/` (not `tests/unit/`) went RED. Documented residuals: the cwd-basename current-app heuristic can false-positive only for a non-canonically-named clone with no `currentApp` override (not the fleet's canonical layout); `isVentureRepo` missing normalization is a pre-existing repo-paths bug (flagged).

### Verification
- **100/100 tests green** (15 new + 85 regression across 8 claim/checkin/dispatch/eligibility suites = zero regression); `schema:lint` 0 violations; TESTING evidence `f22fd55b` (PASS, 98).
- Live smoke: `appOfCwd` ⇒ `ehgengineer`; EHG-targeted ⇒ `repo_mismatch`; EHG_Engineer-targeted ⇒ fit; no-target ⇒ fail-open fit; completed ⇒ `premise_closed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
