### PR TITLE
feat(SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-AND-BACKLOG-CLEAR-001): YouTube review-gap fix + dry-run-default backlog-clear

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -331,8 +331,12 @@ const { randomUUID } = require('crypto');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
 async function run() {
-  // 1. Store chairman decision + mark processed
-  const { error: dbErr } = await sb.from('eva_todoist_intake').update({
+  // 1. Store chairman decision + mark processed. SOURCE_TABLE comes from each REVIEW_ITEMS entry's
+  //    sourceTable field (SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-...): 'eva_todoist_intake' for Todoist
+  //    items, 'eva_youtube_intake' for YouTube items. A hardcoded 'eva_todoist_intake' here would
+  //    silently no-op a YouTube item's review (id lives in the youtube table) — leaving the review gap
+  //    half-open. ALWAYS substitute the item's own sourceTable.
+  const { error: dbErr } = await sb.from('SOURCE_TABLE').update({
     chairman_intent: 'INTENT_VALUE',
     chairman_reviewed_at: new Date().toISOString(),
     status: 'processed',
@@ -340,7 +344,9 @@ async function run() {
   }).eq('id', 'ITEM_UUID');
   if (dbErr) { console.error('DB Error:', dbErr.message); return; }
 
-  // 2. Get the todoist_task_id
+  // 2. Todoist completion only applies to Todoist items — YouTube items have no todoist_task_id and are
+  //    physically moved by the post-processor instead. Skip steps 2-3 when SOURCE_TABLE is the YT table.
+  if ('SOURCE_TABLE' !== 'eva_todoist_intake') { console.log('YouTube item reviewed — playlist move handled by post-processor'); return; }
   const { data: item } = await sb.from('eva_todoist_intake')
     .select('todoist_task_id').eq('id', 'ITEM_UUID').single();
   if (!item?.todoist_task_id) { console.log('No Todoist task to complete'); return; }
@@ -365,7 +371,7 @@ run();
 "
 ```
 
-Replace `INTENT_VALUE` with the mapped capture-intent value and `ITEM_UUID` with the item ID.
+Replace `INTENT_VALUE` with the mapped capture-intent value, `ITEM_UUID` with the item ID, and `SOURCE_TABLE` with that item's `sourceTable` from the `REVIEW_ITEMS` entry (`eva_todoist_intake` or `eva_youtube_intake`). YouTube items skip the Todoist-completion sub-step automatically.
 
 You can batch multiple updates into a single script for efficiency.
 
@@ -402,7 +408,9 @@ node -e "
 require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-sb.from('eva_todoist_intake').update({
+// This block runs only for YouTube items (Gemini video analysis), so it targets eva_youtube_intake
+// (SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-...; a hardcoded eva_todoist_intake here silently no-ops).
+sb.from('eva_youtube_intake').update({
   enrichment_summary: 'EXISTING_SUMMARY | Chairman Analysis: GEMINI_RESULT'
 }).eq('id', 'ITEM_UUID').then(({error}) => {
   if (error) console.error('Error:', error.message);
@@ -533,7 +541,9 @@ For each item in the **selected** brainstorm queue (cherry-picked subset), proce
    require('dotenv').config();
    const { createClient } = require('@supabase/supabase-js');
    const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-   sb.from('eva_todoist_intake').update({
+   // SOURCE_TABLE = the item's sourceTable (eva_todoist_intake | eva_youtube_intake) so a YouTube-sourced
+   // build links correctly (SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-...).
+   sb.from('SOURCE_TABLE').update({
      enrichment_summary: 'EXISTING_SUMMARY | Brainstorm: SESSION_ID | SD: SD_KEY'
    }).eq('id', 'ITEM_UUID').then(({error}) => {
      if (error) console.error('Error:', error.message);

--- a/lib/eva/youtube-backlog-clear.js
+++ b/lib/eva/youtube-backlog-clear.js
@@ -1,0 +1,68 @@
+/**
+ * YouTube backlog-clear — SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-AND-BACKLOG-CLEAR-001 (FR-2).
+ *
+ * Pure planning helpers for clearing the classified+unreviewed eva_youtube_intake backlog by the
+ * chairman's "auto-route by AI-rec" method: each row's EXISTING ai-classified chairman_intent IS the
+ * routing decision. We do not invent a verdict — reference/insight route to the reference lane
+ * (excluded from wave clustering), idea routes to the wave lane. Rows whose intent is null or outside
+ * the routable set are SKIPPED (reported, never silently mis-laned) per the PLAN DB/security review.
+ *
+ * The physical playlist move is NOT done here — the CLI delegates it to the proven
+ * lib/integrations/post-processor.js (insert-to-Processed-then-delete, fail-safe + idempotent).
+ *
+ * @module lib/eva/youtube-backlog-clear
+ */
+
+/** capture-intents that map to the reference lane (stored for lookup, excluded from wave clustering). */
+const REFERENCE_INTENTS = new Set(['reference', 'insight']);
+/** capture-intents that map to the wave lane (genuine ideas that should reach wave clustering). */
+const WAVE_INTENTS = new Set(['idea']);
+
+/**
+ * Derive the routing lane from a row's existing AI chairman_intent. Returns null for an intent that
+ * is missing or outside the routable set (question/value/unknown) — caller SKIPS these.
+ * @param {string|null|undefined} chairmanIntent
+ * @returns {'reference'|'wave'|null}
+ */
+export function deriveLane(chairmanIntent) {
+  const intent = (chairmanIntent || '').toLowerCase();
+  if (REFERENCE_INTENTS.has(intent)) return 'reference';
+  if (WAVE_INTENTS.has(intent)) return 'wave';
+  return null;
+}
+
+/**
+ * Build the backlog-clear plan from the classified+unreviewed rows. PURE.
+ * Splits rows into:
+ *   - toRoute: rows with a routable intent → will be stamped reviewed (auto-routed); each carries lane.
+ *   - toSkip:  rows whose intent is null/non-routable → reported, untouched.
+ * Of the routable rows, those still unprocessed (processed_at null) AND with a youtube_playlist_item_id
+ * are the ones the physical move will relocate (toMove) — the rest are already physically in Processed.
+ *
+ * @param {Array<object>} rows eva_youtube_intake rows (classified_at set, chairman_reviewed_at null)
+ * @returns {{ total:number, toRoute:Array, toSkip:Array, toMove:Array, byLane:object, skipReasons:object }}
+ */
+export function planBacklogClear(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const toRoute = [];
+  const toSkip = [];
+  const byLane = { reference: 0, wave: 0 };
+  const skipReasons = {};
+
+  for (const r of list) {
+    const lane = deriveLane(r.chairman_intent);
+    if (!lane) {
+      const reason = r.chairman_intent ? `non_routable_intent:${r.chairman_intent}` : 'null_intent';
+      skipReasons[reason] = (skipReasons[reason] || 0) + 1;
+      toSkip.push({ id: r.id, chairman_intent: r.chairman_intent ?? null });
+      continue;
+    }
+    byLane[lane]++;
+    toRoute.push({ ...r, lane });
+  }
+
+  // Only unprocessed rows with a deletable playlist-item id are physically relocated by the move.
+  const toMove = toRoute.filter((r) => !r.processed_at && r.youtube_playlist_item_id);
+
+  return { total: list.length, toRoute, toSkip, toMove, byLane, skipReasons };
+}

--- a/package.json
+++ b/package.json
@@ -327,6 +327,7 @@
     "sourcing:backfill-adam-ghosts": "node scripts/sourcing-engine/backfill-adam-ghosts.mjs",
     "sourcing:populate": "node scripts/sourcing-engine/proactive-populator.mjs",
     "sourcing:gauge-gap-miner": "node scripts/sourcing-engine/gauge-gap-miner-sweep.mjs",
+    "distill:yt-backlog-clear": "node scripts/eva/youtube-backlog-clear.mjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",
     "contract:scaffold": "node scripts/artifact-contract.js scaffold",
     "contract:check": "node scripts/artifact-contract.js check",

--- a/scripts/eva/chairman-intake-review.js
+++ b/scripts/eva/chairman-intake-review.js
@@ -24,6 +24,7 @@
 
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import dotenv from 'dotenv';
+import { pathToFileURL } from 'url';
 
 dotenv.config();
 
@@ -72,7 +73,29 @@ async function getUnreviewedItems() {
     console.error('Error fetching items:', error.message);
     return [];
   }
-  return data || [];
+  return (data || []).map((it) => ({ ...it, _source: 'eva_todoist_intake' }));
+}
+
+/**
+ * Find unreviewed YouTube intake (SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-AND-BACKLOG-CLEAR-001 FR-1).
+ * The /distill spec already assumes YouTube items appear in the chairman B1 review (Phase 2b's
+ * clickable-link handling), but the review query omitted them. Surface classified (classified_at set)
+ * + unreviewed eva_youtube_intake rows alongside Todoist. Each row is tagged _source so
+ * storeReviewDecision stamps the correct table.
+ */
+async function getUnreviewedYoutubeItems() {
+  const { data, error } = await supabase
+    .from('eva_youtube_intake')
+    .select('id, title, description, youtube_video_id, target_application, target_aspects, chairman_intent, enrichment_summary, classification_confidence, classified_at')
+    .not('classified_at', 'is', null)
+    .is('chairman_reviewed_at', null)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching YouTube items:', error.message);
+    return [];
+  }
+  return (data || []).map((it) => ({ ...it, _source: 'eva_youtube_intake' }));
 }
 
 /**
@@ -103,7 +126,9 @@ function formatItemForReview(item, index, total) {
     '',
   ];
 
+  // Source link is polymorphic: Todoist items carry todoist_url; YouTube items carry youtube_video_id.
   if (item.todoist_url) lines.push(`**Source:** ${item.todoist_url}`);
+  else if (item.youtube_video_id) lines.push(`**Source:** https://www.youtube.com/watch?v=${item.youtube_video_id}`);
   if (item.target_application) lines.push(`**Application:** ${item.target_application}`);
   if (item.target_aspects) {
     const aspects = Array.isArray(item.target_aspects) ? item.target_aspects.join(', ') : item.target_aspects;
@@ -148,9 +173,9 @@ function inferAIRecommendation(item) {
   return 'Research';
 }
 
-async function storeReviewDecision(itemId, intent, reviewMethod = 'auto') {
+async function storeReviewDecision(itemId, intent, reviewMethod = 'auto', sourceTable = 'eva_todoist_intake') {
   if (dryRun) {
-    console.log(`  [DRY RUN] Would stamp reviewed (${reviewMethod}) for item ${itemId} [intent=${intent}]`);
+    console.log(`  [DRY RUN] Would stamp reviewed (${reviewMethod}) for item ${itemId} [intent=${intent}, table=${sourceTable}]`);
     return true;
   }
 
@@ -158,8 +183,9 @@ async function storeReviewDecision(itemId, intent, reviewMethod = 'auto') {
   // stamp chairman_reviewed_at and set status=processed so the post-processor can find it.
   // The action-intent mapping (idea→build, etc.) is derived at query time via CAPTURE_TO_ACTION_MAP.
   // SD-LEO-FIX-DISTILL-ORPHAN-RECOVERY-001: status must be 'processed' or post-processor query misses it.
+  // SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-...: sourceTable routes the stamp to the correct intake table.
   const { error } = await supabase
-    .from('eva_todoist_intake')
+    .from(sourceTable)
     .update({
       chairman_reviewed_at: new Date().toISOString(),
       status: 'processed',
@@ -233,7 +259,11 @@ async function main() {
     console.log(`  ✅ Recovered ${recovered}/${orphans.length} orphan(s) → status=processed`);
   }
 
-  const items = await getUnreviewedItems();
+  // FR-1: surface BOTH Todoist and YouTube intake so YouTube playlist videos reach the chairman review.
+  const todoistItems = await getUnreviewedItems();
+  const youtubeItems = await getUnreviewedYoutubeItems();
+  const items = [...todoistItems, ...youtubeItems];
+  if (youtubeItems.length > 0) console.log(`  (${todoistItems.length} Todoist + ${youtubeItems.length} YouTube)`);
 
   if (items.length === 0) {
     console.log('  No unreviewed enriched items found. Skipping review step.');
@@ -255,6 +285,7 @@ async function main() {
       captureIntent: item.chairman_intent,
       mappedActionIntent: mapCaptureToActionIntent(item.chairman_intent),
       title: item.title,
+      sourceTable: item._source || 'eva_todoist_intake',
     }));
 
     console.log('REVIEW_ITEMS_START');
@@ -279,7 +310,7 @@ async function main() {
     const captureIntent = item.chairman_intent || 'question';
     const actionIntent = mapCaptureToActionIntent(captureIntent);
 
-    const ok = await storeReviewDecision(item.id, actionIntent, 'auto');
+    const ok = await storeReviewDecision(item.id, actionIntent, 'auto', item._source || 'eva_todoist_intake');
     if (ok) {
       decisions.push({ intent: captureIntent, actionIntent });
       stored++;
@@ -309,6 +340,7 @@ async function main() {
 // Export for programmatic use
 export {
   getUnreviewedItems,
+  getUnreviewedYoutubeItems,
   getOrphanedItems,
   formatItemForReview,
   buildIntentOptions,
@@ -320,7 +352,11 @@ export {
   CAPTURE_TO_ACTION_MAP,
 };
 
-main().catch(err => {
-  console.error('Chairman review error:', err.message);
-  process.exit(1);
-});
+// Only run main() when invoked as a CLI — not when imported (e.g. by unit tests or the pipeline).
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch(err => {
+    console.error('Chairman review error:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/eva/youtube-backlog-clear.mjs
+++ b/scripts/eva/youtube-backlog-clear.mjs
@@ -80,10 +80,21 @@ async function main() {
   const yt = moved?.youtube || moved || {};
   console.log(`  post-processor: processed=${yt.processed ?? 'n/a'} errors=${(yt.errors || []).length}`);
 
-  // FR-3 verify: re-query the drain.
-  const remaining = await loadBacklog(supabase);
-  const remPlan = planBacklogClear(remaining);
-  console.log(`\nVERIFY: classified-unreviewed remaining=${remaining.length} (routable still-to-move=${remPlan.toMove.length}). Target ~0 for routable.`);
+  // FR-3 verify: query the ACTUAL drain state. After stamping, the review backlog
+  // (chairman_reviewed_at IS NULL) is empty by construction, so it cannot reveal whether the physical
+  // move happened — the honest signal is rows still status='processed' with processed_at IS NULL.
+  const { count: unreviewed } = await supabase
+    .from('eva_youtube_intake').select('id', { count: 'exact', head: true })
+    .not('classified_at', 'is', null).is('chairman_reviewed_at', null);
+  const { count: unmoved } = await supabase
+    .from('eva_youtube_intake').select('id', { count: 'exact', head: true })
+    .eq('status', 'processed').is('processed_at', null);
+  console.log(`\nVERIFY: classified-unreviewed remaining=${unreviewed ?? '?'} (target 0). Reviewed-but-NOT-physically-moved=${unmoved ?? '?'} (target 0).`);
+  if ((unmoved ?? 0) > 0) {
+    console.warn(`  ⚠️  ${unmoved} row(s) reviewed but their videos are NOT yet moved out of For-Processing.`);
+    console.warn('     Most likely cause: YouTube not authenticated (run `npm run eva:ideas:auth:youtube`).');
+    console.warn('     Re-run this command (or the post-processor) once authenticated — the move is idempotent.');
+  }
   if (stampErrors.length) for (const e of stampErrors.slice(0, 5)) console.warn(`  [stamp error] ${e.id}: ${e.error}`);
 }
 

--- a/scripts/eva/youtube-backlog-clear.mjs
+++ b/scripts/eva/youtube-backlog-clear.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * youtube-backlog-clear — SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-AND-BACKLOG-CLEAR-001 (FR-2/FR-3).
+ *
+ * Clears the classified+unreviewed eva_youtube_intake backlog by the chairman's "auto-route by AI-rec"
+ * method: each row's EXISTING ai chairman_intent is accepted as the chairman's verdict. Routable rows
+ * (reference/insight -> reference lane; idea -> wave lane) get chairman_reviewed_at + status='processed'
+ * stamped; rows with a null/non-routable intent are SKIPPED and reported. The physical playlist move of
+ * the still-unprocessed rows is then delegated to the PROVEN lib/integrations/post-processor.js
+ * (insert-to-Processed-then-delete, fail-safe + idempotent).
+ *
+ * DRY-RUN BY DEFAULT: the bare command reports the per-lane route plan + the would-move count and writes
+ * NOTHING / moves NOTHING. Staging the review stamps + physical move requires --apply.
+ * (post-processor.js has no internal dry-run, so the WHOLE move is gated behind --apply here; dry-run
+ * counts come from independent read-only selects — PLAN security review C1.)
+ *
+ * Usage:  node scripts/eva/youtube-backlog-clear.mjs            # dry-run plan only
+ *         node scripts/eva/youtube-backlog-clear.mjs --apply    # stamp reviewed + move (chairman-gated)
+ */
+import dotenv from 'dotenv';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { planBacklogClear } from '../../lib/eva/youtube-backlog-clear.js';
+import { postProcessAll } from '../../lib/integrations/post-processor.js';
+
+dotenv.config();
+
+const apply = process.argv.includes('--apply');
+
+/** Load the classified+unreviewed eva_youtube_intake rows (the backlog). Read-only. */
+async function loadBacklog(supabase) {
+  const { data, error } = await supabase
+    .from('eva_youtube_intake')
+    .select('id, youtube_video_id, youtube_playlist_item_id, title, chairman_intent, target_application, classification_confidence, status, classified_at, chairman_reviewed_at, processed_at, destination_playlist_id')
+    .not('classified_at', 'is', null)
+    .is('chairman_reviewed_at', null)
+    .order('created_at', { ascending: true });
+  if (error) { console.error('Error loading backlog:', error.message); return []; }
+  return data || [];
+}
+
+function printPlan(plan) {
+  const fmt = (o) => Object.entries(o || {}).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ') || '(none)';
+  console.log('=== YOUTUBE BACKLOG-CLEAR — auto-route-by-AI-rec plan ===');
+  console.log(`classified+unreviewed rows : ${plan.total}`);
+  console.log(`to auto-route (stamp review): ${plan.toRoute.length}   by lane: ${fmt(plan.byLane)}`);
+  console.log(`to physically move now      : ${plan.toMove.length}   (unprocessed + has playlist-item id)`);
+  console.log(`skipped (non-routable)      : ${plan.toSkip.length}   reasons: ${fmt(plan.skipReasons)}`);
+  for (const r of plan.toRoute.slice(0, 8)) {
+    console.log(`  route ${r.lane.padEnd(9)} <- ${(r.chairman_intent || '').padEnd(9)} | ${(r.title || r.youtube_video_id || '').slice(0, 56)}`);
+  }
+}
+
+async function main() {
+  const supabase = createSupabaseServiceClient();
+  const rows = await loadBacklog(supabase);
+  const plan = planBacklogClear(rows);
+  printPlan(plan);
+
+  if (!apply) {
+    console.log(`\nDRY-RUN — wrote nothing, moved nothing. Re-run with --apply to stamp ${plan.toRoute.length} reviewed + move ${plan.toMove.length}.`);
+    return;
+  }
+
+  // --apply: 1) stamp chairman_reviewed_at + status='processed' on the routable rows (auto-route),
+  //          2) delegate the physical playlist move to the proven post-processor.
+  console.log(`\n--apply: stamping ${plan.toRoute.length} rows reviewed (auto-routed by AI intent)...`);
+  let stamped = 0; const stampErrors = [];
+  for (const r of plan.toRoute) {
+    const { error } = await supabase
+      .from('eva_youtube_intake')
+      .update({ chairman_reviewed_at: new Date().toISOString(), status: 'processed' })
+      .eq('id', r.id)
+      .is('chairman_reviewed_at', null); // idempotent: never re-stamp an already-reviewed row
+    if (error) stampErrors.push({ id: r.id, error: error.message }); else stamped++;
+  }
+  console.log(`  stamped reviewed: ${stamped}  (errors: ${stampErrors.length})`);
+
+  console.log('  delegating physical playlist move to post-processor (insert-then-delete, fail-safe)...');
+  const moved = await postProcessAll({ supabase, verbose: true });
+  const yt = moved?.youtube || moved || {};
+  console.log(`  post-processor: processed=${yt.processed ?? 'n/a'} errors=${(yt.errors || []).length}`);
+
+  // FR-3 verify: re-query the drain.
+  const remaining = await loadBacklog(supabase);
+  const remPlan = planBacklogClear(remaining);
+  console.log(`\nVERIFY: classified-unreviewed remaining=${remaining.length} (routable still-to-move=${remPlan.toMove.length}). Target ~0 for routable.`);
+  if (stampErrors.length) for (const e of stampErrors.slice(0, 5)) console.warn(`  [stamp error] ${e.id}: ${e.error}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('[youtube-backlog-clear] fatal:', e.message); process.exit(1); });

--- a/tests/unit/eva/youtube-backlog-clear.test.js
+++ b/tests/unit/eva/youtube-backlog-clear.test.js
@@ -1,0 +1,78 @@
+/**
+ * SD-LEO-INFRA-DISTILL-YT-REVIEW-GAP-AND-BACKLOG-CLEAR-001 — unit tests.
+ * FR-2 pure planning (deriveLane / planBacklogClear) + FR-1 review-gap query (getUnreviewedYoutubeItems).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { deriveLane, planBacklogClear } from '../../../lib/eva/youtube-backlog-clear.js';
+
+describe('deriveLane — auto-route by existing AI chairman_intent (FR-2)', () => {
+  it('reference/insight -> reference lane (excluded from wave clustering)', () => {
+    expect(deriveLane('reference')).toBe('reference');
+    expect(deriveLane('insight')).toBe('reference');
+    expect(deriveLane('INSIGHT')).toBe('reference'); // case-insensitive
+  });
+  it('idea -> wave lane', () => {
+    expect(deriveLane('idea')).toBe('wave');
+  });
+  it('null / non-routable intent -> null (caller skips, never mis-lanes)', () => {
+    expect(deriveLane(null)).toBeNull();
+    expect(deriveLane(undefined)).toBeNull();
+    expect(deriveLane('question')).toBeNull();
+    expect(deriveLane('value')).toBeNull();
+  });
+});
+
+describe('planBacklogClear — split route/skip/move (FR-2/FR-3)', () => {
+  const rows = [
+    { id: 'r1', chairman_intent: 'reference', processed_at: null, youtube_playlist_item_id: 'pli-1' }, // route+move
+    { id: 'r2', chairman_intent: 'idea', processed_at: null, youtube_playlist_item_id: 'pli-2' },      // route+move
+    { id: 'r3', chairman_intent: 'insight', processed_at: '2026-06-20T00:00:00Z', youtube_playlist_item_id: 'pli-3' }, // route, already moved
+    { id: 'r4', chairman_intent: 'question', processed_at: null, youtube_playlist_item_id: 'pli-4' },  // skip (non-routable)
+    { id: 'r5', chairman_intent: null, processed_at: null, youtube_playlist_item_id: 'pli-5' },        // skip (null)
+    { id: 'r6', chairman_intent: 'idea', processed_at: null, youtube_playlist_item_id: null },         // route, but not movable (no pli id)
+  ];
+
+  it('routes routable intents, skips the rest, and only moves unprocessed rows with a playlist-item id', () => {
+    const plan = planBacklogClear(rows);
+    expect(plan.total).toBe(6);
+    expect(plan.toRoute.map((r) => r.id).sort()).toEqual(['r1', 'r2', 'r3', 'r6']);
+    expect(plan.toSkip.map((r) => r.id).sort()).toEqual(['r4', 'r5']);
+    // r3 already processed; r6 has no playlist-item id -> only r1, r2 physically move
+    expect(plan.toMove.map((r) => r.id).sort()).toEqual(['r1', 'r2']);
+    expect(plan.byLane).toEqual({ reference: 2, wave: 2 }); // reference(r1)+insight(r3)=2 ; idea(r2,r6)=2
+  });
+
+  it('reports skip reasons distinctly (null vs non-routable intent)', () => {
+    const plan = planBacklogClear(rows);
+    expect(plan.skipReasons['null_intent']).toBe(1);
+    expect(plan.skipReasons['non_routable_intent:question']).toBe(1);
+  });
+
+  it('handles empty / non-array input', () => {
+    expect(planBacklogClear([]).total).toBe(0);
+    expect(planBacklogClear(undefined).toRoute).toHaveLength(0);
+  });
+});
+
+describe('getUnreviewedYoutubeItems — FR-1 review-gap query', () => {
+  it('queries eva_youtube_intake (classified+unreviewed) and tags rows with _source', async () => {
+    const calls = { table: null, filters: [] };
+    const builder = {
+      select() { return builder; },
+      not(col, op, val) { calls.filters.push(['not', col, op, val]); return builder; },
+      is(col, val) { calls.filters.push(['is', col, val]); return builder; },
+      order() { return Promise.resolve({ data: [{ id: 'yt1', title: 'A', youtube_video_id: 'vid' }], error: null }); },
+    };
+    vi.resetModules();
+    vi.doMock('../../../lib/supabase-client.js', () => ({
+      createSupabaseServiceClient: () => ({ from: (t) => { calls.table = t; return builder; } }),
+    }));
+    const mod = await import('../../../scripts/eva/chairman-intake-review.js');
+    const rows = await mod.getUnreviewedYoutubeItems();
+    expect(calls.table).toBe('eva_youtube_intake');
+    expect(calls.filters).toContainEqual(['not', 'classified_at', 'is', null]);
+    expect(calls.filters).toContainEqual(['is', 'chairman_reviewed_at', null]);
+    expect(rows[0]._source).toBe('eva_youtube_intake');
+    vi.doUnmock('../../../lib/supabase-client.js');
+  });
+});


### PR DESCRIPTION
## Close the YouTube review gap + clear the classified YT intake backlog

**FR-1 (review-gap):** `chairman-intake-review.js` now also surfaces `eva_youtube_intake` (classified + unreviewed) alongside Todoist, with a source-polymorphic link and table-aware review stamping. Added an entrypoint guard so the module is import-safe. The interactive `/distill` consumer (distill.md) is now `sourceTable`-aware so a reviewed YouTube item's decision persists to the right table (adversarial-caught HIGH — previously hardcoded `eva_todoist_intake` → silent no-op).

**FR-2/FR-3 (backlog-clear):** new `scripts/eva/youtube-backlog-clear.mjs` + pure `lib/eva/youtube-backlog-clear.js`. Auto-routes the backlog by each row's EXISTING AI `chairman_intent` (reference/insight → reference lane, idea → wave; null/non-routable SKIPPED + reported), stamps reviewed, then delegates the physical playlist move to the proven `post-processor.js` (insert-then-delete, fail-safe + idempotent). **DRY-RUN by default**; `--apply` gates both the stamps and the move.

### Live run (chairman-authorized)
- **249 rows stamped reviewed** (0 errors) — review gap closed, 0 classified-unreviewed remaining.
- **Physical move of 38 unprocessed videos PENDING**: YouTube OAuth is not authenticated in this environment ("YouTube: Skipping (not authenticated)"). The 38 are correctly staged (`status=processed`, `processed_at=null`) for the post-processor's `reviewedItems` branch to move on the next authenticated run. **Operational follow-up: run `npm run eva:ideas:auth:youtube` then `npm run distill:yt-backlog-clear -- --apply` (idempotent).**

### Verification
- 7 unit tests pass. Live dry-run: 249 routable (212 reference / 37 wave), 38 to move, 0 skipped.
- Sub-agents: DB 92, Security 88, Testing PASS (92). Retro 90.
- Honest post-apply verify reports `reviewed-but-NOT-physically-moved` count (fixed a self-reporting bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
