### PR TITLE
fix(SD-REFILL-00FHK2ED): repoint eva:health to eva_scheduler_heartbeat

### DIFF
--- a/scripts/eva-health-check.cjs
+++ b/scripts/eva-health-check.cjs
@@ -11,16 +11,46 @@
 
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 
-const supabase = createSupabaseServiceClient();
+/**
+ * SD-REFILL-00FHK2ED: map an eva_scheduler_heartbeat row into the worker-shaped object the health
+ * report builder expects (eva:health was repointed off the never-provisioned eva_worker_heartbeats).
+ * Pure — no DB/clock. The report reads metadata.{consecutiveFailures,circuitBroken,totalRuns,totalErrors},
+ * which live as TOP-LEVEL columns on eva_scheduler_heartbeat, so synthesize them here.
+ * @param {{instance_id?:string,status?:string,last_poll_at?:string,circuit_breaker_state?:string,
+ *          poll_count?:number,dispatch_count?:number,error_count?:number,metadata?:object}} r
+ */
+function mapSchedulerHeartbeat(r) {
+  const row = r || {};
+  return {
+    worker_id: row.instance_id,
+    status: row.status,
+    last_heartbeat: row.last_poll_at,
+    metadata: {
+      ...(row.metadata && typeof row.metadata === 'object' ? row.metadata : {}),
+      consecutiveFailures: row.error_count || 0,
+      circuitBroken: String(row.circuit_breaker_state || '').toUpperCase() === 'OPEN',
+      totalRuns: row.poll_count || 0,
+      totalErrors: row.error_count || 0,
+    },
+  };
+}
+
+// Export the pure mapper for unit tests (require() must not run the CLI or create a DB client).
+module.exports = { mapSchedulerHeartbeat };
 
 const jsonMode = process.argv.includes('--json');
 
 async function main() {
-  // 1. Query worker heartbeats from eva_worker_heartbeats
-  const { data: heartbeats, error: hbError } = await supabase
-    .from('eva_worker_heartbeats')
-    .select('worker_id, status, last_heartbeat, metadata')
-    .order('last_heartbeat', { ascending: false });
+  const supabase = createSupabaseServiceClient();
+  // 1. Query scheduler heartbeats. SD-REFILL-00FHK2ED: repointed from the never-provisioned
+  // eva_worker_heartbeats to eva_scheduler_heartbeat (the table the scheduler actually writes).
+  // Normalize the scheduler-instance shape (instance_id / last_poll_at + top-level counters) into
+  // the worker-shaped rows the report builder below already expects, so downstream logic is unchanged.
+  const { data: schedRows, error: hbError } = await supabase
+    .from('eva_scheduler_heartbeat')
+    .select('instance_id, status, last_poll_at, circuit_breaker_state, poll_count, dispatch_count, error_count, metadata')
+    .order('last_poll_at', { ascending: false });
+  const heartbeats = (schedRows || []).map(mapSchedulerHeartbeat);
 
   // 2. Query recent alerts from workflow_executions (alert records)
   const { data: recentAlerts, error: alertError } = await supabase
@@ -37,12 +67,8 @@ async function main() {
     .eq('status', 'in_progress')
     .order('updated_at', { ascending: false });
 
-  // 4. Query stage execution worker heartbeat
-  const { data: sewHb } = await supabase
-    .from('eva_worker_heartbeats')
-    .select('*')
-    .eq('worker_id', 'stage-execution-worker')
-    .maybeSingle();
+  // (SD-REFILL-00FHK2ED) Removed the per-worker 'stage-execution-worker' heartbeat query: it read
+  // the never-provisioned eva_worker_heartbeats and its result (sewHb) was assigned but never used.
 
   const now = Date.now();
   const pollInterval = 30000; // DEFAULT_POLL_INTERVAL_MS
@@ -191,7 +217,9 @@ function statusIcon(status) {
   }
 }
 
-main().catch(err => {
-  console.error('Health check failed:', err.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Health check failed:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/eva-health-check.cjs
+++ b/scripts/eva-health-check.cjs
@@ -27,7 +27,9 @@ function mapSchedulerHeartbeat(r) {
     last_heartbeat: row.last_poll_at,
     metadata: {
       ...(row.metadata && typeof row.metadata === 'object' ? row.metadata : {}),
-      consecutiveFailures: row.error_count || 0,
+      // NOTE (RCA 8e4e76b2 F2): error_count is a LIFETIME cumulative counter, so it maps to
+      // totalErrors but NOT to consecutiveFailures (a distinct concept the scheduler heartbeat
+      // does not record) — reusing it there would falsely print "<lifetime> consecutive".
       circuitBroken: String(row.circuit_breaker_state || '').toUpperCase() === 'OPEN',
       totalRuns: row.poll_count || 0,
       totalErrors: row.error_count || 0,

--- a/tests/unit/eva-health-check-repoint.test.js
+++ b/tests/unit/eva-health-check-repoint.test.js
@@ -20,8 +20,9 @@ describe('mapSchedulerHeartbeat (SD-REFILL-00FHK2ED)', () => {
     expect(w.last_heartbeat).toBe('2026-06-21T22:00:00Z'); // last_poll_at
     expect(w.metadata.circuitBroken).toBe(false);  // CLOSED
     expect(w.metadata.totalRuns).toBe(120);        // poll_count
-    expect(w.metadata.totalErrors).toBe(2);        // error_count
-    expect(w.metadata.consecutiveFailures).toBe(2);
+    expect(w.metadata.totalErrors).toBe(2);        // error_count (lifetime cumulative)
+    // RCA F2: error_count is lifetime, NOT consecutive — must NOT be synthesized as consecutiveFailures
+    expect(w.metadata.consecutiveFailures).toBeUndefined();
     expect(w.metadata.foo).toBe('bar');            // existing metadata preserved
   });
 

--- a/tests/unit/eva-health-check-repoint.test.js
+++ b/tests/unit/eva-health-check-repoint.test.js
@@ -1,0 +1,44 @@
+/**
+ * SD-REFILL-00FHK2ED — eva:health repoint to eva_scheduler_heartbeat.
+ * Unit-tests the pure scheduler-row -> worker-shape mapper (no DB).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { mapSchedulerHeartbeat } = require('../../scripts/eva-health-check.cjs');
+
+describe('mapSchedulerHeartbeat (SD-REFILL-00FHK2ED)', () => {
+  it('maps the scheduler-instance shape into the worker shape the report expects', () => {
+    const r = {
+      instance_id: 'sched-1', status: 'running', last_poll_at: '2026-06-21T22:00:00Z',
+      circuit_breaker_state: 'CLOSED', poll_count: 120, dispatch_count: 40, error_count: 2,
+      metadata: { foo: 'bar' },
+    };
+    const w = mapSchedulerHeartbeat(r);
+    expect(w.worker_id).toBe('sched-1');           // instance_id -> name source
+    expect(w.status).toBe('running');
+    expect(w.last_heartbeat).toBe('2026-06-21T22:00:00Z'); // last_poll_at
+    expect(w.metadata.circuitBroken).toBe(false);  // CLOSED
+    expect(w.metadata.totalRuns).toBe(120);        // poll_count
+    expect(w.metadata.totalErrors).toBe(2);        // error_count
+    expect(w.metadata.consecutiveFailures).toBe(2);
+    expect(w.metadata.foo).toBe('bar');            // existing metadata preserved
+  });
+
+  it('OPEN circuit breaker -> circuitBroken true', () => {
+    expect(mapSchedulerHeartbeat({ circuit_breaker_state: 'OPEN' }).metadata.circuitBroken).toBe(true);
+    expect(mapSchedulerHeartbeat({ circuit_breaker_state: 'open' }).metadata.circuitBroken).toBe(true);
+    expect(mapSchedulerHeartbeat({ circuit_breaker_state: 'HALF_OPEN' }).metadata.circuitBroken).toBe(false);
+  });
+
+  it('is total on missing/odd input (counters default to 0)', () => {
+    const w = mapSchedulerHeartbeat({});
+    expect(w.metadata.totalRuns).toBe(0);
+    expect(w.metadata.totalErrors).toBe(0);
+    expect(w.metadata.circuitBroken).toBe(false);
+    expect(() => mapSchedulerHeartbeat(null)).not.toThrow();
+    expect(mapSchedulerHeartbeat(null).metadata.totalRuns).toBe(0);
+    // non-object metadata is ignored, not spread
+    expect(mapSchedulerHeartbeat({ metadata: 'x' }).metadata.totalErrors).toBe(0);
+  });
+});


### PR DESCRIPTION
## SD-REFILL-00FHK2ED — repoint eva:health to eva_scheduler_heartbeat

### Problem
`scripts/eva-health-check.cjs` queried the never-provisioned `eva_worker_heartbeats`, so `npm eva:health` errored / showed no workers.

### Fix (code-only — no DDL)
Repointed to `eva_scheduler_heartbeat` (the table the scheduler actually writes) via a pure exported `mapSchedulerHeartbeat()` that normalizes the scheduler-instance shape into the worker shape the report builder already expects. Deleted the dead `sewHb` query (assigned, never read). `main()` guarded behind `require.main` so the mapper is importable. Provisioning `eva_worker_heartbeats` was rejected — no producer ⇒ hollow empty table (and DDL is read-only here).

### Verification
- Live: `eva:health --json` now reports the real scheduler instance (running, healthy, ~1980 runs).
- 3 unit tests on the mapper. TESTING PASS; adversarial RCA CONDITIONAL_PASS (86).
- **RCA F2 fixed**: `error_count` is a lifetime counter → kept as `totalErrors`, dropped the misleading `consecutiveFailures` synthesis.
- Follow-ups flagged: F1 (HALF_OPEN breaker visibility — needs report-model change), F3 (no-workers PID fallback points at the legacy stage-worker), F4 (hardcoded pollInterval vs env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
