### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-PROACTIVE-POPULATOR-001): proactive corpus populator (dry-run-default, chairman-gated)

### DIFF
--- a/lib/sourcing-engine/proactive-populator.js
+++ b/lib/sourcing-engine/proactive-populator.js
@@ -1,0 +1,208 @@
+/**
+ * Proactive corpus populator — SD-LEO-INFRA-SOURCING-ENGINE-PROACTIVE-POPULATOR-001 (child 9/10).
+ *
+ * Enumerates the full sourcing corpus from its 4 canonical sources, classifies+routes each item via
+ * the SHIPPED routeCandidate/stampCandidate, and (only when chairman-approved) STAGES register-first
+ * roadmap_wave_items rows. DRY-RUN BY DEFAULT — the bare path stages NOTHING and emits a per-lane /
+ * per-rung baseline REPORT (the chairman's review artifact, FR-5).
+ *
+ * REUSE, do not re-derive (the duplicate-SSOT trap):
+ *   - stampCandidate / routeCandidate / ledgerLaneColumnExists (lib/sourcing-engine/dedup-autostamp.js + router.js)
+ *   - roadmapLaneColumnExists / resolveTargetWaveId (lib/sourcing-engine/adam-direct-registry.js)
+ *   - shouldWarnRegisterFirst (lib/sourcing-engine/register-first.js)
+ *
+ * HARD SAFEGUARDS (FR-3): writes require apply=true AND chairmanApproved=true; staging only ever
+ * INSERTs roadmap_wave_items at item_disposition='pending' (the STAGED state) — it NEVER sets
+ * promoted_to_sd_key (never promotes staged->belt) and NEVER creates an SD. Idempotent on the
+ * UNIQUE(wave_id, source_type, source_id) key. Dormant-safe: the lane column is omitted when absent.
+ *
+ * @module lib/sourcing-engine/proactive-populator
+ */
+
+import { stampCandidate } from './dedup-autostamp.js';
+import { roadmapLaneColumnExists, resolveTargetWaveId } from './adam-direct-registry.js';
+import { shouldWarnRegisterFirst } from './register-first.js';
+
+/** Map a corpus item to a LIVE-allowed roadmap_wave_items.source_type (CHECK: todoist|youtube|brainstorm). */
+export function corpusSourceType(item) {
+  const pool = item && item.source_pool;
+  if (pool === 'todoist_todo') return 'todoist';
+  if (pool === 'youtube_playlist') return 'youtube';
+  // estate / sd_proposal / deferred-V2 / harness-backlog / Wave-6 -> the live 'brainstorm' staging vehicle
+  // (will migrate to 'adam_direct' once the dormant source_type CHECK extension lands).
+  return 'brainstorm';
+}
+
+/**
+ * Load + normalize the 4 corpus sources into a single de-duplicated candidate list (FR-1).
+ * Each candidate carries { corpus, source_type, source_id (stable, for the UNIQUE key), title,
+ * disposition, rung, sdKeyHint } — the shape routeCandidate/stampCandidate consume. Dedup is by the
+ * (source_type, source_id) pair (the same key the staged-write idempotency uses), so the same intake
+ * item enumerated from two sources collapses to one candidate. PURE over the injected loaders.
+ *
+ * @param {object} sources - { ledger:[], wave6:[], deferred:[], backlog:[] } pre-loaded rows
+ * @returns {Array<{corpus,source_type,source_id,title,disposition,rung,sdKeyHint}>}
+ */
+export function buildCorpus({ ledger = [], wave6 = [], deferred = [], backlog = [] } = {}) {
+  const out = [];
+  const seen = new Set();
+  const push = (c) => {
+    if (!c.source_id) return;
+    const key = `${c.source_type}::${c.source_id}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(c);
+  };
+  for (const r of ledger) {
+    push({ corpus: 'conversion_ledger', source_type: corpusSourceType(r), source_id: r.id,
+      title: r.title || r.source_external_id || r.source_id, disposition: null,
+      rung: r.target_rung || null, sdKeyHint: r.dedup_match_sd_key || null });
+  }
+  for (const r of wave6) {
+    // Already a roadmap_wave_items row: enumerated for the report, but it is ALREADY staged (skip-staging).
+    push({ corpus: 'wave6', source_type: r.source_type, source_id: r.source_id,
+      title: r.title, disposition: r.item_disposition || null, rung: (r.metadata && r.metadata.rung) || null,
+      sdKeyHint: r.promoted_to_sd_key || null, alreadyStaged: true });
+  }
+  for (const r of deferred) {
+    push({ corpus: 'deferred_v2', source_type: 'brainstorm', source_id: r.id,
+      title: r.title || r.sd_key, disposition: null, rung: (r.metadata && r.metadata.rung) || null,
+      sdKeyHint: r.sd_key });
+  }
+  for (const r of backlog) {
+    push({ corpus: 'harness_backlog', source_type: 'brainstorm', source_id: r.id,
+      title: r.title || (r.description || '').slice(0, 80), disposition: null, rung: null,
+      sdKeyHint: r.sd_id || null });
+  }
+  return out;
+}
+
+// Lightweight, deterministic classification keywords (mirror the LEO triage risk taxonomy) so the
+// router sees the authority/outcome signals that drive the non-belt lanes. PURE — keyword match only.
+const CHAIRMAN_AUTHORITY_KEYWORDS = /\b(auth|authentication|authorization|rls|row[-\s]?level|credential|secret|api[-\s]?key|payment|stripe|billing|oauth|token|grant)\b/i;
+const OUTCOME_KEYWORDS = /\b(revenue|venture|customer|operational|go[-\s]?live|deploy to prod|live (venture|customer|payment)|first dollar|distance[-\s]?to[-\s]?(broke|quit)|kr-)\b/i;
+
+/**
+ * Classify a corpus candidate into the routeCandidate input shape (FR-2). Deterministic keyword scan
+ * over title (+ optional description): security/credential/payment text => authority (chairman-gated);
+ * revenue/venture/operational text => needsOutcome (outcome-gated). No keyword => residual belt-ready.
+ * @returns {{ source_id, title, disposition, rung, authority, needsOutcome }}
+ */
+export function classifyCandidate(c) {
+  const text = `${c.title || ''} ${c.description || ''}`;
+  const authority = CHAIRMAN_AUTHORITY_KEYWORDS.test(text) ? 'credential' : null;
+  const needsOutcome = !authority && OUTCOME_KEYWORDS.test(text);
+  return {
+    source_id: c.sdKeyHint || c.source_id,
+    title: c.title,
+    disposition: c.disposition,
+    rung: c.rung,
+    ...(authority ? { authority } : {}),
+    ...(needsOutcome ? { needsOutcome: true } : {}),
+  };
+}
+
+/**
+ * Classify + route every corpus candidate via classifyCandidate -> the SHIPPED stampCandidate (FR-2).
+ * Returns each candidate enriched with { lane, dedup_match_sd_key, re_emit }. PURE over the context.
+ * @param {Array} corpus - from buildCorpus
+ * @param {object} ctx - { existing, inFlight, shippedInfraKeys, outcomeRealizedKeys } for routeCandidate
+ */
+export function routeCorpus(corpus, ctx = {}) {
+  return (corpus || []).map((c) => {
+    const stamp = stampCandidate(classifyCandidate(c), ctx);
+    return { ...c, lane: stamp.lane, dedup_match_sd_key: stamp.dedup_match_sd_key, re_emit: stamp.re_emit };
+  });
+}
+
+/**
+ * Build the per-lane / per-rung baseline REPORT (FR-5) — the chairman's review artifact. PURE.
+ * @param {Array} routed - from routeCorpus
+ * @returns {{ total, by_lane, by_rung, by_corpus, dedup_matches, decline, re_emit, samples }}
+ */
+export function buildReport(routed) {
+  const rows = routed || [];
+  const tally = (keyFn) => rows.reduce((m, r) => { const k = keyFn(r) || 'unknown'; m[k] = (m[k] || 0) + 1; return m; }, {});
+  return {
+    total: rows.length,
+    by_lane: tally((r) => r.lane),
+    by_rung: tally((r) => r.rung),
+    by_corpus: tally((r) => r.corpus),
+    dedup_matches: rows.filter((r) => r.dedup_match_sd_key).length,
+    decline: rows.filter((r) => r.lane === 'decline').length,
+    re_emit: rows.filter((r) => r.re_emit).length,
+    samples: rows.slice(0, 8).map((r) => ({ corpus: r.corpus, lane: r.lane, title: (r.title || '').slice(0, 60) })),
+  };
+}
+
+/**
+ * Stage routed candidates as roadmap_wave_items rows (FR-2/FR-3/FR-4). HARD-SAFEGUARDED:
+ *   - writes ONLY when apply===true AND chairmanApproved===true (else dry-run: counts, no writes).
+ *   - INSERTs at item_disposition='pending' (the STAGED state); NEVER sets promoted_to_sd_key
+ *     (never promotes) and NEVER creates an SD.
+ *   - idempotent: skips a candidate already present (UNIQUE wave_id/source_type/source_id); skips
+ *     items already staged (corpus='wave6'); a 23505 unique-violation is treated as already-staged.
+ *   - dormant-safe: omits the lane column when absent.
+ *
+ * @param {object} supabase
+ * @param {Array} routed - from routeCorpus
+ * @param {{ apply?:boolean, chairmanApproved?:boolean, waveId:string, lanePresent:boolean, cap?:number }} opts
+ * @returns {Promise<{staged:number, skipped:number, dry_run:boolean, chairman_approved:boolean, errors:Array}>}
+ */
+export async function stageCorpus(supabase, routed, opts = {}) {
+  const cap = Number.isInteger(opts.cap) && opts.cap > 0 ? opts.cap : 1000;
+  const dryRun = !(opts.apply && opts.chairmanApproved);
+  const res = { staged: 0, skipped: 0, dry_run: dryRun, chairman_approved: !!opts.chairmanApproved, errors: [] };
+  if (!opts.waveId) { res.dry_run = true; return res; }
+
+  for (const c of (routed || []).slice(0, cap)) {
+    if (c.alreadyStaged) { res.skipped++; continue; } // wave6 items are already roadmap rows
+    if (dryRun) { res.staged++; continue; }            // count what WOULD stage; write nothing
+
+    const payload = {
+      wave_id: opts.waveId,
+      source_type: c.source_type,
+      source_id: c.source_id,
+      title: c.title || c.source_id,
+      item_disposition: 'pending', // STAGED — never 'promoted'; promoted_to_sd_key intentionally unset
+      metadata: { sourced_by: 'proactive-populator', corpus: c.corpus, intended_lane: c.lane,
+        ...(c.dedup_match_sd_key ? { dedup_match_sd_key: c.dedup_match_sd_key } : {}),
+        ...(c.re_emit ? { re_emit: true } : {}) },
+    };
+    if (opts.lanePresent && c.lane) payload.lane = c.lane;
+
+    const { error } = await supabase.from('roadmap_wave_items').insert(payload);
+    if (error) {
+      if (error.code === '23505') { res.skipped++; continue; } // already staged (idempotent)
+      if (error.code === '23514') { res.errors.push({ source_id: c.source_id, error: 'source_type/lane CHECK (dormant)' }); res.dry_run = true; continue; }
+      res.errors.push({ source_id: c.source_id, error: error.message });
+      continue;
+    }
+    res.staged++;
+  }
+  return res;
+}
+
+/**
+ * End-to-end populate (loaders injected so the lib stays testable). Loads the 4 sources, builds the
+ * corpus, routes it, builds the report, and (chairman-gated) stages. Returns { report, staging }.
+ * @param {object} supabase
+ * @param {object} deps - { loadSources: async(supabase)=>({ledger,wave6,deferred,backlog}), loadContext: async(supabase)=>ctx }
+ * @param {{ apply?:boolean, chairmanApproved?:boolean, cap?:number }} [opts]
+ */
+export async function populate(supabase, deps, opts = {}) {
+  const sources = await deps.loadSources(supabase);
+  const ctx = deps.loadContext ? await deps.loadContext(supabase) : {};
+  const corpus = buildCorpus(sources);
+  const routed = routeCorpus(corpus, ctx);
+  const report = buildReport(routed);
+
+  const waveId = await resolveTargetWaveId(supabase);
+  const lanePresent = await roadmapLaneColumnExists(supabase);
+  const staging = await stageCorpus(supabase, routed, {
+    apply: opts.apply, chairmanApproved: opts.chairmanApproved, waveId, lanePresent, cap: opts.cap,
+  });
+  // FR: surface a register-first warn count (advisory, never blocks).
+  report.register_first_warn = routed.filter((r) => r.sdKeyHint && shouldWarnRegisterFirst({ sd_key: r.sdKeyHint, metadata: {} }, !!r.alreadyStaged)).length;
+  return { report, staging, wave_id: waveId, lane_column_present: lanePresent };
+}

--- a/lib/sourcing-engine/proactive-populator.js
+++ b/lib/sourcing-engine/proactive-populator.js
@@ -19,9 +19,24 @@
  * @module lib/sourcing-engine/proactive-populator
  */
 
+import { v5 as uuidv5, validate as isUuid } from 'uuid';
 import { stampCandidate } from './dedup-autostamp.js';
 import { roadmapLaneColumnExists, resolveTargetWaveId } from './adam-direct-registry.js';
 import { shouldWarnRegisterFirst } from './register-first.js';
+
+// Fixed namespace for deriving a STABLE, valid UUID source_id from a non-UUID corpus key.
+// roadmap_wave_items.source_id is a UUID-typed column; some sources (notably the deferred
+// strategic_directives_v2 cluster, whose .id is varchar and frequently the sd_key STRING)
+// would otherwise throw 22P02 on the staged INSERT and silently drop the candidate. UUIDv5 is
+// deterministic, so the same key always maps to the same source_id — idempotency is preserved.
+const SOURCE_ID_NAMESPACE = uuidv5.URL;
+
+/** Return a valid UUID for use as roadmap_wave_items.source_id: pass UUIDs through, derive UUIDv5 from any other key. */
+export function toUuidSourceId(value) {
+  if (value == null) return value;
+  const s = String(value);
+  return isUuid(s) ? s : uuidv5(s, SOURCE_ID_NAMESPACE);
+}
 
 /** Map a corpus item to a LIVE-allowed roadmap_wave_items.source_type (CHECK: todoist|youtube|brainstorm). */
 export function corpusSourceType(item) {
@@ -48,6 +63,11 @@ export function buildCorpus({ ledger = [], wave6 = [], deferred = [], backlog = 
   const seen = new Set();
   const push = (c) => {
     if (!c.source_id) return;
+    // Normalize source_id to a valid UUID (the staged column is UUID-typed). Preserve the original
+    // key in source_key when it changed, so the staged row stays traceable to its origin id/sd_key.
+    const uuid = toUuidSourceId(c.source_id);
+    if (uuid !== c.source_id) c.source_key = c.source_id;
+    c.source_id = uuid;
     const key = `${c.source_type}::${c.source_id}`;
     if (seen.has(key)) return;
     seen.add(key);
@@ -166,6 +186,7 @@ export async function stageCorpus(supabase, routed, opts = {}) {
       title: c.title || c.source_id,
       item_disposition: 'pending', // STAGED — never 'promoted'; promoted_to_sd_key intentionally unset
       metadata: { sourced_by: 'proactive-populator', corpus: c.corpus, intended_lane: c.lane,
+        ...(c.source_key ? { source_key: c.source_key } : {}),
         ...(c.dedup_match_sd_key ? { dedup_match_sd_key: c.dedup_match_sd_key } : {}),
         ...(c.re_emit ? { re_emit: true } : {}) },
     };

--- a/package.json
+++ b/package.json
@@ -325,6 +325,7 @@
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
     "prod-error-sweep": "node scripts/clockwork/prod-error-sweep-loop.cjs",
     "sourcing:backfill-adam-ghosts": "node scripts/sourcing-engine/backfill-adam-ghosts.mjs",
+    "sourcing:populate": "node scripts/sourcing-engine/proactive-populator.mjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",

--- a/scripts/sourcing-engine/proactive-populator.mjs
+++ b/scripts/sourcing-engine/proactive-populator.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * proactive-populator — SD-LEO-INFRA-SOURCING-ENGINE-PROACTIVE-POPULATOR-001 (FR-1..FR-5 CLI).
+ *
+ * DRY-RUN BY DEFAULT: the bare command enumerates the 4 corpus sources, routes each via the shipped
+ * router, and prints a per-lane / per-rung baseline REPORT (the chairman's review artifact). It
+ * STAGES NOTHING. Staging requires BOTH --apply AND --chairman-approved (or POPULATOR_CHAIRMAN_APPROVED=
+ * true) — and even then it only INSERTs staged roadmap_wave_items rows (item_disposition='pending');
+ * it NEVER promotes staged->belt and NEVER creates an SD (those remain separate chairman-gated steps).
+ *
+ * Usage:  npm run sourcing:populate                         # dry-run REPORT only
+ *         npm run sourcing:populate -- --apply --chairman-approved   # stage (chairman-gated)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { populate } from '../../lib/sourcing-engine/proactive-populator.js';
+
+const apply = process.argv.includes('--apply');
+const chairmanApproved = process.argv.includes('--chairman-approved') || process.env.POPULATOR_CHAIRMAN_APPROVED === 'true';
+const capArg = (process.argv.find((a) => a.startsWith('--cap=')) || '').split('=')[1];
+
+const TERMINAL_DISPOSITIONS = ['built', 'already_covered', 'duplicate', 'declined', 'deferred_to_rung'];
+
+async function loadSources(db) {
+  // 1. conversion_ledger — undispositioned backlog
+  const { data: ledger } = await db.from('conversion_ledger')
+    .select('id,source_pool,source_id,source_external_id,title,target_rung,dedup_match_sd_key,disposition')
+    .is('disposition', null).limit(2000);
+  // 2. Wave-6 (highest-rank wave of the LEO Roadmap) — already-staged items, enumerated for the report
+  let wave6 = [];
+  try {
+    const { data: rm } = await db.from('strategic_roadmaps').select('id').eq('title', 'LEO Roadmap').eq('status', 'active').limit(1);
+    if (rm && rm[0]) {
+      const { data: w } = await db.from('roadmap_waves').select('id').eq('roadmap_id', rm[0].id).order('sequence_rank', { ascending: false }).limit(1);
+      if (w && w[0]) {
+        const { data: items } = await db.from('roadmap_wave_items')
+          .select('id,source_type,source_id,title,item_disposition,promoted_to_sd_key,metadata')
+          .eq('wave_id', w[0].id).limit(2000);
+        wave6 = (items || []).filter((it) => !['promoted', 'dropped'].includes(it.item_disposition));
+      }
+    }
+  } catch { /* fail-soft: wave6 stays empty */ }
+  // 3. deferred V2 cluster
+  const { data: deferred } = await db.from('strategic_directives_v2').select('id,sd_key,title,status,metadata').eq('status', 'deferred').limit(500);
+  // 4. harness backlog (exclude auto-capture noise)
+  const { data: backlogRaw } = await db.from('feedback').select('id,title,description,status,category,sd_id,metadata').eq('category', 'harness_backlog').eq('status', 'new').limit(1000);
+  const backlog = (backlogRaw || []).filter((r) => !(r.metadata && r.metadata.flag_class) && !/^(Completion flag|Fleet retro|Coordinator review)/i.test(r.title || ''));
+  return { ledger: ledger || [], wave6, deferred: deferred || [], backlog };
+}
+
+async function loadContext(db) {
+  const { data: sds } = await db.from('strategic_directives_v2').select('sd_key,title,status').limit(4000);
+  const existing = (sds || []).map((s) => ({ sd_key: s.sd_key, title: s.title }));
+  const shippedInfraKeys = (sds || []).filter((s) => s.status === 'completed').map((s) => s.sd_key);
+  // outcomeRealizedKeys left empty = the SAFE direction (a shipped-but-unrealized SD re-emits; never falsely closes work).
+  return { existing, inFlight: [], shippedInfraKeys, outcomeRealizedKeys: [] };
+}
+
+function printReport(out) {
+  const { report: r, staging: s, wave_id, lane_column_present } = out;
+  const fmt = (o) => Object.entries(o || {}).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ');
+  console.log('=== PROACTIVE POPULATOR — baseline corpus report ===');
+  console.log(`total corpus candidates: ${r.total}`);
+  console.log(`by corpus : ${fmt(r.by_corpus)}`);
+  console.log(`by lane   : ${fmt(r.by_lane)}`);
+  console.log(`by rung   : ${fmt(r.by_rung)}`);
+  console.log(`dedup matches: ${r.dedup_matches}  |  decline: ${r.decline}  |  re-emit: ${r.re_emit}  |  register-first warns: ${r.register_first_warn}`);
+  console.log(`wave: ${wave_id ? wave_id.slice(0, 8) : 'none'}  |  lane column: ${lane_column_present ? 'present' : 'DORMANT'}`);
+  console.log(`staging: ${s.dry_run ? 'DRY-RUN' : 'APPLIED'} (chairman_approved=${s.chairman_approved}) — staged=${s.staged} skipped=${s.skipped} errors=${s.errors.length}`);
+  if (s.dry_run && (apply && !chairmanApproved)) console.log('  note: --apply given but NOT chairman-approved -> dry-run. Add --chairman-approved to stage.');
+  if (s.errors.length) for (const e of s.errors.slice(0, 5)) console.warn(`  [error] ${e.source_id}: ${e.error}`);
+}
+
+async function main() {
+  const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const out = await populate(db, { loadSources, loadContext }, { apply, chairmanApproved, cap: capArg ? Number(capArg) : undefined });
+  printReport(out);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('[proactive-populator] fatal:', e.message); process.exit(1); });

--- a/tests/unit/sourcing-engine/proactive-populator.test.js
+++ b/tests/unit/sourcing-engine/proactive-populator.test.js
@@ -5,6 +5,7 @@
  * apply AND chairman-approved, never promotes, idempotent, dormant-safe (FR-3/FR-4).
  */
 import { describe, it, expect } from 'vitest';
+import { validate as isUuid } from 'uuid';
 import {
   corpusSourceType,
   buildCorpus,
@@ -12,6 +13,7 @@ import {
   routeCorpus,
   buildReport,
   stageCorpus,
+  toUuidSourceId,
 } from '../../../lib/sourcing-engine/proactive-populator.js';
 
 describe('corpusSourceType — maps to a live-allowed roadmap_wave_items.source_type', () => {
@@ -40,6 +42,24 @@ describe('buildCorpus — enumerate 4 sources, dedup by (source_type, source_id)
 
   it('skips items with no source_id', () => {
     expect(buildCorpus({ backlog: [{ title: 'no id' }] })).toHaveLength(0);
+  });
+
+  it('normalizes a non-UUID source id to a STABLE valid UUID + preserves the original key (22P02 guard)', () => {
+    // strategic_directives_v2.id is varchar — frequently the sd_key STRING, which would throw 22P02
+    // against the UUID-typed roadmap_wave_items.source_id. The deferred candidate must carry a UUID.
+    const run = () => buildCorpus({ deferred: [{ id: 'SD-LEO-FIX-REMEDIATION-NPM-AUDIT-003', sd_key: 'SD-LEO-FIX-REMEDIATION-NPM-AUDIT-003', title: 'X' }] })[0];
+    const a = run();
+    expect(isUuid(a.source_id)).toBe(true);
+    expect(a.source_key).toBe('SD-LEO-FIX-REMEDIATION-NPM-AUDIT-003'); // original preserved for traceability
+    expect(run().source_id).toBe(a.source_id);                        // deterministic -> idempotent
+  });
+
+  it('passes an already-UUID source id through unchanged (no source_key churn)', () => {
+    const uuid = '98d7fd7f-bb80-4ba5-98a9-b76c6c3f2baa';
+    expect(toUuidSourceId(uuid)).toBe(uuid);
+    const c = buildCorpus({ backlog: [{ id: uuid, title: 'Y' }] })[0];
+    expect(c.source_id).toBe(uuid);
+    expect(c.source_key).toBeUndefined();
   });
 });
 
@@ -133,5 +153,28 @@ describe('stageCorpus — HARD safeguards: dry-run default, chairman-gated, neve
     const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: null, lanePresent: true });
     expect(res.dry_run).toBe(true);
     expect(db.inserted).toHaveLength(0);
+  });
+
+  it('schema-aware: a real UUID source_id from the normalized corpus inserts cleanly (no 22P02)', async () => {
+    // Fake DB that enforces the live roadmap_wave_items.source_id UUID type — rejects non-UUID like Postgres 22P02.
+    const inserted = [];
+    const uuidDb = { inserted, from: () => ({ insert: (row) => {
+      if (!isUuid(String(row.source_id))) return Promise.resolve({ error: { code: '22P02', message: `invalid input syntax for type uuid: "${row.source_id}"` } });
+      inserted.push(row); return Promise.resolve({ error: null });
+    } }) };
+    const corpus = buildCorpus({ deferred: [{ id: 'SD-NON-UUID-KEY-007', sd_key: 'SD-NON-UUID-KEY-007', title: 'Deferred thing' }] });
+    const routedCorpus = routeCorpus(corpus, { existing: [], inFlight: [] });
+    const res = await stageCorpus(uuidDb, routedCorpus, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: false });
+    expect(res.errors).toHaveLength(0);           // would be 22P02 without the UUIDv5 normalization
+    expect(inserted).toHaveLength(1);
+    expect(isUuid(String(inserted[0].source_id))).toBe(true);
+    expect(inserted[0].metadata.source_key).toBe('SD-NON-UUID-KEY-007'); // origin traceable
+  });
+
+  it('dormant CHECK violation (23514) forces dry-run rather than throwing', async () => {
+    const db = fakeDb({ code: '23514', message: 'source_type/lane CHECK' });
+    const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: true });
+    expect(res.dry_run).toBe(true);          // forced back to dry-run on a dormant CHECK
+    expect(res.errors.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/tests/unit/sourcing-engine/proactive-populator.test.js
+++ b/tests/unit/sourcing-engine/proactive-populator.test.js
@@ -1,0 +1,137 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-PROACTIVE-POPULATOR-001 — pure unit tests.
+ * Corpus enumeration + dedup (FR-1), classify+route via the shipped router (FR-2), the per-lane/
+ * per-rung report (FR-5), and the HARD-SAFEGUARDED staged-write: dry-run by default, writes only when
+ * apply AND chairman-approved, never promotes, idempotent, dormant-safe (FR-3/FR-4).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  corpusSourceType,
+  buildCorpus,
+  classifyCandidate,
+  routeCorpus,
+  buildReport,
+  stageCorpus,
+} from '../../../lib/sourcing-engine/proactive-populator.js';
+
+describe('corpusSourceType — maps to a live-allowed roadmap_wave_items.source_type', () => {
+  it('todoist_todo -> todoist, youtube_playlist -> youtube, else brainstorm', () => {
+    expect(corpusSourceType({ source_pool: 'todoist_todo' })).toBe('todoist');
+    expect(corpusSourceType({ source_pool: 'youtube_playlist' })).toBe('youtube');
+    expect(corpusSourceType({ source_pool: 'estate_corpus' })).toBe('brainstorm');
+    expect(corpusSourceType({})).toBe('brainstorm');
+  });
+});
+
+describe('buildCorpus — enumerate 4 sources, dedup by (source_type, source_id) (FR-1)', () => {
+  it('merges the 4 sources and dedups the same intake item', () => {
+    const corpus = buildCorpus({
+      ledger: [{ id: 'L1', source_pool: 'todoist_todo', title: 'A' }, { id: 'L1', source_pool: 'todoist_todo', title: 'A dup' }],
+      wave6: [{ id: 'W1', source_type: 'youtube', source_id: 'yt-1', title: 'W', item_disposition: 'pending' }],
+      deferred: [{ id: 'D1', sd_key: 'SD-D', title: 'Deferred thing' }],
+      backlog: [{ id: 'B1', title: 'Backlog thing' }],
+    });
+    // L1 appears twice but same (todoist, L1) -> collapses to 1; total = 1 + 1 + 1 + 1 = 4
+    expect(corpus).toHaveLength(4);
+    expect(corpus.filter((c) => c.corpus === 'conversion_ledger')).toHaveLength(1);
+    expect(corpus.find((c) => c.corpus === 'wave6').alreadyStaged).toBe(true);
+    expect(corpus.find((c) => c.corpus === 'deferred_v2').sdKeyHint).toBe('SD-D');
+  });
+
+  it('skips items with no source_id', () => {
+    expect(buildCorpus({ backlog: [{ title: 'no id' }] })).toHaveLength(0);
+  });
+});
+
+describe('classifyCandidate — risk-keyword -> authority / needsOutcome (FR-2)', () => {
+  it('credential/auth/payment text -> chairman authority', () => {
+    expect(classifyCandidate({ title: 'Rotate the Stripe API key' }).authority).toBe('credential');
+    expect(classifyCandidate({ title: 'Fix RLS on ventures' }).authority).toBe('credential');
+  });
+  it('revenue/venture/operational text -> needsOutcome', () => {
+    expect(classifyCandidate({ title: 'Take a real dollar from a live customer' }).needsOutcome).toBe(true);
+    expect(classifyCandidate({ title: 'distance-to-broke gauge' }).needsOutcome).toBe(true);
+  });
+  it('ordinary build text -> neither (residual belt-ready)', () => {
+    const c = classifyCandidate({ title: 'Refactor the gate pipeline' });
+    expect(c.authority).toBeUndefined();
+    expect(c.needsOutcome).toBeUndefined();
+  });
+});
+
+describe('routeCorpus + buildReport — differentiated lanes (FR-2/FR-5)', () => {
+  const corpus = buildCorpus({
+    backlog: [
+      { id: 'b1', title: 'Add RLS to payments table' },     // chairman-gated
+      { id: 'b2', title: 'Take a real dollar live revenue' }, // outcome-gated
+      { id: 'b3', title: 'Refactor the router' },             // belt-ready
+    ],
+  });
+
+  it('routes each candidate and the report tallies per lane', () => {
+    const routed = routeCorpus(corpus, { existing: [], inFlight: [] });
+    const report = buildReport(routed);
+    expect(report.total).toBe(3);
+    expect(report.by_lane['chairman-gated']).toBe(1);
+    expect(report.by_lane['outcome-gated']).toBe(1);
+    expect(report.by_lane['belt-ready']).toBe(1);
+    expect(report.samples.length).toBeGreaterThan(0);
+  });
+
+  it('dedup matches an existing SD by title (>=2-token shipped router)', () => {
+    const dupCorpus = buildCorpus({ backlog: [{ id: 'b9', title: 'Calibrate the gates cohort' }] });
+    const routed = routeCorpus(dupCorpus, { existing: [{ sd_key: 'SD-EXIST', title: 'Calibrate the gates cohort' }] });
+    expect(routed[0].lane).toBe('dedup');
+    expect(routed[0].dedup_match_sd_key).toBe('SD-EXIST');
+  });
+});
+
+describe('stageCorpus — HARD safeguards: dry-run default, chairman-gated, never promotes (FR-3/FR-4)', () => {
+  const routed = [
+    { corpus: 'harness_backlog', source_type: 'brainstorm', source_id: 'b1', title: 'X', lane: 'belt-ready' },
+    { corpus: 'wave6', source_type: 'youtube', source_id: 'w1', title: 'Y', lane: 'belt-ready', alreadyStaged: true },
+  ];
+  const fakeDb = (insertErr) => { const inserted = []; return { inserted, from: () => ({ insert: (row) => { if (!insertErr) inserted.push(row); return Promise.resolve(insertErr ? { error: insertErr } : { error: null }); } }) }; };
+
+  it('DRY-RUN by default (apply omitted): counts, writes nothing', async () => {
+    const db = fakeDb();
+    const res = await stageCorpus(db, routed, { waveId: 'wave-1', lanePresent: false });
+    expect(res.dry_run).toBe(true);
+    expect(res.staged).toBe(1); // the non-alreadyStaged one would-stage
+    expect(res.skipped).toBe(1); // wave6 already staged
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('apply WITHOUT chairman-approval stays dry-run (writes nothing)', async () => {
+    const db = fakeDb();
+    const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: false, waveId: 'wave-1', lanePresent: false });
+    expect(res.dry_run).toBe(true);
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('apply AND chairman-approved stages at item_disposition=pending, NEVER sets promoted_to_sd_key', async () => {
+    const db = fakeDb();
+    const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: true });
+    expect(res.dry_run).toBe(false);
+    expect(db.inserted).toHaveLength(1);
+    const row = db.inserted[0];
+    expect(row.item_disposition).toBe('pending');
+    expect(row).not.toHaveProperty('promoted_to_sd_key');
+    expect(row.metadata.sourced_by).toBe('proactive-populator');
+    expect(row.lane).toBe('belt-ready'); // lanePresent -> lane stamped
+  });
+
+  it('idempotent: a 23505 unique-violation is treated as already-staged (skipped, not an error)', async () => {
+    const db = fakeDb({ code: '23505', message: 'duplicate key' });
+    const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: true });
+    expect(res.errors).toHaveLength(0);
+    expect(res.skipped).toBeGreaterThanOrEqual(1);
+  });
+
+  it('no wave => forced dry-run (never inserts an orphan)', async () => {
+    const db = fakeDb();
+    const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: null, lanePresent: true });
+    expect(res.dry_run).toBe(true);
+    expect(db.inserted).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
@
## Sourcing-engine child 9/10

Proactive corpus populator: enumerates the ~812-item sourcing backlog from its 4 canonical sources (conversion_ledger, the highest-rank LEO Roadmap wave, the deferred V2 cluster, the harness_backlog corpus), classifies + routes each item through the SHIPPED routeCandidate/stampCandidate, and emits a per-lane/per-rung baseline REPORT for chairman review.

### HARD SAFEGUARD (FR-3)
- DRY-RUN by default — the bare command stages nothing.
- Staging roadmap_wave_items requires BOTH --apply AND --chairman-approved.
- Even then only inserts item_disposition=pending — never promotes staged->belt, never creates an SD.
- No resolved wave -> forced dry-run (no orphan inserts).

### Idempotent + dormant-safe
- UNIQUE(wave_id, source_type, source_id); 23505 -> already-staged skip.
- Optional lane column omitted when dormant; 23514 CHECK -> forced dry-run.
- source_id normalized to UUID (UUIDv5-from-key) — guards the GAUGE-GAP-MINER-class 22P02 the deferred strategic_directives_v2.id (varchar) would throw on apply day.

### Reuse, not re-derive
Imports the shipped sourcing-engine SSOTs (stampCandidate, routeCandidate, resolveTargetWaveId, roadmapLaneColumnExists, shouldWarnRegisterFirst) — no duplicate routing/dedup logic.

### Verification
- 17 unit tests pass (13 base + 4 from the adversarial 22P02 fix incl. a schema-aware UUID-rejecting fake DB).
- Live dry-run: 812 candidates routed (768 belt-ready / 31 outcome-gated / 13 chairman-gated), zero writes.
- Sub-agents: DB 95, Security 96, Design 95, Testing PASS. Retro 90.

Ships INERT — activation requires explicit chairman --apply --chairman-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@