### PR TITLE
fix(SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001): trust heartbeat_at over lagging is_alive in claim reap + canonical reactivate-sd

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -207,6 +207,50 @@ export { isBuildForbiddenSession };
 // predicate — a within-cap armed silence window means the holder is legitimately quiet, NOT dead.
 import { isWithinArmedSilenceWindow } from './fleet/silence-cap.cjs';
 
+// ── Liveness predicate (SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 FR-1) ─────
+// claude_sessions.is_alive LAGS heartbeat_at: a live, actively-heartbeating /loop
+// worker can transiently read is_alive=false, and the old predicate reaped its claim
+// on that ALONE — causing claim/release thrash on the same SD. heartbeat_at is the
+// liveness source of truth: an is_alive===false owner is DEAD only once its heartbeat
+// has ALSO gone stale beyond the claim TTL.
+/** Documented claim_sd TTL (~15 min) — see the foreign_claim remediation text below. */
+export const CLAIM_TTL_MS = 900_000;
+
+/**
+ * @param {string|number|Date|null|undefined} heartbeatAt
+ * @param {number} nowMs
+ * @param {number} [ttlMs=CLAIM_TTL_MS]
+ * @returns {boolean} true when the heartbeat is missing/unparseable or older than ttlMs.
+ *   FAIL-OPEN: a missing/invalid heartbeat is treated as STALE so an is_alive=false owner
+ *   with no heartbeat is still reaped (genuinely dead). A non-finite nowMs cannot judge
+ *   staleness, so it returns false (not stale) rather than false-reap a live-looking owner.
+ */
+export function isHeartbeatStale(heartbeatAt, nowMs, ttlMs = CLAIM_TTL_MS) {
+  if (heartbeatAt == null) return true;
+  const ts = heartbeatAt instanceof Date ? heartbeatAt.getTime() : new Date(heartbeatAt).getTime();
+  if (!Number.isFinite(ts)) return true;
+  if (!Number.isFinite(nowMs)) return false;
+  return (nowMs - ts) > ttlMs;
+}
+
+/**
+ * Pure liveness verdict for a claim-owner row (SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 FR-1).
+ * DEAD when: owner is missing, status is 'stale'/'released', OR is_alive===false AND the
+ * heartbeat is stale beyond ttlMs. A live-but-lagging owner (is_alive===false but a FRESH
+ * heartbeat) is NOT dead — this is what stops the thrash. Preserves the prior fail-open
+ * behavior for the missing-owner and explicit-lifecycle-status cases.
+ * @param {{status?:string, is_alive?:boolean, heartbeat_at?:any}|null|undefined} owner
+ * @param {number} nowMs
+ * @param {number} [ttlMs=CLAIM_TTL_MS]
+ * @returns {boolean}
+ */
+export function ownerIsDeadByLiveness(owner, nowMs, ttlMs = CLAIM_TTL_MS) {
+  if (!owner) return true;
+  if (owner.status === 'stale' || owner.status === 'released') return true;
+  if (owner.is_alive === false) return isHeartbeatStale(owner.heartbeat_at, nowMs, ttlMs);
+  return false;
+}
+
 function explainRemediation(reason) {
   switch (reason) {
     case 'ambiguous':
@@ -373,11 +417,15 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // working it). sd_key is the source-of-truth, NOT claiming_session_id.
     const { data: owner } = await supabase
       .from('claude_sessions')
-      .select('status, is_alive, sd_key, expected_silence_until')
+      .select('status, is_alive, sd_key, expected_silence_until, heartbeat_at')
       .eq('session_id', sd.claiming_session_id)
       .maybeSingle();
 
-    const ownerIsDead = !owner || owner.status === 'stale' || owner.status === 'released' || owner.is_alive === false;
+    // SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 FR-1: trust heartbeat_at over the lagging
+    // is_alive column — an is_alive===false owner is dead ONLY when its heartbeat is ALSO
+    // stale (> CLAIM_TTL_MS); a live-but-lagging owner is NOT reaped (stops the thrash).
+    // Missing owner + status stale/released still mark dead (fail-open via ownerIsDeadByLiveness).
+    const ownerIsDead = ownerIsDeadByLiveness(owner, Date.now());
     // SD-LEO-INFRA-CLAIM-SILENCE-CONSUME-VERIFY-001 (SEAM 1, PRIMARY): a parked /loop worker
     // arms expected_silence_until and lets its heartbeat lapse legitimately — appearing "dead"
     // here. Honor a within-cap armed silence window exactly as the sweep does (ALIVE_SOURCE_SIDE):

--- a/package.json
+++ b/package.json
@@ -313,6 +313,7 @@
     "story:template": "node scripts/story-requirements-template.js",
     "sd:next": "node scripts/sd-next.js",
     "sd:cancel": "node scripts/cancel-sd.js",
+    "sd:reactivate": "node scripts/reactivate-sd.js",
     "sd:park": "node scripts/sd-park.js park",
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",

--- a/scripts/reactivate-sd.js
+++ b/scripts/reactivate-sd.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Canonical SD Reactivation Script — SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 (FR-3)
+ *
+ * Atomically moves an SD OUT of status='deferred': flips status (default 'draft'),
+ * syncs metadata.blocker (stamps metadata.reactivated_at + marks the blocker cleared), and
+ * emits an sd_transition_audit row (transition_type='REACTIVATE'). The direct-UPDATE path
+ * used for ad-hoc reactivations bypasses BOTH the blocker sync and the audit — this routine
+ * closes that gap (the gap a chairman-authorized manual reactivation exposed). Mirrors the
+ * canonical scripts/cancel-sd.js structure (parseArgs -> resolveSD -> guarded atomic update).
+ *
+ * Per the SD's explicit anti-requirement, the claim-validity predicate is NOT made to read
+ * metadata.blocker — nothing reads it; that would be dead defensive code against a non-cause.
+ *
+ * "Atomic" here = the status + metadata flip is ONE guarded UPDATE keyed on status='deferred', so a
+ * concurrent reactivation cannot double-apply. NOTE: the guard is on the STATUS column; metadata is a
+ * read-modify-write (last-writer-wins) — a concurrent writer mutating a DIFFERENT metadata key in the
+ * narrow read->write window would be overwritten (low risk: manual single-actor reactivation). The
+ * audit row is emitted immediately after the flip (loud-but-non-fatal on failure — the state change
+ * must not be masked by an audit hiccup), mirroring cancel-sd.js.
+ *
+ * Usage:
+ *   node scripts/reactivate-sd.js <SD-KEY-or-UUID> [--to <status>] [--reason "<text>"]
+ *   node scripts/reactivate-sd.js --help
+ *
+ * Defaults: --to draft
+ */
+
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { randomUUID } from 'node:crypto';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// Valid reactivation targets — where a 'deferred' SD can be moved back to.
+export const VALID_REACTIVATION_TARGETS = new Set(['draft', 'active', 'in_progress']);
+// Terminal statuses that must NOT be reactivated (loud refusal).
+const TERMINAL_STATUSES = new Set(['completed', 'cancelled']);
+
+/**
+ * PURE: compute the reactivation update + audit pre/post state for an SD.
+ * Returns {ok:false, reason} when the SD is not 'deferred' (caller decides exit code);
+ * throws on an invalid target status.
+ * @param {{status?:string,current_phase?:string,metadata?:object,sd_key?:string,id?:string}} sd
+ * @param {{toStatus?:string, reason?:string, nowIso?:string}} [opts]
+ */
+export function computeReactivation(sd, { toStatus = 'draft', reason = null, nowIso } = {}) {
+  if (!sd) throw new Error('computeReactivation: sd is required');
+  if (!VALID_REACTIVATION_TARGETS.has(toStatus)) {
+    throw new Error(`computeReactivation: invalid --to status '${toStatus}' (allowed: ${[...VALID_REACTIVATION_TARGETS].join(', ')})`);
+  }
+  if (sd.status !== 'deferred') {
+    return { ok: false, reason: 'not_deferred', terminal: TERMINAL_STATUSES.has(sd.status), currentStatus: sd.status };
+  }
+  const ts = nowIso || new Date().toISOString();
+  const priorMeta = (sd.metadata && typeof sd.metadata === 'object' && !Array.isArray(sd.metadata)) ? sd.metadata : {};
+  const priorBlocker = (priorMeta.blocker && typeof priorMeta.blocker === 'object' && !Array.isArray(priorMeta.blocker))
+    ? priorMeta.blocker : null;
+
+  // Sync metadata.blocker: stamp reactivated_at and mark the blocker cleared (preserve the
+  // object for the audit trail rather than silently dropping it — internally consistent).
+  const nextMeta = { ...priorMeta, reactivated_at: ts };
+  if (priorBlocker) nextMeta.blocker = { ...priorBlocker, status: 'cleared', cleared_at: ts };
+  if (reason) nextMeta.reactivation_reason = String(reason).slice(0, 500);
+
+  const updates = { status: toStatus, metadata: nextMeta, updated_at: ts };
+  const pre_state = { status: sd.status, current_phase: sd.current_phase ?? null, blocker_status: priorBlocker?.status ?? null };
+  const post_state = { status: toStatus, reactivated_at: ts, blocker_status: priorBlocker ? 'cleared' : null };
+  return { ok: true, updates, pre_state, post_state, blockerCleared: !!priorBlocker };
+}
+
+/**
+ * PURE: build the sd_transition_audit insert row for a reactivation.
+ * sd_id (uuid) + request_id (text) are NOT NULL on the table.
+ */
+export function buildReactivationAudit({ sdId, pre_state, post_state, sessionId = null, requestId, nowIso }) {
+  if (!sdId) throw new Error('buildReactivationAudit: sdId is required');
+  if (!requestId) throw new Error('buildReactivationAudit: requestId is required (request_id is NOT NULL)');
+  if (!pre_state) throw new Error('buildReactivationAudit: pre_state is required (pre_state is NOT NULL)');
+  const ts = nowIso || new Date().toISOString();
+  return {
+    sd_id: sdId,
+    transition_type: 'REACTIVATE',
+    session_id: sessionId,
+    request_id: requestId,
+    pre_state,
+    post_state: post_state ?? null,
+    status: 'completed',
+    started_at: ts,
+    completed_at: ts,
+  };
+}
+
+// ── CLI (IO) ────────────────────────────────────────────────────────────────
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage: node scripts/reactivate-sd.js <SD-KEY-or-UUID> [--to <status>] [--reason "<text>"]
+
+Atomically reactivates a DEFERRED SD (SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 FR-3):
+  - flips status OUT of 'deferred' (default --to draft; also: active, in_progress)
+  - syncs metadata: stamps metadata.reactivated_at and marks metadata.blocker.status='cleared'
+  - emits an sd_transition_audit row (transition_type='REACTIVATE', pre_state/post_state)
+
+The status+metadata flip is one guarded UPDATE (WHERE status='deferred' — concurrent-safe).
+Idempotent: re-running on an already-reactivated SD is a no-op. Refuses completed/cancelled SDs.
+
+Options:
+  --to <status>      Target status (draft | active | in_progress). Default: draft
+  --reason "<text>"  Optional reactivation reason (recorded in metadata)
+
+Examples:
+  node scripts/reactivate-sd.js SD-LEO-FIX-FOO-001 --reason "Chairman cleared the gate"
+  node scripts/reactivate-sd.js SD-LEO-FIX-FOO-001 --to in_progress
+`);
+    process.exit(args.includes('--help') || args.includes('-h') ? 0 : 1);
+  }
+  const toIdx = args.indexOf('--to');
+  const toStatus = toIdx !== -1 ? args[toIdx + 1] : 'draft';
+  const reasonIdx = args.indexOf('--reason');
+  const reason = reasonIdx !== -1 ? args[reasonIdx + 1] : null;
+  const consumed = new Set([toIdx, toIdx + 1, reasonIdx, reasonIdx + 1].filter(i => i >= 0));
+  const sdInput = args.find((a, i) => !a.startsWith('-') && !consumed.has(i));
+  if (!sdInput) {
+    console.error('❌ Missing SD identifier (sd_key or UUID)');
+    process.exit(1);
+  }
+  return { sdInput, toStatus, reason };
+}
+
+async function resolveSD(supabase, input) {
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(input);
+  // uuid_id is the real uuid PK (sd_transition_audit.sd_id FKs to it); id is a varchar
+  // surrogate (often itself uuid-shaped). A UUID input may be either, so match both.
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, uuid_id, sd_key, title, status, current_phase, metadata')
+    .or(isUuid ? `uuid_id.eq.${input},id.eq.${input}` : `sd_key.eq.${input}`)
+    .limit(1)
+    .single();
+  if (error || !data) {
+    console.error(`❌ SD not found: ${input}`);
+    process.exit(1);
+  }
+  return data;
+}
+
+async function main() {
+  const { sdInput, toStatus, reason } = parseArgs();
+  const supabase = createSupabaseServiceClient();
+  const sd = await resolveSD(supabase, sdInput);
+
+  console.log(`SD: ${sd.sd_key} — ${sd.title?.slice(0, 80)}`);
+  console.log(`  Current status: ${sd.status} / phase: ${sd.current_phase}`);
+  console.log(`  Reactivating to: ${toStatus}${reason ? ` (reason: ${reason})` : ''}`);
+  console.log('');
+
+  const plan = computeReactivation(sd, { toStatus, reason });
+  if (!plan.ok) {
+    if (plan.terminal) {
+      console.error(`❌ Cannot reactivate ${sd.sd_key}: status='${plan.currentStatus}' is terminal. Use a different remediation path.`);
+      process.exit(1);
+    }
+    console.log(`ℹ️  SD ${sd.sd_key} is status='${plan.currentStatus}', not 'deferred' — nothing to reactivate (idempotent no-op).`);
+    process.exit(0);
+  }
+
+  // Guarded atomic flip — only applies if the SD is STILL 'deferred'.
+  const { data: updated, error: upErr } = await supabase
+    .from('strategic_directives_v2')
+    .update(plan.updates)
+    .eq('id', sd.id)
+    .eq('status', 'deferred')
+    .select('sd_key, status');
+  if (upErr) {
+    console.error(`❌ Failed to reactivate ${sd.sd_key}:`, upErr.message);
+    process.exit(1);
+  }
+  if (!updated || updated.length === 0) {
+    console.log(`ℹ️  ${sd.sd_key} was no longer 'deferred' at write time (concurrent change) — no-op.`);
+    process.exit(0);
+  }
+  console.log(`✓ ${sd.sd_key} reactivated: status=${toStatus}, metadata.reactivated_at stamped${plan.blockerCleared ? ', metadata.blocker.status=cleared' : ''}`);
+
+  // Emit the sd_transition_audit row (loud-but-non-fatal — the flip already landed).
+  const auditRow = buildReactivationAudit({
+    // sd_transition_audit.sd_id FKs to strategic_directives_v2.uuid_id (NOT the varchar id).
+    sdId: sd.uuid_id,
+    pre_state: plan.pre_state,
+    post_state: plan.post_state,
+    sessionId: process.env.CLAUDE_SESSION_ID || null,
+    requestId: randomUUID(),
+  });
+  const { error: auditErr } = await supabase.from('sd_transition_audit').insert(auditRow);
+  if (auditErr) {
+    console.warn(`⚠️  sd_transition_audit write for ${sd.sd_key} failed (non-fatal — SD already reactivated):`, auditErr.message);
+  } else {
+    console.log(`✓ sd_transition_audit: REACTIVATE recorded for ${sd.sd_key}`);
+  }
+
+  console.log('\n✅ Reactivation complete.');
+}
+
+// Only run main() when invoked directly (not when imported by tests).
+const invokedDirectly = process.argv[1] && /reactivate-sd\.js$/.test(process.argv[1]);
+if (invokedDirectly) {
+  main().catch(err => { console.error('Fatal error:', err); process.exit(1); });
+}

--- a/tests/unit/claim-validity-gate-sd-key-drift.test.js
+++ b/tests/unit/claim-validity-gate-sd-key-drift.test.js
@@ -94,8 +94,15 @@ describe('telemetry: console.warn emits sd_key_drift verdict (audit trail)', () 
 // ── Backward compat: stale-heartbeat path still works ────────────────────
 
 describe('backward compat: stale-heartbeat path preserved (no regression)', () => {
-  it('ownerIsDead boolean retains its 4-condition definition (status stale/released, is_alive false, missing)', () => {
-    expect(src).toMatch(/ownerIsDead\s*=\s*!owner\s*\|\|\s*owner\.status\s*===\s*['"]stale['"]\s*\|\|\s*owner\.status\s*===\s*['"]released['"]\s*\|\|\s*owner\.is_alive\s*===\s*false/);
+  it('ownerIsDead delegates to ownerIsDeadByLiveness (SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 FR-1: is_alive now gated on heartbeat staleness; missing + status stale/released preserved)', () => {
+    // The inline 4-condition predicate was replaced by the pure ownerIsDeadByLiveness helper,
+    // which trusts heartbeat_at over the lagging is_alive column (is_alive===false => dead ONLY
+    // when the heartbeat is ALSO stale). The helper preserves the missing-owner + lifecycle-status
+    // dead signals (fail-open), so the prior conditions still hold for those cases.
+    expect(src).toMatch(/ownerIsDead\s*=\s*ownerIsDeadByLiveness\(owner,\s*Date\.now\(\)\)/);
+    expect(src).toMatch(/if\s*\(!owner\)\s*return true;/);
+    expect(src).toMatch(/owner\.status\s*===\s*['"]stale['"]\s*\|\|\s*owner\.status\s*===\s*['"]released['"]/);
+    expect(src).toMatch(/owner\.is_alive\s*===\s*false\)\s*return isHeartbeatStale/);
   });
 
   it('foreign_claim throw still fires when neither ownerIsDead NOR ownerHasSdKeyDrifted', () => {

--- a/tests/unit/claim-validity-isalive-lag.test.js
+++ b/tests/unit/claim-validity-isalive-lag.test.js
@@ -1,0 +1,82 @@
+/**
+ * SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 (FR-2) — both-direction adversarial tests
+ * for the hardened liveness predicate.
+ *
+ * PURE, no DB. ownerIsDeadByLiveness / isHeartbeatStale ARE the reap decision: the
+ * claim-validity gate auto-releases an orphaned claim iff (ownerIsDead && !silenced) OR
+ * sd_key drift — so proving the predicate proves the reap behavior. The two mandatory
+ * directions: (a) a genuinely-dead owner IS still reaped (no claim held forever);
+ * (b) a live-but-lagging owner (is_alive=false BUT fresh heartbeat) is NOT reaped (thrash stops).
+ */
+import { describe, it, expect } from 'vitest';
+import { ownerIsDeadByLiveness, isHeartbeatStale, CLAIM_TTL_MS } from '../../lib/claim-validity-gate.js';
+
+const NOW = 1_700_000_000_000;
+const minsAgo = (m) => NOW - m * 60_000;
+const secsAgo = (s) => NOW - s * 1000;
+
+describe('isHeartbeatStale (FR-1 — heartbeat is the liveness source of truth)', () => {
+  it('CLAIM_TTL_MS is the documented ~15-min claim TTL', () => {
+    expect(CLAIM_TTL_MS).toBe(900_000);
+  });
+  it('a fresh heartbeat (within TTL) is NOT stale', () => {
+    expect(isHeartbeatStale(minsAgo(5), NOW)).toBe(false);
+  });
+  it('a heartbeat older than the TTL IS stale', () => {
+    expect(isHeartbeatStale(minsAgo(20), NOW)).toBe(true);
+  });
+  it('boundary: exactly at the TTL is NOT stale; one ms past IS stale (strictly greater)', () => {
+    expect(isHeartbeatStale(NOW - CLAIM_TTL_MS, NOW)).toBe(false);
+    expect(isHeartbeatStale(NOW - CLAIM_TTL_MS - 1, NOW)).toBe(true);
+  });
+  it('FAIL-OPEN: a missing/null/undefined heartbeat is treated as stale', () => {
+    expect(isHeartbeatStale(null, NOW)).toBe(true);
+    expect(isHeartbeatStale(undefined, NOW)).toBe(true);
+  });
+  it('FAIL-OPEN: an unparseable heartbeat is treated as stale', () => {
+    expect(isHeartbeatStale('not-a-date', NOW)).toBe(true);
+  });
+  it('accepts ISO-string and Date inputs', () => {
+    expect(isHeartbeatStale(new Date(minsAgo(5)).toISOString(), NOW)).toBe(false);
+    expect(isHeartbeatStale(new Date(minsAgo(30)), NOW)).toBe(true);
+  });
+  it('a non-finite now cannot judge staleness -> NOT stale (never false-reap a live-looking owner)', () => {
+    expect(isHeartbeatStale(minsAgo(999), NaN)).toBe(false);
+  });
+});
+
+describe('ownerIsDeadByLiveness — both mandatory directions (FR-2)', () => {
+  // ── Direction (a): genuinely-dead owner IS still reaped ──────────────────
+  it('(a) is_alive=false AND stale heartbeat (>900s) => DEAD (claim reaped)', () => {
+    expect(ownerIsDeadByLiveness({ is_alive: false, heartbeat_at: minsAgo(20) }, NOW)).toBe(true);
+  });
+  it('(a) is_alive=false AND no heartbeat => DEAD (fail-open, reaped)', () => {
+    expect(ownerIsDeadByLiveness({ is_alive: false, heartbeat_at: null }, NOW)).toBe(true);
+  });
+
+  // ── Direction (b): live-but-lagging owner is NOT reaped (thrash stops) ────
+  it('(b) is_alive=false BUT fresh heartbeat (30s ago) => NOT dead (thrash stops)', () => {
+    expect(ownerIsDeadByLiveness({ is_alive: false, heartbeat_at: secsAgo(30) }, NOW)).toBe(false);
+  });
+  it('(b) is_alive=false BUT heartbeat just within the TTL (14m ago) => NOT dead', () => {
+    expect(ownerIsDeadByLiveness({ is_alive: false, heartbeat_at: minsAgo(14) }, NOW)).toBe(false);
+  });
+
+  // ── Fail-open: missing owner + explicit lifecycle statuses still dead ─────
+  it('a missing owner is DEAD (fail-open preserved)', () => {
+    expect(ownerIsDeadByLiveness(null, NOW)).toBe(true);
+    expect(ownerIsDeadByLiveness(undefined, NOW)).toBe(true);
+  });
+  it("status 'stale'/'released' is DEAD regardless of a fresh heartbeat (explicit lifecycle wins)", () => {
+    expect(ownerIsDeadByLiveness({ status: 'stale', is_alive: true, heartbeat_at: secsAgo(1) }, NOW)).toBe(true);
+    expect(ownerIsDeadByLiveness({ status: 'released', is_alive: true, heartbeat_at: secsAgo(1) }, NOW)).toBe(true);
+  });
+
+  // ── No regression: is_alive=true was never reaped and still isn't ─────────
+  it('a fully-live owner (is_alive=true, fresh heartbeat) is NOT dead', () => {
+    expect(ownerIsDeadByLiveness({ status: 'active', is_alive: true, heartbeat_at: minsAgo(5) }, NOW)).toBe(false);
+  });
+  it('is_alive=true with a stale heartbeat is still NOT dead (only is_alive=false consults heartbeat; no regression)', () => {
+    expect(ownerIsDeadByLiveness({ is_alive: true, heartbeat_at: minsAgo(999) }, NOW)).toBe(false);
+  });
+});

--- a/tests/unit/reactivate-sd.test.js
+++ b/tests/unit/reactivate-sd.test.js
@@ -1,0 +1,128 @@
+/**
+ * SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001 (FR-4) — tests for the canonical
+ * reactivate-sd routine's PURE core: the status flip out of 'deferred', the
+ * metadata.blocker sync (reactivated_at stamped + blocker cleared), and the
+ * sd_transition_audit row shape (transition_type='REACTIVATE', pre/post_state).
+ * No DB — the IO wrapper is exercised via its pure building blocks.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeReactivation,
+  buildReactivationAudit,
+  VALID_REACTIVATION_TARGETS,
+} from '../../scripts/reactivate-sd.js';
+
+const NOW_ISO = '2026-06-16T03:00:00.000Z';
+
+const deferredSd = (overrides = {}) => ({
+  id: '3c9ebdcc-3620-43f9-bd26-c7e007ef77b1',
+  sd_key: 'SD-LEO-FIX-FOO-001',
+  status: 'deferred',
+  current_phase: 'LEAD',
+  metadata: { blocker: { kind: 'chairman_migration', status: 'open', note: 'awaiting attest' }, foo: 'bar' },
+  ...overrides,
+});
+
+describe('computeReactivation — status flip out of deferred (FR-3/FR-4)', () => {
+  it('flips status to the default target (draft) when deferred', () => {
+    const r = computeReactivation(deferredSd(), { nowIso: NOW_ISO });
+    expect(r.ok).toBe(true);
+    expect(r.updates.status).toBe('draft');
+  });
+
+  it('honors an explicit --to target', () => {
+    const r = computeReactivation(deferredSd(), { toStatus: 'in_progress', nowIso: NOW_ISO });
+    expect(r.updates.status).toBe('in_progress');
+  });
+
+  it('stamps metadata.reactivated_at and marks the blocker cleared (synced, not dropped)', () => {
+    const r = computeReactivation(deferredSd(), { nowIso: NOW_ISO });
+    expect(r.updates.metadata.reactivated_at).toBe(NOW_ISO);
+    expect(r.updates.metadata.blocker.status).toBe('cleared');
+    expect(r.updates.metadata.blocker.cleared_at).toBe(NOW_ISO);
+    // prior metadata preserved
+    expect(r.updates.metadata.foo).toBe('bar');
+    expect(r.updates.metadata.blocker.kind).toBe('chairman_migration');
+    expect(r.blockerCleared).toBe(true);
+  });
+
+  it('records a reactivation_reason when provided (capped)', () => {
+    const r = computeReactivation(deferredSd(), { reason: 'chairman cleared the gate', nowIso: NOW_ISO });
+    expect(r.updates.metadata.reactivation_reason).toBe('chairman cleared the gate');
+  });
+
+  it('handles an SD with no blocker (just stamps reactivated_at)', () => {
+    const r = computeReactivation(deferredSd({ metadata: { foo: 'bar' } }), { nowIso: NOW_ISO });
+    expect(r.ok).toBe(true);
+    expect(r.updates.metadata.reactivated_at).toBe(NOW_ISO);
+    expect(r.updates.metadata.blocker).toBeUndefined();
+    expect(r.blockerCleared).toBe(false);
+  });
+
+  it('tolerates null/array/missing metadata without throwing', () => {
+    for (const meta of [null, undefined, [], 'nope']) {
+      const r = computeReactivation(deferredSd({ metadata: meta }), { nowIso: NOW_ISO });
+      expect(r.ok).toBe(true);
+      expect(r.updates.metadata.reactivated_at).toBe(NOW_ISO);
+    }
+  });
+
+  it('pre_state/post_state capture the transition for the audit row', () => {
+    const r = computeReactivation(deferredSd(), { nowIso: NOW_ISO });
+    expect(r.pre_state).toEqual({ status: 'deferred', current_phase: 'LEAD', blocker_status: 'open' });
+    expect(r.post_state).toEqual({ status: 'draft', reactivated_at: NOW_ISO, blocker_status: 'cleared' });
+  });
+});
+
+describe('computeReactivation — guards (FR-3)', () => {
+  it('returns ok:false for a non-deferred SD (idempotent no-op signal)', () => {
+    const r = computeReactivation(deferredSd({ status: 'draft' }), { nowIso: NOW_ISO });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_deferred');
+    expect(r.terminal).toBe(false);
+  });
+
+  it('flags terminal statuses (completed/cancelled) for a loud refusal', () => {
+    expect(computeReactivation(deferredSd({ status: 'completed' })).terminal).toBe(true);
+    expect(computeReactivation(deferredSd({ status: 'cancelled' })).terminal).toBe(true);
+  });
+
+  it('throws on an invalid --to target', () => {
+    expect(() => computeReactivation(deferredSd(), { toStatus: 'deferred' })).toThrow(/invalid --to/);
+    expect(() => computeReactivation(deferredSd(), { toStatus: 'bogus' })).toThrow(/invalid --to/);
+  });
+
+  it('exposes the valid reactivation targets (does NOT allow re-deferring)', () => {
+    expect([...VALID_REACTIVATION_TARGETS].sort()).toEqual(['active', 'draft', 'in_progress']);
+    expect(VALID_REACTIVATION_TARGETS.has('deferred')).toBe(false);
+  });
+});
+
+describe('buildReactivationAudit — sd_transition_audit row shape (FR-3/FR-4)', () => {
+  const pre = { status: 'deferred', current_phase: 'LEAD', blocker_status: 'open' };
+  const post = { status: 'draft', reactivated_at: NOW_ISO, blocker_status: 'cleared' };
+
+  it('emits transition_type=REACTIVATE with status=completed + pre/post_state', () => {
+    const row = buildReactivationAudit({ sdId: 'uuid-1', pre_state: pre, post_state: post, requestId: 'req-1', nowIso: NOW_ISO });
+    expect(row.transition_type).toBe('REACTIVATE');
+    expect(row.status).toBe('completed');
+    expect(row.sd_id).toBe('uuid-1');
+    expect(row.pre_state).toEqual(pre);
+    expect(row.post_state).toEqual(post);
+    expect(row.started_at).toBe(NOW_ISO);
+    expect(row.completed_at).toBe(NOW_ISO);
+  });
+
+  it('carries the session_id (nullable) and a non-null request_id', () => {
+    const row = buildReactivationAudit({ sdId: 'uuid-1', pre_state: pre, sessionId: 'sess-9', requestId: 'req-1', nowIso: NOW_ISO });
+    expect(row.session_id).toBe('sess-9');
+    expect(row.request_id).toBe('req-1');
+    expect(row.post_state).toBeNull();
+  });
+
+  it('throws when the NOT NULL fields (sdId, requestId, pre_state) are missing', () => {
+    expect(() => buildReactivationAudit({ pre_state: pre, requestId: 'r' })).toThrow(/sdId/);
+    expect(() => buildReactivationAudit({ sdId: 'u', pre_state: pre })).toThrow(/requestId/);
+    expect(() => buildReactivationAudit({ sdId: 'u', requestId: 'r' })).toThrow(/pre_state/);
+  });
+});


### PR DESCRIPTION
## Summary
Stops fleet **claim/release thrash**. `lib/claim-validity-gate.js` auto-released a peer's claim whenever `claude_sessions.is_alive===false`, but `is_alive` **lags** `heartbeat_at` — so a live, actively-heartbeating /loop worker was misread as dead and reaped (observed live this session: the same SD self-claimed+released across passes).

## Changes
- **FR-1 (causal)**: new pure exports `CLAIM_TTL_MS` (900s), `isHeartbeatStale()`, `ownerIsDeadByLiveness()`. The foreign-claim reap branch now treats an `is_alive===false` owner as dead **only** when `heartbeat_at` is **also** stale beyond the TTL — trusting heartbeat over the lagging column. Missing owner + status `stale`/`released` still mark dead (**fail-open preserved**). Owner select widened with `heartbeat_at`.
- **FR-2**: both-direction adversarial tests — genuinely-dead owner still reaped; live-but-lagging owner NOT reaped.
- **FR-3**: NEW `scripts/reactivate-sd.js` (`npm run sd:reactivate`) — canonical atomic reactivation OUT of `status='deferred'`: guarded status flip + `metadata.blocker` sync + an `sd_transition_audit` row (`transition_type='REACTIVATE'`). Mirrors `cancel-sd.js`.
- **FR-4**: tests for the `computeReactivation` + `buildReactivationAudit` pure cores.

## Review + verification
- Adversarial review caught + fixed a **HIGH** (audit wrote the varchar `id` into the uuid FK `sd_transition_audit.sd_id` → silent insert failure; now passes `uuid_id`, **live-verified** with a self-cleaning probe) and a MED (UUID-input resolution).
- 79 tests green across `claim-*` + the new suites; no regression. **No schema change, no migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)