### PR TITLE
feat(SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001): reclaim orphaned .worktrees/ dirs (durable disk-full fix)

### DIFF
--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -164,22 +164,31 @@ export function countFilesystemWorktreeDirs(worktreesDir) {
  * that preceded the active-claim reaping incident. Reporting-accuracy only
  * (never deletes; the orphan warning remains warning-only).
  *
+ * SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (FR-1/FR-3): additively returns the actual
+ * reapable orphan PATHS (`reapableDirs`) so the sweep can RECLAIM them (not just count),
+ * and accepts a `minAgeMs`/`now` recent-dir guard so a freshly-created dir mid-`git
+ * worktree add` is never reaped. Defaults (`minAgeMs=0`) preserve every existing caller's
+ * behavior byte-for-byte (now - mtime is never < 0, so nothing is newly excluded).
+ *
  * @param {string} worktreesDir
  * @param {Array<{path:string}>|string[]} [registered=[]] - git-registered worktrees (or paths)
- * @param {{liveOwners?: Set<string>, gitRunner?: function}} [opts]
+ * @param {{liveOwners?: Set<string>, gitRunner?: function, minAgeMs?: number, now?: number}} [opts]
  *        liveOwners: normalized paths owned by a fresh-heartbeat session.
- * @returns {{reapable: number, excluded: Array<{dir:string, reason:string}>, total: number}}
+ *        minAgeMs: exclude dirs whose mtime is newer than (now - minAgeMs) as 'too_recent'.
+ *        now: clock injection for deterministic tests (defaults to Date.now()).
+ * @returns {{reapable: number, reapableDirs: Array<{dir:string, full:string}>, excluded: Array<{dir:string, reason:string}>, total: number}}
  */
 export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
-  const { liveOwners = new Set(), gitRunner } = opts;
-  if (!worktreesDir || !fs.existsSync(worktreesDir)) return { reapable: 0, excluded: [], total: 0 };
+  const { liveOwners = new Set(), gitRunner, minAgeMs = 0, now = Date.now() } = opts;
+  const empty = { reapable: 0, reapableDirs: [], excluded: [], total: 0 };
+  if (!worktreesDir || !fs.existsSync(worktreesDir)) return { ...empty };
   const registeredSet = new Set(
     (registered || []).map((r) => normalizePath(typeof r === 'string' ? r : r.path))
   );
   let entries;
-  try { entries = fs.readdirSync(worktreesDir); } catch { return { reapable: 0, excluded: [], total: 0 }; }
+  try { entries = fs.readdirSync(worktreesDir); } catch { return { ...empty }; }
   const excluded = [];
-  let reapable = 0;
+  const reapableDirs = [];
   let total = 0;
   for (const entry of entries) {
     if (WORKTREE_QUOTA_HELPERS.has(entry)) continue;
@@ -189,15 +198,22 @@ export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
     total++;
     const normFull = normalizePath(full);
     if (liveOwners.has(normFull)) { excluded.push({ dir: entry, reason: 'live_owner' }); continue; }
+    // FR-3 recent-dir guard: never reap a dir created within minAgeMs (could be a
+    // worktree mid-`git worktree add` not yet registered). minAgeMs=0 → no-op.
+    if (minAgeMs > 0) {
+      let mtimeMs = 0;
+      try { mtimeMs = fs.statSync(full).mtimeMs; } catch { mtimeMs = now; }
+      if (now - mtimeMs < minAgeMs) { excluded.push({ dir: entry, reason: 'too_recent' }); continue; }
+    }
     // A plain leftover dir (no .git) cannot carry its OWN uncommitted/unpushed
     // state — git status from it would report the ENCLOSING repo — so it is a
     // genuine reapable orphan. Only worktree-root dirs get the dirty/unpushed predicate.
-    if (!fs.existsSync(path.join(full, '.git'))) { reapable++; continue; }
+    if (!fs.existsSync(path.join(full, '.git'))) { reapableDirs.push({ dir: entry, full }); continue; }
     const verdict = isReapable(full, { liveOwner: false, gitRunner });
-    if (verdict.reapable) reapable++;
+    if (verdict.reapable) reapableDirs.push({ dir: entry, full });
     else excluded.push({ dir: entry, reason: verdict.reason });
   }
-  return { reapable, excluded, total };
+  return { reapable: reapableDirs.length, reapableDirs, excluded, total };
 }
 
 /**
@@ -231,7 +247,7 @@ export function emitOrphanWarningIfAny(fsCount, registeredCount, logger = consol
     logger(
       `[worktree-quota] ORPHAN_DETECTED: ${orphanCount} orphan directories ` +
       `in .worktrees/ (fs=${fsCount}, git-registered=${registeredCount})${excludedNote}. ` +
-      `Run cleanup or invoke the reaper.`
+      'Run cleanup or invoke the reaper.'
     );
   } else if (excludedNote) {
     logger(`[worktree-quota] no reapable orphans${excludedNote}.`);

--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -182,8 +182,14 @@ export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
   const { liveOwners = new Set(), gitRunner, minAgeMs = 0, now = Date.now() } = opts;
   const empty = { reapable: 0, reapableDirs: [], excluded: [], total: 0 };
   if (!worktreesDir || !fs.existsSync(worktreesDir)) return { ...empty };
+  // SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (review HIGH): on Windows the filesystem is
+  // case-INSENSITIVE, so the registered-worktree exclusion must compare case-insensitively
+  // or a registered worktree whose on-disk casing differs from git's recorded casing could
+  // slip through and be REAPED. cmpKey lowercases only on win32 (Linux paths stay case-sensitive).
+  const ciWin = process.platform === 'win32';
+  const cmpKey = (p) => { const n = normalizePath(p); return ciWin ? n.toLowerCase() : n; };
   const registeredSet = new Set(
-    (registered || []).map((r) => normalizePath(typeof r === 'string' ? r : r.path))
+    (registered || []).map((r) => cmpKey(typeof r === 'string' ? r : r.path))
   );
   let entries;
   try { entries = fs.readdirSync(worktreesDir); } catch { return { ...empty }; }
@@ -194,10 +200,14 @@ export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
     if (WORKTREE_QUOTA_HELPERS.has(entry)) continue;
     const full = path.join(worktreesDir, entry);
     try { if (!fs.statSync(full).isDirectory()) continue; } catch { continue; }
-    if (registeredSet.has(normalizePath(full))) continue; // registered → not an orphan
+    if (registeredSet.has(cmpKey(full))) continue; // registered → not an orphan (case-insensitive on Windows)
     total++;
     const normFull = normalizePath(full);
-    if (liveOwners.has(normFull)) { excluded.push({ dir: entry, reason: 'live_owner' }); continue; }
+    // SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (review HIGH): `liveOwners` may be produced with a
+    // DIFFERENT normalizePath — worktree-reapability.js lowercases on ALL platforms, this module
+    // does not — so compare case-insensitively too, else the live-owner guard is silently defeated
+    // by path-casing drift across the module boundary and a live-claimed dir could be reaped.
+    if (liveOwners.has(normFull) || liveOwners.has(normFull.toLowerCase())) { excluded.push({ dir: entry, reason: 'live_owner' }); continue; }
     // FR-3 recent-dir guard: never reap a dir created within minAgeMs (could be a
     // worktree mid-`git worktree add` not yet registered). minAgeMs=0 → no-op.
     if (minAgeMs > 0) {

--- a/lib/worktree-reaper/orphan-sweep.js
+++ b/lib/worktree-reaper/orphan-sweep.js
@@ -1,0 +1,259 @@
+/**
+ * orphan-sweep.js — SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001
+ *
+ * Durable fix for the recurring disk-full fleet blocker: reclaim ORPHANED `.worktrees/`
+ * directories — dirs present on disk but NOT in `git worktree list` (e.g. a worktree dir
+ * left behind when `git worktree remove` fails on a Windows permission lock). The reaper's
+ * main scan enumerates git-REGISTERED worktrees only, so disk-only orphans are structurally
+ * invisible to it and accumulate unbounded until the disk fills.
+ *
+ * This module REUSES the existing safe primitives — it adds NO new detector and NO new
+ * junction-unlink logic:
+ *   • selection  → lib/worktree-quota.js::classifyOrphanDirs (orphan set + isReapable guard
+ *                  + the FR-3 recent-dir guard), enumerating registered via listActiveWorktrees.
+ *   • reclamation → the same junction-safe path the reaper uses (removeWorktreeViaGit, which
+ *                  pre-unlinks the node_modules junction, then safeRecursiveRm as fallback).
+ *
+ * CARDINAL SAFETY INVARIANT: NEVER raw-rm an orphan. A raw recursive delete can FOLLOW the
+ * orphan's node_modules junction and gut the shared node_modules fleet-wide (ERR_MODULE_NOT_FOUND).
+ * All removal goes through safeRecursiveRm, which unlinks every junction/symlink descendant
+ * BEFORE fs.rmSync.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { classifyOrphanDirs, listActiveWorktrees, WORKTREE_QUOTA_HELPERS } from '../worktree-quota.js';
+import { safeRecursiveRm, removeWorktreeViaGit } from '../worktree-manager.js';
+
+// FR-3: never reap a dir created within this window (could be a worktree mid-`git worktree add`).
+export const DEFAULT_ORPHAN_MIN_AGE_MS = 30 * 60 * 1000; // 30 min
+
+/**
+ * Resolve the recent-dir age threshold from env, falling back to the default. Non-finite or
+ * negative env values fall back (fail-safe toward MORE conservatism, never 0/disabled by typo).
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ * @returns {number}
+ */
+export function resolveMinAgeMs(env = process.env) {
+  const raw = env && env.WORKTREE_ORPHAN_MIN_AGE_MS;
+  if (raw == null || raw === '') return DEFAULT_ORPHAN_MIN_AGE_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_ORPHAN_MIN_AGE_MS;
+}
+
+// The typed-layout parent dirs. Worktrees live INSIDE these (.worktrees/qf/<id>,
+// .worktrees/sd/<id>, .worktrees/adhoc/<id>), so an orphan under them is invisible to a
+// top-level scan (classifyOrphanDirs skips these helper names at the top level). We descend
+// one level into each so typed-layout leftovers (the dominant orphan case — e.g. a qf/<id>
+// dir left behind when `git worktree remove` hits a Windows lock) are caught. `_archive` is
+// deliberately NOT scanned: it is the reaper's preserve destination, not abandoned work.
+const TYPED_SUBDIRS = ['qf', 'sd', 'adhoc'];
+
+/**
+ * PURE-over-IO: select the reapable orphan directories across BOTH the flat legacy layout
+ * (.worktrees/<id>) and the typed layout (.worktrees/{qf,sd,adhoc}/<id>). Composes
+ * classifyOrphanDirs per scan root (no change to its shared semantics) and merges. Returns
+ * the actual paths so the caller can reclaim them.
+ *
+ * @param {{repoRoot: string, worktreesDir: string, now?: number, minAgeMs?: number,
+ *          liveOwners?: Set<string>, gitRunner?: function, registered?: Array,
+ *          listRegistered?: function}} opts
+ * @returns {{reapable: number, reapableDirs: Array<{dir:string, full:string}>,
+ *            excluded: Array<{dir:string, reason:string}>, total: number}}
+ */
+export function selectReapableOrphans(opts = {}) {
+  const {
+    repoRoot,
+    worktreesDir,
+    now = Date.now(),
+    minAgeMs = DEFAULT_ORPHAN_MIN_AGE_MS,
+    liveOwners = new Set(),
+    gitRunner,
+    listRegistered = listActiveWorktrees,
+  } = opts;
+  const registered = opts.registered || (repoRoot ? listRegistered(repoRoot) : []);
+  const cfg = { liveOwners, gitRunner, minAgeMs, now };
+
+  // Scan the top level (flat layout) plus each typed subdir (one level down).
+  const scanRoots = [worktreesDir, ...TYPED_SUBDIRS.map((s) => path.join(worktreesDir, s))];
+  const merged = { reapable: 0, reapableDirs: [], excluded: [], total: 0 };
+  const seen = new Set();
+  for (const rootDir of scanRoots) {
+    let exists = false;
+    try { exists = fs.existsSync(rootDir) && fs.statSync(rootDir).isDirectory(); } catch { exists = false; }
+    if (!exists) continue;
+    const r = classifyOrphanDirs(rootDir, registered, cfg);
+    // Label nested entries with their typed prefix so summaries are unambiguous (qf/<id>).
+    const prefix = rootDir === worktreesDir ? '' : path.basename(rootDir) + '/';
+    for (const d of r.reapableDirs) {
+      if (seen.has(d.full)) continue;
+      seen.add(d.full);
+      merged.reapableDirs.push({ dir: prefix + d.dir, full: d.full });
+    }
+    for (const e of r.excluded) merged.excluded.push({ dir: prefix + e.dir, reason: e.reason });
+    merged.total += r.total;
+  }
+  merged.reapable = merged.reapableDirs.length;
+  return merged;
+}
+
+/**
+ * Best-effort recursive byte size of a directory, NOT following symlinks/junctions (so a
+ * node_modules junction to the shared store is counted as ~0, not the whole shared tree).
+ * Fail-soft: returns the bytes accumulated so far on any error.
+ * @param {string} dir
+ * @param {{fsImpl?: typeof fs}} [opts]
+ * @returns {number}
+ */
+export function dirSizeBytes(dir, { fsImpl = fs } = {}) {
+  let total = 0;
+  let stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let st;
+    try { st = fsImpl.lstatSync(cur); } catch { continue; }
+    if (st.isSymbolicLink()) continue; // never traverse a junction/symlink
+    if (st.isDirectory()) {
+      let entries;
+      try { entries = fsImpl.readdirSync(cur); } catch { continue; }
+      for (const e of entries) stack.push(path.join(cur, e));
+    } else {
+      total += st.size || 0;
+    }
+  }
+  return total;
+}
+
+/**
+ * Default junction-safe orphan remover — mirrors scripts/worktree-reaper.mjs::removeWorktree:
+ * try `git worktree remove --force` (pre-unlinks the node_modules junction) which FAILS on an
+ * unregistered path, then fall back to safeRecursiveRm (unlinks all junctions/symlinks first).
+ * NEVER a raw fs.rmSync. Returns {ok, method, error?}.
+ * @param {string} full
+ * @param {string} repoRoot
+ * @returns {{ok: boolean, method: string, error?: string}}
+ */
+export function defaultRemoveOrphan(full, repoRoot) {
+  const abs = path.resolve(full);
+  // Most orphans are unregistered (git will refuse), but a prunable-but-still-listed dir may
+  // succeed here and get its junction safely pre-unlinked — so we try it first, allowFail.
+  try {
+    const primary = removeWorktreeViaGit(abs, repoRoot, { allowFail: true });
+    if (primary && primary.ok) return { ok: true, method: 'git-worktree-remove' };
+  } catch { /* fall through to junction-safe fs removal */ }
+  try {
+    if (fs.existsSync(abs)) safeRecursiveRm(abs); // unlinks junctions/symlinks BEFORE rmSync
+    return { ok: true, method: 'safe-recursive-rm' };
+  } catch (e) {
+    return { ok: false, method: 'failed', error: String(e?.message || e) };
+  }
+}
+
+/**
+ * Reclaim the selected orphan dirs. Dry-run by default (execute=false → removes nothing).
+ * Fail-soft PER orphan: a removal error on one orphan is recorded and the loop continues.
+ *
+ * @param {Array<{dir:string, full:string}>} reapableDirs
+ * @param {{execute?: boolean, repoRoot: string, remove?: function, sizeOf?: function,
+ *          logger?: function}} [opts]
+ * @returns {{reclaimed: Array<{dir, bytes, method}>, failed: Array<{dir, error}>,
+ *            reclaimed_count: number, reclaimed_bytes: number, dry_run: boolean}}
+ */
+export function reclaimOrphans(reapableDirs = [], opts = {}) {
+  const {
+    execute = false,
+    repoRoot,
+    remove = defaultRemoveOrphan,
+    sizeOf = (full) => dirSizeBytes(full),
+    logger = () => {},
+  } = opts;
+  const reclaimed = [];
+  const failed = [];
+  for (const { dir, full } of reapableDirs) {
+    let bytes = 0;
+    try { bytes = sizeOf(full); } catch { bytes = 0; }
+    if (!execute) { reclaimed.push({ dir, bytes, method: 'dry-run' }); continue; }
+    try {
+      const res = remove(full, repoRoot);
+      if (res && res.ok) {
+        reclaimed.push({ dir, bytes, method: res.method });
+      } else {
+        failed.push({ dir, error: (res && res.error) || 'unknown removal failure' });
+        logger(`[orphan-sweep] FAILED to reclaim ${dir}: ${(res && res.error) || 'unknown'}`);
+      }
+    } catch (e) {
+      // Fail-soft: never let one orphan abort the sweep.
+      failed.push({ dir, error: String(e?.message || e) });
+      logger(`[orphan-sweep] ERROR reclaiming ${dir}: ${String(e?.message || e)}`);
+    }
+  }
+  const reclaimed_bytes = reclaimed.reduce((s, r) => s + (r.bytes || 0), 0);
+  return {
+    reclaimed,
+    failed,
+    reclaimed_count: reclaimed.length,
+    reclaimed_bytes,
+    dry_run: !execute,
+  };
+}
+
+/**
+ * Build the durable one-line summary record (stderr JSON line + best-effort audit_log).
+ * @param {object} sel - selectReapableOrphans result
+ * @param {object} rec - reclaimOrphans result
+ * @param {{now?: number}} [opts]
+ */
+export function buildOrphanSummary(sel, rec, { now = Date.now() } = {}) {
+  return {
+    schema_version: 1,
+    timestamp: new Date(now).toISOString(),
+    event: 'orphan_sweep',
+    scanned: sel.total,
+    reapable: sel.reapable,
+    excluded_count: sel.excluded.length,
+    reclaimed_count: rec.reclaimed_count,
+    reclaimed_bytes: rec.reclaimed_bytes,
+    failed_count: rec.failed.length,
+    dry_run: rec.dry_run,
+  };
+}
+
+/**
+ * Orchestrate one orphan sweep: select → reclaim → summarize. Top-level fail-soft so a sweep
+ * error NEVER aborts the caller (the hourly reaper). The summary is emitted via `emit`.
+ *
+ * @param {{repoRoot: string, worktreesDir: string, execute?: boolean, minAgeMs?: number,
+ *          now?: number, liveOwners?: Set<string>, gitRunner?: function, remove?: function,
+ *          emit?: function, logger?: function, listRegistered?: function}} [opts]
+ * @returns {{ok: boolean, summary?: object, error?: string}}
+ */
+export function runOrphanSweep(opts = {}) {
+  const {
+    repoRoot,
+    worktreesDir,
+    execute = false,
+    minAgeMs = resolveMinAgeMs(),
+    now = Date.now(),
+    liveOwners,
+    gitRunner,
+    remove,
+    emit = (rec) => { try { process.stderr.write(JSON.stringify(rec) + '\n'); } catch { /* ignore */ } },
+    logger = (m) => { try { process.stderr.write(m + '\n'); } catch { /* ignore */ } },
+    listRegistered,
+  } = opts;
+  try {
+    const sel = selectReapableOrphans({ repoRoot, worktreesDir, now, minAgeMs, liveOwners, gitRunner, listRegistered });
+    const rec = reclaimOrphans(sel.reapableDirs, { execute, repoRoot, remove, logger });
+    const summary = buildOrphanSummary(sel, rec, { now });
+    emit(summary);
+    return { ok: true, summary, selection: sel, reclamation: rec };
+  } catch (e) {
+    // Cardinal fail-soft: a sweep failure must never break the reaper or the tick.
+    const error = String(e?.message || e);
+    logger(`[orphan-sweep] sweep aborted (fail-soft): ${error}`);
+    return { ok: false, error };
+  }
+}
+
+// Re-export the helper set for callers that want to display what is preserved.
+export { WORKTREE_QUOTA_HELPERS };

--- a/lib/worktree-reaper/orphan-sweep.js
+++ b/lib/worktree-reaper/orphan-sweep.js
@@ -22,8 +22,9 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { classifyOrphanDirs, listActiveWorktrees, WORKTREE_QUOTA_HELPERS } from '../worktree-quota.js';
-import { safeRecursiveRm, removeWorktreeViaGit } from '../worktree-manager.js';
+import { safeRecursiveRm } from '../worktree-manager.js';
 
 // FR-3: never reap a dir created within this window (could be a worktree mid-`git worktree add`).
 export const DEFAULT_ORPHAN_MIN_AGE_MS = 30 * 60 * 1000; // 30 min
@@ -125,24 +126,29 @@ export function dirSizeBytes(dir, { fsImpl = fs } = {}) {
 }
 
 /**
- * Default junction-safe orphan remover — mirrors scripts/worktree-reaper.mjs::removeWorktree:
- * try `git worktree remove --force` (pre-unlinks the node_modules junction) which FAILS on an
- * unregistered path, then fall back to safeRecursiveRm (unlinks all junctions/symlinks first).
- * NEVER a raw fs.rmSync. Returns {ok, method, error?}.
+ * Default junction-safe orphan remover. Orphans are UNREGISTERED by construction (the selection
+ * excludes everything in `git worktree list`), so we go STRAIGHT to safeRecursiveRm — which
+ * recursively unlinks EVERY junction/symlink descendant (not just the top-level node_modules)
+ * BEFORE fs.rmSync. This is strictly safer than trying `git worktree remove --force` first,
+ * whose pre-unlink only covers the top-level node_modules and could follow a NESTED junction
+ * (review MEDIUM). A best-effort `git worktree prune` afterward clears any stale registration
+ * for a prunable leftover. NEVER a raw fs.rmSync. Returns {ok, method, error?}.
+ *
  * @param {string} full
  * @param {string} repoRoot
+ * @param {{rm?: function, runGit?: function}} [deps] - injectable for tests
  * @returns {{ok: boolean, method: string, error?: string}}
  */
-export function defaultRemoveOrphan(full, repoRoot) {
+export function defaultRemoveOrphan(full, repoRoot, { rm = safeRecursiveRm, runGit } = {}) {
   const abs = path.resolve(full);
-  // Most orphans are unregistered (git will refuse), but a prunable-but-still-listed dir may
-  // succeed here and get its junction safely pre-unlinked — so we try it first, allowFail.
   try {
-    const primary = removeWorktreeViaGit(abs, repoRoot, { allowFail: true });
-    if (primary && primary.ok) return { ok: true, method: 'git-worktree-remove' };
-  } catch { /* fall through to junction-safe fs removal */ }
-  try {
-    if (fs.existsSync(abs)) safeRecursiveRm(abs); // unlinks junctions/symlinks BEFORE rmSync
+    if (!fs.existsSync(abs)) return { ok: true, method: 'already-gone' };
+    rm(abs); // safeRecursiveRm: unlinks ALL junctions/symlinks BEFORE fs.rmSync — never raw-rm
+    // Best-effort: clear a stale git registration for a prunable leftover. Never throws.
+    try {
+      if (runGit) runGit(['worktree', 'prune'], { cwd: repoRoot });
+      else if (repoRoot) execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
+    } catch { /* prune is best-effort */ }
     return { ok: true, method: 'safe-recursive-rm' };
   } catch (e) {
     return { ok: false, method: 'failed', error: String(e?.message || e) };

--- a/package.json
+++ b/package.json
@@ -431,6 +431,8 @@
     "worktree:reap": "node scripts/worktree-reaper.mjs",
     "worktree:reap:execute": "node scripts/worktree-reaper.mjs --execute",
     "worktree:reap:full": "node scripts/worktree-reaper.mjs --execute --stage2 --yes",
+    "worktree:orphan-sweep": "node scripts/worktree-reaper.mjs --orphan-sweep",
+    "worktree:orphan-sweep:execute": "node scripts/worktree-reaper.mjs --orphan-sweep --execute",
     "worktree:cleanup-pending": "node scripts/cleanup-pending-sweep.mjs",
     "worktree:cleanup-pending:dry": "node scripts/cleanup-pending-sweep.mjs --dry-run",
     "handoff": "node scripts/handoff.js",

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -58,6 +58,8 @@ import { createClient } from '@supabase/supabase-js';
 
 import { listActiveWorktrees, countActiveWorktrees, MAX_WORKTREE_COUNT } from '../lib/worktree-quota.js';
 import { safeRecursiveRm, safeRecursiveCp, removeWorktreeViaGit } from '../lib/worktree-manager.js';
+// SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (FR-1/FR-4): reclaim unregistered .worktrees/ dirs.
+import { runOrphanSweep } from '../lib/worktree-reaper/orphan-sweep.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001: single-source reapability helpers.
 // These three used to be defined locally below; the canonical home is now
 // lib/worktree-reapability.js so every removal path shares one implementation.
@@ -103,6 +105,11 @@ function parseArgs(argv) {
     yes: args.includes('--yes'),
     verbose: args.includes('--verbose') || args.includes('-v'),
     phantomOnly: args.includes('--phantom-only'),
+    // SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001: --orphan-sweep = run ONLY the orphan sweep
+    // (standalone, for manual inspection); --no-orphan-sweep = skip the sweep that is
+    // otherwise folded into the normal flow (so the hourly tick includes it).
+    orphanSweep: args.includes('--orphan-sweep'),
+    noOrphanSweep: args.includes('--no-orphan-sweep'),
     help: args.includes('--help') || args.includes('-h'),
     days: DEFAULT_IDLE_DAYS,
     threshold: DEFAULT_POOL_THRESHOLD,
@@ -149,6 +156,9 @@ Options:
   --repo <path>         Run against a different repo (chdir before scanning); useful when
                         the target repo's quota is full but you can't easily cd into it
   --phantom-only        Legacy mode: only report phantoms (missing dirs / prunable)
+  --orphan-sweep        Standalone: ONLY reclaim ORPHANED .worktrees/ dirs (on disk but
+                        NOT in 'git worktree list'). Dry-run unless --execute. Junction-safe.
+  --no-orphan-sweep     Skip the orphan sweep that is otherwise folded into a normal run.
   --verbose, -v         Include per-worktree detector trace in the table
   --help, -h            Show this help
 
@@ -923,6 +933,53 @@ function runPhantomOnlyMode({ repoRoot, worktrees }) {
 
 // ── Main ───────────────────────────────────────────────────────────────
 
+/**
+ * SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (FR-1/FR-2/FR-4): run + report one orphan sweep.
+ * Reclaims unregistered `.worktrees/` dirs via the junction-safe path. Conservative:
+ * EXECUTE removal is forced to dry-run when Supabase is unavailable, because without it
+ * the live-owner (active-claim) guard cannot be verified — mirroring the reaper's own
+ * "refuse to remove without active-claim verification" stance (main():~1096). Fail-soft.
+ *
+ * @param {{repoRoot: string, worktreesDir: string, supabase: object|null, execute: boolean}} p
+ * @returns {Promise<object>} the runOrphanSweep result
+ */
+async function runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execute }) {
+  const owners = supabase ? await loadClaimMap(supabase).catch(() => new Map()) : new Map();
+  const liveOwners = new Set([...owners.keys()]);
+  const effectiveExecute = execute && !!supabase;
+  if (execute && !supabase) {
+    console.log('🧹 Orphan sweep: Supabase unavailable — running DRY-RUN (cannot verify active-claim ownership).');
+  }
+  const sweep = runOrphanSweep({
+    repoRoot,
+    worktreesDir,
+    execute: effectiveExecute,
+    liveOwners,
+    emit: emitJsonLine,
+    logger: (m) => process.stderr.write(m + '\n'),
+  });
+  const s = sweep.summary || {};
+  console.log(
+    `🧹 Orphan sweep: scanned=${s.scanned ?? '?'} reapable=${s.reapable ?? '?'} ` +
+    `reclaimed=${s.reclaimed_count ?? 0} bytes=${s.reclaimed_bytes ?? 0} ` +
+    `excluded=${s.excluded_count ?? 0} failed=${s.failed_count ?? 0}${s.dry_run ? ' (dry-run)' : ''}`
+  );
+  // FR-4 durable summary: best-effort audit_log row when an EXECUTE run actually acted. Fail-soft.
+  if (sweep.ok && supabase && effectiveExecute && ((s.reclaimed_count || 0) > 0 || (s.failed_count || 0) > 0)) {
+    try {
+      await supabase.from('audit_log').insert({
+        event_type: 'worktree_orphan_sweep',
+        entity_type: 'worktree',
+        entity_id: 'orphan_sweep',
+        severity: (s.failed_count || 0) > 0 ? 'warning' : 'info',
+        created_by: 'worktree-reaper',
+        metadata: s,
+      });
+    } catch { /* fail-soft: the stderr JSON line is the primary durable signal */ }
+  }
+  return sweep;
+}
+
 export async function main(argv = process.argv) {
   const opts = parseArgs(argv);
   if (opts.help) {
@@ -961,6 +1018,21 @@ export async function main(argv = process.argv) {
   // Phantom-only mode: preserves legacy cleanup-phantom-worktrees.js behavior.
   if (opts.phantomOnly) {
     return runPhantomOnlyMode({ repoRoot, worktrees: allWorktrees });
+  }
+
+  // SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001: standalone orphan-sweep mode (manual /
+  // `npm run worktree:orphan-sweep[:execute]`). Reclaims ONLY unregistered .worktrees/ dirs.
+  if (opts.orphanSweep) {
+    await runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execute: opts.execute });
+    return 0; // fail-soft: the sweep never produces a non-zero reaper exit
+  }
+
+  // FR-4 durability: fold the orphan sweep into the NORMAL reaper flow so the hourly
+  // worktree-reaper-tick.cjs spawn includes it with NO separate cron. Runs BEFORE the
+  // registered-worktree stage scan (and its early returns), is dry-run unless --execute,
+  // and is fully fail-soft so it can never abort the reaper. Opt out with --no-orphan-sweep.
+  if (!opts.noOrphanSweep) {
+    await runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execute: opts.execute });
   }
 
   // Load reference data (best-effort — reaper is useful even with empty maps).

--- a/tests/unit/worktree-reaper/orphan-sweep.test.js
+++ b/tests/unit/worktree-reaper/orphan-sweep.test.js
@@ -1,0 +1,197 @@
+/**
+ * SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 — orphan .worktrees/ sweep.
+ *
+ * Real-fs tests (mkdtemp sandbox + shared-node_modules CANARY) proving:
+ *  - FR-1/FR-3: the reapable orphan set = filesystem dirs MINUS (registered + recent + helpers).
+ *  - FR-2: reclamation goes through the junction-safe path; a CANARY file in a shared
+ *          node_modules store SURVIVES removal of an orphan that junctions to it (no raw-rm).
+ *  - FR-3: dry-run is the default (removes nothing).
+ *  - FR-4: per-orphan failures are fail-soft (one failure never aborts the sweep).
+ *  - back-compat: classifyOrphanDirs default (minAgeMs=0) excludes nothing new and now
+ *                 additionally returns the reapable PATHS.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  selectReapableOrphans,
+  reclaimOrphans,
+  dirSizeBytes,
+  defaultRemoveOrphan,
+  resolveMinAgeMs,
+  DEFAULT_ORPHAN_MIN_AGE_MS,
+} from '../../../lib/worktree-reaper/orphan-sweep.js';
+import { classifyOrphanDirs } from '../../../lib/worktree-quota.js';
+
+let root, worktreesDir, sharedStore, canary;
+
+function mkLeftover(name, { withGit = false } = {}) {
+  const dir = path.join(worktreesDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'file.txt'), 'x'.repeat(100));
+  if (withGit) fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /somewhere');
+  return dir;
+}
+
+// Junction (Windows) / dir-symlink (POSIX) from <dir>/node_modules to the shared store.
+function linkNodeModules(dir) {
+  const nm = path.join(dir, 'node_modules');
+  const type = process.platform === 'win32' ? 'junction' : 'dir';
+  fs.symlinkSync(sharedStore, nm, type);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'orphan-sweep-'));
+  worktreesDir = path.join(root, '.worktrees');
+  fs.mkdirSync(worktreesDir, { recursive: true });
+  sharedStore = path.join(root, 'shared_node_modules', '@supabase', 'supabase-js');
+  fs.mkdirSync(sharedStore, { recursive: true });
+  canary = path.join(sharedStore, 'CANARY.txt');
+  fs.writeFileSync(canary, 'do-not-delete');
+});
+
+afterEach(() => {
+  // Defensive teardown: unlink any junctions first so the test cleanup never follows them.
+  try {
+    for (const e of fs.readdirSync(worktreesDir)) {
+      const nm = path.join(worktreesDir, e, 'node_modules');
+      try { if (fs.lstatSync(nm).isSymbolicLink()) fs.unlinkSync(nm); } catch { /* none */ }
+    }
+  } catch { /* worktreesDir gone */ }
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('selectReapableOrphans (FR-1/FR-3)', () => {
+  it('selects orphans = fs dirs minus registered + recent + helpers', () => {
+    const oldOrphan = mkLeftover('old-orphan');
+    const registered = mkLeftover('registered-wt', { withGit: true });
+    const recent = mkLeftover('fresh-dir');
+    fs.mkdirSync(path.join(worktreesDir, '_archive'), { recursive: true }); // helper, never an orphan
+
+    // Age the old orphan well past the threshold; leave 'fresh-dir' new.
+    const now = Date.now();
+    const old = new Date(now - 2 * 60 * 60 * 1000);
+    fs.utimesSync(oldOrphan, old, old);
+
+    const sel = selectReapableOrphans({
+      worktreesDir,
+      registered: [registered],          // registered worktree path → excluded
+      now,
+      minAgeMs: 30 * 60 * 1000,          // 30 min
+    });
+
+    const reapNames = sel.reapableDirs.map((r) => r.dir);
+    expect(reapNames).toContain('old-orphan');
+    expect(reapNames).not.toContain('registered-wt'); // registered → excluded
+    expect(reapNames).not.toContain('fresh-dir');     // too recent → excluded
+    expect(reapNames).not.toContain('_archive');      // helper → not counted
+    expect(sel.excluded.find((e) => e.dir === 'fresh-dir')?.reason).toBe('too_recent');
+  });
+
+  it('descends into typed subdirs (qf/sd/adhoc) — the dominant real orphan case', () => {
+    // A QF leftover under .worktrees/qf/<id> (exactly the kind left when `git worktree
+    // remove` hits a Windows lock). A top-level-only scan would MISS this.
+    fs.mkdirSync(path.join(worktreesDir, 'qf'), { recursive: true });
+    const qfOrphan = mkLeftover(path.join('qf', 'QF-20260616-999'));
+    fs.mkdirSync(path.join(worktreesDir, 'adhoc'), { recursive: true });
+    const registeredQf = mkLeftover(path.join('adhoc', 'ADHOC-LIVE'), { withGit: true });
+    // _archive contents must NEVER be reaped (it is the reaper's preserve destination).
+    fs.mkdirSync(path.join(worktreesDir, '_archive', 'preserved-from-x'), { recursive: true });
+
+    const now = Date.now();
+    const old = new Date(now - 2 * 60 * 60 * 1000);
+    fs.utimesSync(qfOrphan, old, old);
+
+    const sel = selectReapableOrphans({
+      worktreesDir,
+      registered: [registeredQf],
+      now,
+      minAgeMs: 30 * 60 * 1000,
+    });
+    const reapNames = sel.reapableDirs.map((r) => r.dir);
+    expect(reapNames).toContain('qf/QF-20260616-999'); // nested orphan caught + prefixed
+    expect(reapNames).not.toContain('adhoc/ADHOC-LIVE'); // registered → excluded
+    expect(reapNames.some((n) => n.includes('preserved-from-x'))).toBe(false); // _archive never scanned
+  });
+});
+
+describe('reclaimOrphans dry-run (FR-3)', () => {
+  it('removes nothing by default', () => {
+    const d = mkLeftover('orphan-1');
+    const res = reclaimOrphans([{ dir: 'orphan-1', full: d }], { execute: false, repoRoot: root });
+    expect(res.dry_run).toBe(true);
+    expect(res.reclaimed_count).toBe(1);
+    expect(fs.existsSync(d)).toBe(true); // still on disk
+  });
+});
+
+describe('reclaimOrphans junction safety — CANARY survives (FR-2)', () => {
+  it('reclaims an orphan that junctions to shared node_modules without gutting the store', () => {
+    const orphan = mkLeftover('orphan-junctioned');
+    linkNodeModules(orphan);
+    expect(fs.existsSync(canary)).toBe(true);
+
+    const res = reclaimOrphans([{ dir: 'orphan-junctioned', full: orphan }], {
+      execute: true,
+      repoRoot: root, // not a git repo → removeWorktreeViaGit fails → safeRecursiveRm fallback
+    });
+
+    expect(res.reclaimed_count).toBe(1);
+    expect(res.failed.length).toBe(0);
+    expect(fs.existsSync(orphan)).toBe(false);  // orphan removed
+    expect(fs.existsSync(canary)).toBe(true);   // shared store CANARY survived (junction not followed)
+  });
+});
+
+describe('reclaimOrphans fail-soft (FR-4)', () => {
+  it('a removal error on one orphan does not stop the others', () => {
+    const a = mkLeftover('a');
+    const b = mkLeftover('b');
+    const c = mkLeftover('c');
+    const remove = (full) => {
+      if (full.endsWith('b')) throw new Error('boom');
+      fs.rmSync(full, { recursive: true, force: true });
+      return { ok: true, method: 'test-rm' };
+    };
+    const res = reclaimOrphans(
+      [{ dir: 'a', full: a }, { dir: 'b', full: b }, { dir: 'c', full: c }],
+      { execute: true, repoRoot: root, remove },
+    );
+    expect(res.reclaimed_count).toBe(2);
+    expect(res.failed.length).toBe(1);
+    expect(res.failed[0].dir).toBe('b');
+    expect(fs.existsSync(a)).toBe(false);
+    expect(fs.existsSync(b)).toBe(true);  // failed one left in place
+    expect(fs.existsSync(c)).toBe(false);
+  });
+});
+
+describe('dirSizeBytes — never follows junctions', () => {
+  it('counts file bytes but not the shared store behind a junction', () => {
+    const d = mkLeftover('sized'); // file.txt = 100 bytes
+    linkNodeModules(d);            // junction to a large shared store
+    const bytes = dirSizeBytes(d);
+    expect(bytes).toBe(100); // only the real file; junction target excluded
+  });
+});
+
+describe('classifyOrphanDirs back-compat (additive)', () => {
+  it('default minAgeMs=0 excludes nothing new and returns reapable PATHS', () => {
+    const o1 = mkLeftover('o1');
+    mkLeftover('o2');
+    const res = classifyOrphanDirs(worktreesDir, []); // no minAgeMs
+    expect(res.reapable).toBe(2);
+    expect(res.reapableDirs.map((r) => r.dir).sort()).toEqual(['o1', 'o2']);
+    expect(res.excluded.find((e) => e.reason === 'too_recent')).toBeUndefined();
+    expect(res.reapableDirs.find((r) => r.dir === 'o1').full).toBe(o1);
+  });
+});
+
+describe('resolveMinAgeMs', () => {
+  it('defaults when unset and parses a valid override', () => {
+    expect(resolveMinAgeMs({})).toBe(DEFAULT_ORPHAN_MIN_AGE_MS);
+    expect(resolveMinAgeMs({ WORKTREE_ORPHAN_MIN_AGE_MS: '60000' })).toBe(60000);
+    expect(resolveMinAgeMs({ WORKTREE_ORPHAN_MIN_AGE_MS: 'garbage' })).toBe(DEFAULT_ORPHAN_MIN_AGE_MS);
+  });
+});

--- a/tests/unit/worktree-reaper/orphan-sweep.test.js
+++ b/tests/unit/worktree-reaper/orphan-sweep.test.js
@@ -188,6 +188,20 @@ describe('classifyOrphanDirs back-compat (additive)', () => {
   });
 });
 
+describe('classifyOrphanDirs live-owner guard — cross-module casing (review HIGH)', () => {
+  it('excludes a live-owned orphan even when liveOwners was lowercased by a different normalizePath', () => {
+    const live = mkLeftover('Live-Orphan-MixedCase'); // no .git, would otherwise be reapable
+    const now = Date.now();
+    const old = new Date(now - 2 * 60 * 60 * 1000);
+    fs.utimesSync(live, old, old);
+    // Simulate the producer (worktree-reapability.js::normalizePath) which LOWERCASES on all platforms.
+    const lowered = path.resolve(live).replace(/\\/g, '/').toLowerCase();
+    const res = classifyOrphanDirs(worktreesDir, [], { liveOwners: new Set([lowered]), minAgeMs: 30 * 60 * 1000, now });
+    expect(res.reapableDirs.find((r) => r.dir === 'Live-Orphan-MixedCase')).toBeUndefined();
+    expect(res.excluded.find((e) => e.dir === 'Live-Orphan-MixedCase')?.reason).toBe('live_owner');
+  });
+});
+
 describe('resolveMinAgeMs', () => {
   it('defaults when unset and parses a valid override', () => {
     expect(resolveMinAgeMs({})).toBe(DEFAULT_ORPHAN_MIN_AGE_MS);


### PR DESCRIPTION
## Summary
Durable fix for the recurring disk-full fleet blocker. The reaper enumerates git-REGISTERED worktrees only, so `.worktrees/` dirs left on disk but NOT in `git worktree list` (e.g. a worktree dir stranded when `git worktree remove` hits a Windows permission lock — exactly the failure hit earlier this session) accumulate unbounded and fill the disk.

Detection already existed (`classifyOrphanDirs`, warn-only) and the junction-safe removal primitive (`safeRecursiveRm`) already existed — this is a **wiring gap**, not a new capability.

## Changes
- **FR-1/FR-3**: `classifyOrphanDirs` additively returns reapable PATHS + a `minAgeMs`/`now` recent-dir guard (default `minAgeMs=0` keeps all existing callers byte-identical).
- **New** `lib/worktree-reaper/orphan-sweep.js`: selection (flat + typed `qf/sd/adhoc` layouts; `_archive` never scanned), junction-safe reclamation (`safeRecursiveRm` recursive junction-unlink — **never raw-rm**), dry-run default, fail-soft per orphan.
- **FR-4**: folded into the normal reaper flow so the hourly `worktree-reaper-tick.cjs` spawn includes it (no new cron); reclaimed-space summary (stderr JSON + best-effort `audit_log`); EXECUTE forced to dry-run when Supabase unavailable.
- **FR-5**: 9 unit tests + 15 regression = 24/24.

## Safety (cardinal invariant: never gut shared node_modules)
- CANARY test proves a shared `node_modules` store survives removal of an orphan that junctions to it.
- Adversarial review caught + fixed a HIGH (cross-module `normalizePath` casing mismatch silently defeated the live-owner guard on Windows) and a MEDIUM (nested-junction risk in the git-first removal path).

## Live validation
Reclaimed the real stranded `.worktrees/qf/QF-20260616-776` dir junction-safely; shared node_modules intact; durable audit_log summary row written (`reclaimed_count=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)