### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-OUTCOME-DECOMPOSER-001): outcome-gated decomposer (propose-and-pause)

### DIFF
--- a/lib/sourcing-engine/escalator.js
+++ b/lib/sourcing-engine/escalator.js
@@ -25,25 +25,43 @@ const DORMANT_CODES = new Set(['PGRST205', 'PGRST204', '42P01']);
 /**
  * Build the chairman-queue row for a routed candidate, or null if its lane is not a queue lane.
  * PURE — no IO. `item` is the classified candidate (source_id/title); `routed` is routeCandidate output.
+ *
+ * OVERRIDES (backward-compatible — all default to the original lane-derived behavior; added for the
+ * outcome-decomposer child 7, which queues a DISTINCT gate_type so its proposal row coexists with this
+ * escalator's plain outcome-gated row for the same source_id under the (source_id, gate_type) key):
+ *   - opts.gateType        : override the gate_type column (default = lane)
+ *   - opts.escalationType  : override escalation_type (default = authority reason / 'outcome')
+ *   - opts.extraContext    : shallow-merged into the context jsonb (e.g. proposed_enablers)
+ *
  * @param {{source_id?:string, title?:string}} item
  * @param {{lane?:string, rung?:string|null, disposition?:string|null, escalation?:object, enablers?:string[]}} routed
- * @param {{slaHours?:number}} [opts]
+ * @param {{slaHours?:number, gateType?:string, escalationType?:string, extraContext?:object}} [opts]
  * @returns {object|null}
  */
 export function buildQueueRow(item = {}, routed = {}, opts = {}) {
   const lane = routed && routed.lane;
   if (!QUEUE_LANES.includes(lane)) return null;
-  const escalation_type = lane === LANE.CHAIRMAN_GATED
-    ? ((routed.escalation && routed.escalation.reason) || 'chairman')
-    : 'outcome';
+  // Overrides are accepted only as NON-EMPTY strings — an empty gate_type would be non-null in SQL and
+  // silently collide every row on (source_id, '') under the UNIQUE idempotency key.
+  const hasGateType = typeof opts.gateType === 'string' && opts.gateType !== '';
+  const hasEscType = typeof opts.escalationType === 'string' && opts.escalationType !== '';
+  const escalation_type = hasEscType
+    ? opts.escalationType
+    : (lane === LANE.CHAIRMAN_GATED
+        ? ((routed.escalation && routed.escalation.reason) || 'chairman')
+        : 'outcome');
+  const gate_type = hasGateType ? opts.gateType : lane;
   const slaHours = opts.slaHours != null ? opts.slaHours : DEFAULT_SLA_HOURS[lane];
   return {
     source_id: item.source_id != null ? item.source_id : null,
     title: item.title != null ? item.title : null,
     lane,
-    gate_type: lane,
+    gate_type,
     escalation_type,
     context: {
+      // extraContext spreads FIRST so the routed-derived base keys (rung/disposition/escalation/enablers)
+      // always win on a key collision — extras can only ADD fields, never clobber the canonical payload.
+      ...(opts.extraContext && typeof opts.extraContext === 'object' ? opts.extraContext : {}),
       rung: routed.rung != null ? routed.rung : null,
       disposition: routed.disposition != null ? routed.disposition : null,
       escalation: routed.escalation || null,
@@ -59,11 +77,16 @@ export function buildQueueRow(item = {}, routed = {}, opts = {}) {
  * verdict object. Fail-soft when the client is missing or the table is absent (DORMANT).
  * @param {object} item   - classified candidate (source_id/title)
  * @param {object} routed - routeCandidate output
- * @param {{ supabase?:object, nowIso?:string, slaHours?:number }} [deps]
+ * @param {{ supabase?:object, nowIso?:string, slaHours?:number, gateType?:string, escalationType?:string, extraContext?:object }} [deps]
  * @returns {Promise<{escalated:boolean, reason?:string, id?:string|null, deduped?:boolean, degraded?:boolean, error?:string}>}
  */
 export async function escalateToChairmanQueue(item, routed, deps = {}) {
-  const row = buildQueueRow(item, routed, { slaHours: deps.slaHours });
+  const row = buildQueueRow(item, routed, {
+    slaHours: deps.slaHours,
+    gateType: deps.gateType,
+    escalationType: deps.escalationType,
+    extraContext: deps.extraContext,
+  });
   if (!row) return { escalated: false, reason: 'not_a_gated_lane' };
   // Idempotency depends on UNIQUE (source_id, gate_type); in Postgres NULL != NULL, so a null
   // source_id would defeat the upsert conflict and re-insert on every router pass. Refuse it loudly

--- a/lib/sourcing-engine/outcome-decomposer.js
+++ b/lib/sourcing-engine/outcome-decomposer.js
@@ -1,0 +1,114 @@
+/**
+ * lib/sourcing-engine/outcome-decomposer.js
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-OUTCOME-DECOMPOSER-001 — sourcing-engine child 7/10.
+ *
+ * The OUTCOME-GATED axis of the engine's no-drop guarantee, and its keystone value-add: it turns the
+ * gauge from a dead-end into a forward router. An outcome-gated capability (one whose required state is
+ * an OUTCOME, not a build — a venture EARNING, a >=90% breakage-caught rate, distance-to-quit
+ * instrumented) reads unbuilt forever with no buildable next step. This decomposer takes such a
+ * candidate and PROPOSES the fleet-BUILDABLE enablers that move the outcome (the instrumentation, the
+ * rails, the surfaces), then PAUSES for chairman review — it NEVER auto-creates enabler SDs
+ * (chairman-ratified decision #2: propose-and-pause).
+ *
+ * REUSE, don't reinvent (FR-3, the duplicate-SSOT trap):
+ *   - routeCandidate (child 1) decides the outcome-gated lane — we guard on its verdict, not a re-derive.
+ *   - the shipped escalator (child 4, escalateToChairmanQueue) is the ONE queue-writer to
+ *     sourcing_chairman_queue. We reuse it with a DISTINCT gate_type ('outcome_decomposition') so the
+ *     proposal row coexists with child 4's plain 'outcome-gated' escalation for the same source_id under
+ *     the (source_id, gate_type) idempotency key — rather than hand-rolling a second insert path.
+ *
+ * The decomposition core is PURE (deterministic mapping from the candidate's own enabler hints to a
+ * proposed enabler list with rationale; no LLM hard-dependency — enrichment is an optional future layer).
+ */
+// @wire-check-exempt: child-7 library whose only consumers today are its test and the unbuilt sibling
+// engine children (the populator/orchestrator that will drive the decomposer over outcome-gated ledger
+// rows). Per the engine design the pure decomposer + propose-and-pause writer land before that driver,
+// reusing the shipped routeCandidate + escalator SSOTs. Pinned by tests/unit/sourcing-engine/outcome-decomposer.test.js.
+import { routeCandidate, LANES } from './router.js';
+import { escalateToChairmanQueue } from './escalator.js';
+
+/** The chairman-queue gate_type for a decomposition proposal — DISTINCT from child 4's lane-named gate. */
+export const DECOMPOSITION_GATE_TYPE = 'outcome_decomposition';
+
+/**
+ * PURE (FR-1): decompose an outcome-gated candidate into a PROPOSED fleet-buildable enabler list.
+ *
+ * Deterministic: each enabler is derived from the candidate's own enabler hints (the strings the
+ * classifier/router attached) — never fabricated. A hint may be a plain string or an object
+ * {capability|title, target_rung?, rationale?}; it is normalized to a proposed enabler carrying a
+ * rationale that links it to the outcome. With no hints the proposal is empty (safe: propose nothing
+ * rather than invent buildable work).
+ *
+ * @param {{title?:string, outcome?:string, enablers?:Array<string|object>, targetRung?:string|null, rung?:string|null}} candidate
+ * @returns {{ outcome:(string|null), target_rung:(string|null), enablers:Array<{capability:string, rationale:string, target_rung:(string|null), buildable:boolean}>, proposed_count:number, reason?:string }}
+ */
+export function decomposeOutcome(candidate) {
+  const c = candidate || {}; // crash-safe on null/undefined, mirroring routeCandidate's house style
+  const outcome = c.outcome != null ? c.outcome : (c.title != null ? c.title : null);
+  const targetRung = c.targetRung != null ? c.targetRung : (c.rung != null ? c.rung : null);
+  const hints = Array.isArray(c.enablers) ? c.enablers : [];
+
+  const enablers = [];
+  for (const h of hints) {
+    let capability = null;
+    let rung = targetRung;
+    let rationale = null;
+    if (typeof h === 'string' && h.trim()) {
+      capability = h.trim();
+    } else if (h && typeof h === 'object') {
+      capability = (h.capability || h.title || '').toString().trim() || null;
+      if (h.target_rung != null) rung = h.target_rung;
+      if (typeof h.rationale === 'string' && h.rationale.trim()) rationale = h.rationale.trim();
+    }
+    if (!capability) continue; // skip empty/malformed hints rather than emit a blank enabler
+    enablers.push({
+      capability,
+      rationale: rationale || `Fleet-buildable enabler advancing the outcome${outcome ? ` "${outcome}"` : ''}.`,
+      target_rung: rung != null ? rung : null,
+      buildable: true,
+    });
+  }
+
+  const out = { outcome, target_rung: targetRung, enablers, proposed_count: enablers.length };
+  if (enablers.length === 0) out.reason = 'no_enabler_hints';
+  return out;
+}
+
+/**
+ * FR-2/FR-3/FR-4: PROPOSE-AND-PAUSE. For an outcome-gated candidate, compute the proposed enabler list
+ * and write ONE pending chairman-queue row (gate_type='outcome_decomposition') via the shipped
+ * escalator. NEVER drafts an enabler SD. Idempotent on (source_id, 'outcome_decomposition') via the
+ * escalator's upsert. Fail-soft (dormant table / no client) is inherited from the escalator.
+ *
+ * @param {object} candidate - classified candidate (must carry source_id; title/enablers/targetRung)
+ * @param {object|null} [routed] - routeCandidate output; computed from `candidate` when omitted (reuse)
+ * @param {{ supabase?:object, nowIso?:string, slaHours?:number }} [deps]
+ * @returns {Promise<{ proposed:boolean, reason?:string, decomposition?:object, queue?:object }>}
+ */
+export async function proposeOutcomeDecomposition(candidate, routed = null, deps = {}) {
+  const item = candidate || {};
+  const r = routed || routeCandidate(item, deps.routeContext || {});
+  if (!r || r.lane !== LANES.OUTCOME_GATED) {
+    return { proposed: false, reason: 'not_outcome_gated' };
+  }
+
+  const decomposition = decomposeOutcome(item);
+
+  const queue = await escalateToChairmanQueue(item, r, {
+    supabase: deps.supabase,
+    nowIso: deps.nowIso,
+    slaHours: deps.slaHours,
+    gateType: DECOMPOSITION_GATE_TYPE,
+    escalationType: DECOMPOSITION_GATE_TYPE,
+    extraContext: {
+      decomposition_source: 'outcome-decomposer',
+      outcome: decomposition.outcome,
+      proposed_enablers: decomposition.enablers,
+      proposed_count: decomposition.proposed_count,
+    },
+  });
+
+  // FR-2: we ONLY queue a proposal for chairman review — no enabler SD is drafted here.
+  return { proposed: queue.escalated === true, reason: queue.reason, decomposition, queue };
+}

--- a/tests/unit/sourcing-engine/escalator.test.js
+++ b/tests/unit/sourcing-engine/escalator.test.js
@@ -69,6 +69,43 @@ describe('buildQueueRow (FR-2)', () => {
     expect(row.sla_hours).toBe(24);
   });
 
+  it('opts.gateType / escalationType / extraContext override the lane-derived defaults (child-7 reuse)', () => {
+    const row = buildQueueRow(
+      { source_id: 's' },
+      { lane: LANE.OUTCOME_GATED, rung: 'V2' },
+      { gateType: 'outcome_decomposition', escalationType: 'outcome_decomposition', extraContext: { proposed_enablers: [{ capability: 'X' }] } },
+    );
+    expect(row.lane).toBe('outcome-gated'); // lane column unchanged — still the router lane
+    expect(row.gate_type).toBe('outcome_decomposition'); // distinct idempotency axis
+    expect(row.escalation_type).toBe('outcome_decomposition');
+    expect(row.context.proposed_enablers).toEqual([{ capability: 'X' }]);
+    expect(row.context.rung).toBe('V2'); // base context preserved
+  });
+
+  it('omitting the overrides preserves the original lane-derived behavior (back-compat)', () => {
+    const row = buildQueueRow({ source_id: 's' }, { lane: LANE.OUTCOME_GATED });
+    expect(row.gate_type).toBe('outcome-gated');
+    expect(row.escalation_type).toBe('outcome');
+    expect(row.context.proposed_enablers).toBeUndefined();
+  });
+
+  it('extraContext can ADD fields but never clobbers the routed base context keys', () => {
+    const row = buildQueueRow(
+      { source_id: 's' },
+      { lane: LANE.OUTCOME_GATED, rung: 'V2', enablers: ['base'] },
+      { extraContext: { enablers: ['CLOBBER'], rung: 'V9', proposed_enablers: [{ capability: 'X' }] } },
+    );
+    expect(row.context.enablers).toEqual(['base']); // base wins
+    expect(row.context.rung).toBe('V2');            // base wins
+    expect(row.context.proposed_enablers).toEqual([{ capability: 'X' }]); // additive field survives
+  });
+
+  it('rejects an empty-string gateType/escalationType override (would break the idempotency key)', () => {
+    const row = buildQueueRow({ source_id: 's' }, { lane: LANE.OUTCOME_GATED }, { gateType: '', escalationType: '' });
+    expect(row.gate_type).toBe('outcome-gated'); // falls back to lane, not ''
+    expect(row.escalation_type).toBe('outcome');
+  });
+
   it('QUEUE_LANES + DEFAULT_SLA_HOURS only cover the two gated lanes', () => {
     expect(QUEUE_LANES).toEqual(['chairman-gated', 'outcome-gated']);
     expect(DEFAULT_SLA_HOURS['chairman-gated']).toBe(72);

--- a/tests/unit/sourcing-engine/outcome-decomposer.test.js
+++ b/tests/unit/sourcing-engine/outcome-decomposer.test.js
@@ -1,0 +1,127 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-OUTCOME-DECOMPOSER-001 (child 7/10) — FR-6 unit tests.
+ *
+ * The outcome-gated decomposer: PROPOSE a fleet-buildable enabler list + PAUSE for chairman review.
+ *   FR-1: pure decomposeOutcome maps the candidate's enabler hints -> proposed enablers with rationale.
+ *   FR-2: propose-and-pause writes ONE pending chairman-queue row (gate_type='outcome_decomposition');
+ *         NO enabler SD is auto-created.
+ *   FR-3: reuses routeCandidate (lane guard) + the shipped escalator (one queue-writer SSOT).
+ *   FR-4: idempotent — a re-run upserts on (source_id, 'outcome_decomposition'), no duplicate.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  decomposeOutcome,
+  proposeOutcomeDecomposition,
+  DECOMPOSITION_GATE_TYPE,
+} from '../../../lib/sourcing-engine/outcome-decomposer.js';
+import { LANE } from '../../../lib/sourcing-engine/lane.js';
+import { routeCandidate } from '../../../lib/sourcing-engine/router.js';
+
+// A recording supabase stub: from().upsert().select() resolves to `result`; records every call+table.
+function recordingSupabase(result = { data: [{ id: 'q1' }], error: null }) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      const q = { table };
+      const api = {
+        upsert(row, opts) { q.op = 'upsert'; q.row = row; q.opts = opts; calls.push(q); return api; },
+        insert(row) { q.op = 'insert'; q.row = row; calls.push(q); return api; },
+        select(cols) { q.select = cols; return api; },
+        then(resolve) { return resolve(result); },
+      };
+      return api;
+    },
+  };
+}
+
+describe('FR-1: decomposeOutcome (pure)', () => {
+  it('maps string enabler hints to proposed enablers with an outcome-linked rationale', () => {
+    const d = decomposeOutcome({
+      title: 'Venture is EARNING real revenue',
+      enablers: ['Payment rail integration', 'Revenue instrumentation surface'],
+      targetRung: 'V2',
+    });
+    expect(d.outcome).toBe('Venture is EARNING real revenue');
+    expect(d.target_rung).toBe('V2');
+    expect(d.proposed_count).toBe(2);
+    expect(d.enablers[0]).toMatchObject({ capability: 'Payment rail integration', buildable: true, target_rung: 'V2' });
+    expect(d.enablers[0].rationale).toContain('Venture is EARNING real revenue');
+  });
+
+  it('accepts object hints (capability/title + per-enabler rung + rationale)', () => {
+    const d = decomposeOutcome({
+      title: '>=90% breakage caught',
+      enablers: [{ capability: 'Breakage detector', target_rung: 'V1', rationale: 'Detects breaks to measure the rate' }],
+    });
+    expect(d.enablers[0]).toMatchObject({ capability: 'Breakage detector', target_rung: 'V1', rationale: 'Detects breaks to measure the rate' });
+  });
+
+  it('proposes nothing (safe) when there are no enabler hints, and records a reason', () => {
+    const d = decomposeOutcome({ title: 'Distance-to-quit instrumented' });
+    expect(d.proposed_count).toBe(0);
+    expect(d.enablers).toEqual([]);
+    expect(d.reason).toBe('no_enabler_hints');
+  });
+
+  it('skips empty/malformed hints rather than emitting a blank enabler', () => {
+    const d = decomposeOutcome({ title: 'O', enablers: ['', '   ', {}, { capability: '' }, 'Real enabler'] });
+    expect(d.proposed_count).toBe(1);
+    expect(d.enablers[0].capability).toBe('Real enabler');
+  });
+
+  it('is crash-safe on null/undefined input (house-style pure primitive)', () => {
+    for (const bad of [null, undefined]) {
+      const d = decomposeOutcome(bad);
+      expect(d).toMatchObject({ outcome: null, target_rung: null, enablers: [], proposed_count: 0, reason: 'no_enabler_hints' });
+    }
+  });
+});
+
+describe('FR-2/FR-3/FR-4: proposeOutcomeDecomposition (propose-and-pause)', () => {
+  const outcomeCandidate = { source_id: 'led-7', title: 'Venture is EARNING', needsOutcome: true, targetRung: 'V2', enablers: ['Payment rail'] };
+
+  it('writes ONE pending chairman-queue row with the decomposition gate_type + proposed enablers', async () => {
+    const sb = recordingSupabase({ data: [{ id: 'qid' }], error: null });
+    const res = await proposeOutcomeDecomposition(outcomeCandidate, null, { supabase: sb, nowIso: '2026-06-20T00:00:00.000Z' });
+    expect(res.proposed).toBe(true);
+    expect(sb.calls).toHaveLength(1);
+    const call = sb.calls[0];
+    expect(call.table).toBe('sourcing_chairman_queue');
+    expect(call.op).toBe('upsert');
+    expect(call.row.gate_type).toBe('outcome_decomposition');
+    expect(call.row.state).toBe('pending');
+    expect(call.row.context.proposed_enablers[0]).toMatchObject({ capability: 'Payment rail', buildable: true });
+    expect(call.row.context.decomposition_source).toBe('outcome-decomposer');
+  });
+
+  it('does NOT auto-create any enabler SD (no insert into strategic_directives_v2)', async () => {
+    const sb = recordingSupabase();
+    await proposeOutcomeDecomposition(outcomeCandidate, null, { supabase: sb });
+    expect(sb.calls.every((c) => c.table === 'sourcing_chairman_queue')).toBe(true);
+    expect(sb.calls.some((c) => c.table === 'strategic_directives_v2')).toBe(false);
+    expect(sb.calls.some((c) => c.op === 'insert')).toBe(false);
+  });
+
+  it('is idempotent — upserts on (source_id, gate_type); a conflict returns proposed:true without duplicating', async () => {
+    const sb = recordingSupabase({ data: [], error: null }); // ignoreDuplicates => empty on conflict
+    const res = await proposeOutcomeDecomposition(outcomeCandidate, null, { supabase: sb });
+    expect(res.proposed).toBe(true);
+    expect(res.queue.deduped).toBe(true);
+    expect(sb.calls[0].opts).toMatchObject({ onConflict: 'source_id,gate_type', ignoreDuplicates: true });
+  });
+
+  it('skips a non-outcome-gated candidate (reuses routeCandidate lane verdict)', async () => {
+    const sb = recordingSupabase();
+    const beltReady = { source_id: 'b', title: 'plain buildable' };
+    expect(routeCandidate(beltReady).lane).toBe(LANE.BELT_READY);
+    const res = await proposeOutcomeDecomposition(beltReady, null, { supabase: sb });
+    expect(res).toMatchObject({ proposed: false, reason: 'not_outcome_gated' });
+    expect(sb.calls).toHaveLength(0);
+  });
+
+  it('the decomposition gate_type constant is distinct from the lane-named gate', () => {
+    expect(DECOMPOSITION_GATE_TYPE).toBe('outcome_decomposition');
+    expect(DECOMPOSITION_GATE_TYPE).not.toBe(LANE.OUTCOME_GATED);
+  });
+});


### PR DESCRIPTION
Sourcing engine child 7/10: outcome-gated decomposer. PROPOSEs fleet-buildable enabler lists and PAUSEs for chairman review, closing the gauge dead-end.

Pure decomposeOutcome + propose-and-pause writer reusing routeCandidate (outcome-gated lane verdict) and the shipped escalateToChairmanQueue as single queue-writer. Idempotent under UNIQUE(source_id, gate_type).

SD completed via LEAD-FINAL-APPROVAL (score 99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)