### PR TITLE
fix(SD-LEO-INFRA-VDR-COCKPIT-PROBE-STALE-FIX-001): repoint stale 'The cockpit' VDR probe to shipped surfaces

### DIFF
--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -79,8 +79,15 @@ export const VDR_REGISTRY = [
     probe: { type: 'kr_status', code: 'KR-2026-07-02' } }, // ≥90% breakage caught before customers
   { capability: 'Calibrate the gates', layer: 'process',
     probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'lib', pattern: 'calibration[_-]?cohort|gate.*BLOCK.*calibrat', builtWhen: 'present' } },
+  // SD-LEO-INFRA-VDR-COCKPIT-PROBE-STALE-FIX-001: the prior pattern (CANONICAL_SURFACES|six_surfaces|
+  // SURFACE_REGISTRY) matched NOTHING in ehg/src, so this BUILT capability scored unbuilt(0) and
+  // under-counted the vision gauge. VERIFY-FIRST (FR-1): the canonical chairman cockpit is the
+  // SurvivabilityCockpit lead (mounted in BriefingDashboard) + the six authorized surfaces mounted in
+  // src/pages/chairman-v3/VisionAlignmentPage.tsx — all confirmed shipped (SD-EHG-COCKPIT-BUILD-001).
+  // code_grep 'present' is honestly capped at PARTIAL (0.5) by codeGrepProbe's anti-inflation rule
+  // (code presence is intent, not a live realization), so the honest correction is unbuilt(0)→partial.
   { capability: 'The cockpit', layer: 'application',
-    probe: { type: 'code_grep', repo: 'ehg', path: 'src', pattern: 'CANONICAL_SURFACES|six[_-]?surfaces|SURFACE_REGISTRY', builtWhen: 'present' } },
+    probe: { type: 'code_grep', repo: 'ehg', path: 'src', pattern: 'SurvivabilityCockpit|SystemAlertsBoardView|OpsBalancedScorecardView|PortfolioGapAnalysisView|RoadmapWaveView|InitiativeRollupView|MonthlyCeoReportViewer', builtWhen: 'present' } },
   { capability: 'Turn the fleet dial with data', layer: 'infrastructure',
     probe: { type: 'code_grep', repo: 'EHG_Engineer', path: 'scripts', pattern: 'token_count|tokens_used|effort_level', builtWhen: 'present' } },
   { capability: 'A queryable, structured north star', layer: 'application',

--- a/tests/unit/vision/vdr-cockpit-probe.test.js
+++ b/tests/unit/vision/vdr-cockpit-probe.test.js
@@ -1,0 +1,74 @@
+// SD-LEO-INFRA-VDR-COCKPIT-PROBE-STALE-FIX-001 — regression guard for the 'The cockpit' VDR probe.
+//
+// The prior pattern (CANONICAL_SURFACES|six_surfaces|SURFACE_REGISTRY) matched NOTHING in ehg/src,
+// so a BUILT capability scored unbuilt(0) and under-counted the vision gauge. This test pins the
+// CORRECTED pattern to the canonical chairman cockpit surfaces and — critically — proves the probe
+// is NOT a tautology: a fixture where the surfaces are PRESENT scores partial, where ABSENT scores
+// unbuilt, so a future genuine cockpit regression (surfaces deleted) is still caught.
+//
+// Hermetic: the grep seam is injected and applies the probe's OWN regex against fixture source text,
+// so the test exercises the real registered pattern (not a hand-copied duplicate).
+import { describe, it, expect } from 'vitest';
+import { VDR_REGISTRY } from '../../../lib/vision/vdr-registry.js';
+import { runProbe } from '../../../lib/vision/vdr-probes.js';
+
+const COCKPIT = 'The cockpit';
+const entry = VDR_REGISTRY.find((e) => e.capability === COCKPIT);
+
+// The seven canonical surfaces (FR-1, verified shipped in ehg/src + mounted in VisionAlignmentPage /
+// BriefingDashboard). Used only to build realistic PRESENT/ABSENT fixtures.
+const CANONICAL_SURFACES = [
+  'SurvivabilityCockpit', 'SystemAlertsBoardView', 'OpsBalancedScorecardView',
+  'PortfolioGapAnalysisView', 'RoadmapWaveView', 'InitiativeRollupView', 'MonthlyCeoReportViewer',
+];
+
+// A grep seam that runs the probe's actual regex against the provided fixture source text. This is
+// what makes the test non-tautological: it uses entry.probe.pattern, not a re-typed copy.
+function fixtureGrepSeam(sourceText) {
+  return (pattern /*, sub, repo */) => {
+    const re = new RegExp(pattern);
+    return { accessible: true, matched: re.test(sourceText) };
+  };
+}
+
+describe('FR-2: the cockpit probe targets the real shipped surfaces (no stale tokens)', () => {
+  it('is a code_grep over ehg/src for the canonical surfaces, builtWhen present', () => {
+    expect(entry).toBeTruthy();
+    expect(entry.layer).toBe('application');
+    expect(entry.probe).toMatchObject({ type: 'code_grep', repo: 'ehg', path: 'src', builtWhen: 'present' });
+  });
+  it('every canonical surface name is an alternative in the pattern; no dead stale tokens remain', () => {
+    for (const s of CANONICAL_SURFACES) expect(entry.probe.pattern).toContain(s);
+    for (const stale of ['CANONICAL_SURFACES', 'SURFACE_REGISTRY', 'six']) {
+      expect(entry.probe.pattern).not.toContain(stale);
+    }
+  });
+});
+
+describe('FR-5 regression guard: the probe band moves with reality (NOT a tautology)', () => {
+  it('PRESENT (surfaces mounted) → partial (code presence is honest intent, capped at 0.5)', async () => {
+    const src = CANONICAL_SURFACES.map((s) => `import { ${s} } from "@/components/chairman-v3/${s}";`).join('\n');
+    const res = await runProbe(entry.probe, { grep: fixtureGrepSeam(src) });
+    expect(res.status).toBe('partial');
+    expect(res.value).toBe(true);
+  });
+  it('PRESENT with only ONE surface still matches (alternation) → partial', async () => {
+    const res = await runProbe(entry.probe, { grep: fixtureGrepSeam('export function RoadmapWaveView(){}') });
+    expect(res.status).toBe('partial');
+  });
+  it('ABSENT (surfaces deleted — a real regression) → unbuilt(0), so the regression is caught', async () => {
+    const src = 'export function SomeUnrelatedThing(){}\nimport { Foo } from "./bar";';
+    const res = await runProbe(entry.probe, { grep: fixtureGrepSeam(src) });
+    expect(res.status).toBe('unbuilt');
+    expect(res.value).toBe(false);
+  });
+  it('the OLD stale tokens alone do NOT satisfy the corrected probe (proves the fix, not a rename)', async () => {
+    const staleOnly = 'const CANONICAL_SURFACES = []; // six_surfaces SURFACE_REGISTRY';
+    const res = await runProbe(entry.probe, { grep: fixtureGrepSeam(staleOnly) });
+    expect(res.status).toBe('unbuilt');
+  });
+  it('an inaccessible ehg checkout → unknown (never a fabricated build credit)', async () => {
+    const res = await runProbe(entry.probe, { grep: () => ({ accessible: false, matched: false }) });
+    expect(res.status).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
The `'The cockpit'` VDR probe (lib/vision/vdr-registry.js) grepped ehg/src for `CANONICAL_SURFACES|six_surfaces|SURFACE_REGISTRY` — tokens that exist nowhere — so this already-shipped capability scored `unbuilt(0)` and under-counted the chairman vision gauge.

## Change
- **FR-1 VERIFY-FIRST**: confirmed the 7 canonical cockpit surfaces are shipped + mounted in ehg/src (SurvivabilityCockpit in BriefingDashboard + the six in VisionAlignmentPage.tsx).
- **FR-2**: repoint the probe pattern to those verified component names (matches exactly 9 files, all under chairman-v3 — zero over-match).
- **FR-3**: `assertRegistryCoherence` keys on capability NAME (unchanged) → stays `ok:true`, gauge `available:true`.
- **FR-4**: cockpit `unbuilt(0)` → `partial(0.5)` (codeGrepProbe honestly caps a present-match at partial, not built). Gauge: overall **50→52%**, build_pct **53→57%**, application layer **50→60%**.
- **FR-5**: new hermetic regression test (tests/unit/vision/vdr-cockpit-probe.test.js) — PRESENT→partial, ABSENT→unbuilt (non-tautological), inaccessible→unknown.

## Verification
- New test: 7/7 pass. Full vision/vdr suite: 148/148 pass, zero regressions.
- Adversarial review: safe to ship — clean match, non-tautological test, coherence-safe, sound regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)