### PR TITLE
fix(SD-LEO-FEAT-STORE-WIPE-SAME-001): recursively unlink nested node_modules junctions before worktree removal

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1469,11 +1469,23 @@ export function removeWorktreeViaGit(wtPath, repoRoot, options = {}) {
  * (recurrence of feedback 95022758 / 9d091303 after the original guards shipped).
  * @param {string} wtPath - worktree directory path
  */
-function preUnlinkWorktreeNodeModules(wtPath) {
+export function preUnlinkWorktreeNodeModules(wtPath) {
   try {
     const nmPath = `${wtPath}/node_modules`;
     const lst = fs.lstatSync(nmPath);
-    if (lst.isSymbolicLink()) _unlinkSymOrJunction(nmPath);
+    if (lst.isSymbolicLink()) {
+      // node_modules IS itself a junction/symlink into the shared store — unlink the link.
+      _unlinkSymOrJunction(nmPath);
+    } else if (lst.isDirectory()) {
+      // SD-LEO-FEAT-STORE-WIPE-SAME-001: node_modules is a REAL directory (a worker ran
+      // npm install/ci), but it can contain NESTED junctions/symlinks into the shared store
+      // (workspace deps, .bin links). The prior top-level-only isSymbolicLink() check no-op'd
+      // here, so `git worktree remove --force` followed a nested junction and recursively wiped
+      // the shared store (twice on 2026-06-20). Recursively unlink every nested link FIRST so
+      // git's native deletion can never follow one out of the worktree. force=true: a single
+      // bad entry must not abort the pre-unlink (best-effort, mirrors this fn's contract).
+      _unlinkLinksRecursive(nmPath, true);
+    }
   } catch { /* no node_modules, not a link, or already gone — nothing to unlink */ }
 }
 

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -58,16 +58,44 @@ function getAliveMarkerSessionIds() {
 // link / already gone is a no-op). Mirrors preUnlinkWorktreeNodeModules +
 // _unlinkSymOrJunction (lib/worktree-manager.js); inlined to keep this hot CJS
 // SessionStart hook free of ESM dynamic imports.
+function _unlinkLinkInline(p) {
+  try {
+    fs.unlinkSync(p);
+  } catch (err) {
+    // Windows: directory junctions sometimes need rmdir to drop the reparse point.
+    if (process.platform === 'win32' && (err.code === 'EPERM' || err.code === 'EISDIR')) fs.rmdirSync(p);
+    else throw err;
+  }
+}
+
+// SD-LEO-FEAT-STORE-WIPE-SAME-001: walk a real node_modules dir and unlink every NESTED
+// junction/symlink (best-effort), so a later `git worktree remove --force` cannot follow one
+// out into the shared store. Does NOT delete regular files/dirs — git remove handles those.
+function _unlinkNestedLinks(dir) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const entry of entries) {
+    const child = path.join(dir, entry.name);
+    let st;
+    try { st = fs.lstatSync(child); } catch { continue; }
+    if (st.isSymbolicLink()) { try { _unlinkLinkInline(child); } catch { /* best-effort */ } continue; }
+    if (st.isDirectory()) _unlinkNestedLinks(child);
+  }
+}
+
 function unlinkNodeModulesJunction(wtPath) {
   try {
     const nm = path.join(wtPath, 'node_modules');
-    if (!fs.lstatSync(nm).isSymbolicLink()) return;
-    try {
-      fs.unlinkSync(nm);
-    } catch (err) {
-      // Windows: directory junctions sometimes need rmdir to drop the reparse point.
-      if (process.platform === 'win32' && (err.code === 'EPERM' || err.code === 'EISDIR')) fs.rmdirSync(nm);
-      else throw err;
+    const lst = fs.lstatSync(nm);
+    if (lst.isSymbolicLink()) {
+      // node_modules IS itself a junction into the shared store — unlink the link.
+      _unlinkLinkInline(nm);
+    } else if (lst.isDirectory()) {
+      // node_modules is a REAL dir (worker ran npm install) but may hold NESTED junctions into
+      // the shared store. The prior top-level-only check returned here, letting git remove follow
+      // a nested junction and wipe the shared store. Unlink nested links first. (Mirrors the
+      // recursive fix in lib/worktree-manager.js preUnlinkWorktreeNodeModules.)
+      _unlinkNestedLinks(nm);
     }
   } catch { /* no node_modules, not a link, or already gone — nothing to unlink */ }
 }

--- a/tests/lib/worktree-manager-preunlink-nested-junction.test.js
+++ b/tests/lib/worktree-manager-preunlink-nested-junction.test.js
@@ -1,0 +1,95 @@
+/**
+ * Shared-store wipe prevention — SD-LEO-FEAT-STORE-WIPE-SAME-001.
+ *
+ * The shared node_modules store was wiped twice in 75 min by the worktree reaper:
+ * preUnlinkWorktreeNodeModules only unlinked node_modules when the TOP-LEVEL path was a
+ * symlink/junction. Once a worker ran npm install, node_modules became a REAL directory holding a
+ * NESTED junction into the shared store; the top-level check no-op'd, so `git worktree remove
+ * --force` (and any recursive delete) followed the nested junction and wiped the shared store.
+ *
+ * These tests prove the fix DELETER-AGNOSTICALLY: after preUnlinkWorktreeNodeModules, the nested
+ * junction is UNLINKED (so neither `git worktree remove --force` — which DOES follow junctions —
+ * nor any recursive delete can reach the store), while the sentinel shared store stays INTACT. We
+ * assert the link is gone rather than relying on a specific deleter, because Node's own fs.rmSync
+ * does NOT follow junctions (only git's native remove does) — so "link unlinked" is the faithful
+ * regression signal (it FAILS pre-fix, where the top-level-only check no-op'd on a real dir).
+ * Covers the nested-junction layout (the bug) and the top-level-junction layout (no regression).
+ * Junctions on Windows; dir symlinks elsewhere (Node maps the 'junction' type to a symlink on POSIX).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { preUnlinkWorktreeNodeModules } from '../../lib/worktree-manager.js';
+
+let tmp, store, sentinel, wt;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'store-wipe-'));
+  // The SHARED store that must survive — with a sentinel file inside it.
+  store = path.join(tmp, 'shared-store');
+  fs.mkdirSync(store, { recursive: true });
+  sentinel = path.join(store, 'SENTINEL.txt');
+  fs.writeFileSync(sentinel, 'do-not-delete');
+  wt = path.join(tmp, 'worktree');
+  fs.mkdirSync(wt, { recursive: true });
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function link(target, linkPath) {
+  fs.symlinkSync(target, linkPath, 'junction'); // 'junction' on win32; symlink elsewhere
+}
+
+describe('preUnlinkWorktreeNodeModules — shared-store survives worktree deletion (SD-LEO-FEAT-STORE-WIPE-SAME-001)', () => {
+  it('NESTED junction inside a REAL node_modules: sentinel store survives the recursive delete', () => {
+    const nm = path.join(wt, 'node_modules');
+    fs.mkdirSync(nm, { recursive: true });                 // REAL directory (worker ran npm install)
+    fs.writeFileSync(path.join(nm, 'package.json'), '{}'); // some real content
+    const nestedLink = path.join(nm, '.shared');
+    link(store, nestedLink);                                // NESTED junction into the shared store
+
+    preUnlinkWorktreeNodeModules(wt);
+
+    // FAITHFUL regression signal: the nested junction is UNLINKED (pre-fix it was left in place,
+    // so git's native remove would follow it into the store). lstat throws once it's gone.
+    expect(() => fs.lstatSync(nestedLink)).toThrow();
+    // Stand-in cleanup delete of the worktree — store must remain regardless of deleter.
+    fs.rmSync(wt, { recursive: true, force: true });
+    expect(fs.existsSync(sentinel)).toBe(true);  // shared store SURVIVES
+    expect(fs.existsSync(store)).toBe(true);
+  });
+
+  it('TOP-LEVEL node_modules junction: sentinel store survives (no regression)', () => {
+    link(store, path.join(wt, 'node_modules'));            // node_modules IS a junction into the store
+
+    preUnlinkWorktreeNodeModules(wt);
+    fs.rmSync(wt, { recursive: true, force: true });
+
+    expect(fs.existsSync(sentinel)).toBe(true);
+    expect(fs.existsSync(store)).toBe(true);
+  });
+
+  it('deeply nested junction (node_modules/dep/node_modules/.bin -> store) also survives', () => {
+    const deep = path.join(wt, 'node_modules', 'dep', 'node_modules');
+    fs.mkdirSync(deep, { recursive: true });
+    const deepLink = path.join(deep, '.bin');
+    link(store, deepLink);
+
+    preUnlinkWorktreeNodeModules(wt);
+    expect(() => fs.lstatSync(deepLink)).toThrow(); // deeply-nested junction unlinked
+    fs.rmSync(wt, { recursive: true, force: true });
+
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+
+  it('clean worktree (no node_modules) is a no-op and removes normally', () => {
+    fs.writeFileSync(path.join(wt, 'file.txt'), 'x');
+    expect(() => preUnlinkWorktreeNodeModules(wt)).not.toThrow();
+    fs.rmSync(wt, { recursive: true, force: true });
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The shared `node_modules` store was wiped **twice in 75 min** by the hourly worktree-reaper cron (watchdog force-armed `--execute --stage0 --all-pools` under disk pressure).

**RCA (empirically proven):** `preUnlinkWorktreeNodeModules` (lib/worktree-manager.js) only unlinked `node_modules` when the **top-level** path was a symlink. Once a worker runs `npm install`, `node_modules` becomes a **real directory** holding a **nested junction** into the shared store; the top-level check no-op'd, so `git worktree remove --force` followed the nested junction and recursively deleted the shared store. The safe recursive fallback only runs when git-remove *fails* — but it *succeeds* while emptying the store.

## Fix
- **lib/worktree-manager.js** `preUnlinkWorktreeNodeModules`: when `node_modules` is a real dir, recursively unlink every nested junction/symlink first (reuse `_unlinkLinksRecursive`). Top-level path unchanged. Exported for testability.
- **scripts/hooks/concurrent-session-worktree.cjs** `unlinkNodeModulesJunction`: mirror the recursive nested-link unlink (inline) — the SessionStart cleanup path had the identical blind spot.
- **Regression tests**: assert the nested junction is **unlinked** (deleter-agnostic — `fs.rmSync` doesn't follow junctions, only git does) and the sentinel shared store survives, for nested / deeply-nested / top-level layouts.

## Testing
151 worktree-manager + reaper tests pass (no regression); 4 new regression tests.

## Note
RCA flagged a latent amplifier: the watchdog auto-arms live `--stage0 --all-pools` deletion under disk pressure — worth a follow-up to gate that off until safety is proven. Pattern: `PAT-INFRA-NESTED-JUNCTION-WORKTREE-WIPE-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)