### PR TITLE
fix(SD-LEO-INFRA-GR-MIGRATION-PROSE-FALSE-BLOCK-001): GR-MIGRATION-REVIEW requires a real data-layer signal

### DIFF
--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -312,14 +312,33 @@ const DEFAULT_GUARDRAILS = [
       const scope = (sdData.scope || '').toLowerCase();
       const md = sdData.metadata || {};
 
-      const hasDDL = /\b(alter\s+table|create\s+table|drop\s+table|truncate\s+table|add\s+(?:\w+\s+)?column|drop\s+(?:\w+\s+)?column|rename\s+(?:\w+\s+)?column|alter\s+(?:\w+\s+)?column|create\s+(?:unique\s+)?index|create\s+materialized\s+view|create\s+schema)\b/.test(scope);
+      // (a) Real DDL syntax. Table/column/verb forms tolerate intervening identifiers
+      //     (e.g. "add a new status column") so natural prose-described schema changes
+      //     still block; the create/alter/grant verbs require exact adjacency to the
+      //     SQL object keyword (e.g. "create trigger", NOT "create a trigger for CI")
+      //     so they do not false-fire on non-SQL prose.
+      // Column DDL allows up to 3 intervening identifier words (e.g. "add a new status
+      // column") but a negative lookahead excludes common UI "<x> column <noun>" compounds
+      // (column chart / column header / column layout …) so dashboards do not false-fire.
+      const columnDDL = /\b(?:add|drop|rename|alter)\s+(?:[a-z][\w-]*\s+){0,3}column\b(?!\s+(?:chart|charts|header|headers|layout|width|sort|sorting|filter|group|grouping|view|component|widget|family|set|name|count|definition|type|selector|picker|menu|list))/.test(scope);
+      const hasDDL = columnDDL || /\b(?:alter\s+table|create\s+table|drop\s+table|truncate\s+table|rename\s+table|create\s+(?:unique\s+)?index|create\s+(?:materialized\s+)?view|create\s+(?:type|enum|trigger|function|sequence|extension|policy|schema)|alter\s+(?:sequence|type|policy|schema)|add\s+(?:\w+\s+){0,2}(?:foreign\s+key|primary\s+key|unique\s+constraint|check\s+constraint)|(?:grant|revoke)\s+\w+\s+on)\b/.test(scope);
+      // (b) A governed data-layer file path (the supabase/ tree or a *.sql file).
       const hasGovernedFile = /\bsupabase\//.test(scope) || /\.sql\b/.test(scope);
+      // (c) An explicit structured metadata signal.
       const hasMetaSignal = md.requires_migration === true
         || md.touches_schema === true
         || (Array.isArray(md.governed_files)
           && md.governed_files.some((f) => /(^|\/)supabase\/|\.sql$/i.test(String(f))));
+      // (d) Narrow prose co-occurrence: a migration/schema-change word TOGETHER WITH an
+      //     UNAMBIGUOUS data-layer noun (rls / row-level-security / foreign key). This
+      //     recovers prose like "new RLS migration" without re-introducing the bare-word
+      //     false-block — deliberately EXCLUDES ambiguous nouns (table/column/index/
+      //     trigger/sequence/policy) that appear in non-DB prose.
+      const hasMigrationWord = /\b(?:migrat\w+|schema\s+change|schema\s+migration)\b/.test(scope);
+      const hasUnambiguousDataNoun = /\b(?:rls|row[-\s.]level[-\s.]security|foreign\s+key)\b/.test(scope);
 
-      const hasMigrationScope = hasDDL || hasGovernedFile || hasMetaSignal;
+      const hasMigrationScope = hasDDL || hasGovernedFile || hasMetaSignal
+        || (hasMigrationWord && hasUnambiguousDataNoun);
       const hasMigrationReview = md.migration_reviewed === true
         || md.migration_plan === true;
 

--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -299,16 +299,35 @@ const DEFAULT_GUARDRAILS = [
     mode: MODES.BLOCKING,
     description: 'SDs involving database schema migration changes require explicit migration review',
     check: (sdData) => {
+      // SD-LEO-INFRA-GR-MIGRATION-PROSE-FALSE-BLOCK-001: require a REAL data-layer signal,
+      // not a bare conceptual prose word. The old regex matched 'migration'/'schema change'
+      // ANYWHERE in narrative, so any pure-JS SD that merely DISCUSSED migrations was
+      // false-blocked at creation (feedback 008916c6). We now fire only on:
+      //   (a) a real DDL operation (SQL syntax, not the word "migration"),
+      //   (b) a governed data-layer file path (the supabase/ tree or a *.sql file), or
+      //   (c) an explicit metadata signal.
+      // The column patterns allow an identifier between the verb and "column"
+      // (e.g. "add user_preferences column") so genuine prose-described schema changes
+      // STILL block — the gate is NOT weakened — while the bare conceptual word does not.
       const scope = (sdData.scope || '').toLowerCase();
-      const hasMigrationScope = /\b(migration|alter\s*table|add\s*column|drop\s*column|schema\s*change|database\s*migration)\b/.test(scope);
-      const hasMigrationReview = sdData.metadata?.migration_reviewed === true
-        || sdData.metadata?.migration_plan === true;
+      const md = sdData.metadata || {};
+
+      const hasDDL = /\b(alter\s+table|create\s+table|drop\s+table|truncate\s+table|add\s+(?:\w+\s+)?column|drop\s+(?:\w+\s+)?column|rename\s+(?:\w+\s+)?column|alter\s+(?:\w+\s+)?column|create\s+(?:unique\s+)?index|create\s+materialized\s+view|create\s+schema)\b/.test(scope);
+      const hasGovernedFile = /\bsupabase\//.test(scope) || /\.sql\b/.test(scope);
+      const hasMetaSignal = md.requires_migration === true
+        || md.touches_schema === true
+        || (Array.isArray(md.governed_files)
+          && md.governed_files.some((f) => /(^|\/)supabase\/|\.sql$/i.test(String(f))));
+
+      const hasMigrationScope = hasDDL || hasGovernedFile || hasMetaSignal;
+      const hasMigrationReview = md.migration_reviewed === true
+        || md.migration_plan === true;
 
       if (hasMigrationScope && !hasMigrationReview) {
         return {
           violated: true,
           severity: 'high',
-          message: 'SD involves database migration. Provide migration plan in metadata (migration_reviewed: true) or document migration steps.',
+          message: 'SD involves database migration (real DDL / governed supabase file / metadata flag). Provide migration plan in metadata (migration_reviewed: true) or document migration steps.',
         };
       }
       return { violated: false };

--- a/tests/unit/governance/gr-migration-prose-detector.test.js
+++ b/tests/unit/governance/gr-migration-prose-detector.test.js
@@ -1,0 +1,55 @@
+/**
+ * SD-LEO-INFRA-GR-MIGRATION-PROSE-FALSE-BLOCK-001 — GR-MIGRATION-REVIEW detector.
+ *
+ * Proves the BLOCKING guardrail now requires a REAL data-layer signal (real DDL op,
+ * governed supabase/ or *.sql file path, or a metadata flag) instead of a bare conceptual
+ * prose word — so a pure-JS SD that merely DISCUSSES migrations is no longer false-blocked
+ * (feedback 008916c6), while every genuine migration STILL blocks (gate not weakened).
+ */
+import { describe, it, expect } from 'vitest';
+import { check } from '../../../lib/governance/guardrail-registry.js';
+
+const mig = (sdData) => check(sdData).violations.find((v) => v.guardrail === 'GR-MIGRATION-REVIEW');
+
+describe('GR-MIGRATION-REVIEW — bare prose word no longer false-blocks (FR-1)', () => {
+  it('PASSES a pure-JS SD that only MENTIONS "migration"/"schema change" in prose', () => {
+    // This is the exact false-block class: a governance SD discussing the keyword filter.
+    expect(mig({ scope: 'Refine the GR-MIGRATION-REVIEW keyword filter so a bare prose word about migration or a schema change no longer false-blocks pure-JS SDs', metadata: {} })).toBeUndefined();
+  });
+  it('PASSES prose mentioning "database migration" with no DDL/path/flag', () => {
+    expect(mig({ scope: 'Document how the database migration review process works for operators', metadata: {} })).toBeUndefined();
+  });
+});
+
+describe('GR-MIGRATION-REVIEW — genuine data-layer signals STILL block (FR-1/FR-2, gate not weakened)', () => {
+  it('BLOCKS a real DDL token (alter table)', () => {
+    expect(mig({ scope: 'ALTER TABLE ventures ADD COLUMN status', metadata: {} })).toBeDefined();
+  });
+  it('BLOCKS prose-described column DDL with an identifier (VAL-1 regression: "add <id> column")', () => {
+    expect(mig({ scope: 'Database migration to add user_preferences column', metadata: {} })).toBeDefined();
+  });
+  it('BLOCKS a governed supabase/ file path', () => {
+    expect(mig({ scope: 'Edit supabase/migrations/20260616_add_x.sql to add the column', metadata: {} })).toBeDefined();
+  });
+  it('BLOCKS a bare *.sql file reference', () => {
+    expect(mig({ scope: 'Apply the new schema in db/changes/add_index.sql', metadata: {} })).toBeDefined();
+  });
+  it('BLOCKS an explicit metadata.requires_migration flag even with pure prose', () => {
+    expect(mig({ scope: 'pure prose with no ddl', metadata: { requires_migration: true } })).toBeDefined();
+  });
+  it('BLOCKS a governed_files[] metadata entry under supabase/', () => {
+    expect(mig({ scope: 'pure prose', metadata: { governed_files: ['supabase/migrations/x.sql'] } })).toBeDefined();
+  });
+});
+
+describe('GR-MIGRATION-REVIEW — attestation bypass unchanged', () => {
+  it('PASSES a real DDL SD when migration_reviewed is attested', () => {
+    expect(mig({ scope: 'ALTER TABLE users ADD COLUMN x', metadata: { migration_reviewed: true } })).toBeUndefined();
+  });
+  it('PASSES a real DDL SD when migration_plan is set', () => {
+    expect(mig({ scope: 'ALTER TABLE users ADD COLUMN x', metadata: { migration_plan: true } })).toBeUndefined();
+  });
+  it('does NOT bypass on a non-true attestation value (must be strict ===true)', () => {
+    expect(mig({ scope: 'ALTER TABLE users ADD COLUMN x', metadata: { migration_reviewed: 'true' } })).toBeDefined();
+  });
+});

--- a/tests/unit/governance/gr-migration-prose-detector.test.js
+++ b/tests/unit/governance/gr-migration-prose-detector.test.js
@@ -42,6 +42,37 @@ describe('GR-MIGRATION-REVIEW — genuine data-layer signals STILL block (FR-1/F
   });
 });
 
+describe('GR-MIGRATION-REVIEW — broadened DDL coverage (adversarial-review close-the-holes)', () => {
+  it.each([
+    ['add a new status column to ventures', 'multi-word column gap'],
+    ['drop the email column from users', 'two-word column gap'],
+    ['rename table ventures to portfolios', 'rename table (exact SQL form)'],
+    ['create trigger audit_ins on ventures', 'create trigger'],
+    ['create type mood as enum', 'create type/enum'],
+    ['create function compute_health()', 'create function'],
+    ['alter sequence venture_seq restart', 'alter sequence'],
+    ['add foreign key fk_owner to orders', 'add foreign key'],
+    ['add a unique constraint on email', 'add constraint'],
+    ['grant select on ventures to anon', 'grant ... on'],
+    ['new RLS migration for tenants', 'RLS + migration co-occurrence'],
+    ['schema migration adding a foreign key', 'foreign key + migration co-occurrence'],
+  ])('BLOCKS genuine schema prose: %s (%s)', (scope) => {
+    expect(mig({ scope, metadata: {} })).toBeDefined();
+  });
+});
+
+describe('GR-MIGRATION-REVIEW — broadening does NOT re-introduce governance false-blocks', () => {
+  it.each([
+    ['create a trigger for the build pipeline when a release ships', 'CI trigger, not SQL'],
+    ['index the search results and add a column chart to the dashboard', 'UI/search prose (no adjacent DDL verb)'],
+    ['document the migration review policy and the deploy sequence', 'migration + ambiguous nouns (policy/sequence) only'],
+    ['refine the migration keyword filter so a schema change discussion no longer false-blocks', 'pure governance prose'],
+    ['grant the user access to the migration dashboard', 'grant access (not grant ... on)'],
+  ])('PASSES pure-JS/governance prose: %s (%s)', (scope) => {
+    expect(mig({ scope, metadata: {} })).toBeUndefined();
+  });
+});
+
 describe('GR-MIGRATION-REVIEW — attestation bypass unchanged', () => {
   it('PASSES a real DDL SD when migration_reviewed is attested', () => {
     expect(mig({ scope: 'ALTER TABLE users ADD COLUMN x', metadata: { migration_reviewed: true } })).toBeUndefined();


### PR DESCRIPTION
## Summary
The BLOCKING governance guardrail GR-MIGRATION-REVIEW (lib/governance/guardrail-registry.js:303) matched bare conceptual words (`migration` / `schema change` / `database migration`) ANYWHERE in SD prose, so any pure-JS SD that merely *discussed* migrations was false-blocked at creation (`process.exit(1)`). A coordinator had to reword SD-LEO-INFRA-DEP-RESOLVER twice (feedback 008916c6).

## Change
The detector now fires only on a **real data-layer signal**:
- a real DDL operation (SQL syntax: `alter table`, `create trigger/type/function/sequence`, `add <id> column`, `grant ... on`, `add foreign key`, ...),
- a governed data-layer file path (`supabase/` tree or `*.sql`), or
- an explicit metadata flag (`requires_migration` / `touches_schema` / `governed_files[]`).

The bare conceptual words are dropped. Column DDL tolerates intervening identifiers (`add a new status column` still blocks) with a negative-lookahead excluding UI `column <chart|header|...>` compounds (so `add a column chart` passes). A narrow `migration`+`rls`/`foreign key` co-occurrence recovers `new RLS migration` without re-introducing the bare-word false-block.

## Gate not weakened
Adversarial review confirmed: no bypass weakening (attestation strict `===true`); genuine DDL/governed-file/flag SDs still block; the residual pure-natural-language slip is mitigated by the **fail-closed apply-time migration governance** (migration-tier-classifier + apply-migration 3-factor gate) that catches anything actually shipping a `.sql` file.

84/84 governance tests (false-positive-passes + true-positive-blocks + UI-FP-guard + adversarial broadening). Sibling GR-SECURITY-BASELINE same-class hardening deferred (flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)