### PR TITLE
fix(SD-LEO-INFRA-EXEC-EMAIL-FORECAST-APPLY-001): persist the hourly build-completion forecast (--apply)

### DIFF
--- a/.github/workflows/adam-exec-email-cron.yml
+++ b/.github/workflows/adam-exec-email-cron.yml
@@ -146,10 +146,14 @@ jobs:
       # ETA stayed frozen and the FR-3 self-correction (needs >=2 rows) never accumulated. Same guard +
       # continue-on-error as the gauge step so a writer failure can NEVER block the chairman email; the
       # forecaster is itself fail-soft (records a degraded row rather than throwing).
+      # SD-LEO-INFRA-EXEC-EMAIL-FORECAST-APPLY-001: must use the :apply script — the bare
+      # vision:build-forecast runs DRY (build-completion-forecast.mjs persists ONLY with --apply,
+      # else returns {written:false,reason:dry_run}), so the un-freeze fix above was itself a no-op:
+      # every hourly run computed+printed but wrote NO row and the ETA stayed frozen.
       - name: Historize the build-completion forecast (advance the ETA + self-correction)
         if: steps.guard.outputs.should_send == 'true'
         continue-on-error: true
-        run: npm run vision:build-forecast
+        run: npm run vision:build-forecast:apply
 
       - name: Send chairman exec email (observe-only until ADAM_EMAIL_LIVE repo var = true)
         if: steps.guard.outputs.should_send == 'true'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "vision:seed-v2-autonomous-marketing": "node scripts/okr/seed-v2-autonomous-marketing-criteria.mjs",
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "vision:build-forecast": "node scripts/vision/build-completion-forecast.mjs",
+    "vision:build-forecast:apply": "node scripts/vision/build-completion-forecast.mjs --apply",
     "vision:rung-rollup": "node scripts/vision/rung-progress-rollup.mjs",
     "vision:rung-health": "node scripts/vision/rung-health-convergence.mjs",
     "vision:coherence": "node scripts/vision-coherence-check.mjs",

--- a/tests/unit/exec-email/exec-email-forecast-apply.test.js
+++ b/tests/unit/exec-email/exec-email-forecast-apply.test.js
@@ -1,0 +1,39 @@
+// SD-LEO-INFRA-EXEC-EMAIL-FORECAST-APPLY-001 — the hourly forecast-historize cron step must PERSIST a
+// row, not run dry. build-completion-forecast.mjs writes ONLY with --apply (else {written:false,
+// reason:dry_run}), so the cron must invoke the :apply npm script. Without this the un-freeze fix
+// (FROZEN-001) was a no-op: every run computed+printed but wrote no row → the chairman ETA stayed
+// frozen. This wiring test catches a regression that drops --apply / reverts to the bare script.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const YML = readFileSync(path.join(REPO_ROOT, '.github/workflows/adam-exec-email-cron.yml'), 'utf8');
+const PKG = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+const FORECASTER = readFileSync(path.join(REPO_ROOT, 'scripts/vision/build-completion-forecast.mjs'), 'utf8');
+
+describe('exec-email cron — forecast historize PERSISTS (not dry-run)', () => {
+  it('the forecast-historize step runs an --apply path (the :apply npm script)', () => {
+    expect(YML).toMatch(/run:\s*npm run vision:build-forecast:apply\b/);
+    // and NOT the bare dry-run script as the cron command
+    expect(YML).not.toMatch(/run:\s*npm run vision:build-forecast\s*$/m);
+  });
+
+  it('the :apply npm script passes --apply to the forecaster', () => {
+    expect(PKG.scripts['vision:build-forecast:apply']).toBeDefined();
+    expect(PKG.scripts['vision:build-forecast:apply']).toMatch(/build-completion-forecast\.mjs\s+--apply\b/);
+  });
+
+  it('the bare vision:build-forecast script stays DRY (no --apply) so manual runs do not persist', () => {
+    expect(PKG.scripts['vision:build-forecast']).toBeDefined();
+    expect(PKG.scripts['vision:build-forecast']).not.toMatch(/--apply/);
+  });
+
+  it('the forecaster genuinely gates persistence on --apply (the reason this matters)', () => {
+    // pins the contract the fix depends on: APPLY=args.includes('--apply') + dry_run short-circuit
+    expect(FORECASTER).toMatch(/APPLY\s*=\s*args\.includes\(\s*['"]--apply['"]\s*\)/);
+    expect(FORECASTER).toMatch(/dry_run/);
+  });
+});


### PR DESCRIPTION
## Summary
The frozen-forecast fix (`SD-LEO-INFRA-EXEC-EMAIL-FORECAST-FROZEN-001`) wired the build-completion forecaster into the hourly `adam-exec-email` cron, but the step ran `npm run vision:build-forecast` **without `--apply`**. `build-completion-forecast.mjs` persists **only** with `--apply` (`APPLY = args.includes('--apply')`; returns `{written:false, reason:dry_run}` otherwise), and the npm script had no `--apply` either — so every hourly run computed+printed but wrote **no row**. `build_completion_forecast_log` stayed at 1 stale row, the chairman exec email kept rendering the frozen `2026-07-16` ETA, and FR-3 self-correction (needs ≥2 rows) never accumulated. The un-freeze fix was itself a no-op (wired-to-fire-but-no-op, recursively).

## Fix
- Add `package.json` script `vision:build-forecast:apply` = `node scripts/vision/build-completion-forecast.mjs --apply`.
- Point the cron's *Historize the build-completion forecast* step at `npm run vision:build-forecast:apply`.
- The bare `vision:build-forecast` stays dry-run for safe manual invocation.

## Adversarial-verified (LIVE)
RCA confirmed end-to-end (not a second no-op): the cron's `env:` is **job-scoped** so the historize step inherits `SUPABASE_URL`/`SERVICE_ROLE_KEY` (same as the gauge step); a live `--apply` run wrote a row (count **1→2**) and FR-3 self-correction fired (signed error −0.96, EWMA cap 1→0.97). The historize step runs **after** the gauge step (fresh read). LOW follow-up: `build_completion_forecast_log` has no retention SSOT entry (hourly append) — flagged.

## Tests
9/9 (4 new `tests/unit/exec-email/exec-email-forecast-apply.test.js` + 5 existing cron-wiring regression): asserts the cron uses the `--apply` path, the `:apply` script passes `--apply`, the bare script stays dry, and the forecaster gates persistence on `--apply`. Rebased onto latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
