### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-ROUTER-CORE-001): pure sourcing-engine router (5 lane rules)

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-SOURCING-ENGINE-ROUTER-CORE-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-SOURCING-ENGINE-ROUTER-CORE-001.json
@@ -1,0 +1,69 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Pure routeCandidate(classifiedItem, context) in lib/sourcing-engine/router.js",
+      "description": "Export a PURE, TOTAL function routeCandidate(classifiedItem, context) -> { lane, rung, disposition, escalation?, blocker?, enablers?, dedup_match_sd_key?, re_emit? }. No LLM (the classifier ran upstream), no DB IO, no Date.now()/Math.random(). Given a sparse or null item it never throws. The module also exports the frozen LANES vocabulary, CHAIRMAN_AUTHORITIES, and a jaccard() helper.",
+      "acceptance_criteria": [
+        "routeCandidate is importable from lib/sourcing-engine/router.js and is side-effect-free",
+        "Returns exactly one lane per call from the frozen LANES set",
+        "Handles null/empty item and empty context without throwing (totality)"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "requirement": "The 5 lane rules per the parent design",
+      "description": "Implement the five lanes with this precedence: (1) dedup — exact normalized title OR Jaccard>=threshold OR source_id is itself an existing sd_key -> dedup_match_sd_key, with a re_emit flag set true ONLY when the matched SD is infra-shipped but its outcome is not yet realized; (2) chairman-gated — authority in {grant,rls,credential,operational,vision} -> escalation {to:'chairman', reason}; (3) outcome-gated — needsOutcome -> target rung + enabler hints; (4) blocked-on — a write-surface or declared-dependency conflict with an in-flight SD -> blocker {sd_key, reason}; (5) belt-ready — the residual (novel, non-gated, conflict-free, fleet-buildable).",
+      "acceptance_criteria": [
+        "Each of the 5 lanes is produced for its triggering input",
+        "Precedence holds: dedup > chairman-gated > outcome-gated > blocked-on > belt-ready",
+        "The infra-shipped-but-outcome-open re-emit flag is true only when shipped AND not outcome-realized"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "requirement": "LANE is a field DISTINCT from disposition (no overload)",
+      "description": "The router passes disposition (BUILD|RESEARCH|REFERENCE|CANCEL|null) through unchanged and never re-derives or overloads it. The lane vocabulary shares no value with the disposition vocabulary, so a consumer can store lane and disposition as independent fields (this child does NOT read/write the lane column — that is child LEDGER-LANE-COLUMN).",
+      "acceptance_criteria": [
+        "disposition is returned unchanged across every lane",
+        "No LANES value collides with any disposition value",
+        "The router never mutates or recomputes disposition"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "requirement": "Unit tests covering each lane rule + the separation + the re-emit",
+      "description": "tests/unit/sourcing-engine-router.test.js covers each of the 5 lane rules, the precedence ordering, the lane/disposition separation (FR-3), the infra-shipped-but-outcome-open re-emit flag (both true and false branches), the jaccard helper edge cases, and totality on sparse/null input.",
+      "acceptance_criteria": [
+        "npx vitest run tests/unit/sourcing-engine-router.test.js passes",
+        "Every lane has at least one positive case and the dedup re-emit has both true and false cases",
+        "A totality case (null item) and the lane/disposition non-collision are asserted"
+      ]
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Every lane is reachable",
+      "steps": "Run npx vitest run tests/unit/sourcing-engine-router.test.js.",
+      "expected_result": "All 29 assertions pass; each of belt-ready, blocked-on, chairman-gated, outcome-gated, dedup is produced for its triggering input."
+    },
+    {
+      "id": "TS-2",
+      "scenario": "Lane never overloads disposition",
+      "steps": "Assert no value in LANES appears in the disposition vocabulary and that disposition is returned unchanged across lanes.",
+      "expected_result": "LANES and the disposition set are disjoint; disposition passes through verbatim."
+    },
+    {
+      "id": "TS-3",
+      "scenario": "Infra-shipped-but-outcome-open re-emits",
+      "steps": "Route a dedup-matching item whose matched SD is in shippedInfraKeys but not in outcomeRealizedKeys.",
+      "expected_result": "lane=dedup, dedup_match_sd_key set, re_emit=true; when the same key is also outcome-realized, re_emit=false."
+    }
+  ],
+  "acceptance_criteria": [
+    "A pure, total routeCandidate maps a classified candidate onto exactly one of five sourcing lanes",
+    "lane is a first-class field distinct from disposition and never overloads it",
+    "Unit tests cover all 5 lanes, precedence, the separation, and the re-emit flag"
+  ]
+}

--- a/lib/sourcing-engine/router.js
+++ b/lib/sourcing-engine/router.js
@@ -1,0 +1,179 @@
+/**
+ * Pure sourcing-engine router — SD-LEO-INFRA-SOURCING-ENGINE-ROUTER-CORE-001 (FR-1..FR-4).
+ *
+ * routeCandidate(classifiedItem, context) is a PURE, TOTAL decision function: no LLM (the
+ * classifier ran upstream), no DB IO, no Date.now()/Math.random(). It maps an already-classified
+ * candidate onto exactly ONE of five sourcing LANES, returning the lane plus the routing payload a
+ * downstream writer needs.
+ *
+ * LANE is a FIRST-CLASS field, DISTINCT from `disposition` (FR-3). `disposition` is the item's
+ * lifecycle verdict (BUILD | RESEARCH | REFERENCE | CANCEL — see lib/intake/backlog-disposition.mjs);
+ * `lane` is the sourcing route. The router passes `disposition` through unchanged and never re-derives
+ * or overloads it.
+ *
+ * This child does NOT read/write the `lane` COLUMN (that is child LEDGER-LANE-COLUMN) and does NOT
+ * wire into leo-create-sd (that is child REGISTER-FIRST). It is only the pure decision.
+ */
+
+/** The five sourcing lanes (frozen — the canonical vocabulary). */
+export const LANES = Object.freeze({
+  BELT_READY: 'belt-ready',         // fleet-buildable + conflict-free + non-gated + novel
+  BLOCKED_ON: 'blocked-on',         // dep / write-surface conflict with an in-flight SD
+  CHAIRMAN_GATED: 'chairman-gated', // needs chairman authority (grant/rls/credential/operational/vision)
+  OUTCOME_GATED: 'outcome-gated',   // needs an operational outcome before it is buildable
+  DEDUP: 'dedup',                   // already represented by an existing SD
+});
+
+/** Authority kinds that force the chairman-gated lane. */
+export const CHAIRMAN_AUTHORITIES = Object.freeze([
+  'grant', 'rls', 'credential', 'operational', 'vision',
+]);
+
+const DEFAULT_JACCARD_THRESHOLD = 0.8;
+
+/** Normalize a title for exact-match comparison: lowercase, trim, collapse internal whitespace. */
+function normTitle(t) {
+  return String(t == null ? '' : t).toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+/** Tokenize a title into a Set of lowercased word tokens (for Jaccard similarity). */
+function tokenize(t) {
+  const norm = normTitle(t);
+  if (!norm) return new Set();
+  return new Set(norm.split(/[^a-z0-9]+/).filter(Boolean));
+}
+
+/** Jaccard similarity between two token Sets: |A∩B| / |A∪B| (0 when both empty). */
+export function jaccard(a, b) {
+  const A = a instanceof Set ? a : tokenize(a);
+  const B = b instanceof Set ? b : tokenize(b);
+  if (A.size === 0 && B.size === 0) return 0;
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter++;
+  const union = A.size + B.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+function toSet(v) {
+  if (v instanceof Set) return v;
+  if (Array.isArray(v)) return new Set(v);
+  return new Set();
+}
+
+const SD_KEY_RE = /^SD-[A-Z0-9-]+$/;
+
+/**
+ * Find the existing SD this candidate duplicates, or null. Match wins on ANY of:
+ *   (1) source_id is itself an existing sd_key,
+ *   (2) exact normalized title equality,
+ *   (3) Jaccard(title) >= threshold.
+ * @returns {{ sd_key:string, reason:'source_id'|'exact_title'|'jaccard', score?:number }|null}
+ */
+function findDedupMatch(item, existing, threshold) {
+  const srcId = item && item.source_id;
+  // (1) source_id already an sd_key present in the existing set
+  if (typeof srcId === 'string' && SD_KEY_RE.test(srcId)) {
+    const hit = existing.find((e) => e && e.sd_key === srcId);
+    if (hit) return { sd_key: hit.sd_key, reason: 'source_id' };
+  }
+  const myNorm = normTitle(item && item.title);
+  const myTokens = tokenize(item && item.title);
+  let best = null;
+  for (const e of existing) {
+    if (!e || !e.sd_key) continue;
+    if (myNorm && normTitle(e.title) === myNorm) {
+      return { sd_key: e.sd_key, reason: 'exact_title' }; // exact beats fuzzy
+    }
+    const score = jaccard(myTokens, tokenize(e.title));
+    if (score >= threshold && (!best || score > best.score)) {
+      best = { sd_key: e.sd_key, reason: 'jaccard', score };
+    }
+  }
+  return best;
+}
+
+/** Does this candidate conflict with an in-flight SD (shared write-surface OR a declared dep)? */
+function findBlocker(item, inFlight) {
+  const mySurfaces = toSet(item && item.writeSurfaces);
+  const myDeps = toSet(item && item.dependsOn);
+  for (const f of inFlight) {
+    if (!f || !f.sd_key) continue;
+    if (myDeps.has(f.sd_key)) return { sd_key: f.sd_key, reason: 'dependency' };
+    const theirs = toSet(f.writeSurfaces);
+    for (const s of mySurfaces) {
+      if (theirs.has(s)) return { sd_key: f.sd_key, reason: 'write_surface', surface: s };
+    }
+  }
+  return null;
+}
+
+/**
+ * Route a classified candidate onto exactly one sourcing lane.
+ *
+ * @param {{
+ *   source_id?: string, title?: string,
+ *   disposition?: ('BUILD'|'RESEARCH'|'REFERENCE'|'CANCEL'|null),
+ *   rung?: (string|null),
+ *   authority?: ('grant'|'rls'|'credential'|'operational'|'vision'|null),
+ *   needsOutcome?: boolean, targetRung?: (string|null), enablers?: string[],
+ *   writeSurfaces?: string[], dependsOn?: string[]
+ * }} classifiedItem
+ * @param {{
+ *   existing?: Array<{sd_key:string, title?:string}>,
+ *   inFlight?: Array<{sd_key:string, writeSurfaces?:string[]}>,
+ *   jaccardThreshold?: number,
+ *   shippedInfraKeys?: (string[]|Set<string>),
+ *   outcomeRealizedKeys?: (string[]|Set<string>)
+ * }} [context]
+ * @returns {{ lane:string, rung:(string|null), disposition:(string|null),
+ *   escalation?:object, blocker?:object, enablers?:string[],
+ *   dedup_match_sd_key?:string, re_emit?:boolean }}
+ */
+export function routeCandidate(classifiedItem, context = {}) {
+  const item = classifiedItem || {};
+  const ctx = context || {};
+  const existing = Array.isArray(ctx.existing) ? ctx.existing : [];
+  const inFlight = Array.isArray(ctx.inFlight) ? ctx.inFlight : [];
+  const threshold =
+    typeof ctx.jaccardThreshold === 'number' ? ctx.jaccardThreshold : DEFAULT_JACCARD_THRESHOLD;
+
+  const disposition = item.disposition == null ? null : item.disposition;
+  const rung = item.rung == null ? null : item.rung;
+  const base = { rung, disposition };
+
+  // (1) DEDUP — have we already sourced this? Short-circuits, but carries the re-emit flag for the
+  // 'infra shipped, but the OUTCOME is not yet realized' case so a downstream writer can re-emit it
+  // as outcome work rather than silently suppressing it.
+  const dup = findDedupMatch(item, existing, threshold);
+  if (dup) {
+    const shipped = toSet(ctx.shippedInfraKeys);
+    const realized = toSet(ctx.outcomeRealizedKeys);
+    const re_emit = shipped.has(dup.sd_key) && !realized.has(dup.sd_key);
+    return { ...base, lane: LANES.DEDUP, dedup_match_sd_key: dup.sd_key, re_emit };
+  }
+
+  // (2) CHAIRMAN-GATED — needs an authority only the chairman can grant.
+  if (item.authority && CHAIRMAN_AUTHORITIES.includes(item.authority)) {
+    return { ...base, lane: LANES.CHAIRMAN_GATED, escalation: { to: 'chairman', reason: item.authority } };
+  }
+
+  // (3) OUTCOME-GATED — not buildable until an operational outcome exists; surface the target rung
+  // it unlocks plus any enabler hints so the consumer knows what must land first.
+  if (item.needsOutcome === true) {
+    return {
+      ...base,
+      lane: LANES.OUTCOME_GATED,
+      rung: item.targetRung == null ? rung : item.targetRung,
+      enablers: Array.isArray(item.enablers) ? item.enablers : [],
+    };
+  }
+
+  // (4) BLOCKED-ON — a dep or write-surface conflict with an in-flight SD.
+  const blocker = findBlocker(item, inFlight);
+  if (blocker) {
+    return { ...base, lane: LANES.BLOCKED_ON, blocker };
+  }
+
+  // (5) BELT-READY — the residual: novel (passed dedup), non-gated, conflict-free → fleet-buildable.
+  return { ...base, lane: LANES.BELT_READY };
+}

--- a/lib/sourcing-engine/router.js
+++ b/lib/sourcing-engine/router.js
@@ -43,16 +43,28 @@ function tokenize(t) {
   return new Set(norm.split(/[^a-z0-9]+/).filter(Boolean));
 }
 
+/** Intersection size of two token Sets. */
+function intersectionSize(A, B) {
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter++;
+  return inter;
+}
+
 /** Jaccard similarity between two token Sets: |A∩B| / |A∪B| (0 when both empty). */
 export function jaccard(a, b) {
   const A = a instanceof Set ? a : tokenize(a);
   const B = b instanceof Set ? b : tokenize(b);
   if (A.size === 0 && B.size === 0) return 0;
-  let inter = 0;
-  for (const x of A) if (B.has(x)) inter++;
+  const inter = intersectionSize(A, B);
   const union = A.size + B.size - inter;
   return union === 0 ? 0 : inter / union;
 }
+
+// A fuzzy (non-exact) dedup match requires at least this many SHARED tokens, so a single
+// coincidental token can never fuzzy-merge two otherwise-distinct candidates (a true single-token
+// duplicate is caught by the exact-title path first). Reorderings like "auth user"/"user auth"
+// share 2 tokens and still match.
+const MIN_FUZZY_TOKEN_OVERLAP = 2;
 
 function toSet(v) {
   if (v instanceof Set) return v;
@@ -84,8 +96,13 @@ function findDedupMatch(item, existing, threshold) {
     if (myNorm && normTitle(e.title) === myNorm) {
       return { sd_key: e.sd_key, reason: 'exact_title' }; // exact beats fuzzy
     }
-    const score = jaccard(myTokens, tokenize(e.title));
-    if (score >= threshold && (!best || score > best.score)) {
+    const eTokens = tokenize(e.title);
+    const score = jaccard(myTokens, eTokens);
+    if (
+      score >= threshold &&
+      intersectionSize(myTokens, eTokens) >= MIN_FUZZY_TOKEN_OVERLAP &&
+      (!best || score > best.score)
+    ) {
       best = { sd_key: e.sd_key, reason: 'jaccard', score };
     }
   }

--- a/tests/unit/sourcing-engine-router.test.js
+++ b/tests/unit/sourcing-engine-router.test.js
@@ -123,6 +123,31 @@ describe('sourcing-engine router — dedup', () => {
     expect(r.dedup_match_sd_key).toBe('SD-SIM-001');
   });
 
+  it('a single shared token never fuzzy-dedups two distinct one-word titles', () => {
+    const r = routeCandidate(
+      { title: 'sourcing' },
+      { existing: [{ sd_key: 'SD-ONEWORD-001', title: 'sourcing' }], jaccardThreshold: 0.5 }
+    );
+    // identical single-word titles ARE an exact match (caught by the exact path)...
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-ONEWORD-001');
+    // ...but a single COINCIDENTAL shared token below the 2-token floor must NOT fuzzy-merge:
+    const r2 = routeCandidate(
+      { title: 'sourcing alpha' },
+      { existing: [{ sd_key: 'SD-ONEWORD-002', title: 'sourcing beta gamma delta' }], jaccardThreshold: 0.1 }
+    );
+    expect(r2.lane).toBe(LANES.BELT_READY); // inter=1 < MIN_FUZZY_TOKEN_OVERLAP, no fuzzy dup
+  });
+
+  it('a two-token reordering still fuzzy-dedups (>=2 shared tokens)', () => {
+    const r = routeCandidate(
+      { title: 'auth user' },
+      { existing: [{ sd_key: 'SD-REORDER-001', title: 'user auth' }], jaccardThreshold: 0.8 }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-REORDER-001');
+  });
+
   it('below the Jaccard threshold is NOT a dup', () => {
     const r = routeCandidate(
       { title: 'completely different subject matter entirely' },
@@ -209,6 +234,9 @@ describe('sourcing-engine router — jaccard helper', () => {
   });
   it('identical token sets yield 1', () => {
     expect(jaccard('alpha beta', 'beta alpha')).toBe(1);
+  });
+  it('pins a known fractional value (2 of 3 tokens) = 2/3', () => {
+    expect(jaccard('a b c', 'a b')).toBeCloseTo(2 / 3, 10);
   });
 });
 

--- a/tests/unit/sourcing-engine-router.test.js
+++ b/tests/unit/sourcing-engine-router.test.js
@@ -1,0 +1,226 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-ROUTER-CORE-001 — unit tests for the pure sourcing router.
+ * Covers each of the 5 lane rules, the lane/disposition separation (FR-3), and the
+ * infra-shipped-but-outcome-open re-emit flag.
+ */
+import { describe, it, expect } from 'vitest';
+import { routeCandidate, jaccard, LANES, CHAIRMAN_AUTHORITIES } from '../../lib/sourcing-engine/router.js';
+
+describe('sourcing-engine router — lane vocabulary', () => {
+  it('exposes exactly the five frozen lanes', () => {
+    expect(Object.values(LANES).sort()).toEqual(
+      ['belt-ready', 'blocked-on', 'chairman-gated', 'dedup', 'outcome-gated']
+    );
+    expect(Object.isFrozen(LANES)).toBe(true);
+  });
+});
+
+describe('sourcing-engine router — belt-ready (the residual)', () => {
+  it('routes a novel, non-gated, conflict-free candidate to belt-ready', () => {
+    const r = routeCandidate(
+      { source_id: 'intake-1', title: 'Guard the foo resolver', disposition: 'BUILD', rung: 'V1' },
+      { existing: [], inFlight: [] }
+    );
+    expect(r.lane).toBe(LANES.BELT_READY);
+    expect(r.rung).toBe('V1');
+    expect(r.disposition).toBe('BUILD');
+  });
+
+  it('belt-ready carries no blocker/escalation payload', () => {
+    const r = routeCandidate({ title: 'Net new thing' }, {});
+    expect(r.lane).toBe(LANES.BELT_READY);
+    expect(r.blocker).toBeUndefined();
+    expect(r.escalation).toBeUndefined();
+  });
+});
+
+describe('sourcing-engine router — chairman-gated', () => {
+  it.each(CHAIRMAN_AUTHORITIES)('routes authority=%s to chairman-gated with escalation', (authority) => {
+    const r = routeCandidate({ title: 'Touch RLS', authority }, {});
+    expect(r.lane).toBe(LANES.CHAIRMAN_GATED);
+    expect(r.escalation).toEqual({ to: 'chairman', reason: authority });
+  });
+
+  it('an unknown authority value does NOT gate (falls through to belt-ready)', () => {
+    const r = routeCandidate({ title: 'Harmless', authority: 'cosmetic' }, {});
+    expect(r.lane).toBe(LANES.BELT_READY);
+  });
+});
+
+describe('sourcing-engine router — outcome-gated', () => {
+  it('routes needsOutcome with the target rung and enabler hints', () => {
+    const r = routeCandidate(
+      { title: 'Autonomous campaign exec', rung: 'V1', needsOutcome: true, targetRung: 'V2', enablers: ['publisher live'] },
+      {}
+    );
+    expect(r.lane).toBe(LANES.OUTCOME_GATED);
+    expect(r.rung).toBe('V2'); // target rung overrides the item rung
+    expect(r.enablers).toEqual(['publisher live']);
+  });
+
+  it('defaults enablers to [] and keeps item rung when targetRung absent', () => {
+    const r = routeCandidate({ title: 'X', rung: 'V1', needsOutcome: true }, {});
+    expect(r.lane).toBe(LANES.OUTCOME_GATED);
+    expect(r.rung).toBe('V1');
+    expect(r.enablers).toEqual([]);
+  });
+});
+
+describe('sourcing-engine router — blocked-on', () => {
+  it('routes a write-surface conflict with an in-flight SD to blocked-on', () => {
+    const r = routeCandidate(
+      { title: 'Edit the gauge', writeSurfaces: ['lib/vision/vdr-registry.js'] },
+      { inFlight: [{ sd_key: 'SD-IN-FLIGHT-001', writeSurfaces: ['lib/vision/vdr-registry.js'] }] }
+    );
+    expect(r.lane).toBe(LANES.BLOCKED_ON);
+    expect(r.blocker).toEqual({ sd_key: 'SD-IN-FLIGHT-001', reason: 'write_surface', surface: 'lib/vision/vdr-registry.js' });
+  });
+
+  it('routes a declared dependency on an in-flight SD to blocked-on', () => {
+    const r = routeCandidate(
+      { title: 'Child', dependsOn: ['SD-PARENT-001'] },
+      { inFlight: [{ sd_key: 'SD-PARENT-001' }] }
+    );
+    expect(r.lane).toBe(LANES.BLOCKED_ON);
+    expect(r.blocker).toEqual({ sd_key: 'SD-PARENT-001', reason: 'dependency' });
+  });
+
+  it('no conflict with the in-flight set → not blocked', () => {
+    const r = routeCandidate(
+      { title: 'Independent', writeSurfaces: ['lib/a.js'] },
+      { inFlight: [{ sd_key: 'SD-OTHER-001', writeSurfaces: ['lib/b.js'] }] }
+    );
+    expect(r.lane).toBe(LANES.BELT_READY);
+  });
+});
+
+describe('sourcing-engine router — dedup', () => {
+  it('matches when source_id is itself an existing sd_key', () => {
+    const r = routeCandidate(
+      { source_id: 'SD-EXISTING-001', title: 'whatever' },
+      { existing: [{ sd_key: 'SD-EXISTING-001', title: 'unrelated title' }] }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-EXISTING-001');
+    expect(r.re_emit).toBe(false);
+  });
+
+  it('matches on exact (normalized) title', () => {
+    const r = routeCandidate(
+      { title: '  Fix   The Belt  ' },
+      { existing: [{ sd_key: 'SD-DUP-001', title: 'fix the belt' }] }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-DUP-001');
+  });
+
+  it('matches on Jaccard >= threshold', () => {
+    const r = routeCandidate(
+      { title: 'guard the sourcing engine router core' },
+      { existing: [{ sd_key: 'SD-SIM-001', title: 'guard the sourcing engine router' }], jaccardThreshold: 0.8 }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-SIM-001');
+  });
+
+  it('below the Jaccard threshold is NOT a dup', () => {
+    const r = routeCandidate(
+      { title: 'completely different subject matter entirely' },
+      { existing: [{ sd_key: 'SD-SIM-001', title: 'guard the sourcing engine router' }], jaccardThreshold: 0.8 }
+    );
+    expect(r.lane).toBe(LANES.BELT_READY);
+  });
+
+  it('infra-shipped but outcome-NOT-realized sets re_emit=true', () => {
+    const r = routeCandidate(
+      { title: 'Autonomous campaign execution' },
+      {
+        existing: [{ sd_key: 'SD-INFRA-001', title: 'autonomous campaign execution' }],
+        shippedInfraKeys: ['SD-INFRA-001'],
+        outcomeRealizedKeys: [],
+      }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-INFRA-001');
+    expect(r.re_emit).toBe(true);
+  });
+
+  it('infra-shipped AND outcome-realized does NOT re-emit', () => {
+    const r = routeCandidate(
+      { title: 'Autonomous campaign execution' },
+      {
+        existing: [{ sd_key: 'SD-INFRA-001', title: 'autonomous campaign execution' }],
+        shippedInfraKeys: ['SD-INFRA-001'],
+        outcomeRealizedKeys: ['SD-INFRA-001'],
+      }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.re_emit).toBe(false);
+  });
+
+  it('dedup wins over a chairman authority (already tracked short-circuits)', () => {
+    const r = routeCandidate(
+      { title: 'touch rls', authority: 'rls' },
+      { existing: [{ sd_key: 'SD-DUP-002', title: 'touch rls' }] }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+  });
+});
+
+describe('sourcing-engine router — lane is DISTINCT from disposition (FR-3)', () => {
+  it('passes disposition through unchanged across every lane', () => {
+    for (const disposition of ['BUILD', 'RESEARCH', 'REFERENCE', 'CANCEL', null]) {
+      const beltReady = routeCandidate({ title: `novel ${disposition}`, disposition }, {});
+      expect(beltReady.disposition).toBe(disposition);
+      expect(beltReady.lane).toBe(LANES.BELT_READY);
+      const gated = routeCandidate({ title: 'x', disposition, authority: 'vision' }, {});
+      expect(gated.disposition).toBe(disposition);
+      expect(gated.lane).toBe(LANES.CHAIRMAN_GATED);
+    }
+  });
+
+  it('never returns a lane value that collides with a disposition value', () => {
+    const dispositions = new Set(['BUILD', 'RESEARCH', 'REFERENCE', 'CANCEL']);
+    for (const lane of Object.values(LANES)) expect(dispositions.has(lane)).toBe(false);
+  });
+});
+
+describe('sourcing-engine router — precedence order', () => {
+  it('chairman-gated beats outcome-gated and blocked-on', () => {
+    const r = routeCandidate(
+      { title: 'x', authority: 'grant', needsOutcome: true, writeSurfaces: ['lib/a.js'] },
+      { inFlight: [{ sd_key: 'SD-A-001', writeSurfaces: ['lib/a.js'] }] }
+    );
+    expect(r.lane).toBe(LANES.CHAIRMAN_GATED);
+  });
+
+  it('outcome-gated beats blocked-on', () => {
+    const r = routeCandidate(
+      { title: 'x', needsOutcome: true, writeSurfaces: ['lib/a.js'] },
+      { inFlight: [{ sd_key: 'SD-A-001', writeSurfaces: ['lib/a.js'] }] }
+    );
+    expect(r.lane).toBe(LANES.OUTCOME_GATED);
+  });
+});
+
+describe('sourcing-engine router — jaccard helper', () => {
+  it('two empty titles yield 0 (no false dup on empty)', () => {
+    expect(jaccard('', '')).toBe(0);
+  });
+  it('identical token sets yield 1', () => {
+    expect(jaccard('alpha beta', 'beta alpha')).toBe(1);
+  });
+});
+
+describe('sourcing-engine router — totality (no throw on sparse input)', () => {
+  it('handles an empty item and empty context', () => {
+    const r = routeCandidate({}, {});
+    expect(r.lane).toBe(LANES.BELT_READY);
+    expect(r.rung).toBeNull();
+    expect(r.disposition).toBeNull();
+  });
+  it('handles a null item', () => {
+    const r = routeCandidate(null);
+    expect(r.lane).toBe(LANES.BELT_READY);
+  });
+});


### PR DESCRIPTION
## What

Adds `lib/sourcing-engine/router.js` — a pure, total `routeCandidate(classifiedItem, context)` that maps an already-classified candidate onto exactly one of five sourcing lanes: **belt-ready · blocked-on · chairman-gated · outcome-gated · dedup**. No LLM (the classifier ran upstream), no DB IO, no `Date.now`/`Math.random`.

## Design

- **LANE is a first-class field DISTINCT from `disposition`** (BUILD/RESEARCH/REFERENCE/CANCEL) — the router passes disposition through unchanged and never overloads it. The two vocabularies are disjoint.
- **Precedence**: dedup → chairman-gated → outcome-gated → blocked-on → belt-ready.
- **Dedup** matches on exact normalized title, Jaccard ≥ threshold (with a ≥2-shared-token floor so a single coincidental token never fuzzy-merges distinct candidates), or `source_id` already an sd_key. Carries the **infra-shipped-but-outcome-open re_emit flag** so a downstream writer can re-emit outcome work instead of suppressing it.
- Scope-bounded: this child holds **only the pure decision** — the lane column (LEDGER-LANE-COLUMN) and `leo-create-sd` wiring (REGISTER-FIRST) are sibling SDs.

## Tests

`tests/unit/sourcing-engine-router.test.js` — 32 cases: each lane, precedence, lane/disposition separation, the re_emit true/false branches, the fuzzy-dedup token floor, jaccard boundaries, and totality on null/empty input.

Adversarial review: no Critical/High/Medium; the one LOW (short-title fuzzy floor) is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)