### PR TITLE
feat(SD-LEO-INFRA-EXEC-EMAIL-FORECAST-FROZEN-001): run forecaster on cron + degraded forecast marker

### DIFF
--- a/.github/workflows/adam-exec-email-cron.yml
+++ b/.github/workflows/adam-exec-email-cron.yml
@@ -140,6 +140,17 @@ jobs:
         continue-on-error: true
         run: npm run vision:gauge
 
+      # SD-LEO-INFRA-EXEC-EMAIL-FORECAST-FROZEN-001 (FR-1): run the build-completion FORECASTER writer
+      # on the SAME hourly cadence, AFTER the gauge snapshot it reads. Without this the cron only ran
+      # vision:gauge, so build_completion_forecast_log never gained a 2nd row — the 'Estimated completion'
+      # ETA stayed frozen and the FR-3 self-correction (needs >=2 rows) never accumulated. Same guard +
+      # continue-on-error as the gauge step so a writer failure can NEVER block the chairman email; the
+      # forecaster is itself fail-soft (records a degraded row rather than throwing).
+      - name: Historize the build-completion forecast (advance the ETA + self-correction)
+        if: steps.guard.outputs.should_send == 'true'
+        continue-on-error: true
+        run: npm run vision:build-forecast
+
       - name: Send chairman exec email (observe-only until ADAM_EMAIL_LIVE repo var = true)
         if: steps.guard.outputs.should_send == 'true'
         run: |

--- a/lib/vision/build-completion-forecast.mjs
+++ b/lib/vision/build-completion-forecast.mjs
@@ -177,6 +177,27 @@ export function formatForecastLine(f, prevF) {
   return `${head} (${f.confidence}${delta})`;
 }
 
+// SD-LEO-INFRA-EXEC-EMAIL-FORECAST-FROZEN-001 (FR-2): pure classifier so the exec-summary renderer can
+// distinguish an ERROR-omitted forecast from a genuine "no forecast yet". Given the build_completion_forecast_log
+// read result ({ error, rows }), return { degraded, hasForecast }:
+//   - a real query error / thrown exception → degraded:true (render an honest degraded marker)
+//   - an UNPROVISIONED/dormant table (relation-does-not-exist / schema-cache) → genuine no-forecast (silent)
+//   - a present-but-empty table → genuine no-forecast (silent)
+//   - >=1 row → hasForecast:true
+// Mirrors the watchdog's tableProvisioned probe so a not-yet-provisioned table never false-alarms.
+const FORECAST_UNPROVISIONED_RE = /relation|does not exist|find the table|schema cache/i;
+export function classifyForecastAvailability({ error, rows } = {}) {
+  if (error) {
+    const msg = (error && (error.message || String(error))) || '';
+    const unprovisioned = FORECAST_UNPROVISIONED_RE.test(msg);
+    return { degraded: !unprovisioned, hasForecast: false };
+  }
+  return { degraded: false, hasForecast: Array.isArray(rows) && !!rows[0] };
+}
+
+// The single-line degraded marker rendered when the forecast was omitted BY ERROR (not genuinely absent).
+export const FORECAST_DEGRADED_MARKER = 'Estimated completion: (forecast unavailable this run)';
+
 // ── helpers ──
 function mk(o) { return o; }
 function clampPct(v) { if (v == null || !Number.isFinite(v)) return null; return Math.max(0, Math.min(100, v)); }

--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -26,7 +26,7 @@ import { computeBuildGauge, formatGaugeForSummary } from '../lib/vision/vdr-regi
 // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-E (FR-4): rung/KR rollup → email, in lockstep
 import { runRollup } from '../lib/vision/rung-progress-rollup.mjs';
 // SD-LEO-INFRA-BUILD-COMPLETION-FORECAST-001 (FR-4): one-line infra-build completion ETA
-import { formatForecastLine } from '../lib/vision/build-completion-forecast.mjs';
+import { formatForecastLine, classifyForecastAvailability, FORECAST_DEGRADED_MARKER } from '../lib/vision/build-completion-forecast.mjs';
 import { formatRungRollupLine } from '../lib/fleet/exec-email-rung-rollup.js';
 // SD-LEO-INFRA-VDR-GREP-SEAM-CROSSREPO-001: the shared code-grep seam so the 5 code_grep probes resolve
 // (the chairman-visible gauge measures all 11 capabilities, not just the 6 DB/KR-backed ones).
@@ -171,15 +171,28 @@ try {
 // the latest persisted forecast run (build_completion_forecast_log), with the delta vs the prior run.
 // Fail-soft: a dormant table / no runs / any error → the line is omitted, NEVER blocks the email.
 let forecastLine = '';
+// SD-LEO-INFRA-EXEC-EMAIL-FORECAST-FROZEN-001 (FR-2): an error-omitted forecast must be DISTINGUISHABLE
+// from a genuine no-forecast. Previously a query error (or throw) and a present-but-empty table both
+// left forecastLine='' and the line silently vanished — so a broken forecast looked identical to "no
+// forecast yet". forecastDegraded marks the error path so the render shows an honest degraded marker.
+// An UNPROVISIONED/dormant table is NOT degraded (it's a genuine "no forecast yet" — stay silent),
+// mirroring the watchdog's tableProvisioned probe below.
+let forecastDegraded = false;
 try {
   const { data: fc, error } = await db.from('build_completion_forecast_log')
     .select('plateau, build_pct, binding_constraint, eta_days, eta_date, confidence, note')
     .order('measured_at', { ascending: false }).limit(2);
-  if (!error && Array.isArray(fc) && fc[0]) {
+  const cls = classifyForecastAvailability({ error, rows: fc }); // pure FR-2 discriminator (error vs genuine-empty)
+  forecastDegraded = cls.degraded;
+  if (cls.hasForecast) {
     const toF = (r) => r && ({ plateau: r.plateau, buildPct: r.build_pct, bindingConstraint: r.binding_constraint, etaDays: r.eta_days, etaDateIso: r.eta_date, confidence: r.confidence, note: r.note });
     forecastLine = formatForecastLine(toF(fc[0]), toF(fc[1]));
   }
-} catch (e) { console.warn('[adam-email] build-completion forecast line skipped (fail-soft): ' + (e?.message || e)); }
+  // else: genuine "no forecast yet" (empty/unprovisioned) → no line, no marker
+} catch (e) {
+  forecastDegraded = true; // a thrown read is an error-omission, not a genuine no-forecast
+  console.warn('[adam-email] build-completion forecast line skipped (fail-soft): ' + (e?.message || e));
+}
 
 // FR-4 (SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001): write a DURABLE 'Adam read the vision gauge'
 // marker so the self-adherence audit can measure the vision-monitoring duty. Best-effort + fail-soft:
@@ -271,11 +284,15 @@ const text = [
   '',
   // FR-3: lead with the fleet-build % (the honest 'built' number); fall back to the rung-% if the
   // segregated number is unavailable; then show V1 rung-completion + operational proofs separately.
-  buildLine || (visPct != null ? `EHG vision: ${visPct}% built` : 'EHG vision: (gauge unavailable)'),
+  // FR-2 (FORECAST-FROZEN): when the gauge produced a number but the build-segmented line is
+  // unavailable, mark the bare fallback so a degraded buildLine is distinguishable from a normal render.
+  buildLine || (visPct != null ? `EHG vision: ${visPct}% built (build-segmented detail unavailable)` : 'EHG vision: (gauge unavailable)'),
   ...(rungNatureLine ? ['   ' + rungNatureLine] : []),
   ...(rungLine ? ['   ' + rungLine] : []),
   ...(rungRollupLine ? ['   ' + rungRollupLine] : []), // FR-4: per-rung completion rollup (Foundation → revenue)
-  ...(forecastLine ? ['   ' + forecastLine] : []), // BUILD-COMPLETION-FORECAST FR-4: infra-build completion ETA
+  // BUILD-COMPLETION-FORECAST FR-4: infra-build completion ETA. FR-2 (FORECAST-FROZEN): on a forecast
+  // ERROR show an explicit degraded marker (not a silent omission); a genuine no-forecast stays silent.
+  ...(forecastLine ? ['   ' + forecastLine] : (forecastDegraded ? ['   ' + FORECAST_DEGRADED_MARKER] : [])),
   ...(operationalLine ? ['   ' + operationalLine] : []),
   ...(layerLine ? ['   ' + layerLine] : []),
   ...(visNote ? ['   ' + visNote] : []),

--- a/tests/unit/forecast-availability.test.js
+++ b/tests/unit/forecast-availability.test.js
@@ -1,0 +1,53 @@
+/**
+ * Forecast availability classifier — SD-LEO-INFRA-EXEC-EMAIL-FORECAST-FROZEN-001 (FR-2).
+ *
+ * The exec-summary email must distinguish an ERROR-omitted build-completion forecast from a genuine
+ * "no forecast yet". Before this, a query error and a present-but-empty table both left the forecast
+ * line silently absent, so a broken forecast looked identical to no forecast. classifyForecastAvailability
+ * is the pure discriminator the renderer keys on. These tests pin the three cases: real error → degraded
+ * (show a marker), unprovisioned/dormant table → genuine no-forecast (silent), rows present → hasForecast.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyForecastAvailability, FORECAST_DEGRADED_MARKER } from '../../lib/vision/build-completion-forecast.mjs';
+
+describe('classifyForecastAvailability (FR-2)', () => {
+  it('flags a real query error as degraded (render a marker, do not silently drop)', () => {
+    const r = classifyForecastAvailability({ error: { message: 'connection reset by peer' }, rows: null });
+    expect(r).toEqual({ degraded: true, hasForecast: false });
+  });
+
+  it('flags a thrown/string error as degraded', () => {
+    const r = classifyForecastAvailability({ error: 'timeout', rows: undefined });
+    expect(r.degraded).toBe(true);
+    expect(r.hasForecast).toBe(false);
+  });
+
+  it('treats an UNPROVISIONED/dormant table as a genuine no-forecast (silent, not degraded)', () => {
+    for (const msg of [
+      'relation "build_completion_forecast_log" does not exist',
+      'Could not find the table in the schema cache',
+    ]) {
+      const r = classifyForecastAvailability({ error: { message: msg }, rows: null });
+      expect(r).toEqual({ degraded: false, hasForecast: false });
+    }
+  });
+
+  it('treats a present-but-empty table as a genuine no-forecast (silent)', () => {
+    expect(classifyForecastAvailability({ error: null, rows: [] })).toEqual({ degraded: false, hasForecast: false });
+  });
+
+  it('reports hasForecast when at least one row is returned', () => {
+    expect(classifyForecastAvailability({ error: null, rows: [{ build_pct: 60 }] })).toEqual({ degraded: false, hasForecast: true });
+  });
+
+  it('is null-safe on missing input', () => {
+    expect(classifyForecastAvailability()).toEqual({ degraded: false, hasForecast: false });
+    expect(classifyForecastAvailability({})).toEqual({ degraded: false, hasForecast: false });
+  });
+
+  it('exposes a single-line degraded marker', () => {
+    expect(typeof FORECAST_DEGRADED_MARKER).toBe('string');
+    expect(FORECAST_DEGRADED_MARKER).not.toContain('\n');
+    expect(FORECAST_DEGRADED_MARKER.toLowerCase()).toContain('unavailable');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes two independent defects in the Adam chairman exec email's build-completion forecast.

**RC1 — frozen ETA (FR-1):** the hourly cron (`adam-exec-email-cron.yml`) historized the vision gauge but never ran the build-completion **forecaster**, so `build_completion_forecast_log` never gained a 2nd row — the "Estimated completion" ETA stayed frozen and the FR-3 self-correction (needs ≥2 rows) never accumulated. Adds a fail-soft `Historize the build-completion forecast` step (`npm run vision:build-forecast`) **after** the gauge snapshot it reads, same once-per-hour guard, `continue-on-error: true`.

**RC2 — silent drop (FR-2):** `forecastLine` + the bare `buildLine` fallback failed soft to empty with **no marker**, so an error-omitted forecast was indistinguishable from a genuine no-forecast. Adds a pure `classifyForecastAvailability` discriminator (real error → degraded marker; unprovisioned/empty table → genuine no-forecast, silent) and a build-segmented degraded marker.

## Tests
- 7 new unit tests pin the classifier's three cases (error / unprovisioned-or-empty / rows-present).
- `node --check` passes for both edited files; smoke suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
