### PR TITLE
docs(SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D): needle-first prioritization awareness (FR-3)

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -730,6 +730,25 @@ same engine-state framing in its DEFICIT verdict and in the `[COORD->ADAM]` belt
 line. So a DEFICIT reads *"engine OFF, N unpromoted → activate/distill"* — not just *"source N
 candidates"*. Read that line before acting on any belt-low signal.
 
+### Prioritize what moves the rung/KR needle (dispatch ordering)
+
+> **SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001 (FR-3).** Measurement is a *dispatch
+> input*, not just a readout — order remaining work by needle-movement, the same axis Adam sources on.
+
+**How progress is measured (so you can rank by it):** `roadmap_waves.progress_pct` is populated
+TYPE-AWARE by the rung-progress rollup (`lib/vision/rung-progress-rollup.mjs`, CLI
+`npm run vision:rung-rollup` — dry-run default, `--apply` persists). **BUILD rungs** (the active
+vision rung, e.g. V1/Foundation) derive their % from `computeBuildGauge.build_pct` (the VDR gauge);
+**OUTCOME rungs** (V2/V3 — Revenue, Distance-to-quit) derive from `key_results` progress via each
+wave's `sd_key_result_alignment`. It REUSES the gauge + KR alignment — not a new measurement system.
+
+**Dispatch ordering:** when choosing what to dispatch from the claimable belt, prefer
+**active-rung-first**, then **highest-impact-on-rung-completion-first** — an SD that closes the
+active build rung's remaining gap (or moves a tracked KR on an outcome rung) outranks an
+equally-ready SD that moves no rung. This is the same needle-first axis Adam sources on (CLAUDE_ADAM.md
+*SOURCING SSOT → Prioritize what moves the rung/KR needle*), so sourcing and dispatch pull the same
+direction. `scripts/coordinator-backlog-rank.mjs` is the rank surface this feeds.
+
 ---
 
 ## Adam advisory lane (read + reply)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 9b7d164a531fd42f -->
+<!-- file_content_hash: b3b595e30e2a89d5 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-20 10:12:53 AM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-20 12:35:55 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 3c67a44920c1819a -->
+<!-- file_content_hash: 674914d0689633e6 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-20 10:12:53 AM
+**Generated**: 2026-06-20 12:35:55 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -95,6 +95,12 @@ When you need candidates, work the sources **top-down** and stop at the first th
 
 > Why: encoding the order-of-operations in the required-reading contract + surfacing the live state of every layer at `/adam` startup makes the *route-the-SSOT-first* duty structurally impossible to miss, so the degrade-to-hand-mining regression cannot recur each fresh session (SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001).
 
+
+### Prioritize what moves the rung/KR needle (SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001)
+
+**How progress is measured (so you can rank by it):** `roadmap_waves.progress_pct` is populated TYPE-AWARE by the rung-progress rollup (`lib/vision/rung-progress-rollup.mjs`, CLI `npm run vision:rung-rollup` — dry-run default, `--apply` persists). **BUILD rungs** (the active vision rung, e.g. V1/Foundation) derive their % from `computeBuildGauge.build_pct` (the VDR gauge); **OUTCOME rungs** (V2/V3 — Revenue, Distance-to-quit) derive from `key_results` progress via each wave's `sd_key_result_alignment`. It REUSES the existing gauge + KR alignment — it is not a new measurement system.
+
+**The needle-first sourcing bar:** once a candidate passes THE SOURCING BAR (real + launch/revenue-aligned), rank the remaining shortlist by **needle-movement** — **active-rung-first**, then **highest-impact-on-rung-completion-first**. A candidate that closes the active build rung's remaining gap (or moves a tracked KR on an outcome rung) outranks an equally-real item that moves no rung. Progress measurement is a sourcing **INPUT**, not just a chairman readout: read the rung `progress_pct` + the gauge before proposing, and say which rung/KR each proposal moves.
 
 ## SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)
 

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: db2eda882dc1c1b6 -->
+<!-- file_content_hash: 56e89ecf400916c9 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 
@@ -49,6 +49,12 @@ When you need candidates, work the sources **top-down** and stop at the first th
 4. **Hand-mining the VDR gauge is LAST-RESORT — and a SMELL.** Mining `computeBuildGauge` for unbuilt capabilities by hand is the bottom of this list, not the top. Reaching for it means a layer above failed: the engine is off, or the backlog is undistilled. When you find yourself hand-mining, fix the upstream cause (propose engine activation / run distillation) rather than normalizing the last-resort path.
 
 > Why: encoding the order-of-operations in the required-reading contract + surfacing the live state of every layer at `/adam` startup makes the *route-the-SSOT-first* duty structurally impossible to miss, so the degrade-to-hand-mining regression cannot recur each fresh session (SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001).
+
+### Prioritize what moves the rung/KR needle (SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001)
+
+**How progress is measured (so you can rank by it):** `roadmap_waves.progress_pct` is populated TYPE-AWARE by the rung-progress rollup (`lib/vision/rung-progress-rollup.mjs`, CLI `npm run vision:rung-rollup` — dry-run default, `--apply` persists). **BUILD rungs** (the active vision rung, e.g. V
+
+*...truncated. Read full file for complete section.*
 
 ## SD Creation How-To + Duty Procedures (Conversion · Build-% Gauge · Escalation)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 88ce0de8c64aa979 -->
+<!-- file_content_hash: 73e76493f9b982a8 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-20 10:12:53 AM
+**Generated**: 2026-06-20 12:35:55 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 6dbbb38dd4813bc4 -->
+<!-- file_content_hash: cfdb2afcfa034e67 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 1d836b8aa8e2cb79 -->
+<!-- file_content_hash: 57d12c480d1c4aa6 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-20 10:12:53 AM
+**Generated**: 2026-06-20 12:35:55 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: d1b4fe249f458c1b -->
+<!-- file_content_hash: 9562e5b9398168d9 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-20 10:12:53 AM*
+*DIGEST generated: 2026-06-20 12:35:55 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 95cd3bd2d403aa06 -->
+<!-- file_content_hash: 098717c9a2f22e8e -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-20 10:12:53 AM*
+*DIGEST generated: 2026-06-20 12:35:55 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 4108f667f32d353c -->
+<!-- file_content_hash: 9c07d3e45d102907 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-20 10:12:53 AM
+**Generated**: 2026-06-20 12:35:55 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 9f2251e79f296cd7 -->
+<!-- file_content_hash: 607e9d986ccd43df -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-20 10:12:53 AM*
+*DIGEST generated: 2026-06-20 12:35:55 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: d3a6060a714e9aef -->
+<!-- file_content_hash: 237ccc38b18ffa2a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-20 10:12:53 AM
+**Generated**: 2026-06-20 12:35:55 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 0920377e0666f0c7 -->
+<!-- file_content_hash: 1c7c96fdf844aee6 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-20 10:12:53 AM*
+*DIGEST generated: 2026-06-20 12:35:55 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 603158ae9654808a -->
+<!-- file_content_hash: 8a1abe9605d22793 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-20 10:12:53 AM
+**Generated**: 2026-06-20 12:35:55 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T14:12:53.024Z -->
-<!-- git_commit: a4eec584 -->
+<!-- generated_at: 2026-06-20T16:35:55.374Z -->
+<!-- git_commit: b46c1ebc -->
 <!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: f842b2ae8ebf0c26 -->
+<!-- file_content_hash: 6c6ffe0fad3bb5d2 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-20 10:12:53 AM*
+*DIGEST generated: 2026-06-20 12:35:55 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,109 @@
 {
-  "generated_at": "2026-06-20T14:12:53.024Z",
-  "git_commit": "a4eec584",
+  "generated_at": "2026-06-20T16:35:55.374Z",
+  "git_commit": "b46c1ebc",
   "db_snapshot_hash": "8bb50c9305e12f02",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19369,
       "estimated_tokens": 4843,
-      "content_hash": "ff9390207a7d39d4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE.md"
+      "content_hash": "070a59945c9e3ca1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 83528,
       "estimated_tokens": 20882,
-      "content_hash": "30eaa6061aa8578e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_CORE.md"
+      "content_hash": "bd3155e94d5cf19d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65129,
       "estimated_tokens": 16283,
-      "content_hash": "f0019db2628ee800",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_LEAD.md"
+      "content_hash": "623dd9bbf37871cd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 90831,
       "estimated_tokens": 22708,
-      "content_hash": "fceb84394ed50096",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_PLAN.md"
+      "content_hash": "37f11c916b304319",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 84822,
       "estimated_tokens": 21206,
-      "content_hash": "8f469b04bdfda184",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_EXEC.md"
+      "content_hash": "f3b070923c62e1ad",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 39998,
-      "estimated_tokens": 10000,
-      "content_hash": "bfb910f67a395d03",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_ADAM.md"
+      "chars": 41261,
+      "estimated_tokens": 10316,
+      "content_hash": "804a634215e32d66",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
       "chars": 16619,
       "estimated_tokens": 4155,
-      "content_hash": "6e673a042dce2489",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_COORDINATOR.md"
+      "content_hash": "b5624e4009409e19",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9612,
       "estimated_tokens": 2403,
-      "content_hash": "cac9b907ab5c8691",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_DIGEST.md"
+      "content_hash": "b81708bec34a1896",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11536,
       "estimated_tokens": 2884,
-      "content_hash": "ef0a374865d97f40",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "e053d01fcf91d881",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5423,
       "estimated_tokens": 1356,
-      "content_hash": "9308b09533718fe1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "d4603c3ad7aad6a0",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8413,
       "estimated_tokens": 2104,
-      "content_hash": "9758331181dc8005",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "4d69e7fda5b9de94",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10836,
       "estimated_tokens": 2709,
-      "content_hash": "81fe8d4559bc6426",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "2878a1e41d24cbb5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
-      "chars": 11866,
-      "estimated_tokens": 2967,
-      "content_hash": "8d6756c4bcfe811f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
+      "chars": 12320,
+      "estimated_tokens": 3080,
+      "content_hash": "91cc6e0e77e1a938",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 3973,
       "estimated_tokens": 994,
-      "content_hash": "b0770fe0c7838420",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "d4fa8b67015b2179",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "5866f504637666be",
+    "global": "bacc644d2124040a",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -363,7 +363,7 @@
       "604": "67885bf567384f02",
       "605": "19e13f356fce24ab",
       "606": "25aa68b575c66d07",
-      "607": "d3cc55fdebcf0ddf"
+      "607": "82e04c0cc0ffb28f"
     },
     "meta": {
       "94": {


### PR DESCRIPTION
## Summary
FR-3 of the PROGRESS-ROLLUP orchestrator: make **Adam** (sourcing) and the **coordinator** (dispatch) explicitly prioritize *"what moves the rung/KR needle"* and understand **how progress is measured** — the FR-1 rung-progress rollup shipped in child -B (`lib/vision/rung-progress-rollup.mjs`).

## Changes (docs-only)
- **CLAUDE_ADAM.md** (via `leo_protocol_sections` id=607 *SOURCING SSOT* + regen): new *"Prioritize what moves the rung/KR needle"* subsection — how `roadmap_waves.progress_pct` is measured (BUILD rungs from `computeBuildGauge.build_pct`, OUTCOME rungs from `key_results` via `sd_key_result_alignment`) + the needle-first sourcing bar (active-rung-first, highest-impact-on-rung-completion-first).
- **.claude/commands/coordinator.md**: parallel *dispatch-ordering* subsection so sourcing and dispatch pull the same needle-first direction (references `scripts/coordinator-backlog-rank.mjs`).
- Regenerated `CLAUDE_*.md` + `claude-generation-manifest.json` kept consistent for the doc-drift gate.

## Verification
- `node scripts/check-claude-md-drift.cjs` → no drift (CLAUDE_ADAM.md matches DB id=607)
- grep confirms both docs carry the needle-first subsection + identical measurement description

Child of the PROGRESS-ROLLUP orchestrator; depends on -B (shipped). No code, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)