### PR TITLE
fix(SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001): persist proposal depends_on into canonical dependencies column

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1568,6 +1568,12 @@ async function createSD(options) {
     scope = null,
     // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Allow explicit target_application
     target_application: explicitTargetApp = null,
+    // SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001 (FR-3): accept dependencies so the
+    // canonical-column write below (~line 1915) is reachable. Previously `dependencies`
+    // was never destructured, so its typeof guard always resolved to [] — the column
+    // could not be populated by ANY caller. Default null preserves behavior for the
+    // direct/--from-feedback/--child callers that omit it.
+    dependencies = null,
   } = options;
 
   // QF-CLAIM-CONFLICT-UX-001 + SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001:
@@ -2276,6 +2282,16 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
     rationale: proposal.rationale || `Materialized from proposal ${filePath || 'unknown'}`,
     scope: proposal.scope || null,
     success_criteria: Array.isArray(proposal.success_criteria) ? proposal.success_criteria : null,
+    // SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001 (FR-1): a proposal that declares
+    // metadata.depends_on must populate the CANONICAL `dependencies` column — that is
+    // what lib/coordinator/claimable-work.cjs and scripts/modules/sd-next/dependency-resolver.js
+    // gate BLOCKED/READY on. metadata.depends_on alone is documented (Dependency Field Guide)
+    // as ignored by the resolver, so the prior closed whitelist silently dropped child
+    // sequencing — forcing manual ordering of the sourcing-engine children. Only set the
+    // key when there is at least one normalized dep (preserves dependencies=[] otherwise).
+    ...(normalizeDependsOn(proposal.metadata?.depends_on).length > 0
+      ? { dependencies: normalizeDependsOn(proposal.metadata?.depends_on) }
+      : {}),
     metadata: {
       source: 'proposal',
       proposal_file_path: filePath || null,
@@ -2285,6 +2301,20 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
       gold_origin: proposal.gold_origin || null,
       necessity: proposal.necessity || null,
       dedup_note: proposal.dedup_note || null,
+      // SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001 (FR-2): carry the proposal's informational
+      // dependency/provenance keys through the closed whitelist. engine_child_index and
+      // parent_sd_key are ordering/lineage hints the coordinator + reporting consume;
+      // depends_on is retained in metadata for back-compat with any reader that still
+      // inspects it (the ENFORCED copy lives in the dependencies column above). Each key
+      // appears ONLY when the proposal declares it (no coercion/defaulting), preserving
+      // the closed-whitelist metadata invariant.
+      ...(proposal.metadata?.engine_child_index !== undefined && proposal.metadata?.engine_child_index !== null
+        ? { engine_child_index: proposal.metadata.engine_child_index }
+        : {}),
+      ...(proposal.metadata?.parent_sd_key ? { parent_sd_key: proposal.metadata.parent_sd_key } : {}),
+      ...(normalizeDependsOn(proposal.metadata?.depends_on).length > 0
+        ? { depends_on: proposal.metadata.depends_on }
+        : {}),
       // FR-1a: canonical Adam-origin attribution (the code-enforced producer for FR-1b's
       // sourcing-cadence consumer; see this function's doc comment). Only stamped for an explicit
       // Adam-origin proposal — never coerced/defaulted, so a non-Adam proposal stays unattributed.
@@ -2300,6 +2330,29 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
       ...(proposal.metadata?.security_reviewed === true || opts.securityReviewed === true ? { security_reviewed: true } : {}),
     },
   };
+}
+
+/**
+ * SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001 (FR-1): normalize a proposal's declared
+ * depends_on into the CANONICAL dependencies-column shape [{ sd_id: <key> }].
+ * Accepts the same loose entry forms the dispatcher's depsArray() tolerates:
+ *   - bare SD-key string            "SD-FOO-001"        -> { sd_id: "SD-FOO-001" }
+ *   - { sd_id: "SD-FOO-001" }       (canonical)          -> passed through
+ *   - { sd_key: "SD-FOO-001" }      (alias)              -> { sd_id: "SD-FOO-001" }
+ * Non-string / empty / malformed entries are dropped (fail-soft — a bad dep entry
+ * must never crash SD creation). Returns [] for any non-array / nullish input, so a
+ * proposal without depends_on yields dependencies=[] (no behavior change). PURE.
+ */
+export function normalizeDependsOn(dependsOn) {
+  if (!Array.isArray(dependsOn)) return [];
+  const out = [];
+  for (const entry of dependsOn) {
+    let key = null;
+    if (typeof entry === 'string') key = entry.trim();
+    else if (entry && typeof entry === 'object') key = (entry.sd_id || entry.sd_key || '').trim();
+    if (key) out.push({ sd_id: key });
+  }
+  return out;
 }
 
 /**

--- a/tests/unit/leo-create-sd-proposal-depends-on.test.js
+++ b/tests/unit/leo-create-sd-proposal-depends-on.test.js
@@ -1,0 +1,120 @@
+/**
+ * Proposal-ingest dependency + provenance passthrough — SD-FDBK-INFRA-LEO-CREATE-PROPOSAL-001
+ *
+ * BUG: leo-create-sd.js --from-proposal (and the shared --proposal-b64 / --proposal-stdin
+ * core via ingestProposalObject) dropped the proposal's declared dependency/provenance
+ * metadata. mapProposalToCreateArgs used a closed metadata whitelist that never copied
+ * metadata.depends_on / engine_child_index / parent_sd_key, and createSD never even
+ * destructured `dependencies`, so the canonical dependencies column always wrote []. The
+ * coordinator dispatcher gates BLOCKED/READY on the dependencies COLUMN (not on
+ * metadata.depends_on), so soft-dep'd children could dispatch out of order.
+ *
+ * THE INVARIANTS:
+ *   FR-1: a declared metadata.depends_on populates args.dependencies in the canonical
+ *         [{sd_id}] shape (key-string | {sd_id} | {sd_key} all normalized; junk dropped).
+ *   FR-2: engine_child_index / parent_sd_key persist onto metadata ONLY when declared
+ *         (no coercion/defaulting — closed-whitelist invariant preserved).
+ *   NO-REGRESSION: a proposal WITHOUT depends_on yields NO `dependencies` key (→ column [])
+ *         and no extra metadata keys.
+ *
+ * PURE: exercises the exported helpers directly. ZERO live DB access.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  mapProposalToCreateArgs,
+  normalizeDependsOn,
+} from '../../scripts/leo-create-sd.js';
+
+const NORMALIZED = {
+  sdKey: 'SD-LEO-INFRA-CHILD-003',
+  title: 'Child proposal',
+  type: 'infrastructure',
+  priority: 'high',
+  rawType: 'infrastructure',
+};
+
+function proposal(metadata = {}) {
+  return {
+    PROPOSAL: true,
+    status_intended: 'draft',
+    proposed_sd_key: 'SD-LEO-INFRA-CHILD-003',
+    title: 'Child proposal',
+    sd_type: 'infrastructure',
+    priority: 'high',
+    rationale: 'child of the sourcing engine',
+    scope: 'DOES: x. DOES NOT: y.',
+    metadata,
+  };
+}
+
+describe('normalizeDependsOn (FR-1 helper)', () => {
+  it('normalizes bare SD-key strings to {sd_id}', () => {
+    expect(normalizeDependsOn(['SD-FOO-001', 'SD-BAR-002'])).toEqual([
+      { sd_id: 'SD-FOO-001' },
+      { sd_id: 'SD-BAR-002' },
+    ]);
+  });
+
+  it('passes {sd_id} through and maps {sd_key} alias to {sd_id}', () => {
+    expect(normalizeDependsOn([{ sd_id: 'SD-FOO-001' }, { sd_key: 'SD-BAR-002' }])).toEqual([
+      { sd_id: 'SD-FOO-001' },
+      { sd_id: 'SD-BAR-002' },
+    ]);
+  });
+
+  it('drops empty/malformed entries fail-soft and trims whitespace', () => {
+    expect(normalizeDependsOn(['  SD-FOO-001  ', '', null, {}, 42, { sd_id: '' }])).toEqual([
+      { sd_id: 'SD-FOO-001' },
+    ]);
+  });
+
+  it('returns [] for non-array / nullish input', () => {
+    expect(normalizeDependsOn(undefined)).toEqual([]);
+    expect(normalizeDependsOn(null)).toEqual([]);
+    expect(normalizeDependsOn('SD-FOO-001')).toEqual([]);
+    expect(normalizeDependsOn([])).toEqual([]);
+  });
+});
+
+describe('mapProposalToCreateArgs — dependency + provenance passthrough', () => {
+  it('FR-1: maps metadata.depends_on into the canonical dependencies column shape', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal({ depends_on: ['SD-FOO-001', 'SD-BAR-002'] }), 'src');
+    expect(args.dependencies).toEqual([{ sd_id: 'SD-FOO-001' }, { sd_id: 'SD-BAR-002' }]);
+  });
+
+  it('FR-1: object-form deps pass through without double-wrapping', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal({ depends_on: [{ sd_id: 'SD-FOO-001' }] }), 'src');
+    expect(args.dependencies).toEqual([{ sd_id: 'SD-FOO-001' }]);
+  });
+
+  it('FR-2: persists engine_child_index and parent_sd_key onto metadata when declared', () => {
+    const args = mapProposalToCreateArgs(
+      NORMALIZED,
+      proposal({ depends_on: ['SD-FOO-001'], engine_child_index: 3, parent_sd_key: 'SD-PARENT-001' }),
+      'src'
+    );
+    expect(args.metadata.engine_child_index).toBe(3);
+    expect(args.metadata.parent_sd_key).toBe('SD-PARENT-001');
+    // depends_on retained in metadata for back-compat (enforced copy is in the column)
+    expect(args.metadata.depends_on).toEqual(['SD-FOO-001']);
+  });
+
+  it('FR-2: engine_child_index of 0 is preserved (not dropped as falsy)', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal({ engine_child_index: 0 }), 'src');
+    expect(args.metadata.engine_child_index).toBe(0);
+  });
+
+  it('NO-REGRESSION: a proposal without depends_on omits dependencies and the extra metadata keys', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal({}), 'src');
+    expect(args.dependencies).toBeUndefined(); // → createSD writes column []
+    expect('engine_child_index' in args.metadata).toBe(false);
+    expect('parent_sd_key' in args.metadata).toBe(false);
+    expect('depends_on' in args.metadata).toBe(false);
+  });
+
+  it('NO-REGRESSION: an all-junk depends_on yields no dependencies key', () => {
+    const args = mapProposalToCreateArgs(NORMALIZED, proposal({ depends_on: ['', null, {}] }), 'src');
+    expect(args.dependencies).toBeUndefined();
+    expect('depends_on' in args.metadata).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`--from-proposal` (and the shared `--proposal-b64`/`--proposal-stdin` core) dropped the proposal's declared dependency/provenance metadata. `mapProposalToCreateArgs` used a closed metadata whitelist that never copied `metadata.depends_on` / `engine_child_index` / `parent_sd_key`, and `createSD` never destructured `dependencies` — so the canonical `dependencies` column always wrote `[]`. The coordinator dispatcher gates BLOCKED/READY on the **dependencies column** (not on `metadata.depends_on`), so soft-dep'd children dispatched out of order (Adam had to hand-sequence the 10 sourcing-engine children).

## Changes
- **FR-1**: `normalizeDependsOn()` maps `metadata.depends_on` (key-string / `{sd_id}` / `{sd_key}`) into the canonical `[{sd_id}]` shape the dispatcher enforces; populates `args.dependencies`.
- **FR-2**: `engine_child_index` / `parent_sd_key` persist onto metadata only when declared (closed-whitelist invariant preserved; `depends_on` retained in metadata for back-compat).
- **FR-3**: `createSD()` now destructures `dependencies = null` so the column write is reachable.

## Testing
10 new unit tests + 63 sibling proposal tests pass. A proposal without `depends_on` still yields `dependencies=[]` (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)