### PR TITLE
fix(SD-FDBK-INFRA-COORDINATOR-BACKLOG-RANK-001): clear stale dispatch_rank on terminal SDs

### DIFF
--- a/lib/coordinator/sd-exclusion.mjs
+++ b/lib/coordinator/sd-exclusion.mjs
@@ -129,3 +129,23 @@ export function bareShellLastCompare(a, b) {
   const bb = isBareShell(b) ? 1 : 0;
   return ba - bb; // authored (0) before bare-shell (1)
 }
+
+/**
+ * SD-FDBK-INFRA-COORDINATOR-BACKLOG-RANK-001: strip the dispatch-rank fields from an SD's metadata.
+ * Pure — returns { changed, meta }. `changed` is false (and `meta` is the original) when there is no
+ * dispatch_rank to clear, so callers can skip a no-op DB write. Used both for the clear-on-no-longer-
+ * claimable sweep and the new terminal-SD sweep: terminal rows are excluded from the ranker's
+ * non-terminal load, so a rank set while claimable then transitioned to terminal would otherwise
+ * linger forever (observed on cancelled REMEDIATION-UNIT-TEST-003/-004 stuck at dispatch_rank=2).
+ *
+ * @param {object|null|undefined} metadata
+ * @returns {{changed: boolean, meta: object|null|undefined}}
+ */
+export function stripDispatchRank(metadata) {
+  if (!metadata || metadata.dispatch_rank == null) return { changed: false, meta: metadata };
+  const meta = { ...metadata };
+  delete meta.dispatch_rank;
+  delete meta.dispatch_rank_at;
+  delete meta.dispatch_rank_by;
+  return { changed: true, meta };
+}

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -32,7 +32,7 @@ import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-
 // demotes bare-shell stubs. FIXTURE_RE catches epoch-stamped TEST-E2E keys; the
 // bare-shell demotion uses the shared bareShellLastCompare so the test suite
 // exercises the real comparator, not a re-implementation.
-import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd } from '../lib/coordinator/sd-exclusion.mjs';
+import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispatchRank } from '../lib/coordinator/sd-exclusion.mjs';
 // SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001: resolve dependency keys via the canonical
 // blocker rule (the same SSOT coordinator-audit.mjs imports) so the ranker and the capacity
 // forecaster AGREE on the 'no dependencies' sentinel ({sd_key:'none'} / bare 'none') and on
@@ -240,15 +240,32 @@ async function main() {
     const rankedNow = new Set(claimable.map(d => d.sd_key));
     for (const d of (sds || [])) {
       if (rankedNow.has(d.sd_key)) continue;
-      if (d.metadata && d.metadata.dispatch_rank != null) {
+      const { changed, meta } = stripDispatchRank(d.metadata);
+      if (!changed) continue;
+      try {
+        const { error: e } = await sb.from('strategic_directives_v2').update({ metadata: meta }).eq('sd_key', d.sd_key);
+        if (!e) clears++;
+      } catch { /* fail-soft */ }
+    }
+    // SD-FDBK-INFRA-COORDINATOR-BACKLOG-RANK-001: the loop above only sees the NON-TERMINAL load (the
+    // line-65 query excludes completed/cancelled/deferred), so a dispatch_rank set while an SD was
+    // claimable then transitioned to terminal lingers forever (observed: cancelled
+    // REMEDIATION-UNIT-TEST-003/-004 stuck at dispatch_rank=2). Sweep terminal SDs that still carry a
+    // rank and clear them. Fail-soft per row; a query error skips the sweep entirely.
+    try {
+      const { data: terminalRanked } = await sb.from('strategic_directives_v2')
+        .select('sd_key, metadata')
+        .in('status', ['completed', 'cancelled', 'deferred'])
+        .not('metadata->>dispatch_rank', 'is', null);
+      for (const d of (terminalRanked || [])) {
+        const { changed, meta } = stripDispatchRank(d.metadata);
+        if (!changed) continue;
         try {
-          const meta = { ...d.metadata };
-          delete meta.dispatch_rank; delete meta.dispatch_rank_at; delete meta.dispatch_rank_by;
           const { error: e } = await sb.from('strategic_directives_v2').update({ metadata: meta }).eq('sd_key', d.sd_key);
           if (!e) clears++;
-        } catch { /* fail-soft */ }
+        } catch { /* fail-soft per row */ }
       }
-    }
+    } catch { /* fail-soft: terminal-sweep query error never kills the pass */ }
   }
   console.log(`[BACKLOG-RANK] done — ${DRY ? 'no writes (dry-run)' : `${writes} rank(s) written, ${clears} stale rank(s) cleared`}`);
 }

--- a/tests/unit/coordinator-sd-exclusion.test.js
+++ b/tests/unit/coordinator-sd-exclusion.test.js
@@ -21,6 +21,7 @@ import {
   isExcludedFromBelt,
   bareShellLastCompare,
   isStartedSd,
+  stripDispatchRank,
   FIXTURE_RE,
 } from '../../lib/coordinator/sd-exclusion.mjs';
 
@@ -215,5 +216,36 @@ describe('production wiring guards (catch call-site deletion)', () => {
 
   it('the ranker SELECTs current_phase for the in-flight guard', () => {
     expect(rankerSrc).toMatch(/select\([^)]*current_phase/s);
+  });
+
+  // SD-FDBK-INFRA-COORDINATOR-BACKLOG-RANK-001: the ranker must sweep stale ranks off TERMINAL SDs too
+  // (they are excluded from the non-terminal load). Pin the terminal-sweep query + stripDispatchRank use.
+  it('the ranker sweeps terminal SDs for stale dispatch_rank', () => {
+    expect(rankerSrc).toMatch(/\.in\(\s*['"]status['"]\s*,\s*\[[^\]]*['"]cancelled['"][^\]]*\]/s);
+    expect(rankerSrc).toMatch(/metadata->>dispatch_rank/);
+    expect(rankerSrc).toMatch(/stripDispatchRank/);
+  });
+});
+
+describe('stripDispatchRank (SD-FDBK-INFRA-COORDINATOR-BACKLOG-RANK-001)', () => {
+  it('strips the three dispatch_rank fields and reports changed', () => {
+    const { changed, meta } = stripDispatchRank({ dispatch_rank: 2, dispatch_rank_at: 't', dispatch_rank_by: 'c', keep: 1 });
+    expect(changed).toBe(true);
+    expect(meta).toEqual({ keep: 1 });
+    expect('dispatch_rank' in meta).toBe(false);
+  });
+  it('no-op (changed:false) when there is no dispatch_rank', () => {
+    const md = { keep: 1 };
+    const r = stripDispatchRank(md);
+    expect(r.changed).toBe(false);
+    expect(r.meta).toBe(md); // returns the original object so the caller skips a no-op write
+  });
+  it('handles null/undefined metadata (changed:false, no throw)', () => {
+    expect(stripDispatchRank(null)).toEqual({ changed: false, meta: null });
+    expect(stripDispatchRank(undefined)).toEqual({ changed: false, meta: undefined });
+  });
+  it('treats dispatch_rank=0 as present (clears it)', () => {
+    // rank 0 is a valid rank; != null guard must not skip it
+    expect(stripDispatchRank({ dispatch_rank: 0 }).changed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
`coordinator-backlog-rank.mjs` left stale `metadata.dispatch_rank` on **terminal** SDs. Its main query excludes `completed/cancelled/deferred`, and the clear-stale loop iterates only that non-terminal set — so a rank set while an SD was claimable, then transitioned to terminal, lingered forever. A live read found **59** terminal SDs carrying stale ranks (incl. cancelled `REMEDIATION-UNIT-TEST-003/-004` at `dispatch_rank=2`).

## Premise correction (verify-the-premise)
The feedback also cited a phantom `ranked #1 ... SD-LEO-FIX-REMEDIATION-UNIT-TEST-005`. Verified against the live DB: **-005 does not exist** and the ranker can only emit keys from `claimable` (a subset of the loaded non-terminal set) — so the phantom is **not reproducible**. The real, live defect is the un-cleared terminal ranks.

## Fix
- Pure `stripDispatchRank(metadata)` helper in `lib/coordinator/sd-exclusion.mjs` (`{changed, meta}`; no-op returns the original so callers skip writes; treats `dispatch_rank=0` as present).
- Reused by the existing clear loop **and** a new **terminal-SD sweep**: queries `status in (completed,cancelled,deferred)` AND `metadata->>dispatch_rank not null`, clears each. Fail-soft per row + on the sweep query; dry-run-safe.

## Adversarial-verified
RCA live-confirmed the `metadata->>dispatch_rank` filter returns exactly the 59 stale rows (not 0, not all 4032 terminal), the sweep is inside `if (!DRY)`, and no legitimate terminal-with-rank case exists. The existing 59 get cleaned on the next coordinator tick post-merge.

## Tests
33/33 (`tests/unit/coordinator-sd-exclusion.test.js`): `stripDispatchRank` (strip/no-op/null/rank=0) + a source assertion pinning the terminal-sweep query. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
