### PR TITLE
fix(QF-20260621-379): chairman exec-email HTML↔plaintext parity (Estimated-completion + 4 lines)

### DIFF
--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -330,8 +330,18 @@ const actionsHtml = nActions
   : `<p style="font-size:14px;margin:0 0 6px"><b>No decisions need you right now.</b></p>`;
 const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
   `<p style="font-size:15px;margin:0 0 12px"><b>Workers:</b> ${esc(workerText)}</p>` +
-  `<p style="font-size:15px;font-weight:600;margin:0 0 0">EHG vision: ${visPct != null ? visPct + '% built' : '(gauge unavailable)'}</p>` +
+  // QF-20260621-379: full plaintext↔HTML parity. Lead with the fleet-build line (buildLine)
+  // using the SAME fallback as plaintext (line ~298) — the HTML previously showed a bare vision-%
+  // and OMITTED rungLine / rungRollupLine / forecastLine / operationalLine, so the chairman (an HTML
+  // reader) never saw the Estimated-completion forecast though it was correct in plaintext + DB.
+  `<p style="font-size:15px;font-weight:600;margin:0 0 0">${esc(buildLine || (visPct != null ? `EHG vision: ${visPct}% built (build-segmented detail unavailable)` : 'EHG vision: (gauge unavailable)'))}</p>` +
   (rungNatureLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(rungNatureLine)}</div>` : '') +
+  (rungLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(rungLine)}</div>` : '') +
+  (rungRollupLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(rungRollupLine)}</div>` : '') +
+  // forecastLine with the degraded fallback mirroring plaintext line ~304 (a forecast ERROR shows an
+  // explicit degraded marker, not a silent omission; a genuine no-forecast stays silent).
+  (forecastLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(forecastLine)}</div>` : (forecastDegraded ? `<div style="font-size:13px;color:#b54708;margin:2px 0 0">${esc(FORECAST_DEGRADED_MARKER)}</div>` : '')) +
+  (operationalLine ? `<div style="font-size:13px;color:#444;margin:2px 0 0">${esc(operationalLine)}</div>` : '') +
   layerHtml + noteHtml + trendHtml + trendAnalysisHtml +
   (watchdogLine ? `<div style="font-size:12px;color:#b54708;margin:2px 0 0">${esc(watchdogLine)}</div>` : '') +
   recentHtml + decisionsHtml +

--- a/tests/unit/adam/exec-summary-html-parity.test.js
+++ b/tests/unit/adam/exec-summary-html-parity.test.js
@@ -1,0 +1,79 @@
+/**
+ * QF-20260621-379 — chairman exec-email HTML↔plaintext parity.
+ *
+ * ROOT CAUSE: the HTML assembly in scripts/adam-exec-summary.mjs led with a bare vision-%
+ * and OMITTED 5 plaintext lines (buildLine lead, rungLine, rungRollupLine, forecastLine with
+ * its degraded fallback, operationalLine). The chairman reads HTML, so he never saw the
+ * Estimated-completion forecast though it was correct in plaintext + the DB.
+ *
+ * The script runs at import time and touches the live DB, so we don't import it. We (1) mirror
+ * the exact HTML fragment logic and assert the 3 forecast states, and (2) read the source and
+ * assert the HTML assembly references each of the 5 lines — a regression guard against any
+ * future edit silently dropping a line from the HTML again.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const FORECAST_DEGRADED_MARKER = 'Estimated completion: (forecast temporarily unavailable)';
+
+// Mirror of the script's HTML fragment (kept identical to scripts/adam-exec-summary.mjs QF-379).
+function htmlFragment({ visPct, buildLine, rungNatureLine, rungLine, rungRollupLine, forecastLine, forecastDegraded, operationalLine }) {
+  return `<p>${esc(buildLine || (visPct != null ? `EHG vision: ${visPct}% built (build-segmented detail unavailable)` : 'EHG vision: (gauge unavailable)'))}</p>` +
+    (rungNatureLine ? `<div>${esc(rungNatureLine)}</div>` : '') +
+    (rungLine ? `<div>${esc(rungLine)}</div>` : '') +
+    (rungRollupLine ? `<div>${esc(rungRollupLine)}</div>` : '') +
+    (forecastLine ? `<div>${esc(forecastLine)}</div>` : (forecastDegraded ? `<div>${esc(FORECAST_DEGRADED_MARKER)}</div>` : '')) +
+    (operationalLine ? `<div>${esc(operationalLine)}</div>` : '');
+}
+
+const base = {
+  visPct: 41,
+  buildLine: 'Fleet build: 12% built (infra scope)',
+  rungNatureLine: 'Rung nature: Foundation',
+  rungLine: 'V1 rung: 3/8 complete',
+  rungRollupLine: 'Rollup: Foundation 60%',
+  operationalLine: 'Operational: 4 live loops',
+};
+
+describe('QF-20260621-379 exec-email HTML parity', () => {
+  it('renders all 5 lines and leads with buildLine when a forecast is present', () => {
+    const fc = 'Estimated completion (infra-build scope): 2026-07-28';
+    const h = htmlFragment({ ...base, forecastLine: fc, forecastDegraded: false });
+    for (const line of [base.buildLine, base.rungNatureLine, base.rungLine, base.rungRollupLine, fc, base.operationalLine]) {
+      expect(h).toContain(esc(line));
+    }
+    // leads with the fleet-build line, not the bare vision-%
+    expect(h.startsWith(`<p>${esc(base.buildLine)}</p>`)).toBe(true);
+  });
+
+  it('shows the degraded marker (not a silent omission) when the forecast errored', () => {
+    const h = htmlFragment({ ...base, forecastLine: '', forecastDegraded: true });
+    expect(h).toContain(esc(FORECAST_DEGRADED_MARKER));
+  });
+
+  it('stays silent on a genuine no-forecast', () => {
+    const h = htmlFragment({ ...base, forecastLine: '', forecastDegraded: false });
+    expect(h).not.toContain('Estimated completion');
+    expect(h).not.toContain('forecast');
+  });
+
+  it('falls back to the vision-% expr when buildLine is empty', () => {
+    const h = htmlFragment({ ...base, buildLine: '', forecastLine: '', forecastDegraded: false });
+    expect(h).toContain('EHG vision: 41% built (build-segmented detail unavailable)');
+  });
+
+  it('SOURCE GUARD: the HTML assembly references each of the 5 parity lines', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, '../../../scripts/adam-exec-summary.mjs'), 'utf8');
+    // Scope to the `const html = '<div...` assembly so we don't match the plaintext array.
+    const start = src.indexOf("const html = '<div");
+    expect(start).toBeGreaterThan(-1);
+    const htmlBlock = src.slice(start, src.indexOf('</div>\';', start));
+    for (const sym of ['buildLine', 'rungLine', 'rungRollupLine', 'forecastLine', 'forecastDegraded', 'FORECAST_DEGRADED_MARKER', 'operationalLine']) {
+      expect(htmlBlock, `HTML assembly must reference ${sym}`).toContain(sym);
+    }
+  });
+});


### PR DESCRIPTION
## QF-20260621-379 — chairman exec-email HTML parity

Chairman-priority, chairman-approved (Adam advisory `3c57610c`). Distinct from QF-20260621-570 (that hardened the **data** path; this fixes what the chairman **sees**).

**Root cause (code + email verified):** the HTML assembly in `scripts/adam-exec-summary.mjs` led with a bare `vision-%` and **omitted 5 lines** that the plaintext alternative has. The chairman's mail client renders HTML, so he never saw the `Estimated completion` forecast he asked for — though it was correct in plaintext and the DB (`build_completion_forecast_log` healthy). The 8:58 AM email had `Estimated completion (infra-build scope): 2026-07-28` in plaintext but **not** in HTML.

### Fix (single file, conflict-free)
Render the 5 plaintext-only lines in plaintext order, each as a `div` mirroring the existing `layerHtml`/`rungNatureLine` pattern, preserving each line's truthiness guard:
1. **`buildLine` as LEAD** — via the SAME fallback expr as plaintext (`buildLine || visPct-fallback`), so HTML leads with fleet-build, not bare vision-%.
2. `rungLine`
3. `rungRollupLine`
4. **`forecastLine` with the degraded fallback** — a forecast ERROR shows `FORECAST_DEGRADED_MARKER` (not a silent omission); a genuine no-forecast stays silent.
5. `operationalLine`

### Tests
`tests/unit/adam/exec-summary-html-parity.test.js` — mirrors the HTML fragment across the 3 forecast states (present / degraded / silent) + the `buildLine` fallback, plus a **source guard** that reads the script and asserts the HTML assembly references all 5 lines (anti-regression: a future edit dropping a line fails the test). 16 tests green across exec-summary suites. `node --check` clean.

**VERIFY-TO-FIRE:** the fix logic was exercised directly (3 forecast states verified); the chairman confirming the line in his next 1–2 rendered exec emails is the downstream confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)