### PR TITLE
feat(SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001): wire the VDR code-grep seam so all 11 capabilities probe

### DIFF
--- a/lib/vision/vdr-grep-seam.js
+++ b/lib/vision/vdr-grep-seam.js
@@ -1,0 +1,94 @@
+/**
+ * SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001 — shared io.grep seam + cross-repo repo-root map for the VDR gauge.
+ *
+ * The Vision Denominator Registry's code_grep probes (lib/vision/vdr-probes.js codeGrepProbe) need an
+ * injected `io.grep(pattern, sub, repo) => { matched, accessible }`. Without it every code_grep probe
+ * returns 'unknown' ('no grep seam') and is excluded from the denominator, so the gauge measures only
+ * the DB/KR-backed subset (6 of 11). This module is the single, injectable source for that seam, plus
+ * the repo-name -> filesystem-root map (so a probe can target the EHG_Engineer tree OR the sibling 'ehg'
+ * app checkout). It was extracted, behavior-identical, from the inline copy in scripts/vision-gauge-refresh.mjs.
+ *
+ * HONESTY CONTRACT (anti-inflation; the gauge must never lie high):
+ *   - accessible:false  → codeGrepProbe maps to 'unknown' (EXCLUDED from the denominator, never guessed).
+ *     Returned when a repo's checkout is absent/unreadable on the run host, or git grep errors unexpectedly.
+ *   - matched:true       → codeGrepProbe maps to 'partial' (code presence = intent, NOT realization), never 'built'.
+ *   - matched:false      → codeGrepProbe maps to 'unbuilt'.
+ *   So wiring this seam GROWS the probeable denominator toward 11; it never inflates the percentage.
+ *
+ * Archived/dead/test paths are excluded from the git-grep pathspec so a vocabulary hit there cannot
+ * credit a capability (review: 'effort_level' in scripts/archive/* once false-credited the fleet-dial cap).
+ *
+ * All IO is injectable (exec, existsSync) so the seam is unit-testable without a real git/FS.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// lib/vision/vdr-grep-seam.js → ../.. is the EHG_Engineer repo root (fallback when a caller omits engineerRoot).
+const DEFAULT_ENGINEER_ROOT = path.resolve(__dirname, '..', '..');
+
+// Pathspec exclusions: a vocabulary match in archived/dead/test code must not credit a live capability.
+export const GREP_EXCLUDES = [':!**/archive/**', ':!**/__tests__/**', ':!**/*.test.*', ':!**/*.spec.*'];
+
+/**
+ * Resolve the repo-name -> filesystem-root map for the VDR code_grep probes.
+ *   'EHG_Engineer' → engineerRoot (default: this repo root, resolved from the module location).
+ *   'ehg'          → env.VDR_EHG_REPO_ROOT (if set) || ehgRoot || the sibling checkout <engineerRoot>/../ehg.
+ * The sibling default IS the documented default C:/Users/rickf/Projects/_EHG/ehg on the primary host, but is
+ * computed portably (and overridable via VDR_EHG_REPO_ROOT) so it is correct on any host / in a worktree.
+ * No existence check here — an absent root is detected (and honestly reported accessible:false) by the seam.
+ * @param {object} [opts]
+ * @param {string} [opts.engineerRoot] - EHG_Engineer repo root
+ * @param {string} [opts.ehgRoot]      - explicit 'ehg' app checkout root (overridden by env.VDR_EHG_REPO_ROOT)
+ * @param {object} [opts.env]          - environment bag (defaults to process.env)
+ * @returns {{ EHG_Engineer: string, ehg: string }}
+ */
+export function resolveRepoRoots({ engineerRoot, ehgRoot, env = process.env } = {}) {
+  const engineer = engineerRoot || DEFAULT_ENGINEER_ROOT;
+  const ehg = (env && env.VDR_EHG_REPO_ROOT) || ehgRoot || path.resolve(engineer, '..', 'ehg');
+  return { EHG_Engineer: engineer, ehg };
+}
+
+/**
+ * Build the injectable code-grep seam. Returns grep(pattern, sub, repo) => { matched, accessible }.
+ * `git grep -lE <pattern> -- <sub> <excludes>` over TRACKED files in repoRoots[repo], scoped to <sub>.
+ * @param {object} opts
+ * @param {object} opts.repoRoots          - { <repoName>: <absRoot> } (from resolveRepoRoots)
+ * @param {Function} [opts.exec]           - execFileSync-compatible (sync). Default: node's execFileSync.
+ * @param {Function} [opts.existsSync]     - fs.existsSync-compatible. Default: node's fs.existsSync.
+ * @param {number} [opts.timeoutMs]        - git grep timeout (default 20000)
+ * @returns {(pattern:string, sub:string, repo:string) => { matched:boolean, accessible:boolean }}
+ */
+export function makeGrepSeam({ repoRoots, exec = execFileSync, existsSync = fs.existsSync, timeoutMs = 20000 } = {}) {
+  const roots = repoRoots || {};
+  return function grep(pattern, sub, repo) {
+    const root = roots[repo];
+    // Absent/unknown repo or missing checkout → honest 'unknown' (never a guess).
+    if (!root || !existsSync(root)) return { accessible: false, matched: false };
+    const target = sub ? path.join(root, sub) : root;
+    if (!existsSync(target)) return { accessible: false, matched: false };
+    try {
+      exec('git', ['-C', root, 'grep', '-lE', pattern, '--', sub || '.', ...GREP_EXCLUDES],
+        { stdio: 'pipe', timeout: timeoutMs });
+      return { accessible: true, matched: true };   // exit 0 ⇒ at least one tracked file matched
+    } catch (e) {
+      // git grep exit 1 ⇒ accessible but no match. Any other status (128 git error, 124 timeout, …)
+      // ⇒ accessible:false so the probe degrades to 'unknown' — a seam failure NEVER fabricates a match.
+      if (e && e.status === 1) return { accessible: true, matched: false };
+      return { accessible: false, matched: false };
+    }
+  };
+}
+
+/**
+ * One-liner convenience: resolve roots + build the seam. The canonical wiring for computeBuildGauge callers.
+ * @param {object} [opts] - forwarded to resolveRepoRoots ({ engineerRoot, ehgRoot, env }) + makeGrepSeam ({ exec, existsSync, timeoutMs })
+ * @returns {(pattern:string, sub:string, repo:string) => { matched:boolean, accessible:boolean }}
+ */
+export function makeDefaultGrepSeam(opts = {}) {
+  const repoRoots = resolveRepoRoots(opts);
+  return makeGrepSeam({ repoRoots, exec: opts.exec, existsSync: opts.existsSync, timeoutMs: opts.timeoutMs });
+}

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -23,6 +23,9 @@ import { renderDecisionLines } from '../lib/chairman/decision-layman.mjs';
 // SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4): the LIVE VDR build-% gauge, replacing the
 // static .adam-vision-build.json number.
 import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-registry.js';
+// SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001: the shared code-grep seam so the 5 code_grep probes resolve
+// (the chairman-visible gauge measures all 11 capabilities, not just the 6 DB/KR-backed ones).
+import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
 // SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001: honest sparse-pulse worker-count source.
 import { resolveWorkerCount, SPARSE_THRESHOLD } from '../lib/fleet/worker-count-source.mjs';
 
@@ -105,8 +108,10 @@ try {
   // (visionSource:true → the re-anchorable ladder pointer), so the gauge re-points automatically when
   // the chairman promotes the next rung — no code edit, no dependency on a missing EHG-VISION.md file.
   // Still fail-soft: an unavailable ladder/DB degrades to "(gauge unavailable)", never a false 0%.
-  // no grep seam ⇒ code_grep probes report 'unknown' (excluded from the denominator)
-  const gauge = await computeBuildGauge({ io: { supabase: db }, visionSource: true });
+  // SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001: inject the shared code-grep seam so the 5 code_grep probes
+  // resolve (present⇒'partial', absent checkout⇒'unknown'/excluded — never a guessed/inflated number).
+  const grep = makeDefaultGrepSeam();
+  const gauge = await computeBuildGauge({ io: { supabase: db, grep }, visionSource: true });
   const fmt = formatGaugeForSummary(gauge, { em: EM }); // single-source display mapping (shared with the Chairman-UI tile)
   visPct = fmt.pct;
   layerLine = fmt.layerLine;

--- a/scripts/vision-gauge-refresh.mjs
+++ b/scripts/vision-gauge-refresh.mjs
@@ -17,42 +17,19 @@
  */
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
-import { execFileSync } from 'node:child_process';
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
+// SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001: the cross-repo code-grep seam + repo-root map were extracted
+// from this file into a SINGLE shared source so scripts/adam-exec-summary.mjs injects the identical seam.
+import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
-// Sibling-repo roots for cross-repo code_grep probes (e.g. the ehg app UI). Absent ⇒ 'unknown'.
-const REPO_ROOTS = {
-  EHG_Engineer: REPO_ROOT,
-  ehg: path.resolve(REPO_ROOT, '..', 'ehg'),
-};
-
-/**
- * Portable code-grep seam for the VDR: `git grep` over tracked files (no ripgrep dependency),
- * scoped to a subdir pathspec. Returns { accessible, matched }; accessible=false ⇒ the probe
- * degrades to 'unknown' (honest — never guessed).
- */
-function grep(pattern, sub, repo) {
-  const root = REPO_ROOTS[repo];
-  if (!root || !fs.existsSync(root)) return { accessible: false, matched: false };
-  const target = sub ? path.join(root, sub) : root;
-  if (!fs.existsSync(target)) return { accessible: false, matched: false };
-  try {
-    // Exclude archived/dead/test paths so a vocabulary hit there cannot credit a capability
-    // (review: 'effort_level' in scripts/archive/* false-credited the fleet-dial capability).
-    execFileSync('git', ['-C', root, 'grep', '-lE', pattern, '--', sub || '.',
-      ':!**/archive/**', ':!**/__tests__/**', ':!**/*.test.*', ':!**/*.spec.*'],
-      { stdio: 'pipe', timeout: 20000 });
-    return { accessible: true, matched: true };
-  } catch (e) {
-    if (e && e.status === 1) return { accessible: true, matched: false };
-    return { accessible: false, matched: false };
-  }
-}
+// Shared seam: git grep over tracked files (archive/test excluded); an absent/unreadable checkout
+// returns accessible:false so the probe degrades to 'unknown' (honest — never guessed). The 'ehg'
+// sibling root is overridable via VDR_EHG_REPO_ROOT (default <repo>/../ehg).
+const grep = makeDefaultGrepSeam({ engineerRoot: REPO_ROOT });
 
 async function main() {
   const dryRun = process.argv.includes('--dry-run');

--- a/tests/unit/vdr-grep-seam.test.js
+++ b/tests/unit/vdr-grep-seam.test.js
@@ -1,0 +1,135 @@
+/**
+ * SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001 (FR-5 / activation test).
+ *
+ * The PURE core of the VDR code-grep seam: repo-name→filesystem-root resolution (incl. the
+ * VDR_EHG_REPO_ROOT override), the git-grep adapter (matched/accessible) with archive/test
+ * pathspec exclusions, and the END-TO-END honesty contract through codeGrepProbe — a match is
+ * 'partial' (never 'built'), an inaccessible checkout is 'unknown' (excluded, never guessed).
+ * All IO (exec/existsSync) is injected; no real git, FS, or DB.
+ */
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  resolveRepoRoots,
+  makeGrepSeam,
+  makeDefaultGrepSeam,
+  GREP_EXCLUDES,
+} from '../../lib/vision/vdr-grep-seam.js';
+import { codeGrepProbe } from '../../lib/vision/vdr-probes.js';
+
+const ENGINEER = '/repo/EHG_Engineer';
+
+describe('resolveRepoRoots — repo-name → filesystem-root map', () => {
+  it('maps EHG_Engineer to engineerRoot and ehg to the sibling checkout by default', () => {
+    const roots = resolveRepoRoots({ engineerRoot: ENGINEER, env: {} });
+    expect(roots.EHG_Engineer).toBe(ENGINEER);
+    expect(roots.ehg).toBe(path.resolve(ENGINEER, '..', 'ehg'));
+  });
+
+  it('honors an explicit ehgRoot over the sibling default', () => {
+    const roots = resolveRepoRoots({ engineerRoot: ENGINEER, ehgRoot: '/custom/ehg', env: {} });
+    expect(roots.ehg).toBe('/custom/ehg');
+  });
+
+  it('VDR_EHG_REPO_ROOT env override wins over ehgRoot and the sibling default', () => {
+    const roots = resolveRepoRoots({ engineerRoot: ENGINEER, ehgRoot: '/custom/ehg', env: { VDR_EHG_REPO_ROOT: '/env/ehg' } });
+    expect(roots.ehg).toBe('/env/ehg');
+  });
+
+  it('falls back to a module-derived engineerRoot when none is passed', () => {
+    const roots = resolveRepoRoots({ env: {} });
+    expect(typeof roots.EHG_Engineer).toBe('string');
+    expect(roots.EHG_Engineer.length).toBeGreaterThan(0);
+  });
+});
+
+describe('makeGrepSeam — git-grep adapter (matched / accessible), both directions', () => {
+  const repoRoots = { EHG_Engineer: ENGINEER, ehg: '/repo/ehg' };
+
+  it('exit 0 (a tracked file matched) => { matched:true, accessible:true }', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => 'src/x.tsx\n', existsSync: () => true });
+    expect(grep('PerformanceGauge', 'src', 'ehg')).toEqual({ matched: true, accessible: true });
+  });
+
+  it('git grep exit 1 (no match) => { matched:false, accessible:true } (built denominator, just unbuilt)', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => { const e = new Error('no match'); e.status = 1; throw e; }, existsSync: () => true });
+    expect(grep('nope', 'src', 'ehg')).toEqual({ matched: false, accessible: true });
+  });
+
+  it('unexpected git error (status 128) => { accessible:false } (fail-open → unknown, NEVER a guessed match)', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => { const e = new Error('fatal: not a git repo'); e.status = 128; throw e; }, existsSync: () => true });
+    expect(grep('x', 'src', 'ehg')).toEqual({ matched: false, accessible: false });
+  });
+
+  it('a timeout-style error (no status 1) => { accessible:false }', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => { const e = new Error('ETIMEDOUT'); e.status = null; throw e; }, existsSync: () => true });
+    expect(grep('x', 'src', 'ehg').accessible).toBe(false);
+  });
+
+  it('unknown repo key => { accessible:false } (never a path guess)', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => '', existsSync: () => true });
+    expect(grep('x', 'src', 'no-such-repo')).toEqual({ matched: false, accessible: false });
+  });
+
+  it('absent repo root => { accessible:false } (honest unknown for an absent checkout)', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => '', existsSync: (p) => p !== '/repo/ehg' && p !== path.join('/repo/ehg', 'src') });
+    expect(grep('x', 'src', 'ehg').accessible).toBe(false);
+  });
+
+  it('root present but sub path absent => { accessible:false } (do not grep a missing subtree)', () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => '', existsSync: (p) => p === '/repo/ehg' }); // root exists, target does not
+    expect(grep('x', 'src', 'ehg').accessible).toBe(false);
+  });
+
+  it('passes the archive/test pathspec exclusions to git grep (dead-code hits cannot credit a capability)', () => {
+    let captured = null;
+    const grep = makeGrepSeam({ repoRoots, exec: (cmd, args) => { captured = { cmd, args }; return ''; }, existsSync: () => true });
+    grep('CANONICAL_SURFACES', 'src', 'ehg');
+    expect(captured.cmd).toBe('git');
+    expect(captured.args).toContain('grep');
+    expect(captured.args).toContain('-lE');
+    for (const ex of GREP_EXCLUDES) expect(captured.args).toContain(ex);
+    // scoped to the repo root + subpath
+    expect(captured.args).toContain('-C');
+    expect(captured.args).toContain('/repo/ehg');
+    expect(captured.args).toContain('src');
+  });
+});
+
+describe('makeDefaultGrepSeam — one-liner wiring (resolve roots + build seam)', () => {
+  it('returns a working grep bound to resolved roots', () => {
+    const grep = makeDefaultGrepSeam({ engineerRoot: ENGINEER, env: {}, exec: () => 'lib/x.js\n', existsSync: () => true });
+    expect(grep('calibration_cohort', 'lib', 'EHG_Engineer')).toEqual({ matched: true, accessible: true });
+  });
+});
+
+describe('honesty contract end-to-end (seam → codeGrepProbe) — the gauge must never lie high', () => {
+  const repoRoots = { EHG_Engineer: ENGINEER, ehg: '/repo/ehg' };
+  const def = { type: 'code_grep', repo: 'ehg', path: 'src', pattern: 'distance-to-broke', builtWhen: 'present' };
+
+  it('a code MATCH yields PARTIAL (intent, not realization) — NEVER built', async () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => 'src/x.tsx\n', existsSync: () => true });
+    const r = await codeGrepProbe(def, { grep });
+    expect(r.status).toBe('partial');
+  });
+
+  it('no match yields UNBUILT', async () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => { const e = new Error('nm'); e.status = 1; throw e; }, existsSync: () => true });
+    const r = await codeGrepProbe(def, { grep });
+    expect(r.status).toBe('unbuilt');
+  });
+
+  it('an absent checkout yields UNKNOWN (excluded from the denominator), never a guessed number', async () => {
+    const grep = makeGrepSeam({ repoRoots, exec: () => '', existsSync: () => false }); // checkout absent
+    const r = await codeGrepProbe(def, { grep });
+    expect(r.status).toBe('unknown');
+  });
+
+  it('builtWhen:absent — a clean ABSENCE is built; a match is unbuilt (the inverse contract holds)', async () => {
+    const absentDef = { ...def, builtWhen: 'absent' };
+    const noMatch = makeGrepSeam({ repoRoots, exec: () => { const e = new Error('nm'); e.status = 1; throw e; }, existsSync: () => true });
+    const match = makeGrepSeam({ repoRoots, exec: () => 'x\n', existsSync: () => true });
+    expect((await codeGrepProbe(absentDef, { grep: noMatch })).status).toBe('built');
+    expect((await codeGrepProbe(absentDef, { grep: match })).status).toBe('unbuilt');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001

The live VDR vision build-% gauge measured only **6 of 11** capabilities: the 5 `code_grep` probes returned `'unknown'` ("no grep seam") because `io.grep` was not injected by the **primary** caller (`scripts/adam-exec-summary.mjs`, the chairman-visible gauge). The grep seam + cross-repo root map already existed **inline** in `scripts/vision-gauge-refresh.mjs` but were unshared.

### Change (consolidate, not greenfield)
- **NEW `lib/vision/vdr-grep-seam.js`** — `resolveRepoRoots` (`EHG_Engineer`→repo root; `ehg`→`VDR_EHG_REPO_ROOT` || sibling default) + `makeGrepSeam`/`makeDefaultGrepSeam` (`git grep -lE` over tracked files, archive/test pathspec excluded; absent/unreadable checkout or unexpected git error → `accessible:false`). Extracted behavior-identical from the inline copy; IO injectable.
- **`scripts/adam-exec-summary.mjs`** (PRIMARY) — inject the shared seam into `computeBuildGauge`.
- **`scripts/vision-gauge-refresh.mjs`** — import the shared seam; drop its local `grep()`/`REPO_ROOTS` (single source).
- **NEW `tests/unit/vdr-grep-seam.test.js`** — 17 pure both-directions tests.

### Honesty preserved (verified end-to-end)
A code **match → `partial`** (intent, not realization), **never `built`**; an absent checkout → **`unknown`** (excluded), never guessed. `lib/vision/vdr-probes.js` and `vdr-registry.js` status logic are **byte-unchanged**. The denominator grows **6→11** (or 6→8 if the `ehg` checkout is absent) **without inflating the %** (proof: overall stays a low honest 9%). Code-only, no DB changes.

### Evidence
- TESTING `4b23590a` (activation_invariant_verified=true, 17/17 + 43/43 broader VDR)
- SECURITY/adversarial `80ed8d9d` (all 5 checks pass, no HIGH; tried to make the gauge lie high, could not)
- VALIDATION `5c861c54` (5/5 FRs) · REGRESSION `f45cb048` (probes/registry byte-unchanged, honesty invariant preserved, 43/43)
- Retro `d93c768c` (SD_COMPLETION, quality 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)