### PR TITLE
fix(SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001): forecaster excludes fixture/released sessions

### DIFF
--- a/.prd-payloads/SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001.json
@@ -1,0 +1,69 @@
+{
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Exclude fixture/test sessions from the forecaster's live-worker set",
+      "description": "scripts/coordinator-capacity-forecast.mjs hand-rolled its worker filter (!is_coordinator && role!==adam), so a fixture/test session with a fresh heartbeat counted as a live idle/at-risk worker — inflating demand and producing a false deficit + spurious Adam reach-out. Reuse the EXISTING canonical session SSOT (SD-FDBK-INFRA-SHARED-FLEET-WORKER-001) the dashboard already uses: isDispatchableFleetMember (lib/fleet/session-predicates.mjs) drops coordinator (by id) + adam + non_fleet + fixture/test sessions. No new parallel predicate is created — a NEW isFixtureSession would re-introduce the very divergence this fixes.",
+      "acceptance_criteria": [
+        "A fixture/test session (drain_test_/test-/probe/QF-TEST/fixture id, or metadata fixture marker) is not counted as a live worker",
+        "The forecaster resolves the active coordinator id and excludes it via isDispatchableFleetMember, matching the dashboard",
+        "No new fixture-session predicate is added; the canonical session-predicates.mjs SSOT is reused"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "requirement": "Guard released/terminal sessions from the live-worker count",
+      "description": "A session with status in {released, completed, terminated, inactive} is not an available worker even with a recent heartbeat. The forecaster now selects the status column and excludes those statuses before counting. Encapsulated in the pure isLiveCountableWorker helper (RELEASED_WORKER_STATUSES) plus a stale metadata.is_coordinator guard.",
+      "acceptance_criteria": [
+        "A released/terminal-status session is excluded from the live-worker count",
+        "An active-status real worker is still counted",
+        "A stale metadata.is_coordinator session is excluded even when it is not the active coordinator id"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "requirement": "Audit fleet-dashboard.cjs + worker-status.cjs for the same fixture-counting",
+      "description": "Audit confirmed: fleet-dashboard.cjs ALREADY excludes fixtures via the same isDispatchableFleetMember SSOT (SD-FDBK-INFRA-SHARED-FLEET-WORKER-001) for its idle/available-worker panel — so after FR-1 the forecaster and dashboard AGREE. lib/fleet/worker-status.cjs getActiveSessions is a raw heartbeat-window query primitive (no worker-counting / fixture classification), so it needs no change. Documented so the agreement is intentional, not accidental.",
+      "acceptance_criteria": [
+        "The forecaster and dashboard use the same isDispatchableFleetMember SSOT for the live-worker set",
+        "worker-status.cjs is confirmed to be a query primitive with no worker-counting to fix",
+        "No divergent inline fixture/worker classification remains in the forecaster"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "requirement": "Tests",
+      "description": "scripts/lib/live-countable-worker.mjs extracts the forecaster's filter into a pure isLiveCountableWorker(session, coordinatorId) (the forecaster runs main() on import and cannot be imported by a test). tests/unit/live-countable-worker.test.js covers: fixture ids not counted, adam/non_fleet/coordinator excluded, released-status excluded, a real worker counted, a mixed set filtering to only real workers, and totality on null input.",
+      "acceptance_criteria": [
+        "npx vitest run tests/unit/live-countable-worker.test.js passes",
+        "A fixture/test session is NOT counted and a real worker IS; demand reflects only real workers",
+        "A regression case with a fixture-named session asserts exclusion"
+      ]
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Live-worker predicate",
+      "steps": "Run npx vitest run tests/unit/live-countable-worker.test.js.",
+      "expected_result": "20 assertions pass: fixtures/adam/non_fleet/coordinator/released excluded, real workers counted, mixed-set filters correctly, totality holds."
+    },
+    {
+      "id": "TS-2",
+      "scenario": "Forecaster excludes fixtures live",
+      "steps": "Run node scripts/coordinator-capacity-forecast.mjs against the live DB.",
+      "expected_result": "Completes; the live-worker count excludes fixture/test + released + coordinator + adam + non_fleet sessions, matching the dashboard."
+    },
+    {
+      "id": "TS-3",
+      "scenario": "SSOT reuse (no parallel predicate)",
+      "steps": "Inspect scripts/lib/live-countable-worker.mjs and scripts/coordinator-capacity-forecast.mjs.",
+      "expected_result": "isLiveCountableWorker wraps the canonical isDispatchableFleetMember from lib/fleet/session-predicates.mjs; no new fixture-session predicate is introduced."
+    }
+  ],
+  "acceptance_criteria": [
+    "The capacity forecaster never counts a fixture/test or released/coordinator/adam/non_fleet session as a live worker",
+    "The forecaster's live-worker set agrees with the dashboard via the shared isDispatchableFleetMember SSOT",
+    "A pure isLiveCountableWorker helper is unit-tested for fixture/released exclusion and real-worker inclusion"
+  ]
+}

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -32,6 +32,10 @@ import { dirname, join } from 'path';
 // fixtures AND bare-shell stubs (neither can pass LEAD-TO-PLAN) never inflate belt depth —
 // counting them as claimable over-reports capacity and suppresses the deficit/Adam alert.
 import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
+// SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: the pure live-worker predicate (wraps the
+// canonical isDispatchableFleetMember SSOT the dashboard uses, + the released-status guard) so the
+// forecaster's live-worker set AGREES with fleet-dashboard.cjs and excludes fixture/test sessions.
+import { isLiveCountableWorker } from './lib/live-countable-worker.mjs';
 // SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001: an idle worker is STALLED only when
 // its loop isn't claiming DESPITE available work — gate the stall label on belt depth, not heartbeat
 // age alone, so an empty-belt idle worker isn't a false-positive STALLED.
@@ -39,6 +43,9 @@ import { classifyIdleWorker } from './lib/capacity-idle-classifier.mjs';
 
 const require = createRequire(import.meta.url);
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+// SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: resolve the active coordinator id so the
+// shared isDispatchableFleetMember excludes the coordinator by id exactly like the dashboard does.
+const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 // SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001: resolve dependency keys via the canonical
 // blocker rule (lib/utils/parse-sd-dependencies.cjs, same SSOT coordinator-audit.mjs uses) instead of
 // a hand-rolled resolver. parseSdDependencies counts ONLY /^SD-/ entries as real blockers, so the
@@ -90,7 +97,9 @@ async function main() {
   const liveCutoff = new Date(Date.now() - HEARTBEAT_LIVE_MS).toISOString();
   const [{ data: sessions }, { data: sds }, { data: openQfRows }] = await Promise.all([
     sb.from('claude_sessions')
-      .select('session_id, terminal_id, sd_key, heartbeat_at, loop_state, metadata')
+      // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: + status so released/terminal sessions
+      // are not counted as available workers even with a recent heartbeat (FR-2).
+      .select('session_id, terminal_id, sd_key, heartbeat_at, loop_state, metadata, status')
       .gte('heartbeat_at', liveCutoff),
     sb.from('strategic_directives_v2')
       // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + metadata (is_fixture marker) and
@@ -131,11 +140,15 @@ async function main() {
   }
   if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell) excluded from belt depth`);
 
-  // ── classify live workers (exclude coordinator + adam) ──
-  const workers = (sessions || []).filter(s => {
-    const md = s.metadata || {};
-    return !md.is_coordinator && md.role !== 'adam';
-  });
+  // ── classify live workers (exclude coordinator + adam + non_fleet + fixtures + released) ──
+  // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: use the canonical isDispatchableFleetMember
+  // SSOT (the dashboard's predicate) so a fixture/test session (FR-1) never counts as live idle/at-risk
+  // demand; ALSO drop released/terminal sessions (FR-2) which are not available workers even with a
+  // recent heartbeat. Keep the metadata.is_coordinator guard so a stale coordinator-marked session is
+  // excluded even when it is not the CURRENTLY-active coordinator id.
+  let coordinatorId = null;
+  try { coordinatorId = await getActiveCoordinatorId(sb); } catch { coordinatorId = null; }
+  const workers = (sessions || []).filter(s => isLiveCountableWorker(s, coordinatorId));
 
   const rows = [];
   let idleNow = 0, freeingSoon = 0, building = 0, stalled = 0;

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -32,9 +32,10 @@ import { dirname, join } from 'path';
 // fixtures AND bare-shell stubs (neither can pass LEAD-TO-PLAN) never inflate belt depth —
 // counting them as claimable over-reports capacity and suppresses the deficit/Adam alert.
 import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
-// SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: the pure live-worker predicate (wraps the
-// canonical isDispatchableFleetMember SSOT the dashboard uses, + the released-status guard) so the
-// forecaster's live-worker set AGREES with fleet-dashboard.cjs and excludes fixture/test sessions.
+// SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: the pure live-worker predicate. It wraps the
+// canonical isDispatchableFleetMember SSOT the dashboard uses (so the forecaster AGREES with
+// fleet-dashboard.cjs on coordinator/adam/non_fleet/fixture exclusion) and ADDS a released-status
+// guard (FR-2; the forecaster is deliberately stricter than the dashboard on status).
 import { isLiveCountableWorker } from './lib/live-countable-worker.mjs';
 // SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001: an idle worker is STALLED only when
 // its loop isn't claiming DESPITE available work — gate the stall label on belt depth, not heartbeat

--- a/scripts/lib/live-countable-worker.mjs
+++ b/scripts/lib/live-countable-worker.mjs
@@ -1,0 +1,29 @@
+/**
+ * Pure "is this session a live, capacity-countable worker?" predicate for the capacity forecaster.
+ * SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001 (FR-1/FR-2).
+ *
+ * Extracted from scripts/coordinator-capacity-forecast.mjs (which runs main() on import and so cannot
+ * be imported by a test). Wraps the canonical session SSOT isDispatchableFleetMember
+ * (lib/fleet/session-predicates.mjs, SD-FDBK-INFRA-SHARED-FLEET-WORKER-001) — which already drops the
+ * coordinator (by id) + adam + non_fleet + fixture/test sessions — and adds two forecaster-specific
+ * guards: a stale metadata.is_coordinator marker, and a released/terminal session status (a worker
+ * that released its claim is not available even with a fresh heartbeat).
+ */
+
+import { isDispatchableFleetMember } from '../../lib/fleet/session-predicates.mjs';
+
+// Session statuses that mean "not an available worker" even within the live-heartbeat window.
+export const RELEASED_WORKER_STATUSES = new Set(['released', 'completed', 'terminated', 'inactive']);
+
+/**
+ * @param {{session_id?:string, terminal_id?:string, status?:string, metadata?:object}} session
+ * @param {string|null} coordinatorId - the active coordinator's session_id (excluded by id)
+ * @returns {boolean} true when the session should be counted as a live fleet worker
+ */
+export function isLiveCountableWorker(session, coordinatorId) {
+  if (!session || typeof session !== 'object') return false;
+  const md = session.metadata || {};
+  if (md.is_coordinator) return false; // a stale coordinator-marked session is never a worker
+  if (session.status && RELEASED_WORKER_STATUSES.has(session.status)) return false; // FR-2
+  return isDispatchableFleetMember(session, coordinatorId); // FR-1: drops adam/non_fleet/fixture
+}

--- a/scripts/lib/live-countable-worker.mjs
+++ b/scripts/lib/live-countable-worker.mjs
@@ -12,7 +12,14 @@
 
 import { isDispatchableFleetMember } from '../../lib/fleet/session-predicates.mjs';
 
-// Session statuses that mean "not an available worker" even within the live-heartbeat window.
+// Session statuses that mean "not an available worker" even within the live-heartbeat window (FR-2).
+// NOTE on agreement with the dashboard: this predicate AGREES with fleet-dashboard.cjs on the identity
+// polluters (coordinator/adam/non_fleet/fixture, via the shared isDispatchableFleetMember SSOT) but is
+// deliberately STRICTER on status — the dashboard applies no status guard. The transient
+// "recoverable-released" window (a still-heartbeating worker the sweep briefly marked 'released' before
+// its next heartbeat resets it to 'active', lib/session-manager.mjs) can drop one real idle worker for
+// a single tick; that errs toward UNDER-counting demand (a missed reach-out), never toward starving a
+// worker, and self-heals on the next heartbeat — the accepted, safe direction for FR-2.
 export const RELEASED_WORKER_STATUSES = new Set(['released', 'completed', 'terminated', 'inactive']);
 
 /**

--- a/tests/unit/live-countable-worker.test.js
+++ b/tests/unit/live-countable-worker.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001 — the capacity forecaster's live-worker
+ * predicate: a fixture/test session is NOT counted; a real worker IS; released/coordinator/adam
+ * sessions are excluded so demand(soon) reflects only real workers.
+ */
+import { describe, it, expect } from 'vitest';
+import { isLiveCountableWorker, RELEASED_WORKER_STATUSES } from '../../scripts/lib/live-countable-worker.mjs';
+
+const COORD = 'coord-session-uuid';
+const realWorker = { session_id: '32925831-81d7-40a1-b0a9-36987b3730a4', status: 'active', metadata: { callsign: 'Echo' } };
+
+describe('forecaster live-worker predicate — fixtures (FR-1)', () => {
+  it('a real worker session IS counted', () => {
+    expect(isLiveCountableWorker(realWorker, COORD)).toBe(true);
+  });
+
+  it.each([
+    'drain_test_123', 'test_execute_9', 'test-session-x', 'test_session_y',
+    'test-switch-claim-guards-session', 'qf-route-probe-A', 'QF-TEST-001', 'some-fixture-id',
+  ])('a fixture-id session (%s) is NOT counted', (sid) => {
+    expect(isLiveCountableWorker({ session_id: sid, status: 'active' }, COORD)).toBe(false);
+  });
+
+  it('a session with metadata.role=adam is NOT counted', () => {
+    expect(isLiveCountableWorker({ session_id: 'real-uuid-1', status: 'active', metadata: { role: 'adam' } }, COORD)).toBe(false);
+  });
+
+  it('a non_fleet session is NOT counted', () => {
+    expect(isLiveCountableWorker({ session_id: 'real-uuid-2', status: 'active', metadata: { non_fleet: true } }, COORD)).toBe(false);
+  });
+
+  it('the active coordinator (by id) is NOT counted', () => {
+    expect(isLiveCountableWorker({ session_id: COORD, status: 'active', metadata: {} }, COORD)).toBe(false);
+  });
+
+  it('a stale metadata.is_coordinator marker is NOT counted even when not the active coordinator id', () => {
+    expect(isLiveCountableWorker({ session_id: 'stale-coord', status: 'active', metadata: { is_coordinator: true } }, COORD)).toBe(false);
+  });
+});
+
+describe('forecaster live-worker predicate — released/terminal status (FR-2)', () => {
+  it.each([...RELEASED_WORKER_STATUSES])('a %s session is NOT counted (not available even with a fresh heartbeat)', (status) => {
+    expect(isLiveCountableWorker({ session_id: 'real-uuid-3', status, metadata: {} }, COORD)).toBe(false);
+  });
+
+  it('an active status real worker IS counted', () => {
+    expect(isLiveCountableWorker({ session_id: 'real-uuid-4', status: 'active', metadata: {} }, COORD)).toBe(true);
+  });
+});
+
+describe('forecaster live-worker predicate — demand reflects only real workers (FR-4)', () => {
+  it('filtering a mixed session set leaves only the real workers', () => {
+    const sessions = [
+      realWorker,                                                              // real
+      { session_id: 'drain_test_1', status: 'active', metadata: {} },          // fixture
+      { session_id: 'r2', status: 'active', metadata: { role: 'adam' } },      // adam
+      { session_id: 'r3', status: 'released', metadata: {} },                  // released
+      { session_id: COORD, status: 'active', metadata: {} },                   // coordinator
+      { session_id: 'r4', status: 'active', metadata: { callsign: 'Foxtrot' } }, // real
+    ];
+    const live = sessions.filter((s) => isLiveCountableWorker(s, COORD));
+    expect(live.map((s) => s.session_id).sort()).toEqual([realWorker.session_id, 'r4'].sort());
+  });
+});
+
+describe('forecaster live-worker predicate — totality', () => {
+  it('null/garbage input is not a worker (never throws)', () => {
+    expect(isLiveCountableWorker(null, COORD)).toBe(false);
+    expect(isLiveCountableWorker(undefined, undefined)).toBe(false);
+    expect(isLiveCountableWorker({}, null)).toBe(true); // empty session, no exclusion signal -> real
+  });
+});


### PR DESCRIPTION
## What

The capacity forecaster hand-rolled its worker filter (`!is_coordinator && role!==adam`), so a fixture/test session with a fresh heartbeat counted as a live idle worker — inflating demand and producing a false deficit + a spurious Adam reach-out. It also counted released/terminal sessions.

## Fix

Reuse the **EXISTING canonical session SSOT** the dashboard already uses (`isDispatchableFleetMember`, `lib/fleet/session-predicates.mjs`, SD-FDBK-INFRA-SHARED-FLEET-WORKER-001) — which drops coordinator (by id) + adam + non_fleet + fixture/test sessions — instead of a new parallel predicate. The forecaster's live-worker set now **agrees with fleet-dashboard.cjs** on those identity polluters. Adds a released-status guard (FR-2; deliberately stricter than the dashboard on status — documented).

- **FR-3 audit**: the dashboard already uses the SSOT (agrees); `worker-status.cjs getActiveSessions` is a raw heartbeat-window query primitive (no worker-counting) — no change.
- Extracted the filter into pure `scripts/lib/live-countable-worker.mjs` (the forecaster runs `main()` on import).

## Tests

`tests/unit/live-countable-worker.test.js` — 20 cases: fixture-id exclusion, adam/non_fleet/coordinator/stale-is_coordinator exclusion, released-status exclusion, real-worker inclusion, the mixed-set filter, and totality. Forecaster smokes clean (no fixtures counted). Adversarial review: no Critical/High; reused the SSOT (no duplicate predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)