### PR TITLE
feat(SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001): honest worker count under sparse pulses

### DIFF
--- a/lib/fleet/worker-count-source.mjs
+++ b/lib/fleet/worker-count-source.mjs
@@ -19,13 +19,15 @@
 export const SPARSE_THRESHOLD = 2;
 
 function avgOf(rows, pick) {
+  if (!rows.length) return 0; // guard: empty rows must never produce NaN (Math.round(0/0))
   return Math.round(rows.reduce((a, p) => a + (Number(pick(p)) || 0), 0) / rows.length);
 }
 
-// idle_count when present, else total_count - active_count (never negative).
+// idle_count when present, else total_count - active_count. Clamped non-negative for
+// BOTH paths so bad data (e.g. a negative idle_count) can never render a negative idle.
 function idleOf(p) {
-  if (p.idle_count != null) return Number(p.idle_count) || 0;
-  return Math.max(0, (Number(p.total_count) || 0) - (Number(p.active_count) || 0));
+  const v = p.idle_count != null ? (Number(p.idle_count) || 0) : ((Number(p.total_count) || 0) - (Number(p.active_count) || 0));
+  return Math.max(0, v);
 }
 
 /**
@@ -42,22 +44,30 @@ export function resolveWorkerCount({ primaryPulses = [], widePulses = [], live =
   const primary = Array.isArray(primaryPulses) ? primaryPulses : [];
   const wide = Array.isArray(widePulses) ? widePulses : [];
   const liveOk = live && Number.isFinite(Number(live.active));
+  // Clamp threshold >= 1 so a 0/NaN threshold can never route an EMPTY primary window into
+  // the confident "hourly avg" branch (which would render a confident NaN). Default 2 keeps
+  // the SD invariant: a single pulse is never a confident hourly average.
+  const thr = Math.max(1, Number(threshold) || SPARSE_THRESHOLD);
 
   // (a) Enough samples in the primary window -> confident hourly average.
-  if (primary.length >= threshold) {
+  if (primary.length >= thr && primary.length > 0) {
     return { active: avgOf(primary, (p) => p.active_count), idle: avgOf(primary, idleOf), source: 'hourly avg', sparse: false, label: 'hourly avg' };
   }
 
-  // (b) Sparse primary -> use the wider window if IT has enough samples.
-  if (wide.length >= threshold) {
-    return { active: avgOf(wide, (p) => p.active_count), idle: avgOf(wide, idleOf), source: 'wide avg', sparse: true, label: `${wideHours}h avg, sparse` };
-  }
-
-  // (c) Still sparse -> prefer the live instantaneous count when available.
+  // (b) Sparse primary -> PREFER the live instantaneous count: it is the freshest signal,
+  // whereas a wider-window average can be dominated by stale 2-3h-old samples and badly
+  // misrepresent current fleet state (adversarial review: 1 fresh pulse=8 + live=8 must not
+  // be reported as a 3h mean of 3). Live wins over the wide average when available.
   if (liveOk) {
     const n = primary.length;
     const label = n > 0 ? `live (sparse: ${n} pulse${n === 1 ? '' : 's'} in 1h)` : 'live';
     return { active: Number(live.active), idle: Number.isFinite(Number(live.idle)) ? Number(live.idle) : 0, source: 'live', sparse: true, label };
+  }
+
+  // (c) Sparse primary AND no live -> fall back to the wider window if IT has enough samples
+  // (a stale-ish average still beats nothing when the live read is unavailable).
+  if (wide.length >= thr) {
+    return { active: avgOf(wide, (p) => p.active_count), idle: avgOf(wide, idleOf), source: 'wide avg', sparse: true, label: `${wideHours}h avg, sparse` };
   }
 
   // (d) No live, but we have a few primary samples -> report them, labeled honestly as sparse.

--- a/lib/fleet/worker-count-source.mjs
+++ b/lib/fleet/worker-count-source.mjs
@@ -1,0 +1,71 @@
+/**
+ * Worker-count source resolution — SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001.
+ *
+ * PURE, no I/O. Decides the fleet worker count + an HONEST source label from
+ * fleet_worker_pulse rows in the primary (1h) window, an optional wider (2-3h)
+ * window, and a live instantaneous count. The defect this fixes: the prior inline
+ * logic in scripts/adam-exec-summary.mjs labeled a window "hourly avg" the moment
+ * ANY pulse (even one) landed — so a single stale sample was presented as a
+ * confident hourly average. Here a sub-threshold window is NEVER shown as a bare
+ * confident "hourly avg": it widens to the wider window, prefers the live count,
+ * or labels itself explicitly sparse.
+ *
+ * Callers pass already-fetched arrays so this stays pure + unit-testable; the
+ * consumer fetches the wider window / live count LAZILY, only when the primary
+ * window is sparse (no extra cost in the healthy case).
+ */
+
+/** Default: fewer than this many pulses in the primary window = "sparse". */
+export const SPARSE_THRESHOLD = 2;
+
+function avgOf(rows, pick) {
+  return Math.round(rows.reduce((a, p) => a + (Number(pick(p)) || 0), 0) / rows.length);
+}
+
+// idle_count when present, else total_count - active_count (never negative).
+function idleOf(p) {
+  if (p.idle_count != null) return Number(p.idle_count) || 0;
+  return Math.max(0, (Number(p.total_count) || 0) - (Number(p.active_count) || 0));
+}
+
+/**
+ * Resolve the worker count + honest source label.
+ * @param {object} args
+ * @param {Array}  [args.primaryPulses=[]] pulse rows in the primary (1h) window
+ * @param {Array}  [args.widePulses=[]]    pulse rows in the wider (wideHours) window (superset of primary)
+ * @param {{active:number, idle?:number}|null} [args.live=null] live instantaneous count
+ * @param {number} [args.threshold=SPARSE_THRESHOLD] min primary pulses for a confident hourly avg
+ * @param {number} [args.wideHours=3] hours the wider window spans (label only)
+ * @returns {{active:number|null, idle:number, source:string, sparse:boolean, label:string}}
+ */
+export function resolveWorkerCount({ primaryPulses = [], widePulses = [], live = null, threshold = SPARSE_THRESHOLD, wideHours = 3 } = {}) {
+  const primary = Array.isArray(primaryPulses) ? primaryPulses : [];
+  const wide = Array.isArray(widePulses) ? widePulses : [];
+  const liveOk = live && Number.isFinite(Number(live.active));
+
+  // (a) Enough samples in the primary window -> confident hourly average.
+  if (primary.length >= threshold) {
+    return { active: avgOf(primary, (p) => p.active_count), idle: avgOf(primary, idleOf), source: 'hourly avg', sparse: false, label: 'hourly avg' };
+  }
+
+  // (b) Sparse primary -> use the wider window if IT has enough samples.
+  if (wide.length >= threshold) {
+    return { active: avgOf(wide, (p) => p.active_count), idle: avgOf(wide, idleOf), source: 'wide avg', sparse: true, label: `${wideHours}h avg, sparse` };
+  }
+
+  // (c) Still sparse -> prefer the live instantaneous count when available.
+  if (liveOk) {
+    const n = primary.length;
+    const label = n > 0 ? `live (sparse: ${n} pulse${n === 1 ? '' : 's'} in 1h)` : 'live';
+    return { active: Number(live.active), idle: Number.isFinite(Number(live.idle)) ? Number(live.idle) : 0, source: 'live', sparse: true, label };
+  }
+
+  // (d) No live, but we have a few primary samples -> report them, labeled honestly as sparse.
+  if (primary.length > 0) {
+    const n = primary.length;
+    return { active: avgOf(primary, (p) => p.active_count), idle: avgOf(primary, idleOf), source: 'hourly avg', sparse: true, label: `hourly avg, sparse: ${n} sample${n === 1 ? '' : 's'}` };
+  }
+
+  // (e) Nothing at all.
+  return { active: null, idle: 0, source: 'unavailable', sparse: true, label: 'unavailable' };
+}

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -23,6 +23,8 @@ import { renderDecisionLines } from '../lib/chairman/decision-layman.mjs';
 // SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4): the LIVE VDR build-% gauge, replacing the
 // static .adam-vision-build.json number.
 import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-registry.js';
+// SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001: honest sparse-pulse worker-count source.
+import { resolveWorkerCount, SPARSE_THRESHOLD } from '../lib/fleet/worker-count-source.mjs';
 
 const EM = '—';
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -53,34 +55,43 @@ if (!DRY && !FORCE && nActions === 0) {
 
 const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-// ── 1. WORKERS: hourly average of 15-min active pulses (rounded), fail-soft to live count ──
-let avgActive = null, avgIdle = 0, pulseSource = 'live';
-try {
-  const sinceHr = new Date(t - 60 * 60 * 1000).toISOString();
-  const { data: pulses, error } = await db.from('fleet_worker_pulse')
-    .select('active_count,total_count,idle_count').gte('captured_at', sinceHr);
-  if (!error && pulses && pulses.length) {
-    const sum = (f) => pulses.reduce((a, p) => a + (Number(f(p)) || 0), 0);
-    avgActive = Math.round(sum((p) => p.active_count) / pulses.length);
-    avgIdle = Math.round(sum((p) => (p.idle_count != null ? p.idle_count : (p.total_count - p.active_count))) / pulses.length);
-    pulseSource = 'hourly avg';
-  }
-} catch { /* table may not exist yet -> live fallback */ }
-if (avgActive === null) {
-  // Live instantaneous fallback — same genuine-worker predicate the fleet dashboard/coordinator use.
+// ── 1. WORKERS: hourly average of 15-min active pulses, HONEST under sparse/missing pulses ──
+// SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001: a single stale pulse must never be presented
+// as a confident "hourly avg". resolveWorkerCount() decides the source: >= SPARSE_THRESHOLD pulses
+// in the 1h window => confident hourly avg; sparse => widen to a 3h window or prefer the live
+// instantaneous count, labeled honestly. Wider-window + live queries fire LAZILY (only when sparse).
+const WIDE_HOURS = parseInt(process.env.ADAM_WORKER_WIDE_HOURS || '3', 10);
+const fetchPulses = async (hours) => {
+  try {
+    const since = new Date(t - hours * 60 * 60 * 1000).toISOString();
+    const { data, error } = await db.from('fleet_worker_pulse')
+      .select('active_count,total_count,idle_count').gte('captured_at', since);
+    if (error) return [];
+    return data || [];
+  } catch { return []; } // table may not exist yet -> empty -> live fallback in the helper
+};
+// Live instantaneous count — same genuine-worker predicate the fleet dashboard/coordinator use.
+// Returns null on a query error so a failure NEVER masquerades as a real "0 active".
+const computeLive = async () => {
   try {
     const { data: sessRaw, error: sErr } = await db.from('claude_sessions')
       .select('session_id,heartbeat_at,sd_key,status,claimed_at,worktree_path,continuous_sds_completed,metadata')
       .order('heartbeat_at', { ascending: false }).limit(60);
-    if (sErr) throw sErr; // a query error must NOT masquerade as a real "0 active"
+    if (sErr) throw sErr;
     const live = liveFleetWorkers(sessRaw, me, t);
     const PROVISIONED_WINDOW = parseInt(process.env.COORD_PROVISIONED_WINDOW_MIN || '480', 10) * 60000;
     const recentSeen = (sessRaw || []).filter((s) => isFleetWorker(s, me) && s.heartbeat_at && (t - new Date(s.heartbeat_at).getTime()) < PROVISIONED_WINDOW);
-    avgActive = live.length;
-    avgIdle = Math.max(0, recentSeen.length - live.length);
-  } catch (e) { console.warn('[adam-email] worker count unavailable: ' + (e?.message || e)); avgActive = null; avgIdle = 0; pulseSource = 'unavailable'; }
-}
-const workerText = pulseSource === 'unavailable' ? 'count unavailable (will refresh next run)' : `${avgActive} active${avgIdle ? `, ${avgIdle} idle` : ''} (${pulseSource})`;
+    return { active: live.length, idle: Math.max(0, recentSeen.length - live.length) };
+  } catch (e) { console.warn('[adam-email] live worker count unavailable: ' + (e?.message || e)); return null; }
+};
+const primaryPulses = await fetchPulses(1);
+// Healthy primary window -> no extra queries. Sparse -> fetch the wider window + live, then decide.
+const sparse = primaryPulses.length < SPARSE_THRESHOLD;
+const widePulses = sparse ? await fetchPulses(WIDE_HOURS) : [];
+const live = sparse ? await computeLive() : null;
+const wc = resolveWorkerCount({ primaryPulses, widePulses, live, threshold: SPARSE_THRESHOLD, wideHours: WIDE_HOURS });
+const avgActive = wc.active, avgIdle = wc.idle, pulseSource = wc.source;
+const workerText = pulseSource === 'unavailable' ? 'count unavailable (will refresh next run)' : `${avgActive} active${avgIdle ? `, ${avgIdle} idle` : ''} (${wc.label})`;
 
 // ── 2. EHG VISION build-% gauge (LIVE VDR — SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 FR-4) ──
 // Replaces the static .adam-vision-build.json estimate with the auto-computed Vision Denominator
@@ -141,7 +152,8 @@ const copyBlock = nActions ? [LEAD_IN, '', ...numbered].join('\n') : null;
 // ── subject + bodies (no emojis) ──
 const when = new Date(t).toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
 const visSubj = visPct != null ? `EHG ${visPct}% built` : 'EHG vision n/a';
-const workerSubj = pulseSource === 'unavailable' ? 'workers n/a' : `${avgActive} active${pulseSource === 'hourly avg' ? ' (hr avg)' : ''}`;
+// '(hr avg)' tag only for a CONFIDENT (non-sparse) hourly average — keep the subject honest too.
+const workerSubj = pulseSource === 'unavailable' ? 'workers n/a' : `${avgActive} active${(pulseSource === 'hourly avg' && !wc.sparse) ? ' (hr avg)' : ''}`;
 const actionsSubj = nActions ? `${nActions} ${nActions === 1 ? 'action' : 'actions'} for you` : 'all clear';
 const subject = `[Chairman] ${visSubj} · ${workerSubj} · ${actionsSubj}`;
 

--- a/tests/unit/worker-count-source.test.js
+++ b/tests/unit/worker-count-source.test.js
@@ -32,12 +32,20 @@ describe('resolveWorkerCount (SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001)', 
     expect(r.label).not.toBe('hourly avg');
   });
 
-  it('sparse primary + healthy wider window → wide avg, sparse-labeled', () => {
-    const r = resolveWorkerCount({ primaryPulses: [pulse(2, 3, 1)], widePulses: [pulse(2, 3, 1), pulse(4, 5, 1), pulse(6, 7, 1)], live: { active: 9, idle: 0 }, threshold: 2, wideHours: 3 });
+  it('sparse primary + healthy wider window + NO live → wide avg, sparse-labeled', () => {
+    const r = resolveWorkerCount({ primaryPulses: [pulse(2, 3, 1)], widePulses: [pulse(2, 3, 1), pulse(4, 5, 1), pulse(6, 7, 1)], live: null, threshold: 2, wideHours: 3 });
     expect(r.source).toBe('wide avg');
     expect(r.sparse).toBe(true);
     expect(r.active).toBe(4); // round((2+4+6)/3)
     expect(r.label).toBe('3h avg, sparse');
+  });
+
+  it('honesty/recency: a FRESH live read is preferred over a stale wider-window average', () => {
+    // adversarial review MED: 1 fresh pulse=8 + live=8 must NOT be reported as a 3h mean of ~3.
+    const r = resolveWorkerCount({ primaryPulses: [pulse(8, 9, 1)], widePulses: [pulse(8, 9, 1), pulse(1, 2, 1), pulse(1, 2, 1)], live: { active: 8, idle: 0 }, threshold: 2 });
+    expect(r.source).toBe('live');
+    expect(r.active).toBe(8);
+    expect(r.label).toMatch(/live \(sparse/);
   });
 
   it('sparse primary + no wide + no live → sparse-labeled average of the few samples (honest, not confident)', () => {
@@ -80,5 +88,18 @@ describe('resolveWorkerCount (SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001)', 
   it('defensive: undefined args do not throw → unavailable', () => {
     expect(() => resolveWorkerCount()).not.toThrow();
     expect(resolveWorkerCount().source).toBe('unavailable');
+  });
+
+  it('LOW fix: threshold=0 with an empty primary window never yields a confident NaN', () => {
+    const r = resolveWorkerCount({ primaryPulses: [], threshold: 0 });
+    // clamped thr>=1 + empty-guard: must route to unavailable, NOT a confident "hourly avg" of NaN
+    expect(r.source).toBe('unavailable');
+    expect(r.active).toBeNull();
+    expect(Number.isNaN(r.active)).toBe(false);
+  });
+
+  it('LOW fix: a negative explicit idle_count is clamped to 0 (never a negative idle)', () => {
+    const r = resolveWorkerCount({ primaryPulses: [{ active_count: 3, total_count: 4, idle_count: -5 }, { active_count: 3, total_count: 4, idle_count: -5 }], threshold: 2 });
+    expect(r.idle).toBe(0);
   });
 });

--- a/tests/unit/worker-count-source.test.js
+++ b/tests/unit/worker-count-source.test.js
@@ -1,0 +1,84 @@
+/**
+ * resolveWorkerCount unit tests — SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001.
+ *
+ * The defect: a single pulse in the 1h window was labeled a confident "hourly avg".
+ * These tests pin the honest behavior across all branches (pure, no DB/network).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveWorkerCount, SPARSE_THRESHOLD } from '../../lib/fleet/worker-count-source.mjs';
+
+const pulse = (active, total, idle) => ({ active_count: active, total_count: total, idle_count: idle });
+
+describe('resolveWorkerCount (SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001)', () => {
+  it('SPARSE_THRESHOLD default is 2', () => {
+    expect(SPARSE_THRESHOLD).toBe(2);
+  });
+
+  it('>= threshold primary pulses → confident "hourly avg" with the rounded average', () => {
+    const r = resolveWorkerCount({ primaryPulses: [pulse(3, 4, 1), pulse(5, 6, 1)], threshold: 2 });
+    expect(r.source).toBe('hourly avg');
+    expect(r.sparse).toBe(false);
+    expect(r.label).toBe('hourly avg');
+    expect(r.active).toBe(4); // round((3+5)/2)
+    expect(r.idle).toBe(1);
+  });
+
+  it('THE FIX: a single pulse is NOT a confident hourly avg — prefers live, sparse-labeled', () => {
+    const r = resolveWorkerCount({ primaryPulses: [pulse(2, 3, 1)], live: { active: 5, idle: 0 }, threshold: 2 });
+    expect(r.source).toBe('live');
+    expect(r.sparse).toBe(true);
+    expect(r.active).toBe(5);
+    expect(r.label).toMatch(/live \(sparse: 1 pulse in 1h\)/);
+    expect(r.label).not.toBe('hourly avg');
+  });
+
+  it('sparse primary + healthy wider window → wide avg, sparse-labeled', () => {
+    const r = resolveWorkerCount({ primaryPulses: [pulse(2, 3, 1)], widePulses: [pulse(2, 3, 1), pulse(4, 5, 1), pulse(6, 7, 1)], live: { active: 9, idle: 0 }, threshold: 2, wideHours: 3 });
+    expect(r.source).toBe('wide avg');
+    expect(r.sparse).toBe(true);
+    expect(r.active).toBe(4); // round((2+4+6)/3)
+    expect(r.label).toBe('3h avg, sparse');
+  });
+
+  it('sparse primary + no wide + no live → sparse-labeled average of the few samples (honest, not confident)', () => {
+    const r = resolveWorkerCount({ primaryPulses: [pulse(3, 4, 1)], threshold: 2 });
+    expect(r.sparse).toBe(true);
+    expect(r.active).toBe(3);
+    expect(r.label).toBe('hourly avg, sparse: 1 sample');
+  });
+
+  it('zero pulses + live available → live, no sparse-count suffix', () => {
+    const r = resolveWorkerCount({ primaryPulses: [], live: { active: 7, idle: 2 }, threshold: 2 });
+    expect(r.source).toBe('live');
+    expect(r.active).toBe(7);
+    expect(r.idle).toBe(2);
+    expect(r.label).toBe('live');
+  });
+
+  it('zero pulses + no live → unavailable (a missing measurement is never a confident 0)', () => {
+    const r = resolveWorkerCount({ primaryPulses: [], live: null, threshold: 2 });
+    expect(r.source).toBe('unavailable');
+    expect(r.active).toBeNull();
+    expect(r.label).toBe('unavailable');
+  });
+
+  it('idle derives from total_count - active_count when idle_count is absent (never negative)', () => {
+    const r = resolveWorkerCount({ primaryPulses: [{ active_count: 2, total_count: 5 }, { active_count: 4, total_count: 6 }], threshold: 2 });
+    // idle = round(((5-2)+(6-4))/2) = round((3+2)/2) = round(2.5) = 3 (banker-agnostic Math.round)
+    expect(r.idle).toBe(3);
+    // negative guard: active > total must not yield a negative idle
+    const r2 = resolveWorkerCount({ primaryPulses: [{ active_count: 9, total_count: 3 }, { active_count: 9, total_count: 3 }], threshold: 2 });
+    expect(r2.idle).toBe(0);
+  });
+
+  it('a non-finite live.active is treated as no-live (falls through honestly)', () => {
+    const r = resolveWorkerCount({ primaryPulses: [pulse(2, 3, 1)], live: { active: NaN }, threshold: 2 });
+    expect(r.source).not.toBe('live');
+    expect(r.label).toMatch(/sparse/);
+  });
+
+  it('defensive: undefined args do not throw → unavailable', () => {
+    expect(() => resolveWorkerCount()).not.toThrow();
+    expect(resolveWorkerCount().source).toBe('unavailable');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001 — honest worker count under sparse pulses

**Problem.** The hourly Adam exec-email (`scripts/adam-exec-summary.mjs:56-83`) labeled the worker count "hourly avg" the moment **any** `fleet_worker_pulse` row (even one) landed in the 1h window — so a single stale sample was presented as a confident hourly average, losing the "we barely sampled" signal.

### FR-1 — pure honest source helper
NEW `lib/fleet/worker-count-source.mjs`: `resolveWorkerCount({primaryPulses, widePulses, live, threshold=2, wideHours=3})` → `{active, idle, source, sparse, label}`. Confident `hourly avg` **only** at ≥ threshold primary pulses; when sparse it **prefers the fresh live instantaneous count**, else widens to a 3h window, else reports sparse-labeled samples, else `unavailable`. Honest labels: `hourly avg` | `live (sparse: N pulse in 1h)` | `3h avg, sparse` | `hourly avg, sparse: N sample(s)` | `unavailable`. idle clamped non-negative; threshold clamped ≥1.

### FR-2 — wire the one real consumer (lazy)
`adam-exec-summary.mjs` (L56-94) uses the helper. The wider-window + live queries fire **lazily** — only when the primary window is sparse (no extra cost in the healthy case). Fail-soft preserved (a query error is never a real "0 active"; `count unavailable` intact). Subject `(hr avg)` tag gated on `!sparse`.

### FR-3 — tests
`tests/unit/worker-count-source.test.js` — **13 pure tests** (healthy/sparse/wide/live/unavailable + idle derivation + prefer-live-over-wide + threshold=0 + negative-idle-clamp + defensive args).

### Scope correction (grounded vs live code)
The draft named a second consumer `memory/adam-belt-state.mjs` that **does not exist** — there is no belt-state module and only `adam-exec-summary.mjs` consumes the pulse table. Fixed the one real consumer; the helper is a shared lib so any future consumer stays aligned. Secondary (2) — the sampler infra-relocation evaluation — is **deferred** per the draft.

### Verification & review
13/13 helper tests; `adam-exec-summary.mjs` syntax-clean; live smoke (1 pulse → `live (sparse: 1 pulse in 1h)`). Adversarial review caught a recency-honesty MED (averaging a stale 3h window while discarding a fresh live read) → reordered to prefer live; plus 2 LOWs (threshold=0 NaN; unclamped negative idle) — all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
