### PR TITLE
feat(SD-LEO-INFRA-SD-START-STALE-BASE-WARN-001): warn/auto-rebase when worktree base is behind origin/main

### DIFF
--- a/lib/worktree/stale-base-guard.mjs
+++ b/lib/worktree/stale-base-guard.mjs
@@ -1,0 +1,122 @@
+/**
+ * Worktree stale-base guard — SD-LEO-INFRA-SD-START-STALE-BASE-WARN-001.
+ *
+ * When sd-start.js attaches/creates a worktree whose base is BEHIND origin/main, the worker builds
+ * on a stale base. A later merge-as-is can REVERT sibling changes (especially file deletions) that
+ * landed on main after the base commit — a real regression risk in a fleet that merges PRs
+ * continuously (confirmed hit twice in one session: PROACTIVE-POPULATOR + DISTILL).
+ *
+ * This module is the durable guard: on worktree resolution, detect the behind-count vs origin/main
+ * and either WARN (default — loud, with the safe remedy) or AUTO-REBASE (opt-in, only when the tree
+ * is clean). It REUSES lib/governance/checkout-freshness.js (the existing fail-open behind-count +
+ * protocol-drift SSOT) rather than re-deriving a rev-list, and it is itself FAIL-OPEN: any git error
+ * degrades to a skip so the guard can NEVER block a claim/startup.
+ *
+ * @module lib/worktree/stale-base-guard
+ */
+
+import { execFileSync } from 'node:child_process';
+import { checkoutFreshness } from '../governance/checkout-freshness.js';
+
+/**
+ * PURE decision: given the behind-count, tree cleanliness, and whether auto-rebase is opted in,
+ * decide what to do. No IO.
+ *   behind <= 0                         -> 'none'
+ *   behind > 0 && autoRebase && clean   -> 'rebase'   (safe: reset --hard preserves untracked)
+ *   behind > 0 && autoRebase && !clean  -> 'warn'     (refuse to rebase a dirty tree — never clobber WIP)
+ *   behind > 0 && !autoRebase           -> 'warn'
+ * @returns {{action:'none'|'warn'|'rebase', reason:string}}
+ */
+export function decideStaleBaseAction({ behind = 0, treeClean = true, autoRebase = false } = {}) {
+  const n = Number.isFinite(Number(behind)) ? Math.max(0, Number(behind)) : 0;
+  if (n === 0) return { action: 'none', reason: 'base up to date with origin/main' };
+  if (autoRebase && treeClean) return { action: 'rebase', reason: `auto-rebase: clean tree, behind by ${n}` };
+  if (autoRebase && !treeClean) return { action: 'warn', reason: `auto-rebase requested but tree is dirty (behind by ${n}) — refusing to clobber WIP` };
+  return { action: 'warn', reason: `behind by ${n}; warn-by-default (pass --rebase-base / SD_START_AUTO_REBASE=1 to auto-rebase)` };
+}
+
+/** PURE: the loud warning text. Names the behind-count, any protocol drift, and the safe remedy. */
+export function renderStaleBaseWarning({ behind, baseRef = 'origin/main', criticalDiff = [], dirty = false } = {}) {
+  const lines = [];
+  lines.push(`⚠️  STALE WORKTREE BASE — this worktree is behind ${baseRef} by ${behind} commit(s).`);
+  lines.push(`    Building on a stale base risks a merge-as-is REVERTING sibling work (esp. file deletions) that landed on ${baseRef} after your base commit.`);
+  if (criticalDiff && criticalDiff.length) {
+    lines.push(`    🛑 Protocol file(s) also drifted vs base: ${criticalDiff.join(', ')} — you may be operating on stale rules.`);
+  }
+  if (dirty) {
+    lines.push(`    Safe remedy (tree has changes): commit/stash first, then  git merge origin/main  (or  git rebase origin/main).`);
+  } else {
+    lines.push(`    Safe remedy (clean tree):  git reset --hard origin/main   (preserves untracked NEW files)  —  or  git merge origin/main.`);
+  }
+  lines.push(`    Opt-in auto-rebase next time: pass --rebase-base to sd-start, or set SD_START_AUTO_REBASE=1.`);
+  return lines.join('\n');
+}
+
+/** Default IO seam: tree-clean probe + hard-reset, both scoped to the worktree root. */
+export function makeGuardGit({ cwd, remote = 'origin', timeout = 15000 } = {}) {
+  const git = (args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout });
+  return {
+    isClean: () => git(['status', '--porcelain']).trim().length === 0,
+    // reset --hard to the remote tip; untracked NEW files are preserved (reset only touches tracked).
+    resetHard: (baseRef) => { git(['reset', '--hard', baseRef]); },
+  };
+}
+
+/**
+ * Orchestrate the guard for a resolved worktree. FAIL-OPEN: any error returns {skipped:true} and is
+ * never re-thrown. Emits via the injected `log`/`warn` (default console).
+ *
+ * @param {object} opts
+ *   cwd          - the worktree root (absolute). REQUIRED.
+ *   baseRef      - default 'origin/main'
+ *   autoRebase   - opt-in auto-rebase (default false => warn-by-default)
+ *   freshnessFn  - injected checkoutFreshness (default the real one, with fetch:true)
+ *   git          - injected {isClean, resetHard} (default makeGuardGit)
+ *   log/warn     - injected loggers (default console.log/console.warn)
+ * @returns {{action:string, behind:number, skipped?:boolean, rebased?:boolean, error?:string}}
+ */
+export function runStaleBaseGuard(opts = {}) {
+  const {
+    cwd,
+    baseRef = 'origin/main',
+    autoRebase = false,
+    freshnessFn = (c) => checkoutFreshness(c, { baseRef, fetch: true, role: 'sd-start' }),
+    git = null,
+    log = console.log,
+    warn = console.warn,
+  } = opts;
+  try {
+    if (!cwd) return { action: 'none', behind: 0, skipped: true, error: 'no cwd' };
+    const fr = freshnessFn(cwd);
+    const behind = Number(fr?.behind) || 0;
+    const criticalDiff = Array.isArray(fr?.criticalDiff) ? fr.criticalDiff : [];
+    if (behind === 0) {
+      // Still surface protocol drift even at behind=0 (a local hand-edit of CLAUDE*.md).
+      if (criticalDiff.length) warn(renderStaleBaseWarning({ behind: 0, baseRef, criticalDiff }));
+      return { action: 'none', behind: 0 };
+    }
+    const g = git || makeGuardGit({ cwd });
+    let treeClean = true;
+    try { treeClean = g.isClean(); } catch { treeClean = false; /* unknown => treat dirty (safe: never auto-clobber) */ }
+    const decision = decideStaleBaseAction({ behind, treeClean, autoRebase });
+    if (decision.action === 'rebase') {
+      try {
+        g.resetHard(baseRef);
+        log(`✅ STALE WORKTREE BASE auto-rebased to ${baseRef} (was behind ${behind}; clean tree, untracked files preserved).`);
+        return { action: 'rebase', behind, rebased: true };
+      } catch (err) {
+        // Rebase failed — fall back to a loud warn rather than leaving the worker unaware.
+        warn(renderStaleBaseWarning({ behind, baseRef, criticalDiff, dirty: !treeClean }));
+        warn(`    (auto-rebase attempted but failed: ${err?.message || String(err)} — apply the remedy manually)`);
+        return { action: 'warn', behind, rebased: false, error: err?.message || String(err) };
+      }
+    }
+    warn(renderStaleBaseWarning({ behind, baseRef, criticalDiff, dirty: !treeClean }));
+    return { action: 'warn', behind };
+  } catch (err) {
+    // FAIL-OPEN: the guard must never block a claim.
+    return { action: 'none', behind: 0, skipped: true, error: err?.message || String(err) };
+  }
+}
+
+export default { decideStaleBaseAction, renderStaleBaseWarning, makeGuardGit, runStaleBaseGuard };

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -51,6 +51,10 @@ import { formatRosterClaim } from './modules/sd-next/display/claim-formatters.js
 // patterns, so no behavior regresses for existing error shapes.
 import { classify as classifyWorktreeFailure } from '../lib/protocol-policies/worktree-failure-classification.js';
 import { decideOwnConflictReattach } from '../lib/exec-context-guard.mjs';
+// SD-LEO-INFRA-SD-START-STALE-BASE-WARN-001: warn (or opt-in auto-rebase) when a resolved worktree's
+// base is behind origin/main, so a worker never silently builds on a stale base (a merge-as-is would
+// revert sibling work that landed after the base commit). Fail-open; reuses checkout-freshness.
+import { runStaleBaseGuard } from '../lib/worktree/stale-base-guard.mjs';
 import { getNextReadyChild } from './modules/handoff/child-sd-selector.js';
 import { checkSDAge, handleTimelineViolation, formatBlockMessage } from './modules/governance/timeline-violation-handler.js';
 import {
@@ -1505,6 +1509,20 @@ async function main() {
     await releaseClaimOnWorktreeFailure('resolution');
     process.exit(1);
   }
+
+  // 4.7. SD-LEO-INFRA-SD-START-STALE-BASE-WARN-001: stale-base guard.
+  // The worktree resolved successfully — now check whether its base is BEHIND origin/main. Building
+  // on a stale base risks a merge-as-is reverting sibling work (esp. deletions) that landed after the
+  // base commit. Warn-by-default with the safe remedy; opt-in auto-rebase via --rebase-base /
+  // SD_START_AUTO_REBASE. Fail-open: the guard never throws / never blocks the claim.
+  try {
+    const wtCwd = worktreeInfo?.cwd || worktreeInfo?.worktree?.path || null;
+    if (wtCwd) {
+      const autoRebase = process.argv.includes('--rebase-base')
+        || ['1', 'true', 'on'].includes(String(process.env.SD_START_AUTO_REBASE || '').toLowerCase());
+      runStaleBaseGuard({ cwd: wtCwd, autoRebase });
+    }
+  } catch { /* fail-open: a stale-base check must never block sd-start */ }
 
   // 4.9. SD-LEO-INFRA-HANDOFF-INTEGRITY-RECOVERY-001: Pre-claim health check
   // Verify handoff chain integrity before proceeding

--- a/tests/unit/worktree-stale-base-guard.test.mjs
+++ b/tests/unit/worktree-stale-base-guard.test.mjs
@@ -1,0 +1,117 @@
+// Tests for lib/worktree/stale-base-guard.mjs
+// SD-LEO-INFRA-SD-START-STALE-BASE-WARN-001
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  decideStaleBaseAction,
+  renderStaleBaseWarning,
+  runStaleBaseGuard,
+} from '../../lib/worktree/stale-base-guard.mjs';
+
+test('decideStaleBaseAction: behind=0 => none', () => {
+  assert.equal(decideStaleBaseAction({ behind: 0 }).action, 'none');
+  assert.equal(decideStaleBaseAction({ behind: 0, autoRebase: true }).action, 'none');
+});
+
+test('decideStaleBaseAction: behind>0, warn-by-default (no auto-rebase)', () => {
+  assert.equal(decideStaleBaseAction({ behind: 3, autoRebase: false }).action, 'warn');
+});
+
+test('decideStaleBaseAction: behind>0 + autoRebase + clean => rebase', () => {
+  assert.equal(decideStaleBaseAction({ behind: 3, autoRebase: true, treeClean: true }).action, 'rebase');
+});
+
+test('decideStaleBaseAction: behind>0 + autoRebase + DIRTY => warn (never clobber WIP)', () => {
+  assert.equal(decideStaleBaseAction({ behind: 3, autoRebase: true, treeClean: false }).action, 'warn');
+});
+
+test('decideStaleBaseAction: negative/garbage behind clamps to none', () => {
+  assert.equal(decideStaleBaseAction({ behind: -5 }).action, 'none');
+  assert.equal(decideStaleBaseAction({ behind: NaN }).action, 'none');
+});
+
+test('renderStaleBaseWarning names behind-count + clean-tree remedy (reset --hard preserves untracked)', () => {
+  const out = renderStaleBaseWarning({ behind: 4, baseRef: 'origin/main' });
+  assert.match(out, /behind origin\/main by 4/);
+  assert.match(out, /git reset --hard origin\/main/);
+  assert.match(out, /preserves untracked/);
+  assert.match(out, /SD_START_AUTO_REBASE/);
+});
+
+test('renderStaleBaseWarning: dirty tree recommends commit/stash + merge, NOT reset', () => {
+  const out = renderStaleBaseWarning({ behind: 2, dirty: true });
+  assert.match(out, /commit\/stash first/);
+  assert.doesNotMatch(out, /reset --hard/);
+});
+
+test('renderStaleBaseWarning surfaces protocol drift when present', () => {
+  const out = renderStaleBaseWarning({ behind: 1, criticalDiff: ['CLAUDE.md'] });
+  assert.match(out, /Protocol file\(s\) also drifted/);
+  assert.match(out, /CLAUDE\.md/);
+});
+
+test('runStaleBaseGuard: behind=0 => action none, no warning emitted', () => {
+  const warns = [];
+  const r = runStaleBaseGuard({ cwd: '/wt', freshnessFn: () => ({ behind: 0, criticalDiff: [] }), warn: (m) => warns.push(m), log: () => {} });
+  assert.equal(r.action, 'none');
+  assert.equal(warns.length, 0);
+});
+
+test('runStaleBaseGuard: behind=0 but protocol drift => still warns', () => {
+  const warns = [];
+  const r = runStaleBaseGuard({ cwd: '/wt', freshnessFn: () => ({ behind: 0, criticalDiff: ['CLAUDE_CORE.md'] }), warn: (m) => warns.push(m), log: () => {} });
+  assert.equal(r.action, 'none');
+  assert.equal(warns.length, 1);
+  assert.match(warns[0], /CLAUDE_CORE\.md/);
+});
+
+test('runStaleBaseGuard: behind>0, warn-by-default emits the warning, does NOT reset', () => {
+  const warns = [];
+  let resetCalled = false;
+  const git = { isClean: () => true, resetHard: () => { resetCalled = true; } };
+  const r = runStaleBaseGuard({ cwd: '/wt', autoRebase: false, git, freshnessFn: () => ({ behind: 5, criticalDiff: [] }), warn: (m) => warns.push(m), log: () => {} });
+  assert.equal(r.action, 'warn');
+  assert.equal(r.behind, 5);
+  assert.equal(resetCalled, false);
+  assert.match(warns[0], /behind origin\/main by 5/);
+});
+
+test('runStaleBaseGuard: behind>0 + autoRebase + clean => resets and logs', () => {
+  const logs = [];
+  let resetTo = null;
+  const git = { isClean: () => true, resetHard: (ref) => { resetTo = ref; } };
+  const r = runStaleBaseGuard({ cwd: '/wt', autoRebase: true, git, freshnessFn: () => ({ behind: 2, criticalDiff: [] }), log: (m) => logs.push(m), warn: () => {} });
+  assert.equal(r.action, 'rebase');
+  assert.equal(r.rebased, true);
+  assert.equal(resetTo, 'origin/main');
+  assert.match(logs[0], /auto-rebased/);
+});
+
+test('runStaleBaseGuard: behind>0 + autoRebase + DIRTY => warns, does NOT reset', () => {
+  const warns = [];
+  let resetCalled = false;
+  const git = { isClean: () => false, resetHard: () => { resetCalled = true; } };
+  const r = runStaleBaseGuard({ cwd: '/wt', autoRebase: true, git, freshnessFn: () => ({ behind: 1, criticalDiff: [] }), warn: (m) => warns.push(m), log: () => {} });
+  assert.equal(r.action, 'warn');
+  assert.equal(resetCalled, false);
+});
+
+test('runStaleBaseGuard: rebase failure falls back to a loud warn', () => {
+  const warns = [];
+  const git = { isClean: () => true, resetHard: () => { throw new Error('reset boom'); } };
+  const r = runStaleBaseGuard({ cwd: '/wt', autoRebase: true, git, freshnessFn: () => ({ behind: 2, criticalDiff: [] }), warn: (m) => warns.push(m), log: () => {} });
+  assert.equal(r.action, 'warn');
+  assert.equal(r.rebased, false);
+  assert.ok(warns.some((w) => /reset boom/.test(w)));
+});
+
+test('runStaleBaseGuard: FAIL-OPEN — freshnessFn throws => skipped, never re-throws', () => {
+  const r = runStaleBaseGuard({ cwd: '/wt', freshnessFn: () => { throw new Error('git down'); }, warn: () => {}, log: () => {} });
+  assert.equal(r.skipped, true);
+  assert.equal(r.action, 'none');
+});
+
+test('runStaleBaseGuard: no cwd => skipped', () => {
+  const r = runStaleBaseGuard({ cwd: null, warn: () => {}, log: () => {} });
+  assert.equal(r.skipped, true);
+});


### PR DESCRIPTION
## Summary
When `sd-start.js` resolves a worktree whose base is behind `origin/main`, the worker builds on a stale base — a merge-as-is can **REVERT sibling work** (esp. file deletions) that landed on main after the base commit. Confirmed hit twice in one session.

## Changes
- New `lib/worktree/stale-base-guard.mjs` (fail-open; **reuses** `lib/governance/checkout-freshness.js` for the behind-count SSOT): `decideStaleBaseAction` (pure) + `renderStaleBaseWarning` (pure) + `runStaleBaseGuard` (orchestrator).
- `scripts/sd-start.js` calls it after worktree resolution:
  - **FR-2 WARN-BY-DEFAULT**: loud warning naming the behind-count + protocol drift + safe remedy (`git reset --hard origin/main` preserves untracked NEW files).
  - **FR-3 OPT-IN AUTO-REBASE** (`--rebase-base` / `SD_START_AUTO_REBASE=1`): resets to `origin/main` **only on a clean tree**; dirty tree falls back to WARN (never clobber WIP).
  - **FR-4 FAIL-OPEN**: any git error / missing cwd → skip; never blocks the claim (defense-in-depth: internal + call-site try/catch).
- **FR-5**: `tests/unit/worktree-stale-base-guard.test.mjs` (16 tests).

## Verification
- Testing agent: 16/16 pass, `node --check` clean, fail-open confirmed.
- Adversarial review: **SHIP** — data-loss path correctly clean-tree-gated (unknown state → treated dirty → no reset), reuse genuine, behind-direction + worktree-scoping correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)