### PR TITLE
fix(SD-LEO-INFRA-GR-SECURITY-BASELINE-PROSE-FALSE-BLOCK-001): GR-SECURITY-BASELINE requires a real signal, not a bare prose word

### DIFF
--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -358,10 +358,43 @@ const DEFAULT_GUARDRAILS = [
     mode: MODES.BLOCKING,
     description: 'SDs touching authentication, authorization, RLS, or credentials require security assessment',
     check: (sdData) => {
+      // SD-LEO-INFRA-GR-SECURITY-BASELINE-PROSE-FALSE-BLOCK-001: require a REAL security
+      // signal, not a bare conceptual prose word — mirroring the sibling GR-MIGRATION-REVIEW
+      // repair above. The old regex matched 'token'/'secret'/'auth' ANYWHERE in narrative,
+      // so a pure-JS governance/tooling SD that merely DISCUSSED a concept (UI "design
+      // tokens", a CI "secret", "the auth flow") was false-blocked at creation. It also had
+      // two unescaped dots ('row.level.security', 'api.key') where '.' matched ANY char.
+      // We now fire only on:
+      //   (a) a STRONG security-mechanism keyword (concrete, rarely innocent in JS prose),
+      //   (b) a real credential-TYPE compound (a bearer/session/refresh/access/api/auth
+      //       token, or a client/api/app/shared secret, or a secret-key) — NOT a UI/parse
+      //       "token" or a generic "secret", or
+      //       (c) an explicit metadata signal.
+      // The bare ambiguous words auth/token/secret no longer fire on their own, so genuine
+      // security SDs STILL block (gate NOT weakened) while prose discussion does not.
       const scope = (sdData.scope || '').toLowerCase();
-      const hasSecurityScope = /\b(auth|authentication|authorization|rls|row.level.security|credential|secret|token|api.key|oauth|jwt|password|encryption)\b/.test(scope);
-      const hasSecurityAssessment = sdData.metadata?.security_reviewed === true
-        || sdData.metadata?.threat_model === true;
+      const md = sdData.metadata || {};
+
+      // (a) STRONG concrete security mechanisms. The two former-unescaped-dot patterns are
+      //     now separator classes ([-\s.]) so they match real spellings (space/hyphen/dot)
+      //     but NOT an arbitrary character (e.g. "rowXlevelYsecurity"/"apiZkey" no longer match).
+      const hasStrongSecurity = /\b(?:authentication|authorization|rls|row[-\s.]level[-\s.]security|oauth|jwt|api[-\s.]?key|passwords?|passwd|credentials?|encryption|encrypt(?:ed)?|decrypt|rbac|csrf|mfa|2fa|sso|saml)\b/.test(scope);
+      // (b) Real credential-TYPE compounds: an auth-context token, or a scoped secret.
+      //     Excludes bare "token" (UI/design/parse/lexer tokens) and bare "secret" ("secret
+      //     sauce", a CI "secret") which are the prose false-block class.
+      const hasCredentialCompound = /\b(?:bearer|session|refresh|access|api|csrf|auth)[-\s.]?tokens?\b/.test(scope)
+        || /\b(?:client|api|app|shared)[-\s.]?secrets?\b/.test(scope)
+        || /\bsecret[-\s.]?key\b/.test(scope);
+      // (c) An explicit structured metadata signal.
+      const hasMetaSignal = md.touches_auth === true
+        || md.touches_security === true
+        || md.touches_credentials === true
+        || (Array.isArray(md.governed_files)
+          && md.governed_files.some((f) => /(^|\/)(?:auth|security|rls)\b|\.(?:pem|key)$/i.test(String(f))));
+
+      const hasSecurityScope = hasStrongSecurity || hasCredentialCompound || hasMetaSignal;
+      const hasSecurityAssessment = md.security_reviewed === true
+        || md.threat_model === true;
 
       if (hasSecurityScope && !hasSecurityAssessment) {
         return {

--- a/tests/unit/governance/gr-security-baseline-prose-detector.test.js
+++ b/tests/unit/governance/gr-security-baseline-prose-detector.test.js
@@ -1,0 +1,94 @@
+/**
+ * SD-LEO-INFRA-GR-SECURITY-BASELINE-PROSE-FALSE-BLOCK-001 — GR-SECURITY-BASELINE detector.
+ *
+ * Proves the BLOCKING guardrail now requires a REAL security signal (a concrete mechanism
+ * keyword, a real credential-TYPE compound, or a metadata signal) instead of a bare
+ * conceptual prose word — so a pure-JS SD that merely DISCUSSES a concept (UI "design
+ * tokens", a CI "secret", "the auth flow") is no longer false-blocked, while every genuine
+ * security scope STILL blocks (gate not weakened). Mirrors the sibling
+ * tests/unit/governance/gr-migration-prose-detector.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import { check } from '../../../lib/governance/guardrail-registry.js';
+
+const sec = (sdData) => check(sdData).violations.find((v) => v.guardrail === 'GR-SECURITY-BASELINE');
+
+describe('GR-SECURITY-BASELINE — bare prose word no longer false-blocks (FR-1)', () => {
+  it.each([
+    ['manage design tokens for the UI theme', 'UI design tokens'],
+    ['the lexer emits tokens for each statement', 'parse/lexer tokens'],
+    ['add a token bucket rate limiter', 'token bucket (rate limiting)'],
+    ['store the GitHub Actions secret for CI', 'CI secret in tooling prose'],
+    ['the secret to fast lookups is a hash map', 'idiomatic "secret"'],
+    ['document the auth flow for operators', 'bare "auth" in a doc SD'],
+    ['refine the GR-SECURITY-BASELINE keyword filter so a bare prose word no longer false-blocks', 'pure governance prose'],
+  ])('PASSES pure-JS/governance prose: %s (%s)', (scope) => {
+    expect(sec({ scope, metadata: {} })).toBeUndefined();
+  });
+});
+
+describe('GR-SECURITY-BASELINE — genuine security scope STILL blocks (FR-1, gate not weakened)', () => {
+  it.each([
+    ['add oauth login to the app', 'oauth'],
+    ['issue a jwt on sign-in', 'jwt'],
+    ['enforce row-level-security on tenants', 'row-level-security'],
+    ['add authentication to the login flow', 'authentication'],
+    ['implement rbac authorization', 'authorization + rbac'],
+    ['store API credentials in the vault', 'credentials'],
+    ['harden password hashing', 'password'],
+    ['add field-level encryption', 'encryption'],
+    ['issue an api-key for the worker', 'api-key'],
+    ['rotate the auth token', 'auth token compound'],
+    ['validate the bearer token', 'bearer token compound'],
+    ['refresh the session token', 'session token compound'],
+    ['store the client secret', 'client secret compound'],
+    ['rotate the secret key', 'secret-key compound'],
+    ['require mfa for admins', 'mfa'],
+    ['add csrf protection', 'csrf'],
+  ])('BLOCKS genuine security scope: %s (%s)', (scope) => {
+    expect(sec({ scope, metadata: {} })).toBeDefined();
+  });
+
+  it('BLOCKS on an explicit metadata.touches_security flag even with pure prose', () => {
+    expect(sec({ scope: 'pure prose with no security word', metadata: { touches_security: true } })).toBeDefined();
+  });
+  it('BLOCKS on metadata.touches_auth / touches_credentials', () => {
+    expect(sec({ scope: 'pure prose', metadata: { touches_auth: true } })).toBeDefined();
+    expect(sec({ scope: 'pure prose', metadata: { touches_credentials: true } })).toBeDefined();
+  });
+  it('BLOCKS a governed_files[] entry under an auth/security path or a *.pem/*.key file', () => {
+    expect(sec({ scope: 'pure prose', metadata: { governed_files: ['src/auth/login.js'] } })).toBeDefined();
+    expect(sec({ scope: 'pure prose', metadata: { governed_files: ['config/server.key'] } })).toBeDefined();
+  });
+});
+
+describe('GR-SECURITY-BASELINE — dot patterns now match only real separators (FR-2)', () => {
+  it.each([
+    ['migrate to row.level.security', 'literal-dot spelling'],
+    ['enforce row-level-security', 'hyphen spelling'],
+    ['document row level security', 'space spelling'],
+    ['rotate the api.key', 'api.key literal dot'],
+    ['issue an api key', 'api key space'],
+    ['generate an apikey', 'apikey no separator'],
+  ])('BLOCKS real separator spelling: %s (%s)', (scope) => {
+    expect(sec({ scope, metadata: {} })).toBeDefined();
+  });
+  it.each([
+    ['the rowXlevelYsecurity helper function', 'arbitrary-char row.level.security'],
+    ['call the apiZkey() utility', 'arbitrary-char api.key'],
+  ])('PASSES arbitrary-character forms the unescaped dot used to match: %s (%s)', (scope) => {
+    expect(sec({ scope, metadata: {} })).toBeUndefined();
+  });
+});
+
+describe('GR-SECURITY-BASELINE — attestation bypass unchanged & strict', () => {
+  it('PASSES a genuine security SD when security_reviewed is attested', () => {
+    expect(sec({ scope: 'add oauth login', metadata: { security_reviewed: true } })).toBeUndefined();
+  });
+  it('PASSES a genuine security SD when threat_model is set', () => {
+    expect(sec({ scope: 'enforce row-level-security', metadata: { threat_model: true } })).toBeUndefined();
+  });
+  it('does NOT bypass on a non-true attestation value (must be strict ===true)', () => {
+    expect(sec({ scope: 'add oauth login', metadata: { security_reviewed: 'true' } })).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a false-positive in the GR-SECURITY-BASELINE **BLOCKING** governance guardrail (`lib/governance/guardrail-registry.js`), mirroring the already-shipped sibling GR-MIGRATION-REVIEW repair in the same file. The bare-word detector fired on a security concept word **anywhere** in narrative, so a pure-JS governance/tooling SD that merely **discussed** a concept (UI `design tokens`, a CI `secret`, `the auth flow`) was false-blocked at creation. Two patterns also had unescaped dots (`row.level.security`, `api.key`) where `.` matched any character.

- **FR-1**: rewrote the check to fire only on a REAL signal — (a) a STRONG concrete mechanism keyword (`authentication|authorization|rls|oauth|jwt|api-key|password|credential|encryption|rbac|csrf|mfa|2fa|sso|saml`), (b) a real credential-TYPE compound (`bearer|session|refresh|access|api|auth` token; `client|api|app|shared` secret; `secret-key`), or (c) a metadata signal (`touches_auth|touches_security|touches_credentials`, or `governed_files` under auth/security/rls or a `.pem`/`.key`). Bare `auth`/`token`/`secret` no longer fire alone.
- **FR-2**: escaped the two dots to separator classes (`row[-\s.]level[-\s.]security`, `api[-\s.]?key`) — real spellings match, arbitrary chars do not.
- **FR-3**: `tests/unit/governance/gr-security-baseline-prose-detector.test.js` (37 tests) mirroring the sibling detector test.

## Evidence
- Handoffs: LEAD-TO-PLAN 94 · PLAN-TO-EXEC 98 · EXEC-TO-PLAN 94 · PLAN-TO-LEAD 96
- TESTING PASS(98) + SECURITY PASS @ EXEC — a **38-scope adversarial gate-hole audit** returned `gate_hole_found: false` (every genuine security scope still blocks; the few misses are metadata-covered / the documented sibling tradeoff)
- VALIDATION PASS(98) / REGRESSION PASS(97) @ PLAN_VERIFICATION — **144 tests** across 6 governance/guardrail files, zero regressions; only the GR-SECURITY-BASELINE block changed
- Retrospective quality 90
- Surgical 2-file diff (+130/-3); GR-MIGRATION-REVIEW, all other guardrails, the public API, the severity, and the strict `===true` bypass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
