### PR TITLE
fix(SD-REFILL-00EAHZRZ): migration-readiness probe recognizes DROP-IF-EXISTS+CREATE as idempotent

### DIFF
--- a/scripts/check-migration-readiness.mjs
+++ b/scripts/check-migration-readiness.mjs
@@ -118,6 +118,26 @@ export function parseDeclaredObjects(sql) {
   return [...parseFunctions(sql), ...parseTriggers(sql)];
 }
 
+/**
+ * SD-REFILL-00EAHZRZ: collect objects that are idempotently dropped before (re)creation.
+ * A `DROP {TRIGGER|FUNCTION} IF EXISTS <name>` makes a following bare `CREATE` of that object
+ * idempotent — semantically equivalent to `CREATE OR REPLACE` — so the bare CREATE must NOT be
+ * flagged CONFLICTING just because the object already exists live. Keyed `${kind}:${name}` to
+ * match the lowercased name parseTriggers/parseFunctions store (function names are matched
+ * unqualified, mirroring how an unqualified DROP ... IF EXISTS resolves on the search_path).
+ * @param {string} sql
+ * @returns {Set<string>}
+ */
+export function parseDropIfExists(sql) {
+  const set = new Set();
+  const trigRe = /DROP\s+TRIGGER\s+IF\s+EXISTS\s+([a-z_][\w]*)/gi;
+  const funcRe = /DROP\s+FUNCTION\s+IF\s+EXISTS\s+(?:[a-z_][\w]*\.)?([a-z_][\w]*)/gi;
+  let m;
+  while ((m = trigRe.exec(sql)) !== null) set.add(`trigger:${m[1].toLowerCase()}`);
+  while ((m = funcRe.exec(sql)) !== null) set.add(`function:${m[1].toLowerCase()}`);
+  return set;
+}
+
 export function normalizeBody(text) {
   if (text == null) return '';
   return String(text)
@@ -173,6 +193,10 @@ export function shortDiff(a, b, lines = 6) {
 
 export async function evaluateMigration({ filePath, sql, client }) {
   const declared = parseDeclaredObjects(sql);
+  // SD-REFILL-00EAHZRZ: a `DROP ... IF EXISTS <name>` ahead of a bare CREATE of the same object
+  // makes that CREATE idempotent — treat it like CREATE OR REPLACE (status IDEMPOTENT, not CONFLICTING).
+  const droppedIfExists = parseDropIfExists(sql);
+  const isIdempotentRecreate = (obj) => droppedIfExists.has(`${obj.kind}:${obj.name}`);
   const findings = [];
   for (const obj of declared) {
     if (obj.kind === 'function') {
@@ -182,14 +206,14 @@ export async function evaluateMigration({ filePath, sql, client }) {
         continue;
       }
       if (!obj.hasOrReplace) {
-        findings.push({ ...obj, status: 'CONFLICTING' });
+        findings.push({ ...obj, status: isIdempotentRecreate(obj) ? 'IDEMPOTENT' : 'CONFLICTING' });
         continue;
       }
       findings.push({ ...obj, status: compareBodies(obj.body, live) ? 'MATCHES' : 'DIVERGED', live });
     } else if (obj.kind === 'trigger') {
       const exists = await queryLiveTrigger(client, obj.name);
       if (!exists) findings.push({ ...obj, status: 'NEW' });
-      else if (!obj.hasOrReplace) findings.push({ ...obj, status: 'CONFLICTING' });
+      else if (!obj.hasOrReplace) findings.push({ ...obj, status: isIdempotentRecreate(obj) ? 'IDEMPOTENT' : 'CONFLICTING' });
       else findings.push({ ...obj, status: 'MATCHES' });
     }
   }

--- a/tests/migration-readiness/check-migration-readiness.test.js
+++ b/tests/migration-readiness/check-migration-readiness.test.js
@@ -7,6 +7,7 @@ import {
   parseFunctions,
   parseTriggers,
   parseDeclaredObjects,
+  parseDropIfExists,
   normalizeBody,
   compareBodies,
   evaluateMigration,
@@ -45,6 +46,12 @@ $$ LANGUAGE plpgsql;
 
 const FIXTURE_TRIGGER = `
 CREATE OR REPLACE TRIGGER validate_handoff_trigger
+BEFORE INSERT ON sd_phase_handoffs
+FOR EACH ROW EXECUTE FUNCTION public.auto_validate_handoff();
+`;
+
+const FIXTURE_TRIGGER_NO_OR_REPLACE = `
+CREATE TRIGGER validate_handoff_trigger
 BEFORE INSERT ON sd_phase_handoffs
 FOR EACH ROW EXECUTE FUNCTION public.auto_validate_handoff();
 `;
@@ -127,14 +134,14 @@ describe('evaluateMigration (mocked live DB)', () => {
   });
 
   it('PASS-idempotent: live body normalizes-equals migration body → MATCHES', async () => {
-    const live = `\nBEGIN\n  -- preserve recoverable stale claims\n  IF NEW.claim_status = 'absent' AND OLD.claim_status = 'present' THEN\n    NEW.claim_status := 'recoverable_stale';\n  END IF;\n  RETURN NEW;\nEND;\n`;
+    const live = '\nBEGIN\n  -- preserve recoverable stale claims\n  IF NEW.claim_status = \'absent\' AND OLD.claim_status = \'present\' THEN\n    NEW.claim_status := \'recoverable_stale\';\n  END IF;\n  RETURN NEW;\nEND;\n';
     const client = makeMockClient({ functions: { 'public.sync_is_working_on_with_session': live }, triggers: new Set() });
     const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql: FIXTURE_FUNCTION, client });
     expect(r.findings[0].status).toBe('MATCHES');
   });
 
   it('FAIL-drift: live body differs → DIVERGED', async () => {
-    const live = `BEGIN RETURN NEW; END;`;
+    const live = 'BEGIN RETURN NEW; END;';
     const client = makeMockClient({ functions: { 'public.sync_is_working_on_with_session': live }, triggers: new Set() });
     const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql: FIXTURE_FUNCTION, client });
     expect(r.findings[0].status).toBe('DIVERGED');
@@ -144,6 +151,51 @@ describe('evaluateMigration (mocked live DB)', () => {
     const client = makeMockClient({ functions: { 'public.brand_new_fn': 'BEGIN RETURN; END;' }, triggers: new Set() });
     const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql: FIXTURE_FUNCTION_NO_OR_REPLACE, client });
     expect(r.findings[0].status).toBe('CONFLICTING');
+  });
+
+  // SD-REFILL-00EAHZRZ: DROP ... IF EXISTS + bare CREATE is idempotent (== OR REPLACE), not a conflict.
+  it('IDEMPOTENT: DROP FUNCTION IF EXISTS + bare CREATE on existing function → not CONFLICTING', async () => {
+    const sql = `DROP FUNCTION IF EXISTS public.brand_new_fn();\n${FIXTURE_FUNCTION_NO_OR_REPLACE}`;
+    const client = makeMockClient({ functions: { 'public.brand_new_fn': 'BEGIN RETURN; END;' }, triggers: new Set() });
+    const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql, client });
+    expect(r.findings[0].status).toBe('IDEMPOTENT');
+    expect(r.findings[0].status).not.toBe('CONFLICTING');
+  });
+
+  it('IDEMPOTENT: DROP TRIGGER IF EXISTS + bare CREATE on existing trigger → not CONFLICTING', async () => {
+    const sql = `DROP TRIGGER IF EXISTS validate_handoff_trigger ON sd_phase_handoffs;\n${FIXTURE_TRIGGER_NO_OR_REPLACE}`;
+    const client = makeMockClient({ functions: {}, triggers: new Set(['validate_handoff_trigger']) });
+    const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql, client });
+    expect(r.findings[0].status).toBe('IDEMPOTENT');
+  });
+
+  it('still CONFLICTING: a DROP IF EXISTS for a DIFFERENT object does not exempt the bare CREATE', async () => {
+    const sql = `DROP FUNCTION IF EXISTS public.some_other_fn();\n${FIXTURE_FUNCTION_NO_OR_REPLACE}`;
+    const client = makeMockClient({ functions: { 'public.brand_new_fn': 'BEGIN RETURN; END;' }, triggers: new Set() });
+    const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql, client });
+    expect(r.findings[0].status).toBe('CONFLICTING');
+  });
+
+  it('an IDEMPOTENT migration classifies PASS (no conflict, no drift)', async () => {
+    const sql = `DROP TRIGGER IF EXISTS validate_handoff_trigger ON sd_phase_handoffs;\n${FIXTURE_TRIGGER_NO_OR_REPLACE}`;
+    const client = makeMockClient({ functions: {}, triggers: new Set(['validate_handoff_trigger']) });
+    const r = await evaluateMigration({ filePath: 'database/migrations/x.sql', sql, client });
+    expect(r.findings.every(f => f.status !== 'CONFLICTING' && f.status !== 'DIVERGED')).toBe(true);
+  });
+});
+
+describe('parseDropIfExists (SD-REFILL-00EAHZRZ)', () => {
+  it('captures DROP TRIGGER/FUNCTION IF EXISTS (case-insensitive, schema-qualified) keyed by kind:name', () => {
+    const set = parseDropIfExists(
+      'DROP TRIGGER IF EXISTS my_trig ON t;\ndrop function if exists public.My_Fn();'
+    );
+    expect(set.has('trigger:my_trig')).toBe(true);
+    expect(set.has('function:my_fn')).toBe(true);
+  });
+
+  it('does NOT match a plain DROP without IF EXISTS, nor unrelated text', () => {
+    const set = parseDropIfExists('DROP TRIGGER my_trig ON t;\n-- npm ci note, CREATE TRIGGER foo');
+    expect(set.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## What
`check-migration-readiness.mjs` flagged `MIGRATION_READINESS_FAIL_CONFLICTING_DECLARATION` for a bare `CREATE TRIGGER/FUNCTION` on an object that already exists live — **even when** the migration used the idempotent `DROP {TRIGGER|FUNCTION} IF EXISTS` + `CREATE` pattern immediately above (witnessed on `bypass_ledger_vocab_advisory`, PR #4565). The probe only recognized `CREATE OR REPLACE` as idempotent.

## Fix (code-only, no DDL)
- New pure `parseDropIfExists(sql)` — collects objects with a preceding `DROP ... IF EXISTS`, keyed `kind:name` (case-insensitive, schema-qualified tolerated).
- `evaluateMigration` — a bare `CREATE` on an existing object that is **also** dropped-if-exists now classifies as status `IDEMPOTENT` (which `classifyOutcome` treats as PASS) instead of `CONFLICTING`. Semantically equivalent to `OR REPLACE`.
- **Guard against over-exemption:** a `DROP IF EXISTS` for a *different* object does **not** exempt the bare `CREATE` (still `CONFLICTING`) — covered by a test.
- `CREATE OR REPLACE` drift detection (`DIVERGED`/`MATCHES`) is unchanged.

> The separate apply-before-merge chicken-and-egg timing concern noted in the source report is explicitly out of scope.

## Verification
- `npx vitest run tests/migration-readiness/check-migration-readiness.test.js` → **21 pass** (+6 new: function/trigger idempotent cases, the different-object over-exemption guard, IDEMPOTENT→PASS, and `parseDropIfExists` unit cases).
- `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)