### PR TITLE
feat(SD-FDBK-INFRA-FLEET-SELF-CLAIM-001): surface cross-repo SD starvation in the coordinator charter-audit

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -10,6 +10,10 @@
 // momentarily unclaimed after a reap) is RESUMED via worker-checkin's resume_orphan path, never fresh-ranked, so
 // counting it claimable-needing-rank is a false DUTY-6 the named remediation (run backlog-rank) can never clear.
 import { isStartedSd } from './sd-exclusion.mjs';
+// SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: reuse the SAME claim-time repo-fitness the worker self-claim path
+// uses (lib/fleet/sd-executable-here.cjs), so the cross-repo-starvation verdict matches the skip exactly.
+// isSdExecutableHere(sd,{currentApp}) is filesystem-free when currentApp is supplied → keeps the detector pure.
+import { isSdExecutableHere } from '../fleet/sd-executable-here.cjs';
 
 const DAY_MS = 86400000;
 const SD_KEY_RE = /^(SD-[A-Z0-9][A-Z0-9_-]*)/i;
@@ -142,6 +146,61 @@ export function detectBacklogRankStaleness({ claimableSds = [], nowMs, ttlMs } =
     staleCount: stale.length,
     detail: violation ? `${stale.length} claimable SD(s) with no fresh dispatch_rank (>${Math.round(ttlMs / 60000)}m or absent)` : `none (${claimableSds.length} claimable, all freshly ranked)`,
     remediation: violation ? 'ACTION: run/re-arm coordinator-backlog-rank.mjs (the backlog-rank loop is stale)' : null,
+  };
+}
+
+/**
+ * CROSS-REPO STARVATION (SD-FDBK-INFRA-FLEET-SELF-CLAIM-001): a claimable SD whose target_application NO
+ * live worker checkout can execute silently starves — worker self-claim CORRECTLY skips it (a worker in the
+ * EHG_Engineer checkout cannot build a target_application=ehg SD), but when no live worker is in the right
+ * checkout it sits unclaimed at rank-1 indefinitely, invisible until a human/coordinator dispatches it.
+ * This makes that starvation VISIBLE for explicit dispatch (the worker skip stays correct — we never claim
+ * un-buildable work). An SD is STARVING when:
+ *   (a) it declares a target_application,
+ *   (b) NO app in liveSessionApps can execute it (isSdExecutableHere(sd,{currentApp}).fit === false for every
+ *       live app — the SAME fitness the self-claim path uses, so the verdict matches the skip exactly), AND
+ *   (c) it has sat unclaimed longer than minAgeMs (age from metadata.dispatch_rank_at || created_at).
+ * GUARD: with zero live apps we cannot assess cross-repo fitness (that is a no-fleet problem, not starvation)
+ * → never flag. Pure (currentApp keeps isSdExecutableHere filesystem-free); fail-open per SD.
+ *
+ * @param {{ claimableSds?: Array, liveSessionApps?: string[], nowMs?: number, minAgeMs?: number }} p
+ */
+export function detectCrossRepoStarvation({ claimableSds = [], liveSessionApps = [], nowMs = 0, minAgeMs = 12 * 60 * 1000 } = {}) {
+  const apps = Array.from(new Set((liveSessionApps || []).filter((a) => typeof a === 'string' && a)));
+  // No live fleet baseline → cannot distinguish cross-repo starvation from "no workers at all".
+  if (apps.length === 0) {
+    return { violation: false, starvingCount: 0, starving: [], detail: 'no live worker apps to assess cross-repo fitness', remediation: null };
+  }
+  const starving = [];
+  for (const sd of claimableSds) {
+    try {
+      if (!sd || !sd.target_application) continue; // repo-agnostic SD: executable anywhere, never starves
+      // Executable by ANY live app? (reuse the claim-time fitness; currentApp = filesystem-free)
+      const someAppFits = apps.some((app) => {
+        try { return isSdExecutableHere(sd, { currentApp: app }).fit === true; } catch { return true; /* fail-open: don't flag on a fitness fault */ }
+      });
+      if (someAppFits) continue;
+      // Aged? age from dispatch_rank_at (when it was put on the belt) else created_at.
+      const atRaw = (sd.metadata && sd.metadata.dispatch_rank_at) || sd.created_at;
+      const at = atRaw ? new Date(atRaw).getTime() : NaN;
+      const ageMs = Number.isFinite(at) ? (nowMs - at) : Infinity; // unknown age → treat as aged (it has clearly sat)
+      if (!(ageMs >= minAgeMs)) continue;
+      starving.push({ sd_key: sd.sd_key, target_application: sd.target_application, ageMs });
+    } catch { /* fail-open per SD: a fault never flags */ }
+  }
+  const violation = starving.length > 0;
+  const keys = starving.map((s) => s.sd_key).join(', ');
+  const targets = Array.from(new Set(starving.map((s) => s.target_application))).join(', ');
+  return {
+    violation,
+    starvingCount: starving.length,
+    starving,
+    detail: violation
+      ? `${starving.length} claimable SD(s) starving cross-repo (target_application=[${targets}]) — no live worker checkout (${apps.join(', ')}) can build them: ${keys}`
+      : `none (${claimableSds.length} claimable; live apps: ${apps.join(', ')})`,
+    remediation: violation
+      ? `ACTION: explicitly dispatch ${keys} to a [${targets}]-checkout worker (coordinator WORK_ASSIGNMENT), or spawn/route a worker in that checkout — no live worker can self-claim them.`
+      : null,
   };
 }
 

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -29,7 +29,7 @@ import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-fr
 import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
-  extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectProgressStall,
+  extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectProgressStall, detectCrossRepoStarvation,
   // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3): coordinator mirror detectors.
   detectSourceToCapacity, detectCoordinatorWithoutAdam,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
@@ -47,6 +47,9 @@ import { isDispatchableFleetMember } from '../lib/fleet/session-predicates.mjs';
 const require = createRequire(import.meta.url);
 const { isWithinArmedSilenceWindow } = require('../lib/fleet/silence-cap.cjs');
 const { classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
+// SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: appOfCwd derives a checkout's repo-app (it already strips a
+// /.worktrees/<sd> suffix) — used to map each live worker's worktree_path -> the app it can build.
+const { appOfCwd } = require('../lib/fleet/sd-executable-here.cjs');
 // SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001: reuse the CANONICAL stuck-worker staleness predicate for DUTY-8
 // (no re-derived staleness math → no drift with the stale-session-sweep). GUARDED like the PID resolver above:
 // a missing/broken detectors.cjs degrades detectStuckWorker to null → detectProgressStall fail-opens to a
@@ -88,7 +91,7 @@ async function main() {
 
   // ── FOUNDATIONAL queries — FAIL LOUD (never silent-empty / false all-clean) ──
   const { data: sdRows, error: sdErr } = await db.from('strategic_directives_v2')
-    .select('sd_key,status,current_phase,claiming_session_id,updated_at,created_at,vision_score,dependencies,parent_sd_id,metadata,sd_type')
+    .select('sd_key,status,current_phase,claiming_session_id,updated_at,created_at,vision_score,dependencies,parent_sd_id,metadata,sd_type,target_application')
     .not('status', 'in', '(' + [...TERMINAL].join(',') + ')');
   const sdMarker = foundationalQueryError(sdErr, 'strategic_directives_v2');
   if (sdMarker) { console.error(sdMarker); process.exit(1); }
@@ -96,7 +99,7 @@ async function main() {
 
   // Defense-in-depth: exclude lifecycle-terminated sessions server-side (classifyLiveness also guards this).
   const { data: sessRows, error: sessErr } = await db.from('claude_sessions')
-    .select('session_id,terminal_id,heartbeat_at,sd_key,loop_state,expected_silence_until,status,metadata')
+    .select('session_id,terminal_id,heartbeat_at,sd_key,loop_state,expected_silence_until,status,metadata,worktree_path')
     .not('status', 'in', '(released,stale,ended)')
     .order('heartbeat_at', { ascending: false }).limit(80);
   const sessMarker = foundationalQueryError(sessErr, 'claude_sessions');
@@ -114,6 +117,11 @@ async function main() {
   const coordinatorId = (sessions.find((s) => s.metadata && s.metadata.is_coordinator === true) || {}).session_id
     || process.env.CLAUDE_SESSION_ID || null;
   const liveWorkers = live.filter((s) => !(s.metadata && s.metadata.is_coordinator === true) && isDispatchableFleetMember(s, coordinatorId));
+  // SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: the set of repo-apps the live fleet can build (from each live
+  // worker's worktree_path checkout). A cross-repo SD whose target_application is absent from this set
+  // cannot be self-claimed by anyone → it starves until explicitly dispatched. Idle workers (no worktree)
+  // contribute no app; with zero apps the detector's GUARD declines to flag (no-fleet != cross-repo starve).
+  const liveSessionApps = Array.from(new Set((liveWorkers || []).map((s) => appOfCwd(s.worktree_path)).filter(Boolean)));
 
   // pending WORK_ASSIGNMENTs (unread => still pending; read_at-stamped => drained by the sweep, NOT pending)
   let pendingAssignmentSessionIds = new Set();
@@ -199,6 +207,8 @@ async function main() {
     idle: detectIdleWithWork({ liveSessions: liveWorkers, unclaimedCount: unclaimed.length, pendingAssignmentSessionIds, nowMs, isWithinArmedSilence: isWithinArmedSilenceWindow }),
     dep: detectDependencyHealth({ sds, statusByKey, terminalSet: TERMINAL, nowMs }),
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
+    // SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: cross-repo SDs no live worker checkout can build (silent starvation).
+    crossRepo: detectCrossRepoStarvation({ claimableSds: claimable, liveSessionApps, nowMs }),
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),
     // FR-3 coordinator mirror — added only when their facts resolved (skip-on-error, no spam).
     ...(adamAlive !== null ? { d3lean: detectCoordinatorWithoutAdam({ coordinatorAlive: true, adamAlive }) } : {}),
@@ -223,6 +233,7 @@ async function main() {
   console.log('  DUTY-4 DEPENDENCY    : ' + D.dep.detail + flag(D.dep));
   for (const a of D.dep.anomalies.slice(0, 5)) console.log('      ANOMALY ' + a.sd + ' dep(s) not found: ' + a.unknownDeps.join(','));
   console.log('  DUTY-6 BACKLOG-RANK  : ' + D.rank.detail + flag(D.rank));
+  console.log('  CROSS-REPO STARVATION: ' + D.crossRepo.detail + flag(D.crossRepo)); // FLEET-SELF-CLAIM-001
   console.log('  QUIET-TICK COMMITTED : ' + D.quiet.detail + flag(D.quiet));
   console.log('  DUTY-7 DRAFT-STALL   : ' + D.draft.detail + flag(D.draft)); // SILENT-STALL-PREVENTION-001
   console.log('  DUTY-8 PROGRESS-STALL: ' + D.progress.detail + flag(D.progress)); // PROGRESS-STALL-DETECTION-001

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -8,7 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
-  extractDepKey, resolveWorktreeCount, computeDispatchBelt,
+  extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectCrossRepoStarvation,
 } from '../../../lib/coordinator/charter-audit-detectors.mjs';
 import { STANDARD_LOOPS } from '../../../scripts/coordinator-startup-check.mjs';
 
@@ -256,5 +256,51 @@ describe('STANDARD_LOOPS — durable schedule (FR-6)', () => {
     expect(loop.script).toBe('coordinator-charter-audit.mjs');
     expect(loop.prompt).toMatch(/RE-RUN/i);
     expect(loop.prompt).toMatch(/CHARTER_AUDIT_VIOLATIONS=0/);
+  });
+});
+
+describe('detectCrossRepoStarvation (SD-FDBK-INFRA-FLEET-SELF-CLAIM-001)', () => {
+  const ehgSd = (over = {}) => ({ sd_key: 'SD-EHG-COCKPIT-VENTPERF-BUILD-001', target_application: 'ehg', priority: 'high', created_at: ago(30 * 60 * 1000), ...over });
+
+  it('flags a cross-repo SD that NO live worker checkout can build (the starvation case)', () => {
+    const r = detectCrossRepoStarvation({ claimableSds: [ehgSd()], liveSessionApps: ['EHG_Engineer'], nowMs: NOW });
+    expect(r.violation).toBe(true);
+    expect(r.starvingCount).toBe(1);
+    expect(r.starving[0].sd_key).toBe('SD-EHG-COCKPIT-VENTPERF-BUILD-001');
+    expect(r.remediation).toMatch(/explicitly dispatch/i);
+    expect(r.remediation).toMatch(/SD-EHG-COCKPIT-VENTPERF-BUILD-001/);
+  });
+
+  it('does NOT flag when a live worker checkout CAN build it (an ehg-checkout worker is live)', () => {
+    const r = detectCrossRepoStarvation({ claimableSds: [ehgSd()], liveSessionApps: ['EHG_Engineer', 'ehg'], nowMs: NOW });
+    expect(r.violation).toBe(false);
+    expect(r.starvingCount).toBe(0);
+  });
+
+  it('does NOT flag a repo-agnostic SD (no target_application — executable anywhere)', () => {
+    const sd = { sd_key: 'SD-LEO-INFRA-X-001', priority: 'high', created_at: ago(30 * 60 * 1000) };
+    const r = detectCrossRepoStarvation({ claimableSds: [sd], liveSessionApps: ['EHG_Engineer'], nowMs: NOW });
+    expect(r.violation).toBe(false);
+  });
+
+  it('does NOT flag a too-young cross-repo SD (still inside a brief window)', () => {
+    const r = detectCrossRepoStarvation({ claimableSds: [ehgSd({ created_at: ago(60 * 1000) })], liveSessionApps: ['EHG_Engineer'], nowMs: NOW, minAgeMs: 12 * 60 * 1000 });
+    expect(r.violation).toBe(false);
+  });
+
+  it('uses metadata.dispatch_rank_at for age when present (belt-arrival time)', () => {
+    const r = detectCrossRepoStarvation({ claimableSds: [ehgSd({ created_at: ago(1000), metadata: { dispatch_rank_at: ago(30 * 60 * 1000) } })], liveSessionApps: ['EHG_Engineer'], nowMs: NOW });
+    expect(r.violation).toBe(true);
+  });
+
+  it('GUARD: with zero live worker apps it never flags (no-fleet != cross-repo starvation)', () => {
+    const r = detectCrossRepoStarvation({ claimableSds: [ehgSd()], liveSessionApps: [], nowMs: NOW });
+    expect(r.violation).toBe(false);
+    expect(r.detail).toMatch(/no live worker apps/i);
+  });
+
+  it('empty claimable belt -> no violation', () => {
+    const r = detectCrossRepoStarvation({ claimableSds: [], liveSessionApps: ['EHG_Engineer'], nowMs: NOW });
+    expect(r.violation).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Worker self-claim is repo-aware by design: `scripts/worker-checkin.cjs` skips a candidate when `classifyDispatchIneligibility(...,{cwd})` returns `unfit_repo_mismatch` (via `lib/fleet/sd-executable-here.cjs`) — an EHG_Engineer-checkout worker **cannot build** a `target_application=ehg` (rickfelix/ehg) SD, so skipping it is **correct**. The defect is **silent starvation**: when no live worker is in an ehg checkout, a rank-1 HIGH cross-repo SD (e.g. `SD-EHG-COCKPIT-VENTPERF-BUILD-001`) is skipped by every worker and sits unclaimed 30+ min, invisible until a human/coordinator dispatches it manually.

## Fix — make it visible, don't make self-claim repo-agnostic
Making self-claim repo-agnostic would let a worker claim work it can't build. Instead, surface the starvation for explicit dispatch (the worker skip stays correct):
- **`lib/coordinator/charter-audit-detectors.mjs`**: new pure `detectCrossRepoStarvation`. An SD is STARVING when it declares a `target_application`, **no** live worker app can execute it (reuses the **same** `isSdExecutableHere` fitness as the self-claim path, so the verdict matches the skip exactly), and it has aged past `minAgeMs`. **GUARD**: zero live apps → never flag (no-fleet ≠ cross-repo starvation). Pure + fail-open per SD.
- **`scripts/coordinator-charter-audit.mjs`**: derive `liveSessionApps` via `appOfCwd(worktree_path)` (it already strips the `/.worktrees/<sd>` suffix → the repo-app), add `target_application`/`worktree_path` to the selects, add the `CROSS-REPO STARVATION` duty (auto-counted by `summarizeViolations`) with an explicit-dispatch remediation.

Worker self-claim is **unchanged**; no schema change.

## Tests
- `charter-audit-detectors.test.js` — 43/43 ✅ (7 new: starving / executable / repo-agnostic / too-young / `dispatch_rank_at` age / zero-apps guard / empty belt + 36 regression)
- `node --check` both files — OK
- **Live audit (read-only)**: renders `CROSS-REPO STARVATION:` deriving `live apps: ehgengineer` from real `worktree_path` — proving the duty is actually **wired/invoked**, not a shipped-but-unwired no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
