### PR TITLE
feat(SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-BUDGET-001): loop-contract goal-type + declared run-budget

### DIFF
--- a/lib/loops/loop-contract-registry.js
+++ b/lib/loops/loop-contract-registry.js
@@ -12,7 +12,7 @@
  * are carried as plain strings. So declaring a loop changes NOTHING about how it runs.
  */
 
-import { validateLoopContract, CADENCE_TYPE, BOUNDARY_KIND } from './loop-contract.js';
+import { validateLoopContract, CADENCE_TYPE, BOUNDARY_KIND, GOAL_TYPE } from './loop-contract.js';
 
 /**
  * Exemplar 1 — CI Auto-Triage Loop.
@@ -24,8 +24,16 @@ const CI_AUTOTRIAGE_CONTRACT = {
   id: 'LOOP-CI-AUTOTRIAGE-001',
   name: 'CI Auto-Triage Loop',
   goals: [
-    'Detect recurring, uncovered CI-failure classes (chronic, >= threshold occurrences)',
-    'Trace each chronic class to a corrective work item without auto-fixing it',
+    {
+      description: 'Detect recurring, uncovered CI-failure classes (chronic, >= threshold occurrences)',
+      type: GOAL_TYPE.VERIFIABLE,
+      metric: 'count of ci_failure feedback rows per error_hash class >= the configured recurrence threshold (deterministic, scripts/lib/ci-recurrence-detector.mjs)',
+    },
+    {
+      description: 'Trace each chronic class to a corrective work item without auto-fixing it',
+      type: GOAL_TYPE.VERIFIABLE,
+      metric: 'each chronic class has >= 1 linked DRAFT corrective SD (class->SD linkage row exists)',
+    },
   ],
   workflow: [
     { step: 1, name: 'Fetch open ci_failure feedback rows', action: 'read' },
@@ -45,6 +53,7 @@ const CI_AUTOTRIAGE_CONTRACT = {
   ],
   timeline: { type: CADENCE_TYPE.CRON, cadence: '50 * * * *', description: 'Hourly at :50 (post-capture, post-triage, post-self-heal)', fail_soft: true, proposal_only: true },
   logging: { writes: ['count of DRAFT SDs sourced', 'per-run + per-day cap remaining', 'class->SD linkage'], durable_ledger: null, event_bus: null },
+  budget: { tokens_per_run_estimate: 0, daily_max_runs: 24 },
 };
 
 /**
@@ -57,8 +66,16 @@ const ADAM_OPPORTUNITY_SCAN_CONTRACT = {
   id: 'LOOP-ADAM-OPPORTUNITY-SCAN-001',
   name: 'Adam Opportunity-Scan Heartbeat',
   goals: [
-    'Rotate through portfolio scopes (harness, platform, per-venture) on a deterministic round-robin',
-    'Surface at most one ranked advisory per tick when it clears the rationale bar, else stay silent',
+    {
+      description: 'Rotate through portfolio scopes (harness, platform, per-venture) on a deterministic round-robin',
+      type: GOAL_TYPE.VERIFIABLE,
+      metric: 'the selected scope follows the deterministic weighted round-robin order (lib/adam/scope-registry.js)',
+    },
+    {
+      description: 'Surface at most one ranked advisory per tick when it clears the rationale bar, else stay silent',
+      type: GOAL_TYPE.LLM_AS_JUDGE,
+      rubric_ref: 'lib/adam/rationale-bar.js',
+    },
   ],
   workflow: [
     { step: 1, name: 'Select the scope for this tick (deterministic weighted round-robin)', action: 'select' },
@@ -77,6 +94,7 @@ const ADAM_OPPORTUNITY_SCAN_CONTRACT = {
   ],
   timeline: { type: CADENCE_TYPE.CRON, cadence: '37 * * * *', description: 'Hourly at :37 (offset from the exec-email cron to dodge runner congestion)', fail_soft: true, advisory_only: true },
   logging: { writes: ['ADAM_OK | SURFACED | SUPPRESSED_FLAG_OFF verdict', 'selected scope', 'ledger entry (bounded 500)'], durable_ledger: 'local .json', event_bus: null },
+  budget: { tokens_per_run_estimate: 0, daily_max_runs: 24 },
 };
 
 /** The canonical declared set. Frozen — runtime cannot mutate it. */

--- a/lib/loops/loop-contract.js
+++ b/lib/loops/loop-contract.js
@@ -11,13 +11,17 @@
  * A loop contract has the chairman's named fields:
  *   - id         : stable identifier (e.g. 'LOOP-CI-AUTOTRIAGE-001')
  *   - name       : human label
- *   - goals      : string[]  — what the loop is FOR (>=1)
+ *   - goals      : (string | { description, type:GOAL_TYPE, metric?, rubric_ref? })[] — what the loop is
+ *                  FOR (>=1). A bare string is back-compat (verifiable); a typed object declares whether the
+ *                  goal is VERIFIABLE (deterministic; SHOULD carry a metric) or LLM_AS_JUDGE (MUST carry a rubric_ref).
  *   - workflow   : ordered step objects { step:number, name:string, action?:string } (>=1)
  *   - boundaries : { kind: 'may'|'may_not', description:string }[] — explicit limits
  *                  (>=1 of EACH kind: a loop must say both what it may and may NOT do)
  *   - tasks      : object[]   — concrete artifacts (entrypoint/config/etc.) (optional, type-checked)
  *   - timeline   : { cadence:string, type?:CADENCE_TYPE, ... } — when it runs (cadence required)
  *   - logging    : object     — the logging contract (what it writes) (optional, type-checked)
+ *   - budget     : { tokens_per_run_estimate?, daily_max_runs?, pause_if_budget_below_pct? } — declared
+ *                  run-cost (optional, declaration only; enforcement is a follow-on)
  *
  * Design mirrors lib/adam/adherence-probes.js + lib/governance/guardrail-registry.js:
  * frozen enums, pure total functions, fail-loud (never silent-pass).
@@ -35,9 +39,20 @@ export const BOUNDARY_KIND = Object.freeze({
   MAY_NOT: 'may_not',
 });
 
+/**
+ * SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-BUDGET-001 (FR-1): how a loop's goal is judged.
+ *   VERIFIABLE   — a deterministic signal + threshold decides done/not-done (SHOULD carry a `metric`).
+ *   LLM_AS_JUDGE — a qualitative rubric decides; MUST carry a `rubric_ref` (the anti-brittleness guard:
+ *                  a judge-style goal without a defined rubric is exactly the brittle failure mode to block).
+ */
+export const GOAL_TYPE = Object.freeze({
+  VERIFIABLE: 'verifiable',
+  LLM_AS_JUDGE: 'llm_as_judge',
+});
+
 /** Canonical field list (the chairman's named fields). Required vs optional below. */
 export const LOOP_CONTRACT_FIELDS = Object.freeze([
-  'id', 'name', 'goals', 'workflow', 'boundaries', 'tasks', 'timeline', 'logging',
+  'id', 'name', 'goals', 'workflow', 'boundaries', 'tasks', 'timeline', 'logging', 'budget',
 ]);
 
 /** Required fields — absence/emptiness => invalid (fail-loud). */
@@ -64,10 +79,27 @@ export function validateLoopContract(contract) {
     if (!isNonEmptyString(safeGet(contract, 'id'))) errors.push('id: required non-empty string');
     if (!isNonEmptyString(safeGet(contract, 'name'))) errors.push('name: required non-empty string');
 
-    // goals — non-empty array of non-empty strings
+    // goals — non-empty array. Each goal is EITHER a bare non-empty string (back-compat: treated as a
+    // verifiable goal) OR a typed object { description, type, metric?, rubric_ref? } (FR-1). A
+    // type=llm_as_judge goal MUST carry a rubric_ref (fail-loud anti-brittleness guard).
     const goals = safeGet(contract, 'goals');
-    if (!isNonEmptyArray(goals)) errors.push('goals: required non-empty array');
-    else if (!goals.every(isNonEmptyString)) errors.push('goals: every goal must be a non-empty string');
+    if (!isNonEmptyArray(goals)) {
+      errors.push('goals: required non-empty array');
+    } else {
+      const goalTypes = new Set(Object.values(GOAL_TYPE));
+      goals.forEach((g, i) => {
+        if (isNonEmptyString(g)) return; // bare string = verifiable (back-compat), allowed
+        if (!g || typeof g !== 'object' || Array.isArray(g)) {
+          errors.push(`goals[${i}]: must be a non-empty string or a { description, type } object`);
+          return;
+        }
+        if (!isNonEmptyString(g.description)) errors.push(`goals[${i}].description: required non-empty string`);
+        if (!goalTypes.has(g.type)) errors.push(`goals[${i}].type: must be one of {${[...goalTypes].join(',')}}`);
+        if (g.type === GOAL_TYPE.LLM_AS_JUDGE && !isNonEmptyString(g.rubric_ref)) {
+          errors.push(`goals[${i}]: type=llm_as_judge requires a non-empty rubric_ref (anti-brittleness guard)`);
+        }
+      });
+    }
 
     // workflow — non-empty array of ordered step objects
     const workflow = safeGet(contract, 'workflow');
@@ -113,6 +145,26 @@ export function validateLoopContract(contract) {
     const logging = safeGet(contract, 'logging');
     if (logging !== undefined && (typeof logging !== 'object' || logging === null || Array.isArray(logging))) {
       errors.push('logging: when present, must be an object');
+    }
+
+    // budget — optional DECLARATION (FR-2): { tokens_per_run_estimate?, daily_max_runs?,
+    // pause_if_budget_below_pct? }. Each present field must be a non-negative number; the pct field is
+    // 0-100. This SD declares the budget only — enforcement/auto-pause in the cron executor is a follow-on.
+    const budget = safeGet(contract, 'budget');
+    if (budget !== undefined) {
+      if (typeof budget !== 'object' || budget === null || Array.isArray(budget)) {
+        errors.push('budget: when present, must be an object');
+      } else {
+        for (const k of ['tokens_per_run_estimate', 'daily_max_runs', 'pause_if_budget_below_pct']) {
+          const v = budget[k];
+          if (v !== undefined && (typeof v !== 'number' || Number.isNaN(v) || v < 0)) {
+            errors.push(`budget.${k}: when present, must be a non-negative number`);
+          }
+        }
+        if (typeof budget.pause_if_budget_below_pct === 'number' && budget.pause_if_budget_below_pct > 100) {
+          errors.push('budget.pause_if_budget_below_pct: must be between 0 and 100');
+        }
+      }
     }
   } catch (e) {
     return { valid: false, errors: [`validation threw (treated as invalid): ${e && e.message}`] };

--- a/tests/unit/loops/loop-contract-registry.test.js
+++ b/tests/unit/loops/loop-contract-registry.test.js
@@ -12,7 +12,7 @@ import {
   get,
   assertContractsValid,
 } from '../../../lib/loops/loop-contract-registry.js';
-import { validateLoopContract, BOUNDARY_KIND } from '../../../lib/loops/loop-contract.js';
+import { validateLoopContract, BOUNDARY_KIND, GOAL_TYPE } from '../../../lib/loops/loop-contract.js';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
@@ -67,6 +67,39 @@ describe('registry shape + invariants', () => {
   it('assertContractsValid() does not throw (all declared valid)', () => {
     expect(() => assertContractsValid()).not.toThrow();
     expect(assertContractsValid()).toBe(true);
+  });
+});
+
+// SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-BUDGET-001 (FR-3): exemplars migrated to typed goals.
+describe('exemplar goals are typed (FR-3)', () => {
+  it('every exemplar goal is a typed object with a valid GOAL_TYPE (no bare strings remain)', () => {
+    const validTypes = new Set(Object.values(GOAL_TYPE));
+    for (const c of LOOP_CONTRACTS) {
+      for (const g of c.goals) {
+        expect(typeof g, `${c.id} goal should be an object`).toBe('object');
+        expect(validTypes.has(g.type), `${c.id} goal type ${g.type}`).toBe(true);
+      }
+    }
+  });
+
+  it('CI-AUTOTRIAGE goals are all verifiable and carry a metric', () => {
+    for (const g of get('LOOP-CI-AUTOTRIAGE-001').goals) {
+      expect(g.type).toBe(GOAL_TYPE.VERIFIABLE);
+      expect(typeof g.metric).toBe('string');
+      expect(g.metric.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the ADAM rationale-bar goal is llm_as_judge and names its rubric_ref', () => {
+    const judged = get('LOOP-ADAM-OPPORTUNITY-SCAN-001').goals.filter((g) => g.type === GOAL_TYPE.LLM_AS_JUDGE);
+    expect(judged).toHaveLength(1);
+    expect(judged[0].rubric_ref).toBe('lib/adam/rationale-bar.js');
+  });
+
+  it('every declared budget (when present) passes validation', () => {
+    for (const c of LOOP_CONTRACTS) {
+      if (c.budget !== undefined) expect(validateLoopContract(c).valid).toBe(true);
+    }
   });
 });
 

--- a/tests/unit/loops/loop-contract.test.js
+++ b/tests/unit/loops/loop-contract.test.js
@@ -7,6 +7,7 @@ import {
   validateLoopContract,
   CADENCE_TYPE,
   BOUNDARY_KIND,
+  GOAL_TYPE,
   LOOP_CONTRACT_FIELDS,
 } from '../../../lib/loops/loop-contract.js';
 
@@ -86,6 +87,119 @@ describe('validateLoopContract — fail-loud (each missing required field is nam
     const c = completeContract();
     c.goals = [];
     expect(validateLoopContract(c).valid).toBe(false);
+  });
+});
+
+// SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-BUDGET-001 (FR-1): GOAL_TYPE + typed-goal validation.
+describe('GOAL_TYPE + typed goals (FR-1)', () => {
+  it('exposes a frozen GOAL_TYPE enum {verifiable, llm_as_judge}', () => {
+    expect(Object.isFrozen(GOAL_TYPE)).toBe(true);
+    expect(Object.values(GOAL_TYPE)).toEqual(['verifiable', 'llm_as_judge']);
+  });
+
+  it('a bare-string goal is still valid (back-compat)', () => {
+    const c = completeContract();
+    c.goals = ['do the thing'];
+    expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('a typed verifiable goal object (with a metric) is valid', () => {
+    const c = completeContract();
+    c.goals = [{ description: 'reach threshold', type: GOAL_TYPE.VERIFIABLE, metric: 'count >= N' }];
+    expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('a verifiable goal WITHOUT a metric is still valid (metric is SHOULD, not MUST)', () => {
+    const c = completeContract();
+    c.goals = [{ description: 'reach threshold', type: GOAL_TYPE.VERIFIABLE }];
+    expect(validateLoopContract(c).valid).toBe(true);
+  });
+
+  it('an llm_as_judge goal WITH a rubric_ref is valid', () => {
+    const c = completeContract();
+    c.goals = [{ description: 'clears the bar', type: GOAL_TYPE.LLM_AS_JUDGE, rubric_ref: 'lib/adam/rationale-bar.js' }];
+    expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('an llm_as_judge goal WITHOUT a rubric_ref is invalid and names rubric_ref (anti-brittleness guard)', () => {
+    const c = completeContract();
+    c.goals = [{ description: 'clears the bar', type: GOAL_TYPE.LLM_AS_JUDGE }];
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('rubric_ref');
+  });
+
+  it('a goal object missing a description is invalid', () => {
+    const c = completeContract();
+    c.goals = [{ type: GOAL_TYPE.VERIFIABLE }];
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('description');
+  });
+
+  it('a goal object with an unknown type is invalid', () => {
+    const c = completeContract();
+    c.goals = [{ description: 'x', type: 'vibes' }];
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('type');
+  });
+
+  it('mixed bare-string and typed goals are accepted together', () => {
+    const c = completeContract();
+    c.goals = ['legacy goal', { description: 'judged goal', type: GOAL_TYPE.LLM_AS_JUDGE, rubric_ref: 'r' }];
+    expect(validateLoopContract(c).valid).toBe(true);
+  });
+});
+
+// SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-BUDGET-001 (FR-2): optional budget declaration.
+describe('budget declaration (FR-2)', () => {
+  it('declares "budget" as a known field', () => {
+    expect(LOOP_CONTRACT_FIELDS).toContain('budget');
+  });
+
+  it('an absent budget is valid (optional)', () => {
+    expect(validateLoopContract(completeContract()).valid).toBe(true);
+  });
+
+  it('a well-formed budget is valid', () => {
+    const c = completeContract();
+    c.budget = { tokens_per_run_estimate: 1500, daily_max_runs: 24, pause_if_budget_below_pct: 10 };
+    expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('a negative numeric budget field is invalid', () => {
+    const c = completeContract();
+    c.budget = { daily_max_runs: -1 };
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('daily_max_runs');
+  });
+
+  it('pause_if_budget_below_pct > 100 is invalid', () => {
+    const c = completeContract();
+    c.budget = { pause_if_budget_below_pct: 150 };
+    const res = validateLoopContract(c);
+    expect(res.valid).toBe(false);
+    expect(res.errors.join(' ')).toContain('pause_if_budget_below_pct');
+  });
+
+  it('a non-object budget is invalid', () => {
+    const c = completeContract();
+    c.budget = 'cheap';
+    expect(validateLoopContract(c).valid).toBe(false);
+  });
+
+  it('a null budget is invalid (null is typeof object — must be explicitly rejected)', () => {
+    const c = completeContract();
+    c.budget = null;
+    expect(validateLoopContract(c).valid).toBe(false);
+  });
+
+  it('pause_if_budget_below_pct = 0 is valid (0 is a real number, not a falsy reject)', () => {
+    const c = completeContract();
+    c.budget = { pause_if_budget_below_pct: 0 };
+    expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
   });
 });
 


### PR DESCRIPTION
Extends the loop-contract framework (base #4874) so every loop is self-describing on the two distinctions the autonomous-loop model turns on.

**FR-1 (goal type):** frozen `GOAL_TYPE {verifiable, llm_as_judge}`; goals evolve from bare strings to typed `{description, type, metric?, rubric_ref?}`. A `llm_as_judge` goal **MUST** carry a `rubric_ref` (fail-loud anti-brittleness guard — a judge-style loop without a defined rubric is the brittle failure mode). Bare-string goals stay valid (back-compat); validator remains pure/total.

**FR-2 (budget):** optional `budget {tokens_per_run_estimate?, daily_max_runs?, pause_if_budget_below_pct?}` so the registry can scale past 2 loops without collective budget exhaustion. Declaration only — enforcement/auto-pause is a documented follow-on.

**FR-3 (exemplars):** both migrated to typed goals + budget; the ADAM rationale-bar goal → `llm_as_judge` with `rubric_ref='lib/adam/rationale-bar.js'` (a real file). `assertContractsValid()` still green at import.

**FR-4 (tests):** 21 new tests (44 total in `tests/unit/loops/`); judge-rubric guard mutation-verified. No regression to the 23 base tests.

Additive, single-repo, no schema change, no runtime behavior change (declaring a loop still changes nothing about how it runs). Independent adversarial review: **SHIP** (0 HIGH/MEDIUM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)