### PR TITLE
fix(SD-REFILL-002XLOD1): un-quarantine 7 supabase-mock-chain unit tests via strict chainable mock helper

### DIFF
--- a/lib/llm/usage-logger.test.js
+++ b/lib/llm/usage-logger.test.js
@@ -6,8 +6,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock Supabase
+// The from() builder must support BOTH the model_usage_log insert path AND the
+// FR-3 sd_id fallback read (`from('claude_sessions').select().eq().maybeSingle()`).
+// A bare `{ insert }` broke the read chain with "db.from(...).select is not a
+// function"; this builder keeps the insert spy and adds a chainable select path.
 const mockInsert = vi.fn();
-const mockFrom = vi.fn(() => ({ insert: mockInsert }));
+const mockFrom = vi.fn(() => ({
+  insert: mockInsert,
+  select: vi.fn(() => ({
+    eq: vi.fn(() => ({
+      maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    })),
+  })),
+}));
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({ from: mockFrom }))
@@ -17,15 +28,21 @@ vi.mock('@supabase/supabase-js', () => ({
 process.env.SUPABASE_URL = 'https://test.supabase.co';
 process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
 
-const { logUsage } = await import('./usage-logger.js');
+const { logUsage, _resetClaimCacheForTest } = await import('./usage-logger.js');
+
+// logUsage is fire-and-forget: the model_usage_log insert runs in microtasks
+// after the FR-3 sd_id fallback (claude_sessions read) resolves. Flush the
+// microtask/timer queue so the insert has actually been issued before asserting.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('logUsage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetClaimCacheForTest();
     mockInsert.mockResolvedValue({ error: null });
   });
 
-  it('inserts a row into model_usage_log', () => {
+  it('inserts a row into model_usage_log', async () => {
     logUsage({
       model: 'gemini-2.5-pro',
       provider: 'google',
@@ -34,6 +51,7 @@ describe('logUsage', () => {
       outputTokens: 50,
       durationMs: 1200
     });
+    await flush();
 
     expect(mockFrom).toHaveBeenCalledWith('model_usage_log');
     expect(mockInsert).toHaveBeenCalledWith(
@@ -52,8 +70,9 @@ describe('logUsage', () => {
     );
   });
 
-  it('includes cache_hit flag when true', () => {
+  it('includes cache_hit flag when true', async () => {
     logUsage({ model: 'test', provider: 'cache', cacheHit: true });
+    await flush();
 
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -62,13 +81,14 @@ describe('logUsage', () => {
     );
   });
 
-  it('includes sd_id and phase when provided', () => {
+  it('includes sd_id and phase when provided', async () => {
     logUsage({
       model: 'test',
       provider: 'google',
       sdId: 'SD-TEST-001',
       phase: 'EXEC'
     });
+    await flush();
 
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -78,8 +98,9 @@ describe('logUsage', () => {
     );
   });
 
-  it('defaults to unknown model when not provided', () => {
+  it('defaults to unknown model when not provided', async () => {
     logUsage({});
+    await flush();
 
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/helpers/supabase-chain-mock.js
+++ b/tests/helpers/supabase-chain-mock.js
@@ -1,0 +1,61 @@
+/**
+ * Strict chainable Supabase mock (SD-REFILL-002XLOD1).
+ *
+ * Fixes the recurring "supabase.from(...).update(...).eq is not a function"
+ * quarantine class: hand-rolled mocks made every method `mockReturnThis()`, but
+ * tests then overrode a mid-chain method (e.g. `update.mockResolvedValue(...)`)
+ * to return a resolved plain object — so the next chained call (`.eq()`) blew up.
+ *
+ * Recipe (from SD-LEO-FIX-FIX-PHANTOM-COLUMN-001):
+ *  - Builder/filter methods stay chainable: they return the same chain object,
+ *    so any `.from().update().eq()...` length composes.
+ *  - The chain is THENABLE: awaiting it anywhere (the update path awaits the
+ *    chain itself, not a terminal resolver) resolves to a configurable result.
+ *  - `single`/`maybeSingle` are terminal vi.fns returning real promises, so a
+ *    test can still do `mock.maybeSingle.mockResolvedValue({ data, error })`
+ *    for the read path without breaking chaining.
+ *
+ * Every method is a vi.fn() spy, so `toHaveBeenCalledWith(...)` assertions work.
+ */
+import { vi } from 'vitest';
+
+const CHAIN_METHODS = [
+  'from', 'select', 'insert', 'update', 'upsert', 'delete',
+  'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'is',
+  'in', 'contains', 'containedBy', 'match', 'not', 'or', 'filter',
+  'order', 'limit', 'range', 'returns', 'overrideTypes',
+  'channel', 'on', 'rpc',
+];
+
+/**
+ * @param {object} [opts]
+ * @param {{data:any,error:any}} [opts.result] default resolution for the
+ *   thenable chain (update/delete paths that await the chain directly).
+ * @returns chain mock (also the client: `client.from(...)` returns the chain)
+ */
+export function createSupabaseChainMock(opts = {}) {
+  const state = { result: opts.result ?? { data: null, error: null } };
+  const chain = {};
+
+  for (const m of CHAIN_METHODS) {
+    chain[m] = vi.fn(() => chain);
+  }
+
+  // Terminal resolvers — real promises so per-test .mockResolvedValue works.
+  chain.single = vi.fn(() => Promise.resolve(state.result));
+  chain.maybeSingle = vi.fn(() => Promise.resolve(state.result));
+  chain.subscribe = vi.fn(() => chain);
+  chain.unsubscribe = vi.fn(() => Promise.resolve({ error: null }));
+
+  // Make the chain awaitable for terminal builder calls (e.g. `await
+  // from().update({...}).eq('id', x)`), which don't end in single/maybeSingle.
+  chain.then = (resolve, reject) =>
+    Promise.resolve(state.result).then(resolve, reject);
+
+  // Allow tests to set what the awaited chain (non-single path) resolves to.
+  chain.__setResult = (result) => { state.result = result; return chain; };
+
+  return chain;
+}
+
+export default createSupabaseChainMock;

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -67,14 +67,6 @@
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
     {
-      "file": "lib/llm/usage-logger.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: db.from(...).select is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "lib/security/encryption.test.js",
       "reason_class": "suite-load-error",
       "error_signature": "Error: Cannot find module '/lib/security/encryption.js' imported from C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-LEO-FIX-GREEN-MAIN-TRIAGE-001/lib/security/encryption.test.js",
@@ -459,14 +451,6 @@
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
     {
-      "file": "tests/unit/brand-variants.service.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: query.order is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "tests/unit/brand-variants.validation.test.js",
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected [Function] to throw an error",
@@ -551,14 +535,6 @@
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected 'FAILED' to be 'COMPLETED' // Object.is equality",
       "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/unit/eva/artifact-persistence-advance-reset.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: supabase.from(...).select is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
       "quarantined_at": "2026-06-11T10:09:40.363Z",
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
@@ -695,14 +671,6 @@
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected false to be true // Object.is equality",
       "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.364Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/unit/eva/economic-lens-analysis.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: dedupQuery.limit(...).maybeSingle is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
       "quarantined_at": "2026-06-11T10:09:40.364Z",
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
@@ -1219,14 +1187,6 @@
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
     {
-      "file": "tests/unit/services/brand-genome.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: supabase.from(...).upsert is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
-      "quarantined_at": "2026-06-11T10:09:40.365Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "tests/unit/session-summary/secret-redactor.test.js",
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected 'createClerkClient({ secret_key=[REDAC…' to contain 'CLERK_SECRET_KEY_REDACTED'",
@@ -1239,22 +1199,6 @@
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: Files writing raw to claude_sessions without going through lib/session-writer.cjs:",
       "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.365Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/unit/stage-17/selection-flow.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: supabase.from(...).select(...).eq(...).eq(...).eq(...).eq is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
-      "quarantined_at": "2026-06-11T10:09:40.365Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
-      "file": "tests/unit/stage-gates-ext.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "AssertionError: expected { isGated: true, gateType: 'TASTE' } to deeply equal { isGated: false, gateType: null }",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
       "quarantined_at": "2026-06-11T10:09:40.365Z",
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
@@ -1377,6 +1321,14 @@
       "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
       "quarantined_at": "2026-06-11T10:09:40.365Z",
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
+    },
+    {
+      "file": "tests/unit/stage-gates-ext.test.js",
+      "reason_class": "assertion-drift",
+      "error_signature": "AssertionError: expected { isGated: true, gateType: 'TASTE' } to deeply equal { isGated: false, gateType: null } (production added TASTE gate SD-LEO-ORCH-GSTACK-TASTE-GATE-001-A + promotion severity logic changed; out-of-class for supabase-mock-chain sweep SD-REFILL-002XLOD1)",
+      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
+      "quarantined_at": "2026-06-22T17:48:33.555Z",
+      "quarantined_by": "SD-REFILL-002XLOD1"
     }
   ]
 }

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -1115,14 +1115,6 @@
       "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
     },
     {
-      "file": "tests/unit/rca-runtime-triggers.test.js",
-      "reason_class": "supabase-mock-chain",
-      "error_signature": "TypeError: supabase.from(...).update(...).eq is not a function",
-      "linked_ref": "feedback:e594e162-7234-4176-ba30-0f5b9435269b",
-      "quarantined_at": "2026-06-11T10:09:40.365Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "tests/unit/reality-gates.test.js",
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected false to be true // Object.is equality",

--- a/tests/unit/brand-variants.service.test.js
+++ b/tests/unit/brand-variants.service.test.js
@@ -25,34 +25,45 @@ const createMockSupabaseClient = () => {
     nextId: 1
   };
 
+  // Chainable, thenable SELECT builder. Accumulates .eq() filters and an
+  // optional .order(), so getBrandVariants()'s `select().eq().eq().order()`
+  // composes (the old mock returned a non-chainable object → "query.order is
+  // not a function"). Awaiting resolves the filtered+sorted rows; .single()
+  // resolves the first match.
+  const makeSelectBuilder = () => {
+    const filters = [];
+    let sort = null;
+    const applyFilters = () =>
+      mockData.variants.filter(v => filters.every(([f, val]) => v[f] === val));
+    const applySort = (rows) => {
+      if (!sort) return rows;
+      const { field, ascending } = sort;
+      return [...rows].sort((a, b) =>
+        ascending ? (a[field] > b[field] ? 1 : -1) : (a[field] < b[field] ? 1 : -1));
+    };
+    const builder = {
+      eq(field, value) {
+        filters.push([field, value]);
+        return builder;
+      },
+      order(field, options = {}) {
+        sort = { field, ascending: !!options.ascending };
+        return builder;
+      },
+      async single() {
+        const variant = applyFilters()[0];
+        return { data: variant || null, error: variant ? null : { message: 'Not found' } };
+      },
+      async then(resolve) {
+        return resolve({ data: applySort(applyFilters()), error: null });
+      }
+    };
+    return builder;
+  };
+
   return {
     from: (table) => ({
-      select: (columns = '*') => ({
-        eq: (field, value) => ({
-          single: async () => {
-            const variant = mockData.variants.find(v => v[field] === value);
-            return { data: variant || null, error: variant ? null : { message: 'Not found' } };
-          },
-          async then(resolve) {
-            const filtered = mockData.variants.filter(v => v[field] === value);
-            return resolve({ data: filtered, error: null });
-          }
-        }),
-        order: (field, options) => ({
-          async then(resolve) {
-            const sorted = [...mockData.variants].sort((a, b) => {
-              if (options.ascending) {
-                return a[field] > b[field] ? 1 : -1;
-              }
-              return a[field] < b[field] ? 1 : -1;
-            });
-            return resolve({ data: sorted, error: null });
-          }
-        }),
-        async then(resolve) {
-          return resolve({ data: mockData.variants, error: null });
-        }
-      }),
+      select: (columns = '*') => makeSelectBuilder(),
       insert: (data) => ({
         select: () => ({
           single: async () => {

--- a/tests/unit/eva/artifact-persistence-advance-reset.test.js
+++ b/tests/unit/eva/artifact-persistence-advance-reset.test.js
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { createSupabaseChainMock } from '../../helpers/supabase-chain-mock.js';
 import { resetStaleStageWork, advanceStage } from '../../../lib/eva/artifact-persistence-service.js';
 
 const VENTURE_ID = '94856fc6-9ba9-4f56-9a5c-85041031a0fc'; // LexiGuard
@@ -29,6 +30,14 @@ const lexiguardVentureRow = {
 
 /**
  * Build a mock supabase that records UPDATE payloads for assertion.
+ *
+ * Only the two tables the reset logic touches (venture_stage_work, ventures)
+ * have bespoke handlers. advanceStage() also runs checkExitGates / checkGateDebt
+ * which read other tables (venture_stages, eva_stage_gate_results,
+ * chairman_decisions); the fallback returns a fully chainable + thenable
+ * createSupabaseChainMock() that resolves empty so those checks pass through to
+ * allowed/not-blocked (the previous `|| {}` fallback broke with
+ * "supabase.from(...).select is not a function").
  */
 function createMockSupabase({ stageWorkRow, ventureRow, rpcResult = { success: true } }) {
   const updates = { venture_stage_work: [], ventures: [] };
@@ -63,7 +72,7 @@ function createMockSupabase({ stageWorkRow, ventureRow, rpcResult = { success: t
     }),
   };
   const supabase = {
-    from: vi.fn().mockImplementation((tbl) => fromHandlers[tbl]?.() || {}),
+    from: vi.fn().mockImplementation((tbl) => fromHandlers[tbl]?.() || createSupabaseChainMock()),
     rpc: vi.fn().mockResolvedValue({ data: rpcResult, error: null }),
   };
   return { supabase, updates };

--- a/tests/unit/eva/economic-lens-analysis.test.js
+++ b/tests/unit/eva/economic-lens-analysis.test.js
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSupabaseChainMock } from '../../helpers/supabase-chain-mock.js';
 
 // Must mock before importing
 vi.mock('../../../lib/llm/index.js', () => ({
@@ -96,17 +97,8 @@ describe('EconomicLensAnalysis', () => {
       mockLLMClient = { complete: vi.fn() };
       getLLMClient.mockReturnValue(mockLLMClient);
 
-      mockSupabase = {
-        from: vi.fn().mockReturnThis(),
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        in: vi.fn().mockReturnThis(),
-        order: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockReturnThis(),
-        single: vi.fn(),
-        update: vi.fn().mockReturnThis(),
-        insert: vi.fn().mockReturnThis()
-      };
+      // Cache-hit path mock (single .single() resolver is overridden per-test).
+      mockSupabase = createSupabaseChainMock();
     });
 
     it('should return cached result when available and not forcing refresh', async () => {
@@ -129,52 +121,23 @@ describe('EconomicLensAnalysis', () => {
     it('should call LLM when forcing refresh', async () => {
       const { analyzeEconomicLens } = await import('../../../lib/eva/economic-lens-analysis.js');
 
-      // Build a chainable mock that tracks calls
-      const chainable = () => {
-        const chain = {};
-        const methods = ['from', 'select', 'eq', 'in', 'order', 'limit', 'update', 'insert'];
-        methods.forEach(m => { chain[m] = vi.fn(() => chain); });
+      // forceRefresh path issues these terminal reads/writes in order:
+      //   single():     (1) ventures lookup, (2) insert .select('id').single()
+      //                 from writeArtifact, (3) created_at fetch
+      //   maybeSingle(): writeArtifact dedup (no existing → null)
+      //   order():      fetchUpstreamContext (awaited → empty array)
+      // A single chainable+thenable mock composes the deep .eq()/.limit() chains;
+      // we sequence only the terminal resolvers (the old bespoke mock lacked
+      // maybeSingle → "dedupQuery.limit(...).maybeSingle is not a function").
+      const sb = createSupabaseChainMock();
+      sb.single
+        .mockResolvedValueOnce({ data: { id: 'v1', name: 'Test Venture' }, error: null }) // ventures
+        .mockResolvedValueOnce({ data: { id: 'new-id' }, error: null })                   // insert .select('id')
+        .mockResolvedValueOnce({ data: { id: 'new-id', created_at: '2026-03-11' }, error: null }); // created_at fetch
+      sb.maybeSingle.mockResolvedValue({ data: null, error: null }); // writeArtifact dedup: no existing
+      // fetchUpstreamContext awaits the chain after .order(); resolve to no rows.
+      sb.__setResult({ data: [], error: null });
 
-        // single() returns different values based on call order
-        let singleCallCount = 0;
-        chain.single = vi.fn(() => {
-          singleCallCount++;
-          if (singleCallCount === 1) {
-            // Venture lookup
-            return Promise.resolve({ data: { id: 'v1', name: 'Test Venture' }, error: null });
-          }
-          return Promise.resolve({ data: null, error: null });
-        });
-
-        // order returns data for upstream artifacts query
-        const origOrder = chain.order;
-        chain.order = vi.fn((...args) => {
-          const result = origOrder(...args);
-          // Make it awaitable for the upstream artifacts query
-          result.then = (resolve) => resolve({ data: [], error: null });
-          return result;
-        });
-
-        // select on insert returns inserted data
-        let selectAfterInsert = false;
-        const origInsert = chain.insert;
-        chain.insert = vi.fn((...args) => {
-          selectAfterInsert = true;
-          return origInsert(...args);
-        });
-        const origSelect = chain.select;
-        chain.select = vi.fn((...args) => {
-          if (selectAfterInsert) {
-            selectAfterInsert = false;
-            return Promise.resolve({ data: [{ id: 'new-id', created_at: '2026-03-11' }], error: null });
-          }
-          return origSelect(...args);
-        });
-
-        return chain;
-      };
-
-      const sb = chainable();
       mockLLMClient.complete.mockResolvedValueOnce({
         content: validLLMResponse,
         model: 'claude-sonnet-4-20250514'

--- a/tests/unit/rca-runtime-triggers.test.js
+++ b/tests/unit/rca-runtime-triggers.test.js
@@ -12,6 +12,7 @@
 
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createClient } from '@supabase/supabase-js';
+import { createSupabaseChainMock } from '../helpers/supabase-chain-mock.js';
 
 // Mock Supabase client
 vi.mock('@supabase/supabase-js');
@@ -20,19 +21,7 @@ describe('RCA Runtime Triggers', () => {
   let mockSupabase;
 
   beforeEach(() => {
-    mockSupabase = {
-      from: vi.fn().mockReturnThis(),
-      select: vi.fn().mockReturnThis(),
-      insert: vi.fn().mockReturnThis(),
-      update: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      in: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn(),
-      single: vi.fn(),
-      channel: vi.fn().mockReturnThis(),
-      on: vi.fn().mockReturnThis(),
-      subscribe: vi.fn()
-    };
+    mockSupabase = createSupabaseChainMock();
 
     createClient.mockReturnValue(mockSupabase);
   });
@@ -114,7 +103,8 @@ describe('RCA Runtime Triggers', () => {
       };
 
       mockSupabase.maybeSingle.mockResolvedValue({ data: existingRCR, error: null });
-      mockSupabase.update.mockResolvedValue({ data: { ...existingRCR, recurrence_count: 2 }, error: null });
+      // update().eq() is awaited but its result is discarded by production code;
+      // the chainable mock stays chainable so .eq() resolves via the thenable chain.
 
       const params = {
         failure_signature: 'test_regression:login_test:SD-AUTH-001',

--- a/tests/unit/services/brand-genome.test.js
+++ b/tests/unit/services/brand-genome.test.js
@@ -57,6 +57,15 @@ function createMockSupabase({ data = [], error = null, singleData = null } = {})
     };
   });
 
+  // createBrandGenome() uses .upsert().select().single(); mirror the insert
+  // branch so the write path composes (the old mock had no upsert →
+  // "supabase.from(...).upsert is not a function").
+  const insertOrUpsertReturn = () => ({
+    select: vi.fn().mockReturnValue({
+      single: vi.fn().mockResolvedValue({ data: singleData, error }),
+    }),
+  });
+
   // Build the mock from builder
   const fromMock = vi.fn().mockReturnValue({
     select: vi.fn().mockReturnValue({
@@ -79,11 +88,8 @@ function createMockSupabase({ data = [], error = null, singleData = null } = {})
       order: orderFn,
       maybeSingle: vi.fn().mockResolvedValue({ data: singleData, error }),
     }),
-    insert: vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        single: vi.fn().mockResolvedValue({ data: singleData, error }),
-      }),
-    }),
+    insert: vi.fn().mockImplementation(insertOrUpsertReturn),
+    upsert: vi.fn().mockImplementation(insertOrUpsertReturn),
     update: vi.fn().mockReturnValue({
       eq: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({

--- a/tests/unit/stage-17/selection-flow.test.js
+++ b/tests/unit/stage-17/selection-flow.test.js
@@ -24,38 +24,75 @@ vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({
 
 import { writeArtifact } from '../../../lib/eva/artifact-persistence-service.js';
 
+// Fully chainable + thenable Supabase mock. The query builder accumulates
+// arbitrary .eq()/.in()/.contains()/.limit() calls (the old bespoke mock only
+// nested a few levels deep → "...eq().eq().eq().eq is not a function" and
+// "...eq().eq().eq().limit is not a function"). Distinct queries are served by
+// their terminal call:
+//   .single()      → the source/archetype artifact (fetchArtifactById)
+//   .maybeSingle() → the wireframe_screens artifact (drives expectedScreens)
+//   .contains()… (awaited) → approved-mobile lookup → [{ content }]
+//   select(.., {count:'exact'}) (awaited) → { count } (approved-artifact count)
+//   plain awaited select chain → { data: [] } (e.g. the retire-existing lookup)
 function createMockSupabase(opts = {}) {
-  const { artifactContent = '<html>Test</html>', metadata = {}, count = 0 } = opts;
-  return {
-    from: vi.fn().mockReturnValue({
-      select: vi.fn().mockImplementation((sel, selectOpts) => {
-        if (selectOpts?.count === 'exact') {
-          return {
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                in: vi.fn().mockResolvedValue({ count, error: null }),
-              }),
-            }),
-          };
-        }
-        return {
-          eq: vi.fn().mockImplementation((col, val) => ({
-            single: vi.fn().mockResolvedValue({
-              data: { id: val, content: artifactContent, artifact_data: {}, metadata, title: 'Screen', artifact_type: 'stage_17_archetype' },
-              error: null,
-            }),
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                contains: vi.fn().mockReturnValue({
-                  limit: vi.fn().mockResolvedValue({ data: [{ content: '<html>Mobile</html>' }], error: null }),
-                }),
-              }),
-            }),
-          })),
-        };
-      }),
-    }),
+  const {
+    artifactContent = '<html>Test</html>',
+    metadata = {},
+    count = 0,
+    // expectedScreens drives isDesignPassComplete's completion threshold. The
+    // original suite treated 14 as the magic "all screens approved" count, so
+    // keep 14 as the default screen count (preserves the test intent against
+    // the refactored wireframe-screens-based completion check).
+    screenCount = 14,
+  } = opts;
+
+  const archetypeRow = {
+    id: 'archetype-id',
+    content: artifactContent,
+    artifact_data: {},
+    metadata,
+    title: 'Screen',
+    artifact_type: 'stage_17_archetype',
   };
+  const wireframeRow = {
+    artifact_data: { screens: Array.from({ length: screenCount }, (_, i) => ({ id: `s${i}` })) },
+  };
+
+  const from = vi.fn((table) => {
+    const builder = {
+      _isCount: false,
+      _hasContains: false,
+      select(sel, selectOpts) {
+        if (selectOpts?.count === 'exact') this._isCount = true;
+        return builder;
+      },
+      eq(col, val) { this._lastEqVal = val; return builder; },
+      in() { return builder; },
+      contains() { this._hasContains = true; return builder; },
+      order() { return builder; },
+      update() { return builder; },
+      limit() { return builder; },
+      // Terminal: source/archetype artifact (echo id so variant-suffix logic works)
+      single: vi.fn(() =>
+        Promise.resolve({ data: { ...archetypeRow, id: builder._lastEqVal ?? archetypeRow.id }, error: null })),
+      // Terminal: wireframe_screens artifact (expectedScreens source)
+      maybeSingle: vi.fn(() => Promise.resolve({ data: wireframeRow, error: null })),
+      // Awaited chain:
+      //   count query → { count }
+      //   approved-mobile lookup (contains) → [{ content }]
+      //   otherwise → empty list
+      then(resolve, reject) {
+        let result;
+        if (this._isCount) result = { count, error: null };
+        else if (this._hasContains) result = { data: [{ content: artifactContent }], error: null };
+        else result = { data: [], error: null };
+        return Promise.resolve(result).then(resolve, reject);
+      },
+    };
+    return builder;
+  });
+
+  return { from };
 }
 
 describe('selection-flow', () => {


### PR DESCRIPTION
## Summary
Fixes the recurring `supabase.from(...).update(...).eq is not a function` quarantine class (reason_class=`supabase-mock-chain`, linked feedback e594e162). Hand-rolled mocks made every method `mockReturnThis()`, but tests overrode mid-chain builder methods (e.g. `update.mockResolvedValue`) to return resolved plain objects, breaking the next chained call.

## Changes
- **New** `tests/helpers/supabase-chain-mock.js` — strict chainable+thenable Supabase mock (builders chain, `single`/`maybeSingle` terminal+overridable, chain awaitable for `update().eq()` paths).
- Un-quarantined **7 files** (102 tests green): rca-runtime-triggers, usage-logger, brand-variants.service, eva/artifact-persistence-advance-reset, eva/economic-lens-analysis, services/brand-genome, stage-17/selection-flow.
- `tests/quarantine-manifest.json`: removed the 7 entries (173→166).

## Deliberately NOT included
- `tests/unit/stage-gates-ext.test.js` — **out-of-class**: 3 genuine assertion-drift failures from a new production TASTE gate (SD-LEO-ORCH-GSTACK-TASTE-GATE-001-A), not mock-chain. Left quarantined with `reason_class` updated to `assertion-drift` for separate triage.

No production source changed; no assertions weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)