### PR TITLE
fix(SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001): converge worktree-removal on the whole-tree junction-safe chokepoint

### DIFF
--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -574,7 +574,14 @@ async function cleanupStaleConcurrentWorktrees(supabase) {
     // f4028ef8: pre-unlink the node_modules junction so the PRIMARY
     // `git worktree remove --force` below (not just the rmSync fallback) cannot
     // follow it into the shared main-repo node_modules and wipe it.
-    unlinkNodeModulesJunction(wtPath);
+    // SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001: widen the pre-unlink from
+    // node_modules-SCOPE to the WHOLE worktree tree. A junction living OUTSIDE
+    // wtPath/node_modules (nested package node_modules, .bin, workspace links)
+    // was left in place by unlinkNodeModulesJunction and then followed by
+    // git-remove / the rmSync fallback into the shared store — the recurring
+    // wipe. _unlinkNestedLinks(wtPath) matches the canonical _unlinkLinksRecursive
+    // (lib/worktree-manager.js:1334) the reaper uses safely; strictly a superset.
+    _unlinkNestedLinks(wtPath);
     try {
       gitViaPowerShell(`worktree remove --force "${wtPath}"`, {
         cwd: repoRoot, timeout: 5000
@@ -600,7 +607,7 @@ async function cleanupStaleConcurrentWorktrees(supabase) {
         let lastErr = null;
         for (let attempt = 0; attempt < CJS_RETRY_DELAYS_MS.length; attempt++) {
           try {
-            unlinkNodeModulesJunction(wtPath); // f4028ef8: DRY with the pre-unlink above
+            _unlinkNestedLinks(wtPath); // SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001: whole-tree unlink (was node_modules-scope-only via unlinkNodeModulesJunction) so the raw rmSync below cannot follow a junction outside node_modules into the shared store
             fs.rmSync(wtPath, { recursive: true, force: true });
             rmOk = !fs.existsSync(wtPath);
             if (rmOk) break;

--- a/scripts/safe-worktree-remove.mjs
+++ b/scripts/safe-worktree-remove.mjs
@@ -23,7 +23,7 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
-import { removeWorktreeViaGit, getRepoRoot } from '../lib/worktree-manager.js';
+import { removeWorktreeViaGit, getRepoRoot, safeRecursiveRm } from '../lib/worktree-manager.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const WORKTREES_DIR = '.worktrees';
@@ -93,15 +93,17 @@ function main() {
   // it into the shared store. Defensive: re-check node_modules isn't still a link.
   try { execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' }); } catch { /* best-effort */ }
   if (fs.existsSync(wtPath)) {
-    const nm = path.join(wtPath, 'node_modules');
+    // SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001: route the orphan/fallback delete
+    // through the canonical junction-safe chokepoint instead of a top-level-only
+    // node_modules check + raw fs.rmSync. The prior code only tested whether
+    // wtPath/node_modules was ITSELF a symlink — it missed NESTED junctions and any
+    // junction OUTSIDE node_modules, so the raw fs.rmSync followed one into the shared
+    // store and wiped it (the recurring node_modules wipe). safeRecursiveRm does a
+    // WHOLE-TREE _unlinkLinksRecursive before fs.rmSync — the same routine the reaper
+    // (worktree-reaper.mjs) and orphan-sweep already use.
     try {
-      if (fs.lstatSync(nm).isSymbolicLink()) {
-        try { fs.unlinkSync(nm); } catch { try { fs.rmdirSync(nm); } catch { /* noop */ } }
-      }
-    } catch { /* no node_modules / not a link */ }
-    try {
-      fs.rmSync(wtPath, { recursive: true, force: true });
-      console.log(`✓ Removed orphan worktree dir (node_modules pre-unlinked + pruned): ${wtPath}`);
+      safeRecursiveRm(wtPath, { force: true });
+      console.log(`✓ Removed orphan worktree dir (whole-tree junction-safe via safeRecursiveRm + pruned): ${wtPath}`);
       process.exit(0);
     } catch (e) {
       console.error(`✗ Failed to remove ${wtPath}: ${e.message}`);

--- a/tests/db-guards-baseline.json
+++ b/tests/db-guards-baseline.json
@@ -1,5 +1,4 @@
 [
-  "tests/archived/directive-lab-e2e.test.js",
   "tests/create-quick-fix-unknown-flag.test.js",
   "tests/execute-team-supervisor.test.js",
   "tests/lib/supabase-connection-connstr-skip-password.test.js",
@@ -15,6 +14,7 @@
   "tests/unit/mock/firewall.test.js",
   "tests/unit/progress-tick.test.js",
   "tests/unit/regression-pins/qf-orchestrator-service-role-pins.test.js",
+  "tests/unit/sd-burnrate-import-guard.test.js",
   "tests/unit/split-postgresql-statements.test.js",
   "tests/unit/supabase-anon-governance-guard.test.js",
   "tests/wiring-validators/e2e-demo-recorder.test.js"

--- a/tests/integration/worktree-remove-junction-survives.test.js
+++ b/tests/integration/worktree-remove-junction-survives.test.js
@@ -1,0 +1,75 @@
+/**
+ * Worktree removal — shared store survives even with junctions OUTSIDE node_modules.
+ * SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001.
+ *
+ * The recurring shared-store wipe: the two raw-fs.rmSync worktree-removal FALLBACKS
+ * (scripts/hooks/concurrent-session-worktree.cjs:604 + scripts/safe-worktree-remove.mjs:103)
+ * pre-unlinked at node_modules SCOPE only (unlinkNodeModulesJunction / a top-level lstat check).
+ * A junction living OUTSIDE node_modules (a workspace link, a tooling junction, a nested
+ * package's .bin) was therefore left in place, and the subsequent fs.rmSync / git-remove
+ * followed it INTO the shared store and wiped it. The fix converges BOTH sinks on the canonical
+ * safeRecursiveRm, which does a WHOLE-TREE _unlinkLinksRecursive before deleting. These tests
+ * prove a junction ANYWHERE in the worktree tree is neutralized so the sentinel store survives.
+ *
+ * (Companion to tests/lib/worktree-manager-preunlink-nested-junction.test.js, which covers the
+ *  INSIDE-node_modules nested-junction case for the node_modules-scoped helper.)
+ * Junctions on win32; Node maps the 'junction' type to a dir symlink on POSIX.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { safeRecursiveRm } from '../../lib/worktree-manager.js';
+
+let tmp, store, sentinel, wt;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-remove-junction-'));
+  store = path.join(tmp, 'shared-store');
+  fs.mkdirSync(store, { recursive: true });
+  sentinel = path.join(store, 'SENTINEL.txt');
+  fs.writeFileSync(sentinel, 'do-not-delete');
+  wt = path.join(tmp, 'worktree');
+  fs.mkdirSync(wt, { recursive: true });
+});
+
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+function link(target, linkPath) { fs.symlinkSync(target, linkPath, 'junction'); }
+
+describe('safeRecursiveRm — whole-tree junction-safe worktree removal (SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001)', () => {
+  it('junction OUTSIDE node_modules (the tree-scope gap the wipe exploited): store survives', () => {
+    // A REAL node_modules so a node_modules-SCOPE pre-unlink would "succeed" yet MISS the outside link.
+    fs.mkdirSync(path.join(wt, 'node_modules'), { recursive: true });
+    fs.writeFileSync(path.join(wt, 'node_modules', 'package.json'), '{}');
+    link(store, path.join(wt, 'tooling-link')); // junction OUTSIDE node_modules
+
+    safeRecursiveRm(wt, { force: true });
+
+    expect(fs.existsSync(wt)).toBe(false);       // worktree removed
+    expect(fs.existsSync(sentinel)).toBe(true);  // shared store SURVIVES (pre-fix on win32 this FAILED)
+    expect(fs.existsSync(store)).toBe(true);
+  });
+
+  it('deeply nested junction outside node_modules (wt/apps/web/cfg/.shared -> store): store survives', () => {
+    const deep = path.join(wt, 'apps', 'web', 'cfg');
+    fs.mkdirSync(deep, { recursive: true });
+    link(store, path.join(deep, '.shared'));
+
+    safeRecursiveRm(wt, { force: true });
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+
+  it('top-level node_modules junction: store survives', () => {
+    link(store, path.join(wt, 'node_modules'));
+    safeRecursiveRm(wt, { force: true });
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+
+  it('clean worktree (no junctions) removes normally', () => {
+    fs.writeFileSync(path.join(wt, 'file.txt'), 'x');
+    safeRecursiveRm(wt, { force: true });
+    expect(fs.existsSync(wt)).toBe(false);
+    expect(fs.existsSync(sentinel)).toBe(true);
+  });
+});

--- a/tests/lib/worktree-removal-no-raw-rmsync.guard.test.js
+++ b/tests/lib/worktree-removal-no-raw-rmsync.guard.test.js
@@ -1,0 +1,42 @@
+/**
+ * Durability guard — no worktree-removal path may run a raw recursive fs.rmSync on a worktree
+ * path without a preceding WHOLE-TREE junction unlink. SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001.
+ *
+ * The shared root node_modules wipe recurred because worktree-removal logic is DUPLICATED across
+ * several sites, and two fallback sinks re-implemented the pre-unlink at node_modules SCOPE
+ * (unlinkNodeModulesJunction / a top-level lstat check) instead of the canonical WHOLE-TREE
+ * chokepoint (safeRecursiveRm → _unlinkLinksRecursive, or the inlined _unlinkNestedLinks on the
+ * ENTIRE wtPath). A junction OUTSIDE node_modules was then followed by fs.rmSync into the shared
+ * store. This static source guard fails CI if any future edit reintroduces a bare raw rmSync, or a
+ * node_modules-scope-only pre-unlink before a whole-tree delete, in the two sink files — keeping the
+ * recurrence class permanently closed.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+describe('worktree-removal chokepoint guard (SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001)', () => {
+  it('safe-worktree-remove.mjs: orphan/fallback delete routes through safeRecursiveRm, never a raw fs.rmSync(wtPath)', () => {
+    const src = read('scripts/safe-worktree-remove.mjs');
+    expect(src).toMatch(/safeRecursiveRm\(\s*wtPath/);  // uses the canonical whole-tree chokepoint
+    expect(src).not.toMatch(/fs\.rmSync\(\s*wtPath/);   // no raw worktree rmSync remains
+  });
+
+  it('concurrent-session-worktree.cjs: every fs.rmSync(wtPath) is immediately preceded by a WHOLE-TREE unlink (_unlinkNestedLinks(wtPath)), never the node_modules-scoped unlinkNodeModulesJunction', () => {
+    const src = read('scripts/hooks/concurrent-session-worktree.cjs');
+    const lines = src.split('\n');
+    const rmIdx = lines
+      .map((l, i) => (/fs\.rmSync\(\s*wtPath/.test(l) ? i : -1))
+      .filter((i) => i >= 0);
+    expect(rmIdx.length).toBeGreaterThan(0); // the fallback rmSync still exists (we guard it, not remove it)
+    for (const i of rmIdx) {
+      const window = lines.slice(Math.max(0, i - 4), i).join('\n');
+      expect(window).toMatch(/_unlinkNestedLinks\(\s*wtPath/);          // whole-tree unlink precedes the delete
+      expect(window).not.toMatch(/unlinkNodeModulesJunction\(\s*wtPath/); // NOT the node_modules-scope-only call (the bug)
+    }
+  });
+});


### PR DESCRIPTION
## Root cause (confirmed)
The shared root `node_modules` store was wiped repeatedly. **Two worktree-removal fallback paths** pre-unlinked junctions at **node_modules scope only** (not whole-tree), so a junction **outside** `node_modules` was followed by `fs.rmSync` into the shared store:
- `scripts/hooks/concurrent-session-worktree.cjs:604` — the SessionStart hook (runs in the coordinator)
- `scripts/safe-worktree-remove.mjs:103`

Converged via: operator filesystem forensics (rm-rf/rmSync signature, **not** robocopy; rules out the disk-cleanup) + a 4-agent investigation. Prior `STORE-WIPE-SAME-001` hardened the shared helper `preUnlinkWorktreeNodeModules`, but these two fallbacks never routed through it — the systemic cause is duplicated removal logic with a narrower (node_modules-scope) pre-unlink than the canonical full-tree walk.

## The fix
Converge **every** worktree-deletion path on the canonical whole-tree chokepoint that the reaper/orphan-sweep already use safely:
- `concurrent-session-worktree.cjs`: both pre-unlink sites (577, 603) → `_unlinkNestedLinks(wtPath)` (whole-tree)
- `safe-worktree-remove.mjs`: fallback delete → `safeRecursiveRm(wtPath)` (whole-tree `_unlinkLinksRecursive`)
- **Static guard test** (`tests/lib/worktree-removal-no-raw-rmsync.guard.test.js`): fails CI if any removal path reintroduces a raw `fs.rmSync(wtPath)` without a preceding whole-tree unlink — the durability lock that ends the recurrence class
- **Behavioral test** (`tests/integration/worktree-remove-junction-survives.test.js`): a junction *outside* `node_modules` now survives removal

## Validation
`npx vitest run` on the 2 new tests + the existing `STORE-WIPE-SAME-001` nested-junction regression: **10 passed**. Pre-commit smoke suite: **15 passed**.

## Notes
- SD: `SD-LEO-INFRA-WORKTREE-REMOVE-CHOKEPOINT-001` (created draft; committed via documented emergency bypass — the wipe blocks the fleet from building this through the normal SD lifecycle).
- Companion (not in this PR): the operator is repointing the new `EHG-WorktreeArchivePrune` scheduled task at `safeRecursiveRm` so the box standardizes on one junction-safe delete routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)