### PR TITLE
feat(SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001): auto-emit /signal at the gate-2x threshold

### DIFF
--- a/lib/hooks/auto-signal-threshold.cjs
+++ b/lib/hooks/auto-signal-threshold.cjs
@@ -51,4 +51,40 @@ function buildAutoSignalArgs({ toolName, signature, attempts, sdKey } = {}) {
   return ['stuck', body, '--severity', 'high'];
 }
 
-module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs };
+/**
+ * SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001 (FR-1): the GATE-2x enforcement-site decision —
+ * the documented follow-up to the RCA-2x threshold above. Same safety contract: kill-switch, real-
+ * identity guard, fires EXACTLY ONCE on the 2nd gate-retry crossing (retryCount===2). The caller
+ * (the BaseExecutor gate-retry loop) fire-and-forget spawns worker-signal.cjs when this returns true.
+ * Workers under-escalate at gate recurrence because the threshold is prompt-advisory; moving the
+ * DETECTION into the handoff enforcement loop removes that discretion (mirrors SUBAGENT_EVIDENCE_MISSING).
+ *
+ * @param {{ retryCount:number, sessionId?:string, env?:object }} opts
+ * @returns {boolean}
+ */
+function shouldEmitGateAutoSignal({ retryCount, sessionId, env = process.env } = {}) {
+  if (env && env.LEO_AUTO_SIGNAL === 'off') return false;        // kill-switch
+  if (!sessionId || sessionId === 'unknown') return false;       // need a real worker identity
+  if (!Number.isInteger(retryCount)) return false;
+  return retryCount === 2;                                        // once, on the 2nd-retry crossing
+}
+
+/**
+ * Build the argv for the gate-2x /signal. Reuses the canonical worker-signal.cjs CLI. Type 'stuck'
+ * (the worker is stuck on a recurring gate failure — one retry from exhaustion); severity 'high'.
+ * Body is single-line + bounded.
+ *
+ * @param {{ gateName?:string, sdKey?:string, retryCount?:number }} opts
+ * @returns {string[]} argv after the script path (e.g. ['stuck', '<body>', '--severity', 'high'])
+ */
+function buildGateAutoSignalArgs({ gateName, sdKey, retryCount } = {}) {
+  const gate = String(gateName == null ? '' : gateName).replace(/\s+/g, ' ').slice(0, 80) || 'a gate';
+  const n = Number.isInteger(retryCount) ? retryCount : 2;
+  const body =
+    `AUTO-SIGNAL (enforcement-layer gate recurrence): gate "${gate}" failed ${n}x during handoff` +
+    `${sdKey ? ' (SD ' + sdKey + ')' : ''} — auto-retries near exhaustion. Auto-escalated per ` +
+    `SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001 (worker may be stuck on a failing gate).`;
+  return ['stuck', body, '--severity', 'high'];
+}
+
+module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs };

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -10,6 +10,7 @@ import { safeTruncate as _safeTruncate } from '../../../../lib/utils/safe-trunca
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+import { createRequire } from 'module';
 import { shouldSkipAndContinue, executeSkipAndContinue } from '../skip-and-continue.js';
 import { resolveRepoPath, ENGINEER_ROOT, isVentureRepo, resolveGateRepoContext } from '../../../../lib/repo-paths.js';
 // SD-LEO-FIX-HANDOFF-PIPELINE-GIT-001: Shared git context to eliminate redundant execSync calls
@@ -413,6 +414,30 @@ export class BaseExecutor {
             // Retry eligible — increment and loop
             currentRetryCount++;
             console.log(`\n   🔄 Gate retry ${currentRetryCount}/${maxGateRetries}: ${skipCheck.reason}`);
+            // SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001 (FR-1): auto-emit a /signal at the gate-2x
+            // crossing — enforcement-layer escalation mirroring the shipped RCA-2x wiring. Fire-and-forget
+            // (detached + unref), env-gated (LEO_AUTO_SIGNAL=off), wrapped fail-open: it can NEVER block,
+            // slow, or throw into the handoff. Removes worker discretion at the gate-recurrence threshold.
+            try {
+              const _req = createRequire(import.meta.url);
+              const { shouldEmitGateAutoSignal, buildGateAutoSignalArgs } =
+                _req(path.join(ENGINEER_ROOT, 'lib', 'hooks', 'auto-signal-threshold.cjs'));
+              const _sessionId = process.env.CLAUDE_SESSION_ID;
+              if (shouldEmitGateAutoSignal({ retryCount: currentRetryCount, sessionId: _sessionId, env: process.env })) {
+                const { spawn } = _req('child_process');
+                const _args = buildGateAutoSignalArgs({
+                  gateName: gateResults.failedGate,
+                  sdKey: sd?.sd_key || sd?.id,
+                  retryCount: currentRetryCount,
+                });
+                const _child = spawn(
+                  process.execPath,
+                  [path.join(ENGINEER_ROOT, 'scripts', 'worker-signal.cjs'), ..._args],
+                  { detached: true, stdio: 'ignore', env: { ...process.env, CLAUDE_SESSION_ID: _sessionId } }
+                );
+                _child.unref();
+              }
+            } catch { /* fail-open: auto-signal must never block the handoff */ }
             continue;
           }
         }

--- a/tests/unit/auto-signal-threshold.test.js
+++ b/tests/unit/auto-signal-threshold.test.js
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { shouldEmitAutoSignal, buildAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
+const { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
 
 const SID = '11111111-2222-4333-8444-555555555555';
 
@@ -66,5 +66,61 @@ describe('buildAutoSignalArgs (FR-1)', () => {
   it('omits the SD clause when no sdKey is known', () => {
     const args = buildAutoSignalArgs({ toolName: 'Bash', signature: 'sig', attempts: 2 });
     expect(args[1]).not.toContain('(SD ');
+  });
+});
+
+// SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001 (FR-1): the gate-2x enforcement-site decision.
+describe('shouldEmitGateAutoSignal (gate-2x)', () => {
+  it('fires exactly on the 2nd gate-retry crossing', () => {
+    expect(shouldEmitGateAutoSignal({ retryCount: 2, sessionId: SID, env: {} })).toBe(true);
+  });
+
+  it('does NOT fire on the 1st retry (no recurrence yet)', () => {
+    expect(shouldEmitGateAutoSignal({ retryCount: 1, sessionId: SID, env: {} })).toBe(false);
+  });
+
+  it('does NOT re-fire on the 3rd+ retry (dedupe — once per escalation)', () => {
+    expect(shouldEmitGateAutoSignal({ retryCount: 3, sessionId: SID, env: {} })).toBe(false);
+    expect(shouldEmitGateAutoSignal({ retryCount: 5, sessionId: SID, env: {} })).toBe(false);
+  });
+
+  it('respects the LEO_AUTO_SIGNAL=off kill-switch', () => {
+    expect(shouldEmitGateAutoSignal({ retryCount: 2, sessionId: SID, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
+  });
+
+  it('does not fire without a real session identity', () => {
+    expect(shouldEmitGateAutoSignal({ retryCount: 2, sessionId: undefined, env: {} })).toBe(false);
+    expect(shouldEmitGateAutoSignal({ retryCount: 2, sessionId: 'unknown', env: {} })).toBe(false);
+  });
+
+  it('ignores non-integer retryCount (fail-safe)', () => {
+    expect(shouldEmitGateAutoSignal({ retryCount: NaN, sessionId: SID, env: {} })).toBe(false);
+    expect(shouldEmitGateAutoSignal({ retryCount: undefined, sessionId: SID, env: {} })).toBe(false);
+  });
+});
+
+describe('buildGateAutoSignalArgs (gate-2x)', () => {
+  it('builds a stuck/high single-line body referencing the gate + SD', () => {
+    const args = buildGateAutoSignalArgs({ gateName: 'WIRE_CHECK_GATE', sdKey: 'SD-X-001', retryCount: 2 });
+    expect(args[0]).toBe('stuck');
+    expect(args).toContain('--severity');
+    expect(args[args.indexOf('--severity') + 1]).toBe('high');
+    const body = args[1];
+    expect(body).toContain('WIRE_CHECK_GATE');
+    expect(body).toContain('SD-X-001');
+    expect(body).toContain('SD-LEO-INFRA-SIGNAL-THRESHOLD-AUTO-EMIT-001');
+    expect(body).not.toContain('\n');
+  });
+
+  it('bounds a long/multi-line gate name and defaults a missing retryCount', () => {
+    const args = buildGateAutoSignalArgs({ gateName: 'g'.repeat(200) + '\n weird', sdKey: 'SD-Y' });
+    expect(args[1]).not.toContain('\n');
+    expect(args[1]).toContain('2x'); // retryCount defaults to 2
+  });
+
+  it('omits the SD clause when no sdKey is known and falls back to "a gate"', () => {
+    const args = buildGateAutoSignalArgs({ retryCount: 2 });
+    expect(args[1]).not.toContain('(SD ');
+    expect(args[1]).toContain('a gate');
   });
 });


### PR DESCRIPTION
## Summary
Workers under-escalate at the `/signal` recurrence thresholds because they're prompt-advisory. SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001 shipped the **RCA-2x** enforcement-layer auto-emit; this ships the documented **gate-2x** follow-up.

- **FR-1/FR-2:** new pure `shouldEmitGateAutoSignal({retryCount,sessionId,env})` (fires once on `retryCount===2`, kill-switch + real-identity guards) + `buildGateAutoSignalArgs` (`['stuck', body, '--severity','high']` referencing the failed gate + SD) in `lib/hooks/auto-signal-threshold.cjs`. Wired into the BaseExecutor gate-retry loop: at the 2nd gate-retry crossing, fire-and-forget spawn `worker-signal.cjs` (detached+unref, `CLAUDE_SESSION_ID` in env, `createRequire`+`ENGINEER_ROOT`), wrapped **fail-open** so it can never block/slow/throw into the handoff.
- **FR-3 (follow-up):** the **queued-work-release** site is deferred with a surfaced design question — it lives in the *sessionless* `stale-session-sweep`, yet `worker-signal.cjs` requires `CLAUDE_SESSION_ID` and the sweep already re-dispatches released work, so emitter-identity/redundancy needs a coordinator decision (raised via `/signal prd-ambiguous`).

## Tests
- 9 new unit tests (6 decision + 3 arg-builder) for the gate-2x functions; RCA-2x functions unchanged. `node --check` clean for both files; auto-signal suite 18/18.

## Note
The 2 ESLint `no-unused-vars` warnings on `BaseExecutor.js` (`execSync`, `ClaimIdentityError`) are **pre-existing** (unrelated to this change, already on main) — left untouched to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
