### PR TITLE
fix(SD-REFILL-00V2SADI): noise-floor red-merge-detector against flaky ci_test_failure_count

### DIFF
--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -59,6 +59,12 @@ function median(nums) {
  *     that baseline (persistence — a lone transient bounce never qualifies).
  * Needs ≥3 snapshots (latest + prev + ≥1 settled baseline reading).
  *
+ * ONE-SHOT-PER-EVENT contract: a regression fires during the ~run window before it
+ * settles into the trailing median (which then absorbs it) — by design, paired with the
+ * dedup + storm-guard so a single event yields exactly one QF, not one per merge. A
+ * FURTHER sustained rise above the new elevated baseline still fires (masking does not
+ * compound). (RCA 105b7143)
+ *
  * @param {Array<{findings: Array<{failed_count: number, commit_sha?: string, branch?: string}>}>} snapshots newest-first
  * @param {Array<{id: string, description?: string}>} openRedMergeQfs
  * @param {{noiseFloor?: number}} [opts]
@@ -115,6 +121,7 @@ async function main() {
     .select('id, findings, created_at')
     .eq('dimension', DIMENSION)
     .order('created_at', { ascending: false })
+    .order('id', { ascending: false }) // deterministic tie-break for same-second snapshots (RCA 105b7143)
     .limit(10);
   if (error) { console.error('snapshot read failed:', error.message); process.exit(1); }
   // Pass a trailing WINDOW (not just 2) so decide() can compute a robust settled-median

--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -26,24 +26,70 @@ const DIMENSION = 'ci_test_failure_count'; // must match compare-to-main-snapsho
 const TABLE = 'codebase_health_snapshots';
 
 /**
- * Pure decision: given the two latest main snapshots (newest first) and the
- * list of OPEN red-merge QFs, decide what to do.
+ * NOISE FLOOR — the minimum amount the failure count must sit ABOVE the settled
+ * baseline to count as elevated. Persistence (below) does the heavy lifting; the
+ * floor only ignores trivial wiggle. Env-overridable. (SD-REFILL-00V2SADI)
+ */
+export const DEFAULT_NOISE_FLOOR = (() => {
+  const n = Number(process.env.RED_MERGE_NOISE_FLOOR);
+  return Number.isFinite(n) && n >= 0 ? n : 1;
+})();
+
+/** Median of the finite numbers in `nums` (NaN if none). Pure. */
+function median(nums) {
+  const a = nums.filter(Number.isFinite).slice().sort((x, y) => x - y);
+  if (!a.length) return NaN;
+  const m = Math.floor(a.length / 2);
+  return a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2;
+}
+
+/**
+ * Pure decision: given a trailing window of recent main snapshots (NEWEST FIRST)
+ * and the list of OPEN red-merge QFs, decide what to do.
+ *
+ * ci_test_failure_count on main is FLAKY — it bounces across adjacent runs (the
+ * motivating sequence: 102→103→118→103→114→103). The original rule (fire whenever
+ * latest > the single immediately-prior snapshot) tripped a false-positive
+ * CI-blocking QF on every transient up-bounce. (SD-REFILL-00V2SADI)
+ *
+ * Hardened rule — a CONFIRMED rise, never a single spike:
+ *   • baseline = MEDIAN of the SETTLED window (excludes the candidate latest TWO
+ *     readings, so a 1- or 2-run flaky spike cannot inflate its own baseline),
+ *   • fire only when BOTH the latest AND the prior reading sit ≥ NOISE_FLOOR above
+ *     that baseline (persistence — a lone transient bounce never qualifies).
+ * Needs ≥3 snapshots (latest + prev + ≥1 settled baseline reading).
+ *
  * @param {Array<{findings: Array<{failed_count: number, commit_sha?: string, branch?: string}>}>} snapshots newest-first
  * @param {Array<{id: string, description?: string}>} openRedMergeQfs
- * @returns {{action: 'file_qf'|'noop', reason: string, signature?: string, newFailed?: number, prevFailed?: number, sha?: string}}
+ * @param {{noiseFloor?: number}} [opts]
+ * @returns {{action: 'file_qf'|'noop', reason: string, signature?: string, newFailed?: number, prevFailed?: number, baseline?: number, sha?: string}}
  */
-export function decide(snapshots = [], openRedMergeQfs = []) {
+export function decide(snapshots = [], openRedMergeQfs = [], opts = {}) {
+  const noiseFloor = Number.isFinite(opts.noiseFloor) ? opts.noiseFloor : DEFAULT_NOISE_FLOOR;
   const f = (s) => (s && s.findings && s.findings[0]) || {};
-  if (snapshots.length < 2) return { action: 'noop', reason: 'fewer than 2 main snapshots — no baseline to compare' };
-  const [latest, prev] = snapshots;
-  const newFailed = Number(f(latest).failed_count ?? NaN);
-  const prevFailed = Number(f(prev).failed_count ?? NaN);
+  if (snapshots.length < 3) {
+    return { action: 'noop', reason: `insufficient history (${snapshots.length} main snapshot(s); need ≥3 for confirmed-rise detection)` };
+  }
+  const counts = snapshots.map((s) => Number(f(s).failed_count ?? NaN));
+  const [newFailed, prevFailed] = counts;
   if (!Number.isFinite(newFailed) || !Number.isFinite(prevFailed)) {
     return { action: 'noop', reason: 'snapshot missing failed_count' };
   }
-  if (newFailed <= prevFailed) return { action: 'noop', reason: `green: failed ${newFailed} <= baseline ${prevFailed}` };
+  // Settled baseline excludes the candidate latest two readings, so a 1- or 2-run
+  // flaky spike cannot inflate its own baseline.
+  const baseline = median(counts.slice(2));
+  if (!Number.isFinite(baseline)) return { action: 'noop', reason: 'no settled baseline' };
 
-  const sha = f(latest).commit_sha || 'unknown-sha';
+  // PERSISTENCE + NOISE FLOOR: a single transient bounce never qualifies.
+  const elevated = (v) => v - baseline >= noiseFloor;
+  if (!(elevated(newFailed) && elevated(prevFailed))) {
+    return {
+      action: 'noop',
+      reason: `no confirmed rise: latest ${newFailed}, prev ${prevFailed} vs settled median ${baseline} (floor ${noiseFloor})`,
+    };
+  }
+
+  const sha = f(snapshots[0]).commit_sha || 'unknown-sha';
   const signature = `red-merge:${DIMENSION}:${sha}`;
   if (openRedMergeQfs.some((q) => (q.description || '').includes(signature))) {
     return { action: 'noop', reason: `dedup: open QF already carries signature ${signature}` };
@@ -53,7 +99,11 @@ export function decide(snapshots = [], openRedMergeQfs = []) {
     // signatures must not file a QF per merge.
     return { action: 'noop', reason: `storm guard: ${openRedMergeQfs.length} red-merge QF(s) already open` };
   }
-  return { action: 'file_qf', reason: `red merge: failed ${prevFailed} -> ${newFailed}`, signature, newFailed, prevFailed, sha };
+  return {
+    action: 'file_qf',
+    reason: `confirmed red merge: settled median ${baseline} -> sustained ${prevFailed},${newFailed}`,
+    signature, newFailed, prevFailed, baseline, sha,
+  };
 }
 
 async function main() {
@@ -67,7 +117,9 @@ async function main() {
     .order('created_at', { ascending: false })
     .limit(10);
   if (error) { console.error('snapshot read failed:', error.message); process.exit(1); }
-  const mainSnaps = (snaps || []).filter((s) => (s.findings?.[0]?.branch || '') === 'main').slice(0, 2);
+  // Pass a trailing WINDOW (not just 2) so decide() can compute a robust settled-median
+  // baseline + confirm persistence — the flaky-bounce noise floor (SD-REFILL-00V2SADI).
+  const mainSnaps = (snaps || []).filter((s) => (s.findings?.[0]?.branch || '') === 'main').slice(0, 8);
 
   const { data: openQfs } = await db
     .from('quick_fixes')

--- a/tests/unit/medium-effort-hardening.test.js
+++ b/tests/unit/medium-effort-hardening.test.js
@@ -175,6 +175,18 @@ describe('FR-3: red-merge decide()', async () => {
     // same window with the default floor (1) DOES confirm.
     expect(decide([snap(105, 's'), snap(105), snap(103), snap(103)], []).action).toBe('file_qf');
   });
+
+  // SD-REFILL-00V2SADI / RCA 105b7143: one-shot-per-event contract.
+  it('plateau: fires during the detection window, then the trailing median absorbs it (one-shot)', () => {
+    // age1-2 of a plateau (118 just landed on a 103 floor) => fires.
+    expect(decide([snap(118, 'land'), snap(118), snap(103), snap(103), snap(102)], []).action).toBe('file_qf');
+    // long-settled plateau (118 is now the median) => noop (already alerted once; dedup/storm-guard own re-alerting).
+    expect(decide([snap(118), snap(118), snap(118), snap(118), snap(118)], []).action).toBe('noop');
+  });
+
+  it('masking does NOT compound: a further rise above an elevated baseline still fires', () => {
+    expect(decide([snap(130, 'higher'), snap(130), snap(118), snap(118), snap(118)], []).action).toBe('file_qf');
+  });
 });
 
 // ── FR-1: recordFailure routing (TS-1) ───────────────────────────────────────

--- a/tests/unit/medium-effort-hardening.test.js
+++ b/tests/unit/medium-effort-hardening.test.js
@@ -129,32 +129,51 @@ describe('FR-3: red-merge decide()', async () => {
   const { decide } = await import('../../scripts/ci/red-merge-detector.mjs');
   const snap = (failed, sha = 'abc123def456') => ({ findings: [{ failed_count: failed, commit_sha: sha, branch: 'main' }] });
 
-  it('red merge (failed count rose) => file_qf with signature', () => {
-    const v = decide([snap(105, 'newsha'), snap(100)], []);
+  // SD-REFILL-00V2SADI: contract change — a CONFIRMED rise fires, not a single up-tick.
+  // A sustained rise (latest TWO readings both above the settled median) fires.
+  it('confirmed red merge (sustained rise) => file_qf with signature', () => {
+    const v = decide([snap(121, 'newsha'), snap(120), snap(103), snap(103), snap(102)], []);
     expect(v.action).toBe('file_qf');
     expect(v.signature).toContain('newsha');
-    expect(v.newFailed).toBe(105);
+    expect(v.newFailed).toBe(121);
   });
 
-  it('green or improving => noop', () => {
-    expect(decide([snap(100), snap(100)], []).action).toBe('noop');
-    expect(decide([snap(90), snap(100)], []).action).toBe('noop');
+  // The motivating flaky bounce 102→103→118→103→114→103 must NEVER fire — neither when
+  // a transient spike is the latest reading, nor after it settles back down.
+  it('flaky bounce (transient single-run spike) => noop', () => {
+    // newest-first; latest is the 114 spike, prior reading already settled back to 103.
+    expect(decide([snap(114, 'spike'), snap(103), snap(118), snap(103), snap(102)], []).action).toBe('noop');
+    // and one tick later, settled back to 103 on top of the bouncy history.
+    expect(decide([snap(103), snap(114), snap(103), snap(118), snap(103), snap(102)], []).action).toBe('noop');
+  });
+
+  it('green or improving / flat => noop', () => {
+    expect(decide([snap(103), snap(103), snap(103), snap(103)], []).action).toBe('noop');
+    expect(decide([snap(100), snap(110), snap(112), snap(111)], []).action).toBe('noop'); // latest improved
   });
 
   it('idempotent rerun: same signature already open => noop (dedup)', () => {
-    const v = decide([snap(105, 'samesha'), snap(100)], [{ id: 'QF-1', description: 'red-merge:ci_test_failure_count:samesha ...' }]);
+    const v = decide([snap(121, 'samesha'), snap(120), snap(103), snap(103)], [{ id: 'QF-1', description: 'red-merge:ci_test_failure_count:samesha ...' }]);
     expect(v.action).toBe('noop');
     expect(v.reason).toContain('dedup');
   });
 
   it('storm guard: any open red-merge QF blocks a second filing', () => {
-    const v = decide([snap(110, 'othersha'), snap(105)], [{ id: 'QF-1', description: 'red-merge:ci_test_failure_count:somesha' }]);
+    const v = decide([snap(121, 'othersha'), snap(120), snap(103), snap(103)], [{ id: 'QF-1', description: 'red-merge:ci_test_failure_count:somesha' }]);
     expect(v.action).toBe('noop');
     expect(v.reason).toContain('storm guard');
   });
 
-  it('insufficient history => noop', () => {
+  it('insufficient history (<3 snapshots) => noop', () => {
     expect(decide([snap(105)], []).action).toBe('noop');
+    expect(decide([snap(105, 'x'), snap(100)], []).action).toBe('noop');
+  });
+
+  it('noiseFloor is configurable (a sub-floor sustained rise stays noop)', () => {
+    // settled median 103; sustained 105,105 is +2 — below a floor of 5 => noop.
+    expect(decide([snap(105), snap(105), snap(103), snap(103)], [], { noiseFloor: 5 }).action).toBe('noop');
+    // same window with the default floor (1) DOES confirm.
+    expect(decide([snap(105, 's'), snap(105), snap(103), snap(103)], []).action).toBe('file_qf');
   });
 });
 


### PR DESCRIPTION
## SD-REFILL-00V2SADI — red-merge-detector flaky noise floor

### Problem
scripts/ci/red-merge-detector.mjs decide() filed a CI-blocking red-merge QF on ANY single-run rise in main's `ci_test_failure_count` vs the immediately-prior snapshot. That count is **flaky** (bounces 102→103→118→103→114→103 across adjacent runs), so every transient up-bounce filed a false-positive QF.

### Fix
Hardened decide() to fire only on a **confirmed** rise:
- baseline = **median of the settled window** (`counts.slice(2)`, excludes the candidate latest two readings, so a 1–2-run spike can't inflate its own baseline)
- fire only when **both** the latest AND prior reading sit ≥ `NOISE_FLOOR` above baseline (persistence — a lone bounce never qualifies)
- requires ≥3 snapshots; `main()` now passes a trailing window of 8 (was 2)
- `RED_MERGE_NOISE_FLOOR` env-overridable (default 1)
- `.order('id',desc)` secondary sort for deterministic newest-first on same-second snapshots

**Contract change** from SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001 FR-3 (single-rise-fires → confirmed-rise-fires); pinned tests updated + flaky-bounce/plateau regression fixtures added. dedup + storm-guard + PR-leg semantics preserved.

### Verification
- 29 unit tests pass (incl. the observed bounce → noop; sustained rise → fire; plateau one-shot; masking does not compound).
- Live dry-run: latest 139 / prev 132 / settled median 132 → noop (correctly unconfirmed).
- TESTING: PASS. Adversarial RCA: CONDITIONAL_PASS → both MEDIUM findings (tie-ordering + plateau contract) addressed in follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
