### PR TITLE
feat(SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E): rung-completion rollup in exec email (FR-4, lockstep)

### DIFF
--- a/lib/fleet/exec-email-rung-rollup.js
+++ b/lib/fleet/exec-email-rung-rollup.js
@@ -1,0 +1,68 @@
+/**
+ * Exec-email rung-rollup line — SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E (FR-4).
+ *
+ * Renders the type-aware rung/KR progress rollup (lib/vision/rung-progress-rollup.mjs, FR-1 child -B)
+ * into a single chairman-readable line for the hourly executive-summary email, so the chairman sees
+ * rung-completion % (Foundation → revenue rails) — not just raw SD counts.
+ *
+ * LOCKSTEP / NO DIVERGENCE: the caller passes the SAME runRollup() result the rollup compute produces
+ * (which itself reuses computeBuildGauge for the active build rung), so the email number can never
+ * diverge from the canonical rollup. HONESTY-PRESERVED: a rung with progress_pct=null renders as
+ * "(not yet measurable)" — never a fabricated 0% (mirrors the rollup's own honest-null contract).
+ *
+ * @module lib/fleet/exec-email-rung-rollup
+ */
+
+/** Canonical rung display order (Foundation → revenue → future). */
+const RUNG_ORDER = ['V1', 'V2', 'V3'];
+
+/**
+ * Aggregate runRollup rows into one progress % per rung. PURE.
+ * A rung's % is the rounded mean of its waves' non-null progress_pct; null when no wave under that rung
+ * is measurable (honest-null, never fabricated 0).
+ * @param {Array<{rung_key:?string, progress_pct:?number}>} rows
+ * @returns {Object<string, {pct:?number, waves:number, measured:number}>} keyed by rung_key
+ */
+export function aggregateRungProgress(rows) {
+  const byRung = {};
+  for (const r of Array.isArray(rows) ? rows : []) {
+    const key = r && r.rung_key;
+    if (!key) continue; // unmappable waves are excluded, not zero-counted
+    const slot = byRung[key] || (byRung[key] = { sum: 0, measured: 0, waves: 0 });
+    slot.waves += 1;
+    if (typeof r.progress_pct === 'number' && Number.isFinite(r.progress_pct)) {
+      slot.sum += r.progress_pct;
+      slot.measured += 1;
+    }
+  }
+  const out = {};
+  for (const [key, s] of Object.entries(byRung)) {
+    out[key] = { pct: s.measured > 0 ? Math.round(s.sum / s.measured) : null, waves: s.waves, measured: s.measured };
+  }
+  return out;
+}
+
+/**
+ * Format the rung-rollup line for the email. PURE + FAIL-SOFT (returns '' rather than throwing).
+ * @param {{ ok?:boolean, rows?:Array }} rollupResult - the runRollup() return value
+ * @param {{ em?:string }} [opts] - em = the separator glyph used elsewhere in the email (default '—')
+ * @returns {string} e.g. "Rung progress (Foundation → revenue): V1 88% · V2 (not yet measurable)"  or ''
+ */
+export function formatRungRollupLine(rollupResult, opts = {}) {
+  if (!rollupResult || rollupResult.ok === false || !Array.isArray(rollupResult.rows) || rollupResult.rows.length === 0) {
+    return '';
+  }
+  const agg = aggregateRungProgress(rollupResult.rows);
+  const presentRungs = RUNG_ORDER.filter((k) => agg[k]);
+  // include any non-standard rung keys after the canonical ones, deterministically
+  for (const k of Object.keys(agg).sort()) if (!presentRungs.includes(k)) presentRungs.push(k);
+  if (presentRungs.length === 0) return '';
+
+  const parts = presentRungs.map((k) => {
+    const a = agg[k];
+    return a.pct == null ? `${k} (not yet measurable)` : `${k} ${a.pct}%`;
+  });
+  return `Rung progress (Foundation → revenue): ${parts.join('  ·  ')}`;
+}
+
+export default { aggregateRungProgress, formatRungRollupLine };

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -23,6 +23,9 @@ import { renderDecisionLines, prepareDecisions, DEAD_VENTURE_STATUSES } from '..
 // SD-LEO-INFRA-AUTOMATED-ONE-ROADMAP-001 (FR-4): the LIVE VDR build-% gauge, replacing the
 // static .adam-vision-build.json number.
 import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-registry.js';
+// SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E (FR-4): rung/KR rollup → email, in lockstep
+import { runRollup } from '../lib/vision/rung-progress-rollup.mjs';
+import { formatRungRollupLine } from '../lib/fleet/exec-email-rung-rollup.js';
 // SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001: the shared code-grep seam so the 5 code_grep probes resolve
 // (the chairman-visible gauge measures all 11 capabilities, not just the 6 DB/KR-backed ones).
 import { makeDefaultGrepSeam } from '../lib/vision/vdr-grep-seam.js';
@@ -131,6 +134,7 @@ let buildLine = '';
 let rungLine = '';
 let operationalLine = '';
 let rungNatureLine = ''; // SD-LEO-INFRA-VISION-LADDER-ROADMAP-COHERENCE-001 (FR-5): per-rung + per-nature
+let rungRollupLine = ''; // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E (FR-4): rung-completion rollup
 try {
   // SD-LEO-INFRA-VISION-LADDER-V1-001 (FR-5): source the denominator from the ACTIVE vision rung
   // (visionSource:true → the re-anchorable ladder pointer), so the gauge re-points automatically when
@@ -148,6 +152,13 @@ try {
   rungLine = fmt.rungLine;
   operationalLine = fmt.operationalLine;
   rungNatureLine = fmt.rungNatureLine; // FR-5
+  // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E (FR-4): roll the type-aware rung/KR
+  // progress into the email IN LOCKSTEP — reuse the SAME gauge just computed (computeGaugeFn returns it,
+  // no second compute, no divergence) and DRY-RUN (apply:false → the email reads, never writes progress_pct).
+  try {
+    const rollup = await runRollup({ supabase: db, computeGaugeFn: async () => gauge, apply: false, log: () => {} });
+    rungRollupLine = formatRungRollupLine(rollup, { em: EM });
+  } catch (e) { console.warn('[adam-email] rung-rollup line skipped (fail-soft): ' + (e?.message || e)); }
 } catch (e) {
   console.warn('[adam-email] live VDR gauge failed (fail-soft): ' + (e?.message || e));
   visPct = null;
@@ -247,6 +258,7 @@ const text = [
   buildLine || (visPct != null ? `EHG vision: ${visPct}% built` : 'EHG vision: (gauge unavailable)'),
   ...(rungNatureLine ? ['   ' + rungNatureLine] : []),
   ...(rungLine ? ['   ' + rungLine] : []),
+  ...(rungRollupLine ? ['   ' + rungRollupLine] : []), // FR-4: per-rung completion rollup (Foundation → revenue)
   ...(operationalLine ? ['   ' + operationalLine] : []),
   ...(layerLine ? ['   ' + layerLine] : []),
   ...(visNote ? ['   ' + visNote] : []),

--- a/tests/unit/fleet/exec-email-rung-rollup.test.js
+++ b/tests/unit/fleet/exec-email-rung-rollup.test.js
@@ -1,0 +1,60 @@
+/**
+ * SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E (FR-4) — pure unit tests for the
+ * exec-email rung-rollup line: aggregation, honest-null rendering, ordering, and fail-soft.
+ */
+import { describe, it, expect } from 'vitest';
+import { aggregateRungProgress, formatRungRollupLine } from '../../../lib/fleet/exec-email-rung-rollup.js';
+
+describe('aggregateRungProgress', () => {
+  it('means non-null progress per rung; excludes unmappable waves', () => {
+    const agg = aggregateRungProgress([
+      { rung_key: 'V1', progress_pct: 80 },
+      { rung_key: 'V1', progress_pct: 96 },
+      { rung_key: 'V2', progress_pct: null },
+      { rung_key: null, progress_pct: 50 }, // unmappable -> excluded
+    ]);
+    expect(agg.V1).toEqual({ pct: 88, waves: 2, measured: 2 }); // (80+96)/2
+    expect(agg.V2).toEqual({ pct: null, waves: 1, measured: 0 }); // honest-null, never 0
+    expect(agg.null).toBeUndefined();
+  });
+
+  it('handles empty / non-array input', () => {
+    expect(aggregateRungProgress([])).toEqual({});
+    expect(aggregateRungProgress(undefined)).toEqual({});
+  });
+});
+
+describe('formatRungRollupLine', () => {
+  const rows = [
+    { rung_key: 'V1', progress_pct: 88 },
+    { rung_key: 'V2', progress_pct: null },
+  ];
+
+  it('renders rungs in V1→V2→V3 order with honest-null for unmeasurable', () => {
+    const line = formatRungRollupLine({ ok: true, rows });
+    expect(line).toBe('Rung progress (Foundation → revenue): V1 88%  ·  V2 (not yet measurable)');
+  });
+
+  it('orders non-standard rung keys deterministically after the canonical ones', () => {
+    const line = formatRungRollupLine({ ok: true, rows: [
+      { rung_key: 'Z9', progress_pct: 10 },
+      { rung_key: 'V1', progress_pct: 50 },
+    ] });
+    expect(line.indexOf('V1')).toBeLessThan(line.indexOf('Z9'));
+  });
+
+  it('FAIL-SOFT: returns empty string for missing/empty/failed rollup (never throws, never breaks the email)', () => {
+    expect(formatRungRollupLine(null)).toBe('');
+    expect(formatRungRollupLine({ ok: false, rows })).toBe('');
+    expect(formatRungRollupLine({ ok: true, rows: [] })).toBe('');
+    expect(formatRungRollupLine({ ok: true })).toBe('');
+    expect(formatRungRollupLine({ ok: true, rows: [{ rung_key: null, progress_pct: 5 }] })).toBe(''); // all unmappable
+  });
+
+  it('a MEASURED 0% renders "0%", NOT "(not yet measurable)" (== null guard, not falsy)', () => {
+    // load-bearing honest-null contract: 0 is a real measurement; only null is "unmeasurable"
+    const line = formatRungRollupLine({ ok: true, rows: [{ rung_key: 'V1', progress_pct: 0 }] });
+    expect(line).toBe('Rung progress (Foundation → revenue): V1 0%');
+    expect(line).not.toContain('not yet measurable');
+  });
+});


### PR DESCRIPTION
## Child -E (FR-4): rung-completion rollup in the exec email, in lockstep

Wires child **-B**'s type-aware rung/KR progress rollup (`lib/vision/rung-progress-rollup.mjs` `runRollup`) into the hourly executive-summary email so the chairman sees **per-rung completion %** (Foundation → revenue rails), not just raw SD counts.

**No divergence by construction:** the email reuses the SAME `computeBuildGauge` result already computed for the existing rung line (`computeGaugeFn` returns it — no second compute), and runs the rollup **dry-run** (`apply:false` → reads `roadmap_waves`/`key_results`, never writes `progress_pct`).

**Honest + fail-soft:** new pure formatter `lib/fleet/exec-email-rung-rollup.js` — a `null` rung renders `(not yet measurable)` (a measured **0%** renders `0%`, `== null` guard); a failed/empty rollup yields an empty line so the email **never breaks** (double fail-soft: `runRollup` is internally fail-soft + the email wraps it in try/catch).

**Verified live:** `Rung progress (Foundation → revenue): V1 63%  ·  V2 20%  ·  V3 (not yet measurable)` — V1 63% matches the gauge's "V1 foundation: 63% built" line in the same email.

- 6 unit tests pass. Sub-agents: DB PASS, Testing PASS (95). Retro 90.
- Depends on `-B` (completed). No migration; additive + read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
