### PR TITLE
feat(SD-LEO-INFRA-ADAM-GAUGE-ESTATE-SOURCING-001): THE SPINE WIRE — gauge as an additional sourcing lens

### DIFF
--- a/lib/adam/gauge-lens.js
+++ b/lib/adam/gauge-lens.js
@@ -1,0 +1,49 @@
+/**
+ * SD-LEO-INFRA-ADAM-GAUGE-ESTATE-SOURCING-001 (FR-1) — the gauge lens read helper.
+ *
+ * Reads the LIVE VDR vision build gauge (lib/vision/vdr-registry.js computeBuildGauge) and
+ * exposes per-capability build% in a shape Adam's sourcing scorer (selectAdvisory's
+ * capabilityGapTerm) can consume. This is the SPINE WIRE's read side — it turns the live
+ * measurement into an ADDITIONAL sourcing lens (lower build% => higher rank), never a primary
+ * anchor.
+ *
+ * HONEST GAUGE (anti-honesty-lie): a capability whose probe is 'unknown' (score null) is
+ * NOT measurable and is EXCLUDED — it must never be treated as build%=0 (which would fabricate
+ * a gap and inflate its rank). FAIL-SOFT: any gauge unavailability returns { available:false,
+ * gaps:{} } so the capability_gap term self-gates to a 1.0 no-op — the sourcing hot path never
+ * throws and never invents a gap.
+ *
+ * NOTE: the named table `vision_build_gauge` does NOT exist (its migration is dormant); this
+ * reads the LIVE compute only. There is no historization/trend (no history table exists).
+ */
+import { computeBuildGauge, STATUS_SCORE } from '../vision/vdr-registry.js';
+
+/**
+ * Read per-capability build% from the live gauge.
+ * @param {object} io - { supabase, grep } injected probe IO (forwarded to computeBuildGauge)
+ * @param {object} [deps] - { computeBuildGauge } injection seam for hermetic unit tests
+ * @returns {Promise<{ available: boolean, gaps: Record<string, number>, overall_pct: number|null }>}
+ *          gaps maps capability label -> build% (0-100; built=100, partial=50, unbuilt=0).
+ *          'unknown' capabilities are excluded (not present in gaps).
+ */
+export async function readCapabilityGaps(io = {}, deps = {}) {
+  const compute = deps.computeBuildGauge || computeBuildGauge;
+  try {
+    const gauge = await compute({ io, visionSource: true });
+    if (!gauge || !gauge.available || !Array.isArray(gauge.components)) {
+      return { available: false, gaps: {}, overall_pct: null };
+    }
+    const gaps = {};
+    for (const c of gauge.components) {
+      // Exclude unknown (score null) — not measurable, never coerce to build%=0 (honest gauge).
+      if (!c || c.score == null) continue;
+      const score = STATUS_SCORE[c.status];
+      if (score == null) continue; // defensive: unknown/invalid status excluded
+      gaps[c.capability] = Math.round(score * 100); // built->100, partial->50, unbuilt->0
+    }
+    return { available: true, gaps, overall_pct: gauge.overall_pct ?? null };
+  } catch {
+    // Fail-soft: the sourcing scorer degrades to a no-op capability_gap term, never throws.
+    return { available: false, gaps: {}, overall_pct: null };
+  }
+}

--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -155,6 +155,46 @@ export function waveAlignmentTerm(candidate, waveAlignment) {
 }
 
 /**
+ * SD-LEO-INFRA-ADAM-GAUGE-ESTATE-SOURCING-001 (FR-2) — THE SPINE WIRE capability_gap term.
+ * The LIVE vision gauge as an ADDITIONAL sourcing lens: a candidate that DECLARES the vision
+ * capability it advances (candidate.capability) is nudged UP when that capability's build% is LOW
+ * (the gauge says it's the weakest) and left untouched when it's already built.
+ *
+ * PURE + self-gating, MIRRORING waveAlignmentTerm: the per-capability build% map is PRE-COMPUTED by
+ * the caller (lib/adam/gauge-lens.js readCapabilityGaps) and injected via opts.capabilityGap. When
+ * no map is provided, the candidate declares no capability, or the capability is not in the map
+ * (e.g. an 'unknown'/unmeasurable capability excluded by FR-1), the term is INACTIVE — multiplier
+ * 1.0, a provable no-op (byte-identical baseline; current production candidates declare no capability).
+ *
+ * CARDINAL INVARIANT: the multiplier is folded into _effective in selectAdvisory, where the
+ * status-tier sort is compared FIRST — so capability_gap can ONLY reorder candidates WITHIN a
+ * status tier; it can NEVER override the KR-status tier (preferences + roadmap stay PRIMARY).
+ * Bound: lower build% => higher multiplier, capped at CLAMP_HI (same bound as preference/wave) so it
+ * can never dominate. built (100%) => 1.0; unbuilt (0%) => CLAMP_HI; partial (50%) => midpoint.
+ *
+ * @param {object} candidate                     carries an optional `capability` (a VDR capability label)
+ * @param {{ gaps?: Record<string, number> }} [capabilityGap]  readCapabilityGaps() result (gaps: cap -> build% 0-100)
+ * @returns {{ active: boolean, multiplier: number, buildPct: number|null }}
+ */
+export function capabilityGapTerm(candidate, capabilityGap) {
+  const gaps = capabilityGap && capabilityGap.gaps;
+  const cap = candidate && candidate.capability;
+  if (!gaps || !cap || !Object.prototype.hasOwnProperty.call(gaps, cap)) {
+    return { active: false, multiplier: 1.0, buildPct: null };
+  }
+  // Defense-in-depth: require a real number. Number(null|''|false) all coerce to 0 (a phantom
+  // max-boost); reject non-numbers so a malformed caller map can never invent a 0% gap.
+  const buildPct = gaps[cap];
+  if (typeof buildPct !== 'number' || !Number.isFinite(buildPct)) {
+    return { active: false, multiplier: 1.0, buildPct: null };
+  }
+  // Lower build% => higher multiplier (bounded by CLAMP_HI). Linear: 100%->1.0, 0%->CLAMP_HI.
+  const frac = Math.max(0, Math.min(1, 1 - buildPct / 100));
+  const multiplier = 1.0 + (CLAMP_HI - 1.0) * frac;
+  return { active: true, multiplier, buildPct };
+}
+
+/**
  * Evaluate a single candidate against the bar.
  * @param {object} candidate
  * @param {object} [opts]
@@ -246,6 +286,8 @@ function candidateClass(c) {
  * @param {Set<string>|Array<string>} [opts.openSdKeys]
  * @param {object} [opts.prefWeights]   class -> bounded weight (from preference-model)
  * @param {object} [opts.waveAlignment] pre-computed calculateAlignment() for LEO_ROADMAP_ID
+ * @param {object} [opts.capabilityGap] FR-2 SPINE WIRE: readCapabilityGaps() result ({gaps: cap->build%});
+ *        an ADDITIONAL intra-tier multiplier (lower build% => higher rank). 1.0 no-op when absent.
  * @returns {{ surfaced: object|null, verdict: 'ADAM_OK'|'SURFACED', cleared: number, evaluated: Array, trace: Array }}
  */
 export function selectAdvisory(candidates, opts = {}) {
@@ -264,11 +306,15 @@ export function selectAdvisory(candidates, opts = {}) {
     const cls = candidateClass(x.candidate);
     const prefW = clamp(prefWeights[cls] ?? 1.0); // bounded; missing -> identity 1.0
     const wave = waveAlignmentTerm(x.candidate, opts.waveAlignment); // 1.0 when inactive
+    const capGap = capabilityGapTerm(x.candidate, opts.capabilityGap); // FR-2: 1.0 when inactive
     x._class = cls;
     x._prefW = prefW;
     x._waveMul = wave.multiplier;
+    x._capGapMul = capGap.multiplier;
     x._tier = statusTierOf(x.candidate); // DOMINANT sort key (CARDINAL INVARIANT)
-    x._effective = (x.score ?? 0) * prefW * wave.multiplier;
+    // FR-2: capability_gap is ANOTHER bounded intra-tier multiplier folded into _effective —
+    // the statusTier sort (below) is compared FIRST, so it can never override KR-status.
+    x._effective = (x.score ?? 0) * prefW * wave.multiplier * capGap.multiplier;
   }
 
   // BASELINE order = OKR-only ordering, statusTier-dominant (raw score, then confidence).
@@ -295,7 +341,7 @@ export function selectAdvisory(candidates, opts = {}) {
   finalOrder.forEach((x, finalRank) => {
     const baseRank = baseRankByCand.get(x.candidate);
     if (baseRank !== finalRank) {
-      const combined = x._prefW * x._waveMul;
+      const combined = x._prefW * x._waveMul * x._capGapMul;
       trace.push({
         base_rank: baseRank,
         final_rank: finalRank,

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -229,6 +229,17 @@ async function main() {
         let waveAlignment = null;
         try { waveAlignment = await calculateAlignment(supabase, LEO_ROADMAP_ID); } catch { waveAlignment = null; }
         selectOpts.waveAlignment = waveAlignment;
+        // SD-LEO-INFRA-ADAM-GAUGE-ESTATE-SOURCING-001 (FR-1/FR-2 SPINE WIRE): the LIVE vision gauge
+        // as an ADDITIONAL intra-tier lens (lower build% => higher rank). Per-candidate no-op until a
+        // candidate DECLARES a `capability`; fail-soft to empty gaps on any gauge unavailability.
+        // The capability_gap multiplier is bounded + folded into _effective, so it NEVER overrides
+        // the KR-status tier (tier compared first). This closes loop piece B (gauge as a lens).
+        let capabilityGap = null;
+        try {
+          const { readCapabilityGaps } = await import('../lib/adam/gauge-lens.js');
+          capabilityGap = await readCapabilityGaps({ supabase });
+        } catch { capabilityGap = null; }
+        selectOpts.capabilityGap = capabilityGap;
       } catch (e) {
         // Fail-soft: drop the perturbation entirely -> byte-identical baseline.
         process.stderr.write(`[adam-scan] preference/wave term skipped (fail-soft): ${e.message}\n`);

--- a/tests/unit/adam/rationale-bar-capability-gap.test.js
+++ b/tests/unit/adam/rationale-bar-capability-gap.test.js
@@ -1,0 +1,175 @@
+/**
+ * SD-LEO-INFRA-ADAM-GAUGE-ESTATE-SOURCING-001 (FR-2/FR-4/FR-5) — THE SPINE WIRE capability_gap term.
+ *
+ * Proves the gauge-as-a-lens is ADDITIVE and TIER-SAFE:
+ *  (a) a low-build% capability raises a candidate's rank WITHIN its status tier, but NEVER overrides
+ *      a higher KR-status-tier item (cross-tier no-inversion),
+ *  (c) toggling the term measurably changes ranking (emits a perturbation trace),
+ *  (d) preferences + roadmap remain the dominant terms (capability_gap is just another bounded
+ *      intra-tier multiplier — the statusTier sort still dominates),
+ *  + a byte-identical no-op baseline when opts.capabilityGap is absent (zero regression),
+ *  + FR-4: candidates still pass through evaluateCandidate -> passesConstSelfCheck (CONST-002),
+ *  + FR-1: readCapabilityGaps excludes 'unknown' and fails soft.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  selectAdvisory,
+  capabilityGapTerm,
+} from '../../../lib/adam/rationale-bar.js';
+import { CLAMP_HI } from '../../../lib/adam/preference-model.js';
+import { readCapabilityGaps } from '../../../lib/adam/gauge-lens.js';
+
+const base = (over = {}) => ({
+  scope_key: 'harness',
+  class: 'default',
+  opportunity: 'op', evidence: 'ev', rationale: 'ra', risk: 'ri', counterfactual: 'cf',
+  objective_kr: { objective: 'O-GOV', kr: 'KR', kr_status: 'on_track', off_track_delta: null },
+  contribution_type: 'enabling', // raw 10 on_track
+  confidence: 0.5,
+  ...over,
+});
+
+describe('FR-2: capabilityGapTerm — pure, self-gating, bounded (mirrors waveAlignmentTerm)', () => {
+  it('1.0 no-op when no data, no candidate.capability, or an unknown/excluded capability', () => {
+    expect(capabilityGapTerm(base({ capability: 'X' }), undefined)).toEqual({ active: false, multiplier: 1.0, buildPct: null });
+    expect(capabilityGapTerm(base(), { gaps: { X: 0 } })).toEqual({ active: false, multiplier: 1.0, buildPct: null }); // candidate has no capability
+    expect(capabilityGapTerm(base({ capability: 'NotMeasured' }), { gaps: { X: 0 } })).toEqual({ active: false, multiplier: 1.0, buildPct: null }); // capability excluded (unknown)
+  });
+
+  it('lower build% => higher multiplier, bounded by CLAMP_HI (built=1.0, unbuilt=CLAMP_HI, partial=midpoint)', () => {
+    const built = capabilityGapTerm(base({ capability: 'C' }), { gaps: { C: 100 } });
+    const partial = capabilityGapTerm(base({ capability: 'C' }), { gaps: { C: 50 } });
+    const unbuilt = capabilityGapTerm(base({ capability: 'C' }), { gaps: { C: 0 } });
+    expect(built.multiplier).toBeCloseTo(1.0, 6);
+    expect(unbuilt.multiplier).toBeCloseTo(CLAMP_HI, 6);
+    expect(partial.multiplier).toBeCloseTo(1.0 + (CLAMP_HI - 1.0) * 0.5, 6);
+    // monotonic: lower build% strictly higher multiplier
+    expect(unbuilt.multiplier).toBeGreaterThan(partial.multiplier);
+    expect(partial.multiplier).toBeGreaterThan(built.multiplier);
+    expect(unbuilt.multiplier).toBeLessThanOrEqual(CLAMP_HI);
+  });
+
+  it('clamps out-of-range build% (>100 => 1.0; <0 => CLAMP_HI) and never exceeds the bound', () => {
+    expect(capabilityGapTerm(base({ capability: 'C' }), { gaps: { C: 200 } }).multiplier).toBeCloseTo(1.0, 6);
+    expect(capabilityGapTerm(base({ capability: 'C' }), { gaps: { C: -50 } }).multiplier).toBeCloseTo(CLAMP_HI, 6);
+  });
+
+  it('defense-in-depth: a non-number gaps value (null/empty/false/NaN) self-gates to 1.0 (NO phantom max-boost)', () => {
+    for (const bad of [null, '', false, NaN, '0', undefined]) {
+      const r = capabilityGapTerm(base({ capability: 'C' }), { gaps: { C: bad } });
+      expect(r.multiplier).toBe(1.0); // never the 1.25 a coerced-to-0 value would produce
+      expect(r.active).toBe(false);
+    }
+  });
+});
+
+describe('FR-5(a/c): low-build% capability raises rank WITHIN a tier + emits a trace', () => {
+  it('a low-build% candidate overtakes a high-build% same-tier candidate when the term is applied', () => {
+    // Two SAME-tier (on_track, tier 2) same-raw (enabling=10) candidates; baseline order breaks on confidence.
+    const lowBuild = base({ class: 'low', dedup_key: 'low', capability: 'Weak cap', confidence: 0.5, objective_kr: { objective: 'O', kr: 'KR-low', kr_status: 'on_track' } });
+    const highBuild = base({ class: 'high', dedup_key: 'high', capability: 'Strong cap', confidence: 0.9, objective_kr: { objective: 'O', kr: 'KR-high', kr_status: 'on_track' } });
+
+    const baseline = selectAdvisory([lowBuild, highBuild], { openSdKeys: new Set() });
+    expect(baseline.surfaced.dedup_key).toBe('high'); // tie on raw -> higher confidence wins
+    expect(baseline.trace).toEqual([]);
+
+    const gapped = selectAdvisory([lowBuild, highBuild], {
+      openSdKeys: new Set(),
+      capabilityGap: { gaps: { 'Weak cap': 0, 'Strong cap': 100 } },
+    });
+    // low: 10 * CLAMP_HI ; high: 10 * 1.0 -> low overtakes (intra-tier nudge).
+    expect(gapped.surfaced.dedup_key).toBe('low');
+    const moved = gapped.trace.find((t) => t.final_rank === 0);
+    expect(moved).toBeDefined();
+    expect(moved.base_rank).not.toBe(moved.final_rank);
+    expect(moved.moved_by_weight).toBe(true);
+    expect(moved.weight).toBeCloseTo(CLAMP_HI, 6);
+  });
+});
+
+describe('FR-5(a/d): cross-tier NO-INVERSION — KR-status tier always dominates capability_gap', () => {
+  it('an on_track UNBUILT-capability candidate NEVER overrides an off_track BUILT-capability item', () => {
+    // on_track + lowest build% (max capability_gap boost) vs off_track + highest build% (no boost).
+    const onTrackWeakCap = base({
+      class: 'on', dedup_key: 'on', capability: 'Weak', confidence: 0.9, contribution_type: 'direct', // raw 15 on_track
+      objective_kr: { objective: 'O', kr: 'KR-on', kr_status: 'on_track' },
+    });
+    const offTrackBuiltCap = base({
+      class: 'off', dedup_key: 'off', capability: 'Strong', confidence: 0.5, contribution_type: 'supporting', // raw 15 off_track
+      objective_kr: { objective: 'O', kr: 'KR-off', kr_status: 'off_track' },
+    });
+    const r = selectAdvisory([onTrackWeakCap, offTrackBuiltCap], {
+      openSdKeys: new Set(),
+      capabilityGap: { gaps: { Weak: 0, Strong: 100 } },
+    });
+    // Even with the on_track candidate getting the MAX capability_gap multiplier and the off_track
+    // one getting 1.0, the off_track (tier 5) candidate still surfaces over on_track (tier 2).
+    expect(r.surfaced.dedup_key).toBe('off');
+  });
+
+  it('the capability_gap term composes with preferences but neither overrides the tier (preferences+roadmap stay dominant)', () => {
+    const onTrack = base({ class: 'on', dedup_key: 'on', capability: 'Weak', objective_kr: { objective: 'O', kr: 'KR-on', kr_status: 'on_track' } });
+    const atRisk = base({ class: 'ar', dedup_key: 'ar', capability: 'Strong', objective_kr: { objective: 'O', kr: 'KR-ar', kr_status: 'at_risk' } });
+    const r = selectAdvisory([onTrack, atRisk], {
+      openSdKeys: new Set(),
+      prefWeights: { on: CLAMP_HI, ar: 1.0 },           // preference favors on_track
+      capabilityGap: { gaps: { Weak: 0, Strong: 100 } }, // capability_gap favors on_track
+    });
+    // Both intra-tier boosts pile onto the on_track candidate, yet at_risk (tier 4) still wins over on_track (tier 2).
+    expect(r.surfaced.dedup_key).toBe('ar');
+  });
+});
+
+describe('FR-5: byte-identical no-op baseline (zero regression when capabilityGap absent)', () => {
+  it('absent capabilityGap yields the same selection + empty trace as the no-opts baseline', () => {
+    const cands = [
+      base({ class: 'a', dedup_key: 'a', capability: 'Weak', objective_kr: { objective: 'O', kr: 'KR-a', kr_status: 'on_track' } }),
+      base({ class: 'b', dedup_key: 'b', capability: 'Strong', confidence: 0.9, objective_kr: { objective: 'O', kr: 'KR-b', kr_status: 'on_track' } }),
+    ];
+    const baseline = selectAdvisory(cands, { openSdKeys: new Set() });
+    const noGap = selectAdvisory(cands, { openSdKeys: new Set() }); // no capabilityGap opt
+    expect(noGap.surfaced.dedup_key).toBe(baseline.surfaced.dedup_key);
+    expect(noGap.trace).toEqual([]);
+    // even when a gauge map is supplied, candidates with capabilities NOT in the map stay no-op
+    const unmatched = selectAdvisory(cands, { openSdKeys: new Set(), capabilityGap: { gaps: { 'Some other cap': 0 } } });
+    expect(unmatched.surfaced.dedup_key).toBe(baseline.surfaced.dedup_key);
+    expect(unmatched.trace).toEqual([]);
+  });
+});
+
+describe('FR-4: CONST-002 preserved through selectAdvisory (capability_gap adds no bypass)', () => {
+  it('an approve-action candidate is rejected even with a capability_gap boost', () => {
+    const violating = base({ class: 'v', dedup_key: 'v', capability: 'Weak', action: 'auto-approve', objective_kr: { objective: 'O', kr: 'KR-v', kr_status: 'on_track' } });
+    const clean = base({ class: 'c', dedup_key: 'c', capability: 'Strong', objective_kr: { objective: 'O', kr: 'KR-c', kr_status: 'on_track' } });
+    const r = selectAdvisory([violating, clean], { openSdKeys: new Set(), capabilityGap: { gaps: { Weak: 0, Strong: 100 } } });
+    // The CONST-violating candidate cannot surface despite the max capability_gap boost.
+    expect(r.surfaced.dedup_key).toBe('c');
+    const ev = r.evaluated.find((e) => e.candidate.dedup_key === 'v');
+    expect(ev.clears).toBe(false);
+    expect(ev.reasons.join(' ')).toMatch(/CONST-002/);
+  });
+});
+
+describe('FR-1: readCapabilityGaps — excludes unknown, maps status->build%, fail-soft', () => {
+  const fakeGauge = (components, available = true, overall_pct = 50) => async () => ({ available, components, overall_pct });
+
+  it('maps built/partial/unbuilt to 100/50/0 and EXCLUDES unknown (never build%=0)', async () => {
+    const components = [
+      { capability: 'Built cap', status: 'built', score: 1 },
+      { capability: 'Partial cap', status: 'partial', score: 0.5 },
+      { capability: 'Unbuilt cap', status: 'unbuilt', score: 0 },
+      { capability: 'Unknown cap', status: 'unknown', score: null },
+    ];
+    const out = await readCapabilityGaps({}, { computeBuildGauge: fakeGauge(components) });
+    expect(out.available).toBe(true);
+    expect(out.gaps).toEqual({ 'Built cap': 100, 'Partial cap': 50, 'Unbuilt cap': 0 });
+    expect(out.gaps).not.toHaveProperty('Unknown cap'); // unknown excluded, NOT coerced to 0
+  });
+
+  it('fails soft to { available:false, gaps:{} } when the gauge is unavailable or throws', async () => {
+    const unavail = await readCapabilityGaps({}, { computeBuildGauge: fakeGauge([], false) });
+    expect(unavail).toEqual({ available: false, gaps: {}, overall_pct: null });
+    const thrown = await readCapabilityGaps({}, { computeBuildGauge: async () => { throw new Error('db down'); } });
+    expect(thrown).toEqual({ available: false, gaps: {}, overall_pct: null });
+  });
+});


### PR DESCRIPTION
## Summary
Wires the **LIVE VDR vision gauge** into Adam's `selectAdvisory` sourcing as an **ADDITIONAL lens** (lower build% ⇒ higher rank) that **never overrides** the primary KR-status tier (preferences + roadmap stay primary). Reverses ANCHORING-001's do-not-couple decision — now meaningful because the gauge measures live (18 capabilities).

## Shipped (re-scoped at LEAD on grounding evidence)
- **FR-1** — `lib/adam/gauge-lens.js` `readCapabilityGaps(io)` over **live** `computeBuildGauge` → `{ capability: build% }` (built=100/partial=50/unbuilt=0). **Excludes `unknown`** (never coerced to 0 — honest gauge); fail-soft `{available:false, gaps:{}}`. (The named `vision_build_gauge` table does not exist; reads live compute only.)
- **FR-2** — `capabilityGapTerm` in `rationale-bar.js` mirroring `waveAlignmentTerm`: pure, self-gating to a **1.0 no-op**, bounded by `CLAMP_HI`. `selectAdvisory` folds it into `_effective` (`score·prefW·waveMul·capGapMul`); the **statusTier sort is compared first** ⇒ it can only reorder *within* a tier, **provably never overriding KR-status**.
- **FR-2 wire** — `scripts/adam-opportunity-scan.cjs` now reads `readCapabilityGaps` and passes `opts.capabilityGap` (behind the same gate flag as prefWeights/waveAlignment, fail-soft) → closes loop piece B and gives `gauge-lens.js` a live importer (no WIRE_CHECK orphan).
- **FR-4** — candidates still flow `selectAdvisory → evaluateCandidate → passesConstSelfCheck` (CONST-002 preserved; no bypass).
- **FR-5 a/c/d** — adversarial tests: cross-tier no-inversion with the lower-tier candidate at **MAX boost**; intra-tier reorder + trace; preferences+roadmap stay dominant; byte-identical no-op baseline; malformed/out-of-range build% self-gates. **131/131 adam unit tests pass (0 regressions).**

## Deferred (durable `metadata.followup_sd`, gated on ESTATE-DISPOSITION-001)
**FR-3 briefEstate + FR-5b** — `conversion_ledger` is empty (0 rows), its populating SD `ESTATE-DISPOSITION-001` is draft/unshipped, and the capability-linkage + compounding-score fields briefEstate must read **do not exist** in any applied/pending migration. Cannot build a reader for non-existent schema. The capability_gap term is per-candidate inert in production until estate candidates (FR-3) declare a `capability` — the spine is wired and ready.

## Safety
Adversarial review found no core bugs; the cardinal invariant (tier-first sort) is airtight, the multiplier is hard-bounded `[1.0, 1.25]`, `unknown` capabilities are excluded, and the no-op baseline is byte-identical. It also caught a dark-seam risk (term with no live caller) → wired into the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)