### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-B): dry-run staged-candidate verifier

### DIFF
--- a/lib/sourcing-engine/refill-dry-run-verifier.js
+++ b/lib/sourcing-engine/refill-dry-run-verifier.js
@@ -1,0 +1,68 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-B — dry-run staged-candidate verifier.
+ *
+ * The auto-refill feature must NOT promote staged roadmap_wave_items blindly. This is the
+ * operator/coordinator PREVIEW step: given the staged corpus, report which rows the FR-1
+ * candidate-validity predicate (evaluateRefillCandidate, the -A SSOT) would accept as valid
+ * auto-promote candidates vs reject (with the per-reason breakdown) — WITHOUT writing anything.
+ * The -C auto-refill cron promotes; this -B verifier lets a human eyeball what it WOULD promote.
+ *
+ * PURE: verifyStagedCandidates() takes rows in → report out, no DB/fs/clock. The thin CLI
+ * (scripts/sourcing-engine/refill-verify.mjs) is the only I/O and is what makes this module
+ * INVOKED, not merely reachable (per the INVOCATION-PATH-PROOF lesson). Mirrors -A's ESM style.
+ */
+import { evaluateRefillCandidate, REFILL_INVALID_REASONS } from './refill-candidate-validity.js';
+
+export { REFILL_INVALID_REASONS };
+
+/**
+ * Run the -A candidate-validity predicate over a set of staged roadmap_wave_items rows and
+ * aggregate a dry-run report. Pure + total (never throws on odd input).
+ *
+ * @param {Array<Object>} rows - roadmap_wave_items rows (any shape; the predicate is total)
+ * @returns {{
+ *   total:number, validCount:number, invalidCount:number,
+ *   valid:Array<Object>, invalid:Array<{item:Object, reason:string}>,
+ *   byReason:Object<string,number>
+ * }}
+ */
+export function verifyStagedCandidates(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const valid = [];
+  const invalid = [];
+  const byReason = {};
+  for (const r of list) {
+    const verdict = evaluateRefillCandidate(r);
+    if (verdict.valid) {
+      valid.push(r);
+    } else {
+      invalid.push({ item: r, reason: verdict.reason });
+      byReason[verdict.reason] = (byReason[verdict.reason] || 0) + 1;
+    }
+  }
+  return {
+    total: list.length,
+    validCount: valid.length,
+    invalidCount: invalid.length,
+    valid,
+    invalid,
+    byReason,
+  };
+}
+
+/**
+ * Render the dry-run report as human-readable lines (no I/O — returns the lines). Pure.
+ * @param {ReturnType<typeof verifyStagedCandidates>} report
+ * @returns {string[]}
+ */
+export function formatVerifierReport(report) {
+  const r = report || { total: 0, validCount: 0, invalidCount: 0, byReason: {} };
+  const lines = [
+    `Staged candidates verified (DRY RUN — no writes): ${r.total}`,
+    `  ✅ would auto-promote: ${r.validCount}`,
+    `  ⛔ rejected: ${r.invalidCount}`,
+  ];
+  const reasons = Object.keys(r.byReason || {}).sort();
+  for (const reason of reasons) lines.push(`     - ${reason}: ${r.byReason[reason]}`);
+  return lines;
+}

--- a/package.json
+++ b/package.json
@@ -333,6 +333,7 @@
     "prod-error-sweep": "node scripts/clockwork/prod-error-sweep-loop.cjs",
     "sourcing:backfill-adam-ghosts": "node scripts/sourcing-engine/backfill-adam-ghosts.mjs",
     "sourcing:populate": "node scripts/sourcing-engine/proactive-populator.mjs",
+    "sourcing:refill-verify": "node scripts/sourcing-engine/refill-verify.mjs",
     "sourcing:gauge-gap-miner": "node scripts/sourcing-engine/gauge-gap-miner-sweep.mjs",
     "distill:yt-backlog-clear": "node scripts/eva/youtube-backlog-clear.mjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",

--- a/scripts/sourcing-engine/refill-verify.mjs
+++ b/scripts/sourcing-engine/refill-verify.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Dry-run staged-candidate verifier CLI — SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-B.
+ *
+ * Reads the staged roadmap_wave_items corpus and reports which rows the candidate-validity
+ * predicate (-A) would accept as valid auto-promote candidates vs reject — DRY RUN, no writes.
+ * This is the operator/coordinator preview before the -C auto-refill cron promotes anything.
+ *
+ * Usage: node scripts/sourcing-engine/refill-verify.mjs [--json] [--limit N]
+ *
+ * Also the module's wiring: it makes lib/sourcing-engine/refill-dry-run-verifier.js INVOKED
+ * (an npm entry point), not merely reachable.
+ */
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
+import { verifyStagedCandidates, formatVerifierReport } from '../../lib/sourcing-engine/refill-dry-run-verifier.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const limIdx = args.indexOf('--limit');
+  const limit = limIdx >= 0 && Number(args[limIdx + 1]) > 0 ? Number(args[limIdx + 1]) : 1000;
+
+  const supabase = await createSupabaseServiceClient('engineer', { verbose: false });
+
+  // Staged = item_disposition='pending' AND not yet promoted. Read-only.
+  const { data: rows, error } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane')
+    .eq('item_disposition', 'pending')
+    .is('promoted_to_sd_key', null)
+    .limit(limit);
+
+  if (error) {
+    console.error('refill-verify: query failed:', error.message);
+    process.exit(2);
+  }
+
+  const report = verifyStagedCandidates(rows || []);
+
+  if (json) {
+    console.log(JSON.stringify({
+      total: report.total,
+      validCount: report.validCount,
+      invalidCount: report.invalidCount,
+      byReason: report.byReason,
+      validIds: report.valid.map((r) => r.id),
+    }, null, 2));
+  } else {
+    console.log('🔎 Auto-refill dry-run verification (staged → belt candidates)');
+    for (const line of formatVerifierReport(report)) console.log(line);
+  }
+
+  process.exit(0);
+}
+
+main().catch((e) => { console.error('refill-verify error:', e.message); process.exit(2); });

--- a/tests/unit/sourcing-engine/refill-dry-run-verifier.test.js
+++ b/tests/unit/sourcing-engine/refill-dry-run-verifier.test.js
@@ -1,0 +1,85 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-B — dry-run staged-candidate verifier.
+ * Pure: composes the -A predicate over a set of staged rows into a dry-run report.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  verifyStagedCandidates,
+  formatVerifierReport,
+  REFILL_INVALID_REASONS,
+} from '../../../lib/sourcing-engine/refill-dry-run-verifier.js';
+
+const validRow = (over = {}) => ({
+  id: 'id-' + Math.round(over.n ?? 1) , // label only
+  title: 'Real captured roadmap item',
+  source_type: 'todoist',
+  source_id: 'src-123',
+  item_disposition: 'pending',
+  promoted_to_sd_key: null,
+  lane: 'belt-ready',
+  ...over,
+});
+
+describe('verifyStagedCandidates', () => {
+  it('counts a clean valid candidate as would-promote', () => {
+    const r = verifyStagedCandidates([validRow()]);
+    expect(r.total).toBe(1);
+    expect(r.validCount).toBe(1);
+    expect(r.invalidCount).toBe(0);
+    expect(r.valid).toHaveLength(1);
+  });
+
+  it('buckets invalid rows by the -A predicate reason', () => {
+    const rows = [
+      validRow(),
+      validRow({ promoted_to_sd_key: 'SD-X-001' }),       // already_promoted
+      validRow({ item_disposition: 'dropped' }),           // not_staged
+      validRow({ lane: 'decline' }),                       // declined_lane
+      validRow({ title: '' }),                             // missing_title
+      validRow({ source_id: '' }),                         // missing_provenance
+      validRow({ title: 'TEST fixture row' }),             // test_fixture
+    ];
+    const r = verifyStagedCandidates(rows);
+    expect(r.total).toBe(7);
+    expect(r.validCount).toBe(1);
+    expect(r.invalidCount).toBe(6);
+    expect(r.byReason[REFILL_INVALID_REASONS.ALREADY_PROMOTED]).toBe(1);
+    expect(r.byReason[REFILL_INVALID_REASONS.NOT_STAGED]).toBe(1);
+    expect(r.byReason[REFILL_INVALID_REASONS.DECLINED_LANE]).toBe(1);
+    expect(r.byReason[REFILL_INVALID_REASONS.MISSING_TITLE]).toBe(1);
+    expect(r.byReason[REFILL_INVALID_REASONS.MISSING_PROVENANCE]).toBe(1);
+    expect(r.byReason[REFILL_INVALID_REASONS.TEST_FIXTURE]).toBe(1);
+  });
+
+  it('is total/safe on odd input (null, non-array, malformed rows)', () => {
+    expect(verifyStagedCandidates(null).total).toBe(0);
+    expect(verifyStagedCandidates(undefined).total).toBe(0);
+    expect(verifyStagedCandidates('nope').total).toBe(0);
+    const r = verifyStagedCandidates([null, 42, {}, validRow()]);
+    expect(r.total).toBe(4);
+    expect(r.validCount).toBe(1); // only the well-formed row
+    expect(r.invalidCount).toBe(3);
+  });
+
+  it('is read-only — does not mutate the input rows', () => {
+    const row = validRow();
+    const snapshot = JSON.stringify(row);
+    verifyStagedCandidates([row]);
+    expect(JSON.stringify(row)).toBe(snapshot);
+  });
+});
+
+describe('formatVerifierReport', () => {
+  it('renders a DRY-RUN summary with per-reason breakdown', () => {
+    const report = verifyStagedCandidates([validRow(), validRow({ title: '' })]);
+    const lines = formatVerifierReport(report);
+    expect(lines[0]).toMatch(/DRY RUN/);
+    expect(lines.join('\n')).toMatch(/would auto-promote: 1/);
+    expect(lines.join('\n')).toMatch(/rejected: 1/);
+    expect(lines.join('\n')).toMatch(/missing_title: 1/);
+  });
+
+  it('is safe on an empty/odd report', () => {
+    expect(formatVerifierReport(undefined)[0]).toMatch(/0/);
+  });
+});


### PR DESCRIPTION
## Summary
Auto-refill child of AUTO-REFILL-SELECTION-GATE-001: the operator/coordinator **preview** before auto-refill promotes. A pure `verifyStagedCandidates(rows)` runs the -A candidate-validity predicate (`evaluateRefillCandidate`) over the staged `roadmap_wave_items` corpus and reports which rows **would** be valid auto-promote candidates vs rejected (per-reason breakdown) — **WITHOUT writing**. Lets a human eyeball what the -C auto-refill cron *would* promote before it does.

Reuses the -A SSOT (no duplication). Wired via a **read-only** CLI (`scripts/sourcing-engine/refill-verify.mjs`) + npm `sourcing:refill-verify` so the module is *invoked*, not merely reachable (INVOCATION-PATH-PROOF lesson).

## Safety
Pure, total-safe, read-only. The CLI issues a single SELECT — no insert/update/delete. Adversarial review: **clean, no ship-blocking defects** (write-safety + predicate-fidelity confirmed).

## Tests
6 unit tests (valid-count, per-reason bucketing, total-safe on odd input, no-mutation, report rendering) + **live dogfood-verified** (surfaced the real promotable staged candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)