### PR TITLE
fix(SD-REFILL-00Z7INJF): red-merge-detector dedup across all QF statuses (window gap)

### DIFF
--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -35,6 +35,22 @@ export const DEFAULT_NOISE_FLOOR = (() => {
   return Number.isFinite(n) && n >= 0 ? n : 1;
 })();
 
+/**
+ * Does a QF description carry this exact signature? Delimiter-anchored so a sha-PREFIX cannot
+ * collide (`:abc123` must not match a QF for `:abc123def456`). A match requires the char after the
+ * signature to be end-of-string or a non-hex char (SHAs are [0-9a-f]). (SD-REFILL-00Z7INJF / RCA F2)
+ */
+function descHasSignature(desc, signature) {
+  const d = desc || '';
+  let idx = d.indexOf(signature);
+  while (idx !== -1) {
+    const after = d[idx + signature.length];
+    if (after === undefined || !/[0-9a-fA-F]/.test(after)) return true;
+    idx = d.indexOf(signature, idx + 1);
+  }
+  return false;
+}
+
 /** Median of the finite numbers in `nums` (NaN if none). Pure. */
 function median(nums) {
   const a = nums.filter(Number.isFinite).slice().sort((x, y) => x - y);
@@ -101,9 +117,13 @@ export function decide(snapshots = [], openRedMergeQfs = [], opts = {}) {
   // EVER. A QF that completed minutes ago must still suppress a re-file while the snapshot pair
   // still shows the rise. opts.dedupeQfs carries recent red-merge QFs of any status (caller bounds
   // the window); fall back to the open list when absent. (SD-REFILL-00Z7INJF)
-  const dedupeQfs = Array.isArray(opts.dedupeQfs) ? opts.dedupeQfs : openRedMergeQfs;
-  if (dedupeQfs.some((q) => (q.description || '').includes(signature))) {
-    return { action: 'noop', reason: `dedup: a QF already carries signature ${signature}` };
+  // Skip dedup on the 'unknown-sha' sentinel — its signature is degenerate, so deduping on it would
+  // wrongly suppress DISTINCT sha-less regressions (RCA f4ab2603 F5).
+  if (sha !== 'unknown-sha') {
+    const dedupeQfs = Array.isArray(opts.dedupeQfs) ? opts.dedupeQfs : openRedMergeQfs;
+    if (dedupeQfs.some((q) => descHasSignature(q.description, signature))) {
+      return { action: 'noop', reason: `dedup: a QF already carries signature ${signature}` };
+    }
   }
   if (openRedMergeQfs.length > 0) {
     // Storm guard: one open red-merge QF at a time — a flaky test flipping

--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -97,8 +97,13 @@ export function decide(snapshots = [], openRedMergeQfs = [], opts = {}) {
 
   const sha = f(snapshots[0]).commit_sha || 'unknown-sha';
   const signature = `red-merge:${DIMENSION}:${sha}`;
-  if (openRedMergeQfs.some((q) => (q.description || '').includes(signature))) {
-    return { action: 'noop', reason: `dedup: open QF already carries signature ${signature}` };
+  // Dedup across ANY QF status: an offending sha is immutable and should be flagged at most once,
+  // EVER. A QF that completed minutes ago must still suppress a re-file while the snapshot pair
+  // still shows the rise. opts.dedupeQfs carries recent red-merge QFs of any status (caller bounds
+  // the window); fall back to the open list when absent. (SD-REFILL-00Z7INJF)
+  const dedupeQfs = Array.isArray(opts.dedupeQfs) ? opts.dedupeQfs : openRedMergeQfs;
+  if (dedupeQfs.some((q) => (q.description || '').includes(signature))) {
+    return { action: 'noop', reason: `dedup: a QF already carries signature ${signature}` };
   }
   if (openRedMergeQfs.length > 0) {
     // Storm guard: one open red-merge QF at a time — a flaky test flipping
@@ -134,7 +139,17 @@ async function main() {
     .in('status', ['open', 'in_progress'])
     .ilike('title', '%red-merge%');
 
-  const verdict = decide(mainSnaps, openQfs || []);
+  // Dedup window: red-merge QFs of ANY status created in the last 48h, so a QF that completed
+  // minutes ago still suppresses a re-file for the same offending sha (SD-REFILL-00Z7INJF). The
+  // open list above remains the storm-guard input (open/in_progress only).
+  const since48h = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+  const { data: recentQfs } = await db
+    .from('quick_fixes')
+    .select('id, description, status, created_at')
+    .gte('created_at', since48h)
+    .ilike('title', '%red-merge%');
+
+  const verdict = decide(mainSnaps, openQfs || [], { dedupeQfs: recentQfs || [] });
   console.log(`[red-merge-detector] ${verdict.action}: ${verdict.reason}`);
   if (verdict.action !== 'file_qf') return;
 

--- a/tests/unit/medium-effort-hardening.test.js
+++ b/tests/unit/medium-effort-hardening.test.js
@@ -187,6 +187,26 @@ describe('FR-3: red-merge decide()', async () => {
   it('masking does NOT compound: a further rise above an elevated baseline still fires', () => {
     expect(decide([snap(130, 'higher'), snap(130), snap(118), snap(118), snap(118)], []).action).toBe('file_qf');
   });
+
+  // SD-REFILL-00Z7INJF: dedup window gap — a QF that COMPLETED minutes ago must still suppress a
+  // re-file for the same offending sha. opts.dedupeQfs carries red-merge QFs of ANY status.
+  const win = [snap(121, 'donesha'), snap(120), snap(103), snap(103), snap(102)]; // a confirmed rise
+  it('dedup matches a COMPLETED QF with the same signature (any status) => noop', () => {
+    const v = decide(win, [], { dedupeQfs: [{ id: 'QF-old', status: 'completed', description: 'red-merge:ci_test_failure_count:donesha ...' }] });
+    expect(v.action).toBe('noop');
+    expect(v.reason).toContain('dedup');
+  });
+
+  it('storm guard counts OPEN only: a completed QF for a DIFFERENT sha does not block a fresh fire', () => {
+    const v = decide(win, [], { dedupeQfs: [{ id: 'QF-x', status: 'completed', description: 'red-merge:ci_test_failure_count:othersha' }] });
+    expect(v.action).toBe('file_qf'); // different sig => no dedup; completed => no storm-guard
+  });
+
+  it('backward compatible: absent dedupeQfs falls back to the open list for dedup', () => {
+    const v = decide(win, [{ id: 'QF-open', description: 'red-merge:ci_test_failure_count:donesha' }]);
+    expect(v.action).toBe('noop');
+    expect(v.reason).toContain('dedup');
+  });
 });
 
 // ── FR-1: recordFailure routing (TS-1) ───────────────────────────────────────

--- a/tests/unit/medium-effort-hardening.test.js
+++ b/tests/unit/medium-effort-hardening.test.js
@@ -207,6 +207,22 @@ describe('FR-3: red-merge decide()', async () => {
     expect(v.action).toBe('noop');
     expect(v.reason).toContain('dedup');
   });
+
+  // RCA f4ab2603 F2: a sha-PREFIX must not collide. Candidate 'donesha' must NOT be deduped by a QF
+  // for 'doneshaEXTRA' (':donesha' is a substring of ':doneshaEXTRA' but not the same sha).
+  it('dedup is delimiter-anchored: a sha-prefix does not collide', () => {
+    const v = decide(win, [], { dedupeQfs: [{ id: 'QF-y', status: 'completed', description: 'red-merge:ci_test_failure_count:doneshaEXTRA more' }] });
+    expect(v.action).toBe('file_qf');
+  });
+
+  // RCA f4ab2603 F5: the 'unknown-sha' sentinel must never dedup (degenerate signature would
+  // suppress DISTINCT sha-less regressions). snap() with no sha -> commit_sha defaults present, so
+  // build an explicit sha-less window.
+  it('unknown-sha sentinel is never deduped', () => {
+    const noSha = (failed) => ({ findings: [{ failed_count: failed, branch: 'main' }] }); // no commit_sha
+    const v = decide([noSha(121), noSha(120), noSha(103), noSha(103)], [], { dedupeQfs: [{ id: 'QF-u', status: 'completed', description: 'red-merge:ci_test_failure_count:unknown-sha prior' }] });
+    expect(v.action).toBe('file_qf');
+  });
 });
 
 // ── FR-1: recordFailure routing (TS-1) ───────────────────────────────────────


### PR DESCRIPTION
## SD-REFILL-00Z7INJF — red-merge-detector dedup window gap

### Problem
main() dedup'd against **open** quick_fixes only, so a red-merge QF that completed minutes earlier (QF-20260611-101, sha 13fa5b152b) didn't suppress a re-file for the same offending sha — refiled as QF-20260611-977 while the snapshot pair still showed the rise.

### Fix
A sha is immutable → flag at most once, ever.
- main() also queries red-merge QFs of **any status** created within 48h, passed as `opts.dedupeQfs`
- decide() dedups the signature against `dedupeQfs` (falls back to the open list when absent)
- **storm-guard unchanged** (open/in_progress only) — a completed QF for a different sha never blocks a genuine new red merge

### RCA-driven hardening (adversarial pass on the false-negative direction)
- **F2:** `descHasSignature()` delimiter-anchors the match so a sha-**prefix** can't collide (`:abc123` no longer matches `:abc123def`)
- **F5:** never dedup on the `unknown-sha` sentinel (a degenerate signature must not suppress distinct sha-less regressions)
- Follow-ups flagged: F3 (quoted-signature) + F6 (48h window → unbounded structured key)

### Verification
34 unit tests pass; dry-run clean. TESTING PASS; adversarial RCA CONDITIONAL_PASS (both blocking-class MEDIUMs fixed). Complements SD-REFILL-00V2SADI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
