### PR TITLE
feat(SD-LEO-INFRA-STRENGTHEN-COMPLETION-DELIVERABLE-001): wire PCVP verifier + deliverable canary into a real entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,8 @@ scripts/verify-*.cjs
 !scripts/verify-eva-revival.mjs
 # SD-LEO-INFRA-MIGRATION-APPLY-STATE-001: repo-wide migration apply-state verifier (npm migration:apply-state)
 !scripts/verify-migration-apply-state.mjs
+# SD-LEO-INFRA-STRENGTHEN-COMPLETION-DELIVERABLE-001: PCVP completion verifier + deliverable-canary entry point (npm sd:verify-completion)
+!scripts/verify-completion.mjs
 !scripts/verify-git-commit-status.js
 !scripts/verify-app-architecture.js
 # Marketing schema contract verifier (SD-EHG-MARKETING-DISTRIBUTION-INFRASTRUCTURE-ORCH-001-A)

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
     "sd:claim": "node scripts/claude-session-coordinator.mjs claim",
     "sd:release": "node scripts/claude-session-coordinator.mjs release",
     "sd:verify": "node scripts/sd-verify.js",
+    "sd:verify-completion": "node scripts/verify-completion.mjs",
     "sd:verify:list": "node scripts/sd-verify.js --list",
     "sd:complete": "node scripts/sd-verify.js --complete",
     "sd:hierarchy": "node scripts/lib/sd-hierarchy-mapper.js",

--- a/scripts/verify-completion.mjs
+++ b/scripts/verify-completion.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-STRENGTHEN-COMPLETION-DELIVERABLE-001 — FR-4 wiring CLI.
+ *
+ * The invocation path for the PCVP completion verifier (lib/eva/post-completion-verifier.js)
+ * and, transitively, the live-end-state deliverable canary (lib/eva/deliverable-canary.js).
+ * Without this entry point the verifier subsystem was statically orphaned (no package.json
+ * script reached it), so the canary it now hosts had no way to run. This CLI is the
+ * fleet completion-integrity reporting consumer the PRD declared (runBatchVerification),
+ * and it makes the CLI -> verifier -> canary chain reachable from a real entry point.
+ *
+ * The canary runs ADVISORY by default; set LEO_DELIVERABLE_CANARY_ENFORCE=block to escalate
+ * a confirmed canary failure to a hard verdict (the verifier honours the env flag itself).
+ *
+ * Usage:
+ *   node scripts/verify-completion.mjs <SD-ID|SD-KEY>      # verify one SD
+ *   node scripts/verify-completion.mjs --results <SD-ID>   # show stored verification results
+ *   node scripts/verify-completion.mjs --batch [--status completed] [--limit 50] [--type infrastructure]
+ */
+
+import { verifyCompletion, getVerificationResults, runBatchVerification } from '../lib/eva/post-completion-verifier.js';
+
+function argValue(flag, fallback) {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--batch')) {
+    const options = {
+      status: argValue('--status', 'completed'),
+      limit: parseInt(argValue('--limit', '50'), 10),
+    };
+    const type = argValue('--type', null);
+    if (type) options.sdType = type;
+    const summary = await runBatchVerification(options);
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  if (args.includes('--results')) {
+    const sdId = argValue('--results', null);
+    if (!sdId) { console.error('Error: --results requires an SD id/key'); process.exit(1); }
+    const results = await getVerificationResults(sdId);
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  const sdId = args.find((a) => !a.startsWith('--'));
+  if (!sdId) {
+    console.error('Usage: node scripts/verify-completion.mjs <SD-ID|SD-KEY> | --results <SD-ID> | --batch [--status s] [--limit n] [--type t]');
+    process.exit(1);
+  }
+
+  const result = await verifyCompletion(sdId);
+  console.log(JSON.stringify(result, null, 2));
+  if (result && result.pass === false) process.exit(2);
+}
+
+main().catch((err) => {
+  console.error('verify-completion failed:', err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Wire-fix follow-up to #4793

PR #4793 shipped the live-end-state **deliverable canary** but it was statically **orphaned**: its only importer (`lib/eva/post-completion-verifier.js`) had no package.json-discoverable entry point, so `WIRE_CHECK_GATE` correctly flagged it unreachable at LEAD-FINAL.

### Fix (in-scope FR-4 wiring)
- **NEW `scripts/verify-completion.mjs`** — a thin CLI that statically imports the verifier and invokes `verifyCompletion` / `getVerificationResults` / `runBatchVerification`.
- **`package.json`** — register it as `sd:verify-completion` (`node scripts/verify-completion.mjs`).
- **`.gitignore`** — `!scripts/verify-completion.mjs` negation (`scripts/verify-*.mjs` is ignored by default — the documented silent-drop trap).

This makes the **CLI → verifier → canary** chain reachable from a real entry point, and gives the long-orphaned PCVP verifier the fleet completion-integrity reporting entry point the PRD declared.

### Verified end-to-end
`node scripts/verify-completion.mjs SD-LEO-INFRA-STRENGTHEN-COMPLETION-DELIVERABLE-001` runs the verifier and the advisory canary — canary `verdict=pass` on this SD's own 3 declared deliverables (present + adequate at main), proving no false-fail on a legitimate completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)