### PR TITLE
feat(SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001): cross-repo guards auth via EHG_RO_PAT + fail-loud

### DIFF
--- a/.github/workflows/design-prompts-cross-repo.yml
+++ b/.github/workflows/design-prompts-cross-repo.yml
@@ -11,9 +11,11 @@ name: Design Prompts Cross-Repo Parity
 # (the QF/PR #3941 class of drift). The twin workflow lives in rickfelix/ehg and
 # triggers on the frontend copy.
 #
-# ADVISORY: continue-on-error: true. Flip to blocking (remove that line + add
-# "Design Prompts Cross-Repo Parity" to required status checks) in a 1-line
-# follow-up once the false-positive rate is confirmed ~0.
+# ADVISORY (content divergence only): the DIVERGENCE compare is advisory at the
+# STEP level (continue-on-error on the compare step). A configured-token cross-repo
+# checkout FAILURE is now BLOCKING (SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 FR-3
+# removed the job-level continue-on-error). To make divergence itself blocking, drop
+# the compare step's continue-on-error + add this workflow to required status checks.
 
 on:
   pull_request:

--- a/.github/workflows/design-prompts-cross-repo.yml
+++ b/.github/workflows/design-prompts-cross-repo.yml
@@ -33,7 +33,11 @@ jobs:
   parity:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true  # ADVISORY; remove this line to make blocking
+    # SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 (FR-3): job-level continue-on-error REMOVED so a
+    # configured-token cross-repo-checkout FAILURE (token lapse/expiry) actually fails the job and is
+    # surfaced — it green-masked the broken guard for ~12 days. The design-prompts DIVERGENCE result
+    # stays advisory at the STEP level (continue-on-error on the compare step) so only a real token
+    # regression is blocking, not a content divergence.
     steps:
       - name: Checkout EHG_Engineer
         uses: actions/checkout@v4
@@ -50,13 +54,28 @@ jobs:
         with:
           repository: rickfelix/ehg
           path: ehg-sibling
-          token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.GITHUB_TOKEN }}
+          # SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 (FR-1): fall back to the scoped
+          # cross-repo PAT (EHG_RO_PAT), NOT the default GITHUB_TOKEN — the default can't read the
+          # private rickfelix/ehg, so it 404'd and the guard was silently skipped. Mirrors the
+          # now-working exec-email cron (GH_TOKEN_CROSS_REPO || EHG_RO_PAT).
+          token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.EHG_RO_PAT }}
           fetch-depth: 1
 
-      - name: Sibling repo unreachable (advisory skip)
+      # SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 (FR-3): distinguish "no token configured"
+      # (clean advisory skip) from "token configured but checkout FAILED" (real regression — fail loud).
+      # Secrets are mapped to env (the supported pattern; secrets are not directly testable in bash) so a
+      # token lapse/expiry surfaces instead of being silently warned-and-skipped like a missing token.
+      - name: Sibling checkout outcome gate
         if: steps.sibling_checkout.outcome != 'success'
+        env:
+          EHG_RO_PAT: ${{ secrets.EHG_RO_PAT }}
+          GH_TOKEN_CROSS_REPO: ${{ secrets.GH_TOKEN_CROSS_REPO }}
         run: |
-          echo "::warning ::Could not check out the sibling rickfelix/ehg repo (private; needs the GH_TOKEN_CROSS_REPO secret). Skipping the S17/S19 design-prompts cross-repo comparison. Set GH_TOKEN_CROSS_REPO to enable it. SD-FDBK-FIX-DRIFT-CHECK-FAILS-001."
+          if [ -n "$EHG_RO_PAT" ] || [ -n "$GH_TOKEN_CROSS_REPO" ]; then
+            echo "::error ::Cross-repo checkout of rickfelix/ehg FAILED despite a configured token (EHG_RO_PAT / GH_TOKEN_CROSS_REPO) — the token likely EXPIRED or lost access. The S17/S19 design-prompts drift guard is DISABLED until the secret is rotated. SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001."
+            exit 1
+          fi
+          echo "::warning ::No cross-repo token configured (EHG_RO_PAT / GH_TOKEN_CROSS_REPO) — skipping the S17/S19 design-prompts cross-repo comparison (advisory). Set EHG_RO_PAT to enable it."
 
       - name: Setup Node
         if: steps.sibling_checkout.outcome == 'success'
@@ -65,10 +84,12 @@ jobs:
           node-version: '20'
 
       - name: Compare shared design-prompts checksum across repos
+        id: compare_prompts
         if: steps.sibling_checkout.outcome == 'success'
+        continue-on-error: true  # FR-3: DIVERGENCE stays advisory (only a token regression is blocking)
         run: node scripts/design-prompts-cross-repo-check.mjs ehg-sibling/src/components/stage17/gvos/shared-design-prompts.json
 
       - name: Note about advisory mode
-        if: failure()
+        if: steps.compare_prompts.outcome == 'failure'
         run: |
-          echo "::warning ::S17/S19 shared design-prompts diverged. This gate is in advisory mode (continue-on-error). Re-vendor the shared JSON into both repos and run 'npm run design-prompts:sync'. See SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001."
+          echo "::warning ::S17/S19 shared design-prompts diverged. This comparison is advisory. Re-vendor the shared JSON into both repos and run 'npm run design-prompts:sync'. See SD-LEO-INFRA-UNIFY-STAGE-DESIGN-001."

--- a/.github/workflows/venture-stages-drift-guard.yml
+++ b/.github/workflows/venture-stages-drift-guard.yml
@@ -12,9 +12,11 @@ name: Venture Stages Drift Guard
 # on-disk existence in the checked-out ehg sibling. It runs on PRs/pushes that
 # touch the generator, the committed stage-config.js, or this workflow.
 #
-# ADVISORY: continue-on-error: true. Flip to blocking (remove that line + add
-# "Venture Stages Drift Guard" to required status checks) in a 1-line follow-up
-# once the false-positive rate is confirmed ~0. Modeled on
+# ADVISORY (content drift only): the DRIFT compare is advisory at the STEP level
+# (continue-on-error on the drift_check step). A configured-token cross-repo checkout
+# FAILURE is now BLOCKING (SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 FR-3 removed
+# the job-level continue-on-error). To make drift itself blocking, drop the drift_check
+# step's continue-on-error + add this workflow to required status checks. Modeled on
 # .github/workflows/design-prompts-cross-repo.yml + schema-drift-guard.yml.
 
 on:

--- a/.github/workflows/venture-stages-drift-guard.yml
+++ b/.github/workflows/venture-stages-drift-guard.yml
@@ -38,7 +38,10 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true # ADVISORY; remove this line to make blocking
+    # SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 (FR-3): job-level continue-on-error REMOVED so a
+    # configured-token cross-repo-checkout FAILURE (token lapse/expiry) fails the job and is surfaced —
+    # it green-masked the broken guard for ~12 days. The venture_stages DRIFT result stays advisory at
+    # the STEP level so only a real token regression is blocking, not a content drift.
     steps:
       - name: Checkout EHG_Engineer
         uses: actions/checkout@v4
@@ -55,13 +58,24 @@ jobs:
         with:
           repository: rickfelix/ehg
           path: ehg-sibling
-          token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.GITHUB_TOKEN }}
+          # FR-2: fall back to the scoped cross-repo PAT (EHG_RO_PAT), NOT the default GITHUB_TOKEN
+          # (which can't read the private rickfelix/ehg). Mirrors the exec-email cron.
+          token: ${{ secrets.GH_TOKEN_CROSS_REPO || secrets.EHG_RO_PAT }}
           fetch-depth: 1
 
-      - name: Sibling repo unreachable (advisory skip)
+      # FR-3: distinguish "no token configured" (advisory skip) from "token configured but checkout
+      # FAILED" (real regression — fail loud). Secrets mapped to env so a lapse/expiry surfaces.
+      - name: Sibling checkout outcome gate
         if: steps.sibling_checkout.outcome != 'success'
+        env:
+          EHG_RO_PAT: ${{ secrets.EHG_RO_PAT }}
+          GH_TOKEN_CROSS_REPO: ${{ secrets.GH_TOKEN_CROSS_REPO }}
         run: |
-          echo "::warning ::Could not check out the sibling rickfelix/ehg repo (private; needs the GH_TOKEN_CROSS_REPO secret). Skipping the venture_stages cross-repo drift check. Set GH_TOKEN_CROSS_REPO to enable it. SD-FDBK-FIX-DRIFT-CHECK-FAILS-001."
+          if [ -n "$EHG_RO_PAT" ] || [ -n "$GH_TOKEN_CROSS_REPO" ]; then
+            echo "::error ::Cross-repo checkout of rickfelix/ehg FAILED despite a configured token (EHG_RO_PAT / GH_TOKEN_CROSS_REPO) — the token likely EXPIRED or lost access. The venture_stages drift guard is DISABLED until the secret is rotated. SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001."
+            exit 1
+          fi
+          echo "::warning ::No cross-repo token configured (EHG_RO_PAT / GH_TOKEN_CROSS_REPO) — skipping the venture_stages cross-repo drift check (advisory). Set EHG_RO_PAT to enable it."
 
       - name: Setup Node
         if: steps.sibling_checkout.outcome == 'success'
@@ -74,7 +88,9 @@ jobs:
         run: npm install --no-audit --no-fund @supabase/supabase-js dotenv
 
       - name: Check venture_stages <-> artifacts drift
+        id: drift_check
         if: steps.sibling_checkout.outcome == 'success'
+        continue-on-error: true  # FR-3: DRIFT stays advisory (only a token regression is blocking)
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -84,6 +100,6 @@ jobs:
         run: node scripts/generate-stage-config.cjs --check
 
       - name: Note about advisory mode
-        if: failure()
+        if: steps.drift_check.outcome == 'failure'
         run: |
-          echo "::warning ::venture_stages drifted from stage-config.js and/or ehg venture-workflow.ts. This gate is in advisory mode (continue-on-error). Regenerate with 'npm run venture-stages:generate' (in EHG_Engineer) and commit both artifacts. See SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-D."
+          echo "::warning ::venture_stages drifted from stage-config.js and/or ehg venture-workflow.ts. This drift check is advisory. Regenerate with 'npm run venture-stages:generate' (in EHG_Engineer) and commit both artifacts. See SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-D."

--- a/tests/unit/crossrepo-drift-guards.test.js
+++ b/tests/unit/crossrepo-drift-guards.test.js
@@ -1,0 +1,63 @@
+/**
+ * SD-LEO-INFRA-CROSSREPO-DRIFT-GUARDS-EHG-PAT-001 — config-coherence regression guard for the two
+ * cross-repo drift workflows. Pins: (FR-1/FR-2) the sibling checkout uses the scoped EHG_RO_PAT, not
+ * the default GITHUB_TOKEN; (FR-3) the job-level continue-on-error is removed so a configured-token
+ * checkout FAILURE actually fails the job, while the DIVERGENCE/DRIFT compare stays advisory at the
+ * step level. Parses the YAML so a future revert (re-adding GITHUB_TOKEN or job-level
+ * continue-on-error) is caught here, not silently after a 12-day green-mask.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const yaml = require('js-yaml');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const WORKFLOWS = [
+  { file: '.github/workflows/design-prompts-cross-repo.yml', compareStepId: 'compare_prompts' },
+  { file: '.github/workflows/venture-stages-drift-guard.yml', compareStepId: 'drift_check' },
+];
+
+function loadJob(file) {
+  const doc = yaml.load(readFileSync(join(repoRoot, file), 'utf8'));
+  return Object.values(doc.jobs)[0];
+}
+
+describe.each(WORKFLOWS)('cross-repo drift workflow $file', ({ file, compareStepId }) => {
+  const job = loadJob(file);
+  const steps = job.steps;
+  const sibling = steps.find((s) => s.id === 'sibling_checkout');
+  const gate = steps.find((s) => s.name === 'Sibling checkout outcome gate');
+  const compare = steps.find((s) => s.id === compareStepId);
+
+  it('FR-1/FR-2: the sibling checkout token falls back to EHG_RO_PAT, NOT GITHUB_TOKEN', () => {
+    expect(sibling).toBeTruthy();
+    const token = sibling.with.token;
+    expect(token).toContain('EHG_RO_PAT');
+    expect(token).not.toContain('GITHUB_TOKEN');
+  });
+
+  it('FR-3: job-level continue-on-error is REMOVED (a token-lapse checkout failure fails the job)', () => {
+    expect('continue-on-error' in job).toBe(false);
+  });
+
+  it('FR-3: an outcome gate fails LOUD (exit 1) only when a token is configured', () => {
+    expect(gate).toBeTruthy();
+    expect(gate.if).toContain("steps.sibling_checkout.outcome != 'success'");
+    // maps both token secrets to env so a configured-but-failed checkout is distinguishable
+    expect(gate.env).toHaveProperty('EHG_RO_PAT');
+    expect(gate.env).toHaveProperty('GH_TOKEN_CROSS_REPO');
+    expect(gate.run).toContain('exit 1');     // configured token + failure -> hard fail
+    expect(gate.run).toContain('::error');     // loud annotation
+    expect(gate.run).toContain('::warning');   // no token -> advisory skip
+  });
+
+  it('FR-3: the divergence/drift compare stays ADVISORY at the step level', () => {
+    expect(compare).toBeTruthy();
+    expect(compare['continue-on-error']).toBe(true);
+    expect(compare.if).toContain("steps.sibling_checkout.outcome == 'success'");
+  });
+});


### PR DESCRIPTION
## Summary
The two cross-repo drift guards (`design-prompts-cross-repo.yml`, `venture-stages-drift-guard.yml`) shallow-clone the PRIVATE `rickfelix/ehg` sibling to byte-compare twinned artifacts — but the sibling `actions/checkout` token fell back to `secrets.GITHUB_TOKEN` (which cannot read a private cross-repo) so it 404'd, and a **job-level** `continue-on-error: true` masked that as a silent green skip for ~12 days.

## Changes
- **FR-1/FR-2**: repoint the sibling checkout token fallback to `${{ secrets.GH_TOKEN_CROSS_REPO || secrets.EHG_RO_PAT }}` (mirrors the fixed exec-email vision cron).
- **FR-3 (anti-silent-regression)**: remove the **job-level** `continue-on-error` so a configured-token checkout FAILURE fails the job; add a **'Sibling checkout outcome gate'** step that maps both token secrets to env and fails LOUD (`::error` + `exit 1`) **only when a token is configured** (real lapse/expiry), else an advisory `::warning` skip. The divergence/drift compare stays advisory at the **step** level.
- **FR-5**: `tests/unit/crossrepo-drift-guards.test.js` (8 tests) pins the contract so a revert (re-adding GITHUB_TOKEN or job-level continue-on-error) fails at test time.

## Test
`npx vitest run tests/unit/crossrepo-drift-guards.test.js` → 8/8 pass. Workflow-YAML-only + one new test; no app code, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)