### PR TITLE
feat(SD-LEO-FEAT-TEST-FIXTURE-SDS-001): exclude test-fixture SDs from v_sd_next_candidates

### DIFF
--- a/database/migrations/20260620_v_sd_next_candidates_exclude_test_fixtures.sql
+++ b/database/migrations/20260620_v_sd_next_candidates_exclude_test_fixtures.sql
@@ -1,0 +1,98 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260620_v_sd_next_candidates_exclude_test_fixtures.sql
+--
+-- SD-LEO-FEAT-TEST-FIXTURE-SDS-001
+--
+-- Test-fixture SDs (TEST-*, SD-DEMO-RACE-*/SD-DEMO-*) created transiently by race-condition /
+-- lifecycle tests leak into v_sd_next_candidates, so an autonomous worker's self_claim grabs a
+-- phantom (often already-dropped) SD — wasting a claim cycle and, for remediation fixtures, a
+-- LEAD review. This adds two key-prefix exclusions to the work-selection view so fixture SDs never
+-- surface as next-candidate work. Real SDs are unaffected: every genuine SD is prefixed by a
+-- category (SD-LEO-*, SD-EHG-*, SD-FDBK-*, SD-MAN-*, QF-*, ...); neither 'TEST-%' nor 'SD-DEMO-%'
+-- matches them — notably SD-LEO-FEAT-TEST-FIXTURE-SDS-001 (this SD) starts with SD-LEO- and is NOT
+-- excluded.
+--
+-- The view body below is reproduced EXACTLY from the live definition
+-- (pg_get_viewdef('public.v_sd_next_candidates') as of 2026-06-20); the ONLY change is the two added
+-- final-WHERE predicates:
+--   AND sd.sd_key NOT LIKE 'TEST-%'
+--   AND sd.sd_key NOT LIKE 'SD-DEMO-%'
+-- The dependency_status CTE, the CASE/readiness_priority expression, and the ORDER BY are preserved
+-- verbatim. No other behavior is altered.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.v_sd_next_candidates AS
+ WITH active_baseline AS (
+         SELECT sd_execution_baselines.id
+           FROM sd_execution_baselines
+          WHERE sd_execution_baselines.is_active = true
+         LIMIT 1
+        ), dependency_status AS (
+         SELECT bi_1.sd_id,
+            bi_1.sequence_rank,
+            bi_1.track,
+            bi_1.dependencies_snapshot,
+            COALESCE(( SELECT count(*) = 0
+                   FROM jsonb_array_elements(
+                        CASE
+                            WHEN jsonb_typeof(bi_1.dependencies_snapshot) = 'array'::text THEN bi_1.dependencies_snapshot
+                            ELSE '[]'::jsonb
+                        END) dep(value)
+                     CROSS JOIN LATERAL ( SELECT
+                                CASE
+                                    WHEN jsonb_typeof(dep.value) = 'string'::text THEN split_part(dep.value #>> '{}'::text[], ' '::text, 1)
+                                    WHEN jsonb_typeof(dep.value) = 'object'::text THEN COALESCE(dep.value ->> 'sd_key'::text, dep.value ->> 'sd_id'::text, dep.value ->> 'orchestrator'::text)
+                                    ELSE NULL::text
+                                END AS ref) r
+                  WHERE r.ref IS NOT NULL AND lower(r.ref) <> 'none'::text AND (EXISTS ( SELECT 1
+                           FROM strategic_directives_v2 sd2
+                          WHERE (sd2.sd_key = r.ref OR sd2.id::text = r.ref) AND sd2.status::text <> 'completed'::text))), true) AS deps_satisfied
+           FROM sd_baseline_items bi_1
+          WHERE bi_1.baseline_id = (( SELECT active_baseline.id
+                   FROM active_baseline))
+        )
+ SELECT bi.sd_id,
+    sd.title,
+    sd.priority,
+    sd.status,
+    sd.progress_percentage,
+    bi.sequence_rank,
+    bi.track,
+    bi.track_name,
+    bi.estimated_effort_hours,
+    bi.dependency_health_score,
+    ds.deps_satisfied,
+    ea.status AS execution_status,
+    sd.is_working_on,
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END AS readiness_priority
+   FROM sd_baseline_items bi
+     JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key
+     JOIN dependency_status ds ON bi.sd_id = ds.sd_id
+     LEFT JOIN sd_execution_actuals ea ON bi.sd_id = ea.sd_id AND ea.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline))
+  WHERE bi.baseline_id = (( SELECT active_baseline.id
+           FROM active_baseline)) AND (sd.status::text <> ALL (ARRAY['completed'::character varying::text, 'cancelled'::character varying::text, 'deferred'::character varying::text]))
+    AND sd.sd_key NOT LIKE 'TEST-%'
+    AND sd.sd_key NOT LIKE 'SD-DEMO-%'
+  ORDER BY (
+        CASE
+            WHEN sd.is_working_on = true THEN 1
+            WHEN ea.status = 'in_progress'::text THEN 2
+            WHEN ds.deps_satisfied AND (sd.status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text])) THEN 3
+            WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+            ELSE 5
+        END), bi.sequence_rank;
+
+COMMIT;
+
+-- Rollback (manual): re-run CREATE OR REPLACE VIEW with the two
+--   AND sd.sd_key NOT LIKE 'TEST-%' / 'SD-DEMO-%'
+-- predicates removed from the final WHERE.

--- a/tests/unit/v-sd-next-candidates-fixture-exclusion.test.mjs
+++ b/tests/unit/v-sd-next-candidates-fixture-exclusion.test.mjs
@@ -1,0 +1,55 @@
+// Guards the test-fixture exclusion in the v_sd_next_candidates migration.
+// SD-LEO-FEAT-TEST-FIXTURE-SDS-001
+//
+// The exclusion lives in SQL (the view), so this guard (a) asserts the migration keeps BOTH
+// fixture-prefix predicates, and (b) pins the pure key-classification logic those predicates encode,
+// so a future view rewrite can't silently drop the exclusion or start matching real SD prefixes.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MIGRATION = resolve(REPO_ROOT, 'database/migrations/20260620_v_sd_next_candidates_exclude_test_fixtures.sql');
+
+// The exact predicates the view uses to exclude transient test fixtures.
+const FIXTURE_PREFIXES = ['TEST-', 'SD-DEMO-'];
+export function isTestFixtureSdKey(sdKey) {
+  const k = String(sdKey || '');
+  return FIXTURE_PREFIXES.some((p) => k.startsWith(p));
+}
+
+test('migration keeps BOTH fixture-prefix exclusions in the final WHERE', () => {
+  const sql = readFileSync(MIGRATION, 'utf-8');
+  assert.match(sql, /sd\.sd_key NOT LIKE 'TEST-%'/);
+  assert.match(sql, /sd\.sd_key NOT LIKE 'SD-DEMO-%'/);
+  // still a CREATE OR REPLACE of the right view (not an accidental DROP/rename)
+  assert.match(sql, /CREATE OR REPLACE VIEW public\.v_sd_next_candidates/);
+});
+
+test('classifier excludes the known transient fixtures', () => {
+  for (const k of ['TEST-LIFECYCLE-001', 'TEST-MGMT-FIXES-001', 'TEST-MGMT-VALIDATION-001', 'SD-DEMO-RACE-001', 'SD-DEMO-RACE-CONDITION-XYZ']) {
+    assert.equal(isTestFixtureSdKey(k), true, `${k} should be classified as a fixture`);
+  }
+});
+
+test('classifier does NOT exclude real SDs (incl. ones containing TEST/FIXTURE in the name)', () => {
+  for (const k of [
+    'SD-LEO-FEAT-TEST-FIXTURE-SDS-001', // THIS SD — contains TEST-FIXTURE but is real (SD-LEO- prefix)
+    'SD-LEO-INFRA-ASKUSER-GUARD-FAILOPEN-HARDEN-001',
+    'SD-EHG-COCKPIT-BUILD-001',
+    'SD-FDBK-INFRA-ADD-PRD-DATABASE-001',
+    'SD-MAN-INFRA-FOO-001',
+    'QF-20260620-001',
+  ]) {
+    assert.equal(isTestFixtureSdKey(k), false, `${k} must NOT be excluded`);
+  }
+});
+
+test('fixture prefixes never match a leading SD- category prefix (anchored at start only)', () => {
+  // 'SD-DEMO-' must match SD-DEMO-* but not e.g. a hypothetical SD-DEMONSTRATE (still SD-DEMO prefix
+  // — acceptable: no real category is 'DEMO'); and 'TEST-' is start-anchored so SD-...-TEST-... is safe.
+  assert.equal(isTestFixtureSdKey('SD-LEO-DEMO-001'), false); // 'DEMO' mid-key is not excluded
+  assert.equal(isTestFixtureSdKey('MY-TEST-001'), false);     // 'TEST' mid-key is not excluded
+});


### PR DESCRIPTION
## Summary
Transient test fixtures (`TEST-*`, `SD-DEMO-RACE-*`/`SD-DEMO-*`) leaked into the work-selection view `v_sd_next_candidates`, so autonomous /loop workers self_claimed phantom SDs — wasting claim cycles and (for remediation fixtures) LEAD reviews (`SD-LEO-FIX-REMEDIATION-UNIT-TEST-004` was dispatched to a worker this session).

## Change
- `CREATE OR REPLACE VIEW v_sd_next_candidates` adding two start-anchored exclusions to the final WHERE: `sd.sd_key NOT LIKE 'TEST-%'` AND `NOT LIKE 'SD-DEMO-%'`. The migration reproduces the **live** view definition verbatim (preserving the `dependency_status` CTE) and changes only the WHERE.
- Applied via the governed `apply-migration` 3-factor path (`MIGRATION_APPLY_PROD_PASS`). **Live-verified: 0 fixtures in the view, 6 real candidates, this SD still present.**
- 4-test guard pins both predicates + the pure key classification (real SDs incl. this one are never excluded).
- Reclassified feature→infrastructure at LEAD (a work-selection view fix has no user-facing surface).

## Verification
- Testing agent: 4/4 pass, live view fixtures=0 + real SDs retained.
- Adversarial review: **SHIP** — view-def fidelity confirmed (live matches migration), no over-match, reclassification legitimate. Noted scope: SD-LEO-prefixed remediation fixtures need a separate metadata predicate (currently 0 leaking) — flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)