### PR TITLE
feat(SD-LEO-FEAT-WINDOWS-LIBUV-ASSERTION-001): unref heartbeat interval (Windows libuv assertion + exit-143 hang)

### DIFF
--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -38,6 +38,27 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 const GRACEFUL_EXIT_TIMEOUT_MS = 5000; // 5 second timeout for graceful release (FR-3/US-002)
 const GRACEFUL_EXIT_RETRIES = 3; // Number of retry attempts
 
+/**
+ * SD-LEO-FEAT-WINDOWS-LIBUV-ASSERTION-001: arm an UNREF'd interval.
+ *
+ * A ref'd setInterval keeps the Node event loop alive on its own; on Windows, when the process then
+ * exits (e.g. the direct process.exit(0) in the SIGINT/SIGTERM handler, or a natural drain) libuv
+ * force-closes the timer's async handle while it is already in the closing state, tripping
+ * "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\\win\\async.c line 76". unref()'ing the
+ * timer takes it out of that force-close path AND fixes the documented exit-143 hang (the heartbeat no
+ * longer holds the loop open after the worker's real work drains). The heartbeat still fires during
+ * genuine async work, because the worker's own pending operations keep the loop alive.
+ *
+ * @param {Function} fn  - interval callback
+ * @param {number}   ms  - interval period
+ * @returns {ReturnType<typeof setInterval>} the unref'd timer
+ */
+export function armUnrefInterval(fn, ms) {
+  const timer = setInterval(fn, ms);
+  if (timer && typeof timer.unref === 'function') timer.unref();
+  return timer;
+}
+
 // Module state
 let heartbeatInterval = null;
 let currentSessionId = null;
@@ -114,12 +135,12 @@ async function releaseSessionWithRetry(reason = 'graceful_exit') {
  * SD-LEO-INFRA-ISL-001 (US-002): Enhanced with graceful exit handlers
  * SD-LEO-INFRA-LEO-PROTOCOL-POLICY-001 (FR-007): Supports ownership modes
  *
- * ⚠️ This arms a ref'd 30s setInterval that keeps the Node event loop alive.
- * It is intended for LONG-RUNNING workers (handoff.js, BaseExecutor.js,
- * add-prd-to-database.js). If you call it from a short-lived claim-and-exit CLI,
- * you MUST call stopHeartbeat() (or process.exit()) before the script returns —
- * otherwise the process hangs until an external watchdog SIGTERMs it (exit 143).
- * See QF-20260424-805 (add-prd-to-database.js) and QF-20260523-820 (sd-start.js).
+ * This arms an UNREF'd 30s setInterval (SD-LEO-FEAT-WINDOWS-LIBUV-ASSERTION-001). It fires during
+ * any genuine async work (the worker's own pending operations keep the loop alive), but does NOT hold
+ * the loop open by itself — so the process drains naturally when real work finishes instead of hanging
+ * until an external watchdog SIGTERMs it (the old ref'd timer caused exit 143; see QF-20260424-805 /
+ * QF-20260523-820) and it avoids the Windows libuv UV_HANDLE_CLOSING force-close-on-exit assertion.
+ * Calling stopHeartbeat() when done is still good hygiene (it clears the timer and flips is_alive).
  *
  * @param {string} sessionId - Session ID to send heartbeats for
  * @param {object} [options]
@@ -159,8 +180,9 @@ export function startHeartbeat(sessionId, options = {}) {
   // Send initial heartbeat
   sendHeartbeat();
 
-  // Start interval
-  heartbeatInterval = setInterval(() => {
+  // Start interval (UNREF'd — see armUnrefInterval: avoids the Windows libuv UV_HANDLE_CLOSING
+  // assertion on exit and the exit-143 hang, while still firing during real async work).
+  heartbeatInterval = armUnrefInterval(() => {
     sendHeartbeat();
   }, HEARTBEAT_INTERVAL_MS);
 

--- a/tests/unit/heartbeat-manager-unref-interval.test.js
+++ b/tests/unit/heartbeat-manager-unref-interval.test.js
@@ -1,0 +1,38 @@
+/**
+ * SD-LEO-FEAT-WINDOWS-LIBUV-ASSERTION-001 — the heartbeat interval must be UNREF'd so that on Windows
+ * libuv does not force-close the timer's async handle while it is already closing on process exit
+ * ("Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src/win/async.c line 76"), and so a
+ * short-lived CLI does not hang to exit-143 waiting on a ref'd timer. We assert the property directly
+ * via Node's Timeout.hasRef(): an unref'd timer reports hasRef() === false.
+ */
+import { describe, it, expect } from 'vitest';
+import { armUnrefInterval } from '../../lib/heartbeat-manager.mjs';
+
+describe('armUnrefInterval (SD-LEO-FEAT-WINDOWS-LIBUV-ASSERTION-001)', () => {
+  it('returns a timer that is NOT keeping the event loop alive (hasRef() === false)', () => {
+    const t = armUnrefInterval(() => {}, 1_000_000);
+    try {
+      expect(typeof t.hasRef).toBe('function');
+      expect(t.hasRef()).toBe(false); // unref'd: does not hold the loop open / not in the force-close path
+    } finally {
+      clearInterval(t);
+    }
+  });
+
+  it('contrast: a plain ref\'d setInterval DOES keep the loop alive (hasRef() === true)', () => {
+    const t = setInterval(() => {}, 1_000_000);
+    try {
+      expect(t.hasRef()).toBe(true);
+    } finally {
+      clearInterval(t);
+    }
+  });
+
+  it('still returns a working, clearable timer handle', () => {
+    let fired = 0;
+    const t = armUnrefInterval(() => { fired++; }, 1_000_000);
+    expect(t).toBeDefined();
+    clearInterval(t); // must not throw
+    expect(fired).toBe(0); // long period → never fired in this synchronous test
+  });
+});


### PR DESCRIPTION
## Summary
Windows prints `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src\win\async.c line 76` at the end of many node CLI runs (worker-checkin, add-prd-to-database, sd-start). `lib/heartbeat-manager.mjs` armed a **ref'd** 30s `setInterval`; a ref'd timer keeps the loop alive on its own, and on Windows exit libuv force-closes its async handle while it is already closing → assertion. The same ref'd timer also caused the documented **exit-143 hang**.

## Fix
Arm the interval **unref'd** via a new exported `armUnrefInterval()` helper (`setInterval` + `.unref()`). An unref'd timer is out of the force-close path and no longer holds the loop open after real work drains, while still firing during genuine async work (the worker's own pending ops keep the loop alive). Docstring updated. 3 unit tests assert `hasRef()===false` on the armed timer (vs `true` for a plain `setInterval`).

## Scope (adversarial-confirmed)
The fix is correct and **zero-regression** (all 6 `startHeartbeat` callers are claim-and-exit CLIs / cooperative subprocesses — none relies on the timer for loop keepalive; the `sd-start`/`add-prd` `stopHeartbeat()+exit` workarounds become redundant-but-harmless). **It removes the timer as a cause and fixes the hang, but does not fully eliminate the assertion**: the reviewer empirically reproduced it with *no timer* — a Supabase/undici keep-alive socket force-closed by the direct `process.exit(0)` in the SIGINT/SIGTERM handler can trip it on its own. Fully eliminating it requires graceful socket teardown/drain before `process.exit(0)` — filed as a follow-up (out of scope for this minimal timer fix).

## Tests
3 new (`tests/unit/heartbeat-manager-unref-interval.test.js`) + existing heartbeat suites (40 total) green. `node --check` clean. Rebased onto latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
