### PR TITLE
fix(SD-LEO-INFRA-LEO-CREATE-SD-UNUSED-VARS-001): remove 3 dead bindings in leo-create-sd.js

### DIFF
--- a/scripts/__tests__/leo-create-sd-types.test.js
+++ b/scripts/__tests__/leo-create-sd-types.test.js
@@ -11,9 +11,9 @@
  *   5. fail-loud: garbage → throws (post-FR-4 — replaces silent default-to-feature)
  *   6. fail-loud: empty string → throws
  *
- * Probe technique: extracts `mapToDbType` source + `VALID_DB_SD_TYPES` from
- * leo-create-sd.js AND splices the lib/sd-type-enum.js exports inline so the
- * extracted function can resolve `assertValidSdType`. Mirrors the existing
+ * Probe technique: extracts the `mapToDbType` source from leo-create-sd.js AND
+ * splices the lib/sd-type-enum.js exports inline so the extracted function can
+ * resolve `assertValidSdType`. Mirrors the existing
  * leo-create-sd-mapper.test.js probe but with the dependency injected.
  */
 
@@ -38,13 +38,14 @@ function runMapper(userType) {
   // Strip the `export ` prefix from sd-type-enum.js so the source can be eval'd in CJS.
   const enumStripped = enumSrc.replace(/\bexport\s+(const|function)\b/g, '$1');
 
-  const validMatch = src.match(/const VALID_DB_SD_TYPES = \[([\s\S]*?)\];/);
+  // mapToDbType resolves via the local `map` object + assertValidSdType (spliced from
+  // enumStripped); it does not reference the former VALID_DB_SD_TYPES const, which was
+  // removed as dead code (SD-LEO-INFRA-LEO-CREATE-SD-UNUSED-VARS-001), so we no longer splice it.
   const fnMatch = src.match(/function mapToDbType\(userType\)\s*\{[\s\S]*?\n\}/);
-  if (!validMatch || !fnMatch) throw new Error('Could not extract mapper from script');
+  if (!fnMatch) throw new Error('Could not extract mapper from script');
 
   const code = [
     enumStripped,
-    validMatch[0],
     fnMatch[0],
     'try {',
     '  const result = mapToDbType(' + JSON.stringify(userType) + ');',

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -60,7 +60,7 @@ import { validateSDFields } from './modules/validate-sd-fields.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // SD-LEO-INFRA-SD-AUTHORING-TARGET-AUTODETECT-001: path-based target detector
 import { detectFromKeyChanges } from './modules/handoff/executors/lead-to-plan/gates/target-application.js';
-import { assertValidSdType, isValidSdType } from '../lib/sd-type-enum.js';
+import { assertValidSdType } from '../lib/sd-type-enum.js';
 
 const supabase = createSupabaseServiceClient();
 
@@ -895,7 +895,6 @@ async function createFromPlan(planPath = null, skipConfirmation = false, overrid
   console.log('   PLAN SUMMARY');
   console.log('   ═══════════════════════════════════════════');
   console.log(`   Title: ${parsed.title || '(untitled)'}`);
-  const typeSource = overrides.typeOverride ? 'override' : (priorityFromPlan !== undefined ? 'from plan' : 'inferred');
   // Type source is independent — re-derive to avoid coupling with priority detection.
   const typeLabel = overrides.typeOverride ? ' (override)' : (parsed.type && priorityFromPlan !== undefined ? ' (from plan or inferred)' : ' (inferred)');
   console.log(`   Type${typeLabel}: ${parsed.type}`);
@@ -1221,15 +1220,6 @@ function mapPriority(feedbackPriority) {
  * orchestrator, qa, refactor, security, implementation, strategic_observation,
  * architectural_review, discovery_spike, ux_debt, product_decision
  */
-// QF-20260504-251: VALID_DB_SD_TYPES aligned with actual sd_type_check enum.
-// Removed: 'qa', 'library', 'fix' (rejected by DB constraint).
-// Added: 'discovery_spike', 'ux_debt' (valid per constraint).
-const VALID_DB_SD_TYPES = [
-  'feature', 'infrastructure', 'bugfix', 'database', 'security',
-  'refactor', 'documentation', 'docs', 'orchestrator', 'performance',
-  'enhancement', 'uat', 'implementation', 'discovery_spike', 'ux_debt'
-];
-
 function mapToDbType(userType) {
   const map = {
     // User-friendly -> Database type
@@ -1266,9 +1256,8 @@ function mapToDbType(userType) {
     assertValidSdType(userType, `unknown --type value: no synonym match in mapToDbType for ${JSON.stringify(userType)}`);
   }
   // assertValidSdType is the contract anchor: throws unless `mapped` is in
-  // CANONICAL_SD_TYPES (lib/sd-type-enum.js), which mirrors the DB CHECK constraint.
-  // The legacy VALID_DB_SD_TYPES const above is retained for documentation but is no
-  // longer the validator of record.
+  // CANONICAL_SD_TYPES (lib/sd-type-enum.js), which mirrors the DB CHECK constraint
+  // and is the single validator of record.
   assertValidSdType(mapped, `mapToDbType produced non-canonical sd_type from input ${JSON.stringify(userType)}`);
   return mapped;
 }


### PR DESCRIPTION
## Summary
Make the SD-authoring entrypoint `scripts/leo-create-sd.js` eslint-clean by removing 3 verified-dead bindings (eslint reported exactly these 3 `no-unused-vars`, zero runtime consumers):
- unused `isValidSdType` named import (line 63) — only `assertValidSdType` from that import is used
- unused `typeSource` const (line 898) — superseded by sibling `typeLabel`
- unused `VALID_DB_SD_TYPES` const (line 1227) + its stale QF-251 comments — self-documented as legacy/non-validator; the source of truth is `lib/sd-type-enum.js`

Deletions-only on the script (net −11 LOC); canonical `sd-type-enum.js` untouched.

## Also: a consumer the static check couldn't see
A repo-wide grep (adversarial step) found `scripts/__tests__/leo-create-sd-types.test.js` **regex-extracts** `const VALID_DB_SD_TYPES = [...]` from the source and throws if absent — invisible to eslint's `no-unused-vars`. `mapToDbType` never actually references that const (it resolves via its local `map` + `assertValidSdType`), so the splice was vestigial; dropped the `validMatch` extraction. All 6 mapper test cases stay green.

## Verification
- `npx eslint scripts/leo-create-sd.js` → 0 problems (was 3).
- `node scripts/leo-create-sd.js --help` loads; dynamic import OK (no ReferenceError).
- `scripts/__tests__/leo-create-sd-types.test.js` → 6/6 pass after the splice removal.
- TESTING sub-agent PASS (row 03dd3c9a); handoffs 94/98/94/95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)