### PR TITLE
fix(QF-20260621-219): auto-refill drafts mint at LEAD + isSdInFlight treats LEAD_APPROVAL as claimable

### DIFF
--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -108,6 +108,13 @@ export function buildRefillSdPayload(item, sdKey) {
     sd_key: sdKey,
     title: String(f.title || 'Auto-refill candidate').slice(0, 200),
     status: 'draft',
+    // QF-20260621-219 (PART 1): mint at the INITIAL phase like every other new draft. The
+    // strategic_directives_v2.current_phase column DEFAULT is 'LEAD_APPROVAL', so omitting this
+    // landed every auto-refilled draft at LEAD_APPROVAL — which worker-checkin's isSdInFlight()
+    // read as "already started past LEAD" and skipped before claim_sd, leaving an eligible belt
+    // un-claimable (chairman-escalated claim-stall, manually phase-corrected by the coordinator
+    // every run). Set 'LEAD' explicitly so new drafts are self-claimable without a manual fix.
+    current_phase: 'LEAD',
     sd_type: type, // concrete (never null): explicit type override 23502s the NOT-NULL default 'feature'
     category, // NOT NULL, no default; aligns with sd_type per createSD convention
     priority: 'medium', // NOT NULL, no default; valid per priority_check (critical|high|medium|low)

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -584,13 +584,19 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
  */
 async function isSdInFlight(sb, sdKey, mySessionId) {
   try {
-    // (a) already started past the initial LEAD draft
+    // (a) already started past the initial draft
     const { data: sd } = await sb
       .from('strategic_directives_v2')
       .select('current_phase')
       .eq('sd_key', sdKey)
       .maybeSingle();
-    if (sd && sd.current_phase && sd.current_phase !== 'LEAD') return true;
+    // QF-20260621-219 (PART 2): LEAD_APPROVAL is an INITIAL (claimable) phase too, not in-flight.
+    // The current_phase column DEFAULT is 'LEAD_APPROVAL', so a brand-new never-touched
+    // auto-refilled draft sits at LEAD_APPROVAL and was wrongly skipped here BEFORE claim_sd — the
+    // eligible belt looked full but 0% claimable (chairman-escalated claim-stall). Phase only
+    // advances past these on an ACCEPTED handoff, so LEAD and LEAD_APPROVAL are equivalent
+    // un-started states for claimability.
+    if (sd && sd.current_phase && sd.current_phase !== 'LEAD' && sd.current_phase !== 'LEAD_APPROVAL') return true;
     // (b) a live foreign session already holds it
     const { data: live } = await sb
       .from('v_active_sessions')

--- a/tests/unit/sourcing-engine/refill-auto-promote.test.js
+++ b/tests/unit/sourcing-engine/refill-auto-promote.test.js
@@ -115,6 +115,15 @@ describe('buildRefillSdKey / buildRefillSdPayload (pure)', () => {
     expect(good.category).toBe('Security');
   });
 
+  it('QF-20260621-219: mints the draft at the INITIAL phase LEAD (not the LEAD_APPROVAL column default)', () => {
+    // The current_phase column DEFAULT is 'LEAD_APPROVAL'; omitting it landed every auto-refilled
+    // draft there, which worker-checkin's isSdInFlight read as "already started" → un-claimable belt
+    // (chairman-escalated claim-stall). The payload must set current_phase explicitly to 'LEAD'.
+    const p = buildRefillSdPayload(validRow(), 'SD-REFILL-PHASE');
+    expect(p.current_phase).toBe('LEAD');
+    expect(p.current_phase).not.toBe('LEAD_APPROVAL');
+  });
+
   it('falls back to a traceable title for an empty title and caps length', () => {
     // The canonical deriver yields a traceable default ("Roadmap item <id>") for an empty title —
     // non-empty + identifiable, better than a generic constant.

--- a/tests/unit/worker-checkin-insdinflight-lead-approval.test.js
+++ b/tests/unit/worker-checkin-insdinflight-lead-approval.test.js
@@ -1,0 +1,60 @@
+// QF-20260621-219 (PART 2): isSdInFlight must treat LEAD_APPROVAL as an INITIAL (claimable) phase,
+// not "already started". The strategic_directives_v2.current_phase column DEFAULT is 'LEAD_APPROVAL',
+// so a brand-new never-touched auto-refilled draft sits at LEAD_APPROVAL; before this fix isSdInFlight
+// returned true for it (phase !== 'LEAD') and the worker skipped it BEFORE claim_sd, leaving an
+// eligible belt 0% claimable (the chairman-escalated claim-stall). Both LEAD and LEAD_APPROVAL are
+// un-started states (phase only advances on an ACCEPTED handoff).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { isSdInFlight } = require('../../scripts/worker-checkin.cjs');
+
+// Stub: query 1 is from('strategic_directives_v2')...maybeSingle(); query 2 is
+// from('v_active_sessions')...limit(). Route by table name.
+function stub({ phase = null, liveSessions = [] } = {}) {
+  return {
+    from(table) {
+      if (table === 'v_active_sessions') {
+        const chain = {
+          select() { return chain; },
+          eq() { return chain; },
+          neq() { return chain; },
+          limit() { return Promise.resolve({ data: liveSessions, error: null }); },
+        };
+        return chain;
+      }
+      // strategic_directives_v2
+      const chain = {
+        select() { return chain; },
+        eq() { return chain; },
+        maybeSingle() { return Promise.resolve({ data: phase === undefined ? null : { current_phase: phase }, error: null }); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('QF-20260621-219: isSdInFlight treats LEAD_APPROVAL as claimable (not in-flight)', () => {
+  it('returns FALSE for a LEAD draft (the canonical initial phase)', async () => {
+    expect(await isSdInFlight(stub({ phase: 'LEAD' }), 'SD-REFILL-X', 'me')).toBe(false);
+  });
+
+  it('returns FALSE for a LEAD_APPROVAL draft (the column-default initial phase — the fix)', async () => {
+    expect(await isSdInFlight(stub({ phase: 'LEAD_APPROVAL' }), 'SD-REFILL-X', 'me')).toBe(false);
+  });
+
+  it('returns TRUE for a genuinely-started SD (phase advanced past the initial draft)', async () => {
+    expect(await isSdInFlight(stub({ phase: 'PLAN_PRD' }), 'SD-REFILL-X', 'me')).toBe(true);
+    expect(await isSdInFlight(stub({ phase: 'EXEC' }), 'SD-REFILL-X', 'me')).toBe(true);
+  });
+
+  it('returns TRUE when a LIVE foreign session holds it, even at LEAD_APPROVAL', async () => {
+    expect(await isSdInFlight(stub({ phase: 'LEAD_APPROVAL', liveSessions: [{ session_id: 'other' }] }), 'SD-REFILL-X', 'me')).toBe(true);
+  });
+
+  it('fails OPEN (returns false) so a guard error never blocks self_claim', async () => {
+    const throwing = { from() { throw new Error('db down'); } };
+    expect(await isSdInFlight(throwing, 'SD-REFILL-X', 'me')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
DURABLE 2-part fix for the chairman-escalated **claim-stall** (Adam-root-caused 2026-06-21; the coordinator manually phase-corrected `LEAD_APPROVAL`→`LEAD` every auto-refill run).

`strategic_directives_v2.current_phase` column **DEFAULT is `'LEAD_APPROVAL'`**, so auto-refilled drafts landed there, and `worker-checkin`'s `isSdInFlight()` read any phase `!= 'LEAD'` as "already started" → skipped the SD **before** `claim_sd` → an eligible belt was **0% claimable** despite N claimable `SD-REFILL-*` drafts.

## Parts
- **PART 1** — `lib/sourcing-engine/refill-auto-promote.js` `buildRefillSdPayload` now sets `current_phase: 'LEAD'` explicitly (the initial phase like every other new draft), instead of inheriting the `LEAD_APPROVAL` column default.
- **PART 2** — `scripts/worker-checkin.cjs` `isSdInFlight()` now treats **both** `'LEAD'` and `'LEAD_APPROVAL'` as un-started/claimable initial phases (phase only advances on an ACCEPTED handoff), so the 13 existing `LEAD_APPROVAL` drafts (and any other path hitting the column default) are claimable without a manual correction.

Retires the manual stop-gap (Adam feedback e5c10dd8).

## Testing
- +1 PART-1 test (payload mints at LEAD), +5 PART-2 `isSdInFlight` tests (LEAD/LEAD_APPROVAL claimable, started→in-flight, live-foreign-hold→in-flight, fail-open)
- Existing refill-auto-promote suite green — **21 tests total**

🤖 Generated with [Claude Code](https://claude.com/claude-code)