### PR TITLE
feat(SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001): sd_backlog_map.disposition column + distillation + ordinal-23 probe repoint

### DIFF
--- a/database/migrations/20260619_sd_backlog_map_disposition.sql
+++ b/database/migrations/20260619_sd_backlog_map_disposition.sql
@@ -1,0 +1,24 @@
+-- SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001 (FR-1)
+-- Add a first-class disposition column to sd_backlog_map so vision ordinal-23
+-- ('Backlog distilled and dispositioned') can read an actual disposition instead of the
+-- completion_status='COMPLETED' lower-bound proxy.
+--
+-- ADDITIVE + NULLABLE + REVERSIBLE: no data migration, no existing-row change. NULL means
+-- un-dispositioned (still counts in the backlog gauge denominator, not the numerator). The
+-- CHECK allows NULL OR one of the four terminal dispositions. Backfill is the separate,
+-- idempotent distillation pass (scripts/distill-backlog-dispositions.mjs), NOT this migration.
+--
+-- Rollback: ALTER TABLE sd_backlog_map DROP COLUMN disposition;
+
+ALTER TABLE sd_backlog_map
+  ADD COLUMN IF NOT EXISTS disposition text DEFAULT NULL;
+
+ALTER TABLE sd_backlog_map
+  DROP CONSTRAINT IF EXISTS chk_sd_backlog_map_disposition;
+
+ALTER TABLE sd_backlog_map
+  ADD CONSTRAINT chk_sd_backlog_map_disposition
+  CHECK (disposition IS NULL OR disposition IN ('BUILD', 'RESEARCH', 'REFERENCE', 'CANCEL'));
+
+COMMENT ON COLUMN sd_backlog_map.disposition IS
+  'Distillation verdict for the backlog item: BUILD|RESEARCH|REFERENCE|CANCEL, or NULL when un-dispositioned. Set by scripts/distill-backlog-dispositions.mjs (completion_status proxy + conversion_ledger feeder) or by a human; read by vision ordinal-23. SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001.';

--- a/lib/intake/backlog-disposition.mjs
+++ b/lib/intake/backlog-disposition.mjs
@@ -1,0 +1,51 @@
+/**
+ * Pure backlog-item disposition classifier (no IO).
+ * SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001 (FR-2 / FR-3).
+ *
+ * Distils an sd_backlog_map item into a first-class disposition
+ * (BUILD | RESEARCH | REFERENCE | CANCEL), or NULL when genuinely undecided.
+ * completion_status is the AUTHORITATIVE signal (it is the item's real lifecycle
+ * state); the conversion_ledger feeder only fills items completion_status leaves
+ * undecided, so a converted-from-intake origin never overrides a CANCELLED/etc state.
+ */
+
+export const VALID_DISPOSITIONS = ['BUILD', 'RESEARCH', 'REFERENCE', 'CANCEL'];
+
+// completion_status → disposition. Statuses not listed (NOT_STARTED, IN_PROGRESS,
+// DEFERRED) are genuinely undecided → NULL (still count in the gauge denominator).
+export const DISPOSITION_BY_COMPLETION = {
+  COMPLETED: 'BUILD',            // it was built/shipped
+  CANCELLED: 'CANCEL',           // explicitly killed
+  UTILIZED_ELSEWHERE: 'REFERENCE', // absorbed/used elsewhere → reference, not net-new build
+};
+
+/**
+ * @param {{completion_status?:string, sd_id?:string}} item
+ * @param {Set<string>} convertedSdKeys - sd_id values that are the linked_sd_key of a
+ *   conversion_ledger row with disposition='converted' (the integrated intake feeder).
+ * @returns {('BUILD'|'RESEARCH'|'REFERENCE'|'CANCEL'|null)}
+ */
+export function classifyDisposition(item, convertedSdKeys = new Set()) {
+  const byStatus = DISPOSITION_BY_COMPLETION[item && item.completion_status] || null;
+  if (byStatus) return byStatus;
+  // Feeder ONLY fills genuinely-undecided items: a backlog item whose SD was converted
+  // from an intake-pool item is real, sourced work → BUILD.
+  if (item && item.sd_id && convertedSdKeys instanceof Set && convertedSdKeys.has(item.sd_id)) {
+    return 'BUILD';
+  }
+  return null; // undecided — leave NULL (counts in denominator, not numerator)
+}
+
+/**
+ * Build the converted-SD-key set from conversion_ledger rows (the integrated feeder).
+ * A row feeds a disposition only when it was 'converted' AND carries a linked_sd_key.
+ * @param {Array<{disposition?:string, linked_sd_key?:string}>} ledgerRows
+ * @returns {Set<string>}
+ */
+export function convertedSdKeySet(ledgerRows) {
+  const set = new Set();
+  for (const r of ledgerRows || []) {
+    if (r && r.disposition === 'converted' && r.linked_sd_key) set.add(r.linked_sd_key);
+  }
+  return set;
+}

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -148,10 +148,14 @@ export const VDR_REGISTRY = [
   // withholds the whole gauge if they drift). DB-signal probes only (no cross-repo grep). Honest
   // banding: a stray/seed row never credits 'built'.
   { capability: 'Backlog distilled and dispositioned', layer: 'process',
-    // count_ratio: dispositioned (completion_status=COMPLETED) / total backlog items. Live ~13/145 ≈ 9%
-    // → partial (matches reality: distillation begun, not complete). conversion_ledger is the future
-    // 'integrated' feeder (empty today); add it to numerFilter when populated. builtAt 0.7 = mostly-dispositioned.
-    probe: { type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: 'COMPLETED' }, builtAt: 0.7 } },
+    // count_ratio: dispositioned (disposition IS NOT NULL) / total backlog items. Reads the first-class
+    // sd_backlog_map.disposition column (BUILD|RESEARCH|REFERENCE|CANCEL), set by
+    // scripts/distill-backlog-dispositions.mjs (completion_status proxy + conversion_ledger feeder) — no
+    // longer the completion_status='COMPLETED' lower-bound proxy. FAIL-SOFT: until the additive migration
+    // (20260619_sd_backlog_map_disposition.sql, chairman-applied) lands, the column is absent and
+    // count_ratio returns 'unknown' (the gauge EXCLUDES it — never a false built/unbuilt). builtAt 0.7.
+    // SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001.
+    probe: { type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { disposition: { not: null } }, builtAt: 0.7 } },
   { capability: 'Application presentation-surface consolidation', layer: 'application',
     // count_ratio = routes mapped to a canonical feature_area / total routes. (Review finding: a raw
     // gte-count is BACKWARDS for "consolidation" — more routes != more consolidated. A presence count

--- a/package.json
+++ b/package.json
@@ -320,6 +320,7 @@
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
+    "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",
     "payments:test-charge": "node scripts/payments/test-charge-harness.mjs",

--- a/scripts/distill-backlog-dispositions.mjs
+++ b/scripts/distill-backlog-dispositions.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * distill-backlog-dispositions — set sd_backlog_map.disposition from completion_status
+ * + the conversion_ledger integrated feeder.
+ * SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001 (FR-2 / FR-3).
+ *
+ * DEFAULT = dry-run (zero writes; reports the disposition plan). --apply to write.
+ * Idempotent: an item already at its target disposition is skipped.
+ * FAIL-SOFT on column absence: if the disposition column isn't migrated yet, the pass
+ * reports 'column not yet migrated' and exits 0 (the migration is chairman-applied).
+ *
+ * Usage:
+ *   node scripts/distill-backlog-dispositions.mjs            # dry-run (default)
+ *   node scripts/distill-backlog-dispositions.mjs --apply
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { classifyDisposition, convertedSdKeySet } from '../lib/intake/backlog-disposition.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+
+function db() {
+  return createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
+
+async function main() {
+  const sb = db();
+  console.log(`\n=== backlog disposition distillation (${DRY_RUN ? 'DRY-RUN — zero writes' : 'APPLY'}) ===`);
+
+  // FAIL-SOFT: probe the column first. If the additive migration isn't applied yet, no-op.
+  const probe = await sb.from('sd_backlog_map').select('disposition').limit(1);
+  if (probe.error && /disposition/.test(probe.error.message) && /exist|column/i.test(probe.error.message)) {
+    console.log('   [SKIP] sd_backlog_map.disposition not migrated yet (chairman-gated apply) — no-op.');
+    return;
+  }
+  if (probe.error) { console.log('   [ALERT] probe failed (fail-soft):', probe.error.message); return; }
+
+  const { data: items, error } = await sb
+    .from('sd_backlog_map')
+    .select('sd_id, backlog_id, completion_status, disposition');
+  if (error) { console.log('   [ALERT] load failed (fail-soft):', error.message); return; }
+
+  // FR-3: conversion_ledger integrated feeder (empty today; dormant until populated).
+  let convertedSet = new Set();
+  try {
+    const { data: ledger } = await sb.from('conversion_ledger').select('disposition, linked_sd_key');
+    convertedSet = convertedSdKeySet(ledger || []);
+  } catch (e) { console.log('   feeder load skipped (fail-soft):', e.message); }
+  console.log(`   backlog items: ${items.length} | conversion_ledger converted-SD feeders: ${convertedSet.size}`);
+
+  let set = 0, alreadyAt = 0, leftNull = 0, failed = 0;
+  const dist = {};
+  for (const it of items) {
+    const target = classifyDisposition(it, convertedSet);
+    if (!target) { leftNull++; continue; }
+    dist[target] = (dist[target] || 0) + 1;
+    if (it.disposition === target) { alreadyAt++; continue; } // idempotent
+    if (DRY_RUN) { set++; continue; }
+    try {
+      const { error: upErr } = await sb
+        .from('sd_backlog_map')
+        .update({ disposition: target })
+        .eq('sd_id', it.sd_id)
+        .eq('backlog_id', it.backlog_id);
+      if (upErr) { console.error(`   ❌ ${it.sd_id}/${it.backlog_id}: ${upErr.message}`); failed++; }
+      else set++;
+    } catch (e) { console.error(`   ❌ ${it.sd_id}/${it.backlog_id}: ${e.message}`); failed++; }
+  }
+
+  console.log('\n--- disposition plan ---');
+  console.log('   distribution         :', JSON.stringify(dist));
+  console.log(`   ${DRY_RUN ? 'would set' : 'set'}             : ${set}`);
+  console.log(`   already-at-target    : ${alreadyAt}  (idempotent)`);
+  console.log(`   left NULL (undecided): ${leftNull}`);
+  console.log(`   failed               : ${failed}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('[distill-backlog-dispositions] fatal:', e.message); process.exit(1); });

--- a/tests/unit/intake/backlog-disposition.test.js
+++ b/tests/unit/intake/backlog-disposition.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001 (FR-5)
+ * Pure tests for the backlog disposition classifier + the conversion_ledger feeder set.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifyDisposition,
+  convertedSdKeySet,
+  VALID_DISPOSITIONS,
+  DISPOSITION_BY_COMPLETION,
+} from '../../../lib/intake/backlog-disposition.mjs';
+
+describe('classifyDisposition — completion_status mapping', () => {
+  it('COMPLETED → BUILD', () => {
+    expect(classifyDisposition({ completion_status: 'COMPLETED' })).toBe('BUILD');
+  });
+  it('CANCELLED → CANCEL', () => {
+    expect(classifyDisposition({ completion_status: 'CANCELLED' })).toBe('CANCEL');
+  });
+  it('UTILIZED_ELSEWHERE → REFERENCE', () => {
+    expect(classifyDisposition({ completion_status: 'UTILIZED_ELSEWHERE' })).toBe('REFERENCE');
+  });
+  it('NOT_STARTED / IN_PROGRESS / DEFERRED → null (genuinely undecided)', () => {
+    expect(classifyDisposition({ completion_status: 'NOT_STARTED' })).toBeNull();
+    expect(classifyDisposition({ completion_status: 'IN_PROGRESS' })).toBeNull();
+    expect(classifyDisposition({ completion_status: 'DEFERRED' })).toBeNull();
+  });
+  it('unknown/missing status → null', () => {
+    expect(classifyDisposition({ completion_status: 'WAT' })).toBeNull();
+    expect(classifyDisposition({})).toBeNull();
+    expect(classifyDisposition(null)).toBeNull();
+  });
+  it('only ever returns a valid disposition or null', () => {
+    for (const s of ['COMPLETED', 'CANCELLED', 'UTILIZED_ELSEWHERE', 'NOT_STARTED', 'x']) {
+      const d = classifyDisposition({ completion_status: s });
+      expect(d === null || VALID_DISPOSITIONS.includes(d)).toBe(true);
+    }
+  });
+});
+
+describe('classifyDisposition — conversion_ledger feeder (fills only undecided)', () => {
+  const converted = new Set(['SD-FROM-INTAKE-1']);
+  it('a converted-from-intake SD with an UNDECIDED status → BUILD', () => {
+    expect(classifyDisposition({ completion_status: 'NOT_STARTED', sd_id: 'SD-FROM-INTAKE-1' }, converted)).toBe('BUILD');
+  });
+  it('completion_status is AUTHORITATIVE — the feeder never overrides a decided status', () => {
+    // CANCELLED stays CANCEL even if the SD was converted from intake.
+    expect(classifyDisposition({ completion_status: 'CANCELLED', sd_id: 'SD-FROM-INTAKE-1' }, converted)).toBe('CANCEL');
+  });
+  it('a non-converted undecided item stays null', () => {
+    expect(classifyDisposition({ completion_status: 'NOT_STARTED', sd_id: 'SD-OTHER' }, converted)).toBeNull();
+  });
+  it('tolerates a non-Set feeder arg', () => {
+    expect(classifyDisposition({ completion_status: 'NOT_STARTED', sd_id: 'x' }, undefined)).toBeNull();
+  });
+});
+
+describe('convertedSdKeySet', () => {
+  it('includes only converted rows that carry a linked_sd_key', () => {
+    const set = convertedSdKeySet([
+      { disposition: 'converted', linked_sd_key: 'SD-A' },
+      { disposition: 'converted', linked_sd_key: null },   // no key → excluded
+      { disposition: 'dismissed', linked_sd_key: 'SD-B' }, // not converted → excluded
+      { disposition: 'deferred', linked_sd_key: 'SD-C' },  // not converted → excluded
+    ]);
+    expect([...set]).toEqual(['SD-A']);
+  });
+  it('empty/undefined ledger → empty set (dormant feeder is honest)', () => {
+    expect(convertedSdKeySet([]).size).toBe(0);
+    expect(convertedSdKeySet(undefined).size).toBe(0);
+  });
+});
+
+describe('DISPOSITION_BY_COMPLETION map invariant', () => {
+  it('every mapped value is a valid disposition', () => {
+    for (const v of Object.values(DISPOSITION_BY_COMPLETION)) {
+      expect(VALID_DISPOSITIONS).toContain(v);
+    }
+  });
+});

--- a/tests/unit/vision/vdr-consolidation-probes.test.js
+++ b/tests/unit/vision/vdr-consolidation-probes.test.js
@@ -81,12 +81,14 @@ describe('FR-2: count_ratio is a registered runner with honest bands + fail-open
 });
 
 describe('FR-3: the 3 consolidation entries are registered with the honest shape', () => {
-  it('Backlog → count_ratio on sd_backlog_map (numerator completion_status=COMPLETED), layer process', () => {
+  it('Backlog → count_ratio on sd_backlog_map (numerator disposition IS NOT NULL), layer process', () => {
+    // SD-LEO-INFRA-BACKLOG-DISPOSITION-COLUMN-WORKFLOW-001: repointed from the completion_status=COMPLETED
+    // lower-bound proxy to the first-class disposition column (fail-soft 'unknown' until the migration lands).
     const e = entryFor(BACKLOG);
     expect(e).toBeTruthy();
     expect(e.layer).toBe('process');
-    expect(e.probe).toMatchObject({ type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { completion_status: 'COMPLETED' } });
-    expect(e.probe.builtAt).toBeGreaterThan(0.5); // not gamed to today's 9%
+    expect(e.probe).toMatchObject({ type: 'count_ratio', table: 'sd_backlog_map', numerFilter: { disposition: { not: null } } });
+    expect(e.probe.builtAt).toBeGreaterThan(0.5); // not gamed to today's ratio
   });
   it('Surface → count_ratio on ehg_page_routes (mapped feature_area / total), layer application, builtAt 1.0', () => {
     const e = entryFor(SURFACE);


### PR DESCRIPTION
## Summary
Gives the vision ordinal-23 capability ('Backlog distilled and dispositioned') a **first-class** `sd_backlog_map.disposition` column to read, instead of the `completion_status='COMPLETED'` lower-bound proxy. Adopted from an orphaned in-progress SD.

- **FR-1** — additive migration `20260619_sd_backlog_map_disposition.sql`: `disposition` (BUILD|RESEARCH|REFERENCE|CANCEL, NULL default, CHECK). **DORMANT — chairman-gated apply** (not applied here; the whole feature is fail-soft until it lands).
- **FR-2** — pure classifier `lib/intake/backlog-disposition.mjs` (COMPLETED→BUILD, CANCELLED→CANCEL, UTILIZED_ELSEWHERE→REFERENCE, else NULL; completion_status authoritative).
- **FR-3** — conversion_ledger integrated feeder (via `linked_sd_key`; empty today → dormant, fills only undecided items).
- **FR-4** — repoint the ordinal-23 `count_ratio` probe to `disposition IS NOT NULL`. **Fail-soft**: absent column → probe returns `unknown` → gauge **excludes** it (never a false 0/unbuilt).
- **FR-5** — `scripts/distill-backlog-dispositions.mjs` (dry-run default, idempotent, fail-soft `[SKIP]` on column absence) + tests.

## Verification (adversarially live-verified)
- 28/28 new+updated unit tests; full vision suite 91 green.
- **Gauge honesty:** with the column absent (live), the probe returns `unknown` and `computeBuildGauge` filters it from the denominator — confirmed against the live DB, not a false 0.
- **No post-activation lie-high:** live distribution (159 rows: 146 NOT_STARTED, 13 COMPLETED, 0 others; conversion_ledger 0 converted) bounds the activated ratio to ~13/159 ≈ 8% partial — cannot jump to ≥70% built.
- Distillation fail-soft `[SKIP]`s (column not migrated); detects PostgREST `42703` + the message regex.
- TESTING sub-agent PASS (row cde2f438); handoffs 94/93/96. package.json distill entry rooted for WIRE_CHECK.

Activation follow-up: chairman applies the migration, then `npm run distill:backlog-dispositions -- --apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)