### PR TITLE
fix(SD-LEO-INFRA-DISTILL-ARCHIVE-PATH-AND-YT-PROCESSED-001): fix /distill archive (path + YT processed branch + fail-loud)

### DIFF
--- a/lib/integrations/post-processor.js
+++ b/lib/integrations/post-processor.js
@@ -26,6 +26,23 @@ function createSupabaseClient() {
 }
 
 /**
+ * Dedupe a union of intake rows by `id`, preserving first-seen order.
+ * SD-LEO-INFRA-DISTILL-ARCHIVE-PATH-AND-YT-PROCESSED-001 (adversarial review): the selection
+ * branches (classified vs orphan-recovery) are NOT mutually exclusive — a pending row with both
+ * classified_at and chairman_reviewed_at set matches both — so a naive concat would process it
+ * twice in one run (harmless re-complete for Todoist, but a DUPLICATE non-idempotent playlist
+ * insert for YouTube). Dedup by id makes a single run process each row exactly once.
+ */
+export function dedupeById(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const r of rows) {
+    if (r && !seen.has(r.id)) { seen.add(r.id); out.push(r); }
+  }
+  return out;
+}
+
+/**
  * Complete a Todoist task via the Sync API v1 (item_complete).
  * The SDK's moveTask/closeTask silently fail in some cases.
  * @param {string} taskId
@@ -101,7 +118,7 @@ async function postProcessTodoist(options = {}) {
     .not('chairman_reviewed_at', 'is', null)
     .is('processed_at', null);
 
-  const items = [...(legacyItems || []), ...(classifiedItems || []), ...(reviewedItems || []), ...(orphanedItems || [])];
+  const items = dedupeById([...(legacyItems || []), ...(classifiedItems || []), ...(reviewedItems || []), ...(orphanedItems || [])]);
 
   if (!items || items.length === 0) {
     if (options.verbose) console.log('  Todoist: No items to post-process');
@@ -195,9 +212,11 @@ async function postProcessYouTube(options = {}) {
     return results;
   }
 
-  // Get items ready for archival:
+  // Get items ready for archival (mirror postProcessTodoist's 4-branch union):
   // - Legacy evaluation flow: status in approved/rejected/needs_revision
-  // - New distill flow: classified (classified_at set) and still pending
+  // - New distill flow (pending): classified (classified_at set) and still pending
+  // - New distill flow (reviewed): chairman reviewed and marked processed, but not yet moved
+  // - Orphan recovery: reviewed by chairman but still pending
   const { data: legacyItems } = await supabase
     .from('eva_youtube_intake')
     .select('id, youtube_video_id, youtube_playlist_item_id, status')
@@ -211,7 +230,24 @@ async function postProcessYouTube(options = {}) {
     .not('classified_at', 'is', null)
     .is('processed_at', null);
 
-  const items = [...(legacyItems || []), ...(classifiedItems || [])];
+  // SD-LEO-INFRA-DISTILL-ARCHIVE-PATH-AND-YT-PROCESSED-001 (FR-2): without this branch a
+  // chairman-reviewed video marked status='processed' could NEVER be picked up for the physical
+  // move, so it stayed in the For-Processing playlist indefinitely (Todoist already had this branch).
+  const { data: reviewedItems } = await supabase
+    .from('eva_youtube_intake')
+    .select('id, youtube_video_id, youtube_playlist_item_id, status')
+    .eq('status', 'processed')
+    .is('processed_at', null);
+
+  // Orphan recovery: reviewed by chairman but still pending (mirror SD-LEO-FIX-DISTILL-ORPHAN-RECOVERY-001)
+  const { data: orphanedItems } = await supabase
+    .from('eva_youtube_intake')
+    .select('id, youtube_video_id, youtube_playlist_item_id, status')
+    .eq('status', 'pending')
+    .not('chairman_reviewed_at', 'is', null)
+    .is('processed_at', null);
+
+  const items = dedupeById([...(legacyItems || []), ...(classifiedItems || []), ...(reviewedItems || []), ...(orphanedItems || [])]);
 
   if (!items || items.length === 0) {
     if (options.verbose) console.log('  YouTube: No items to post-process');

--- a/scripts/eva-intake-archive.js
+++ b/scripts/eva-intake-archive.js
@@ -27,6 +27,10 @@ async function main() {
     for (const e of [...result.todoist.errors, ...result.youtube.errors]) {
       console.log(`      - ${e.id}: ${e.error}`);
     }
+    // SD-LEO-INFRA-DISTILL-ARCHIVE-PATH-AND-YT-PROCESSED-001 (FR-3): a partial archive failure
+    // (some items errored at source) must NOT be swallowed as exit 0 — exit non-zero so the
+    // pipeline's Step 5 sees !ok and fails loud (::error:: annotation + a harness-bug feedback row).
+    process.exitCode = 1;
   }
 }
 

--- a/scripts/eva-intake-pipeline.js
+++ b/scripts/eva-intake-pipeline.js
@@ -172,7 +172,14 @@ if (fromStep <= 5 && !skipArchive) {
   } else {
     const ok = run('node scripts/eva-intake-archive.js');
     if (!ok) {
-      console.error('  ⚠ Archive had errors. Items remain in source. Check output above.\n');
+      // SD-LEO-INFRA-DISTILL-ARCHIVE-PATH-AND-YT-PROCESSED-001 (FR-3): a broken archive used to
+      // log a soft warning and continue, silently stranding chairman-reviewed items in their source
+      // (For-Processing playlist / open Todoist tasks) for days. Surface it LOUDLY (::error::) AND
+      // durably (a feedback row via log-harness-bug.js, which is idempotent) so it is caught at once.
+      console.error('\n  ❌ ARCHIVE STEP FAILED — processed items were NOT moved at source (Todoist/YouTube).');
+      console.error('     Chairman-reviewed items remain stranded. Filing a harness-bug alert so this is not missed.\n');
+      console.error('::error title=EVA intake archive failed::Step 5 archive did not complete; processed items remain in their source playlist/project. See pipeline output above.');
+      run('node scripts/log-harness-bug.js "EVA intake pipeline Step 5 (archive) FAILED — chairman-reviewed items were not moved at source (Todoist complete / YouTube Processed playlist). Investigate scripts/eva-intake-archive.js + lib/integrations/post-processor.js." --severity high');
     }
   }
 } else {

--- a/tests/unit/distill-archive-yt-processed.test.js
+++ b/tests/unit/distill-archive-yt-processed.test.js
@@ -1,0 +1,151 @@
+// SD-LEO-INFRA-DISTILL-ARCHIVE-PATH-AND-YT-PROCESSED-001 — guards the three compounding bugs that
+// silently stranded chairman-reviewed videos in the YouTube For-Processing playlist:
+//   FR-1: the pipeline's archive step invoked scripts/eva-intake-archive.js but the file had been
+//         relocated to scripts/archive/one-time/ (ENOENT) — restored to scripts/ so the path + its
+//         ../lib import both resolve.
+//   FR-2: postProcessYouTube had no status='processed' (reviewedItems) or orphan-recovery branch, so
+//         a video the review step marked 'processed' could NEVER be picked up for the physical move.
+//   FR-3: an archive failure was a soft warning that silently stranded items — now loud (::error::)
+//         + durable (a feedback row via log-harness-bug.js), and the archive script exits non-zero.
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const read = (rel) => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+// --- FR-1: the archive script is restored to scripts/ and its ../lib import resolves --------------
+describe('FR-1: archive script path + import resolve', () => {
+  it('scripts/eva-intake-archive.js exists (restored from scripts/archive/one-time/)', () => {
+    expect(existsSync(path.join(REPO_ROOT, 'scripts/eva-intake-archive.js'))).toBe(true);
+    expect(existsSync(path.join(REPO_ROOT, 'scripts/archive/one-time/eva-intake-archive.js'))).toBe(false);
+  });
+
+  it("the script's ../lib/integrations/post-processor.js import resolves from scripts/", () => {
+    const src = read('scripts/eva-intake-archive.js');
+    const m = src.match(/import\(['"]([^'"]*post-processor\.js)['"]\)/);
+    expect(m, 'expected a dynamic import of post-processor.js').toBeTruthy();
+    const resolved = path.resolve(REPO_ROOT, 'scripts', m[1]); // relative to the script's dir = scripts/
+    expect(resolved).toBe(path.join(REPO_ROOT, 'lib', 'integrations', 'post-processor.js'));
+    expect(existsSync(resolved)).toBe(true);
+  });
+
+  it('the pipeline still invokes the scripts/ path (matches where the file now lives)', () => {
+    expect(read('scripts/eva-intake-pipeline.js')).toMatch(/node scripts\/eva-intake-archive\.js/);
+  });
+});
+
+// --- FR-2 (adversarial): the branch union is deduped by id so an overlapping row is processed once -
+describe('FR-2: dedupeById prevents a double playlist insert from overlapping branches', () => {
+  it('a row matching both classified and orphan branches appears exactly once', async () => {
+    const { dedupeById } = await import('../../lib/integrations/post-processor.js');
+    const row = { id: 'dup', youtube_video_id: 'v', status: 'pending' };
+    const out = dedupeById([row, { id: 'other', status: 'pending' }, row]);
+    expect(out).toHaveLength(2);
+    expect(out.filter((r) => r.id === 'dup')).toHaveLength(1);
+    expect(out[0].id).toBe('dup'); // first-seen order preserved
+  });
+  it('tolerates null/empty entries', async () => {
+    const { dedupeById } = await import('../../lib/integrations/post-processor.js');
+    expect(dedupeById([null, { id: 'a' }, undefined])).toEqual([{ id: 'a' }]);
+  });
+});
+
+// --- FR-3: archive failure is loud + durable, and the script exits non-zero on per-item errors ----
+describe('FR-3: archive failure is surfaced loudly, not swallowed', () => {
+  it('pipeline Step 5 emits a ::error:: annotation and files a harness-bug row on failure', () => {
+    const src = read('scripts/eva-intake-pipeline.js');
+    expect(src).toMatch(/::error title=EVA intake archive failed::/);
+    expect(src).toMatch(/log-harness-bug\.js/);
+    // and it is no longer JUST the old soft one-liner that swallowed the failure
+    expect(src).toMatch(/ARCHIVE STEP FAILED/);
+  });
+
+  it('the archive script exits non-zero when any item errored (so the pipeline sees !ok)', () => {
+    const src = read('scripts/eva-intake-archive.js');
+    expect(src).toMatch(/totalErrors\s*>\s*0/);
+    expect(src).toMatch(/process\.exitCode\s*=\s*1/);
+  });
+});
+
+// --- FR-2: postProcessYouTube actually RUNS a status='processed' selection + moves it --------------
+// Mock the YouTube auth + client so postProcessYouTube proceeds to its DB selection without a network
+// call; inject a recording Supabase so we can assert which branches were queried and what got updated.
+vi.mock('../../lib/integrations/youtube/oauth-manager.js', () => ({
+  getAuthenticatedClient: vi.fn(async () => ({}))
+}));
+vi.mock('googleapis', () => ({
+  google: {
+    youtube: () => ({
+      playlists: { list: vi.fn(async () => ({ data: { items: [{ id: 'PROCESSED_PL', snippet: { title: 'Processed' } }] } })) },
+      playlistItems: { insert: vi.fn(async () => ({})), delete: vi.fn(async () => ({})) }
+    })
+  }
+}));
+
+function makeRecordingSupabase(selectResolver) {
+  const selects = [];
+  const updates = [];
+  function builder(table) {
+    const q = { table, op: 'select', filters: [], update: null };
+    const api = {
+      select(cols) { q.cols = cols; return api; },
+      in(col, vals) { q.filters.push(['in', col, vals]); return api; },
+      eq(col, val) { q.filters.push(['eq', col, val]); return api; },
+      not(col, op, val) { q.filters.push(['not', col, op, val]); return api; },
+      is(col, val) { q.filters.push(['is', col, val]); return api; },
+      update(vals) { q.op = 'update'; q.update = vals; updates.push(q); return api; },
+      then(resolve) {
+        if (q.op === 'select') { selects.push(q); return resolve({ data: selectResolver(q), error: null }); }
+        return resolve({ data: null, error: null });
+      }
+    };
+    return api;
+  }
+  return { client: { from: (t) => builder(t) }, selects, updates };
+}
+
+// A filter matcher: does this recorded query contain a filter matching the predicate tuple?
+const hasFilter = (q, kind, col, ...rest) =>
+  q.filters.some(([k, c, ...r]) => k === kind && c === col && JSON.stringify(r) === JSON.stringify(rest));
+
+describe('FR-2: postProcessYouTube selects + moves status=processed (reviewed) and orphaned items', () => {
+  let savedTodoistToken;
+  beforeAll(() => {
+    // Isolate the YouTube path: with no Todoist token, postProcessTodoist short-circuits (no network).
+    savedTodoistToken = process.env.TODOIST_API_TOKEN;
+    delete process.env.TODOIST_API_TOKEN;
+  });
+  afterAll(() => { if (savedTodoistToken !== undefined) process.env.TODOIST_API_TOKEN = savedTodoistToken; });
+
+  it('issues a reviewedItems branch (status=processed + processed_at NULL) and an orphan branch, then moves the reviewed video', async () => {
+    const { postProcessAll } = await import('../../lib/integrations/post-processor.js');
+
+    const reviewed = { id: 'row-reviewed', youtube_video_id: 'vid-reviewed', youtube_playlist_item_id: 'pli-reviewed', status: 'processed' };
+    const rec = makeRecordingSupabase((q) => {
+      if (q.table !== 'eva_youtube_intake') return [];
+      // Only the reviewedItems branch returns a row; all other branches are empty.
+      if (hasFilter(q, 'eq', 'status', 'processed') && hasFilter(q, 'is', 'processed_at', null)) return [reviewed];
+      return [];
+    });
+
+    const result = await postProcessAll({ supabase: rec.client, verbose: false });
+
+    const yt = rec.selects.filter((q) => q.table === 'eva_youtube_intake');
+    // reviewedItems branch (the core FR-2 fix) was issued
+    expect(yt.some((q) => hasFilter(q, 'eq', 'status', 'processed') && hasFilter(q, 'is', 'processed_at', null))).toBe(true);
+    // orphan-recovery branch (mirror of the Todoist side) was issued
+    expect(yt.some((q) => hasFilter(q, 'not', 'chairman_reviewed_at', 'is', null) && hasFilter(q, 'eq', 'status', 'pending'))).toBe(true);
+
+    // the reviewed video was actually moved: marked processed with a destination playlist id
+    const mv = rec.updates.find((q) => q.table === 'eva_youtube_intake');
+    expect(mv, 'expected an update marking the reviewed video processed').toBeTruthy();
+    expect(mv.update.status).toBe('processed');
+    expect(mv.update.destination_playlist_id).toBe('PROCESSED_PL');
+    expect(mv.update.processed_at).toBeTruthy();
+    expect(result.youtube.processed).toBe(1);
+    expect(result.youtube.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes three compounding bugs that silently stranded chairman-reviewed YouTube videos in the For-Processing playlist (Adam-diagnosed; 25 videos were corrected manually — this fixes the root cause).

**FR-1 (path + import):** `git mv scripts/archive/one-time/eva-intake-archive.js → scripts/eva-intake-archive.js`. The pipeline's Step-5 `node scripts/eva-intake-archive.js` invocation was ENOENT-ing (the file had been relocated), and the script's `../lib/integrations/post-processor.js` import only resolves from `scripts/`. One move fixes both.

**FR-2 (YT processed branch):** `postProcessYouTube` gains a `reviewedItems` branch (`status='processed'` + `processed_at IS NULL`) and an orphan-recovery branch (`status='pending'` + `chairman_reviewed_at NOT NULL` + `processed_at IS NULL`), mirroring `postProcessTodoist`. A `dedupeById` helper (applied to both integrations) defends the classified∩orphan double-insert hazard.

**FR-3 (fail loud):** an archive failure now emits a `::error::` annotation **and** files a durable `feedback` row via `log-harness-bug.js` (idempotent); the archive script exits non-zero on per-item errors so partial failures reach the pipeline — no more silent soft-warning that strands items for days.

**FR-4 (tests):** `tests/unit/distill-archive-yt-processed.test.js` — 8 tests incl. a functional `postProcessYouTube` run (recording Supabase + mocked YouTube client) that fails if the fix is reverted. 71/71 green across the intake + post-processor folders.

Additive, single-repo, no schema change. Independent adversarial review verdict: SHIP (0 HIGH/MEDIUM; mutation-tested the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)