### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001): activate the sourcing engine end-to-end

### DIFF
--- a/.github/workflows/sourcing-deferred-watcher-cron.yml
+++ b/.github/workflows/sourcing-deferred-watcher-cron.yml
@@ -1,0 +1,62 @@
+name: "Sourcing deferred-watcher (cron)"
+
+# SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-3)
+#
+# Activates the sourcing-engine deferred/blocked-on watcher (child 8/10). Re-evaluates
+# conversion_ledger candidates parked in a 'blocked-on-X' lane and re-routes them (advisory lane
+# UPDATE only — never creates an SD, never promotes to belt) once their blocker clears. Gated by the
+# SOURCING_DEFERRED_WATCHER_V1 flag (set ON here). Idempotent + fail-soft; concurrency cancels an
+# in-flight run. KILL-SWITCH: set the env flag to 'off' (or disable this workflow) to revert.
+
+on:
+  schedule:
+    # Every 6 hours at :23 (offset from other crons; advisory lane re-eval needs no high cadence).
+    - cron: '23 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (preview only, no lane writes)"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Re-evaluate blocked-on sourcing candidates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # FR-3 activation flag (kill-switch: set to 'off' to revert).
+      SOURCING_DEFERRED_WATCHER_V1: 'on'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run deferred-watcher sweep
+        run: |
+          ARGS=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="--dry-run"
+          fi
+          node scripts/sourcing-engine-deferred-watcher-sweep.mjs $ARGS

--- a/.github/workflows/sourcing-gauge-gap-miner-cron.yml
+++ b/.github/workflows/sourcing-gauge-gap-miner-cron.yml
@@ -1,0 +1,65 @@
+name: "Sourcing gauge-gap miner (cron)"
+
+# SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-3)
+#
+# Activates the sourcing-engine VDR gauge-gap miner (child 10/10). Mines unbuilt/partial active-rung
+# capabilities from computeBuildGauge and STAGES them as roadmap_wave_items candidates
+# (item_disposition='pending', source_type='vdr_gauge') — it NEVER promotes to belt and NEVER creates
+# an SD (promotion stays the separate leo-create-sd --from-roadmap-item step). Gated by the
+# SOURCING_GAUGE_GAP_MINER_V1 flag (set ON here); runs --apply (the dormant additive migrations —
+# lane column + vdr_gauge source_type CHECK — are applied, so staging is live). Dormant-safe: forces
+# dry-run if either migration is missing. KILL-SWITCH: set the env flag to 'off' (or disable this
+# workflow) to revert; staged rows are idempotent on (wave_id, source_type, source_id).
+
+on:
+  schedule:
+    # Daily at 06:41 UTC (offset from other crons; gauge gaps change slowly).
+    - cron: '41 6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (preview only, no staging writes)"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  mine:
+    name: Mine VDR gauge gaps into staged roadmap items
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # FR-3 activation flag (kill-switch: set to 'off' to revert).
+      SOURCING_GAUGE_GAP_MINER_V1: 'on'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run gauge-gap miner sweep
+        run: |
+          ARGS="--apply"
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS=""
+          fi
+          node scripts/sourcing-engine/gauge-gap-miner-sweep.mjs $ARGS

--- a/database/migrations/20260619_sourcing_engine_lane_column.sql
+++ b/database/migrations/20260619_sourcing_engine_lane_column.sql
@@ -1,4 +1,7 @@
 -- SD-LEO-INFRA-SOURCING-ENGINE-LEDGER-LANE-COLUMN-001 (FR-1 / FR-2)
+-- @approved-by: codestreetlabs@gmail.com
+-- Prod-apply approval (additive-only) stamped during SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001
+-- go-live, chairman-authorized 2026-06-20. Additive nullable column + additive CHECK; reversible.
 -- Sourcing engine child 2/10 — the schema foundation.
 --
 -- Adds a SEPARATE, mutable `lane` column (DISTINCT from the terminal `disposition`) to

--- a/database/migrations/20260620_roadmap_wave_items_adam_direct_source_type.sql
+++ b/database/migrations/20260620_roadmap_wave_items_adam_direct_source_type.sql
@@ -1,4 +1,8 @@
 -- SD-LEO-INFRA-SOURCING-ENGINE-ADAM-DIRECT-REGISTRY-001 (FR-2 enabler)
+-- @approved-by: codestreetlabs@gmail.com
+-- Prod-apply approval (additive-only) stamped during SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001
+-- go-live, chairman-authorized 2026-06-20. Additive CHECK widen; reversible. APPLY BEFORE the
+-- vdr_gauge widening (this array omits vdr_gauge; vdr_gauge migration carries the full set).
 -- DORMANT (TIER-2): extend roadmap_wave_items.source_type CHECK to admit 'adam_direct', so
 -- Adam-direct candidates + ghost-backfill rows can be registered. ADDITIVE + REVERSIBLE (widening a
 -- CHECK never invalidates existing rows). Workers do NOT self-apply: Adam applies under the

--- a/database/migrations/20260620_roadmap_wave_items_vdr_gauge_source_type.sql
+++ b/database/migrations/20260620_roadmap_wave_items_vdr_gauge_source_type.sql
@@ -1,4 +1,8 @@
 -- SD-LEO-INFRA-SOURCING-ENGINE-GAUGE-GAP-MINER-001 (FR-2 enabler)
+-- @approved-by: codestreetlabs@gmail.com
+-- Prod-apply approval (additive-only) stamped during SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001
+-- go-live, chairman-authorized 2026-06-20. Additive CHECK widen (full set incl adam_direct+vdr_gauge);
+-- reversible. APPLY LAST (after adam_direct) — this array is the complete allowed set.
 -- DORMANT (TIER-2): extend roadmap_wave_items.source_type CHECK to admit 'vdr_gauge', so the gauge-gap
 -- miner can register STAGED candidates (one per unbuilt/partial active-rung capability) as roadmap
 -- items. ADDITIVE + REVERSIBLE (widening a CHECK never invalidates existing rows). Workers do NOT

--- a/database/migrations/20260620_sourcing_chairman_queue.sql
+++ b/database/migrations/20260620_sourcing_chairman_queue.sql
@@ -1,4 +1,7 @@
 -- SD-LEO-INFRA-SOURCING-ENGINE-CHAIRMAN-QUEUE-001 (FR-1 / FR-2)
+-- @approved-by: codestreetlabs@gmail.com
+-- Prod-apply approval (additive-only) stamped during SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001
+-- go-live, chairman-authorized 2026-06-20. Additive CREATE TABLE IF NOT EXISTS; reversible.
 -- Sourcing engine child 4/10 — the chairman decision-queue lane.
 --
 -- A durable home for candidates the router lanes to 'chairman-gated' (needs an authority only the

--- a/docs/sourcing-engine-activation-runbook.md
+++ b/docs/sourcing-engine-activation-runbook.md
@@ -1,0 +1,58 @@
+# Sourcing Engine — Activation Runbook
+
+SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (go-live, chairman-authorized 2026-06-20).
+
+The sourcing engine (10/10 children shipped) was built **dormant by design**. This runbook records
+how it was activated and how to revert each step.
+
+## FR-1 — Migrations (APPLIED to prod)
+
+Applied via `scripts/apply-migration.js --prod-deploy` (chairman 3-factor: `@approved-by` header +
+single-use `MIGRATION_APPLY_TOKEN` + git user.email). All additive-only + reversible. **Order matters**
+for the two source_type widenings (adam_direct omits vdr_gauge; apply adam_direct first, vdr_gauge last):
+
+1. `20260619_sourcing_engine_lane_column.sql` — nullable `lane` column + CHECK on conversion_ledger + roadmap_wave_items
+2. `20260620_sourcing_chairman_queue.sql` — CREATE TABLE sourcing_chairman_queue
+3. `20260620_roadmap_wave_items_adam_direct_source_type.sql` — widen source_type CHECK += adam_direct
+4. `20260620_roadmap_wave_items_vdr_gauge_source_type.sql` — widen source_type CHECK += vdr_gauge (full set; LAST)
+
+Revert: drop the added columns/table/CHECK additions (all additive, so reverting is safe but rarely needed).
+
+## FR-2 — Disposition / quality gate (CODE)
+
+`lib/sourcing-engine/proactive-populator.js::dispositionGate()` curates the routed corpus to KEEPERS
+before staging. Drops: `already_staged`, `noise` (empty/short/untitled), `raw_intake`
+(todoist/youtube — personal-productivity intake, chairman policy; `--keep-raw` re-includes), `decline`,
+`terminal_dup` (lane=dedup), `already_covered` (dedup_match set & not re_emit). Keeps novel/gated/re_emit.
+
+Also fixed the real dedup bug: `loadContext` hit PostgREST's 1000-row cap, so dedup only saw 1000 of
+3994 SDs (`fetchAllRows` now paginates). The dormant lane column governs PERSISTENCE, not MATCHING —
+that was the SD's mis-hypothesis.
+
+Curated dry-run: 814 corpus -> **kept 208** (188 harness_backlog + 20 estate_corpus), dropped 606
+(raw_intake 599, terminal_dup 7).
+
+## FR-3 — Activation flags
+
+**Behavioral flags** (actually gate code; set ON in the new cron workflows' `env:`):
+
+| Flag | Gates | Activated via | Kill-switch |
+|------|-------|---------------|-------------|
+| `SOURCING_DEFERRED_WATCHER_V1` | deferred-watcher sweep (advisory lane re-eval) | `.github/workflows/sourcing-deferred-watcher-cron.yml` (every 6h) | set env `off` / disable workflow |
+| `SOURCING_GAUGE_GAP_MINER_V1` | gauge-gap miner sweep (stages vdr_gauge roadmap items) | `.github/workflows/sourcing-gauge-gap-miner-cron.yml` (daily, `--apply`) | set env `off` / disable workflow |
+| `POPULATOR_CHAIRMAN_APPROVED` / `--chairman-approved` | proactive-populator STAGING | per-run flag (`npm run sourcing:populate -- --apply --chairman-approved`) | omit the flag (dry-run) |
+
+**Display-only flags** (read by `adam-startup-check.readSourcingFlags` for the state probe; they signal
+intended-on state but do **not** gate code today — documented honestly, not false-gating):
+`SOURCING_ENGINE_V1`, `SOURCING_ROADMAP_ENGINE_V1`, `SOURCING_PROACTIVE_POPULATOR_V1`, `LEO_ROADMAP_AUTOSOURCE`.
+If/when these are meant to gate, wire them at the relevant read-sites and add to the cron envs.
+
+All crons stage/advise only — none promotes to belt or creates an SD (promotion stays the separate,
+gated `leo-create-sd --from-roadmap-item` step).
+
+## FR-4 — E2E verification
+
+1. Dry-run report (chairman review artifact): `npm run sourcing:populate`
+2. Stage curated keepers (chairman-gated): `npm run sourcing:populate -- --apply --chairman-approved [--cap=N]`
+3. Promote a sample: `node scripts/leo-create-sd.js --from-roadmap-item <id>`
+4. Confirm belt depth rises with curated keepers, without hand-sourcing and without raw-intake noise.

--- a/lib/sourcing-engine/proactive-populator.js
+++ b/lib/sourcing-engine/proactive-populator.js
@@ -172,12 +172,20 @@ export function buildReport(routed) {
  * PURE. Conservative by design: it only drops terminal-dup / declined / already-realized / noise, so
  * a genuine candidate is never silently dropped (the false-negative risk called out in the PRD).
  *
- * @param {Array} routed - from routeCorpus (each { lane, dedup_match_sd_key, re_emit, title, source_id, ... })
- * @param {{ minTitleLen?:number }} [opts]
+ * RAW-INTAKE policy (opts.dropRawIntake, chairman-set 2026-06-20): the SD's necessity is explicit
+ * that the raw todoist/youtube corpus is personal-productivity intake that "must be DISPOSITIONED
+ * before reaching the belt" — it is not curated engineering work. When dropRawIntake is true, any
+ * candidate whose source_type is 'todoist' or 'youtube' is dropped (reason 'raw_intake'); the items
+ * stay UNTOUCHED in conversion_ledger, so a later policy can re-include them. Default false keeps the
+ * pure function source-agnostic (the CLI runner opts in).
+ *
+ * @param {Array} routed - from routeCorpus (each { lane, dedup_match_sd_key, re_emit, title, source_id, source_type, ... })
+ * @param {{ minTitleLen?:number, dropRawIntake?:boolean, rawIntakeSourceTypes?:string[] }} [opts]
  * @returns {{ keepers:Array, dropped:Array, drop_by_reason:Object }}
  */
 export function dispositionGate(routed, opts = {}) {
   const minTitleLen = Number.isInteger(opts.minTitleLen) && opts.minTitleLen > 0 ? opts.minTitleLen : 6;
+  const rawTypes = new Set(opts.rawIntakeSourceTypes || ['todoist', 'youtube']);
   const keepers = [];
   const dropped = [];
   const drop_by_reason = {};
@@ -193,6 +201,7 @@ export function dispositionGate(routed, opts = {}) {
       || title === String(c.source_id)
       || (c.source_key != null && title === String(c.source_key));
     if (isUntitled) { drop(c, 'noise'); continue; }
+    if (opts.dropRawIntake && rawTypes.has(c.source_type)) { drop(c, 'raw_intake'); continue; }
     if (c.lane === 'decline') { drop(c, 'decline'); continue; }
     if (c.lane === 'dedup') { drop(c, 'terminal_dup'); continue; }
     if (c.dedup_match_sd_key && !c.re_emit) { drop(c, 'already_covered'); continue; }
@@ -266,7 +275,7 @@ export async function populate(supabase, deps, opts = {}) {
 
   // FR-2: disposition / quality gate — curate the routed corpus to KEEPERS before staging, so the
   // belt only ever fills with quality work (raw belt-ready intake is noise/dup/already-done heavy).
-  const disposition = dispositionGate(routed, { minTitleLen: opts.minTitleLen });
+  const disposition = dispositionGate(routed, { minTitleLen: opts.minTitleLen, dropRawIntake: opts.dropRawIntake, rawIntakeSourceTypes: opts.rawIntakeSourceTypes });
   report.disposition_kept = disposition.keepers.length;
   report.disposition_dropped = disposition.dropped.length;
   report.drop_by_reason = disposition.drop_by_reason;

--- a/lib/sourcing-engine/proactive-populator.js
+++ b/lib/sourcing-engine/proactive-populator.js
@@ -156,6 +156,52 @@ export function buildReport(routed) {
 }
 
 /**
+ * DISPOSITION / QUALITY GATE — SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-2).
+ *
+ * Runs AFTER routeCorpus and BEFORE stageCorpus to curate the routed corpus down to a KEEPER
+ * set, so only quality work reaches the belt (the raw ~768-of-811 belt-ready intake is noise/
+ * dup/already-done heavy). Drops, with a per-reason tally:
+ *   - already_staged : wave6 rows that are already roadmap_wave_items (never re-stage)
+ *   - noise          : empty / too-short / untitled raw intake (title missing or == its own id/key)
+ *   - decline        : router lane 'decline'
+ *   - terminal_dup   : router lane 'dedup' (source is itself an existing SD key — terminal duplicate)
+ *   - already_covered: dedup_match_sd_key set AND NOT re_emit (an existing SHIPPED+realized SD already covers it)
+ * KEEPS everything else — novel belt-ready, chairman-gated, outcome-gated, blocked-on, and crucially
+ * re_emit candidates (matched an infra SD whose OUTCOME is not yet realized => still open work).
+ *
+ * PURE. Conservative by design: it only drops terminal-dup / declined / already-realized / noise, so
+ * a genuine candidate is never silently dropped (the false-negative risk called out in the PRD).
+ *
+ * @param {Array} routed - from routeCorpus (each { lane, dedup_match_sd_key, re_emit, title, source_id, ... })
+ * @param {{ minTitleLen?:number }} [opts]
+ * @returns {{ keepers:Array, dropped:Array, drop_by_reason:Object }}
+ */
+export function dispositionGate(routed, opts = {}) {
+  const minTitleLen = Number.isInteger(opts.minTitleLen) && opts.minTitleLen > 0 ? opts.minTitleLen : 6;
+  const keepers = [];
+  const dropped = [];
+  const drop_by_reason = {};
+  const drop = (c, reason) => {
+    dropped.push({ ...c, drop_reason: reason });
+    drop_by_reason[reason] = (drop_by_reason[reason] || 0) + 1;
+  };
+  for (const c of (routed || [])) {
+    if (c.alreadyStaged) { drop(c, 'already_staged'); continue; }
+    const title = (c.title || '').trim();
+    const isUntitled = !title
+      || title.length < minTitleLen
+      || title === String(c.source_id)
+      || (c.source_key != null && title === String(c.source_key));
+    if (isUntitled) { drop(c, 'noise'); continue; }
+    if (c.lane === 'decline') { drop(c, 'decline'); continue; }
+    if (c.lane === 'dedup') { drop(c, 'terminal_dup'); continue; }
+    if (c.dedup_match_sd_key && !c.re_emit) { drop(c, 'already_covered'); continue; }
+    keepers.push(c);
+  }
+  return { keepers, dropped, drop_by_reason };
+}
+
+/**
  * Stage routed candidates as roadmap_wave_items rows (FR-2/FR-3/FR-4). HARD-SAFEGUARDED:
  *   - writes ONLY when apply===true AND chairmanApproved===true (else dry-run: counts, no writes).
  *   - INSERTs at item_disposition='pending' (the STAGED state); NEVER sets promoted_to_sd_key
@@ -218,9 +264,17 @@ export async function populate(supabase, deps, opts = {}) {
   const routed = routeCorpus(corpus, ctx);
   const report = buildReport(routed);
 
+  // FR-2: disposition / quality gate — curate the routed corpus to KEEPERS before staging, so the
+  // belt only ever fills with quality work (raw belt-ready intake is noise/dup/already-done heavy).
+  const disposition = dispositionGate(routed, { minTitleLen: opts.minTitleLen });
+  report.disposition_kept = disposition.keepers.length;
+  report.disposition_dropped = disposition.dropped.length;
+  report.drop_by_reason = disposition.drop_by_reason;
+
   const waveId = await resolveTargetWaveId(supabase);
   const lanePresent = await roadmapLaneColumnExists(supabase);
-  const staging = await stageCorpus(supabase, routed, {
+  // Stage ONLY the curated keepers (never the raw routed corpus).
+  const staging = await stageCorpus(supabase, disposition.keepers, {
     apply: opts.apply, chairmanApproved: opts.chairmanApproved, waveId, lanePresent, cap: opts.cap,
   });
   // FR: surface a register-first warn count (advisory, never blocks).

--- a/scripts/sourcing-engine/proactive-populator.mjs
+++ b/scripts/sourcing-engine/proactive-populator.mjs
@@ -48,10 +48,32 @@ async function loadSources(db) {
   return { ledger: ledger || [], wave6, deferred: deferred || [], backlog };
 }
 
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-2): page through ALL rows of a table.
+ * PostgREST silently caps a single response at 1000 rows regardless of .limit(), so the prior
+ * single-shot load returned only the first 1000 of ~4000 SDs — which is WHY the dedup context was
+ * incomplete and dry-run reported dedup_matches=0 (NOT the dormant lane column, as the SD hypothesized:
+ * the lane column governs PERSISTENCE, the existing-SD set governs MATCHING). A duplicate that lives
+ * past row 1000 was simply invisible to findDedupMatch, so the belt would flood with already-covered work.
+ * @param {object} db  @param {string} table  @param {string} select  @param {number} [pageSize]
+ */
+export async function fetchAllRows(db, table, select, pageSize = 1000) {
+  const out = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await db.from(table).select(select).range(from, from + pageSize - 1);
+    if (error) throw new Error(`fetchAllRows(${table}): ${error.message}`);
+    if (!data || data.length === 0) break;
+    out.push(...data);
+    if (data.length < pageSize) break; // last page
+  }
+  return out;
+}
+
 async function loadContext(db) {
-  const { data: sds } = await db.from('strategic_directives_v2').select('sd_key,title,status').limit(4000);
-  const existing = (sds || []).map((s) => ({ sd_key: s.sd_key, title: s.title }));
-  const shippedInfraKeys = (sds || []).filter((s) => s.status === 'completed').map((s) => s.sd_key);
+  // Load EVERY SD (paginated) so dedup matches against the full corpus, not just the first 1000.
+  const sds = await fetchAllRows(db, 'strategic_directives_v2', 'sd_key,title,status');
+  const existing = sds.map((s) => ({ sd_key: s.sd_key, title: s.title }));
+  const shippedInfraKeys = sds.filter((s) => s.status === 'completed').map((s) => s.sd_key);
   // outcomeRealizedKeys left empty = the SAFE direction (a shipped-but-unrealized SD re-emits; never falsely closes work).
   return { existing, inFlight: [], shippedInfraKeys, outcomeRealizedKeys: [] };
 }
@@ -65,6 +87,8 @@ function printReport(out) {
   console.log(`by lane   : ${fmt(r.by_lane)}`);
   console.log(`by rung   : ${fmt(r.by_rung)}`);
   console.log(`dedup matches: ${r.dedup_matches}  |  decline: ${r.decline}  |  re-emit: ${r.re_emit}  |  register-first warns: ${r.register_first_warn}`);
+  // FR-2: disposition / quality gate — how the raw routed corpus curates to keepers before staging.
+  console.log(`disposition: kept=${r.disposition_kept} dropped=${r.disposition_dropped}  by-reason: ${fmt(r.drop_by_reason) || '(none)'}`);
   console.log(`wave: ${wave_id ? wave_id.slice(0, 8) : 'none'}  |  lane column: ${lane_column_present ? 'present' : 'DORMANT'}`);
   console.log(`staging: ${s.dry_run ? 'DRY-RUN' : 'APPLIED'} (chairman_approved=${s.chairman_approved}) — staged=${s.staged} skipped=${s.skipped} errors=${s.errors.length}`);
   if (s.dry_run && (apply && !chairmanApproved)) console.log('  note: --apply given but NOT chairman-approved -> dry-run. Add --chairman-approved to stage.');

--- a/scripts/sourcing-engine/proactive-populator.mjs
+++ b/scripts/sourcing-engine/proactive-populator.mjs
@@ -18,6 +18,10 @@ import { populate } from '../../lib/sourcing-engine/proactive-populator.js';
 const apply = process.argv.includes('--apply');
 const chairmanApproved = process.argv.includes('--chairman-approved') || process.env.POPULATOR_CHAIRMAN_APPROVED === 'true';
 const capArg = (process.argv.find((a) => a.startsWith('--cap=')) || '').split('=')[1];
+// SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-2, chairman policy 2026-06-20): the disposition
+// gate drops raw todoist/youtube intake by default (it is personal-productivity intake, not curated
+// engineering work). --keep-raw disables that drop (re-includes the raw corpus).
+const dropRawIntake = !process.argv.includes('--keep-raw');
 
 const TERMINAL_DISPOSITIONS = ['built', 'already_covered', 'duplicate', 'declined', 'deferred_to_rung'];
 
@@ -97,7 +101,7 @@ function printReport(out) {
 
 async function main() {
   const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-  const out = await populate(db, { loadSources, loadContext }, { apply, chairmanApproved, cap: capArg ? Number(capArg) : undefined });
+  const out = await populate(db, { loadSources, loadContext }, { apply, chairmanApproved, cap: capArg ? Number(capArg) : undefined, dropRawIntake });
   printReport(out);
 }
 

--- a/tests/unit/sourcing-engine/proactive-populator-disposition.test.js
+++ b/tests/unit/sourcing-engine/proactive-populator-disposition.test.js
@@ -1,0 +1,137 @@
+/**
+ * Disposition / quality gate — SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-2).
+ *
+ * The gate runs AFTER routeCorpus and BEFORE stageCorpus, curating the routed corpus to a KEEPER
+ * set so the belt only fills with quality work (raw belt-ready intake is noise/dup/already-done heavy).
+ * It drops {already_staged, noise, decline, terminal_dup, already_covered} and keeps everything else,
+ * INCLUDING re_emit candidates (matched an infra SD whose outcome is not yet realized => still open work).
+ *
+ * PURE: exercises dispositionGate directly + populate() wiring with injected deps. ZERO live DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  dispositionGate,
+  populate,
+} from '../../../lib/sourcing-engine/proactive-populator.js';
+
+// A routed candidate (post-routeCorpus shape) with sensible defaults.
+function routed(over = {}) {
+  return {
+    corpus: 'conversion_ledger',
+    source_type: 'brainstorm',
+    source_id: '11111111-1111-1111-1111-111111111111',
+    title: 'A genuinely actionable piece of work',
+    lane: 'belt-ready',
+    dedup_match_sd_key: null,
+    re_emit: false,
+    ...over,
+  };
+}
+
+describe('dispositionGate (FR-2) — curate routed corpus to keepers', () => {
+  it('keeps a novel belt-ready candidate', () => {
+    const { keepers, dropped } = dispositionGate([routed()]);
+    expect(keepers).toHaveLength(1);
+    expect(dropped).toHaveLength(0);
+  });
+
+  it('drops already_staged (wave6) items', () => {
+    const { keepers, drop_by_reason } = dispositionGate([routed({ alreadyStaged: true })]);
+    expect(keepers).toHaveLength(0);
+    expect(drop_by_reason.already_staged).toBe(1);
+  });
+
+  it('drops noise: empty, too-short, and untitled (title === source_id / source_key)', () => {
+    const r = dispositionGate([
+      routed({ title: '' }),
+      routed({ title: 'abc' }), // shorter than default minTitleLen 6
+      routed({ title: 'src-1', source_id: 'src-1' }),
+      routed({ title: 'orig-key', source_key: 'orig-key' }),
+    ]);
+    expect(r.keepers).toHaveLength(0);
+    expect(r.drop_by_reason.noise).toBe(4);
+  });
+
+  it('drops decline and terminal_dup (lane dedup) candidates', () => {
+    const r = dispositionGate([
+      routed({ lane: 'decline' }),
+      routed({ lane: 'dedup' }),
+    ]);
+    expect(r.keepers).toHaveLength(0);
+    expect(r.drop_by_reason.decline).toBe(1);
+    expect(r.drop_by_reason.terminal_dup).toBe(1);
+  });
+
+  it('drops already_covered (dedup_match_sd_key set, NOT re_emit) but KEEPS re_emit', () => {
+    const r = dispositionGate([
+      routed({ dedup_match_sd_key: 'SD-DONE-001', re_emit: false }),       // already covered -> drop
+      routed({ dedup_match_sd_key: 'SD-OPEN-001', re_emit: true, lane: 'outcome-gated' }), // still open -> keep
+    ]);
+    expect(r.drop_by_reason.already_covered).toBe(1);
+    expect(r.keepers).toHaveLength(1);
+    expect(r.keepers[0].dedup_match_sd_key).toBe('SD-OPEN-001');
+  });
+
+  it('keeps chairman-gated / outcome-gated / blocked-on (real work, just gated)', () => {
+    const r = dispositionGate([
+      routed({ lane: 'chairman-gated' }),
+      routed({ lane: 'outcome-gated' }),
+      routed({ lane: 'blocked-on-SD-FOO-001' }),
+    ]);
+    expect(r.keepers).toHaveLength(3);
+    expect(r.dropped).toHaveLength(0);
+  });
+
+  it('mixed corpus: keepers = {genuine, re_emit}, dropped = {noise, terminal_dup, already_covered}', () => {
+    const r = dispositionGate([
+      routed({ title: 'Build the thing properly' }),                     // keep
+      routed({ title: '', source_id: 'x' }),                             // noise
+      routed({ lane: 'dedup', title: 'SD-EXISTING-001' }),              // terminal_dup
+      routed({ dedup_match_sd_key: 'SD-DONE-001' }),                    // already_covered
+      routed({ dedup_match_sd_key: 'SD-OPEN-001', re_emit: true, lane: 'outcome-gated' }), // keep (re_emit)
+    ]);
+    expect(r.keepers).toHaveLength(2);
+    expect(r.dropped).toHaveLength(3);
+    expect(r.drop_by_reason).toEqual({ noise: 1, terminal_dup: 1, already_covered: 1 });
+  });
+
+  it('respects a custom minTitleLen', () => {
+    const r = dispositionGate([routed({ title: 'short' })], { minTitleLen: 3 });
+    expect(r.keepers).toHaveLength(1); // 'short' (5) >= 3
+  });
+});
+
+describe('populate() wiring (FR-2) — stages only keepers + reports disposition counts', () => {
+  it('stages keepers only and surfaces disposition_kept/dropped/drop_by_reason', async () => {
+    const loadSources = async () => ({
+      ledger: [
+        { id: '11111111-1111-1111-1111-111111111111', source_pool: 'estate', title: 'Genuine actionable work item' },
+        { id: '22222222-2222-2222-2222-222222222222', source_pool: 'estate', title: '' }, // noise
+      ],
+      wave6: [],
+      deferred: [],
+      backlog: [],
+    });
+    const loadContext = async () => ({});
+    // dry-run (no apply/chairmanApproved) => stageCorpus counts what WOULD stage, writes nothing.
+    const supabase = {
+      from() {
+        return {
+          // resolveTargetWaveId / roadmapLaneColumnExists call .select; return benign shapes.
+          select() { return this; },
+          eq() { return this; },
+          order() { return this; },
+          limit() { return Promise.resolve({ data: [{ id: 'wave-1' }], error: null }); },
+          maybeSingle() { return Promise.resolve({ data: { id: 'wave-1' }, error: null }); },
+          single() { return Promise.resolve({ data: { id: 'wave-1' }, error: null }); },
+          insert() { return Promise.resolve({ error: null }); },
+        };
+      },
+    };
+    const { report } = await populate(supabase, { loadSources, loadContext }, {});
+    expect(report.total).toBe(2);              // raw routed
+    expect(report.disposition_kept).toBe(1);   // only the genuine item
+    expect(report.disposition_dropped).toBe(1);
+    expect(report.drop_by_reason.noise).toBe(1);
+  });
+});

--- a/tests/unit/sourcing-engine/proactive-populator-disposition.test.js
+++ b/tests/unit/sourcing-engine/proactive-populator-disposition.test.js
@@ -95,6 +95,20 @@ describe('dispositionGate (FR-2) — curate routed corpus to keepers', () => {
     expect(r.drop_by_reason).toEqual({ noise: 1, terminal_dup: 1, already_covered: 1 });
   });
 
+  it('dropRawIntake drops todoist/youtube source types, keeps brainstorm/estate (FR-2 chairman policy)', () => {
+    const corpus = [
+      routed({ source_type: 'todoist', title: 'Buy milk and call the dentist' }),
+      routed({ source_type: 'youtube', title: 'Cool video about rockets to watch later' }),
+      routed({ source_type: 'brainstorm', title: 'Harness backlog: fix the reaper race' }),
+    ];
+    const off = dispositionGate(corpus);
+    expect(off.keepers).toHaveLength(3); // default: source-agnostic
+    const on = dispositionGate(corpus, { dropRawIntake: true });
+    expect(on.keepers).toHaveLength(1);
+    expect(on.keepers[0].source_type).toBe('brainstorm');
+    expect(on.drop_by_reason.raw_intake).toBe(2);
+  });
+
   it('respects a custom minTitleLen', () => {
     const r = dispositionGate([routed({ title: 'short' })], { minTitleLen: 3 });
     expect(r.keepers).toHaveLength(1); // 'short' (5) >= 3

--- a/tests/unit/sourcing-engine/proactive-populator-fetchall.test.js
+++ b/tests/unit/sourcing-engine/proactive-populator-fetchall.test.js
@@ -1,0 +1,61 @@
+/**
+ * fetchAllRows pagination — SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001 (FR-2).
+ *
+ * PostgREST silently caps a single response at 1000 rows regardless of .limit(), so the populator's
+ * dedup CONTEXT (the existing-SD set) was truncated to the first 1000 of ~4000 SDs — which is why the
+ * dry-run reported dedup_matches=0 (a duplicate living past row 1000 was invisible to findDedupMatch).
+ * fetchAllRows pages via .range() until a short page, returning the FULL set.
+ */
+import { describe, it, expect } from 'vitest';
+import { fetchAllRows } from '../../../scripts/sourcing-engine/proactive-populator.mjs';
+
+// Minimal supabase-like stub whose .range() serves from a fixed dataset in 1000-row pages.
+function stubDb(total, pageSize = 1000) {
+  const rows = Array.from({ length: total }, (_, i) => ({ sd_key: `SD-${i}`, title: `t${i}`, status: 'completed' }));
+  let lastRange = null;
+  return {
+    _rows: rows,
+    get lastRange() { return lastRange; },
+    from() {
+      return {
+        select() { return this; },
+        range(from, to) {
+          lastRange = [from, to];
+          return Promise.resolve({ data: rows.slice(from, to + 1), error: null });
+        },
+      };
+    },
+  };
+}
+
+describe('fetchAllRows — pages past the PostgREST 1000-row cap (FR-2)', () => {
+  it('returns ALL rows when the table exceeds one page (3994 > 1000)', async () => {
+    const db = stubDb(3994);
+    const out = await fetchAllRows(db, 'strategic_directives_v2', 'sd_key,title,status');
+    expect(out).toHaveLength(3994);
+    expect(out[0].sd_key).toBe('SD-0');
+    expect(out[3993].sd_key).toBe('SD-3993');
+  });
+
+  it('stops on a short final page (no infinite loop, no extra fetch)', async () => {
+    const db = stubDb(1500);
+    const out = await fetchAllRows(db, 't', 'c');
+    expect(out).toHaveLength(1500);
+  });
+
+  it('returns an empty array for an empty table', async () => {
+    const db = stubDb(0);
+    expect(await fetchAllRows(db, 't', 'c')).toHaveLength(0);
+  });
+
+  it('handles an exact-multiple-of-pageSize table (1000) without dropping rows', async () => {
+    const db = stubDb(1000);
+    const out = await fetchAllRows(db, 't', 'c');
+    expect(out).toHaveLength(1000);
+  });
+
+  it('throws (fail-loud) on a query error rather than silently truncating', async () => {
+    const db = { from() { return { select() { return this; }, range() { return Promise.resolve({ data: null, error: { message: 'boom' } }); } }; } };
+    await expect(fetchAllRows(db, 't', 'c')).rejects.toThrow(/fetchAllRows\(t\): boom/);
+  });
+});


### PR DESCRIPTION
## Summary
Activate the dormant sourcing engine (10/10 children shipped, all inert) end-to-end.

### FR-1 — Migrations (APPLIED to prod, additive-only, audit-logged)
- `conversion_ledger.lane` + `roadmap_wave_items.lane` (nullable + CHECK)
- `sourcing_chairman_queue` table
- `roadmap_wave_items.source_type` CHECK widened += `adam_direct`, `vdr_gauge`
- Stamped `@approved-by` headers (chairman 3-factor, applied in correct order)

### FR-2 — Disposition / quality gate + the real dedup fix
- `dispositionGate()` curates the routed corpus to keepers before staging (drops already_staged/noise/raw_intake/decline/terminal_dup/already_covered; keeps novel/gated/re_emit).
- **Verify-the-premise:** the SD blamed the dormant lane column for `dedup_matches=0`; after applying it, dedup was *still* 0. Real cause: `loadContext` hit PostgREST's 1000-row cap (saw 1000 of 3994 SDs). Fixed with `fetchAllRows` pagination.
- Chairman policy: drop raw todoist/youtube intake. **Curated dry-run: 814 → kept 208 (188 harness_backlog + 20 estate), dropped 606 (raw_intake 599, terminal_dup 7).**

### FR-3 — Activation (cron workflows + runbook)
- `sourcing-deferred-watcher-cron.yml` (SOURCING_DEFERRED_WATCHER_V1=on) + `sourcing-gauge-gap-miner-cron.yml` (SOURCING_GAUGE_GAP_MINER_V1=on, --apply).
- Runbook documents behavioral-vs-display flags (4 umbrella flags are display-only state-probe signals, not gating), kill-switches, revert.

### FR-4 — E2E verified
- 208 curated keepers staged live to `roadmap_wave_items` (item_disposition=pending, lane=belt-ready, idempotent, 0 errors).
- Promotion path (`leo-create-sd --from-roadmap-item`) is pre-shipped/tested machinery; it is currently blocked by the SD-CREATE-SKILL enforcement hook (flagged).

## Testing
32 unit tests pass (10 disposition incl raw-intake, 5 fetchAll pagination, 17 existing populator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)