### PR TITLE
test(SD-REFILL-00WD6UBF): regression-guard the QF-creation-race grace window (stale-session-sweep)

### DIFF
--- a/tests/unit/scripts/stale-sweep-orphan-qf-not-released.test.js
+++ b/tests/unit/scripts/stale-sweep-orphan-qf-not-released.test.js
@@ -38,3 +38,32 @@ describe('QF-20260609-456: orphan classifier does not release live QF builders',
     expect(region).toMatch(/qfExistsSet\.add\(/);
   });
 });
+
+// SD-REFILL-00WD6UBF: the SECOND arm of isHeldQfClaim — the QF-CREATION-RACE grace window. A worker
+// self-claiming a freshly-created QF can have its claim read by the sweep BEFORE the QF INSERT is
+// visible/committed, so the QF id is absent from qfExistsSet. Without a grace window that claim would
+// be orphan-released with "QF-XXX not found" mid-build (witnessed QF-20260609-564/255/703/666). The
+// fix treats a QF claimed within QF_CLAIM_GRACE_SECONDS as HELD even when absent from quick_fixes.
+// These pins guard that grace arm (it was shipped but previously only the qfExistsSet arm was tested).
+describe('SD-REFILL-00WD6UBF: grace window protects a freshly-claimed (not-yet-visible) QF', () => {
+  it('isHeldQfClaim treats a recently-claimed QF (claim age < grace) as held even if absent from quick_fixes', () => {
+    expect(src).toMatch(/ageSec\s*<\s*QF_CLAIM_GRACE_SECONDS/);
+  });
+
+  it('QF_CLAIM_GRACE_SECONDS is configurable and defaults to 60s', () => {
+    expect(src).toMatch(/QF_CLAIM_GRACE_SECONDS\s*=\s*Number\(process\.env\.QF_CLAIM_GRACE_SECONDS\)\s*\|\|\s*60/);
+  });
+
+  it('claim age is derived from claude_sessions.claimed_at (the claim-age source)', () => {
+    const idx = src.indexOf('qfClaimAgeBySession');
+    expect(idx).toBeGreaterThan(0);
+    const region = src.slice(idx, idx + 800);
+    expect(region).toMatch(/claimed_at/);
+    expect(region).toMatch(/from\(['"`]claude_sessions['"`]\)/);
+  });
+
+  it('unknown claim age falls through to Infinity so a truly-absent QF is still releasable', () => {
+    // Fail-safe: a QF that does not exist AND has no known/recent claim age must NOT be held forever.
+    expect(src).toMatch(/qfClaimAgeBySession\.has\(s\.session_id\)\s*\?\s*qfClaimAgeBySession\.get\(s\.session_id\)\s*:\s*Infinity/);
+  });
+});


### PR DESCRIPTION
## Summary
The stale-session-sweep can read a worker's QF claim before the freshly-created QF's INSERT is visible, so the QF id is absent from `quick_fixes` and the claim was orphan-released `QF-XXX not found` mid-build (witnessed QF-20260609-564/255/703/666).

**Verify-the-premise:** the requested fix — a grace window treating a QF claimed <60s ago as held even when absent from `quick_fixes` — is **already shipped** in `isHeldQfClaim` (`QF_CLAIM_GRACE_SECONDS||60`; claim age from `claude_sessions.claimed_at`; unknown age → `Infinity`). Only the `qfExistsSet` arm was regression-tested; the **grace-window arm** (this SD's exact fix) was unguarded.

## Change (test-only)
Adds 4 static source-pin assertions for the grace arm to `stale-sweep-orphan-qf-not-released.test.js`:
- `ageSec < QF_CLAIM_GRACE_SECONDS` (grace arm present)
- `QF_CLAIM_GRACE_SECONDS = Number(env) || 60` (default + override)
- claim age from `claude_sessions.claimed_at`
- unknown-age → `Infinity` fail-safe (truly-absent QF stays releasable)

No sweep code change; 7/7 tests pass.

## Note
Committed with an authorized `--no-verify` override: Gate 0's SD-key regex truncated `SD-REFILL-00WD6UBF` → `SD-REFILL-00` (known gate-bug, flagged this session). All other pre-commit checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
