### PR TITLE
feat(SD-LEO-FEAT-VISION-SCORER-NEVER-001): auto-run vision-scorer at the gate + persist score onto the SD

### DIFF
--- a/scripts/eva/vision-scorer.js
+++ b/scripts/eva/vision-scorer.js
@@ -642,6 +642,29 @@ ${rawResponse.substring(0, 1000)}`;
 
     scoreRecord.id = inserted.id;
 
+    // SD-LEO-FEAT-VISION-SCORER-NEVER-001: sync the score back onto the SD's own
+    // strategic_directives_v2.vision_score / vision_score_action columns. The scorer
+    // historically wrote ONLY eva_vision_scores, leaving the SD column null forever —
+    // so the dashboard showed no score and the GATE_VISION_SCORE fast-path (which reads
+    // sd.vision_score first) always missed. Now every successful scoring run populates
+    // the cached column. Non-blocking: a sync failure must never fail the scoring run.
+    if (sdKey) {
+      try {
+        const { error: syncError } = await supabase
+          .from('strategic_directives_v2')
+          .update({
+            vision_score: Math.round(parsed.total_score),
+            vision_score_action: thresholdAction,
+          })
+          .eq('sd_key', sdKey);
+        if (syncError) {
+          console.warn(`[vision-scorer] vision_score sync failed for ${sdKey}: ${syncError.message}`);
+        }
+      } catch (e) {
+        console.warn(`[vision-scorer] vision_score sync threw for ${sdKey}: ${e?.message || e}`);
+      }
+    }
+
     // Publish vision.scored event — notification orchestrator subscribes
     // via event bus (SD-MAN-INFRA-EVENT-BUS-BACKBONE-001).
     // Errors are caught per-subscriber in the event bus; never fail the scoring run.

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -226,8 +226,14 @@ export async function autoScoreUnscoredSD(sdKey, supabase, deps = {}) {
   let timer;
   try {
     console.log(`   ⏳ No score yet — auto-running vision-scorer for ${sdKey} (bounded ${Math.round(timeoutMs / 1000)}s)…`);
+    // Attach a no-op .catch to the scorer promise so that if it REJECTS after we've already lost the
+    // timeout race (the LLM error arrives past the bound), it never surfaces as an unhandledRejection
+    // (which can crash a process run with --unhandled-rejections=strict). NOTE: the timeout bounds our
+    // WAIT, not the underlying LLM WORK — threading an AbortSignal into scoreSD is a follow-up.
+    const scoring = scorer({ sdKey, supabase, quiet: true });
+    if (scoring && typeof scoring.then === 'function') scoring.catch(() => {});
     const result = await Promise.race([
-      scorer({ sdKey, supabase, quiet: true }),
+      scoring,
       new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('vision auto-score timeout')), timeoutMs); }),
     ]);
     if (result && typeof result.total_score === 'number') {

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -200,13 +200,58 @@ function getDimensionWarnings(dimensionScores) {
 }
 
 /**
+ * SD-LEO-FEAT-VISION-SCORER-NEVER-001: run ONE bounded, awaited vision-score for an
+ * unscored SD right when the gate needs it. The conception-time score (leo-create-sd.js)
+ * and the LEAD-entry async trigger are both fire-and-forget and routinely never complete,
+ * so unscored SDs sat at GATE_VISION_SCORE forever waiting for a human to run the scorer.
+ * This makes the scorer auto-run at the one moment the score is actually required.
+ *
+ * FAIL-OPEN by construction: the scorer is lazy-imported (tests inject deps.scoreSD) and
+ * raced against a timeout; on ANY timeout/error (e.g. no LLM key in CI) it returns null and
+ * the caller falls through to the existing hard block — removing no protection.
+ *
+ * @param {string} sdKey
+ * @param {Object} supabase
+ * @param {Object} [deps] - { scoreSD, timeoutMs } injectable seams for testing
+ * @returns {Promise<Object|null>} the score record ({total_score, threshold_action, dimension_scores}) or null
+ */
+export async function autoScoreUnscoredSD(sdKey, supabase, deps = {}) {
+  if (!sdKey || !supabase) return null;
+  const timeoutMs = Number.isFinite(deps.timeoutMs)
+    ? deps.timeoutMs
+    : Number(process.env.VISION_SCORE_GATE_TIMEOUT_MS) || 120000;
+  const scorer = typeof deps.scoreSD === 'function'
+    ? deps.scoreSD
+    : async (o) => (await import('../../../../../eva/vision-scorer.js')).scoreSD(o);
+  let timer;
+  try {
+    console.log(`   ⏳ No score yet — auto-running vision-scorer for ${sdKey} (bounded ${Math.round(timeoutMs / 1000)}s)…`);
+    const result = await Promise.race([
+      scorer({ sdKey, supabase, quiet: true }),
+      new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('vision auto-score timeout')), timeoutMs); }),
+    ]);
+    if (result && typeof result.total_score === 'number') {
+      console.log(`   ✅ Auto-score complete for ${sdKey}: ${Math.round(result.total_score)}/100`);
+      return result;
+    }
+    return null;
+  } catch (e) {
+    console.log(`   ⚠️  Auto-score for ${sdKey} did not complete (${e?.message || e}) — falling through to hard block.`);
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * Validate vision alignment score for the SD (hard enforcement).
  *
  * @param {Object} sd - Strategic Directive (must have sd_key, sd_type)
  * @param {Object} supabase - Supabase client
+ * @param {Object} [deps] - injectable seams (deps.scoreSD, deps.timeoutMs) for the auto-score
  * @returns {Promise<Object>} Gate result — may block (valid: false)
  */
-export async function validateVisionScore(sd, supabase) {
+export async function validateVisionScore(sd, supabase, deps = {}) {
   const sdKey = sd.sd_key || sd.id;
   const sdType = (sd.sd_type || 'unknown').toLowerCase();
   const baseThreshold = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
@@ -277,6 +322,20 @@ export async function validateVisionScore(sd, supabase) {
     } catch (e) {
       // Intentionally suppressed: DB unavailable — proceed to hard block
       console.debug('[VisionScore] DB score lookup suppressed:', e?.message || e);
+    }
+  }
+
+  // ── SD-LEO-FEAT-VISION-SCORER-NEVER-001: auto-run the scorer for an unscored SD ──
+  // If the SD is STILL unscored (the fire-and-forget conception/LEAD-entry scores never
+  // completed), run ONE bounded, awaited score now so the SD never sits at this gate
+  // indefinitely. Fail-open: on timeout/error this returns null and we fall through to the
+  // existing hard block below — no protection is removed.
+  if (visionScore === null && supabase && sdKey) {
+    const auto = await autoScoreUnscoredSD(sdKey, supabase, deps);
+    if (auto && typeof auto.total_score === 'number') {
+      visionScore = auto.total_score;
+      thresholdAction = auto.threshold_action ?? thresholdAction;
+      dimensionScores = auto.dimension_scores ?? dimensionScores;
     }
   }
 

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -85,14 +85,12 @@ export class LeadToPlanExecutor extends BaseExecutor {
     // Surfaces known gaps from prior failed runs so they can be fixed without a full retry cycle.
     await displayTranslationFidelityPreview(sd, this.supabase);
 
-    // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: opportunistic, FAIL-OPEN, NON-BLOCKING vision-score populate.
-    // If the conception-time async score silently failed, this fires a re-score WITHOUT awaiting it — purely to
-    // raise the pass-rate of the hard createVisionScoreGate below (which is unchanged and remains the safety net).
-    // Import-guarded + fire-and-forget so it can NEVER block this handoff; setup() still returns null regardless.
-    try {
-      const { triggerAsyncVisionScore } = await import('./gates/vision-score-async-trigger.js');
-      triggerAsyncVisionScore(sd, this.supabase);
-    } catch { /* non-blocking: a silent-stall re-score must never affect the LEAD handoff */ }
+    // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001 superseded by SD-LEO-FEAT-VISION-SCORER-NEVER-001:
+    // the old opportunistic fire-and-forget re-score here ran in PARALLEL with the createVisionScoreGate
+    // below, so once the gate began auto-scoring (FR-2) every unscored SD was scored TWICE in one handoff
+    // (two LLM calls, two eva_vision_scores rows, two racing strategic_directives_v2.vision_score writes).
+    // The gate's autoScoreUnscoredSD is now the single, awaited, fail-open authoritative score path, so the
+    // redundant warm-up trigger is removed. createVisionScoreGate remains the hard safety net.
 
     return null;
   }

--- a/tests/unit/eva/vision-score-gate-autoscore.test.js
+++ b/tests/unit/eva/vision-score-gate-autoscore.test.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-FEAT-VISION-SCORER-NEVER-001 — the GATE_VISION_SCORE gate must AUTO-RUN the scorer
+ * (bounded + awaited) for an unscored SD instead of blocking forever and telling a human to run
+ * the scorer by hand. Fail-OPEN: on timeout/error the auto-score returns null and the gate falls
+ * through to its existing hard block (no protection removed). Fakes only — zero DB / LLM.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  autoScoreUnscoredSD,
+  validateVisionScore,
+} from '../../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js';
+
+// Minimal supabase stub: eva_vision_scores fallback returns empty; audit-log insert is swallowed.
+function stubSupabase() {
+  return {
+    from() {
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        order() { return chain; },
+        limit() { return Promise.resolve({ data: [], error: null }); },
+        insert() { return Promise.resolve({ data: null, error: null }); },
+        update() { return chain; },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('autoScoreUnscoredSD', () => {
+  it('returns the score record when the injected scorer succeeds', async () => {
+    const scoreSD = vi.fn().mockResolvedValue({ total_score: 88, threshold_action: 'accept', dimension_scores: { a: { score: 90 } } });
+    const r = await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD });
+    expect(r).toMatchObject({ total_score: 88, threshold_action: 'accept' });
+    expect(scoreSD).toHaveBeenCalledWith(expect.objectContaining({ sdKey: 'SD-X-001' }));
+  });
+
+  it('returns null (fail-open) when the scorer REJECTS', async () => {
+    const scoreSD = vi.fn().mockRejectedValue(new Error('no LLM key'));
+    expect(await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD })).toBeNull();
+  });
+
+  it('returns null (fail-open) when the scorer exceeds the bounded timeout', async () => {
+    const scoreSD = vi.fn(() => new Promise((res) => setTimeout(() => res({ total_score: 99 }), 50)));
+    expect(await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD, timeoutMs: 5 })).toBeNull();
+  });
+
+  it('returns null when the scorer resolves without a numeric total_score', async () => {
+    const scoreSD = vi.fn().mockResolvedValue({ summary: 'oops' });
+    expect(await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD })).toBeNull();
+  });
+
+  it('returns null for a missing sdKey or supabase', async () => {
+    expect(await autoScoreUnscoredSD(null, stubSupabase(), { scoreSD: vi.fn() })).toBeNull();
+    expect(await autoScoreUnscoredSD('SD-X', null, { scoreSD: vi.fn() })).toBeNull();
+  });
+});
+
+describe('validateVisionScore — auto-scores an unscored SD instead of blocking', () => {
+  const baseSd = { sd_key: 'SD-FEAT-001', sd_type: 'infrastructure', vision_score: null, metadata: {} };
+
+  it('PASSES when the auto-score returns a score above threshold (was: hard block)', async () => {
+    // infrastructure threshold = 80; auto-score 92 → pass.
+    const scoreSD = vi.fn().mockResolvedValue({ total_score: 92, threshold_action: 'accept', dimension_scores: null });
+    const res = await validateVisionScore({ ...baseSd }, stubSupabase(), { scoreSD });
+    expect(scoreSD).toHaveBeenCalledTimes(1);
+    expect(res.passed).toBe(true);
+  });
+
+  it('still HARD-BLOCKS (fail-open) when the auto-score cannot complete', async () => {
+    const scoreSD = vi.fn().mockRejectedValue(new Error('LLM unavailable'));
+    const res = await validateVisionScore({ ...baseSd }, stubSupabase(), { scoreSD });
+    expect(scoreSD).toHaveBeenCalledTimes(1);
+    expect(res.passed).toBe(false);
+    expect(res.remediation).toContain('vision-scorer.js');
+  });
+
+  it('does NOT auto-score an SD that already has a cached vision_score', async () => {
+    const scoreSD = vi.fn();
+    const res = await validateVisionScore({ ...baseSd, vision_score: 85 }, stubSupabase(), { scoreSD });
+    expect(scoreSD).not.toHaveBeenCalled();
+    expect(res.passed).toBe(true);
+  });
+
+  it('does NOT auto-score an orchestrator child (exempt, returns before scoring)', async () => {
+    const scoreSD = vi.fn();
+    const res = await validateVisionScore(
+      { ...baseSd, metadata: { parent_orchestrator: 'SD-PARENT-001' } }, stubSupabase(), { scoreSD });
+    expect(scoreSD).not.toHaveBeenCalled();
+    expect(res.passed).toBe(true);
+  });
+});

--- a/tests/unit/eva/vision-score-gate-autoscore.test.js
+++ b/tests/unit/eva/vision-score-gate-autoscore.test.js
@@ -45,6 +45,15 @@ describe('autoScoreUnscoredSD', () => {
     expect(await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD, timeoutMs: 5 })).toBeNull();
   });
 
+  it('a scorer that REJECTS after the timeout does not throw or leak (no unhandledRejection)', async () => {
+    // The losing scorer promise rejects past the bound; the gate must already have returned null and the
+    // late rejection must be swallowed by the attached .catch. We flush the microtask/timer queue to give
+    // the late rejection a chance to surface as an unhandledRejection (it must not).
+    const scoreSD = vi.fn(() => new Promise((_, rej) => setTimeout(() => rej(new Error('late LLM error')), 30)));
+    expect(await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD, timeoutMs: 5 })).toBeNull();
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
   it('returns null when the scorer resolves without a numeric total_score', async () => {
     const scoreSD = vi.fn().mockResolvedValue({ summary: 'oops' });
     expect(await autoScoreUnscoredSD('SD-X-001', stubSupabase(), { scoreSD })).toBeNull();


### PR DESCRIPTION
## Summary
SDs sat at `GATE_VISION_SCORE` with `vision_score=null` indefinitely: conception-time scoring (`leo-create-sd.js`) is fire-and-forget and the process exits before it completes, and the LEAD-entry async trigger races the gate. The scorer also only wrote `eva_vision_scores`, never `strategic_directives_v2.vision_score`.

- **FR-1**: `vision-scorer.js` now syncs `vision_score` + `vision_score_action` onto `strategic_directives_v2` after the `eva_vision_scores` insert (non-blocking).
- **FR-2**: `validateVisionScore` runs one **bounded** (`VISION_SCORE_GATE_TIMEOUT_MS`, 120s default), **awaited**, lazy-imported **fail-open** auto-score (`autoScoreUnscoredSD`) for an unscored, non-exempt SD before its hard block. On timeout/error it returns null and the existing hard block runs unchanged.

## Adversarial-review hardening (2nd commit)
- **HIGH**: removed the now-redundant fire-and-forget `triggerAsyncVisionScore` in `index.js setup()` — with the gate auto-scoring, it caused double scoring (two LLM calls / two `eva_vision_scores` rows / two racing `vision_score` writes) per handoff. The in-gate auto-score is the single awaited authoritative path.
- **MEDIUM**: attached a no-op catch to the scorer promise in the timeout race so a late rejection can't become an unhandledRejection. AbortSignal threading noted as a follow-up.

## Tests
10 new unit tests (`tests/unit/eva/vision-score-gate-autoscore.test.js`) plus 45 existing vision tests, all green. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
