### PR TITLE
fix(SD-FDBK-INFRA-RETROSPECTIVES-CHECK-LEARNING-001): canonical learning_category allowlist + normalizer

### DIFF
--- a/lib/retro/learning-category.cjs
+++ b/lib/retro/learning-category.cjs
@@ -1,0 +1,103 @@
+/**
+ * Canonical retrospectives.learning_category allowlist + normalizer.
+ * SD-FDBK-INFRA-RETROSPECTIVES-CHECK-LEARNING-001.
+ *
+ * The `check_learning_category` CHECK constraint on `retrospectives` accepts EXACTLY these 9 values
+ * (verified live 2026-06-21). Plausible-sounding categories that workers/manual inserts often reach for
+ * — PROTOCOL_PROCESS, PROCESS, INFRASTRUCTURE, CI_CD, TOOLING, WORKFLOW, CONFIGURATION, OTHER — are NOT
+ * in the set and get REJECTED by the constraint, forcing a poor-fit category or an outright insert
+ * failure. Rather than widen a constraint that is already reasonable, this module makes the canonical
+ * list discoverable and coerces any near-miss to the nearest valid value so a retro NEVER fails on
+ * category. Import { LEARNING_CATEGORIES, normalizeLearningCategory } from here in every retro writer.
+ */
+
+'use strict';
+
+/** The exact set permitted by the check_learning_category constraint (keep in sync with the DB). */
+const LEARNING_CATEGORIES = Object.freeze([
+  'APPLICATION_ISSUE',
+  'PROCESS_IMPROVEMENT',
+  'TESTING_STRATEGY',
+  'DATABASE_SCHEMA',
+  'DEPLOYMENT_ISSUE',
+  'PERFORMANCE_OPTIMIZATION',
+  'USER_EXPERIENCE',
+  'SECURITY_VULNERABILITY',
+  'DOCUMENTATION',
+]);
+
+/** Safe default when nothing else matches (also the legacy generate-retrospective.js default). */
+const DEFAULT_LEARNING_CATEGORY = 'APPLICATION_ISSUE';
+
+const VALID = new Set(LEARNING_CATEGORIES);
+
+// Common rejected/near-miss inputs → the closest valid canonical value. Keys are normalized
+// (uppercased, non-alphanumerics collapsed to '_') so 'ci/cd', 'CI-CD', 'ci_cd' all map the same.
+const ALIASES = Object.freeze({
+  // process / infra / tooling / workflow / config → PROCESS_IMPROVEMENT
+  PROTOCOL_PROCESS: 'PROCESS_IMPROVEMENT',
+  PROCESS: 'PROCESS_IMPROVEMENT',
+  WORKFLOW: 'PROCESS_IMPROVEMENT',
+  CONFIGURATION: 'PROCESS_IMPROVEMENT',
+  CONFIG: 'PROCESS_IMPROVEMENT',
+  TOOLING: 'PROCESS_IMPROVEMENT',
+  INFRASTRUCTURE: 'PROCESS_IMPROVEMENT',
+  INFRA: 'PROCESS_IMPROVEMENT',
+  GOVERNANCE: 'PROCESS_IMPROVEMENT',
+  // ci/cd / deploy / pipeline / release → DEPLOYMENT_ISSUE
+  CI_CD: 'DEPLOYMENT_ISSUE',
+  CICD: 'DEPLOYMENT_ISSUE',
+  CI: 'DEPLOYMENT_ISSUE',
+  DEPLOY: 'DEPLOYMENT_ISSUE',
+  DEPLOYMENT: 'DEPLOYMENT_ISSUE',
+  PIPELINE: 'DEPLOYMENT_ISSUE',
+  RELEASE: 'DEPLOYMENT_ISSUE',
+  // testing
+  TEST: 'TESTING_STRATEGY',
+  TESTING: 'TESTING_STRATEGY',
+  QA: 'TESTING_STRATEGY',
+  // database
+  DATABASE: 'DATABASE_SCHEMA',
+  SCHEMA: 'DATABASE_SCHEMA',
+  DB: 'DATABASE_SCHEMA',
+  MIGRATION: 'DATABASE_SCHEMA',
+  // performance
+  PERFORMANCE: 'PERFORMANCE_OPTIMIZATION',
+  PERF: 'PERFORMANCE_OPTIMIZATION',
+  OPTIMIZATION: 'PERFORMANCE_OPTIMIZATION',
+  // security
+  SECURITY: 'SECURITY_VULNERABILITY',
+  AUTH: 'SECURITY_VULNERABILITY',
+  RLS: 'SECURITY_VULNERABILITY',
+  // docs
+  DOCS: 'DOCUMENTATION',
+  DOC: 'DOCUMENTATION',
+  // ux
+  UI: 'USER_EXPERIENCE',
+  UX: 'USER_EXPERIENCE',
+  USER: 'USER_EXPERIENCE',
+  // explicit catch-alls
+  OTHER: DEFAULT_LEARNING_CATEGORY,
+  GENERAL: DEFAULT_LEARNING_CATEGORY,
+});
+
+/**
+ * Coerce any input to a value the check_learning_category constraint accepts.
+ * - already-valid → returned unchanged
+ * - known alias (case/separator-insensitive) → mapped to the nearest valid value
+ * - anything else (null/empty/unknown) → DEFAULT_LEARNING_CATEGORY
+ * Always returns a member of LEARNING_CATEGORIES, so the insert never fails on this column.
+ *
+ * @param {unknown} input
+ * @returns {string} a valid learning_category
+ */
+function normalizeLearningCategory(input) {
+  if (typeof input !== 'string') return DEFAULT_LEARNING_CATEGORY;
+  const key = input.trim().toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  if (!key) return DEFAULT_LEARNING_CATEGORY;
+  if (VALID.has(key)) return key;
+  if (Object.prototype.hasOwnProperty.call(ALIASES, key)) return ALIASES[key];
+  return DEFAULT_LEARNING_CATEGORY;
+}
+
+module.exports = { LEARNING_CATEGORIES, DEFAULT_LEARNING_CATEGORY, normalizeLearningCategory };

--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -34,6 +34,10 @@ import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { resolveSdInput } from './lib/sd-id-resolver.js';
 import { getFilteredRetrospective } from './modules/handoff/retro-filters.js';
 import { resolveCanonicalAppName } from '../lib/repo-paths.js';
+// SD-FDBK-INFRA-RETROSPECTIVES-CHECK-LEARNING-001: canonical learning_category allowlist + normalizer
+// so any category (incl. plausible-but-rejected guesses) coerces to a constraint-valid value.
+import learningCategoryModule from '../lib/retro/learning-category.cjs';
+const { normalizeLearningCategory } = learningCategoryModule;
 import dotenv from 'dotenv';
 // import fs from 'fs'; // Currently unused - available for file operations if needed
 
@@ -121,7 +125,9 @@ async function generateRetrospective(sdInput) {
     return 'APPLICATION_ISSUE';
   };
 
-  const learning_category = determinelearning_category(sd);
+  // Coerce to a constraint-valid value (defense-in-depth: the heuristic already returns valid values,
+  // but normalization guarantees no insert ever fails on check_learning_category). SD-FDBK-INFRA-RETROSPECTIVES-CHECK-LEARNING-001.
+  const learning_category = normalizeLearningCategory(determinelearning_category(sd));
 
   // High-quality content arrays (will be converted to JSONB)
   const what_went_well_array = [

--- a/tests/unit/learning-category.test.js
+++ b/tests/unit/learning-category.test.js
@@ -1,0 +1,71 @@
+/**
+ * Canonical learning_category allowlist + normalizer — SD-FDBK-INFRA-RETROSPECTIVES-CHECK-LEARNING-001.
+ *
+ * The retrospectives.check_learning_category CHECK accepts exactly 9 values; plausible near-misses
+ * (PROTOCOL_PROCESS, CI_CD, TOOLING, WORKFLOW, CONFIGURATION, OTHER, ...) are rejected. These tests pin
+ * that normalizeLearningCategory coerces any input to a constraint-valid value so a retro never fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { LEARNING_CATEGORIES, DEFAULT_LEARNING_CATEGORY, normalizeLearningCategory } = require('../../lib/retro/learning-category.cjs');
+
+describe('LEARNING_CATEGORIES', () => {
+  it('is the exact 9-value constraint set', () => {
+    expect([...LEARNING_CATEGORIES].sort()).toEqual([
+      'APPLICATION_ISSUE', 'DATABASE_SCHEMA', 'DEPLOYMENT_ISSUE', 'DOCUMENTATION',
+      'PERFORMANCE_OPTIMIZATION', 'PROCESS_IMPROVEMENT', 'SECURITY_VULNERABILITY',
+      'TESTING_STRATEGY', 'USER_EXPERIENCE',
+    ].sort());
+  });
+  it('the default is itself a valid category', () => {
+    expect(LEARNING_CATEGORIES).toContain(DEFAULT_LEARNING_CATEGORY);
+  });
+});
+
+describe('normalizeLearningCategory', () => {
+  it('returns already-valid values unchanged', () => {
+    for (const c of LEARNING_CATEGORIES) expect(normalizeLearningCategory(c)).toBe(c);
+  });
+
+  it('maps the plausible-but-rejected guesses to the nearest valid value', () => {
+    expect(normalizeLearningCategory('PROTOCOL_PROCESS')).toBe('PROCESS_IMPROVEMENT');
+    expect(normalizeLearningCategory('PROCESS')).toBe('PROCESS_IMPROVEMENT');
+    expect(normalizeLearningCategory('INFRASTRUCTURE')).toBe('PROCESS_IMPROVEMENT');
+    expect(normalizeLearningCategory('TOOLING')).toBe('PROCESS_IMPROVEMENT');
+    expect(normalizeLearningCategory('WORKFLOW')).toBe('PROCESS_IMPROVEMENT');
+    expect(normalizeLearningCategory('CONFIGURATION')).toBe('PROCESS_IMPROVEMENT');
+    expect(normalizeLearningCategory('CI_CD')).toBe('DEPLOYMENT_ISSUE');
+  });
+
+  it('is case- and separator-insensitive', () => {
+    expect(normalizeLearningCategory('ci/cd')).toBe('DEPLOYMENT_ISSUE');
+    expect(normalizeLearningCategory('  Ci-Cd  ')).toBe('DEPLOYMENT_ISSUE');
+    expect(normalizeLearningCategory('application_issue')).toBe('APPLICATION_ISSUE');
+    expect(normalizeLearningCategory('database schema')).toBe('DATABASE_SCHEMA');
+  });
+
+  it('maps domain aliases sensibly', () => {
+    expect(normalizeLearningCategory('test')).toBe('TESTING_STRATEGY');
+    expect(normalizeLearningCategory('migration')).toBe('DATABASE_SCHEMA');
+    expect(normalizeLearningCategory('perf')).toBe('PERFORMANCE_OPTIMIZATION');
+    expect(normalizeLearningCategory('auth')).toBe('SECURITY_VULNERABILITY');
+    expect(normalizeLearningCategory('docs')).toBe('DOCUMENTATION');
+    expect(normalizeLearningCategory('ux')).toBe('USER_EXPERIENCE');
+  });
+
+  it('falls back to the default for unknown/empty/non-string input', () => {
+    expect(normalizeLearningCategory('OTHER')).toBe(DEFAULT_LEARNING_CATEGORY);
+    expect(normalizeLearningCategory('zzz-unknown')).toBe(DEFAULT_LEARNING_CATEGORY);
+    expect(normalizeLearningCategory('')).toBe(DEFAULT_LEARNING_CATEGORY);
+    expect(normalizeLearningCategory(null)).toBe(DEFAULT_LEARNING_CATEGORY);
+    expect(normalizeLearningCategory(undefined)).toBe(DEFAULT_LEARNING_CATEGORY);
+    expect(normalizeLearningCategory(42)).toBe(DEFAULT_LEARNING_CATEGORY);
+  });
+
+  it('ALWAYS returns a constraint-valid value', () => {
+    for (const input of ['PROTOCOL_PROCESS', 'CI_CD', 'OTHER', '', null, 'random', 'TOOLING', 'security']) {
+      expect(LEARNING_CATEGORIES).toContain(normalizeLearningCategory(input));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The `retrospectives.check_learning_category` CHECK rejects plausible-but-invalid categories (`PROTOCOL_PROCESS`, `PROCESS`, `INFRASTRUCTURE`, `CI_CD`, `TOOLING`, `WORKFLOW`, `CONFIGURATION`, `OTHER`), forcing a poor-fit category or an insert failure.

**Verify-the-premise:** the live constraint actually accepts **9** reasonable values (`APPLICATION_ISSUE, PROCESS_IMPROVEMENT, TESTING_STRATEGY, DATABASE_SCHEMA, DEPLOYMENT_ISSUE, PERFORMANCE_OPTIMIZATION, USER_EXPERIENCE, SECURITY_VULNERABILITY, DOCUMENTATION`) — **not 2** as the SD assumed. So the real defect is **discoverability**, not a too-narrow constraint → no DDL/widening needed.

## Fix (the SD's non-DDL option)
- NEW `lib/retro/learning-category.cjs`: documented 9-value `LEARNING_CATEGORIES` allowlist + `normalizeLearningCategory(input)` that coerces any near-miss (case/separator-insensitive) to the nearest valid value and **always** returns a constraint-valid member.
- Wired into the canonical writer `scripts/generate-retrospective.js` (ESM default-import of the CJS helper, verified at runtime) so a retro can never fail on this column.
- No DB migration; the 9-value constraint is preserved.

## Tests
- 8 unit tests (valid passthrough, near-miss mapping, case/separator-insensitivity, default fallback, always-valid invariant). `node --check` clean for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
