### PR TITLE
feat(SD-REFILL-00RXDLKM): SessionStart auto-heal for emptied shared node_modules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/node-modules-autoheal.cjs",
+            "timeout": 60
+          },
+          {
+            "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-state-sync.cjs",
             "timeout": 5
           },

--- a/scripts/hooks/__tests__/node-modules-autoheal.test.js
+++ b/scripts/hooks/__tests__/node-modules-autoheal.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for node-modules-autoheal.cjs (SD-REFILL-00RXDLKM).
+ *
+ * Exercises the pure, dependency-injected decision logic without running a real
+ * npm install: detection (needsHeal), the single-healer lock (acquireHealLock /
+ * isStaleLock), and the additive-only command (buildHealCommand). The hook gates
+ * main() behind `require.main === module`, so a plain require() yields the exports
+ * with no SessionStart side-effects.
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const HOOK_PATH = path.resolve(__dirname, '../node-modules-autoheal.cjs');
+
+function loadHook() {
+  delete require.cache[require.resolve(HOOK_PATH)];
+  return require(HOOK_PATH);
+}
+
+const ROOT = '/repo';
+
+describe('needsHeal (FR-1 detection)', () => {
+  const NM = path.join(ROOT, 'node_modules');
+  const DEP_PKG = path.join(NM, '@supabase', 'supabase-js', 'package.json');
+
+  it('TS-1: heals when the sentinel dep package.json is absent from THIS store', () => {
+    const { needsHeal } = loadHook();
+    // node_modules dir exists, but the sentinel's package.json does not.
+    const existsSync = (p) => p === NM;
+    expect(needsHeal(ROOT, { existsSync })).toBe(true);
+  });
+
+  it('TS-2: fast-exits (false) when the sentinel dep is present', () => {
+    const { needsHeal } = loadHook();
+    const existsSync = (p) => p === NM || p === DEP_PKG;
+    expect(needsHeal(ROOT, { existsSync })).toBe(false);
+  });
+
+  it('heals when node_modules is entirely missing', () => {
+    const { needsHeal } = loadHook();
+    expect(needsHeal(ROOT, { existsSync: () => false })).toBe(true);
+  });
+
+  it('does NOT use require.resolve (no upward walk to a parent store) — exact-path only', () => {
+    const { needsHeal } = loadHook();
+    // Sentinel exists ONLY in a parent node_modules, not this store → must still heal.
+    const parentDepPkg = path.join(ROOT, '..', 'node_modules', '@supabase', 'supabase-js', 'package.json');
+    const existsSync = (p) => p === NM || p === parentDepPkg; // parent has it, this store does not
+    expect(needsHeal(ROOT, { existsSync })).toBe(true);
+  });
+
+  it('TS-3: never auto-installs on an unexpected fs error', () => {
+    const { needsHeal } = loadHook();
+    const existsSync = () => { throw new Error('EACCES'); };
+    expect(needsHeal(ROOT, { existsSync })).toBe(false);
+  });
+});
+
+describe('isStaleLock (FR-2 TTL)', () => {
+  it('TS-5: a lock older than the TTL is stale (reclaimable)', () => {
+    const { isStaleLock } = loadHook();
+    expect(isStaleLock(1000, 1000 + 200000, 180000)).toBe(true);
+  });
+
+  it('a fresh lock is NOT stale', () => {
+    const { isStaleLock } = loadHook();
+    expect(isStaleLock(1000, 1000 + 5000, 180000)).toBe(false);
+  });
+
+  it('an unreadable mtime is treated as stale (reclaim rather than wedge)', () => {
+    const { isStaleLock } = loadHook();
+    expect(isStaleLock(NaN, 5000, 180000)).toBe(true);
+  });
+});
+
+describe('acquireHealLock (FR-2 single-healer)', () => {
+  it('first caller acquires the lock (mkdir succeeds)', () => {
+    const { acquireHealLock } = loadHook();
+    const got = acquireHealLock('/repo/.lock', { mkdir: () => {}, statMtimeMs: () => 0, rmdir: () => {} });
+    expect(got).toBe(true);
+  });
+
+  it('TS-4: a second concurrent caller skips while a fresh lock is held', () => {
+    const { acquireHealLock } = loadHook();
+    const eexist = () => { const e = new Error('exists'); e.code = 'EEXIST'; throw e; };
+    const got = acquireHealLock('/repo/.lock', {
+      mkdir: eexist,
+      statMtimeMs: () => 1000,
+      nowMs: 1000 + 5000,   // 5s old → fresh
+      ttlMs: 180000,
+      rmdir: () => { throw new Error('should not reclaim a fresh lock'); },
+    });
+    expect(got).toBe(false);
+  });
+
+  it('reclaims a STALE lock then re-acquires', () => {
+    const { acquireHealLock } = loadHook();
+    let calls = 0;
+    const mkdir = () => { calls++; if (calls === 1) { const e = new Error('exists'); e.code = 'EEXIST'; throw e; } /* 2nd: succeeds */ };
+    let reclaimed = false;
+    const got = acquireHealLock('/repo/.lock', {
+      mkdir,
+      statMtimeMs: () => 1000,
+      nowMs: 1000 + 200000,  // 200s old → stale
+      ttlMs: 180000,
+      rmdir: () => { reclaimed = true; },
+    });
+    expect(reclaimed).toBe(true);
+    expect(got).toBe(true);
+  });
+
+  it('an unexpected mkdir error (not EEXIST) fails closed (no heal)', () => {
+    const { acquireHealLock } = loadHook();
+    const got = acquireHealLock('/repo/.lock', {
+      mkdir: () => { const e = new Error('EACCES'); e.code = 'EACCES'; throw e; },
+      statMtimeMs: () => 0, rmdir: () => {},
+    });
+    expect(got).toBe(false);
+  });
+});
+
+describe('buildHealCommand (FR-3 additive-only)', () => {
+  it('TS-6: is `npm install` with safe flags — never npm ci / never destructive', () => {
+    const { buildHealCommand } = loadHook();
+    const { cmd, args } = buildHealCommand();
+    expect(cmd).toBe('npm');
+    expect(args).toEqual(['install', '--ignore-scripts', '--no-audit', '--no-fund']);
+    expect(args).not.toContain('ci');
+    expect(args.join(' ')).not.toMatch(/rm|ci|prune|--force/);
+  });
+});

--- a/scripts/hooks/node-modules-autoheal.cjs
+++ b/scripts/hooks/node-modules-autoheal.cjs
@@ -1,0 +1,165 @@
+/**
+ * node_modules Empty-Store Auto-Heal Hook
+ * SD-REFILL-00RXDLKM
+ *
+ * Trigger: SessionStart
+ *
+ * The shared node_modules store is periodically emptied mid-session (parallel-session
+ * junction-reap, a non-Bash `npm ci`, or an override-flagged install), bricking every
+ * parallel session with ERR_MODULE_NOT_FOUND (@supabase/supabase-js, dotenv). The existing
+ * NPM CI SHARED-STORE WIPE GUARD (pre-tool-enforce.cjs ENFORCEMENT 12c) only intercepts the
+ * Bash tool's `npm ci` and cannot cover non-Bash invocations. This hook is the RECOVERY
+ * counterpart: detect an empty store at session start and ADDITIVELY re-install it, so a wipe
+ * self-heals regardless of how it happened.
+ *
+ * Safety properties:
+ *   - HERD-SAFE: an atomic single-healer lock (fs.mkdirSync) means exactly one session installs
+ *     when N sessions all detect an empty store in the same window; the rest skip.
+ *   - ADDITIVE-ONLY: runs `npm install --ignore-scripts --no-audit --no-fund` — NEVER `npm ci`
+ *     or `rm -rf node_modules` — so the hook can itself never wipe the shared store.
+ *   - FAIL-OPEN: any error exits 0 with a logged warning; it can never block session startup.
+ *   - FAST-EXIT: a healthy store is a <200ms no-op (no install).
+ *
+ * All decision logic is pure + dependency-injected so tests never run a real install.
+ * main() is guarded behind require.main === module so the helpers are importable.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// The critical dependency used as the "is the store alive?" sentinel. If THIS resolves, the
+// store is populated; the wipe class always takes it out (it is a top-level prod dependency).
+const CRITICAL_DEP = '@supabase/supabase-js';
+
+// Stale-lock TTL: a heal that started longer ago than this is assumed crashed and its lock is
+// reclaimable, so a dead healer can never wedge the heal forever. Overridable for tests/ops.
+const HEAL_LOCK_TTL_MS = Number(process.env.HEAL_LOCK_TTL_MS) || 180000;
+
+const LOCK_DIRNAME = '.node-modules-heal.lock';
+
+/** Single structured, grep-able log line. Never throws. */
+function logHeal(event, extra = {}, logger = console.error) {
+  try {
+    logger(`[node-modules-autoheal] ${JSON.stringify({ event, ...extra })}`);
+  } catch { /* logging must never break the hook */ }
+}
+
+/**
+ * Pure detection: does THIS repo-root store need healing? True when rootDir/node_modules is
+ * missing OR the critical sentinel dependency's package.json is absent from it.
+ *
+ * IMPORTANT: this checks the EXACT filesystem path rootDir/node_modules/<dep>/package.json — it
+ * deliberately does NOT use require.resolve, because require.resolve walks UP the directory tree
+ * and would resolve the sentinel in a PARENT node_modules (e.g. a git worktree whose own store is
+ * emptied falling back to the main-repo store), masking the very wipe we must detect.
+ *
+ * An unexpected fs error resolves to FALSE — we never auto-install on a signal we cannot read
+ * cleanly (a false-positive heal is worse than a missed one; the empty-store signal is a plain
+ * missing path).
+ *
+ * @param {string} rootDir repo root containing node_modules
+ * @param {object} [opts]
+ * @param {(p:string)=>boolean} [opts.existsSync]
+ * @returns {boolean}
+ */
+function needsHeal(rootDir, opts = {}) {
+  const existsSync = opts.existsSync || fs.existsSync;
+  try {
+    const nm = path.join(rootDir, 'node_modules');
+    if (!existsSync(nm)) return true; // store entirely gone
+    // Exact-path check for the sentinel dep — NO upward walk (see note above).
+    const depPkg = path.join(nm, ...CRITICAL_DEP.split('/'), 'package.json');
+    return !existsSync(depPkg);
+  } catch {
+    return false; // never auto-install on an unexpected error
+  }
+}
+
+/**
+ * Pure: is a lock whose dir mtime is `lockMtimeMs` stale at `nowMs` given `ttlMs`?
+ * @returns {boolean}
+ */
+function isStaleLock(lockMtimeMs, nowMs, ttlMs) {
+  if (typeof lockMtimeMs !== 'number' || Number.isNaN(lockMtimeMs)) return true; // unreadable → reclaim
+  return (nowMs - lockMtimeMs) > ttlMs;
+}
+
+/**
+ * Acquire the single-healer lock by atomically creating the lock dir. fs.mkdirSync is atomic on
+ * both Windows and POSIX (EEXIST when it already exists), so exactly one concurrent caller wins.
+ * If the existing lock is stale (older than ttlMs), it is reclaimed once and re-attempted.
+ *
+ * @param {string} lockPath
+ * @param {object} [io] injectable fs surface for tests
+ * @returns {boolean} true if THIS caller now holds the lock (and must release it)
+ */
+function acquireHealLock(lockPath, io = {}) {
+  const mkdir = io.mkdir || ((p) => fs.mkdirSync(p));
+  const statMtimeMs = io.statMtimeMs || ((p) => fs.statSync(p).mtimeMs);
+  const rmdir = io.rmdir || ((p) => fs.rmSync(p, { recursive: true, force: true }));
+  const nowMs = io.nowMs != null ? io.nowMs : Date.now();
+  const ttlMs = io.ttlMs != null ? io.ttlMs : HEAL_LOCK_TTL_MS;
+  try {
+    mkdir(lockPath);
+    return true; // created → we own it
+  } catch (e) {
+    if (!e || e.code !== 'EEXIST') return false; // unexpected error → do not heal (fail-open)
+    // Lock exists. Reclaim it only if stale, then retry once.
+    let mtime;
+    try { mtime = statMtimeMs(lockPath); } catch { mtime = NaN; }
+    if (!isStaleLock(mtime, nowMs, ttlMs)) return false; // a live healer owns it → skip
+    try { rmdir(lockPath); } catch { return false; }
+    try { mkdir(lockPath); return true; } catch { return false; } // lost the reclaim race → skip
+  }
+}
+
+/**
+ * Pure: the additive, never-destructive heal command. ALWAYS `npm install` with the safe flags —
+ * never `npm ci`, never a remove. Returns { cmd, args } for spawnSync.
+ */
+function buildHealCommand() {
+  return { cmd: 'npm', args: ['install', '--ignore-scripts', '--no-audit', '--no-fund'] };
+}
+
+/** Thin imperative wrapper: detect → lock → additive install → release. Fail-open. */
+function main(rootDir = path.resolve(__dirname, '..', '..')) {
+  try {
+    if (!needsHeal(rootDir)) { return 0; } // healthy store → silent fast-exit
+    const lockPath = path.join(rootDir, LOCK_DIRNAME);
+    if (!acquireHealLock(lockPath)) {
+      logHeal('heal-skip', { reason: 'another session is healing (lock held)' });
+      return 0;
+    }
+    try {
+      logHeal('heal-start', { dep: CRITICAL_DEP });
+      const { cmd, args } = buildHealCommand();
+      const res = spawnSync(cmd, args, { cwd: rootDir, encoding: 'utf8', stdio: 'ignore', shell: process.platform === 'win32', windowsHide: true });
+      if (res.status === 0 && !needsHeal(rootDir)) {
+        logHeal('heal-done', {});
+      } else {
+        logHeal('heal-fail', { status: res.status, error: res.error && res.error.message });
+      }
+    } finally {
+      try { fs.rmSync(lockPath, { recursive: true, force: true }); } catch { /* best-effort release */ }
+    }
+  } catch (e) {
+    logHeal('heal-error', { error: e && e.message }); // fail-open: never block session start
+  }
+  return 0;
+}
+
+module.exports = {
+  CRITICAL_DEP,
+  HEAL_LOCK_TTL_MS,
+  LOCK_DIRNAME,
+  needsHeal,
+  isStaleLock,
+  acquireHealLock,
+  buildHealCommand,
+  main,
+};
+
+if (require.main === module) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Summary
A wiped/emptied shared `node_modules` bricks every parallel session with `ERR_MODULE_NOT_FOUND` (@supabase/supabase-js, dotenv). The existing NPM CI SHARED-STORE WIPE GUARD (pre-tool-enforce.cjs ENFORCEMENT 12c) only intercepts the **Bash** tool's `npm ci` and cannot cover non-Bash invocations (a PowerShell `npm ci`, an override-flagged install, a pre-guard session). This adds the **recovery counterpart**: a SessionStart hook that detects an empty store and additively re-installs it — covering every wipe path.

## What it does
- **FR-1 `needsHeal`** — exact-path check of `node_modules/@supabase/supabase-js/package.json` (deliberately **not** `require.resolve`, which walks up to a parent store and masks an emptied worktree store — caught live during dogfooding).
- **FR-2 herd-safe single-healer lock** — atomic `mkdirSync` + stale-TTL reclaim, so N sessions on an empty store trigger exactly **one** install (no re-wipe herd).
- **FR-3 additive-only** — `npm install --ignore-scripts --no-audit --no-fund`, **never** `npm ci` / `rm -rf`, so the hook can never itself wipe the store.
- **FR-4** — fail-open, <200ms healthy fast-exit, `require.main`-guarded, registered **first** in SessionStart.

## Testing
- 13 unit tests (pure detect / lock / command logic), all passing.
- Live dogfood: removed `node_modules/@supabase`, ran the hook → `heal-start` → `heal-done` → store restored, `needsHeal` false. Healthy path: silent, 56ms, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)