### PR TITLE
feat(SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001): production-error sweep loop -> DRAFT corrective SDs

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001.json
@@ -1,0 +1,118 @@
+{
+  "executive_summary": "The production-breakage detector/surface family writes recurring breakage signals into system_alerts (each carrying metadata.break_class), but nothing turns a recurring spike into actionable work — that last mile is missing. This PRD delivers a fail-soft, flag-gated (default OFF) cron sweep that reads system_alerts over a rolling window, groups by (break_class, source), detects classes recurring above a threshold, and sources exactly ONE DRAFT corrective/diagnostic SD per recurring uncovered class — never auto-fixing and never auto-resolving the alert (CONST-002). It mirrors the proven scripts/clockwork/ci-autotriage-loop.cjs doctrine and reuses its status-aware isCovered/stripDeadLinks dedup so a stale CANCELLED link cannot immortalize a class.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Fail-soft flag-gated sweep over system_alerts, grouped by (break_class, source)",
+      "description": "A new scripts/clockwork/prod-error-sweep-loop.cjs mirroring the ci-autotriage-loop.cjs structure: gated behind PROD_ERROR_SWEEP_LOOP_ENABLE (default OFF -> prints [SKIP] and exits 0), default DRY-RUN unless --apply, with --threshold/--per-run/--per-day overrides. It reads unresolved system_alerts (resolved_at IS NULL) created within a rolling window (default 24h), and groups them by the (break_class, source_service) tuple. The break-class set is the FROZEN denominator imported from lib/coordinator/break-class-taxonomy.cjs (BREAK_CLASSES) — alerts whose metadata.break_class is not an enumerated class are ignored. Detection is pure (new scripts/lib/prod-error-recurrence-detector.mjs): a class is a candidate when its windowed occurrence count is >= threshold (default 3).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "With PROD_ERROR_SWEEP_LOOP_ENABLE unset, the script prints [SKIP] and exits 0 having written nothing.",
+        "With the flag on and no --apply, it lists each recurring uncovered (break_class, source) class above the threshold and writes nothing.",
+        "Only break_class values present in BREAK_CLASSES from break-class-taxonomy.cjs are considered; unknown classes are skipped.",
+        "Detection groups by the (break_class, source_service) tuple and counts occurrences within the configured window."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Source ONE DRAFT corrective SD per recurring uncovered class, carrying alert context, never auto-fixing or auto-resolving",
+      "description": "For each recurring uncovered class, the loop creates a durable bridge feedback row (category='production_error') carrying the alert context (occurrence count, source, break_class, a sample alert title/message), then sources exactly ONE DRAFT corrective SD through the canonical CLI: node scripts/leo-create-sd.js --from-feedback <bridgeId> --type infrastructure (SD_CREATE_VIA_SKILL=1). The created SD key is read back authoritatively from feedback.strategic_directive_id (never scraped from stdout), tagged metadata.sourced_by='prod-error-sweep' + metadata.break_class. The loop NEVER edits code, NEVER merges, and NEVER writes system_alerts.resolved_at — diagnosis is deferred to the worker who picks up the DRAFT SD (CONST-002), exactly the ci-autotriage boundary.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Each recurring uncovered class produces exactly one DRAFT SD via leo-create-sd.js --from-feedback (no hand-rolled inserts).",
+        "The bridge feedback row and SD metadata carry the alert context: occurrence count, source, break_class, and a sample.",
+        "No system_alerts row is ever updated (resolved_at stays null); no code is edited and nothing is merged by the loop.",
+        "Per-run and per-day anti-spam caps bound how many SDs a single run / day can source (defaults 3 / 10)."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Status-aware idempotency reusing isCovered / stripDeadLinks",
+      "description": "Before sourcing, the loop fetches open production_error bridge rows for the candidate classes and applies the ci-autotriage stripDeadLinks logic (TERMINAL_SD_STATUSES = cancelled/archived/superseded/rejected): a bridge row linked ONLY to a terminal SD is treated as uncovered so a stale CANCELLED link cannot immortalize a class. A (break_class, source) class is COVERED — and skipped — when an open bridge row for it still links to a non-terminal SD (reusing isCovered from scripts/lib/ci-recurrence-detector.mjs). Re-running the loop immediately after an apply re-sources nothing.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "A class already covered by an open, non-terminal corrective SD is skipped (no duplicate SD).",
+        "A class whose only corrective SD is in a terminal status (cancelled/archived/superseded/rejected) is treated as uncovered and may be re-sourced.",
+        "An immediate re-run after --apply sources zero additional SDs for the just-covered classes."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Bounded run ledger + loud outcome-gated warnings, fail-soft",
+      "description": "Each run logs a bounded summary: window, candidate count, sourced count, per-run/per-day remaining, and per-class -> SD linkage, prefixed [prod-error-sweep]. Degraded conditions (alert fetch failed, per-day count failed, create/tag failed for a class) emit a loud [ALERT] line but the run continues and the process always exits 0 (fail-soft, never throws) — mirroring the ci-autotriage main().catch(exit 0) contract. A single class failure never aborts the remaining classes.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Every run prints a bounded summary line with window, candidates, sourced, and caps.",
+        "A fetch/count/create failure logs a loud [ALERT] line and the run continues; the process exits 0 even on internal error.",
+        "One class failing to source does not prevent the other classes in the run from being processed."
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Register the loop contract, wire it into package.json, and pin behavior with tests",
+      "description": "Declare the loop in lib/loops/loop-contract-registry.js as a third exemplar contract (id LOOP-PROD-ERROR-SWEEP-001) with goals, ordered workflow steps, may/may_not boundaries (may: read system_alerts, detect classes, source DRAFT SDs, link bridge rows; may_not: edit code, merge, auto-fix, write strategy tables, or resolve alerts), tasks (entrypoint + pure_logic + flag), and a cron timeline. The contract is DATA ONLY (assertContractsValid must still pass). Note: goal_type=verifiable is NOT added because SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-BUDGET-001 has not shipped (the schema does not yet accept it). Add a package.json scripts entry (prod-error-sweep) so WIRE_CHECK can reach the new entrypoint, and add tests covering recurrence detection, status-aware idempotency, and the no-auto-fix/no-auto-resolve boundary.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "lib/loops/loop-contract-registry.js declares LOOP-PROD-ERROR-SWEEP-001 and assertContractsValid() still passes (loud at import).",
+        "package.json has a scripts entry invoking scripts/clockwork/prod-error-sweep-loop.cjs so WIRE_CHECK resolves the entrypoint.",
+        "Tests cover: threshold-based recurrence detection, status-aware idempotency (covered vs terminal-link), and a boundary assertion that the detector module exposes no resolve/fix capability."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Pure detector module", "description": "scripts/lib/prod-error-recurrence-detector.mjs is pure (no DB/IO), mirroring scripts/lib/ci-recurrence-detector.mjs; the loop script owns all IO." },
+    { "id": "TR-2", "title": "No schema change", "description": "Additive only: new bridge feedback rows use the existing feedback table (category='production_error', a free varchar); system_alerts is read-only. No migration." },
+    { "id": "TR-3", "title": "Canonical sourcing only", "description": "SDs are created exclusively via scripts/leo-create-sd.js --from-feedback with SD_CREATE_VIA_SKILL=1; never a hand-rolled strategic_directives_v2 insert." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Recurrence detection groups by (break_class, source) and applies the threshold", "type": "unit", "expected": "detectRecurringClasses returns only tuples whose windowed count meets the threshold, sorted deterministically." },
+    { "id": "TS-2", "scenario": "Status-aware idempotency skips covered classes but re-sources terminal-linked ones", "type": "unit", "expected": "A class with an open non-terminal corrective SD is excluded; a class whose only link is a cancelled SD is included again." },
+    { "id": "TS-3", "scenario": "No-auto-fix / no-auto-resolve boundary", "type": "unit", "expected": "The detector exposes only read/classify functions (no resolve/fix/update); the loop never writes system_alerts.resolved_at." }
+  ],
+  "acceptance_criteria": [
+    "The loop is OFF by default and fail-soft (always exits 0).",
+    "Recurring uncovered (break_class, source) classes each yield exactly one traceably-linked DRAFT corrective SD.",
+    "No alert is auto-resolved and no code is auto-fixed by the loop.",
+    "The loop is declared in the loop-contract registry and reachable from package.json (WIRE_CHECK)."
+  ],
+  "risks": [
+    { "risk": "Sourcing storm if many classes recur at once", "mitigation": "Per-run (3) and per-day (10) caps, mirroring ci-autotriage applyCaps.", "severity": "low" },
+    { "risk": "Bridge feedback rows pollute the inbox", "mitigation": "Dedicated category='production_error' + status-aware idempotency prevents duplicate rows per covered class.", "severity": "low" },
+    { "risk": "Stale CANCELLED link permanently suppresses a still-recurring class", "mitigation": "stripDeadLinks treats terminal-SD links as uncovered, reused verbatim from ci-autotriage.", "severity": "medium" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["LEO fleet workers who pick up the DRAFT corrective SDs", "Coordinator/Adam who see new infrastructure SDs in the queue", "the loop-contract registry consumers (npm run loops:list)"],
+    "dependencies": ["lib/coordinator/break-class-taxonomy.cjs (BREAK_CLASSES denominator)", "scripts/lib/ci-recurrence-detector.mjs (isCovered)", "scripts/leo-create-sd.js --from-feedback", "system_alerts table (read-only)", "feedback table (bridge rows)"],
+    "data_contracts": ["system_alerts.metadata.break_class encoding (read)", "feedback category='production_error' bridge row (write)", "feedback.strategic_directive_id linkage (read-back)", "strategic_directives_v2.metadata.sourced_by='prod-error-sweep' tag (write); no schema change"],
+    "runtime_config": ["PROD_ERROR_SWEEP_LOOP_ENABLE (default false)", "--apply (default DRY-RUN)", "--threshold (default 3)", "--per-run (default 3)", "--per-day (default 10)", "SD_CREATE_VIA_SKILL=1 for the create child process"],
+    "observability_rollout": ["[prod-error-sweep] log lines (bounded per-run summary + [ALERT] degraded warnings)", "ships INERT (flag OFF) — enable in a controlled window and watch sourced DRAFT SD volume + system_alerts staying unresolved", "metadata.sourced_by='prod-error-sweep' makes sourced SDs queryable for the per-day cap and audit"]
+  },
+  "system_architecture": {
+    "summary": "Pure detector (scripts/lib) + fail-soft clockwork loop (scripts/clockwork) reading system_alerts and sourcing DRAFT SDs via the canonical CLI; declared as a loop contract.",
+    "components": [
+      { "name": "scripts/lib/prod-error-recurrence-detector.mjs", "change": "NEW pure detector (group by break_class+source, threshold, coverage filter)" },
+      { "name": "scripts/clockwork/prod-error-sweep-loop.cjs", "change": "NEW fail-soft flag-gated loop (IO, sourcing, ledger)" },
+      { "name": "lib/loops/loop-contract-registry.js", "change": "ADD LOOP-PROD-ERROR-SWEEP-001 contract" },
+      { "name": "package.json", "change": "ADD prod-error-sweep scripts entry (WIRE_CHECK)" },
+      { "name": "tests/unit/prod-error-recurrence-detector.test.js", "change": "NEW unit tests (recurrence, idempotency, boundary)" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Mirror the ci-autotriage-loop doctrine, swapping the feedback(ci_failure) source for system_alerts(break_class) and adding a bridge-feedback sourcing hop so the existing --from-feedback path and isCovered/stripDeadLinks dedup are reused unchanged.",
+    "steps": [
+      "Write the pure detector scripts/lib/prod-error-recurrence-detector.mjs (classKey=break_class::source, detectRecurringClasses with threshold + coveredKeys exclusion, applyCaps).",
+      "Write scripts/clockwork/prod-error-sweep-loop.cjs: flag gate, read unresolved windowed system_alerts, build coveredKeys from open production_error bridge rows after stripDeadLinks, cap, then per class create bridge row -> leo-create-sd.js --from-feedback -> read-back -> tag.",
+      "Declare LOOP-PROD-ERROR-SWEEP-001 in loop-contract-registry.js (no goal_type) and add the package.json entry.",
+      "Add tests/unit/prod-error-recurrence-detector.test.js (recurrence, idempotency, boundary).",
+      "Run TESTING + SECURITY sub-agents, commit early, EXEC-TO-PLAN."
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run: PROD_ERROR_SWEEP_LOOP_ENABLE unset, node scripts/clockwork/prod-error-sweep-loop.cjs", "expected_outcome": "Prints [SKIP] disabled and exits 0; writes nothing (flag-gated default OFF)." },
+    { "step_number": 2, "instruction": "Run: PROD_ERROR_SWEEP_LOOP_ENABLE=true node scripts/clockwork/prod-error-sweep-loop.cjs", "expected_outcome": "Lists recurring uncovered (break_class, source) classes above threshold from system_alerts; writes nothing (DRY-RUN)." },
+    { "step_number": 3, "instruction": "Seed >=3 unresolved system_alerts sharing one (break_class, source), then run with --apply", "expected_outcome": "Sources exactly ONE DRAFT corrective SD via leo-create-sd.js --from-feedback carrying alert context; links the bridge feedback row; system_alerts stay unresolved." },
+    { "step_number": 4, "instruction": "Re-run --apply immediately, then cancel the sourced SD and run again", "expected_outcome": "Immediate re-run sources nothing (covered); after the SD is cancelled, the class is treated as uncovered again (stripDeadLinks)." }
+  ],
+  "activation_test_id": "tests/unit/prod-error-recurrence-detector.test.js",
+  "metadata": { "sd_key": "SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001" }
+}

--- a/lib/loops/loop-contract-registry.js
+++ b/lib/loops/loop-contract-registry.js
@@ -79,10 +79,50 @@ const ADAM_OPPORTUNITY_SCAN_CONTRACT = {
   logging: { writes: ['ADAM_OK | SURFACED | SUPPRESSED_FLAG_OFF verdict', 'selected scope', 'ledger entry (bounded 500)'], durable_ledger: 'local .json', event_bus: null },
 };
 
+/**
+ * Exemplar 3 — Production-error Sweep Loop.
+ * Entrypoint: scripts/clockwork/prod-error-sweep-loop.cjs (npm run prod-error-sweep)
+ * Built by SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001 — the last mile that turns recurring
+ * system_alerts breakage spikes into DRAFT corrective SDs.
+ *
+ * NOTE: goal_type=verifiable is intentionally NOT declared — SD-LEO-INFRA-LOOP-CONTRACT-GOAL-TYPE-
+ * BUDGET-001 (which would add that field to the contract schema) has not shipped, so the validator
+ * does not yet accept it. The contract is DATA ONLY (declaring it changes nothing about how the loop
+ * runs); add goal_type later when that SD lands.
+ */
+const PROD_ERROR_SWEEP_CONTRACT = {
+  id: 'LOOP-PROD-ERROR-SWEEP-001',
+  name: 'Production-error Sweep Loop',
+  goals: [
+    'Detect recurring, uncovered production-breakage classes from system_alerts (chronic, >= threshold occurrences per (break_class, source))',
+    'Source one DRAFT corrective SD per recurring class WITHOUT auto-fixing or auto-resolving the alert (CONST-002)',
+  ],
+  workflow: [
+    { step: 1, name: 'Fetch unresolved system_alerts within the window', action: 'read' },
+    { step: 2, name: 'Strip dead links on open production_error bridge rows so stale links do not suppress recurrence', action: 'cleanup' },
+    { step: 3, name: 'Detect chronic uncovered (break_class, source) classes within the frozen taxonomy', action: 'classify' },
+    { step: 4, name: 'Bridge each class to a feedback row and source one DRAFT corrective SD via leo-create-sd.js --from-feedback', action: 'propose' },
+    { step: 5, name: 'Tag the sourced SD metadata.sourced_by=prod-error-sweep + break_class (alerts left unresolved)', action: 'relate' },
+  ],
+  boundaries: [
+    { kind: BOUNDARY_KIND.MAY, description: 'Read system_alerts, detect chronic classes (pure logic), insert durable bridge feedback rows, source DRAFT SDs via the canonical CLI, and tag SD metadata.' },
+    { kind: BOUNDARY_KIND.MAY_NOT, description: 'Edit code, merge, auto-fix breakage, write directly to strategy tables, or RESOLVE the system_alerts rows (diagnosis is deferred to the SD worker — CONST-002).' },
+  ],
+  tasks: [
+    { task: 'entrypoint', file: 'scripts/clockwork/prod-error-sweep-loop.cjs' },
+    { task: 'pure_logic', file: 'scripts/lib/prod-error-recurrence-detector.mjs' },
+    { task: 'taxonomy', file: 'lib/coordinator/break-class-taxonomy.cjs' },
+    { task: 'flag', key: 'PROD_ERROR_SWEEP_LOOP_ENABLE', default: 'false' },
+  ],
+  timeline: { type: CADENCE_TYPE.CRON, cadence: '40 * * * *', description: 'Hourly at :40 (offset from the CI-autotriage :50 and Adam :37 ticks to dodge runner congestion)', fail_soft: true, proposal_only: true },
+  logging: { writes: ['count of unresolved alerts in window', 'covered class-key count', 'chronic uncovered class count', 'per-run + per-day cap remaining', 'class->SD linkage'], durable_ledger: null, event_bus: null },
+};
+
 /** The canonical declared set. Frozen — runtime cannot mutate it. */
 export const LOOP_CONTRACTS = Object.freeze([
   Object.freeze(CI_AUTOTRIAGE_CONTRACT),
   Object.freeze(ADAM_OPPORTUNITY_SCAN_CONTRACT),
+  Object.freeze(PROD_ERROR_SWEEP_CONTRACT),
 ]);
 
 /** Enumerable summaries (id, name, cadence) for every declared loop. */

--- a/package.json
+++ b/package.json
@@ -322,6 +322,7 @@
     "checkin": "node scripts/worker-checkin.cjs",
     "canary:sweep": "node scripts/canary-trigger-sweep.mjs",
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
+    "prod-error-sweep": "node scripts/clockwork/prod-error-sweep-loop.cjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",

--- a/scripts/clockwork/prod-error-sweep-loop.cjs
+++ b/scripts/clockwork/prod-error-sweep-loop.cjs
@@ -168,7 +168,6 @@ async function stripDeadLinks(db, rows) {
  * from, and the row coverage/idempotency is tracked on. Returns the new row id, or null on failure.
  */
 async function insertBridgeRow(db, c) {
-  const sources = [c.source].filter(Boolean);
   const description = [
     `Recurring production breakage detected by the prod-error-sweep loop.`,
     ``,

--- a/scripts/clockwork/prod-error-sweep-loop.cjs
+++ b/scripts/clockwork/prod-error-sweep-loop.cjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * prod-error-sweep-loop — the missing LAST MILE of the production-breakage pipeline.
+ * SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001.
+ *
+ * The breakage-detector family writes recurring breakage signals into system_alerts (each row
+ * carrying metadata.break_class), but nothing turns a recurring spike into actionable work. This
+ * loop closes that gap: it reads system_alerts over a window, groups by (break_class, source),
+ * and for each recurring UNCOVERED class sources ONE DRAFT corrective SD — WITHOUT ever editing
+ * code, merging, or RESOLVING the alert (CONST-002; diagnosis happens when a worker picks the
+ * DRAFT SD up, NOT here). Same boundary and doctrine as scripts/clockwork/ci-autotriage-loop.cjs.
+ *
+ * Flow each tick (fail-soft, flag-gated default OFF):
+ *   1. fetch UNRESOLVED system_alerts in the window (resolved_at IS NULL, created_at >= now-window)
+ *   2. fetch the open production_error BRIDGE feedback rows + strip DEAD links (a bridge row linked
+ *      only to a cancelled/archived SD is treated as uncovered so a stale link can't immortalize a
+ *      recurring class) -> compute the covered class-key set
+ *   3. detect chronic, NOT-yet-covered (break_class, source) classes (pure detector; only the FROZEN
+ *      break-class taxonomy denominator is considered)
+ *   4. cap per-run + per-day (anti-spam)
+ *   5. per class: insert a durable BRIDGE feedback row (category='production_error') carrying the
+ *      alert context, source ONE DRAFT corrective SD via the canonical leo-create-sd.js
+ *      --from-feedback (read the SD key back from feedback.strategic_directive_id — authoritative,
+ *      NOT scraped from stdout), and tag metadata.sourced_by='prod-error-sweep' + break_class.
+ *      The system_alerts rows are NEVER touched (never resolved).
+ *
+ * Default DRY-RUN (like the sibling clockwork scripts). Pass --apply to write.
+ * Gate: PROD_ERROR_SWEEP_LOOP_ENABLE !== 'true' -> [SKIP] exit 0.
+ */
+require('dotenv/config');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const { createClient } = require('@supabase/supabase-js');
+const { BREAK_CLASSES } = require('../../lib/coordinator/break-class-taxonomy.cjs');
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const THRESHOLD = Number((args.find((a) => a.startsWith('--threshold=')) || '').split('=')[1]) || undefined;
+const PER_RUN_CAP = Number((args.find((a) => a.startsWith('--per-run=')) || '').split('=')[1]) || undefined;
+const PER_DAY_CAP = Number((args.find((a) => a.startsWith('--per-day=')) || '').split('=')[1]) || undefined;
+const WINDOW_HOURS = Number((args.find((a) => a.startsWith('--window-hours=')) || '').split('=')[1]) || undefined;
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const TERMINAL_SD_STATUSES = ['cancelled', 'archived', 'superseded', 'rejected'];
+const BRIDGE_CATEGORY = 'production_error';
+
+function log(...a) { console.log('[prod-error-sweep]', ...a); }
+
+async function main() {
+  // flag-gated, default OFF. Fail-soft no-op when disabled.
+  if (process.env.PROD_ERROR_SWEEP_LOOP_ENABLE !== 'true') {
+    log('[SKIP] disabled (set PROD_ERROR_SWEEP_LOOP_ENABLE=true to enable)');
+    return;
+  }
+  const db = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+  const { detectRecurringClasses, applyCaps, handledClassKeys, DEFAULT_THRESHOLD, DEFAULT_PER_RUN_CAP, DEFAULT_PER_DAY_CAP, DEFAULT_WINDOW_HOURS } =
+    await import('../lib/prod-error-recurrence-detector.mjs');
+  const { isCovered } = await import('../lib/ci-recurrence-detector.mjs');
+
+  // 1. unresolved system_alerts in the window. We only READ here — alerts are never resolved.
+  const windowHours = WINDOW_HOURS || DEFAULT_WINDOW_HOURS;
+  const windowStart = new Date(Date.now() - windowHours * 3600 * 1000).toISOString();
+  const { data: alerts, error } = await db
+    .from('system_alerts')
+    .select('id,alert_type,severity,title,message,source_service,metadata,resolved_at,created_at')
+    .is('resolved_at', null)
+    .gte('created_at', windowStart);
+  if (error) { log('[ALERT] system_alerts fetch failed (fail-soft):', error.message); return; }
+  log(`unresolved alerts in last ${windowHours}h: ${alerts ? alerts.length : 0}`);
+
+  // 2. open production_error bridge rows -> strip dead links -> HANDLED class-key set
+  //    (covered by an open SD OR already surfaced as a new/triaged inbox row awaiting human triage).
+  const bridgeRows = await fetchOpenBridgeRows(db);
+  await stripDeadLinks(db, bridgeRows);
+  const handledKeys = handledClassKeys(bridgeRows, isCovered);
+  if (handledKeys.size) log(`handled class keys (open SD or surfaced inbox row): ${handledKeys.size}`);
+
+  // 3. detect chronic, un-handled (break_class, source) classes within the frozen taxonomy.
+  const threshold = THRESHOLD || DEFAULT_THRESHOLD;
+  const candidates = detectRecurringClasses(alerts || [], { threshold, legalClasses: BREAK_CLASSES, coveredKeys: handledKeys });
+  log(`chronic uncovered classes (threshold ${threshold}): ${candidates.length}`);
+
+  // 4. anti-spam caps: per-run + remaining per-day budget (count today's prod-error-sweep SDs).
+  const since = new Date(); since.setUTCHours(0, 0, 0, 0);
+  let sourcedToday = 0;
+  try {
+    const { count } = await db
+      .from('strategic_directives_v2')
+      .select('id', { count: 'exact', head: true })
+      .eq('metadata->>sourced_by', 'prod-error-sweep')
+      .gte('created_at', since.toISOString());
+    sourcedToday = count || 0;
+  } catch (e) { log('[ALERT] per-day count failed (fail-soft, assume 0):', e.message); }
+  const capped = applyCaps(candidates, {
+    perRunCap: PER_RUN_CAP || DEFAULT_PER_RUN_CAP,
+    sourcedToday,
+    perDayCap: PER_DAY_CAP || DEFAULT_PER_DAY_CAP,
+  });
+  log(`sourcing this run: ${capped.length} (sourcedToday=${sourcedToday})${APPLY ? '' : ' [DRY-RUN]'}`);
+
+  // 5. per candidate, fail-soft: bridge -> source a DRAFT SD -> tag. Alerts are never resolved.
+  for (const c of capped) {
+    try {
+      log(`class ${c.classKey} (sev=${c.severity || '?'}, x${c.occurrenceTotal}) sample="${(c.sampleTitle || '').slice(0, 60)}"`);
+      if (!APPLY) { log('  [DRY-RUN] would bridge + source a DRAFT corrective SD via --from-feedback (alert NOT resolved)'); continue; }
+      const bridgeId = await insertBridgeRow(db, c);
+      if (!bridgeId) { log('  [ALERT] bridge-row insert failed — skipping (fail-soft)'); continue; }
+      const sdKey = await sourceDraftSd(db, bridgeId);
+      if (!sdKey) {
+        // SD creation was blocked (e.g. a creation guardrail that needs a human review the loop
+        // must NOT self-attest) or otherwise failed. Leave the bridge row 'new' in the inbox as the
+        // durable surfaced record + annotate it so a human knows to triage/escalate it manually.
+        await markBridgeNeedsEscalation(db, bridgeId);
+        log('  no NEW SD linked (creation guardrail or duplicate-guard) — bridge row left in inbox for human triage (fail-soft)');
+        continue;
+      }
+      log(`  sourced DRAFT ${sdKey} (bridge ${bridgeId})`);
+      const tagged = await tagSourcedBy(db, sdKey, c);
+      if (!tagged) log(`  [ALERT] could not tag ${sdKey} sourced_by=prod-error-sweep — per-day accounting may undercount`);
+    } catch (e) {
+      log(`  [ALERT] class ${c.classKey} failed (fail-soft):`, e.message);
+    }
+  }
+}
+
+/** Open production_error bridge rows (the durable triage records this loop links coverage on). */
+async function fetchOpenBridgeRows(db) {
+  try {
+    const { data } = await db
+      .from('feedback')
+      .select('id,status,strategic_directive_id,resolution_sd_id,metadata')
+      .eq('category', BRIDGE_CATEGORY)
+      .in('status', ['new', 'triaged', 'in_progress']);
+    return data || [];
+  } catch (e) { log('[ALERT] bridge-row fetch failed (fail-soft, treat all uncovered):', e.message); return []; }
+}
+
+/**
+ * Treat bridge rows linked ONLY to a terminal (cancelled/archived/...) SD as uncovered, by clearing
+ * their in-memory link fields. Prevents a dead link from immortalizing a recurring class. Verbatim
+ * mirror of the ci-autotriage stripDeadLinks contract.
+ */
+async function stripDeadLinks(db, rows) {
+  const keys = [...new Set(rows.map((r) => r.strategic_directive_id || r.resolution_sd_id).filter(Boolean))];
+  if (!keys.length) return;
+  const statusByKey = {};
+  try {
+    const { data } = await db.from('strategic_directives_v2').select('id,status').in('id', keys);
+    for (const sd of data || []) statusByKey[sd.id] = sd.status;
+  } catch (e) { log('[ALERT] dead-link status lookup failed (fail-soft, keep links):', e.message); return; }
+  let stripped = 0;
+  for (const r of rows) {
+    const link = r.strategic_directive_id || r.resolution_sd_id;
+    if (link && TERMINAL_SD_STATUSES.includes(statusByKey[link])) {
+      r.strategic_directive_id = null;
+      r.resolution_sd_id = null;
+      stripped++;
+    }
+  }
+  if (stripped) log(`stripped ${stripped} dead (terminal-SD) link(s) so stale links don't suppress recurring classes`);
+}
+
+/**
+ * Insert the durable BRIDGE feedback row carrying the alert context. This is the analog of a
+ * ci_failure feedback row: a durable triage record the canonical --from-feedback path can source
+ * from, and the row coverage/idempotency is tracked on. Returns the new row id, or null on failure.
+ */
+async function insertBridgeRow(db, c) {
+  const sources = [c.source].filter(Boolean);
+  const description = [
+    `Recurring production breakage detected by the prod-error-sweep loop.`,
+    ``,
+    `Break class: ${c.breakClass}`,
+    `Source: ${c.source || 'unknown'}`,
+    `Occurrences in window: ${c.occurrenceTotal}`,
+    `Sample alert: ${c.sampleTitle || '(no title)'}`,
+    c.sampleMessage ? `Sample message: ${c.sampleMessage}` : '',
+    ``,
+    `Diagnose and remediate the recurring ${c.breakClass} breakage from ${c.source || 'the source service'}. ` +
+    `This DRAFT corrective SD was sourced WITHOUT auto-fixing or auto-resolving the alerts (CONST-002).`,
+  ].filter((l) => l !== '').join('\n');
+  try {
+    const { data, error } = await db
+      .from('feedback')
+      .insert({
+        category: BRIDGE_CATEGORY,
+        source_application: 'EHG_Engineer',
+        source_type: 'error_capture',
+        type: 'issue',
+        status: 'new',
+        priority: c.severity === 'critical' ? 'high' : 'medium',
+        title: `Recurring ${c.breakClass} breakage from ${c.source || 'unknown'} (x${c.occurrenceTotal})`,
+        description,
+        metadata: {
+          sourced_by: 'prod-error-sweep',
+          break_class: c.breakClass,
+          alert_source: c.source,
+          alert_ids: c.alertIds,
+          occurrence_total: c.occurrenceTotal,
+        },
+      })
+      .select('id')
+      .single();
+    if (error) { log('  [ALERT] bridge insert error:', error.message); return null; }
+    return data.id;
+  } catch (e) { log('  [ALERT] bridge insert threw:', e.message); return null; }
+}
+
+/**
+ * Source a DRAFT corrective SD via the canonical CLI (never a hand-rolled insert), then read the
+ * created SD key back from feedback.strategic_directive_id (the authoritative value
+ * createFromFeedback writes) rather than scraping stdout. Returns the NEW SD key, or null when the
+ * spawn created nothing new (e.g. the --from-feedback duplicate guard fired).
+ */
+async function sourceDraftSd(db, feedbackId) {
+  const { data: before } = await db.from('feedback').select('strategic_directive_id').eq('id', feedbackId).maybeSingle();
+  const beforeLink = before ? before.strategic_directive_id : null;
+  try {
+    execFileSync('node', ['scripts/leo-create-sd.js', '--from-feedback', feedbackId, '--type', 'infrastructure'], {
+      cwd: REPO_ROOT, encoding: 'utf8', timeout: 120000, env: { ...process.env, SD_CREATE_VIA_SKILL: '1' },
+    });
+  } catch (e) {
+    log('  [ALERT] leo-create-sd --from-feedback failed:', (e.message || '').split('\n')[0]);
+    return null;
+  }
+  const { data: after } = await db.from('feedback').select('strategic_directive_id').eq('id', feedbackId).maybeSingle();
+  const afterLink = after ? after.strategic_directive_id : null;
+  if (afterLink && afterLink !== beforeLink) return afterLink;
+  return null; // duplicate-guard hit or no link written — do not tag a pre-existing/foreign SD
+}
+
+/**
+ * Annotate a bridge row whose SD creation was blocked/failed so it is an honest durable record:
+ * it stays status='new' (a handled inbox item — see handledClassKeys) and carries an explicit
+ * needs_human_escalation marker. Best-effort, fail-soft.
+ */
+async function markBridgeNeedsEscalation(db, bridgeId) {
+  try {
+    const { data: row } = await db.from('feedback').select('id,metadata').eq('id', bridgeId).maybeSingle();
+    if (!row) return;
+    const md = row.metadata || {};
+    md.sourcing_status = 'needs_human_escalation';
+    await db.from('feedback').update({ metadata: md }).eq('id', row.id);
+  } catch { /* fail-soft: the row already sits in the inbox as the surfaced record */ }
+}
+
+async function tagSourcedBy(db, sdKey, c) {
+  try {
+    const { data: sd } = await db.from('strategic_directives_v2').select('id,metadata').eq('id', sdKey).maybeSingle();
+    if (!sd) return false;
+    const md = sd.metadata || {};
+    md.sourced_by = 'prod-error-sweep';
+    md.break_class = c.breakClass;
+    md.alert_source = c.source;
+    md.alert_class_key = c.classKey;
+    const { error } = await db.from('strategic_directives_v2').update({ metadata: md }).eq('id', sd.id);
+    return !error;
+  } catch { return false; }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('[prod-error-sweep] [ALERT] fatal (fail-soft):', e.message); process.exit(0); });

--- a/scripts/lib/prod-error-recurrence-detector.mjs
+++ b/scripts/lib/prod-error-recurrence-detector.mjs
@@ -1,0 +1,167 @@
+/**
+ * Production-error recurrence detector (pure, no IO).
+ * SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001 (FR-1/FR-3/FR-5).
+ *
+ * The sibling of scripts/lib/ci-recurrence-detector.mjs, but the source signal is
+ * system_alerts (each row carrying metadata.break_class, written by the production
+ * breakage-detector family) instead of ci_failure feedback rows.
+ *
+ * Given the unresolved, windowed system_alerts rows (the caller filters resolved_at IS NULL
+ * and created_at >= window-start), this clusters them by the (break_class, source) tuple and
+ * returns the chronic, NOT-yet-covered classes that warrant ONE DRAFT corrective SD. It never
+ * decides to FIX anything and never resolves an alert — it only identifies which recurring
+ * breakage CLASSES need a work item sourced (CONST-002; diagnosis happens when a worker picks
+ * the DRAFT SD up, NOT here). The module exposes ONLY read/classify pure functions — no
+ * resolve/update/fix capability exists here by construction (the no-auto-fix boundary).
+ *
+ * Class key: `${break_class}::${source}` — the (break_class, source) grouping FR-1 specifies.
+ * Only break_class values that are members of the FROZEN break-class taxonomy denominator are
+ * considered (the caller passes the legal set); unknown classes are ignored.
+ */
+
+export const DEFAULT_THRESHOLD = 3;
+export const DEFAULT_PER_RUN_CAP = 3;
+export const DEFAULT_PER_DAY_CAP = 10;
+export const DEFAULT_WINDOW_HOURS = 24;
+
+/** The class key for an alert: the (break_class, source) tuple FR-1 groups by. */
+export function classKey(breakClass, source) {
+  return `${breakClass || '?'}::${source || '?'}`;
+}
+
+/** Read an alert's break_class from metadata (the canonical encoding the detector reads back). */
+export function alertBreakClass(alert) {
+  const meta = (alert && alert.metadata) || {};
+  return meta.break_class || null;
+}
+
+/** Read an alert's source (source_service is the canonical column; metadata.source is a fallback). */
+export function alertSource(alert) {
+  if (!alert) return null;
+  const meta = alert.metadata || {};
+  return alert.source_service || meta.source || null;
+}
+
+/**
+ * Bridge-row statuses that mean "already surfaced for human triage" — a class with an OPEN bridge
+ * row in one of these statuses has already been raised into the inbox (e.g. its corrective SD was
+ * guardrail-blocked at creation, so it sits awaiting a human who can provide the required review).
+ * Re-surfacing it would spam the inbox, so it counts as handled.
+ */
+export const BRIDGE_HANDLED_STATUSES = Object.freeze(['new', 'triaged']);
+
+/**
+ * Build the set of COVERED class keys from the open production_error bridge feedback rows.
+ * Mirrors the ci-autotriage coverage model: a class is covered when an OPEN bridge row for it
+ * still links to a corrective SD. The caller is expected to have already applied stripDeadLinks
+ * (clearing links to TERMINAL SDs) so a stale CANCELLED link cannot immortalize a class — here
+ * a row only counts as coverage when isLinked(row) is still true after that stripping.
+ *
+ * @param {Array} bridgeRows - feedback rows (category='production_error'); each carries
+ *   metadata.break_class + metadata.alert_source and the linkage columns.
+ * @param {(row:any)=>boolean} isLinked - the ci-recurrence-detector isCovered predicate.
+ * @returns {Set<string>} covered class keys
+ */
+export function coveredClassKeys(bridgeRows, isLinked) {
+  const covered = new Set();
+  for (const row of bridgeRows || []) {
+    if (!isLinked(row)) continue;
+    const meta = (row && row.metadata) || {};
+    if (!meta.break_class) continue;
+    covered.add(classKey(meta.break_class, meta.alert_source));
+  }
+  return covered;
+}
+
+/**
+ * Build the set of HANDLED class keys — the superset of coverage the loop uses to decide which
+ * classes to skip. A class is handled when an OPEN bridge row for it either:
+ *   (a) still links to a non-terminal corrective SD after stripDeadLinks (isLinked true) — COVERED, or
+ *   (b) sits in a still-untriaged status (new/triaged) — ALREADY SURFACED, awaiting human triage
+ *       (e.g. its SD creation was guardrail-blocked, so the bridge row is the durable inbox record).
+ *
+ * The ONLY case that stays re-sourceable is a bridge row that WAS linked but whose SD has since gone
+ * terminal: stripDeadLinks clears its link (isLinked false) and its status is no longer new/triaged
+ * (createFromFeedback advanced it to in_progress when it linked) — so it is neither (a) nor (b) and
+ * the class can be sourced again. This preserves FR-3's re-source-on-cancel while preventing the
+ * inbox spam a guardrail-blocked class would otherwise cause every tick.
+ *
+ * @param {Array} bridgeRows - feedback rows (post stripDeadLinks)
+ * @param {(row:any)=>boolean} isLinked - the ci-recurrence-detector isCovered predicate
+ * @returns {Set<string>} handled class keys
+ */
+export function handledClassKeys(bridgeRows, isLinked) {
+  const handled = new Set();
+  for (const row of bridgeRows || []) {
+    const meta = (row && row.metadata) || {};
+    if (!meta.break_class) continue;
+    const isHandled = isLinked(row) || BRIDGE_HANDLED_STATUSES.includes(row && row.status);
+    if (isHandled) handled.add(classKey(meta.break_class, meta.alert_source));
+  }
+  return handled;
+}
+
+/**
+ * Cluster unresolved windowed system_alerts into chronic, uncovered candidate classes.
+ *
+ * @param {Array} alerts - system_alerts rows (caller pre-filters to unresolved + in-window)
+ * @param {Object} opts
+ * @param {number} [opts.threshold] - min occurrences for a class to be chronic
+ * @param {Set<string>|string[]} [opts.legalClasses] - the FROZEN break-class set; alerts whose
+ *        break_class is not a member are ignored (no legalClasses => accept any non-empty class)
+ * @param {Set<string>|string[]} [opts.coveredKeys] - class keys already covered by an open SD
+ * @returns {Array<{classKey, breakClass, source, representativeId, alertIds, occurrenceTotal, sampleTitle, sampleMessage, severity}>}
+ */
+export function detectRecurringClasses(alerts, { threshold = DEFAULT_THRESHOLD, legalClasses = null, coveredKeys = null } = {}) {
+  const legal = legalClasses == null ? null : new Set(legalClasses);
+  const covered = coveredKeys == null ? new Set() : new Set(coveredKeys);
+
+  const groups = new Map();
+  for (const alert of alerts || []) {
+    const bc = alertBreakClass(alert);
+    if (!bc) continue; // no class encoding => cannot route
+    if (legal && !legal.has(bc)) continue; // outside the frozen taxonomy => ignore
+    const src = alertSource(alert);
+    const key = classKey(bc, src);
+    if (!groups.has(key)) groups.set(key, { breakClass: bc, source: src, rows: [] });
+    groups.get(key).rows.push(alert);
+  }
+
+  const candidates = [];
+  for (const [key, group] of groups) {
+    if (covered.has(key)) continue; // already covered by an open corrective SD => never double-source
+    const rows = group.rows;
+    if (rows.length < threshold) continue; // not chronic
+    // Representative = oldest alert (stable, deterministic).
+    const rep = rows.slice().sort((a, b) => new Date(a.created_at || 0) - new Date(b.created_at || 0))[0];
+    candidates.push({
+      classKey: key,
+      breakClass: group.breakClass,
+      source: group.source,
+      representativeId: rep.id,
+      alertIds: rows.map((r) => r.id),
+      occurrenceTotal: rows.length,
+      sampleTitle: rep.title || null,
+      sampleMessage: rep.message || null,
+      severity: rep.severity || null,
+    });
+  }
+
+  // Deterministic: most-recurring class first, then by key.
+  candidates.sort(
+    (a, b) =>
+      b.occurrenceTotal - a.occurrenceTotal ||
+      (a.classKey < b.classKey ? -1 : a.classKey > b.classKey ? 1 : 0)
+  );
+  return candidates;
+}
+
+/**
+ * Anti-spam cap: never source more than perRunCap this run, nor exceed perDayCap across the day.
+ * Identical contract to ci-recurrence-detector applyCaps.
+ */
+export function applyCaps(candidates, { perRunCap = DEFAULT_PER_RUN_CAP, sourcedToday = 0, perDayCap = DEFAULT_PER_DAY_CAP } = {}) {
+  const remainingDay = Math.max(0, perDayCap - (Number(sourcedToday) || 0));
+  const limit = Math.min(perRunCap, remainingDay);
+  return (candidates || []).slice(0, Math.max(0, limit));
+}

--- a/tests/unit/prod-error-recurrence-detector.test.js
+++ b/tests/unit/prod-error-recurrence-detector.test.js
@@ -1,0 +1,199 @@
+/**
+ * SD-LEO-INFRA-PROD-ERROR-SWEEP-LOOP-001
+ * Pure tests for the production-error recurrence detector: it flags only chronic,
+ * NOT-yet-covered (break_class, source) classes within the FROZEN break-class taxonomy
+ * for DRAFT corrective sourcing — excluding covered classes (status-aware via stripDeadLinks),
+ * respecting the anti-spam caps, and exposing NO resolve/fix capability (the no-auto-fix boundary).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import {
+  detectRecurringClasses,
+  applyCaps,
+  coveredClassKeys,
+  handledClassKeys,
+  classKey,
+  alertBreakClass,
+  alertSource,
+  DEFAULT_THRESHOLD,
+  DEFAULT_PER_RUN_CAP,
+  DEFAULT_PER_DAY_CAP,
+} from '../../scripts/lib/prod-error-recurrence-detector.mjs';
+import { isCovered } from '../../scripts/lib/ci-recurrence-detector.mjs';
+
+const require = createRequire(import.meta.url);
+const { BREAK_CLASSES } = require('../../lib/coordinator/break-class-taxonomy.cjs');
+
+const alert = (over = {}) => ({
+  id: over.id || 'al-' + Math.round((over._n || 1) * 1000),
+  severity: over.severity || 'warning',
+  title: over.title || 'Alert title',
+  message: over.message || 'Alert message',
+  source_service: 'source_type' in over ? over.source_type : 'svc-a',
+  resolved_at: null,
+  created_at: over.created_at || '2026-06-19T00:00:00Z',
+  metadata: { break_class: 'break_class' in over ? over.break_class : 'schema-drift' },
+});
+
+describe('prod-error-recurrence-detector — recurrence detection (FR-1)', () => {
+  it('flags a (break_class, source) class only when occurrences meet the threshold', () => {
+    const alerts = [
+      alert({ id: 'a1' }), alert({ id: 'a2' }), alert({ id: 'a3' }), // 3x schema-drift::svc-a
+    ];
+    const out = detectRecurringClasses(alerts, { threshold: 3, legalClasses: BREAK_CLASSES });
+    expect(out).toHaveLength(1);
+    expect(out[0].classKey).toBe('schema-drift::svc-a');
+    expect(out[0].occurrenceTotal).toBe(3);
+    expect(out[0].breakClass).toBe('schema-drift');
+    expect(out[0].source).toBe('svc-a');
+  });
+
+  it('does not flag a class below the threshold', () => {
+    const alerts = [alert({ id: 'a1' }), alert({ id: 'a2' })]; // only 2x
+    expect(detectRecurringClasses(alerts, { threshold: 3, legalClasses: BREAK_CLASSES })).toHaveLength(0);
+  });
+
+  it('groups by the (break_class, source) tuple — same class, different source = separate classes', () => {
+    const alerts = [
+      alert({ id: 'a1', source_type: 'svc-a' }), alert({ id: 'a2', source_type: 'svc-a' }),
+      alert({ id: 'a3', source_type: 'svc-b' }), alert({ id: 'a4', source_type: 'svc-b' }),
+    ];
+    // threshold 2 -> two distinct classes
+    const out = detectRecurringClasses(alerts, { threshold: 2, legalClasses: BREAK_CLASSES });
+    expect(out.map((c) => c.classKey).sort()).toEqual(['schema-drift::svc-a', 'schema-drift::svc-b']);
+  });
+
+  it('ignores alerts outside the frozen break-class taxonomy', () => {
+    const alerts = [
+      alert({ id: 'a1', break_class: 'not-a-real-class' }),
+      alert({ id: 'a2', break_class: 'not-a-real-class' }),
+      alert({ id: 'a3', break_class: 'not-a-real-class' }),
+    ];
+    expect(detectRecurringClasses(alerts, { threshold: 3, legalClasses: BREAK_CLASSES })).toHaveLength(0);
+  });
+
+  it('ignores alerts with no break_class encoding', () => {
+    const noClass = alert({ id: 'a1' }); noClass.metadata = {};
+    expect(detectRecurringClasses([noClass, noClass, noClass], { threshold: 3, legalClasses: BREAK_CLASSES })).toHaveLength(0);
+  });
+
+  it('sorts deterministically: most-recurring class first', () => {
+    const alerts = [
+      alert({ id: 'a1', break_class: 'migration-fail', source_type: 'm' }),
+      alert({ id: 'a2', break_class: 'migration-fail', source_type: 'm' }),
+      alert({ id: 'a3', break_class: 'schema-drift', source_type: 's' }),
+      alert({ id: 'a4', break_class: 'schema-drift', source_type: 's' }),
+      alert({ id: 'a5', break_class: 'schema-drift', source_type: 's' }),
+    ];
+    const out = detectRecurringClasses(alerts, { threshold: 2, legalClasses: BREAK_CLASSES });
+    expect(out[0].classKey).toBe('schema-drift::s'); // 3 beats 2
+    expect(out[0].occurrenceTotal).toBe(3);
+  });
+
+  it('picks the oldest alert as the representative', () => {
+    const alerts = [
+      alert({ id: 'newer', created_at: '2026-06-19T05:00:00Z' }),
+      alert({ id: 'older', created_at: '2026-06-19T01:00:00Z' }),
+      alert({ id: 'mid', created_at: '2026-06-19T03:00:00Z' }),
+    ];
+    const out = detectRecurringClasses(alerts, { threshold: 3, legalClasses: BREAK_CLASSES });
+    expect(out[0].representativeId).toBe('older');
+  });
+});
+
+describe('prod-error-recurrence-detector — status-aware idempotency (FR-3)', () => {
+  const chronic = () => [alert({ id: 'a1' }), alert({ id: 'a2' }), alert({ id: 'a3' })];
+
+  it('excludes a class covered by an open, non-terminal corrective SD', () => {
+    const bridge = [{ id: 'b1', status: 'in_progress', strategic_directive_id: 'SD-X', resolution_sd_id: null, metadata: { break_class: 'schema-drift', alert_source: 'svc-a' } }];
+    const coveredKeys = coveredClassKeys(bridge, isCovered);
+    expect([...coveredKeys]).toContain('schema-drift::svc-a');
+    const out = detectRecurringClasses(chronic(), { threshold: 3, legalClasses: BREAK_CLASSES, coveredKeys });
+    expect(out).toHaveLength(0);
+  });
+
+  it('re-sources a class whose bridge link was stripped (terminal SD) — stripDeadLinks analog', () => {
+    // Caller stripped the dead link in place (terminal SD) => bridge row now has null links.
+    const strippedBridge = [{ id: 'b1', status: 'in_progress', strategic_directive_id: null, resolution_sd_id: null, metadata: { break_class: 'schema-drift', alert_source: 'svc-a' } }];
+    const coveredKeys = coveredClassKeys(strippedBridge, isCovered);
+    expect(coveredKeys.size).toBe(0); // not covered: link was stripped
+    const out = detectRecurringClasses(chronic(), { threshold: 3, legalClasses: BREAK_CLASSES, coveredKeys });
+    expect(out).toHaveLength(1); // treated as uncovered again
+  });
+
+  it('coveredClassKeys ignores bridge rows with no break_class', () => {
+    const bridge = [{ id: 'b1', status: 'new', strategic_directive_id: 'SD-X', resolution_sd_id: null, metadata: {} }];
+    expect(coveredClassKeys(bridge, isCovered).size).toBe(0);
+  });
+
+  it('handledClassKeys also skips a surfaced (status=new, unlinked) guardrail-blocked bridge row', () => {
+    // A guardrail-blocked class: bridge row exists, never linked, status stayed new.
+    const bridge = [{ id: 'b1', status: 'new', strategic_directive_id: null, resolution_sd_id: null, metadata: { break_class: 'RLS-regression', alert_source: 'svc-a' } }];
+    // coveredClassKeys (linked-only) would NOT count it -> would spam a duplicate each run.
+    expect(coveredClassKeys(bridge, isCovered).size).toBe(0);
+    // handledClassKeys treats it as already surfaced -> the class is skipped (no inbox spam).
+    const handled = handledClassKeys(bridge, isCovered);
+    expect([...handled]).toContain('RLS-regression::svc-a');
+    const alerts = [alert({ id: 'a1', break_class: 'RLS-regression' }), alert({ id: 'a2', break_class: 'RLS-regression' }), alert({ id: 'a3', break_class: 'RLS-regression' })];
+    expect(detectRecurringClasses(alerts, { threshold: 3, legalClasses: BREAK_CLASSES, coveredKeys: handled })).toHaveLength(0);
+  });
+
+  it('handledClassKeys keeps a dead-linked (status=in_progress, stripped) bridge row re-sourceable', () => {
+    // WAS linked, SD went terminal -> caller stripped the link; status stayed in_progress.
+    const bridge = [{ id: 'b1', status: 'in_progress', strategic_directive_id: null, resolution_sd_id: null, metadata: { break_class: 'schema-drift', alert_source: 'svc-a' } }];
+    expect(handledClassKeys(bridge, isCovered).size).toBe(0); // not handled -> re-sourceable
+  });
+
+  it('handledClassKeys counts a still-linked (non-terminal) bridge row as handled', () => {
+    const bridge = [{ id: 'b1', status: 'in_progress', strategic_directive_id: 'SD-X', resolution_sd_id: null, metadata: { break_class: 'schema-drift', alert_source: 'svc-a' } }];
+    expect([...handledClassKeys(bridge, isCovered)]).toContain('schema-drift::svc-a');
+  });
+});
+
+describe('prod-error-recurrence-detector — anti-spam caps (FR-4)', () => {
+  it('caps per-run', () => {
+    const cands = Array.from({ length: 5 }, (_, i) => ({ classKey: 'k' + i }));
+    expect(applyCaps(cands, { perRunCap: 2, sourcedToday: 0, perDayCap: 10 })).toHaveLength(2);
+  });
+  it('respects the remaining per-day budget', () => {
+    const cands = Array.from({ length: 5 }, (_, i) => ({ classKey: 'k' + i }));
+    expect(applyCaps(cands, { perRunCap: 3, sourcedToday: 9, perDayCap: 10 })).toHaveLength(1);
+  });
+  it('returns nothing when the per-day budget is exhausted', () => {
+    const cands = [{ classKey: 'k0' }];
+    expect(applyCaps(cands, { perRunCap: 3, sourcedToday: 10, perDayCap: 10 })).toHaveLength(0);
+  });
+});
+
+describe('prod-error-recurrence-detector — no-auto-fix / no-auto-resolve boundary (FR-2)', () => {
+  it('exposes ONLY pure read/classify functions — no resolve/fix/update capability', async () => {
+    const mod = await import('../../scripts/lib/prod-error-recurrence-detector.mjs');
+    const fnNames = Object.keys(mod).filter((k) => typeof mod[k] === 'function');
+    // every exported function name is a read/classify verb — none mutate, resolve, or fix.
+    const forbidden = /resolve|fix|update|delete|insert|write|merge|close/i;
+    for (const name of fnNames) expect(name).not.toMatch(forbidden);
+    // the canonical detect/cap/cover surface is present.
+    expect(fnNames.sort()).toEqual(
+      ['alertBreakClass', 'alertSource', 'applyCaps', 'classKey', 'coveredClassKeys', 'detectRecurringClasses', 'handledClassKeys'].sort()
+    );
+  });
+
+  it('detection is pure: it never mutates the input alerts', () => {
+    const alerts = [alert({ id: 'a1' }), alert({ id: 'a2' }), alert({ id: 'a3' })];
+    const snapshot = JSON.parse(JSON.stringify(alerts));
+    detectRecurringClasses(alerts, { threshold: 3, legalClasses: BREAK_CLASSES });
+    expect(alerts).toEqual(snapshot);
+  });
+
+  it('helpers read the canonical encoding (break_class in metadata, source_service column)', () => {
+    expect(classKey('schema-drift', 'svc-a')).toBe('schema-drift::svc-a');
+    expect(alertBreakClass(alert({ break_class: 'RLS-regression' }))).toBe('RLS-regression');
+    expect(alertSource(alert({ source_type: 'svc-z' }))).toBe('svc-z');
+  });
+
+  it('exposes sane defaults', () => {
+    expect(DEFAULT_THRESHOLD).toBe(3);
+    expect(DEFAULT_PER_RUN_CAP).toBe(3);
+    expect(DEFAULT_PER_DAY_CAP).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
The missing **last mile** of the production-breakage pipeline. The breakage-detector family writes recurring signals into `system_alerts` (each carrying `metadata.break_class`), but nothing turned a spike into actionable work. This adds a fail-soft, flag-gated (default OFF) cron loop that reads `system_alerts` over a window, groups by `(break_class, source)`, detects classes recurring above a threshold, and sources **ONE DRAFT corrective SD** per recurring uncovered class via the canonical `leo-create-sd.js --from-feedback`. It mirrors the proven `scripts/clockwork/ci-autotriage-loop.cjs` doctrine.

**CONST-002 boundary:** the loop NEVER edits code, merges, auto-fixes, or **resolves** an alert — diagnosis is deferred to the worker who picks up the DRAFT SD.

## What's new
- `scripts/lib/prod-error-recurrence-detector.mjs` (NEW, pure): group by `(break_class, source)`, threshold, frozen-taxonomy filter, `applyCaps`, and status-aware `coveredClassKeys`/`handledClassKeys`.
- `scripts/clockwork/prod-error-sweep-loop.cjs` (NEW): flag-gated (`PROD_ERROR_SWEEP_LOOP_ENABLE`, default OFF), DRY-RUN default, bridges each recurring class to a durable `production_error` feedback row then sources via `--from-feedback`, tags `metadata.sourced_by`. Alerts left UNRESOLVED.
- `lib/loops/loop-contract-registry.js`: declare `LOOP-PROD-ERROR-SWEEP-001` (data-only).
- `package.json`: `prod-error-sweep` entry (WIRE_CHECK reachability).
- `tests/unit/prod-error-recurrence-detector.test.js` (NEW): 20 tests.

## Honesty-over-coverage
Security/migration break classes (e.g. `RLS-regression` -> `GR-SECURITY-BASELINE`) hit SD-creation guardrails that need a human review the loop must NOT self-attest. Those classes get a `new` inbox bridge row for **human escalation** instead — never a falsely-attested SD. `handledClassKeys` prevents inbox spam (an open `new`/`triaged` row counts as surfaced) while keeping a dead-linked (terminal-SD) row re-sourceable (FR-3 re-source-on-cancel).

## Verification
- 20/20 unit tests (recurrence, status-aware idempotency, no-auto-fix/no-auto-resolve boundary).
- Live-smoke validated end-to-end (seed 3 alerts -> ONE DRAFT SD + linked bridge + alerts UNRESOLVED -> idempotent skip), then all smoke artifacts cleaned. Live smoke caught two real `feedback` NOT-NULL/CHECK constraints a fake-client test misses.
- Adversarial review verdict: **SHIP** (no critical/high).
- Handoffs: LEAD-TO-PLAN 94 / PLAN-TO-EXEC 98 / EXEC-TO-PLAN 93 / PLAN-TO-LEAD 96. TESTING+SECURITY @ EXEC, VALIDATION+REGRESSION @ PLAN_VERIFICATION (all PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
