### PR TITLE
fix(SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-FEEDBACK-TYPE-001): chairman decision-queue feedback writers emit a constraint-allowed type

### DIFF
--- a/lib/chairman/feedback-decision-type.mjs
+++ b/lib/chairman/feedback-decision-type.mjs
@@ -1,0 +1,20 @@
+// feedback-decision-type.mjs — SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-FEEDBACK-TYPE-001
+//
+// The single source of truth for the feedback.type literal emitted by the chairman
+// decision-queue feedback writers (recordFlagCall, recordDeferral in
+// scripts/chairman-decisions.mjs).
+//
+// INVARIANT: this value MUST be a member of the live feedback_type_check CHECK
+// constraint allowed set {issue, enhancement}. It was previously hardcoded as
+// 'improvement' in both writers — a value the constraint REJECTS — which made the
+// flag-enablement and deferral decision paths 100% broken (every INSERT threw
+// 'feedback violates check constraint feedback_type_check'). 'enhancement' is the
+// semantically-closest allowed value for these chairman-audit rows (the durable
+// discriminator for them is the category field, not the type).
+//
+// Extracted into this side-effect-free module (rather than inlined) so the regression
+// test can import the literal directly — scripts/chairman-decisions.mjs runs its CLI at
+// module top-level and cannot be safely imported by a test. The test asserts this value
+// against the LIVE constraint (real INSERT probe), so a future drift to a disallowed
+// value is caught.
+export const CHAIRMAN_FEEDBACK_TYPE = 'enhancement';

--- a/scripts/chairman-decisions.mjs
+++ b/scripts/chairman-decisions.mjs
@@ -14,6 +14,7 @@ import {
   parseArgs, routeDecision, sortPending, effectivePriority, formatAge, USAGE,
 } from '../lib/chairman/decision-queue.mjs';
 import { armCliTeardown } from '../lib/cli-graceful-exit.js';
+import { CHAIRMAN_FEEDBACK_TYPE } from '../lib/chairman/feedback-decision-type.mjs';
 
 const parsed = parseArgs(process.argv.slice(2));
 if (parsed.error) {
@@ -82,7 +83,7 @@ const writers = {
   recordFlagCall: async (id, decision, rationale) => {
     const { data: flag } = await db.from('leo_feature_flags').select('flag_key').eq('id', id).maybeSingle();
     const { data, error } = await db.from('feedback').insert({
-      type: 'improvement', source_application: 'EHG_Engineer', source_type: 'auto_capture',
+      type: CHAIRMAN_FEEDBACK_TYPE, source_application: 'EHG_Engineer', source_type: 'auto_capture',
       category: 'chairman_flag_decision', status: 'new', severity: 'low',
       title: `Chairman call on flag ${flag?.flag_key || id}: ${decision}`,
       description: rationale || '(no rationale provided)',
@@ -108,7 +109,7 @@ const writers = {
   // deferral — durable audit row; the item stays pending (visibility act, not a decision).
   recordDeferral: async (d) => {
     const { data, error } = await db.from('feedback').insert({
-      type: 'improvement', source_application: 'EHG_Engineer', source_type: 'auto_capture',
+      type: CHAIRMAN_FEEDBACK_TYPE, source_application: 'EHG_Engineer', source_type: 'auto_capture',
       category: 'chairman_decision_deferred', status: 'new', severity: 'low',
       title: `Chairman deferred ${d.decisionType}:${d.id}`,
       description: d.rationale || '(no rationale provided)',

--- a/tests/database/chairman-decisions-feedback-type.test.js
+++ b/tests/database/chairman-decisions-feedback-type.test.js
@@ -1,0 +1,76 @@
+/**
+ * Chairman decision-queue feedback-type regression guard
+ * SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-FEEDBACK-TYPE-001
+ *
+ * The chairman decision-queue CLI (scripts/chairman-decisions.mjs) writes a feedback
+ * audit row from recordFlagCall (flag-enablement) and recordDeferral (deferral). Both
+ * previously hardcoded type:'improvement' — a value the live feedback_type_check CHECK
+ * constraint REJECTS (it allows only {issue, enhancement}) — making both decision paths
+ * 100% broken. The fix routes both writers through the shared CHAIRMAN_FEEDBACK_TYPE
+ * constant.
+ *
+ * This test asserts the emitted value against the LIVE constraint (NOT a mock) via real
+ * INSERT probes, and proves the old value is still rejected — so a future literal drift
+ * back to a disallowed value is caught.
+ *
+ * Sandbox: probe rows use a PROBE-CDQFT-* title and category='harness_backlog'; each
+ * probe row is deleted in the same test (no residue). No peer rows are touched.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+import { CHAIRMAN_FEEDBACK_TYPE } from '../../lib/chairman/feedback-decision-type.mjs';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+// The exact NOT-NULL columns the live feedback table requires, so a probe isolates the
+// feedback_type_check constraint rather than failing on an unrelated NOT-NULL violation.
+const probeRow = (type) => ({
+  type,
+  source_application: 'EHG_Engineer',
+  source_type: 'auto_capture',
+  category: 'harness_backlog',
+  status: 'new',
+  severity: 'low',
+  title: 'PROBE-CDQFT ephemeral ' + type,
+  description: 'ephemeral feedback_type_check probe — safe to delete',
+});
+
+const createdIds = [];
+afterAll(async () => {
+  if (createdIds.length) await supabase.from('feedback').delete().in('id', createdIds);
+});
+
+describe('chairman feedback-type constant (SD-LEO-INFRA-CHAIRMAN-DECISION-QUEUE-FEEDBACK-TYPE-001)', () => {
+  it('is not the constraint-violating "improvement" literal', () => {
+    expect(CHAIRMAN_FEEDBACK_TYPE).not.toBe('improvement');
+  });
+
+  it('is ACCEPTED by the live feedback_type_check constraint (real INSERT probe)', async () => {
+    const { data, error } = await supabase
+      .from('feedback')
+      .insert(probeRow(CHAIRMAN_FEEDBACK_TYPE))
+      .select('id')
+      .single();
+    expect(error).toBeNull();
+    expect(data?.id).toBeTruthy();
+    if (data?.id) createdIds.push(data.id);
+  });
+
+  it('the OLD "improvement" value is still REJECTED by feedback_type_check (proves the gate is live, not mocked)', async () => {
+    const { data, error } = await supabase
+      .from('feedback')
+      .insert(probeRow('improvement'))
+      .select('id')
+      .single();
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error.message).toContain('feedback_type_check');
+    // Defensive: if a future constraint change ever accepted it, clean up so we leak nothing.
+    if (data?.id) createdIds.push(data.id);
+  });
+});


### PR DESCRIPTION
## Summary
Restores the chairman decision-queue CLI (`scripts/chairman-decisions.mjs`), which was **100% broken** for two decision paths. `recordFlagCall` (flag-enablement) and `recordDeferral` (deferral) INSERTed into `feedback` with `type:'improvement'` — a value the live `feedback_type_check` constraint **rejects** (it allows only `{issue, enhancement}`). Every such INSERT threw `feedback violates check constraint feedback_type_check`. Live-verified with the exact writer shape: `improvement` rejected, `enhancement` accepted.

- **FR-1**: new side-effect-free `lib/chairman/feedback-decision-type.mjs` exporting `CHAIRMAN_FEEDBACK_TYPE='enhancement'` (single source of truth, importable by tests — `chairman-decisions.mjs` runs its CLI at module top-level and cannot be imported safely).
- **FR-2**: both writers emit `CHAIRMAN_FEEDBACK_TYPE`; all other INSERT fields unchanged.
- **FR-3**: `tests/database/chairman-decisions-feedback-type.test.js` asserts against the **live** constraint via real INSERT probes (new value accepted + cleaned up; `improvement` still rejected), catching future literal drift.

## Evidence
- Handoffs: LEAD-TO-PLAN 94 · PLAN-TO-EXEC 98 · EXEC-TO-PLAN 94 · PLAN-TO-LEAD 96
- TESTING PASS(99) @ EXEC; VALIDATION PASS(98) / REGRESSION PASS(97) @ PLAN_VERIFICATION (70 tests across 5 chairman test files green, zero regressions)
- Retrospective quality 80
- Surgical 3-file diff (+99/-2); `lib/chairman/decision-queue.mjs` routing untouched; `category` (chairman_flag_decision / chairman_decision_deferred) remains the row discriminator, so no reader is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
