### PR TITLE
feat(SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001): semantic problem-phrased dedup

### DIFF
--- a/lib/sourcing-engine/proactive-populator.js
+++ b/lib/sourcing-engine/proactive-populator.js
@@ -76,6 +76,7 @@ export function buildCorpus({ ledger = [], wave6 = [], deferred = [], backlog = 
   for (const r of ledger) {
     push({ corpus: 'conversion_ledger', source_type: corpusSourceType(r), source_id: r.id,
       title: r.title || r.source_external_id || r.source_id, disposition: null,
+      description: r.description || null, // SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001: carry problem text for semantic dedup
       rung: r.target_rung || null, sdKeyHint: r.dedup_match_sd_key || null });
   }
   for (const r of wave6) {
@@ -86,13 +87,14 @@ export function buildCorpus({ ledger = [], wave6 = [], deferred = [], backlog = 
   }
   for (const r of deferred) {
     push({ corpus: 'deferred_v2', source_type: 'brainstorm', source_id: r.id,
-      title: r.title || r.sd_key, disposition: null, rung: (r.metadata && r.metadata.rung) || null,
-      sdKeyHint: r.sd_key });
+      title: r.title || r.sd_key, disposition: null, description: r.description || null,
+      rung: (r.metadata && r.metadata.rung) || null, sdKeyHint: r.sd_key });
   }
   for (const r of backlog) {
     push({ corpus: 'harness_backlog', source_type: 'brainstorm', source_id: r.id,
-      title: r.title || (r.description || '').slice(0, 80), disposition: null, rung: null,
-      sdKeyHint: r.sd_id || null });
+      title: r.title || (r.description || '').slice(0, 80), disposition: null,
+      description: r.description || null, // carry full problem text for semantic dedup
+      rung: null, sdKeyHint: r.sd_id || null });
   }
   return out;
 }
@@ -115,6 +117,9 @@ export function classifyCandidate(c) {
   return {
     source_id: c.sdKeyHint || c.source_id,
     title: c.title,
+    // SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001: pass the problem text through so findDedupMatch's
+    // semantic problem-key path can catch problem-phrased restatements (not just title matches).
+    description: c.description == null ? null : c.description,
     disposition: c.disposition,
     rung: c.rung,
     ...(authority ? { authority } : {}),

--- a/lib/sourcing-engine/router.js
+++ b/lib/sourcing-engine/router.js
@@ -70,6 +70,51 @@ export function jaccard(a, b) {
 // share 2 tokens and still match.
 const MIN_FUZZY_TOKEN_OVERLAP = 2;
 
+// SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001: PROBLEM-PHRASED dedup. The title-only paths miss
+// restatements of already-shipped work that use different title wording (Adam triage: 116/208 = 56%
+// of staged keepers were such dups). A description-aware problem-key catches them. PRECISION-FIRST:
+// a false positive would DROP novel work via the disposition gate's already_covered path, while a
+// miss merely leaves a dup on the belt for triage — so the bar is deliberately high.
+// Semantic match uses the OVERLAP COEFFICIENT |A∩B| / min(|A|,|B|), not Jaccard: a short
+// problem-phrased restatement vs a long shipped-SD body shares most of the SHORTER key's tokens even
+// though Jaccard is dragged down by the longer body's extra words. The min-overlap guard is what
+// preserves precision — a candidate that merely shares a few generic infra tokens can never reach it.
+const SEMANTIC_OVERLAP_COEFF_THRESHOLD = 0.6; // >=60% of the smaller problem-key's tokens must be shared
+const MIN_SEMANTIC_OVERLAP = 4;               // AND >=4 shared meaningful tokens (generic overlap never matches)
+
+// Tokens with no discriminating value for "is this the same PROBLEM?" — dropped from the problem-key.
+const PROBLEM_STOPWORDS = new Set([
+  'the', 'a', 'an', 'to', 'of', 'in', 'on', 'for', 'and', 'or', 'is', 'are', 'was', 'were', 'be',
+  'that', 'this', 'it', 'its', 'with', 'at', 'by', 'from', 'as', 'not', 'no', 'but', 'if', 'when',
+  'so', 'do', 'does', 'did', 'can', 'should', 'must', 'via', 'per', 'only', 'any', 'all', 'we',
+  'our', 'you', 'your', 'they', 'their', 'there', 'here', 'into', 'out', 'up', 'down', 'then',
+  'than', 'has', 'have', 'had', 'will', 'would', 'could', 'may', 'might', 'sd', 'qf', 'fix', 'add',
+]);
+
+/**
+ * SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001: normalize a candidate's PROBLEM TEXT (title + optional
+ * description) into a Set of meaningful tokens for semantic dedup. Strips identifiers that carry no
+ * problem-meaning (SD/QF keys, version numbers like v2.1.108, UUIDs, URLs), punctuation, short noise
+ * tokens, bare numbers, and stopwords — so the residue is the words that describe the PROBLEM. PURE.
+ */
+export function normalizeProblemKey(title, description) {
+  const cleaned = `${title == null ? '' : title} ${description == null ? '' : description}`
+    .toLowerCase()
+    .replace(/\b(?:sd|qf)-[a-z0-9-]+/g, ' ')                                   // SD/QF keys
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g, ' ') // UUIDs
+    .replace(/\bv?\d+(?:\.\d+)+\b/g, ' ')                                       // version numbers
+    .replace(/https?:\/\/\S+/g, ' ')                                            // URLs
+    .replace(/[^a-z0-9]+/g, ' ');                                              // punctuation
+  const out = new Set();
+  for (const tok of cleaned.split(/\s+/)) {
+    if (!tok || tok.length < 3) continue;   // drop 1-2 char noise
+    if (/^\d+$/.test(tok)) continue;        // bare numbers carry no problem-meaning
+    if (PROBLEM_STOPWORDS.has(tok)) continue;
+    out.add(tok);
+  }
+  return out;
+}
+
 function toSet(v) {
   if (v instanceof Set) return v;
   if (Array.isArray(v)) return new Set(v);
@@ -110,7 +155,30 @@ function findDedupMatch(item, existing, threshold) {
       best = { sd_key: e.sd_key, reason: 'jaccard', score };
     }
   }
-  return best;
+  if (best) return best; // a title-level match (exact/jaccard) wins — existing behavior unchanged
+
+  // SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001: PROBLEM-PHRASED dedup. Only runs when the title paths
+  // found nothing. Compares normalized problem-keys (title+description) so a restatement of shipped
+  // work with different title wording is caught. PRECISION-FIRST: requires BOTH a high Jaccard AND a
+  // minimum meaningful-token overlap, and the candidate must itself carry enough signal — a sparse or
+  // opaque title (e.g. a bare version number) yields too few tokens and is never force-matched.
+  const myKey = normalizeProblemKey(item && item.title, item && item.description);
+  if (myKey.size >= MIN_SEMANTIC_OVERLAP) {
+    let semBest = null;
+    for (const e of existing) {
+      if (!e || !e.sd_key) continue;
+      const eKey = normalizeProblemKey(e.title, e.description);
+      const overlap = intersectionSize(myKey, eKey);
+      if (overlap < MIN_SEMANTIC_OVERLAP) continue;
+      const denom = Math.min(myKey.size, eKey.size);
+      const score = denom === 0 ? 0 : overlap / denom; // overlap coefficient
+      if (score >= SEMANTIC_OVERLAP_COEFF_THRESHOLD && (!semBest || score > semBest.score)) {
+        semBest = { sd_key: e.sd_key, reason: 'semantic', score };
+      }
+    }
+    if (semBest) return semBest;
+  }
+  return null;
 }
 
 /** Does this candidate conflict with an in-flight SD (shared write-surface OR a declared dep)? */

--- a/scripts/sourcing-engine/proactive-populator.mjs
+++ b/scripts/sourcing-engine/proactive-populator.mjs
@@ -28,7 +28,7 @@ const TERMINAL_DISPOSITIONS = ['built', 'already_covered', 'duplicate', 'decline
 async function loadSources(db) {
   // 1. conversion_ledger — undispositioned backlog
   const { data: ledger } = await db.from('conversion_ledger')
-    .select('id,source_pool,source_id,source_external_id,title,target_rung,dedup_match_sd_key,disposition')
+    .select('id,source_pool,source_id,source_external_id,title,description,target_rung,dedup_match_sd_key,disposition')
     .is('disposition', null).limit(2000);
   // 2. Wave-6 (highest-rank wave of the LEO Roadmap) — already-staged items, enumerated for the report
   let wave6 = [];
@@ -45,7 +45,7 @@ async function loadSources(db) {
     }
   } catch { /* fail-soft: wave6 stays empty */ }
   // 3. deferred V2 cluster
-  const { data: deferred } = await db.from('strategic_directives_v2').select('id,sd_key,title,status,metadata').eq('status', 'deferred').limit(500);
+  const { data: deferred } = await db.from('strategic_directives_v2').select('id,sd_key,title,description,status,metadata').eq('status', 'deferred').limit(500);
   // 4. harness backlog (exclude auto-capture noise)
   const { data: backlogRaw } = await db.from('feedback').select('id,title,description,status,category,sd_id,metadata').eq('category', 'harness_backlog').eq('status', 'new').limit(1000);
   const backlog = (backlogRaw || []).filter((r) => !(r.metadata && r.metadata.flag_class) && !/^(Completion flag|Fleet retro|Coordinator review)/i.test(r.title || ''));
@@ -75,8 +75,10 @@ export async function fetchAllRows(db, table, select, pageSize = 1000) {
 
 async function loadContext(db) {
   // Load EVERY SD (paginated) so dedup matches against the full corpus, not just the first 1000.
-  const sds = await fetchAllRows(db, 'strategic_directives_v2', 'sd_key,title,status');
-  const existing = sds.map((s) => ({ sd_key: s.sd_key, title: s.title }));
+  // SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001: also load description so findDedupMatch's semantic
+  // problem-key path can catch problem-phrased restatements (not just title matches).
+  const sds = await fetchAllRows(db, 'strategic_directives_v2', 'sd_key,title,description,status');
+  const existing = sds.map((s) => ({ sd_key: s.sd_key, title: s.title, description: s.description }));
   const shippedInfraKeys = sds.filter((s) => s.status === 'completed').map((s) => s.sd_key);
   // outcomeRealizedKeys left empty = the SAFE direction (a shipped-but-unrealized SD re-emits; never falsely closes work).
   return { existing, inFlight: [], shippedInfraKeys, outcomeRealizedKeys: [] };

--- a/tests/unit/sourcing-engine/router-semantic-dedup.test.js
+++ b/tests/unit/sourcing-engine/router-semantic-dedup.test.js
@@ -4,8 +4,8 @@
  * findDedupMatch was title-only (exact normalized title OR Jaccard>=0.8 over title tokens), so it
  * missed PROBLEM-PHRASED restatements of already-shipped work (Adam triage: 116/208 = 56% of staged
  * keepers were such dups). A description-aware problem-key path now catches them — PRECISION-FIRST:
- * a false positive would drop NOVEL work via the disposition gate, so the bar is high (>=0.5 Jaccard
- * over normalized problem-key token-sets AND >=4 shared meaningful tokens). These tests pin both the
+ * a false positive would drop NOVEL work via the disposition gate, so the bar is high (>=0.6
+ * overlap-coefficient over normalized problem-key token-sets AND >=4 shared meaningful tokens). These tests pin both the
  * catch (problem-phrased dup) and the precision guard (novel work never falsely flagged).
  */
 import { describe, it, expect } from 'vitest';

--- a/tests/unit/sourcing-engine/router-semantic-dedup.test.js
+++ b/tests/unit/sourcing-engine/router-semantic-dedup.test.js
@@ -1,0 +1,85 @@
+/**
+ * Semantic / problem-phrased dedup — SD-LEO-INFRA-SOURCING-DEDUP-SEMANTIC-001.
+ *
+ * findDedupMatch was title-only (exact normalized title OR Jaccard>=0.8 over title tokens), so it
+ * missed PROBLEM-PHRASED restatements of already-shipped work (Adam triage: 116/208 = 56% of staged
+ * keepers were such dups). A description-aware problem-key path now catches them — PRECISION-FIRST:
+ * a false positive would drop NOVEL work via the disposition gate, so the bar is high (>=0.5 Jaccard
+ * over normalized problem-key token-sets AND >=4 shared meaningful tokens). These tests pin both the
+ * catch (problem-phrased dup) and the precision guard (novel work never falsely flagged).
+ */
+import { describe, it, expect } from 'vitest';
+import { routeCandidate, normalizeProblemKey, LANES } from '../../../lib/sourcing-engine/router.js';
+
+describe('normalizeProblemKey (FR-1)', () => {
+  it('strips SD/QF keys, version numbers, uuids, urls, punctuation, stopwords, short/number tokens', () => {
+    const k = normalizeProblemKey(
+      'SD-LEO-FOO-001 v2.1.108 reaper destroyed uncommitted worktree changes',
+      'see https://x.y/z and 550e8400-e29b-41d4-a716-446655440000 — the QF-1 fix is at 42'
+    );
+    // identifiers/stopwords/numbers gone; meaningful problem words kept
+    expect(k.has('reaper')).toBe(true);
+    expect(k.has('destroyed')).toBe(true);
+    expect(k.has('uncommitted')).toBe(true);
+    expect(k.has('worktree')).toBe(true);
+    for (const junk of ['sd', 'qf', 'v2', '108', '42', 'the', 'and', 'fix']) {
+      expect(k.has(junk)).toBe(false);
+    }
+  });
+
+  it('an opaque/short title yields too few tokens to ever drive a match', () => {
+    expect(normalizeProblemKey('v2.1.108', null).size).toBe(0);
+  });
+});
+
+const existing = [{
+  sd_key: 'SD-LEO-INFRA-REAPER-PRESERVE-001',
+  title: 'Worktree reaper preserve-before-delete hardening',
+  description: 'The worktree reaper destroyed uncommitted tracked changes when removing a worktree because preservation only copied untracked files.',
+}];
+
+describe('findDedupMatch semantic path via routeCandidate (FR-1) — catch problem-phrased dups', () => {
+  it('catches a restatement with a DIFFERENT title but the same problem text', () => {
+    const r = routeCandidate({
+      source_id: 'uuid-1',
+      title: 'Data loss during cleanup',                          // title shares ~nothing with the SD title
+      description: 'Reaper removing a worktree destroyed uncommitted tracked changes; preservation only handled untracked files.',
+    }, { existing });
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-LEO-INFRA-REAPER-PRESERVE-001');
+  });
+
+  it('PRECISION: a novel candidate sharing only generic tokens is NOT flagged', () => {
+    const r = routeCandidate({
+      source_id: 'uuid-2',
+      title: 'Add a dashboard widget for revenue trends',
+      description: 'Build a new dashboard panel charting weekly revenue so the chairman can see trends.',
+    }, { existing });
+    expect(r.lane).not.toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key == null || r.dedup_match_sd_key === undefined).toBe(true);
+  });
+
+  it('PRECISION: an opaque candidate (bare version title, no description) is NOT force-matched', () => {
+    const r = routeCandidate({ source_id: 'uuid-3', title: 'v2.1.108', description: null }, { existing });
+    expect(r.lane).not.toBe(LANES.DEDUP);
+  });
+
+  it('a title-level (exact) match still wins first — no regression', () => {
+    const r = routeCandidate(
+      { source_id: 'uuid-4', title: 'Worktree reaper preserve-before-delete hardening', description: 'unrelated body' },
+      { existing }
+    );
+    expect(r.lane).toBe(LANES.DEDUP);
+    expect(r.dedup_match_sd_key).toBe('SD-LEO-INFRA-REAPER-PRESERVE-001');
+  });
+
+  it('no existing description → degrades to title-only (no semantic false-positive)', () => {
+    const titleOnly = [{ sd_key: 'SD-X-001', title: 'Worktree reaper preserve hardening' }];
+    const r = routeCandidate(
+      { source_id: 'uuid-5', title: 'Completely different feature', description: 'reaper removing a worktree destroyed uncommitted tracked changes preservation untracked' },
+      { existing: titleOnly }
+    );
+    // existing has no description; candidate problem-key can't reach >=4 overlap on title alone here
+    expect(r.lane).not.toBe(LANES.DEDUP);
+  });
+});


### PR DESCRIPTION
## Summary
The sourcing-engine `findDedupMatch` was TITLE-only, missing problem-phrased restatements of already-shipped work — Adam's triage of the 208 staged keepers found **116/208 (56%)** were such dups. This adds a description-aware, **precision-first** semantic problem-key matcher.

## Changes
- **`normalizeProblemKey(title, description)`** — strips SD/QF keys, version numbers, UUIDs, URLs, punctuation, short/number tokens, stopwords → the words describing the PROBLEM. Pure.
- **`findDedupMatch` semantic pass** — runs only when title paths find nothing (title match still wins). Match when overlap-coefficient `|A∩B|/min(|A|,|B|) >= 0.6` **AND** `>=4` shared meaningful tokens (`reason='semantic'`). Overlap-coeff (not Jaccard) handles a short restatement vs a long SD body; the min-overlap guard rejects generic-token overlap.
- **Thread descriptions** — `loadContext` loads all ~4000 SD descriptions (paginated); `buildCorpus`/`classifyCandidate` carry candidate descriptions. Absent description → title-only (no regression).

## Why it's safe (precision-first)
A false positive would drop novel work via the disposition gate's `already_covered` path, so the bar is high. Live dry-run: **dedup_matches 7 → 163**; of those **122 matched a shipped-but-UNrealized SD → re_emit → outcome-gated (KEPT for review, never dropped)**; only terminal dups hard-drop.

## Testing
7 new tests (catch problem-phrased dup, reject novel, opaque-title, no-regression) + 73 sourcing tests green.

## Follow-ups (flagged)
Per-candidate recompute of existing problem-keys is O(candidates×SDs) — fine for the batch cron, but memoizing the existing-SD keys would speed it up. Embedding-based matching could raise recall on same-domain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)