### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001): chairman decision-queue lane (sourcing engine 4/10)

### DIFF
--- a/database/migrations/20260620_sourcing_chairman_queue.sql
+++ b/database/migrations/20260620_sourcing_chairman_queue.sql
@@ -1,0 +1,42 @@
+-- SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001 (FR-1 / FR-2)
+-- Sourcing engine child 4/10 — the chairman decision-queue lane.
+--
+-- A durable home for candidates the router lanes to 'chairman-gated' (needs an authority only the
+-- chairman can grant: grant/rls/credential/operational/vision) or escalates as 'outcome-gated'. Without
+-- it, gated items have nowhere to land and the engine can't run hands-off-except-at-input-points. The
+-- escalator (lib/sourcing-engine/escalator.js) writes ONE row per (source_id, gate_type) — a tracked
+-- decision row with an SLA + state, not a transient prose ask.
+--
+-- DORMANT: the fleet AUTHORS + TESTS this migration; workers CANNOT self-apply prod. Adam applies this
+-- ADDITIVE CREATE TABLE via the database-agent under the chairman's additive-DDL delegation. A bare
+-- CREATE TABLE is additive and NOT chairman-gated; the chairman is paged ONLY if an RLS policy is later
+-- required (deferred — this table is fleet-internal queue state, read/written by the engine, not a
+-- user-facing surface). Until applied, the escalator fail-softs (PGRST205/PGRST204 -> degraded, no throw).
+--
+-- Idempotent (IF NOT EXISTS) so a re-run is a no-op.
+
+CREATE TABLE IF NOT EXISTS sourcing_chairman_queue (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_id       text,                          -- the candidate's source ref (conversion_ledger / roadmap item)
+  title           text,
+  lane            text NOT NULL,                 -- the router lane that queued it: 'chairman-gated' | 'outcome-gated'
+  gate_type       text NOT NULL,                 -- the gate kind (same axis as lane; part of the idempotency key)
+  escalation_type text,                          -- chairman authority (grant|rls|credential|operational|vision) or 'outcome'
+  context         jsonb NOT NULL DEFAULT '{}'::jsonb,  -- the routed payload: { rung, disposition, escalation, enablers }
+  sla_hours       integer,                       -- the decision SLA window (hours)
+  sla_due_at      timestamptz,                   -- created_at + sla_hours (when the decision is due)
+  state           text NOT NULL DEFAULT 'pending'
+                    CHECK (state IN ('pending', 'decided', 'deferred_until', 'escalated')),
+  deferred_until  timestamptz,                   -- set when state = 'deferred_until'
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  decided_at      timestamptz,                   -- set when state leaves 'pending'
+  -- Idempotency: one open queue row per (item, gate). The escalator upserts on this key, so a re-run of
+  -- the router over the same candidate never duplicates the chairman ask.
+  UNIQUE (source_id, gate_type)
+);
+
+-- Fast lookups for the pending decision queue (the chairman/Adam reader) and SLA breach scans.
+CREATE INDEX IF NOT EXISTS idx_sourcing_chairman_queue_state ON sourcing_chairman_queue (state);
+CREATE INDEX IF NOT EXISTS idx_sourcing_chairman_queue_sla   ON sourcing_chairman_queue (sla_due_at) WHERE state = 'pending';
+
+COMMENT ON TABLE sourcing_chairman_queue IS 'Sourcing-engine chairman decision-queue lane (chairman-gated + outcome-gated candidates). Writer: lib/sourcing-engine/escalator.js. SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001.';

--- a/lib/sourcing-engine/escalator.js
+++ b/lib/sourcing-engine/escalator.js
@@ -1,0 +1,96 @@
+/**
+ * Sourcing-engine chairman decision-queue escalator.
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001 (FR-2 / FR-3) — child 4/10.
+ *
+ * Consumes the router's routeCandidate output (lib/sourcing-engine/router.js) and, for a candidate
+ * laned chairman-gated or outcome-gated, writes ONE tracked decision row to sourcing_chairman_queue
+ * (database/migrations/20260620_sourcing_chairman_queue.sql) with an SLA + state='pending'. Idempotent
+ * on (source_id, gate_type). Fail-soft while the table is DORMANT (not yet applied) — never throws.
+ */
+import { LANE } from './lane.js';
+
+/** Default decision SLA windows (hours), by gate. Declared here; the reader (chairman/Adam) enforces. */
+export const DEFAULT_SLA_HOURS = Object.freeze({
+  [LANE.CHAIRMAN_GATED]: 72,   // 3 days for an authority grant (grant/rls/credential/operational/vision)
+  [LANE.OUTCOME_GATED]: 168,   // 7 days — waits on an operational outcome before it is buildable
+});
+
+/** The two router lanes that land in the chairman decision queue. */
+export const QUEUE_LANES = Object.freeze([LANE.CHAIRMAN_GATED, LANE.OUTCOME_GATED]);
+
+// Table/column-absent codes (PostgREST PGRST205/204, Postgres 42P01) => the migration is DORMANT; fail-soft.
+const DORMANT_CODES = new Set(['PGRST205', 'PGRST204', '42P01']);
+
+/**
+ * Build the chairman-queue row for a routed candidate, or null if its lane is not a queue lane.
+ * PURE — no IO. `item` is the classified candidate (source_id/title); `routed` is routeCandidate output.
+ * @param {{source_id?:string, title?:string}} item
+ * @param {{lane?:string, rung?:string|null, disposition?:string|null, escalation?:object, enablers?:string[]}} routed
+ * @param {{slaHours?:number}} [opts]
+ * @returns {object|null}
+ */
+export function buildQueueRow(item = {}, routed = {}, opts = {}) {
+  const lane = routed && routed.lane;
+  if (!QUEUE_LANES.includes(lane)) return null;
+  const escalation_type = lane === LANE.CHAIRMAN_GATED
+    ? ((routed.escalation && routed.escalation.reason) || 'chairman')
+    : 'outcome';
+  const slaHours = opts.slaHours != null ? opts.slaHours : DEFAULT_SLA_HOURS[lane];
+  return {
+    source_id: item.source_id != null ? item.source_id : null,
+    title: item.title != null ? item.title : null,
+    lane,
+    gate_type: lane,
+    escalation_type,
+    context: {
+      rung: routed.rung != null ? routed.rung : null,
+      disposition: routed.disposition != null ? routed.disposition : null,
+      escalation: routed.escalation || null,
+      enablers: Array.isArray(routed.enablers) ? routed.enablers : [],
+    },
+    sla_hours: slaHours != null ? slaHours : null,
+    state: 'pending',
+  };
+}
+
+/**
+ * Escalate a routed candidate to the chairman queue (idempotent upsert). NEVER throws; returns a
+ * verdict object. Fail-soft when the client is missing or the table is absent (DORMANT).
+ * @param {object} item   - classified candidate (source_id/title)
+ * @param {object} routed - routeCandidate output
+ * @param {{ supabase?:object, nowIso?:string, slaHours?:number }} [deps]
+ * @returns {Promise<{escalated:boolean, reason?:string, id?:string|null, deduped?:boolean, degraded?:boolean, error?:string}>}
+ */
+export async function escalateToChairmanQueue(item, routed, deps = {}) {
+  const row = buildQueueRow(item, routed, { slaHours: deps.slaHours });
+  if (!row) return { escalated: false, reason: 'not_a_gated_lane' };
+  // Idempotency depends on UNIQUE (source_id, gate_type); in Postgres NULL != NULL, so a null
+  // source_id would defeat the upsert conflict and re-insert on every router pass. Refuse it loudly
+  // — a real candidate always carries a source ref (conversion_ledger / roadmap id).
+  if (row.source_id == null || row.source_id === '') return { escalated: false, reason: 'no_source_id' };
+  const supabase = deps.supabase;
+  if (!supabase) return { escalated: false, reason: 'no_client' };
+  if (row.sla_hours != null) {
+    const now = deps.nowIso ? new Date(deps.nowIso) : new Date();
+    row.sla_due_at = new Date(now.getTime() + row.sla_hours * 3600 * 1000).toISOString();
+  }
+  let data, error;
+  try {
+    ({ data, error } = await supabase
+      .from('sourcing_chairman_queue')
+      .upsert(row, { onConflict: 'source_id,gate_type', ignoreDuplicates: true })
+      .select('id'));
+  } catch (e) {
+    return { escalated: false, reason: 'threw', degraded: true, error: e && e.message };
+  }
+  if (error) {
+    if (DORMANT_CODES.has(error.code) || /Could not find the table|does not exist/i.test(error.message || '')) {
+      return { escalated: false, reason: 'table_absent_dormant', degraded: true };
+    }
+    return { escalated: false, reason: 'error', error: error.message };
+  }
+  // With ignoreDuplicates, a conflict returns no row — still a success (the item is already queued).
+  const id = data && data[0] && data[0].id;
+  return { escalated: true, id: id || null, deduped: !id };
+}

--- a/tests/unit/sourcing-engine/escalator.db.test.js
+++ b/tests/unit/sourcing-engine/escalator.db.test.js
@@ -1,0 +1,25 @@
+// SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001 (FR-1/FR-4) — DB-tier DORMANT live probe.
+//
+// Confirmatory-only: a SUCCESSFUL select proves sourcing_chairman_queue exists once Adam applies the
+// migration. ANY inability to verify — no creds, network unreachable, or PGRST205/42P01 table-absent
+// (not applied yet) — SKIPS rather than fails. Green hermetically; becomes a real PASS only when the
+// table is live AND the DB is reachable. Lives in *.db.test.js so the unit tier stays hermetic.
+import { describe, it, expect } from 'vitest';
+
+describe('sourcing_chairman_queue live probe (FR-1 — dormant: skip until applied)', () => {
+  it('the table exists + carries the gate columns once the migration is applied', async (ctx) => {
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return ctx.skip();
+    let error;
+    try {
+      const { createClient } = await import('@supabase/supabase-js');
+      const s = createClient(url, key);
+      ({ error } = await s.from('sourcing_chairman_queue').select('id, lane, gate_type, state, sla_due_at').limit(1));
+    } catch {
+      return ctx.skip(); // DB unreachable — cannot verify, do not false-fail
+    }
+    if (error) return ctx.skip(); // PGRST205/42P01 (dormant) or any connection error => skip
+    expect(error).toBeNull(); // reached only when the table is present and queryable
+  });
+});

--- a/tests/unit/sourcing-engine/escalator.test.js
+++ b/tests/unit/sourcing-engine/escalator.test.js
@@ -1,0 +1,186 @@
+// SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001 (FR-4)
+// Guards the chairman decision-queue escalator: per-lane row building, the idempotent fail-soft upsert,
+// the migration-file content, and the FR-3 integration with the shipped routeCandidate. Hermetic — the
+// DORMANT live table probe lives in escalator.db.test.js so the unit tier stays DB-free.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildQueueRow,
+  escalateToChairmanQueue,
+  DEFAULT_SLA_HOURS,
+  QUEUE_LANES,
+} from '../../../lib/sourcing-engine/escalator.js';
+import { LANE } from '../../../lib/sourcing-engine/lane.js';
+import { routeCandidate } from '../../../lib/sourcing-engine/router.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SQL = readFileSync(path.join(REPO_ROOT, 'database/migrations/20260620_sourcing_chairman_queue.sql'), 'utf8');
+
+// A recording supabase stub: from().upsert().select() resolves to `result`; records the upsert call.
+function recordingSupabase(result = { data: [{ id: 'q1' }], error: null }) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      const q = { table };
+      const api = {
+        upsert(row, opts) { q.op = 'upsert'; q.row = row; q.opts = opts; calls.push(q); return api; },
+        select(cols) { q.select = cols; return api; },
+        then(resolve) { return resolve(result); },
+      };
+      return api;
+    },
+  };
+}
+
+// --- FR-2/FR-3: buildQueueRow (pure) ---------------------------------------------------------------
+describe('buildQueueRow (FR-2)', () => {
+  it('a chairman-gated routed candidate produces a pending row with the authority + a 72h SLA', () => {
+    const item = { source_id: 'src-1', title: 'needs a credential' };
+    const routed = { lane: LANE.CHAIRMAN_GATED, rung: 'V1', disposition: 'BUILD', escalation: { to: 'chairman', reason: 'credential' } };
+    const row = buildQueueRow(item, routed);
+    expect(row).toMatchObject({
+      source_id: 'src-1', title: 'needs a credential',
+      lane: 'chairman-gated', gate_type: 'chairman-gated',
+      escalation_type: 'credential', sla_hours: 72, state: 'pending',
+    });
+    expect(row.context).toMatchObject({ rung: 'V1', disposition: 'BUILD', escalation: { reason: 'credential' } });
+  });
+
+  it('an outcome-gated routed candidate escalates with type=outcome, its enablers, and a 168h SLA', () => {
+    const routed = { lane: LANE.OUTCOME_GATED, rung: 'V2', enablers: ['SD-X-001'] };
+    const row = buildQueueRow({ source_id: 'src-2' }, routed);
+    expect(row).toMatchObject({ lane: 'outcome-gated', gate_type: 'outcome-gated', escalation_type: 'outcome', sla_hours: 168, state: 'pending' });
+    expect(row.context.enablers).toEqual(['SD-X-001']);
+    expect(row.context.rung).toBe('V2');
+  });
+
+  it('returns null for non-queue lanes (belt-ready / dedup / blocked-on / decline)', () => {
+    for (const lane of [LANE.BELT_READY, LANE.DEDUP, LANE.DECLINE, 'blocked-on', undefined]) {
+      expect(buildQueueRow({ source_id: 's' }, { lane })).toBeNull();
+    }
+  });
+
+  it('an explicit slaHours overrides the per-lane default', () => {
+    const row = buildQueueRow({ source_id: 's' }, { lane: LANE.CHAIRMAN_GATED }, { slaHours: 24 });
+    expect(row.sla_hours).toBe(24);
+  });
+
+  it('QUEUE_LANES + DEFAULT_SLA_HOURS only cover the two gated lanes', () => {
+    expect(QUEUE_LANES).toEqual(['chairman-gated', 'outcome-gated']);
+    expect(DEFAULT_SLA_HOURS['chairman-gated']).toBe(72);
+    expect(DEFAULT_SLA_HOURS['outcome-gated']).toBe(168);
+  });
+});
+
+// --- FR-2: escalateToChairmanQueue (IO, fail-soft, idempotent) -------------------------------------
+describe('escalateToChairmanQueue (FR-2)', () => {
+  it('not_a_gated_lane for a belt-ready candidate (no write attempted)', async () => {
+    const sb = recordingSupabase();
+    const r = await escalateToChairmanQueue({ source_id: 's' }, { lane: LANE.BELT_READY }, { supabase: sb });
+    expect(r).toEqual({ escalated: false, reason: 'not_a_gated_lane' });
+    expect(sb.calls).toHaveLength(0);
+  });
+
+  it('no_client when no supabase is injected', async () => {
+    const r = await escalateToChairmanQueue({ source_id: 's' }, { lane: LANE.CHAIRMAN_GATED }, {});
+    expect(r).toEqual({ escalated: false, reason: 'no_client' });
+  });
+
+  it('no_source_id (no write) when source_id is missing/empty — null defeats the upsert idempotency key', async () => {
+    const sb = recordingSupabase();
+    for (const item of [{ title: 't' }, { source_id: null }, { source_id: '' }]) {
+      const r = await escalateToChairmanQueue(item, { lane: LANE.CHAIRMAN_GATED }, { supabase: sb });
+      expect(r).toEqual({ escalated: false, reason: 'no_source_id' });
+    }
+    expect(sb.calls).toHaveLength(0); // never reaches the DB
+  });
+
+  it('idempotent-upserts on (source_id, gate_type) with a computed sla_due_at and state=pending', async () => {
+    const sb = recordingSupabase({ data: [{ id: 'qid' }], error: null });
+    const r = await escalateToChairmanQueue(
+      { source_id: 'src-9', title: 't' },
+      { lane: LANE.CHAIRMAN_GATED, escalation: { reason: 'rls' } },
+      { supabase: sb, nowIso: '2026-06-20T00:00:00.000Z' },
+    );
+    expect(r.escalated).toBe(true);
+    expect(r.id).toBe('qid');
+    const call = sb.calls[0];
+    expect(call.table).toBe('sourcing_chairman_queue');
+    expect(call.opts).toMatchObject({ onConflict: 'source_id,gate_type', ignoreDuplicates: true });
+    expect(call.row.state).toBe('pending');
+    expect(call.row.escalation_type).toBe('rls');
+    // 72h after 2026-06-20T00:00:00Z
+    expect(call.row.sla_due_at).toBe('2026-06-23T00:00:00.000Z');
+  });
+
+  it('a conflict (already queued) returns escalated:true, deduped:true — no duplicate', async () => {
+    const sb = recordingSupabase({ data: [], error: null }); // ignoreDuplicates => empty on conflict
+    const r = await escalateToChairmanQueue({ source_id: 'dup' }, { lane: LANE.OUTCOME_GATED }, { supabase: sb });
+    expect(r.escalated).toBe(true);
+    expect(r.deduped).toBe(true);
+  });
+
+  it('fail-soft (degraded) when the table is absent / DORMANT (PGRST205), never throws', async () => {
+    const sb = recordingSupabase({ data: null, error: { code: 'PGRST205', message: 'Could not find the table' } });
+    const r = await escalateToChairmanQueue({ source_id: 's' }, { lane: LANE.CHAIRMAN_GATED }, { supabase: sb });
+    expect(r).toMatchObject({ escalated: false, reason: 'table_absent_dormant', degraded: true });
+  });
+
+  it('a thrown transport error degrades, never throws', async () => {
+    const sb = { from() { return { upsert() { return { select() { throw new Error('socket hang up'); } }; } }; } };
+    const r = await escalateToChairmanQueue({ source_id: 's' }, { lane: LANE.CHAIRMAN_GATED }, { supabase: sb });
+    expect(r.escalated).toBe(false);
+    expect(r.degraded).toBe(true);
+  });
+});
+
+// --- FR-3: integration with the shipped routeCandidate --------------------------------------------
+describe('routeCandidate -> escalator integration (FR-3)', () => {
+  it('a chairman-authority candidate routes to chairman-gated and builds a valid queue row', () => {
+    const routed = routeCandidate({ source_id: 'i', title: 'grant me', authority: 'grant' });
+    expect(routed.lane).toBe('chairman-gated');
+    const row = buildQueueRow({ source_id: 'i', title: 'grant me' }, routed);
+    expect(row).not.toBeNull();
+    expect(row.gate_type).toBe('chairman-gated');
+    expect(row.escalation_type).toBe('grant');
+  });
+
+  it('a needsOutcome candidate routes to outcome-gated and builds an outcome queue row', () => {
+    const routed = routeCandidate({ source_id: 'o', needsOutcome: true, targetRung: 'V2', enablers: ['e1'] });
+    expect(routed.lane).toBe('outcome-gated');
+    const row = buildQueueRow({ source_id: 'o' }, routed);
+    expect(row.escalation_type).toBe('outcome');
+    expect(row.context.enablers).toEqual(['e1']);
+  });
+
+  it('a belt-ready candidate is NOT queued', () => {
+    const routed = routeCandidate({ source_id: 'b', title: 'plain buildable' });
+    expect(routed.lane).toBe('belt-ready');
+    expect(buildQueueRow({ source_id: 'b' }, routed)).toBeNull();
+  });
+});
+
+// --- FR-1: migration file content ------------------------------------------------------------------
+describe('sourcing_chairman_queue migration (FR-1)', () => {
+  it('creates the table idempotently with the state CHECK enum and the idempotency UNIQUE key', () => {
+    expect(SQL).toMatch(/CREATE TABLE IF NOT EXISTS\s+sourcing_chairman_queue/i);
+    expect(SQL).toMatch(/state\s+text[\s\S]*CHECK\s*\(\s*state IN \('pending', 'decided', 'deferred_until', 'escalated'\)\s*\)/i);
+    expect(SQL).toMatch(/UNIQUE\s*\(\s*source_id,\s*gate_type\s*\)/i);
+  });
+
+  it('declares the gate columns (lane, gate_type, escalation_type) + SLA + context jsonb', () => {
+    for (const col of ['lane', 'gate_type', 'escalation_type', 'sla_hours', 'sla_due_at', 'context']) {
+      expect(SQL).toMatch(new RegExp(`\\b${col}\\b`));
+    }
+    expect(SQL).toMatch(/jsonb/i);
+  });
+
+  it('documents the DORMANT apply path (Adam / additive-DDL delegation)', () => {
+    expect(SQL).toMatch(/DORMANT/);
+    expect(SQL.toLowerCase()).toMatch(/adam|additive-ddl/);
+  });
+});


### PR DESCRIPTION
## Summary
Sourcing-engine child 4/10 — the **chairman decision-queue lane**. Adds the durable home for candidates the router (`routeCandidate`) lanes to `chairman-gated` (an authority only the chairman can grant — grant/rls/credential/operational/vision) or escalates as `outcome-gated` (waits on an operational outcome).

## What ships
- **`database/migrations/20260620_sourcing_chairman_queue.sql`** — DORMANT additive `CREATE TABLE IF NOT EXISTS sourcing_chairman_queue` with a `state` CHECK enum (`pending`/`decided`/`deferred_until`/`escalated`), a `UNIQUE (source_id, gate_type)` idempotency key, and two indexes. A bare CREATE TABLE is additive and not chairman-gated; **Adam applies it under the additive-DDL delegation** (workers author+test, don't self-apply prod).
- **`lib/sourcing-engine/escalator.js`** — `buildQueueRow` (PURE; 72h chairman-gated / 168h outcome-gated SLA; context jsonb carries rung/disposition/escalation/enablers) + `escalateToChairmanQueue` (idempotent upsert on `(source_id, gate_type)`, **null-source_id guard** so NULL can't defeat the idempotency key, **never throws** — a missing client, an absent table (DORMANT), or a thrown transport error all return a structured `degraded` verdict).
- **tests** — 18 hermetic unit tests + a `*.db.test.js` live probe that **SKIPs** until Adam applies the migration.

## DORMANT
The escalator fail-softs while the table is absent (`PGRST205/PGRST204/42P01` → degraded). The live probe flips SKIP→PASS once the migration is applied. No consumer assumes the table is live.

## Verification
`npx vitest run tests/unit/sourcing-engine/` → **26 passed / 3 skipped** (the dormant live probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)