### PR TITLE
fix(SD-REFILL-001KNKE4): forbid build claims on is_coordinator sessions (coordinator-identity collision guard)

### DIFF
--- a/lib/claim/build-forbidden-session.cjs
+++ b/lib/claim/build-forbidden-session.cjs
@@ -12,12 +12,22 @@
  * or role==='adam' returns true; any other/missing metadata returns false
  * (never broadens rejection to legitimate fleet workers).
  *
+ * SD-REFILL-001KNKE4: also forbid is_coordinator===true sessions. A coordinator
+ * DISPATCHES work; it never self-claims a build SD. Critically, a worker window
+ * can COLLIDE onto the coordinator's claude_sessions row (terminal_id/SSE-port
+ * sharing → same CLAUDE_SESSION_ID); when that worker self-claims, it reads the
+ * coordinator's metadata (is_coordinator=true) here and is short-circuited to
+ * idle — so it can never write a worker claim onto the coordinator row and
+ * corrupt coordinator identity (a state the stale-session-sweep cannot self-heal
+ * because the coordinator's own heartbeat keeps the row fresh). Covers BOTH the
+ * acquisition-time guard (worker-checkin) and the handoff-time tripwire.
+ *
  * @param {object|null} metadata - claude_sessions.metadata
  * @returns {boolean}
  */
 function isBuildForbiddenSession(metadata) {
   const md = metadata || {};
-  return md.non_fleet === true || md.role === 'adam';
+  return md.non_fleet === true || md.role === 'adam' || md.is_coordinator === true;
 }
 
 module.exports = { isBuildForbiddenSession };

--- a/tests/unit/claim-self-only-authorization.test.js
+++ b/tests/unit/claim-self-only-authorization.test.js
@@ -26,6 +26,14 @@ describe('isBuildForbiddenSession (FR-1 predicate)', () => {
   it('rejects a role=adam session', () => {
     expect(isBuildForbiddenSession({ role: 'adam' })).toBe(true);
   });
+  // SD-REFILL-001KNKE4: a coordinator session must never hold/acquire a build claim. Critically,
+  // a worker colliding onto the coordinator's session row (shared CLAUDE_SESSION_ID) reads
+  // is_coordinator=true here and is short-circuited, so it can't write a worker claim onto the
+  // coordinator row and corrupt coordinator identity.
+  it('rejects an is_coordinator session', () => {
+    expect(isBuildForbiddenSession({ is_coordinator: true })).toBe(true);
+    expect(isBuildForbiddenSession({ is_coordinator: true, role: 'coordinator', callsign: 'Coord' })).toBe(true);
+  });
   it('allows a normal fleet session', () => {
     expect(isBuildForbiddenSession({ role: 'worker', callsign: 'Bravo' })).toBe(false);
   });
@@ -34,6 +42,8 @@ describe('isBuildForbiddenSession (FR-1 predicate)', () => {
     expect(isBuildForbiddenSession(undefined)).toBe(false);
     expect(isBuildForbiddenSession({})).toBe(false);
     expect(isBuildForbiddenSession({ non_fleet: 'true' })).toBe(false); // string, not boolean true
+    expect(isBuildForbiddenSession({ is_coordinator: 'true' })).toBe(false); // string, not boolean true
+    expect(isBuildForbiddenSession({ is_coordinator: false })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
A worker window collided onto the **coordinator's** `session_id` (terminal_id/SSE-port sharing → same `CLAUDE_SESSION_ID`) and self-claimed an SD into the coordinator's `claude_sessions` row while `metadata.is_coordinator=true`, corrupting coordinator identity. The stale-session-sweep can't self-heal it (the coordinator's own heartbeat keeps the row fresh).

## Fix (option c — single source of truth)
Extend the shared `isBuildForbiddenSession` predicate (`lib/claim/build-forbidden-session.cjs`) to also forbid `metadata.is_coordinator===true`. A coordinator dispatches work and never self-claims a build SD; when a worker collides onto the coordinator row, `worker-checkin` reads `is_coordinator=true` through this predicate and short-circuits to idle **before every acquisition tier**, so it can never write a worker claim onto the coordinator row. The predicate is the single source consumed by BOTH the acquisition guard (`worker-checkin`) AND the handoff-time tripwire (`assertValidClaim`), so all claim paths are covered. Fail-safe preserved (only explicit boolean `true` forbids).

## Tests
- 11 unit tests incl. `is_coordinator` true/false/string cases + the SSOT-agreement test proving the ESM gate re-export and the CJS module agree on all cases.

## Note
The 3 ESLint warnings on the test file (`col`/`val`/`tryClaim`) are **pre-existing** (lines 62/108, outside this change's added lines), already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
