### PR TITLE
test(SD-FDBK-INFRA-RETROSPECTIVE-EXISTS-GATE-001): race-guard for the LEAD-TO-PLAN retro freshness boundary

### DIFF
--- a/scripts/modules/handoff/retro-filters.test.js
+++ b/scripts/modules/handoff/retro-filters.test.js
@@ -164,3 +164,115 @@ describe('getFilteredRetrospective — HANDOFF exclusion (NORMALIZE-HANDOFF-RETR
     expect(retrospective).toBeNull();
   });
 });
+
+/**
+ * SD-FDBK-INFRA-RETROSPECTIVE-EXISTS-GATE-001 — RACE GUARD.
+ *
+ * The RETROSPECTIVE_EXISTS gate at LEAD-FINAL was hypothesized to false-fail because the freshness
+ * boundary might resolve to the LATEST-accepted handoff (PLAN-TO-LEAD, stamped AFTER the SD_COMPLETION
+ * retro is generated during PLAN-TO-LEAD setup), so a legitimate retro would fail created_at > boundary.
+ * VERIFY-THE-PREMISE: resolveLeadToPlanAcceptedAt is ALREADY pinned to from_phase='LEAD' AND
+ * to_phase='PLAN' (since the original gate commit, SD-LEO-INFRA-RETROSPECTIVE-GATES-FAIL-001), so the
+ * boundary is the LEAD-TO-PLAN handoff and the race cannot occur. But the no-op-.eq() mock above never
+ * PROVED that pin excludes a PLAN-TO-LEAD handoff. These tests use a handoff-PREDICATE-aware mock that
+ * actually applies the from_phase/to_phase/status .eq() filters, pinning the invariant so a future
+ * un-pinning (which would re-introduce the race) fails here. No production code change.
+ *
+ * The boundary must NOT be loosened (e.g. `>` → `>=` or dropping the filter) — that would re-admit
+ * stale pre-LEAD-TO-PLAN handoff retros fleet-wide, the exact thing the gate exists to block (covered
+ * by the pre-boundary-retro-fails case below).
+ */
+function buildHandoffPredicateSupabase({ handoffRows = [], rows = [] } = {}) {
+  const handoffChain = () => {
+    const eqs = {};
+    let orderDesc = false;
+    const c = {
+      select: () => c,
+      eq: (col, val) => { eqs[col] = val; return c; },
+      order: (_col, opts) => { orderDesc = opts && opts.ascending === false; return c; },
+      limit: () => c,
+      maybeSingle: () => {
+        let out = handoffRows.filter((r) => Object.entries(eqs).every(([k, v]) => r[k] === v));
+        if (orderDesc) out = [...out].sort((a, b) => (a.accepted_at < b.accepted_at ? 1 : -1));
+        return Promise.resolve({ data: out[0] || null, error: null });
+      },
+    };
+    return c;
+  };
+  // Reuse the retrospectives predicate chain shape from buildPredicateSupabase.
+  const retroChain = () => {
+    const eqs = {};
+    let orPred = null; let gtPred = null; let orderDesc = false;
+    const c = {
+      select: () => c,
+      eq: (col, val) => { eqs[col] = val; return c; },
+      or: (str) => { orPred = str; return c; },
+      gt: (col, val) => { gtPred = { col, val }; return c; },
+      is: () => c,
+      order: (_col, opts) => { orderDesc = opts && opts.ascending === false; return c; },
+      limit: () => c,
+      maybeSingle: () => {
+        let out = rows.filter((r) => Object.entries(eqs).every(([k, v]) => r[k] === v));
+        if (orPred) out = out.filter((r) => r.retrospective_type == null || r.retrospective_type === 'SD_COMPLETION');
+        if (gtPred) out = out.filter((r) => r[gtPred.col] > gtPred.val);
+        if (orderDesc) out = [...out].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+        return Promise.resolve({ data: out[0] || null, error: null });
+      },
+    };
+    return c;
+  };
+  return {
+    from: vi.fn((table) => {
+      if (table === 'sd_phase_handoffs') return { select: () => handoffChain() };
+      if (table === 'retrospectives') return { select: () => retroChain() };
+      return { select: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) };
+    }),
+  };
+}
+
+describe('retro-gate freshness boundary is pinned to LEAD-TO-PLAN (SD-FDBK-INFRA-RETROSPECTIVE-EXISTS-GATE-001)', () => {
+  const sdUuid = 'sd-uuid';
+  const leadToPlanAccepted = '2026-04-01T00:00:00.000Z';   // T1 — the correct boundary
+  const planToLeadAccepted = '2026-04-20T00:00:00.000Z';   // T2 > T1 — stamped later, must be IGNORED
+
+  it('resolveLeadToPlanAcceptedAt returns the LEAD-TO-PLAN accepted_at and IGNORES a later PLAN-TO-LEAD handoff', async () => {
+    const supabase = buildHandoffPredicateSupabase({
+      handoffRows: [
+        { sd_id: sdUuid, from_phase: 'LEAD', to_phase: 'PLAN', status: 'accepted', accepted_at: leadToPlanAccepted },
+        { sd_id: sdUuid, from_phase: 'PLAN', to_phase: 'LEAD', status: 'accepted', accepted_at: planToLeadAccepted },
+      ],
+    });
+    const result = await resolveLeadToPlanAcceptedAt(sdUuid, null, supabase);
+    expect(result).toBe(leadToPlanAccepted); // NOT planToLeadAccepted — the race cannot occur
+  });
+
+  it('end-to-end: a retro generated AFTER LEAD-TO-PLAN but BEFORE PLAN-TO-LEAD PASSES (the race that was feared cannot happen)', async () => {
+    const retroDuringPlanToLead = '2026-04-10T00:00:00.000Z'; // T1 < this < T2
+    const supabase = buildHandoffPredicateSupabase({
+      handoffRows: [
+        { sd_id: sdUuid, from_phase: 'LEAD', to_phase: 'PLAN', status: 'accepted', accepted_at: leadToPlanAccepted },
+        { sd_id: sdUuid, from_phase: 'PLAN', to_phase: 'LEAD', status: 'accepted', accepted_at: planToLeadAccepted },
+      ],
+      rows: [
+        { id: 'completion', sd_id: sdUuid, retro_type: 'SD_COMPLETION', retrospective_type: null, created_at: retroDuringPlanToLead },
+      ],
+    });
+    const { retrospective, leadToPlanAcceptedAt } = await getFilteredRetrospective(sdUuid, null, supabase);
+    expect(leadToPlanAcceptedAt).toBe(leadToPlanAccepted);
+    expect(retrospective?.id).toBe('completion'); // created_at > T1 → passes (would FAIL if boundary were T2)
+  });
+
+  it("end-to-end: a retro created BEFORE the LEAD-TO-PLAN boundary FAILS (the gate's real job is preserved)", async () => {
+    const stalePreLeadRetro = '2026-03-15T00:00:00.000Z'; // < T1
+    const supabase = buildHandoffPredicateSupabase({
+      handoffRows: [
+        { sd_id: sdUuid, from_phase: 'LEAD', to_phase: 'PLAN', status: 'accepted', accepted_at: leadToPlanAccepted },
+      ],
+      rows: [
+        { id: 'stale', sd_id: sdUuid, retro_type: 'SD_COMPLETION', retrospective_type: null, created_at: stalePreLeadRetro },
+      ],
+    });
+    const { retrospective } = await getFilteredRetrospective(sdUuid, null, supabase);
+    expect(retrospective).toBeNull(); // freshness filter still rejects a stale pre-LEAD retro
+  });
+});


### PR DESCRIPTION
## Summary
Filed as a RETROSPECTIVE_EXISTS gate race at LEAD-FINAL: the freshness boundary was hypothesized to resolve to the latest-accepted handoff (PLAN-TO-LEAD, stamped *after* the SD_COMPLETION retro), false-failing a legitimate retro.

**Verify-the-premise: already fixed.** `resolveLeadToPlanAcceptedAt` (scripts/modules/handoff/retro-filters.js) is pinned to `from_phase='LEAD' AND to_phase='PLAN' AND status='accepted'` — it resolves to the **LEAD-TO-PLAN** handoff, never PLAN-TO-LEAD. The pin has been present since the original gate commit (`45632ae`, SD-LEO-INFRA-RETROSPECTIVE-GATES-FAIL-001). The grounding hypothesis came from grepping for a non-existent `handoff_type` column; the pin uses `from_phase`/`to_phase`. **The race cannot occur.**

But the existing unit tests use a **no-op `.eq()` mock** for `sd_phase_handoffs`, so they never *proved* the pin excludes a PLAN-TO-LEAD handoff. This is a **test-only regression guard** closing that gap.

## Change (test-only — no production change)
Added a handoff-predicate-aware mock + 3 tests to `retro-filters.test.js`:
- `resolveLeadToPlanAcceptedAt` returns the LEAD-TO-PLAN `accepted_at` **even when a later PLAN-TO-LEAD accepted handoff exists** → a future un-pin (which would re-introduce the race) fails here.
- end-to-end: a retro created **after LEAD-TO-PLAN but before PLAN-TO-LEAD PASSES** (proves the feared race can't happen).
- end-to-end: a retro created **before the LEAD-TO-PLAN boundary FAILS** (the gate's real job — rejecting stale pre-LEAD retros — is preserved; the freshness filter is **not** loosened).

`scripts/modules/handoff/retro-filters.js` is unchanged (empty diff).

## Tests
- `retro-filters.test.js` — 12/12 ✅ (9 existing + 3 new)
- `lead-final-approval/gates/retrospective-exists.test.js` — 7/7 ✅ (gate regression)
- `node --check` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
