### PR TITLE
feat(SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-C): LEAD-FINAL invocation-path proof gate (FR-3)

### DIFF
--- a/lib/invocation-detector/requires-invocation.js
+++ b/lib/invocation-detector/requires-invocation.js
@@ -76,7 +76,14 @@ export function classifyRequiresInvocation(scriptPath, ctx = {}) {
     return { requiresInvocation: true, reason: 'lives under a cron/clockwork dir', confidence: 90 };
   }
   if (AUTONOMOUS_SUFFIX_RE.test(target)) {
-    return { requiresInvocation: true, reason: 'autonomous-runner filename suffix (-loop/-cron/-sweep/…)', confidence: 85 };
+    // A -loop/-sweep suffix asserts intent, BUT a pure LIBRARY can carry a loop-ish name
+    // (scripts/modules/**/rewrite-loop.js, rca-feedback-loop.js — exports only, no main()). When
+    // content is available and shows NO runnable surface, treat it as a library, not a runner
+    // (adversarial false-positive). Path-only (no content) trusts the suffix. The lib/ guard above
+    // already covers lib/-rooted modules; this covers scripts/modules/** library helpers.
+    if (!content || RUNNABLE_RE.test(content)) {
+      return { requiresInvocation: true, reason: 'autonomous-runner filename suffix (-loop/-cron/-sweep/…)', confidence: content ? 85 : 70 };
+    }
   }
   if (content && RUNNABLE_RE.test(content) && SCHEDULE_CONTENT_RE.test(content)) {
     return { requiresInvocation: true, reason: 'runnable program with in-code scheduling semantics', confidence: 78 };

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -35,6 +35,11 @@ export { createWiringValidationGate };
 import { createWireCheckGate } from './gates/wire-check-gate.js';
 export { createWireCheckGate };
 
+// Invocation-Path Proof Gate — autonomous code must have a LIVE trigger, not just be reachable
+// (SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-C)
+import { createInvocationPathGate } from './gates/invocation-path-gate.js';
+export { createInvocationPathGate };
+
 // Phantom Test Audit Gate — call-surface alignment check (SD-FDBK-ENH-PAT-PHANTOM-TABLE-001)
 import { createPhantomTestAuditGate } from './gates/phantom-test-audit-gate.js';
 export { createPhantomTestAuditGate };
@@ -1201,6 +1206,10 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   // Wire Check Gate — AST call graph reachability for new files
   // (SD-MAN-INFRA-FIX-ORCHESTRATOR-CHILD-001-C)
   gates.push(createWireCheckGate(supabase));
+  // Invocation-Path Proof — autonomous code (per FR-2 classifier) must have a LIVE production
+  // trigger (per FR-1 detector), complementing WIRE_CHECK's reachable-only check.
+  // (SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-C)
+  gates.push(createInvocationPathGate(supabase));
   gates.push(createPhantomTestAuditGate(supabase));
 
   // Learning-or-Bypass-Resolved Gate — completion safeguard

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
@@ -80,12 +80,15 @@ export function createInvocationPathGate(_supabase) {
         return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF skipped for venture target_application=${sd.target_application}`], details: { skipped: 'venture_opt_out' } };
       }
 
-      // Step 1: added/modified JS in scripts/ & lib/ vs origin/main. Fail-OPEN on diff error.
+      // Step 1: ADDED JS in scripts/ & lib/ vs origin/main. Fail-OPEN on diff error.
+      // --diff-filter=A (added only, mirrors WIRE_CHECK): a violation must be one this SD
+      // INTRODUCED. Flagging a merely-MODIFIED pre-existing un-wired runner would false-block an
+      // innocent SD for a wiring gap it did not cause (adversarial HIGH).
       const mainRef = getMainRef({ cwd: ROOT_DIR }).ref;
       let changed = [];
       try {
         const diff = execSync(
-          `git diff --name-only --diff-filter=AM ${mainRef}...HEAD -- "*.js" "*.mjs" "*.cjs"`,
+          `git diff --name-only --diff-filter=A ${mainRef}...HEAD -- "*.js" "*.mjs" "*.cjs"`,
           { encoding: 'utf8', cwd: ROOT_DIR, timeout: 10000 }
         );
         changed = diff.split('\n').map((f) => f.trim()).filter(Boolean)

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
@@ -1,0 +1,151 @@
+/**
+ * INVOCATION_PATH_PROOF gate — LEAD-FINAL-APPROVAL.
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-C (FR-3).
+ *
+ * BLOCKS completion when an SD ships AUTONOMOUS-RUNNABLE code (per the FR-2 classifier) that has
+ * NO live production trigger (per the FR-1 detector). This is the systemic catch for the
+ * months-long "shipped + tested + completed but nothing ever fires it" (WIRED-TO-FIRE) class.
+ *
+ * Complements WIRE_CHECK_GATE: that gate proves a new file is statically REACHABLE from an entry
+ * point; this gate proves an autonomous runner is actually INVOKED by a live trigger. Reachable
+ * != invoked.
+ *
+ * Conservative by construction: the FR-2 classifier only flags genuine autonomous runners
+ * (cron/clockwork dir, -loop/-cron/-sweep suffix, loop-contract entrypoint, in-code scheduling),
+ * so libraries/tests/manual-CLIs are never flagged. Fail-OPEN on infra/diff errors (a new
+ * blocking gate must not false-block on a git/load hiccup) — only a DETECTED violation blocks.
+ *
+ * Phase: LEAD-FINAL-APPROVAL
+ */
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { detectInvocationPath, loadTriggerSources } from '../../../../../../lib/invocation-detector/index.js';
+import { classifyRequiresInvocation } from '../../../../../../lib/invocation-detector/requires-invocation.js';
+import { getMainRef } from '../../../shared-git-context.js';
+import { isVentureRepo } from '../../../../../../lib/repo-paths.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '../../../../../../');
+
+const GATE_NAME = 'INVOCATION_PATH_PROOF';
+
+function safeRead(absPath) {
+  try { return fs.readFileSync(absPath, 'utf8'); } catch { return ''; }
+}
+
+/**
+ * PURE-ish core: for each changed file, flag a violation when it is autonomous-runnable (FR-2)
+ * but has no live trigger (FR-1). Composes the two SSOTs; I/O is injected (readFile), so the
+ * decision is unit-testable without git/fs. @returns {{violations:[], autonomousChecked:number}}
+ *
+ * @param {string[]} changedFiles - repo-relative paths
+ * @param {Object} sources - loadTriggerSources() output (pkgScripts/workflows/settings/loopContracts/parentScripts)
+ * @param {(file:string)=>string} readFile - returns file content for FR-2 content signals
+ */
+export function evaluateInvocationViolations(changedFiles, sources, readFile = () => '') {
+  const violations = [];
+  let autonomousChecked = 0;
+  for (const f of changedFiles || []) {
+    const content = readFile(f) || '';
+    const requires = classifyRequiresInvocation(f, { content, loopContracts: sources?.loopContracts });
+    if (!requires.requiresInvocation) continue;
+    autonomousChecked++;
+    const det = detectInvocationPath(f, sources || {});
+    if (!det.invoked) violations.push({ file: f, requires_reason: requires.reason });
+  }
+  return { violations, autonomousChecked };
+}
+
+/**
+ * Create the invocation-path proof gate.
+ * @param {Object} _supabase - kept for gate-interface consistency (unused)
+ * @returns {Object} Gate definition
+ */
+export function createInvocationPathGate(_supabase) {
+  return {
+    name: GATE_NAME,
+    validator: async (ctx) => {
+      console.log('\n🔌 GATE: Invocation-Path Proof (autonomous code must be wired to fire)');
+      console.log('-'.repeat(50));
+
+      // Venture opt-out: the detector's trigger sources (GHA workflows, package.json, the
+      // loop-contract registry) are EHG_Engineer-rooted, so a venture-targeted SD's separate repo
+      // would not resolve meaningfully here. Opt out unless the SD forces wiring. (Mirrors WIRE_CHECK.)
+      const sd = ctx?.sd || {};
+      if (isVentureRepo(sd.target_application) && sd?.metadata?.wiring_required !== true) {
+        console.log(`   ⏭️  Venture SD (target_application=${sd.target_application}) — INVOCATION_PATH_PROOF opted out (set metadata.wiring_required=true to force).`);
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF skipped for venture target_application=${sd.target_application}`], details: { skipped: 'venture_opt_out' } };
+      }
+
+      // Step 1: added/modified JS in scripts/ & lib/ vs origin/main. Fail-OPEN on diff error.
+      const mainRef = getMainRef({ cwd: ROOT_DIR }).ref;
+      let changed = [];
+      try {
+        const diff = execSync(
+          `git diff --name-only --diff-filter=AM ${mainRef}...HEAD -- "*.js" "*.mjs" "*.cjs"`,
+          { encoding: 'utf8', cwd: ROOT_DIR, timeout: 10000 }
+        );
+        changed = diff.split('\n').map((f) => f.trim()).filter(Boolean)
+          .filter((f) => f.startsWith('scripts/') || f.startsWith('lib/'))
+          .filter((f) => !f.includes('/tmp-') && !f.includes('/.tmp-'))
+          .map((f) => f.replace(/\\/g, '/'));
+      } catch (err) {
+        const message = err?.message || String(err);
+        console.log(`   ⚠️  git diff against ${mainRef} failed — fail-open (advisory): ${message}`);
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF could not compute git diff (fail-open): ${message}`], details: { mainRef, error: message } };
+      }
+
+      if (changed.length === 0) {
+        console.log('   No changed JS in scripts/ or lib/ — auto-pass');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [] };
+      }
+
+      // Step 2: load the live trigger sources ONCE, then classify+detect per file.
+      let sources;
+      try {
+        sources = await loadTriggerSources(ROOT_DIR, { includeParentShell: true });
+      } catch (err) {
+        const message = err?.message || String(err);
+        console.log(`   ⚠️  trigger-source load failed — fail-open (advisory): ${message}`);
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [`INVOCATION_PATH_PROOF could not load trigger sources (fail-open): ${message}`], details: { error: message } };
+      }
+
+      const { violations, autonomousChecked } = evaluateInvocationViolations(
+        changed, sources, (f) => safeRead(path.resolve(ROOT_DIR, f))
+      );
+      for (const v of violations) console.log(`   🚩 ${v.file} — autonomous (${v.requires_reason}) but NO live trigger`);
+
+      console.log(`   Autonomous runners checked: ${autonomousChecked} | violations: ${violations.length}`);
+
+      if (violations.length === 0) {
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details: { autonomousChecked, violations: 0 } };
+      }
+
+      const remediation = [
+        'This SD ships autonomous-runnable code with no live production trigger (WIRED-TO-FIRE). Wire each file with ONE of:',
+        '  • A scheduled GitHub Actions workflow (.github/workflows/*.yml with `on: schedule: cron`) whose run: step invokes it (directly or via `npm run`).',
+        '  • A loop-contract registry entry (lib/loops/loop-contract-registry.js) PAIRED with a scheduled workflow that wires its entrypoint.',
+        '  • A .claude hook registration (.claude/settings.json) if it is a lifecycle hook.',
+        '  • A parent script that shells it, or an npm script + workflow.',
+        'If the file is NOT actually autonomous (a library/manual CLI/helper), it should not match the FR-2 classifier — verify its name/location (avoid -loop/-cron/-sweep suffix, cron/clockwork dirs, and in-code setInterval/cron unless it truly runs autonomously).',
+      ];
+
+      return {
+        passed: false,
+        score: 0,
+        max_score: 100,
+        issues: [
+          `${violations.length} autonomous-runnable file(s) ship without a live production trigger:`,
+          ...violations.map((v) => `  - ${v.file} (${v.requires_reason})`),
+          ...remediation,
+        ],
+        warnings: [],
+        details: { autonomousChecked, violations: violations.length, violationFiles: violations.map((v) => v.file) },
+      };
+    },
+    required: true,
+  };
+}

--- a/tests/unit/invocation-detector/invocation-path-gate.test.js
+++ b/tests/unit/invocation-detector/invocation-path-gate.test.js
@@ -65,6 +65,18 @@ describe('evaluateInvocationViolations — the FR-1 ∧ FR-2 core', () => {
     expect(evaluateInvocationViolations([], SOURCES).violations).toHaveLength(0);
     expect(evaluateInvocationViolations(undefined, undefined).violations).toHaveLength(0);
   });
+
+  // Adversarial HIGH regression: a -loop/-sweep-named PURE LIBRARY under scripts/modules/ (no
+  // runnable surface) must NOT be flagged as an autonomous runner (false violation).
+  it('a scripts/modules library with a -loop name (no main) is NOT a violation', () => {
+    const r = evaluateInvocationViolations(
+      ['scripts/modules/prd/rewrite-loop.js', 'scripts/modules/pocock/rca-feedback-loop.js'],
+      SOURCES,
+      () => 'export function rewrite(){}\nexport const X = 1;', // library: exports only, no main()/argv
+    );
+    expect(r.autonomousChecked).toBe(0);
+    expect(r.violations).toHaveLength(0);
+  });
 });
 
 describe('createInvocationPathGate — gate shape & opt-out', () => {

--- a/tests/unit/invocation-detector/invocation-path-gate.test.js
+++ b/tests/unit/invocation-detector/invocation-path-gate.test.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-C (FR-3) — LEAD-FINAL invocation-path proof gate.
+ * Composes the FR-1 detector + FR-2 classifier: BLOCK when autonomous-runnable code ships with
+ * no live trigger. Tests the pure evaluation core + the gate shape/opt-out, and asserts the gate
+ * is WIRED into the LEAD-FINAL pipeline (else it would be the very inert-gate it fights).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createInvocationPathGate,
+  evaluateInvocationViolations,
+} from '../../../scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js';
+
+// A synthetic "live" trigger source set: a cron workflow + matching loop-contract for one script.
+const SOURCES = {
+  pkgScripts: { 'wired': 'node scripts/clockwork/wired-loop.cjs' },
+  workflows: [{
+    file: '.github/workflows/wired.yml',
+    content: "on:\n  schedule:\n    - cron: '0 * * * *'\njobs:\n  j:\n    steps:\n      - run: npm run wired\n",
+  }],
+  settings: { hooks: {} },
+  loopContracts: [{ id: 'L1', timeline: { cadence: '0 * * * *' }, tasks: [{ task: 'entrypoint', file: 'scripts/clockwork/wired-loop.cjs' }] }],
+  parentScripts: [],
+};
+
+describe('evaluateInvocationViolations — the FR-1 ∧ FR-2 core', () => {
+  it('autonomous + has a live trigger → NO violation', () => {
+    const r = evaluateInvocationViolations(['scripts/clockwork/wired-loop.cjs'], SOURCES);
+    expect(r.autonomousChecked).toBe(1);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it('autonomous (cron dir) + NO live trigger → VIOLATION (the WIRED-TO-FIRE catch)', () => {
+    const r = evaluateInvocationViolations(['scripts/cron/orphan-runner.mjs'], SOURCES);
+    expect(r.autonomousChecked).toBe(1);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].file).toBe('scripts/cron/orphan-runner.mjs');
+  });
+
+  it('a -loop suffix runner with no trigger → VIOLATION', () => {
+    const r = evaluateInvocationViolations(['scripts/ghost-sweep-loop.cjs'], SOURCES);
+    expect(r.violations).toHaveLength(1);
+  });
+
+  it('a NON-autonomous file (library / manual CLI) is skipped, never a violation', () => {
+    const r = evaluateInvocationViolations(
+      ['lib/some-util.js', 'scripts/print-report.mjs', 'tests/x.test.js'],
+      SOURCES,
+      () => 'export const a = 1;',
+    );
+    expect(r.autonomousChecked).toBe(0);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it('mixes: only the unwired autonomous file violates', () => {
+    const r = evaluateInvocationViolations(
+      ['scripts/clockwork/wired-loop.cjs', 'scripts/cron/orphan-runner.mjs', 'lib/helper.js'],
+      SOURCES,
+      () => 'export const a = 1;',
+    );
+    expect(r.autonomousChecked).toBe(2);
+    expect(r.violations.map((v) => v.file)).toEqual(['scripts/cron/orphan-runner.mjs']);
+  });
+
+  it('empty / undefined inputs are safe', () => {
+    expect(evaluateInvocationViolations([], SOURCES).violations).toHaveLength(0);
+    expect(evaluateInvocationViolations(undefined, undefined).violations).toHaveLength(0);
+  });
+});
+
+describe('createInvocationPathGate — gate shape & opt-out', () => {
+  it('returns a required gate with the canonical name + validator', () => {
+    const g = createInvocationPathGate(null);
+    expect(g.name).toBe('INVOCATION_PATH_PROOF');
+    expect(g.required).toBe(true);
+    expect(typeof g.validator).toBe('function');
+  });
+
+  it('opts out (advisory pass) for a venture target without wiring_required', async () => {
+    const g = createInvocationPathGate(null);
+    const res = await g.validator({ sd: { target_application: 'rickfelix/ehg', metadata: {} } });
+    expect(res.passed).toBe(true);
+    expect(res.details.skipped).toBe('venture_opt_out');
+  });
+});
+
+describe('gate wiring — INVOCATION_PATH_PROOF must be registered in the LEAD-FINAL pipeline', () => {
+  it('gates.js exports createInvocationPathGate (it is imported + pushed)', async () => {
+    const mod = await import('../../../scripts/modules/handoff/executors/lead-final-approval/gates.js');
+    expect(typeof mod.createInvocationPathGate).toBe('function');
+    expect(mod.createInvocationPathGate(null).name).toBe('INVOCATION_PATH_PROOF');
+  });
+});

--- a/tests/unit/invocation-detector/requires-invocation.test.js
+++ b/tests/unit/invocation-detector/requires-invocation.test.js
@@ -66,6 +66,15 @@ describe('classifyRequiresInvocation — conservative FALSE (no false violations
       expect(classifyRequiresInvocation(p, { content: main }).requiresInvocation, p).toBe(false);
     }
   });
+  it('a -loop/-sweep-named PURE LIBRARY (no runnable surface) is NOT required (adversarial -C HIGH)', () => {
+    const lib = 'export function step(){}\nexport const N = 1;'; // exports only, no main/argv/shebang
+    expect(classifyRequiresInvocation('scripts/modules/prd/rewrite-loop.js', { content: lib }).requiresInvocation).toBe(false);
+    expect(classifyRequiresInvocation('scripts/modules/qf/compliance-loop.js', { content: lib }).requiresInvocation).toBe(false);
+    // but a -loop file that IS runnable still requires a trigger:
+    expect(classifyRequiresInvocation('scripts/x-loop.cjs', { content: 'async function main(){}\nmain();' }).requiresInvocation).toBe(true);
+    // and path-only (no content) still trusts the suffix (can't verify):
+    expect(classifyRequiresInvocation('scripts/y-loop.cjs').requiresInvocation).toBe(true);
+  });
   it('a plain runnable CLI with no scheduling semantics defaults to FALSE', () => {
     const content = '#!/usr/bin/env node\nasync function main(){ console.log("report"); }\nmain();';
     expect(classifyRequiresInvocation('scripts/print-report.mjs', { content }).requiresInvocation).toBe(false);


### PR DESCRIPTION
## Summary
The **capstone** of the INVOCATION-PATH-PROOF orchestrator: a LEAD-FINAL gate (`INVOCATION_PATH_PROOF`, required:true) that **BLOCKS completion when an SD ships autonomous-runnable code (per the FR-2 classifier) with no live production trigger (per the FR-1 detector)** — the systemic catch for the months-long *shipped-but-never-wired-to-fire* class. Complements WIRE_CHECK_GATE (reachable) with **invoked**.

The gate is itself **wired** into the pipeline (`gates.push` after WIRE_CHECK) — dogfooding its own thesis (a gate that catches un-invoked code must be invoked). Pure `evaluateInvocationViolations` core; conservative; fail-open on infra errors; venture opt-out mirrors WIRE_CHECK.

## Adversarial-hardened
Review caught a HIGH false-block: `--diff-filter=AM` would flag a *merely-modified* pre-existing un-wired runner (6 existing files, 3 false positives). Fixed: (1) gate uses `--diff-filter=A` (added only — a violation must be one the SD *introduced*); (2) the FR-2 classifier no longer flags a `-loop`/`-sweep`-named **pure library** under `scripts/modules/**` (extends the `lib/` guard). +2 regression tests.

## Tests
11 gate tests + 54 from -A/-B = **65 dir-wide**. Includes a genuine wiring assertion (fails if the gate is unpushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)