### PR TITLE
fix(SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001): drain ALL directed Adam message-classes (ADAM_INBOX_KINDS)

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -222,6 +222,40 @@ function isDirectiveRow(r) {
 }
 
 /**
+ * SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001 — the Adam inbox must drain ALL classes DIRECTED to the Adam
+ * session, not just the reply lane + the shared DIRECTIVE_KINDS (which FULL-LANE already covered).
+ * Live data showed several genuinely Adam-directed classes still undrained, so this Adam-SCOPED
+ * allowlist = the imported DIRECTIVE_KINDS (workers consume that; we do NOT mutate it) PLUS the
+ * chairman/coordinator-directed classes that target Adam directly. Classify the KIND via the allowlist
+ * (QF-20260610-545), never a broad payload->>kind server filter.
+ *
+ * DELIBERATELY EXCLUDED (owned by dedicated handlers — the Adam inbox must never mark them read first):
+ *   canary_request   -> the canary responder
+ *   comms_check      -> /checkin roll-call
+ *   ack / coordinator_ack -> terminal acknowledgements (nothing to action)
+ *   (untyped: no payload.kind) -> roll_call + other untyped rows (NOT directed action items)
+ */
+const ADAM_INBOX_KINDS = Object.freeze([
+  ...DIRECTIVE_KINDS,
+  'chairman_heads_up',
+  'chairman_handoff',
+  'coordinator_advisory',
+  'coordinator_adam_feedback',
+  'assist_request',
+  'reconcile_consult',
+]);
+
+/**
+ * Is this row a directed Adam-inbox message? True when its payload.kind is in the Adam-scoped
+ * ADAM_INBOX_KINDS allowlist (a SUPERSET of DIRECTIVE_KINDS). Untyped rows (no payload.kind) and any
+ * excluded/responder-owned kind return false (never drained by the Adam inbox).
+ */
+function isAdamInboxRow(r) {
+  const k = r && r.payload && r.payload.kind;
+  return k != null && ADAM_INBOX_KINDS.includes(k);
+}
+
+/**
  * SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 — unified FULL-LANE inbox drain (the corrective for the
  * reply-only blindspot that left SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001's full-lane criterion
  * unmet). `drainReplies` surfaces ONLY the reply lane, so coordinator DIRECTIVE-kind rows (any
@@ -249,13 +283,15 @@ async function drainInbox(supabase, sessionId) {
     .limit(100);
   if (error) { console.error('ERROR: inbox query failed:', error.message); process.exit(1); }
 
-  const rows = (allRows || []).filter((r) => isReplyRow(r) || isDirectiveRow(r));
-  if (rows.length === 0) { console.log('(no unread directed inbox rows — replies or directives)'); return; }
+  // SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001: widen the drain to ALL directed Adam classes
+  // (isAdamInboxRow ⊇ DIRECTIVE_KINDS) — responder-owned + untyped rows stay untouched.
+  const rows = (allRows || []).filter((r) => isReplyRow(r) || isAdamInboxRow(r));
+  if (rows.length === 0) { console.log('(no unread directed inbox rows — replies or directed classes)'); return; }
 
-  console.log(`${rows.length} inbox row${rows.length === 1 ? '' : 's'} (full lane — replies + directives):`);
+  console.log(`${rows.length} inbox row${rows.length === 1 ? '' : 's'} (full lane — replies + all directed classes):`);
   const ids = [];
   for (const r of rows) {
-    const lane = isReplyRow(r) ? 'reply' : 'directive';
+    const lane = isReplyRow(r) ? 'reply' : (isDirectiveRow(r) ? 'directive' : 'adam-directed');
     const kind = (r.payload && r.payload.kind) || r.message_type || '?';
     const text = (r.payload && r.payload.body) || r.body || r.subject || '(empty)';
     const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
@@ -413,7 +449,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, drainAdamOutbound };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/tests/unit/coordination/adam-inbox-all-classes.test.js
+++ b/tests/unit/coordination/adam-inbox-all-classes.test.js
@@ -1,0 +1,109 @@
+// SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001 — the Adam inbox must drain ALL directed Adam classes, not
+// just the reply lane + the shared DIRECTIVE_KINDS that FULL-LANE covered. These tests exercise the
+// REAL classification (isAdamInboxRow / ADAM_INBOX_KINDS) + drainInbox's AND-only fetch + JS filter,
+// and PIN that the shared DIRECTIVE_KINDS is NOT mutated (workers consume it) and that responder-owned
+// + untyped rows are never scooped.
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { drainInbox, isAdamInboxRow, isDirectiveRow, ADAM_INBOX_KINDS } = require('../../../scripts/adam-advisory.cjs');
+const { DIRECTIVE_KINDS } = require('../../../lib/fleet/worker-status.cjs');
+
+const NEW_ADAM_KINDS = ['chairman_heads_up', 'chairman_handoff', 'coordinator_advisory', 'coordinator_adam_feedback', 'assist_request', 'reconcile_consult'];
+const EXCLUDED_KINDS = ['canary_request', 'comms_check', 'ack', 'coordinator_ack'];
+
+describe('ADAM_INBOX_KINDS allowlist', () => {
+  it('is a SUPERSET of the shared DIRECTIVE_KINDS', () => {
+    for (const k of DIRECTIVE_KINDS) expect(ADAM_INBOX_KINDS).toContain(k);
+  });
+  it('adds the 6 Adam-directed classes the live data showed undrained', () => {
+    for (const k of NEW_ADAM_KINDS) expect(ADAM_INBOX_KINDS).toContain(k);
+  });
+  it('does NOT contain responder-owned / terminal kinds', () => {
+    for (const k of EXCLUDED_KINDS) expect(ADAM_INBOX_KINDS).not.toContain(k);
+  });
+  it('does NOT mutate the shared DIRECTIVE_KINDS (workers consume it)', () => {
+    for (const k of NEW_ADAM_KINDS) expect(DIRECTIVE_KINDS).not.toContain(k);
+  });
+});
+
+describe('isAdamInboxRow predicate', () => {
+  it('matches every DIRECTIVE_KIND and every new Adam-directed class', () => {
+    for (const k of [...DIRECTIVE_KINDS, ...NEW_ADAM_KINDS]) {
+      expect(isAdamInboxRow({ payload: { kind: k } })).toBe(true);
+    }
+  });
+  it('does NOT match excluded kinds, untyped rows, or null', () => {
+    for (const k of EXCLUDED_KINDS) expect(isAdamInboxRow({ payload: { kind: k } })).toBe(false);
+    expect(isAdamInboxRow({ payload: {} })).toBe(false);   // untyped (roll_call etc.)
+    expect(isAdamInboxRow({})).toBe(false);
+    expect(isAdamInboxRow(null)).toBe(false);
+  });
+  it('a new Adam class is NOT a DIRECTIVE row (it is the new lane)', () => {
+    expect(isDirectiveRow({ payload: { kind: 'chairman_heads_up' } })).toBe(false);
+    expect(isAdamInboxRow({ payload: { kind: 'chairman_heads_up' } })).toBe(true);
+  });
+});
+
+// AND-only fetch + JS-filter stub (mirrors adam-advisory-full-lane.test.js).
+function stub(rows) {
+  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false };
+  const selectChain = {
+    select() { return selectChain; },
+    eq(col, val) { captured.eq[col] = val; return selectChain; },
+    or() { captured.usedOr = true; return selectChain; },
+    is(col) { captured.isNull.push(col); return selectChain; },
+    order() { return selectChain; },
+    limit() { return Promise.resolve({ data: rows, error: null }); },
+  };
+  const updateChain = {
+    update() { return updateChain; },
+    in(_col, ids) { captured.updatedIds = ids; return updateChain; },
+    is() { return Promise.resolve({ error: null }); },
+  };
+  const supabase = { from() { return new Proxy({}, { get(_t, p) { return (p in selectChain) ? selectChain[p] : updateChain[p]; } }); } };
+  return { supabase, captured };
+}
+
+describe('drainInbox (all-classes drain)', () => {
+  it('surfaces+consumes reply + DIRECTIVE_KINDS + new Adam classes, but NOT excluded/untyped', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const now = new Date().toISOString();
+    const rows = [
+      { id: 'reply', payload: { kind: 'coordinator_reply', body: 'r' }, created_at: now },
+      { id: 'directive', payload: { kind: 'work_assignment', body: 'd' }, created_at: now },
+      { id: 'heads_up', payload: { kind: 'chairman_heads_up', body: 'chairman' }, created_at: now },
+      { id: 'handoff', payload: { kind: 'chairman_handoff', body: 'handoff' }, created_at: now },
+      { id: 'advisory', payload: { kind: 'coordinator_advisory', body: 'adv' }, created_at: now },
+      { id: 'adam_fb', payload: { kind: 'coordinator_adam_feedback', body: 'fb' }, created_at: now },
+      { id: 'assist', payload: { kind: 'assist_request', body: 'assist' }, created_at: now },
+      { id: 'reconcile', payload: { kind: 'reconcile_consult', body: 'rec' }, created_at: now },
+      // must NOT be drained:
+      { id: 'canary', payload: { kind: 'canary_request' }, created_at: now },
+      { id: 'comms', payload: { kind: 'comms_check' }, created_at: now },
+      { id: 'ack', payload: { kind: 'ack' }, created_at: now },
+      { id: 'untyped', payload: {}, created_at: now },
+    ];
+    const { supabase, captured } = stub(rows);
+    await drainInbox(supabase, 'adam-session');
+    expect(captured.eq.target_session).toBe('adam-session');
+    expect(captured.isNull).toContain('read_at');
+    expect(captured.usedOr).toBe(false); // AND-only — no PostgREST .or() trap
+    expect(captured.updatedIds).toEqual(['reply', 'directive', 'heads_up', 'handoff', 'advisory', 'adam_fb', 'assist', 'reconcile']);
+    // none of the excluded/untyped ids consumed
+    for (const bad of ['canary', 'comms', 'ack', 'untyped']) expect(captured.updatedIds).not.toContain(bad);
+    logSpy.mockRestore();
+  });
+
+  it('reports cleanly when only excluded/untyped rows are present (nothing drained)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const now = new Date().toISOString();
+    const { supabase, captured } = stub([
+      { id: 'canary', payload: { kind: 'canary_request' }, created_at: now },
+      { id: 'untyped', payload: {}, created_at: now },
+    ]);
+    await drainInbox(supabase, 'adam-session');
+    expect(captured.updatedIds).toBeNull();
+    logSpy.mockRestore();
+  });
+});

--- a/tests/unit/resilient-symmetric-adam.test.js
+++ b/tests/unit/resilient-symmetric-adam.test.js
@@ -119,7 +119,9 @@ describe('FR-7: self-surfacing on startup (both sides)', () => {
   it('adam-register adamReplyMirror lists the consume-reply path', () => {
     const m = adamReplyMirror();
     expect(m).toContain('adam-advisory.cjs send');
-    expect(m).toContain('adam-advisory.cjs replies');
+    // SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001: the mirror now points to the FULL-LANE `inbox` drain
+    // (SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 repointed replies->inbox); this assertion was left stale.
+    expect(m).toContain('adam-advisory.cjs inbox');
     expect(m).toContain('coordinator-adam-comms.md');
   });
 });


### PR DESCRIPTION
## SD-LEO-FIX-ADAM-INBOX-ALL-CLASSES-001 — drain ALL directed Adam message-classes

Extends the Adam inbox reader so it surfaces + marks-read **every** class DIRECTED to the Adam session, not just the reply lane + the shared `DIRECTIVE_KINDS` that FULL-LANE (PR #4789) already covered.

### Grounding (the premise was partly stale)
The SD's premise ("the reader only drains `coordinator_reply`") was **stale** — SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001 already drains the reply lane + all 6 `DIRECTIVE_KINDS`. A live-DB query (distinct `payload.kind` where `target_session` is an Adam session) found the **genuine residual gap**: 6 more directed classes still undrained. So this is a focused **extension**, not a rebuild. (`OVERLAPPING_SCOPE_DETECTION` gate passed 100% but didn't catch the overlap; manual grounding did.)

### What ships (code-only, no schema change)
- **NEW Adam-scoped `ADAM_INBOX_KINDS`** in `scripts/adam-advisory.cjs` = the shared `DIRECTIVE_KINDS` **+** `chairman_heads_up`, `chairman_handoff`, `coordinator_advisory`, `coordinator_adam_feedback`, `assist_request`, `reconcile_consult`; plus an `isAdamInboxRow` predicate.
- **`drainInbox` widened** to `(isReplyRow || isAdamInboxRow)`, labeling each row by lane and preserving the two-stage ACK (`read_at`=DELIVERED, `acknowledged_at` withheld).
- **Deliberately EXCLUDES** responder-owned kinds (`canary_request`, `comms_check`, `ack`/`coordinator_ack`) and untyped roll-call rows — the inbox must never mark-read a message another handler owns.
- **Shared `DIRECTIVE_KINDS` (`lib/fleet/worker-status.cjs`) byte-unchanged** — workers consume it; the Adam additions live in a separate allowlist.
- **Companion (keep-main-green):** fixed a pre-existing red test (`resilient-symmetric-adam.test.js` asserted the old `replies` mirror string FULL-LANE repointed to `inbox`).

### Adversarial review — SAFE, no CRITICAL/HIGH
The key risk: marking a row read could starve a dedicated responder polling that kind unread. Verified across **both repos + live DB** that none of the 6 included kinds has a competing unread-dependent consumer (the ecosystem treats `acknowledged_at` as authoritative; `read_at` is freely stamped; `receipts.cjs findUndelivered` treats `read_at`=DELIVERED as the success handshake; `read-adam-directives.cjs` safety-net keys on `acknowledged_at IS NULL`).

### Honest scope note
The 6 included kinds currently show **unread=0** (newest 2026-06-09), so this is **defensive completeness** (the correct superset-allowlist shape), not an actively-recurring leak.

### Verification
- **86 adam tests green** (9 new: inclusion / exclusion / DIRECTIVE_KINDS-unchanged / drain). TESTING sub-agent PASS. EXEC-TO-PLAN 98 · retro q90 · PLAN-TO-LEAD 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
