### PR TITLE
fix(SD-REFILL-00OFH2SF): skip informational/skipped findings in FR-C remediation-SD generator

### DIFF
--- a/lib/eva/quality-findings/sd-generator.js
+++ b/lib/eva/quality-findings/sd-generator.js
@@ -316,6 +316,26 @@ export function isLikelyTestFixture(row) {
   return typeof sig === 'string' && sig.startsWith(FIXTURE_SIG_PREFIX);
 }
 
+// SD-REFILL-00OFH2SF: a finding can carry a remediation-qualifying severity yet be purely
+// INFORMATIONAL — a check that was SKIPPED because the tool isn't available has nothing to
+// remediate, but the generator filed a full-LEAD remediation SD for it anyway (SD-LEO-FIX-
+// REMEDIATION-NPM-AUDIT-002 + LINT-MEDIUM-002, both cancelled). The skip is recorded in the
+// finding's evidence_pointer.legacy_detail/legacy_title, NOT in severity.
+const INFORMATIONAL_FINDING_RE = /not a vulnerability finding|\bskipped\b|\bnot available\b/i;
+/**
+ * True when a finding is an informational/skipped check (nothing to remediate). Total — a
+ * missing/odd evidence_pointer is NOT informational (fail-safe: never over-exclude a real finding).
+ * Conservative by design: real vulnerability findings never carry these markers.
+ * @param {{evidence_pointer?: {legacy_detail?: string, legacy_title?: string}}} row
+ * @returns {boolean}
+ */
+export function isInformationalSkippedFinding(row) {
+  const ep = row && row.evidence_pointer;
+  if (!ep || typeof ep !== 'object') return false;
+  const text = `${ep.legacy_detail || ''}\n${ep.legacy_title || ''}`;
+  return INFORMATIONAL_FINDING_RE.test(text);
+}
+
 /**
  * Select pending FAIL/WARN-equivalent findings, optionally scoped to one venture.
  *
@@ -342,6 +362,13 @@ export async function selectPendingFindings(supabase, ventureId = null) {
         finding_id: r.id, venture_id: r.venture_id, sig: r.evidence_pointer?.sig ?? null,
         finding_category: r.finding_category, severity: r.severity,
       }, { entityId: r.id, severity: 'warning' });
+    } else if (isInformationalSkippedFinding(r)) {
+      // SD-REFILL-00OFH2SF: skipped/unavailable check — nothing to remediate, do not file an SD.
+      await writeAuditLog(supabase, 'informational_skipped', {
+        finding_id: r.id, venture_id: r.venture_id,
+        finding_category: r.finding_category, severity: r.severity,
+        legacy_detail: r.evidence_pointer?.legacy_detail ?? null,
+      }, { entityId: r.id, severity: 'info' });
     } else out.push(r);
   }
   return out;

--- a/lib/eva/quality-findings/sd-generator.js
+++ b/lib/eva/quality-findings/sd-generator.js
@@ -321,7 +321,15 @@ export function isLikelyTestFixture(row) {
 // remediate, but the generator filed a full-LEAD remediation SD for it anyway (SD-LEO-FIX-
 // REMEDIATION-NPM-AUDIT-002 + LINT-MEDIUM-002, both cancelled). The skip is recorded in the
 // finding's evidence_pointer.legacy_detail/legacy_title, NOT in severity.
-const INFORMATIONAL_FINDING_RE = /not a vulnerability finding|\bskipped\b|\bnot available\b/i;
+// Anchored to CHECK-DIDN'T-RUN phrasings, NOT bare 'skipped'/'not available' (RCA b62ba6b5):
+//   • bare \bskipped\b over-excludes real findings ("test skipped due to flake — must re-enable",
+//     "can be skipped via config but the secret is real"),
+//   • bare 'not available' over-excludes ("widget not available in production", "no patch available yet").
+// These patterns match only the tool/check-couldn't-run intent the finding producers actually emit
+// (bun: "audit not available for bun"; lint: "could not run … deps unavailable"), closing both the
+// F1 over-exclusion and the F2 under-exclusion (the lint "could not run / deps unavailable" skip the
+// first cut missed and which was still filing SDs).
+const INFORMATIONAL_FINDING_RE = /not a vulnerability finding|could not run|not available for\b|deps?\s+(?:were\s+)?unavailable\b/i;
 /**
  * True when a finding is an informational/skipped check (nothing to remediate). Total — a
  * missing/odd evidence_pointer is NOT informational (fail-safe: never over-exclude a real finding).

--- a/tests/unit/eva/quality-findings/sd-generator.test.js
+++ b/tests/unit/eva/quality-findings/sd-generator.test.js
@@ -11,6 +11,7 @@ import {
   buildCreateSdArgs,
   generateRemediationSD,
   generateBatch,
+  isInformationalSkippedFinding,
 } from '../../../../lib/eva/quality-findings/sd-generator.js';
 import { computeFindingHash, FINDING_CATEGORIES } from '../../../../lib/eva/quality-findings/finding-shape.js';
 
@@ -192,5 +193,36 @@ describe('generateBatch', () => {
     expect(r.created).toEqual([]);
     expect(r.skipped).toEqual([]);
     expect(r.errors).toEqual([]);
+  });
+});
+
+describe('isInformationalSkippedFinding (SD-REFILL-00OFH2SF)', () => {
+  it('excludes a SKIPPED check (the real bun-audit case)', () => {
+    const f = validFinding({ finding_category: 'npm_audit', severity: 'medium', evidence_pointer: {
+      legacy_check: 'npm_audit',
+      legacy_title: 'Dependency audit not available for bun',
+      legacy_detail: 'bun has no first-class audit command; skipped (not a vulnerability finding).',
+    } });
+    expect(isInformationalSkippedFinding(f)).toBe(true);
+  });
+
+  it('matches the "not available" marker in legacy_title alone', () => {
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_title: 'Dependency audit not available for bun' } })).toBe(true);
+  });
+
+  it('KEEPS a real medium vulnerability finding (no informational markers)', () => {
+    const real = validFinding({ finding_category: 'npm_audit', severity: 'medium', evidence_pointer: {
+      legacy_title: 'Vulnerable dependency: lodash <4.17.21',
+      legacy_detail: 'Prototype pollution in lodash; upgrade to 4.17.21.',
+    } });
+    expect(isInformationalSkippedFinding(real)).toBe(false);
+  });
+
+  it('is total / fail-safe: missing or odd evidence_pointer is NOT informational (never over-excludes)', () => {
+    expect(isInformationalSkippedFinding({})).toBe(false);
+    expect(isInformationalSkippedFinding({ evidence_pointer: null })).toBe(false);
+    expect(isInformationalSkippedFinding({ evidence_pointer: 'str' })).toBe(false);
+    expect(isInformationalSkippedFinding(null)).toBe(false);
+    expect(isInformationalSkippedFinding({ evidence_pointer: { file: 'src/foo.js' } })).toBe(false);
   });
 });

--- a/tests/unit/eva/quality-findings/sd-generator.test.js
+++ b/tests/unit/eva/quality-findings/sd-generator.test.js
@@ -225,4 +225,20 @@ describe('isInformationalSkippedFinding (SD-REFILL-00OFH2SF)', () => {
     expect(isInformationalSkippedFinding(null)).toBe(false);
     expect(isInformationalSkippedFinding({ evidence_pointer: { file: 'src/foo.js' } })).toBe(false);
   });
+
+  // RCA b62ba6b5 F2 (under-exclusion, live): the lint "could not run / deps unavailable" skip the
+  // first regex MISSED (it was still filing SDs) must now be excluded.
+  it('excludes the lint "could not run / deps unavailable" skip', () => {
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_title: 'Lint could not run (eslint/deps unavailable)' } })).toBe(true);
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_detail: 'eslint or its deps were unavailable.' } })).toBe(true);
+  });
+
+  // RCA b62ba6b5 F1 (over-exclusion): real findings that merely MENTION skipped/not-available must
+  // be KEPT — the predicate anchors on check-didn't-run phrasings, not bare tokens.
+  it('KEEPS real findings that merely mention skipped/not-available', () => {
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_detail: 'No upstream patch is not available yet; pin the version.' } })).toBe(false);
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_detail: 'This gitleaks rule can be skipped via config but the secret is real.' } })).toBe(false);
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_detail: 'Payment flow test was skipped due to flake — must re-enable.' } })).toBe(false);
+    expect(isInformationalSkippedFinding({ evidence_pointer: { legacy_title: 'The widget is not available in production builds.' } })).toBe(false);
+  });
 });


### PR DESCRIPTION
## SD-REFILL-00OFH2SF — skip informational/skipped findings in the FR-C remediation-SD generator

### Problem
`lib/eva/quality-findings/sd-generator.js` `selectPendingFindings()` filtered by severity + test-fixture only. A check that was **skipped** (tool unavailable) is recorded at a qualifying severity but has nothing to remediate — so the generator auto-filed a pointless remediation SD that burns a full LEAD cycle (SD-LEO-FIX-REMEDIATION-NPM-AUDIT-002 + LINT-MEDIUM-002, both cancelled).

### Fix
Pure `isInformationalSkippedFinding()` predicate over `evidence_pointer.legacy_detail`/`legacy_title`, wired into `selectPendingFindings` as an exclusion with an `informational_skipped` audit_log note (mirrors the existing `test_fixture_skipped` path). Total/fail-safe: a missing/odd evidence_pointer is never over-excluded.

### Adversarial-RCA hardening (false-negative + over-exclusion pass)
The predicate is anchored to **check-didn't-run** phrasings — `/not a vulnerability finding|could not run|not available for|deps unavailable/i` — NOT bare `skipped`/`not available`. This:
- **closes over-exclusion (F1):** real findings that merely mention skipped/not-available are KEPT ('test skipped due to flake — must re-enable', 'widget not available in production', 'no patch available yet')
- **closes under-exclusion (F2):** a live lint skip phrased 'could not run / deps unavailable' (which the first cut missed and was still filing SDs) is now excluded

### Verification
26 unit tests pass; live corpus checked. TESTING PASS; adversarial RCA CONDITIONAL_PASS (both blocking MEDIUMs closed). Follow-ups flagged: excluded findings stay `pending` → audit churn (mirrors existing test_fixture pattern); structured producer skip-flag instead of free-text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
