### PR TITLE
docs(coordinator): require typed payload.kind on all Coordinator→Adam messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: b3b595e30e2a89d5 -->
+<!-- file_content_hash: 6126bef5d8e7580e -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-20 12:35:55 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-20 7:03:19 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 674914d0689633e6 -->
+<!-- file_content_hash: c1dbb89b5e77b585 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 7:03:19 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 56e89ecf400916c9 -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: a6327afe9beea7ad -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 73e76493f9b982a8 -->
+<!-- file_content_hash: 4e6a2b6e17f47e45 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 7:03:19 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -45,6 +45,18 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 **Deploy-verification practice — SYNC → RESTART → CANARY-VERIFY.** Merged + git-synced ≠ RUNNING. On ANY worker-code refresh the coordinator must (1) **sync** the checkout to `origin/main` — use `npm run resync:safe` (`node scripts/safe-root-resync.mjs`), the canonical SYNC step; **never** use ad-hoc `git clean -fdx` (the `-x` flag deletes gitignored runtime state including `node_modules/` and `.claude/active-coordinator.json` — 3 confirmed prod incidents; see `docs/runbooks/safe-root-resync.md`), (2) **restart** the long-lived worker process (a synced file is not loaded until the process restarts — verify the process StartTime is *after* the sync), and (3) **canary-verify** at runtime (have a worker re-run one stage and confirm the new behavior is live) BEFORE declaring a deploy-gap closed. Never declare a deploy closed on git state alone. *(credit: Adam canary loop, 2026-06-07.)*
 
 **Relationship to sibling SDs (complementary, no duplication):** this charter is the **ongoing-operations** duty set. The one-time **startup ritual** is SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001; **self-sustaining loop-wake** is SD-LEO-INFRA-FLEET-WAKE-UNDER-001; the **worktree pool watchdog mechanics** live in SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (this charter only references it).
+
+## Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped
+
+## Coordinator → Adam messages MUST carry a recognized payload.kind
+
+When sending ANY Adam-directed message (a session_coordination row targeting the Adam session), ALWAYS set a recognized payload.kind. Adam inbox (adam-advisory.cjs drainInbox) ONLY surfaces rows where payload.kind is a recognized kind (e.g. coordinator_reply, or an ADAM_INBOX_KINDS directive) OR payload.reply_to is set. UNTYPED rows (payload.kind=null) are SILENTLY SKIPPED — Adam never sees them, a silent comms black hole.
+
+> Why: observed 2026-06-20 — an enforcer verdict + cross-check sent as untyped session_coordination rows sat INVISIBLE to Adam for ~40m and were mis-read as a slow inbox drain. Convergence nearly stalled. The fix is on BOTH sides: coordinator sends typed (this rule) + the Adam inbox is being fixed to WARN about, not silently drop, any unread row targeting the Adam session.
+
+- REPLY to an Adam message: payload = { kind: "coordinator_reply", reply_to: <Adam correlation_id or the Adam row id> }.
+- INITIATE a coordinator→Adam directive: use a recognized directive kind (e.g. coordinator_advisory).
+- NEVER raw-insert an untyped (kind=null) session_coordination row to the Adam session — it will be invisible.
 
 ---
 

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: cfdb2afcfa034e67 -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: c2b2c4cc2820b01f -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 
@@ -33,6 +33,18 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 3. **Flow + silent-failure detection.** Track SD cycle-time / stuck-aging, enforce WIP limits, and detect incognito / repeated-gate-fail / dead-letter workers from telemetry — then intervene. *Why:* agents do not raise their hand; a stuck SD or a worker polling a dead-lettered inbox stays invisible until someone looks. *Mechanism:* `stale-session-sweep.cjs` (`WIP_GUARD`, `WORKER_STRUGGLING` for `handoff_fa
 
 *...truncated. Read full file for complete section.*
+
+## Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped
+
+## Coordinator → Adam messages MUST carry a recognized payload.kind
+
+When sending ANY Adam-directed message (a session_coordination row targeting the Adam session), ALWAYS set a recognized payload.kind. Adam inbox (adam-advisory.cjs drainInbox) ONLY surfaces rows where payload.kind is a recognized kind (e.g. coordinator_reply, or an ADAM_INBOX_KINDS directive) OR payload.reply_to is set. UNTYPED rows (payload.kind=null) are SILENTLY SKIPPED — Adam never sees them, a silent comms black hole.
+
+> Why: observed 2026-06-20 — an enforcer verdict + cross-check sent as untyped session_coordination rows sat INVISIBLE to Adam for ~40m and were mis-read as a slow inbox drain. Convergence nearly stalled. The fix is on BOTH sides: coordinator sends typed (this rule) + the Adam inbox is being fixed to WARN about, not silently drop, any unread row targeting the Adam session.
+
+- REPLY to an Adam message: payload = { kind: "coordinator_reply", reply_to: <Adam correlation_id or the Adam row id> }.
+- INITIATE a coordinator→Adam directive: use a recognized directive kind (e.g. coordinator_advisory).
+- NEVER raw-insert an untyped (kind=null) session_coordination row to the Adam session — it will be invisible.
 
 ---
 *The coordinator is NOT a worker and NOT Adam. Full contract in CLAUDE_COORDINATOR.md.*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 57d12c480d1c4aa6 -->
+<!-- file_content_hash: 9b81349a627c1d03 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 7:03:19 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1535,11 +1535,11 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 | Pattern ID | Category | Severity | Count | Trend | Top Solution |
 |------------|----------|----------|-------|-------|--------------|
+| PAT-HF-LEADTOPLAN-90e39736 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-HF-PLANTOEXEC-3e540545 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-RETRO-PLANTOEXEC-SD-EVA-F | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-RETRO-PLANTOLEAD-e8842331 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-HF-PLANTOLEAD-e8842331 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
-| PAT-RETRO-PLANTOEXEC-3e540545 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-RETRO-PLANTOEXEC-SD-EVA-F | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 
 ### Prevention Checklists
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 9562e5b9398168d9 -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: a81db7aba841a4d4 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 7:03:19 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 098717c9a2f22e8e -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: e7aebf95b6fd9ba7 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 7:03:19 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 9c07d3e45d102907 -->
+<!-- file_content_hash: 7eee9938f60a74d1 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 7:03:19 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 607e9d986ccd43df -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: 7560584b733f466a -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 7:03:19 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 237ccc38b18ffa2a -->
+<!-- file_content_hash: 03eb236a87898773 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 7:03:19 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 1c7c96fdf844aee6 -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: c627251859c03c17 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 7:03:19 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 8a1abe9605d22793 -->
+<!-- file_content_hash: 2c36721e16b5f032 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-20 12:35:55 PM
+**Generated**: 2026-06-20 7:03:19 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T16:35:55.374Z -->
-<!-- git_commit: b46c1ebc -->
-<!-- db_snapshot_hash: 8bb50c9305e12f02 -->
-<!-- file_content_hash: 6c6ffe0fad3bb5d2 -->
+<!-- generated_at: 2026-06-20T23:03:19.491Z -->
+<!-- git_commit: 9e791cf5 -->
+<!-- db_snapshot_hash: 0945bb04f15cd34d -->
+<!-- file_content_hash: d0470fb8a1ded756 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-20 12:35:55 PM*
+*DIGEST generated: 2026-06-20 7:03:19 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,109 @@
 {
-  "generated_at": "2026-06-20T16:35:55.374Z",
-  "git_commit": "b46c1ebc",
-  "db_snapshot_hash": "8bb50c9305e12f02",
+  "generated_at": "2026-06-20T23:03:19.491Z",
+  "git_commit": "9e791cf5",
+  "db_snapshot_hash": "0945bb04f15cd34d",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 19369,
-      "estimated_tokens": 4843,
-      "content_hash": "070a59945c9e3ca1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE.md"
+      "chars": 19368,
+      "estimated_tokens": 4842,
+      "content_hash": "ea7fe314a08e1655",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 83528,
-      "estimated_tokens": 20882,
-      "content_hash": "bd3155e94d5cf19d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_CORE.md"
+      "chars": 83518,
+      "estimated_tokens": 20880,
+      "content_hash": "b20bb9f9a08de38c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 65129,
-      "estimated_tokens": 16283,
-      "content_hash": "623dd9bbf37871cd",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_LEAD.md"
+      "chars": 65128,
+      "estimated_tokens": 16282,
+      "content_hash": "b3dfab2d0aa882d1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 90831,
+      "chars": 90830,
       "estimated_tokens": 22708,
-      "content_hash": "37f11c916b304319",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_PLAN.md"
+      "content_hash": "3fc9626608b8f6ad",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 84822,
+      "chars": 84821,
       "estimated_tokens": 21206,
-      "content_hash": "f3b070923c62e1ad",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_EXEC.md"
+      "content_hash": "a6dbde534ad27f04",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 41261,
-      "estimated_tokens": 10316,
-      "content_hash": "804a634215e32d66",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_ADAM.md"
+      "chars": 41260,
+      "estimated_tokens": 10315,
+      "content_hash": "f28815857830a38a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 16619,
-      "estimated_tokens": 4155,
-      "content_hash": "b5624e4009409e19",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_COORDINATOR.md"
+      "chars": 17915,
+      "estimated_tokens": 4479,
+      "content_hash": "3ae6b2ac47f802fa",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 9612,
+      "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "b81708bec34a1896",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_DIGEST.md"
+      "content_hash": "b7e9769b282b5bfc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 11536,
+      "chars": 11535,
       "estimated_tokens": 2884,
-      "content_hash": "e053d01fcf91d881",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "b1142fbea33419a6",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 5423,
+      "chars": 5422,
       "estimated_tokens": 1356,
-      "content_hash": "d4603c3ad7aad6a0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "6b0a007f000ec4d0",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 8413,
-      "estimated_tokens": 2104,
-      "content_hash": "4d69e7fda5b9de94",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_PLAN_DIGEST.md"
+      "chars": 8412,
+      "estimated_tokens": 2103,
+      "content_hash": "ce78b1e2a24558be",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 10836,
+      "chars": 10835,
       "estimated_tokens": 2709,
-      "content_hash": "2878a1e41d24cbb5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "bc3c4aed50e2cbcd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "91cc6e0e77e1a938",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "5264f6639fe27c1d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
-      "chars": 3973,
-      "estimated_tokens": 994,
-      "content_hash": "d4fa8b67015b2179",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-D\\CLAUDE_COORDINATOR_DIGEST.md"
+      "chars": 5270,
+      "estimated_tokens": 1318,
+      "content_hash": "768b565b3e4f20b4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "bacc644d2124040a",
+    "global": "a43537e0cd0c4516",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -363,7 +363,9 @@
       "604": "67885bf567384f02",
       "605": "19e13f356fce24ab",
       "606": "25aa68b575c66d07",
-      "607": "82e04c0cc0ffb28f"
+      "607": "82e04c0cc0ffb28f",
+      "608": "7f99a4321502367e",
+      "609": "9790a74a362ff0ca"
     },
     "meta": {
       "94": {
@@ -1660,6 +1662,16 @@
         "section_type": "adam_role_contract",
         "target_file": "CLAUDE_ADAM.md",
         "title": "SOURCING SSOT — order of operations"
+      },
+      "608": {
+        "section_type": "system_coherence",
+        "target_file": null,
+        "title": "LEO System Coherence — the Flywheel (doc pointer)"
+      },
+      "609": {
+        "section_type": "coordinator_role_contract",
+        "target_file": "CLAUDE_COORDINATOR.md",
+        "title": "Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped"
       }
     }
   }


### PR DESCRIPTION
## Summary
Bakes a recurring-friction fix into the coordinator role contract: **every Coordinator→Adam message must carry a recognized `payload.kind`** (or `payload.reply_to`). Adds `leo_protocol_sections` id=609 (`coordinator_role_contract`) and regenerates the CLAUDE_*.md family so it renders into **CLAUDE_COORDINATOR.md**.

## Why
Adam's inbox (`adam-advisory.cjs drainInbox`) **silently skips untyped (`kind=null`) rows**. On 2026-06-20, an enforcer verdict + cross-check sent as untyped `session_coordination` rows sat **invisible to Adam for ~40m** — mis-read as a slow inbox drain — and nearly stalled coordinator↔Adam convergence on the belt-quarantine investigation.

## The rule
- **Reply** to Adam: `payload = { kind: "coordinator_reply", reply_to: <correlation_id> }`
- **Initiate** a directive: use a recognized directive kind (e.g. `coordinator_advisory`)
- **Never** raw-insert an untyped row to the Adam session — it's invisible.

## Two-sided fix
This is the coordinator-side half. The reciprocal — the Adam inbox should **warn about**, not silently drop, any unread row targeting the Adam session — is being filed separately by Adam.

## Verification
`check-claude-md-drift.cjs` → **OK no drift**; rule confirmed rendered into CLAUDE_COORDINATOR.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)