### PR TITLE
feat(SD-LEO-INFRA-CLAIM-TTL-EXEC-HEARTBEAT-001): time-based claim heartbeat on tool activity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -107,6 +107,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/post-tool-clear-telemetry.cjs",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/claim-heartbeat-on-tool.cjs",
+            "timeout": 5
           }
         ]
       },

--- a/lib/claim/heartbeat-throttle.cjs
+++ b/lib/claim/heartbeat-throttle.cjs
@@ -1,0 +1,36 @@
+/**
+ * Claim-heartbeat throttle — SD-LEO-INFRA-CLAIM-TTL-EXEC-HEARTBEAT-001.
+ *
+ * The shipped SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 refreshes a worker's claim heartbeat ONLY
+ * when a sub-agent writes evidence. A long EXEC build that makes NO DB write in the window (a big code
+ * build / Explore with no sub-agent calls) still ages past the 900s claim TTL and gets reaped + stolen.
+ * This adds a TIME-based heartbeat: a PostToolUse hook refreshes the claim on tool activity, THROTTLED
+ * by this pure decision so we touch the DB at most once per window (not on every keystroke-level call).
+ *
+ * CommonJS (.cjs) so the .cjs PostToolUse hook can require it under the repo's package.json type=module.
+ * @module lib/claim/heartbeat-throttle
+ */
+
+/** Default: refresh at most once per 120s — comfortably inside the 900s TTL even across slow tool gaps. */
+const DEFAULT_THROTTLE_MS = 120_000;
+
+/**
+ * Decide whether to refresh the claim heartbeat now. PURE.
+ * Refresh when we've never touched (lastTouchMs null/undefined/non-finite) or the last touch is at least
+ * throttleMs old. A future/garbage lastTouchMs (clock skew) refreshes too — failing toward keeping the
+ * claim alive is the SAFE direction (an extra write costs nothing; a missed heartbeat costs a reap+steal).
+ *
+ * @param {number|null|undefined} lastTouchMs - epoch ms of the last heartbeat write (null if never)
+ * @param {number} nowMs - current epoch ms
+ * @param {number} [throttleMs=DEFAULT_THROTTLE_MS]
+ * @returns {boolean}
+ */
+function shouldRefreshHeartbeat(lastTouchMs, nowMs, throttleMs = DEFAULT_THROTTLE_MS) {
+  if (lastTouchMs == null || !Number.isFinite(lastTouchMs)) return true; // never touched -> refresh
+  const elapsed = nowMs - lastTouchMs;
+  if (!Number.isFinite(elapsed)) return true;
+  if (elapsed < 0) return true;            // clock skew / future stamp -> safe direction = refresh
+  return elapsed >= throttleMs;
+}
+
+module.exports = { shouldRefreshHeartbeat, DEFAULT_THROTTLE_MS };

--- a/scripts/hooks/claim-heartbeat-on-tool.cjs
+++ b/scripts/hooks/claim-heartbeat-on-tool.cjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse hook — TIME-based claim heartbeat (SD-LEO-INFRA-CLAIM-TTL-EXEC-HEARTBEAT-001).
+ *
+ * The shipped on-evidence-write heartbeat (CLAIM-TTL-LONG-SUBAGENT-TICK-001) refreshes a claim ONLY when
+ * a sub-agent writes evidence. A long EXEC build that makes NO DB write in the window (a big code build /
+ * Explore with no sub-agent calls) still ages past the 900s claim TTL and gets REAPED + STOLEN (Alpha
+ * lost SOURCING-ENGINE-PROACTIVE-POPULATOR to Echo exactly this way). This closes the residual gap: ANY
+ * tool call (Bash/Edit/Write/Read/...) during a build refreshes the claim, THROTTLED to at most once per
+ * window so we don't write on every call.
+ *
+ * Hook contract (mirrors post-tool-loop-state.cjs):
+ *   - Resolve the session id payload-first (stdin), env + identity-marker fallbacks.
+ *   - CLAIM-GUARDED write: update heartbeat_at WHERE session_id=X AND sd_key IS NOT NULL — a non-claiming
+ *     (idle/released) session is a no-op, so we never resurrect a released claim.
+ *   - Throttled by lib/claim/heartbeat-throttle.cjs via a per-session tmp marker (cheap skip path: no DB
+ *     read/write on throttled calls).
+ *   - ALWAYS exit 0, fully best-effort — a heartbeat hook must NEVER block or fail a tool call.
+ *   - Disable with LEO_CLAIM_HEARTBEAT_ON_TOOL=off; tune with LEO_CLAIM_HB_THROTTLE_MS.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+const { shouldRefreshHeartbeat, DEFAULT_THROTTLE_MS } = require('../../lib/claim/heartbeat-throttle.cjs');
+
+function isOff(v) {
+  const f = String(v == null ? 'on' : v).toLowerCase();
+  return f === 'off' || f === '0' || f === 'false';
+}
+
+/**
+ * Minimal claim-guarded heartbeat PATCH via raw https (agent:false → no keep-alive socket left open,
+ * so the hook exits cleanly — the heavy supabase-js client leaves async handles that trip the Windows
+ * libuv UV_HANDLE_CLOSING assertion on a fire-every-tool hook). Resolves { ok } and NEVER rejects.
+ * The ?sd_key=not.is.null filter makes a non-claiming (released/idle) session a no-op.
+ */
+function patchHeartbeat(baseUrl, key, sessionId, isoNow) {
+  return new Promise((resolve) => {
+    try {
+      const u = new URL(`${baseUrl.replace(/\/$/, '')}/rest/v1/claude_sessions`);
+      u.searchParams.set('session_id', `eq.${sessionId}`);
+      u.searchParams.set('sd_key', 'not.is.null');
+      const body = JSON.stringify({ heartbeat_at: isoNow });
+      const req = https.request(u, {
+        method: 'PATCH',
+        agent: false, // no connection pooling -> socket closes -> clean process exit
+        headers: {
+          apikey: key,
+          Authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      }, (res) => {
+        res.resume(); // drain
+        res.on('end', () => resolve({ ok: res.statusCode >= 200 && res.statusCode < 300 }));
+      });
+      req.on('error', () => resolve({ ok: false }));
+      req.setTimeout(3000, () => { try { req.destroy(); } catch { /* noop */ } resolve({ ok: false }); });
+      req.end(body);
+    } catch { resolve({ ok: false }); }
+  });
+}
+
+(async () => {
+  try {
+    if (isOff(process.env.LEO_CLAIM_HEARTBEAT_ON_TOOL)) return;
+
+    const sidLib = require('../../lib/hooks/session-id.cjs');
+    const payload = await sidLib.readHookStdinPayload();
+    let sessionId = payload && sidLib.isValidSessionId(payload.session_id) ? payload.session_id : '';
+    if (!sessionId && sidLib.isValidSessionId(process.env.CLAUDE_SESSION_ID)) sessionId = process.env.CLAUDE_SESSION_ID;
+    if (!sessionId && sidLib.isValidSessionId(process.env.SESSION_ID)) sessionId = process.env.SESSION_ID;
+    if (!sessionId) {
+      const m = sidLib.readSessionIdFromIdentityMarker({}) || sidLib.readLatestMarkerByMtime();
+      if (sidLib.isValidSessionId(m)) sessionId = m;
+    }
+    if (!sessionId) return;
+
+    const throttleMs = Number(process.env.LEO_CLAIM_HB_THROTTLE_MS) > 0
+      ? Number(process.env.LEO_CLAIM_HB_THROTTLE_MS) : DEFAULT_THROTTLE_MS;
+
+    // Per-session throttle marker (cheap skip path — most tool calls never reach the DB).
+    const stateFile = path.join(os.tmpdir(), `leo-claim-hb-${sessionId}.ts`);
+    let last = null;
+    try { const n = parseInt(fs.readFileSync(stateFile, 'utf8'), 10); if (Number.isFinite(n)) last = n; } catch { /* never touched */ }
+    const now = Date.now();
+    if (!shouldRefreshHeartbeat(last, now, throttleMs)) return;
+
+    // CLAIM-GUARDED refresh via raw https (the SessionStart hooks inject SUPABASE_URL + the service key
+    // into the env). The ?sd_key=not.is.null filter makes a non-claiming/released session a no-op, so we
+    // never resurrect a released claim.
+    let baseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    let key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+    if (!baseUrl || !key) {
+      // Self-load .env (best-effort) so the hook works whether or not the harness pre-injected env.
+      try { require('dotenv').config({ override: false, quiet: true }); } catch { /* dotenv optional */ }
+      baseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+      key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+    }
+    if (!baseUrl || !key) return; // still missing -> fail-open
+    const { ok } = await patchHeartbeat(baseUrl, key, sessionId, new Date(now).toISOString());
+    if (ok) { try { fs.writeFileSync(stateFile, String(now)); } catch { /* throttle marker best-effort */ } }
+  } catch { /* fail-open: a heartbeat hook must NEVER block a tool call */ }
+  process.exit(0);
+})();

--- a/scripts/hooks/claim-heartbeat-on-tool.cjs
+++ b/scripts/hooks/claim-heartbeat-on-tool.cjs
@@ -67,16 +67,21 @@ function patchHeartbeat(baseUrl, key, sessionId, isoNow) {
   try {
     if (isOff(process.env.LEO_CLAIM_HEARTBEAT_ON_TOOL)) return;
 
+    // SELF-ATTRIBUTED session id ONLY. A claim-refreshing write MUST target THIS process's own session.
+    // We deliberately do NOT fall back to the identity-marker / latest-marker-by-mtime resolvers other
+    // hooks use: on a multi-session host the mtime fallback returns whichever session most recently wrote
+    // a marker — possibly a DIFFERENT (even dead-but-claimed) session — and refreshing its heartbeat would
+    // KEEP A ZOMBIE CLAIM ALIVE and block reassignment (the exact failure the TTL exists to prevent;
+    // adversarial review HIGH). A missed heartbeat self-corrects on the next tool call that carries a good
+    // stdin session_id; a wrong-session heartbeat does not. Trusted sources only: stdin payload (CC ties it
+    // to THIS invocation) + this process's own env. (Dropping the marker chain also avoids the slow
+    // findClaudeCodeCcPid execSync on the hot path.)
     const sidLib = require('../../lib/hooks/session-id.cjs');
     const payload = await sidLib.readHookStdinPayload();
     let sessionId = payload && sidLib.isValidSessionId(payload.session_id) ? payload.session_id : '';
     if (!sessionId && sidLib.isValidSessionId(process.env.CLAUDE_SESSION_ID)) sessionId = process.env.CLAUDE_SESSION_ID;
     if (!sessionId && sidLib.isValidSessionId(process.env.SESSION_ID)) sessionId = process.env.SESSION_ID;
-    if (!sessionId) {
-      const m = sidLib.readSessionIdFromIdentityMarker({}) || sidLib.readLatestMarkerByMtime();
-      if (sidLib.isValidSessionId(m)) sessionId = m;
-    }
-    if (!sessionId) return;
+    if (!sessionId) return; // no self-attributed id -> skip (self-corrects next tool call)
 
     const throttleMs = Number(process.env.LEO_CLAIM_HB_THROTTLE_MS) > 0
       ? Number(process.env.LEO_CLAIM_HB_THROTTLE_MS) : DEFAULT_THROTTLE_MS;

--- a/tests/unit/claim-heartbeat-throttle.test.js
+++ b/tests/unit/claim-heartbeat-throttle.test.js
@@ -1,0 +1,45 @@
+// SD-LEO-INFRA-CLAIM-TTL-EXEC-HEARTBEAT-001 — pure throttle decision for the time-based claim heartbeat.
+// shouldRefreshHeartbeat gates how often the PostToolUse hook touches claude_sessions.heartbeat_at:
+// refresh when never-touched or aged >= throttle, and ALWAYS fail toward refreshing (the safe direction —
+// a missed refresh costs a reap+steal; an extra write costs nothing).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { shouldRefreshHeartbeat, DEFAULT_THROTTLE_MS } = require('../../lib/claim/heartbeat-throttle.cjs');
+
+describe('shouldRefreshHeartbeat', () => {
+  const T = 120_000;
+
+  it('refreshes when never touched (null/undefined/NaN)', () => {
+    expect(shouldRefreshHeartbeat(null, 1_000_000, T)).toBe(true);
+    expect(shouldRefreshHeartbeat(undefined, 1_000_000, T)).toBe(true);
+    expect(shouldRefreshHeartbeat(NaN, 1_000_000, T)).toBe(true);
+  });
+
+  it('does NOT refresh inside the throttle window', () => {
+    const now = 1_000_000;
+    expect(shouldRefreshHeartbeat(now - 1, now, T)).toBe(false);           // 1ms ago
+    expect(shouldRefreshHeartbeat(now - (T - 1), now, T)).toBe(false);     // just under the window
+  });
+
+  it('refreshes at and beyond the throttle boundary (>=)', () => {
+    const now = 1_000_000;
+    expect(shouldRefreshHeartbeat(now - T, now, T)).toBe(true);            // exactly at the window
+    expect(shouldRefreshHeartbeat(now - (T + 5_000), now, T)).toBe(true);  // well aged
+  });
+
+  it('refreshes on clock skew / future stamp (safe direction)', () => {
+    const now = 1_000_000;
+    expect(shouldRefreshHeartbeat(now + 50_000, now, T)).toBe(true);       // last touch in the future
+  });
+
+  it('respects a custom throttleMs and exposes a sane default', () => {
+    const now = 1_000_000;
+    expect(shouldRefreshHeartbeat(now - 30_000, now, 20_000)).toBe(true);  // aged past a tighter window
+    expect(shouldRefreshHeartbeat(now - 10_000, now, 20_000)).toBe(false); // inside a tighter window
+    expect(DEFAULT_THROTTLE_MS).toBe(120_000);
+    // default is comfortably inside the 900s claim TTL
+    expect(DEFAULT_THROTTLE_MS).toBeLessThan(900_000);
+  });
+});


### PR DESCRIPTION
## Time-based claim heartbeat on tool activity

**Closes the residual claim-TTL gap.** The shipped on-evidence-write heartbeat (`CLAIM-TTL-LONG-SUBAGENT-TICK-001`) refreshes a claim **only** when a sub-agent writes evidence. A long EXEC build (>15 min) with no DB write in the window still ages past the 900s TTL and gets **reaped + stolen** (Alpha lost `SOURCING-ENGINE-PROACTIVE-POPULATOR` to Echo exactly this way; hit again on `ACTIVATION` during a long Explore this session).

**FR-1:** a no-matcher PostToolUse hook (`scripts/hooks/claim-heartbeat-on-tool.cjs`) refreshes `claude_sessions.heartbeat_at` on **any** tool call, so any build/Explore activity keeps the claim alive across no-DB-write windows. Registered in `.claude/settings.json`.

**FR-2:** throttled to once/120s (pure `lib/claim/heartbeat-throttle.cjs` + a per-session tmp marker; cheap skip path, no DB on throttled calls). **Claim-guarded** (`?session_id=eq.X&sd_key=not.is.null`) so a released/idle session is a no-op. Fully **fail-open**, env-disableable (`LEO_CLAIM_HEARTBEAT_ON_TOOL=off`, `LEO_CLAIM_HB_THROTTLE_MS`).

**FR-3:** raw `https` PATCH (`agent:false`) instead of the heavy `supabase-js` client, so the fire-every-tool hook **exits cleanly on Windows** instead of tripping the libuv `UV_HANDLE_CLOSING` assertion. 5 unit tests; live-verified (5-min-stale → now, exit 0 no assertion, throttled no-op).

### Safety
- **Adversarial HIGH fixed:** session id is resolved from **self-attributed sources only** (stdin `payload.session_id` + this process's env). The marker/mtime fallbacks were dropped — on a multi-session host they could resolve to a *different (even dead-but-claimed)* session and keep a zombie claim alive. A missed heartbeat self-corrects; a wrong-session one doesn't. (Also removes a slow `execSync` from the hot path.)
- PLAN DB review **PASS (92)** (claim-guard verified against the real release/reap code — no resurrection, no TOCTOU). Testing **PASS (92)**. Retro 90.
- No schema change; additive; complements (doesn't replace) the on-evidence-write heartbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
