### PR TITLE
fix(SD-LEO-INFRA-SOURCING-ENGINE-LEDGER-LANE-COLUMN-001): wire-check-exempt the lane schema-foundation module

### DIFF
--- a/lib/sourcing-engine/lane.js
+++ b/lib/sourcing-engine/lane.js
@@ -15,6 +15,13 @@
  * Build it with blockedLane(blocker); validate any value with isValidLane().
  */
 
+// @wire-check-exempt: schema-foundation module landed before its consumer. This canonical lane
+// vocabulary is imported by the sourcing-engine router (child 1, SD-LEO-INFRA-SOURCING-ENGINE-ROUTER-CORE-001,
+// in flight) and the downstream register-first / dedup-autostamp / populator children once they merge.
+// Per the engine design the schema foundation (child 2) lands first so siblings import ONE source of
+// truth rather than each duplicating the lane set. Reachable from prod once the router merges; pinned
+// today by tests/unit/sourcing-engine/lane.test.js.
+
 /** Prefix for the parametric blocked lane. The suffix (the blocker id/name) must be non-empty. */
 export const BLOCKED_LANE_PREFIX = 'blocked-on-';
 


### PR DESCRIPTION
WIRE_CHECK_GATE flagged lib/sourcing-engine/lane.js as unreachable — its consumer (the child-1 sourcing-engine router) is still in flight. Adds a @wire-check-exempt annotation documenting it as an intentional schema-foundation module the siblings import once merged (pinned today by its tests). One-line comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)