### PR TITLE
fix(SD-LEO-FEAT-DATA-LOSS-HIGH-001): preserve modified-tracked files before reaping

### DIFF
--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -50,25 +50,41 @@ export function runGit(args, cwd = process.cwd()) {
 }
 
 /**
- * Working-tree dirty status. Returns {dirtyCount, untracked, exists}.
+ * Working-tree dirty status. Returns {dirtyCount, untracked, modified, exists}.
  * A non-existent path is reported as exists:false / dirtyCount:0 (nothing to lose).
+ *
+ * SD-LEO-FEAT-DATA-LOSS-HIGH-001 (FR-1): `modified` lists TRACKED changed file paths
+ * (porcelain lines NOT starting with '?? '). These are uncommitted edits to existing files —
+ * the ~56-LOC data-loss class — which the reaper's preserve-before-delete step previously
+ * IGNORED (it copied only `untracked`). Rename/copy lines (`R  old -> new`) contribute the
+ * NEW (current) path; pure deletions (a 'D' in the 2-char status) are skipped — there is no
+ * working-tree file to preserve. PURE: status comes from the injected gitRunner only.
+ * Existing fields (dirtyCount/untracked/exists) are unchanged for back-compat.
  */
 export function collectDirtyStatus(wtPath, { gitRunner = runGit } = {}) {
   if (!wtPath || !fs.existsSync(wtPath)) {
-    return { dirtyCount: 0, untracked: [], exists: false };
+    return { dirtyCount: 0, untracked: [], modified: [], exists: false };
   }
   try {
     const res = gitRunner(['status', '--porcelain', '--untracked-files=all'], wtPath);
-    if (res.code !== 0) return { dirtyCount: 0, untracked: [], exists: true };
+    if (res.code !== 0) return { dirtyCount: 0, untracked: [], modified: [], exists: true };
     const lines = (res.stdout || '').split('\n').filter(Boolean);
     const untracked = [];
+    const modified = [];
     let dirty = 0;
     for (const l of lines) {
       dirty++;
-      if (l.startsWith('?? ')) untracked.push(l.slice(3).trim());
+      if (l.startsWith('?? ')) { untracked.push(l.slice(3).trim()); continue; }
+      const status = l.slice(0, 2);
+      if (status.includes('D')) continue; // deletion — no working-tree file to preserve
+      let p = l.slice(3).trim();
+      const arrow = p.indexOf(' -> ');         // rename/copy: keep the NEW path
+      if (arrow !== -1) p = p.slice(arrow + 4).trim();
+      if (p.startsWith('"') && p.endsWith('"')) p = p.slice(1, -1); // git quotes special chars
+      if (p) modified.push(p);
     }
-    return { dirtyCount: dirty, untracked, exists: true };
-  } catch { return { dirtyCount: 0, untracked: [], exists: true }; }
+    return { dirtyCount: dirty, untracked, modified, exists: true };
+  } catch { return { dirtyCount: 0, untracked: [], modified: [], exists: true }; }
 }
 
 /** Count commits on HEAD not yet pushed to the upstream (default origin/main). */

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -1301,10 +1301,15 @@ export async function main(argv = process.argv) {
         continue;
       }
 
+      // SD-LEO-FEAT-DATA-LOSS-HIGH-001 (FR-2): preserve BOTH untracked AND modified-tracked files
+      // before the force-remove. Uncommitted edits to tracked files (the ~56-LOC data-loss class)
+      // were previously destroyed because only `untracked` was copied. Dedupe defensively. The
+      // preserve-before-delete contract is intact: if preservation throws, removal aborts.
+      const toPreserve = [...new Set([...(dirty.untracked || []), ...(dirty.modified || [])])];
       const preserve = preserveUntrackedFiles({
         wtPath,
         preserveRoot: opts.preserveRoot ? path.resolve(opts.preserveRoot) : null,
-        untracked: dirty.untracked,
+        untracked: toPreserve,
         repoRoot,
         logger: (m) => process.stderr.write(`  ${m}\n`),
       });

--- a/tests/unit/worktree-reapability-modified.test.js
+++ b/tests/unit/worktree-reapability-modified.test.js
@@ -1,0 +1,69 @@
+/**
+ * collectDirtyStatus.modified — SD-LEO-FEAT-DATA-LOSS-HIGH-001 (FR-1).
+ *
+ * The reaper's preserve-before-delete step copied ONLY untracked files; uncommitted edits to
+ * TRACKED files (the ~56-LOC data-loss class) were destroyed by `git worktree remove --force`.
+ * collectDirtyStatus now also returns `modified` (tracked changed paths) so the removal path can
+ * preserve them too. These tests pin the porcelain parse (modified vs untracked, renames,
+ * deletions, quoted paths) using an injected gitRunner — PURE, no real git.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { collectDirtyStatus } from '../../lib/worktree-reapability.js';
+
+const git = (stdout, code = 0) => () => ({ code, stdout, stderr: '' });
+
+describe('collectDirtyStatus.modified (FR-1)', () => {
+  let wt;
+  beforeAll(() => { wt = fs.mkdtempSync(path.join(os.tmpdir(), 'reap-mod-')); });
+  afterAll(() => { try { fs.rmSync(wt, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('splits tracked-modified from untracked', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git(' M lib/a.js\nM  lib/b.js\n?? new.txt\n') });
+    expect(s.modified).toEqual(['lib/a.js', 'lib/b.js']);
+    expect(s.untracked).toEqual(['new.txt']);
+    expect(s.dirtyCount).toBe(3);
+  });
+
+  it('rename keeps the NEW path', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git('R  old/x.js -> new/x.js\n') });
+    expect(s.modified).toEqual(['new/x.js']);
+  });
+
+  it('skips deletions (no working-tree file to preserve)', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git(' D gone.js\nD  staged-gone.js\n M kept.js\n') });
+    expect(s.modified).toEqual(['kept.js']);
+    expect(s.dirtyCount).toBe(3); // deletions still count as dirty
+  });
+
+  it('unquotes git-quoted special-char paths', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git(' M "lib/with space.js"\n') });
+    expect(s.modified).toEqual(['lib/with space.js']);
+  });
+
+  it('added (staged-new) tracked files are preserved', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git('A  lib/added.js\n') });
+    expect(s.modified).toEqual(['lib/added.js']);
+  });
+
+  it('clean tree → modified=[] untracked=[] dirtyCount=0 (no regression)', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git('') });
+    expect(s.modified).toEqual([]);
+    expect(s.untracked).toEqual([]);
+    expect(s.dirtyCount).toBe(0);
+  });
+
+  it('missing path → exists:false with empty modified', () => {
+    const s = collectDirtyStatus(path.join(wt, 'nope'), { gitRunner: git(' M x.js\n') });
+    expect(s.exists).toBe(false);
+    expect(s.modified).toEqual([]);
+  });
+
+  it('git error → fail-safe empty modified (never blocks)', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: git('', 128) });
+    expect(s.modified).toEqual([]);
+    expect(s.dirtyCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Closes a HIGH data-loss bug: worktree-reaper.mjs destroyed ~56 LOC of uncommitted work because its preserve-before-delete step copied **only untracked files** before `git worktree remove --force`. Uncommitted edits to **tracked** files were never preserved and were wiped.

The reaper has strong upstream guards (AC8 active-claim, activeQf/activeSd in_progress, idle unpushed-commit), but if any is bypassed — e.g. a claim lapses to the TTL reaper (dropping the worktree out of `v_active_sessions`), or a status flips terminal while edits remain — the dirty-tracked work was lost.

## Changes
- **FR-1** `lib/worktree-reapability.js`: `collectDirtyStatus` now returns `modified[]` (tracked changed paths; rename-aware → new path, deletions skipped, git-quoted paths unquoted). Pure (injected gitRunner); existing fields unchanged.
- **FR-2** `scripts/worktree-reaper.mjs`: removal loop preserves **both** untracked AND modified-tracked files (deduped) before remove. Preserve-before-delete contract intact (preservation failure still aborts removal).
- **FR-3** No regression: clean worktree reaps with zero preserved; untracked-only unchanged.

## Testing
8 new `collectDirtyStatus` tests + 12 reapability + 110 worktree-reaper suite = all green.

## Follow-up (flagged)
Defense-in-depth: the terminal/Stage-0 reclaim path bypasses the canonical `isReapable` predicate (which already refuses dirty/unpushed). Enforcing `isReapable` in the removal loop would *skip* dirty worktrees entirely rather than preserve-then-remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)