### PR TITLE
fix(SD-LEO-INFRA-DEP-RESOLVER-IGNORE-NON-SDKEY-001): coordinator-audit dep gauge ignores non-SD-key deps

### DIFF
--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -20,6 +20,10 @@ import { computeReviewHealth } from '../lib/fleet/review-health.mjs';
 // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: reuse the pure detectors as the single source for the gauges.
 // SD-LEO-INFRA-REVIVE-EVA-HEARTBEAT-ALARM-001: + the EVA scheduler staleness detector.
 import { detectLoopExpiry, detectStalledLoop, detectEvaSchedulerStale } from '../lib/coordinator/detectors.cjs';
+// SD-LEO-INFRA-DEP-RESOLVER-IGNORE-NON-SDKEY-001: reuse the canonical SD-key dependency
+// predicate so prose/file-path/gate-name deps don't inflate the blocked count (ESM-imports-CJS,
+// same pattern as detectors.cjs above). SSOT shared with stale-session-sweep.cjs (QF-20260525-542).
+import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -175,7 +179,10 @@ try {
 // (e) DEPENDENCY / CRITICAL-PATH — blocked vs ready, plus stale-blocked anomalies
 let depLine, depStale = [];
 try {
-  const depOf = (s) => Array.isArray(s.dependencies) ? s.dependencies.map(d => d && (d.sd_id || d.sd_key || d)).filter(Boolean) : [];
+  // Canonical predicate: keeps only /^SD-[A-Z0-9-]+/ keys (string or sd_key/id/sd_id fields);
+  // prose strings, file paths, gate names, and object placeholders are dropped so they no longer
+  // count as unmet blockers (line 185/190 below). Unknown/missing REAL SD-keys still count as unmet.
+  const depOf = (s) => parseSdDependencies(s.dependencies);
   const depKeys = [...new Set(sds.flatMap(depOf))];
   const statusByKey = {};
   if (depKeys.length) {

--- a/tests/unit/coordinator-audit-dep-gauge.test.js
+++ b/tests/unit/coordinator-audit-dep-gauge.test.js
@@ -1,0 +1,65 @@
+/**
+ * SD-LEO-INFRA-DEP-RESOLVER-IGNORE-NON-SDKEY-001
+ * Network-free unit tests for the coordinator-audit DEPENDENCY gauge's dependency
+ * parsing. The gauge's depOf now delegates to the canonical parseSdDependencies
+ * (lib/utils/parse-sd-dependencies.cjs) so prose strings, file paths, gate names,
+ * and object placeholders no longer inflate the blocked count, while genuine
+ * SD-key deps (string or sd_key/id/sd_id field) still count as unmet/blocking.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parseSdDependencies } = require('../../lib/utils/parse-sd-dependencies.cjs');
+
+// Mirror of the gauge's blocked-count predicate (scripts/coordinator-audit.mjs):
+//   depOf(s) = parseSdDependencies(s.dependencies)
+//   isTerminal(st) = TERMINAL.includes(st)  // unknown/missing real SD-key also unmet
+//   blocked if deps.length && deps.some(k => !isTerminal(statusByKey[k]))
+const TERMINAL = ['completed', 'cancelled', 'archived'];
+const depOf = (s) => parseSdDependencies(s.dependencies);
+function isBlocked(s, statusByKey) {
+  const deps = depOf(s);
+  if (!deps.length) return false;
+  return deps.some((k) => !TERMINAL.includes(statusByKey[k]));
+}
+
+describe('coordinator-audit dep gauge — parseSdDependencies delegation', () => {
+  it('drops prose, file-path, and gate-name entries; keeps only SD-keys (string + object)', () => {
+    expect(
+      parseSdDependencies([
+        'scripts/foo.js',
+        'USER_STORY_COVERAGE gate',
+        'metadata-contract note',
+        'SD-LEO-INFRA-REAL-001',
+        { sd_key: 'SD-LEO-INFRA-OBJ-002' },
+      ])
+    ).toEqual(['SD-LEO-INFRA-REAL-001', 'SD-LEO-INFRA-OBJ-002']);
+  });
+
+  it('an SD whose only deps are prose/file-path strings is NOT counted as blocked', () => {
+    const s = { dependencies: ['scripts/coordinator-audit.mjs', 'the USER_STORY_COVERAGE gate', 'a guardrail-name note'] };
+    expect(depOf(s)).toEqual([]);
+    expect(isBlocked(s, {})).toBe(false);
+  });
+
+  it('a genuine non-terminal SD-key dep STILL blocks', () => {
+    const s = { dependencies: ['SD-LEO-INFRA-OPEN-001'] };
+    expect(isBlocked(s, { 'SD-LEO-INFRA-OPEN-001': 'in_progress' })).toBe(true);
+  });
+
+  it('an unknown/missing REAL SD-key dep still counts as unmet (line-185 semantics preserved)', () => {
+    const s = { dependencies: ['SD-LEO-INFRA-GHOST-999'] };
+    expect(isBlocked(s, {})).toBe(true); // statusByKey has no entry -> undefined -> not terminal -> blocked
+  });
+
+  it('a terminal SD-key dep does NOT block; mixed prose+terminal is dep-satisfied', () => {
+    const s = { dependencies: ['scripts/foo.js', 'SD-LEO-INFRA-DONE-001'] };
+    expect(depOf(s)).toEqual(['SD-LEO-INFRA-DONE-001']);
+    expect(isBlocked(s, { 'SD-LEO-INFRA-DONE-001': 'completed' })).toBe(false);
+  });
+
+  it('object dep carrying id/sd_id with an SD-key is kept', () => {
+    expect(parseSdDependencies([{ id: 'SD-LEO-INFRA-ID-003' }, { sd_id: 'SD-LEO-INFRA-SDID-004' }]))
+      .toEqual(['SD-LEO-INFRA-ID-003', 'SD-LEO-INFRA-SDID-004']);
+  });
+});


### PR DESCRIPTION
## Summary
The coordinator-audit DEPENDENCY gauge counted non-SD-key dependency entries (prose strings, file paths like `scripts/foo.js`, gate names, guardrail notes) as unmet blockers, emitting a phantom blocked-count on actively-building SDs. Fired on 4 SDs across 4 workers on 2026-06-16 (feedback a2f3ad8c).

**Fix:** swap the inline `depOf` in `scripts/coordinator-audit.mjs` for the canonical `parseSdDependencies` (lib/utils/parse-sd-dependencies.cjs) — the same SSOT `stale-session-sweep.cjs` already adopted (QF-20260525-542). Only `/^SD-[A-Z0-9-]+/` keys survive; real SD-key deps (incl. unknown/missing) still count as unmet. Pure predicate swap, no schema work.

## Verification
- New unit test `tests/unit/coordinator-audit-dep-gauge.test.js` — 6/6 pass (prose-dropped, SD-key-kept, object sd_key/id/sd_id kept, unknown-key-still-blocks, terminal-not-blocked).
- `node scripts/coordinator-audit.mjs` runs end-to-end; DEPENDENCY gauge renders (ESM-imports-CJS predicate loads).
- Adversarial review against 3,902 live SD rows: **strictly more correct, zero regressions**. Also fixes object deps carrying a UUID in `sd_id` (old picked sd_id-first → never matched) and jsonb-string deps (old `Array.isArray`=false silently dropped a real dep).
- TESTING sub-agent PASS (row 9b04f560); handoffs 94/98/94/96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)