### PR TITLE
fix(SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001): resolve coordinator deps via canonical parseSdDependencies

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001.json
@@ -1,0 +1,59 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Reuse the canonical dependency resolver in the capacity forecaster",
+      "description": "In scripts/coordinator-capacity-forecast.mjs, replace the hand-rolled `depId` resolver (which returns the literal 'none' for {sd_key:'none'} and bare-string 'none', mis-counting it as an unmet dependency) with the canonical parseSdDependencies from lib/utils/parse-sd-dependencies.cjs (the same SSOT scripts/coordinator-audit.mjs already imports). parseSdDependencies only counts entries matching /^SD-[A-Z0-9-]+/ as real blockers, so the 'none' sentinel, the 'No blocking dependencies identified' marker, and free-text placeholders resolve to zero blockers. Result: a draft/unclaimed SD whose only dependency is the 'none' sentinel is counted in claimable[]/beltDepth instead of being excluded, eliminating the false DEFICIT-URGENT and the spurious Adam reach-out.",
+      "acceptance_criteria": [
+        "coordinator-capacity-forecast.mjs imports parseSdDependencies from ../lib/utils/parse-sd-dependencies.cjs",
+        "The hand-rolled `depId` arrow is removed; both the depKeys-build and the `unmet` computation use parseSdDependencies",
+        "A draft, unclaimed, non-orchestrator SD whose dependencies = [{sd_key:'none'}] is included in claimable[]"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "requirement": "Align the backlog ranker to the same resolver and audit the worker-checkin deps path",
+      "description": "In scripts/coordinator-backlog-rank.mjs, replace the identical hand-rolled `depId` (line 44) used in the depKeys set, the dependents-graph edges, and the `unmet` computation with the canonical parseSdDependencies, so the ranker and forecaster agree on the sentinel and on free-text non-SD entries. Audit confirms two siblings need no change and must be documented as already-correct: (a) the worker-checkin claim/deps path resolves deps via lib/fleet/claim-eligibility.cjs draftDepsSatisfied, which already skips k==='none'||k==='None' as non-blocking; (b) FR-3 root in scripts/leo-create-sd.js already stores dependencies:[] for no-deps (QF-20260525-542). No new duplicate helper (e.g. lib/coordinator/deps.mjs) is created — reusing the existing SSOT avoids a third parallel implementation of the blocker rule.",
+      "acceptance_criteria": [
+        "coordinator-backlog-rank.mjs imports parseSdDependencies and removes the hand-rolled `depId`",
+        "depKeys, the dependents map, and the `unmet` filter all resolve via parseSdDependencies",
+        "No new lib/coordinator/deps.mjs is added; the canonical lib/utils/parse-sd-dependencies.cjs is the single shared resolver"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "requirement": "Regression test pinning the sentinel resolution and forecaster/ranker parity",
+      "description": "Add tests/unit/coordinator-dep-sentinel.test.js asserting parseSdDependencies returns zero blockers for the 'none' sentinel in every live shape ({sd_key:'none'}, {sd_id:'none'}, {id:'none'}, bare string 'none', case-insensitive 'NONE', and a 'No blocking dependencies identified' free-text object) while preserving a genuine SD-key dependency. The test exercises the exact resolver both consumers now share, pinning the regression (a none-sentinel SD is claimable belt, not dep-blocked).",
+      "acceptance_criteria": [
+        "node --test tests/unit/coordinator-dep-sentinel.test.js passes",
+        "Cases cover {sd_key:'none'}, {sd_id:'none'}, {id:'none'}, bare 'none', 'NONE', a free-text non-SD object, and a real SD-key dep preserved",
+        "Test asserts a mixed array [{sd_key:'none'}, {sd_id:'SD-REAL-001'}] resolves to exactly ['SD-REAL-001']"
+      ]
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Sentinel resolves to zero blockers",
+      "steps": "Run node --test tests/unit/coordinator-dep-sentinel.test.js. parseSdDependencies([{sd_key:'none'}]) returns [] and parseSdDependencies(['none']) returns [].",
+      "expected_result": "All assertions pass; the 'none' sentinel and free-text placeholders yield zero real blockers."
+    },
+    {
+      "id": "TS-2",
+      "scenario": "Forecaster counts a none-sentinel SD as claimable belt",
+      "steps": "Run node scripts/coordinator-capacity-forecast.mjs against the live DB and inspect the BELT line and claimable SD list.",
+      "expected_result": "The script completes without error and a draft/unclaimed SD whose only dependency is the 'none' sentinel is counted in beltDepth (not excluded as unmet)."
+    },
+    {
+      "id": "TS-3",
+      "scenario": "Ranker agrees with forecaster on the sentinel",
+      "steps": "Run node scripts/coordinator-backlog-rank.mjs --dry-run and inspect which SDs are treated as claimable leaves.",
+      "expected_result": "The script completes without error; a none-sentinel-dep SD is a claimable leaf (deps met), matching the forecaster — no divergence between ranker and forecaster."
+    }
+  ],
+  "acceptance_criteria": [
+    "The 'none' dependency sentinel no longer counts as an unmet dependency in the forecaster belt-depth or the backlog ranker",
+    "Forecaster and ranker share the single canonical parseSdDependencies resolver and agree on the sentinel",
+    "A regression test pins the sentinel resolution; existing coordinator behavior for real SD-key deps is unchanged"
+  ]
+}

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -33,15 +33,16 @@ import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-
 // bare-shell demotion uses the shared bareShellLastCompare so the test suite
 // exercises the real comparator, not a re-implementation.
 import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd } from '../lib/coordinator/sd-exclusion.mjs';
+// SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001: resolve dependency keys via the canonical
+// blocker rule (the same SSOT coordinator-audit.mjs imports) so the ranker and the capacity
+// forecaster AGREE on the 'no dependencies' sentinel ({sd_key:'none'} / bare 'none') and on
+// free-text non-SD placeholders. parseSdDependencies returns ONLY real /^SD-/ blocker keys —
+// handling both the [{sd_id}]/[{sd_key}] object and raw-string shapes the old hand-rolled
+// resolver coerced, while correctly dropping the sentinel the hand-rolled one mis-counted.
+import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
 
 const DRY = process.argv.includes('--dry-run');
 const PRIORITY_W = { critical: 3, high: 2, medium: 1, med: 1, low: 0 };
-
-// Dependencies appear in TWO shapes in live data: [{sd_id:'SD-…'}] (add-prd convention) and
-// raw string arrays ['SD-…'] (plan-keeper/Adam authoring). Reading only x.sd_id made this
-// ranker blind to string deps — it ranked a BLOCKED child claimable and missed unlock edges
-// (live catch 2026-06-10: PLAN-KEEPER-D ranked claimable while dep -C was draft). Coerce both.
-const depId = (x) => (typeof x === 'string' ? x : (x && (x.sd_id || x.sd_key || x.id)) || null);
 
 const sb = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -59,7 +60,7 @@ async function main() {
   // ── dependency graph: edges dep -> dependents (over non-terminal set + completed deps resolved) ──
   const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
   const depKeys = new Set();
-  (sds || []).forEach(d => (d.dependencies || []).forEach(x => { const k = depId(x); if (k) depKeys.add(k); }));
+  (sds || []).forEach(d => parseSdDependencies(d.dependencies).forEach(k => depKeys.add(k)));
   let depStatus = {};
   if (depKeys.size) {
     const { data: deps } = await sb.from('strategic_directives_v2').select('sd_key,status').in('sd_key', Array.from(depKeys));
@@ -68,9 +69,7 @@ async function main() {
   // dependents[dep] = [sd_keys that list dep and are not terminal]
   const dependents = new Map();
   for (const d of (sds || [])) {
-    for (const x of (d.dependencies || [])) {
-      const k = depId(x);
-      if (!k) continue;
+    for (const k of parseSdDependencies(d.dependencies)) {
       if (!dependents.has(k)) dependents.set(k, []);
       dependents.get(k).push(d.sd_key);
     }
@@ -111,8 +110,8 @@ async function main() {
       console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
       continue;
     }
-    const unmet = (d.dependencies || []).map(depId)
-      .filter(k => k && (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
+    const unmet = parseSdDependencies(d.dependencies)
+      .filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
     if (unmet.length) continue;
     claimable.push(d);
   }

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -39,6 +39,12 @@ import { classifyIdleWorker } from './lib/capacity-idle-classifier.mjs';
 
 const require = createRequire(import.meta.url);
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+// SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001: resolve dependency keys via the canonical
+// blocker rule (lib/utils/parse-sd-dependencies.cjs, same SSOT coordinator-audit.mjs uses) instead of
+// a hand-rolled resolver. parseSdDependencies counts ONLY /^SD-/ entries as real blockers, so the
+// documented 'no dependencies' sentinel ({sd_key:'none'} / bare 'none') and free-text placeholders
+// resolve to zero blockers — a freshly-sourced SD is no longer mis-counted out of belt depth.
+const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -98,10 +104,10 @@ async function main() {
   const openQfCount = Array.isArray(openQfRows) ? openQfRows.length : 0;
 
   // ── resolve dependency statuses → claimable belt ──
-  // Deps appear as [{sd_id}] AND raw string arrays (live mix); coerce both shapes.
-  const depId = (x) => (typeof x === 'string' ? x : (x && (x.sd_id || x.sd_key || x.id)) || null);
+  // parseSdDependencies handles the live shape mix ([{sd_id}], [{sd_key}], raw strings) AND drops the
+  // 'none' sentinel + free-text non-SD placeholders, returning only real /^SD-/ blocker keys.
   const depKeys = new Set();
-  (sds || []).forEach(d => (d.dependencies || []).forEach(x => { const k = depId(x); if (k) depKeys.add(k); }));
+  (sds || []).forEach(d => parseSdDependencies(d.dependencies).forEach(k => depKeys.add(k)));
   let depStatus = {};
   if (depKeys.size) {
     const { data: deps } = await sb.from('strategic_directives_v2').select('sd_key,status').in('sd_key', Array.from(depKeys));
@@ -120,7 +126,7 @@ async function main() {
     // belt — neither can pass LEAD-TO-PLAN. Excluding them keeps beltDepth honest so a
     // forecast deficit (and the proactive Adam reach-out) is not masked by non-distributable rows.
     if (isExcludedFromBelt(d)) { beltExcludes++; continue; }
-    const unmet = (d.dependencies || []).map(depId).filter(k => k && depStatus[k] !== 'completed');
+    const unmet = parseSdDependencies(d.dependencies).filter(k => depStatus[k] !== 'completed');
     if (unmet.length === 0) claimable.push(d);
   }
   if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell) excluded from belt depth`);

--- a/tests/unit/coordinator-dep-sentinel.test.js
+++ b/tests/unit/coordinator-dep-sentinel.test.js
@@ -1,0 +1,89 @@
+/**
+ * SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001
+ * Network-free regression tests for the 'no dependencies' sentinel handling shared by the
+ * capacity forecaster (scripts/coordinator-capacity-forecast.mjs) and the backlog ranker
+ * (scripts/coordinator-backlog-rank.mjs). Both now resolve dependency keys via the canonical
+ * parseSdDependencies (lib/utils/parse-sd-dependencies.cjs) instead of a hand-rolled `depId`
+ * that returned the literal 'none' for {sd_key:'none'} / bare-string 'none' and mis-counted it
+ * as an UNMET dependency — making a freshly-sourced SD invisible to belt depth and emitting a
+ * false DEFICIT-URGENT + spurious Adam reach-out. These tests pin that the sentinel resolves to
+ * zero real blockers while genuine SD-key deps are preserved, and that the forecaster's and
+ * ranker's belt predicates therefore agree.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parseSdDependencies } = require('../../lib/utils/parse-sd-dependencies.cjs');
+
+// Mirror of the forecaster's belt predicate (scripts/coordinator-capacity-forecast.mjs):
+//   unmet = parseSdDependencies(d.dependencies).filter(k => depStatus[k] !== 'completed')
+//   claimable when unmet.length === 0
+function forecasterUnmet(d, depStatus = {}) {
+  return parseSdDependencies(d.dependencies).filter((k) => depStatus[k] !== 'completed');
+}
+// Mirror of the ranker's claimable-leaf predicate (scripts/coordinator-backlog-rank.mjs):
+//   unmet = parseSdDependencies(d.dependencies)
+//     .filter(k => byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed')
+function rankerUnmet(d, byKey = new Map(), depStatus = {}) {
+  return parseSdDependencies(d.dependencies).filter((k) =>
+    byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'
+  );
+}
+
+describe('coordinator dep-sentinel — parseSdDependencies drops the no-dependencies sentinel', () => {
+  it('returns zero blockers for the sentinel in every live shape', () => {
+    expect(parseSdDependencies([{ sd_key: 'none' }])).toEqual([]);
+    expect(parseSdDependencies([{ sd_id: 'none' }])).toEqual([]);
+    expect(parseSdDependencies([{ id: 'none' }])).toEqual([]);
+    expect(parseSdDependencies(['none'])).toEqual([]);
+    expect(parseSdDependencies(['NONE'])).toEqual([]); // not an /^SD-/ key, so resolves to no blocker
+    expect(parseSdDependencies([{ dependency: 'none', status: 'available' }])).toEqual([]);
+    expect(
+      parseSdDependencies([{ type: 'note', dependency: 'No blocking dependencies identified' }])
+    ).toEqual([]);
+  });
+
+  it('preserves a genuine SD-key dependency (string and object shapes)', () => {
+    expect(parseSdDependencies(['SD-LEO-INFRA-REAL-001'])).toEqual(['SD-LEO-INFRA-REAL-001']);
+    expect(parseSdDependencies([{ sd_key: 'SD-LEO-INFRA-REAL-001' }])).toEqual([
+      'SD-LEO-INFRA-REAL-001',
+    ]);
+    expect(parseSdDependencies([{ sd_id: 'SD-LEO-INFRA-REAL-001' }])).toEqual([
+      'SD-LEO-INFRA-REAL-001',
+    ]);
+  });
+
+  it('a mixed array resolves to exactly the real SD-keys, dropping the sentinel', () => {
+    expect(parseSdDependencies([{ sd_key: 'none' }, { sd_id: 'SD-REAL-001' }])).toEqual([
+      'SD-REAL-001',
+    ]);
+  });
+});
+
+describe('coordinator dep-sentinel — forecaster + ranker agree the sentinel is claimable belt', () => {
+  it('forecaster: a none-sentinel SD has zero unmet deps (counted in belt)', () => {
+    const d = { sd_key: 'SD-FRESH-001', dependencies: [{ sd_key: 'none' }] };
+    expect(forecasterUnmet(d)).toEqual([]);
+  });
+
+  it('ranker: the same none-sentinel SD is a claimable leaf (deps met)', () => {
+    const d = { sd_key: 'SD-FRESH-001', dependencies: [{ sd_key: 'none' }] };
+    expect(rankerUnmet(d)).toEqual([]);
+  });
+
+  it('a genuine UNMET SD-key dep is still blocking in both consumers (no false-claimable)', () => {
+    const d = { sd_key: 'SD-CHILD-001', dependencies: [{ sd_key: 'SD-PARENT-001' }] };
+    const depStatus = { 'SD-PARENT-001': 'draft' };
+    const byKey = new Map([['SD-PARENT-001', { sd_key: 'SD-PARENT-001', status: 'draft' }]]);
+    expect(forecasterUnmet(d, depStatus)).toEqual(['SD-PARENT-001']);
+    expect(rankerUnmet(d, byKey, depStatus)).toEqual(['SD-PARENT-001']);
+  });
+
+  it('a completed SD-key dep is met in both consumers', () => {
+    const d = { sd_key: 'SD-CHILD-001', dependencies: [{ sd_key: 'SD-PARENT-001' }] };
+    const depStatus = { 'SD-PARENT-001': 'completed' };
+    const byKey = new Map([['SD-PARENT-001', { sd_key: 'SD-PARENT-001', status: 'completed' }]]);
+    expect(forecasterUnmet(d, depStatus)).toEqual([]);
+    expect(rankerUnmet(d, byKey, depStatus)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

The coordinator capacity-forecaster and backlog-ranker each hand-rolled a `depId` resolver that returned the literal `'none'` for the `{sd_key:'none'}` / bare-string `'none'` no-dependencies sentinel, mis-counting it as an **unmet** dependency. A freshly-sourced SD whose only dependency was the sentinel fell out of belt depth → false `DEFICIT-URGENT` + spurious Adam reach-out.

## Fix

Both `scripts/coordinator-capacity-forecast.mjs` and `scripts/coordinator-backlog-rank.mjs` now resolve dependency keys via the canonical `parseSdDependencies` (`lib/utils/parse-sd-dependencies.cjs`) — the same SSOT `scripts/coordinator-audit.mjs` already imports — which counts only `/^SD-/` entries as real blockers. The sentinel and free-text placeholders resolve to zero blockers, and the forecaster + ranker now agree.

- **No new duplicate helper** (e.g. `lib/coordinator/deps.mjs`) — reusing the existing SSOT avoids a third parallel implementation of the blocker rule.
- **FR-3 root** (`leo-create-sd.js` already stores `[]` for no-deps, QF-20260525-542) and the **worker-checkin claim path** (`claim-eligibility.cjs` already skips `'none'`/`'None'`) were audited and confirmed already correct — no change.
- **Latent fix**: 0 unclaimed-belt none-sentinel SDs exist today; this prevents the regression the moment a fresh draft carries the sentinel.

## Tests

New `tests/unit/coordinator-dep-sentinel.test.js` (7 cases): sentinel in every live shape → zero blockers; real SD-keys preserved; forecaster/ranker predicate parity. Sibling dep tests (16) still green; both scripts smoke clean and agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)