### PR TITLE
feat(SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001): wire already-shipped prefix cross-ref into the promotion path (Phase 1 advisory)

### DIFF
--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -16,7 +16,29 @@
  */
 import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
 import { selectRefillBatch, promoteStagedCandidate } from '../../lib/sourcing-engine/refill-auto-promote.js';
-import { normalizeTitleForCompare } from '../../lib/sourcing-engine/refill-candidate-validity.js';
+import { pathToFileURL } from 'node:url';
+import { normalizeTitleForCompare, crossRefShippedTitleAdvisory } from '../../lib/sourcing-engine/refill-candidate-validity.js';
+
+/**
+ * SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001 (Phase 1 — ADVISORY): for a selected promotion batch, collect the
+ * titles that the bounded crossRefShippedTitleAdvisory flags as a PREFIX/lookalike of an already-shipped SD
+ * (a class the EXACT-match belt axis does NOT catch). ADVISORY ONLY — pure, no verdict change, no writes;
+ * the caller LOGS the result so the false-positive rate is measurable before Phase 2 promotes it to a reject.
+ * Pure/total: reuses the caller's once-per-run shippedTitleSet, O(batch × set).
+ * @param {Array<{title?:string, source_id?:string}>} batch  the selected refill batch
+ * @param {Set<string>} shippedTitleSet  normalizeTitleForCompare() keys of completed SD titles
+ * @returns {{ matches: Array<{title:string, source_id:(string|undefined), matched:string}>, byReason: object }}
+ */
+export function collectShippedTitleAdvisories(batch, shippedTitleSet) {
+  const matches = [];
+  for (const item of Array.isArray(batch) ? batch : []) {
+    if (!item || typeof item !== 'object') continue;
+    const matched = crossRefShippedTitleAdvisory(item.title, shippedTitleSet);
+    if (matched) matches.push({ title: item.title, source_id: item.source_id, matched });
+  }
+  const byReason = matches.length ? { ALREADY_SHIPPED_PREFIX_LOOKALIKE: matches.length } : {};
+  return { matches, byReason };
+}
 
 async function main() {
   const args = process.argv.slice(2);
@@ -59,6 +81,16 @@ async function main() {
 
   const sel = selectRefillBatch(rows || [], { limit, shippedTitleSet });
   const results = [];
+  // SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001 (Phase 1 — ADVISORY): wire the exported-but-unused
+  // crossRefShippedTitleAdvisory into the live promotion caller (its only production call site). It
+  // catches a staged title that is a PREFIX/lookalike of an already-shipped SD title — a class the
+  // EXACT-match belt axis (in selectRefillBatch/evaluateRefillCandidate) does NOT catch. Advisory ONLY:
+  // we LOG matches and surface a count so the false-positive rate is measurable, but we DO NOT change
+  // the verdict (no candidate is dropped). Promoting the match to a hard reject is Phase 2, gated on
+  // the measured FP rate. shippedTitleSet is REUSED (built once above), never a new full-corpus scan.
+  // Phase 1 advisory pass (pure helper) — surfaces lookalike matches WITHOUT changing any verdict.
+  const { matches: advisoryMatches, byReason: advisoryByReason } =
+    collectShippedTitleAdvisories(sel.batch, shippedTitleSet);
   for (const item of sel.batch) {
     // Gate 2 (write) flows through to the only writer; apply:false => dry-run no-op.
     results.push(await promoteStagedCandidate(supabase, item, { apply }));
@@ -70,14 +102,22 @@ async function main() {
       mode: apply ? 'apply' : 'dry_run',
       total: sel.total, validCount: sel.validCount, selected: sel.batch.length, limit: sel.limit,
       promoted, results,
+      advisoryByReason, advisoryMatches, // Phase 1 advisory (no verdict change) — for FP-rate measurement
     }, null, 2));
   } else {
     console.log(`🔁 Auto-refill cron (${apply ? 'APPLY' : 'DRY RUN'})`);
     console.log(`   staged scanned: ${sel.total} | valid: ${sel.validCount} | selected (≤${sel.limit}): ${sel.batch.length}`);
     console.log(apply ? `   ✅ promoted: ${promoted}` : `   would promote: ${sel.batch.length} (no writes — pass --apply)`);
     for (const r of results) console.log(`     - ${r.sd_key || '(none)'}: ${r.reason}`);
+    if (advisoryMatches.length) {
+      console.log(`   ⚠️  advisory (NOT enforced): ${advisoryMatches.length} selected title(s) look like an already-shipped SD:`);
+      for (const a of advisoryMatches) console.log(`        - "${a.title}" ~ shipped "${a.matched}"`);
+    }
   }
   process.exit(0);
 }
 
-main().catch((e) => { console.error('refill-cron error:', e.message); process.exit(2); });
+// Guard CLI execution so the module is importable for unit tests (no main()/DB-client on import).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => { console.error('refill-cron error:', e.message); process.exit(2); });
+}

--- a/tests/unit/sourcing-engine/refill-cron-advisory.test.js
+++ b/tests/unit/sourcing-engine/refill-cron-advisory.test.js
@@ -1,0 +1,52 @@
+/**
+ * SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001 (Phase 1) — wire crossRefShippedTitleAdvisory into the live
+ * promotion caller (scripts/sourcing-engine/refill-cron.mjs).
+ *
+ * The pure matcher already has coverage (refill-substance-recovery.test.js). These tests pin the WIRING
+ * helper collectShippedTitleAdvisories: it (a) flags a selected title that is a prefix/lookalike of a
+ * shipped SD, (b) surfaces a byReason-style count so the false-positive rate is measurable, and
+ * (c) is ADVISORY-ONLY — it never mutates the batch or any verdict. This closes the wired-to-fire gap:
+ * before this SD the matcher was exported but had ZERO production call sites.
+ */
+import { describe, it, expect } from 'vitest';
+import { collectShippedTitleAdvisories } from '../../../scripts/sourcing-engine/refill-cron.mjs';
+import { normalizeTitleForCompare } from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+
+const shipped = new Set([normalizeTitleForCompare('Harden the worktree reaper across all pools')]);
+
+describe('collectShippedTitleAdvisories (Phase 1 advisory wiring)', () => {
+  it('flags a selected title that is a prefix/lookalike of a shipped SD', () => {
+    const batch = [
+      { title: 'Harden the worktree reaper', source_id: 'a' },        // lookalike of shipped
+      { title: 'Add a brand-new marketing dashboard widget', source_id: 'b' }, // novel
+    ];
+    const { matches, byReason } = collectShippedTitleAdvisories(batch, shipped);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].title).toBe('Harden the worktree reaper');
+    expect(matches[0].source_id).toBe('a');
+    expect(matches[0].matched).toBeTruthy();
+    // byReason count makes the FP rate measurable from run output.
+    expect(byReason).toEqual({ ALREADY_SHIPPED_PREFIX_LOOKALIKE: 1 });
+  });
+
+  it('returns no matches / empty byReason when nothing looks shipped', () => {
+    const batch = [{ title: 'Add a brand-new marketing dashboard widget', source_id: 'b' }];
+    const { matches, byReason } = collectShippedTitleAdvisories(batch, shipped);
+    expect(matches).toEqual([]);
+    expect(byReason).toEqual({});
+  });
+
+  it('is advisory-only — does NOT mutate the batch', () => {
+    const batch = [{ title: 'Harden the worktree reaper', source_id: 'a' }];
+    const before = JSON.parse(JSON.stringify(batch));
+    collectShippedTitleAdvisories(batch, shipped);
+    expect(batch).toEqual(before);
+  });
+
+  it('is total on odd input (no batch / no set)', () => {
+    expect(collectShippedTitleAdvisories(null, shipped)).toEqual({ matches: [], byReason: {} });
+    expect(collectShippedTitleAdvisories([{ title: 'x' }], null)).toEqual({ matches: [], byReason: {} });
+    expect(collectShippedTitleAdvisories([null, 42, { title: 'x' }], shipped))
+      .toEqual({ matches: [], byReason: {} });
+  });
+});


### PR DESCRIPTION
## Summary
`crossRefShippedTitleAdvisory` was exported in `lib/sourcing-engine/refill-candidate-validity.js` but had **zero production callers** — a wired-to-fire gap. This wires it into the auto-refill cron (`scripts/sourcing-engine/refill-cron.mjs`), its only production call site, as an **advisory-only** pass.

It logs prefix/lookalike matches of staged candidate titles against already-shipped SD titles and surfaces a `byReason` count so the false-positive rate is measurable — **without changing any promotion verdict**. Enforcement (Phase 2 — a hard reject in `evaluateRefillCandidate`) is deferred until the FP rate is measured, and would conflict with the concurrently-editing sibling SD.

## Changes
- import `crossRefShippedTitleAdvisory` in `refill-cron.mjs`
- new pure exported `collectShippedTitleAdvisories(batch, shippedTitleSet)` → `{matches, byReason}`
- reuse the once-per-run `shippedTitleSet` (no new full-corpus scan)
- surface `advisoryByReason`/`advisoryMatches` in JSON + human output (verdict-neutral)
- guard `main()` with the standard ESM main-module check so the module is importable
- 4 vitest unit tests

## Verification
- TESTING sub-agent: PASS (4/4 new + 53/53 regression)
- Adversarial RCA: PASS — empirically confirmed wired-to-fire (advisory runs in dry-run path, not gated behind `--apply`), import does not run `main()`, fail-open no-op, verdict-neutral, count emitted on both output paths
- LOW scope-note: advisory does not accrue while the cron is **dormant** (Gate-1 `process.exit` precedes it — by deliberate "no DB queries when dormant" design); FP data accrues once `SOURCING_AUTO_REFILL_V1=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)