### PR TITLE
fix(SD-REFILL-00WV9A45): allow DIAGNOSIS/RCA phases in model_usage_log CHECK

### DIFF
--- a/database/migrations/20260622_fix_model_usage_log_phase_diagnosis_rca.sql
+++ b/database/migrations/20260622_fix_model_usage_log_phase_diagnosis_rca.sql
@@ -1,0 +1,77 @@
+-- Migration: 20260622_fix_model_usage_log_phase_diagnosis_rca
+-- SD: SD-REFILL-00WV9A45
+-- @approved-by: rickfelix@example.com
+--
+-- Issue: model_usage_log_phase_check rejects 'DIAGNOSIS' (and 'RCA') — the phase
+--        emitted when a github-agent / rca-agent style diagnostic sub-agent runs.
+--        lib/llm/usage-logger.js writes caller-supplied phase RAW
+--        (`phase: phase || 'UNKNOWN'` — NO normalizePhase), so a diagnosis run
+--        inserting phase='DIAGNOSIS' violates the CHECK constraint (23514) and the
+--        non-blocking usage logger silently drops the row → telemetry hole.
+--        (scripts/track-model-usage.js is protected by normalizePhase()→UNKNOWN, but
+--        that collapses diagnostic runs into UNKNOWN — fidelity loss, see ALLOWED_PHASES.)
+--        Surfaced by github-agent during run wpvlmgl4d.
+--
+-- RCA:   6th expansion of this CHECK constraint, identical pattern to the prior
+--        five (20260426 / 20260429-hyphenated / 20260511-LEAD_FINAL /
+--        20260526-PROSPECTIVE_VALIDATION). track-model-usage.js + lib/llm/usage-logger.js
+--        accept caller-supplied `phase` as free-form; the constraint is the canonical
+--        enum and must be expanded each time a new caller emits a new phase string.
+--        'DIAGNOSIS' is the ROOT CAUSE DIAGNOSIS phase (CLAUDE_PLAN.md Phase 3);
+--        'RCA' is the rca-agent label.
+--
+-- Fix:   Re-add the enum constraint including 'DIAGNOSIS' and 'RCA'. Additive and
+--        idempotent (DROP IF EXISTS + ADD); widens the allowlist only — never rejects
+--        existing data, so it is safe to (re)apply.
+
+ALTER TABLE model_usage_log
+DROP CONSTRAINT IF EXISTS model_usage_log_phase_check;
+
+ALTER TABLE model_usage_log
+ADD CONSTRAINT model_usage_log_phase_check
+CHECK (phase IN (
+  -- Original allowlist
+  'LEAD',
+  'PLAN',
+  'EXEC',
+  'UNKNOWN',
+  -- Completion/standalone (added 2026-04-26 per QF-20260425-002)
+  'STANDALONE',
+  'QF_COMPLETION',
+  'SD_COMPLETION',
+  'HANDOFF',
+  'COMPLETE',
+  -- Underscore sub-phase variants (added 2026-04-26)
+  'LEAD_APPROVAL',
+  'LEAD_FINAL_APPROVAL',
+  'PLAN_DESIGN',
+  'PLAN_VERIFY',
+  'EXEC_IMPLEMENTATION',
+  -- Hyphenated handoff transition strings (added 2026-04-29)
+  'LEAD-TO-PLAN',
+  'PLAN-TO-EXEC',
+  'EXEC-TO-PLAN',
+  'PLAN-TO-LEAD',
+  'LEAD-FINAL',
+  -- Underscore internal phase-state names (added 2026-05-11 per QF-20260511-163)
+  'LEAD_FINAL',
+  -- Prospective sub-agent phases (added 2026-05-26 per QF-20260526-691)
+  'PROSPECTIVE_VALIDATION',
+  -- Diagnostic sub-agent phases (added 2026-06-22 per SD-REFILL-00WV9A45)
+  -- Emitted by github-agent / rca-agent diagnostic runs (ROOT CAUSE DIAGNOSIS).
+  -- usage-logger.js passes caller phase raw, so these MUST be in the enum or the
+  -- non-blocking logger silently drops the row.
+  'DIAGNOSIS',
+  'RCA'
+));
+
+COMMENT ON CONSTRAINT model_usage_log_phase_check ON model_usage_log IS
+'Valid phase values for model usage tracking. Expanded 2026-06-22 (SD-REFILL-00WV9A45) to add DIAGNOSIS and RCA — emitted by github-agent/rca-agent diagnostic sub-agent runs. lib/llm/usage-logger.js passes caller phase raw, so these labels must be in the enum or the non-blocking logger silently drops the row (telemetry hole).';
+
+-- ROLLBACK:
+-- ALTER TABLE model_usage_log DROP CONSTRAINT IF EXISTS model_usage_log_phase_check;
+-- ALTER TABLE model_usage_log ADD CONSTRAINT model_usage_log_phase_check
+--   CHECK (phase IN ('LEAD','PLAN','EXEC','UNKNOWN','STANDALONE','QF_COMPLETION',
+--   'SD_COMPLETION','HANDOFF','COMPLETE','LEAD_APPROVAL','LEAD_FINAL_APPROVAL',
+--   'PLAN_DESIGN','PLAN_VERIFY','EXEC_IMPLEMENTATION','LEAD-TO-PLAN','PLAN-TO-EXEC',
+--   'EXEC-TO-PLAN','PLAN-TO-LEAD','LEAD-FINAL','LEAD_FINAL','PROSPECTIVE_VALIDATION'));

--- a/scripts/track-model-usage.js
+++ b/scripts/track-model-usage.js
@@ -28,6 +28,11 @@ const ALLOWED_PHASES = new Set([
   'HANDOFF', 'COMPLETE', 'LEAD_APPROVAL', 'LEAD_FINAL_APPROVAL', 'PLAN_DESIGN',
   'PLAN_VERIFY', 'EXEC_IMPLEMENTATION', 'LEAD-TO-PLAN', 'PLAN-TO-EXEC', 'EXEC-TO-PLAN',
   'PLAN-TO-LEAD', 'LEAD-FINAL', 'LEAD_FINAL', 'PROSPECTIVE_VALIDATION',
+  // Diagnostic sub-agent phases (added 2026-06-22 per SD-REFILL-00WV9A45): github-agent /
+  // rca-agent diagnosis runs (ROOT CAUSE DIAGNOSIS). Mirrors the constraint widen in
+  // database/migrations/20260622_fix_model_usage_log_phase_diagnosis_rca.sql so these are
+  // tracked distinctly instead of collapsing to UNKNOWN. Requires that migration LIVE.
+  'DIAGNOSIS', 'RCA',
 ]);
 
 // Canonical synonyms used elsewhere that are NOT in ALLOWED_PHASES → their accepted equivalent.

--- a/tests/database/model-usage-log-phase-diagnosis-rca.test.js
+++ b/tests/database/model-usage-log-phase-diagnosis-rca.test.js
@@ -1,0 +1,64 @@
+/**
+ * model_usage_log_phase_check DIAGNOSIS/RCA expansion regression test
+ * SD-REFILL-00WV9A45
+ *
+ * Issue: lib/llm/usage-logger.js writes caller-supplied phase RAW
+ *   (`phase: phase || 'UNKNOWN'`, NO normalizePhase), so a github-agent/rca-agent
+ *   diagnostic run inserting phase='DIAGNOSIS' violated model_usage_log_phase_check
+ *   (23514) and the non-blocking logger silently dropped the row → telemetry hole.
+ *
+ * Fix (6th expansion of this CHECK):
+ *   - database/migrations/20260622_fix_model_usage_log_phase_diagnosis_rca.sql adds
+ *     'DIAGNOSIS' and 'RCA' to the constraint.
+ *   - scripts/track-model-usage.js ALLOWED_PHASES mirrors them so normalizePhase()
+ *     passes them through (tracked distinctly) instead of coercing to UNKNOWN.
+ *
+ * This test is intentionally LIVE-PROBE-FREE: the constraint migration is applied by
+ * the pipeline/chairman (MCP apply_migration is read-only in worker sessions), so a
+ * live INSERT probe of 'DIAGNOSIS' would fail until the migration lands. Instead it
+ * pins (1) the pure normalizePhase pass-through and (2) the migration + ALLOWED_PHASES
+ * source contract — both revert-proof without depending on deploy timing.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { normalizePhase } from '../../scripts/track-model-usage.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(resolve(__dirname, '../../scripts/track-model-usage.js'), 'utf8');
+const MIGRATION = readFileSync(
+  resolve(__dirname, '../../database/migrations/20260622_fix_model_usage_log_phase_diagnosis_rca.sql'),
+  'utf8'
+);
+
+describe('normalizePhase() passes DIAGNOSIS/RCA through (SD-REFILL-00WV9A45)', () => {
+  it("treats 'DIAGNOSIS' as an allowed phase (no longer coerced to UNKNOWN)", () => {
+    expect(normalizePhase('DIAGNOSIS')).toBe('DIAGNOSIS');
+  });
+  it("treats 'RCA' as an allowed phase", () => {
+    expect(normalizePhase('RCA')).toBe('RCA');
+  });
+  it('still falls back to UNKNOWN for genuinely unrecognized phases (no over-widening)', () => {
+    expect(normalizePhase('TOTALLY_BOGUS')).toBe('UNKNOWN');
+    expect(normalizePhase(undefined)).toBe('UNKNOWN');
+  });
+  it('still maps the canonical synonym PLAN_VERIFICATION → PLAN_VERIFY (no regression)', () => {
+    expect(normalizePhase('PLAN_VERIFICATION')).toBe('PLAN_VERIFY');
+  });
+});
+
+describe('source contract: constraint + ALLOWED_PHASES carry DIAGNOSIS/RCA', () => {
+  it('the migration adds both DIAGNOSIS and RCA to model_usage_log_phase_check', () => {
+    expect(MIGRATION).toMatch(/model_usage_log_phase_check/);
+    expect(MIGRATION).toMatch(/'DIAGNOSIS'/);
+    expect(MIGRATION).toMatch(/'RCA'/);
+    // The new values are inside the ADD CONSTRAINT ... CHECK (...) block.
+    const addIdx = MIGRATION.indexOf('ADD CONSTRAINT');
+    expect(addIdx).toBeGreaterThan(-1);
+    expect(MIGRATION.indexOf("'DIAGNOSIS'", addIdx)).toBeGreaterThan(addIdx);
+  });
+  it('ALLOWED_PHASES in track-model-usage.js mirrors the two new values', () => {
+    expect(SRC).toMatch(/'DIAGNOSIS',\s*'RCA'/);
+  });
+});


### PR DESCRIPTION
## SD-REFILL-00WV9A45

`lib/llm/usage-logger.js` writes the caller-supplied phase RAW (`phase || 'UNKNOWN'`, no normalizePhase), so a github-agent/rca-agent diagnostic run inserting `phase='DIAGNOSIS'` violated `model_usage_log_phase_check` (23514) and the non-blocking logger **silently dropped the row** — a telemetry hole. (`track-model-usage.js` was protected by `normalizePhase()->UNKNOWN`, which collapses diagnostic runs into UNKNOWN.)

### Fix
- **Migration** (6th additive expansion, family 20260426/29/0511/0526): adds `DIAGNOSIS` + `RCA`. Additive/idempotent (DROP IF EXISTS + ADD), widens only. **Applied by pipeline/chairman** (MCP apply_migration is read-only in worker sessions) — MERGED ≠ LIVE, apply step flagged.
- `track-model-usage.js` ALLOWED_PHASES mirrors the two values (PROSPECTIVE_VALIDATION precedent) so normalizePhase passes them through, tracked distinctly instead of UNKNOWN.

### Tests
- Live-probe-free (constraint not yet applied) source-contract + pure-helper pins. Suite green; no regression to the existing normalize live-probe tests.

Premise verified live: current constraint lacks DIAGNOSIS/RCA. Resumed from an orphaned in_progress worktree (prior session committed EXEC then was reaped pre-PRD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)