### PR TITLE
fix(SD-LEO-FEAT-PHANTOM-TABLE-READ-001): heal gate reads app_config, not the phantom leo_config table

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -18,10 +18,10 @@
  *
  * - SD heal: BLOCKING — score must be >= (threshold - tolerance)
  *   - Threshold resolved in priority order:
- *     1. leo_config 'heal_gate_threshold' (global override)
+ *     1. app_config 'heal_gate_threshold' (global override)
  *     2. SD-type-aware tier (feature/security=90, infrastructure/docs=80)
  *     3. DEFAULT_HEAL_THRESHOLD (85) as final fallback
- *   - Tolerance buffer: leo_config 'heal_gate_tolerance_buffer' (default 3)
+ *   - Tolerance buffer: app_config 'heal_gate_tolerance_buffer' (default 3)
  *   - Corrective SDs: always use GRADE.A (93) via grade-scale.js
  * - Vision heal: ADVISORY — logged but does not block
  */
@@ -303,10 +303,45 @@ const SD_TYPE_THRESHOLDS = {
 };
 
 /**
+ * Read a single config value from the canonical `app_config` table (key/value).
+ *
+ * SD-LEO-FEAT-PHANTOM-TABLE-READ-001: the heal-gate override tier previously read
+ * a `leo_config` table that does not exist in the live DB (every read returned
+ * PGRST205 and fell open to defaults — the global override was silently dead).
+ * `app_config` is the canonical config table (chairman_email, pocock_provenance_writers,
+ * …); PostgREST itself hinted "Perhaps you meant the table public.app_config".
+ *
+ * Fail-open by contract: returns the raw value string when a row exists, else
+ * null on a missing row, missing/absent table, or any error — the heal gate must
+ * never be broken by a config-read failure.
+ *
+ * @param {Object} supabase
+ * @param {string} key
+ * @returns {Promise<string|null>}
+ */
+async function readAppConfigValue(supabase, key) {
+  try {
+    const { data, error } = await supabase
+      .from('app_config')
+      .select('value')
+      .eq('key', key)
+      .single();
+    // A missing row (PGRST116) or missing table is not an exception in supabase-js —
+    // it surfaces as `error`. Treat any error as "no override" (fail open).
+    if (error) return null;
+    return data?.value != null ? data.value : null;
+  } catch (e) {
+    // Defensive: any thrown error (network, etc.) also fails open.
+    console.debug('[HealBeforeComplete] app_config lookup suppressed:', e?.message || e);
+    return null;
+  }
+}
+
+/**
  * Load the heal gate threshold with SD-type awareness.
  *
  * Resolution order:
- *   1. leo_config 'heal_gate_threshold' (explicit global override)
+ *   1. app_config 'heal_gate_threshold' (explicit global override)
  *   2. SD-type-aware tier from SD_TYPE_THRESHOLDS
  *   3. DEFAULT_HEAL_THRESHOLD (85)
  *
@@ -315,23 +350,13 @@ const SD_TYPE_THRESHOLDS = {
  * @returns {Promise<{threshold: number, source: string}>}
  */
 async function loadHealThreshold(supabase, sdType) {
-  // 1. Check leo_config for explicit global override
-  try {
-    const { data } = await supabase
-      .from('leo_config') // schema-lint-disable-line — phantom table (absent from live DB); read fails open to DEFAULT_HEAL_THRESHOLD via catch. Pre-existing; flagged for cleanup (SD-PAT-FIX-WRITER-CONSUMER-ASYMMETRY-001).
-      .select('value')
-      .eq('key', 'heal_gate_threshold')
-      .single();
-
-    if (data?.value != null) {
-      const parsed = parseInt(data.value, 10);
-      if (!isNaN(parsed) && parsed > 0 && parsed <= 100) {
-        return { threshold: parsed, source: 'leo_config' };
-      }
+  // 1. Check app_config for an explicit global override
+  const overrideValue = await readAppConfigValue(supabase, 'heal_gate_threshold');
+  if (overrideValue != null) {
+    const parsed = parseInt(overrideValue, 10);
+    if (!isNaN(parsed) && parsed > 0 && parsed <= 100) {
+      return { threshold: parsed, source: 'app_config' };
     }
-  } catch (e) {
-    // Intentionally suppressed: Fall through to SD-type tier
-    console.debug('[HealBeforeComplete] leo_config threshold lookup suppressed:', e?.message || e);
   }
 
   // 2. SD-type-aware tier
@@ -344,32 +369,25 @@ async function loadHealThreshold(supabase, sdType) {
 }
 
 /**
- * Load the tolerance buffer from leo_config.
+ * Load the tolerance buffer from app_config.
  * Scores within (threshold - buffer) are accepted with a warning.
  *
  * @param {Object} supabase
  * @returns {Promise<number>}
  */
 async function loadToleranceBuffer(supabase) {
-  try {
-    const { data } = await supabase
-      .from('leo_config') // schema-lint-disable-line — phantom table (absent from live DB); read fails open to DEFAULT_TOLERANCE_BUFFER via catch. Pre-existing; flagged for cleanup (SD-PAT-FIX-WRITER-CONSUMER-ASYMMETRY-001).
-      .select('value')
-      .eq('key', 'heal_gate_tolerance_buffer')
-      .single();
-
-    if (data?.value != null) {
-      const parsed = parseInt(data.value, 10);
-      if (!isNaN(parsed) && parsed >= 0 && parsed <= 10) {
-        return parsed;
-      }
+  const overrideValue = await readAppConfigValue(supabase, 'heal_gate_tolerance_buffer');
+  if (overrideValue != null) {
+    const parsed = parseInt(overrideValue, 10);
+    if (!isNaN(parsed) && parsed >= 0 && parsed <= 10) {
+      return parsed;
     }
-  } catch (e) {
-    // Intentionally suppressed: Fall through to default tolerance buffer
-    console.debug('[HealBeforeComplete] tolerance buffer lookup suppressed:', e?.message || e);
   }
   return DEFAULT_TOLERANCE_BUFFER;
 }
+
+// Exported for unit testing (SD-LEO-FEAT-PHANTOM-TABLE-READ-001).
+export { readAppConfigValue, loadHealThreshold, loadToleranceBuffer };
 
 /**
  * Create the HEAL_BEFORE_COMPLETE gate validator.

--- a/tests/unit/heal-gate-app-config-read.test.js
+++ b/tests/unit/heal-gate-app-config-read.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-LEO-FEAT-PHANTOM-TABLE-READ-001 — the HEAL_BEFORE_COMPLETE gate's global
+ * threshold/tolerance override previously read a non-existent `leo_config` table
+ * (PGRST205, silently dead). It now reads the real `app_config` table via a
+ * shared fail-open helper. These tests lock in: the correct table name, the
+ * override-honored path, fall-through when absent/out-of-range, and fail-open on error.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  readAppConfigValue,
+  loadHealThreshold,
+  loadToleranceBuffer,
+} from '../../scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js';
+
+/**
+ * Build a mock supabase whose .from(table).select().eq(col,val).single() resolves
+ * to `resolver(table, col, val)` => { data, error }. Records every table queried.
+ */
+function makeSupabase(resolver) {
+  const queriedTables = [];
+  const client = {
+    from(table) {
+      queriedTables.push(table);
+      let _col, _val;
+      const builder = {
+        select() { return builder; },
+        eq(col, val) { _col = col; _val = val; return builder; },
+        single() { return Promise.resolve(resolver(table, _col, _val)); },
+      };
+      return builder;
+    },
+  };
+  return { client, queriedTables };
+}
+
+describe('readAppConfigValue — reads the real app_config table, fail-open', () => {
+  it('queries app_config (NEVER leo_config) and returns the value', async () => {
+    const { client, queriedTables } = makeSupabase(() => ({ data: { value: '72' }, error: null }));
+    const v = await readAppConfigValue(client, 'heal_gate_threshold');
+    expect(v).toBe('72');
+    expect(queriedTables).toContain('app_config');
+    expect(queriedTables).not.toContain('leo_config');
+  });
+
+  it('returns null on a supabase error (missing row / missing table)', async () => {
+    const { client } = makeSupabase(() => ({ data: null, error: { code: 'PGRST205', message: 'not found' } }));
+    expect(await readAppConfigValue(client, 'heal_gate_threshold')).toBeNull();
+  });
+
+  it('returns null (no throw) when the read throws', async () => {
+    const client = { from() { throw new Error('network down'); } };
+    expect(await readAppConfigValue(client, 'heal_gate_threshold')).toBeNull();
+  });
+
+  it('returns null when the row has no value', async () => {
+    const { client } = makeSupabase(() => ({ data: { value: null }, error: null }));
+    expect(await readAppConfigValue(client, 'heal_gate_threshold')).toBeNull();
+  });
+});
+
+describe('loadHealThreshold — app_config override → sd_type tier → default', () => {
+  it('honors a valid app_config override with source app_config', async () => {
+    const { client } = makeSupabase((t, c, v) => (v === 'heal_gate_threshold' ? { data: { value: '70' }, error: null } : { data: null, error: null }));
+    expect(await loadHealThreshold(client, 'feature')).toEqual({ threshold: 70, source: 'app_config' });
+  });
+
+  it('falls through to the sd_type tier when no override exists', async () => {
+    const { client, queriedTables } = makeSupabase(() => ({ data: null, error: { code: 'PGRST116' } }));
+    const r = await loadHealThreshold(client, 'feature');
+    expect(r.source).toBe('sd_type:feature');
+    expect(r.threshold).toBeGreaterThan(0);
+    // proves the phantom table is gone — only app_config is ever queried
+    expect(queriedTables).toEqual(['app_config']);
+    expect(queriedTables).not.toContain('leo_config');
+  });
+
+  it('rejects an out-of-range override and falls through', async () => {
+    const { client } = makeSupabase(() => ({ data: { value: '999' }, error: null }));
+    const r = await loadHealThreshold(client, 'feature');
+    expect(r.source).toBe('sd_type:feature');
+  });
+
+  it('falls back to default when no sdType and no override', async () => {
+    const { client } = makeSupabase(() => ({ data: null, error: { code: 'PGRST205' } }));
+    const r = await loadHealThreshold(client, undefined);
+    expect(r.source).toBe('default');
+    expect(r.threshold).toBe(85);
+  });
+
+  it('fails open to sd_type/default when the read throws', async () => {
+    const client = { from() { throw new Error('db down'); } };
+    const r = await loadHealThreshold(client, 'feature');
+    expect(r.source).toBe('sd_type:feature');
+  });
+});
+
+describe('loadToleranceBuffer — app_config override, range-validated, fail-open', () => {
+  it('honors a valid in-range override', async () => {
+    const { client } = makeSupabase(() => ({ data: { value: '2' }, error: null }));
+    expect(await loadToleranceBuffer(client)).toBe(2);
+  });
+
+  it('rejects an out-of-range override and returns the default', async () => {
+    const { client } = makeSupabase(() => ({ data: { value: '50' }, error: null }));
+    expect(await loadToleranceBuffer(client)).toBe(3);
+  });
+
+  it('returns the default when absent / on error', async () => {
+    const { client } = makeSupabase(() => ({ data: null, error: { code: 'PGRST205' } }));
+    expect(await loadToleranceBuffer(client)).toBe(3);
+  });
+});


### PR DESCRIPTION
## What & why
The HEAL_BEFORE_COMPLETE gate's `loadHealThreshold()` / `loadToleranceBuffer()` read their global-override tier from `.from('leo_config')` — **a table that does not exist** in the live DB. Every PLAN-TO-LEAD heal-gate run issued two wasted PostgREST round-trips returning `PGRST205` and fell open to defaults. The global override has been **silently dead** since it was written, and the gate logs recurring phantom-read noise on every handoff.

**Root cause:** a table-name error. The canonical config table is `app_config` (`key`/`value`/`description`; holds `chairman_email`, `pocock_provenance_writers`, …) — PostgREST itself hints *"Perhaps you meant the table public.app_config"*. The consumer was wired to a name the writer never created — the writer/consumer asymmetry that SD-PAT-FIX-WRITER-CONSUMER-ASYMMETRY-001 flagged for cleanup but did not perform.

## Change
- New shared **fail-open `readAppConfigValue(supabase, key)`** reading the real `app_config` table; returns `null` on missing row / missing table / any error.
- Repoint both helpers at it. Resolution order unchanged (override → SD-type tier → default); range validation preserved (threshold 1–100, tolerance 0–10); source label `'leo_config'` → `'app_config'`.
- Remove the two `schema-lint-disable-line` phantom-table suppressions; update docstrings.
- **No schema change** — `app_config` already exists.

## Verification
- **12-unit-test** regression suite (`tests/unit/heal-gate-app-config-read.test.js`): asserts the queried table is `app_config` and **never** `leo_config`, plus override-honored / fall-through / out-of-range / fail-open paths.
- `tests/sd-type-threshold-canonical.test.js` still passes (no regression).
- **DATABASE sub-agent** (PASS 98): confirmed `app_config` exists with the right schema, `leo_config` does not, **no migration required**, and zero `heal_gate_*` keys today → **behavior-identical now**; the override is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)