### PR TITLE
feat(SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001): heartbeat the claim on sub-agent evidence writes

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001.json
@@ -1,0 +1,102 @@
+{
+  "executive_summary": "A worker's claim is authoritative on claude_sessions.heartbeat_at; the stale-session sweep reaps a claim once heartbeat_at is older than 900s (15min) and the stored claim pid is dead. During a long worker tick that orchestrates parallel sub-agent reviews, the original short-lived `node` process that acquired the claim has already exited (its pid is dead) and no process refreshes heartbeat_at between tool calls, so a >15min review tick lets heartbeat_at cross the 900s boundary and the claim is released — the next handoff then trips GATE_CLAIM_VALIDITY_FAILED and the SD churns through deconflict. The purpose-built withHeartbeat() proxy (lib/heartbeat-manager.mjs, FR1 of SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001) was written to close exactly this race by refreshing heartbeat_at at WORK frequency (on every write to the 4 high-traffic tables) rather than tick frequency — but it has ZERO production callers. This PRD wires it into the canonical sub-agent evidence writer (storeSubAgentResults), keyed off the owning CLAUDE_SESSION_ID, so each sub-agent evidence write during a parallel-review tick touches the claim and keeps it live. It changes NO sweep/TTL/schema, so genuine reaping of dead sessions is preserved by construction.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Heartbeat the claim on every sub-agent evidence write (wire withHeartbeat into storeSubAgentResults)",
+      "description": "In lib/sub-agent-executor/results-storage.js, wrap the supabase client used by storeSubAgentResults with withHeartbeat(rawClient, process.env.CLAUDE_SESSION_ID) when CLAUDE_SESSION_ID is set (skip the wrap when unset — fail-soft, no behavior change). The sub_agent_execution_results insert is one of withHeartbeat's 4 trigger tables, so writing each sub-agent's evidence row automatically refreshes claude_sessions.heartbeat_at for the owning session. This is the preferred FR-1(a) HEARTBEAT approach: a periodic claim touch while sub-agents run, at work frequency rather than tick frequency. It reuses the already-built, already-tested proxy rather than adding a parallel mechanism.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "storeSubAgentResults wraps its client with withHeartbeat when process.env.CLAUDE_SESSION_ID is set; the wrap is skipped (raw client used) when it is unset.",
+        "Writing a sub-agent evidence row advances claude_sessions.heartbeat_at for the owning session to ~now.",
+        "The wrap is fail-soft: a heartbeat ping failure never breaks the evidence insert (withHeartbeat swallows ping errors).",
+        "No change to the verdict/confidence/phase/repo_path evidence semantics — only the heartbeat side-effect is added."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Do NOT weaken genuine stale-claim reaping — alive-but-busy vs dead is preserved",
+      "description": "The fix touches ONLY the heartbeat-refresh side-effect on a real write by a real live process. scripts/stale-session-sweep.cjs, the deadness predicate (heartbeat_age>900s AND pid dead), the claim-validity gate (lib/claim-validity-gate.js ownerIsDeadByLiveness), and the claim schema are all unchanged. A genuinely-dead session performs no writes, so withHeartbeat never fires for it and it is still reaped exactly as before. The distinction 'alive-but-busy-in-sub-agent' (still writing evidence) vs 'dead' (writing nothing) falls out naturally: only the former refreshes the heartbeat.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "No edits to scripts/stale-session-sweep.cjs or the sweep's release/deadness predicate.",
+        "No edits to the claim-validity gate's ownerIsDeadByLiveness deadness logic or the 900s TTL constants.",
+        "A session that performs no evidence writes and has a stale heartbeat + dead pid remains classified reapable (regression-tested)."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Regression test — a live >15min sub-agent tick keeps the claim valid",
+      "description": "Add tests/unit/subagent-evidence-heartbeat.test.js proving: (a) storeSubAgentResults wraps with withHeartbeat only when CLAUDE_SESSION_ID is set (injected fake client + heartbeatFn spy); (b) the sub_agent_execution_results insert triggers exactly one heartbeat ping for the owning session; (c) the long-tick scenario: a sequence of evidence writes keeps heartbeat_at fresh so ownerIsDeadByLiveness(owner, now) stays false even after a simulated >15min elapsed-since-claim, i.e. the claim does NOT become GATE_CLAIM_VALIDITY_FAILED; (d) FR-2 guard: a no-write session with a >900s-old heartbeat and is_alive=false is still reported dead by ownerIsDeadByLiveness.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Test asserts withHeartbeat is applied iff CLAUDE_SESSION_ID is set.",
+        "Test asserts an evidence insert fires one heartbeat ping for the owning session.",
+        "Test asserts a heartbeat refreshed by an evidence write keeps ownerIsDeadByLiveness false past the 15min mark (live-but-busy stays valid).",
+        "Test asserts a no-write, stale-heartbeat, is_alive=false owner is still ownerIsDeadByLiveness=true (reaping intact)."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Dedup vs SESSION-CLAIM-LIFECYCLE-001 — extend, do not duplicate",
+      "description": "SD-LEO-INFRA-SESSION-CLAIM-LIFECYCLE-001 (FR19) built the per-sd_type TTL resolution layer (resolveClaimTtlSeconds in lib/claim-guard.mjs) — the LENGTH of the claim window. This SD addresses a different axis: keeping heartbeat_at FRESH within whatever window is configured, during a long sub-agent tick. No TTL constant, the per-type TTL map, or claim-guard logic is duplicated or modified; this SD only wires the existing withHeartbeat proxy (built by SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001) into the sub-agent evidence path. The two layers compose (longer TTL + fresher heartbeat) without overlap.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "No edits to lib/claim-guard.mjs resolveClaimTtlSeconds or the sd_type TTL map.",
+        "The wired mechanism is the pre-existing withHeartbeat from lib/heartbeat-manager.mjs (no new parallel heartbeat helper is introduced).",
+        "The PRD/commit notes the relationship to both SESSION-CLAIM-LIFECYCLE-001 (TTL length) and SESSION-LIFECYCLE-HYGIENE-001 (the withHeartbeat proxy)."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "ESM import", "description": "results-storage.js is ESM; import { withHeartbeat } from '../heartbeat-manager.mjs' (sibling lib path)." },
+    { "id": "TR-2", "title": "No schema change", "description": "Pure code wiring; reads/writes existing claude_sessions.heartbeat_at via the existing updateHeartbeat path inside withHeartbeat. No migration." },
+    { "id": "TR-3", "title": "Fail-soft", "description": "When CLAUDE_SESSION_ID is unset (e.g. non-fleet contexts) the raw client is used unchanged — zero behavior change for existing callers." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "withHeartbeat applied only when CLAUDE_SESSION_ID is set", "type": "unit", "expected": "Wrapped client when set; raw client when unset." },
+    { "id": "TS-2", "scenario": "Evidence insert refreshes the owning session heartbeat", "type": "unit", "expected": "One heartbeat ping fired for the owner after the sub_agent_execution_results insert." },
+    { "id": "TS-3", "scenario": "Live-but-busy long tick stays claim-valid; dead session still reaped", "type": "unit", "expected": "ownerIsDeadByLiveness stays false for a heartbeat-refreshed owner past 15min; stays true for a no-write stale dead owner." }
+  ],
+  "acceptance_criteria": [
+    "A long worker tick running parallel sub-agent reviews refreshes the claim heartbeat on each evidence write and does not trip GATE_CLAIM_VALIDITY_FAILED.",
+    "Genuine stale-claim reaping is unchanged (a dead session is still reaped).",
+    "The fix reuses withHeartbeat and the per-type TTL layer untouched (no duplication)."
+  ],
+  "risks": [
+    { "risk": "An extra heartbeat UPDATE per evidence write adds DB load", "mitigation": "withHeartbeat ping is fire-and-forget and only fires on the 4 high-traffic tables; one UPDATE per evidence row is negligible vs the insert it accompanies.", "severity": "low" },
+    { "risk": "withHeartbeat could mask a truly-dead session if a zombie process kept writing", "mitigation": "A process writing evidence IS alive by definition; the sweep's pid+heartbeat predicate is unchanged for genuinely non-writing dead sessions.", "severity": "low" },
+    { "risk": "CLAUDE_SESSION_ID resolves to a non-owner session", "mitigation": "CLAUDE_SESSION_ID is the worker's own session = the claim owner in the fleet model; if unset the wrap is skipped (no wrong-session pings).", "severity": "low" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["LEO fleet workers running long parallel-sub-agent review ticks", "the GATE_CLAIM_VALIDITY gate (sees fresher heartbeat_at)", "the stale-session-sweep (sees a live session it correctly does not reap)"],
+    "dependencies": ["lib/heartbeat-manager.mjs withHeartbeat (the proxy being wired)", "lib/sub-agent-executor/results-storage.js storeSubAgentResults (the wire point)", "claude_sessions.heartbeat_at (refresh target)", "lib/session-manager.mjs updateHeartbeat (withHeartbeat's default ping fn)"],
+    "data_contracts": ["claude_sessions.heartbeat_at (write, via existing updateHeartbeat)", "sub_agent_execution_results insert (unchanged; now also triggers a heartbeat ping); no schema change"],
+    "runtime_config": ["CLAUDE_SESSION_ID (gates whether the wrap is applied)", "no new env var; existing STALE_SESSION_THRESHOLD_SECONDS / CLAIM_TTL_MS untouched"],
+    "observability_rollout": ["[withHeartbeat] ping-failed warnings (existing) surface any ping issues", "rollout is a code wire active for any CLAUDE_SESSION_ID-bearing worker; observe by confirming heartbeat_at advances during long ticks and GATE_CLAIM_VALIDITY_FAILED / deconflict churn on long-review SDs drops"]
+  },
+  "system_architecture": {
+    "summary": "One-line wire: storeSubAgentResults wraps its client with the pre-built withHeartbeat proxy so each sub-agent evidence write refreshes the owner's heartbeat_at during long ticks.",
+    "components": [
+      { "name": "lib/sub-agent-executor/results-storage.js", "change": "WIRE withHeartbeat around the supabase client (keyed off CLAUDE_SESSION_ID)" },
+      { "name": "lib/heartbeat-manager.mjs", "change": "REUSED unchanged (withHeartbeat — the proxy)" },
+      { "name": "tests/unit/subagent-evidence-heartbeat.test.js", "change": "NEW regression tests (FR-2/FR-3)" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Minimal, least-invasive wire of the purpose-built-but-unwired withHeartbeat proxy into the canonical sub-agent evidence writer, gated on CLAUDE_SESSION_ID, with regression tests proving the long-tick claim stays valid while genuine reaping is preserved.",
+    "steps": [
+      "Import withHeartbeat into lib/sub-agent-executor/results-storage.js and wrap the supabase client returned by getSupabaseClient() with withHeartbeat(client, process.env.CLAUDE_SESSION_ID) when CLAUDE_SESSION_ID is set.",
+      "Add tests/unit/subagent-evidence-heartbeat.test.js: inject a fake client + heartbeatFn spy; assert wrap-iff-session-set, one ping per evidence insert, ownerIsDeadByLiveness stays false for a refreshed owner past 15min, and stays true for a no-write dead owner.",
+      "Run the suite green, live-smoke a single evidence write proving heartbeat_at advances, TESTING+SECURITY @ EXEC, commit early, EXEC-TO-PLAN."
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run: npx vitest run tests/unit/subagent-evidence-heartbeat.test.js", "expected_outcome": "All tests pass: wrap-iff-CLAUDE_SESSION_ID, one heartbeat ping per evidence insert, live-but-busy claim stays valid past 15min, no-write dead session still reaped." },
+    { "step_number": 2, "instruction": "Grep lib/sub-agent-executor/results-storage.js for withHeartbeat", "expected_outcome": "storeSubAgentResults imports withHeartbeat and wraps its client keyed off process.env.CLAUDE_SESSION_ID." },
+    { "step_number": 3, "instruction": "Live: with CLAUDE_SESSION_ID = a live claiming session, write one evidence row via storeSubAgentResults; read claude_sessions.heartbeat_at before/after", "expected_outcome": "heartbeat_at advances to ~now after the write, keeping a long parallel-sub-agent tick under the 900s reap boundary (no GATE_CLAIM_VALIDITY_FAILED)." },
+    { "step_number": 4, "instruction": "Confirm scripts/stale-session-sweep.cjs and the claim-validity deadness predicate are unchanged (git diff)", "expected_outcome": "No changes to the sweep or deadness predicate; genuine reaping of dead sessions intact (FR-2)." }
+  ],
+  "activation_test_id": "tests/unit/subagent-evidence-heartbeat.test.js",
+  "metadata": { "sd_key": "SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001" }
+}

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -12,34 +12,43 @@
 
 import { getSupabaseClient } from './supabase-client.js';
 // SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): keep a worker's claim alive across a long
-// tick that spawns parallel sub-agent reviews. withHeartbeat (built by SD-LEO-FIX-SESSION-LIFECYCLE-
-// HYGIENE-001, previously unwired) refreshes claude_sessions.heartbeat_at on every write to the
-// high-traffic tables — sub_agent_execution_results is one — so writing each sub-agent's evidence
-// row touches the owner's claim at WORK frequency, never crossing the 900s reap boundary mid-tick.
-import { withHeartbeat } from '../heartbeat-manager.mjs';
+// tick that spawns parallel sub-agent reviews. After each sub-agent's evidence row lands we
+// explicitly refresh claude_sessions.heartbeat_at for the owning session (CLAUDE_SESSION_ID), so the
+// claim is touched at WORK frequency and never crosses the 900s reap boundary mid-tick. We call the
+// same updateHeartbeat the heartbeat manager uses, NOT the withHeartbeat client proxy — that proxy's
+// thenable spread drops a supabase-js builder's prototype methods and breaks chained
+// .insert().select().single() writes (latent; its tests use own-method fake builders that mask it).
+import { updateHeartbeat } from '../session-manager.mjs';
 import { USE_TASK_CONTRACTS, RESULT_COMPRESSION_THRESHOLD, PRD_LINKABLE_SUBAGENTS } from './constants.js';
 import { createArtifact } from '../artifact-tools.js';
 // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
 import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
 
 /**
- * SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): decide which client a sub-agent evidence
- * write should use. When a fleet worker session id is supplied (CLAUDE_SESSION_ID — the claim owner
- * in the fleet model), return the withHeartbeat-wrapped client so the evidence insert refreshes
- * claude_sessions.heartbeat_at and the claim stays alive through a long parallel-sub-agent tick.
- * When no session id is supplied (non-fleet contexts), return the raw client unchanged — fail-soft,
- * zero behavior change. A truly-dead session writes nothing, so it is never kept alive by this
- * (FR-2: genuine stale-claim reaping is preserved by construction).
+ * SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): refresh the owning worker's claim heartbeat
+ * after a sub-agent evidence write lands. When a fleet worker session id is supplied (CLAUDE_SESSION_
+ * ID — the claim owner in the fleet model), ping claude_sessions.heartbeat_at so the claim is touched
+ * at WORK frequency and stays alive through a long parallel-sub-agent tick. When no session id is
+ * supplied (non-fleet contexts) it is a no-op — fail-soft, zero behavior change.
  *
- * Pure + exported for unit testing (opts.heartbeatFn lets a test inject a spy without a live DB).
- * @param {object} rawClient - the unwrapped supabase client
+ * FR-2: a truly-dead session writes no evidence, so this never fires for it and genuine stale-claim
+ * reaping is preserved by construction. Fail-soft: a ping failure is logged and swallowed so it can
+ * never break the evidence write that preceded it.
+ *
+ * Pure-ish + exported for unit testing (heartbeatFn lets a test inject a spy without a live DB).
  * @param {string|undefined|null} sessionId - the owning worker session id (CLAUDE_SESSION_ID)
- * @param {object} [opts] - forwarded to withHeartbeat (e.g. { heartbeatFn })
- * @returns {object} the wrapped client when sessionId is a non-empty string, else rawClient
+ * @param {(sessionId:string)=>Promise<any>} [heartbeatFn] - the heartbeat updater (default updateHeartbeat)
+ * @returns {Promise<boolean>} true if a ping was attempted+succeeded, false if skipped or it failed
  */
-export function resolveEvidenceClient(rawClient, sessionId, opts = {}) {
-  if (!sessionId || typeof sessionId !== 'string' || !sessionId.trim()) return rawClient;
-  return withHeartbeat(rawClient, sessionId, opts);
+export async function touchOwnerHeartbeat(sessionId, heartbeatFn = updateHeartbeat) {
+  if (!sessionId || typeof sessionId !== 'string' || !sessionId.trim()) return false;
+  try {
+    await heartbeatFn(sessionId);
+    return true;
+  } catch (e) {
+    console.warn(`[evidence-heartbeat] claim heartbeat ping failed for ${sessionId}: ${e?.message ?? e}`);
+    return false;
+  }
 }
 
 /**
@@ -222,10 +231,7 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   console.log(`\nStoring ${code} results to database...`);
   const _sdKey = options.sdKey || sdId; // For display/logging purposes
 
-  const rawSupabase = await getSupabaseClient();
-  // FR-1: wrap the client so the sub_agent_execution_results insert below refreshes the owning
-  // worker's claim heartbeat (see resolveEvidenceClient).
-  const supabase = resolveEvidenceClient(rawSupabase, process.env.CLAUDE_SESSION_ID);
+  const supabase = await getSupabaseClient();
 
   // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Normalize sd_id to UUID before insert
   // PAT-FK-SDKEY-001: sub_agent_execution_results.sd_id FK expects UUID, not sd_key
@@ -441,6 +447,11 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   }
 
   console.log(`   Stored with ID: ${data.id}`);
+
+  // SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): the evidence row landed — refresh the
+  // owning worker's claim heartbeat so a long parallel-sub-agent tick keeps the claim alive
+  // (touches at WORK frequency, never crossing the 900s reap boundary). Fail-soft, no-op off-fleet.
+  await touchOwnerHeartbeat(process.env.CLAUDE_SESSION_ID);
 
   // ============================================================================
   // PAT-SUBAGENT-PRD-LINK-001: Auto-link sub-agent results to PRD metadata

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -11,10 +11,36 @@
  */
 
 import { getSupabaseClient } from './supabase-client.js';
+// SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): keep a worker's claim alive across a long
+// tick that spawns parallel sub-agent reviews. withHeartbeat (built by SD-LEO-FIX-SESSION-LIFECYCLE-
+// HYGIENE-001, previously unwired) refreshes claude_sessions.heartbeat_at on every write to the
+// high-traffic tables — sub_agent_execution_results is one — so writing each sub-agent's evidence
+// row touches the owner's claim at WORK frequency, never crossing the 900s reap boundary mid-tick.
+import { withHeartbeat } from '../heartbeat-manager.mjs';
 import { USE_TASK_CONTRACTS, RESULT_COMPRESSION_THRESHOLD, PRD_LINKABLE_SUBAGENTS } from './constants.js';
 import { createArtifact } from '../artifact-tools.js';
 // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
 import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
+
+/**
+ * SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): decide which client a sub-agent evidence
+ * write should use. When a fleet worker session id is supplied (CLAUDE_SESSION_ID — the claim owner
+ * in the fleet model), return the withHeartbeat-wrapped client so the evidence insert refreshes
+ * claude_sessions.heartbeat_at and the claim stays alive through a long parallel-sub-agent tick.
+ * When no session id is supplied (non-fleet contexts), return the raw client unchanged — fail-soft,
+ * zero behavior change. A truly-dead session writes nothing, so it is never kept alive by this
+ * (FR-2: genuine stale-claim reaping is preserved by construction).
+ *
+ * Pure + exported for unit testing (opts.heartbeatFn lets a test inject a spy without a live DB).
+ * @param {object} rawClient - the unwrapped supabase client
+ * @param {string|undefined|null} sessionId - the owning worker session id (CLAUDE_SESSION_ID)
+ * @param {object} [opts] - forwarded to withHeartbeat (e.g. { heartbeatFn })
+ * @returns {object} the wrapped client when sessionId is a non-empty string, else rawClient
+ */
+export function resolveEvidenceClient(rawClient, sessionId, opts = {}) {
+  if (!sessionId || typeof sessionId !== 'string' || !sessionId.trim()) return rawClient;
+  return withHeartbeat(rawClient, sessionId, opts);
+}
 
 /**
  * Normalize confidence value from sub-agent results
@@ -196,7 +222,10 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   console.log(`\nStoring ${code} results to database...`);
   const _sdKey = options.sdKey || sdId; // For display/logging purposes
 
-  const supabase = await getSupabaseClient();
+  const rawSupabase = await getSupabaseClient();
+  // FR-1: wrap the client so the sub_agent_execution_results insert below refreshes the owning
+  // worker's claim heartbeat (see resolveEvidenceClient).
+  const supabase = resolveEvidenceClient(rawSupabase, process.env.CLAUDE_SESSION_ID);
 
   // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Normalize sd_id to UUID before insert
   // PAT-FK-SDKEY-001: sub_agent_execution_results.sd_id FK expects UUID, not sd_key

--- a/tests/unit/subagent-evidence-heartbeat.test.js
+++ b/tests/unit/subagent-evidence-heartbeat.test.js
@@ -1,0 +1,124 @@
+/**
+ * SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001
+ *
+ * A worker's claim is reaped once claude_sessions.heartbeat_at crosses the 900s (15min) boundary
+ * and the stored pid is dead. During a long tick running parallel sub-agent reviews, the original
+ * claim-acquiring `node` process has exited and nothing refreshes heartbeat_at between tool calls,
+ * so a >15min review tick lets the claim lapse → the next handoff trips GATE_CLAIM_VALIDITY_FAILED.
+ *
+ * The fix (FR-1) wires the pre-built withHeartbeat proxy into the canonical sub-agent evidence
+ * writer via resolveEvidenceClient, so each evidence write refreshes the owner's heartbeat at WORK
+ * frequency. These tests pin: (FR-1) the wire mechanism, (FR-2) that genuine reaping is preserved,
+ * and (FR-3) that a heartbeat-refreshed long tick stays claim-valid.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveEvidenceClient } from '../../lib/sub-agent-executor/results-storage.js';
+import { ownerIsDeadByLiveness, isHeartbeatStale, CLAIM_TTL_MS } from '../../lib/claim-validity-gate.js';
+
+/** A minimal PostgREST-like chainable thenable returning a fixed result. */
+function fakeBuilder(result = { data: [{ id: 'evt-1' }], error: null }) {
+  const b = {
+    insert() { return b; },
+    update() { return b; },
+    upsert() { return b; },
+    delete() { return b; },
+    select() { return b; },
+    eq() { return b; },
+    single() { return b; },
+    maybeSingle() { return b; },
+    then(onF, onR) { return Promise.resolve(result).then(onF, onR); },
+    catch(onR) { return Promise.resolve(result).catch(onR); },
+  };
+  return b;
+}
+
+/** A fake supabase client recording which tables were touched. */
+function fakeClient() {
+  const touched = [];
+  return {
+    touched,
+    from(table) { touched.push(table); return fakeBuilder(); },
+  };
+}
+
+describe('resolveEvidenceClient — FR-1 wire (heartbeat on sub-agent evidence write)', () => {
+  it('returns the RAW client unchanged when no session id is provided (fail-soft, non-fleet)', () => {
+    const raw = fakeClient();
+    expect(resolveEvidenceClient(raw, undefined)).toBe(raw);
+    expect(resolveEvidenceClient(raw, null)).toBe(raw);
+    expect(resolveEvidenceClient(raw, '')).toBe(raw);
+    expect(resolveEvidenceClient(raw, '   ')).toBe(raw);
+  });
+
+  it('returns a WRAPPED client (not the raw one) when a session id is provided', () => {
+    const raw = fakeClient();
+    const wrapped = resolveEvidenceClient(raw, 'sess-123', { heartbeatFn: async () => {} });
+    expect(wrapped).not.toBe(raw);
+    expect(typeof wrapped.from).toBe('function');
+  });
+
+  it('fires exactly ONE heartbeat ping for the owner after a sub_agent_execution_results insert', async () => {
+    const raw = fakeClient();
+    const pinged = [];
+    const wrapped = resolveEvidenceClient(raw, 'sess-owner', { heartbeatFn: async (sid) => { pinged.push(sid); } });
+    await wrapped.from('sub_agent_execution_results').insert({ verdict: 'PASS' });
+    // ping is fire-and-forget (microtask) — flush the queue before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(pinged).toEqual(['sess-owner']);
+  });
+
+  it('does NOT fire a heartbeat ping when writing a non-trigger table', async () => {
+    const raw = fakeClient();
+    const pinged = [];
+    const wrapped = resolveEvidenceClient(raw, 'sess-owner', { heartbeatFn: async (sid) => { pinged.push(sid); } });
+    await wrapped.from('some_other_table').insert({ x: 1 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(pinged).toEqual([]);
+  });
+
+  it('is fail-soft: a heartbeat ping rejection never breaks the caller write', async () => {
+    const raw = fakeClient();
+    const wrapped = resolveEvidenceClient(raw, 'sess-owner', { heartbeatFn: async () => { throw new Error('ping boom'); } });
+    const res = await wrapped.from('sub_agent_execution_results').insert({ verdict: 'PASS' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(res.error).toBeNull(); // the insert still resolved fine
+  });
+});
+
+describe('FR-3 — a heartbeat-refreshed long tick stays claim-valid', () => {
+  const now = 1_000_000_000_000; // fixed reference now (ms)
+
+  it('a claim refreshed by recent evidence writes is NOT stale even after the original 15min would have elapsed', () => {
+    // The evidence writes refreshed heartbeat_at to "60s ago" — well under the 900s TTL — so the
+    // claim that was ACQUIRED >15min ago is nonetheless live (the refresh reset the clock).
+    const refreshedHeartbeat = new Date(now - 60_000).toISOString();
+    expect(isHeartbeatStale(refreshedHeartbeat, now)).toBe(false);
+  });
+
+  it('a live-but-busy owner (is_alive=true) is never declared dead by liveness, refreshed or not', () => {
+    const busyOwner = { is_alive: true, status: 'active', heartbeat_at: new Date(now - 60_000).toISOString() };
+    expect(ownerIsDeadByLiveness(busyOwner, now)).toBe(false);
+  });
+});
+
+describe('FR-2 — genuine stale-claim reaping is preserved', () => {
+  const now = 1_000_000_000_000;
+
+  it('a no-write session (stale heartbeat + is_alive=false) is STILL declared dead', () => {
+    const deadOwner = { is_alive: false, status: 'active', heartbeat_at: new Date(now - (CLAIM_TTL_MS + 60_000)).toISOString() };
+    expect(ownerIsDeadByLiveness(deadOwner, now)).toBe(true);
+  });
+
+  it('a heartbeat older than the 900s TTL is stale', () => {
+    expect(isHeartbeatStale(new Date(now - (CLAIM_TTL_MS + 1)).toISOString(), now)).toBe(true);
+  });
+
+  it('a released/stale-status owner is dead regardless of heartbeat', () => {
+    expect(ownerIsDeadByLiveness({ status: 'released', is_alive: true, heartbeat_at: new Date(now).toISOString() }, now)).toBe(true);
+    expect(ownerIsDeadByLiveness({ status: 'stale', is_alive: true, heartbeat_at: new Date(now).toISOString() }, now)).toBe(true);
+  });
+
+  it('a null owner is dead', () => {
+    expect(ownerIsDeadByLiveness(null, now)).toBe(true);
+  });
+});

--- a/tests/unit/subagent-evidence-heartbeat.test.js
+++ b/tests/unit/subagent-evidence-heartbeat.test.js
@@ -12,76 +12,42 @@
  * and (FR-3) that a heartbeat-refreshed long tick stays claim-valid.
  */
 import { describe, it, expect } from 'vitest';
-import { resolveEvidenceClient } from '../../lib/sub-agent-executor/results-storage.js';
+import { touchOwnerHeartbeat } from '../../lib/sub-agent-executor/results-storage.js';
 import { ownerIsDeadByLiveness, isHeartbeatStale, CLAIM_TTL_MS } from '../../lib/claim-validity-gate.js';
 
-/** A minimal PostgREST-like chainable thenable returning a fixed result. */
-function fakeBuilder(result = { data: [{ id: 'evt-1' }], error: null }) {
-  const b = {
-    insert() { return b; },
-    update() { return b; },
-    upsert() { return b; },
-    delete() { return b; },
-    select() { return b; },
-    eq() { return b; },
-    single() { return b; },
-    maybeSingle() { return b; },
-    then(onF, onR) { return Promise.resolve(result).then(onF, onR); },
-    catch(onR) { return Promise.resolve(result).catch(onR); },
-  };
-  return b;
-}
-
-/** A fake supabase client recording which tables were touched. */
-function fakeClient() {
-  const touched = [];
-  return {
-    touched,
-    from(table) { touched.push(table); return fakeBuilder(); },
-  };
-}
-
-describe('resolveEvidenceClient — FR-1 wire (heartbeat on sub-agent evidence write)', () => {
-  it('returns the RAW client unchanged when no session id is provided (fail-soft, non-fleet)', () => {
-    const raw = fakeClient();
-    expect(resolveEvidenceClient(raw, undefined)).toBe(raw);
-    expect(resolveEvidenceClient(raw, null)).toBe(raw);
-    expect(resolveEvidenceClient(raw, '')).toBe(raw);
-    expect(resolveEvidenceClient(raw, '   ')).toBe(raw);
-  });
-
-  it('returns a WRAPPED client (not the raw one) when a session id is provided', () => {
-    const raw = fakeClient();
-    const wrapped = resolveEvidenceClient(raw, 'sess-123', { heartbeatFn: async () => {} });
-    expect(wrapped).not.toBe(raw);
-    expect(typeof wrapped.from).toBe('function');
-  });
-
-  it('fires exactly ONE heartbeat ping for the owner after a sub_agent_execution_results insert', async () => {
-    const raw = fakeClient();
+describe('touchOwnerHeartbeat — FR-1 (refresh claim heartbeat on sub-agent evidence write)', () => {
+  it('is a no-op (returns false, no ping) when no session id is provided (non-fleet, fail-soft)', async () => {
     const pinged = [];
-    const wrapped = resolveEvidenceClient(raw, 'sess-owner', { heartbeatFn: async (sid) => { pinged.push(sid); } });
-    await wrapped.from('sub_agent_execution_results').insert({ verdict: 'PASS' });
-    // ping is fire-and-forget (microtask) — flush the queue before asserting.
-    await new Promise((r) => setTimeout(r, 0));
-    expect(pinged).toEqual(['sess-owner']);
-  });
-
-  it('does NOT fire a heartbeat ping when writing a non-trigger table', async () => {
-    const raw = fakeClient();
-    const pinged = [];
-    const wrapped = resolveEvidenceClient(raw, 'sess-owner', { heartbeatFn: async (sid) => { pinged.push(sid); } });
-    await wrapped.from('some_other_table').insert({ x: 1 });
-    await new Promise((r) => setTimeout(r, 0));
+    const spy = async (sid) => { pinged.push(sid); };
+    expect(await touchOwnerHeartbeat(undefined, spy)).toBe(false);
+    expect(await touchOwnerHeartbeat(null, spy)).toBe(false);
+    expect(await touchOwnerHeartbeat('', spy)).toBe(false);
+    expect(await touchOwnerHeartbeat('   ', spy)).toBe(false);
     expect(pinged).toEqual([]);
   });
 
-  it('is fail-soft: a heartbeat ping rejection never breaks the caller write', async () => {
-    const raw = fakeClient();
-    const wrapped = resolveEvidenceClient(raw, 'sess-owner', { heartbeatFn: async () => { throw new Error('ping boom'); } });
-    const res = await wrapped.from('sub_agent_execution_results').insert({ verdict: 'PASS' });
-    await new Promise((r) => setTimeout(r, 0));
-    expect(res.error).toBeNull(); // the insert still resolved fine
+  it('fires exactly ONE heartbeat ping for the owning session when a session id is provided', async () => {
+    const pinged = [];
+    const ok = await touchOwnerHeartbeat('sess-owner', async (sid) => { pinged.push(sid); });
+    expect(ok).toBe(true);
+    expect(pinged).toEqual(['sess-owner']);
+  });
+
+  it('is fail-soft: a ping rejection is swallowed (returns false, does not throw)', async () => {
+    let returned;
+    await expect(
+      (async () => { returned = await touchOwnerHeartbeat('sess-owner', async () => { throw new Error('ping boom'); }); })()
+    ).resolves.toBeUndefined(); // the call itself never rejects
+    expect(returned).toBe(false);
+  });
+
+  it('FR-2 by construction: a session that performs no evidence write never pings (no zombie heartbeat)', async () => {
+    // touchOwnerHeartbeat is only reached AFTER an evidence row lands. A dead session writes nothing,
+    // so this is never called for it. We assert the guard itself never pings without a session id —
+    // i.e. it cannot fabricate liveness for a session that did no work.
+    const pinged = [];
+    await touchOwnerHeartbeat(undefined, async (sid) => { pinged.push(sid); });
+    expect(pinged).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Problem
A worker's claim is reaped once `claude_sessions.heartbeat_at` crosses the 900s (15min) boundary and the stored pid is dead. During a long worker tick that runs **parallel sub-agent reviews**, the short-lived `node` process that acquired the claim has already exited and nothing refreshes `heartbeat_at` between tool calls — so a >15min review tick lets the claim lapse, and the next handoff trips `GATE_CLAIM_VALIDITY_FAILED` + deconflict churn.

## Fix (FR-1, preferred HEARTBEAT approach)
After each sub-agent evidence row lands, `lib/sub-agent-executor/results-storage.js` calls a new exported `touchOwnerHeartbeat(process.env.CLAUDE_SESSION_ID)` that invokes `updateHeartbeat` directly — refreshing the owner's `heartbeat_at` at **work frequency**, so the claim never crosses the reap boundary mid-tick.

- **FR-2 (reaping preserved by construction):** no edits to the sweep, the claim-validity gate, the TTL constants, or claim-guard. A truly-dead session writes no evidence → never pings → still reaped.
- **FR-3:** `tests/unit/subagent-evidence-heartbeat.test.js` (10 tests).
- **FR-4:** extends SESSION-CLAIM-LIFECYCLE-001 (TTL *length*) on the orthogonal *freshness* axis.

## Why not the withHeartbeat proxy
The first implementation wrapped the supabase client with the pre-built `withHeartbeat` proxy (from SESSION-LIFECYCLE-HYGIENE-001). **Adversarial review + a proper worktree live-smoke caught that this breaks every chained `.insert().select().single()` write** — `wrapThenable` does `{ ...thenable }`, dropping a supabase-js v2 builder's prototype methods (`select is not a function`). The proxy's own tests use own-method fake builders that mask the bug. The fix sidesteps the proxy entirely (explicit ping), reusing the same underlying `updateHeartbeat`. The proxy bug is flagged for a follow-up.

## Verification
- Worktree live-smoke: backdated heartbeat 8min → after one evidence write **age 0s**, chained insert did **not** throw.
- 10 new tests + 27 existing `withHeartbeat` tests green.
- Handoffs: LEAD-TO-PLAN 94 / PLAN-TO-EXEC 98 / EXEC-TO-PLAN 94 / PLAN-TO-LEAD 96. TESTING+SECURITY @ EXEC, VALIDATION+REGRESSION @ PLAN_VERIFICATION (all PASS). Adversarial review: BLOCK → corrected → SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
