### PR TITLE
feat(SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C): needle-movement prioritization (FR-2)

### DIFF
--- a/lib/vision/needle-priority.mjs
+++ b/lib/vision/needle-priority.mjs
@@ -1,0 +1,78 @@
+/**
+ * Needle-movement prioritization — SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-2).
+ *
+ * Turns the rung/KR progress MEASUREMENT shipped by FR-1 (lib/vision/rung-progress-rollup.mjs) into
+ * a prioritization INPUT: remaining work is ordered active-rung-first, then highest-impact-on-rung-
+ * completion-first. This is a thin, PURE scoring layer — it REUSES FR-1's mapWaveToRung and runRollup
+ * output rather than re-deriving rung attribution.
+ *
+ * HONESTY: an SD whose rung cannot be resolved (not promoted from a roadmap wave, or a wave with no
+ * rung mapping) scores 0 — it is left in its existing rank order, never guessed onto a rung.
+ *
+ * @module lib/vision/needle-priority
+ */
+
+import { mapWaveToRung } from './rung-progress-rollup.mjs';
+
+/**
+ * PURE: a single SD's needle-movement score.
+ *   - unresolvable rung            -> 0   (neutral; falls back to the existing order)
+ *   - a known FUTURE rung (V2/V3)  -> 1   (+ completion bonus)
+ *   - the ACTIVE build rung (V1)   -> 2   (+ completion bonus)
+ * The completion bonus is the rung's progress_pct scaled to 0..0.1, so within a tier the rung CLOSER
+ * to completion edges up (highest-impact-on-rung-completion-first) without ever crossing tiers.
+ *
+ * @param {?string} sdRung the SD's resolved rung_key (e.g. 'V1'), or null/undefined if unknown
+ * @param {{activeRungKey?:?string, rungProgressByKey?:Object<string,number>}} ctx
+ * @returns {number} score (0, or [1,1.1], or [2,2.1])
+ */
+export function needleScore(sdRung, ctx = {}) {
+  if (!sdRung) return 0;
+  const base = sdRung === ctx.activeRungKey ? 2 : 1;
+  const prog = Number((ctx.rungProgressByKey || {})[sdRung]);
+  const bonus = Number.isFinite(prog) ? Math.max(0, Math.min(100, prog)) / 1000 : 0; // 0..0.1
+  return base + bonus;
+}
+
+/**
+ * PURE: fold FR-1 runRollup() rows into a { [rung_key]: progress_pct } map.
+ * Rows with a null progress_pct (FR-1's honest "unmeasurable") are skipped, never coerced to 0.
+ * If multiple waves map to the same rung, the highest measured progress_pct wins (most-complete view).
+ *
+ * @param {Array<{rung_key:?string, progress_pct:?number}>} rollupRows
+ * @returns {Object<string,number>}
+ */
+export function rungProgressByKey(rollupRows) {
+  const out = {};
+  for (const r of rollupRows || []) {
+    if (!r || !r.rung_key || r.progress_pct == null) continue;
+    const pct = Number(r.progress_pct);
+    if (!Number.isFinite(pct)) continue;
+    if (out[r.rung_key] == null || pct > out[r.rung_key]) out[r.rung_key] = pct;
+  }
+  return out;
+}
+
+/**
+ * PURE: map each promoted SD key to its rung by REUSING FR-1's mapWaveToRung.
+ * Skips wave items with no promoted SD, an unknown wave, or an unmappable wave (honest — no guess).
+ *
+ * @param {Array<{promoted_to_sd_key?:?string, wave_id?:?string}>} waveItems roadmap_wave_items rows
+ * @param {Object<string,object>} wavesById roadmap_waves keyed by id
+ * @returns {Object<string,string>} { [sd_key]: rung_key }
+ */
+export function buildSdRungMap(waveItems, wavesById = {}) {
+  const map = {};
+  for (const it of waveItems || []) {
+    const sdKey = it && it.promoted_to_sd_key;
+    const waveId = it && it.wave_id;
+    if (!sdKey || !waveId) continue;
+    const wave = wavesById[waveId];
+    if (!wave) continue;
+    const rung = mapWaveToRung(wave);
+    if (rung) map[sdKey] = rung;
+  }
+  return map;
+}
+
+export default { needleScore, rungProgressByKey, buildSdRungMap };

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -40,6 +40,14 @@ import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd } from '../
 // handling both the [{sd_id}]/[{sd_key}] object and raw-string shapes the old hand-rolled
 // resolver coerced, while correctly dropping the sentinel the hand-rolled one mis-counted.
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
+// SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-2): needle-movement prioritization.
+// Reuse FR-1's rollup (active rung + per-rung progress) and the pure needle scorer to order remaining
+// work active-rung-first among same-unlock candidates. Loaded fail-soft — any read error leaves the
+// ranking unchanged (every SD scores 0).
+import { runRollup } from '../lib/vision/rung-progress-rollup.mjs';
+import { computeBuildGauge } from '../lib/vision/vdr-registry.js';
+import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
+import { needleScore, rungProgressByKey, buildSdRungMap } from '../lib/vision/needle-priority.mjs';
 
 const DRY = process.argv.includes('--dry-run');
 const PRIORITY_W = { critical: 3, high: 2, medium: 1, med: 1, low: 0 };
@@ -144,6 +152,34 @@ async function main() {
     const m = d.metadata || {};
     return m.source === 'proposal' && !!m.roadmap_phase;
   };
+
+  // ── needle-movement context (FR-2) ── REUSE the FR-1 rollup for the active rung + per-rung progress,
+  // and roadmap_wave_items→waves for each SD's rung. Best-effort: any failure leaves needle scores at 0
+  // (ranking unchanged). The active-rung TIER does not need the build gauge; the gauge only sharpens the
+  // small completion bonus, so a slow/unavailable gauge still yields correct active-rung-first ordering.
+  let activeRungKey = null;
+  let progByKey = {};
+  let sdRungMap = {};
+  try {
+    const grep = makeDefaultGrepSeam();
+    const computeGaugeFn = () => computeBuildGauge({ io: { supabase: sb, grep }, visionSource: true });
+    const roll = await runRollup({ supabase: sb, computeGaugeFn, apply: false, log: () => {} });
+    if (roll && roll.ok) {
+      activeRungKey = roll.activeRungKey || null;
+      progByKey = rungProgressByKey(roll.rows);
+    }
+    const [{ data: waveItems }, { data: waves }] = await Promise.all([
+      sb.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null),
+      sb.from('roadmap_waves').select('id, time_horizon, metadata'),
+    ]);
+    const wavesById = Object.fromEntries((waves || []).map((w) => [w.id, w]));
+    sdRungMap = buildSdRungMap(waveItems, wavesById);
+    console.log(`[BACKLOG-RANK] needle context: activeRung=${activeRungKey} rungs=${Object.keys(progByKey).join(',') || 'none'} sd↦rung=${Object.keys(sdRungMap).length}`);
+  } catch (e) {
+    console.log(`[BACKLOG-RANK] needle context unavailable (fail-soft, ranking unchanged): ${e?.message || e}`);
+  }
+  const needleOf = (d) => needleScore(sdRungMap[d.sd_key], { activeRungKey, rungProgressByKey: progByKey });
+
   claimable.sort((a, b) => {
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs sort below EVERY
     // authored SD (rank-last), so a worker never self-claims a stub that cannot pass
@@ -155,6 +191,11 @@ async function main() {
     if (qa !== qb) return qa - qb;                          // human-authored first
     const ua = unlockScore(a.sd_key), ub = unlockScore(b.sd_key);
     if (ub !== ua) return ub - ua;
+    // FR-2 needle-movement: among same-unlock candidates, order active-rung-first, then highest-impact-
+    // on-rung-completion-first (the completion bonus). Applied AFTER unlock (never overrides critical-path
+    // unlocking) and BEFORE the vision-loop nudge/priority/age. Unknown-rung SDs score 0 (neutral).
+    const na = needleOf(a), nb = needleOf(b);
+    if (nb !== na) return nb - na;
     // FR-1 LEAD-advancement nudge: vision-loop drafts ahead of other claimable SDs at the same unlock level.
     const va = visionLoopDraft(a) ? 1 : 0, vb = visionLoopDraft(b) ? 1 : 0;
     if (vb !== va) return vb - va;

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -270,6 +270,14 @@ async function reachAdam(f) {
   if (!adamId) return false;
   const correlation_id = `cap-${Date.now()}`;
   const idleList = f.rows.filter(r => r.state.startsWith('IDLE')).map(r => r.callsign + '/' + r.sess).join(', ') || 'none';
+  // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-3): feed rung progress into the Adam
+  // sourcing rank — name the active build rung so Adam ranks candidates active-rung-first / highest-
+  // impact-on-rung-completion-first. Best-effort: omit the line if the active rung can't be resolved.
+  let activeRungKey = null;
+  try {
+    const r = await sb.from('vision_ladder_rungs').select('rung_key').eq('is_active', true).maybeSingle();
+    activeRungKey = r && r.data ? r.data.rung_key : null;
+  } catch { activeRungKey = null; }
   const body = [
     `[COORD->ADAM] PREDICTIVE belt-low (capacity forecaster). Verdict=${f.verdict}.`,
     `Belt=${f.beltDepth} claimable vs demand(soon)=${f.demandSoon} (idle ${f.idleNow} + freeing-soon ${f.freeingSoon}) → short by ${f.deficit}.`,
@@ -282,6 +290,8 @@ async function reachAdam(f) {
     // VISION-ALIGNED weakest capabilities (read the per-capability gauge + mine the dispositioned
     // estate) instead of generic harness-backlog grooming.
     `If the engine is dormant while the roadmap is rich, the remediation is to PROPOSE/co-sponsor ACTIVATION (flip the SOURCING_* flags + apply dormant migrations) and/or Wave-0 distillation, escalating to the chairman — before any manual backfill. Otherwise: READ the per-capability vision gauge + MINE the dispositioned estate for the WEAKEST capabilities, then propose a shortlist of CONFLICT-FREE, non-gated, draft-ready SD candidates that move those weakest capabilities forward (NOT generic harness-backlog grooming), propose-only; I'll dispatch. Dedup vs in-flight + SD-LEO-INFRA-SWEEP-CLAIM-SAFETY-001.`,
+    // FR-3 needle-movement: rank the sourcing shortlist by which rung it moves.
+    `NEEDLE-MOVEMENT RANK: order the shortlist ACTIVE-RUNG-FIRST${activeRungKey ? ` (active build rung = ${activeRungKey})` : ''}, then highest-impact-on-rung-completion-first — candidates that advance the active rung's weakest capabilities top the list; future-rung work ranks below.`,
     `Reply via adam-advisory (correlation ${correlation_id}).`,
   ].filter(Boolean).join('\n');
   const res = await insertCoordinationRow(sb, {

--- a/tests/unit/needle-priority.test.js
+++ b/tests/unit/needle-priority.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { needleScore, rungProgressByKey, buildSdRungMap } from '../../lib/vision/needle-priority.mjs';
+
+describe('needleScore (SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C FR-1)', () => {
+  const ctx = { activeRungKey: 'V1', rungProgressByKey: { V1: 50, V2: 80 } };
+
+  it('an unresolvable rung is neutral (0)', () => {
+    expect(needleScore(null, ctx)).toBe(0);
+    expect(needleScore(undefined, ctx)).toBe(0);
+    expect(needleScore('', ctx)).toBe(0);
+  });
+
+  it('ranks active rung > future rung > unknown', () => {
+    expect(needleScore('V1', ctx)).toBeGreaterThan(needleScore('V2', ctx));
+    expect(needleScore('V2', ctx)).toBeGreaterThan(needleScore(null, ctx));
+  });
+
+  it('active rung base is 2.x, future rung base is 1.x', () => {
+    expect(Math.floor(needleScore('V1', ctx))).toBe(2);
+    expect(Math.floor(needleScore('V2', ctx))).toBe(1);
+  });
+
+  it('the completion bonus orders within a tier (closer-to-done edges up) but never crosses tiers', () => {
+    const c = { activeRungKey: null, rungProgressByKey: { V2: 90, V3: 10 } };
+    // both future (base 1); V2 (90%) should edge above V3 (10%)
+    expect(needleScore('V2', c)).toBeGreaterThan(needleScore('V3', c));
+    // ...but the bonus is small enough never to lift a future rung to the active tier
+    const activeCtx = { activeRungKey: 'V1', rungProgressByKey: { V1: 0, V2: 100 } };
+    expect(needleScore('V1', activeCtx)).toBeGreaterThan(needleScore('V2', activeCtx));
+  });
+
+  it('a missing/non-finite rung progress yields no bonus (base only)', () => {
+    expect(needleScore('V1', { activeRungKey: 'V1' })).toBe(2);
+    expect(needleScore('V1', { activeRungKey: 'V1', rungProgressByKey: { V1: NaN } })).toBe(2);
+  });
+});
+
+describe('rungProgressByKey', () => {
+  it('folds rollup rows to {rung_key: progress_pct}, skipping null pct', () => {
+    const rows = [
+      { rung_key: 'V1', progress_pct: 57 },
+      { rung_key: 'V2', progress_pct: null }, // honest unmeasurable -> skipped
+      { rung_key: 'V3', progress_pct: 20 },
+    ];
+    expect(rungProgressByKey(rows)).toEqual({ V1: 57, V3: 20 });
+  });
+
+  it('keeps the highest progress when multiple waves map to the same rung', () => {
+    const rows = [
+      { rung_key: 'V1', progress_pct: 40 },
+      { rung_key: 'V1', progress_pct: 70 },
+    ];
+    expect(rungProgressByKey(rows)).toEqual({ V1: 70 });
+  });
+
+  it('handles empty/garbage input', () => {
+    expect(rungProgressByKey([])).toEqual({});
+    expect(rungProgressByKey(null)).toEqual({});
+    expect(rungProgressByKey([{ rung_key: null, progress_pct: 5 }, {}])).toEqual({});
+  });
+});
+
+describe('buildSdRungMap (reuses mapWaveToRung)', () => {
+  const wavesById = {
+    'w1': { id: 'w1', time_horizon: 'now' },               // -> V1
+    'w2': { id: 'w2', metadata: { rung_key: 'V2' } },       // explicit -> V2
+    'w3': { id: 'w3', time_horizon: 'eventually' },         // -> null (unmappable)
+  };
+
+  it('maps promoted SD keys to rung via the wave linkage', () => {
+    const items = [
+      { promoted_to_sd_key: 'SD-A', wave_id: 'w1' },
+      { promoted_to_sd_key: 'SD-B', wave_id: 'w2' },
+    ];
+    expect(buildSdRungMap(items, wavesById)).toEqual({ 'SD-A': 'V1', 'SD-B': 'V2' });
+  });
+
+  it('skips unpromoted, unknown-wave, and unmappable-wave items (honest, no guess)', () => {
+    const items = [
+      { promoted_to_sd_key: null, wave_id: 'w1' },          // unpromoted
+      { promoted_to_sd_key: 'SD-C', wave_id: 'missing' },   // unknown wave
+      { promoted_to_sd_key: 'SD-D', wave_id: 'w3' },        // unmappable rung
+      { promoted_to_sd_key: 'SD-E', wave_id: 'w1' },        // valid
+    ];
+    expect(buildSdRungMap(items, wavesById)).toEqual({ 'SD-E': 'V1' });
+  });
+
+  it('handles empty input', () => {
+    expect(buildSdRungMap(null)).toEqual({});
+    expect(buildSdRungMap([], {})).toEqual({});
+  });
+});


### PR DESCRIPTION
FR-2 of the needle-movement prioritization family — turns the FR-1 (#4923/#4924) rung/KR progress rollup into a **prioritization input** so remaining work is ordered active-rung-first, highest-impact-on-rung-completion-first.

- `lib/vision/needle-priority.mjs` (NEW, pure): `needleScore` (active rung=2, future=1, unknown=0, + a 0..0.1 completion bonus so a rung closer to done edges up within its tier), `buildSdRungMap` (`promoted_to_sd_key` → rung, **reusing FR-1's `mapWaveToRung`**), `rungProgressByKey`.
- `coordinator-backlog-rank.mjs`: load the FR-1 rollup + `roadmap_wave_items`→waves (fail-soft), add a needle tier to the comparator **directly after `unlock_score`** (never overrides critical-path unlocking) and before the vision-loop nudge.
- `coordinator-capacity-forecast.mjs`: name the active build rung in the Adam belt-low message so Adam ranks the sourcing shortlist active-rung-first (the Adam sourcing-rank surface).

**Honest:** an SD with no resolvable rung scores 0 and keeps its existing order; null progress is never fabricated. Live dry-run verified: `activeRung=V1`, per-rung progress `V1,V2`, fail-soft when no SDs are wave-promoted. 11 unit tests, TESTING sub-agent PASS. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)