### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001): wire coordinator belt-low to the sourcing-engine SSOT

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -698,7 +698,45 @@ When the user mentions any of these phrases, suggest `/coordinator`:
 
 ---
 
+## Sourcing engine + Roadmap-SSOT awareness (belt-low FIRST-CHECK)
+
+> **SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001.** This complements — does not restate —
+> the charter's belt-low→ask-Adam duty (canonical in `CLAUDE_COORDINATOR.md`). It defines the
+> decision path the coordinator runs *before* a manual hand-ask.
+
+**You have a sourcing engine.** The sourcing-engine SD family (10/10 children, shipped) plus the
+`roadmap_wave_items` SSOT and the rung roadmap already exist to keep the belt fed *automatically*.
+Perpetual manual backfill (reflexively pinging Adam to hand-source candidates every time the belt
+dips) is the **anti-pattern** — it means the engine is idle while you do its job by hand.
+
+**On belt-low, the FIRST check is the engine, NOT a hand-ask to Adam:**
+1. **Engine activation-flag state** — are the `SOURCING_*` flags on? (`SOURCING_GAUGE_GAP_MINER_V1`,
+   `SOURCING_DEFERRED_WATCHER_V1`, …). The canonical list + the reader live in
+   `scripts/lib/sourcing-engine-awareness.mjs` (`readSourcingEngineFlags`).
+2. **Unpromoted roadmap depth** — how many `roadmap_wave_items` have `promoted_to_sd_key IS NULL`?
+   A rich unpromoted backlog with the engine OFF is the tell.
+3. **Remediation order:**
+   - **Engine DORMANT + rich backlog** → the fix is to **PROPOSE/co-sponsor ACTIVATION** (flip the
+     flags + apply the dormant migrations) and/or **Wave-0 distillation**, escalating to the
+     chairman — *not* a manual source ask.
+   - **Engine ON + backlog** → let the engine promote/distill; give it a tick before hand-asking.
+   - **Engine ON + 0 unpromoted** → belt-low is genuine worker demand or a genuinely empty backlog;
+     *now* a targeted Adam source ask (weakest-capability shortlist) is appropriate.
+
+**Where this surfaces automatically:** the capacity forecaster
+(`scripts/coordinator-capacity-forecast.mjs`) prints a `SOURCING:` line every run and embeds the
+same engine-state framing in its DEFICIT verdict and in the `[COORD->ADAM]` belt-low ping body
+(`SOURCING ENGINE FIRST-CHECK: …`), plus `engine_on=`/`unpromoted=` on the machine-readable `GAUGE`
+line. So a DEFICIT reads *"engine OFF, N unpromoted → activate/distill"* — not just *"source N
+candidates"*. Read that line before acting on any belt-low signal.
+
+---
+
 ## Adam advisory lane (read + reply)
+
+> **Before a belt-low source ask to Adam:** run the *Sourcing engine + Roadmap-SSOT awareness*
+> FIRST-CHECK above (engine flag state + unpromoted roadmap depth). If the engine is dormant with a
+> rich backlog, the remediation is activation/distillation — not a manual hand-ask.
 
 Adam advisories are `session_coordination` `INFO` rows (`payload.kind=adam_advisory`), **retired
 ONLY by `payload.actioned_at`** (`read_at` = delivered, not actioned). The coordinator-startup

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -37,6 +37,10 @@ import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
 // fleet-dashboard.cjs on coordinator/adam/non_fleet/fixture exclusion) and ADDS a released-status
 // guard (FR-2; the forecaster is deliberately stricter than the dashboard on status).
 import { isLiveCountableWorker } from './lib/live-countable-worker.mjs';
+// SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): surface the sourcing-engine
+// flag state + unpromoted roadmap depth so a belt-low/DEFICIT ping says "engine OFF, N unpromoted
+// -> activate/distill" instead of only "source N candidates" (manual backfill is the anti-pattern).
+import { readSourcingEngineFlags, formatSourcingAwareness } from './lib/sourcing-engine-awareness.mjs';
 // SD-LEO-INFRA-CAPACITY-FORECAST-STALLED-BELT-EMPTY-FP-001: an idle worker is STALLED only when
 // its loop isn't claiming DESPITE available work — gate the stall label on belt depth, not heartbeat
 // age alone, so an empty-belt idle worker isn't a false-positive STALLED.
@@ -203,7 +207,15 @@ async function main() {
   }
   console.log(`  BELT: ${beltDepth} claimable (${claimable.length} SD + ${openQfCount} QF)  |  DEMAND(soon): ${demandSoon} (idle ${idleNow} + freeing-soon ${freeingSoon})  |  buffer ${BELT_BUFFER}`);
   if (claimable.length) console.log(`        claimable SDs: ${claimable.map(d => d.sd_key.replace('SD-LEO-INFRA-', '')).join(', ')}`);
-  console.log(`  VERDICT: ${verdict}` + (deficit > 0 ? `  → belt short by ${deficit} — SOURCE AHEAD (reach Adam)` : ''));
+
+  // SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): sourcing-engine awareness — flag
+  // state + unpromoted roadmap depth so belt-low is read as "activate/distill" before "hand-ask Adam".
+  const sourcingFlags = readSourcingEngineFlags(process.env);
+  const unpromotedCount = await countUnpromotedRoadmapItems(sb);
+  const awareness = formatSourcingAwareness({ flags: sourcingFlags, unpromotedCount });
+  console.log(`  SOURCING: ${awareness.line}`);
+
+  console.log(`  VERDICT: ${verdict}` + (deficit > 0 ? `  → belt short by ${deficit} — ${awareness.recommendation}` : ''));
 
   // ── proactive Adam reach-out on a forecast deficit ──
   if (verdict.startsWith('DEFICIT')) {
@@ -214,14 +226,30 @@ async function main() {
     } else if (since < cooldownMin) {
       console.log(`  ACTION: deficit, but Adam was pinged ${since.toFixed(0)}m ago (< ${cooldownMin}m cooldown) — holding.`);
     } else {
-      const sent = await reachAdam({ verdict, beltDepth, demandSoon, idleNow, freeingSoon, deficit, claimable, rows });
+      const sent = await reachAdam({ verdict, beltDepth, demandSoon, idleNow, freeingSoon, deficit, claimable, rows, awareness });
       if (sent) { writeCooldown(); console.log('  ACTION: ✅ sourcing request dispatched to Adam (cooldown started).'); }
       else console.log('  ACTION: ⚠ no live Adam session found to reach — surface to operator.');
     }
   }
 
-  // machine-readable last line for the cron/log
-  console.log(`  GAUGE belt=${beltDepth} idle=${idleNow} freeing_soon=${freeingSoon} demand=${demandSoon} deficit=${Math.max(0, deficit)} verdict=${verdict}`);
+  // machine-readable last line for the cron/log (+ sourcing-engine awareness fields, FR-2)
+  console.log(`  GAUGE belt=${beltDepth} idle=${idleNow} freeing_soon=${freeingSoon} demand=${demandSoon} deficit=${Math.max(0, deficit)} verdict=${verdict} engine_on=${awareness.anyOn} unpromoted=${awareness.countStr}`);
+}
+
+// SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): unpromoted roadmap depth.
+// Unpromoted = roadmap_wave_items with promoted_to_sd_key IS NULL (mirrors scripts/roadmap-status.js).
+// Fail-soft: any error (table absent/unreadable) → null ("unknown"), never throws or blocks the forecast.
+async function countUnpromotedRoadmapItems(client) {
+  try {
+    const { count, error } = await client
+      .from('roadmap_wave_items')
+      .select('id', { count: 'exact', head: true })
+      .is('promoted_to_sd_key', null);
+    if (error) return null;
+    return typeof count === 'number' ? count : null;
+  } catch {
+    return null;
+  }
 }
 
 function readCooldown() {
@@ -246,18 +274,22 @@ async function reachAdam(f) {
     `[COORD->ADAM] PREDICTIVE belt-low (capacity forecaster). Verdict=${f.verdict}.`,
     `Belt=${f.beltDepth} claimable vs demand(soon)=${f.demandSoon} (idle ${f.idleNow} + freeing-soon ${f.freeingSoon}) → short by ${f.deficit}.`,
     `Claimable now: ${f.claimable.map(d => d.sd_key.replace('SD-LEO-INFRA-', '')).join(', ') || 'NONE'}. Idle/at-risk workers: ${idleList}.`,
+    // SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): surface the engine state FIRST so
+    // the ask is "activate/distill the engine/roadmap" when it's dormant-with-backlog, NOT perpetual
+    // manual sourcing (the anti-pattern). The engine (10/10 children) + roadmap_wave_items are the SSOT.
+    f.awareness ? `SOURCING ENGINE FIRST-CHECK: ${f.awareness.line}` : '',
     // SD-LEO-INFRA-ADAM-DURABLE-SOURCE-TRIGGER-001 (FR-3): retarget the belt-low ask at the
     // VISION-ALIGNED weakest capabilities (read the per-capability gauge + mine the dispositioned
     // estate) instead of generic harness-backlog grooming.
-    `Per protocol I'm reaching out BEFORE the belt empties. Please READ the per-capability vision gauge + MINE the dispositioned estate for the WEAKEST capabilities, then propose a shortlist of CONFLICT-FREE, non-gated, draft-ready SD candidates that move those weakest capabilities forward (NOT generic harness-backlog grooming), propose-only; I'll dispatch. Dedup vs in-flight + SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001.`,
+    `If the engine is dormant while the roadmap is rich, the remediation is to PROPOSE/co-sponsor ACTIVATION (flip the SOURCING_* flags + apply dormant migrations) and/or Wave-0 distillation, escalating to the chairman — before any manual backfill. Otherwise: READ the per-capability vision gauge + MINE the dispositioned estate for the WEAKEST capabilities, then propose a shortlist of CONFLICT-FREE, non-gated, draft-ready SD candidates that move those weakest capabilities forward (NOT generic harness-backlog grooming), propose-only; I'll dispatch. Dedup vs in-flight + SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001.`,
     `Reply via adam-advisory (correlation ${correlation_id}).`,
-  ].join('\n');
+  ].filter(Boolean).join('\n');
   const res = await insertCoordinationRow(sb, {
     message_type: 'INFO',
     sender_session: process.env.CLAUDE_SESSION_ID,
     target_session: adamId,
     subject: `[COORD->ADAM] PREDICTIVE source_work — belt short by ${f.deficit} (${f.verdict})`,
-    payload: { kind: 'coordinator_request', topic: 'source_work', expects_reply: true, correlation_id, body, forecast: { belt: f.beltDepth, demand: f.demandSoon, deficit: f.deficit, verdict: f.verdict } },
+    payload: { kind: 'coordinator_request', topic: 'source_work', expects_reply: true, correlation_id, body, forecast: { belt: f.beltDepth, demand: f.demandSoon, deficit: f.deficit, verdict: f.verdict, sourcing_engine_on: f.awareness ? f.awareness.anyOn : null, unpromoted_roadmap_items: f.awareness ? f.awareness.countStr : null } },
   });
   return !res.error;
 }

--- a/scripts/lib/sourcing-engine-awareness.mjs
+++ b/scripts/lib/sourcing-engine-awareness.mjs
@@ -1,0 +1,69 @@
+/**
+ * sourcing-engine-awareness.mjs — pure helpers so the coordinator's capacity forecaster
+ * (and any belt-low decision path) can surface the SOURCING ENGINE state at the moment it
+ * would otherwise hand-ask Adam for manual backfill.
+ *
+ * SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): a DEFICIT ping must read
+ * "engine OFF, N unpromoted -> activate/distill" instead of only "source N candidates", so the
+ * FIRST remediation on belt-low is checking engine activation-flag state + unpromoted roadmap
+ * depth — NOT perpetual manual sourcing (the anti-pattern).
+ *
+ * Pure (no DB / no env mutation): the caller reads the flags + queries the unpromoted count and
+ * passes them in. The flag-name registry lives here so it is the single place to extend when a
+ * new sourcing-engine flag ships.
+ */
+
+// The canonical sourcing-engine activation flags (mirrors the per-module isXxxFlagEnabled helpers:
+// lib/sourcing-engine/gauge-gap-miner.js, lib/sourcing-engine/deferred-watcher.js). Add new
+// sourcing-engine flags here as they ship so the forecaster surfaces them automatically.
+export const SOURCING_ENGINE_FLAGS = Object.freeze([
+  Object.freeze({ env: 'SOURCING_GAUGE_GAP_MINER_V1', label: 'gauge-gap-miner' }),
+  Object.freeze({ env: 'SOURCING_DEFERRED_WATCHER_V1', label: 'deferred-watcher' }),
+]);
+
+// Same truthiness convention the per-module helpers use: 'on' | '1' | 'true' (case-insensitive).
+export function isSourcingFlagOn(value) {
+  const v = String(value == null ? 'off' : value).toLowerCase();
+  return v === 'on' || v === '1' || v === 'true';
+}
+
+// Read the canonical flags from an env-like object → [{ env, label, enabled }].
+export function readSourcingEngineFlags(env = process.env) {
+  const e = env || {};
+  return SOURCING_ENGINE_FLAGS.map((f) => ({ env: f.env, label: f.label, enabled: isSourcingFlagOn(e[f.env]) }));
+}
+
+/**
+ * Build the human-readable awareness line + a remediation recommendation.
+ * @param {{flags?: Array<{label:string, enabled:boolean}>, unpromotedCount?: number|null}} input
+ * @returns {{ line:string, recommendation:string, anyOn:boolean, allOn:boolean, flagStr:string, countStr:string }}
+ */
+export function formatSourcingAwareness({ flags = [], unpromotedCount = null } = {}) {
+  const anyOn = flags.some((f) => f.enabled);
+  const allOn = flags.length > 0 && flags.every((f) => f.enabled);
+  const flagStr = flags.length ? flags.map((f) => `${f.label}=${f.enabled ? 'on' : 'off'}`).join(', ') : 'none';
+  const known = typeof unpromotedCount === 'number' && Number.isFinite(unpromotedCount);
+  const countStr = known ? String(unpromotedCount) : 'unknown';
+  const hasBacklog = !known || unpromotedCount > 0; // unknown → assume there may be backlog (safer)
+
+  let recommendation;
+  if (!anyOn && hasBacklog) {
+    // The core anti-pattern guard: dormant engine + rich backlog → activate/distill, do NOT hand-ask.
+    recommendation = `engine DORMANT with ${countStr} unpromoted roadmap item(s) → FIRST remediation is to ACTIVATE the engine (flip the SOURCING_* flags + apply the dormant migrations) and/or Wave-0 distillation, escalating to the chairman — perpetual manual backfill is the anti-pattern`;
+  } else if (!anyOn && !hasBacklog) {
+    recommendation = `engine OFF and 0 unpromoted roadmap items → backlog is genuinely empty; manual sourcing / Wave-0 distillation is appropriate`;
+  } else if (hasBacklog) {
+    recommendation = `engine partially/fully ON with ${countStr} unpromoted item(s) → let the engine promote/distill the roadmap before any manual hand-ask`;
+  } else {
+    recommendation = `engine ON, 0 unpromoted → belt-low is real worker demand, not a sourcing gap`;
+  }
+
+  return {
+    line: `Sourcing engine: ${flagStr} | unpromoted roadmap_wave_items: ${countStr}. ${recommendation}`,
+    recommendation,
+    anyOn,
+    allOn,
+    flagStr,
+    countStr,
+  };
+}

--- a/tests/unit/sourcing-engine-awareness.test.js
+++ b/tests/unit/sourcing-engine-awareness.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2) — tests for the pure
+ * sourcing-engine awareness helpers used by the capacity forecaster's belt-low / DEFICIT output.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  SOURCING_ENGINE_FLAGS,
+  isSourcingFlagOn,
+  readSourcingEngineFlags,
+  formatSourcingAwareness,
+} from '../../scripts/lib/sourcing-engine-awareness.mjs';
+
+describe('isSourcingFlagOn', () => {
+  it('treats on/1/true (case-insensitive) as enabled', () => {
+    for (const v of ['on', 'ON', '1', 'true', 'TRUE', 'True']) expect(isSourcingFlagOn(v)).toBe(true);
+  });
+  it('treats anything else (incl. undefined/null/off) as disabled', () => {
+    for (const v of [undefined, null, '', 'off', '0', 'false', 'yes', 'enabled']) expect(isSourcingFlagOn(v)).toBe(false);
+  });
+});
+
+describe('readSourcingEngineFlags', () => {
+  it('reads the canonical flags from an env-like object', () => {
+    const flags = readSourcingEngineFlags({ SOURCING_GAUGE_GAP_MINER_V1: 'on', SOURCING_DEFERRED_WATCHER_V1: 'off' });
+    const byLabel = Object.fromEntries(flags.map((f) => [f.label, f.enabled]));
+    expect(byLabel['gauge-gap-miner']).toBe(true);
+    expect(byLabel['deferred-watcher']).toBe(false);
+    expect(flags.length).toBe(SOURCING_ENGINE_FLAGS.length);
+  });
+  it('defaults every flag to OFF when env is empty', () => {
+    const flags = readSourcingEngineFlags({});
+    expect(flags.every((f) => f.enabled === false)).toBe(true);
+  });
+});
+
+describe('formatSourcingAwareness — belt-low remediation framing', () => {
+  it('DORMANT engine + backlog → recommends ACTIVATE/distill, not manual backfill', () => {
+    const r = formatSourcingAwareness({
+      flags: [{ label: 'gauge-gap-miner', enabled: false }, { label: 'deferred-watcher', enabled: false }],
+      unpromotedCount: 42,
+    });
+    expect(r.anyOn).toBe(false);
+    expect(r.countStr).toBe('42');
+    expect(r.recommendation).toMatch(/ACTIVATE/);
+    expect(r.recommendation).toMatch(/anti-pattern/);
+    expect(r.line).toMatch(/gauge-gap-miner=off, deferred-watcher=off/);
+    expect(r.line).toMatch(/unpromoted roadmap_wave_items: 42/);
+  });
+
+  it('OFF engine + 0 backlog → manual sourcing is appropriate (no false activate nudge)', () => {
+    const r = formatSourcingAwareness({
+      flags: [{ label: 'gauge-gap-miner', enabled: false }, { label: 'deferred-watcher', enabled: false }],
+      unpromotedCount: 0,
+    });
+    expect(r.recommendation).toMatch(/genuinely empty/);
+    expect(r.recommendation).not.toMatch(/ACTIVATE/);
+  });
+
+  it('engine ON + backlog → let the engine promote/distill before a hand-ask', () => {
+    const r = formatSourcingAwareness({
+      flags: [{ label: 'gauge-gap-miner', enabled: true }, { label: 'deferred-watcher', enabled: false }],
+      unpromotedCount: 10,
+    });
+    expect(r.anyOn).toBe(true);
+    expect(r.allOn).toBe(false);
+    expect(r.recommendation).toMatch(/let the engine promote\/distill/);
+  });
+
+  it('engine ON + 0 backlog → belt-low is real worker demand', () => {
+    const r = formatSourcingAwareness({
+      flags: [{ label: 'gauge-gap-miner', enabled: true }, { label: 'deferred-watcher', enabled: true }],
+      unpromotedCount: 0,
+    });
+    expect(r.allOn).toBe(true);
+    expect(r.recommendation).toMatch(/real worker demand/);
+  });
+
+  it('unknown count (null) is reported as "unknown" and treated as possible-backlog', () => {
+    const r = formatSourcingAwareness({
+      flags: [{ label: 'gauge-gap-miner', enabled: false }, { label: 'deferred-watcher', enabled: false }],
+      unpromotedCount: null,
+    });
+    expect(r.countStr).toBe('unknown');
+    // unknown → safer assumption that backlog may exist → activate framing, not "genuinely empty"
+    expect(r.recommendation).toMatch(/ACTIVATE/);
+  });
+
+  it('handles empty flags array without throwing', () => {
+    const r = formatSourcingAwareness({ flags: [], unpromotedCount: 5 });
+    expect(r.flagStr).toBe('none');
+    expect(r.anyOn).toBe(false);
+  });
+
+  it('defaults gracefully with no arguments', () => {
+    const r = formatSourcingAwareness();
+    expect(r.countStr).toBe('unknown');
+    expect(r.flagStr).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
The coordinator reflexively hand-asked Adam for manual backfill on belt-low even though the **sourcing engine (10/10 children, shipped)**, the `roadmap_wave_items` SSOT, and the rung roadmap already exist to feed the belt automatically. Perpetual manual backfill is the **anti-pattern**. This wires the coordinator's belt-low decision path to the engine state.

## Changes
- **FR-1** `.claude/commands/coordinator.md` gains a *Sourcing engine + Roadmap-SSOT awareness (belt-low FIRST-CHECK)* section: on belt-low the FIRST check is engine activation-flag state + unpromoted roadmap depth; dormant-engine + rich-backlog → **PROPOSE/co-sponsor activation** (flip `SOURCING_*` flags + apply dormant migrations) and/or Wave-0 distillation, escalating to the chairman — not a manual ask. Complements (does not restate) the DB charter's belt-low duty.
- **FR-2** `scripts/coordinator-capacity-forecast.mjs` surfaces the `SOURCING_*` flag state + the unpromoted `roadmap_wave_items` count (`promoted_to_sd_key IS NULL`, **fail-soft** → `unknown`) in: a `SOURCING:` render line, the DEFICIT verdict tail, the `[COORD->ADAM]` belt-low ping body (`SOURCING ENGINE FIRST-CHECK: …` + activate/distill-first), `payload.forecast`, and the machine `GAUGE` line (`engine_on=`/`unpromoted=`). A DEFICIT now reads *"engine OFF, N unpromoted → activate/distill"* not just *"source N candidates"*.
- **FR-3** the Adam advisory lane cross-references the FIRST-CHECK at the hand-ask decision point.
- **NEW** pure `scripts/lib/sourcing-engine-awareness.mjs` (flag registry + `readSourcingEngineFlags` + `formatSourcingAwareness`) — the single, unit-tested place for the engine-state framing.

## Verification
- `npx vitest run tests/unit/sourcing-engine-awareness.test.js` → 11 pass (dormant+backlog → ACTIVATE/anti-pattern; OFF+0 → manual appropriate; ON+backlog → let engine distill; unknown → activate framing)
- `tests/unit/capacity-idle-classifier.test.js` → still green (no regression)
- **Live smoke**: `node scripts/coordinator-capacity-forecast.mjs` → `SOURCING: gauge-gap-miner=off, deferred-watcher=off | unpromoted roadmap_wave_items: 492 … engine DORMANT → ACTIVATE` (real estate proves the anti-pattern)

No DDL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)