### PR TITLE
fix(SD-LEO-INFRA-UNIT-TIER-SOURCEPIN-REBASELINE-001): re-baseline 14 chronically-red Unit Tier source-pin tests

### DIFF
--- a/scripts/adam-role-contract-proactive-clause.test.js
+++ b/scripts/adam-role-contract-proactive-clause.test.js
@@ -25,7 +25,10 @@ describe('Adam Role Contract — proactivity-is-propose clause', () => {
 
   it('forbids Adam autonomously BEGINNING self-generated proactive work without the coordinator', () => {
     expect(contract).toMatch(/does \*\*NOT\*\* autonomously|does NOT autonomously/);
-    expect(contract).toMatch(/proactive work requires the coordinator/i);
+    // Re-synced to the current canonical phrasing (the NEVER-HOLD-SOURCING carve-out reworded the
+    // clause): "...proactive work (investigations/building) requires the coordinator's go". Match the
+    // concept (proactive work … requires the coordinator) rather than a frozen exact phrase.
+    expect(contract).toMatch(/proactive work[\s\S]{0,60}requires the coordinator/i);
   });
 
   it('keeps surfacing findings / proposing options always in-bounds', () => {

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1627,7 +1627,11 @@ async function main() {
       if (sd.claiming_session_id === s.session_id) {
         await supabase
           .from('strategic_directives_v2')
-          .update({ claiming_session_id: null, is_working_on: false })
+          // FR-1 (SD-LEO-INFRA-CLAIM-LIFECYCLE-HARDENING-002): an SD-only release that nulls
+          // claiming_session_id MUST also null active_session_id — the sync trigger's CAS branch
+          // only clears active_session_id WHERE it equals THIS fixture's session, so a value
+          // pointing at a different session would dangle. Co-clear unconditionally on the SD write.
+          .update({ claiming_session_id: null, active_session_id: null, is_working_on: false })
           .eq('sd_key', s.sd_key)
           .eq('claiming_session_id', s.session_id); // race guard: only clear if still the fixture
       }

--- a/scripts/worker-signal.test.js
+++ b/scripts/worker-signal.test.js
@@ -75,9 +75,11 @@ describe('WS-9: parseArgs --help flag', () => {
   });
 });
 
-describe('WS-10: type vocabulary fixed at 8 types + severity at 4 levels', () => {
+describe('WS-10: type vocabulary fixed at 9 types + severity at 4 levels', () => {
   it('exposes documented vocabularies and BODY_HARD_CAP=4096', () => {
-    expect(SIGNAL_TYPES).toEqual(['stuck', 'need-sweep', 'prd-ambiguous', 'gate-bug', 'spec-conflict', 'harness-bug', 'feedback', 'other']);
+    // 'unfit' added by SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-4, PR #4777): a worker reporting an
+    // assignment it cannot execute HERE/NOW (repo mismatch / closed premise / missing precondition).
+    expect(SIGNAL_TYPES).toEqual(['stuck', 'need-sweep', 'prd-ambiguous', 'gate-bug', 'spec-conflict', 'harness-bug', 'feedback', 'unfit', 'other']);
     expect(SEVERITIES).toEqual(['low', 'medium', 'high', 'critical']);
     expect(BODY_HARD_CAP).toBe(4096);
     // Sanity: redaction patterns count

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -259,86 +259,6 @@
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
     {
-      "file": "test/unit/discovery-mode.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "LLMEmptyResponseError: trend_scanner_empty_response: got 2 chars from LLM",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "test/unit/modeling.test.js",
-      "reason_class": "assertion-drift",
-      "error_signature": "AssertionError: expected +0 to be 5000000000 // Object.is equality",
-      "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "test/unit/stage-zero.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "LLMUndercountError: trend_scanner_undercount: got 1 of 5 expected",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "test/unit/synthesis-components-4-8.test.js",
-      "reason_class": "assertion-drift",
-      "error_signature": "TypeError: Cannot read properties of null (reading 'type')",
-      "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "test/unit/synthesis-engine.test.js",
-      "reason_class": "assertion-drift",
-      "error_signature": "AssertionError: expected +0 to be 72 // Object.is equality",
-      "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/archived/directive-lab-debug.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "Error: Playwright Test did not expect test.describe() to be called here.",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/archived/directive-lab-e2e.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "Error: Playwright Test did not expect test.describe() to be called here.",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/archived/directive-lab-enhanced-features.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "Error: Playwright Test did not expect test.describe() to be called here.",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/archived/enhanced-directive-lab.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "Error: Playwright Test did not expect test.describe() to be called here.",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/archived/step4-layout-fix-verification.test.js",
-      "reason_class": "unclassified",
-      "error_signature": "Error: Playwright Test did not expect test.describe() to be called here.",
-      "linked_ref": "feedback:f44292ba-e082-4c39-aa9d-ae0000226313",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "tests/capture-session-id-hook.test.js",
       "reason_class": "windows-abort-0xC0000409",
       "error_signature": "AssertionError: expected 3221226505 to be +0 // Object.is equality",
@@ -1015,14 +935,6 @@
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected error to be instance of ManifestoActivationError",
       "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.364Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/unit/handoff-orchestrator.test.js",
-      "reason_class": "duplicate",
-      "error_signature": "AssertionError: expected false to be true // Object.is equality",
-      "linked_ref": "SD-LEO-INFRA-TEST-ESTATE-HYGIENE-001",
       "quarantined_at": "2026-06-11T10:09:40.364Z",
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },

--- a/tests/sd-type-threshold-canonical.test.js
+++ b/tests/sd-type-threshold-canonical.test.js
@@ -41,7 +41,10 @@ const EXCLUDE_FILE_RX = /\.(test|spec)\.(m?js)$/;
 
 const EXPECTED_LITERAL_FILES = [
   'scripts/modules/sd-quality-scoring.js',
-  'scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js',
+  // vision-score.js no longer holds an INLINE literal: SD-PAT-FIX-WRITER-CONSUMER-ASYMMETRY-001
+  // (PR #4657) consolidated it into the shared single-source lib/handoff/threshold-resolver.js,
+  // which vision-score.js now imports/re-exports. Pin the canonical literal at its new home.
+  'lib/handoff/threshold-resolver.js',
   'scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js',
   'scripts/story-requirements-template.js',
 ];

--- a/tests/unit/eva/bridge/build-tasks-writer-descriptor.test.js
+++ b/tests/unit/eva/bridge/build-tasks-writer-descriptor.test.js
@@ -72,9 +72,13 @@ describe('buildBuildTasks — Cloudflare descriptor', () => {
     expect(out).not.toContain('Replit Postgres');
   });
 
-  it('3.5 Deploy line is present and unchanged', () => {
+  it('3.5 Deploy line is present and family-appropriate (Cloudflare)', () => {
+    // FR-4 made the 3.5 Deploy line descriptor-driven (per deploy-target family), so it is no
+    // longer the byte-identical Replit line on cloud paths. Assert presence + family-correctness
+    // (a Cloudflare venture must NOT be told to deploy on Replit) rather than a frozen string.
     expect(out).toContain('3.5 Deploy');
-    expect(out).toContain('Replit hosting (autoscale)');
+    expect(out).toContain('Cloudflare Pages (frontend) + Workers (compute)');
+    expect(out).not.toContain('Replit hosting (autoscale)');
   });
 
   it('is deterministic', () => {
@@ -121,9 +125,11 @@ describe('buildBuildTasks — neon + cloud-run descriptor (F7/F8)', () => {
     expect(child1Block).not.toContain('R2 Workers binding');
   });
 
-  it('3.5 Deploy line still present and unchanged', () => {
+  it('3.5 Deploy line is present and family-appropriate (GCP Cloud Run)', () => {
+    // Descriptor-driven (FR-4): neon + cloud-run (F7/F8) emits the GCP Cloud Run line, not Replit.
     expect(out).toContain('3.5 Deploy');
-    expect(out).toContain('Replit hosting (autoscale)');
+    expect(out).toContain('GCP Cloud Run via `gcloud run deploy`');
+    expect(out).not.toContain('Replit hosting (autoscale)');
   });
 });
 
@@ -182,11 +188,16 @@ describe('3.5 Deploy line invariant', () => {
     expect(buildBuildTasks({})).toContain(DEPLOY_LINE_FRAGMENT);
   });
 
-  it('content is identical in both paths', () => {
-    const cloudOut = buildBuildTasks({ stackDescriptor: CF_DESCRIPTOR });
-    const replitOut = buildBuildTasks({});
-    // Extract the line starting with '3.5 Deploy'
+  it('every descriptor path emits exactly one family-appropriate 3.5 Deploy line', () => {
+    // FR-4: the 3.5 Deploy line is descriptor-driven, so it is NO LONGER identical across paths
+    // (a Cloudflare/GCP venture must not be told to deploy on Replit). The real invariant is that
+    // EACH path emits a single 3.5 Deploy line that matches its own family.
     const extractLine = (s) => s.split('\n').find((l) => l.includes('3.5 Deploy')) || '';
-    expect(extractLine(cloudOut)).toBe(extractLine(replitOut));
+    const cloudLine = extractLine(buildBuildTasks({ stackDescriptor: CF_DESCRIPTOR }));
+    const replitLine = extractLine(buildBuildTasks({}));
+    expect(cloudLine).toContain('3.5 Deploy');
+    expect(replitLine).toContain('3.5 Deploy');
+    expect(cloudLine).toContain('Cloudflare Pages');
+    expect(replitLine).toContain('Replit hosting (autoscale)');
   });
 });

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-26-growth-playbook.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-26-growth-playbook.test.js
@@ -88,7 +88,11 @@ describe('stage-26-growth-playbook — FR-5 entry-precondition refusal', () => {
     expect(result.lifecycle_terminal).toBe(false);
   });
 
-  it('emits SKIP partial_postlaunch_artifacts when only one of the two is present', async () => {
+  it('PROCEEDS (no SKIP) when only one of the two postlaunch artifacts is present', async () => {
+    // SD-LEO-INFRA-DATADISTILL-HONEST-LAUNCH-001 (first-contact defect #11) deliberately removed
+    // the partial_postlaunch_artifacts SKIP: a venture launched minutes ago legitimately has
+    // assumptions_vs_reality but ZERO user feedback yet. PARTIAL data now generates an honest
+    // playbook from what exists (the prompt receives only the present artifacts) — it does NOT skip.
     const result = await analyzeStage26GrowthPlaybook({
       ventureName: 'TestVenture',
       ventureWorkflowStatus: 'in_progress',
@@ -97,9 +101,10 @@ describe('stage-26-growth-playbook — FR-5 entry-precondition refusal', () => {
         { artifact_type: 'postlaunch_user_feedback_summary', is_current: false },
       ],
     });
-    expect(result.status).toBe('no_data');
-    expect(result.reason).toBe('partial_postlaunch_artifacts');
-    expect(result.lifecycle_terminal).toBe(false);
+    expect(result.status).not.toBe('no_data');
+    expect(result.reason).not.toBe('partial_postlaunch_artifacts');
+    // The proceed path runs the generator (lifecycle_terminal carries an LLM-request marker, not a
+    // SKIP's `false`); the load-bearing contract is simply that it did NOT skip on partial data.
   });
 });
 

--- a/tests/unit/heal-vision/heal-vision.test.js
+++ b/tests/unit/heal-vision/heal-vision.test.js
@@ -147,19 +147,25 @@ describe('T4 — Default-omitted regression pin (LOAD-BEARING)', () => {
     // constant produced (= resolve(import.meta.dirname, '../../..') from check-types.js,
     // which is REPO_ROOT). The default `checkTypes` export uses this default.
     // Test: run file_count for a known-EHG-only path against default; should find files.
+    // Probe re-synced (SD-LEO-INFRA-UNIT-TIER-SOURCEPIN-REBASELINE-001): the former probe
+    // `scripts/eva/evidence-rubrics/V*.js` was archived by PR #4629 (estate reconciliation),
+    // so the default-ROOT contract was firing on a vanished sentinel. Repointed to the stable,
+    // archive-immune `lib/eva/stage-templates/stage-*.js` fileset (27 files; also used by the
+    // sibling assertions above). The CONTRACT under test is unchanged: createCheckTypes()
+    // defaults to REPO_ROOT.
     const result = await checkTypes.file_count({
-      glob: 'scripts/eva/evidence-rubrics/V*.js',
+      glob: 'lib/eva/stage-templates/stage-*.js',
       minCount: 5,
     });
     expect(result.passed).toBe(true);
-    // Sanity-check: the legacy path should find at least 11 V*.js rubrics (V01-V11)
+    // Sanity-check: the legacy default path should find many stage templates.
     expect(result.evidence).toMatch(/Found \d+ file/);
   });
 
   it('createCheckTypes({ targetPath: <empty> }) does NOT find EHG files (proves switch works)', async () => {
     const ct = createCheckTypes({ targetPath: emptyFixture });
     const result = await ct.file_count({
-      glob: 'scripts/eva/evidence-rubrics/V*.js',
+      glob: 'lib/eva/stage-templates/stage-*.js',
       minCount: 5,
     });
     expect(result.passed).toBe(false);

--- a/tests/unit/lead-final-approval-pending-pre-insert.test.js
+++ b/tests/unit/lead-final-approval-pending-pre-insert.test.js
@@ -73,16 +73,22 @@ describe('Pin Set 1: LeadFinalApprovalExecutor flag-gated pre-insert (FR-1 + FR-
     expect(helperBody).toMatch(/\.delete\(\)/);
     expect(helperBody).toMatch(/\.eq\(['"]handoff_type['"]\s*,\s*['"]LEAD-FINAL-APPROVAL['"]\)/);
     expect(helperBody).toMatch(/\.eq\(['"]status['"]\s*,\s*['"]pending_acceptance['"]\)/);
-    expect(helperBody).toMatch(/\.eq\(['"]created_by['"]\s*,\s*['"]UNIFIED-HANDOFF-SYSTEM['"]\)/);
+    // created_by scope re-synced: SD-FDBK-FIX-HANDOFF-CLAIM-GATE-001 (FR-4) replaced the single
+    // `.eq('created_by','UNIFIED-HANDOFF-SYSTEM')` with `.in('created_by', recorderIdentities())`
+    // (matches the system tag OR the session identity — strictly safer). Accept either form, but
+    // still FAIL LOUD if the created_by scope is ever dropped entirely (the real data-safety risk).
+    expect(helperBody).toMatch(/\.(?:eq|in)\(['"]created_by['"]\s*,\s*(?:['"]UNIFIED-HANDOFF-SYSTEM['"]|recorderIdentities\(\))\)/);
     // Fail-soft logging marker
     expect(helperBody).toMatch(/LFA_PENDING_CLEANUP_FAILED/);
   });
 
-  test('FR-4 cleanup wired at BOTH post-pre-insert rejection sites (UNAPPLIED_MIGRATIONS + SD_UPDATE_FAILED)', () => {
+  test('FR-4 cleanup wired at every post-pre-insert rejection site (UNAPPLIED_MIGRATIONS + CANONICAL_LFA_WRITE_FAILED x2 + SD_UPDATE_FAILED)', () => {
     const src = readFileSync(EXECUTOR_PATH, 'utf8');
-    // Two cleanup-call sites: enumerate count parity with the count of rejected returns between pre-insert and HandoffRecorder
+    // Cleanup-call sites: count parity with rejected returns between pre-insert and HandoffRecorder.
+    // Grew 2 -> 4 when SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001 added the two CANONICAL_LFA_WRITE_FAILED
+    // rejection branches (canonErr + catch) — each correctly cleans up the pending pre-insert row.
     const cleanupCalls = src.match(/await this\._cleanupPendingPreInsert\(sd\.id,\s*usePendingPath\)/g) || [];
-    expect(cleanupCalls.length).toBe(2);
+    expect(cleanupCalls.length).toBe(4);
   });
 });
 
@@ -168,7 +174,9 @@ describe('Pin Set 4: FR-9 helper in pending-migrations-check.js + FR-2 upsert in
     const upsertRegion = src.slice(upsertAnchor, upsertEnd);
     expect(upsertRegion).toMatch(/\.eq\(['"]handoff_type['"]\s*,\s*['"]LEAD-FINAL-APPROVAL['"]\)/);
     expect(upsertRegion).toMatch(/\.eq\(['"]status['"]\s*,\s*['"]pending_acceptance['"]\)/);
-    expect(upsertRegion).toMatch(/\.eq\(['"]created_by['"]\s*,\s*['"]UNIFIED-HANDOFF-SYSTEM['"]\)/);
+    // created_by scope re-synced to the recorderIdentities() helper (see Pin Set 1 rationale).
+    // Accept either the literal tag or the identity helper; still fails loudly if the scope is dropped.
+    expect(upsertRegion).toMatch(/\.(?:eq|in)\(['"]created_by['"]\s*,\s*(?:['"]UNIFIED-HANDOFF-SYSTEM['"]|recorderIdentities\(\))\)/);
     expect(upsertRegion).toMatch(/upserted_by_recorder/);
   });
 });

--- a/tests/unit/protocol-publication-pipeline.test.js
+++ b/tests/unit/protocol-publication-pipeline.test.js
@@ -134,9 +134,13 @@ describe('FR-4: --only scoped regeneration', () => {
     } finally { fs.rmSync(dir, { recursive: true, force: true }); }
   });
 
-  it('KNOWN_GENERATED_FILES covers the 12 generated files', () => {
-    expect(KNOWN_GENERATED_FILES).toHaveLength(12);
+  it('KNOWN_GENERATED_FILES covers the 14 generated files', () => {
+    // Grew 12 -> 14 when the Coordinator role contract joined the generated set
+    // (CLAUDE_COORDINATOR.md + CLAUDE_COORDINATOR_DIGEST.md).
+    expect(KNOWN_GENERATED_FILES).toHaveLength(14);
     expect(KNOWN_GENERATED_FILES).toContain('CLAUDE.md');
     expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_ADAM_DIGEST.md');
+    expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_COORDINATOR.md');
+    expect(KNOWN_GENERATED_FILES).toContain('CLAUDE_COORDINATOR_DIGEST.md');
   });
 });

--- a/tests/unit/scripts/sweep-residuals.test.js
+++ b/tests/unit/scripts/sweep-residuals.test.js
@@ -22,7 +22,11 @@ function block(after, before) {
 }
 
 describe('FR-1: terminal-target WORK_ASSIGNMENT drain', () => {
-  const fr1 = block('drain WORK_ASSIGNMENT rows whose target SD/QF', 'for (const s of activeSessions)');
+  // `before` anchor re-synced: the old 'for (const s of activeSessions)' literal no longer exists
+  // in the source, so block() silently fell back to a 2500-char window that truncated before the
+  // read_at stamp (line ~1797) and the fail-open WORK_ASSIGNMENT_TERMINAL_DRAIN string (~1803).
+  // Anchor on the next top-level statement after the drain's try/catch instead.
+  const fr1 = block('drain WORK_ASSIGNMENT rows whose target SD/QF', 'await dispatchWorkAssignmentsIfAllowed');
   it('stamps read_at (drain marker), never hard-DELETE on these rows', () => {
     expect(fr1).toMatch(/\.update\(\{\s*read_at: now\.toISOString\(\)\s*\}\)/);
     expect(fr1).not.toMatch(/\.delete\(\)/);

--- a/tests/unit/session-check-concurrency-no-side-effect.test.js
+++ b/tests/unit/session-check-concurrency-no-side-effect.test.js
@@ -56,20 +56,25 @@ describe('session-check-concurrency.js entrypoint guard', () => {
     expect(typeof mod.detectSdKeyDrift).toBe('function');
   }, 5_000);
 
-  it('still runs main() when invoked as a CLI (sanity, exit code is 0/1/2)', () => {
-    // Use spawnSync so this runs as a real child process — the entrypoint
-    // guard's `import.meta.url === pathToFileURL(process.argv[1]).href`
-    // check passes only in this mode.
+  // QUARANTINED (SD-LEO-INFRA-UNIT-TIER-SOURCEPIN-REBASELINE-001, FR-3): this CLI-sanity check spawns
+  // a REAL child that does LIVE DB I/O (session-check-concurrency.js self-loads .env and queries
+  // claude_sessions; creds cannot be stripped from the test side). In isolation it exits in ~1s, but
+  // under full-suite parallelism (~1500 files / 16 workers all touching the DB) the child's query
+  // starves past the spawn timeout → SIGTERM → status=null with no banner printed, so it is
+  // chronically red on main. It is NOT a source regression: the entrypoint-guard mechanism is fully
+  // covered by the HERMETIC static-import test above (the actual QF-20260509-358 regression pin).
+  // A non-hermetic live-DB subprocess check belongs in an integration tier, not the unit tier.
+  // Rehoming tracked via /signal harness-bug. Skipped (not deleted) to preserve intent + history.
+  it.skip('still runs main() when invoked as a CLI (sanity) — NON-HERMETIC, rehome to integration tier', () => {
     const result = spawnSync(process.execPath, [SCRIPT_PATH], {
       cwd: REPO_ROOT,
       encoding: 'utf-8',
       timeout: 15_000,
       env: { ...process.env, NODE_NO_WARNINGS: '1' }
     });
-
-    // 0 = isolated, 1 = concurrent, 2 = could-not-determine. All three are
-    // valid runtime outcomes; what we assert is that main() ran (i.e. one of
-    // the documented exit codes was emitted, NOT a silent no-op).
-    expect([0, 1, 2]).toContain(result.status);
+    // 0 = isolated, 1 = concurrent, 2 = could-not-determine — all valid; OR an observed main() banner.
+    const output = `${result.stdout || ''}${result.stderr || ''}`;
+    const mainRan = /\[ISOLATED\]|\[CONCURRENT SESSIONS DETECTED\]/.test(output);
+    expect(mainRan || [0, 1, 2].includes(result.status)).toBe(true);
   }, 20_000);
 });

--- a/tests/unit/stale-sweep-qf211-claim-guards.test.js
+++ b/tests/unit/stale-sweep-qf211-claim-guards.test.js
@@ -60,8 +60,12 @@ describe('SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: CLAIM_FIX fixture-session guard
 
   it('clears the SD claim ONLY if it still points at the fixture (race guard), then continues', () => {
     const idx = src.indexOf('SWEEP_FIXTURE_SESSION_CLAIM_FIX');
-    const block = src.slice(idx, idx + 800);
+    const block = src.slice(idx, idx + 1300);
     expect(block).toMatch(/claiming_session_id:\s*null/);
+    // FR-1 (SD-LEO-INFRA-CLAIM-LIFECYCLE-HARDENING-002): the SD-only release MUST also null
+    // active_session_id (the sync trigger's CAS branch can't cover a value pointing at another
+    // session). This SD-release site previously omitted it — the claim-lifecycle guard caught it.
+    expect(block).toMatch(/active_session_id:\s*null/);
     expect(block).toMatch(/\.eq\(['"]claiming_session_id['"],\s*s\.session_id\)/); // race guard on the SD clear
     expect(block).toMatch(/continue;/);
   });

--- a/tests/unit/vdr-v1-automation-probes.test.js
+++ b/tests/unit/vdr-v1-automation-probes.test.js
@@ -35,8 +35,9 @@ describe('VDR_REGISTRY — 4 new automation/intelligence entries (ordinals 17-20
   });
 
   it('the registry includes these 4 (alongside the concurrently-landed governance + capability-layer clusters)', () => {
-    // 22 = 11 original + 5 governance (V1-GOV-PROBES) + 2 capability-layer (V1-CAPLAYER-PROBES) + 4 here.
-    expect(VDR_REGISTRY.length).toBe(22);
+    // 25 = 11 original + 5 governance (V1-GOV-PROBES) + 2 capability-layer (V1-CAPLAYER-PROBES)
+    //      + 4 here (automation ordinals 17-20) + 3 consolidation (V1-CONSOLIDATION-PROBES, 23-25).
+    expect(VDR_REGISTRY.length).toBe(25);
   });
 });
 

--- a/tests/unit/worktree-reaper/active-sd-shipped-stale-guard.test.js
+++ b/tests/unit/worktree-reaper/active-sd-shipped-stale-guard.test.js
@@ -17,7 +17,11 @@ vi.mock('../../../lib/worktree-reaper/detectors.js', () => ({
   isNested: vi.fn(() => ({ matched: false })),
   isZombieOnMain: vi.fn(() => ({ matched: false })),
   hasOrphanSD: vi.fn(() => ({ matched: false })),
-  isPatchEquivalentToMain: vi.fn(async () => ({ matched: true, reason: 'patch_equivalent_absorbed', evidence: {} })),
+  // SD-FDBK-FIX-WORKTREE-REAPER-LIVE-001 (PR #4669) demoted an absorbed-cherry match with ZERO
+  // merged PRs to advisory-only (unreliable under squash merges) — stage1 'shipped-stale' authority
+  // now REQUIRES merged-PR backing. Supply merged_pr_count:1 so these "STILL flags shipped-stale"
+  // cases exercise the merged-PR-backed path (the empty-evidence absorbed-no-PR case is advisory).
+  isPatchEquivalentToMain: vi.fn(async () => ({ matched: true, reason: 'patch_equivalent_via_squash', evidence: { merged_pr_count: 1 } })),
   isIdle: vi.fn(() => ({ matched: false })),
 }));
 


### PR DESCRIPTION
## Summary
Re-baselines the chronically-red **Unit Tier source-pin tests** so `npm run test:unit` (vitest `--project unit`) is **green on main** — restoring the green-CI gate integrity these pins are meant to provide. Live inventory at LEAD was 15 files / 23 tests failing; sibling SDs reduced it to 14/22 by EXEC. Final: **1489 passed, 0 failed** (1 newly-skipped non-hermetic test, 11 dangling quarantine entries pruned).

Triage-first, grounded against live source on origin/main, with a 4-agent grounding pass + RCA + adversarial review. Each failing file was classified **STALE PIN** (re-sync to current intended source), **GENUINE REGRESSION** (fix the SOURCE, keep the guard), or **NON-HERMETIC** (quarantine with reason). Load-bearing / scope-lock pins were treated as guards: verified the live source is the intended state before any re-sync.

## Genuine regression (source fixed, guard kept)
- **`scripts/stale-session-sweep.cjs`** — the fixture-session SD-release `UPDATE` nulled `claiming_session_id` **without** co-clearing `active_session_id` (FR-1 invariant; the omitting site was introduced by PR #4691). The `sync_is_working_on` trigger's CAS branch only clears `active_session_id` when it equals the fixture session, so a value pointing at a different session would dangle. Added `active_session_id: null` to match the other 4 release sites. The `claim-lifecycle-hardening` guard correctly caught this — the pin was **not** relaxed; the source was fixed.

## Stale pins re-synced (each still fails loud if the real contract breaks)
`worker-signal` (+`unfit`, PR #4777) · `vdr-v1-automation-probes` (registry 22→25) · `protocol-publication-pipeline` (generated files 12→14) · `sd-type-threshold-canonical` (literal consolidated into `threshold-resolver.js`, PR #4657) · `lead-final-approval-pending-pre-insert` (`created_by` `.eq`→`.in(recorderIdentities())` safer scope; cleanup sites 2→4) · `worktree-reaper` shipped-stale (merged-PR-backed, PR #4669) · `adam-role-contract` (reworded clause) · `build-tasks-writer-descriptor` + `stage-26-growth-playbook` (descriptor-driven deploy line; partial-postlaunch SKIP removed, DATADISTILL #11) · `sweep-residuals` + `stale-sweep-qf211` (dead `block()` anchors re-synced) · `heal-vision` T4 (default-ROOT probe repointed off PR-#4629-archived `evidence-rubrics/V*.js`).

## Non-hermetic (quarantined, FR-3)
- **`session-check-concurrency` CLI-sanity** → `it.skip`: spawns a real child doing live DB I/O (self-loads `.env`; creds can't be stripped test-side), chronically red under full-suite parallelism. The **hermetic static-import regression pin** (the real QF-20260509-358 guard) stays live. Flagged for integration-tier rehoming.
- **`tests/quarantine-manifest.json`** — pruned 11 dangling entries (deleted/archived files); guard `quarantine-manifest.test.js` enforces this.

## Verification
- `npx vitest run --project unit` → **1489 passed | 11 skipped | 0 failed**.
- All 14 previously-failing files pass individually and in the full suite.
- Adversarial review (vs exact live source): every change SOUND — no guard weakened to mask a regression.

## Out of scope (filed separately)
RCA surfaced a **dormant** production regression: PR #4629 archived 20 live `evidence-rubrics/V*.js` files (loaded by `readdirSync`), zeroing the file-based `vision-evidence-scorer.js` (the SD-gating DB-backed `vision-scorer.js` is unaffected). Routed to harness backlog (revive-vs-retire decision + estate-screen blind-spot to `readdirSync` loaders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)