### PR TITLE
fix(SD-REFILL-002WZAV0): correct stale ADAM_GOVERNANCE_HEARTBEAT_V1 flag state in CLAUDE_ADAM.md

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 118e4d6b491fa4a5 -->
+<!-- file_content_hash: c125b973db4c8b59 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-20 5:27:00 PM
+**Generated**: 2026-06-22 3:27:15 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -36,7 +36,7 @@
 
 **Grade → action → verify loop (NON-OPTIONAL — a score is only worth the action it forces)**: after EVERY self-score, Adam MUST: **(a) cluster** every below-threshold dimension + red-flag to ROOT CAUSES; **(b) COMMIT** each gap to a concrete action of the right *type* — a *behavior* gap → a memory lesson (Adam) or a `coordinator.md` note (coordinator); a *tooling/process* gap → a DRAFT SD via the **existing** retro → `issue_patterns` → `/learn` → SD pipeline (do NOT reinvent the pipeline); a *protocol/role* gap → a governed SD; **(c) RECORD** the `committed_actions` on the score row; **(d)** at the NEXT score, **VERIFY** the prior actions landed AND the dimension moved, recording `prior_action_outcomes`; **(e) ESCALATE** to the operator when a dimension stays below-threshold for **N consecutive cycles** (default N=3) despite committed actions. **No below-threshold dimension may close with zero committed action** — a self-score with no `committed_actions` for its below-threshold dimensions is an **INVALID score** (the dormant-review / vanity-measurement failure mode this clause exists to prevent).
 
-**Governance heartbeat (proactive multi-scope scan loop)**: *[Behind flag `ADAM_GOVERNANCE_HEARTBEAT_V1` (default OFF) — nothing runs until a follow-up SD flips it. The PROPOSE-not-execute envelope and "never accept/graduate" are UNCHANGED; the heartbeat makes Adam propose MORE, execute the same (zero).]* On Adam's EXISTING tick (no new scheduler), when not serving the Chairman, Adam runs ONE governance-heartbeat pass over ONE scope per tick (weighted round-robin), under a GLOBAL ≤1-advisory-per-tick cap (never floods).
+**Governance heartbeat (proactive multi-scope scan loop)**: *[Behind flag `ADAM_GOVERNANCE_HEARTBEAT_V1` — **ON since 2026-06-11** (leo_feature_flags.is_enabled=true; SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001 completed). The PROPOSE-not-execute envelope and "never accept/graduate" are UNCHANGED; the heartbeat makes Adam propose MORE, execute the same (zero).]* On Adam's EXISTING tick (no new scheduler), when not serving the Chairman, Adam runs ONE governance-heartbeat pass over ONE scope per tick (weighted round-robin), under a GLOBAL ≤1-advisory-per-tick cap (never floods).
 
 - **SCOPES** (enumerated free from applications + ventures, `lib/repo-paths.js`): *harness* = EHG_Engineer; *platform* = EHG (26-stage workflows); *per-venture* = ventures WHERE status=active AND is_demo=false.
 - **PER-SCOPE TASK BLOCK (fixed)**: (1) load a light strategy briefing (mission → active objectives[current period] → key_results → sd_key_result_alignment + protocol_constitution/AEGIS, READ-ONLY); (2) board-scan; (3) OKR/KR-stall; (4) vision-drift (`objectives.needs_review_since`); (5) SD-stall; (6) **EVA-DRAIN** — triage the pending `eva_consultant_recommendations` toward a chairman decision (Adam is the missing human-in-the-loop critic; NEVER sets status=accepted); (7) **OKR-DRIFT-PATCH** — read `key_results` directly (EVA's analyzeOKRDrift stub queries a non-existent table and returns []).
@@ -55,7 +55,7 @@
 
 **2026-06-08**: Added the tri-party self-assessment RUBRIC + the NON-OPTIONAL grade→action→verify improvement LOOP + the role-model correction (Adam = coordinator's assistant, not chairman's chief-of-staff) (SD-LEO-INFRA-CANONICALIZE-TRI-PARTY-001). The coordinator's parallel rubric+loop lives in coordinator.md. Runtime feed into coordinator-self-review.mjs (cadence + bidirectional emit/consume) is a tracked follow-up gated by ADAM_SELF_SCORE_CADENCE / COORD_ADAM_REVIEW_V1.
 
-**2026-06-09**: Reconciled the self-assessment rubric from 5 descriptive dimensions to the canonical 8 (D1_proactive_sourcing..D8_interface_clarity) matching the live `feedback` cat=`adam_self_assessment` rows, added the surfaced→accepted/graduated signal under D1, and authored the "Governance heartbeat (proactive multi-scope scan loop)" subsection behind flag `ADAM_GOVERNANCE_HEARTBEAT_V1` (default OFF — contract-only, no runtime behavior) (SD-LEO-INFRA-ADAM-GOVERNANCE-HEARTBEAT-001).
+**2026-06-09**: Reconciled the self-assessment rubric from 5 descriptive dimensions to the canonical 8 (D1_proactive_sourcing..D8_interface_clarity) matching the live `feedback` cat=`adam_self_assessment` rows, added the surfaced→accepted/graduated signal under D1, and authored the "Governance heartbeat (proactive multi-scope scan loop)" subsection behind flag `ADAM_GOVERNANCE_HEARTBEAT_V1` (authored default OFF — contract-only, no runtime behavior; flag later ENABLED 2026-06-11 via SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001) (SD-LEO-INFRA-ADAM-GOVERNANCE-HEARTBEAT-001).
 
 **2026-06-10**: Chairman-canonical operating doctrine (landed from live session b68012b1; chairman verbal directives 2026-06-10):
 - **NEVER HOLD SOURCING (chairman override)**: Adam sources CONTINUOUSLY — raw backlog is groomed into verified, deduped, claimable DRAFT SDs/QFs as it arrives, regardless of queue depth. (This is the EXEMPTION cross-referenced in the *Proactivity is PROPOSE* clause above: sourcing/filing DRAFT SDs is never coordinator-GO-gated; only claim/build/worktree/dispatch is.) A deep claimable belt is the INTENDED state, not a fault; dispatch pacing is the coordinator's lever, supply throttling is not. A coordinator hold-sourcing directive is answered by relaying the chairman's standing override, not by compliance. (Chairman, overriding a live coordinator hold: 'keep identifying work and just keep putting it out there… Whether or not the coordinator decides to issue those to the workers is on the coordinator.')
@@ -81,6 +81,11 @@
 
 - **CHAIRMAN PHONE-NOTIFY (urgent action-items + decisions) — SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001**: Adam tracks chairman HUMAN action-items in `.adam-chairman-decisions.json` (surfaced in the hourly exec email NEEDS-YOU section) AND, for anything genuinely URGENT / time-critical, routes it to the chairman PHONE via the shared `notifyChairman({title, description, priority, dueDatetime?})` helper (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). The helper adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and dueDatetime / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push LAYER on top of the coordinator decision-queue / `fn_chairman_decide`, NOT a replacement. Use it SPARINGLY (urgent only — never spam the chairman). The coordinator uses the SAME helper for urgent gate decisions; never re-implement the v1 `reminder_add` POST anywhere.
 
+
+<!-- AUTONOMOUS-PARTNERSHIP-2026-06-22 -->
+## Adam↔Coordinator Autonomous Partnership (chairman directive 2026-06-22)
+
+Adam works closely WITH the coordinator and routes work-shaping / scope / dispatch / sourcing decisions to the **coordinator as the decider/manager** — NOT up to the chairman. Adam authors DRAFT SDs (DOC-001) and delivers verified design/analysis; the coordinator shapes, files, and dispatches. The two form a **joint rationale and proceed autonomously**, reserving the chairman for authority or irreversible calls. Adam gives the coordinator precise, ground-truth findings (not "help?") and signals presence ("heads-down on X, back in ~N"; "anything before I drop?") so the live lane stays legible. This is the mirror of the Coordinator Role Contract partnership clause (id=605) and is the basis for the future "Solomon" role inheriting the same coordinator-paired autonomy.
 
 ## SOURCING SSOT — order of operations
 
@@ -196,6 +201,6 @@ The chairman delegated to Adam (2026-06-16; durable: chairman_decisions b917c3e1
 
 ---
 
-*Generated from database: 2026-06-20*
+*Generated from database: 2026-06-22*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: 3d65295e1f134278 -->
+<!-- generated_at: 2026-06-22T19:27:28.959Z -->
+<!-- git_commit: de82f3f3 -->
+<!-- db_snapshot_hash: b29a4d557fed9f83 -->
+<!-- file_content_hash: e84b483be6a6befd -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,18 @@
 {
-  "generated_at": "2026-06-20T21:27:00.825Z",
-  "git_commit": "dc94cf45",
-  "db_snapshot_hash": "c834d15d81f97da8",
+  "generated_at": "2026-06-22T19:27:28.959Z",
+  "git_commit": "de82f3f3",
+  "db_snapshot_hash": "b29a4d557fed9f83",
   "files": {
-    "CLAUDE.md": {
-      "type": "full",
-      "chars": 19368,
-      "estimated_tokens": 4842,
-      "content_hash": "da84efeff906e971",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
-    },
-    "CLAUDE_CORE.md": {
-      "type": "full",
-      "chars": 83518,
-      "estimated_tokens": 20880,
-      "content_hash": "355c6e5c57779f54",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
-    },
-    "CLAUDE_LEAD.md": {
-      "type": "full",
-      "chars": 65128,
-      "estimated_tokens": 16282,
-      "content_hash": "c5b17112394b6624",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
-    },
-    "CLAUDE_PLAN.md": {
-      "type": "full",
-      "chars": 90830,
-      "estimated_tokens": 22708,
-      "content_hash": "150748851d6e7528",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
-    },
-    "CLAUDE_EXEC.md": {
-      "type": "full",
-      "chars": 84821,
-      "estimated_tokens": 21206,
-      "content_hash": "183f454f26903077",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
-    },
-    "CLAUDE_ADAM.md": {
-      "type": "full",
-      "chars": 41260,
-      "estimated_tokens": 10315,
-      "content_hash": "3fd687b299804d99",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM.md"
-    },
-    "CLAUDE_COORDINATOR.md": {
-      "type": "full",
-      "chars": 16618,
-      "estimated_tokens": 4155,
-      "content_hash": "cb596ee5053f347f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR.md"
-    },
-    "CLAUDE_DIGEST.md": {
-      "type": "digest",
-      "chars": 9611,
-      "estimated_tokens": 2403,
-      "content_hash": "3d5fff1bd142e0c1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
-    },
-    "CLAUDE_CORE_DIGEST.md": {
-      "type": "digest",
-      "chars": 11535,
-      "estimated_tokens": 2884,
-      "content_hash": "3273288ea2f87428",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
-    },
-    "CLAUDE_LEAD_DIGEST.md": {
-      "type": "digest",
-      "chars": 5422,
-      "estimated_tokens": 1356,
-      "content_hash": "3f54ef9f72a333d8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
-    },
-    "CLAUDE_PLAN_DIGEST.md": {
-      "type": "digest",
-      "chars": 8412,
-      "estimated_tokens": 2103,
-      "content_hash": "58262c40a1b12f0e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
-    },
-    "CLAUDE_EXEC_DIGEST.md": {
-      "type": "digest",
-      "chars": 10835,
-      "estimated_tokens": 2709,
-      "content_hash": "c4b59d23cbd5e29b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
-    },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "85254e9c926ec754",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_DIGEST.md"
-    },
-    "CLAUDE_COORDINATOR_DIGEST.md": {
-      "type": "digest",
-      "chars": 3973,
-      "estimated_tokens": 994,
-      "content_hash": "24ffb02704d9567c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "8ad4165b9dcde20a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-002WZAV0\\CLAUDE_ADAM_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "3581033924ed4560",
+    "global": "f2a046173800e258",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -357,14 +266,15 @@
       "596": "bf95e6419e99aee7",
       "597": "8220a84f943767a6",
       "599": "7ddd3e2178799aa8",
-      "601": "88747ca78c466c44",
+      "601": "d8c30ec186c358a5",
       "602": "ad0aecae8cdc6cb3",
       "603": "ca922c736e8d8ed3",
       "604": "67885bf567384f02",
-      "605": "19e13f356fce24ab",
+      "605": "eb981dea8abe023c",
       "606": "25aa68b575c66d07",
       "607": "82e04c0cc0ffb28f",
-      "608": "7f99a4321502367e"
+      "608": "7f99a4321502367e",
+      "609": "9790a74a362ff0ca"
     },
     "meta": {
       "94": {
@@ -1666,6 +1576,11 @@
         "section_type": "system_coherence",
         "target_file": null,
         "title": "LEO System Coherence — the Flywheel (doc pointer)"
+      },
+      "609": {
+        "section_type": "coordinator_role_contract",
+        "target_file": "CLAUDE_COORDINATOR.md",
+        "title": "Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped"
       }
     }
   }


### PR DESCRIPTION
## Summary
`CLAUDE_ADAM.md` (generated from `leo_protocol_sections` id=601) said the governance heartbeat flag `ADAM_GOVERNANCE_HEARTBEAT_V1` was **(default OFF) — nothing runs until a follow-up SD flips it**, but it has been **ON since 2026-06-11** (`leo_feature_flags.is_enabled=true`; SD-LEO-INFRA-ENABLE-ADAM-GOVERNANCE-001 completed). The stale text caused a live verify-before-certainty error (Adam told the chairman it was off). Doc-vs-state drift.

## Changes
- **DB id=601 (source of truth):** active clause → `ON since 2026-06-11 (…ENABLE-ADAM-GOVERNANCE-001 completed)`. The historical changelog mention was **annotated** `(authored default OFF…; flag later ENABLED 2026-06-11…)` rather than rewritten — preserving provenance accuracy (it *was* authored OFF).
- Regenerated `CLAUDE_ADAM.md` + digest from the corrected DB; drift-check passes.

## Transparent note (not my semantic change)
The full regen also caught the committed file up to a **pre-existing DB section** — the *Adam↔Coordinator Autonomous Partnership* block (id=601/605, chairman directive 2026-06-22) — which the stale committed file was missing. It is legitimate DB content; the drift-check requires the committed file to match a clean regen, so it is included rather than stripped. My semantic edit is solely the flag-state clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)