### PR TITLE
fix(SD-LEO-FEAT-ADAM-INBOX-CONSUMPTION-001): regression guard for Adam coordinator_reminder drain (premise falsified)

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -240,6 +240,13 @@ const ADAM_INBOX_KINDS = Object.freeze([
   'chairman_heads_up',
   'chairman_handoff',
   'coordinator_advisory',
+  // SD-LEO-FEAT-ADAM-INBOX-CONSUMPTION-001 (verify-the-premise): the coordinator hourly-review dispatches
+  // Adam a payload.kind='coordinator_reminder' ('review your Adam responsibilities'). This kind is ALREADY
+  // drained by the Adam inbox because it lives in the shared DIRECTIVE_KINDS (worker-status.cjs, added by
+  // #4610 on 2026-06-10) which is spread into ADAM_INBOX_KINDS above — live data confirms 0 unread. It is
+  // intentionally NOT re-listed here to avoid a misleading duplicate; the coupling is pinned by
+  // tests/unit/adam-inbox-coordinator-reminder.test.js so a future DIRECTIVE_KINDS edit can't silently
+  // break Adam's drain of it.
   'coordinator_adam_feedback',
   'assist_request',
   'reconcile_consult',

--- a/tests/unit/adam-inbox-coordinator-reminder.test.js
+++ b/tests/unit/adam-inbox-coordinator-reminder.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import pkg from '../../scripts/adam-advisory.cjs';
+
+const { isAdamInboxRow, isDirectiveRow, ADAM_INBOX_KINDS } = pkg;
+
+// SD-LEO-FEAT-ADAM-INBOX-CONSUMPTION-001 (regression guard): the coordinator hourly-review sends Adam a
+// payload.kind='coordinator_reminder'. The reported "sits unread ~59m/hr" bug was a FALSE PREMISE — the
+// kind has been drainable since #4610 (2026-06-10) because it lives in the shared DIRECTIVE_KINDS, which
+// ADAM_INBOX_KINDS spreads in; live data confirmed 0 unread. This test PINS that non-obvious cross-module
+// coupling so a future DIRECTIVE_KINDS edit can't silently break Adam's drain of the hourly reminder.
+const row = (kind) => (kind === undefined ? { payload: {} } : { payload: { kind } });
+
+describe('Adam inbox drains coordinator_reminder (inheritance guard)', () => {
+  it('coordinator_reminder is in the Adam-scoped allowlist (via shared DIRECTIVE_KINDS)', () => {
+    expect(ADAM_INBOX_KINDS).toContain('coordinator_reminder');
+  });
+
+  it('isAdamInboxRow classifies a coordinator_reminder row as drainable', () => {
+    expect(isAdamInboxRow(row('coordinator_reminder'))).toBe(true);
+  });
+
+  it('still drains the other Adam-directed kinds (regression)', () => {
+    expect(isAdamInboxRow(row('coordinator_advisory'))).toBe(true);
+    expect(isAdamInboxRow(row('chairman_heads_up'))).toBe(true);
+  });
+
+  it('responder-owned / terminal kinds remain NON-drainable', () => {
+    expect(isAdamInboxRow(row('comms_check'))).toBe(false);
+    expect(isAdamInboxRow(row('ack'))).toBe(false);
+    expect(isAdamInboxRow(row('canary_request'))).toBe(false);
+  });
+
+  it('untyped rows (no payload.kind) remain NON-drainable', () => {
+    expect(isAdamInboxRow(row(undefined))).toBe(false);
+    expect(isAdamInboxRow({})).toBe(false);
+    expect(isAdamInboxRow(null)).toBe(false);
+  });
+
+  it('coordinator_reminder is a SHARED directive — that inheritance is exactly what makes Adam drain it', () => {
+    // isDirectiveRow uses the imported DIRECTIVE_KINDS. coordinator_reminder IS in it (workers + Adam both
+    // consume that lane); ADAM_INBOX_KINDS = [...DIRECTIVE_KINDS, ...] so Adam inherits it. If a future
+    // edit removed it from DIRECTIVE_KINDS, BOTH this assertion and the drain above would fail — by design.
+    expect(isDirectiveRow(row('coordinator_reminder'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Filed as "coordinator_reminder sits unread ~59m/hr for the Adam inbox." **That premise was falsified during EXEC.**

`coordinator_reminder` has been drainable by the Adam inbox since #4610 (2026-06-10): it lives in the shared `DIRECTIVE_KINDS` (lib/fleet/worker-status.cjs:81), and `ADAM_INBOX_KINDS` in `scripts/adam-advisory.cjs` is built as `[...DIRECTIVE_KINDS, ...]` — so it's inherited. Live DB check: **0/15** recent `coordinator_reminder` rows unread (all `read_at` stamped). No functional bug existed.

## Deliverable (honest re-scope → regression guard)
- `scripts/adam-advisory.cjs`: replaced a would-be misleading duplicate with a comment documenting the `DIRECTIVE_KINDS` inheritance + the 0-unread live finding. **No functional change.**
- `tests/unit/adam-inbox-coordinator-reminder.test.js` (NEW, 6 tests): pins the non-obvious cross-module coupling — `coordinator_reminder` must stay in `DIRECTIVE_KINDS` so Adam keeps draining it — plus excluded/untyped non-drainable assertions.

Guards against a future `DIRECTIVE_KINDS` edit silently breaking Adam's drain.

## Tests
- `adam-inbox-coordinator-reminder.test.js` — 6/6 ✅
- `coord-adam-comms-resilient.test.js` (sibling) — 35/35 ✅ (no regression)
- `node --check scripts/adam-advisory.cjs` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
