### PR TITLE
fix(SD-REFILL-00QQ60BN): stamp verification cols in complete-quick-fix already-MERGED reconcile

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -43,6 +43,32 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 /**
+ * SD-REFILL-00QQ60BN: build the quick_fixes UPDATE payload for the already-MERGED reconcile path.
+ * The completed_requires_verification CHECK requires (tests_passing AND uat_verified) OR
+ * force_completed for status='completed'. A QF whose verification columns were never stamped
+ * pre-merge would otherwise fail this update forever ("Could not reconcile QF record (non-fatal)"
+ * on every re-run; QF stuck in_progress with a merged PR). A merged PR is the CI witness, so
+ * tests_passing=true is justified; UAT does not run in this reconcile path, so the CHECK is
+ * satisfied via force_completed=true + an appended audit note rather than fabricating uat_verified.
+ * Pure: no DB/clock access — the caller passes nowIso.
+ * @param {{ qf?:object, prUrl:string, mergeSha?:string|null, nowIso:string }} args
+ * @returns {object} the UPDATE payload
+ */
+export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso }) {
+  const reconcileNote = `Reconciled to completed from already-MERGED PR ${prUrl} (SD-REFILL-00QQ60BN merged-PR witness; UAT not re-run in reconcile path).`;
+  const verification_notes = [qf.verification_notes, reconcileNote].filter(Boolean).join(' | ');
+  return {
+    status: 'completed',
+    pr_url: prUrl,
+    commit_sha: mergeSha,
+    tests_passing: true,
+    force_completed: true,
+    verification_notes,
+    completed_at: qf.completed_at || nowIso
+  };
+}
+
+/**
  * Main orchestration function for completing quick-fixes
  * @param {string} qfId - Quick-fix ID
  * @param {object} options - Completion options
@@ -144,20 +170,20 @@ export async function completeQuickFix(qfId, options = {}) {
       if (meta && meta.state === 'MERGED') {
         console.log(`\n✅ PR #${probePrNumber} is already MERGED — reconciling ${qfId} to completed (idempotent re-run short-circuit).\n`);
         const mergeSha = meta.mergeCommit?.oid || qf.commit_sha || null;
+        // SD-REFILL-00QQ60BN: stamp the verification columns the completed_requires_verification
+        // CHECK demands so this reconcile no longer fails forever for an un-stamped QF.
+        const reconcileUpdate = buildMergedReconcileUpdate({
+          qf, prUrl: probePrUrl, mergeSha, nowIso: new Date().toISOString()
+        });
         const { error: reconcileErr } = await supabase
           .from('quick_fixes')
-          .update({
-            status: 'completed',
-            pr_url: probePrUrl,
-            commit_sha: mergeSha,
-            completed_at: qf.completed_at || new Date().toISOString()
-          })
+          .update(reconcileUpdate)
           .eq('id', qfId)
           .neq('status', 'completed');
         if (reconcileErr) {
           console.log(`   ⚠️  Could not reconcile QF record (non-fatal): ${reconcileErr.message}`);
         }
-        return { ...qf, status: 'completed', pr_url: probePrUrl, commit_sha: mergeSha };
+        return { ...qf, ...reconcileUpdate };
       }
     } catch (e) {
       console.log(`   ℹ️  Already-merged probe skipped (will run normal pipeline): ${e.message}`);

--- a/tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js
+++ b/tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js
@@ -143,7 +143,11 @@ describe('FR-4 already-MERGED probe', () => {
   });
 
   it('reconciles the QF to completed and returns early on MERGED', () => {
-    expect(orchSrc).toMatch(/status:\s*'completed'[\s\S]{0,200}\.eq\('id',\s*qfId\)[\s\S]{0,80}\.neq\('status',\s*'completed'\)/);
+    // SD-REFILL-00QQ60BN: the reconcile UPDATE payload is now built by buildMergedReconcileUpdate
+    // (which stamps the verification columns the completed_requires_verification CHECK demands) and
+    // applied via .update(reconcileUpdate). Pin the call + the targeting clauses.
+    expect(orchSrc).toMatch(/buildMergedReconcileUpdate\(\{[\s\S]{0,160}qf,[\s\S]{0,160}\}\)/);
+    expect(orchSrc).toMatch(/\.update\(reconcileUpdate\)[\s\S]{0,80}\.eq\('id',\s*qfId\)[\s\S]{0,80}\.neq\('status',\s*'completed'\)/);
     // The probe must return BEFORE autoDetectGitInfo (which is the next major step).
     const probeIdx = orchSrc.indexOf("meta.state === 'MERGED'");
     const autodetectIdx = orchSrc.indexOf('autoDetectGitInfo(testDir, options)');

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -1,0 +1,59 @@
+// SD-REFILL-00QQ60BN — the already-MERGED reconcile path (orchestrator.js) set status='completed'
+// WITHOUT stamping the verification columns, so the completed_requires_verification CHECK
+//   (status='completed') AND ((tests_passing AND uat_verified) OR force_completed)
+// rejected the UPDATE forever for any QF not pre-stamped — the reconcile printed
+// "Could not reconcile QF record (non-fatal)" on every re-run and the QF stayed in_progress with
+// a merged PR (witnessed on QF-20260610-541 / PR #4587). buildMergedReconcileUpdate now stamps
+// tests_passing=true (merged PR = CI witness) + force_completed=true + an audit note, satisfying
+// the CHECK without fabricating uat_verified.
+
+import { describe, it, expect } from 'vitest';
+import { buildMergedReconcileUpdate } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
+
+// Mirror of the live completed_requires_verification CHECK predicate (asserted against the DB
+// constraint def: (tests_passing AND uat_verified) OR force_completed when status='completed').
+const satisfiesCheck = (u) =>
+  u.status !== 'completed' || ((u.tests_passing === true && u.uat_verified === true) || u.force_completed === true);
+
+describe('buildMergedReconcileUpdate (SD-REFILL-00QQ60BN)', () => {
+  const prUrl = 'https://github.com/rickfelix/EHG_Engineer/pull/4587';
+  const nowIso = '2026-06-22T16:00:00.000Z';
+
+  it('produces an UPDATE that satisfies completed_requires_verification for an un-stamped QF', () => {
+    const qf = { tests_passing: null, uat_verified: null, force_completed: null, verification_notes: null };
+    const u = buildMergedReconcileUpdate({ qf, prUrl, mergeSha: 'abc123', nowIso });
+    expect(u.status).toBe('completed');
+    expect(u.force_completed).toBe(true);      // the CHECK escape used — UAT did not re-run here
+    expect(u.tests_passing).toBe(true);        // merged PR = CI witness
+    expect(satisfiesCheck(u)).toBe(true);
+  });
+
+  it('does NOT fabricate uat_verified (honest reconcile — force_completed carries the CHECK)', () => {
+    const u = buildMergedReconcileUpdate({ qf: {}, prUrl, mergeSha: null, nowIso });
+    expect(u.uat_verified).toBeUndefined();
+  });
+
+  it('records an audit note referencing the merged PR', () => {
+    const u = buildMergedReconcileUpdate({ qf: {}, prUrl, mergeSha: null, nowIso });
+    expect(u.verification_notes).toContain(prUrl);
+    expect(u.verification_notes).toMatch(/merged/i);
+  });
+
+  it('appends to (does not clobber) an existing verification_notes', () => {
+    const u = buildMergedReconcileUpdate({ qf: { verification_notes: 'prior note' }, prUrl, mergeSha: null, nowIso });
+    expect(u.verification_notes.startsWith('prior note | ')).toBe(true);
+    expect(u.verification_notes).toContain(prUrl);
+  });
+
+  it('preserves an existing completed_at and falls back to nowIso otherwise', () => {
+    expect(buildMergedReconcileUpdate({ qf: { completed_at: '2026-01-01T00:00:00.000Z' }, prUrl, nowIso }).completed_at)
+      .toBe('2026-01-01T00:00:00.000Z');
+    expect(buildMergedReconcileUpdate({ qf: {}, prUrl, nowIso }).completed_at).toBe(nowIso);
+  });
+
+  it('carries pr_url and mergeSha through', () => {
+    const u = buildMergedReconcileUpdate({ qf: {}, prUrl, mergeSha: 'deadbeef', nowIso });
+    expect(u.pr_url).toBe(prUrl);
+    expect(u.commit_sha).toBe('deadbeef');
+  });
+});


### PR DESCRIPTION
## SD-REFILL-00QQ60BN

The already-MERGED reconcile path in `complete-quick-fix/orchestrator.js` set `status='completed'` **without** stamping the columns the `completed_requires_verification` CHECK demands — `(tests_passing AND uat_verified) OR force_completed`. For any QF whose verification columns were never stamped pre-merge, the reconcile UPDATE was rejected by the CHECK, printing `Could not reconcile QF record (non-fatal)` on every re-run and leaving the QF stuck `in_progress` with a merged PR (witnessed on QF-20260610-541 / PR #4587).

### Fix
- Extract pure `buildMergedReconcileUpdate({qf, prUrl, mergeSha, nowIso})` that stamps `tests_passing=true` (merged PR = CI witness) + `force_completed=true` + an appended audit note — satisfying the CHECK **without fabricating** `uat_verified`.
- Reconcile path calls the helper; early-return spreads the payload.
- No schema change.

### Tests
- 6 new unit tests (`merged-reconcile-verification.test.js`) incl. a mirror of the live CHECK predicate.
- FR-4 already-MERGED source-pin updated to the refactored shape.
- Full complete-quick-fix unit suite: 221/221 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)