### PR TITLE
feat(SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001): honest operator cash/burn substrate for the distance-to-broke gauge

### DIFF
--- a/.github/workflows/operator-cash-burn-cron.yml
+++ b/.github/workflows/operator-cash-burn-cron.yml
@@ -1,0 +1,44 @@
+name: Operator Cash/Burn Substrate Feed
+
+# Fail-soft hourly feeder for SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001.
+# Over-scheduled (:00,:20,:40) to beat GitHub's habit of dropping scheduled cron runs; the feed
+# itself is idempotent (upsert by period_month) and fail-soft (a failure leaves inputs stale, never
+# writes a fabricated value), so an extra run is harmless and a missed run only delays freshness.
+
+on:
+  schedule:
+    - cron: '0,20,40 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Compute and print, do not write'
+        required: false
+        default: 'false'
+
+concurrency:
+  group: operator-cash-burn-feed
+  cancel-in-progress: false
+
+jobs:
+  feed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+      - name: Feed operator cash/burn substrate
+        continue-on-error: true
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            npm run operator:cash-burn:feed -- --dry-run
+          else
+            npm run operator:cash-burn:feed
+          fi

--- a/database/migrations/20260616_operator_cash_burn_monthly.sql
+++ b/database/migrations/20260616_operator_cash_burn_monthly.sql
@@ -1,0 +1,53 @@
+-- @approved-by: chairman-directed survivability cockpit (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001)
+-- SD: SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001
+-- Additive (TIER-1): new operator-grain cash/burn snapshot table. No destructive DDL.
+--
+-- Operator-grain monthly cash/burn substrate for the distance-to-broke gauge.
+-- CORE CONTRACT: every input is honest. A value column is NULL (unattested) when its
+-- source has never fed it — NEVER 0. Each input carries its own *_last_synced_at so a
+-- stale feed can be suppressed ('stale / not yet measurable') rather than shown as live.
+
+CREATE TABLE IF NOT EXISTS public.operator_cash_burn_monthly (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_month             date NOT NULL,                 -- first-of-month period key
+
+  -- CASH (operator liquid cash on hand) — fed by the sibling cash/bank-feed SD (not this one)
+  cash_usd                 numeric(14,2),                 -- NULL = unattested (no source yet)
+  cash_last_synced_at      timestamptz,
+
+  -- AI BURN (rolling-30d fleet AI spend) — fed hourly by this SD; ALWAYS a lower bound
+  ai_burn_usd              numeric(14,2),                 -- NULL = unattested
+  ai_burn_last_synced_at   timestamptz,
+  ai_burn_is_lower_bound   boolean NOT NULL DEFAULT true, -- main-session Opus tokens uncaptured
+
+  -- OTHER BURN (non-AI business expenses) — optional; NULL = unattested
+  other_burn_usd           numeric(14,2),
+  other_burn_last_synced_at timestamptz,
+
+  -- REVENUE (auto-derived recurring revenue) — fed from income_capture_monthly
+  revenue_usd              numeric(14,2),                 -- NULL = unattested
+  revenue_last_synced_at   timestamptz,
+  revenue_livemode         boolean,                       -- false = Stripe TEST-mode (not live income)
+
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT operator_cash_burn_period_unique UNIQUE (period_month),
+  CONSTRAINT operator_cash_burn_first_of_month CHECK (date_trunc('month', period_month) = period_month)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_cash_burn_period
+  ON public.operator_cash_burn_monthly (period_month DESC);
+
+ALTER TABLE public.operator_cash_burn_monthly ENABLE ROW LEVEL SECURITY;
+
+-- RLS: service_role writes (feeds), authenticated reads (cockpit); anon write-revoked.
+DROP POLICY IF EXISTS operator_cash_burn_service ON public.operator_cash_burn_monthly;
+CREATE POLICY operator_cash_burn_service ON public.operator_cash_burn_monthly
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS operator_cash_burn_auth_read ON public.operator_cash_burn_monthly;
+CREATE POLICY operator_cash_burn_auth_read ON public.operator_cash_burn_monthly
+  FOR SELECT TO authenticated USING (true);
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.operator_cash_burn_monthly FROM anon, authenticated;

--- a/lib/operator/cash-burn-substrate.js
+++ b/lib/operator/cash-burn-substrate.js
@@ -1,0 +1,199 @@
+/**
+ * lib/operator/cash-burn-substrate.js
+ *
+ * Honest operator cash/burn substrate (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001).
+ *
+ * CORE CONTRACT — never fabricate a financial number:
+ *   - A missing input is NULL (unattested), never 0 (mirrors lib/income/replacement-net-source.js).
+ *   - Each input carries its own last_synced_at; an input older than its liveness window is
+ *     SUPPRESSED to 'stale / not yet measurable' rather than presented as live
+ *     (mirrors scripts/continuity/cloud-cap-feeder.mjs liveness-window suppression).
+ *   - The months-of-runway headline renders ONLY when BOTH cash and net-burn are fresh;
+ *     otherwise the accessor returns the partials it honestly has + an 'awaiting …' headline.
+ *
+ * The freshness + compute logic is PURE (row + now + windows in, verdict out) so it is unit-testable
+ * without a DB. Read/write helpers take a Supabase service client.
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Per-input liveness windows (ms). An input refreshed more than this long ago is stale.
+ * AI-burn + revenue are fed hourly (generous 3h window absorbs GitHub cron drops).
+ * Cash is fed by a separate, lower-cadence sibling SD (36h window). Other-burn is optional.
+ */
+export const LIVENESS_WINDOWS_MS = Object.freeze({
+  cash: 36 * HOUR_MS,
+  ai_burn: 3 * HOUR_MS,
+  other_burn: 36 * HOUR_MS,
+  revenue: 3 * HOUR_MS,
+});
+
+export const AI_BURN_LOWER_BOUND_LABEL = 'estimated fleet AI burn, last 30d (lower bound)';
+
+/** First-of-month date string (YYYY-MM-01) for a given Date (defaults to the caller-supplied now). */
+export function periodMonthOf(now) {
+  const d = new Date(now);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}-01`;
+}
+
+/**
+ * Freshness of a single timestamp against a window.
+ * @returns {{ status: 'unattested'|'stale'|'live', ageMs: number|null }}
+ */
+export function freshness(lastSyncedAt, windowMs, nowMs) {
+  if (lastSyncedAt == null) return { status: 'unattested', ageMs: null };
+  const t = Date.parse(lastSyncedAt);
+  if (!Number.isFinite(t)) return { status: 'unattested', ageMs: null };
+  const ageMs = nowMs - t;
+  if (ageMs > windowMs) return { status: 'stale', ageMs };
+  return { status: 'live', ageMs };
+}
+
+/**
+ * Build the honest partial for one input. A value is only surfaced when status === 'live';
+ * a stale value is withheld (suppressed) so an old number is never shown as current.
+ */
+function inputPartial(valueUsd, lastSyncedAt, windowMs, nowMs, extra = {}) {
+  const f = freshness(lastSyncedAt, windowMs, nowMs);
+  const base = {
+    last_synced_at: lastSyncedAt ?? null,
+    age_ms: f.ageMs,
+    status: f.status,
+    ...extra,
+  };
+  if (f.status === 'live') {
+    return { ...base, value_usd: valueUsd == null ? null : Number(valueUsd), label: null };
+  }
+  if (f.status === 'stale') {
+    // Suppress the stale value — do NOT present it as live.
+    return { ...base, value_usd: null, label: 'stale / not yet measurable' };
+  }
+  return { ...base, value_usd: null, label: 'not yet measured' };
+}
+
+/**
+ * FR-6 accessor — compute the honest distance-to-broke verdict from a substrate row.
+ * PURE: no DB. months_of_runway is non-null ONLY when cash is live AND net-burn is live.
+ *
+ * net_burn = ai_burn + other_burn - revenue (revenue/other_burn absent => treated as 0 in the
+ * net, which is the CONSERVATIVE direction: it never understates burn). net-burn is "live" iff
+ * ai_burn (the dominant, always-required term) is live.
+ *
+ * @param {object} row - operator_cash_burn_monthly row (or null)
+ * @param {object} [opts] - { nowMs, windows }
+ */
+export function computeRunway(row, opts = {}) {
+  const nowMs = opts.nowMs ?? Date.now();
+  const w = { ...LIVENESS_WINDOWS_MS, ...(opts.windows || {}) };
+
+  if (!row) {
+    return {
+      months_of_runway: null,
+      headline: 'awaiting cash source',
+      partials: {
+        cash: { value_usd: null, status: 'unattested', label: 'not yet measured', last_synced_at: null, age_ms: null },
+        ai_burn: { value_usd: null, status: 'unattested', label: 'not yet measured', last_synced_at: null, age_ms: null, is_lower_bound: true },
+        other_burn: { value_usd: null, status: 'unattested', label: 'not yet measured', last_synced_at: null, age_ms: null },
+        revenue: { value_usd: null, status: 'unattested', label: 'not yet measured', last_synced_at: null, age_ms: null },
+        net_burn: { value_usd: null, status: 'unattested', label: 'not yet measured' },
+      },
+    };
+  }
+
+  const cash = inputPartial(row.cash_usd, row.cash_last_synced_at, w.cash, nowMs);
+  const aiBurn = inputPartial(row.ai_burn_usd, row.ai_burn_last_synced_at, w.ai_burn, nowMs, {
+    is_lower_bound: row.ai_burn_is_lower_bound !== false,
+    lower_bound_label: AI_BURN_LOWER_BOUND_LABEL,
+  });
+  const otherBurn = inputPartial(row.other_burn_usd, row.other_burn_last_synced_at, w.other_burn, nowMs);
+  const revenue = inputPartial(row.revenue_usd, row.revenue_last_synced_at, w.revenue, nowMs, {
+    livemode: row.revenue_livemode === true,
+    test_mode: row.revenue_livemode === false,
+  });
+
+  // net-burn is live iff ai_burn is live (dominant required term). Absent other_burn/revenue
+  // contribute 0 (conservative: never understates burn).
+  let netBurn;
+  if (aiBurn.status === 'live') {
+    const ai = aiBurn.value_usd ?? 0;
+    const other = otherBurn.status === 'live' ? (otherBurn.value_usd ?? 0) : 0;
+    const rev = revenue.status === 'live' ? (revenue.value_usd ?? 0) : 0;
+    netBurn = { value_usd: Number((ai + other - rev).toFixed(2)), status: 'live', label: null };
+  } else {
+    netBurn = { value_usd: null, status: aiBurn.status, label: aiBurn.label };
+  }
+
+  let months_of_runway = null;
+  let headline;
+  if (cash.status !== 'live') {
+    headline = 'awaiting cash source';
+  } else if (netBurn.status !== 'live') {
+    headline = 'awaiting burn data';
+  } else if (netBurn.value_usd <= 0) {
+    // Net positive (revenue >= burn) — not burning down; runway is not "broke"-bounded.
+    months_of_runway = null;
+    headline = 'net cash-positive (no burn-down)';
+  } else {
+    months_of_runway = Number((cash.value_usd / netBurn.value_usd).toFixed(1));
+    headline = `${months_of_runway} months of runway`;
+  }
+
+  return { months_of_runway, headline, partials: { cash, ai_burn: aiBurn, other_burn: otherBurn, revenue, net_burn: netBurn } };
+}
+
+/** Read the substrate row for a period (defaults to current month). */
+export async function readSubstrateRow(periodMonth, supabase = createSupabaseServiceClient()) {
+  const pm = periodMonth || periodMonthOf(Date.now());
+  const { data, error } = await supabase
+    .from('operator_cash_burn_monthly')
+    .select('*')
+    .eq('period_month', pm)
+    .maybeSingle();
+  if (error) throw new Error(`operator_cash_burn_monthly read failed: ${error.message}`);
+  return data || null;
+}
+
+/**
+ * Honest distance-to-broke read for the cockpit tile (FR-6). Returns the computeRunway verdict
+ * for the period (current month by default).
+ */
+export async function getDistanceToBroke(periodMonth, supabase = createSupabaseServiceClient(), opts = {}) {
+  const row = await readSubstrateRow(periodMonth, supabase);
+  return computeRunway(row, opts);
+}
+
+/**
+ * Upsert one or more inputs for a period, stamping the matching *_last_synced_at. Only writes the
+ * fields provided (never zeroes an input it isn't feeding). nowIso is the sync stamp.
+ *
+ * @param {object} fields - subset of { cash_usd, ai_burn_usd, ai_burn_is_lower_bound,
+ *                                       other_burn_usd, revenue_usd, revenue_livemode }
+ */
+export async function upsertSubstrateInputs(periodMonth, fields, supabase = createSupabaseServiceClient(), nowIso = new Date().toISOString()) {
+  const pm = periodMonth || periodMonthOf(Date.now());
+  const row = { period_month: pm, updated_at: nowIso };
+  if ('cash_usd' in fields) { row.cash_usd = fields.cash_usd; row.cash_last_synced_at = nowIso; }
+  if ('ai_burn_usd' in fields) {
+    row.ai_burn_usd = fields.ai_burn_usd;
+    row.ai_burn_last_synced_at = nowIso;
+    row.ai_burn_is_lower_bound = fields.ai_burn_is_lower_bound !== false;
+  }
+  if ('other_burn_usd' in fields) { row.other_burn_usd = fields.other_burn_usd; row.other_burn_last_synced_at = nowIso; }
+  if ('revenue_usd' in fields) {
+    row.revenue_usd = fields.revenue_usd;
+    row.revenue_last_synced_at = nowIso;
+    if ('revenue_livemode' in fields) row.revenue_livemode = fields.revenue_livemode;
+  }
+  const { data, error } = await supabase
+    .from('operator_cash_burn_monthly')
+    .upsert(row, { onConflict: 'period_month' })
+    .select()
+    .single();
+  if (error) throw new Error(`operator_cash_burn_monthly upsert failed: ${error.message}`);
+  return data;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "migration:apply": "node scripts/apply-migration.js",
     "migration:issue-token": "node scripts/apply-migration.js --issue-token",
     "income:capture": "node scripts/income/run-income-capture.mjs",
+    "operator:cash-burn:feed": "node scripts/operator/feed-operator-cash-burn.mjs",
     "okr:wire-o-2026-07": "node scripts/okr/wire-o-2026-07-kr-alignment.mjs",
     "vision:wire-v1-caplayer": "node scripts/okr/wire-v1-caplayer-criteria.mjs",
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",

--- a/scripts/operator/feed-operator-cash-burn.mjs
+++ b/scripts/operator/feed-operator-cash-burn.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * scripts/operator/feed-operator-cash-burn.mjs
+ *
+ * Fail-soft hourly feeder for the operator cash/burn substrate (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001).
+ *
+ *   FR-2  AI-BURN: total the last 30 days of measured AI spend (via scripts/llm-cost-report.mjs
+ *         --days 30 --json) and write it to income_capture_monthly.business_expenses AND the
+ *         substrate ai_burn input, ALWAYS labeled a lower bound (main-session Opus tokens are
+ *         structurally uncaptured).
+ *   FR-3  REVENUE: mirror income_capture_monthly.recurring_revenue into the substrate revenue input
+ *         with its livemode (test-mode) flag.
+ *   FR-5  BACKFILL: price venture_token_ledger.cost_usd from token counts via lib/cost/llm-pricing.js
+ *         for rows whose model is resolvable — leave unpriceable (unknown-model) rows untouched.
+ *
+ * FAIL-SOFT: each step is independently try/caught. A step failure leaves that input's
+ * last_synced_at stale (so the cockpit suppresses it) and NEVER writes a fabricated value.
+ *
+ * Usage:
+ *   node scripts/operator/feed-operator-cash-burn.mjs            # live write
+ *   node scripts/operator/feed-operator-cash-burn.mjs --dry-run  # compute + print, no write
+ */
+
+import 'dotenv/config';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { priceFor } from '../../lib/cost/llm-pricing.js';
+import { periodMonthOf, upsertSubstrateInputs, AI_BURN_LOWER_BOUND_LABEL } from '../../lib/operator/cash-burn-substrate.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function log(step, msg) { console.log(`[operator-cash-burn] ${step}: ${msg}`); }
+function warn(step, msg) { console.warn(`[operator-cash-burn] ${step}: WARN ${msg}`); }
+
+/** FR-2: rolling-30d AI spend (lower bound) from the cost report CLI. Returns number or null. */
+function readRolling30dAiSpend() {
+  const r = spawnSync(process.execPath, [path.join(REPO_ROOT, 'scripts/llm-cost-report.mjs'), '--days', '30', '--json'], {
+    cwd: REPO_ROOT, encoding: 'utf-8', timeout: 120000, env: { ...process.env, NODE_NO_WARNINGS: '1' },
+  });
+  if (r.status !== 0 || !r.stdout) {
+    warn('FR-2', `llm-cost-report exited status=${r.status} signal=${r.signal} — leaving ai_burn stale`);
+    return null;
+  }
+  // The report may print non-JSON prelude (dotenv tips); parse the JSON object from stdout.
+  const start = r.stdout.indexOf('{');
+  if (start < 0) { warn('FR-2', 'no JSON in cost-report stdout'); return null; }
+  let parsed;
+  try { parsed = JSON.parse(r.stdout.slice(start)); } catch (e) { warn('FR-2', `cost-report JSON parse failed: ${e.message}`); return null; }
+  const total = parsed?.window?.totalUsd;
+  if (typeof total !== 'number' || !Number.isFinite(total)) { warn('FR-2', 'cost-report had no numeric window.totalUsd'); return null; }
+  return Number(total.toFixed(2));
+}
+
+async function main() {
+  const supabase = createSupabaseServiceClient();
+  const nowIso = new Date().toISOString();
+  const periodMonth = periodMonthOf(Date.now());
+  const result = { period_month: periodMonth, dry_run: DRY_RUN, ai_burn: null, revenue: null, backfill: null };
+
+  // ---- FR-2: AI burn ----
+  try {
+    const aiSpend = readRolling30dAiSpend();
+    if (aiSpend == null) {
+      result.ai_burn = { written: false, reason: 'cost-report unavailable (left stale)' };
+    } else {
+      log('FR-2', `rolling-30d AI spend = $${aiSpend} (${AI_BURN_LOWER_BOUND_LABEL})`);
+      if (!DRY_RUN) {
+        // Substrate ai_burn (authoritative source for the gauge).
+        await upsertSubstrateInputs(periodMonth, { ai_burn_usd: aiSpend, ai_burn_is_lower_bound: true }, supabase, nowIso);
+        // Fill the income_capture_monthly.business_expenses slot on the LIVE operator row only
+        // (UPDATE only — never create a partial row the aggregator owns). Scoped to livemode=true
+        // deliberately: fleet AI burn IS a real business expense (the income migration designates
+        // business_expenses as "incl. AI/infra") and the replacement-net / distance-to-quit reader
+        // uses the live row — so this is an intentional, single-direction coupling, not a test-row
+        // write. Until the aggregator has created a live row, the fill is deferred (0 rows) and the
+        // substrate ai_burn above remains the authoritative source for the distance-to-broke gauge.
+        const { data: upd, error: e } = await supabase
+          .from('income_capture_monthly')
+          .update({ business_expenses: aiSpend, updated_at: nowIso })
+          .eq('period_month', periodMonth)
+          .eq('livemode', true)
+          .select('id, livemode');
+        if (e) warn('FR-2', `business_expenses update failed (substrate still written): ${e.message}`);
+        else log('FR-2', `business_expenses updated on ${upd?.length || 0} live income row(s)${(upd?.length || 0) === 0 ? ' (no live row yet — deferred; substrate ai_burn is authoritative)' : ''}`);
+      }
+      result.ai_burn = { written: !DRY_RUN, value_usd: aiSpend, lower_bound: true };
+    }
+  } catch (e) { warn('FR-2', `failed (fail-soft): ${e.message}`); result.ai_burn = { written: false, error: e.message }; }
+
+  // ---- FR-3: revenue mirror ----
+  try {
+    // Prefer the LIVE row; fall back to the TEST-mode row, surfacing the livemode flag honestly.
+    const { data: rows, error } = await supabase
+      .from('income_capture_monthly')
+      .select('recurring_revenue, livemode')
+      .eq('period_month', periodMonth);
+    if (error) throw new Error(error.message);
+    const live = (rows || []).find((r) => r.livemode === true);
+    const test = (rows || []).find((r) => r.livemode === false);
+    const pick = live || test || null;
+    if (!pick) {
+      result.revenue = { written: false, reason: 'no income_capture_monthly row yet (left stale)' };
+    } else {
+      const revUsd = pick.recurring_revenue == null ? null : Number(pick.recurring_revenue);
+      log('FR-3', `revenue = $${revUsd} (livemode=${pick.livemode})`);
+      if (!DRY_RUN && revUsd != null) {
+        await upsertSubstrateInputs(periodMonth, { revenue_usd: revUsd, revenue_livemode: pick.livemode === true }, supabase, nowIso);
+      }
+      result.revenue = { written: !DRY_RUN && revUsd != null, value_usd: revUsd, livemode: pick.livemode === true };
+    }
+  } catch (e) { warn('FR-3', `failed (fail-soft): ${e.message}`); result.revenue = { written: false, error: e.message }; }
+
+  // ---- FR-5: venture_token_ledger.cost_usd backfill (priceable rows only) ----
+  try {
+    // Note: PostgREST caps this at ~1000 rows/page. That is fine because priced rows get cost_usd
+    // set and DROP OUT of the cost_usd.is.null/eq.0 filter, so successive hourly runs drain the
+    // backlog to completion — full coverage is reached over runs, not in one pass.
+    const { data: ledger, error } = await supabase
+      .from('venture_token_ledger')
+      .select('id, model_id, agent_type, tokens_input, tokens_output, cost_usd')
+      .or('cost_usd.is.null,cost_usd.eq.0')
+      .limit(5000);
+    if (error) throw new Error(error.message);
+    let priced = 0, skippedUnknownModel = 0, totalUsd = 0;
+    for (const r of ledger || []) {
+      const p = priceFor(r.model_id) || priceFor(r.agent_type);
+      if (!p) { skippedUnknownModel++; continue; } // honest: never guess a model's price
+      const inT = Number(r.tokens_input || 0);
+      const outT = Number(r.tokens_output || 0);
+      if (inT === 0 && outT === 0) continue;
+      const usd = Number(((inT / 1e6) * p.in + (outT / 1e6) * p.out).toFixed(6));
+      if (usd <= 0) continue;
+      totalUsd += usd;
+      if (!DRY_RUN) {
+        const { error: e2 } = await supabase.from('venture_token_ledger').update({ cost_usd: usd }).eq('id', r.id);
+        if (e2) { warn('FR-5', `row ${r.id} update failed: ${e2.message}`); continue; }
+      }
+      priced++;
+    }
+    log('FR-5', `priced ${priced} row(s) totaling $${totalUsd.toFixed(2)}; ${skippedUnknownModel} left honest (unresolvable model)`);
+    result.backfill = { written: !DRY_RUN, priced, skipped_unknown_model: skippedUnknownModel, total_usd: Number(totalUsd.toFixed(2)) };
+  } catch (e) { warn('FR-5', `failed (fail-soft): ${e.message}`); result.backfill = { written: false, error: e.message }; }
+
+  console.log('[operator-cash-burn] result ' + JSON.stringify(result));
+  return result;
+}
+
+// Entrypoint guard: only run main() as a CLI, never on static import.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().then(() => process.exit(0)).catch((e) => { console.error('[operator-cash-burn] FATAL', e); process.exit(1); });
+}
+
+export { main, readRolling30dAiSpend };

--- a/tests/unit/operator/cash-burn-substrate.test.js
+++ b/tests/unit/operator/cash-burn-substrate.test.js
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the operator cash/burn substrate honest-degrade logic
+ * (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001). Pure functions only — no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  periodMonthOf,
+  freshness,
+  computeRunway,
+  LIVENESS_WINDOWS_MS,
+  AI_BURN_LOWER_BOUND_LABEL,
+} from '../../../lib/operator/cash-burn-substrate.js';
+
+const HOUR = 60 * 60 * 1000;
+const NOW = Date.parse('2026-06-16T12:00:00.000Z');
+const fresh = (hoursAgo) => new Date(NOW - hoursAgo * HOUR).toISOString();
+
+describe('periodMonthOf', () => {
+  it('returns the first-of-month YYYY-MM-01 for the given instant', () => {
+    expect(periodMonthOf(Date.parse('2026-06-16T12:00:00Z'))).toBe('2026-06-01');
+    expect(periodMonthOf(Date.parse('2026-01-31T23:59:00Z'))).toBe('2026-01-01');
+  });
+});
+
+describe('freshness', () => {
+  it('NULL last_synced_at is unattested (never live)', () => {
+    expect(freshness(null, HOUR, NOW)).toEqual({ status: 'unattested', ageMs: null });
+  });
+  it('older than the window is stale', () => {
+    expect(freshness(fresh(5), 3 * HOUR, NOW).status).toBe('stale');
+  });
+  it('within the window is live', () => {
+    expect(freshness(fresh(1), 3 * HOUR, NOW).status).toBe('live');
+  });
+  it('an unparseable timestamp degrades to unattested, not a crash', () => {
+    expect(freshness('not-a-date', HOUR, NOW).status).toBe('unattested');
+  });
+});
+
+describe('computeRunway — honest degrade', () => {
+  it('a null row degrades every input to unattested and withholds the runway headline', () => {
+    const v = computeRunway(null, { nowMs: NOW });
+    expect(v.months_of_runway).toBeNull();
+    expect(v.headline).toBe('awaiting cash source');
+    for (const k of ['cash', 'ai_burn', 'other_burn', 'revenue']) {
+      expect(v.partials[k].value_usd).toBeNull();
+      expect(v.partials[k].status).toBe('unattested');
+    }
+  });
+
+  it('cash absent + ai_burn fresh: net-burn is live but runway is withheld as awaiting cash', () => {
+    const row = {
+      cash_usd: null, cash_last_synced_at: null,
+      ai_burn_usd: 600, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: null, other_burn_last_synced_at: null,
+      revenue_usd: 100, revenue_last_synced_at: fresh(1), revenue_livemode: false,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.months_of_runway).toBeNull();
+    expect(v.headline).toBe('awaiting cash source');
+    expect(v.partials.net_burn.status).toBe('live');
+    expect(v.partials.net_burn.value_usd).toBe(500); // 600 + 0 - 100
+  });
+
+  it('cash + ai_burn fresh: months-of-runway renders (cash / net-burn)', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(2),
+      ai_burn_usd: 800, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: 200, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 0, revenue_last_synced_at: fresh(1), revenue_livemode: false,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.net_burn.value_usd).toBe(1000); // 800 + 200 - 0
+    expect(v.months_of_runway).toBe(5.0); // 5000 / 1000
+    expect(v.headline).toBe('5 months of runway');
+  });
+
+  it('a STALE input is SUPPRESSED — its old value is never shown as live', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(2),
+      ai_burn_usd: 800, ai_burn_last_synced_at: fresh(10), ai_burn_is_lower_bound: true, // 10h > 3h window
+      other_burn_usd: null, other_burn_last_synced_at: null,
+      revenue_usd: null, revenue_last_synced_at: null,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.ai_burn.status).toBe('stale');
+    expect(v.partials.ai_burn.value_usd).toBeNull(); // suppressed, NOT 800
+    expect(v.partials.ai_burn.label).toBe('stale / not yet measurable');
+    expect(v.months_of_runway).toBeNull();
+    expect(v.headline).toBe('awaiting burn data');
+  });
+
+  it('ai_burn carries the lower-bound flag + label when live', () => {
+    const row = {
+      cash_usd: null, cash_last_synced_at: null,
+      ai_burn_usd: 300, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: null, other_burn_last_synced_at: null,
+      revenue_usd: null, revenue_last_synced_at: null,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.ai_burn.is_lower_bound).toBe(true);
+    expect(v.partials.ai_burn.lower_bound_label).toBe(AI_BURN_LOWER_BOUND_LABEL);
+  });
+
+  it('revenue surfaces its test-mode flag honestly', () => {
+    const row = {
+      cash_usd: null, cash_last_synced_at: null,
+      ai_burn_usd: null, ai_burn_last_synced_at: null,
+      other_burn_usd: null, other_burn_last_synced_at: null,
+      revenue_usd: 25, revenue_last_synced_at: fresh(1), revenue_livemode: false,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.revenue.value_usd).toBe(25);
+    expect(v.partials.revenue.test_mode).toBe(true);
+    expect(v.partials.revenue.livemode).toBe(false);
+  });
+
+  it('net cash-positive (revenue >= burn) withholds runway rather than reporting infinite', () => {
+    const row = {
+      cash_usd: 5000, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 100, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: 0, other_burn_last_synced_at: fresh(1),
+      revenue_usd: 500, revenue_last_synced_at: fresh(1), revenue_livemode: true,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.net_burn.value_usd).toBe(-400); // 100 + 0 - 500
+    expect(v.months_of_runway).toBeNull();
+    expect(v.headline).toBe('net cash-positive (no burn-down)');
+  });
+
+  it('NULL-not-zero: a 0-valued cash input is distinct from an absent one and never fabricated', () => {
+    // absent cash → unattested (no value); explicit 0 cash → live 0 (a real, attested zero)
+    const absent = computeRunway({ cash_usd: null, cash_last_synced_at: null, ai_burn_usd: null, ai_burn_last_synced_at: null, other_burn_usd: null, other_burn_last_synced_at: null, revenue_usd: null, revenue_last_synced_at: null }, { nowMs: NOW });
+    expect(absent.partials.cash.status).toBe('unattested');
+    expect(absent.partials.cash.value_usd).toBeNull();
+    const attestedZero = computeRunway({ cash_usd: 0, cash_last_synced_at: fresh(1), ai_burn_usd: null, ai_burn_last_synced_at: null, other_burn_usd: null, other_burn_last_synced_at: null, revenue_usd: null, revenue_last_synced_at: null }, { nowMs: NOW });
+    expect(attestedZero.partials.cash.status).toBe('live');
+    expect(attestedZero.partials.cash.value_usd).toBe(0);
+  });
+
+  it('exposes per-input liveness windows (ai_burn/revenue hourly-tight, cash generous)', () => {
+    expect(LIVENESS_WINDOWS_MS.ai_burn).toBeLessThan(LIVENESS_WINDOWS_MS.cash);
+    expect(LIVENESS_WINDOWS_MS.revenue).toBe(LIVENESS_WINDOWS_MS.ai_burn);
+  });
+});


### PR DESCRIPTION
## Summary
Builds an honest operator-grain **cash/burn substrate** so the cockpit's distance-to-broke (months-of-runway) gauge can be **measured, not guessed**. Core contract throughout: **never fabricate a financial number** — a missing input is NULL (unattested, never 0); a stale input is suppressed ('stale / not yet measurable', never shown as live); months-of-runway renders ONLY when cash AND net-burn are both fresh.

## What shipped (6 FRs)
- **FR-1** `operator_cash_burn_monthly` table (additive; applied live) with a per-input `last_synced_at` freshness column for each of `{cash, ai_burn, other_burn, revenue}`.
- **FR-2** fail-soft hourly feed (`scripts/operator/feed-operator-cash-burn.mjs` + cron) writes the rolling-30d AI spend (from `scripts/llm-cost-report.mjs`) to the substrate `ai_burn` **and** the live `income_capture_monthly.business_expenses` slot, **always labeled a lower bound** (main-session Opus tokens are structurally uncaptured).
- **FR-3** mirrors the existing auto-derived `recurring_revenue` as the inflow partial with its **test-mode** (`livemode`) flag surfaced honestly.
- **FR-4** honest freshness on every input — NULL-not-zero (`replacement-net-source` precedent) + `cloud-cap-feeder` liveness-window suppression.
- **FR-5** backfills `venture_token_ledger.cost_usd` via `lib/cost/llm-pricing.js` for **resolvable models only** — unknown-model rows stay honest (no fabricated price; today all 3235 rows have unpopulated `model_id`, so it honestly prices $0 — an upstream capture gap, not a fabrication).
- **FR-6** `getDistanceToBroke()` accessor renders months-of-runway only when cash AND net-burn are fresh; otherwise returns the honest partials + `awaiting cash source`. The cockpit's distance-to-broke tile (separate, dependency-blocked SD-EHG-COCKPIT-BUILD-001) consumes this.

## Verification
- **Live-verified**: AI burn **$142.01** (lower bound) + revenue **$25** (test-mode) written; cash absent ⇒ runway **withheld** as `awaiting cash source`; net_burn **$117.01**. No fabricated number.
- **14 unit tests** for the honest-degrade logic (freshness, suppression, NULL-not-zero, net-positive withholding, lower-bound + test-mode flags); 100 tests green across touched modules.
- **Adversarial review: SOUND, no HIGH defects.** It caught one MEDIUM — the FR-2 `business_expenses` UPDATE was livemode-agnostic (wrote a meaningless figure to the test row + silently fed the distance-to-quit replacement-net glide-path once a live row exists). **Fixed**: scoped to `livemode=true` (the real operator expense ledger) with the intentional coupling documented; until a live income row exists the fill is deferred and the substrate `ai_burn` is the authoritative gauge source.

## Out-of-scope (honest finding)
`venture_token_ledger.model_id` is unpopulated (all rows `agent_type='claude'`, `model_id=NULL`), so per-venture AI cost can't be priced without fabricating a tier — FR-5 honestly leaves them. The upstream model_id-capture gap is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)