### PR TITLE
feat(SD-LEO-INFRA-MEMORY-MD-WRITE-CONTENTION-001): atomic, lock-guarded MEMORY.md reindex writes

### DIFF
--- a/lib/memory/atomic-write.mjs
+++ b/lib/memory/atomic-write.mjs
@@ -1,0 +1,125 @@
+/**
+ * Contention-safe primitives for the shared MEMORY.md auto-memory index
+ * (SD-LEO-INFRA-MEMORY-MD-WRITE-CONTENTION-001).
+ *
+ * Parallel fleet sessions regenerate the same MEMORY.md via memory/reindex.mjs.
+ * Two problems with a plain writeFileSync of a shared file:
+ *   1. It is not atomic — a concurrent reader can observe a torn/partial file,
+ *      and two writers can interleave.
+ *   2. Read-modify-write (or stale-snapshot regenerate) races can drop a line
+ *      (lost update).
+ *
+ * This module provides:
+ *   - atomicWriteFileSync: write to a unique temp file in the SAME directory,
+ *     then renameSync over the target. rename(2)/ReplaceFile is atomic, so a
+ *     reader always sees either the old or the new COMPLETE file — never a tear.
+ *   - withMemoryIndexLock: an atomic mkdir-based advisory lock with bounded
+ *     retry + stale-lock breaking, so concurrent regenerators serialize and a
+ *     crashed session cannot deadlock the index. Fails OPEN (proceeds) after the
+ *     retry budget — atomicWriteFileSync still prevents a torn file.
+ *
+ * Node built-ins only (fs/path/os) — no new runtime dependency, cross-platform.
+ */
+import { writeFileSync, renameSync, rmSync, mkdirSync, statSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+
+let _tmpCounter = 0;
+
+/**
+ * Atomically write `content` to `filePath` via temp-file + rename.
+ * The temp file lives in the same directory so the rename stays on one
+ * filesystem (a cross-device rename would fall back to a non-atomic copy).
+ * On any failure the temp file is best-effort removed and the error rethrown.
+ *
+ * @param {string} filePath
+ * @param {string} content
+ * @param {object} [opts]
+ * @param {string} [opts.encoding='utf8']
+ */
+export function atomicWriteFileSync(filePath, content, opts = {}) {
+  const encoding = opts.encoding || 'utf8';
+  const dir = dirname(filePath);
+  const unique = `${process.pid}.${Date.now()}.${++_tmpCounter}`;
+  const tmpPath = join(dir, `.${basename(filePath)}.${unique}.tmp`);
+  try {
+    writeFileSync(tmpPath, content, encoding);
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { rmSync(tmpPath, { force: true }); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+}
+
+/**
+ * Run `fn` while holding an atomic mkdir-based lock for the memory index.
+ *
+ * mkdir is atomic across platforms: exactly one caller can create the lock dir;
+ * others get EEXIST and retry. A lock older than `staleMs` is assumed orphaned
+ * (crashed session) and broken. After `retries` exhausted attempts the lock is
+ * NOT acquired and we proceed anyway (fail-open) — combined with
+ * atomicWriteFileSync this still cannot corrupt the file, it only loosens
+ * serialization under pathological contention.
+ *
+ * @param {string} dir            Memory directory (lock lives at <dir>/.memory-index.lock)
+ * @param {() => T} fn            Critical section
+ * @param {object} [opts]
+ * @param {number} [opts.retries=20]
+ * @param {number} [opts.backoffMs=25]
+ * @param {number} [opts.staleMs=30000]
+ * @param {() => number} [opts.now=Date.now]   Injectable clock (tests)
+ * @param {(ms:number)=>void} [opts.sleep]     Injectable sleep (tests); default busy-wait
+ * @returns {{ acquired: boolean, result: T }}
+ * @template T
+ */
+export function withMemoryIndexLock(dir, fn, opts = {}) {
+  const retries = opts.retries ?? 20;
+  const backoffMs = opts.backoffMs ?? 25;
+  const staleMs = opts.staleMs ?? 30000;
+  const now = opts.now || Date.now;
+  const sleep = opts.sleep || defaultSleep;
+  const lockPath = join(dir, '.memory-index.lock');
+
+  let acquired = false;
+  for (let attempt = 0; attempt <= retries && !acquired; attempt++) {
+    try {
+      mkdirSync(lockPath); // atomic: throws EEXIST if held
+      acquired = true;
+      break;
+    } catch (err) {
+      if (err && err.code !== 'EEXIST') throw err; // unexpected fs error — surface it
+      // Lock held — break it if stale, else back off and retry.
+      if (isLockStale(lockPath, staleMs, now)) {
+        try { rmSync(lockPath, { recursive: true, force: true }); } catch { /* race: someone else broke it */ }
+        continue; // retry immediately after breaking a stale lock
+      }
+      if (attempt < retries) sleep(backoffMs);
+    }
+  }
+
+  try {
+    return { acquired, result: fn() };
+  } finally {
+    if (acquired) {
+      try { rmSync(lockPath, { recursive: true, force: true }); } catch { /* best-effort release */ }
+    }
+  }
+}
+
+/**
+ * @returns {boolean} true if the lock dir exists and is older than staleMs.
+ */
+function isLockStale(lockPath, staleMs, now) {
+  try {
+    const st = statSync(lockPath);
+    return (now() - st.mtimeMs) > staleMs;
+  } catch {
+    // Vanished between EEXIST and stat — treat as not-stale; next mkdir will win.
+    return false;
+  }
+}
+
+/** Synchronous, dependency-free backoff (the critical section is tiny). */
+function defaultSleep(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin briefly */ }
+}

--- a/lib/memory/atomic-write.mjs
+++ b/lib/memory/atomic-write.mjs
@@ -43,10 +43,34 @@ export function atomicWriteFileSync(filePath, content, opts = {}) {
   const tmpPath = join(dir, `.${basename(filePath)}.${unique}.tmp`);
   try {
     writeFileSync(tmpPath, content, encoding);
-    renameSync(tmpPath, filePath);
+    renameWithRetry(tmpPath, filePath, opts);
   } catch (err) {
     try { rmSync(tmpPath, { force: true }); } catch { /* best-effort cleanup */ }
     throw err;
+  }
+}
+
+// Windows note: renameSync over an EXISTING target is not a POSIX-style atomic
+// replace — under concurrency it can transiently throw EPERM/EACCES/EBUSY (a
+// sharing violation while another process has the target open). The file is
+// never torn (rename is still all-or-nothing), but the CALL would crash. Retry
+// a bounded number of times with short backoff before rethrowing so the
+// fail-open reindex path (lock budget exhausted) degrades gracefully instead of
+// throwing. POSIX renames don't hit this and pass on the first try.
+const _RENAME_TRANSIENT = new Set(['EPERM', 'EACCES', 'EBUSY']);
+function renameWithRetry(from, to, opts = {}) {
+  const retries = opts.renameRetries ?? 10;
+  const backoffMs = opts.renameBackoffMs ?? 10;
+  const sleep = opts.sleep || defaultSleep;
+  const rename = opts._rename || renameSync; // injectable for tests
+  for (let attempt = 0; ; attempt++) {
+    try {
+      rename(from, to);
+      return;
+    } catch (err) {
+      if (attempt >= retries || !err || !_RENAME_TRANSIENT.has(err.code)) throw err;
+      sleep(backoffMs);
+    }
   }
 }
 

--- a/scripts/modules/memory/reindex.mjs
+++ b/scripts/modules/memory/reindex.mjs
@@ -57,10 +57,15 @@ export function reindex({ memoryDir, dryRun = false, stderr = process.stderr } =
     .sort();
 
   const entries = [];
+  let parseFailures = 0;
   for (const filename of files) {
     try {
       entries.push({ filename, parsed: parseMemoryFrontmatter(join(dir, filename)) });
     } catch (err) {
+      // A read/parse THROW (file vanished mid-loop, EISDIR, permission) means we
+      // cannot trust this snapshot's completeness — track it for the lost-update
+      // guard so a transient error can't silently shrink the index.
+      parseFailures++;
       stderr.write(`[memory/reindex] WARN: skipping ${filename}: ${err.message}\n`);
     }
   }
@@ -100,6 +105,17 @@ export function reindex({ memoryDir, dryRun = false, stderr = process.stderr } =
     stderr.write(`[memory/reindex] GUARD: refusing to overwrite a populated MEMORY.md with an empty index (lost-update guard)\n`);
     return { ok: false, reason: 'lost_update_guard', dryRun: false, lineCount: 0, fileCount: files.length };
   }
+  // FR-3 (partial): if SOME pointer files failed to read this run AND the result
+  // would SHRINK an existing index, the snapshot is untrustworthy — refuse and
+  // self-heal on the next clean run. A shrink with NO read errors is a legitimate
+  // removal and is allowed through.
+  if (parseFailures > 0) {
+    const existingCount = indexFileLineCount(join(dir, INDEX_FILENAME));
+    if (existingCount > indexLines.length) {
+      stderr.write(`[memory/reindex] GUARD: ${parseFailures} pointer file(s) failed to read and the index would shrink ${existingCount}->${indexLines.length}; refusing to drop lines (partial lost-update guard)\n`);
+      return { ok: false, reason: 'partial_lost_update_guard', dryRun: false, lineCount: indexLines.length, existingCount, parseFailures };
+    }
+  }
 
   // FR-1/FR-2: serialize concurrent regenerators with an atomic lock, and write
   // every file atomically (temp + rename) so a concurrent reader/writer never
@@ -124,6 +140,16 @@ function indexFileNonEmpty(indexPath) {
     return readFileSync(indexPath, 'utf8').trim().length > 0;
   } catch {
     return false;
+  }
+}
+
+/** @returns {number} count of non-empty lines in the existing index (0 if absent/unreadable). */
+function indexFileLineCount(indexPath) {
+  try {
+    if (!existsSync(indexPath)) return 0;
+    return readFileSync(indexPath, 'utf8').split('\n').filter(l => l.trim().length > 0).length;
+  } catch {
+    return 0;
   }
 }
 

--- a/scripts/modules/memory/reindex.mjs
+++ b/scripts/modules/memory/reindex.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import process from 'node:process';
 import { parseMemoryFrontmatter } from './frontmatter.js';
 import { clusterByPrefix, buildTopicFilename, buildTopicContent } from './clustering.mjs';
+import { atomicWriteFileSync, withMemoryIndexLock } from '../../../lib/memory/atomic-write.mjs';
 
 const INDEX_FILENAME = 'MEMORY.md';
 const TOPIC_PREFIX = 'topic_';
@@ -86,13 +87,44 @@ export function reindex({ memoryDir, dryRun = false, stderr = process.stderr } =
     return { ok: !overBudget, dryRun: true, indexBytes, lineCount: indexLines.length, topicCount: topics.length, overBudget };
   }
 
-  for (const t of topics) {
-    const path = join(dir, buildTopicFilename(t.prefix));
-    writeFileSync(path, buildTopicContent(t.prefix, t.members), 'utf8');
+  // FR-3 lost-update guard: never replace a populated index with a degenerate
+  // (zero-line) one produced by a transient readdir/parse error. If we computed
+  // zero entries but pointer files exist on disk OR a non-empty index already
+  // exists, refuse the write and fail safe — a real wipe only happens when the
+  // memory dir is genuinely empty (no eligible pointer files).
+  if (indexLines.length === 0 && files.length > 0) {
+    stderr.write(`[memory/reindex] GUARD: refusing to overwrite the index with 0 entries while ${files.length} pointer file(s) exist (lost-update guard)\n`);
+    return { ok: false, reason: 'lost_update_guard', dryRun: false, lineCount: 0, fileCount: files.length };
   }
-  writeFileSync(join(dir, INDEX_FILENAME), indexOutput, 'utf8');
+  if (indexLines.length === 0 && indexFileNonEmpty(join(dir, INDEX_FILENAME))) {
+    stderr.write(`[memory/reindex] GUARD: refusing to overwrite a populated MEMORY.md with an empty index (lost-update guard)\n`);
+    return { ok: false, reason: 'lost_update_guard', dryRun: false, lineCount: 0, fileCount: files.length };
+  }
 
-  return { ok: !overBudget, dryRun: false, indexBytes, lineCount: indexLines.length, topicCount: topics.length, overBudget };
+  // FR-1/FR-2: serialize concurrent regenerators with an atomic lock, and write
+  // every file atomically (temp + rename) so a concurrent reader/writer never
+  // observes a torn or partially-written index. Lock fails open after its retry
+  // budget; the atomic writes still guarantee tear-free output.
+  const { acquired } = withMemoryIndexLock(dir, () => {
+    for (const t of topics) {
+      const path = join(dir, buildTopicFilename(t.prefix));
+      atomicWriteFileSync(path, buildTopicContent(t.prefix, t.members), { encoding: 'utf8' });
+    }
+    atomicWriteFileSync(join(dir, INDEX_FILENAME), indexOutput, { encoding: 'utf8' });
+  });
+
+  return { ok: !overBudget, dryRun: false, indexBytes, lineCount: indexLines.length, topicCount: topics.length, overBudget, lockAcquired: acquired };
+}
+
+/** @returns {boolean} true if the index file exists and has non-whitespace content. */
+function indexFileNonEmpty(indexPath) {
+  try {
+    if (!existsSync(indexPath)) return false;
+    if (statSync(indexPath).size === 0) return false;
+    return readFileSync(indexPath, 'utf8').trim().length > 0;
+  } catch {
+    return false;
+  }
 }
 
 const isMain = import.meta.url === `file://${process.argv[1]}` ||

--- a/tests/unit/memory-atomic-write.test.js
+++ b/tests/unit/memory-atomic-write.test.js
@@ -3,7 +3,7 @@
  * Tests the atomic-write + index-lock primitives and the reindex lost-update guard.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync, mkdirSync, renameSync as renameSyncReal } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { atomicWriteFileSync, withMemoryIndexLock } from '../../lib/memory/atomic-write.mjs';
@@ -31,6 +31,25 @@ describe('atomicWriteFileSync', () => {
     atomicWriteFileSync(target, 'v1');
     atomicWriteFileSync(target, 'v2-longer-content');
     expect(readFileSync(target, 'utf8')).toBe('v2-longer-content');
+  });
+
+  it('retries a transient EPERM rename (Windows sharing violation) then succeeds', () => {
+    const target = join(dir, 'MEMORY.md');
+    let calls = 0;
+    const flakyRename = (from, to) => {
+      calls++;
+      if (calls < 3) { const e = new Error('EPERM'); e.code = 'EPERM'; throw e; }
+      renameSyncReal(from, to);
+    };
+    atomicWriteFileSync(target, 'after-retry', { _rename: flakyRename, renameBackoffMs: 0, sleep: () => {} });
+    expect(calls).toBe(3);
+    expect(readFileSync(target, 'utf8')).toBe('after-retry');
+  });
+
+  it('rethrows a non-transient rename error immediately', () => {
+    const target = join(dir, 'MEMORY.md');
+    const enoent = (from, to) => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; };
+    expect(() => atomicWriteFileSync(target, 'x', { _rename: enoent, sleep: () => {} })).toThrow('ENOENT');
   });
 });
 
@@ -90,6 +109,29 @@ describe('reindex lost-update guard + atomic output', () => {
     expect(r.reason).toBe('lost_update_guard');
     // populated index left intact
     expect(readFileSync(join(dir, 'MEMORY.md'), 'utf8')).toContain('existing');
+  });
+
+  it('refuses to SHRINK a populated index when some pointer files fail to read (partial lost-update)', () => {
+    // 3 pointer "files": 2 are directories named *.md → readFileSync throws (EISDIR/EPERM)
+    // → parseFailures>0; 1 valid. Existing index has 3 lines; result would shrink to 1.
+    writeFileSync(join(dir, 'MEMORY.md'), '- [a](project_a.md)\n- [b](project_b.md)\n- [c](project_c.md)\n');
+    writeFileSync(join(dir, 'project_a.md'), pointerFile('mem-a', 'first'));
+    mkdirSync(join(dir, 'project_b.md')); // a directory → read throws
+    mkdirSync(join(dir, 'project_c.md')); // a directory → read throws
+    const r = reindex({ memoryDir: dir, stderr: { write() {} } });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('partial_lost_update_guard');
+    expect(r.parseFailures).toBeGreaterThan(0);
+    // existing 3-line index left intact (no lines dropped)
+    expect(readFileSync(join(dir, 'MEMORY.md'), 'utf8').split('\n').filter(Boolean).length).toBe(3);
+  });
+
+  it('allows a legitimate shrink (fewer files, NO read errors)', () => {
+    writeFileSync(join(dir, 'MEMORY.md'), '- [a](project_a.md)\n- [b](project_b.md)\n');
+    writeFileSync(join(dir, 'project_a.md'), pointerFile('mem-a', 'only one left'));
+    const r = reindex({ memoryDir: dir });
+    expect(r.ok).toBe(true);
+    expect(r.lineCount).toBe(1); // legitimately removed project_b
   });
 
   it('allows writing an empty index for a genuinely empty memory dir', () => {

--- a/tests/unit/memory-atomic-write.test.js
+++ b/tests/unit/memory-atomic-write.test.js
@@ -1,0 +1,114 @@
+/**
+ * SD-LEO-INFRA-MEMORY-MD-WRITE-CONTENTION-001 — contention-safe MEMORY.md writes.
+ * Tests the atomic-write + index-lock primitives and the reindex lost-update guard.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { atomicWriteFileSync, withMemoryIndexLock } from '../../lib/memory/atomic-write.mjs';
+import { reindex } from '../../scripts/modules/memory/reindex.mjs';
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'memwrite-')); });
+afterEach(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+function pointerFile(name, desc) {
+  return `---\nname: ${name}\ndescription: ${desc}\nmetadata:\n  type: project\n---\n\nbody\n`;
+}
+
+describe('atomicWriteFileSync', () => {
+  it('writes the complete file and leaves no temp file behind', () => {
+    const target = join(dir, 'MEMORY.md');
+    atomicWriteFileSync(target, 'hello world\n');
+    expect(readFileSync(target, 'utf8')).toBe('hello world\n');
+    const leftovers = readdirSync(dir).filter(f => f.includes('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('overwrites an existing file atomically (no torn intermediate)', () => {
+    const target = join(dir, 'MEMORY.md');
+    atomicWriteFileSync(target, 'v1');
+    atomicWriteFileSync(target, 'v2-longer-content');
+    expect(readFileSync(target, 'utf8')).toBe('v2-longer-content');
+  });
+});
+
+describe('withMemoryIndexLock', () => {
+  it('acquires when free and runs the critical section', () => {
+    const r = withMemoryIndexLock(dir, () => 42, { retries: 1 });
+    expect(r).toEqual({ acquired: true, result: 42 });
+    // lock released
+    expect(existsSync(join(dir, '.memory-index.lock'))).toBe(false);
+  });
+
+  it('releases the lock even when fn throws', () => {
+    expect(() => withMemoryIndexLock(dir, () => { throw new Error('boom'); }, { retries: 1 })).toThrow('boom');
+    expect(existsSync(join(dir, '.memory-index.lock'))).toBe(false);
+  });
+
+  it('fails open (acquired=false) when the lock is held and not stale', () => {
+    mkdirSync(join(dir, '.memory-index.lock')); // pre-held, fresh
+    let ran = false;
+    const r = withMemoryIndexLock(dir, () => { ran = true; return 'ok'; }, { retries: 2, backoffMs: 1, staleMs: 999999, sleep: () => {} });
+    expect(r.acquired).toBe(false);
+    expect(ran).toBe(true); // still runs the critical section (atomic write keeps it safe)
+    // pre-existing foreign lock NOT removed by us (we never acquired it)
+    expect(existsSync(join(dir, '.memory-index.lock'))).toBe(true);
+  });
+
+  it('breaks a stale lock and acquires', () => {
+    mkdirSync(join(dir, '.memory-index.lock'));
+    // now() far in the future => existing lock looks stale
+    const future = Date.now() + 10 * 60 * 1000;
+    const r = withMemoryIndexLock(dir, () => 'done', { retries: 3, backoffMs: 1, staleMs: 1000, now: () => future, sleep: () => {} });
+    expect(r.acquired).toBe(true);
+    expect(r.result).toBe('done');
+    expect(existsSync(join(dir, '.memory-index.lock'))).toBe(false);
+  });
+});
+
+describe('reindex lost-update guard + atomic output', () => {
+  it('regenerates the index from pointer files (every entry present)', () => {
+    writeFileSync(join(dir, 'project_a.md'), pointerFile('mem-a', 'first memory'));
+    writeFileSync(join(dir, 'project_b.md'), pointerFile('mem-b', 'second memory'));
+    const r = reindex({ memoryDir: dir });
+    expect(r.ok).toBe(true);
+    const idx = readFileSync(join(dir, 'MEMORY.md'), 'utf8');
+    expect(idx).toContain('mem-a');
+    expect(idx).toContain('mem-b');
+    expect(r.lockAcquired).toBe(true);
+  });
+
+  it('refuses to overwrite a populated index when zero entries would result (pointer files transiently gone)', () => {
+    // Populated index but the memory dir currently has NO pointer files (e.g. a
+    // transient readdir miss / files momentarily absent). Reindex would produce
+    // an empty index — the guard must protect the existing populated one.
+    writeFileSync(join(dir, 'MEMORY.md'), '- [existing](project_x.md) — important\n');
+    const r = reindex({ memoryDir: dir, stderr: { write() {} } });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('lost_update_guard');
+    // populated index left intact
+    expect(readFileSync(join(dir, 'MEMORY.md'), 'utf8')).toContain('existing');
+  });
+
+  it('allows writing an empty index for a genuinely empty memory dir', () => {
+    writeFileSync(join(dir, 'MEMORY.md'), '- [old](old.md)\n');
+    rmSync(join(dir, 'MEMORY.md')); // start clean: no pointer files, no index
+    const r = reindex({ memoryDir: dir });
+    expect(r.ok).toBe(true);
+    expect(r.lineCount).toBe(0);
+  });
+
+  it('two sequential reindex runs converge and never tear the index', () => {
+    writeFileSync(join(dir, 'project_a.md'), pointerFile('mem-a', 'first'));
+    reindex({ memoryDir: dir });
+    writeFileSync(join(dir, 'project_b.md'), pointerFile('mem-b', 'second'));
+    reindex({ memoryDir: dir });
+    const idx = readFileSync(join(dir, 'MEMORY.md'), 'utf8');
+    expect(idx).toContain('mem-a');
+    expect(idx).toContain('mem-b');
+    expect(readdirSync(dir).filter(f => f.includes('.tmp'))).toEqual([]);
+    expect(existsSync(join(dir, '.memory-index.lock'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why
Parallel fleet sessions regenerate the shared **MEMORY.md** auto-memory index via `scripts/modules/memory/reindex.mjs`, which rebuilds the whole index from per-session pointer files. Its `writeFileSync` of the index/topic files is **not atomic**: two sessions reindexing concurrently can tear/clobber the file (a lost update), and a transient `readdir`/parse error could overwrite a populated index with a degenerate one. (Observed live this session as `MEMORY.md` "modified since read" mid-edit.)

## Change
- **New `lib/memory/atomic-write.mjs`** (Node built-ins only, cross-platform):
  - `atomicWriteFileSync(path, content)` — temp-file + `renameSync` (atomic on POSIX & Windows); a concurrent reader/writer always sees the old or the new **complete** file, never a tear.
  - `withMemoryIndexLock(dir, fn)` — atomic `mkdir` lock with bounded retry + **stale-lock breaking** (a crashed session can't deadlock the index); always releases in `finally`; **fails open** after the retry budget (the atomic write still prevents tears).
- **`reindex.mjs`** — run the write phase inside the lock, write index + topic files atomically, and add a **lost-update guard** (FR-3): refuse to overwrite a populated `MEMORY.md` with a zero-entry index produced by a transient error; a genuinely empty dir may still write an empty index.
- No index-format change, no new runtime dependency.

## Verification
- **10 unit tests** (`tests/unit/memory-atomic-write.test.js`): atomic write leaves no temp file / overwrites cleanly; lock acquire / release-on-throw / fail-open-when-held / stale-break; reindex regenerates all entries, the lost-update guard protects a populated index, and an empty dir still writes empty.
- Modules load clean; `reindex` behavior + format unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)