### PR TITLE
fix(SD-LEO-INFRA-DOCMON-COORDINATOR-ALLOWLIST-001): allowlist CLAUDE_COORDINATOR.md + _DIGEST in DOCMON

### DIFF
--- a/.docmon/rules.json
+++ b/.docmon/rules.json
@@ -71,13 +71,15 @@
     "CLAUDE_EXEC_DIGEST.md",
     "CLAUDE_ADAM.md",
     "CLAUDE_ADAM_DIGEST.md",
+    "CLAUDE_COORDINATOR.md",
+    "CLAUDE_COORDINATOR_DIGEST.md",
     "README.md",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "LICENSE.md",
     "CODE_OF_CONDUCT.md"
   ],
-  "max_root_files": 17,
+  "max_root_files": 19,
   "rubric": [
     {
       "id": "RULE-RUBRIC-001",


### PR DESCRIPTION
## Summary
The coordinator-contract docs (CLAUDE_COORDINATOR.md, CLAUDE_COORDINATOR_DIGEST.md), rendered into the repo root from `leo_protocol_sections` id=605, were absent from `.docmon/rules.json` root_allowlist — so DOCMON Documentation Validation false-failed them as orphaned root files (RULE-ROOT-VIOLATION) on any PR regenerating the coordinator CLAUDE_*.md.

## Change (~4 LOC, config-only)
Mirrors the prior ADAM allowlist fix (e09303cfc6) and _DIGEST fix (bf5a216ae3): add both entries to `root_allowlist` and bump `max_root_files` 17→19.

## Verification
DOCMON report shows **zero** CLAUDE_COORDINATOR root-violations after the fix. validation-agent PASS-96, testing-agent PASS-98.

Incidental (flagged separately, not folded in): `CONTEXT.md` is a latent RULE-ROOT-VIOLATION too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)