### PR TITLE
feat(SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001): wire Adam to route the Roadmap-SSOT first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: e72475868356c1e2 -->
+<!-- file_content_hash: 9b7d164a531fd42f -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-16 8:59:38 AM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-20 10:12:53 AM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 74fa677a3a8b02a2 -->
+<!-- file_content_hash: 3c67a44920c1819a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-16 8:59:39 AM
+**Generated**: 2026-06-20 10:12:53 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -82,6 +82,20 @@
 - **CHAIRMAN PHONE-NOTIFY (urgent action-items + decisions) — SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001**: Adam tracks chairman HUMAN action-items in `.adam-chairman-decisions.json` (surfaced in the hourly exec email NEEDS-YOU section) AND, for anything genuinely URGENT / time-critical, routes it to the chairman PHONE via the shared `notifyChairman({title, description, priority, dueDatetime?})` helper (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). The helper adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and dueDatetime / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push LAYER on top of the coordinator decision-queue / `fn_chairman_decide`, NOT a replacement. Use it SPARINGLY (urgent only — never spam the chairman). The coordinator uses the SAME helper for urgent gate decisions; never re-implement the v1 `reminder_add` POST anywhere.
 
 
+## SOURCING SSOT — order of operations
+
+> **Read this BEFORE sourcing anything.** Adam's belt-refill duty silently degraded from *route the SSOT* to *hand-mine the gauge* because the machinery is invisible to a fresh session. This is the required order; the live state of every layer below is printed every `/adam` startup by the **SOURCING SSOT STATE** probe (`scripts/adam-startup-check.mjs`) — read that badge first.
+
+When you need candidates, work the sources **top-down** and stop at the first that yields:
+
+1. **Roadmap-as-SSOT first.** `roadmap_wave_items` + the rung roadmap are the FIRST candidate source. Promote an item via `node scripts/leo-create-sd.js --from-roadmap-item <id>` — the **REGISTER-FIRST** path (it stamps the two-way roadmap↔SD provenance for you; never hand-recreate it). The startup probe prints the unpromoted count per wave.
+2. **Wave-0 distillation if rung-waves are empty.** If the relevant rung-waves have no unpromoted items, **distillation precedes routing** — groom raw backlog (`sd_backlog_map`) into waved, dispositioned candidates first; do not skip straight to gauge-mining. The startup probe prints `sd_backlog_map` disposition %.
+3. **Check the sourcing-engine activation flags BEFORE hand-feeding.** The engine (cron sweeps `SOURCING_ENGINE_V1`, `SOURCING_ROADMAP_ENGINE_V1`, `SOURCING_GAUGE_GAP_MINER_V1`, `SOURCING_DEFERRED_WATCHER_V1`, `SOURCING_PROACTIVE_POPULATOR_V1`, `LEO_ROADMAP_AUTOSOURCE`) populates the belt for you when on. If they are **OFF** (the startup probe flags this), **PROPOSE activation** — flip the flags + apply any dormant migrations — as a chairman/coordinator go-live decision. Do **not** substitute yourself for the dormant engine tick-after-tick; that masks the fact the engine is off and is unsustainable.
+4. **Hand-mining the VDR gauge is LAST-RESORT — and a SMELL.** Mining `computeBuildGauge` for unbuilt capabilities by hand is the bottom of this list, not the top. Reaching for it means a layer above failed: the engine is off, or the backlog is undistilled. When you find yourself hand-mining, fix the upstream cause (propose engine activation / run distillation) rather than normalizing the last-resort path.
+
+> Why: encoding the order-of-operations in the required-reading contract + surfacing the live state of every layer at `/adam` startup makes the *route-the-SSOT-first* duty structurally impossible to miss, so the degrade-to-hand-mining regression cannot recur each fresh session (SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001).
+
+
 ## SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)
 
 This section OPERATIONALIZES the duties NAMED in the Adam Role Contract above — it teaches the HOW so a freshly-engaged Adam can act with zero trial-and-error. Per the chairman keystone (2026-06-13): a LEO role is reliable because its required-reading contract CONTAINS the how-to, not merely names the duty. The canonical scripts cited below are AUTHORITATIVE — if they change, re-verify this section against them rather than letting it drift.
@@ -115,6 +129,8 @@ PROVENANCE (so a verifier checking this section finds the right source): ONLY `s
 ### B. The CONVERSION duty (signal -> well-formed DRAFT SD)
 
 `D1_proactive_sourcing` (above) is not "have ideas" — it is CONVERT a sourced signal into a claimable, correctly-shaped DRAFT SD. Procedure, per item:
+
+> **Route the SSOT FIRST (order of operations).** Before converting, follow **SOURCING SSOT — order of operations** (the subsection above / CLAUDE_ADAM.md): Roadmap-as-SSOT → Wave-0 distillation → check+propose engine-flag activation → hand-mining the VDR gauge only as LAST-RESORT. The live state of each layer prints every `/adam` startup (SOURCING SSOT STATE probe). D1 credit is for routing the SSOT, not for substituting yourself for a dormant engine. (SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001 FR-3)
 1. **Pass THE SOURCING BAR** (the two ordered questions in the contract above — *Is it real?* (live-evidence-verified premise) first, then the alignment/worth question). Verify the premise against LIVE evidence (DB / code / status) — never assert causation off a stale read.
 2. **Choose the source MODE (§A)** that matches the signal — a feedback row -> `--from-feedback`, a plan -> `--from-plan`, a decomposition -> `--child`. The mode wires the provenance; do not hand-recreate it.
 3. **Set the type correctly** (§A hazard) and let the skill generate the `sdKey`.
@@ -174,6 +190,6 @@ The chairman delegated to Adam (2026-06-16; durable: chairman_decisions b917c3e1
 
 ---
 
-*Generated from database: 2026-06-16*
+*Generated from database: 2026-06-20*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: 9f38dcb9065674bb -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: db2eda882dc1c1b6 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 
@@ -36,6 +36,19 @@
 - **Proactivity is PROPOSE, not auto-execute (operator-canonical 2026-06-08)**: When idle, Adam **scans, identifies options, and PRESENTS them to the active coordinator with rationale**, then lets the **coordinator decide** which (if any) Adam works on. Adam does **NOT** autonomously *begin* self-generated proactive work — launching investigations, building — without the coordinator's confirmation. **Sourcing/filing DRAFT SDs is EXEMPT — a DRAFT row is a CONST-002-safe proposal, not a dispatch — and runs CONTINUOUSLY per NEVER HOLD SOURCING (below); only *claiming/worktreeing/driving/dispatching* an SD requires the coordinator's go.** Surfacing findings, canary observations
 
 *...truncated. Read full file for complete section.*
+
+## SOURCING SSOT — order of operations
+
+> **Read this BEFORE sourcing anything.** Adam's belt-refill duty silently degraded from *route the SSOT* to *hand-mine the gauge* because the machinery is invisible to a fresh session. This is the required order; the live state of every layer below is printed every `/adam` startup by the **SOURCING SSOT STATE** probe (`scripts/adam-startup-check.mjs`) — read that badge first.
+
+When you need candidates, work the sources **top-down** and stop at the first that yields:
+
+1. **Roadmap-as-SSOT first.** `roadmap_wave_items` + the rung roadmap are the FIRST candidate source. Promote an item via `node scripts/leo-create-sd.js --from-roadmap-item <id>` — the **REGISTER-FIRST** path (it stamps the two-way roadmap↔SD provenance for you; never hand-recreate it). The startup probe prints the unpromoted count per wave.
+2. **Wave-0 distillation if rung-waves are empty.** If the relevant rung-waves have no unpromoted items, **distillation precedes routing** — groom raw backlog (`sd_backlog_map`) into waved, dispositioned candidates first; do not skip straight to gauge-mining. The startup probe prints `sd_backlog_map` disposition %.
+3. **Check the sourcing-engine activation flags BEFORE hand-feeding.** The engine (cron sweeps `SOURCING_ENGINE_V1`, `SOURCING_ROADMAP_ENGINE_V1`, `SOURCING_GAUGE_GAP_MINER_V1`, `SOURCING_DEFERRED_WATCHER_V1`, `SOURCING_PROACTIVE_POPULATOR_V1`, `LEO_ROADMAP_AUTOSOURCE`) populates the belt for you when on. If they are **OFF** (the startup probe flags this), **PROPOSE activation** — flip the flags + apply any dormant migrations — as a chairman/coordinator go-live decision. Do **not** substitute yourself for the dormant engine tick-after-tick; that masks the fact the engine is off and is unsustainable.
+4. **Hand-mining the VDR gauge is LAST-RESORT — and a SMELL.** Mining `computeBuildGauge` for unbuilt capabilities by hand is the bottom of this list, not the top. Reaching for it means a layer above failed: the engine is off, or the backlog is undistilled. When you find yourself hand-mining, fix the upstream cause (propose engine activation / run distillation) rather than normalizing the last-resort path.
+
+> Why: encoding the order-of-operations in the required-reading contract + surfacing the live state of every layer at `/adam` startup makes the *route-the-SSOT-first* duty structurally impossible to miss, so the degrade-to-hand-mining regression cannot recur each fresh session (SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001).
 
 ## SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: dac93597bf712846 -->
+<!-- file_content_hash: 88ce0de8c64aa979 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-16 8:59:39 AM
+**Generated**: 2026-06-20 10:12:53 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -48,6 +48,6 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 
 ---
 
-*Generated from database: 2026-06-16*
+*Generated from database: 2026-06-20*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: 3152ecbb0fb7e2ab -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: 6dbbb38dd4813bc4 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 5e58a1202900a207 -->
+<!-- file_content_hash: 1d836b8aa8e2cb79 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-16 8:59:38 AM
+**Generated**: 2026-06-20 10:12:53 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1678,7 +1678,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-16*
+*Generated from database: 2026-06-20*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: 13b4cb52428abc79 -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: d1b4fe249f458c1b -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-16 8:59:39 AM*
+*DIGEST generated: 2026-06-20 10:12:53 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: 15db02b814938d87 -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: 95cd3bd2d403aa06 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-16 8:59:39 AM*
+*DIGEST generated: 2026-06-20 10:12:53 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: a0763301168ced86 -->
+<!-- file_content_hash: 4108f667f32d353c -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-16 8:59:39 AM
+**Generated**: 2026-06-20 10:12:53 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2116,6 +2116,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-06-16*
+*Generated from database: 2026-06-20*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: d7aa61219f089b3f -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: 9f2251e79f296cd7 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-16 8:59:39 AM*
+*DIGEST generated: 2026-06-20 10:12:53 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 00fba4a1f47ad638 -->
+<!-- file_content_hash: d3a6060a714e9aef -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-16 8:59:38 AM
+**Generated**: 2026-06-20 10:12:53 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1582,6 +1582,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-16*
+*Generated from database: 2026-06-20*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: d9a64a37f20232de -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: 0920377e0666f0c7 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-16 8:59:39 AM*
+*DIGEST generated: 2026-06-20 10:12:53 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 8d94970b6cb368a3 -->
+<!-- file_content_hash: 603158ae9654808a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-16 8:59:38 AM
+**Generated**: 2026-06-20 10:12:53 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2441,6 +2441,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-16*
+*Generated from database: 2026-06-20*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-16T12:59:38.915Z -->
-<!-- git_commit: bc991d9d -->
-<!-- db_snapshot_hash: 7f0504975a9426f6 -->
-<!-- file_content_hash: 71bac77abcccf191 -->
+<!-- generated_at: 2026-06-20T14:12:53.024Z -->
+<!-- git_commit: a4eec584 -->
+<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
+<!-- file_content_hash: f842b2ae8ebf0c26 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-16 8:59:39 AM*
+*DIGEST generated: 2026-06-20 10:12:53 AM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,109 @@
 {
-  "generated_at": "2026-06-16T12:59:38.915Z",
-  "git_commit": "bc991d9d",
-  "db_snapshot_hash": "7f0504975a9426f6",
+  "generated_at": "2026-06-20T14:12:53.024Z",
+  "git_commit": "a4eec584",
+  "db_snapshot_hash": "8bb50c9305e12f02",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 19368,
-      "estimated_tokens": 4842,
-      "content_hash": "bf24de02d28fae95",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE.md"
+      "chars": 19369,
+      "estimated_tokens": 4843,
+      "content_hash": "ff9390207a7d39d4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 83527,
+      "chars": 83528,
       "estimated_tokens": 20882,
-      "content_hash": "57a7f90178e01508",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_CORE.md"
+      "content_hash": "30eaa6061aa8578e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 65128,
-      "estimated_tokens": 16282,
-      "content_hash": "cd6eddd0a629f8d7",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_LEAD.md"
+      "chars": 65129,
+      "estimated_tokens": 16283,
+      "content_hash": "f0019db2628ee800",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 90830,
+      "chars": 90831,
       "estimated_tokens": 22708,
-      "content_hash": "729ad3d926ce8579",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_PLAN.md"
+      "content_hash": "fceb84394ed50096",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 84821,
+      "chars": 84822,
       "estimated_tokens": 21206,
-      "content_hash": "f8dc0ebfdf6e7cca",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_EXEC.md"
+      "content_hash": "8f469b04bdfda184",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 36961,
-      "estimated_tokens": 9241,
-      "content_hash": "a4787bfa90ea0a80",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_ADAM.md"
+      "chars": 39998,
+      "estimated_tokens": 10000,
+      "content_hash": "bfb910f67a395d03",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 16618,
+      "chars": 16619,
       "estimated_tokens": 4155,
-      "content_hash": "43ee8b6ecaae2584",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_COORDINATOR.md"
+      "content_hash": "6e673a042dce2489",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 9611,
+      "chars": 9612,
       "estimated_tokens": 2403,
-      "content_hash": "4773bec555b87234",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_DIGEST.md"
+      "content_hash": "cac9b907ab5c8691",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 11535,
+      "chars": 11536,
       "estimated_tokens": 2884,
-      "content_hash": "12ab81dea52fbf75",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "ef0a374865d97f40",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 5422,
+      "chars": 5423,
       "estimated_tokens": 1356,
-      "content_hash": "82c742649849c58c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "9308b09533718fe1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 8412,
-      "estimated_tokens": 2103,
-      "content_hash": "29e39d6ca83bf6ca",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_PLAN_DIGEST.md"
+      "chars": 8413,
+      "estimated_tokens": 2104,
+      "content_hash": "9758331181dc8005",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 10835,
+      "chars": 10836,
       "estimated_tokens": 2709,
-      "content_hash": "808c2a20b055222e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "81fe8d4559bc6426",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
-      "chars": 9344,
-      "estimated_tokens": 2336,
-      "content_hash": "4f7667136b6a1639",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_ADAM_DIGEST.md"
+      "chars": 11866,
+      "estimated_tokens": 2967,
+      "content_hash": "8d6756c4bcfe811f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 3973,
       "estimated_tokens": 994,
-      "content_hash": "22c6fc2a22ca4a28",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "b0770fe0c7838420",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "865fab3b6529670d",
+    "global": "5866f504637666be",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -360,9 +360,10 @@
       "601": "88747ca78c466c44",
       "602": "ad0aecae8cdc6cb3",
       "603": "ca922c736e8d8ed3",
-      "604": "2acf962c49efc60c",
+      "604": "67885bf567384f02",
       "605": "19e13f356fce24ab",
-      "606": "25aa68b575c66d07"
+      "606": "25aa68b575c66d07",
+      "607": "d3cc55fdebcf0ddf"
     },
     "meta": {
       "94": {
@@ -1654,6 +1655,11 @@
         "section_type": "adam_role_contract",
         "target_file": "CLAUDE_ADAM.md",
         "title": "Chairman-Delegated DB-Change APPLY Authority (scoped, apply-only, fail-closed, revocable)"
+      },
+      "607": {
+        "section_type": "adam_role_contract",
+        "target_file": "CLAUDE_ADAM.md",
+        "title": "SOURCING SSOT — order of operations"
       }
     }
   }

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -221,11 +221,139 @@ export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   return [renderResponsibilities(repoRoot), '', renderLoops(armed), '', renderContractParity(repoRoot), '', renderFreshness(repoRoot)].join('\n');
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001 (FR-2): the SOURCING SSOT STATE PROBE.
+// A read-only badge printed every /adam startup so a fresh Adam can NEVER miss that the
+// Roadmap-SSOT + the (often dormant) sourcing engine exist before reaching for hand-mining.
+// All helpers are PURE + the DB read is fail-open (a hiccup degrades to a skip line, never
+// throws / blocks startup — same doctrine as the rest of this file).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The sourcing-engine activation flags, in escalation order (umbrella first, then per-engine,
+// then the autosource switch). Each is an env feature flag, OFF unless explicitly on|1|true.
+export const SOURCING_FLAGS = [
+  'SOURCING_ENGINE_V1',
+  'SOURCING_ROADMAP_ENGINE_V1',
+  'SOURCING_GAUGE_GAP_MINER_V1',
+  'SOURCING_DEFERRED_WATCHER_V1',
+  'SOURCING_PROACTIVE_POPULATOR_V1',
+  'LEO_ROADMAP_AUTOSOURCE',
+];
+
+/** Pure flag parse mirroring the sourcing-engine helpers: on|1|true => true; everything else => false. */
+export function isSourcingFlagOn(env, name) {
+  const v = String((env && env[name]) || 'off').toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}
+
+/** Pure: read every SOURCING_FLAGS entry from env => [{ flag, on }]. */
+export function readSourcingFlags(env = {}) {
+  return SOURCING_FLAGS.map((flag) => ({ flag, on: isSourcingFlagOn(env, flag) }));
+}
+
+/**
+ * Pure: aggregate UNPROMOTED roadmap_wave_items (promoted_to_sd_key == null) by wave.
+ * @param {Array<{wave_id:string, promoted_to_sd_key:?string}>} items
+ * @param {Array<{id:string, title:string, sequence_rank:number}>} waves
+ * @returns {{ totalUnpromoted:number, byWave:Array<{wave_id:string,title:string,rank:number,count:number}> }}
+ */
+export function summarizeUnpromotedByWave(items = [], waves = []) {
+  const titleById = new Map((waves || []).map((w) => [w.id, w]));
+  const counts = new Map();
+  let totalUnpromoted = 0;
+  for (const it of items || []) {
+    if (it && (it.promoted_to_sd_key === null || it.promoted_to_sd_key === undefined)) {
+      totalUnpromoted += 1;
+      counts.set(it.wave_id, (counts.get(it.wave_id) || 0) + 1);
+    }
+  }
+  const byWave = [...counts.entries()].map(([wave_id, count]) => {
+    const w = titleById.get(wave_id);
+    return { wave_id, title: (w && w.title) || '(unknown wave)', rank: w ? w.sequence_rank : 9999, count };
+  }).sort((a, b) => a.rank - b.rank);
+  return { totalUnpromoted, byWave };
+}
+
+/** Pure: disposition coverage of sd_backlog_map. */
+export function summarizeBacklogDisposition(total = 0, dispositioned = 0) {
+  const t = Number(total) || 0;
+  const d = Number(dispositioned) || 0;
+  const pct = t === 0 ? 0 : Math.round((100 * d) / t);
+  return { total: t, dispositioned: d, pct };
+}
+
+/** Pure: render the state-probe section from already-resolved data (no I/O). */
+export function renderSourcingStateLines({ flags = [], wave = null, backlog = null } = {}) {
+  const lines = ['═══ SOURCING SSOT STATE (read-only — route the SSOT before hand-mining) ═══'];
+  // Flags
+  const anyOn = flags.some((f) => f.on);
+  lines.push('  Sourcing-engine flags: ' + (anyOn ? '' : '⚠️ ALL OFF — engine dormant; PROPOSE activation, do not substitute yourself tick-after-tick'));
+  for (const f of flags) lines.push(`    ${f.on ? '🟢 on ' : '⚪ off'}  ${f.flag}`);
+  // Roadmap-SSOT unpromoted items
+  if (wave) {
+    lines.push(`  Roadmap-SSOT (roadmap_wave_items) unpromoted: ${wave.totalUnpromoted} — promote via leo-create-sd --from-roadmap-item (REGISTER-FIRST)`);
+    for (const w of wave.byWave.slice(0, 8)) lines.push(`    wave#${w.rank} ${String(w.count).padStart(4)} unpromoted  ${w.title}`);
+    if (wave.byWave.length > 8) lines.push(`    … ${wave.byWave.length - 8} more wave(s)`);
+  } else {
+    lines.push('  Roadmap-SSOT: (unavailable — DB read skipped, fail-open)');
+  }
+  // Backlog disposition
+  if (backlog) {
+    lines.push(`  sd_backlog_map disposition: ${backlog.dispositioned}/${backlog.total} (${backlog.pct}%) — if rung-waves are empty, Wave-0 distillation precedes routing`);
+  } else {
+    lines.push('  sd_backlog_map disposition: (unavailable — DB read skipped, fail-open)');
+  }
+  lines.push('  ↳ Hand-mining the VDR gauge is LAST-RESORT (a SMELL the engine is off / backlog undistilled). See CLAUDE_ADAM.md "SOURCING SSOT — order of operations".');
+  return lines.join('\n');
+}
+
+/**
+ * Fail-open async DB read for the state probe. Returns { wave, backlog } (either may be null on
+ * error). Accepts an injected supabase client for tests; otherwise builds one from env creds.
+ */
+export async function fetchSourcingState({ supabase = null, env = process.env } = {}) {
+  let client = supabase;
+  if (!client) {
+    const url = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return { wave: null, backlog: null };
+    const { createClient } = await import('@supabase/supabase-js');
+    client = createClient(url, key);
+  }
+  let wave = null;
+  let backlog = null;
+  try {
+    const items = await client.from('roadmap_wave_items').select('wave_id,promoted_to_sd_key').is('promoted_to_sd_key', null);
+    const waves = await client.from('roadmap_waves').select('id,title,sequence_rank');
+    if (!items.error && !waves.error) wave = summarizeUnpromotedByWave(items.data || [], waves.data || []);
+  } catch { wave = null; }
+  try {
+    const tot = await client.from('sd_backlog_map').select('*', { count: 'exact', head: true });
+    const disp = await client.from('sd_backlog_map').select('*', { count: 'exact', head: true }).not('disposition', 'is', null);
+    if (!tot.error && !disp.error) backlog = summarizeBacklogDisposition(tot.count, disp.count);
+  } catch { backlog = null; }
+  return { wave, backlog };
+}
+
+/** Compose the full state-probe section (async, fail-open — never throws). */
+export async function renderSourcingState({ supabase = null, env = process.env } = {}) {
+  try {
+    const flags = readSourcingFlags(env);
+    const { wave, backlog } = await fetchSourcingState({ supabase, env });
+    return renderSourcingStateLines({ flags, wave, backlog });
+  } catch (err) {
+    return '═══ SOURCING SSOT STATE ═══\n  ✅ state probe skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 // ── Main (fail-open: always exit 0) ──
-function main() {
+async function main() {
   try {
     console.log('[ADAM-STARTUP] ' + (process.env.CLAUDE_SESSION_ID ? 'session=' + process.env.CLAUDE_SESSION_ID : 'session=unknown'));
     console.log(buildReport(process.argv.slice(2), process.env));
+    // FR-2: the read-only Sourcing SSOT state probe (DB-backed, fail-open).
+    console.log('');
+    console.log(await renderSourcingState({ env: process.env }));
   } catch (err) {
     console.warn('⚠️  adam-startup-check hiccup (non-blocking, fail-open): ' + (err && err.message ? err.message : String(err)));
   }

--- a/tests/unit/adam-sourcing-state-probe.test.mjs
+++ b/tests/unit/adam-sourcing-state-probe.test.mjs
@@ -1,0 +1,129 @@
+// Tests for the SOURCING SSOT STATE probe in scripts/adam-startup-check.mjs
+// SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001 (FR-2)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SOURCING_FLAGS,
+  isSourcingFlagOn,
+  readSourcingFlags,
+  summarizeUnpromotedByWave,
+  summarizeBacklogDisposition,
+  renderSourcingStateLines,
+  fetchSourcingState,
+  renderSourcingState,
+} from '../../scripts/adam-startup-check.mjs';
+
+test('SOURCING_FLAGS lists the six engine activation flags in escalation order', () => {
+  assert.deepEqual(SOURCING_FLAGS, [
+    'SOURCING_ENGINE_V1',
+    'SOURCING_ROADMAP_ENGINE_V1',
+    'SOURCING_GAUGE_GAP_MINER_V1',
+    'SOURCING_DEFERRED_WATCHER_V1',
+    'SOURCING_PROACTIVE_POPULATOR_V1',
+    'LEO_ROADMAP_AUTOSOURCE',
+  ]);
+});
+
+test('isSourcingFlagOn: on|1|true => true; everything else (incl. undefined) => false', () => {
+  for (const v of ['on', 'ON', '1', 'true', 'TRUE']) assert.equal(isSourcingFlagOn({ F: v }, 'F'), true, v);
+  for (const v of ['off', '0', 'false', '', 'yes', undefined]) assert.equal(isSourcingFlagOn({ F: v }, 'F'), false, String(v));
+  assert.equal(isSourcingFlagOn({}, 'MISSING'), false);
+});
+
+test('readSourcingFlags reports per-flag state from env', () => {
+  const flags = readSourcingFlags({ SOURCING_ENGINE_V1: 'on', SOURCING_GAUGE_GAP_MINER_V1: '1' });
+  assert.equal(flags.length, 6);
+  assert.equal(flags.find((f) => f.flag === 'SOURCING_ENGINE_V1').on, true);
+  assert.equal(flags.find((f) => f.flag === 'SOURCING_GAUGE_GAP_MINER_V1').on, true);
+  assert.equal(flags.find((f) => f.flag === 'LEO_ROADMAP_AUTOSOURCE').on, false);
+});
+
+test('summarizeUnpromotedByWave counts only null promoted_to_sd_key, grouped + ordered by wave rank', () => {
+  const items = [
+    { wave_id: 'w2', promoted_to_sd_key: null },
+    { wave_id: 'w1', promoted_to_sd_key: null },
+    { wave_id: 'w1', promoted_to_sd_key: null },
+    { wave_id: 'w1', promoted_to_sd_key: 'SD-X' }, // promoted — excluded
+  ];
+  const waves = [
+    { id: 'w1', title: 'Wave One', sequence_rank: 0 },
+    { id: 'w2', title: 'Wave Two', sequence_rank: 1 },
+  ];
+  const r = summarizeUnpromotedByWave(items, waves);
+  assert.equal(r.totalUnpromoted, 3);
+  assert.deepEqual(r.byWave.map((w) => [w.rank, w.count, w.title]), [[0, 2, 'Wave One'], [1, 1, 'Wave Two']]);
+});
+
+test('summarizeUnpromotedByWave: unknown wave id degrades to a labelled bucket, not a crash', () => {
+  const r = summarizeUnpromotedByWave([{ wave_id: 'ghost', promoted_to_sd_key: null }], []);
+  assert.equal(r.totalUnpromoted, 1);
+  assert.equal(r.byWave[0].title, '(unknown wave)');
+});
+
+test('summarizeBacklogDisposition computes pct and is divide-by-zero safe', () => {
+  assert.deepEqual(summarizeBacklogDisposition(159, 13), { total: 159, dispositioned: 13, pct: 8 });
+  assert.deepEqual(summarizeBacklogDisposition(0, 0), { total: 0, dispositioned: 0, pct: 0 });
+});
+
+test('renderSourcingStateLines warns ALL OFF when no flag is on, and lists the SSOT layers', () => {
+  const out = renderSourcingStateLines({
+    flags: readSourcingFlags({}),
+    wave: { totalUnpromoted: 5, byWave: [{ rank: 0, count: 5, title: 'Wave One' }] },
+    backlog: { total: 10, dispositioned: 2, pct: 20 },
+  });
+  assert.match(out, /ALL OFF/);
+  assert.match(out, /unpromoted: 5/);
+  assert.match(out, /disposition: 2\/10 \(20%\)/);
+  assert.match(out, /LAST-RESORT/);
+});
+
+test('renderSourcingStateLines does NOT warn ALL OFF when a flag is on', () => {
+  const out = renderSourcingStateLines({ flags: readSourcingFlags({ SOURCING_ENGINE_V1: 'on' }), wave: null, backlog: null });
+  assert.doesNotMatch(out, /ALL OFF/);
+  assert.match(out, /🟢 on\s+SOURCING_ENGINE_V1/);
+  assert.match(out, /unavailable — DB read skipped/); // wave + backlog null → fail-open lines
+});
+
+// Injected-supabase fetch: proves the DB read shape without a live DB (FR-2 hermetic).
+function stubSupabase({ items = [], waves = [], total = 0, dispositioned = 0 } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        _table: table,
+        select(_cols, opts) { this._head = !!(opts && opts.head); return this; },
+        is() { return this; },
+        not() { this._dispositioned = true; return this; },
+        then(res, rej) {
+          if (this._table === 'roadmap_wave_items') return Promise.resolve({ data: items, error: null }).then(res, rej);
+          if (this._table === 'roadmap_waves') return Promise.resolve({ data: waves, error: null }).then(res, rej);
+          if (this._table === 'sd_backlog_map') return Promise.resolve({ count: this._dispositioned ? dispositioned : total, error: null }).then(res, rej);
+          return Promise.resolve({ data: [], error: null }).then(res, rej);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+test('fetchSourcingState wires the injected client into the pure summaries', async () => {
+  const supabase = stubSupabase({
+    items: [{ wave_id: 'w1', promoted_to_sd_key: null }, { wave_id: 'w1', promoted_to_sd_key: null }],
+    waves: [{ id: 'w1', title: 'Wave One', sequence_rank: 0 }],
+    total: 100, dispositioned: 25,
+  });
+  const { wave, backlog } = await fetchSourcingState({ supabase, env: {} });
+  assert.equal(wave.totalUnpromoted, 2);
+  assert.deepEqual(backlog, { total: 100, dispositioned: 25, pct: 25 });
+});
+
+test('fetchSourcingState fail-open: no creds + no client => nulls (never throws)', async () => {
+  const { wave, backlog } = await fetchSourcingState({ supabase: null, env: {} });
+  assert.equal(wave, null);
+  assert.equal(backlog, null);
+});
+
+test('renderSourcingState is fail-open and always returns a string section', async () => {
+  const out = await renderSourcingState({ supabase: null, env: {} });
+  assert.equal(typeof out, 'string');
+  assert.match(out, /SOURCING SSOT STATE/);
+});


### PR DESCRIPTION
## Summary
Adam's belt-refill duty silently degraded from *route the Roadmap-SSOT* to *hand-mine the VDR gauge* every fresh session because the Roadmap-SSOT + the (dormant) sourcing engine were invisible. This SD makes the order-of-operations impossible to miss.

## Changes
- **FR-1** New `SOURCING SSOT — order of operations` subsection in `leo_protocol_sections` (adam_role_contract, id 607) → regenerated into `CLAUDE_ADAM.md`: Roadmap-as-SSOT first (`--from-roadmap-item`) → Wave-0 distillation if waves empty → check + propose engine-flag activation → hand-mining the gauge LAST-RESORT.
- **FR-2** Read-only `SOURCING SSOT STATE` probe in `scripts/adam-startup-check.mjs`, printed every `/adam`: unpromoted `roadmap_wave_items` by wave, on/off for the six engine flags, `sd_backlog_map` disposition %. Fail-open (pure helpers + try/catch DB read; never blocks startup); injectable supabase for tests.
- **FR-3** Cross-reference from the `D1_proactive_sourcing` conversion duty (*Route the SSOT FIRST*).
- **FR-5** `tests/unit/adam-sourcing-state-probe.test.mjs` (11 tests); existing startup-check suite green (16); no CLAUDE drift.

## Verification
- Testing agent: 11 + 16 tests pass, exit 0, no drift, fail-open confirmed.
- Adversarial review: **SHIP** — no HIGH/MEDIUM blockers; live DB counts cross-checked (492 unpromoted, 13/159=8%).
- Live: all 6 flags OFF → probe correctly warns "PROPOSE activation, do not substitute yourself".

🤖 Generated with [Claude Code](https://claude.com/claude-code)