### PR TITLE
fix(SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001): Adam inbox tick drains ALL coordinator-directed kinds, not reply-only

### DIFF
--- a/.claude/commands/adam.md
+++ b/.claude/commands/adam.md
@@ -46,7 +46,7 @@ This tags the current session in `claude_sessions.metadata` with `role=adam` and
 - Adam communicates advisories to the **active coordinator** (resolve via `lib/coordinator/resolve.cjs` `getActiveCoordinatorId`).
 - Adam advisories use a **dedicated, non-friction lane** (`payload.kind=adam_advisory`) so they never pollute the worker-friction signal-router — that lane is delivered by Child B (`SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B`). Until Child B ships, route advisories through the existing coordinator comms and label them clearly as advisory.
 - **Boundary (hard):** Adam never claims an SD and never consumes the fleet queue. If Adam identifies work, it SOURCES it (drafts/surfaces it for the coordinator to dispatch) — it does not execute it.
-- **Send / reply (lane is live):** `node scripts/adam-advisory.cjs send "<body>"` (fire-and-forget, **replyable**) or `request "<question>"` (await a sync reply). **Drain replies that arrived after a sync await timed out** with `node scripts/adam-advisory.cjs replies` — the durable reader so a coordinator reply is never lost. Canonical doc: `docs/protocol/coordinator-adam-comms.md` (also printed on `/adam` startup).
+- **Send / reply (lane is live):** `node scripts/adam-advisory.cjs send "<body>"` (fire-and-forget, **replyable**) or `request "<question>"` (await a sync reply). **Drain your full inbox** — replies AND coordinator directives — with `node scripts/adam-advisory.cjs inbox` (the full-lane reader so no coordinator-directed message is lost; the recurring inbox-monitor tick uses it). `replies` remains for the reply-only lane. Canonical doc: `docs/protocol/coordinator-adam-comms.md` (also printed on `/adam` startup).
 
 ## Step 4 — Arm Adam's recurring tick (CronCreate, idempotent)
 
@@ -58,7 +58,7 @@ node scripts/adam-startup-check.mjs
 
 `CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Adam's tick is **five loops**, silence-by-default + propose-only (CONST-002):
 1. **governance-scan** (daily) — the read-only opportunity-scan (`node scripts/adam-opportunity-scan.cjs --scan --scope auto`); runs only when `ADAM_GOVERNANCE_HEARTBEAT_V1=on` (else it prints `SUPPRESSED_FLAG_OFF`).
-2. **inbox-monitor** (every 15 min) — drain coordinator replies (`node scripts/adam-advisory.cjs replies`).
+2. **inbox-monitor** (every 15 min) — drain ALL coordinator-directed kinds, replies + directives (`node scripts/adam-advisory.cjs inbox`).
 3. **offer-help** (every 2 h) — an agent-judgment tick: offer the coordinator concise analysis when it helps, else stay silent.
 4. **self-adherence** (every 6 h) — Adam audits its OWN role-contract adherence (`node scripts/adam-self-adherence-review.mjs`): probes → `adam_adherence_ledger` → propose-only remediation for the coordinator on drift (never builds — CONST-002). SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001.
 5. **belt-countdown** (every 15 min) — an agent-judgment tick: while the fleet is active, post ONE belt-countdown line (ET 12-hour, rolling ETA to belt-dry from DB rows via `node scripts/fleet-dashboard.cjs`); stay silent when the fleet is idle. The contract-named BELT COUNTDOWN DUTY (durable) — previously session-scoped and died every Adam session. SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001.

--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -62,7 +62,8 @@ regardless of the flag.
 |------|---------|--------|
 | **Send** (fire-and-forget, replyable) | `node scripts/adam-advisory.cjs send "<body>"` | Inserts an `adam_advisory` carrying `payload.correlation_id` (replyable) but **not** `expects_reply`. |
 | **Request** (await a sync reply) | `node scripts/adam-advisory.cjs request "<question>" [--timeout <ms>]` | Same, plus `expects_reply=true`; synchronously awaits a `coordinator_reply`. |
-| **Drain replies** (durable reader) | `node scripts/adam-advisory.cjs replies` | Drains `coordinator_reply` rows targeting this Adam session with `read_at IS NULL` — recovers replies that arrived after a sync await timed out. Consumes (stamps `read_at`). |
+| **Drain inbox** (full-lane, durable) | `node scripts/adam-advisory.cjs inbox` | **The recurring inbox-monitor tick.** Drains BOTH the reply lane AND coordinator-directive kinds (the imported `DIRECTIVE_KINDS` allowlist) targeting this Adam session with `read_at IS NULL` — AND-only server filters + JS lane classification (no `payload->>kind` `.or()`/`.in()`). Stamps `read_at`=DELIVERED; directives keep `acknowledged_at` NULL (two-stage ACK — recoverable via `read-adam-directives.cjs` until actioned). |
+| **Drain replies** (reply-lane only, back-compat) | `node scripts/adam-advisory.cjs replies` | Drains only `coordinator_reply` / `payload.reply_to` rows targeting this Adam session with `read_at IS NULL`. Subset of `inbox`. Consumes (stamps `read_at`). |
 
 ## Durable reply path (no lost replies)
 
@@ -91,7 +92,7 @@ node scripts/read-adam-advisories.cjs                                        # p
 node scripts/coordinator-ack-adam.cjs --advisory <id> --reply "sourcing now" # retire + reply
 
 # Adam
-node scripts/adam-advisory.cjs replies                                       # drains the reply
+node scripts/adam-advisory.cjs inbox                                         # drains the full lane (replies + directives)
 ```
 
 ## Receipt contract — ALL directive kinds (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001)

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -79,6 +79,10 @@ const DIRECTIVE_KINDS = Object.freeze([
   'adam_action_required',
   'coordinator_reminder',
   'coordinator_to_adam',
+  // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: a coordinator_directive is a directed action item
+  // for Adam (two-stage no-auto-ack, same as the rest of this allowlist) — without it the
+  // full-lane inbox drain would silently drop a directive carrying this kind.
+  'coordinator_directive',
 ]);
 
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -24,7 +24,8 @@
  * Usage:
  *   node scripts/adam-advisory.cjs send "<advisory body>"                          (fire-and-forget; replyable)
  *   node scripts/adam-advisory.cjs request "<question>" [--timeout 30000]          (awaits a coordinator reply; needs COORDINATOR_TWOWAY_V2=on)
- *   node scripts/adam-advisory.cjs replies                                         (drain coordinator replies that arrived after any sync await timed out)
+ *   node scripts/adam-advisory.cjs replies                                         (drain ONLY the reply lane — kept for back-compat)
+ *   node scripts/adam-advisory.cjs inbox                                           (FULL-LANE drain: replies + coordinator directives — the recurring inbox-monitor tick)
  */
 
 const crypto = require('crypto');
@@ -32,7 +33,10 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signal.cjs');
 const { getActiveCoordinatorId, isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
-const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
+const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
+// SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: reuse the canonical Adam-session resolver for the unattended
+// full-lane tick (env vars are not reliably propagated to cron subprocesses).
+const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
 
 /**
  * Pure: build the advisory payload. INVARIANT: carries payload.kind=adam_advisory
@@ -207,11 +211,72 @@ async function drainReplies(supabase, sessionId) {
     .is('read_at', null);
 }
 
+/**
+ * SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 — is this row a coordinator DIRECTIVE kind? Classifies by
+ * the IMPORTED canonical DIRECTIVE_KINDS allowlist (QF-20260610-545: classify the KIND, never the
+ * sender_type). Never duplicates the literals — source-pinned by coord-adam-comms-resilient.test.js.
+ */
+function isDirectiveRow(r) {
+  const k = r && r.payload && r.payload.kind;
+  return k != null && DIRECTIVE_KINDS.includes(k);
+}
+
+/**
+ * SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 — unified FULL-LANE inbox drain (the corrective for the
+ * reply-only blindspot that left SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001's full-lane criterion
+ * unmet). `drainReplies` surfaces ONLY the reply lane, so coordinator DIRECTIVE-kind rows (any
+ * payload.kind in the imported DIRECTIVE_KINDS allowlist) targeting the Adam session were never
+ * drained by the recurring inbox-monitor tick.
+ *
+ * This drains BOTH lanes for THIS Adam session. It fetches this session's UNREAD rows with AND-ONLY
+ * server filters (target_session + read_at IS NULL) — NEVER a payload->>kind .or()/.in() (the
+ * ambiguous-PostgREST trap PR #4770 hit) — and classifies the lane IN JS:
+ *   reply lane     = isReplyRow(r)            (coordinator_reply OR a payload.reply_to correlation)
+ *   directive lane = isDirectiveRow(r)        (payload.kind in the IMPORTED DIRECTIVE_KINDS)
+ * Lane separation is GUARANTEED by the AND-only target_session scope (every returned row is THIS
+ * session's). Surfaced rows are stamped read_at = DELIVERED. acknowledged_at / payload.actioned_at
+ * are WITHHELD (two-stage ACK, mirroring classifyInboxMessage's {markRead:true, markAck:false}) so a
+ * DELIVERED-but-unacked directive stays recoverable via scripts/read-adam-directives.cjs (the
+ * acknowledged_at IS NULL tier) until Adam genuinely acts.
+ */
+async function drainInbox(supabase, sessionId) {
+  const { data: allRows, error } = await supabase
+    .from('session_coordination')
+    .select('id, sender_session, sender_type, message_type, subject, body, payload, created_at')
+    .eq('target_session', sessionId)
+    .is('read_at', null)
+    .order('created_at', { ascending: true })
+    .limit(100);
+  if (error) { console.error('ERROR: inbox query failed:', error.message); process.exit(1); }
+
+  const rows = (allRows || []).filter((r) => isReplyRow(r) || isDirectiveRow(r));
+  if (rows.length === 0) { console.log('(no unread directed inbox rows — replies or directives)'); return; }
+
+  console.log(`${rows.length} inbox row${rows.length === 1 ? '' : 's'} (full lane — replies + directives):`);
+  const ids = [];
+  for (const r of rows) {
+    const lane = isReplyRow(r) ? 'reply' : 'directive';
+    const kind = (r.payload && r.payload.kind) || r.message_type || '?';
+    const text = (r.payload && r.payload.body) || r.body || r.subject || '(empty)';
+    const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+    console.log(`  • [${lane}/${kind}] (${ageMin}m) ${text}`);
+    ids.push(r.id);
+  }
+  // Consume: stamp read_at = DELIVERED on surfaced rows still NULL (idempotent). Deliberately do NOT
+  // set acknowledged_at / payload.actioned_at — directives stay in the read-but-unacked tier
+  // (read-adam-directives.cjs) until genuinely actioned (two-stage ACK).
+  await supabase
+    .from('session_coordination')
+    .update({ read_at: new Date().toISOString() })
+    .in('id', ids)
+    .is('read_at', null);
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   const mode = argv[0];
-  if (mode !== 'send' && mode !== 'request' && mode !== 'replies') {
-    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>]  |  request "<question>" [--timeout <ms>]  |  replies');
+  if (mode !== 'send' && mode !== 'request' && mode !== 'replies' && mode !== 'inbox') {
+    console.error('Usage: node scripts/adam-advisory.cjs send "<body>" [--reply-to <correlation_or_row_id>]  |  request "<question>" [--timeout <ms>]  |  replies  |  inbox');
     process.exit(2);
   }
 
@@ -222,9 +287,19 @@ async function main() {
   try { supabase = createSupabaseServiceClient(); }
   catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
 
-  // FR-4 — durable reply reader.
+  // FR-4 — durable reply reader (reply lane only; kept for back-compat).
   if (mode === 'replies') {
     await drainReplies(supabase, sessionId);
+    return;
+  }
+
+  // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 — unified FULL-LANE drain (replies + coordinator directives).
+  // Resolve the CANONICAL Adam session (CLAUDE_SESSION_ID only if it IS the Adam session, else the
+  // most-recent role='adam' session) so the unattended cron tick can't drain the wrong/empty session
+  // if the env var didn't propagate; falls back to the env sessionId.
+  if (mode === 'inbox') {
+    const adamId = (await resolveAdamSessionId(supabase)) || sessionId;
+    await drainInbox(supabase, adamId);
     return;
   }
 
@@ -299,14 +374,14 @@ async function main() {
   if (mode === 'request') {
     console.log('  — awaiting coordinator reply…');
     const result = await awaitCoordinatorReply(supabase, { sessionId, correlationId, timeoutMs });
-    if (result.timedOut) { console.log('⌛ No reply within timeout (reply may arrive later — drain it with `node scripts/adam-advisory.cjs replies`).'); process.exit(0); }
+    if (result.timedOut) { console.log('⌛ No reply within timeout (reply may arrive later — drain it with `node scripts/adam-advisory.cjs inbox`).'); process.exit(0); }
     // Consume: stamp read_at so neither the durable `replies` reader nor the inbox re-shows it.
     try { await supabase.from('session_coordination').update({ read_at: new Date().toISOString(), acknowledged_at: new Date().toISOString() }).eq('id', result.reply.id); } catch {}
     console.log('✓ Reply:', (result.reply.payload && result.reply.payload.body) || result.reply.body || '(empty)');
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -146,7 +146,7 @@ function adamReplyMirror() {
     '═══ ADAM ↔ COORDINATOR COMMS (consume-reply path) ═══',
     '  • SEND advisory (fire-and-forget, replyable):  node scripts/adam-advisory.cjs send "<body>"',
     '  • REQUEST (await a sync reply):  node scripts/adam-advisory.cjs request "<question>" [--timeout <ms>]',
-    '  • DRAIN replies that arrived after a timeout:  node scripts/adam-advisory.cjs replies',
+    '  • DRAIN your full inbox (replies + coordinator directives):  node scripts/adam-advisory.cjs inbox',
     '  (canonical doc: docs/protocol/coordinator-adam-comms.md)',
   ].join('\n');
 }

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -52,11 +52,13 @@ export const ADAM_LOOPS = [
     prompt: 'node scripts/adam-opportunity-scan.cjs --scan --scope auto',
   },
   {
+    // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: drain ALL coordinator-directed kinds (replies +
+    // coordinator directives), not reply-only — closes the reply-only blindspot.
     key: 'inbox-monitor',
-    label: 'Adam inbox — drain coordinator replies (durable reader)',
+    label: 'Adam inbox — drain ALL coordinator-directed kinds (full-lane reader)',
     script: 'adam-advisory.cjs',
     cron: '*/15 * * * *',
-    prompt: 'node scripts/adam-advisory.cjs replies',
+    prompt: 'node scripts/adam-advisory.cjs inbox',
   },
   {
     key: 'offer-help',

--- a/scripts/read-adam-directives.cjs
+++ b/scripts/read-adam-directives.cjs
@@ -18,7 +18,11 @@
 require('dotenv').config();
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 
-const DIRECTIVE_SENDERS = ['coordinator', 'orchestrator'];
+// SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: include 'chairman'. The full-lane inbox drain stamps
+// read_at=DELIVERED on directive-kind rows of ANY sender; this acked-NULL safety net must cover
+// chairman too, or a chairman directive is DELIVERED-then-dropped (harness-bug 43c2dee2: 5 chairman
+// messages auto-acked unseen — the exact blindspot this SD lineage closes). Sender-agnostic by intent.
+const DIRECTIVE_SENDERS = ['coordinator', 'orchestrator', 'chairman'];
 
 // Resolve the Adam session id: prefer CLAUDE_SESSION_ID when it is the Adam session, else fall
 // back to the most-recent active session tagged metadata.role='adam'. Returns null if none.

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 import fs from 'node:fs';
 import path from 'node:path';
+import { ADAM_LOOPS } from '../../scripts/adam-startup-check.mjs'; // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 parity test
 const require = createRequire(import.meta.url);
 
 const ROOT = path.resolve(__dirname, '../..');
@@ -21,7 +22,7 @@ const { classifyInboxMessage } = require('../../scripts/hooks/coordination-inbox
 const { ackMessage } = require('../../scripts/worker-checkin.cjs');
 const { buildReplyPayload } = require('../../scripts/coordinator-reply.cjs');
 const { awaitCoordinatorReply, buildRequestPayload } = require('../../scripts/worker-signal.cjs');
-const { buildAdvisoryPayload, resolveReplyToCorrelation } = require('../../scripts/adam-advisory.cjs');
+const { buildAdvisoryPayload, resolveReplyToCorrelation, drainInbox, isReplyRow, isDirectiveRow } = require('../../scripts/adam-advisory.cjs');
 const sweep = require('../../scripts/stale-session-sweep.cjs');
 const receipts = require('../../lib/coordinator/receipts.cjs');
 
@@ -41,6 +42,7 @@ describe('FR-3: DIRECTIVE_KINDS allowlist', () => {
       'adam_action_required',
       'coordinator_reminder',
       'coordinator_to_adam',
+      'coordinator_directive', // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001
     ]);
     expect(Object.isFrozen(ws.DIRECTIVE_KINDS)).toBe(true);
   });
@@ -49,6 +51,7 @@ describe('FR-3: DIRECTIVE_KINDS allowlist', () => {
     const consumers = [
       'scripts/hooks/coordination-inbox.cjs',
       'scripts/worker-checkin.cjs',
+      'scripts/adam-advisory.cjs', // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: full-lane inbox drain consumer
     ];
     for (const file of consumers) {
       const text = src(file);
@@ -370,5 +373,91 @@ describe('FR-2: selectRecentDeadLetters (pure)', () => {
       { id: 'not-dl', payload: { kind: 'coordinator_request' } },
     ], { now: NOW });
     expect(r.map((x) => x.id)).toEqual(['newest', 'recent']);
+  });
+});
+
+// ───────────── SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 — full-lane inbox drain ─────────────
+
+describe('full-lane: isDirectiveRow / isReplyRow lane classification', () => {
+  it('isDirectiveRow matches the IMPORTED DIRECTIVE_KINDS (incl. coordinator_directive), not replies/unknowns', () => {
+    expect(isDirectiveRow({ payload: { kind: 'coordinator_directive' } })).toBe(true);
+    expect(isDirectiveRow({ payload: { kind: 'coordinator_reminder' } })).toBe(true);
+    expect(isDirectiveRow({ payload: { kind: 'coordinator_reply' } })).toBe(false); // reply lane, not directive
+    expect(isDirectiveRow({ payload: { kind: 'totally_unknown' } })).toBe(false);
+    expect(isDirectiveRow({ payload: {} })).toBe(false);
+    expect(isDirectiveRow(null)).toBe(false);
+  });
+  it('isReplyRow matches coordinator_reply OR a payload.reply_to correlation', () => {
+    expect(isReplyRow({ payload: { kind: 'coordinator_reply' } })).toBe(true);
+    expect(isReplyRow({ payload: { reply_to: 'C-1' } })).toBe(true);
+    expect(isReplyRow({ payload: { kind: 'coordinator_directive' } })).toBe(false);
+  });
+});
+
+describe('full-lane: drainInbox surfaces BOTH lanes + two-stage ACK', () => {
+  // AND-only server query (.eq target_session + .is read_at null), then a consume update; the mock
+  // returns the seeded rows on the 1st .from() and captures the read_at update on the 2nd.
+  function mockInboxSb(rows, captured) {
+    let callIdx = 0;
+    return {
+      from() {
+        callIdx += 1;
+        if (callIdx === 1) {
+          const q = {
+            select() { return q; }, eq() { return q; }, is() { return q; }, order() { return q; },
+            limit() { return Promise.resolve({ data: rows, error: null }); },
+          };
+          return q;
+        }
+        const u = {
+          update(patch) { captured.update = patch; return u; },
+          in(_k, ids) { captured.ids = ids; return u; },
+          is() { return Promise.resolve({}); },
+        };
+        return u;
+      },
+    };
+  }
+
+  it('surfaces a coordinator_directive AND a coordinator_reply; stamps read_at (DELIVERED), withholds acknowledged_at/actioned_at', async () => {
+    const rows = [
+      { id: 'dir-1', payload: { kind: 'coordinator_directive', body: 'do X' }, created_at: iso(NOW) },
+      { id: 'rep-1', payload: { kind: 'coordinator_reply', reply_to: 'C-9', body: 'ack' }, created_at: iso(NOW) },
+      { id: 'noise', payload: { kind: 'adam_advisory', body: 'fyi' }, created_at: iso(NOW) }, // neither lane
+    ];
+    const captured = {};
+    await drainInbox(mockInboxSb(rows, captured), UUID_A);
+    expect(captured.ids).toEqual(['dir-1', 'rep-1']);              // both lanes surfaced; noise excluded
+    expect(captured.update).toHaveProperty('read_at');            // DELIVERED
+    expect(captured.update).not.toHaveProperty('acknowledged_at'); // two-stage ACK: withheld
+    expect(captured.update).not.toHaveProperty('actioned_at');
+  });
+
+  it('no surfaced rows (only non-lane noise) → no DB update (idempotent / quiet)', async () => {
+    const captured = {};
+    await drainInbox(mockInboxSb([{ id: 'x', payload: { kind: 'adam_advisory' }, created_at: iso(NOW) }], captured), UUID_A);
+    expect(captured.ids).toBeUndefined();
+    expect(captured.update).toBeUndefined();
+  });
+});
+
+describe('full-lane parity: ADAM_LOOPS inbox-monitor drains the full lane', () => {
+  it('inbox-monitor prompt is the full-lane verb (not reply-only) — re-wiring drift guard', () => {
+    const loop = ADAM_LOOPS.find((l) => l.key === 'inbox-monitor');
+    expect(loop, 'inbox-monitor loop must exist').toBeTruthy();
+    expect(loop.prompt).toBe('node scripts/adam-advisory.cjs inbox');
+    expect(loop.prompt).not.toMatch(/replies\s*$/);
+  });
+});
+
+describe('full-lane safety net: read-adam-directives covers EVERY directive sender', () => {
+  it('DIRECTIVE_SENDERS includes chairman (a DELIVERED-but-unacked chairman directive stays recoverable)', () => {
+    // The full-lane drain stamps read_at on directive rows of ANY sender; the acked-NULL safety net
+    // must therefore not be sender-restricted, or a chairman directive is DELIVERED-then-dropped
+    // (harness-bug 43c2dee2). Adversarial-review finding B1.
+    const { DIRECTIVE_SENDERS } = require('../../scripts/read-adam-directives.cjs');
+    expect(DIRECTIVE_SENDERS).toContain('chairman');
+    expect(DIRECTIVE_SENDERS).toContain('coordinator');
+    expect(DIRECTIVE_SENDERS).toContain('orchestrator');
   });
 });


### PR DESCRIPTION
## SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 — close the reply-only inbox blindspot

Adam's recurring inbox-monitor tick ran `adam-advisory.cjs replies` (reply lane only), so coordinator DIRECTIVE-kind rows to the Adam session were never drained by any loop — the gap that left SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001's "delivery is TESTED full-lane drain" criterion unmet.

### What changed
- **FR-1** — new `inbox` mode (`drainInbox`) in `scripts/adam-advisory.cjs` drains BOTH lanes (replies + coordinator directives) for the Adam session via **AND-only** server filters (`target_session` + `read_at IS NULL`) + **JS** classification against the **imported** `DIRECTIVE_KINDS` — never a `payload->>kind` `.or()`/`.in()` (the PR #4770 trap). Two-stage ACK: stamps `read_at`=DELIVERED, withholds `acknowledged_at`/`actioned_at`. `replies` kept as a back-compat subset.
- **FR-2** — adds `coordinator_directive` to the frozen `DIRECTIVE_KINDS` allowlist (+ source-pin test).
- **FR-3** — repoints the `ADAM_LOOPS` inbox-monitor tick **and** the load-bearing `/adam` cron-arming docs to `inbox`, with a parity drift-guard test.
- **FR-4** — cites the completed parent SD in metadata (not reopened).

### Adversarial-review hardening (caught what the isolated green tests missed)
- **B1** — a `chairman`-sent directive was DELIVERED-then-dropped (the acked-NULL safety net only covered coordinator/orchestrator) → added `chairman` to `read-adam-directives.cjs` `DIRECTIVE_SENDERS` (harness-bug 43c2dee2 class) + a test.
- **E** — the unattended tick now resolves the canonical Adam session via `resolveAdamSessionId` (env vars aren't reliably propagated to cron subprocesses).
- **D** — repointed `.claude/commands/adam.md` (the cron-arming playbook) + `adam-register.cjs` + `coordinator-adam-comms.md` from `replies` to `inbox` (the fix was otherwise half-wired).

### Verification
92 touched-module tests pass; ~89 LOC production logic, rest tests + docs. No new standalone file (a mode + a loop repoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)