### PR TITLE
feat(SD-LEO-INFRA-LOOP-RESUME-DELAY-SHORTEN-001): shorten the /loop resume delay

### DIFF
--- a/lib/coordinator/fleet-quiescence.cjs
+++ b/lib/coordinator/fleet-quiescence.cjs
@@ -25,7 +25,21 @@
  */
 
 const FRESH_S = Number(process.env.QUIESCENCE_FRESH_SECONDS || 300);
-const RECENT_MIN = Number(process.env.QUIESCENCE_RECENT_MINUTES || 20);
+
+/**
+ * SD-LEO-INFRA-LOOP-RESUME-DELAY-SHORTEN-001: resolve the quiescence "recent transitions"
+ * window (minutes). Shortened from 20 to a 5m default so the coordinator's 'active' hysteresis
+ * matches the shorter worker resume cadence (DEFAULT_IDLE_WAKEUP_SECONDS 600s) — but FLOORED at
+ * 3m, even via the QUIESCENCE_RECENT_MINUTES env override, so the fleet does not flash
+ * idle/active when workers complete in bursts. Pure + exported for unit testing.
+ * @param {string|number|undefined} envVal raw QUIESCENCE_RECENT_MINUTES value (or undefined)
+ * @returns {number} minutes, >= 3
+ */
+function resolveRecentMin(envVal) {
+  return Math.max(3, Number(envVal || 5));
+}
+
+const RECENT_MIN = resolveRecentMin(process.env.QUIESCENCE_RECENT_MINUTES);
 
 /**
  * Pure verdict from already-fetched signal counts. Exported for unit testing without a DB.
@@ -89,4 +103,4 @@ async function assessFleetActivity(sb, opts) {
   return { quiescent: verdict.quiescent, reason: verdict.reason, signals: signals };
 }
 
-module.exports = { assessFleetActivity: assessFleetActivity, decideQuiescence: decideQuiescence, FRESH_S: FRESH_S, RECENT_MIN: RECENT_MIN };
+module.exports = { assessFleetActivity: assessFleetActivity, decideQuiescence: decideQuiescence, resolveRecentMin: resolveRecentMin, FRESH_S: FRESH_S, RECENT_MIN: RECENT_MIN };

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -42,7 +42,12 @@ const { NATO, COLORS, nextAvailable, isTestSessionId } = require('./assign-fleet
 
 const ROLL_CALL_TTL_MS = 60 * 60 * 1000;     // availability row lives 1h
 const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (idempotency)
-const DEFAULT_IDLE_WAKEUP_SECONDS = 1200;    // ~20m, matches the fleet idle cadence
+// SD-LEO-INFRA-LOOP-RESUME-DELAY-SHORTEN-001: shortened from 1200 (20m) to 600 (10m) so a
+// finished idle worker re-engages its /loop ~2x faster and the fleet stops looking idle.
+// Trade-off: idle workers re-check roughly twice as often, a modest increase in /checkin DB
+// chatter — but each idle check is a cheap idempotent roll_call (5m dedup), so the cost is
+// small. NOT applied to the propose-only idle branch below, which keeps its own 1200 literal.
+const DEFAULT_IDLE_WAKEUP_SECONDS = 600;      // ~10m, matches the tightened fleet idle cadence
 const SELF_CLAIM_CANDIDATE_LIMIT = 5;
 const QF_CANDIDATE_LIMIT = 25;               // open quick_fixes to consider for self-claim
 const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)

--- a/tests/unit/loop-resume-delay.test.js
+++ b/tests/unit/loop-resume-delay.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import workerCheckin from '../../scripts/worker-checkin.cjs';
+import fleetQuiescence from '../../lib/coordinator/fleet-quiescence.cjs';
+
+const { DEFAULT_IDLE_WAKEUP_SECONDS } = workerCheckin;
+const { resolveRecentMin, RECENT_MIN } = fleetQuiescence;
+
+describe('SD-LEO-INFRA-LOOP-RESUME-DELAY-SHORTEN-001: idle resume cadence', () => {
+  it('DEFAULT_IDLE_WAKEUP_SECONDS is shortened to 600 (was 1200)', () => {
+    expect(DEFAULT_IDLE_WAKEUP_SECONDS).toBe(600);
+  });
+
+  it('DEFAULT_IDLE_WAKEUP_SECONDS stays within the grounded [300,600] range', () => {
+    expect(DEFAULT_IDLE_WAKEUP_SECONDS).toBeGreaterThanOrEqual(300);
+    expect(DEFAULT_IDLE_WAKEUP_SECONDS).toBeLessThanOrEqual(600);
+  });
+});
+
+describe('resolveRecentMin: quiescence window with a >=3m floor', () => {
+  it('defaults to 5 when no override is provided', () => {
+    expect(resolveRecentMin(undefined)).toBe(5);
+    expect(resolveRecentMin('')).toBe(5);
+    expect(resolveRecentMin(0)).toBe(5); // 0 is falsy -> default 5
+  });
+
+  it('honors a valid override above the floor', () => {
+    expect(resolveRecentMin('10')).toBe(10);
+    expect(resolveRecentMin(7)).toBe(7);
+  });
+
+  it('floors any override below 3m to 3 (avoids flash idle/active churn)', () => {
+    expect(resolveRecentMin('1')).toBe(3);
+    expect(resolveRecentMin('2')).toBe(3);
+    expect(resolveRecentMin(3)).toBe(3);
+  });
+
+  it('the module-level RECENT_MIN respects the floor and is <= the old 20m default', () => {
+    expect(RECENT_MIN).toBeGreaterThanOrEqual(3);
+    expect(RECENT_MIN).toBeLessThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
Finished /loop workers waited ~20m before re-engaging, so the fleet looked idle.

- `worker-checkin.cjs`: `DEFAULT_IDLE_WAKEUP_SECONDS` 1200 → 600 (idle workers re-check ~2x faster). The propose-only idle branch keeps its own hardcoded 1200 (FR-3). Documented the modest /checkin DB-chatter trade-off.
- `fleet-quiescence.cjs`: `QUIESCENCE_RECENT_MINUTES` default 20 → 5 via a pure, exported `resolveRecentMin(envVal) = Math.max(3, Number(envVal||5))` — matches the shorter resume but floored at 3m (no flash idle/active churn), even via the env override.
- `silence-cap.cjs` / `park-worker.cjs` untouched: `HARD_CAP_MIN` (30m) stays ≥ the park writer cap (~25m), so parked workers are never mis-reaped (FR-3 preserved by construction).
- FR-4 (adaptive sub-minute wakeup) deferred to a sibling.

6 unit tests (constant range + floor/default). TESTING sub-agent PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)