### PR TITLE
fix(QF-20260622-620): SELECT metadata in coordinator-charter-audit (3rd/last refill-gate site)

### DIFF
--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -211,7 +211,10 @@ async function main() {
   let promotableCount = 0;
   try {
     const { data: staged, error: se } = await db.from('roadmap_wave_items')
-      .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane')
+      // QF-20260622-620: select metadata so promotableCount reflects recovered descriptions
+      // (hasRecoveredSubstance reads item.metadata.description). 3rd/last blind site after PR #5030
+      // fixed refill-cron.mjs + refill-verify.mjs; without it this advisory under-counts the belt.
+      .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, lane, metadata')
       .eq('item_disposition', 'pending').is('promoted_to_sd_key', null).limit(2000);
     if (!se) promotableCount = verifyStagedCandidates(staged || []).validCount;
   } catch { /* fail-open → promotableCount stays 0, no advisory */ }

--- a/tests/unit/sourcing-engine/refill-select-metadata.test.js
+++ b/tests/unit/sourcing-engine/refill-select-metadata.test.js
@@ -30,6 +30,10 @@ const cronSrc = readFileSync(
   fileURLToPath(new URL('../../../scripts/sourcing-engine/refill-cron.mjs', import.meta.url)), 'utf8');
 const verifySrc = readFileSync(
   fileURLToPath(new URL('../../../scripts/sourcing-engine/refill-verify.mjs', import.meta.url)), 'utf8');
+// QF-20260622-620: the 3rd staged-corpus SELECT — coordinator-charter-audit.mjs feeds verifyStagedCandidates
+// to compute promotableCount (the auto-refill-backlog advisory), so it must carry metadata too.
+const charterAuditSrc = readFileSync(
+  fileURLToPath(new URL('../../../scripts/coordinator-charter-audit.mjs', import.meta.url)), 'utf8');
 
 // Extract the roadmap_wave_items .select('...') arguments from a source string. Keyed on
 // item_disposition (a roadmap_wave_items-only column) so the strategic_directives_v2 .select('title')
@@ -64,6 +68,13 @@ describe('QF-20260622-505: refill SELECT carries metadata (description recovery 
 
   it('refill-verify.mjs SELECTs metadata from roadmap_wave_items', () => {
     const args = selectArgs(verifySrc);
+    expect(args.length).toBeGreaterThan(0);
+    expect(args.every((a) => /\bmetadata\b/.test(a))).toBe(true);
+  });
+
+  // QF-20260622-620: the 3rd/last blind site — the coordinator's own promotableCount advisory.
+  it('coordinator-charter-audit.mjs SELECTs metadata from roadmap_wave_items', () => {
+    const args = selectArgs(charterAuditSrc);
     expect(args.length).toBeGreaterThan(0);
     expect(args.every((a) => /\bmetadata\b/.test(a))).toBe(true);
   });


### PR DESCRIPTION
## Context
Follow-up to #5030 (QF-505), which fixed `refill-cron.mjs` + `refill-verify.mjs` to SELECT `metadata` so the auto-refill gate honors the 173 backfilled descriptions. **The belt is unblocked — live `refill-verify.mjs --json` reports `validCount: 92`.**

This is the **3rd and last** staged-corpus SELECT that was still blind: `coordinator-charter-audit.mjs:214`. It feeds `verifyStagedCandidates(...).validCount` → `promotableCount` → `detectAutoRefillBacklog` (the coordinator's *own* "belt can be refilled" advisory). Without `metadata`, `hasRecoveredSubstance` saw `undefined` and the coordinator **under-counted** promotable belt items — a spurious belt-is-thin signal.

## Fix
- Add `metadata` to the line-214 SELECT field list.
- Extend #5030's `tests/unit/sourcing-engine/refill-select-metadata.test.js` with a 3rd source-pin (one test file, all 3 sites guarded — no duplicate test file).

## Validation
`npx vitest run tests/unit/sourcing-engine/refill-select-metadata.test.js` → **5 passed**.

QF-20260622-620 (Tier 1, ~15 LOC). Supersedes the closed #5033 (which duplicated #5030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)