### PR TITLE
chore(SD-EHG-VISION-V2-AUTONOMOUS-MARKETING-CAPABILITY-001): wire seed script (WIRE_CHECK fix)

### DIFF
--- a/.prd-payloads/SD-EHG-VISION-V2-AUTONOMOUS-MARKETING-CAPABILITY-001.json
+++ b/.prd-payloads/SD-EHG-VISION-V2-AUTONOMOUS-MARKETING-CAPABILITY-001.json
@@ -1,0 +1,65 @@
+{
+  "executive_summary": "Ratify (record) the chairman-approved V2 vision capability 'Autonomous customer acquisition & distribution' as ONE vision_ladder_criteria row at the existing inactive V2 rung, WITHOUT touching the live V1 gauge. The coherence model (lib/vision/vdr-registry.js) computes the gauge over the ACTIVE rung only (dbVisionSource selects is_active=true → V1), and assertRegistryCoherence compares VDR_REGISTRY to that active set. So an inactive-V2 criteria row is invisible to V1, and FR-2 DEFERS adding a VDR_REGISTRY probe (a V2 probe while V1 is active would be a staleProbe that withholds the whole V1 gauge). The intended V2 probe (AUTONOMOUS_CAMPAIGN_EXECUTION) is documented for wiring at V2 activation. FR-3 verifies the V1 gauge still computes (same 25-criteria denominator, coherence ok). The V2 rung already exists (rung_key='V2', is_active=false, 0 criteria, id a269840a-...); V1 criteria were script-seeded (precedent), so this row is inserted live via an idempotent seed script.",
+  "system_architecture": {
+    "overview": "One additive governed-data-row INSERT into vision_ladder_criteria (pointing at the existing inactive V2 rung) via an idempotent seed script, plus a unit test proving the V1 gauge/coherence is unaffected. No schema change, no VDR_REGISTRY change, no V1 row touched.",
+    "components": [
+      {"name": "scripts/okr/seed-v2-autonomous-marketing-criteria.mjs", "responsibility": "FR-1: idempotent INSERT of the single V2 criteria row (rung_id=V2 rung, ordinal=1, capability/today/required from the chairman ratification). Service-role, upsert-on-conflict / existence-guarded so re-runs are no-ops. Mirrors scripts/okr/wire-v1-caplayer-criteria.mjs."},
+      {"name": "PRD/SD documentation of the deferred probe", "responsibility": "FR-2: record the INTENDED V2 probe AUTONOMOUS_CAMPAIGN_EXECUTION (code_grep proving lib/eva or an orchestrator invokes publisher.publish()/executePipeline() from the S24 launch path; today: zero refs → would honestly read unbuilt) + secondary candidates (DISTRIBUTION_CHANNEL_LIVE_COUNT, VENTURE_CUSTOMER_COHORT) for the chairman to pick at V2 activation. NO VDR_REGISTRY entry added now."},
+      {"name": "tests/unit/vision/v2-ratification-coherence.test.js", "responsibility": "FR-3: assert the V2 rung stays inactive, the V1 active-rung criteria set is unchanged (count + coherence), and VDR_REGISTRY contains no V2 probe — so the live V1 gauge is unaffected by the ratification."}
+    ]
+  },
+  "functional_requirements": [
+    {"id": "FR-1", "title": "Ratify the V2 capability as one inactive criteria row", "description": "Insert ONE vision_ladder_criteria row at the existing V2 rung (is_active=false): ordinal=1; capability='Autonomous customer acquisition & distribution'; today='marketing/distribution is automated at the PLANNING layer only — stages produce strategy/copy/config/playbook artifacts; EXECUTION is unwired (the lib/marketing publisher (X/Bluesky), content-pipeline.executePipeline(), and email-campaigns infra is built but ORPHANED — lib/eva has zero refs; S24 Go-Live records status=activated but invokes no publish/announce/campaign API)'; required='a venture autonomously runs real campaigns, publishes content, registers/activates real distribution channels, and runs ongoing growth WITHOUT the chairman'. Idempotent insert."},
+    {"id": "FR-2", "title": "Defer the VDR probe (preserve V1 coherence)", "description": "Do NOT add a VDR_REGISTRY entry now — assertRegistryCoherence compares VDR_REGISTRY to the ACTIVE rung (V1) byte-identically, so a V2 probe while V1 is active = a staleProbe that withholds the whole V1 gauge. Document the intended probe AUTONOMOUS_CAMPAIGN_EXECUTION (+ secondary candidates) for wiring at V2 activation."},
+    {"id": "FR-3", "title": "Verify V1 gauge intact", "description": "Assert the V1 active-rung criteria denominator is unchanged (still 25), assertRegistryCoherence is ok over the active rung, and VDR_REGISTRY has no V2 probe — proving the ratification did not affect the live V1 gauge."}
+  ],
+  "technical_requirements": [
+    {"id": "TR-1", "requirement": "The V2 criteria row attaches to the existing inactive V2 rung (id a269840a-0035-49bb-bf41-ea1d0027339b); the seed is idempotent (existence-guarded) so re-runs are no-ops."},
+    {"id": "TR-2", "requirement": "No VDR_REGISTRY change and no V1 criteria mutation — the live gauge (dbVisionSource over is_active=true) and assertRegistryCoherence must be byte-unaffected."},
+    {"id": "TR-3", "requirement": "Insert via the established script pattern (service-role), not a chairman-gated DDL migration — this is a governed DATA row at an inactive rung, chairman-ratified."}
+  ],
+  "implementation_approach": {
+    "summary": "Insert the single ratified V2 criteria row at the existing inactive rung via an idempotent seed script (script precedent), document the deferred probe, and unit-test that the V1 gauge/coherence is unaffected.",
+    "steps": [
+      "Write scripts/okr/seed-v2-autonomous-marketing-criteria.mjs (idempotent insert of the V2 criteria row).",
+      "Run it to insert the row live; confirm V2 rung stays inactive.",
+      "Document the deferred AUTONOMOUS_CAMPAIGN_EXECUTION probe (+ secondary candidates) for V2-activation wiring.",
+      "Unit-test: V1 denominator unchanged (25), assertRegistryCoherence ok, no V2 probe in VDR_REGISTRY."
+    ]
+  },
+  "integration_operationalization": {
+    "consumers": "vision_ladder_criteria is read by lib/vision/vdr-registry.js dbVisionSource (active rung only) and the vision-build gauge / adam-exec-summary. The new row is at the INACTIVE V2 rung, so it has zero live consumers until V2 is activated. The deferred probe (AUTONOMOUS_CAMPAIGN_EXECUTION) would be consumed by VDR_REGISTRY only once V2 is the active rung.",
+    "dependencies": "Depends on the existing inactive V2 rung (vision_ladder_rungs rung_key='V2', id a269840a-...). No SD dependency. Insert pattern mirrors scripts/okr/wire-v1-caplayer-criteria.mjs / seed-v1-automation-criteria.mjs.",
+    "data_contracts": "Adds one vision_ladder_criteria row {rung_id, ordinal=1, capability, today, required}. No schema change, no column change, no V1 row mutation, no VDR_REGISTRY change. The active-rung (V1) criteria set and gauge denominator are unchanged.",
+    "runtime_config": "No env vars or feature flags. The row is inserted at an inactive rung — no runtime behavior changes until the chairman activates V2 (a separate future action) and the probe is wired.",
+    "observability_rollout": "Rollout: the seed script inserts the row immediately; the V2 capability is recorded but dormant (inactive rung). Verification: the V1 gauge still computes with coherence ok and the same denominator. Rollback: delete the single V2 criteria row (no live impact — it was never in the active gauge)."
+  },
+  "acceptance_criteria": [
+    "The chairman-ratified V2 capability 'Autonomous customer acquisition & distribution' is recorded as one criteria row at the V2 rung.",
+    "The V2 rung remains inactive, so the new row is not part of the live vision gauge.",
+    "The live V1 vision gauge still computes exactly as before — same set of criteria, no coherence error introduced.",
+    "No V2 probe was added to the code registry yet (the probe is documented for later), so V1 coherence is preserved.",
+    "Re-running the insert does not create a duplicate row.",
+    "The unit test for this work passes."
+  ],
+  "test_scenarios": [
+    {"id": "TS-1", "title": "V2 criteria row recorded at the inactive rung", "type": "db", "scenario": "After running the seed, query vision_ladder_criteria joined to vision_ladder_rungs for rung_key='V2'.", "expected": "Exactly one V2 criteria row (ordinal=1, the ratified capability) whose rung is is_active=false."},
+    {"id": "TS-2", "title": "V1 gauge/coherence unaffected", "type": "unit", "scenario": "Compute the active-rung criteria set and assertRegistryCoherence (over VDR_REGISTRY vs active criteria).", "expected": "V1 denominator unchanged (25), coherence ok=true (no missingProbes/staleProbes)."},
+    {"id": "TS-3", "title": "No V2 probe in the registry", "type": "unit", "scenario": "Inspect VDR_REGISTRY for an AUTONOMOUS_CAMPAIGN_EXECUTION (or other V2) probe.", "expected": "Absent — FR-2 deferred it, so the registry still matches the active V1 criteria."},
+    {"id": "TS-4", "title": "Idempotent re-run", "type": "db", "scenario": "Run the seed script twice.", "expected": "Still exactly one V2 criteria row (no duplicate)."}
+  ],
+  "risks": [
+    {"risk": "A V2 probe added now would withhold the live V1 gauge", "mitigation": "FR-2 explicitly defers the VDR_REGISTRY probe; TS-3 asserts none is present. Coherence is computed only over the active rung.", "severity": "medium"},
+    {"risk": "Accidentally activating V2 or mutating V1 criteria", "mitigation": "Only an INSERT at the inactive V2 rung; no rung is_active change, no V1 row touched; TS-2 asserts V1 denominator + coherence unchanged.", "severity": "low"},
+    {"risk": "Duplicate criteria row on re-run", "mitigation": "Idempotent existence-guarded seed; TS-4 asserts single row.", "severity": "low"}
+  ],
+  "metadata": {
+    "sd_key": "SD-EHG-VISION-V2-AUTONOMOUS-MARKETING-CAPABILITY-001",
+    "target_application": "EHG_Engineer",
+    "target_files": [
+      "scripts/okr/seed-v2-autonomous-marketing-criteria.mjs",
+      "tests/unit/vision/v2-ratification-coherence.test.js"
+    ],
+    "created_via": "fleet-worker-charlie"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "operator:cash-burn:feed": "node scripts/operator/feed-operator-cash-burn.mjs",
     "okr:wire-o-2026-07": "node scripts/okr/wire-o-2026-07-kr-alignment.mjs",
     "vision:wire-v1-caplayer": "node scripts/okr/wire-v1-caplayer-criteria.mjs",
+    "vision:seed-v2-autonomous-marketing": "node scripts/okr/seed-v2-autonomous-marketing-criteria.mjs",
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "vision:seed-v1-automation": "node scripts/seed-v1-automation-criteria.mjs",
     "setup-db": "node scripts/setup-database.js",

--- a/scripts/okr/seed-v2-autonomous-marketing-criteria.mjs
+++ b/scripts/okr/seed-v2-autonomous-marketing-criteria.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * SD-EHG-VISION-V2-AUTONOMOUS-MARKETING-CAPABILITY-001 (FR-1) — RATIFY the chairman-approved V2
+ * vision capability 'Autonomous customer acquisition & distribution' by recording ONE row in the
+ * EXISTING vision_ladder_criteria table at the EXISTING **inactive** V2 rung.
+ *
+ * COHERENCE-SAFE (the crux): the build gauge (lib/vision/vdr-registry.js) reads criteria via
+ * dbVisionSource, which selects ONLY the is_active=true rung (V1); assertRegistryCoherence then
+ * compares VDR_REGISTRY to that active set. An inactive-V2 criteria row is therefore NEVER in the
+ * parsed set — invisible to the V1 gauge. So:
+ *   - This script REFUSES to run if the V2 rung is somehow active (an active rung would demand a
+ *     matching VDR_REGISTRY probe; inserting without one would withhold the whole gauge).
+ *   - FR-2 deliberately does NOT add a VDR_REGISTRY probe now. The intended probe at V2-activation:
+ *       AUTONOMOUS_CAMPAIGN_EXECUTION = code_grep proving lib/eva (or an orchestrator) invokes
+ *       publisher.publish()/content-pipeline.executePipeline() from the S24 launch path (today: zero
+ *       refs -> would honestly read unbuilt). Secondary candidates (chairman picks at activation):
+ *       DISTRIBUTION_CHANNEL_LIVE_COUNT, VENTURE_CUSTOMER_COHORT.
+ *
+ * IDEMPOTENT: skip-existing on (rung_id, capability) — a re-run inserts nothing.
+ *
+ * Usage:
+ *   node scripts/okr/seed-v2-autonomous-marketing-criteria.mjs            # dry-run preview
+ *   node scripts/okr/seed-v2-autonomous-marketing-criteria.mjs --apply    # execute the insert
+ */
+
+import 'dotenv/config';
+import { fileURLToPath } from 'node:url';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+
+/** The single ratified V2 criteria row (capability text is the chairman-ratified label). */
+export const V2_CRITERION = Object.freeze({
+  ordinal: 1,
+  capability: 'Autonomous customer acquisition & distribution',
+  today:
+    'marketing/distribution is automated at the PLANNING layer only (stages produce strategy/copy/config/playbook artifacts); EXECUTION is unwired — the lib/marketing publisher (X/Bluesky), content-pipeline.executePipeline(), and email-campaigns infra is built but ORPHANED (lib/eva has zero refs); S24 Go-Live records status=activated but invokes no publish/announce/campaign API',
+  required:
+    'a venture autonomously runs real campaigns, publishes content, registers/activates real distribution channels, and runs ongoing growth WITHOUT the chairman',
+});
+
+/** Pure: build the criteria row object for the V2 rung. Testable; no I/O. */
+export function buildV2CriteriaRow(rungId) {
+  return {
+    rung_id: rungId,
+    ordinal: V2_CRITERION.ordinal,
+    capability: V2_CRITERION.capability,
+    today: V2_CRITERION.today,
+    required: V2_CRITERION.required,
+  };
+}
+
+/** Pure: the (rung_id, capability) idempotency key. */
+export function criteriaKey(row) {
+  return `${row.rung_id}::${row.capability}`;
+}
+
+export const _internals = { V2_CRITERION };
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const supabase = createSupabaseServiceClient();
+
+  // Resolve the V2 rung at runtime by rung_key (the id is gen_random_uuid() at seed time, not a
+  // stable literal). REFUSE if it is active — ratifying onto an active rung would require a matching
+  // VDR_REGISTRY probe and, without one, withhold the whole gauge (the exact failure FR-2 avoids).
+  const { data: rung, error: rungErr } = await supabase
+    .from('vision_ladder_rungs')
+    .select('id, rung_key, is_active')
+    .eq('rung_key', 'V2')
+    .maybeSingle();
+  if (rungErr) { console.error('FATAL: V2-rung lookup failed:', rungErr.message); process.exit(1); }
+  if (!rung) { console.error("FATAL: no V2 rung (vision_ladder_rungs rung_key='V2') — cannot ratify"); process.exit(1); }
+  if (rung.is_active !== false) {
+    console.error(`FATAL: V2 rung is_active=${rung.is_active} — refusing to add a coherence-bearing criterion to an ACTIVE rung without a matching VDR_REGISTRY probe (FR-2)`);
+    process.exit(1);
+  }
+  const rungId = rung.id;
+  const row = buildV2CriteriaRow(rungId);
+  console.log(`\n=== seed-v2-autonomous-marketing-criteria (${apply ? 'APPLY' : 'DRY-RUN'}) — rung ${rungId.slice(0, 8)} (V2, inactive) ===\n`);
+
+  // Skip-existing on (rung_id, capability).
+  const { data: existing, error: exErr } = await supabase
+    .from('vision_ladder_criteria')
+    .select('rung_id, capability')
+    .eq('rung_id', rungId);
+  if (exErr) { console.error('FATAL: read existing criteria failed:', exErr.message); process.exit(1); }
+  const have = new Set((existing || []).map(criteriaKey));
+
+  if (have.has(criteriaKey(row))) {
+    console.log(`  [EXISTS (skip)] ordinal ${row.ordinal} <- '${row.capability}'\nNothing to insert — already ratified (idempotent no-op).`);
+    return;
+  }
+  console.log(`  [${apply ? 'INSERT' : 'would insert'}] ordinal ${row.ordinal} <- '${row.capability}'`);
+  if (!apply) { console.log(`\n=== DRY-RUN — re-run with --apply to insert ===\n`); return; }
+
+  const { error: insErr } = await supabase.from('vision_ladder_criteria').insert(row);
+  if (insErr) { console.error('FATAL: insert failed:', insErr.message); process.exit(1); }
+  console.log(`\n=== APPLIED — ratified the V2 capability (1 criteria row) ===\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((e) => { console.error('FATAL:', e.message); process.exit(1); });
+}

--- a/tests/unit/vision/v2-ratification-coherence.test.js
+++ b/tests/unit/vision/v2-ratification-coherence.test.js
@@ -1,0 +1,83 @@
+/**
+ * SD-EHG-VISION-V2-AUTONOMOUS-MARKETING-CAPABILITY-001 — FR-3 (verify V1 gauge intact)
+ *
+ * Proves the V2 ratification is coherence-safe:
+ *  (hermetic) the V2 capability is NOT in VDR_REGISTRY (FR-2 deferred the probe), and the seed
+ *             logic builds the correct row;
+ *  (live)     the V2 rung stays inactive with the single ratified row, the active V1 rung keeps its
+ *             25-criteria denominator, and assertRegistryCoherence is ok over the active rung — so
+ *             the inactive V2 row is invisible to the live V1 gauge.
+ *
+ * The live block runs against the engineer DB (where the seed was applied); it reads only — no writes.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import 'dotenv/config';
+import { VDR_REGISTRY, assertRegistryCoherence } from '../../../lib/vision/vdr-registry.js';
+import { buildV2CriteriaRow, V2_CRITERION, criteriaKey } from '../../../scripts/okr/seed-v2-autonomous-marketing-criteria.mjs';
+import { createDatabaseClient } from '../../../scripts/lib/supabase-connection.js';
+
+const V2_CAP = 'Autonomous customer acquisition & distribution';
+
+describe('FR-2: the V2 probe is deferred (not in VDR_REGISTRY)', () => {
+  it('VDR_REGISTRY contains no V2 capability / autonomous-campaign probe', () => {
+    const caps = VDR_REGISTRY.map((e) => e.capability);
+    expect(caps).not.toContain(V2_CAP);
+    const blob = JSON.stringify(VDR_REGISTRY).toLowerCase();
+    expect(blob).not.toMatch(/autonomous_campaign_execution|autonomous customer acquisition/);
+  });
+});
+
+describe('FR-1: seed logic builds the ratified V2 row', () => {
+  it('buildV2CriteriaRow produces ordinal 1 + the ratified capability for the given rung', () => {
+    const row = buildV2CriteriaRow('rung-xyz');
+    expect(row).toMatchObject({ rung_id: 'rung-xyz', ordinal: 1, capability: V2_CAP });
+    expect(row.today).toMatch(/PLANNING layer only/);
+    expect(row.required).toMatch(/WITHOUT the chairman/);
+    expect(criteriaKey(row)).toBe(`rung-xyz::${V2_CAP}`);
+    expect(V2_CRITERION.capability).toBe(V2_CAP);
+  });
+});
+
+const HAS_DB = Boolean(process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL);
+describe.skipIf(!HAS_DB)('FR-3 (live): V2 recorded inactive; V1 gauge unaffected', () => {
+  let client;
+  beforeAll(async () => {
+    client = await createDatabaseClient('engineer', {
+      connectionString: process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL,
+    });
+  });
+  afterAll(async () => { if (client) await client.end(); });
+
+  it('the V2 rung is inactive and carries the single ratified criterion', async () => {
+    const r = await client.query(
+      `SELECT r.is_active, count(c.id)::int AS n,
+              bool_or(c.capability = $1) AS has_cap
+       FROM vision_ladder_rungs r
+       LEFT JOIN vision_ladder_criteria c ON c.rung_id = r.id
+       WHERE r.rung_key = 'V2'
+       GROUP BY r.is_active`,
+      [V2_CAP],
+    );
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0].is_active).toBe(false);
+    expect(r.rows[0].n).toBe(1);
+    expect(r.rows[0].has_cap).toBe(true);
+  });
+
+  it('the active V1 rung keeps its 25-criteria denominator and assertRegistryCoherence is ok', async () => {
+    const r = await client.query(
+      `SELECT c.capability
+       FROM vision_ladder_rungs r
+       JOIN vision_ladder_criteria c ON c.rung_id = r.id
+       WHERE r.is_active = true`,
+    );
+    // The active-rung denominator must equal the registry probe count (coherence's real invariant) —
+    // derived from VDR_REGISTRY rather than a brittle literal, so a legit future V1 change doesn't
+    // spuriously fail this V2-ratification guard, while a V2 row leaking into the active set still would.
+    expect(r.rows.length).toBe(VDR_REGISTRY.length); // denominator unchanged by the V2 ratification
+    const coherence = assertRegistryCoherence(r.rows.map((x) => ({ capability: x.capability })));
+    expect(coherence.ok).toBe(true);
+    expect(coherence.staleProbes).toEqual([]);
+    expect(coherence.missingProbes).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds the package.json npm-script entry point for scripts/okr/seed-v2-autonomous-marketing-criteria.mjs so WIRE_CHECK_GATE passes at LEAD-FINAL (the seed is invoked as a CLI; mirrors vision:wire-v1-caplayer). Follow-up to the squash-merged #4872.