### PR TITLE
feat(SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001): move 4 revenue/operating capabilities V1->V2 (chairman-ratified vision re-cut)

### DIFF
--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -60,22 +60,18 @@ export function parseCapabilityGap(markdown) {
  * code presence). 'capability' must equal the bold label parsed from the table.
  */
 export const VDR_REGISTRY = [
-  { capability: 'Take a real dollar', layer: 'venture',
-    probe: { type: 'kr_status', code: 'KR-2026-07-04' } }, // ≥1 venture can accept real payment
-  { capability: 'See distance-to-quit', layer: 'application',
-    probe: { type: 'kr_status', code: 'KR-2026-07-05' } }, // the income gauge rendered
+  // SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 (chairman-ratified): the 4 revenue/operating capabilities
+  // 'Take a real dollar', 'See distance-to-quit', 'Run a self-operating venture' and 'Compound
+  // venture-level learning' moved from the active V1 rung to the inactive V2 rung — V1 measures the
+  // FOUNDATION, V2 measures EARNING. Their probes are intentionally absent from the active set (a probe
+  // for an inactive rung = a staleProbe that withholds the whole gauge); they return only when V2 is
+  // activated. Kept in lockstep with vision_ladder_criteria (the active rung now lists 21 capabilities).
   { capability: 'See distance-to-broke', layer: 'application',
     probe: { type: 'code_grep', repo: 'ehg', path: 'src', pattern: 'distance[-_ ]?to[-_ ]?broke', builtWhen: 'present' } },
   { capability: 'Venture-performance read', layer: 'application',
     probe: { type: 'code_grep', repo: 'ehg', path: 'src/components/chairman-v3', pattern: 'PerformanceGauge|performance-gauge|valueAdd|competitiveness', builtWhen: 'present' } },
-  { capability: 'Run a self-operating venture', layer: 'venture',
-    // FIX (review): a stood-up 19-agent org produces sustained traffic; a single stray/seed message
-    // must not credit 'built'. min=20 ⇒ built (org operating); 1..19 ⇒ partial (beginning); 0 ⇒ unbuilt. Revisable.
-    probe: { type: 'db_count', table: 'agent_messages', min: 20, builtWhen: 'gte' } },
-  { capability: 'Compound venture-level learning', layer: 'process',
-    // FIX (review): a compounding venture-learning engine has multiple occurrences; one row ⇒ partial.
-    // min=10 ⇒ built (engine firing); 1..9 ⇒ partial; 0 ⇒ unbuilt. Revisable.
-    probe: { type: 'db_count', table: 'pattern_occurrences', min: 10, builtWhen: 'gte' } },
+  // ('Run a self-operating venture' + 'Compound venture-level learning' moved to inactive V2 — see the
+  // V1->V2-RECUT note at the top of VDR_REGISTRY; their probes return when V2 activates.)
   { capability: 'Solo-operator survivability', layer: 'infrastructure',
     probe: { type: 'kr_status', code: 'KR-2026-07-02' } }, // ≥90% breakage caught before customers
   { capability: 'Calibrate the gates', layer: 'process',
@@ -199,13 +195,11 @@ export const VDR_REGISTRY = [
  * an operational_pct over the operational set, so neither number can be gamed.
  *
  * The classification is STATIC code reviewed at PLAN — this Set is the single reviewable artifact.
- * OPERATIONAL = the 10 KR/chairman/venture/competitive-signal capabilities; everything else buildable.
+ * OPERATIONAL = the KR/chairman/venture/competitive-signal capabilities in the ACTIVE rung; everything
+ * else buildable. (SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 moved 4 revenue/operating capabilities to
+ * the inactive V2 rung, so the active operational set is now 6 — the 4 moved are V2-deferred.)
  */
 export const OPERATIONAL_NATURE = new Set([
-  'Take a real dollar',                          // KR-2026-07-04 — a live venture must accept real payment
-  'See distance-to-quit',                        // KR-2026-07-05 — needs the live income signal
-  'Run a self-operating venture',                // db_count agent_messages — needs a running venture
-  'Compound venture-level learning',             // db_count pattern_occurrences — needs live ventures producing learning
   'Solo-operator survivability',                 // KR-2026-07-02 — live breakage-caught rate
   'A queryable, structured north star',          // row_predicate chairman_ratified — chairman-timed
   'Governance cascade enforced',                 // KR-GOV-3.1 — live governance cascade operation
@@ -214,7 +208,8 @@ export const OPERATIONAL_NATURE = new Set([
   'Competitive vigilance process established',   // db_count OBSERVED — a running vigilance process must observe
 ]);
 
-// Attach the deterministic nature to each registry entry (FR-1: on every one of the 25 entries).
+// Attach the deterministic nature to each registry entry (one per active-rung capability; 21 after the
+// V1->V2 re-cut moved the 4 revenue/operating capabilities to the inactive V2 rung).
 for (const e of VDR_REGISTRY) {
   e.nature = OPERATIONAL_NATURE.has(e.capability) ? 'operational' : 'buildable';
 }

--- a/tests/unit/vision/north-star.test.js
+++ b/tests/unit/vision/north-star.test.js
@@ -94,12 +94,14 @@ describe('ord-11 VDR probe repoint + no double-count (FR-3 / US-003)', () => {
     expect(ord11.probe.table).toBe('north_star');
     expect(ord11.probe.filter).toEqual({ status: 'chairman_ratified' });
   });
-  it('ord-2 still references KR-2026-07-05 (it legitimately belongs there)', () => {
-    expect(ord2.probe).toEqual({ type: 'kr_status', code: 'KR-2026-07-05' });
+  it('See distance-to-quit (the former KR-2026-07-05 owner) is V2-deferred — absent from the active registry', () => {
+    // SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 moved 'See distance-to-quit' to the inactive V2 rung.
+    expect(ord2).toBeUndefined();
   });
-  it('no two capabilities share KR-2026-07-05 (double-count removed)', () => {
+  it('no capability double-counts KR-2026-07-05 (ord-11 repointed; the other owner is now V2-deferred)', () => {
     const sharers = VDR_REGISTRY.filter((c) => c.probe?.code === 'KR-2026-07-05');
-    expect(sharers).toHaveLength(1);
+    expect(sharers.length).toBeLessThanOrEqual(1); // the no-double-count invariant still holds
+    expect(sharers).toHaveLength(0);               // after the recut, KR-2026-07-05 has no active probe
   });
   it('the VDR coherence invariant still holds after the repoint (real assertion, not just no-throw)', () => {
     // assertRegistryCoherence() never throws — it returns a verdict. Assert the verdict is ok,

--- a/tests/unit/vision/v2-ratification-coherence.test.js
+++ b/tests/unit/vision/v2-ratification-coherence.test.js
@@ -4,9 +4,10 @@
  * Proves the V2 ratification is coherence-safe:
  *  (hermetic) the V2 capability is NOT in VDR_REGISTRY (FR-2 deferred the probe), and the seed
  *             logic builds the correct row;
- *  (live)     the V2 rung stays inactive with the single ratified row, the active V1 rung keeps its
- *             25-criteria denominator, and assertRegistryCoherence is ok over the active rung — so
- *             the inactive V2 row is invisible to the live V1 gauge.
+ *  (live)     the V2 rung stays inactive with its ratified rows, the active V1 rung's denominator equals
+ *             the registry probe count (21 after SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 moved the 4
+ *             revenue/operating capabilities to V2), and assertRegistryCoherence is ok over the active
+ *             rung — so the inactive V2 rows are invisible to the live V1 gauge.
  *
  * The live block runs against the engineer DB (where the seed was applied); it reads only — no writes.
  */
@@ -48,7 +49,7 @@ describe.skipIf(!HAS_DB)('FR-3 (live): V2 recorded inactive; V1 gauge unaffected
   });
   afterAll(async () => { if (client) await client.end(); });
 
-  it('the V2 rung is inactive and carries the single ratified criterion', async () => {
+  it('the V2 rung is inactive and carries its ratified + recut-moved criteria (incl. the original ratified cap)', async () => {
     const r = await client.query(
       `SELECT r.is_active, count(c.id)::int AS n,
               bool_or(c.capability = $1) AS has_cap
@@ -60,11 +61,14 @@ describe.skipIf(!HAS_DB)('FR-3 (live): V2 recorded inactive; V1 gauge unaffected
     );
     expect(r.rows).toHaveLength(1);
     expect(r.rows[0].is_active).toBe(false);
-    expect(r.rows[0].n).toBe(1);
+    // SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 moved 4 revenue/operating criteria into V2, so the
+    // inactive rung now carries 5 (the original ratified cap + the 4 moved). It stays inactive, so it is
+    // still invisible to the live V1 gauge.
+    expect(r.rows[0].n).toBe(5);
     expect(r.rows[0].has_cap).toBe(true);
   });
 
-  it('the active V1 rung keeps its 25-criteria denominator and assertRegistryCoherence is ok', async () => {
+  it('the active V1 rung denominator equals the registry probe count (21 post-recut) and assertRegistryCoherence is ok', async () => {
     const r = await client.query(
       `SELECT c.capability
        FROM vision_ladder_rungs r

--- a/tests/unit/vision/vdr-buildable-vs-operational.test.js
+++ b/tests/unit/vision/vdr-buildable-vs-operational.test.js
@@ -32,31 +32,41 @@ function stubSupabase({ countByTable = {}, krRows = {} } = {}) {
 const round = (subset) => (subset.length === 0 ? null : Math.round((100 * subset.reduce((s, c) => s + c.score, 0)) / subset.length));
 
 describe('FR-1 taxonomy completeness', () => {
-  it('every one of the 25 registry entries has a nature in {buildable, operational}', () => {
-    expect(VDR_REGISTRY).toHaveLength(25);
+  it('every one of the 21 active registry entries has a nature in {buildable, operational}', () => {
+    expect(VDR_REGISTRY).toHaveLength(21);
     for (const e of VDR_REGISTRY) expect(['buildable', 'operational']).toContain(e.nature);
   });
-  it('OPERATIONAL_NATURE has exactly 10 members and every one names a real capability (no drift)', () => {
-    expect(OPERATIONAL_NATURE.size).toBe(10);
+  it('OPERATIONAL_NATURE has exactly 6 members and every one names a real capability (no drift)', () => {
+    expect(OPERATIONAL_NATURE.size).toBe(6);
     const caps = new Set(VDR_REGISTRY.map((e) => e.capability));
     for (const c of OPERATIONAL_NATURE) expect(caps.has(c)).toBe(true);
   });
-  it('15 buildable + 10 operational, partitioned by OPERATIONAL_NATURE', () => {
+  it('15 buildable + 6 operational, partitioned by OPERATIONAL_NATURE', () => {
     const buildable = VDR_REGISTRY.filter((e) => e.nature === 'buildable');
     const operational = VDR_REGISTRY.filter((e) => e.nature === 'operational');
     expect(buildable).toHaveLength(15);
-    expect(operational).toHaveLength(10);
+    expect(operational).toHaveLength(6);
     for (const e of operational) expect(OPERATIONAL_NATURE.has(e.capability)).toBe(true);
     for (const e of buildable) expect(OPERATIONAL_NATURE.has(e.capability)).toBe(false);
   });
-  it('the venture/income KR proofs are operational; the code-shipped capabilities are buildable', () => {
+  it('the venture/governance KR proofs are operational; the code-shipped capabilities are buildable', () => {
     const natureOf = (cap) => VDR_REGISTRY.find((e) => e.capability === cap).nature;
-    expect(natureOf('Take a real dollar')).toBe('operational');
-    expect(natureOf('Run a self-operating venture')).toBe('operational');
+    expect(natureOf('Solo-operator survivability')).toBe('operational');
     expect(natureOf('All 7 governance guardrails')).toBe('operational');
     expect(natureOf('The cockpit')).toBe('buildable');
     expect(natureOf('Decision Filter Engine')).toBe('buildable');
     expect(natureOf('Capability Registry')).toBe('buildable');
+  });
+  // SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 (FR-5): the 4 revenue/operating capabilities moved to the
+  // inactive V2 rung; their probes must NOT be in the active VDR_REGISTRY (a probe for an inactive rung is
+  // a staleProbe that withholds the whole gauge). This regression fails if any is re-added before V2 activates.
+  it('the 4 V2-deferred capabilities have NO probe in the active registry while V2 is inactive', () => {
+    const v2Deferred = ['Take a real dollar', 'See distance-to-quit', 'Run a self-operating venture', 'Compound venture-level learning'];
+    const caps = new Set(VDR_REGISTRY.map((e) => e.capability));
+    for (const c of v2Deferred) {
+      expect(caps.has(c), `${c} must not be probed while V2 is inactive`).toBe(false);
+      expect(OPERATIONAL_NATURE.has(c)).toBe(false);
+    }
   });
 });
 

--- a/tests/unit/vision/vdr-db-source.test.js
+++ b/tests/unit/vision/vdr-db-source.test.js
@@ -90,12 +90,12 @@ describe('computeBuildGauge visionSource=true (FR-4) — DB denominator, unchang
     expect(g.available).toBe(true);
     expect(g.coherence.ok).toBe(true); // DB labels match VDR_REGISTRY → no drift
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
-    // unknown_count = 5 original code_grep + 5 governance + 4 automation/intelligence (ordinals 17-20) = 14,
-    // all 'unknown' (no seam / KR-GOV rows in this stub) → excluded. The +3 consolidation probes are unbuilt
-    // at count 0 → they enter the denominator (8 → 11).
+    // unknown_count = 5 original code_grep + 5 governance + 4 automation/intelligence = 14, all 'unknown'
+    // (no seam / KR-GOV rows in this stub) → excluded. After the V1->V2 re-cut the 4 revenue/operating
+    // probes leave the denominator (11 → 7); the +3 consolidation probes (unbuilt at 0) remain.
     expect(g.unknown_count).toBe(14);
-    expect(g.denominator).toBe(11); // 8 + 3 consolidation probes (unbuilt at count 0)
-    expect(g.overall_pct).toBe(18); // (1+0.5+0.5+0×8)/11 = 2.0/11 = 18%; identical to the markdown-source path
+    expect(g.denominator).toBe(7); // 4 DB-backed remaining + 3 consolidation probes (unbuilt at count 0)
+    expect(g.overall_pct).toBe(7); // 0.5/7 = 7%; identical to the markdown-source path
     expect(g.measured_at_note).toMatch(/DB vision source/);
   });
 

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -78,11 +78,10 @@ describe('assertRegistryCoherence (FR-1 fail-loud denominator↔probe lockstep)'
 
 describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', () => {
   it('computes overall % + per-layer with HONEST banding, EXCLUDING unknowns from the denominator', async () => {
-    // 8 DB-backed probeable; 5 code_grep → unknown (no grep seam). With the post-review semantics:
-    //   built(1):  Take-a-dollar (KR04 achieved)
-    //   partial(.5): self-operating (agent_messages=2 < min20), survivability (KR02 45/90)
-    //   unbuilt(0): distance-to-quit (KR05 0/1), venture-learning (pattern_occurrences=0), north-star (KR05 0/1),
-    //              Capability Registry (sd_capabilities=0 < min50), Expertise on-demand (specialist_registry=0 < min10)
+    // After the V1->V2 re-cut (SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001) the 4 revenue/operating caps
+    // (Take-a-dollar, distance-to-quit, self-operating, venture-learning) are V2-deferred — NOT probed.
+    // Remaining DB-backed in this stub: survivability (KR02 45/90 → partial 0.5), north-star (KR05 0/1 → 0),
+    //   Capability Registry (0 < min50 → 0), Expertise on-demand (0 < min10 → 0), + 3 consolidation probes (0).
     const io = {
       supabase: stubSupabase({
         countByTable: { agent_messages: 2, pattern_occurrences: 0, key_results: 1 },
@@ -98,16 +97,16 @@ describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', ()
     expect(g.coherence.ok).toBe(true);
     expect(g.total_capabilities).toBe(VDR_REGISTRY.length);
     // unknown_count = 5 original code_grep + 5 governance (V1-GOV-PROBES) + 4 automation/intelligence
-    // (V1-AUTOMATION-PROBES, ordinals 17-20) = 14, all 'unknown' (no seam / KR-GOV rows in this stub) →
-    // EXCLUDED. The +3 consolidation probes (V1-CONSOLIDATION-PROBES) are unbuilt at count 0, so they
-    // ENTER the denominator (8 → 11).
+    // (V1-AUTOMATION-PROBES) = 14, all 'unknown' (no seam / KR-GOV rows in this stub) → EXCLUDED. The 4
+    // moved revenue/operating probes leave the denominator (11 → 7); the +3 consolidation probes (unbuilt
+    // at count 0) still ENTER it.
     expect(g.unknown_count).toBe(14);
-    expect(g.denominator).toBe(11); // 8 + 3 consolidation probes (unbuilt at count 0)
-    // numerator unchanged (1 + 0.5 + 0.5 + 0×8) = 2.0; 2.0/11 = 18%
-    expect(g.overall_pct).toBe(18);
+    expect(g.denominator).toBe(7); // 4 DB-backed remaining (survivability + north-star + Cap Registry + Expertise) + 3 consolidation
+    // numerator 0.5 (survivability only); 0.5/7 = 7%
+    expect(g.overall_pct).toBe(7);
     // infrastructure scored = survivability(0.5) + Capability Registry(0) + Expertise on-demand(0) = 0.5/3 = 17%
-    // application/process gain consolidation probes that are all 0 → those layer %s stay 0 (numerator 0).
-    expect(g.per_layer).toMatchObject({ venture: 75, infrastructure: 17, application: 0, process: 0 });
+    // venture layer now has 0 probes (both moved to V2) → venture %=null; application/process stay 0.
+    expect(g.per_layer).toMatchObject({ infrastructure: 17, application: 0, process: 0 });
     for (const c of g.components) expect(STATUS_SCORE).toHaveProperty(c.status);
   });
 


### PR DESCRIPTION
**Chairman-ratified** vision re-cut. The 4 revenue/operating capabilities (*Take a real dollar*, *See distance-to-quit*, *Run a self-operating venture*, *Compound venture-level learning*) can only progress once a venture EARNS, so they belong on the inactive **V2** rung, not the active **V1**. Leaving them in V1 made V1% conflate *foundation-built* with *income-realized* (it could never approach 100% by building).

**Lockstep (DB + code):**
- **DB (applied live):** the 4 `vision_ladder_criteria` rows re-pointed to the inactive V2 rung (V1 25→21, V2 1→5).
- **CODE (this PR):** the 4 probes removed from the active `VDR_REGISTRY` (25→21) and `OPERATIONAL_NATURE` (10→6) so `assertRegistryCoherence` byte-matches the new 21-criterion active rung. **No V2 probe added** — a probe for an inactive rung is a staleProbe that withholds the whole gauge; the 4 return only when V2 activates.

Result: V1% = *is the foundation built* (rises as the 4 zeros leave the denominator); V2% = *are we earning* (0% until a venture operates). Coherence holds (live DB 21 == registry 21).

**Tests:** 96/96 vision green — taxonomy recut to 21/6, the stub gauge math recomputed (denominator 11→7, overall 18→7), 3 sibling test files updated (the adversarial reviewer caught them: `vdr-db-source`, `north-star`, `v2-ratification-coherence`), and an FR-5 regression that the 4 are NOT probed while V2 inactive. Adversarial verdict **SHIP** after those fixes; the live-DB coherence simulation confirmed the lockstep reconciles. FR-4 (ord-13 reword) left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)