### PR TITLE
feat(SD-REFILL-00R7REXL): DUTY-3b orphan check for in_progress+unclaimed SDs

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -315,6 +315,53 @@ export function detectProgressStall({ liveSessions = [], sds = [], nowMs, thresh
 }
 
 /**
+ * DUTY-3b (SD-REFILL-00R7REXL): in_progress SDs that are UNCLAIMED with no live worker — true orphans.
+ * Refines SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001: DUTY-2 only inspects CLAIMED sessions,
+ * DUTY-3/5/6 the draft/ready belt, DUTY-4 belt deps, DUTY-7/9 drafts, DUTY-8 CLAIMED-frozen — so an
+ * in_progress + claiming_session_id=NULL SD with no live session is invisible to every other duty
+ * (off the claimable belt AND not self-recoverable by any /checkin). This was the false 'all-clear'
+ * while SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001 sat in_progress/PLAN_PRD with claiming_session_id=NULL.
+ *
+ * PID-liveness gate (c1df435f): a worker mid long-Task whose claim was transiently hard-cap-released
+ * keeps heartbeating against its sd_key in claude_sessions — so an SD whose sd_key matches ANY live
+ * session (caller passes the already heartbeat|armed-silence|PID-resolved `live` set) is NOT an orphan.
+ * Orchestrator parents / fixtures / human-action SDs are legitimately unclaimed → excluded via the
+ * canonical classifyIneligibility predicate. Age-gated so a just-released claim isn't flagged instantly.
+ *
+ * @param {object} p {sds, liveSessions, classifyIneligibility(s)->reason|null, nowMs, minAgeMs}
+ */
+export function detectInProgressOrphans({ sds = [], liveSessions = [], classifyIneligibility, nowMs, minAgeMs = 10 * 60 * 1000 } = {}) {
+  if (!Array.isArray(sds) || !Array.isArray(liveSessions)) {
+    return { violation: false, orphanCount: 0, samples: [], detail: 'in-progress-orphan not evaluable (fail-open)', remediation: null };
+  }
+  const liveSdKeys = new Set(liveSessions.filter((s) => s && s.sd_key).map((s) => s.sd_key));
+  const orphans = sds.filter((s) => {
+    if (!s || s.status !== 'in_progress') return false;        // only in_progress
+    if (s.claiming_session_id) return false;                   // has a claim → DUTY-8's domain if frozen, not orphan
+    if (liveSdKeys.has(s.sd_key)) return false;                // a live session still works it (transient claim release)
+    if (typeof classifyIneligibility === 'function' && classifyIneligibility(s)) return false; // parent/fixture/human-action
+    if (Number.isFinite(nowMs) && Number.isFinite(minAgeMs)) { // age guard — don't flag a just-released claim
+      const upd = s.updated_at ? new Date(s.updated_at).getTime() : NaN;
+      if (Number.isFinite(upd) && (nowMs - upd) < minAgeMs) return false;
+    }
+    return true;
+  });
+  const samples = orphans.slice(0, 10).map((s) => ({ sd_key: s.sd_key, phase: s.current_phase ?? null }));
+  const matched = orphans.length > 0;
+  return {
+    violation: matched,
+    orphanCount: orphans.length,
+    samples,
+    detail: matched
+      ? `${orphans.length} in_progress SD(s) UNCLAIMED with no live worker (orphan — off the belt, not self-recoverable) — ${samples.slice(0, 3).map((x) => `${x.sd_key}(${x.phase || '?'})`).join(', ')}`
+      : 'none (every in_progress SD is claimed or has a live worker)',
+    remediation: matched
+      ? 'ACTION: recover the orphaned in_progress SD(s) — reset to a claimable state (re-open to the belt) or reassign to a live worker; in_progress + claiming_session_id=NULL with no PID-heartbeating session means no /checkin will ever self-resume them'
+      : null,
+  };
+}
+
+/**
  * Resolve the authoritative worktree count, detecting countActiveWorktrees's SILENT git-failure: that helper
  * swallows a git-CLI error and returns 0 (it never throws), which would read as a false-clean 0/20. If git
  * reports 0 but the filesystem shows worktree directories, git failed -> return -1 (the fail-loud sentinel

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -34,6 +34,8 @@ import {
   detectSourceToCapacity, detectCoordinatorWithoutAdam,
   // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: auto-refill awareness advisory.
   detectAutoRefillBacklog,
+  // SD-REFILL-00R7REXL: DUTY-3b — in_progress + unclaimed orphans (invisible to DUTY-2/3/4/5/7/8/9).
+  detectInProgressOrphans,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
 // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: the -B dry-run verifier supplies the promotable count.
 import { verifyStagedCandidates } from '../lib/sourcing-engine/refill-dry-run-verifier.js';
@@ -85,6 +87,11 @@ const LEAD_AGING_MS = (Number.isFinite(_leadAgingDays) && _leadAgingDays >= 0 ? 
 // rather than nagging every healthy long-EXEC worker. Env-tunable via PROGRESS_STALL_HOURS_THRESHOLD.
 const _progressStallHrs = Number(process.env.PROGRESS_STALL_HOURS_THRESHOLD);
 const PROGRESS_STALL_MS = (Number.isFinite(_progressStallHrs) && _progressStallHrs >= 0 ? _progressStallHrs : 4) * 3600000;
+// SD-REFILL-00R7REXL — DUTY-3b threshold: an in_progress + UNCLAIMED SD with no live worker is only flagged an
+// orphan once its updated_at is older than this, so a claim just hard-cap-released (the worker is about to
+// self-resume, or the 15min orphan-adoption window hasn't elapsed) is not mis-flagged. Honor an explicit 0; default 10min.
+const _orphanMinAgeMin = Number(process.env.ORPHAN_MIN_AGE_MINUTES);
+const ORPHAN_MIN_AGE_MS = (Number.isFinite(_orphanMinAgeMin) && _orphanMinAgeMin >= 0 ? _orphanMinAgeMin : 10) * 60000;
 const TERMINAL = new Set(['completed', 'cancelled', 'archived', 'deferred']);
 const depKeysOf = (s) => (Array.isArray(s.dependencies) ? s.dependencies.map(extractDepKey).filter(Boolean) : []);
 
@@ -245,6 +252,10 @@ async function main() {
     // SD-LEO-INFRA-PROGRESS-STALL-DETECTION-001: DUTY-8 — claim-holders heartbeat-ALIVE but claimed SD FROZEN.
     // Reuses the canonical detectStuckWorker predicate (injected); advisory remediation count only (no new exit).
     progress: detectProgressStall({ liveSessions: liveWorkers, sds, nowMs, thresholdMs: PROGRESS_STALL_MS, isWithinArmedSilence: isWithinArmedSilenceWindow, detectStuck: detectStuckWorker }),
+    // SD-REFILL-00R7REXL: DUTY-3b — in_progress + unclaimed orphan with no live worker. Liveness gate uses
+    // the full `live` set (heartbeat|armed-silence|PID) NOT liveWorkers, so a long-Task worker whose claim
+    // was transiently hard-cap-released (still heartbeating its sd_key) is never mis-flagged (c1df435f).
+    orphan: detectInProgressOrphans({ sds, liveSessions: live, classifyIneligibility: classifyDispatchIneligibility, nowMs, minAgeMs: ORPHAN_MIN_AGE_MS }),
   };
 
   const flag = (r) => (r.remediation ? '  ⚠ ' + r.remediation : '');
@@ -260,6 +271,7 @@ async function main() {
   console.log('  DUTY-7 DRAFT-STALL   : ' + D.draft.detail + flag(D.draft)); // SILENT-STALL-PREVENTION-001
   console.log('  DUTY-8 PROGRESS-STALL: ' + D.progress.detail + flag(D.progress)); // PROGRESS-STALL-DETECTION-001
   console.log('  DUTY-9 LEAD-AGING    : ' + D.leadAging.detail + flag(D.leadAging)); // ADAM-VISION-SD-FLOW-001
+  console.log('  DUTY-3b IN-PROG ORPHAN: ' + D.orphan.detail + flag(D.orphan)); // SD-REFILL-00R7REXL
   // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3) — coordinator mirror adherence.
   if (D.srcCap) console.log('  SOURCE-TO-CAPACITY   : ' + D.srcCap.detail + flag(D.srcCap));
   if (D.d3lean) console.log('  D3-LEAN (coord/Adam) : ' + D.d3lean.detail + flag(D.d3lean));

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -9,7 +9,7 @@ import {
   classifyLiveness, detectIdleWithWork, detectDependencyHealth, detectWorktreePool,
   detectBacklogRankStaleness, detectQuietTickUnverified, foundationalQueryError, summarizeViolations,
   extractDepKey, resolveWorktreeCount, computeDispatchBelt, detectCrossRepoStarvation,
-  detectAutoRefillBacklog,
+  detectAutoRefillBacklog, detectInProgressOrphans,
 } from '../../../lib/coordinator/charter-audit-detectors.mjs';
 import { STANDARD_LOOPS } from '../../../scripts/coordinator-startup-check.mjs';
 
@@ -338,5 +338,50 @@ describe('detectAutoRefillBacklog (SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E
     expect(detectAutoRefillBacklog({ promotableCount: -5 }).violation).toBe(false);
     expect(detectAutoRefillBacklog().violation).toBe(false);
     expect(detectAutoRefillBacklog({ promotableCount: 2.9 }).promotableCount).toBe(2); // floored
+  });
+});
+
+describe('detectInProgressOrphans — DUTY-3b in_progress+unclaimed orphan (SD-REFILL-00R7REXL)', () => {
+  const OLD = ago(30 * 60 * 1000); // older than the 10min default min-age
+  const orphanSd = (over = {}) => ({ sd_key: 'SD-ORPHAN-001', status: 'in_progress', claiming_session_id: null, current_phase: 'PLAN_PRD', updated_at: OLD, ...over });
+
+  it('flags an in_progress + UNCLAIMED SD with no live worker (the false-all-clear case)', () => {
+    const r = detectInProgressOrphans({ sds: [orphanSd()], liveSessions: [], nowMs: NOW });
+    expect(r.violation).toBe(true);
+    expect(r.orphanCount).toBe(1);
+    expect(r.samples[0]).toEqual({ sd_key: 'SD-ORPHAN-001', phase: 'PLAN_PRD' });
+    expect(r.remediation).toMatch(/recover/i);
+  });
+
+  it('does NOT flag when a live session still holds the sd_key (transient hard-cap claim release — c1df435f)', () => {
+    const r = detectInProgressOrphans({ sds: [orphanSd()], liveSessions: [{ session_id: 'live-1', sd_key: 'SD-ORPHAN-001' }], nowMs: NOW });
+    expect(r.violation).toBe(false);
+    expect(r.orphanCount).toBe(0);
+  });
+
+  it('does NOT flag a CLAIMED in_progress SD (DUTY-8 domain, not orphan)', () => {
+    const r = detectInProgressOrphans({ sds: [orphanSd({ claiming_session_id: 'sess-x' })], liveSessions: [], nowMs: NOW });
+    expect(r.violation).toBe(false);
+  });
+
+  it('does NOT flag a draft / completed / non-in_progress SD', () => {
+    const sds = [orphanSd({ status: 'draft' }), orphanSd({ sd_key: 'SD-X', status: 'completed' })];
+    expect(detectInProgressOrphans({ sds, liveSessions: [], nowMs: NOW }).violation).toBe(false);
+  });
+
+  it('excludes orchestrator parents / fixtures / human-action via classifyIneligibility', () => {
+    const r = detectInProgressOrphans({ sds: [orphanSd()], liveSessions: [], nowMs: NOW, classifyIneligibility: () => 'orchestrator_parent' });
+    expect(r.violation).toBe(false);
+  });
+
+  it('age-gates: a just-released claim (updated_at fresher than minAgeMs) is NOT yet an orphan', () => {
+    const r = detectInProgressOrphans({ sds: [orphanSd({ updated_at: ago(60 * 1000) })], liveSessions: [], nowMs: NOW });
+    expect(r.violation).toBe(false);
+  });
+
+  it('is total / fail-open on odd input', () => {
+    expect(detectInProgressOrphans().violation).toBe(false);
+    expect(detectInProgressOrphans({ sds: null, liveSessions: null }).violation).toBe(false);
+    expect(detectInProgressOrphans({ sds: [orphanSd()], liveSessions: [] }).violation).toBe(true); // nowMs undefined → age guard skipped, still flags
   });
 });


### PR DESCRIPTION
## SD-REFILL-00R7REXL

`coordinator-charter-audit.mjs` gave a false 'all-clear' (0 violations) while an SD sat `in_progress/PLAN_PRD` with `claiming_session_id=NULL` and no live worker. DUTY-2 inspects only CLAIMED sessions; DUTY-3/5/6 the draft/ready belt; DUTY-4 belt deps; DUTY-7/9 drafts; DUTY-8 CLAIMED-frozen — so an in_progress + unclaimed SD with no live session was **invisible to every duty** (off the claimable belt AND not self-recoverable by any /checkin).

### Fix
- Pure `detectInProgressOrphans()` + wired as **DUTY-3b**.
- **PID-liveness gate** uses the full `heartbeat|armed-silence|PID`-resolved live set (not `liveWorkers`) so a long-Task worker whose claim was transiently hard-cap-released (still heartbeating its `sd_key`) is never mis-flagged (c1df435f).
- Excludes orchestrator parents / fixtures / human-action via the canonical `classifyDispatchIneligibility`.
- Age-gated via `ORPHAN_MIN_AGE_MINUTES` (default 10m) so a just-released claim isn't flagged instantly.

### Tests
- 7 new unit tests (charter-audit-detectors suite 55/55 green).
- Live audit run clean (`DUTY-3b IN-PROG ORPHAN: none`, `CHARTER_AUDIT_VIOLATIONS=0`).

Refines SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)