### PR TITLE
fix(SD-LEO-INFRA-DESIGN-GATE-CROSSREPO-DIFF-001): design gate diffs committed changeset (not working tree) + fail-loud

### DIFF
--- a/lib/sub-agents/design/checks.js
+++ b/lib/sub-agents/design/checks.js
@@ -24,13 +24,13 @@ export async function checkDesignSystem(repoPath, _sdId) {
   try {
     // Check for inline styles (violation)
     const { stdout: inlineStyles } = await execAsync(
-      `grep -r "style={{" src/components 2>/dev/null | wc -l`,
+      'grep -r "style={{" src/components 2>/dev/null | wc -l',
     { cwd: repoPath }
     );
 
     // Check for non-Tailwind custom CSS
     const { stdout: customCSS } = await execAsync(
-      `find src/components -name "*.css" 2>/dev/null | wc -l`,
+      'find src/components -name "*.css" 2>/dev/null | wc -l',
     { cwd: repoPath }
     );
 
@@ -62,7 +62,7 @@ export async function analyzeComponents(repoPath, _sdId) {
   try {
     // Find all component files
     const { stdout: componentFiles } = await execAsync(
-      `find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null`,
+      'find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null',
     { cwd: repoPath }
     );
 
@@ -135,8 +135,8 @@ export async function checkAccessibility(repoPath, sdId, supabase) {
     const passed = score >= scoreThreshold;
     const issues = passed ? 0 : 1;
 
-    // Extract affected files from git diff
-    const affectedFiles = await getGitDiffFiles(repoPath);
+    // Extract affected files from git diff (null = git failed, already logged loudly per FR-4 → []).
+    const affectedFiles = (await getGitDiffFiles(repoPath)) || [];
 
     console.log(`   📊 Design Score: ${score}/100 (threshold: ${scoreThreshold}) ${passed ? '✅ PASS' : '❌ FAIL'}`);
 
@@ -159,12 +159,12 @@ export async function checkAccessibility(repoPath, sdId, supabase) {
     // Fall back to simple grep checks
     try {
       const { stdout: missingAltFiles } = await execAsync(
-        `grep -rl "<img" src/components 2>/dev/null | grep -v "alt="`,
+        'grep -rl "<img" src/components 2>/dev/null | grep -v "alt="',
       { cwd: repoPath }
       );
 
       const { stdout: missingAriaFiles } = await execAsync(
-        `grep -rl "<button" src/components 2>/dev/null | grep -v "aria-label"`,
+        'grep -rl "<button" src/components 2>/dev/null | grep -v "aria-label"',
       { cwd: repoPath }
       );
 
@@ -202,13 +202,13 @@ export async function checkResponsiveDesign(repoPath, _sdId) {
   try {
     // Check for responsive breakpoints usage
     const { stdout: responsiveClasses } = await execAsync(
-      `grep -r "sm:\\|md:\\|lg:\\|xl:" src/components 2>/dev/null | wc -l`,
+      'grep -r "sm:\\|md:\\|lg:\\|xl:" src/components 2>/dev/null | wc -l',
     { cwd: repoPath }
     );
 
     // Count total components
     const { stdout: totalComponents } = await execAsync(
-      `find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null | wc -l`,
+      'find src/components -name "*.tsx" -o -name "*.jsx" 2>/dev/null | wc -l',
     { cwd: repoPath }
     );
 
@@ -238,13 +238,13 @@ export async function checkDesignConsistency(repoPath, _sdId) {
   try {
     // Check for consistent spacing (Tailwind scale)
     const { stdout: customSpacing } = await execAsync(
-      `grep -r "margin:\\|padding:" src/components 2>/dev/null | wc -l`,
+      'grep -r "margin:\\|padding:" src/components 2>/dev/null | wc -l',
     { cwd: repoPath }
     );
 
     // Check for hex colors (should use Tailwind palette)
     const { stdout: hexColors } = await execAsync(
-      `grep -r "#[0-9a-fA-F]\\{6\\}" src/components 2>/dev/null | wc -l`,
+      'grep -r "#[0-9a-fA-F]\\{6\\}" src/components 2>/dev/null | wc -l',
     { cwd: repoPath }
     );
 

--- a/lib/sub-agents/design/utils.js
+++ b/lib/sub-agents/design/utils.js
@@ -120,20 +120,42 @@ export async function enhanceWithRiskContext(affectedFiles, patternType, repoPat
 }
 
 /**
- * Get files changed in current git diff
+ * Get the UI files changed by an SD's committed changeset.
+ *
+ * SD-LEO-INFRA-DESIGN-GATE-CROSSREPO-DIFF-001 (FR-1/FR-3): compare the BRANCH changeset against
+ * the base (`<baseRef>..HEAD`), NOT the working tree (`git diff HEAD`). By EXEC-TO-PLAN the worker's
+ * changes are already COMMITTED, so `git diff HEAD` (working-tree vs HEAD) returns EMPTY → the
+ * design gate reported files_analyzed:0 on every committed SD (and always on a cross-repo `ehg`
+ * checkout). Mirrors checkForNonUIDiff's proven `git diff --name-only origin/main..HEAD` pattern.
+ *
+ * The repo root is resolved target-application-aware by the caller (resolveDesignRepo →
+ * resolveRepoPath) and passed in as `repoPath`, so this runs against the correct (possibly ehg) tree.
+ *
+ * FR-4 (fail-loud): a git failure (e.g. base ref not fetched, unresolved repo) is logged LOUDLY and
+ * returns null — distinct from a genuine empty changeset ([]) — so a broken resolution never
+ * masquerades as an honest "0 files".
+ *
+ * @param {string} repoPath - target repo root (already resolved by the caller)
+ * @param {string} [baseRef='origin/main'] - base ref for the changeset comparison
+ * @returns {Promise<string[]|null>} UI files (.tsx/.jsx) changed; [] = empty changeset; null = git failed
  */
-export async function getGitDiffFiles(repoPath) {
+export async function getGitDiffFiles(repoPath, baseRef = 'origin/main') {
   try {
     const { stdout } = await execAsync(
-      `git diff --name-only HEAD 2>/dev/null`,
-    { cwd: repoPath }
+      `git diff --name-only ${baseRef}..HEAD`,
+      { cwd: repoPath },
     );
-
-    const files = stdout.trim().split('\n').filter(f => f && f.endsWith('.tsx') || f.endsWith('.jsx'));
-    return files;
-  } catch {
-    // No git or no changes
-    return [];
+    return stdout
+      .trim()
+      .split('\n')
+      .map(f => f.trim())
+      .filter(f => f && (f.endsWith('.tsx') || f.endsWith('.jsx')));
+  } catch (err) {
+    // FR-4: do NOT silently report 0 — a failed diff (bad base ref / unresolved repo / no git) is loud.
+    console.error(
+      `   ❌ [design] git diff failed in '${repoPath}' vs '${baseRef}..HEAD' — cannot determine changed files (NOT reporting 0): ${err?.message || err}`,
+    );
+    return null;
   }
 }
 
@@ -192,8 +214,10 @@ export async function validateUxContractCompliance(sdId, repoPath) {
     result.max_component_loc = contracts.uxContract.max_component_loc;
     result.min_wcag_level = contracts.uxContract.min_wcag_level;
 
-    // Get changed files from git diff (focus on what's being modified)
-    const changedFiles = await getGitDiffFiles(repoPath);
+    // Get changed files from git diff (focus on what's being modified).
+    // getGitDiffFiles returns null on a git failure (already logged loudly per FR-4); coalesce to []
+    // for downstream safety — the loud signal is the FR-4 contract, not a crash.
+    const changedFiles = (await getGitDiffFiles(repoPath)) || [];
     const componentFiles = changedFiles.filter(f =>
       f.endsWith('.tsx') || f.endsWith('.jsx')
     );

--- a/tests/unit/sub-agents/design-getgitdifffiles-changeset.test.js
+++ b/tests/unit/sub-agents/design-getgitdifffiles-changeset.test.js
@@ -1,0 +1,84 @@
+/**
+ * SD-LEO-INFRA-DESIGN-GATE-CROSSREPO-DIFF-001 (FR-1/FR-3/FR-4) — getGitDiffFiles changeset + fail-loud.
+ *
+ * Bug: getGitDiffFiles ran `git diff --name-only HEAD` (working-tree vs HEAD), which is EMPTY once
+ * the worker's changes are COMMITTED by EXEC-TO-PLAN → the design gate reported files_analyzed:0 on
+ * every committed SD (and always on a cross-repo ehg checkout). Fix: compare the branch changeset
+ * `<baseRef>..HEAD` (default origin/main), honor an overridable baseRef, run against the caller-
+ * resolved repoPath, and FAIL LOUD (return null, not []) on a git failure.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// getGitDiffFiles uses `promisify(exec)`. Attach util.promisify.custom to the mocked exec so
+// promisify(exec) returns our directly-controllable async fn (execAsyncImpl) — no callback dance.
+const execAsyncImpl = vi.hoisted(() => vi.fn());
+const execMock = vi.hoisted(() => {
+  const { promisify } = require('node:util');
+  const fn = vi.fn();
+  fn[promisify.custom] = execAsyncImpl;
+  return fn;
+});
+vi.mock('child_process', () => ({ exec: execMock }));
+// Stub utils.js's heavy transitive imports so importing the SUT stays lightweight + hermetic.
+vi.mock('../../../lib/utils/risk-context.js', () => ({
+  getRiskContext: vi.fn(),
+  calculateContextualConfidence: vi.fn(),
+  getAggregateRiskStats: vi.fn(),
+}));
+vi.mock('../../../scripts/modules/contract-validation.js', () => ({
+  validateComponentAgainstUxContract: vi.fn(),
+  getInheritedContracts: vi.fn(),
+}));
+
+const { getGitDiffFiles } = await import('../../../lib/sub-agents/design/utils.js');
+
+/** execAsync(cmd, opts) resolves to { stdout } (the promisify.custom contract). */
+function execResolves(stdout) {
+  execAsyncImpl.mockResolvedValue({ stdout, stderr: '' });
+}
+/** execAsync rejects (git failure). Use the ONE-SHOT `mockRejectedValueOnce` rather than the
+ *  persistent `mockImplementation`/`mockRejectedValue`. A PERSISTENT rejecting mock leaves a
+ *  rejected promise in vitest's mock bookkeeping that its onUnhandledRejection listener flags as
+ *  unhandled and (mis)attributes to whichever test is in flight — even though getGitDiffFiles
+ *  awaits the call inside its own try/catch and returns null (verified: the throw never escapes the
+ *  SUT). A no-op `.catch` on a local promise reference does NOT cover the copy vitest inspects, so
+ *  that workaround does not help. The one-shot variant produces the rejected promise exactly once,
+ *  at call time, where the awaiting SUT consumes it immediately — no lingering tracked rejection. */
+function execRejects(message) {
+  execAsyncImpl.mockRejectedValueOnce(new Error(message));
+}
+
+describe('getGitDiffFiles — committed-changeset diff (FR-1/FR-3)', () => {
+  beforeEach(() => execAsyncImpl.mockReset());
+
+  it('diffs the branch changeset vs origin/main (NOT the working tree HEAD) against the given repoPath', async () => {
+    execResolves('src/a.tsx\nsrc/b.js\nsrc/c.jsx\nREADME.md\n');
+    const files = await getGitDiffFiles('/repos/ehg');
+    expect(files).toEqual(['src/a.tsx', 'src/c.jsx']); // .tsx/.jsx only; .js/.md excluded
+    const [cmd, opts] = execAsyncImpl.mock.calls[0];
+    expect(cmd).toContain('git diff --name-only origin/main..HEAD');
+    expect(cmd).not.toMatch(/diff --name-only HEAD\b/); // not the working-tree form
+    expect(opts.cwd).toBe('/repos/ehg'); // runs against the caller-resolved (cross-repo) root
+  });
+
+  it('returns [] for a genuinely empty changeset (not a failure)', async () => {
+    execResolves('\n');
+    expect(await getGitDiffFiles('/repos/ehg')).toEqual([]);
+  });
+
+  it('honors an overridable baseRef', async () => {
+    execResolves('x.tsx\n');
+    await getGitDiffFiles('/repos/ehg', 'origin/develop');
+    expect(execAsyncImpl.mock.calls[0][0]).toContain('origin/develop..HEAD');
+  });
+
+  it('FR-4: returns null + logs loudly on a git failure (never a silent 0)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    execRejects('fatal: bad revision origin/main..HEAD');
+    const result = await getGitDiffFiles('/repos/ehg');
+    expect(result).toBeNull(); // null (failure) is DISTINCT from [] (empty changeset)
+    expect(errSpy).toHaveBeenCalledOnce();
+    expect(errSpy.mock.calls[0][0]).toMatch(/git diff failed/i);
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the EXEC-TO-PLAN **DESIGN sub-agent reporting `files_analyzed: 0`** on cross-repo (ehg) SDs — and, it turns out, on **every committed SD**.

## Root cause (verified, not assumed)
The SD's framing was "make repo/diff resolution target_application-aware" — but reading the live code, repo resolution is **already** target-aware (`resolveDesignRepo` → `resolveRepoPath`, from a prior SD). The actual defect was narrower: `getGitDiffFiles` ran `git diff --name-only HEAD` — the **working-tree** diff vs HEAD — which is **empty once the worker's changes are committed** (by EXEC-TO-PLAN they always are). A cross-repo ehg checkout made it 100%, but it mis-fired same-repo post-commit too.

## Fix
- `lib/sub-agents/design/utils.js` `getGitDiffFiles(repoPath, baseRef='origin/main')`: diff the **committed changeset `<baseRef>..HEAD`** (mirrors the proven `checkForNonUIDiff`), against the caller-resolved (cross-repo) `repoPath`. Fixed the `.tsx/.jsx` filter precedence bug.
- **FR-4 fail-loud**: a git failure returns `null` (distinct from `[]` empty changeset) + a loud `console.error` — never a silent 0. Both callers coalesce `null → []` after the loud signal.
- `resolveDesignRepo` untouched (already correct).

## Tests
- `tests/unit/sub-agents/design-getgitdifffiles-changeset.test.js` — 4 tests: changeset-not-working-tree diff vs origin/main against the given repoPath, empty changeset = `[]`, overridable baseRef, fail-loud = `null` + loud log.
- TESTING sub-agent PASS (`539f479f`). RCA `5c28b803` resolved a vitest mock artifact (one-shot `mockRejectedValueOnce` + `promisify.custom`).

## Note
This is the exact gate defect that under-reported on my own cockpit SD this session — dogfooding surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
