### PR TITLE
fix(SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001): degraded schema lint is advisory, not a hard block

### DIFF
--- a/scripts/lint/schema-lint-exit.mjs
+++ b/scripts/lint/schema-lint-exit.mjs
@@ -1,0 +1,21 @@
+/**
+ * Pure exit-decision helper for the schema-reference lint.
+ * SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001 (FR-1/FR-3).
+ *
+ * A --diff run whose base is UNRESOLVABLE (a flaky/partial CI fetch) falls back
+ * to a whole-repo sweep (degradedFallback=true). That sweep re-surfaces the
+ * pre-existing phantom backlog, NOT new drift, so it must NOT block the PR.
+ * The run already knows it is degraded; this helper makes the EXIT honor it:
+ * a degraded run is ADVISORY (exit 0) regardless of violation count, while a
+ * resolvable-base run keeps full diff-scoped blocking (exit 1 on violations).
+ *
+ * An explicit `--all` run sets degradedFallback=false (the flag is set only in
+ * the --diff catch), so its exit behavior is unchanged.
+ *
+ * @param {{violations:number, degradedFallback:boolean}} state
+ * @returns {0|1}
+ */
+export function computeExitCode({ violations = 0, degradedFallback = false } = {}) {
+  if (degradedFallback) return 0; // degraded sweep is advisory — never blocks
+  return violations > 0 ? 1 : 0;
+}

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -25,6 +25,9 @@ import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { extractReferences, findViolations } from './schema-reference-extract.mjs';
+// SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001: a degraded --diff run (unresolvable base ->
+// whole-repo fallback) is ADVISORY and must not block; the pure helper encodes that exit rule.
+import { computeExitCode } from './schema-lint-exit.mjs';
 
 const SNAPSHOT_PATH = 'database/schema-reference-snapshot.json';
 const ALLOWLIST_PATH = 'scripts/lint/schema-reference-allowlist.json';
@@ -140,6 +143,18 @@ if (asJson) {
   console.log(JSON.stringify({ mode, files_checked: files.length, violations: allViolations }, null, 1));
 } else if (allViolations.length === 0) {
   console.log(`✅ schema-reference-lint (${mode}): ${files.length} file(s) checked, 0 violations`);
+} else if (degradedFallback) {
+  // Degraded full-repo sweep (the --diff base was unresolvable): these are the pre-existing
+  // backlog, NOT new drift, and the check is NON-BLOCKING (advisory). Print as a warning.
+  console.warn(`⚠️  schema-reference-lint (advisory — DEGRADED full-repo sweep, diff base unresolvable): ${allViolations.length} pre-existing reference(s) across ${files.length} file(s) checked. NOT blocking this PR (no diff base to scope new drift).`);
+  for (const v of allViolations) {
+    console.warn(`   ${v.file}:${v.line}  missing ${v.missing}  (${v.kind})`);
+  }
+  console.warn(
+    '\nThis is the known phantom backlog re-surfaced because the diff base could not be fetched; ' +
+    'it does not reflect new drift introduced by this change. To clear the backlog: ' +
+    'npm run schema:snapshot:lint (commit the result) or update ' + ALLOWLIST_PATH + '.'
+  );
 } else {
   console.error(`❌ schema-reference-lint (${mode}): ${allViolations.length} violation(s) in ${files.length} file(s) checked:\n`);
   for (const v of allViolations) {
@@ -154,4 +169,6 @@ if (asJson) {
   );
 }
 
-process.exitCode = allViolations.length > 0 ? 1 : 0;
+// FR-1: a degraded --diff run (unresolvable base) is advisory and exits 0; a resolvable-base run
+// keeps full diff-scoped blocking. An explicit --all run keeps degradedFallback=false -> unchanged.
+process.exitCode = computeExitCode({ violations: allViolations.length, degradedFallback });

--- a/tests/unit/schema-lint-exit.test.js
+++ b/tests/unit/schema-lint-exit.test.js
@@ -1,0 +1,34 @@
+/**
+ * SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001
+ * Pins the schema-reference lint exit decision: a degraded --diff run (unresolvable
+ * base -> whole-repo fallback) is ADVISORY (exit 0) regardless of violation count,
+ * while a resolvable-base run keeps full diff-scoped blocking (exit 1 on violations).
+ */
+import { describe, it, expect } from 'vitest';
+import { computeExitCode } from '../../scripts/lint/schema-lint-exit.mjs';
+
+describe('computeExitCode — schema-reference lint exit decision', () => {
+  it('degraded run with the pre-existing backlog exits 0 (advisory, non-blocking)', () => {
+    expect(computeExitCode({ violations: 601, degradedFallback: true })).toBe(0);
+  });
+
+  it('degraded run with zero violations also exits 0', () => {
+    expect(computeExitCode({ violations: 0, degradedFallback: true })).toBe(0);
+  });
+
+  it('resolvable-base run with genuine NEW drift exits 1 (blocking preserved)', () => {
+    expect(computeExitCode({ violations: 1, degradedFallback: false })).toBe(1);
+  });
+
+  it('clean run (no violations, not degraded) exits 0', () => {
+    expect(computeExitCode({ violations: 0, degradedFallback: false })).toBe(0);
+  });
+
+  it('defaults to 0 when called with no arguments', () => {
+    expect(computeExitCode()).toBe(0);
+  });
+
+  it('non-degraded with many violations still blocks (the happy-path blocking case)', () => {
+    expect(computeExitCode({ violations: 42, degradedFallback: false })).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
The schema-reference lint false-failed clean worker PRs. When the `--diff` base is unresolvable (the workflow's `git fetch origin <base> --depth=1 || true` swallows a flaky/partial fetch), `candidateFiles()` falls back to a whole-repo sweep (`degradedFallback=true`) that re-surfaces the pre-existing ~597-violation phantom backlog (feedback fdb5a294); the script still exited 1, so a zero-new-drift PR failed (verified PR #4824).

**Fix:** route the exit through a new pure helper `scripts/lint/schema-lint-exit.mjs` `computeExitCode({violations, degradedFallback})` — a degraded run is **advisory (exit 0)**; a resolvable-base run keeps **exit 1** on genuine new drift. Degraded output is reframed as a warning banner, not a block-implying error. The script already used `degradedFallback` to suppress the breakage alert; this extends that known-degraded signal to the exit decision.

## Verification
- New unit test `tests/unit/schema-lint-exit.test.js` — 6/6 (degraded→0, resolvable+drift→1, clean→0, safe default).
- Degraded run (`SCHEMA_LINT_BASE=origin/does-not-exist ... --diff`) now exits 0 with an advisory banner (was exit 1).
- Resolvable-base diff keeps blocking (exit 1 on real new drift); clean diff exits 0 — no regression. `--all` exit behavior unchanged.
- Adversarial review (full data-flow trace): fail-open is set ONLY in the `--diff` catch (unresolvable base) — zero false-negative paths; safe blocking default.
- TESTING sub-agent PASS (row b94eca1b); handoffs 94/98/94/95.

Single-repo EHG_Engineer, code + test only; no schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)