### PR TITLE
feat(SD-LEO-INFRA-V1-CAPLAYER-PROBES-001): VDR capability-layer probes (Capability Registry, Expertise on-demand)

### DIFF
--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -89,6 +89,20 @@ export const VDR_REGISTRY = [
     // track the unbuilt capability. Probe its ACHIEVEMENT (kr_status), so a pending KR reads
     // 'unbuilt'/'partial', matching the vision's TODAY assessment (current_value=0).
     probe: { type: 'kr_status', code: 'KR-2026-07-05' } },
+  // SD-LEO-INFRA-V1-CAPLAYER-PROBES-001 (FR-2): the 2 chairman-ratified capability-layer
+  // capabilities that literally name V1 ("capability-saturated"): the Capability Registry and
+  // Expertise on-demand. Labels are BYTE-IDENTICAL to the vision_ladder_criteria rows (ordinals
+  // 21-22) — the coherence invariant withholds the whole gauge if they drift.
+  // MEASUREMENT STRENGTH (FR-4, anti-honesty-lie doctrine): the band is a registry-POPULATION
+  // proxy. min is non-trivial (>1, and below the live count) so a single seed row never credits
+  // 'built' and the threshold is not gamed to today's value. A populated count proves the registry
+  // EXISTS and is governed/versioned — it does NOT independently prove the EVA-router/admission-filter
+  // (registry) or live combinatorial panel-composition (expertise); those are deeper realizations
+  // tracked elsewhere. Revisable.
+  { capability: 'Capability Registry', layer: 'infrastructure',
+    probe: { type: 'db_count', table: 'sd_capabilities', min: 50, builtWhen: 'gte' } }, // >=50 governed capabilities ⇒ substantially-populated registry (live 214); 1..49 partial; 0 unbuilt
+  { capability: 'Expertise on-demand', layer: 'infrastructure',
+    probe: { type: 'db_count', table: 'specialist_registry', min: 10, builtWhen: 'gte' } }, // >=10 registered specialists ⇒ enough for combinatorial composition (live 30); 1..9 partial; 0 unbuilt
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "migration:issue-token": "node scripts/apply-migration.js --issue-token",
     "income:capture": "node scripts/income/run-income-capture.mjs",
     "okr:wire-o-2026-07": "node scripts/okr/wire-o-2026-07-kr-alignment.mjs",
+    "vision:wire-v1-caplayer": "node scripts/okr/wire-v1-caplayer-criteria.mjs",
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "setup-db": "node scripts/setup-database.js",
     "setup-db-supabase": "node scripts/setup-database-supabase.js",

--- a/scripts/okr/wire-v1-caplayer-criteria.mjs
+++ b/scripts/okr/wire-v1-caplayer-criteria.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-V1-CAPLAYER-PROBES-001 (FR-1) — wire the 2 capability-layer criteria into the
+ * active V1 vision rung so the VDR build-% gauge measures the capabilities that literally name V1
+ * ("capability-saturated"): the Capability Registry and Expertise on-demand.
+ *
+ * Inserts 2 row-level records into the EXISTING vision_ladder_criteria table (NO new tables/columns,
+ * NO migration, NO structural change) for the active V1 rung at ordinals 21-22. The capability
+ * labels are BYTE-IDENTICAL to the matching VDR_REGISTRY probes in lib/vision/vdr-registry.js — the
+ * assertRegistryCoherence invariant withholds the whole gauge if they drift, so these two land
+ * together (this script is run right after the registry code merges; the fail-soft withhold is the
+ * safety net for the seconds-long window).
+ *
+ * COHERENCE / ATOMIC LANDING: merge the registry code FIRST, then run this with --apply. Until both
+ * sides agree, computeBuildGauge fail-softs (available:false) rather than emit a false number.
+ *
+ * IDEMPOTENT: skip-existing on (rung_id, capability) — a re-run inserts nothing.
+ *
+ * Usage:
+ *   node scripts/okr/wire-v1-caplayer-criteria.mjs            # dry-run preview
+ *   node scripts/okr/wire-v1-caplayer-criteria.mjs --apply    # execute the inserts
+ */
+
+import 'dotenv/config';
+import { fileURLToPath } from 'node:url';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+
+// The active V1 rung (verified live 2026-06-15: vision_ladder_rungs is_active=true, rung_key='V1').
+export const V1_RUNG_ID = '0f056dcd-2d8e-470a-8a28-921d322e6461';
+
+/**
+ * The 2 capability-layer criteria. `capability` MUST equal the VDR_REGISTRY label byte-for-byte.
+ * `today`/`required` carry the honest measurement-strength framing (FR-4): the gauge probe is a
+ * registry-POPULATION proxy; full routable/composition realization is the deeper, separate target.
+ */
+const CRITERIA = Object.freeze([
+  {
+    ordinal: 21,
+    capability: 'Capability Registry',
+    today: 'a governed, versioned capability registry exists and is substantially populated (sd_capabilities: capability_key, maturity_score, reuse tracking); its EVA-router/admission-filter routing is not yet independently verified',
+    required: 'a versioned, governed, routable capability registry (EVA-router + admission filter) — the gauge probes registry population as a deterministic proxy',
+  },
+  {
+    ordinal: 22,
+    capability: 'Expertise on-demand',
+    today: 'a specialist registry exists with expertise domains and deliberation history (specialist_registry: expertise_domains, total_deliberations, outcome wins/losses); live combinatorial multi-expert composition is not yet independently verified',
+    required: 'on-demand combinatorial composition of multiple domain experts — the gauge probes specialist-registry population as a deterministic proxy',
+  },
+]);
+
+/**
+ * Pure: build the criteria row objects for a given rung. Testable; no I/O.
+ * @param {string} [rungId] - the active V1 rung id (defaults to the documented V1_RUNG_ID; main()
+ *   passes the LIVE-resolved id so a re-seeded DB with a different rung uuid still inserts correctly).
+ * @returns {Array<{rung_id:string, ordinal:number, capability:string, today:string, required:string}>}
+ */
+export function buildCriteriaRows(rungId = V1_RUNG_ID) {
+  return CRITERIA.map((c) => ({
+    rung_id: rungId,
+    ordinal: c.ordinal,
+    capability: c.capability,
+    today: c.today,
+    required: c.required,
+  }));
+}
+
+/** Pure: the (rung_id, capability) idempotency key. */
+export function criteriaKey(row) {
+  return `${row.rung_id}::${row.capability}`;
+}
+
+export const _internals = { V1_RUNG_ID, CRITERIA };
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const supabase = createSupabaseServiceClient();
+
+  // Resolve the ACTIVE V1 rung at runtime. The rung id is gen_random_uuid() at seed time
+  // (database/migrations/20260615_vision_ladder_active_pointer.sql), so it is NOT a stable literal —
+  // a re-seeded DB (fresh CI/staging) has a different uuid. Hardcoding it would FK-violate on a
+  // re-seeded DB and, once the registry code is merged, withhold the gauge forever via staleProbes.
+  // Resolve by is_active=true + assert rung_key='V1' (the migration's own robust pattern).
+  const { data: rung, error: rungErr } = await supabase
+    .from('vision_ladder_rungs')
+    .select('id, rung_key, is_active')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (rungErr) { console.error('FATAL: active-rung lookup failed:', rungErr.message); process.exit(1); }
+  if (!rung) { console.error('FATAL: no active vision rung (vision_ladder_rungs is_active=true) — cannot wire criteria'); process.exit(1); }
+  if (rung.rung_key !== 'V1') { console.error(`FATAL: active rung is '${rung.rung_key}', expected 'V1' — refusing to wire V1 capability-layer criteria onto the wrong rung`); process.exit(1); }
+  const rungId = rung.id;
+  if (rungId !== V1_RUNG_ID) console.warn(`NOTE: live active V1 rung id ${rungId} differs from the documented ${V1_RUNG_ID} (re-seeded DB?) — using the LIVE id.`);
+
+  const rows = buildCriteriaRows(rungId);
+  console.log(`\n=== wire-v1-caplayer-criteria (${apply ? 'APPLY' : 'DRY-RUN'}) — ${rows.length} rows for rung ${rungId.slice(0, 8)} ===\n`);
+
+  // Skip-existing on (rung_id, capability).
+  const { data: existing, error: exErr } = await supabase
+    .from('vision_ladder_criteria')
+    .select('rung_id, capability, ordinal')
+    .eq('rung_id', rungId);
+  if (exErr) { console.error('FATAL: read existing criteria failed:', exErr.message); process.exit(1); }
+  const have = new Set((existing || []).map(criteriaKey));
+
+  for (const r of rows) {
+    const status = have.has(criteriaKey(r)) ? 'EXISTS (skip)' : (apply ? 'INSERT' : 'would insert');
+    console.log(`  [${status}] ordinal ${r.ordinal} <- '${r.capability}'`);
+  }
+
+  const toInsert = rows.filter((r) => !have.has(criteriaKey(r)));
+  if (!toInsert.length) { console.log(`\nNothing to insert — both capability-layer criteria already present (idempotent no-op).`); return; }
+  if (!apply) { console.log(`\n=== DRY-RUN — re-run with --apply to insert ${toInsert.length} row(s) ===\n`); return; }
+
+  const { error: insErr } = await supabase.from('vision_ladder_criteria').insert(toInsert);
+  if (insErr) { console.error('FATAL: insert failed:', insErr.message); process.exit(1); }
+  console.log(`\n=== APPLIED — inserted ${toInsert.length} criteria row(s) ===\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((e) => { console.error('FATAL:', e.message); process.exit(1); });
+}

--- a/tests/unit/vision/vdr-caplayer-probes.test.js
+++ b/tests/unit/vision/vdr-caplayer-probes.test.js
@@ -1,0 +1,142 @@
+// SD-LEO-INFRA-V1-CAPLAYER-PROBES-001 (FR-3) — adversarial band-movement + coherence tests for the
+// two capability-layer probes (Capability Registry, Expertise on-demand). Hermetic: injected
+// supabase seam, no live DB, no grep seam (db_count probes only).
+import { describe, it, expect } from 'vitest';
+import {
+  assertRegistryCoherence,
+  computeBuildGauge,
+  VDR_REGISTRY,
+} from '../../../lib/vision/vdr-registry.js';
+import { runProbe } from '../../../lib/vision/vdr-probes.js';
+import { buildCriteriaRows, _internals as wireInternals, V1_RUNG_ID } from '../../../scripts/okr/wire-v1-caplayer-criteria.mjs';
+
+const CAP_REGISTRY = 'Capability Registry';
+const EXPERTISE = 'Expertise on-demand';
+
+// Chainable supabase stub (same shape as vdr-registry.test.js): count/head queries resolve to { count }.
+function stubSupabase({ countByTable = {} } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+        then(res, rej) { return Promise.resolve({ count: countByTable[table] ?? 0, error: null }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+// Build a CAPABILITY GAP markdown table from labels so coherence passes/fails by construction.
+function visionFixture(labels = VDR_REGISTRY.map((e) => e.capability)) {
+  const rows = labels.map((l) => `| **${l}** | today cell | required cell |`).join('\n');
+  return ['## CAPABILITY GAP — at-a-glance table', '', '| Vision capability | TODAY | REQUIRED |', '|---|---|---|', rows, '', '## NEXT', 'excluded'].join('\n');
+}
+
+const entryFor = (cap) => VDR_REGISTRY.find((e) => e.capability === cap);
+
+describe('FR-2: the 2 capability-layer entries are registered with the honest shape', () => {
+  it('Capability Registry → db_count on sd_capabilities, layer infrastructure, min 50 (>1, below live 214)', () => {
+    const e = entryFor(CAP_REGISTRY);
+    expect(e).toBeTruthy();
+    expect(e.layer).toBe('infrastructure');
+    expect(e.probe).toMatchObject({ type: 'db_count', table: 'sd_capabilities', min: 50, builtWhen: 'gte' });
+    expect(e.probe.min).toBeGreaterThan(1); // anti-seed-inflation (FR-4 honesty)
+  });
+  it('Expertise on-demand → db_count on specialist_registry, layer infrastructure, min 10 (>1, below live 30)', () => {
+    const e = entryFor(EXPERTISE);
+    expect(e).toBeTruthy();
+    expect(e.layer).toBe('infrastructure');
+    expect(e.probe).toMatchObject({ type: 'db_count', table: 'specialist_registry', min: 10, builtWhen: 'gte' });
+    expect(e.probe.min).toBeGreaterThan(1);
+  });
+});
+
+describe('FR-3 adversarial: the band MOVES with the count (unbuilt → partial → built)', () => {
+  it('Capability Registry: 0 → unbuilt, 1..49 → partial, >=50 → built', async () => {
+    const probe = entryFor(CAP_REGISTRY).probe;
+    const run = (n) => runProbe(probe, { supabase: stubSupabase({ countByTable: { sd_capabilities: n } }) });
+    expect((await run(0)).status).toBe('unbuilt');
+    expect((await run(1)).status).toBe('partial');   // a single seed row must NOT credit built (doctrine)
+    expect((await run(49)).status).toBe('partial');
+    expect((await run(50)).status).toBe('built');
+    expect((await run(214)).status).toBe('built');    // the live count
+  });
+  it('Expertise on-demand: 0 → unbuilt, 1..9 → partial, >=10 → built', async () => {
+    const probe = entryFor(EXPERTISE).probe;
+    const run = (n) => runProbe(probe, { supabase: stubSupabase({ countByTable: { specialist_registry: n } }) });
+    expect((await run(0)).status).toBe('unbuilt');
+    expect((await run(1)).status).toBe('partial');
+    expect((await run(9)).status).toBe('partial');
+    expect((await run(10)).status).toBe('built');
+    expect((await run(30)).status).toBe('built');     // the live count
+  });
+});
+
+describe('FR-3 coherence: criteria↔probe lockstep withholds the WHOLE gauge on drift (both directions)', () => {
+  it('matched (both labels present in vision + registry) → coherence ok:true, gauge available', async () => {
+    const io = { supabase: stubSupabase({ countByTable: { sd_capabilities: 214, specialist_registry: 30 } }) };
+    const g = await computeBuildGauge({ io, visionMarkdown: visionFixture() });
+    expect(g.coherence.ok).toBe(true);
+    expect(g.available).toBe(true);
+    // both new capability-layer components are PROBED (not unmapped/unknown) and built at live counts
+    const cr = g.components.find((c) => c.capability === CAP_REGISTRY);
+    const ex = g.components.find((c) => c.capability === EXPERTISE);
+    expect(cr).toMatchObject({ layer: 'infrastructure', status: 'built' });
+    expect(ex).toMatchObject({ layer: 'infrastructure', status: 'built' });
+  });
+
+  it('criterion-without-probe → missingProbes → gauge withholds (available:false)', async () => {
+    // a vision criterion exists with no matching registry probe (simulate the new label added to
+    // criteria but NOT to the registry — the mid-rollout hazard this SD guards against).
+    const md = visionFixture([...VDR_REGISTRY.map((e) => e.capability), 'Phantom Capability With No Probe']);
+    const g = await computeBuildGauge({ io: { supabase: stubSupabase({}) }, visionMarkdown: md });
+    expect(g.coherence.ok).toBe(false);
+    expect(g.coherence.missingProbes).toContain('Phantom Capability With No Probe');
+    expect(g.available).toBe(false);
+    expect(g.overall_pct).toBeNull();
+  });
+
+  it('probe-without-criterion → staleProbes → gauge withholds (available:false)', async () => {
+    // the registry has the 2 new probes but the vision criteria omit one of them (simulate the new
+    // probe shipped in code but the criteria INSERT not yet applied — the other rollout direction).
+    const labelsMinusExpertise = VDR_REGISTRY.map((e) => e.capability).filter((c) => c !== EXPERTISE);
+    const g = await computeBuildGauge({ io: { supabase: stubSupabase({}) }, visionMarkdown: visionFixture(labelsMinusExpertise) });
+    expect(g.coherence.ok).toBe(false);
+    expect(g.coherence.staleProbes).toContain(EXPERTISE);
+    expect(g.available).toBe(false);
+    expect(g.overall_pct).toBeNull();
+  });
+
+  it('assertRegistryCoherence directly: both new labels are matched by the registry', () => {
+    const r = assertRegistryCoherence(VDR_REGISTRY.map((e) => ({ capability: e.capability })));
+    expect(r.ok).toBe(true);
+    expect(r.missingProbes).toEqual([]);
+    expect(r.staleProbes).toEqual([]);
+  });
+});
+
+// Guard the HIGH-risk byte-identity axis at the SOURCE (review finding): the wire-script criteria
+// labels and the VDR_REGISTRY probe labels must be byte-identical, or the live gauge withholds
+// forever. The other coherence tests use a fixture derived FROM the registry, so they cannot catch
+// a drift between the wire script's CRITERIA literals and the registry literals — this one does.
+describe('FR-1/FR-2 source-of-truth: wire-script criteria labels == VDR_REGISTRY labels (byte-identical)', () => {
+  it('the 2 wire-script CRITERIA capabilities are exactly the 2 capability-layer labels', () => {
+    const caps = wireInternals.CRITERIA.map((c) => c.capability);
+    expect(caps).toEqual([CAP_REGISTRY, EXPERTISE]);
+  });
+  it('every wire-script criterion capability has a byte-identical VDR_REGISTRY probe (no drift → no forever-withhold)', () => {
+    const registered = new Set(VDR_REGISTRY.map((e) => e.capability));
+    for (const c of wireInternals.CRITERIA) expect(registered.has(c.capability)).toBe(true);
+    // and the registry's 2 new infra db_count entries are exactly the wire-script set
+    const newInfra = VDR_REGISTRY.filter((e) => e.probe.type === 'db_count' && ['sd_capabilities', 'specialist_registry'].includes(e.probe.table)).map((e) => e.capability);
+    expect(new Set(newInfra)).toEqual(new Set(wireInternals.CRITERIA.map((c) => c.capability)));
+  });
+  it('buildCriteriaRows defaults to the documented V1 rung but accepts a live-resolved id (dynamic-rung fix)', () => {
+    expect(buildCriteriaRows().every((r) => r.rung_id === V1_RUNG_ID)).toBe(true);
+    const custom = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    expect(buildCriteriaRows(custom).every((r) => r.rung_id === custom)).toBe(true);
+    expect(buildCriteriaRows().map((r) => r.ordinal)).toEqual([21, 22]);
+  });
+});

--- a/tests/unit/vision/vdr-db-source.test.js
+++ b/tests/unit/vision/vdr-db-source.test.js
@@ -73,7 +73,9 @@ describe('dbVisionSource (FR-4) — reads active rung criteria from the ladder p
 
 describe('computeBuildGauge visionSource=true (FR-4) — DB denominator, unchanged probe math', () => {
   it('computes the gauge from the DB source with the SAME 4-state/unknowns-excluded math', async () => {
-    // Same probe inputs as the markdown-source test: 6 DB-backed probeable, 5 code_grep unknown.
+    // Same probe inputs as the markdown-source test: 6 original DB-backed probeable + the 2
+    // capability-layer db_count probes (sd_capabilities/specialist_registry, no count here → 0 →
+    // unbuilt) = 8 scored; 5 code_grep unknown.
     const io = {
       supabase: stubLadderSupabase({
         countByTable: { agent_messages: 2, pattern_occurrences: 0, key_results: 1 },
@@ -89,8 +91,8 @@ describe('computeBuildGauge visionSource=true (FR-4) — DB denominator, unchang
     expect(g.coherence.ok).toBe(true); // DB labels match VDR_REGISTRY → no drift
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
     expect(g.unknown_count).toBe(5);
-    expect(g.denominator).toBe(6);
-    expect(g.overall_pct).toBe(33); // identical to the markdown-source path
+    expect(g.denominator).toBe(8); // +2: the capability-layer db_count probes (unbuilt at count 0)
+    expect(g.overall_pct).toBe(25); // (1+0.5+0.5+0+0+0+0+0)/8 = 2.0/8 = 25%; identical to the markdown-source path
     expect(g.measured_at_note).toMatch(/DB vision source/);
   });
 

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -78,10 +78,11 @@ describe('assertRegistryCoherence (FR-1 fail-loud denominator↔probe lockstep)'
 
 describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', () => {
   it('computes overall % + per-layer with HONEST banding, EXCLUDING unknowns from the denominator', async () => {
-    // 6 DB-backed probeable; 5 code_grep → unknown (no grep seam). With the post-review semantics:
+    // 8 DB-backed probeable; 5 code_grep → unknown (no grep seam). With the post-review semantics:
     //   built(1):  Take-a-dollar (KR04 achieved)
     //   partial(.5): self-operating (agent_messages=2 < min20), survivability (KR02 45/90)
-    //   unbuilt(0): distance-to-quit (KR05 0/1), venture-learning (pattern_occurrences=0), north-star (KR05 0/1)
+    //   unbuilt(0): distance-to-quit (KR05 0/1), venture-learning (pattern_occurrences=0), north-star (KR05 0/1),
+    //              Capability Registry (sd_capabilities=0 < min50), Expertise on-demand (specialist_registry=0 < min10)
     const io = {
       supabase: stubSupabase({
         countByTable: { agent_messages: 2, pattern_occurrences: 0, key_results: 1 },
@@ -97,10 +98,11 @@ describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', ()
     expect(g.coherence.ok).toBe(true);
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
     expect(g.unknown_count).toBe(5);
-    expect(g.denominator).toBe(6);
-    // (1 + 0.5 + 0.5 + 0 + 0 + 0) / 6 = 2.0/6 = 33%
-    expect(g.overall_pct).toBe(33);
-    expect(g.per_layer).toMatchObject({ venture: 75, infrastructure: 50, application: 0, process: 0 });
+    expect(g.denominator).toBe(8); // +2: the capability-layer db_count probes (unbuilt at count 0)
+    // (1 + 0.5 + 0.5 + 0 + 0 + 0 + 0 + 0) / 8 = 2.0/8 = 25%
+    expect(g.overall_pct).toBe(25);
+    // infrastructure scored = survivability(0.5) + Capability Registry(0) + Expertise on-demand(0) = 0.5/3 = 17%
+    expect(g.per_layer).toMatchObject({ venture: 75, infrastructure: 17, application: 0, process: 0 });
     for (const c of g.components) expect(STATUS_SCORE).toHaveProperty(c.status);
   });
 


### PR DESCRIPTION
## Summary
Teach the existing VDR (Vision Denominator Registry) build-% gauge to measure the 2 chairman-ratified V1 capability-layer capabilities that literally name V1 ("capability-saturated"): the **Capability Registry** and **Expertise on-demand**.

## What ships
- **`lib/vision/vdr-registry.js`** — +2 `db_count` VDR_REGISTRY probes (layer `infrastructure`): `Capability Registry` → `sd_capabilities` (min 50); `Expertise on-demand` → `specialist_registry` (min 10). Labels byte-identical to the criteria rows.
- **`scripts/okr/wire-v1-caplayer-criteria.mjs`** (NEW, `npm run vision:wire-v1-caplayer`) — idempotent insert of 2 `vision_ladder_criteria` rows (ordinals 21-22) for the active V1 rung; **resolves the rung at runtime by `is_active=true`** (the rung uuid is `gen_random_uuid()` at seed time — never hardcoded for the insert, per adversarial review).
- **`tests/unit/vision/vdr-caplayer-probes.test.js`** (NEW) — adversarial band-movement (0→unbuilt, 0<n<min→partial, n≥min→built) + coherence both-directions + a source-of-truth label-identity guard.
- **`tests/unit/vision/{vdr-registry,vdr-db-source}.test.js`** — gauge math updated for the +2 probes (denominator 6→8, overall 33→25%, infra 50→17%).
- **`package.json`** — wired `vision:wire-v1-caplayer`.

## Coherence invariant (atomic landing)
`assertRegistryCoherence` withholds the **whole** gauge if criteria labels and registry probes drift. Criteria rows + registry code therefore land together; the fail-soft withhold (`available:false`, never a false number) is the safety net. Apply sequence: merge this PR, then `npm run vision:wire-v1-caplayer -- --apply`.

## Measurement honesty (doctrine)
`db_count` is a registry-**population** proxy. `min>1` (and below the live counts 214/30) defeats seed-row inflation; a count proves the registry **exists** and is governed/versioned but does **not** independently prove the EVA-router/admission-filter (registry) or live combinatorial panel-composition (expertise) — documented in-code and in the criterion text.

⚠️ **Expected one-time live gauge swing**: on `--apply`, both new caps band `built` at the live counts (214/30), moving the chairman build-% gauge from **0% → 25%** (the other 6 probeable caps currently read unbuilt). This is the intended honest measurement, disclosed for chairman visibility.

## Verification
37/37 vision-module tests green. Adversarial review verdict: SHIP (hardcoded-rung-uuid fixed; label byte-identity confirmed; insert constraints satisfied; fail-soft net confirmed live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)