### PR TITLE
feat(SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001): durable Adam scan trigger + missing-run watchdog

### DIFF
--- a/.github/workflows/adam-opportunity-scan-cron.yml
+++ b/.github/workflows/adam-opportunity-scan-cron.yml
@@ -1,0 +1,63 @@
+name: "Adam opportunity scan (cron)"
+
+# SD: SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 (FR-1)
+#
+# Moves Adam's recurring opportunity-scan/source tick off session-scoped CronCreate (which
+# dies with the session) onto a DURABLE GitHub-Actions schedule, mirroring
+# adam-exec-email-cron.yml. Runs the existing read-only/propose-only `--scan` subcommand via
+# the existing `npm run adam:scan` script (scripts/adam-opportunity-scan.cjs --scan).
+#
+# FAIL-SOFT + PROPOSE-ONLY: the scan is read-only and ships INERT behind
+# ADAM_GOVERNANCE_HEARTBEAT_V1 (default OFF). The scheduled run only does real evaluation when
+# the repo variable ADAM_GOVERNANCE_HEARTBEAT_V1 == 'on' (mirrors the exec-email observe-only
+# bring-up). Candidates still route through selectAdvisory — the scan never auto-creates SDs.
+# The final `|| true` keeps a scan error from hard-failing the scheduled job.
+
+on:
+  schedule:
+    # Hourly (FR-2: matches the exec-email measurement-loop cadence; governance-scan's daily
+    # cadence is too slow). Fires at :37 — a non-:00 minute, offset from the exec-email :17 —
+    # to dodge GitHub Actions' top-of-hour scheduling congestion (queued runs get delayed or
+    # dropped) and to spread fleet cron load. The belt-low coordinator_request event
+    # (coordinator-capacity-forecast.mjs reachAdam, FR-3) is the responsive event-driven
+    # complement to this heartbeat tick.
+    - cron: '37 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  adam-scan:
+    name: Adam opportunity scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # Observe-only until the operator sets repo var ADAM_GOVERNANCE_HEARTBEAT_V1=on.
+      # With it off (default), the scan no-ops cleanly (ships INERT behind the flag).
+      ADAM_GOVERNANCE_HEARTBEAT_V1: ${{ vars.ADAM_GOVERNANCE_HEARTBEAT_V1 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Adam opportunity scan (read-only / propose-only; inert until ADAM_GOVERNANCE_HEARTBEAT_V1=on)
+        run: |
+          echo "Running adam:scan (flag=${ADAM_GOVERNANCE_HEARTBEAT_V1:-off})"
+          npm run adam:scan || true

--- a/lib/fleet/adam-source-watchdog.mjs
+++ b/lib/fleet/adam-source-watchdog.mjs
@@ -1,0 +1,55 @@
+/**
+ * Adam source/gauge missing-run watchdog — SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 (FR-4).
+ *
+ * PURE, no I/O. Catches a DROPPED trigger: when Adam's durable scan tick or the vision-gauge
+ * refresh fails to run, no row is written at all — a hole the HISTORIZE available=false fail-soft
+ * cannot see (it only records when a run actually executes). This watchdog asserts a recent
+ * vision_build_gauge run (and, when its timestamp is provided, a recent Adam source event) and
+ * returns a verdict the exec-summary renders as a degraded line.
+ *
+ * FAIL-SOFT: when the still-chairman-gated vision_build_gauge table is ABSENT, the verdict is
+ * 'unprovisioned' (degrade honestly, never crash or fabricate a hole). The source-event arm is
+ * only evaluated when lastSourceAtMs is actually provided (not undefined), so an unavailable
+ * source signal never raises a false alarm.
+ */
+
+export const GAUGE_MAX_AGE_MS = 90 * 60 * 1000;   // a vision-gauge run is expected within ~90 min
+export const SOURCE_MAX_AGE_MS = 90 * 60 * 1000;  // an Adam source event is expected within its (hourly) window
+
+/**
+ * @param {object} a
+ * @param {boolean} [a.tableProvisioned=true]  false ⇒ vision_build_gauge does not exist yet (gated)
+ * @param {number|null} [a.lastGaugeAtMs]       epoch ms of the latest vision_build_gauge run (null ⇒ none)
+ * @param {number} [a.lastSourceAtMs]           epoch ms of the latest Adam source event; OMIT (undefined) to skip the source arm
+ * @param {number} a.nowMs
+ * @param {number} [a.gaugeMaxAgeMs]
+ * @param {number} [a.sourceMaxAgeMs]
+ * @returns {{verdict:'ok'|'missing'|'unprovisioned', missing:string[], label:string|null}}
+ */
+export function assessAdamSourceWatchdog({
+  tableProvisioned = true,
+  lastGaugeAtMs = null,
+  lastSourceAtMs,
+  nowMs,
+  gaugeMaxAgeMs = GAUGE_MAX_AGE_MS,
+  sourceMaxAgeMs = SOURCE_MAX_AGE_MS,
+} = {}) {
+  if (!tableProvisioned) {
+    return { verdict: 'unprovisioned', missing: [], label: 'vision-gauge watchdog: table not yet provisioned (HISTORIZE migration pending)' };
+  }
+  const missing = [];
+  const gaugeStale = !Number.isFinite(lastGaugeAtMs) || (nowMs - lastGaugeAtMs) > gaugeMaxAgeMs;
+  if (gaugeStale) missing.push('vision_build_gauge');
+
+  // Source arm only when a timestamp was actually provided — an absent signal must not false-alarm.
+  const sourceChecked = lastSourceAtMs !== undefined;
+  const sourceStale = sourceChecked && (!Number.isFinite(lastSourceAtMs) || (nowMs - lastSourceAtMs) > sourceMaxAgeMs);
+  if (sourceStale) missing.push('adam_source_event');
+
+  if (missing.length === 0) return { verdict: 'ok', missing, label: null };
+
+  const parts = [];
+  if (gaugeStale) parts.push(Number.isFinite(lastGaugeAtMs) ? `vision-gauge run ${Math.round((nowMs - lastGaugeAtMs) / 60000)}m stale` : 'no vision-gauge run on record');
+  if (sourceStale) parts.push(Number.isFinite(lastSourceAtMs) ? `Adam source ${Math.round((nowMs - lastSourceAtMs) / 60000)}m stale` : 'no Adam source event in window');
+  return { verdict: 'missing', missing, label: `missing run — ${parts.join('; ')}` };
+}

--- a/lib/fleet/adam-source-watchdog.mjs
+++ b/lib/fleet/adam-source-watchdog.mjs
@@ -34,6 +34,11 @@ export function assessAdamSourceWatchdog({
   gaugeMaxAgeMs = GAUGE_MAX_AGE_MS,
   sourceMaxAgeMs = SOURCE_MAX_AGE_MS,
 } = {}) {
+  // Defensive (shared lib): a non-finite nowMs can't yield a trustworthy staleness verdict —
+  // degrade to 'ok' (never false-alarm the chairman email) rather than emit a garbage line.
+  if (!Number.isFinite(nowMs)) {
+    return { verdict: 'ok', missing: [], label: null };
+  }
   if (!tableProvisioned) {
     return { verdict: 'unprovisioned', missing: [], label: 'vision-gauge watchdog: table not yet provisioned (HISTORIZE migration pending)' };
   }

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -28,6 +28,8 @@ import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-regi
 import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
 // SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001: honest sparse-pulse worker-count source.
 import { resolveWorkerCount, SPARSE_THRESHOLD } from '../lib/fleet/worker-count-source.mjs';
+// SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 (FR-4): missing-run watchdog seam.
+import { assessAdamSourceWatchdog } from '../lib/fleet/adam-source-watchdog.mjs';
 
 const EM = '—';
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -189,12 +191,29 @@ const workerSubj = pulseSource === 'unavailable' ? 'workers n/a' : `${avgActive}
 const actionsSubj = nActions ? `${nActions} ${nActions === 1 ? 'action' : 'actions'} for you` : 'all clear';
 const subject = `[Chairman] ${visSubj} · ${workerSubj} · ${actionsSubj}`;
 
+// FR-4 (SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001): missing-run watchdog. Catches a DROPPED
+// vision-gauge run — no row gets written at all, which the HISTORIZE available=false fail-soft
+// cannot see (it only records when a run actually executes). FAIL-SOFT throughout: the still-gated
+// vision_build_gauge table being ABSENT yields 'unprovisioned' (no line), any query error yields no
+// line, and only a genuine MISSING run renders a degraded line — the watchdog never blocks the email.
+let watchdogLine = null;
+try {
+  const { data: lastGauge, error: gErr } = await db.from('vision_build_gauge').select('measured_at').order('measured_at', { ascending: false }).limit(1);
+  const tableProvisioned = !(gErr && /relation|does not exist|find the table|schema cache/i.test(gErr.message || ''));
+  const lastGaugeAtMs = (!gErr && lastGauge && lastGauge[0] && lastGauge[0].measured_at) ? new Date(lastGauge[0].measured_at).getTime() : null;
+  // Source arm omitted (lastSourceAtMs undefined) until a durable DB Adam-source-event signal is defined,
+  // so an unavailable source signal cannot false-alarm; the pure seam supports it and is unit-tested.
+  const wd = assessAdamSourceWatchdog({ tableProvisioned, lastGaugeAtMs, nowMs: t });
+  if (wd.verdict === 'missing' && wd.label) watchdogLine = 'Watchdog: ' + wd.label;
+} catch { /* fail-soft: the watchdog never blocks the email */ }
+
 const text = [
   `Workers: ${workerText}`,
   '',
   visPct != null ? `EHG vision: ${visPct}% built` : 'EHG vision: (gauge unavailable)',
   ...(layerLine ? ['   ' + layerLine] : []),
   ...(visNote ? ['   ' + visNote] : []),
+  ...(watchdogLine ? ['   ' + watchdogLine] : []),
   ...(quitLine ? ['', quitLine] : []),
   ...(decisionsLine ? [decisionsLine] : []),
   '',
@@ -217,7 +236,9 @@ const actionsHtml = nActions
 const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
   `<p style="font-size:15px;margin:0 0 12px"><b>Workers:</b> ${esc(workerText)}</p>` +
   `<p style="font-size:15px;font-weight:600;margin:0 0 0">EHG vision: ${visPct != null ? visPct + '% built' : '(gauge unavailable)'}</p>` +
-  layerHtml + noteHtml + quitHtml + decisionsHtml +
+  layerHtml + noteHtml +
+  (watchdogLine ? `<div style="font-size:12px;color:#b54708;margin:2px 0 0">${esc(watchdogLine)}</div>` : '') +
+  quitHtml + decisionsHtml +
   '<hr style="border:none;border-top:1px solid #e1e4e8;margin:14px 0">' +
   actionsHtml +
   `<p style="font-size:11px;color:#999;margin:14px 0 0">as of ${esc(when)} ET ${EM} Adam ${EM} LEO Fleet Advisor</p></div>`;

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -218,7 +218,10 @@ async function reachAdam(f) {
     `[COORD->ADAM] PREDICTIVE belt-low (capacity forecaster). Verdict=${f.verdict}.`,
     `Belt=${f.beltDepth} claimable vs demand(soon)=${f.demandSoon} (idle ${f.idleNow} + freeing-soon ${f.freeingSoon}) → short by ${f.deficit}.`,
     `Claimable now: ${f.claimable.map(d => d.sd_key.replace('SD-LEO-INFRA-', '')).join(', ') || 'NONE'}. Idle/at-risk workers: ${idleList}.`,
-    `Per protocol I'm reaching out BEFORE the belt empties. Please propose a shortlist of CONFLICT-FREE, non-gated, draft-ready SD candidates (groom harness backlog + cross-program), propose-only; I'll dispatch. Dedup vs in-flight + SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001.`,
+    // SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 (FR-3): retarget the belt-low ask at the
+    // VISION-ALIGNED weakest capabilities (read the per-capability gauge + mine the dispositioned
+    // estate) instead of generic harness-backlog grooming.
+    `Per protocol I'm reaching out BEFORE the belt empties. Please READ the per-capability vision gauge + MINE the dispositioned estate for the WEAKEST capabilities, then propose a shortlist of CONFLICT-FREE, non-gated, draft-ready SD candidates that move those weakest capabilities forward (NOT generic harness-backlog grooming), propose-only; I'll dispatch. Dedup vs in-flight + SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001.`,
     `Reply via adam-advisory (correlation ${correlation_id}).`,
   ].join('\n');
   const res = await insertCoordinationRow(sb, {

--- a/tests/unit/adam-durable-source-trigger.test.js
+++ b/tests/unit/adam-durable-source-trigger.test.js
@@ -65,6 +65,11 @@ describe('assessAdamSourceWatchdog (SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001
     expect(r.verdict).toBe('ok');
   });
 
+  it('defensive: a non-finite nowMs degrades to ok (never false-alarms the chairman email)', () => {
+    expect(assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(999), nowMs: NaN }).verdict).toBe('ok');
+    expect(assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(999) }).verdict).toBe('ok'); // nowMs undefined
+  });
+
   it('defensive: empty args do not throw', () => {
     expect(() => assessAdamSourceWatchdog({ nowMs: NOW })).not.toThrow();
     // no gauge timestamp + provisioned default true → missing (no run on record)

--- a/tests/unit/adam-durable-source-trigger.test.js
+++ b/tests/unit/adam-durable-source-trigger.test.js
@@ -1,0 +1,73 @@
+/**
+ * Adam durable-source-trigger watchdog tests — SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 (FR-5).
+ * Pure, no I/O. Pins the watchdog verdicts (ok / missing / unprovisioned) + the no-false-alarm
+ * contract for the source arm.
+ */
+import { describe, it, expect } from 'vitest';
+import { assessAdamSourceWatchdog, GAUGE_MAX_AGE_MS } from '../../lib/fleet/adam-source-watchdog.mjs';
+
+const NOW = 1_700_000_000_000;
+const minsAgo = (m) => NOW - m * 60_000;
+
+describe('assessAdamSourceWatchdog (SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001)', () => {
+  it('FAIL-SOFT: absent gated table → unprovisioned, no crash, honest label', () => {
+    const r = assessAdamSourceWatchdog({ tableProvisioned: false, nowMs: NOW });
+    expect(r.verdict).toBe('unprovisioned');
+    expect(r.missing).toEqual([]);
+    expect(r.label).toMatch(/not yet provisioned/i);
+  });
+
+  it('a fresh gauge run (within 90m) and no source arm → ok (no degraded line)', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(20), nowMs: NOW });
+    expect(r.verdict).toBe('ok');
+    expect(r.label).toBeNull();
+  });
+
+  it('a STALE gauge run (>90m) → missing, label names the stale gauge', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(120), nowMs: NOW });
+    expect(r.verdict).toBe('missing');
+    expect(r.missing).toContain('vision_build_gauge');
+    expect(r.label).toMatch(/vision-gauge run \d+m stale/);
+  });
+
+  it('table provisioned but NO gauge run on record → missing (the dropped-trigger hole)', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: null, nowMs: NOW });
+    expect(r.verdict).toBe('missing');
+    expect(r.label).toMatch(/no vision-gauge run on record/);
+  });
+
+  it('NO false alarm: the source arm is skipped when lastSourceAtMs is undefined', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(10), nowMs: NOW }); // no lastSourceAtMs
+    expect(r.verdict).toBe('ok');
+    expect(r.missing).not.toContain('adam_source_event');
+  });
+
+  it('source arm: a stale Adam source event (provided) → missing names the source event', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(10), lastSourceAtMs: minsAgo(200), nowMs: NOW });
+    expect(r.verdict).toBe('missing');
+    expect(r.missing).toContain('adam_source_event');
+    expect(r.label).toMatch(/Adam source \d+m stale/);
+  });
+
+  it('source arm: a fresh source event + fresh gauge → ok', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(10), lastSourceAtMs: minsAgo(10), nowMs: NOW });
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('both stale → missing lists both runs', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: minsAgo(200), lastSourceAtMs: minsAgo(200), nowMs: NOW });
+    expect(r.verdict).toBe('missing');
+    expect(r.missing).toEqual(expect.arrayContaining(['vision_build_gauge', 'adam_source_event']));
+  });
+
+  it('boundary: a gauge run exactly at the max age is still ok (not stale)', () => {
+    const r = assessAdamSourceWatchdog({ lastGaugeAtMs: NOW - GAUGE_MAX_AGE_MS, nowMs: NOW });
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('defensive: empty args do not throw', () => {
+    expect(() => assessAdamSourceWatchdog({ nowMs: NOW })).not.toThrow();
+    // no gauge timestamp + provisioned default true → missing (no run on record)
+    expect(assessAdamSourceWatchdog({ nowMs: NOW }).verdict).toBe('missing');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 — durable Adam scan trigger + missing-run watchdog

**Problem.** Adam's recurring opportunity-scan/source tick ran only off session-scoped `CronCreate`, so it died with the session — a durability hole in the proactive sourcing loop.

### FR-1 — durable GitHub-Action
NEW `.github/workflows/adam-opportunity-scan-cron.yml` mirroring `adam-exec-email-cron.yml`: hourly (`37 * * * *`, offset from exec-email `:17` to dodge top-of-hour GH-Actions congestion), **fail-soft** (`npm run adam:scan || true`), gated by `ADAM_GOVERNANCE_HEARTBEAT_V1` via a repo var (observe-only until set). **Reuses** the existing `adam:scan` script (compose-not-greenfield). Passes `check:workflow-yaml` (all 101 workflows parse).

### FR-2 — cadence
Hourly heartbeat (matches the exec-email measurement loop) + the belt-low `coordinator_request` event (FR-3) as the event-driven complement. Documented inline.

### FR-3 — retarget the belt-low ask
`coordinator-capacity-forecast.mjs` `reachAdam` now routes Adam to **read the per-capability vision gauge + mine the dispositioned estate for the weakest capabilities**, not generic "groom harness backlog". Propose-only contract unchanged.

### FR-4 — missing-run watchdog (fail-soft)
NEW pure `lib/fleet/adam-source-watchdog.mjs` (`assessAdamSourceWatchdog`) wired into `adam-exec-summary.mjs`. Catches a **dropped** vision-gauge run — *no row written at all*, which HISTORIZE's `available=false` (records only when a run executes) structurally cannot see. **Fail-soft:** the still-chairman-gated `vision_build_gauge` table being absent → `unprovisioned` (no line, no crash); the source arm is skipped unless a timestamp is provided (no false alarm); the watchdog **never blocks the email**.

### FR-5 — tests
11 pure unit tests (ok/missing/unprovisioned verdicts, no-false-alarm, boundary, defensive).

### Verification & review
11/11 tests; new workflow YAML-valid; 3 scripts syntax-clean. **Adversarial review found no HIGH/MED defects** and verified the FR-4 fail-soft chain end-to-end against the live prod DB (table absent → no watchdog line → no false-alarm; flag gating env-off-short-circuits). Added a defensive `nowMs` guard (review L1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
