### PR TITLE
feat(SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001): RLS + search_path security hygiene + sentinel re-baseline

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001.json
@@ -1,0 +1,115 @@
+{
+  "executive_summary": "Close two genuine Supabase database-linter SECURITY findings and re-baseline the weekly security-linter sentinel so its signal lands on real gaps. (1) scope_completion_chain is a public table created additively with RLS disabled and zero policies (rls_disabled_in_public). (2) fn_advance_venture_stage is SECURITY DEFINER with a mutable search_path (function_search_path_mutable, a CVE-2018-1058-class privilege-escalation surface). Both are fixed by a single chairman-gated TIER-2 migration that ships DORMANT (worker authors + tests; the chairman applies via the 3-factor attestation gate). Separately, the sentinel was flagging ~24 disposable quarantine/parity/backup table copies from the 2026-06-09/10 purge sweep as RLS gaps, drowning the two real findings; FR-4 exempts exactly those disposable copies (tool-generated _qparity suffix by pattern; overloaded _backup/_quarantine names by explicit review-list) without ever exempting a live table.",
+  "system_architecture": {
+    "overview": "Three artifacts, no runtime behavior change for product code. The migration ships dormant (chairman-applied); the sentinel re-baseline and tests take effect on merge.",
+    "components": [
+      {"name": "20260616_security_hygiene_rls_searchpath.sql", "responsibility": "Chairman-gated TIER-2 migration: ENABLE RLS + SELECT-only read_all policy on scope_completion_chain (mirrors bypass_ledger/goal_evaluator_verdicts), ALTER FUNCTION fn_advance_venture_stage SET search_path = pg_catalog, public, and a DO $verify$ self-check. Ships dormant with an unfilled @approved-by."},
+      {"name": "scripts/sentinels/audit-security-linter.mjs", "responsibility": "Adds exported isExemptTable() (explicit disposable-table set + single _qparity tool-suffix pattern) applied to the rlsDisabled and sensitiveExposed filters, plus an import.meta.url entrypoint guard so the module is importable without opening a DB connection."},
+      {"name": "tests/unit/security-hygiene-rls-searchpath.test.js", "responsibility": "Unit coverage for the exemption logic (24 disposables exempt, live tables not, real dated backups not) and migration-content assertions."}
+    ]
+  },
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Enable RLS + read policy on scope_completion_chain",
+      "description": "In the chairman-gated migration, ALTER TABLE scope_completion_chain ENABLE ROW LEVEL SECURITY and create a SELECT-only policy scope_completion_chain_read_all USING (true), mirroring the live *_read_all convention on sibling tables bypass_ledger and goal_evaluator_verdicts. No write policy: the only writer/reader is service-role (runtime-probe-coverage-gate.js) and the owner-privileged witnesses VIEW, both of which bypass RLS, so enabling RLS is behavior-neutral while satisfying rls_disabled_in_public."
+    },
+    {
+      "id": "FR-2",
+      "title": "Pin fn_advance_venture_stage search_path",
+      "description": "ALTER FUNCTION public.fn_advance_venture_stage(uuid, integer, integer, jsonb, uuid) SET search_path = pg_catalog, public. The function body references only unqualified public objects and pg_catalog built-ins (verified: every referenced table/function lives in public or pg_catalog; gen_random_uuid resolves to the native pg_catalog version), so pg_catalog, public is the exact resolution order it already relies on — behavior is preserved while closing function_search_path_mutable."
+    },
+    {
+      "id": "FR-3",
+      "title": "Ship the migration dormant (chairman-gated TIER-2)",
+      "description": "The migration uses ALTER (RLS + function) statements that are TIER-2 and do not auto-apply. The worker authors and tests it but leaves the @approved-by attestation line unfilled (CONST-002). A self-verifying DO $verify$ block raises loudly if either fix did not land, so a chairman apply either fully succeeds or fails visibly."
+    },
+    {
+      "id": "FR-4",
+      "title": "Re-baseline the sentinel to exempt disposable copies only",
+      "description": "Add isExemptTable() to scripts/sentinels/audit-security-linter.mjs exempting the 24 disposable purge-sweep copies: the 20 tool-generated _qparityYYYYMMDD copies via an anchored pattern, and the 4 overloaded _backup/_quarantine names via an explicit reviewed set. A real dated backup/quarantine table (e.g. view_definitions_backup_YYYYMMDD) must remain flagged. Apply the exemption to both the rlsDisabled and sensitiveExposed filters."
+    },
+    {
+      "id": "FR-5",
+      "title": "Make the sentinel importable + test both surfaces",
+      "description": "Guard the sentinel's main() with an import.meta.url entrypoint check so importing the module (for tests) does not open a DB connection. Add tests/unit/security-hygiene-rls-searchpath.test.js asserting (a) all 24 disposables are exempt, (b) scope_completion_chain and other live tables are NOT exempt, (c) real dated backups are not pattern-exempted, and (d) the migration SQL contains the RLS enable, the read policy, the pinned search_path, an unfilled @approved-by, and the self-verify block."
+    }
+  ],
+  "technical_requirements": [
+    {"id": "TR-1", "requirement": "Migration is additive/behavior-preserving and idempotent (ENABLE RLS, IF NOT EXISTS policy guard via pg_policy, ALTER FUNCTION ... SET are all re-runnable)."},
+    {"id": "TR-2", "requirement": "No non-service-role writer to scope_completion_chain exists in the codebase (verified by grep); enabling RLS with a SELECT-only policy breaks no consumer."},
+    {"id": "TR-3", "requirement": "Sentinel exemption must be precise: zero false-positive exemptions of live tables; the only pattern is the campaign-only _qparityYYYYMMDD suffix."},
+    {"id": "TR-4", "requirement": "The sentinel continues to run live as a CLI (GitHub Actions Monday cron) after the entrypoint guard is added."}
+  ],
+  "implementation_approach": {
+    "summary": "Ground every gap against the live DB before coding, then author a dormant migration + a precise sentinel exemption, verify end-to-end, and drive the LEO chain. Migration application is chairman-only.",
+    "steps": [
+      "Ground against live DB: RLS state of scope_completion_chain, fn_advance_venture_stage proconfig, full disposable-table list, sibling read_all policy convention.",
+      "Author the dormant migration mirroring the live sibling read_all policy; use search_path = pg_catalog, public (not '') because the function uses unqualified public objects.",
+      "Harden the sentinel with an explicit-set + single-pattern exemption (overloaded _backup/_quarantine names listed, never pattern-matched) and an entrypoint guard.",
+      "Verify: run the live sentinel (25 RLS findings -> 1 real) and the unit suite; then drive LEAD->PLAN->EXEC->...->LEAD-FINAL."
+    ]
+  },
+  "integration_operationalization": {
+    "consumers": "scope_completion_chain: written/read by scripts/modules/handoff/executors/lead-final-approval/gates/runtime-probe-coverage-gate.js (service-role, bypasses RLS) and aggregated by the writer_consumer_asymmetry_witnesses VIEW (owner-privileged, bypasses RLS). fn_advance_venture_stage: called by the venture stage-advance path. audit-security-linter.mjs: consumed by the security-linter-sentinel GitHub Actions workflow and importable by the unit test.",
+    "dependencies": "Depends on the existing sibling migrations 20260516130000 (scope_completion_chain table), 20260516130002 (witnesses view), and the live bypass_ledger/goal_evaluator_verdicts read_all policy convention. Application depends on the chairman 3-factor attestation gate (feature flag + --issue-token + @approved-by) per apply-migration.js TIER-2 classification.",
+    "data_contracts": "scope_completion_chain columns unchanged (RLS is additive). fn_advance_venture_stage signature (uuid, integer, integer, jsonb, uuid) and return contract unchanged; only search_path metadata is pinned. The read_all policy exposes SELECT to public role exactly as siblings do.",
+    "runtime_config": "Migration ships dormant — no runtime config until the chairman applies it. The sentinel reads SUPABASE_POOLER_URL/DATABASE_URL (CI) or SUPABASE_DB_PASSWORD (local), unchanged. No new env vars or feature flags.",
+    "observability_rollout": "Rollout: code merges immediately; the sentinel re-baseline takes effect on next Monday cron (or workflow_dispatch). The migration is applied later by the chairman. Verification: the live sentinel goes from 25 RLS findings to 1 (scope_completion_chain) + 1 mutable function (fn_advance_venture_stage), and to fully CLEAN once the chairman applies the migration. Rollback: git revert the PR (sentinel) and/or a DISABLE RLS + DROP POLICY + reset search_path migration (function/table) — no data impact."
+  },
+  "acceptance_criteria": [
+    "The security-linter sentinel no longer reports the ~24 disposable purge-sweep copies as RLS gaps, so its output shows only the genuinely unprotected tables.",
+    "The sentinel still reports scope_completion_chain as an RLS gap and fn_advance_venture_stage as a mutable-search-path function until the chairman applies the migration (the findings are honestly surfaced, not silenced).",
+    "A real dated backup table such as view_definitions_backup_20260124 is still flagged by the sentinel — only the four reviewed disposable copies are explicitly exempt.",
+    "The migration, when applied with the chairman's attestation, enables row-level security on scope_completion_chain with a read policy and pins the venture-stage function's search path, and its self-check passes; if either fix fails to land, the migration aborts with a clear error.",
+    "The migration ships without a filled-in approval attestation, so it cannot be auto-applied and waits for the chairman.",
+    "The unit test suite for this work passes, covering both the exemption logic and the migration file contents."
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "title": "All 24 disposable copies are exempt; live tables are not",
+      "type": "unit",
+      "scenario": "Import isExemptTable() from the sentinel and call it on the 24 disposable table names captured live (qparity/quarantine/backup copies) and on a list of real live tables including scope_completion_chain, ventures, eva_decisions, bypass_ledger, goal_evaluator_verdicts.",
+      "expected": "isExemptTable returns true for all 24 disposable names and for schema_migrations/spatial_ref_sys; returns false for every real live table including scope_completion_chain."
+    },
+    {
+      "id": "TS-2",
+      "title": "Real dated backups are not pattern-exempted",
+      "type": "unit",
+      "scenario": "Call isExemptTable() on view_definitions_backup_20260124, product_requirements_v2_backup_20260206, rls_policy_backup_20260603, and some_feature_quarantine_20270101.",
+      "expected": "isExemptTable returns false for all of them — the overloaded _backup/_quarantine conventions are exempted only via the explicit reviewed set, never by an open-ended suffix pattern."
+    },
+    {
+      "id": "TS-3",
+      "title": "Migration content asserts both fixes and dormant attestation",
+      "type": "unit",
+      "scenario": "Read the migration SQL file and assert it contains the RLS enable on scope_completion_chain, the scope_completion_chain_read_all SELECT policy USING (true), ALTER FUNCTION ... SET search_path = pg_catalog, public (and NOT search_path = ''), an @approved-by line with no email value, and the DO $verify$ self-check raise messages.",
+      "expected": "All assertions pass: both fixes are present, the function path is pinned to pg_catalog, public, the attestation is unfilled (dormant), and the self-verify block is present."
+    },
+    {
+      "id": "TS-4",
+      "title": "Live sentinel run reduces RLS noise to the real gap",
+      "type": "integration",
+      "scenario": "Run node scripts/sentinels/audit-security-linter.mjs against the live consolidated DB before the chairman applies the migration.",
+      "expected": "rls_disabled_in_public reports exactly 1 table (scope_completion_chain) instead of ~25, and function_search_path_mutable reports exactly 1 function (fn_advance_venture_stage); the disposable copies no longer appear."
+    }
+  ],
+  "risks": [
+    {"risk": "search_path = pg_catalog, public shadows a public object the function relies on", "mitigation": "Verified the function body references no object whose name collides with a pg_catalog built-in; gen_random_uuid resolves natively in pg_catalog. Adversarial review confirmed no shadowing.", "severity": "low"},
+    {"risk": "Enabling RLS breaks a non-service-role writer to scope_completion_chain", "mitigation": "Grepped the codebase: the only consumer is the service-role runtime gate (read) and the owner-privileged witnesses VIEW; no anon/authenticated writer exists. SELECT-only policy added; service-role bypasses RLS.", "severity": "low"},
+    {"risk": "Sentinel exemption silently hides a future real RLS gap", "mitigation": "Overloaded _backup/_quarantine names are an explicit reviewed set; only the campaign-only _qparityYYYYMMDD suffix is a pattern. A test asserts real dated backups stay flagged.", "severity": "low"},
+    {"risk": "Worker self-applies the chairman-gated migration", "mitigation": "Ships dormant with an unfilled @approved-by; apply-migration.js TIER-2 gate blocks until the chairman attests. CONST-002 honored.", "severity": "low"}
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001",
+    "target_application": "EHG_Engineer",
+    "target_files": [
+      "database/migrations/20260616_security_hygiene_rls_searchpath.sql",
+      "scripts/sentinels/audit-security-linter.mjs",
+      "tests/unit/security-hygiene-rls-searchpath.test.js"
+    ],
+    "created_via": "fleet-worker-charlie",
+    "chairman_gated_migration": "database/migrations/20260616_security_hygiene_rls_searchpath.sql"
+  }
+}

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D",
-  "expectedBranch": "feat/SD-EHG-FEAT-AUTOMATED-RESILIENT-VENTURE-001-D",
-  "createdAt": "2026-06-14T21:48:20.163Z",
+  "sdKey": "SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001",
+  "createdAt": "2026-06-16T14:50:43.759Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260616_security_hygiene_rls_searchpath.sql
+++ b/database/migrations/20260616_security_hygiene_rls_searchpath.sql
@@ -1,0 +1,104 @@
+-- ============================================================================
+-- SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001 — FR-3
+-- Security hygiene: enable RLS on scope_completion_chain + pin
+-- fn_advance_venture_stage search_path.
+-- ============================================================================
+--
+-- ⚠️ TIER-2 / CHAIRMAN-GATED — SHIPS DORMANT ⚠️
+-- This migration contains ALTER (RLS-enable, ALTER FUNCTION) statements, which
+-- are TIER-2 under the migration-tier classifier and therefore do NOT auto-apply
+-- post-merge. It requires the chairman's 3-factor attestation to apply:
+--   1. the migration-apply feature flag,
+--   2. --issue-token <token>, and
+--   3. the @approved-by line below filled in with the chairman's email.
+--
+-- The authoring worker MUST NOT self-author the attestation (CONST-002). The
+-- line below is intentionally left WITHOUT a value so apply-migration.js blocks
+-- until the chairman fills it in and runs the gated apply:
+--   node scripts/apply-migration.js database/migrations/20260616_security_hygiene_rls_searchpath.sql \
+--     --issue-token <token> --prod-deploy
+--
+-- @approved-by:
+-- ============================================================================
+--
+-- WHY THESE TWO GAPS:
+--   (1) scope_completion_chain (created additively in 20260516130000, no RLS)
+--       is a public table with RLS disabled and 0 policies — flagged by the
+--       Supabase database linter rule `rls_disabled_in_public` and by the
+--       weekly security-linter sentinel. It is written/read by service-role
+--       callers (runtime-probe-coverage-gate.js) and aggregated by the
+--       owner-privileged writer_consumer_asymmetry_witnesses VIEW; both bypass
+--       RLS, so enabling RLS with a permissive read policy is behavior-neutral.
+--   (2) fn_advance_venture_stage is SECURITY DEFINER with a mutable search_path
+--       (proconfig = null) — flagged by `function_search_path_mutable`, a real
+--       privilege-escalation surface (CVE-2018-1058 class). Its body references
+--       only unqualified public objects + built-ins, so pinning
+--       search_path = pg_catalog, public preserves behavior exactly.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- (1) scope_completion_chain — enable RLS + permissive read policy
+--     Mirrors the *_read_all convention used by sibling instrumentation tables
+--     bypass_ledger / goal_evaluator_verdicts:  FOR SELECT TO public USING (true).
+--     Writes continue to flow through service-role (which bypasses RLS), so no
+--     write policy is added — least privilege for any future anon/auth reader.
+-- ----------------------------------------------------------------------------
+ALTER TABLE scope_completion_chain ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policy
+    WHERE polrelid = 'scope_completion_chain'::regclass
+      AND polname = 'scope_completion_chain_read_all'
+  ) THEN
+    CREATE POLICY scope_completion_chain_read_all
+      ON scope_completion_chain
+      FOR SELECT
+      USING (true);
+  END IF;
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- (2) fn_advance_venture_stage — pin search_path (behavior-preserving)
+--     Signature is fixed: (uuid, integer, integer, jsonb, uuid). The body uses
+--     only unqualified public tables/functions + pg_catalog built-ins, so
+--     pg_catalog, public is the exact resolution order it already relies on.
+-- ----------------------------------------------------------------------------
+ALTER FUNCTION public.fn_advance_venture_stage(uuid, integer, integer, jsonb, uuid)
+  SET search_path = pg_catalog, public;
+
+-- ----------------------------------------------------------------------------
+-- Self-verification — fails the migration loudly if either fix did not land.
+-- ----------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_rls_enabled  boolean;
+  v_policy_count integer;
+  v_searchpath   text[];
+BEGIN
+  SELECT c.relrowsecurity,
+         (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid)
+    INTO v_rls_enabled, v_policy_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname = 'scope_completion_chain';
+
+  IF v_rls_enabled IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'VERIFY FAILED: RLS not enabled on scope_completion_chain';
+  END IF;
+  IF v_policy_count < 1 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: no policy on scope_completion_chain';
+  END IF;
+
+  SELECT p.proconfig
+    INTO v_searchpath
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'fn_advance_venture_stage';
+
+  IF v_searchpath IS NULL
+     OR NOT EXISTS (SELECT 1 FROM unnest(v_searchpath) x WHERE x LIKE 'search_path=%') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_advance_venture_stage search_path not pinned';
+  END IF;
+
+  RAISE NOTICE 'VERIFY OK: scope_completion_chain RLS + policy present; fn_advance_venture_stage search_path pinned';
+END $verify$;

--- a/scripts/sentinels/audit-security-linter.mjs
+++ b/scripts/sentinels/audit-security-linter.mjs
@@ -31,9 +31,44 @@ import { createDatabaseClient } from '../lib/supabase-connection.js';
 const JSON_MODE = process.argv.includes('--json');
 const STRICT = process.argv.includes('--strict');
 
-// Tables intentionally without RLS (system / PostGIS). Matches the exemption
-// set in scripts/audit-rls-policies.js.
-const EXEMPTED_TABLES = new Set(['schema_migrations', 'spatial_ref_sys']);
+// Tables intentionally without RLS — system/PostGIS plus the disposable
+// quarantine/backup copies left by the 20260609/20260610 SD-MAN purge sweep.
+// They hold pre-image copies slated for drop, never carry live reads, and are
+// not worth an RLS policy — exempting them keeps the sentinel's signal on REAL
+// gaps instead of drowning in ~two dozen false positives.
+//
+// `_backup`/`_quarantine` are OVERLOADED naming conventions in this repo (real
+// dated backup tables also use `<feature>_backup_YYYYMMDD`), so those copies are
+// listed EXPLICITLY and by review — never by an open-ended suffix pattern that
+// could silently swallow a future real table's RLS gap (the very failure this
+// anti-noise change must not introduce).
+const EXEMPTED_TABLES = new Set([
+  'schema_migrations',
+  'spatial_ref_sys',
+  // SD-MAN purge/quarantine campaign copies (2026-06-09/10) — non-`_qparity` suffix.
+  'management_reviews_quarantine_20260610',
+  'venture_artifacts_storm_quarantine_20260610',
+  'sd_baseline_items_purge_backup_20260609',
+  'sd_baseline_items_recon_backup',
+]);
+
+// `_qparityYYYYMMDD` is a TOOL-GENERATED quarantine-parity suffix unique to the
+// purge sweep — no human-authored feature table uses it — so it is safe to
+// exempt by pattern. Anchored to the suffix with an 8-digit datestamp so it
+// cannot match a live table (e.g. `scope_completion_chain` matches none).
+const EXEMPTED_TABLE_PATTERNS = [
+  /_qparity\d{8}$/i,
+];
+
+/**
+ * True if a public table is intentionally exempt from the RLS requirement:
+ * either an explicit system table or a disposable quarantine/backup copy.
+ * Exported so the exemption set is unit-testable against the live table list.
+ */
+export function isExemptTable(name) {
+  if (EXEMPTED_TABLES.has(name)) return true;
+  return EXEMPTED_TABLE_PATTERNS.some((re) => re.test(name));
+}
 
 function log(msg = '') { if (!JSON_MODE) console.log(msg); }
 
@@ -92,8 +127,8 @@ async function main() {
 
     result = {
       securityDefinerViews: views.rows.map(r => r.name),
-      rlsDisabled: tables.rows.map(r => r.name).filter(n => !EXEMPTED_TABLES.has(n)),
-      sensitiveExposed: sensitive.rows.map(r => r.name).filter(n => !EXEMPTED_TABLES.has(n)),
+      rlsDisabled: tables.rows.map(r => r.name).filter(n => !isExemptTable(n)),
+      sensitiveExposed: sensitive.rows.map(r => r.name).filter(n => !isExemptTable(n)),
       securityDefinerMutableFns: secdefFns.rows.map(r => r.name),
       triggerEnabled: trig.rows.length === 1 && trig.rows[0].evtenabled !== 'D',
     };
@@ -128,7 +163,14 @@ async function main() {
   if (STRICT && !clean) process.exitCode = 1;
 }
 
-main().catch(err => {
-  console.error('Sentinel error:', err.message);
-  process.exitCode = 1;
-});
+// Only run the live audit when invoked directly (node scripts/sentinels/...).
+// When imported (e.g. by the exemption unit test) the module just exposes
+// isExemptTable without opening a DB connection.
+import { pathToFileURL } from 'node:url';
+const INVOKED_DIRECTLY = import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
+if (INVOKED_DIRECTLY) {
+  main().catch(err => {
+    console.error('Sentinel error:', err.message);
+    process.exitCode = 1;
+  });
+}

--- a/tests/unit/security-hygiene-rls-searchpath.test.js
+++ b/tests/unit/security-hygiene-rls-searchpath.test.js
@@ -1,0 +1,142 @@
+/**
+ * SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001 — FR-5
+ *
+ * Two surfaces:
+ *   (FR-4) scripts/sentinels/audit-security-linter.mjs isExemptTable() —
+ *          disposable quarantine/parity/backup copies are exempt; the live real
+ *          tables are NOT. The disposable list is the live RLS-disabled-public
+ *          set captured at authoring time (2026-06-16).
+ *   (FR-3) database/migrations/20260616_security_hygiene_rls_searchpath.sql —
+ *          content assertions: enables RLS + read policy on scope_completion_chain,
+ *          pins fn_advance_venture_stage search_path, ships DORMANT (no
+ *          @approved-by value), and self-verifies.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { isExemptTable } from '../../scripts/sentinels/audit-security-linter.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../database/migrations/20260616_security_hygiene_rls_searchpath.sql',
+);
+
+// Live RLS-disabled-public tables that ARE disposable (queried 2026-06-16).
+// Every one of these must be exempted so the sentinel does not drown in noise.
+const DISPOSABLE_TABLES = [
+  'capital_transactions_preimg_qparity20260610',
+  'eva_audit_log_preimg_qparity20260610',
+  'eva_automation_executions_qparity20260610',
+  'eva_decisions_qparity20260610',
+  'eva_events_qparity20260610',
+  'eva_scheduler_metrics_qparity20260610',
+  'eva_scheduler_queue_qparity20260610',
+  'eva_stage_gate_results_qparity20260610',
+  'eva_ventures_qparity20260610',
+  'factory_guardrail_state_qparity20260610',
+  'management_reviews_quarantine_20260610',
+  'quarantine_meta_qparity20260610',
+  'sd_baseline_items_purge_backup_20260609',
+  'sd_baseline_items_recon_backup',
+  'stage_executions_qparity20260610',
+  'venture_artifact_summaries_qparity20260610',
+  'venture_artifacts_qparity20260610',
+  'venture_artifacts_storm_quarantine_20260610',
+  'venture_data_room_artifacts_qparity20260610',
+  'venture_resources_qparity20260610',
+  'venture_separability_scores_qparity20260610',
+  'venture_stage_transitions_qparity20260610',
+  'venture_stage_work_qparity20260610',
+  'ventures_qparity20260610',
+];
+
+// Real, live tables that MUST NOT be exempted — including the very table this
+// SD adds RLS to (scope_completion_chain) and the canonical originals whose
+// quarantine copies are exempted above (must not be falsely matched).
+const REAL_TABLES = [
+  'scope_completion_chain',
+  'ventures',
+  'eva_decisions',
+  'eva_events',
+  'venture_artifacts',
+  'venture_stage_work',
+  'sd_baseline_items',
+  'management_reviews',
+  'bypass_ledger',
+  'goal_evaluator_verdicts',
+  'strategic_directives_v2',
+  'product_requirements_v2',
+];
+
+describe('FR-4: audit-security-linter isExemptTable', () => {
+  it('exempts the explicit system tables', () => {
+    expect(isExemptTable('schema_migrations')).toBe(true);
+    expect(isExemptTable('spatial_ref_sys')).toBe(true);
+  });
+
+  it('exempts every disposable quarantine/parity/backup table (24)', () => {
+    expect(DISPOSABLE_TABLES).toHaveLength(24);
+    for (const name of DISPOSABLE_TABLES) {
+      expect(isExemptTable(name), `${name} should be exempt`).toBe(true);
+    }
+  });
+
+  it('does NOT exempt real live tables (incl. scope_completion_chain)', () => {
+    for (const name of REAL_TABLES) {
+      expect(isExemptTable(name), `${name} must NOT be exempt`).toBe(false);
+    }
+  });
+
+  it('anchors patterns to the suffix — mid-name tokens do not match', () => {
+    // "quarantine"/"backup" as a non-suffix substring must not exempt a real table.
+    expect(isExemptTable('quarantine_policy_config')).toBe(false);
+    expect(isExemptTable('backup_schedule_settings')).toBe(false);
+    expect(isExemptTable('qparity_dashboard')).toBe(false);
+  });
+
+  it('does NOT exempt real dated backup/quarantine tables by pattern', () => {
+    // `_backup_YYYYMMDD` / `_quarantine_YYYYMMDD` are OVERLOADED conventions —
+    // real dated backup tables exist (e.g. view_definitions_backup_20260124).
+    // Only the four reviewed campaign copies are exempt (explicit list); any
+    // OTHER dated backup/quarantine table must stay flagged for RLS review.
+    expect(isExemptTable('view_definitions_backup_20260124')).toBe(false);
+    expect(isExemptTable('product_requirements_v2_backup_20260206')).toBe(false);
+    expect(isExemptTable('rls_policy_backup_20260603')).toBe(false);
+    expect(isExemptTable('some_feature_quarantine_20270101')).toBe(false);
+  });
+});
+
+describe('FR-3: migration SQL content', () => {
+  const sql = readFileSync(MIGRATION_PATH, 'utf8');
+
+  it('enables RLS on scope_completion_chain', () => {
+    expect(sql).toMatch(/ALTER TABLE scope_completion_chain ENABLE ROW LEVEL SECURITY/i);
+  });
+
+  it('creates a permissive read policy mirroring the sibling convention', () => {
+    expect(sql).toMatch(/CREATE POLICY scope_completion_chain_read_all/i);
+    expect(sql).toMatch(/FOR SELECT\s+USING \(true\)/i);
+  });
+
+  it('pins fn_advance_venture_stage search_path behavior-preservingly', () => {
+    expect(sql).toMatch(
+      /ALTER FUNCTION public\.fn_advance_venture_stage\(uuid, integer, integer, jsonb, uuid\)\s*SET search_path = pg_catalog, public/i,
+    );
+    // NOT search_path = '' — the body uses unqualified public objects.
+    expect(sql).not.toMatch(/SET search_path = ''/);
+  });
+
+  it('ships DORMANT — chairman attestation line present but UNFILLED (CONST-002)', () => {
+    // The @approved-by line must exist (so the chairman knows where to attest)
+    // but carry NO value (so apply-migration.js blocks until the chairman fills it).
+    expect(sql).toMatch(/@approved-by:/);
+    expect(sql).not.toMatch(/@approved-by:\s*\S+@\S+/);
+  });
+
+  it('self-verifies both fixes', () => {
+    expect(sql).toMatch(/VERIFY FAILED: RLS not enabled on scope_completion_chain/);
+    expect(sql).toMatch(/VERIFY FAILED: fn_advance_venture_stage search_path not pinned/);
+  });
+});


### PR DESCRIPTION
@
## Summary
Closes two genuine Supabase database-linter SECURITY findings and re-baselines the weekly security-linter sentinel so its signal lands on real gaps.

- **scope_completion_chain** had RLS disabled + 0 policies (`rls_disabled_in_public`) → migration ENABLEs RLS + a SELECT-only `read_all` policy mirroring sibling tables (`bypass_ledger`, `goal_evaluator_verdicts`). Behavior-neutral: the only writer/reader is service-role (bypasses RLS) + the owner-privileged witnesses VIEW.
- **fn_advance_venture_stage** was SECURITY DEFINER with a mutable `search_path` (`function_search_path_mutable`, CVE-2018-1058 class) → `ALTER FUNCTION ... SET search_path = pg_catalog, public`. Behavior-preserving (body uses only unqualified public objects + pg_catalog builtins). Root cause: migration 20260611 redefined the function without a `SET search_path` clause.
- **Sentinel re-baseline**: `audit-security-linter.mjs` gained `isExemptTable()` exempting 24 disposable purge-sweep copies — the tool-generated `_qparityYYYYMMDD` suffix by pattern, the overloaded `_backup`/`_quarantine` names by an **explicit reviewed list** (never an open-ended pattern that could silently swallow a future real table). Live sentinel went from 25 RLS findings to exactly the 1 real gap.

## Chairman-gated (ships DORMANT)
The migration is TIER-2 (ALTER) and ships dormant: the `@approved-by` attestation line is intentionally **unfilled** (CONST-002 — worker never self-attests). The chairman applies it via the 3-factor gate (flag + `--issue-token` + `@approved-by`). A `DO $verify$` block fails loudly if either fix does not land.

## Tests
- `tests/unit/security-hygiene-rls-searchpath.test.js` — 10 tests (exemption logic incl. false-positive guards + migration content).
- Sub-agents: TESTING PASS (`82fa9993`), SECURITY PASS 0 HIGH (`2a07c385`).
- Adversarial review caught a MED (open-ended `_backup`/`_quarantine` patterns would exempt a future real dated backup) → fixed pre-ship via explicit reviewed-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@