### PR TITLE
fix(SD-REFILL-00TH22DQ): derive pattern-alert SD priority from severity (stop critical inflation)

### DIFF
--- a/scripts/pattern-alert-sd-creator.js
+++ b/scripts/pattern-alert-sd-creator.js
@@ -11,7 +11,8 @@
  * - Occurrence count >= 7 AND severity = 'high'
  * - Trend = 'increasing' AND occurrence count >= 4
  *
- * Created SDs are always CRITICAL priority to ensure immediate attention.
+ * Created SDs take their priority from the pattern's actual severity
+ * (derivePatternSdPriority) — NOT a blanket 'critical' (SD-REFILL-00TH22DQ).
  *
  * Usage:
  *   node scripts/pattern-alert-sd-creator.js [--dry-run] [--threshold=N]
@@ -60,7 +61,13 @@ const CONFIG = {
 
   // SD metadata
   SD_PREFIX: 'SD-PAT-FIX',
-  SD_PRIORITY: 'critical', // Always critical to ensure immediate attention
+  // SD-REFILL-00TH22DQ (priority inflation, belt-audit 2026-06-10): the created SD
+  // priority is DERIVED from the pattern's actual severity (derivePatternSdPriority),
+  // not hardcoded. Previously every filed SD was stamped 'critical' regardless of
+  // whether it qualified via critical severity, high severity, or merely an increasing
+  // trend on a low/medium-severity pattern — so 50/50 SD-PAT-FIX-* landed at 'critical'
+  // (47 later cancelled). DEFAULT_SD_PRIORITY is only the fallback for an unknown severity.
+  DEFAULT_SD_PRIORITY: 'medium',
   SD_STATUS: 'draft', // Start as draft for review before approval
 
   // Category to team mapping for assignment suggestions
@@ -256,6 +263,26 @@ export function effectiveOccurrences(pattern) {
 }
 
 /**
+ * SD-REFILL-00TH22DQ — derive the created SD's priority from the pattern's actual
+ * severity instead of stamping every auto-filed pattern SD 'critical' (the
+ * priority-inflation belt-audit finding 2026-06-10). The three filing triggers
+ * (critical severity, high severity, increasing trend on ANY severity) collapsed
+ * to one priority before; an increasing-trend pattern at medium/low severity was
+ * the worst inflater. Map severity → SD priority 1:1 over the validated enum
+ * (critical|high|medium|low); an unknown/missing severity (trend-only qualifier)
+ * falls back to DEFAULT_SD_PRIORITY ('medium' — recurring but not asserted urgent).
+ * Pure — exported for tests.
+ */
+export function derivePatternSdPriority(pattern) {
+  const sev = String(pattern?.severity || '').toLowerCase();
+  if (sev === 'critical') return 'critical';
+  if (sev === 'high') return 'high';
+  if (sev === 'medium') return 'medium';
+  if (sev === 'low') return 'low';
+  return CONFIG.DEFAULT_SD_PRIORITY;
+}
+
+/**
  * Generate SD key
  * SD-LEO-SDKEY-001: Uses centralized SDKeyGenerator for consistent naming
  */
@@ -337,7 +364,7 @@ ${suggestedTeam}
 *Pattern first seen: ${pattern.first_seen_sd_id || 'Unknown'}*
 *Pattern last seen: ${pattern.last_seen_sd_id || 'Unknown'}*`,
     status: CONFIG.SD_STATUS,
-    priority: CONFIG.SD_PRIORITY,
+    priority: derivePatternSdPriority(pattern),
     rationale: `This pattern has occurred ${pattern.occurrence_count} times with ${pattern.severity} severity. Recurring issues indicate a systemic problem requiring root cause resolution.`,
     scope: `Resolve the root cause of recurring pattern ${pattern.pattern_id} (category: ${pattern.category}). In scope: root-cause analysis of the recorded occurrences, a permanent fix, and prevention-checklist updates. Out of scope: unrelated refactors beyond the pattern's blast radius.`,
     // SD-PAT-FIX-LEAD-PLAN-REJECTED-004 (FR-2): emit a COMPLETE SD. Before

--- a/tests/unit/pattern-alert-priority-derivation.test.js
+++ b/tests/unit/pattern-alert-priority-derivation.test.js
@@ -1,0 +1,56 @@
+/**
+ * SD-REFILL-00TH22DQ — pattern-alert-sd-creator priority inflation (belt-audit 2026-06-10).
+ *
+ * The generator filed SD-PAT-FIX-* SDs from three triggers (critical severity,
+ * high severity, OR an increasing trend on ANY severity) but stamped EVERY created
+ * SD with a hardcoded 'critical' priority. Live evidence: 50/50 SD-PAT-FIX-* SDs at
+ * 'critical' (47 later cancelled). An increasing-trend pattern at medium/low severity
+ * was the worst inflater. Fix: derive the SD priority from the pattern's actual
+ * severity (derivePatternSdPriority), 1:1 over the validated SD priority enum
+ * (critical|high|medium|low), falling back to 'medium' for an unknown/trend-only
+ * severity. These tests pin the derivation and that buildSdDataForPattern consumes it.
+ */
+import { describe, it, expect } from 'vitest';
+import { derivePatternSdPriority, buildSdDataForPattern } from '../../scripts/pattern-alert-sd-creator.js';
+
+const SD_PRIORITY_ENUM = new Set(['critical', 'high', 'medium', 'low']);
+
+describe('SD-REFILL-00TH22DQ: pattern SD priority is derived from severity, not hardcoded critical', () => {
+  it('maps each severity 1:1 to the SD priority enum', () => {
+    expect(derivePatternSdPriority({ severity: 'critical' })).toBe('critical');
+    expect(derivePatternSdPriority({ severity: 'high' })).toBe('high');
+    expect(derivePatternSdPriority({ severity: 'medium' })).toBe('medium');
+    expect(derivePatternSdPriority({ severity: 'low' })).toBe('low');
+  });
+
+  it('is case-insensitive on severity', () => {
+    expect(derivePatternSdPriority({ severity: 'CRITICAL' })).toBe('critical');
+    expect(derivePatternSdPriority({ severity: 'High' })).toBe('high');
+  });
+
+  it('falls back to medium for unknown/missing severity (trend-only qualifier)', () => {
+    expect(derivePatternSdPriority({ severity: 'unknown' })).toBe('medium');
+    expect(derivePatternSdPriority({})).toBe('medium');
+    expect(derivePatternSdPriority({ severity: null })).toBe('medium');
+    expect(derivePatternSdPriority(null)).toBe('medium');
+  });
+
+  it('NEVER inflates a non-critical pattern to critical (the regression)', () => {
+    // The exact inflation case: an increasing-trend MEDIUM pattern must not be critical.
+    expect(derivePatternSdPriority({ severity: 'medium', trend: 'increasing' })).not.toBe('critical');
+    expect(derivePatternSdPriority({ severity: 'low', trend: 'increasing' })).not.toBe('critical');
+  });
+
+  it('always returns a value the strategic_directives_v2 priority CHECK accepts', () => {
+    for (const sev of ['critical', 'high', 'medium', 'low', 'unknown', undefined, null]) {
+      expect(SD_PRIORITY_ENUM.has(derivePatternSdPriority({ severity: sev }))).toBe(true);
+    }
+  });
+
+  it('buildSdDataForPattern consumes the derived priority (not a constant)', () => {
+    const base = { pattern_id: 'P-X', issue_summary: 'demo', occurrence_count: 6, trend: 'increasing', category: 'protocol', prevention_checklist: [] };
+    expect(buildSdDataForPattern({ ...base, severity: 'medium' }, 'SD-PAT-FIX-A-001').priority).toBe('medium');
+    expect(buildSdDataForPattern({ ...base, severity: 'high' }, 'SD-PAT-FIX-B-001').priority).toBe('high');
+    expect(buildSdDataForPattern({ ...base, severity: 'critical' }, 'SD-PAT-FIX-C-001').priority).toBe('critical');
+  });
+});


### PR DESCRIPTION
## Summary
`pattern-alert-sd-creator` auto-files `SD-PAT-FIX-*` SDs from three triggers (critical sev 5+, high sev 7+, **increasing trend 4+ at ANY severity**) but stamped **every** created SD with a hardcoded `CONFIG.SD_PRIORITY='critical'` — the priority-inflation belt-audit finding (2026-06-10).

**Live evidence:** all 50 `SD-PAT-FIX-*` SDs are `priority=critical` (47 later cancelled), so nothing could be triaged relative to anything else. The increasing-trend-any-severity trigger was the worst inflater — a medium/low-severity pattern filed as critical.

## Fix
- New pure `derivePatternSdPriority(pattern)`: `critical/high/medium/low` mapped 1:1 (case-insensitive); unknown/trend-only severity → `CONFIG.DEFAULT_SD_PRIORITY` (`medium`); always within the validated `strategic_directives_v2.priority` CHECK enum.
- `buildSdDataForPattern` consumes the derived value; the `SD_PRIORITY` constant is removed.
- **Filing thresholds unchanged** — only the priority stamped on the resulting SD changes.

## Changes
- `scripts/pattern-alert-sd-creator.js`
- `tests/unit/pattern-alert-priority-derivation.test.js` (+6 assertions)

## Testing
- New derivation tests: 6/6
- Existing pattern-alert suites (`pattern-sd-completeness`, `pattern-alert-cancelled-disposition`): 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)