### PR TITLE
feat(SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-D): advisory-default rollout + docs + 3 exemplars

### DIFF
--- a/docs/protocol/invocation-path-proof.md
+++ b/docs/protocol/invocation-path-proof.md
@@ -1,0 +1,60 @@
+# Invocation-Path Proof (WIRED-TO-FIRE)
+
+> SD-LEO-INFRA-INVOCATION-PATH-PROOF-001 (children -A detector, -B classifier, -C gate, -D this doc + rollout).
+> The systemic catch for the months-long *"shipped + tested + completed but nothing ever fires it"* class.
+
+## REACHABLE vs INVOKED — the distinction this gate adds
+
+Two different questions, two different gates:
+
+| Gate | Proves | Example it catches |
+|------|--------|--------------------|
+| **WIRE_CHECK_GATE** | The new code is **REACHABLE** — a `package.json` script / import path exists so a human *could* run it. | A new CLI with no `npm run` entry. |
+| **INVOCATION_PATH_PROOF** (this) | The autonomous code is **INVOKED** — a *live* production trigger (scheduled GHA workflow / loop-contract+workflow / `.claude` hook / parent-shell) actually fires it on its own. | A `*-loop.cjs` that ships, tests green, completes — but no cron ever runs it, so it sits inert in prod forever. |
+
+**Reachable ≠ invoked.** An npm script proves a human can type it; it does not prove anything autonomous ever calls it. Autonomous runners (crons, sweep loops, daemons) are *supposed* to fire without a human — if nothing schedules them, they are dead on arrival, and that failure is silent (no error, just nothing happens). This gate makes that silence loud at LEAD-FINAL.
+
+## The mechanism (how -A/-B/-C compose)
+
+1. **Classifier — `lib/invocation-detector/requires-invocation.js`** (child -B): decides whether a changed file *requires* a live invocation path. Conservative / fail-open (defaults to NOT-required). A file REQUIRES invocation when it is a genuine autonomous runner:
+   - lives under a `cron/` or `clockwork/` directory, **or**
+   - its filename ends in `-loop` / `-cron` / `-sweep` / `-sweeper` / `-daemon` / `-worker` / `-autotriage`, **or**
+   - it is a declared loop-contract entrypoint, **or**
+   - it has a runnable surface (main / shebang / `process.argv`) **and** in-code scheduling (`setInterval`, `cron`, `--once`, `while (true)`, `every N minutes`).
+   - Libraries (`lib/**`), tests, and one-off/archive files are **never** flagged.
+
+2. **Detector — `lib/invocation-detector/index.js`** (child -A): maps a script to its live triggers across five matchers — `NPM_SCRIPT`, `GHA_WORKFLOW` (only counts when `on: schedule: cron` actually fires the `run:` step), `CLAUDE_HOOK`, `LOOP_CONTRACT_REGISTRY` (registry alone is **data-only**; counts as invoked only when a scheduled workflow wires its entrypoint), and `PARENT_SCRIPT_SHELL`. Returns `{ invoked, triggers[], excluded, warnings }`.
+
+3. **Gate — `scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js`** (child -C): at LEAD-FINAL-APPROVAL, for each **added** `*.js/.mjs/.cjs` under `scripts/`/`lib/` in the SD's diff, a **violation** = *classifier says requires-invocation* **and** *detector says not invoked*. Venture-targeted SDs opt out (their triggers live in another repo) unless `metadata.wiring_required=true`. Fail-OPEN on git/load errors.
+
+## How to satisfy the gate
+
+Wire each flagged file with **one** live trigger:
+
+- A **scheduled GitHub Actions workflow** (`.github/workflows/*.yml` with `on: schedule: cron`) whose `run:` step invokes it (directly or via `npm run`).
+- A **loop-contract registry entry** (`lib/loops/loop-contract-registry.js`) **paired** with a scheduled workflow that wires its entrypoint (registry alone is not enough).
+- A **`.claude` hook** registration (`.claude/settings.json`) if it is a lifecycle hook.
+- A **parent script** that shells it, or an **npm script + workflow**.
+
+If the file is *not* actually autonomous (a library / manual CLI / helper), it should not match the classifier — check its name/location (avoid the autonomous suffixes, the `cron/`·`clockwork/` dirs, and in-code scheduling).
+
+Ship-dormant is fine: a runner gated behind a flag (e.g. `... --apply` / `*_ENABLE`) still needs the workflow that *would* invoke it to exist — the cron proves it is wired; the flag controls whether it acts.
+
+## Rollout criteria (advisory → blocking)
+
+The gate defaults to **ADVISORY** so it cannot mass-fail existing SDs on day one before the wired-to-fire discipline is adopted:
+
+- **`INVOCATION_PATH_PROOF_MODE` unset / `advisory`** (default): violations are reported as **warnings**; the gate **passes**. Use this to measure the real false-positive rate across live SDs.
+- **`INVOCATION_PATH_PROOF_MODE=block`**: violations **fail** the SD (the enforcing posture).
+
+**Promotion criteria:** flip to `block` once advisory runs show the false-positive rate is acceptable (the classifier is conservative, so genuine violations should dominate) and the known exemplars below are all resolved. Promotion is a one-line env change — no code change.
+
+## The 3 backfilled exemplars (current status)
+
+| Instance | File | Status | Proof / rationale |
+|----------|------|--------|-------------------|
+| **exec-email** | `scripts/adam-exec-summary.mjs` | **WIRED** | `.github/workflows/adam-exec-email-cron.yml` (scheduled) drives the exec-email pipeline. |
+| **prod-error-sweep** | `scripts/clockwork/prod-error-sweep-loop.cjs` | **WIRED** | `.github/workflows/prod-error-sweep-loop.yml` `cron: '40 * * * *'` + the `lib/loops/loop-contract-registry.js` entry (SD-LEO-INFRA-PROD-ERROR-SWEEP-WIRE-001). Ship-dormant behind `PROD_ERROR_SWEEP_LOOP_ENABLE`. |
+| **staged→belt** | `scripts/sourcing-engine/proactive-populator.mjs` | **NOT-REQUIRED** (not a violation) | Manual / chairman-gated: no `-loop/-cron/-sweep` suffix, not in `cron/`·`clockwork/`, no in-code scheduling, no loop-contract entry → the classifier returns NOT-required, so it correctly does not need an invocation path. (Auto-promotion is a separate, deliberately chairman-gated decision — see SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001.) |
+
+The staged→belt case is the important nuance: *not every un-wired script is a violation* — only ones the classifier judges genuinely autonomous. A manual, chairman-gated step is correctly exempt.

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js
@@ -37,6 +37,55 @@ function safeRead(absPath) {
 }
 
 /**
+ * SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-D (FR-4): rollout mode resolver.
+ * -C shipped the gate HARD-BLOCKING, which can mass-fail existing SDs on day one before the
+ * wired-to-fire discipline is adopted. Resolve a warn-first ADVISORY default that surfaces
+ * violations WITHOUT failing, promotable to BLOCK via INVOCATION_PATH_PROOF_MODE=block.
+ * @param {object} [env] @returns {'advisory'|'block'}
+ */
+export function resolveInvocationMode(env = process.env) {
+  return (env && env.INVOCATION_PATH_PROOF_MODE) === 'block' ? 'block' : 'advisory';
+}
+
+/**
+ * PURE verdict resolver: turn a violations result + mode into the gate verdict.
+ * - no violations  -> PASS (both modes)
+ * - violations + advisory -> PASS, violations surfaced as WARNINGS (enforcement opt-in)
+ * - violations + block    -> FAIL (passed:false) with issues + remediation (the -C behavior)
+ * @param {{violations:Array, autonomousChecked:number}} evalResult
+ * @param {'advisory'|'block'} mode
+ * @param {string[]} remediation
+ */
+export function resolveInvocationVerdict(evalResult, mode, remediation = []) {
+  const violations = (evalResult && evalResult.violations) || [];
+  const autonomousChecked = (evalResult && evalResult.autonomousChecked) || 0;
+  if (violations.length === 0) {
+    return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details: { mode, autonomousChecked, violations: 0 } };
+  }
+  const lines = violations.map((v) => `  - ${v.file} (${v.requires_reason})`);
+  const headline = `${violations.length} autonomous-runnable file(s) ship without a live production trigger:`;
+  if (mode === 'block') {
+    return {
+      passed: false, score: 0, max_score: 100,
+      issues: [headline, ...lines, ...remediation],
+      warnings: [],
+      details: { mode, autonomousChecked, violations: violations.length, violationFiles: violations.map((v) => v.file) },
+    };
+  }
+  // advisory (default): warn, do not fail — so the gate cannot mass-fail existing SDs during rollout.
+  return {
+    passed: true, score: 100, max_score: 100,
+    issues: [],
+    warnings: [
+      `[ADVISORY] ${headline}`,
+      ...lines,
+      'Enforcement is opt-in: set INVOCATION_PATH_PROOF_MODE=block to FAIL on these. See docs/protocol/invocation-path-proof.md.',
+    ],
+    details: { mode, autonomousChecked, violations: violations.length, violationFiles: violations.map((v) => v.file) },
+  };
+}
+
+/**
  * PURE-ish core: for each changed file, flag a violation when it is autonomous-runnable (FR-2)
  * but has no live trigger (FR-1). Composes the two SSOTs; I/O is injected (readFile), so the
  * decision is unit-testable without git/fs. @returns {{violations:[], autonomousChecked:number}}
@@ -123,10 +172,6 @@ export function createInvocationPathGate(_supabase) {
 
       console.log(`   Autonomous runners checked: ${autonomousChecked} | violations: ${violations.length}`);
 
-      if (violations.length === 0) {
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details: { autonomousChecked, violations: 0 } };
-      }
-
       const remediation = [
         'This SD ships autonomous-runnable code with no live production trigger (WIRED-TO-FIRE). Wire each file with ONE of:',
         '  • A scheduled GitHub Actions workflow (.github/workflows/*.yml with `on: schedule: cron`) whose run: step invokes it (directly or via `npm run`).',
@@ -136,18 +181,11 @@ export function createInvocationPathGate(_supabase) {
         'If the file is NOT actually autonomous (a library/manual CLI/helper), it should not match the FR-2 classifier — verify its name/location (avoid -loop/-cron/-sweep suffix, cron/clockwork dirs, and in-code setInterval/cron unless it truly runs autonomously).',
       ];
 
-      return {
-        passed: false,
-        score: 0,
-        max_score: 100,
-        issues: [
-          `${violations.length} autonomous-runnable file(s) ship without a live production trigger:`,
-          ...violations.map((v) => `  - ${v.file} (${v.requires_reason})`),
-          ...remediation,
-        ],
-        warnings: [],
-        details: { autonomousChecked, violations: violations.length, violationFiles: violations.map((v) => v.file) },
-      };
+      // SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-D (FR-4): advisory-by-default rollout. Advisory surfaces
+      // violations as warnings (passed:true); INVOCATION_PATH_PROOF_MODE=block restores -C's hard fail.
+      const mode = resolveInvocationMode();
+      if (violations.length > 0) console.log(`   Mode: ${mode}${mode === 'advisory' ? ' (advisory — warns, does not fail; set INVOCATION_PATH_PROOF_MODE=block to enforce)' : ' (BLOCKING)'}`);
+      return resolveInvocationVerdict({ violations, autonomousChecked }, mode, remediation);
     },
     required: true,
   };

--- a/tests/unit/invocation-path-rollout-mode.test.js
+++ b/tests/unit/invocation-path-rollout-mode.test.js
@@ -1,0 +1,51 @@
+// SD-LEO-INFRA-INVOCATION-PATH-PROOF-001-D (FR-4): advisory<->blocking rollout for the
+// INVOCATION_PATH_PROOF gate. Advisory (default) surfaces violations as warnings WITHOUT failing
+// (so it cannot mass-fail existing SDs on day one); block restores the -C hard-fail.
+import { describe, it, expect } from 'vitest';
+import { resolveInvocationMode, resolveInvocationVerdict } from '../../scripts/modules/handoff/executors/lead-final-approval/gates/invocation-path-gate.js';
+
+const VIOLATIONS = { violations: [{ file: 'scripts/foo-loop.cjs', requires_reason: 'autonomous_suffix' }], autonomousChecked: 1 };
+const NONE = { violations: [], autonomousChecked: 1 };
+const REMEDIATION = ['wire it'];
+
+describe('resolveInvocationMode', () => {
+  it('defaults to advisory when the flag is unset', () => {
+    expect(resolveInvocationMode({})).toBe('advisory');
+  });
+  it('is block only when explicitly INVOCATION_PATH_PROOF_MODE=block', () => {
+    expect(resolveInvocationMode({ INVOCATION_PATH_PROOF_MODE: 'block' })).toBe('block');
+    expect(resolveInvocationMode({ INVOCATION_PATH_PROOF_MODE: 'advisory' })).toBe('advisory');
+    expect(resolveInvocationMode({ INVOCATION_PATH_PROOF_MODE: 'anything-else' })).toBe('advisory');
+  });
+});
+
+describe('resolveInvocationVerdict', () => {
+  it('advisory + violations -> PASS with violations as warnings (no mass-fail)', () => {
+    const v = resolveInvocationVerdict(VIOLATIONS, 'advisory', REMEDIATION);
+    expect(v.passed).toBe(true);
+    expect(v.issues).toEqual([]);
+    expect(v.warnings.join('\n')).toContain('scripts/foo-loop.cjs');
+    expect(v.warnings.join('\n')).toContain('ADVISORY');
+    expect(v.details).toMatchObject({ mode: 'advisory', violations: 1 });
+  });
+
+  it('block + violations -> FAIL with issues + remediation (the -C behavior)', () => {
+    const v = resolveInvocationVerdict(VIOLATIONS, 'block', REMEDIATION);
+    expect(v.passed).toBe(false);
+    expect(v.score).toBe(0);
+    expect(v.issues.join('\n')).toContain('scripts/foo-loop.cjs');
+    expect(v.issues).toContain('wire it');
+    expect(v.warnings).toEqual([]);
+    expect(v.details).toMatchObject({ mode: 'block', violations: 1 });
+  });
+
+  it('no violations -> PASS in both modes', () => {
+    for (const mode of ['advisory', 'block']) {
+      const v = resolveInvocationVerdict(NONE, mode, REMEDIATION);
+      expect(v.passed).toBe(true);
+      expect(v.issues).toEqual([]);
+      expect(v.warnings).toEqual([]);
+      expect(v.details).toMatchObject({ mode, violations: 0 });
+    }
+  });
+});


### PR DESCRIPTION
## What & why
FR-4, the final child of the invocation-path-proof orchestrator. Sibling **-C** shipped the `INVOCATION_PATH_PROOF` LEAD-FINAL gate **hard-blocking** (`passed:false` on any violation, `required:true`) — on day one that can **mass-fail** any SD adding an autonomous script without a live trigger, before the team has adopted the wired-to-fire discipline.

## Change
- **Rollout mode** — new pure `resolveInvocationMode` (env `INVOCATION_PATH_PROOF_MODE`, default **`advisory`**) + `resolveInvocationVerdict`. Advisory surfaces violations as **warnings** and **passes**; `=block` restores -C's hard fail. Wired into the gate's violations branch; the PASS / venture-opt-out / fail-open paths are unchanged.
- **Docs** — `docs/protocol/invocation-path-proof.md`: REACHABLE (`WIRE_CHECK`) vs INVOKED (this gate), how detector(-A)/classifier(-B)/gate(-C) compose, how to satisfy the gate, and the advisory→blocking rollout/promotion criteria.
- **Backfill the 3 exemplars** with current status: exec-email (`adam-exec-summary.mjs`, wired), prod-error-sweep (`prod-error-sweep-loop.cjs`, now wired by #4979, ship-dormant), staged→belt (`proactive-populator.mjs`, **NOT-REQUIRED** — manual/chairman-gated, correctly not a violation — the key nuance that not every un-wired script is a gap).

## Verification
- **5 rollout-mode unit tests** (`invocation-path-rollout-mode.test.js`): mode resolver (default advisory; block only when explicit), advisory+violations→pass+warnings, block+violations→fail+issues, no-violations→pass both modes.
- Existing -C gate tests still **10/10** (no regression).

Production invocation path: the LEAD-FINAL-APPROVAL gate pipeline runs `INVOCATION_PATH_PROOF` on every SD completion (advisory by default now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)