### PR TITLE
feat(SD-LEO-INFRA-ADD-PRD-EXIT-CODE-SUCCESS-001): exit 0 after a successful PRD write

### DIFF
--- a/scripts/add-prd-to-database.js
+++ b/scripts/add-prd-to-database.js
@@ -169,6 +169,39 @@ export function extractContentArg(args) {
 
 export { CONTENT_PAYLOAD_MAX_BYTES };
 
+/**
+ * SD-LEO-INFRA-ADD-PRD-EXIT-CODE-SUCCESS-001: make the process exit code reflect the
+ * real outcome. addPRDToDatabase resolves once the PRD + user-story rows have landed, but
+ * lingering undici/supabase keep-alive sockets can keep the event loop alive until Bash
+ * SIGTERMs the process at its timeout (exit 143) — so callers and automation mis-read a
+ * successful write as a failure. Mapping the outcome to an explicit exit code (0 success,
+ * 1 failure) and forcing a prompt, flushed exit makes the signal deterministic.
+ */
+export function resolveExitCode(outcome) {
+  return outcome === 'success' ? 0 : 1;
+}
+
+/**
+ * Drain stdout/stderr, then call exitFn(code) exactly once. Draining first avoids
+ * truncating buffered output on piped runs; the unref'd safety timer guarantees we never
+ * hang waiting on a 'drain' that may never fire (e.g. a closed/destroyed pipe under the
+ * EPIPE-tolerant handlers above). exitFn is injectable for unit testing.
+ */
+export function flushAndExit(code, exitFn = process.exit, { timeoutMs = 250 } = {}) {
+  let exited = false;
+  const done = () => { if (!exited) { exited = true; exitFn(code); } };
+  let pending = 0;
+  for (const stream of [process.stdout, process.stderr]) {
+    if (stream && !stream.destroyed && typeof stream.writableLength === 'number' && stream.writableLength > 0) {
+      pending++;
+      stream.once('drain', () => { if (--pending === 0) done(); });
+    }
+  }
+  if (pending === 0) { done(); return; }
+  const t = setTimeout(done, timeoutMs);
+  if (t && typeof t.unref === 'function') t.unref();
+}
+
 if (isMainModule(import.meta.url)) {
   // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR1 call-site migration):
   // PRD creation is sub-agent-heavy and regularly exceeds the 15-min claim
@@ -218,13 +251,21 @@ if (isMainModule(import.meta.url)) {
 
   const sdId = args[0];
   const prdTitle = args.slice(1).filter(a => !a.startsWith('--')).join(' ');
-  // QF-20260424-805: Stop the heartbeat interval after addPRDToDatabase resolves
-  // so Node can exit naturally. Without this, setInterval keeps the event loop
-  // alive forever and Bash SIGTERMs the process at its 10-min default timeout
-  // (exit 143) — even though the PRD + user-story rows already landed in the DB.
-  // Cooperative mode means stopHeartbeat does NOT release the parent session's
-  // claim; only the in-process timer is cleared.
-  addPRDToDatabase(sdId, prdTitle, contentOverride).finally(() => {
-    if (heartbeatActive) stopHeartbeat();
-  });
+  // QF-20260424-805: Stop the heartbeat interval after addPRDToDatabase resolves so the
+  // setInterval no longer keeps the event loop alive. SD-LEO-INFRA-ADD-PRD-EXIT-CODE-SUCCESS-001:
+  // stopping the heartbeat alone is not enough — lingering undici/supabase keep-alive sockets can
+  // still hold the loop open until Bash SIGTERMs the process (exit 143) AFTER the PRD + user-story
+  // rows already landed, so callers mis-read the success as a failure. Map the outcome to an
+  // explicit, flushed exit code instead: 0 on a resolved write (incl. inline-mode null), 1 on a
+  // rejection. Cooperative mode means stopHeartbeat does NOT release the parent session's claim.
+  addPRDToDatabase(sdId, prdTitle, contentOverride)
+    .then(() => {
+      if (heartbeatActive) stopHeartbeat();
+      flushAndExit(resolveExitCode('success'));
+    })
+    .catch((err) => {
+      console.error(`\n❌ add-prd-to-database failed: ${err?.message || err}`);
+      if (heartbeatActive) stopHeartbeat();
+      flushAndExit(resolveExitCode('failure'));
+    });
 }

--- a/tests/unit/add-prd-exit-code.test.js
+++ b/tests/unit/add-prd-exit-code.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveExitCode, flushAndExit } from '../../scripts/add-prd-to-database.js';
+
+describe('resolveExitCode (SD-LEO-INFRA-ADD-PRD-EXIT-CODE-SUCCESS-001)', () => {
+  it('maps a successful write to exit code 0', () => {
+    expect(resolveExitCode('success')).toBe(0);
+  });
+
+  it('maps a failed write to exit code 1', () => {
+    expect(resolveExitCode('failure')).toBe(1);
+  });
+
+  it('treats any non-success outcome as failure (1)', () => {
+    expect(resolveExitCode(undefined)).toBe(1);
+    expect(resolveExitCode(null)).toBe(1);
+    expect(resolveExitCode('error')).toBe(1);
+  });
+});
+
+describe('flushAndExit', () => {
+  it('invokes the injected exit fn with the success code when no output is buffered', () => {
+    const exitFn = vi.fn();
+    flushAndExit(0, exitFn);
+    expect(exitFn).toHaveBeenCalledTimes(1);
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it('invokes the injected exit fn with the failure code', () => {
+    const exitFn = vi.fn();
+    flushAndExit(1, exitFn);
+    expect(exitFn).toHaveBeenCalledTimes(1);
+    expect(exitFn).toHaveBeenCalledWith(1);
+  });
+
+  it('exits exactly once (no double-exit)', () => {
+    const exitFn = vi.fn();
+    flushAndExit(0, exitFn);
+    // The synchronous no-buffer path must not schedule a second exit.
+    expect(exitFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('passing resolveExitCode through flushAndExit yields the mapped code', () => {
+    const exitFn = vi.fn();
+    flushAndExit(resolveExitCode('success'), exitFn);
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
add-prd-to-database.js completed the DB write but then hung on lingering undici/supabase keep-alive sockets until Bash SIGTERMs the process (exit 143), so callers and automation mis-read a landed PRD as a failure. Stopping the heartbeat (QF-20260424-805) was not enough — the idle sockets still kept the loop alive.

**Fix (+97/-9):** map the outcome to an explicit, flushed exit code.
- `resolveExitCode(outcome)` → 0 for `success`, 1 otherwise
- `flushAndExit(code, exitFn)` drains stdout/stderr then exits, with an unref'd safety timer so a closed pipe can't hang it
- the CLI entrypoint now `.then(success → flushAndExit(0))` / `.catch(failure → flushAndExit(1))`, stopping the heartbeat on both paths
- both helpers exported and unit-tested (7 tests)

Verified: a live successful run now exits **0 promptly** instead of intermittently 143. TESTING sub-agent PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)