### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E): coordinator auto-refill awareness advisory

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -204,6 +204,33 @@ export function detectCrossRepoStarvation({ claimableSds = [], liveSessionApps =
   };
 }
 
+/**
+ * AUTO-REFILL AWARENESS ADVISORY (SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E): make the coordinator
+ * AWARE that the staged→belt corpus HAS valid auto-promote candidates waiting, so it neither false-flags
+ * "belt dry" nor hand-promotes from harness_backlog blindly (the documented anti-pattern). `promotableCount`
+ * is the -B dry-run verifier's validCount (verifyStagedCandidates(...).validCount — the -A predicate applied to
+ * the staged roadmap_wave_items). ADVISORY only: surfaces a remediation, never a hard exit. Suppressed once the
+ * chairman-gated -C auto-refill cron is live (it drains them). Pure; conservative (no candidates → no advisory).
+ *
+ * @param {{ promotableCount?: number, autoRefillLive?: boolean, threshold?: number }} p
+ */
+export function detectAutoRefillBacklog({ promotableCount = 0, autoRefillLive = false, threshold = 1 } = {}) {
+  const n = Number.isFinite(promotableCount) && promotableCount > 0 ? Math.floor(promotableCount) : 0;
+  const violation = !autoRefillLive && n >= threshold;
+  return {
+    violation,
+    promotableCount: n,
+    detail: violation
+      ? `${n} staged roadmap_wave_items are valid auto-promote candidates but auto-refill is not draining them (cron not live)`
+      : (autoRefillLive
+        ? `auto-refill live (${n} promotable staged candidate(s))`
+        : (n === 0 ? 'no promotable staged candidates' : `${n} promotable (below advisory threshold ${threshold})`)),
+    remediation: violation
+      ? `ADVISORY: ${n} promotable staged candidate(s) waiting — preview with 'npm run sourcing:refill-verify', then enable the chairman-gated auto-refill cron to drain them (do NOT hand-promote from harness_backlog).`
+      : null,
+  };
+}
+
 /** QUIET-TICK committed-action verification: the latest coordinator_review lacks prior_action_outcomes for the
  *  prior cycle's committed_actions (the grade->action->verify loop is broken). reviews are latest-first. */
 export function detectQuietTickUnverified({ coordinatorReviews = [] } = {}) {

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -32,7 +32,11 @@ import {
   extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectProgressStall, detectCrossRepoStarvation,
   // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3): coordinator mirror detectors.
   detectSourceToCapacity, detectCoordinatorWithoutAdam,
+  // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: auto-refill awareness advisory.
+  detectAutoRefillBacklog,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
+// SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: the -B dry-run verifier supplies the promotable count.
+import { verifyStagedCandidates } from '../lib/sourcing-engine/refill-dry-run-verifier.js';
 // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: DUTY-7 silent-stall detector (drafts stranded with null vision_score).
 import { findStalledDrafts } from '../lib/coordinator/draft-stall-detector.mjs';
 // SD-LEO-INFRA-ADAM-VISION-SD-FLOW-001: DUTY-9 LEAD-aging detector (scored, unclaimed Adam-sourced vision drafts
@@ -201,6 +205,17 @@ async function main() {
     }
   } catch { /* leave sourceReqRecently null → skip */ }
 
+  // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: count valid auto-promote candidates in the staged
+  // corpus (read-only) via the -B dry-run verifier + -A predicate, so the coordinator is AWARE the belt
+  // can be refilled. Best-effort / fail-open: any error leaves promotableCount=0 (no advisory).
+  let promotableCount = 0;
+  try {
+    const { data: staged, error: se } = await db.from('roadmap_wave_items')
+      .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane')
+      .eq('item_disposition', 'pending').is('promoted_to_sd_key', null).limit(2000);
+    if (!se) promotableCount = verifyStagedCandidates(staged || []).validCount;
+  } catch { /* fail-open → promotableCount stays 0, no advisory */ }
+
   // ── run the pure detectors ──
   const D = {
     pool: detectWorktreePool({ count: wtCount, max: MAX_WORKTREE_COUNT }),
@@ -209,6 +224,9 @@ async function main() {
     rank: detectBacklogRankStaleness({ claimableSds: claimable, nowMs, ttlMs: DISPATCH_RANK_TTL_MS }),
     // SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: cross-repo SDs no live worker checkout can build (silent starvation).
     crossRepo: detectCrossRepoStarvation({ claimableSds: claimable, liveSessionApps, nowMs }),
+    // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: belt CAN be refilled — promotable staged candidates
+    // exist but auto-refill isn't draining them. Advisory; suppressed once AUTO_REFILL_CRON_LIVE=true.
+    autoRefill: detectAutoRefillBacklog({ promotableCount, autoRefillLive: process.env.AUTO_REFILL_CRON_LIVE === 'true' }),
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),
     // FR-3 coordinator mirror — added only when their facts resolved (skip-on-error, no spam).
     ...(adamAlive !== null ? { d3lean: detectCoordinatorWithoutAdam({ coordinatorAlive: true, adamAlive }) } : {}),
@@ -234,6 +252,7 @@ async function main() {
   for (const a of D.dep.anomalies.slice(0, 5)) console.log('      ANOMALY ' + a.sd + ' dep(s) not found: ' + a.unknownDeps.join(','));
   console.log('  DUTY-6 BACKLOG-RANK  : ' + D.rank.detail + flag(D.rank));
   console.log('  CROSS-REPO STARVATION: ' + D.crossRepo.detail + flag(D.crossRepo)); // FLEET-SELF-CLAIM-001
+  console.log('  AUTO-REFILL BACKLOG  : ' + D.autoRefill.detail + flag(D.autoRefill)); // AUTO-REFILL-SELECTION-GATE-001-E
   console.log('  QUIET-TICK COMMITTED : ' + D.quiet.detail + flag(D.quiet));
   console.log('  DUTY-7 DRAFT-STALL   : ' + D.draft.detail + flag(D.draft)); // SILENT-STALL-PREVENTION-001
   console.log('  DUTY-8 PROGRESS-STALL: ' + D.progress.detail + flag(D.progress)); // PROGRESS-STALL-DETECTION-001

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -9,6 +9,7 @@ import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
   extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectCrossRepoStarvation,
+  detectAutoRefillBacklog,
 } from '../../../lib/coordinator/charter-audit-detectors.mjs';
 import { STANDARD_LOOPS } from '../../../scripts/coordinator-startup-check.mjs';
 
@@ -302,5 +303,40 @@ describe('detectCrossRepoStarvation (SD-FDBK-INFRA-FLEET-SELF-CLAIM-001)', () =>
   it('empty claimable belt -> no violation', () => {
     const r = detectCrossRepoStarvation({ claimableSds: [], liveSessionApps: ['EHG_Engineer'], nowMs: NOW });
     expect(r.violation).toBe(false);
+  });
+});
+
+describe('detectAutoRefillBacklog (SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E)', () => {
+  it('promotable candidates + auto-refill NOT live -> advisory violation with remediation', () => {
+    const r = detectAutoRefillBacklog({ promotableCount: 17, autoRefillLive: false });
+    expect(r.violation).toBe(true);
+    expect(r.promotableCount).toBe(17);
+    expect(r.detail).toMatch(/17 staged/);
+    expect(r.remediation).toMatch(/sourcing:refill-verify/);
+  });
+
+  it('no promotable candidates -> no advisory (conservative)', () => {
+    const r = detectAutoRefillBacklog({ promotableCount: 0, autoRefillLive: false });
+    expect(r.violation).toBe(false);
+    expect(r.remediation).toBeNull();
+    expect(r.detail).toMatch(/no promotable/);
+  });
+
+  it('auto-refill LIVE suppresses the advisory even with candidates (cron drains them)', () => {
+    const r = detectAutoRefillBacklog({ promotableCount: 50, autoRefillLive: true });
+    expect(r.violation).toBe(false);
+    expect(r.detail).toMatch(/auto-refill live/);
+  });
+
+  it('respects a custom threshold (below -> no advisory)', () => {
+    expect(detectAutoRefillBacklog({ promotableCount: 3, threshold: 10 }).violation).toBe(false);
+    expect(detectAutoRefillBacklog({ promotableCount: 10, threshold: 10 }).violation).toBe(true);
+  });
+
+  it('is total-safe on odd input (NaN/negative/undefined -> 0, no advisory)', () => {
+    expect(detectAutoRefillBacklog({ promotableCount: NaN }).promotableCount).toBe(0);
+    expect(detectAutoRefillBacklog({ promotableCount: -5 }).violation).toBe(false);
+    expect(detectAutoRefillBacklog().violation).toBe(false);
+    expect(detectAutoRefillBacklog({ promotableCount: 2.9 }).promotableCount).toBe(2); // floored
   });
 });


### PR DESCRIPTION
## Summary
Auto-refill child of AUTO-REFILL-SELECTION-GATE-001: a pure `detectAutoRefillBacklog` that surfaces to the coordinator — as a charter-audit **advisory** — that N staged `roadmap_wave_items` are valid auto-promote candidates (count via the -B `verifyStagedCandidates` over staged rows, applying the -A predicate) but auto-refill isn't draining them. So the coordinator stops false-flagging *belt-dry* / hand-promoting from `harness_backlog` blindly.

**Wired LIVE** into `scripts/coordinator-charter-audit.mjs` (a new `AUTO-REFILL BACKLOG` duty line, read-only fail-open fetch, invoked every coordinator tick — *invoked, not merely reachable*). Advisory only (a remediation, never a hard exit); conservative (0 candidates → none); suppressed once `AUTO_REFILL_CRON_LIVE=true` (the chairman-gated -C cron drains them). Reuses the -A/-B SSOTs.

## Adversarial-hardened
Review: **clean, no ship-blockers** — crash-safety of the coordinator-audit wiring confirmed (fail-open), advisory-only (no hard exit), purity/total-safety verified. One LOW: `AUTO_REFILL_CRON_LIVE` has no producer yet — wire it when -C ships.

## Note
Committed with `--no-verify` via the documented `LEO_ALLOW_NO_VERIFY` override: the Gate 0 pre-commit hook's *validation passed* but its supabase-js client tripped the Windows libuv UV_HANDLE_CLOSING assertion on exit 4× (harness bug, signaled). Detector-only diff, no secrets/CLAUDE.md.

## Tests
48 detector tests (5 new: advisory / conservative-zero / suppression / threshold / total-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)