### PR TITLE
feat(SD-LEO-INFRA-CI-FAILURE-AUTOTRIAGE-LOOP-001): CI-failure auto-triage loop (detect→source DRAFT SD→link, no auto-fix)

### DIFF
--- a/.github/workflows/clockwork-ci-autotriage-loop.yml
+++ b/.github/workflows/clockwork-ci-autotriage-loop.yml
@@ -1,0 +1,44 @@
+name: "Clockwork: CI Auto-Triage Loop"
+
+# The missing MIDDLE of the CI-triage pipeline (SD-LEO-INFRA-CI-FAILURE-AUTOTRIAGE-LOOP-001):
+# turns recurring, NOT-yet-covered CI-failure classes into traceably-linked DRAFT corrective SDs.
+# Never edits code or merges (CONST-002); diagnosis happens when the DRAFT SD is worked.
+# Default OFF: the script skips unless CI_AUTOTRIAGE_LOOP_ENABLE=true (set the repo variable to opt in).
+# Runs at :50 — AFTER capture (:15), triage (:30) and self-heal resolve (:45) so it only sees
+# genuinely-recurring, unresolved, uncovered classes.
+
+on:
+  schedule:
+    - cron: '50 * * * *'
+  workflow_dispatch:
+    # Manual trigger for testing
+
+permissions:
+  actions: read
+
+jobs:
+  autotriage-loop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run CI Auto-Triage Loop (fail-soft; default OFF; --apply gated by the flag)
+        continue-on-error: true
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          # Default OFF — the script no-ops unless this repo variable is set to 'true'.
+          CI_AUTOTRIAGE_LOOP_ENABLE: ${{ vars.CI_AUTOTRIAGE_LOOP_ENABLE }}
+        run: node scripts/clockwork/ci-autotriage-loop.cjs --apply

--- a/scripts/clockwork/ci-autotriage-loop.cjs
+++ b/scripts/clockwork/ci-autotriage-loop.cjs
@@ -10,12 +10,14 @@
  * Flow each tick (fail-soft, flag-gated default OFF):
  *   1. fetch OPEN ci_failure rows (feedback category='ci_failure', status in new/triaged/in_progress
  *      — self-healed rows auto-resolve-recovered closed are status='resolved' and excluded)
- *   2. detect chronic, NOT-yet-covered classes (pure ci-recurrence-detector)
- *   3. cap per-run + per-day (anti-spam)
- *   4. per class: source ONE DRAFT corrective SD via the canonical leo-create-sd.js --from-feedback,
+ *   2. strip DEAD links (rows linked only to a cancelled/archived SD are treated as uncovered so a
+ *      stale link can't immortalize a recurring class)
+ *   3. detect chronic, NOT-yet-covered classes (pure ci-recurrence-detector)
+ *   4. cap per-run + per-day (anti-spam)
+ *   5. per class: source ONE DRAFT corrective SD via the canonical leo-create-sd.js --from-feedback,
+ *      read the created SD key back from the DB (authoritative — NOT scraped from stdout),
  *      tag metadata.sourced_by='ci-autotriage', and LINK the whole class to that SD
- *      (strategic_directive_id + resolution_sd_id, status='in_progress' — NOT resolved;
- *      mirrors the safe sd-from-feedback.js linkage so a still-failing class is never mislabeled).
+ *      (strategic_directive_id + resolution_sd_id, status='in_progress' — NOT resolved).
  *
  * Default DRY-RUN (like the sibling clockwork scripts). Pass --apply to write.
  * Gate: CI_AUTOTRIAGE_LOOP_ENABLE !== 'true' → [SKIP] exit 0.
@@ -31,11 +33,12 @@ const THRESHOLD = Number((args.find((a) => a.startsWith('--threshold=')) || '').
 const PER_RUN_CAP = Number((args.find((a) => a.startsWith('--per-run=')) || '').split('=')[1]) || undefined;
 const PER_DAY_CAP = Number((args.find((a) => a.startsWith('--per-day=')) || '').split('=')[1]) || undefined;
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TERMINAL_SD_STATUSES = ['cancelled', 'archived', 'superseded', 'rejected'];
 
 function log(...a) { console.log('[ci-autotriage-loop]', ...a); }
 
 async function main() {
-  // FR-6: flag-gated, default OFF. Fail-soft no-op when disabled.
+  // flag-gated, default OFF. Fail-soft no-op when disabled.
   if (process.env.CI_AUTOTRIAGE_LOOP_ENABLE !== 'true') {
     log('[SKIP] disabled (set CI_AUTOTRIAGE_LOOP_ENABLE=true to enable)');
     return;
@@ -53,15 +56,19 @@ async function main() {
     .select('id,status,error_hash,resolution_type,strategic_directive_id,resolution_sd_id,occurrence_count,created_at,error_message,metadata')
     .eq('category', 'ci_failure')
     .in('status', ['new', 'triaged', 'in_progress']);
-  if (error) { log('fetch failed (fail-soft):', error.message); return; }
+  if (error) { log('[ALERT] fetch failed (fail-soft):', error.message); return; }
   log(`open ci_failure rows: ${rows ? rows.length : 0}`);
 
-  // 2. detect chronic, uncovered classes.
+  // 2. strip DEAD links: a row whose only corrective link points at a terminal (cancelled/archived)
+  //    SD is treated as UNCOVERED so a stale link can't permanently suppress a still-recurring class.
+  await stripDeadLinks(db, rows || []);
+
+  // 3. detect chronic, uncovered classes.
   const threshold = THRESHOLD || DEFAULT_THRESHOLD;
   const candidates = detectChronicClasses(rows || [], { threshold });
   log(`chronic uncovered classes (threshold ${threshold}): ${candidates.length}`);
 
-  // 3. anti-spam caps: per-run + remaining per-day budget (count today's ci-autotriage SDs).
+  // 4. anti-spam caps: per-run + remaining per-day budget (count today's ci-autotriage SDs).
   const since = new Date(); since.setUTCHours(0, 0, 0, 0);
   let sourcedToday = 0;
   try {
@@ -71,7 +78,7 @@ async function main() {
       .eq('metadata->>sourced_by', 'ci-autotriage')
       .gte('created_at', since.toISOString());
     sourcedToday = count || 0;
-  } catch (e) { log('per-day count failed (fail-soft, assume 0):', e.message); }
+  } catch (e) { log('[ALERT] per-day count failed (fail-soft, assume 0):', e.message); }
   const capped = applyCaps(candidates, {
     perRunCap: PER_RUN_CAP || DEFAULT_PER_RUN_CAP,
     sourcedToday,
@@ -79,42 +86,83 @@ async function main() {
   });
   log(`sourcing this run: ${capped.length} (sourcedToday=${sourcedToday})${APPLY ? '' : ' [DRY-RUN]'}`);
 
-  // 4. per candidate, fail-soft: source a DRAFT SD + link the class.
+  // 5. per candidate, fail-soft: source a DRAFT SD + link the class.
   for (const c of capped) {
     try {
       log(`class ${c.classSignature} (${c.workflow_name || '?'}, x${c.occurrenceTotal}) rep=${c.representativeId}`);
       if (!APPLY) { log('  [DRY-RUN] would source a DRAFT corrective SD via --from-feedback + link the class'); continue; }
-      const sdKey = sourceDraftSd(c.representativeId);
-      if (!sdKey) { log('  could not source/parse SD key — skipping (fail-soft)'); continue; }
+      const sdKey = await sourceDraftSd(db, c.representativeId);
+      if (!sdKey) { log('  no NEW SD linked (duplicate-guard or create failed) — skipping (fail-soft)'); continue; }
       log(`  sourced DRAFT ${sdKey}`);
-      await tagSourcedBy(db, sdKey, c.classSignature);
+      const tagged = await tagSourcedBy(db, sdKey, c.classSignature);
+      if (!tagged) log(`  [ALERT] could not tag ${sdKey} sourced_by=ci-autotriage — per-day accounting may undercount`);
       await linkClass(db, c.rowIds, sdKey);
       log(`  linked ${c.rowIds.length} class row(s) → ${sdKey} (status in_progress, not resolved)`);
     } catch (e) {
-      log(`  class ${c.classSignature} failed (fail-soft):`, e.message);
+      log(`  [ALERT] class ${c.classSignature} failed (fail-soft):`, e.message);
     }
   }
 }
 
-/** Source a DRAFT corrective SD via the canonical CLI (never a hand-rolled insert). Returns the SD key or null. */
-function sourceDraftSd(feedbackId) {
-  const out = execFileSync('node', ['scripts/leo-create-sd.js', '--from-feedback', feedbackId, '--type', 'infrastructure'], {
-    cwd: REPO_ROOT,
-    encoding: 'utf8',
-    timeout: 120000,
-    env: { ...process.env, SD_CREATE_VIA_SKILL: '1' },
-  });
-  const m = out.match(/SD[- ]?Created:?\s*(SD-[A-Z0-9-]+)/i) || out.match(/\b(SD-[A-Z0-9][A-Z0-9-]+)\b/);
-  return m ? m[1] : null;
+/**
+ * Treat rows linked ONLY to a terminal (cancelled/archived/...) SD as uncovered, by clearing their
+ * in-memory link fields before detection. Prevents a dead link from immortalizing a recurring class.
+ */
+async function stripDeadLinks(db, rows) {
+  const keys = [...new Set(rows.map((r) => r.strategic_directive_id || r.resolution_sd_id).filter(Boolean))];
+  if (!keys.length) return;
+  const statusByKey = {};
+  try {
+    const { data } = await db.from('strategic_directives_v2').select('id,status').in('id', keys);
+    for (const sd of data || []) statusByKey[sd.id] = sd.status;
+  } catch (e) { log('[ALERT] dead-link status lookup failed (fail-soft, keep links):', e.message); return; }
+  let stripped = 0;
+  for (const r of rows) {
+    const link = r.strategic_directive_id || r.resolution_sd_id;
+    if (link && TERMINAL_SD_STATUSES.includes(statusByKey[link])) {
+      r.strategic_directive_id = null;
+      r.resolution_sd_id = null;
+      stripped++;
+    }
+  }
+  if (stripped) log(`stripped ${stripped} dead (terminal-SD) link(s) so stale links don't suppress recurring classes`);
+}
+
+/**
+ * Source a DRAFT corrective SD via the canonical CLI (never a hand-rolled insert), then read the
+ * created SD key back from the DB (feedback.strategic_directive_id — the authoritative value
+ * createFromFeedback writes) rather than scraping stdout. Returns the NEW SD key, or null when the
+ * spawn created nothing new (e.g. the --from-feedback duplicate guard fired) — never a foreign key.
+ */
+async function sourceDraftSd(db, feedbackId) {
+  // pre-read the rep row's link (the detector should have excluded covered classes, so expect null).
+  const { data: before } = await db.from('feedback').select('strategic_directive_id').eq('id', feedbackId).maybeSingle();
+  const beforeLink = before ? before.strategic_directive_id : null;
+  try {
+    execFileSync('node', ['scripts/leo-create-sd.js', '--from-feedback', feedbackId, '--type', 'infrastructure'], {
+      cwd: REPO_ROOT, encoding: 'utf8', timeout: 120000, env: { ...process.env, SD_CREATE_VIA_SKILL: '1' },
+    });
+  } catch (e) {
+    log('  [ALERT] leo-create-sd --from-feedback failed:', (e.message || '').split('\n')[0]);
+    return null;
+  }
+  // authoritative: re-read the link createFromFeedback wrote; only accept a NEW, changed value.
+  const { data: after } = await db.from('feedback').select('strategic_directive_id').eq('id', feedbackId).maybeSingle();
+  const afterLink = after ? after.strategic_directive_id : null;
+  if (afterLink && afterLink !== beforeLink) return afterLink;
+  return null; // duplicate-guard hit or no link written — do not tag/relink a pre-existing/foreign SD
 }
 
 async function tagSourcedBy(db, sdKey, classSignature) {
-  const { data: sd } = await db.from('strategic_directives_v2').select('id,metadata').eq('sd_key', sdKey).maybeSingle();
-  if (!sd) return;
-  const md = sd.metadata || {};
-  md.sourced_by = 'ci-autotriage';
-  md.ci_class_signature = classSignature;
-  await db.from('strategic_directives_v2').update({ metadata: md }).eq('id', sd.id);
+  try {
+    const { data: sd } = await db.from('strategic_directives_v2').select('id,metadata').eq('id', sdKey).maybeSingle();
+    if (!sd) return false;
+    const md = sd.metadata || {};
+    md.sourced_by = 'ci-autotriage';
+    md.ci_class_signature = classSignature;
+    const { error } = await db.from('strategic_directives_v2').update({ metadata: md }).eq('id', sd.id);
+    return !error;
+  } catch { return false; }
 }
 
 /** Link every still-open row in the class to the corrective SD — status stays in_progress (NOT resolved). */
@@ -126,4 +174,4 @@ async function linkClass(db, rowIds, sdKey) {
     .neq('status', 'resolved');
 }
 
-main().then(() => process.exit(0)).catch((e) => { console.error('[ci-autotriage-loop] fatal (fail-soft):', e.message); process.exit(0); });
+main().then(() => process.exit(0)).catch((e) => { console.error('[ci-autotriage-loop] [ALERT] fatal (fail-soft):', e.message); process.exit(0); });

--- a/scripts/clockwork/ci-autotriage-loop.cjs
+++ b/scripts/clockwork/ci-autotriage-loop.cjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * ci-autotriage-loop — the missing MIDDLE of the CI-triage pipeline.
+ * SD-LEO-INFRA-CI-FAILURE-AUTOTRIAGE-LOOP-001.
+ *
+ * Turns recurring CI failures into traceably-linked DRAFT corrective SDs WITHOUT
+ * ever editing code or merging (CONST-002 — corrective work flows through the normal
+ * gated SD/QF pipeline; diagnosis happens when a worker picks the DRAFT SD up, NOT here).
+ *
+ * Flow each tick (fail-soft, flag-gated default OFF):
+ *   1. fetch OPEN ci_failure rows (feedback category='ci_failure', status in new/triaged/in_progress
+ *      — self-healed rows auto-resolve-recovered closed are status='resolved' and excluded)
+ *   2. detect chronic, NOT-yet-covered classes (pure ci-recurrence-detector)
+ *   3. cap per-run + per-day (anti-spam)
+ *   4. per class: source ONE DRAFT corrective SD via the canonical leo-create-sd.js --from-feedback,
+ *      tag metadata.sourced_by='ci-autotriage', and LINK the whole class to that SD
+ *      (strategic_directive_id + resolution_sd_id, status='in_progress' — NOT resolved;
+ *      mirrors the safe sd-from-feedback.js linkage so a still-failing class is never mislabeled).
+ *
+ * Default DRY-RUN (like the sibling clockwork scripts). Pass --apply to write.
+ * Gate: CI_AUTOTRIAGE_LOOP_ENABLE !== 'true' → [SKIP] exit 0.
+ */
+require('dotenv/config');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const { createClient } = require('@supabase/supabase-js');
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const THRESHOLD = Number((args.find((a) => a.startsWith('--threshold=')) || '').split('=')[1]) || undefined;
+const PER_RUN_CAP = Number((args.find((a) => a.startsWith('--per-run=')) || '').split('=')[1]) || undefined;
+const PER_DAY_CAP = Number((args.find((a) => a.startsWith('--per-day=')) || '').split('=')[1]) || undefined;
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function log(...a) { console.log('[ci-autotriage-loop]', ...a); }
+
+async function main() {
+  // FR-6: flag-gated, default OFF. Fail-soft no-op when disabled.
+  if (process.env.CI_AUTOTRIAGE_LOOP_ENABLE !== 'true') {
+    log('[SKIP] disabled (set CI_AUTOTRIAGE_LOOP_ENABLE=true to enable)');
+    return;
+  }
+  const db = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+  const { detectChronicClasses, applyCaps, DEFAULT_THRESHOLD, DEFAULT_PER_RUN_CAP, DEFAULT_PER_DAY_CAP } =
+    await import('../lib/ci-recurrence-detector.mjs');
+
+  // 1. open ci_failure rows (resolved/self-healed rows are status='resolved' → excluded here).
+  const { data: rows, error } = await db
+    .from('feedback')
+    .select('id,status,error_hash,resolution_type,strategic_directive_id,resolution_sd_id,occurrence_count,created_at,error_message,metadata')
+    .eq('category', 'ci_failure')
+    .in('status', ['new', 'triaged', 'in_progress']);
+  if (error) { log('fetch failed (fail-soft):', error.message); return; }
+  log(`open ci_failure rows: ${rows ? rows.length : 0}`);
+
+  // 2. detect chronic, uncovered classes.
+  const threshold = THRESHOLD || DEFAULT_THRESHOLD;
+  const candidates = detectChronicClasses(rows || [], { threshold });
+  log(`chronic uncovered classes (threshold ${threshold}): ${candidates.length}`);
+
+  // 3. anti-spam caps: per-run + remaining per-day budget (count today's ci-autotriage SDs).
+  const since = new Date(); since.setUTCHours(0, 0, 0, 0);
+  let sourcedToday = 0;
+  try {
+    const { count } = await db
+      .from('strategic_directives_v2')
+      .select('id', { count: 'exact', head: true })
+      .eq('metadata->>sourced_by', 'ci-autotriage')
+      .gte('created_at', since.toISOString());
+    sourcedToday = count || 0;
+  } catch (e) { log('per-day count failed (fail-soft, assume 0):', e.message); }
+  const capped = applyCaps(candidates, {
+    perRunCap: PER_RUN_CAP || DEFAULT_PER_RUN_CAP,
+    sourcedToday,
+    perDayCap: PER_DAY_CAP || DEFAULT_PER_DAY_CAP,
+  });
+  log(`sourcing this run: ${capped.length} (sourcedToday=${sourcedToday})${APPLY ? '' : ' [DRY-RUN]'}`);
+
+  // 4. per candidate, fail-soft: source a DRAFT SD + link the class.
+  for (const c of capped) {
+    try {
+      log(`class ${c.classSignature} (${c.workflow_name || '?'}, x${c.occurrenceTotal}) rep=${c.representativeId}`);
+      if (!APPLY) { log('  [DRY-RUN] would source a DRAFT corrective SD via --from-feedback + link the class'); continue; }
+      const sdKey = sourceDraftSd(c.representativeId);
+      if (!sdKey) { log('  could not source/parse SD key — skipping (fail-soft)'); continue; }
+      log(`  sourced DRAFT ${sdKey}`);
+      await tagSourcedBy(db, sdKey, c.classSignature);
+      await linkClass(db, c.rowIds, sdKey);
+      log(`  linked ${c.rowIds.length} class row(s) → ${sdKey} (status in_progress, not resolved)`);
+    } catch (e) {
+      log(`  class ${c.classSignature} failed (fail-soft):`, e.message);
+    }
+  }
+}
+
+/** Source a DRAFT corrective SD via the canonical CLI (never a hand-rolled insert). Returns the SD key or null. */
+function sourceDraftSd(feedbackId) {
+  const out = execFileSync('node', ['scripts/leo-create-sd.js', '--from-feedback', feedbackId, '--type', 'infrastructure'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 120000,
+    env: { ...process.env, SD_CREATE_VIA_SKILL: '1' },
+  });
+  const m = out.match(/SD[- ]?Created:?\s*(SD-[A-Z0-9-]+)/i) || out.match(/\b(SD-[A-Z0-9][A-Z0-9-]+)\b/);
+  return m ? m[1] : null;
+}
+
+async function tagSourcedBy(db, sdKey, classSignature) {
+  const { data: sd } = await db.from('strategic_directives_v2').select('id,metadata').eq('sd_key', sdKey).maybeSingle();
+  if (!sd) return;
+  const md = sd.metadata || {};
+  md.sourced_by = 'ci-autotriage';
+  md.ci_class_signature = classSignature;
+  await db.from('strategic_directives_v2').update({ metadata: md }).eq('id', sd.id);
+}
+
+/** Link every still-open row in the class to the corrective SD — status stays in_progress (NOT resolved). */
+async function linkClass(db, rowIds, sdKey) {
+  await db
+    .from('feedback')
+    .update({ strategic_directive_id: sdKey, resolution_sd_id: sdKey, status: 'in_progress' })
+    .in('id', rowIds)
+    .neq('status', 'resolved');
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('[ci-autotriage-loop] fatal (fail-soft):', e.message); process.exit(0); });

--- a/scripts/lib/ci-recurrence-detector.mjs
+++ b/scripts/lib/ci-recurrence-detector.mjs
@@ -1,0 +1,98 @@
+/**
+ * CI-failure recurrence detector (pure, no IO).
+ * SD-LEO-INFRA-CI-FAILURE-AUTOTRIAGE-LOOP-001 (FR-1/FR-5).
+ *
+ * Given the OPEN ci_failure rows (feedback rows, category='ci_failure', already
+ * filtered by the caller to status IN ('new','triaged','in_progress') — which
+ * structurally excludes the self-healed rows auto-resolve-recovered closes), this
+ * clusters them by class signature and returns the chronic, NOT-yet-covered classes
+ * that warrant a DRAFT corrective SD. It never decides to fix anything — it only
+ * identifies which recurring failure CLASSES need a work item sourced.
+ *
+ * Class signature: the upstream error_hash (SHA256(workflow_name:branch)) IS the
+ * stable per-class key gh-failure-monitor already computes; fall back to
+ * repo:workflow_name when error_hash is absent.
+ */
+
+export const DEFAULT_THRESHOLD = 3;
+export const DEFAULT_PER_RUN_CAP = 3;
+export const DEFAULT_PER_DAY_CAP = 10;
+
+// Resolution types auto-resolve-recovered sets on self-healed rows — never source these.
+const SELF_HEAL_RESOLUTION_TYPES = ['auto_resolved', 'pr_merged_moot', 'workflow_unhealthy'];
+
+export function classSignature(row) {
+  const meta = (row && row.metadata) || {};
+  if (row && row.error_hash) return String(row.error_hash);
+  return `${meta.repo || '?'}:${meta.workflow_name || '?'}`;
+}
+
+/** A row is self-healed/resolved if it is already resolved or carries a self-heal resolution_type. */
+export function isSelfHealedOrResolved(row) {
+  if (!row) return false;
+  if (row.status === 'resolved') return true;
+  return SELF_HEAL_RESOLUTION_TYPES.includes(row.resolution_type);
+}
+
+/** A row is already covered if it links to a corrective SD (either linkage column). */
+export function isCovered(row) {
+  return Boolean(row && (row.strategic_directive_id || row.resolution_sd_id));
+}
+
+/**
+ * Cluster open ci_failure rows into chronic, uncovered candidate classes.
+ * @param {Array} rows - feedback rows (caller pre-filters to open ci_failure)
+ * @param {{threshold?:number}} opts
+ * @returns {Array<{classSignature, representativeId, rowIds, occurrenceTotal, workflow_name, repo, sampleError}>}
+ */
+export function detectChronicClasses(rows, { threshold = DEFAULT_THRESHOLD } = {}) {
+  const groups = new Map();
+  for (const row of rows || []) {
+    if (isSelfHealedOrResolved(row)) continue; // belt-and-suspenders vs the status pre-filter
+    const sig = classSignature(row);
+    if (!groups.has(sig)) groups.set(sig, []);
+    groups.get(sig).push(row);
+  }
+
+  const candidates = [];
+  for (const [sig, classRows] of groups) {
+    // Covered if ANY row in the class already links to a corrective SD → never double-source.
+    if (classRows.some(isCovered)) continue;
+    // Chronic by total occurrences (occurrence_count already dedups repeat failures per row).
+    const occurrenceTotal = classRows.reduce((n, r) => n + (Number(r.occurrence_count) || 1), 0);
+    if (occurrenceTotal < threshold) continue;
+    // Representative = oldest row (stable, deterministic).
+    const rep = classRows.slice().sort(
+      (a, b) => new Date(a.created_at || 0) - new Date(b.created_at || 0)
+    )[0];
+    const meta = (rep && rep.metadata) || {};
+    candidates.push({
+      classSignature: sig,
+      representativeId: rep.id,
+      rowIds: classRows.map((r) => r.id),
+      occurrenceTotal,
+      workflow_name: meta.workflow_name || null,
+      repo: meta.repo || null,
+      sampleError: rep.error_message || null,
+    });
+  }
+
+  // Deterministic: most-recurring class first, then by signature.
+  candidates.sort(
+    (a, b) =>
+      b.occurrenceTotal - a.occurrenceTotal ||
+      (a.classSignature < b.classSignature ? -1 : a.classSignature > b.classSignature ? 1 : 0)
+  );
+  return candidates;
+}
+
+/**
+ * Anti-spam cap: never source more than perRunCap this run, nor exceed perDayCap across the day.
+ * @param {Array} candidates - from detectChronicClasses (already sorted by priority)
+ * @param {{perRunCap?:number, sourcedToday?:number, perDayCap?:number}} opts
+ */
+export function applyCaps(candidates, { perRunCap = DEFAULT_PER_RUN_CAP, sourcedToday = 0, perDayCap = DEFAULT_PER_DAY_CAP } = {}) {
+  const remainingDay = Math.max(0, perDayCap - (Number(sourcedToday) || 0));
+  const limit = Math.min(perRunCap, remainingDay);
+  return (candidates || []).slice(0, Math.max(0, limit));
+}

--- a/tests/unit/ci-recurrence-detector.test.js
+++ b/tests/unit/ci-recurrence-detector.test.js
@@ -1,0 +1,122 @@
+/**
+ * SD-LEO-INFRA-CI-FAILURE-AUTOTRIAGE-LOOP-001
+ * Pure tests for the CI-failure recurrence detector: it flags only chronic, OPEN,
+ * NOT-yet-covered failure classes for DRAFT corrective sourcing — excluding self-healed
+ * and already-covered classes, and respecting the anti-spam caps.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  detectChronicClasses,
+  applyCaps,
+  classSignature,
+  isSelfHealedOrResolved,
+  isCovered,
+  DEFAULT_THRESHOLD,
+} from '../../scripts/lib/ci-recurrence-detector.mjs';
+
+const row = (over = {}) => ({
+  id: over.id || 'fb-' + Math.round((over._n || 1) * 1000),
+  status: 'new',
+  error_hash: 'hashA',
+  resolution_type: null,
+  strategic_directive_id: null,
+  resolution_sd_id: null,
+  occurrence_count: 1,
+  created_at: '2026-06-19T00:00:00Z',
+  error_message: 'workflow X failed',
+  metadata: { repo: 'rickfelix/EHG_Engineer', workflow_name: 'CI', branch: 'feat/x' },
+  ...over,
+});
+
+describe('classSignature', () => {
+  it('uses error_hash when present', () => {
+    expect(classSignature(row({ error_hash: 'h1' }))).toBe('h1');
+  });
+  it('falls back to repo:workflow_name when no error_hash', () => {
+    expect(classSignature(row({ error_hash: null }))).toBe('rickfelix/EHG_Engineer:CI');
+  });
+});
+
+describe('isSelfHealedOrResolved / isCovered', () => {
+  it('treats resolved + self-heal resolution_types as self-healed', () => {
+    expect(isSelfHealedOrResolved(row({ status: 'resolved' }))).toBe(true);
+    expect(isSelfHealedOrResolved(row({ resolution_type: 'auto_resolved' }))).toBe(true);
+    expect(isSelfHealedOrResolved(row({ resolution_type: 'pr_merged_moot' }))).toBe(true);
+    expect(isSelfHealedOrResolved(row({ resolution_type: 'workflow_unhealthy' }))).toBe(true);
+    expect(isSelfHealedOrResolved(row())).toBe(false);
+  });
+  it('treats either linkage column as covered', () => {
+    expect(isCovered(row({ strategic_directive_id: 'SD-X' }))).toBe(true);
+    expect(isCovered(row({ resolution_sd_id: 'SD-Y' }))).toBe(true);
+    expect(isCovered(row())).toBe(false);
+  });
+});
+
+describe('detectChronicClasses', () => {
+  it('flags a chronic, open, uncovered class (occurrence_count sums to >= threshold)', () => {
+    const rows = [
+      row({ id: 'a', error_hash: 'hChronic', occurrence_count: 2 }),
+      row({ id: 'b', error_hash: 'hChronic', occurrence_count: 2 }),
+    ];
+    const out = detectChronicClasses(rows, { threshold: 3 });
+    expect(out).toHaveLength(1);
+    expect(out[0].classSignature).toBe('hChronic');
+    expect(out[0].occurrenceTotal).toBe(4);
+    expect(out[0].rowIds.sort()).toEqual(['a', 'b']);
+    expect(out[0].representativeId).toBeDefined();
+  });
+
+  it('excludes a below-threshold (transient) class', () => {
+    const rows = [row({ id: 'a', error_hash: 'hLow', occurrence_count: 1 })];
+    expect(detectChronicClasses(rows, { threshold: 3 })).toHaveLength(0);
+  });
+
+  it('excludes a self-healed class even above threshold', () => {
+    const rows = [
+      row({ id: 'a', error_hash: 'hHeal', occurrence_count: 5, resolution_type: 'auto_resolved' }),
+    ];
+    expect(detectChronicClasses(rows, { threshold: 3 })).toHaveLength(0);
+  });
+
+  it('excludes a class already covered by a corrective SD (no double-source)', () => {
+    const rows = [
+      row({ id: 'a', error_hash: 'hCov', occurrence_count: 5, strategic_directive_id: 'SD-OPEN-1' }),
+      row({ id: 'b', error_hash: 'hCov', occurrence_count: 5 }),
+    ];
+    expect(detectChronicClasses(rows, { threshold: 3 })).toHaveLength(0);
+  });
+
+  it('picks the oldest row as the representative', () => {
+    const rows = [
+      row({ id: 'new', error_hash: 'hRep', occurrence_count: 2, created_at: '2026-06-19T10:00:00Z' }),
+      row({ id: 'old', error_hash: 'hRep', occurrence_count: 2, created_at: '2026-06-19T01:00:00Z' }),
+    ];
+    expect(detectChronicClasses(rows, { threshold: 3 })[0].representativeId).toBe('old');
+  });
+
+  it('orders candidates by occurrenceTotal desc (most-recurring first)', () => {
+    const rows = [
+      row({ id: 'a', error_hash: 'hSmall', occurrence_count: 3 }),
+      row({ id: 'b', error_hash: 'hBig', occurrence_count: 9 }),
+    ];
+    const out = detectChronicClasses(rows, { threshold: 3 });
+    expect(out.map((c) => c.classSignature)).toEqual(['hBig', 'hSmall']);
+  });
+
+  it('default threshold is a small positive integer', () => {
+    expect(DEFAULT_THRESHOLD).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('applyCaps (anti-spam)', () => {
+  const cands = [1, 2, 3, 4, 5].map((n) => ({ classSignature: 'c' + n }));
+  it('caps to perRunCap', () => {
+    expect(applyCaps(cands, { perRunCap: 2, sourcedToday: 0, perDayCap: 10 })).toHaveLength(2);
+  });
+  it('respects remaining per-day budget', () => {
+    expect(applyCaps(cands, { perRunCap: 5, sourcedToday: 9, perDayCap: 10 })).toHaveLength(1);
+  });
+  it('returns nothing when the day cap is exhausted', () => {
+    expect(applyCaps(cands, { perRunCap: 5, sourcedToday: 10, perDayCap: 10 })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Builds the missing **middle** of the CI-triage pipeline: a fail-soft, flag-gated (**default OFF**), scheduled loop that turns recurring CI-failure **classes** into traceably-linked **DRAFT** corrective SDs — **without ever editing code or merging** (CONST-002; diagnosis happens when a worker picks the DRAFT SD up, not in-cron).

Pipeline today: capture (`gh-failure-monitor`) → classify (`auto-triage`) → self-heal resolve (`auto-resolve-recovered`). This adds: **detect chronic class → source DRAFT corrective SD → link the class**.

## What it does (grounded against live)
- **Store:** `feedback` table (category='ci_failure'); `error_hash`=SHA256(workflow_name:branch) is the class signature; `occurrence_count` dedups.
- **FR-1 detector** (`scripts/lib/ci-recurrence-detector.mjs`, pure, 14 unit tests): clusters open rows (status new/triaged/in_progress — self-healed are status=resolved, excluded), flags chronic (occurrence ≥ threshold) classes **not already covered**.
- **FR-2:** diagnosis is **deferred** to the worked SD (a GH-Actions cron can't run a Claude agent; the DRAFT SD carries failure context). CONST-002 preserved.
- **FR-3/4:** sources ONE DRAFT SD via the canonical `leo-create-sd.js --from-feedback` (tagged `metadata.sourced_by='ci-autotriage'`) and links the whole class (`strategic_directive_id`+`resolution_sd_id`, `status='in_progress'` — **not** resolved; verified constraint-safe).
- **FR-5 anti-spam:** dedup by class signature, skip-if-covered, threshold, per-run/per-day caps.
- **FR-6:** fail-soft hourly cron at :50 (after capture/triage/resolve), continue-on-error, default-OFF via `CI_AUTOTRIAGE_LOOP_ENABLE` repo variable.

## Verification
- Detector unit tests 14/14.
- Default-OFF → `[SKIP]`; flag-on dry-run runs end-to-end (0 open ci_failure rows today → clean no-op). Dry-run default; `--apply` to write.
- Adversarial review caught + fixed 3 orchestrator bugs the pure tests couldn't: SD-key was stdout-scraped (primary regex never matched; loose fallback could grab a foreign key from the duplicate-guard line) → now **re-reads `feedback.strategic_directive_id` from the DB** (authoritative); guarded `tagSourcedBy` + `[ALERT]` logs; `stripDeadLinks` so a stale cancelled-SD link can't immortalize a recurring class. (resolution_sd_id-with-in_progress and the double-link verified SAFE.)
- TESTING sub-agent PASS (row b69e06ed); handoffs 94/95/94/96.

Single-repo EHG_Engineer; no schema/migration (link columns already exist). Shipped as one cohesive SD (decomposition advisory; the 6 FRs form one coupled loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)