### PR TITLE
feat(SD-LEO-INFRA-CHARTER-DUTY3-PARKED-WORKER-FLAG-001): exclude parked workers from DUTY-3 idle-with-work

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -54,19 +54,31 @@ export function classifyLiveness(s, { nowMs, staleThresholdMs, isWithinArmedSile
 
 /**
  * DUTY-3 idle-with-work: count workers that are ALIVE + idle (no sd_key) + NOT holding a pending unread
- * WORK_ASSIGNMENT, while claimable (unclaimed) work exists. The pending-assignment exclusion prevents
- * re-flagging an already-remediated worker (no duplicate-assignment spray). Fires only when idle-eligible>0
- * AND unclaimed>0.
+ * WORK_ASSIGNMENT + NOT PARKED, while claimable (unclaimed) work exists. The pending-assignment exclusion
+ * prevents re-flagging an already-remediated worker (no duplicate-assignment spray). Fires only when
+ * idle-eligible>0 AND unclaimed>0.
+ *
+ * SD-LEO-INFRA-CHARTER-DUTY3-PARKED-WORKER-FLAG-001 (same spirit as #4952 detectStalledLoop: parked != idle):
+ * a worker between /loop ticks (loop_state='awaiting_tick') or inside an armed expected_silence_until window
+ * is PARKED — it will self-claim on its next wake and the coordinator cannot remediate it (dispatch finds 0
+ * reachable-free workers), so counting it idle-while-unclaimed produced a perpetual un-remediable
+ * VIOLATIONS=1 + dispatch whack-a-mole. Exclude parked workers. Pass nowMs + isWithinArmedSilence (the
+ * canonical lib/fleet/silence-cap.cjs predicate) to evaluate the armed-silence window; both are optional so
+ * a caller that omits them simply skips the silence check (the awaiting_tick exclusion still applies).
  */
-export function detectIdleWithWork({ liveSessions = [], unclaimedCount = 0, pendingAssignmentSessionIds = new Set() } = {}) {
-  const idleEligible = liveSessions.filter((s) => s && !s.sd_key && !pendingAssignmentSessionIds.has(s.session_id));
+export function detectIdleWithWork({ liveSessions = [], unclaimedCount = 0, pendingAssignmentSessionIds = new Set(), nowMs, isWithinArmedSilence } = {}) {
+  const isParked = (s) =>
+    s.loop_state === 'awaiting_tick' ||
+    !!(isWithinArmedSilence && isWithinArmedSilence(s.expected_silence_until, nowMs));
+  const idleEligible = liveSessions.filter((s) =>
+    s && !s.sd_key && !pendingAssignmentSessionIds.has(s.session_id) && !isParked(s));
   const violation = idleEligible.length > 0 && unclaimedCount > 0;
   return {
     violation,
     idleCount: idleEligible.length,
     unclaimedCount,
     detail: violation
-      ? `${idleEligible.length} live-idle worker(s) (excl. pending-assignment) while ${unclaimedCount} SD(s) unclaimed`
+      ? `${idleEligible.length} live-idle worker(s) (excl. pending-assignment + parked) while ${unclaimedCount} SD(s) unclaimed`
       : `none (${idleEligible.length} idle-eligible, ${unclaimedCount} unclaimed)`,
     remediation: violation ? 'ACTION: assign the unclaimed SD(s) to the idle worker(s) — dispatch a WORK_ASSIGNMENT or wake their loop' : null,
   };

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -96,7 +96,7 @@ async function main() {
 
   // Defense-in-depth: exclude lifecycle-terminated sessions server-side (classifyLiveness also guards this).
   const { data: sessRows, error: sessErr } = await db.from('claude_sessions')
-    .select('session_id,terminal_id,heartbeat_at,sd_key,expected_silence_until,status,metadata')
+    .select('session_id,terminal_id,heartbeat_at,sd_key,loop_state,expected_silence_until,status,metadata')
     .not('status', 'in', '(released,stale,ended)')
     .order('heartbeat_at', { ascending: false }).limit(80);
   const sessMarker = foundationalQueryError(sessErr, 'claude_sessions');
@@ -196,7 +196,7 @@ async function main() {
   // ── run the pure detectors ──
   const D = {
     pool: detectWorktreePool({ count: wtCount, max: MAX_WORKTREE_COUNT }),
-    idle: detectIdleWithWork({ liveSessions: liveWorkers, unclaimedCount: unclaimed.length, pendingAssignmentSessionIds }),
+    idle: detectIdleWithWork({ liveSessions: liveWorkers, unclaimedCount: unclaimed.length, pendingAssignmentSessionIds, nowMs, isWithinArmedSilence: isWithinArmedSilenceWindow }),
     dep: detectDependencyHealth({ sds, statusByKey, terminalSet: TERMINAL, nowMs }),
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -117,6 +117,33 @@ describe('detectIdleWithWork — DUTY-3 + pending-assignment suppression (FR-3/F
   it('no unclaimed work -> no violation', () => {
     expect(detectIdleWithWork({ liveSessions: [{ session_id: 'w1', sd_key: null }], unclaimedCount: 0 }).violation).toBe(false);
   });
+
+  // SD-LEO-INFRA-CHARTER-DUTY3-PARKED-WORKER-FLAG-001: parked workers (between /loop ticks) are NOT
+  // idle-while-unclaimed — they self-claim on next wake and the coordinator cannot remediate them.
+  it('a PARKED worker (loop_state=awaiting_tick) is NOT flagged (parked != idle)', () => {
+    const r = detectIdleWithWork({ liveSessions: [{ session_id: 'w1', sd_key: null, loop_state: 'awaiting_tick' }], unclaimedCount: 2 });
+    expect(r.violation).toBe(false);
+    expect(r.idleCount).toBe(0);
+  });
+  it('a worker inside an armed expected_silence_until window is NOT flagged', () => {
+    const nowMs = 1_000_000;
+    const isWithinArmedSilence = (until, now) => !!until && new Date(until).getTime() > now;
+    const r = detectIdleWithWork({
+      liveSessions: [{ session_id: 'w1', sd_key: null, expected_silence_until: new Date(nowMs + 600_000).toISOString() }],
+      unclaimedCount: 2, nowMs, isWithinArmedSilence,
+    });
+    expect(r.violation).toBe(false);
+  });
+  it('a genuinely-active idle worker (loop_state active, no silence) IS still flagged', () => {
+    const nowMs = 1_000_000;
+    const isWithinArmedSilence = (until, now) => !!until && new Date(until).getTime() > now;
+    const r = detectIdleWithWork({
+      liveSessions: [{ session_id: 'w1', sd_key: null, loop_state: 'active', expected_silence_until: null }],
+      unclaimedCount: 2, nowMs, isWithinArmedSilence,
+    });
+    expect(r.violation).toBe(true);
+    expect(r.detail).toMatch(/parked/);
+  });
 });
 
 describe('extractDepKey — SD-key vs free-text prose (FR-5 dep-resolver correctness)', () => {


### PR DESCRIPTION
@
## Summary
coordinator-charter-audit **DUTY-3** counted a worker between /loop ticks (`loop_state=awaiting_tick`, or inside an armed `expected_silence_until` window) as idle-while-N-unclaimed. The coordinator cannot remediate it — those workers self-claim on their next wake; dispatch finds 0 reachable-free workers — so `CHARTER_AUDIT_VIOLATIONS` stuck at 1 every tick the belt had work (whack-a-mole + noise). Same class as #4952 (`detectStalledLoop` SSOT: parked != stalled).

## Fix
`detectIdleWithWork` excludes parked workers (`awaiting_tick` OR armed-silence) via optional `nowMs` + `isWithinArmedSilence` params; `coordinator-charter-audit.mjs` adds `loop_state` to the `claude_sessions` select and passes `nowMs` + the canonical `isWithinArmedSilenceWindow`. A genuinely-active idle worker with unclaimed work is still flagged.

## Adversarial-verified (the #4952 lesson)
RCA confirmed the SELECT-omission class is NOT present: the select includes both `loop_state` AND `expected_silence_until`, `liveWorkers` is derived from that select, the `isWithinArmedSilence` signature matches, `nowMs` is in scope, and a permanently-dead `awaiting_tick` loop still goes heartbeat-stale → dropped from `liveWorkers` → reaped (no blind spot).

## Tests
36/36 (3 new: awaiting_tick excluded, armed-silence excluded, active idle still flagged + a positive control). `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@