### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C): flag-gated auto-refill cron (staged->belt, dormant)

### DIFF
--- a/.github/workflows/sourcing-auto-refill-cron.yml
+++ b/.github/workflows/sourcing-auto-refill-cron.yml
@@ -1,0 +1,51 @@
+name: Sourcing Auto-Refill Cron
+
+# SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C: schedule the flag-gated auto-refill cron
+# (scripts/sourcing-engine/refill-cron.mjs) that promotes VALID staged roadmap_wave_items onto the
+# belt (create draft SD + stamp promoted_to_sd_key), closing the staged->belt gap that the coordinator
+# currently bridges by hand (the documented anti-pattern). SHIP-DORMANT by design: the script exits
+# [SKIP] (exit 0) unless SOURCING_AUTO_REFILL_V1 === 'true', so wiring the schedule is safe — the
+# chairman flips the repo variable SOURCING_AUTO_REFILL_V1=true to activate it (no code change). Until
+# then every run is a clean no-op SKIP. Mirrors the sibling prod-error-sweep-loop.yml.
+on:
+  schedule:
+    # Hourly at :25 (offset from the other sourcing/sweep crons to avoid the top-of-hour cluster).
+    - cron: '25 * * * *'
+  workflow_dispatch: {}
+
+# The cron creates SDs — never overlap runs; newest waits rather than piling up.
+concurrency:
+  group: sourcing-auto-refill-cron
+  cancel-in-progress: false
+
+jobs:
+  auto-refill:
+    name: Auto-refill staged -> belt (gated by SOURCING_AUTO_REFILL_V1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+
+      - name: Run auto-refill cron (SKIP unless SOURCING_AUTO_REFILL_V1=true)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Chairman activation switch — set repo variable SOURCING_AUTO_REFILL_V1=true to enable.
+          # Absent/anything-but-'true' => the script logs [SKIP] and exits 0 (ship-dormant).
+          SOURCING_AUTO_REFILL_V1: ${{ vars.SOURCING_AUTO_REFILL_V1 }}
+        # Fail-soft: a refill hiccup must never mark the schedule red.
+        continue-on-error: true
+        # --apply is REQUIRED: the script has TWO gates — the SOURCING_AUTO_REFILL_V1 skip (fires first,
+        # returns early when off) AND a separate --apply WRITE gate (default DRY-RUN promotes ZERO items).
+        # Omitting --apply would make this a no-op even when enabled (the exact wired-but-no-op class this
+        # SD's double-gate guards against). With the enable flag OFF the run still SKIPs before --apply
+        # matters, so passing it unconditionally is safe. Mirrors prod-error-sweep-loop.yml.
+        run: node scripts/sourcing-engine/refill-cron.mjs --apply

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -14,8 +14,9 @@
  * selectRefillBatch + buildRefillSdPayload are PURE + TOTAL (no DB/fs/clock; never throw on odd input).
  * ESM (this repo is type:module) — mirrors lib/sourcing-engine/refill-dry-run-verifier.js.
  */
+import { randomUUID } from 'crypto';
 import { verifyStagedCandidates } from './refill-dry-run-verifier.js';
-import { buildTwoWayStamp } from './register-first.js';
+import { buildTwoWayStamp, deriveSdFieldsFromRoadmapItem } from './register-first.js';
 
 /** Default per-run promotion cap — a single run never promotes more than this onto the belt. */
 export const DEFAULT_REFILL_BATCH_LIMIT = 10;
@@ -67,20 +68,32 @@ export function buildRefillSdKey(item) {
  */
 export function buildRefillSdPayload(item, sdKey) {
   const it = item || {};
-  const title = (it.title && String(it.title).trim()) || 'Auto-refill candidate';
+  const md = it.metadata && typeof it.metadata === 'object' ? it.metadata : {};
+  // Reuse the CANONICAL promotion-field deriver (the same one manual --from-roadmap-item promotion
+  // uses) so auto-refill cannot drift from it: it returns sd_type=null when untyped (so createSD's
+  // key-prefix default applies instead of a baked 'feature'), DISTINCT description/scope (not title
+  // clones -> not a bare-shell), strategic_intent, and a needs_enrichment flag for thin items.
+  const f = deriveSdFieldsFromRoadmapItem(it);
   return {
+    // id is NOT NULL with no DB default — omitting it makes every insert fail 23502 (the raw-insert
+    // path bypasses createSD which mints it). Mint a uuid here (mirrors leo-create-sd.js).
+    id: randomUUID(),
     sd_key: sdKey,
-    title: title.slice(0, 200),
+    title: String(f.title || 'Auto-refill candidate').slice(0, 200),
     status: 'draft',
-    sd_type: 'feature',
-    description: 'Auto-promoted from staged roadmap_wave_items by the auto-refill cron '
-      + `(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C). Source: ${it.source_type || 'unknown'}:${it.source_id || it.id || 'unknown'}.`,
-    scope: `Staged candidate: ${title}`.slice(0, 500),
+    sd_type: f.type ?? null, // null -> createSD/key-prefix default; explicit metadata.sd_type wins
+    // target_application: honor an explicit item hint; else EHG_Engineer (auto-refill operates on the
+    // engineer roadmap belt) rather than the DB's EHG default which would mis-route harness items.
+    target_application: md.target_application || 'EHG_Engineer',
+    description: f.description,
+    scope: f.scope,
+    strategic_intent: f.strategic_intent,
     metadata: {
       sourced_by: 'auto-refill',
       promoted_from_roadmap_item_id: it.id || null,
       source_type: it.source_type || null,
       source_id: it.source_id || null,
+      ...(f.needs_enrichment ? { needs_enrichment: f.needs_enrichment } : {}),
       ...(it.lane ? { lane: it.lane } : {}),
     },
   };
@@ -115,7 +128,14 @@ export async function promoteStagedCandidate(supabase, item, opts = {}) {
 
   const { error: insErr } = await supabase
     .from('strategic_directives_v2').insert(buildRefillSdPayload(item, sdKey));
-  if (insErr) { out.reason = `insert_failed: ${insErr.message}`; return out; }
+  if (insErr) {
+    // A concurrent cron/manual promote can win the race between the existence check and the insert;
+    // the sd_key unique constraint (23505) makes that a clean idempotent no-op, not a failure.
+    if (insErr.code === '23505' || /duplicate key|already exists/i.test(insErr.message || '')) {
+      out.reason = 'sd_exists'; return out;
+    }
+    out.reason = `insert_failed: ${insErr.message}`; return out;
+  }
 
   // Two-way stamp (fail-soft — the SD already exists; a missed stamp is recoverable, not corrupting).
   const stamp = buildTwoWayStamp(item, sdKey);

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C — flag-gated auto-refill promote (staged -> belt).
+ *
+ * The LIVE-FLIP step that closes the staged->belt gap: proactive-populator STAGES roadmap_wave_items at
+ * item_disposition='pending' and stops; the coordinator hand-promotes every tick (the anti-pattern). This
+ * module promotes VALID staged candidates onto the belt = create a draft SD from the staged row + stamp
+ * roadmap_wave_items.promoted_to_sd_key (two-way link via register-first buildTwoWayStamp).
+ *
+ * SAFETY: it reuses the -A candidate-validity SSOT through -B's verifyStagedCandidates (no predicate
+ * re-implementation -> can't drift), caps every run at a batch limit so it can never flood the belt, and is
+ * DOUBLE-GATED at the CLI (SOURCING_AUTO_REFILL_V1 enable flag + --apply write flag). promoteStagedCandidate
+ * is the ONLY writer and is a no-op preview unless apply:true.
+ *
+ * selectRefillBatch + buildRefillSdPayload are PURE + TOTAL (no DB/fs/clock; never throw on odd input).
+ * ESM (this repo is type:module) — mirrors lib/sourcing-engine/refill-dry-run-verifier.js.
+ */
+import { verifyStagedCandidates } from './refill-dry-run-verifier.js';
+import { buildTwoWayStamp } from './register-first.js';
+
+/** Default per-run promotion cap — a single run never promotes more than this onto the belt. */
+export const DEFAULT_REFILL_BATCH_LIMIT = 10;
+
+/**
+ * Select the staged rows to promote this run: the VALID candidates (per the -A/-B SSOT), capped at limit.
+ * Pure + total.
+ * @param {Array<Object>} rows  staged roadmap_wave_items rows
+ * @param {{limit?:number}} [opts]
+ * @returns {{ batch:Array<Object>, validCount:number, total:number, limit:number, byReason:Object }}
+ */
+export function selectRefillBatch(rows, opts = {}) {
+  const limit = Number.isInteger(opts.limit) && opts.limit > 0 ? opts.limit : DEFAULT_REFILL_BATCH_LIMIT;
+  const report = verifyStagedCandidates(rows);
+  return {
+    batch: report.valid.slice(0, limit),
+    validCount: report.validCount,
+    total: report.total,
+    limit,
+    byReason: report.byReason,
+  };
+}
+
+/** Short, stable suffix from a string (no clock/random) so promotion keys are deterministic + idempotent. */
+function stableSuffix(input) {
+  let h = 0;
+  const s = String(input == null ? '' : input);
+  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  return Math.abs(h).toString(36).toUpperCase().slice(0, 8).padStart(8, '0');
+}
+
+/**
+ * Build the deterministic SD key for a staged item. Deterministic on source -> re-running the cron never
+ * mints a second key for the same item (paired with the already_promoted predicate guard for idempotency).
+ * @param {{source_type?:string, source_id?:string, id?:string}} item
+ * @returns {string}
+ */
+export function buildRefillSdKey(item) {
+  const it = item || {};
+  return `SD-REFILL-${stableSuffix(`${it.source_type || ''}:${it.source_id || it.id || ''}`)}`;
+}
+
+/**
+ * Build the draft-SD insert payload from a staged roadmap_wave_items row. Pure. Mirrors the minimal shape
+ * roadmap-manager.js uses for a promoted item (draft + traceable provenance in metadata).
+ * @param {{id?:string, title?:string, source_type?:string, source_id?:string, lane?:string, wave_id?:string}} item
+ * @param {string} sdKey
+ * @returns {Object} strategic_directives_v2 insert payload
+ */
+export function buildRefillSdPayload(item, sdKey) {
+  const it = item || {};
+  const title = (it.title && String(it.title).trim()) || 'Auto-refill candidate';
+  return {
+    sd_key: sdKey,
+    title: title.slice(0, 200),
+    status: 'draft',
+    sd_type: 'feature',
+    description: 'Auto-promoted from staged roadmap_wave_items by the auto-refill cron '
+      + `(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C). Source: ${it.source_type || 'unknown'}:${it.source_id || it.id || 'unknown'}.`,
+    scope: `Staged candidate: ${title}`.slice(0, 500),
+    metadata: {
+      sourced_by: 'auto-refill',
+      promoted_from_roadmap_item_id: it.id || null,
+      source_type: it.source_type || null,
+      source_id: it.source_id || null,
+      ...(it.lane ? { lane: it.lane } : {}),
+    },
+  };
+}
+
+/**
+ * Promote a SINGLE staged candidate onto the belt: create a draft SD + stamp the roadmap row's
+ * promoted_to_sd_key (two-way link). The ONLY writer here. Dry-run (apply:false, the default) performs NO
+ * writes and just reports what it WOULD do. Idempotent: an item already carrying promoted_to_sd_key, or
+ * whose deterministic key already exists, is a no-op.
+ *
+ * @param {object} supabase  service-role client
+ * @param {Object} item      a staged roadmap_wave_items row (must have id)
+ * @param {{apply?:boolean}} [opts]
+ * @returns {Promise<{promoted:boolean, dry_run:boolean, sd_key:string|null, reason:string|null}>}
+ */
+export async function promoteStagedCandidate(supabase, item, opts = {}) {
+  const apply = opts.apply === true;
+  const out = { promoted: false, dry_run: !apply, sd_key: null, reason: null };
+  if (!item || !item.id) { out.reason = 'missing_item_id'; return out; }
+  if (item.promoted_to_sd_key) { out.reason = 'already_promoted'; out.sd_key = item.promoted_to_sd_key; return out; }
+
+  const sdKey = buildRefillSdKey(item);
+  out.sd_key = sdKey;
+
+  // Idempotency guard: never mint a duplicate SD for the same deterministic key.
+  const { data: existing } = await supabase
+    .from('strategic_directives_v2').select('sd_key').eq('sd_key', sdKey).limit(1);
+  if (existing && existing.length) { out.reason = 'sd_exists'; return out; }
+
+  if (!apply) { out.reason = 'dry_run'; return out; }
+
+  const { error: insErr } = await supabase
+    .from('strategic_directives_v2').insert(buildRefillSdPayload(item, sdKey));
+  if (insErr) { out.reason = `insert_failed: ${insErr.message}`; return out; }
+
+  // Two-way stamp (fail-soft — the SD already exists; a missed stamp is recoverable, not corrupting).
+  const stamp = buildTwoWayStamp(item, sdKey);
+  const { error: upErr } = await supabase
+    .from('roadmap_wave_items').update(stamp.roadmap).eq('id', item.id);
+  if (upErr) { out.promoted = true; out.reason = `promoted_stamp_warn: ${upErr.message}`; return out; }
+
+  out.promoted = true;
+  out.reason = 'promoted';
+  return out;
+}

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -22,6 +22,16 @@ import { buildTwoWayStamp, deriveSdFieldsFromRoadmapItem } from './register-firs
 export const DEFAULT_REFILL_BATCH_LIMIT = 10;
 
 /**
+ * Allowed sd_type values (mirrors the DB sd_type_check constraint). The deriver passes metadata.sd_type
+ * straight through, so a staged item carrying an out-of-list value would 23514 on raw insert; clamp to a
+ * safe default instead (defense-in-depth — no live staged item currently carries metadata.sd_type).
+ */
+const ALLOWED_SD_TYPES = new Set([
+  'feature', 'bugfix', 'database', 'infrastructure', 'security', 'refactor', 'documentation',
+  'orchestrator', 'performance', 'enhancement', 'docs', 'discovery_spike', 'implementation', 'ux_debt', 'uat',
+]);
+
+/**
  * Select the staged rows to promote this run: the VALID candidates (per the -A/-B SSOT), capped at limit.
  * Pure + total.
  * @param {Array<Object>} rows  staged roadmap_wave_items rows
@@ -85,7 +95,9 @@ export function buildRefillSdPayload(item, sdKey) {
   // misalign with the category. So pin a concrete type: the deriver's value when typed, else
   // 'infrastructure' (the engineer roadmap belt). Category mirrors createSD (capitalize(type)) so the two
   // stay aligned in BOTH branches (RCA SD-LEO-ENH-AUTO-PROCEED-001-12). Both pass sd_type_check.
-  const type = f.type || 'infrastructure';
+  // Clamp to the sd_type_check list: the deriver passes metadata.sd_type through unverified, so an
+  // out-of-list value would 23514 on raw insert. Untyped/invalid -> 'infrastructure' (the engineer belt).
+  const type = f.type && ALLOWED_SD_TYPES.has(f.type) ? f.type : 'infrastructure';
   const category = type.charAt(0).toUpperCase() + type.slice(1);
   return {
     // id is NOT NULL with no DB default — omitting it makes every insert fail 23502 (the raw-insert

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -74,6 +74,19 @@ export function buildRefillSdPayload(item, sdKey) {
   // key-prefix default applies instead of a baked 'feature'), DISTINCT description/scope (not title
   // clones -> not a bare-shell), strategic_intent, and a needs_enrichment flag for thin items.
   const f = deriveSdFieldsFromRoadmapItem(it);
+  // The raw-insert path bypasses createSD, so EVERY NOT-NULL-without-default column the DB triggers do
+  // NOT backfill must be set here or the insert 23502-fails on live-flip. The authoritative set (per the
+  // live schema) is: id, sd_key, title, status, category, priority, description, scope, rationale. The
+  // remaining NOT-NULL columns (sequence_rank, sd_code_user_facing, uuid_internal_pk) are filled by BEFORE
+  // INSERT triggers (auto_assign_sequence_rank / trg_sync_sd_code_user_facing / trg_sync_uuid_internal_pk).
+  // sd_type is NOT NULL with a DB default of 'feature'. The raw-insert path does NOT run createSD's
+  // key-prefix type resolution, and passing an explicit null OVERRIDES the default -> 23502. Falling
+  // through to the 'feature' default would bake the wrong type the deriver's null was meant to avoid AND
+  // misalign with the category. So pin a concrete type: the deriver's value when typed, else
+  // 'infrastructure' (the engineer roadmap belt). Category mirrors createSD (capitalize(type)) so the two
+  // stay aligned in BOTH branches (RCA SD-LEO-ENH-AUTO-PROCEED-001-12). Both pass sd_type_check.
+  const type = f.type || 'infrastructure';
+  const category = type.charAt(0).toUpperCase() + type.slice(1);
   return {
     // id is NOT NULL with no DB default — omitting it makes every insert fail 23502 (the raw-insert
     // path bypasses createSD which mints it). Mint a uuid here (mirrors leo-create-sd.js).
@@ -81,13 +94,17 @@ export function buildRefillSdPayload(item, sdKey) {
     sd_key: sdKey,
     title: String(f.title || 'Auto-refill candidate').slice(0, 200),
     status: 'draft',
-    sd_type: f.type ?? null, // null -> createSD/key-prefix default; explicit metadata.sd_type wins
+    sd_type: type, // concrete (never null): explicit type override 23502s the NOT-NULL default 'feature'
+    category, // NOT NULL, no default; aligns with sd_type per createSD convention
+    priority: 'medium', // NOT NULL, no default; valid per priority_check (critical|high|medium|low)
     // target_application: honor an explicit item hint; else EHG_Engineer (auto-refill operates on the
     // engineer roadmap belt) rather than the DB's EHG default which would mis-route harness items.
     target_application: md.target_application || 'EHG_Engineer',
     description: f.description,
     scope: f.scope,
     strategic_intent: f.strategic_intent,
+    // rationale: NOT NULL, no default; traceable provenance string (mirrors leo-create-sd.js promotion).
+    rationale: `Auto-refill promotion from staged roadmap_wave_items ${it.id || '(unknown)'} (${it.source_type || 'unknown-source'}).`,
     metadata: {
       sourced_by: 'auto-refill',
       promoted_from_roadmap_item_id: it.id || null,

--- a/package.json
+++ b/package.json
@@ -334,6 +334,7 @@
     "sourcing:backfill-adam-ghosts": "node scripts/sourcing-engine/backfill-adam-ghosts.mjs",
     "sourcing:populate": "node scripts/sourcing-engine/proactive-populator.mjs",
     "sourcing:refill-verify": "node scripts/sourcing-engine/refill-verify.mjs",
+    "sourcing:refill-cron": "node scripts/sourcing-engine/refill-cron.mjs",
     "sourcing:gauge-gap-miner": "node scripts/sourcing-engine/gauge-gap-miner-sweep.mjs",
     "distill:yt-backlog-clear": "node scripts/eva/youtube-backlog-clear.mjs",
     "distill:backlog-dispositions": "node scripts/distill-backlog-dispositions.mjs",

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Flag-gated auto-refill cron — SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C.
+ *
+ * Promotes VALID staged roadmap_wave_items onto the belt (create draft SD + stamp promoted_to_sd_key),
+ * reusing the -A predicate via -B's verifier. Ships DORMANT.
+ *
+ * DOUBLE-GATED (both required to write — guards against the recurring wired-but-no-op trap):
+ *   1. SOURCING_AUTO_REFILL_V1 === 'true'   (enable flag; default OFF -> [SKIP] exit 0). Checked FIRST.
+ *   2. --apply                              (write flag; default DRY-RUN -> promotes nothing).
+ *
+ * Usage: node scripts/sourcing-engine/refill-cron.mjs [--apply] [--limit N] [--json]
+ *
+ * Also the module's wiring: makes lib/sourcing-engine/refill-auto-promote.js INVOKED (npm entry point),
+ * not merely reachable (per the INVOCATION-PATH-PROOF lesson). Mirrors the sibling -B CLI refill-verify.mjs.
+ */
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
+import { selectRefillBatch, promoteStagedCandidate } from '../../lib/sourcing-engine/refill-auto-promote.js';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes('--apply');
+  const json = args.includes('--json');
+  const limIdx = args.indexOf('--limit');
+  const limit = limIdx >= 0 && Number(args[limIdx + 1]) > 0 ? Number(args[limIdx + 1]) : undefined;
+
+  // Gate 1 (enable) — checked FIRST so --apply is safe unconditionally when the flag is off.
+  if (process.env.SOURCING_AUTO_REFILL_V1 !== 'true') {
+    console.log('[SKIP] auto-refill dormant (SOURCING_AUTO_REFILL_V1 != "true"). No action.');
+    process.exit(0);
+  }
+
+  const supabase = await createSupabaseServiceClient('engineer', { verbose: false });
+
+  // Staged = item_disposition='pending' AND not yet promoted.
+  const { data: rows, error } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id')
+    .eq('item_disposition', 'pending')
+    .is('promoted_to_sd_key', null)
+    .limit(1000);
+
+  if (error) { console.error('refill-cron: query failed:', error.message); process.exit(2); }
+
+  const sel = selectRefillBatch(rows || [], { limit });
+  const results = [];
+  for (const item of sel.batch) {
+    // Gate 2 (write) flows through to the only writer; apply:false => dry-run no-op.
+    results.push(await promoteStagedCandidate(supabase, item, { apply }));
+  }
+  const promoted = results.filter((r) => r.promoted).length;
+
+  if (json) {
+    console.log(JSON.stringify({
+      mode: apply ? 'apply' : 'dry_run',
+      total: sel.total, validCount: sel.validCount, selected: sel.batch.length, limit: sel.limit,
+      promoted, results,
+    }, null, 2));
+  } else {
+    console.log(`🔁 Auto-refill cron (${apply ? 'APPLY' : 'DRY RUN'})`);
+    console.log(`   staged scanned: ${sel.total} | valid: ${sel.validCount} | selected (≤${sel.limit}): ${sel.batch.length}`);
+    console.log(apply ? `   ✅ promoted: ${promoted}` : `   would promote: ${sel.batch.length} (no writes — pass --apply)`);
+    for (const r of results) console.log(`     - ${r.sd_key || '(none)'}: ${r.reason}`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => { console.error('refill-cron error:', e.message); process.exit(2); });

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -35,7 +35,8 @@ async function main() {
   // Staged = item_disposition='pending' AND not yet promoted.
   const { data: rows, error } = await supabase
     .from('roadmap_wave_items')
-    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id')
+    // lane is live (sourcing-engine activation migrations) but postdates the schema-reference snapshot.
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id') // schema-lint-disable-line
     .eq('item_disposition', 'pending')
     .is('promoted_to_sd_key', null)
     .limit(1000);

--- a/tests/unit/sourcing-engine/refill-auto-promote.test.js
+++ b/tests/unit/sourcing-engine/refill-auto-promote.test.js
@@ -77,12 +77,31 @@ describe('buildRefillSdKey / buildRefillSdPayload (pure)', () => {
     // id is NOT NULL in strategic_directives_v2 with no DB default — the raw-insert path MUST mint one
     // (omitting it 23502-fails every promotion on live-flip). Guard against that regression.
     expect(p.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    // untyped item -> sd_type null so the createSD/key-prefix default applies (not a baked 'feature').
-    expect(p.sd_type).toBeNull();
+    // sd_type is NOT NULL (DB default 'feature'); the raw-insert path can't rely on key-prefix resolution
+    // and an explicit null 23502s. Untyped belt item -> concrete 'infrastructure' (not a baked 'feature'),
+    // with category aligned (capitalize). Guards against the live NOT-NULL failure the null shape shipped.
+    expect(p.sd_type).toBe('infrastructure');
+    expect(p.category).toBe('Infrastructure');
     // explicit target so harness items don't fall to the DB's EHG default.
     expect(p.target_application).toBe('EHG_Engineer');
     // DISTINCT description (not a title clone) via the canonical deriver.
     expect(p.description).not.toBe(p.title);
+  });
+
+  it('sets EVERY NOT-NULL-without-default column the DB triggers do not backfill (no live 23502)', () => {
+    // Authoritative set from the live schema (information_schema NOT NULL + no default), MINUS the three
+    // a BEFORE INSERT trigger fills (sequence_rank, sd_code_user_facing, uuid_internal_pk). The raw-insert
+    // path bypasses createSD, so omitting any of THESE 23502-fails every promotion on live-flip. This test
+    // is the regression guard against column-drift (3 columns surfaced one-at-a-time across two rounds).
+    const REQUIRED = ['id', 'sd_key', 'title', 'status', 'sd_type', 'category', 'priority', 'description', 'scope', 'rationale'];
+    const p = buildRefillSdPayload(validRow(), 'SD-REFILL-ABC');
+    for (const col of REQUIRED) {
+      expect(p[col], `payload.${col} must be set (NOT NULL, no DB default, not trigger-backfilled)`).not.toBeNull();
+      expect(p[col], `payload.${col} must be set`).not.toBeUndefined();
+    }
+    expect(p.priority).toBe('medium'); // valid per priority_check
+    expect(p.category.length).toBeGreaterThan(0); // no DB default; createSD-convention value
+    expect(p.rationale).toContain(validRow().id); // traceable provenance
   });
 
   it('falls back to a traceable title for an empty title and caps length', () => {
@@ -115,10 +134,15 @@ function makeStub({ existingSd = [] } = {}) {
         },
         insert(payload) {
           writes.inserts.push({ table: this._table, payload });
-          // Simulate the strategic_directives_v2 NOT-NULL constraints so a payload missing id (the
-          // live-fail the prior build shipped) is caught by tests instead of a fake {error:null}.
-          if (this._table === 'strategic_directives_v2' && (!payload || !payload.id)) {
-            return Promise.resolve({ error: { code: '23502', message: 'null value in column "id"' } });
+          // Simulate strategic_directives_v2's NOT-NULL-without-default columns that NO trigger backfills
+          // (sequence_rank/sd_code_user_facing/uuid_internal_pk ARE trigger-filled, so excluded). A payload
+          // missing any of these 23502-fails live; assert that here instead of a fake {error:null}.
+          if (this._table === 'strategic_directives_v2') {
+            const REQUIRED = ['id', 'sd_key', 'title', 'status', 'sd_type', 'category', 'priority', 'description', 'scope', 'rationale'];
+            const missing = REQUIRED.find((c) => payload == null || payload[c] == null);
+            if (missing) {
+              return Promise.resolve({ error: { code: '23502', message: `null value in column "${missing}"` } });
+            }
           }
           return Promise.resolve({ error: null });
         },

--- a/tests/unit/sourcing-engine/refill-auto-promote.test.js
+++ b/tests/unit/sourcing-engine/refill-auto-promote.test.js
@@ -104,6 +104,17 @@ describe('buildRefillSdKey / buildRefillSdPayload (pure)', () => {
     expect(p.rationale).toContain(validRow().id); // traceable provenance
   });
 
+  it('clamps an out-of-sd_type_check metadata.sd_type to a safe default (no live 23514)', () => {
+    // The deriver passes metadata.sd_type through unverified; an out-of-list value would 23514 on raw
+    // insert. Clamp to 'infrastructure'. A valid metadata.sd_type is preserved (+ category aligned).
+    const bad = buildRefillSdPayload(validRow({ metadata: { sd_type: 'not-a-real-type' } }), 'SD-REFILL-BAD');
+    expect(bad.sd_type).toBe('infrastructure');
+    expect(bad.category).toBe('Infrastructure');
+    const good = buildRefillSdPayload(validRow({ metadata: { sd_type: 'security' } }), 'SD-REFILL-GOOD');
+    expect(good.sd_type).toBe('security');
+    expect(good.category).toBe('Security');
+  });
+
   it('falls back to a traceable title for an empty title and caps length', () => {
     // The canonical deriver yields a traceable default ("Roadmap item <id>") for an empty title —
     // non-empty + identifiable, better than a generic constant.

--- a/tests/unit/sourcing-engine/refill-auto-promote.test.js
+++ b/tests/unit/sourcing-engine/refill-auto-promote.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectRefillBatch,
+  buildRefillSdKey,
+  buildRefillSdPayload,
+  promoteStagedCandidate,
+  DEFAULT_REFILL_BATCH_LIMIT,
+} from '../../../lib/sourcing-engine/refill-auto-promote.js';
+
+// A valid staged candidate per the -A predicate (pending, unpromoted, titled, traceable, non-fixture).
+const validRow = (over = {}) => ({
+  id: 'rwi-1',
+  title: 'Real candidate',
+  source_type: 'conversion_ledger',
+  source_id: 'led-123',
+  item_disposition: 'pending',
+  promoted_to_sd_key: null,
+  lane: 'belt',
+  ...over,
+});
+
+describe('selectRefillBatch — SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-C', () => {
+  it('returns only valid candidates (reusing the -A/-B SSOT)', () => {
+    const rows = [
+      validRow({ id: 'a' }),
+      validRow({ id: 'b', item_disposition: 'declined' }), // not_staged
+      validRow({ id: 'c', promoted_to_sd_key: 'SD-X' }),   // already_promoted
+      validRow({ id: 'd', title: '' }),                    // missing_title
+      validRow({ id: 'e', title: 'TEST seed' }),           // test_fixture
+    ];
+    const sel = selectRefillBatch(rows);
+    expect(sel.total).toBe(5);
+    expect(sel.validCount).toBe(1);
+    expect(sel.batch.map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('caps the batch at the limit (valid candidates beyond limit are deferred)', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => validRow({ id: `v${i}` }));
+    const sel = selectRefillBatch(rows, { limit: 2 });
+    expect(sel.validCount).toBe(5);
+    expect(sel.batch).toHaveLength(2);
+    expect(sel.limit).toBe(2);
+  });
+
+  it('defaults to DEFAULT_REFILL_BATCH_LIMIT for a missing/invalid limit', () => {
+    expect(selectRefillBatch([], {}).limit).toBe(DEFAULT_REFILL_BATCH_LIMIT);
+    expect(selectRefillBatch([], { limit: -3 }).limit).toBe(DEFAULT_REFILL_BATCH_LIMIT);
+  });
+
+  it('is total on empty/malformed corpus', () => {
+    expect(selectRefillBatch(null).batch).toEqual([]);
+    expect(selectRefillBatch(undefined).total).toBe(0);
+    expect(selectRefillBatch([null, 42, 'x']).validCount).toBe(0);
+  });
+});
+
+describe('buildRefillSdKey / buildRefillSdPayload (pure)', () => {
+  it('builds a deterministic key (same source -> same key, for idempotency)', () => {
+    const k1 = buildRefillSdKey(validRow());
+    const k2 = buildRefillSdKey(validRow());
+    expect(k1).toBe(k2);
+    expect(k1).toMatch(/^SD-REFILL-[0-9A-Z]{8}$/);
+  });
+
+  it('different source -> different key', () => {
+    expect(buildRefillSdKey(validRow({ source_id: 'a' }))).not.toBe(buildRefillSdKey(validRow({ source_id: 'b' })));
+  });
+
+  it('builds a draft SD payload with traceable provenance', () => {
+    const p = buildRefillSdPayload(validRow(), 'SD-REFILL-ABC');
+    expect(p.sd_key).toBe('SD-REFILL-ABC');
+    expect(p.status).toBe('draft');
+    expect(p.title).toBe('Real candidate');
+    expect(p.metadata.sourced_by).toBe('auto-refill');
+    expect(p.metadata.promoted_from_roadmap_item_id).toBe('rwi-1');
+    expect(p.metadata.source_id).toBe('led-123');
+  });
+
+  it('clamps an empty title to a safe default and caps length', () => {
+    const p = buildRefillSdPayload({ id: 'x', title: '' }, 'SD-REFILL-Z');
+    expect(p.title).toBe('Auto-refill candidate');
+    const long = buildRefillSdPayload({ id: 'y', title: 'z'.repeat(500) }, 'SD-REFILL-Y');
+    expect(long.title.length).toBe(200);
+  });
+});
+
+// Minimal supabase stub: records writes so we can assert dry-run performs none.
+function makeStub({ existingSd = [] } = {}) {
+  const writes = { inserts: [], updates: [] };
+  const client = {
+    from(table) {
+      return {
+        _table: table,
+        _filters: {},
+        select() { return this; },
+        eq(col, val) { this._filters[col] = val; return this; },
+        limit() {
+          if (this._table === 'strategic_directives_v2') {
+            const hit = existingSd.includes(this._filters.sd_key);
+            return Promise.resolve({ data: hit ? [{ sd_key: this._filters.sd_key }] : [], error: null });
+          }
+          return Promise.resolve({ data: [], error: null });
+        },
+        insert(payload) { writes.inserts.push({ table: this._table, payload }); return Promise.resolve({ error: null }); },
+        update(payload) {
+          const u = { table: this._table, payload, _filters: {} };
+          writes.updates.push(u);
+          return { eq: (c, v) => { u._filters[c] = v; return Promise.resolve({ error: null }); } };
+        },
+      };
+    },
+  };
+  return { client, writes };
+}
+
+describe('promoteStagedCandidate (only writer)', () => {
+  it('dry-run (default) performs NO writes', async () => {
+    const { client, writes } = makeStub();
+    const r = await promoteStagedCandidate(client, validRow(), { apply: false });
+    expect(r.promoted).toBe(false);
+    expect(r.dry_run).toBe(true);
+    expect(r.reason).toBe('dry_run');
+    expect(writes.inserts).toHaveLength(0);
+    expect(writes.updates).toHaveLength(0);
+  });
+
+  it('apply creates the SD and stamps the roadmap link', async () => {
+    const { client, writes } = makeStub();
+    const r = await promoteStagedCandidate(client, validRow(), { apply: true });
+    expect(r.promoted).toBe(true);
+    expect(r.reason).toBe('promoted');
+    expect(writes.inserts).toHaveLength(1);
+    expect(writes.inserts[0].table).toBe('strategic_directives_v2');
+    expect(writes.updates).toHaveLength(1);
+    expect(writes.updates[0].table).toBe('roadmap_wave_items');
+    expect(writes.updates[0].payload.promoted_to_sd_key).toBe(r.sd_key);
+  });
+
+  it('no-op when the item is already promoted', async () => {
+    const { client, writes } = makeStub();
+    const r = await promoteStagedCandidate(client, validRow({ promoted_to_sd_key: 'SD-OLD' }), { apply: true });
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('already_promoted');
+    expect(writes.inserts).toHaveLength(0);
+  });
+
+  it('no-op when the deterministic SD key already exists (idempotent re-run)', async () => {
+    const key = buildRefillSdKey(validRow());
+    const { client, writes } = makeStub({ existingSd: [key] });
+    const r = await promoteStagedCandidate(client, validRow(), { apply: true });
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('sd_exists');
+    expect(writes.inserts).toHaveLength(0);
+  });
+
+  it('warns (not throws) on a missing item id', async () => {
+    const { client } = makeStub();
+    const r = await promoteStagedCandidate(client, {}, { apply: true });
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('missing_item_id');
+  });
+});

--- a/tests/unit/sourcing-engine/refill-auto-promote.test.js
+++ b/tests/unit/sourcing-engine/refill-auto-promote.test.js
@@ -74,11 +74,23 @@ describe('buildRefillSdKey / buildRefillSdPayload (pure)', () => {
     expect(p.metadata.sourced_by).toBe('auto-refill');
     expect(p.metadata.promoted_from_roadmap_item_id).toBe('rwi-1');
     expect(p.metadata.source_id).toBe('led-123');
+    // id is NOT NULL in strategic_directives_v2 with no DB default — the raw-insert path MUST mint one
+    // (omitting it 23502-fails every promotion on live-flip). Guard against that regression.
+    expect(p.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    // untyped item -> sd_type null so the createSD/key-prefix default applies (not a baked 'feature').
+    expect(p.sd_type).toBeNull();
+    // explicit target so harness items don't fall to the DB's EHG default.
+    expect(p.target_application).toBe('EHG_Engineer');
+    // DISTINCT description (not a title clone) via the canonical deriver.
+    expect(p.description).not.toBe(p.title);
   });
 
-  it('clamps an empty title to a safe default and caps length', () => {
+  it('falls back to a traceable title for an empty title and caps length', () => {
+    // The canonical deriver yields a traceable default ("Roadmap item <id>") for an empty title —
+    // non-empty + identifiable, better than a generic constant.
     const p = buildRefillSdPayload({ id: 'x', title: '' }, 'SD-REFILL-Z');
-    expect(p.title).toBe('Auto-refill candidate');
+    expect(p.title.length).toBeGreaterThan(0);
+    expect(p.title).toContain('x');
     const long = buildRefillSdPayload({ id: 'y', title: 'z'.repeat(500) }, 'SD-REFILL-Y');
     expect(long.title.length).toBe(200);
   });
@@ -101,7 +113,15 @@ function makeStub({ existingSd = [] } = {}) {
           }
           return Promise.resolve({ data: [], error: null });
         },
-        insert(payload) { writes.inserts.push({ table: this._table, payload }); return Promise.resolve({ error: null }); },
+        insert(payload) {
+          writes.inserts.push({ table: this._table, payload });
+          // Simulate the strategic_directives_v2 NOT-NULL constraints so a payload missing id (the
+          // live-fail the prior build shipped) is caught by tests instead of a fake {error:null}.
+          if (this._table === 'strategic_directives_v2' && (!payload || !payload.id)) {
+            return Promise.resolve({ error: { code: '23502', message: 'null value in column "id"' } });
+          }
+          return Promise.resolve({ error: null });
+        },
         update(payload) {
           const u = { table: this._table, payload, _filters: {} };
           writes.updates.push(u);


### PR DESCRIPTION
## What & why
Child -C (the LIVE-FLIP) of the auto-refill orchestrator. Closes the staged→belt manual-promotion gap: 683 staged `roadmap_wave_items` sit unpromoted because `proactive-populator` stages-then-stops and the coordinator hand-promotes (the documented anti-pattern). This is a **flag-gated, ship-DORMANT** cron that auto-promotes the *valid* staged candidates to the belt.

## Safety (ship-dormant, double-gated)
- **Enable gate** `SOURCING_AUTO_REFILL_V1` (default OFF) — checked FIRST; `[SKIP] exit 0` until the chairman flips the repo variable. No code change to activate/deactivate.
- **Write gate** `--apply` (default DRY-RUN — promotes nothing).
- **Reuses the -A/-B candidate-validity SSOT** via `verifyStagedCandidates` (no predicate re-implementation → can't drift).
- **Batch-limit cap** per run (`DEFAULT_REFILL_BATCH_LIMIT`) so it can never flood the belt.
- **Idempotent** — checks `sd_key` existence before insert.
- Workflow `.github/workflows/sourcing-auto-refill-cron.yml` (`cron: '25 * * * *'`) wires the schedule but the script SKIPs unless the flag is true (safe to land).

## Files
- `lib/sourcing-engine/refill-auto-promote.js` (pure selection + promotion helpers)
- `scripts/sourcing-engine/refill-cron.mjs` (double-gated entrypoint)
- `.github/workflows/sourcing-auto-refill-cron.yml` + `package.json` script
- `tests/unit/sourcing-engine/refill-auto-promote.test.js` (13 tests)

## Verification
- 13/13 unit tests pass; the cron SKIPs (exit 0) with the flag off, dry-runs without `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)