### PR TITLE
fix(QF-20260621-393): Gate-0 SD-key extraction accepts alnum-terminal SD-REFILL keys

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -683,7 +683,15 @@ fi
 # (leo-create-sd --child emits -B/-C/...). Without it the key truncates to the
 # PARENT orchestrator (often legitimately draft while children run), falsely
 # blocking every child commit with "SD is in DRAFT status".
-SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z0-9]+(-[A-Z0-9]+)*-[0-9]+(-[A-Z])?' | head -1)
+# QF-20260621-393: the old pattern's MANDATORY trailing '-[0-9]+' segment truncated
+# alnum-terminal keys (auto-refill mints SD-REFILL-<8 alnum>, NO trailing -digits):
+# SD-REFILL-00XUUGXQ -> 'SD-REFILL-00' (the '-00' satisfied '-[0-9]+', alnum tail dropped)
+# -> validate-sd-commit.js can't find the truncated key -> false 'not found' -> the WHOLE
+# SD-REFILL belt was forced onto LEO_ALLOW_NO_VERIFY on every commit. Accept SD- followed by
+# >=2 dash-separated alnum segments (greedy -> captures the whole key, digit-terminal OR
+# alnum-terminal, incl. the -B child suffix as a segment). grep -oE is case-sensitive so
+# lowercase prose ('SD-based-thing') never matches; a real key always has >=2 segments.
+SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z0-9]+(-[A-Z0-9]+)+' | head -1)
 
 if [ ! -z "$SD_ID" ]; then
   echo "   Found SD reference: $SD_ID"

--- a/tests/unit/gate0-sd-key-extraction.test.js
+++ b/tests/unit/gate0-sd-key-extraction.test.js
@@ -1,0 +1,69 @@
+/**
+ * QF-20260621-393 (chairman flag #6, flag_review:63843f8e): the Gate-0 pre-commit
+ * SD-key EXTRACTION (.husky/pre-commit "SD_ID=$(... grep -oE ...)") must capture
+ * alnum-terminal keys WHOLE. Auto-refill mints SD-REFILL-<8 alnum> (no trailing
+ * -digits); the old pattern's mandatory '-[0-9]+' segment truncated them
+ * (SD-REFILL-00XUUGXQ -> 'SD-REFILL-00'), so validate-sd-commit.js couldn't find
+ * the key -> false 'not found' -> the WHOLE SD-REFILL belt was forced onto
+ * LEO_ALLOW_NO_VERIFY on every commit.
+ *
+ * This test reads the LIVE regex out of .husky/pre-commit (so a revert fails it)
+ * and pins that BOTH a digit-terminal key and an alnum-terminal key extract whole,
+ * while lowercase prose and a single-segment "SD-FOO" do not over-match. The ERE
+ * pattern grep uses is also a valid JS RegExp, so we exercise the exact shipped string.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const HOOK = readFileSync(resolve(process.cwd(), '.husky/pre-commit'), 'utf8');
+
+// Pull the regex literal out of the `SD_ID=$(... grep -oE '<REGEX>' ...)` extraction line.
+function extractHookRegex() {
+  const line = HOOK.split('\n').find(l => l.includes('SD_ID=') && l.includes('grep -oE'));
+  expect(line, 'SD_ID extraction line with grep -oE not found in .husky/pre-commit').toBeTruthy();
+  const m = line.match(/grep -oE '([^']+)'/);
+  expect(m, 'could not parse the grep -oE regex literal').toBeTruthy();
+  return m[1];
+}
+
+// Mirror `grep -oE | head -1`: first (leftmost-longest-ish) match. JS RegExp without
+// the longest-match guarantee is fine here since our pattern is greedy and anchored on SD-.
+function firstMatch(input, ere) {
+  const re = new RegExp(ere, 'g'); // ERE pattern is JS-compatible
+  const m = re.exec(input);
+  return m ? m[0] : null;
+}
+
+describe('QF-20260621-393: Gate-0 SD-key extraction captures alnum-terminal keys whole', () => {
+  const ere = extractHookRegex();
+
+  it('extracts an alnum-terminal SD-REFILL key WHOLE (the regression)', () => {
+    expect(firstMatch('SD-REFILL-00XUUGXQ', ere)).toBe('SD-REFILL-00XUUGXQ');
+    expect(firstMatch('SD-REFILL-007PVF5E', ere)).toBe('SD-REFILL-007PVF5E');
+    expect(firstMatch('SD-REFILL-00ED3P4B', ere)).toBe('SD-REFILL-00ED3P4B');
+  });
+
+  it('still extracts a digit-terminal key whole (no regression for the existing family)', () => {
+    expect(firstMatch('SD-LEO-FEAT-CLAIM-PATH-RESPECTED-001', ere)).toBe('SD-LEO-FEAT-CLAIM-PATH-RESPECTED-001');
+    expect(firstMatch('SD-FEATURE-001', ere)).toBe('SD-FEATURE-001');
+  });
+
+  it('still captures the -B child suffix whole', () => {
+    expect(firstMatch('SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B', ere)).toBe('SD-LEO-ORCH-ADAM-PLAN-KEEPER-001-B');
+  });
+
+  it('extracts a key embedded in a branch name', () => {
+    expect(firstMatch('feat/SD-REFILL-00TH22DQ', ere)).toBe('SD-REFILL-00TH22DQ');
+  });
+
+  it('does NOT over-match lowercase prose or a bare single-segment SD-FOO', () => {
+    expect(firstMatch('fixing the SD-based approach here', ere)).toBe(null);
+    expect(firstMatch('SD-REFILL needs work', ere)).toBe(null); // single segment after SD- -> not a key
+  });
+
+  it('the mandatory trailing -[0-9]+ truncator is gone from the extraction pattern', () => {
+    // Guard against a revert to the old `...-[0-9]+(-[A-Z])?` shape that truncated alnum keys.
+    expect(ere.endsWith('-[0-9]+(-[A-Z])?')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Chairman-flagged (#6, flag_review:63843f8e). The `.husky/pre-commit` SD-key extraction (`SD_ID=$(... grep -oE ...)`) used `SD-[A-Z0-9]+(-[A-Z0-9]+)*-[0-9]+(-[A-Z])?`. The **mandatory trailing `-[0-9]+`** segment truncated alnum-terminal keys minted by auto-refill (`SD-REFILL` + 8 alphanumerics, no trailing `-digits`): `SD-REFILL-00XUUGXQ` matched only `SD-REFILL-00`. `validate-sd-commit.js` couldn't find the truncated key → false "not found" → the **whole `SD-REFILL` belt was forced onto `LEO_ALLOW_NO_VERIFY` on every commit**.

## Fix
Accept `SD-[A-Z0-9]+(-[A-Z0-9]+)+` — `SD-` + ≥2 dash-separated alnum segments, greedy so it captures the whole key (digit-terminal **or** alnum-terminal, incl. the `-B` child suffix as a segment). `grep -oE` is case-sensitive so lowercase prose never matches; a real key always has ≥2 segments.

The L631 branch-**presence** check is intentionally untouched (it matched via `-00` and is not the operative defect; the distinct QF-20260524-250 widened only the first segment).

## Verification (end-to-end)
- `SD-REFILL-00XUUGXQ` now extracts whole and `validate-sd-commit.js` resolves it → Gate 0 passes
- the old truncated `SD-REFILL-00` still gives the false "not found" (proves the bug class)
- +6 source-pinned regression tests that read the **live** hook regex (fail on revert)

## Changes
- `.husky/pre-commit` (extraction regex + comment)
- `tests/unit/gate0-sd-key-extraction.test.js` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)