### PR TITLE
feat(SD-LEO-INFRA-REGISTER-TWO-EVERY-001): register two every-3-day propose-only Adam duties (doc-drift + github-assessment)

### DIFF
--- a/.claude/commands/adam.md
+++ b/.claude/commands/adam.md
@@ -56,17 +56,19 @@ This tags the current session in `claude_sessions.metadata` with `role=adam` and
 node scripts/adam-startup-check.mjs
 ```
 
-`CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Adam's tick is **five loops**, silence-by-default + propose-only (CONST-002):
+`CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Adam's tick is **seven loops**, silence-by-default + propose-only (CONST-002):
 1. **governance-scan** (daily) — the read-only opportunity-scan (`node scripts/adam-opportunity-scan.cjs --scan --scope auto`); runs only when `ADAM_GOVERNANCE_HEARTBEAT_V1=on` (else it prints `SUPPRESSED_FLAG_OFF`).
 2. **inbox-monitor** (every 15 min) — drain ALL coordinator-directed kinds, replies + directives (`node scripts/adam-advisory.cjs inbox`).
 3. **offer-help** (every 2 h) — an agent-judgment tick: offer the coordinator concise analysis when it helps, else stay silent.
 4. **self-adherence** (every 6 h) — Adam audits its OWN role-contract adherence (`node scripts/adam-self-adherence-review.mjs`): probes → `adam_adherence_ledger` → propose-only remediation for the coordinator on drift (never builds — CONST-002). SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001.
 5. **belt-countdown** (every 15 min) — an agent-judgment tick: while the fleet is active, post ONE belt-countdown line (ET 12-hour, rolling ETA to belt-dry from DB rows via `node scripts/fleet-dashboard.cjs`); stay silent when the fleet is idle. The contract-named BELT COUNTDOWN DUTY (durable) — previously session-scoped and died every Adam session. SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001.
+6. **doc-drift** (every 3 days) — propose-only doc-drift review (`node scripts/adam-doc-drift-review.mjs`): reads only the SDs/QFs completed in the trailing 3 days, maps each by sd_type to likely doc dirs, clusters, and surfaces ONE doc-update proposal (feedback `adam_doc_drift`). Edits no docs (CONST-002). Ships INERT behind `ADAM_DOC_DRIFT_V1`. SD-LEO-INFRA-REGISTER-TWO-EVERY-001.
+7. **github-assessment** (every 3 days) — read-only GitHub-health assessment (`node scripts/adam-github-assessment.mjs`): aggregates CI red / failed runs / PR hygiene / merge conflicts / open dependabot+code-scanning alerts into ONE ranked advisory; silent when clean. Ships INERT behind `ADAM_GH_ASSESS_V1`. SD-LEO-INFRA-REGISTER-TWO-EVERY-001.
 
-**Arm them via `CronCreate` — IDEMPOTENTLY.** Run `CronList`, map each existing cron to its loop KEY (`governance-scan` | `inbox-monitor` | `offer-help` | `self-adherence` | `belt-countdown` — keys are the canonical comma-free tokens; prompts can contain commas and won't survive the CSV split), then re-invoke with the armed keys for an `armed|MISSING` verdict, and arm ONLY the missing loops:
+**Arm them via `CronCreate` — IDEMPOTENTLY.** Run `CronList`, map each existing cron to its loop KEY (`governance-scan` | `inbox-monitor` | `offer-help` | `self-adherence` | `belt-countdown` | `doc-drift` | `github-assessment` — keys are the canonical comma-free tokens; prompts can contain commas and won't survive the CSV split), then re-invoke with the armed keys for an `armed|MISSING` verdict, and arm ONLY the missing loops:
 
 ```bash
-node scripts/adam-startup-check.mjs --armed "governance-scan,inbox-monitor,offer-help,self-adherence,belt-countdown"
+node scripts/adam-startup-check.mjs --armed "governance-scan,inbox-monitor,offer-help,self-adherence,belt-countdown,doc-drift,github-assessment"
 ```
 
 For each `❌ MISSING` loop, call the emitted `CronCreate({ cron, prompt, recurring: true })`. Skip any already in `CronList` (including any interim hand-armed cron) — this is the durable replacement for hand-arming Adam's tick.
@@ -89,4 +91,4 @@ Adam is a **singleton role-session** — the Adam analogue of the coordinator si
 
 ## Result
 
-After `/adam`: the role contract has been read in full and **verified** (`contract_read: true` in the register output), the session is tagged `role=adam`/`non_fleet=true` (idempotent), the coordination protocol is established, and Adam's recurring tick (governance-scan + inbox-monitor + offer-help + self-adherence + belt-countdown) is armed. Adam is now active as an advisory/analysis session, invisible to fleet accounting.
+After `/adam`: the role contract has been read in full and **verified** (`contract_read: true` in the register output), the session is tagged `role=adam`/`non_fleet=true` (idempotent), the coordination protocol is established, and Adam's recurring tick (governance-scan + inbox-monitor + offer-help + self-adherence + belt-countdown + doc-drift + github-assessment) is armed. Adam is now active as an advisory/analysis session, invisible to fleet accounting.

--- a/.github/workflows/adam-doc-drift-cron.yml
+++ b/.github/workflows/adam-doc-drift-cron.yml
@@ -1,0 +1,56 @@
+name: "Adam doc-drift review (cron)"
+
+# SD: SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 1)
+#
+# Durable, server-side every-3-day Adam doc-drift review — mirrors adam-opportunity-scan-cron.yml.
+# Runs the read-only / propose-only scripts/adam-doc-drift-review.mjs, which reads only the SDs/QFs
+# COMPLETED in the trailing 3 days, maps them by sd_type to likely doc dirs, clusters, and surfaces ONE
+# propose-only feedback flag (category adam_doc_drift). CONST-002: it edits no docs.
+#
+# SHIPS INERT: the job is gated on the repo variable ADAM_DOC_DRIFT_V1 (default unset = OFF) — the
+# scheduled run is a no-op skip until the operator sets ADAM_DOC_DRIFT_V1='true'. Fail-soft (`|| true`).
+
+on:
+  schedule:
+    # Every 3rd day-of-month at 09:00 UTC (roughly every 3 days; resets at month boundaries — acceptable
+    # per scope). Offset from the github-assessment tick (:30) to spread fleet cron load.
+    - cron: '0 9 */3 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  adam-doc-drift:
+    name: Adam doc-drift review
+    # Inert until the operator flips the repo var. Unset/anything-but-'true' => job is skipped.
+    if: ${{ vars.ADAM_DOC_DRIFT_V1 == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      ADAM_DOC_DRIFT_V1: ${{ vars.ADAM_DOC_DRIFT_V1 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Adam doc-drift review (read-only / propose-only)
+        run: |
+          echo "Running adam doc-drift review (flag=${ADAM_DOC_DRIFT_V1:-off})"
+          node scripts/adam-doc-drift-review.mjs || true

--- a/.github/workflows/adam-github-assessment-cron.yml
+++ b/.github/workflows/adam-github-assessment-cron.yml
@@ -1,0 +1,60 @@
+name: "Adam github-assessment (cron)"
+
+# SD: SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 2)
+#
+# Durable, server-side every-3-day Adam GitHub-health assessment — mirrors adam-opportunity-scan-cron.yml.
+# Runs the read-only scripts/adam-github-assessment.mjs, which aggregates existing GitHub-health producers
+# (CI red, failed runs, PR hygiene, merge conflicts) plus open dependabot/code-scanning alerts into ONE
+# ranked advisory via adam-advisory.cjs send (silent when clean). CONST-002: read-only.
+#
+# SHIPS INERT: the job is gated on the repo variable ADAM_GH_ASSESS_V1 (default unset = OFF). The gh API
+# reads need a token + extra read scopes (pull-requests, actions, security-events). Fail-soft (`|| true`).
+
+on:
+  schedule:
+    # Every 3rd day-of-month at 09:30 UTC (offset from the doc-drift tick at :00 to spread cron load).
+    - cron: '30 9 */3 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+  security-events: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  adam-github-assessment:
+    name: Adam github-assessment
+    # Inert until the operator flips the repo var. Unset/anything-but-'true' => job is skipped.
+    if: ${{ vars.ADAM_GH_ASSESS_V1 == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      ADAM_GH_ASSESS_V1: ${{ vars.ADAM_GH_ASSESS_V1 }}
+      # gh CLI auth for the PR-hygiene + dependabot/code-scanning alert reads.
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Adam github-assessment (read-only; one ranked advisory, silent when clean)
+        run: |
+          echo "Running adam github-assessment (flag=${ADAM_GH_ASSESS_V1:-off})"
+          node scripts/adam-github-assessment.mjs || true

--- a/scripts/adam-doc-drift-review.mjs
+++ b/scripts/adam-doc-drift-review.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 1) — every-3-day propose-only doc-drift review.
+ *
+ * Near-verbatim sibling of scripts/adam-self-adherence-review.mjs (same IO-seam / pure-analyzer /
+ * propose-only-feedback shape) with WINDOW_DAYS=3. It reads ONLY the SDs/QFs COMPLETED in the trailing
+ * 3 days (delta-scoped — NOT a full doc scour; doc-health-audit.mjs is explicitly out of scope), maps
+ * each by sd_type to the doc directories most likely affected (SD_TYPE_DOC_DIRECTORIES), clusters by
+ * dir + type WITHOUT enumerating (~125 completions/window), and surfaces ONE propose-only doc-update
+ * proposal to the coordinator via a feedback flag.
+ *
+ * CONST-002: this NEVER edits a doc, claims an SD, opens a PR, or runs a handoff. It writes a single
+ * feedback row (the coordinator/fleet triages it into doc work). Inertness is enforced at the WORKFLOW
+ * level: .github/workflows/adam-doc-drift-cron.yml gates on ADAM_DOC_DRIFT_V1 (default OFF) — the script
+ * itself just does its read-only analysis + propose-only write when invoked.
+ *
+ *   node scripts/adam-doc-drift-review.mjs            # real run (reads completions, writes one proposal)
+ *   node scripts/adam-doc-drift-review.mjs --dry-run  # reads + reports the cluster, NO feedback write
+ */
+import 'dotenv/config';
+import crypto from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+import { SD_TYPE_DOC_DIRECTORIES } from '../lib/utils/post-completion-requirements.js';
+
+const WINDOW_DAYS = 3;
+const PROPOSAL_CATEGORY = 'adam_doc_drift';
+
+/** ISO timestamp for `windowDays` ago. */
+export function windowStart(windowDays = WINDOW_DAYS, nowMs = Date.now()) {
+  return new Date(nowMs - windowDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * IO seam — read-only. Completed SDs (updated_at is the completion proxy; there is NO completed_at
+ * column on strategic_directives_v2, per sd-burnrate.js/sd-status.js) excluding QF-% keys, UNION
+ * completed QFs (quick_fixes carries completed_at natively). Fail-soft per source: a query error logs
+ * and continues with whatever resolved, so one broken source never sinks the whole review.
+ */
+export async function resolveCompletions(supabase, { windowDays = WINDOW_DAYS, nowMs = Date.now() } = {}) {
+  const since = windowStart(windowDays, nowMs);
+  const items = [];
+  try {
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, sd_type, updated_at')
+      .eq('status', 'completed')
+      .gte('updated_at', since)
+      .not('sd_key', 'like', 'QF-%');
+    if (error) throw error;
+    for (const r of (data || [])) items.push({ key: r.sd_key, title: r.title, sd_type: r.sd_type || 'feature', kind: 'sd' });
+  } catch (e) { console.warn(`[doc-drift] completed-SD query failed (continuing): ${e.message}`); }
+  try {
+    const { data, error } = await supabase
+      .from('quick_fixes')
+      .select('id, title, type, completed_at')
+      .eq('status', 'completed')
+      .gte('completed_at', since);
+    if (error) throw error;
+    // QF.type (bug/polish/typo/documentation/...) only maps cleanly if it is a known doc-dir key;
+    // otherwise default a small fix to 'bugfix' (troubleshooting/changelog area) rather than mis-routing.
+    for (const r of (data || [])) {
+      const t = (r.type && SD_TYPE_DOC_DIRECTORIES[r.type]) ? r.type : 'bugfix';
+      items.push({ key: r.id, title: r.title, sd_type: t, kind: 'qf' });
+    }
+  } catch (e) { console.warn(`[doc-drift] completed-QF query failed (continuing): ${e.message}`); }
+  return items;
+}
+
+/**
+ * PURE/TOTAL: cluster completed items by candidate doc directory and by work type, summarizing WITHOUT
+ * enumerating the ~125 completions. Unknown sd_types fall back to the 'feature' dir set. Returns ranked
+ * dir + type breakdowns (the proposal surfaces the top areas, never the full list).
+ * @param {Array<{sd_type?:string}>} items
+ * @param {Object<string,string[]>} [dirMap]
+ */
+export function clusterDocDrift(items, dirMap = SD_TYPE_DOC_DIRECTORIES) {
+  const list = Array.isArray(items) ? items : [];
+  const byDir = new Map();
+  const byType = new Map();
+  for (const it of list) {
+    const t = (it && typeof it.sd_type === 'string' && it.sd_type.trim() ? it.sd_type : 'feature').toLowerCase();
+    byType.set(t, (byType.get(t) || 0) + 1);
+    const dirs = (dirMap && (dirMap[t] || dirMap.feature)) || [];
+    for (const d of dirs) {
+      const e = byDir.get(d) || { count: 0, types: new Set() };
+      e.count += 1; e.types.add(t); byDir.set(d, e);
+    }
+  }
+  const dirRank = [...byDir.entries()]
+    .map(([dir, e]) => ({ dir, count: e.count, types: [...e.types].sort() }))
+    .sort((a, b) => b.count - a.count || a.dir.localeCompare(b.dir));
+  const typeRank = [...byType.entries()]
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+  return { total: list.length, dirRank, typeRank };
+}
+
+/** PURE: render the propose-only proposal text (clustered, top-N, no enumeration). */
+export function formatDocDriftProposal(cluster, windowDays = WINDOW_DAYS) {
+  const c = cluster || { total: 0, dirRank: [], typeRank: [] };
+  if (!c.total) return `Doc-drift review (trailing ${windowDays}d): 0 completions — nothing to review.`;
+  return [
+    `Doc-drift review (trailing ${windowDays}d): ${c.total} completed SD(s)/QF(s) may have drifted their docs.`,
+    'Top doc areas to review (by affected-completion count):',
+    ...c.dirRank.slice(0, 8).map((d) => `  - ${d.dir} (${d.count}; types: ${d.types.join('/')})`),
+    `By work type: ${c.typeRank.slice(0, 8).map((t) => `${t.type}×${t.count}`).join(', ')}`,
+    'PROPOSE-ONLY: triage which dirs actually need updates (Adam does not edit docs — CONST-002).',
+  ].join('\n');
+}
+
+/** PROPOSE-ONLY (CONST-002): write a single feedback flag. Returns the feedback id. */
+export async function sourceDocDriftProposal(supabase, cluster, { windowDays = WINDOW_DAYS, runId = crypto.randomUUID() } = {}) {
+  const { data, error } = await supabase
+    .from('feedback')
+    .insert({
+      type: 'issue',
+      source_application: 'EHG_Engineer',
+      source_type: 'manual_capture',
+      category: PROPOSAL_CATEGORY,
+      status: 'new',
+      severity: 'low',
+      title: `Adam doc-drift proposal (${cluster.total} completions, ${windowDays}d)`,
+      description: formatDocDriftProposal(cluster, windowDays),
+      metadata: { run_id: runId, window_days: windowDays, dir_rank: cluster.dirRank.slice(0, 12), type_rank: cluster.typeRank, sd: 'SD-LEO-INFRA-REGISTER-TWO-EVERY-001' },
+    })
+    .select('id')
+    .single();
+  if (error) throw error;
+  return data.id;
+}
+
+/** Run one doc-drift review. Silent (no write) when the window is empty. */
+export async function runDocDriftReview(supabase, { dryRun = false, windowDays = WINDOW_DAYS, runId = crypto.randomUUID() } = {}) {
+  const items = await resolveCompletions(supabase, { windowDays });
+  const cluster = clusterDocDrift(items);
+  if (dryRun || cluster.total === 0) return { runId, cluster, proposalRef: null, dryRun };
+  const proposalRef = await sourceDocDriftProposal(supabase, cluster, { windowDays, runId });
+  return { runId, cluster, proposalRef, dryRun: false };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const result = await runDocDriftReview(supabase, { dryRun });
+  console.log(formatDocDriftProposal(result.cluster));
+  console.log(result.proposalRef
+    ? `-> propose-only feedback ${result.proposalRef}`
+    : (result.cluster.total === 0 ? 'no completions in window -> silent' : '[dry-run] no write'));
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+if (isMain) main().catch((e) => { console.error('doc-drift review failed:', e.message); process.exit(1); });

--- a/scripts/adam-github-assessment.mjs
+++ b/scripts/adam-github-assessment.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 2) — every-3-day propose-only GitHub-health assessment.
+ *
+ * Read-only assessor that AGGREGATES existing GitHub-health producers into ONE ranked advisory for the
+ * coordinator (it computes nothing new except the dependabot/code-scanning alert reads). Producers:
+ *   (1) CI red on main      — codebase_health_snapshots latest dimension='ci_test_failure_count'
+ *   (2) failed runs (3d)    — feedback rows category='ci_failure' (gh-failure-monitor.cjs)
+ *   (3) PR hygiene          — gh pr list --json: open / stale(>14d) / oversized(>400 LOC) / conflicts
+ *   (4) merge conflicts     — derived from the same gh pr list (mergeable=CONFLICTING)
+ *   (5) security alerts     — gh api open dependabot + code-scanning alerts (the one genuinely-new read)
+ *
+ * CONST-002: read-only; surfaces ONE ranked advisory via `node scripts/adam-advisory.cjs send` and is
+ * SILENT when everything is clean. Inertness is enforced at the WORKFLOW level
+ * (.github/workflows/adam-github-assessment-cron.yml gates on ADAM_GH_ASSESS_V1, default OFF).
+ *
+ *   node scripts/adam-github-assessment.mjs            # assess + send one advisory (or silent)
+ *   node scripts/adam-github-assessment.mjs --dry-run  # assess + print, NO advisory send
+ */
+import 'dotenv/config';
+import { execFileSync } from 'node:child_process';
+import { createClient } from '@supabase/supabase-js';
+
+const WINDOW_DAYS = 3;
+const REPO = process.env.ADAM_GH_REPO || 'rickfelix/EHG_Engineer';
+const STALE_PR_DAYS = 14;
+const OVERSIZED_PR_LOC = 400;
+
+function windowStart(windowDays = WINDOW_DAYS, nowMs = Date.now()) {
+  return new Date(nowMs - windowDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/** Run a gh command, returning parsed JSON (or null on any failure — fail-soft). */
+function ghJson(args) {
+  try {
+    const out = execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 60_000 });
+    return JSON.parse(out);
+  } catch { return null; }
+}
+
+/**
+ * PURE/TOTAL: derive PR-hygiene counts from a `gh pr list` JSON array. Drafts are excluded from the
+ * actionable counts. nowMs injected for deterministic tests.
+ * @param {Array<object>} prs
+ */
+export function summarizePrs(prs, { nowMs = Date.now(), staleDays = STALE_PR_DAYS, oversizedLoc = OVERSIZED_PR_LOC } = {}) {
+  const list = Array.isArray(prs) ? prs.filter((p) => p && !p.isDraft) : [];
+  const staleMs = staleDays * 24 * 60 * 60 * 1000;
+  let stale = 0, oversized = 0, conflicts = 0;
+  for (const p of list) {
+    const age = p.createdAt ? nowMs - new Date(p.createdAt).getTime() : 0;
+    if (age >= staleMs) stale += 1;
+    if ((Number(p.additions) || 0) + (Number(p.deletions) || 0) > oversizedLoc) oversized += 1;
+    if (typeof p.mergeable === 'string' && p.mergeable.toUpperCase() === 'CONFLICTING') conflicts += 1;
+  }
+  return { open: list.length, stale, oversized, conflicts };
+}
+
+/**
+ * PURE/TOTAL: rank the assembled facts into severity-ordered findings + a one-line summary. Returns
+ * { findings:[{area,severity,detail}], summary, clean:boolean }. `clean` => the caller stays SILENT.
+ * Unknown/unmeasured facts (null) are simply omitted (never a fabricated alarm).
+ */
+export function rankGithubHealth(facts = {}) {
+  const f = facts || {};
+  const findings = [];
+  const push = (area, severity, detail) => findings.push({ area, severity, detail });
+  if (Number(f.ciRedOnMain) > 0) push('ci', 'high', `CI red on main: ${f.ciRedOnMain} failing`);
+  if (Number(f.openRedMergeQfs) > 0) push('ci', 'high', `${f.openRedMergeQfs} open red-merge QF(s)`);
+  if (Number(f.alertsDependabot) > 0) push('security', 'high', `${f.alertsDependabot} open dependabot alert(s)`);
+  if (Number(f.alertsCodeScanning) > 0) push('security', 'high', `${f.alertsCodeScanning} open code-scanning alert(s)`);
+  if (Number(f.prConflicts) > 0) push('pr', 'medium', `${f.prConflicts} PR(s) with merge conflicts`);
+  if (Number(f.failedRuns) > 0) push('ci', 'medium', `${f.failedRuns} failed CI run(s) in ${f.windowDays || WINDOW_DAYS}d`);
+  if (Number(f.prStale) > 0) push('pr', 'low', `${f.prStale} stale PR(s) (>${STALE_PR_DAYS}d)`);
+  if (Number(f.prOversized) > 0) push('pr', 'low', `${f.prOversized} oversized PR(s) (>${OVERSIZED_PR_LOC} LOC)`);
+  const rank = { high: 0, medium: 1, low: 2 };
+  findings.sort((a, b) => rank[a.severity] - rank[b.severity]);
+  const clean = findings.length === 0;
+  const summary = clean
+    ? 'GitHub health: all clear.'
+    : `GitHub health (${findings.length} item${findings.length === 1 ? '' : 's'}): ` + findings.map((x) => x.detail).join('; ');
+  return { findings, summary, clean };
+}
+
+/** IO seam — fail-soft per producer. Assemble the facts the ranker needs. */
+export async function resolveGithubHealth(supabase, { windowDays = WINDOW_DAYS, nowMs = Date.now() } = {}) {
+  const since = windowStart(windowDays, nowMs);
+  const facts = { windowDays, ciRedOnMain: null, openRedMergeQfs: null, failedRuns: null, prOpen: null, prStale: null, prOversized: null, prConflicts: null, alertsDependabot: null, alertsCodeScanning: null };
+
+  // (1) CI red on main — latest ci_test_failure_count snapshot.
+  try {
+    const { data } = await supabase.from('codebase_health_snapshots')
+      .select('score, finding_count, scanned_at').eq('dimension', 'ci_test_failure_count')
+      .order('scanned_at', { ascending: false }).limit(1);
+    const row = data && data[0];
+    if (row) facts.ciRedOnMain = Number.isFinite(row.finding_count) ? row.finding_count : (Number(row.score) || 0);
+  } catch { /* null */ }
+
+  // (1b) open red-merge QFs.
+  try {
+    const { count } = await supabase.from('quick_fixes')
+      .select('id', { count: 'exact', head: true }).eq('status', 'open').ilike('title', '%red-merge%');
+    if (Number.isFinite(count)) facts.openRedMergeQfs = count;
+  } catch { /* null */ }
+
+  // (2) failed CI runs in window.
+  try {
+    const { count } = await supabase.from('feedback')
+      .select('id', { count: 'exact', head: true }).eq('category', 'ci_failure').gte('created_at', since);
+    if (Number.isFinite(count)) facts.failedRuns = count;
+  } catch { /* null */ }
+
+  // (3)+(4) PR hygiene + conflicts via one gh pr list.
+  const prs = ghJson(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '100', '--json', 'number,createdAt,additions,deletions,mergeable,isDraft']);
+  if (Array.isArray(prs)) {
+    const s = summarizePrs(prs, { nowMs });
+    facts.prOpen = s.open; facts.prStale = s.stale; facts.prOversized = s.oversized; facts.prConflicts = s.conflicts;
+  }
+
+  // (5) security alerts (may 404 if a feature is disabled — fail-soft to null).
+  const dep = ghJson(['api', `repos/${REPO}/dependabot/alerts`, '--paginate', '-q', '[.[] | select(.state=="open")] | length']);
+  if (Number.isFinite(Number(dep))) facts.alertsDependabot = Number(dep);
+  const cs = ghJson(['api', `repos/${REPO}/code-scanning/alerts`, '--paginate', '-q', '[.[] | select(.state=="open")] | length']);
+  if (Number.isFinite(Number(cs))) facts.alertsCodeScanning = Number(cs);
+
+  return facts;
+}
+
+/** Surface ONE ranked advisory via adam-advisory.cjs send (propose-only). Returns true if sent. */
+export function sendAdvisory(summary) {
+  try {
+    execFileSync('node', ['scripts/adam-advisory.cjs', 'send', summary], { encoding: 'utf8', stdio: ['ignore', 'ignore', 'ignore'], timeout: 60_000 });
+    return true;
+  } catch { return false; }
+}
+
+export async function runGithubAssessment(supabase, { dryRun = false, windowDays = WINDOW_DAYS } = {}) {
+  const facts = await resolveGithubHealth(supabase, { windowDays });
+  const ranked = rankGithubHealth(facts);
+  if (dryRun || ranked.clean) return { facts, ranked, sent: false };
+  const sent = sendAdvisory(ranked.summary);
+  return { facts, ranked, sent };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { ranked, sent } = await runGithubAssessment(supabase, { dryRun });
+  console.log(ranked.summary);
+  console.log(ranked.clean ? 'clean -> silent (no advisory)' : (sent ? '-> advisory sent' : '[dry-run / send-skipped] no advisory'));
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+if (isMain) main().catch((e) => { console.error('github-assessment failed:', e.message); process.exit(1); });

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -88,6 +88,28 @@ export const ADAM_LOOPS = [
     cron: '*/15 * * * *',
     prompt: 'Adam belt-countdown tick: if the fleet is active, post ONE belt-countdown line via node scripts/adam-advisory.cjs send "<line>" — Eastern time in 12-hour format with a rolling ETA to belt-dry (claimable-SD depth vs current fleet burn; read depth/burn from DB rows via node scripts/fleet-dashboard.cjs, never hand-convert ET↔UTC). If the fleet is idle/empty, STAY SILENT.',
   },
+  {
+    // SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 1): every-3-day propose-only doc-drift review. Reads ONLY
+    // the SDs/QFs COMPLETED in the trailing 3 days (delta-scoped, NOT a full doc scour), maps each by
+    // sd_type to the doc dirs most likely affected, clusters, and surfaces a doc-update PROPOSAL to the
+    // coordinator. Edits no docs (CONST-002). Ships INERT behind ADAM_DOC_DRIFT_V1 (default OFF).
+    key: 'doc-drift',
+    label: 'Every-3-day doc-drift review (delta-scoped completed SDs/QFs -> doc-dir proposal, propose-only, gated on ADAM_DOC_DRIFT_V1)',
+    script: 'adam-doc-drift-review.mjs',
+    cron: '0 9 */3 * *',
+    prompt: 'node scripts/adam-doc-drift-review.mjs',
+  },
+  {
+    // SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 2): every-3-day propose-only GitHub-health assessment.
+    // Aggregates existing GitHub-health producers (CI red, failed runs, open/stale/oversized PRs, merge
+    // conflicts) PLUS open dependabot/code-scanning alerts into ONE ranked advisory to the coordinator.
+    // Read-only (CONST-002). Ships INERT behind ADAM_GH_ASSESS_V1 (default OFF).
+    key: 'github-assessment',
+    label: 'Every-3-day GitHub-health assessment (CI/PR/alerts -> one ranked advisory, propose-only, gated on ADAM_GH_ASSESS_V1)',
+    script: 'adam-github-assessment.mjs',
+    cron: '30 9 */3 * *',
+    prompt: 'node scripts/adam-github-assessment.mjs',
+  },
 ];
 
 // Parse the armed-cron basenames/prompts the agent passes from its CronList output.

--- a/tests/unit/adam-doc-drift-review.test.mjs
+++ b/tests/unit/adam-doc-drift-review.test.mjs
@@ -1,0 +1,49 @@
+/**
+ * SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 1) — doc-drift pure-analyzer tests.
+ * The script touches the live DB at import-of-main only; the PURE clusterDocDrift / formatDocDriftProposal
+ * are unit-tested here without a DB (mirrors lib/adam/adherence-probes.js test style).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { clusterDocDrift, formatDocDriftProposal } from '../../scripts/adam-doc-drift-review.mjs';
+
+const DIRMAP = {
+  infrastructure: ['docs/06_deployment/', 'docs/operations/'],
+  feature: ['docs/04_features/'],
+  bugfix: ['docs/troubleshooting/'],
+};
+
+test('clusterDocDrift maps by sd_type to doc dirs and ranks by affected-completion count', () => {
+  const items = [
+    { sd_type: 'infrastructure' }, { sd_type: 'infrastructure' }, { sd_type: 'feature' }, { sd_type: 'bugfix' },
+  ];
+  const c = clusterDocDrift(items, DIRMAP);
+  assert.equal(c.total, 4);
+  // infrastructure dirs hit twice -> top of dirRank
+  assert.equal(c.dirRank[0].count, 2);
+  assert.ok(c.dirRank[0].dir.startsWith('docs/'));
+  // type breakdown present
+  const infra = c.typeRank.find((t) => t.type === 'infrastructure');
+  assert.equal(infra.count, 2);
+});
+
+test('clusterDocDrift falls back to the feature dir set for an unknown sd_type', () => {
+  const c = clusterDocDrift([{ sd_type: 'totally-unknown' }], DIRMAP);
+  assert.equal(c.total, 1);
+  assert.deepEqual(c.dirRank.map((d) => d.dir), ['docs/04_features/']);
+});
+
+test('clusterDocDrift is TOTAL on odd input (null/array/missing type)', () => {
+  assert.equal(clusterDocDrift(null, DIRMAP).total, 0);
+  assert.equal(clusterDocDrift(undefined, DIRMAP).total, 0);
+  assert.equal(clusterDocDrift([{}], DIRMAP).total, 1); // missing type -> feature fallback, no throw
+});
+
+test('formatDocDriftProposal: empty window says nothing to review; non-empty is clustered + propose-only', () => {
+  assert.match(formatDocDriftProposal({ total: 0, dirRank: [], typeRank: [] }, 3), /0 completions — nothing to review/);
+  const c = clusterDocDrift([{ sd_type: 'infrastructure' }], DIRMAP);
+  const out = formatDocDriftProposal(c, 3);
+  assert.match(out, /trailing 3d/);
+  assert.match(out, /PROPOSE-ONLY/);
+  assert.match(out, /CONST-002/);
+});

--- a/tests/unit/adam-github-assessment.test.mjs
+++ b/tests/unit/adam-github-assessment.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (DUTY 2) — github-assessment pure-function tests.
+ * The script's IO (DB + gh CLI) runs only in main(); the PURE summarizePrs / rankGithubHealth are
+ * unit-tested here without any IO.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { summarizePrs, rankGithubHealth } from '../../scripts/adam-github-assessment.mjs';
+
+const NOW = new Date('2026-06-21T00:00:00Z').getTime();
+const daysAgo = (d) => new Date(NOW - d * 24 * 60 * 60 * 1000).toISOString();
+
+test('summarizePrs counts open/stale/oversized/conflicts and excludes drafts', () => {
+  const prs = [
+    { createdAt: daysAgo(20), additions: 10, deletions: 5, mergeable: 'MERGEABLE' },       // stale
+    { createdAt: daysAgo(2), additions: 300, deletions: 200, mergeable: 'CONFLICTING' },   // oversized + conflict
+    { createdAt: daysAgo(1), additions: 5, deletions: 1, mergeable: 'MERGEABLE', isDraft: true }, // draft -> excluded
+  ];
+  const s = summarizePrs(prs, { nowMs: NOW });
+  assert.equal(s.open, 2);
+  assert.equal(s.stale, 1);
+  assert.equal(s.oversized, 1);
+  assert.equal(s.conflicts, 1);
+});
+
+test('summarizePrs is TOTAL on odd input', () => {
+  assert.deepEqual(summarizePrs(null), { open: 0, stale: 0, oversized: 0, conflicts: 0 });
+  assert.deepEqual(summarizePrs(undefined), { open: 0, stale: 0, oversized: 0, conflicts: 0 });
+});
+
+test('rankGithubHealth: clean facts => clean=true (caller stays silent)', () => {
+  const r = rankGithubHealth({ ciRedOnMain: 0, prOpen: 3, prStale: 0, failedRuns: 0, alertsDependabot: 0 });
+  assert.equal(r.clean, true);
+  assert.match(r.summary, /all clear/);
+});
+
+test('rankGithubHealth: null facts are omitted (no fabricated alarm)', () => {
+  const r = rankGithubHealth({});
+  assert.equal(r.clean, true);
+  assert.equal(r.findings.length, 0);
+});
+
+test('rankGithubHealth: severity-orders findings (high before low) and summarizes', () => {
+  const r = rankGithubHealth({ ciRedOnMain: 4, prStale: 2, alertsDependabot: 1, failedRuns: 9 });
+  assert.equal(r.clean, false);
+  // first finding must be a high-severity one (ci red or dependabot), last a low (stale PR)
+  assert.equal(r.findings[0].severity, 'high');
+  assert.equal(r.findings[r.findings.length - 1].severity, 'low');
+  assert.match(r.summary, /GitHub health \(\d+ items?\)/);
+});

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -21,11 +21,12 @@ import {
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('ADAM_LOOPS has the 5 expected tick loops with the expected keys', () => {
+test('ADAM_LOOPS has the 7 expected tick loops with the expected keys', () => {
   // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
-  // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty).
-  assert.equal(ADAM_LOOPS.length, 5);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown']);
+  // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty);
+  // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties).
+  assert.equal(ADAM_LOOPS.length, 7);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown', 'doc-drift', 'github-assessment']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);
@@ -128,16 +129,16 @@ test('loopStatus: armed on key, prompt or script match, MISSING when provided-bu
   assert.equal(loopStatus(offer, { provided: true, set: new Set([offer.prompt]) }), 'armed');
 });
 
-test('end-to-end CSV verdict: --armed with all 5 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
+test('end-to-end CSV verdict: --armed with all 7 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
   const armed = parseArmedSet(['--armed', ADAM_LOOPS.map((l) => l.key).join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 5 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 7 Adam tick loops armed\. Nothing to arm\./);
   assert.doesNotMatch(out, /MISSING/);
 });
 
 test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent note)', () => {
   const out = renderLoops(parseArmedSet([], {}));
-  assert.match(out, /ADAM RECURRING TICK \(5 loops\)/);
+  assert.match(out, /ADAM RECURRING TICK \(7 loops\)/);
   assert.match(out, /CronCreate\(\{ cron: "0 13 \* \* \*"/); // governance-scan spec emitted
   assert.match(out, /idempotent/i);
 });
@@ -145,7 +146,7 @@ test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent
 test('renderLoops reports "Nothing to arm" when all loops are in the armed set', () => {
   const armedSet = new Set(ADAM_LOOPS.map((l) => l.prompt));
   const out = renderLoops({ provided: true, set: armedSet });
-  assert.match(out, /All 5 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 7 Adam tick loops armed\. Nothing to arm\./);
 });
 
 test('renderResponsibilities is fail-open (bad repoRoot → fallback, never throws)', () => {


### PR DESCRIPTION
## SD-LEO-INFRA-REGISTER-TWO-EVERY-001 — two propose-only Adam duties

Chairman-directed (Rick, 2026-06-21). Adds two recurring, **propose-only** (CONST-002) Adam-role duties by **copying the proven Adam-tick patterns** — no new scheduling mechanism. Both analyze + surface to the coordinator only (edit no docs/code, claim no SDs, open no PRs) and **ship INERT** behind default-OFF repo-var flags.

### Deliverables (FR-1…FR-6)
- **FR-1/FR-2** — registered two `ADAM_LOOPS` entries in `scripts/adam-startup-check.mjs` (`doc-drift` `0 9 */3 * *`, `github-assessment` `30 9 */3 * *`); bumped the pinned `adam-startup-check.test.mjs` 5→7.
- **FR-3** — `scripts/adam-doc-drift-review.mjs`: every-3-day delta-scoped review of SDs/QFs **completed in the trailing 3 days**, mapped by `sd_type` → `SD_TYPE_DOC_DIRECTORIES`, **clustered (no enumeration)**, surfaced as one `adam_doc_drift` feedback flag. Mirrors `adam-self-adherence-review.mjs` (IO-seam / pure analyzer / propose-only).
- **FR-4** — `scripts/adam-github-assessment.mjs`: read-only aggregation of 5 producers (CI red, failed runs 3d, PR hygiene open/stale/oversized, merge conflicts, open dependabot+code-scanning alerts) → **one ranked advisory** via `adam-advisory.cjs send`; **silent when clean**; fail-soft per producer.
- **FR-5** — two GHA cron workflows, each **job-gated on a default-OFF repo var** (`ADAM_DOC_DRIFT_V1` / `ADAM_GH_ASSESS_V1`) so they skip cleanly until the operator flips the flag; fail-soft; the github one adds `GH_TOKEN` + read scopes.
- **FR-6** — `.claude/commands/adam.md` parity: five→seven loops, items 6/7, extended key lists.

### Verification
- **25 unit tests green** (pinned registration + pure analyzers for both probes).
- **Dogfood dry-runs** (read-only): doc-drift → 135 completions clustered to ranked doc areas; github-assessment → "171 failed CI runs in 3d; 2 stale PRs".
- Both workflows YAML-validated; both probe scripts `node --check` clean and run read-only.

**Activation is a separate chairman/coordinator flag-flip** — this PR ships everything inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)