### PR TITLE
feat(SD-LEO-INFRA-BELT-001-PART-001): recover feedback.description so the auto-refill belt stops drying

### DIFF
--- a/lib/sourcing-engine/proactive-populator.js
+++ b/lib/sourcing-engine/proactive-populator.js
@@ -246,6 +246,12 @@ export async function stageCorpus(supabase, routed, opts = {}) {
       title: c.title || c.source_id,
       item_disposition: 'pending', // STAGED — never 'promoted'; promoted_to_sd_key intentionally unset
       metadata: { sourced_by: 'proactive-populator', corpus: c.corpus, intended_lane: c.lane,
+        // SD-LEO-INFRA-BELT-001-PART-001 (FR-3 recovery): carry the candidate's full source substance
+        // (feedback.description etc.) onto the staged row so the title's 120-char truncation is no
+        // longer a deceptive shell. roadmap_wave_items has no description column, so it rides in
+        // metadata.description — read by deriveSdFieldsFromRoadmapItem (onto the promoted SD, shrinking
+        // needs_enrichment) and by evaluateRefillCandidate's recovery-aware substance check.
+        ...(typeof c.description === 'string' && c.description.trim() ? { description: c.description } : {}),
         ...(c.source_key ? { source_key: c.source_key } : {}),
         ...(c.dedup_match_sd_key ? { dedup_match_sd_key: c.dedup_match_sd_key } : {}),
         ...(c.re_emit ? { re_emit: true } : {}) },

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -56,6 +56,34 @@ export function isSubstanceThinTitle(title) {
   return t.length >= TITLE_TRUNCATION_CAP && t.endsWith('...');
 }
 
+// SD-LEO-INFRA-BELT-001-PART-001 (FR-3 recovery): a 120-char truncated TITLE is only a deceptive
+// shell because the populator historically dropped feedback.description. Once the full substance is
+// recovered (carried into roadmap_wave_items.metadata.description by the populator / one-shot
+// backfill), a truncated-title item is NO LONGER substance-thin — it has real recovered content.
+// This floor distinguishes a real recovered body (live feedstock descriptions run ~180-400 chars)
+// from a trivial stub, and rejects a "description" that is itself merely the truncation shell.
+export const MIN_RECOVERED_SUBSTANCE_LEN = 40;
+
+/**
+ * Does this staged item carry a SUBSTANTIAL recovered description (the full source substance the
+ * populator now carries into metadata.description)? PURE/TOTAL. A description that is itself a
+ * truncation shell, or shorter than MIN_RECOVERED_SUBSTANCE_LEN, does NOT count as recovered substance.
+ * @param {{ metadata?:object, description?:string }} item
+ * @returns {boolean}
+ */
+export function hasRecoveredSubstance(item) {
+  if (!item || typeof item !== 'object') return false;
+  const md = item.metadata && typeof item.metadata === 'object' ? item.metadata : {};
+  // Accept the carried metadata.description (canonical) or a top-level description, for callers that
+  // pass the recovered body directly.
+  const raw = nonEmpty(md.description) ? md.description : (nonEmpty(item.description) ? item.description : '');
+  const d = typeof raw === 'string' ? raw.trim() : '';
+  if (d.length < MIN_RECOVERED_SUBSTANCE_LEN) return false;
+  // A "description" that is itself a 120-char truncation shell is not recovered substance.
+  if (isSubstanceThinTitle(d)) return false;
+  return true;
+}
+
 /**
  * Normalize a title for the shipped-lookalike axis (FR-2): lowercase, strip a trailing truncation
  * ellipsis, strip a leading "SD-KEY:" prefix if present, collapse internal whitespace, trim. EXACT
@@ -73,6 +101,38 @@ export function normalizeTitleForCompare(title) {
     .replace(/^\s*sd-[a-z0-9-]+:\s*/i, '')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+/**
+ * SD-LEO-INFRA-BELT-001-PART-001 (FR-2): bounded, ADVISORY shipped-SD cross-reference. Complements the
+ * exact-match already_shipped_lookalike axis (which fires on a normalized-equal title) by surfacing a
+ * candidate whose normalized title is a PREFIX of (or equals) an already-shipped title — the common
+ * shape of a truncated re-promotion of work that already shipped under a longer title. ADVISORY by
+ * design: it returns the matched shipped title (or null) for the caller to LOG; it does NOT change the
+ * {valid,reason} verdict (advisory-default — promote to a hard reason only once the FP rate is measured,
+ * the safe-rollout pattern). BOUNDED: iterates the caller-injected shippedTitleSet, which the caller
+ * builds once per <=10-row promotion batch (never a full-corpus scan). PURE/TOTAL.
+ *
+ * @param {string} title  the candidate title
+ * @param {Set<string>} shippedTitleSet  normalizeTitleForCompare() keys of shipped/in-progress SD titles
+ * @returns {string|null}  the matched normalized shipped key, or null when no advisory match
+ */
+// Minimum normalized stem length for a PREFIX cross-ref match; below it, only exact match counts.
+export const MIN_CROSSREF_STEM_LEN = 12;
+
+export function crossRefShippedTitleAdvisory(title, shippedTitleSet) {
+  if (!shippedTitleSet || typeof shippedTitleSet.has !== 'function') return null;
+  const norm = normalizeTitleForCompare(title);
+  if (!norm) return null;
+  // Guard against a trivially-short normalized title prefix-matching many shipped titles: below this
+  // stem floor, only an EXACT match counts. A real title stem (e.g. "harden the worktree reaper") is
+  // well above it, so the truncated-prefix case is still caught.
+  if (norm.length < MIN_CROSSREF_STEM_LEN) return shippedTitleSet.has(norm) ? norm : null;
+  for (const shipped of shippedTitleSet) {
+    if (typeof shipped !== 'string') continue;
+    if (shipped === norm || shipped.startsWith(norm) || norm.startsWith(shipped)) return shipped;
+  }
+  return null;
 }
 
 /**
@@ -120,7 +180,12 @@ export function evaluateRefillCandidate(item, opts = {}) {
   // reports its structural reason first. (1) substance: a 120-char truncation shell carries only a
   // fragment. (2) lookalike: a title that normalizes to an already-shipped SD's title is a stale
   // re-promotion. Both conservative — they never fire on a well-formed, novel, full-length title.
-  if (isSubstanceThinTitle(item.title)) {
+  // SD-LEO-INFRA-BELT-001-PART-001 (FR-3 recovery): a truncated-title shell is substance_thin ONLY
+  // when no substantial recovered description exists. The populator now carries feedback.description
+  // into metadata.description (and a one-shot backfill recovers it for the existing truncated rows),
+  // so a truncated title WITH real recovered content is a valid candidate — not the deceptive shell
+  // part-1 rejected. This only LOOSENS the part-1 reject; a full-length title was never thin anyway.
+  if (isSubstanceThinTitle(item.title) && !hasRecoveredSubstance(item)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN };
   }
   const shippedTitleSet = opts && opts.shippedTitleSet;

--- a/scripts/sourcing-engine/backfill-refill-descriptions.mjs
+++ b/scripts/sourcing-engine/backfill-refill-descriptions.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-BELT-001-PART-001 (FR-3c) — one-shot, VISIBLE + LOGGED, reversible backfill.
+ *
+ * Part-1 (PR #5012) added a substance_thin REJECT to evaluateRefillCandidate keyed on a 120-char
+ * truncated title. The populator historically copied ONLY feedback.title and DROPPED
+ * feedback.description, so ~173 staged roadmap_wave_items are truncation shells and get rejected —
+ * drying the belt (promotable=0). The forward fix (FR-3a) makes the populator carry
+ * feedback.description into metadata.description; this one-shot recovers that substance for the
+ * EXISTING truncated rows so the belt can refill from existing feedstock.
+ *
+ * SAFE: dry-run by DEFAULT (pass --apply to write). Additive only — writes metadata.description
+ * (preserving every existing metadata key); never deletes, never changes disposition/title/lane.
+ * Idempotent: a row that already carries metadata.description is skipped. Reversible: clearing the
+ * added metadata.description restores the prior state. Every row is reported (recovered / skipped /
+ * no-source-description) — never a silent change.
+ *
+ * Usage:
+ *   node scripts/sourcing-engine/backfill-refill-descriptions.mjs            # dry-run (default)
+ *   node scripts/sourcing-engine/backfill-refill-descriptions.mjs --apply    # write
+ */
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { isSubstanceThinTitle, MIN_RECOVERED_SUBSTANCE_LEN } from '../../lib/sourcing-engine/refill-candidate-validity.js';
+
+dotenv.config();
+
+const APPLY = process.argv.includes('--apply');
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function log(...a) { console.log('[backfill-refill-descriptions]', ...a); }
+
+async function main() {
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    console.error('Missing Supabase service-role credentials');
+    process.exit(1);
+  }
+  const sb = createClient(SUPABASE_URL, SERVICE_KEY);
+  log(APPLY ? 'APPLY mode — will WRITE metadata.description' : 'DRY-RUN (default) — no writes; pass --apply to write');
+
+  // Candidate rows: staged (pending), truncated title shell, missing a recovered metadata.description.
+  const { data: rows, error } = await sb
+    .from('roadmap_wave_items')
+    .select('id, source_type, source_id, title, metadata, item_disposition')
+    .eq('item_disposition', 'pending');
+  if (error) { console.error('query failed:', error.message); process.exit(1); }
+
+  const candidates = (rows || []).filter((r) => {
+    const md = r.metadata && typeof r.metadata === 'object' ? r.metadata : {};
+    const alreadyHas = typeof md.description === 'string' && md.description.trim().length >= MIN_RECOVERED_SUBSTANCE_LEN;
+    return isSubstanceThinTitle(r.title) && !alreadyHas;
+  });
+  log(`pending=${(rows || []).length} truncated-without-description=${candidates.length}`);
+  if (!candidates.length) { log('nothing to recover — done'); return; }
+
+  // Bounded batch lookup of source feedback descriptions (source_id = feedback row id).
+  const ids = [...new Set(candidates.map((c) => c.source_id).filter(Boolean))];
+  const descById = new Map();
+  for (let i = 0; i < ids.length; i += 100) {
+    const slice = ids.slice(i, i + 100);
+    // feedback carries the full substance in `description` (title is the 120-char truncated shell —
+    // never fall back to it). The feedback table has no detail/summary column.
+    const { data: fb, error: fbErr } = await sb.from('feedback').select('id, description').in('id', slice);
+    if (fbErr) { console.error('feedback lookup failed:', fbErr.message); process.exit(1); }
+    for (const f of (fb || [])) {
+      if (typeof f.description === 'string' && f.description.trim()) descById.set(f.id, f.description);
+    }
+  }
+
+  let recovered = 0, noSource = 0;
+  for (const c of candidates) {
+    const desc = descById.get(c.source_id);
+    if (!desc || desc.trim().length < MIN_RECOVERED_SUBSTANCE_LEN) {
+      noSource++;
+      log(`SKIP no-usable-source-description: ${c.id} (source ${c.source_id}) "${(c.title || '').slice(0, 50)}…"`);
+      continue;
+    }
+    recovered++;
+    log(`RECOVER: ${c.id} <- feedback ${c.source_id} (${desc.trim().length} chars)`);
+    if (APPLY) {
+      const md = { ...(c.metadata && typeof c.metadata === 'object' ? c.metadata : {}), description: desc };
+      const { error: upErr } = await sb.from('roadmap_wave_items').update({ metadata: md }).eq('id', c.id);
+      if (upErr) log(`  WRITE FAILED ${c.id}: ${upErr.message}`);
+    }
+  }
+  log(`SUMMARY: ${APPLY ? 'wrote' : 'would-write'}=${recovered} skipped-no-source=${noSource} total-candidates=${candidates.length}`);
+  if (!APPLY) log('re-run with --apply to perform the writes');
+}
+
+main().catch((e) => { console.error('fatal:', e?.message || e); process.exit(1); });

--- a/tests/unit/sourcing-engine/proactive-populator.test.js
+++ b/tests/unit/sourcing-engine/proactive-populator.test.js
@@ -141,6 +141,20 @@ describe('stageCorpus — HARD safeguards: dry-run default, chairman-gated, neve
     expect(row.lane).toBe('belt-ready'); // lanePresent -> lane stamped
   });
 
+  it('SD-LEO-INFRA-BELT-001-PART-001 (FR-3a): carries candidate description into metadata.description', async () => {
+    const db = fakeDb();
+    const withDesc = [{ corpus: 'harness_backlog', source_type: 'brainstorm', source_id: 'b1', title: 'X',
+      description: 'The full source substance recovered from feedback.description (well over the floor).', lane: 'belt-ready' }];
+    await stageCorpus(db, withDesc, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: true });
+    expect(db.inserted[0].metadata.description).toBe('The full source substance recovered from feedback.description (well over the floor).');
+  });
+
+  it('SD-LEO-INFRA-BELT-001-PART-001 (FR-3a): omits metadata.description when the candidate has none', async () => {
+    const db = fakeDb();
+    await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: true });
+    expect(db.inserted[0].metadata).not.toHaveProperty('description'); // no empty key forced
+  });
+
   it('idempotent: a 23505 unique-violation is treated as already-staged (skipped, not an error)', async () => {
     const db = fakeDb({ code: '23505', message: 'duplicate key' });
     const res = await stageCorpus(db, routed, { apply: true, chairmanApproved: true, waveId: 'wave-1', lanePresent: true });

--- a/tests/unit/sourcing-engine/refill-substance-recovery.test.js
+++ b/tests/unit/sourcing-engine/refill-substance-recovery.test.js
@@ -1,0 +1,90 @@
+/**
+ * SD-LEO-INFRA-BELT-001-PART-001 — FR-3 substance-recovery + FR-2 advisory cross-ref.
+ *
+ * Part-1 (PR #5012) rejected any 120-char truncated-title row as substance_thin, drying the belt by
+ * blocking 173 REAL staged items whose only flaw was that the populator dropped feedback.description.
+ * FR-3 carries the recovered description (metadata.description) and makes the substance check gate on
+ * it: a truncated title WITH substantial recovered content is now VALID; truncated WITHOUT it stays
+ * substance_thin (narrow lane). FR-2 adds a bounded ADVISORY shipped-SD cross-reference.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateRefillCandidate, REFILL_INVALID_REASONS,
+  hasRecoveredSubstance, MIN_RECOVERED_SUBSTANCE_LEN,
+  crossRefShippedTitleAdvisory, normalizeTitleForCompare, TITLE_TRUNCATION_CAP,
+} from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+
+// A 120-char truncated-title shell (the populator's truncation marker).
+const truncatedTitle = ('x'.repeat(TITLE_TRUNCATION_CAP - 3) + '...');
+const realDescription = 'The EVA scheduler poll loop throws CONTEXT_LOAD_FAILED on orphaned queue rows after the fixture purge; self-heal by evicting them.'; // ~130 chars
+
+const stagedTruncated = (over = {}) => ({
+  item_disposition: 'pending',
+  promoted_to_sd_key: null,
+  title: truncatedTitle,
+  source_type: 'brainstorm',
+  source_id: '22222222-2222-2222-2222-222222222222',
+  lane: 'belt',
+  ...over,
+});
+
+describe('FR-3: substance check gates on recovered description', () => {
+  it('truncated title WITH a substantial recovered metadata.description is VALID (recovery)', () => {
+    const r = evaluateRefillCandidate(stagedTruncated({ metadata: { description: realDescription } }));
+    expect(r).toEqual({ valid: true, reason: null });
+  });
+
+  it('truncated title WITHOUT a recovered description stays substance_thin (narrow lane preserved)', () => {
+    const r = evaluateRefillCandidate(stagedTruncated());
+    expect(r).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN });
+  });
+
+  it('truncated title with only a TRIVIAL description (< floor) stays substance_thin', () => {
+    const r = evaluateRefillCandidate(stagedTruncated({ metadata: { description: 'too short' } }));
+    expect(r).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN });
+  });
+
+  it('truncated title whose "description" is itself a truncation shell does NOT count as recovered', () => {
+    const r = evaluateRefillCandidate(stagedTruncated({ metadata: { description: truncatedTitle } }));
+    expect(r).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN });
+  });
+
+  it('a full-length (non-truncated) title is unaffected — never substance_thin', () => {
+    const r = evaluateRefillCandidate(stagedTruncated({ title: 'Harden the worktree reaper' }));
+    expect(r).toEqual({ valid: true, reason: null });
+  });
+});
+
+describe('FR-3: hasRecoveredSubstance (pure/total)', () => {
+  it('true only for a substantial, non-shell description (metadata or top-level)', () => {
+    expect(hasRecoveredSubstance({ metadata: { description: realDescription } })).toBe(true);
+    expect(hasRecoveredSubstance({ description: realDescription })).toBe(true);
+    expect(hasRecoveredSubstance({ metadata: { description: 'x'.repeat(MIN_RECOVERED_SUBSTANCE_LEN - 1) } })).toBe(false);
+    expect(hasRecoveredSubstance({ metadata: { description: truncatedTitle } })).toBe(false);
+  });
+  it('total on odd input', () => {
+    expect(hasRecoveredSubstance(null)).toBe(false);
+    expect(hasRecoveredSubstance(undefined)).toBe(false);
+    expect(hasRecoveredSubstance({})).toBe(false);
+    expect(hasRecoveredSubstance(42)).toBe(false);
+  });
+});
+
+describe('FR-2: crossRefShippedTitleAdvisory (bounded, advisory, pure)', () => {
+  const shipped = new Set([normalizeTitleForCompare('Harden the worktree reaper across all pools')]);
+  it('surfaces a truncated-prefix re-promotion of a shipped title', () => {
+    expect(crossRefShippedTitleAdvisory('Harden the worktree reaper', shipped)).toBeTruthy();
+  });
+  it('returns null for an unrelated title', () => {
+    expect(crossRefShippedTitleAdvisory('Add a brand-new marketing dashboard widget', shipped)).toBe(null);
+  });
+  it('is total on odd input (no set / non-set)', () => {
+    expect(crossRefShippedTitleAdvisory('anything', null)).toBe(null);
+    expect(crossRefShippedTitleAdvisory('anything', {})).toBe(null);
+    expect(crossRefShippedTitleAdvisory('', shipped)).toBe(null);
+  });
+  it('does NOT change the evaluateRefillCandidate verdict (advisory-only)', () => {
+    // A valid candidate stays valid regardless of any shipped cross-ref (advisory is caller-side).
+    expect(evaluateRefillCandidate(stagedTruncated({ metadata: { description: realDescription } })).valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Part-2 of the chairman-blessed auto-refill belt-quality design. Part-1 (PR #5012) added a `substance_thin` REJECT keyed on a 120-char truncated title — which **dried the belt** by rejecting **173** staged `roadmap_wave_items` whose only flaw was that the populator dropped `feedback.description`. Live-verified: those 173 feedback rows carry full 594-729-char descriptions; the title is just the 120-char shell.

## Changes
- **FR-3a** — `proactive-populator.js` `stageCorpus` carries the candidate description into `metadata.description` (`roadmap_wave_items` has no description column). `deriveSdFieldsFromRoadmapItem` already reads it → the promoted SD gets real substance, `needs_enrichment` shrinks.
- **FR-3b** — `evaluateRefillCandidate` `substance_thin` now fires **only** when the title is a truncation shell **AND** there's no substantial recovered description (`hasRecoveredSubstance` over `metadata.description`; `MIN_RECOVERED_SUBSTANCE_LEN` floor; a description that is itself a shell doesn't count). This only **loosens** the part-1 reject.
- **FR-3c** — `scripts/sourcing-engine/backfill-refill-descriptions.mjs`: one-shot, **dry-run-default**, visible + logged, reversible recovery of `feedback.description` onto the existing 173 rows. Dogfood dry-run: **would-write=173, skipped=0**. Running `--apply` is the operator's gated step (promotion stays behind `SOURCING_AUTO_REFILL_V1`).
- **FR-2** — `crossRefShippedTitleAdvisory`: bounded, advisory (log-only) normalized-prefix shipped-SD cross-reference complementing the exact-match lookalike axis; does not change the verdict.

## Testing
- +12 regression tests (both directions: truncated+description→valid; truncated+none→substance_thin)
- Existing predicate + populator suites green — **50 tests total**
- Dogfooded the backfill dry-run against live data (caught + fixed a wrong-column select)
- No DDL

🤖 Generated with [Claude Code](https://claude.com/claude-code)