### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-A): pure candidate-validity predicate (auto-refill foundation)

### DIFF
--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-A (FOUNDATION) — pure candidate-validity predicate.
+ *
+ * The auto-refill feature closes the staged->belt gap: proactive-populator.js STAGES roadmap_wave_items
+ * at item_disposition='pending' and never sets promoted_to_sd_key (it stages-then-stops), so hundreds of
+ * staged items sit on the shelf until the coordinator hand-promotes them (an anti-pattern). The sibling
+ * children (-B dry-run verifier, -C auto-refill cron, -D claim-eligibility wire, -E coordinator awareness)
+ * all need ONE decision: is a given staged roadmap_wave_items row a VALID candidate to auto-promote onto
+ * the belt? This is that single PURE SSOT.
+ *
+ * CONSERVATIVE by design: default INVALID unless the item clearly qualifies, so auto-refill never promotes
+ * malformed / already-promoted / duplicate / fixture junk. Lane/outcome ROUTING (which lane a valid
+ * candidate belongs to) is intentionally NOT decided here — that is the consumers' job; this predicate only
+ * answers the lifecycle/structural question "is this a well-formed, staged, un-promoted, real candidate".
+ *
+ * PURE: no DB, no fs, no clock. TOTAL: never throws on odd input.
+ * ESM module (this repo is type:module; .js === ESM — mirrors lib/sourcing-engine/register-first.js).
+ */
+
+// Canonical fixture-key pattern (mirrors lib/fleet/claim-eligibility.cjs TEST_FIXTURE_KEY_RE) so a
+// TEST/DEMO fixture seeded into the corpus is never auto-promoted onto the real belt.
+export const FIXTURE_KEY_RE = /^SD-(DEMO|TEST)\b/i;
+// A fixture can also surface as a TEST/DEMO-prefixed title (staged items have no sd_key of their own).
+export const FIXTURE_TITLE_RE = /^\s*(SD-)?(DEMO|TEST)\b/i;
+
+export const REFILL_INVALID_REASONS = Object.freeze({
+  MISSING_ITEM: 'missing_item',
+  ALREADY_PROMOTED: 'already_promoted',
+  NOT_STAGED: 'not_staged',
+  DECLINED_LANE: 'declined_lane',
+  MISSING_TITLE: 'missing_title',
+  MISSING_PROVENANCE: 'missing_provenance',
+  TEST_FIXTURE: 'test_fixture',
+});
+
+const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
+
+/**
+ * Decide whether a staged roadmap_wave_items row is a VALID auto-refill candidate.
+ * Checks run in lifecycle-first order so an on-belt / non-staged row reports the lifecycle reason
+ * rather than a field gripe. Returns the FIRST failing reason; { valid:true } only when ALL pass.
+ *
+ * @param {{ item_disposition?:string, promoted_to_sd_key?:(string|null), title?:string,
+ *           source_type?:string, source_id?:string, lane?:string }} item  a roadmap_wave_items row
+ * @returns {{ valid:boolean, reason:(string|null) }}
+ */
+export function evaluateRefillCandidate(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM };
+  }
+  // Lifecycle first: an item already promoted to the belt, or not in the staged ('pending') state, is
+  // not a refill candidate regardless of its fields.
+  if (nonEmpty(item.promoted_to_sd_key)) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.ALREADY_PROMOTED };
+  }
+  if (item.item_disposition !== 'pending') {
+    return { valid: false, reason: REFILL_INVALID_REASONS.NOT_STAGED };
+  }
+  // A lane explicitly routed away from the belt must never be auto-promoted.
+  if (typeof item.lane === 'string' && item.lane.trim().toLowerCase() === 'decline') {
+    return { valid: false, reason: REFILL_INVALID_REASONS.DECLINED_LANE };
+  }
+  // Structural: an SD cannot be created without a title, and provenance must be traceable.
+  if (!nonEmpty(item.title)) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.MISSING_TITLE };
+  }
+  if (!nonEmpty(item.source_type) || !nonEmpty(item.source_id)) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.MISSING_PROVENANCE };
+  }
+  // Never auto-promote a TEST/DEMO fixture into the real belt.
+  if (FIXTURE_TITLE_RE.test(item.title) ||
+      (nonEmpty(item.source_id) && FIXTURE_KEY_RE.test(item.source_id))) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.TEST_FIXTURE };
+  }
+  return { valid: true, reason: null };
+}

--- a/tests/unit/sourcing-engine/refill-candidate-validity.test.js
+++ b/tests/unit/sourcing-engine/refill-candidate-validity.test.js
@@ -1,0 +1,70 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-A — pure candidate-validity predicate tests.
+ * Pins: the VALID staged case, every INVALID reason, lifecycle-first ordering, and totality on odd input.
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluateRefillCandidate, REFILL_INVALID_REASONS } from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+
+// A well-formed staged refill candidate (the 683-item live shape: pending, unpromoted, real provenance).
+const validItem = (over = {}) => ({
+  item_disposition: 'pending',
+  promoted_to_sd_key: null,
+  title: 'Harden the worktree reaper',
+  source_type: 'conversion_ledger',
+  source_id: '11111111-1111-1111-1111-111111111111',
+  lane: 'belt',
+  ...over,
+});
+
+describe('evaluateRefillCandidate (FOUNDATION SSOT)', () => {
+  it('a well-formed staged, unpromoted item is VALID', () => {
+    expect(evaluateRefillCandidate(validItem())).toEqual({ valid: true, reason: null });
+  });
+
+  it('an already-promoted item is INVALID (already_promoted) — lifecycle reason wins', () => {
+    // even with other fields also bad, the lifecycle reason is reported first
+    const r = evaluateRefillCandidate(validItem({ promoted_to_sd_key: 'SD-LEO-INFRA-X-001', title: '' }));
+    expect(r).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.ALREADY_PROMOTED });
+  });
+
+  it('a non-staged item (item_disposition != pending) is INVALID (not_staged)', () => {
+    expect(evaluateRefillCandidate(validItem({ item_disposition: 'declined' }))).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.NOT_STAGED });
+    expect(evaluateRefillCandidate(validItem({ item_disposition: null }))).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.NOT_STAGED });
+  });
+
+  it('a decline-lane item is INVALID (declined_lane), case/space-insensitive', () => {
+    expect(evaluateRefillCandidate(validItem({ lane: 'decline' })).reason).toBe(REFILL_INVALID_REASONS.DECLINED_LANE);
+    expect(evaluateRefillCandidate(validItem({ lane: ' Decline ' })).reason).toBe(REFILL_INVALID_REASONS.DECLINED_LANE);
+  });
+
+  it('a missing/empty title is INVALID (missing_title)', () => {
+    expect(evaluateRefillCandidate(validItem({ title: '' })).reason).toBe(REFILL_INVALID_REASONS.MISSING_TITLE);
+    expect(evaluateRefillCandidate(validItem({ title: '   ' })).reason).toBe(REFILL_INVALID_REASONS.MISSING_TITLE);
+    expect(evaluateRefillCandidate(validItem({ title: undefined })).reason).toBe(REFILL_INVALID_REASONS.MISSING_TITLE);
+  });
+
+  it('missing source_type or source_id is INVALID (missing_provenance)', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: '' })).reason).toBe(REFILL_INVALID_REASONS.MISSING_PROVENANCE);
+    expect(evaluateRefillCandidate(validItem({ source_id: null })).reason).toBe(REFILL_INVALID_REASONS.MISSING_PROVENANCE);
+  });
+
+  it('a TEST/DEMO fixture (by title or sd-key-shaped source_id) is INVALID (test_fixture)', () => {
+    expect(evaluateRefillCandidate(validItem({ title: 'TEST harness probe' })).reason).toBe(REFILL_INVALID_REASONS.TEST_FIXTURE);
+    expect(evaluateRefillCandidate(validItem({ title: 'SD-DEMO sample' })).reason).toBe(REFILL_INVALID_REASONS.TEST_FIXTURE);
+    expect(evaluateRefillCandidate(validItem({ source_id: 'SD-TEST-FIXTURE-001' })).reason).toBe(REFILL_INVALID_REASONS.TEST_FIXTURE);
+  });
+
+  it('does NOT false-flag a normal title that merely contains test/demo mid-word', () => {
+    // FIXTURE_TITLE_RE is anchored — "Latest dashboard" / "Demonstrate X" should NOT match a leading TEST/DEMO token.
+    expect(evaluateRefillCandidate(validItem({ title: 'Refactor the latest dashboard widget' })).valid).toBe(true);
+  });
+
+  it('is TOTAL on odd input (null / {} / array / number) — never throws, returns missing_item or a reason', () => {
+    expect(evaluateRefillCandidate(null)).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM });
+    expect(evaluateRefillCandidate(undefined)).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM });
+    expect(evaluateRefillCandidate([])).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM });
+    expect(evaluateRefillCandidate(42)).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM });
+    // empty object: not already-promoted, item_disposition undefined -> not_staged
+    expect(evaluateRefillCandidate({})).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.NOT_STAGED });
+  });
+});


### PR DESCRIPTION
## Summary
FOUNDATION child (no deps) of `SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001` (staged→belt auto-refill). `proactive-populator.js` **stages** `roadmap_wave_items` at `item_disposition='pending'` and never sets `promoted_to_sd_key` (stages-then-stops) — **683 pending&unpromoted** items sit on the shelf today, hand-promoted by the coordinator (anti-pattern). The 4 sibling children (dry-run verifier, auto-refill cron, claim-eligibility wire, coordinator awareness) all need **one** decision: is a staged item a valid candidate to auto-promote?

## Change — single pure SSOT
`lib/sourcing-engine/refill-candidate-validity.js` → `evaluateRefillCandidate(item)` → `{valid, reason}`. **Conservative** (default INVALID unless clearly valid). **Lifecycle-first ordering** so an on-belt/non-staged row reports the lifecycle reason, not a field gripe: `already_promoted → not_staged → declined_lane → missing_title → missing_provenance → test_fixture`. Grounded in the live `roadmap_wave_items` shape (pending=staged; `promoted_to_sd_key`=on belt; canonical `SD-(DEMO|TEST)` fixture guard). **Pure** (no DB/fs/clock) + **total** (never throws). ESM (`.js`===ESM in this repo).

No consumers wired (foundation only); `proactive-populator.js` unchanged; no schema change.

## Tests
- `refill-candidate-validity.test.js` — 9/9 ✅ (valid + every invalid reason + lifecycle-first ordering + anchored-fixture non-false-flag + null/`{}`/array/number totality)
- `node --check` — OK
- purity grep (no supabase/createClient/fs/Date.now) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
