### PR TITLE
feat(SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001): file-free DB-direct SD sourcing (--proposal-b64 / --proposal-stdin)

### DIFF
--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -62,11 +62,15 @@ recall but is NOT the source of truth.)
    an operator-attached session (Adam or coordinator) running on `main` with no claim is hard-blocked
    by the worktree-hygiene Write guard, so materialize a DRAFT SD from a proposal WITHOUT writing a
    payload file and WITHOUT a throwaway worktree:
-   `node scripts/leo-create-sd.js --proposal-b64 "$(node -e "process.stdout.write(Buffer.from(JSON.stringify(PROPOSAL_OBJ)).toString('base64'))")"`
-   (or pipe the JSON: `… | node scripts/leo-create-sd.js --proposal-stdin`). Both flow through the same
-   validate → idempotency → create core as `--from-proposal` (add `--dry-run` to validate without
-   writing). Base64-on-the-wire is preferred — it is immune to the Bash single-quote mangling that
-   defeats inline JSON. Do **not** Write-then-`--from-proposal` and do **not** spin a worktree just to source.
+   `SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --proposal-b64 "$(node -e "process.stdout.write(Buffer.from(JSON.stringify(PROPOSAL_OBJ)).toString('base64'))")"`
+   (or pipe the JSON: `… | SD_CREATE_VIA_SKILL=1 node scripts/leo-create-sd.js --proposal-stdin`). Both
+   flow through the same validate → idempotency → create core as `--from-proposal` (add `--dry-run` to
+   validate without writing). The `SD_CREATE_VIA_SKILL=1` prefix is REQUIRED — the `ENF-SD-CREATE-SKILL`
+   PreToolUse hook (`scripts/hooks/pre-tool-enforce.cjs`) blocks every direct `leo-create-sd.js` call
+   (including `--from-proposal`) without it; proposal ingest is the sanctioned non-interactive path so the
+   prefix is the documented bypass. Base64-on-the-wire is preferred — it is immune to the Bash
+   single-quote mangling that defeats inline JSON. Do **not** Write-then-`--from-proposal` and do **not**
+   spin a worktree just to source.
 4. **Background monitoring during operator conversations.** Run the cron ticks but respond minimally;
    surface ONLY important events (stuck/struggling worker, empty-queue+idle, claim/worktree conflict,
    a worker question, a completion). Keep one coherent conversation; don't dump a dashboard every tick.

--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -58,6 +58,15 @@ recall but is NOT the source of truth.)
    (b) **harness backlog** (`feedback` where `category='harness_backlog'`, open), (c) inbox. Source
    backlog → DRAFT SDs ONLY when the queue would starve available workers; when the queue already has
    surplus (more unclaimed SDs than builders) it's **worker-bound** → wake workers, don't flood it.
+   **Canonical sourcing command (file-free, DB-direct — SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001):**
+   an operator-attached session (Adam or coordinator) running on `main` with no claim is hard-blocked
+   by the worktree-hygiene Write guard, so materialize a DRAFT SD from a proposal WITHOUT writing a
+   payload file and WITHOUT a throwaway worktree:
+   `node scripts/leo-create-sd.js --proposal-b64 "$(node -e "process.stdout.write(Buffer.from(JSON.stringify(PROPOSAL_OBJ)).toString('base64'))")"`
+   (or pipe the JSON: `… | node scripts/leo-create-sd.js --proposal-stdin`). Both flow through the same
+   validate → idempotency → create core as `--from-proposal` (add `--dry-run` to validate without
+   writing). Base64-on-the-wire is preferred — it is immune to the Bash single-quote mangling that
+   defeats inline JSON. Do **not** Write-then-`--from-proposal` and do **not** spin a worktree just to source.
 4. **Background monitoring during operator conversations.** Run the cron ticks but respond minimally;
    surface ONLY important events (stuck/struggling worker, empty-queue+idle, claim/worktree conflict,
    a worker question, a completion). Keep one coherent conversation; don't dump a dashboard every tick.

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2252,6 +2252,12 @@ export async function createFromProposalB64(b64, options = {}) {
  */
 function readStdinUtf8() {
   return new Promise((resolve, reject) => {
+    // No piped input (interactive TTY): 'end' would never fire and the process would
+    // hang until Ctrl-C. Fail loud instead — the caller surfaces [INVALID_PROPOSAL].
+    if (process.stdin.isTTY) {
+      reject(new Error('stdin is a TTY (no piped proposal JSON)'));
+      return;
+    }
     let data = '';
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', (chunk) => { data += chunk; });
@@ -2436,7 +2442,11 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // The base64 string is the first non-flag positional (base64 never starts with '-').
       const dryRun = args.includes('--dry-run');
       const b64KnownFlags = new Set(['--proposal-b64', '--dry-run']);
-      const b64Arg = args.find((a, i) => i > 0 && !a.startsWith('-') && !b64KnownFlags.has(a)) || args[1];
+      // No `|| args[1]` fallback: if no non-flag positional is present (e.g.
+      // `--proposal-b64 --dry-run`), b64Arg stays undefined so createFromProposalB64's
+      // guard reports the clear "requires a base64-encoded proposal JSON string" error
+      // instead of base64-decoding the literal '--dry-run' flag into junk.
+      const b64Arg = args.find((a, i) => i > 0 && !a.startsWith('-') && !b64KnownFlags.has(a));
       await createFromProposalB64(b64Arg, { dryRun });
     } else if (args[0] === '--proposal-stdin') {
       // SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001: file-free DB-direct sourcing via a pipe.

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2152,16 +2152,47 @@ function resolveProposalFiles(pathOrGlob) {
 }
 
 /**
+ * Per-proposal ingest CORE (SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001): given an
+ * already-parsed proposal OBJECT and a string `source` label, run validateProposalShape
+ * -> keyExists -> mapProposalToCreateArgs -> (dryRun ? report : createSD). Returns a
+ * {sdKey, file, action} row. This is the SINGLE shared path for every ingest route
+ * (file, --proposal-b64, --proposal-stdin) so they cannot drift. No FS/argv access here —
+ * callers are responsible for materializing the proposal object.
+ * @param {object} proposal — parsed proposal object
+ * @param {string} source — provenance label (file path, '<proposal-b64>', '<proposal-stdin>')
+ * @param {{dryRun?:boolean, deps?:{keyExists?:Function, createSD?:Function}}} options
+ */
+export async function ingestProposalObject(proposal, source, options = {}) {
+  const { dryRun = false, deps = {} } = options;
+  const _keyExists = deps.keyExists || keyExists;
+  const _createSD = deps.createSD || createSD;
+
+  const normalized = validateProposalShape(proposal, source);
+  const exists = await _keyExists(normalized.sdKey);
+  if (exists) {
+    console.log(`⏭️  ${normalized.sdKey} already exists, skipping (${source})`);
+    return { sdKey: normalized.sdKey, file: source, action: 'skipped' };
+  }
+  const args = mapProposalToCreateArgs(normalized, proposal, source);
+  if (dryRun) {
+    console.log(`🔎 [dry-run] would create ${args.sdKey} (${args.type}/${args.priority}) — ${args.title}`);
+    return { sdKey: normalized.sdKey, file: source, action: 'dry-run' };
+  }
+  await _createSD(args);
+  console.log(`✅ Created DRAFT SD ${args.sdKey} from ${source}`);
+  return { sdKey: normalized.sdKey, file: source, action: 'created' };
+}
+
+/**
  * --from-proposal ingest: read PROPOSAL-*.json file(s), validate, and create a
- * DRAFT SD per file via the existing createSD() path (verbatim key). Idempotent
- * (skips an already-materialized key). --dry-run validates + reports, zero writes.
+ * DRAFT SD per file via the shared ingestProposalObject() core (verbatim key).
+ * Idempotent (skips an already-materialized key). --dry-run validates + reports,
+ * zero writes.
  * @param {string} pathOrGlob
  * @param {{dryRun?:boolean, deps?:{keyExists?:Function, createSD?:Function, readFile?:Function, resolveFiles?:Function}}} options
  */
 export async function createFromProposal(pathOrGlob, options = {}) {
-  const { dryRun = false, deps = {} } = options;
-  const _keyExists = deps.keyExists || keyExists;
-  const _createSD = deps.createSD || createSD;
+  const { deps = {} } = options;
   const _readFile = deps.readFile || readFileSync;
   const _resolveFiles = deps.resolveFiles || resolveProposalFiles;
 
@@ -2181,24 +2212,83 @@ export async function createFromProposal(pathOrGlob, options = {}) {
       console.error(`[INVALID_PROPOSAL] ${file}: invalid JSON: ${e.message}`);
       process.exit(1);
     }
-    const normalized = validateProposalShape(proposal, file);
-    const exists = await _keyExists(normalized.sdKey);
-    if (exists) {
-      console.log(`⏭️  ${normalized.sdKey} already exists, skipping (${file})`);
-      results.push({ sdKey: normalized.sdKey, file, action: 'skipped' });
-      continue;
-    }
-    const args = mapProposalToCreateArgs(normalized, proposal, file);
-    if (dryRun) {
-      console.log(`🔎 [dry-run] would create ${args.sdKey} (${args.type}/${args.priority}) — ${args.title}`);
-      results.push({ sdKey: normalized.sdKey, file, action: 'dry-run' });
-      continue;
-    }
-    await _createSD(args);
-    console.log(`✅ Created DRAFT SD ${args.sdKey} from ${file}`);
-    results.push({ sdKey: normalized.sdKey, file, action: 'created' });
+    // Delegate to the shared core; the whole `options` (dryRun + deps) carries through.
+    results.push(await ingestProposalObject(proposal, file, options));
   }
   return results;
+}
+
+/**
+ * --proposal-b64 ingest (SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001): base64-decode a
+ * proposal JSON and route the OBJECT through ingestProposalObject(). FILE-FREE — lets an
+ * operator-attached session (Adam/coordinator) on main source a DRAFT SD without writing
+ * a payload file (which the worktree-hygiene Write guard blocks). base64-on-the-wire is
+ * PREFERRED over a raw --proposal-json argv flag because it is immune to the Bash
+ * single-quote mangling that defeats inline JSON. Buffer.from(.,'base64') is lenient
+ * (never throws on junk — it drops out-of-alphabet bytes), so the post-decode JSON.parse
+ * is the load-bearing validator that fails loud on garbage input.
+ * @param {string} b64
+ * @param {{dryRun?:boolean, deps?:{keyExists?:Function, createSD?:Function}}} options
+ */
+export async function createFromProposalB64(b64, options = {}) {
+  if (!b64 || typeof b64 !== 'string') {
+    console.error('[INVALID_PROPOSAL] --proposal-b64 requires a base64-encoded proposal JSON string');
+    process.exit(1);
+  }
+  const raw = Buffer.from(b64, 'base64').toString('utf8');
+  let proposal;
+  try {
+    proposal = JSON.parse(raw);
+  } catch (e) {
+    console.error(`[INVALID_PROPOSAL] --proposal-b64: invalid JSON after base64 decode: ${e.message}`);
+    process.exit(1);
+  }
+  return [await ingestProposalObject(proposal, '<proposal-b64>', options)];
+}
+
+/**
+ * Read all of process.stdin as a UTF-8 string (resolves on 'end'). Extracted so
+ * --proposal-stdin can inject a fake reader in unit tests (no real pipe needed).
+ */
+function readStdinUtf8() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+/**
+ * --proposal-stdin ingest (SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001): read a proposal
+ * JSON from stdin and route the OBJECT through ingestProposalObject(). FILE-FREE
+ * pipe-based counterpart to --proposal-b64. The stdin reader is injectable
+ * (deps.readStdin) so tests need no real pipe. Fails loud on empty stdin / invalid JSON.
+ * @param {{dryRun?:boolean, deps?:{keyExists?:Function, createSD?:Function, readStdin?:Function}}} options
+ */
+export async function createFromProposalStdin(options = {}) {
+  const { deps = {} } = options;
+  const _readStdin = deps.readStdin || readStdinUtf8;
+  let raw;
+  try {
+    raw = await _readStdin();
+  } catch (e) {
+    console.error(`[INVALID_PROPOSAL] --proposal-stdin: cannot read stdin: ${e.message}`);
+    process.exit(1);
+  }
+  if (!raw || !raw.trim()) {
+    console.error('[INVALID_PROPOSAL] --proposal-stdin: empty stdin (expected a proposal JSON on stdin)');
+    process.exit(1);
+  }
+  let proposal;
+  try {
+    proposal = JSON.parse(raw);
+  } catch (e) {
+    console.error(`[INVALID_PROPOSAL] --proposal-stdin: invalid JSON: ${e.message}`);
+    process.exit(1);
+  }
+  return [await ingestProposalObject(proposal, '<proposal-stdin>', options)];
 }
 
 // Export for programmatic use (e.g., corrective-sd-generator)
@@ -2222,6 +2312,8 @@ Usage:
   node scripts/leo-create-sd.js --from-feedback <feedback-id>
   node scripts/leo-create-sd.js --from-qf <QF-ID>
   node scripts/leo-create-sd.js --from-proposal <path|glob> [--dry-run]
+  node scripts/leo-create-sd.js --proposal-b64 <base64> [--dry-run]      # file-free DB-direct sourcing
+  cat PROPOSAL.json | node scripts/leo-create-sd.js --proposal-stdin [--dry-run]
   node scripts/leo-create-sd.js --from-plan [path] [--type <type>] [--title "<title>"]
   node scripts/leo-create-sd.js --child <parent-key> [index] [--type <type>] [--title "<title>"]
   node scripts/leo-create-sd.js <source> <type> "<title>"
@@ -2255,7 +2347,13 @@ Flags:
                         Pairs with computeReposForSD() at lead-final-approval/gates.js
                         (SD-LEO-INFRA-CROSS-REPO-MERGE-001). Supported in all 3 modes:
                         direct LEO, --from-plan, --child.
-  --dry-run          (--from-proposal only) Validate + report would-create SDs; ZERO database writes.
+  --dry-run          (--from-proposal / --proposal-b64 / --proposal-stdin) Validate + report
+                     would-create SDs; ZERO database writes.
+  --proposal-b64 <b64>  File-free DB-direct sourcing: base64-encoded proposal JSON ingested via
+                        the same validate -> keyExists -> create core as --from-proposal. PREFERRED
+                        for operator-attached (Adam/coordinator) sessions on main — needs NO payload
+                        file and NO worktree (base64-on-the-wire is immune to Bash quote mangling).
+  --proposal-stdin      File-free DB-direct sourcing via a pipe: read the proposal JSON from stdin.
   --help             Show this help message
 
 Dependency Field Guide:
@@ -2333,6 +2431,17 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const fpKnownFlags = new Set(['--from-proposal', '--dry-run']);
       const proposalArg = args.find((a, i) => i > 0 && !a.startsWith('-') && !fpKnownFlags.has(a)) || args[1];
       await createFromProposal(proposalArg, { dryRun });
+    } else if (args[0] === '--proposal-b64') {
+      // SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001: file-free DB-direct sourcing.
+      // The base64 string is the first non-flag positional (base64 never starts with '-').
+      const dryRun = args.includes('--dry-run');
+      const b64KnownFlags = new Set(['--proposal-b64', '--dry-run']);
+      const b64Arg = args.find((a, i) => i > 0 && !a.startsWith('-') && !b64KnownFlags.has(a)) || args[1];
+      await createFromProposalB64(b64Arg, { dryRun });
+    } else if (args[0] === '--proposal-stdin') {
+      // SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001: file-free DB-direct sourcing via a pipe.
+      const dryRun = args.includes('--dry-run');
+      await createFromProposalStdin({ dryRun });
     } else if (args[0] === '--from-plan') {
       // Check for --yes flag (skip confirmation for auto-detect)
       const hasYesFlag = args.includes('--yes') || args.includes('-y');

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -313,4 +313,13 @@ describe('createFromProposalB64 / createFromProposalStdin (file-free routes)', (
     await expect(createFromProposalStdin({ deps })).rejects.toThrow('process.exit(1)');
     expect(deps.createSD).not.toHaveBeenCalled();
   });
+
+  // Adversarial review LOW-2: a stdin read failure (e.g. the real reader rejecting on an
+  // interactive TTY with no piped input) must fail loud, never hang or proceed.
+  it('--proposal-stdin when the reader rejects → [INVALID_PROPOSAL] cannot read stdin + exit 1', async () => {
+    const deps = { readStdin: async () => { throw new Error('stdin is a TTY (no piped proposal JSON)'); }, createSD: vi.fn() };
+    await expect(createFromProposalStdin({ deps })).rejects.toThrow('process.exit(1)');
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('cannot read stdin');
+  });
 });

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -14,6 +14,9 @@ import {
   validateProposalShape,
   mapProposalToCreateArgs,
   createFromProposal,
+  ingestProposalObject,
+  createFromProposalB64,
+  createFromProposalStdin,
 } from '../../scripts/leo-create-sd.js';
 
 function validProposal(overrides = {}) {
@@ -202,5 +205,112 @@ describe('createFromProposal (dry-run + idempotency, injected deps, zero DB/FS)'
     const res = await createFromProposal('.prd-payloads/PROPOSAL-*.json', { dryRun: true, deps });
     expect(res).toHaveLength(2);
     expect(res.every(r => r.action === 'dry-run')).toBe(true);
+  });
+});
+
+// SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001: file-free DB-direct ingest. The shared
+// core (ingestProposalObject) plus the two file-free routes (--proposal-b64 / --proposal-stdin)
+// must flow through the SAME validate -> keyExists -> map -> createSD path as the file route.
+describe('ingestProposalObject (shared core — SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001)', () => {
+  let logSpy;
+  beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+  afterEach(() => { logSpy.mockRestore(); });
+
+  it('create path → {sdKey, file: source, action: created}, createSD called once with verbatim key', async () => {
+    const deps = { keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({ id: 'x' })) };
+    const res = await ingestProposalObject(validProposal(), '<unit>', { deps });
+    expect(res).toEqual({ sdKey: 'SD-LEO-INFRA-EXAMPLE-001', file: '<unit>', action: 'created' });
+    expect(deps.createSD).toHaveBeenCalledTimes(1);
+    expect(deps.createSD.mock.calls[0][0].sdKey).toBe('SD-LEO-INFRA-EXAMPLE-001');
+  });
+
+  it('dry-run → action=dry-run, createSD never called; existing key → action=skipped', async () => {
+    const dryDeps = { keyExists: vi.fn(async () => false), createSD: vi.fn() };
+    expect((await ingestProposalObject(validProposal(), '<unit>', { dryRun: true, deps: dryDeps })).action).toBe('dry-run');
+    expect(dryDeps.createSD).not.toHaveBeenCalled();
+
+    const existDeps = { keyExists: vi.fn(async () => true), createSD: vi.fn() };
+    expect((await ingestProposalObject(validProposal(), '<unit>', { deps: existDeps })).action).toBe('skipped');
+    expect(existDeps.createSD).not.toHaveBeenCalled();
+  });
+});
+
+describe('createFromProposalB64 / createFromProposalStdin (file-free routes)', () => {
+  let exitSpy, errorSpy, logSpy;
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit(${code})`); });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => { exitSpy.mockRestore(); errorSpy.mockRestore(); logSpy.mockRestore(); });
+
+  const b64Of = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64');
+
+  // The core parity guarantee: sourcing via base64 produces the SAME createSD args as the
+  // file path for the SAME proposal — modulo the provenance label (proposal_file_path),
+  // which legitimately records WHERE the proposal came from.
+  it('b64 ingest produces createSD args identical (modulo provenance) to the file path', async () => {
+    const proposal = validProposal();
+
+    const fileDeps = { resolveFiles: () => ['fake.json'], readFile: () => JSON.stringify(proposal), keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({})) };
+    await createFromProposal('fake.json', { deps: fileDeps });
+    const fileArgs = fileDeps.createSD.mock.calls[0][0];
+
+    const b64Deps = { keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({})) };
+    await createFromProposalB64(b64Of(proposal), { deps: b64Deps });
+    const b64Args = b64Deps.createSD.mock.calls[0][0];
+
+    const strip = (a) => { const c = JSON.parse(JSON.stringify(a)); delete c.metadata.proposal_file_path; return c; };
+    expect(strip(b64Args)).toEqual(strip(fileArgs));
+    expect(b64Args.metadata.proposal_file_path).toBe('<proposal-b64>');
+    expect(fileArgs.metadata.proposal_file_path).toBe('fake.json');
+  });
+
+  it('--proposal-b64 --dry-run never calls createSD; result file=<proposal-b64>', async () => {
+    const deps = { keyExists: vi.fn(async () => false), createSD: vi.fn() };
+    const res = await createFromProposalB64(b64Of(validProposal()), { dryRun: true, deps });
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(res).toEqual([{ sdKey: 'SD-LEO-INFRA-EXAMPLE-001', file: '<proposal-b64>', action: 'dry-run' }]);
+  });
+
+  it('--proposal-b64 idempotent: existing key skipped, createSD not called', async () => {
+    const deps = { keyExists: vi.fn(async () => true), createSD: vi.fn() };
+    const res = await createFromProposalB64(b64Of(validProposal()), { deps });
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(res[0].action).toBe('skipped');
+  });
+
+  it('--proposal-b64 with non-JSON after decode → [INVALID_PROPOSAL] + exit 1', async () => {
+    const deps = { keyExists: vi.fn(async () => false), createSD: vi.fn() };
+    // base64-decodes to plain text → JSON.parse fails (the load-bearing validator)
+    await expect(createFromProposalB64(Buffer.from('this is not json').toString('base64'), { deps })).rejects.toThrow('process.exit(1)');
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('[INVALID_PROPOSAL]');
+  });
+
+  it('--proposal-b64 with empty/non-string arg → [INVALID_PROPOSAL] + exit 1', async () => {
+    await expect(createFromProposalB64('', {})).rejects.toThrow('process.exit(1)');
+    expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('[INVALID_PROPOSAL]');
+  });
+
+  it('--proposal-stdin routes injected stdin JSON through the shared core (file=<proposal-stdin>)', async () => {
+    const deps = { readStdin: async () => JSON.stringify(validProposal()), keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({})) };
+    const res = await createFromProposalStdin({ deps });
+    expect(deps.createSD).toHaveBeenCalledTimes(1);
+    expect(deps.createSD.mock.calls[0][0].sdKey).toBe('SD-LEO-INFRA-EXAMPLE-001');
+    expect(res).toEqual([{ sdKey: 'SD-LEO-INFRA-EXAMPLE-001', file: '<proposal-stdin>', action: 'created' }]);
+  });
+
+  it('--proposal-stdin with empty stdin → [INVALID_PROPOSAL] + exit 1', async () => {
+    const deps = { readStdin: async () => '   ', createSD: vi.fn() };
+    await expect(createFromProposalStdin({ deps })).rejects.toThrow('process.exit(1)');
+    expect(deps.createSD).not.toHaveBeenCalled();
+    expect(errorSpy.mock.calls.map(c => c[0]).join('\n')).toContain('[INVALID_PROPOSAL]');
+  });
+
+  it('--proposal-stdin with invalid JSON → [INVALID_PROPOSAL] + exit 1', async () => {
+    const deps = { readStdin: async () => '{ not valid json', createSD: vi.fn() };
+    await expect(createFromProposalStdin({ deps })).rejects.toThrow('process.exit(1)');
+    expect(deps.createSD).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001 — file-free DB-direct SD sourcing

**Problem.** Operator-attached sessions (Adam / coordinator) run on `main` with no claim and are hard-blocked by the worktree-hygiene Write guard. Sourcing a DRAFT SD via `leo-create-sd.js --from-proposal` (file-only ingest) therefore forced writing a payload file (blocked) + a throwaway worktree — ~6 failed attempts observed for a single SD.

**Corrective (a) — shipped here.** The per-proposal ingest core (`validateProposalShape → keyExists → mapProposalToCreateArgs → createSD`) is extracted into a reusable exported `ingestProposalObject(proposal, source, {dryRun, deps})`. Two new FILE-FREE routes flow through it:
- `--proposal-b64 <base64>` — quoting-immune on the wire (preferred; immune to Bash single-quote mangling)
- `--proposal-stdin` — pipe the proposal JSON

`createFromProposal` now delegates to the shared core, so the file path stays byte-identical (pinned by the existing tests). `--help` and the Adam/coordinator role-contract doc (`docs/protocol/fleet-coordinator-and-worker-behavior.md`) document file-free DB-direct sourcing as the canonical sanctioned path.

**Corrective (b) — deferred (transparent).** The `pre-tool-enforce.cjs` role-aware hygiene-guard exemption is deferred to a dedicated security review; (a) removes sourcing's dependence on it.

### Verification
- Proposal unit suite **39/39 pass**; full `leo-create-sd` regression **67/67 pass** (5 files).
- Live smoke: `--proposal-b64 --dry-run` prints the would-create line with **no payload file + no worktree** (exit 0). File-based `--from-proposal` confirmed byte-identical.
- Adversarial review caught a real HIGH the green tests missed: the documented command omitted `SD_CREATE_VIA_SKILL=1` and was hard-blocked by the `ENF-SD-CREATE-SKILL` hook → doc fixed to show the working command. + 2 LOW polish (missing-positional clean error; stdin TTY fail-loud).

### Scope
`scripts/leo-create-sd.js`, `tests/unit/leo-create-sd-from-proposal.test.js`, `docs/protocol/fleet-coordinator-and-worker-behavior.md`. Additive, no schema change, no new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
