### PR TITLE
fix(SD-LEO-FIX-UNIT-TIER-STARTUP-001): fix Unit Tier YAML startup_failure + workflow-lint guard

### DIFF
--- a/.github/workflows/unit-tier.yml
+++ b/.github/workflows/unit-tier.yml
@@ -31,4 +31,9 @@ jobs:
 
       - name: Quarantine burn-down summary
         if: always()
-        run: node scripts/unit-tier-quarantine.mjs report .claude-unit-run.log 2>/dev/null || node -e "const m=require('./tests/quarantine-manifest.json'); const by={}; for(const e of m.quarantined) by[e.reason_class]=(by[e.reason_class]||0)+1; console.log('Quarantined files: '+m.quarantined.length); console.log(JSON.stringify(by,null,1));"
+        # SD-LEO-FIX-UNIT-TIER-STARTUP-001: block scalar (run: |) so the embedded
+        # "Quarantined files: " colon-space is literal text, not a YAML mapping
+        # separator. A plain scalar here caused a top-level parse failure (34:276)
+        # -> startup_failure on every run since #4619. Command is byte-identical.
+        run: |
+          node scripts/unit-tier-quarantine.mjs report .claude-unit-run.log 2>/dev/null || node -e "const m=require('./tests/quarantine-manifest.json'); const by={}; for(const e of m.quarantined) by[e.reason_class]=(by[e.reason_class]||0)+1; console.log('Quarantined files: '+m.quarantined.length); console.log(JSON.stringify(by,null,1));"

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ scripts/check-*.cjs
 # SD-LEO-INFRA-AUTO-CHECK-EXTERNAL-001: the external-status attribution-guard CLI is a permanent,
 # shared script (the runtime consumer of lib/fleet/external-status-check.mjs) — must be committed.
 !scripts/check-external-status.mjs
+# SD-LEO-FIX-UNIT-TIER-STARTUP-001 (FR-2): the workflow-YAML lint guard is a permanent, shared
+# author-time/CI check over .github/workflows/*.yml — must be committed.
+!scripts/check-workflow-yaml.mjs
 scripts/cleanup-*.js
 !scripts/cleanup-phantom-worktrees.js
 scripts/complete-*.mjs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -818,5 +818,22 @@ echo ""
 echo "📐 Checking CLAUDE_*.md drift vs leo_protocol_sections..."
 node scripts/hooks/pre-commit-claude-md-drift.cjs || exit 1
 
+# ============================================================================
+# STAGE 11: Workflow-YAML Parse Gate (BLOCKING when a workflow file is staged)
+# ============================================================================
+# SD-LEO-FIX-UNIT-TIER-STARTUP-001 (FR-2): if this commit stages a
+# .github/workflows/*.yml|*.yaml, parse-validate it so a plain-scalar ': ' (or any
+# YAML parse) defect FAILS LOUD at author time instead of shipping a phantom-green
+# workflow — the exact class that caused startup_failure on every Unit Tier run since
+# #4619. Scoped to staged workflow files; no-op on unrelated commits.
+echo ""
+echo "🔧 Checking staged workflow YAML..."
+STAGED_WORKFLOWS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^\.github/workflows/.*\.(yml|yaml)$' || true)
+if [ -n "$STAGED_WORKFLOWS" ]; then
+  node scripts/check-workflow-yaml.mjs $STAGED_WORKFLOWS || exit 1
+else
+  echo "✅ No workflow files staged — skipping workflow-YAML gate"
+fi
+
 echo ""
 echo "✅ Pre-commit checks passed. Proceeding with commit."

--- a/package.json
+++ b/package.json
@@ -501,6 +501,7 @@
     "check:migration-readiness": "node scripts/check-migration-readiness.mjs",
     "check:ghosts": "node scripts/ghost-completion-check.mjs",
     "check:external-status": "node scripts/check-external-status.mjs",
+    "check:workflow-yaml": "node scripts/check-workflow-yaml.mjs",
     "validate:capability-trigger": "node scripts/validate-capability-lifecycle-trigger.mjs --live",
     "qf:create": "node scripts/create-quick-fix.js",
     "migration:apply-state": "node scripts/verify-migration-apply-state.mjs",

--- a/scripts/check-workflow-yaml.mjs
+++ b/scripts/check-workflow-yaml.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Workflow-YAML lint guard — SD-LEO-FIX-UNIT-TIER-STARTUP-001 (FR-2, the class fix).
+ *
+ * Fail-loud parse of every .github/workflows/*.yml|*.yaml so a plain-scalar ': '
+ * (or any YAML parse) defect FAILS at author time instead of shipping a phantom-green
+ * workflow. The line-34 defect that broke unit-tier.yml on every run since #4619 was a
+ * top-level YAML parse rejection invisible to byte/BOM/tab scans and "looks-valid"
+ * eyeballing — exactly the class this guard catches.
+ *
+ * Usage:
+ *   node scripts/check-workflow-yaml.mjs            # walk .github/workflows/
+ *   node scripts/check-workflow-yaml.mjs <file...>  # check specific file(s)
+ *
+ * Exit 0 if every checked file parses; non-zero (naming each offender + the parse
+ * error) otherwise. Scope is intentionally a YAML PARSE check, not actionlint-level
+ * schema validation — any parseable workflow passes.
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const WORKFLOW_DIR = '.github/workflows';
+
+/**
+ * PURE: validate a single workflow YAML string. Returns {ok:true} on a clean parse,
+ * else {ok:false, error} carrying the js-yaml first-line message. Never throws.
+ * @param {string} yamlString
+ * @returns {{ok:boolean, error?:string}}
+ */
+export function validateWorkflowYaml(yamlString) {
+  try {
+    yaml.load(yamlString);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e && e.message ? e.message : e).split('\n')[0] };
+  }
+}
+
+/**
+ * Resolve the list of workflow files to check: explicit CLI args when given, else a
+ * sorted walk of .github/workflows/*.yml|*.yaml.
+ * @param {string[]} args
+ * @returns {string[]}
+ */
+export function resolveWorkflowFiles(args = []) {
+  if (args.length > 0) return args;
+  if (!existsSync(WORKFLOW_DIR)) return [];
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => ['.yml', '.yaml'].includes(extname(f)))
+    .sort()
+    .map((f) => join(WORKFLOW_DIR, f));
+}
+
+function main() {
+  const files = resolveWorkflowFiles(process.argv.slice(2));
+  if (files.length === 0) {
+    console.error('[WORKFLOW_YAML] no workflow files found to check');
+    process.exitCode = 1;
+    return;
+  }
+  let failures = 0;
+  for (const file of files) {
+    let raw;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch (e) {
+      console.error(`✗ ${file}: cannot read: ${e.message}`);
+      failures++;
+      continue;
+    }
+    const res = validateWorkflowYaml(raw);
+    if (res.ok) {
+      console.log(`✓ ${file}`);
+    } else {
+      console.error(`✗ ${file}: ${res.error}`);
+      failures++;
+    }
+  }
+  if (failures > 0) {
+    console.error(`[WORKFLOW_YAML] ${failures} workflow file(s) failed to parse`);
+    process.exitCode = 1;
+  } else {
+    console.log(`[WORKFLOW_YAML] all ${files.length} workflow file(s) parse OK`);
+  }
+}
+
+// ESM main-module guard: only run main() when invoked directly, not on import (tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/tests/fixtures/workflow-yaml/bad-plain-scalar.yml
+++ b/tests/fixtures/workflow-yaml/bad-plain-scalar.yml
@@ -1,0 +1,14 @@
+name: Bad Plain Scalar Fixture
+# SD-LEO-FIX-UNIT-TIER-STARTUP-001 (FR-3): a deliberately-broken workflow. The run:
+# below is an unquoted plain scalar whose embedded "Quarantined files: " colon-space
+# is parsed by YAML as a mapping separator -> top-level parse rejection. This is the
+# exact class that broke unit-tier.yml; the lint guard MUST fail loud on it.
+on:
+  push:
+    branches: [main]
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - name: broken summary
+        run: node -e "console.log('Quarantined files: '+1)"

--- a/tests/unit/check-workflow-yaml.test.js
+++ b/tests/unit/check-workflow-yaml.test.js
@@ -1,0 +1,64 @@
+/**
+ * Workflow-YAML lint guard unit tests — SD-LEO-FIX-UNIT-TIER-STARTUP-001 (FR-3).
+ *
+ * Exercises the PURE validateWorkflowYaml() (no filesystem) + resolveWorkflowFiles()
+ * arg passthrough. The bad-plain-scalar fixture reproduces the exact defect class that
+ * broke unit-tier.yml (an unquoted ': ' colon-space parsed as a mapping separator).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { validateWorkflowYaml, resolveWorkflowFiles } from '../../scripts/check-workflow-yaml.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(here, '..', 'fixtures', 'workflow-yaml', 'bad-plain-scalar.yml');
+
+const VALID_WORKFLOW = `name: Example
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: summary
+        run: |
+          node -e "console.log('Quarantined files: '+1)"
+`;
+
+describe('validateWorkflowYaml (pure)', () => {
+  it('returns {ok:true} for a valid workflow YAML string', () => {
+    expect(validateWorkflowYaml(VALID_WORKFLOW)).toEqual({ ok: true });
+  });
+
+  it('a block-scalar run: keeps the embedded colon-space literal (no parse error)', () => {
+    // The same ": " content that breaks a plain scalar is safe under "run: |".
+    expect(validateWorkflowYaml(VALID_WORKFLOW).ok).toBe(true);
+  });
+
+  it('returns {ok:false, error} for the bad-plain-scalar fixture (the defect class)', () => {
+    const bad = readFileSync(FIXTURE, 'utf8');
+    const res = validateWorkflowYaml(bad);
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/mapping/i); // "bad indentation of a mapping entry"
+  });
+
+  it('never throws on garbage input — returns a structured failure', () => {
+    const res = validateWorkflowYaml('foo: [unterminated');
+    expect(res.ok).toBe(false);
+    expect(typeof res.error).toBe('string');
+  });
+});
+
+describe('resolveWorkflowFiles', () => {
+  it('returns explicit args verbatim when provided', () => {
+    expect(resolveWorkflowFiles(['a.yml', 'b.yaml'])).toEqual(['a.yml', 'b.yaml']);
+  });
+
+  it('returns an array when walking the default dir (no args)', () => {
+    // From the repo root this finds .github/workflows/*; shape assertion only
+    // (count varies). Pure-arg path is asserted above.
+    expect(Array.isArray(resolveWorkflowFiles([]))).toBe(true);
+  });
+});


### PR DESCRIPTION
## SD-LEO-FIX-UNIT-TIER-STARTUP-001 — fix Unit Tier startup_failure + workflow-YAML lint guard

**Problem.** The 'Unit Tier' keep-main-green workflow has failed at **startup** on every run since #4619. Root cause (github-agent 0.97, reproduced via js-yaml): line 34 of `.github/workflows/unit-tier.yml` ('Quarantine burn-down summary') uses an unquoted **plain YAML scalar** for `run:`, and the embedded `console.log('Quarantined files: '+…)` contains a colon-space (`: `) that YAML parses as a **mapping separator** → top-level file parse failure at `34:276`. Parse fails before `name:`/`on:` are read, so GitHub launches **ZERO jobs** (startup_failure) and the `on.push.branches` filter never applies.

### Corrective (FR-1)
Convert line 34 to a **block scalar** (`run: |`), command byte-for-byte identical (`: `, quotes, `||`, `;` all literal). Verified: js-yaml now parses `unit-tier.yml` clean and reads `name: 'Unit Tier'`, `on: push,pull_request`.

### Preventive (FR-2 — the class fix)
`scripts/check-workflow-yaml.mjs`: a fail-loud guard (pure `validateWorkflowYaml` seam + fs-walk driver) that js-yaml-parses every `.github/workflows/*.yml`. **Wired into the pre-commit hook (STAGE 11, scoped to staged workflow files)** and `npm run check:workflow-yaml`; de-gitignored via a `!`-negation so it stages + passes WIRE_CHECK. Clean over all 100 workflows; exits 1 on a plain-scalar `: ` defect. This class is invisible to byte/BOM/tab scans and eyeballing — only an enforced parse catches it.

### FR-3
`tests/fixtures/workflow-yaml/bad-plain-scalar.yml` + 6 unit tests (pure validate pass/fail, garbage-safe, arg passthrough).

### Verification
6/6 unit tests pass; guard exit 0 over 100 workflows; exit 1 on the bad fixture; `unit-tier.yml` parses clean. Adversarial review caught that FR-2 was initially unwired (manual-only) → added the pre-commit STAGE 11 enforcement to close the preventive loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
