### PR TITLE
fix(SD-LEO-INFRA-VISION-GAUGE-CRON-EHG-CHECKOUT-001): check out ehg in the gauge cron so the vision % covers all 25 capabilities

### DIFF
--- a/.github/workflows/adam-exec-email-cron.yml
+++ b/.github/workflows/adam-exec-email-cron.yml
@@ -57,10 +57,56 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       CLAUDE_NOTIFY_EMAIL: ${{ secrets.CLAUDE_NOTIFY_EMAIL }}
+      # SD-LEO-INFRA-VISION-GAUGE-CRON-EHG-CHECKOUT-001 (FR-3): point the VDR gauge's cross-repo grep
+      # seam (lib/vision/vdr-grep-seam.js resolveRepoRoots, which already honors VDR_EHG_REPO_ROOT) at
+      # the ehg checkout, so the 3 ehg-targeted code_grep probes resolve and the vision % is computed
+      # over 25/25 (not 22/25). Without this, the seam falls back to the sibling <engineerRoot>/../ehg
+      # path, which does not exist in CI. When the ehg checkout is skipped (no PAT — see below) this dir
+      # is absent and the seam honestly bands those probes 'unknown' (gauge degrades to 22/25 exactly as
+      # today — never a fabricated 'built'). Verified live: with this set, denominator=25, unknown_count=0.
+      VDR_EHG_REPO_ROOT: ${{ github.workspace }}/ehg
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # SD-LEO-INFRA-VISION-GAUGE-CRON-EHG-CHECKOUT-001 (FR-1/FR-2): also check out rickfelix/ehg
+      # so the VDR gauge's 3 ehg-targeted code_grep probes (distance-to-broke, venture-performance
+      # read, the cockpit) resolve and the automated vision % covers all 25 capabilities (not 22/25).
+      #
+      # AUTH (FR-2): rickfelix/ehg is PRIVATE, so the default GITHUB_TOKEN cannot read it — this step
+      # needs a read-only cross-repo token. It REUSES the established org secret `GH_TOKEN_CROSS_REPO`
+      # already used by the other rickfelix/ehg cross-repo workflows (design-prompts-cross-repo.yml,
+      # venture-stages-drift-guard.yml), so no NEW secret provisioning is needed if that one exists; a
+      # repo-local read-only `EHG_RO_PAT` is the documented fallback if an operator prefers a scoped PAT.
+      # `continue-on-error: true` makes it FAIL-SOFT: if neither secret is present the auth 404s but the
+      # cron + chairman email continue uninterrupted and the gauge stays at 22/25 (the ehg probes band
+      # 'unknown', exactly as today). The next hourly snapshot once a token is present auto-upgrades to
+      # 25/25 (FR-5, no further code change). Verified live: with the checkout present the gauge yields
+      # denominator=25, unknown_count=0.
+      - name: Checkout ehg (for cross-repo VDR gauge probes)
+        id: ehg_checkout
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          repository: rickfelix/ehg
+          path: ehg
+          token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.EHG_RO_PAT }}
+          persist-credentials: false
+
+      # SD-LEO-INFRA-VISION-GAUGE-CRON-EHG-CHECKOUT-001 (FR-4): make a missing probe target repo
+      # LOUD (a GitHub Actions ::warning:: annotation), not a silent drop to 22/25. Non-blocking:
+      # it never fails the cron (the gauge degrades honestly), it just surfaces WHY coverage < 25/25
+      # so the cross-repo-token gap is visible in every run until it is closed. Gated on the ehg
+      # checkout step's own outcome (the precedent pattern in the other cross-repo workflows), so the
+      # diagnostic tracks the actual checkout result, not a filesystem-layout heuristic.
+      - name: Report cross-repo VDR gauge coverage (loud, non-blocking)
+        run: |
+          if [ "${{ steps.ehg_checkout.outcome }}" = "success" ] && [ -d "${VDR_EHG_REPO_ROOT}/src" ]; then
+            echo "VDR gauge: ehg checkout present at ${VDR_EHG_REPO_ROOT} — all 25 capabilities are repo-probeable (denominator should be 25, 0 unknown for repo-availability reasons)."
+          else
+            echo "::warning title=VDR gauge coverage <25/25::ehg checkout unavailable (step outcome='${{ steps.ehg_checkout.outcome }}', path '${VDR_EHG_REPO_ROOT}') — the 3 ehg-targeted code_grep probes band 'unknown', so the automated vision % covers only 22/25. Ensure the GH_TOKEN_CROSS_REPO org secret (or a read-only EHG_RO_PAT, Contents:read on rickfelix/ehg) is present (FR-2); the next hourly snapshot then auto-upgrades to 25/25."
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/tests/unit/vision-gauge-cron-ehg-checkout.test.js
+++ b/tests/unit/vision-gauge-cron-ehg-checkout.test.js
@@ -1,0 +1,50 @@
+// SD-LEO-INFRA-VISION-GAUGE-CRON-EHG-CHECKOUT-001 (FR-1/FR-2/FR-3/FR-4) — pin the cron wiring that
+// lets the VDR gauge probe all 25 capabilities. The grep seam's VDR_EHG_REPO_ROOT override is already
+// covered by tests/unit/vdr-grep-seam.test.js; this guards the WORKFLOW half (the ehg checkout + the
+// env export + the fail-soft + the loud coverage diagnostic) so a future edit can't silently revert it
+// and drop the automated vision % back to 22/25 without anyone noticing.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const YML = readFileSync(path.join(REPO_ROOT, '.github/workflows/adam-exec-email-cron.yml'), 'utf8');
+
+describe('adam-exec-email cron — cross-repo VDR gauge coverage wiring', () => {
+  it('FR-1: checks out rickfelix/ehg into the workspace (path: ehg)', () => {
+    expect(YML).toMatch(/repository:\s*rickfelix\/ehg/);
+    expect(YML).toMatch(/path:\s*ehg\b/);
+    // a second actions/checkout (the EHG_Engineer one plus the ehg one)
+    expect((YML.match(/actions\/checkout@v4/g) || []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('FR-2: the ehg checkout reuses the established GH_TOKEN_CROSS_REPO secret (with EHG_RO_PAT fallback)', () => {
+    // Reuse the org cross-repo secret the other rickfelix/ehg workflows already use, so the gauge can
+    // reach 25/25 on merge without provisioning a brand-new secret; EHG_RO_PAT is the documented fallback.
+    expect(YML).toMatch(/token:\s*\$\{\{\s*secrets\.GH_TOKEN_CROSS_REPO\s*\|\|\s*secrets\.EHG_RO_PAT\s*\}\}/);
+  });
+
+  it('FR-2: the ehg checkout is FAIL-SOFT (continue-on-error) so a missing PAT never breaks the cron', () => {
+    // Anchor on the actual `repository: rickfelix/ehg` config (NOT a comment mention of the repo) so
+    // continue-on-error is checked against the real checkout step's window.
+    const cfgIdx = YML.indexOf('repository: rickfelix/ehg');
+    expect(cfgIdx).toBeGreaterThanOrEqual(0);
+    const window = YML.slice(Math.max(0, cfgIdx - 400), cfgIdx + 200);
+    expect(window).toMatch(/continue-on-error:\s*true/);
+  });
+
+  it('FR-3: exports VDR_EHG_REPO_ROOT at the workspace ehg path (the grep seam honors it)', () => {
+    expect(YML).toMatch(/VDR_EHG_REPO_ROOT:\s*\$\{\{\s*github\.workspace\s*\}\}\/ehg/);
+    // and does NOT use the wrong knob (repo-paths EHG_REPO_PATH never reaches the grep seam)
+    expect(YML).not.toMatch(/EHG_REPO_PATH/);
+  });
+
+  it('FR-4: a loud, NON-blocking coverage diagnostic warns when the ehg checkout is missing', () => {
+    expect(YML).toMatch(/::warning title=VDR gauge coverage/);
+    // the ehg checkout step carries an id, and the diagnostic gates on its outcome (precedent pattern)
+    expect(YML).toMatch(/id:\s*ehg_checkout/);
+    expect(YML).toMatch(/steps\.ehg_checkout\.outcome/);
+  });
+});


### PR DESCRIPTION
## Summary
The VDR vision gauge has 3 `repo:'ehg'` code_grep probes, but the **adam-exec-email cron** (which historizes the gauge hourly) checked out only EHG_Engineer — not the **private** rickfelix/ehg repo — so those probes banded `'unknown'` and the automated vision % was computed over **22/25**, never reflecting EHG-app completions.

## What shipped (workflow-only)
- **FR-1** A 2nd `actions/checkout` for rickfelix/ehg (`path: ehg`, `id: ehg_checkout`).
- **FR-2** Auth with the **established `GH_TOKEN_CROSS_REPO`** org secret — the convention the other rickfelix/ehg cross-repo workflows already use (`EHG_RO_PAT` documented fallback). **fail-soft** (`continue-on-error`) + `persist-credentials: false` so a missing token degrades honestly and the PAT is never written to `.git/config`.
- **FR-3** Export `VDR_EHG_REPO_ROOT=${{ github.workspace }}/ehg` — the env override the gauge's grep seam (`lib/vision/vdr-grep-seam.js` `resolveRepoRoots`) **already honors** (the sibling `../ehg` fallback doesn't exist in CI). No `repo-paths`/`EHG_REPO_PATH` change — that knob never reaches the grep seam (an early wrong approach, caught + reverted via a live gauge replay).
- **FR-4** A loud, **outcome-gated, non-blocking** `::warning::` when the ehg checkout is unavailable, so a drop to 22/25 is visible, not silent.
- **FR-5** Automatic — the next hourly snapshot once a token is present reflects 25/25.

## Verification
- **Live-verified**: with `VDR_EHG_REPO_ROOT` set to a real ehg checkout, `computeBuildGauge` returns **denominator=25, unknown_count=0** (the 3 ehg probes band partial/unbuilt — never a fabricated `'built'`).
- **Merge-safe**: a missing token degrades to 22/25 exactly as today, never breaks the chairman email or the historize step (both `continue-on-error`).
- 5 YAML source-pin tests; the grep-seam `VDR_EHG_REPO_ROOT` override is already unit-tested (`vdr-grep-seam.test.js`).
- **Adversarial review: SHIP** — it caught the **`GH_TOKEN_CROSS_REPO` reuse** (vs a brand-new unprovisioned secret), so the gauge reaches 25/25 **on merge** rather than staying dormant; also confirmed fail-soft, no token leak (`persist-credentials:false`), honest banding untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)