### PR TITLE
fix(SD-LEO-INFRA-REFILL-SELECT-METADATA-001): select metadata so the auto-refill belt promotes recovered descriptions

### DIFF
--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -211,7 +211,9 @@ async function main() {
   let promotableCount = 0;
   try {
     const { data: staged, error: se } = await db.from('roadmap_wave_items')
-      .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane')
+      // SD-LEO-INFRA-REFILL-SELECT-METADATA-001: select metadata so verifyStagedCandidates' promotableCount
+      // reflects recovered descriptions (hasRecoveredSubstance reads item.metadata.description).
+      .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, metadata')
       .eq('item_disposition', 'pending').is('promoted_to_sd_key', null).limit(2000);
     if (!se) promotableCount = verifyStagedCandidates(staged || []).validCount;
   } catch { /* fail-open → promotableCount stays 0, no advisory */ }

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -59,7 +59,10 @@ async function main() {
   const { data: rows, error } = await supabase
     .from('roadmap_wave_items')
     // lane is live (sourcing-engine activation migrations) but postdates the schema-reference snapshot.
-    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id') // schema-lint-disable-line
+    // SD-LEO-INFRA-REFILL-SELECT-METADATA-001: metadata MUST be selected — hasRecoveredSubstance reads
+    // item.metadata.description; without it the gate sees undefined and rejects every recovered row as
+    // substance_thin, so the belt promotes 0 even after the description backfill wrote 173 of them.
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, wave_id, metadata') // schema-lint-disable-line
     .eq('item_disposition', 'pending')
     .is('promoted_to_sd_key', null)
     .limit(1000);

--- a/scripts/sourcing-engine/refill-verify.mjs
+++ b/scripts/sourcing-engine/refill-verify.mjs
@@ -25,7 +25,9 @@ async function main() {
   // Staged = item_disposition='pending' AND not yet promoted. Read-only.
   const { data: rows, error } = await supabase
     .from('roadmap_wave_items')
-    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane')
+    // SD-LEO-INFRA-REFILL-SELECT-METADATA-001: select metadata so hasRecoveredSubstance can read
+    // item.metadata.description — else every recovered row is wrongly rejected substance_thin.
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, metadata')
     .eq('item_disposition', 'pending')
     .is('promoted_to_sd_key', null)
     .limit(limit);

--- a/tests/lib/refill-select-metadata.test.js
+++ b/tests/lib/refill-select-metadata.test.js
@@ -1,0 +1,65 @@
+/**
+ * SD-LEO-INFRA-REFILL-SELECT-METADATA-001 — the auto-refill SELECTs MUST fetch `metadata`.
+ *
+ * The bug: refill-cron.mjs, refill-verify.mjs, and coordinator-charter-audit.mjs SELECTed
+ * roadmap_wave_items WITHOUT the `metadata` field. So hasRecoveredSubstance read
+ * item.metadata.description = undefined and the gate rejected every recovered row as
+ * substance_thin — the belt promoted 0 even after the backfill wrote 173 descriptions.
+ *
+ * A PURE hasRecoveredSubstance test passes pre-fix and MISSES this entire class (the gate logic
+ * was always correct — the QUERY was blind). So the primary guard is QUERY-SHAPED: assert each
+ * roadmap_wave_items SELECT carries `metadata`. The behavioral test then proves the end-to-end:
+ * a truncated-title row WITH metadata.description promotes; the same row WITHOUT it is rejected.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { verifyStagedCandidates } from '../../lib/sourcing-engine/refill-dry-run-verifier.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+const SELECT_SITES = [
+  'scripts/sourcing-engine/refill-cron.mjs',
+  'scripts/sourcing-engine/refill-verify.mjs',
+  'scripts/coordinator-charter-audit.mjs',
+];
+
+describe('auto-refill query carries metadata (SD-LEO-INFRA-REFILL-SELECT-METADATA-001)', () => {
+  // QUERY-SHAPED durability guard: every roadmap_wave_items .select() that reads the staged corpus
+  // (identified by item_disposition) must include `metadata` — else the gate goes blind again.
+  for (const f of SELECT_SITES) {
+    it(`${f}: the staged roadmap_wave_items SELECT includes metadata`, () => {
+      const src = read(f);
+      const selectLines = src
+        .split('\n')
+        .filter((l) => /\.select\(/.test(l) && /item_disposition/.test(l));
+      expect(selectLines.length, `expected a staged-corpus .select() in ${f}`).toBeGreaterThan(0);
+      for (const line of selectLines) {
+        expect(line, `${f}: staged .select() must carry metadata`).toMatch(/\bmetadata\b/);
+      }
+    });
+  }
+
+  // BEHAVIORAL: the gate honors recovered substance — a truncated-title row WITH metadata.description
+  // promotes; the same row WITHOUT it is rejected substance_thin. Proves the SELECT fix is load-bearing.
+  it('a truncated-title staged row promotes WITH metadata.description and is rejected WITHOUT it', () => {
+    const truncated = 'x'.repeat(125) + '...'; // >=120 chars ending in an ellipsis = a substance_thin shell
+    const recovered = 'A genuine recovered feedback description, comfortably over forty characters long.';
+    const base = {
+      id: 'rwi-test-1',
+      title: truncated,
+      source_type: 'manual_feedback',
+      source_id: 'fb-test-1',
+      item_disposition: 'pending',
+    };
+    const opts = { shippedTitleSet: new Set() };
+
+    const withMeta = verifyStagedCandidates([{ ...base, metadata: { description: recovered } }], opts);
+    const withoutMeta = verifyStagedCandidates([{ ...base, metadata: {} }], opts);
+
+    expect(withMeta.validCount).toBe(1); // recovered substance present -> promotes
+    expect(withoutMeta.validCount).toBe(0); // no recovered substance -> substance_thin reject
+  });
+});


### PR DESCRIPTION
## Root cause
The auto-refill gate was **blind**: `refill-cron.mjs:62`, `refill-verify.mjs:28`, and `coordinator-charter-audit.mjs:214` SELECTed `roadmap_wave_items` **without `metadata`**. `hasRecoveredSubstance` reads `item.metadata.description`, so it saw `undefined` and rejected every recovered row as `substance_thin` — the belt promoted **0** even after the BELT-001 backfill wrote **173** real descriptions. (Re-file of the lost QF-20260622-505.)

## Fix
- Add `metadata` to all 3 staged-corpus SELECTs.
- `tests/lib/refill-select-metadata.test.js`: **query-shaped guard** (each staged SELECT must carry `metadata` — a pure `hasRecoveredSubstance` test passes pre-fix and *misses* the class) + a **behavioral** test (a truncated-title row promotes *with* `metadata.description`, is rejected *without* it).

## Validation
`npx vitest run tests/lib/refill-select-metadata.test.js` → **4 passed**.

## Impact
Unblocks the build-out belt — the ~92 recovered brainstorm items now flow to idle workers (the gauge-moving build work). Companion to #5032 (env) — together they unblock the build pipeline.

SD `SD-LEO-INFRA-REFILL-SELECT-METADATA-001` (committed via documented emergency bypass — harness-bootstrap pipeline-unblock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)