### PR TITLE
fix(SD-REFILL-007PVF5E): repair well-determined phantom-column refs in EVA stage-execution-worker

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2606,21 +2606,12 @@ export class StageExecutionWorker {
       .maybeSingle();
     logoSpec = brandArtifact?.artifact_data?.logoSpec || null;
 
-    // Legacy fallback: older ventures may have logoSpec mirrored into stage_data.
+    // SD-REFILL-007PVF5E: removed the dead legacy venture_stage_work.stage_data fallback — that
+    // column does not exist live (the read threw), and logoSpec is canonically sourced from the
+    // identity_brand_name artifact above (SD-LEO-FEAT-VENTURE-BRAND-GROUNDED-001/FR-3), so the
+    // fallback could never have recovered a spec the canonical read missed.
     if (!logoSpec) {
-      const { data: s11Work } = await this._supabase
-        .from('venture_stage_work')
-        .select('stage_data') // pre-existing phantom ref (pre-dates SD-LEO-FIX-PERSIST-KILL-GATE-001; tracked via feedback) schema-lint-disable-line
-        .eq('venture_id', ventureId)
-        .eq('lifecycle_stage', 11)
-        .order('updated_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      logoSpec = s11Work?.stage_data?.logoSpec || null;
-    }
-
-    if (!logoSpec) {
-      logger.log('[S11-Logo] No logoSpec in identity_brand_name artifact or S11 stage_data — skipping');
+      logger.log('[S11-Logo] No logoSpec in identity_brand_name artifact — skipping');
       return;
     }
 
@@ -2779,12 +2770,17 @@ export class StageExecutionWorker {
       // Low-confidence path → chairman_warning audit row (visible for manual override
       // via SQL runbook until the S11 chairman-override UI ships in a follow-up SD).
       if (result.confidence < 0.85) {
-        const { error: warnErr } = await this._supabase.from('audit_log').insert({ // pre-existing phantom ref (pre-dates SD-LEO-FIX-PERSIST-KILL-GATE-001; tracked via feedback) schema-lint-disable-line
+        // SD-REFILL-007PVF5E: conform to the live audit_log schema (mirrors lib/eva/forward-gate.js):
+        // event_subtype/venture_id/details do not exist as columns; entity_type/entity_id are NOT NULL.
+        // Fold the former phantom fields into metadata and address the row to the venture entity.
+        const { error: warnErr } = await this._supabase.from('audit_log').insert({
           event_type: 'chairman_warning',
-          event_subtype: 'gvos_low_confidence_archetype',
-          venture_id: ventureId,
+          entity_type: 'venture',
+          entity_id: ventureId,
           severity: 'warning',
-          details: {
+          metadata: {
+            event_subtype: 'gvos_low_confidence_archetype',
+            venture_id: ventureId,
             archetype_prompt_token: result.archetypePromptToken,
             confidence: result.confidence,
             rationale: result.rationale,
@@ -3800,7 +3796,9 @@ export class StageExecutionWorker {
     try {
       const { error } = await this._supabase
         .from('chairman_decisions')
-        .update({ status: 'approved', decision: 'proceed', resolved_at: new Date().toISOString() }) // pre-existing phantom ref (pre-dates SD-LEO-FIX-PERSIST-KILL-GATE-001; tracked via feedback) schema-lint-disable-line
+        // SD-REFILL-007PVF5E: dropped phantom resolved_at (no such column live); updated_at is
+        // trigger-maintained. status+decision are the intended resolution effect.
+        .update({ status: 'approved', decision: 'proceed' })
         .eq('venture_id', ventureId)
         .eq('lifecycle_stage', 19)
         .eq('status', 'pending')
@@ -4149,7 +4147,7 @@ export class StageExecutionWorker {
         .from('venture_stage_work')
         .select('advisory_data')
         .eq('venture_id', ventureId)
-        .eq('stage_number', stageNumber)
+        .eq('lifecycle_stage', stageNumber)
         .maybeSingle();
 
       const advisory = existing?.advisory_data || {};
@@ -4163,14 +4161,17 @@ export class StageExecutionWorker {
       });
       advisory.gate_overrides = overrides;
 
+      // SD-REFILL-007PVF5E: venture_stage_work has no stage_number column; the real unique
+      // constraint is UNIQUE(venture_id, lifecycle_stage). The old onConflict threw Postgres 42P10
+      // (no matching constraint) and wrote 0 rows. Map stage_number -> lifecycle_stage.
       await this._supabase
         .from('venture_stage_work')
-        .upsert({ // pre-existing phantom ref (pre-dates SD-LEO-FIX-PERSIST-KILL-GATE-001; tracked via feedback) schema-lint-disable-line
+        .upsert({
           venture_id: ventureId,
-          stage_number: stageNumber,
+          lifecycle_stage: stageNumber,
           advisory_data: advisory,
           updated_at: new Date().toISOString(),
-        }, { onConflict: 'venture_id,stage_number' });
+        }, { onConflict: 'venture_id,lifecycle_stage' });
 
       this._logger.log(`[Worker] Advisory warning recorded for stage ${stageNumber} gate override`);
     } catch (err) {

--- a/tests/unit/eva/phantom-column-cleanup.test.js
+++ b/tests/unit/eva/phantom-column-cleanup.test.js
@@ -1,0 +1,70 @@
+/**
+ * SD-REFILL-007PVF5E (FR-5) — source-conformance guard for the phantom-column cleanup.
+ *
+ * Scans the two EVA files and asserts the IN-SCOPE phantom-column refs were removed and remapped to
+ * live columns, while the documented AMBIGUOUS sites (chairman_decisions.metadata?.strategy in the S17
+ * strategy gate, decision-filter-engine triggers/violations) remain pragma-marked and untouched (kept
+ * deliberately — a forced remap would silently degrade gate behavior; tracked as a product-gap follow-up).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const worker = readFileSync(resolve(repoRoot, 'lib/eva/stage-execution-worker.js'), 'utf8');
+const dfe = readFileSync(resolve(repoRoot, 'lib/eva/decision-filter-engine.js'), 'utf8');
+
+describe('phantom-column cleanup — in-scope sites fixed', () => {
+  it('venture_stage_work upsert no longer references the phantom stage_number column', () => {
+    // narrow to the venture_stage_work upsert (venture_stages.stage_number is a DIFFERENT, live column)
+    expect(worker).not.toMatch(/\bstage_number:\s*stageNumber/); // phantom upsert key (\b excludes p_stage_number RPC param)
+    expect(worker).not.toMatch(/onConflict:\s*'venture_id,stage_number'/); // phantom conflict target
+    // the real unique constraint is used for the upsert conflict target
+    expect(worker).toMatch(/onConflict:\s*'venture_id,lifecycle_stage'/);
+  });
+
+  it('venture_stage_work upsert/read use lifecycle_stage', () => {
+    // the advisory-warning method now keys off lifecycle_stage
+    expect(worker).toMatch(/\.eq\('lifecycle_stage', stageNumber\)/);
+    expect(worker).toMatch(/lifecycle_stage:\s*stageNumber/);
+  });
+
+  it('the dead legacy stage_data fallback is gone', () => {
+    expect(worker).not.toMatch(/\.select\('stage_data'\)/);
+    expect(worker).not.toMatch(/s11Work\?\.stage_data/);
+  });
+
+  it('audit_log insert conforms to the live schema (NOT NULL entity_type/entity_id, metadata-folded)', () => {
+    // the chairman_warning audit insert must carry the required entity columns
+    const insertBlock = worker.slice(worker.indexOf("event_type: 'chairman_warning'"), worker.indexOf("event_type: 'chairman_warning'") + 600);
+    expect(insertBlock).toMatch(/entity_type:\s*'venture'/);
+    expect(insertBlock).toMatch(/entity_id:\s*ventureId/);
+    // the former phantom values are folded into metadata (no standalone details: key)
+    expect(insertBlock).toMatch(/metadata:\s*\{/);
+    expect(insertBlock).not.toMatch(/\n\s{8}details:\s*\{/); // 'details' was a direct insert key; now gone
+    // event_subtype is now NESTED inside metadata (appears after 'metadata: {'), not a top-level column
+    expect(insertBlock.indexOf('metadata: {')).toBeLessThan(insertBlock.indexOf('event_subtype'));
+    expect(insertBlock).toMatch(/event_subtype:\s*'gvos_low_confidence_archetype'/);
+  });
+
+  it('the chairman_decisions resolve update dropped the phantom resolved_at', () => {
+    expect(worker).not.toMatch(/resolved_at:\s*new Date/);
+  });
+});
+
+describe('phantom-column cleanup — ambiguous sites deliberately kept', () => {
+  it('the S17 strategy-gate metadata.strategy reads remain (pragma-marked) — not force-remapped', () => {
+    // these still read metadata?.strategy; a remap would silently degrade the gate (no live writer)
+    expect(worker).toMatch(/metadata\?\.strategy/);
+    // and they stay pragma-suppressed so the schema-lint does not block on a known, tracked gap
+    const pragmaCount = (worker.match(/schema-lint-disable-line/g) || []).length;
+    expect(pragmaCount).toBe(3); // exactly the three S17 strategy-cluster selects
+  });
+
+  it('decision-filter-engine triggers/violations select remains pragma-marked', () => {
+    expect(dfe).toMatch(/schema-lint-disable-line/);
+    expect(dfe).toMatch(/metadata\?\.(triggers|violations)|d\.metadata/);
+  });
+});

--- a/tests/unit/eva/stage-execution-worker-s11-brand-grounded.test.js
+++ b/tests/unit/eva/stage-execution-worker-s11-brand-grounded.test.js
@@ -283,13 +283,11 @@ describe('FR-3: _postStageHook_S11_LogoGeneration (logoSpec source)', () => {
     expect(wrote.artifactData.logoSpec).toEqual(logoSpec);
   });
 
-  it('falls back to venture_stage_work.stage_data.logoSpec when no artifact logoSpec', async () => {
-    const legacySpec = { iconConcept: 'legacy-icon', primaryColor: '#000000' };
+  // SD-REFILL-007PVF5E: the legacy venture_stage_work.stage_data fallback was REMOVED — that column
+  // does not exist in the live DB (the read threw), so the fallback only ever "worked" against a mock.
+  // With no artifact logoSpec, the hook now skips; a (would-be) legacy stage_data spec is never read.
+  it('does NOT fall back to the removed stage_data path — skips when the artifact has no logoSpec', async () => {
     const supabase = createQueuedSupabase({
-      venture_stage_work: [
-        { data: [{ lifecycle_stage: 11 }], error: null }, // viability gate
-        { data: { stage_data: { logoSpec: legacySpec } }, error: null }, // legacy fallback
-      ],
       venture_artifacts: [
         { data: [], error: null }, // idempotency
         { data: { artifact_data: {} }, error: null }, // identity_brand_name has NO logoSpec
@@ -302,8 +300,8 @@ describe('FR-3: _postStageHook_S11_LogoGeneration (logoSpec source)', () => {
 
     await worker._postStageHook_S11_LogoGeneration(VID);
 
-    expect(renderLogo).toHaveBeenCalledTimes(1);
-    expect(renderLogo).toHaveBeenCalledWith(legacySpec, expect.objectContaining({ ventureName: 'LegacyCo' }));
+    // no second venture_stage_work read, no render — the canonical artifact is the only logoSpec source
+    expect(renderLogo).not.toHaveBeenCalled();
   });
 
   it('skips (no render) when neither artifact nor stage_data has a logoSpec', async () => {

--- a/tests/unit/eva/stage-execution-worker-s19-surfacing.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-surfacing.test.js
@@ -210,7 +210,8 @@ describe('FR-2 _resolveVisionPendingDecision', () => {
     expect(updates).toHaveLength(1);
     expect(updates[0].payload.status).toBe('approved');
     expect(updates[0].payload.decision).toBe('proceed');
-    expect(typeof updates[0].payload.resolved_at).toBe('string');
+    // SD-REFILL-007PVF5E: phantom resolved_at dropped (no such column live; updated_at is trigger-maintained)
+    expect(updates[0].payload.resolved_at).toBeUndefined();
 
     const filters = eqStrings(supabase._calls, 'chairman_decisions');
     expect(filters).toContain('venture_id=v-1');


### PR DESCRIPTION
## What
Repairs the **live-verified subset** of pragma-marked phantom-column references in `lib/eva/stage-execution-worker.js` — code that selects/inserts/updates columns absent from the live DB, so each path threw at runtime (`column does not exist` / Postgres `42P10`). **Code-only, no DDL.** A database-agent verified every live-column target and the real `venture_stage_work` unique constraint.

## In scope (fixed)
- **venture_stage_work upsert/read** — `onConflict:'venture_id,stage_number'` → `'venture_id,lifecycle_stage'` + `.eq('stage_number')` → `.eq('lifecycle_stage')`. The old conflict target matched no constraint (42P10) and wrote 0 rows.
- **audit_log insert** — fold `event_subtype`/`venture_id`/`details` into `metadata`; add NOT-NULL `entity_type:'venture'`/`entity_id` (mirrors `lib/eva/forward-gate.js`).
- **chairman_decisions resolve** — drop phantom `resolved_at` (`updated_at` is trigger-maintained).
- **delete dead legacy S11 `stage_data` fallback** — superseded by the canonical `venture_artifacts.artifact_data.logoSpec` read; `stage_data` never existed live.

## Deliberately OUT of scope (kept pragma-marked + follow-up `a0ba4935`)
- **S17 `chairman_decisions.metadata?.strategy` reads** — *no writer persists a scalar `strategy`*; any remap reads an unwritten key → silently null → the strategy gate degrades to "use all" for every venture. A real product gap, not a column rename.
- **`decision-filter-engine.js` triggers/violations** — data lives in different columns per producer (`dfe_context` vs `brief_data` vs `context`); a single-col remap silently undercounts override analytics.
- The entangled `metadata->>decision_type` filter (shares the ambiguous select) was excluded too.

> Principle: only ship sites where the correct mapping is live-verified and behavior-preserving; never trade a loud throw for a **silent** gate degradation.

## Tests
- New source-conformance guard `tests/unit/eva/phantom-column-cleanup.test.js` (asserts in-scope refs fixed + ambiguous sites still pragma-marked).
- Updated 2 existing tests that pinned the now-removed phantom behavior (the `stage_data` fallback; the `resolved_at` field).
- **129 passed / 2 skipped** across the affected `stage-execution-worker*` + `decision-filter*` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)