### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-DEFERRED-WATCHER-001): deferred/blocked-on lane watcher (cron default-OFF)

### DIFF
--- a/lib/sourcing-engine/deferred-watcher.js
+++ b/lib/sourcing-engine/deferred-watcher.js
@@ -1,0 +1,114 @@
+/**
+ * lib/sourcing-engine/deferred-watcher.js
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-DEFERRED-WATCHER-001 — sourcing-engine child 8/10.
+ *
+ * The DEFERRED / BLOCKED-ON axis of the engine's no-drop guarantee. The router (child 1) lanes a
+ * candidate 'blocked-on-X' instead of dropping it — but a blocked-on item that is never re-checked is
+ * effectively dropped. This module re-evaluates a blocked-on (or deferred) candidate against current
+ * state and, when its blocker has CLEARED, re-routes it (typically back to belt-ready) so it re-enters
+ * the belt instead of sitting blocked forever.
+ *
+ * REUSE, don't reinvent (the dep-sentinel lesson):
+ *   - the canonical dependency parser parseSdDependencies (lib/utils/parse-sd-dependencies.cjs) is the
+ *     SSOT for deciding whether a blocker ref is a real SD-key blocker — we do NOT hand-roll a depId.
+ *   - the shipped routeCandidate (child 1) re-computes the lane once the blocker is removed from
+ *     context, so the re-emit respects EVERY other gate (dedup / chairman / outcome / a DIFFERENT
+ *     in-flight blocker) — we never blindly force belt-ready.
+ *
+ * PURE: this module is I/O-free and deterministic so it unit-tests without a DB. The cron
+ * (scripts/sourcing-engine-deferred-watcher-sweep.mjs) is the thin I/O + persistence wrapper.
+ */
+import { routeCandidate, LANES } from './router.js';
+import { blockedLane, isValidLane, BLOCKED_LANE_PREFIX } from './lane.js';
+import depParser from '../utils/parse-sd-dependencies.cjs';
+
+const { parseSdDependencies } = depParser;
+
+/** Feature-flag helper for the watcher cron: on|1|true => enabled; everything else (incl. undefined) => OFF. */
+export function isWatcherFlagEnabled(env = process.env) {
+  const v = String((env && env.SOURCING_DEFERRED_WATCHER_V1) || 'off').toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}
+
+/** Is `lane` a persisted parametric blocked-on lane ('blocked-on-<blocker>')? */
+export function isBlockedLane(lane) {
+  return typeof lane === 'string' && lane.startsWith(BLOCKED_LANE_PREFIX) && lane.length > BLOCKED_LANE_PREFIX.length;
+}
+
+/** Extract the blocker descriptor (the suffix) from a 'blocked-on-<blocker>' lane, or null. */
+export function extractBlocker(lane) {
+  if (!isBlockedLane(lane)) return null;
+  return lane.slice(BLOCKED_LANE_PREFIX.length);
+}
+
+/**
+ * PURE (FR-1/FR-3): re-evaluate ONE blocked-on/deferred registry row and return the re-lane decision.
+ *
+ * @param {{ id?:*, lane:string, classified?:object }} row - registry row; `classified` is the original
+ *   routeCandidate classifiedItem shape (writeSurfaces/dependsOn/authority/needsOutcome/title/...),
+ *   used to re-route faithfully once the blocker clears. Absent → re-route from an empty item, which
+ *   (no remaining conflicts) lands belt-ready.
+ * @param {{
+ *   completedSdKeys?: (Set<string>|string[]),       // SD-keys whose blocking SD has completed/shipped
+ *   clearedBlockerDescriptors?: (Set<string>|string[]), // non-SD blocker descriptors recorded as cleared
+ *   routeContext?: object                            // routeCandidate context (existing/inFlight/...)
+ * }} ctx
+ * @returns {{ action:'skip'|'stay'|'re-lane', reason:string, from?:string, to?:string,
+ *   lane?:string, blocker?:string, routed_lane?:string }}
+ */
+export function reEvaluateBlockedCandidate(row, ctx = {}) {
+  const lane = row && row.lane;
+  if (!isBlockedLane(lane)) {
+    return { action: 'skip', reason: 'not-blocked-lane' };
+  }
+  const blocker = extractBlocker(lane);
+
+  // Canonical SSOT: is the blocker a real SD-key blocker? parseSdDependencies returns the SD-key(s)
+  // it recognizes (or [] for a free-text / non-SD descriptor) — never a hand-rolled depId.
+  const sdBlockers = parseSdDependencies([blocker]);
+  const isSdBlocker = sdBlockers.length > 0;
+  const sdKey = isSdBlocker ? sdBlockers[0] : null;
+
+  const completed = toSet(ctx.completedSdKeys);
+  const clearedDescriptors = toSet(ctx.clearedBlockerDescriptors);
+  const cleared = isSdBlocker ? completed.has(sdKey) : clearedDescriptors.has(blocker);
+
+  if (!cleared) {
+    return { action: 'stay', reason: 'blocker-open', lane, blocker };
+  }
+
+  // Blocker cleared → re-route through the shipped router with the cleared blocker removed from the
+  // in-flight set, so the new lane respects every other gate (dedup / chairman / outcome / another
+  // in-flight blocker). We never blindly force belt-ready.
+  const routeContext = ctx.routeContext && typeof ctx.routeContext === 'object' ? ctx.routeContext : {};
+  const inFlight = Array.isArray(routeContext.inFlight)
+    ? routeContext.inFlight.filter((f) => !(f && f.sd_key === sdKey))
+    : [];
+  const r = routeCandidate(row.classified || {}, { ...routeContext, inFlight });
+
+  // Map the router's bare lane vocabulary onto the persisted lane vocabulary.
+  let to;
+  if (r.lane === LANES.BLOCKED_ON) {
+    // Still blocked, by a DIFFERENT in-flight conflict — re-lane onto the new parametric blocked lane.
+    to = blockedLane(r.blocker && r.blocker.sd_key);
+  } else {
+    to = r.lane; // belt-ready / chairman-gated / outcome-gated / dedup are all valid FIXED_LANES
+  }
+
+  if (!isValidLane(to)) {
+    // Defensive: never propose a lane the CHECK constraint would reject.
+    return { action: 'stay', reason: 'reroute-invalid-lane', lane, blocker, routed_lane: r.lane };
+  }
+  if (to === lane) {
+    // No net change (re-blocked on the same descriptor) — idempotent stay.
+    return { action: 'stay', reason: 'blocker-cleared-still-blocked', lane, blocker, routed_lane: r.lane };
+  }
+  return { action: 're-lane', reason: 'blocker-cleared', from: lane, to, blocker, routed_lane: r.lane };
+}
+
+function toSet(v) {
+  if (v instanceof Set) return v;
+  if (Array.isArray(v)) return new Set(v);
+  return new Set();
+}

--- a/package.json
+++ b/package.json
@@ -339,6 +339,7 @@
     "working-context": "node scripts/working-context.cjs",
     "chairman:notify": "node lib/integrations/todoist/chairman-notify.js",
     "adam:retro": "node scripts/adam-retro.cjs",
+    "sourcing:deferred-watcher": "node scripts/sourcing-engine-deferred-watcher-sweep.mjs",
     "adam:scan": "node scripts/adam-opportunity-scan.cjs --scan",
     "adam:briefing": "node scripts/adam-opportunity-scan.cjs --briefing",
     "adam:self-score": "node scripts/adam-self-assessment-writer.cjs",

--- a/scripts/sourcing-engine-deferred-watcher-sweep.mjs
+++ b/scripts/sourcing-engine-deferred-watcher-sweep.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * scripts/sourcing-engine-deferred-watcher-sweep.mjs
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-DEFERRED-WATCHER-001 (FR-2/FR-3) — the deferred/blocked-on lane
+ * watcher cron. DEFAULT-OFF behind SOURCING_DEFERRED_WATCHER_V1 (mirrors the adam opportunity-scan /
+ * canary-trigger default-off pattern): when the flag is off it prints SUPPRESSED_FLAG_OFF and exits 0.
+ *
+ * When ON it re-evaluates conversion_ledger rows on a 'blocked-on-<X>' lane and, for any whose blocker
+ * has CLEARED (the blocking SD completed, or a recorded non-SD descriptor cleared), re-lanes the row
+ * via the pure reEvaluateBlockedCandidate (which re-routes through the shipped router). The re-lane is:
+ *   - IDEMPOTENT: once re-laned off 'blocked-on-%', the row is no longer selected, so a re-run is a no-op.
+ *   - ADVISORY: it only re-labels the registry lane. It does NOT create an SD and does NOT promote
+ *     staged->belt — the promotion policy + chairman gate still govern actual belt entry.
+ *
+ * DORMANT-SAFE: conversion_ledger.lane ships via a TIER-2 migration that may be unapplied. We reuse the
+ * shipped ledgerLaneColumnExists probe and no-op cleanly (exit 0) until the column lands.
+ */
+import { reEvaluateBlockedCandidate, isWatcherFlagEnabled } from '../lib/sourcing-engine/deferred-watcher.js';
+import { ledgerLaneColumnExists } from '../lib/sourcing-engine/dedup-autostamp.js';
+
+/**
+ * Run the sweep. Pure-DI (supabase + env injected) so it unit-tests without a live DB.
+ *
+ * @param {{ supabase:object, env?:object, dryRun?:boolean }} opts
+ * @returns {Promise<{ suppressed:boolean, lane_column_missing:boolean, scanned:number,
+ *   re_laned:number, stayed:number, skipped:number, dry_run:boolean, errors:Array }>}
+ */
+export async function runDeferredWatcherSweep({ supabase, env = process.env, dryRun = false } = {}) {
+  const result = {
+    suppressed: false, lane_column_missing: false,
+    scanned: 0, re_laned: 0, stayed: 0, skipped: 0, dry_run: dryRun, errors: [],
+  };
+
+  if (!isWatcherFlagEnabled(env)) {
+    result.suppressed = true;
+    return result;
+  }
+
+  // DORMANT-SAFE: bail cleanly until the lane column migration is applied.
+  const laneColumnPresent = await ledgerLaneColumnExists(supabase);
+  if (!laneColumnPresent) {
+    result.lane_column_missing = true;
+    result.dry_run = true;
+    dryRun = true;
+    return result;
+  }
+
+  // Completed SD-keys = the cleared-blocker universe for SD blockers.
+  const { data: sds, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status')
+    .eq('status', 'completed');
+  if (sdErr) throw new Error(`load completed SDs failed: ${sdErr.message}`);
+  const completedSdKeys = new Set((sds || []).map((s) => s.sd_key));
+
+  // Blocked-on registry rows. NOTE: conversion_ledger has `target_rung`, NOT `rung` (selecting a
+  // non-existent column 42703-throws); and routeCandidate only passes rung THROUGH (never routes on
+  // it), so we omit it entirely — the re-lane decision is identical without it.
+  const { data: rows, error: rErr } = await supabase
+    .from('conversion_ledger')
+    .select('id, source_id, title, disposition, lane')
+    .like('lane', 'blocked-on-%');
+  if (rErr) throw new Error(`load blocked rows failed: ${rErr.message}`);
+
+  for (const row of rows || []) {
+    result.scanned++;
+    try {
+      const decision = reEvaluateBlockedCandidate(
+        { id: row.id, lane: row.lane, classified: { source_id: row.source_id, title: row.title, disposition: row.disposition } },
+        { completedSdKeys },
+      );
+      if (decision.action === 're-lane') {
+        if (!dryRun) {
+          const { error: uErr } = await supabase.from('conversion_ledger').update({ lane: decision.to }).eq('id', row.id);
+          if (uErr) { result.errors.push({ id: row.id, error: uErr.message }); continue; }
+        }
+        result.re_laned++;
+      } else if (decision.action === 'stay') {
+        result.stayed++;
+      } else {
+        result.skipped++;
+      }
+    } catch (err) {
+      result.errors.push({ id: row.id, error: err?.message || String(err) });
+    }
+  }
+  return result;
+}
+
+// CLI tail (FR-2): default-off, prints SUPPRESSED_FLAG_OFF + exits 0 when the flag is off.
+const isMain = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/')); }
+  catch { return false; }
+})();
+
+if (isMain) {
+  (async () => {
+    if (!isWatcherFlagEnabled(process.env)) {
+      console.log('SUPPRESSED_FLAG_OFF (SOURCING_DEFERRED_WATCHER_V1 not enabled)');
+      process.exit(0);
+    }
+    const { createClient } = await import('@supabase/supabase-js');
+    const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+    const dryRun = process.argv.includes('--dry-run');
+    const res = await runDeferredWatcherSweep({ supabase, env: process.env, dryRun });
+    if (res.lane_column_missing) {
+      console.log('NO-OP: conversion_ledger.lane column is dormant (migration unapplied) — nothing to sweep.');
+      process.exit(0);
+    }
+    console.log(`[deferred-watcher] scanned=${res.scanned} re_laned=${res.re_laned} stayed=${res.stayed} skipped=${res.skipped} dry_run=${res.dry_run} errors=${res.errors.length}`);
+    if (res.errors.length) console.error(JSON.stringify(res.errors, null, 2));
+    process.exit(0);
+  })().catch((err) => { console.error(`[deferred-watcher] FATAL: ${err?.message || err}`); process.exit(1); });
+}

--- a/tests/unit/sourcing-engine/deferred-watcher.test.js
+++ b/tests/unit/sourcing-engine/deferred-watcher.test.js
@@ -1,0 +1,173 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-DEFERRED-WATCHER-001 (child 8/10) — FR-5 unit tests.
+ *
+ * Pure re-eval (FR-1/FR-3) + the default-off, dormant-safe cron (FR-2):
+ *   - a blocked-on candidate whose blocking SD is now completed re-emits to belt-ready;
+ *   - one whose blocker is still open stays blocked;
+ *   - re-route reuses the shipped router, so another gate (e.g. chairman authority) is respected;
+ *   - the cron is a no-op when the flag is off, and dormant-safe when the lane column is unapplied;
+ *   - re-runs are idempotent (a re-laned row is no longer selected).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  reEvaluateBlockedCandidate,
+  isWatcherFlagEnabled,
+  isBlockedLane,
+  extractBlocker,
+} from '../../../lib/sourcing-engine/deferred-watcher.js';
+import { runDeferredWatcherSweep } from '../../../scripts/sourcing-engine-deferred-watcher-sweep.mjs';
+
+/** Minimal chainable + thenable Supabase mock for the sweep. */
+function makeSupabaseMock({ laneColumnExists, completedSds = [], blockedRows = [] }) {
+  const updates = [];
+  const from = (table) => {
+    const state = { table, selectCols: null, _update: null, _like: null };
+    const b = {
+      select(cols) { state.selectCols = cols; return b; },
+      eq() { return b; },
+      like(col, pat) { state._like = [col, pat]; return b; },
+      limit() { return b; },
+      update(patch) { state._update = patch; return b; },
+      then(resolve, reject) { return Promise.resolve(resolveResult(state)).then(resolve, reject); },
+    };
+    return b;
+  };
+  // Schema-aware: conversion_ledger has NO `rung` column (it has `target_rung`). Selecting a
+  // non-existent column 42703-throws live — so the mock rejects it, ensuring a column-name bug
+  // cannot pass green (regression guard for the adversarial-review HIGH finding).
+  const CL_MISSING_COLS = ['rung'];
+  const resolveResult = (state) => {
+    if (state._update) { updates.push({ table: state.table, patch: state._update }); return { data: null, error: null }; }
+    if (state.table === 'conversion_ledger' && state.selectCols === 'lane') {
+      return laneColumnExists
+        ? { data: [], error: null }
+        : { data: null, error: { code: '42703', message: 'column conversion_ledger.lane does not exist' } };
+    }
+    if (state.table === 'conversion_ledger' && typeof state.selectCols === 'string') {
+      const requested = state.selectCols.split(',').map((c) => c.trim());
+      const bad = requested.find((c) => CL_MISSING_COLS.includes(c));
+      if (bad) return { data: null, error: { code: '42703', message: `column conversion_ledger.${bad} does not exist` } };
+    }
+    if (state.table === 'strategic_directives_v2') return { data: completedSds, error: null };
+    if (state.table === 'conversion_ledger') return { data: blockedRows, error: null };
+    return { data: [], error: null };
+  };
+  return { from, _updates: updates };
+}
+
+describe('FR-1 helpers: blocked-lane detection', () => {
+  it('isBlockedLane / extractBlocker recognize the parametric blocked lane', () => {
+    expect(isBlockedLane('blocked-on-SD-FOO-001')).toBe(true);
+    expect(isBlockedLane('belt-ready')).toBe(false);
+    expect(isBlockedLane('blocked-on-')).toBe(false); // empty suffix is not valid
+    expect(extractBlocker('blocked-on-SD-FOO-001')).toBe('SD-FOO-001');
+    expect(extractBlocker('belt-ready')).toBeNull();
+  });
+});
+
+describe('FR-1/FR-3: reEvaluateBlockedCandidate', () => {
+  it('re-lanes to belt-ready when the blocking SD has completed', () => {
+    const d = reEvaluateBlockedCandidate(
+      { id: 'L1', lane: 'blocked-on-SD-LEO-INFRA-CHAIRMAN-QUEUE-004', classified: { title: 'Outcome decomposer wiring' } },
+      { completedSdKeys: new Set(['SD-LEO-INFRA-CHAIRMAN-QUEUE-004']) },
+    );
+    expect(d.action).toBe('re-lane');
+    expect(d.from).toBe('blocked-on-SD-LEO-INFRA-CHAIRMAN-QUEUE-004');
+    expect(d.to).toBe('belt-ready');
+    expect(d.routed_lane).toBe('belt-ready');
+  });
+
+  it('stays blocked when the blocking SD is still open', () => {
+    const d = reEvaluateBlockedCandidate(
+      { id: 'L2', lane: 'blocked-on-SD-LEO-INFRA-CHAIRMAN-QUEUE-004' },
+      { completedSdKeys: new Set() }, // blocker not completed
+    );
+    expect(d.action).toBe('stay');
+    expect(d.reason).toBe('blocker-open');
+  });
+
+  it('skips a row that is not on a blocked-on lane (idempotent re-run)', () => {
+    expect(reEvaluateBlockedCandidate({ id: 'L3', lane: 'belt-ready' }, {}).action).toBe('skip');
+    expect(reEvaluateBlockedCandidate({ id: 'L4', lane: 'dedup' }, {}).action).toBe('skip');
+  });
+
+  it('clears a non-SD blocker via the recorded cleared-descriptor set', () => {
+    const d = reEvaluateBlockedCandidate(
+      { id: 'L5', lane: 'blocked-on-payment-rail-live' },
+      { completedSdKeys: new Set(), clearedBlockerDescriptors: new Set(['payment-rail-live']) },
+    );
+    expect(d.action).toBe('re-lane');
+    expect(d.to).toBe('belt-ready');
+  });
+
+  it('does NOT clear a non-SD blocker that is not recorded as cleared', () => {
+    const d = reEvaluateBlockedCandidate(
+      { id: 'L6', lane: 'blocked-on-payment-rail-live' },
+      { completedSdKeys: new Set(['SD-X-001']) },
+    );
+    expect(d.action).toBe('stay');
+  });
+
+  it('reuses the shipped router: a cleared blocker still routes chairman-gated when authority applies', () => {
+    const d = reEvaluateBlockedCandidate(
+      { id: 'L7', lane: 'blocked-on-SD-DEP-001', classified: { title: 'RLS policy work', authority: 'rls' } },
+      { completedSdKeys: new Set(['SD-DEP-001']) },
+    );
+    // Blocker cleared, but the router's chairman-gated gate still fires → not blindly belt-ready.
+    expect(d.action).toBe('re-lane');
+    expect(d.to).toBe('chairman-gated');
+    expect(d.routed_lane).toBe('chairman-gated');
+  });
+});
+
+describe('FR-2: default-off + dormant-safe cron', () => {
+  it('is a no-op when the flag is off (touches no DB)', async () => {
+    const sb = makeSupabaseMock({ laneColumnExists: true });
+    const res = await runDeferredWatcherSweep({ supabase: sb, env: {} });
+    expect(res.suppressed).toBe(true);
+    expect(res.scanned).toBe(0);
+    expect(sb._updates.length).toBe(0);
+  });
+
+  it('isWatcherFlagEnabled honors on/1/true and defaults OFF', () => {
+    expect(isWatcherFlagEnabled({})).toBe(false);
+    expect(isWatcherFlagEnabled({ SOURCING_DEFERRED_WATCHER_V1: 'on' })).toBe(true);
+    expect(isWatcherFlagEnabled({ SOURCING_DEFERRED_WATCHER_V1: 'true' })).toBe(true);
+    expect(isWatcherFlagEnabled({ SOURCING_DEFERRED_WATCHER_V1: 'off' })).toBe(false);
+  });
+
+  it('no-ops (zero writes) when the lane column is dormant, even with the flag on', async () => {
+    const sb = makeSupabaseMock({ laneColumnExists: false });
+    const res = await runDeferredWatcherSweep({ supabase: sb, env: { SOURCING_DEFERRED_WATCHER_V1: 'on' } });
+    expect(res.lane_column_missing).toBe(true);
+    expect(res.dry_run).toBe(true);
+    expect(sb._updates.length).toBe(0);
+  });
+
+  it('re-lanes a cleared-blocker row and persists belt-ready when live (idempotent on re-run)', async () => {
+    const sb = makeSupabaseMock({
+      laneColumnExists: true,
+      completedSds: [{ sd_key: 'SD-DONE-001', status: 'completed' }],
+      blockedRows: [
+        { id: 'R1', source_id: 's1', title: 'cleared item', disposition: null, rung: null, lane: 'blocked-on-SD-DONE-001' },
+        { id: 'R2', source_id: 's2', title: 'still blocked item', disposition: null, rung: null, lane: 'blocked-on-SD-OPEN-999' },
+      ],
+    });
+    const res = await runDeferredWatcherSweep({ supabase: sb, env: { SOURCING_DEFERRED_WATCHER_V1: 'on' } });
+    expect(res.scanned).toBe(2);
+    expect(res.re_laned).toBe(1);
+    expect(res.stayed).toBe(1);
+    expect(sb._updates).toEqual([{ table: 'conversion_ledger', patch: { lane: 'belt-ready' } }]);
+  });
+
+  it('dry-run computes the re-lane but writes nothing', async () => {
+    const sb = makeSupabaseMock({
+      laneColumnExists: true,
+      completedSds: [{ sd_key: 'SD-DONE-001', status: 'completed' }],
+      blockedRows: [{ id: 'R1', source_id: 's1', title: 'cleared item', disposition: null, rung: null, lane: 'blocked-on-SD-DONE-001' }],
+    });
+    const res = await runDeferredWatcherSweep({ supabase: sb, env: { SOURCING_DEFERRED_WATCHER_V1: 'on' }, dryRun: true });
+    expect(res.re_laned).toBe(1);
+    expect(sb._updates.length).toBe(0);
+  });
+});


### PR DESCRIPTION
@
## Summary
Sourcing-engine child 8/10 — the **deferred/blocked-on axis** of the engine no-drop guarantee. The router lanes a candidate `blocked-on-X` instead of dropping it, but an item never re-checked is effectively dropped. This watcher re-evaluates blocked-on/deferred `conversion_ledger` rows and re-emits them to **belt-ready** when their blocker clears (the blocking SD completed). Today Adam does this re-check by hand.

## What shipped
- `lib/sourcing-engine/deferred-watcher.js` — PURE `reEvaluateBlockedCandidate`. Reuses the shipped `routeCandidate` (re-routes with the cleared blocker removed from `inFlight`, so chairman/outcome/dedup/another-blocker gates are all respected — never a blind belt-ready force) and the canonical `parseSdDependencies` SSOT (no hand-rolled depId).
- `scripts/sourcing-engine-deferred-watcher-sweep.mjs` — cron, **DEFAULT-OFF** behind `SOURCING_DEFERRED_WATCHER_V1` (prints `SUPPRESSED_FLAG_OFF`, exit 0). Re-lane is **idempotent** (re-laned rows leave the `blocked-on-%` set) + **advisory** (updates `conversion_ledger.lane` only — no SD creation, no staged→belt promotion). Dormant-safe via the shipped `ledgerLaneColumnExists` probe.
- `package.json` — `sourcing:deferred-watcher` npm entry (FR-4 WIRE_CHECK).
- 12 unit tests.

## Adversarial review caught a HIGH (fixed)
The blocked-rows select used `rung`, but `conversion_ledger` has `target_rung`, **not** `rung` (→ `42703`). Masked today by the dormant-probe early-exit, but lethal the moment the lane migration activates the watcher. Dropped `rung` (`routeCandidate` never routes on it) and hardened the test mock to reject the missing column so the bug class cannot pass green again.

## Test
`npx vitest run tests/unit/sourcing-engine/deferred-watcher.test.js` → 12/12 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@