### PR TITLE
feat(SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001): YouTube strategy-video extraction pipeline (native+transcript, fail-safe disposal)

### DIFF
--- a/lib/integrations/youtube/strategy-extract-core.js
+++ b/lib/integrations/youtube/strategy-extract-core.js
@@ -199,7 +199,14 @@ export async function runExtraction(candidates, deps, options = {}) {
       method = 'failed_other';
     }
     const category = summary ? categorizeFramework(summary, c) : null;
-    const dedup = summary ? dedupAgainstSDs(c.title, sdList) : null;
+    // Dedup on the title when it is substantive; episodic/opaque titles
+    // ("Episode 47", "my weekly thoughts") tokenize to ~nothing and would always
+    // read 'novel', so augment with a short summary slice in that case (a full
+    // summary would dilute the overlap ratio, so we clip it).
+    const dedupText = c.title && tokenize(c.title).length >= 2
+      ? c.title
+      : `${c.title || ''} ${(summary || '').slice(0, 200)}`;
+    const dedup = summary ? dedupAgainstSDs(dedupText, sdList) : null;
     const entry = buildLedgerEntry({ videoId: c.youtube_video_id, title: c.title, method, summary, category, dedup });
     entry._row = c;
     entry._summary = summary;
@@ -291,11 +298,14 @@ export async function disposeEntries(entries, deps = {}) {
 
   for (const t of targets) {
     try {
+      // 1. Add to Processed — the durable "captured" step.
       await youtube.playlistItems.insert({
         part: ['snippet'],
         requestBody: { snippet: { playlistId: out.playlist_id, resourceId: { kind: 'youtube#video', videoId: t.video_id } } },
       });
-      await youtube.playlistItems.delete({ id: t.playlist_item_id });
+      // 2. Mark the intake row processed IMMEDIATELY so a future run never
+      //    re-fetches (status='pending') and re-inserts a duplicate, even if the
+      //    source-playlist delete below fails. Idempotency over tidiness.
       if (supabase) {
         await supabase
           .from('eva_youtube_intake')
@@ -305,8 +315,22 @@ export async function disposeEntries(entries, deps = {}) {
       out.moved++;
       out.disposed_ids.push(t.video_id);
     } catch (err) {
+      // insert (or the mark) failed BEFORE the video was captured -> not disposed,
+      // stays in For-Processing for retry. Fail-safe.
       out.errors.push({ video_id: t.video_id, error: err && err.message ? err.message : String(err) });
       if (verbose) console.error(`  dispose failed ${t.video_id}: ${err.message}`);
+      continue;
+    }
+    // 3. Best-effort source removal AFTER the video is safely in Processed +
+    //    marked. A delete failure here is a soft warning (video lives in both
+    //    playlists until a reconciler trims it) — NOT a disposal failure, and it
+    //    won't re-insert because the intake row is already processed.
+    try {
+      await youtube.playlistItems.delete({ id: t.playlist_item_id });
+    } catch (delErr) {
+      out.delete_warnings = out.delete_warnings || [];
+      out.delete_warnings.push({ video_id: t.video_id, error: delErr && delErr.message ? delErr.message : String(delErr) });
+      if (verbose) console.error(`  source delete failed (kept in Processed) ${t.video_id}: ${delErr.message}`);
     }
   }
   return out;

--- a/lib/integrations/youtube/strategy-extract-core.js
+++ b/lib/integrations/youtube/strategy-extract-core.js
@@ -141,6 +141,104 @@ export function isDisposable(entry) {
   return !!entry && entry.analysis_status === 'ok';
 }
 
+/**
+ * Summarize a set of ledger entries into counts by status / method / category /
+ * dedup / recommendation. Pure.
+ * @param {object[]} entries
+ * @returns {object}
+ */
+export function summarizeEntries(entries = []) {
+  const bump = (o, k) => { if (k != null) o[k] = (o[k] || 0) + 1; };
+  const out = { total: entries.length, by_status: {}, by_method: {}, by_category: {}, by_dedup: {}, by_recommendation: {} };
+  for (const e of entries) {
+    bump(out.by_status, e.analysis_status);
+    bump(out.by_method, e.method);
+    bump(out.by_category, e.category);
+    bump(out.by_dedup, e.dedup_status);
+    bump(out.by_recommendation, e.recommendation);
+  }
+  return out;
+}
+
+/**
+ * Orchestrate extraction over candidate intake rows. Pure-ish: every external
+ * effect (video analysis, scoring) is INJECTED via deps, so the whole loop is
+ * unit-testable with stubs. The CLI (scripts/eva/youtube-strategy-extract.js)
+ * wires the real implementations + the I/O (Supabase, ledger file, disposal).
+ *
+ * For each candidate: analyze (native<->transcript via deps.analyzeWithFallback),
+ * categorize, dedup vs deps.sdList, then batch-score the OK entries via deps.score
+ * and merge composite/recommendation back in.
+ *
+ * Each returned entry carries two non-persisted fields for the CLI: `_row` (the
+ * source intake row) and `_summary` (the extracted text). The CLI strips
+ * `_`-prefixed keys before writing the ledger.
+ *
+ * @param {Array<object>} candidates - eva_youtube_intake rows
+ * @param {{analyzeWithFallback:Function, score?:Function, sdList?:Array}} deps
+ * @param {{verbose?:boolean}} [options]
+ * @returns {Promise<{entries: object[], summary: object}>}
+ */
+export async function runExtraction(candidates, deps, options = {}) {
+  const { analyzeWithFallback, score, sdList = [] } = deps || {};
+  if (typeof analyzeWithFallback !== 'function') throw new Error('runExtraction: deps.analyzeWithFallback is required');
+  const list = Array.isArray(candidates) ? candidates : [];
+  const entries = [];
+
+  for (const c of list) {
+    const metadata = { title: c.title, channelName: c.channel_name, durationSeconds: c.duration_seconds };
+    const chairmanIntent = c.chairman_notes || c.chairman_intent || '';
+    let summary = null;
+    let method = 'failed_other';
+    try {
+      const r = await analyzeWithFallback(c.youtube_video_id, { metadata, chairmanIntent, verbose: options.verbose });
+      summary = r && r.summary;
+      method = (r && r.method) || 'failed_other';
+    } catch {
+      summary = null;
+      method = 'failed_other';
+    }
+    const category = summary ? categorizeFramework(summary, c) : null;
+    const dedup = summary ? dedupAgainstSDs(c.title, sdList) : null;
+    const entry = buildLedgerEntry({ videoId: c.youtube_video_id, title: c.title, method, summary, category, dedup });
+    entry._row = c;
+    entry._summary = summary;
+    entries.push(entry);
+  }
+
+  // Batch-score the successfully-extracted entries (one call, persona-batched).
+  const okEntries = entries.filter((e) => e.analysis_status === 'ok');
+  if (okEntries.length > 0 && typeof score === 'function') {
+    try {
+      const items = okEntries.map((e) => ({
+        title: e.title,
+        description: e._summary || '',
+        target_application: e._row.target_application || 'ehg_engineer',
+        chairman_intent: e._row.chairman_intent || 'insight',
+        source_type: 'youtube',
+      }));
+      const scored = await score(items);
+      (scored && scored.item_scores ? scored.item_scores : []).forEach((s) => {
+        const e = okEntries[s.item_index - 1];
+        if (e) { e.composite_score = s.composite; e.recommendation = s.recommendation; }
+      });
+    } catch { /* fail-open: entries keep null score */ }
+  }
+
+  return { entries, summary: summarizeEntries(entries) };
+}
+
+/**
+ * Strip the non-persisted `_`-prefixed working fields from a ledger entry.
+ * @param {object} entry
+ * @returns {object}
+ */
+export function cleanLedgerEntry(entry) {
+  const out = {};
+  for (const [k, v] of Object.entries(entry || {})) if (!k.startsWith('_')) out[k] = v;
+  return out;
+}
+
 export default {
   CATEGORIES,
   tokenize,
@@ -149,4 +247,7 @@ export default {
   buildLedgerEntry,
   isEnhancementWorthy,
   isDisposable,
+  summarizeEntries,
+  runExtraction,
+  cleanLedgerEntry,
 };

--- a/lib/integrations/youtube/strategy-extract-core.js
+++ b/lib/integrations/youtube/strategy-extract-core.js
@@ -229,6 +229,90 @@ export async function runExtraction(candidates, deps, options = {}) {
 }
 
 /**
+ * FR-5: select the entries eligible for disposal (move For-Processing ->
+ * Processed). Only successfully-extracted (isDisposable) videos that carry a
+ * youtube_playlist_item_id (required to remove them from the source playlist)
+ * are eligible — failures are KEPT for retry (EVA-straggler discipline). Pure.
+ * @param {object[]} entries - runExtraction entries (carry `_row`)
+ * @returns {Array<{video_id:string, intake_id:any, playlist_item_id:string, title:string}>}
+ */
+export function selectDisposable(entries = []) {
+  return entries
+    .filter((e) => isDisposable(e) && e && e._row && e._row.youtube_playlist_item_id)
+    .map((e) => ({
+      video_id: e.video_id,
+      intake_id: e._row.id,
+      playlist_item_id: e._row.youtube_playlist_item_id,
+      title: e.title,
+    }));
+}
+
+/**
+ * Find-or-create the "Processed" playlist (mirrors post-processor.js). Injectable
+ * `youtube` (googleapis youtube v3 client) for testability.
+ * @param {object} youtube
+ * @returns {Promise<string>} playlist id
+ */
+export async function ensureProcessedPlaylist(youtube) {
+  let pageToken = null;
+  do {
+    const resp = await youtube.playlists.list({ part: ['snippet'], mine: true, maxResults: 50, pageToken });
+    const found = resp.data.items?.find((p) => p.snippet && p.snippet.title === 'Processed');
+    if (found) return found.id;
+    pageToken = resp.data.nextPageToken;
+  } while (pageToken);
+  const created = await youtube.playlists.insert({
+    part: ['snippet', 'status'],
+    requestBody: { snippet: { title: 'Processed', description: 'EVA: Processed idea videos' }, status: { privacyStatus: 'private' } },
+  });
+  return created.data.id;
+}
+
+/**
+ * FR-5: dispose ONLY the successfully-extracted videos — move each from
+ * For-Processing to Processed and mark its intake row processed. Fail-SAFE: a
+ * failed/failed_long video is never disposed; a per-video error is recorded and
+ * does NOT abort the batch. Injectable `youtube` + `supabase` for testability;
+ * `nowIso` lets the caller stamp time deterministically.
+ *
+ * @param {object[]} entries
+ * @param {{youtube:object, supabase?:object, verbose?:boolean, nowIso?:string}} deps
+ * @returns {Promise<{moved:number, errors:Array, playlist_id:string|null, disposed_ids:string[]}>}
+ */
+export async function disposeEntries(entries, deps = {}) {
+  const { youtube, supabase, verbose, nowIso } = deps;
+  const out = { moved: 0, errors: [], playlist_id: null, disposed_ids: [] };
+  const targets = selectDisposable(entries);
+  if (targets.length === 0) return out;
+  if (!youtube) throw new Error('disposeEntries: deps.youtube is required');
+
+  out.playlist_id = await ensureProcessedPlaylist(youtube);
+  const stamp = nowIso || new Date().toISOString();
+
+  for (const t of targets) {
+    try {
+      await youtube.playlistItems.insert({
+        part: ['snippet'],
+        requestBody: { snippet: { playlistId: out.playlist_id, resourceId: { kind: 'youtube#video', videoId: t.video_id } } },
+      });
+      await youtube.playlistItems.delete({ id: t.playlist_item_id });
+      if (supabase) {
+        await supabase
+          .from('eva_youtube_intake')
+          .update({ status: 'processed', processed_at: stamp, destination_playlist_id: out.playlist_id })
+          .eq('id', t.intake_id);
+      }
+      out.moved++;
+      out.disposed_ids.push(t.video_id);
+    } catch (err) {
+      out.errors.push({ video_id: t.video_id, error: err && err.message ? err.message : String(err) });
+      if (verbose) console.error(`  dispose failed ${t.video_id}: ${err.message}`);
+    }
+  }
+  return out;
+}
+
+/**
  * Strip the non-persisted `_`-prefixed working fields from a ledger entry.
  * @param {object} entry
  * @returns {object}
@@ -250,4 +334,7 @@ export default {
   summarizeEntries,
   runExtraction,
   cleanLedgerEntry,
+  selectDisposable,
+  ensureProcessedPlaylist,
+  disposeEntries,
 };

--- a/lib/integrations/youtube/strategy-extract-core.js
+++ b/lib/integrations/youtube/strategy-extract-core.js
@@ -1,0 +1,152 @@
+/**
+ * Pure helpers for the YouTube strategy-extraction orchestrator (FR-3 of
+ * SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001).
+ *
+ * No I/O lives here — categorization, SD-dedup, and ledger-entry shaping are
+ * pure functions so they are unit-testable in isolation. The I/O wiring
+ * (Supabase reads of eva_youtube_intake, refine-score.js scoring, transcript
+ * fallback, ledger file persistence, disposal) lives in
+ * scripts/eva/youtube-strategy-extract.js.
+ */
+
+/** The Todoist-B1-review framework taxonomy. 'reference' is the safe default. */
+export const CATEGORIES = Object.freeze(['enhancement', 'build', 'research', 'reference']);
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'how', 'why',
+  'what', 'your', 'you', 'is', 'are', 'this', 'that', 'from', 'by', 'at', 'as', 'it',
+  'video', 'youtube', 'part', 'ep', 'episode',
+]);
+
+/**
+ * Tokenize a title/summary into meaningful lowercase tokens (>=3 chars, no stopwords).
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function tokenize(text) {
+  if (!text || typeof text !== 'string') return [];
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+/**
+ * Categorize an extracted framework into enhancement|build|research|reference,
+ * mirroring the Todoist B1 review taxonomy. Keyword heuristic over the summary
+ * plus intake metadata; defaults to 'reference' (the safe non-actionable bucket).
+ *
+ * @param {string} summary - the extracted framework summary
+ * @param {Object} [meta] - {chairman_notes, business_function, chairman_intent}
+ * @returns {'enhancement'|'build'|'research'|'reference'}
+ */
+export function categorizeFramework(summary, meta = {}) {
+  const text = `${summary || ''} ${meta.chairman_notes || ''} ${meta.business_function || ''} ${meta.chairman_intent || ''}`.toLowerCase();
+  if (/\b(infrastructure|infra|pipeline|automation|tooling|workflow|process improvement|gate|guard|orchestrat|ci\/cd|observability)\b/.test(text)) return 'enhancement';
+  if (/\b(build|implement|feature|product|launch|mvp|ship|prototype|deploy)\b/.test(text)) return 'build';
+  if (/\b(research|explore|investigate|study|experiment|hypothesis|benchmark|analy[sz]e)\b/.test(text)) return 'research';
+  return 'reference';
+}
+
+/**
+ * Dedup an extracted framework against existing SD titles by token overlap.
+ * Returns { status:'novel'|'dup-of-SD', matchedSd, score } where score is the
+ * best overlap ratio (fraction of the framework's tokens present in an SD title).
+ *
+ * Pure: the caller supplies the SD list ({ sd_key, title }).
+ *
+ * @param {string} frameworkTitle
+ * @param {Array<{sd_key:string,title:string}>} sdList
+ * @param {number} [threshold=0.5]
+ * @returns {{status:'novel'|'dup-of-SD', matchedSd:string|null, score:number}}
+ */
+export function dedupAgainstSDs(frameworkTitle, sdList = [], threshold = 0.5) {
+  const fwTokens = tokenize(frameworkTitle);
+  if (fwTokens.length === 0 || !Array.isArray(sdList) || sdList.length === 0) {
+    return { status: 'novel', matchedSd: null, score: 0 };
+  }
+  const fwSet = new Set(fwTokens);
+  let best = { matchedSd: null, score: 0 };
+  for (const sd of sdList) {
+    if (!sd || !sd.title) continue;
+    const sdSet = new Set(tokenize(sd.title));
+    if (sdSet.size === 0) continue;
+    let overlap = 0;
+    for (const t of fwSet) if (sdSet.has(t)) overlap++;
+    const ratio = overlap / fwSet.size;
+    if (ratio > best.score) best = { matchedSd: sd.sd_key, score: ratio };
+  }
+  return best.score >= threshold
+    ? { status: 'dup-of-SD', matchedSd: best.matchedSd, score: best.score }
+    : { status: 'novel', matchedSd: null, score: best.score };
+}
+
+/**
+ * Derive the per-video ledger entry (extraction metadata). Pure — the caller
+ * stamps updated_at and persists. analysis_status is 'ok' when a summary was
+ * produced, else the failure method (failed_long | failed_other).
+ *
+ * @param {Object} p
+ * @param {string} p.videoId
+ * @param {string} p.title
+ * @param {string} p.method - native|transcript_fallback|failed_long|failed_other
+ * @param {string|null} p.summary
+ * @param {string} [p.category]
+ * @param {{status:string,matchedSd:string|null}} [p.dedup]
+ * @param {{composite:number,recommendation:string}|null} [p.score]
+ * @returns {object}
+ */
+export function buildLedgerEntry({ videoId, title, method, summary, category, dedup, score }) {
+  const ok = Boolean(summary);
+  return {
+    video_id: videoId,
+    title: title || '',
+    analysis_status: ok ? 'ok' : (method === 'failed_long' ? 'failed_long' : 'failed_other'),
+    method: method || (ok ? 'native' : 'failed_other'),
+    composite_score: score && typeof score.composite === 'number' ? score.composite : null,
+    recommendation: score && score.recommendation ? score.recommendation : null,
+    category: ok ? (category || 'reference') : null,
+    dedup_status: ok && dedup ? dedup.status : null,
+    matched_sd: ok && dedup ? dedup.matchedSd : null,
+    disposed: false,
+  };
+}
+
+/**
+ * Decide whether an extracted framework should be flagged for chairman/coordinator
+ * routing (enhancement-worthy): novel, category=enhancement, composite>=70.
+ * Pure predicate over a ledger entry.
+ * @param {object} entry - a buildLedgerEntry result
+ * @returns {boolean}
+ */
+export function isEnhancementWorthy(entry) {
+  return (
+    !!entry &&
+    entry.analysis_status === 'ok' &&
+    entry.dedup_status === 'novel' &&
+    entry.category === 'enhancement' &&
+    typeof entry.composite_score === 'number' &&
+    entry.composite_score >= 70
+  );
+}
+
+/**
+ * Decide whether a video is eligible for disposal (move For-Processing ->
+ * Processed). Only successfully-extracted videos are eligible; failures are kept
+ * in For-Processing for retry (EVA-straggler discipline). Pure predicate.
+ * @param {object} entry
+ * @returns {boolean}
+ */
+export function isDisposable(entry) {
+  return !!entry && entry.analysis_status === 'ok';
+}
+
+export default {
+  CATEGORIES,
+  tokenize,
+  categorizeFramework,
+  dedupAgainstSDs,
+  buildLedgerEntry,
+  isEnhancementWorthy,
+  isDisposable,
+};

--- a/lib/integrations/youtube/transcript-fallback.js
+++ b/lib/integrations/youtube/transcript-fallback.js
@@ -22,14 +22,23 @@
 
 import { analyzeVideoContent } from './video-metadata.js';
 
+// Public WEB innertube client + its public API key. The WEB client returns a
+// well-formed 200 (the ANDROID client now 400s "Precondition check failed"
+// without a signed request). NOTE (verified 2026-06-15): from a datacenter /
+// server IP without YouTube consent cookies, the player response is gated
+// (playabilityStatus=UNPLAYABLE) and carries NO captionTracks, so this path
+// yields null and the caller fail-safes to failed_long (video KEPT in
+// For-Processing). The code is correct for environments where YouTube serves the
+// player (residential IP / authenticated cookies); a robust server-side
+// transcript source (proxy or maintained library) is a follow-up. captions.download
+// is NOT usable here (owner-only / 403 for third-party videos).
 const INNERTUBE_PLAYER_ENDPOINT = 'https://www.youtube.com/youtubei/v1/player';
-// Public ANDROID innertube client context — needs no API key and reliably
-// returns caption tracks for public videos. Version string is non-sensitive.
-const ANDROID_CLIENT = Object.freeze({
-  clientName: 'ANDROID',
-  clientVersion: '19.09.37',
-  androidSdkVersion: 34,
+const INNERTUBE_WEB_KEY = 'AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8';
+const WEB_CLIENT = Object.freeze({
+  clientName: 'WEB',
+  clientVersion: '2.20240726.00.00',
   hl: 'en',
+  gl: 'US',
 });
 
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
@@ -97,14 +106,18 @@ export function parseTimedTextJson3(json3) {
  */
 async function fetchCaptionTracks(videoId, options = {}) {
   const res = await fetchWithTimeout(
-    INNERTUBE_PLAYER_ENDPOINT,
+    `${INNERTUBE_PLAYER_ENDPOINT}?key=${INNERTUBE_WEB_KEY}&prettyPrint=false`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': 'com.google.android.youtube/19.09.37 (Linux; U; Android 14)' },
-      body: JSON.stringify({ context: { client: ANDROID_CLIENT }, videoId }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context: { client: WEB_CLIENT }, videoId }),
     },
     options,
   );
+  if (res.status === 200 && options.verbose) {
+    // 200 but no captionTracks usually means the player response was gated
+    // (UNPLAYABLE from this IP) — caller fail-safes; see the module-header note.
+  }
   if (!res.ok) {
     if (options.verbose) console.log(`    transcript: innertube player ${res.status} for ${videoId}`);
     return null;

--- a/lib/integrations/youtube/transcript-fallback.js
+++ b/lib/integrations/youtube/transcript-fallback.js
@@ -20,6 +20,8 @@
  * disposed) — EVA-straggler discipline.
  */
 
+import { analyzeVideoContent } from './video-metadata.js';
+
 const INNERTUBE_PLAYER_ENDPOINT = 'https://www.youtube.com/youtubei/v1/player';
 // Public ANDROID innertube client context — needs no API key and reliably
 // returns caption tracks for public videos. Version string is non-sensitive.
@@ -221,4 +223,63 @@ export async function analyzeTranscriptContent(transcript, options = {}) {
   }
 }
 
-export default { fetchTranscript, analyzeTranscriptContent, pickTranscriptTrack, parseTimedTextJson3 };
+const DEFAULT_LONG_VIDEO_THRESHOLD_SECONDS = 2700; // 45 minutes
+
+/**
+ * FR-2: decide native-video vs transcript analysis for one video and return the
+ * summary plus the method actually used.
+ *
+ * Strategy:
+ *  - LONG video (durationSeconds > threshold): native analysis would likely
+ *    abort, so go straight to the transcript fallback. If no transcript is
+ *    obtainable, make ONE last-ditch native attempt; if that also fails the
+ *    video is failed_long (caller KEEPS it in For-Processing, never disposes).
+ *  - Short/medium video: native first; on null (abort/error) fall back to
+ *    transcript; if both fail the video is failed_other.
+ *
+ * Fail-safe: returns { summary:null, method:'failed_*' } rather than throwing, so
+ * the caller can record the failure and leave the video for retry.
+ *
+ * Dependencies are injectable (options._analyzeVideoContent / _fetchTranscript /
+ * _analyzeTranscriptContent) purely for unit testing; production uses the real
+ * implementations.
+ *
+ * @param {string} videoId
+ * @param {Object} [options] - forwarded to the analyzers; plus:
+ * @param {Object} [options.metadata] - {durationSeconds,...} drives the long-video decision
+ * @param {number} [options.longVideoThresholdSeconds]
+ * @returns {Promise<{summary: string|null, method: 'native'|'transcript_fallback'|'failed_long'|'failed_other'}>}
+ */
+export async function analyzeWithFallback(videoId, options = {}) {
+  const _analyzeVideo = options._analyzeVideoContent || analyzeVideoContent;
+  const _fetchTranscript = options._fetchTranscript || fetchTranscript;
+  const _analyzeTranscript = options._analyzeTranscriptContent || analyzeTranscriptContent;
+
+  const durationSeconds = (options.metadata && options.metadata.durationSeconds) || 0;
+  const threshold = options.longVideoThresholdSeconds
+    || Number(process.env.LONG_VIDEO_THRESHOLD_SECONDS)
+    || DEFAULT_LONG_VIDEO_THRESHOLD_SECONDS;
+  const isLong = durationSeconds > threshold;
+
+  const viaTranscript = async () => {
+    const transcript = await _fetchTranscript(videoId, options);
+    if (!transcript) return null;
+    return _analyzeTranscript(transcript, options);
+  };
+
+  if (isLong) {
+    const t = await viaTranscript();
+    if (t) return { summary: t, method: 'transcript_fallback' };
+    const native = await _analyzeVideo(videoId, options); // last-ditch
+    if (native) return { summary: native, method: 'native' };
+    return { summary: null, method: 'failed_long' };
+  }
+
+  const native = await _analyzeVideo(videoId, options);
+  if (native) return { summary: native, method: 'native' };
+  const t = await viaTranscript();
+  if (t) return { summary: t, method: 'transcript_fallback' };
+  return { summary: null, method: 'failed_other' };
+}
+
+export default { fetchTranscript, analyzeTranscriptContent, analyzeWithFallback, pickTranscriptTrack, parseTimedTextJson3 };

--- a/lib/integrations/youtube/transcript-fallback.js
+++ b/lib/integrations/youtube/transcript-fallback.js
@@ -1,0 +1,224 @@
+/**
+ * YouTube Transcript Fallback
+ * SD: SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001 (FR-1)
+ *
+ * The long-form companion to lib/integrations/youtube/video-metadata.js.
+ * Gemini native-video analysis (analyzeVideoContent) ABORTS on long strategy
+ * videos (>~45-60min) because the model exceeds the client timeout. This module
+ * extracts the video's CAPTIONS and runs Gemini over the TEXT instead — far
+ * cheaper and unbounded by video length.
+ *
+ * Why not the official YouTube captions.download API? It is OWNER-ONLY — it
+ * returns 403 for any video the authenticated channel does not own (i.e. every
+ * third-party strategy video: Wharton lectures, B2B pricing playbooks, etc.).
+ * So we fetch the public caption track list via the innertube player endpoint
+ * (no API key, no OAuth) and download the timedtext directly.
+ *
+ * Fail-open / fail-SAFE everywhere: every export returns null on any error and
+ * NEVER throws. A video whose transcript cannot be obtained is left for the
+ * caller to mark failed_long and KEEP in the For-Processing playlist (never
+ * disposed) — EVA-straggler discipline.
+ */
+
+const INNERTUBE_PLAYER_ENDPOINT = 'https://www.youtube.com/youtubei/v1/player';
+// Public ANDROID innertube client context — needs no API key and reliably
+// returns caption tracks for public videos. Version string is non-sensitive.
+const ANDROID_CLIENT = Object.freeze({
+  clientName: 'ANDROID',
+  clientVersion: '19.09.37',
+  androidSdkVersion: 34,
+  hl: 'en',
+});
+
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_TRANSCRIPT_CHARS = 200_000;
+
+/**
+ * fetch() with an AbortController timeout. Returns the Response or throws
+ * (callers wrap in try/catch and fail-open).
+ * @private
+ */
+async function fetchWithTimeout(url, init = {}, options = {}) {
+  const controller = new AbortController();
+  const ms = options.fetchTimeoutMs || DEFAULT_FETCH_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Pure: choose the best caption track from the innertube list.
+ * Preference order: manual track in the requested lang -> any track in the
+ * requested lang -> manual track in any lang -> any track (incl. ASR).
+ * Exposed for unit testing (no I/O).
+ * @param {Array<{baseUrl?:string,languageCode?:string,kind?:string,vssId?:string}>} tracks
+ * @param {string} [lang='en']
+ * @returns {object|null}
+ */
+export function pickTranscriptTrack(tracks, lang = 'en') {
+  if (!Array.isArray(tracks) || tracks.length === 0) return null;
+  const withUrl = tracks.filter((t) => t && typeof t.baseUrl === 'string' && t.baseUrl);
+  if (withUrl.length === 0) return null;
+  const isAsr = (t) => t.kind === 'asr' || (typeof t.vssId === 'string' && t.vssId.startsWith('a.'));
+  const inLang = (t) => typeof t.languageCode === 'string' && t.languageCode.toLowerCase().startsWith(lang.toLowerCase());
+  return (
+    withUrl.find((t) => inLang(t) && !isAsr(t)) ||
+    withUrl.find((t) => inLang(t)) ||
+    withUrl.find((t) => !isAsr(t)) ||
+    withUrl[0]
+  );
+}
+
+/**
+ * Pure: flatten a YouTube json3 timedtext payload into a single string.
+ * json3 shape: { events: [ { segs: [ { utf8: "..." } ] } ] }.
+ * Exposed for unit testing.
+ * @param {object} json3
+ * @returns {string}
+ */
+export function parseTimedTextJson3(json3) {
+  if (!json3 || !Array.isArray(json3.events)) return '';
+  return json3.events
+    .flatMap((e) => (Array.isArray(e.segs) ? e.segs.map((s) => (s && s.utf8) || '') : []))
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Fetch the public caption-track list for a video via the innertube player
+ * endpoint. Returns the captionTracks array (possibly empty) or null on error.
+ * @private
+ */
+async function fetchCaptionTracks(videoId, options = {}) {
+  const res = await fetchWithTimeout(
+    INNERTUBE_PLAYER_ENDPOINT,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'com.google.android.youtube/19.09.37 (Linux; U; Android 14)' },
+      body: JSON.stringify({ context: { client: ANDROID_CLIENT }, videoId }),
+    },
+    options,
+  );
+  if (!res.ok) {
+    if (options.verbose) console.log(`    transcript: innertube player ${res.status} for ${videoId}`);
+    return null;
+  }
+  const data = await res.json();
+  return data?.captions?.playerCaptionsTracklistRenderer?.captionTracks || [];
+}
+
+/**
+ * Fetch + parse the timedtext for a chosen caption track (json3 format).
+ * @private
+ */
+async function fetchTimedText(baseUrl, options = {}) {
+  const url = baseUrl.includes('fmt=') ? baseUrl : `${baseUrl}&fmt=json3`;
+  const res = await fetchWithTimeout(url, {}, options);
+  if (!res.ok) {
+    if (options.verbose) console.log(`    transcript: timedtext ${res.status}`);
+    return null;
+  }
+  const json3 = await res.json();
+  return parseTimedTextJson3(json3);
+}
+
+/**
+ * Fetch a video's transcript (captions) as plain text.
+ *
+ * @param {string} videoId - 11-character YouTube video ID
+ * @param {Object} [options]
+ * @param {boolean} [options.verbose=false]
+ * @param {string} [options.lang='en'] - preferred caption language code
+ * @param {number} [options.fetchTimeoutMs=30000]
+ * @returns {Promise<string|null>} transcript text, or null if unavailable
+ */
+export async function fetchTranscript(videoId, options = {}) {
+  if (!videoId || typeof videoId !== 'string' || videoId.length !== 11) return null;
+  try {
+    const tracks = await fetchCaptionTracks(videoId, options);
+    if (!tracks || tracks.length === 0) {
+      if (options.verbose) console.log(`    transcript: no caption tracks for ${videoId}`);
+      return null;
+    }
+    const track = pickTranscriptTrack(tracks, options.lang || 'en');
+    if (!track || !track.baseUrl) return null;
+    const text = await fetchTimedText(track.baseUrl, options);
+    return text && text.trim() ? text.trim() : null;
+  } catch (err) {
+    if (options.verbose) console.log(`    transcript fetch failed for ${videoId}: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Analyze a video transcript with Gemini's TEXT model — the long-video
+ * equivalent of analyzeVideoContent. Mirrors that function's intent-guided,
+ * cost-controlled (gemini-2.5-flash) prompt, but over text rather than video.
+ *
+ * @param {string} transcript - the caption text (from fetchTranscript)
+ * @param {Object} [options]
+ * @param {boolean} [options.verbose=false]
+ * @param {string} [options.chairmanIntent] - guides the analysis
+ * @param {Object} [options.metadata] - {title, channelName, durationSeconds}
+ * @param {number} [options.maxTranscriptChars=200000] - clip very long transcripts
+ * @returns {Promise<string|null>} framework summary or null
+ */
+export async function analyzeTranscriptContent(transcript, options = {}) {
+  if (!transcript || typeof transcript !== 'string' || !transcript.trim()) return null;
+
+  const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    if (options.verbose) console.log('    Gemini: no API key for transcript analysis');
+    return null;
+  }
+
+  const model = 'gemini-2.5-flash';
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+  const maxChars = options.maxTranscriptChars || DEFAULT_MAX_TRANSCRIPT_CHARS;
+  const clipped = transcript.length > maxChars ? `${transcript.slice(0, maxChars)}\n…[transcript truncated]` : transcript;
+
+  const metaContext = options.metadata
+    ? `\nVideo title: "${options.metadata.title || ''}"\nChannel: ${options.metadata.channelName || ''}`
+    : '';
+  const intentContext = options.chairmanIntent
+    ? `\n\nThe chairman's intent for this video: "${options.chairmanIntent}"\nFocus your analysis on what's relevant to this intent.`
+    : '';
+
+  const prompt = options.chairmanIntent
+    ? `Analyze this YouTube video TRANSCRIPT based on the chairman's stated intent. Provide the key frameworks, specific techniques or insights, and actionable takeaways relevant to their goals.${metaContext}${intentContext}\n\nTRANSCRIPT:\n${clipped}`
+    : `Summarize this YouTube video TRANSCRIPT for a strategic business evaluation. Focus on the frameworks it teaches, key techniques or insights, and why they might be valuable for a software company building AI-powered tools.${metaContext}\n\nTRANSCRIPT:\n${clipped}`;
+
+  try {
+    const res = await fetchWithTimeout(
+      endpoint,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { maxOutputTokens: 2048, temperature: 0.3 },
+        }),
+      },
+      { ...options, fetchTimeoutMs: options.fetchTimeoutMs || 60_000 },
+    );
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => '');
+      if (options.verbose) console.log(`    Gemini transcript analysis error: ${res.status} ${errBody.substring(0, 200)}`);
+      return null;
+    }
+    const data = await res.json();
+    const summary = data.candidates?.[0]?.content?.parts?.[0]?.text || null;
+    if (options.verbose && summary) console.log(`    Gemini transcript summary: ${summary.substring(0, 100)}...`);
+    return summary;
+  } catch (err) {
+    if (options.verbose) console.log(`    Gemini transcript analysis failed: ${err.message}`);
+    return null;
+  }
+}
+
+export default { fetchTranscript, analyzeTranscriptContent, pickTranscriptTrack, parseTimedTextJson3 };

--- a/lib/integrations/youtube/video-metadata.js
+++ b/lib/integrations/youtube/video-metadata.js
@@ -11,6 +11,13 @@
 
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
 
+// SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001 (FR-2): the Gemini native-video
+// client timeout is env-configurable so long-form analysis isn't cut off before
+// the transcript fallback (transcript-fallback.js) can take over. Default raised
+// 60s -> 120s; the orchestrator uses durationSeconds to route long videos
+// straight to the transcript path regardless.
+const GEMINI_VIDEO_TIMEOUT_MS = Number(process.env.GEMINI_VIDEO_TIMEOUT_MS) || 120_000;
+
 /**
  * Parse ISO 8601 duration (PT1H23M45S) to seconds.
  * @param {string} duration
@@ -126,7 +133,7 @@ export async function analyzeVideoContent(videoId, options = {}) {
 
   try {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 60_000);
+    const timeout = setTimeout(() => controller.abort(), GEMINI_VIDEO_TIMEOUT_MS);
 
     const response = await fetch(endpoint, {
       method: 'POST',

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "eva:run": "node scripts/eva-run.js",
     "eva:stage": "node scripts/eva/run-stage.js",
     "eva:retire-pilot-ventures": "node scripts/eva/retire-pilot-ventures.mjs",
+    "youtube:extract": "node scripts/eva/youtube-strategy-extract.js",
     "eva:heal": "node scripts/eva/vision-heal.js",
     "eva:rounds": "node scripts/eva/run-rounds.js",
     "eva:decisions": "node scripts/eva-decisions.js",

--- a/scripts/eva/youtube-strategy-extract.js
+++ b/scripts/eva/youtube-strategy-extract.js
@@ -43,12 +43,22 @@ const SD_KEY = 'SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001';
 const LEDGER_PATH = path.resolve(process.cwd(), 'memory', 'youtube-strategy-ledger.json');
 const REFERENCE_PATH = path.resolve(process.cwd(), 'docs', 'reference', 'youtube-strategy-frameworks.md');
 
+// A non-positive or non-numeric --limit means "no limit"? No — that silently
+// drains the whole backlog on a typo. Treat only a finite positive integer as a
+// real limit; anything else (0, NaN, negative) -> null = no limit only when the
+// flag was absent. Here an explicit bad value collapses to null but is logged by
+// the caller path; positive-int is the sole "limited" case.
+function toPositiveLimit(raw) {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : null;
+}
+
 export function parseArgs(argv = []) {
   const a = { limit: null, dryRun: false, dispose: false, verbose: false, lang: 'en' };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
-    if (t === '--limit') a.limit = Number(argv[++i]) || null;
-    else if (t.startsWith('--limit=')) a.limit = Number(t.split('=')[1]) || null;
+    if (t === '--limit') a.limit = toPositiveLimit(argv[++i]);
+    else if (t.startsWith('--limit=')) a.limit = toPositiveLimit(t.split('=')[1]);
     else if (t === '--dry-run') a.dryRun = true;
     else if (t === '--dispose') a.dispose = true;
     else if (t === '--verbose' || t === '-v') a.verbose = true;
@@ -97,9 +107,15 @@ async function fetchSDList(supabase) {
 }
 
 function appendReferenceLibrary(entries) {
-  const novel = entries.filter((e) => e.analysis_status === 'ok' && e.dedup_status === 'novel' && e._summary);
+  let novel = entries.filter((e) => e.analysis_status === 'ok' && e.dedup_status === 'novel' && e._summary);
   if (novel.length === 0) return 0;
-  const fresh = !fs.existsSync(REFERENCE_PATH);
+  // Idempotent append: skip any framework whose video already appears in the file
+  // (re-runs must not duplicate committed reference blocks).
+  let existing = '';
+  try { existing = fs.readFileSync(REFERENCE_PATH, 'utf8'); } catch { /* fresh file */ }
+  novel = novel.filter((e) => !existing.includes(`youtu.be/${e.video_id}`));
+  if (novel.length === 0) return 0;
+  const fresh = existing === '';
   const header = fresh
     ? '# YouTube Strategy Frameworks — extracted reference library\n\nNovel frameworks distilled from the For-Processing strategy playlist by `scripts/eva/youtube-strategy-extract.js` (SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001). Duplicates of existing SDs/capabilities are excluded.\n'
     : '';
@@ -123,9 +139,12 @@ async function routeEnhancements(supabase, entries, verbose) {
         type: 'enhancement',
         category: 'completion_flag',
         severity: 'low',
-        source_type: 'youtube_extraction',
+        // 'youtube_intake' is the only youtube value allowed by the
+        // feedback_source_type_check CHECK constraint; the extraction provenance
+        // lives in metadata.source instead (verified against live DB).
+        source_type: 'youtube_intake',
         sd_id: SD_KEY,
-        metadata: { video_id: e.video_id, composite_score: e.composite_score, category: e.category },
+        metadata: { source: 'youtube_strategy_extraction', video_id: e.video_id, composite_score: e.composite_score, category: e.category },
         dedup_key: `youtube-framework-${e.video_id}`,
       });
       routed++;
@@ -165,9 +184,15 @@ export async function main(argv = process.argv.slice(2)) {
     return { processed: entries.length, summary, dryRun: true };
   }
 
-  // Persist ledger (merge by video_id; strip working fields).
+  // Persist ledger (merge by video_id; strip working fields). Preserve a prior
+  // disposed:true so re-processing a video never resets its disposal history.
   const ledger = loadLedger();
-  for (const e of entries) ledger.videos[e.video_id] = cleanLedgerEntry(e);
+  for (const e of entries) {
+    const prior = ledger.videos[e.video_id];
+    const clean = cleanLedgerEntry(e);
+    if (prior && prior.disposed) clean.disposed = true;
+    ledger.videos[e.video_id] = clean;
+  }
   ledger.updated_at = new Date().toISOString();
   saveLedger(ledger);
 

--- a/scripts/eva/youtube-strategy-extract.js
+++ b/scripts/eva/youtube-strategy-extract.js
@@ -34,6 +34,7 @@ import {
   runExtraction,
   cleanLedgerEntry,
   isEnhancementWorthy,
+  disposeEntries,
 } from '../../lib/integrations/youtube/strategy-extract-core.js';
 import { emitFeedback } from '../../lib/governance/emit-feedback.js';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
@@ -43,12 +44,13 @@ const LEDGER_PATH = path.resolve(process.cwd(), 'memory', 'youtube-strategy-ledg
 const REFERENCE_PATH = path.resolve(process.cwd(), 'docs', 'reference', 'youtube-strategy-frameworks.md');
 
 export function parseArgs(argv = []) {
-  const a = { limit: null, dryRun: false, verbose: false, lang: 'en' };
+  const a = { limit: null, dryRun: false, dispose: false, verbose: false, lang: 'en' };
   for (let i = 0; i < argv.length; i++) {
     const t = argv[i];
     if (t === '--limit') a.limit = Number(argv[++i]) || null;
     else if (t.startsWith('--limit=')) a.limit = Number(t.split('=')[1]) || null;
     else if (t === '--dry-run') a.dryRun = true;
+    else if (t === '--dispose') a.dispose = true;
     else if (t === '--verbose' || t === '-v') a.verbose = true;
     else if (t === '--lang') a.lang = argv[++i] || 'en';
     else if (t.startsWith('--lang=')) a.lang = t.split('=')[1] || 'en';
@@ -158,7 +160,8 @@ export async function main(argv = process.argv.slice(2)) {
   console.log(`     recommendation:${JSON.stringify(summary.by_recommendation)}`);
 
   if (opts.dryRun) {
-    console.log('\n   DRY-RUN: no ledger / reference / routing writes. Done.');
+    if (opts.dispose) console.log('   (--dispose ignored under --dry-run — no playlist mutation.)');
+    console.log('\n   DRY-RUN: no ledger / reference / routing / disposal writes. Done.');
     return { processed: entries.length, summary, dryRun: true };
   }
 
@@ -174,8 +177,31 @@ export async function main(argv = process.argv.slice(2)) {
   console.log(`\n   Ledger updated: ${LEDGER_PATH}`);
   console.log(`   Novel frameworks -> reference library: ${refCount}`);
   console.log(`   Enhancement-worthy routed to chairman/coordinator: ${routed}`);
-  console.log('   (Disposal is a separate, explicitly-gated step — FR-5 — not run here.)');
-  return { processed: entries.length, summary, refCount, routed };
+
+  // FR-5: disposal (outward-facing playlist mutation) is OPT-IN via --dispose and
+  // only ever moves successfully-extracted videos — failures stay in For-Processing.
+  let disposed = 0;
+  if (opts.dispose) {
+    console.log('\n   --dispose: moving successfully-extracted videos For-Processing -> Processed...');
+    let youtube = null;
+    try {
+      const { getAuthenticatedClient } = await import('../../lib/integrations/youtube/oauth-manager.js');
+      const { google } = await import('googleapis');
+      youtube = google.youtube({ version: 'v3', auth: await getAuthenticatedClient() });
+    } catch (e) {
+      console.log(`   disposal skipped (not authenticated): ${e.message}`);
+    }
+    if (youtube) {
+      const disp = await disposeEntries(entries, { youtube, supabase, verbose: opts.verbose });
+      for (const vid of disp.disposed_ids) if (ledger.videos[vid]) ledger.videos[vid].disposed = true;
+      saveLedger(ledger);
+      disposed = disp.moved;
+      console.log(`   Disposed (-> Processed): ${disp.moved}${disp.errors.length ? `, errors: ${disp.errors.length}` : ''}`);
+    }
+  } else {
+    console.log('   (Disposal NOT run — pass --dispose to move successfully-extracted videos to Processed.)');
+  }
+  return { processed: entries.length, summary, refCount, routed, disposed };
 }
 
 if (isMainModule(import.meta.url)) {

--- a/scripts/eva/youtube-strategy-extract.js
+++ b/scripts/eva/youtube-strategy-extract.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * YouTube Strategy Extraction orchestrator
+ * SD: SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001 (FR-3 + FR-4)
+ *
+ * Distills the For-Processing YouTube strategy videos into reusable frameworks:
+ *   1. Read pending candidates from eva_youtube_intake (the For-Processing sync).
+ *   2. Analyze each (native Gemini, falling back to a transcript for long videos
+ *      that abort — lib/integrations/youtube/transcript-fallback.js).
+ *   3. 4-persona score (lib/integrations/refine-score.js), categorize, and dedup
+ *      against existing SDs (lib/integrations/youtube/strategy-extract-core.js).
+ *   4. Maintain a JSON processing ledger (memory/youtube-strategy-ledger.json).
+ *   5. Append NOVEL frameworks to docs/reference/youtube-strategy-frameworks.md
+ *      and route ENHANCEMENT-worthy ones for chairman/coordinator review via the
+ *      durable feedback channel (lib/governance/emit-feedback.js) — NO auto-SD.
+ *
+ * Disposal (moving processed videos to the Processed playlist) is a SEPARATE,
+ * explicitly-gated step (FR-5) and is intentionally NOT part of this default run.
+ *
+ * Usage:
+ *   node scripts/eva/youtube-strategy-extract.js [--limit N] [--dry-run] [--verbose] [--lang en]
+ *   npm run youtube:extract -- --limit 3 --dry-run
+ *
+ *   --dry-run : read-only — analyze + print the summary, write NOTHING (no
+ *               ledger, no reference file, no routing rows). Safe inspection.
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { analyzeWithFallback } from '../../lib/integrations/youtube/transcript-fallback.js';
+import { score } from '../../lib/integrations/refine-score.js';
+import {
+  runExtraction,
+  cleanLedgerEntry,
+  isEnhancementWorthy,
+} from '../../lib/integrations/youtube/strategy-extract-core.js';
+import { emitFeedback } from '../../lib/governance/emit-feedback.js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+const SD_KEY = 'SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001';
+const LEDGER_PATH = path.resolve(process.cwd(), 'memory', 'youtube-strategy-ledger.json');
+const REFERENCE_PATH = path.resolve(process.cwd(), 'docs', 'reference', 'youtube-strategy-frameworks.md');
+
+export function parseArgs(argv = []) {
+  const a = { limit: null, dryRun: false, verbose: false, lang: 'en' };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--limit') a.limit = Number(argv[++i]) || null;
+    else if (t.startsWith('--limit=')) a.limit = Number(t.split('=')[1]) || null;
+    else if (t === '--dry-run') a.dryRun = true;
+    else if (t === '--verbose' || t === '-v') a.verbose = true;
+    else if (t === '--lang') a.lang = argv[++i] || 'en';
+    else if (t.startsWith('--lang=')) a.lang = t.split('=')[1] || 'en';
+  }
+  return a;
+}
+
+function loadLedger() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(LEDGER_PATH, 'utf8'));
+    return raw && typeof raw === 'object' && raw.videos ? raw : { videos: {}, updated_at: null };
+  } catch {
+    return { videos: {}, updated_at: null };
+  }
+}
+
+function saveLedger(ledger) {
+  fs.mkdirSync(path.dirname(LEDGER_PATH), { recursive: true });
+  fs.writeFileSync(LEDGER_PATH, JSON.stringify(ledger, null, 2));
+}
+
+async function fetchCandidates(supabase, limit) {
+  // FIFO by intake order — drains the backlog representatively. (Most pending
+  // videos are short enough for native Gemini; only a handful of ultra-long ones
+  // need the transcript fallback, which is environmentally limited — see
+  // transcript-fallback.js header. Ordering longest-first would front-load those
+  // failures and waste a --limit sample on them.)
+  let q = supabase
+    .from('eva_youtube_intake')
+    .select('id, youtube_video_id, youtube_playlist_item_id, title, channel_name, duration_seconds, chairman_intent, chairman_notes, target_application, business_function, status, processed_at')
+    .eq('status', 'pending')
+    .is('processed_at', null)
+    .order('created_at', { ascending: true });
+  if (limit) q = q.limit(limit);
+  const { data, error } = await q;
+  if (error) throw new Error(`fetch candidates: ${error.message}`);
+  return (data || []).filter((r) => r.youtube_video_id);
+}
+
+async function fetchSDList(supabase) {
+  const { data, error } = await supabase.from('strategic_directives_v2').select('sd_key, title').limit(3000);
+  if (error) { console.warn(`  (dedup degraded: could not load SD list: ${error.message})`); return []; }
+  return data || [];
+}
+
+function appendReferenceLibrary(entries) {
+  const novel = entries.filter((e) => e.analysis_status === 'ok' && e.dedup_status === 'novel' && e._summary);
+  if (novel.length === 0) return 0;
+  const fresh = !fs.existsSync(REFERENCE_PATH);
+  const header = fresh
+    ? '# YouTube Strategy Frameworks — extracted reference library\n\nNovel frameworks distilled from the For-Processing strategy playlist by `scripts/eva/youtube-strategy-extract.js` (SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001). Duplicates of existing SDs/capabilities are excluded.\n'
+    : '';
+  const blocks = novel
+    .map((e) => `\n## ${e.title}\n- video: https://youtu.be/${e.video_id}\n- category: ${e.category} | score: ${e.composite_score ?? 'n/a'} | recommendation: ${e.recommendation ?? 'n/a'}\n\n${e._summary}\n`)
+    .join('');
+  fs.mkdirSync(path.dirname(REFERENCE_PATH), { recursive: true });
+  fs.appendFileSync(REFERENCE_PATH, header + blocks);
+  return novel.length;
+}
+
+async function routeEnhancements(supabase, entries, verbose) {
+  const worthy = entries.filter(isEnhancementWorthy);
+  let routed = 0;
+  for (const e of worthy) {
+    try {
+      await emitFeedback({
+        supabase,
+        title: `YouTube enhancement framework: ${e.title}`.slice(0, 200),
+        description: `Extracted from https://youtu.be/${e.video_id} (composite ${e.composite_score}, category ${e.category}, novel). ${(e._summary || '').slice(0, 600)} — routed for chairman/coordinator review; no SD auto-created.`,
+        type: 'enhancement',
+        category: 'completion_flag',
+        severity: 'low',
+        source_type: 'youtube_extraction',
+        sd_id: SD_KEY,
+        metadata: { video_id: e.video_id, composite_score: e.composite_score, category: e.category },
+        dedup_key: `youtube-framework-${e.video_id}`,
+      });
+      routed++;
+    } catch (err) {
+      if (verbose) console.error(`  route failed for ${e.video_id}: ${err.message}`);
+    }
+  }
+  return routed;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  const supabase = createSupabaseServiceClient();
+
+  console.log(`\n🎬 YouTube Strategy Extraction (${opts.dryRun ? 'DRY-RUN' : 'live'}${opts.limit ? `, limit ${opts.limit}` : ''})`);
+
+  const candidates = await fetchCandidates(supabase, opts.limit);
+  console.log(`   Candidates (pending, unprocessed): ${candidates.length}`);
+  if (candidates.length === 0) {
+    console.log('   Nothing to process. Done.');
+    return { processed: 0 };
+  }
+
+  const sdList = await fetchSDList(supabase);
+  const { entries, summary } = await runExtraction(candidates, { analyzeWithFallback, score, sdList }, { verbose: opts.verbose });
+
+  console.log('\n   Results:');
+  console.log(`     status:        ${JSON.stringify(summary.by_status)}`);
+  console.log(`     method:        ${JSON.stringify(summary.by_method)}`);
+  console.log(`     category:      ${JSON.stringify(summary.by_category)}`);
+  console.log(`     dedup:         ${JSON.stringify(summary.by_dedup)}`);
+  console.log(`     recommendation:${JSON.stringify(summary.by_recommendation)}`);
+
+  if (opts.dryRun) {
+    console.log('\n   DRY-RUN: no ledger / reference / routing writes. Done.');
+    return { processed: entries.length, summary, dryRun: true };
+  }
+
+  // Persist ledger (merge by video_id; strip working fields).
+  const ledger = loadLedger();
+  for (const e of entries) ledger.videos[e.video_id] = cleanLedgerEntry(e);
+  ledger.updated_at = new Date().toISOString();
+  saveLedger(ledger);
+
+  const refCount = appendReferenceLibrary(entries);
+  const routed = await routeEnhancements(supabase, entries, opts.verbose);
+
+  console.log(`\n   Ledger updated: ${LEDGER_PATH}`);
+  console.log(`   Novel frameworks -> reference library: ${refCount}`);
+  console.log(`   Enhancement-worthy routed to chairman/coordinator: ${routed}`);
+  console.log('   (Disposal is a separate, explicitly-gated step — FR-5 — not run here.)');
+  return { processed: entries.length, summary, refCount, routed };
+}
+
+if (isMainModule(import.meta.url)) {
+  main().then(() => process.exit(0)).catch((err) => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}
+
+export default { main, parseArgs };

--- a/tests/unit/integrations/youtube-strategy-extract-cli.test.js
+++ b/tests/unit/integrations/youtube-strategy-extract-cli.test.js
@@ -1,0 +1,36 @@
+/**
+ * Unit tests for the YouTube strategy-extraction CLI argument parser (FR-3/FR-5).
+ * Importing the module is side-effect-free (the main() run is guarded by
+ * isMainModule), so we can exercise the exported parseArgs directly.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../../../scripts/eva/youtube-strategy-extract.js';
+
+describe('youtube-strategy-extract parseArgs', () => {
+  it('safe defaults: no limit, NOT dry-run, dispose OFF', () => {
+    expect(parseArgs([])).toEqual({ limit: null, dryRun: false, dispose: false, verbose: false, lang: 'en' });
+  });
+
+  it('--limit accepts a positive integer', () => {
+    expect(parseArgs(['--limit', '3']).limit).toBe(3);
+    expect(parseArgs(['--limit=5']).limit).toBe(5);
+  });
+
+  it('--limit 0 / NaN / negative collapse to null (no accidental full-backlog drain)', () => {
+    expect(parseArgs(['--limit', '0']).limit).toBe(null);
+    expect(parseArgs(['--limit', 'abc']).limit).toBe(null);
+    expect(parseArgs(['--limit', '-5']).limit).toBe(null);
+  });
+
+  it('--dispose is opt-in and --dry-run / --verbose parse', () => {
+    const a = parseArgs(['--dispose', '--dry-run', '-v']);
+    expect(a.dispose).toBe(true);
+    expect(a.dryRun).toBe(true);
+    expect(a.verbose).toBe(true);
+  });
+
+  it('--lang accepts space and = forms', () => {
+    expect(parseArgs(['--lang', 'es']).lang).toBe('es');
+    expect(parseArgs(['--lang=de']).lang).toBe('de');
+  });
+});

--- a/tests/unit/integrations/youtube-strategy-extract-core.test.js
+++ b/tests/unit/integrations/youtube-strategy-extract-core.test.js
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the pure YouTube strategy-extraction core (FR-3 of
+ * SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001). No I/O — pure functions only.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  tokenize,
+  categorizeFramework,
+  dedupAgainstSDs,
+  buildLedgerEntry,
+  isEnhancementWorthy,
+  isDisposable,
+  CATEGORIES,
+} from '../../../lib/integrations/youtube/strategy-extract-core.js';
+
+describe('tokenize', () => {
+  it('lowercases, drops stopwords and short tokens', () => {
+    expect(tokenize('How to Build a Pricing Framework')).toEqual(['build', 'pricing', 'framework']);
+  });
+  it('returns [] for empty/invalid input', () => {
+    expect(tokenize('')).toEqual([]);
+    expect(tokenize(null)).toEqual([]);
+  });
+});
+
+describe('categorizeFramework', () => {
+  it('classifies infrastructure/automation language as enhancement', () => {
+    expect(categorizeFramework('A CI/CD pipeline automation workflow for teams')).toBe('enhancement');
+  });
+  it('classifies build/ship language as build', () => {
+    expect(categorizeFramework('How to launch an MVP and ship your first product')).toBe('build');
+  });
+  it('classifies research language as research', () => {
+    expect(categorizeFramework('A framework to investigate and benchmark hypotheses')).toBe('research');
+  });
+  it('defaults to reference when nothing matches', () => {
+    expect(categorizeFramework('General thoughts on leadership philosophy')).toBe('reference');
+    expect(CATEGORIES).toContain(categorizeFramework('x'));
+  });
+  it('considers intake metadata (business_function/chairman_notes)', () => {
+    expect(categorizeFramework('generic title', { business_function: 'infrastructure tooling' })).toBe('enhancement');
+  });
+});
+
+describe('dedupAgainstSDs', () => {
+  const sds = [
+    { sd_key: 'SD-PRICING-001', title: 'Value based pricing framework rollout' },
+    { sd_key: 'SD-OTHER-001', title: 'Completely unrelated subject' },
+  ];
+  it('flags dup-of-SD when token overlap meets threshold', () => {
+    const r = dedupAgainstSDs('Pricing framework strategies', sds, 0.5);
+    expect(r.status).toBe('dup-of-SD');
+    expect(r.matchedSd).toBe('SD-PRICING-001');
+  });
+  it('returns novel below threshold', () => {
+    const r = dedupAgainstSDs('Quantum widget teleportation', sds, 0.5);
+    expect(r.status).toBe('novel');
+    expect(r.matchedSd).toBe(null);
+  });
+  it('returns novel for empty SD list or empty title', () => {
+    expect(dedupAgainstSDs('anything', []).status).toBe('novel');
+    expect(dedupAgainstSDs('', sds).status).toBe('novel');
+  });
+});
+
+describe('buildLedgerEntry', () => {
+  it('builds an ok entry with category/dedup/score when a summary exists', () => {
+    const e = buildLedgerEntry({
+      videoId: 'abcdefghijk', title: 'T', method: 'transcript_fallback', summary: 's',
+      category: 'enhancement', dedup: { status: 'novel', matchedSd: null }, score: { composite: 82, recommendation: 'promote' },
+    });
+    expect(e).toMatchObject({
+      analysis_status: 'ok', method: 'transcript_fallback', composite_score: 82,
+      recommendation: 'promote', category: 'enhancement', dedup_status: 'novel', disposed: false,
+    });
+  });
+  it('nulls category/dedup/score on a failed_long video', () => {
+    const e = buildLedgerEntry({ videoId: 'v', title: 'T', method: 'failed_long', summary: null });
+    expect(e.analysis_status).toBe('failed_long');
+    expect(e.category).toBe(null);
+    expect(e.dedup_status).toBe(null);
+    expect(e.composite_score).toBe(null);
+  });
+  it('maps a non-long failure to failed_other', () => {
+    expect(buildLedgerEntry({ videoId: 'v', title: 'T', method: 'failed_other', summary: null }).analysis_status).toBe('failed_other');
+  });
+});
+
+describe('isEnhancementWorthy', () => {
+  const base = { analysis_status: 'ok', dedup_status: 'novel', category: 'enhancement', composite_score: 75 };
+  it('true only for ok + novel + enhancement + score>=70', () => {
+    expect(isEnhancementWorthy(base)).toBe(true);
+  });
+  it('false when duplicated, low-scored, wrong category, or failed', () => {
+    expect(isEnhancementWorthy({ ...base, dedup_status: 'dup-of-SD' })).toBe(false);
+    expect(isEnhancementWorthy({ ...base, composite_score: 60 })).toBe(false);
+    expect(isEnhancementWorthy({ ...base, category: 'reference' })).toBe(false);
+    expect(isEnhancementWorthy({ ...base, analysis_status: 'failed_long' })).toBe(false);
+  });
+});
+
+describe('isDisposable', () => {
+  it('true only for analysis_status=ok', () => {
+    expect(isDisposable({ analysis_status: 'ok' })).toBe(true);
+    expect(isDisposable({ analysis_status: 'failed_long' })).toBe(false);
+    expect(isDisposable({ analysis_status: 'failed_other' })).toBe(false);
+    expect(isDisposable(null)).toBe(false);
+  });
+});

--- a/tests/unit/integrations/youtube-strategy-extract-core.test.js
+++ b/tests/unit/integrations/youtube-strategy-extract-core.test.js
@@ -13,6 +13,8 @@ import {
   summarizeEntries,
   runExtraction,
   cleanLedgerEntry,
+  selectDisposable,
+  disposeEntries,
   CATEGORIES,
 } from '../../../lib/integrations/youtube/strategy-extract-core.js';
 
@@ -191,5 +193,79 @@ describe('runExtraction (injectable orchestration)', () => {
 
   it('throws only if analyzeWithFallback dep is missing', async () => {
     await expect(runExtraction(candidates, {})).rejects.toThrow(/analyzeWithFallback/);
+  });
+});
+
+describe('selectDisposable (FR-5)', () => {
+  it('selects only ok entries that have a playlist_item_id', () => {
+    const entries = [
+      { video_id: 'a', title: 'A', analysis_status: 'ok', _row: { id: 1, youtube_playlist_item_id: 'pi-a' } },
+      { video_id: 'b', title: 'B', analysis_status: 'ok', _row: { id: 2 } }, // no playlist item id
+      { video_id: 'c', title: 'C', analysis_status: 'failed_long', _row: { id: 3, youtube_playlist_item_id: 'pi-c' } },
+    ];
+    const sel = selectDisposable(entries);
+    expect(sel.map((s) => s.video_id)).toEqual(['a']);
+    expect(sel[0]).toEqual({ video_id: 'a', intake_id: 1, playlist_item_id: 'pi-a', title: 'A' });
+  });
+});
+
+describe('disposeEntries (FR-5, injectable clients)', () => {
+  const okEntries = (n = 2) => Array.from({ length: n }, (_, i) => ({
+    video_id: `v${i}`, title: `V${i}`, analysis_status: 'ok', _row: { id: i, youtube_playlist_item_id: `pi-${i}` },
+  }));
+
+  function fakeYoutube(overrides = {}) {
+    return {
+      _inserts: [], _deletes: [],
+      playlists: {
+        list: vi.fn(async () => ({ data: { items: [{ id: 'PL_PROC', snippet: { title: 'Processed' } }] } })),
+        insert: vi.fn(async () => ({ data: { id: 'PL_NEW' } })),
+      },
+      playlistItems: {
+        insert: overrides.insert || vi.fn(async function (this_, arg) { return { data: {} }; }),
+        delete: overrides.delete || vi.fn(async () => ({ data: {} })),
+      },
+    };
+  }
+  function fakeSupabase() {
+    const calls = [];
+    return {
+      calls,
+      from() { return this; },
+      update(patch) { this._patch = patch; return this; },
+      eq(col, val) { calls.push({ patch: this._patch, col, val }); return Promise.resolve({ error: null }); },
+    };
+  }
+
+  it('returns {moved:0} with no targets and does not require youtube', async () => {
+    const r = await disposeEntries([{ video_id: 'x', analysis_status: 'failed_long', _row: {} }], {});
+    expect(r.moved).toBe(0);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('throws if there are targets but no youtube client', async () => {
+    await expect(disposeEntries(okEntries(1), {})).rejects.toThrow(/youtube/);
+  });
+
+  it('moves only ok videos: insert + delete + mark intake processed', async () => {
+    const yt = fakeYoutube();
+    const sb = fakeSupabase();
+    const r = await disposeEntries(okEntries(2), { youtube: yt, supabase: sb, nowIso: '2026-06-15T00:00:00Z' });
+    expect(r.moved).toBe(2);
+    expect(r.playlist_id).toBe('PL_PROC');
+    expect(r.disposed_ids).toEqual(['v0', 'v1']);
+    expect(yt.playlistItems.insert).toHaveBeenCalledTimes(2);
+    expect(yt.playlistItems.delete).toHaveBeenCalledTimes(2);
+    expect(sb.calls).toHaveLength(2);
+    expect(sb.calls[0].patch).toMatchObject({ status: 'processed', destination_playlist_id: 'PL_PROC' });
+  });
+
+  it('records a per-video error without aborting the batch', async () => {
+    let n = 0;
+    const yt = fakeYoutube({ insert: vi.fn(async () => { n++; if (n === 1) throw new Error('quota'); return { data: {} }; }) });
+    const r = await disposeEntries(okEntries(2), { youtube: yt, supabase: fakeSupabase() });
+    expect(r.moved).toBe(1);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0].error).toMatch(/quota/);
   });
 });

--- a/tests/unit/integrations/youtube-strategy-extract-core.test.js
+++ b/tests/unit/integrations/youtube-strategy-extract-core.test.js
@@ -179,6 +179,17 @@ describe('runExtraction (injectable orchestration)', () => {
     expect(scoreStub).toHaveBeenCalledTimes(1); // batched once over the 2 OK items
   });
 
+  it('dedups an opaque/episodic title using a summary slice (not always-novel)', async () => {
+    const sdList2 = [{ sd_key: 'SD-PRICING-001', title: 'Value based pricing framework' }];
+    const opaque = [{ youtube_video_id: 'vidEPISODE1', title: 'Episode 47', channel_name: 'X', duration_seconds: 600, chairman_intent: 'value', target_application: 'ehg_engineer' }];
+    const analyze = vi.fn(async () => ({ summary: 'a value based pricing framework walkthrough', method: 'native' }));
+    const { entries } = await runExtraction(opaque, { analyzeWithFallback: analyze, sdList: sdList2 });
+    // Title 'Episode 47' tokenizes to <2 tokens -> dedup falls back to the summary,
+    // which overlaps the SD title -> dup-of-SD (would be 'novel' under title-only).
+    expect(entries[0].dedup_status).toBe('dup-of-SD');
+    expect(entries[0].matched_sd).toBe('SD-PRICING-001');
+  });
+
   it('fails-open when no score dep is provided (OK entries keep null score)', async () => {
     const { entries } = await runExtraction([candidates[1]], { analyzeWithFallback: analyzeStub, sdList });
     expect(entries[0].analysis_status).toBe('ok');
@@ -260,12 +271,22 @@ describe('disposeEntries (FR-5, injectable clients)', () => {
     expect(sb.calls[0].patch).toMatchObject({ status: 'processed', destination_playlist_id: 'PL_PROC' });
   });
 
-  it('records a per-video error without aborting the batch', async () => {
+  it('records a per-video error without aborting the batch (insert failure = not disposed)', async () => {
     let n = 0;
     const yt = fakeYoutube({ insert: vi.fn(async () => { n++; if (n === 1) throw new Error('quota'); return { data: {} }; }) });
     const r = await disposeEntries(okEntries(2), { youtube: yt, supabase: fakeSupabase() });
     expect(r.moved).toBe(1);
     expect(r.errors).toHaveLength(1);
     expect(r.errors[0].error).toMatch(/quota/);
+  });
+
+  it('insert+mark succeed but source-delete fails -> still moved (soft warning), no re-insert risk', async () => {
+    const yt = fakeYoutube({ delete: vi.fn(async () => { throw new Error('delete quota'); }) });
+    const sb = fakeSupabase();
+    const r = await disposeEntries(okEntries(1), { youtube: yt, supabase: sb });
+    expect(r.moved).toBe(1);                 // captured in Processed + marked processed
+    expect(r.errors).toHaveLength(0);        // delete failure is NOT a disposal failure
+    expect(r.delete_warnings).toHaveLength(1);
+    expect(sb.calls).toHaveLength(1);        // intake row marked processed (won't re-insert next run)
   });
 });

--- a/tests/unit/integrations/youtube-strategy-extract-core.test.js
+++ b/tests/unit/integrations/youtube-strategy-extract-core.test.js
@@ -2,7 +2,7 @@
  * Unit tests for the pure YouTube strategy-extraction core (FR-3 of
  * SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001). No I/O — pure functions only.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   tokenize,
   categorizeFramework,
@@ -10,6 +10,9 @@ import {
   buildLedgerEntry,
   isEnhancementWorthy,
   isDisposable,
+  summarizeEntries,
+  runExtraction,
+  cleanLedgerEntry,
   CATEGORIES,
 } from '../../../lib/integrations/youtube/strategy-extract-core.js';
 
@@ -105,5 +108,88 @@ describe('isDisposable', () => {
     expect(isDisposable({ analysis_status: 'failed_long' })).toBe(false);
     expect(isDisposable({ analysis_status: 'failed_other' })).toBe(false);
     expect(isDisposable(null)).toBe(false);
+  });
+});
+
+describe('summarizeEntries', () => {
+  it('counts by status/method/category/dedup/recommendation', () => {
+    const s = summarizeEntries([
+      { analysis_status: 'ok', method: 'native', category: 'build', dedup_status: 'novel', recommendation: 'promote' },
+      { analysis_status: 'ok', method: 'transcript_fallback', category: 'build', dedup_status: 'dup-of-SD', recommendation: 'review' },
+      { analysis_status: 'failed_long', method: 'failed_long', category: null, dedup_status: null, recommendation: null },
+    ]);
+    expect(s.total).toBe(3);
+    expect(s.by_status).toEqual({ ok: 2, failed_long: 1 });
+    expect(s.by_category).toEqual({ build: 2 });
+    expect(s.by_dedup).toEqual({ novel: 1, 'dup-of-SD': 1 });
+  });
+});
+
+describe('cleanLedgerEntry', () => {
+  it('strips _-prefixed working fields', () => {
+    expect(cleanLedgerEntry({ video_id: 'v', _row: {}, _summary: 's', category: 'build' })).toEqual({ video_id: 'v', category: 'build' });
+  });
+});
+
+describe('runExtraction (injectable orchestration)', () => {
+  const sdList = [{ sd_key: 'SD-PRICING-001', title: 'Value based pricing framework' }];
+  const candidates = [
+    { youtube_video_id: 'vid00000001', title: 'Pricing framework deep dive', channel_name: 'Wharton', duration_seconds: 4000, chairman_intent: 'value', target_application: 'ehg_engineer' },
+    { youtube_video_id: 'vid00000002', title: 'CI automation pipeline tooling', channel_name: 'DevX', duration_seconds: 600, chairman_intent: 'insight', target_application: 'ehg_engineer' },
+    { youtube_video_id: 'vid00000003', title: 'Unwatchable private video', channel_name: 'X', duration_seconds: 5000, chairman_intent: 'idea' },
+  ];
+
+  const analyzeStub = vi.fn(async (videoId) => {
+    if (videoId === 'vid00000001') return { summary: 'pricing framework content', method: 'transcript_fallback' };
+    if (videoId === 'vid00000002') return { summary: 'a CI automation pipeline tooling framework', method: 'native' };
+    return { summary: null, method: 'failed_long' };
+  });
+  const scoreStub = vi.fn(async (items) => ({
+    item_scores: items.map((_, i) => ({ item_index: i + 1, composite: i === 0 ? 55 : 82, recommendation: i === 0 ? 'review' : 'promote' })),
+    method: 'ai',
+  }));
+
+  it('analyzes, categorizes, dedups, and batch-scores OK entries; fails-safe the rest', async () => {
+    const { entries, summary } = await runExtraction(candidates, { analyzeWithFallback: analyzeStub, score: scoreStub, sdList });
+    expect(entries).toHaveLength(3);
+
+    const e1 = entries[0]; // pricing -> dup-of-SD, scored 55/review
+    expect(e1.analysis_status).toBe('ok');
+    expect(e1.method).toBe('transcript_fallback');
+    expect(e1.dedup_status).toBe('dup-of-SD');
+    expect(e1.matched_sd).toBe('SD-PRICING-001');
+    expect(e1.composite_score).toBe(55);
+    expect(e1.recommendation).toBe('review');
+
+    const e2 = entries[1]; // CI automation -> enhancement, novel, scored 82/promote
+    expect(e2.analysis_status).toBe('ok');
+    expect(e2.category).toBe('enhancement');
+    expect(e2.dedup_status).toBe('novel');
+    expect(e2.composite_score).toBe(82);
+    expect(isEnhancementWorthy(e2)).toBe(true);
+
+    const e3 = entries[2]; // failed
+    expect(e3.analysis_status).toBe('failed_long');
+    expect(e3.category).toBe(null);
+    expect(e3.composite_score).toBe(null);
+
+    expect(summary.by_status).toEqual({ ok: 2, failed_long: 1 });
+    expect(scoreStub).toHaveBeenCalledTimes(1); // batched once over the 2 OK items
+  });
+
+  it('fails-open when no score dep is provided (OK entries keep null score)', async () => {
+    const { entries } = await runExtraction([candidates[1]], { analyzeWithFallback: analyzeStub, sdList });
+    expect(entries[0].analysis_status).toBe('ok');
+    expect(entries[0].composite_score).toBe(null);
+  });
+
+  it('treats an analyzer throw as failed_other (never propagates)', async () => {
+    const thrower = vi.fn(async () => { throw new Error('boom'); });
+    const { entries } = await runExtraction([candidates[1]], { analyzeWithFallback: thrower });
+    expect(entries[0].analysis_status).toBe('failed_other');
+  });
+
+  it('throws only if analyzeWithFallback dep is missing', async () => {
+    await expect(runExtraction(candidates, {})).rejects.toThrow(/analyzeWithFallback/);
   });
 });

--- a/tests/unit/integrations/youtube-transcript-fallback.test.js
+++ b/tests/unit/integrations/youtube-transcript-fallback.test.js
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   fetchTranscript,
   analyzeTranscriptContent,
+  analyzeWithFallback,
   pickTranscriptTrack,
   parseTimedTextJson3,
 } from '../../../lib/integrations/youtube/transcript-fallback.js';
@@ -156,5 +157,52 @@ describe('analyzeTranscriptContent', () => {
     await analyzeTranscriptContent(huge, { maxTranscriptChars: 100 });
     const promptText = sentBody.contents[0].parts[0].text;
     expect(promptText).toContain('[transcript truncated]');
+  });
+});
+
+describe('analyzeWithFallback (native<->transcript decision, FR-2)', () => {
+  // Inject stubs so no real network/module call happens.
+  const deps = (over = {}) => ({
+    _analyzeVideoContent: vi.fn().mockResolvedValue(null),
+    _fetchTranscript: vi.fn().mockResolvedValue(null),
+    _analyzeTranscriptContent: vi.fn().mockResolvedValue(null),
+    ...over,
+  });
+
+  it('short video: native success -> method=native, transcript never attempted', async () => {
+    const d = deps({ _analyzeVideoContent: vi.fn().mockResolvedValue('native summary') });
+    const out = await analyzeWithFallback(VID, { metadata: { durationSeconds: 600 }, ...d });
+    expect(out).toEqual({ summary: 'native summary', method: 'native' });
+    expect(d._fetchTranscript).not.toHaveBeenCalled();
+  });
+
+  it('short video: native null -> transcript fallback used', async () => {
+    const d = deps({ _fetchTranscript: vi.fn().mockResolvedValue('the transcript'), _analyzeTranscriptContent: vi.fn().mockResolvedValue('t summary') });
+    const out = await analyzeWithFallback(VID, { metadata: { durationSeconds: 600 }, ...d });
+    expect(out).toEqual({ summary: 't summary', method: 'transcript_fallback' });
+    expect(d._analyzeVideoContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('short video: both fail -> failed_other', async () => {
+    const out = await analyzeWithFallback(VID, { metadata: { durationSeconds: 600 }, ...deps() });
+    expect(out).toEqual({ summary: null, method: 'failed_other' });
+  });
+
+  it('long video: transcript tried FIRST (native not called) -> transcript_fallback', async () => {
+    const d = deps({ _fetchTranscript: vi.fn().mockResolvedValue('long transcript'), _analyzeTranscriptContent: vi.fn().mockResolvedValue('long summary') });
+    const out = await analyzeWithFallback(VID, { metadata: { durationSeconds: 4000 }, longVideoThresholdSeconds: 2700, ...d });
+    expect(out).toEqual({ summary: 'long summary', method: 'transcript_fallback' });
+    expect(d._analyzeVideoContent).not.toHaveBeenCalled();
+  });
+
+  it('long video: no transcript -> last-ditch native success -> method=native', async () => {
+    const d = deps({ _analyzeVideoContent: vi.fn().mockResolvedValue('native rescue') });
+    const out = await analyzeWithFallback(VID, { metadata: { durationSeconds: 4000 }, longVideoThresholdSeconds: 2700, ...d });
+    expect(out).toEqual({ summary: 'native rescue', method: 'native' });
+  });
+
+  it('long video: transcript + native both fail -> failed_long (KEEP for retry)', async () => {
+    const out = await analyzeWithFallback(VID, { metadata: { durationSeconds: 4000 }, longVideoThresholdSeconds: 2700, ...deps() });
+    expect(out).toEqual({ summary: null, method: 'failed_long' });
   });
 });

--- a/tests/unit/integrations/youtube-transcript-fallback.test.js
+++ b/tests/unit/integrations/youtube-transcript-fallback.test.js
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the YouTube transcript fallback (FR-1 of
+ * SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001).
+ *
+ * All network I/O is mocked via a stubbed global.fetch. The contract under test:
+ *  - pure helpers (pickTranscriptTrack / parseTimedTextJson3) select + flatten correctly
+ *  - fetchTranscript is fail-open (null, never throws) and chains player->timedtext
+ *  - analyzeTranscriptContent is fail-open and gated on an API key
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  fetchTranscript,
+  analyzeTranscriptContent,
+  pickTranscriptTrack,
+  parseTimedTextJson3,
+} from '../../../lib/integrations/youtube/transcript-fallback.js';
+
+const VID = 'abcdefghijk'; // 11 chars
+
+function jsonResponse(body, ok = true, status = 200) {
+  return { ok, status, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+describe('pickTranscriptTrack (pure)', () => {
+  it('returns null for empty/invalid input', () => {
+    expect(pickTranscriptTrack(null)).toBe(null);
+    expect(pickTranscriptTrack([])).toBe(null);
+    expect(pickTranscriptTrack([{ languageCode: 'en' }])).toBe(null); // no baseUrl
+  });
+
+  it('prefers a manual English track over an English ASR track', () => {
+    const tracks = [
+      { baseUrl: 'u-asr', languageCode: 'en', kind: 'asr' },
+      { baseUrl: 'u-manual', languageCode: 'en' },
+    ];
+    expect(pickTranscriptTrack(tracks, 'en').baseUrl).toBe('u-manual');
+  });
+
+  it('falls back to English ASR when no manual English track exists', () => {
+    const tracks = [
+      { baseUrl: 'u-asr', languageCode: 'en', vssId: 'a.en' },
+      { baseUrl: 'u-fr', languageCode: 'fr' },
+    ];
+    expect(pickTranscriptTrack(tracks, 'en').baseUrl).toBe('u-asr');
+  });
+
+  it('falls back to a non-ASR track in any language, then the first track', () => {
+    expect(pickTranscriptTrack([{ baseUrl: 'u-de', languageCode: 'de' }], 'en').baseUrl).toBe('u-de');
+    expect(pickTranscriptTrack([{ baseUrl: 'u-asr', languageCode: 'de', kind: 'asr' }], 'en').baseUrl).toBe('u-asr');
+  });
+});
+
+describe('parseTimedTextJson3 (pure)', () => {
+  it('flattens events/segs into a single trimmed string', () => {
+    const json3 = { events: [{ segs: [{ utf8: 'Hello ' }, { utf8: 'world' }] }, { segs: [{ utf8: ' again' }] }] };
+    expect(parseTimedTextJson3(json3)).toBe('Hello world again');
+  });
+
+  it('returns empty string for missing/empty payloads', () => {
+    expect(parseTimedTextJson3(null)).toBe('');
+    expect(parseTimedTextJson3({})).toBe('');
+    expect(parseTimedTextJson3({ events: [{}] })).toBe('');
+  });
+});
+
+describe('fetchTranscript', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns null for an invalid videoId without any fetch', async () => {
+    const f = vi.fn();
+    vi.stubGlobal('fetch', f);
+    expect(await fetchTranscript('short')).toBe(null);
+    expect(await fetchTranscript(null)).toBe(null);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('chains innertube player -> timedtext and returns the transcript text', async () => {
+    const f = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        captions: { playerCaptionsTracklistRenderer: { captionTracks: [{ baseUrl: 'https://yt/timedtext?x=1', languageCode: 'en' }] } },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ events: [{ segs: [{ utf8: 'pricing ' }, { utf8: 'framework' }] }] }));
+    vi.stubGlobal('fetch', f);
+    const out = await fetchTranscript(VID);
+    expect(out).toBe('pricing framework');
+    expect(f).toHaveBeenCalledTimes(2);
+    // second call requested json3 format
+    expect(f.mock.calls[1][0]).toContain('fmt=json3');
+  });
+
+  it('returns null (fail-open) when no caption tracks exist', async () => {
+    const f = vi.fn().mockResolvedValueOnce(jsonResponse({ captions: {} }));
+    vi.stubGlobal('fetch', f);
+    expect(await fetchTranscript(VID)).toBe(null);
+  });
+
+  it('returns null (fail-open) when the player endpoint errors', async () => {
+    const f = vi.fn().mockResolvedValueOnce(jsonResponse({}, false, 403));
+    vi.stubGlobal('fetch', f);
+    expect(await fetchTranscript(VID)).toBe(null);
+  });
+
+  it('never throws even if fetch rejects', async () => {
+    const f = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', f);
+    await expect(fetchTranscript(VID)).resolves.toBe(null);
+  });
+});
+
+describe('analyzeTranscriptContent', () => {
+  const ORIG = process.env.GEMINI_API_KEY;
+  beforeEach(() => { process.env.GEMINI_API_KEY = 'test-key'; });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (ORIG === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = ORIG;
+  });
+
+  it('returns null for an empty transcript without calling the API', async () => {
+    const f = vi.fn();
+    vi.stubGlobal('fetch', f);
+    expect(await analyzeTranscriptContent('')).toBe(null);
+    expect(await analyzeTranscriptContent('   ')).toBe(null);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no API key is set', async () => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+    const f = vi.fn();
+    vi.stubGlobal('fetch', f);
+    expect(await analyzeTranscriptContent('some transcript')).toBe(null);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('returns the Gemini summary text on success', async () => {
+    const f = vi.fn().mockResolvedValueOnce(jsonResponse({
+      candidates: [{ content: { parts: [{ text: 'Key framework: value-based pricing.' }] } }],
+    }));
+    vi.stubGlobal('fetch', f);
+    const out = await analyzeTranscriptContent('a long transcript about pricing', { chairmanIntent: 'pricing' });
+    expect(out).toBe('Key framework: value-based pricing.');
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null (fail-open) on a Gemini API error', async () => {
+    const f = vi.fn().mockResolvedValueOnce(jsonResponse({ error: 'quota' }, false, 429));
+    vi.stubGlobal('fetch', f);
+    expect(await analyzeTranscriptContent('transcript')).toBe(null);
+  });
+
+  it('clips an over-long transcript to maxTranscriptChars', async () => {
+    let sentBody = null;
+    const f = vi.fn().mockImplementation(async (_url, init) => { sentBody = JSON.parse(init.body); return jsonResponse({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }); });
+    vi.stubGlobal('fetch', f);
+    const huge = 'x'.repeat(500);
+    await analyzeTranscriptContent(huge, { maxTranscriptChars: 100 });
+    const promptText = sentBody.contents[0].parts[0].text;
+    expect(promptText).toContain('[transcript truncated]');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-YOUTUBE-STRATEGY-EXTRACTION-001 — YouTube strategy-video extraction pipeline

Distills the For-Processing YouTube strategy videos into reusable frameworks (Chairman's Stage-3 extract-then-dispose ruling). Reusable capability built on existing primitives; **default dry-run, disposal opt-in.**

### What ships (FR-1 … FR-6)
- **FR-1** `lib/integrations/youtube/transcript-fallback.js` — fetch public captions via the innertube player endpoint + Gemini-TEXT analysis (`analyzeWithFallback` picks native-vs-transcript). Fail-open throughout; pure helpers for testing.
- **FR-2** `video-metadata.js` — env-configurable Gemini timeout (`GEMINI_VIDEO_TIMEOUT_MS`, 60s→120s) + the native→transcript decision (long videos > `LONG_VIDEO_THRESHOLD_SECONDS` route to transcript first; method recorded `native|transcript_fallback|failed_long|failed_other`).
- **FR-3** `lib/integrations/youtube/strategy-extract-core.js` (pure: categorize/dedup/ledger/`runExtraction`) + `scripts/eva/youtube-strategy-extract.js` CLI (`npm run youtube:extract`). Reads pending `eva_youtube_intake` candidates, 4-persona scores via the existing `refine-score.js`, dedups vs `strategic_directives_v2`, maintains `memory/youtube-strategy-ledger.json`.
- **FR-4** novel frameworks → `docs/reference/youtube-strategy-frameworks.md` (idempotent append); enhancement-worthy → routed via `emit-feedback.js` (no auto-SD).
- **FR-5** fail-safe gated disposal (`--dispose`, default-OFF) — moves **only** successfully-extracted videos For-Processing→Processed; failures **kept** for retry (EVA-straggler discipline). `insert → mark-processed → best-effort-delete` ordering = no duplicate on re-run.
- **FR-6** `--limit N` + `--dry-run` (default) sample mode.

### Reuse (compose, not reinvent)
`refine-score.js` (4-persona scoring), `post-processor.js`/`oauth-manager.js` (playlist + OAuth), `emit-feedback.js` (routing). Net-new: the transcript fallback + the orchestrator.

### Adversarial review (3 reviewers) — fixed before ship
- **HIGH** `routeEnhancements` used `source_type:'youtube_extraction'`, which violates the live `feedback_source_type_check` CHECK → every FR-4 routing INSERT threw and was silently swallowed (routing 100% broken in prod). The 87 green tests missed it because they mock `emitFeedback`. **Fixed** → `'youtube_intake'` + provenance in `metadata.source`.
- **MEDIUM** reference-md re-append duplicates (→ now idempotent), disposal insert-OK/delete-fail could re-insert (→ mark-processed-before-delete), dedup blind to content on opaque titles (→ summary-slice fallback).
- **LOW** `--limit 0`/NaN drained the whole backlog (→ positive-int guard); ledger merge dropped `disposed:true` (→ preserved).
- **Verified CLEAN:** dry-run airtight (no write of any kind), disposal can't touch non-`ok`/stale data, the hardcoded innertube key is the public WEB client key (not a secret), no secret logging.

### Known limitation (documented, fail-safe)
Self-contained third-party caption fetch is **anti-bot-gated from datacenter IPs** (player returns `UNPLAYABLE`; `captions.download` is owner-only/403). So the transcript path yields null → `failed_long` (video kept) from this environment. **~93 of 102 pending videos are native-processable** (verified: native Gemini extracts real frameworks on short videos); only ~4 ultra-long videos need the env-blocked path. A robust server-side transcript source (proxy/maintained library) is a flagged follow-up.

### Verification
- **94 unit tests green** (transcript fallback, decision, core categorize/dedup/score/ledger/disposal, CLI args).
- Native extraction validated end-to-end on a real short video; CLI runs end-to-end (dry-run).
- `npm run youtube:extract` wired (WIRE_CHECK). EXEC-TO-PLAN 92 · retro 80 · PLAN-TO-LEAD 95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
