### PR TITLE
fix(SD-REFILL-00ABJMAZ): restore createSupabaseServiceClient import in sd-burnrate.js

### DIFF
--- a/scripts/sd-burnrate.js
+++ b/scripts/sd-burnrate.js
@@ -14,7 +14,7 @@
  * - Take periodic snapshots for trending
  */
 
-// import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { execSync } from 'child_process'; // Unused - available for future shell commands
 import dotenv from 'dotenv';
 

--- a/tests/unit/sd-burnrate-import-guard.test.js
+++ b/tests/unit/sd-burnrate-import-guard.test.js
@@ -1,0 +1,31 @@
+/**
+ * Regression guard: scripts/sd-burnrate.js must IMPORT createSupabaseServiceClient if it uses it.
+ * SD-REFILL-00ABJMAZ — the import was commented out (line 17) while line 23 called the symbol, so
+ * `npm run sd:burnrate` (a documented essential command) crashed immediately with
+ * "ReferenceError: createSupabaseServiceClient is not defined". This pins the fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../../scripts/sd-burnrate.js');
+
+describe('sd-burnrate.js import guard (SD-REFILL-00ABJMAZ)', () => {
+  const src = readFileSync(SRC, 'utf8');
+
+  it('calls createSupabaseServiceClient (the symbol the script depends on)', () => {
+    expect(src).toMatch(/createSupabaseServiceClient\s*\(/);
+  });
+
+  it('has an ACTIVE (non-commented) import of createSupabaseServiceClient', () => {
+    const lines = src.split('\n');
+    const activeImport = lines.some((line) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) return false; // skip commented/JSDoc
+      return /import\s*\{[^}]*\bcreateSupabaseServiceClient\b[^}]*\}\s*from/.test(line);
+    });
+    expect(activeImport, 'createSupabaseServiceClient must be imported via an active (uncommented) import statement').toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes a crash in `npm run sd:burnrate` (documented essential command): scripts/sd-burnrate.js:17 import was commented out while line 23 used the symbol → ReferenceError. Uncomment the import + add a regression-guard test (asserts symbol is used AND actively imported).

RCA-confirmed live; fix verified (command now prints burn-rate analysis). Sub-agents PASS: TESTING, VALIDATION, REGRESSION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)