### PR TITLE
fix(SD-REFILL-00202Z4B): word-boundary QF keyword match so 'authoring' no longer trips 'auth'

### DIFF
--- a/scripts/classify-quick-fix.js
+++ b/scripts/classify-quick-fix.js
@@ -19,11 +19,15 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import { pathToFileURL } from 'url';
 import { analyzePatterns, createPatternRetrospective } from '../lib/utils/quickfix-rca-integration.js';
 // SD-LEO-INFRA-SESSION-AWARE-AUTO-001 (FR-2): session-aware QF adoption.
 import { claimQuickFix } from '../lib/quick-fix-claim.mjs';
 
 dotenv.config();
+
+// SD-REFILL-00202Z4B: export the pure matchers for unit tests (CLI is guarded below).
+export { matchesKeyword, analyzeDescription, CLASSIFICATION_RULES };
 
 // Classification rules
 const CLASSIFICATION_RULES = {
@@ -50,20 +54,42 @@ const CLASSIFICATION_RULES = {
   ]
 };
 
+// SD-REFILL-00202Z4B: escape regex metacharacters so a keyword is matched literally.
+function escapeRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * SD-REFILL-00202Z4B: word-boundary keyword match. The prior naive `combined.includes(keyword)`
+ * substring-matched 'auth' INSIDE 'authoring'/'author'/'authentic', force-escalating low-LOC doc QFs
+ * to a full SD (witnessed: QF-20260614-918, a doc fix for the Adam contract, escalated on 'authoring').
+ * Anchor with \b on both sides, but tolerate a trailing plural/gerund suffix so genuinely-risky inflected
+ * forms still match (refactor→refactoring/refactors, database→databases, migration→migrations,
+ * "breaking change"→"breaking changes"). 'authoring' is NOT matched: after 'auth' comes 'o' (a word char),
+ * so no suffix option and no \b applies. Case-insensitive. Pure.
+ * @param {string} text already-lowercased haystack
+ * @param {string} keyword the keyword/phrase to test
+ * @returns {boolean}
+ */
+function matchesKeyword(text, keyword) {
+  const re = new RegExp(`\\b${escapeRegExp(keyword.toLowerCase())}(?:e?s|ing|ed)?\\b`, 'i');
+  return re.test(text);
+}
+
 function analyzeDescription(description, title) {
   const combined = `${title} ${description}`.toLowerCase();
   const issues = [];
 
-  // Check for forbidden keywords
+  // Check for forbidden keywords (word-boundary, not naive substring — see matchesKeyword)
   for (const keyword of CLASSIFICATION_RULES.forbiddenKeywords) {
-    if (combined.includes(keyword.toLowerCase())) {
+    if (matchesKeyword(combined, keyword)) {
       issues.push(`Contains forbidden keyword: "${keyword}"`);
     }
   }
 
   // Check for risk keywords
   for (const keyword of CLASSIFICATION_RULES.riskKeywords) {
-    if (combined.includes(keyword.toLowerCase())) {
+    if (matchesKeyword(combined, keyword)) {
       issues.push(`Contains risk keyword: "${keyword}"`);
     }
   }
@@ -291,10 +317,11 @@ async function classifyQuickFix(qfId, options = {}) {
   }
 }
 
-// CLI argument parsing
-const args = process.argv.slice(2);
+// CLI argument parsing — guarded so importing this module (for tests) does not run the CLI.
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const args = isMain ? process.argv.slice(2) : [];
 
-if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+if (isMain && (args.length === 0 || args.includes('--help') || args.includes('-h'))) {
   console.log(`
 LEO Quick-Fix Workflow - Classify Issue
 
@@ -320,13 +347,15 @@ Examples:
   process.exit(0);
 }
 
-const qfId = args[0];
-const options = {
-  autoEscalate: args.includes('--auto-escalate')
-};
+if (isMain) {
+  const qfId = args[0];
+  const options = {
+    autoEscalate: args.includes('--auto-escalate')
+  };
 
-// Run
-classifyQuickFix(qfId, options).catch((err) => {
-  console.error('❌ Error:', err.message);
-  process.exit(1);
-});
+  // Run
+  classifyQuickFix(qfId, options).catch((err) => {
+    console.error('❌ Error:', err.message);
+    process.exit(1);
+  });
+}

--- a/tests/unit/classify-quick-fix-keyword-boundary.test.js
+++ b/tests/unit/classify-quick-fix-keyword-boundary.test.js
@@ -1,0 +1,63 @@
+// SD-REFILL-00202Z4B — classify-quick-fix forbidden/risk keyword matching must be word-boundary, not
+// naive substring. The prior `combined.includes('auth')` matched 'auth' INSIDE 'authoring'/'author'/
+// 'authentic', force-escalating low-LOC doc QFs to a full SD (witnessed: QF-20260614-918, a documentation
+// fix for the Adam contract, escalated because its description contained 'authoring'). matchesKeyword now
+// anchors with \b on both sides while tolerating a plural/gerund suffix so genuinely-risky inflected forms
+// (refactoring, databases, migrations, "breaking changes") still match.
+import { describe, it, expect } from 'vitest';
+import { matchesKeyword, analyzeDescription } from '../../scripts/classify-quick-fix.js';
+
+describe('matchesKeyword — word-boundary keyword match (SD-REFILL-00202Z4B)', () => {
+  it('does NOT match "auth" inside authoring/author/authentic (the false-escalation bug)', () => {
+    expect(matchesKeyword('fix the adam authoring contract', 'auth')).toBe(false);
+    expect(matchesKeyword('the author of the doc', 'auth')).toBe(false);
+    expect(matchesKeyword('authentic content', 'auth')).toBe(false);
+  });
+
+  it('still matches "auth" as a standalone word', () => {
+    expect(matchesKeyword('add an auth check', 'auth')).toBe(true);
+    expect(matchesKeyword('AUTH middleware', 'auth')).toBe(true);
+    expect(matchesKeyword('disable auth.', 'auth')).toBe(true); // punctuation boundary
+  });
+
+  it('matches the longer auth keywords as whole words', () => {
+    expect(matchesKeyword('add authentication', 'authentication')).toBe(true);
+    expect(matchesKeyword('change authorization rules', 'authorization')).toBe(true);
+  });
+
+  it('tolerates plural/gerund suffixes so risky inflected forms still match (no regression)', () => {
+    expect(matchesKeyword('big refactoring effort', 'refactor')).toBe(true);
+    expect(matchesKeyword('several refactors', 'refactor')).toBe(true);
+    expect(matchesKeyword('touches two databases', 'database')).toBe(true);
+    expect(matchesKeyword('run the migrations', 'migration')).toBe(true);
+    expect(matchesKeyword('breaking changes ahead', 'breaking change')).toBe(true);
+  });
+
+  it('matches multi-word phrases on a word boundary', () => {
+    expect(matchesKeyword('add a new table for x', 'new table')).toBe(true);
+    expect(matchesKeyword('touches multiple files', 'multiple files')).toBe(true);
+    expect(matchesKeyword('a renewable feature', 'new feature')).toBe(false); // not fooled by 'new' in 'renewable'
+  });
+
+  it('does NOT match unrelated substrings (security in "insecurity"? — boundary protects)', () => {
+    expect(matchesKeyword('insecurity is not security', 'security')).toBe(true); // standalone 'security' present
+    expect(matchesKeyword('feeling insecure today', 'security')).toBe(false);   // only inside 'insecure'
+  });
+});
+
+describe('analyzeDescription — end-to-end (SD-REFILL-00202Z4B)', () => {
+  it('does NOT flag a doc QF that merely mentions "authoring"', () => {
+    const issues = analyzeDescription('Update the Adam authoring contract wording', 'Doc fix: authoring contract');
+    expect(issues).toEqual([]);
+  });
+
+  it('still flags a real auth/security change', () => {
+    const issues = analyzeDescription('Add auth middleware and RLS policy', 'Security: auth gate');
+    expect(issues.some((i) => /auth/i.test(i))).toBe(true);
+  });
+
+  it('still flags a refactor risk keyword', () => {
+    const issues = analyzeDescription('Large refactor across modules', 'Refactor pass');
+    expect(issues.some((i) => /refactor/i.test(i))).toBe(true);
+  });
+});


### PR DESCRIPTION
## SD-REFILL-00202Z4B

`classify-quick-fix.js` forbidden/risk keyword detection used naive `combined.includes(keyword)`, matching **'auth' inside 'authoring'/'author'/'authentic'** and force-escalating low-LOC documentation QFs to a full SD (witnessed: QF-20260614-918, a doc fix for the Adam contract, escalated on 'authoring').

### Fix
- Pure `matchesKeyword()`: `\b`-anchored both sides with a tolerated plural/gerund suffix `(?:e?s|ing|ed)?` so 'authoring'/'author' no longer match 'auth', while genuinely-risky inflected forms still do (`refactoring`, `databases`, `migrations`, `breaking changes`).
- `escapeRegExp` on every keyword (defensive).
- Export the pure matchers + guard the CLI behind an `import.meta.url` main check so they're unit-testable.

### Tests
- 9 new unit tests (false-escalation fix, true positives preserved, no inflection regression, boundary correctness). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)