### PR TITLE
feat(SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001): multi-pool worktree reaping

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001.json
@@ -1,0 +1,69 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Multi-repo reaping across every registered pool",
+      "description": "Add an --all-pools mode to scripts/worktree-reaper.mjs that reaps orphaned worktrees in BOTH the EHG_Engineer pool AND the ehg pool (and any other registered application pool), using the SAME orphan/liveness criteria per pool. Implemented by resolving the pools from the applications registry (lib/worktree-reaper/pools.js resolveRegisteredPools — current repo + every registered local_path that exists with a .git, deduped) and fanning out one --repo child reaper per pool. The decision logic is already repo-agnostic, so each pool inherits the full single-repo reaper unchanged.",
+      "acceptance_criteria": [
+        "--all-pools resolves the current repo plus every existing-git registered application pool, deduped",
+        "Each resolved pool is reaped via a --repo child (the ehg pool, previously never scanned, is now scanned)",
+        "Missing or non-git registered paths are excluded; the orchestrator returns the worst child exit"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "requirement": "Per-pool cap awareness with a loud near/at-cap warning",
+      "description": "computePoolCapStatus(used, cap, threshold) returns utilization + a warn flag (used/cap >= threshold) + atCap (used >= cap). The orchestrator computes each pool's used count via listActiveWorktrees(pool.root) against MAX_WORKTREE_COUNT and emits a loud 'POOL NEAR/AT CAP' warning for any pool at/above the threshold, then prints per-pool used/cap regardless.",
+      "acceptance_criteria": [
+        "computePoolCapStatus.warn is true at/above the threshold and false below",
+        "atCap is true when used >= cap; the helper is total on degenerate input (cap<=0 falls back, fails loud)",
+        "A loud per-pool warning line is emitted when a pool is at/above the cap threshold"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "requirement": "Same safety as the single-repo reaper",
+      "description": "Multi-repo reaping never reaps a worktree owned by a live heartbeating session. This is preserved by construction: --all-pools spawns the existing single-repo reaper per pool via --repo, so every per-pool run keeps active-claim protection (v_active_sessions + claiming_session_id), preserve-before-delete, the Supabase-unavailable refusal, and dry-run-by-default. No change to the reaping core.",
+      "acceptance_criteria": [
+        "A live-owned worktree is never reclaimed even with a stale terminal row (classifyStage0 returns active_sd_protected)",
+        "Each pool runs the unchanged single-repo safety (active-claim, preserve-before-delete, dry-run default)",
+        "The orchestrator passes through the operator flags (execute/stage0/stage2/yes/days/threshold) to each pool"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "requirement": "Tests for multi-repo reaping",
+      "description": "tests/unit/worktree-reaper-pools.test.js covers resolveRegisteredPools (include/exclude/dedup), computePoolCapStatus (warn/atCap/degenerate), buildPassthroughFlags (flag passthrough, no --all-pools/--repo, non-default days/threshold), and the FR-4 scenario over an ehg-pool listing: an orphan is reaped, a live-owned worktree is not, and draining the orphans drops the pool below cap.",
+      "acceptance_criteria": [
+        "npx vitest run tests/unit/worktree-reaper-pools.test.js passes",
+        "An orphaned ehg-pool worktree is selected for reclaim; a live-owned one is not",
+        "Post-reclaim pool utilization drops below the cap threshold"
+      ]
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Pool resolution + cap helpers",
+      "steps": "Run npx vitest run tests/unit/worktree-reaper-pools.test.js.",
+      "expected_result": "13 assertions pass covering pool include/exclude/dedup, cap warn/atCap, flag passthrough, and the ehg-pool reaping decision."
+    },
+    {
+      "id": "TS-2",
+      "scenario": "Live multi-pool fan-out",
+      "steps": "From the main repo root run node scripts/worktree-reaper.mjs --all-pools --no-orphan-sweep.",
+      "expected_result": "Fans out a --repo child per registered pool (incl ehg), prints per-pool used/cap, each child exits 0 in dry-run, worst exit reported; the ehg pool is scanned."
+    },
+    {
+      "id": "TS-3",
+      "scenario": "Live worktree is protected across pools",
+      "steps": "Drive classifyStage0 with an ehg-pool worktree whose SD is in activeSdSet.",
+      "expected_result": "reclaim=false with reason active_sd_protected — a live-owned worktree is never reaped regardless of pool."
+    }
+  ],
+  "acceptance_criteria": [
+    "The reaper reaps orphaned worktrees in every registered pool (EHG_Engineer, ehg, and any other registered app), not just the current repo",
+    "Per-pool cap awareness emits a loud warning when a pool is at/above the cap threshold",
+    "Live-owned worktrees are never reaped; each pool keeps the full single-repo safety"
+  ]
+}

--- a/lib/worktree-reaper/pools.js
+++ b/lib/worktree-reaper/pools.js
@@ -1,0 +1,96 @@
+/**
+ * Multi-repo worktree pool resolution — SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001 (FR-1/FR-2).
+ *
+ * The worktree reaper historically scanned ONE repo (the cwd / --repo target). The fleet now runs
+ * worktrees in more than one registered application pool (EHG_Engineer AND the ehg frontend), so an
+ * orphaned ehg worktree was never reaped — the ehg pool could fill to its cap unattended. These pure
+ * helpers resolve which pools to reap (from the `applications` registry) and compute per-pool cap
+ * status, so the reaper can iterate every registered pool with the SAME per-pool safety.
+ *
+ * Pure + dependency-injected (no fs/DB/git of their own) so they unit-test without a live repo.
+ */
+
+import path from 'node:path';
+
+/** Normalize a filesystem path for cross-pool dedup: forward slashes, drop trailing slash, lowercase
+ *  on Windows (case-insensitive FS). */
+export function normalizePoolPath(p, platform = process.platform) {
+  if (!p) return '';
+  let s = String(p).replace(/\\/g, '/').replace(/\/+$/, '');
+  if (platform === 'win32') s = s.toLowerCase();
+  return s;
+}
+
+/**
+ * Resolve the set of worktree pools to reap from the application registry.
+ *
+ * A pool is included when its `local_path` exists on disk AND looks like a git repo root (has a .git
+ * entry — dir or file). The current repo is always included (and flagged isCurrent) even if it is not
+ * in the registry, so --all-pools never silently skips the repo it was launched from. Deduped by
+ * normalized path (so EHG_Engineer registered twice, or registered === current, yields one entry).
+ *
+ * @param {{
+ *   applications?: Array<{name?:string, local_path?:string}>,
+ *   currentRepoRoot: string,
+ *   currentRepoName?: string,
+ *   existsSync: (p:string)=>boolean,
+ *   hasGit: (root:string)=>boolean,
+ *   platform?: string
+ * }} deps
+ * @returns {Array<{name:string, root:string, isCurrent:boolean}>}
+ */
+export function resolveRegisteredPools(deps) {
+  const {
+    applications = [],
+    currentRepoRoot,
+    currentRepoName = 'current',
+    existsSync,
+    hasGit,
+    platform = process.platform,
+  } = deps || {};
+
+  const byKey = new Map();
+  const add = (name, root, isCurrent) => {
+    if (!root) return;
+    const abs = path.resolve(root);
+    const key = normalizePoolPath(abs, platform);
+    if (!key || byKey.has(key)) return;
+    // The current repo is trusted (the reaper is running in it); registry pools must verify on disk.
+    if (!isCurrent) {
+      if (!existsSync(abs) || !hasGit(abs)) return;
+    }
+    byKey.set(key, { name: name || 'unknown', root: abs, isCurrent: Boolean(isCurrent) });
+  };
+
+  // Current repo first so it owns the dedup key if the registry also lists it.
+  add(currentRepoName, currentRepoRoot, true);
+  for (const app of applications) {
+    if (app && app.local_path) add(app.name, app.local_path, false);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Per-pool capacity status. `warn` is true when utilization is at or above the threshold — the loud
+ * "pool approaching cap" signal (FR-2). Total function; a non-positive cap falls back to 1 to avoid
+ * div-by-zero (yielding warn=true, which fails loud rather than silent).
+ *
+ * @param {number} used  active worktree count in the pool
+ * @param {number} cap   the pool cap (MAX_WORKTREE_COUNT)
+ * @param {number} threshold  utilization fraction in (0,1] at/above which to warn
+ * @returns {{ used:number, cap:number, utilization:number, percent:number, warn:boolean, atCap:boolean }}
+ */
+export function computePoolCapStatus(used, cap, threshold = 0.8) {
+  const safeUsed = Number.isFinite(used) && used >= 0 ? used : 0;
+  const safeCap = Number.isFinite(cap) && cap > 0 ? cap : 1;
+  const safeThreshold = Number.isFinite(threshold) && threshold > 0 && threshold <= 1 ? threshold : 0.8;
+  const utilization = safeUsed / safeCap;
+  return {
+    used: safeUsed,
+    cap: safeCap,
+    utilization,
+    percent: Math.round(utilization * 100),
+    warn: utilization >= safeThreshold,
+    atCap: safeUsed >= safeCap,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -437,6 +437,8 @@
     "worktree:reap": "node scripts/worktree-reaper.mjs",
     "worktree:reap:execute": "node scripts/worktree-reaper.mjs --execute",
     "worktree:reap:full": "node scripts/worktree-reaper.mjs --execute --stage2 --yes",
+    "worktree:reap:all-pools": "node scripts/worktree-reaper.mjs --all-pools",
+    "worktree:reap:all-pools:execute": "node scripts/worktree-reaper.mjs --all-pools --execute",
     "worktree:orphan-sweep": "node scripts/worktree-reaper.mjs --orphan-sweep",
     "worktree:orphan-sweep:execute": "node scripts/worktree-reaper.mjs --orphan-sweep --execute",
     "worktree:cleanup-pending": "node scripts/cleanup-pending-sweep.mjs",

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -71,6 +71,9 @@ import {
   isPatchEquivalentToMain,
   isIdle,
 } from '../lib/worktree-reaper/detectors.js';
+// SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001: resolve every registered worktree pool (EHG_Engineer +
+// ehg + any other registered app) and compute per-pool cap status, so --all-pools reaps each pool.
+import { resolveRegisteredPools, computePoolCapStatus } from '../lib/worktree-reaper/pools.js';
 
 const SCHEMA_VERSION = '1.0';
 const DEFAULT_IDLE_DAYS = 7;
@@ -110,6 +113,9 @@ function parseArgs(argv) {
     // otherwise folded into the normal flow (so the hourly tick includes it).
     orphanSweep: args.includes('--orphan-sweep'),
     noOrphanSweep: args.includes('--no-orphan-sweep'),
+    // SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001: reap EVERY registered pool (spawns a per-pool
+    // --repo child so each pool keeps the full single-repo safety), not just the current repo.
+    allPools: args.includes('--all-pools'),
     help: args.includes('--help') || args.includes('-h'),
     days: DEFAULT_IDLE_DAYS,
     threshold: DEFAULT_POOL_THRESHOLD,
@@ -155,6 +161,9 @@ Options:
   --preserve-root <p>   Override preserve destination root (default: scratch/preserved-from-*)
   --repo <path>         Run against a different repo (chdir before scanning); useful when
                         the target repo's quota is full but you can't easily cd into it
+  --all-pools           Reap EVERY registered worktree pool (EHG_Engineer + ehg + any other
+                        registered app) by spawning a per-pool --repo child; loudly warns when
+                        any pool is at/above the cap threshold. Passes through the other flags.
   --phantom-only        Legacy mode: only report phantoms (missing dirs / prunable)
   --orphan-sweep        Standalone: ONLY reclaim ORPHANED .worktrees/ dirs (on disk but
                         NOT in 'git worktree list'). Dry-run unless --execute. Junction-safe.
@@ -980,6 +989,76 @@ async function runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execu
   return sweep;
 }
 
+// ── Multi-pool orchestration (SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001) ──
+
+/** Rebuild the per-pool child's flag list from opts (everything EXCEPT --all-pools and --repo, which
+ *  the orchestrator sets itself). Keeps every pool's run identical to a manual single-repo invocation. */
+export function buildPassthroughFlags(opts) {
+  const f = [];
+  if (opts.execute) f.push('--execute');
+  if (opts.stage0) f.push('--stage0');
+  if (opts.stage2) f.push('--stage2');
+  if (opts.yes) f.push('--yes');
+  if (opts.verbose) f.push('--verbose');
+  if (opts.phantomOnly) f.push('--phantom-only');
+  if (opts.orphanSweep) f.push('--orphan-sweep');
+  if (opts.noOrphanSweep) f.push('--no-orphan-sweep');
+  if (opts.days && opts.days !== DEFAULT_IDLE_DAYS) f.push('--days', String(opts.days));
+  if (opts.threshold && opts.threshold !== DEFAULT_POOL_THRESHOLD) f.push('--threshold', String(opts.threshold));
+  if (opts.preserveRoot) f.push('--preserve-root', opts.preserveRoot);
+  return f;
+}
+
+/**
+ * Reap EVERY registered worktree pool. Spawns a per-pool `--repo <root>` child so each pool keeps the
+ * full single-repo safety (active-claim protection, preserve-before-delete, dry-run default) — the
+ * decision logic is already repo-agnostic, so only the iteration is new here. Emits a loud warning for
+ * any pool at/above the cap threshold (FR-2) and returns the worst child exit code.
+ */
+async function runAllPools(opts, { repoRoot, repoName, supabase }) {
+  let applications = [];
+  if (supabase) {
+    try {
+      const { data } = await supabase.from('applications').select('name, local_path');
+      applications = data || [];
+    } catch { /* fail-soft: still reap the current pool below */ }
+  }
+  const pools = resolveRegisteredPools({
+    applications,
+    currentRepoRoot: repoRoot,
+    currentRepoName: repoName,
+    existsSync: (p) => fs.existsSync(p),
+    hasGit: (root) => fs.existsSync(path.join(root, '.git')),
+  });
+
+  console.log(`\n🌐 MULTI-POOL REAPER — ${pools.length} registered pool(s), ${opts.execute ? 'EXECUTE' : 'DRY-RUN'}`);
+  const passthrough = buildPassthroughFlags(opts);
+  const thisFile = fileURLToPath(import.meta.url);
+  let worst = 0;
+  for (const pool of pools) {
+    let used = 0;
+    try { used = listActiveWorktrees(pool.root).length; } catch { used = 0; }
+    const cap = computePoolCapStatus(used, MAX_WORKTREE_COUNT, opts.threshold);
+    const tag = `${pool.name} (${pool.root})`;
+    if (cap.warn) {
+      console.warn(
+        `\n⚠️  POOL ${cap.atCap ? 'AT' : 'NEAR'} CAP: ${tag} — ${cap.used}/${cap.cap} (${cap.percent}%) ` +
+        `>= ${Math.round((opts.threshold || DEFAULT_POOL_THRESHOLD) * 100)}% threshold`,
+      );
+    }
+    console.log(`\n──▶ Pool: ${tag} — ${cap.used}/${cap.cap} worktrees (${cap.percent}%)`);
+    const res = spawnSync('node', [thisFile, '--repo', pool.root, ...passthrough], {
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    const code = res.status == null ? 9 : res.status;
+    if (code > worst) worst = code;
+    console.log(`◀── Pool ${pool.name} reaper exited ${code}`);
+  }
+  console.log(`\n🌐 Multi-pool reaper done — ${pools.length} pool(s), worst exit ${worst}`);
+  return worst;
+}
+
 export async function main(argv = process.argv) {
   const opts = parseArgs(argv);
   if (opts.help) {
@@ -1013,6 +1092,14 @@ export async function main(argv = process.argv) {
 
   const worktreesDir = path.join(repoRoot, '.worktrees');
   const supabase = getSupabaseClient();
+
+  // SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001: --all-pools fans out one --repo child per registered
+  // pool (the current repo included), so a single invocation reaps EHG_Engineer AND ehg AND any other
+  // registered app. Each child keeps the full single-repo safety; this returns the worst child exit.
+  if (opts.allPools) {
+    return await runAllPools(opts, { repoRoot, repoName: path.basename(repoRoot), supabase });
+  }
+
   const allWorktrees = listActiveWorktrees(repoRoot);
 
   // Phantom-only mode: preserves legacy cleanup-phantom-worktrees.js behavior.

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -1015,7 +1015,15 @@ export function buildPassthroughFlags(opts) {
  * decision logic is already repo-agnostic, so only the iteration is new here. Emits a loud warning for
  * any pool at/above the cap threshold (FR-2) and returns the worst child exit code.
  */
-async function runAllPools(opts, { repoRoot, repoName, supabase }) {
+export async function runAllPools(opts, { repoRoot, repoName, supabase }, deps = {}) {
+  // Dependency injection (defaults wire the real runtime; tests inject fakes so the orchestration
+  // glue — pool fan-out, per-pool child argv, worst-exit selection — is unit-testable without git/DB).
+  const existsSync = deps.existsSync || ((p) => fs.existsSync(p));
+  const hasGit = deps.hasGit || ((root) => fs.existsSync(path.join(root, '.git')));
+  const usedCounter = deps.listUsed || ((root) => { try { return listActiveWorktrees(root).length; } catch { return 0; } });
+  const spawn = deps.spawn || ((cmd, argv) => spawnSync(cmd, argv, { stdio: 'inherit', windowsHide: true }));
+  const thisFile = deps.selfPath || fileURLToPath(import.meta.url);
+
   let applications = [];
   if (supabase) {
     try {
@@ -1027,17 +1035,15 @@ async function runAllPools(opts, { repoRoot, repoName, supabase }) {
     applications,
     currentRepoRoot: repoRoot,
     currentRepoName: repoName,
-    existsSync: (p) => fs.existsSync(p),
-    hasGit: (root) => fs.existsSync(path.join(root, '.git')),
+    existsSync,
+    hasGit,
   });
 
   console.log(`\n🌐 MULTI-POOL REAPER — ${pools.length} registered pool(s), ${opts.execute ? 'EXECUTE' : 'DRY-RUN'}`);
   const passthrough = buildPassthroughFlags(opts);
-  const thisFile = fileURLToPath(import.meta.url);
   let worst = 0;
   for (const pool of pools) {
-    let used = 0;
-    try { used = listActiveWorktrees(pool.root).length; } catch { used = 0; }
+    const used = usedCounter(pool.root);
     const cap = computePoolCapStatus(used, MAX_WORKTREE_COUNT, opts.threshold);
     const tag = `${pool.name} (${pool.root})`;
     if (cap.warn) {
@@ -1047,11 +1053,8 @@ async function runAllPools(opts, { repoRoot, repoName, supabase }) {
       );
     }
     console.log(`\n──▶ Pool: ${tag} — ${cap.used}/${cap.cap} worktrees (${cap.percent}%)`);
-    const res = spawnSync('node', [thisFile, '--repo', pool.root, ...passthrough], {
-      stdio: 'inherit',
-      windowsHide: true,
-    });
-    const code = res.status == null ? 9 : res.status;
+    const res = spawn('node', [thisFile, '--repo', pool.root, ...passthrough]);
+    const code = res && res.status != null ? res.status : 9;
     if (code > worst) worst = code;
     console.log(`◀── Pool ${pool.name} reaper exited ${code}`);
   }

--- a/tests/unit/worktree-reaper-pools.test.js
+++ b/tests/unit/worktree-reaper-pools.test.js
@@ -15,6 +15,7 @@ import {
   classifyStage0,
   selectStage0Reclaim,
   computePoolUtilization,
+  runAllPools,
 } from '../../scripts/worktree-reaper.mjs';
 
 const EHG_ENG = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
@@ -127,6 +128,51 @@ describe('pools — buildPassthroughFlags', () => {
     expect(buildPassthroughFlags({ days: 7, threshold: 0.8 })).not.toContain('--days');
     const f = buildPassthroughFlags({ days: 14, threshold: 0.5 });
     expect(f).toEqual(expect.arrayContaining(['--days', '14', '--threshold', '0.5']));
+  });
+});
+
+describe('runAllPools — orchestration fan-out (injected spawner)', () => {
+  const fakeSupabase = (apps) => ({ from: () => ({ select: async () => ({ data: apps }) }) });
+
+  it('spawns one --repo child per resolved pool, never leaks --all-pools, returns the worst exit', async () => {
+    const calls = [];
+    // ehg child fails (exit 4); keyed by normalized path so backslash-resolved roots still match.
+    const statuses = { [normalizePoolPath(EHG_ENG)]: 0, [normalizePoolPath(EHG)]: 4 };
+    const worst = await runAllPools(
+      { execute: true, threshold: 0.8 },
+      { repoRoot: EHG_ENG, repoName: 'EHG_Engineer', supabase: fakeSupabase([{ name: 'EHG', local_path: EHG }]) },
+      {
+        existsSync: () => true,
+        hasGit: () => true,
+        listUsed: () => 0,
+        selfPath: '/abs/worktree-reaper.mjs',
+        spawn: (cmd, argv) => {
+          calls.push({ cmd, argv });
+          const root = normalizePoolPath(argv[2]);
+          return { status: statuses[root] ?? 0 };
+        },
+      }
+    );
+    // one child per pool (current EHG_Engineer + registered EHG)
+    expect(calls).toHaveLength(2);
+    for (const c of calls) {
+      expect(c.cmd).toBe('node');
+      expect(c.argv[0]).toBe('/abs/worktree-reaper.mjs');
+      expect(c.argv[1]).toBe('--repo');
+      expect(c.argv).toContain('--execute');
+      expect(c.argv).not.toContain('--all-pools'); // no recursion / fork bomb
+      expect(c.argv.filter((a) => a === '--repo')).toHaveLength(1); // exactly the orchestrator's --repo
+    }
+    expect(worst).toBe(4); // worst child exit propagates
+  });
+
+  it('a spawn that returns null status counts as exit 9 (failure), not 0', async () => {
+    const worst = await runAllPools(
+      { threshold: 0.8 },
+      { repoRoot: EHG_ENG, repoName: 'EHG_Engineer', supabase: fakeSupabase([]) },
+      { existsSync: () => true, hasGit: () => true, listUsed: () => 0, selfPath: '/x.mjs', spawn: () => ({ status: null }) }
+    );
+    expect(worst).toBe(9);
   });
 });
 

--- a/tests/unit/worktree-reaper-pools.test.js
+++ b/tests/unit/worktree-reaper-pools.test.js
@@ -1,0 +1,172 @@
+/**
+ * SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001 — unit tests for multi-repo worktree reaping.
+ * Covers the pure pool resolver + per-pool cap status, the child flag passthrough, and (FR-4) the
+ * end-to-end reaping decision applied to an ehg-pool listing: an orphan is reaped, a live-owned
+ * worktree is not, and the pool drains below cap.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRegisteredPools,
+  computePoolCapStatus,
+  normalizePoolPath,
+} from '../../lib/worktree-reaper/pools.js';
+import {
+  buildPassthroughFlags,
+  classifyStage0,
+  selectStage0Reclaim,
+  computePoolUtilization,
+} from '../../scripts/worktree-reaper.mjs';
+
+const EHG_ENG = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
+const EHG = 'C:/Users/rickf/Projects/_EHG/ehg';
+
+describe('pools — resolveRegisteredPools', () => {
+  const allExist = () => true;
+  const allGit = () => true;
+
+  it('includes the current repo AND every registered app that exists with a .git', () => {
+    const pools = resolveRegisteredPools({
+      applications: [
+        { name: 'EHG_Engineer', local_path: EHG_ENG },
+        { name: 'EHG', local_path: EHG },
+      ],
+      currentRepoRoot: EHG_ENG,
+      currentRepoName: 'EHG_Engineer',
+      existsSync: allExist,
+      hasGit: allGit,
+      platform: 'win32',
+    });
+    const roots = pools.map((p) => normalizePoolPath(p.root, 'win32'));
+    expect(roots).toContain(normalizePoolPath(EHG_ENG, 'win32'));
+    expect(roots).toContain(normalizePoolPath(EHG, 'win32'));
+    // current repo registered === current -> deduped to ONE entry, flagged current
+    expect(pools.filter((p) => p.isCurrent)).toHaveLength(1);
+    expect(pools).toHaveLength(2);
+  });
+
+  it('always includes the current repo even when it is not in the registry', () => {
+    const pools = resolveRegisteredPools({
+      applications: [{ name: 'EHG', local_path: EHG }],
+      currentRepoRoot: EHG_ENG,
+      currentRepoName: 'EHG_Engineer',
+      existsSync: allExist,
+      hasGit: allGit,
+      platform: 'win32',
+    });
+    expect(pools.some((p) => p.isCurrent && normalizePoolPath(p.root, 'win32') === normalizePoolPath(EHG_ENG, 'win32'))).toBe(true);
+    expect(pools).toHaveLength(2);
+  });
+
+  it('excludes a registered path that does not exist or is not a git repo', () => {
+    const pools = resolveRegisteredPools({
+      applications: [
+        { name: 'Gone', local_path: 'C:/nope/missing' },
+        { name: 'NotARepo', local_path: 'C:/some/plain/dir' },
+        { name: 'EHG', local_path: EHG },
+      ],
+      currentRepoRoot: EHG_ENG,
+      currentRepoName: 'EHG_Engineer',
+      // predicates are slash-insensitive because resolveRegisteredPools path.resolve()s first
+      existsSync: (p) => !/[/\\]nope[/\\]missing$/.test(p), // missing path fails exists
+      hasGit: (root) => !/[/\\]some[/\\]plain[/\\]dir$/.test(root), // plain dir has no .git
+      platform: 'win32',
+    });
+    const names = pools.map((p) => p.name).sort();
+    expect(names).toEqual(['EHG', 'EHG_Engineer']);
+  });
+
+  it('dedups duplicate registry rows for the same path', () => {
+    const pools = resolveRegisteredPools({
+      applications: [
+        { name: 'EHG', local_path: EHG },
+        { name: 'EHG-dup', local_path: EHG },
+      ],
+      currentRepoRoot: EHG_ENG,
+      currentRepoName: 'EHG_Engineer',
+      existsSync: () => true,
+      hasGit: () => true,
+      platform: 'win32',
+    });
+    expect(pools.filter((p) => normalizePoolPath(p.root, 'win32') === normalizePoolPath(EHG, 'win32'))).toHaveLength(1);
+  });
+});
+
+describe('pools — computePoolCapStatus', () => {
+  it('warns at/above the threshold and not below', () => {
+    expect(computePoolCapStatus(16, 20, 0.8).warn).toBe(true);  // 80% == threshold
+    expect(computePoolCapStatus(17, 20, 0.8).warn).toBe(true);  // above
+    expect(computePoolCapStatus(15, 20, 0.8).warn).toBe(false); // 75% below
+  });
+  it('flags atCap when used >= cap', () => {
+    expect(computePoolCapStatus(20, 20, 0.8).atCap).toBe(true);
+    expect(computePoolCapStatus(21, 20, 0.8).atCap).toBe(true);
+    expect(computePoolCapStatus(19, 20, 0.8).atCap).toBe(false);
+  });
+  it('is total on degenerate input (non-positive cap falls back, fails loud)', () => {
+    const s = computePoolCapStatus(3, 0, 0.8);
+    expect(s.cap).toBe(1);
+    expect(s.warn).toBe(true); // 3/1 >= 0.8
+    expect(Number.isFinite(s.utilization)).toBe(true);
+  });
+  it('reports percent', () => {
+    expect(computePoolCapStatus(10, 20, 0.8).percent).toBe(50);
+  });
+});
+
+describe('pools — buildPassthroughFlags', () => {
+  it('passes execute/stage flags but NOT --all-pools or --repo', () => {
+    const f = buildPassthroughFlags({ execute: true, stage0: true, stage2: true, yes: true, allPools: true, repo: 'X' });
+    expect(f).toContain('--execute');
+    expect(f).toContain('--stage0');
+    expect(f).toContain('--stage2');
+    expect(f).toContain('--yes');
+    expect(f).not.toContain('--all-pools');
+    expect(f).not.toContain('--repo');
+  });
+  it('only emits --days/--threshold when non-default', () => {
+    expect(buildPassthroughFlags({ days: 7, threshold: 0.8 })).not.toContain('--days');
+    const f = buildPassthroughFlags({ days: 14, threshold: 0.5 });
+    expect(f).toEqual(expect.arrayContaining(['--days', '14', '--threshold', '0.5']));
+  });
+});
+
+describe('FR-4 — multi-repo reaping decision over an ehg-pool listing', () => {
+  // Simulate the ehg pool at the cap with two worktrees: one orphan (terminal SD, no claim) and one
+  // live-owned (active claim). The reaping decision is repo-agnostic — these are the same pure units
+  // the reaper runs per pool — so proving it on an ehg-pool listing proves multi-repo behavior.
+  const ehgWorktrees = [
+    { path: `${EHG}/.worktrees/SD-EHG-ORPHAN-001`, branch: 'feat/SD-EHG-ORPHAN-001' },
+    { path: `${EHG}/.worktrees/SD-EHG-LIVE-001`, branch: 'feat/SD-EHG-LIVE-001' },
+  ];
+
+  it('reaps the orphan and keeps the live-owned worktree', () => {
+    const statusResolver = (key) => (key === 'SD-EHG-ORPHAN-001' ? 'terminal' : 'active');
+    const reclaim = selectStage0Reclaim(ehgWorktrees, {
+      activeSdSet: new Set(['SD-EHG-LIVE-001']),
+      terminalSdSet: new Set(['SD-EHG-ORPHAN-001']),
+      statusResolver,
+    });
+    const reclaimedKeys = reclaim.map((r) => r.sd_key);
+    expect(reclaimedKeys).toContain('SD-EHG-ORPHAN-001');
+    expect(reclaimedKeys).not.toContain('SD-EHG-LIVE-001');
+  });
+
+  it('a live (active) worktree is never reclaimed even if a stale terminal row exists', () => {
+    const v = classifyStage0(
+      { path: `${EHG}/.worktrees/SD-EHG-LIVE-001`, branch: 'feat/SD-EHG-LIVE-001' },
+      { activeSdSet: new Set(['SD-EHG-LIVE-001']), terminalSdSet: new Set(['SD-EHG-LIVE-001']) }
+    );
+    expect(v.reclaim).toBe(false);
+    expect(v.reason).toBe('active_sd_protected');
+  });
+
+  it('draining the orphan drops the ehg pool below the cap threshold', () => {
+    const cap = 20;
+    const before = 20; // at cap
+    expect(computePoolCapStatus(before, cap, 0.8).warn).toBe(true);
+    // reclaim 5 terminal orphans → 15/20 = 75% < 80%
+    const after = before - 5;
+    expect(computePoolUtilization(after, cap).utilization).toBeLessThan(0.8);
+    expect(computePoolCapStatus(after, cap, 0.8).warn).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The worktree reaper scanned only ONE repo (cwd / `--repo`), so an orphaned **ehg** worktree was never reaped and the ehg pool could fill to its cap unattended. Adds `--all-pools`: reap every registered application pool (EHG_Engineer + ehg + any other registered app).

## How (safety-preserving by construction)

`--all-pools` resolves the pools from the `applications` registry (current repo + each registered `local_path` that exists with a `.git`, deduped) and **spawns one `--repo` child reaper per pool**. The reaping decision core is already repo-agnostic, so each pool inherits the **full single-repo safety unchanged** — active-claim protection, preserve-before-delete, Supabase-unavailable refusal, dry-run default. The orchestrator itself removes nothing; it only reads worktree lists and spawns children. No recursion: `buildPassthroughFlags` strips `--all-pools` and `--repo` from the child flags.

- NEW `lib/worktree-reaper/pools.js` — pure `resolveRegisteredPools` + `computePoolCapStatus` + `normalizePoolPath`.
- Per-pool cap awareness (FR-2): loud `POOL NEAR/AT CAP` warning at/above the threshold (advisory only — never gates removal).
- `runAllPools` accepts injected deps for testability.
- `package.json`: `worktree:reap:all-pools` + `:execute`.

## Tests

`tests/unit/worktree-reaper-pools.test.js` — 15 cases: pool include/exclude/dedup, cap warn/atCap, flag passthrough (no leak), the runAllPools fan-out (per-pool argv, worst-exit, null-status=9), and the FR-4 ehg-pool scenario (orphan reaped, live-owned kept, drains below cap). Full reaper suite: 108/108, zero regression. Adversarial review (safety-critical): no Critical/High/Medium; verified live across 6 pools incl ehg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)