### PR TITLE
fix(SD-LEO-INFRA-REACTIVATE-SD-ARGV-FIX-001): guard reactivate-sd.js argv parsing

### DIFF
--- a/scripts/reactivate-sd.js
+++ b/scripts/reactivate-sd.js
@@ -93,6 +93,29 @@ export function buildReactivationAudit({ sdId, pre_state, post_state, sessionId 
 
 // ── CLI (IO) ────────────────────────────────────────────────────────────────
 
+/**
+ * Pure argv resolver — no IO, no process.exit. Returns { sdInput, toStatus, reason }
+ * where sdInput is undefined when no SD positional is present.
+ *
+ * Bug fix (SD-LEO-INFRA-REACTIVATE-SD-ARGV-FIX-001): a flag's value index is only
+ * marked "consumed" when the flag is actually present. Previously the consumed set was
+ * `[toIdx, toIdx+1, reasonIdx, reasonIdx+1].filter(i => i >= 0)`; when --to/--reason was
+ * omitted, indexOf returned -1 and (-1)+1 === 0 passed the (i >= 0) filter, wrongly
+ * consuming args[0] (the SD-key positional) — so EVERY invocation without an explicit
+ * --to dropped the SD identifier and failed with "Missing SD identifier".
+ */
+export function resolveArgs(args) {
+  const toIdx = args.indexOf('--to');
+  const toStatus = toIdx !== -1 ? args[toIdx + 1] : 'draft';
+  const reasonIdx = args.indexOf('--reason');
+  const reason = reasonIdx !== -1 ? args[reasonIdx + 1] : null;
+  const consumed = new Set();
+  if (toIdx !== -1) { consumed.add(toIdx); consumed.add(toIdx + 1); }
+  if (reasonIdx !== -1) { consumed.add(reasonIdx); consumed.add(reasonIdx + 1); }
+  const sdInput = args.find((a, i) => !a.startsWith('-') && !consumed.has(i));
+  return { sdInput, toStatus, reason };
+}
+
 function parseArgs() {
   const args = process.argv.slice(2);
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
@@ -116,12 +139,7 @@ Examples:
 `);
     process.exit(args.includes('--help') || args.includes('-h') ? 0 : 1);
   }
-  const toIdx = args.indexOf('--to');
-  const toStatus = toIdx !== -1 ? args[toIdx + 1] : 'draft';
-  const reasonIdx = args.indexOf('--reason');
-  const reason = reasonIdx !== -1 ? args[reasonIdx + 1] : null;
-  const consumed = new Set([toIdx, toIdx + 1, reasonIdx, reasonIdx + 1].filter(i => i >= 0));
-  const sdInput = args.find((a, i) => !a.startsWith('-') && !consumed.has(i));
+  const { sdInput, toStatus, reason } = resolveArgs(args);
   if (!sdInput) {
     console.error('❌ Missing SD identifier (sd_key or UUID)');
     process.exit(1);

--- a/tests/unit/reactivate-sd.test.js
+++ b/tests/unit/reactivate-sd.test.js
@@ -10,6 +10,7 @@ import {
   computeReactivation,
   buildReactivationAudit,
   VALID_REACTIVATION_TARGETS,
+  resolveArgs,
 } from '../../scripts/reactivate-sd.js';
 
 const NOW_ISO = '2026-06-16T03:00:00.000Z';
@@ -95,6 +96,50 @@ describe('computeReactivation — guards (FR-3)', () => {
   it('exposes the valid reactivation targets (does NOT allow re-deferring)', () => {
     expect([...VALID_REACTIVATION_TARGETS].sort()).toEqual(['active', 'draft', 'in_progress']);
     expect(VALID_REACTIVATION_TARGETS.has('deferred')).toBe(false);
+  });
+});
+
+describe('resolveArgs — argv parsing (SD-LEO-INFRA-REACTIVATE-SD-ARGV-FIX-001)', () => {
+  // BUG 1/2 regression: the documented default-to-draft invocation (no --to) must
+  // resolve the SD-key positional and default target=draft, instead of dropping it.
+  it('resolves the SD key and defaults target=draft when --to is omitted (--reason present)', () => {
+    const r = resolveArgs(['SD-LEO-FIX-FOO-001', '--reason', 'x']);
+    expect(r.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(r.toStatus).toBe('draft');
+    expect(r.reason).toBe('x');
+  });
+
+  it('resolves a bare SD key (no flags at all) and defaults target=draft', () => {
+    const r = resolveArgs(['SD-LEO-FIX-FOO-001']);
+    expect(r.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(r.toStatus).toBe('draft');
+    expect(r.reason).toBeNull();
+  });
+
+  it('honors an explicit --to and does not consume the positional', () => {
+    const r = resolveArgs(['SD-LEO-FIX-FOO-001', '--to', 'in_progress']);
+    expect(r.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(r.toStatus).toBe('in_progress');
+  });
+
+  it('resolves the positional regardless of flag order (SD key last)', () => {
+    const r = resolveArgs(['--reason', 'cleared', '--to', 'active', 'SD-LEO-FIX-FOO-001']);
+    expect(r.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(r.toStatus).toBe('active');
+    expect(r.reason).toBe('cleared');
+  });
+
+  it('does not mistake a flag value for the SD positional', () => {
+    // 'draft' here is the --to value, not the SD key; with no real positional sdInput is undefined.
+    const r = resolveArgs(['--to', 'draft', '--reason', 'note']);
+    expect(r.sdInput).toBeUndefined();
+  });
+
+  it('resolves a UUID positional with --reason and no --to', () => {
+    const uuid = '3c9ebdcc-3620-43f9-bd26-c7e007ef77b1';
+    const r = resolveArgs([uuid, '--reason', 'chairman cleared']);
+    expect(r.sdInput).toBe(uuid);
+    expect(r.toStatus).toBe('draft');
   });
 });
 


### PR DESCRIPTION
## Summary
`scripts/reactivate-sd.js` failed with **"Missing SD identifier"** on its documented default-to-draft invocation (`node scripts/reactivate-sd.js <SD-KEY> --reason "..."`, no `--to`).

**Root cause:** `parseArgs()` built its consumed-index set as `[toIdx, toIdx+1, reasonIdx, reasonIdx+1].filter(i => i >= 0)`. When `--to`/`--reason` is omitted, `indexOf` returns `-1` and `(-1)+1 === 0` passed the `(i >= 0)` filter — wrongly marking `args[0]` (the SD-key positional) as a consumed flag value, dropping the SD identifier.

## Changes
- Extract a pure, exported `resolveArgs(args)` (no IO, no `process.exit`) that only consumes a flag's value index when the flag is present (`toIdx !== -1` / `reasonIdx !== -1`). `parseArgs()` keeps the help text + missing-identifier exit and delegates the parse.
- Add 6 regression tests covering bare key, key+`--reason` (no `--to`), explicit `--to`, flag-order-independence, flag-value-not-mistaken-for-positional, and a UUID positional.

## Fixes
Both harness-backlog feedback rows trace to this one defect: `258a03a2-94b8-456f-9248-b559a6cdc42c` (BUG 1, root cause) and `e6cc2e55-36ac-45d3-bbc9-15989305a2b1` (BUG 2 — the suspected dotenvx argv-passthrough issue is **disproven**: a live smoke now reaches "SD not found" instead of "Missing SD identifier").

## Verification
- `npx vitest run tests/unit/reactivate-sd.test.js` → 20 pass (14 existing + 6 new)
- Live smoke: `node scripts/reactivate-sd.js SD-DOES-NOT-EXIST-999 --reason "smoke"` → "SD not found" (positional parsed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)