### PR TITLE
feat(SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001): scoped, fail-closed, audited, revocable Adam DB-apply delegation

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: fe705ac3a65b4368 -->
+<!-- file_content_hash: 4d259dd92e60dfbd -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-16 10:27:01 PM
+**Generated**: 2026-06-16 11:05:28 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -149,6 +149,26 @@ Sourcing is not finished when a candidate clears the bar — it is finished when
 ## Adam Self-Adherence Loop (SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001)
 
 Adam runs a 4th recurring tick (self-adherence, every 6h: node scripts/adam-self-adherence-review.mjs) that audits Adam's OWN role-contract adherence. Pure role-derived probes (lib/adam/adherence-probes.js: sourcing-cadence, vision-monitoring, friction-signaling, propose-only/never-build) emit pass|fail|unknown — FAIL-LOUD: an un-runnable probe is unknown, NEVER a silent pass. Each verdict is written (one row per probe per run) to the adam_adherence_ledger table. On drift (any fail) the loop SOURCES a propose-only remediation — a feedback flag (category=adam_adherence_drift) for the coordinator to triage into a gap-closing SD — and NEVER builds the fix itself (CONST-002). This is the self-improving governance loop: Adam's own adherence is measured and remediated, not assumed.
+
+## Chairman-Delegated DB-Change APPLY Authority (scoped, apply-only, fail-closed, revocable)
+
+## Chairman-Delegated DB-Change APPLY Authority (SCOPED, APPLY-ONLY, REVOCABLE)
+
+The chairman delegated to Adam (2026-06-16; durable: chairman_decisions b917c3e1 + SD metadata.chairman_authorization) the authority to APPLY a SCOPED set of PRODUCTION database changes, so additive vision-loop work no longer dead-ends at the chairman. Enforced in CODE, not conversational interpretation.
+
+**APPLY-ONLY — NOT a build right.** Strictly a database-APPLY authority. CONST-002 is UNCHANGED: Adam still never holds a BUILD claim, never drives/claims an SD, and proposes all work. The delegated-apply path does not touch claim acquisition (lib/claim/build-forbidden-session.cjs / the claim-validity gate).
+
+**In scope (delegatable):** provably-additive DDL (CREATE TABLE/INDEX, add nullable column, CHECK-widen) AND governed data-row INSERTs into allow-listed governed tables.
+
+**CHAIRMAN-ONLY (fail-closed, never delegatable):** destructive changes (DROP / rename / SET NOT NULL / DELETE / UPDATE / TRUNCATE) AND any permission / access-control / data-access-policy change (GRANT/REVOKE, CREATE/ALTER/DROP POLICY, ENABLE/DISABLE RLS) — these stay on the chairman 3-factor --prod-deploy gate.
+
+**Enforcement (code, not prose):** lib/migration/adam-delegated-apply.js isDelegatableForApply (a STRICT SUBSET of the additive tier-classifier that EXCLUDES create_policy/enable_rls tokens) + the bounded classifyGovernedInsert; gated by scripts/lib/migration-guards.js validateDelegatedApplyGuards. A forgeable "-- @delegated-by: adam" line is ONLY a routing marker — the REAL authority is a valid delegation TOKEN (the same crypto-token factor the chairman path uses). Default-deny on any error/ambiguity.
+
+**Kill-switch (revocable, default-OFF):** disabled unless LEO_ADAM_DBAPPLY_DELEGATION === "on" (fail-closed: unset/typo/error => disabled => chairman gate). The chairman can instantly revoke by unsetting it.
+
+**Audited:** every delegated-apply attempt (applied / rejected / error) is recorded in adam_delegated_apply_ledger (who/what/when/approval-basis/verdict).
+
+**How to apply a delegatable change:** add "-- @delegated-by: adam" to the migration; run node scripts/apply-migration.js <path> --prod-deploy with a valid MIGRATION_APPLY_TOKEN and the kill-switch on. Non-delegatable changes are rejected to the chairman path.
 
 ---
 

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T02:27:01.050Z -->
-<!-- git_commit: 0e0c4847 -->
-<!-- db_snapshot_hash: 5d958fb45bf60028 -->
-<!-- file_content_hash: 2d6c601b79509314 -->
+<!-- generated_at: 2026-06-16T03:05:27.477Z -->
+<!-- git_commit: 7690b69d -->
+<!-- db_snapshot_hash: 7f0504975a9426f6 -->
+<!-- file_content_hash: 4e0cf66e527c042d -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 
@@ -61,6 +61,26 @@ Every SD Adam sources is created through ONE canonical path. NEVER hand-insert i
 - `strategic_objectives`: array of `{objective, metric}` — supply **2+** (the `sd-objectives-validator` handoff gate scores 2+ as full marks, 1 as a warning, 0 as an issue; the create-time defaults may emit plain strings, while the `--from-plan` parser emits `{objective, metr
 
 *...truncated. Read full file for complete section.*
+
+## Chairman-Delegated DB-Change APPLY Authority (scoped, apply-only, fail-closed, revocable)
+
+## Chairman-Delegated DB-Change APPLY Authority (SCOPED, APPLY-ONLY, REVOCABLE)
+
+The chairman delegated to Adam (2026-06-16; durable: chairman_decisions b917c3e1 + SD metadata.chairman_authorization) the authority to APPLY a SCOPED set of PRODUCTION database changes, so additive vision-loop work no longer dead-ends at the chairman. Enforced in CODE, not conversational interpretation.
+
+**APPLY-ONLY — NOT a build right.** Strictly a database-APPLY authority. CONST-002 is UNCHANGED: Adam still never holds a BUILD claim, never drives/claims an SD, and proposes all work. The delegated-apply path does not touch claim acquisition (lib/claim/build-forbidden-session.cjs / the claim-validity gate).
+
+**In scope (delegatable):** provably-additive DDL (CREATE TABLE/INDEX, add nullable column, CHECK-widen) AND governed data-row INSERTs into allow-listed governed tables.
+
+**CHAIRMAN-ONLY (fail-closed, never delegatable):** destructive changes (DROP / rename / SET NOT NULL / DELETE / UPDATE / TRUNCATE) AND any permission / access-control / data-access-policy change (GRANT/REVOKE, CREATE/ALTER/DROP POLICY, ENABLE/DISABLE RLS) — these stay on the chairman 3-factor --prod-deploy gate.
+
+**Enforcement (code, not prose):** lib/migration/adam-delegated-apply.js isDelegatableForApply (a STRICT SUBSET of the additive tier-classifier that EXCLUDES create_policy/enable_rls tokens) + the bounded classifyGovernedInsert; gated by scripts/lib/migration-guards.js validateDelegatedApplyGuards. A forgeable "-- @delegated-by: adam" line is ONLY a routing marker — the REAL authority is a valid delegation TOKEN (the same crypto-token factor the chairman path uses). Default-deny on any error/ambiguity.
+
+**Kill-switch (revocable, default-OFF):** disabled unless LEO_ADAM_DBAPPLY_DELEGATION === "on" (fail-closed: unset/typo/error => disabled => chairman gate). The chairman can instantly revoke by unsetting it.
+
+**Audited:** every delegated-apply attempt (applied / rejected / error) is recorded in adam_delegated_apply_ledger (who/what/when/approval-basis/verdict).
+
+**How to apply a delegatable change:** add "-- @delegated-by: adam" to the migration; run node scripts/apply-migration.js <path> --prod-deploy with a valid MIGRATION_APPLY_TOKEN and the kill-switch on. Non-delegatable changes are rejected to the chairman path.
 
 ---
 *Adam is NOT a worker and NOT the coordinator. Full contract in CLAUDE_ADAM.md.*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,95 +1,25 @@
 {
-  "generated_at": "2026-06-16T02:27:01.050Z",
-  "git_commit": "0e0c4847",
-  "db_snapshot_hash": "5d958fb45bf60028",
+  "generated_at": "2026-06-16T03:05:27.477Z",
+  "git_commit": "7690b69d",
+  "db_snapshot_hash": "7f0504975a9426f6",
   "files": {
-    "CLAUDE.md": {
-      "type": "full",
-      "chars": 19369,
-      "estimated_tokens": 4843,
-      "content_hash": "ac4d80b4fca34a4e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE.md"
-    },
-    "CLAUDE_CORE.md": {
-      "type": "full",
-      "chars": 83528,
-      "estimated_tokens": 20882,
-      "content_hash": "bd12f4b2a2614293",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_CORE.md"
-    },
-    "CLAUDE_LEAD.md": {
-      "type": "full",
-      "chars": 65129,
-      "estimated_tokens": 16283,
-      "content_hash": "3d462284b49a23a7",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_LEAD.md"
-    },
-    "CLAUDE_PLAN.md": {
-      "type": "full",
-      "chars": 90831,
-      "estimated_tokens": 22708,
-      "content_hash": "d210e822483ba9f8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_PLAN.md"
-    },
-    "CLAUDE_EXEC.md": {
-      "type": "full",
-      "chars": 84822,
-      "estimated_tokens": 21206,
-      "content_hash": "0dc1cd0f0abcefdc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_EXEC.md"
-    },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 33764,
-      "estimated_tokens": 8441,
-      "content_hash": "bd9daf1a022cb26d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_ADAM.md"
-    },
-    "CLAUDE_DIGEST.md": {
-      "type": "digest",
-      "chars": 9612,
-      "estimated_tokens": 2403,
-      "content_hash": "bb3d24fc80aaa69c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_DIGEST.md"
-    },
-    "CLAUDE_CORE_DIGEST.md": {
-      "type": "digest",
-      "chars": 11536,
-      "estimated_tokens": 2884,
-      "content_hash": "7d8130541fb4a950",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_CORE_DIGEST.md"
-    },
-    "CLAUDE_LEAD_DIGEST.md": {
-      "type": "digest",
-      "chars": 5423,
-      "estimated_tokens": 1356,
-      "content_hash": "054536e48b2fb492",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_LEAD_DIGEST.md"
-    },
-    "CLAUDE_PLAN_DIGEST.md": {
-      "type": "digest",
-      "chars": 8413,
-      "estimated_tokens": 2104,
-      "content_hash": "95e5aaaa7e313a9f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_PLAN_DIGEST.md"
-    },
-    "CLAUDE_EXEC_DIGEST.md": {
-      "type": "digest",
-      "chars": 10836,
-      "estimated_tokens": 2709,
-      "content_hash": "a5023c48f888fa39",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_EXEC_DIGEST.md"
+      "chars": 36180,
+      "estimated_tokens": 9045,
+      "content_hash": "6f255e8b7f483433",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
-      "chars": 6928,
-      "estimated_tokens": 1732,
-      "content_hash": "04ff87f29d8658f9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-VISION-GAUGE-HISTORIZE-001\\CLAUDE_ADAM_DIGEST.md"
+      "chars": 9344,
+      "estimated_tokens": 2336,
+      "content_hash": "29bb5f53c445599c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001\\CLAUDE_ADAM_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "be14b9a0856d7108",
+    "global": "fb40765324e4ba9e",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -347,7 +277,8 @@
       "602": "ad0aecae8cdc6cb3",
       "603": "ca922c736e8d8ed3",
       "604": "bb29fe0a029f8d7e",
-      "605": "98f34c97e157d332"
+      "605": "98f34c97e157d332",
+      "606": "25aa68b575c66d07"
     },
     "meta": {
       "94": {
@@ -1634,6 +1565,11 @@
         "section_type": "coordinator_role_contract",
         "target_file": "CLAUDE_COORDINATOR.md",
         "title": "Coordinator Role Contract — Fleet Supervisor / SRE Session"
+      },
+      "606": {
+        "section_type": "adam_role_contract",
+        "target_file": "CLAUDE_ADAM.md",
+        "title": "Chairman-Delegated DB-Change APPLY Authority (scoped, apply-only, fail-closed, revocable)"
       }
     }
   }

--- a/database/migrations/20260616_adam_delegated_apply_ledger.sql
+++ b/database/migrations/20260616_adam_delegated_apply_ledger.sql
@@ -1,0 +1,46 @@
+-- 20260616_adam_delegated_apply_ledger.sql
+-- SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001 (FR-4): the audit ledger for Adam delegated DB applies.
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- CHAIRMAN-BOOTSTRAP (NOT self-applyable by the delegation): this migration ENABLEs RLS + CREATEs a
+-- POLICY — exactly the data-access-policy class the delegation reserves as CHAIRMAN-ONLY (fail-closed).
+-- So the ledger's own table is created via the chairman 3-factor --prod-deploy path, BEFORE the
+-- delegation kill-switch (LEO_ADAM_DBAPPLY_DELEGATION) is ever turned on. Default-OFF delegation means
+-- no delegated apply (hence no ledger write) can occur until the chairman has bootstrapped this table.
+--
+-- Records EVERY delegated-apply attempt (applied / rejected / error) — who/what/when/approval-basis.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS adam_delegated_apply_ledger (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  migration_path    text,
+  migration_sha256  text,
+  delegatable       boolean NOT NULL,            -- the fail-closed scope verdict (isDelegatableForApply)
+  delegatable_kind  text,                        -- 'additive' | 'governed_insert' | NULL (when not delegatable)
+  outcome           text NOT NULL,               -- 'applied' | 'rejected' | 'error'
+  reject_factor     text,                        -- guard factor on rejection (scope / token / kill_switch / flag / delegated_marker)
+  reason            text,                        -- human-readable basis
+  approval_basis    text,                        -- the durable chairman-authorization reference
+  approved_by       text NOT NULL DEFAULT 'adam (delegated)',
+  success           boolean,                     -- true on applied, false on rejected/error
+  error             text,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_adam_delegated_apply_ledger_created ON adam_delegated_apply_ledger (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_adam_delegated_apply_ledger_outcome ON adam_delegated_apply_ledger (outcome);
+
+ALTER TABLE adam_delegated_apply_ledger ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY adam_delegated_apply_ledger_read ON adam_delegated_apply_ledger
+  FOR SELECT USING (auth.role() = 'authenticated' OR auth.role() = 'service_role');
+CREATE POLICY adam_delegated_apply_ledger_service_write ON adam_delegated_apply_ledger
+  FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+
+COMMENT ON TABLE adam_delegated_apply_ledger IS
+  'SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001: audit of every Adam delegated DB-apply attempt (applied/rejected/error). Chairman-bootstrapped; delegation is default-OFF (LEO_ADAM_DBAPPLY_DELEGATION).';
+
+COMMIT;
+
+-- ROLLBACK: DROP TABLE IF EXISTS adam_delegated_apply_ledger;

--- a/lib/migration/adam-delegated-apply.js
+++ b/lib/migration/adam-delegated-apply.js
@@ -1,0 +1,168 @@
+/**
+ * SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001 — the FAIL-CLOSED delegated-apply boundary.
+ *
+ * Chairman-authorized (2026-06-16) scope: Adam may APPLY additive DB changes (CREATE TABLE/INDEX,
+ * add nullable column, CHECK-widen) + governed data-row inserts. DESTRUCTIVE (DROP/rename/NOT-NULL)
+ * and ANY permission/access-control/data-access-policy change remain CHAIRMAN-ONLY.
+ *
+ * This module is the load-bearing access-control boundary for delegating PRODUCTION apply rights to
+ * an AI. It is PURE (no I/O), DEFAULT-DENY, and reuses the shipped, proven tier classifier
+ * byte-unchanged. Two grounding+security-review-verified gaps are closed here:
+ *   GAP A: classifyMigration returns tier:1 for CREATE POLICY + ENABLE RLS (data-access-policy
+ *          changes the chairman reserved) — so delegatable is a STRICT SUBSET of TIER-1 that
+ *          EXCLUDES any create_policy / enable_rls:* token. (Empirically the EXACT TIER-1 leak;
+ *          every other access-control vector — ALTER POLICY, FORCE/DISABLE RLS, GRANT/REVOKE,
+ *          ALTER DEFAULT PRIVILEGES, ALTER OWNER, SECURITY DEFINER, GRANT-in-DO — is already TIER-2.)
+ *   GAP B: the classifier rejects ALL DML to TIER-2, so governed data-row INSERTs use a SEPARATE,
+ *          conservative, fail-closed helper here (the proven classifier is NOT relaxed).
+ *
+ * SECURITY NOTE (SEC-H1, enforced in the apply layer, not here): authenticating the delegate by a
+ * STRING (an @-line) is forgeable; the apply path MUST additionally require a real secret factor
+ * (the delegation token). This module only decides WHAT is in-scope; the apply gate decides WHO.
+ */
+import { classifyMigration } from '../../scripts/lib/migration-tier-classifier.mjs';
+
+/**
+ * Hardcoded allow-list of GOVERNED tables a delegated data-row INSERT may target. Default-deny:
+ * any table not in this set is NOT delegatable (chairman path). Extend ONLY via security review.
+ */
+export const DELEGATABLE_INSERT_TABLES = Object.freeze([
+  'vision_ladder_criteria',
+  'conversion_ledger',
+]);
+
+// Zero-width / BOM chars JS \s does NOT match (mirrors the classifier's FC-18 defense).
+const ZERO_WIDTH_RE = /[​‌‍﻿]/g;
+
+// Tokens that must NEVER appear in a delegated governed INSERT (destructive / privilege / volatile /
+// data-access / smuggling vectors). Fail-closed: presence => reject. NOTE: 'DO'/'SET' are deliberately
+// NOT here — they collide with the legitimate `ON CONFLICT ... DO NOTHING` clause; the mutation form
+// `ON CONFLICT ... DO UPDATE` is still rejected by the UPDATE token, and a standalone `DO $$` block
+// cannot occur (the statement must start with INSERT INTO and be single-statement).
+const INSERT_FORBIDDEN_RE =
+  /\b(DROP|TRUNCATE|DELETE|UPDATE|ALTER|CREATE|RENAME|GRANT|REVOKE|MERGE|CALL|COPY|EXECUTE|LISTEN|NOTIFY|VACUUM|ANALYZE|CLUSTER|REINDEX|REFRESH|LOCK|RETURNING|nextval|setval|currval|pg_sleep|dblink|pg_read|pg_ls|lo_import|lo_export)\b/i;
+
+// A real relation reference in a FROM/JOIN that is NOT a parenthesized VALUES list (blocks
+// INSERT ... SELECT ... FROM <sensitive_table>). Allowed source is ONLY a literal VALUES list.
+const FROM_OR_JOIN_RE = /\b(?:FROM|JOIN)\s+(?!\(\s*VALUES\b)/i;
+
+/** Strip SQL comments (-- to EOL and /* block *​/) so comment-evasion cannot hide tokens. */
+function stripSqlComments(sql) {
+  return String(sql)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+    .replace(/--[^\n\r]*/g, ' ');       // line comments
+}
+
+/** Count top-level (non-string, non-comment) semicolons to reject multi-statement smuggling. */
+function topLevelSemicolons(noComments) {
+  let n = 0, inS = false, inD = false;
+  for (let i = 0; i < noComments.length; i++) {
+    const c = noComments[i];
+    if (c === "'" && !inD) inS = !inS;
+    else if (c === '"' && !inS) inD = !inD;
+    else if (c === ';' && !inS && !inD) n++;
+  }
+  return n;
+}
+
+/**
+ * GAP A — is the migration additive AND free of any data-access-policy (create_policy / enable_rls)
+ * statement? Delegatable additive == classifier TIER-1 MINUS the policy/RLS leak. Default-deny.
+ * @param {string} sql
+ * @returns {{ delegatable: boolean, reason: string, matched: string[] }}
+ */
+export function isDelegatableAdditive(sql) {
+  try {
+    const verdict = classifyMigration(sql);
+    if (!verdict || verdict.tier !== 1) {
+      return { delegatable: false, reason: `not_tier1:${verdict && verdict.reason}`, matched: (verdict && verdict.matched) || [] };
+    }
+    const matched = Array.isArray(verdict.matched) ? verdict.matched : [];
+    // EXACT leak surface: token-suffixed enable_rls:* + create_policy. Use some() with startsWith.
+    const policyTok = matched.find((t) => t === 'create_policy' || (typeof t === 'string' && t.startsWith('enable_rls:')));
+    if (policyTok) {
+      return { delegatable: false, reason: `policy_or_rls_chairman_only:${policyTok}`, matched };
+    }
+    return { delegatable: true, reason: 'additive_no_policy_rls', matched };
+  } catch (e) {
+    return { delegatable: false, reason: `additive_classifier_error:${e && e.message ? e.message : e}`, matched: [] };
+  }
+}
+
+/**
+ * GAP B — is this a single, bounded, governed data-row INSERT into an allow-listed table?
+ * CONSERVATIVE / fail-closed: single statement, no CTE (WITH), no RETURNING, no sub-SELECT from a
+ * real relation (only a literal VALUES source), no forbidden/volatile token, comment + zero-width
+ * normalized, table in DELEGATABLE_INSERT_TABLES. Anything else => not delegatable.
+ * @param {string} sql
+ * @returns {{ delegatable: boolean, reason: string, table: string|null }}
+ */
+export function classifyGovernedInsert(sql) {
+  try {
+    if (typeof sql !== 'string' || !sql.trim()) return { delegatable: false, reason: 'empty_or_non_string', table: null };
+    const norm = sql.replace(ZERO_WIDTH_RE, ''); // strip zero-width BEFORE anything else
+    const body = stripSqlComments(norm).trim().replace(/;+\s*$/, ''); // drop trailing semicolons
+    if (!body) return { delegatable: false, reason: 'comment_or_empty_only', table: null };
+    if (topLevelSemicolons(body) > 0) return { delegatable: false, reason: 'multi_statement', table: null };
+    if (/^\s*with\b/i.test(body)) return { delegatable: false, reason: 'cte_not_allowed', table: null }; // CTE-smuggle (WITH x AS (DELETE..) INSERT..)
+    const m = body.match(/^\s*insert\s+into\s+(?:"?([a-z_][a-z0-9_$]*)"?\.)?"?([a-z_][a-z0-9_$]*)"?/i);
+    if (!m) return { delegatable: false, reason: 'not_a_top_level_insert', table: null };
+    const schema = (m[1] || 'public').toLowerCase();
+    const table = m[2].toLowerCase();
+    if (schema !== 'public') return { delegatable: false, reason: `non_public_schema:${schema}`, table };
+    if (!DELEGATABLE_INSERT_TABLES.includes(table)) return { delegatable: false, reason: `table_not_allow_listed:${table}`, table };
+    // ALLOW-LIST (NOT a deny-list): only a LITERAL `VALUES` insert. A deny-list of dangerous tokens
+    // leaks (pg_read_binary_file / current_setting / query_to_xml / dblink_exec read files/secrets/run
+    // SQL AT APPLY TIME inside a VALUES tuple). So: no SELECT-form, no DEFAULT VALUES, and the VALUES
+    // tuples must contain ONLY literals (numbers / quoted strings / NULL/TRUE/FALSE / ::type casts) —
+    // NO function call (identifier '(') and NO bare special value keyword (current_user, etc.).
+    // Strip string literals ONCE (with '' escapes) so quoted content — which cannot execute — never
+    // trips a structural keyword check. ALL structural checks run on `sb` (the de-stringed body).
+    const sb = body.replace(/'(?:[^']|'')*'/g, "''");
+    if (FROM_OR_JOIN_RE.test(sb)) return { delegatable: false, reason: 'sub_select_from_relation', table };
+    if (/\bselect\b/i.test(sb)) return { delegatable: false, reason: 'select_not_allowed', table }; // no INSERT...SELECT (incl. no-FROM constant SELECT)
+    if (/\bdefault\s+values\b/i.test(sb)) return { delegatable: false, reason: 'default_values_not_allowed', table };
+    if (INSERT_FORBIDDEN_RE.test(sb)) return { delegatable: false, reason: 'forbidden_or_volatile_token', table }; // RETURNING / DO UPDATE / DDL-mix (defense-in-depth)
+    const vm = sb.match(/\bvalues\s*\(/i);
+    if (!vm) return { delegatable: false, reason: 'no_values_tuple', table };
+    // VALUES region = after the VALUES keyword, minus an optional ON CONFLICT ... DO NOTHING tail.
+    const region = sb.slice(vm.index).replace(/^\s*values/i, '').replace(/\bon\s+conflict\b[\s\S]*$/i, '');
+    if (/[a-z_][a-z0-9_$]*\s*\(/i.test(region)) return { delegatable: false, reason: 'function_call_in_values', table }; // any identifier( = function call (executes at apply time)
+    const residue = region.replace(/::\s*[a-z_][a-z0-9_]*/gi, '').replace(/\b(null|true|false)\b/gi, '');
+    if (/[a-z_]/i.test(residue)) return { delegatable: false, reason: 'non_literal_token_in_values', table }; // current_user / bare identifier / keyword
+    return { delegatable: true, reason: 'governed_literal_insert', table };
+  } catch (e) {
+    return { delegatable: false, reason: `governed_insert_error:${e && e.message ? e.message : e}`, table: null };
+  }
+}
+
+/**
+ * THE delegated-apply scope decision. A migration is delegatable iff it is (additive-no-policy/rls)
+ * OR (a single governed literal INSERT). Default-deny on anything else / any error.
+ * @param {string} sql
+ * @returns {{ delegatable: boolean, kind: 'additive'|'governed_insert'|null, reason: string, detail: object }}
+ */
+export function isDelegatableForApply(sql) {
+  const add = isDelegatableAdditive(sql);
+  if (add.delegatable) return { delegatable: true, kind: 'additive', reason: add.reason, detail: add };
+  const ins = classifyGovernedInsert(sql);
+  if (ins.delegatable) return { delegatable: true, kind: 'governed_insert', reason: ins.reason, detail: ins };
+  // Not delegatable — surface both reasons for the audit row.
+  return { delegatable: false, kind: null, reason: `not_delegatable (additive:${add.reason}; insert:${ins.reason})`, detail: { add, ins } };
+}
+
+/**
+ * FR-4 kill-switch — delegation is OFF unless the env flag is EXACTLY 'on'. Fail-closed: unset,
+ * typo, wrong case, or any non-'on' value => disabled => the chairman 3-factor gate is the only path.
+ * @param {object} [env]
+ * @returns {boolean}
+ */
+export function isDelegationEnabled(env = (typeof process !== 'undefined' ? process.env : {})) {
+  try {
+    return String((env && env.LEO_ADAM_DBAPPLY_DELEGATION) || '').trim() === 'on';
+  } catch {
+    return false;
+  }
+}
+
+export const KILL_SWITCH_ENV = 'LEO_ADAM_DBAPPLY_DELEGATION';

--- a/scripts/apply-migration.js
+++ b/scripts/apply-migration.js
@@ -42,10 +42,36 @@ import { parseDeclaredObjects, detectDestructiveDDL } from './lib/migration-obje
 import { captureObjectDefinitions, buildObjectDiffs } from './lib/migration-verification.js';
 import {
   validateProdDeployGuards,
+  validateDelegatedApplyGuards,
+  extractDelegatedBy,
   hashToken,
   generateTokenValue,
 } from './lib/migration-guards.js';
 import { getLatestSuccessForPath } from '../lib/migration-audit-reader.js';
+
+// SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001 (FR-4): audit-always ledger write for delegated
+// applies. SEPARATE short-lived connection so the row survives an apply-tx ROLLBACK (SEC-H cond 7).
+// Fail-soft: a ledger write failure is logged loudly but never crashes the apply path.
+const DELEGATION_APPROVAL_BASIS =
+  'chairman authorization 2026-06-16 (chairman_decisions b917c3e1; SD metadata.chairman_authorization)';
+async function recordDelegatedApply(row) {
+  let fc = null;
+  try {
+    fc = await createDatabaseClient('engineer', { verify: false });
+    await fc.query(
+      `INSERT INTO public.adam_delegated_apply_ledger
+         (migration_path, migration_sha256, delegatable, delegatable_kind, outcome, reject_factor, reason, approval_basis, success, error)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+      [row.migration_path ?? null, row.migration_sha256 ?? null, row.delegatable === true,
+       row.delegatable_kind ?? null, row.outcome, row.reject_factor ?? null, row.reason ?? null,
+       DELEGATION_APPROVAL_BASIS, row.success ?? null, row.error ? String(row.error).slice(0, 4000) : null]
+    );
+  } catch (e) {
+    process.stderr.write(`[delegated-apply-ledger-write-failed] ${e.message} (outcome=${row.outcome})\n`);
+  } finally {
+    if (fc) await fc.end().catch(() => {});
+  }
+}
 
 const GLOBAL_MIGRATION_LOCK_ID = 0x6d69_6772; // 'migr' as int — stable global advisory lock id
 const LOCK_WAIT_MS = 5000;
@@ -231,19 +257,42 @@ async function applyMode({ args, repoRoot }) {
     return 1;
   }
 
-  const guards = await validateProdDeployGuards({
-    flagPresent: prodDeploy,
-    tokenEnv: process.env.MIGRATION_APPLY_TOKEN,
-    sqlContent: sql,
-    gitUserEmail: gitUserEmail(),
-    client: auditClient,
-  });
+  // SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001: route by the `-- @delegated-by: adam` marker.
+  // Delegated path = SCOPED (additive + governed data-row only), fail-closed, kill-switch-gated,
+  // token-authenticated (SEC-H1). The chairman path (validateProdDeployGuards) is UNCHANGED and
+  // remains the only path for non-delegated / non-delegatable changes.
+  const isDelegated = extractDelegatedBy(sql) !== null;
+  const guards = isDelegated
+    ? await validateDelegatedApplyGuards({
+        flagPresent: prodDeploy,
+        tokenEnv: process.env.MIGRATION_APPLY_TOKEN,
+        sqlContent: sql,
+        client: auditClient,
+        env: process.env,
+      })
+    : await validateProdDeployGuards({
+        flagPresent: prodDeploy,
+        tokenEnv: process.env.MIGRATION_APPLY_TOKEN,
+        sqlContent: sql,
+        gitUserEmail: gitUserEmail(),
+        client: auditClient,
+      });
   if (!guards.ok) {
     emitMarker(`[MIGRATION_APPLY_PROD_FAIL_GUARDS=${guards.factor}]`);
     process.stderr.write(`Guard rejection: ${guards.reason}\n`);
+    if (isDelegated) {
+      await recordDelegatedApply({
+        migration_path: absPath, migration_sha256: sha,
+        delegatable: !!(guards.scope && guards.scope.delegatable),
+        delegatable_kind: guards.scope && guards.scope.kind,
+        outcome: 'rejected', reject_factor: guards.factor, reason: guards.reason, success: false,
+      });
+    }
     await auditClient.end();
     return 1;
   }
+  // For the audit table, identify the applier on both paths.
+  const appliedBy = isDelegated ? 'adam (delegated)' : guards.approver;
 
   const useTx = !noTx;
   if (noTx && !iKnow) {
@@ -267,6 +316,12 @@ async function applyMode({ args, repoRoot }) {
       if (!okPath || !okGlobal) {
         await auditClient.query('ROLLBACK');
         emitMarker('[MIGRATION_APPLY_PROD_FAIL_LOCK_CONTENTION]');
+        if (isDelegated) {
+          await recordDelegatedApply({
+            migration_path: absPath, migration_sha256: sha, delegatable: true, delegatable_kind: guards.kind,
+            outcome: 'rejected', reject_factor: 'lock_contention', reason: guards.scopeReason, success: false,
+          });
+        }
         await auditClient.end();
         return 1;
       }
@@ -297,7 +352,7 @@ async function applyMode({ args, repoRoot }) {
         await writeAuditRow(fc, {
           migration_path: absPath,
           migration_sha256: sha,
-          applied_by: guards.approver,
+          applied_by: appliedBy,
           prod_deploy: true,
           dry_run: false,
           statement_count: stmtCount,
@@ -311,6 +366,12 @@ async function applyMode({ args, repoRoot }) {
         await fc.end();
       }
 
+      if (isDelegated) {
+        await recordDelegatedApply({
+          migration_path: absPath, migration_sha256: sha, delegatable: true, delegatable_kind: guards.kind,
+          outcome: 'error', reason: guards.scopeReason, success: false, error: errorMsg,
+        });
+      }
       await auditClient.end();
       return 1;
     }
@@ -321,7 +382,7 @@ async function applyMode({ args, repoRoot }) {
     auditId = await writeAuditRow(auditClient, {
       migration_path: absPath,
       migration_sha256: sha,
-      applied_by: guards.approver,
+      applied_by: appliedBy,
       prod_deploy: true,
       dry_run: false,
       statement_count: stmtCount,
@@ -345,6 +406,14 @@ async function applyMode({ args, repoRoot }) {
     process.stderr.write(`unexpected error: ${errorMsg}\n`);
   } finally {
     await auditClient.end().catch(() => {});
+  }
+
+  if (isDelegated) {
+    await recordDelegatedApply({
+      migration_path: absPath, migration_sha256: sha, delegatable: true, delegatable_kind: guards.kind,
+      outcome: success ? 'applied' : 'error', reason: guards.scopeReason,
+      success, error: success ? null : errorMsg,
+    });
   }
 
   if (success) emitMarker('[MIGRATION_APPLY_PROD_PASS]');

--- a/scripts/lib/migration-guards.js
+++ b/scripts/lib/migration-guards.js
@@ -92,3 +92,49 @@ export async function validateProdDeployGuards({ flagPresent, tokenEnv, sqlConte
   if (!t.ok) return t;
   return { ok: true, approver: a.approver, tokenRowId: t.tokenRowId, tokenHash: t.tokenHash };
 }
+
+// ── SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001 — Adam delegated-apply gate ──
+// Chairman-authorized (2026-06-16) SCOPED delegation: Adam may APPLY additive + governed-data-row
+// changes ONLY. This is a SEPARATE wrapper — checkApproverFactor / validateProdDeployGuards above
+// are NOT broadened (the chairman path stays the only path for non-delegatable changes).
+//
+// SEC-H1 (confused-deputy defense): the `-- @delegated-by: adam` line is just a forgeable ROUTING
+// marker — it is NOT the authority. The REAL secret factor is the SAME crypto token mechanism the
+// chairman path uses (checkTokenFactor: an unconsumed, <1h, hashed-in-DB token). A forged
+// @delegated-by line without a valid token is REJECTED. The fail-closed SCOPE boundary
+// (isDelegatableForApply) + the default-OFF kill-switch (isDelegationEnabled) gate everything.
+import { isDelegatableForApply, isDelegationEnabled } from '../../lib/migration/adam-delegated-apply.js';
+
+const DELEGATED_BY_RE = /^\s*--\s*@delegated-by:\s*adam\s*$/im;
+
+export function extractDelegatedBy(sqlContent) {
+  if (typeof sqlContent !== 'string') return null;
+  return DELEGATED_BY_RE.test(sqlContent) ? 'adam' : null;
+}
+
+/**
+ * Adam delegated-apply guard. ALL factors must pass, in fail-closed order:
+ *   (1) --prod-deploy flag present
+ *   (2) kill-switch ON (LEO_ADAM_DBAPPLY_DELEGATION === 'on'); default-OFF => reject (chairman path)
+ *   (3) SCOPE: isDelegatableForApply(sql) true (additive-no-policy/rls OR governed literal INSERT)
+ *   (4) routing marker `-- @delegated-by: adam` present
+ *   (5) REAL SECRET: a valid unconsumed delegation token (checkTokenFactor) — SEC-H1
+ * Returns { ok, path:'delegated', kind, scopeReason, tokenRowId, tokenHash } or { ok:false, factor, reason }.
+ */
+export async function validateDelegatedApplyGuards({ flagPresent, tokenEnv, sqlContent, client, env }) {
+  const f = checkFlagFactor(flagPresent);
+  if (!f.ok) return { ...f, path: 'delegated' };
+  if (!isDelegationEnabled(env)) {
+    return { ok: false, factor: 'kill_switch', reason: 'delegation disabled (LEO_ADAM_DBAPPLY_DELEGATION != on) — chairman path required', path: 'delegated' };
+  }
+  const scope = isDelegatableForApply(sqlContent);
+  if (!scope.delegatable) {
+    return { ok: false, factor: 'scope', reason: `not delegatable (chairman-only): ${scope.reason}`, path: 'delegated', scope };
+  }
+  if (!extractDelegatedBy(sqlContent)) {
+    return { ok: false, factor: 'delegated_marker', reason: 'missing -- @delegated-by: adam routing marker', path: 'delegated' };
+  }
+  const t = await checkTokenFactor(client, tokenEnv); // SEC-H1: the real secret (NOT the @delegated-by string)
+  if (!t.ok) return { ...t, path: 'delegated' };
+  return { ok: true, path: 'delegated', kind: scope.kind, scopeReason: scope.reason, tokenRowId: t.tokenRowId, tokenHash: t.tokenHash };
+}

--- a/tests/unit/adam-delegated-apply-guards.test.js
+++ b/tests/unit/adam-delegated-apply-guards.test.js
@@ -1,0 +1,117 @@
+/**
+ * SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001 (FR-5/FR-6, SEC-H1) — delegated-apply GATE tests.
+ *
+ * Proves the enforcement layer (validateDelegatedApplyGuards): the forgeable `-- @delegated-by: adam`
+ * marker is NOT authority (a real crypto token is required — SEC-H1 confused-deputy defense), the
+ * kill-switch is default-OFF fail-closed, and a VALID token can NEVER bypass the fail-closed scope
+ * boundary (a destructive/policy change is rejected even with a valid token). The chairman path
+ * (validateProdDeployGuards/checkApproverFactor) is NOT broadened.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateDelegatedApplyGuards,
+  extractDelegatedBy,
+  validateProdDeployGuards,
+} from '../../scripts/lib/migration-guards.js';
+
+const TOKEN = 'a'.repeat(64); // a plausible 64-hex token value
+const ADDITIVE = 'CREATE TABLE IF NOT EXISTS public.foo (id uuid primary key);\n-- @delegated-by: adam\n';
+const GOVERNED_INSERT = "INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability) VALUES ('0f056dcd-2d8e-470a-8a28-921d322e6461', 99, 'X') ON CONFLICT (rung_id, capability) DO NOTHING;\n-- @delegated-by: adam\n";
+const DESTRUCTIVE = 'DROP TABLE public.foo;\n-- @delegated-by: adam\n';
+const POLICY = 'CREATE POLICY p ON public.foo FOR SELECT USING (true);\n-- @delegated-by: adam\n';
+
+// Mock pg client for checkTokenFactor: returns a fresh unconsumed token row, or none.
+function mockClient({ validToken = false, consumed = false, expired = false } = {}) {
+  return {
+    query: async () => {
+      if (!validToken) return { rows: [] };
+      const issued = expired ? new Date(Date.now() - 2 * 60 * 60 * 1000) : new Date(Date.now() - 1000);
+      return { rows: [{ id: 'tok-1', token_issued_at: issued.toISOString(), token_consumed_at: consumed ? new Date().toISOString() : null }] };
+    },
+  };
+}
+const ON = { LEO_ADAM_DBAPPLY_DELEGATION: 'on' };
+
+describe('extractDelegatedBy — routing marker only', () => {
+  it('detects -- @delegated-by: adam (case-insensitive) and nothing else', () => {
+    expect(extractDelegatedBy('-- @delegated-by: adam')).toBe('adam');
+    expect(extractDelegatedBy('-- @delegated-by: someone')).toBeNull();
+    expect(extractDelegatedBy('no marker')).toBeNull();
+  });
+});
+
+describe('SEC-H1 — the @delegated-by marker is NOT authority; a real token is required', () => {
+  it('REJECTS a delegatable change with the marker + kill-switch ON but NO valid token (impersonation attempt)', async () => {
+    const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: ADDITIVE, client: mockClient({ validToken: false }), env: ON });
+    expect(r.ok).toBe(false);
+    expect(r.factor).toBe('token'); // the forged marker got past routing but the real-secret factor blocks it
+  });
+
+  it('REJECTS when the token is consumed or expired (real-secret freshness enforced)', async () => {
+    const consumed = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: ADDITIVE, client: mockClient({ validToken: true, consumed: true }), env: ON });
+    expect(consumed.ok).toBe(false);
+    expect(consumed.factor).toBe('token');
+    const expired = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: ADDITIVE, client: mockClient({ validToken: true, expired: true }), env: ON });
+    expect(expired.ok).toBe(false);
+    expect(expired.factor).toBe('token');
+  });
+});
+
+describe('Fail-closed scope — a VALID token can NEVER apply a non-delegatable change', () => {
+  it('REJECTS a destructive change even with a valid token + marker + kill-switch on', async () => {
+    const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: DESTRUCTIVE, client: mockClient({ validToken: true }), env: ON });
+    expect(r.ok).toBe(false);
+    expect(r.factor).toBe('scope');
+  });
+  it('REJECTS a CREATE POLICY change even with a valid token (GAP-A through the gate)', async () => {
+    const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: POLICY, client: mockClient({ validToken: true }), env: ON });
+    expect(r.ok).toBe(false);
+    expect(r.factor).toBe('scope');
+  });
+});
+
+describe('Kill-switch — default-OFF, fail-closed (gates before scope/token)', () => {
+  it('REJECTS when the kill-switch is unset (default) or not exactly "on"', async () => {
+    for (const env of [{}, { LEO_ADAM_DBAPPLY_DELEGATION: 'ON' }, { LEO_ADAM_DBAPPLY_DELEGATION: 'true' }]) {
+      const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: ADDITIVE, client: mockClient({ validToken: true }), env });
+      expect(r.ok).toBe(false);
+      expect(r.factor).toBe('kill_switch');
+    }
+  });
+});
+
+describe('Routing + flag factors', () => {
+  it('REJECTS a delegatable change missing the @delegated-by marker (falls to chairman path)', async () => {
+    const noMarker = 'CREATE TABLE IF NOT EXISTS public.foo (id uuid primary key);';
+    const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: noMarker, client: mockClient({ validToken: true }), env: ON });
+    expect(r.ok).toBe(false);
+    expect(r.factor).toBe('delegated_marker');
+  });
+  it('REJECTS without the --prod-deploy flag', async () => {
+    const r = await validateDelegatedApplyGuards({ flagPresent: false, tokenEnv: TOKEN, sqlContent: ADDITIVE, client: mockClient({ validToken: true }), env: ON });
+    expect(r.ok).toBe(false);
+    expect(r.factor).toBe('flag');
+  });
+});
+
+describe('Happy path — additive + governed INSERT with all factors', () => {
+  it('ALLOWS an additive change with marker + kill-switch on + valid token', async () => {
+    const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: ADDITIVE, client: mockClient({ validToken: true }), env: ON });
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe('delegated');
+    expect(r.kind).toBe('additive');
+  });
+  it('ALLOWS a governed literal INSERT with all factors', async () => {
+    const r = await validateDelegatedApplyGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: GOVERNED_INSERT, client: mockClient({ validToken: true }), env: ON });
+    expect(r.ok).toBe(true);
+    expect(r.kind).toBe('governed_insert');
+  });
+});
+
+describe('Chairman path NOT broadened (regression guard)', () => {
+  it('validateProdDeployGuards still rejects a non-matching approver (delegation did not touch it)', async () => {
+    const r = await validateProdDeployGuards({ flagPresent: true, tokenEnv: TOKEN, sqlContent: '-- @approved-by: someone@else.com\nCREATE TABLE public.foo (id int);', gitUserEmail: 'chairman@example.com', client: mockClient({ validToken: true }) });
+    expect(r.ok).toBe(false);
+    expect(r.factor).toBe('approver');
+  });
+});

--- a/tests/unit/adam-delegated-apply.test.js
+++ b/tests/unit/adam-delegated-apply.test.js
@@ -1,0 +1,173 @@
+/**
+ * SD-LEO-INFRA-ADAM-DBCHANGE-APPLY-DELEGATION-001 (FR-3/FR-6) — adversarial boundary tests.
+ *
+ * Proves the FAIL-CLOSED access-control boundary for delegating PRODUCTION apply rights to an AI.
+ * These are NOT green-by-construction: they feed destructive / policy / RLS / DML-smuggle vectors
+ * and assert REJECTION, and feed legitimate additive + governed-INSERT and assert ALLOW. Mirrors the
+ * MIGRATION-TIER-CLASSIFIER lesson: an allow-list boundary must be attacked, not assumed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isDelegatableForApply,
+  isDelegatableAdditive,
+  classifyGovernedInsert,
+  isDelegationEnabled,
+  DELEGATABLE_INSERT_TABLES,
+} from '../../lib/migration/adam-delegated-apply.js';
+
+describe('GAP A — additive delegatable is a STRICT SUBSET of classifier TIER-1 (policy/RLS excluded)', () => {
+  it('ALLOWS provably-additive DDL', () => {
+    expect(isDelegatableForApply('CREATE TABLE IF NOT EXISTS public.foo (id uuid primary key);').delegatable).toBe(true);
+    expect(isDelegatableForApply('CREATE INDEX IF NOT EXISTS idx_foo ON public.foo (id);').delegatable).toBe(true);
+    expect(isDelegatableForApply('ALTER TABLE public.foo ADD COLUMN bar text;').delegatable).toBe(true);
+  });
+
+  it('REJECTS CREATE POLICY and ENABLE RLS even though the classifier rates them TIER-1 (the GAP-A leak)', () => {
+    const pol = isDelegatableForApply('CREATE POLICY p ON public.foo FOR SELECT USING (true);');
+    expect(pol.delegatable).toBe(false);
+    expect(pol.reason).toMatch(/policy_or_rls_chairman_only|not_delegatable/);
+    const rls = isDelegatableForApply('ALTER TABLE public.foo ENABLE ROW LEVEL SECURITY;');
+    expect(rls.delegatable).toBe(false);
+  });
+
+  it('REJECTS a MIXED-token TIER-1 migration (CREATE TABLE + ENABLE RLS) — the table-suffixed enable_rls token must be caught', () => {
+    const mixed = 'CREATE TABLE IF NOT EXISTS public.foo (id uuid primary key);\nALTER TABLE public.foo ENABLE ROW LEVEL SECURITY;';
+    const r = isDelegatableAdditive(mixed);
+    // If the classifier rates the pair TIER-1, the enable_rls:* token MUST still force not-delegatable.
+    expect(r.delegatable).toBe(false);
+  });
+
+  it('REJECTS all other access-control vectors (already TIER-2): GRANT / REVOKE / ALTER POLICY / DROP POLICY / GRANT-in-DO / SECURITY DEFINER', () => {
+    for (const sql of [
+      'GRANT SELECT ON public.foo TO someone;',
+      'REVOKE SELECT ON public.foo FROM someone;',
+      'ALTER POLICY p ON public.foo USING (true);',
+      'DROP POLICY p ON public.foo;',
+      'DO $$ BEGIN GRANT SELECT ON public.foo TO someone; END $$;',
+      'CREATE FUNCTION f() RETURNS void LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;',
+    ]) {
+      expect(isDelegatableForApply(sql).delegatable, sql).toBe(false);
+    }
+  });
+});
+
+describe('Destructive changes are NEVER delegatable (chairman-only)', () => {
+  it('REJECTS DROP / TRUNCATE / RENAME / SET NOT NULL / DELETE / UPDATE', () => {
+    for (const sql of [
+      'DROP TABLE public.foo;',
+      'TRUNCATE public.foo;',
+      'ALTER TABLE public.foo RENAME TO bar;',
+      'ALTER TABLE public.foo ALTER COLUMN bar SET NOT NULL;',
+      'DELETE FROM public.foo;',
+      'UPDATE public.foo SET bar = 1;',
+    ]) {
+      expect(isDelegatableForApply(sql).delegatable, sql).toBe(false);
+    }
+  });
+});
+
+describe('GAP B — governed data-row INSERT: bounded, fail-closed', () => {
+  it('ALLOWS a single literal VALUES insert into an allow-listed table', () => {
+    const sql = "INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability, today, required) VALUES ('0f056dcd-2d8e-470a-8a28-921d322e6461', 99, 'X', 'a', 'b') ON CONFLICT (rung_id, capability) DO NOTHING;";
+    const r = isDelegatableForApply(sql);
+    expect(r.delegatable).toBe(true);
+    expect(r.kind).toBe('governed_insert');
+  });
+
+  it('REJECTS CTE-smuggled DML (WITH x AS (DELETE ...) INSERT ...) — a single statement length check would miss this', () => {
+    const sql = "WITH x AS (DELETE FROM conversion_ledger RETURNING *) INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability) VALUES ('u', 1, 'y');";
+    const r = classifyGovernedInsert(sql);
+    expect(r.delegatable).toBe(false);
+    expect(r.reason).toMatch(/cte_not_allowed/);
+  });
+
+  it('REJECTS RETURNING, INSERT...SELECT-from-a-relation, non-allow-listed table, multi-statement, DO UPDATE, and comment-hidden 2nd statement', () => {
+    const cases = [
+      "INSERT INTO vision_ladder_criteria (rung_id, ordinal) VALUES ('u', 1) RETURNING id;",                 // RETURNING
+      'INSERT INTO vision_ladder_criteria SELECT * FROM auth.users;',                                          // sub-SELECT from a real relation
+      "INSERT INTO secrets (k, v) VALUES ('a', 'b');",                                                         // table not allow-listed
+      'INSERT INTO vision_ladder_criteria (ordinal) VALUES (1); DROP TABLE conversion_ledger;',               // multi-statement
+      "INSERT INTO vision_ladder_criteria (rung_id, capability) VALUES ('u','c') ON CONFLICT (rung_id, capability) DO UPDATE SET capability = 'z';", // DO UPDATE (mutation)
+      'INSERT INTO vision_ladder_criteria (ordinal) VALUES (1) -- \n; DROP TABLE conversion_ledger;',         // comment-hidden 2nd statement
+    ];
+    for (const sql of cases) {
+      expect(classifyGovernedInsert(sql).delegatable, sql).toBe(false);
+    }
+  });
+
+  it('REJECTS INSERT into an allow-listed table that also references a sensitive relation via JOIN', () => {
+    const sql = 'INSERT INTO conversion_ledger (id) SELECT id FROM public.foo JOIN auth.users USING (id);';
+    expect(classifyGovernedInsert(sql).delegatable).toBe(false);
+  });
+
+  it('the allow-list is the governed set (vision_ladder_criteria, conversion_ledger) — anything else is chairman-only', () => {
+    expect(DELEGATABLE_INSERT_TABLES).toContain('vision_ladder_criteria');
+    expect(DELEGATABLE_INSERT_TABLES).toContain('conversion_ledger');
+    expect(classifyGovernedInsert("INSERT INTO chairman_decisions (decision) VALUES ('go');").delegatable).toBe(false);
+  });
+
+  it('CRITICAL — REJECTS function-call / read-server-state expressions inside VALUES (literal-only allow-list, not a deny-list)', () => {
+    // These execute AT APPLY TIME and would read files/secrets/run SQL — must all be rejected.
+    const exec = [
+      "INSERT INTO conversion_ledger (note) VALUES (convert_from(pg_read_binary_file('postgresql.conf'),'UTF8'));",
+      "INSERT INTO conversion_ledger (note) VALUES (pg_read_file('/etc/passwd'));",
+      "INSERT INTO conversion_ledger (note) VALUES (pg_stat_file('/etc/passwd'));",
+      "INSERT INTO conversion_ledger (note) VALUES (pg_ls_dir('/'));",
+      "INSERT INTO conversion_ledger (note) VALUES (query_to_xml('SELECT 1', true, true, '')::text);",
+      "INSERT INTO conversion_ledger (note) VALUES (dblink_exec('host=evil', 'SELECT 1'));",
+      "INSERT INTO conversion_ledger (note) VALUES (current_setting('app.jwt_secret'));",
+      'INSERT INTO conversion_ledger (note) VALUES (gen_random_uuid());', // any function call rejected (rely on column default)
+    ];
+    for (const sql of exec) {
+      const r = classifyGovernedInsert(sql);
+      expect(r.delegatable, sql).toBe(false);
+      expect(r.reason, sql).toMatch(/function_call_in_values/);
+    }
+  });
+
+  it('CRITICAL — REJECTS bare special value keywords (current_user/session_user) and INSERT...SELECT-without-FROM and DEFAULT VALUES', () => {
+    expect(classifyGovernedInsert('INSERT INTO conversion_ledger (note) VALUES (current_user);').delegatable).toBe(false);
+    expect(classifyGovernedInsert('INSERT INTO conversion_ledger (note) VALUES (session_user);').delegatable).toBe(false);
+    expect(classifyGovernedInsert("INSERT INTO conversion_ledger (note) SELECT current_setting('app.secret');").delegatable).toBe(false); // no-FROM constant SELECT
+    expect(classifyGovernedInsert('INSERT INTO conversion_ledger DEFAULT VALUES;').delegatable).toBe(false);
+  });
+
+  it('ALLOWS genuine literal VALUES (numbers, quoted strings with escapes, NULL/TRUE/FALSE, ::type casts, multi-row, ON CONFLICT DO NOTHING)', () => {
+    const ok = [
+      "INSERT INTO vision_ladder_criteria (rung_id, ordinal, capability) VALUES ('0f056dcd-2d8e-470a-8a28-921d322e6461'::uuid, 12, 'Govern-by-exception') ON CONFLICT (rung_id, capability) DO NOTHING;",
+      "INSERT INTO conversion_ledger (title, normalized_priority) VALUES ('it''s fine', 3), ('row two', NULL);",
+      "INSERT INTO conversion_ledger (title, intake_status) VALUES ('x', 'pending');",
+    ];
+    for (const sql of ok) {
+      const r = classifyGovernedInsert(sql);
+      expect(r.delegatable, sql).toBe(true);
+      expect(r.kind === undefined || isDelegatableForApply(sql).kind === 'governed_insert').toBeTruthy();
+    }
+  });
+});
+
+describe('Default-deny on degenerate / error input', () => {
+  it('REJECTS empty, whitespace, non-string, comment-only', () => {
+    for (const sql of ['', '   ', null, undefined, 42, '-- just a comment', '/* x */']) {
+      expect(isDelegatableForApply(sql).delegatable, String(sql)).toBe(false);
+    }
+  });
+
+  it('REJECTS a multi-statement additive+destructive mix', () => {
+    expect(isDelegatableForApply('CREATE TABLE public.foo (id int); DROP TABLE public.bar;').delegatable).toBe(false);
+  });
+});
+
+describe('FR-4 kill-switch — default-OFF, fail-closed (exact sentinel)', () => {
+  it('enabled ONLY when the env flag is exactly "on"', () => {
+    expect(isDelegationEnabled({ LEO_ADAM_DBAPPLY_DELEGATION: 'on' })).toBe(true);
+    expect(isDelegationEnabled({ LEO_ADAM_DBAPPLY_DELEGATION: ' on ' })).toBe(true); // trimmed
+  });
+
+  it('disabled (fail-closed) for unset / wrong-case / truthy-looking / typo values', () => {
+    for (const v of [undefined, '', 'ON', 'On', 'true', '1', 'yes', 'enabled', 'o n']) {
+      expect(isDelegationEnabled({ LEO_ADAM_DBAPPLY_DELEGATION: v }), String(v)).toBe(false);
+    }
+    expect(isDelegationEnabled({})).toBe(false); // unset => OFF
+  });
+});


### PR DESCRIPTION
## Summary
Makes the **chairman-authorized** (2026-06-16; durable: `chairman_decisions` `b917c3e1` + SD `metadata.chairman_authorization`) scoped DB-change APPLY delegation to Adam **real, enforced, audited, and revocable**. Adam may APPLY **additive DB changes + governed data-row inserts ONLY**; **destructive + permission/access-control/data-access-policy changes stay chairman-only (fail-closed)**.

> ⚠️ Security-critical: grants an AI scoped production-apply rights. This SD was **held + escalated** until a durable chairman authorization existed; the chairman then explicitly authorized the scope. CONST-002 build-claim enforcement is **untouched** (a delegated apply is not a build claim); the chairman 3-factor gate is **not broadened**.

## What's in it (FRs)
- **FR-1** — additive changes reuse the shipped tier-classifier (`migration-tier-classifier.mjs`, byte-unchanged).
- **FR-2/FR-3** — `lib/migration/adam-delegated-apply.js`: the fail-closed boundary.
  - `isDelegatableForApply` = classifier TIER-1 **minus** `create_policy`/`enable_rls:*` (**GAP-A**: those rate TIER-1 but are chairman-only).
  - `classifyGovernedInsert` = a **literal-only allow-list** (**GAP-B**): single statement, no CTE/RETURNING/SELECT/`DEFAULT VALUES`, allow-listed table, and **no function-calls / special keywords in VALUES** (an adversarial review caught that a deny-list let `pg_read_binary_file()`/`current_setting()`/`query_to_xml()`/`dblink_exec()` **execute at apply time** — arbitrary file/secret read + SQL exec; now rejected by allow-list). Default-deny on any error.
- **FR-5 / SEC-H1** — `validateDelegatedApplyGuards` in `migration-guards.js`: the forgeable `-- @delegated-by: adam` line only **routes**; the **real authority is a valid crypto token** (reuses `checkTokenFactor`). Wired into `apply-migration.js` (chairman path otherwise). Governed `leo_protocol_sections` row (id=606) + regenerated `CLAUDE_ADAM.md`/`_DIGEST`.
- **FR-4** — `adam_delegated_apply_ledger` (chairman-bootstrap; it contains RLS/policy) + **audit-always** writes (reject / lock-contention / ddl-error / success) on a **separate connection** (survive tx rollback). Kill-switch `LEO_ADAM_DBAPPLY_DELEGATION` **default-OFF, fail-closed** (exact `'on'`).
- **FR-6** — PLAN security-agent review (CONDITIONAL_PASS; 8 must-fix conditions, all addressed) + a full adversarial corpus.

## Security verification
- PLAN security review (`security-agent`) + a post-implementation adversarial review that **empirically attacked** the boundary and caught the critical VALUES-execution hole → fixed (deny-list → allow-list) and proven.
- Adversarial tests cover: GAP-A mixed-token, GAP-B CTE/RETURNING/INSERT-SELECT/**function-exec/current_user/DEFAULT VALUES**, SEC-H1 impersonation (marker without token → reject), valid-token-cannot-bypass-scope, kill-switch sentinel, audit-always.
- **97/97** apply-migration + delegation unit tests pass; classifier + chairman path + CONST-002 claim files byte-unchanged (0 regressions).

## Operational
Default-OFF: no delegated apply can occur until the chairman bootstraps the ledger table (chairman 3-factor) and sets `LEO_ADAM_DBAPPLY_DELEGATION=on`. Revoke instantly by unsetting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)