### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D): claim-time source-integrity guard for auto-refilled SDs (fail-open)

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -133,8 +133,50 @@ async function evaluateDispatchEligibility(sb, sdKey, ctx) {
   // passed sdKey separately.
   const ineligible = classifyDispatchIneligibility({ ...data, sd_key: data.sd_key || sdKey }, ctx);
   if (ineligible) return { eligible: false, reason: ineligible };
+  // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D: claim-time source-integrity guard for auto-refilled
+  // SDs only. -C enforces candidate-validity at PROMOTION time; this re-consults the SOURCE row at CLAIM
+  // time so a source that was declined/deleted/unlinked AFTER promotion no longer routes onto a worker.
+  // Fail-open: any uncertainty (no marker, no source-id, fetch/parse/import error) leaves the SD eligible
+  // — a well-formed promoted SD is never stranded on a transient fault. The minted key is always
+  // SD-REFILL-*, so the sd_key fixture guard above cannot see a fixture that entered via the source.
+  const refillSource = await refillSourceIneligibility(sb, { ...data, sd_key: data.sd_key || sdKey });
+  if (refillSource) return { eligible: false, reason: refillSource };
   const depsOk = await draftDepsSatisfied(sb, data, { throwOnError: true }); // propagate dep-query errors
   return depsOk ? { eligible: true } : { eligible: false, reason: 'dep_blocked' };
+}
+
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D: for an auto-refilled SD, fetch its SOURCE
+ * roadmap_wave_items row and re-check the post-promotion invariants via the pure -A SSOT helper
+ * evaluateClaimTimeRefillSource. Returns a `refill_source_<reason>` string when the source is no longer
+ * a valid promotion, or null (eligible) otherwise. FAIL-OPEN by contract: only auto-refilled SDs
+ * (metadata.sourced_by==='auto-refill' with a promoted_from_roadmap_item_id) are checked, and ANY error
+ * — missing marker, missing source id, fetch failure, import failure — returns null so dispatch is never
+ * blocked on uncertainty (byte-identical to pre-D behavior for every non-auto-refill SD).
+ * @param {object} sb       service-role client
+ * @param {{ sd_key?:string, metadata?:object }} sdRow  the already-fetched SD row
+ * @returns {Promise<string|null>}
+ */
+async function refillSourceIneligibility(sb, sdRow) {
+  try {
+    const md = (sdRow && sdRow.metadata) || {};
+    if (md.sourced_by !== 'auto-refill') return null;            // scope: auto-refill SDs only
+    const sourceId = md.promoted_from_roadmap_item_id;
+    if (!sourceId) return null;                                  // no traceable source -> fail-open
+    const { data: source, error } = await sb
+      .from('roadmap_wave_items')
+      .select('promoted_to_sd_key, lane, title, source_id')
+      .eq('id', sourceId)
+      .maybeSingle();
+    if (error) return null;                                      // fetch fault -> fail-open
+    // ESM helper from a CJS module: dynamic import is valid here (this fn is async).
+    const { evaluateClaimTimeRefillSource } = await import('../sourcing-engine/refill-candidate-validity.js');
+    const verdict = evaluateClaimTimeRefillSource(source, sdRow.sd_key);
+    if (verdict && verdict.valid === false && verdict.reason) return `refill_source_${verdict.reason}`;
+    return null;
+  } catch {
+    return null;                                                 // any fault -> fail-open (never strand)
+  }
 }
 
 /**

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -74,3 +74,63 @@ export function evaluateRefillCandidate(item) {
   }
   return { valid: true, reason: null };
 }
+
+// SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D — claim-time source-integrity reasons.
+// Distinct from the PRE-promotion REFILL_INVALID_REASONS: at claim time the source IS promoted, so
+// 'already_promoted'/'not_staged' are EXPECTED states, not failures. Only the invariants that should
+// still hold for a still-valid promotion are checked here.
+export const REFILL_CLAIM_SOURCE_REASONS = Object.freeze({
+  SOURCE_MISSING: 'source_missing',
+  SOURCE_UNLINKED: 'source_unlinked',
+  DECLINED_LANE: 'declined_lane',
+  TEST_FIXTURE: 'test_fixture',
+});
+
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D (claim-time complement of evaluateRefillCandidate).
+ *
+ * Re-validate the SOURCE roadmap_wave_items row of an ALREADY-promoted auto-refill SD at the moment a
+ * worker tries to CLAIM the promoted SD. This catches post-promotion drift that promotion-time
+ * validation (-A inside -C) cannot see: the source being declined, deleted, or unlinked AFTER the SD was
+ * minted onto the belt.
+ *
+ * Why a separate helper instead of reusing evaluateRefillCandidate: that predicate runs the
+ * already_promoted and not_staged axes FIRST, and both are the EXPECTED state once the source has been
+ * promoted (promoted_to_sd_key is set; item_disposition is no longer 'pending'). Running it verbatim at
+ * claim time would mark every auto-refilled SD invalid — the domain mismatch. So this helper deliberately
+ * OMITS those two axes and instead asserts the invariants that must still hold for a valid promotion:
+ *   source_missing   — the source row is gone (null/non-object)
+ *   source_unlinked  — source.promoted_to_sd_key no longer points back to THIS SD (cleared / re-pointed)
+ *   declined_lane    — the source's lane was routed to 'decline' after promotion
+ *   test_fixture     — the source is a TEST/DEMO fixture (its minted SD-REFILL-* key hides this from the
+ *                      sd_key-based fixture guard in claim-eligibility)
+ *
+ * Returns the FIRST failing reason; { valid:true, reason:null } only when ALL hold. PURE: no DB/fs/clock.
+ * TOTAL: never throws on odd input.
+ *
+ * @param {{ promoted_to_sd_key?:(string|null), lane?:string, title?:string, source_id?:string }} sourceItem
+ *        the SOURCE roadmap_wave_items row the SD was promoted from
+ * @param {string} expectedSdKey  the SD key that the source MUST still link back to (SD-REFILL-*)
+ * @returns {{ valid:boolean, reason:(string|null) }}
+ */
+export function evaluateClaimTimeRefillSource(sourceItem, expectedSdKey) {
+  if (!sourceItem || typeof sourceItem !== 'object' || Array.isArray(sourceItem)) {
+    return { valid: false, reason: REFILL_CLAIM_SOURCE_REASONS.SOURCE_MISSING };
+  }
+  // The two-way link must still resolve to THIS SD. A null/cleared or re-pointed link means the
+  // promotion is stale/orphaned -> do not let a worker build it.
+  if (!nonEmpty(sourceItem.promoted_to_sd_key) || sourceItem.promoted_to_sd_key !== expectedSdKey) {
+    return { valid: false, reason: REFILL_CLAIM_SOURCE_REASONS.SOURCE_UNLINKED };
+  }
+  // A lane routed away from the belt after promotion must not remain claimable.
+  if (typeof sourceItem.lane === 'string' && sourceItem.lane.trim().toLowerCase() === 'decline') {
+    return { valid: false, reason: REFILL_CLAIM_SOURCE_REASONS.DECLINED_LANE };
+  }
+  // A fixture that slipped onto the belt: the minted SD key is always SD-REFILL-*, so the SD-key fixture
+  // guard cannot see a TEST/DEMO source — check the source's own title/source_id here.
+  if ((nonEmpty(sourceItem.title) && FIXTURE_TITLE_RE.test(sourceItem.title)) ||
+      (nonEmpty(sourceItem.source_id) && FIXTURE_KEY_RE.test(sourceItem.source_id))) {
+    return { valid: false, reason: REFILL_CLAIM_SOURCE_REASONS.TEST_FIXTURE };
+  }
+  return { valid: true, reason: null };
+}

--- a/tests/unit/fleet/claim-eligibility-refill-source.test.js
+++ b/tests/unit/fleet/claim-eligibility-refill-source.test.js
@@ -1,0 +1,100 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D (FR-2) — integration tests for the claim-time
+ * source-integrity wire in evaluateDispatchEligibility.
+ *
+ * A stub supabase client serves the SD row (strategic_directives_v2) and the source row
+ * (roadmap_wave_items). SDs carry NO dependencies so draftDepsSatisfied short-circuits to eligible
+ * without a third query — isolating the new auto-refill source axis.
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluateDispatchEligibility } from '../../../lib/fleet/claim-eligibility.cjs';
+
+const SD_KEY = 'SD-REFILL-00ABCD12';
+const SOURCE_ID = '4004aa2c-0139-41e0-9cd3-fa42a8148621';
+
+/** A baseline dispatchable SD row (no deps, not terminal, not a parent/fixture). */
+function sdRow(overrides = {}) {
+  return {
+    sd_key: SD_KEY,
+    sd_type: 'infrastructure',
+    dependencies: [],
+    status: 'draft',
+    target_application: 'EHG_Engineer',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+const autoRefillMeta = { sourced_by: 'auto-refill', promoted_from_roadmap_item_id: SOURCE_ID };
+
+/** Build a stub supabase client + a record of which tables were queried. */
+function makeStub({ sd, source = null, sourceError = null }) {
+  const queried = [];
+  const sb = {
+    from(table) {
+      queried.push(table);
+      const builder = {
+        select() { return builder; },
+        eq() { return builder; },
+        in() { return builder; },
+        async maybeSingle() {
+          if (table === 'strategic_directives_v2') return { data: sd, error: null };
+          if (table === 'roadmap_wave_items') return { data: source, error: sourceError };
+          return { data: null, error: null };
+        },
+        // thenable safety net for any `await builder` path (deps query) — unused with empty deps
+        then(resolve) { resolve({ data: [], error: null }); },
+      };
+      return builder;
+    },
+  };
+  return { sb, queried };
+}
+
+const validSource = () => ({ promoted_to_sd_key: SD_KEY, lane: 'build', title: 'real candidate', source_id: SOURCE_ID });
+
+describe('evaluateDispatchEligibility — auto-refill claim-time source guard', () => {
+  it('blocks an auto-refill SD whose source lane was declined post-promotion', async () => {
+    const { sb } = makeStub({ sd: sdRow({ metadata: autoRefillMeta }), source: { ...validSource(), lane: 'decline' } });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: false, reason: 'refill_source_declined_lane' });
+  });
+
+  it('blocks an auto-refill SD whose source was unlinked/re-pointed', async () => {
+    const { sb } = makeStub({ sd: sdRow({ metadata: autoRefillMeta }), source: { ...validSource(), promoted_to_sd_key: null } });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: false, reason: 'refill_source_source_unlinked' });
+  });
+
+  it('blocks an auto-refill SD whose source row is gone', async () => {
+    const { sb } = makeStub({ sd: sdRow({ metadata: autoRefillMeta }), source: null });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: false, reason: 'refill_source_source_missing' });
+  });
+
+  it('allows an auto-refill SD whose source is still validly linked and non-declined', async () => {
+    const { sb } = makeStub({ sd: sdRow({ metadata: autoRefillMeta }), source: validSource() });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: true });
+  });
+
+  it('FAIL-OPEN: a source-fetch error never blocks dispatch', async () => {
+    const { sb } = makeStub({ sd: sdRow({ metadata: autoRefillMeta }), sourceError: { message: 'boom' } });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: true });
+  });
+
+  it('FAIL-OPEN: an auto-refill SD missing promoted_from_roadmap_item_id is not fetched and stays eligible', async () => {
+    const { sb, queried } = makeStub({ sd: sdRow({ metadata: { sourced_by: 'auto-refill' } }) });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: true });
+    expect(queried).not.toContain('roadmap_wave_items');
+  });
+
+  it('BYTE-IDENTICAL: a non-auto-refill SD never triggers a source fetch', async () => {
+    const { sb, queried } = makeStub({ sd: sdRow({ metadata: { sourced_by: 'leo' } }) });
+    const verdict = await evaluateDispatchEligibility(sb, SD_KEY);
+    expect(verdict).toEqual({ eligible: true });
+    expect(queried).not.toContain('roadmap_wave_items');
+  });
+});

--- a/tests/unit/sourcing-engine/refill-claim-time-source.test.js
+++ b/tests/unit/sourcing-engine/refill-claim-time-source.test.js
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D (FR-1) — unit tests for the pure claim-time
+ * source-integrity helper evaluateClaimTimeRefillSource.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateClaimTimeRefillSource,
+  REFILL_CLAIM_SOURCE_REASONS,
+} from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+
+const SD_KEY = 'SD-REFILL-00ABCD12';
+
+/** A still-valid promoted source: links back to SD_KEY, on a real lane, real title/provenance. */
+const validSource = () => ({
+  promoted_to_sd_key: SD_KEY,
+  lane: 'build',
+  title: 'Coordinator morning-trigger detection',
+  source_id: '5d194c35-1307-44e0-8bf7-14d38ece03c0',
+});
+
+describe('evaluateClaimTimeRefillSource', () => {
+  it('returns valid for a still-linked, non-declined, non-fixture source', () => {
+    expect(evaluateClaimTimeRefillSource(validSource(), SD_KEY)).toEqual({ valid: true, reason: null });
+  });
+
+  it('source_missing for null / non-object / array', () => {
+    expect(evaluateClaimTimeRefillSource(null, SD_KEY).reason).toBe(REFILL_CLAIM_SOURCE_REASONS.SOURCE_MISSING);
+    expect(evaluateClaimTimeRefillSource(undefined, SD_KEY).reason).toBe(REFILL_CLAIM_SOURCE_REASONS.SOURCE_MISSING);
+    expect(evaluateClaimTimeRefillSource('nope', SD_KEY).reason).toBe(REFILL_CLAIM_SOURCE_REASONS.SOURCE_MISSING);
+    expect(evaluateClaimTimeRefillSource([], SD_KEY).reason).toBe(REFILL_CLAIM_SOURCE_REASONS.SOURCE_MISSING);
+  });
+
+  it('source_unlinked when promoted_to_sd_key is null/empty', () => {
+    const s = { ...validSource(), promoted_to_sd_key: null };
+    expect(evaluateClaimTimeRefillSource(s, SD_KEY)).toEqual({ valid: false, reason: REFILL_CLAIM_SOURCE_REASONS.SOURCE_UNLINKED });
+    expect(evaluateClaimTimeRefillSource({ ...validSource(), promoted_to_sd_key: '' }, SD_KEY).reason)
+      .toBe(REFILL_CLAIM_SOURCE_REASONS.SOURCE_UNLINKED);
+  });
+
+  it('source_unlinked when the link points to a DIFFERENT SD (re-pointed)', () => {
+    const s = { ...validSource(), promoted_to_sd_key: 'SD-REFILL-99ZZZZ99' };
+    expect(evaluateClaimTimeRefillSource(s, SD_KEY).reason).toBe(REFILL_CLAIM_SOURCE_REASONS.SOURCE_UNLINKED);
+  });
+
+  it('declined_lane when the source lane was routed to decline after promotion', () => {
+    expect(evaluateClaimTimeRefillSource({ ...validSource(), lane: 'decline' }, SD_KEY).reason)
+      .toBe(REFILL_CLAIM_SOURCE_REASONS.DECLINED_LANE);
+    // case/space-insensitive
+    expect(evaluateClaimTimeRefillSource({ ...validSource(), lane: '  DECLINE ' }, SD_KEY).reason)
+      .toBe(REFILL_CLAIM_SOURCE_REASONS.DECLINED_LANE);
+  });
+
+  it('test_fixture when the source title or source_id is a TEST/DEMO fixture', () => {
+    expect(evaluateClaimTimeRefillSource({ ...validSource(), title: 'TEST harness probe' }, SD_KEY).reason)
+      .toBe(REFILL_CLAIM_SOURCE_REASONS.TEST_FIXTURE);
+    expect(evaluateClaimTimeRefillSource({ ...validSource(), source_id: 'SD-DEMO-001' }, SD_KEY).reason)
+      .toBe(REFILL_CLAIM_SOURCE_REASONS.TEST_FIXTURE);
+  });
+
+  it('EXCLUDED AXES: an already-promoted, non-pending source that is otherwise valid stays VALID', () => {
+    // The raw -A predicate would short-circuit on already_promoted / not_staged; the claim-time helper
+    // deliberately does NOT — these are the expected post-promotion state. No item_disposition field is
+    // even consulted here.
+    const s = { ...validSource(), item_disposition: 'promoted' };
+    expect(evaluateClaimTimeRefillSource(s, SD_KEY)).toEqual({ valid: true, reason: null });
+    // reasons surfaced are never the pre-promotion lifecycle ones
+    expect(evaluateClaimTimeRefillSource(s, SD_KEY).reason).not.toBe('already_promoted');
+    expect(evaluateClaimTimeRefillSource(s, SD_KEY).reason).not.toBe('not_staged');
+  });
+
+  it('is total — never throws on odd input', () => {
+    expect(() => evaluateClaimTimeRefillSource({}, SD_KEY)).not.toThrow();
+    expect(() => evaluateClaimTimeRefillSource({ lane: 42 }, SD_KEY)).not.toThrow();
+    expect(() => evaluateClaimTimeRefillSource(validSource(), undefined)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What
Adds a **claim-time source-integrity guard** for auto-refilled SDs. When a worker tries to claim an SD minted by auto-refill (`metadata.sourced_by==='auto-refill'`, `SD-REFILL-*` key), `evaluateDispatchEligibility` re-consults its **source** `roadmap_wave_item` and skips the SD if the source drifted after promotion.

## Why (domain-correct reframing of -D)
The literal task ("wire `evaluateRefillCandidate` into claim-eligibility") is **domain-mismatched**: that staged-item predicate runs `already_promoted`/`not_staged` first, and both are the *expected* state once a source is promoted — running it at claim time would block **every** auto-refilled SD. And -C already enforces candidate-validity at **promotion** time.

The genuine, non-redundant gap: a source can be **declined / deleted / unlinked AFTER promotion**, leaving an orphaned `SD-REFILL-*` in the claim queue. The minted key is always `SD-REFILL-*`, so the existing `sd_key`-based fixture guard is also blind to a fixture that entered via the source. This PR closes both — a TOCTOU complement to -C.

## Changes
- **FR-1** `lib/sourcing-engine/refill-candidate-validity.js`: new pure SSOT helper `evaluateClaimTimeRefillSource(sourceItem, expectedSdKey)` — `source_missing → source_unlinked → declined_lane → test_fixture`, **excluding** the promotion-expected axes; reuses the `FIXTURE_*` constants; pure + total.
- **FR-2** `lib/fleet/claim-eligibility.cjs`: scoped, **fail-open** wire into the async `evaluateDispatchEligibility` (dynamic-imports the ESM helper; only auto-refill SDs incur the source fetch; any error/missing marker → eligible, byte-identical for every other SD).
- **FR-3** 8 unit + 7 integration tests (15 green).

## Verification
- `npx vitest run` on both new files → 15/15.
- Exercised against the **10 live `SD-REFILL-*` SDs**: all stay `eligible:true` (sources validly linked, non-declined); a declined source correctly yields `declined_lane`.
- No schema change. Pure function unchanged (`classifyDispatchIneligibility` stays DB-free/synchronous).

> Pre-existing (not introduced here): `tests/unit/fleet/sd-executable-here.test.js > with ctx` fails on clean HEAD too — cwd-dependent `isSdExecutableHere` test, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)