### PR TITLE
fix(SD-REFILL-003T5I5M): non-blocking EXCEPTION guard on feedback auto-close trigger

### DIFF
--- a/database/migrations/20260621_auto_close_feedback_exception_guard.sql
+++ b/database/migrations/20260621_auto_close_feedback_exception_guard.sql
@@ -1,0 +1,55 @@
+-- SD-REFILL-003T5I5M: add the non-blocking EXCEPTION guard to fn_auto_close_feedback_on_sd_completion.
+--
+-- Root cause (verified live via pg_get_functiondef 2026-06-21): the feedback auto-close trigger
+-- function had a bare BEGIN...END with NO EXCEPTION handler, so any feedback-table constraint
+-- failure during the auto-close UPDATE propagated and ABORTED the SD-completion transaction.
+-- Its siblings (fn_auto_close_quick_fixes_on_sd_completion, fn_auto_close_deliverables) both end
+-- with `EXCEPTION WHEN OTHERS THEN RAISE WARNING ...; RETURN NEW;` — completion writes are sacred
+-- (ROOT-FIX-TRG doctrine), and a side-effect trigger must never block them.
+--
+-- This migration CREATE OR REPLACEs the function with a BYTE-IDENTICAL body plus the sibling guard
+-- appended. The trigger binding is unchanged. Reversible via the _DOWN migration.
+
+CREATE OR REPLACE FUNCTION public.fn_auto_close_feedback_on_sd_completion()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+BEGIN
+  -- Only fire when SD transitions TO completed status
+  IF NEW.status = 'completed' AND (OLD.status IS NULL OR OLD.status != 'completed') THEN
+    -- Close all feedback linked via strategic_directive_id FK
+    UPDATE feedback
+    SET
+      status = 'resolved',
+      resolution_type = 'sd_completed',
+      resolution_notes = COALESCE(resolution_notes, '') ||
+        CASE WHEN resolution_notes IS NOT NULL AND resolution_notes != '' THEN '; ' ELSE '' END ||
+        'Auto-resolved: linked SD ' || COALESCE(NEW.sd_key, NEW.id::text) || ' completed',
+      resolved_at = NOW(),
+      updated_at = NOW()
+    WHERE strategic_directive_id = NEW.id
+      AND status NOT IN ('resolved', 'wont_fix', 'shipped');
+
+    -- Also close feedback linked via resolution_sd_id (legacy linkage)
+    UPDATE feedback
+    SET
+      status = 'resolved',
+      resolution_type = 'sd_completed',
+      resolution_notes = COALESCE(resolution_notes, '') ||
+        CASE WHEN resolution_notes IS NOT NULL AND resolution_notes != '' THEN '; ' ELSE '' END ||
+        'Auto-resolved: linked SD ' || COALESCE(NEW.sd_key, NEW.id::text) || ' completed',
+      resolved_at = NOW(),
+      updated_at = NOW()
+    WHERE resolution_sd_id = NEW.id
+      AND status NOT IN ('resolved', 'wont_fix', 'shipped');
+  END IF;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Non-blocking: log warning but never prevent SD completion (parity with the sibling
+  -- auto-close triggers; ROOT-FIX-TRG doctrine — completion writes are sacred). SD-REFILL-003T5I5M.
+  RAISE WARNING 'fn_auto_close_feedback_on_sd_completion failed for SD %: %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$function$;

--- a/database/migrations/20260621_auto_close_feedback_exception_guard_DOWN.sql
+++ b/database/migrations/20260621_auto_close_feedback_exception_guard_DOWN.sql
@@ -1,0 +1,43 @@
+-- DOWN for SD-REFILL-003T5I5M: restore fn_auto_close_feedback_on_sd_completion to its prior
+-- (un-guarded) definition — a bare BEGIN...END with no EXCEPTION handler. Byte-identical to the
+-- pre-migration live definition (pg_get_functiondef 2026-06-21). Reverting re-introduces the
+-- hazard where a feedback-table failure aborts SD completion; only run this to roll back.
+
+CREATE OR REPLACE FUNCTION public.fn_auto_close_feedback_on_sd_completion()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+BEGIN
+  -- Only fire when SD transitions TO completed status
+  IF NEW.status = 'completed' AND (OLD.status IS NULL OR OLD.status != 'completed') THEN
+    -- Close all feedback linked via strategic_directive_id FK
+    UPDATE feedback
+    SET
+      status = 'resolved',
+      resolution_type = 'sd_completed',
+      resolution_notes = COALESCE(resolution_notes, '') ||
+        CASE WHEN resolution_notes IS NOT NULL AND resolution_notes != '' THEN '; ' ELSE '' END ||
+        'Auto-resolved: linked SD ' || COALESCE(NEW.sd_key, NEW.id::text) || ' completed',
+      resolved_at = NOW(),
+      updated_at = NOW()
+    WHERE strategic_directive_id = NEW.id
+      AND status NOT IN ('resolved', 'wont_fix', 'shipped');
+
+    -- Also close feedback linked via resolution_sd_id (legacy linkage)
+    UPDATE feedback
+    SET
+      status = 'resolved',
+      resolution_type = 'sd_completed',
+      resolution_notes = COALESCE(resolution_notes, '') ||
+        CASE WHEN resolution_notes IS NOT NULL AND resolution_notes != '' THEN '; ' ELSE '' END ||
+        'Auto-resolved: linked SD ' || COALESCE(NEW.sd_key, NEW.id::text) || ' completed',
+      resolved_at = NOW(),
+      updated_at = NOW()
+    WHERE resolution_sd_id = NEW.id
+      AND status NOT IN ('resolved', 'wont_fix', 'shipped');
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;

--- a/tests/unit/auto-close-feedback-exception-guard-migration.test.js
+++ b/tests/unit/auto-close-feedback-exception-guard-migration.test.js
@@ -1,0 +1,50 @@
+/**
+ * SD-REFILL-003T5I5M — static parity test for the feedback auto-close EXCEPTION-guard migration.
+ *
+ * Verifies the UP migration adds the non-blocking guard (parity with the sibling auto-close
+ * triggers), that the auto-close UPDATE logic is unchanged vs the DOWN (un-guarded) definition,
+ * and that the DOWN restores the pre-guard function. Pure file reads — no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIG = resolve(__dirname, '../../database/migrations');
+const UP = readFileSync(resolve(MIG, '20260621_auto_close_feedback_exception_guard.sql'), 'utf8');
+const DOWN = readFileSync(resolve(MIG, '20260621_auto_close_feedback_exception_guard_DOWN.sql'), 'utf8');
+
+// The two auto-close UPDATE statements — must be byte-identical in UP and DOWN (only the guard differs).
+const updateBlocks = (sql) => (sql.match(/UPDATE feedback[\s\S]*?status NOT IN \('resolved', 'wont_fix', 'shipped'\);/g) || []);
+
+describe('SD-REFILL-003T5I5M — feedback auto-close EXCEPTION-guard migration', () => {
+  it('UP CREATE OR REPLACEs the feedback auto-close function', () => {
+    expect(UP).toMatch(/CREATE OR REPLACE FUNCTION public\.fn_auto_close_feedback_on_sd_completion\(\)/);
+  });
+
+  it('UP adds the non-blocking EXCEPTION guard (parity with sibling auto-close triggers)', () => {
+    expect(UP).toMatch(/EXCEPTION WHEN OTHERS THEN/);
+    expect(UP).toMatch(/RAISE WARNING 'fn_auto_close_feedback_on_sd_completion failed for SD %: %', NEW\.id, SQLERRM;/);
+    // the guard must RETURN NEW so completion is never blocked
+    const tail = UP.slice(UP.indexOf('EXCEPTION WHEN OTHERS THEN'));
+    expect(tail).toMatch(/RETURN NEW;/);
+  });
+
+  it('DOWN restores the pre-guard function (no EXCEPTION handler)', () => {
+    expect(DOWN).toMatch(/CREATE OR REPLACE FUNCTION public\.fn_auto_close_feedback_on_sd_completion\(\)/);
+    expect(DOWN).not.toMatch(/EXCEPTION WHEN OTHERS THEN/);
+  });
+
+  it('auto-close UPDATE logic is byte-identical between UP and DOWN (only the guard changes)', () => {
+    const up = updateBlocks(UP);
+    const down = updateBlocks(DOWN);
+    expect(up).toHaveLength(2);        // FK linkage + legacy resolution_sd_id linkage
+    expect(down).toHaveLength(2);
+    expect(up).toEqual(down);
+  });
+
+  it('UP fires only on the transition TO completed (logic unchanged)', () => {
+    expect(UP).toMatch(/NEW\.status = 'completed' AND \(OLD\.status IS NULL OR OLD\.status != 'completed'\)/);
+  });
+});


### PR DESCRIPTION
## SD-REFILL-003T5I5M — non-blocking EXCEPTION guard on fn_auto_close_feedback_on_sd_completion

### Problem
`fn_auto_close_feedback_on_sd_completion()` had a bare `BEGIN…END` with **no EXCEPTION handler** (verified live via pg_get_functiondef). A feedback-table constraint failure during auto-close therefore aborts the entire SD-completion transaction. Both sibling auto-close triggers (`quick_fixes`, `deliverables`) end with `EXCEPTION WHEN OTHERS THEN RAISE WARNING …; RETURN NEW;` — completion writes are sacred (ROOT-FIX-TRG doctrine).

### Fix
Migration `CREATE OR REPLACE`s the function with a **byte-identical body** + the sibling guard appended; DOWN restores the pre-guard def. No logic change, no trigger-binding change.

### Verification
- Static parity test (5 passing): UP has the guard, DOWN doesn't, the two auto-close UPDATEs are byte-identical UP↔DOWN.
- TESTING PASS. Adversarial RCA **PASS** (97): confirmed via live pg_get_functiondef that the UP body is byte-identical to the current def apart from the guard, the guard exactly matches siblings, scope is correct, DOWN is byte-identical to the live un-guarded def, and search_path/volatility/security attributes are preserved. The WHEN-OTHERS masking is intentional + doctrine-aligned.

**Prod application via the migration pipeline** (not autonomous apply). Optional follow-up: the warning is log-only — a periodic log-scan could surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
