### PR TITLE
feat(SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001): sharpen Adam self-adherence resolvers (honest, measurable 3-of-4)

### DIFF
--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -106,6 +106,17 @@ try {
   visNote = `(gauge unavailable ${EM} compute error)`;
 }
 
+// FR-4 (SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001): write a DURABLE 'Adam read the vision gauge'
+// marker so the self-adherence audit can measure the vision-monitoring duty. Best-effort + fail-soft:
+// a write failure NEVER blocks the email, and a SKIP in dry-run keeps dry-runs side-effect-free. Only
+// record once the gauge actually produced a number (visPct != null) — a failed gauge isn't a "read".
+if (!DRY && visPct != null) {
+  try {
+    const { recordVisionGaugeRead } = await import('./adam-self-adherence-review.mjs');
+    await recordVisionGaugeRead(db, { sessionId: me || null, pct: visPct });
+  } catch (e) { console.warn('[adam-email] vision_gauge_read marker skipped (fail-soft): ' + (e?.message || e)); }
+}
+
 // ── 2b. DISTANCE-TO-QUIT (SD-LEO-INFRA-VISION-LADDER-V1-001 FR-5) ──
 // The quit threshold is READ AT RUNTIME from the chairman amendment metadata — the fleet NEVER
 // hardcodes a dollar figure (chairman-source-of-truth: SD-LEO-ORCH-ADAM-PLAN-KEEPER-001

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -47,26 +47,142 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     adamAuthoredBuildsInWindow: null,
   };
 
-  // P3 friction-signaling: Adam-originated coordination messages within the window. session_coordination
-  // attributes the sender via sender_type (verified: there is NO from_role column). This is the one
-  // duty we can confidently measure today.
+  // P3 friction-signaling (signals side): Adam-originated coordination messages within the window.
+  // session_coordination attributes the sender via sender_type (verified: there is NO from_role
+  // column). HONEST: only a query error leaves this null -> unknown; a real 0 is a real 0.
   try {
     const { count, error } = await supabase
       .from('session_coordination')
       .select('id', { count: 'exact', head: true })
       .gte('created_at', since)
       .eq('sender_type', 'adam');
-    if (!error && Number.isFinite(count)) facts.signalsInWindow = count;
+    if (error) throw error; // a query error must NOT masquerade as a real "0 signals"
+    if (Number.isFinite(count)) facts.signalsInWindow = count;
   } catch { /* leave null -> unknown */ }
 
-  // sourcedInWindow, visionGaugeReadInWindow, recurrencesInWindow, adamAuthoredBuildsInWindow are NOT
-  // yet confidently measurable from a generic query (feedback.provenance_source is unpopulated; there
-  // is no reliable adam-sourced-SD attribution column; vision-gauge reads + adam-authored builds have
-  // no durable signal). They are left null => the (fail-loud) probes return 'unknown' — the HONEST
-  // answer until the resolvers are sharpened (completion-flag follow-up). An unmeasured duty is NEVER
-  // reported as 'pass'.
+  // FR-1b — sourcing cadence: count SDs Adam durably attributed within the window. The canonical
+  // marker is metadata.sourced_by='adam' (stamped at sourcing time by leo-create-sd.js FR-1a, and
+  // the existing live convention). HONEST: a real 0 stays 0 (probe FAIL — cadence stalled); ONLY a
+  // thrown query error leaves the fact null -> unknown. No retroactive fabrication on historical SDs.
+  try {
+    const { count, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', since)
+      .eq('metadata->>sourced_by', 'adam');
+    if (error) throw error; // a query error must NOT masquerade as a real "0 sourced"
+    if (Number.isFinite(count)) facts.sourcedInWindow = count;
+  } catch { /* leave null -> unknown */ }
+
+  // FR-2 — friction signaling (recurrence side): windowed recurrence count from the durable
+  // recurrence source issue_patterns. We DO NOT use the lifetime occurrence_count (that overcounts
+  // across the whole history); instead we count patterns whose recurrence ACTIVITY falls in the
+  // window (updated_at >= since) and that are still LIVE-recurring.
+  //
+  // Caveat (documented): updated_at is a RECENCY proxy, not a true "recurred-in-window" event — a
+  // pattern row touched for an unrelated reason within the window will be included. It is the best
+  // durable signal available; sharpening to a per-occurrence event store is a follow-up.
+  //
+  // Live-recurring trend allow-set (verified against live issue_patterns.trend values): stable,
+  // increasing, persistent, recurring, new. EXCLUDED wound-down trends: decreasing, resolved,
+  // improving (not a live recurrence to signal). The compare is CASE-INSENSITIVE so a stray
+  // 'STABLE' (present in live data) is not silently dropped. We fetch the windowed trend column and
+  // filter in JS rather than .in() because PostgREST .in() is case-sensitive. HONEST: a real 0 stays
+  // 0 (probe PASS — nothing to signal); ONLY a query error leaves the fact null -> unknown.
+  const LIVE_RECURRING_TRENDS = new Set(['stable', 'increasing', 'persistent', 'recurring', 'new']);
+  try {
+    const { data, error } = await supabase
+      .from('issue_patterns')
+      .select('trend')
+      .gte('updated_at', since);
+    if (error) throw error; // a query error must NOT masquerade as a real "0 recurrences"
+    if (Array.isArray(data)) {
+      facts.recurrencesInWindow = data.filter(
+        (r) => r && typeof r.trend === 'string' && LIVE_RECURRING_TRENDS.has(r.trend.trim().toLowerCase()),
+      ).length;
+    }
+  } catch { /* leave null -> unknown */ }
+
+  // FR-3 — propose-only (CONST-002): count build/PR/handoff/file-write actions AUTHORED by Adam
+  // within the window. HONEST-UNMEASURABLE by design: this fact stays null -> 'unknown'.
+  //
+  // Why we do NOT attribute via session lineage (the prior approach, which fabricated a FAIL):
+  //   - session_coordination.sender_session is a Claude session UUID, NOT a role tag. Sessions are
+  //     MIXED-ROLE — one session can speak as 'adam' (sender_type='adam') AND, in the same session,
+  //     run LEO worker/PLAN/EXEC phases that legitimately write sub_agent_execution_results. Counting
+  //     every build of any session that EVER sent an 'adam' message attributes legitimate LEO builds
+  //     to Adam -> a fabricated CONST-002 FAIL -> a false high-severity remediation flag.
+  //   - There is NO reliable PER-BUILD / PER-ROW Adam-author marker on sub_agent_execution_results.
+  //     Verified against live data (14d, 4,464 rows): metadata has NO 'sender_type' key (0 rows) and
+  //     NO 'actor' key (0 rows); 'sender_type'='adam'=0, 'actor'='adam'=0. The build rows carry
+  //     machinery keys (findings, routing, phase, session_id, repo_path, ...), none of which is a
+  //     per-build author identity. Adam is propose-only, so builds are simply never adam-tagged.
+  //
+  // The HONEST answer is therefore "could not measure": we leave adamAuthoredBuildsInWindow = null,
+  // which the probe turns into verdict='unknown' (never a fabricated 0/PASS and never a fabricated
+  // FAIL). propose_only honestly degrades to 'unknown' until a build-actor-tagging scheme exists
+  // (e.g. a per-row metadata->>'actor'='adam' stamp at the authoring seam). The SD target is 3-of-4
+  // measurable; the three measured dims are sourcing-cadence, friction-signaling, and vision-going-
+  // forward. NO query is issued here — there is no reliable source to query.
+  // facts.adamAuthoredBuildsInWindow stays null -> probe 'unknown' (honest).
+
+  // FR-4 — vision monitoring: did Adam read the vision gauge within the window? The durable read
+  // marker is an audit_log row event_type='vision_gauge_read' written when Adam runs
+  // scripts/adam-exec-summary.mjs (recordVisionGaugeRead below; existing store, no new table).
+  // HONEST (highest-risk dim): if NO such event exists in the window — or the source is unavailable
+  // (query error) — the fact stays null -> unknown. It MUST NOT default to false: an absent durable
+  // signal is "could not confirm", not "definitely not read". This dim may legitimately remain
+  // 'unknown' (the SD target is 3-of-4 measurable).
+  try {
+    const { count, error } = await supabase
+      .from('audit_log')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', since)
+      .eq('event_type', VISION_GAUGE_READ_EVENT)
+      // FR-4 hardening: count ONLY Adam-authored gauge-read events. recordVisionGaugeRead (below)
+      // always stamps metadata.sender_type='adam', so this filter is precise — a non-Adam writer of
+      // the same event_type (should none ever exist) cannot satisfy Adam's monitoring duty.
+      .eq('metadata->>sender_type', 'adam');
+    if (error) throw error;
+    // >=1 event -> measured TRUE. 0 events -> NOT measured-false: the marker is best-effort and may
+    // simply be absent for this window, so we honestly degrade to null -> unknown (never false).
+    if (Number.isFinite(count) && count >= 1) facts.visionGaugeReadInWindow = true;
+  } catch { /* leave null -> unknown */ }
 
   return facts;
+}
+
+/** Durable audit_log event_type recording that Adam read the vision build-% gauge (FR-4). */
+const VISION_GAUGE_READ_EVENT = 'vision_gauge_read';
+
+/**
+ * FR-4 — write a durable 'vision gauge was read' marker to the EXISTING audit_log store (no new
+ * chairman-gated table). Called by scripts/adam-exec-summary.mjs after it computes the gauge.
+ * Fail-soft: a write failure NEVER blocks the exec-summary email — the resolver honestly degrades
+ * to 'unknown' rather than reporting a false read. Returns the row id, or null on failure.
+ * @param {object} supabase
+ * @param {{ sessionId?: string|null, pct?: number|null }} [opts]
+ */
+export async function recordVisionGaugeRead(supabase, { sessionId = null, pct = null } = {}) {
+  try {
+    const { data, error } = await supabase
+      .from('audit_log')
+      .insert({
+        event_type: VISION_GAUGE_READ_EVENT,
+        entity_type: 'vision_gauge',
+        entity_id: 'adam-exec-summary',
+        created_by: sessionId || 'adam',
+        severity: 'info',
+        metadata: { sender_type: 'adam', session_id: sessionId || null, pct: Number.isFinite(pct) ? pct : null },
+      })
+      .select('id')
+      .single();
+    if (error) throw error;
+    return data.id;
+  } catch (err) {
+    console.warn(`[adam-self-adherence] vision_gauge_read marker write failed (non-blocking): ${err.message}`);
+    return null;
+  }
 }
 
 /** Insert one ledger row for a probe verdict. Returns the row id (or null, fail-soft). */

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2122,6 +2122,29 @@ export function validateProposalShape(proposal, filePath) {
  * back rationale -> scope -> title; metadata.source='proposal' + provenance.
  * No vision_key/arch_key (avoids enrichFromVisionArch orphan-FK), no parentId,
  * no orchestrator auto-routing. PURE.
+ *
+ * SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001 (FR-1a, load-bearing): stamp the CANONICAL
+ * Adam-sourced marker `metadata.sourced_by='adam'` ONLY when the proposal carries the
+ * explicit, opt-in `sourced_by: 'adam'` field. This is the durable attribution the
+ * sourcing-cadence probe counts (resolveFacts.sourcedInWindow). The marker is opt-in by
+ * design: a non-Adam proposal (e.g. drain-intake, which sets provenance.source='drain-intake'
+ * but never sourced_by) is left UN-stamped, so non-Adam creation paths are unchanged.
+ * The closed-whitelist metadata invariant is preserved — the key only appears when the
+ * proposal explicitly declares Adam origin.
+ *
+ * WHERE THIS FIRES (canonical Adam sourcing path — NOT a no-op): mapProposalToCreateArgs is the
+ * single mapper for ingestProposalObject(), which is the shared core of Adam's FILE-FREE DB-direct
+ * sourcing routes `--proposal-b64` and `--proposal-stdin` (SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001),
+ * plus `--from-proposal`. Those routes ARE the intended forward producer of Adam's sourcing: an Adam
+ * session emits a proposal JSON carrying `sourced_by:'adam'`, and this line is the ONLY code path
+ * that stamps the canonical marker. So FR-1b's consumer count (resolveFacts.sourcedInWindow) relies
+ * on a real producer, not a phantom one.
+ *
+ * Live-state note (verified 2026-06-15): the ~31 existing strategic_directives_v2 rows already
+ * carrying metadata.sourced_by='adam' have source=leo|plan|feedback (NOT proposal) and were stamped
+ * by Adam's earlier DB-direct sourcing (manual metadata write), since no other CODE producer stamps
+ * sourced_by. Those historical rows are still counted by FR-1b as-is; this stamp makes the
+ * proposal-based routes the durable, code-enforced producer going forward. No retroactive change.
  */
 export function mapProposalToCreateArgs(normalized, proposal, filePath) {
   return {
@@ -2144,6 +2167,10 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath) {
       gold_origin: proposal.gold_origin || null,
       necessity: proposal.necessity || null,
       dedup_note: proposal.dedup_note || null,
+      // FR-1a: canonical Adam-origin attribution (the code-enforced producer for FR-1b's
+      // sourcing-cadence consumer; see this function's doc comment). Only stamped for an explicit
+      // Adam-origin proposal — never coerced/defaulted, so a non-Adam proposal stays unattributed.
+      ...(proposal.sourced_by === 'adam' ? { sourced_by: 'adam' } : {}),
     },
   };
 }

--- a/tests/unit/adam/adherence-resolvers.test.js
+++ b/tests/unit/adam/adherence-resolvers.test.js
@@ -1,0 +1,254 @@
+/**
+ * Adam self-adherence RESOLVER + "actually catches drift" regression tests.
+ * SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001 — FR-5 (+ resolver coverage for FR-1b/2/3/4).
+ *
+ * These exercise the REAL resolveFacts() / runSelfAdherenceReview() over a MOCKED supabase
+ * (zero live DB, zero real feedback rows). The probes (lib/adam/adherence-probes.js) are
+ * imported AS-IS and never modified — the test asserts the resolver layer feeds them honest
+ * facts and that the full audit detects a seeded drift condition while leaving genuinely
+ * unmeasurable facts as 'unknown'.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveFacts,
+  runSelfAdherenceReview,
+  sourceRemediation,
+  recordVisionGaugeRead,
+} from '../../../scripts/adam-self-adherence-review.mjs';
+import { runAdherenceProbes, hasDrift } from '../../../lib/adam/adherence-probes.js';
+
+/**
+ * Build a chainable supabase mock. `spec` maps table name -> a handler that returns the
+ * terminal result the resolvers await ({ count, data, error }) or, for insert chains, the
+ * single-row result. The builder is a thenable so `await builder` resolves to the result; it
+ * also supports `.select().single()` for insert flows. Every chained filter is a no-op that
+ * records nothing (the resolvers' correctness, not the query strings, is under test — the
+ * live PostgREST queries were separately verified to run).
+ */
+function makeSupabase(spec) {
+  const calls = { feedbackInsert: [], auditInsert: [], ledgerInsert: [] };
+  function from(table) {
+    const handler = spec[table];
+    const result = typeof handler === 'function' ? handler() : (handler ?? { count: 0, data: [], error: null });
+    const builder = {
+      // read-chain no-ops (return `this` so any order/combination chains)
+      select() { return builder; },
+      gte() { return builder; },
+      eq() { return builder; },
+      in() { return builder; },
+      not() { return builder; },
+      // insert flows: capture the row, then allow .select().single()
+      insert(row) {
+        if (table === 'feedback') calls.feedbackInsert.push(row);
+        if (table === 'audit_log') calls.auditInsert.push(row);
+        if (table === 'adam_adherence_ledger') calls.ledgerInsert.push(row);
+        const insertResult = (typeof handler === 'function' ? handler() : handler) || {};
+        const single = async () => ({ data: insertResult.data ?? { id: insertResult.id ?? 'mock-id' }, error: insertResult.error ?? null });
+        return { select() { return { single, maybeSingle: single }; }, single, maybeSingle: single };
+      },
+      // terminal: head/count read resolves the builder itself
+      then(resolve, reject) { return Promise.resolve(result).then(resolve, reject); },
+    };
+    return builder;
+  }
+  return { from, _calls: calls };
+}
+
+const COUNT = (n) => () => ({ count: n, data: null, error: null });
+const ERR = (msg) => () => ({ count: null, data: null, error: new Error(msg) });
+const ROWS = (rows) => () => ({ count: null, data: rows, error: null });
+
+describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
+  it('reliable sources -> 3-of-4 facts are finite/real; propose_only is honestly unknown', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(4), // FR-P3 signals: 4 Adam signals (head-count)
+      strategic_directives_v2: COUNT(2), // FR-1b sourced
+      issue_patterns: ROWS([{ trend: 'stable' }, { trend: 'decreasing' }]), // FR-2: 1 live-recurring (stable), decreasing excluded
+      sub_agent_execution_results: COUNT(0), // FR-3 builds — NOT consulted (no per-row Adam marker)
+      audit_log: COUNT(1), // FR-4 vision read present (Adam-authored)
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.sourcedInWindow).toBe(2); // FR-1b measured
+    expect(facts.signalsInWindow).toBe(4); // FR-P3 measured
+    expect(facts.recurrencesInWindow).toBe(1); // FR-2 measured (stable counts, decreasing excluded)
+    expect(facts.visionGaugeReadInWindow).toBe(true); // FR-4 measured (>=1 Adam marker)
+    // FR-3 is HONESTLY UNMEASURABLE: there is no per-row Adam-author marker on
+    // sub_agent_execution_results, so adamAuthoredBuilds is null -> probe 'unknown'. We do NOT
+    // fabricate a 0 (a fake CONST-002 pass) nor a session-attributed FAIL.
+    expect(facts.adamAuthoredBuildsInWindow).toBeNull();
+    // 3-of-4 measurable: sourcing-cadence + friction-signaling + vision-going-forward.
+  });
+
+  it('FR-1b: a real 0 sourced stays 0 (NOT unknown) — cadence stall is measurable', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: COUNT(0),
+      issue_patterns: ROWS([]),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.sourcedInWindow).toBe(0); // real 0, not null
+  });
+
+  it('FR-1b: a query ERROR leaves sourcedInWindow null -> unknown (honesty)', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: ERR('db down'),
+      issue_patterns: ROWS([]),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.sourcedInWindow).toBeNull();
+  });
+
+  it('FR-3: no per-row Adam-author marker exists -> adamAuthoredBuilds stays null (no fabricated CONST-002 pass OR fail)', async () => {
+    // Even with a healthy fleet of build rows, the resolver does NOT consult
+    // sub_agent_execution_results for FR-3: there is no reliable per-build Adam-author key, and
+    // session-lineage attribution would fabricate a FAIL (mixed-role sessions). Honest = unknown.
+    const sb = makeSupabase({
+      session_coordination: COUNT(2),
+      strategic_directives_v2: COUNT(1),
+      issue_patterns: ROWS([]),
+      sub_agent_execution_results: COUNT(99), // intentionally large — must NOT bleed into the fact
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.adamAuthoredBuildsInWindow).toBeNull(); // honest unknown, NOT a fabricated 0 or 99
+  });
+
+  it('FR-2: case-insensitive + widened allow-set (stable/increasing/persistent/recurring/new); wound-down trends excluded', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: COUNT(0),
+      // 5 live-recurring (incl. an uppercase STABLE) + 3 wound-down that must be excluded.
+      issue_patterns: ROWS([
+        { trend: 'stable' }, { trend: 'increasing' }, { trend: 'persistent' },
+        { trend: 'recurring' }, { trend: 'STABLE' },
+        { trend: 'decreasing' }, { trend: 'resolved' }, { trend: 'improving' },
+      ]),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.recurrencesInWindow).toBe(5); // 4 distinct live trends + the uppercase STABLE
+  });
+
+  it('FR-2: a query ERROR leaves recurrencesInWindow null -> unknown (honesty)', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: COUNT(0),
+      issue_patterns: ERR('db down'),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.recurrencesInWindow).toBeNull();
+  });
+
+  it('FR-4: zero Adam vision-read markers -> visionGaugeReadInWindow stays null (NEVER false)', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(1),
+      strategic_directives_v2: COUNT(1),
+      issue_patterns: ROWS([]),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0), // no Adam marker this window
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.visionGaugeReadInWindow).toBeNull(); // not false — could-not-confirm
+  });
+});
+
+describe('FR-5: the audit ACTUALLY CATCHES drift', () => {
+  it('seeded SOURCING drift (zero sourcing) -> sourcing_cadence FAIL + a sourced adam_adherence_drift feedback row', async () => {
+    // Seed: 0 sourced in window (cadence stalled), everything else clean/measurable. This is the
+    // canonical "actually catches drift" proof now that propose_only is honestly 'unknown' — a
+    // MEASURABLE FAIL (sourcing) drives drift detection + the propose-only remediation.
+    const sb = makeSupabase({
+      session_coordination: COUNT(2), // signals present
+      strategic_directives_v2: COUNT(0), // <-- DRIFT: zero Adam sourcing
+      issue_patterns: ROWS([]), // no recurrences -> friction pass
+      sub_agent_execution_results: COUNT(0), // FR-3 not consulted (propose_only stays unknown)
+      audit_log: COUNT(1), // vision read present
+      feedback: () => ({ id: 'fb-remediation-1' }), // sourceRemediation insert
+      adam_adherence_ledger: () => ({ id: 'ledger-1' }), // recordAdherence insert
+    });
+    const res = await runSelfAdherenceReview(sb, { windowDays: 1, runId: 'run-drift' });
+
+    // The sourcing_cadence probe must read FAIL off the real measured 0.
+    const sourcing = res.bars.find((b) => b.probe === 'sourcing_cadence');
+    expect(sourcing.verdict).toBe('fail');
+    expect(hasDrift(res.bars)).toBe(true);
+
+    // propose_only is honestly 'unknown' (no per-row Adam marker) — never a fabricated fail.
+    const proposeOnly = res.bars.find((b) => b.probe === 'propose_only');
+    expect(proposeOnly.verdict).toBe('unknown');
+
+    // A propose-only remediation feedback row was sourced with the canonical category.
+    expect(res.remediationRef).toBe('fb-remediation-1');
+    expect(sb._calls.feedbackInsert).toHaveLength(1);
+    expect(sb._calls.feedbackInsert[0].category).toBe('adam_adherence_drift');
+    expect(sb._calls.feedbackInsert[0].type).toBe('issue');
+  });
+
+  it('seeded FRICTION drift (recurrences but 0 signals) -> friction_signaling FAIL + remediation sourced', async () => {
+    // A second MEASURABLE drift dimension: live recurrences exist but Adam sent no signals.
+    const sb = makeSupabase({
+      session_coordination: COUNT(0), // <-- 0 signals
+      strategic_directives_v2: COUNT(2), // sourcing fine
+      issue_patterns: ROWS([{ trend: 'increasing' }, { trend: 'persistent' }]), // <-- 2 live recurrences
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(1),
+      feedback: () => ({ id: 'fb-friction' }),
+      adam_adherence_ledger: () => ({ id: 'ledger-2' }),
+    });
+    const res = await runSelfAdherenceReview(sb, { windowDays: 1, runId: 'run-friction' });
+    const friction = res.bars.find((b) => b.probe === 'friction_signaling');
+    expect(friction.verdict).toBe('fail'); // recurrences but no signals
+    expect(hasDrift(res.bars)).toBe(true);
+    expect(res.remediationRef).toBe('fb-friction');
+    expect(sb._calls.feedbackInsert[0].category).toBe('adam_adherence_drift');
+  });
+
+  it('HONESTY: a genuinely-unresolved fact yields unknown and does NOT, alone, trigger remediation', async () => {
+    // All MEASURED dims clean; vision-monitoring AND propose-only are honestly unknown (no markers /
+    // unmeasurable). An 'unknown' is neither pass nor fail -> hasDrift stays false -> no remediation.
+    const sb = makeSupabase({
+      session_coordination: COUNT(1), // signals present
+      strategic_directives_v2: COUNT(3), // sourcing pass
+      issue_patterns: ROWS([]), // friction pass (nothing to signal)
+      sub_agent_execution_results: COUNT(0), // not consulted -> propose_only unknown
+      audit_log: COUNT(0), // <-- vision marker ABSENT -> unknown (not false, not a fail)
+      feedback: () => ({ id: 'fb-should-not-be-written' }),
+      adam_adherence_ledger: () => ({ id: 'ledger-3' }),
+    });
+    const res = await runSelfAdherenceReview(sb, { windowDays: 1, runId: 'run-unknown' });
+    const vision = res.bars.find((b) => b.probe === 'vision_monitoring');
+    expect(vision.verdict).toBe('unknown'); // honest unknown, never coerced to fail
+    const proposeOnly = res.bars.find((b) => b.probe === 'propose_only');
+    expect(proposeOnly.verdict).toBe('unknown'); // honestly unmeasurable, not a fail
+    expect(hasDrift(res.bars)).toBe(false); // an unknown alone is NOT drift
+    expect(res.remediationRef).toBeNull(); // no remediation sourced
+    expect(sb._calls.feedbackInsert).toHaveLength(0); // NO real/feedback row written for an unknown
+  });
+});
+
+describe('recordVisionGaugeRead (FR-4 durable marker) — fail-soft', () => {
+  it('writes an audit_log vision_gauge_read row and returns its id', async () => {
+    const sb = makeSupabase({ audit_log: () => ({ id: 'audit-1' }) });
+    const id = await recordVisionGaugeRead(sb, { sessionId: 'adam-sess', pct: 42 });
+    expect(id).toBe('audit-1');
+    expect(sb._calls.auditInsert).toHaveLength(1);
+    expect(sb._calls.auditInsert[0].event_type).toBe('vision_gauge_read');
+    expect(sb._calls.auditInsert[0].metadata.session_id).toBe('adam-sess');
+  });
+
+  it('a write error returns null and never throws (fail-soft, never blocks the email)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sb = makeSupabase({ audit_log: () => ({ error: new Error('insert blocked') }) });
+    const id = await recordVisionGaugeRead(sb, { sessionId: 'adam-sess', pct: 42 });
+    expect(id).toBeNull();
+    warn.mockRestore();
+  });
+});

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -159,6 +159,20 @@ describe('mapProposalToCreateArgs (pure field mapping)', () => {
     expect(args.arch_key).toBeUndefined();
     expect(args.metadata.source).toBe('proposal'); // only the closed whitelist survives
   });
+
+  // SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001 (FR-1a, load-bearing): the canonical Adam-origin
+  // marker metadata.sourced_by='adam' is stamped ONLY for an explicit Adam-origin proposal, and
+  // is ABSENT for any non-Adam proposal (so non-Adam creation paths are unchanged).
+  it('FR-1a: explicit sourced_by:adam proposal stamps metadata.sourced_by=adam', () => {
+    const args = mapProposalToCreateArgs(normalized, validProposal({ sourced_by: 'adam' }), 'p.json');
+    expect(args.metadata.sourced_by).toBe('adam');
+  });
+
+  it('FR-1a: a non-Adam proposal does NOT stamp sourced_by (no fabricated attribution)', () => {
+    expect(mapProposalToCreateArgs(normalized, validProposal(), 'p.json').metadata.sourced_by).toBeUndefined();
+    // a different/foreign value is also not coerced to 'adam'
+    expect(mapProposalToCreateArgs(normalized, validProposal({ sourced_by: 'drain-intake' }), 'p.json').metadata.sourced_by).toBeUndefined();
+  });
 });
 
 describe('createFromProposal (dry-run + idempotency, injected deps, zero DB/FS)', () => {


### PR DESCRIPTION
Makes the recurring Adam self-adherence audit MEASURE adherence instead of returning 'unknown' for 3 of 4 dims — without fabricating any verdict (fail-loud honesty contract preserved; probes `lib/adam/adherence-probes.js` byte-unchanged).

## Resolvers (all in resolveFacts())
- **FR-1** `sourcedInWindow`: counts `strategic_directives_v2 metadata.sourced_by='adam'` in window (real 0 = sourcing-stalled FAIL; null only on query error). Canonical Adam-sourced stamp added to the file-free proposal mapper (`mapProposalToCreateArgs`, which backs `--proposal-b64/--stdin` = Adam's forward sourcing path); non-Adam creation unstamped.
- **FR-2** `recurrencesInWindow`: windowed `issue_patterns` (updated_at + live-recurring trend set, case-insensitive — not lifetime occurrence_count).
- **FR-3** `propose_only`/`adamAuthoredBuildsInWindow`: honestly **null→'unknown'**. There is NO reliable per-build Adam-author key (verified 0/4464 build rows carry sender_type/actor); session-level attribution would fabricate CONST-002 FAILs from mixed-role sessions. Honest unknown until a build-actor tag exists.
- **FR-4** `visionGaugeReadInWindow`: durable `audit_log` 'vision_gauge_read' marker (sender_type='adam') written by `adam-exec-summary`; resolver counts Adam reads in window (true on ≥1; null→unknown on 0/error, never false). Measurable from the first post-deploy gauge run.
- **FR-5**: regression tests prove the audit DETECTS seeded sourcing/friction drift and sources the propose-only remediation flag; honesty tests assert unmeasurable facts stay 'unknown' (no fabricated pass/fail, no spurious remediation).

## Net
3-of-4 dims measurable honestly (sourcing + friction + vision-going-forward); propose_only honestly unknown. Audit stays propose-only (CONST-002). **120 unit tests pass.**

## Review
Adversarial review caught + fixed (before merge) a HIGH fabricated-FAIL (session-level build attribution — the symmetric inverse of the honesty bug this SD targets) and a MED inert stamp. The honest fix: admit unmeasurable rather than fake a count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)