### PR TITLE
fix(SD-REFILL-00V80FV3): dep-resolver semantic split — deferred/cancelled deps not dependency-satisfied

### DIFF
--- a/lib/coordinator/dep-readiness.mjs
+++ b/lib/coordinator/dep-readiness.mjs
@@ -1,0 +1,37 @@
+/**
+ * Dependency-readiness predicate for the coordinator audit (SD-REFILL-00V80FV3).
+ *
+ * Semantic split: a dependency is SATISFIED only when its work is actually DELIVERED
+ * (status 'completed' or 'archived'). The lifecycle-TERMINAL set additionally includes
+ * 'deferred' and 'cancelled' — those exclude an SD from the audit's active-SD list, but a
+ * dependency in those states is NOT delivered, so a dependent blocked on it is genuinely
+ * blocked (not dep-satisfied / stale-blocked). Counting deferred/cancelled deps as satisfied
+ * mis-reported the coordinator blocked-vs-ready gauges.
+ *
+ * Pure + total: no DB/clock/fs; never throws on odd input.
+ */
+
+/** Dependency statuses that mean the depended-upon work was actually DELIVERED. */
+export const DEP_SATISFIED = ['completed', 'archived'];
+
+/**
+ * Is a single dependency satisfied (delivered)? Unknown/missing/deferred/cancelled -> false.
+ * @param {string|undefined|null} status
+ * @returns {boolean}
+ */
+export function isDepSatisfied(status) {
+  return DEP_SATISFIED.includes(status);
+}
+
+/**
+ * Is a dependent SD blocked? Blocked iff it has at least one dependency whose status is not
+ * delivered (not in DEP_SATISFIED). A dependent with no dependencies is never blocked.
+ * @param {Array<string>} depKeys     resolved SD-key dependencies of the dependent
+ * @param {Record<string,string>} statusByKey   sd_key -> status map (missing keys => unmet)
+ * @returns {boolean}
+ */
+export function isDependentBlocked(depKeys, statusByKey) {
+  if (!Array.isArray(depKeys) || depKeys.length === 0) return false;
+  const map = statusByKey && typeof statusByKey === 'object' ? statusByKey : {};
+  return depKeys.some((k) => !isDepSatisfied(map[k]));
+}

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -24,6 +24,7 @@ import { detectLoopExpiry, detectStalledLoop, detectEvaSchedulerStale } from '..
 // predicate so prose/file-path/gate-name deps don't inflate the blocked count (ESM-imports-CJS,
 // same pattern as detectors.cjs above). SSOT shared with stale-session-sweep.cjs (QF-20260525-542).
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
+import { isDependentBlocked } from '../lib/coordinator/dep-readiness.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -189,13 +190,14 @@ try {
     const { data: depRows } = await db.from('strategic_directives_v2').select('sd_key,status').in('sd_key', depKeys);
     for (const r of (depRows || [])) statusByKey[r.sd_key] = r.status;
   }
-  const isTerminal = (st) => TERMINAL.includes(st); // unknown/missing dep also counts as unmet
+  // A dep is satisfied only when DELIVERED (completed/archived); deferred/cancelled/unknown/missing
+  // count the dependent as blocked (SD-REFILL-00V80FV3 semantic split — see lib/coordinator/dep-readiness.mjs).
   let blocked = 0, ready = 0;
   for (const s of sds) {
     const deps = depOf(s);
     if (!deps.length) continue;
-    if (deps.some(k => !isTerminal(statusByKey[k]))) { blocked++; continue; }
-    ready++; // all deps terminal/satisfied
+    if (isDependentBlocked(deps, statusByKey)) { blocked++; continue; }
+    ready++; // all deps delivered (completed/archived)
     if (!s.claiming_session_id && s.updated_at && (t - new Date(s.updated_at).getTime()) >= DAY) depStale.push(s.sd_key);
   }
   depLine = blocked + ' blocked (unmet deps) | ' + ready + ' dep-satisfied | ' + depStale.length + ' stale-blocked (deps done, idle >1d)';

--- a/tests/unit/coordinator-dep-readiness.test.js
+++ b/tests/unit/coordinator-dep-readiness.test.js
@@ -1,0 +1,53 @@
+/**
+ * SD-REFILL-00V80FV3 — dep-resolver semantic split on status=deferred.
+ * coordinator-audit.mjs counted a deferred (or cancelled) dependency as satisfied because it reused
+ * the lifecycle-TERMINAL set ([completed,cancelled,archived,deferred]) for dependency-satisfaction.
+ * A deferred/cancelled dep is NOT delivered, so the dependent must count as BLOCKED, not dep-satisfied.
+ */
+import { describe, it, expect } from 'vitest';
+import { DEP_SATISFIED, isDepSatisfied, isDependentBlocked } from '../../lib/coordinator/dep-readiness.mjs';
+
+describe('isDepSatisfied (delivered-only)', () => {
+  it('treats completed/archived as satisfied', () => {
+    expect(isDepSatisfied('completed')).toBe(true);
+    expect(isDepSatisfied('archived')).toBe(true);
+  });
+  it('does NOT treat deferred or cancelled as satisfied (the bug)', () => {
+    expect(isDepSatisfied('deferred')).toBe(false);
+    expect(isDepSatisfied('cancelled')).toBe(false);
+  });
+  it('does NOT treat in-flight/unknown/missing as satisfied', () => {
+    for (const s of ['in_progress', 'draft', 'active', 'blocked', undefined, null, '']) {
+      expect(isDepSatisfied(s)).toBe(false);
+    }
+  });
+  it('DEP_SATISFIED excludes the lifecycle-only terminal states', () => {
+    expect(DEP_SATISFIED).not.toContain('deferred');
+    expect(DEP_SATISFIED).not.toContain('cancelled');
+    expect(DEP_SATISFIED).toEqual(['completed', 'archived']);
+  });
+});
+
+describe('isDependentBlocked', () => {
+  it('no dependencies -> not blocked', () => {
+    expect(isDependentBlocked([], {})).toBe(false);
+    expect(isDependentBlocked(undefined, {})).toBe(false);
+  });
+  it('all deps delivered -> not blocked', () => {
+    expect(isDependentBlocked(['A', 'B'], { A: 'completed', B: 'archived' })).toBe(false);
+  });
+  it('REGRESSION: a deferred dep blocks the dependent (was mis-counted as satisfied)', () => {
+    expect(isDependentBlocked(['A'], { A: 'deferred' })).toBe(true);
+    expect(isDependentBlocked(['A', 'B'], { A: 'completed', B: 'deferred' })).toBe(true);
+  });
+  it('a cancelled dep blocks the dependent', () => {
+    expect(isDependentBlocked(['A'], { A: 'cancelled' })).toBe(true);
+  });
+  it('an unknown/missing dep key blocks the dependent', () => {
+    expect(isDependentBlocked(['A'], {})).toBe(true);
+    expect(isDependentBlocked(['A'], { A: 'in_progress' })).toBe(true);
+  });
+  it('total on a null status map', () => {
+    expect(isDependentBlocked(['A'], null)).toBe(true);
+  });
+});


### PR DESCRIPTION
coordinator-audit.mjs's DEPENDENCY gauge reused lifecycle-TERMINAL [completed,cancelled,archived,deferred] as the dependency-satisfaction predicate, so dependents blocked on a deferred/cancelled dep were mis-counted as dep-satisfied (skewing the coordinator blocked-vs-ready gauge).

Fix: a dep is satisfied only when DELIVERED (completed/archived). Extracted a pure SSOT `lib/coordinator/dep-readiness.mjs` (DEP_SATISFIED/isDepSatisfied/isDependentBlocked) + wired it in. TERMINAL still gates the active-SD exclusion (unchanged). 10 unit tests; split is idiomatic to the repo (existing TERMINAL-vs-COMPLETED splits in eva code).

Sub-agents PASS: TESTING (mutation-verified), VALIDATION (semantic + no-regression), REGRESSION (3-file scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)