### PR TITLE
fix(SD-FDBK-INFRA-PHANTOM-TEST-AUDIT-001): phantom audit diffs merge-base, not raw origin/main

### DIFF
--- a/scripts/phantom-test-audit.js
+++ b/scripts/phantom-test-audit.js
@@ -64,7 +64,7 @@ export function auditPhantomTableTests({ removedTables, changedFiles, testFiles 
   const issues = [
     `PHANTOM_TEST_AUDIT: ${orphaned.length} orphaned test reference(s) to removed table literal(s):`,
     ...orphaned.map(o => `  - test "${o.testFile}" references removed table '${o.table}' but was NOT edited in this PR`),
-    `Edit the listed test file(s) in the same PR, OR set PHANTOM_TEST_AUDIT_BYPASS=1 with bypass reason in handoff governance_metadata.`,
+    'Edit the listed test file(s) in the same PR, OR set PHANTOM_TEST_AUDIT_BYPASS=1 with bypass reason in handoff governance_metadata.',
   ];
   return {
     passed: false,
@@ -97,9 +97,34 @@ export const PHANTOM_COMMIT_TRIGGER = /phantom.*table|dead.*query/i;
  * @param {string} opts.baseRef - Base ref (default origin/main)
  * @returns {{triggered: boolean, result: ReturnType<auditPhantomTableTests> | null}}
  */
+/**
+ * Resolve the effective audit base = the MERGE-BASE of HEAD and baseRef, not the raw baseRef tip.
+ * SD-FDBK-INFRA-PHANTOM-TEST-AUDIT-001: on a worktree branch N commits BEHIND origin/main,
+ * `git diff origin/main..HEAD` (two-dot in diff = compare the two tips) surfaces origin/main's
+ * ADVANCING commits as reversed removals, so extractRemovedLiterals harvests literals that the
+ * branch never touched and the audit reports hundreds of false phantom orphans (Alpha 2026-06-21:
+ * 668 false orphans on a 5-behind branch, only cleared by resetting the worktree to origin/main).
+ * The merge-base excludes commits already on main, scoping the diff to what THIS branch changed.
+ * Fall back to baseRef when the merge-base can't be resolved (no common ancestor / detached HEAD /
+ * git error) — never worse than the prior behavior.
+ *
+ * @param {Object} opts
+ * @param {string} opts.repoPath - Repo root
+ * @param {string} [opts.baseRef] - Base ref (default origin/main)
+ * @param {(cmd: string, cwd: string) => string} [opts.git] - Injectable git runner (for tests)
+ * @returns {string} merge-base commit SHA, or baseRef if it cannot be resolved
+ */
+export function resolveAuditBase({ repoPath, baseRef = 'origin/main', git = safeGit }) {
+  const mergeBase = (git(`git merge-base HEAD ${baseRef}`, repoPath) || '').trim().split('\n')[0].trim();
+  return mergeBase || baseRef;
+}
+
 export function collectAndAudit({ repoPath, baseRef = 'origin/main' }) {
-  // Commit subjects in baseRef..HEAD; subject-only (--format=%s)
-  const subjects = safeGit(`git log ${baseRef}..HEAD --format=%s`, repoPath);
+  // Diff against the merge-base, not the raw baseRef tip (stale-base false-positive fix; see resolveAuditBase).
+  const base = resolveAuditBase({ repoPath, baseRef });
+
+  // Commit subjects in base..HEAD; subject-only (--format=%s)
+  const subjects = safeGit(`git log ${base}..HEAD --format=%s`, repoPath);
   const triggered = subjects
     .split('\n')
     .map(s => s.trim())
@@ -111,11 +136,11 @@ export function collectAndAudit({ repoPath, baseRef = 'origin/main' }) {
   }
 
   // Removed string literals from src diff (single-line single/double-quoted).
-  const diff = safeGit(`git diff ${baseRef}..HEAD -- "scripts/*" "lib/*" "src/*"`, repoPath, { maxBuffer: 16 * 1024 * 1024 });
+  const diff = safeGit(`git diff ${base}..HEAD -- "scripts/*" "lib/*" "src/*"`, repoPath, { maxBuffer: 16 * 1024 * 1024 });
   const removedTables = extractRemovedLiterals(diff);
 
   // Files changed in this PR.
-  const changedRaw = safeGit(`git diff --name-only ${baseRef}..HEAD`, repoPath);
+  const changedRaw = safeGit(`git diff --name-only ${base}..HEAD`, repoPath);
   const changedFiles = changedRaw.split('\n').map(s => s.trim()).filter(Boolean);
 
   // Test files to scan (recursive from tests/ and __tests__/).

--- a/tests/unit/handoff/gates/phantom-test-audit-gate.test.js
+++ b/tests/unit/handoff/gates/phantom-test-audit-gate.test.js
@@ -11,7 +11,6 @@ import { resolve } from 'node:path';
 import {
   auditPhantomTableTests,
   PHANTOM_COMMIT_TRIGGER,
-  collectAndAudit,
   resolveAuditBase,
 } from '../../../../scripts/phantom-test-audit.js';
 import { createPhantomTestAuditGate } from '../../../../scripts/modules/handoff/executors/lead-final-approval/gates/phantom-test-audit-gate.js';
@@ -186,7 +185,7 @@ describe('TS-MB: resolveAuditBase diffs against the merge-base, not the raw base
   it('returns the merge-base SHA when git resolves one (excludes commits already on main)', () => {
     const MB = 'abc1234def5678abc1234def5678abc1234def56';
     const calls = [];
-    const fakeGit = (cmd, cwd) => { calls.push(cmd); return MB + '\n'; };
+    const fakeGit = (cmd) => { calls.push(cmd); return MB + '\n'; };
     const base = resolveAuditBase({ repoPath: '/repo', baseRef: 'origin/main', git: fakeGit });
     expect(base).toBe(MB);
     // It asks for the merge-base of HEAD and the base ref (the fix), not the raw tip.

--- a/tests/unit/handoff/gates/phantom-test-audit-gate.test.js
+++ b/tests/unit/handoff/gates/phantom-test-audit-gate.test.js
@@ -12,6 +12,7 @@ import {
   auditPhantomTableTests,
   PHANTOM_COMMIT_TRIGGER,
   collectAndAudit,
+  resolveAuditBase,
 } from '../../../../scripts/phantom-test-audit.js';
 import { createPhantomTestAuditGate } from '../../../../scripts/modules/handoff/executors/lead-final-approval/gates/phantom-test-audit-gate.js';
 import { HAS_REAL_DB } from '../../../helpers/db-available.js';
@@ -72,8 +73,11 @@ describe('TS-2c: body content is NOT scanned for trigger (FR-6)', () => {
     // source-level static-pin so a future refactor that adds %b fails the
     // test loudly.
     const src = readFileSync(resolve(ROOT_DIR, 'scripts/phantom-test-audit.js'), 'utf8');
-    expect(src).toMatch(/git log\s+\$\{baseRef\}\.\.HEAD\s+--format=%s/);
+    // The diff base is the merge-base (resolved into `base`), not the raw ${baseRef} tip
+    // (SD-FDBK-INFRA-PHANTOM-TEST-AUDIT-001 stale-base false-positive fix). Pin subject-only format.
+    expect(src).toMatch(/git log\s+\$\{base\}\.\.HEAD\s+--format=%s/);
     expect(src).not.toMatch(/git log[^`]*--format=%b/);
+    expect(src).toMatch(/git merge-base HEAD \$\{baseRef\}/);
   });
 });
 
@@ -175,5 +179,33 @@ describe('TS-6: gate validator returns canonical verdict shape (FR-2+FR-4)', () 
     expect(Array.isArray(verdict.issues)).toBe(true);
     expect(Array.isArray(verdict.warnings)).toBe(true);
     expect(verdict.details).toBeDefined();
+  });
+});
+
+describe('TS-MB: resolveAuditBase diffs against the merge-base, not the raw baseRef tip (SD-FDBK-INFRA-PHANTOM-TEST-AUDIT-001)', () => {
+  it('returns the merge-base SHA when git resolves one (excludes commits already on main)', () => {
+    const MB = 'abc1234def5678abc1234def5678abc1234def56';
+    const calls = [];
+    const fakeGit = (cmd, cwd) => { calls.push(cmd); return MB + '\n'; };
+    const base = resolveAuditBase({ repoPath: '/repo', baseRef: 'origin/main', git: fakeGit });
+    expect(base).toBe(MB);
+    // It asks for the merge-base of HEAD and the base ref (the fix), not the raw tip.
+    expect(calls[0]).toBe('git merge-base HEAD origin/main');
+  });
+
+  it('falls back to baseRef when the merge-base cannot be resolved (no common ancestor / git error)', () => {
+    expect(resolveAuditBase({ repoPath: '/repo', baseRef: 'origin/main', git: () => '' })).toBe('origin/main');
+    expect(resolveAuditBase({ repoPath: '/repo', baseRef: 'origin/main', git: () => '\n  \n' })).toBe('origin/main');
+  });
+
+  it('trims whitespace and takes only the first line of git output', () => {
+    const MB = '0123456789012345678901234567890123456789';
+    expect(resolveAuditBase({ repoPath: '/repo', git: () => `  ${MB}  \nstderr-noise` })).toBe(MB);
+  });
+
+  it('honors a custom baseRef', () => {
+    const calls = [];
+    resolveAuditBase({ repoPath: '/repo', baseRef: 'upstream/release', git: (cmd) => { calls.push(cmd); return ''; } });
+    expect(calls[0]).toBe('git merge-base HEAD upstream/release');
   });
 });


### PR DESCRIPTION
## Summary
PHANTOM_TEST_AUDIT (LEAD-FINAL gate) false-positived on **stale-base worktree branches**. `collectAndAudit` diffed `origin/main..HEAD` (two-dot = compare tips), so a branch N commits **behind** origin/main surfaced origin/main's *advancing* commits as reversed removals — `extractRemovedLiterals` then harvested literals the branch never touched (`path`, `child_process`, `high`, `function`, `off`, `ignore`, `tool`, …) and the audit flagged them as phantom table reads.

Cost a full LEAD-FINAL cycle (Alpha, 2026-06-21): **668 false orphans on a 5-behind branch**, only cleared by hard-resetting the worktree to origin/main. Reported via `/signal gate-bug`.

## Fix
- New pure `resolveAuditBase({repoPath, baseRef, git})` runs `git merge-base HEAD <baseRef>` and `collectAndAudit` diffs against the resolved **merge-base** in all three git reads (`git log`, `git diff`, `git diff --name-only`), excluding commits already on main.
- Falls back to `baseRef` when no merge-base resolves (no common ancestor / detached HEAD / git error) — never worse than today.
- On healthy branches `merge-base == origin/main`, so behavior is unchanged.

## Tests
- 4 new TS-MB unit tests inject a fake git runner (merge-base resolved / empty→fallback / whitespace+first-line / custom baseRef).
- Updated the static source pin to assert `git log ${base}..HEAD` and `git merge-base HEAD ${baseRef}`.
- Full `phantom-test-audit-gate.test.js` passes (18 passed, 1 DB-skipped); ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
