### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001): Adam-direct registry + ghost-backfill (dormant-safe)

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001.json
@@ -1,0 +1,115 @@
+{
+  "executive_summary": "Adam-direct (chairman-directed) candidates and historically Adam-sourced SDs bypass the sourcing-engine's roadmap entirely — 78 Adam-sourced SDs currently have NO roadmap_wave_items row, so register-first / routeCandidate / lane coherence never sees them. This SD closes that gap by REUSING the shipped pieces (routeCandidate, isValidLane, shouldWarnRegisterFirst — never a parallel SSOT): a single-candidate register (FR-1, soft-warn on skip) and an idempotent ghost-backfill (FR-2). The whole thing is DORMANT-SAFE + DRY-RUN-DEFAULT: it forces dry-run whenever a precondition is unmet (the roadmap_wave_items.lane column is dormant, the source_type CHECK does not yet admit 'adam_direct', or no target wave resolves), so it computes exactly what it WOULD register (78 ghosts) but never mutates the chairman-visible roadmap until an operator applies the migrations and passes --apply.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Register an Adam-direct candidate as a roadmap_wave_items row (soft-warn on skip)",
+      "description": "registerAdamDirectCandidate (lib/sourcing-engine/adam-direct-registry.js) registers a single Adam-direct SD as a roadmap_wave_items row, routing it through the SHIPPED routeCandidate for its lane and gating lane writes on the column's presence. It is idempotent (an already-registered SD is a no-op) and SOFT-WARNS (never throws/blocks) when registration cannot proceed, reusing the SHIPPED shouldWarnRegisterFirst nudge (the ratified register-first=soft-warn decision). No parallel insert/route/lane code is written.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "registerAdamDirectCandidate routes via routeCandidate and only writes a lane that passes isValidLane.",
+        "An already-registered SD (existing roadmap_wave_items.promoted_to_sd_key) is a no-op (registered=false, no warn).",
+        "A candidate that cannot register (no wave / dormant column / CHECK violation / missing key) SOFT-WARNS via shouldWarnRegisterFirst and does NOT throw.",
+        "No new insert/route/lane SSOT — routeCandidate, isValidLane, shouldWarnRegisterFirst are imported, not re-derived."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Ghost-backfill Adam-sourced SDs lacking a roadmap row (idempotent)",
+      "description": "backfillAdamGhosts enumerates Adam-sourced SDs (metadata.sourced_by='adam' — the canonical attribution, NOT a top-level column or sd_key prefix) that have NO roadmap_wave_items row (promoted_to_sd_key match), and registers one row each. Idempotent: findAdamGhostSds excludes already-registered SDs, so a re-run sources nothing new. dedup_match_sd_key = the SD itself; lane via the router. Live dry-run verified: 78 ghosts would register, 0 written.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "findAdamGhostSds returns only Adam SDs whose sd_key is not already a promoted_to_sd_key.",
+        "backfillAdamGhosts registers exactly one row per ghost (no duplicates), counting candidates and would-register.",
+        "A re-run after a successful apply registers zero additional rows (idempotent via exclusion)."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Reuse the canonical shipped pieces (no duplicate-SSOT)",
+      "description": "The module imports routeCandidate (lib/sourcing-engine/router.js), isValidLane (lib/sourcing-engine/lane.js), and shouldWarnRegisterFirst (lib/sourcing-engine/register-first.js). It adds only a roadmap_wave_items.lane column probe (mirror of dedup-autostamp's ledgerLaneColumnExists, but for roadmap_wave_items), a target-wave resolver, ghost enumeration, and the dormant-safe register/backfill. No parallel insert/route/lane logic.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "routeCandidate, isValidLane, shouldWarnRegisterFirst are imported from their shipped modules.",
+        "No re-implementation of routing, lane validation, or the register-first warn.",
+        "The lane-column probe mirrors the existing dormant-column-probe pattern (42703/PGRST204 detection, throws on unrelated errors)."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "WIRE_CHECK reachability for the new lib + CLI",
+      "description": "The lib's consumer is scripts/sourcing-engine/backfill-adam-ghosts.mjs, wired via the package.json 'sourcing:backfill-adam-ghosts' script — so WIRE_CHECK resolves the new module through a real entry point (no @wire-check-exempt needed). The CLI is dry-run by default; --apply is gated (and still dormant-safe).",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "package.json has a sourcing:backfill-adam-ghosts script invoking the CLI.",
+        "The CLI imports backfillAdamGhosts, so the lib is reachable from a package.json entry point (WIRE_CHECK).",
+        "The CLI is dry-run by default; --apply does not bypass the dormant-safety guards."
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Tests — register+lane, ghost backfill, idempotency, soft-warn, dormant-safety",
+      "description": "tests/unit/sourcing-engine/adam-direct-registry.test.js (15 pure unit tests with an injected fake supabase): an Adam-direct candidate registers+lanes; a registry-bypassing ghost SD enumerates+would-register; a re-run is idempotent (exclusion); a candidate that skips registration soft-warns (does not throw); and the backfill is dormant-safe (dry-run when lane column absent / source_type CHECK dormant / no wave).",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Tests cover buildAdamRoadmapItem routing + lane gating, findAdamGhostSds enumeration, backfill dry-run-default + dormant-safety + 23514 downgrade, and registerAdamDirectCandidate idempotency + soft-warn.",
+        "Tests assert NO writes occur in dry-run (db.inserted is empty).",
+        "All tests pass."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Dormant-safe by construction", "description": "Two dormant deps (roadmap_wave_items.lane column + the source_type CHECK extension). The build forces dry-run when either is absent — ships INERT, never mutates the chairman roadmap prematurely." },
+    { "id": "TR-2", "title": "ESM", "description": "lib/sourcing-engine modules are ESM; the new module + CLI use ESM imports." },
+    { "id": "TR-3", "title": "Additive reversible DDL", "description": "The source_type CHECK widening is additive (never invalidates existing rows) + reversible. DORMANT — Adam applies under the additive-DDL delegation; the worker does not self-apply." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Ghost backfill is dry-run-default and writes nothing", "type": "unit", "expected": "78-candidate live dry-run registers 0 rows; unit dry-run db.inserted empty." },
+    { "id": "TS-2", "scenario": "Idempotent + soft-warn", "type": "unit", "expected": "already-registered = no-op; skip = soft-warn, no throw." },
+    { "id": "TS-3", "scenario": "Dormant-safety", "type": "unit", "expected": "lane column absent / source_type 23514 / no wave each force dry-run." }
+  ],
+  "acceptance_criteria": [
+    "Adam-direct candidates + Adam ghost SDs can register as roadmap items via the shipped register-first/router/lane pieces.",
+    "The build is dormant-safe and dry-run-default — never mutates the chairman roadmap until migrations applied + --apply.",
+    "Idempotent + soft-warn; no duplicate-SSOT.",
+    "Live dry-run proves 78 ghosts would register, 0 written."
+  ],
+  "risks": [
+    { "risk": "Autonomous bulk insert of 78 rows into the chairman-visible roadmap", "mitigation": "DRY-RUN-DEFAULT + dormant-gated (lane column + source_type CHECK both must be applied by an operator first); --apply still forced to dry-run while dormant.", "severity": "high" },
+    { "risk": "Wrong target wave for historical ghosts", "mitigation": "Deterministic resolver (LEO Roadmap, highest sequence_rank active wave); reviewable while dormant before any live apply.", "severity": "medium" },
+    { "risk": "Duplicate-SSOT (re-deriving router/lane/register code)", "mitigation": "FR-3 imports the shipped routeCandidate/isValidLane/shouldWarnRegisterFirst; the lane probe mirrors the existing pattern.", "severity": "low" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["the sourcing-engine roadmap coherence (register-first/router/lane)", "operators running npm run sourcing:backfill-adam-ghosts", "the LEO Roadmap (chairman-visible) once migrations applied", "Adam-direct intake (registerAdamDirectCandidate)"],
+    "dependencies": ["lib/sourcing-engine/router.js routeCandidate", "lib/sourcing-engine/lane.js isValidLane", "lib/sourcing-engine/register-first.js shouldWarnRegisterFirst", "roadmap_wave_items + strategic_directives_v2 + strategic_roadmaps + roadmap_waves tables", "the DORMANT 20260619 lane column migration + this SD's DORMANT source_type CHECK migration"],
+    "data_contracts": ["roadmap_wave_items insert (wave_id, source_type='adam_direct', source_id=SD uuid, promoted_to_sd_key=SD key, metadata.dedup_match_sd_key)", "metadata.sourced_by='adam' = Adam attribution (read)", "source_type CHECK widening (DORMANT additive)", "no breaking change"],
+    "runtime_config": ["--apply (default DRY-RUN)", "--cap=N (bound a run)", "no new env var; dormant-safety is automatic (probes lane column + 23514)"],
+    "observability_rollout": ["[backfill-adam-ghosts] DRY-RUN/APPLIED report with candidate/registered counts + dormant notes", "ships INERT (dry-run) until an operator applies BOTH migrations then runs --apply", "metadata.registered_by='adam-direct-registry' tags backfilled rows for audit"]
+  },
+  "system_architecture": {
+    "summary": "One new lib module reusing the shipped router/lane/register-first pieces + a dormant CHECK migration + a CLI, all dormant-safe + dry-run-default so the chairman roadmap is never mutated prematurely.",
+    "components": [
+      { "name": "lib/sourcing-engine/adam-direct-registry.js", "change": "NEW register + ghost-backfill (reuses router/lane/register-first)" },
+      { "name": "database/migrations/20260620_roadmap_wave_items_adam_direct_source_type.sql", "change": "NEW DORMANT additive CHECK widening (adam_direct)" },
+      { "name": "scripts/sourcing-engine/backfill-adam-ghosts.mjs", "change": "NEW CLI (dry-run default)" },
+      { "name": "package.json", "change": "ADD sourcing:backfill-adam-ghosts (WIRE_CHECK)" },
+      { "name": "tests/unit/sourcing-engine/adam-direct-registry.test.js", "change": "NEW 15 unit tests" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Reuse the shipped sourcing-engine pieces; add a dormant-safe register/backfill keyed off metadata.sourced_by='adam', dry-run-default so the chairman roadmap is never mutated until an operator applies the dormant migrations + --apply.",
+    "steps": [
+      "Write lib/sourcing-engine/adam-direct-registry.js: roadmapLaneColumnExists probe, resolveTargetWaveId, findAdamGhostSds, buildAdamRoadmapItem (routeCandidate+isValidLane), registerAdamDirectCandidate (FR-1), backfillAdamGhosts (FR-2) — all dormant-safe/dry-run-default.",
+      "Author the DORMANT source_type CHECK-widening migration (not applied by the worker).",
+      "Add the CLI + package.json entry; write 15 tests; live-smoke the dry-run (78 ghosts, 0 writes).",
+      "TESTING+SECURITY @ EXEC, adversarial review, EXEC-TO-PLAN."
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run: npx vitest run tests/unit/sourcing-engine/adam-direct-registry.test.js", "expected_outcome": "15 tests pass (register+lane, ghost enumeration, dry-run-default, dormant-safety, idempotency, soft-warn)." },
+    { "step_number": 2, "instruction": "Run: npm run sourcing:backfill-adam-ghosts (no --apply) against the live DB", "expected_outcome": "DRY-RUN: ~78 ghosts WOULD register into the LEO Roadmap wave; 0 roadmap_wave_items rows written; 0 source_type=adam_direct rows after." },
+    { "step_number": 3, "instruction": "Inspect the module imports + the migration", "expected_outcome": "Reuses routeCandidate/isValidLane/shouldWarnRegisterFirst (FR-3); the source_type CHECK migration is DORMANT (not applied), additive + reversible." }
+  ],
+  "activation_test_id": "tests/unit/sourcing-engine/adam-direct-registry.test.js",
+  "metadata": { "sd_key": "SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001" }
+}

--- a/database/migrations/20260620_roadmap_wave_items_adam_direct_source_type.sql
+++ b/database/migrations/20260620_roadmap_wave_items_adam_direct_source_type.sql
@@ -1,0 +1,26 @@
+-- SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001 (FR-2 enabler)
+-- DORMANT (TIER-2): extend roadmap_wave_items.source_type CHECK to admit 'adam_direct', so
+-- Adam-direct candidates + ghost-backfill rows can be registered. ADDITIVE + REVERSIBLE (widening a
+-- CHECK never invalidates existing rows). Workers do NOT self-apply: Adam applies under the
+-- chairman's additive-DDL delegation. Until applied, the engine is dormant-safe (lib/sourcing-engine/
+-- adam-direct-registry.js forces dry-run on a 23514 CHECK violation) — it computes what it WOULD
+-- register but writes nothing, so the chairman-visible roadmap is never mutated prematurely.
+--
+-- Pairs with database/migrations/20260619_sourcing_engine_lane_column.sql (the DORMANT lane column);
+-- BOTH must be applied before the backfill writes live.
+
+ALTER TABLE roadmap_wave_items
+  DROP CONSTRAINT IF EXISTS roadmap_wave_items_source_type_check;
+
+ALTER TABLE roadmap_wave_items
+  ADD CONSTRAINT roadmap_wave_items_source_type_check
+  CHECK (source_type = ANY (ARRAY['todoist'::text, 'youtube'::text, 'brainstorm'::text, 'adam_direct'::text]));
+
+COMMENT ON CONSTRAINT roadmap_wave_items_source_type_check ON roadmap_wave_items IS
+  'Allowed intake source types. adam_direct added by SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001 '
+  'so Adam-direct candidates + ghost-backfilled Adam SDs can register as roadmap items.';
+
+-- Rollback (only if NO adam_direct rows exist; otherwise widen-only is the safe state):
+--   ALTER TABLE roadmap_wave_items DROP CONSTRAINT IF EXISTS roadmap_wave_items_source_type_check;
+--   ALTER TABLE roadmap_wave_items ADD CONSTRAINT roadmap_wave_items_source_type_check
+--     CHECK (source_type = ANY (ARRAY['todoist'::text, 'youtube'::text, 'brainstorm'::text]));

--- a/lib/sourcing-engine/adam-direct-registry.js
+++ b/lib/sourcing-engine/adam-direct-registry.js
@@ -1,0 +1,217 @@
+/**
+ * Adam-direct registry — SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001.
+ *
+ * Closes the gap where Adam-direct (chairman-directed) candidates and historically Adam-sourced SDs
+ * bypass the roadmap entirely (no roadmap_wave_items row), so the sourcing-engine's register-first +
+ * router + lane coherence never sees them.
+ *
+ * REUSE, do not re-derive (FR-3 — duplicate-SSOT is the recurring trap):
+ *   - routeCandidate  (lib/sourcing-engine/router.js)  — the SHIPPED pure router → lane.
+ *   - isValidLane     (lib/sourcing-engine/lane.js)     — the SHIPPED CHECK-constraint mirror.
+ * This module adds only: a roadmap_wave_items.lane column probe (mirror of dedup-autostamp's
+ * ledgerLaneColumnExists, but for roadmap_wave_items), a target-wave resolver, ghost enumeration,
+ * and a dormant-safe register/backfill.
+ *
+ * DORMANT-SAFE BY CONSTRUCTION (two dormant deps): (1) roadmap_wave_items.lane is a DORMANT column
+ * (LEDGER-LANE-COLUMN-001 migration not applied) and (2) the source_type CHECK does not yet admit
+ * 'adam_direct' (this SD's own DORMANT migration). When either is absent the backfill runs DRY-RUN —
+ * it computes exactly what it WOULD register but writes nothing — so this ships INERT and never
+ * mutates the chairman-visible roadmap until an operator applies the migrations and passes --apply.
+ *
+ * @module lib/sourcing-engine/adam-direct-registry
+ */
+
+import { routeCandidate } from './router.js';
+import { isValidLane } from './lane.js';
+// FR-1 soft-warn: REUSE the shipped register-first nudge (do NOT re-derive the warn logic).
+import { shouldWarnRegisterFirst } from './register-first.js';
+
+/** The source_type this SD registers Adam-direct rows under (gated by the dormant CHECK extension). */
+export const ADAM_DIRECT_SOURCE_TYPE = 'adam_direct';
+
+/** The canonical roadmap Adam-direct items register into. */
+export const ADAM_ROADMAP_TITLE = 'LEO Roadmap';
+
+/**
+ * Probe whether roadmap_wave_items.lane exists (the DORMANT lane column). Mirrors the
+ * ledgerLaneColumnExists 42703/PGRST204 detection but for roadmap_wave_items. Throws on unrelated
+ * (auth/network) errors so a real outage is never mistaken for "column missing".
+ * @param {object} supabase
+ * @returns {Promise<boolean>}
+ */
+export async function roadmapLaneColumnExists(supabase) {
+  const { error } = await supabase.from('roadmap_wave_items').select('lane').limit(1);
+  if (!error) return true;
+  const code = error.code || '';
+  const msg = String(error.message || '').toLowerCase();
+  if (code === '42703' || code === 'PGRST204' || (msg.includes('column') && msg.includes('lane')) || msg.includes('does not exist') || msg.includes('could not find')) {
+    return false;
+  }
+  throw new Error(`roadmapLaneColumnExists: unexpected error probing roadmap_wave_items.lane: ${error.message}`);
+}
+
+/**
+ * Resolve the target wave id for Adam-direct registration: the highest sequence_rank wave of the
+ * canonical "LEO Roadmap". Returns null fail-soft when no roadmap/wave can be resolved (the caller
+ * then forces dry-run — never inserts an orphan row without a wave).
+ * @param {object} supabase
+ * @returns {Promise<string|null>}
+ */
+export async function resolveTargetWaveId(supabase) {
+  try {
+    const { data: roadmaps } = await supabase
+      .from('strategic_roadmaps').select('id').eq('title', ADAM_ROADMAP_TITLE).eq('status', 'active').limit(1);
+    const roadmapId = roadmaps && roadmaps[0] && roadmaps[0].id;
+    if (!roadmapId) return null;
+    const { data: waves } = await supabase
+      .from('roadmap_waves').select('id,sequence_rank').eq('roadmap_id', roadmapId)
+      .order('sequence_rank', { ascending: false }).order('created_at', { ascending: false }).limit(1);
+    return (waves && waves[0] && waves[0].id) || null;
+  } catch (_) {
+    return null; // fail-soft: unresolved wave => dry-run
+  }
+}
+
+/**
+ * Enumerate Adam-sourced SDs (metadata.sourced_by='adam' — the canonical attribution, NOT a
+ * top-level column or sd_key prefix) that have NO corresponding roadmap_wave_items row
+ * (promoted_to_sd_key match). These are the "ghosts" FR-2 backfills.
+ * @param {object} supabase
+ * @returns {Promise<Array<{id:string, sd_key:string, title:string, status:string, disposition?:string}>>}
+ */
+export async function findAdamGhostSds(supabase) {
+  const { data: adam, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id,sd_key,title,status,metadata')
+    .eq('metadata->>sourced_by', 'adam');
+  if (error) throw new Error(`findAdamGhostSds: SD query failed: ${error.message}`);
+  const keys = (adam || []).map((r) => r.sd_key).filter(Boolean);
+  if (keys.length === 0) return [];
+  // Which of those keys already have a roadmap_wave_items row?
+  const { data: rows } = await supabase
+    .from('roadmap_wave_items').select('promoted_to_sd_key').in('promoted_to_sd_key', keys);
+  const registered = new Set((rows || []).map((r) => r.promoted_to_sd_key).filter(Boolean));
+  return (adam || [])
+    .filter((sd) => sd.sd_key && !registered.has(sd.sd_key))
+    .map((sd) => ({
+      id: sd.id, sd_key: sd.sd_key, title: sd.title, status: sd.status,
+      disposition: (sd.metadata && sd.metadata.disposition) || null,
+    }));
+}
+
+/**
+ * Compute the roadmap_wave_items insert payload for an Adam SD, routing it through the SHIPPED
+ * router for its lane. PURE (no IO). Returns { payload, lane } — payload carries lane only when
+ * lanePresent (dormant-safe: a missing column means the insert omits lane, which is nullable).
+ * @param {{id,sd_key,title,disposition?}} sd
+ * @param {{ waveId:string, lanePresent:boolean }} ctx
+ */
+export function buildAdamRoadmapItem(sd, { waveId, lanePresent }) {
+  const routed = routeCandidate({ source_id: sd.sd_key, title: sd.title, disposition: sd.disposition || null });
+  const lane = routed && routed.lane;
+  const payload = {
+    wave_id: waveId,
+    source_type: ADAM_DIRECT_SOURCE_TYPE,
+    source_id: sd.id, // the SD's own UUID (the originating "intake" for an Adam-direct candidate)
+    title: sd.title || sd.sd_key,
+    promoted_to_sd_key: sd.sd_key, // the uni-directional SD link the register-first guard reads
+    metadata: { sourced_by: 'adam', registered_by: 'adam-direct-registry', dedup_match_sd_key: sd.sd_key },
+  };
+  if (lanePresent && isValidLane(lane)) payload.lane = lane;
+  return { payload, lane };
+}
+
+/**
+ * FR-1: register a SINGLE Adam-direct candidate as a roadmap_wave_items row, dormant-safe. Returns a
+ * SOFT-WARN (never throws/blocks) when registration cannot proceed — mirroring the ratified
+ * register-first=soft-warn decision via the SHIPPED shouldWarnRegisterFirst nudge. Idempotent: an SD
+ * already represented by a roadmap row is a no-op.
+ *
+ * @param {object} supabase
+ * @param {{id,sd_key,title,disposition?}} sd
+ * @param {{ apply?:boolean }} [opts]
+ * @returns {Promise<{registered:boolean, warn:boolean, reason:string|null, dry_run:boolean, lane:string|null}>}
+ */
+export async function registerAdamDirectCandidate(supabase, sd, opts = {}) {
+  const out = { registered: false, warn: false, reason: null, dry_run: !opts.apply, lane: null };
+  if (!sd || !sd.sd_key || !sd.id) {
+    out.warn = shouldWarnRegisterFirst(sd || {}, false); out.reason = 'missing sd_key/id'; return out;
+  }
+  // Idempotency: already registered?
+  const { data: existing } = await supabase
+    .from('roadmap_wave_items').select('id').eq('promoted_to_sd_key', sd.sd_key).limit(1);
+  if (existing && existing.length) { out.reason = 'already registered'; return out; }
+
+  const waveId = await resolveTargetWaveId(supabase);
+  if (!waveId) { out.warn = shouldWarnRegisterFirst(sd, false); out.reason = 'no target wave (soft-warn)'; out.dry_run = true; return out; }
+  const lanePresent = await roadmapLaneColumnExists(supabase);
+  if (!lanePresent) out.dry_run = true;
+
+  const { payload, lane } = buildAdamRoadmapItem(sd, { waveId, lanePresent });
+  out.lane = lane || null;
+  if (out.dry_run) { out.reason = lanePresent ? 'dry-run (apply omitted)' : 'dry-run (lane column dormant)'; return out; }
+
+  const { error } = await supabase.from('roadmap_wave_items').insert(payload);
+  if (error) {
+    // source_type CHECK not yet extended (dormant) => soft-warn, do not throw (register-first=soft-warn).
+    out.warn = shouldWarnRegisterFirst(sd, false);
+    out.reason = (error.code === '23514' || String(error.message || '').toLowerCase().includes('source_type'))
+      ? 'source_type CHECK dormant (soft-warn)' : `insert failed: ${error.message}`;
+    out.dry_run = true;
+    return out;
+  }
+  out.registered = true;
+  return out;
+}
+
+/**
+ * Backfill roadmap_wave_items rows for Adam ghost SDs. DORMANT-SAFE + IDEMPOTENT + DRY-RUN-DEFAULT.
+ *
+ * Forces dry-run (writes nothing) whenever a precondition is unmet: no resolvable target wave, the
+ * lane column is absent, OR a probe insert reveals the source_type CHECK does not yet admit
+ * 'adam_direct' (PG 23514). On a real apply it inserts exactly one row per ghost (the
+ * promoted_to_sd_key UNIQUE-by-construction enumeration makes a re-run a no-op — already-registered
+ * SDs are excluded by findAdamGhostSds).
+ *
+ * @param {object} supabase
+ * @param {{ apply?:boolean, cap?:number }} [opts] - apply defaults false (dry-run); cap bounds a run
+ * @returns {Promise<{registered:number, candidates:number, dry_run:boolean, lane_column_missing:boolean, source_type_unsupported:boolean, wave_id:string|null, errors:Array}>}
+ */
+export async function backfillAdamGhosts(supabase, opts = {}) {
+  const cap = Number.isInteger(opts.cap) && opts.cap > 0 ? opts.cap : 100;
+  const result = { registered: 0, candidates: 0, dry_run: !opts.apply, lane_column_missing: false, source_type_unsupported: false, wave_id: null, errors: [] };
+
+  const ghosts = (await findAdamGhostSds(supabase)).slice(0, cap);
+  result.candidates = ghosts.length;
+  if (ghosts.length === 0) return result;
+
+  const waveId = await resolveTargetWaveId(supabase);
+  result.wave_id = waveId;
+  if (!waveId) { result.dry_run = true; return result; } // no wave => cannot insert; dry-run only
+
+  const lanePresent = await roadmapLaneColumnExists(supabase);
+  if (!lanePresent) { result.lane_column_missing = true; result.dry_run = true; }
+
+  let dryRun = result.dry_run;
+  for (const sd of ghosts) {
+    let payload;
+    try {
+      ({ payload } = buildAdamRoadmapItem(sd, { waveId, lanePresent }));
+    } catch (e) { result.errors.push({ sd_key: sd.sd_key, error: e.message }); continue; }
+
+    if (dryRun) { result.registered++; continue; } // count what WOULD be registered
+
+    const { error } = await supabase.from('roadmap_wave_items').insert(payload);
+    if (error) {
+      // source_type CHECK not yet extended (dormant) => 23514: downgrade the WHOLE run to dry-run.
+      if (error.code === '23514' || (String(error.message || '').toLowerCase().includes('source_type'))) {
+        result.source_type_unsupported = true; result.dry_run = true; dryRun = true; result.registered++;
+        continue;
+      }
+      result.errors.push({ sd_key: sd.sd_key, error: error.message });
+      continue;
+    }
+    result.registered++;
+  }
+  return result;
+}

--- a/package.json
+++ b/package.json
@@ -324,6 +324,7 @@
     "canary:sweep": "node scripts/canary-trigger-sweep.mjs",
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
     "prod-error-sweep": "node scripts/clockwork/prod-error-sweep-loop.cjs",
+    "sourcing:backfill-adam-ghosts": "node scripts/sourcing-engine/backfill-adam-ghosts.mjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",

--- a/scripts/sourcing-engine/backfill-adam-ghosts.mjs
+++ b/scripts/sourcing-engine/backfill-adam-ghosts.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * backfill-adam-ghosts — SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001 (FR-2 CLI).
+ *
+ * Registers Adam-sourced "ghost" SDs (metadata.sourced_by='adam' with no roadmap_wave_items row)
+ * into the LEO Roadmap via the dormant-safe backfillAdamGhosts. DRY-RUN by default — pass --apply to
+ * write (and even then it stays dry-run until BOTH the lane column + source_type CHECK migrations are
+ * applied, so it can never prematurely mutate the chairman-visible roadmap).
+ *
+ * Usage:  npm run sourcing:backfill-adam-ghosts            # dry-run report
+ *         npm run sourcing:backfill-adam-ghosts -- --apply # live (only effective once migrations applied)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { backfillAdamGhosts } from '../../lib/sourcing-engine/adam-direct-registry.js';
+
+const apply = process.argv.includes('--apply');
+const capArg = (process.argv.find((a) => a.startsWith('--cap=')) || '').split('=')[1];
+
+async function main() {
+  const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const res = await backfillAdamGhosts(db, { apply, cap: capArg ? Number(capArg) : undefined });
+  const mode = res.dry_run ? 'DRY-RUN' : 'APPLIED';
+  console.log(`[backfill-adam-ghosts] ${mode}: ${res.registered}/${res.candidates} ghost(s) ${res.dry_run ? 'would register' : 'registered'} (wave=${res.wave_id ? res.wave_id.slice(0, 8) : 'none'})`);
+  if (res.lane_column_missing) console.log('  note: roadmap_wave_items.lane column dormant — forced dry-run (apply the lane migration to enable lane stamping).');
+  if (res.source_type_unsupported) console.log("  note: source_type CHECK does not yet admit 'adam_direct' — forced dry-run (apply 20260620_roadmap_wave_items_adam_direct_source_type.sql).");
+  if (res.errors.length) for (const e of res.errors) console.warn(`  [error] ${e.sd_key}: ${e.error}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('[backfill-adam-ghosts] fatal:', e.message); process.exit(1); });

--- a/tests/unit/sourcing-engine/adam-direct-registry.test.js
+++ b/tests/unit/sourcing-engine/adam-direct-registry.test.js
@@ -1,0 +1,183 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001 — pure unit tests.
+ * An Adam-direct candidate registers+lanes; a registry-bypassing ghost SD backfills exactly one row;
+ * a re-run is idempotent; a candidate that skips registration soft-warns (does not throw); and the
+ * whole thing is DORMANT-SAFE (dry-run when the lane column / source_type CHECK are absent).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildAdamRoadmapItem,
+  roadmapLaneColumnExists,
+  findAdamGhostSds,
+  registerAdamDirectCandidate,
+  backfillAdamGhosts,
+  ADAM_DIRECT_SOURCE_TYPE,
+} from '../../../lib/sourcing-engine/adam-direct-registry.js';
+
+/**
+ * Configurable fake supabase. Each .from(table) chain is awaitable and resolves to the configured
+ * response for (table, op). Inserts are recorded so a test can assert WHAT would be written.
+ */
+function makeDb(cfg = {}) {
+  const inserted = [];
+  const resolve = (table, op, row) => {
+    const t = cfg[table] || {};
+    if (op === 'insert') { if (!(t.insert && t.insert.error)) inserted.push({ table, row }); return t.insert || { error: null }; }
+    return t.select || { data: [], error: null };
+  };
+  const builder = (table) => {
+    const b = { _op: 'select', _row: null };
+    b.select = () => b; b.eq = () => b; b.in = () => b; b.limit = () => b; b.order = () => b; b.not = () => b; b.is = () => b;
+    b.insert = (row) => { b._op = 'insert'; b._row = row; return b; };
+    b.then = (res, rej) => Promise.resolve(resolve(table, b._op, b._row)).then(res, rej);
+    b.catch = (rej) => b.then(undefined, rej);
+    return b;
+  };
+  return { inserted, from: (table) => builder(table) };
+}
+
+describe('buildAdamRoadmapItem — routes via the shipped router, lane gated by column presence (FR-1/FR-3)', () => {
+  const sd = { id: 'uuid-1', sd_key: 'SD-LEO-X-001', title: 'Some infra capability', disposition: 'BUILD' };
+
+  it('produces a roadmap_wave_items payload with the SD link + adam_direct source_type', () => {
+    const { payload } = buildAdamRoadmapItem(sd, { waveId: 'wave-1', lanePresent: true });
+    expect(payload.wave_id).toBe('wave-1');
+    expect(payload.source_type).toBe(ADAM_DIRECT_SOURCE_TYPE);
+    expect(payload.source_id).toBe('uuid-1');
+    expect(payload.promoted_to_sd_key).toBe('SD-LEO-X-001');
+    expect(payload.metadata.sourced_by).toBe('adam');
+    expect(payload.metadata.dedup_match_sd_key).toBe('SD-LEO-X-001');
+  });
+
+  it('OMITS lane when the column is dormant (lanePresent=false) — dormant-safe', () => {
+    const { payload } = buildAdamRoadmapItem(sd, { waveId: 'wave-1', lanePresent: false });
+    expect(payload).not.toHaveProperty('lane');
+  });
+
+  it('includes a VALID lane when the column is present', () => {
+    const { payload, lane } = buildAdamRoadmapItem(sd, { waveId: 'wave-1', lanePresent: true });
+    // router returns one of the canonical lanes; payload.lane only set when isValidLane(lane)
+    if (payload.lane !== undefined) expect(typeof payload.lane).toBe('string');
+    expect(typeof lane === 'string' || lane === undefined || lane === null).toBe(true);
+  });
+});
+
+describe('roadmapLaneColumnExists — dormant probe', () => {
+  it('true when the lane select succeeds', async () => {
+    expect(await roadmapLaneColumnExists(makeDb({ roadmap_wave_items: { select: { data: [{}] } } }))).toBe(true);
+  });
+  it('false on 42703 (column absent)', async () => {
+    expect(await roadmapLaneColumnExists(makeDb({ roadmap_wave_items: { select: { error: { code: '42703', message: 'column "lane" does not exist' } } } }))).toBe(false);
+  });
+  it('throws on an unrelated (auth) error — never mistakes an outage for missing-column', async () => {
+    await expect(roadmapLaneColumnExists(makeDb({ roadmap_wave_items: { select: { error: { code: '42501', message: 'permission denied' } } } }))).rejects.toThrow();
+  });
+});
+
+describe('findAdamGhostSds — enumerate Adam SDs without a roadmap row (FR-2)', () => {
+  it('returns only Adam SDs whose sd_key is NOT already promoted', async () => {
+    const db = makeDb({
+      strategic_directives_v2: { select: { data: [
+        { id: 'u1', sd_key: 'SD-A', title: 'A', status: 'draft', metadata: { sourced_by: 'adam' } },
+        { id: 'u2', sd_key: 'SD-B', title: 'B', status: 'draft', metadata: { sourced_by: 'adam' } },
+      ] } },
+      roadmap_wave_items: { select: { data: [{ promoted_to_sd_key: 'SD-A' }] } },
+    });
+    const ghosts = await findAdamGhostSds(db);
+    expect(ghosts.map((g) => g.sd_key)).toEqual(['SD-B']);
+  });
+});
+
+describe('backfillAdamGhosts — dormant-safe, dry-run-default, idempotent (FR-2/FR-5)', () => {
+  const adamRows = [
+    { id: 'u1', sd_key: 'SD-A', title: 'A', status: 'draft', metadata: { sourced_by: 'adam' } },
+    { id: 'u2', sd_key: 'SD-B', title: 'B', status: 'draft', metadata: { sourced_by: 'adam' } },
+  ];
+  const baseCfg = (laneErr) => ({
+    strategic_directives_v2: { select: { data: adamRows } },
+    roadmap_wave_items: { select: laneErr ? { error: { code: '42703', message: 'lane does not exist' } } : { data: [] } },
+    strategic_roadmaps: { select: { data: [{ id: 'rm-1' }] } },
+    roadmap_waves: { select: { data: [{ id: 'wave-1', sequence_rank: 5 }] } },
+  });
+
+  it('DRY-RUN by default: counts candidates, writes nothing', async () => {
+    const db = makeDb(baseCfg(false));
+    const res = await backfillAdamGhosts(db, { /* apply omitted */ });
+    expect(res.dry_run).toBe(true);
+    expect(res.candidates).toBe(2);
+    expect(res.registered).toBe(2); // would-register
+    expect(db.inserted).toHaveLength(0); // nothing written
+  });
+
+  it('lane column dormant forces dry-run even with --apply', async () => {
+    // roadmap_wave_items lane select errors 42703 -> lane_column_missing -> dry-run.
+    // But the ghost enumeration ALSO reads roadmap_wave_items.promoted_to_sd_key; in this fake both
+    // return the same configured select. Use a wave + adam rows, lane probe errors.
+    const cfg = baseCfg(true);
+    // findAdamGhostSds reads roadmap_wave_items promoted list — with an error it yields [] => all are ghosts.
+    const db = makeDb(cfg);
+    const res = await backfillAdamGhosts(db, { apply: true });
+    expect(res.lane_column_missing).toBe(true);
+    expect(res.dry_run).toBe(true);
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('no target wave => dry-run (never inserts an orphan row)', async () => {
+    const cfg = baseCfg(false);
+    cfg.strategic_roadmaps = { select: { data: [] } }; // no roadmap
+    const db = makeDb(cfg);
+    const res = await backfillAdamGhosts(db, { apply: true });
+    expect(res.wave_id).toBeNull();
+    expect(res.dry_run).toBe(true);
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('source_type CHECK dormant (23514) downgrades a live apply to dry-run', async () => {
+    const cfg = baseCfg(false);
+    cfg.roadmap_wave_items = { select: { data: [{}] }, insert: { error: { code: '23514', message: 'source_type check' } } };
+    const db = makeDb(cfg);
+    const res = await backfillAdamGhosts(db, { apply: true });
+    expect(res.source_type_unsupported).toBe(true);
+    expect(res.dry_run).toBe(true);
+  });
+
+  it('no ghosts => zero candidates, no writes', async () => {
+    const cfg = baseCfg(false);
+    cfg.strategic_directives_v2 = { select: { data: [] } };
+    const db = makeDb(cfg);
+    const res = await backfillAdamGhosts(db, { apply: true });
+    expect(res.candidates).toBe(0);
+    expect(db.inserted).toHaveLength(0);
+  });
+});
+
+describe('registerAdamDirectCandidate — idempotent + soft-warn (FR-1)', () => {
+  const sd = { id: 'u1', sd_key: 'SD-A', title: 'A' };
+
+  it('idempotent: already-registered SD is a no-op (no warn, not registered)', async () => {
+    const db = makeDb({ roadmap_wave_items: { select: { data: [{ id: 'existing' }] } } });
+    const out = await registerAdamDirectCandidate(db, sd, { apply: true });
+    expect(out.registered).toBe(false);
+    expect(out.reason).toBe('already registered');
+    expect(out.warn).toBe(false);
+  });
+
+  it('missing sd_key/id => soft-warn, does NOT throw', async () => {
+    const db = makeDb({});
+    const out = await registerAdamDirectCandidate(db, { title: 'no key' }, { apply: true });
+    expect(out.registered).toBe(false);
+    expect(typeof out.warn).toBe('boolean');
+    expect(out.reason).toContain('missing');
+  });
+
+  it('lane dormant => dry-run (no write)', async () => {
+    const db = makeDb({
+      roadmap_wave_items: { select: { error: { code: '42703', message: 'lane does not exist' } } },
+      strategic_roadmaps: { select: { data: [{ id: 'rm-1' }] } },
+      roadmap_waves: { select: { data: [{ id: 'wave-1', sequence_rank: 5 }] } },
+    });
+    const out = await registerAdamDirectCandidate(db, sd, { apply: true });
+    expect(out.dry_run).toBe(true);
+    expect(db.inserted).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Sourcing-engine **child 5/10**. Closes the gap where Adam-direct candidates + **78 historically Adam-sourced SDs** bypass the roadmap (no `roadmap_wave_items` row), so register-first / `routeCandidate` / lane coherence never sees them.

## What's new (5 FRs)
- **FR-1** `registerAdamDirectCandidate` — registers one Adam-direct SD, soft-warns on skip (never throws), idempotent.
- **FR-2** `backfillAdamGhosts` — idempotent ghost-backfill of Adam SDs lacking a roadmap row.
- **FR-3** **REUSES** `routeCandidate` (router.js), `isValidLane` (lane.js), `shouldWarnRegisterFirst` (register-first.js) — no duplicate-SSOT.
- **FR-4** `scripts/sourcing-engine/backfill-adam-ghosts.mjs` + `package.json` `sourcing:backfill-adam-ghosts` (WIRE_CHECK).
- **FR-5** `tests/unit/sourcing-engine/adam-direct-registry.test.js` — 15 tests.
- DORMANT additive `source_type` CHECK-widening migration (adds `adam_direct`; Adam applies under delegation).

## Safety — DORMANT-SAFE + DRY-RUN-DEFAULT
The only write target (`roadmap_wave_items`, the chairman-visible LEO Roadmap) is **quad-gated**: `--apply` AND lane column present AND source_type CHECK admits `adam_direct` AND a target wave resolves. The lane column + source_type CHECK are **both currently dormant**, so the live behavior is dry-run only. **Live dry-run verified: 78 ghosts would register, 0 rows written.** The build ships INERT until an operator applies both migrations and passes `--apply`. `UNIQUE(wave_id, source_type, source_id)` gives race-safe idempotency.

## Verification
- 15 tests + live dry-run (78 candidates, 0 writes).
- Adversarial review: **SHIP** (no critical/high/medium; 3 LOW non-blocking — parallel-race mitigated by the existing UNIQUE constraint).
- Handoffs: LEAD-TO-PLAN 94 / PLAN-TO-EXEC 98 / EXEC-TO-PLAN 92 / PLAN-TO-LEAD 95. TESTING+SECURITY @ EXEC, VALIDATION+REGRESSION @ PLAN_VERIFICATION (all PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
