### PR TITLE
fix(SD-REFILL-000XFP8B): CLAIM_FIX rejects non-UUID session ids (defense-in-depth)

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -33,7 +33,7 @@ const { evaluateDispatchEligibility, classifyDispatchIneligibility } = require('
 // and inserts raw (it does NOT route through insertCoordinationRow), so the dispatch-side terminal
 // guard would never reach it. Call assertSdDispatchable here so the sweep also refuses to nudge a
 // worker about a terminal/non-existent SD (it fails OPEN on a transient DB error).
-const { assertSdDispatchable } = require('../lib/coordinator/dispatch.cjs');
+const { assertSdDispatchable, isFullUuid } = require('../lib/coordinator/dispatch.cjs');
 // SD-LEO-INFRA-EXPOSE-CLAIM-OWNER-001 (FR-3): single shared definition of which
 // classified session statuses count as "currently holding the SD claim" — used
 // by BOTH the available-to-claim filter and the worker-render filter below so
@@ -1672,6 +1672,41 @@ async function main() {
           .eq('claiming_session_id', s.session_id); // race guard: only clear if still the fixture
       }
       actions.push('CLAIM_FIX: released FIXTURE session ' + s.session_id.substring(0, 20) + ' (never re-assert onto ' + s.sd_key + ')');
+      continue;
+    }
+
+    // SD-REFILL-000XFP8B: defense-in-depth beyond isFixtureSession. The witnessed offender
+    // (test-claim-refuse-caller, a non-UUID test session id) IS caught by the ^test- positive
+    // marker above, but isFixtureSession is positive-markers-only — a NON-test-prefixed bad
+    // session id (a replayed/synthetic claim, a malformed worker id) slips through and would
+    // drive a CLAIM_FIX re-assert, stamping claiming_session_id with a non-worker id. A REAL
+    // fleet worker ALWAYS has a full 8-4-4-4-12 UUID session_id (SessionStart hook generates
+    // UUIDs); anything that is not a full UUID can never be a legitimate claim owner. Fail
+    // CLOSED toward "not a worker": bilaterally release the stale sd_key (mirroring the fixture
+    // path) so CLAIM_FIX never adopts a non-UUID session as the claim owner. isFullUuid is the
+    // SAME pure shape-check the coordinator uses to gate dispatch targets (dispatch.cjs SSOT).
+    if (!isFullUuid(s.session_id)) {
+      await supabase
+        .from('claude_sessions')
+        .update({
+          sd_key: null,
+          status: s.status === 'ACTIVE' ? 'idle' : 'released',
+          released_at: now.toISOString(),
+          released_reason: 'SWEEP_NON_UUID_SESSION_CLAIM_FIX',
+          worktree_path: null,
+          worktree_branch: null,
+          current_branch: null,
+        })
+        .eq('session_id', s.session_id)
+        .eq('sd_key', s.sd_key); // race guard: only clear if still pointing at this SD
+      if (sd.claiming_session_id === s.session_id) {
+        await supabase
+          .from('strategic_directives_v2')
+          .update({ claiming_session_id: null, active_session_id: null, is_working_on: false })
+          .eq('sd_key', s.sd_key)
+          .eq('claiming_session_id', s.session_id); // race guard: only clear if still this session
+      }
+      actions.push('CLAIM_FIX: released NON-UUID session ' + String(s.session_id).substring(0, 20) + ' (never re-assert onto ' + s.sd_key + ')');
       continue;
     }
 

--- a/tests/unit/scripts/sweep-claim-fix-non-uuid-guard.test.js
+++ b/tests/unit/scripts/sweep-claim-fix-non-uuid-guard.test.js
@@ -1,0 +1,60 @@
+/**
+ * SD-REFILL-000XFP8B — CLAIM_FIX must never adopt a NON-UUID session as a claim owner.
+ *
+ * Witnessed: the stale-session-sweep CLAIM_FIX path set
+ * strategic_directives_v2.claiming_session_id = 'test-claim-refuse-caller' (a non-UUID test
+ * session id) on a REAL SD. That specific id is caught by the existing isFixtureSession guard
+ * (it matches the ^test- positive marker), but isFixtureSession is positive-markers-ONLY — a
+ * non-`test-`-prefixed bad/synthetic session id would slip through and drive a CLAIM_FIX
+ * re-assert, stamping claiming_session_id with a non-worker id.
+ *
+ * Defense-in-depth: a REAL fleet worker ALWAYS has a full 8-4-4-4-12 UUID session_id
+ * (SessionStart hook generates UUIDs). The fix gates the CLAIM_FIX loop on
+ * isFullUuid(s.session_id) — anything that is not a full UUID can never be a legitimate claim
+ * owner, so the sweep bilaterally releases its stale sd_key instead of re-asserting.
+ *
+ * Static source-pins (the orphan/claim-fix logic is inline in main() — the cron entry point —
+ * matching the stale-session-sweep-claim-safety.test.js guard convention).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+const SOURCE = readFileSync(resolve(REPO_ROOT, 'scripts/stale-session-sweep.cjs'), 'utf8');
+
+describe('SD-REFILL-000XFP8B: CLAIM_FIX rejects non-UUID session ids (defense-in-depth)', () => {
+  it('isFullUuid is imported from the dispatch SSOT (same shape-check the coordinator uses)', () => {
+    // Reuse the canonical pure helper, do not re-declare a parallel regex.
+    expect(SOURCE).toMatch(/require\(\s*['"`]\.\.\/lib\/coordinator\/dispatch\.cjs['"`]\s*\)/);
+    expect(SOURCE).toMatch(/isFullUuid/);
+  });
+
+  it('the CLAIM_FIX loop short-circuits when the session id is not a full UUID', () => {
+    expect(SOURCE).toMatch(/if\s*\(\s*!isFullUuid\(s\.session_id\)\s*\)/);
+  });
+
+  it('a non-UUID session is bilaterally released (sd_key nulled) with a distinct reason', () => {
+    const idx = SOURCE.indexOf('SWEEP_NON_UUID_SESSION_CLAIM_FIX');
+    expect(idx).toBeGreaterThan(0);
+    // The guard nulls the session's stale sd_key (the bilateral release).
+    const region = SOURCE.slice(idx - 400, idx + 400);
+    expect(region).toMatch(/sd_key:\s*null/);
+  });
+
+  it('it ALSO clears the SD-side claim only when the SD still points at this session (race guard)', () => {
+    const idx = SOURCE.indexOf('SWEEP_NON_UUID_SESSION_CLAIM_FIX');
+    const region = SOURCE.slice(idx, idx + 600);
+    expect(region).toMatch(/sd\.claiming_session_id === s\.session_id/);
+    expect(region).toMatch(/claiming_session_id:\s*null,\s*active_session_id:\s*null,\s*is_working_on:\s*false/);
+  });
+
+  it('the non-UUID guard sits BEFORE the terminal / eligibility / re-assert branches', () => {
+    const uuidGuard = SOURCE.indexOf('!isFullUuid(s.session_id)');
+    const reassert = SOURCE.indexOf('CLAIM_FIX: set claiming_session_id on');
+    expect(uuidGuard).toBeGreaterThan(0);
+    expect(reassert).toBeGreaterThan(uuidGuard);
+  });
+});


### PR DESCRIPTION
## Summary
The stale-session-sweep CLAIM_FIX path re-asserts `claiming_session_id = session_id` to reconcile a broken claim. The existing `isFixtureSession` guard releases positively-marked fixtures (the witnessed offender `test-claim-refuse-caller` matches `^test-`), but it is **positive-markers-only**, so a non-`test-`-prefixed synthetic/replayed/malformed session id slips through and would stamp a real SD claim with a non-worker id.

**Defense-in-depth:** a real fleet worker always has a full 8-4-4-4-12 UUID `session_id` (SessionStart hook). The CLAIM_FIX loop now gates on `isFullUuid(session_id)` — the same pure shape-check the coordinator uses for dispatch targets (`dispatch.cjs` SSOT) — and bilaterally releases the stale `sd_key` (reason `SWEEP_NON_UUID_SESSION_CLAIM_FIX`) instead of re-asserting. The SD-side clear is race-guarded on `claiming_session_id === session_id`.

**Verify-the-premise:** the exact witnessed offender is already caught by `isFixtureSession`; this closes the broader non-UUID class.

## Changes
- `scripts/stale-session-sweep.cjs`: import `isFullUuid` from the existing `dispatch.cjs` require; add the `!isFullUuid(session_id)` bilateral-release guard before the terminal/eligibility/re-assert branches.
- `tests/unit/scripts/sweep-claim-fix-non-uuid-guard.test.js`: +5 static source-pin regression tests.

## Testing
- New guard tests: 5/5 pass
- Existing `stale-session-sweep-claim-safety.test.js`: 15/15 (no regression)
- `npm run test:smoke`: 15/15
- Module loads clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)