### PR TITLE
fix(QF-20260622-505): SELECT metadata in refill gate queries so description recovery works

### DIFF
--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -59,7 +59,7 @@ async function main() {
   const { data: rows, error } = await supabase
     .from('roadmap_wave_items')
     // lane is live (sourcing-engine activation migrations) but postdates the schema-reference snapshot.
-    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id') // schema-lint-disable-line
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id, metadata') // schema-lint-disable-line
     .eq('item_disposition', 'pending')
     .is('promoted_to_sd_key', null)
     .limit(1000);

--- a/scripts/sourcing-engine/refill-verify.mjs
+++ b/scripts/sourcing-engine/refill-verify.mjs
@@ -25,7 +25,7 @@ async function main() {
   // Staged = item_disposition='pending' AND not yet promoted. Read-only.
   const { data: rows, error } = await supabase
     .from('roadmap_wave_items')
-    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane')
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, metadata')
     .eq('item_disposition', 'pending')
     .is('promoted_to_sd_key', null)
     .limit(limit);

--- a/tests/unit/sourcing-engine/refill-select-metadata.test.js
+++ b/tests/unit/sourcing-engine/refill-select-metadata.test.js
@@ -1,0 +1,70 @@
+/**
+ * QF-20260622-505 — auto-refill gate query must SELECT metadata so description-recovery works.
+ *
+ * refill-cron.mjs and refill-verify.mjs both query roadmap_wave_items and pass each row verbatim to
+ * evaluateRefillCandidate. That predicate's substance check (hasRecoveredSubstance) reads
+ * metadata.description — the field the BELT-001-PART-001 backfill recovered into 173 truncated-title
+ * rows. If the SELECT list omits `metadata`, every row arrives with metadata=undefined, so
+ * hasRecoveredSubstance() returns false and every recovered row is rejected substance_thin — the
+ * backfill is inert. Same dropped-field class as the original BELT-001 bug.
+ *
+ * Two layers of guard:
+ *  1. Behavioural — a row carrying metadata.description >= the floor clears substance_thin (the
+ *     contract the SELECT must feed). Already covered for the predicate, re-pinned here as the
+ *     end-state these queries must produce.
+ *  2. Source pin — both live SELECT strings include `metadata`, so the dropped-field regression
+ *     cannot silently return (a behavioural test alone can't see what the SELECT omits).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  evaluateRefillCandidate, REFILL_INVALID_REASONS, TITLE_TRUNCATION_CAP,
+} from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+
+const truncatedTitle = ('x'.repeat(TITLE_TRUNCATION_CAP - 3) + '...');
+const recoveredDescription =
+  'The refill gate query dropped metadata, so recovered descriptions never reached the substance check.'; // >=40 chars
+
+const cronSrc = readFileSync(
+  fileURLToPath(new URL('../../../scripts/sourcing-engine/refill-cron.mjs', import.meta.url)), 'utf8');
+const verifySrc = readFileSync(
+  fileURLToPath(new URL('../../../scripts/sourcing-engine/refill-verify.mjs', import.meta.url)), 'utf8');
+
+// Extract the roadmap_wave_items .select('...') arguments from a source string. Keyed on
+// item_disposition (a roadmap_wave_items-only column) so the strategic_directives_v2 .select('title')
+// query in refill-cron.mjs is not mistaken for a staged-candidate query.
+const selectArgs = (src) =>
+  [...src.matchAll(/\.select\(\s*'([^']*)'/g)].map((m) => m[1]).filter((s) => /item_disposition/.test(s));
+
+describe('QF-20260622-505: refill SELECT carries metadata (description recovery is live)', () => {
+  it('a recovered metadata.description row clears substance_thin (the SELECT must feed this)', () => {
+    const row = {
+      item_disposition: 'pending', promoted_to_sd_key: null, title: truncatedTitle,
+      source_type: 'brainstorm', source_id: '22222222-2222-2222-2222-222222222222',
+      lane: 'belt', metadata: { description: recoveredDescription },
+    };
+    expect(evaluateRefillCandidate(row)).toEqual({ valid: true, reason: null });
+  });
+
+  it('the SAME row WITHOUT metadata (the bug) is wrongly rejected substance_thin', () => {
+    const row = {
+      item_disposition: 'pending', promoted_to_sd_key: null, title: truncatedTitle,
+      source_type: 'brainstorm', source_id: '22222222-2222-2222-2222-222222222222', lane: 'belt',
+    };
+    expect(evaluateRefillCandidate(row))
+      .toEqual({ valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN });
+  });
+
+  it('refill-cron.mjs SELECTs metadata from roadmap_wave_items', () => {
+    const args = selectArgs(cronSrc);
+    expect(args.length).toBeGreaterThan(0);
+    expect(args.every((a) => /\bmetadata\b/.test(a))).toBe(true);
+  });
+
+  it('refill-verify.mjs SELECTs metadata from roadmap_wave_items', () => {
+    const args = selectArgs(verifySrc);
+    expect(args.length).toBeGreaterThan(0);
+    expect(args.every((a) => /\bmetadata\b/.test(a))).toBe(true);
+  });
+});


### PR DESCRIPTION
## QF-20260622-505

`refill-cron.mjs` and `refill-verify.mjs` queried `roadmap_wave_items` without the `metadata` field, so each row reached `evaluateRefillCandidate` with `metadata=undefined`. `hasRecoveredSubstance()` then returned false for every truncated-title row, rejecting all 173 backfilled rows as `substance_thin` — rendering the BELT-001-PART-001 description backfill **inert**. Same dropped-field class as the original BELT-001 bug.

### Fix
- Add `metadata` to both `roadmap_wave_items` SELECT lists.
- New `refill-select-metadata.test.js`: behavioural (recovered `metadata.description` row clears `substance_thin`; same row without metadata is wrongly rejected) + source pin asserting both SELECTs carry `metadata` so the regression cannot silently return.

### Tests
- 4 new tests pass; full sourcing-engine suite 220/220 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)