### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-BELT-001): belt-quality gate — reject substance-thin + already-shipped-lookalike refill candidates

### DIFF
--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -35,12 +35,14 @@ const ALLOWED_SD_TYPES = new Set([
  * Select the staged rows to promote this run: the VALID candidates (per the -A/-B SSOT), capped at limit.
  * Pure + total.
  * @param {Array<Object>} rows  staged roadmap_wave_items rows
- * @param {{limit?:number}} [opts]
+ * @param {{limit?:number, shippedTitleSet?:Set<string>}} [opts]  SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-4):
+ *        shippedTitleSet is the INJECTED normalized already-shipped-title Set; the I/O caller builds it once
+ *        per run via a bounded query, keeping this function PURE. Default empty -> lookalike axis no-ops.
  * @returns {{ batch:Array<Object>, validCount:number, total:number, limit:number, byReason:Object }}
  */
 export function selectRefillBatch(rows, opts = {}) {
   const limit = Number.isInteger(opts.limit) && opts.limit > 0 ? opts.limit : DEFAULT_REFILL_BATCH_LIMIT;
-  const report = verifyStagedCandidates(rows);
+  const report = verifyStagedCandidates(rows, { shippedTitleSet: opts.shippedTitleSet });
   return {
     batch: report.valid.slice(0, limit),
     validCount: report.validCount,

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -31,9 +31,49 @@ export const REFILL_INVALID_REASONS = Object.freeze({
   MISSING_TITLE: 'missing_title',
   MISSING_PROVENANCE: 'missing_provenance',
   TEST_FIXTURE: 'test_fixture',
+  // SD-LEO-INFRA-AUTO-REFILL-BELT-001 — belt-quality axes (run AFTER the structural axes above).
+  SUBSTANCE_THIN: 'substance_thin',
+  ALREADY_SHIPPED_LOOKALIKE: 'already_shipped_lookalike',
 });
 
 const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
+
+// SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-1): the proactive-populator truncates a long captured title to
+// 120 chars and appends a '...' ellipsis marker. Live ground truth: 173/staged-pending rows are EXACTLY
+// length 120 ending '...', and NO shorter length ends '...'. Such a title is a substance-thin SHELL — the
+// real content was cut, so the SD would carry only a fragment. Anchored on BOTH the cap AND the '...'
+// marker so a short title that legitimately ends in '...' is never falsely flagged (conservative).
+export const TITLE_TRUNCATION_CAP = 120;
+
+/**
+ * Is this title a truncation shell (substance-thin)? PURE/TOTAL.
+ * @param {string} title
+ * @returns {boolean}
+ */
+export function isSubstanceThinTitle(title) {
+  if (typeof title !== 'string') return false;
+  const t = title.trim();
+  return t.length >= TITLE_TRUNCATION_CAP && t.endsWith('...');
+}
+
+/**
+ * Normalize a title for the shipped-lookalike axis (FR-2): lowercase, strip a trailing truncation
+ * ellipsis, strip a leading "SD-KEY:" prefix if present, collapse internal whitespace, trim. EXACT
+ * normalized equality only — no fuzzy/prefix matching, so two titles match iff they are the same string
+ * modulo case/ws/ellipsis (e.g. a re-promoted truncated title vs its already-shipped truncated twin).
+ * PURE/TOTAL.
+ * @param {string} title
+ * @returns {string}
+ */
+export function normalizeTitleForCompare(title) {
+  if (typeof title !== 'string') return '';
+  return title
+    .toLowerCase()
+    .replace(/\.\.\.\s*$/, '')
+    .replace(/^\s*sd-[a-z0-9-]+:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 /**
  * Decide whether a staged roadmap_wave_items row is a VALID auto-refill candidate.
@@ -42,9 +82,13 @@ const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
  *
  * @param {{ item_disposition?:string, promoted_to_sd_key?:(string|null), title?:string,
  *           source_type?:string, source_id?:string, lane?:string }} item  a roadmap_wave_items row
+ * @param {{ shippedTitleSet?:Set<string> }} [opts]  SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-3): an OPTIONAL
+ *        injected Set of normalizeTitleForCompare() keys of already-shipped/completed SD titles. Default
+ *        empty -> the lookalike axis no-ops (backward compatible). The CALLER builds this once per <=10-row
+ *        batch via a bounded query, keeping this predicate PURE and O(1) per item.
  * @returns {{ valid:boolean, reason:(string|null) }}
  */
-export function evaluateRefillCandidate(item) {
+export function evaluateRefillCandidate(item, opts = {}) {
   if (!item || typeof item !== 'object' || Array.isArray(item)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM };
   }
@@ -71,6 +115,18 @@ export function evaluateRefillCandidate(item) {
   if (FIXTURE_TITLE_RE.test(item.title) ||
       (nonEmpty(item.source_id) && FIXTURE_KEY_RE.test(item.source_id))) {
     return { valid: false, reason: REFILL_INVALID_REASONS.TEST_FIXTURE };
+  }
+  // Belt-quality axes (SD-LEO-INFRA-AUTO-REFILL-BELT-001), run LAST so a structurally-broken row still
+  // reports its structural reason first. (1) substance: a 120-char truncation shell carries only a
+  // fragment. (2) lookalike: a title that normalizes to an already-shipped SD's title is a stale
+  // re-promotion. Both conservative — they never fire on a well-formed, novel, full-length title.
+  if (isSubstanceThinTitle(item.title)) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN };
+  }
+  const shippedTitleSet = opts && opts.shippedTitleSet;
+  if (shippedTitleSet && typeof shippedTitleSet.has === 'function' &&
+      shippedTitleSet.has(normalizeTitleForCompare(item.title))) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.ALREADY_SHIPPED_LOOKALIKE };
   }
   return { valid: true, reason: null };
 }

--- a/lib/sourcing-engine/refill-dry-run-verifier.js
+++ b/lib/sourcing-engine/refill-dry-run-verifier.js
@@ -20,19 +20,22 @@ export { REFILL_INVALID_REASONS };
  * aggregate a dry-run report. Pure + total (never throws on odd input).
  *
  * @param {Array<Object>} rows - roadmap_wave_items rows (any shape; the predicate is total)
+ * @param {{ shippedTitleSet?:Set<string> }} [opts] - SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-4): forwarded
+ *        verbatim to evaluateRefillCandidate so the belt-quality lookalike axis fires here too. Default
+ *        empty (backward compatible — the dry-run CLI and any older caller still work unchanged).
  * @returns {{
  *   total:number, validCount:number, invalidCount:number,
  *   valid:Array<Object>, invalid:Array<{item:Object, reason:string}>,
  *   byReason:Object<string,number>
  * }}
  */
-export function verifyStagedCandidates(rows) {
+export function verifyStagedCandidates(rows, opts = {}) {
   const list = Array.isArray(rows) ? rows : [];
   const valid = [];
   const invalid = [];
   const byReason = {};
   for (const r of list) {
-    const verdict = evaluateRefillCandidate(r);
+    const verdict = evaluateRefillCandidate(r, opts);
     if (verdict.valid) {
       valid.push(r);
     } else {

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -16,6 +16,7 @@
  */
 import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
 import { selectRefillBatch, promoteStagedCandidate } from '../../lib/sourcing-engine/refill-auto-promote.js';
+import { normalizeTitleForCompare } from '../../lib/sourcing-engine/refill-candidate-validity.js';
 
 async function main() {
   const args = process.argv.slice(2);
@@ -43,7 +44,20 @@ async function main() {
 
   if (error) { console.error('refill-cron: query failed:', error.message); process.exit(2); }
 
-  const sel = selectRefillBatch(rows || [], { limit });
+  // SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-4): build the already-shipped-title Set ONCE per run (one
+  // bounded query) so the lookalike belt-quality axis rejects a staged title that re-promotes a title
+  // whose SD already COMPLETED. Fail-open: a query error yields an empty Set (axis no-ops), never blocks.
+  let shippedTitleSet = new Set();
+  try {
+    const { data: shipped } = await supabase
+      .from('strategic_directives_v2')
+      .select('title')
+      .eq('status', 'completed')
+      .limit(5000);
+    shippedTitleSet = new Set((shipped || []).map((s) => normalizeTitleForCompare(s.title)).filter(Boolean));
+  } catch { /* fail-open: empty set -> lookalike axis no-ops */ }
+
+  const sel = selectRefillBatch(rows || [], { limit, shippedTitleSet });
   const results = [];
   for (const item of sel.batch) {
     // Gate 2 (write) flows through to the only writer; apply:false => dry-run no-op.

--- a/tests/unit/sourcing-engine/refill-candidate-validity.test.js
+++ b/tests/unit/sourcing-engine/refill-candidate-validity.test.js
@@ -3,7 +3,7 @@
  * Pins: the VALID staged case, every INVALID reason, lifecycle-first ordering, and totality on odd input.
  */
 import { describe, it, expect } from 'vitest';
-import { evaluateRefillCandidate, REFILL_INVALID_REASONS } from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+import { evaluateRefillCandidate, REFILL_INVALID_REASONS, isSubstanceThinTitle, normalizeTitleForCompare, TITLE_TRUNCATION_CAP } from '../../../lib/sourcing-engine/refill-candidate-validity.js';
 
 // A well-formed staged refill candidate (the 683-item live shape: pending, unpromoted, real provenance).
 const validItem = (over = {}) => ({
@@ -66,5 +66,69 @@ describe('evaluateRefillCandidate (FOUNDATION SSOT)', () => {
     expect(evaluateRefillCandidate(42)).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.MISSING_ITEM });
     // empty object: not already-promoted, item_disposition undefined -> not_staged
     expect(evaluateRefillCandidate({})).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.NOT_STAGED });
+  });
+});
+
+// SD-LEO-INFRA-AUTO-REFILL-BELT-001 — belt-quality axes (substance + already-shipped-lookalike).
+const shell = 'a'.repeat(TITLE_TRUNCATION_CAP - 3) + '...'; // exactly TITLE_TRUNCATION_CAP chars ending '...'
+
+describe('isSubstanceThinTitle (FR-1 truncation-shell)', () => {
+  it('flags a 120-char title ending "..." (the live 173/staged shell shape)', () => {
+    expect(shell.length).toBe(TITLE_TRUNCATION_CAP);
+    expect(isSubstanceThinTitle(shell)).toBe(true);
+  });
+  it('does NOT flag a full-length title without the ellipsis marker', () => {
+    expect(isSubstanceThinTitle('a'.repeat(TITLE_TRUNCATION_CAP))).toBe(false); // long but not truncated
+    expect(isSubstanceThinTitle('Harden the worktree reaper')).toBe(false);
+  });
+  it('does NOT flag a SHORT title that merely ends in "..." (cap-anchored, conservative)', () => {
+    expect(isSubstanceThinTitle('TODO: figure this out...')).toBe(false);
+  });
+  it('is total on odd input', () => {
+    expect(isSubstanceThinTitle(null)).toBe(false);
+    expect(isSubstanceThinTitle(42)).toBe(false);
+    expect(isSubstanceThinTitle(undefined)).toBe(false);
+  });
+});
+
+describe('normalizeTitleForCompare (FR-2 normalizer)', () => {
+  it('lowercases, strips a trailing ellipsis, strips a leading SD-key prefix, collapses ws', () => {
+    expect(normalizeTitleForCompare('SD-LEO-X-001:  Foo   Bar...')).toBe('foo bar');
+    expect(normalizeTitleForCompare('Foo Bar')).toBe('foo bar');
+  });
+  it('a truncated title and its un-truncated twin normalize equal', () => {
+    expect(normalizeTitleForCompare('Foo Bar Baz...')).toBe(normalizeTitleForCompare('foo bar baz'));
+  });
+  it('is total on odd input', () => {
+    expect(normalizeTitleForCompare(null)).toBe('');
+    expect(normalizeTitleForCompare(42)).toBe('');
+  });
+});
+
+describe('evaluateRefillCandidate belt-quality axes', () => {
+  it('rejects a substance-thin truncation shell (substance_thin), AFTER structural axes', () => {
+    expect(evaluateRefillCandidate(validItem({ title: shell }))).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN });
+  });
+  it('a structurally-broken row still reports its structural reason BEFORE substance', () => {
+    // not_staged wins over a substance-thin title
+    expect(evaluateRefillCandidate(validItem({ title: shell, item_disposition: 'promoted' })).reason)
+      .toBe(REFILL_INVALID_REASONS.NOT_STAGED);
+  });
+  it('rejects an already-shipped lookalike when the injected Set contains its normalized title', () => {
+    const set = new Set([normalizeTitleForCompare('Harden the worktree reaper')]);
+    expect(evaluateRefillCandidate(validItem(), { shippedTitleSet: set }))
+      .toEqual({ valid: false, reason: REFILL_INVALID_REASONS.ALREADY_SHIPPED_LOOKALIKE });
+  });
+  it('a novel title with a non-matching injected Set is still VALID (no over-block)', () => {
+    const set = new Set([normalizeTitleForCompare('Some entirely different shipped SD')]);
+    expect(evaluateRefillCandidate(validItem(), { shippedTitleSet: set })).toEqual({ valid: true, reason: null });
+  });
+  it('is backward compatible: no opts arg => lookalike axis no-ops, substance axis still applies', () => {
+    expect(evaluateRefillCandidate(validItem())).toEqual({ valid: true, reason: null });
+    expect(evaluateRefillCandidate(validItem({ title: shell }))).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN });
+  });
+  it('tolerates a malformed opts.shippedTitleSet (not a Set) without throwing', () => {
+    expect(evaluateRefillCandidate(validItem(), { shippedTitleSet: ['not', 'a', 'set'] })).toEqual({ valid: true, reason: null });
+    expect(evaluateRefillCandidate(validItem(), {})).toEqual({ valid: true, reason: null });
   });
 });


### PR DESCRIPTION
## SD-LEO-INFRA-AUTO-REFILL-BELT-001 — auto-refill belt-quality gate

Chairman-directed root fix for the auto-refill flood: the cron (`sourcing-auto-refill-cron.yml`) promotes brainstorm-corpus `roadmap_wave_items` onto the claimable belt, but the promotion predicate `evaluateRefillCandidate` only rejected empty titles / lifecycle / fixtures — so the dominant live junk (substance-thin truncation shells + stale already-shipped lookalikes) flooded through. Workers then burn full LEAD cycles verifying and declining them (9 declined in one session, ~1/10 genuinely real).

### Fix — two deterministic, conservative axes on the shared SSOT
- **`substance_thin` (FR-1):** a title at the 120-char cap ending `...` is a populator truncation **shell**. Live calibration: **173/581** staged rows are exactly len-120 ending `...`, and *no shorter length* ends `...`. Anchored on **both** the cap and the ellipsis so a short title ending `...` is never falsely flagged.
- **`already_shipped_lookalike` (FR-2):** an **injected** `Set` of normalized completed-SD titles; a candidate whose `normalizeTitleForCompare()` key is in the Set is a stale re-promotion. **Exact-normalized membership only** (no fuzzy) — O(1) per item; the caller builds the Set **once per ≤10-row batch**.

### Purity & wiring (FR-3/FR-4/FR-5)
- The shipped-Set is an **optional injected arg** (default no-op → backward compatible); `evaluateRefillCandidate` stays pure/total. Threaded through `verifyStagedCandidates → selectRefillBatch → refill-cron.mjs`, which fetches the completed-title Set once per run (bounded, **fail-open**).
- New axes run **after** the existing structural axes (a broken row still reports its structural reason first).

### Verification
- **Dogfood (live 581 staged):** would-promote drops to **9**; `substance_thin` rejects **92** — exactly the "92/96 truncated shells" the design predicted. `already_shipped_lookalike` is conservative (0 false-positives this run).
- **43 unit tests green** incl. no-over-block, ordering, backward-compat, totality, and a malformed-Set guard. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)