### PR TITLE
feat(SD-LEO-INFRA-WIRE-ALL-POOLS-001): reap every pool in the hourly worktree-reaper tick

### DIFF
--- a/scripts/fleet/worktree-reaper-tick.cjs
+++ b/scripts/fleet/worktree-reaper-tick.cjs
@@ -154,6 +154,38 @@ function poolWatchdogDecision({ used, cap = MAX_WORKTREE_COUNT, threshold = DEFA
 }
 
 /**
+ * SD-LEO-INFRA-WIRE-ALL-POOLS-001: should the hourly tick reap EVERY registered pool?
+ * Default ON; opt out only with a falsey WORKTREE_REAPER_ALL_POOLS token (false/0/off/no),
+ * mirroring the WORKTREE_POOL_WATCHDOG convention. Pure (env injected) for unit testing.
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {boolean}
+ */
+function isAllPoolsEnabled(env = process.env) {
+  return !['false', '0', 'off', 'no'].includes(
+    String(env.WORKTREE_REAPER_ALL_POOLS || '').trim().toLowerCase(),
+  );
+}
+
+/**
+ * Build the argv for the reaper spawn. Pure (no I/O) so the flag wiring is unit-testable.
+ * With `allPools` true the reaper fans out a per-pool --repo child running the unchanged
+ * single-repo reaper (active-claim-protected, preserve-before-delete, dry-run-default all
+ * inherited; buildPassthroughFlags excludes --all-pools/--repo so no child re-fans-out).
+ * Without it, only the current repo is reaped — the pre-2026-06-20 behavior. The current
+ * repo stays covered either way (it is one of the pools resolveRegisteredPools returns).
+ * The watchdog appends --stage0/--execute to this base array afterward.
+ * @param {{ reaperScript:string, execute?:boolean, stage2?:boolean, allPools?:boolean }} o
+ * @returns {string[]}
+ */
+function buildReaperArgs({ reaperScript, execute, stage2, allPools }) {
+  const args = [reaperScript];
+  if (execute) args.push('--execute');
+  if (stage2) args.push('--stage2', '--yes');
+  if (allPools) args.push('--all-pools');
+  return args;
+}
+
+/**
  * Tick the counter and invoke the reaper when due.
  * Returns the post-invocation state for caller visibility.
  *
@@ -203,9 +235,7 @@ function tick(opts = {}) {
     return { invoked: false, counter: state.sweep_counter, cadence, result: 'skipped_in_flight', pid: state.last_pid, enabled: true };
   }
 
-  const args = [reaperScript];
-  if (execute) args.push('--execute');
-  if (stage2) args.push('--stage2', '--yes');
+  const args = buildReaperArgs({ reaperScript, execute, stage2, allPools: isAllPoolsEnabled() });
 
   // SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (FR-002): pool-utilization watchdog.
   // When the pool is at/above threshold, proactively run Stage-0 (terminal-SD
@@ -287,6 +317,8 @@ module.exports = {
   resolvePoolThreshold,
   countActiveWorktrees,
   poolWatchdogDecision,
+  isAllPoolsEnabled,
+  buildReaperArgs,
   DEFAULT_CADENCE,
   DEFAULT_POOL_THRESHOLD,
   MAX_WORKTREE_COUNT,

--- a/tests/unit/fleet/worktree-reaper-tick-all-pools.test.js
+++ b/tests/unit/fleet/worktree-reaper-tick-all-pools.test.js
@@ -1,0 +1,67 @@
+// SD-LEO-INFRA-WIRE-ALL-POOLS-001 (FR-1/FR-2/FR-4)
+// Pins that the hourly worktree-reaper tick passes --all-pools to the reaper by default (so
+// the ehg pool is reaped, not just EHG_Engineer) and omits it under the
+// WORKTREE_REAPER_ALL_POOLS=off opt-out. Tests the pure exported helpers directly —
+// isAllPoolsEnabled (env predicate) feeds buildReaperArgs (argv builder) — so no spawn / git
+// / temp dirs are needed and the flag wiring is asserted deterministically.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { isAllPoolsEnabled, buildReaperArgs } = require('../../../scripts/fleet/worktree-reaper-tick.cjs');
+
+const REAPER = '/repo/scripts/worktree-reaper.mjs';
+
+describe('isAllPoolsEnabled (SD-LEO-INFRA-WIRE-ALL-POOLS-001 FR-2)', () => {
+  it('defaults ON when the env var is unset or empty', () => {
+    expect(isAllPoolsEnabled({})).toBe(true);
+    expect(isAllPoolsEnabled({ WORKTREE_REAPER_ALL_POOLS: '' })).toBe(true);
+  });
+
+  it('opts out on any falsey token (case/space-insensitive)', () => {
+    for (const v of ['false', '0', 'off', 'no', 'OFF', 'No', ' off ']) {
+      expect(isAllPoolsEnabled({ WORKTREE_REAPER_ALL_POOLS: v }), `"${v}"`).toBe(false);
+    }
+  });
+
+  it('stays ON for any non-falsey value', () => {
+    for (const v of ['true', '1', 'on', 'yes', 'anything']) {
+      expect(isAllPoolsEnabled({ WORKTREE_REAPER_ALL_POOLS: v }), `"${v}"`).toBe(true);
+    }
+  });
+});
+
+describe('buildReaperArgs (SD-LEO-INFRA-WIRE-ALL-POOLS-001 FR-1)', () => {
+  it('appends --all-pools when allPools is true (the reaper fans out to every pool)', () => {
+    const args = buildReaperArgs({ reaperScript: REAPER, allPools: true });
+    expect(args).toContain('--all-pools');
+    expect(args[0]).toBe(REAPER);
+  });
+
+  it('omits --all-pools when allPools is false (current-repo-only, pre-2026-06-20 behavior)', () => {
+    const args = buildReaperArgs({ reaperScript: REAPER, allPools: false });
+    expect(args).not.toContain('--all-pools');
+  });
+
+  it('composes with the existing execute / stage2 flags', () => {
+    const args = buildReaperArgs({ reaperScript: REAPER, execute: true, stage2: true, allPools: true });
+    expect(args).toEqual([REAPER, '--execute', '--stage2', '--yes', '--all-pools']);
+  });
+
+  it('dry-run default: no --execute unless asked, even with --all-pools on', () => {
+    const args = buildReaperArgs({ reaperScript: REAPER, allPools: true });
+    expect(args).not.toContain('--execute');
+  });
+});
+
+describe('end-to-end flag derivation (FR-1 + FR-2)', () => {
+  it('default env -> argv carries --all-pools', () => {
+    const args = buildReaperArgs({ reaperScript: REAPER, allPools: isAllPoolsEnabled({}) });
+    expect(args).toContain('--all-pools');
+  });
+
+  it('WORKTREE_REAPER_ALL_POOLS=off -> argv omits --all-pools', () => {
+    const args = buildReaperArgs({ reaperScript: REAPER, allPools: isAllPoolsEnabled({ WORKTREE_REAPER_ALL_POOLS: 'off' }) });
+    expect(args).not.toContain('--all-pools');
+  });
+});


### PR DESCRIPTION
## Summary
Durable fix for the **2026-06-20 disk-full fleet-stall**. The hourly worktree-reaper cron tick (`scripts/fleet/worktree-reaper-tick.cjs`) spawned `scripts/worktree-reaper.mjs` against **only the current repo**, so the separate **ehg** repo worktree pool was never reaped — its `node_modules`-heavy orphans accumulated until the host disk filled and a fleet worker couldn't `git worktree add`.

This wires in `--all-pools` (the multi-repo fan-out already shipped in `worktree-reaper.mjs`, PR #4890) so every registered pool self-reclaims each cycle.

## What changed
- `scripts/fleet/worktree-reaper-tick.cjs`: the reaper args now include `--all-pools`, **default ON**, opt out with `WORKTREE_REAPER_ALL_POOLS=off` (mirrors `WORKTREE_POOL_WATCHDOG`). Two new **pure exported helpers** — `isAllPoolsEnabled(env)` + `buildReaperArgs(...)` — make the flag wiring unit-testable without spawn/git/temp dirs.
- `tests/unit/fleet/worktree-reaper-tick-all-pools.test.js`: NEW, pins both branches (default-on argv carries `--all-pools`; opt-out omits it) + the falsey-token matrix + dry-run-default.

## Safety (preserved unchanged)
- **Current repo stays covered** — `resolveRegisteredPools` includes the current repo as a pool (`isCurrent`), so EHG_Engineer is still reaped.
- **dry-run-default** preserved (`--execute` only when `WORKTREE_REAPER_EXECUTE`/watchdog).
- **Per-pool** children run the unchanged single-repo reaper via `--repo` → active-claim-protected + preserve-before-delete inherited.
- **No recursion** — `buildPassthroughFlags` excludes `--all-pools`/`--repo`, so a per-pool child can't re-fan-out.

## Verification
`npx vitest run tests/unit/fleet/` → 36 passed. New file: 9 cases. Existing `tests/unit/worktree-reaper/{tick,pool-watchdog}.test.js` → 35 passed (no regression). Independent adversarial review: **SHIP** (current-repo-coverage regression specifically refuted against `lib/worktree-reaper/pools.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)