### PR TITLE
fix(coordinator-charter-audit): stop DUTY-3 coordinator+Adam and DUTY-6 in-flight false-positives

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -5,6 +5,12 @@
 // returns { violation:boolean, detail:string, remediation:(string|null), ... }. The audit is READ-ONLY:
 // these functions never mutate state; `remediation` is the NAMED action the coordinator agent performs.
 
+// DUTY-6 belt parity: reuse the CANONICAL in-flight predicate (current_phase set AND != LEAD) so the audit's
+// claimable belt EXACTLY mirrors coordinator-backlog-rank.mjs's isStartedSd skip — a started/mid-build SD (even
+// momentarily unclaimed after a reap) is RESUMED via worker-checkin's resume_orphan path, never fresh-ranked, so
+// counting it claimable-needing-rank is a false DUTY-6 the named remediation (run backlog-rank) can never clear.
+import { isStartedSd } from './sd-exclusion.mjs';
+
 const DAY_MS = 86400000;
 const SD_KEY_RE = /^(SD-[A-Z0-9][A-Z0-9_-]*)/i;
 
@@ -234,6 +240,9 @@ export function computeDispatchBelt({ sds = [], statusByKey = {}, terminalSet, c
   const unclaimed = sds.filter((s) =>
     !s.claiming_session_id && !s.parent_sd_id && (!classifyIneligibility || classifyIneligibility(s) === null));
   const claimable = unclaimed.filter((s) =>
+    // in-flight (started, past LEAD) SDs are RESUMED, not fresh-ranked — mirror backlog-rank's isStartedSd skip so
+    // an unclaimed in_progress orphan is NOT a false DUTY-6 rank-staleness violation (it has no fresh rank by design).
+    !isStartedSd(s) &&
     (Array.isArray(s.dependencies) ? s.dependencies.map(extractDepKey).filter(Boolean) : []).every((k) => isTerminal(statusByKey[k])));
   return { unclaimed, claimable };
 }

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -33,6 +33,11 @@ import {
 } from '../lib/coordinator/charter-audit-detectors.mjs';
 // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: DUTY-7 silent-stall detector (drafts stranded with null vision_score).
 import { findStalledDrafts } from '../lib/coordinator/draft-stall-detector.mjs';
+// DUTY-3/8 worker-set fix: reuse the CANONICAL fleet-membership predicate (the same one coordinator-audit.mjs uses
+// via liveFleetWorkers) so the coordinator's OWN session + Adam (role=adam) / non_fleet / fixtures are never
+// miscounted as idle WORKERS. detectIdleWithWork only knows "no sd_key" → without this, the coordinator + Adam —
+// which legitimately never hold an SD claim — read as idle workers (a false DUTY-3 no WORK_ASSIGNMENT can clear).
+import { isDispatchableFleetMember } from '../lib/fleet/session-predicates.mjs';
 
 const require = createRequire(import.meta.url);
 const { isWithinArmedSilenceWindow } = require('../lib/fleet/silence-cap.cjs');
@@ -82,7 +87,7 @@ async function main() {
 
   // Defense-in-depth: exclude lifecycle-terminated sessions server-side (classifyLiveness also guards this).
   const { data: sessRows, error: sessErr } = await db.from('claude_sessions')
-    .select('session_id,terminal_id,heartbeat_at,sd_key,expected_silence_until,status')
+    .select('session_id,terminal_id,heartbeat_at,sd_key,expected_silence_until,status,metadata')
     .not('status', 'in', '(released,stale,ended)')
     .order('heartbeat_at', { ascending: false }).limit(80);
   const sessMarker = foundationalQueryError(sessErr, 'claude_sessions');
@@ -92,6 +97,14 @@ async function main() {
   // ── AUTHORITATIVE liveness (heartbeat | armed-silence | live PID) ──
   const isPidAlive = (s) => { const pid = resolveCcPidFromTerminalId(s.terminal_id, s.session_id); return pid != null && isProcessRunning(pid); };
   const live = sessions.filter((s) => classifyLiveness(s, { nowMs, staleThresholdMs: STALE_MS, isWithinArmedSilence: isWithinArmedSilenceWindow, isPidAlive }).alive);
+  // DUTY-3/8 operate on genuine WORKERS only: exclude the coordinator's own session + Adam + non_fleet + fixtures
+  // via the canonical predicate. detectIdleWithWork/detectProgressStall only check "no sd_key", so without this the
+  // coordinator and Adam (which never hold an SD claim) are counted as idle workers — a false DUTY-3 no
+  // WORK_ASSIGNMENT can ever clear. coordinatorId is resolved from the live set (is_coordinator), with an env
+  // fallback + a belt-and-suspenders is_coordinator filter in case the predicate's coordinatorId arg is unset.
+  const coordinatorId = (sessions.find((s) => s.metadata && s.metadata.is_coordinator === true) || {}).session_id
+    || process.env.CLAUDE_SESSION_ID || null;
+  const liveWorkers = live.filter((s) => !(s.metadata && s.metadata.is_coordinator === true) && isDispatchableFleetMember(s, coordinatorId));
 
   // pending WORK_ASSIGNMENTs (unread => still pending; read_at-stamped => drained by the sweep, NOT pending)
   let pendingAssignmentSessionIds = new Set();
@@ -144,7 +157,7 @@ async function main() {
   // ── run the pure detectors ──
   const D = {
     pool: detectWorktreePool({ count: wtCount, max: MAX_WORKTREE_COUNT }),
-    idle: detectIdleWithWork({ liveSessions: live, unclaimedCount: unclaimed.length, pendingAssignmentSessionIds }),
+    idle: detectIdleWithWork({ liveSessions: liveWorkers, unclaimedCount: unclaimed.length, pendingAssignmentSessionIds }),
     dep: detectDependencyHealth({ sds, statusByKey, terminalSet: TERMINAL, nowMs }),
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),
@@ -154,7 +167,7 @@ async function main() {
     draft: findStalledDrafts(sds, nowMs, { thresholdMs: DRAFT_STALL_MS, scoredKeys: scoredDraftKeys }),
     // SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001: DUTY-8 — claim-holders heartbeat-ALIVE but claimed SD FROZEN.
     // Reuses the canonical detectStuckWorker predicate (injected); advisory remediation count only (no new exit).
-    progress: detectProgressStall({ liveSessions: live, sds, nowMs, thresholdMs: PROGRESS_STALL_MS, isWithinArmedSilence: isWithinArmedSilenceWindow, detectStuck: detectStuckWorker }),
+    progress: detectProgressStall({ liveSessions: liveWorkers, sds, nowMs, thresholdMs: PROGRESS_STALL_MS, isWithinArmedSilence: isWithinArmedSilenceWindow, detectStuck: detectStuckWorker }),
   };
 
   const flag = (r) => (r.remediation ? '  ⚠ ' + r.remediation : '');

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -85,6 +85,15 @@ describe('computeDispatchBelt — canonical dispatch-eligibility (FR-3/FR-5)', (
     expect(computeDispatchBelt({ sds, statusByKey: { 'SD-DEP-001': 'in_progress' }, terminalSet: TERMINAL, classifyIneligibility: classify }).claimable).toHaveLength(0);
     expect(computeDispatchBelt({ sds, statusByKey: { 'SD-DEP-001': 'completed' }, terminalSet: TERMINAL, classifyIneligibility: classify }).claimable).toHaveLength(1);
   });
+  it('an in-flight (started, current_phase past LEAD) unclaimed SD is excluded from claimable but stays in unclaimed (DUTY-6 belt parity: backlog-rank skips isStartedSd, so the audit must not count it rank-stale)', () => {
+    const sds = [
+      { sd_key: 'SD-ORPHAN-001', sd_type: 'infrastructure', claiming_session_id: null, parent_sd_id: null, current_phase: 'PLAN_PRD', dependencies: [] },
+      { sd_key: 'SD-FRESH-001', sd_type: 'infrastructure', claiming_session_id: null, parent_sd_id: null, current_phase: 'LEAD', dependencies: [] },
+    ];
+    const r = computeDispatchBelt({ sds, statusByKey: {}, terminalSet: TERMINAL, classifyIneligibility: classify });
+    expect(r.unclaimed.map((s) => s.sd_key).sort()).toEqual(['SD-FRESH-001', 'SD-ORPHAN-001']); // both are unclaimed leaves
+    expect(r.claimable.map((s) => s.sd_key)).toEqual(['SD-FRESH-001']);                          // in-flight orphan NOT fresh-rankable
+  });
 });
 
 describe('extractDepKey — object-sentinel parity (FR-5)', () => {


### PR DESCRIPTION
## Problem

The coordinator charter-audit's standing **"confirm CHARTER_AUDIT_VIOLATIONS=0, never observe-only"** mandate was **structurally unsatisfiable** — two detector false-positives kept it pinned at ≥1 no matter what real remediation the coordinator performed. Confirmed live 3× in one session; logged 7+ times in the harness backlog, never fixed.

## Root causes & fixes

**DUTY-3 (idle-with-work) — coordinator + Adam miscounted as idle workers**
- `detectIdleWithWork` only knows "no `sd_key`". The caller (`coordinator-charter-audit.mjs`) passed the **coordinator's own session** and **Adam** (`role=adam`) into the worker set. Neither ever holds an SD claim, so both were perpetually flagged "idle workers" — a violation no `WORK_ASSIGNMENT` can clear (you can't assign an SD to the coordinator or Adam).
- **Fix:** filter the live set through the canonical `isDispatchableFleetMember` predicate (the same one `coordinator-audit.mjs` uses via `liveFleetWorkers`, which already reports 0 live-idle correctly) before the DUTY-3/DUTY-8 detectors. Adds `metadata` to the session select + an `is_coordinator` belt-and-suspenders.

**DUTY-6 (backlog-rank staleness) — in-flight orphans counted as claimable-needing-rank**
- `computeDispatchBelt` counted an in-flight (started, `current_phase` past LEAD) unclaimed orphan as claimable, but `coordinator-backlog-rank.mjs` deliberately **skips** such SDs (`isStartedSd`) — they're resumed via worker-checkin, never fresh-ranked. So the named remediation ("run backlog-rank") could never clear it.
- **Fix:** exclude `isStartedSd` from the `claimable` belt, mirroring backlog-rank exactly.

Both reuse **existing canonical predicates** (`isDispatchableFleetMember`, `isStartedSd`) rather than re-deriving looser logic.

## Verification

- Live audit goes **`CHARTER_AUDIT_VIOLATIONS` 1 → 0** with no real idle worker present (DUTY-3 now `none (0 idle-eligible)`).
- **33/33** detector unit tests pass, including a new in-flight-exclusion case. Existing `computeDispatchBelt` tests unaffected (`isStartedSd` is fail-open on SDs without `current_phase`).
- A genuinely idle worker (real `sd_key`-less fleet member) still triggers DUTY-3 — only the coordinator/Adam/in-flight false-positives are removed.

Closes the recurring charter-audit FP feedback cluster (DUTY-3 coordinator+Adam, DUTY-6 in_progress-unclaimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)