### PR TITLE
fix(SD-FDBK-INFRA-MEMORY-REINDEX-SCRIPTS-001): correct memory-dir slug encoding

### DIFF
--- a/scripts/modules/memory/reindex.mjs
+++ b/scripts/modules/memory/reindex.mjs
@@ -12,12 +12,22 @@ const MAX_LINE_CHARS = 120;
 const TARGET_BYTES = 15 * 1024;
 const EXPIRED_PREFIX = '(!) ';
 
-function resolveMemoryDir(arg) {
+export function resolveMemoryDir(arg, opts = {}) {
   if (arg) return arg;
-  const home = process.env.HOME || process.env.USERPROFILE || '';
-  const cwd = process.cwd();
-  const encoded = cwd.replace(/[\\/:]/g, '-').replace(/^-+/, '');
-  return join(home, '.claude', 'projects', `C--${encoded.replace(/^C--/, '')}`, 'memory');
+  const env = opts.env || process.env;
+  // Explicit override wins — robust against any path-encoding edge case (SD-FDBK-INFRA-MEMORY-REINDEX-SCRIPTS-001).
+  if (env.CLAUDE_MEMORY_DIR) return env.CLAUDE_MEMORY_DIR;
+  const home = opts.home || env.HOME || env.USERPROFILE || '';
+  const cwd = opts.cwd || process.cwd();
+  // Claude Code encodes a project dir into its ~/.claude/projects/<slug> name by replacing EVERY
+  // non-alphanumeric character (the drive colon, path separators, AND underscores) with a single '-',
+  // preserving case and NOT collapsing consecutive hyphens. The prior code only replaced [\\/:], so an
+  // underscore segment like \_EHG\EHG_Engineer encoded to '-_EHG-EHG_Engineer' instead of the real
+  // '--EHG-EHG-Engineer' — the resolved dir never existed and reindex failed with missing_dir on this
+  // machine, forcing a fall back to hand-editing MEMORY.md. Verified live: the real dir for
+  // C:\Users\rickf\Projects\_EHG\EHG_Engineer is 'C--Users-rickf-Projects--EHG-EHG-Engineer'.
+  const encoded = cwd.replace(/[^a-zA-Z0-9]/g, '-');
+  return join(home, '.claude', 'projects', encoded, 'memory');
 }
 
 function buildIndexLine(filename, parsed) {

--- a/tests/memory/reindex.test.js
+++ b/tests/memory/reindex.test.js
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os';
 import { PassThrough } from 'node:stream';
 
 import { reindex, resolveMemoryDir } from '../../scripts/modules/memory/reindex.mjs';
-import { clusterByPrefix, buildTopicFilename, buildTopicContent } from '../../scripts/modules/memory/clustering.mjs';
+import { clusterByPrefix, buildTopicContent } from '../../scripts/modules/memory/clustering.mjs';
 
 const TARGET_BYTES = 15 * 1024;
 const MAX_LINE_CHARS = 120;

--- a/tests/memory/reindex.test.js
+++ b/tests/memory/reindex.test.js
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { PassThrough } from 'node:stream';
 
-import { reindex } from '../../scripts/modules/memory/reindex.mjs';
+import { reindex, resolveMemoryDir } from '../../scripts/modules/memory/reindex.mjs';
 import { clusterByPrefix, buildTopicFilename, buildTopicContent } from '../../scripts/modules/memory/clustering.mjs';
 
 const TARGET_BYTES = 15 * 1024;
@@ -194,5 +194,40 @@ describe('reindex.mjs', () => {
     const source = readFileSync(join(import.meta.url.replace('file://', '').replace(/^\/([A-Z]:)/, '$1').replace('tests/memory/reindex.test.js', 'scripts/modules/memory/reindex.mjs')), 'utf8');
     expect(source).toContain("from './frontmatter.js'");
     expect(source).toContain('parseMemoryFrontmatter');
+  });
+});
+
+// SD-FDBK-INFRA-MEMORY-REINDEX-SCRIPTS-001: the project-dir slug must match Claude Code's actual
+// encoding (every non-alphanumeric char -> '-', including underscores), not the old [\\/:]-only scheme.
+describe('resolveMemoryDir slug encoding', () => {
+  it('encodes the real EHG_Engineer path to the actual Claude Code slug (underscores -> hyphens)', () => {
+    const dir = resolveMemoryDir(undefined, {
+      cwd: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer',
+      home: 'C:\\Users\\rickf',
+      env: {},
+    });
+    // Real on-disk dir is C--Users-rickf-Projects--EHG-EHG-Engineer (double-hyphen before EHG, hyphen in EHG-Engineer).
+    expect(dir.replace(/\\/g, '/')).toBe('C:/Users/rickf/.claude/projects/C--Users-rickf-Projects--EHG-EHG-Engineer/memory');
+  });
+
+  it('does NOT leave underscores or single-hyphenate a leading-underscore segment (the bug)', () => {
+    const dir = resolveMemoryDir(undefined, { cwd: 'C:\\Users\\x\\Projects\\_EHG\\EHG_Engineer', home: '/h', env: {} });
+    expect(dir).not.toContain('_EHG');
+    expect(dir).not.toContain('EHG_Engineer');
+    expect(dir).toContain('--EHG-EHG-Engineer');
+  });
+
+  it('encodes a POSIX path (every non-alphanumeric -> hyphen)', () => {
+    const dir = resolveMemoryDir(undefined, { cwd: '/home/u/proj_a/sub.dir', home: '/home/u', env: {} });
+    expect(dir.replace(/\\/g, '/')).toBe('/home/u/.claude/projects/-home-u-proj-a-sub-dir/memory');
+  });
+
+  it('honors an explicit CLAUDE_MEMORY_DIR override', () => {
+    const dir = resolveMemoryDir(undefined, { cwd: '/anything', home: '/h', env: { CLAUDE_MEMORY_DIR: '/custom/mem' } });
+    expect(dir).toBe('/custom/mem');
+  });
+
+  it('an explicit arg still wins over everything', () => {
+    expect(resolveMemoryDir('/explicit/dir', { env: { CLAUDE_MEMORY_DIR: '/x' } })).toBe('/explicit/dir');
   });
 });


### PR DESCRIPTION
## Summary
`memory:reindex` resolved the wrong `~/.claude/projects/<slug>/memory` directory. `resolveMemoryDir` encoded the cwd with `/[\/:]/g -> '-'`, leaving **underscores intact**, so `C:\Users\rickf\Projects\_EHG\EHG_Engineer` became `C--Users-rickf-Projects-_EHG-EHG_Engineer` instead of Claude Code's real `C--Users-rickf-Projects--EHG-EHG-Engineer`. Reindex then failed with `missing_dir` on this machine and the fleet fell back to hand-editing `MEMORY.md` — the adoption gap #4962 flagged.

## Fix
- Encode with `/[^a-zA-Z0-9]/g -> '-'` (Claude Code's actual scheme: every non-alphanumeric char incl. underscores → `-`, case-preserving, no hyphen-collapsing).
- Add an explicit `CLAUDE_MEMORY_DIR` env override (robust escape hatch) + injectable `cwd/home/env`.
- Export `resolveMemoryDir` so the encoding is unit-tested.

## Tests
- 5 new slug-encoding tests (real EHG path → live slug, no-underscore invariant, POSIX path, env override, arg precedence). Full `tests/memory/reindex.test.js` passes (16); ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
