### PR TITLE
chore(db-retention): lower size-monitor DEFAULT_CAP_GB 12→8 after disk reclaim

### DIFF
--- a/lib/db-retention/size-monitor.mjs
+++ b/lib/db-retention/size-monitor.mjs
@@ -11,8 +11,9 @@
 
 const GB = 1024 * 1024 * 1024;
 
-/** Default provisioned-disk cap (GB) — current Supabase tier after the 8→12 auto-expand. Override via env. */
-export const DEFAULT_CAP_GB = 12;
+/** Default provisioned-disk cap (GB) — Supabase tier resized back to 8GB 2026-06-20 after the
+ * chairman-authorized governance_audit_log reclaim (~2GB TOAST recovered, DB 6.3→4.37GB). Override via env. */
+export const DEFAULT_CAP_GB = 8;
 /** Warn/critical fractions of the cap. Critical fires BELOW the 90% auto-expand so we act first. */
 export const WARN_FRACTION = 0.75;
 export const CRITICAL_FRACTION = 0.85;

--- a/tests/unit/db-size-monitor.test.mjs
+++ b/tests/unit/db-size-monitor.test.mjs
@@ -12,24 +12,24 @@ import {
 
 const GB = 1024 ** 3;
 
-test('defaults: 12GB cap, warn 75% / critical 85%', () => {
-  assert.equal(DEFAULT_CAP_GB, 12);
+test('defaults: 8GB cap, warn 75% / critical 85%', () => {
+  assert.equal(DEFAULT_CAP_GB, 8);
 });
 
 test('evaluateSizeAlert: under 75% → ok', () => {
-  const v = evaluateSizeAlert({ dbBytes: 6.3 * GB }, { capGB: 12 });
+  const v = evaluateSizeAlert({ dbBytes: 4.37 * GB }, { capGB: 8 }); // current: 4.37GB / 8GB ≈ 55%
   assert.equal(v.level, 'ok');
   assert.ok(v.dbPct > 50 && v.dbPct < 56);
 });
 
 test('evaluateSizeAlert: at/above 75% → warn', () => {
-  assert.equal(evaluateSizeAlert({ dbBytes: 9 * GB }, { capGB: 12 }).level, 'warn'); // 75%
-  assert.equal(evaluateSizeAlert({ dbBytes: 9.5 * GB }, { capGB: 12 }).level, 'warn');
+  assert.equal(evaluateSizeAlert({ dbBytes: 6 * GB }, { capGB: 8 }).level, 'warn'); // 75% = 6.0GB
+  assert.equal(evaluateSizeAlert({ dbBytes: 6.4 * GB }, { capGB: 8 }).level, 'warn');
 });
 
 test('evaluateSizeAlert: at/above 85% → critical (fires before the 90% auto-expand)', () => {
-  assert.equal(evaluateSizeAlert({ dbBytes: 10.2 * GB }, { capGB: 12 }).level, 'critical'); // 85%
-  assert.equal(evaluateSizeAlert({ dbBytes: 11 * GB }, { capGB: 12 }).level, 'critical');
+  assert.equal(evaluateSizeAlert({ dbBytes: 6.8 * GB }, { capGB: 8 }).level, 'critical'); // 85% = 6.8GB
+  assert.equal(evaluateSizeAlert({ dbBytes: 7.5 * GB }, { capGB: 8 }).level, 'critical');
 });
 
 test('evaluateSizeAlert: surfaces table offenders ≥1GB only', () => {


### PR DESCRIPTION
## Summary
The chairman confirmed the Supabase disk was resized back to **8GB** after the chairman-authorized `governance_audit_log` reclaim (~2GB TOAST recovered; DB **6.3→4.37GB ≈ 55%**). This updates `DEFAULT_CAP_GB` `12→8` in `lib/db-retention/size-monitor.mjs` so the monitor's warn (75% = 6.0GB) / critical (85% = 6.8GB) thresholds fire against the real provisioned disk again, and refreshes the unit suite to the 8GB cap.

At 4.37GB / 8GB the monitor reports **OK** (warn at 6.0GB, crit at 6.8GB).

## Closes
The DB-reclaim workstream — and with it the full belt-quarantine → root-cause-fix → reclaim arc.

## Verification
`node --test tests/unit/db-size-monitor.test.mjs` → 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)