### PR TITLE
fix(SD-FDBK-INFRA-FATAL-CRASH-STALE-001): stale-session-sweep crash on IDENTITY_SPLIT (builder .catch())

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -494,7 +494,12 @@ async function splitCollidingSessions(supabase, collisions, actions, warnings) {
           original_session_id: collision.session_id
         },
         sender_type: 'sweep'
-      }).catch(() => {});
+      // SD-FDBK-INFRA-FATAL-CRASH-STALE-001: a PostgREST builder is thenable but exposes no catch
+      // method, so chaining catch directly onto the insert builder threw TypeError synchronously and
+      // main's rejection handler did process.exit(1), aborting the ENTIRE sweep tick on the
+      // (intermittent) IDENTITY_SPLIT path. then() yields a real Promise first, so the rejection
+      // handler is valid — the same fire-and-forget pattern this file already uses near line 1621.
+      }).then(() => {}).catch(() => {});
 
       actions.push('IDENTITY_SPLIT: PID ' + extra.pid + ' → new session ' + newSessionId.substring(0, 20) + ' (terminal_id=' + newTerminalId + ')');
     }

--- a/tests/unit/stale-session-sweep-builder-catch.test.js
+++ b/tests/unit/stale-session-sweep-builder-catch.test.js
@@ -1,0 +1,43 @@
+/**
+ * SD-FDBK-INFRA-FATAL-CRASH-STALE-001 — regression guard for the FATAL builder-.catch() crash.
+ *
+ * A Supabase PostgREST builder (.insert/.update/.upsert/.delete/.select) is THENABLE but does NOT
+ * expose a .catch() method. Calling `.insert(...).catch(...)` therefore throws
+ * "TypeError: ...catch is not a function" SYNCHRONOUSLY (when .catch is evaluated), and in
+ * stale-session-sweep.cjs that propagated to main().catch -> process.exit(1), aborting the ENTIRE
+ * sweep tick on the (intermittent) IDENTITY_SPLIT path. The fix is `.then(() => {}).catch(...)`:
+ * .then() returns a real Promise on which .catch() is valid.
+ *
+ * This guard scans the source so the bug class can't silently reappear anywhere in the file: every
+ * `.catch(` must be preceded in its chain by a `.then(` (real Promise) or be `main().catch`. The code
+ * comments in this file deliberately avoid the literal "<dot>catch(" token so the scan never false-flags
+ * prose (the fix comment says "catch method"/"rejection handler" instead).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.resolve(__dirname, '../../scripts/stale-session-sweep.cjs'), 'utf8');
+
+describe('stale-session-sweep: no Supabase builder .catch() without a preceding .then()', () => {
+  it('every .catch() is on a real Promise (.then(...).catch or main().catch), never a raw thenable builder', () => {
+    const offenders = [];
+    for (const m of SRC.matchAll(/\.catch\s*\(/g)) {
+      const idx = m.index;
+      const before = SRC.slice(Math.max(0, idx - 60), idx);
+      const onRealPromise = /\.then\s*\(/.test(before) || /main\s*\(\s*\)\s*$/.test(before.trimEnd());
+      if (!onRealPromise) {
+        const lineNo = SRC.slice(0, idx).split('\n').length;
+        offenders.push(`line ${lineNo}: ...${before.slice(-40).replace(/\n/g, '\\n')}.catch(`);
+      }
+    }
+    expect(offenders, `builder .catch() without a preceding .then() (FATAL — crashes the sweep tick):\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('the IDENTITY_COLLISION notification insert uses the .then().catch() fire-and-forget pattern', () => {
+    // Anchor on the specific site this SD fixed so a future edit that reverts it is caught explicitly.
+    expect(SRC).toMatch(/sender_type:\s*'sweep'[\s\S]{0,400}?\}\)\s*\.then\(\s*\(\)\s*=>\s*\{\}\s*\)\s*\.catch\(/);
+  });
+});


### PR DESCRIPTION
## Summary
`scripts/stale-session-sweep.cjs` (a core coordinator monitor) crashed **FATALLY** on the IDENTITY_SPLIT path: it did `await supabase.from('session_coordination').insert({...}).catch(() => {})`. A PostgREST builder is **thenable but exposes no `.catch()` method**, so `.catch` is evaluated synchronously and throws `TypeError`, which propagated to `main()`'s rejection handler → `process.exit(1)`, **aborting the entire sweep tick** (no dead-claim release / dead-letter cleanup / conflict resolution that tick). Intermittent because the IDENTITY_SPLIT path only fires on a `terminal_id` collision (two Claude Code PIDs sharing a session).

## Fix
`.insert({...}).then(() => {}).catch(() => {})` — `.then()` yields a real Promise on which the rejection handler is valid, preserving the fire-and-forget intent. This is the **exact pattern the same file already uses near line 1621**; the other two `.catch` sites (the L1621 `.then().catch` and `main().catch` on a real async Promise) were already correct and are unchanged.

## Tests
- `stale-session-sweep-builder-catch.test.js` (NEW, 2) — a **whole-file guard** asserting every `.catch(` is on a real Promise (`.then(...).catch` or `main().catch`), never a raw thenable builder, so the bug class can't reappear *anywhere* in the file; plus an anchored check on the IDENTITY_COLLISION insert. ✅
- `stale-session-sweep-terminal-parser.test.js` (sibling) — 4/4 ✅ (no regression)
- `node --check` — OK

Minimal diff (only the one broken site + the guard test); no behavior change beyond not crashing; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
