### PR TITLE
fix(SD-LEO-INFRA-ESTATE-LEDGER-PROJECTION-001): project estate classification onto conversion_ledger (mineable backlog)

### DIFF
--- a/lib/intake/conversion-ledger.js
+++ b/lib/intake/conversion-ledger.js
@@ -122,6 +122,36 @@ export async function setDisposition(id, verdict, opts = {}) {
 }
 
 /**
+ * Record a triage VERDICT on a ledger row WITHOUT a terminal disposition —
+ * SD-LEO-INFRA-ESTATE-LEDGER-PROJECTION-001 (FR-2). The estate drain deliberately leaves novel
+ * improvement-candidates UNdispositioned (they ARE the backlog), but the row must still SELF-DESCRIBE
+ * so the backlog is mineable. This sets triage_verdict (+ optional dedup_score) and marks
+ * intake_status='triaged', leaving `disposition` NULL so the honest backlog gauge is unaffected
+ * (backlogDepth counts terminal dispositions only). Idempotent — re-writes the same values.
+ *
+ * @param {string} id - conversion_ledger.id
+ * @param {{triage_verdict:string, dedup_score?:number}} verdict
+ * @param {Object} [opts] - {client}
+ */
+export async function recordVerdict(id, verdict, opts = {}) {
+  const db = opts.client || defaultClient();
+  if (!id) throw new Error('recordVerdict: id is required');
+  if (!verdict || typeof verdict.triage_verdict !== 'string' || verdict.triage_verdict.length === 0) {
+    throw new Error('recordVerdict: a non-empty triage_verdict string is required');
+  }
+  const patch = {
+    triage_verdict: verdict.triage_verdict,
+    intake_status: 'triaged', // CHECK allows {registered,triaged} only — NOT 'dispositioned'
+    updated_at: new Date().toISOString(),
+  };
+  if (verdict.dedup_score != null) patch.dedup_score = verdict.dedup_score;
+  // Deliberately does NOT touch `disposition` — an undispositioned backlog row stays in the gauge.
+  const { data, error } = await db.from('conversion_ledger').update(patch).eq('id', id).select('*').maybeSingle();
+  if (error) throw new Error(`recordVerdict failed: ${error.message}`);
+  return data;
+}
+
+/**
  * Backlog depth — items with no terminal disposition yet.
  * @param {Object} [opts] - {client}
  * @returns {Promise<number>}

--- a/package.json
+++ b/package.json
@@ -324,6 +324,7 @@
     "llc:track": "node scripts/legal/track-llc-formation.mjs",
     "intake:drain": "node scripts/intake/drain-intake.mjs",
     "intake:drain-estate": "node scripts/intake/drain-intake.mjs --pools estate",
+    "intake:backfill-estate-projection": "node scripts/intake/backfill-estate-ledger-projection.mjs",
     "stage-contracts:check": "node scripts/validate-stage-contract-connectivity.mjs",
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",

--- a/scripts/intake/backfill-estate-ledger-projection.mjs
+++ b/scripts/intake/backfill-estate-ledger-projection.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Corrective backfill — SD-LEO-INFRA-ESTATE-LEDGER-PROJECTION-001 (FR-1).
+ *
+ * The estate drain (SD-LEO-INFRA-ESTATE-DISPOSITION-001) registered all 561 idea-estate items into
+ * conversion_ledger and wrote each one's disposition_classification + 0-3 compounding_score into the
+ * SOURCE row's raw_data — but for the dominant case (a novel improvement-candidate left UNdispositioned
+ * to stay in the backlog) it never PROJECTED a verdict onto the ledger row. Result: every estate ledger
+ * row has a NULL triage_verdict and the backlog is un-mineable.
+ *
+ * This one-shot, idempotent backfill reads each source table's raw_data back-pointer
+ * (raw_data.conversion_ledger_id) + the already-computed raw_data.disposition_classification and projects
+ * the classification onto the referenced ledger row via recordVerdict() — setting triage_verdict +
+ * intake_status='triaged'. It NEVER writes a terminal disposition (the backlog gauge is unaffected) and
+ * NEVER mints SDs (linked_sd_key stays NULL). The forward fix (FR-2, in drain-intake.mjs) prevents
+ * recurrence; this corrects the rows already drained.
+ *
+ *   DEFAULT = --dry-run: zero writes; reports the projection plan.
+ *   --apply : projects each verdict onto its ledger row (idempotent — a re-run reports 0 net updates).
+ *
+ * Usage:
+ *   node scripts/intake/backfill-estate-ledger-projection.mjs            # dry-run (default)
+ *   node scripts/intake/backfill-estate-ledger-projection.mjs --apply
+ */
+import dotenv from 'dotenv';
+dotenv.config({ path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.env', override: true });
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { recordVerdict } from '../../lib/intake/conversion-ledger.js';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+
+// The 3 estate source tables (the 4th pool, ehg_folder, has no source rows).
+export const ESTATE_SOURCE_TABLES = ['eva_todoist_intake', 'eva_youtube_intake', 'eva_claude_code_intake'];
+
+/** PURE: extract the projection {ledger_id, classification} from a source row's raw_data, or null. */
+export function extractProjection(row) {
+  const raw = (row && row.raw_data && typeof row.raw_data === 'object' && !Array.isArray(row.raw_data)) ? row.raw_data : {};
+  const ledger_id = raw.conversion_ledger_id || null;
+  const classification = raw.disposition_classification || null;
+  if (!ledger_id || !classification) return null;
+  return { source_id: row.id, ledger_id, classification };
+}
+
+async function loadProjectable(sb, table) {
+  const { data, error } = await sb.from(table).select('id, raw_data');
+  if (error) throw new Error(`load ${table}: ${error.message}`);
+  return (data || []).map((r) => extractProjection(r)).filter(Boolean).map((p) => ({ ...p, table }));
+}
+
+async function main() {
+  const sb = createSupabaseServiceClient();
+  console.log(`\n=== estate ledger projection backfill (${DRY_RUN ? 'DRY-RUN — zero writes' : 'APPLY'}) ===`);
+  const loaded = await Promise.all(ESTATE_SOURCE_TABLES.map((t) => loadProjectable(sb, t)));
+  const items = loaded.flat();
+  console.log(`   projectable source rows: ${ESTATE_SOURCE_TABLES.map((t, i) => `${t}=${loaded[i].length}`).join(', ')} | total=${items.length}`);
+
+  let updated = 0, alreadyProjected = 0, orphanBackPointer = 0, failed = 0;
+  const verdictDist = {};
+  for (const it of items) {
+    verdictDist[it.classification] = (verdictDist[it.classification] || 0) + 1;
+    // Read current ledger state so idempotency (already-projected) is observable + reportable.
+    const { data: cur, error: rdErr } = await sb.from('conversion_ledger')
+      .select('id, triage_verdict').eq('id', it.ledger_id).maybeSingle();
+    if (rdErr) { console.warn(`   ⚠️  read ${it.ledger_id}: ${rdErr.message}`); failed++; continue; }
+    if (!cur) { orphanBackPointer++; continue; } // back-pointer references a missing ledger row
+    if (cur.triage_verdict === it.classification) { alreadyProjected++; continue; }
+    if (DRY_RUN) { updated++; continue; }
+    try {
+      await recordVerdict(it.ledger_id, { triage_verdict: it.classification }, { client: sb });
+      updated++;
+    } catch (e) { console.error(`   ❌ ${it.ledger_id}: ${e.message}`); failed++; }
+  }
+
+  console.log('\n--- projection plan ---');
+  console.log('   verdict distribution :', JSON.stringify(verdictDist));
+  console.log(`   ${DRY_RUN ? 'would update' : 'updated'}     : ${updated}`);
+  console.log(`   already-projected    : ${alreadyProjected}  (idempotent)`);
+  console.log(`   orphan back-pointer  : ${orphanBackPointer}  (no ledger row)`);
+  console.log(`   failed               : ${failed}`);
+  if (DRY_RUN) console.log('\n   DRY-RUN: zero writes. Re-run with --apply to project the verdicts onto the ledger.');
+}
+
+const invokedDirectly = process.argv[1] && /backfill-estate-ledger-projection\.mjs$/.test(process.argv[1]);
+if (invokedDirectly) main().catch((e) => { console.error('backfill FAILED:', e?.stack || e); process.exit(1); });

--- a/scripts/intake/drain-intake.mjs
+++ b/scripts/intake/drain-intake.mjs
@@ -24,7 +24,7 @@ import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import { classify } from '../../lib/intake/triage-classifier.js';
-import { registerItem, setDisposition, backlogDepth } from '../../lib/intake/conversion-ledger.js';
+import { registerItem, setDisposition, recordVerdict, backlogDepth } from '../../lib/intake/conversion-ledger.js';
 // SD-LEO-INFRA-ESTATE-DISPOSITION-001 (FR-2): pure 0-3 compounding score captured at disposition time.
 import { computeCompoundingScore } from '../../lib/intake/compounding-score.js';
 // SD-LEO-INFRA-ESTATE-DISPOSITION-001: pure, unit-tested estate-disposition helpers.
@@ -230,6 +230,12 @@ async function runEstateDrain(sb) {
           dedup_match_sd_key: verdict.dedup_match_sd_key, dedup_score: verdict.dedup_score,
           dismiss_reason: verdict.dismiss_reason,
         }, { client: sb });
+      } else {
+        // FR-2 (SD-LEO-INFRA-ESTATE-LEDGER-PROJECTION-001): DECOUPLE recording from promotion.
+        // A suppressed-promote / ambiguous item stays UNdispositioned (it IS the backlog), but the
+        // ledger row must SELF-DESCRIBE so the backlog is mineable — record the classification as the
+        // queryable verdict (intake_status='triaged', disposition stays NULL). NO SD is created here.
+        await recordVerdict(row.id, { triage_verdict: classification }, { client: sb });
       }
       await markOffEstateSource(sb, item, row.id, score, classification);
       applied++;

--- a/tests/unit/intake/estate-ledger-projection-contract.test.js
+++ b/tests/unit/intake/estate-ledger-projection-contract.test.js
@@ -1,0 +1,98 @@
+/**
+ * SD-LEO-INFRA-ESTATE-LEDGER-PROJECTION-001 (FR-3) — consumer-contract test.
+ *
+ * The 37 existing estate tests assert helper PURITY but never assert the END-STATE ledger contract,
+ * which is why an all-NULL-triage_verdict ledger passed every gate. This test pins the contract the
+ * drain's record step + the backfill must satisfy: a registered estate ledger row ends with a
+ * non-NULL, queryable triage_verdict and intake_status='triaged', WITHOUT a terminal disposition
+ * (so the honest backlog gauge is unaffected). Hermetic — mock client, no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { recordVerdict } from '../../../lib/intake/conversion-ledger.js';
+import { extractProjection } from '../../../scripts/intake/backfill-estate-ledger-projection.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const drainSrc = readFileSync(resolve(__dirname, '../../..', 'scripts/intake/drain-intake.mjs'), 'utf8');
+
+// Minimal chainable supabase mock capturing the update patch + returning the post-update row.
+function mockClient() {
+  const calls = { table: null, update: null, eqId: null };
+  const chain = {
+    update(patch) { calls.update = patch; return chain; },
+    eq(col, val) { if (col === 'id') calls.eqId = val; return chain; },
+    select() { return chain; },
+    async maybeSingle() { return { data: { id: calls.eqId, disposition: null, ...calls.update }, error: null }; },
+  };
+  return { calls, from(table) { calls.table = table; return chain; } };
+}
+
+describe('recordVerdict — the ledger self-describes without exiting the backlog (FR-2/FR-3 contract)', () => {
+  it('CONTRACT: a recorded row carries a non-NULL triage_verdict + intake_status=triaged and NO disposition', async () => {
+    const c = mockClient();
+    const row = await recordVerdict('ledger-1', { triage_verdict: 'improvement-candidate' }, { client: c });
+    expect(c.calls.table).toBe('conversion_ledger');
+    expect(c.calls.eqId).toBe('ledger-1');
+    expect(c.calls.update.triage_verdict).toBe('improvement-candidate');
+    expect(c.calls.update.intake_status).toBe('triaged');
+    expect('disposition' in c.calls.update).toBe(false); // never writes a terminal disposition
+    // end-state row: queryable verdict present, still in the backlog (disposition NULL)
+    expect(row.triage_verdict).toBeTruthy();
+    expect(row.disposition).toBeNull();
+  });
+
+  it('carries dedup_score ONLY when supplied', async () => {
+    const c1 = mockClient();
+    await recordVerdict('l', { triage_verdict: 'drop' }, { client: c1 });
+    expect('dedup_score' in c1.calls.update).toBe(false);
+    const c2 = mockClient();
+    await recordVerdict('l', { triage_verdict: 'drop', dedup_score: 0.42 }, { client: c2 });
+    expect(c2.calls.update.dedup_score).toBe(0.42);
+  });
+
+  it('rejects a missing/empty triage_verdict and a missing id (a row MUST carry a queryable verdict)', async () => {
+    const c = mockClient();
+    await expect(recordVerdict('l', {}, { client: c })).rejects.toThrow(/triage_verdict/);
+    await expect(recordVerdict('l', { triage_verdict: '' }, { client: c })).rejects.toThrow(/triage_verdict/);
+    await expect(recordVerdict('', { triage_verdict: 'x' }, { client: c })).rejects.toThrow(/id is required/);
+  });
+});
+
+describe('extractProjection — the backfill reads the source back-pointer + classification (FR-1)', () => {
+  it('extracts {source_id, ledger_id, classification} from a drained source row raw_data', () => {
+    const p = extractProjection({ id: 's1', raw_data: { conversion_ledger_id: 'L1', disposition_classification: 'improvement-candidate', compounding_score: 2 } });
+    expect(p).toEqual({ source_id: 's1', ledger_id: 'L1', classification: 'improvement-candidate' });
+  });
+
+  it('returns null when the back-pointer OR classification is absent (un-drained / un-classified rows skipped)', () => {
+    expect(extractProjection({ id: 's', raw_data: { disposition_classification: 'drop' } })).toBeNull(); // no ledger_id
+    expect(extractProjection({ id: 's', raw_data: { conversion_ledger_id: 'L' } })).toBeNull();          // no classification
+    expect(extractProjection({ id: 's', raw_data: null })).toBeNull();
+    expect(extractProjection({ id: 's', raw_data: [] })).toBeNull();
+    expect(extractProjection({ id: 's' })).toBeNull();
+  });
+});
+
+// The drain's suppressed-promote RECORD step is an un-mocked IO call-site inside runEstateDrain, so
+// the helper tests above can't exercise it. Pin the wiring by source-text (mirrors
+// claim-validity-gate-sd-key-drift.test.js) so a refactor can't silently swap recordVerdict for
+// setDisposition or pass the wrong verdict value — the exact caller-interaction class that hides from
+// isolated green tests.
+describe('drain wiring: the suppressed-promote path RECORDS a verdict on the ledger (FR-2 call-site)', () => {
+  it('imports recordVerdict from the conversion-ledger lib', () => {
+    expect(drainSrc).toMatch(/import\s*\{[^}]*\brecordVerdict\b[^}]*\}\s*from\s*['"][^'"]*conversion-ledger\.js['"]/);
+  });
+  it('the if(disposition){setDisposition} block has an else that calls recordVerdict(row.id, {triage_verdict: classification})', () => {
+    expect(drainSrc).toMatch(/\}\s*else\s*\{[\s\S]*?recordVerdict\(\s*row\.id\s*,\s*\{\s*triage_verdict:\s*classification\s*\}/);
+  });
+  it('no recordVerdict call ever passes a disposition (the record step never exits the backlog gauge)', () => {
+    // robust: scan every recordVerdict(...) call's arguments — none may carry a disposition key.
+    for (const m of drainSrc.matchAll(/recordVerdict\(([\s\S]*?)\)\s*,\s*\{\s*client/g)) {
+      expect(m[1]).not.toMatch(/disposition/);
+    }
+    // and at least one recordVerdict call exists (the FR-2 wiring is present)
+    expect(drainSrc).toMatch(/recordVerdict\(/);
+  });
+});


### PR DESCRIPTION
## Summary
The estate drain registered all **561** idea-estate items into `conversion_ledger` and computed each one's classification, but only wrote the verdict onto a ledger row for **terminal** dispositions — the dominant suppressed-promote/undispositioned case wrote the classification only into the source `raw_data`, leaving **all 561 ledger rows with NULL `triage_verdict`** (registered but un-mineable). The 37 existing tests asserted helper purity and never the end-state ledger contract, so the all-NULL ledger passed every gate.

## Changes
- **FR-1** NEW `scripts/intake/backfill-estate-ledger-projection.mjs` (`npm run intake:backfill-estate-projection`) — idempotent corrective backfill. **Live `--apply`: 561 rows → non-NULL `triage_verdict` + `intake_status='triaged'`, 0 dispositions written, idempotent re-run (0 updated / 561 already-projected).**
- **FR-2** NEW `recordVerdict()` in `lib/intake/conversion-ledger.js` (sets `triage_verdict` + `intake_status='triaged'` — **never** a disposition; live CHECK allows only `{registered,triaged}`, NOT the SD-text's `dispositioned`). `drain-intake.mjs runEstateDrain` now records the verdict on the suppressed-promote path — **decoupling RECORD from PROMOTE** (still no SD created, `disposition` stays NULL).
- **FR-3** `tests/unit/intake/estate-ledger-projection-contract.test.js` — the end-state contract + a source-text assertion pinning the drain `else` call-site (closing the caller-interaction dark seam isolated helper tests miss). **45 intake tests green.**
- **FR-4** `v_estate_traceback` verified to still resolve (561 rows).

## Safety
- **Backlog-gauge safe**: never writes a terminal disposition (`backlogDepth` counts terminal only); live `disposition IS NOT NULL` = **0**.
- No schema change, no migration, no new column, no governed-row insert. Adversarial review: 0 HIGH/MED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)