### PR TITLE
feat(SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001): action-time DB-validated Adam + coordinator adherence

### DIFF
--- a/lib/adam/action-time-adherence.mjs
+++ b/lib/adam/action-time-adherence.mjs
@@ -1,0 +1,84 @@
+/**
+ * action-time-adherence.mjs — SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-2).
+ *
+ * Runs the CARDINAL Adam adherence probes at ACTION-TIME (per-tick / pre-advisory-send), not only
+ * in the 6h retrospective audit, and records a DB-validated verdict to adam_adherence_ledger —
+ * but ONLY on a verdict transition (dedupe-on-change), so steady-state PASS ticks write nothing.
+ *
+ * Cardinal safety contract (per VALIDATION): flag-gated (default-OFF), FAIL-OPEN, WARN-only —
+ * this MUST NEVER block Adam's tick or an advisory send. Any error degrades to a no-op + warn.
+ */
+import { randomUUID } from 'node:crypto';
+import { runCardinalProbes, decideLedgerWrites } from './adherence-probes.js';
+
+/** Is the action-time check enabled? Default-OFF; mirror the COORD_ADAM_ACTION_ACK_V1 flag style. */
+export function isActionTimeAdherenceEnabled(env = process.env) {
+  return String(env?.ADAM_ACTION_TIME_ADHERENCE_V1 ?? '').trim().toLowerCase() === 'on';
+}
+
+/**
+ * PURE — fetch the latest verdict-by-probe map from a list of recent ledger rows (newest first).
+ * Used to dedupe-on-change. Returns { probe: verdict } from the most recent row per probe.
+ * @param {Array<{probe:string, verdict:string, created_at?:string}>} rows
+ */
+export function latestVerdictsByProbe(rows = []) {
+  const out = {};
+  for (const r of rows || []) {
+    if (r && r.probe && !(r.probe in out)) out[r.probe] = r.verdict;
+  }
+  return out;
+}
+
+/**
+ * IO — run the cardinal probes over resolved facts and record ONLY changed verdicts. Fail-open:
+ * returns a result summary and NEVER throws (any error → { ok:false, recorded:0, warn }).
+ *
+ * @param {object} deps
+ * @param {object} deps.supabase - service-role client (from()/select()/insert())
+ * @param {object} deps.facts - resolved cardinal-probe facts (claimableBelt, idleWorkers, sourceableBacklogCount, advisoryBody, adamAuthoredBuildsInWindow)
+ * @param {function} [deps.recordAdherence] - the canonical ledger writer (supabase, runId, bar) — injectable for tests
+ * @param {boolean} [deps.enabled] - override the flag (defaults to isActionTimeAdherenceEnabled())
+ * @param {function} [deps.warn] - warn sink (default console.warn)
+ * @returns {Promise<{ok:boolean, recorded:number, bars:Array, warn?:string}>}
+ */
+export async function recordActionTimeAdherence({ supabase, facts = {}, recordAdherence, enabled, warn = console.warn } = {}) {
+  try {
+    if (!(enabled ?? isActionTimeAdherenceEnabled())) return { ok: true, recorded: 0, bars: [], skipped: 'flag-off' };
+    if (!supabase || typeof supabase.from !== 'function' || typeof recordAdherence !== 'function') {
+      warn?.('[adam-action-time-adherence] missing supabase/recordAdherence — skipping (fail-open)');
+      return { ok: false, recorded: 0, bars: [], warn: 'missing deps' };
+    }
+    const bars = runCardinalProbes(facts);
+
+    // Read recent ledger rows to dedupe on verdict change.
+    let prev = {};
+    try {
+      const { data } = await supabase
+        .from('adam_adherence_ledger')
+        .select('probe, verdict, created_at')
+        .order('created_at', { ascending: false })
+        .limit(60);
+      prev = latestVerdictsByProbe(data || []);
+    } catch (e) {
+      warn?.(`[adam-action-time-adherence] ledger read failed (fail-open, recording all): ${e?.message ?? e}`);
+    }
+
+    const toWrite = decideLedgerWrites(prev, bars);
+    if (toWrite.length === 0) return { ok: true, recorded: 0, bars };
+
+    const runId = randomUUID();
+    let recorded = 0;
+    for (const bar of toWrite) {
+      try { await recordAdherence(supabase, runId, bar); recorded += 1; }
+      catch (e) { warn?.(`[adam-action-time-adherence] ledger write failed for ${bar.probe} (fail-open): ${e?.message ?? e}`); }
+    }
+    // WARN-only surfacing of any action-time FAIL (never blocks).
+    const fails = bars.filter((b) => b.verdict === 'fail');
+    if (fails.length) warn?.(`[adam-action-time-adherence] WARN: ${fails.length} cardinal adherence FAIL(s): ${fails.map((f) => f.probe).join(', ')}`);
+    return { ok: true, recorded, bars };
+  } catch (e) {
+    // Cardinal fail-open: NEVER let an adherence check break the tick / send.
+    warn?.(`[adam-action-time-adherence] aborted (fail-open): ${e?.message ?? e}`);
+    return { ok: false, recorded: 0, bars: [], warn: String(e?.message ?? e) };
+  }
+}

--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -94,13 +94,93 @@ export function probeProposeOnly(facts = {}) {
     : bar('propose_only', duty, VERDICT.FAIL, `${builds} Adam-authored build(s) detected — CONST-002 propose-only violated`);
 }
 
+/**
+ * P5 — D1 belt-starvation. Governed duty (CONST-002 / D1): Adam sources gap-closing work BEFORE
+ * the claimable belt empties. Drift = the belt hit 0 WHILE workers sat idle AND a genuine
+ * (auto-capture-excluded) sourceable backlog still existed — the exact failure mode this session.
+ * Belt-empty alone is NOT a fail (it can be a legitimately drained queue); the FAIL requires all
+ * three: belt==0 AND idle>0 AND sourceableBacklog>0.
+ * @param {{ claimableBelt?: number|null, idleWorkers?: number|null, sourceableBacklogCount?: number|null }} facts
+ */
+export function probeBeltStarvation(facts = {}) {
+  const duty = 'belt-starvation: Adam sources before the claimable belt empties — belt=0 while workers idle and sourceable backlog exists is a sourcing failure (CONST-002 / D1)';
+  const belt = facts.claimableBelt;
+  const idle = facts.idleWorkers;
+  const backlog = facts.sourceableBacklogCount;
+  if (unresolved(belt) || !Number.isFinite(Number(belt))
+    || unresolved(idle) || !Number.isFinite(Number(idle))
+    || unresolved(backlog) || !Number.isFinite(Number(backlog))) {
+    return bar('belt_starvation', duty, VERDICT.UNKNOWN, 'claimableBelt/idleWorkers/sourceableBacklogCount unresolved — cannot confirm belt health (not a pass)');
+  }
+  const b = Number(belt), i = Number(idle), k = Number(backlog);
+  return (b === 0 && i > 0 && k > 0)
+    ? bar('belt_starvation', duty, VERDICT.FAIL, `belt=0 while ${i} worker(s) idle and ${k} sourceable backlog item(s) exist — sourcing starved the belt`)
+    : bar('belt_starvation', duty, VERDICT.PASS, `belt=${b}, idle=${i}, sourceable backlog=${k} — no starvation`);
+}
+
+/** Fleet-lifecycle / capacity-dispatch language Adam must never use (that is the coordinator's lane). */
+const DISPATCH_LANGUAGE = /\b(spin\s+(?:up|down)|stand\s+(?:up|down)\s+(?:a\s+)?worker|(?:assign|dispatch|deploy|reallocat\w*|add|remove)\s+(?:a\s+|the\s+)?workers?|scale\s+(?:the\s+)?fleet|reallocate\s+(?:the\s+)?fleet)\b/i;
+
+/**
+ * P6 — D2 dispatch-boundary. Governed duty (CONST-002 / D2): Adam NEVER directs fleet capacity
+ * (spin up/down, assign/dispatch/reallocate workers, scale the fleet) — that is the coordinator's
+ * lane. Drift = an Adam advisory whose body contains fleet-lifecycle/dispatch language.
+ * @param {{ advisoryBody?: string|null }} facts
+ */
+export function probeDispatchBoundary(facts = {}) {
+  const duty = 'dispatch-boundary: Adam never directs fleet capacity (spin up/down, assign/dispatch/reallocate workers) — that is the coordinator lane (CONST-002 / D2)';
+  const body = facts.advisoryBody;
+  if (unresolved(body)) {
+    return bar('dispatch_boundary', duty, VERDICT.UNKNOWN, 'advisoryBody unresolved — cannot confirm boundary (not a pass)');
+  }
+  const m = String(body).match(DISPATCH_LANGUAGE);
+  return m
+    ? bar('dispatch_boundary', duty, VERDICT.FAIL, `advisory body contains fleet-dispatch language ("${m[0]}") — Adam crossed into the coordinator's capacity lane`)
+    : bar('dispatch_boundary', duty, VERDICT.PASS, 'no fleet-dispatch language in the advisory body — boundary upheld');
+}
+
 /** The canonical probe set (each defined once). The review script (FR-3) resolves facts + runs these. */
 export const ADHERENCE_PROBES = Object.freeze([
   probeSourcingCadence,
   probeVisionMonitoring,
   probeFrictionSignaling,
   probeProposeOnly,
+  probeBeltStarvation,
+  probeDispatchBoundary,
 ]);
+
+/**
+ * The CARDINAL subset run at ACTION-TIME (per-tick + pre-advisory-send), not only in the 6h
+ * retrospective audit. Slow window-count dims (sourcing-cadence, vision-monitoring) stay in the
+ * retro audit; these three are cheap, fact-injectable, and the cardinal boundaries.
+ * SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-2).
+ */
+export const CARDINAL_ACTION_TIME_PROBES = Object.freeze([
+  probeBeltStarvation,
+  probeDispatchBoundary,
+  probeProposeOnly,
+]);
+
+/** Run only the cardinal action-time subset. PURE; same fail-open-to-unknown contract. */
+export function runCardinalProbes(facts = {}) {
+  return CARDINAL_ACTION_TIME_PROBES.map((p) => {
+    try { return p(facts); }
+    catch (e) { return bar(p.name || 'unknown_probe', 'unknown', VERDICT.UNKNOWN, `probe errored (fail-open to unknown): ${e?.message ?? e}`); }
+  });
+}
+
+/**
+ * FR-2 dedupe-on-change: given the PREVIOUS verdict-by-probe map and the CURRENT bars, return only
+ * the bars whose verdict CHANGED (or are newly seen). Steady-state PASS ticks therefore write
+ * NOTHING to the ledger — avoiding per-tick flood. PURE.
+ * @param {Object<string,string>} prevVerdicts - { probeKey: 'pass'|'fail'|'unknown' }
+ * @param {Array<{probe:string, verdict:string}>} currentBars
+ * @returns {Array} the subset of currentBars to record
+ */
+export function decideLedgerWrites(prevVerdicts = {}, currentBars = []) {
+  const prev = prevVerdicts || {};
+  return (currentBars || []).filter((b) => b && b.probe && prev[b.probe] !== b.verdict);
+}
 
 /**
  * Run all probes over a resolved-facts object. PURE. Returns one bar per probe; never throws — a

--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -118,8 +118,19 @@ export function probeBeltStarvation(facts = {}) {
     : bar('belt_starvation', duty, VERDICT.PASS, `belt=${b}, idle=${i}, sourceable backlog=${k} — no starvation`);
 }
 
-/** Fleet-lifecycle / capacity-dispatch language Adam must never use (that is the coordinator's lane). */
-const DISPATCH_LANGUAGE = /\b(spin\s+(?:up|down)|stand\s+(?:up|down)\s+(?:a\s+)?worker|(?:assign|dispatch|deploy|reallocat\w*|add|remove)\s+(?:a\s+|the\s+)?workers?|scale\s+(?:the\s+)?fleet|reallocate\s+(?:the\s+)?fleet)\b/i;
+/**
+ * Fleet-lifecycle / capacity-dispatch language Adam must never use (that is the coordinator's lane).
+ * Each clause is anchored on a FLEET NOUN (worker/fleet/session/loop/instance/agent/node) so that
+ * non-fleet prose like "spin up a research pass" or "assign a priority score" does NOT false-fire —
+ * only language that actually directs fleet capacity matches.
+ */
+const FLEET_NOUN = '(?:worker|fleet|session|loop|instance|agent|node)s?';
+const DISPATCH_LANGUAGE = new RegExp(
+  '\\b(' +
+    `(?:spin|stand)\\s+(?:up|down)\\s+(?:a\\s+|the\\s+|\\w+\\s+){0,3}${FLEET_NOUN}` +
+    `|(?:assign|dispatch|deploy|reallocat\\w*|add|remove)\\s+(?:a\\s+|the\\s+|\\w+\\s+){0,2}${FLEET_NOUN}` +
+    '|scale\\s+(?:up\\s+|down\\s+|the\\s+)?fleet' +
+  ')\\b', 'i');
 
 /**
  * P6 — D2 dispatch-boundary. Governed duty (CONST-002 / D2): Adam NEVER directs fleet capacity

--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -253,6 +253,51 @@ export function foundationalQueryError(error, table) {
   return `[COORD-CHARTER-AUDIT] QUERY_ERROR: ${table}: ${error.message || String(error)}`;
 }
 
+/**
+ * SOURCE-TO-CAPACITY handshake (SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 FR-3):
+ * when the claimable belt is low AND workers are idle, the coordinator must have actually REQUESTED
+ * work (pinged Adam to source) — belt-low + idle + no recent source request is a coordinator
+ * sourcing-handshake failure. `sourceRequestedRecently` is an injected fact (a recent
+ * coordinator_request / adam_advisory sourcing-ping row exists). Belt-low alone is NOT a violation.
+ * @param {{ claimableBelt?: number|null, idleWorkers?: number|null, sourceRequestedRecently?: boolean|null, beltLowThreshold?: number }} facts
+ */
+export function detectSourceToCapacity({ claimableBelt, idleWorkers, sourceRequestedRecently, beltLowThreshold = 1 } = {}) {
+  // Fail-loud: an unresolved input is reported, never silently treated as healthy.
+  if (claimableBelt == null || idleWorkers == null || sourceRequestedRecently == null) {
+    return { violation: true, detail: 'SOURCE-TO-CAPACITY inputs unresolved (belt/idle/sourceRequested) — cannot confirm the handshake (fail-loud)', remediation: 'ACTION: resolve the belt/idle/source-request facts before trusting the handshake' };
+  }
+  const beltLow = Number(claimableBelt) <= beltLowThreshold;
+  const idle = Number(idleWorkers) > 0;
+  const violation = beltLow && idle && sourceRequestedRecently !== true;
+  return {
+    violation,
+    detail: violation
+      ? `belt low (${claimableBelt}<=${beltLowThreshold}) + ${idleWorkers} idle worker(s) but NO recent coordinator source-request — sourcing handshake not initiated`
+      : `belt=${claimableBelt}, idle=${idleWorkers}, sourceRequestedRecently=${sourceRequestedRecently} — handshake ok`,
+    remediation: violation ? 'ACTION: ping Adam to source gap-closing SDs (belt-low source-to-capacity handshake)' : null,
+  };
+}
+
+/**
+ * D3-lean (FR-3): the coordinator should not run alone — Adam is its sourcing counterpart. A live
+ * coordinator session with NO live Adam session is a D3 structural gap. `coordinatorAlive` and
+ * `adamAlive` are injected liveness facts (from the session-role rows the host already loads).
+ * @param {{ coordinatorAlive?: boolean|null, adamAlive?: boolean|null }} facts
+ */
+export function detectCoordinatorWithoutAdam({ coordinatorAlive, adamAlive } = {}) {
+  if (coordinatorAlive == null || adamAlive == null) {
+    return { violation: true, detail: 'D3-lean inputs unresolved (coordinatorAlive/adamAlive) — cannot confirm pairing (fail-loud)', remediation: 'ACTION: resolve coordinator/Adam liveness before trusting the pairing' };
+  }
+  const violation = coordinatorAlive === true && adamAlive !== true;
+  return {
+    violation,
+    detail: violation
+      ? 'coordinator is live but NO live Adam session — running lean (D3 structural gap)'
+      : `coordinatorAlive=${coordinatorAlive}, adamAlive=${adamAlive} — pairing ok`,
+    remediation: violation ? 'ACTION: start/revive the Adam session so the coordinator has its sourcing counterpart' : null,
+  };
+}
+
 /** Collect violations (each with its remediation) from a list of detector results. */
 export function summarizeViolations(results = []) {
   const violations = results.filter((r) => r && r.violation).map((r) => ({ detail: r.detail, remediation: r.remediation || null }));

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -171,14 +171,11 @@ async function main() {
   let sourceReqRecently = null; // null ⇒ unresolved ⇒ skip the source-to-capacity detector this run
   try {
     const { data: recent, error: e } = await db.from('claude_sessions')
-      .select('session_id, callsign, metadata, heartbeat_at')
+      .select('session_id, metadata, heartbeat_at')
       .gte('heartbeat_at', new Date(nowMs - 15 * 60 * 1000).toISOString());
     if (!e) {
-      adamAlive = (recent || []).some((s) => {
-        const cs = String(s.callsign || '').toLowerCase();
-        const role = String(s?.metadata?.role || s?.metadata?.session_role || '').toLowerCase();
-        return cs.includes('adam') || role === 'adam';
-      });
+      // Adam's canonical marker is metadata.role === 'adam' (lib/fleet/genuine-worker.mjs).
+      adamAlive = (recent || []).some((s) => String(s?.metadata?.role || '').toLowerCase() === 'adam');
     }
   } catch { /* leave adamAlive null → skip */ }
   try {

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -30,6 +30,8 @@ import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
   extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectProgressStall,
+  // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3): coordinator mirror detectors.
+  detectSourceToCapacity, detectCoordinatorWithoutAdam,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
 // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: DUTY-7 silent-stall detector (drafts stranded with null vision_score).
 import { findStalledDrafts } from '../lib/coordinator/draft-stall-detector.mjs';
@@ -161,6 +163,39 @@ async function main() {
     .select('metadata,created_at').eq('category', 'coordinator_review').order('created_at', { ascending: false }).limit(2);
   if (revErr) console.error('[COORD-CHARTER-AUDIT] WARN: coordinator_review query failed (fail-open): ' + revErr.message);
 
+  // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3): resolve facts for the coordinator
+  // mirror detectors. Best-effort + skip-on-error (a transient query failure SKIPS the detector this
+  // run rather than passing null → a fail-loud violation, so we never spam violations on a DB hiccup).
+  const idleWorkerCount = (liveWorkers || []).filter((s) => s && !s.sd_key).length;
+  let adamAlive = null;       // null ⇒ unresolved ⇒ skip the D3-lean detector this run
+  let sourceReqRecently = null; // null ⇒ unresolved ⇒ skip the source-to-capacity detector this run
+  try {
+    const { data: recent, error: e } = await db.from('claude_sessions')
+      .select('session_id, callsign, metadata, heartbeat_at')
+      .gte('heartbeat_at', new Date(nowMs - 15 * 60 * 1000).toISOString());
+    if (!e) {
+      adamAlive = (recent || []).some((s) => {
+        const cs = String(s.callsign || '').toLowerCase();
+        const role = String(s?.metadata?.role || s?.metadata?.session_role || '').toLowerCase();
+        return cs.includes('adam') || role === 'adam';
+      });
+    }
+  } catch { /* leave adamAlive null → skip */ }
+  try {
+    // A recent coordinator→Adam sourcing handshake (belt-low source request). Best-effort proxy:
+    // a recent adam_advisory / coordinator sourcing ping in session_coordination within 30 min.
+    const { data: src, error: e } = await db.from('session_coordination')
+      .select('id, message_type, payload, created_at')
+      .gte('created_at', new Date(nowMs - 30 * 60 * 1000).toISOString())
+      .limit(200);
+    if (!e) {
+      sourceReqRecently = (src || []).some((m) => {
+        const blob = JSON.stringify(m || {}).toLowerCase();
+        return /source|sourcing|belt[-_ ]?low|capacity|gap[-_ ]?clos/.test(blob);
+      });
+    }
+  } catch { /* leave sourceReqRecently null → skip */ }
+
   // ── run the pure detectors ──
   const D = {
     pool: detectWorktreePool({ count: wtCount, max: MAX_WORKTREE_COUNT }),
@@ -168,6 +203,9 @@ async function main() {
     dep: detectDependencyHealth({ sds, statusByKey, terminalSet: TERMINAL, nowMs }),
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),
+    // FR-3 coordinator mirror — added only when their facts resolved (skip-on-error, no spam).
+    ...(adamAlive !== null ? { d3lean: detectCoordinatorWithoutAdam({ coordinatorAlive: true, adamAlive }) } : {}),
+    ...(sourceReqRecently !== null ? { srcCap: detectSourceToCapacity({ claimableBelt: claimable.length, idleWorkers: idleWorkerCount, sourceRequestedRecently: sourceReqRecently }) } : {}),
     // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: drafts stranded with a null vision_score (silent stall).
     // Advisory remediation count only — summarizeViolations never drives a process.exit (foundational-query
     // failures are the ONLY hard exits), so a stalled draft surfaces a remediation action, never a hard fail.
@@ -192,6 +230,9 @@ async function main() {
   console.log('  DUTY-7 DRAFT-STALL   : ' + D.draft.detail + flag(D.draft)); // SILENT-STALL-PREVENTION-001
   console.log('  DUTY-8 PROGRESS-STALL: ' + D.progress.detail + flag(D.progress)); // PROGRESS-STALL-DETECTION-001
   console.log('  DUTY-9 LEAD-AGING    : ' + D.leadAging.detail + flag(D.leadAging)); // ADAM-VISION-SD-FLOW-001
+  // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3) — coordinator mirror adherence.
+  if (D.srcCap) console.log('  SOURCE-TO-CAPACITY   : ' + D.srcCap.detail + flag(D.srcCap));
+  if (D.d3lean) console.log('  D3-LEAN (coord/Adam) : ' + D.d3lean.detail + flag(D.d3lean));
 
   // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: ADVISORY freshness dimension — fail-open and deliberately
   // kept OUT of `D`/summarizeViolations, so a stale checkout surfaces a warning but never trips the

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2296,6 +2296,40 @@ async function main() {
     console.log('ADAM_ACTION_ACK: ' + (aaErr && aaErr.message ? aaErr.message : 'unknown'));
   }
 
+  // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-2): run the CARDINAL Adam adherence
+  // probes at ACTION-TIME (per sweep tick) — not only the 6h retrospective audit — and record a
+  // DB-validated verdict to adam_adherence_ledger ONLY on a verdict transition (dedupe-on-change).
+  // Flag-gated (ADAM_ACTION_TIME_ADHERENCE_V1=on; default-OFF), FAIL-OPEN, WARN-only: it can NEVER
+  // block the sweep. Both modules are ESM, so dynamic-import them from this CJS sweep.
+  try {
+    const [{ recordActionTimeAdherence, isActionTimeAdherenceEnabled }, { recordAdherence }] = await Promise.all([
+      import('../lib/adam/action-time-adherence.mjs'),
+      import('./adam-self-adherence-review.mjs'),
+    ]);
+    if (isActionTimeAdherenceEnabled()) {
+      // Resolve the cheaply-available cardinal facts; the rest honestly degrade to 'unknown'.
+      let sourceableBacklogCount = null;
+      try {
+        const { sourceableBacklog } = await import('./lib/sourceable-backlog.mjs');
+        const { data: bl } = await supabase.from('feedback')
+          .select('id, status, title, metadata')
+          .eq('category', 'harness_backlog').in('status', ['open', 'new', 'backlog']);
+        sourceableBacklogCount = Array.isArray(bl) ? sourceableBacklog(bl).length : null;
+      } catch { /* unresolved → probe returns unknown (fail-loud) */ }
+      let advisoryBody = null;
+      try {
+        const { data: adv } = await supabase.from('chairman_decisions')
+          .select('decision').order('created_at', { ascending: false }).limit(1);
+        if (adv && adv[0]) advisoryBody = String(adv[0].decision || '');
+      } catch { /* unresolved → D2 unknown */ }
+      const facts = { sourceableBacklogCount, advisoryBody };
+      const res = await recordActionTimeAdherence({ supabase, facts, recordAdherence });
+      if (res && res.recorded > 0) console.log('  ADAM_ACTION_TIME_ADHERENCE: recorded ' + res.recorded + ' verdict transition(s)');
+    }
+  } catch (atErr) {
+    console.log('ADAM_ACTION_TIME_ADHERENCE: ' + (atErr && atErr.message ? atErr.message : 'unknown') + ' (fail-open)');
+  }
+
   // SD-LEO-INFRA-ADD-PART-MUTUAL-001 — 3-part mutual self-ID handshake housekeeping.
   // The reactive RESPONDER self-heal (a coordinator replying + re-registering its
   // is_coordinator flag) runs in COORDINATOR context (coordinator-comms-check.mjs); the

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2307,7 +2307,12 @@ async function main() {
       import('./adam-self-adherence-review.mjs'),
     ]);
     if (isActionTimeAdherenceEnabled()) {
-      // Resolve the cheaply-available cardinal facts; the rest honestly degrade to 'unknown'.
+      // The sweep tick's action-time check resolves the ADVISORY-BOUNDARY (D2) fact (the latest
+      // advisory body) — that is the pre-send boundary self-check. The belt-starvation (D1) and
+      // propose-only facts (claimableBelt/idleWorkers/adamAuthoredBuildsInWindow) are NOT cheaply
+      // available here, so those probes honestly degrade to 'unknown' in this path (never a silent
+      // pass). D1 belt-starvation is fully evaluated where belt/idle live: the 6h retrospective audit
+      // (adam-self-adherence-review) and the coordinator charter-audit's SOURCE-TO-CAPACITY detector.
       let sourceableBacklogCount = null;
       try {
         const { sourceableBacklog } = await import('./lib/sourceable-backlog.mjs');

--- a/tests/integration/adam-self-adherence-review.test.js
+++ b/tests/integration/adam-self-adherence-review.test.js
@@ -44,7 +44,7 @@ describe('runSelfAdherenceReview (FR-3/FR-6)', () => {
   it('a real run ledgers one row per probe (run_id grouped), unknowns => no remediation', async () => {
     const sb = makeSb();
     const r = await runSelfAdherenceReview(sb, { runId: 'run-1' });
-    expect(sb.inserts.adam_adherence_ledger).toHaveLength(4); // one per probe
+    expect(sb.inserts.adam_adherence_ledger).toHaveLength(6); // one per probe (4 original + 2 red-flag: belt-starvation, dispatch-boundary)
     expect(sb.inserts.adam_adherence_ledger.every((row) => row.run_id === 'run-1')).toBe(true);
     // current resolvers leave most facts null => unknown => no fail => no remediation
     expect(r.remediationRef).toBeNull();

--- a/tests/unit/adam/adherence-probes.test.js
+++ b/tests/unit/adam/adherence-probes.test.js
@@ -54,16 +54,16 @@ describe('FAIL-LOUD contract (FR-5): unresolved facts NEVER silent-pass', () => 
     const hostile = {};
     Object.defineProperty(hostile, 'sourcedInWindow', { get() { throw new Error('boom'); }, enumerable: true });
     const bars = runAdherenceProbes(hostile);
-    expect(bars).toHaveLength(4);
+    expect(bars).toHaveLength(6);
     expect(bars[0].verdict).toBe('unknown');
   });
 });
 
 describe('runAdherenceProbes + hasDrift', () => {
-  it('runs the full canonical probe set (4) with {probe,duty,verdict,detail} shape', () => {
-    expect(ADHERENCE_PROBES).toHaveLength(4);
-    const bars = runAdherenceProbes({ sourcedInWindow: 1, visionGaugeReadInWindow: true, recurrencesInWindow: 0, signalsInWindow: 0, adamAuthoredBuildsInWindow: 0 });
-    expect(bars).toHaveLength(4);
+  it('runs the full canonical probe set (6) with {probe,duty,verdict,detail} shape', () => {
+    expect(ADHERENCE_PROBES).toHaveLength(6);
+    const bars = runAdherenceProbes({ sourcedInWindow: 1, visionGaugeReadInWindow: true, recurrencesInWindow: 0, signalsInWindow: 0, adamAuthoredBuildsInWindow: 0, claimableBelt: 1, idleWorkers: 0, sourceableBacklogCount: 0, advisoryBody: 'ok' });
+    expect(bars).toHaveLength(6);
     for (const b of bars) {
       expect(typeof b.probe).toBe('string');
       expect(typeof b.duty).toBe('string');

--- a/tests/unit/adam/adherence-redflag-probes.test.js
+++ b/tests/unit/adam/adherence-redflag-probes.test.js
@@ -1,0 +1,149 @@
+/**
+ * SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 — Adam red-flag probes (FR-1) +
+ * action-time dedupe (FR-2). Proves the D1 belt-starvation + D2 dispatch-boundary probes
+ * PASS/FAIL/UNKNOWN (fail-loud on unresolved) and that ledger writes dedupe on verdict change.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  probeBeltStarvation,
+  probeDispatchBoundary,
+  decideLedgerWrites,
+  runCardinalProbes,
+  CARDINAL_ACTION_TIME_PROBES,
+  ADHERENCE_PROBES,
+} from '../../../lib/adam/adherence-probes.js';
+import {
+  recordActionTimeAdherence,
+  latestVerdictsByProbe,
+  isActionTimeAdherenceEnabled,
+} from '../../../lib/adam/action-time-adherence.mjs';
+
+/** Minimal supabase stub: from().select().order().limit() → resolves the seeded ledger rows. */
+function supabaseStub(ledgerRows) {
+  const q = {
+    select() { return q; }, order() { return q; },
+    limit() { return Promise.resolve({ data: ledgerRows, error: null }); },
+  };
+  return { from() { return q; } };
+}
+
+describe('probeBeltStarvation (D1, FR-1)', () => {
+  it('FAILs when belt=0 AND idle>0 AND sourceable backlog>0 (the exact session failure)', () => {
+    expect(probeBeltStarvation({ claimableBelt: 0, idleWorkers: 2, sourceableBacklogCount: 5 }).verdict).toBe('fail');
+  });
+  it('PASSes when the belt has work', () => {
+    expect(probeBeltStarvation({ claimableBelt: 3, idleWorkers: 2, sourceableBacklogCount: 5 }).verdict).toBe('pass');
+  });
+  it('PASSes when no workers are idle (belt-empty is legitimately drained)', () => {
+    expect(probeBeltStarvation({ claimableBelt: 0, idleWorkers: 0, sourceableBacklogCount: 5 }).verdict).toBe('pass');
+  });
+  it('PASSes when the backlog is empty (nothing to source)', () => {
+    expect(probeBeltStarvation({ claimableBelt: 0, idleWorkers: 2, sourceableBacklogCount: 0 }).verdict).toBe('pass');
+  });
+  it('UNKNOWN (fail-loud) when any input is unresolved', () => {
+    expect(probeBeltStarvation({ claimableBelt: null, idleWorkers: 2, sourceableBacklogCount: 5 }).verdict).toBe('unknown');
+    expect(probeBeltStarvation({ claimableBelt: 0, idleWorkers: undefined, sourceableBacklogCount: 5 }).verdict).toBe('unknown');
+    expect(probeBeltStarvation({}).verdict).toBe('unknown');
+  });
+});
+
+describe('probeDispatchBoundary (D2, FR-1)', () => {
+  it.each([
+    'we should spin down two workers',
+    'spin up a worker to cover the backlog',
+    'assign a worker to this SD',
+    'dispatch a worker now',
+    'reallocate the workers to track B',
+    'scale the fleet up',
+  ])('FAILs on fleet-dispatch language: "%s"', (body) => {
+    expect(probeDispatchBoundary({ advisoryBody: body }).verdict).toBe('fail');
+  });
+  it.each([
+    'the vision build-% gauge slipped; recommend sourcing a gap-closing SD',
+    'distance-to-quit is at $0 — income not yet instrumented',
+    'I assigned the venture a higher priority score',
+  ])('PASSes on a clean advisory body: "%s"', (body) => {
+    expect(probeDispatchBoundary({ advisoryBody: body }).verdict).toBe('pass');
+  });
+  it('UNKNOWN (fail-loud) when the body is unresolved', () => {
+    expect(probeDispatchBoundary({}).verdict).toBe('unknown');
+    expect(probeDispatchBoundary({ advisoryBody: null }).verdict).toBe('unknown');
+  });
+});
+
+describe('decideLedgerWrites — dedupe-on-change (FR-2)', () => {
+  it('writes on a verdict transition and on a newly-seen probe', () => {
+    const bars = [{ probe: 'belt_starvation', verdict: 'fail' }, { probe: 'dispatch_boundary', verdict: 'pass' }];
+    const out = decideLedgerWrites({ belt_starvation: 'pass' }, bars);
+    expect(out.map((b) => b.probe)).toEqual(['belt_starvation', 'dispatch_boundary']); // changed + new
+  });
+  it('writes NOTHING in steady state (no verdict change)', () => {
+    const bars = [{ probe: 'belt_starvation', verdict: 'pass' }, { probe: 'propose_only', verdict: 'pass' }];
+    const out = decideLedgerWrites({ belt_starvation: 'pass', propose_only: 'pass' }, bars);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('cardinal action-time subset (FR-2)', () => {
+  it('is exactly {belt-starvation, dispatch-boundary, propose-only}', () => {
+    expect(CARDINAL_ACTION_TIME_PROBES.map((p) => p.name)).toEqual([
+      'probeBeltStarvation', 'probeDispatchBoundary', 'probeProposeOnly',
+    ]);
+  });
+  it('runCardinalProbes returns one bar per cardinal probe (fail-open to unknown)', () => {
+    const bars = runCardinalProbes({}); // all unresolved
+    expect(bars).toHaveLength(3);
+    expect(bars.every((b) => b.verdict === 'unknown')).toBe(true);
+  });
+  it('the full ADHERENCE_PROBES set now includes the 2 new red-flag probes', () => {
+    const names = ADHERENCE_PROBES.map((p) => p.name);
+    expect(names).toContain('probeBeltStarvation');
+    expect(names).toContain('probeDispatchBoundary');
+  });
+});
+
+describe('recordActionTimeAdherence — FR-2 action-time IO (flag-gated, fail-open, dedupe)', () => {
+  const flagOn = (env) => isActionTimeAdherenceEnabled({ ADAM_ACTION_TIME_ADHERENCE_V1: 'on' }) || env;
+  it('is a no-op when the flag is off', async () => {
+    const writes = [];
+    const res = await recordActionTimeAdherence({
+      supabase: supabaseStub([]), facts: { claimableBelt: 0, idleWorkers: 2, sourceableBacklogCount: 5, advisoryBody: 'ok', adamAuthoredBuildsInWindow: 0 },
+      recordAdherence: async (_s, _r, bar) => writes.push(bar), enabled: false,
+    });
+    expect(res.recorded).toBe(0);
+    expect(writes).toHaveLength(0);
+  });
+  it('records ONLY changed verdicts on a transition (belt-starvation pass→fail)', async () => {
+    const writes = [];
+    const prevLedger = [{ probe: 'belt_starvation', verdict: 'pass' }, { probe: 'dispatch_boundary', verdict: 'pass' }, { probe: 'propose_only', verdict: 'pass' }];
+    const res = await recordActionTimeAdherence({
+      supabase: supabaseStub(prevLedger),
+      facts: { claimableBelt: 0, idleWorkers: 2, sourceableBacklogCount: 5, advisoryBody: 'clean body', adamAuthoredBuildsInWindow: 0 },
+      recordAdherence: async (_s, _r, bar) => writes.push(bar), enabled: true, warn: () => {},
+    });
+    expect(res.recorded).toBe(1);
+    expect(writes.map((b) => b.probe)).toEqual(['belt_starvation']); // only the changed one
+    expect(writes[0].verdict).toBe('fail');
+  });
+  it('writes nothing in steady state (all verdicts unchanged)', async () => {
+    const writes = [];
+    const steady = [{ probe: 'belt_starvation', verdict: 'pass' }, { probe: 'dispatch_boundary', verdict: 'pass' }, { probe: 'propose_only', verdict: 'pass' }];
+    const res = await recordActionTimeAdherence({
+      supabase: supabaseStub(steady),
+      facts: { claimableBelt: 4, idleWorkers: 0, sourceableBacklogCount: 0, advisoryBody: 'clean', adamAuthoredBuildsInWindow: 0 },
+      recordAdherence: async (_s, _r, bar) => writes.push(bar), enabled: true, warn: () => {},
+    });
+    expect(res.recorded).toBe(0);
+    expect(writes).toHaveLength(0);
+  });
+  it('fail-open: never throws on a bad writer', async () => {
+    const res = await recordActionTimeAdherence({
+      supabase: supabaseStub([]), facts: {}, recordAdherence: async () => { throw new Error('boom'); }, enabled: true, warn: () => {},
+    });
+    expect(res.ok).toBe(true); // unresolved facts → unknown verdicts → may write; writer throws are swallowed
+  });
+  it('latestVerdictsByProbe takes the newest row per probe', () => {
+    const map = latestVerdictsByProbe([{ probe: 'belt_starvation', verdict: 'fail' }, { probe: 'belt_starvation', verdict: 'pass' }]);
+    expect(map.belt_starvation).toBe('fail'); // first (newest) wins
+  });
+});

--- a/tests/unit/coordinator/charter-audit-mirror-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-mirror-detectors.test.js
@@ -1,0 +1,49 @@
+/**
+ * SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 — coordinator mirror detectors (FR-3).
+ * Proves the SOURCE-TO-CAPACITY handshake + D3-lean detectors flag the right violations and
+ * fail-loud on unresolved inputs.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  detectSourceToCapacity,
+  detectCoordinatorWithoutAdam,
+} from '../../../lib/coordinator/charter-audit-detectors.mjs';
+
+describe('detectSourceToCapacity (FR-3 handshake)', () => {
+  it('violates when belt-low + idle but no recent source request', () => {
+    const r = detectSourceToCapacity({ claimableBelt: 0, idleWorkers: 2, sourceRequestedRecently: false });
+    expect(r.violation).toBe(true);
+    expect(r.remediation).toMatch(/ping Adam/i);
+  });
+  it('passes when the coordinator DID request work on a low belt', () => {
+    expect(detectSourceToCapacity({ claimableBelt: 0, idleWorkers: 2, sourceRequestedRecently: true }).violation).toBe(false);
+  });
+  it('passes when the belt is healthy (no handshake needed)', () => {
+    expect(detectSourceToCapacity({ claimableBelt: 5, idleWorkers: 2, sourceRequestedRecently: false }).violation).toBe(false);
+  });
+  it('passes when no workers are idle', () => {
+    expect(detectSourceToCapacity({ claimableBelt: 0, idleWorkers: 0, sourceRequestedRecently: false }).violation).toBe(false);
+  });
+  it('fail-loud (violation) when any input is unresolved', () => {
+    expect(detectSourceToCapacity({ claimableBelt: null, idleWorkers: 2, sourceRequestedRecently: false }).violation).toBe(true);
+    expect(detectSourceToCapacity({}).violation).toBe(true);
+  });
+});
+
+describe('detectCoordinatorWithoutAdam (FR-3 D3-lean)', () => {
+  it('violates when a coordinator is live but no live Adam', () => {
+    const r = detectCoordinatorWithoutAdam({ coordinatorAlive: true, adamAlive: false });
+    expect(r.violation).toBe(true);
+    expect(r.remediation).toMatch(/Adam/i);
+  });
+  it('passes when both coordinator and Adam are live', () => {
+    expect(detectCoordinatorWithoutAdam({ coordinatorAlive: true, adamAlive: true }).violation).toBe(false);
+  });
+  it('passes when the coordinator is not live (nothing to pair)', () => {
+    expect(detectCoordinatorWithoutAdam({ coordinatorAlive: false, adamAlive: false }).violation).toBe(false);
+  });
+  it('fail-loud (violation) on unresolved liveness', () => {
+    expect(detectCoordinatorWithoutAdam({ coordinatorAlive: null, adamAlive: true }).violation).toBe(true);
+    expect(detectCoordinatorWithoutAdam({}).violation).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Bring Adam + coordinator role-adherence to the worker DB-validation standard by **extending existing infra** (no new tables).

- **FR-1**: 2 pure Adam red-flag probes — **D1 belt-starvation** (belt=0 AND idle>0 AND sourceable-backlog>0 → fail, the exact failure this session) and **D2 dispatch-boundary** (an advisory body with fleet-lifecycle/dispatch language → fail). Fail-loud to `unknown`; added to `ADHERENCE_PROBES` so the 6h retro audit runs them.
- **FR-2**: `action-time-adherence.mjs` runs the cardinal subset at ACTION-TIME and records `adam_adherence_ledger` verdicts **only on a verdict transition** (dedupe-on-change). Wired into the sweep tick: **flag-gated (default-OFF), fail-open, WARN-only** — never blocks.
- **FR-3**: 2 coordinator mirror detectors (SOURCE-TO-CAPACITY handshake + D3-lean) wired into `coordinator-charter-audit.mjs` with skip-on-error fact resolution.
- **FR-4**: reuse — no new tables/migration.
- **FR-5**: 34 pure unit tests.

## Adversarial review (fixed before merge)
HIGH (FR-3 was dead code → wired); MEDIUM (belt-starvation no-op in sweep → documented, evaluated in retro + charter-audit); LOW (D2 `spin up/down` false-positive → anchored on a fleet noun); + 3 sibling count-pin regressions fixed. One pre-existing `leo-create-sd` comment-guard test fails identically on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)