### PR TITLE
chore(SD-FDBK-INFRA-DECOMPOSE-PLAN-DEADLOCK-001): wire promote-orchestrator CLI into npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,6 +322,7 @@
     "sd:next": "node scripts/sd-next.js",
     "sd:cancel": "node scripts/cancel-sd.js",
     "sd:reactivate": "node scripts/reactivate-sd.js",
+    "sd:promote-orchestrator": "node scripts/promote-parent-to-orchestrator.js",
     "sd:park": "node scripts/sd-park.js park",
     "sd:unpark": "node scripts/sd-park.js unpark",
     "signal": "node scripts/worker-signal.cjs",


### PR DESCRIPTION
Follow-up to #4983: satisfies WIRE_CHECK_GATE by adding `npm run sd:promote-orchestrator` for the new CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)