### PR TITLE
feat(SD-LEO-INFRA-VDR-GAUGE-BELT-001): vdr_gauge belt-safety guard + required passthrough

### DIFF
--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -34,9 +34,18 @@ export const REFILL_INVALID_REASONS = Object.freeze({
   // SD-LEO-INFRA-AUTO-REFILL-BELT-001 — belt-quality axes (run AFTER the structural axes above).
   SUBSTANCE_THIN: 'substance_thin',
   ALREADY_SHIPPED_LOOKALIKE: 'already_shipped_lookalike',
+  // SD-LEO-INFRA-VDR-GAUGE-BELT-001 (FR-1) — a raw-label source_type that the GENERAL funnel must not promote.
+  RAW_LABEL_SOURCE: 'raw_label_source',
 });
 
 const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
+
+// SD-LEO-INFRA-VDR-GAUGE-BELT-001 (FR-1): source_types whose staged items must NEVER be promoted by the
+// GENERAL auto-refill funnel — they belong to a SEPARATE, dedicated, flag-gated promoter. 'vdr_gauge'
+// items are the gauge-gap miner's domain; the source_type-blind funnel let 5 of them leak onto the belt
+// (miner flag OFF). CONSERVATIVE denylist (only proven raw-label types) — never an allowlist that could
+// block a legitimate new source. Case-insensitive compare.
+export const RAW_LABEL_SOURCE_TYPES = new Set(['vdr_gauge']);
 
 // SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-1): the proactive-populator truncates a long captured title to
 // 120 chars and appends a '...' ellipsis marker. Live ground truth: 173/staged-pending rows are EXACTLY
@@ -170,6 +179,13 @@ export function evaluateRefillCandidate(item, opts = {}) {
   }
   if (!nonEmpty(item.source_type) || !nonEmpty(item.source_id)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.MISSING_PROVENANCE };
+  }
+  // SD-LEO-INFRA-VDR-GAUGE-BELT-001 (FR-1): a raw-label source_type (vdr_gauge) belongs to a dedicated
+  // flag-gated promoter, NOT the general funnel — reject it here so the source_type-blind funnel can no
+  // longer leak those items onto the belt. Runs after MISSING_PROVENANCE so an empty source_type still
+  // reports the provenance reason first.
+  if (RAW_LABEL_SOURCE_TYPES.has(item.source_type.trim().toLowerCase())) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.RAW_LABEL_SOURCE };
   }
   // Never auto-promote a TEST/DEMO fixture into the real belt.
   if (FIXTURE_TITLE_RE.test(item.title) ||

--- a/lib/vision/vdr-registry.js
+++ b/lib/vision/vdr-registry.js
@@ -431,6 +431,11 @@ export async function computeBuildGauge({ io = {}, visionMarkdown, visionSource,
       detail: result.detail,
       value: result.value,
       score: STATUS_SCORE[result.status],
+      // SD-LEO-INFRA-VDR-GAUGE-BELT-001 (FR-2): pass the per-capability acceptance criterion through.
+      // vision_ladder_criteria.required is SELECTed by dbVisionSource (line ~263) and carried on the row
+      // but was previously DROPPED here — without it, capability-gap translation has no target to compare
+      // a probe's 'today' state against. Purely additive; scoring/availability are unchanged.
+      required: row.required == null ? '' : String(row.required),
     });
   }
 

--- a/tests/unit/sourcing-engine/refill-candidate-validity.test.js
+++ b/tests/unit/sourcing-engine/refill-candidate-validity.test.js
@@ -132,3 +132,20 @@ describe('evaluateRefillCandidate belt-quality axes', () => {
     expect(evaluateRefillCandidate(validItem(), {})).toEqual({ valid: true, reason: null });
   });
 });
+
+describe('evaluateRefillCandidate raw-label source guard (SD-LEO-INFRA-VDR-GAUGE-BELT-001 FR-1)', () => {
+  it('rejects a staged item whose source_type is the raw-label vdr_gauge', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: 'vdr_gauge' })))
+      .toEqual({ valid: false, reason: REFILL_INVALID_REASONS.RAW_LABEL_SOURCE });
+  });
+  it('is case-insensitive on source_type', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: 'VDR_GAUGE' })).reason).toBe(REFILL_INVALID_REASONS.RAW_LABEL_SOURCE);
+  });
+  it('does NOT block a normal source_type (no over-block)', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: 'conversion_ledger' }))).toEqual({ valid: true, reason: null });
+    expect(evaluateRefillCandidate(validItem({ source_type: 'brainstorm' }))).toEqual({ valid: true, reason: null });
+  });
+  it('a MISSING source_type still reports the provenance reason first (ordering preserved)', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: '' })).reason).toBe(REFILL_INVALID_REASONS.MISSING_PROVENANCE);
+  });
+});

--- a/tests/unit/vision/vdr-registry.test.js
+++ b/tests/unit/vision/vdr-registry.test.js
@@ -110,6 +110,15 @@ describe('computeBuildGauge (FR-1 numerator math + honest unknown handling)', ()
     for (const c of g.components) expect(STATUS_SCORE).toHaveProperty(c.status);
   });
 
+  it('SD-LEO-INFRA-VDR-GAUGE-BELT-001 FR-2: mapped components carry the per-capability `required` acceptance criterion', async () => {
+    const io = { supabase: stubSupabase({}) };
+    const g = await computeBuildGauge({ io, visionMarkdown: visionFixture() });
+    const mapped = g.components.filter((c) => c.layer !== 'unmapped');
+    expect(mapped.length).toBeGreaterThan(0);
+    // The fixture's "required cell" column is the acceptance criterion that was previously dropped.
+    for (const c of mapped) expect(c).toHaveProperty('required', 'required cell');
+  });
+
   it('FIX: all-unknown (0 probeable) ⇒ overall_pct=null + available:false (not a confident 0%)', async () => {
     // no supabase, no grep ⇒ every probe is 'unknown'
     const g = await computeBuildGauge({ io: {}, visionMarkdown: visionFixture() });


### PR DESCRIPTION
## SD-LEO-INFRA-VDR-GAUGE-BELT-001 — gauge belt-safety + translation-unblock

Smallest-safe first PR of the chairman-blessed gauge-driving plan. Closes a proven belt-safety leak and unblocks capability-gap translation — **no dependency on the deferred keystone, does not activate the gauge-gap miner**.

### FR-1 — belt-safety leak (source_type-blind funnel)
The general auto-refill funnel (`refill-cron.mjs` via the shared `evaluateRefillCandidate` SSOT) was `source_type`-blind, so raw-label `source_type='vdr_gauge'` staged items auto-promoted onto the belt — **5 already did** with the miner flag OFF, and the dormant interlock is disarmed (one flag-flip from re-flooding). Added a conservative `RAW_LABEL_SOURCE_TYPES` denylist (`{vdr_gauge}`) + `raw_label_source` reason, checked **after** `MISSING_PROVENANCE` (empty source_type still reports provenance first), case-insensitive. The miner remains `vdr_gauge`'s separate gated promoter.
- **Dogfood:** all 5 live `vdr_gauge` staged rows now return `raw_label_source`.

### FR-2 — translation-unblock (dropped acceptance criterion)
`vision_ladder_criteria.required` (26/26 rows) is SELECTed by `dbVisionSource` but was **dropped** from the `computeBuildGauge` component object (`vdr-registry.js` ~426-434). Passed it through (`required: row.required`, total on null) so capability-gap translation has the per-capability acceptance criterion to compare each probe's `today` against. **Purely additive** — scoring/availability unchanged.

### Verification
**47 LOC.** 44 targeted tests + full sourcing-engine suite (**205**) green; both new axes covered (vdr_gauge rejected / normal still promotes / ordering preserved; mapped components carry `required`). `node --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)