### PR TITLE
feat(SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A): wire invocation-detector CLI

### DIFF
--- a/lib/invocation-detector/index.js
+++ b/lib/invocation-detector/index.js
@@ -84,11 +84,61 @@ export function matchNpmScriptRefs(scriptPath, pkgScripts = {}, sourceFile = 'pa
 }
 
 /**
+ * Strip YAML comments (a `#` outside quotes to end-of-line) so a commented-out
+ * `# schedule:` / `# - cron:` never satisfies the scheduled check. Quote-aware so a `#` inside
+ * a quoted cron value is preserved. Pure.
+ */
+export function stripYamlComments(content) {
+  return String(content || '').split('\n').map((line) => {
+    let inS = false, inD = false, out = '';
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if (c === "'" && !inD) inS = !inS;
+      else if (c === '"' && !inS) inD = !inD;
+      if (c === '#' && !inS && !inD) break;
+      out += c;
+    }
+    return out;
+  }).join('\n');
+}
+
+/**
+ * Extract the `on:` trigger block (block or inline form), comment-stripped. Used to confine the
+ * schedule/cron check to the actual trigger declaration — NOT a `schedule`-named job or a
+ * commented line elsewhere in the file. Pure.
+ */
+export function extractOnTriggers(content) {
+  const lines = stripYamlComments(content).split('\n');
+  const i = lines.findIndex((l) => /^on:/.test(l));
+  if (i < 0) return '';
+  const inline = lines[i].slice(3).trim();
+  if (inline) return inline; // on: [push, schedule]  OR  on: push
+  const block = [];
+  for (let j = i + 1; j < lines.length; j++) {
+    if (/^\S/.test(lines[j])) break; // next top-level key ends the on: block
+    block.push(lines[j]);
+  }
+  return block.join('\n');
+}
+
+/**
+ * Is the workflow actually CRON-scheduled? schedule: + cron: must both live inside the `on:`
+ * block (comment-stripped). Pure. @returns {{scheduled:boolean, cron:string|null}}
+ */
+export function detectSchedule(content) {
+  const on = extractOnTriggers(content);
+  const scheduled = /\bschedule:/.test(on) && /\bcron:\s*['"]?[^'"\n#]+/.test(on);
+  const cronM = scheduled ? on.match(/\bcron:\s*['"]?([^'"\n#]+)/) : null;
+  return { scheduled, cron: cronM ? cronM[1].trim() : null };
+}
+
+/**
  * GHA_WORKFLOW matcher: does a workflow's `run:` step invoke this script (directly via
- * `node path` or indirectly via `npm run <name>` that maps to it), AND is the workflow
- * actually scheduled (`on: schedule: cron:`)? A scheduled-but-flag-gated workflow still
- * counts as INVOKED (the cron fires the script; the flag gates behaviour inside) — the flag
- * is reported, not used to deny invocation. Archived/dormant (no schedule) → not invoked. Pure.
+ * `node path` or indirectly via `npm run <name>`), AND is the workflow actually CRON-scheduled?
+ * A scheduled-but-flag-gated workflow still counts as scheduled (the cron fires the script; the
+ * flag gates behaviour inside — reported, not used to deny). Archived workflows and an explicit
+ * `if: github.event_name == '<non-schedule>'` step/job guard demote scheduled→false (conservative:
+ * a wire-check SSOT must avoid FALSE-POSITIVE invocation). Pure.
  *
  * @param {string} scriptPath
  * @param {{file:string, content:string}} workflow
@@ -100,38 +150,48 @@ export function matchGhaWorkflowRef(scriptPath, workflow, npmScriptIndex = {}) {
   const target = normalizeEntry(scriptPath);
   const file = normalizeEntry(workflow.file);
   if (file.includes('/archived/') || file.includes('/archive/')) return null;
-  const content = workflow.content;
+  const content = stripYamlComments(workflow.content);
 
-  // Collect every run: command (single-line and the first line of block scalars).
-  const runLines = [];
+  // Find the run: line that invokes the target (and its char offset, to inspect a step `if:` guard).
   const re = /\brun:\s*(?:[|>][+-]?\s*)?(.+)/g;
-  let m;
-  while ((m = re.exec(content)) !== null) runLines.push(m[1].trim());
-
-  let runLine = null;
-  for (const line of runLines) {
-    const nodeEntry = extractNodeEntry(line);
-    if (nodeEntry === target) { runLine = line; break; }
-    // `npm run <name>` indirection.
+  let m, runLine = null, runIdx = -1;
+  while ((m = re.exec(content)) !== null) {
+    const line = m[1].trim();
     const npm = line.match(/npm\s+run\s+([\w:.-]+)/);
-    if (npm && npmScriptIndex[npm[1]] && npmScriptIndex[npm[1]].entry === target) { runLine = line; break; }
+    if (extractNodeEntry(line) === target
+      || (npm && npmScriptIndex[npm[1]] && npmScriptIndex[npm[1]].entry === target)) {
+      runLine = line; runIdx = m.index; break;
+    }
   }
   if (!runLine) return null;
 
-  const scheduled = /^\s*on:|[\s{]on:/.test(content) && /\bschedule:/.test(content) && /\bcron:\s*['"]?([^'"\n]+)/.test(content);
-  const cronMatch = content.match(/\bcron:\s*['"]?([^'"\n]+)/);
-  const flagMatch = runLine.match(/\b([A-Z][A-Z0-9_]{4,})\b(?=.*(?:enable|true|gate))/i)
-    || content.match(/if:\s*[^\n]*vars\.([A-Z0-9_]+)/);
+  let { scheduled, cron } = detectSchedule(workflow.content);
+  const warnings = [];
+  // Step/job event guard: an `if:` referencing github.event_name in the ~800 chars preceding the
+  // run-line that excludes 'schedule' means the cron trigger does NOT reach this step.
+  if (scheduled) {
+    const before = content.slice(Math.max(0, runIdx - 800), runIdx);
+    const guard = before.match(/if:[^\n]*github\.event_name[^\n]*/g);
+    if (guard && guard.some((g) => !/schedule/.test(g))) {
+      scheduled = false;
+      warnings.push(`run-step is event-guarded (${guard[guard.length - 1].trim()}); cron may not reach it`);
+    }
+  }
+
+  // flag_gate: prefer a real GHA flag ref (vars./env./secrets.X), else an UPPER_SNAKE token in the
+  // run-line adjacent to enable/gate/flag. NO `i` flag — the [A-Z] anchor must stay uppercase.
+  let flagGate = null;
+  const varRef = content.match(/\b(?:vars|env|secrets)\.([A-Z][A-Z0-9_]{2,})\b/);
+  if (varRef) flagGate = varRef[1];
+  else {
+    const tok = runLine.match(/\b([A-Z][A-Z0-9_]{4,})\b/);
+    if (tok && /\b(enable|gate|flag)\b/i.test(runLine)) flagGate = tok[1];
+  }
 
   return {
     type: TRIGGER_TYPES.GHA_WORKFLOW,
     source_file: workflow.file,
-    evidence: {
-      run_line: runLine,
-      scheduled: !!scheduled,
-      cron: scheduled && cronMatch ? cronMatch[1].trim() : null,
-      flag_gate: flagMatch ? flagMatch[1] : null,
-    },
+    evidence: { run_line: runLine, scheduled, cron: scheduled ? cron : null, flag_gate: flagGate, warnings },
   };
 }
 
@@ -210,19 +270,26 @@ export function matchParentShellRef(scriptPath, parent) {
   // OR a literal '...scripts/x.cjs' arg passed to a child_process call.
   const base = target.split('/').pop();
   if (!content.includes(base)) return null;
+  const escBase = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const callRe = /\b(execSync|execFileSync|exec|spawnSync|spawn|fork)\s*\(/g;
   let m;
   while ((m = callRe.exec(content)) !== null) {
-    // Examine a window after the call site for a literal reference to the target path.
+    // Window after the call site, scanned GLOBALLY (a non-matching same-basename string earlier in
+    // the window must not mask the real one — MEDIUM-5). Accept BOTH the array-arg form
+    // ('scripts/x.cjs') AND the single-string form ('node scripts/x.cjs ...') via extractNodeEntry (MEDIUM-4).
     const window = content.slice(m.index, m.index + 400);
-    const litRe = new RegExp(`["'\`](?:\\$\\{[^}]+\\}/|\\./)?([^"'\`]*${base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})["'\`]`);
-    const lit = window.match(litRe);
-    if (lit && normalizeEntry(lit[1]) === target) {
-      return {
-        type: TRIGGER_TYPES.PARENT_SCRIPT_SHELL,
-        source_file: parent.file,
-        evidence: { invocation_call: m[1], child_script: target },
-      };
+    const litRe = new RegExp(`["'\`]([^"'\`]*${escBase}[^"'\`]*)["'\`]`, 'g');
+    let lit;
+    while ((lit = litRe.exec(window)) !== null) {
+      const raw = lit[1];
+      const direct = normalizeEntry(raw.replace(/^\$\{[^}]+\}\//, '').replace(/^\.\//, ''));
+      if (direct === target || extractNodeEntry(raw) === target) {
+        return {
+          type: TRIGGER_TYPES.PARENT_SCRIPT_SHELL,
+          source_file: parent.file,
+          evidence: { invocation_call: m[1], child_script: target },
+        };
+      }
     }
   }
   return null;

--- a/lib/invocation-detector/index.js
+++ b/lib/invocation-detector/index.js
@@ -1,0 +1,370 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Invocation-path detector (FOUNDATION) — SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A (FR-1).
+ *
+ * Given a script entry-point (e.g. "scripts/foo.cjs"), determine whether a LIVE production
+ * trigger actually references it: a scheduled GHA workflow `run:` step, an npm script, a
+ * registered+wired loop-contract, a .claude hook, or a parent script that shells it.
+ *
+ * KEY INVARIANT: invocation != reachability. Static reachability (the file is importable from
+ * an entry point) is NOT invocation. Only a concrete trigger reference counts. This module is
+ * the SSOT consumed by the classifier (-B) and the gate (-C).
+ *
+ * DESIGN: every matcher is PURE (string/array in → trigger|null out, no I/O), so the matching
+ * logic is fully unit-testable without a filesystem. `detectInvocationPath` is a thin pure
+ * assembler over injected trigger-source data; `loadTriggerSources(rootDir)` is the only I/O
+ * (separated so callers can inject fixtures). Mirrors the pure-core + injectable-seam pattern.
+ */
+
+export const TRIGGER_TYPES = Object.freeze({
+  GHA_WORKFLOW: 'GHA_WORKFLOW',
+  NPM_SCRIPT: 'NPM_SCRIPT',
+  LOOP_CONTRACT_REGISTRY: 'LOOP_CONTRACT_REGISTRY',
+  CLAUDE_HOOK: 'CLAUDE_HOOK',
+  PARENT_SCRIPT_SHELL: 'PARENT_SCRIPT_SHELL',
+});
+
+/**
+ * Canonicalize an entry-point path to a forward-slash, repo-relative, no-leading-`./` form so
+ * "scripts/foo.js", "./scripts/foo.js" and "C:\\repo\\scripts\\foo.js" (with rootDir) compare equal.
+ * Pure. @returns {string}
+ */
+export function normalizeEntry(p, rootDir = '') {
+  if (!p) return '';
+  let s = String(p).replace(/\\/g, '/').trim();
+  if (rootDir) {
+    const r = String(rootDir).replace(/\\/g, '/').replace(/\/+$/, '');
+    if (r && s.startsWith(r + '/')) s = s.slice(r.length + 1);
+  }
+  s = s.replace(/^\.\//, '').replace(/^\/+/, '');
+  return s;
+}
+
+/**
+ * Extract the script entry-point a shell command runs, if any: `node scripts/x.cjs --flag`,
+ * `node ${CLAUDE_PROJECT_DIR}/scripts/x.cjs`. Returns the normalized path or null. Pure.
+ */
+export function extractNodeEntry(command) {
+  if (!command) return null;
+  // node [flags] <path.(js|mjs|cjs)>  — tolerate ${VAR}/ prefixes and quotes.
+  const m = String(command).match(/node\s+(?:--[\w-]+(?:=\S+)?\s+)*["']?(?:\$\{[^}]+\}\/|\.\/)?([^\s"';&|]+\.(?:c|m)?js)\b/);
+  return m ? normalizeEntry(m[1]) : null;
+}
+
+/** Build a map of npm scriptName → normalized entry-point from a package.json scripts object. Pure. */
+export function indexNpmScripts(pkgScripts = {}) {
+  const byName = {};
+  for (const [name, cmd] of Object.entries(pkgScripts || {})) {
+    const entry = extractNodeEntry(cmd);
+    if (entry) byName[name] = { entry, command: cmd };
+  }
+  return byName;
+}
+
+/**
+ * NPM_SCRIPT matcher: does any package.json script invoke this entry-point? Pure.
+ * @returns {Array<{type, source_file, evidence}>}
+ */
+export function matchNpmScriptRefs(scriptPath, pkgScripts = {}, sourceFile = 'package.json') {
+  const target = normalizeEntry(scriptPath);
+  const idx = indexNpmScripts(pkgScripts);
+  const out = [];
+  for (const [name, { entry, command }] of Object.entries(idx)) {
+    if (entry === target) {
+      out.push({
+        type: TRIGGER_TYPES.NPM_SCRIPT,
+        source_file: sourceFile,
+        evidence: { script_name: name, command, extracted_entry: entry },
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * GHA_WORKFLOW matcher: does a workflow's `run:` step invoke this script (directly via
+ * `node path` or indirectly via `npm run <name>` that maps to it), AND is the workflow
+ * actually scheduled (`on: schedule: cron:`)? A scheduled-but-flag-gated workflow still
+ * counts as INVOKED (the cron fires the script; the flag gates behaviour inside) — the flag
+ * is reported, not used to deny invocation. Archived/dormant (no schedule) → not invoked. Pure.
+ *
+ * @param {string} scriptPath
+ * @param {{file:string, content:string}} workflow
+ * @param {Object} npmScriptIndex - output of indexNpmScripts (to resolve `npm run x`)
+ * @returns {{type, source_file, evidence}|null}
+ */
+export function matchGhaWorkflowRef(scriptPath, workflow, npmScriptIndex = {}) {
+  if (!workflow || !workflow.content) return null;
+  const target = normalizeEntry(scriptPath);
+  const file = normalizeEntry(workflow.file);
+  if (file.includes('/archived/') || file.includes('/archive/')) return null;
+  const content = workflow.content;
+
+  // Collect every run: command (single-line and the first line of block scalars).
+  const runLines = [];
+  const re = /\brun:\s*(?:[|>][+-]?\s*)?(.+)/g;
+  let m;
+  while ((m = re.exec(content)) !== null) runLines.push(m[1].trim());
+
+  let runLine = null;
+  for (const line of runLines) {
+    const nodeEntry = extractNodeEntry(line);
+    if (nodeEntry === target) { runLine = line; break; }
+    // `npm run <name>` indirection.
+    const npm = line.match(/npm\s+run\s+([\w:.-]+)/);
+    if (npm && npmScriptIndex[npm[1]] && npmScriptIndex[npm[1]].entry === target) { runLine = line; break; }
+  }
+  if (!runLine) return null;
+
+  const scheduled = /^\s*on:|[\s{]on:/.test(content) && /\bschedule:/.test(content) && /\bcron:\s*['"]?([^'"\n]+)/.test(content);
+  const cronMatch = content.match(/\bcron:\s*['"]?([^'"\n]+)/);
+  const flagMatch = runLine.match(/\b([A-Z][A-Z0-9_]{4,})\b(?=.*(?:enable|true|gate))/i)
+    || content.match(/if:\s*[^\n]*vars\.([A-Z0-9_]+)/);
+
+  return {
+    type: TRIGGER_TYPES.GHA_WORKFLOW,
+    source_file: workflow.file,
+    evidence: {
+      run_line: runLine,
+      scheduled: !!scheduled,
+      cron: scheduled && cronMatch ? cronMatch[1].trim() : null,
+      flag_gate: flagMatch ? flagMatch[1] : null,
+    },
+  };
+}
+
+/**
+ * CLAUDE_HOOK matcher: is this script wired as a hook command in .claude/settings.json?
+ * `settings` is the parsed JSON object. Walks every hooks.<Event>[].hooks[].command. Pure.
+ * @returns {Array<{type, source_file, evidence}>}
+ */
+export function matchHookRefs(scriptPath, settings = {}, sourceFile = '.claude/settings.json') {
+  const target = normalizeEntry(scriptPath);
+  const hooks = settings && settings.hooks;
+  if (!hooks || typeof hooks !== 'object') return [];
+  const out = [];
+  for (const [eventName, groups] of Object.entries(hooks)) {
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups) {
+      const inner = group && Array.isArray(group.hooks) ? group.hooks : [];
+      for (const h of inner) {
+        const entry = extractNodeEntry(h && h.command);
+        if (entry === target) {
+          out.push({
+            type: TRIGGER_TYPES.CLAUDE_HOOK,
+            source_file: sourceFile,
+            evidence: { hook_event: eventName, matcher: group.matcher || null, command: h.command },
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * LOOP_CONTRACT_REGISTRY matcher: a registry entry declares this script as a task entrypoint
+ * AND (registration != invocation) a scheduled workflow actually wires that entrypoint. Only
+ * then is_invoked=true. `loopContracts` is the LOOP_CONTRACTS array; `wiredEntrypoints` is the
+ * set/array of entrypoints proven live by a scheduled GHA workflow (from matchGhaWorkflowRef). Pure.
+ * @returns {{type, source_file, evidence}|null}
+ */
+export function matchLoopContractRef(scriptPath, loopContracts = [], wiredEntrypoints = [], sourceFile = 'lib/loops/loop-contract-registry.js') {
+  const target = normalizeEntry(scriptPath);
+  const wired = new Set((wiredEntrypoints || []).map((e) => normalizeEntry(e)));
+  for (const c of loopContracts || []) {
+    const tasks = (c && Array.isArray(c.tasks)) ? c.tasks : [];
+    const entryTask = tasks.find((t) => t && t.file && normalizeEntry(t.file) === target);
+    if (!entryTask) continue;
+    const flagTask = tasks.find((t) => t && t.task === 'flag' && t.key);
+    const isWired = wired.has(target);
+    return {
+      type: TRIGGER_TYPES.LOOP_CONTRACT_REGISTRY,
+      source_file: sourceFile,
+      evidence: {
+        loop_id: c.id || null,
+        declared_cadence: (c.timeline && c.timeline.cadence) || null,
+        declared_entrypoint: target,
+        is_invoked: isWired, // registry alone is DATA-ONLY; needs a live wired workflow
+        flag_gate: flagTask ? flagTask.key : null,
+      },
+    };
+  }
+  return null;
+}
+
+/**
+ * PARENT_SCRIPT_SHELL matcher: does another script shell this entry-point via
+ * execSync('node scripts/x')/spawnSync('node', ['scripts/x', ...])/a literal arg path? Pure.
+ * @param {{file:string, content:string}} parent
+ * @returns {{type, source_file, evidence}|null}
+ */
+export function matchParentShellRef(scriptPath, parent) {
+  if (!parent || !parent.content) return null;
+  const target = normalizeEntry(scriptPath);
+  if (normalizeEntry(parent.file) === target) return null; // don't self-reference
+  const content = parent.content;
+  // execSync('node scripts/x.cjs ...')  OR  spawnSync('node', ['scripts/x.cjs', ...])
+  // OR a literal '...scripts/x.cjs' arg passed to a child_process call.
+  const base = target.split('/').pop();
+  if (!content.includes(base)) return null;
+  const callRe = /\b(execSync|execFileSync|exec|spawnSync|spawn|fork)\s*\(/g;
+  let m;
+  while ((m = callRe.exec(content)) !== null) {
+    // Examine a window after the call site for a literal reference to the target path.
+    const window = content.slice(m.index, m.index + 400);
+    const litRe = new RegExp(`["'\`](?:\\$\\{[^}]+\\}/|\\./)?([^"'\`]*${base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})["'\`]`);
+    const lit = window.match(litRe);
+    if (lit && normalizeEntry(lit[1]) === target) {
+      return {
+        type: TRIGGER_TYPES.PARENT_SCRIPT_SHELL,
+        source_file: parent.file,
+        evidence: { invocation_call: m[1], child_script: target },
+      };
+    }
+  }
+  return null;
+}
+
+const EXCLUDED_RE = /(^|\/)(one-off|archive|archived|__tests__|node_modules)(\/|$)|(^|\/)_[^/]*$|\.(test|spec)\.[cm]?js$/i;
+
+/** Is this entry-point excluded by convention (one-off/archive/test)? Pure. */
+export function isExcludedEntry(scriptPath) {
+  return EXCLUDED_RE.test(normalizeEntry(scriptPath));
+}
+
+/**
+ * PURE assembler: given a script path and pre-loaded trigger sources, compute the invocation
+ * verdict. No I/O — callers inject `sources` (see loadTriggerSources for the live wiring).
+ *
+ * @param {string} scriptPath
+ * @param {{
+ *   pkgScripts?: Object,
+ *   workflows?: Array<{file,content}>,
+ *   settings?: Object,
+ *   loopContracts?: Array,
+ *   parentScripts?: Array<{file,content}>,
+ *   rootDir?: string,
+ * }} sources
+ * @returns {{invoked:boolean, triggers:Array, excluded:boolean, warnings:string[]}}
+ */
+export function detectInvocationPath(scriptPath, sources = {}) {
+  const warnings = [];
+  const target = normalizeEntry(scriptPath, sources.rootDir);
+  if (!target) return { invoked: false, triggers: [], excluded: false, warnings: ['empty scriptPath'] };
+
+  const npmIndex = indexNpmScripts(sources.pkgScripts || {});
+  const triggers = [];
+
+  // NPM scripts
+  triggers.push(...matchNpmScriptRefs(target, sources.pkgScripts || {}));
+
+  // GHA workflows (also yields the set of entrypoints proven live, for loop-contract wiring)
+  const wiredEntrypoints = [];
+  for (const wf of sources.workflows || []) {
+    const t = matchGhaWorkflowRef(target, wf, npmIndex);
+    if (t) {
+      triggers.push(t);
+      if (t.evidence.scheduled) wiredEntrypoints.push(target);
+    }
+  }
+
+  // Hooks
+  triggers.push(...matchHookRefs(target, sources.settings || {}));
+
+  // Loop-contract registry (needs a live wired workflow to count as invoked)
+  const lc = matchLoopContractRef(target, sources.loopContracts || [], wiredEntrypoints);
+  if (lc) triggers.push(lc);
+
+  // Parent-script shelling
+  for (const ps of sources.parentScripts || []) {
+    const t = matchParentShellRef(target, ps);
+    if (t) triggers.push(t);
+  }
+
+  // INVOCATION verdict: a trigger counts as live unless it is a registry-only entry whose
+  // workflow isn't wired, or a GHA run-ref in an UN-scheduled (dispatch-only) workflow.
+  const liveTriggers = triggers.filter((t) => {
+    if (t.type === TRIGGER_TYPES.LOOP_CONTRACT_REGISTRY) return t.evidence.is_invoked === true;
+    if (t.type === TRIGGER_TYPES.GHA_WORKFLOW) return t.evidence.scheduled === true;
+    return true; // npm script, hook, parent-shell are live references by their nature
+  });
+
+  return {
+    invoked: liveTriggers.length > 0,
+    triggers,
+    excluded: isExcludedEntry(target),
+    warnings,
+  };
+}
+
+// ───────────────────────── I/O boundary (the only impure part) ─────────────────────────
+
+function safeRead(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return null; }
+}
+
+function listFiles(dir, exts, acc = [], depth = 0) {
+  if (depth > 8) return acc;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === '.git') continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) listFiles(full, exts, acc, depth + 1);
+    else if (exts.some((x) => e.name.endsWith(x))) acc.push(full);
+  }
+  return acc;
+}
+
+/**
+ * Load the live trigger sources for a repo. This is the sole I/O; the pure assembler does the
+ * rest. `includeParentShell` (default true) scans `scriptDirs` for execSync/spawnSync refs —
+ * disable it for a fast metadata-only query. @returns {Promise<sources>}
+ */
+export async function loadTriggerSources(rootDir = process.cwd(), { includeParentShell = true, scriptDirs = ['scripts', 'lib'] } = {}) {
+  const root = rootDir.replace(/\\/g, '/').replace(/\/+$/, '');
+
+  let pkgScripts = {};
+  try { pkgScripts = JSON.parse(safeRead(path.join(root, 'package.json')) || '{}').scripts || {}; } catch { /* none */ }
+
+  let settings = {};
+  try { settings = JSON.parse(safeRead(path.join(root, '.claude', 'settings.json')) || '{}'); } catch { /* none */ }
+
+  const wfDir = path.join(root, '.github', 'workflows');
+  const workflows = listFiles(wfDir, ['.yml', '.yaml'])
+    .map((f) => ({ file: path.relative(root, f).replace(/\\/g, '/'), content: safeRead(f) || '' }));
+
+  let loopContracts = [];
+  try {
+    const mod = await import('file://' + path.join(root, 'lib', 'loops', 'loop-contract-registry.js').replace(/\\/g, '/'));
+    loopContracts = mod.LOOP_CONTRACTS || mod.default?.LOOP_CONTRACTS || mod.default || [];
+    if (!Array.isArray(loopContracts)) loopContracts = [];
+  } catch { /* registry optional */ }
+
+  let parentScripts = [];
+  if (includeParentShell) {
+    for (const d of scriptDirs) {
+      const files = listFiles(path.join(root, d), ['.js', '.cjs', '.mjs']);
+      for (const f of files) {
+        const content = safeRead(f);
+        if (content && /\b(execSync|execFileSync|spawnSync|spawn|fork|exec)\s*\(/.test(content)) {
+          parentScripts.push({ file: path.relative(root, f).replace(/\\/g, '/'), content });
+        }
+      }
+    }
+  }
+
+  return { pkgScripts, settings, workflows, loopContracts, parentScripts, rootDir: root };
+}
+
+/**
+ * Convenience: load the repo's trigger sources and run the detector. The live entry point the
+ * classifier (-B) and gate (-C) consume. @returns {Promise<verdict>}
+ */
+export async function detectInvocationPathFromRepo(scriptPath, rootDir = process.cwd(), opts = {}) {
+  const sources = await loadTriggerSources(rootDir, opts);
+  return detectInvocationPath(scriptPath, sources);
+}

--- a/package.json
+++ b/package.json
@@ -326,6 +326,7 @@
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
+    "invocation:check": "node scripts/invocation-check.mjs",
     "canary:sweep": "node scripts/canary-trigger-sweep.mjs",
     "ci:autotriage:loop": "node scripts/clockwork/ci-autotriage-loop.cjs",
     "prod-error-sweep": "node scripts/clockwork/prod-error-sweep-loop.cjs",

--- a/scripts/invocation-check.mjs
+++ b/scripts/invocation-check.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * CLI for the invocation-path detector (SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A, FR-1).
+ *
+ * Usage: node scripts/invocation-check.mjs <script-path> [--json] [--no-parent-shell]
+ *
+ * Prints whether a LIVE production trigger references the given script entry-point. This is also
+ * the foundation SSOT's own wiring: it makes lib/invocation-detector reachable+INVOKED (the very
+ * thing the detector checks for) instead of merely reachable-once -B/-C consume it. Exit code 0
+ * when invoked, 1 when NOT invoked (so CI/gates can `node scripts/invocation-check.mjs x || ...`).
+ */
+import { detectInvocationPathFromRepo } from '../lib/invocation-detector/index.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const includeParentShell = !args.includes('--no-parent-shell');
+  const scriptPath = args.find((a) => !a.startsWith('--'));
+
+  if (!scriptPath) {
+    console.error('Usage: node scripts/invocation-check.mjs <script-path> [--json] [--no-parent-shell]');
+    process.exit(2);
+  }
+
+  const result = await detectInvocationPathFromRepo(scriptPath, process.cwd(), { includeParentShell });
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`${result.invoked ? '✅ INVOKED' : '❌ NOT INVOKED'}: ${scriptPath}${result.excluded ? ' (excluded by convention)' : ''}`);
+    for (const t of result.triggers) {
+      const sched = t.evidence?.scheduled === false ? ' [not-scheduled]' : '';
+      console.log(`   • ${t.type} ← ${t.source_file}${sched}`);
+    }
+    if (!result.triggers.length) console.log('   (no production trigger references this entry-point)');
+  }
+
+  process.exit(result.invoked ? 0 : 1);
+}
+
+main().catch((e) => { console.error('invocation-check error:', e.message); process.exit(2); });

--- a/tests/unit/invocation-detector/adversarial-fixes.test.js
+++ b/tests/unit/invocation-detector/adversarial-fixes.test.js
@@ -1,0 +1,117 @@
+/**
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A — regression guards for the adversarial-review
+ * findings. A wire-check SSOT's worst failure is FALSE-POSITIVE invocation, so these pin the
+ * fixes for HIGH-1 (trigger-scoped schedule), HIGH-2 (commented schedule), MEDIUM-3 (flag_gate),
+ * MEDIUM-4 (execSync single-string), MEDIUM-5 (same-basename precedence).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  TRIGGER_TYPES,
+  matchGhaWorkflowRef,
+  matchParentShellRef,
+  stripYamlComments,
+  extractOnTriggers,
+  detectSchedule,
+} from '../../../lib/invocation-detector/index.js';
+
+describe('HIGH-2: commented-out schedule/cron must NOT read as scheduled', () => {
+  const wf = {
+    file: '.github/workflows/dormant.yml',
+    content: [
+      'on:',
+      '  workflow_dispatch:',
+      '  # schedule:',
+      "  #   - cron: '0 0 * * *'",
+      'jobs:',
+      '  j:',
+      '    steps:',
+      '      - run: node scripts/x.cjs',
+    ].join('\n'),
+  };
+  it('strips full-line comments so a dormant workflow is not invoked', () => {
+    const t = matchGhaWorkflowRef('scripts/x.cjs', wf);
+    expect(t.evidence.scheduled).toBe(false);
+    expect(t.evidence.cron).toBeNull();
+  });
+  it('stripYamlComments preserves a # inside a quoted value', () => {
+    expect(stripYamlComments("cron: '0 0 * * #'  # note")).toBe("cron: '0 0 * * #'  ");
+  });
+});
+
+describe('HIGH-1: schedule must be scoped to the on: block / not reach event-guarded steps', () => {
+  it('a `schedule`-named job key elsewhere does not count as a trigger', () => {
+    const wf = {
+      file: '.github/workflows/x.yml',
+      content: 'on:\n  push:\njobs:\n  schedule:\n    steps:\n      - run: node scripts/x.cjs --cron\n',
+    };
+    expect(detectSchedule(wf.content).scheduled).toBe(false);
+    expect(matchGhaWorkflowRef('scripts/x.cjs', wf).evidence.scheduled).toBe(false);
+  });
+  it('an explicit event-guard excluding schedule demotes scheduled→false with a warning', () => {
+    const wf = {
+      file: '.github/workflows/x.yml',
+      content: [
+        'on:',
+        '  push:',
+        '  schedule:',
+        "    - cron: '0 0 * * *'",
+        'jobs:',
+        '  j:',
+        '    steps:',
+        "      - if: github.event_name == 'push'",
+        '        run: node scripts/only-on-push.cjs',
+      ].join('\n'),
+    };
+    const t = matchGhaWorkflowRef('scripts/only-on-push.cjs', wf);
+    expect(t.evidence.scheduled).toBe(false);
+    expect(t.evidence.warnings.some((w) => /event-guarded/.test(w))).toBe(true);
+  });
+  it('a genuinely scheduled, UN-guarded step stays scheduled=true', () => {
+    const wf = {
+      file: '.github/workflows/x.yml',
+      content: "on:\n  push:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  j:\n    steps:\n      - run: node scripts/both.cjs\n",
+    };
+    expect(matchGhaWorkflowRef('scripts/both.cjs', wf).evidence.scheduled).toBe(true);
+  });
+});
+
+describe('MEDIUM-3: flag_gate must be a real ENV/UPPER_SNAKE token, not a lowercase word', () => {
+  it('does not match lowercase words like "please"/"enable"', () => {
+    const wf = {
+      file: '.github/workflows/x.yml',
+      content: "on:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  j:\n    steps:\n      - run: node scripts/x.cjs && echo please enable true\n",
+    };
+    expect(matchGhaWorkflowRef('scripts/x.cjs', wf).evidence.flag_gate).toBeNull();
+  });
+  it('extracts a real vars.X flag reference', () => {
+    const wf = {
+      file: '.github/workflows/x.yml',
+      content: "on:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  j:\n    if: vars.SWEEP_ENABLE == 'true'\n    steps:\n      - run: node scripts/x.cjs\n",
+    };
+    expect(matchGhaWorkflowRef('scripts/x.cjs', wf).evidence.flag_gate).toBe('SWEEP_ENABLE');
+  });
+});
+
+describe('MEDIUM-4: matchParentShellRef matches the execSync single-string form', () => {
+  it("execSync('node scripts/child.cjs') is detected", () => {
+    const parent = { file: 'scripts/runner.cjs', content: "execSync('node scripts/child.cjs --x', {});" };
+    const t = matchParentShellRef('scripts/child.cjs', parent);
+    expect(t).toMatchObject({ type: TRIGGER_TYPES.PARENT_SCRIPT_SHELL, evidence: { invocation_call: 'execSync' } });
+  });
+});
+
+describe('MEDIUM-5: a same-basename ref preceding the real one does not mask it', () => {
+  it('finds scripts/b/sweep.cjs even when scripts/a/sweep.cjs appears first in the window', () => {
+    const parent = { file: 'scripts/p.cjs', content: "spawnSync('node', ['scripts/a/sweep.cjs']); spawnSync('node', ['scripts/b/sweep.cjs']);" };
+    const t = matchParentShellRef('scripts/b/sweep.cjs', parent);
+    expect(t).not.toBeNull();
+    expect(t.evidence.child_script).toBe('scripts/b/sweep.cjs');
+  });
+});
+
+describe('helper: extractOnTriggers', () => {
+  it('returns inline and block trigger forms', () => {
+    expect(extractOnTriggers('on: [push, schedule]\njobs:\n').trim()).toBe('[push, schedule]');
+    expect(extractOnTriggers('on:\n  schedule:\n    - cron: "x"\njobs:\n')).toContain('schedule:');
+  });
+});

--- a/tests/unit/invocation-detector/index.test.js
+++ b/tests/unit/invocation-detector/index.test.js
@@ -1,0 +1,201 @@
+/**
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A (FR-1) — pure invocation-path detector.
+ * Tests the PURE matchers + assembler. Core invariant: invocation != reachability.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  TRIGGER_TYPES,
+  normalizeEntry,
+  extractNodeEntry,
+  indexNpmScripts,
+  matchNpmScriptRefs,
+  matchGhaWorkflowRef,
+  matchHookRefs,
+  matchLoopContractRef,
+  matchParentShellRef,
+  isExcludedEntry,
+  detectInvocationPath,
+} from '../../../lib/invocation-detector/index.js';
+
+describe('normalizeEntry', () => {
+  it('canonicalizes slashes, ./ prefix, and rootDir', () => {
+    expect(normalizeEntry('./scripts/foo.js')).toBe('scripts/foo.js');
+    expect(normalizeEntry('scripts\\foo.cjs')).toBe('scripts/foo.cjs');
+    expect(normalizeEntry('C:/repo/scripts/foo.js', 'C:/repo')).toBe('scripts/foo.js');
+    expect(normalizeEntry('C:\\repo\\scripts\\foo.js', 'C:\\repo')).toBe('scripts/foo.js');
+    expect(normalizeEntry('')).toBe('');
+  });
+});
+
+describe('extractNodeEntry', () => {
+  it('pulls the entry from node commands incl. flags, ${VAR}/ and quotes', () => {
+    expect(extractNodeEntry('node scripts/x.cjs --apply')).toBe('scripts/x.cjs');
+    expect(extractNodeEntry('node --enable-source-maps scripts/y.mjs')).toBe('scripts/y.mjs');
+    expect(extractNodeEntry('node ${CLAUDE_PROJECT_DIR}/scripts/hooks/h.cjs')).toBe('scripts/hooks/h.cjs');
+    expect(extractNodeEntry('npm run foo')).toBeNull();
+    expect(extractNodeEntry('gh run list')).toBeNull();
+  });
+});
+
+describe('matchNpmScriptRefs', () => {
+  const pkg = { 'adam:scan': 'node scripts/adam-opportunity-scan.cjs --scan', 'other': 'node scripts/z.js' };
+  it('matches the script whose command runs the target', () => {
+    const r = matchNpmScriptRefs('scripts/adam-opportunity-scan.cjs', pkg);
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({ type: TRIGGER_TYPES.NPM_SCRIPT, evidence: { script_name: 'adam:scan' } });
+  });
+  it('returns [] when no script references it', () => {
+    expect(matchNpmScriptRefs('scripts/nope.js', pkg)).toEqual([]);
+  });
+});
+
+describe('matchGhaWorkflowRef', () => {
+  const scheduledDirect = {
+    file: '.github/workflows/sweep.yml',
+    content: 'name: sweep\non:\n  schedule:\n    - cron: \'40 * * * *\'\njobs:\n  go:\n    steps:\n      - run: node scripts/clockwork/sweep.cjs --apply\n',
+  };
+  it('detects a scheduled workflow running the script directly (INVOKED)', () => {
+    const t = matchGhaWorkflowRef('scripts/clockwork/sweep.cjs', scheduledDirect);
+    expect(t).toMatchObject({ type: TRIGGER_TYPES.GHA_WORKFLOW, evidence: { scheduled: true, cron: '40 * * * *' } });
+  });
+  it('resolves an `npm run <name>` indirection to the entry-point', () => {
+    const wf = {
+      file: '.github/workflows/scan.yml',
+      content: 'on:\n  schedule:\n    - cron: \'37 * * * *\'\njobs:\n  s:\n    steps:\n      - run: npm run adam:scan || true\n',
+    };
+    const idx = indexNpmScripts({ 'adam:scan': 'node scripts/adam-opportunity-scan.cjs' });
+    const t = matchGhaWorkflowRef('scripts/adam-opportunity-scan.cjs', wf, idx);
+    expect(t.type).toBe(TRIGGER_TYPES.GHA_WORKFLOW);
+    expect(t.evidence.scheduled).toBe(true);
+  });
+  it('reports scheduled=false for a dispatch-only (un-scheduled) workflow', () => {
+    const wf = { file: '.github/workflows/manual.yml', content: 'on:\n  workflow_dispatch:\njobs:\n  m:\n    steps:\n      - run: node scripts/clockwork/sweep.cjs\n' };
+    const t = matchGhaWorkflowRef('scripts/clockwork/sweep.cjs', wf);
+    expect(t.evidence.scheduled).toBe(false);
+    expect(t.evidence.cron).toBeNull();
+  });
+  it('ignores archived workflows entirely', () => {
+    const wf = { ...scheduledDirect, file: '.github/workflows/archived/sweep.yml' };
+    expect(matchGhaWorkflowRef('scripts/clockwork/sweep.cjs', wf)).toBeNull();
+  });
+  it('returns null when the workflow does not reference the script', () => {
+    expect(matchGhaWorkflowRef('scripts/other.cjs', scheduledDirect)).toBeNull();
+  });
+});
+
+describe('matchHookRefs', () => {
+  const settings = {
+    hooks: {
+      SessionStart: [{ hooks: [{ type: 'command', command: 'node ${CLAUDE_PROJECT_DIR}/scripts/hooks/sync.cjs' }] }],
+      PostToolUse: [{ matcher: 'Bash', hooks: [{ command: 'node ${CLAUDE_PROJECT_DIR}/scripts/hooks/cap.cjs' }] }],
+    },
+  };
+  it('finds a hook command and reports event + matcher', () => {
+    const r = matchHookRefs('scripts/hooks/cap.cjs', settings);
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({ type: TRIGGER_TYPES.CLAUDE_HOOK, evidence: { hook_event: 'PostToolUse', matcher: 'Bash' } });
+  });
+  it('returns [] when not hooked', () => {
+    expect(matchHookRefs('scripts/hooks/none.cjs', settings)).toEqual([]);
+  });
+});
+
+describe('matchLoopContractRef — registration != invocation', () => {
+  const contracts = [{
+    id: 'LOOP-SWEEP-001',
+    timeline: { cadence: '40 * * * *' },
+    tasks: [{ task: 'entrypoint', file: 'scripts/clockwork/sweep.cjs' }, { task: 'flag', key: 'SWEEP_ENABLE', default: 'off' }],
+  }];
+  it('is_invoked=false when the registry entry exists but NO workflow wires it (DATA-ONLY)', () => {
+    const t = matchLoopContractRef('scripts/clockwork/sweep.cjs', contracts, []);
+    expect(t.evidence).toMatchObject({ loop_id: 'LOOP-SWEEP-001', is_invoked: false, flag_gate: 'SWEEP_ENABLE' });
+  });
+  it('is_invoked=true once a scheduled workflow wires the same entrypoint', () => {
+    const t = matchLoopContractRef('scripts/clockwork/sweep.cjs', contracts, ['scripts/clockwork/sweep.cjs']);
+    expect(t.evidence.is_invoked).toBe(true);
+  });
+  it('returns null when no contract declares the script', () => {
+    expect(matchLoopContractRef('scripts/x.cjs', contracts, [])).toBeNull();
+  });
+});
+
+describe('matchParentShellRef', () => {
+  it('detects spawnSync(node, [path]) and execSync(node path)', () => {
+    const parent = { file: 'scripts/runner.cjs', content: 'const r = spawnSync(\'node\', [\'scripts/child.cjs\', \'--x\'], {});' };
+    const t = matchParentShellRef('scripts/child.cjs', parent);
+    expect(t).toMatchObject({ type: TRIGGER_TYPES.PARENT_SCRIPT_SHELL, evidence: { invocation_call: 'spawnSync' } });
+  });
+  it('does not self-reference', () => {
+    const parent = { file: 'scripts/child.cjs', content: 'execSync(\'node scripts/child.cjs\')' };
+    expect(matchParentShellRef('scripts/child.cjs', parent)).toBeNull();
+  });
+  it('returns null when the basename is absent', () => {
+    expect(matchParentShellRef('scripts/child.cjs', { file: 'scripts/p.cjs', content: 'doNothing()' })).toBeNull();
+  });
+});
+
+describe('isExcludedEntry', () => {
+  it('excludes one-off/archive/test/underscore-prefixed', () => {
+    expect(isExcludedEntry('scripts/one-off/_probe.js')).toBe(true);
+    expect(isExcludedEntry('scripts/archive/202606/old.cjs')).toBe(true);
+    expect(isExcludedEntry('tests/unit/x.test.js')).toBe(true);
+    expect(isExcludedEntry('scripts/real.cjs')).toBe(false);
+  });
+});
+
+describe('detectInvocationPath — assembler + invocation!=reachability invariant', () => {
+  const sources = {
+    pkgScripts: { 'sweep': 'node scripts/clockwork/sweep.cjs --apply' },
+    workflows: [{
+      file: '.github/workflows/sweep.yml',
+      content: 'on:\n  schedule:\n    - cron: \'40 * * * *\'\njobs:\n  g:\n    steps:\n      - run: npm run sweep\n',
+    }],
+    settings: { hooks: {} },
+    loopContracts: [{ id: 'LOOP-SWEEP-001', timeline: { cadence: '40 * * * *' }, tasks: [{ task: 'entrypoint', file: 'scripts/clockwork/sweep.cjs' }] }],
+    parentScripts: [],
+  };
+
+  it('a scheduled+npm+wired-registry script is INVOKED with all three triggers', () => {
+    const r = detectInvocationPath('scripts/clockwork/sweep.cjs', sources);
+    expect(r.invoked).toBe(true);
+    const types = r.triggers.map((t) => t.type).sort();
+    expect(types).toContain(TRIGGER_TYPES.NPM_SCRIPT);
+    expect(types).toContain(TRIGGER_TYPES.GHA_WORKFLOW);
+    expect(types).toContain(TRIGGER_TYPES.LOOP_CONTRACT_REGISTRY);
+    const lc = r.triggers.find((t) => t.type === TRIGGER_TYPES.LOOP_CONTRACT_REGISTRY);
+    expect(lc.evidence.is_invoked).toBe(true); // wired by the scheduled workflow
+  });
+
+  it('REACHABILITY != INVOCATION: a registry-only script with NO scheduled workflow is NOT invoked', () => {
+    const dataOnly = {
+      pkgScripts: {},
+      workflows: [],
+      settings: { hooks: {} },
+      loopContracts: [{ id: 'LOOP-DORMANT-001', timeline: { cadence: '5 * * * *' }, tasks: [{ task: 'entrypoint', file: 'scripts/dormant.cjs' }] }],
+    };
+    const r = detectInvocationPath('scripts/dormant.cjs', dataOnly);
+    expect(r.invoked).toBe(false); // declared but never wired
+    expect(r.triggers).toHaveLength(1);
+    expect(r.triggers[0].evidence.is_invoked).toBe(false);
+  });
+
+  it('a dispatch-only workflow run-ref does NOT make a script invoked', () => {
+    const r = detectInvocationPath('scripts/manual.cjs', {
+      workflows: [{ file: '.github/workflows/m.yml', content: 'on:\n  workflow_dispatch:\njobs:\n  j:\n    steps:\n      - run: node scripts/manual.cjs\n' }],
+    });
+    expect(r.invoked).toBe(false);
+    expect(r.triggers[0].evidence.scheduled).toBe(false);
+  });
+
+  it('a totally orphan script is not invoked and yields no triggers', () => {
+    const r = detectInvocationPath('scripts/orphan.cjs', sources);
+    expect(r.invoked).toBe(false);
+    expect(r.triggers).toEqual([]);
+  });
+
+  it('flags excluded entries while still computing triggers', () => {
+    const r = detectInvocationPath('scripts/one-off/_x.js', { pkgScripts: {} });
+    expect(r.excluded).toBe(true);
+    expect(r.invoked).toBe(false);
+  });
+});

--- a/tests/unit/invocation-detector/repo-integration.test.js
+++ b/tests/unit/invocation-detector/repo-integration.test.js
@@ -1,0 +1,55 @@
+/**
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A (FR-1) — integration: run the detector against the
+ * REAL repo trigger sources to prove the I/O loader wires correctly (the detector must not
+ * itself be "reachable but never invoked").
+ */
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadTriggerSources, detectInvocationPath, TRIGGER_TYPES } from '../../../lib/invocation-detector/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..'); // worktree root
+
+describe('invocation-detector against the real repo', () => {
+  it('loads real trigger sources (package.json scripts, workflows, settings hooks)', async () => {
+    const sources = await loadTriggerSources(ROOT, { includeParentShell: false });
+    expect(Object.keys(sources.pkgScripts).length).toBeGreaterThan(0);
+    expect(Array.isArray(sources.workflows)).toBe(true);
+    expect(sources.settings && typeof sources.settings).toBe('object');
+  });
+
+  it('classifies a known .claude hook script as INVOKED (hook trigger present)', async () => {
+    const sources = await loadTriggerSources(ROOT, { includeParentShell: false });
+    // Find any hook command in the real settings.json and prove the detector flags it invoked.
+    const hooks = sources.settings.hooks || {};
+    let hookEntry = null;
+    for (const groups of Object.values(hooks)) {
+      for (const g of (Array.isArray(groups) ? groups : [])) {
+        for (const h of (g.hooks || [])) {
+          const m = (h.command || '').match(/\/((?:scripts|lib)\/[^\s"';]+\.[cm]?js)\b/);
+          if (m) { hookEntry = m[1]; break; }
+        }
+        if (hookEntry) break;
+      }
+      if (hookEntry) break;
+    }
+    expect(hookEntry, 'expected at least one hook command in settings.json').toBeTruthy();
+    const r = detectInvocationPath(hookEntry, sources);
+    expect(r.invoked).toBe(true);
+    expect(r.triggers.some((t) => t.type === TRIGGER_TYPES.CLAUDE_HOOK)).toBe(true);
+  });
+
+  it('classifies a non-existent orphan path as NOT invoked', async () => {
+    const sources = await loadTriggerSources(ROOT, { includeParentShell: false });
+    const r = detectInvocationPath('scripts/__definitely_not_wired_xyz__.cjs', sources);
+    expect(r.invoked).toBe(false);
+    expect(r.triggers).toEqual([]);
+  });
+
+  it('this detector module itself reports excluded=false and is a real lib entry', async () => {
+    const sources = await loadTriggerSources(ROOT, { includeParentShell: false });
+    const r = detectInvocationPath('lib/invocation-detector/index.js', sources);
+    expect(r.excluded).toBe(false); // it's a real SSOT, not a one-off/test
+  });
+});


### PR DESCRIPTION
Follow-up to PR #4981 (same SD): the detector module was reachable-but-unconsumed (its -B/-C consumers don't exist yet), so WIRE_CHECK_GATE flagged it unreachable — the exact reachable-vs-invoked tension this SD addresses. Adds `scripts/invocation-check.mjs` (real CLI entry-point) + npm `invocation:check` so the SSOT is AST-reachable and genuinely runnable (dogfood). CLI exit 0/1 = invoked/not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)