### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001): VDR gauge-gap miner — gauge becomes a forward router

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SECURITY-HYGIENE-RLS-SEARCHPATH-001",
-  "createdAt": "2026-06-16T14:50:43.759Z",
+  "sdKey": "SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001",
+  "createdAt": "2026-06-20T10:19:54.376Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260620_roadmap_wave_items_vdr_gauge_source_type.sql
+++ b/database/migrations/20260620_roadmap_wave_items_vdr_gauge_source_type.sql
@@ -1,0 +1,29 @@
+-- SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001 (FR-2 enabler)
+-- DORMANT (TIER-2): extend roadmap_wave_items.source_type CHECK to admit 'vdr_gauge', so the gauge-gap
+-- miner can register STAGED candidates (one per unbuilt/partial active-rung capability) as roadmap
+-- items. ADDITIVE + REVERSIBLE (widening a CHECK never invalidates existing rows). Workers do NOT
+-- self-apply: Adam applies under the chairman's additive-DDL delegation. Until applied, the engine is
+-- dormant-safe (lib/sourcing-engine/gauge-gap-miner.js forces dry-run on a 23514 CHECK violation) — it
+-- computes what it WOULD stage but writes nothing, so the chairman-visible roadmap is never mutated
+-- prematurely.
+--
+-- Pairs with database/migrations/20260619_sourcing_engine_lane_column.sql (the DORMANT lane column);
+-- BOTH must be applied before the miner stages live. Stacks on the adam_direct widening
+-- (20260620_roadmap_wave_items_adam_direct_source_type.sql) — order-independent (each re-creates the
+-- full allowed set), but the array below MUST include every previously-admitted value.
+
+ALTER TABLE roadmap_wave_items
+  DROP CONSTRAINT IF EXISTS roadmap_wave_items_source_type_check;
+
+ALTER TABLE roadmap_wave_items
+  ADD CONSTRAINT roadmap_wave_items_source_type_check
+  CHECK (source_type = ANY (ARRAY['todoist'::text, 'youtube'::text, 'brainstorm'::text, 'adam_direct'::text, 'vdr_gauge'::text]));
+
+COMMENT ON CONSTRAINT roadmap_wave_items_source_type_check ON roadmap_wave_items IS
+  'Allowed intake source types. vdr_gauge added by SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001 '
+  'so the VDR gauge-gap miner can register STAGED capability-gap candidates as roadmap items.';
+
+-- Rollback (only if NO vdr_gauge rows exist; otherwise widen-only is the safe state):
+--   ALTER TABLE roadmap_wave_items DROP CONSTRAINT IF EXISTS roadmap_wave_items_source_type_check;
+--   ALTER TABLE roadmap_wave_items ADD CONSTRAINT roadmap_wave_items_source_type_check
+--     CHECK (source_type = ANY (ARRAY['todoist'::text, 'youtube'::text, 'brainstorm'::text, 'adam_direct'::text]));

--- a/lib/sourcing-engine/gauge-gap-miner.js
+++ b/lib/sourcing-engine/gauge-gap-miner.js
@@ -39,6 +39,7 @@
  *
  * @module lib/sourcing-engine/gauge-gap-miner
  */
+import { v5 as uuidv5 } from 'uuid';
 import { stampCandidate, deriveOutcomeRealizedKeys } from './dedup-autostamp.js';
 import { resolveTargetWaveId, roadmapLaneColumnExists } from './adam-direct-registry.js';
 import { isValidLane } from './lane.js';
@@ -46,10 +47,21 @@ import { isValidLane } from './lane.js';
 /** The source_type gauge-mined candidates register under (gated by the DORMANT CHECK extension). */
 export const VDR_GAUGE_SOURCE_TYPE = 'vdr_gauge';
 
-/** Stable source_id for a capability gap ('vdr:<capability>') — NOT an sd_key, so the router's
- *  source_id dedup path never false-matches it against an SD. */
-export function gaugeGapSourceId(capability) {
+/** Human-readable trace label for a capability gap (stored in metadata.source_label). */
+export function gaugeGapLabel(capability) {
   return `vdr:${String(capability == null ? '' : capability).trim()}`;
+}
+
+/**
+ * DETERMINISTIC source_id for a capability gap. roadmap_wave_items.source_id is a UUID column — a
+ * non-UUID string (the obvious 'vdr:<capability>' key) 22P02-throws on insert (masked today only by the
+ * dormant lane/source_type gates, lethal on activation). We derive a STABLE UUIDv5 from the capability
+ * (same capability => same id) so the insert is valid AND idempotency still holds; the human-readable
+ * 'vdr:<capability>' key lives in metadata.source_label. NOT an sd_key, so the router's source_id dedup
+ * path never false-matches it against an SD.
+ */
+export function gaugeGapSourceId(capability) {
+  return uuidv5(gaugeGapLabel(capability), uuidv5.URL);
 }
 
 /**
@@ -110,6 +122,7 @@ export function buildStagedRoadmapItem(gap, stamp, { waveId, lanePresent, active
       sourcing_stage: 'staged',
       staged_by: 'vdr-gauge-gap-miner',
       capability: g.capability,
+      source_label: gaugeGapLabel(g.capability), // human-readable key (source_id is a UUIDv5 of this)
       nature: g.nature || null,
       gauge_status: g.status || null,
       rung: activeRungKey,

--- a/lib/sourcing-engine/gauge-gap-miner.js
+++ b/lib/sourcing-engine/gauge-gap-miner.js
@@ -1,0 +1,231 @@
+/**
+ * lib/sourcing-engine/gauge-gap-miner.js
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001 — sourcing-engine child 10/10.
+ *
+ * Turns the READ-ONLY VDR vision gauge into a FORWARD ROUTER (closes the gauge dead-end on the
+ * proactive axis). It reads computeBuildGauge, enumerates active-rung capabilities scored
+ * unbuilt/partial, routes each gap through the SHIPPED router + dedup helper, and registers it as a
+ * STAGED roadmap_wave_items candidate so the weakest BUILDABLE caps continuously feed the sourcing
+ * belt. This is the systematized, automated version of Adam's manual adam-gauge-weakest read.
+ *
+ * REUSE, don't reinvent (duplicate-SSOT is the recurring trap — this child was HELD until DEDUP shipped
+ * precisely so it can reuse the dedup helper):
+ *   - computeBuildGauge / STATUS_SCORE  (lib/vision/vdr-registry.js)        — the live gauge.
+ *   - stampCandidate / deriveOutcomeRealizedKeys (lib/sourcing-engine/dedup-autostamp.js)
+ *                                                                            — the SHIPPED dedup match +
+ *     the infra-shipped!=outcome-realized RE-EMIT rule. We do NOT write a new matcher.
+ *   - routeCandidate (lib/sourcing-engine/router.js, via stampCandidate)    — the pure lane decision.
+ *   - resolveTargetWaveId / roadmapLaneColumnExists (lib/sourcing-engine/adam-direct-registry.js)
+ *                                                                            — the target wave + the
+ *     DORMANT roadmap_wave_items.lane probe (mirror of the ledger probe). Reused, not re-derived.
+ *   - isValidLane (lib/sourcing-engine/lane.js)                             — the CHECK-constraint mirror.
+ *
+ * BUILDABLE-FIRST: an operational/income-nature gap is NOT something the fleet can source an SD to
+ * complete (only a venture/operation flips it). We route it OFF the belt-lead to the chairman-gated
+ * lane (authority:'operational') — never belt-ready. Only buildable gaps lead the belt.
+ *
+ * STAGED-ONLY (FR-4, the hard safeguard): this module NEVER sets promoted_to_sd_key and NEVER mints an
+ * SD. It registers staged candidates (metadata.sourcing_stage='staged'); the chairman baseline gate
+ * governs promotion staged->belt.
+ *
+ * DORMANT-SAFE BY CONSTRUCTION: roadmap_wave_items.lane is a DORMANT column and the 'vdr_gauge'
+ * source_type is a DORMANT CHECK extension. When either is absent the runner forces dry-run (computes
+ * exactly what it WOULD stage but writes nothing), so it ships INERT and never mutates the
+ * chairman-visible roadmap until an operator applies the migrations and passes --apply.
+ *
+ * The decision helpers are PURE (no I/O) so they unit-test without a DB; mineGaugeGaps is the thin
+ * I/O wrapper.
+ *
+ * @module lib/sourcing-engine/gauge-gap-miner
+ */
+import { stampCandidate, deriveOutcomeRealizedKeys } from './dedup-autostamp.js';
+import { resolveTargetWaveId, roadmapLaneColumnExists } from './adam-direct-registry.js';
+import { isValidLane } from './lane.js';
+
+/** The source_type gauge-mined candidates register under (gated by the DORMANT CHECK extension). */
+export const VDR_GAUGE_SOURCE_TYPE = 'vdr_gauge';
+
+/** Stable source_id for a capability gap ('vdr:<capability>') — NOT an sd_key, so the router's
+ *  source_id dedup path never false-matches it against an SD. */
+export function gaugeGapSourceId(capability) {
+  return `vdr:${String(capability == null ? '' : capability).trim()}`;
+}
+
+/**
+ * PURE (FR-1): select the minable gaps from a computeBuildGauge result — active-rung capabilities
+ * scored unbuilt (0) or partial (0.5). 'unknown' (score null) is EXCLUDED (not measurable — never
+ * coerced into a gap, the honest-gauge rule); 'built' (score 1) is excluded (no gap).
+ *
+ * @param {object} gauge - a computeBuildGauge() result ({ available, components:[{capability, nature, status, score}] })
+ * @returns {Array<{capability:string, nature:(string|undefined), status:string, score:number}>}
+ */
+export function selectGaugeGaps(gauge) {
+  if (!gauge || gauge.available !== true || !Array.isArray(gauge.components)) return [];
+  return gauge.components.filter((c) => c && c.score != null && c.score < 1 && c.capability);
+}
+
+/**
+ * PURE (FR-1/FR-2): map a gauge gap component to the router's classifiedItem shape. Operational/income
+ * nature -> authority:'operational' so the SHIPPED router lanes it chairman-gated (off the belt-lead);
+ * buildable -> no authority so it falls through to the belt-ready residual (subject to dedup).
+ *
+ * @param {{capability:string, nature?:string, status?:string}} gap
+ * @param {{activeRungKey?:string}} [opts]
+ * @returns {{source_id:string, title:string, disposition:string, rung:(string|null), authority:(string|null)}}
+ */
+export function gapToCandidate(gap, opts = {}) {
+  const g = gap || {};
+  const isOperational = g.nature === 'operational';
+  return {
+    source_id: gaugeGapSourceId(g.capability),
+    title: g.capability,
+    disposition: 'BUILD',
+    rung: opts.activeRungKey == null ? null : opts.activeRungKey,
+    authority: isOperational ? 'operational' : null,
+  };
+}
+
+/**
+ * PURE (FR-2/FR-4): build the roadmap_wave_items insert payload for ONE staged candidate. STAGED-ONLY —
+ * promoted_to_sd_key is INTENTIONALLY absent (null) so no automated promoter mistakes it for a minted
+ * SD; metadata.sourcing_stage='staged'. lane is included only when lanePresent && the lane is valid
+ * (dormant-safe: a missing column means the insert omits lane, which is nullable).
+ *
+ * @param {{capability:string, nature?:string, status?:string}} gap
+ * @param {{lane:(string|null), dedup_match_sd_key:(string|null), re_emit:boolean}} stamp - stampCandidate output
+ * @param {{waveId:string, lanePresent:boolean, activeRungKey?:string}} ctx
+ * @returns {object} roadmap_wave_items insert payload
+ */
+export function buildStagedRoadmapItem(gap, stamp, { waveId, lanePresent, activeRungKey = null }) {
+  const g = gap || {};
+  const s = stamp || {};
+  const payload = {
+    wave_id: waveId,
+    source_type: VDR_GAUGE_SOURCE_TYPE,
+    source_id: gaugeGapSourceId(g.capability),
+    title: g.capability,
+    promoted_to_sd_key: null, // STAGED-ONLY safeguard (FR-4): never promoted by the miner.
+    metadata: {
+      sourcing_stage: 'staged',
+      staged_by: 'vdr-gauge-gap-miner',
+      capability: g.capability,
+      nature: g.nature || null,
+      gauge_status: g.status || null,
+      rung: activeRungKey,
+      dedup_match_sd_key: s.dedup_match_sd_key || null,
+      re_emit: s.re_emit === true,
+    },
+  };
+  if (lanePresent && isValidLane(s.lane)) payload.lane = s.lane;
+  return payload;
+}
+
+/**
+ * I/O runner (FR-1..FR-5): mine the live gauge, route + dedup each gap via the SHIPPED helpers, and
+ * register STAGED roadmap_wave_items candidates. DRY-RUN by default; pass apply:true to write (and even
+ * then it stays dry-run until BOTH the lane column + the vdr_gauge source_type CHECK migrations land).
+ *
+ * Dedup semantics (FR-3, reusing stampCandidate):
+ *   - terminal duplicate (covered by a completed SD AND outcome-realized) -> lane 'dedup', re_emit=false
+ *     -> SKIPPED (not re-minted).
+ *   - covered-but-still-unbuilt (re_emit) -> lane 'outcome-gated' carrying dedup_match_sd_key -> STAGED.
+ *   - novel buildable -> belt-ready -> STAGED; novel operational -> chairman-gated -> STAGED.
+ * Idempotency: a capability that already has a roadmap_wave_items row (source_type=vdr_gauge,
+ * source_id=vdr:<cap>) is skipped, so a cadence re-run never re-mints the same gap.
+ *
+ * @param {object} opts
+ * @param {object} opts.supabase - service-role client
+ * @param {object} [opts.io] - { supabase, grep } forwarded to computeBuildGauge (defaults to { supabase })
+ * @param {boolean} [opts.apply] - default false (dry-run)
+ * @param {string} [opts.activeRungKey] - active rung label stamped on candidates (default 'V1')
+ * @param {object} [opts.deps] - { computeBuildGauge } injection seam for hermetic tests
+ * @returns {Promise<{available:boolean, gaps:number, staged:number, chairman_routed:number,
+ *   deduped:number, re_emit:number, skipped_existing:number, dry_run:boolean,
+ *   lane_column_missing:boolean, source_type_unsupported:boolean, wave_id:(string|null), errors:Array}>}
+ */
+export async function mineGaugeGaps({ supabase, io, apply = false, activeRungKey = 'V1', deps = {} } = {}) {
+  const computeBuildGauge =
+    deps.computeBuildGauge || (await import('../vision/vdr-registry.js')).computeBuildGauge;
+  const result = {
+    available: false, gaps: 0, staged: 0, chairman_routed: 0, deduped: 0, re_emit: 0,
+    skipped_existing: 0, dry_run: !apply, lane_column_missing: false, source_type_unsupported: false,
+    wave_id: null, errors: [],
+  };
+
+  // FR-1: read the live gauge. Fail-soft — an unavailable gauge yields no gaps (HONEST: could-not-
+  // measure != 0%), never a throw.
+  const gauge = await computeBuildGauge({ io: io || { supabase }, visionSource: true });
+  const gaps = selectGaugeGaps(gauge);
+  result.available = !!(gauge && gauge.available);
+  result.gaps = gaps.length;
+  if (gaps.length === 0) return result;
+
+  // FR-3 dedup inputs: existing SDs (dedup-against set) + completed (shippedInfraKeys) + the gauge-
+  // derived outcome-realized set (reusing the SHIPPED deriveOutcomeRealizedKeys, same gauge).
+  const { data: sds, error: sdErr } = await supabase
+    .from('strategic_directives_v2').select('sd_key, title, status, metadata');
+  if (sdErr) throw new Error(`load SDs failed: ${sdErr.message}`);
+  const existing = (sds || []).map((s) => ({ sd_key: s.sd_key, title: s.title }));
+  const shippedInfraKeys = new Set((sds || []).filter((s) => s.status === 'completed').map((s) => s.sd_key));
+  const sdCapabilityPairs = [];
+  for (const s of sds || []) {
+    const caps = s.metadata && s.metadata.delivers_capabilities;
+    for (const cap of Array.isArray(caps) ? caps : []) {
+      if (typeof cap === 'string') sdCapabilityPairs.push({ sd_key: s.sd_key, capability: cap });
+    }
+  }
+  const outcomeRealizedKeys = deriveOutcomeRealizedKeys(sdCapabilityPairs, gauge.components);
+
+  // Target wave + DORMANT lane-column probe (both reused from adam-direct-registry).
+  const waveId = await resolveTargetWaveId(supabase);
+  result.wave_id = waveId;
+  if (!waveId) { result.dry_run = true; return result; } // no wave => cannot insert; dry-run only.
+  const lanePresent = await roadmapLaneColumnExists(supabase);
+  if (!lanePresent) { result.lane_column_missing = true; result.dry_run = true; }
+
+  // Idempotency set: capabilities already staged (source_type=vdr_gauge).
+  const { data: existingRows } = await supabase
+    .from('roadmap_wave_items').select('source_id').eq('source_type', VDR_GAUGE_SOURCE_TYPE);
+  const alreadyStaged = new Set((existingRows || []).map((r) => r.source_id).filter(Boolean));
+
+  let dryRun = result.dry_run;
+  for (const gap of gaps) {
+    try {
+      const srcId = gaugeGapSourceId(gap.capability);
+      if (alreadyStaged.has(srcId)) { result.skipped_existing++; continue; }
+
+      const candidate = gapToCandidate(gap, { activeRungKey });
+      const stamp = stampCandidate(candidate, { existing, shippedInfraKeys, outcomeRealizedKeys });
+
+      // Terminal duplicate (covered + outcome-realized) -> do NOT re-mint (FR-3).
+      if (stamp.lane === 'dedup' && stamp.re_emit !== true) { result.deduped++; continue; }
+      if (stamp.re_emit) result.re_emit++;
+      if (stamp.lane === 'chairman-gated') result.chairman_routed++;
+
+      const payload = buildStagedRoadmapItem(gap, stamp, { waveId, lanePresent, activeRungKey });
+      if (dryRun) { result.staged++; continue; }
+
+      const { error } = await supabase.from('roadmap_wave_items').insert(payload);
+      if (error) {
+        // source_type CHECK not yet extended (dormant) => 23514: downgrade the WHOLE run to dry-run.
+        if (error.code === '23514' || String(error.message || '').toLowerCase().includes('source_type')) {
+          result.source_type_unsupported = true; result.dry_run = true; dryRun = true; result.staged++;
+          continue;
+        }
+        result.errors.push({ capability: gap.capability, error: error.message });
+        continue;
+      }
+      result.staged++;
+    } catch (err) {
+      result.errors.push({ capability: gap && gap.capability, error: err?.message || String(err) });
+    }
+  }
+  return result;
+}
+
+/** Feature-flag helper for the miner cron: on|1|true => enabled; everything else (incl. undefined) => OFF. */
+export function isGaugeGapMinerFlagEnabled(env = process.env) {
+  const v = String((env && env.SOURCING_GAUGE_GAP_MINER_V1) || 'off').toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}

--- a/package.json
+++ b/package.json
@@ -325,6 +325,7 @@
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
     "prod-error-sweep": "node scripts/clockwork/prod-error-sweep-loop.cjs",
     "sourcing:backfill-adam-ghosts": "node scripts/sourcing-engine/backfill-adam-ghosts.mjs",
+    "sourcing:gauge-gap-miner": "node scripts/sourcing-engine/gauge-gap-miner-sweep.mjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",

--- a/scripts/sourcing-engine/gauge-gap-miner-sweep.mjs
+++ b/scripts/sourcing-engine/gauge-gap-miner-sweep.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * scripts/sourcing-engine/gauge-gap-miner-sweep.mjs
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001 (FR-5) — the VDR gauge-gap miner cron.
+ * DEFAULT-OFF behind SOURCING_GAUGE_GAP_MINER_V1 (mirrors the deferred-watcher / adam opportunity-scan
+ * default-off pattern): when the flag is off it prints SUPPRESSED_FLAG_OFF and exits 0.
+ *
+ * When ON it mines the live VDR gauge for unbuilt/partial active-rung capabilities and registers each
+ * as a STAGED roadmap_wave_items candidate (router-laned, dedup-reused). It NEVER promotes staged->belt
+ * and NEVER mints an SD — the chairman baseline gate governs promotion.
+ *
+ * DRY-RUN by default; pass --apply to write. Dormant-safe: the runner forces dry-run until BOTH the
+ * roadmap_wave_items.lane column and the 'vdr_gauge' source_type CHECK migrations are applied, so it can
+ * never prematurely mutate the chairman-visible roadmap.
+ *
+ * Usage:  npm run sourcing:gauge-gap-miner -- --dry-run     # report only (default)
+ *         npm run sourcing:gauge-gap-miner -- --apply        # live (effective once migrations applied + flag on)
+ */
+import 'dotenv/config';
+import { mineGaugeGaps, isGaugeGapMinerFlagEnabled } from '../../lib/sourcing-engine/gauge-gap-miner.js';
+
+const isMain = (() => {
+  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/')); }
+  catch { return false; }
+})();
+
+if (isMain) {
+  (async () => {
+    if (!isGaugeGapMinerFlagEnabled(process.env)) {
+      console.log('SUPPRESSED_FLAG_OFF (SOURCING_GAUGE_GAP_MINER_V1 not enabled)');
+      process.exit(0);
+    }
+    const { createClient } = await import('@supabase/supabase-js');
+    const supabase = createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY,
+    );
+    const apply = process.argv.includes('--apply');
+    const res = await mineGaugeGaps({ supabase, apply });
+    const mode = res.dry_run ? 'DRY-RUN' : 'APPLIED';
+    console.log(
+      `[gauge-gap-miner] ${mode}: gaps=${res.gaps} staged=${res.staged} chairman_routed=${res.chairman_routed} ` +
+      `deduped=${res.deduped} re_emit=${res.re_emit} skipped_existing=${res.skipped_existing} ` +
+      `available=${res.available} wave=${res.wave_id ? res.wave_id.slice(0, 8) : 'none'} errors=${res.errors.length}`,
+    );
+    if (res.lane_column_missing) console.log('  note: roadmap_wave_items.lane column dormant — forced dry-run (apply the lane migration to enable lane stamping).');
+    if (res.source_type_unsupported) console.log("  note: source_type CHECK does not yet admit 'vdr_gauge' — forced dry-run (apply 20260620_roadmap_wave_items_vdr_gauge_source_type.sql).");
+    if (res.errors.length) for (const e of res.errors) console.warn(`  [error] ${e.capability}: ${e.error}`);
+    process.exit(0);
+  })().catch((err) => { console.error(`[gauge-gap-miner] FATAL: ${err?.message || err}`); process.exit(1); });
+}

--- a/tests/unit/sourcing-engine/gauge-gap-miner.test.js
+++ b/tests/unit/sourcing-engine/gauge-gap-miner.test.js
@@ -21,11 +21,14 @@ import {
   VDR_GAUGE_SOURCE_TYPE,
 } from '../../../lib/sourcing-engine/gauge-gap-miner.js';
 import { stampCandidate } from '../../../lib/sourcing-engine/dedup-autostamp.js';
+import { validate as uuidValidate } from 'uuid';
 
 /**
- * Schema-aware Supabase mock — models the REAL roadmap_wave_items columns (source_type, source_id,
- * title, promoted_to_sd_key, metadata, lane) so a column-name drift would surface (the target_rung-vs-
- * rung lesson). Tracks inserts so STAGED-only + dormant-safe can be asserted.
+ * Schema-aware AND TYPE-aware Supabase mock — models the REAL roadmap_wave_items columns (source_type,
+ * source_id, title, promoted_to_sd_key, metadata, lane) AND enforces that source_id is a valid UUID
+ * (the live column is UUID-typed; a non-UUID 22P02-throws — the activation-lethal bug class the
+ * adversarial review caught, mirroring the target_rung-vs-rung lesson). Tracks inserts so STAGED-only +
+ * dormant-safe can be asserted.
  */
 function makeSupabaseMock({ laneColumnExists = true, sds = [], waveResolvable = true, existingStaged = [], insertError = null } = {}) {
   const inserts = [];
@@ -40,6 +43,10 @@ function makeSupabaseMock({ laneColumnExists = true, sds = [], waveResolvable = 
       order() { return b; },
       insert(payload) {
         if (insertError) return Promise.resolve({ data: null, error: insertError });
+        // TYPE-aware: the live source_id column is UUID — reject a non-UUID exactly as Postgres would.
+        if (table === 'roadmap_wave_items' && payload && payload.source_id != null && !uuidValidate(payload.source_id)) {
+          return Promise.resolve({ data: null, error: { code: '22P02', message: `invalid input syntax for type uuid: "${payload.source_id}"` } });
+        }
         inserts.push(payload);
         return Promise.resolve({ data: [payload], error: null });
       },
@@ -97,7 +104,9 @@ describe('FR-2: gapToCandidate routing', () => {
   it('a buildable gap carries no authority (belt-ready residual)', () => {
     const c = gapToCandidate({ capability: 'Build a thing', nature: 'buildable' }, { activeRungKey: 'V1' });
     expect(c.authority).toBeNull();
-    expect(c.source_id).toBe('vdr:Build a thing');
+    // source_id must be a valid UUID (the live column is UUID-typed), deterministic per capability.
+    expect(uuidValidate(c.source_id)).toBe(true);
+    expect(c.source_id).toBe(gaugeGapSourceId('Build a thing'));
     expect(c.rung).toBe('V1');
     expect(c.disposition).toBe('BUILD');
   });
@@ -144,6 +153,10 @@ describe('FR-1/2/4: mineGaugeGaps runner (live-ish, dry-run)', () => {
     for (const row of supabase._inserts) {
       expect(row.promoted_to_sd_key).toBeNull();
       expect(row.metadata.sourcing_stage).toBe('staged');
+      // Activation-safe: source_id is a valid UUID (the mock 22P02-rejects a non-UUID), and the
+      // human-readable key is preserved in metadata.source_label.
+      expect(uuidValidate(row.source_id)).toBe(true);
+      expect(row.metadata.source_label).toBe(`vdr:${row.metadata.capability}`);
     }
     const lanes = supabase._inserts.map((r) => r.lane).sort();
     expect(lanes).toEqual(['belt-ready', 'chairman-gated']);

--- a/tests/unit/sourcing-engine/gauge-gap-miner.test.js
+++ b/tests/unit/sourcing-engine/gauge-gap-miner.test.js
@@ -1,0 +1,255 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001 (child 10/10) — FR-1..FR-6 unit tests.
+ *
+ * The miner turns the read-only VDR gauge into a forward router: unbuilt/partial active-rung caps
+ * become STAGED roadmap candidates, routed via the SHIPPED router + dedup helper.
+ *   FR-1: select gaps (unbuilt/partial), exclude unknown + built.
+ *   FR-2: buildable -> belt-ready staged; operational -> chairman-gated (off the belt-lead).
+ *   FR-3: REUSE stampCandidate — a covered+realized cap dedups (no re-mint); a covered-but-open cap re-emits.
+ *   FR-4: staged-only — no promoted_to_sd_key, no SD minted.
+ *   FR-5: cron flag default-off.
+ *   + dormant-safe (lane column absent / source_type 23514 -> dry-run) + idempotency.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  selectGaugeGaps,
+  gapToCandidate,
+  gaugeGapSourceId,
+  buildStagedRoadmapItem,
+  mineGaugeGaps,
+  isGaugeGapMinerFlagEnabled,
+  VDR_GAUGE_SOURCE_TYPE,
+} from '../../../lib/sourcing-engine/gauge-gap-miner.js';
+import { stampCandidate } from '../../../lib/sourcing-engine/dedup-autostamp.js';
+
+/**
+ * Schema-aware Supabase mock — models the REAL roadmap_wave_items columns (source_type, source_id,
+ * title, promoted_to_sd_key, metadata, lane) so a column-name drift would surface (the target_rung-vs-
+ * rung lesson). Tracks inserts so STAGED-only + dormant-safe can be asserted.
+ */
+function makeSupabaseMock({ laneColumnExists = true, sds = [], waveResolvable = true, existingStaged = [], insertError = null } = {}) {
+  const inserts = [];
+  const from = (table) => {
+    const state = { table, selectCols: null, filters: {} };
+    const b = {
+      select(cols) { state.selectCols = cols; return b; },
+      eq(col, val) { state.filters[col] = val; return b; },
+      in() { return b; },
+      like() { return b; },
+      limit() { return b; },
+      order() { return b; },
+      insert(payload) {
+        if (insertError) return Promise.resolve({ data: null, error: insertError });
+        inserts.push(payload);
+        return Promise.resolve({ data: [payload], error: null });
+      },
+      then(resolve, reject) { return Promise.resolve(resolveResult(state)).then(resolve, reject); },
+    };
+    return b;
+  };
+  const resolveResult = (state) => {
+    if (state.table === 'strategic_directives_v2') return { data: sds, error: null };
+    if (state.table === 'strategic_roadmaps') return { data: waveResolvable ? [{ id: 'roadmap-1' }] : [], error: null };
+    if (state.table === 'roadmap_waves') return { data: waveResolvable ? [{ id: 'wave-1', sequence_rank: 5 }] : [], error: null };
+    if (state.table === 'roadmap_wave_items' && state.selectCols === 'lane') {
+      return laneColumnExists
+        ? { data: [], error: null }
+        : { data: null, error: { code: '42703', message: 'column roadmap_wave_items.lane does not exist' } };
+    }
+    if (state.table === 'roadmap_wave_items' && state.selectCols === 'source_id') {
+      return { data: existingStaged.map((s) => ({ source_id: s })), error: null };
+    }
+    return { data: [], error: null };
+  };
+  return { from, _inserts: inserts };
+}
+
+const fakeGauge = (components) => async () => ({ available: true, components });
+
+// A gauge with one buildable unbuilt cap, one operational unbuilt cap, one unknown, one built.
+const MIXED_COMPONENTS = [
+  { capability: 'Build a thing', nature: 'buildable', status: 'unbuilt', score: 0 },
+  { capability: 'Take a real dollar', nature: 'operational', status: 'unbuilt', score: 0 },
+  { capability: 'Mystery cap', nature: 'buildable', status: 'unknown', score: null },
+  { capability: 'Already built cap', nature: 'buildable', status: 'built', score: 1 },
+];
+
+describe('FR-1: selectGaugeGaps', () => {
+  it('selects unbuilt/partial caps; excludes unknown and built', () => {
+    const gaps = selectGaugeGaps({ available: true, components: MIXED_COMPONENTS });
+    const caps = gaps.map((g) => g.capability);
+    expect(caps).toContain('Build a thing');
+    expect(caps).toContain('Take a real dollar');
+    expect(caps).not.toContain('Mystery cap'); // unknown excluded (not measurable)
+    expect(caps).not.toContain('Already built cap'); // built excluded (no gap)
+  });
+  it('includes a partial cap', () => {
+    const gaps = selectGaugeGaps({ available: true, components: [{ capability: 'Half done', nature: 'buildable', status: 'partial', score: 0.5 }] });
+    expect(gaps.map((g) => g.capability)).toEqual(['Half done']);
+  });
+  it('returns [] for an unavailable gauge (fail-soft, never a fabricated gap)', () => {
+    expect(selectGaugeGaps({ available: false, components: MIXED_COMPONENTS })).toEqual([]);
+    expect(selectGaugeGaps(null)).toEqual([]);
+  });
+});
+
+describe('FR-2: gapToCandidate routing', () => {
+  it('a buildable gap carries no authority (belt-ready residual)', () => {
+    const c = gapToCandidate({ capability: 'Build a thing', nature: 'buildable' }, { activeRungKey: 'V1' });
+    expect(c.authority).toBeNull();
+    expect(c.source_id).toBe('vdr:Build a thing');
+    expect(c.rung).toBe('V1');
+    expect(c.disposition).toBe('BUILD');
+  });
+  it('an operational gap routes off the belt-lead via authority=operational (chairman-gated)', () => {
+    const c = gapToCandidate({ capability: 'Take a real dollar', nature: 'operational' });
+    expect(c.authority).toBe('operational');
+    // The SHIPPED router maps authority=operational -> chairman-gated.
+    expect(stampCandidate(c, {}).lane).toBe('chairman-gated');
+  });
+});
+
+describe('FR-4: buildStagedRoadmapItem (staged-only)', () => {
+  it('never sets promoted_to_sd_key and marks the row staged', () => {
+    const payload = buildStagedRoadmapItem(
+      { capability: 'Build a thing', nature: 'buildable', status: 'unbuilt' },
+      { lane: 'belt-ready', dedup_match_sd_key: null, re_emit: false },
+      { waveId: 'wave-1', lanePresent: true, activeRungKey: 'V1' },
+    );
+    expect(payload.promoted_to_sd_key).toBeNull();
+    expect(payload.metadata.sourcing_stage).toBe('staged');
+    expect(payload.source_type).toBe(VDR_GAUGE_SOURCE_TYPE);
+    expect(payload.lane).toBe('belt-ready');
+  });
+  it('omits lane when the lane column is dormant', () => {
+    const payload = buildStagedRoadmapItem(
+      { capability: 'Build a thing' },
+      { lane: 'belt-ready', dedup_match_sd_key: null, re_emit: false },
+      { waveId: 'wave-1', lanePresent: false },
+    );
+    expect(payload).not.toHaveProperty('lane');
+  });
+});
+
+describe('FR-1/2/4: mineGaugeGaps runner (live-ish, dry-run)', () => {
+  it('stages a buildable gap belt-ready, routes an operational gap chairman-gated, excludes unknown/built', async () => {
+    const supabase = makeSupabaseMock({ sds: [] });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(MIXED_COMPONENTS) } });
+    expect(res.gaps).toBe(2); // only the two non-unknown, non-built caps
+    expect(res.staged).toBe(2);
+    expect(res.chairman_routed).toBe(1); // the operational cap
+    expect(res.dry_run).toBe(false);
+    // Two staged rows; none promoted (FR-4).
+    expect(supabase._inserts).toHaveLength(2);
+    for (const row of supabase._inserts) {
+      expect(row.promoted_to_sd_key).toBeNull();
+      expect(row.metadata.sourcing_stage).toBe('staged');
+    }
+    const lanes = supabase._inserts.map((r) => r.lane).sort();
+    expect(lanes).toEqual(['belt-ready', 'chairman-gated']);
+  });
+});
+
+describe('FR-3: reuse shipped dedup + re-emit', () => {
+  const COVERED_REALIZED_SD = {
+    sd_key: 'SD-COVERED-REALIZED-001', title: 'Covered cap', status: 'completed',
+    metadata: { delivers_capabilities: ['A built capability'] },
+  };
+  const COVERED_OPEN_SD = {
+    sd_key: 'SD-COVERED-OPEN-001', title: 'Open infra cap', status: 'completed',
+    metadata: { delivers_capabilities: [] },
+  };
+
+  it('a covered+realized cap dedups with NO re-mint (terminal duplicate)', async () => {
+    const components = [
+      { capability: 'Covered cap', nature: 'buildable', status: 'partial', score: 0.5 }, // the gap
+      { capability: 'A built capability', nature: 'buildable', status: 'built', score: 1 }, // realizes the SD
+    ];
+    const supabase = makeSupabaseMock({ sds: [COVERED_REALIZED_SD] });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(components) } });
+    expect(res.deduped).toBe(1);
+    expect(res.staged).toBe(0);
+    expect(supabase._inserts).toHaveLength(0); // not re-minted
+  });
+
+  it('a covered-but-outcome-open cap re-emits as a staged outcome-gated candidate', async () => {
+    const components = [
+      { capability: 'Open infra cap', nature: 'buildable', status: 'unbuilt', score: 0 }, // gap matches a completed SD, but no built capability realizes it
+    ];
+    const supabase = makeSupabaseMock({ sds: [COVERED_OPEN_SD] });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(components) } });
+    expect(res.re_emit).toBe(1);
+    expect(res.staged).toBe(1);
+    expect(supabase._inserts).toHaveLength(1);
+    expect(supabase._inserts[0].lane).toBe('outcome-gated');
+    expect(supabase._inserts[0].metadata.dedup_match_sd_key).toBe('SD-COVERED-OPEN-001');
+    expect(supabase._inserts[0].metadata.re_emit).toBe(true);
+  });
+
+  it("the runner's dedup verdict is the SHIPPED stampCandidate's verdict (no new matcher)", () => {
+    const candidate = gapToCandidate({ capability: 'Covered cap', nature: 'buildable' });
+    const stamp = stampCandidate(candidate, {
+      existing: [{ sd_key: 'SD-COVERED-REALIZED-001', title: 'Covered cap' }],
+      shippedInfraKeys: ['SD-COVERED-REALIZED-001'],
+      outcomeRealizedKeys: ['SD-COVERED-REALIZED-001'],
+    });
+    expect(stamp.lane).toBe('dedup');
+    expect(stamp.re_emit).toBe(false);
+  });
+});
+
+describe('dormant-safe + idempotency', () => {
+  it('forces dry-run when the lane column is dormant (no writes)', async () => {
+    const supabase = makeSupabaseMock({ laneColumnExists: false });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(MIXED_COMPONENTS) } });
+    expect(res.lane_column_missing).toBe(true);
+    expect(res.dry_run).toBe(true);
+    expect(supabase._inserts).toHaveLength(0);
+    expect(res.staged).toBe(2); // computed what it WOULD stage
+  });
+
+  it('forces dry-run when source_type CHECK rejects vdr_gauge (23514)', async () => {
+    const supabase = makeSupabaseMock({ insertError: { code: '23514', message: 'roadmap_wave_items_source_type_check' } });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(MIXED_COMPONENTS) } });
+    expect(res.source_type_unsupported).toBe(true);
+    expect(res.dry_run).toBe(true);
+    expect(supabase._inserts).toHaveLength(0); // insert attempted, rejected, nothing persisted
+  });
+
+  it('forces dry-run when no target wave resolves', async () => {
+    const supabase = makeSupabaseMock({ waveResolvable: false });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(MIXED_COMPONENTS) } });
+    expect(res.wave_id).toBeNull();
+    expect(res.dry_run).toBe(true);
+    expect(supabase._inserts).toHaveLength(0);
+  });
+
+  it('skips a capability already staged (idempotent re-run, no re-mint)', async () => {
+    const supabase = makeSupabaseMock({ existingStaged: [gaugeGapSourceId('Build a thing')] });
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: fakeGauge(MIXED_COMPONENTS) } });
+    expect(res.skipped_existing).toBe(1);
+    // only the operational cap remains to stage
+    expect(supabase._inserts.map((r) => r.source_id)).toEqual([gaugeGapSourceId('Take a real dollar')]);
+  });
+
+  it('fail-soft: an unavailable gauge yields no gaps and no writes', async () => {
+    const supabase = makeSupabaseMock();
+    const res = await mineGaugeGaps({ supabase, apply: true, deps: { computeBuildGauge: async () => ({ available: false, components: [] }) } });
+    expect(res.available).toBe(false);
+    expect(res.gaps).toBe(0);
+    expect(supabase._inserts).toHaveLength(0);
+  });
+});
+
+describe('FR-5: cron flag default-off', () => {
+  it('off by default and for unrecognized values', () => {
+    expect(isGaugeGapMinerFlagEnabled({})).toBe(false);
+    expect(isGaugeGapMinerFlagEnabled({ SOURCING_GAUGE_GAP_MINER_V1: 'off' })).toBe(false);
+    expect(isGaugeGapMinerFlagEnabled({ SOURCING_GAUGE_GAP_MINER_V1: 'maybe' })).toBe(false);
+  });
+  it('on for on|1|true', () => {
+    expect(isGaugeGapMinerFlagEnabled({ SOURCING_GAUGE_GAP_MINER_V1: 'on' })).toBe(true);
+    expect(isGaugeGapMinerFlagEnabled({ SOURCING_GAUGE_GAP_MINER_V1: '1' })).toBe(true);
+    expect(isGaugeGapMinerFlagEnabled({ SOURCING_GAUGE_GAP_MINER_V1: 'TRUE' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Sourcing-engine **child 10/10**. Turns the read-only VDR vision gauge into a **forward router**: enumerates unbuilt/partial active-rung capabilities and registers each as a **STAGED** `roadmap_wave_items` candidate, routed through the SHIPPED router + dedup helper. Systematizes Adam's manual gauge-weakest read into an engine loop.

## What it does (FR-1..FR-6)
- **FR-1** `selectGaugeGaps`: unbuilt/partial active-rung caps; **excludes unknown** (not measurable — honest gauge) and built.
- **FR-2** buildable → `belt-ready` staged; **operational/income → `chairman-gated`** (off the belt-lead per buildable-first). register-first via reused `resolveTargetWaveId`.
- **FR-3** REUSE `stampCandidate` + `deriveOutcomeRealizedKeys` (no new matcher): covered+realized cap dedups (no re-mint); covered-but-open cap re-emits `outcome-gated`.
- **FR-4** **STAGED-ONLY safeguard**: never sets `promoted_to_sd_key`, never mints an SD — chairman baseline gate governs promotion.
- **FR-5** default-OFF cron (`SOURCING_GAUGE_GAP_MINER_V1`) + `package.json` WIRE_CHECK entry.
- **Dormant-safe**: dry-run until the `roadmap_wave_items.lane` column + the `vdr_gauge` source_type CHECK migrations are applied.

## Reuse (no duplicate-SSOT — this child was HELD for DEDUP)
`stampCandidate`/`deriveOutcomeRealizedKeys` (dedup-autostamp) · `resolveTargetWaveId`/`roadmapLaneColumnExists` (adam-direct-registry) · `routeCandidate` (router) · `isValidLane` (lane) · `computeBuildGauge` (vdr-registry).

## Adversarial catch (HIGH ship-blocker, fixed)
`roadmap_wave_items.source_id` is **UUID-typed**; the obvious `vdr:<capability>` string would `22P02` on every insert once the migrations land (masked by dormancy, lethal on activation — the target_rung-vs-rung bug class on TYPE). Fixed: `source_id` is now a deterministic **UUIDv5** of the capability (idempotency preserved); human key in `metadata.source_label`. The test mock is now **type-aware** (22P02-rejects a non-UUID), catching the regression class at unit tier.

## Tests / smoke
- 18 unit tests pass (schema- + type-aware mock).
- Live dry-run smoke: `gaps=5 staged=5 chairman_routed=4 deduped=0 re_emit=0`, lane column dormant → forced dry-run, **zero writes**.

## Activation
Adam applies `20260620_roadmap_wave_items_vdr_gauge_source_type.sql` (+ the dormant lane column) and sets the flag on; ships INERT until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)