### PR TITLE
feat(SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001): advisory log-only forward gate on chairman decisions

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -8,6 +8,10 @@
  */
 
 import { ServiceError } from './shared-services.js';
+// SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001: ADVISORY/log-only forward gate.
+// Scores each chairman decision via the pure evaluateDecision() engine and records the
+// verdict to audit_log ONLY — never mutates chairman_decisions, never blocks (fail-open).
+import { recordForwardGateScore } from './forward-gate.js';
 
 const POLLING_INTERVAL_MS = 10_000; // 10 seconds
 const REALTIME_CHANNEL = 'chairman-decisions';
@@ -253,6 +257,11 @@ export async function createOrReusePendingDecision({
         .eq('id', existing.id);
     }
     logger.log(`   Reusing existing PENDING decision: ${existing.id}`);
+    // ADVISORY/log-only forward gate (fail-open, idempotent — never blocks/alters the decision).
+    await recordForwardGateScore(
+      { id: existing.id, lifecycle_stage: stageNumber, brief_data: briefData, summary, decision_type: decisionType },
+      { supabase, logger },
+    );
     return { id: existing.id, isNew: false };
   }
 
@@ -326,6 +335,11 @@ export async function createOrReusePendingDecision({
   }
 
   logger.log(`   New PENDING decision created: ${created.id}`);
+  // ADVISORY/log-only forward gate (fail-open, idempotent — never blocks/alters the decision).
+  await recordForwardGateScore(
+    { id: created.id, lifecycle_stage: stageNumber, brief_data: briefData, summary, decision_type: decisionType, health_score: healthScore },
+    { supabase, logger },
+  );
   return { id: created.id, isNew: true };
 }
 

--- a/lib/eva/forward-gate.js
+++ b/lib/eva/forward-gate.js
@@ -37,10 +37,9 @@ export function decisionToEngineInput(decision = {}) {
   if (decision.lifecycle_stage !== undefined && decision.lifecycle_stage !== null) {
     input.stage = String(decision.lifecycle_stage);
   }
-  // health_score is stored 0-100; evaluateDecision reads visionScore as 0-100.
-  if (decision.health_score !== undefined && decision.health_score !== null) {
-    input.visionScore = Number(decision.health_score);
-  }
+  // NB: chairman_decisions.health_score is CATEGORICAL ('green'/'red'/NULL), NOT a 0-100
+  // vision score — verified live. We deliberately do NOT map it to evaluateDecision.visionScore
+  // (that would feed the engine NaN). It is carried in the audit metadata as raw context only.
   const description = decision.summary || brief.summary || brief.ventureName || decision.decision_type;
   if (description) input.description = String(description);
   // Pass through any explicit numeric/array signals the brief carries (advisory only).
@@ -74,8 +73,11 @@ export async function hasForwardGateScore(decisionId, supabase) {
  * Advisory-score a chairman decision and log the verdict to audit_log.
  *
  * ADVISORY / LOG-ONLY: writes ONLY to audit_log; never touches chairman_decisions;
- * never throws (fail-open). Idempotent: a decision that already has a coverage row
- * is skipped.
+ * never throws (fail-open). Idempotent under serial use: a decision that already has a
+ * coverage row is skipped (best-effort check-then-insert; no unique constraint, so two
+ * truly-concurrent calls for the same decision could both insert — harmless duplicate
+ * advisory rows, never a correctness issue, since each decision is created+scored once
+ * inline on the forward path).
  *
  * @param {Object} decision - a chairman_decisions row (must have .id)
  * @param {Object} opts

--- a/lib/eva/forward-gate.js
+++ b/lib/eva/forward-gate.js
@@ -1,0 +1,133 @@
+/**
+ * Chairman-decision Forward Gate (ADVISORY / LOG-ONLY)
+ *
+ * SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001
+ *
+ * Runs the PURE evaluateDecision() engine over a chairman decision on the forward
+ * path and records the advisory verdict to `audit_log` ONLY. It is deliberately
+ * authority-neutral:
+ *   - it NEVER writes/updates `chairman_decisions` (decision/status/authority),
+ *   - it NEVER blocks, rejects, or overrides a decision or its acceptance,
+ *   - any error is swallowed (fail-open) so it can never stall decision creation.
+ *
+ * CONST-002: the forward gate is advisory; a harden-to-blocking mode is OUT OF
+ * SCOPE (a separate, chairman-gated follow-up). The advisory verdict lives in a
+ * separate table so the chairman's authority is provably untouched.
+ *
+ * The audit_log coverage rows it emits are ALSO the signal the vision ordinal-13
+ * ("Decision Filter Engine") probe reads (db_count over event_type below).
+ */
+
+import { evaluateDecision } from './decision-filter-engine.js';
+
+export const FORWARD_GATE_EVENT = 'chairman_forward_gate_score';
+const FORWARD_GATE_ENTITY = 'chairman_decision';
+
+/**
+ * Adapt a chairman_decisions row into an evaluateDecision() input.
+ * Honest mapping: only fields that genuinely exist on the decision are passed;
+ * the engine tolerates a sparse input (missing prefs become advisory triggers).
+ *
+ * @param {Object} decision - a chairman_decisions row
+ * @returns {Object} evaluateDecision input
+ */
+export function decisionToEngineInput(decision = {}) {
+  const brief = (decision && typeof decision.brief_data === 'object' && decision.brief_data) || {};
+  const input = {};
+  if (decision.lifecycle_stage !== undefined && decision.lifecycle_stage !== null) {
+    input.stage = String(decision.lifecycle_stage);
+  }
+  // health_score is stored 0-100; evaluateDecision reads visionScore as 0-100.
+  if (decision.health_score !== undefined && decision.health_score !== null) {
+    input.visionScore = Number(decision.health_score);
+  }
+  const description = decision.summary || brief.summary || brief.ventureName || decision.decision_type;
+  if (description) input.description = String(description);
+  // Pass through any explicit numeric/array signals the brief carries (advisory only).
+  if (Number.isFinite(brief.cost)) input.cost = brief.cost;
+  if (Number.isFinite(brief.score)) input.score = brief.score;
+  if (Array.isArray(brief.technologies)) input.technologies = brief.technologies;
+  if (Array.isArray(brief.vendors)) input.vendors = brief.vendors;
+  return input;
+}
+
+/**
+ * Has this decision already been advisory-scored? (idempotency guard)
+ * @returns {Promise<boolean>}
+ */
+export async function hasForwardGateScore(decisionId, supabase) {
+  if (!decisionId || !supabase) return false;
+  try {
+    const { count, error } = await supabase
+      .from('audit_log')
+      .select('*', { count: 'exact', head: true })
+      .eq('event_type', FORWARD_GATE_EVENT)
+      .eq('entity_id', decisionId);
+    if (error) return false;
+    return (Number(count) || 0) > 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Advisory-score a chairman decision and log the verdict to audit_log.
+ *
+ * ADVISORY / LOG-ONLY: writes ONLY to audit_log; never touches chairman_decisions;
+ * never throws (fail-open). Idempotent: a decision that already has a coverage row
+ * is skipped.
+ *
+ * @param {Object} decision - a chairman_decisions row (must have .id)
+ * @param {Object} opts
+ * @param {Object} opts.supabase - Supabase client
+ * @param {Object} [opts.logger=console]
+ * @param {Object} [opts.preferences] - chairman preference map (advisory)
+ * @returns {Promise<{logged: boolean, skipped?: boolean, verdict?: Object, reason?: string}>}
+ */
+export async function recordForwardGateScore(decision, { supabase, logger = console, preferences } = {}) {
+  try {
+    if (!decision || !decision.id || !supabase) {
+      return { logged: false, reason: 'missing decision.id or supabase' };
+    }
+
+    // Idempotency: never double-log coverage for the same decision.
+    if (await hasForwardGateScore(decision.id, supabase)) {
+      return { logged: false, skipped: true, reason: 'coverage row already exists' };
+    }
+
+    // Run the genuine PURE engine over the real decision (no IO inside evaluateDecision).
+    const input = decisionToEngineInput(decision);
+    const verdict = evaluateDecision(input, { preferences, logger: { info() {}, debug() {} } });
+
+    // ADVISORY record — audit_log ONLY. entity_id + severity satisfy live constraints.
+    const { error } = await supabase.from('audit_log').insert({
+      event_type: FORWARD_GATE_EVENT,
+      entity_type: FORWARD_GATE_ENTITY,
+      entity_id: decision.id,
+      severity: 'info',
+      metadata: {
+        advisory: true,
+        const_002: 'log-only; chairman authority unchanged',
+        auto_proceed: verdict.auto_proceed,
+        recommendation: verdict.recommendation,
+        escalation_level: verdict.escalation_level ?? null,
+        escalation_label: verdict.escalation_label ?? null,
+        trigger_count: Array.isArray(verdict.triggers) ? verdict.triggers.length : 0,
+        triggers: verdict.triggers,
+        lifecycle_stage: decision.lifecycle_stage ?? null,
+        decision_type: decision.decision_type ?? null,
+      },
+    });
+
+    if (error) {
+      // Fail-open: log and continue — never block the decision path.
+      try { logger.warn?.(`[ForwardGate] advisory log failed (non-fatal): ${error.message}`); } catch (_) {}
+      return { logged: false, reason: error.message };
+    }
+    return { logged: true, verdict };
+  } catch (e) {
+    // Absolute fail-open guarantee — the advisory gate can never stall decision creation.
+    try { logger.warn?.(`[ForwardGate] advisory scoring threw (non-fatal): ${e.message}`); } catch (_) {}
+    return { logged: false, reason: e.message };
+  }
+}

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -131,8 +131,12 @@ export const VDR_REGISTRY = [
     // No KR measures this capability → code_grep the live doctrine-of-constraint trigger fn.
     probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'database/migrations', pattern: 'enforce_doctrine_of_constraint', builtWhen: 'present' } },
   { capability: 'Decision Filter Engine', layer: 'process',
-    // No KR measures this → code_grep the decision-filter engine (lib/eva specifically; lib/governance lacks evaluateDecision).
-    probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'lib/eva', pattern: 'evaluateDecision', builtWhen: 'present' } },
+    // SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001: the engine is no longer merely DEFINED in lib/eva
+    // (code_grep ⇒ partial, intent-only) — it is now WIRED as an advisory forward gate on the
+    // chairman-decision path that records a verdict to audit_log per scored decision. Read that REAL
+    // coverage: db_count over audit_log event_type=chairman_forward_gate_score (>=1 ⇒ built). This
+    // bands 'built' on genuine coverage and honestly drops to 'unbuilt' if the gate ever stops logging.
+    probe: { type: 'db_count', table: 'audit_log', filter: { event_type: 'chairman_forward_gate_score' }, builtWhen: 'gte', min: 1 } },
   { capability: 'Governance cascade enforced', layer: 'process',
     // KR-GOV-3.1 = "Governance cascade layers operational: 6 of 6" — THE cascade KR. Live 2/6 at_risk → partial.
     // (NOT KR-GOV-2.3 'vision event handlers' just because it is achieved — that would inflate a half-built capability.)

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -131,12 +131,17 @@ export const VDR_REGISTRY = [
     // No KR measures this capability → code_grep the live doctrine-of-constraint trigger fn.
     probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'database/migrations', pattern: 'enforce_doctrine_of_constraint', builtWhen: 'present' } },
   { capability: 'Decision Filter Engine', layer: 'process',
-    // SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001: the engine is no longer merely DEFINED in lib/eva
-    // (code_grep ⇒ partial, intent-only) — it is now WIRED as an advisory forward gate on the
-    // chairman-decision path that records a verdict to audit_log per scored decision. Read that REAL
-    // coverage: db_count over audit_log event_type=chairman_forward_gate_score (>=1 ⇒ built). This
-    // bands 'built' on genuine coverage and honestly drops to 'unbuilt' if the gate ever stops logging.
-    probe: { type: 'db_count', table: 'audit_log', filter: { event_type: 'chairman_forward_gate_score' }, builtWhen: 'gte', min: 1 } },
+    // HONEST BAND = partial. SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001 WIRED the engine as an
+    // ADVISORY forward filter (it now actually runs over each chairman decision and records a verdict
+    // to audit_log — see recordForwardGateScore) — genuine progress over the prior "defined but never
+    // invoked" state. But the live vision_ladder_criteria ord-13 REQUIRED state is "a live
+    // decision-filter engine GATING chairman decisions", and CONST-002 forbids this gate from
+    // gating/blocking/overriding (advisory-only; a harden-to-blocking mode is a separate chairman-gated
+    // SD). Advisory wiring is NOT gating, so banding 'built' would be a LIE-HIGH inflating the
+    // chairman's governance gauge. We keep code_grep (presence ⇒ partial) — the honest band — until a
+    // future enforce-mode SD makes the engine actually gate, which a coverage/enforce probe can then
+    // promote to 'built'. (The audit_log forward-gate coverage exists as advisory telemetry/foundation.)
+    probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'lib/eva', pattern: 'evaluateDecision', builtWhen: 'present' } },
   { capability: 'Governance cascade enforced', layer: 'process',
     // KR-GOV-3.1 = "Governance cascade layers operational: 6 of 6" — THE cascade KR. Live 2/6 at_risk → partial.
     // (NOT KR-GOV-2.3 'vision event handlers' just because it is achieved — that would inflate a half-built capability.)

--- a/scripts/backfill-forward-gate-scores.mjs
+++ b/scripts/backfill-forward-gate-scores.mjs
@@ -6,8 +6,10 @@
  *
  * Advisory-scores EXISTING chairman_decisions through the genuine pure
  * evaluateDecision() engine and records the verdict to audit_log (via
- * recordForwardGateScore). This seeds HONEST forward-gate coverage — the engine
- * truly evaluates each real decision; nothing is fabricated.
+ * recordForwardGateScore), establishing an advisory forward-gate audit baseline over
+ * the existing decision history — the engine truly evaluates each real decision;
+ * nothing is fabricated. (This is telemetry/foundation; the vision ord-13 gauge stays
+ * honestly 'partial' until a future enforce-mode SD makes the gate actually gate.)
  *
  * ADVISORY / LOG-ONLY: writes ONLY to audit_log, never to chairman_decisions.
  * Idempotent: decisions that already carry a coverage row are skipped.

--- a/scripts/backfill-forward-gate-scores.mjs
+++ b/scripts/backfill-forward-gate-scores.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Backfill forward-gate advisory coverage.
+ *
+ * SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001 (FR-4)
+ *
+ * Advisory-scores EXISTING chairman_decisions through the genuine pure
+ * evaluateDecision() engine and records the verdict to audit_log (via
+ * recordForwardGateScore). This seeds HONEST forward-gate coverage — the engine
+ * truly evaluates each real decision; nothing is fabricated.
+ *
+ * ADVISORY / LOG-ONLY: writes ONLY to audit_log, never to chairman_decisions.
+ * Idempotent: decisions that already carry a coverage row are skipped.
+ *
+ * Usage:
+ *   node scripts/backfill-forward-gate-scores.mjs [--limit N] [--dry-run]
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { recordForwardGateScore, hasForwardGateScore } from '../lib/eva/forward-gate.js';
+
+export async function backfillForwardGateScores({ supabase, limit = null, dryRun = false, logger = console } = {}) {
+  if (!supabase) throw new Error('supabase client required');
+  let q = supabase
+    .from('chairman_decisions')
+    .select('id, lifecycle_stage, health_score, brief_data, summary, decision_type')
+    .order('created_at', { ascending: true });
+  if (Number.isFinite(limit)) q = q.limit(limit);
+  const { data: decisions, error } = await q;
+  if (error) throw new Error(`failed to load chairman_decisions: ${error.message}`);
+
+  let scored = 0;
+  let skipped = 0;
+  for (const d of decisions || []) {
+    if (dryRun) {
+      const exists = await hasForwardGateScore(d.id, supabase);
+      if (exists) skipped++; else scored++;
+      continue;
+    }
+    const res = await recordForwardGateScore(d, { supabase, logger });
+    if (res.logged) scored++;
+    else skipped++;
+  }
+  return { total: (decisions || []).length, scored, skipped, dryRun };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const limIdx = args.indexOf('--limit');
+  const limit = limIdx >= 0 ? Number(args[limIdx + 1]) : null;
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+  backfillForwardGateScores({ supabase, limit, dryRun })
+    .then((r) => {
+      console.log(`[ForwardGate backfill] total=${r.total} scored=${r.scored} skipped=${r.skipped}${r.dryRun ? ' (dry-run)' : ''}`);
+      process.exit(0);
+    })
+    .catch((e) => {
+      console.error(`[ForwardGate backfill] FAILED: ${e.message}`);
+      process.exit(1);
+    });
+}

--- a/tests/unit/eva/forward-gate.test.js
+++ b/tests/unit/eva/forward-gate.test.js
@@ -6,7 +6,7 @@
  *   - NEVER writes/updates chairman_decisions (authority unchanged — CONST-002),
  *   - is idempotent and fail-open (never blocks/alters decision creation).
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   recordForwardGateScore,
   decisionToEngineInput,
@@ -42,7 +42,8 @@ function makeSupabase({ existingCount = 0, insertError = null, insertThrows = fa
 const sampleDecision = {
   id: 'dec-1',
   lifecycle_stage: 10,
-  health_score: 72,
+  // health_score is CATEGORICAL in production ('green'/'red'/NULL) — realistic fixture.
+  health_score: 'green',
   summary: 'Gate decision for stage 10',
   decision_type: 'stage_gate',
   brief_data: { ventureName: 'Acme', cost: 1200, technologies: ['x'] },
@@ -52,10 +53,15 @@ describe('decisionToEngineInput', () => {
   it('maps live decision fields into an evaluateDecision input (honest, sparse-tolerant)', () => {
     const input = decisionToEngineInput(sampleDecision);
     expect(input.stage).toBe('10');
-    expect(input.visionScore).toBe(72);
     expect(input.description).toBe('Gate decision for stage 10');
     expect(input.cost).toBe(1200);
     expect(input.technologies).toEqual(['x']);
+  });
+
+  it('does NOT feed categorical health_score as a numeric visionScore (would be NaN)', () => {
+    // Regression guard: health_score 'green'/'red' must never become input.visionScore.
+    expect(decisionToEngineInput(sampleDecision)).not.toHaveProperty('visionScore');
+    expect(decisionToEngineInput({ id: 'd', lifecycle_stage: 5, health_score: 'red' })).not.toHaveProperty('visionScore');
   });
 
   it('tolerates a bare decision with no brief_data', () => {
@@ -155,12 +161,59 @@ describe('TS-3: forward path (createOrReusePendingDecision) proceeds unchanged w
     };
   }
 
-  it('still returns the decision even when advisory scoring fails (fail-open)', async () => {
+  it('still returns the decision even when advisory scoring fails (fail-open) — reuse branch', async () => {
     const logger = { log() {}, warn() {}, error() {} };
     const result = await createOrReusePendingDecision({
       ventureId: 'v1', stageNumber: 10, supabase: wiringSupabase(), logger,
     });
     expect(result.id).toBe('existing-id');
     expect(result.isNew).toBe(false);
+  });
+
+  /** table-aware fake: NO existing decision → new-created branch; audit insert throws (fail-open). */
+  function newCreateSupabase() {
+    let stageWorkQueried = false;
+    return {
+      rpc: async () => ({ data: { creates_decision: true, gate_type: 'kill', review_mode: 'review' }, error: null }),
+      from(table) {
+        if (table === 'chairman_decisions') {
+          return {
+            select() { return this; },
+            eq() { return this; },
+            single: async () => ({ data: null }), // none existing → create
+            insert() { return { select: () => ({ single: async () => ({ data: { id: 'new-id' }, error: null }) }) }; },
+          };
+        }
+        if (table === 'venture_stage_work') {
+          stageWorkQueried = true;
+          return {
+            select() { return this; },
+            eq() { return this; },
+            not() { return this; },
+            order() { return this; },
+            limit() { return this; },
+            maybeSingle: async () => ({ data: { health_score: 'green' } }),
+          };
+        }
+        // audit_log: coverage check → 0, insert throws to prove fail-open on the NEW branch
+        return {
+          select() { return this; },
+          eq() { return this; },
+          then(resolve) { resolve({ count: 0, error: null }); },
+          insert() { throw new Error('audit boom (new branch)'); },
+        };
+      },
+      _stageWorkQueried: () => stageWorkQueried,
+    };
+  }
+
+  it('scores + returns the decision on the NEW-created branch even when scoring throws (fail-open)', async () => {
+    const logger = { log() {}, warn() {}, error() {} };
+    const sb = newCreateSupabase();
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 22, supabase: sb, logger,
+    });
+    expect(result.id).toBe('new-id');
+    expect(result.isNew).toBe(true);
   });
 });

--- a/tests/unit/eva/forward-gate.test.js
+++ b/tests/unit/eva/forward-gate.test.js
@@ -1,0 +1,166 @@
+/**
+ * SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001
+ *
+ * The ADVISORY/log-only chairman-decision forward gate:
+ *   - runs the PURE evaluateDecision() over each decision and logs the verdict to audit_log,
+ *   - NEVER writes/updates chairman_decisions (authority unchanged — CONST-002),
+ *   - is idempotent and fail-open (never blocks/alters decision creation).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  recordForwardGateScore,
+  decisionToEngineInput,
+  hasForwardGateScore,
+  FORWARD_GATE_EVENT,
+} from '../../../lib/eva/forward-gate.js';
+import { createOrReusePendingDecision } from '../../../lib/eva/chairman-decision-watcher.js';
+
+/** Fake supabase recording every write; select-count awaits to `existingCount`. */
+function makeSupabase({ existingCount = 0, insertError = null, insertThrows = false } = {}) {
+  const writes = [];
+  const sb = {
+    writes,
+    from(table) {
+      const builder = {
+        select() { return builder; },
+        eq() { return builder; },
+        update(payload) { writes.push({ table, op: 'update', payload }); return { eq: () => Promise.resolve({ error: null }) }; },
+        insert(payload) {
+          writes.push({ table, op: 'insert', payload });
+          if (insertThrows) throw new Error('insert boom');
+          return Promise.resolve({ error: insertError });
+        },
+        // select-count await (hasForwardGateScore)
+        then(resolve) { resolve({ count: existingCount, error: null }); },
+      };
+      return builder;
+    },
+  };
+  return sb;
+}
+
+const sampleDecision = {
+  id: 'dec-1',
+  lifecycle_stage: 10,
+  health_score: 72,
+  summary: 'Gate decision for stage 10',
+  decision_type: 'stage_gate',
+  brief_data: { ventureName: 'Acme', cost: 1200, technologies: ['x'] },
+};
+
+describe('decisionToEngineInput', () => {
+  it('maps live decision fields into an evaluateDecision input (honest, sparse-tolerant)', () => {
+    const input = decisionToEngineInput(sampleDecision);
+    expect(input.stage).toBe('10');
+    expect(input.visionScore).toBe(72);
+    expect(input.description).toBe('Gate decision for stage 10');
+    expect(input.cost).toBe(1200);
+    expect(input.technologies).toEqual(['x']);
+  });
+
+  it('tolerates a bare decision with no brief_data', () => {
+    const input = decisionToEngineInput({ id: 'd', lifecycle_stage: 3 });
+    expect(input.stage).toBe('3');
+    expect(input).not.toHaveProperty('cost');
+  });
+});
+
+describe('recordForwardGateScore — TS-1: invokes evaluateDecision and logs advisory score', () => {
+  it('writes exactly one audit_log row with score/triggers, severity=info, entity_id=decision.id', async () => {
+    const sb = makeSupabase({ existingCount: 0 });
+    const res = await recordForwardGateScore(sampleDecision, { supabase: sb });
+    expect(res.logged).toBe(true);
+    expect(res.verdict).toBeTruthy();
+    expect(typeof res.verdict.recommendation).toBe('string'); // engine genuinely ran
+    const inserts = sb.writes.filter((w) => w.op === 'insert');
+    expect(inserts).toHaveLength(1);
+    const row = inserts[0];
+    expect(row.table).toBe('audit_log');
+    expect(row.payload.event_type).toBe(FORWARD_GATE_EVENT);
+    expect(row.payload.entity_type).toBe('chairman_decision');
+    expect(row.payload.entity_id).toBe('dec-1');
+    expect(row.payload.severity).toBe('info');
+    expect(row.payload.metadata.advisory).toBe(true);
+    expect(Array.isArray(row.payload.metadata.triggers)).toBe(true);
+  });
+});
+
+describe('recordForwardGateScore — TS-2: CONST-002 authority is untouched', () => {
+  it('issues ZERO writes/updates to chairman_decisions (only audit_log)', async () => {
+    const sb = makeSupabase({ existingCount: 0 });
+    await recordForwardGateScore(sampleDecision, { supabase: sb });
+    const chairmanWrites = sb.writes.filter((w) => w.table === 'chairman_decisions');
+    expect(chairmanWrites).toHaveLength(0);
+    expect(sb.writes.every((w) => w.table === 'audit_log')).toBe(true);
+  });
+});
+
+describe('recordForwardGateScore — TS-4: idempotent', () => {
+  it('skips (no insert) when a coverage row already exists for the decision', async () => {
+    const sb = makeSupabase({ existingCount: 1 });
+    const res = await recordForwardGateScore(sampleDecision, { supabase: sb });
+    expect(res.logged).toBe(false);
+    expect(res.skipped).toBe(true);
+    expect(sb.writes.filter((w) => w.op === 'insert')).toHaveLength(0);
+  });
+});
+
+describe('recordForwardGateScore — fail-open', () => {
+  it('returns {logged:false} and never throws when the audit insert errors', async () => {
+    const sb = makeSupabase({ existingCount: 0, insertError: { message: 'db down' } });
+    const res = await recordForwardGateScore(sampleDecision, { supabase: sb });
+    expect(res.logged).toBe(false);
+  });
+
+  it('returns {logged:false} and never throws when the audit insert THROWS', async () => {
+    const sb = makeSupabase({ existingCount: 0, insertThrows: true });
+    await expect(recordForwardGateScore(sampleDecision, { supabase: sb })).resolves.toMatchObject({ logged: false });
+  });
+
+  it('returns {logged:false} on missing decision.id or supabase', async () => {
+    expect(await recordForwardGateScore(null, { supabase: makeSupabase() })).toMatchObject({ logged: false });
+    expect(await recordForwardGateScore({ id: 'x' }, {})).toMatchObject({ logged: false });
+  });
+});
+
+describe('hasForwardGateScore', () => {
+  it('true when count>0, false when 0', async () => {
+    expect(await hasForwardGateScore('d', makeSupabase({ existingCount: 3 }))).toBe(true);
+    expect(await hasForwardGateScore('d', makeSupabase({ existingCount: 0 }))).toBe(false);
+  });
+});
+
+describe('TS-3: forward path (createOrReusePendingDecision) proceeds unchanged with the gate wired', () => {
+  /** table-aware fake: a decision-creating stage, an existing pending decision, and an audit_log that THROWS. */
+  function wiringSupabase() {
+    return {
+      rpc: async () => ({ data: { creates_decision: true, gate_type: 'kill', review_mode: 'review' }, error: null }),
+      from(table) {
+        if (table === 'chairman_decisions') {
+          return {
+            select() { return this; },
+            eq() { return this; },
+            single: async () => ({ data: { id: 'existing-id' } }),
+            update() { return { eq: async () => ({ error: null }) }; },
+          };
+        }
+        // audit_log: hasForwardGateScore awaits → 0; insert rejects to prove fail-open
+        return {
+          select() { return this; },
+          eq() { return this; },
+          then(resolve) { resolve({ count: 0, error: null }); },
+          insert() { return Promise.reject(new Error('audit boom')); },
+        };
+      },
+    };
+  }
+
+  it('still returns the decision even when advisory scoring fails (fail-open)', async () => {
+    const logger = { log() {}, warn() {}, error() {} };
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 10, supabase: wiringSupabase(), logger,
+    });
+    expect(result.id).toBe('existing-id');
+    expect(result.isNew).toBe(false);
+  });
+});

--- a/tests/unit/vdr-governance-probes.test.js
+++ b/tests/unit/vdr-governance-probes.test.js
@@ -79,9 +79,10 @@ describe('FR-2/FR-3: governance kr_status probes — score tracks the live KR si
 describe('FR-2/FR-3: governance code_grep probes — partial on match, unbuilt on miss, unknown without a seam (never false-built)', () => {
   const GREP_CAPS = [
     ['Govern-by-exception', 'database/migrations', 'enforce_doctrine_of_constraint'],
-    // 'Decision Filter Engine' moved to a db_count audit_log coverage probe by
-    // SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001 (it is now WIRED, not merely defined) — see its
-    // dedicated db_count describe block below.
+    // 'Decision Filter Engine' stays code_grep (HONEST band = partial) even after
+    // SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001 wired it as an ADVISORY forward filter: the ord-13
+    // required state is "gating" and CONST-002 forbids gating, so advisory wiring is not 'built'.
+    ['Decision Filter Engine', 'lib/eva', 'evaluateDecision'],
   ];
 
   for (const [cap, expectedPath, expectedPattern] of GREP_CAPS) {
@@ -111,47 +112,13 @@ describe('FR-2/FR-3: governance code_grep probes — partial on match, unbuilt o
   }
 });
 
-describe('SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001: ord-13 Decision Filter Engine reads forward-gate coverage (db_count audit_log)', () => {
-  /** Mock supabase whose audit_log count(event_type=chairman_forward_gate_score) is `n`. */
-  function countMock(n) {
-    return {
-      from(table) {
-        const b = {
-          select() { return b; },
-          eq() { return b; },
-          then(resolve) {
-            if (table === 'audit_log') return resolve({ count: n, error: null });
-            return resolve({ count: null, error: { message: 'unexpected table ' + table } });
-          },
-        };
-        return b;
-      },
-    };
-  }
-
-  it('is wired to db_count over audit_log event_type=chairman_forward_gate_score (NOT code_grep)', () => {
-    const e = reg('Decision Filter Engine');
-    expect(e.probe.type).toBe('db_count');
-    expect(e.probe.table).toBe('audit_log');
-    expect(e.probe.filter).toEqual({ event_type: 'chairman_forward_gate_score' });
-    expect(e.probe.builtWhen).toBe('gte');
-    expect(e.probe.min).toBe(1);
-    expect(e.layer).toBe('process');
-  });
-
-  it('bands BUILT on real coverage (>=1 scored decision) and UNBUILT on zero — honest both ways', async () => {
+describe('SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001: ord-13 stays HONEST partial (advisory wiring != gating)', () => {
+  it('Decision Filter Engine is NOT banded built — required state is gating, CONST-002 forbids gating', async () => {
     const probe = reg('Decision Filter Engine').probe;
-    expect((await runProbe(probe, { supabase: countMock(52) })).status).toBe('built');
-    expect((await runProbe(probe, { supabase: countMock(1) })).status).toBe('built');
-    expect((await runProbe(probe, { supabase: countMock(0) })).status).toBe('unbuilt');
-  });
-
-  it('label stays byte-identical so assertRegistryCoherence holds after the probe-type change', () => {
-    const rows = VDR_REGISTRY.map((x) => ({ capability: x.capability, today: '', required: '' }));
-    const res = assertRegistryCoherence(rows);
-    expect(res.ok).toBe(true);
-    expect(res.missingProbes).toEqual([]);
-    expect(res.staleProbes).toEqual([]);
+    // The engine IS present (advisory-wired) → code_grep matches → partial, never built.
+    const matched = await runProbe(probe, { grep: () => ({ matched: true, accessible: true }) });
+    expect(matched.status).toBe('partial');
+    expect(matched.status).not.toBe('built');
   });
 });
 
@@ -232,10 +199,7 @@ describe('FR-3: computeBuildGauge end-to-end — governance contributes, coheren
     expect(byCap['OKR-driven prioritization + day-28 hard stop']).toBe('built');
     expect(byCap['Governance cascade enforced']).toBe('built');
     expect(byCap['Govern-by-exception']).toBe('partial');
-    // Decision Filter Engine is now a db_count audit_log probe; gaugeMock returns a count error for
-    // db_count → 'unknown' (excluded, never false-built). Live coverage bands it 'built' (see the
-    // dedicated db_count describe block above).
-    expect(byCap['Decision Filter Engine']).toBe('unknown');
+    expect(byCap['Decision Filter Engine']).toBe('partial');
     // governance lives in the 'process' layer breakdown
     expect(gauge.per_layer.process).not.toBeNull();
   });

--- a/tests/unit/vdr-governance-probes.test.js
+++ b/tests/unit/vdr-governance-probes.test.js
@@ -79,7 +79,9 @@ describe('FR-2/FR-3: governance kr_status probes — score tracks the live KR si
 describe('FR-2/FR-3: governance code_grep probes — partial on match, unbuilt on miss, unknown without a seam (never false-built)', () => {
   const GREP_CAPS = [
     ['Govern-by-exception', 'database/migrations', 'enforce_doctrine_of_constraint'],
-    ['Decision Filter Engine', 'lib/eva', 'evaluateDecision'],
+    // 'Decision Filter Engine' moved to a db_count audit_log coverage probe by
+    // SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001 (it is now WIRED, not merely defined) — see its
+    // dedicated db_count describe block below.
   ];
 
   for (const [cap, expectedPath, expectedPattern] of GREP_CAPS) {
@@ -107,6 +109,50 @@ describe('FR-2/FR-3: governance code_grep probes — partial on match, unbuilt o
       expect((await runProbe(probe, {})).status).toBe('unknown');
     });
   }
+});
+
+describe('SD-LEO-INFRA-DFE-CHAIRMAN-FORWARD-GATE-001: ord-13 Decision Filter Engine reads forward-gate coverage (db_count audit_log)', () => {
+  /** Mock supabase whose audit_log count(event_type=chairman_forward_gate_score) is `n`. */
+  function countMock(n) {
+    return {
+      from(table) {
+        const b = {
+          select() { return b; },
+          eq() { return b; },
+          then(resolve) {
+            if (table === 'audit_log') return resolve({ count: n, error: null });
+            return resolve({ count: null, error: { message: 'unexpected table ' + table } });
+          },
+        };
+        return b;
+      },
+    };
+  }
+
+  it('is wired to db_count over audit_log event_type=chairman_forward_gate_score (NOT code_grep)', () => {
+    const e = reg('Decision Filter Engine');
+    expect(e.probe.type).toBe('db_count');
+    expect(e.probe.table).toBe('audit_log');
+    expect(e.probe.filter).toEqual({ event_type: 'chairman_forward_gate_score' });
+    expect(e.probe.builtWhen).toBe('gte');
+    expect(e.probe.min).toBe(1);
+    expect(e.layer).toBe('process');
+  });
+
+  it('bands BUILT on real coverage (>=1 scored decision) and UNBUILT on zero — honest both ways', async () => {
+    const probe = reg('Decision Filter Engine').probe;
+    expect((await runProbe(probe, { supabase: countMock(52) })).status).toBe('built');
+    expect((await runProbe(probe, { supabase: countMock(1) })).status).toBe('built');
+    expect((await runProbe(probe, { supabase: countMock(0) })).status).toBe('unbuilt');
+  });
+
+  it('label stays byte-identical so assertRegistryCoherence holds after the probe-type change', () => {
+    const rows = VDR_REGISTRY.map((x) => ({ capability: x.capability, today: '', required: '' }));
+    const res = assertRegistryCoherence(rows);
+    expect(res.ok).toBe(true);
+    expect(res.missingProbes).toEqual([]);
+    expect(res.staleProbes).toEqual([]);
+  });
 });
 
 describe('FR-1/FR-3: coherence invariant — criteria rows ↔ VDR_REGISTRY must stay 1:1 (atomic-PR guard)', () => {
@@ -186,7 +232,10 @@ describe('FR-3: computeBuildGauge end-to-end — governance contributes, coheren
     expect(byCap['OKR-driven prioritization + day-28 hard stop']).toBe('built');
     expect(byCap['Governance cascade enforced']).toBe('built');
     expect(byCap['Govern-by-exception']).toBe('partial');
-    expect(byCap['Decision Filter Engine']).toBe('partial');
+    // Decision Filter Engine is now a db_count audit_log probe; gaugeMock returns a count error for
+    // db_count → 'unknown' (excluded, never false-built). Live coverage bands it 'built' (see the
+    // dedicated db_count describe block above).
+    expect(byCap['Decision Filter Engine']).toBe('unknown');
     // governance lives in the 'process' layer breakdown
     expect(gauge.per_layer.process).not.toBeNull();
   });


### PR DESCRIPTION
## Summary
Wires the existing PURE `evaluateDecision()` engine into the chairman-decision FORWARD path as an **advisory, log-only** risk filter. Previously the engine was defined but never invoked on this path (dead code); now each chairman decision is risk-scored and the verdict is recorded to `audit_log` (event_type=`chairman_forward_gate_score`).

## CONST-002 — authority untouched
- Writes **only** to `audit_log`; **zero** writes/updates to `chairman_decisions`.
- Fail-open on both wired branches — a scoring error never blocks/alters decision creation.
- No RLS/policy/approval change. A harden-to-blocking mode is **out of scope** (future chairman-gated SD).

## Honest grounding (adversarial review caught 2 HIGHs)
- **ord-13 stays `partial`, not `built`**: live `vision_ladder_criteria` ord-13 required state is *'a live decision-filter engine **gating** chairman decisions'*. CONST-002 forbids gating here, so advisory wiring is **not** built — banding it built (via a sticky append-only audit_log count) would inflate the chairman's governance gauge. Kept ord-13 at honest `code_grep => partial`.
- **Dropped a NaN `visionScore` mapping**: `chairman_decisions.health_score` is categorical (`green`/`red`/NULL), not 0-100.

## Changes
- `lib/eva/forward-gate.js` (new) — `recordForwardGateScore()` advisory helper (idempotent serial, fail-open).
- `lib/eva/chairman-decision-watcher.js` — wired into `createOrReusePendingDecision` (new + reuse branches).
- `scripts/backfill-forward-gate-scores.mjs` (new) — advisory audit baseline over existing decisions (52 live, idempotent).
- `lib/vision/vdr-registry.js` — ord-13 documented + kept honest.
- Tests: 43 unit (forward-gate + watcher + vdr-governance-probes); 0 regressions across 5067 eva tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)