### PR TITLE
feat(SD-LEO-INFRA-VALIDATE-DESIGN-ONLY-STORIES-001): validate design-only SD stories against their spec (no rubber-stamp)

### DIFF
--- a/scripts/auto-validate-user-stories-on-exec-complete.js
+++ b/scripts/auto-validate-user-stories-on-exec-complete.js
@@ -24,6 +24,108 @@ import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import dotenv from 'dotenv';
 dotenv.config();
 
+// ── SD-LEO-INFRA-VALIDATE-DESIGN-ONLY-STORIES-001 ──────────────────────────────────────────────
+// Design-only SDs (docs/spec deliverables, no UI/code) should have their user stories validated
+// AGAINST the spec deliverable, not content-blind rubber-stamped. Detection is NARROW and FAIL-OPEN:
+// any uncertainty resolves to designOnly=false (the existing universal behavior is unchanged).
+const CODE_PATH = /\.(c|m)?[jt]sx?$|\.(sql|py|go|rb|java|css|scss|html|vue|svelte)$|^(src|lib|scripts|app|components|api|server|client)\//i;
+const DOC_PATH = /\.(md|mdx|txt|rst|adoc)$|^docs\//i;
+// Deliberately SPECIFIC markers only — a loose "no build"/"no code" alternative would false-positive
+// on code SDs ("no build changes needed"), mis-routing them to the design-only path. Fail-safe toward
+// the default (code) path: if in doubt, NOT design-only.
+const DESIGN_MARKER = /design[- ]only|reviewable (design[- ])?spec|phase-?0 design (pass|spec)|\bno-build\b/i;
+
+/**
+ * Classify an SD as design-only. Priority: explicit metadata flag → deliverable-path shape →
+ * SD-text marker. Fail-open (returns designOnly:false) on any uncertainty.
+ * @param {Object|null} sd - { metadata, title, description, scope }
+ * @param {Array|null} deliverables - [{ deliverable_name }]
+ * @returns {{ designOnly: boolean, reason: string }}
+ */
+export function classifyDesignOnly(sd, deliverables) {
+  if (sd?.metadata?.design_only === true) return { designOnly: true, reason: 'metadata.design_only flag' };
+  const names = (deliverables || []).map(d => (d?.deliverable_name || '').trim()).filter(Boolean);
+  const pathLike = names.filter(n => /\.[a-z0-9]+$/i.test(n) || n.includes('/'));
+  if (pathLike.length > 0) {
+    if (pathLike.some(n => CODE_PATH.test(n))) return { designOnly: false, reason: 'has code/UI deliverable paths' };
+    if (pathLike.every(n => DOC_PATH.test(n))) return { designOnly: true, reason: 'all deliverable paths are docs/spec' };
+  }
+  // Text-marker fallback: the cockpit Phase-0 spec SDs declare "DESIGN-ONLY — NO build" in their scope.
+  const blob = [sd?.title, sd?.description, sd?.scope].filter(Boolean).join(' ');
+  if (blob && DESIGN_MARKER.test(blob)) return { designOnly: true, reason: 'design-only marker in SD text' };
+  return { designOnly: false, reason: 'no design-only signal (fail-open)' };
+}
+
+const BOILERPLATE_AC = /\bis built( successfully)?\b|\bworks as expected\b|\bimplemented successfully\b|\buied successfully\b|\bdone successfully\b/i;
+
+/**
+ * Normalize an acceptance-criterion to text. The corpus stores ACs BOTH as plain strings AND as
+ * objects ({ given, when, then, scenario, criterion, ... }) — ~50/50 live — so a string-only filter
+ * would silently drop every object-shaped AC and false-fail well-formed design stories.
+ */
+function acToText(x) {
+  if (typeof x === 'string') return x;
+  if (x && typeof x === 'object') {
+    return [x.given, x.when, x.then, x.scenario, x.criterion, x.text, x.description, x.title]
+      .filter(v => typeof v === 'string' && v.trim()).join(' ');
+  }
+  return '';
+}
+
+/**
+ * Minimal quality bar for a design-only SD's story: ≥2 substantive, non-boilerplate acceptance
+ * criteria. (The SD-level classifyDesignOnly already established this is a spec deliverable, so a
+ * per-story "must name the spec" keyword check was dropped — it false-failed good design ACs that
+ * describe the artifact's content without the literal word "spec".) Returns { ok, reason }.
+ */
+export function storyMeetsDesignBar(story) {
+  const ac = Array.isArray(story?.acceptance_criteria) ? story.acceptance_criteria : [];
+  const substantive = ac.map(acToText).filter(s => s.trim().length >= 15);
+  if (substantive.length < 2) return { ok: false, reason: 'fewer than 2 substantive acceptance criteria' };
+  const title = (story?.title || '').toLowerCase().trim();
+  const allBoilerplate = substantive.every(s => BOILERPLATE_AC.test(s) || s.toLowerCase().trim() === title);
+  if (allBoilerplate) return { ok: false, reason: 'acceptance criteria are boilerplate / title-echo' };
+  return { ok: true };
+}
+
+/**
+ * Tailored design-only validation: promote/validate ONLY stories that meet the bar; surface the rest.
+ * @returns {Promise<Object>} { validated, designOnly:true, count, passing, failing, warnings, message }
+ */
+async function validateDesignOnlyStories(supabase, resolvedSdId, stories) {
+  const evaluated = stories.map(s => ({ s, bar: storyMeetsDesignBar(s) }));
+  const passing = evaluated.filter(e => e.bar.ok).map(e => e.s);
+  const failing = evaluated.filter(e => !e.bar.ok);
+  const warnings = failing.map(e => `Story "${e.s.title}" below the design-only quality bar: ${e.bar.reason}`);
+
+  // Promote status -> 'completed' for ALL design stories (the spec deliverable landed), so the SEPARATE
+  // required USER_STORY_COVERAGE gate (counts status='completed') is NOT hard-blocked — honoring the
+  // "advisory, don't hard-block the wave" intent. Withhold only validation_status for thin stories.
+  const toPromote = stories.filter(s => s.status === 'ready' || s.status === 'draft').map(s => s.id);
+  if (toPromote.length > 0) {
+    const { error } = await supabase.from('user_stories').update({ status: 'completed' }).in('id', toPromote);
+    if (error) return { validated: false, designOnly: true, error: error.message, warnings };
+    stories.forEach(s => { if (toPromote.includes(s.id)) s.status = 'completed'; });
+  }
+  // Validate ONLY stories meeting the bar; thin/boilerplate stories stay validation_status='pending'
+  // and are surfaced as advisory warnings (the un-masking) rather than rubber-stamped.
+  const toValidate = passing.filter(s => s.status === 'completed' && s.validation_status === 'pending').map(s => s.id);
+  if (toValidate.length > 0) {
+    const { error } = await supabase.from('user_stories').update({ validation_status: 'validated' }).in('id', toValidate);
+    if (error) return { validated: false, designOnly: true, error: error.message, warnings };
+  }
+  const validated = failing.length === 0;
+  console.log(validated
+    ? `✅ design-only: all ${passing.length} stories met the bar and were validated`
+    : `⚠️  design-only: ${passing.length} validated, ${failing.length} below the quality bar (surfaced, advisory)`);
+  return {
+    validated, designOnly: true, count: toValidate.length, passing: passing.length, failing: failing.length, warnings,
+    message: validated
+      ? `Design-only: validated ${passing.length} stories against the spec`
+      : `Design-only: ${failing.length} story(ies) below the quality bar (not validated)`,
+  };
+}
+
 /**
  * Auto-validate user stories for a given SD
  *
@@ -42,23 +144,35 @@ async function autoValidateUserStories(sdId, sbClient) {
   // stories are ever auto-validated.
   const isUuid = typeof sdId === 'string' &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdId);
+  // SD-LEO-INFRA-VALIDATE-DESIGN-ONLY-STORIES-001: also capture the SD row (metadata/text) here so
+  // design-only classification needs no extra query. One strategic_directives_v2 read per path.
   let resolvedSdId = sdId;
+  let sdRow = null;
   if (sdId && !isUuid) {
-    const { data: sdRow } = await supabase
+    const { data } = await supabase
       .from('strategic_directives_v2')
-      .select('id')
+      .select('id, metadata, title, description, scope')
       .eq('sd_key', sdId)
       .maybeSingle();
-    if (sdRow?.id) {
-      resolvedSdId = sdRow.id;
+    if (data?.id) {
+      resolvedSdId = data.id;
+      sdRow = data;
       console.log(`   ↳ resolved sd_key ${sdId} → ${resolvedSdId}`);
     }
+  } else if (isUuid) {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('metadata, title, description, scope')
+      .eq('id', sdId)
+      .maybeSingle();
+    sdRow = data || null;
   }
 
-  // 1. Get all user stories for this SD
+  // 1. Get all user stories for this SD (acceptance_criteria + implementation_context drive the
+  // design-only quality bar — SD-LEO-INFRA-VALIDATE-DESIGN-ONLY-STORIES-001).
   const { data: stories, error: storiesError } = await supabase
     .from('user_stories')
-    .select('id, title, status, validation_status')
+    .select('id, title, status, validation_status, acceptance_criteria, implementation_context')
     .eq('sd_id', resolvedSdId);
 
   if (storiesError) {
@@ -66,12 +180,7 @@ async function autoValidateUserStories(sdId, sbClient) {
     return { validated: false, error: storiesError.message };
   }
 
-  if (!stories || stories.length === 0) {
-    console.log('✅ No user stories to validate (acceptable for infra/docs SDs)');
-    return { validated: true, count: 0, message: 'No user stories' };
-  }
-
-  // 2. Check if all deliverables are complete
+  // 2. Deliverables (used for the completion gate AND for design-only path classification).
   const { data: deliverables, error: delError } = await supabase
     .from('sd_scope_deliverables')
     .select('deliverable_name, completion_status')
@@ -82,6 +191,22 @@ async function autoValidateUserStories(sdId, sbClient) {
     return { validated: false, error: delError.message };
   }
 
+  const { designOnly, reason: designReason } = classifyDesignOnly(sdRow, deliverables);
+  if (designOnly) console.log(`   🎨 design-only SD (${designReason}) — validating stories against the spec deliverable`);
+
+  // FR-3: a design-only SD that produced a spec deliverable but ZERO stories is SURFACED (advisory
+  // warning), not silently auto-passed. Non-design-only infra/docs SDs keep the {validated:true} contract.
+  if (!stories || stories.length === 0) {
+    if (designOnly) {
+      console.log('⚠️  design-only SD has a spec deliverable but ZERO user stories — surfacing (not auto-passing)');
+      return { validated: false, count: 0, designOnly: true,
+        warnings: ['design-only SD produced a spec deliverable but has ZERO user stories to validate against it'],
+        message: 'Design-only SD has no stories to validate' };
+    }
+    console.log('✅ No user stories to validate (acceptable for infra/docs SDs)');
+    return { validated: true, count: 0, message: 'No user stories' };
+  }
+
   const allDeliverablesComplete = deliverables && deliverables.length > 0 &&
     deliverables.every(d => d.completion_status === 'completed');
 
@@ -90,6 +215,13 @@ async function autoValidateUserStories(sdId, sbClient) {
     return { validated: false, message: 'Deliverables incomplete' };
   }
 
+  // FR-2: design-only SDs get a tailored quality check — only stories meeting the bar against the
+  // spec are promoted/validated; thin/boilerplate stories are surfaced, not rubber-stamped.
+  if (designOnly) {
+    return await validateDesignOnlyStories(supabase, resolvedSdId, stories);
+  }
+
+  // ── default path (code-bearing SDs): the existing universal promotion + validation ──
   // 2b. Promote status IN ('ready','draft') -> 'completed' (deliverables prove the work landed).
   // SD-FDBK-INFRA-COMPLETION-FLAG-HARNESS-001: PLAN / add-prd-to-database create user stories as
   // status='draft'. Promoting only 'ready' left those draft stories untouched, so they failed

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/story-auto-validation.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/story-auto-validation.js
@@ -27,6 +27,11 @@ export function createStoryAutoValidationGate(supabase) {
       try {
         const result = await autoValidateUserStories(sdId, supabase);
 
+        // SD-LEO-INFRA-VALIDATE-DESIGN-ONLY-STORIES-001: surface per-story design-only quality
+        // warnings (thin/boilerplate stories that did NOT meet the bar) through the gate. Advisory
+        // only (required:false) — a failing design-only quality bar must NOT hard-block the wave.
+        const designWarnings = Array.isArray(result.warnings) ? result.warnings : [];
+
         if (result.validated) {
           console.log(`   ✅ Story auto-validation passed (${result.count} stories)`);
           return {
@@ -34,18 +39,19 @@ export function createStoryAutoValidationGate(supabase) {
             score: 100,
             max_score: 100,
             issues: [],
-            warnings: result.message ? [result.message] : []
+            warnings: [...(result.message ? [result.message] : []), ...designWarnings]
           };
         }
 
-        // Not validated but not necessarily a failure (e.g., deliverables incomplete)
-        console.log(`   ⚠️  Story auto-validation skipped: ${result.message}`);
+        // Not validated but not necessarily a failure (deliverables incomplete, or a design-only
+        // SD with thin stories / zero stories — surfaced as advisory warnings, not a hard block).
+        console.log(`   ⚠️  Story auto-validation: ${result.message}`);
         return {
           passed: true,
           score: 70,
           max_score: 100,
           issues: [],
-          warnings: [`Story auto-validation skipped: ${result.message}`]
+          warnings: [`Story auto-validation: ${result.message}`, ...designWarnings]
         };
       } catch (error) {
         console.log(`   ⚠️  Story auto-validation error: ${error.message}`);

--- a/tests/unit/auto-validate-user-stories-draft.test.js
+++ b/tests/unit/auto-validate-user-stories-draft.test.js
@@ -15,7 +15,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { autoValidateUserStories } from '../../scripts/auto-validate-user-stories-on-exec-complete.js';
+import { autoValidateUserStories, classifyDesignOnly, storyMeetsDesignBar } from '../../scripts/auto-validate-user-stories-on-exec-complete.js';
 
 /**
  * Minimal chainable + awaitable mock of the supabase-js query builder.
@@ -28,13 +28,20 @@ function makeClient(opts) {
     const resolve = () => {
       if (st.table === 'strategic_directives_v2') {
         recorded.resolvedByKey = st.eqs.sd_key ?? null;
-        return { data: { id: opts.uuid }, error: null };
+        // opts.sdRow lets a test supply metadata/description for design-only classification.
+        return { data: { id: opts.uuid, ...(opts.sdRow || {}) }, error: null };
       }
       if (st.table === 'sd_scope_deliverables') return { data: opts.deliverables, error: null };
       if (st.table === 'user_stories') {
         if (st.op === 'update') {
-          if (st.updateData?.status === 'completed') recorded.promoteStatusIn = st.ins.status ?? null;
-          if (st.updateData?.validation_status === 'validated') recorded.validateCalled = true;
+          if (st.updateData?.status === 'completed') {
+            recorded.promoteStatusIn = st.ins.status ?? null;
+            if (st.ins.id) recorded.promotedIds = st.ins.id;
+          }
+          if (st.updateData?.validation_status === 'validated') {
+            recorded.validateCalled = true;
+            if (st.ins.id) recorded.validatedIds = st.ins.id;
+          }
           return { data: opts.stories, error: null };
         }
         return { data: opts.stories, error: null };
@@ -129,4 +136,88 @@ test('no user stories returns the {validated:true,count:0} contract (infra/docs 
   assert.equal(res.validated, true, 'no stories is an acceptable pass for infra/docs SDs');
   assert.equal(res.count, 0);
   assert.equal(recorded.promoteStatusIn, null, 'nothing to promote when there are no stories');
+});
+
+// ── SD-LEO-INFRA-VALIDATE-DESIGN-ONLY-STORIES-001 ──────────────────────────────────────────────
+
+test('classifyDesignOnly: explicit metadata.design_only flag wins', () => {
+  assert.equal(classifyDesignOnly({ metadata: { design_only: true } }, []).designOnly, true);
+});
+
+test('classifyDesignOnly: all-docs deliverable paths → design-only; any code path → not', () => {
+  assert.equal(classifyDesignOnly({}, [{ deliverable_name: 'docs/04_features/spec.md' }]).designOnly, true);
+  assert.equal(classifyDesignOnly({}, [{ deliverable_name: 'docs/x.md' }, { deliverable_name: 'src/foo.ts' }]).designOnly, false);
+});
+
+test('classifyDesignOnly: generic deliverable names + a design-only marker in SD text → design-only', () => {
+  const sd = { description: 'DESIGN-ONLY — NO build and NO code in this SD; reviewable spec.' };
+  const generic = [{ deliverable_name: 'Documentation updated' }, { deliverable_name: 'Core functionality implemented' }];
+  assert.equal(classifyDesignOnly(sd, generic).designOnly, true);
+});
+
+test('classifyDesignOnly: generic names + no marker → FAIL-OPEN to not-design-only', () => {
+  const generic = [{ deliverable_name: 'Documentation updated' }, { deliverable_name: 'Unit tests written' }];
+  assert.equal(classifyDesignOnly({ description: 'Add a feature' }, generic).designOnly, false);
+});
+
+test('storyMeetsDesignBar: substantive non-boilerplate ACs pass; thin/boilerplate fail', () => {
+  const good = { title: 'Review the spec', acceptance_criteria: [
+    'Opening the design spec, a reviewer can see the cockpit purpose stated clearly.',
+    'The spec ends with an open-questions section for the chairman.' ] };
+  assert.equal(storyMeetsDesignBar(good).ok, true);
+  assert.equal(storyMeetsDesignBar({ title: 't', acceptance_criteria: ['only one criterion here, long enough'] }).ok, false, '<2 substantive → fail');
+  assert.equal(storyMeetsDesignBar({ title: 't', acceptance_criteria: ['It is built successfully', 'Works as expected'] }).ok, false, 'boilerplate → fail');
+  // substantive + non-boilerplate, no literal "spec" keyword → PASS (the per-story spec-keyword check
+  // was dropped; the SD is already classified design-only, and a good design AC can describe content).
+  assert.equal(storyMeetsDesignBar({ title: 't', acceptance_criteria: [
+    'The metric reads months-of-runway = liquid cash / monthly net burn.',
+    'No alternative formula is left ambiguous in the document.' ] }).ok, true);
+});
+
+test('storyMeetsDesignBar: OBJECT-shaped acceptance_criteria are normalized (not silently dropped)', () => {
+  // ~half the corpus stores ACs as {given,when,then} objects — these must be measured, not ignored.
+  const objStory = { title: 'Object ACs', acceptance_criteria: [
+    { given: 'the metric-definition section of the spec is open', when: 'an engineer reads the formula', then: 'it reads months-of-runway = liquid cash / monthly net burn' },
+    { scenario: 'A reviewer checks the open-questions list and finds the chairman decisions enumerated.' } ] };
+  assert.equal(storyMeetsDesignBar(objStory).ok, true, 'object ACs must be normalized + pass the bar');
+  // an object AC that is empty/thin still fails
+  assert.equal(storyMeetsDesignBar({ title: 't', acceptance_criteria: [{ given: '', when: '', then: '' }] }).ok, false);
+});
+
+test('design-only branch: good story validated, thin story surfaced (advisory, not rubber-stamped)', async () => {
+  const stories = [
+    { id: 'g1', title: 'Good', status: 'ready', validation_status: 'pending', implementation_context: 'see the design spec',
+      acceptance_criteria: ['The spec documents the gauge purpose and data source clearly.', 'The spec lists open questions for the chairman.'] },
+    { id: 't1', title: 'Thin', status: 'ready', validation_status: 'pending',
+      acceptance_criteria: ['It is built successfully'] },
+  ];
+  const { client, recorded } = makeClient({
+    uuid: '77777777-7777-7777-7777-777777777777',
+    sdRow: { metadata: { design_only: true } },
+    stories,
+    deliverables: [{ deliverable_name: 'docs/04_features/spec.md', completion_status: 'completed' }],
+  });
+  const res = await autoValidateUserStories('77777777-7777-7777-7777-777777777777', client);
+  assert.equal(res.designOnly, true);
+  assert.equal(res.validated, false, 'a thin story keeps the SD from a clean validated pass');
+  assert.equal(res.passing, 1, 'only the good story is validated');
+  assert.equal(res.failing, 1, 'the thin story is surfaced');
+  assert.ok(res.warnings.some(w => w.includes('Thin')), 'the thin story is named in the warnings');
+  // Option A: ALL design stories are promoted status->completed (so USER_STORY_COVERAGE is not
+  // hard-blocked), but only the good story is validation_status->validated.
+  assert.deepEqual([...(recorded.promotedIds || [])].sort(), ['g1', 't1'], 'all stories promoted to completed');
+  assert.deepEqual(recorded.validatedIds, ['g1'], 'only the good story is validated');
+});
+
+test('FR-3: a design-only SD with a spec deliverable but ZERO stories is surfaced, not auto-passed', async () => {
+  const { client } = makeClient({
+    uuid: '88888888-8888-8888-8888-888888888888',
+    sdRow: { metadata: { design_only: true } },
+    stories: [],
+    deliverables: [{ deliverable_name: 'docs/04_features/spec.md', completion_status: 'completed' }],
+  });
+  const res = await autoValidateUserStories('88888888-8888-8888-8888-888888888888', client);
+  assert.equal(res.validated, false, 'design-only + zero stories must NOT silently auto-pass');
+  assert.equal(res.designOnly, true);
+  assert.ok(res.warnings && res.warnings.length >= 1, 'the zero-stories case is surfaced as a warning');
 });


### PR DESCRIPTION
## Summary
Fixes the content-blind rubber-stamp in `scripts/auto-validate-user-stories-on-exec-complete.js` that let **design-only Phase-0 spec SDs** auto-validate thin/boilerplate user stories with zero assertion against the spec they document (surfaced across the W0 cockpit design wave — the friction flagged 3× as harness_backlog `c8bd1822`). Scoped to 2 files + tests; **14 unit tests**.

## What changed
- **FR-1** `classifyDesignOnly` — narrow, **fail-open** detection (metadata.design_only flag → all-docs/spec deliverable paths → a *specific* text marker). Any uncertainty → not-design-only (the existing universal path). Deliberately fail-safe toward the code path.
- **FR-2** `storyMeetsDesignBar` — ≥2 substantive, non-boilerplate acceptance criteria; **normalizes BOTH string and {given,when,then} object ACs** (the corpus is ~50/50 — a string-only check would false-fail object-AC design SDs).
- **FR-3** design-only + **zero stories** → surfaced (advisory warning), not the prior silent `validated:true`.
- **FR-4** the gate stays `required:false` advisory and surfaces the thin-story warnings.

## Does NOT hard-block the wave (Option A)
Adversarial review found that withholding promotion would trip the **separate `required:true` USER_STORY_COVERAGE gate** → hard-blocking the very design SDs this targets. So `validateDesignOnlyStories` **promotes ALL design stories `status=completed`** (coverage gate counts completed) and withholds **only `validation_status`** for thin stories, surfacing them as advisory warnings.

## Review
Adversarial review caught two ship-blockers invisible to green tests — (CRITICAL) object-shaped acceptance_criteria normalization, (HIGH) the cross-gate hard-block → Option A — both fixed + test-covered. The default code-bearing path and the function return contract (validated/count/message) are unchanged; existing importers unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)