### PR TITLE
feat(SD-LEO-INFRA-PROPOSAL-INGEST-REVIEW-FLAGS-001): proposal-ingest route honors review-attestation flags (parity)

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2146,7 +2146,7 @@ export function validateProposalShape(proposal, filePath) {
  * sourced_by. Those historical rows are still counted by FR-1b as-is; this stamp makes the
  * proposal-based routes the durable, code-enforced producer going forward. No retroactive change.
  */
-export function mapProposalToCreateArgs(normalized, proposal, filePath) {
+export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {}) {
   return {
     sdKey: normalized.sdKey,
     title: normalized.title,
@@ -2171,6 +2171,15 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath) {
       // sourcing-cadence consumer; see this function's doc comment). Only stamped for an explicit
       // Adam-origin proposal — never coerced/defaulted, so a non-Adam proposal stays unattributed.
       ...(proposal.sourced_by === 'adam' ? { sourced_by: 'adam' } : {}),
+      // SD-LEO-INFRA-PROPOSAL-INGEST-REVIEW-FLAGS-001 (FR-1/FR-3): bring the proposal-ingest
+      // route to PARITY with the direct-args route (~line 2989) for the review-attestation
+      // flags. The attestation is stamped ONLY on an explicit `=== true` — from the proposal's
+      // own metadata OR the threaded CLI flag (opts). NEVER coerced/defaulted: a 'true' string,
+      // 1, false, or absence all leave the flag UNSET, so a genuinely-unreviewed governed
+      // proposal is STILL blocked by GR-MIGRATION-REVIEW / GR-SECURITY-BASELINE. This removes a
+      // FALSE block (an already-reviewed proposal), it does NOT weaken the review gate.
+      ...(proposal.metadata?.migration_reviewed === true || opts.migrationReviewed === true ? { migration_reviewed: true } : {}),
+      ...(proposal.metadata?.security_reviewed === true || opts.securityReviewed === true ? { security_reviewed: true } : {}),
     },
   };
 }
@@ -2219,7 +2228,7 @@ function resolveProposalFiles(pathOrGlob) {
  * @param {{dryRun?:boolean, deps?:{keyExists?:Function, createSD?:Function}}} options
  */
 export async function ingestProposalObject(proposal, source, options = {}) {
-  const { dryRun = false, deps = {} } = options;
+  const { dryRun = false, deps = {}, migrationReviewed = false, securityReviewed = false } = options;
   const _keyExists = deps.keyExists || keyExists;
   const _createSD = deps.createSD || createSD;
 
@@ -2229,7 +2238,10 @@ export async function ingestProposalObject(proposal, source, options = {}) {
     console.log(`⏭️  ${normalized.sdKey} already exists, skipping (${source})`);
     return { sdKey: normalized.sdKey, file: source, action: 'skipped' };
   }
-  const args = mapProposalToCreateArgs(normalized, proposal, source);
+  // FR-2: forward the threaded review-attestation flags (from --migration-reviewed /
+  // --security-reviewed on the proposal-ingest CLI routes) to the mapper, which honors them
+  // ONLY on an explicit `=== true` (FR-3 guard lives in mapProposalToCreateArgs).
+  const args = mapProposalToCreateArgs(normalized, proposal, source, { migrationReviewed, securityReviewed });
   if (dryRun) {
     console.log(`🔎 [dry-run] would create ${args.sdKey} (${args.type}/${args.priority}) — ${args.title}`);
     return { sdKey: normalized.sdKey, file: source, action: 'dry-run' };
@@ -2396,8 +2408,13 @@ Flags:
                      Supported in both direct creation AND --from-plan mode.
   --migration-reviewed  Set metadata.migration_reviewed=true to satisfy GR-MIGRATION-REVIEW
                         guardrail (required when scope contains migration/schema keywords).
+                        Honored on direct, --from-feedback, --child AND the proposal-ingest
+                        routes (--from-proposal / --proposal-b64 / --proposal-stdin); on the
+                        proposal routes proposal.metadata.migration_reviewed===true also attests.
   --security-reviewed   Set metadata.security_reviewed=true to satisfy GR-SECURITY-BASELINE
                         guardrail (required when scope contains auth/credential/RLS keywords).
+                        Honored on the same routes as --migration-reviewed (incl. proposal
+                        metadata.security_reviewed===true).
   --scope-slice <JSON>  (--child only) Declare the slice of parent orchestrator scope this
                         child claims. JSON shape: {stages?: number[], deliverable_globs?: string[]}.
                         Example: --scope-slice='{"stages":[18]}'
@@ -2490,24 +2507,38 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001: materialize PROPOSAL-*.json into DRAFT SDs.
       // path/glob = first non-flag positional after --from-proposal; --dry-run = no writes.
       const dryRun = args.includes('--dry-run');
-      const fpKnownFlags = new Set(['--from-proposal', '--dry-run']);
+      // FR-2: --migration-reviewed/--security-reviewed are known flags (not the path positional).
+      const fpKnownFlags = new Set(['--from-proposal', '--dry-run', '--migration-reviewed', '--security-reviewed']);
       const proposalArg = args.find((a, i) => i > 0 && !a.startsWith('-') && !fpKnownFlags.has(a)) || args[1];
-      await createFromProposal(proposalArg, { dryRun });
+      await createFromProposal(proposalArg, {
+        dryRun,
+        migrationReviewed: args.includes('--migration-reviewed'),
+        securityReviewed: args.includes('--security-reviewed'),
+      });
     } else if (args[0] === '--proposal-b64') {
       // SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001: file-free DB-direct sourcing.
       // The base64 string is the first non-flag positional (base64 never starts with '-').
       const dryRun = args.includes('--dry-run');
-      const b64KnownFlags = new Set(['--proposal-b64', '--dry-run']);
+      // FR-2: --migration-reviewed/--security-reviewed are known flags (not the base64 positional).
+      const b64KnownFlags = new Set(['--proposal-b64', '--dry-run', '--migration-reviewed', '--security-reviewed']);
       // No `|| args[1]` fallback: if no non-flag positional is present (e.g.
       // `--proposal-b64 --dry-run`), b64Arg stays undefined so createFromProposalB64's
       // guard reports the clear "requires a base64-encoded proposal JSON string" error
       // instead of base64-decoding the literal '--dry-run' flag into junk.
       const b64Arg = args.find((a, i) => i > 0 && !a.startsWith('-') && !b64KnownFlags.has(a));
-      await createFromProposalB64(b64Arg, { dryRun });
+      await createFromProposalB64(b64Arg, {
+        dryRun,
+        migrationReviewed: args.includes('--migration-reviewed'),
+        securityReviewed: args.includes('--security-reviewed'),
+      });
     } else if (args[0] === '--proposal-stdin') {
       // SD-LEO-INFRA-OPERATOR-SOURCING-DBDIRECT-001: file-free DB-direct sourcing via a pipe.
       const dryRun = args.includes('--dry-run');
-      await createFromProposalStdin({ dryRun });
+      await createFromProposalStdin({
+        dryRun,
+        migrationReviewed: args.includes('--migration-reviewed'),
+        securityReviewed: args.includes('--security-reviewed'),
+      });
     } else if (args[0] === '--from-plan') {
       // Check for --yes flag (skip confirmation for auto-detect)
       const hasYesFlag = args.includes('--yes') || args.includes('-y');

--- a/tests/unit/leo-create-sd-proposal-review-flags.test.js
+++ b/tests/unit/leo-create-sd-proposal-review-flags.test.js
@@ -1,0 +1,198 @@
+/**
+ * Proposal-ingest review-attestation parity — SD-LEO-INFRA-PROPOSAL-INGEST-REVIEW-FLAGS-001
+ *
+ * The proposal-ingest route (mapProposalToCreateArgs / ingestProposalObject and the
+ * --from-proposal / --proposal-b64 / --proposal-stdin entry points) now honors the
+ * migration_reviewed / security_reviewed review-attestation flags — bringing it to PARITY
+ * with the direct-args route. The attestation comes from EITHER source:
+ *   (a) proposal.metadata.migration_reviewed / security_reviewed === true, or
+ *   (b) the threaded CLI flags --migration-reviewed / --security-reviewed (opts).
+ *
+ * THE EXISTENTIAL INVARIANT (FR-3, tested in BOTH directions): the attestation is set
+ * ONLY on a strict `=== true`. A 'true' string, 1, false, null, or absence ALL leave the
+ * flag UNSET — so a genuinely-unreviewed governed proposal is STILL blocked by
+ * GR-MIGRATION-REVIEW / GR-SECURITY-BASELINE. The fix removes a FALSE block (an
+ * already-reviewed proposal), it does NOT weaken the review gate.
+ *
+ * PURE: exercises the exported helpers with INJECTED deps. ZERO live DB access — keyExists
+ * and createSD are faked through opts.deps (the real createSD uses a non-injectable supabase
+ * singleton, never reached here).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  mapProposalToCreateArgs,
+  ingestProposalObject,
+  createFromProposalB64,
+  createFromProposalStdin,
+} from '../../scripts/leo-create-sd.js';
+
+const NORMALIZED = {
+  sdKey: 'SD-LEO-INFRA-EXAMPLE-001',
+  title: 'Example proposal',
+  type: 'infrastructure',
+  priority: 'high',
+  rawType: 'infrastructure',
+};
+
+function validProposal(overrides = {}) {
+  return {
+    PROPOSAL: true,
+    status_intended: 'draft',
+    proposed_sd_key: 'SD-LEO-INFRA-EXAMPLE-001',
+    title: 'Example proposal',
+    sd_type: 'infrastructure',
+    priority: 'high',
+    rationale: 'because the belt needs refilling',
+    scope: 'DOES: x. DOES NOT: y.',
+    success_criteria: ['criterion a'],
+    provenance: 'coordinator-go',
+    roadmap_phase: 'phase-1',
+    ...overrides,
+  };
+}
+
+const b64Of = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64');
+
+// ---------------------------------------------------------------------------
+// FR-1 + FR-3: mapProposalToCreateArgs honors the attestation ONLY on === true,
+// from proposal.metadata OR the opts (threaded CLI flags), never by coercion.
+// ---------------------------------------------------------------------------
+describe('mapProposalToCreateArgs — review-attestation pass-through (FR-1/FR-3)', () => {
+  it('proposal.metadata.migration_reviewed===true → created metadata.migration_reviewed=true', () => {
+    const p = validProposal({ metadata: { migration_reviewed: true } });
+    expect(mapProposalToCreateArgs(NORMALIZED, p, 'p.json').metadata.migration_reviewed).toBe(true);
+  });
+
+  it('proposal.metadata.security_reviewed===true → created metadata.security_reviewed=true', () => {
+    const p = validProposal({ metadata: { security_reviewed: true } });
+    expect(mapProposalToCreateArgs(NORMALIZED, p, 'p.json').metadata.security_reviewed).toBe(true);
+  });
+
+  it('opts.migrationReviewed===true (threaded CLI flag) → created metadata.migration_reviewed=true', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, validProposal(), 'p.json', { migrationReviewed: true });
+    expect(args.metadata.migration_reviewed).toBe(true);
+  });
+
+  it('opts.securityReviewed===true (threaded CLI flag) → created metadata.security_reviewed=true', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, validProposal(), 'p.json', { securityReviewed: true });
+    expect(args.metadata.security_reviewed).toBe(true);
+  });
+
+  it('neither metadata nor opts → flags ABSENT (unattested stays unattested)', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, validProposal(), 'p.json');
+    expect(args.metadata).not.toHaveProperty('migration_reviewed');
+    expect(args.metadata).not.toHaveProperty('security_reviewed');
+  });
+
+  // FR-3 / TS-4 — the no-weakening guard: any non-strict-true value must NOT attest.
+  it.each([
+    ['string "true"', 'true'],
+    ['number 1', 1],
+    ['false', false],
+    ['null', null],
+    ['object {}', {}],
+  ])('proposal.metadata.migration_reviewed=%s (non-true) → flag NOT set', (_label, value) => {
+    const p = validProposal({ metadata: { migration_reviewed: value, security_reviewed: value } });
+    const args = mapProposalToCreateArgs(NORMALIZED, p, 'p.json');
+    expect(args.metadata).not.toHaveProperty('migration_reviewed');
+    expect(args.metadata).not.toHaveProperty('security_reviewed');
+  });
+
+  it.each([
+    ['string "true"', 'true'],
+    ['number 1', 1],
+    ['false', false],
+  ])('opts.migrationReviewed=%s (non-true) → flag NOT set (no coercion)', (_label, value) => {
+    const args = mapProposalToCreateArgs(NORMALIZED, validProposal(), 'p.json', {
+      migrationReviewed: value,
+      securityReviewed: value,
+    });
+    expect(args.metadata).not.toHaveProperty('migration_reviewed');
+    expect(args.metadata).not.toHaveProperty('security_reviewed');
+  });
+
+  it('flags are independent: only the attested one is set', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, validProposal({ metadata: { migration_reviewed: true } }), 'p.json');
+    expect(args.metadata.migration_reviewed).toBe(true);
+    expect(args.metadata).not.toHaveProperty('security_reviewed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-2: ingestProposalObject threads migrationReviewed/securityReviewed from its
+// options into mapProposalToCreateArgs, so the created SD's metadata carries them.
+// ---------------------------------------------------------------------------
+describe('ingestProposalObject — threads review flags into createSD args (FR-2)', () => {
+  let logSpy;
+  beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+  afterEach(() => { logSpy.mockRestore(); });
+
+  const baseDeps = () => ({ keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({ id: 'x' })) });
+
+  it('options.migrationReviewed=true → createSD args metadata.migration_reviewed=true', async () => {
+    const deps = baseDeps();
+    await ingestProposalObject(validProposal(), '<unit>', { deps, migrationReviewed: true });
+    expect(deps.createSD.mock.calls[0][0].metadata.migration_reviewed).toBe(true);
+  });
+
+  it('options.securityReviewed=true → createSD args metadata.security_reviewed=true', async () => {
+    const deps = baseDeps();
+    await ingestProposalObject(validProposal(), '<unit>', { deps, securityReviewed: true });
+    expect(deps.createSD.mock.calls[0][0].metadata.security_reviewed).toBe(true);
+  });
+
+  it('proposal.metadata attestation also honored on the shared core (no CLI flag)', async () => {
+    const deps = baseDeps();
+    await ingestProposalObject(validProposal({ metadata: { migration_reviewed: true } }), '<unit>', { deps });
+    expect(deps.createSD.mock.calls[0][0].metadata.migration_reviewed).toBe(true);
+  });
+
+  it('FR-3 no-weakening: neither flag nor metadata → createSD args carry NO attestation', async () => {
+    const deps = baseDeps();
+    await ingestProposalObject(validProposal(), '<unit>', { deps });
+    const md = deps.createSD.mock.calls[0][0].metadata;
+    expect(md).not.toHaveProperty('migration_reviewed');
+    expect(md).not.toHaveProperty('security_reviewed');
+  });
+
+  it('FR-3 no-weakening: non-true option value → createSD args carry NO attestation', async () => {
+    const deps = baseDeps();
+    await ingestProposalObject(validProposal(), '<unit>', { deps, migrationReviewed: 'true', securityReviewed: 1 });
+    const md = deps.createSD.mock.calls[0][0].metadata;
+    expect(md).not.toHaveProperty('migration_reviewed');
+    expect(md).not.toHaveProperty('security_reviewed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FR-2 end-to-end on the file-free routes (--proposal-b64 / --proposal-stdin):
+// the options carry straight through ingestProposalObject to the created SD.
+// ---------------------------------------------------------------------------
+describe('file-free routes thread review flags (FR-2)', () => {
+  let logSpy, errorSpy;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => { logSpy.mockRestore(); errorSpy.mockRestore(); });
+
+  it('--proposal-b64 with migrationReviewed=true → created metadata.migration_reviewed=true', async () => {
+    const deps = { keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({})) };
+    await createFromProposalB64(b64Of(validProposal()), { deps, migrationReviewed: true });
+    expect(deps.createSD.mock.calls[0][0].metadata.migration_reviewed).toBe(true);
+  });
+
+  it('--proposal-stdin with securityReviewed=true → created metadata.security_reviewed=true', async () => {
+    const deps = { readStdin: async () => JSON.stringify(validProposal()), keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({})) };
+    await createFromProposalStdin({ deps, securityReviewed: true });
+    expect(deps.createSD.mock.calls[0][0].metadata.security_reviewed).toBe(true);
+  });
+
+  it('--proposal-stdin with NO attestation → created metadata carries neither flag', async () => {
+    const deps = { readStdin: async () => JSON.stringify(validProposal()), keyExists: vi.fn(async () => false), createSD: vi.fn(async () => ({})) };
+    await createFromProposalStdin({ deps });
+    const md = deps.createSD.mock.calls[0][0].metadata;
+    expect(md).not.toHaveProperty('migration_reviewed');
+    expect(md).not.toHaveProperty('security_reviewed');
+  });
+});


### PR DESCRIPTION
@
## Summary
Brings the proposal-ingest route of `scripts/leo-create-sd.js` to **parity** with the direct-args route for the `migration_reviewed` / `security_reviewed` review-attestation flags.

- **FR-1**: `mapProposalToCreateArgs` gains a 4th `opts={}` param; stamps each flag into the created SD metadata **only on a strict `=== true`** — from `proposal.metadata` OR the threaded `opts`.
- **FR-2**: `ingestProposalObject` threads `migrationReviewed`/`securityReviewed`; all 3 CLI routes (`--from-proposal` / `--proposal-b64` / `--proposal-stdin`) parse `--migration-reviewed`/`--security-reviewed` (added to the known-flag sets so they are not mistaken for a positional arg) and forward them.
- **FR-3 (no-weakening guard)**: non-true values (`"true"`, `1`, `false`, `null`, `{}`) never attest → a genuinely-unreviewed governed proposal is **STILL blocked** by GR-MIGRATION-REVIEW / GR-SECURITY-BASELINE. Removes a FALSE block; does not relax the gate.
- **FR-4**: 22 pure both-directions activation tests + 69 existing `leo-create-sd` tests green; zero regressions.

## Evidence
- EXEC-TO-PLAN PASS 98 · PLAN-TO-LEAD PASS 96
- TESTING PASS(95) / SECURITY PASS(98) @ EXEC; VALIDATION PASS(98) / REGRESSION PASS(97) @ PLAN_VERIFICATION
- SECURITY adversarially confirmed the gate is NOT weakened (strict `=== true` on both `||` branches; `...(cond ? {f:true} : {})` emits an empty object when false so the key is absent; `guardrail-registry.js` byte-unchanged; trust sources identical to the direct-args route)
- Retrospective quality 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@