### PR TITLE
feat(SD-EHG-OPERATOR-CASH-BANK-FEED-001): bank + Stripe cash feed for distance-to-broke (chairman-gated, read-only)

### DIFF
--- a/.prd-payloads/SD-EHG-OPERATOR-CASH-BANK-FEED-001.json
+++ b/.prd-payloads/SD-EHG-OPERATOR-CASH-BANK-FEED-001.json
@@ -1,0 +1,77 @@
+{
+  "executive_summary": "Feed real cash-on-hand into the operator distance-to-broke runway gauge so months-of-runway (cash / net-burn) renders honestly, retiring the interim 'awaiting cash source' partial state. The runway substrate (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001, completed) already provides the operator_cash_burn_monthly table, the upsertSubstrateInputs() write helper, freshness windows, and computeRunway()/getDistanceToBroke() — so FR-5 is largely automatic once cash flows. This SD adds the cash SOURCES with a hard read-only security contract: (FR-3) Stripe Balance via the already-wired read-only getStripe() client (testable now); (FR-1) a server-side token vault for a long-lived bank-READ token reusing the existing AES-256-GCM lib/security/encryption.cjs, where the token NEVER enters the gauge/client code path; (FR-2) a fail-soft pull step in feed-operator-cash-burn.mjs that writes cash_usd + categorized other_burn_usd with last_synced_at freshness. (FR-4) The actual bank CONNECTION (enrolling the chairman's account) is a CHAIRMAN-ONLY action — this SD ships the integration design, credential-handling contract, the vault, and the pull; it CONNECTS NOTHING until the chairman enrolls (the Teller path is authored but inert).",
+  "system_architecture": {
+    "overview": "All cash-read work lives in EHG_Engineer (lib/operator/, scripts/operator/); the separate /ehg/ cockpit consumes getDistanceToBroke() unchanged, so the PR stays in EHG_Engineer with no cross-repo change. The bank-read token is vaulted server-side and only a derived numeric cash row reaches the substrate; the gauge never sees a credential.",
+    "components": [
+      {"name": "lib/operator/cash-sources/stripe-balance.js", "responsibility": "FR-3: read-only Stripe available-balance slice via getStripe() (lib/payments/stripe-client.js). Calls stripe.balance.retrieve() server-side; returns a numeric USD cash slice; fail-soft (returns null on error, never throws into the feeder). No write/payout scope."},
+      {"name": "lib/operator/cash-sources/bank-read-service.js", "responsibility": "FR-1/FR-4: greenfield Teller bank-READ service mirroring the Stripe client guard+lazy pattern. Loads the vaulted bank-read token server-side ONLY; read-only scope; INERT (returns null cash slice) until the chairman enrolls an account. Plaid noted as the compliance alternative."},
+      {"name": "lib/operator/cash-sources/token-vault.js", "responsibility": "FR-1: server-side token vault wrapping lib/security/encryption.cjs (AES-256-GCM). encrypt/decrypt the long-lived bank-read token; decrypted token is held only in the bank-read service, never returned to callers, never logged, never imported by gauge/client code."},
+      {"name": "scripts/operator/feed-operator-cash-burn.mjs (extended)", "responsibility": "FR-2: add a fail-soft cash-pull step that sums available cash slices (Stripe now; bank when enrolled) and calls upsertSubstrateInputs(periodMonth, { cash_usd, cash_last_synced_at, other_burn_usd?, other_burn_last_synced_at? }). A failed/stale pull preserves the prior value (never zeroes cash)."},
+      {"name": "tests/unit/operator/cash-bank-feed.test.js", "responsibility": "FR-5/contract: unit tests for the Stripe slice (mocked), the vault round-trip, the inert-without-enrollment bank path, the fail-soft feeder, and a guard that the token never appears in the gauge code path."}
+    ]
+  },
+  "functional_requirements": [
+    {"id": "FR-1", "title": "Server-side bank-read token vault + enrollment design", "description": "Design the Teller enrollment flow and build a server-side token vault (reusing lib/security/encryption.cjs AES-256-GCM) for the long-lived bank-READ token. HARD contract: read-only scope, NO payout/write scope EVER requested; the token is vaulted server-side and NEVER appears in the gauge code path; the gauge reads ONLY a derived numeric balance/burn row."},
+    {"id": "FR-2", "title": "Fail-soft periodic cash + burn pull", "description": "Add a fail-soft step to feed-operator-cash-burn.mjs that writes cash-on-hand (sum of available slices) and categorized burn-part-(b) (broader non-AI business expenses) into operator_cash_burn_monthly with last_synced_at freshness. A failed pull is a logged skip that preserves the prior value, never a crash or a zeroing."},
+    {"id": "FR-3", "title": "Stripe Balance cash slice (read-only)", "description": "Add Stripe Balance via the already-wired read-only getStripe() client as a second, low-sensitivity cash slice (funds sitting in Stripe). Uses stripe.balance.retrieve() server-side; works in test-mode now; restricted (rk_) key supported. No write/payout scope."},
+    {"id": "FR-4", "title": "Chairman-gated connection (connects nothing)", "description": "The ACTUAL bank CONNECTION (enrolling the chairman's account) is a CHAIRMAN-ONLY action. This SD ships the integration design + credential-handling contract + the vault + the pull; the Teller bank-read path is authored but INERT and connects nothing until the chairman enrolls. No live bank token is committed or self-provisioned (CONST-002 spirit)."},
+    {"id": "FR-5", "title": "Distance-to-broke renders on fresh cash", "description": "Once cash is fresh, the distance-to-broke headline months-of-runway renders (cash / net-burn) with honest freshness via the existing getDistanceToBroke(); the interim partial-only ('awaiting cash source') state retires. This is wiring + verification — the substrate's computeRunway() already implements the freshness/headline logic."}
+  ],
+  "technical_requirements": [
+    {"id": "TR-1", "requirement": "The bank-read token must never be returned to callers, logged, serialized into the substrate, or importable by gauge/client code — only the derived numeric cash slice flows onward. A test asserts the token is absent from the gauge code path."},
+    {"id": "TR-2", "requirement": "Both cash sources are READ-ONLY: Stripe via balance.retrieve() (no charges/payouts); Teller/Plaid requesting read scope only. No write/payout scope is ever requested."},
+    {"id": "TR-3", "requirement": "The pull is fail-soft and idempotent per period_month: errors log a skip and preserve the prior substrate value; success stamps the matching *_last_synced_at. Stripe runs in test-mode in CI/fleet (existing guard)."},
+    {"id": "TR-4", "requirement": "The Teller path is inert without an enrolled token (returns a null slice), so the whole SD ships and is testable with zero live bank credentials; live connection is the chairman's enrollment action."}
+  ],
+  "implementation_approach": {
+    "summary": "Reuse the substrate's existing write/freshness/runway machinery; add only the cash SOURCES behind a strict read-only, server-side-only credential contract. Build the testable Stripe slice first, then the vault, then the inert Teller service, then the fail-soft feeder step. Verify the gauge auto-renders. Bank enrollment is chairman-only.",
+    "steps": [
+      "Build lib/operator/cash-sources/stripe-balance.js (read-only balance.retrieve via getStripe(); fail-soft) — testable in test-mode now.",
+      "Build lib/operator/cash-sources/token-vault.js over lib/security/encryption.cjs; build bank-read-service.js that loads the vaulted token server-side and stays inert until enrollment.",
+      "Extend feed-operator-cash-burn.mjs with a fail-soft cash-pull step that sums available slices and upserts cash_usd + other_burn_usd with freshness.",
+      "Add unit tests incl. the never-in-gauge-path guard; verify getDistanceToBroke() renders months-of-runway on fresh cash and retires the interim headline.",
+      "Drive the LEO chain; do NOT self-provision a live bank token (chairman-gated)."
+    ]
+  },
+  "integration_operationalization": {
+    "consumers": "operator_cash_burn_monthly.cash_usd is consumed by getDistanceToBroke()/computeRunway() (lib/operator/cash-burn-substrate.js), which the /ehg/ cockpit distance-to-broke gauge renders. The new cash-source modules are consumed only by scripts/operator/feed-operator-cash-burn.mjs (server-side). The vault/bank-read token has exactly one consumer: bank-read-service.js (server-side).",
+    "dependencies": "Hard dependency on SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001 (COMPLETED) for the operator_cash_burn_monthly table, upsertSubstrateInputs(), and getDistanceToBroke(). Reuses lib/payments/stripe-client.js getStripe() (FR-3) and lib/security/encryption.cjs (FR-1). Teller SDK is a new npm dependency (read-only client). Live bank connection depends on the chairman's enrollment (FR-4).",
+    "data_contracts": "Writes operator_cash_burn_monthly { cash_usd numeric, cash_last_synced_at timestamptz, other_burn_usd numeric, other_burn_last_synced_at timestamptz } via upsertSubstrateInputs (existing contract, unchanged columns). Cash slice functions return { usd: number|null, source: string } | null. No schema change. The bank-read token lives encrypted at rest, never in the row.",
+    "runtime_config": "STRIPE_SECRET_KEY / restricted rk_ key (existing, test-mode in CI). Teller credentials (app id + a vaulted bank-read token) provided only at chairman enrollment — absent by default, keeping the bank path inert. Encryption master key via existing .leo-keys (lib/security/encryption.cjs). No new public-facing config.",
+    "observability_rollout": "Rollout: code merges; the feeder's cash step runs on the existing feed-operator-cash-burn schedule. Until the chairman enrolls, only the Stripe slice contributes (test-mode) and the gauge shows runway from Stripe cash + AI burn. Verification: getDistanceToBroke() returns months_of_runway with cash status 'live' once cash is fresh. Rollback: git revert the PR (no data/schema impact; substrate columns are pre-existing); the bank token, if ever enrolled, is revoked chairman-side."
+  },
+  "acceptance_criteria": [
+    "After the cash-read step runs, the operator runway view shows a real months-of-runway number (cash divided by net burn) instead of the interim 'awaiting cash source' message.",
+    "The cash number is marked fresh, with a last-synced timestamp, and a failed refresh keeps the last known cash value rather than dropping it to zero.",
+    "Money sitting in Stripe is counted as part of cash-on-hand using a read-only key — no charges or payouts are ever made.",
+    "The long-lived bank login token is stored encrypted on the server and never appears anywhere the gauge or any browser code can read it — only the resulting cash number is shared.",
+    "No bank account is actually connected by this work: the bank-reading path stays dormant and connects nothing until the chairman personally enrolls an account.",
+    "The unit tests for this work pass, including a check that the bank token is absent from the gauge code path."
+  ],
+  "test_scenarios": [
+    {"id": "TS-1", "title": "Stripe balance slice is read-only and fail-soft", "type": "unit", "scenario": "Call the Stripe balance slice with a mocked getStripe() returning a known available balance; then with a client that throws.", "expected": "Returns the numeric USD balance on success; returns null (logged skip) on error; never calls a charge/payout method and never throws into the feeder."},
+    {"id": "TS-2", "title": "Token vault round-trips without leaking", "type": "unit", "scenario": "Encrypt a fake bank-read token via the vault, then decrypt it inside the bank-read service.", "expected": "Decrypt returns the original token only inside the service; the token is never part of any returned cash slice, log line, or substrate row."},
+    {"id": "TS-3", "title": "Bank path inert without enrollment", "type": "unit", "scenario": "Run the bank-read service with no vaulted token configured.", "expected": "Returns a null cash slice (inert); the feeder proceeds on the Stripe slice alone; no connection attempt is made."},
+    {"id": "TS-4", "title": "Feeder writes fresh cash; gauge renders runway", "type": "integration", "scenario": "Run the extended feed-operator-cash-burn.mjs cash step (Stripe test-mode), then call getDistanceToBroke(currentMonth).", "expected": "operator_cash_burn_monthly.cash_usd is upserted with cash_last_synced_at ~now; getDistanceToBroke returns months_of_runway = cash/net-burn with cash status 'live' and the interim 'awaiting cash source' headline is gone."},
+    {"id": "TS-5", "title": "Token never in gauge code path", "type": "unit", "scenario": "Static guard: assert the gauge/consumer modules (cash-burn-substrate.js / gauge path) do not import the vault or bank-read service and contain no token reference.", "expected": "No gauge/client module references the token, the vault, or the bank-read service — only the derived cash row."}
+  ],
+  "risks": [
+    {"risk": "Bank-read token leaks into logs/client/gauge", "mitigation": "Token vaulted server-side (encryption.cjs); held only in bank-read-service; TS-5 static guard asserts absence from the gauge path; never serialized into the substrate row.", "severity": "high"},
+    {"risk": "Accidental write/payout scope", "mitigation": "Stripe uses balance.retrieve() only (read); Teller/Plaid request read scope only; no charge/payout/transfer call exists in the new modules.", "severity": "high"},
+    {"risk": "Worker self-connects a live bank account", "mitigation": "FR-4 chairman-gated: the Teller path is inert without an enrolled token; no live token is committed or self-provisioned.", "severity": "medium"},
+    {"risk": "A failed pull zeroes cash and shows false runway collapse", "mitigation": "Fail-soft: errors log a skip and preserve the prior value; freshness windows mark stale cash rather than zero (TS-1/TS-4).", "severity": "medium"}
+  ],
+  "metadata": {
+    "sd_key": "SD-EHG-OPERATOR-CASH-BANK-FEED-001",
+    "target_application": "EHG_Engineer",
+    "target_files": [
+      "lib/operator/cash-sources/stripe-balance.js",
+      "lib/operator/cash-sources/bank-read-service.js",
+      "lib/operator/cash-sources/token-vault.js",
+      "scripts/operator/feed-operator-cash-burn.mjs",
+      "tests/unit/operator/cash-bank-feed.test.js"
+    ],
+    "created_via": "fleet-worker",
+    "depends_on": ["SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001"]
+  }
+}

--- a/lib/operator/cash-sources/bank-read-service.js
+++ b/lib/operator/cash-sources/bank-read-service.js
@@ -1,0 +1,64 @@
+/**
+ * lib/operator/cash-sources/bank-read-service.js
+ *
+ * SD-EHG-OPERATOR-CASH-BANK-FEED-001 — FR-1/FR-4: Teller.io bank-READ service
+ * (Plaid is the compliance alternative). Reads cash-on-hand + categorized
+ * non-AI business burn from the chairman's enrolled bank accounts.
+ *
+ * HARD CONTRACT:
+ *   - CHAIRMAN-GATED / INERT BY DEFAULT (FR-4): with no vaulted token this returns
+ *     null and makes NO connection attempt. The actual connection only exists once
+ *     the chairman enrolls (storeBankReadToken) — this SD connects nothing.
+ *   - READ-ONLY (TR-2): only account/balance/transaction READS; the service exposes
+ *     and uses no transfer / payment / payout capability.
+ *   - The decrypted token is held ONLY here, passed ONLY to the injected read
+ *     client, never logged, never returned, never written to the substrate row.
+ *
+ * The Teller client is provided via `tellerClientFactory` (wired at enrollment).
+ * Absent a factory the service stays inert rather than guess a transport — so the
+ * module ships and is fully testable with zero live bank credentials or SDK deps.
+ */
+
+import { loadBankReadToken } from './token-vault.js';
+
+/**
+ * Read the bank cash slice (+ optional categorized non-AI burn). INERT (null) when
+ * the chairman has not enrolled or no read client is wired.
+ *
+ * @param {object} [opts]
+ * @param {function} [opts.loadToken] - async () => token|null (tests); defaults to the vault
+ * @param {function} [opts.tellerClientFactory] - (token) => readClient with
+ *        listAccounts() and getBalance(accountId); only READ methods are used
+ * @returns {Promise<{usd:number, other_burn_usd:(number|null), source:'bank'}|null>}
+ */
+export async function readBankCashSlice({ loadToken = loadBankReadToken, tellerClientFactory } = {}) {
+  const token = await loadToken();
+  if (!token) return null; // INERT — chairman has not enrolled; connect nothing
+  // Greenfield: the read transport is wired at enrollment. Without it, stay inert
+  // rather than fabricate a connection.
+  if (typeof tellerClientFactory !== 'function') return null;
+  try {
+    const client = tellerClientFactory(token); // token never leaves this scope
+    const accounts = (await client.listAccounts()) || []; // READ
+    let cashUsd = 0;
+    for (const acct of accounts) {
+      const bal = await client.getBalance(acct.id); // READ
+      if (String(bal?.currency || 'USD').toUpperCase() === 'USD') {
+        cashUsd += Number(bal?.available || 0);
+      }
+    }
+    // Categorized non-AI burn (FR-2 part-b) is derived from transaction
+    // categorization when the connection exposes it; null until then.
+    const otherBurnUsd =
+      typeof client.getCategorizedBurnUsd === 'function'
+        ? Number((await client.getCategorizedBurnUsd()) || 0)
+        : null;
+    return {
+      usd: Number(cashUsd.toFixed(2)),
+      other_burn_usd: otherBurnUsd == null ? null : Number(otherBurnUsd.toFixed(2)),
+      source: 'bank',
+    };
+  } catch {
+    return null; // fail-soft
+  }
+}

--- a/lib/operator/cash-sources/stripe-balance.js
+++ b/lib/operator/cash-sources/stripe-balance.js
@@ -1,0 +1,41 @@
+/**
+ * lib/operator/cash-sources/stripe-balance.js
+ *
+ * SD-EHG-OPERATOR-CASH-BANK-FEED-001 — FR-3: read-only Stripe Balance cash slice.
+ *
+ * Funds sitting in Stripe are a low-sensitivity slice of cash-on-hand. This uses
+ * the already-wired getStripe() client (lib/payments/stripe-client.js, which
+ * fail-closes live keys in fleet/CI so this runs in TEST mode) and calls ONLY
+ * stripe.balance.retrieve() — a READ. No charge / payout / transfer / refund is
+ * ever invoked here (TR-2, RISK: accidental write scope).
+ *
+ * Fail-soft: any error returns null so the feeder leaves cash stale rather than
+ * crashing or fabricating a number.
+ */
+
+import { getStripe } from '../../payments/stripe-client.js';
+
+/**
+ * Read the available USD balance held in Stripe as a cash slice.
+ * Uses `available` (settled) only — the conservative cash-on-hand figure; pending
+ * in-flight funds are excluded.
+ *
+ * @param {object} [opts]
+ * @param {object} [opts.stripeClient] - injected Stripe client (tests); defaults to getStripe()
+ * @param {object} [opts.env] - environment for the key guard
+ * @returns {Promise<{usd:number, source:'stripe'}|null>} null on any error
+ */
+export async function readStripeCashSlice({ stripeClient, env = process.env } = {}) {
+  try {
+    const stripe = stripeClient || (await getStripe(env));
+    const bal = await stripe.balance.retrieve(); // READ-ONLY
+    const available = Array.isArray(bal?.available) ? bal.available : null;
+    if (!available) return null;
+    const usdCents = available
+      .filter((b) => String(b?.currency || '').toLowerCase() === 'usd')
+      .reduce((sum, b) => sum + (Number(b?.amount) || 0), 0);
+    return { usd: Number((usdCents / 100).toFixed(2)), source: 'stripe' };
+  } catch {
+    return null; // fail-soft: leave cash stale, never throw into the feeder
+  }
+}

--- a/lib/operator/cash-sources/token-vault.js
+++ b/lib/operator/cash-sources/token-vault.js
@@ -1,0 +1,70 @@
+/**
+ * lib/operator/cash-sources/token-vault.js
+ *
+ * SD-EHG-OPERATOR-CASH-BANK-FEED-001 — FR-1: server-side vault for the long-lived
+ * bank-READ token.
+ *
+ * HARD CONTRACT (security):
+ *   - The token is encrypted at rest via the existing AES-256-GCM credential
+ *     encryption (lib/security/encryption.cjs). It is NEVER stored in plaintext,
+ *     NEVER written to the operator_cash_burn_monthly row, and NEVER returned to
+ *     the gauge / browser code path — only the bank-read service (server-side)
+ *     ever holds the decrypted value, and only the derived numeric cash slice
+ *     flows onward.
+ *   - loadBankReadToken() is INERT when the chairman has not enrolled: a missing
+ *     vault returns null (no throw), so the whole feature ships and runs with zero
+ *     live bank credentials.
+ *
+ * `enc` is injectable so unit tests run hermetically (no .leo-keys / filesystem).
+ */
+
+import credentialEncryption from '../../security/encryption.cjs';
+
+/** App namespace for the operator bank-read credential vault. */
+export const BANK_READ_APP_ID = 'operator-bank-read';
+const TOKEN_KEY = 'bank_read_token';
+
+/**
+ * Encrypt a bank-read token in memory. Returns the AES-256-GCM blob
+ * ({ encrypted, metadata }) — never the plaintext.
+ */
+export async function encryptBankReadToken(token, { enc = credentialEncryption } = {}) {
+  if (!token || typeof token !== 'string') {
+    throw new Error('bank-read token must be a non-empty string');
+  }
+  return enc.encrypt({ [TOKEN_KEY]: token }, BANK_READ_APP_ID);
+}
+
+/** Decrypt an in-memory vault blob back to the token string (or null if absent). */
+export async function decryptBankReadToken(blob, { enc = credentialEncryption } = {}) {
+  if (!blob || !blob.encrypted) return null;
+  const obj = await enc.decrypt(blob.encrypted, blob.metadata);
+  return obj?.[TOKEN_KEY] ?? null;
+}
+
+/**
+ * Persist the bank-read token to the server-side encrypted credential store
+ * (applications/operator-bank-read/.env.encrypted). This is the CHAIRMAN
+ * ENROLLMENT action (FR-4) — it provisions the only path by which a live token
+ * ever enters the vault.
+ */
+export async function storeBankReadToken(token, { enc = credentialEncryption } = {}) {
+  if (!token || typeof token !== 'string') {
+    throw new Error('bank-read token must be a non-empty string');
+  }
+  return enc.encryptAppCredentials(BANK_READ_APP_ID, { [TOKEN_KEY]: token });
+}
+
+/**
+ * Load the decrypted bank-read token server-side. INERT until enrollment: returns
+ * null (never throws) when no vault exists, so the bank-read path connects nothing
+ * and the feeder degrades to the Stripe slice alone.
+ */
+export async function loadBankReadToken({ enc = credentialEncryption } = {}) {
+  try {
+    const creds = await enc.decryptAppCredentials(BANK_READ_APP_ID);
+    return creds?.[TOKEN_KEY] ?? null;
+  } catch {
+    return null; // not enrolled — inert by design
+  }
+}

--- a/lib/operator/cash-sources/token-vault.js
+++ b/lib/operator/cash-sources/token-vault.js
@@ -64,7 +64,17 @@ export async function loadBankReadToken({ enc = credentialEncryption } = {}) {
   try {
     const creds = await enc.decryptAppCredentials(BANK_READ_APP_ID);
     return creds?.[TOKEN_KEY] ?? null;
-  } catch {
-    return null; // not enrolled — inert by design
+  } catch (err) {
+    // Distinguish "no vault yet" (legitimately inert) from a GENUINE decrypt/auth-tag
+    // failure (tampered or corrupted vault, rotated key). Both stay fail-soft (return
+    // null so the feeder degrades to bank-absent), but a real integrity failure is
+    // surfaced loudly — never silently masked as "not enrolled". No token is ever in
+    // the message (the failure happens before any plaintext exists).
+    const msg = String(err?.message || err);
+    const missing = err?.code === 'ENOENT' || /ENOENT|no such file|not found/i.test(msg);
+    if (!missing) {
+      console.warn(`[bank-read-vault] WARN bank-read vault present but UNREADABLE (tamper/corruption/key-rotation?) — staying inert: ${msg}`);
+    }
+    return null;
   }
 }

--- a/scripts/operator/feed-operator-cash-burn.mjs
+++ b/scripts/operator/feed-operator-cash-burn.mjs
@@ -28,6 +28,8 @@ import path from 'node:path';
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import { priceFor } from '../../lib/cost/llm-pricing.js';
 import { periodMonthOf, upsertSubstrateInputs, AI_BURN_LOWER_BOUND_LABEL } from '../../lib/operator/cash-burn-substrate.js';
+import { readStripeCashSlice } from '../../lib/operator/cash-sources/stripe-balance.js';
+import { readBankCashSlice } from '../../lib/operator/cash-sources/bank-read-service.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -59,7 +61,36 @@ async function main() {
   const supabase = createSupabaseServiceClient();
   const nowIso = new Date().toISOString();
   const periodMonth = periodMonthOf(Date.now());
-  const result = { period_month: periodMonth, dry_run: DRY_RUN, ai_burn: null, revenue: null, backfill: null };
+  const result = { period_month: periodMonth, dry_run: DRY_RUN, cash: null, ai_burn: null, revenue: null, backfill: null };
+
+  // ---- FR-2/FR-3: cash-on-hand (bank is PRIMARY + chairman-gated; Stripe is a SECOND slice) ----
+  // HONESTY (mirrors the substrate's "missing is NULL, never 0"): the bulk of cash lives in the
+  // bank, so the BANK is the primary source that establishes the cash reading. Stripe (FR-3) is an
+  // ADDITIVE "second slice" (funds sitting in Stripe) — alone it is NOT a complete cash picture, so
+  // writing it standalone would render a misleadingly-LOW runway. Until the chairman enrolls the
+  // bank (FR-4), cash stays UNATTESTED and the gauge honestly shows 'awaiting cash source' rather
+  // than a false near-zero. Fail-soft throughout: a failed pull preserves the prior value.
+  try {
+    const bankSlice = await readBankCashSlice();
+    if (!bankSlice) {
+      // Inert: no primary cash source yet. Peek Stripe for logging only; do NOT write cash.
+      const stripePeek = await readStripeCashSlice();
+      log('FR-cash', `bank cash slice inert (chairman not enrolled) — cash left unattested${stripePeek ? `; Stripe would add $${stripePeek.usd} once a bank is connected` : ''}`);
+      result.cash = { written: false, reason: 'primary bank source not enrolled (cash left unattested — gauge stays "awaiting cash source")' };
+    } else {
+      const stripeSlice = await readStripeCashSlice(); // additive second slice
+      const cashUsd = Number((Number(bankSlice.usd) + (stripeSlice ? Number(stripeSlice.usd) || 0 : 0)).toFixed(2));
+      const sources = ['bank', ...(stripeSlice ? ['stripe'] : [])];
+      const otherBurn = bankSlice.other_burn_usd; // categorized non-AI burn (FR-2 part-b), bank-derived
+      log('FR-cash', `cash-on-hand = $${cashUsd} from ${sources.join('+')}`);
+      if (!DRY_RUN) {
+        const fields = { cash_usd: cashUsd };
+        if (otherBurn != null) fields.other_burn_usd = Number(Number(otherBurn).toFixed(2));
+        await upsertSubstrateInputs(periodMonth, fields, supabase, nowIso);
+      }
+      result.cash = { written: !DRY_RUN, value_usd: cashUsd, sources, other_burn_usd: otherBurn };
+    }
+  } catch (e) { warn('FR-cash', `failed (fail-soft): ${e.message}`); result.cash = { written: false, error: e.message }; }
 
   // ---- FR-2: AI burn ----
   try {

--- a/tests/unit/operator/cash-bank-feed.test.js
+++ b/tests/unit/operator/cash-bank-feed.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-EHG-OPERATOR-CASH-BANK-FEED-001 — FR-5/contract tests.
+ *
+ * Surfaces:
+ *  - stripe-balance.js: read-only available-USD slice, fail-soft, no write scope.
+ *  - token-vault.js: encrypt/decrypt round-trip (injected enc), inert load.
+ *  - bank-read-service.js: inert without a token; read-only when connected.
+ *  - never-in-gauge-path guard: the gauge module (cash-burn-substrate.js) must not
+ *    import any cash-source / vault module or reference the bank token.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readStripeCashSlice } from '../../../lib/operator/cash-sources/stripe-balance.js';
+import { encryptBankReadToken, decryptBankReadToken, loadBankReadToken } from '../../../lib/operator/cash-sources/token-vault.js';
+import { readBankCashSlice } from '../../../lib/operator/cash-sources/bank-read-service.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '../../..');
+
+describe('FR-3: Stripe cash slice (read-only, fail-soft)', () => {
+  it('sums available USD balance into a cash slice', async () => {
+    const stripeClient = { balance: { retrieve: vi.fn(async () => ({ available: [{ amount: 1234567, currency: 'usd' }, { amount: 9999, currency: 'eur' }] })) } };
+    const slice = await readStripeCashSlice({ stripeClient });
+    expect(slice).toEqual({ usd: 12345.67, source: 'stripe' }); // EUR excluded; cents→USD
+    expect(stripeClient.balance.retrieve).toHaveBeenCalledOnce();
+  });
+
+  it('returns a 0 slice when the account has no available USD (still a valid read)', async () => {
+    const stripeClient = { balance: { retrieve: vi.fn(async () => ({ available: [] })) } };
+    expect(await readStripeCashSlice({ stripeClient })).toEqual({ usd: 0, source: 'stripe' });
+  });
+
+  it('is fail-soft: returns null when the balance read throws', async () => {
+    const stripeClient = { balance: { retrieve: vi.fn(async () => { throw new Error('network'); }) } };
+    expect(await readStripeCashSlice({ stripeClient })).toBeNull();
+  });
+
+  it('uses ONLY balance.retrieve — never a charge/payout/transfer method (static)', () => {
+    const src = readFileSync(join(REPO_ROOT, 'lib/operator/cash-sources/stripe-balance.js'), 'utf8');
+    expect(src).toMatch(/balance\.retrieve\(\)/);
+    expect(src).not.toMatch(/\.(charges|payouts|transfers|refunds|paymentIntents)\b/);
+  });
+});
+
+describe('FR-1: token vault', () => {
+  // Injected fake enc — hermetic (no .leo-keys / filesystem).
+  // base64 stands in for the real AES-256-GCM enc — obscures the plaintext and round-trips.
+  const fakeEnc = {
+    encrypt: vi.fn(async (data, appId) => ({ encrypted: Buffer.from(JSON.stringify(data)).toString('base64'), metadata: { appId } })),
+    decrypt: vi.fn(async (blob) => JSON.parse(Buffer.from(String(blob), 'base64').toString('utf8'))),
+  };
+
+  it('round-trips a token without exposing plaintext in the blob', async () => {
+    const blob = await encryptBankReadToken('tok_secret_123', { enc: fakeEnc });
+    expect(blob.encrypted).not.toContain('tok_secret_123');
+    const back = await decryptBankReadToken(blob, { enc: fakeEnc });
+    expect(back).toBe('tok_secret_123');
+  });
+
+  it('rejects an empty token', async () => {
+    await expect(encryptBankReadToken('', { enc: fakeEnc })).rejects.toThrow(/non-empty/);
+  });
+
+  it('loadBankReadToken is silently inert (null, no warn) when no vault is enrolled', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const enc = { decryptAppCredentials: vi.fn(async () => { const e = new Error('ENOENT: no such file'); e.code = 'ENOENT'; throw e; }) };
+    expect(await loadBankReadToken({ enc })).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('loadBankReadToken warns (but stays null) on a genuine decrypt/tamper failure', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const enc = { decryptAppCredentials: vi.fn(async () => { throw new Error('Decryption failed: Unsupported state or unable to authenticate data'); }) };
+    expect(await loadBankReadToken({ enc })).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toMatch(/UNREADABLE/);
+    warn.mockRestore();
+  });
+});
+
+describe('FR-4: bank-read service is inert until enrollment', () => {
+  it('returns null and makes no connection when no token is vaulted', async () => {
+    const factory = vi.fn();
+    const slice = await readBankCashSlice({ loadToken: async () => null, tellerClientFactory: factory });
+    expect(slice).toBeNull();
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('returns null when a token exists but no read client is wired (still inert)', async () => {
+    expect(await readBankCashSlice({ loadToken: async () => 'tok' })).toBeNull();
+  });
+
+  it('reads USD balances read-only when connected', async () => {
+    const client = {
+      listAccounts: vi.fn(async () => [{ id: 'a1' }, { id: 'a2' }]),
+      getBalance: vi.fn(async (id) => ({ currency: 'USD', available: id === 'a1' ? 100 : 50 })),
+    };
+    const slice = await readBankCashSlice({ loadToken: async () => 'tok', tellerClientFactory: () => client });
+    expect(slice).toEqual({ usd: 150, other_burn_usd: null, source: 'bank' });
+  });
+});
+
+describe('contract: bank token never in the gauge code path', () => {
+  it('the gauge module does not import any cash-source/vault module or reference the token', () => {
+    const gauge = readFileSync(join(REPO_ROOT, 'lib/operator/cash-burn-substrate.js'), 'utf8');
+    expect(gauge).not.toMatch(/cash-sources/);
+    expect(gauge).not.toMatch(/token-vault|bank-read-service/);
+    expect(gauge).not.toMatch(/bank_read_token/);
+  });
+});


### PR DESCRIPTION
## Summary
Feeds real cash-on-hand into the operator distance-to-broke runway gauge so months-of-runway (cash / net-burn) renders honestly. The runway substrate (SD-EHG-OPERATOR-RUNWAY-SUBSTRATE-001) already provides the table, write helper, freshness, and `getDistanceToBroke()` — this SD adds the cash SOURCES under a hard read-only, chairman-gated contract.

## What shipped
- **`lib/operator/cash-sources/stripe-balance.js`** — read-only Stripe available-USD slice via the already-wired `getStripe()` (`balance.retrieve()` only; fail-soft). FR-3.
- **`lib/operator/cash-sources/token-vault.js`** — AES-256-GCM vault for the long-lived bank-READ token (over `lib/security/encryption.cjs`). Inert until enrolled; the token is never in the gauge/result/log path. FR-1.
- **`lib/operator/cash-sources/bank-read-service.js`** — Teller bank-read, INERT by default: no vaulted token means no connection. Read-only (account/balance reads only). FR-1/FR-4.
- **`scripts/operator/feed-operator-cash-burn.mjs`** — fail-soft cash step. The chairman-gated bank is the PRIMARY source; Stripe is an additive second slice. FR-2.
- **FR-5** renders automatically via the substrate's `getDistanceToBroke()` once cash is fresh.

## Chairman-gated / honest
The actual bank connection (enrolling an account) is a chairman-only action — this SD connects nothing. Until enrollment, cash stays unattested and the gauge honestly shows "awaiting cash source" rather than a false near-zero runway.

## Security / quality
- Read-only by construction (static test forbids charges/payouts/transfers); token never leaves the server-side service (static never-in-gauge-path guard).
- 12 unit tests pass. TESTING (`195b588a`) + SECURITY (`6f7727e3`) sub-agents PASS, 0 new findings.
- Adversarial review caught + fixed: a HIGH (empty/test-mode Stripe rendering a false "0 months of runway") via bank-primary/Stripe-additive; a MED (vault loader masking tamper as "not enrolled") via a missing-vs-tamper distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
