### PR TITLE
fix(SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001): gate IDLE-STALLED on belt depth

### DIFF
--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -152,7 +152,8 @@ async function main() {
       idleNow++;
       const hbAgeS = Math.round((Date.now() - new Date(w.heartbeat_at).getTime()) / 1000);
       // A stale heartbeat is only a STALL if there is claimable work the loop is failing to take.
-      // beltDepth inputs (claimable[], openQfCount) are already in scope here (finalized below @161).
+      // beltDepth inputs are already populated before this loop (openQfCount + claimable[]); the
+      // beltDepth re-derivation lower down is only for the verdict math.
       const { stalled: stalledFlag, state: idleState, detail: idleDetail } =
         classifyIdleWorker({ hbAgeS, beltDepth: claimable.length + openQfCount });
       if (stalledFlag) stalled++;

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -32,6 +32,10 @@ import { dirname, join } from 'path';
 // fixtures AND bare-shell stubs (neither can pass LEAD-TO-PLAN) never inflate belt depth —
 // counting them as claimable over-reports capacity and suppresses the deficit/Adam alert.
 import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
+// SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001: an idle worker is STALLED only when
+// its loop isn't claiming DESPITE available work — gate the stall label on belt depth, not heartbeat
+// age alone, so an empty-belt idle worker isn't a false-positive STALLED.
+import { classifyIdleWorker } from './lib/capacity-idle-classifier.mjs';
 
 const require = createRequire(import.meta.url);
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
@@ -147,11 +151,14 @@ async function main() {
       // idle: distinguish a healthy idle from a stalled loop (alive but never converting work)
       idleNow++;
       const hbAgeS = Math.round((Date.now() - new Date(w.heartbeat_at).getTime()) / 1000);
-      const stalledFlag = hbAgeS > 180; // alive heartbeat but >3m without claiming = likely stalled loop
+      // A stale heartbeat is only a STALL if there is claimable work the loop is failing to take.
+      // beltDepth inputs (claimable[], openQfCount) are already in scope here (finalized below @161).
+      const { stalled: stalledFlag, state: idleState, detail: idleDetail } =
+        classifyIdleWorker({ hbAgeS, beltDepth: claimable.length + openQfCount });
       if (stalledFlag) stalled++;
       rows.push({
-        sess: w.session_id.slice(0, 8), callsign, state: stalledFlag ? 'IDLE⚠STALLED' : 'IDLE',
-        detail: stalledFlag ? 'alive but loop not claiming (needs /loop re-arm)' : 'available',
+        sess: w.session_id.slice(0, 8), callsign, state: idleState,
+        detail: idleDetail,
         eta: `idle ${hbAgeS}s`,
       });
     }

--- a/scripts/lib/capacity-idle-classifier.mjs
+++ b/scripts/lib/capacity-idle-classifier.mjs
@@ -1,0 +1,22 @@
+/**
+ * Pure idle/stall classifier for the coordinator capacity forecast.
+ * SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001 (FR-1).
+ *
+ * A worker is IDLE-STALLED only when its loop is alive but NOT claiming DESPITE
+ * available claimable work — i.e. a stale heartbeat AND a non-empty belt. When
+ * the belt is empty there is nothing to claim, so a stale-heartbeat idle worker
+ * is correctly idle, NOT stalled — labeling it STALLED is a false positive that
+ * inflates the STALLED count and emits misleading "needs /loop re-arm" guidance.
+ *
+ * @param {{hbAgeS:number, beltDepth:number, ttlS?:number}} input
+ *   hbAgeS    - heartbeat age in seconds
+ *   beltDepth - claimable SDs + open QFs (worker-claimable work available now)
+ *   ttlS      - stall threshold in seconds (default 180 = the prior inline value)
+ * @returns {{stalled:boolean, state:string, detail:string}}
+ */
+export function classifyIdleWorker({ hbAgeS, beltDepth, ttlS = 180 } = {}) {
+  const stalled = hbAgeS > ttlS && beltDepth > 0;
+  return stalled
+    ? { stalled: true, state: 'IDLE⚠STALLED', detail: 'alive but loop not claiming (needs /loop re-arm)' }
+    : { stalled: false, state: 'IDLE', detail: 'available' };
+}

--- a/tests/unit/capacity-idle-classifier.test.js
+++ b/tests/unit/capacity-idle-classifier.test.js
@@ -1,0 +1,42 @@
+/**
+ * SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001
+ * The capacity forecast labels an idle worker STALLED only when its loop is alive but NOT claiming
+ * DESPITE available work — a stale heartbeat AND a non-empty belt. An empty belt means there is
+ * nothing to claim, so a stale-heartbeat idle worker is correctly idle (not a false-positive STALL).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyIdleWorker } from '../../scripts/lib/capacity-idle-classifier.mjs';
+
+describe('classifyIdleWorker — belt-depth-gated stall classification', () => {
+  it('stale heartbeat + EMPTY belt is NOT stalled (the false-positive being fixed)', () => {
+    const r = classifyIdleWorker({ hbAgeS: 300, beltDepth: 0 });
+    expect(r.stalled).toBe(false);
+    expect(r.state).toBe('IDLE');
+    expect(r.detail).toBe('available');
+  });
+
+  it('stale heartbeat + NON-EMPTY belt IS stalled (genuine stall preserved)', () => {
+    const r = classifyIdleWorker({ hbAgeS: 300, beltDepth: 2 });
+    expect(r.stalled).toBe(true);
+    expect(r.state).toBe('IDLE⚠STALLED');
+    expect(r.detail).toMatch(/loop re-arm/);
+  });
+
+  it('fresh heartbeat + non-empty belt is NOT stalled', () => {
+    expect(classifyIdleWorker({ hbAgeS: 60, beltDepth: 5 }).stalled).toBe(false);
+  });
+
+  it('boundary: hbAgeS exactly at ttlS (180) is NOT stalled (strict greater-than)', () => {
+    expect(classifyIdleWorker({ hbAgeS: 180, beltDepth: 5 }).stalled).toBe(false);
+    expect(classifyIdleWorker({ hbAgeS: 181, beltDepth: 5 }).stalled).toBe(true);
+  });
+
+  it('custom ttlS is honored', () => {
+    expect(classifyIdleWorker({ hbAgeS: 100, beltDepth: 3, ttlS: 90 }).stalled).toBe(true);
+    expect(classifyIdleWorker({ hbAgeS: 100, beltDepth: 0, ttlS: 90 }).stalled).toBe(false);
+  });
+
+  it('defaults to not-stalled when called with no args', () => {
+    expect(classifyIdleWorker().stalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`scripts/coordinator-capacity-forecast.mjs` labeled an alive idle worker **IDLE⚠STALLED** ('alive but loop not claiming — needs /loop re-arm') purely on heartbeat age (>180s), regardless of whether any claimable work existed. So an idle worker with an **empty belt** (0 claimable SDs + 0 open QFs) — which is correctly idle — was mislabeled STALLED, inflating the STALLED count and emitting misleading re-arm guidance.

A true stall is "loop not claiming **despite** available work." **Fix:** gate the stall on belt depth — `stalled = hbAgeS > ttlS(180) && beltDepth > 0` — via a new pure helper `scripts/lib/capacity-idle-classifier.mjs` `classifyIdleWorker({hbAgeS, beltDepth, ttlS})`, wired into the idle branch with `beltDepth = claimable.length + openQfCount` (already in scope). Single-repo, code-only, no schema/migration.

## Verification
- New unit test `tests/unit/capacity-idle-classifier.test.js` — 6/6 (empty-belt→not-stalled, non-empty-belt→stalled, fresh, boundary at ttlS strict `>`, custom ttlS, no-arg default).
- `node scripts/coordinator-capacity-forecast.mjs` renders cleanly (wired-in classifier import loads).
- Adversarial review: fix correct, no blocking defects; string contracts/`stalled++` counter/threshold preserved. One LOW by-design residual noted (beltDepth is fleet-global not per-worker — a strictly narrower false-positive than the empty-belt one fixed).
- TESTING sub-agent PASS (row 41c4c348); handoffs 94/98/94/95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)