### PR TITLE
feat(SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001): auto-type SD-LEO-*/SD-MAN-INFRA-*/SD-LEARN-FIX- as infrastructure at creation

### DIFF
--- a/lib/sourcing-engine/register-first.js
+++ b/lib/sourcing-engine/register-first.js
@@ -26,15 +26,19 @@ import { routeCandidate } from './router.js';
  * "promoted-thin, needs enrichment" SD rather than a deceptive 3-way clone.
  *
  * @param {{id?:string, title?:string, source_type?:string, source_id?:string, item_disposition?:string, metadata?:object}} item
- * @returns {{title:string, type:string, description:string, scope:string, strategic_intent:string, metadata:object}}
+ * @returns {{title:string, type:(string|null), description:string, scope:string, strategic_intent:string, metadata:object}}
  */
 export function deriveSdFieldsFromRoadmapItem(item) {
   const it = item || {};
   const md = it.metadata && typeof it.metadata === 'object' ? it.metadata : {};
-  // Disposition -> SD type hint (BUILD/RESEARCH/REFERENCE/CANCEL are dispositions, not SD types):
-  // a BUILD item becomes a feature/infrastructure SD; everything else defaults to feature and lets
-  // the normal type inference / --type override take over.
-  const type = md.sd_type || 'feature';
+  // Disposition -> SD type hint (BUILD/RESEARCH/REFERENCE/CANCEL are dispositions, not SD types).
+  // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001: do NOT bake a 'feature' default here. An explicit
+  // metadata.sd_type still wins; when absent we return null so the createSD SSOT (resolveSdType in
+  // scripts/leo-create-sd.js) can apply the key-prefix default — SD-LEO-* / SD-MAN-INFRA-* /
+  // SD-LEARN-FIX- promotions land as infrastructure instead of paying the per-SD feature->infra
+  // reclassify tax. Previously this returned 'feature', which pre-empted that default for every
+  // typeless promoted harness SD.
+  const type = md.sd_type || null;
   const title = it.title || `Roadmap item ${it.id || ''}`.trim();
 
   // Provenance line names where the work came from (distinct, not a title clone).

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1401,6 +1401,36 @@ function mapToDbType(userType) {
 }
 
 /**
+ * SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001 (FR-1): infer the DEFAULT sd_type from the SD key prefix.
+ * The key prefixes SD-LEO-*, SD-MAN-INFRA-* and SD-LEARN-FIX-* are infrastructure by definition
+ * (harness/governance work), so a typeless SD with one of those keys should default to
+ * 'infrastructure' rather than 'feature' — removing the per-SD feature->infra reclassify tax.
+ * Returns 'infrastructure' for those prefixes, otherwise null (no opinion → caller falls back to
+ * its own default). Pure; exported for unit test.
+ * @param {string} sdKey
+ * @returns {('infrastructure'|null)}
+ */
+function inferDefaultSdTypeFromKey(sdKey) {
+  if (typeof sdKey !== 'string') return null;
+  // Anchored, case-insensitive; \b/hyphen boundary so SD-LEONARDO-* does NOT match SD-LEO-.
+  if (/^SD-(LEO|MAN-INFRA|LEARN-FIX)-/i.test(sdKey)) return 'infrastructure';
+  return null;
+}
+
+/**
+ * SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001 (FR-1/FR-2/FR-3): resolve the effective sd_type for createSD.
+ * Precedence: an explicit (truthy) rawType ALWAYS wins (FR-2 — --type / proposal sd_type / child
+ * override never overridden); otherwise the key-prefix default applies (FR-1); otherwise 'feature'
+ * (FR-3 — SD-EHG-* and other product keys are unchanged). Pure; exported for unit test.
+ * @param {string|null|undefined} rawType  the caller-supplied type (may be unset)
+ * @param {string} sdKey
+ * @returns {string}
+ */
+function resolveSdType(rawType, sdKey) {
+  return rawType || inferDefaultSdTypeFromKey(sdKey) || 'feature';
+}
+
+/**
  * Build default success_metrics based on SD type and title
  * Ensures validator requirements (3+ items with {metric, target}) are met
  */
@@ -1573,7 +1603,10 @@ async function createSD(options) {
     sdKey,
     title,
     description,
-    type,
+    // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001: capture the caller-supplied type as rawType; the
+    // effective `type` is resolved below via resolveSdType so a typeless infra-prefixed key
+    // (SD-LEO-*/SD-MAN-INFRA-*/SD-LEARN-FIX-) defaults to infrastructure. Explicit type still wins.
+    type: rawType,
     priority = 'medium',
     rationale,
     parentId = null,
@@ -1603,6 +1636,11 @@ async function createSD(options) {
     // direct/--from-feedback/--child callers that omit it.
     dependencies = null,
   } = options;
+
+  // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001 (FR-1/FR-2/FR-3): resolve the effective sd_type. An explicit
+  // caller type wins; otherwise an infra-prefixed key (SD-LEO-*/SD-MAN-INFRA-*/SD-LEARN-FIX-) defaults
+  // to infrastructure; otherwise 'feature'. Always a string, so downstream type.charAt/mapToDbType are safe.
+  const type = resolveSdType(rawType, sdKey);
 
   // QF-CLAIM-CONFLICT-UX-001 + SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001:
   // Detect Quick-Fix prefix and redirect via Unified Work-Item Router
@@ -2569,7 +2607,8 @@ export async function createFromProposalStdin(options = {}) {
 
 // Export for programmatic use (e.g., corrective-sd-generator)
 // SD-LEO-INFRA-BUILDDEFAULTSMOKETESTSTEPS-KEYWORD-DETECTOR-001 (FR-4): export buildDefaultSmokeTestSteps for unit-test access.
-export { createSD, buildDefaultSmokeTestSteps };
+// SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001 (FR-4): export the pure type-default resolvers for unit test.
+export { createSD, buildDefaultSmokeTestSteps, inferDefaultSdTypeFromKey, resolveSdType };
 
 // ============================================================================
 // CLI Handler

--- a/tests/unit/derive-sd-fields-roadmap.test.js
+++ b/tests/unit/derive-sd-fields-roadmap.test.js
@@ -72,7 +72,9 @@ describe('deriveSdFieldsFromRoadmapItem (thin-stub fix)', () => {
   it('still returns title/type/metadata.source for back-compat', () => {
     const f = deriveSdFieldsFromRoadmapItem(titleOnly);
     expect(f.title).toBeTruthy();
-    expect(f.type).toBe('feature');
+    // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001: type is null (was 'feature') when metadata.sd_type is absent —
+    // the createSD SSOT applies the key-prefix default instead of the deriver baking 'feature'.
+    expect(f.type).toBeNull();
     expect(f.metadata.source).toBe('roadmap_item');
     expect(f.metadata.source_id).toBe('rwi-1');
   });

--- a/tests/unit/leo-create-sd-default-type-by-key.test.js
+++ b/tests/unit/leo-create-sd-default-type-by-key.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { inferDefaultSdTypeFromKey, resolveSdType } from '../../scripts/leo-create-sd.js';
+import { deriveSdFieldsFromRoadmapItem } from '../../lib/sourcing-engine/register-first.js';
+
+// SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001: the leo-create-sd type-inference path defaults a TYPELESS
+// SD-LEO-* / SD-MAN-INFRA-* / SD-LEARN-FIX- key to 'infrastructure' (harness work is infra by
+// definition), killing the per-SD feature->infra reclassify tax. An explicit type always wins;
+// product keys (SD-EHG-*) still default 'feature'.
+
+describe('inferDefaultSdTypeFromKey (FR-1)', () => {
+  it('returns infrastructure for the harness key prefixes', () => {
+    expect(inferDefaultSdTypeFromKey('SD-LEO-INFRA-FOO-001')).toBe('infrastructure');
+    expect(inferDefaultSdTypeFromKey('SD-LEO-FEAT-FOO-001')).toBe('infrastructure');
+    expect(inferDefaultSdTypeFromKey('SD-MAN-INFRA-BAR-001')).toBe('infrastructure');
+    expect(inferDefaultSdTypeFromKey('SD-LEARN-FIX-BAZ-001')).toBe('infrastructure');
+  });
+
+  it('returns null for product / non-harness keys (caller falls back to feature)', () => {
+    expect(inferDefaultSdTypeFromKey('SD-EHG-MARKETING-001')).toBeNull();
+    expect(inferDefaultSdTypeFromKey('SD-FDBK-INFRA-001')).toBeNull();
+    expect(inferDefaultSdTypeFromKey('SD-2025-001')).toBeNull();
+  });
+
+  it('does not over-match a longer token that merely starts with the prefix letters', () => {
+    // SD-LEONARDO-* must NOT be treated as SD-LEO- (hyphen boundary in the regex).
+    expect(inferDefaultSdTypeFromKey('SD-LEONARDO-001')).toBeNull();
+    expect(inferDefaultSdTypeFromKey('SD-LEARNING-001')).toBeNull();
+  });
+
+  it('is null-safe for non-string input', () => {
+    expect(inferDefaultSdTypeFromKey(undefined)).toBeNull();
+    expect(inferDefaultSdTypeFromKey(null)).toBeNull();
+    expect(inferDefaultSdTypeFromKey(42)).toBeNull();
+  });
+});
+
+describe('resolveSdType (FR-1/FR-2/FR-3)', () => {
+  it('FR-1: a TYPELESS infra-prefixed key defaults to infrastructure', () => {
+    expect(resolveSdType(undefined, 'SD-LEO-INFRA-FOO-001')).toBe('infrastructure');
+    expect(resolveSdType(null, 'SD-MAN-INFRA-FOO-001')).toBe('infrastructure');
+    expect(resolveSdType(undefined, 'SD-LEARN-FIX-FOO-001')).toBe('infrastructure');
+  });
+
+  it('FR-2: an explicit type ALWAYS wins over the prefix default', () => {
+    expect(resolveSdType('feature', 'SD-LEO-INFRA-FOO-001')).toBe('feature');
+    expect(resolveSdType('bugfix', 'SD-LEO-FOO-001')).toBe('bugfix');
+    expect(resolveSdType('database', 'SD-MAN-INFRA-FOO-001')).toBe('database');
+  });
+
+  it('FR-3: a TYPELESS product key still defaults to feature', () => {
+    expect(resolveSdType(undefined, 'SD-EHG-MARKETING-001')).toBe('feature');
+    expect(resolveSdType(null, 'SD-FDBK-INFRA-001')).toBe('feature');
+  });
+});
+
+describe('deriveSdFieldsFromRoadmapItem no longer bakes a feature default (FR-3)', () => {
+  it('returns type=null when the roadmap item carries no metadata.sd_type', () => {
+    // null lets the createSD SSOT (resolveSdType) apply the key-prefix default for promoted SDs.
+    const fields = deriveSdFieldsFromRoadmapItem({ id: 'rwi-1', title: 'Harden the reaper' });
+    expect(fields.type).toBeNull();
+  });
+
+  it('still passes through an explicit metadata.sd_type unchanged', () => {
+    const fields = deriveSdFieldsFromRoadmapItem({ id: 'rwi-2', title: 'X', metadata: { sd_type: 'bugfix' } });
+    expect(fields.type).toBe('bugfix');
+  });
+
+  it('end-to-end: a typeless LEO-source promotion resolves to infrastructure', () => {
+    // The from-roadmap path generates an SD-LEO-* key, then createSD calls resolveSdType(fields.type, key).
+    const fields = deriveSdFieldsFromRoadmapItem({ id: 'rwi-3', title: 'Reap orphan worktrees' });
+    expect(resolveSdType(fields.type, 'SD-LEO-GEN-REAP-ORPHAN-001')).toBe('infrastructure');
+  });
+});

--- a/tests/unit/register-first.test.js
+++ b/tests/unit/register-first.test.js
@@ -17,7 +17,9 @@ describe('register-first — deriveSdFieldsFromRoadmapItem (FR-1)', () => {
       id: 'item-1', title: 'Build the thing', source_type: 'conversion_ledger', source_id: 'led-1', item_disposition: 'BUILD',
     });
     expect(f.title).toBe('Build the thing');
-    expect(f.type).toBe('feature'); // default when metadata.sd_type absent
+    // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001: the deriver no longer bakes a 'feature' default — it returns
+    // null when metadata.sd_type is absent so the createSD SSOT (resolveSdType) can apply the key-prefix default.
+    expect(f.type).toBeNull();
     expect(f.metadata).toMatchObject({ source: 'roadmap_item', source_id: 'item-1', roadmap_item_source_type: 'conversion_ledger', roadmap_item_source_id: 'led-1', item_disposition: 'BUILD' });
   });
   it('honors metadata.sd_type and tolerates a missing title', () => {
@@ -27,7 +29,8 @@ describe('register-first — deriveSdFieldsFromRoadmapItem (FR-1)', () => {
   });
   it('is total on null', () => {
     const f = deriveSdFieldsFromRoadmapItem(null);
-    expect(f.type).toBe('feature');
+    // SD-LEO-INFRA-AUTOTYPE-INFRA-KEYS-001: null default (was 'feature') — SSOT applies the prefix default.
+    expect(f.type).toBeNull();
     expect(f.metadata.source).toBe('roadmap_item');
   });
 });


### PR DESCRIPTION
## Summary
Nearly every harness SD (SD-LEO-*, SD-MAN-INFRA-*, SD-LEARN-FIX-) was auto-typed `sd_type='feature'` at creation because the leo-create-sd type-inference path defaults to `feature` when no explicit `--type` is given. `feature` forces the vision-score gate + a 100-word description requirement, so fleet workers reclassify feature→infrastructure on **almost every harness SD** — a recurring per-SD tax. Worse, the reclassify is timing-locked after handoffs, producing the DESIGN empty-repo false-negative chain that cost a documented gate bypass on `SD-LEO-FEAT-PRE-EXISTING-BUG-001` earlier this session.

These key prefixes are infrastructure by definition. This defaults their type at creation — **no gate weakened** (a genuine feature SD still types feature).

## Change (SSOT)
- **`scripts/leo-create-sd.js`**: pure `inferDefaultSdTypeFromKey(sdKey)` + `resolveSdType(rawType, sdKey)` (exported). `createSD` resolves its effective type via `resolveSdType` → a TYPELESS infra-prefixed key defaults to `infrastructure`. An explicit `--type`/proposal `sd_type` **always wins** (FR-2); `SD-EHG-*` and other product keys still default `feature` (FR-3).
- **`lib/sourcing-engine/register-first.js`**: the from-roadmap deriver stops baking a `feature` default (returns `null` when no `metadata.sd_type`) so the SSOT applies the key-prefix default to **promoted SDs** — the dominant tax path.
- **Tests**: new `leo-create-sd-default-type-by-key.test.js` (10 tests — FR-1/2/3, `SD-LEONARDO`/`SD-LEARNING` boundary non-match, null-safety, deriver end-to-end); updated the 3 existing deriver tests that pinned the old `feature` default → `null`.

No schema change.

## Tests
- `leo-create-sd-default-type-by-key.test.js` — 10/10 ✅
- `register-first.test.js` + `derive-sd-fields-roadmap.test.js` — 22/22 ✅
- `tests/unit/leo-create-sd` broad regression (8 files) — 111/111 ✅
- `node --check` both files — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
