### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-CANDIDATE-001): reject non-buildable vdr_gauge source items

### DIFF
--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -31,10 +31,21 @@ export const REFILL_INVALID_REASONS = Object.freeze({
   MISSING_TITLE: 'missing_title',
   MISSING_PROVENANCE: 'missing_provenance',
   TEST_FIXTURE: 'test_fixture',
+  // SD-LEO-INFRA-AUTO-REFILL-CANDIDATE-001 — the SOURCE-TYPE class: some corpora are measurement/gauge
+  // tables whose "items" are desired-state criteria, not buildable engineering work.
+  NON_BUILDABLE_SOURCE: 'non_buildable_source',
   // SD-LEO-INFRA-AUTO-REFILL-BELT-001 — belt-quality axes (run AFTER the structural axes above).
   SUBSTANCE_THIN: 'substance_thin',
   ALREADY_SHIPPED_LOOKALIKE: 'already_shipped_lookalike',
 });
+
+// SD-LEO-INFRA-AUTO-REFILL-CANDIDATE-001 — source types that are NEVER buildable engineering work and
+// must never be auto-promoted onto the belt. vdr_gauge items come from vision_build_gauge (a metrics
+// table: overall_pct, total_capabilities, measured_at); their "titles" are vision-ladder CAPABILITY
+// CRITERIA (measured desired-states, e.g. "Governance cascade enforced") — no code target, no defect.
+// brainstorm / conversion_ledger / adam-direct sources remain buildable. Extend this set as new
+// non-buildable measurement/gauge corpora surface.
+export const NON_BUILDABLE_SOURCE_TYPES = new Set(['vdr_gauge']);
 
 const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
 
@@ -163,6 +174,14 @@ export function evaluateRefillCandidate(item, opts = {}) {
   // A lane explicitly routed away from the belt must never be auto-promoted.
   if (typeof item.lane === 'string' && item.lane.trim().toLowerCase() === 'decline') {
     return { valid: false, reason: REFILL_INVALID_REASONS.DECLINED_LANE };
+  }
+  // SD-LEO-INFRA-AUTO-REFILL-CANDIDATE-001: SOURCE-TYPE class — reject corpora that are non-buildable by
+  // nature (measurement/gauge desired-states, not engineering work). Runs after the lifecycle checks
+  // (an already-promoted/non-staged row still reports its lifecycle reason) and before the structural
+  // title/provenance checks (a non-buildable source is rejected regardless of how well-formed its
+  // fields are). Buildable corpora (brainstorm/conversion_ledger/adam-direct) fall straight through.
+  if (typeof item.source_type === 'string' && NON_BUILDABLE_SOURCE_TYPES.has(item.source_type.trim())) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.NON_BUILDABLE_SOURCE };
   }
   // Structural: an SD cannot be created without a title, and provenance must be traceable.
   if (!nonEmpty(item.title)) {

--- a/tests/unit/sourcing-engine/refill-candidate-validity.test.js
+++ b/tests/unit/sourcing-engine/refill-candidate-validity.test.js
@@ -3,7 +3,7 @@
  * Pins: the VALID staged case, every INVALID reason, lifecycle-first ordering, and totality on odd input.
  */
 import { describe, it, expect } from 'vitest';
-import { evaluateRefillCandidate, REFILL_INVALID_REASONS, isSubstanceThinTitle, normalizeTitleForCompare, TITLE_TRUNCATION_CAP } from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+import { evaluateRefillCandidate, REFILL_INVALID_REASONS, NON_BUILDABLE_SOURCE_TYPES, isSubstanceThinTitle, normalizeTitleForCompare, TITLE_TRUNCATION_CAP } from '../../../lib/sourcing-engine/refill-candidate-validity.js';
 
 // A well-formed staged refill candidate (the 683-item live shape: pending, unpromoted, real provenance).
 const validItem = (over = {}) => ({
@@ -130,5 +130,45 @@ describe('evaluateRefillCandidate belt-quality axes', () => {
   it('tolerates a malformed opts.shippedTitleSet (not a Set) without throwing', () => {
     expect(evaluateRefillCandidate(validItem(), { shippedTitleSet: ['not', 'a', 'set'] })).toEqual({ valid: true, reason: null });
     expect(evaluateRefillCandidate(validItem(), {})).toEqual({ valid: true, reason: null });
+  });
+});
+
+describe('evaluateRefillCandidate NON_BUILDABLE_SOURCE axis (SD-LEO-INFRA-AUTO-REFILL-CANDIDATE-001)', () => {
+  it('rejects a vdr_gauge source item (non_buildable_source)', () => {
+    const r = evaluateRefillCandidate(validItem({ source_type: 'vdr_gauge' }));
+    expect(r).toEqual({ valid: false, reason: REFILL_INVALID_REASONS.NON_BUILDABLE_SOURCE });
+  });
+
+  it('rejects vdr_gauge case/space-insensitively (trimmed)', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: ' vdr_gauge ' })).reason)
+      .toBe(REFILL_INVALID_REASONS.NON_BUILDABLE_SOURCE);
+  });
+
+  it('keeps buildable source types VALID (brainstorm / conversion_ledger / adam-direct)', () => {
+    for (const st of ['brainstorm', 'conversion_ledger', 'adam-direct']) {
+      expect(evaluateRefillCandidate(validItem({ source_type: st, source_id: 'sid-' + st })))
+        .toEqual({ valid: true, reason: null });
+    }
+  });
+
+  it('PRECEDENCE: a lifecycle reason (already_promoted / not_staged / declined_lane) wins over non_buildable_source', () => {
+    expect(evaluateRefillCandidate(validItem({ source_type: 'vdr_gauge', promoted_to_sd_key: 'SD-X-001' })).reason)
+      .toBe(REFILL_INVALID_REASONS.ALREADY_PROMOTED);
+    expect(evaluateRefillCandidate(validItem({ source_type: 'vdr_gauge', item_disposition: 'declined' })).reason)
+      .toBe(REFILL_INVALID_REASONS.NOT_STAGED);
+    expect(evaluateRefillCandidate(validItem({ source_type: 'vdr_gauge', lane: 'decline' })).reason)
+      .toBe(REFILL_INVALID_REASONS.DECLINED_LANE);
+  });
+
+  it('PRECEDENCE: non_buildable_source wins over the structural title/provenance checks', () => {
+    // a vdr_gauge item with an empty title still reports non_buildable_source (source-type fires first)
+    expect(evaluateRefillCandidate(validItem({ source_type: 'vdr_gauge', title: '' })).reason)
+      .toBe(REFILL_INVALID_REASONS.NON_BUILDABLE_SOURCE);
+  });
+
+  it('the set excludes the buildable corpora (guards against accidental over-broadening)', () => {
+    expect(NON_BUILDABLE_SOURCE_TYPES.has('vdr_gauge')).toBe(true);
+    expect(NON_BUILDABLE_SOURCE_TYPES.has('brainstorm')).toBe(false);
+    expect(NON_BUILDABLE_SOURCE_TYPES.has('conversion_ledger')).toBe(false);
   });
 });


### PR DESCRIPTION
Hardens the auto-refill candidate-validity SSOT (the -A predicate the whole flywheel reuses) to reject source_type=vdr_gauge as non_buildable_source. vdr_gauge comes from vision_build_gauge (a metrics table); its items are vision-ladder capability criteria, not buildable work — 4+ were deferred for product triage this session. The fix is the systemic root cause for that belt-flood class.

NON_BUILDABLE_SOURCE_TYPES set + reason; check placed after lifecycle / before structural; -B/-C inherit it (no consumer edits). +6 tests; 28/28 file, 207/207 sourcing-engine suite green. Live data: only 5 vdr_gauge items exist, all capability criteria; todoist/brainstorm/youtube unaffected.

Sub-agents PASS (EXEC + VERIFY): TESTING (mutation-verified precedence), VALIDATION (5 axes incl. live data), REGRESSION (additive 2-file diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)