### PR TITLE
feat(SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001): chairman-preference + roadmap-Q2 anchoring in Adam prioritization

### DIFF
--- a/lib/adam/briefings/harness.js
+++ b/lib/adam/briefings/harness.js
@@ -1,23 +1,226 @@
 /**
  * Harness briefing — read-only signal scan over EHG_Engineer governance tables.
- * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001.
+ * SD-LEO-INFRA-ADAM-OPPORTUNITY-SCAN-001 (signal scan) +
+ * SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-1: map signals -> KR-anchored candidates).
  *
  * Anchors to the O-GOV objectives/KRs. Sources: feedback(harness_backlog),
  * retrospectives, gate-tuning recommendations, pending EVA recommendations.
  * Empty tables are reported as "no signal", never as an error.
  *
- * Today there is no programmatic live-KR feed wired here, so the briefing
- * surfaces SIGNAL COUNTS only and emits NO fabricated candidate — the rationale
- * bar would (correctly) keep it silent without a cited live KR.
+ * CARDINAL SAFETY RULE (FR-1): a candidate is emitted ONLY when its harness
+ * signal class resolves to a REAL key_results row (queried live, joined to an
+ * O-GOV objective). A signal whose mapped objective has NO live KR is EXCLUDED —
+ * never given a fabricated anchor. hasLiveAnchor() therefore passes legitimately.
  */
-export function summarizeHarness({ backlog = [], retros = [], gateRecs = [], evaRecs = [] } = {}) {
+
+/**
+ * Static class -> O-GOV objective-code mapping. Each harness signal class is
+ * routed to the governance objective it actually concerns. The CONCRETE KR row
+ * (and its live status) is resolved at runtime from key_results — never invented.
+ *
+ *   harness_backlog  -> O-GOV-1 (Foundation Cleanup & Consolidation) — backlog/cleanup debt
+ *   gate_tuning      -> O-GOV-2 (Raise LEO Intelligence Integration Score) — gate/quality tuning
+ *   eva_consultant   -> O-GOV-3 (Deploy Strategic Governance Stack) — governance-stack recs
+ *
+ * `class` is the candidate class key the preference model (FR-2) weights by.
+ */
+const SIGNAL_CLASS_TO_OBJECTIVE = Object.freeze({
+  'harness-backlog': 'O-GOV-1',
+  'gate-tuning': 'O-GOV-2',
+  'eva-consultant': 'O-GOV-3',
+});
+
+/**
+ * Pick the best live KR under an objective to anchor to: prefer the worst-status
+ * (off_track > at_risk > on_track/pending > completed/achieved) so the candidate
+ * legitimately reflects where the objective is hurting. Returns null when the
+ * objective has no live KR (-> the signal is excluded, never faked).
+ *
+ * key_results.status domain observed live: on_track | pending | at_risk |
+ * achieved. The rationale bar's scorer maps unknown statuses -> on_track (1.0).
+ */
+const STATUS_RANK = Object.freeze({
+  off_track: 5,
+  at_risk: 4,
+  not_started: 3,
+  pending: 3,
+  on_track: 2,
+  completed: 1,
+  achieved: 1,
+});
+
+function pickAnchorKr(krRows) {
+  if (!Array.isArray(krRows) || krRows.length === 0) return null;
+  let best = null;
+  let bestRank = -1;
+  for (const kr of krRows) {
+    const rank = STATUS_RANK[kr.status] ?? 2; // unknown -> on_track-ish
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = kr;
+    }
+  }
+  return best;
+}
+
+/**
+ * Normalize a key_results row + objective code into the objective_kr anchor shape
+ * the rationale bar expects: { objective, kr, kr_status, off_track_delta }.
+ */
+function toAnchor(objectiveCode, krRow) {
+  if (!krRow) return null;
+  // off_track_delta: a real, computed signed gap (current - target) when numeric,
+  // else null. NEVER fabricated — purely derived from the live KR row.
+  let delta = null;
+  if (typeof krRow.current_value === 'number' && typeof krRow.target_value === 'number') {
+    delta = Math.round((krRow.current_value - krRow.target_value) * 100) / 100;
+  }
+  return {
+    objective: objectiveCode,
+    kr: krRow.code || krRow.id, // real KR code/id — never invented
+    kr_status: krRow.status || 'on_track',
+    off_track_delta: delta,
+    key_result_id: krRow.id,
+  };
+}
+
+/**
+ * Build a candidate from one harness-signal class. Returns null when no live KR
+ * anchors the class (the signal is then excluded — the cardinal safety rule).
+ * Pure: no DB; takes the pre-fetched KR rows for the class's objective.
+ *
+ * @param {object} args
+ * @param {string} args.signalClass    candidate class key (e.g. 'harness-backlog')
+ * @param {string} args.objectiveCode  O-GOV objective code
+ * @param {Array}  args.krRows         live key_results rows under that objective
+ * @param {number} args.count          number of open signals of this class
+ * @param {string} args.contribution_type  'direct'|'enabling'|'supporting'
+ * @param {object} args.copy           { opportunity, evidence, rationale, risk, counterfactual }
+ * @param {number} [args.confidence]
+ * @param {string} args.dedup_key
+ */
+export function buildCandidateFromSignal({
+  signalClass,
+  objectiveCode,
+  krRows,
+  count,
+  contribution_type,
+  copy,
+  confidence = 0.6,
+  dedup_key,
+}) {
+  if (!count || count <= 0) return null; // no signal -> no candidate
+  const krRow = pickAnchorKr(krRows);
+  const anchor = toAnchor(objectiveCode, krRow);
+  if (!anchor || !anchor.kr) return null; // NO live KR -> EXCLUDE (never fabricate)
+  return {
+    scope_key: 'harness',
+    class: signalClass,
+    objective_kr: anchor,
+    contribution_type,
+    opportunity: copy.opportunity,
+    evidence: copy.evidence,
+    rationale: copy.rationale,
+    risk: copy.risk,
+    counterfactual: copy.counterfactual,
+    confidence,
+    dedup_key,
+    roadmap_id: '3aa2f3e2-75fa-4fc8-a17e-44d553b86674', // FR-3: LEO Roadmap (self-gates to no-op today)
+  };
+}
+
+/**
+ * Map raw harness signal inputs (counts + the live KR rows per O-GOV objective)
+ * into scored candidate objects. PURE + DB-free (fully unit-testable).
+ *
+ * @param {object} args
+ * @param {Array} [args.backlog]   feedback rows (harness_backlog)
+ * @param {Array} [args.retros]
+ * @param {Array} [args.gateRecs]  gate-tuning recommendation rows
+ * @param {Array} [args.evaRecs]   pending EVA consultant recs
+ * @param {Map<string,Array>} [args.krByObjective]  objectiveCode -> live key_results rows
+ */
+export function summarizeHarness({
+  backlog = [],
+  retros = [],
+  gateRecs = [],
+  evaRecs = [],
+  krByObjective = new Map(),
+} = {}) {
+  // Only gate-tuning recs that recommend an ACTUAL threshold change are actionable;
+  // MONITOR rows are not a governance opportunity.
+  const actionableGateRecs = (gateRecs || []).filter(
+    (r) => r && typeof r.recommendation === 'string' && /^(INCREASE|DECREASE)/i.test(r.recommendation)
+  );
+  // Engineer-domain EVA recs that propose creating an SD are governance-stack work.
+  const engineerEvaRecs = (evaRecs || []).filter(
+    (r) => r && r.action_type === 'create_sd'
+  );
+
   const signals = {
     open_harness_backlog: backlog.length,
     recent_retros: retros.length,
     gate_tuning_recs: gateRecs.length,
+    actionable_gate_recs: actionableGateRecs.length,
     pending_eva_recs: evaRecs.length,
+    engineer_eva_recs: engineerEvaRecs.length,
   };
-  return { scope_key: 'harness', signals, candidates: [], gaps: [] };
+
+  const get = (code) => krByObjective.get?.(code) || [];
+
+  const rawCandidates = [
+    buildCandidateFromSignal({
+      signalClass: 'harness-backlog',
+      objectiveCode: SIGNAL_CLASS_TO_OBJECTIVE['harness-backlog'],
+      krRows: get(SIGNAL_CLASS_TO_OBJECTIVE['harness-backlog']),
+      count: backlog.length,
+      contribution_type: 'enabling',
+      confidence: 0.6,
+      dedup_key: 'harness-backlog-cleanup',
+      copy: {
+        opportunity: `Burn down the open harness backlog (${backlog.length} item${backlog.length === 1 ? '' : 's'}) to advance Foundation Cleanup.`,
+        evidence: `feedback(category=harness_backlog,status=new) holds ${backlog.length} unresolved harness signal${backlog.length === 1 ? '' : 's'}.`,
+        rationale: 'A scoped cleanup SD reduces accumulated process/cleanup debt against the Foundation Cleanup KR.',
+        risk: 'Some backlog items may be stale or already-superseded; triage before scoping.',
+        counterfactual: 'If left to accumulate, the backlog grows and the cleanup KR drifts further from target.',
+      },
+    }),
+    buildCandidateFromSignal({
+      signalClass: 'gate-tuning',
+      objectiveCode: SIGNAL_CLASS_TO_OBJECTIVE['gate-tuning'],
+      krRows: get(SIGNAL_CLASS_TO_OBJECTIVE['gate-tuning']),
+      count: actionableGateRecs.length,
+      contribution_type: 'direct',
+      confidence: 0.7,
+      dedup_key: 'harness-gate-tuning',
+      copy: {
+        opportunity: `Apply ${actionableGateRecs.length} actionable gate-threshold tuning recommendation${actionableGateRecs.length === 1 ? '' : 's'} to raise LEO intelligence.`,
+        evidence: `v_ai_quality_tuning_recommendations flags ${actionableGateRecs.length} INCREASE/DECREASE recommendation${actionableGateRecs.length === 1 ? '' : 's'}.`,
+        rationale: 'Tuning gate thresholds to the evidence improves the LEO Intelligence Integration score.',
+        risk: 'Over-tuning could mask real defects; apply per-type with review.',
+        counterfactual: 'If thresholds stay misaligned, gate pass-rates and intelligence score remain below target.',
+      },
+    }),
+    buildCandidateFromSignal({
+      signalClass: 'eva-consultant',
+      objectiveCode: SIGNAL_CLASS_TO_OBJECTIVE['eva-consultant'],
+      krRows: get(SIGNAL_CLASS_TO_OBJECTIVE['eva-consultant']),
+      count: engineerEvaRecs.length,
+      contribution_type: 'supporting',
+      confidence: 0.55,
+      dedup_key: 'harness-eva-consultant',
+      copy: {
+        opportunity: `Review ${engineerEvaRecs.length} pending EVA consultant recommendation${engineerEvaRecs.length === 1 ? '' : 's'} for governance-stack work.`,
+        evidence: `eva_consultant_recommendations holds ${engineerEvaRecs.length} pending create_sd recommendation${engineerEvaRecs.length === 1 ? '' : 's'}.`,
+        rationale: 'Acting on vetted EVA recommendations advances the Strategic Governance Stack.',
+        risk: 'EVA recs vary in confidence; filter by confidence_tier before scoping.',
+        counterfactual: 'If pending recs are never reviewed, governance-stack gaps persist unaddressed.',
+      },
+    }),
+  ];
+
+  const candidates = rawCandidates.filter(Boolean);
+  return { scope_key: 'harness', signals, candidates, gaps: [] };
 }
 
 async function safe(fn) {
@@ -29,6 +232,37 @@ async function safe(fn) {
   }
 }
 
+/**
+ * Fetch live key_results rows grouped by O-GOV objective code. Read-only,
+ * fail-soft: any error yields an empty Map (-> all signals excluded, never faked).
+ * @returns {Promise<Map<string,Array>>}
+ */
+export async function fetchKrByObjective(supabase) {
+  const map = new Map();
+  try {
+    const codes = [...new Set(Object.values(SIGNAL_CLASS_TO_OBJECTIVE))];
+    const { data: objs } = await supabase
+      .from('objectives')
+      .select('id, code')
+      .in('code', codes);
+    if (!objs || objs.length === 0) return map;
+    const idToCode = new Map(objs.map((o) => [o.id, o.code]));
+    const { data: krs } = await supabase
+      .from('key_results')
+      .select('id, code, title, status, objective_id, current_value, target_value')
+      .in('objective_id', [...idToCode.keys()]);
+    for (const kr of krs || []) {
+      const code = idToCode.get(kr.objective_id);
+      if (!code) continue;
+      if (!map.has(code)) map.set(code, []);
+      map.get(code).push(kr);
+    }
+  } catch {
+    return new Map();
+  }
+  return map;
+}
+
 export async function briefHarness(supabase) {
   const backlog = await safe(async () =>
     (await supabase.from('feedback').select('id').eq('category', 'harness_backlog').eq('status', 'new')).data
@@ -37,10 +271,12 @@ export async function briefHarness(supabase) {
     (await supabase.from('retrospectives').select('id').order('created_at', { ascending: false }).limit(20)).data
   );
   const gateRecs = await safe(async () =>
-    (await supabase.from('v_ai_quality_tuning_recommendations').select('sd_type')).data
+    (await supabase.from('v_ai_quality_tuning_recommendations').select('sd_type, recommendation')).data
   );
   const evaRecs = await safe(async () =>
-    (await supabase.from('eva_consultant_recommendations').select('id').eq('status', 'pending').limit(50)).data
+    (await supabase.from('eva_consultant_recommendations').select('id, action_type, confidence_tier').eq('status', 'pending').limit(50)).data
   );
-  return summarizeHarness({ backlog, retros, gateRecs, evaRecs });
+  // Live KR anchors — the cardinal safety rule depends on these being real.
+  const krByObjective = await fetchKrByObjective(supabase);
+  return summarizeHarness({ backlog, retros, gateRecs, evaRecs, krByObjective });
 }

--- a/lib/adam/preference-model.js
+++ b/lib/adam/preference-model.js
@@ -1,0 +1,267 @@
+/**
+ * Adam preference model — SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-2).
+ *
+ * PURE / injectable. Computes a BOUNDED per-candidate-class weight map that the
+ * rationale bar (selectAdvisory) applies as a multiplier on the raw OKR score.
+ * The map is the UNION of:
+ *   (a) EXPLICIT chairman_preferences rows (resolved via chairman-preference-store
+ *       getPreferences) — the DOMINANT term; and
+ *   (b) the chairman_decisions verdicts as a WEAK soft prior — these are
+ *       gate/review verdicts, NOT topical priorities, so their derived class is
+ *       conservative and their weight contribution is small and never dominant.
+ *
+ * CARDINAL SAFETY RULES (the whole point of this SD):
+ *   - A preference/Q2 weight must NEVER override genuine objective (KR-status)
+ *     signal. The PRIMARY guarantee now lives in selectAdvisory: the KR-status
+ *     TIER is the DOMINANT sort key, so an off-track (or at_risk) candidate
+ *     ALWAYS outranks a less-urgent one regardless of class, preference weight,
+ *     or wave alignment. The bounded clamp below is NO LONGER load-bearing for
+ *     CROSS-tier safety — it only nudges INTRA-tier order (see note).
+ *   - Weights are BOUNDED: clamp() keeps every weight in [CLAMP_LO, CLAMP_HI]
+ *     around 1.0. A weight is NEVER 0 (never zeroes a candidate) and is never
+ *     non-finite. This keeps the intra-tier nudge proportionate.
+ *   - A FLAT all-1.0 weight map produces selection BYTE-IDENTICAL to the
+ *     (statusTier-dominant) OKR-only ordering (the multiplier is identity 1.0).
+ *   - The explicit chairman_preferences term DOMINATES the weak decisions prior.
+ *
+ * INTRA-TIER NOTE (clamp is now only an intra-tier nudge):
+ *   Cross-class inversion WITHIN the same status tier (e.g. boosting an on-track
+ *   gate-tuning candidate above an on-track eva-consultant one) is the INTENDED,
+ *   acceptable effect of the chairman directive — both are at the SAME objective
+ *   urgency. The OLD proof (3*CLAMP_LO >= 1*CLAMP_HI, ratio 1.5625 <= 3) showed
+ *   the clamp alone could not invert off-track below on-track within ONE
+ *   contribution class; that arithmetic still holds but is now SUPERSEDED as the
+ *   safety mechanism by the statusTier-dominant sort, which holds across ALL
+ *   classes and contribution types (the clamp could NOT, e.g. off-track/supporting
+ *   raw 15 vs on-track/direct raw 15 was invertible by weight under the old
+ *   score-dominant sort — the tier sort fixes exactly that case).
+ */
+
+// Bounded clamp range, symmetric in ratio around 1.0 (0.8 = 1/1.25).
+export const CLAMP_LO = 0.8;
+export const CLAMP_HI = 1.25;
+
+// Standing directive seeded as the first explicit preference (FR-2 data seed).
+export const WORKER_CAPABILITY_PREF_KEY = 'priority.worker_capability_over_adam_autonomy';
+export const STANDING_WORKER_CAPABILITY_DIRECTIVE = Object.freeze({
+  chairmanId: 'ehg_chairman',
+  ventureId: null, // global
+  key: WORKER_CAPABILITY_PREF_KEY,
+  // Class weights the chairman's standing directive expresses: prefer
+  // worker-capability work over Adam-autonomy work. Bounded values (pre-clamp).
+  value: {
+    'worker-capability': CLAMP_HI,
+    'adam-autonomy': CLAMP_LO,
+  },
+  valueType: 'object',
+  source: 'chairman_directive',
+});
+
+/**
+ * FIX 3 (dead no-op closure) — candidate SOURCE class -> directive TOPIC class.
+ *
+ * THE BUG: harness candidates carry a SOURCE class (harness-backlog /
+ * gate-tuning / eva-consultant), but the chairman's standing directive
+ * (STANDING_WORKER_CAPABILITY_DIRECTIVE) keys on a TOPIC vocabulary
+ * (worker-capability / adam-autonomy). selectAdvisory looked up prefWeights by
+ * the raw source class, which NEVER matched the directive keys -> identity 1.0 ->
+ * the directive was a guaranteed no-op (proven: prefWeights['harness-backlog']
+ * is undefined for a directive that only defines 'worker-capability' /
+ * 'adam-autonomy').
+ *
+ * THE BRIDGE (semantically correct): a candidate's TOPIC is what the chairman
+ * actually expressed a priority over. We derive it from the candidate's
+ * objective (O-GOV-1/2/3) — the governance objective it concerns — falling back
+ * to the source class. The directive 'worker-capability > adam-autonomy' is a
+ * topic priority; the harness source class is a SOURCE; this map is the bridge.
+ *
+ *   O-GOV-2 "Raise LEO Intelligence Integration Score"  (gate-tuning)
+ *       -> 'worker-capability'  (making the LEO machinery / workers smarter)
+ *   O-GOV-3 "Deploy Strategic Governance Stack"         (eva-consultant)
+ *       -> 'adam-autonomy'      (governance-stack / Adam-machinery work)
+ *   O-GOV-1 "Foundation Cleanup & Consolidation"        (harness-backlog)
+ *       -> UNMAPPED (neutral infra debt — neither topic; stays at identity 1.0)
+ *
+ * Source class is mapped equivalently as a fallback (when objective is absent)
+ * so the bridge is robust to either keying axis.
+ */
+export const CANDIDATE_TOPIC_BY_OBJECTIVE = Object.freeze({
+  'O-GOV-2': 'worker-capability',
+  'O-GOV-3': 'adam-autonomy',
+  // O-GOV-1 deliberately omitted -> neutral (identity weight).
+});
+
+export const CANDIDATE_TOPIC_BY_SOURCE_CLASS = Object.freeze({
+  'gate-tuning': 'worker-capability',
+  'eva-consultant': 'adam-autonomy',
+  // 'harness-backlog' deliberately omitted -> neutral (identity weight).
+});
+
+/**
+ * Resolve a candidate's preference TOPIC class (the directive vocabulary), or
+ * null when the candidate maps to no directive topic (-> identity weight 1.0).
+ * Prefers the objective_kr.objective axis (most semantically precise), then the
+ * source class. PURE.
+ *
+ * @param {object} candidate
+ * @returns {string|null}
+ */
+export function candidatePreferenceClass(candidate) {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const objective = candidate.objective_kr && candidate.objective_kr.objective;
+  if (objective && CANDIDATE_TOPIC_BY_OBJECTIVE[objective]) {
+    return CANDIDATE_TOPIC_BY_OBJECTIVE[objective];
+  }
+  const sourceClass = candidate.class || candidate.scope_key;
+  if (sourceClass && CANDIDATE_TOPIC_BY_SOURCE_CLASS[sourceClass]) {
+    return CANDIDATE_TOPIC_BY_SOURCE_CLASS[sourceClass];
+  }
+  return null;
+}
+
+/** Clamp a numeric weight into the documented bounded range. Non-finite -> 1.0. */
+export function clamp(w) {
+  if (typeof w !== 'number' || !Number.isFinite(w)) return 1.0;
+  if (w < CLAMP_LO) return CLAMP_LO;
+  if (w > CLAMP_HI) return CLAMP_HI;
+  return w;
+}
+
+/** The list of explicit preference keys the model resolves. */
+export const PREFERENCE_KEYS = [WORKER_CAPABILITY_PREF_KEY];
+
+/**
+ * Derive a WEAK class prior from chairman_decisions. These are gate/review
+ * verdicts (approve/go/reject across stage gates), NOT topical priorities — so
+ * we only nudge a single conservative class ('conservative') by a tiny amount
+ * reflecting overall verdict caution, and we cap the total nudge so it can never
+ * approach, let alone dominate, the explicit term. Returns { weights, consumed }.
+ *
+ * @param {Array} decisions  chairman_decisions rows (each may have .status/.decision)
+ * @param {number} [perDecisionNudge=0.01]  weak influence per decision
+ * @param {number} [maxNudge=0.1]           cap on the aggregate decisions nudge
+ */
+export function deriveDecisionsPrior(decisions, { perDecisionNudge = 0.01, maxNudge = 0.1 } = {}) {
+  const rows = Array.isArray(decisions) ? decisions : [];
+  if (rows.length === 0) return { weights: {}, consumed: 0 };
+  // Count rejections/blocks as a caution signal toward the 'conservative' class.
+  let cautious = 0;
+  for (const d of rows) {
+    const verdict = String(d?.decision ?? d?.status ?? '').toLowerCase();
+    if (/reject|deny|block|no[-_ ]?go|kill|hold/.test(verdict)) cautious += 1;
+  }
+  // Magnitude is small and capped: at most maxNudge ABOVE 1.0, never dominant.
+  const nudge = Math.min(maxNudge, cautious * perDecisionNudge);
+  const weights = nudge > 0 ? { conservative: 1.0 + nudge } : {};
+  return { weights, consumed: rows.length };
+}
+
+/**
+ * Compute the bounded preference weight map. PURE given injected inputs.
+ *
+ * @param {object} args
+ * @param {object} [args.store]        chairman-preference-store-like (getPreferences)
+ * @param {object} [args.supabase]     used to build a default store if store omitted
+ * @param {string} [args.chairmanId='ehg_chairman']
+ * @param {string|null} [args.ventureId=null]
+ * @param {Array} [args.decisions=[]]  chairman_decisions rows (weak prior)
+ * @returns {Promise<{ weights: object, explicitClasses: string[], decisionsConsumed: number, source: string }>}
+ */
+export async function computePreferenceWeights({
+  store,
+  supabase,
+  chairmanId = 'ehg_chairman',
+  ventureId = null,
+  decisions = [],
+} = {}) {
+  // Resolve the explicit (dominant) preference term, fail-soft.
+  let explicitWeights = {};
+  const explicitClasses = [];
+  try {
+    let resolver = store;
+    if (!resolver && supabase) {
+      const mod = await import('../eva/chairman-preference-store.js');
+      resolver = mod.createChairmanPreferenceStore({ supabaseClient: supabase });
+    }
+    if (resolver && typeof resolver.getPreferences === 'function') {
+      const resolved = await resolver.getPreferences({ chairmanId, ventureId, keys: PREFERENCE_KEYS });
+      for (const [, pref] of resolved instanceof Map ? resolved : Object.entries(resolved || {})) {
+        const val = pref?.value;
+        if (val && typeof val === 'object' && !Array.isArray(val)) {
+          for (const [cls, w] of Object.entries(val)) {
+            if (typeof w === 'number') {
+              explicitWeights[cls] = w; // dominant — overwrites any prior
+              explicitClasses.push(cls);
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    explicitWeights = {};
+  }
+
+  // Weak decisions prior (soft, capped — never dominant).
+  const { weights: priorWeights, consumed: decisionsConsumed } = deriveDecisionsPrior(decisions);
+
+  // UNION: start from the weak prior, then let the explicit term DOMINATE
+  // (overwrite) any overlapping class. Finally clamp every value to the range.
+  const merged = { ...priorWeights };
+  for (const [cls, w] of Object.entries(explicitWeights)) merged[cls] = w; // dominant
+  const weights = {};
+  for (const [cls, w] of Object.entries(merged)) weights[cls] = clamp(w);
+
+  return {
+    weights,
+    explicitClasses: [...new Set(explicitClasses)],
+    decisionsConsumed,
+    source: explicitClasses.length ? 'explicit+decisions' : (decisionsConsumed ? 'decisions-only' : 'empty'),
+  };
+}
+
+/**
+ * Idempotent seed of the standing 'worker-capability > Adam-autonomy' directive
+ * as an EXPLICIT chairman_preferences row. Skips the write if the row already
+ * exists (resolves via the store). This is a one-row DATA seed against the
+ * existing chairman_preferences table — NO schema change.
+ *
+ * INVOCATION: run at deploy/activation, e.g.
+ *   node -e "import('./lib/adam/preference-model.js').then(m =>
+ *     m.seedStandingPreference({ supabase }))"
+ * It is NOT executed during EXEC/tests — it performs a live DB write.
+ *
+ * @param {object} args
+ * @param {object} [args.store]    chairman-preference-store-like
+ * @param {object} [args.supabase] used to construct a default store if store omitted
+ * @returns {Promise<{ seeded: boolean, skipped: boolean, error?: string }>}
+ */
+export async function seedStandingPreference({ store, supabase } = {}) {
+  let resolver = store;
+  if (!resolver) {
+    if (!supabase) return { seeded: false, skipped: false, error: 'no store or supabase provided' };
+    const mod = await import('../eva/chairman-preference-store.js');
+    resolver = mod.createChairmanPreferenceStore({ supabaseClient: supabase });
+  }
+  const d = STANDING_WORKER_CAPABILITY_DIRECTIVE;
+  // Idempotency: skip if already present.
+  try {
+    const existing = await resolver.getPreference({
+      chairmanId: d.chairmanId,
+      ventureId: d.ventureId,
+      key: d.key,
+    });
+    if (existing) return { seeded: false, skipped: true };
+  } catch {
+    // fall through to attempt the write
+  }
+  const res = await resolver.setPreference({
+    chairmanId: d.chairmanId,
+    ventureId: d.ventureId,
+    key: d.key,
+    value: d.value,
+    valueType: d.valueType,
+    source: d.source,
+  });
+  if (!res?.success) return { seeded: false, skipped: false, error: res?.error || 'setPreference failed' };
+  return { seeded: true, skipped: false };
+}

--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -17,6 +17,55 @@ import {
   getContributionWeights,
   getKRStatusMultipliers,
 } from '../eva/okr-priority-integrator.js';
+import { clamp, CLAMP_HI, candidatePreferenceClass } from './preference-model.js';
+
+/**
+ * CARDINAL INVARIANT (the whole point of this SD): a preference/Q2 weight must
+ * NEVER override genuine objective (KR-status) signal. We enforce this with a
+ * DOMINANT status tier that is the PRIMARY sort key — preference + wave
+ * multipliers only ever reorder candidates WITHIN the same status tier.
+ *
+ * statusTier rank (higher = more urgent, surfaces first):
+ *   off_track   -> 5  (most urgent)
+ *   at_risk     -> 4
+ *   not_started -> 3
+ *   pending     -> 3  (treated as not-yet-acted, mid urgency)
+ *   unknown     -> 2  (defaults to on_track-ish; never urgent)
+ *   on_track    -> 2
+ *   completed   -> 1
+ *   achieved    -> 1  (least urgent)
+ *
+ * Because statusTier is compared BEFORE the (bounded) effective score, an
+ * off-track candidate ALWAYS outranks an on-track one regardless of class,
+ * preference weight, or wave alignment — the bounded-clamp arithmetic is no
+ * longer load-bearing for cross-tier safety (it only nudges intra-tier order).
+ */
+const STATUS_TIER = Object.freeze({
+  off_track: 5,
+  at_risk: 4,
+  not_started: 3,
+  pending: 3,
+  on_track: 2,
+  completed: 1,
+  achieved: 1,
+});
+
+/** Map a candidate's KR status to its dominant urgency tier (unknown -> on_track tier 2). */
+export function statusTierOf(candidate) {
+  const status = candidate && candidate.objective_kr && candidate.objective_kr.kr_status;
+  return STATUS_TIER[status] ?? 2; // unknown / no anchor -> on_track-ish (never urgent)
+}
+
+/** Is the candidate at an URGENT objective tier (off_track / at_risk)? */
+export function isUrgentStatus(candidate) {
+  const status = candidate && candidate.objective_kr && candidate.objective_kr.kr_status;
+  return status === 'off_track' || status === 'at_risk';
+}
+
+// FR-3: the LEO Roadmap. The Q2 wave-alignment term keys STRICTLY on this id and
+// self-gates to a 1.0 no-op until it has waves (it has 0 today), so it can never
+// false-fire on the EVA-Intake roadmap (ed12bf74…, 462 items).
+export const LEO_ROADMAP_ID = '3aa2f3e2-75fa-4fc8-a17e-44d553b86674';
 
 export const REQUIRED_RATIONALE_FIELDS = [
   'opportunity',
@@ -70,10 +119,48 @@ export function hasLiveAnchor(candidate) {
 }
 
 /**
+ * FR-3 — the Q2 wave-alignment term. PURE: derives the multiplier and the
+ * align/unaligned verdict from a PRE-COMPUTED alignment object (the caller runs
+ * okr-wave-linker.calculateAlignment keyed on LEO_ROADMAP_ID and injects it).
+ *
+ * SELF-GATING: when the alignment has 0 waves (today's LEO Roadmap state) OR no
+ * alignment is provided, the term is INACTIVE — multiplier 1.0, never unaligned.
+ * This makes it a provable no-op until the LEO Roadmap has waves, so it can never
+ * false-fire on the EVA-Intake roadmap.
+ *
+ * When waves exist: a candidate whose roadmap_wave_ref OKR is in the aligned set
+ * is "aligned" (multiplier CLAMP_HI); a Q1-passing candidate that is NOT aligned
+ * is flagged unaligned (caller routes it to backlog).
+ *
+ * @param {object} candidate
+ * @param {object} [waveAlignment]  calculateAlignment() result for LEO_ROADMAP_ID
+ * @returns {{ active: boolean, multiplier: number, aligned: boolean|null }}
+ */
+export function waveAlignmentTerm(candidate, waveAlignment) {
+  const waves = waveAlignment && Array.isArray(waveAlignment.waves) ? waveAlignment.waves : [];
+  if (waves.length === 0) {
+    // Inactive — provable no-op (self-gated on 0 waves / missing alignment).
+    return { active: false, multiplier: 1.0, aligned: null };
+  }
+  // Active: derive the aligned OKR-id set from the roadmap's wave linkages.
+  const alignedOkrIds = new Set();
+  for (const w of waves) {
+    for (const id of w.okr_ids || []) alignedOkrIds.add(id);
+  }
+  // A candidate aligns when its declared roadmap_wave_ref (an OKR id/code) is
+  // among the roadmap's aligned OKRs. No ref => unaligned (when the term is on).
+  const ref = candidate && candidate.roadmap_wave_ref;
+  const aligned = Boolean(ref && alignedOkrIds.has(ref));
+  return { active: true, multiplier: aligned ? CLAMP_HI : 1.0, aligned };
+}
+
+/**
  * Evaluate a single candidate against the bar.
  * @param {object} candidate
- * @param {{openSdKeys?: Set<string>|Array<string>}} [opts]
- * @returns {{ clears: boolean, score: number|null, reasons: string[] }}
+ * @param {object} [opts]
+ * @param {Set<string>|Array<string>} [opts.openSdKeys]
+ * @param {object} [opts.waveAlignment] pre-computed calculateAlignment() for LEO_ROADMAP_ID
+ * @returns {{ clears: boolean, score: number|null, reasons: string[], waveUnaligned: boolean }}
  */
 export function evaluateCandidate(candidate, opts = {}) {
   const openSdKeys =
@@ -100,33 +187,131 @@ export function evaluateCandidate(candidate, opts = {}) {
   const cc = passesConstSelfCheck(candidate);
   if (!cc.ok) reasons.push(...cc.violations);
 
-  return { clears: reasons.length === 0, score, reasons };
+  // FR-3 + CARDINAL INVARIANT (FIX 2): Q1-pass / Q2-unaligned routing. Only
+  // ACTIVE when the LEO Roadmap has waves (self-gated). A candidate that
+  // otherwise clears (Q1 pass) but is NOT wave-aligned is routed to backlog —
+  // BUT this exclusion applies ONLY to NON-URGENT candidates (on_track /
+  // achieved / completed / pending / not_started / unknown). An off_track or
+  // at_risk KR candidate can NEVER be excluded/routed-to-backlog by Q2 wave
+  // unalignment; genuine objective signal always clears the wave gate. (Wave
+  // alignment may still nudge an urgent candidate's INTRA-TIER order via the
+  // multiplier in selectAdvisory, but it never excludes it here.)
+  const wave = waveAlignmentTerm(candidate, opts.waveAlignment);
+  const q1Pass = reasons.length === 0;
+  const urgent = isUrgentStatus(candidate);
+  const waveUnaligned = wave.active && q1Pass && wave.aligned === false && !urgent;
+  if (waveUnaligned) reasons.push('Q2 wave-unaligned (routed to backlog)');
+
+  return { clears: reasons.length === 0, score, reasons, waveUnaligned };
+}
+
+/**
+ * Resolve a candidate's PREFERENCE class key for weighting (FR-2).
+ *
+ * FIX 3 (dead no-op): candidates carry a SOURCE class (harness-backlog /
+ * gate-tuning / eva-consultant) but the chairman's seeded directive keys on a
+ * TOPIC vocabulary (worker-capability / adam-autonomy). Resolving the raw source
+ * class against prefWeights always missed -> identity 1.0 -> the directive had
+ * ZERO effect. candidatePreferenceClass() bridges source class + objective_kr.objective
+ * to the directive's topic vocabulary so the weight actually applies. It returns
+ * the topic when one is mapped, else falls back to the raw source class /
+ * scope_key (so non-harness scopes keyed directly by class still work).
+ */
+function candidateClass(c) {
+  return candidatePreferenceClass(c) || (c && (c.class || c.scope_key)) || 'default';
 }
 
 /**
  * Evaluate all candidates, rank the cleared ones, and apply the GLOBAL <=1
  * advisory cap. Returns the single advisory to surface (or null => ADAM_OK).
+ *
+ * CARDINAL INVARIANT (FIX 1): the DOMINANT sort key is the KR-status tier. We
+ * sort by (statusTier DESC, effectiveScore DESC, confidence DESC) where
+ *   effectiveScore = rawScore * clamp(prefWeights[class] ?? 1.0) * waveMultiplier.
+ * Because statusTier is compared FIRST, an off-track candidate ALWAYS outranks
+ * an on-track one regardless of class, preference weight, or wave alignment —
+ * the preference weight can only reorder candidates WITHIN the same status tier.
+ * (The bounded clamp's cross-class safety now comes from this statusTier-dominant
+ * sort, NOT from the clamp arithmetic; intra-tier inversion across classes is the
+ * intended, acceptable effect of the weight.)
+ *
+ * BYTE-IDENTICAL baseline: a FLAT all-1.0 prefWeights map with no wave alignment
+ * yields effectiveScore === rawScore for every candidate, so the ordering is the
+ * same (statusTier, then rawScore, then confidence) as the OKR-only baseline —
+ * which is itself now sorted statusTier-first. On every rank change a
+ * perturbation trace is emitted.
+ *
  * @param {Array} candidates
  * @param {object} [opts]
- * @returns {{ surfaced: object|null, verdict: 'ADAM_OK'|'SURFACED', cleared: number, evaluated: Array }}
+ * @param {Set<string>|Array<string>} [opts.openSdKeys]
+ * @param {object} [opts.prefWeights]   class -> bounded weight (from preference-model)
+ * @param {object} [opts.waveAlignment] pre-computed calculateAlignment() for LEO_ROADMAP_ID
+ * @returns {{ surfaced: object|null, verdict: 'ADAM_OK'|'SURFACED', cleared: number, evaluated: Array, trace: Array }}
  */
 export function selectAdvisory(candidates, opts = {}) {
+  const prefWeights = opts.prefWeights || {};
   const evaluated = (candidates || []).map((c) => {
     const e = evaluateCandidate(c, opts);
     return { candidate: c, ...e };
   });
   const cleared = evaluated.filter((x) => x.clears);
   if (cleared.length === 0) {
-    return { surfaced: null, verdict: 'ADAM_OK', cleared: 0, evaluated };
+    return { surfaced: null, verdict: 'ADAM_OK', cleared: 0, evaluated, trace: [] };
   }
-  cleared.sort(
-    (a, b) => (b.score ?? 0) - (a.score ?? 0) || (b.candidate.confidence ?? 0) - (a.candidate.confidence ?? 0)
+
+  // Annotate each cleared candidate with its status tier, bounded weight + effective score.
+  for (const x of cleared) {
+    const cls = candidateClass(x.candidate);
+    const prefW = clamp(prefWeights[cls] ?? 1.0); // bounded; missing -> identity 1.0
+    const wave = waveAlignmentTerm(x.candidate, opts.waveAlignment); // 1.0 when inactive
+    x._class = cls;
+    x._prefW = prefW;
+    x._waveMul = wave.multiplier;
+    x._tier = statusTierOf(x.candidate); // DOMINANT sort key (CARDINAL INVARIANT)
+    x._effective = (x.score ?? 0) * prefW * wave.multiplier;
+  }
+
+  // BASELINE order = OKR-only ordering, statusTier-dominant (raw score, then confidence).
+  const baseline = [...cleared].sort(
+    (a, b) =>
+      b._tier - a._tier ||
+      (b.score ?? 0) - (a.score ?? 0) ||
+      (b.candidate.confidence ?? 0) - (a.candidate.confidence ?? 0)
   );
+  const baseRankByCand = new Map(baseline.map((x, i) => [x.candidate, i]));
+
+  // FINAL order = statusTier (DOMINANT), then effective score, then confidence.
+  // statusTier compared FIRST guarantees off-track always outranks on-track; the
+  // preference/wave weight can only reorder WITHIN a tier.
+  const finalOrder = [...cleared].sort(
+    (a, b) =>
+      b._tier - a._tier ||
+      (b._effective ?? 0) - (a._effective ?? 0) ||
+      (b.candidate.confidence ?? 0) - (a.candidate.confidence ?? 0)
+  );
+
+  // Emit a rank-perturbation trace for EVERY candidate whose rank moved.
+  const trace = [];
+  finalOrder.forEach((x, finalRank) => {
+    const baseRank = baseRankByCand.get(x.candidate);
+    if (baseRank !== finalRank) {
+      const combined = x._prefW * x._waveMul;
+      trace.push({
+        base_rank: baseRank,
+        final_rank: finalRank,
+        moved_by_weight: combined !== 1.0,
+        class: x._class,
+        weight: combined,
+      });
+    }
+  });
+
   return {
-    surfaced: { ...cleared[0].candidate, okr_score: cleared[0].score },
+    surfaced: { ...finalOrder[0].candidate, okr_score: finalOrder[0].score, effective_score: finalOrder[0]._effective },
     verdict: 'SURFACED',
     cleared: cleared.length,
     evaluated,
+    trace,
   };
 }
 

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -155,6 +155,22 @@ try {
   quitLine = `Distance-to-quit: (unavailable ${EM} threshold source not reachable this run)`;
 }
 
+// ── 2c. chairman_decisions CONSUMED counter (SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 FR-4) ──
+// How many chairman_decisions the Adam preference model consumed as a weak soft
+// prior this run. Fail-soft on EVERY branch: a query/import error degrades to a
+// graceful "(unavailable)" line and NEVER crashes the summary.
+let decisionsLine = null;
+try {
+  const { data: decisions } = await db.from('chairman_decisions').select('id, decision, status');
+  const rows = decisions || [];
+  const { deriveDecisionsPrior } = await import('../lib/adam/preference-model.js');
+  const { consumed } = deriveDecisionsPrior(rows);
+  decisionsLine = `chairman_decisions consumed: ${consumed} of ${rows.length}`;
+} catch (e) {
+  console.warn('[adam-email] chairman_decisions-consumed counter unavailable (fail-soft): ' + (e?.message || e));
+  decisionsLine = 'chairman_decisions consumed: (unavailable)';
+}
+
 // ── 3. ACTIONS FOR YOU: render the pending decisions (fetched above) as a copy-paste block ──
 const LEAD_IN = "I have received the following executive decisions via email and I'm ready to address them:";
 const numbered = lines.map((l, i) => `${i + 1}. ${l}`);
@@ -175,6 +191,7 @@ const text = [
   ...(layerLine ? ['   ' + layerLine] : []),
   ...(visNote ? ['   ' + visNote] : []),
   ...(quitLine ? ['', quitLine] : []),
+  ...(decisionsLine ? [decisionsLine] : []),
   '',
   '──────────────────────────────────────────────',
   nActions ? `${nActions} ${nActions === 1 ? 'action' : 'actions'} for you` : 'No decisions need you right now.',
@@ -186,6 +203,7 @@ const text = [
 const layerHtml = layerLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(layerLine)}</div>` : '';
 const noteHtml = visNote ? `<div style="font-size:12px;color:#888;margin:2px 0 0">${esc(visNote)}</div>` : '';
 const quitHtml = quitLine ? `<p style="font-size:14px;margin:10px 0 0">${esc(quitLine)}</p>` : '';
+const decisionsHtml = decisionsLine ? `<p style="font-size:12px;color:#888;margin:4px 0 0">${esc(decisionsLine)}</p>` : '';
 const actionsHtml = nActions
   ? `<p style="font-size:14px;margin:0 0 2px"><b>${nActions} ${nActions === 1 ? 'action' : 'actions'} for you</b></p>` +
     `<p style="font-size:12px;color:#888;margin:0 0 6px">On your phone, press and hold the box below, tap "Select All", then "Copy" — then paste it into Claude Code.</p>` +
@@ -194,7 +212,7 @@ const actionsHtml = nActions
 const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
   `<p style="font-size:15px;margin:0 0 12px"><b>Workers:</b> ${esc(workerText)}</p>` +
   `<p style="font-size:15px;font-weight:600;margin:0 0 0">EHG vision: ${visPct != null ? visPct + '% built' : '(gauge unavailable)'}</p>` +
-  layerHtml + noteHtml + quitHtml +
+  layerHtml + noteHtml + quitHtml + decisionsHtml +
   '<hr style="border:none;border-top:1px solid #e1e4e8;margin:14px 0">' +
   actionsHtml +
   `<p style="font-size:11px;color:#999;margin:14px 0 0">as of ${esc(when)} ET ${EM} Adam ${EM} LEO Fleet Advisor</p></div>`;

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -108,7 +108,7 @@ function appendLedger(entry) {
   return entry;
 }
 
-function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = null }) {
+function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = null, trace = null }) {
   return {
     ts: new Date().toISOString(),
     scope: scope ? scope.scope_key : 'none',
@@ -116,6 +116,8 @@ function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = n
     cleared,
     flag: flagEnabled ? 'on' : 'off',
     ...(detail ? { detail } : {}),
+    // SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001: audit the rank perturbations.
+    ...(Array.isArray(trace) && trace.length ? { trace } : {}),
   };
 }
 
@@ -200,12 +202,41 @@ async function main() {
     }
 
     // mode === 'scan'
-    const { selectAdvisory, formatAdvisoryBody } = await import('../lib/adam/rationale-bar.js');
+    const { selectAdvisory, formatAdvisoryBody, LEO_ROADMAP_ID } = await import('../lib/adam/rationale-bar.js');
     const { applyLivenessGuard } = await import('../lib/adam/liveness-guard.js');
 
     const guarded = applyLivenessGuard(briefing.candidates || [], liveVentureCount);
     const openSdKeys = await fetchOpenSdKeys(supabase);
-    const result = selectAdvisory(guarded.kept, { openSdKeys });
+
+    // SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-2/FR-3): compute the bounded
+    // preference weights + the LEO-Roadmap Q2 wave alignment, and attach both to
+    // selectAdvisory. Behavior change is GATED BY THE FLAG: when the gate is off
+    // we pass NEITHER (flat/no-op path) so selection is byte-identical to today.
+    let selectOpts = { openSdKeys };
+    if (gateEnabled) {
+      try {
+        const { computePreferenceWeights } = await import('../lib/adam/preference-model.js');
+        const { calculateAlignment } = await import('../lib/integrations/okr-wave-linker.js');
+        // chairman_decisions: weak soft prior (read-only, fail-soft to []).
+        let decisions = [];
+        try {
+          const { data } = await supabase.from('chairman_decisions').select('id, decision, status');
+          decisions = data || [];
+        } catch { decisions = []; }
+        const pref = await computePreferenceWeights({ supabase, decisions });
+        selectOpts.prefWeights = pref.weights;
+        // Q2 alignment keyed STRICTLY on the LEO Roadmap; self-gates to no-op on 0 waves.
+        let waveAlignment = null;
+        try { waveAlignment = await calculateAlignment(supabase, LEO_ROADMAP_ID); } catch { waveAlignment = null; }
+        selectOpts.waveAlignment = waveAlignment;
+      } catch (e) {
+        // Fail-soft: drop the perturbation entirely -> byte-identical baseline.
+        process.stderr.write(`[adam-scan] preference/wave term skipped (fail-soft): ${e.message}\n`);
+        selectOpts = { openSdKeys };
+      }
+    }
+
+    const result = selectAdvisory(guarded.kept, selectOpts);
 
     if (!result.surfaced) {
       const entry = appendLedger(buildLedgerEntry({ scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled: gateEnabled }));
@@ -224,7 +255,7 @@ async function main() {
     }
 
     // gate ON (env AND registry): emit exactly ONE advisory via the existing lane.
-    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null }));
+    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null, trace: result.trace }));
     const r = spawnSync('node', [ADVISORY_CLI, 'send', body], { stdio: 'inherit' });
     process.exit(r.status == null ? 0 : r.status);
   } catch (e) {

--- a/tests/unit/adam/exec-summary-decisions-counter.test.js
+++ b/tests/unit/adam/exec-summary-decisions-counter.test.js
@@ -1,0 +1,39 @@
+/**
+ * SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-4) — the exec-summary
+ * 'chairman_decisions consumed: N of <total>' counter line.
+ *
+ * The exec-summary script (scripts/adam-exec-summary.mjs) runs at import time and
+ * touches the live DB, so we don't import it here. Instead we assert the SAME
+ * function the script uses (deriveDecisionsPrior) and reproduce the exact line
+ * shape + the fail-soft fallback the script emits.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveDecisionsPrior } from '../../../lib/adam/preference-model.js';
+
+// Mirror of the script's line builder (kept identical to scripts/adam-exec-summary.mjs FR-4).
+function decisionsLineFrom(rows) {
+  try {
+    const r = rows || [];
+    const { consumed } = deriveDecisionsPrior(r);
+    return `chairman_decisions consumed: ${consumed} of ${r.length}`;
+  } catch {
+    return 'chairman_decisions consumed: (unavailable)';
+  }
+}
+
+describe('FR-4 chairman_decisions-consumed counter', () => {
+  it('renders N of <total> reflecting the consumed decisions', () => {
+    const rows = Array.from({ length: 51 }, (_, i) => ({ id: i, decision: 'approve' }));
+    expect(decisionsLineFrom(rows)).toBe('chairman_decisions consumed: 51 of 51');
+  });
+
+  it('degrades gracefully to 0 of 0 when there are no decisions (no crash)', () => {
+    expect(decisionsLineFrom([])).toBe('chairman_decisions consumed: 0 of 0');
+    expect(decisionsLineFrom(null)).toBe('chairman_decisions consumed: 0 of 0');
+  });
+
+  it('is fail-soft: a thrown source degrades to (unavailable), never crashes', () => {
+    const bad = { get length() { throw new Error('boom'); } };
+    expect(decisionsLineFrom(bad)).toBe('chairman_decisions consumed: (unavailable)');
+  });
+});

--- a/tests/unit/adam/harness-candidates.test.js
+++ b/tests/unit/adam/harness-candidates.test.js
@@ -1,0 +1,198 @@
+/**
+ * SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-1) — briefHarness emits scored
+ * candidates anchored to REAL key_results KRs; unmappable signals are EXCLUDED,
+ * never fabricated. Pure tests + a mocked supabase for briefHarness (no live DB).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  summarizeHarness,
+  buildCandidateFromSignal,
+  briefHarness,
+  fetchKrByObjective,
+} from '../../../lib/adam/briefings/harness.js';
+import { evaluateCandidate, hasLiveAnchor } from '../../../lib/adam/rationale-bar.js';
+
+// A realistic live KR row (shape from key_results).
+const krRow = (over = {}) => ({
+  id: 'kr-uuid-1',
+  code: 'KR-GOV-1.1',
+  title: 'Reduce dead code references to zero',
+  status: 'on_track',
+  objective_id: 'obj-gov-1',
+  current_value: 2,
+  target_value: 0,
+  ...over,
+});
+
+describe('buildCandidateFromSignal (FR-1 anchoring)', () => {
+  it('anchors a candidate to a REAL KR row (objective_kr.kr === the live code)', () => {
+    const c = buildCandidateFromSignal({
+      signalClass: 'harness-backlog',
+      objectiveCode: 'O-GOV-1',
+      krRows: [krRow()],
+      count: 3,
+      contribution_type: 'enabling',
+      confidence: 0.6,
+      dedup_key: 'harness-backlog-cleanup',
+      copy: { opportunity: 'o', evidence: 'e', rationale: 'r', risk: 'k', counterfactual: 'cf' },
+    });
+    expect(c).not.toBeNull();
+    expect(c.objective_kr.kr).toBe('KR-GOV-1.1'); // the REAL code, not invented
+    expect(c.objective_kr.key_result_id).toBe('kr-uuid-1');
+    expect(c.objective_kr.kr_status).toBe('on_track');
+    expect(c.objective_kr.off_track_delta).toBe(2); // current(2) - target(0), derived
+    expect(hasLiveAnchor(c)).toBe(true);
+    expect(c.class).toBe('harness-backlog');
+  });
+
+  it('EXCLUDES a signal that maps to NO live KR (returns null, never fabricates)', () => {
+    const c = buildCandidateFromSignal({
+      signalClass: 'gate-tuning',
+      objectiveCode: 'O-GOV-2',
+      krRows: [], // no live KR under this objective
+      count: 5,
+      contribution_type: 'direct',
+      dedup_key: 'harness-gate-tuning',
+      copy: { opportunity: 'o', evidence: 'e', rationale: 'r', risk: 'k', counterfactual: 'cf' },
+    });
+    expect(c).toBeNull();
+  });
+
+  it('returns null when there is no signal (count 0) even with live KRs', () => {
+    const c = buildCandidateFromSignal({
+      signalClass: 'harness-backlog',
+      objectiveCode: 'O-GOV-1',
+      krRows: [krRow()],
+      count: 0,
+      contribution_type: 'enabling',
+      dedup_key: 'x',
+      copy: { opportunity: 'o', evidence: 'e', rationale: 'r', risk: 'k', counterfactual: 'cf' },
+    });
+    expect(c).toBeNull();
+  });
+
+  it('prefers the worst-status KR under an objective as the anchor', () => {
+    const c = buildCandidateFromSignal({
+      signalClass: 'harness-backlog',
+      objectiveCode: 'O-GOV-1',
+      krRows: [krRow({ code: 'KR-A', status: 'achieved' }), krRow({ code: 'KR-B', status: 'at_risk' })],
+      count: 1,
+      contribution_type: 'enabling',
+      dedup_key: 'x',
+      copy: { opportunity: 'o', evidence: 'e', rationale: 'r', risk: 'k', counterfactual: 'cf' },
+    });
+    expect(c.objective_kr.kr).toBe('KR-B'); // at_risk outranks achieved
+  });
+});
+
+describe('summarizeHarness (FR-1)', () => {
+  const krByObjective = new Map([
+    ['O-GOV-1', [krRow({ code: 'KR-GOV-1.1', status: 'on_track' })]],
+    ['O-GOV-2', [krRow({ code: 'KR-GOV-2.2', status: 'at_risk', objective_id: 'obj-gov-2' })]],
+    ['O-GOV-3', [krRow({ code: 'KR-GOV-3.1', status: 'at_risk', objective_id: 'obj-gov-3' })]],
+  ]);
+
+  it('emits >=1 KR-anchored candidate that clears the rationale bar end-to-end', () => {
+    const r = summarizeHarness({
+      backlog: [1, 2, 3],
+      gateRecs: [{ recommendation: 'INCREASE (+5%): tighten' }],
+      evaRecs: [{ action_type: 'create_sd' }],
+      krByObjective,
+    });
+    expect(r.candidates.length).toBeGreaterThanOrEqual(1);
+    for (const c of r.candidates) {
+      const e = evaluateCandidate(c, { openSdKeys: new Set() });
+      expect(e.clears).toBe(true); // legitimately clears (real anchor, non-zero score)
+      expect(c.objective_kr.kr).toMatch(/^KR-GOV-/);
+    }
+  });
+
+  it('excludes the gate-tuning candidate when no recommendation is actionable (MONITOR only)', () => {
+    const r = summarizeHarness({
+      backlog: [],
+      gateRecs: [{ recommendation: 'MONITOR: keep tracking' }],
+      evaRecs: [],
+      krByObjective,
+    });
+    expect(r.candidates.find((c) => c.class === 'gate-tuning')).toBeUndefined();
+    expect(r.signals.actionable_gate_recs).toBe(0);
+  });
+
+  it('returns NO candidates (candidates:[]) when no live KR map is provided (cardinal rule)', () => {
+    const r = summarizeHarness({ backlog: [1, 2], gateRecs: [{ recommendation: 'INCREASE' }], evaRecs: [{ action_type: 'create_sd' }] });
+    expect(r.candidates).toEqual([]); // every signal excluded — none fabricated
+  });
+});
+
+describe('fetchKrByObjective + briefHarness (mocked supabase, no live DB)', () => {
+  // A chainable supabase mock that resolves table reads to fixtures.
+  function mockSupabase(fixtures) {
+    return {
+      from(table) {
+        const ctx = { table };
+        const chain = {
+          select() { return chain; },
+          eq() { return chain; },
+          order() { return chain; },
+          limit() { return chain; },
+          in() { return chain; },
+          then(resolve) { return Promise.resolve({ data: fixtures[ctx.table] || [], error: null }).then(resolve); },
+        };
+        return chain;
+      },
+    };
+  }
+
+  it('groups live KRs by O-GOV objective code', async () => {
+    const sb = mockSupabase({
+      objectives: [{ id: 'obj-gov-1', code: 'O-GOV-1' }, { id: 'obj-gov-2', code: 'O-GOV-2' }],
+      key_results: [
+        krRow({ id: 'k1', code: 'KR-GOV-1.1', objective_id: 'obj-gov-1' }),
+        krRow({ id: 'k2', code: 'KR-GOV-2.2', objective_id: 'obj-gov-2' }),
+      ],
+    });
+    const map = await fetchKrByObjective(sb);
+    expect(map.get('O-GOV-1')[0].code).toBe('KR-GOV-1.1');
+    expect(map.get('O-GOV-2')[0].code).toBe('KR-GOV-2.2');
+  });
+
+  it('briefHarness returns KR-anchored candidates (not candidates:[]) when signals + KRs exist', async () => {
+    const sb = mockSupabase({
+      feedback: [{ id: 'f1' }, { id: 'f2' }],
+      retrospectives: [{ id: 'r1' }],
+      v_ai_quality_tuning_recommendations: [{ sd_type: 'bugfix', recommendation: 'INCREASE (+5%)' }],
+      eva_consultant_recommendations: [{ id: 'e1', action_type: 'create_sd', confidence_tier: 'medium' }],
+      objectives: [
+        { id: 'obj-gov-1', code: 'O-GOV-1' },
+        { id: 'obj-gov-2', code: 'O-GOV-2' },
+        { id: 'obj-gov-3', code: 'O-GOV-3' },
+      ],
+      key_results: [
+        krRow({ id: 'k1', code: 'KR-GOV-1.1', objective_id: 'obj-gov-1', status: 'on_track' }),
+        krRow({ id: 'k2', code: 'KR-GOV-2.2', objective_id: 'obj-gov-2', status: 'at_risk' }),
+        krRow({ id: 'k3', code: 'KR-GOV-3.1', objective_id: 'obj-gov-3', status: 'at_risk' }),
+      ],
+    });
+    const r = await briefHarness(sb);
+    expect(r.candidates.length).toBeGreaterThanOrEqual(1);
+    expect(r.candidates.every((c) => /^KR-GOV-/.test(c.objective_kr.kr))).toBe(true);
+  });
+
+  it('briefHarness fails soft to candidates:[] when the KR query errors (never fabricates)', async () => {
+    const sb = {
+      from(table) {
+        const chain = {
+          select() { return chain; }, eq() { return chain; }, order() { return chain; }, limit() { return chain; }, in() { return chain; },
+          then(resolve) {
+            if (table === 'key_results' || table === 'objectives') return Promise.resolve({ data: null, error: { message: 'boom' } }).then(resolve);
+            if (table === 'feedback') return Promise.resolve({ data: [{ id: 'f1' }], error: null }).then(resolve);
+            return Promise.resolve({ data: [], error: null }).then(resolve);
+          },
+        };
+        return chain;
+      },
+    };
+    const r = await briefHarness(sb);
+    expect(r.candidates).toEqual([]);
+  });
+});

--- a/tests/unit/adam/preference-model.test.js
+++ b/tests/unit/adam/preference-model.test.js
@@ -1,0 +1,118 @@
+/**
+ * SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-2) — preference-model.js:
+ * bounded weight map (explicit DOMINANT + decisions WEAK prior), idempotent seed.
+ * Pure tests with an injected store; NO live DB, NO real chairman_preferences write.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  computePreferenceWeights,
+  deriveDecisionsPrior,
+  clamp,
+  CLAMP_LO,
+  CLAMP_HI,
+  seedStandingPreference,
+  STANDING_WORKER_CAPABILITY_DIRECTIVE,
+  WORKER_CAPABILITY_PREF_KEY,
+} from '../../../lib/adam/preference-model.js';
+
+// Injected store stub mimicking ChairmanPreferenceStore.getPreferences/getPreference/setPreference.
+function makeStore({ prefs = new Map(), existing = null } = {}) {
+  return {
+    getPreferences: vi.fn(async () => prefs),
+    getPreference: vi.fn(async () => existing),
+    setPreference: vi.fn(async () => ({ success: true, record: { id: 'new-1' } })),
+  };
+}
+
+describe('clamp (bounded weights)', () => {
+  it('clamps into [CLAMP_LO, CLAMP_HI] and never to 0', () => {
+    expect(clamp(10)).toBe(CLAMP_HI);
+    expect(clamp(0)).toBe(CLAMP_LO);
+    expect(clamp(-5)).toBe(CLAMP_LO);
+    expect(clamp(1.0)).toBe(1.0);
+    expect(clamp(NaN)).toBe(1.0);
+    expect(clamp(undefined)).toBe(1.0);
+  });
+  it('the clamp range can never invert off-track(3x) below on-track(1x): HI/LO <= 3', () => {
+    expect(CLAMP_HI / CLAMP_LO).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('deriveDecisionsPrior (WEAK soft prior)', () => {
+  it('reports consumed = row count and a small capped nudge', () => {
+    const decisions = Array.from({ length: 51 }, (_, i) => ({ id: i, decision: i < 5 ? 'reject' : 'approve' }));
+    const { weights, consumed } = deriveDecisionsPrior(decisions);
+    expect(consumed).toBe(51);
+    // 5 cautious * 0.01 = 0.05 -> conservative class weight 1.05 (well below dominant).
+    expect(weights.conservative).toBeCloseTo(1.05, 5);
+  });
+  it('caps the aggregate nudge so decisions can never dominate', () => {
+    const decisions = Array.from({ length: 100 }, () => ({ decision: 'reject' }));
+    const { weights } = deriveDecisionsPrior(decisions);
+    expect(weights.conservative).toBeLessThanOrEqual(1.1); // maxNudge cap
+  });
+  it('empty -> no weights, consumed 0', () => {
+    expect(deriveDecisionsPrior([])).toEqual({ weights: {}, consumed: 0 });
+  });
+});
+
+describe('computePreferenceWeights (UNION, explicit DOMINANT)', () => {
+  it('unions explicit prefs (dominant) with the weak decisions prior, all bounded', async () => {
+    const prefs = new Map([[WORKER_CAPABILITY_PREF_KEY, { value: { 'worker-capability': 1.25, 'adam-autonomy': 0.8 }, valueType: 'object' }]]);
+    const store = makeStore({ prefs });
+    const decisions = [{ decision: 'reject' }, { decision: 'approve' }];
+    const r = await computePreferenceWeights({ store, decisions });
+    expect(r.weights['worker-capability']).toBe(1.25);
+    expect(r.weights['adam-autonomy']).toBe(0.8);
+    expect(r.weights.conservative).toBeCloseTo(1.01, 5); // weak prior survives (no overlap)
+    expect(r.decisionsConsumed).toBe(2);
+    expect(r.explicitClasses).toContain('worker-capability');
+  });
+
+  it('explicit term DOMINATES (overwrites) an overlapping decisions-prior class', async () => {
+    // Decisions would nudge 'conservative'; an explicit pref for the same class wins.
+    const prefs = new Map([[WORKER_CAPABILITY_PREF_KEY, { value: { conservative: 0.8 }, valueType: 'object' }]]);
+    const store = makeStore({ prefs });
+    const r = await computePreferenceWeights({ store, decisions: [{ decision: 'reject' }] });
+    expect(r.weights.conservative).toBe(0.8); // explicit, not the 1.01 prior
+  });
+
+  it('clamps an out-of-range explicit weight', async () => {
+    const prefs = new Map([[WORKER_CAPABILITY_PREF_KEY, { value: { 'worker-capability': 99, 'adam-autonomy': 0 }, valueType: 'object' }]]);
+    const store = makeStore({ prefs });
+    const r = await computePreferenceWeights({ store, decisions: [] });
+    expect(r.weights['worker-capability']).toBe(CLAMP_HI);
+    expect(r.weights['adam-autonomy']).toBe(CLAMP_LO); // never 0
+  });
+
+  it('fails soft to empty when the store throws', async () => {
+    const store = { getPreferences: vi.fn(async () => { throw new Error('db down'); }) };
+    const r = await computePreferenceWeights({ store, decisions: [] });
+    expect(r.weights).toEqual({});
+  });
+});
+
+describe('seedStandingPreference (idempotent, NOT run live here)', () => {
+  it('writes the standing directive when absent', async () => {
+    const store = makeStore({ existing: null });
+    const r = await seedStandingPreference({ store });
+    expect(r.seeded).toBe(true);
+    expect(store.setPreference).toHaveBeenCalledTimes(1);
+    const arg = store.setPreference.mock.calls[0][0];
+    expect(arg.chairmanId).toBe('ehg_chairman');
+    expect(arg.ventureId).toBeNull();
+    expect(arg.key).toBe(WORKER_CAPABILITY_PREF_KEY);
+  });
+
+  it('skips the write when already present (idempotent)', async () => {
+    const store = makeStore({ existing: { id: 'p1', key: WORKER_CAPABILITY_PREF_KEY } });
+    const r = await seedStandingPreference({ store });
+    expect(r.skipped).toBe(true);
+    expect(store.setPreference).not.toHaveBeenCalled();
+  });
+
+  it('the standing directive expresses worker-capability > adam-autonomy', () => {
+    const v = STANDING_WORKER_CAPABILITY_DIRECTIVE.value;
+    expect(v['worker-capability']).toBeGreaterThan(v['adam-autonomy']);
+  });
+});

--- a/tests/unit/adam/preference-no-op-closed.test.js
+++ b/tests/unit/adam/preference-no-op-closed.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FIX 3) — the chairman directive is
+ * NO LONGER a no-op.
+ *
+ * Proves end-to-end that a REAL briefing candidate (built by summarizeHarness)
+ * receives a non-1.0 weight from the seeded standing directive, via the
+ * candidate-SOURCE-class -> directive-TOPIC-class bridge (candidatePreferenceClass).
+ * Pure + DB-free: candidates are built from injected KR rows; the directive value
+ * is taken from STANDING_WORKER_CAPABILITY_DIRECTIVE (no live seed, no live DB).
+ */
+import { describe, it, expect } from 'vitest';
+import { summarizeHarness } from '../../../lib/adam/briefings/harness.js';
+import {
+  candidatePreferenceClass,
+  STANDING_WORKER_CAPABILITY_DIRECTIVE,
+  CLAMP_HI,
+  CLAMP_LO,
+} from '../../../lib/adam/preference-model.js';
+import { selectAdvisory, statusTierOf } from '../../../lib/adam/rationale-bar.js';
+
+// Live KR rows per O-GOV objective (the shape fetchKrByObjective returns).
+function krByObjective({ g1 = 'on_track', g2 = 'on_track', g3 = 'on_track' } = {}) {
+  return new Map([
+    ['O-GOV-1', [{ id: 'kr-1', code: 'KR-GOV-1', status: g1 }]],
+    ['O-GOV-2', [{ id: 'kr-2', code: 'KR-GOV-2', status: g2 }]],
+    ['O-GOV-3', [{ id: 'kr-3', code: 'KR-GOV-3', status: g3 }]],
+  ]);
+}
+
+// A harness briefing with all three signal classes present.
+function fullBriefing(krMap) {
+  return summarizeHarness({
+    backlog: [{ id: 'b1' }, { id: 'b2' }], // harness-backlog -> O-GOV-1
+    gateRecs: [{ recommendation: 'INCREASE threshold X' }], // gate-tuning -> O-GOV-2
+    evaRecs: [{ action_type: 'create_sd' }], // eva-consultant -> O-GOV-3
+    krByObjective: krMap,
+  });
+}
+
+describe('candidatePreferenceClass bridges real candidates to the directive vocabulary', () => {
+  it('a real gate-tuning (O-GOV-2) candidate maps to worker-capability', () => {
+    const { candidates } = fullBriefing(krByObjective());
+    const gate = candidates.find((c) => c.class === 'gate-tuning');
+    expect(gate).toBeDefined();
+    expect(gate.objective_kr.objective).toBe('O-GOV-2');
+    expect(candidatePreferenceClass(gate)).toBe('worker-capability');
+  });
+
+  it('a real eva-consultant (O-GOV-3) candidate maps to adam-autonomy', () => {
+    const { candidates } = fullBriefing(krByObjective());
+    const eva = candidates.find((c) => c.class === 'eva-consultant');
+    expect(eva).toBeDefined();
+    expect(eva.objective_kr.objective).toBe('O-GOV-3');
+    expect(candidatePreferenceClass(eva)).toBe('adam-autonomy');
+  });
+
+  it('a real harness-backlog (O-GOV-1) candidate is neutral (no topic -> identity)', () => {
+    const { candidates } = fullBriefing(krByObjective());
+    const backlog = candidates.find((c) => c.class === 'harness-backlog');
+    expect(backlog).toBeDefined();
+    expect(candidatePreferenceClass(backlog)).toBeNull();
+  });
+});
+
+describe('FIX 3: the seeded directive is no longer a no-op on a REAL candidate', () => {
+  it('at least one real briefing candidate receives a non-1.0 weight from the seeded directive', () => {
+    // The seeded directive value keyed on the TOPIC vocabulary.
+    const prefWeights = STANDING_WORKER_CAPABILITY_DIRECTIVE.value;
+    expect(prefWeights['worker-capability']).toBe(CLAMP_HI);
+    expect(prefWeights['adam-autonomy']).toBe(CLAMP_LO);
+
+    const { candidates } = fullBriefing(krByObjective());
+    // Resolve each real candidate's effective weight the way selectAdvisory does.
+    const applied = candidates.map((c) => {
+      const topic = candidatePreferenceClass(c);
+      const w = topic && prefWeights[topic] != null ? prefWeights[topic] : 1.0;
+      return { class: c.class, topic, weight: w };
+    });
+    const nonIdentity = applied.filter((a) => a.weight !== 1.0);
+    // PROOF the directive now bites: gate-tuning (HI) and eva-consultant (LO) both differ from 1.0.
+    expect(nonIdentity.length).toBeGreaterThanOrEqual(1);
+    const gate = applied.find((a) => a.class === 'gate-tuning');
+    const eva = applied.find((a) => a.class === 'eva-consultant');
+    expect(gate.weight).toBe(CLAMP_HI); // boosted
+    expect(eva.weight).toBe(CLAMP_LO); // demoted
+  });
+
+  it('the now-live directive STILL cannot invert off-track signal (FIX 1 + FIX 3 together)', () => {
+    // gate-tuning is boosted (worker-capability=HI) but anchored to an ON-TRACK KR;
+    // eva-consultant is demoted (adam-autonomy=LO) but anchored to an OFF-TRACK KR.
+    // The off-track eva-consultant MUST still surface despite being demoted.
+    const krMap = krByObjective({ g2: 'on_track', g3: 'off_track' });
+    const { candidates } = fullBriefing(krMap);
+    const eva = candidates.find((c) => c.class === 'eva-consultant');
+    const gate = candidates.find((c) => c.class === 'gate-tuning');
+    expect(statusTierOf(eva)).toBe(5); // off_track
+    expect(statusTierOf(gate)).toBe(2); // on_track
+
+    const r = selectAdvisory(candidates, {
+      openSdKeys: new Set(),
+      prefWeights: STANDING_WORKER_CAPABILITY_DIRECTIVE.value,
+    });
+    // Even though eva-consultant is demoted (LO) and gate-tuning is boosted (HI),
+    // the off-track eva-consultant wins on statusTier dominance.
+    expect(r.surfaced.class).toBe('eva-consultant');
+  });
+});

--- a/tests/unit/adam/rationale-bar-perturbation.test.js
+++ b/tests/unit/adam/rationale-bar-perturbation.test.js
@@ -1,0 +1,178 @@
+/**
+ * SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001 (FR-2/FR-3) — selectAdvisory
+ * preference weighting + Q2 wave-alignment, with the cardinal-safety guarantees:
+ *   - flat all-1.0 weight map == OKR-only baseline (byte-identical selection)
+ *   - bounded clamp never zeroes / never inverts off-track below on-track
+ *   - perturbation trace {base_rank, final_rank, moved_by_weight, class, weight}
+ *   - Q2 term self-gates to no-op on 0 waves
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  selectAdvisory,
+  evaluateCandidate,
+  waveAlignmentTerm,
+  LEO_ROADMAP_ID,
+} from '../../../lib/adam/rationale-bar.js';
+import { CLAMP_LO, CLAMP_HI } from '../../../lib/adam/preference-model.js';
+
+const base = (over = {}) => ({
+  scope_key: 'harness',
+  class: 'default',
+  opportunity: 'op', evidence: 'ev', rationale: 'ra', risk: 'ri', counterfactual: 'cf',
+  objective_kr: { objective: 'O-GOV', kr: 'KR', kr_status: 'on_track', off_track_delta: null },
+  contribution_type: 'direct',
+  confidence: 0.5,
+  ...over,
+});
+
+// On-track direct = 1.5*1.0*10 = 15 ; off-track direct = 1.5*3.0*10 = 45.
+const onTrack = (over) => base({ class: 'on', dedup_key: 'on', objective_kr: { objective: 'O', kr: 'KR-on', kr_status: 'on_track' }, ...over });
+const offTrack = (over) => base({ class: 'off', dedup_key: 'off', objective_kr: { objective: 'O', kr: 'KR-off', kr_status: 'off_track' }, ...over });
+
+describe('flat all-1.0 weight map == OKR-only baseline (byte-identical)', () => {
+  it('selection + order match the no-opts baseline', () => {
+    const cands = [onTrack(), offTrack({ confidence: 0.9 }), base({ class: 'mid', dedup_key: 'mid', objective_kr: { objective: 'O', kr: 'KR-mid', kr_status: 'at_risk' } })];
+    const baseline = selectAdvisory(cands, { openSdKeys: new Set() });
+    const flat = selectAdvisory(cands, { openSdKeys: new Set(), prefWeights: { on: 1.0, off: 1.0, mid: 1.0, default: 1.0 } });
+    expect(flat.surfaced.dedup_key).toBe(baseline.surfaced.dedup_key);
+    expect(flat.surfaced.okr_score).toBe(baseline.surfaced.okr_score);
+    expect(flat.trace).toEqual([]); // no perturbation
+    expect(baseline.trace).toEqual([]);
+  });
+
+  it('an EMPTY prefWeights map is also byte-identical (missing class -> identity 1.0)', () => {
+    const cands = [onTrack(), offTrack()];
+    const baseline = selectAdvisory(cands, { openSdKeys: new Set() });
+    const empty = selectAdvisory(cands, { openSdKeys: new Set(), prefWeights: {} });
+    expect(empty.surfaced.dedup_key).toBe(baseline.surfaced.dedup_key);
+    expect(empty.trace).toEqual([]);
+  });
+});
+
+describe('demoting weight map re-ranks WITHIN a status tier + emits a trace', () => {
+  it('a preferred lower-raw candidate overtakes a higher-raw one in the SAME status tier', () => {
+    // FIX 1: preference weighting may only reorder WITHIN a status tier. Use two
+    // SAME-tier (both on_track, tier 2) candidates that differ on raw OKR score.
+    // 'pref' = supporting on_track = 0.5*1.0*10 = 5 ; 'other' = direct on_track = 15.
+    const pref = base({ class: 'pref', dedup_key: 'pref', contribution_type: 'supporting', objective_kr: { objective: 'O', kr: 'KR-p', kr_status: 'on_track' }, confidence: 0.5 });
+    const other = base({ class: 'other', dedup_key: 'other', contribution_type: 'direct', objective_kr: { objective: 'O', kr: 'KR-o', kr_status: 'on_track' }, confidence: 0.5 });
+    const baseline = selectAdvisory([pref, other], { openSdKeys: new Set() });
+    expect(baseline.surfaced.dedup_key).toBe('other'); // raw: 15 > 5
+
+    // Use a same-tier same-raw pair (both enabling on_track = 10) where 'other'
+    // ranks first in the BASELINE via its higher confidence, then the intra-tier
+    // weight flips 'pref' to the top -> a genuine rank perturbation is traced.
+    const prefClose = base({ class: 'pref', dedup_key: 'pref', contribution_type: 'enabling', objective_kr: { objective: 'O', kr: 'KR-p', kr_status: 'on_track' }, confidence: 0.5 }); // raw 10
+    const otherClose = base({ class: 'other', dedup_key: 'other', contribution_type: 'enabling', objective_kr: { objective: 'O', kr: 'KR-o', kr_status: 'on_track' }, confidence: 0.9 }); // raw 10, higher conf -> baseline rank 0
+    const baselineClose = selectAdvisory([prefClose, otherClose], { openSdKeys: new Set() });
+    expect(baselineClose.surfaced.dedup_key).toBe('other'); // tie on raw -> confidence breaks for 'other'
+
+    const weighted = selectAdvisory([prefClose, otherClose], { openSdKeys: new Set(), prefWeights: { pref: CLAMP_HI, other: CLAMP_LO } });
+    // 10*1.25=12.5 vs 10*0.8=8 -> pref wins (intra-tier nudge flips the baseline order).
+    expect(weighted.surfaced.dedup_key).toBe('pref');
+    const moved = weighted.trace.find((t) => t.final_rank === 0);
+    expect(moved).toBeDefined();
+    expect(moved.base_rank).not.toBe(moved.final_rank);
+    expect(moved.moved_by_weight).toBe(true);
+    expect(moved.class).toBe('pref');
+    expect(typeof moved.weight).toBe('number');
+  });
+});
+
+describe('bounded clamp: never zeroes, never inverts off-track below on-track', () => {
+  it('worst-case (off-track LO vs on-track HI) keeps off-track ahead within same contribution class', () => {
+    const on = onTrack({ confidence: 0.5 });   // 15
+    const off = offTrack({ confidence: 0.5 });  // 45
+    // Attempt to demote off-track and boost on-track to the clamp extremes.
+    const r = selectAdvisory([on, off], { openSdKeys: new Set(), prefWeights: { on: 999, off: 0 } });
+    // clamped: off 45*0.8=36 ; on 15*1.25=18.75 -> off still wins (no inversion).
+    expect(r.surfaced.dedup_key).toBe('off');
+  });
+
+  it('a 0/huge weight never zeroes a candidate (clamp floor/ceiling applied)', () => {
+    const a = base({ class: 'a', dedup_key: 'a', objective_kr: { objective: 'O', kr: 'KR-a', kr_status: 'on_track' } });
+    const r = selectAdvisory([a], { openSdKeys: new Set(), prefWeights: { a: 0 } });
+    expect(r.surfaced).not.toBeNull();
+    expect(r.surfaced.effective_score).toBeGreaterThan(0); // 15 * 0.8 = 12 > 0
+  });
+});
+
+describe('FR-3 Q2 wave-alignment self-gating', () => {
+  it('waveAlignmentTerm is a 1.0 no-op when there are 0 waves (or no alignment)', () => {
+    expect(waveAlignmentTerm(base({ roadmap_wave_ref: 'O-GOV-1' }), { waves: [] })).toEqual({ active: false, multiplier: 1.0, aligned: null });
+    expect(waveAlignmentTerm(base(), undefined)).toEqual({ active: false, multiplier: 1.0, aligned: null });
+  });
+
+  it('selection equals baseline when the LEO Roadmap has 0 waves (no false-fire)', () => {
+    const cands = [onTrack(), offTrack()];
+    const baseline = selectAdvisory(cands, { openSdKeys: new Set() });
+    const withEmptyWaves = selectAdvisory(cands, { openSdKeys: new Set(), waveAlignment: { waves: [], overall_alignment_pct: 0 } });
+    expect(withEmptyWaves.surfaced.dedup_key).toBe(baseline.surfaced.dedup_key);
+    expect(withEmptyWaves.trace).toEqual([]);
+  });
+
+  it('an EVA-Intake-style alignment with 0 waves on the LEO roadmap never drives the term', () => {
+    // The caller keys calculateAlignment on LEO_ROADMAP_ID; if that roadmap has 0
+    // waves the injected alignment is {waves:[]} regardless of EVA-Intake having 462.
+    expect(LEO_ROADMAP_ID).toBe('3aa2f3e2-75fa-4fc8-a17e-44d553b86674');
+    const r = waveAlignmentTerm(base({ roadmap_wave_ref: 'anything' }), { waves: [] });
+    expect(r.active).toBe(false);
+  });
+
+  it('when waves EXIST: a NON-URGENT (on_track) Q1-pass/Q2-unaligned candidate routes to backlog', () => {
+    const waveAlignment = { waves: [{ wave_id: 'w1', okr_ids: ['O-GOV-1'] }], overall_alignment_pct: 100 };
+    const aligned = base({ class: 'al', dedup_key: 'al', roadmap_wave_ref: 'O-GOV-1', objective_kr: { objective: 'O', kr: 'KR-al', kr_status: 'on_track' } });
+    // A NON-URGENT (on_track) unaligned candidate IS routed to backlog (does not clear).
+    const unaligned = base({ class: 'un', dedup_key: 'un', roadmap_wave_ref: 'O-OTHER', objective_kr: { objective: 'O', kr: 'KR-un', kr_status: 'on_track' } });
+
+    const eUn = evaluateCandidate(unaligned, { waveAlignment });
+    expect(eUn.clears).toBe(false);
+    expect(eUn.waveUnaligned).toBe(true);
+    expect(eUn.reasons.join(' ')).toMatch(/Q2 wave-unaligned/);
+
+    // The aligned candidate clears and surfaces.
+    const r = selectAdvisory([unaligned, aligned], { openSdKeys: new Set(), waveAlignment });
+    expect(r.surfaced.dedup_key).toBe('al');
+  });
+
+  it('FIX 2: an OFF-TRACK wave-unaligned candidate is NEVER excluded (genuine signal clears the wave gate)', () => {
+    const waveAlignment = { waves: [{ wave_id: 'w1', okr_ids: ['O-GOV-1'] }], overall_alignment_pct: 100 };
+    // Off-track AND wave-unaligned: must still clear (urgent objective signal wins).
+    const offUnaligned = base({ class: 'off', dedup_key: 'off', roadmap_wave_ref: 'O-OTHER', objective_kr: { objective: 'O', kr: 'KR-off', kr_status: 'off_track' } });
+    const eOff = evaluateCandidate(offUnaligned, { waveAlignment });
+    expect(eOff.clears).toBe(true);
+    expect(eOff.waveUnaligned).toBe(false);
+    expect(eOff.reasons).toEqual([]);
+
+    // at_risk is likewise urgent -> also clears despite being wave-unaligned.
+    const atRiskUnaligned = base({ class: 'ar', dedup_key: 'ar', roadmap_wave_ref: 'O-OTHER', objective_kr: { objective: 'O', kr: 'KR-ar', kr_status: 'at_risk' } });
+    expect(evaluateCandidate(atRiskUnaligned, { waveAlignment }).clears).toBe(true);
+
+    // And when an off-track unaligned competes with an on-track aligned, off-track surfaces.
+    const onAligned = base({ class: 'on', dedup_key: 'on', roadmap_wave_ref: 'O-GOV-1', objective_kr: { objective: 'O', kr: 'KR-on', kr_status: 'on_track' } });
+    const r = selectAdvisory([onAligned, offUnaligned], { openSdKeys: new Set(), waveAlignment });
+    expect(r.surfaced.dedup_key).toBe('off');
+  });
+});
+
+describe('FIX 1: CROSS-CLASS NO-INVERSION (statusTier dominates preference weight)', () => {
+  it('an off-track/supporting candidate STILL surfaces first vs on-track/direct even when weights favor on-track', () => {
+    // The exact worst case from the SD: raw tie at 15.
+    //   off-track/supporting = 0.5*3.0*10 = 15 (tier 5, off_track)
+    //   on-track/direct      = 1.5*1.0*10 = 15 (tier 2, on_track)
+    const offSupporting = base({
+      class: 'worker-capability', dedup_key: 'off-sup', contribution_type: 'supporting',
+      objective_kr: { objective: 'O', kr: 'KR-off', kr_status: 'off_track' }, confidence: 0.5,
+    });
+    const onDirect = base({
+      class: 'on-direct-cls', dedup_key: 'on-dir', contribution_type: 'direct',
+      objective_kr: { objective: 'O', kr: 'KR-on', kr_status: 'on_track' }, confidence: 0.9,
+    });
+    // Demote the off-track one, boost the on-track one to the clamp extremes.
+    const prefWeights = { 'worker-capability': CLAMP_LO, 'on-direct-cls': CLAMP_HI };
+    const r = selectAdvisory([onDirect, offSupporting], { openSdKeys: new Set(), prefWeights });
+    // Under the OLD score-dominant sort: off 15*0.8=12 < on 15*1.25=18.75 -> INVERSION.
+    // Under the statusTier-dominant sort: off_track (tier 5) > on_track (tier 2) -> off wins.
+    expect(r.surfaced.dedup_key).toBe('off-sup');
+  });
+});


### PR DESCRIPTION
Adam capability #5 — wires chairman-preference + roadmap-Q2 anchoring into Adam's sourcing/prioritization through ONE seam (rationale-bar.js selectAdvisory @ adam-opportunity-scan.cjs:208), behind ADAM_GOVERNANCE_HEARTBEAT_V1 (flag OFF -> SUPPRESSED_FLAG_OFF, observably inert).

## Cardinal invariant: a preference/Q2 weight NEVER overrides genuine objective (KR-status) signal
Enforced STRUCTURALLY: KR-status TIER is the dominant sort key (off_track=5 > at_risk=4 > on_track=2); the bounded preference weight only reorders WITHIN a status tier. An off-track candidate can never be outranked OR excluded by an on-track one regardless of class/weight/wave.

## FRs
- **FR-1** briefHarness emits scored candidates anchored to REAL key_results KRs (worst-status-first; off_track_delta from real fields, never invented; unmappable signals excluded).
- **FR-2** new pure lib/adam/preference-model.js computePreferenceWeights() = explicit chairman_preferences (dominant, via shipped chairman-preference-store) UNION chairman_decisions (weak prior); bounded clamp [0.8,1.25]; rank-perturbation trace; idempotent seed of 'worker-capability > adam-autonomy' (NOT run live).
- **FR-3** okr-wave-linker Q2 term keyed STRICTLY on LEO Roadmap 3aa2f3e2 (0 waves -> self-gating no-op; cannot false-fire on EVA-Intake ed12bf74).
- **FR-4** exec-summary 'chairman_decisions consumed: N of <total>' counter (fail-soft).

## Review
Adversarial review caught TWO HIGH bugs the first-pass 113 green tests MISSED — both the exact failure the SD exists to prevent (a preference weight silently overriding off-track objective signal): cross-class multiplier inversion + Q2 wave-gate exclusion of off-track candidates; plus a MED dead-no-op (disjoint preference vs candidate vocab). All fixed via the statusTier-dominant sort + off-track wave-gate bypass + a real candidate->topic class bridge. flat-1.0/flag-OFF byte-identical to the (statusTier-first) baseline. 120 unit tests pass; no fabricated KR anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)