### PR TITLE
docs(flywheel): end-to-end system-coherence map + protocol doc-pointer (row 608)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: b3b595e30e2a89d5 -->
+<!-- file_content_hash: fd7e57b24f18d378 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-20 12:35:55 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-20 5:27:00 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 674914d0689633e6 -->
+<!-- file_content_hash: 118e4d6b491fa4a5 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 5:27:00 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 56e89ecf400916c9 -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: 3d65295e1f134278 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 73e76493f9b982a8 -->
+<!-- file_content_hash: f1f20a8288fd39d9 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 5:27:00 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: cfdb2afcfa034e67 -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: facfcc333c2283c4 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 57d12c480d1c4aa6 -->
+<!-- file_content_hash: 0ae26b2a604ec74f -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 5:27:00 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1535,11 +1535,11 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 | Pattern ID | Category | Severity | Count | Trend | Top Solution |
 |------------|----------|----------|-------|-------|--------------|
+| PAT-HF-LEADTOPLAN-90e39736 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-HF-PLANTOEXEC-3e540545 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-RETRO-PLANTOEXEC-SD-EVA-F | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-RETRO-PLANTOLEAD-e8842331 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-HF-PLANTOLEAD-e8842331 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-RETRO-PLANTOEXEC-3e540545 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-RETRO-PLANTOEXEC-SD-EVA-F | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 
 ### Prevention Checklists
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 9562e5b9398168d9 -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: 2970d1a1c0d94919 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 5:27:00 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 098717c9a2f22e8e -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: 4265d04751458621 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 5:27:00 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 9c07d3e45d102907 -->
+<!-- file_content_hash: 710af571c047af82 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 5:27:00 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 607e9d986ccd43df -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: 63ddaac0d277d0e2 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 5:27:00 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 237ccc38b18ffa2a -->
+<!-- file_content_hash: 700e96f0c5996022 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 5:27:00 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 1c7c96fdf844aee6 -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: e66cec116279187b -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 5:27:00 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 8a1abe9605d22793 -->
+<!-- file_content_hash: af7745fe03e07537 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 5:27:00 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 6c6ffe0fad3bb5d2 -->
+<!-- generated_at: 2026-06-20T21:27:00.825Z -->
+<!-- git_commit: dc94cf45 -->
+<!-- db_snapshot_hash: c834d15d81f97da8 -->
+<!-- file_content_hash: 606ead4b8fd4fb7e -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 5:27:00 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,109 @@
 {
-  "generated_at": "2026-06-20T16:35:55.374Z",
-  "git_commit": "b46c1ebc",
-  "db_snapshot_hash": "8bb50c9305e12f02",
+  "generated_at": "2026-06-20T21:27:00.825Z",
+  "git_commit": "dc94cf45",
+  "db_snapshot_hash": "c834d15d81f97da8",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 19369,
-      "estimated_tokens": 4843,
-      "content_hash": "070a59945c9e3ca1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE.md"
+      "chars": 19368,
+      "estimated_tokens": 4842,
+      "content_hash": "da84efeff906e971",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 83528,
-      "estimated_tokens": 20882,
-      "content_hash": "bd3155e94d5cf19d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_CORE.md"
+      "chars": 83518,
+      "estimated_tokens": 20880,
+      "content_hash": "355c6e5c57779f54",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 65129,
-      "estimated_tokens": 16283,
-      "content_hash": "623dd9bbf37871cd",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_LEAD.md"
+      "chars": 65128,
+      "estimated_tokens": 16282,
+      "content_hash": "c5b17112394b6624",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 90831,
+      "chars": 90830,
       "estimated_tokens": 22708,
-      "content_hash": "37f11c916b304319",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_PLAN.md"
+      "content_hash": "150748851d6e7528",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 84822,
+      "chars": 84821,
       "estimated_tokens": 21206,
-      "content_hash": "f3b070923c62e1ad",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_EXEC.md"
+      "content_hash": "183f454f26903077",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 41261,
-      "estimated_tokens": 10316,
-      "content_hash": "804a634215e32d66",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_ADAM.md"
+      "chars": 41260,
+      "estimated_tokens": 10315,
+      "content_hash": "3fd687b299804d99",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 16619,
+      "chars": 16618,
       "estimated_tokens": 4155,
-      "content_hash": "b5624e4009409e19",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_COORDINATOR.md"
+      "content_hash": "cb596ee5053f347f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 9612,
+      "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "b81708bec34a1896",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_DIGEST.md"
+      "content_hash": "3d5fff1bd142e0c1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 11536,
+      "chars": 11535,
       "estimated_tokens": 2884,
-      "content_hash": "e053d01fcf91d881",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "3273288ea2f87428",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 5423,
+      "chars": 5422,
       "estimated_tokens": 1356,
-      "content_hash": "d4603c3ad7aad6a0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "3f54ef9f72a333d8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 8413,
-      "estimated_tokens": 2104,
-      "content_hash": "4d69e7fda5b9de94",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_PLAN_DIGEST.md"
+      "chars": 8412,
+      "estimated_tokens": 2103,
+      "content_hash": "58262c40a1b12f0e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 10836,
+      "chars": 10835,
       "estimated_tokens": 2709,
-      "content_hash": "2878a1e41d24cbb5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "c4b59d23cbd5e29b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "91cc6e0e77e1a938",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "85254e9c926ec754",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 3973,
       "estimated_tokens": 994,
-      "content_hash": "d4fa8b67015b2179",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "24ffb02704d9567c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "bacc644d2124040a",
+    "global": "3581033924ed4560",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -363,7 +363,8 @@
       "604": "67885bf567384f02",
       "605": "19e13f356fce24ab",
       "606": "25aa68b575c66d07",
-      "607": "82e04c0cc0ffb28f"
+      "607": "82e04c0cc0ffb28f",
+      "608": "7f99a4321502367e"
     },
     "meta": {
       "94": {
@@ -1660,6 +1661,11 @@
         "section_type": "adam_role_contract",
         "target_file": "CLAUDE_ADAM.md",
         "title": "SOURCING SSOT — order of operations"
+      },
+      "608": {
+        "section_type": "system_coherence",
+        "target_file": null,
+        "title": "LEO System Coherence — the Flywheel (doc pointer)"
       }
     }
   }

--- a/docs/flywheel/01-north-star.md
+++ b/docs/flywheel/01-north-star.md
@@ -1,0 +1,65 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, north-star, strategy]
+---
+
+# Link 1 — The North Star
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+The North Star is the single terminal target every other link points at. It is the top of the
+down-flow: the vision ladder (link 2) is the *path* to it, the OKRs (link 3) *measure* progress
+toward it, and the build gauge / forecast (links 10/12) report *how far / how fast*.
+
+## Source of truth (verified 2026-06-20)
+
+- **Table:** `north_star` (1 row, `status = 'chairman_ratified'`).
+- **Code reader:** `lib/vision/north-star.js`.
+- **Probe coupling:** the VDR capability *"A queryable, structured north star"* probes this
+  table directly (`row_predicate`, `table: 'north_star'`, `filter: { status: 'chairman_ratified' }`,
+  `builtWhen: 'exists'`) — so the north star being a *real, queryable, structured* record is
+  itself a measured V1 capability (`lib/vision/vdr-registry.js`, ~line 93–99). The probe was
+  deliberately repointed OFF the shared KR-2026-07-05 to avoid double-counting (FR-3 coherence
+  fix).
+
+## The live definition (read from the DB)
+
+| Field | Value |
+|-------|-------|
+| `definition` | "EHG income-replacement: monthly EHG monthly net profit of **$18,000/mo net**, sustained **6 consecutive qualifying months**. Leading sub-target: **10+ validated businesses**." |
+| `metric` | EHG monthly net profit |
+| `target` | `{ unit: "$/mo", amount: 18000, qualifier: "net" }` |
+| `status` | `chairman_ratified` |
+
+> Note: the canonical mission/vision prose (`docs/vision/ehg-mission-vision-canonical.md`)
+> describes the *end-state* qualitatively ("a handful (3–5) of self-operating businesses … the
+> Chairman in pure strategic oversight … deliberately not timeboxed"). The `north_star` **table**
+> is the *quantified, queryable* contract ($18k/mo net, 6 months, 10+ validated businesses). The
+> table is the machine-readable source of truth; the prose is the human narrative. They are
+> complementary, not contradictory — the prose is the *why*, the table is the *measurable target*.
+
+## Existing documentation
+
+- `docs/reference/schema/engineer/tables/north_star.md` — auto-generated schema reference (columns,
+  types). **Coverage: good (schema), but no flywheel context.**
+- `docs/04_features/ehg-northstar-contract-phase0.md` — the phase-0 contract feature doc.
+- `docs/vision/ehg-mission-vision-canonical.md` — the canonical prose mission/vision.
+
+## How it connects down and up
+
+- **Down:** the North Star is decomposed into the vision ladder's rungs ([02-vision-ladder.md]).
+  V1 is explicitly framed as the *income-replacement precursor* (see the V1 rung title), V2 as
+  *first revenue*, V3 as *portfolio scaled to the chairman quit-threshold*.
+- **Up:** the executive summary email ([15-executive-summary-email.md]) does **not** currently
+  print the north-star number directly (it was removed in the v3 email simplification, chairman
+  directive 2026-06-14); the email leads with the **build %** instead. The north-star target
+  remains the anchor that the V2/V3 rungs and the distance-to-quit instrumentation are built to
+  hit. **[Honesty flag]** The chairman's recurring surface today reports *build progress*, not
+  *income progress* — by design, because income is a V2/operational concern that is correctly 0
+  until a venture earns.

--- a/docs/flywheel/02-vision-ladder.md
+++ b/docs/flywheel/02-vision-ladder.md
@@ -1,0 +1,99 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, vision-ladder, rungs, buildable-operational]
+---
+
+# Link 2 — The Vision / Mission Ladder (V1 → V2 → V3)
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+The vision ladder turns the North Star into an **ordered, gated path**. Exactly one rung is
+active at a time; the active rung defines *what the fleet builds now*. The ladder is the spine
+that links 4 (roadmap), 10 (build gauge), 11 (prioritization) and 14 (governance) all hang off.
+
+## The three rungs (verified live, `vision_ladder_rungs`)
+
+| `rung_key` | `sequence` | `is_active` | Title (live) |
+|-----------|:--:|:--:|------|
+| **V1** | 1 | **true** | V1 — Capability-saturated, solo-operable EHG (income-replacement **precursor**) |
+| V2 | 2 | false | V2 — First revenue venture(s): distance-to-quit instrumented (named placeholder) |
+| V3 | 3 | false | V3 — Portfolio scaled to the chairman quit-threshold (named placeholder) |
+
+- **V1 = Foundation.** Build the machine + the product to the point of being capability-saturated
+  and solo-operable. This is a *precursor* to income, deliberately not income itself.
+- **V2 = Earning.** First revenue venture(s), distance-to-quit instrumented.
+- **V3 = Outcomes.** Portfolio scaled to the chairman quit-threshold.
+
+## Criteria (the rung's capability checklist)
+
+- **Table:** `vision_ladder_criteria` (26 rows total; the active V1 rung lists 21 capabilities
+  after the V1→V2 re-cut — see below). Columns: `rung_id`, `ordinal`, `capability`, `today`,
+  `required`, `nature`.
+- The active rung's criteria are read by `dbVisionSource()` (`vdr-registry.js`) — this is the
+  **denominator** for the build gauge. The gauge re-points automatically when the chairman
+  activates the next rung; no code edit needed.
+
+### Buildable vs operational `nature`
+
+Each capability has a deterministic `nature` (SD-LEO-INFRA-GAUGE-BUILDABLE-VS-OPERATIONAL-001):
+
+- **`buildable`** — the fleet can complete it by shipping code / populating a fleet table.
+- **`operational`** — only flips when a live VENTURE / OPERATION / CHAIRMAN / COMPETITIVE signal
+  makes it true (e.g. a KR that depends on live income, a running venture, live governance
+  enforcement). The fleet **cannot** make these true by shipping code alone.
+
+The reviewable source-of-truth is the **`OPERATIONAL_NATURE` Set** in
+`lib/vision/vdr-registry.js` (lines 212-219, with the fail-loud coherence invariant at 227-235). On the active V1 rung the operational set is **6**:
+
+1. `Solo-operator survivability` (KR-2026-07-02 — live breakage-caught rate)
+2. `A queryable, structured north star` (chairman-ratified record)
+3. `Governance cascade enforced` (KR-GOV-3.1 — live cascade)
+4. `OKR-driven prioritization + day-28 hard stop` (KR-GOV-3.3)
+5. `All 7 governance guardrails` (KR-GOV-3.2)
+6. `Competitive vigilance process established` (OBSERVED competitor baselines)
+
+A startup invariant **fails loud** if `OPERATIONAL_NATURE` names a capability not in the registry
+(`vdr-registry.js` ~229–235), so the taxonomy can't silently drift.
+
+### The V1→V2 re-cut (why some capabilities aren't measured yet)
+
+The chairman-ratified **SD-LEO-INFRA-VISION-LADDER-V1-V2-RECUT-001** moved **4 revenue/operating
+capabilities** off the active V1 rung onto the inactive V2 rung: *Take a real dollar*, *See
+distance-to-quit*, *Run a self-operating venture*, *Compound venture-level learning*. Their VDR
+probes are intentionally **absent** from the active set (a probe for an inactive rung would be a
+`staleProbe` that withholds the whole gauge); they return only **when V2 is activated**. This is
+the [progression-gate.md](progression-gate.md) principle in code.
+
+## Coherence enforcement (no drift)
+
+- **`assertRegistryCoherence`** (gating): the parsed vision capabilities and `VDR_REGISTRY` must
+  stay in lockstep — if a capability is added/removed/renamed, the gauge **withholds** (returns
+  `available:false`) rather than silently measure a wrong denominator.
+- **`placement-rules.js` + `assertLadderRoadmapCoherence`** (advisory): the
+  `REVENUE-NOT-IN-FOUNDATION` rule flags the 4 named revenue capabilities if they reappear on V1.
+  Advisory-only — it can never suppress the live chairman gauge.
+- Full write-up: `docs/vision/ladder-roadmap-coherence.md`.
+
+## Existing documentation
+
+- `docs/vision/ehg-mission-vision-canonical.md` — mission/vision prose. **Coverage: good (prose).**
+- `docs/vision/ladder-roadmap-coherence.md` — backward/forward coherence. **Coverage: good.**
+- `docs/reference/schema/engineer/tables/vision_ladder_rungs.md`, `vision_ladder_criteria.md` —
+  schema. **Coverage: good (schema).**
+- `lib/vision/vdr-registry.js`, `lib/vision/placement-rules.js` — the code source of truth.
+- **Gap:** no doc previously tied the *ladder → active rung → build gauge denominator* mechanics
+  together for a non-author reader. This doc + [10-vdr-build-gauge.md] fill it.
+
+## Connects to
+
+- **Up from:** North Star ([01-north-star.md]).
+- **Down to:** Roadmap waves ([04-roadmap-waves.md]) via `RUNG_BY_HORIZON`; build gauge
+  ([10-vdr-build-gauge.md]) via the active-rung denominator; prioritization
+  ([11-prioritization.md]) which scores active-rung-first.
+- **Controlled by:** chairman rung activation ([14-governance.md]).

--- a/docs/flywheel/03-okrs-key-results.md
+++ b/docs/flywheel/03-okrs-key-results.md
@@ -1,0 +1,81 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, okr, key-results, measurement]
+---
+
+# Link 3 — OKRs / Key Results
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+Key Results are the **measurement instrument for the outcome rungs (V2/V3)** — and for several
+operational-nature V1 capabilities. Where the build gauge (link 10) measures *buildable*
+capabilities by probing code/tables, OKRs measure *outcomes* (live signals: breakage-caught
+rate, governance cascade operational, income, distance-to-quit). They are how the system knows
+whether an *operational* capability has actually flipped.
+
+## Source of truth (verified 2026-06-20)
+
+- **`key_results`** (43 rows). Key columns: `objective_id`, `code` (e.g. `KR-GOV-3.1`),
+  `metric_type`, `baseline_value`, `current_value`, `target_value`, `direction`
+  (increase/decrease), `status`, `is_active`, `vision_dimension_code`.
+- **`sd_key_result_alignment`** (73 rows): links an SD to the key result(s) it contributes to
+  (`sd_id`, `key_result_id`, `contribution_type`, `contribution_weight`). This is how shipped
+  work is *credited* to an outcome — part of closing the loop (link 13).
+- **`roadmap_waves.okr_objective_ids`** (uuid[]): a wave's linked objectives — how an *outcome*
+  wave's progress is derived (see below).
+
+## The progress formula (verified in code)
+
+A single KR's progress %, mirroring the `v_okr_hierarchy` SQL view, is implemented purely in
+`lib/vision/rung-progress-rollup.mjs` `krProgressPct(kr)`:
+
+```
+reject if baseline/current/target is null      (Number(null)===0 would fabricate a span)
+b, cur, t = Number(baseline, current, target)
+decrease  = direction === 'decrease'
+denom     = decrease ? (b - t) : (t - b)
+if denom === 0 → null                            (zero span = undefined, never 0%-by-fiat)
+num       = decrease ? (b - cur) : (cur - b)
+pct       = clamp(0..100, num / denom * 100)
+```
+
+- `aggregateKrProgress(krRows)` = the mean over *measurable* KRs (nulls skipped, never coerced to
+  0). This is the **honesty doctrine**: an unmeasurable KR yields `null` + a reason, never a
+  fabricated 0%.
+
+## How KRs roll up into rung/wave progress
+
+`computeWaveRollup` (same module) decides each wave's `progress_pct` **type-aware**:
+
+- **Build rung** (the active rung, V1) → reuse `computeBuildGauge.build_pct` (link 10). Outcome
+  KRs are *not* used for the build rung.
+- **Outcome rung** (V2/V3) → mean of `aggregateKrProgress` over the KRs under the wave's
+  `okr_objective_ids`. If the wave has no linked objectives or no measurable KRs → `null` + reason
+  (honest, never 0%).
+
+So OKRs are the *measurement substrate* for the future (outcome) rungs, while the build gauge is
+the substrate for the present (foundation) rung. See [04-roadmap-waves.md] for how this writes
+`roadmap_waves.progress_pct`, and [15-executive-summary-email.md] for how it reaches the chairman.
+
+## Existing documentation
+
+- `docs/reference/schema/engineer/tables/key_results.md`, `sd_key_result_alignment.md`,
+  `okr_vision_alignment_records.md` — schema. **Coverage: good (schema).**
+- `database/migrations/20260104_okr_strategic_hierarchy.sql` — the `v_okr_hierarchy` formula
+  (the SQL the JS mirrors). **Coverage: good (code).**
+- **Gap:** no doc explained that OKRs measure the *outcome* rungs while the gauge measures the
+  *build* rung, nor traced the progress formula for a reader. This doc fills it.
+
+## Connects to
+
+- **Up from:** Vision ladder ([02-vision-ladder.md]) — KRs are the operational/outcome measure.
+- **Down to:** Roadmap waves ([04-roadmap-waves.md]) — `okr_objective_ids` drives outcome-wave %.
+- **Closes the loop:** `sd_key_result_alignment` credits shipped SDs to KRs ([13-feedback-learning.md]).
+- **Governance:** the monthly OKR generator parks generations for chairman acceptance
+  (`okr_generation_log`, surface 5 in `docs/governance/chairman-decision-surfaces.md`).

--- a/docs/flywheel/04-roadmap-waves.md
+++ b/docs/flywheel/04-roadmap-waves.md
@@ -1,0 +1,103 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, roadmap, waves, time-horizon]
+---
+
+# Link 4 — Roadmap → Waves
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+The roadmap is where the abstract vision ladder becomes an **executable sequence**. Rungs are
+sliced into **waves**; each wave holds **wave-items** (candidates sourced from the backlog); a
+wave-item is **promoted** into a claimable SD for the fleet. This is the hand-off from the
+strategy layer to the supply layer.
+
+## Source of truth (verified 2026-06-20)
+
+- **`strategic_roadmaps`** (2 rows). Columns include `vision_key`, `title`, `status`,
+  `current_baseline_version`.
+- **`roadmap_waves`** (12 rows). Key columns: `sequence_rank`, `title`, `status`,
+  `depends_on_wave_ids` (uuid[]), `okr_objective_ids` (uuid[]), `proposed_okrs` (jsonb),
+  `progress_pct`, `time_horizon` (now/next/later/eventually), `metadata` (may hold `rung_key`).
+- **`roadmap_wave_items`** (728 rows). Key columns: `wave_id`, `source_type`
+  (todoist/youtube/brainstorm/...), `source_id`, `title`, **`promoted_to_sd_key`** (NULL until
+  promoted to the belt), `priority_rank`, `item_disposition` (e.g. `pending`), `lane`.
+
+## time_horizon → rung mapping (the progression encoding)
+
+```
+RUNG_BY_HORIZON = { now: 'V1', next: 'V2', later: 'V3' }   // 'eventually' → null
+```
+
+(`lib/vision/rung-progress-rollup.mjs:20`.) Wave→rung resolution (`mapWaveToRung`): explicit
+`metadata.rung_key` wins; else the `time_horizon` map; else `null` (honest — never guessed). This
+mapping is *the* mechanism by which "where a wave sits on the timeline" equals "which rung it
+advances" — the heart of [progression-gate.md].
+
+## [Honesty flag] Two roadmap structures currently coexist
+
+A read of `roadmap_waves` on 2026-06-20 shows **two overlapping wave structures** in the same
+table:
+
+1. **The older "Engineering" set** — `Wave 1: Foundational AI Protocol & Engineering Core`,
+   `Wave 2: Strategic Research & Venture Evaluation (EVA)`, … `Wave 6: New Items`. These have
+   **`time_horizon = null`** and `progress_pct = 0`, so they do **not** map to a rung and do not
+   currently contribute measured progress.
+2. **The newer rung-aligned set** — `Wave 0: Distillation`, `Wave 1: EHG Foundation`,
+   `Wave 2: Revenue rails ready`, all `time_horizon='now'` (→ V1, progress ~57%); `Wave 3 (GATED):
+   First revenue push`, `Wave 4: Distance-to-quit live`, both `time_horizon='next'` (→ V2, ~20%);
+   `Wave 5 (V3): Scale to the chairman quit-threshold`, `time_horizon='later'` (→ V3, 0%).
+
+> **Implication for the chairman review:** the rung-aligned (now/next/later) waves are the ones
+> that drive the gauge/forecast and the progression gate. The older null-horizon "Engineering"
+> waves appear to be legacy/parallel structure. **Recommendation:** confirm whether the older set
+> should be retired, re-horizoned, or kept as a separate planning lens, so a reader isn't confused
+> by two "Wave 1"s. (This doc reports the state truthfully; it does not change any rows.)
+
+## How `progress_pct` is populated
+
+`runRollup` (`lib/vision/rung-progress-rollup.mjs`) writes `roadmap_waves.progress_pct`
+type-aware: build rung waves ← `computeBuildGauge.build_pct`; outcome rung waves ←
+`aggregateKrProgress` over `okr_objective_ids`. **DRY-RUN by default** (`apply:false`); only
+`--apply` persists, and only for rows with a non-null % (never a fabricated 0). The exec-summary
+email reads this rollup **DRY-RUN** (read-only) so the email never mutates roadmap state.
+
+## Promotion to the belt
+
+A wave-item becomes claimable fleet work when it is **promoted**:
+`node scripts/leo-create-sd.js --from-roadmap-item <id>` — the **register-first** path
+(`lib/sourcing-engine/register-first.js`) stamps the two-way roadmap↔SD provenance and sets
+`roadmap_wave_items.promoted_to_sd_key`. **684 of 728 unpromoted (live metric, as of 2026-06-20)** wave-items
+(`promoted_to_sd_key IS NULL`) — a large reservoir of sourced-but-not-yet-belted
+work. See [07-sourcing-engine.md] for the automated promotion path.
+
+> **[Gap — promotion has no target-repo routing]** Promotion via `leo-create-sd --from-roadmap-item`
+> provides no way to set the target repo: it accepts no `--target-repos` flag
+> (`leo-create-sd.js` `riKnownFlags` ~line 2685) and `deriveSdFieldsFromRoadmapItem`
+> (`lib/sourcing-engine/register-first.js:22`) sets no `target_application`, so `createSD` defaults
+> to `getCurrentVenture() || 'EHG_Engineer'` (`leo-create-sd.js` ~line 1902). Nothing FORBIDS EHG
+> (`ALLOWED_REPOS` includes it, line 86) — but there is no ROUTING mechanism, so EHG-product roadmap
+> items (Waves 2/3/4) default to the harness repo and cannot be promoted to `rickfelix/ehg`. The
+> product-promotion-pipeline SD addresses this by adding `--target-repos` to `--from-roadmap-item`
+> and/or deriving the target from the item's wave.
+
+## Existing documentation
+
+- `docs/reference/schema/engineer/tables/strategic_roadmaps.md`, `roadmap_waves.md`,
+  `roadmap_wave_items.md`, `roadmap_baseline_snapshots.md` — schema. **Coverage: good (schema).**
+- `docs/vision/ladder-roadmap-coherence.md` — wave↔rung coherence (advisory). **Coverage: partial.**
+- **Gap:** no doc explained the wave→rung mapping mechanics, the promotion mechanism, or the
+  two-coexisting-structures state. This doc fills it.
+
+## Connects to
+
+- **Up from:** Vision ladder ([02-vision-ladder.md]); OKRs ([03-okrs-key-results.md]).
+- **Down to:** Backlog intake ([05-backlog-intake.md]) feeds wave-items; the sourcing engine
+  ([07-sourcing-engine.md]) promotes them to the belt ([08-belt-coordinator-fleet.md]).
+- **Measured by:** the build gauge / rung rollup ([10-vdr-build-gauge.md]).

--- a/docs/flywheel/05-backlog-intake.md
+++ b/docs/flywheel/05-backlog-intake.md
@@ -1,0 +1,78 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, intake, conversion-ledger, backlog]
+---
+
+# Link 5 — Backlog Creation / Intake
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+Intake is the **funnel** that turns raw, heterogeneous ideas (the chairman's Todoist, YouTube
+playlists, brainstorms, the estate corpus, harness-backlog feedback, deferred SDs) into
+normalized, dispositioned candidates that can be placed on a roadmap wave. It is also where the
+**feedback loop re-enters** the down-flow (lessons captured at link 13 land here as
+`harness_backlog` feedback).
+
+## Source of truth (verified 2026-06-20)
+
+- **`conversion_ledger`** (624 rows) — the canonical intake ledger. Key columns: `source_pool`
+  (e.g. `todoist_todo`, `youtube_playlist`, …), `source_id`, `source_external_id`, `title`,
+  `normalized_priority`, `intake_status`, `disposition`, `triage_verdict`, `dedup_match_sd_key`,
+  `dedup_score`, `linked_sd_key`, `target_rung`, `lane`.
+- **`roadmap_wave_items`** (728) — the destination once a ledger item is placed on a wave (see
+  [04-roadmap-waves.md]).
+
+## The intake sources (the corpus)
+
+The proactive populator (`lib/sourcing-engine/proactive-populator.js`, `buildCorpus`) enumerates
+**4 canonical corpus inputs**, mapped to a LIVE-allowed `roadmap_wave_items.source_type`
+(`corpusSourceType`):
+
+| Source | Origin | Maps to source_type |
+|--------|--------|---------------------|
+| `todoist_todo` | Chairman's Todoist (via intake) | `todoist` |
+| `youtube_playlist` | YouTube intake | `youtube` |
+| estate corpus / sd_proposal / deferred-V2 / harness-backlog / Wave-6 | the estate + the harness's own backlog/feedback + deferred SDs | `brainstorm` (the live staging vehicle; migrates to `adam_direct` once the dormant `source_type` CHECK extension lands) |
+| (deferred SD cluster) | `strategic_directives_v2` rows reactivated draft→deferred | `brainstorm` |
+
+> **Gotcha encoded in code:** `roadmap_wave_items.source_id` is **UUID-typed**, but some sources
+> (notably deferred SDs whose `.id` is a varchar sd_key string) would throw `22P02` on insert and
+> silently drop. `toUuidSourceId()` derives a stable UUIDv5 so the same key always maps to the same
+> id (idempotency preserved). Documented here so future source-additions don't reintroduce the drop.
+
+## Disposition + dedup
+
+- **Disposition** (BUILD | RESEARCH | REFERENCE | CANCEL) is the item's lifecycle verdict — set by
+  `scripts/distill-backlog-dispositions.mjs` and surfaced as `sd_backlog_map.disposition`. It is
+  **distinct** from `lane` (the sourcing route — see [07-sourcing-engine.md]).
+- **Dedup**: `dedup-autostamp.js` stamps `dedup_match_sd_key` / `dedup_score` so an idea already
+  represented by a shipped SD is caught (the router's `DEDUP` lane). This is **dedup hygiene** —
+  see [progression-gate.md] for why it is distinct from "tapering."
+
+## Distillation precedes routing
+
+The chairman-Adam SSOT contract is explicit: if the relevant rung-waves have **no unpromoted
+items**, **distillation comes first** — groom raw backlog (`sd_backlog_map`) into waved,
+dispositioned candidates before reaching for the engine or (last-resort) gauge-mining. See
+[06-adam-sourcing.md].
+
+## Existing documentation
+
+- `docs/reference/schema/engineer/tables/conversion_ledger.md` — schema. **Coverage: good (schema).**
+- `docs/reference/brainstorm-metadata-convention.md`, `docs/reference/audit-to-sd-pipeline.md` —
+  adjacent intake conventions. **Coverage: partial (touches intake, not the full funnel).**
+- **Gap:** no doc enumerated all intake sources → conversion_ledger → wave-items as one funnel.
+  This doc fills it.
+
+## Connects to
+
+- **Up from:** Roadmap waves ([04-roadmap-waves.md]) — intake fills wave-items.
+- **Sourced by:** Adam ([06-adam-sourcing.md]) and the automated engine ([07-sourcing-engine.md]).
+- **Fed by the loop:** retro/learn/heal/signal → `feedback` (`category=harness_backlog`) re-enters
+  here ([13-feedback-learning.md]).

--- a/docs/flywheel/06-adam-sourcing.md
+++ b/docs/flywheel/06-adam-sourcing.md
@@ -1,0 +1,106 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, adam, sourcing, ssot, propose-only]
+---
+
+# Link 6 — How Adam Sources Work
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+Adam is the chairman's advisor/analyst and a **belt-supply** source. When the belt runs low, Adam
+finds candidates — but under a strict order of operations and a hard constitutional rule:
+**Adam PROPOSES, the coordinator DECIDES** (CONST-002 / propose-only). Adam executes directly only
+a chairman-directed task. Adam is `metadata.role='adam'` + `non_fleet=true` (excluded from worker
+counts / ETA / revival).
+
+## Source of truth (verified 2026-06-20)
+
+- **`CLAUDE_ADAM.md`** (generated from `leo_protocol_sections` id=601, section_type
+  `adam_role_contract`).
+- **`leo_protocol_sections` id=607** — "SOURCING SSOT — order of operations" (the canonical
+  contract; content read directly below).
+- **`.claude/commands/adam.md`**, **`scripts/adam-startup-check.mjs`** (the SOURCING SSOT STATE
+  startup probe), **`scripts/adam-advisory.cjs`** (the non-friction advisory lane).
+
+## The SSOT order of operations (canonical, from section 607)
+
+> Read this BEFORE sourcing anything. Work the sources **top-down**, stop at the first that yields:
+
+1. **Roadmap-as-SSOT first.** `roadmap_wave_items` + the rung roadmap are the FIRST candidate
+   source. Promote via `node scripts/leo-create-sd.js --from-roadmap-item <id>` (the
+   **register-first** path — never hand-recreate the provenance). The startup probe prints the
+   unpromoted count per wave. *(684 unpromoted (live metric) as of 2026-06-20.)*
+2. **Wave-0 distillation if rung-waves are empty.** Groom raw backlog (`sd_backlog_map`) into
+   waved, dispositioned candidates first; do **not** skip straight to gauge-mining. The probe
+   prints `sd_backlog_map` disposition %.
+3. **Check the sourcing-engine activation flags BEFORE hand-feeding.** The engine crons
+   (`SOURCING_ENGINE_V1`, `SOURCING_ROADMAP_ENGINE_V1`, `SOURCING_GAUGE_GAP_MINER_V1`,
+   `SOURCING_DEFERRED_WATCHER_V1`, `SOURCING_PROACTIVE_POPULATOR_V1`, `LEO_ROADMAP_AUTOSOURCE`)
+   populate the belt for you when ON. If they are **OFF**, **PROPOSE activation** — do not
+   substitute yourself for the dormant engine tick-after-tick (that masks the engine being off).
+
+   > **[State note — 2026-06-20]** The above is the canonical SSOT contract instruction. Per the
+   > corrected engine state ([07-sourcing-engine.md]), the 2 behavioral staging crons
+   > (deferred-watcher + gauge-gap-miner) are in fact **ACTIVE with flags ON in GitHub Actions**
+   > (commit 4ba41115 / PR #4933). A **local** `process.env` probe reports a **false "dormant"** —
+   > so "if they are OFF" should be confirmed against the workflow env, not a local probe, before
+   > proposing activation.
+4. **Hand-mining the VDR gauge is LAST-RESORT — and a SMELL.** Mining `computeBuildGauge` for
+   unbuilt capabilities by hand is the bottom of the list. Reaching for it means a layer above
+   failed; fix the upstream cause (propose engine activation / run distillation).
+
+> **[Gap — promotion has no target-repo routing]** Promotion via `leo-create-sd --from-roadmap-item`
+> provides no way to set the target repo: it accepts no `--target-repos` flag
+> (`leo-create-sd.js` `riKnownFlags` ~line 2685) and `deriveSdFieldsFromRoadmapItem`
+> (`lib/sourcing-engine/register-first.js:22`) sets no `target_application`, so `createSD` defaults
+> to `getCurrentVenture() || 'EHG_Engineer'` (`leo-create-sd.js` ~line 1902). Nothing FORBIDS EHG
+> (`ALLOWED_REPOS` includes it, line 86) — but there is no ROUTING mechanism, so EHG-product roadmap
+> items (Waves 2/3/4) default to the harness repo and cannot be promoted to `rickfelix/ehg`. The
+> product-promotion-pipeline SD addresses this by adding `--target-repos` to `--from-roadmap-item`
+> and/or deriving the target from the item's wave.
+
+> Why (from the contract): encoding the order in required-reading + surfacing live layer-state at
+> `/adam` startup makes the *route-the-SSOT-first* duty structurally impossible to miss, so the
+> "degrade to hand-mining" regression cannot recur each fresh session
+> (SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001).
+
+## Propose-only and the belt-supply exemption
+
+- **Default:** Adam proposes; the coordinator decides/dispatches. Adam never claims/drives/
+  dispatches fleet SDs.
+- **Exempt lane (chairman correction 2026-06-20):** belt **SUPPLY** — source / file / reactivate
+  deferred→draft — is Adam's autonomous lane; do it **verify-first + report**. Only **claim /
+  drive / dispatch** needs coordinator-go.
+- **Escalation aggregation:** Adam is the designated AskUserQuestion user and the escalation
+  aggregation point — workers proceed autonomously (never AskUser, it stalls them) → escalate to
+  Adam → Adam triages what reaches the chairman (urgent AskUser / phone-push / hourly exec email).
+  Protects the chairman's attention.
+
+## D1 proactive sourcing
+
+Adam's "D1 proactive sourcing" duty is the scheduled belt-refill check that runs the SSOT order
+above. The startup probe (`adam-startup-check.mjs`) prints the **SOURCING SSOT STATE** badge:
+unpromoted `roadmap_wave_items` by wave, the 6 engine flags, and `sd_backlog_map` disposition %.
+
+## Existing documentation
+
+- `CLAUDE_ADAM.md` + `leo_protocol_sections` id=601/604/606/607 — the role contract. **Coverage: good.**
+- `docs/protocol/coordinator-adam-comms.md` — Adam↔coordinator comms. **Coverage: good.**
+- `docs/protocol/README.md` (the LEO Harness overview) — Adam role summary. **Coverage: good.**
+- **Gap:** the *sourcing* SSOT order existed only in the DB section + CLAUDE_ADAM.md; this doc
+  surfaces it in the flywheel context so a non-Adam reader sees where Adam sits in the chain.
+
+## Connects to
+
+- **Up from:** Roadmap waves ([04-roadmap-waves.md]) — Adam routes the SSOT.
+- **Sources from:** Backlog intake ([05-backlog-intake.md]).
+- **Hands to:** the coordinator ([08-belt-coordinator-fleet.md]) — propose, not dispatch.
+- **Complemented by:** the automated engine ([07-sourcing-engine.md]) — when ON, the engine does
+  Adam's belt-refill automatically.
+- **Reports up via:** the executive summary email ([15-executive-summary-email.md]).

--- a/docs/flywheel/07-sourcing-engine.md
+++ b/docs/flywheel/07-sourcing-engine.md
@@ -1,0 +1,107 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, sourcing-engine, belt, automation, crons-active, env-probe-false-negative]
+---
+
+# Link 7 — Automated Belt Feed (the Sourcing Engine)
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+The sourcing engine is the **automated replacement for Adam's manual belt-refill** (link 6). When
+its flags are ON, cron sweeps continuously enumerate the corpus, classify+route each candidate to
+a lane, dedup, stage into `roadmap_wave_items`, and (where chairman-approved) promote to claimable
+SDs — keeping the belt full without a human in the loop. It is the forward complement to the
+backward coherence enforcement (drift prevented at the source).
+
+> **[ENGINE STATE — CRITICAL, corrected 2026-06-20]** The 2 behavioral staging crons (Sourcing
+> **deferred-watcher** + Sourcing **gauge-gap miner**) are **REGISTERED + ACTIVE with their flags ON
+> in GitHub Actions** (commit 4ba41115 / PR #4933). The local-env flag probe (`adam-startup-check`
+> + the forecaster awareness module) reads `process.env` — which **never carries the GitHub-Actions
+> workflow env** — so it reports a **FALSE "dormant."** That false-negative is itself a known gap
+> (the probe should read the deployed workflow env / a DB `engine_state` row). As of 2026-06-20 the
+> crons are **ARMED** but had **not yet been observed firing** (GitHub new-schedule latency); a
+> manual `workflow_dispatch` confirms execution. NOTE the 4 umbrella `SOURCING_*` flags remain a
+> **display/registry only**.
+>
+> An activation runbook exists at `docs/sourcing-engine-activation-runbook.md`
+> (SD-LEO-INFRA-SOURCING-ENGINE-ACTIVATION-001) documenting the chairman-authorized go-live + how
+> to revert each step.
+
+## Components (verified — `lib/sourcing-engine/*`)
+
+| File | Role |
+|------|------|
+| `router.js` | **PURE** `routeCandidate()` — maps a classified candidate to exactly ONE of 5 lanes. No LLM, no IO. |
+| `lane.js` | The `lane` first-class field persistence (distinct from `disposition`). |
+| `proactive-populator.js` | Enumerates the 4-source corpus, classifies+routes, **stages** `roadmap_wave_items` (dry-run default; chairman-double-gated). |
+| `dedup-autostamp.js` | Stamps dedup match/score so shipped work isn't re-minted (the `DEDUP` lane). |
+| `register-first.js` | The `--from-roadmap-item` promotion path; stamps two-way roadmap↔SD provenance. |
+| `adam-direct-registry.js` | Adam-direct candidate registration + `resolveTargetWaveId`. |
+| `deferred-watcher.js` | Watches deferred SDs to re-surface them as candidates. |
+| `gauge-gap-miner.js` | Turns the read-only VDR gauge into a forward router (mines unbuilt caps → staged candidates). |
+| `outcome-decomposer.js` | Decomposes outcome-rung work. |
+| `escalator.js` | Escalation routing. |
+
+## The 5 lanes (`router.js`, frozen vocabulary)
+
+| Lane | Meaning |
+|------|---------|
+| `belt-ready` | fleet-buildable + conflict-free + non-gated + novel → goes to the belt |
+| `blocked-on` | dep / write-surface conflict with an in-flight SD |
+| `chairman-gated` | needs chairman authority (grant/rls/credential/operational/vision) |
+| `outcome-gated` | needs an operational outcome before it is buildable (V2/V3-class) |
+| `dedup` | already represented by an existing SD |
+
+`lane` is **distinct from `disposition`** (BUILD/RESEARCH/REFERENCE/CANCEL). The router passes
+disposition through unchanged and never overloads it.
+
+## The crons / flags (env-driven)
+
+These are **environment flags read via `process.env`** (NOT rows in `leo_feature_flags`):
+
+- `SOURCING_ENGINE_V1`, `SOURCING_ROADMAP_ENGINE_V1`, `SOURCING_PROACTIVE_POPULATOR_V1`
+- `SOURCING_GAUGE_GAP_MINER_V1` (gates `scripts/sourcing-engine/gauge-gap-miner-sweep.mjs`)
+- `SOURCING_DEFERRED_WATCHER_V1` (gates `scripts/sourcing-engine-deferred-watcher-sweep.mjs`)
+- `LEO_ROADMAP_AUTOSOURCE` (checked by `scripts/adam-startup-check.mjs`)
+
+Each sweep checks its flag and prints `SUPPRESSED_FLAG_OFF` when the flag is not enabled. In
+**GitHub Actions** the deferred-watcher + gauge-gap-miner crons run with their flags **ON** (commit
+4ba41115 / PR #4933), so they execute on schedule there. The caveat (see the ENGINE STATE callout
+above): a **local** `process.env` probe cannot see the workflow env, so a local read reports a
+**false "dormant"** even while the crons are armed in CI.
+
+## Hard safeguards (staging is conservative)
+
+From `proactive-populator.js`: writes require `apply=true` **AND** `chairmanApproved=true`. Staging
+only ever **INSERTs** `roadmap_wave_items` at `item_disposition='pending'` (the STAGED state) — it
+**never** sets `promoted_to_sd_key` (never promotes staged→belt automatically) and **never** creates
+an SD. Idempotent on `UNIQUE(wave_id, source_type, source_id)`. Dormant-safe (lane column omitted
+when absent). So even fully activated, the populator stages candidates for review; promotion to the
+belt remains a deliberate `--from-roadmap-item` act.
+
+## Promotion to the belt
+
+`node scripts/leo-create-sd.js --from-roadmap-item <id>` → register-first stamps provenance + sets
+`roadmap_wave_items.promoted_to_sd_key` → the SD becomes claimable (the "belt"). See
+[08-belt-coordinator-fleet.md].
+
+## Existing documentation
+
+- `docs/sourcing-engine-activation-runbook.md` — activation + revert. **Coverage: good (ops).**
+- `docs/vision/ladder-roadmap-coherence.md` — the engine as the *forward complement*. **Coverage: good.**
+- `docs/reference/schema/engineer/tables/conversion_ledger.md`, `roadmap_wave_items.md` — schema.
+- **Gap:** no doc enumerated the engine's components, lanes, flags, and safeguards as one picture
+  for a reader. This doc fills it.
+
+## Connects to
+
+- **Up from / replaces:** Adam's manual sourcing ([06-adam-sourcing.md]).
+- **Sources from:** Backlog intake ([05-backlog-intake.md]) corpus.
+- **Feeds:** the belt ([08-belt-coordinator-fleet.md]).
+- **Steered by:** the build gauge ([10-vdr-build-gauge.md]) via the gauge-gap-miner.

--- a/docs/flywheel/08-belt-coordinator-fleet.md
+++ b/docs/flywheel/08-belt-coordinator-fleet.md
@@ -1,0 +1,80 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, belt, coordinator, fleet, dispatch, capacity]
+---
+
+# Link 8 — Belt → Coordinator → Fleet
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+This is where *sourced work becomes executing work*. The **belt** is the queue of claimable SDs;
+the **coordinator** dispatches conflict-free work to live workers and keeps the belt full; the
+**fleet** of ~6 workers each claim exactly one SD and drive it through LEO execution (link 9). The
+coordinator's prime KPI: **an idle worker while sourceable work exists is a failure.**
+
+> This link is already documented thoroughly in **`docs/protocol/README.md`** ("The LEO Harness").
+> This page is the *flywheel-context bridge*; for full role specs follow the cross-links below
+> rather than duplicating them here.
+
+## Source of truth (verified)
+
+- **Code:** `lib/coordinator/*` (`dispatch.cjs` fail-closed, `resolve.cjs`, `signal-router.cjs`),
+  `scripts/coordinator-audit.mjs`, `scripts/coordinator-startup-check.mjs`,
+  `scripts/stale-session-sweep.cjs`, `scripts/fleet-dashboard.cjs`, `scripts/worker-checkin.cjs`.
+- **Tables:** `claude_sessions` (liveness: `heartbeat_at`, `loop_state`, `sd_key`, `metadata`),
+  `session_coordination` (the message bus), `strategic_directives_v2` (claim fields).
+- **Docs:** `docs/protocol/README.md`, `docs/protocol/fleet-coordinator-and-worker-behavior.md`,
+  `docs/protocol/fleet-worker-loop-directive.md`, `docs/reference/fleet-coordination.md`,
+  `.claude/commands/coordinator.md`, `.claude/commands/checkin.md`.
+
+## The belt (claimable-SD queue)
+
+A "belt" SD is a `strategic_directives_v2` row that is sourced, promoted
+(`roadmap_wave_items.promoted_to_sd_key` set), and not yet claimed. Workers pull from it via the
+tiered self-claim ladder in `worker-checkin.cjs`: resume current claim → coordinator
+`WORK_ASSIGNMENT` → stranded-final recovery → baselined queue → un-baselined draft → quick-fix →
+idle. Claims are atomic via the `claim_sd` RPC (one at a time; foreign-holder rejection;
+stale-takeover at ≥900s heartbeat age).
+
+## The coordinator (manager / SRE)
+
+Runs hands-free on cron loops with four SRE duties: **resource-pool management** (keep the belt
+full), **liveness supervision** (judge by `loop_state`, not heartbeat age), **flow + silent-failure
+detection**, **dependency watching**. It **dispatches** (never builds), **sweeps** dead
+claims/worktrees every 5 min, **revives** dead workers (requests a spawn), and **escalates** genuine
+human questions to the chairman via the executive email. **No agent calls another directly** — every
+interaction is a `session_coordination` row.
+
+## Capacity forecaster / belt-low detection
+
+The coordinator's capacity forecaster surfaces when the belt is running low ("belt-low") and, before
+hand-asking Adam, checks the **sourcing engine state first** (engine flags + unpromoted
+`roadmap_wave_items` count) — perpetual manual backfill is an anti-pattern
+(SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001). When belt-low + engine OFF + unpromoted
+items exist, the forecaster nudges *activate/distill* rather than asking a human to hand-mine. The
+needle-movement rank (link 11) and the build forecast (link 12) also feed the coordinator's backlog
+ordering.
+
+## Existing documentation
+
+- `docs/protocol/README.md` — the canonical harness overview. **Coverage: good.**
+- `docs/protocol/fleet-coordinator-and-worker-behavior.md`, `fleet-worker-loop-directive.md`,
+  `coordinator-worker-revival.md`. **Coverage: good.**
+- `docs/reference/fleet-coordination.md`, `docs/reference/worker-registry-guide.md`,
+  `docs/reference/heartbeat-manager.md`. **Coverage: good.**
+- **Gap (filled here):** none of the above placed the belt/coordinator/fleet *inside* the broader
+  vision→roadmap→sourcing flywheel. This page is that bridge.
+
+## Connects to
+
+- **Up from:** the sourcing engine / Adam fill the belt ([07-sourcing-engine.md], [06-adam-sourcing.md]).
+- **Down to:** LEO execution — a claimed SD runs LEAD→PLAN→EXEC ([09-leo-execution.md]).
+- **Ordered by:** prioritization ([11-prioritization.md]); informed by the forecast
+  ([12-forecasting.md]).
+- **Reports up via:** the executive summary email's worker count ([15-executive-summary-email.md]).

--- a/docs/flywheel/09-leo-execution.md
+++ b/docs/flywheel/09-leo-execution.md
@@ -1,0 +1,84 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, leo-protocol, lead-plan-exec, gates, handoffs]
+---
+
+# Link 9 — LEO Execution (LEAD → PLAN → EXEC)
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+This is the **per-worker workflow** — how a single worker turns one claimed SD into a shipped PR.
+Where link 8 (the harness) is *that* work flows, LEO execution is *how* a single SD is built. Its
+output (a merged PR + gate-validated phase records) is what the build gauge (link 10) later measures
+and what the learning loop (link 13) reflects on.
+
+> This link is documented authoritatively in **`CLAUDE.md`** + **`CLAUDE_CORE/LEAD/PLAN/EXEC.md`**
+> (all generated from `leo_protocol_sections`). This page is the flywheel bridge; for the binding
+> rules, read those files.
+
+## Source of truth (verified)
+
+- **Protocol files:** `CLAUDE.md` (orchestrator router), `CLAUDE_CORE.md`, `CLAUDE_LEAD.md`,
+  `CLAUDE_PLAN.md`, `CLAUDE_EXEC.md` — **generated from `leo_protocol_sections`** (the DB is the
+  source of truth; the .md files are artifacts).
+- **State tables:** `strategic_directives_v2` (SD state/phase/claim), `product_requirements_v2`
+  (PRDs), `sd_phase_handoffs` (gate-validated transitions), `sub_agent_execution_results` (formal
+  sub-agent evidence — gates query this).
+- **Process scripts:** `scripts/handoff.js`, `scripts/add-prd-to-database.js`,
+  `scripts/leo-create-sd.js`.
+
+## The three phases
+
+| Phase | Concern | Artifact |
+|-------|---------|----------|
+| **LEAD** | Strategy: approve + scope the SD | strategic intent in `strategic_directives_v2` |
+| **PLAN** | Architecture: produce the PRD, validate gates | `product_requirements_v2` |
+| **EXEC** | Implementation: ship code + tests | the merged PR |
+
+Transitions are **phase handoffs** (`node scripts/handoff.js execute <PHASE> <SD-ID>`) that run the
+full gate pipeline and write canonical phase state. A non-final handoff is **TERMINAL** — phase work
+must be written to the DB before the next phase begins.
+
+## Gates + sub-agent evidence (the verification oracle)
+
+- The **gate pipeline + `sub_agent_execution_results`** are the external verification oracle a worker
+  must satisfy before a phase advances — *"manual DB checks are not evidence; the row is."* This
+  embodies the 2026 best practice that **the agent doing the work must not be the agent deciding it's
+  done.**
+- Required sub-agents are invoked via the Task tool **before** `handoff.js execute`; the handoff
+  blocks with `SUBAGENT_EVIDENCE_MISSING` if no fresh row exists for the current phase.
+- Target gate pass rate: 85% (SD-type overrides 60–90% with documented justification).
+- The **post-completion-tail Stop hook** is the harness's "Ralph loop": it re-injects `/document →
+  /heal → /learn` when a worker claims done (feeding link 13), rather than letting it stop on a
+  self-declared completion.
+
+## Where it sits relative to the gauge
+
+LEO execution **builds** the capabilities; it does **not** measure them. The VDR build gauge (link
+10) probes *live signals* (code presence, table counts, KR status) independently of whether a
+handoff said "done" — so a worker cannot inflate the gauge by declaring completion. Shipped work
+moves the gauge only when the live probe actually flips. This separation is deliberate (anti-honesty-
+lie doctrine).
+
+## Existing documentation
+
+- `CLAUDE*.md` + `leo_protocol_sections` — **Coverage: good (canonical).**
+- `docs/leo/` (phases, gates, handoffs, sub-agents, commands, api). **Coverage: good.**
+- `docs/protocol/README.md` — protocol-vs-harness boundary. **Coverage: good.**
+- `docs/reference/validation-gate-registry.md`, `error-code-catalog.md`, `handoff-state-machines.md`.
+- **Gap (filled here):** the relationship *LEO execution builds → the gauge independently measures →
+  the loop reflects* was implicit. This page makes it explicit in flywheel context.
+
+## Connects to
+
+- **Up from:** a claimed belt SD ([08-belt-coordinator-fleet.md]).
+- **Produces:** a shipped PR → measured by the build gauge ([10-vdr-build-gauge.md]).
+- **Feeds the loop:** `/document → /heal → /learn` + retros ([13-feedback-learning.md]);
+  `sd_key_result_alignment` credits the SD to a KR ([03-okrs-key-results.md]).
+- **Bounded by:** the five Canonical Pause Points + chairman authority ([14-governance.md]).

--- a/docs/flywheel/10-vdr-build-gauge.md
+++ b/docs/flywheel/10-vdr-build-gauge.md
@@ -1,0 +1,112 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, vdr, build-gauge, measurement, computeBuildGauge]
+---
+
+# Link 10 — VDR Build Gauge
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+The Vision Denominator Registry (VDR) build gauge is the system's **"% built" instrument** for the
+**active rung**. It is the steering signal: it tells the chairman how far V1 is, drives the
+forecast (link 12), feeds prioritization's "needle-movers" (link 11), and leads the executive email
+(link 15). Crucially it is **measured independently of any "done" declaration** — it probes live
+signals, so completion can't be faked.
+
+## Source of truth (verified — `lib/vision/vdr-registry.js`, 546 lines)
+
+- **`computeBuildGauge({ io, visionSource })`** — the gauge function.
+- **`VDR_REGISTRY`** — one entry per capability `{ capability, layer, probe, nature }`.
+- **`vision_build_gauge`** table (85 rows) — the historized results. Latest read 2026-06-20:
+  **`overall_pct = 55`, `available = true`.**
+- **`vdr-probes.js`** — the typed probe runner (`row_predicate`, `kr_status`, `code_grep`,
+  `db_count`, `count_ratio`).
+
+## The calculation (traced)
+
+**Denominator** = the active rung's REQUIRED capabilities, read from the DB via `dbVisionSource(io)`:
+`vision_ladder_rungs WHERE is_active` → `vision_ladder_criteria` (ordered by `ordinal`). The gauge
+re-points automatically when the chairman activates the next rung.
+
+**Numerator** = one **typed probe per capability** run against **live signals** (no LLM in steady
+state). Each probe returns a status scored by `STATUS_SCORE`:
+
+```
+built: 1   ·   partial: 0.5   ·   unbuilt: 0   ·   unknown: null  (EXCLUDED from the denominator)
+```
+
+**`overall_pct`** = `round(100 × Σ score / count(scored))` over capabilities whose status is **not**
+`unknown`. Unknowns are excluded so the % is **never fabricated** — and if *zero* capabilities are
+probeable (e.g. DB unreachable), the gauge returns `available:false` / `overall_pct:null`, NOT a
+confident false 0%.
+
+**Per-layer** breakdown over `LAYERS = [infrastructure, application, venture, process]`.
+
+### Buildable vs operational split (the anti-conflation guard)
+
+`computeBuildGauge` additionally computes (using each entry's `nature`):
+
+- **`build_pct`** = % over **buildable** capabilities only — *the honest "fleet-build" number* the
+  chairman cares about.
+- **`operational_pct`** + `operational_status` = the operational set's honest band, shown
+  **separately** (built/awaiting/unmeasured) so it is never silently dragged to 0 nor folded into
+  the build number.
+
+This is why the email can say *"V1 foundation: NN% built (buildable) — NN% operational — income/
+north-star tracked separately on V2."* See [progression-gate.md] for why this split matters.
+
+### Probe types in the registry (examples, verified)
+
+| Capability (example) | Probe | Notes |
+|----------------------|-------|-------|
+| A queryable, structured north star | `row_predicate` on `north_star` (status chairman_ratified) | link 1 coupling |
+| Solo-operator survivability | `kr_status` KR-2026-07-02 | operational |
+| Capability Registry | `db_count` `sd_capabilities` min 50 | population proxy |
+| The cockpit | `code_grep` repo `ehg` (7 shipped surfaces) | product-side; `present` capped at PARTIAL |
+| Backlog distilled and dispositioned | `count_ratio` `sd_backlog_map` disposition not null | fail-soft to unknown if column absent |
+
+> **Anti-inflation rule:** `code_grep` `present` is honestly capped at **partial (0.5)**, never
+> `built` — code presence is *intent*, not a *live realization*. Promoting to `built` requires a
+> live coverage/enforce probe.
+
+## Coherence gating
+
+If the parsed vision capabilities and `VDR_REGISTRY` have **drifted**
+(`assertRegistryCoherence().ok === false`), the gauge **withholds** (returns `available:false`)
+rather than measure a wrong denominator. Ladder/roadmap placement coherence
+(`assertLadderRoadmapCoherence`) is computed every run but is **advisory-only** — it can never
+suppress the live gauge.
+
+## Display mapping (single source)
+
+`formatGaugeForSummary(gauge)` is the **single** display mapping shared by the exec-summary email
+(link 15) AND the Chairman-UI tile — so both render the same number the same way (no divergence). It
+emits `buildLine`, `rungLine`, `operationalLine`, `rungNatureLine`, `layerLine`, `note`.
+
+## Rung rollup reuse
+
+`runRollup` (`rung-progress-rollup.mjs`) reuses **this exact gauge** (`computeGaugeFn` thunk → no
+second compute, no divergence) to populate `roadmap_waves.progress_pct` for the build rung — see
+[04-roadmap-waves.md].
+
+## Existing documentation
+
+- `docs/reference/schema/engineer/tables/vision_build_gauge.md` — schema. **Coverage: good (schema).**
+- `docs/reference/vision/`, `docs/reference/vision-fidelity-gate.md` — adjacent vision-gate docs.
+- `docs/vision/ladder-roadmap-coherence.md` — the per-rung/per-nature reporting. **Coverage: good.**
+- **Gap (filled here):** no doc traced the gauge calculation (denominator/numerator/scoring/buildable
+  split/coherence-gating) for a reader. This doc fills it.
+
+## Connects to
+
+- **Up from:** the active rung's criteria ([02-vision-ladder.md]); measures shipped work
+  ([09-leo-execution.md]).
+- **Feeds:** the forecast ([12-forecasting.md]), prioritization ([11-prioritization.md]), the
+  rung rollup ([04-roadmap-waves.md]), and the exec email ([15-executive-summary-email.md]).
+- **Steers sourcing:** the gauge-gap-miner mines this gauge for unbuilt caps ([07-sourcing-engine.md]).

--- a/docs/flywheel/11-prioritization.md
+++ b/docs/flywheel/11-prioritization.md
@@ -1,0 +1,76 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, prioritization, needle-movement, unlock-score]
+---
+
+# Link 11 — Prioritization
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+Prioritization decides **which** unbuilt work the fleet does first. It orders work
+**active-rung-first**, then **highest-impact-on-rung-completion-first** — so the fleet always moves
+the needle on the rung that is actually active (V1 today), and within that rung favors the wave
+closest to completion. This is the operational expression of [progression-gate.md].
+
+## Source of truth (verified — `lib/vision/needle-priority.mjs`, 78 lines)
+
+A thin, **PURE** scoring layer that REUSES the rung rollup (link 4/10), not a new measurement
+system.
+
+### `needleScore(sdRung, ctx)` — the calculation
+
+```
+if sdRung is null/unknown          → 0          (neutral; keep existing order, never guess a rung)
+base = (sdRung === activeRungKey) ? 2 : 1        (active rung 2; known future rung 1)
+bonus = clamp(0..100, rungProgressByKey[sdRung]) / 1000   → 0..0.1   (completion tiebreak)
+score = base + bonus
+```
+
+- **Tiers never cross:** the completion bonus is capped at 0.1, so an active-rung SD (≥2.0) always
+  outranks a future-rung SD (≤1.1), which always outranks an unknown-rung SD (0). Within a tier, the
+  rung *closer to completion* edges up (highest-impact-on-rung-completion-first).
+- **Honesty:** an SD whose rung can't be resolved scores 0 and falls back to its existing rank — it
+  is never guessed onto a rung.
+
+### Supporting functions
+
+- `rungProgressByKey(rollupRows)` — folds `runRollup` rows into `{ [rung_key]: progress_pct }`
+  (null progress skipped, never coerced to 0; highest measured % wins per rung).
+- `buildSdRungMap(waveItems, wavesById)` — maps each promoted SD key to its rung by reusing
+  `mapWaveToRung` (skips unpromoted / unmappable — honest, no guess).
+
+## Where it plugs in
+
+- **Coordinator backlog rank** — the needle-movement comparator is wired into
+  `coordinator-backlog-rank` *after* the unlock_score (SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-
+  PRIORITIZATION-001-C), so the coordinator dispatches the highest-needle work first.
+- **Unlock score** — the pre-existing dependency-unlock heuristic (an SD that unblocks many others
+  ranks higher); needle-movement refines the order on top of it.
+- **Adam forecaster / belt-low** — the belt-low message surfaces the needle ranking too.
+
+## [Current-state note]
+
+Needle-movement is **LATENT-live**: it is wired and tested, but its effect is proportional to how
+many SDs are promoted from rung-mapped waves. With 684 unpromoted wave-items (live metric, as of 2026-06-20) and the rung-aligned
+waves still filling, its influence grows as the now/next/later waves get promoted to the belt.
+(Verified-honest: the code is shipped; the ranking has limited material effect until more rung-mapped
+SDs are on the belt.)
+
+## Existing documentation
+
+- `docs/reference/central-planner.md`, `docs/reference/severity-weighted-pattern-prioritization.md`
+  — adjacent prioritization heuristics. **Coverage: partial (not the rung-first needle rank).**
+- **Gap (filled here):** no doc traced the needle-movement score or its active-rung-first tiering.
+  This doc fills it.
+
+## Connects to
+
+- **Up from:** the rung rollup ([04-roadmap-waves.md]) + the build gauge ([10-vdr-build-gauge.md]).
+- **Plugs into:** the coordinator's dispatch order ([08-belt-coordinator-fleet.md]).
+- **Expresses:** the progression gate ([progression-gate.md]) — active-rung-first.

--- a/docs/flywheel/12-forecasting.md
+++ b/docs/flywheel/12-forecasting.md
@@ -1,0 +1,130 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, forecasting, eta, ewma, self-correcting]
+---
+
+# Link 12 — Forecasting (Build-Completion ETA)
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+The forecaster estimates the **date the BUILDABLE scope reaches 100%** — the chairman's "when will
+the foundation be built?" answer. It is honest about the *sourcing-bound* case (if nothing is queued
+and nothing is being sourced, it reports a **PLATEAU**, never a false date) and it **self-corrects**
+its learned parameters against observed reality. Operational capabilities are excluded (they need
+live ventures).
+
+## Source of truth (verified — `lib/vision/build-completion-forecast.mjs`, 186 lines)
+
+- **`computeForecast(i)`** — the pure forecast (all IO injected; `nowMs` required, deterministic).
+- **`build_completion_forecast_log`** table — **APPLIED 2026-06-20** (chairman-authorized,
+  `[MIGRATION_APPLY_PROD_PASS]`, additive-only) persistence. The forecast computes regardless of the
+  table; with the table live and the first row persisted, the email ETA line now renders (the line
+  fail-softs to omitted only if the table ever has no rows / errors).
+
+## Inputs (what it consumes)
+
+| Input | Meaning | Sourced from |
+|-------|---------|--------------|
+| `buildPct` | current VDR `build_pct` (0–100) | the build gauge (link 10) |
+| `buildableRemaining` | count of buildable caps not yet built | the build gauge components |
+| `velocityPerDay` | completed SDs/day (recent window) | shipped-SD history |
+| `sourcingPerDay` | new claimable buildable SDs/day (recent window) | sourcing history |
+| `queueDepth` | claimable buildable SDs available now (deps met) | the belt |
+| `capsPerCompletion` | LEARNED: buildable caps advanced per completed SD (default 1) | EWMA self-correction |
+
+## The calculation (traced)
+
+1. **Early exits:** `buildPct ≥ 100` → ETA 0; `buildableRemaining === 0` → ETA 0 (gauge may lag).
+2. **Throughput:** `velocityCapsPerDay = velocityPerDay × capsPerCompletion`.
+3. **PLATEAU (honest):** if `queueDepth === 0` AND `sourcingPerDay < 0.05` (SOURCING_EPS) → **no
+   date**, report a plateau at the current % until sourced.
+4. **Velocity stalled but work exists:** `velocityCapsPerDay < 1e-6` → unknown ETA, `velocity`-bound.
+5. **Two-phase ETA (the normal case):**
+   - `capsCoveredByQueue = min(buildableRemaining, queueDepth × capsPerCompletion)`.
+   - `capsNeedingSourcing = buildableRemaining − capsCoveredByQueue`.
+   - **Phase 1** (burn the queue): `daysQueuePhase = capsCoveredByQueue / velocityCapsPerDay`.
+   - **Phase 2** (source the rest): if sourcing ~0 → partial-then-plateau; else
+     `daysSourcingPhase = capsNeedingSourcing / min(velocityCapsPerDay, sourcingCapsPerDay)` — the
+     **slower** of "complete what's sourced" vs "source the rest" governs the tail.
+   - `etaDays = daysQueuePhase + daysSourcingPhase`; `etaDateIso = nowMs + etaDays`.
+   - **bindingConstraint** = `velocity` | `sourcing` | `plateau` | `none` (what's gating completion).
+
+## Confidence model (two-factor)
+
+`confidence = downgradeForHorizon( forecastConfidence(...), etaDays )`:
+
+- **forecastConfidence** by constraint mix: `velocity ≤ 0` → low; sourcing-share > 0.5 → low
+  (mostly gated by the volatile sourcing variable); > 0 → medium; fully queue-covered → high.
+- **downgradeForHorizon** caps confidence by distance: `etaDays > 365` caps at low; `> 120` caps at
+  medium. *A 168-day linear projection should never read "high" to the chairman, even if
+  mathematically correct.*
+
+## Self-correction (EWMA, clamped)
+
+`adjustLearnedRate(prior, observed, alpha=0.3)` nudges `capsPerCompletion` toward observed reality
+each run. **Critical safety (FR-3):** the EWMA nudge (×1.1/×0.9) has **no fixed point**, so an
+un-clamped value drifts geometrically over many runs (→ hundreds or → 0), collapsing every ETA. It
+is therefore **clamped to `[0.2, 5]`** (`CAPS_PER_COMPLETION_MIN/MAX`) on both read and adjust.
+`scoreForecastError(prior, actual)` measures how far a prior forecast was off (signed/abs error days,
+plateau_broke/plateau_held) to feed the trend.
+
+> **General lesson encoded:** any multiplicative self-learning nudge needs a hard clamp.
+
+## Output line (link 15)
+
+`formatForecastLine(f, prevF)` renders the single exec-summary line, e.g.:
+*"Estimated completion (infra-build scope): 2026-08-11 (~52d, sourcing-bound) (medium [Δ +4d vs last])"*
+or, when plateaued, *"PLATEAU at 23% until sourced."* The Δ vs the prior run shows movement.
+
+## First persisted live forecast (`build_completion_forecast_log` row `2f81e572`, 2026-06-20)
+
+The first row written after the migration was applied:
+
+| Field | Value |
+|-------|-------|
+| `build_pct` | 23 |
+| `buildable_remaining` | 12 |
+| `queue_depth` | 3 |
+| `velocity_per_day` | 27.64 |
+| `sourcing_per_day` | 0.36 |
+| `binding_constraint` | `sourcing` |
+| `eta_date` | 2026-07-16 |
+| `confidence` | `low` |
+
+Rendered exec-email line: `Estimated completion (infra-build scope): 2026-07-16 (~26d,
+sourcing-bound) (low)`. This is the expected shape while V1 is sourcing-constrained — the binding
+constraint being `sourcing` is itself a signal to activate the engine / distill the backlog
+(links 6/7), and the `low` confidence is the horizon/constraint-mix cap doing its job.
+
+> **[Two different `build_pct` numbers — not a contradiction]** The forecaster's `build_pct = 23` is a
+> **conservative, narrower** metric: the active-rung (V1) **BUILDABLE** capabilities actually built
+> (~3 of ~15). The **VDR gauge `overall_pct` ≈ 55%** ([10-vdr-build-gauge.md]) is a **blended** metric
+> across **all** probed capabilities and layers (buildable + operational, all rungs probed). They
+> measure **different scopes**, so 23 vs 55 is expected — not a discrepancy. The **ETA deliberately
+> uses the conservative buildable measure**, so the completion date reflects only the foundation work
+> the fleet can actually finish by shipping code.
+
+## Fail-soft behavior
+
+- `build_completion_forecast_log` with no rows / any read error → the email line is **omitted**,
+  never blocks the email (link 15 wraps the read in try/catch). (The table is applied as of
+  2026-06-20 and now holds rows, so the line renders; the omit-path remains the safety net.)
+- `computeForecast` is pure and total; bad inputs are coerced (nonNeg/clampPct) rather than thrown.
+
+## Existing documentation
+
+- **Gap:** no prior doc covered the forecaster at all (it is recent — SD-LEO-INFRA-BUILD-COMPLETION-
+  FORECAST-001). This doc + the source file are the documentation.
+
+## Connects to
+
+- **Up from:** the build gauge ([10-vdr-build-gauge.md]) + velocity/sourcing/queue from the fleet &
+  sourcing layers ([08-belt-coordinator-fleet.md], [07-sourcing-engine.md]).
+- **Reports up via:** the executive summary email ([15-executive-summary-email.md]).
+- **Signals back:** a `sourcing`-bound forecast nudges activate/distill ([06-adam-sourcing.md]).

--- a/docs/flywheel/13-feedback-learning.md
+++ b/docs/flywheel/13-feedback-learning.md
@@ -1,0 +1,86 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, feedback, learning, retro, heal, signal, adam-adherence]
+---
+
+# Link 13 — Feedback / Learning Loops
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+This is the **up-flow that closes the loop**. Every shipped SD and every lesson learned flows back
+up: lessons become backlog (so the system fixes its own friction), shipped work credits the KRs and
+advances the rungs, and an adherence metric measures whether the system is converging on its own
+rules. *"The system gets measurably better every cycle"* (the mission) is implemented here.
+
+## The post-completion tail (the Ralph loop)
+
+When a worker claims done, the **post-completion-tail Stop hook** re-injects continuation work rather
+than letting the worker stop on a self-declared completion:
+
+- **`/document`** — capture documentation.
+- **`/heal`** — fix what the run revealed.
+- **`/learn`** — extract lessons.
+- **completion-flags capture** (`scripts/capture-completion-flags.js`) — the reflective "are there
+  gaps we failed to close?" pass; incidental findings route to the durable feedback channel ("0
+  flags" shown explicitly).
+
+These are **continuation steps, never pause points** (CLAUDE.md). Enforced by the
+post-completion-tail-enforcement Stop hook + the completion-flags witness check.
+
+## Signal → backlog (friction becomes work)
+
+- **`/signal <type>`** (stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug
+  | feedback | other) writes a `session_coordination` row to the coordinator.
+- **`lib/coordinator/signal-router.cjs`** promotes a fingerprinted signal to a `harness_backlog`
+  `feedback` row at **≥3 distinct callsigns** OR **any critical** signal.
+- **`scripts/log-harness-bug.js`** writes `feedback` (`category='harness_backlog'`) directly.
+- These `harness_backlog` feedback rows **re-enter intake** (link 5) → become candidates → become
+  SDs. *This is the literal loop closure:* the system's own friction is sourced as new work.
+
+## Lessons + retros
+
+- Retrospectives are stored in the `retrospectives` table (database-first).
+- `/learn` extracts patterns; the auto-learning capture hooks
+  (`docs/reference/auto-learning-capture-hooks.md`) persist them; future workers consult prior
+  issues (`scripts/search-prior-issues.js`) **before** work — so the next worker starts from a higher
+  baseline (the moat = learning speed).
+
+## Crediting shipped work to outcomes
+
+`sd_key_result_alignment` (link 3) credits a shipped SD to the KR(s) it contributes to. As V1
+buildable capabilities ship, the build gauge (link 10) flips them `built`, raising `build_pct` and
+advancing the V1 rung — and as V2 activates, shipped revenue work will move the outcome KRs. *That
+is how shipped work advances the rungs.*
+
+## The adam_adherence convergence metric
+
+- **`adam_adherence_ledger`** (72 rows). Columns: `run_id`, `probe`, `duty`, `verdict`, `detail`,
+  `remediation_ref`. Each run scores Adam against its own duties (e.g. "read the vision gauge", "route
+  the SSOT first"). The exec-summary writes a durable *"Adam read the vision gauge"* marker
+  (`recordVisionGaugeRead`) so the self-adherence audit can measure the vision-monitoring duty.
+- This is a **convergence / catch-rate metric**: it measures whether the advisor is actually
+  following the contract, so drift (e.g. the "degrade to hand-mining" regression) is *detected*, not
+  silently tolerated. (SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-F was the
+  convergence-metric child.)
+
+## Existing documentation
+
+- `docs/reference/auto-learning-capture-hooks.md`, `progressive-learning-format.md`,
+  `retrospective-patterns-skill-content.md`, `pattern-lifecycle.md`. **Coverage: good (mechanics).**
+- `docs/04_features/23a_feedback_loops.md`. **Coverage: partial.**
+- `docs/reference/schema/engineer/tables/adam_adherence_ledger.md` — schema. **Coverage: good (schema).**
+- **Gap (filled here):** no doc tied signal→backlog→intake→SD as *the loop closure*, nor framed the
+  adherence ledger as the convergence metric in flywheel context. This doc fills it.
+
+## Connects to
+
+- **Up from:** LEO execution's post-completion tail ([09-leo-execution.md]).
+- **Closes to:** backlog intake ([05-backlog-intake.md]) — friction becomes new work.
+- **Advances:** the rungs ([02-vision-ladder.md]) via the gauge + KR credit ([10], [03]).
+- **Audited by:** the adherence ledger; surfaced in the exec email ([15-executive-summary-email.md]).

--- a/docs/flywheel/14-governance.md
+++ b/docs/flywheel/14-governance.md
@@ -1,0 +1,85 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, governance, chairman, rung-activation, authorization]
+---
+
+# Link 14 — Governance / Chairman Control
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+Governance is the layer that **wraps everything**. The Chairman governs **by exception** — override
+authority, not approval authority; reviews decisions, never enters data. Two governance levers
+directly shape the flywheel: **rung activation** (what the fleet builds shifts only on a chairman
+flip) and **authorization gates** (irreversible/dangerous acts hard-wait for chairman authority).
+
+## Rung activation (the progression control)
+
+- **Mechanism:** `vision_ladder_rungs.is_active`. Exactly one rung is active (today **V1**). When the
+  chairman judges V1 sufficiently saturated, flipping `V2.is_active=true` shifts the build front
+  toward Earning/revenue capabilities — and the build gauge **automatically re-points** to the new
+  rung's criteria (`dbVisionSource` reads `WHERE is_active`).
+- **Why this is the gate:** per [progression-gate.md], this is *the* "milestone gate" for shifting
+  the fleet — it is the existing roadmap/ladder position + a chairman act, **not** an invented metric.
+- The V1→V2 re-cut (4 revenue capabilities deferred to inactive V2) means activating V2 is what
+  *turns on* those capabilities' probes — a deliberate chairman-timed reveal.
+
+## Authorization gates (irreversible / dangerous acts)
+
+| Act | Gate |
+|-----|------|
+| DB migrations to prod | 3-factor: `@approved-by:<git-email>` header per file + single-use `MIGRATION_APPLY_TOKEN` + git user.email (see `docs/sourcing-engine-activation-runbook.md`) |
+| Destructive / outward-facing irreversible ops | chairman-authorized via AskUserQuestion before auto-deciding |
+| Sourcing-engine populator staging | requires `apply=true` AND `chairmanApproved=true`; never auto-promotes to the belt ([07-sourcing-engine.md]) |
+| Engine flag flips (go-live) | chairman/coordinator go-live decision ([06-adam-sourcing.md] SSOT step 3) |
+| Adam-delegated DB-change apply | scoped, apply-only, fail-closed, revocable (`leo_protocol_sections` id=606) |
+| Push enforcement bypass | `EMERGENCY_PUSH` with ticket reference |
+| Handoff gate bypass | `--bypass-validation --bypass-reason`, rate-limited (3/SD, 10/day) |
+
+## Chairman decision surfaces
+
+The canonical inventory is **`docs/governance/chairman-decision-surfaces.md`** — the **10 places** a
+"chairman needs to decide" can live and which the unified queue
+(`chairman_unified_decisions` / `chairman_pending_decisions`) covers:
+
+1. `chairman_decisions` (covered) · 2. `venture_decisions` (covered) · 3. `agent_messages`
+escalations (covered) · 4. `feedback` critical/high (covered) · 5. `okr_generation_log` (covered) ·
+6. `leo_feature_flags` enable-or-kill (covered) · 7. CHAIRMAN-PENDING markers (uncovered) · 8.
+AskUserQuestion ephemeral (proxied on write) · 9. `session_coordination` (uncovered — agent-to-agent)
+· 10. Todoist external (out of scope by design).
+
+> **Constitutional rule:** the queue **NEVER decides anything**. Recommendations are display-only
+> defaults; pending-too-long (>72h) escalates *visibility* only. Every decision is an explicit
+> chairman act producing exactly one source write (`scripts/chairman-decisions.mjs decide`).
+
+## The chairman's primary interface
+
+- **Pull:** the unified decision queue + `scripts/chairman-decisions.mjs list|decide` +
+  the `/decisions` skill.
+- **Push:** the **executive summary email** ([15-executive-summary-email.md]) — "Decisions awaiting
+  you" (top 10 by age + one-line recommendation), rendered as a copy-paste block the chairman pastes
+  back into Claude Code to action.
+- **Tiered HITL:** workers proceed autonomously (never AskUser) → escalate to Adam → Adam triages
+  what reaches the chairman (urgent AskUser / phone-push / batched hourly email). Protects the
+  chairman's attention.
+
+## Existing documentation
+
+- `docs/governance/chairman-decision-surfaces.md` — the surface inventory. **Coverage: good.**
+- `docs/reference/activation-invariant-rule.md`, `docs/reference/always-ask-first-never.md`,
+  `docs/runbooks/payment-rail-chairman-checklist.md`. **Coverage: partial (specific gates).**
+- `leo_protocol_sections` id=606 — Adam DB-change apply authority. **Coverage: good.**
+- **Gap (filled here):** no doc tied rung activation + the authorization gates + the decision
+  surfaces together as *the governance wrapper of the flywheel*. This doc fills it.
+
+## Connects to
+
+- **Controls:** rung activation ([02-vision-ladder.md]) → shifts the build front ([progression-gate.md]).
+- **Gates:** sourcing activation ([07-sourcing-engine.md]), migrations, destructive ops, LEO bypasses
+  ([09-leo-execution.md]).
+- **Surfaced via:** the executive summary email ([15-executive-summary-email.md]).

--- a/docs/flywheel/15-executive-summary-email.md
+++ b/docs/flywheel/15-executive-summary-email.md
@@ -1,0 +1,174 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, executive-summary, chairman-email, adam, calculation]
+---
+
+# Link 15 — Executive Summary Email (the Chairman's primary recurring status surface)
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+
+## Role in the flywheel
+
+This is the **chairman's primary recurring status surface** — the up-flow's headline report. It
+reuses the build gauge (link 10) and the build-completion forecast (link 12) and surfaces the fleet
+state and the pending decisions (link 14). It is deliberately **simple**: two headline numbers + an
+action list. Crucially, it **reuses** the same calculation engines the rest of the flywheel uses — it
+does not recompute anything its own way, so the email can never diverge from the gauge/forecast.
+
+## Source of truth (verified — `scripts/adam-exec-summary.mjs`, 332 lines, "v3")
+
+- **Sender:** Adam (`Adam — LEO Fleet Advisor`), via `lib/notifications/resend-adapter.js`.
+- **Recipient:** `process.env.CLAUDE_NOTIFY_EMAIL`.
+- **Cadence / trigger:** the GitHub-Actions cron **`adam-exec-email-cron.yml`** (the 30-min /
+  hourly executive email). A once-per-hour **send guard** (`lib/fleet/exec-email-send-guard.js`
+  `shouldSendNow` / `recordSent`) prevents duplicate sends; the send-gating decision is done in the
+  workflow CLI. `--dry-run` / `ADAM_EMAIL_DRYRUN` previews without sending; `--force` overrides the
+  quiescence gate.
+- **Quiescence gate (QF-20260612-437):** when the fleet is fully OFF AND there are **no pending
+  chairman actions**, the hourly send is skipped (fails *open* to ACTIVE on any query error so a real
+  email is never dropped). Pending actions always surface regardless of fleet state.
+
+## What it contains (the v3 layout)
+
+The chairman directed (2026-06-14) **two headline numbers + their action list, nothing else**:
+
+1. **WORKERS** — `N active[, M idle] (source label)`.
+2. **EHG VISION BUILD-%** — the live VDR build gauge, with the per-rung/per-nature line, the rung
+   rollup, the forecast line, operational proofs, the per-layer line, and the gauge note.
+3. **DONE IN THE LAST HOUR** — a couple of plain-language sentences on what shipped since the
+   previous email (non-technical chairman-readable).
+4. **ACTIONS FOR YOU** — `chairman_pending_decisions` rendered as a single copy-paste block the
+   chairman selects and pastes back into Claude Code; every line ends with the real
+   `decision_type:id` reference so a pasted instruction resolves to the exact row.
+
+> **Removed vs v2** (chairman directive): the north-star number, per-scope roll-up, value-delivered
+> buckets, meta:product ratio, distance-to-quit prose, tri-party self-score, the canary, the embedded
+> coordinator fleet card, and the vision trend sparkline. **No emojis anywhere.**
+
+## HOW it calculates the estimates and forecasts (the part to read)
+
+The email's headline numbers are **not** computed in this script — they are **reused** from the
+canonical engines. This is the anti-divergence design.
+
+### Number 1 — WORKERS (hourly average, honest under sparse data)
+
+- A 15-min pulse job records active-vs-idle into `fleet_worker_pulse`. The email **averages the last
+  hour** of pulses (`resolveWorkerCount`, `lib/fleet/worker-count-source.mjs`).
+- **Sparse/missing-data honesty** (SD-LEO-INFRA-WORKER-COUNT-PULSE-RESILIENCE-001): if there are
+  `< SPARSE_THRESHOLD` pulses in the 1h window, it **widens to a 3h window** or **prefers the live
+  instantaneous count** (`computeLive` — the same genuine-worker predicate the fleet dashboard uses),
+  labeled honestly. The wider-window + live queries fire **lazily** (only when sparse). A query error
+  returns `null` so a failure never masquerades as a real "0 active". The `(hr avg)` subject tag only
+  appears for a *confident* (non-sparse) hourly average.
+
+### Number 2 — EHG VISION BUILD-% (reuses computeBuildGauge — link 10)
+
+```js
+const grep  = makeDefaultGrepSeam();                         // shared cross-repo grep seam
+const gauge = await computeBuildGauge({ io:{ supabase: db, grep }, visionSource:true });
+const fmt   = formatGaugeForSummary(gauge, { em: EM });      // SAME display mapping as the Chairman-UI tile
+```
+
+- `visionSource:true` → the denominator is the **active vision rung** (`vision_ladder_rungs WHERE
+  is_active` → `vision_ladder_criteria`), so the gauge **auto-re-points** when the chairman activates
+  the next rung — no code edit, no dependency on a missing `EHG-VISION.md` file.
+- The grep seam (`makeDefaultGrepSeam`) lets the cross-repo `code_grep` probes resolve so all
+  capabilities are measured, not just the DB/KR-backed ones (present⇒partial, absent checkout⇒
+  unknown/excluded — never a guessed/inflated number).
+- `formatGaugeForSummary` is the **single source** of display strings (shared with the Chairman-UI
+  tile) → `buildLine` (leads with fleet-build %), `rungNatureLine` (V1 foundation NN% built / NN%
+  operational / income tracked on V2), `rungLine` (V1 rung-completion over all criteria),
+  `operationalLine`, `layerLine`, `visNote`.
+- **The full calculation (denominator/numerator/scoring/buildable-vs-operational split) is in**
+  [10-vdr-build-gauge.md] — the email simply renders it.
+
+### The rung rollup line (reuses the SAME gauge — no recompute)
+
+```js
+const rollup = await runRollup({ supabase: db, computeGaugeFn: async () => gauge, apply:false });
+rungRollupLine = formatRungRollupLine(rollup, { em: EM });
+```
+
+- `computeGaugeFn` returns the **already-computed** gauge (a thunk) → **no second compute, no
+  divergence** (the email's rollup % equals the gauge % by construction).
+- `apply:false` → the email **reads, never writes** `roadmap_waves.progress_pct` (it is a reporting
+  surface, not a mutator). See [04-roadmap-waves.md].
+
+### The forecast line (reads the persisted forecast — link 12)
+
+```js
+const { data: fc } = await db.from('build_completion_forecast_log')
+   .select('plateau,build_pct,binding_constraint,eta_days,eta_date,confidence,note')
+   .order('measured_at',{ascending:false}).limit(2);
+forecastLine = formatForecastLine(toF(fc[0]), toF(fc[1]));   // current + delta-vs-prior
+```
+
+- The email reads the **latest two** persisted forecast rows and renders the current ETA + the **Δ
+  vs the prior run** (`formatForecastLine`). The forecast itself (two-phase ETA, EWMA self-
+  correction, plateau honesty, horizon-capped confidence) is documented in [12-forecasting.md].
+- **[APPLIED — 2026-06-20]** The `build_completion_forecast_log` table migration
+  (`database/migrations/20260620_build_completion_forecast_log.sql`) was **APPLIED 2026-06-20**
+  (chairman-authorized, `[MIGRATION_APPLY_PROD_PASS]`, additive-only). The exec-email ETA line now
+  **RENDERS**. First live value:
+  > `Estimated completion (infra-build scope): 2026-07-16 (~26d, sourcing-bound) (low)`
+- **Fail-soft (still the behavior):** if the table ever has no rows / is absent / any error → the
+  forecast line is simply **omitted**, never blocking the email. So the email is safe both before
+  and after the row exists.
+
+### ACTIONS FOR YOU (pending decisions — link 14)
+
+- Reads `chairman_pending_decisions` (limit 200), **first**, so the quiescence gate can see them.
+- Drops stale approvals for **dead ventures** (terminal status or hard-deleted) and collapses
+  auto-generated "Corrective:" gap findings, so the action count is real, not inflated
+  (`prepareDecisions` / `renderDecisionLines`, `lib/chairman/decision-layman.mjs`).
+- Renders a copy-paste block; each line ends with `decision_type:id`. Free-text flags shown **as
+  received** (no LLM, chairman 2026-06-14).
+
+## Fail-soft doctrine (every section)
+
+The email is engineered so **no single section can block the send**:
+
+- The live VDR gauge failing → `visPct=null`, `"(gauge unavailable)"` line, email still sends.
+- The rung-rollup / forecast / done-in-last-hour / decisions-consumed / watchdog lines each wrapped
+  in their own try/catch → degrade to an honest empty/"unavailable" line.
+- A **missing-run watchdog** (`assessAdamSourceWatchdog`) catches a *dropped* gauge run (no row
+  written at all) and renders a degraded line — but the watchdog itself never blocks the email.
+- After a successful send, the **send marker** is recorded; a marker-write failure is logged **LOUD**
+  (it re-opens the duplicate-send path) but does not throw.
+
+## Durable adherence marker (feeds link 13)
+
+When the gauge produces a number (and not in dry-run), the email writes a durable *"Adam read the
+vision gauge"* marker (`recordVisionGaugeRead`) so the adam-adherence audit
+(`adam_adherence_ledger`) can measure the vision-monitoring duty. See [13-feedback-learning.md].
+
+## The overall process (sequence)
+
+1. Cron fires `adam-exec-email-cron.yml` → runs `adam-exec-summary.mjs`.
+2. Fetch pending decisions → evaluate the quiescence gate (skip if fleet OFF + no actions).
+3. WORKERS: average pulses (widen/live-fallback if sparse).
+4. VISION: `computeBuildGauge` → `formatGaugeForSummary` → reuse-gauge `runRollup` (dry-run) →
+   read `build_completion_forecast_log` → `formatForecastLine`.
+5. DONE-IN-LAST-HOUR: load completed work in the half-open window since the last send marker.
+6. ACTIONS: render `chairman_pending_decisions` as a copy-paste block.
+7. Compose subject `[Chairman] EHG NN% built · N active · K actions for you` + text + HTML.
+8. Send via Resend → record the send marker (LOUD on failure) → write the adherence marker.
+
+## Existing documentation
+
+- `docs/governance/chairman-decision-surfaces.md` lists the email as the ≥1-live-consumer of the
+  decision queue. **Coverage: partial (mentions, doesn't explain the calc).**
+- **Gap (filled here):** no doc explained the email's cadence, contents, *and especially how it
+  calculates/reuses the gauge + forecast* + its fail-soft doctrine. This doc fills it — it is the
+  thorough treatment the chairman asked for.
+
+## Connects to
+
+- **Reuses:** the build gauge ([10-vdr-build-gauge.md]), the rung rollup ([04-roadmap-waves.md]), the
+  forecast ([12-forecasting.md]).
+- **Surfaces:** fleet state ([08-belt-coordinator-fleet.md]) + pending decisions ([14-governance.md]).
+- **Feeds:** the adherence ledger ([13-feedback-learning.md]).

--- a/docs/flywheel/README.md
+++ b/docs/flywheel/README.md
@@ -1,0 +1,163 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, vision, roadmap, sourcing, fleet, governance, end-to-end]
+---
+
+# The EHG Flywheel — End-to-End System Map
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** This is the first attempt at a single, canonical,
+> end-to-end map of the EHG self-improving system, from the North Star down to a worker
+> claiming an SD off the belt, and the feedback loops back up. Component docs already
+> existed (see the cross-links per link); this set is the *connective tissue* that ties
+> them together. Every claim here is grounded in code / DB read on 2026-06-20; items that
+> are aspirational or not-yet-built are flagged inline as **[NOT-YET]** or **[DORMANT]**.
+
+## What this is
+
+EHG runs as a **flywheel**: the Chairman's intent flows *down* through a vision ladder,
+a roadmap, a backlog, a sourcing engine, a coordinator, and a fleet of workers that build
+and ship; the work and lessons flow *back up* to advance the rungs and sharpen the system —
+so the next turn starts from a higher baseline. This document is the index/overview; each
+**link** in the chain has a detail doc in this folder.
+
+The system has **two layers**, and this map covers both and their seam:
+
+- **The LEO Harness** (this repo, `EHG_Engineer`) — the multi-agent machine that decides
+  *what to build next* and ships it (coordinator + Adam + workers + the DB-as-session-log).
+- **The EHG Product** (`rickfelix/ehg`) — the actual venture/EVA/Chairman-UI/cockpit
+  application the harness builds.
+
+> **[Gap — promotion has no target-repo routing]** Promotion via `leo-create-sd --from-roadmap-item`
+> provides no way to set the target repo (no `--target-repos` flag; `deriveSdFieldsFromRoadmapItem`
+> sets no `target_application`), so EHG-product roadmap items (Waves 2/3/4) default to the harness
+> repo and cannot be promoted to `rickfelix/ehg`. Nothing FORBIDS EHG (`ALLOWED_REPOS` includes it) —
+> there is simply no ROUTING mechanism. Detail + the product-promotion-pipeline fix:
+> [04-roadmap-waves.md](04-roadmap-waves.md) and [06-adam-sourcing.md](06-adam-sourcing.md).
+
+> **Two concurrent build fronts today.** Both the LEO Harness and the EHG Product are
+> actively being built right now. "Taper the harness" is a **future** condition (net-new
+> harness work naturally thins as the harness matures, gated on rung-advancement) — **not**
+> a directive to stop harness work and pivot to product today. See
+> [progression-gate.md](progression-gate.md).
+
+## The flywheel (ASCII map)
+
+```
+                          ┌────────────────────────────────────────────────┐
+                          │            CHAIRMAN (human, solo)                │
+                          │   intent · ideation · rung activation · the rare │
+                          │   ❓decision · kill authority                     │
+                          └───────────────┬──────────────────────▲──────────┘
+                                          │ governs by exception  │ exec-summary email
+                                  (DOWN: what to build)           │ (the recurring status surface)
+                                          ▼                       │ (15) ← all gauges/forecasts
+   ┌─────────────────────────────────── STRATEGY LAYER ──────────┴──────────────────────────┐
+   │ (1) NORTH STAR ........... $18k/mo net, 6 mo · 10+ validated businesses (north_star)     │
+   │        │                                                                                 │
+   │        ▼                                                                                 │
+   │ (2) VISION LADDER ........ V1 Foundation → V2 Earning → V3 Outcomes                       │
+   │        │                   (vision_ladder_rungs.is_active · vision_ladder_criteria)       │
+   │        │                   buildable vs operational nature (lib/vision/vdr-registry.js)   │
+   │        ▼                                                                                 │
+   │ (3) OKRs / KEY RESULTS ... measure outcome-rung (V2/V3) progress (key_results)           │
+   │        │                                                                                 │
+   │        ▼                                                                                 │
+   │ (4) ROADMAP → WAVES ...... strategic_roadmaps + roadmap_waves (time_horizon now/next/    │
+   │        │                   later → V1/V2/V3) + roadmap_wave_items                         │
+   └────────┼─────────────────────────────────────────────────────────────────────────────┘
+            ▼
+   ┌─────────────────────────────────── SUPPLY LAYER ───────────────────────────────────────┐
+   │ (5) BACKLOG INTAKE ....... conversion_ledger ← todoist/youtube/brainstorm/estate/        │
+   │        │                   harness_backlog feedback/deferred SDs → roadmap_wave_items     │
+   │        ▼                                                                                 │
+   │ (6) HOW ADAM SOURCES ..... route the roadmap SSOT (not hand-mine); propose-only (CONST-   │
+   │        │                   002); D1 proactive sourcing (CLAUDE_ADAM.md / section 607)     │
+   │        ▼                                                                                 │
+   │ (7) AUTOMATED BELT FEED .. sourcing engine [2 CRONS ACTIVE in CI] — proactive-populator +  │
+   │        │                   dispositionGate + router/lane; deferred-watcher + gauge-gap-    │
+   │        │                   miner crons; promotion via leo-create-sd --from-roadmap-item    │
+   └────────┼─────────────────────────────────────────────────────────────────────────────┘
+            ▼
+   ┌────────────────────────────── EXECUTION LAYER ─────────────────────────────────────────┐
+   │ (8) BELT → COORDINATOR → FLEET ..... claimable-SD queue ("belt") → coordinator dispatch   │
+   │        │                            → worker claim; capacity forecaster / belt-low detect  │
+   │        ▼                                                                                  │
+   │ (9) LEO EXECUTION .................. LEAD → PLAN → EXEC · gates · handoffs · sub-agent      │
+   │        │                            evidence (CLAUDE*.md / leo_protocol_sections)          │
+   │        ▼                                                                                  │
+   │     SHIPPED PR  ───────────────────────────────────────────────────────────────────────┐ │
+   └────────┼────────────────────────────────────────────────────────────────────────────┘ │ │
+            ▼                                                                                │ │
+   ┌────────────────────── MEASUREMENT / STEERING LAYER ────────────────────────────────────┐ │
+   │ (10) VDR BUILD GAUGE ..... active-rung completion, per-nature (computeBuildGauge)        │ │
+   │ (11) PRIORITIZATION ...... needle-movement rank (active-rung-first) (needle-priority)    │ │
+   │ (12) FORECASTING ......... build-completion ETA off the wave estate (build-completion-   │ │
+   │        │                   forecast.mjs)                                                 │ │
+   └────────┼────────────────────────────────────────────────────────────────────────────┘ │
+            │  these three feed (8) prioritization AND (15) the chairman email ──────────────┘ │
+            ▼                                                                                   │
+   ┌────────────────────── FEEDBACK / LEARNING LOOP ────────────────────────────────────────┐ │
+   │ (13) RETRO / LEARN / HEAL / SIGNAL → harness_backlog → (5) intake (closes the loop)       │ │
+   │        adam_adherence convergence metric · shipped work + lessons advance the rungs ──────┘ │
+   └─────────────────────────────────────────────────────────────────────────────────────────┘
+   ┌────────────────────── GOVERNANCE / CHAIRMAN CONTROL (wraps everything) ─────────────────┐
+   │ (14) rung activation (V1→V2 flip) · authorization gates (migrations, destructive ops,     │
+   │      populator chairman-approval) · chairman decision surfaces                            │
+   └───────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## The links (per-link summary + detail-doc cross-links)
+
+Each row: the link, its one-line role, its **source of truth** (verified), a coverage note,
+and the detail doc. Coverage ratings are in [doc-inventory.md](doc-inventory.md).
+
+| # | Link | Role (one line) | Source of truth (verified 2026-06-20) | Detail doc |
+|---|------|-----------------|----------------------------------------|------------|
+| 1 | **North Star** | The terminal target everything points at | `north_star` table (1 row, `status=chairman_ratified`): **$18k/mo net, sustained 6 mo**; leading sub-target **10+ validated businesses** | [01-north-star.md](01-north-star.md) |
+| 2 | **Vision Ladder** | Ordered rungs V1→V2→V3; the active rung is what we build now | `vision_ladder_rungs` (3 rows; **V1 active**, V2/V3 inactive) + `vision_ladder_criteria` (26 rows); `nature` (buildable/operational) in `lib/vision/vdr-registry.js` | [02-vision-ladder.md](02-vision-ladder.md) |
+| 3 | **OKRs / Key Results** | Measure outcome-rung (V2/V3) progress | `key_results` (43 rows), `sd_key_result_alignment` (73 rows), `roadmap_waves.okr_objective_ids` | [03-okrs-key-results.md](03-okrs-key-results.md) |
+| 4 | **Roadmap → Waves** | Sequence the rungs into executable waves; encode time_horizon→rung | `strategic_roadmaps` (2), `roadmap_waves` (12; `time_horizon` now/next/later → V1/V2/V3 via `RUNG_BY_HORIZON`), `roadmap_wave_items` (728) | [04-roadmap-waves.md](04-roadmap-waves.md) |
+| 5 | **Backlog Intake** | Funnel raw ideas into the roadmap | `conversion_ledger` (624) ← todoist/youtube/brainstorm/estate/harness_backlog/deferred → `roadmap_wave_items` | [05-backlog-intake.md](05-backlog-intake.md) |
+| 6 | **How Adam Sources** | Route the SSOT first; propose-only | `CLAUDE_ADAM.md`; `leo_protocol_sections` id=607 (`adam_role_contract`) "SOURCING SSOT — order of operations" | [06-adam-sourcing.md](06-adam-sourcing.md) |
+| 7 | **Automated Belt Feed** | The engine that fills the belt without a human | `lib/sourcing-engine/*` (router, lane, proactive-populator, dedup-autostamp, register-first); deferred-watcher + gauge-gap-miner crons **ACTIVE in GitHub Actions** (local env-probe shows a false "dormant" — see 07) | [07-sourcing-engine.md](07-sourcing-engine.md) |
+| 8 | **Belt → Coordinator → Fleet** | Dispatch claimable SDs to live workers | `lib/coordinator/*`, `scripts/fleet-dashboard.cjs`; `docs/protocol/*`; `claude_sessions`, `session_coordination` | [08-belt-coordinator-fleet.md](08-belt-coordinator-fleet.md) |
+| 9 | **LEO Execution** | One worker builds one SD LEAD→PLAN→EXEC | `CLAUDE.md`, `CLAUDE_CORE/LEAD/PLAN/EXEC.md`, `leo_protocol_sections`; `sub_agent_execution_results` | [09-leo-execution.md](09-leo-execution.md) |
+| 10 | **VDR Build Gauge** | "% built" of the active rung, per-nature | `computeBuildGauge` (`lib/vision/vdr-registry.js`), `vision_build_gauge` table (latest **55% overall, available**) | [10-vdr-build-gauge.md](10-vdr-build-gauge.md) |
+| 11 | **Prioritization** | Order work active-rung-first, highest-impact-first | `lib/vision/needle-priority.mjs` + coordinator backlog rank + unlock score | [11-prioritization.md](11-prioritization.md) |
+| 12 | **Forecasting** | ETA to 100% of the buildable scope | `lib/vision/build-completion-forecast.mjs` (+ `build_completion_forecast_log` — APPLIED 2026-06-20, ETA line live) | [12-forecasting.md](12-forecasting.md) |
+| 13 | **Feedback / Learning** | Lessons + shipped work flow back up | retro/learn/heal/signal → `feedback` (`category=harness_backlog`); `adam_adherence_ledger` (72) | [13-feedback-learning.md](13-feedback-learning.md) |
+| 14 | **Governance / Chairman Control** | Rung activation + authorization gates | `docs/governance/chairman-decision-surfaces.md`; `vision_ladder_rungs.is_active`; migration/destructive-op gates | [14-governance.md](14-governance.md) |
+| 15 | **Executive Summary Email** | The Chairman's recurring status surface (reuses 10+12) | `scripts/adam-exec-summary.mjs` (cron `adam-exec-email-cron.yml`) | [15-executive-summary-email.md](15-executive-summary-email.md) |
+
+## Cross-cutting docs
+
+- **[progression-gate.md](progression-gate.md)** — *How we know what to build next.* The
+  V1→V2→V3 progression is **already encoded** in the roadmap/vision ladder; the "milestone
+  gate" for shifting the fleet's build front is the existing ladder position + chairman-
+  controlled rung activation, **not** an invented metric. Two concurrent build fronts today.
+  **Read this if you read nothing else.**
+- **[doc-inventory.md](doc-inventory.md)** — per-link coverage audit (good/partial/none) +
+  the confirmed gap list + canonical-home recommendation.
+
+## How to read this set
+
+1. New to EHG? Read this README top-to-bottom, then [progression-gate.md](progression-gate.md).
+2. Want the down-flow (strategy → work)? Links 1 → 8 in order.
+3. Want the up-flow (steering & learning)? Links 10 → 13, then back to 5.
+4. Want a specific component? Jump to its detail doc via the table above.
+
+## Honesty ledger (what is live vs aspirational, as of 2026-06-20)
+
+| Claim | State |
+|-------|-------|
+| North Star is a queryable, chairman-ratified DB record | **LIVE** (`north_star`, 1 row) |
+| V1 is the active rung; V2/V3 inactive | **LIVE** (`vision_ladder_rungs.is_active`) |
+| Build gauge computes and is available | **LIVE** (latest 55% overall) |
+| Sourcing engine is built (10/10 children) | **LIVE (built) + 2 CRONS ACTIVE** — the deferred-watcher + gauge-gap-miner staging crons are registered with flags ON in GitHub Actions (commit 4ba41115 / PR #4933), armed as of 2026-06-20 (not yet observed firing; `workflow_dispatch` confirms). A **local** `process.env` flag probe reports a **false "dormant"** because it cannot see the workflow env (a known gap). The 4 umbrella `SOURCING_*` flags are display/registry only. Activation runbook: `docs/sourcing-engine-activation-runbook.md`. |
+| `build_completion_forecast_log` persistence | **APPLIED 2026-06-20** (chairman-authorized, `[MIGRATION_APPLY_PROD_PASS]`, additive-only); first row persisted → exec-email ETA line now renders (`2026-07-16, ~26d, sourcing-bound, low`). Forecast computes regardless; line omitted only if the table ever has no rows |
+| Two roadmap structures coexist in `roadmap_waves` | **LIVE** — an older Wave 1-6 "Engineering" set (`time_horizon=null`) and a newer rung-aligned now/next/later set; see [04-roadmap-waves.md](04-roadmap-waves.md) |
+| V2/V3 rungs have shipped capabilities | **[NOT-YET]** — by design; V1 precedes V2 |

--- a/docs/flywheel/doc-inventory.md
+++ b/docs/flywheel/doc-inventory.md
@@ -1,0 +1,145 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, audit, inventory, gap-analysis, recommendation]
+---
+
+# Flywheel Documentation Inventory, Gap List & Canonical-Home Recommendation
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** [← back to the flywheel map](README.md)
+>
+> Deliverables A (inventory), B (gap list), and D (recommendation) of the documentation audit.
+> All ratings reflect a read of code + DB + `docs/` on 2026-06-20.
+
+## A. Doc inventory (per link)
+
+Coverage legend: **good** = the component is well-documented somewhere; **partial** = touched but
+not complete / not in flywheel context; **none** = no dedicated doc existed before this set.
+
+| # | Link | Existing doc / code (exact paths) | Coverage (before this set) |
+|---|------|-----------------------------------|----------------------------|
+| 1 | North Star | `docs/reference/schema/engineer/tables/north_star.md`; `docs/04_features/ehg-northstar-contract-phase0.md`; `docs/vision/ehg-mission-vision-canonical.md`; `north_star` table; `lib/vision/north-star.js` | **good** (schema + prose); flywheel context **none** |
+| 2 | Vision Ladder | `docs/vision/ehg-mission-vision-canonical.md`; `docs/vision/ladder-roadmap-coherence.md`; schema `vision_ladder_rungs.md`/`vision_ladder_criteria.md`; `lib/vision/vdr-registry.js`; `lib/vision/placement-rules.js` | **good** |
+| 3 | OKRs / Key Results | schema `key_results.md`/`sd_key_result_alignment.md`/`okr_vision_alignment_records.md`; `database/migrations/20260104_okr_strategic_hierarchy.sql`; `lib/vision/rung-progress-rollup.mjs` | **partial** (schema + formula; not the "OKRs measure outcome rungs" framing) |
+| 4 | Roadmap → Waves | schema `strategic_roadmaps.md`/`roadmap_waves.md`/`roadmap_wave_items.md`; `docs/vision/ladder-roadmap-coherence.md`; `lib/vision/rung-progress-rollup.mjs` | **partial** (schema; wave→rung mechanics + promotion **none**) |
+| 5 | Backlog Intake | schema `conversion_ledger.md`; `docs/reference/brainstorm-metadata-convention.md`; `docs/reference/audit-to-sd-pipeline.md`; `lib/sourcing-engine/proactive-populator.js` | **partial** (no single "funnel" doc) |
+| 6 | How Adam Sources | `CLAUDE_ADAM.md`; `leo_protocol_sections` id=601/604/606/607; `.claude/commands/adam.md`; `docs/protocol/coordinator-adam-comms.md`; `scripts/adam-startup-check.mjs` | **good** (role); flywheel context **partial** |
+| 7 | Sourcing Engine | `docs/sourcing-engine-activation-runbook.md`; `docs/vision/ladder-roadmap-coherence.md`; `lib/sourcing-engine/*` (router/lane/proactive-populator/dedup-autostamp/register-first/...) | **partial** (runbook + forward-complement; no component/lane/flag map) |
+| 8 | Belt → Coordinator → Fleet | `docs/protocol/README.md`; `docs/protocol/fleet-coordinator-and-worker-behavior.md`; `docs/protocol/fleet-worker-loop-directive.md`; `docs/reference/fleet-coordination.md`; `lib/coordinator/*`; `scripts/fleet-dashboard.cjs` | **good**; flywheel context **partial** |
+| 9 | LEO Execution | `CLAUDE.md`; `CLAUDE_CORE/LEAD/PLAN/EXEC.md`; `leo_protocol_sections`; `docs/leo/*`; `docs/reference/validation-gate-registry.md` | **good** |
+| 10 | VDR Build Gauge | schema `vision_build_gauge.md`; `docs/vision/ladder-roadmap-coherence.md`; `lib/vision/vdr-registry.js`; `lib/vision/vdr-probes.js` | **partial** (no calculation trace) |
+| 11 | Prioritization | `docs/reference/central-planner.md`; `docs/reference/severity-weighted-pattern-prioritization.md`; `lib/vision/needle-priority.mjs` | **partial** (no rung-first needle-rank doc) |
+| 12 | Forecasting | `lib/vision/build-completion-forecast.mjs` only | **none** (code only) |
+| 13 | Feedback / Learning | `docs/reference/auto-learning-capture-hooks.md`; `progressive-learning-format.md`; `retrospective-patterns-skill-content.md`; `docs/04_features/23a_feedback_loops.md`; schema `adam_adherence_ledger.md` | **good** (mechanics); loop-closure framing **partial** |
+| 14 | Governance / Chairman | `docs/governance/chairman-decision-surfaces.md`; `docs/reference/activation-invariant-rule.md`; `leo_protocol_sections` id=606 | **good** (surfaces); rung-activation-as-gate framing **partial** |
+| 15 | Executive Summary Email | `scripts/adam-exec-summary.mjs`; mentioned in `docs/governance/chairman-decision-surfaces.md` | **none** (calc/cadence/contents undocumented) |
+
+## B. Gap list + the master-doc confirmation
+
+### Does a single end-to-end master doc exist today? — **NO (confirmed).**
+
+Verified two ways:
+
+1. **Database-first:** queried `leo_protocol_sections` for any
+   flywheel/end-to-end/north-star/master/coherence/self-improvement/overview section. The **only**
+   match was `id=217 "Database Schema Overview"` (a schema doc, not a flywheel map). No end-to-end
+   master section exists in the DB.
+2. **Filesystem:** the closest existing overview is `docs/protocol/README.md` ("The LEO Harness") —
+   an excellent canonical overview, but it covers **only links 8–9** (the fleet/coordinator/worker
+   harness + the protocol-vs-harness boundary). It does **not** climb up to the North Star, the
+   vision ladder, OKRs, the roadmap, intake, sourcing, the gauge, prioritization, forecasting, or the
+   chairman email. `docs/index.md` is a navigation index, not a narrative end-to-end map.
+
+**Conclusion:** component docs exist (most links rated good/partial), but **no single doc tied the
+full North-Star → worker-claim → feedback-loop chain together.** That is precisely the gap this
+`docs/flywheel/` set fills.
+
+### Thin / undocumented links (priority order for chairman attention)
+
+| Link | Gap severity | What was missing |
+|------|:---:|------------------|
+| 12 Forecasting | **highest** | No doc at all; the calculation (two-phase ETA, EWMA self-correction + clamp, horizon-capped confidence, plateau honesty) lived only in code. |
+| 15 Exec Email | **highest** | No doc; the cadence, contents, and especially *how it reuses computeBuildGauge + the forecast* were undocumented — yet it is the chairman's primary surface. |
+| 10 Build Gauge | high | Calculation (denominator/numerator/scoring/buildable-vs-operational split/coherence-gating) untraced. |
+| 11 Prioritization | high | The active-rung-first needle score was code-only. |
+| 4 Roadmap→Waves | medium | wave→rung mapping + promotion mechanics undocumented; **two coexisting wave structures** (legacy Wave 1-6 null-horizon vs rung-aligned now/next/later) never flagged. |
+| 5 Intake | medium | No single funnel doc enumerating all sources → conversion_ledger → wave-items. |
+| 7 Sourcing Engine | medium | No component/lane/flag/safeguard map; dormant-by-default state not surfaced in one place. |
+| 1,3,6,8,9,13,14 | low | Well-covered individually; needed flywheel-context bridges + cross-links. |
+
+### Honesty flags raised during the audit (for chairman review)
+
+1. **Two roadmap structures coexist** in `roadmap_waves` (legacy Wave 1-6 with `time_horizon=null`
+   and `progress_pct=0`, vs the rung-aligned now/next/later set). Recommend deciding whether to
+   retire/re-horizon the legacy set ([04-roadmap-waves.md]).
+2. **The sourcing engine is built and its 2 behavioral crons are ACTIVE** — the deferred-watcher
+   + gauge-gap-miner staging crons run with flags ON in GitHub Actions (commit 4ba41115 / PR #4933),
+   armed as of 2026-06-20 (not yet observed firing; `workflow_dispatch` confirms). A **local**
+   `process.env` flag probe reports a **false "dormant"** because it cannot read the workflow env
+   (a known false-negative gap; the probe should read the deployed workflow env / a DB engine_state
+   row). The 4 umbrella `SOURCING_*` flags are display/registry only. ([07-sourcing-engine.md]).
+3. **`build_completion_forecast_log` is APPLIED (2026-06-20)** — chairman-authorized, additive-only;
+   the first row is persisted, so the exec-email ETA line now renders. The forecast computes
+   regardless; the line omits only if the table ever has no rows ([12-forecasting.md]).
+4. **The exec email does not print the north-star income number** (removed in v3); it leads with
+   build %. Income is a V2/operational concern, correctly 0 until a venture earns ([01-north-star.md],
+   [15-executive-summary-email.md]).
+5. **V2/V3 rungs have no shipped capabilities yet** — by design (V1 precedes V2). The needle-rank is
+   LATENT-live until more rung-mapped SDs reach the belt ([11-prioritization.md]).
+
+## D. Recommendation — where these docs should live to be canonical
+
+Given **"database is the source of truth,"** here is the recommended canonical home and sync model.
+
+### The split (what goes where, and why)
+
+| Content type | Canonical home | Rationale |
+|--------------|----------------|-----------|
+| **Live values** (gauge %, rung active flag, north-star target, wave progress, flags) | **The DB tables** (`north_star`, `vision_ladder_rungs`, `vision_build_gauge`, `roadmap_waves`, …) — already true | Markdown drifts; the DB is queryable and validated. These docs must **never restate** a live value as authoritative — they describe *how to read it* and link to the table. |
+| **Calculation logic** (the formulas) | **The code** (`lib/vision/*`) — already true | The code is the executable source of truth; the docs trace it for humans and point to the file+function. |
+| **The flywheel narrative / map** (this set) | **`docs/flywheel/` markdown** (recommended) | It is connective architecture documentation, not protocol rules a gate enforces. It fits the existing `docs/vision/`, `docs/governance/`, `docs/protocol/` convention (top-level topic folders). It is read by humans + AI crawlers, not consumed by the gate pipeline. |
+| **Protocol *rules* an agent must obey** (e.g. the Adam SSOT order) | **`leo_protocol_sections`** (already true — id=607) → generated into `CLAUDE_ADAM.md` | These ARE enforced/loaded by agents at runtime; they belong in the DB, regenerated into the .md artifacts. The flywheel doc **references** them, does not duplicate them. |
+
+### The concrete recommendation
+
+1. **Keep this flywheel set as `docs/flywheel/` markdown** (do **not** move the narrative into
+   `leo_protocol_sections`). The narrative is architecture documentation; `leo_protocol_sections` is
+   for *runtime-loaded protocol rules*. Putting a 15-link map into the protocol-section table would
+   bloat the generated CLAUDE*.md files that every session loads, for content no agent needs at
+   runtime.
+
+2. **Add ONE pointer row to the DB so it is discoverable database-first.** Create a single
+   `leo_protocol_sections` row (e.g. section_type `documentation`, title *"EHG Flywheel — End-to-End
+   Map (pointer)"*) whose content is 3–4 lines saying *"the canonical end-to-end system map lives at
+   `docs/flywheel/README.md`; this set is narrative architecture docs, kept in markdown; live values
+   are in the DB tables it links to."* This satisfies "database-first" discoverability (a session can
+   find it by querying the DB) **without** putting the whole narrative in the DB. *(Not created by
+   this audit — it would modify a DB row, which was out of scope. Recommended as a follow-up.)*
+
+3. **Link it from the existing indexes** (a one-line addition each, recommended as follow-up edits):
+   - `docs/index.md` → add a "The EHG Flywheel (End-to-End Map)" row under a new top section.
+   - `docs/protocol/README.md` → add "for the full strategy→fleet→feedback map, see
+     `docs/flywheel/`" (it currently stops at the harness boundary).
+   - `docs/vision/README` (if/when one exists) and `docs/governance/` → cross-link.
+
+4. **Sync model (how markdown + DB stay honest):**
+   - **No duplicated live values.** These docs state *where* a value lives and *how it's computed*,
+     never hard-code the current number as authoritative (the few numbers shown are timestamped
+     "verified 2026-06-20" snapshots, explicitly labeled).
+   - **Code/DB are the source of truth; docs are descriptive.** When code/schema changes, the
+     corresponding flywheel detail doc is updated in the same SD that changes the behavior (treat it
+     like the `docs/vision/ladder-roadmap-coherence.md` precedent — a doc shipped alongside its SD).
+   - **A lightweight drift check (optional follow-up):** a CI lint that asserts the file paths /
+     function names cited in `docs/flywheel/*` still exist (similar to `WIRE_CHECK_GATE`), so a
+     rename surfaces a stale citation. This keeps the *references* honest even as values move.
+
+### Why not "both, fully mirrored"?
+
+Full mirroring (the same narrative in markdown AND `leo_protocol_sections`) was considered and
+**rejected**: it doubles the maintenance surface and reintroduces exactly the drift the database-first
+rule exists to prevent. The chosen model — **narrative in markdown, a single discoverability pointer +
+live values in the DB, code as the calc source of truth** — is database-first where it matters (values
++ runtime rules) and markdown where it's appropriate (human-facing architecture narrative).

--- a/docs/flywheel/progression-gate.md
+++ b/docs/flywheel/progression-gate.md
@@ -1,0 +1,134 @@
+---
+category: documentation
+status: draft
+version: 0.1.0
+author: docmon-agent (Information Architecture Lead)
+last_updated: 2026-06-20
+tags: [flywheel, progression, vision-ladder, governance, build-front]
+---
+
+# Progression Gate (V1 → V2 → V3) — How We Know What To Build Next
+
+> **Reviewed by Adam 2026-06-20 (chairman delegated the review); living doc — keep current as behavior changes.** Encodes the chairman-Adam agreement of 2026-06-20.
+> This is the conceptual keystone of the flywheel: it answers *"what should the fleet build
+> right now, and what would make us shift?"* without inventing a new metric.
+
+## The principle (canonical)
+
+**The foundation → product → revenue progression is ALREADY ENCODED in the roadmap / vision
+ladder.** It does not need a separate, invented "milestone metric."
+
+- The **vision ladder** orders capability into rungs: **V1 Foundation → V2 Earning → V3
+  Outcomes** (`vision_ladder_rungs`, ordered by `sequence`; exactly one `is_active=true`).
+- The **roadmap** sequences those rungs into waves, and each wave's `time_horizon` maps to a
+  rung deterministically: **`now → V1`, `next → V2`, `later → V3`**
+  (`RUNG_BY_HORIZON` in `lib/vision/rung-progress-rollup.mjs`, line 20). `eventually → null`
+  (too far out to attribute).
+- **V1 precedes V2 precedes V3** by construction. So *position on the ladder/roadmap IS the
+  progression signal.* You do not need to ask "have we hit milestone X?" — you ask "which
+  rung is active, and what unbuilt capabilities does it still have?"
+
+**Therefore the "milestone gate" for shifting what the fleet builds is:**
+
+> the existing **roadmap / vision-ladder position** + **chairman-controlled rung activation**.
+
+It is not a number someone made up. It is the active rung (`vision_ladder_rungs.is_active`)
+plus the chairman's decision to flip the next rung active. See [14-governance.md](14-governance.md)
+for the rung-activation control.
+
+## Why this matters (the failure it prevents)
+
+A single blended "% built" can be **misread as income progress**. If a revenue capability
+(rightly a V2/Earning concern) were sitting on the V1/Foundation rung, then "V1 is 80% built"
+could be mistaken for "we are 80% of the way to revenue." The vision ladder + the
+**buildable vs operational** nature split exist precisely to prevent that conflation:
+
+- **V1 Foundation** measures *fleet build-debt* — capabilities the fleet can complete by
+  shipping code. Its honest number is `build_pct` (buildable capabilities only).
+- **V2 Earning / V3 Outcomes** measure *operational proofs* — capabilities that only flip
+  when a live venture/operation makes them true. These are correctly **0 until a venture
+  runs** and are tracked **separately**, never folded into the build number.
+
+This is enforced in code: `OPERATIONAL_NATURE` (a reviewed Set in `vdr-registry.js`) tags the
+operational capabilities, and `formatGaugeForSummary` emits the per-rung/per-nature line
+*"V1 foundation: NN% built (buildable) — NN% operational — income/north-star tracked
+separately on V2."* See [10-vdr-build-gauge.md](10-vdr-build-gauge.md) and
+`docs/vision/ladder-roadmap-coherence.md`.
+
+## Two concurrent build fronts (today)
+
+There are **TWO build fronts being actively built right now**, and both need building today:
+
+| Front | Repo | What it builds |
+|-------|------|----------------|
+| **The LEO Harness** | `EHG_Engineer` (this repo) | The autonomous machine itself: coordinator, Adam, workers, sourcing engine, gates, gauges, forecasting, the learning loop |
+| **The EHG Product** | `rickfelix/ehg` | The actual application: ventures, EVA, the Chairman UI / cockpit surfaces |
+
+The V1 active rung's capabilities span **both** fronts (the VDR registry has `layer` values
+`infrastructure`/`process` that are harness-side, and `application`/`venture` that are
+product-side; several probes target the `ehg` repo via `code_grep`). Building V1 means
+advancing *both* fronts — not one then the other.
+
+> **[Gap — promotion has no target-repo routing]** Promotion via `leo-create-sd --from-roadmap-item`
+> provides no way to set the target repo: it accepts no `--target-repos` flag
+> (`leo-create-sd.js` `riKnownFlags` ~line 2685) and `deriveSdFieldsFromRoadmapItem`
+> (`lib/sourcing-engine/register-first.js:22`) sets no `target_application`, so `createSD` defaults
+> to `getCurrentVenture() || 'EHG_Engineer'` (`leo-create-sd.js` ~line 1902). Nothing FORBIDS EHG
+> (`ALLOWED_REPOS` includes it, line 86) — but there is no ROUTING mechanism, so EHG-product roadmap
+> items (Waves 2/3/4) default to the harness repo and cannot be promoted to `rickfelix/ehg`. The
+> product-promotion-pipeline SD addresses this by adding `--target-repos` to `--from-roadmap-item`
+> and/or deriving the target from the item's wave.
+
+## "Taper the harness" — a future condition, not a directive to pivot now
+
+> **Taper the harness ≠ stop harness work and pivot to product now.**
+
+"Taper" means **net-new harness work naturally thins as the harness matures** — a *future*
+condition that is itself **gated on rung-advancement** (as V1 saturates and the system moves
+toward V2/Earning, there is simply less foundation left to build, so harness throughput tapers
+on its own). It is an emergent outcome of the progression, not an instruction to redirect the
+fleet today.
+
+**Right now**, with **V1 active** and the build gauge at ~55% overall (latest
+`vision_build_gauge` row, 2026-06-20), there is substantial V1 foundation work remaining on
+both fronts. The correct posture is: **keep building V1 on both the harness and the product.**
+
+## Dedup hygiene ≠ tapering (distinct concept)
+
+A separate, always-on discipline that is easy to confuse with tapering:
+
+- **Dedup hygiene** = *not re-minting work that has already shipped* (the sourcing engine's
+  `dedup-autostamp.js` / the router's `DEDUP` lane catch this; see
+  [07-sourcing-engine.md](07-sourcing-engine.md)). This is hygiene applied to **every** new
+  candidate at sourcing time, regardless of rung.
+- **Tapering** = *the natural thinning of net-new foundation work as a rung saturates.*
+
+Dedup hygiene removes duplicates; tapering reflects there being less genuinely-new work. They
+are unrelated mechanisms — do not treat "we deduped a lot today" as evidence the harness should
+taper, and do not treat "the harness is tapering" as license to skip dedup checks.
+
+## The decision procedure (practical)
+
+When deciding what the fleet builds next, in order:
+
+1. **Which rung is active?** Read `vision_ladder_rungs WHERE is_active` (today: **V1**).
+2. **What does the active rung still need?** The unbuilt/partial **buildable** capabilities in
+   the active rung's `vision_ladder_criteria` (surfaced by `computeBuildGauge` components with
+   `nature='buildable'` and `status != 'built'`). These are the "needle-movers" — see
+   [11-prioritization.md](11-prioritization.md).
+3. **Source candidates for those gaps** via the SSOT order (roadmap items → distillation →
+   engine → last-resort gauge-mining). See [06-adam-sourcing.md](06-adam-sourcing.md).
+4. **Shift the front only on chairman rung activation.** When the chairman judges V1
+   sufficiently saturated, they flip `V2.is_active=true` (a governance act, [14-governance.md]).
+   *That* — not a self-invented threshold — is when the fleet's build front shifts toward
+   Earning/revenue capabilities.
+
+## Source-of-truth references (verified 2026-06-20)
+
+- Rungs and active flag: `vision_ladder_rungs` (V1 active; V2/V3 inactive).
+- Horizon→rung map: `RUNG_BY_HORIZON` (`lib/vision/rung-progress-rollup.mjs:20`).
+- Buildable vs operational: `OPERATIONAL_NATURE` + per-nature gauge
+  (`lib/vision/vdr-registry.js`).
+- Coherence enforcement (revenue-not-in-foundation): `lib/vision/placement-rules.js` +
+  `assertLadderRoadmapCoherence` (advisory) + `docs/vision/ladder-roadmap-coherence.md`.
+- Rung activation control: `docs/governance/chairman-decision-surfaces.md`.


### PR DESCRIPTION
## Summary
Commits the **docs/flywheel/** set (18 files) — the connective-tissue documentation of the EHG flywheel — and adds a DB-queryable protocol pointer to it.

- **docs/flywheel/README.md** — the end-to-end flywheel map (North Star → vision ladder → OKRs → roadmap/waves → backlog intake → Adam sourcing → sourcing engine/belt → coordinator/fleet → LEO execution → VDR gauge → prioritization → forecasting → feedback/learning → governance → exec-summary email), with an honesty ledger (live vs aspirational).
- **docs/flywheel/progression-gate.md** — the V1→V2→V3 progression principle (build before measuring adoption before claiming outcome; two concurrent build fronts today).
- **docs/flywheel/01-15** — per-link detail docs; **doc-inventory.md** — coverage audit.
- Chairman-delegated; **reviewed by Adam 2026-06-20**.

## Protocol pointer
Adds `leo_protocol_sections` **id=608** (`section_type=system_coherence`, `context_tier=REFERENCE`, `target_file=null`) as a DB-queryable pointer into the set. It is **DB-only** — not rendered into any CLAUDE_*.md phase-file body (matches the `governance_*` null-target convention).

## Why the CLAUDE_*.md churn
Regenerating via `scripts/generate-claude-md-from-db.js` was required so the manifest's `section_digests` tracks row 608 and the drift guard (`check-claude-md-drift.cjs`) goes green. The 14 CLAUDE_*.md file diffs are the generator's routine volatile-telemetry refresh; the substantive change is `claude-generation-manifest.json` (`"608": "7f99a4321502367e"`). Committed as the full regenerated set per the manifest's all-or-nothing contract.

## Verification
- `node scripts/check-claude-md-drift.cjs` → **OK no drift**.
- Pre-commit CLAUDE-protection hook recognized the files as regenerated (valid generator markers), not manual edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)