### PR TITLE
fix(SD-LEO-INFRA-CANARY-SUPPORT-TRIGGER-RELIABILITY-001): wire-check reachability (canary:sweep entry + exempt)

### DIFF
--- a/lib/coordinator/canary-trigger.cjs
+++ b/lib/coordinator/canary-trigger.cjs
@@ -1,3 +1,5 @@
+// @wire-check-exempt: library consumed by scripts/canary-trigger-sweep.mjs (npm run canary:sweep)
+// via createRequire + by tests/unit/canary-trigger.test.js, and the future canary responder.
 /**
  * canary-trigger — reliably request Adam's pre-merge / full-row canary verification.
  * SD-LEO-INFRA-CANARY-SUPPORT-TRIGGER-RELIABILITY-001.

--- a/package.json
+++ b/package.json
@@ -320,6 +320,7 @@
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
+    "canary:sweep": "node scripts/canary-trigger-sweep.mjs",
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",


### PR DESCRIPTION
Follow-up to merged PR #4875 (replaces the conflicting #4877). WIRE_CHECK_GATE at LEAD-FINAL flagged the two new canary-trigger files as unreachable. Adds the canary:sweep npm script (entry point for scripts/canary-trigger-sweep.mjs) + a @wire-check-exempt marker on lib/coordinator/canary-trigger.cjs (consumed via createRequire by the sweep + tests + the future canary responder). Cherry-picked clean onto current main. Tests 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)