### PR TITLE
fix(SD-LEO-FEAT-PRE-EXISTING-BUG-001): stop writing non-existent management_reviews.capability_gaps

### DIFF
--- a/lib/pipeline/management-review-artifact.mjs
+++ b/lib/pipeline/management-review-artifact.mjs
@@ -1,0 +1,93 @@
+/**
+ * Pure builder for the management_reviews upsert artifact.
+ * SD-LEO-FEAT-PRE-EXISTING-BUG-001.
+ *
+ * Pre-existing bug: scripts/pipeline/management-review-generator.js wrote a `capability_gaps` field into
+ * the management_reviews upsert, but that column does NOT exist in the live schema — so every live run
+ * failed with a PostgREST 42703 ("column does not exist") and the generator was non-functional. No code
+ * reads management_reviews.capability_gaps, so the correct minimal fix is to STOP writing it (not add a
+ * dead column). The gap data is still computed and surfaced in the console summary + the narrative.
+ *
+ * Extracting the payload construction into a pure function makes it unit-testable without a DB or running
+ * the CLI, and the exported column allowlist guards against re-introducing a non-existent column.
+ */
+
+/**
+ * The real columns of the live `management_reviews` table (writable subset the generator targets).
+ * A key not in this set is a non-existent column and must never be written.
+ */
+export const MANAGEMENT_REVIEWS_COLUMNS = Object.freeze([
+  'review_date',
+  'review_type',
+  'baseline_version_from',
+  'baseline_version_to',
+  'planned_capabilities',
+  'actual_capabilities',
+  'planned_ventures',
+  'actual_ventures',
+  'planned_sds',
+  'actual_sds',
+  'okr_snapshot',
+  'risk_snapshot',
+  'strategy_health',
+  'decisions',
+  'actions',
+  'pipeline_snapshot',
+  'eva_narrative',
+  'eva_proposals',
+  'chairman_notes',
+  'chairman_approved_proposals',
+  'overall_score',
+]);
+
+/**
+ * PURE: build the management_reviews upsert payload from the gathered data.
+ * Writes ONLY real columns — notably it does NOT write `capability_gaps` (the non-existent column that
+ * 42703-errored the upsert). `reviewDate` is injected so the function stays deterministic for tests.
+ *
+ * @param {object} parts
+ *   reviewDate    - YYYY-MM-DD string (injected; caller passes new Date().toISOString().split('T')[0])
+ *   baselineData  - { version?, totalItems? }
+ *   sdData        - { completed }
+ *   ventureData   - { activeCount, ventures: [{stage}] }
+ *   okrData       - { snapshot }
+ *   riskData      - { hasForecasts } (+ the forecast object itself when hasForecasts)
+ *   pipelineData  - any (pipeline snapshot)
+ *   narrative     - string
+ * @returns {object} the review row (real columns only)
+ */
+export function buildReviewArtifact(parts = {}) {
+  const {
+    reviewDate,
+    baselineData = {},
+    sdData = {},
+    ventureData = {},
+    okrData = {},
+    riskData = {},
+    pipelineData = null,
+    narrative = null,
+  } = parts;
+
+  const ventures = Array.isArray(ventureData.ventures) ? ventureData.ventures : [];
+
+  return {
+    review_date: reviewDate,
+    review_type: 'weekly',
+    baseline_version_from: baselineData.version || 1,
+    baseline_version_to: baselineData.version || 1,
+    planned_sds: baselineData.totalItems || 0,
+    actual_sds: sdData.completed,
+    planned_ventures: ventureData.activeCount,
+    actual_ventures: ventures.filter((v) => v.stage >= 5).length,
+    okr_snapshot: okrData.snapshot,
+    risk_snapshot: riskData.hasForecasts ? riskData : null,
+    // capability_gaps intentionally OMITTED — the column does not exist in management_reviews (42703) and
+    // nothing reads it. Gap data remains in the console summary + the narrative. (SD-LEO-FEAT-PRE-EXISTING-BUG-001)
+    strategy_health: null,
+    pipeline_snapshot: pipelineData,
+    eva_narrative: narrative,
+    eva_proposals: null,
+  };
+}
+
+export default { MANAGEMENT_REVIEWS_COLUMNS, buildReviewArtifact };

--- a/scripts/pipeline/management-review-generator.js
+++ b/scripts/pipeline/management-review-generator.js
@@ -8,6 +8,9 @@
  */
 
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+// SD-LEO-FEAT-PRE-EXISTING-BUG-001: build the upsert payload via a pure helper that omits the
+// non-existent capability_gaps column (which 42703-errored every live run).
+import { buildReviewArtifact } from '../../lib/pipeline/management-review-artifact.mjs';
 
 const supabase = createSupabaseServiceClient();
 const STALE_THRESHOLD_HOURS = 24;
@@ -319,24 +322,18 @@ async function generateReview() {
     return;
   }
 
-  // Build review artifact
-  const review = {
-    review_date: new Date().toISOString().split('T')[0],
-    review_type: 'weekly',
-    baseline_version_from: baselineData.version || 1,
-    baseline_version_to: baselineData.version || 1,
-    planned_sds: baselineData.totalItems || 0,
-    actual_sds: sdData.completed,
-    planned_ventures: ventureData.activeCount,
-    actual_ventures: ventureData.ventures.filter(v => v.stage >= 5).length,
-    okr_snapshot: okrData.snapshot,
-    risk_snapshot: riskData.hasForecasts ? riskData : null,
-    capability_gaps: gapData.hasGaps ? gapData : null,
-    strategy_health: null,
-    pipeline_snapshot: pipelineData,
-    eva_narrative: narrative,
-    eva_proposals: null,
-  };
+  // Build review artifact (SD-LEO-FEAT-PRE-EXISTING-BUG-001: via the pure helper, which omits the
+  // non-existent capability_gaps column — gapData is still surfaced in the summary + narrative above).
+  const review = buildReviewArtifact({
+    reviewDate: new Date().toISOString().split('T')[0],
+    baselineData,
+    sdData,
+    ventureData,
+    okrData,
+    riskData,
+    pipelineData,
+    narrative,
+  });
 
   // Upsert (not insert) so a same-day re-run updates the existing row in place rather than appending
   // a duplicate that would violate the UNIQUE(review_date, review_type) guard

--- a/tests/unit/management-review-artifact.test.js
+++ b/tests/unit/management-review-artifact.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildReviewArtifact, MANAGEMENT_REVIEWS_COLUMNS } from '../../lib/pipeline/management-review-artifact.mjs';
+
+// SD-LEO-FEAT-PRE-EXISTING-BUG-001: the generator must NOT write the non-existent capability_gaps column
+// (which 42703-errored every live run). These tests guard the payload shape against a non-existent column.
+
+const sampleParts = {
+  reviewDate: '2026-06-20',
+  baselineData: { version: 3, totalItems: 12 },
+  sdData: { completed: 7 },
+  ventureData: { activeCount: 4, ventures: [{ stage: 6 }, { stage: 2 }, { stage: 9 }] },
+  okrData: { snapshot: { objectives: 3 } },
+  riskData: { hasForecasts: true, totalForecasts: 5 },
+  pipelineData: { stages: 40 },
+  narrative: 'Weekly review narrative.',
+};
+
+describe('buildReviewArtifact (management_reviews payload)', () => {
+  it('does NOT include the non-existent capability_gaps column', () => {
+    const review = buildReviewArtifact(sampleParts);
+    expect(review).not.toHaveProperty('capability_gaps');
+  });
+
+  it('writes ONLY real management_reviews columns (allowlist enforced)', () => {
+    const review = buildReviewArtifact(sampleParts);
+    for (const key of Object.keys(review)) {
+      expect(MANAGEMENT_REVIEWS_COLUMNS).toContain(key);
+    }
+  });
+
+  it('maps the gathered data onto the expected real columns', () => {
+    const review = buildReviewArtifact(sampleParts);
+    expect(review.review_date).toBe('2026-06-20');
+    expect(review.review_type).toBe('weekly');
+    expect(review.baseline_version_from).toBe(3);
+    expect(review.actual_sds).toBe(7);
+    expect(review.planned_ventures).toBe(4);
+    expect(review.actual_ventures).toBe(2); // stages 6 and 9 are >= 5
+    expect(review.okr_snapshot).toEqual({ objectives: 3 });
+    expect(review.risk_snapshot).toEqual(sampleParts.riskData); // hasForecasts -> the forecast object
+    expect(review.eva_narrative).toBe('Weekly review narrative.');
+  });
+
+  it('null risk_snapshot when there are no forecasts', () => {
+    const review = buildReviewArtifact({ ...sampleParts, riskData: { hasForecasts: false } });
+    expect(review.risk_snapshot).toBeNull();
+  });
+
+  it('tolerates sparse/empty inputs without throwing or inventing columns', () => {
+    const review = buildReviewArtifact({ reviewDate: '2026-06-20' });
+    expect(review).not.toHaveProperty('capability_gaps');
+    for (const key of Object.keys(review)) {
+      expect(MANAGEMENT_REVIEWS_COLUMNS).toContain(key);
+    }
+    expect(review.actual_ventures).toBe(0); // no ventures -> 0
+    expect(review.baseline_version_from).toBe(1); // default
+  });
+
+  it('the allowlist itself excludes capability_gaps (defense in depth)', () => {
+    expect(MANAGEMENT_REVIEWS_COLUMNS).not.toContain('capability_gaps');
+  });
+});


### PR DESCRIPTION
A high-value harness defect surfaced + triaged during this session's belt-quarantine incident.

`scripts/pipeline/management-review-generator.js` wrote a `capability_gaps` field into the `management_reviews` upsert, but **that column does not exist in the live schema** (verified: `select capability_gaps` → PostgREST 42703). So every live run failed and the generator was **non-functional**. Nothing reads `management_reviews.capability_gaps` (grep-confirmed).

- NEW `lib/pipeline/management-review-artifact.mjs`: pure `buildReviewArtifact()` building the payload from **real columns only** (capability_gaps omitted) + an exported `MANAGEMENT_REVIEWS_COLUMNS` allowlist. Gap data is still computed and surfaced in the console summary + the narrative.
- the generator builds its payload via the helper instead of the inline object.
- 6 regression tests assert no `capability_gaps` key + every key is a real column (guards against re-adding a non-existent column).

No schema change (the column is not added — nothing consumes it). DATABASE + DESIGN + TESTING sub-agents PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)