### PR TITLE
feat(SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-B): requires-invocation classifier (FR-2)

### DIFF
--- a/lib/invocation-detector/requires-invocation.js
+++ b/lib/invocation-detector/requires-invocation.js
@@ -6,21 +6,28 @@
  * sub-agent helpers). Pairs with the FR-1 detector (./index.js): a VIOLATION is a script that
  * requires-invocation AND lacks an invocation path.
  *
- * CONSERVATIVE / FAIL-OPEN: the bad outcome is a FALSE violation (calling a library/helper
- * "needs a trigger" → the gate then flags it for a missing trigger it never needed). So we
- * default to requiresInvocation=FALSE and only return TRUE on a POSITIVE autonomous signal.
- * Pure (path/content/registry in → verdict out), so it is fully unit-testable.
+ * CONSERVATIVE / FAIL-OPEN: the bad outcome is a FALSE violation (calling a library/helper/
+ * manual-CLI "needs a trigger" → the gate then flags a missing trigger it never needed). So:
+ *   - negative gates (excluded/test/library) run FIRST and content-INDEPENDENTLY, and
+ *   - requiresInvocation=TRUE requires a GENUINE autonomous signal, never a bare filename
+ *     substring: a declared loop-contract entrypoint, a cron/clockwork directory, a
+ *     suffix-anchored -loop/-cron/-sweep/-daemon/-worker filename, or real in-code scheduling
+ *     semantics (setInterval / cron / --once / every-N / while(true)).
+ * False NEGATIVES (a real runner with an unconventional name not in cron/clockwork/registry) are
+ * the SAFE direction (no false violation) — by convention such runners belong in the
+ * loop-contract registry or a cron/clockwork dir, where they ARE caught. Pure.
  */
 import { isExcludedEntry, normalizeEntry } from './index.js';
 
-/** Filename/path tokens that denote an autonomously-scheduled runner. */
-const AUTONOMOUS_NAME_RE = /(?:^|[/-])(cron|loop|sweep|sweeper|reaper|monitor|scheduler|poller|heartbeat|watcher|populator|starter|dispatcher|forecaster|backfill|autotriage)(?:[-./]|$)/i;
-/** A script living under a cron/clockwork/loops directory is autonomous by location. */
-const AUTONOMOUS_DIR_RE = /(?:^|\/)(cron|clockwork|loops|schedulers?)\//i;
-/** Content signals that the script is meant to run autonomously on a schedule/tick. */
-const AUTONOMOUS_CONTENT_RE = /\b(cron|schedule[ds]?|setInterval|every\s+\d|--once\b|tick\b|autonomous|nightly|hourly|daily)\b/i;
-/** A runnable program: a top-level main()/IIFE or process.argv/exit usage (has a CLI surface). */
-const RUNNABLE_RE = /\b(process\.argv|process\.exit|#!.*node|async function main\b|function main\b|\.parse\(process\.argv|yargs|commander)\b/;
+/** Autonomous-by-LOCATION: cron/clockwork dirs hold scheduled runners (NOT lib/loops, a data dir). */
+const AUTONOMOUS_DIR_RE = /(?:^|\/)(?:cron|clockwork)\//i;
+/** Autonomous-by-SUFFIX: a filename ending in -loop/-cron/-sweep/-daemon/-worker (anchored, so a
+ *  'scroll-loop-helper' / 'action-dispatcher' substring does NOT match). */
+const AUTONOMOUS_SUFFIX_RE = /-(?:loop|cron|sweep|sweeper|daemon|worker|autotriage)\.[cm]?js$/i;
+/** Autonomous-by-CONTENT: real scheduling/tick semantics in code (not a comment word). */
+const SCHEDULE_CONTENT_RE = /\bsetInterval\s*\(|\bcron\b|--once\b|\bevery\s+\d+\s*(?:ms|s|m|min|mins|minutes|hours?|h)\b|while\s*\(\s*true\s*\)/i;
+/** A runnable program surface (shebang / main / argv). Used to corroborate the content path. */
+const RUNNABLE_RE = /#!.*node|\basync function main\b|\bfunction main\b|\bprocess\.argv\b|\.parse\(process\.argv/;
 
 const NOT_REQUIRED = Object.freeze({ requiresInvocation: false });
 
@@ -45,37 +52,39 @@ export function classifyRequiresInvocation(scriptPath, ctx = {}) {
   const target = normalizeEntry(scriptPath);
   const content = ctx.content || '';
 
-  // ── Negative gates first (conservative): things that NEVER need their own trigger. ──
+  // ── Negative gates first (conservative, content-INDEPENDENT). ──
   if (!target) return { ...NOT_REQUIRED, reason: 'empty path', confidence: 100 };
   if (isExcludedEntry(target)) return { ...NOT_REQUIRED, reason: 'excluded (one-off/archive/test)', confidence: 95 };
-  if (/\.(test|spec)\.[cm]?js$/.test(target) || /(^|\/)tests?\//.test(target)) {
+  if (/\.(test|spec)\.[cm]?js$/.test(target) || /(?:^|\/)tests?\//.test(target)) {
     return { ...NOT_REQUIRED, reason: 'test file', confidence: 95 };
   }
-  // A pure library module: under lib/ with no runnable surface (no shebang/main/argv). Libraries
-  // are reached via import from an entry point — they are never themselves triggered.
-  if (/^lib\//.test(target) && content && !RUNNABLE_RE.test(content)) {
-    return { ...NOT_REQUIRED, reason: 'library module (no runnable entry surface)', confidence: 85 };
-  }
 
-  // ── Positive autonomous signals → requires a live trigger. ──
+  // ── Strongest positive: an explicit loop-contract registry entry overrides location. ──
   if (isLoopContractEntrypoint(target, ctx.loopContracts)) {
     return { requiresInvocation: true, reason: 'declared loop-contract entrypoint', confidence: 95 };
   }
-  if (AUTONOMOUS_DIR_RE.test(target)) {
-    return { requiresInvocation: true, reason: 'lives under a cron/clockwork/loops dir', confidence: 90 };
-  }
-  if (AUTONOMOUS_NAME_RE.test(target)) {
-    // Strong if it also looks runnable; still TRUE on the name alone (the name asserts intent).
-    const runnable = !content || RUNNABLE_RE.test(content);
-    return { requiresInvocation: true, reason: 'autonomous-runner filename pattern', confidence: runnable ? 85 : 70 };
-  }
-  if (content && RUNNABLE_RE.test(content) && AUTONOMOUS_CONTENT_RE.test(content)) {
-    return { requiresInvocation: true, reason: 'runnable program with schedule/tick semantics', confidence: 75 };
+
+  // Libraries live under lib/ and are reached via import — never self-triggered (the registry
+  // case above already handled the rare lib-as-entrypoint). Content-independent → kills the
+  // path-only false-positive where an autonomous-NAMED lib file slipped past a content-gated check.
+  if (/^lib\//.test(target)) {
+    return { ...NOT_REQUIRED, reason: 'library module (import-reached, not self-triggered)', confidence: 85 };
   }
 
-  // ── Default: NOT required (conservative). A plain CLI tool, sub-agent helper, or a script
-  // with no autonomous signal is treated as manually/import-invoked → not a violation source. ──
-  return { ...NOT_REQUIRED, reason: 'no autonomous signal (treated as manual/library/helper)', confidence: 60 };
+  // ── Genuine autonomous signals (never a bare filename substring). ──
+  if (AUTONOMOUS_DIR_RE.test(target)) {
+    return { requiresInvocation: true, reason: 'lives under a cron/clockwork dir', confidence: 90 };
+  }
+  if (AUTONOMOUS_SUFFIX_RE.test(target)) {
+    return { requiresInvocation: true, reason: 'autonomous-runner filename suffix (-loop/-cron/-sweep/…)', confidence: 85 };
+  }
+  if (content && RUNNABLE_RE.test(content) && SCHEDULE_CONTENT_RE.test(content)) {
+    return { requiresInvocation: true, reason: 'runnable program with in-code scheduling semantics', confidence: 78 };
+  }
+
+  // ── Conservative default: a plain CLI tool, sub-agent helper, or autonomous-named-but-
+  // unconventional script with no genuine signal is treated as manual/import-invoked. ──
+  return { ...NOT_REQUIRED, reason: 'no genuine autonomous signal (treated as manual/library/helper)', confidence: 55 };
 }
 
 /**

--- a/lib/invocation-detector/requires-invocation.js
+++ b/lib/invocation-detector/requires-invocation.js
@@ -1,0 +1,96 @@
+/**
+ * Requires-invocation classifier (FR-2) — SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-B.
+ *
+ * Decide whether a script NEEDS a live production trigger (autonomous-runnable: crons, loops,
+ * sweeps, scheduled writers) versus NOT (libraries, test-only, one-off, manually-invoked CLIs,
+ * sub-agent helpers). Pairs with the FR-1 detector (./index.js): a VIOLATION is a script that
+ * requires-invocation AND lacks an invocation path.
+ *
+ * CONSERVATIVE / FAIL-OPEN: the bad outcome is a FALSE violation (calling a library/helper
+ * "needs a trigger" → the gate then flags it for a missing trigger it never needed). So we
+ * default to requiresInvocation=FALSE and only return TRUE on a POSITIVE autonomous signal.
+ * Pure (path/content/registry in → verdict out), so it is fully unit-testable.
+ */
+import { isExcludedEntry, normalizeEntry } from './index.js';
+
+/** Filename/path tokens that denote an autonomously-scheduled runner. */
+const AUTONOMOUS_NAME_RE = /(?:^|[/-])(cron|loop|sweep|sweeper|reaper|monitor|scheduler|poller|heartbeat|watcher|populator|starter|dispatcher|forecaster|backfill|autotriage)(?:[-./]|$)/i;
+/** A script living under a cron/clockwork/loops directory is autonomous by location. */
+const AUTONOMOUS_DIR_RE = /(?:^|\/)(cron|clockwork|loops|schedulers?)\//i;
+/** Content signals that the script is meant to run autonomously on a schedule/tick. */
+const AUTONOMOUS_CONTENT_RE = /\b(cron|schedule[ds]?|setInterval|every\s+\d|--once\b|tick\b|autonomous|nightly|hourly|daily)\b/i;
+/** A runnable program: a top-level main()/IIFE or process.argv/exit usage (has a CLI surface). */
+const RUNNABLE_RE = /\b(process\.argv|process\.exit|#!.*node|async function main\b|function main\b|\.parse\(process\.argv|yargs|commander)\b/;
+
+const NOT_REQUIRED = Object.freeze({ requiresInvocation: false });
+
+/**
+ * Is this a loop-contract entrypoint? Such a script is DECLARED to run on a cadence, so it
+ * unambiguously requires a live trigger. Pure.
+ */
+export function isLoopContractEntrypoint(scriptPath, loopContracts = []) {
+  const target = normalizeEntry(scriptPath);
+  return (loopContracts || []).some((c) =>
+    (c && Array.isArray(c.tasks) ? c.tasks : []).some((t) => t && t.file && normalizeEntry(t.file) === target));
+}
+
+/**
+ * Classify whether a script requires a live invocation trigger. Pure.
+ *
+ * @param {string} scriptPath
+ * @param {{content?: string, loopContracts?: Array}} [ctx]
+ * @returns {{requiresInvocation: boolean, reason: string, confidence: number}}
+ */
+export function classifyRequiresInvocation(scriptPath, ctx = {}) {
+  const target = normalizeEntry(scriptPath);
+  const content = ctx.content || '';
+
+  // ── Negative gates first (conservative): things that NEVER need their own trigger. ──
+  if (!target) return { ...NOT_REQUIRED, reason: 'empty path', confidence: 100 };
+  if (isExcludedEntry(target)) return { ...NOT_REQUIRED, reason: 'excluded (one-off/archive/test)', confidence: 95 };
+  if (/\.(test|spec)\.[cm]?js$/.test(target) || /(^|\/)tests?\//.test(target)) {
+    return { ...NOT_REQUIRED, reason: 'test file', confidence: 95 };
+  }
+  // A pure library module: under lib/ with no runnable surface (no shebang/main/argv). Libraries
+  // are reached via import from an entry point — they are never themselves triggered.
+  if (/^lib\//.test(target) && content && !RUNNABLE_RE.test(content)) {
+    return { ...NOT_REQUIRED, reason: 'library module (no runnable entry surface)', confidence: 85 };
+  }
+
+  // ── Positive autonomous signals → requires a live trigger. ──
+  if (isLoopContractEntrypoint(target, ctx.loopContracts)) {
+    return { requiresInvocation: true, reason: 'declared loop-contract entrypoint', confidence: 95 };
+  }
+  if (AUTONOMOUS_DIR_RE.test(target)) {
+    return { requiresInvocation: true, reason: 'lives under a cron/clockwork/loops dir', confidence: 90 };
+  }
+  if (AUTONOMOUS_NAME_RE.test(target)) {
+    // Strong if it also looks runnable; still TRUE on the name alone (the name asserts intent).
+    const runnable = !content || RUNNABLE_RE.test(content);
+    return { requiresInvocation: true, reason: 'autonomous-runner filename pattern', confidence: runnable ? 85 : 70 };
+  }
+  if (content && RUNNABLE_RE.test(content) && AUTONOMOUS_CONTENT_RE.test(content)) {
+    return { requiresInvocation: true, reason: 'runnable program with schedule/tick semantics', confidence: 75 };
+  }
+
+  // ── Default: NOT required (conservative). A plain CLI tool, sub-agent helper, or a script
+  // with no autonomous signal is treated as manually/import-invoked → not a violation source. ──
+  return { ...NOT_REQUIRED, reason: 'no autonomous signal (treated as manual/library/helper)', confidence: 60 };
+}
+
+/**
+ * Convenience pairing with the FR-1 detector: a script is a VIOLATION when it requires a live
+ * trigger but the detector found none. `invokedResult` is the {invoked,...} from
+ * detectInvocationPath. Pure. @returns {{violation:boolean, requires, reason}}
+ */
+export function isMissingInvocationViolation(scriptPath, invokedResult, ctx = {}) {
+  const requires = classifyRequiresInvocation(scriptPath, ctx);
+  const invoked = !!(invokedResult && invokedResult.invoked);
+  return {
+    violation: requires.requiresInvocation && !invoked,
+    requires,
+    reason: requires.requiresInvocation
+      ? (invoked ? 'requires + invoked → ok' : 'requires a live trigger but none found → VIOLATION')
+      : 'does not require a live trigger',
+  };
+}

--- a/scripts/invocation-check.mjs
+++ b/scripts/invocation-check.mjs
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 /**
- * CLI for the invocation-path detector (SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A, FR-1).
+ * CLI for the invocation-path detector (SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-A FR-1 + -B FR-2).
  *
- * Usage: node scripts/invocation-check.mjs <script-path> [--json] [--no-parent-shell]
+ * Usage: node scripts/invocation-check.mjs <script-path> [--json] [--no-parent-shell] [--violation]
  *
- * Prints whether a LIVE production trigger references the given script entry-point. This is also
- * the foundation SSOT's own wiring: it makes lib/invocation-detector reachable+INVOKED (the very
- * thing the detector checks for) instead of merely reachable-once -B/-C consume it. Exit code 0
- * when invoked, 1 when NOT invoked (so CI/gates can `node scripts/invocation-check.mjs x || ...`).
+ * Prints whether a LIVE production trigger references the given script entry-point (FR-1), and —
+ * with --violation — whether the script REQUIRES one and is missing it (FR-2, the WIRED-TO-FIRE
+ * violation). This is also the SSOTs' own wiring: it makes lib/invocation-detector (both modules)
+ * reachable+INVOKED instead of merely reachable-once -C consumes them. Exit 0 when invoked / no
+ * violation, 1 when NOT invoked (or --violation and it IS a violation).
  */
 import { detectInvocationPathFromRepo } from '../lib/invocation-detector/index.js';
+import { isMissingInvocationViolation } from '../lib/invocation-detector/requires-invocation.js';
 
 async function main() {
   const args = process.argv.slice(2);
@@ -22,10 +24,12 @@ async function main() {
     process.exit(2);
   }
 
+  const violationMode = args.includes('--violation');
   const result = await detectInvocationPathFromRepo(scriptPath, process.cwd(), { includeParentShell });
+  const verdict = violationMode ? isMissingInvocationViolation(scriptPath, result) : null;
 
   if (json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(violationMode ? { ...verdict, invoked: result.invoked, triggers: result.triggers } : result, null, 2));
   } else {
     console.log(`${result.invoked ? '✅ INVOKED' : '❌ NOT INVOKED'}: ${scriptPath}${result.excluded ? ' (excluded by convention)' : ''}`);
     for (const t of result.triggers) {
@@ -33,9 +37,15 @@ async function main() {
       console.log(`   • ${t.type} ← ${t.source_file}${sched}`);
     }
     if (!result.triggers.length) console.log('   (no production trigger references this entry-point)');
+    if (violationMode) {
+      console.log(verdict.violation
+        ? `   🚩 VIOLATION: requires a live trigger (${verdict.requires.reason}) but none found`
+        : `   ✓ no violation: ${verdict.reason}`);
+    }
   }
 
-  process.exit(result.invoked ? 0 : 1);
+  // Exit non-zero on a missing-invocation violation (--violation) or a plain not-invoked check.
+  process.exit((violationMode ? verdict.violation : !result.invoked) ? 1 : 0);
 }
 
 main().catch((e) => { console.error('invocation-check error:', e.message); process.exit(2); });

--- a/tests/unit/invocation-detector/requires-invocation.test.js
+++ b/tests/unit/invocation-detector/requires-invocation.test.js
@@ -1,7 +1,8 @@
 /**
  * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-B (FR-2) — requires-invocation classifier.
- * Conservative: default FALSE; only a positive autonomous signal returns TRUE (a false
- * "requires" would produce a false violation).
+ * Conservative: default FALSE; TRUE only on a GENUINE autonomous signal (registry / cron-dir /
+ * -loop suffix / in-code scheduling) — never a bare filename substring. The false-VIOLATION
+ * direction (a non-runner classified requires=true) is the worst failure and is pinned below.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -10,49 +11,64 @@ import {
   isMissingInvocationViolation,
 } from '../../../lib/invocation-detector/requires-invocation.js';
 
-describe('classifyRequiresInvocation — positive (autonomous) signals', () => {
+describe('classifyRequiresInvocation — positive (genuine autonomous) signals', () => {
   it('a script under scripts/cron/ requires a trigger', () => {
     const r = classifyRequiresInvocation('scripts/cron/leo-build-starter.mjs');
     expect(r.requiresInvocation).toBe(true);
-    expect(r.reason).toMatch(/cron\/clockwork\/loops dir/);
+    expect(r.reason).toMatch(/cron\/clockwork/);
   });
-  it('a clockwork loop file requires a trigger (dir + name)', () => {
+  it('a clockwork-dir loop file requires a trigger', () => {
     expect(classifyRequiresInvocation('scripts/clockwork/prod-error-sweep-loop.cjs').requiresInvocation).toBe(true);
   });
-  it('an autonomous-runner filename pattern requires a trigger', () => {
-    expect(classifyRequiresInvocation('scripts/worktree-reaper.mjs').requiresInvocation).toBe(true);
-    expect(classifyRequiresInvocation('scripts/adam-opportunity-scan-monitor.cjs').requiresInvocation).toBe(true);
+  it('a -loop / -sweep suffix filename requires a trigger (suffix-anchored)', () => {
+    expect(classifyRequiresInvocation('scripts/ci-autotriage-loop.cjs').requiresInvocation).toBe(true);
+    expect(classifyRequiresInvocation('scripts/error-sweep.mjs').requiresInvocation).toBe(true);
   });
-  it('a declared loop-contract entrypoint requires a trigger', () => {
+  it('a declared loop-contract entrypoint requires a trigger (overrides location)', () => {
     const contracts = [{ id: 'L1', tasks: [{ task: 'entrypoint', file: 'scripts/plain-name.cjs' }] }];
-    const r = classifyRequiresInvocation('scripts/plain-name.cjs', { loopContracts: contracts });
-    expect(r.requiresInvocation).toBe(true);
-    expect(r.reason).toMatch(/loop-contract/);
+    expect(classifyRequiresInvocation('scripts/plain-name.cjs', { loopContracts: contracts }).requiresInvocation).toBe(true);
   });
-  it('a runnable program with schedule/tick semantics in content requires a trigger', () => {
-    const content = '#!/usr/bin/env node\nasync function main(){ /* runs every hour */ setInterval(()=>{}, 3600000); }\nmain();';
+  it('a runnable program with in-code scheduling semantics requires a trigger', () => {
+    const content = '#!/usr/bin/env node\nasync function main(){ setInterval(()=>{}, 3600000); }\nmain();';
     expect(classifyRequiresInvocation('scripts/some-runner.mjs', { content }).requiresInvocation).toBe(true);
   });
 });
 
-describe('classifyRequiresInvocation — negative (conservative) signals', () => {
+describe('classifyRequiresInvocation — conservative FALSE (no false violations)', () => {
   it('a test file never requires a trigger', () => {
     expect(classifyRequiresInvocation('tests/unit/x.test.js').requiresInvocation).toBe(false);
     expect(classifyRequiresInvocation('scripts/foo.spec.cjs').requiresInvocation).toBe(false);
   });
-  it('a one-off / archived script never requires a trigger', () => {
+  it('one-off / archived scripts never require a trigger', () => {
     expect(classifyRequiresInvocation('scripts/one-off/_probe.js').requiresInvocation).toBe(false);
     expect(classifyRequiresInvocation('scripts/archive/old.cjs').requiresInvocation).toBe(false);
   });
-  it('a pure library module (lib/, no runnable surface) never requires a trigger', () => {
-    const r = classifyRequiresInvocation('lib/invocation-detector/index.js', { content: 'export function f(){}\nexport const X=1;' });
-    expect(r.requiresInvocation).toBe(false);
-    expect(r.reason).toMatch(/library/);
+  it('ANY lib/ module is not required — content-independent (adversarial HIGH-1)', () => {
+    expect(classifyRequiresInvocation('lib/invocation-detector/index.js').requiresInvocation).toBe(false);
+    // path-only (no content) autonomous-NAMED lib files must STILL be false:
+    expect(classifyRequiresInvocation('lib/ui/scroll-loop-helper.js').requiresInvocation).toBe(false);
+    expect(classifyRequiresInvocation('lib/state/action-dispatcher.js').requiresInvocation).toBe(false);
+    expect(classifyRequiresInvocation('lib/perf/performance-monitor-lib.js').requiresInvocation).toBe(false);
   });
-  it('a plain manually-invoked CLI with NO autonomous signal defaults to NOT required', () => {
-    const content = '#!/usr/bin/env node\nasync function main(){ console.log("does a one-shot thing"); }\nmain();';
-    const r = classifyRequiresInvocation('scripts/print-report.mjs', { content });
-    expect(r.requiresInvocation).toBe(false); // conservative: no cron/loop/sweep signal
+  it('the loop-contract REGISTRY (a data file under lib/loops) is NOT required (adversarial MED-1)', () => {
+    expect(classifyRequiresInvocation('lib/loops/loop-contract-registry.js').requiresInvocation).toBe(false);
+  });
+  it('manual CLIs with autonomous-ish substrings but no genuine signal are NOT required (adversarial HIGH-2)', () => {
+    const main = 'async function main(){ console.log("one shot"); }\nmain();';
+    for (const p of [
+      'scripts/cache-populator.js',
+      'scripts/db-monitor.js',
+      'scripts/queue-dispatcher.js',
+      'scripts/release-reaper.js',
+      'scripts/event-loop-util.js',
+      'scripts/app-starter.mjs',
+    ]) {
+      expect(classifyRequiresInvocation(p, { content: main }).requiresInvocation, p).toBe(false);
+    }
+  });
+  it('a plain runnable CLI with no scheduling semantics defaults to FALSE', () => {
+    const content = '#!/usr/bin/env node\nasync function main(){ console.log("report"); }\nmain();';
+    expect(classifyRequiresInvocation('scripts/print-report.mjs', { content }).requiresInvocation).toBe(false);
   });
   it('empty path is not required', () => {
     expect(classifyRequiresInvocation('').requiresInvocation).toBe(false);
@@ -74,16 +90,14 @@ describe('isMissingInvocationViolation — pairs FR-2 with FR-1', () => {
     expect(v.reason).toMatch(/VIOLATION/);
   });
   it('requires + invoked → not a violation', () => {
-    const v = isMissingInvocationViolation('scripts/cron/live-loop.mjs', { invoked: true });
-    expect(v.violation).toBe(false);
+    expect(isMissingInvocationViolation('scripts/cron/live-loop.mjs', { invoked: true }).violation).toBe(false);
   });
-  it('does-not-require (library) → never a violation even when not invoked', () => {
+  it('a library is never a violation even when not invoked', () => {
     const v = isMissingInvocationViolation('lib/util.js', { invoked: false }, { content: 'export const a=1;' });
     expect(v.violation).toBe(false);
     expect(v.reason).toMatch(/does not require/);
   });
-  it('a manually-invoked CLI with no trigger is NOT a violation (conservative)', () => {
-    const v = isMissingInvocationViolation('scripts/one-shot-tool.mjs', { invoked: false }, { content: 'async function main(){}\nmain();' });
-    expect(v.violation).toBe(false);
+  it('a manual CLI with an autonomous-ish name is NOT a violation (conservative)', () => {
+    expect(isMissingInvocationViolation('scripts/cache-populator.js', { invoked: false }, { content: 'async function main(){}\nmain();' }).violation).toBe(false);
   });
 });

--- a/tests/unit/invocation-detector/requires-invocation.test.js
+++ b/tests/unit/invocation-detector/requires-invocation.test.js
@@ -1,0 +1,89 @@
+/**
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-B (FR-2) — requires-invocation classifier.
+ * Conservative: default FALSE; only a positive autonomous signal returns TRUE (a false
+ * "requires" would produce a false violation).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifyRequiresInvocation,
+  isLoopContractEntrypoint,
+  isMissingInvocationViolation,
+} from '../../../lib/invocation-detector/requires-invocation.js';
+
+describe('classifyRequiresInvocation — positive (autonomous) signals', () => {
+  it('a script under scripts/cron/ requires a trigger', () => {
+    const r = classifyRequiresInvocation('scripts/cron/leo-build-starter.mjs');
+    expect(r.requiresInvocation).toBe(true);
+    expect(r.reason).toMatch(/cron\/clockwork\/loops dir/);
+  });
+  it('a clockwork loop file requires a trigger (dir + name)', () => {
+    expect(classifyRequiresInvocation('scripts/clockwork/prod-error-sweep-loop.cjs').requiresInvocation).toBe(true);
+  });
+  it('an autonomous-runner filename pattern requires a trigger', () => {
+    expect(classifyRequiresInvocation('scripts/worktree-reaper.mjs').requiresInvocation).toBe(true);
+    expect(classifyRequiresInvocation('scripts/adam-opportunity-scan-monitor.cjs').requiresInvocation).toBe(true);
+  });
+  it('a declared loop-contract entrypoint requires a trigger', () => {
+    const contracts = [{ id: 'L1', tasks: [{ task: 'entrypoint', file: 'scripts/plain-name.cjs' }] }];
+    const r = classifyRequiresInvocation('scripts/plain-name.cjs', { loopContracts: contracts });
+    expect(r.requiresInvocation).toBe(true);
+    expect(r.reason).toMatch(/loop-contract/);
+  });
+  it('a runnable program with schedule/tick semantics in content requires a trigger', () => {
+    const content = '#!/usr/bin/env node\nasync function main(){ /* runs every hour */ setInterval(()=>{}, 3600000); }\nmain();';
+    expect(classifyRequiresInvocation('scripts/some-runner.mjs', { content }).requiresInvocation).toBe(true);
+  });
+});
+
+describe('classifyRequiresInvocation — negative (conservative) signals', () => {
+  it('a test file never requires a trigger', () => {
+    expect(classifyRequiresInvocation('tests/unit/x.test.js').requiresInvocation).toBe(false);
+    expect(classifyRequiresInvocation('scripts/foo.spec.cjs').requiresInvocation).toBe(false);
+  });
+  it('a one-off / archived script never requires a trigger', () => {
+    expect(classifyRequiresInvocation('scripts/one-off/_probe.js').requiresInvocation).toBe(false);
+    expect(classifyRequiresInvocation('scripts/archive/old.cjs').requiresInvocation).toBe(false);
+  });
+  it('a pure library module (lib/, no runnable surface) never requires a trigger', () => {
+    const r = classifyRequiresInvocation('lib/invocation-detector/index.js', { content: 'export function f(){}\nexport const X=1;' });
+    expect(r.requiresInvocation).toBe(false);
+    expect(r.reason).toMatch(/library/);
+  });
+  it('a plain manually-invoked CLI with NO autonomous signal defaults to NOT required', () => {
+    const content = '#!/usr/bin/env node\nasync function main(){ console.log("does a one-shot thing"); }\nmain();';
+    const r = classifyRequiresInvocation('scripts/print-report.mjs', { content });
+    expect(r.requiresInvocation).toBe(false); // conservative: no cron/loop/sweep signal
+  });
+  it('empty path is not required', () => {
+    expect(classifyRequiresInvocation('').requiresInvocation).toBe(false);
+  });
+});
+
+describe('isLoopContractEntrypoint', () => {
+  const contracts = [{ id: 'L1', tasks: [{ task: 'entrypoint', file: 'scripts/x.cjs' }, { task: 'flag', key: 'K' }] }];
+  it('matches a declared entrypoint and ignores non-entrypoint tasks', () => {
+    expect(isLoopContractEntrypoint('scripts/x.cjs', contracts)).toBe(true);
+    expect(isLoopContractEntrypoint('scripts/y.cjs', contracts)).toBe(false);
+  });
+});
+
+describe('isMissingInvocationViolation — pairs FR-2 with FR-1', () => {
+  it('requires + NOT invoked → VIOLATION', () => {
+    const v = isMissingInvocationViolation('scripts/cron/dead-loop.mjs', { invoked: false });
+    expect(v.violation).toBe(true);
+    expect(v.reason).toMatch(/VIOLATION/);
+  });
+  it('requires + invoked → not a violation', () => {
+    const v = isMissingInvocationViolation('scripts/cron/live-loop.mjs', { invoked: true });
+    expect(v.violation).toBe(false);
+  });
+  it('does-not-require (library) → never a violation even when not invoked', () => {
+    const v = isMissingInvocationViolation('lib/util.js', { invoked: false }, { content: 'export const a=1;' });
+    expect(v.violation).toBe(false);
+    expect(v.reason).toMatch(/does not require/);
+  });
+  it('a manually-invoked CLI with no trigger is NOT a violation (conservative)', () => {
+    const v = isMissingInvocationViolation('scripts/one-shot-tool.mjs', { invoked: false }, { content: 'async function main(){}\nmain();' });
+    expect(v.violation).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
FR-2 of the INVOCATION-PATH-PROOF orchestrator: a **requires-invocation classifier** deciding whether a script *needs* a live production trigger (autonomous-runnable: crons/loops/sweeps/scheduled-writers) vs not (libraries/tests/one-off/manual-CLIs/helpers). Pairs with the FR-1 detector: `isMissingInvocationViolation` = requires-invocation **and** not-invoked = the WIRED-TO-FIRE violation the -C gate consumes.

**Conservative / fail-open** — the worst failure is a *false* violation, so it defaults FALSE and returns TRUE only on a GENUINE signal (loop-contract registry, `cron`/`clockwork` dir, a suffix-anchored `-loop`/`-cron`/`-sweep` filename, or real in-code scheduling). Reuses the -A SSOT (`isExcludedEntry`/`normalizeEntry`) — no duplication.

## Adversarial-hardened
Review caught false-VIOLATION defects (bare substrings `monitor`/`dispatcher`/`populator` + a content-gated lib gate flagged non-runners). Fixed: negative gates run first & content-independently; positive signals are genuine (suffix-anchored / dir / registry / in-code scheduling), never a bare substring. Pinned with the reviewer's exact false-match inputs (`lib/loops/loop-contract-registry.js`, `scripts/cache-populator.js`, `lib/ui/scroll-loop-helper.js`, …).

## Wiring
Extended `scripts/invocation-check.mjs` with `--violation` (reports + exits 1 on a missing-invocation violation), making the new module reachable (preempts the WIRE_CHECK miss -A hit).

## Tests
17 classifier tests (positive + the false-violation direction) + the existing 37 = 54 dir-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)