### PR TITLE
feat(SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001): auto-emit /signal at the RCA recurrence threshold

### DIFF
--- a/lib/hooks/auto-signal-threshold.cjs
+++ b/lib/hooks/auto-signal-threshold.cjs
@@ -1,0 +1,54 @@
+/**
+ * Auto-signal threshold decision — SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001 (FR-1).
+ *
+ * Workers systematically UNDER-escalate: the /signal recurrence thresholds (gate-2x, RCA-2x,
+ * claim-release) are PROMPT-ADVISORY, so Opus defaults to the lowest-friction path and the live
+ * signal loses. This module makes the ENFORCEMENT LAYER decide — deterministically — when to
+ * auto-emit a /signal at the RCA recurrence threshold, removing worker discretion.
+ *
+ * PURE (no I/O): the pre-tool-enforce hook calls shouldEmitAutoSignal() at the RCA tiered-enforcement
+ * crossing and, when true, fire-and-forget spawns worker-signal.cjs with buildAutoSignalArgs().
+ * Kept in its own module (not inline in the hot-path hook) so it is unit-testable WITHOUT importing
+ * the hook (which would execute the enforcement pipeline on require).
+ *
+ * SAFETY CONTRACT (enforced by the caller): the emission is fire-and-forget (detached + unref, never
+ * awaited), env-disableable (LEO_AUTO_SIGNAL=off), and wrapped fail-open so it can NEVER block or
+ * throw into a tool call. This module only decides + formats; it performs no I/O.
+ */
+
+'use strict';
+
+/**
+ * Should the enforcement layer auto-emit a /signal at this RCA recurrence attempt?
+ * Fires EXACTLY ONCE per signature escalation — on the 2nd-attempt crossing (the warn tier). The
+ * 3rd attempt hard-blocks (handled by the hook) and must NOT re-signal (dedupe by exact ===2).
+ *
+ * @param {{ attempts:number, sessionId?:string, env?:object }} opts
+ * @returns {boolean}
+ */
+function shouldEmitAutoSignal({ attempts, sessionId, env = process.env } = {}) {
+  if (env && env.LEO_AUTO_SIGNAL === 'off') return false;        // kill-switch
+  if (!sessionId || sessionId === 'unknown') return false;       // need a real worker identity
+  if (!Number.isInteger(attempts)) return false;
+  return attempts === 2;                                          // once, on the crossing (not >=2)
+}
+
+/**
+ * Build the argv for `node scripts/worker-signal.cjs <type> "<body>" --severity <sev>`. Reuses the
+ * canonical signal CLI (no re-implementation of the session_coordination row shape the router keys
+ * on). Type 'stuck' = recurrence/blocked; severity 'high' (a 2nd-attempt recurrence is one repeat
+ * from a hard block). Body is single-line + bounded.
+ *
+ * @param {{ toolName:string, signature:string, attempts:number, sdKey?:string }} opts
+ * @returns {string[]} argv after the script path (e.g. ['stuck', '<body>', '--severity', 'high'])
+ */
+function buildAutoSignalArgs({ toolName, signature, attempts, sdKey } = {}) {
+  const sig = String(signature == null ? '' : signature).replace(/\s+/g, ' ').slice(0, 120);
+  const body =
+    `AUTO-SIGNAL (enforcement-layer RCA recurrence): ${toolName || 'tool'} repeated ${attempts}x on ` +
+    `signature "${sig}"${sdKey ? ' (SD ' + sdKey + ')' : ''} without intervening RCA — next repeat ` +
+    `hard-blocks. Auto-escalated per SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001 (worker may be stuck).`;
+  return ['stuck', body, '--severity', 'high'];
+}
+
+module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1205,6 +1205,26 @@ async function main() {
           `next repeat ${bypassed ? '(bypass active)' : 'will be blocked'}. ` +
           `Consider invoking rca-agent if this indicates a persistent failure.`
         );
+
+        // SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001 (FR-1): at the RCA recurrence threshold, AUTO-EMIT a
+        // /signal to the coordinator instead of relying on worker discretion (workers under-escalate
+        // because the threshold is prompt-advisory). Fires ONCE per signature (===2 crossing),
+        // FIRE-AND-FORGET (detached + unref, never awaited), env-disableable (LEO_AUTO_SIGNAL=off),
+        // FAIL-OPEN (any error swallowed — auto-signal must NEVER block or slow a tool call).
+        try {
+          const { shouldEmitAutoSignal, buildAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
+          if (shouldEmitAutoSignal({ attempts, sessionId: _SESSION_ID, env: process.env })) {
+            const path = require('path');
+            const { spawn } = require('child_process');
+            const args = buildAutoSignalArgs({ toolName: TOOL_NAME, signature, attempts, sdKey: claimedSdKey });
+            const child = spawn(
+              process.execPath,
+              [path.join(__dirname, '..', 'worker-signal.cjs'), ...args],
+              { detached: true, stdio: 'ignore', env: { ...process.env, CLAUDE_SESSION_ID: _SESSION_ID } }
+            );
+            child.unref();
+          }
+        } catch { /* fail-open: auto-signal must never block tool execution */ }
       }
     }
   } catch (rcaErr) {

--- a/tests/unit/auto-signal-threshold.test.js
+++ b/tests/unit/auto-signal-threshold.test.js
@@ -1,0 +1,70 @@
+/**
+ * Auto-signal threshold decision — SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001 (FR-1).
+ *
+ * The enforcement layer now AUTO-EMITS a /signal at the RCA recurrence threshold instead of relying
+ * on worker discretion. These tests pin the pure decision + arg-format helper (the hook fire-and-
+ * forget spawns worker-signal.cjs with them). Critical invariants: fires EXACTLY ONCE per escalation
+ * (on the ===2 crossing, not the 3rd hard-block), respects the LEO_AUTO_SIGNAL=off kill-switch, and
+ * never fires without a real session identity.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { shouldEmitAutoSignal, buildAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
+
+const SID = '11111111-2222-4333-8444-555555555555';
+
+describe('shouldEmitAutoSignal (FR-1)', () => {
+  it('fires exactly on the 2nd-attempt crossing', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: {} })).toBe(true);
+  });
+
+  it('does NOT fire on the 1st attempt (no recurrence yet)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 1, sessionId: SID, env: {} })).toBe(false);
+  });
+
+  it('does NOT re-fire on the 3rd+ attempt (dedupe — 3rd hard-blocks, already signalled at 2)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, env: {} })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 5, sessionId: SID, env: {} })).toBe(false);
+  });
+
+  it('respects the LEO_AUTO_SIGNAL=off kill-switch', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
+  });
+
+  it('does not fire without a real session identity', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: undefined, env: {} })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: 'unknown', env: {} })).toBe(false);
+  });
+
+  it('ignores non-integer attempts (fail-safe)', () => {
+    expect(shouldEmitAutoSignal({ attempts: NaN, sessionId: SID, env: {} })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: undefined, sessionId: SID, env: {} })).toBe(false);
+  });
+});
+
+describe('buildAutoSignalArgs (FR-1)', () => {
+  it('builds a stuck/high signal with a single-line bounded body referencing the SD', () => {
+    const args = buildAutoSignalArgs({ toolName: 'Bash', signature: 'git reset --hard', attempts: 2, sdKey: 'SD-X-001' });
+    expect(args[0]).toBe('stuck');
+    expect(args).toContain('--severity');
+    expect(args[args.indexOf('--severity') + 1]).toBe('high');
+    const body = args[1];
+    expect(body).toContain('Bash');
+    expect(body).toContain('SD-X-001');
+    expect(body).toContain('SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001');
+    expect(body).not.toContain('\n');           // single-line (safe to pass as one argv element)
+  });
+
+  it('collapses whitespace and bounds a long/multi-line signature', () => {
+    const longSig = 'a'.repeat(400) + '\n\tweird   spacing';
+    const args = buildAutoSignalArgs({ toolName: 'Edit', signature: longSig, attempts: 2 });
+    expect(args[1]).not.toContain('\n');
+    expect(args[1].length).toBeLessThan(400);   // signature was truncated to <=120
+  });
+
+  it('omits the SD clause when no sdKey is known', () => {
+    const args = buildAutoSignalArgs({ toolName: 'Bash', signature: 'sig', attempts: 2 });
+    expect(args[1]).not.toContain('(SD ');
+  });
+});


### PR DESCRIPTION
## Summary
Workers systematically under-escalate because the /signal recurrence thresholds are prompt-advisory CLAUDE.md heuristics. This moves the decision into the **enforcement layer**: at the RCA tiered-enforcement crossing in `scripts/hooks/pre-tool-enforce.cjs` (which already counts recurrence), auto-emit a /signal to the coordinator via the canonical `worker-signal.cjs`.

## Changes
- **NEW** `lib/hooks/auto-signal-threshold.cjs` — pure `shouldEmitAutoSignal` (decision) + `buildAutoSignalArgs` (formatting), kept out of the hot-path hook so it's unit-testable without importing the hook.
- **`scripts/hooks/pre-tool-enforce.cjs`** — at the RCA-2x warn crossing, fire-and-forget spawn `worker-signal.cjs`.

## Hot-path safety (runs on every tool call)
- Fires **exactly once** per signature (===2 crossing; 3rd hard-blocks, no re-signal).
- **Fire-and-forget** (detached + unref, never awaited → zero added latency).
- **Kill-switch** `LEO_AUTO_SIGNAL=off`.
- Inside the existing **fail-open** try/catch — can never block/throw into a tool call. RCA counter/block logic unchanged.

## Testing
9 new unit tests; hook + RCA-tiered suites green; `node -c` valid.

## Scope
Ships the RCA-recurrence threshold (the hook chokepoint). gate-2x (handoff.js) + claim-release are documented follow-ups; the pure helper is site-agnostic for reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
