### PR TITLE
feat(SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-B): type-aware rung/KR progress rollup (FR-1)

### DIFF
--- a/lib/vision/rung-progress-rollup.mjs
+++ b/lib/vision/rung-progress-rollup.mjs
@@ -1,0 +1,172 @@
+/**
+ * Rung/KR progress rollup — SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-B (FR-1).
+ *
+ * Populate roadmap_waves.progress_pct TYPE-AWARE by REUSING the existing measurement systems — it
+ * does NOT build a new one:
+ *   - BUILD rungs (the active vision build rung, e.g. V1 Foundation) derive their % from the existing
+ *     computeBuildGauge (lib/vision/vdr-registry.js).
+ *   - OUTCOME rungs (future revenue / distance-to-quit, e.g. V2/V3) derive their % from key_results
+ *     progress (the v_okr_hierarchy formula) via each wave's okr_objective_ids.
+ *
+ * Wave→rung attribution is the existing advisory mapping (metadata.rung_key, else time_horizon:
+ * now→V1, next→V2, later→V3). HONESTY: a wave with no resolvable rung, or an outcome wave with no
+ * linked objectives / no probeable KR, yields progress_pct=null with an explicit reason — it is NEVER
+ * fabricated as 0%. Write is DRY-RUN by default; --apply persists.
+ *
+ * @module lib/vision/rung-progress-rollup
+ */
+
+/** Advisory time-horizon → vision rung mapping (SD-LEO-INFRA-VISION-LADDER-ROADMAP-COHERENCE-001). */
+export const RUNG_BY_HORIZON = Object.freeze({ now: 'V1', next: 'V2', later: 'V3' });
+// 'eventually' intentionally maps to null — too far out to attribute to a concrete rung.
+
+/** PURE: resolve a wave's rung_key. metadata.rung_key (explicit) wins; else the time_horizon map; else null. */
+export function mapWaveToRung(wave) {
+  const md = (wave && wave.metadata) || {};
+  if (md.rung_key) return String(md.rung_key);
+  const th = wave && wave.time_horizon;
+  return (th && RUNG_BY_HORIZON[th]) || null;
+}
+
+/**
+ * PURE: a single key_result's progress %, mirroring the v_okr_hierarchy formula
+ * (database/migrations/20260104_okr_strategic_hierarchy.sql). Clamped 0–100. Returns null when the
+ * KR is unmeasurable (non-numeric fields or a zero span), so a degenerate KR never fabricates 0%.
+ */
+export function krProgressPct(kr) {
+  if (!kr) return null;
+  // Reject null/undefined BEFORE coercion — Number(null)===0 would otherwise fabricate a span.
+  if (kr.baseline_value == null || kr.current_value == null || kr.target_value == null) return null;
+  const b = Number(kr.baseline_value);
+  const cur = Number(kr.current_value);
+  const t = Number(kr.target_value);
+  if (![b, cur, t].every(Number.isFinite)) return null;
+  const decrease = (kr && kr.direction) === 'decrease';
+  const denom = decrease ? (b - t) : (t - b);
+  if (denom === 0) return null; // zero span — undefined progress, never 0%-by-fiat
+  const num = decrease ? (b - cur) : (cur - b);
+  const pct = (num / denom) * 100;
+  return Math.max(0, Math.min(100, pct));
+}
+
+/** PURE: mean progress over measurable KRs (each 0–100). null when none are measurable. */
+export function aggregateKrProgress(krRows) {
+  const vals = (krRows || []).map(krProgressPct).filter((v) => v !== null);
+  if (!vals.length) return null;
+  return Math.round(vals.reduce((s, v) => s + v, 0) / vals.length);
+}
+
+/**
+ * PURE: decide one wave's rollup row. Returns
+ *   { wave_id, title, rung_key, type, progress_pct, source, reason }
+ * progress_pct is null (never fabricated) when it cannot be honestly measured.
+ *
+ * @param {object} wave - roadmap_waves row (id, title, time_horizon, okr_objective_ids, metadata)
+ * @param {object} ctx
+ *   activeRungKey   - vision_ladder_rungs.rung_key WHERE is_active (the build rung)
+ *   gaugeBuildPct   - computeBuildGauge build_pct for the active rung (number|null)
+ *   krAggByObjective- { [objectiveId]: aggregateKrProgress(...) | null }
+ */
+export function computeWaveRollup(wave, ctx = {}) {
+  const base = { wave_id: wave && wave.id, title: (wave && wave.title) || null };
+  const rungKey = mapWaveToRung(wave);
+  if (!rungKey) {
+    return { ...base, rung_key: null, type: null, progress_pct: null, source: 'skip', reason: 'no rung mapping (time_horizon null/eventually + no metadata.rung_key)' };
+  }
+  const isBuildRung = rungKey === ctx.activeRungKey;
+  if (isBuildRung) {
+    const g = ctx.gaugeBuildPct;
+    if (g == null || !Number.isFinite(Number(g))) {
+      return { ...base, rung_key: rungKey, type: 'build', progress_pct: null, source: 'computeBuildGauge', reason: 'gauge unavailable' };
+    }
+    return { ...base, rung_key: rungKey, type: 'build', progress_pct: Math.round(Number(g)), source: 'computeBuildGauge', reason: `active build rung ${rungKey} → reuse build gauge` };
+  }
+  // Outcome rung: derive from KR progress for the wave's linked objectives.
+  const objs = (wave && wave.okr_objective_ids) || [];
+  if (!objs.length) {
+    return { ...base, rung_key: rungKey, type: 'outcome', progress_pct: null, source: 'key_results', reason: 'outcome rung with no okr_objective_ids on the wave' };
+  }
+  const aggs = objs.map((o) => (ctx.krAggByObjective || {})[o]).filter((v) => v !== null && v !== undefined);
+  if (!aggs.length) {
+    return { ...base, rung_key: rungKey, type: 'outcome', progress_pct: null, source: 'key_results', reason: 'outcome rung with no measurable KRs under its objective(s)' };
+  }
+  const pct = Math.round(aggs.reduce((s, v) => s + v, 0) / aggs.length);
+  return { ...base, rung_key: rungKey, type: 'outcome', progress_pct: pct, source: 'key_results', reason: `outcome rung ${rungKey} ← ${aggs.length} objective KR-set(s)` };
+}
+
+/** PURE: roll up every wave. Returns the rows array (no IO). */
+export function rollupWaves(waves, ctx = {}) {
+  return (waves || []).map((w) => computeWaveRollup(w, ctx));
+}
+
+/**
+ * IO runner. FAIL-SOFT: a read error degrades to an empty/unknown result rather than throwing.
+ * DRY-RUN by default; pass { apply:true } to persist progress_pct (only for rows with a non-null %).
+ *
+ * @param {object} opts
+ *   supabase       - REQUIRED supabase client
+ *   computeGaugeFn - async () => gauge object (reuse computeBuildGauge); injected for tests
+ *   apply          - boolean (default false → dry-run)
+ *   log            - logger (default console.log)
+ * @returns {{ ok:boolean, apply:boolean, activeRungKey:?string, gaugeBuildPct:?number, rows:Array, written:number, error?:string }}
+ */
+export async function runRollup(opts = {}) {
+  const { supabase, computeGaugeFn, apply = false, log = console.log } = opts;
+  if (!supabase) return { ok: false, apply, activeRungKey: null, gaugeBuildPct: null, rows: [], written: 0, error: 'no supabase client' };
+  try {
+    // active build rung
+    let activeRungKey = null;
+    try {
+      const r = await supabase.from('vision_ladder_rungs').select('rung_key,is_active').eq('is_active', true).maybeSingle();
+      activeRungKey = r && r.data ? r.data.rung_key : null;
+    } catch { activeRungKey = null; }
+
+    // build gauge (reuse) — fail-soft to null
+    let gaugeBuildPct = null;
+    if (typeof computeGaugeFn === 'function') {
+      try {
+        const g = await computeGaugeFn();
+        // prefer build_pct (buildable-only); fall back to overall_pct; null when gauge unavailable
+        gaugeBuildPct = g && g.available !== false ? (g.build_pct ?? g.overall_pct ?? null) : null;
+      } catch { gaugeBuildPct = null; }
+    }
+
+    // key_results grouped by objective → per-objective aggregate
+    const krAggByObjective = {};
+    try {
+      const kr = await supabase.from('key_results').select('objective_id,baseline_value,current_value,target_value,direction');
+      if (kr && !kr.error && Array.isArray(kr.data)) {
+        const byObj = {};
+        for (const row of kr.data) { (byObj[row.objective_id] = byObj[row.objective_id] || []).push(row); }
+        for (const [obj, rows] of Object.entries(byObj)) krAggByObjective[obj] = aggregateKrProgress(rows);
+      }
+    } catch { /* leave empty → outcome rungs report unknown */ }
+
+    // waves
+    let waves = [];
+    try {
+      const w = await supabase.from('roadmap_waves').select('id,title,time_horizon,okr_objective_ids,metadata,progress_pct');
+      if (w && !w.error && Array.isArray(w.data)) waves = w.data;
+    } catch { waves = []; }
+
+    const rows = rollupWaves(waves, { activeRungKey, gaugeBuildPct, krAggByObjective });
+
+    let written = 0;
+    if (apply) {
+      for (const row of rows) {
+        if (row.progress_pct == null) continue; // never write a fabricated 0
+        try {
+          const u = await supabase.from('roadmap_waves').update({ progress_pct: row.progress_pct }).eq('id', row.wave_id);
+          if (!u || !u.error) written += 1;
+        } catch { /* fail-soft per-row; keep going */ }
+      }
+    }
+
+    log(`[rung-rollup] ${apply ? 'APPLY' : 'DRY-RUN'} activeRung=${activeRungKey} gaugeBuildPct=${gaugeBuildPct} waves=${rows.length} writable=${rows.filter((r) => r.progress_pct != null).length} written=${written}`);
+    return { ok: true, apply, activeRungKey, gaugeBuildPct, rows, written };
+  } catch (err) {
+    return { ok: false, apply, activeRungKey: null, gaugeBuildPct: null, rows: [], written: 0, error: err && err.message ? err.message : String(err) };
+  }
+}
+
+export default { RUNG_BY_HORIZON, mapWaveToRung, krProgressPct, aggregateKrProgress, computeWaveRollup, rollupWaves, runRollup };

--- a/scripts/vision/rung-progress-rollup.mjs
+++ b/scripts/vision/rung-progress-rollup.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Rung/KR progress rollup CLI — SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-B (FR-1).
+//
+// Populates roadmap_waves.progress_pct type-aware by REUSING computeBuildGauge (build rungs) and
+// key_results progress (outcome rungs). DRY-RUN by default; pass --apply to persist.
+//
+// Usage:
+//   node scripts/vision/rung-progress-rollup.mjs            # dry-run report
+//   node scripts/vision/rung-progress-rollup.mjs --apply    # persist progress_pct
+//
+// Fail-soft: a hiccup degrades to an empty/unknown result, never a fabricated %.
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { computeBuildGauge } from '../../lib/vision/vdr-registry.js';
+import { makeDefaultGrepSeam } from '../../lib/vision/vdr-grep-seam.js';
+import { runRollup } from '../../lib/vision/rung-progress-rollup.mjs';
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('[rung-rollup] missing Supabase creds'); process.exit(1); }
+  const supabase = createClient(url, key);
+  const grep = makeDefaultGrepSeam({ engineerRoot: process.cwd() });
+  const computeGaugeFn = () => computeBuildGauge({ io: { supabase, grep }, visionSource: true });
+
+  const res = await runRollup({ supabase, computeGaugeFn, apply });
+  if (!res.ok) { console.error('[rung-rollup] ERROR:', res.error); process.exit(1); }
+
+  console.log(`\n  Active build rung: ${res.activeRungKey} | build gauge: ${res.gaugeBuildPct}%`);
+  console.log(`  ${apply ? 'APPLIED' : 'DRY-RUN (pass --apply to persist)'} — wrote ${res.written} row(s)\n`);
+  for (const r of res.rows) {
+    const pct = r.progress_pct == null ? '  —' : `${String(r.progress_pct).padStart(3)}%`;
+    console.log(`  ${pct}  [${(r.type || 'skip').padEnd(7)}] ${(r.rung_key || '--').padEnd(3)}  ${(r.title || '').slice(0, 42).padEnd(42)}  ${r.reason}`);
+  }
+  process.exit(0);
+}
+
+const isDirect = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (isDirect || import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('rung-progress-rollup.mjs')) {
+  main().catch((e) => { console.error('[rung-rollup] fatal:', e?.message || e); process.exit(1); });
+}

--- a/tests/unit/vision/rung-progress-rollup.test.mjs
+++ b/tests/unit/vision/rung-progress-rollup.test.mjs
@@ -1,0 +1,194 @@
+// Tests for lib/vision/rung-progress-rollup.mjs
+// SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-B (FR-1)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  RUNG_BY_HORIZON,
+  mapWaveToRung,
+  krProgressPct,
+  aggregateKrProgress,
+  computeWaveRollup,
+  rollupWaves,
+  runRollup,
+} from '../../../lib/vision/rung-progress-rollup.mjs';
+
+test('RUNG_BY_HORIZON maps now/next/later → V1/V2/V3 (not eventually)', () => {
+  assert.equal(RUNG_BY_HORIZON.now, 'V1');
+  assert.equal(RUNG_BY_HORIZON.next, 'V2');
+  assert.equal(RUNG_BY_HORIZON.later, 'V3');
+  assert.equal(RUNG_BY_HORIZON.eventually, undefined);
+});
+
+test('mapWaveToRung: metadata.rung_key wins over time_horizon', () => {
+  assert.equal(mapWaveToRung({ metadata: { rung_key: 'V2' }, time_horizon: 'now' }), 'V2');
+  assert.equal(mapWaveToRung({ time_horizon: 'next' }), 'V2');
+  assert.equal(mapWaveToRung({ time_horizon: null }), null);
+  assert.equal(mapWaveToRung({ time_horizon: 'eventually' }), null);
+  assert.equal(mapWaveToRung({}), null);
+});
+
+test('krProgressPct: increase direction = (cur-base)/(target-base), clamped 0-100', () => {
+  assert.equal(krProgressPct({ baseline_value: 0, current_value: 5, target_value: 10, direction: 'increase' }), 50);
+  assert.equal(krProgressPct({ baseline_value: 0, current_value: 0, target_value: 1, direction: 'increase' }), 0);
+  assert.equal(krProgressPct({ baseline_value: 0, current_value: 20, target_value: 10, direction: 'increase' }), 100); // clamp
+});
+
+test('krProgressPct: decrease direction inverts the span', () => {
+  assert.equal(krProgressPct({ baseline_value: 100, current_value: 50, target_value: 0, direction: 'decrease' }), 50);
+  assert.equal(krProgressPct({ baseline_value: 100, current_value: 100, target_value: 0, direction: 'decrease' }), 0);
+});
+
+test('krProgressPct: zero span / non-numeric => null (never fabricates 0)', () => {
+  assert.equal(krProgressPct({ baseline_value: 5, current_value: 5, target_value: 5, direction: 'increase' }), null);
+  assert.equal(krProgressPct({ baseline_value: null, current_value: 1, target_value: 2 }), null);
+  assert.equal(krProgressPct({}), null);
+});
+
+test('aggregateKrProgress: mean of measurable KRs; null when none measurable', () => {
+  assert.equal(aggregateKrProgress([
+    { baseline_value: 0, current_value: 5, target_value: 10, direction: 'increase' }, // 50
+    { baseline_value: 0, current_value: 10, target_value: 10, direction: 'increase' }, // 100
+  ]), 75);
+  assert.equal(aggregateKrProgress([{ baseline_value: 5, current_value: 5, target_value: 5 }]), null);
+  assert.equal(aggregateKrProgress([]), null);
+});
+
+test('computeWaveRollup: BUILD rung (active) → gauge build pct', () => {
+  const r = computeWaveRollup({ id: 'w1', title: 'Foundation', time_horizon: 'now' }, { activeRungKey: 'V1', gaugeBuildPct: 57, krAggByObjective: {} });
+  assert.equal(r.type, 'build');
+  assert.equal(r.rung_key, 'V1');
+  assert.equal(r.progress_pct, 57);
+  assert.equal(r.source, 'computeBuildGauge');
+});
+
+test('computeWaveRollup: BUILD rung but gauge unavailable → null (honest)', () => {
+  const r = computeWaveRollup({ id: 'w1', time_horizon: 'now' }, { activeRungKey: 'V1', gaugeBuildPct: null });
+  assert.equal(r.type, 'build');
+  assert.equal(r.progress_pct, null);
+});
+
+test('computeWaveRollup: OUTCOME rung → KR aggregate of linked objectives', () => {
+  const r = computeWaveRollup(
+    { id: 'w3', title: 'Revenue', time_horizon: 'next', okr_objective_ids: ['obj-a', 'obj-b'] },
+    { activeRungKey: 'V1', krAggByObjective: { 'obj-a': 20, 'obj-b': 40 } },
+  );
+  assert.equal(r.type, 'outcome');
+  assert.equal(r.rung_key, 'V2');
+  assert.equal(r.progress_pct, 30);
+  assert.equal(r.source, 'key_results');
+});
+
+test('computeWaveRollup: OUTCOME rung with no objectives → null + reason', () => {
+  const r = computeWaveRollup({ id: 'w5', time_horizon: 'later', okr_objective_ids: [] }, { activeRungKey: 'V1', krAggByObjective: {} });
+  assert.equal(r.type, 'outcome');
+  assert.equal(r.progress_pct, null);
+  assert.match(r.reason, /no okr_objective_ids/);
+});
+
+test('computeWaveRollup: OUTCOME rung whose objectives have no measurable KRs → null', () => {
+  const r = computeWaveRollup({ id: 'w5', time_horizon: 'next', okr_objective_ids: ['obj-x'] }, { activeRungKey: 'V1', krAggByObjective: { 'obj-x': null } });
+  assert.equal(r.progress_pct, null);
+  assert.match(r.reason, /no measurable KRs/);
+});
+
+test('computeWaveRollup: no rung mapping → skip (null), never fabricated', () => {
+  const r = computeWaveRollup({ id: 'w0', title: 'Themed', time_horizon: null }, { activeRungKey: 'V1' });
+  assert.equal(r.source, 'skip');
+  assert.equal(r.progress_pct, null);
+});
+
+test('rollupWaves maps all waves', () => {
+  const rows = rollupWaves(
+    [{ id: 'a', time_horizon: 'now' }, { id: 'b', time_horizon: null }],
+    { activeRungKey: 'V1', gaugeBuildPct: 50, krAggByObjective: {} },
+  );
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].progress_pct, 50);
+  assert.equal(rows[1].progress_pct, null);
+});
+
+// ── runRollup IO with an injected supabase stub ──
+function stubSupabase({ activeRung = { rung_key: 'V1' }, krs = [], waves = [], captureUpdates } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        _table: table, _filters: {},
+        select() { return chain; },
+        eq(col, val) { chain._filters[col] = val; return chain; },
+        maybeSingle() {
+          if (table === 'vision_ladder_rungs') return Promise.resolve({ data: activeRung, error: null });
+          return Promise.resolve({ data: null, error: null });
+        },
+        update(payload) { chain._payload = payload; return chain; },
+        then(res, rej) {
+          if (table === 'key_results') return Promise.resolve({ data: krs, error: null }).then(res, rej);
+          if (table === 'roadmap_waves') {
+            if (chain._payload) { // an update().eq() resolution
+              if (captureUpdates) captureUpdates({ id: chain._filters.id, payload: chain._payload });
+              return Promise.resolve({ error: null }).then(res, rej);
+            }
+            return Promise.resolve({ data: waves, error: null }).then(res, rej);
+          }
+          return Promise.resolve({ data: [], error: null }).then(res, rej);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+test('runRollup dry-run: computes rows, writes nothing', async () => {
+  const updates = [];
+  const supabase = stubSupabase({
+    krs: [{ objective_id: 'obj-a', baseline_value: 0, current_value: 2, target_value: 10, direction: 'increase' }],
+    waves: [
+      { id: 'w1', title: 'F', time_horizon: 'now' },
+      { id: 'w3', title: 'R', time_horizon: 'next', okr_objective_ids: ['obj-a'] },
+      { id: 'wx', title: 'T', time_horizon: null },
+    ],
+    captureUpdates: (u) => updates.push(u),
+  });
+  const res = await runRollup({ supabase, computeGaugeFn: async () => ({ available: true, build_pct: 57 }), apply: false, log: () => {} });
+  assert.equal(res.ok, true);
+  assert.equal(res.activeRungKey, 'V1');
+  assert.equal(res.gaugeBuildPct, 57);
+  assert.equal(res.written, 0);
+  assert.equal(updates.length, 0);
+  const byId = Object.fromEntries(res.rows.map((r) => [r.wave_id, r]));
+  assert.equal(byId.w1.progress_pct, 57);   // build
+  assert.equal(byId.w3.progress_pct, 20);   // outcome: 2/10=20%
+  assert.equal(byId.wx.progress_pct, null); // skip
+});
+
+test('runRollup apply: persists only non-null rows', async () => {
+  const updates = [];
+  const supabase = stubSupabase({
+    krs: [{ objective_id: 'obj-a', baseline_value: 0, current_value: 5, target_value: 10, direction: 'increase' }],
+    waves: [
+      { id: 'w1', time_horizon: 'now' },
+      { id: 'w3', time_horizon: 'next', okr_objective_ids: ['obj-a'] },
+      { id: 'wx', time_horizon: null }, // skip → must NOT be written
+    ],
+    captureUpdates: (u) => updates.push(u),
+  });
+  const res = await runRollup({ supabase, computeGaugeFn: async () => ({ available: true, build_pct: 60 }), apply: true, log: () => {} });
+  assert.equal(res.written, 2);
+  assert.equal(updates.length, 2);
+  assert.deepEqual(updates.map((u) => u.id).sort(), ['w1', 'w3']);
+  assert.equal(updates.find((u) => u.id === 'w1').payload.progress_pct, 60);
+  assert.equal(updates.find((u) => u.id === 'w3').payload.progress_pct, 50);
+});
+
+test('runRollup fail-soft: gauge throw → build rungs null, no throw', async () => {
+  const supabase = stubSupabase({ waves: [{ id: 'w1', time_horizon: 'now' }] });
+  const res = await runRollup({ supabase, computeGaugeFn: async () => { throw new Error('gauge boom'); }, apply: false, log: () => {} });
+  assert.equal(res.ok, true);
+  assert.equal(res.gaugeBuildPct, null);
+  assert.equal(res.rows[0].progress_pct, null);
+});
+
+test('runRollup: no supabase → ok:false, never throws', async () => {
+  const res = await runRollup({ supabase: null });
+  assert.equal(res.ok, false);
+  assert.match(res.error, /no supabase/);
+});


### PR DESCRIPTION
## Summary
`roadmap_waves.progress_pct` was 0 for every wave. This child (FR-1) populates it **type-aware** by **reusing** the existing measurement systems — not building a new one.

## Changes
- New `lib/vision/rung-progress-rollup.mjs` (pure compute + fail-soft injectable IO) + `scripts/vision/rung-progress-rollup.mjs` CLI.
  - **BUILD rungs** (active vision rung, e.g. V1) → `computeBuildGauge.build_pct`.
  - **OUTCOME rungs** (V2/V3) → `key_results` progress (v_okr_hierarchy formula) aggregated over each wave's `okr_objective_ids`.
  - Wave→rung via existing advisory map (`metadata.rung_key`, else `time_horizon` now→V1/next→V2/later→V3).
  - **Honesty**: unresolvable rungs / KR-less outcome waves → `null` + reason, **never a fabricated 0**; `--apply` skips null rows.
- **FR-5**: `tests/unit/vision/rung-progress-rollup.test.mjs` (17 tests; a failing null-field test caught `Number(null)===0` fabricating a span → fixed).

## Verification
- Testing agent: 17/17 pass, live persistence confirmed (5 waves: 3 build@57%, 2 outcome@20%), honest no-fabrication.
- Adversarial review: **SHIP** — honesty/reuse/KR-formula/wave-mapping correct; `progress_pct` is a pure readout (no gate impact); themed waves untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)