### PR TITLE
feat(SD-LEO-INFRA-PRODUCT-PROMOTION-TARGET-REPO-001): --target-repos on --from-roadmap-item → product items route to EHG repo

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -573,6 +573,19 @@ async function persistLaneFailSoft(sb, item, lane) {
  * (FR-4). FR-5 hard guard: an already-promoted item never double-promotes. Mirrors the createFromFeedback
  * contract (--type / --title overrides, guardrail review flags).
  */
+/**
+ * SD-LEO-INFRA-PRODUCT-PROMOTION-TARGET-REPO-001: compute the repo-routing overrides for a
+ * promoted roadmap SD from a (already-validated, normalized) --target-repos list. Pure + exported.
+ * The first repo is the primary target_application (drives EXEC/gate/branch repo resolution); the
+ * full list is stamped to metadata.target_repos. Empty/missing → {} (createSD keeps its default).
+ * @param {string[]|null|undefined} targetRepos
+ * @returns {{ target_application?: string, target_repos?: string[] }}
+ */
+export function buildPromotionRepoOverrides(targetRepos) {
+  if (!Array.isArray(targetRepos) || targetRepos.length === 0) return {};
+  return { target_application: targetRepos[0], target_repos: targetRepos };
+}
+
 async function createFromRoadmapItem(itemId, options = {}) {
   const { migrationReviewed = false, securityReviewed = false } = options;
   console.log(`\n🗺️  Creating SD from roadmap item: ${itemId}`);
@@ -612,6 +625,11 @@ async function createFromRoadmapItem(itemId, options = {}) {
   const sdTitle = options.titleOverride || fields.title;
   const sdKey = await generateSDKey({ source: SD_SOURCES.LEO, type, title: sdTitle, venturePrefix: null });
 
+  // SD-LEO-INFRA-PRODUCT-PROMOTION-TARGET-REPO-001: route the promoted SD to a product repo when
+  // --target-repos is given (the PRIMARY repo → top-level target_application that branch-resolver/
+  // repo-paths read to resolve EXEC/gates/branch onto rickfelix/ehg; the full list → metadata.target_repos).
+  const repoOverrides = buildPromotionRepoOverrides(options.targetRepos);
+
   const sd = await createSD({
     sdKey,
     title: sdTitle,
@@ -619,10 +637,12 @@ async function createFromRoadmapItem(itemId, options = {}) {
     type,
     priority: 'medium',
     rationale: `Promoted from roadmap_wave_items ${item.id} (register-first path).`,
+    ...(repoOverrides.target_application ? { target_application: repoOverrides.target_application } : {}),
     metadata: {
       ...fields.metadata,
       ...(migrationReviewed ? { migration_reviewed: true } : {}),
       ...(securityReviewed ? { security_reviewed: true } : {}),
+      ...(repoOverrides.target_repos ? { target_repos: repoOverrides.target_repos } : {}),
     },
   });
 
@@ -2596,8 +2616,10 @@ Flags:
                         to ONLY these repos. Required for SDs spanning both platform repos.
                         Example: --target-repos EHG,EHG_Engineer
                         Pairs with computeReposForSD() at lead-final-approval/gates.js
-                        (SD-LEO-INFRA-CROSS-REPO-MERGE-001). Supported in all 3 modes:
-                        direct LEO, --from-plan, --child.
+                        (SD-LEO-INFRA-CROSS-REPO-MERGE-001). Supported in: direct LEO,
+                        --from-plan, --child, AND --from-roadmap-item (the latter also sets
+                        the promoted SD's target_application to the PRIMARY repo so product
+                        roadmap items route to rickfelix/ehg — SD-LEO-INFRA-PRODUCT-PROMOTION-TARGET-REPO-001).
   --dry-run          (--from-proposal / --proposal-b64 / --proposal-stdin) Validate + report
                      would-create SDs; ZERO database writes.
   --proposal-b64 <b64>  File-free DB-direct sourcing: base64-encoded proposal JSON ingested via
@@ -2678,11 +2700,16 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       // SD with the two-way stamp. Mirrors --from-feedback flag parsing (--type/--title/review flags).
       const riTypeIdx = args.indexOf('--type');
       const riTitleIdx = args.indexOf('--title');
+      // SD-LEO-INFRA-PRODUCT-PROMOTION-TARGET-REPO-001: --target-repos routes a promoted roadmap
+      // item to a product repo (e.g. EHG → rickfelix/ehg), unblocking the 268 product roadmap items
+      // that --from-roadmap-item could not target (it forced venturePrefix=null / EHG_Engineer).
+      const riTargetReposIdx = args.indexOf('--target-repos');
       const riFlagValuePositions = new Set(
         [riTypeIdx !== -1 ? riTypeIdx + 1 : -1,
-         riTitleIdx !== -1 ? riTitleIdx + 1 : -1].filter(i => i > 0)
+         riTitleIdx !== -1 ? riTitleIdx + 1 : -1,
+         riTargetReposIdx !== -1 ? riTargetReposIdx + 1 : -1].filter(i => i > 0)
       );
-      const riKnownFlags = new Set(['--from-roadmap-item', '--type', '--title', '--migration-reviewed', '--security-reviewed']);
+      const riKnownFlags = new Set(['--from-roadmap-item', '--type', '--title', '--migration-reviewed', '--security-reviewed', '--target-repos']);
       const roadmapItemId = args.find((arg, i) =>
         i > 0 && !arg.startsWith('-') && !riFlagValuePositions.has(i) && !riKnownFlags.has(arg)
       ) || args[1];
@@ -2691,6 +2718,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         titleOverride: riTitleIdx !== -1 ? args[riTitleIdx + 1] : null,
         migrationReviewed: args.includes('--migration-reviewed'),
         securityReviewed: args.includes('--security-reviewed'),
+        targetRepos: riTargetReposIdx !== -1 ? parseTargetReposArg(args[riTargetReposIdx + 1]) : null,
       });
     } else if (args[0] === '--from-qf') {
       await createFromQF(args[1]);

--- a/tests/unit/promotion-target-repo.test.js
+++ b/tests/unit/promotion-target-repo.test.js
@@ -1,0 +1,47 @@
+/**
+ * SD-LEO-INFRA-PRODUCT-PROMOTION-TARGET-REPO-001 — tests for repo routing on the
+ * --from-roadmap-item promotion path: parse + validate --target-repos and translate it into the
+ * promoted SD's target_application (primary repo) + metadata.target_repos overrides.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseTargetReposArg, buildPromotionRepoOverrides } from '../../scripts/leo-create-sd.js';
+
+describe('parseTargetReposArg (reused on the roadmap-item route)', () => {
+  it('normalizes case → canonical repo names', () => {
+    expect(parseTargetReposArg('ehg')).toEqual(['EHG']);
+    expect(parseTargetReposArg('EHG_Engineer')).toEqual(['EHG_Engineer']);
+    expect(parseTargetReposArg('ehg,ehg_engineer')).toEqual(['EHG', 'EHG_Engineer']);
+  });
+  it('dedups and trims', () => {
+    expect(parseTargetReposArg(' EHG , ehg ')).toEqual(['EHG']);
+  });
+  it('returns null for empty/missing', () => {
+    expect(parseTargetReposArg(null)).toBeNull();
+    expect(parseTargetReposArg('')).toBeNull();
+    expect(parseTargetReposArg('   ')).toBeNull();
+  });
+});
+
+describe('buildPromotionRepoOverrides', () => {
+  it('routes a product roadmap item to EHG: primary → target_application, list → target_repos', () => {
+    expect(buildPromotionRepoOverrides(['EHG'])).toEqual({ target_application: 'EHG', target_repos: ['EHG'] });
+  });
+  it('uses the FIRST repo as the primary target_application for a multi-repo list', () => {
+    expect(buildPromotionRepoOverrides(['EHG', 'EHG_Engineer'])).toEqual({
+      target_application: 'EHG',
+      target_repos: ['EHG', 'EHG_Engineer'],
+    });
+  });
+  it('returns {} (no override → createSD keeps its default) for empty/missing', () => {
+    expect(buildPromotionRepoOverrides(null)).toEqual({});
+    expect(buildPromotionRepoOverrides([])).toEqual({});
+    expect(buildPromotionRepoOverrides(undefined)).toEqual({});
+  });
+
+  it('end-to-end: --target-repos EHG promotes to the product repo (parse → overrides)', () => {
+    const parsed = parseTargetReposArg('ehg');               // CLI value
+    const overrides = buildPromotionRepoOverrides(parsed);   // what createFromRoadmapItem applies
+    expect(overrides.target_application).toBe('EHG');         // routes EXEC/gates/branch → rickfelix/ehg
+    expect(overrides.target_repos).toEqual(['EHG']);
+  });
+});


### PR DESCRIPTION
## Summary
`leo-create-sd --from-roadmap-item` forced `venturePrefix=null` and couldn't target `rickfelix/ehg`, so the **268 product roadmap items** (EVA 106 / Chairman-UI 132 / Ventures 30) were **unpromotable** — the #1 product-build-front blocker (Adam two-front analysis 2026-06-20).

## Changes (`scripts/leo-create-sd.js`)
- Parse `--target-repos` on the `--from-roadmap-item` branch (reuse `parseTargetReposArg` + `ALLOWED_REPOS`; added to `riKnownFlags`/`riFlagValuePositions` so it isn't mistaken for the item-id positional).
- NEW pure `buildPromotionRepoOverrides(targetRepos)`: the **primary** repo → the promoted SD's top-level `target_application` (what `branch-resolver`/`repo-paths` read to route EXEC/gates/branch onto `rickfelix/ehg`); the full list → `metadata.target_repos` (parity with child/direct/from-plan). Absent the flag → no override (createSD keeps its `EHG_Engineer` default).
- Register-first two-way stamp + lane routing preserved; `--help` updated.

## Verification
- `npx vitest run tests/unit/promotion-target-repo.test.js` → **7 pass** (parse/normalize; primary→`target_application`, list→`metadata.target_repos`; empty→`{}`)
- `node --check` clean

Now `--from-roadmap-item <id> --target-repos EHG` promotes a product roadmap item to an SD that targets the EHG product repo. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)