### PR TITLE
feat(SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001): guard coordinator dispatch against terminal/non-existent SDs

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -83,6 +83,71 @@ async function assertValidTarget(supabase, target, logger = console) {
   return { ok: true, kind: 'live_session' };
 }
 
+// SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: terminal statuses that must NEVER be dispatched. These
+// mirror the claim_sd RPC's terminal guard (SD-LEO-FIX-CLAIM-RPC-TERMINAL-001) so the dispatch side
+// and the claim side never disagree: claim_sd already REFUSES a terminal SD/QF, so a coordinator that
+// dispatches one only creates a WORK_ASSIGNMENT the worker's claim_sd will bounce ('sd_terminal_status')
+// — a wasted dispatch + a confusing worker error. Refusing at the dispatch choke point closes that gap.
+const TERMINAL_SD_STATUSES = Object.freeze(new Set(['completed', 'cancelled', 'deferred']));
+const TERMINAL_QF_STATUSES = Object.freeze(new Set(['completed', 'cancelled', 'escalated']));
+
+/** Pure: is an SD status terminal (un-dispatchable)? */
+function isTerminalSdStatus(status) {
+  return TERMINAL_SD_STATUSES.has(String(status || '').toLowerCase());
+}
+/** Pure: is a quick-fix status terminal (un-dispatchable)? 'escalated' is a one-way promotion. */
+function isTerminalQfStatus(status) {
+  return TERMINAL_QF_STATUSES.has(String(status || '').toLowerCase());
+}
+
+/**
+ * SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a WORK_ASSIGNMENT for a SD/QF whose
+ * lifecycle has already ended. Only applies to WORK_ASSIGNMENT rows that name an assigned SD/QF.
+ * Mirrors claim_sd:
+ *   - terminal status (completed/cancelled/deferred; QF: completed/cancelled/escalated) -> REFUSE (closed).
+ *   - non-existent SD/QF -> REFUSE (closed; mirrors claim_sd sd_not_found).
+ *   - a transient DB lookup error -> FAIL-OPEN (allow + log; claim_sd remains the backstop) so a
+ *     momentary hiccup never wedges all coordinator dispatch.
+ * @private
+ * @throws {Error} err.code DISPATCH_SD_TERMINAL | DISPATCH_SD_NOT_FOUND
+ */
+async function assertSdDispatchable(supabase, row, logger = console) {
+  if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
+  const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
+  const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+  if (!sdKey) return; // a WORK_ASSIGNMENT with no named SD (e.g. a generic nudge) — nothing to check
+  const isQf = /^QF-/.test(sdKey);
+  let status, found;
+  try {
+    if (isQf) {
+      const { data, error } = await supabase.from('quick_fixes').select('status').eq('id', sdKey).maybeSingle();
+      if (error) throw error;
+      found = !!data; status = data && data.status;
+    } else {
+      const { data, error } = await supabase.from('strategic_directives_v2').select('status').eq('sd_key', sdKey).maybeSingle();
+      if (error) throw error;
+      found = !!data; status = data && data.status;
+    }
+  } catch (e) {
+    // FAIL-OPEN on a transient lookup error: do not wedge dispatch; claim_sd still guards at claim time.
+    logger && logger.warn && logger.warn(`[dispatch] SD-dispatchable check skipped for ${sdKey} (lookup error, fail-open): ${e.message}`);
+    return;
+  }
+  if (!found) {
+    const e = new Error(`[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} does not exist — refusing to dispatch a phantom id (mirrors claim_sd sd_not_found).`);
+    e.code = 'DISPATCH_SD_NOT_FOUND';
+    logger && logger.error && logger.error(e.message);
+    throw e;
+  }
+  const terminal = isQf ? isTerminalQfStatus(status) : isTerminalSdStatus(status);
+  if (terminal) {
+    const e = new Error(`[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} is in terminal status '${status}' — refusing to dispatch a finished/cancelled SD (claim_sd would reject it as sd_terminal_status).`);
+    e.code = 'DISPATCH_SD_TERMINAL';
+    logger && logger.error && logger.error(e.message);
+    throw e;
+  }
+}
+
 /**
  * SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001 (FR-5): stamp an ADVISORY
  * payload.effort_recommendation on WORK_ASSIGNMENT rows at this choke point —
@@ -148,6 +213,9 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
     throw e;
   }
   await assertValidTarget(supabase, row.target_session, logger);
+  // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a terminal/non-existent SD before the
+  // insert (mirrors claim_sd's terminal guard — fails CLOSED on terminal/not-found, open on a DB hiccup).
+  await assertSdDispatchable(supabase, row, logger);
   await stampEffortRecommendation(supabase, row, logger);
   let q = supabase.from('session_coordination').insert(row);
   if (select) {
@@ -174,4 +242,7 @@ module.exports = {
   insertCoordinationRow,
   dispatchToWorker,
   stampEffortRecommendation,
+  isTerminalSdStatus,
+  isTerminalQfStatus,
+  assertSdDispatchable,
 };

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -114,7 +114,13 @@ function isTerminalQfStatus(status) {
 async function assertSdDispatchable(supabase, row, logger = console) {
   if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
   const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
-  const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+  // Resolve the named SD from EVERY key real producers actually emit:
+  //   row.target_sd (top-level)  — stale-session-sweep + coordinator-cold-recovery
+  //   payload.sd_key             — coordinator-cold-recovery resume payload
+  //   payload.current_sd         — stale-session-sweep payload
+  //   payload.assigned_sd        — explicit assignment payloads
+  // (Omitting payload.current_sd was the gap that let the sweep's nudge slip past the guard.)
+  const sdKey = row.target_sd || payload.sd_key || payload.current_sd || payload.assigned_sd || null;
   if (!sdKey) return; // a WORK_ASSIGNMENT with no named SD (e.g. a generic nudge) — nothing to check
   const isQf = /^QF-/.test(sdKey);
   let status, found;
@@ -193,8 +199,10 @@ async function stampEffortRecommendation(supabase, row, logger = console) {
 }
 
 /**
- * Validated session_coordination insert. The single code path coordinator-side
- * inserts route through. Validates row.target_session, then performs the insert.
+ * Validated session_coordination insert. The INTENDED choke point coordinator-side
+ * inserts route through — though some producers (notably the stale-session-sweep cron)
+ * still insert raw and therefore call assertSdDispatchable directly. Validates
+ * row.target_session, refuses terminal/non-existent targets, then performs the insert.
  *
  * @param {object} supabase - Supabase client
  * @param {object} row - session_coordination row (must include target_session)

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -29,6 +29,11 @@ const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
 const { evaluateDispatchEligibility, classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
+// SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: the sweep is the primary scheduled WORK_ASSIGNMENT producer
+// and inserts raw (it does NOT route through insertCoordinationRow), so the dispatch-side terminal
+// guard would never reach it. Call assertSdDispatchable here so the sweep also refuses to nudge a
+// worker about a terminal/non-existent SD (it fails OPEN on a transient DB error).
+const { assertSdDispatchable } = require('../lib/coordinator/dispatch.cjs');
 // SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): single shared definition of which
 // classified session statuses count as "currently holding the SD claim" — used
 // by BOTH the available-to-claim filter and the worker-render filter below so
@@ -595,17 +600,26 @@ async function dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, availa
 
     if (existing && existing.length > 0) continue; // Don't spam
 
-    await supabase
-      .from('session_coordination')
-      .insert({
-        target_session: s.session_id,
-        target_sd: s.sd_key,
-        message_type: 'WORK_ASSIGNMENT',
-        subject: 'Next work available when ' + s.sd_key.split('-').pop() + ' completes',
-        body: 'When you complete ' + s.sd_key + ', pick up the next unclaimed child.\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
-        payload: { available_sds: available, current_sd: s.sd_key },
-        sender_type: 'sweep'
-      });
+    const row = {
+      target_session: s.session_id,
+      target_sd: s.sd_key,
+      message_type: 'WORK_ASSIGNMENT',
+      subject: 'Next work available when ' + s.sd_key.split('-').pop() + ' completes',
+      body: 'When you complete ' + s.sd_key + ', pick up the next unclaimed child.\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
+      payload: { available_sds: available, current_sd: s.sd_key },
+      sender_type: 'sweep'
+    };
+    // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to nudge about a terminal/non-existent SD.
+    // assertSdDispatchable throws DISPATCH_SD_TERMINAL/NOT_FOUND (skip this worker) and fails OPEN
+    // on a transient DB error (the nudge proceeds; claim_sd remains the backstop).
+    try {
+      await assertSdDispatchable(supabase, row, console);
+    } catch (e) {
+      console.log('[SWEEP] WORK_ASSIGNMENT skipped for ' + s.session_id + ' (' + (e.code || 'guard') + '): ' + s.sd_key);
+      continue;
+    }
+
+    await supabase.from('session_coordination').insert(row);
     dispatched++;
   }
   return { dispatched, skipped: 0, blocked: false };

--- a/tests/unit/coordinator-dispatch-terminal-guard.test.js
+++ b/tests/unit/coordinator-dispatch-terminal-guard.test.js
@@ -1,0 +1,115 @@
+/**
+ * SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001 — the coordinator dispatch choke point must refuse to create
+ * a WORK_ASSIGNMENT for a terminal (completed/cancelled/deferred) or non-existent SD/QF, mirroring the
+ * claim_sd RPC's terminal guard so dispatch and claim never disagree. Non-WORK_ASSIGNMENT rows and a
+ * transient DB lookup error must NOT be blocked (fail-open).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  isTerminalSdStatus, isTerminalQfStatus, assertSdDispatchable, insertCoordinationRow,
+} = require('../../lib/coordinator/dispatch.cjs');
+
+const LIVE_TARGET = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const silentLog = { warn() {}, error() {}, log() {} };
+
+// Supabase stub: resolves SD/QF status from a fixture map; can simulate a lookup error.
+function stubSupabase({ sds = {}, qfs = {}, throwOn = null, liveSessions = [LIVE_TARGET] } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        _table: table, _eq: null,
+        select() { return chain; },
+        eq(_col, val) { chain._eq = val; return chain; },
+        limit() { return chain; },
+        maybeSingle() {
+          if (throwOn === table) return Promise.resolve({ data: null, error: { message: 'transient boom' } });
+          if (table === 'strategic_directives_v2') {
+            return Promise.resolve({ data: chain._eq in sds ? { status: sds[chain._eq] } : null, error: null });
+          }
+          if (table === 'quick_fixes') {
+            return Promise.resolve({ data: chain._eq in qfs ? { status: qfs[chain._eq] } : null, error: null });
+          }
+          if (table === 'claude_sessions') {
+            return Promise.resolve({ data: liveSessions.includes(chain._eq) ? { session_id: chain._eq, status: 'active' } : null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        // insert path for insertCoordinationRow
+        insert(r) { chain._inserted = r; return chain; },
+        then(res, rej) { return Promise.resolve({ data: chain._inserted || null, error: null }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('pure terminal-status classifiers', () => {
+  it('SD terminal set = completed/cancelled/deferred', () => {
+    for (const s of ['completed', 'cancelled', 'deferred', 'COMPLETED']) expect(isTerminalSdStatus(s)).toBe(true);
+    for (const s of ['draft', 'active', 'in_progress', 'pending_approval', '', null, undefined]) expect(isTerminalSdStatus(s)).toBe(false);
+  });
+  it('QF terminal set = completed/cancelled/escalated', () => {
+    for (const s of ['completed', 'cancelled', 'escalated']) expect(isTerminalQfStatus(s)).toBe(true);
+    for (const s of ['open', 'in_progress', null]) expect(isTerminalQfStatus(s)).toBe(false);
+  });
+});
+
+describe('assertSdDispatchable', () => {
+  const wa = (sdKey) => ({ message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, payload: { assigned_sd: sdKey } });
+
+  it('REFUSES a completed SD (DISPATCH_SD_TERMINAL)', async () => {
+    const sb = stubSupabase({ sds: { 'SD-X-001': 'completed' } });
+    await expect(assertSdDispatchable(sb, wa('SD-X-001'), silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+  });
+  it('REFUSES cancelled + deferred SDs', async () => {
+    const sb = stubSupabase({ sds: { 'SD-C': 'cancelled', 'SD-D': 'deferred' } });
+    await expect(assertSdDispatchable(sb, wa('SD-C'), silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+    await expect(assertSdDispatchable(sb, wa('SD-D'), silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+  });
+  it('ALLOWS a draft/active SD', async () => {
+    const sb = stubSupabase({ sds: { 'SD-OK': 'draft' } });
+    await expect(assertSdDispatchable(sb, wa('SD-OK'), silentLog)).resolves.toBeUndefined();
+  });
+  it('REFUSES a non-existent SD (DISPATCH_SD_NOT_FOUND)', async () => {
+    const sb = stubSupabase({ sds: {} });
+    await expect(assertSdDispatchable(sb, wa('SD-GHOST'), silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_NOT_FOUND' });
+  });
+  it('REFUSES a terminal QF (escalated)', async () => {
+    const sb = stubSupabase({ qfs: { 'QF-1': 'escalated' } });
+    await expect(assertSdDispatchable(sb, wa('QF-1'), silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+  });
+  it('ALLOWS an open QF', async () => {
+    const sb = stubSupabase({ qfs: { 'QF-2': 'open' } });
+    await expect(assertSdDispatchable(sb, wa('QF-2'), silentLog)).resolves.toBeUndefined();
+  });
+  it('IGNORES non-WORK_ASSIGNMENT rows', async () => {
+    const sb = stubSupabase({ sds: { 'SD-X': 'completed' } });
+    await expect(assertSdDispatchable(sb, { message_type: 'INFO', payload: { assigned_sd: 'SD-X' } }, silentLog)).resolves.toBeUndefined();
+  });
+  it('IGNORES a WORK_ASSIGNMENT with no named SD', async () => {
+    const sb = stubSupabase({});
+    await expect(assertSdDispatchable(sb, { message_type: 'WORK_ASSIGNMENT', payload: {} }, silentLog)).resolves.toBeUndefined();
+  });
+  it('FAILS-OPEN on a transient lookup error (does not block dispatch)', async () => {
+    const sb = stubSupabase({ throwOn: 'strategic_directives_v2' });
+    await expect(assertSdDispatchable(sb, wa('SD-ANY'), silentLog)).resolves.toBeUndefined();
+  });
+});
+
+describe('insertCoordinationRow integration: terminal SD is refused before insert', () => {
+  it('throws DISPATCH_SD_TERMINAL and does NOT insert for a completed SD', async () => {
+    const sb = stubSupabase({ sds: { 'SD-DONE': 'completed' } });
+    await expect(insertCoordinationRow(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, payload: { assigned_sd: 'SD-DONE' },
+    }, { logger: silentLog })).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+  });
+  it('allows a draft SD through to the insert', async () => {
+    const sb = stubSupabase({ sds: { 'SD-GO': 'active' } });
+    const res = await insertCoordinationRow(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, payload: { assigned_sd: 'SD-GO' },
+    }, { logger: silentLog });
+    expect(res.error).toBeNull();
+  });
+});

--- a/tests/unit/coordinator-dispatch-terminal-guard.test.js
+++ b/tests/unit/coordinator-dispatch-terminal-guard.test.js
@@ -57,7 +57,13 @@ describe('pure terminal-status classifiers', () => {
 });
 
 describe('assertSdDispatchable', () => {
-  const wa = (sdKey) => ({ message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, payload: { assigned_sd: sdKey } });
+  // Realistic producer shape: stale-session-sweep emits target_sd (top-level) + payload.current_sd —
+  // NOT payload.assigned_sd. Using the real shape is what makes these tests catch a resolution-key
+  // regression instead of masking one (the adversarial-review fix for this SD).
+  const wa = (sdKey) => ({
+    message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET,
+    target_sd: sdKey, payload: { available_sds: [], current_sd: sdKey },
+  });
 
   it('REFUSES a completed SD (DISPATCH_SD_TERMINAL)', async () => {
     const sb = stubSupabase({ sds: { 'SD-X-001': 'completed' } });
@@ -91,6 +97,24 @@ describe('assertSdDispatchable', () => {
   it('IGNORES a WORK_ASSIGNMENT with no named SD', async () => {
     const sb = stubSupabase({});
     await expect(assertSdDispatchable(sb, { message_type: 'WORK_ASSIGNMENT', payload: {} }, silentLog)).resolves.toBeUndefined();
+  });
+  it('resolves the SD from payload.current_sd alone (sweep nudge with no top-level target_sd)', async () => {
+    const sb = stubSupabase({ sds: { 'SD-SWEEP': 'completed' } });
+    await expect(assertSdDispatchable(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, payload: { current_sd: 'SD-SWEEP' },
+    }, silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+  });
+  it('resolves the SD from payload.sd_key alone (cold-recovery resume shape)', async () => {
+    const sb = stubSupabase({ sds: { 'SD-RESUME': 'cancelled' } });
+    await expect(assertSdDispatchable(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: 'broadcast', payload: { kind: 'resume', sd_key: 'SD-RESUME' },
+    }, silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
+  });
+  it('resolves the SD from top-level target_sd alone', async () => {
+    const sb = stubSupabase({ sds: { 'SD-TOP': 'deferred' } });
+    await expect(assertSdDispatchable(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, target_sd: 'SD-TOP', payload: {},
+    }, silentLog)).rejects.toMatchObject({ code: 'DISPATCH_SD_TERMINAL' });
   });
   it('FAILS-OPEN on a transient lookup error (does not block dispatch)', async () => {
     const sb = stubSupabase({ throwOn: 'strategic_directives_v2' });


### PR DESCRIPTION
@
## Summary
The coordinator dispatch choke point could create a WORK_ASSIGNMENT for a terminal (completed/cancelled/deferred; QF: completed/cancelled/escalated) or non-existent SD/QF even though `claim_sd` already refuses such targets, producing wasted dispatch + confusing worker claim errors.

Adds `assertSdDispatchable` (+ pure `isTerminalSdStatus`/`isTerminalQfStatus`) mirroring the live `claim_sd` terminal guard:
- Fails **CLOSED** on terminal / not-found.
- Fails **OPEN** on a transient DB lookup error so a hiccup never wedges dispatch.

## Adversarial-review hardening (2nd commit)
- **F1**: the stale-session-sweep cron is the primary scheduled WORK_ASSIGNMENT producer and inserts raw, bypassing `insertCoordinationRow`. It now calls `assertSdDispatchable` directly (skips a worker on a terminal/non-existent SD; fails open).
- **F2**: key resolution now reads `target_sd / payload.sd_key / payload.current_sd / payload.assigned_sd` — the keys real producers actually emit (sweep + cold-recovery).
- **F3**: tests rewritten to the real sweep shape + per-key resolution tests.
- **F4**: softened the over-claimed single-choke-point docstring.

## Tests
16 unit tests (`tests/unit/coordinator-dispatch-terminal-guard.test.js`) — classifiers, guard branches, per-key resolution, fail-open, insert integration. `node --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@