### PR TITLE
feat(SD-LEO-FEAT-SHARED-TREE-HIJACK-001): block shared-root branch checkout that hijacks the active coordinator

### DIFF
--- a/scripts/hooks/lib/shared-tree-guard.cjs
+++ b/scripts/hooks/lib/shared-tree-guard.cjs
@@ -43,39 +43,124 @@ function splitSegments(cmd) {
 }
 
 /**
+ * Tokenize a segment on whitespace, honouring simple single/double quoting so a
+ * quoted path with spaces stays one token. Pure, no shell semantics beyond that.
+ * @param {string} segment
+ * @returns {string[]}
+ */
+function tokenize(segment) {
+  const s = String(segment || '');
+  const out = [];
+  let cur = '';
+  let has = false; // whether the current token has started (handles empty quotes)
+  let quote = null; // active quote char or null
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; has = true; continue; }
+    if (/\s/.test(ch)) {
+      if (has) { out.push(cur); cur = ''; has = false; }
+      continue;
+    }
+    cur += ch; has = true;
+  }
+  if (has) out.push(cur);
+  return out;
+}
+
+// git GLOBAL options (before the subcommand) that consume the FOLLOWING token
+// when given in space form. The `=` form is self-contained in one token.
+const GIT_GLOBAL_OPTS_WITH_VALUE = new Set(['-C', '-c', '--work-tree', '--git-dir', '--namespace', '--exec-path', '--super-prefix']);
+
+/**
+ * Strip leading `VAR=value` environment-assignment tokens (e.g. `FOO=bar git …`).
+ * @param {string[]} tokens
+ * @returns {string[]}
+ */
+function stripLeadingEnvAssignments(tokens) {
+  let i = 0;
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+  return tokens.slice(i);
+}
+
+/**
+ * Parse a git segment: locate the subcommand verb past any leading env vars and
+ * git GLOBAL options, and collect the directory-redirecting globals
+ * (-C / --work-tree / --git-dir) so the caller can resolve the EFFECTIVE working
+ * tree the op touches. Returns null if the segment is not a git invocation.
+ * @param {string} segment
+ * @returns {{ verb:string, rest:string, dirs:{C:?string, workTree:?string, gitDir:?string} } | null}
+ */
+function parseGitSegment(segment) {
+  let tokens = stripLeadingEnvAssignments(tokenize(segment));
+  if (tokens.length === 0 || tokens[0] !== 'git') return null;
+  tokens = tokens.slice(1);
+
+  const dirs = { C: null, workTree: null, gitDir: null };
+  const captureDir = (opt, val) => {
+    if (opt === '-C') dirs.C = val;
+    else if (opt === '--work-tree') dirs.workTree = val;
+    else if (opt === '--git-dir') dirs.gitDir = val;
+  };
+
+  let i = 0;
+  for (; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (!t.startsWith('-')) break; // first non-option token = the subcommand verb
+    // `--opt=value` self-contained form
+    const eq = t.indexOf('=');
+    if (eq !== -1) {
+      captureDir(t.slice(0, eq), t.slice(eq + 1));
+      continue;
+    }
+    // space form: option consumes the next token as its value
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(t)) {
+      const val = tokens[i + 1];
+      captureDir(t, val);
+      i++; // skip the value token
+      continue;
+    }
+    // valueless global option (--no-pager, --paginate, --bare, …) — skip
+  }
+
+  const verb = tokens[i];
+  if (verb !== 'checkout' && verb !== 'switch' && verb !== 'reset') return null;
+  const rest = ' ' + tokens.slice(i + 1).join(' ') + ' ';
+  return { verb, rest, dirs };
+}
+
+/**
  * Extract the `-C <dir>` argument from a single git segment, if present.
- * Returns the raw directory string or null.
+ * (Retained for back-compat / direct testing; parseGitSegment is the primary path.)
  * @param {string} segment
  */
 function extractGitCDir(segment) {
-  // -C <dir> or -C=<dir>; tolerate quotes around the dir.
-  const m = segment.match(/\s-C(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))/);
-  if (!m) return null;
-  return m[1] || m[2] || m[3] || null;
+  const p = parseGitSegment(segment);
+  return (p && p.dirs.C) || null;
 }
 
 /**
  * Classify a single git segment as a HEAD-moving branch operation in scope for
- * the guard. Returns { kind } when blockable-in-principle, else null.
+ * the guard. Returns { kind, dirs } when blockable-in-principle, else null.
  *  - checkout/switch to a branch (incl. -b/-c create+switch) → kind 'branch'
  *  - reset --hard [<ref>]                                    → kind 'reset'
  *  - file-restore checkout (contains ` -- `)                 → null (HEAD stays)
+ * `dirs` carries any -C / --work-tree / --git-dir so the caller can resolve the
+ * effective working tree (defends `--work-tree=<shared-root>` — itself a hijack).
  * @param {string} segment
  */
 function classifyHeadMovingGitOp(segment) {
-  const s = String(segment || '').trim();
-  // Must be a git invocation (optionally `git -C <dir> ...`).
-  if (!/^git(\s|$)/.test(s)) return null;
-
-  // `git checkout` / `git switch`
-  const sub = s.match(/^git\b(?:\s+-C(?:=\S+|\s+\S+))?\s+(checkout|switch|reset)\b(.*)$/);
-  if (!sub) return null;
-  const verb = sub[1];
-  const rest = sub[2] || '';
+  const p = parseGitSegment(segment);
+  if (!p) return null;
+  const { verb, rest, dirs } = p;
 
   if (verb === 'reset') {
     // Only `--hard` mutates the working tree enough to revert the host.
-    return /(^|\s)--hard(\s|$)/.test(rest) ? { kind: 'reset' } : null;
+    return /(^|\s)--hard(\s|$)/.test(rest) ? { kind: 'reset', dirs } : null;
   }
 
   // checkout / switch: a file-restore form has a `--` path separator and never
@@ -86,7 +171,7 @@ function classifyHeadMovingGitOp(segment) {
   if (/(^|\s)(-h|--help)(\s|$)/.test(rest)) return null;
 
   // Otherwise this checkout/switch moves HEAD to a (possibly new) branch.
-  return { kind: 'branch' };
+  return { kind: 'branch', dirs };
 }
 
 /**
@@ -123,10 +208,13 @@ function decideSharedTreeCheckout(cmd, ctx) {
     const op = classifyHeadMovingGitOp(seg);
     if (!op) continue;
 
-    // Resolve the effective directory of THIS op: a `-C <dir>` wins over the
-    // process cwd. If that directory is inside an isolated worktree, allow it.
-    const cDir = extractGitCDir(seg);
-    const effectiveDir = cDir || (ctx && ctx.cwd) || '';
+    // Resolve the effective working tree THIS op touches. `--work-tree` sets the
+    // working tree explicitly (a `--work-tree=<shared-root>` from inside a
+    // worktree IS a hijack and must be judged on the target, not the cwd); else
+    // `-C <dir>` changes git's directory; else the process cwd. If the resolved
+    // tree is inside an isolated worktree, the op is safe.
+    const dirs = op.dirs || {};
+    const effectiveDir = dirs.workTree || dirs.C || (ctx && ctx.cwd) || '';
     if (WORKTREE_PATH_RE.test(effectiveDir)) {
       // Isolated worktree — safe, keep scanning other segments.
       continue;
@@ -142,7 +230,10 @@ function decideSharedTreeCheckout(cmd, ctx) {
 module.exports = {
   decideSharedTreeCheckout,
   classifyHeadMovingGitOp,
+  parseGitSegment,
   extractGitCDir,
+  tokenize,
+  stripLeadingEnvAssignments,
   splitSegments,
   WORKTREE_PATH_RE,
 };

--- a/scripts/hooks/lib/shared-tree-guard.cjs
+++ b/scripts/hooks/lib/shared-tree-guard.cjs
@@ -1,0 +1,148 @@
+'use strict';
+/**
+ * Shared-Tree Hijack Guard (ENF-17 / SD-LEO-FEAT-SHARED-TREE-HIJACK-001)
+ *
+ * Pure decision logic for the PreToolUse Bash guard that prevents a worker from
+ * running a HEAD-moving git operation (checkout/switch to a branch, or
+ * `reset --hard`) inside the SHARED operator/coordinator ROOT working tree while
+ * a DIFFERENT session holds the active-coordinator pointer.
+ *
+ * Live incident (2026-06-11, HIGH): a worker building QF-20260610-626 ran
+ * `git checkout` of its qf/ branch in the shared root, un-deploying the
+ * coordinator's branch — coordinator scripts/hooks vanished from disk and every
+ * supervision cron loop would have MODULE_NOT_FOUND'd on its next tick.
+ *
+ * Design invariants:
+ *  - PURE: no git subprocess, no network, no fs (the caller injects cwd + the
+ *    already-read coordinator session id). Pure string/path logic only → fast,
+ *    Windows-safe, can never hang.
+ *  - FAIL-OPEN: if there is no active coordinator, or the current session IS the
+ *    coordinator, or anything is ambiguous, ALLOW. The guard only fires when
+ *    there is a foreign host to protect, so a solo operator is never locked out.
+ *  - WORKTREE-SAFE: a branch op whose effective directory is inside a
+ *    .worktrees/<sd>/ subtree (including via `git -C <worktree>`) is always
+ *    allowed — isolated worktrees cannot hijack the shared host.
+ *  - FILE-RESTORE-SAFE: `git checkout -- <path>` / `git checkout <ref> -- <path>`
+ *    do not move HEAD and are never blocked.
+ */
+
+// Matches a path that lives inside a .worktrees/<segment>/ subtree (both separators).
+const WORKTREE_PATH_RE = /[/\\]\.worktrees[/\\][^/\\]+/i;
+
+/**
+ * Split a command line into shell-segment-delimited sub-commands so we evaluate
+ * each `git ...` invocation independently (e.g. `cd x && git checkout y`).
+ * @param {string} cmd
+ * @returns {string[]}
+ */
+function splitSegments(cmd) {
+  return String(cmd || '')
+    .split(/(?:&&|\|\||[;&|()\n])/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Extract the `-C <dir>` argument from a single git segment, if present.
+ * Returns the raw directory string or null.
+ * @param {string} segment
+ */
+function extractGitCDir(segment) {
+  // -C <dir> or -C=<dir>; tolerate quotes around the dir.
+  const m = segment.match(/\s-C(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))/);
+  if (!m) return null;
+  return m[1] || m[2] || m[3] || null;
+}
+
+/**
+ * Classify a single git segment as a HEAD-moving branch operation in scope for
+ * the guard. Returns { kind } when blockable-in-principle, else null.
+ *  - checkout/switch to a branch (incl. -b/-c create+switch) → kind 'branch'
+ *  - reset --hard [<ref>]                                    → kind 'reset'
+ *  - file-restore checkout (contains ` -- `)                 → null (HEAD stays)
+ * @param {string} segment
+ */
+function classifyHeadMovingGitOp(segment) {
+  const s = String(segment || '').trim();
+  // Must be a git invocation (optionally `git -C <dir> ...`).
+  if (!/^git(\s|$)/.test(s)) return null;
+
+  // `git checkout` / `git switch`
+  const sub = s.match(/^git\b(?:\s+-C(?:=\S+|\s+\S+))?\s+(checkout|switch|reset)\b(.*)$/);
+  if (!sub) return null;
+  const verb = sub[1];
+  const rest = sub[2] || '';
+
+  if (verb === 'reset') {
+    // Only `--hard` mutates the working tree enough to revert the host.
+    return /(^|\s)--hard(\s|$)/.test(rest) ? { kind: 'reset' } : null;
+  }
+
+  // checkout / switch: a file-restore form has a `--` path separator and never
+  // moves HEAD, so it is out of scope.
+  if (/(^|\s)--(\s|$)/.test(rest)) return null;
+
+  // `git checkout --help` / `git switch --help` are informational.
+  if (/(^|\s)(-h|--help)(\s|$)/.test(rest)) return null;
+
+  // Otherwise this checkout/switch moves HEAD to a (possibly new) branch.
+  return { kind: 'branch' };
+}
+
+/**
+ * Decide whether a Bash command must be blocked as a shared-tree hijack.
+ *
+ * @param {string} cmd                       The Bash tool's command string.
+ * @param {object} ctx
+ * @param {string} ctx.cwd                   Effective working directory of the tool call.
+ * @param {string} ctx.sessionId            The current session id.
+ * @param {string|null} ctx.coordinatorSessionId  Active-coordinator session id (null if none).
+ * @param {object} [ctx.env]                 Environment (for LEO_SHARED_TREE_GUARD=off).
+ * @returns {{ block: boolean, reason: string, kind?: string }}
+ */
+function decideSharedTreeCheckout(cmd, ctx) {
+  const env = (ctx && ctx.env) || {};
+  if (env.LEO_SHARED_TREE_GUARD === 'off') {
+    return { block: false, reason: 'guard_disabled' };
+  }
+
+  const sessionId = ctx && ctx.sessionId;
+  const coordinatorSessionId = ctx && ctx.coordinatorSessionId;
+
+  // Fail-open: no foreign coordinator host to protect.
+  if (!coordinatorSessionId || typeof coordinatorSessionId !== 'string') {
+    return { block: false, reason: 'no_active_coordinator' };
+  }
+  // The coordinator may manage its own root tree.
+  if (sessionId && coordinatorSessionId === sessionId) {
+    return { block: false, reason: 'session_is_coordinator' };
+  }
+
+  const segments = splitSegments(cmd);
+  for (const seg of segments) {
+    const op = classifyHeadMovingGitOp(seg);
+    if (!op) continue;
+
+    // Resolve the effective directory of THIS op: a `-C <dir>` wins over the
+    // process cwd. If that directory is inside an isolated worktree, allow it.
+    const cDir = extractGitCDir(seg);
+    const effectiveDir = cDir || (ctx && ctx.cwd) || '';
+    if (WORKTREE_PATH_RE.test(effectiveDir)) {
+      // Isolated worktree — safe, keep scanning other segments.
+      continue;
+    }
+
+    // A HEAD-moving op in the shared root while a foreign coordinator is active.
+    return { block: true, reason: 'shared_root_hijack', kind: op.kind };
+  }
+
+  return { block: false, reason: 'no_head_moving_op_in_shared_root' };
+}
+
+module.exports = {
+  decideSharedTreeCheckout,
+  classifyHeadMovingGitOp,
+  extractGitCDir,
+  splitSegments,
+  WORKTREE_PATH_RE,
+};

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -18,6 +18,7 @@
  * 12. npm install Concurrency Guard (QF-20260426-822) - HARD BLOCK (exit 2)
  * 13. Worktree Hygiene Guard (SD-LEO-INFRA-PRE-TOOL-WORKTREE-GUARD-001) - HARD BLOCK on main/master + WARN-ONCE on inherited dirt
  * 15. Force-Push Gate (SD-FDBK-INFRA-ALLOW-FORCE-LEASE-001) - HARD BLOCK by default; OVERRIDE on solo SD/QF feature branches when LEO_FORCE_PUSH_OWN_BRANCH=allow
+ * 17. Shared-Tree Hijack Guard (SD-LEO-FEAT-SHARED-TREE-HIJACK-001) - HARD BLOCK on HEAD-moving git op (checkout/switch/reset --hard) in the shared ROOT while a foreign coordinator is active; fail-open
  *
  * Hook API:
  *   Input:  CLAUDE_TOOL_INPUT (JSON), CLAUDE_TOOL_NAME (string)
@@ -1383,6 +1384,46 @@ async function main() {
       // Fail-open: any internal error in ENF-16 must NOT block tool execution.
       if (process.env.LEO_TELEMETRY_DEBUG === '1') {
         process.stderr.write(`[pre-tool-enforce] ENF-16 errored (fail-open): ${noVerifyErr.message}\n`);
+      }
+    }
+
+    // --- ENFORCEMENT 17: Shared-Tree Hijack Guard (SD-LEO-FEAT-SHARED-TREE-HIJACK-001) ---
+    // Blocks a HEAD-moving git op (checkout/switch to a branch, or `reset --hard`) run in the
+    // SHARED operator/coordinator ROOT working tree while a DIFFERENT session holds the
+    // active-coordinator pointer. Live HIGH incident 2026-06-11: a QF worker's `git checkout`
+    // in the shared root un-deployed the coordinator's branch, reverting its scripts/hooks on
+    // disk mid-tick while loaded skills kept running. The pointer was only RESTORED after the
+    // fact (post-checkout-role-restore.cjs); this defends BEFORE the destructive checkout.
+    // Decision logic is pure + unit-tested in lib/shared-tree-guard.cjs; this owns pointer-read,
+    // cwd resolution, audit + exit. Fail-OPEN (no coordinator / self / any error → allow), so a
+    // solo operator is never locked out. Disable with LEO_SHARED_TREE_GUARD=off.
+    try {
+      const { decideSharedTreeCheckout } = require('./lib/shared-tree-guard.cjs');
+      let coordinatorSessionId = null;
+      try {
+        const pointer = require('../../lib/coordinator/resolve.cjs').readPointerFile();
+        coordinatorSessionId = pointer && pointer.session_id ? pointer.session_id : null;
+      } catch { coordinatorSessionId = null; }
+      const verdict = decideSharedTreeCheckout(cmd, {
+        cwd: (input && input.cwd) || process.cwd(),
+        sessionId: _SESSION_ID,
+        coordinatorSessionId,
+        env: process.env,
+      });
+      if (verdict.block) {
+        const auditPromise = auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'ENF-17', 'Shared-tree hijack guard: HEAD-moving git op in shared root while a foreign coordinator is active', 'block', { kind: verdict.kind, coordinator_session_id: coordinatorSessionId });
+        process.stderr.write(
+          `[ENF-17] SHARED-TREE HIJACK BLOCKED: a '${verdict.kind === 'reset' ? 'git reset --hard' : 'git checkout/switch'}' in the SHARED ROOT tree\n` +
+          `  would revert coordinator ${coordinatorSessionId}'s branch on disk (scripts/hooks vanish mid-tick — the 2026-06-11 incident).\n` +
+          `  Work in an isolated worktree instead: node scripts/sd-start.js <SD>  (or: npm run session:worktree)\n` +
+          `  A branch op INSIDE .worktrees/<sd>/ (or via 'git -C <worktree>') is allowed. Override: LEO_SHARED_TREE_GUARD=off\n`
+        );
+        await auditAndExit(auditPromise, 2);
+      }
+    } catch (sharedTreeErr) {
+      // Fail-open: any internal error in ENF-17 must NOT block tool execution.
+      if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+        process.stderr.write(`[pre-tool-enforce] ENF-17 errored (fail-open): ${sharedTreeErr.message}\n`);
       }
     }
   }

--- a/tests/unit/shared-tree-guard.test.js
+++ b/tests/unit/shared-tree-guard.test.js
@@ -95,6 +95,32 @@ describe('decideSharedTreeCheckout — allows safe ops (FR-1 file-restore + FR-2
   });
 });
 
+describe('decideSharedTreeCheckout — classifier bypass hardening (adversarial HIGH fixes)', () => {
+  it('blocks a hijack via --work-tree pointed at the shared root from inside a worktree', () => {
+    // The op runs with cwd in a worktree but --work-tree targets the shared root => hijack.
+    const v = decideSharedTreeCheckout(`git --work-tree=${ROOT} --git-dir=${ROOT}/.git checkout x`, foreign({ cwd: WT }));
+    expect(v).toMatchObject({ block: true, reason: 'shared_root_hijack' });
+  });
+
+  it('allows --work-tree pointed at an isolated worktree', () => {
+    expect(decideSharedTreeCheckout(`git --work-tree=${WT} checkout x`, foreign({ cwd: ROOT })).block).toBe(false);
+  });
+
+  it('blocks checkout behind leading git global options (-c / --no-pager)', () => {
+    expect(decideSharedTreeCheckout('git -c core.pager=cat checkout x', foreign()).block).toBe(true);
+    expect(decideSharedTreeCheckout('git --no-pager checkout x', foreign()).block).toBe(true);
+  });
+
+  it('blocks checkout behind a leading env-var assignment', () => {
+    expect(decideSharedTreeCheckout('FOO=bar git checkout x', foreign()).block).toBe(true);
+    expect(decideSharedTreeCheckout('GIT_PAGER=cat BAR=1 git switch y', foreign()).block).toBe(true);
+  });
+
+  it('still honours -C <worktree> even with other leading globals present', () => {
+    expect(decideSharedTreeCheckout(`git --no-pager -C ${WT} checkout x`, foreign({ cwd: ROOT })).block).toBe(false);
+  });
+});
+
 describe('decideSharedTreeCheckout — flag disable (FR-3)', () => {
   it('allows everything when LEO_SHARED_TREE_GUARD=off', () => {
     const v = decideSharedTreeCheckout('git checkout some-branch', foreign({ env: { LEO_SHARED_TREE_GUARD: 'off' } }));

--- a/tests/unit/shared-tree-guard.test.js
+++ b/tests/unit/shared-tree-guard.test.js
@@ -1,0 +1,119 @@
+/**
+ * Tests for the ENF-17 Shared-Tree Hijack Guard (SD-LEO-FEAT-SHARED-TREE-HIJACK-001).
+ *
+ * The guard blocks a HEAD-moving git op (checkout/switch to a branch, or `reset --hard`)
+ * run in the SHARED repo ROOT while a DIFFERENT session holds the active-coordinator
+ * pointer — the 2026-06-11 incident where a QF worker's shared-root checkout un-deployed
+ * the coordinator's branch. It must FAIL-OPEN (no coordinator / self / worktree / error)
+ * so a solo or isolated worker is never locked out, and must NOT touch file-restore checkouts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  decideSharedTreeCheckout,
+  classifyHeadMovingGitOp,
+  extractGitCDir,
+} = require('../../scripts/hooks/lib/shared-tree-guard.cjs');
+
+const ME = 'sess-worker-aaaa';
+const COORD = 'sess-coordinator-bbbb';
+const ROOT = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
+const WT = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-X';
+
+// Foreign coordinator active, current session is a worker in the shared root.
+const foreign = (over = {}) => ({ cwd: ROOT, sessionId: ME, coordinatorSessionId: COORD, env: {}, ...over });
+
+describe('decideSharedTreeCheckout — blocks shared-root hijack (FR-1)', () => {
+  it('blocks git checkout <branch> in the shared root while a foreign coordinator is active', () => {
+    const v = decideSharedTreeCheckout('git checkout some-branch', foreign());
+    expect(v).toMatchObject({ block: true, reason: 'shared_root_hijack', kind: 'branch' });
+  });
+
+  it('blocks git switch <branch> in the shared root', () => {
+    expect(decideSharedTreeCheckout('git switch other', foreign()).block).toBe(true);
+  });
+
+  it('blocks git checkout -b <branch> (create+switch moves HEAD)', () => {
+    expect(decideSharedTreeCheckout('git checkout -b qf/QF-1', foreign()).block).toBe(true);
+  });
+
+  it('blocks git reset --hard in the shared root (same hijack class)', () => {
+    const v = decideSharedTreeCheckout('git reset --hard origin/main', foreign());
+    expect(v).toMatchObject({ block: true, kind: 'reset' });
+  });
+
+  it('blocks a checkout chained after a shell separator', () => {
+    expect(decideSharedTreeCheckout('cd subdir && git checkout feat/y', foreign()).block).toBe(true);
+  });
+});
+
+describe('decideSharedTreeCheckout — allows safe ops (FR-1 file-restore + FR-2)', () => {
+  it('allows file-restore checkout (git checkout -- file) — HEAD does not move', () => {
+    expect(decideSharedTreeCheckout('git checkout -- src/app.js', foreign()).block).toBe(false);
+  });
+
+  it('allows ref-scoped file restore (git checkout main -- file)', () => {
+    expect(decideSharedTreeCheckout('git checkout main -- src/app.js', foreign()).block).toBe(false);
+  });
+
+  it('allows git reset (soft/mixed, no --hard)', () => {
+    expect(decideSharedTreeCheckout('git reset HEAD~1', foreign()).block).toBe(false);
+    expect(decideSharedTreeCheckout('git reset --soft HEAD~1', foreign()).block).toBe(false);
+  });
+
+  it('allows checkout when effective cwd is inside an isolated worktree', () => {
+    expect(decideSharedTreeCheckout('git checkout feat/x', foreign({ cwd: WT })).block).toBe(false);
+  });
+
+  it('allows checkout targeting a worktree via git -C <worktree> from the root', () => {
+    const v = decideSharedTreeCheckout(`git -C ${WT} checkout feat/x`, foreign({ cwd: ROOT }));
+    expect(v.block).toBe(false);
+  });
+
+  it('allows when no active coordinator (fail-open for solo operator)', () => {
+    expect(decideSharedTreeCheckout('git checkout some-branch', foreign({ coordinatorSessionId: null })).block).toBe(false);
+  });
+
+  it('allows when the current session IS the coordinator', () => {
+    expect(decideSharedTreeCheckout('git checkout some-branch', foreign({ sessionId: COORD })).block).toBe(false);
+  });
+
+  it('treats a malformed/empty coordinator id as no-coordinator (allow)', () => {
+    expect(decideSharedTreeCheckout('git checkout some-branch', foreign({ coordinatorSessionId: '' })).block).toBe(false);
+  });
+
+  it('allows git checkout --help (informational)', () => {
+    expect(decideSharedTreeCheckout('git checkout --help', foreign()).block).toBe(false);
+  });
+
+  it('allows non-git and non-branch commands', () => {
+    expect(decideSharedTreeCheckout('npm test', foreign()).block).toBe(false);
+    expect(decideSharedTreeCheckout('git status', foreign()).block).toBe(false);
+    expect(decideSharedTreeCheckout('git commit -m "checkout"', foreign()).block).toBe(false);
+  });
+});
+
+describe('decideSharedTreeCheckout — flag disable (FR-3)', () => {
+  it('allows everything when LEO_SHARED_TREE_GUARD=off', () => {
+    const v = decideSharedTreeCheckout('git checkout some-branch', foreign({ env: { LEO_SHARED_TREE_GUARD: 'off' } }));
+    expect(v).toMatchObject({ block: false, reason: 'guard_disabled' });
+  });
+});
+
+describe('classifyHeadMovingGitOp / extractGitCDir helpers', () => {
+  it('classifies branch vs reset vs file-restore', () => {
+    expect(classifyHeadMovingGitOp('git checkout x')).toMatchObject({ kind: 'branch' });
+    expect(classifyHeadMovingGitOp('git switch -c x')).toMatchObject({ kind: 'branch' });
+    expect(classifyHeadMovingGitOp('git reset --hard')).toMatchObject({ kind: 'reset' });
+    expect(classifyHeadMovingGitOp('git checkout -- f')).toBeNull();
+    expect(classifyHeadMovingGitOp('git status')).toBeNull();
+  });
+
+  it('extracts the -C dir (space and = forms, quoted)', () => {
+    expect(extractGitCDir('git -C /tmp/x checkout y')).toBe('/tmp/x');
+    expect(extractGitCDir('git -C="/tmp/a b" checkout y')).toBe('/tmp/a b');
+    expect(extractGitCDir('git checkout y')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why
ENF-17 PreToolUse guard preventing the **shared-tree hijack** incident class.

**Live HIGH incident (2026-06-11):** a worker building QF-20260610-626 ran `git checkout` of its `qf/` branch inside the operator/coordinator **shared ROOT** working tree (not an isolated worktree). The checkout un-deployed the coordinator's branch — its scripts/hooks reverted on disk mid-tick while already-loaded skills kept running, and every supervision cron loop would have `MODULE_NOT_FOUND`'d on its next tick. Grounding confirmed the active-coordinator pointer was only **restored after the fact** (`post-checkout-role-restore.cjs`); nothing defended *before* the destructive checkout.

## Change
- **New pure `scripts/hooks/lib/shared-tree-guard.cjs`** — `decideSharedTreeCheckout` classifies HEAD-moving git ops (`checkout`/`switch` to a branch, `reset --hard`), resolves a `git -C <dir>` target, and blocks **only** when the effective dir is the shared ROOT (not a `.worktrees/` subtree) **AND** a different session holds the active-coordinator pointer.
- **Wire ENF-17 into `pre-tool-enforce.cjs`** Bash path — reuses `resolve.cjs` `readPointerFile` (one source of truth for the pointer shape), audits the decision, and exits 2 with a worktree-isolation remedy message.
- **Fail-open**: no coordinator / self-coordinator / file-restore checkout (`git checkout -- file`) / any internal error → allow. Solo + isolated workers are never locked out.
- **Disable** via `LEO_SHARED_TREE_GUARD=off`. Pure logic (no git subprocess / network) → fast, Windows-safe.

## Out of scope (follow-ups)
- Mandate worktree isolation for the QF workflow (drop the main-tree exception).
- Run coordinator loops from a pinned detached host.

## Verification
- **18 unit tests** (`tests/unit/shared-tree-guard.test.js`) — block/allow matrix incl. `git -C <worktree>`, file-restore, `reset --hard`/`--soft`, no-coordinator, self-coordinator, malformed pointer, flag-off.
- **E2E smoke** against the real hook: shared-root `reset --hard` and `checkout <branch>` → BLOCK (ENF-17 message + exit 2); file-restore, `git -C <worktree> checkout`, and self-coordinator → ALLOW.
- `enforcement-hook-registration` regression test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)