### PR TITLE
feat(SD-FDBK-INFRA-DISK-FULL-RECURS-001): free-space floor on worktree creation (fleet disk-full guard)

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -875,12 +875,16 @@ export function createWorkTypeWorktree({ workType, workKey, branch, force = fals
   // git-registered worktrees (via `git worktree list --porcelain`) instead of
   // filesystem directories. Orphan directories no longer inflate the count.
   // Error contract (message text + errorCode WORKTREE_QUOTA_EXCEEDED) is
-  // preserved by the helper. Non-quota errors (e.g., permission issues) are
+  // preserved by the helper. Incidental errors (e.g., permission issues) are
   // swallowed here to match prior behavior and not block creation.
+  // SD-FDBK-INFRA-DISK-FULL-RECURS-001: the disk-pressure guard (WORKTREE_DISK_PRESSURE) is an
+  // INTENTIONAL hard block — this generic factory (createWorkTypeWorktree, used by quick-fix /
+  // team-spawner / plan-to-exec / lead-final / sd-start) must propagate it too, else the guard is a
+  // no-op on the dominant creation path. Re-throw BOTH deliberate quota codes; swallow only the rest.
   try {
     enforceWorktreeQuota(repoRoot, worktreesDir);
   } catch (e) {
-    if (e.errorCode === 'WORKTREE_QUOTA_EXCEEDED') throw e;
+    if (e.errorCode === 'WORKTREE_QUOTA_EXCEEDED' || e.errorCode === 'WORKTREE_DISK_PRESSURE') throw e;
     // Ignore other errors (e.g., permission issues) — don't block creation
   }
   const worktreeDir = path.join(worktreesDir, subDir);

--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -32,8 +32,52 @@ import path from 'node:path';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-4): shared reapability predicate,
 // used to exclude owned/dirty/unpushed dirs from the ORPHAN_DETECTED count.
 import { isReapable } from './worktree-reapability.js';
+// SD-FDBK-INFRA-DISK-FULL-RECURS-001: reuse the canonical free-space reader (statfs-based, returns
+// undefined when unreadable) so the disk-floor guard and the node_modules-isolation decision share one
+// SSOT. No import cycle: worktree-provision.js does not import this module.
+import { getFreeDiskBytes } from './worktree-provision.js';
 
 export const MAX_WORKTREE_COUNT = 20;
+
+// SD-FDBK-INFRA-DISK-FULL-RECURS-001: a free-space FLOOR enforced at worktree-creation time. The quota
+// only ever capped COUNT (20), so on a near-full disk a new `git worktree add` (+ a possibly isolated
+// ~0.5-1GB node_modules) could fill the volume and corrupt git ops — the recurring fleet-wide disk-full.
+// Block creation BEFORE that with a clear, reaper-pointing error. Env-tunable; default 5GB leaves
+// headroom for one worktree + isolated node_modules. FAIL-OPEN: an unreadable free-space read never
+// blocks (see checkDiskFloor).
+export const WORKTREE_DISK_FLOOR_BYTES = Math.max(0, Number(process.env.WORKTREE_DISK_FLOOR_GB) || 5) * 1024 * 1024 * 1024;
+
+/**
+ * Pure: is there enough free disk to create another worktree? FAIL-OPEN — an unreadable free-space value
+ * (undefined/null/NaN, e.g. statfs unsupported) returns ok:true so the guard never blocks on an
+ * unknowable. Blocks ONLY when a well-formed freeBytes is strictly below the floor.
+ * @param {number|undefined} freeBytes
+ * @param {number} floorBytes
+ * @returns {{ok:boolean, reason:string, freeBytes:(number|undefined), floorBytes:number}}
+ */
+export function checkDiskFloor(freeBytes, floorBytes = WORKTREE_DISK_FLOOR_BYTES) {
+  if (freeBytes == null || !Number.isFinite(freeBytes)) {
+    return { ok: true, reason: 'unreadable', freeBytes, floorBytes };
+  }
+  if (freeBytes >= floorBytes) return { ok: true, reason: 'sufficient', freeBytes, floorBytes };
+  return { ok: false, reason: 'below_floor', freeBytes, floorBytes };
+}
+
+const DISK_GB = 1024 * 1024 * 1024;
+/** Build the disk-pressure block error (errorCode WORKTREE_DISK_PRESSURE) with reaper remediation. */
+export function createDiskPressureError(freeBytes, floorBytes) {
+  const freeGb = Number.isFinite(freeBytes) ? (freeBytes / DISK_GB).toFixed(2) : 'unknown';
+  const floorGb = (floorBytes / DISK_GB).toFixed(1);
+  const err = new Error(
+    `Worktree creation blocked (disk pressure): only ${freeGb}GB free on the .worktrees volume (floor ${floorGb}GB). ` +
+    'Reclaim space first — run: node scripts/worktree-reaper.mjs --execute --stage0 (then --stage2 / --orphan-sweep if still low). ' +
+    'Override the floor with WORKTREE_DISK_FLOOR_GB if intentional.',
+  );
+  err.errorCode = 'WORKTREE_DISK_PRESSURE';
+  err.freeBytes = freeBytes;
+  err.floorBytes = floorBytes;
+  return err;
+}
 
 /**
  * Helper-directory names that live under `.worktrees/` but are not worktrees.
@@ -297,7 +341,8 @@ export function createQuotaExceededError(count, max = MAX_WORKTREE_COUNT) {
  * @throws {Error} With errorCode `WORKTREE_QUOTA_EXCEEDED` when at/over limit.
  */
 export function enforceWorktreeQuota(repoRoot, worktreesDir, options = {}) {
-  const { max = MAX_WORKTREE_COUNT, logger = console.warn, liveOwners, gitRunner } = options;
+  const { max = MAX_WORKTREE_COUNT, logger = console.warn, liveOwners, gitRunner,
+    getFreeDisk = getFreeDiskBytes, diskFloorBytes = WORKTREE_DISK_FLOOR_BYTES } = options;
   // FR-4: reuse the registered list as both the quota count and classifier input.
   const registered = listActiveWorktrees(repoRoot);
   const count = registered.length;
@@ -305,6 +350,16 @@ export function enforceWorktreeQuota(repoRoot, worktreesDir, options = {}) {
   const orphanCount = emitOrphanWarningIfAny(fsCount, count, logger, { worktreesDir, registered, liveOwners, gitRunner });
   if (count >= max) {
     throw createQuotaExceededError(count, max);
+  }
+  // SD-FDBK-INFRA-DISK-FULL-RECURS-001: count slots can be free while the DISK is full. Block creation
+  // before `git worktree add` fills the volume (the recurring fleet-wide disk-full). FAIL-OPEN: an
+  // unreadable free-space read (getFreeDiskBytes -> undefined) never blocks. Opt-out: WORKTREE_DISK_FLOOR_GB=0.
+  if (diskFloorBytes > 0) {
+    const freeBytes = getFreeDisk(worktreesDir);
+    const disk = checkDiskFloor(freeBytes, diskFloorBytes);
+    if (!disk.ok) {
+      throw createDiskPressureError(disk.freeBytes, disk.floorBytes);
+    }
   }
   return { count, orphanCount };
 }

--- a/tests/unit/worktree-quota-disk-floor.test.js
+++ b/tests/unit/worktree-quota-disk-floor.test.js
@@ -1,0 +1,69 @@
+/**
+ * SD-FDBK-INFRA-DISK-FULL-RECURS-001 — worktree creation must be blocked when the .worktrees volume is
+ * below a free-space FLOOR (the recurring fleet-wide disk-full), not only when the COUNT quota is hit.
+ * The guard is FAIL-OPEN: an unreadable free-space read never blocks. Tests the pure helpers and the
+ * enforceWorktreeQuota integration via the injectable getFreeDisk seam (no real disk needed).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  checkDiskFloor, createDiskPressureError, enforceWorktreeQuota, WORKTREE_DISK_FLOOR_BYTES,
+} from '../../lib/worktree-quota.js';
+
+const GB = 1024 * 1024 * 1024;
+
+describe('checkDiskFloor (pure, fail-open)', () => {
+  it('ok when free >= floor', () => {
+    expect(checkDiskFloor(10 * GB, 5 * GB)).toMatchObject({ ok: true, reason: 'sufficient' });
+  });
+  it('blocks when free strictly below floor', () => {
+    expect(checkDiskFloor(2 * GB, 5 * GB)).toMatchObject({ ok: false, reason: 'below_floor' });
+  });
+  it('boundary: free exactly at floor is ok', () => {
+    expect(checkDiskFloor(5 * GB, 5 * GB).ok).toBe(true);
+  });
+  it('FAIL-OPEN on unreadable free space (undefined/null/NaN)', () => {
+    for (const v of [undefined, null, NaN]) {
+      expect(checkDiskFloor(v, 5 * GB)).toMatchObject({ ok: true, reason: 'unreadable' });
+    }
+  });
+  it('default floor is the exported WORKTREE_DISK_FLOOR_BYTES', () => {
+    // with the module default floor, 0 bytes free must block (unless the env opted out to 0)
+    if (WORKTREE_DISK_FLOOR_BYTES > 0) expect(checkDiskFloor(0).ok).toBe(false);
+    else expect(checkDiskFloor(0).ok).toBe(true);
+  });
+});
+
+describe('createDiskPressureError', () => {
+  it('carries errorCode WORKTREE_DISK_PRESSURE + reaper remediation', () => {
+    const e = createDiskPressureError(2 * GB, 5 * GB);
+    expect(e.errorCode).toBe('WORKTREE_DISK_PRESSURE');
+    expect(e.message).toMatch(/worktree-reaper\.mjs/);
+    expect(e.message).toMatch(/2\.00GB free/);
+    expect(e.message).toMatch(/floor 5\.0GB/);
+  });
+});
+
+describe('enforceWorktreeQuota — disk-floor integration (injected getFreeDisk)', () => {
+  // A gitRunner that reports an empty worktree list keeps the COUNT check passing so we isolate the disk path.
+  const emptyGit = () => 'worktree /repo\nHEAD abc\nbranch refs/heads/main\n';
+  const base = { max: 20, logger: () => {}, gitRunner: emptyGit, diskFloorBytes: 5 * GB };
+
+  it('throws WORKTREE_DISK_PRESSURE when free disk is below the floor', () => {
+    expect(() => enforceWorktreeQuota('/repo', '/repo/.worktrees', { ...base, getFreeDisk: () => 1 * GB }))
+      .toThrow(/disk pressure/i);
+  });
+  it('does NOT throw when free disk is above the floor', () => {
+    expect(() => enforceWorktreeQuota('/repo', '/repo/.worktrees', { ...base, getFreeDisk: () => 50 * GB }))
+      .not.toThrow();
+  });
+  it('FAIL-OPEN: does NOT throw when free disk is unreadable (undefined)', () => {
+    expect(() => enforceWorktreeQuota('/repo', '/repo/.worktrees', { ...base, getFreeDisk: () => undefined }))
+      .not.toThrow();
+  });
+  it('opt-out: diskFloorBytes=0 skips the disk check entirely', () => {
+    const spy = vi.fn(() => 0);
+    expect(() => enforceWorktreeQuota('/repo', '/repo/.worktrees', { ...base, diskFloorBytes: 0, getFreeDisk: spy }))
+      .not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/worktree-quota-disk-floor.test.js
+++ b/tests/unit/worktree-quota-disk-floor.test.js
@@ -5,11 +5,26 @@
  * enforceWorktreeQuota integration via the injectable getFreeDisk seam (no real disk needed).
  */
 import { describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
 import {
   checkDiskFloor, createDiskPressureError, enforceWorktreeQuota, WORKTREE_DISK_FLOOR_BYTES,
 } from '../../lib/worktree-quota.js';
+import { getFreeDiskBytes } from '../../lib/worktree-provision.js';
 
 const GB = 1024 * 1024 * 1024;
+
+describe('getFreeDiskBytes — real statfs smoke (the fail-open-no-op risk)', () => {
+  // The guard fails OPEN when free space is unreadable. If fs.statfsSync silently stopped working on
+  // this platform/Node version, the guard would become a permanent no-op with no other signal. This
+  // smoke test asserts the real reader returns a finite positive number on a known dir, so a Node
+  // downgrade/regression that breaks statfs is caught here rather than silently disabling the guard.
+  it('returns a finite positive byte count for os.tmpdir()', () => {
+    const free = getFreeDiskBytes(os.tmpdir());
+    expect(typeof free).toBe('number');
+    expect(Number.isFinite(free)).toBe(true);
+    expect(free).toBeGreaterThan(0);
+  });
+});
 
 describe('checkDiskFloor (pure, fail-open)', () => {
   it('ok when free >= floor', () => {


### PR DESCRIPTION
## Summary
Disk-full on C: recurs fleet-wide during parallel multi-worktree EXEC. The worktree quota capped COUNT (20) but never **DISK** — on a near-full volume a new `git worktree add` (+ a possibly isolated ~0.5-1GB node_modules) could fill the disk and corrupt git ops.

## Fix
Enforce a free-space **FLOOR** at the single quota choke point `enforceWorktreeQuota`, reusing the canonical statfs `getFreeDiskBytes`. Below the floor it throws `WORKTREE_DISK_PRESSURE` with a reaper-pointing remediation instead of crashing mid-op. Env-tunable (`WORKTREE_DISK_FLOOR_GB`, default 5; `0`=off), **FAIL-OPEN** on an unreadable read, injectable `getFreeDisk`/`diskFloorBytes` seam for tests.

## Adversarial-found HIGH (fixed) — the #4952 choke-point lesson
`lib/worktree-manager.js` `createWorkTypeWorktree` (the dominant creation path: quick-fix, team-spawner, plan-to-exec, lead-final, sd-start) wrapped `enforceWorktreeQuota` in a try/catch that re-threw **only** `WORKTREE_QUOTA_EXCEEDED`, silently swallowing the new `WORKTREE_DISK_PRESSURE` so the guard was a no-op there. Now re-throws both deliberate codes. RCA verified `fs.statfsSync` works on Windows/C: (12GB free) so the fail-open path isn't a silent no-op, and a real-`getFreeDiskBytes` smoke test guards against a Node regression.

## Tests
11/11 (`tests/unit/worktree-quota-disk-floor.test.js`): pure predicate (fail-open/boundary), error contract, `enforceWorktreeQuota` integration via injection, opt-out, + real-statfs smoke. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
