### PR TITLE
feat(SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001): VDR gauge — 3 consolidation probes + count_ratio runner

### DIFF
--- a/database/migrations/20260615_vision_ladder_consolidation_criteria.sql
+++ b/database/migrations/20260615_vision_ladder_consolidation_criteria.sql
@@ -1,0 +1,88 @@
+-- 20260615_vision_ladder_consolidation_criteria.sql
+-- SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001 (FR-1 + FR-4): seed the 3 chairman-ratified V1
+-- CONSOLIDATION-cluster criteria rows (ordinals 23-25) into the EXISTING vision_ladder_criteria table
+-- for the active V1 rung, and record the 2 always-on operating invariants as text-only rung metadata.
+--
+-- DATA-ROWS-ONLY (additive): no new tables, no new columns, no DDL — this only INSERTs 3 consolidation
+-- criteria rows + writes a jsonb key into the EXISTING vision_ladder_rungs.metadata. Sorts AFTER
+-- 20260615_vision_ladder_active_pointer.sql (which created the table + seeded ordinals 1-11) by filename.
+--
+-- COHERENCE INVARIANT (assertRegistryCoherence): these 3 capability labels are BYTE-IDENTICAL to the 3
+-- VDR_REGISTRY entries added in lib/vision/vdr-registry.js in the SAME PR. The DB rows (denominator) and
+-- the code probes (numerator) MUST land together — a label drift drives coherence.ok=false and the WHOLE
+-- gauge withholds (available:false). Land FR-1 (this file) and FR-3 (registry code) ATOMICALLY.
+--
+-- HONEST-GAUGE NOTE: this supplies only the DENOMINATOR (which capabilities count). The NUMERATOR is the
+-- live typed probes (FR-3): count_ratio on sd_backlog_map (~13/145 ≈ 9% → partial), db_count on
+-- ehg_page_routes (>=6 → built), db_count on competitive_baselines (>=1 → built). today/required below are
+-- DESCRIPTIVE chairman-ladder metadata only — NOT used to credit 'built' (presence != realized).
+--
+-- FR-4: the 2 always-on operating PROPERTIES are recorded as text in metadata->'operating_invariants' —
+-- they are NOT criteria rows and have NO probe (adding a probe would make coherence demand a criteria/
+-- registry pair and withhold). They do not affect the gauge denominator or coherence.
+--
+-- IDEMPOTENT: ON CONFLICT (rung_id, capability) DO NOTHING for the rows; jsonb_set for the invariants is
+-- naturally idempotent (same value each apply). (rung_id, capability) is the table's ONLY UNIQUE
+-- constraint; (rung_id, ordinal) is a plain non-unique index and must NOT be a conflict target.
+--
+-- CHAIRMAN-GATED: NO -- @approved-by line. Ships dormant; until the chairman applies it the gauge
+-- WITHHOLDS the 3 new capabilities (registry present, criteria absent → staleProbes) — by design.
+
+BEGIN;
+
+INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability, today, required)
+SELECT r.id, c.ordinal, c.capability, c.today, c.required
+FROM vision_ladder_rungs r
+CROSS JOIN (VALUES
+  (23, 'Backlog distilled and dispositioned',              'backlog distillation begun (~13/145 items dispositioned/COMPLETED); conversion-ledger integration not yet started', 'the backlog is fully distilled and each item dispositioned (build/research/reference/cancel) or integrated'),
+  (24, 'Application presentation-surface consolidation',   'a bounded canonical surface set exists (8 feature-area-mapped authenticated routes)',                                 'all application presentation surfaces consolidated into the canonical surface set'),
+  (25, 'Competitive vigilance process established',        'competitive vigilance process running (competitive_baselines populated)',                                            'a recurring competitive-vigilance process is established (and exercised)')
+) AS c(ordinal, capability, today, required)
+WHERE r.rung_key = 'V1'
+ON CONFLICT (rung_id, capability) DO NOTHING;
+
+-- FR-4: 2 text-only operating invariants on the V1 rung metadata (no probe, no criteria row).
+UPDATE vision_ladder_rungs
+SET metadata = jsonb_set(
+      COALESCE(metadata, '{}'::jsonb),
+      '{operating_invariants}',
+      '["Compute is not a constraint", "Governance-only app / no data-entry GUI"]'::jsonb,
+      true)
+WHERE rung_key = 'V1';
+
+-- In-DB self-verification: prove the 3 consolidation rows landed, V1 has >=14 criteria, and the 2
+-- operating invariants are recorded.
+DO $verify$
+DECLARE
+  cons_count integer;
+  inv_count  integer;
+BEGIN
+  SELECT count(*) INTO cons_count
+    FROM vision_ladder_criteria c JOIN vision_ladder_rungs r ON r.id = c.rung_id
+   WHERE r.rung_key = 'V1'
+     AND c.capability IN (
+       'Backlog distilled and dispositioned',
+       'Application presentation-surface consolidation',
+       'Competitive vigilance process established');
+  IF cons_count <> 3 THEN
+    RAISE EXCEPTION 'vision ladder consolidation: expected 3 consolidation criteria, found %', cons_count;
+  END IF;
+
+  SELECT jsonb_array_length(metadata->'operating_invariants') INTO inv_count
+    FROM vision_ladder_rungs WHERE rung_key = 'V1';
+  IF inv_count IS NULL OR inv_count <> 2 THEN
+    RAISE EXCEPTION 'vision ladder consolidation: expected 2 operating_invariants, found %', inv_count;
+  END IF;
+END
+$verify$;
+
+COMMIT;
+
+-- ROLLBACK (reverse): remove ONLY the 3 consolidation rows + the operating_invariants key:
+--   DELETE FROM vision_ladder_criteria c USING vision_ladder_rungs r
+--    WHERE c.rung_id = r.id AND r.rung_key = 'V1'
+--      AND c.capability IN (
+--        'Backlog distilled and dispositioned',
+--        'Application presentation-surface consolidation',
+--        'Competitive vigilance process established');
+--   UPDATE vision_ladder_rungs SET metadata = metadata - 'operating_invariants' WHERE rung_key = 'V1';

--- a/database/migrations/20260615_vision_ladder_consolidation_criteria.sql
+++ b/database/migrations/20260615_vision_ladder_consolidation_criteria.sql
@@ -34,9 +34,9 @@ INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability, today, require
 SELECT r.id, c.ordinal, c.capability, c.today, c.required
 FROM vision_ladder_rungs r
 CROSS JOIN (VALUES
-  (23, 'Backlog distilled and dispositioned',              'backlog distillation begun (~13/145 items dispositioned/COMPLETED); conversion-ledger integration not yet started', 'the backlog is fully distilled and each item dispositioned (build/research/reference/cancel) or integrated'),
-  (24, 'Application presentation-surface consolidation',   'a bounded canonical surface set exists (8 feature-area-mapped authenticated routes)',                                 'all application presentation surfaces consolidated into the canonical surface set'),
-  (25, 'Competitive vigilance process established',        'competitive vigilance process running (competitive_baselines populated)',                                            'a recurring competitive-vigilance process is established (and exercised)')
+  (23, 'Backlog distilled and dispositioned',              'backlog distillation begun (~13/145 items COMPLETED — a strict lower-bound proxy for dispositioned; no separate disposition column yet); conversion-ledger integration not yet started', 'the backlog is fully distilled and each item dispositioned (build/research/reference/cancel) or integrated'),
+  (24, 'Application presentation-surface consolidation',   'all 8 presentation routes are mapped to canonical feature areas (orphan-free); surface-count reduction not separately measured',                                          'all application presentation surfaces consolidated into the canonical surface set'),
+  (25, 'Competitive vigilance process established',        'only placeholder STATUS_QUO/ASSUMPTION baselines exist (stale); no OBSERVED competitor baselines yet — process not yet established',                                      'a recurring competitive-vigilance process is established (and exercised) producing OBSERVED baselines')
 ) AS c(ordinal, capability, today, required)
 WHERE r.rung_key = 'V1'
 ON CONFLICT (rung_id, capability) DO NOTHING;

--- a/lib/vision/vdr-probes.js
+++ b/lib/vision/vdr-probes.js
@@ -119,11 +119,59 @@ export async function codeGrepProbe(def, io) {
   }
 }
 
+/**
+ * count_ratio: ratio = COUNT(table + numerFilter) / COUNT(table + denomFilter). The existing runners
+ * cannot express a ratio (db_count is a single threshold). Honest banding (anti-inflation):
+ *   ratio >= def.builtAt  ⇒ built;  0 < ratio < builtAt ⇒ partial;  ratio == 0 (or denom == 0) ⇒ unbuilt;
+ *   no supabase / count error / throw ⇒ unknown (NEVER fabricated).
+ * Filters (numerFilter / denomFilter, both optional ⇒ all rows) accept, per column:
+ *   - scalar value          → .eq(col, v)
+ *   - array of values       → .in(col, v)   (e.g. "dispositioned+integrated" statuses in ONE count)
+ *   - { not: null }         → .not(col, 'is', null)
+ * SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001 (FR-2).
+ */
+export async function countRatioProbe(def, io) {
+  const supabase = io && io.supabase;
+  if (!supabase) return { status: 'unknown', value: null, detail: 'no supabase client' };
+  const applyFilter = (q, filter) => {
+    if (filter && typeof filter === 'object') {
+      for (const [k, v] of Object.entries(filter)) {
+        if (Array.isArray(v)) q = q.in(k, v);
+        else if (v && typeof v === 'object' && 'not' in v && v.not === null) q = q.not(k, 'is', null);
+        else q = q.eq(k, v);
+      }
+    }
+    return q;
+  };
+  const countWith = async (filter) => {
+    let q = supabase.from(def.table).select('*', { count: 'exact', head: true });
+    q = applyFilter(q, filter);
+    const { count, error } = await q;
+    if (error) throw new Error(error.message);
+    return Number(count) || 0;
+  };
+  try {
+    const denom = await countWith(def.denomFilter);
+    if (denom === 0) return { status: 'unbuilt', value: 0, detail: `${def.table} denominator=0` };
+    const numer = await countWith(def.numerFilter);
+    const ratio = numer / denom;
+    const builtAt = Number.isFinite(def.builtAt) ? def.builtAt : 0.5;
+    let status;
+    if (ratio >= builtAt) status = 'built';
+    else if (ratio > 0) status = 'partial';
+    else status = 'unbuilt';
+    return { status, value: ratio, detail: `${def.table} ${numer}/${denom}=${(ratio * 100).toFixed(0)}% (built when >=${(builtAt * 100).toFixed(0)}%; partial when >0)` };
+  } catch (e) {
+    return { status: 'unknown', value: null, detail: `count_ratio threw: ${e.message}` };
+  }
+}
+
 export const PROBE_RUNNERS = {
   kr_status: krStatusProbe,
   db_count: dbCountProbe,
   row_predicate: rowPredicateProbe,
   code_grep: codeGrepProbe,
+  count_ratio: countRatioProbe,
 };
 
 /** Run one probe def by type. Unknown type ⇒ 'unknown' (never fabricated). */

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -151,15 +151,18 @@ export const VDR_REGISTRY = [
     // 'integrated' feeder (empty today); add it to numerFilter when populated. builtAt 0.7 = mostly-dispositioned.
     probe: { type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: 'COMPLETED' }, builtAt: 0.7 } },
   { capability: 'Application presentation-surface consolidation', layer: 'application',
-    // db_count (chosen to avoid any cross-repo grep / UI trigger word): the consolidated canonical
-    // surface set is registered in ehg_page_routes. Live 8 routes, all feature-area-mapped & authenticated
-    // (/chairman, /ventures, /analytics, /reports/builder, /automation, /eva …) → a bounded canonical set
-    // exists. min 6 = the canonical-surface floor (chairman-confirmable); >=6 ⇒ built, 1..5 partial, 0 unbuilt.
-    probe: { type: 'db_count', table: 'ehg_page_routes', min: 6, builtWhen: 'gte' } },
+    // count_ratio = routes mapped to a canonical feature_area / total routes. (Review finding: a raw
+    // gte-count is BACKWARDS for "consolidation" — more routes != more consolidated. A presence count
+    // would lie-high.) This measures canonical ORGANIZATION (orphan-free): builtAt 1.0 ⇒ built ONLY at
+    // 100% mapped; any orphan/unmapped route drops it to partial. Live 8/8 mapped → built. DB-signal only.
+    // NOTE: measures orphan-free canonical organization, NOT surface-count REDUCTION — chairman-refinable.
+    probe: { type: 'count_ratio', table: 'ehg_page_routes', numerFilter: { feature_area_id: { not: null } }, builtAt: 1.0 } },
   { capability: 'Competitive vigilance process established', layer: 'process',
-    // db_count: the bar is ESTABLISH-the-process, not full exercise. >=1 competitive_baselines row ⇒ the
-    // vigilance process is running (live 4) → built; 0 ⇒ unbuilt. (No 'partial' band needed at min 1.)
-    probe: { type: 'db_count', table: 'competitive_baselines', min: 1, builtWhen: 'gte' } },
+    // db_count of OBSERVED competitor baselines only. (Review finding: the 4 live competitive_baselines
+    // rows are ALL STATUS_QUO / epistemic_tag='ASSUMPTION' placeholder seeds, stale 2+ weeks — NOT a
+    // running vigilance process, so a raw count>=1 would lie-high.) Filtering to epistemic_tag='OBSERVED'
+    // ⇒ live count 0 → unbuilt (honest: process not yet established); >=1 real observed baseline ⇒ built.
+    probe: { type: 'db_count', table: 'competitive_baselines', filter: { epistemic_tag: 'OBSERVED' }, min: 1, builtWhen: 'gte' } },
 ];
 
 /**

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -141,6 +141,25 @@ export const VDR_REGISTRY = [
     probe: { type: 'kr_status', code: 'KR-GOV-3.3' } },
   { capability: 'All 7 governance guardrails', layer: 'process',
     probe: { type: 'kr_status', code: 'KR-GOV-3.2' } }, // KR-GOV-3.2 "Governance guardrails enforced: 7 of 7" achieved 7/7 → built
+  // ── SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001: 3 V1 CONSOLIDATION-cluster capabilities (ordinals
+  // 23-25). Labels are BYTE-IDENTICAL to the vision_ladder_criteria rows (the coherence invariant
+  // withholds the whole gauge if they drift). DB-signal probes only (no cross-repo grep). Honest
+  // banding: a stray/seed row never credits 'built'.
+  { capability: 'Backlog distilled and dispositioned', layer: 'process',
+    // count_ratio: dispositioned (completion_status=COMPLETED) / total backlog items. Live ~13/145 ≈ 9%
+    // → partial (matches reality: distillation begun, not complete). conversion_ledger is the future
+    // 'integrated' feeder (empty today); add it to numerFilter when populated. builtAt 0.7 = mostly-dispositioned.
+    probe: { type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: 'COMPLETED' }, builtAt: 0.7 } },
+  { capability: 'Application presentation-surface consolidation', layer: 'application',
+    // db_count (chosen to avoid any cross-repo grep / UI trigger word): the consolidated canonical
+    // surface set is registered in ehg_page_routes. Live 8 routes, all feature-area-mapped & authenticated
+    // (/chairman, /ventures, /analytics, /reports/builder, /automation, /eva …) → a bounded canonical set
+    // exists. min 6 = the canonical-surface floor (chairman-confirmable); >=6 ⇒ built, 1..5 partial, 0 unbuilt.
+    probe: { type: 'db_count', table: 'ehg_page_routes', min: 6, builtWhen: 'gte' } },
+  { capability: 'Competitive vigilance process established', layer: 'process',
+    // db_count: the bar is ESTABLISH-the-process, not full exercise. >=1 competitive_baselines row ⇒ the
+    // vigilance process is running (live 4) → built; 0 ⇒ unbuilt. (No 'partial' band needed at min 1.)
+    probe: { type: 'db_count', table: 'competitive_baselines', min: 1, builtWhen: 'gte' } },
 ];
 
 /**

--- a/tests/unit/vdr-governance-probes.test.js
+++ b/tests/unit/vdr-governance-probes.test.js
@@ -121,8 +121,8 @@ describe('FR-1/FR-3: coherence invariant — criteria rows ↔ VDR_REGISTRY must
     }
   });
 
-  it('registry has 18 entries (11 original + 2 capability-layer + 5 governance)', () => {
-    expect(VDR_REGISTRY.length).toBe(18);
+  it('registry has 21 entries (11 original + 2 capability-layer + 5 governance + 3 consolidation)', () => {
+    expect(VDR_REGISTRY.length).toBe(21);
   });
 
   it('a matched criteria set is coherent (ok:true, no missing/stale probes)', () => {
@@ -180,7 +180,7 @@ describe('FR-3: computeBuildGauge end-to-end — governance contributes, coheren
     const gauge = await computeBuildGauge({ io, visionSource: async () => rows16() });
     expect(gauge.available).toBe(true);
     expect(gauge.coherence.ok).toBe(true);
-    expect(gauge.total_capabilities).toBe(18);
+    expect(gauge.total_capabilities).toBe(21); // +3 consolidation probes (SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001)
     const byCap = Object.fromEntries(gauge.components.map((c) => [c.capability, c.status]));
     expect(byCap['All 7 governance guardrails']).toBe('built');
     expect(byCap['OKR-driven prioritization + day-28 hard stop']).toBe('built');

--- a/tests/unit/vdr-governance-probes.test.js
+++ b/tests/unit/vdr-governance-probes.test.js
@@ -121,8 +121,8 @@ describe('FR-1/FR-3: coherence invariant — criteria rows ↔ VDR_REGISTRY must
     }
   });
 
-  it('registry has 21 entries (11 original + 2 capability-layer + 5 governance + 3 consolidation)', () => {
-    expect(VDR_REGISTRY.length).toBe(21);
+  it('registry has 25 entries (11 original + 4 automation + 2 capability-layer + 5 governance + 3 consolidation)', () => {
+    expect(VDR_REGISTRY.length).toBe(25);
   });
 
   it('a matched criteria set is coherent (ok:true, no missing/stale probes)', () => {
@@ -180,7 +180,7 @@ describe('FR-3: computeBuildGauge end-to-end — governance contributes, coheren
     const gauge = await computeBuildGauge({ io, visionSource: async () => rows16() });
     expect(gauge.available).toBe(true);
     expect(gauge.coherence.ok).toBe(true);
-    expect(gauge.total_capabilities).toBe(21); // +3 consolidation probes (SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001)
+    expect(gauge.total_capabilities).toBe(25); // +4 automation +3 consolidation since the 18-entry baseline
     const byCap = Object.fromEntries(gauge.components.map((c) => [c.capability, c.status]));
     expect(byCap['All 7 governance guardrails']).toBe('built');
     expect(byCap['OKR-driven prioritization + day-28 hard stop']).toBe('built');

--- a/tests/unit/vision/vdr-consolidation-probes.test.js
+++ b/tests/unit/vision/vdr-consolidation-probes.test.js
@@ -1,0 +1,174 @@
+// SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001 (FR-5) — adversarial band-movement + coherence tests for the
+// 3 consolidation-cluster probes (Backlog distilled, Presentation-surface consolidation, Competitive
+// vigilance) and the new count_ratio runner. Hermetic: injected supabase seam, no live DB, no grep.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { assertRegistryCoherence, computeBuildGauge, VDR_REGISTRY } from '../../../lib/vision/vdr-registry.js';
+import { runProbe, countRatioProbe, PROBE_RUNNERS } from '../../../lib/vision/vdr-probes.js';
+
+const BACKLOG = 'Backlog distilled and dispositioned';
+const SURFACE = 'Application presentation-surface consolidation';
+const VIGILANCE = 'Competitive vigilance process established';
+const CONSOLIDATION_LABELS = [BACKLOG, SURFACE, VIGILANCE];
+
+const entryFor = (cap) => VDR_REGISTRY.find((e) => e.capability === cap);
+
+// db_count stub (same shape as vdr-caplayer-probes.test.js): any count/head query on `table` resolves to count.
+function stubSupabase({ countByTable = {} } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        in() { return chain; },
+        not() { return chain; },
+        then(res, rej) { return Promise.resolve({ count: countByTable[table] ?? 0, error: null }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+// count_ratio stub: returns `numer` once any filter (.eq/.in/.not) is applied, else `denom`.
+// count_ratio queries the denominator (no filter) first, then the numerator (filtered).
+function stubRatio({ denom, numer, error = null }) {
+  return {
+    from() {
+      let filtered = false;
+      const chain = {
+        select() { return chain; },
+        eq() { filtered = true; return chain; },
+        in() { filtered = true; return chain; },
+        not() { filtered = true; return chain; },
+        then(res, rej) { return Promise.resolve({ count: filtered ? numer : denom, error }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+function visionFixture(labels = VDR_REGISTRY.map((e) => e.capability)) {
+  const rows = labels.map((l) => `| **${l}** | today cell | required cell |`).join('\n');
+  return ['## CAPABILITY GAP — at-a-glance table', '', '| Vision capability | TODAY | REQUIRED |', '|---|---|---|', rows, '', '## NEXT', 'excluded'].join('\n');
+}
+
+describe('FR-2: count_ratio is a registered runner with honest bands + fail-open', () => {
+  it('is registered in PROBE_RUNNERS', () => {
+    expect(PROBE_RUNNERS.count_ratio).toBe(countRatioProbe);
+  });
+  it('bands: ratio>=builtAt→built, 0<ratio<builtAt→partial, 0→unbuilt, denom==0→unbuilt', async () => {
+    const def = { type: 'count_ratio', table: 't', numerFilter: { s: 'x' }, builtAt: 0.7 };
+    const run = (denom, numer) => runProbe(def, { supabase: stubRatio({ denom, numer }) });
+    expect((await run(145, 0)).status).toBe('unbuilt');     // 0%
+    expect((await run(145, 13)).status).toBe('partial');    // 9% (the live backlog reality)
+    expect((await run(100, 69)).status).toBe('partial');    // 69% < 70%
+    expect((await run(100, 70)).status).toBe('built');      // 70% == builtAt
+    expect((await run(100, 100)).status).toBe('built');     // 100%
+    expect((await run(0, 0)).status).toBe('unbuilt');       // denom==0 → unbuilt, never divide-by-zero
+  });
+  it('fail-open: no supabase → unknown; count error → unknown (never fabricated)', async () => {
+    expect((await countRatioProbe({ table: 't' }, {})).status).toBe('unknown');
+    expect((await countRatioProbe({ table: 't' }, { supabase: stubRatio({ denom: 10, numer: 5, error: { message: 'boom' } }) })).status).toBe('unknown');
+  });
+  it('numerFilter as an array drives an .in() numerator (dispositioned+integrated in one count)', async () => {
+    const def = { type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: ['COMPLETED', 'INTEGRATED'] }, builtAt: 0.7 };
+    const r = await runProbe(def, { supabase: stubRatio({ denom: 145, numer: 13 }) });
+    expect(r.status).toBe('partial');
+    expect(r.value).toBeCloseTo(13 / 145, 5);
+  });
+});
+
+describe('FR-3: the 3 consolidation entries are registered with the honest shape', () => {
+  it('Backlog → count_ratio on sd_backlog_map (numerator completion_status=COMPLETED), layer process', () => {
+    const e = entryFor(BACKLOG);
+    expect(e).toBeTruthy();
+    expect(e.layer).toBe('process');
+    expect(e.probe).toMatchObject({ type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: 'COMPLETED' } });
+    expect(e.probe.builtAt).toBeGreaterThan(0.5); // not gamed to today's 9%
+  });
+  it('Surface → db_count on ehg_page_routes min 6, layer application', () => {
+    const e = entryFor(SURFACE);
+    expect(e.layer).toBe('application');
+    expect(e.probe).toMatchObject({ type: 'db_count', table: 'ehg_page_routes', min: 6, builtWhen: 'gte' });
+  });
+  it('Vigilance → db_count on competitive_baselines min 1, layer process', () => {
+    const e = entryFor(VIGILANCE);
+    expect(e.layer).toBe('process');
+    expect(e.probe).toMatchObject({ type: 'db_count', table: 'competitive_baselines', min: 1, builtWhen: 'gte' });
+  });
+});
+
+describe('FR-3 adversarial: each band MOVES with the signal (not green-by-construction)', () => {
+  it('Backlog count_ratio: 0→unbuilt, 13/145→partial, 102/145→built', async () => {
+    const probe = entryFor(BACKLOG).probe; // builtAt 0.7
+    const run = (denom, numer) => runProbe(probe, { supabase: stubRatio({ denom, numer }) });
+    expect((await run(145, 0)).status).toBe('unbuilt');
+    expect((await run(145, 13)).status).toBe('partial');   // the live ~9%
+    expect((await run(145, 102)).status).toBe('built');    // ~70%
+  });
+  it('Surface db_count: 0→unbuilt, 5→partial, 8(live)→built', async () => {
+    const probe = entryFor(SURFACE).probe;
+    const run = (n) => runProbe(probe, { supabase: stubSupabase({ countByTable: { ehg_page_routes: n } }) });
+    expect((await run(0)).status).toBe('unbuilt');
+    expect((await run(5)).status).toBe('partial');
+    expect((await run(8)).status).toBe('built'); // live count
+  });
+  it('Vigilance db_count: 0→unbuilt, 4(live)→built', async () => {
+    const probe = entryFor(VIGILANCE).probe;
+    const run = (n) => runProbe(probe, { supabase: stubSupabase({ countByTable: { competitive_baselines: n } }) });
+    expect((await run(0)).status).toBe('unbuilt');
+    expect((await run(4)).status).toBe('built'); // live count
+  });
+});
+
+describe('FR-5 coherence: criteria↔probe lockstep withholds the WHOLE gauge on drift', () => {
+  it('matched → coherence ok, gauge available, the 3 components probed', async () => {
+    const io = { supabase: stubSupabase({ countByTable: { sd_backlog_map: 145, ehg_page_routes: 8, competitive_baselines: 4 } }) };
+    const g = await computeBuildGauge({ io, visionMarkdown: visionFixture() });
+    expect(g.coherence.ok).toBe(true);
+    expect(g.available).toBe(true);
+    for (const cap of CONSOLIDATION_LABELS) {
+      const c = g.components.find((x) => x.capability === cap);
+      expect(c, `component ${cap}`).toBeTruthy();
+      expect(['built', 'partial', 'unbuilt']).toContain(c.status); // probed (not unmapped/unknown)
+    }
+  });
+  it('probe-without-criterion (criteria migration not yet applied) → staleProbes → gauge withholds', async () => {
+    const labelsMinusBacklog = VDR_REGISTRY.map((e) => e.capability).filter((c) => c !== BACKLOG);
+    const g = await computeBuildGauge({ io: { supabase: stubSupabase({}) }, visionMarkdown: visionFixture(labelsMinusBacklog) });
+    expect(g.coherence.ok).toBe(false);
+    expect(g.coherence.staleProbes).toContain(BACKLOG);
+    expect(g.available).toBe(false);
+  });
+  it('assertRegistryCoherence: all 3 consolidation labels are matched by the registry', () => {
+    const r = assertRegistryCoherence(VDR_REGISTRY.map((e) => ({ capability: e.capability })));
+    expect(r.ok).toBe(true);
+    expect(r.missingProbes).toEqual([]);
+    expect(r.staleProbes).toEqual([]);
+  });
+});
+
+// Source-of-truth byte-identity (the HIGH-risk axis): the migration's criteria labels and the
+// VDR_REGISTRY probe labels must be byte-identical, or the live gauge withholds forever.
+describe('FR-1/FR-3 byte-identity: migration criteria labels == VDR_REGISTRY labels', () => {
+  const migrationSql = readFileSync(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../database/migrations/20260615_vision_ladder_consolidation_criteria.sql'),
+    'utf8',
+  );
+  it('each canonical label appears verbatim in the migration AND has a VDR_REGISTRY probe', () => {
+    const registered = new Set(VDR_REGISTRY.map((e) => e.capability));
+    for (const label of CONSOLIDATION_LABELS) {
+      expect(migrationSql.includes(label), `migration contains "${label}"`).toBe(true);
+      expect(registered.has(label), `registry has "${label}"`).toBe(true);
+    }
+  });
+  it('the migration writes the 2 operating invariants and is chairman-gated (no @approved-by)', () => {
+    expect(migrationSql).toContain('operating_invariants');
+    expect(migrationSql).toContain('Compute is not a constraint');
+    expect(migrationSql).toContain('Governance-only app / no data-entry GUI');
+    expect(migrationSql).not.toMatch(/@approved-by\s*[=:]/); // chairman-gated: no actual attestation value (the header may mention the term)
+    expect(migrationSql).toContain('ON CONFLICT (rung_id, capability) DO NOTHING'); // idempotent
+  });
+});

--- a/tests/unit/vision/vdr-consolidation-probes.test.js
+++ b/tests/unit/vision/vdr-consolidation-probes.test.js
@@ -88,15 +88,17 @@ describe('FR-3: the 3 consolidation entries are registered with the honest shape
     expect(e.probe).toMatchObject({ type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: 'COMPLETED' } });
     expect(e.probe.builtAt).toBeGreaterThan(0.5); // not gamed to today's 9%
   });
-  it('Surface → db_count on ehg_page_routes min 6, layer application', () => {
+  it('Surface → count_ratio on ehg_page_routes (mapped feature_area / total), layer application, builtAt 1.0', () => {
     const e = entryFor(SURFACE);
     expect(e.layer).toBe('application');
-    expect(e.probe).toMatchObject({ type: 'db_count', table: 'ehg_page_routes', min: 6, builtWhen: 'gte' });
+    // count_ratio (orphan-free organization), NOT a backwards gte presence-count.
+    expect(e.probe).toMatchObject({ type: 'count_ratio', table: 'ehg_page_routes', numerFilter: { feature_area_id: { not: null } }, builtAt: 1.0 });
   });
-  it('Vigilance → db_count on competitive_baselines min 1, layer process', () => {
+  it('Vigilance → db_count on competitive_baselines (OBSERVED only) min 1, layer process', () => {
     const e = entryFor(VIGILANCE);
     expect(e.layer).toBe('process');
-    expect(e.probe).toMatchObject({ type: 'db_count', table: 'competitive_baselines', min: 1, builtWhen: 'gte' });
+    // OBSERVED filter excludes STATUS_QUO/ASSUMPTION seed rows (anti-lie-high).
+    expect(e.probe).toMatchObject({ type: 'db_count', table: 'competitive_baselines', filter: { epistemic_tag: 'OBSERVED' }, min: 1, builtWhen: 'gte' });
   });
 });
 
@@ -108,18 +110,18 @@ describe('FR-3 adversarial: each band MOVES with the signal (not green-by-constr
     expect((await run(145, 13)).status).toBe('partial');   // the live ~9%
     expect((await run(145, 102)).status).toBe('built');    // ~70%
   });
-  it('Surface db_count: 0→unbuilt, 5→partial, 8(live)→built', async () => {
-    const probe = entryFor(SURFACE).probe;
-    const run = (n) => runProbe(probe, { supabase: stubSupabase({ countByTable: { ehg_page_routes: n } }) });
-    expect((await run(0)).status).toBe('unbuilt');
-    expect((await run(5)).status).toBe('partial');
-    expect((await run(8)).status).toBe('built'); // live count
+  it('Surface count_ratio (mapped/total): orphans→partial, all-mapped(8/8 live)→built', async () => {
+    const probe = entryFor(SURFACE).probe; // builtAt 1.0
+    const run = (denom, numer) => runProbe(probe, { supabase: stubRatio({ denom, numer }) });
+    expect((await run(8, 0)).status).toBe('unbuilt');  // 0 mapped
+    expect((await run(8, 7)).status).toBe('partial');  // 1 orphan route → not fully consolidated
+    expect((await run(8, 8)).status).toBe('built');    // all mapped (the live state)
   });
-  it('Vigilance db_count: 0→unbuilt, 4(live)→built', async () => {
+  it('Vigilance db_count(OBSERVED): 0→unbuilt (live: only ASSUMPTION seeds), 1→built', async () => {
     const probe = entryFor(VIGILANCE).probe;
     const run = (n) => runProbe(probe, { supabase: stubSupabase({ countByTable: { competitive_baselines: n } }) });
-    expect((await run(0)).status).toBe('unbuilt');
-    expect((await run(4)).status).toBe('built'); // live count
+    expect((await run(0)).status).toBe('unbuilt'); // 0 OBSERVED → process not established (honest live read)
+    expect((await run(1)).status).toBe('built');   // >=1 real observed baseline → established
   });
 });
 

--- a/tests/unit/vision/vdr-db-source.test.js
+++ b/tests/unit/vision/vdr-db-source.test.js
@@ -90,11 +90,12 @@ describe('computeBuildGauge visionSource=true (FR-4) — DB denominator, unchang
     expect(g.available).toBe(true);
     expect(g.coherence.ok).toBe(true); // DB labels match VDR_REGISTRY → no drift
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
-    // unknown_count = 5 original code_grep + 5 governance + 4 automation/intelligence (ordinals 17-20) = 14.
-    // All code_grep with no seam (or KR-GOV rows absent) in this stub → 'unknown'; denominator/overall unchanged.
+    // unknown_count = 5 original code_grep + 5 governance + 4 automation/intelligence (ordinals 17-20) = 14,
+    // all 'unknown' (no seam / KR-GOV rows in this stub) → excluded. The +3 consolidation probes are unbuilt
+    // at count 0 → they enter the denominator (8 → 11).
     expect(g.unknown_count).toBe(14);
-    expect(g.denominator).toBe(8); // +2: the capability-layer db_count probes (unbuilt at count 0)
-    expect(g.overall_pct).toBe(25); // (1+0.5+0.5+0+0+0+0+0)/8 = 2.0/8 = 25%; identical to the markdown-source path
+    expect(g.denominator).toBe(11); // 8 + 3 consolidation probes (unbuilt at count 0)
+    expect(g.overall_pct).toBe(18); // (1+0.5+0.5+0×8)/11 = 2.0/11 = 18%; identical to the markdown-source path
     expect(g.measured_at_note).toMatch(/DB vision source/);
   });
 

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -97,15 +97,16 @@ describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', ()
     expect(g.available).toBe(true);
     expect(g.coherence.ok).toBe(true);
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
-    // unknown_count = 5 original code_grep + 5 governance (SD-LEO-INFRA-V1-GOV-PROBES-001) + 4
-    // automation/intelligence (SD-LEO-INFRA-V1-AUTOMATION-PROBES-001, ordinals 17-20) = 14. All are
-    // code_grep with no seam (or KR-GOV rows absent) in this stub → 'unknown', so denominator/overall
-    // are UNCHANGED (honest gauge: unknowns excluded from the denominator).
+    // unknown_count = 5 original code_grep + 5 governance (V1-GOV-PROBES) + 4 automation/intelligence
+    // (V1-AUTOMATION-PROBES, ordinals 17-20) = 14, all 'unknown' (no seam / KR-GOV rows in this stub) →
+    // EXCLUDED. The +3 consolidation probes (V1-CONSOLIDATION-PROBES) are unbuilt at count 0, so they
+    // ENTER the denominator (8 → 11).
     expect(g.unknown_count).toBe(14);
-    expect(g.denominator).toBe(8); // +2: the capability-layer db_count probes (unbuilt at count 0)
-    // (1 + 0.5 + 0.5 + 0 + 0 + 0 + 0 + 0) / 8 = 2.0/8 = 25%
-    expect(g.overall_pct).toBe(25);
+    expect(g.denominator).toBe(11); // 8 + 3 consolidation probes (unbuilt at count 0)
+    // numerator unchanged (1 + 0.5 + 0.5 + 0×8) = 2.0; 2.0/11 = 18%
+    expect(g.overall_pct).toBe(18);
     // infrastructure scored = survivability(0.5) + Capability Registry(0) + Expertise on-demand(0) = 0.5/3 = 17%
+    // application/process gain consolidation probes that are all 0 → those layer %s stay 0 (numerator 0).
     expect(g.per_layer).toMatchObject({ venture: 75, infrastructure: 17, application: 0, process: 0 });
     for (const c of g.components) expect(STATUS_SCORE).toHaveProperty(c.status);
   });


### PR DESCRIPTION
## SD-LEO-INFRA-V1-CONSOLIDATION-PROBES-001 — VDR gauge: 3 consolidation probes + count_ratio runner

Teaches the chairman-visible VDR vision gauge to MEASURE 3 chairman-ratified V1 consolidation capabilities, and adds the one new probe-runner shape they need. **Criteria rows + registry entries ship together and land atomically, or the gauge withholds** (the coherence invariant).

### What ships (5 FRs)
- **FR-2** `lib/vision/vdr-probes.js` — NEW `countRatioProbe` (`numer/denom` ratio; `.in`/`.eq`/not-null filters; honest bands `built`/`partial`/`unbuilt`; fail-open `unknown`) registered in `PROBE_RUNNERS` (the existing runners can't express a ratio).
- **FR-3** `lib/vision/vdr-registry.js` — 3 entries, capabilities byte-identical to the criteria rows:
  - *Backlog distilled and dispositioned* → `count_ratio` on `sd_backlog_map` (COMPLETED/total ≈ 13/145 → **partial**)
  - *Application presentation-surface consolidation* → `count_ratio` on `ehg_page_routes` (routes mapped to a canonical feature_area / total, builtAt 1.0 → orphan-free **built**)
  - *Competitive vigilance process established* → `db_count` on `competitive_baselines` (OBSERVED only, min 1)
- **FR-1 + FR-4** `database/migrations/20260615_vision_ladder_consolidation_criteria.sql` — **chairman-gated**, idempotent: 3 `vision_ladder_criteria` rows (ordinals 23-25, `ON CONFLICT rung_id+capability`) + 2 text-only `operating_invariants` in `vision_ladder_rungs.metadata`; in-migration `DO $verify$`; **no `@approved-by`** (dormant until the chairman applies — the gauge withholds the 3 until then, by design).
- **FR-5** `tests/unit/vision/vdr-consolidation-probes.test.js` — adversarial band-movement + coherence + migration byte-identity (15 tests).

### Adversarial review — caught + fixed the VDR lie-high class
- **HIGH (fixed):** the surface probe shipped as `db_count gte`, which is **backwards** for "consolidation" (more routes ≠ more consolidated → credited `built` for the wrong reason). Replaced with `count_ratio` (orphan-free mapped/total, built only at 100%).
- **MEDIUM (fixed):** the vigilance probe credited `built` off 4 stale `STATUS_QUO`/`ASSUMPTION` seed rows; filtered to `epistemic_tag='OBSERVED'` → live 0 → honest `unbuilt`.
- **MEDIUM (flagged):** backlog `COMPLETED` is a strict *under*-crediting proxy for "dispositioned" (no disposition column live) — honest direction; documented.
- Review **PASS** on `count_ratio` correctness, the atomic-or-withhold coherence, migration safety/idempotency, and the ripple arithmetic.

### Compose-not-greenfield + ripple
Mirrored the sibling V1-GOV-PROBES / V1-CAPLAYER-PROBES migration + test patterns. Expanding `VDR_REGISTRY` 18→21 legitimately shifted 3 sibling gauge-math tests (denominator 8→11, overall_pct 25→18) — updated with verified arithmetic (numerator 2.0 unchanged; 2.0/11 = 18%).

### Verification
- **69 gauge tests green** (5 files). TESTING sub-agent PASS. EXEC-TO-PLAN 93 · retro q90 · PLAN-TO-LEAD 94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
