### PR TITLE
feat(SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001): canonical typed loop-contract framework + 2 exemplars

### DIFF
--- a/lib/loops/loop-contract-registry.js
+++ b/lib/loops/loop-contract-registry.js
@@ -1,0 +1,126 @@
+/**
+ * Loop-Contract Registry — enumerable, queryable declarations.
+ *
+ * SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001 (FR-2, FR-3)
+ *
+ * A frozen array of declared loop contracts plus list()/get()/assertContractsValid().
+ * Mirrors the house registry style (lib/adam/adherence-probes.js Object.freeze set,
+ * lib/governance/guardrail-registry.js list()/get() + _test reset).
+ *
+ * FR-3: two EXISTING loops are declared here as exemplars. The declarations are DATA
+ * ONLY — this module never imports or runs the loop entrypoints; cron strings + flags
+ * are carried as plain strings. So declaring a loop changes NOTHING about how it runs.
+ */
+
+import { validateLoopContract, CADENCE_TYPE, BOUNDARY_KIND } from './loop-contract.js';
+
+/**
+ * Exemplar 1 — CI Auto-Triage Loop.
+ * Entrypoint: scripts/clockwork/ci-autotriage-loop.cjs
+ * Workflow:   .github/workflows/clockwork-ci-autotriage-loop.yml (cron '50 * * * *')
+ * Built by SD-LEO-INFRA-CI-FAILURE-AUTOTRIAGE-LOOP-001.
+ */
+const CI_AUTOTRIAGE_CONTRACT = {
+  id: 'LOOP-CI-AUTOTRIAGE-001',
+  name: 'CI Auto-Triage Loop',
+  goals: [
+    'Detect recurring, uncovered CI-failure classes (chronic, >= threshold occurrences)',
+    'Trace each chronic class to a corrective work item without auto-fixing it',
+  ],
+  workflow: [
+    { step: 1, name: 'Fetch open ci_failure feedback rows', action: 'read' },
+    { step: 2, name: 'Strip dead links to terminal SDs so stale links do not suppress recurrence', action: 'cleanup' },
+    { step: 3, name: 'Detect chronic uncovered classes (per-class threshold)', action: 'classify' },
+    { step: 4, name: 'Source one DRAFT corrective SD per class via leo-create-sd.js --from-feedback', action: 'propose' },
+    { step: 5, name: 'Link the class rows to the corrective SD (status in_progress)', action: 'relate' },
+  ],
+  boundaries: [
+    { kind: BOUNDARY_KIND.MAY, description: 'Read feedback rows, detect chronic classes (pure logic), source DRAFT SDs via the canonical CLI, tag metadata, link class rows.' },
+    { kind: BOUNDARY_KIND.MAY_NOT, description: 'Edit code, merge, auto-fix CI, write directly to strategy tables, or resolve the class rows (diagnosis is deferred to the SD worker — CONST-002).' },
+  ],
+  tasks: [
+    { task: 'entrypoint', file: 'scripts/clockwork/ci-autotriage-loop.cjs' },
+    { task: 'pure_logic', file: 'scripts/lib/ci-recurrence-detector.mjs' },
+    { task: 'flag', key: 'CI_AUTOTRIAGE_LOOP_ENABLE', default: 'false' },
+  ],
+  timeline: { type: CADENCE_TYPE.CRON, cadence: '50 * * * *', description: 'Hourly at :50 (post-capture, post-triage, post-self-heal)', fail_soft: true, proposal_only: true },
+  logging: { writes: ['count of DRAFT SDs sourced', 'per-run + per-day cap remaining', 'class->SD linkage'], durable_ledger: null, event_bus: null },
+};
+
+/**
+ * Exemplar 2 — Adam Opportunity-Scan heartbeat.
+ * Entrypoint: scripts/adam-opportunity-scan.cjs (npm run adam:scan)
+ * Workflow:   .github/workflows/adam-opportunity-scan-cron.yml (cron '37 * * * *')
+ * Ships INERT behind ADAM_GOVERNANCE_HEARTBEAT_V1 (default OFF).
+ */
+const ADAM_OPPORTUNITY_SCAN_CONTRACT = {
+  id: 'LOOP-ADAM-OPPORTUNITY-SCAN-001',
+  name: 'Adam Opportunity-Scan Heartbeat',
+  goals: [
+    'Rotate through portfolio scopes (harness, platform, per-venture) on a deterministic round-robin',
+    'Surface at most one ranked advisory per tick when it clears the rationale bar, else stay silent',
+  ],
+  workflow: [
+    { step: 1, name: 'Select the scope for this tick (deterministic weighted round-robin)', action: 'select' },
+    { step: 2, name: 'Run a read-only per-scope briefing', action: 'read' },
+    { step: 3, name: 'Apply the rationale bar to candidate advisories', action: 'rank' },
+    { step: 4, name: 'Either append ADAM_OK to the local ledger or shell ONE advisory to adam-advisory.cjs', action: 'surface' },
+  ],
+  boundaries: [
+    { kind: BOUNDARY_KIND.MAY, description: 'Read existing tables, compute briefings, rank advisories, append the append-only local ledger, shell at most one advisory.' },
+    { kind: BOUNDARY_KIND.MAY_NOT, description: 'Write to strategy tables, create SDs directly, or modify portfolio scope (the advisory script — not the scan — decides; CONST-002).' },
+  ],
+  tasks: [
+    { task: 'entrypoint', file: 'scripts/adam-opportunity-scan.cjs' },
+    { task: 'scope_registry', file: 'lib/adam/scope-registry.js' },
+    { task: 'flag', key: 'ADAM_GOVERNANCE_HEARTBEAT_V1', default: 'off' },
+  ],
+  timeline: { type: CADENCE_TYPE.CRON, cadence: '37 * * * *', description: 'Hourly at :37 (offset from the exec-email cron to dodge runner congestion)', fail_soft: true, advisory_only: true },
+  logging: { writes: ['ADAM_OK | SURFACED | SUPPRESSED_FLAG_OFF verdict', 'selected scope', 'ledger entry (bounded 500)'], durable_ledger: 'local .json', event_bus: null },
+};
+
+/** The canonical declared set. Frozen — runtime cannot mutate it. */
+export const LOOP_CONTRACTS = Object.freeze([
+  Object.freeze(CI_AUTOTRIAGE_CONTRACT),
+  Object.freeze(ADAM_OPPORTUNITY_SCAN_CONTRACT),
+]);
+
+/** Enumerable summaries (id, name, cadence) for every declared loop. */
+export function list() {
+  return LOOP_CONTRACTS.map((c) => ({
+    id: c.id,
+    name: c.name,
+    cadence: c.timeline && c.timeline.cadence,
+    cadence_type: c.timeline && c.timeline.type,
+  }));
+}
+
+/** Full contract for a loop id, or undefined. */
+export function get(loopId) {
+  return LOOP_CONTRACTS.find((c) => c.id === loopId);
+}
+
+/**
+ * Coherence guard (mirrors VDR assertRegistryCoherence): run the validator over every
+ * declared contract and THROW listing any invalid one. Loud-by-design — a malformed
+ * declaration must never sit silently in the registry.
+ * @returns {true} when all declared contracts are valid.
+ */
+export function assertContractsValid() {
+  const failures = [];
+  for (const c of LOOP_CONTRACTS) {
+    const { valid, errors } = validateLoopContract(c);
+    if (!valid) failures.push(`${(c && c.id) || '<no id>'}: ${errors.join('; ')}`);
+  }
+  if (failures.length) {
+    throw new Error(`Loop-contract registry incoherent — invalid contract(s):\n  - ${failures.join('\n  - ')}`);
+  }
+  return true;
+}
+
+// Loud at import: a malformed declaration fails fast (house style — VDR taxonomy guard).
+assertContractsValid();
+
+export const _test = Object.freeze({
+  contracts: () => LOOP_CONTRACTS,
+});

--- a/lib/loops/loop-contract.js
+++ b/lib/loops/loop-contract.js
@@ -1,0 +1,126 @@
+/**
+ * Canonical Loop-Contract schema + validator.
+ *
+ * SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001 (FR-1)
+ *
+ * A typed contract every operational loop (Adam/coordinator ticks, CI-triage,
+ * distill, future V2 venture loops) can declare, so loops are self-describing,
+ * bounded, and auditable. This module is the SCHEMA + a pure, fail-loud validator —
+ * it builds no loops and runs none.
+ *
+ * A loop contract has the chairman's named fields:
+ *   - id         : stable identifier (e.g. 'LOOP-CI-AUTOTRIAGE-001')
+ *   - name       : human label
+ *   - goals      : string[]  — what the loop is FOR (>=1)
+ *   - workflow   : ordered step objects { step:number, name:string, action?:string } (>=1)
+ *   - boundaries : { kind: 'may'|'may_not', description:string }[] — explicit limits
+ *                  (>=1 of EACH kind: a loop must say both what it may and may NOT do)
+ *   - tasks      : object[]   — concrete artifacts (entrypoint/config/etc.) (optional, type-checked)
+ *   - timeline   : { cadence:string, type?:CADENCE_TYPE, ... } — when it runs (cadence required)
+ *   - logging    : object     — the logging contract (what it writes) (optional, type-checked)
+ *
+ * Design mirrors lib/adam/adherence-probes.js + lib/governance/guardrail-registry.js:
+ * frozen enums, pure total functions, fail-loud (never silent-pass).
+ */
+
+export const CADENCE_TYPE = Object.freeze({
+  CRON: 'cron',
+  INTERVAL: 'interval',
+  EVENT: 'event',
+  MANUAL: 'manual',
+});
+
+export const BOUNDARY_KIND = Object.freeze({
+  MAY: 'may',
+  MAY_NOT: 'may_not',
+});
+
+/** Canonical field list (the chairman's named fields). Required vs optional below. */
+export const LOOP_CONTRACT_FIELDS = Object.freeze([
+  'id', 'name', 'goals', 'workflow', 'boundaries', 'tasks', 'timeline', 'logging',
+]);
+
+/** Required fields — absence/emptiness => invalid (fail-loud). */
+const REQUIRED_FIELDS = Object.freeze(['id', 'name', 'goals', 'workflow', 'boundaries', 'timeline']);
+
+const isNonEmptyString = (v) => typeof v === 'string' && v.trim().length > 0;
+const isNonEmptyArray = (v) => Array.isArray(v) && v.length > 0;
+
+/**
+ * Validate a loop contract. PURE and TOTAL — never throws, even on hostile input
+ * (a throwing getter degrades to valid:false). Returns the offending field(s) by name.
+ *
+ * @param {Object} contract
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateLoopContract(contract) {
+  const errors = [];
+  try {
+    if (!contract || typeof contract !== 'object' || Array.isArray(contract)) {
+      return { valid: false, errors: ['contract must be a non-null object'] };
+    }
+
+    // id / name — non-empty strings
+    if (!isNonEmptyString(safeGet(contract, 'id'))) errors.push('id: required non-empty string');
+    if (!isNonEmptyString(safeGet(contract, 'name'))) errors.push('name: required non-empty string');
+
+    // goals — non-empty array of non-empty strings
+    const goals = safeGet(contract, 'goals');
+    if (!isNonEmptyArray(goals)) errors.push('goals: required non-empty array');
+    else if (!goals.every(isNonEmptyString)) errors.push('goals: every goal must be a non-empty string');
+
+    // workflow — non-empty array of ordered step objects
+    const workflow = safeGet(contract, 'workflow');
+    if (!isNonEmptyArray(workflow)) {
+      errors.push('workflow: required non-empty array of ordered steps');
+    } else {
+      const bad = workflow.some((w) => !w || typeof w !== 'object' || typeof w.step !== 'number' || !isNonEmptyString(w.name));
+      if (bad) errors.push('workflow: each step needs a numeric step and a non-empty name');
+    }
+
+    // boundaries — >=1 MAY and >=1 MAY_NOT, each with a description
+    const boundaries = safeGet(contract, 'boundaries');
+    if (!isNonEmptyArray(boundaries)) {
+      errors.push('boundaries: required non-empty array of {kind, description}');
+    } else {
+      const kinds = new Set(Object.values(BOUNDARY_KIND));
+      const shapeBad = boundaries.some((b) => !b || typeof b !== 'object' || !kinds.has(b.kind) || !isNonEmptyString(b.description));
+      if (shapeBad) errors.push(`boundaries: each needs kind in {${[...kinds].join(',')}} and a non-empty description`);
+      const hasMay = boundaries.some((b) => b && b.kind === BOUNDARY_KIND.MAY);
+      const hasMayNot = boundaries.some((b) => b && b.kind === BOUNDARY_KIND.MAY_NOT);
+      if (!hasMay) errors.push('boundaries: must declare at least one "may"');
+      if (!hasMayNot) errors.push('boundaries: must declare at least one "may_not"');
+    }
+
+    // timeline — object with a non-empty cadence string; type (if present) must be a known CADENCE_TYPE
+    const timeline = safeGet(contract, 'timeline');
+    if (!timeline || typeof timeline !== 'object' || Array.isArray(timeline)) {
+      errors.push('timeline: required object with a cadence');
+    } else {
+      if (!isNonEmptyString(timeline.cadence)) errors.push('timeline.cadence: required non-empty string');
+      if (timeline.type !== undefined && !Object.values(CADENCE_TYPE).includes(timeline.type)) {
+        errors.push(`timeline.type: must be one of {${Object.values(CADENCE_TYPE).join(',')}}`);
+      }
+    }
+
+    // tasks — optional, but if present must be an array of objects
+    const tasks = safeGet(contract, 'tasks');
+    if (tasks !== undefined && (!Array.isArray(tasks) || tasks.some((t) => !t || typeof t !== 'object'))) {
+      errors.push('tasks: when present, must be an array of objects');
+    }
+
+    // logging — optional, but if present must be an object
+    const logging = safeGet(contract, 'logging');
+    if (logging !== undefined && (typeof logging !== 'object' || logging === null || Array.isArray(logging))) {
+      errors.push('logging: when present, must be an object');
+    }
+  } catch (e) {
+    return { valid: false, errors: [`validation threw (treated as invalid): ${e && e.message}`] };
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/** Read a property without letting a throwing getter blow up the validator. */
+function safeGet(obj, key) {
+  try { return obj[key]; } catch (_) { return undefined; }
+}

--- a/lib/loops/loop-contract.js
+++ b/lib/loops/loop-contract.js
@@ -74,7 +74,7 @@ export function validateLoopContract(contract) {
     if (!isNonEmptyArray(workflow)) {
       errors.push('workflow: required non-empty array of ordered steps');
     } else {
-      const bad = workflow.some((w) => !w || typeof w !== 'object' || typeof w.step !== 'number' || !isNonEmptyString(w.name));
+      const bad = workflow.some((w) => !w || typeof w !== 'object' || typeof w.step !== 'number' || Number.isNaN(w.step) || !isNonEmptyString(w.name));
       if (bad) errors.push('workflow: each step needs a numeric step and a non-empty name');
     }
 

--- a/tests/unit/loops/loop-contract-registry.test.js
+++ b/tests/unit/loops/loop-contract-registry.test.js
@@ -16,11 +16,17 @@ import { validateLoopContract, BOUNDARY_KIND } from '../../../lib/loops/loop-con
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
-/** Extract the first `cron: '...'` schedule from a workflow yml. */
-function cronFromWorkflow(relPath) {
+/** Extract ALL active (non-commented) `cron: '...'` schedules from a workflow yml. */
+function activeCronsFromWorkflow(relPath) {
   const text = readFileSync(resolve(repoRoot, relPath), 'utf8');
-  const m = text.match(/cron:\s*['"]([^'"]+)['"]/);
-  return m ? m[1] : null;
+  return text
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*#/.test(line)) // drop full-line comments so a commented cron can't match
+    .map((line) => {
+      const m = line.match(/cron:\s*['"]([^'"]+)['"]/);
+      return m ? m[1] : null;
+    })
+    .filter(Boolean);
 }
 
 describe('registry shape + invariants', () => {
@@ -70,11 +76,11 @@ describe('cron-coherence: declared cadence matches the LIVE workflow .yml (anti-
     ['LOOP-ADAM-OPPORTUNITY-SCAN-001', '.github/workflows/adam-opportunity-scan-cron.yml'],
   ];
   for (const [loopId, yml] of cases) {
-    it(`${loopId} declared cadence === cron in ${yml}`, () => {
+    it(`${loopId} declared cadence is among the active crons in ${yml}`, () => {
       const declared = get(loopId).timeline.cadence;
-      const live = cronFromWorkflow(yml);
-      expect(live, `no cron found in ${yml}`).toBeTruthy();
-      expect(declared).toBe(live);
+      const liveCrons = activeCronsFromWorkflow(yml);
+      expect(liveCrons.length, `no active cron found in ${yml}`).toBeGreaterThan(0);
+      expect(liveCrons).toContain(declared);
     });
   }
 });

--- a/tests/unit/loops/loop-contract-registry.test.js
+++ b/tests/unit/loops/loop-contract-registry.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001 (FR-2, FR-3, FR-4)
+ * Registry shape/count invariants + cron-coherence vs the LIVE workflow .yml.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  LOOP_CONTRACTS,
+  list,
+  get,
+  assertContractsValid,
+} from '../../../lib/loops/loop-contract-registry.js';
+import { validateLoopContract, BOUNDARY_KIND } from '../../../lib/loops/loop-contract.js';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** Extract the first `cron: '...'` schedule from a workflow yml. */
+function cronFromWorkflow(relPath) {
+  const text = readFileSync(resolve(repoRoot, relPath), 'utf8');
+  const m = text.match(/cron:\s*['"]([^'"]+)['"]/);
+  return m ? m[1] : null;
+}
+
+describe('registry shape + invariants', () => {
+  it('LOOP_CONTRACTS is frozen', () => {
+    expect(Object.isFrozen(LOOP_CONTRACTS)).toBe(true);
+  });
+
+  it('declares the 2 exemplars and every entry validates', () => {
+    expect(LOOP_CONTRACTS).toHaveLength(2);
+    for (const c of LOOP_CONTRACTS) {
+      expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
+    }
+  });
+
+  it('every exemplar declares at least one MAY and one MAY_NOT boundary', () => {
+    for (const c of LOOP_CONTRACTS) {
+      expect(c.boundaries.some((b) => b.kind === BOUNDARY_KIND.MAY)).toBe(true);
+      expect(c.boundaries.some((b) => b.kind === BOUNDARY_KIND.MAY_NOT)).toBe(true);
+    }
+  });
+
+  it('list() returns id+name+cadence summaries', () => {
+    const summaries = list();
+    expect(summaries).toHaveLength(2);
+    for (const s of summaries) {
+      expect(typeof s.id).toBe('string');
+      expect(typeof s.name).toBe('string');
+      expect(typeof s.cadence).toBe('string');
+    }
+  });
+
+  it('get() returns the full contract for a known id, undefined otherwise', () => {
+    expect(get('LOOP-CI-AUTOTRIAGE-001')).toBeTruthy();
+    expect(get('LOOP-CI-AUTOTRIAGE-001').id).toBe('LOOP-CI-AUTOTRIAGE-001');
+    expect(get('LOOP-NOPE-999')).toBeUndefined();
+  });
+
+  it('assertContractsValid() does not throw (all declared valid)', () => {
+    expect(() => assertContractsValid()).not.toThrow();
+    expect(assertContractsValid()).toBe(true);
+  });
+});
+
+describe('cron-coherence: declared cadence matches the LIVE workflow .yml (anti-drift)', () => {
+  const cases = [
+    ['LOOP-CI-AUTOTRIAGE-001', '.github/workflows/clockwork-ci-autotriage-loop.yml'],
+    ['LOOP-ADAM-OPPORTUNITY-SCAN-001', '.github/workflows/adam-opportunity-scan-cron.yml'],
+  ];
+  for (const [loopId, yml] of cases) {
+    it(`${loopId} declared cadence === cron in ${yml}`, () => {
+      const declared = get(loopId).timeline.cadence;
+      const live = cronFromWorkflow(yml);
+      expect(live, `no cron found in ${yml}`).toBeTruthy();
+      expect(declared).toBe(live);
+    });
+  }
+});

--- a/tests/unit/loops/loop-contract.test.js
+++ b/tests/unit/loops/loop-contract.test.js
@@ -1,0 +1,106 @@
+/**
+ * SD-LEO-INFRA-LOOP-CONTRACT-FRAMEWORK-001 (FR-1, FR-4)
+ * Typed loop-contract schema + fail-loud validator.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateLoopContract,
+  CADENCE_TYPE,
+  BOUNDARY_KIND,
+  LOOP_CONTRACT_FIELDS,
+} from '../../../lib/loops/loop-contract.js';
+
+/** A complete, valid contract fixture. */
+function completeContract() {
+  return {
+    id: 'LOOP-TEST-001',
+    name: 'Test Loop',
+    goals: ['do the thing'],
+    workflow: [{ step: 1, name: 'first step', action: 'read' }],
+    boundaries: [
+      { kind: BOUNDARY_KIND.MAY, description: 'read tables' },
+      { kind: BOUNDARY_KIND.MAY_NOT, description: 'write strategy tables' },
+    ],
+    tasks: [{ task: 'entrypoint', file: 'scripts/x.cjs' }],
+    timeline: { type: CADENCE_TYPE.CRON, cadence: '0 * * * *' },
+    logging: { writes: ['verdict'] },
+  };
+}
+
+describe('enums + field list', () => {
+  it('exposes frozen CADENCE_TYPE and BOUNDARY_KIND', () => {
+    expect(Object.isFrozen(CADENCE_TYPE)).toBe(true);
+    expect(Object.isFrozen(BOUNDARY_KIND)).toBe(true);
+    expect(Object.values(CADENCE_TYPE)).toEqual(['cron', 'interval', 'event', 'manual']);
+    expect(BOUNDARY_KIND.MAY).toBe('may');
+    expect(BOUNDARY_KIND.MAY_NOT).toBe('may_not');
+  });
+
+  it('declares the chairman named fields', () => {
+    for (const f of ['goals', 'workflow', 'boundaries', 'tasks', 'timeline', 'logging']) {
+      expect(LOOP_CONTRACT_FIELDS).toContain(f);
+    }
+  });
+});
+
+describe('validateLoopContract — happy path', () => {
+  it('a complete contract is valid with no errors', () => {
+    expect(validateLoopContract(completeContract())).toEqual({ valid: true, errors: [] });
+  });
+});
+
+describe('validateLoopContract — fail-loud (each missing required field is named)', () => {
+  for (const field of ['id', 'name', 'goals', 'workflow', 'boundaries', 'timeline']) {
+    it(`missing "${field}" => invalid and names the field`, () => {
+      const c = completeContract();
+      delete c[field];
+      const res = validateLoopContract(c);
+      expect(res.valid).toBe(false);
+      expect(res.errors.join(' ')).toContain(field);
+    });
+  }
+
+  it('a boundaries array with only "may" (no may_not) is invalid', () => {
+    const c = completeContract();
+    c.boundaries = [{ kind: BOUNDARY_KIND.MAY, description: 'read' }];
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('may_not');
+  });
+
+  it('a workflow step missing a numeric step or name is invalid', () => {
+    const c = completeContract();
+    c.workflow = [{ name: 'no step number' }];
+    expect(validateLoopContract(c).valid).toBe(false);
+  });
+
+  it('an unknown timeline.type is invalid', () => {
+    const c = completeContract();
+    c.timeline = { type: 'weekly', cadence: '0 0 * * 0' };
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('timeline.type');
+  });
+
+  it('empty goals array is invalid (never silent-pass)', () => {
+    const c = completeContract();
+    c.goals = [];
+    expect(validateLoopContract(c).valid).toBe(false);
+  });
+});
+
+describe('validateLoopContract — total / never throws', () => {
+  it('null, non-object, and array inputs are invalid (no throw)', () => {
+    expect(validateLoopContract(null).valid).toBe(false);
+    expect(validateLoopContract(42).valid).toBe(false);
+    expect(validateLoopContract([]).valid).toBe(false);
+  });
+
+  it('a hostile throwing getter degrades to invalid, not an exception', () => {
+    const hostile = completeContract();
+    Object.defineProperty(hostile, 'goals', { get() { throw new Error('boom'); } });
+    let res;
+    expect(() => { res = validateLoopContract(hostile); }).not.toThrow();
+    expect(res.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
A canonical, typed **loop-contract** framework (code-only, no migration): every operational loop can declare a contract with the chairman's named fields — goals, ordered workflow, explicit boundaries (may / may_not), tasks, timeline/cadence, and a logging contract — so loops become self-describing, bounded, and auditable.

## Changes
- `lib/loops/loop-contract.js` — typed schema + frozen `CADENCE_TYPE`/`BOUNDARY_KIND` enums + `validateLoopContract()` (pure, total/never-throws, **fail-loud**: names any missing required field, never silent-pass).
- `lib/loops/loop-contract-registry.js` — frozen `LOOP_CONTRACTS` + `list()`/`get()`/`assertContractsValid()` (loud-at-import).
- **FR-3 exemplars (zero behavior change):** declares 2 EXISTING loops as contracts — CI-autotriage (cron `50 * * * *`) and Adam opportunity-scan (cron `37 * * * *`) — as DATA only; the loop scripts are never imported/run/modified.
- `tests/unit/loops/*` — 23 unit tests: fail-loud validation, registry shape/count, and a **cron-coherence test** that reads the live `.github/workflows` .yml and asserts the declared cadence is among the active crons (anti-drift).

## Honest notes (adversarial review)
No CRITICAL/HIGH/MEDIUM. Two LOW hardenings applied: reject `step:NaN`; coherence test strips comment lines so a future commented/second cron can't match the wrong line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)