### PR TITLE
feat(SD-LEO-INFRA-V1-GOV-PROBES-001): VDR governance-cluster probes (5 V1 capabilities)

### DIFF
--- a/database/migrations/20260615_vision_ladder_governance_criteria.sql
+++ b/database/migrations/20260615_vision_ladder_governance_criteria.sql
@@ -1,0 +1,68 @@
+-- 20260615_vision_ladder_governance_criteria.sql
+-- SD-LEO-INFRA-V1-GOV-PROBES-001 (FR-1): seed the 5 chairman-ratified V1 GOVERNANCE-cluster criteria
+-- rows (ordinals 12-16) into the EXISTING vision_ladder_criteria table for the active V1 rung.
+--
+-- DATA-ROWS-ONLY (additive): no new tables, no new columns, no DDL — this only INSERTs 5 governance
+-- criteria rows into the table created by 20260615_vision_ladder_active_pointer.sql (which seeded the
+-- 11 V1 criteria at ordinals 1-11). Sorts AFTER that migration by filename so the table exists first.
+--
+-- COHERENCE INVARIANT (assertRegistryCoherence): these 5 capability labels are BYTE-IDENTICAL to the 5
+-- VDR_REGISTRY entries added in lib/vision/vdr-registry.js in the SAME PR. The DB rows (denominator) and
+-- the code probes (numerator) MUST land together — a label drift drives coherence.ok=false and the WHOLE
+-- gauge withholds (available:false). Land FR-1 (this file) and FR-2 (registry code) ATOMICALLY.
+--
+-- HONEST-GAUGE NOTE: this supplies only the DENOMINATOR (which capabilities count). The NUMERATOR is the
+-- live typed probes. today/required below are DESCRIPTIVE chairman-ladder metadata only — they are NOT
+-- used to credit 'built' (presence != realized). The 3 kr_status probes read 'built' from live ACHIEVED
+-- governance KRs (KR-GOV-3.2/2.2/2.3); the 2 code_grep probes read 'partial' (intent) or 'unknown'.
+--
+-- IDEMPOTENT: ON CONFLICT (rung_id, capability) DO NOTHING — (rung_id, capability) is the table's ONLY
+-- UNIQUE constraint; (rung_id, ordinal) is a plain non-unique index and must NOT be a conflict target.
+
+BEGIN;
+
+INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability, today, required)
+SELECT r.id, c.ordinal, c.capability, c.today, c.required
+FROM vision_ladder_rungs r
+CROSS JOIN (VALUES
+  (12, 'Govern-by-exception',                          'doctrine-of-constraint enforced at the DB; not yet surfaced as chairman govern-by-exception', 'chairman governs by exception (defaults enforced, exceptions surfaced)'),
+  (13, 'Decision Filter Engine',                       'decision-filter engine exists (lib/eva) but not wired as the canonical governance filter',     'a live decision-filter engine gating chairman decisions'),
+  (14, 'Governance cascade enforced',                  'governance cascade layers 2 of 6 operational (KR-GOV-3.1 at_risk)',                            'all 6 governance cascade layers operational end-to-end'),
+  (15, 'OKR-driven prioritization + day-28 hard stop', 'OKR priority in ranking done (KR-GOV-2.2); monthly OKR automation + day-28 hard-stop not yet (KR-GOV-3.3, 0/3)', 'OKR-driven prioritization WITH a day-28 hard stop'),
+  (16, 'All 7 governance guardrails',                  'all 7 governance guardrails enforced (KR-GOV-3.2, 7/7)',                                       'all 7 governance guardrails enforced')
+) AS c(ordinal, capability, today, required)
+WHERE r.rung_key = 'V1'
+ON CONFLICT (rung_id, capability) DO NOTHING;
+
+-- In-DB self-verification: prove the 5 governance rows landed and V1 now has >=16 criteria.
+DO $verify$
+DECLARE
+  gov_count integer;
+  v1_total  integer;
+BEGIN
+  SELECT count(*) INTO gov_count
+    FROM vision_ladder_criteria c JOIN vision_ladder_rungs r ON r.id = c.rung_id
+   WHERE r.rung_key = 'V1'
+     AND c.capability IN (
+       'Govern-by-exception','Decision Filter Engine','Governance cascade enforced',
+       'OKR-driven prioritization + day-28 hard stop','All 7 governance guardrails');
+  IF gov_count <> 5 THEN
+    RAISE EXCEPTION 'vision ladder governance: expected 5 governance criteria, found %', gov_count;
+  END IF;
+  SELECT count(*) INTO v1_total
+    FROM vision_ladder_criteria c JOIN vision_ladder_rungs r ON r.id = c.rung_id
+   WHERE r.rung_key = 'V1';
+  IF v1_total < 16 THEN
+    RAISE EXCEPTION 'vision ladder governance: expected >=16 V1 criteria after seed, found %', v1_total;
+  END IF;
+END
+$verify$;
+
+COMMIT;
+
+-- ROLLBACK (reverse): remove ONLY the 5 governance rows (leaves the original 11 untouched):
+--   DELETE FROM vision_ladder_criteria c USING vision_ladder_rungs r
+--    WHERE c.rung_id = r.id AND r.rung_key = 'V1'
+--      AND c.capability IN (
+--        'Govern-by-exception','Decision Filter Engine','Governance cascade enforced',
+--        'OKR-driven prioritization + day-28 hard stop','All 7 governance guardrails');

--- a/database/migrations/20260615_vision_ladder_governance_criteria.sql
+++ b/database/migrations/20260615_vision_ladder_governance_criteria.sql
@@ -13,8 +13,9 @@
 --
 -- HONEST-GAUGE NOTE: this supplies only the DENOMINATOR (which capabilities count). The NUMERATOR is the
 -- live typed probes. today/required below are DESCRIPTIVE chairman-ladder metadata only — they are NOT
--- used to credit 'built' (presence != realized). The 3 kr_status probes read 'built' from live ACHIEVED
--- governance KRs (KR-GOV-3.2/2.2/2.3); the 2 code_grep probes read 'partial' (intent) or 'unknown'.
+-- used to credit 'built' (presence != realized). The 3 kr_status probes map to their SEMANTICALLY-CORRECT
+-- governance KRs and read their HONEST live band: KR-GOV-3.2 (7/7 → built), KR-GOV-3.1 (2/6 → partial),
+-- KR-GOV-3.3 (0/3 → unbuilt); the 2 code_grep probes read 'partial' (intent) or 'unknown' (no seam).
 --
 -- IDEMPOTENT: ON CONFLICT (rung_id, capability) DO NOTHING — (rung_id, capability) is the table's ONLY
 -- UNIQUE constraint; (rung_id, ordinal) is a plain non-unique index and must NOT be a conflict target.

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -103,6 +103,32 @@ export const VDR_REGISTRY = [
     probe: { type: 'db_count', table: 'sd_capabilities', min: 50, builtWhen: 'gte' } }, // >=50 governed capabilities ⇒ substantially-populated registry (live 214); 1..49 partial; 0 unbuilt
   { capability: 'Expertise on-demand', layer: 'infrastructure',
     probe: { type: 'db_count', table: 'specialist_registry', min: 10, builtWhen: 'gte' } }, // >=10 registered specialists ⇒ enough for combinatorial composition (live 30); 1..9 partial; 0 unbuilt
+  // ── SD-LEO-INFRA-V1-GOV-PROBES-001: 5 V1 GOVERNANCE-cluster capabilities (ordinals 12-16) ──
+  // Governance is the chairman-weighted dimension the gauge previously omitted (incl. the
+  // highest-weighted 'Govern-by-exception'). PROBE-SOURCE DOCTRINE (anti-honesty-lie): map each
+  // capability to the SEMANTICALLY-CORRECT live KR and report its HONEST band (built/partial/unbuilt
+  // as the KR actually stands) — NOT merely whichever governance KR happens to be 'achieved'. Reading
+  // 'built' off a semantically-wrong-but-achieved KR (e.g. the cascade capability off 'vision event
+  // handlers') would inflate a half-built capability, which is exactly what this gauge exists to
+  // prevent. Where no KR measures the capability, code_grep bands 'partial' (intent, capped by
+  // codeGrepProbe — never 'built') or 'unknown' (no seam, excluded — never false-0). These labels are
+  // BYTE-IDENTICAL to the vision_ladder_criteria rows at ordinals 12-16 (assertRegistryCoherence).
+  { capability: 'Govern-by-exception', layer: 'process',
+    // No KR measures this capability → code_grep the live doctrine-of-constraint trigger fn.
+    probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'database/migrations', pattern: 'enforce_doctrine_of_constraint', builtWhen: 'present' } },
+  { capability: 'Decision Filter Engine', layer: 'process',
+    // No KR measures this → code_grep the decision-filter engine (lib/eva specifically; lib/governance lacks evaluateDecision).
+    probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'lib/eva', pattern: 'evaluateDecision', builtWhen: 'present' } },
+  { capability: 'Governance cascade enforced', layer: 'process',
+    // KR-GOV-3.1 = "Governance cascade layers operational: 6 of 6" — THE cascade KR. Live 2/6 at_risk → partial.
+    // (NOT KR-GOV-2.3 'vision event handlers' just because it is achieved — that would inflate a half-built capability.)
+    probe: { type: 'kr_status', code: 'KR-GOV-3.1' } },
+  { capability: 'OKR-driven prioritization + day-28 hard stop', layer: 'process',
+    // KR-GOV-3.3 = "Monthly OKR automation operational" owns the day-28 hard-stop (desc: "hard-stop SD creation (day 28)").
+    // Live 0/3 at_risk → unbuilt. (NOT KR-GOV-2.2, which covers only the prioritization half — reading it 'built' inflates.)
+    probe: { type: 'kr_status', code: 'KR-GOV-3.3' } },
+  { capability: 'All 7 governance guardrails', layer: 'process',
+    probe: { type: 'kr_status', code: 'KR-GOV-3.2' } }, // KR-GOV-3.2 "Governance guardrails enforced: 7 of 7" achieved 7/7 → built
 ];
 
 /**

--- a/tests/unit/vdr-governance-probes.test.js
+++ b/tests/unit/vdr-governance-probes.test.js
@@ -1,0 +1,202 @@
+/**
+ * SD-LEO-INFRA-V1-GOV-PROBES-001 (FR-3) — adversarial tests for the 5 V1 governance-cluster probes.
+ *
+ * These tests are NOT green-by-construction: each probe is fed DIFFERENT live signals and the
+ * capability score is asserted to CHANGE across built/partial/unbuilt/unknown. They also pin the
+ * registry WIRING (probe.code / probe.path / probe.pattern) so a wrong-KR or wrong-path edit fails,
+ * and they enforce the coherence INVARIANT that the criteria rows (denominator) and VDR_REGISTRY
+ * entries (numerator) must stay 1:1 or the WHOLE gauge withholds (the atomic-PR guard). All IO is
+ * injected — no real DB, FS, or git.
+ */
+import { describe, it, expect } from 'vitest';
+import { VDR_REGISTRY, assertRegistryCoherence, computeBuildGauge } from '../../lib/vision/vdr-registry.js';
+import { runProbe } from '../../lib/vision/vdr-probes.js';
+
+const GOV_CAPS = [
+  'Govern-by-exception',
+  'Decision Filter Engine',
+  'Governance cascade enforced',
+  'OKR-driven prioritization + day-28 hard stop',
+  'All 7 governance guardrails',
+];
+
+/** Find a VDR_REGISTRY entry by its capability label (throws if the wiring is missing). */
+function reg(cap) {
+  const e = VDR_REGISTRY.find((x) => x.capability === cap);
+  if (!e) throw new Error(`no VDR_REGISTRY entry for capability "${cap}"`);
+  return e;
+}
+
+/** Minimal supabase mock for kr_status: from('key_results').select().eq('code',code).maybeSingle(). */
+function krSupabase(rowsByCode) {
+  return {
+    from() {
+      let code = null;
+      const b = {
+        select() { return b; },
+        eq(col, val) { if (col === 'code') code = val; return b; },
+        maybeSingle() { return Promise.resolve({ data: rowsByCode[code] ?? null, error: null }); },
+      };
+      return b;
+    },
+  };
+}
+
+describe('FR-2/FR-3: governance kr_status probes — score tracks the live KR signal', () => {
+  // Each capability is wired to its SEMANTICALLY-CORRECT KR (honest reading), not merely an achieved one:
+  //   guardrails → KR-GOV-3.2 (7/7 achieved → built); cascade → KR-GOV-3.1 (2/6 at_risk → partial live);
+  //   OKR+hard-stop → KR-GOV-3.3 (0/3 at_risk → unbuilt live, owns the day-28 hard-stop).
+  const KR_CAPS = [
+    ['All 7 governance guardrails', 'KR-GOV-3.2'],
+    ['OKR-driven prioritization + day-28 hard stop', 'KR-GOV-3.3'],
+    ['Governance cascade enforced', 'KR-GOV-3.1'],
+  ];
+
+  for (const [cap, code] of KR_CAPS) {
+    it(`${cap} is wired to kr_status ${code} (layer process)`, () => {
+      const e = reg(cap);
+      expect(e.probe.type).toBe('kr_status');
+      expect(e.probe.code).toBe(code);
+      expect(e.layer).toBe('process');
+    });
+
+    it(`${cap} reads built→partial→unbuilt→unknown as the KR signal changes (adversarial)`, async () => {
+      const probe = reg(cap).probe;
+      // BUILT — status achieved (the live state these were chosen for)
+      expect((await runProbe(probe, { supabase: krSupabase({ [code]: { code, status: 'achieved', current_value: 7, target_value: 7 } }) })).status).toBe('built');
+      // PARTIAL — in progress, current>0 but below target and not achieved
+      expect((await runProbe(probe, { supabase: krSupabase({ [code]: { code, status: 'on_track', current_value: 1, target_value: 9 } }) })).status).toBe('partial');
+      // UNBUILT — zero progress
+      expect((await runProbe(probe, { supabase: krSupabase({ [code]: { code, status: 'at_risk', current_value: 0, target_value: 5 } }) })).status).toBe('unbuilt');
+      // UNKNOWN — KR row missing (excluded from denominator, never false-0)
+      expect((await runProbe(probe, { supabase: krSupabase({}) })).status).toBe('unknown');
+      // UNKNOWN — no supabase client
+      expect((await runProbe(probe, {})).status).toBe('unknown');
+    });
+  }
+});
+
+describe('FR-2/FR-3: governance code_grep probes — partial on match, unbuilt on miss, unknown without a seam (never false-built)', () => {
+  const GREP_CAPS = [
+    ['Govern-by-exception', 'database/migrations', 'enforce_doctrine_of_constraint'],
+    ['Decision Filter Engine', 'lib/eva', 'evaluateDecision'],
+  ];
+
+  for (const [cap, expectedPath, expectedPattern] of GREP_CAPS) {
+    it(`${cap} is wired to code_grep ${expectedPath} /${expectedPattern}/ in EHG_Engineer (layer process)`, () => {
+      const e = reg(cap);
+      expect(e.probe.type).toBe('code_grep');
+      expect(e.probe.repo).toBe('EHG_Engineer');
+      expect(e.probe.path).toBe(expectedPath);
+      expect(e.probe.pattern).toBe(expectedPattern);
+      expect(e.probe.builtWhen).toBe('present');
+      expect(e.layer).toBe('process');
+    });
+
+    it(`${cap} reads partial→unbuilt→unknown as the grep signal changes — and is NEVER built`, async () => {
+      const probe = reg(cap).probe;
+      // MATCHED → partial (code presence is intent, not realization — capped, never built)
+      const matched = await runProbe(probe, { grep: () => ({ matched: true, accessible: true }) });
+      expect(matched.status).toBe('partial');
+      expect(matched.status).not.toBe('built');
+      // NO MATCH → unbuilt
+      expect((await runProbe(probe, { grep: () => ({ matched: false, accessible: true }) })).status).toBe('unbuilt');
+      // INACCESSIBLE checkout → unknown (excluded, never guessed)
+      expect((await runProbe(probe, { grep: () => ({ matched: true, accessible: false }) })).status).toBe('unknown');
+      // NO grep seam at all → unknown (the adam-exec-summary email path)
+      expect((await runProbe(probe, {})).status).toBe('unknown');
+    });
+  }
+});
+
+describe('FR-1/FR-3: coherence invariant — criteria rows ↔ VDR_REGISTRY must stay 1:1 (atomic-PR guard)', () => {
+  // The active-rung criteria rows the DB source yields, simulated from the registry labels.
+  const rowsFromRegistry = () => VDR_REGISTRY.map((e) => ({ capability: e.capability, today: '', required: '' }));
+
+  it('all 5 governance capabilities are registered at layer process', () => {
+    for (const cap of GOV_CAPS) {
+      const e = VDR_REGISTRY.find((x) => x.capability === cap);
+      expect(e, `missing registry entry: ${cap}`).toBeTruthy();
+      expect(e.layer).toBe('process');
+    }
+  });
+
+  it('registry has 18 entries (11 original + 2 capability-layer + 5 governance)', () => {
+    expect(VDR_REGISTRY.length).toBe(18);
+  });
+
+  it('a matched criteria set is coherent (ok:true, no missing/stale probes)', () => {
+    const res = assertRegistryCoherence(rowsFromRegistry());
+    expect(res.ok).toBe(true);
+    expect(res.missingProbes).toEqual([]);
+    expect(res.staleProbes).toEqual([]);
+  });
+
+  it('OMITTING a governance criteria row (registry has the probe, vision lacks the row) → staleProbe → NOT coherent', () => {
+    const rows = rowsFromRegistry().filter((r) => r.capability !== 'All 7 governance guardrails');
+    const res = assertRegistryCoherence(rows);
+    expect(res.ok).toBe(false);
+    expect(res.staleProbes).toContain('All 7 governance guardrails');
+  });
+
+  it('a governance criteria row with NO matching probe → missingProbe → NOT coherent', () => {
+    const rows = [...rowsFromRegistry(), { capability: 'Unprobed governance capability', today: '', required: '' }];
+    const res = assertRegistryCoherence(rows);
+    expect(res.ok).toBe(false);
+    expect(res.missingProbes).toContain('Unprobed governance capability');
+  });
+});
+
+describe('FR-3: computeBuildGauge end-to-end — governance contributes, coherence holds, drift withholds', () => {
+  const rows16 = () => VDR_REGISTRY.map((e) => ({ capability: e.capability, today: '', required: '' }));
+
+  /** Mock io: kr 'achieved' only for the listed codes; counts unsupported (→unknown); grep matches. */
+  function gaugeMock({ achievedCodes = [], grepMatched = true } = {}) {
+    const supabase = {
+      from(table) {
+        let code = null;
+        const b = {
+          select() { return b; },
+          eq(col, val) { if (col === 'code') code = val; return b; },
+          maybeSingle() {
+            if (table === 'key_results' && achievedCodes.includes(code)) {
+              return Promise.resolve({ data: { code, status: 'achieved', current_value: 1, target_value: 1 }, error: null });
+            }
+            return Promise.resolve({ data: null, error: null }); // not found → unknown
+          },
+          // db_count / row_predicate await the builder → return an error so they read 'unknown' (excluded)
+          then(resolve) { resolve({ count: null, error: { message: 'mock count unsupported' } }); },
+        };
+        return b;
+      },
+    };
+    return { supabase, grep: () => ({ matched: grepMatched, accessible: true }) };
+  }
+
+  it('with the 16=16 set, the gauge is available + coherent and governance KR caps read built when their KRs are achieved', async () => {
+    // Plumbing test: force all 3 governance KRs achieved to prove the built-path wiring through the gauge.
+    // (Live readings differ honestly — see the per-probe banding tests + the live verification.)
+    const io = gaugeMock({ achievedCodes: ['KR-GOV-3.2', 'KR-GOV-3.3', 'KR-GOV-3.1'], grepMatched: true });
+    const gauge = await computeBuildGauge({ io, visionSource: async () => rows16() });
+    expect(gauge.available).toBe(true);
+    expect(gauge.coherence.ok).toBe(true);
+    expect(gauge.total_capabilities).toBe(18);
+    const byCap = Object.fromEntries(gauge.components.map((c) => [c.capability, c.status]));
+    expect(byCap['All 7 governance guardrails']).toBe('built');
+    expect(byCap['OKR-driven prioritization + day-28 hard stop']).toBe('built');
+    expect(byCap['Governance cascade enforced']).toBe('built');
+    expect(byCap['Govern-by-exception']).toBe('partial');
+    expect(byCap['Decision Filter Engine']).toBe('partial');
+    // governance lives in the 'process' layer breakdown
+    expect(gauge.per_layer.process).not.toBeNull();
+  });
+
+  it('withholds the gauge (available:false, pct null) when a vision criteria has no probe (drift)', async () => {
+    const visionSource = async () => [...rows16(), { capability: 'Phantom gov cap', today: '', required: '' }];
+    const gauge = await computeBuildGauge({ io: gaugeMock(), visionSource });
+    expect(gauge.available).toBe(false);
+    expect(gauge.overall_pct).toBeNull();
+    expect(gauge.coherence.ok).toBe(false);
+    expect(gauge.coherence.missingProbes).toContain('Phantom gov cap');
+  });
+});

--- a/tests/unit/vision/vdr-db-source.test.js
+++ b/tests/unit/vision/vdr-db-source.test.js
@@ -90,7 +90,9 @@ describe('computeBuildGauge visionSource=true (FR-4) — DB denominator, unchang
     expect(g.available).toBe(true);
     expect(g.coherence.ok).toBe(true); // DB labels match VDR_REGISTRY → no drift
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
-    expect(g.unknown_count).toBe(5);
+    // +5 governance probes (SD-LEO-INFRA-V1-GOV-PROBES-001) are unknown under this mock (no KR-GOV rows,
+    // no grep seam): unknown_count = 5 original code_grep + 5 governance = 10. denominator/overall unchanged.
+    expect(g.unknown_count).toBe(10);
     expect(g.denominator).toBe(8); // +2: the capability-layer db_count probes (unbuilt at count 0)
     expect(g.overall_pct).toBe(25); // (1+0.5+0.5+0+0+0+0+0)/8 = 2.0/8 = 25%; identical to the markdown-source path
     expect(g.measured_at_note).toMatch(/DB vision source/);

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -97,7 +97,10 @@ describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', ()
     expect(g.available).toBe(true);
     expect(g.coherence.ok).toBe(true);
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
-    expect(g.unknown_count).toBe(5);
+    // +5 governance probes (SD-LEO-INFRA-V1-GOV-PROBES-001) are all unknown under this mock (no KR-GOV
+    // rows, no grep seam): unknown_count = 5 original code_grep + 5 governance = 10. denominator/overall
+    // UNCHANGED because unknowns are excluded from the denominator (honest gauge).
+    expect(g.unknown_count).toBe(10);
     expect(g.denominator).toBe(8); // +2: the capability-layer db_count probes (unbuilt at count 0)
     // (1 + 0.5 + 0.5 + 0 + 0 + 0 + 0 + 0) / 8 = 2.0/8 = 25%
     expect(g.overall_pct).toBe(25);


### PR DESCRIPTION
## Summary
Teaches the VDR vision build-% gauge to **MEASURE** 5 chairman-ratified V1 **governance** capabilities (ordinals 12-16 on the active V1 rung) — the chairman-weighted dimension the gauge previously omitted, including the highest-weighted *Govern-by-exception*. MEASUREMENT-ONLY: builds no capability.

FR-1 (criteria rows) + FR-2 (registry probes) land **atomically** because `assertRegistryCoherence` withholds the *entire* gauge on any label drift between the `vision_ladder_criteria` rows (denominator) and `VDR_REGISTRY` entries (numerator).

## What changed
- **FR-1** — `database/migrations/20260615_vision_ladder_governance_criteria.sql`: idempotent INSERT of 5 criteria rows (ordinals 12-16) `ON CONFLICT (rung_id, capability)` (the table's only UNIQUE index); non-null `today`/`required`; `DO $verify$` asserts 5 governance rows + `>=16` V1 criteria.
- **FR-2** — 5 `VDR_REGISTRY` entries (layer `process`), each mapped to its **semantically-correct** live signal with its **honest** band:

  | Capability | Probe | Live band |
  |---|---|---|
  | All 7 governance guardrails | `kr_status` KR-GOV-3.2 (7/7) | **built** |
  | Governance cascade enforced | `kr_status` KR-GOV-3.1 (2/6) | **partial** |
  | OKR-driven prioritization + day-28 hard stop | `kr_status` KR-GOV-3.3 (0/3) | **unbuilt** |
  | Govern-by-exception | `code_grep` enforce_doctrine_of_constraint | partial/unknown |
  | Decision Filter Engine | `code_grep` lib/eva evaluateDecision | partial/unknown |

- **FR-3** — `tests/unit/vdr-governance-probes.test.js`: adversarial per-probe tests (score tracks the signal across built/partial/unbuilt/unknown) + coherence/drift test (omit either side → gauge withheld).
- Updated `vdr-registry.test.js` / `vdr-db-source.test.js`: `unknown_count` 5→10 (the 5 governance probes are unknown under the hermetic mocks; denominator/overall unchanged — unknowns excluded).

## Honesty note (anti-honesty-lie doctrine)
Adversarial review caught that the original proposal mapped *cascade* and *OKR* to **achieved-but-semantically-wrong** KRs (KR-GOV-2.3 "vision event handlers", KR-GOV-2.2 "sd:next ranking") — which would have **inflated** half-built capabilities to "built". Re-pointed to the semantically-correct KRs (3.1 cascade-layers, 3.3 monthly-OKR/day-28-hardstop), which honestly read partial/unbuilt. A gauge built to never lie high must report the true state. `code_grep` matches cap at `partial` (never built); no seam → `unknown` (excluded, never false-0).

## Verification
- Live-verified end-to-end: gauge measures 18 capabilities; governance reads built/partial/unbuilt honestly against live KR data.
- 87/87 vdr+vision unit tests pass (0 regressions). Pre-commit gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)