### PR TITLE
fix(QF-20260621-174): surface Adam action-required advisories on */2 inbox loop + un-bury under LIMIT

### DIFF
--- a/lib/coordinator/adam-advisory-store.cjs
+++ b/lib/coordinator/adam-advisory-store.cjs
@@ -41,6 +41,29 @@ async function selectUnactionedAdvisories(supabase, coordinatorId, opts = {}) {
   return { rows: data || [], error: null };
 }
 
+// QF-20260621-174: the unactioned backlog reached 80+ rows (mostly belt-countdown status
+// relays), burying genuine action-required asks under the old LIMIT 20. This predicate lets
+// the render path partition the lane so action-required advisories surface un-truncated.
+// Matches an explicit reply request OR action-phrasing in the subject/body. PURE/TOTAL.
+const ACTION_REQUIRED_RE =
+  /action[\s-]?(required|requested)|please file|chairman[\s-]?priority|expects?[\s-]?reply|needs?\s+(a\s+)?(decision|reply|response)/i;
+
+/**
+ * Is this advisory one the coordinator must ACT on (vs a passive status relay)?
+ * True when payload.expects_reply is set, or the subject/body uses action phrasing.
+ * @param {object} row - a session_coordination advisory row
+ * @returns {boolean}
+ */
+function isActionRequiredAdvisory(row) {
+  if (!row || typeof row !== 'object') return false;
+  const p = row.payload || {};
+  if (p.expects_reply === true) return true;
+  const text = [row.subject, row.body, p.body, p.subject]
+    .filter((s) => typeof s === 'string')
+    .join(' ');
+  return ACTION_REQUIRED_RE.test(text);
+}
+
 /**
  * Fetch a single advisory row by id (for ack/reply resolution).
  * @returns {Promise<{row:object|null, error:object|null}>}
@@ -75,6 +98,7 @@ module.exports = {
   ADAM_ADVISORY_KIND,
   BROADCAST_COORDINATOR,
   selectUnactionedAdvisories,
+  isActionRequiredAdvisory,
   fetchAdvisory,
   stampActioned,
 };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1182,8 +1182,10 @@ async function printAdamInbox() {
   // which is why FR1 gives it a durable TTL). It also covers the broadcast-coordinator
   // sentinel, which this inline query previously MISSED. Unifying here removes a
   // writer/consumer-asymmetry drift surface (PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001).
-  const { selectUnactionedAdvisories } = require('../lib/coordinator/adam-advisory-store.cjs');
-  const { rows: advisories, error } = await selectUnactionedAdvisories(supabase, coordinatorId, { limit: 20 });
+  const { selectUnactionedAdvisories, isActionRequiredAdvisory } = require('../lib/coordinator/adam-advisory-store.cjs');
+  // QF-20260621-174: fetch a wide window (was 20) so action-required asks are never buried
+  // under the 80+ belt-countdown status relays; the render partitions + caps below.
+  const { rows: advisories, error } = await selectUnactionedAdvisories(supabase, coordinatorId, { limit: 200 });
 
   if (error) {
     console.log('  (adam inbox query failed: ' + error.message + ')');
@@ -1197,13 +1199,20 @@ async function printAdamInbox() {
     return;
   }
 
-  console.log('  ' + advisories.length + ' unactioned advisory(ies)');
+  // QF-20260621-174: partition the lane so action-required advisories ALWAYS render
+  // un-truncated; passive status relays (belt-countdowns) get a capped tail so they can
+  // never crowd out an ask. Both subsets stamp read_at below (DELIVERED, not actioned).
+  const actionRows = advisories.filter(isActionRequiredAdvisory);
+  const statusRows = advisories.filter((a) => !isActionRequiredAdvisory(a));
+
+  console.log('  ' + advisories.length + ' unactioned (' + actionRows.length +
+    ' action-required, ' + statusRows.length + ' status relay(s))');
   console.log('');
   console.log('  ' + pad('Callsign', 12) + pad('Reply?', 8) + pad('Age', 8) + 'Body');
   console.log('  ' + '─'.repeat(68));
 
   const ids = [];
-  for (const a of advisories) {
+  const renderRow = (a) => {
     const callsign = a.payload?.sender_callsign || '(none)';
     const wantsReply = a.payload?.expects_reply ? 'yes' : '-';
     const ageMin = Math.floor((Date.now() - new Date(a.created_at).getTime()) / 60_000);
@@ -1211,6 +1220,13 @@ async function printAdamInbox() {
     const bodyPreview = (a.body || a.payload?.body || '').replace(/\n/g, ' ').substring(0, 32);
     console.log('  ' + pad(callsign, 12) + pad(wantsReply, 8) + pad(ageStr, 8) + bodyPreview);
     ids.push(a.id);
+  };
+
+  for (const a of actionRows) renderRow(a); // action-required: never truncated
+  const STATUS_CAP = 15;
+  for (const a of statusRows.slice(0, STATUS_CAP)) renderRow(a);
+  if (statusRows.length > STATUS_CAP) {
+    console.log('  … and ' + (statusRows.length - STATUS_CAP) + ' older status relay(s) hidden');
   }
 
   // FR-1: stamp read_at = DELIVERED (transport-level "the coordinator saw it on a render"),
@@ -1457,6 +1473,10 @@ async function main() {
       // FR-2/FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): sender-side receipts.
       await printUndeliveredOutbound();
       await printDeadLetters();
+      // QF-20260621-174: surface the Adam advisory lane on the suppression-immune */2 inbox
+      // loop too — the ~5min 'all' loop is collapsed by FLEET_DASH_SUPPRESS during quiet
+      // periods, so action-required advisories could otherwise sit unsurfaced for long stretches.
+      await printAdamInbox();
     },
     adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
     context:       async () => await printWorkingContext(), // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3)

--- a/tests/unit/adam-advisory-action-required.test.js
+++ b/tests/unit/adam-advisory-action-required.test.js
@@ -1,0 +1,47 @@
+/**
+ * Unit tests — QF-20260621-174
+ * Adam advisory lane: action-required vs status-relay partition predicate.
+ *
+ * The unactioned backlog reached 80+ rows (mostly belt-countdown status relays), burying
+ * genuine action-required asks under the old LIMIT 20. isActionRequiredAdvisory lets the
+ * render path partition the lane so action-required advisories surface un-truncated.
+ * These tests pin the predicate (pure/total) — the dashboard render + LIMIT raise are
+ * behavioural (covered by the QF smoke steps).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { isActionRequiredAdvisory } = require('../../lib/coordinator/adam-advisory-store.cjs');
+
+describe('isActionRequiredAdvisory (QF-20260621-174)', () => {
+  it('is true when payload.expects_reply is set', () => {
+    expect(isActionRequiredAdvisory({ payload: { expects_reply: true }, body: 'fyi only' })).toBe(true);
+  });
+
+  it('matches action phrasing in the body', () => {
+    expect(isActionRequiredAdvisory({ body: 'ACTION REQUIRED: file the SD' })).toBe(true);
+    expect(isActionRequiredAdvisory({ body: 'Please file a quick-fix for this' })).toBe(true);
+    expect(isActionRequiredAdvisory({ body: 'chairman-priority ask' })).toBe(true);
+    expect(isActionRequiredAdvisory({ body: 'needs a decision from you' })).toBe(true);
+    expect(isActionRequiredAdvisory({ body: 'action requested' })).toBe(true);
+  });
+
+  it('matches action phrasing in the subject', () => {
+    expect(isActionRequiredAdvisory({ subject: 'Action Requested', body: '' })).toBe(true);
+  });
+
+  it('is false for a passive belt-countdown status relay', () => {
+    expect(isActionRequiredAdvisory({ body: 'belt at 7 SDs, countdown to refill in 3h' })).toBe(false);
+    expect(isActionRequiredAdvisory({ body: 'status: sourcing nominal' })).toBe(false);
+  });
+
+  it('is total — never throws on odd input', () => {
+    expect(isActionRequiredAdvisory(null)).toBe(false);
+    expect(isActionRequiredAdvisory(undefined)).toBe(false);
+    expect(isActionRequiredAdvisory('string')).toBe(false);
+    expect(isActionRequiredAdvisory({})).toBe(false);
+    expect(isActionRequiredAdvisory({ payload: null })).toBe(false);
+    expect(isActionRequiredAdvisory({ payload: { expects_reply: false } })).toBe(false);
+  });
+});


### PR DESCRIPTION
## QF-20260621-174 — Adam advisory lane reliability

**Symptom (audited 2026-06-21):** The Adam→coordinator advisory lane (`payload.kind=adam_advisory`) was surfaced only by `printAdamInbox`, which the suppression-immune `*/2` `inbox` standing loop never called — only the ~5min `all` loop did, and that collapses under `FLEET_DASH_SUPPRESS` during quiet periods. Action-required advisories (incl. chairman-priority asks) could sit unsurfaced for long stretches. Compounding it, the unactioned backlog reached 80+ rows (mostly belt-countdown status relays), burying action asks under the old `LIMIT 20`.

### LEG A — wire into the suppression-immune loop
Add `await printAdamInbox()` to the `inbox` section handler so the already-armed `*/2` loop covers BOTH lanes.

### SCALE FIX — partition the lane so action items can't be buried
- New pure, total `isActionRequiredAdvisory(row)` predicate in `lib/coordinator/adam-advisory-store.cjs` (`expects_reply` OR action phrasing: action required/requested, please file, chairman-priority, needs a decision/reply/response).
- `printAdamInbox` fetches a wide window (`limit:200`, was 20), renders **every** action-required advisory un-truncated, then a capped (15) tail of status relays with an "older … hidden" note.
- `read_at` stamps only rendered rows; un-rendered relays stay unactioned (gate is `actioned_at IS NULL`) and re-surface — no data loss.

No separate `adam` cron added (redundant with dashboard+inbox); retirement stays via `coordinator-ack-adam.cjs` (read_at ≠ actioned_at by design).

### Tests
`tests/unit/adam-advisory-action-required.test.js` (6 cases: expects_reply, body/subject action phrasing, passive belt-countdown false, totality on odd input). Existing `resilient-symmetric-adam` + `adam-machinery-consumer-invariant` suites stay green (23 passed total). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)