### PR TITLE
fix(SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001): sibling VDR test count pins 25->21

### DIFF
--- a/tests/unit/vdr-governance-probes.test.js
+++ b/tests/unit/vdr-governance-probes.test.js
@@ -134,8 +134,8 @@ describe('FR-1/FR-3: coherence invariant — criteria rows ↔ VDR_REGISTRY must
     }
   });
 
-  it('registry has 25 entries (11 original + 4 automation + 2 capability-layer + 5 governance + 3 consolidation)', () => {
-    expect(VDR_REGISTRY.length).toBe(25);
+  it('registry has 21 entries (7 original after the V1->V2 re-cut + 4 automation + 2 capability-layer + 5 governance + 3 consolidation)', () => {
+    expect(VDR_REGISTRY.length).toBe(21);
   });
 
   it('a matched criteria set is coherent (ok:true, no missing/stale probes)', () => {
@@ -193,7 +193,7 @@ describe('FR-3: computeBuildGauge end-to-end — governance contributes, coheren
     const gauge = await computeBuildGauge({ io, visionSource: async () => rows16() });
     expect(gauge.available).toBe(true);
     expect(gauge.coherence.ok).toBe(true);
-    expect(gauge.total_capabilities).toBe(25); // +4 automation +3 consolidation since the 18-entry baseline
+    expect(gauge.total_capabilities).toBe(21); // 7 original (post V1->V2 re-cut) +4 automation +2 caplayer +5 governance +3 consolidation
     const byCap = Object.fromEntries(gauge.components.map((c) => [c.capability, c.status]));
     expect(byCap['All 7 governance guardrails']).toBe('built');
     expect(byCap['OKR-driven prioritization + day-28 hard stop']).toBe('built');

--- a/tests/unit/vdr-v1-automation-probes.test.js
+++ b/tests/unit/vdr-v1-automation-probes.test.js
@@ -35,9 +35,10 @@ describe('VDR_REGISTRY — 4 new automation/intelligence entries (ordinals 17-20
   });
 
   it('the registry includes these 4 (alongside the concurrently-landed governance + capability-layer clusters)', () => {
-    // 25 = 11 original + 5 governance (V1-GOV-PROBES) + 2 capability-layer (V1-CAPLAYER-PROBES)
-    //      + 4 here (automation ordinals 17-20) + 3 consolidation (V1-CONSOLIDATION-PROBES, 23-25).
-    expect(VDR_REGISTRY.length).toBe(25);
+    // 21 = 7 original (after SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001 moved 4 revenue/operating caps to
+    //      inactive V2) + 5 governance (V1-GOV-PROBES) + 2 capability-layer (V1-CAPLAYER-PROBES)
+    //      + 4 here (automation ordinals 17-20) + 3 consolidation (V1-CONSOLIDATION-PROBES).
+    expect(VDR_REGISTRY.length).toBe(21);
   });
 });
 


### PR DESCRIPTION
The V1->V2 re-cut (#4891) shrank VDR_REGISTRY 25->21; two non-vision sibling test suites (vdr-governance-probes, vdr-v1-automation-probes) hardcoded the old 25 and went red on main. Test-only count fix (REGRESSION sub-agent catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)