### PR TITLE
feat(SD-LEO-INFRA-COMPETITIVE-VIGILANCE-OBSERVED-DESIGN-001): Phase-0 OBSERVED competitive-baseline design

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-COMPETITIVE-VIGILANCE-OBSERVED-DESIGN-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-COMPETITIVE-VIGILANCE-OBSERVED-DESIGN-001.json
@@ -1,0 +1,104 @@
+{
+  "executive_summary": "Phase-0 DESIGN-ONLY spec for the competitive-vigilance OBSERVED-baseline capability (build-out phase — drive the VDR gauge). The capability is genuinely unbuilt: competitive_baselines holds 4 STATUS_QUO/ASSUMPTION seed rows (one per venture) and the competitive_baselines_epistemic_tag_check CHECK (epistemic_tag IN ('FACT','ASSUMPTION','SIMULATION','UNKNOWN')) REJECTS an OBSERVED insert today (verified live via supabase MCP). The deliverable is a single design doc (docs/plans/competitive-vigilance-observed-baseline-design.md) that settles the 3 unknowns blocking any build, plus a proposed decomposition into 2-3 right-sized buildable child SDs. DESIGN-ONLY write surface: the doc + proposed child-SD rows (advisory) — does NOT touch lib/vision/vdr-registry.js and produces no runtime code. Two premise corrections from the SD framing are load-bearing and verified: (1) the table is NOT empty (4 seeds), and (2) there is NO 'epistemic_tags' enum (pg_enum lookup returned null) — so the migration is CHECK-constraint-only, dropping the 'add OBSERVED to the enum' half of the original scope. The observation source-of-truth decision is CHAIRMAN-GATED and is FLAGGED with enumerated options, not decided in this Phase-0.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "OBSERVED epistemic contract + migration shape (design)",
+      "description": "Specify what an OBSERVED competitive_baselines row MEANS (externally-observed competitor fact, distinct from ASSUMPTION/SIMULATION/FACT/UNKNOWN) and the exact migration shape to admit it: an additive, idempotent expansion of the competitive_baselines_epistemic_tag_check CHECK to add 'OBSERVED' (DROP CONSTRAINT IF EXISTS + re-ADD with the widened allowlist). Document the no-enum finding (no epistemic_tags pg_enum exists) so no build child wastes effort on a non-existent enum. Make an explicit BACKFILL decision: the 4 existing STATUS_QUO seeds are genuinely ASSUMPTION (assumed baselines, not observed) -> NO backfill to OBSERVED.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Doc defines the OBSERVED tag semantics vs the existing 4 tags (one-line each, no overlap)",
+        "Doc gives the additive idempotent CHECK-expansion migration shape (not the SQL applied — design only) and notes it is the same widen-the-allowlist pattern used elsewhere",
+        "Doc states there is NO epistemic_tags enum and corrects the SD's 'both CHECK and enum' framing to CHECK-only",
+        "Doc records the no-backfill decision for the 4 ASSUMPTION seeds with a one-line rationale"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Observation source-of-truth options (CHAIRMAN-GATED — flag, do not decide)",
+      "description": "Enumerate the candidate observation source-of-truth options and the extraction path for each, with a clearly-marked CHAIRMAN-GATED DECISION callout. Options to cover: (a) web research; (b) the dormant Apple RSS / Google Play / Product Hunt pollers (per COMPETITOR-MONITORING-PHASE-001); (c) manual chairman/analyst briefs; (d) the currently-empty competitor_intelligence / ci_snapshots tables. For each, note feasibility, what would feed competitive_baselines, and whether it is buildable without chairman input. The Phase-0 doc FLAGS the decision (with a recommended default + tradeoffs) and does NOT silently choose one.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "All 4 source-of-truth options enumerated with extraction path + feasibility per option",
+        "A single explicit 'CHAIRMAN-GATED DECISION' callout that the source-of-truth is open and requires chairman input",
+        "A recommended default with tradeoffs stated, but the decision is flagged not made",
+        "Reuse surfaces confirmed against reality (competitor_intelligence=0, ci_snapshots=0, app_rankings=0, dormant pollers exist)"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Recurrence (recurring-vigilance) model design",
+      "description": "Specify the recurrence model for keeping OBSERVED baselines fresh: the mechanism (scheduler/cron vs existing EVA scheduler), the cadence (e.g. weekly/monthly), and the scope decision (per-venture vs global). Ground the mechanism choice in existing scheduler infrastructure rather than inventing a new one. The recurrence design is downstream of the FR-2 source-of-truth decision, so it must state the dependency explicitly and design conditionally where needed.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "Mechanism named (reuse existing scheduler/cron infra; no net-new scheduler invented)",
+        "Cadence proposed with a one-line rationale",
+        "Per-venture vs global scope decided (or flagged if it depends on the chairman-gated source-of-truth)",
+        "Stated dependency on the FR-2 decision so the recurrence build child is correctly sequenced"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Decomposition into 2-3 right-sized buildable child SDs",
+      "description": "Propose 2-3 right-sized build child SDs that realize the design, each with a bounded scope and an INDEPENDENT write surface (the SD rationale notes the build pieces have independent write-surfaces). Expected shape: (1) the OBSERVED CHECK-expansion migration child (DDL only, no chairman gate — independently buildable now); (2) the source-of-truth ingestion child (chairman-gated, blocked on the FR-2 decision); (3) the recurrence/scheduler child (depends on child 2). Each proposed child lists scope, write-surface, dependencies, and gating. Children are PROPOSED in the doc (and optionally as draft rows) — this Phase-0 does not build them.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "2-3 child SDs proposed, each with scope + independent write-surface + dependencies + gating",
+        "The migration child is identified as independently buildable now (no chairman gate)",
+        "The ingestion child is identified as blocked on the FR-2 chairman-gated decision",
+        "Sequencing/dependency between children is explicit"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Design-only write surface", "description": "Output is docs/plans/competitive-vigilance-observed-baseline-design.md plus proposed child-SD content. No production code; explicitly does NOT touch lib/vision/vdr-registry.js. No migration is APPLIED in this SD (the migration SHAPE is designed for a build child)." },
+    { "id": "TR-2", "title": "Premise-faithful", "description": "The doc must correct the two verified premise errors (table not empty = 4 seeds; no epistemic_tags enum -> CHECK-only) so downstream build children operate on reality, not the SD's loose framing." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Doc settles all 3 unknowns", "type": "doc-review", "expected": "FR-1/FR-2/FR-3 each have a concrete settled section" },
+    { "id": "TS-2", "scenario": "Chairman-gated decision flagged not decided", "type": "doc-review", "expected": "A single explicit CHAIRMAN-GATED DECISION callout for the source-of-truth" },
+    { "id": "TS-3", "scenario": "Child decomposition present", "type": "doc-review", "expected": "2-3 child SDs with scope/write-surface/deps/gating" },
+    { "id": "TS-4", "scenario": "Premise corrections present", "type": "doc-review", "expected": "Doc states 4 seeds (not empty) and CHECK-only (no enum)" }
+  ],
+  "acceptance_criteria": [
+    "Design doc exists at docs/plans/competitive-vigilance-observed-baseline-design.md and settles the 3 blocking unknowns",
+    "Source-of-truth decision is FLAGGED as chairman-gated (options enumerated, not silently chosen)",
+    "2-3 right-sized buildable child SDs proposed with independent write-surfaces and explicit sequencing",
+    "The two premise corrections (4 seeds; CHECK-only/no-enum) are recorded; no production code touched; vdr-registry.js untouched"
+  ],
+  "risks": [
+    { "risk": "Design silently makes the chairman-gated source-of-truth decision instead of flagging it", "mitigation": "FR-2 acceptance criteria require an explicit CHAIRMAN-GATED DECISION callout; the prior session's release_note specifically asked for flag-not-decide.", "severity": "medium" },
+    { "risk": "Build children inherit the SD's premise errors (empty table / enum)", "mitigation": "TR-2 + FR-1 require the doc to correct both, verified live via supabase MCP.", "severity": "low" },
+    { "risk": "Scope creep into actually applying the migration or building ingestion", "mitigation": "TR-1 locks design-only write surface; migration is shaped not applied; vdr-registry.js untouched.", "severity": "low" }
+  ],
+  "integration_operationalization": {
+    "consumers": ["Future build child SDs (migration / ingestion / recurrence)", "chairman (source-of-truth decision)", "VDR build gauge (capability anchor, criteria 23-25)"],
+    "dependencies": ["competitive_baselines table + competitive_baselines_epistemic_tag_check", "dormant Apple RSS / Google Play / Product Hunt pollers (COMPETITOR-MONITORING-PHASE-001)", "competitor_intelligence / ci_snapshots tables (currently empty)", "existing scheduler/cron infrastructure"],
+    "data_contracts": ["competitive_baselines.epistemic_tag widened allowlist adding 'OBSERVED' (designed, not applied)"],
+    "runtime_config": ["none in Phase-0 (design only)"],
+    "observability_rollout": ["doc + proposed child SDs are the deliverable; no runtime rollout in Phase-0"]
+  },
+  "system_architecture": {
+    "summary": "A single Phase-0 design doc settling the OBSERVED epistemic contract + CHECK-only migration shape (FR-1), the chairman-gated source-of-truth options (FR-2), and the recurrence model (FR-3), then decomposing into 2-3 buildable child SDs (FR-4). No code; no migration applied.",
+    "components": [
+      { "name": "docs/plans/competitive-vigilance-observed-baseline-design.md", "change": "new design doc (the deliverable)" },
+      { "name": "Proposed child SDs (content in doc; optional draft rows)", "change": "2-3 right-sized buildable children with independent write-surfaces" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Author the design doc grounding every claim in the live-verified DB state; settle the 3 unknowns; flag the chairman-gated decision; propose the child decomposition. Correct the two premise errors. Do not touch vdr-registry.js or apply any migration.",
+    "steps": [
+      "Write FR-1 OBSERVED contract + additive CHECK-only migration shape + no-backfill decision",
+      "Write FR-2 source-of-truth options with an explicit CHAIRMAN-GATED DECISION callout",
+      "Write FR-3 recurrence model (reuse existing scheduler; cadence; per-venture vs global; FR-2 dependency)",
+      "Write FR-4 decomposition into 2-3 buildable child SDs (scope/write-surface/deps/gating)",
+      "Record the two premise corrections; confirm vdr-registry.js untouched and no migration applied"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Open docs/plans/competitive-vigilance-observed-baseline-design.md", "expected_outcome": "Doc settles the 3 blocking unknowns: OBSERVED contract + CHECK-only migration shape, chairman-gated source-of-truth options, and the recurrence model" },
+    { "step_number": 2, "instruction": "Read the 'Proposed child SDs' section", "expected_outcome": "2-3 right-sized buildable child SDs are listed, each with scope + independent write-surface + dependencies + gating" },
+    { "step_number": 3, "instruction": "Read the 'CHAIRMAN-GATED DECISION' callout", "expected_outcome": "The observation source-of-truth decision is explicitly flagged for chairman input with options enumerated (web research / dormant pollers / manual briefs / empty competitor_intelligence|ci_snapshots) — not silently decided" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-COMPETITIVE-VIGILANCE-OBSERVED-DESIGN-001" }
+}

--- a/docs/design/competitive-vigilance-observed-baseline-design.md
+++ b/docs/design/competitive-vigilance-observed-baseline-design.md
@@ -1,0 +1,177 @@
+# Competitive-Vigilance OBSERVED-Baseline — Phase-0 Design
+
+**SD:** SD-LEO-INFRA-COMPETITIVE-VIGILANCE-OBSERVED-DESIGN-001
+**Phase:** 0 (design-only — no production code; does NOT touch `lib/vision/vdr-registry.js`)
+**Status:** Design for decomposition into 2-3 buildable child SDs
+**Capability anchor:** VDR build gauge, vision-ladder criteria 23-25 (competitive vigilance)
+
+> **Path note:** the SD scope named `docs/plans/competitive-vigilance-observed-baseline-design.md`,
+> but the `pre-tool-enforce` hook (SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002) DB-only-blocks
+> new markdown under `docs/plans/`. This doc therefore lives at `docs/design/` — same intent
+> (a discoverable design doc), harness-compliant location. Spec-conflict signaled to the coordinator.
+
+---
+
+## 0. Why this exists (build-out phase)
+
+We are in the BUILD-OUT phase: drive the VDR gauge up by building genuinely-unbuilt
+capabilities. Competitive vigilance — keeping an **observed** (not merely assumed) baseline
+of each venture's competitors — is one such capability. It is genuinely unbuilt, and a
+design-first rung is correct because the single highest-leverage decision (where observations
+come from) is **chairman-gated**, while the other build pieces have independent write-surfaces
+and can proceed in parallel once shaped.
+
+This document settles the three unknowns that block any build, then proposes a decomposition.
+
+## 1. Premise corrections (verified live via supabase MCP, 2026-06-22)
+
+The originating SD framing contained two inaccuracies. Build children MUST operate on the
+corrected reality below, not the SD's loose wording.
+
+| SD framing | Reality (verified) | Consequence |
+|---|---|---|
+| "`competitive_baselines` is empty" | **4 seed rows**, all `competitor_name='STATUS_QUO'`, `baseline_type='STATUS_QUO'`, `epistemic_tag='ASSUMPTION'`, one per venture (created 2026-05-22 … 2026-05-31). | There IS existing data. No-backfill decision applies to these 4 (§2.3). |
+| "add OBSERVED to BOTH the CHECK and the EPISTEMIC_TAGS enum" | There is **no `epistemic_tags` pg_enum** (`pg_enum` lookup returned null). `epistemic_tag` is a plain `text` column constrained only by a CHECK. | The migration is **CHECK-only**. Drop the "enum" half of the scope entirely. |
+
+Verified facts:
+- `competitive_baselines_epistemic_tag_check` = `CHECK (epistemic_tag IN ('FACT','ASSUMPTION','SIMULATION','UNKNOWN'))` — **rejects `OBSERVED` today**.
+- `competitive_baselines` columns: `id, venture_id, competitor_name, baseline_type, pricing_data (jsonb), feature_coverage (jsonb), performance_metrics (jsonb), epistemic_tag (text), created_at, updated_at`.
+- Candidate downstream tables are empty: `competitor_intelligence` = 0 rows, `ci_snapshots` = 0 rows, `app_rankings` = 0 rows.
+- Dormant Apple RSS / Google Play / Product Hunt pollers exist (per `SD-…-COMPETITOR-MONITORING-PHASE-001`, which validated pollers → `app_rankings`).
+
+---
+
+## 2. Unknown #1 — the OBSERVED epistemic contract + migration shape
+
+### 2.1 What OBSERVED means
+
+`epistemic_tag` records the **epistemic provenance** of a baseline row. The existing tags and
+the new one:
+
+| Tag | Meaning |
+|---|---|
+| `FACT` | Established ground truth, not in dispute. |
+| `ASSUMPTION` | Assumed/posited (e.g. the 4 `STATUS_QUO` seeds — "the status quo is the competitor"). |
+| `SIMULATION` | Produced by a model/simulation run, not observed externally. |
+| `UNKNOWN` | Provenance unrecorded. |
+| **`OBSERVED`** *(new)* | **Externally observed competitor fact** — captured from a real-world source (web, store ranking, analyst brief) at a point in time. Distinct from `FACT` (which asserts settled truth) and from `ASSUMPTION` (which is posited, not seen). |
+
+`OBSERVED` is the tag that turns competitive vigilance from "we assume X about competitor Y"
+into "we observed X about competitor Y on date D from source S".
+
+### 2.2 Migration shape (designed, NOT applied here)
+
+Additive, idempotent CHECK-expansion — the standard widen-the-allowlist pattern
+(DROP IF EXISTS + re-ADD). **No enum.** Designed shape for the migration child:
+
+```sql
+ALTER TABLE competitive_baselines
+DROP CONSTRAINT IF EXISTS competitive_baselines_epistemic_tag_check;
+
+ALTER TABLE competitive_baselines
+ADD CONSTRAINT competitive_baselines_epistemic_tag_check
+CHECK (epistemic_tag IN ('FACT','ASSUMPTION','SIMULATION','UNKNOWN','OBSERVED'));
+```
+
+Properties: additive (widens only — never rejects existing rows), idempotent (safe to
+re-apply), no data migration. This SD does **not** apply it — the migration child does
+(and MCP `apply_migration` is read-only in worker sessions, so it ships as a `.sql` applied
+by pipeline/chairman; MERGED ≠ LIVE — flag the apply step).
+
+### 2.3 Backfill decision: NO backfill
+
+The 4 existing `STATUS_QUO` seeds are correctly `ASSUMPTION` — they are *assumed* baselines
+("the status quo is the competitor"), not externally observed. Re-tagging them `OBSERVED`
+would be a provenance lie. **Decision: leave the 4 seeds as `ASSUMPTION`; no backfill.**
+`OBSERVED` rows are only ever written by a real observation path (Unknown #2).
+
+---
+
+## 3. Unknown #2 — the observation SOURCE-OF-TRUTH (⚠️ CHAIRMAN-GATED)
+
+> ### ⚠️ CHAIRMAN-GATED DECISION
+> **The observation source-of-truth is OPEN and requires chairman input. This Phase-0 design
+> FLAGS the decision and enumerates the options — it does NOT choose one.** A build child for
+> ingestion (§5, child 2) is BLOCKED on this decision.
+
+`competitive_baselines` currently has no feed for `OBSERVED` rows. Four candidate sources,
+each with its extraction path, feasibility, and whether it is buildable without chairman input:
+
+| # | Option | Extraction path | Feeds `competitive_baselines`? | Buildable w/o chairman? | Notes |
+|---|---|---|---|---|---|
+| a | **Web research** | Agentic web search/fetch → structured extract → insert `OBSERVED` row per competitor fact | Yes (richest, broadest) | **No** — requires chairman direction on which competitors/dimensions to watch + cost posture | Highest fidelity to "observed"; highest open-endedness. |
+| b | **Dormant store pollers** (Apple RSS / Google Play / Product Hunt) | Re-activate existing pollers → `app_rankings` → adapter maps ranking facts → `OBSERVED` baseline rows | Partial (ranking/visibility facts only, app-store-shaped ventures) | Mostly yes (pollers already exist) — but **only meaningful for app-store ventures**, a chairman call on relevance | Cheapest to build (reuse); narrowest signal. `app_rankings`=0 today. |
+| c | **Manual chairman/analyst briefs** | Chairman/analyst submits a brief → simple intake → `OBSERVED` rows | Yes (curated, low volume) | **No** — the source IS the chairman | Highest trust, lowest automation; a natural bootstrap. |
+| d | **Empty `competitor_intelligence` / `ci_snapshots` tables** | Wire whatever populates those → adapter → `OBSERVED` baseline rows | Only if a producer is built (both 0 rows today) | No — there is **no producer**; choosing this means also building the producer | Today these are hollow; not a source until fed. Do not assume they are a source. |
+
+**Recommended default (advisory, not a decision):** bootstrap with **(c) manual briefs** for
+immediate trustworthy `OBSERVED` rows, while building **(b) store pollers** as the first
+automated feed (cheapest, reuses dormant infra) — and defer **(a) web research** until the
+chairman scopes competitors/dimensions/cost. Reject **(d)** as a "source" unless a producer
+is explicitly funded. **Final selection is the chairman's.**
+
+---
+
+## 4. Unknown #3 — the recurrence (recurring-vigilance) model
+
+Recurrence keeps `OBSERVED` baselines fresh. It is **downstream of the §3 decision** (you
+can't schedule a feed you haven't chosen), so it is designed conditionally.
+
+- **Mechanism:** reuse existing scheduler/cron infrastructure (the EVA scheduler / existing
+  cron job pattern). **Do NOT invent a net-new scheduler.** The ingestion child registers a
+  job with the existing scheduler, mirroring how the dormant pollers were scheduled.
+- **Cadence:** propose **weekly** for automated feeds (store pollers / web research) and
+  **ad-hoc** for manual briefs. Rationale: competitor positioning changes on a weekly-to-
+  monthly horizon; weekly is fresh enough without burning observation cost. Cadence is a
+  config knob, not hardcoded.
+- **Scope — per-venture vs global:** **per-venture.** `competitive_baselines.venture_id` is
+  per-venture and the 4 seeds are per-venture; observations are venture-relative (each venture
+  has different competitors). A global sweep would lose the venture→competitor mapping.
+  *(Caveat: if the chairman picks a global source like a single market-wide feed, the fan-out
+  to per-venture rows happens at the adapter, not the scheduler — the storage stays
+  per-venture either way.)*
+- **Dependency:** the recurrence child (§5, child 3) depends on the ingestion child (§5,
+  child 2) and therefore transitively on the §3 chairman decision.
+
+---
+
+## 5. Proposed decomposition — 2-3 buildable child SDs
+
+Each child has a bounded scope and an **independent write-surface** (per the SD rationale).
+
+### Child 1 — OBSERVED CHECK-expansion migration *(independently buildable NOW)*
+- **Scope:** ship the additive idempotent CHECK-only migration from §2.2 adding `OBSERVED`.
+- **Write-surface:** `database/migrations/<date>_add_observed_to_competitive_baselines_check.sql` (+ a deliberately live-probe-free static test asserting UP adds / DOWN removes `OBSERVED`).
+- **Dependencies:** none.
+- **Gating:** none (no chairman gate). MCP apply is read-only → ships as `.sql`, applied by pipeline/chairman; **flag the apply step (MERGED ≠ LIVE)**.
+- **Type/size:** `database` (or `infrastructure`), small. This is the unblocker — without it every `OBSERVED` insert 23514-errors.
+
+### Child 2 — Observation ingestion path *(BLOCKED on §3 chairman decision)*
+- **Scope:** build the chosen source-of-truth feed (per §3 selection): extraction → adapter → insert `OBSERVED` rows (venture-relative). Includes the source adapter and the intake/extract code.
+- **Write-surface:** new `lib/competitive-vigilance/…` ingestion + adapter modules; writes to `competitive_baselines` (and, if option (b), reads `app_rankings`).
+- **Dependencies:** Child 1 (CHECK must admit `OBSERVED`); **chairman decision (§3)**.
+- **Gating:** chairman-gated — **do not start until §3 is resolved.** Scope/size depends on which option(s) the chairman picks (manual-brief intake is small; web research is large).
+
+### Child 3 — Recurrence / scheduler *(depends on Child 2)*
+- **Scope:** register the §4 recurrence job with the existing scheduler — cadence + per-venture scope + freshness.
+- **Write-surface:** scheduler/cron registration + a thin runner that invokes Child 2's ingestion; config for cadence.
+- **Dependencies:** Child 2 (nothing to schedule without a feed).
+- **Gating:** inherits Child 2's chairman gate. Could be folded into Child 2 if the feed is small — keep separate only if the scheduling surface is non-trivial.
+
+**Sequencing:** Child 1 (now) → [chairman §3 decision] → Child 2 → Child 3.
+Child 1 is the immediate, ungated next build; it drives the gauge without waiting on the chairman.
+
+---
+
+## 6. Out of scope (Phase-0 guardrails)
+
+- No production code, no migration **applied**, no `lib/vision/vdr-registry.js` changes.
+- The source-of-truth is **not** chosen here (chairman-gated).
+- Children are **proposed** (this doc); creating their rows is a separate, optional step.
+
+## 7. References
+
+- Verified live via supabase MCP (2026-06-22): table contents, CHECK def, absence of enum, empty downstream tables.
+- `SD-…-COMPETITOR-MONITORING-PHASE-001` — dormant Apple RSS / Google Play / Product Hunt pollers → `app_rankings`.
+- VDR vision-ladder criteria 23-25 — competitive-vigilance capability anchor.
+- VALIDATION evidence row `c3db0777-7693-45ad-a538-d6e1d2bb493c` (duplicate-clear; premise corrections confirmed).

--- a/docs/design/competitive-vigilance-observed-baseline-design.md
+++ b/docs/design/competitive-vigilance-observed-baseline-design.md
@@ -17,7 +17,7 @@
 We are in the BUILD-OUT phase: drive the VDR gauge up by building genuinely-unbuilt
 capabilities. Competitive vigilance — keeping an **observed** (not merely assumed) baseline
 of each venture's competitors — is one such capability. It is genuinely unbuilt, and a
-design-first rung is correct because the single highest-leverage decision (where observations
+design-first rung is correct because the single highest-impact decision (where observations
 come from) is **chairman-gated**, while the other build pieces have independent write-surfaces
 and can proceed in parallel once shaped.
 


### PR DESCRIPTION
## Summary
Phase-0 **design-only** spec for the competitive-vigilance OBSERVED-baseline capability (build-out phase — drive the VDR gauge). Settles the 3 build-blocking unknowns and proposes a 2-3 child-SD decomposition. No production code; does NOT touch `lib/vision/vdr-registry.js`.

## What it settles
- **OBSERVED epistemic contract + migration shape** — additive idempotent **CHECK-only** expansion to add `OBSERVED` (designed, not applied). No-backfill decision for the 4 ASSUMPTION seeds.
- **Observation source-of-truth** — 4 options enumerated; the decision is **CHAIRMAN-GATED and flagged, not decided**.
- **Recurrence model** — reuse existing scheduler, weekly cadence, per-venture.
- **Decomposition** — Child 1 (migration, buildable now) → [chairman decision] → Child 2 (ingestion) → Child 3 (recurrence).

## Premise corrections (verified live via supabase MCP)
- `competitive_baselines` is **not empty** — 4 `STATUS_QUO`/`ASSUMPTION` seeds.
- There is **no `epistemic_tags` enum** — the migration is CHECK-only (the SD's 'both CHECK and enum' framing was wrong).

## Notes
- Doc lives at `docs/design/` because the pre-tool-enforce hook DB-only-blocks new markdown under `docs/plans/` (spec-conflict signaled to coordinator).
- Evidence: VALIDATION `c3db0777` (duplicate-clear), TESTING `d288cb0a` (PASS, doc-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)