### PR TITLE
fix(SD-REFILL-00HKPG2F): exempt generated protocol-doc drift from git-state gate

### DIFF
--- a/scripts/check-git-state.js
+++ b/scripts/check-git-state.js
@@ -29,6 +29,23 @@ function isPerWorktreeMetadata(file) {
   return PER_WORKTREE_METADATA.includes((file || '').trim());
 }
 
+// SD-REFILL-00HKPG2F: the DB-generated protocol docs (CLAUDE*.md, *_DIGEST.md, and
+// claude-generation-manifest.json — all marked "GENERATED FILE - DO NOT EDIT DIRECTLY",
+// source of truth: leo_protocol_sections) are regenerated from the DB at session start and
+// sit uncommitted on main, yet are uncommittable there (no-direct-commit-to-main pre-commit
+// hook) with no maintenance branch. That regen drift tripped this git-state gate for every
+// worker, forcing a restore-to-HEAD that re-introduces DB drift. Excluded from the blocking
+// classification below (mirrors isPerWorktreeMetadata / QF-20260529-729) — this does NOT
+// untrack them, and DB-fidelity stays enforced independently by scripts/check-claude-md-drift.cjs.
+const GENERATED_PROTOCOL_DOC_RE = /^CLAUDE(_[A-Z0-9]+)*(_DIGEST)?\.md$/;
+const GENERATED_PROTOCOL_DOC_FILES = ['claude-generation-manifest.json'];
+function isGeneratedProtocolDoc(file) {
+  // Match on the trimmed basename so it works whether git reports a repo-root or nested path.
+  const base = (file || '').trim().split(/[\\/]/).pop();
+  if (!base) return false;
+  return GENERATED_PROTOCOL_DOC_RE.test(base) || GENERATED_PROTOCOL_DOC_FILES.includes(base);
+}
+
 async function gitCommand(command, cwd) {
   try {
     const { stdout, stderr } = await execAsync(command, cwd ? { cwd } : undefined);
@@ -61,7 +78,8 @@ async function checkGitState(options = {}) {
       unpushedCommits: 0,
       stagedFiles: [],
       modifiedFiles: [],
-      untrackedFiles: []
+      untrackedFiles: [],
+      exemptedGeneratedDocs: []
     }
   };
 
@@ -83,6 +101,13 @@ async function checkGitState(options = {}) {
 
       // QF-20260529-729: skip per-worktree metadata noise — never blocks a handoff.
       if (isPerWorktreeMetadata(file)) return;
+
+      // SD-REFILL-00HKPG2F: skip DB-generated protocol-doc regen drift — never blocks a
+      // handoff (recorded for transparency below as a non-blocking warning, not discarded).
+      if (isGeneratedProtocolDoc(file)) {
+        result.details.exemptedGeneratedDocs.push(file);
+        return;
+      }
 
       // Classify by status
       if (status[0] === '?' && status[1] === '?') {
@@ -147,6 +172,18 @@ async function checkGitState(options = {}) {
         console.log(`   ⚠️  Untracked files: ${blockingUntracked.length}`);
       }
     }
+
+    // SD-REFILL-00HKPG2F: surface exempted generated-doc drift as a NON-BLOCKING warning so
+    // the divergence stays visible (not silently masked) while never failing the gate.
+    if (result.details.exemptedGeneratedDocs.length > 0) {
+      result.warnings.push({
+        type: 'GENERATED_DOC_DRIFT_EXEMPTED',
+        message: `${result.details.exemptedGeneratedDocs.length} generated protocol-doc(s) have uncommitted regen drift (exempt — does not block handoff)`,
+        files: result.details.exemptedGeneratedDocs,
+        remediation: 'Regenerate + commit via a protocol-doc maintenance path: node scripts/generate-claude-md-from-db.js'
+      });
+      console.log(`   ⚠️  Generated protocol-doc drift (exempt): ${result.details.exemptedGeneratedDocs.length}`);
+    }
   } else {
     console.log('   ✅ Working directory clean');
   }
@@ -208,7 +245,7 @@ async function checkGitState(options = {}) {
   return result;
 }
 
-export { checkGitState, isPerWorktreeMetadata, PER_WORKTREE_METADATA };
+export { checkGitState, isPerWorktreeMetadata, PER_WORKTREE_METADATA, isGeneratedProtocolDoc };
 
 // CLI execution — only when run directly (node scripts/check-git-state.js), NOT when
 // imported. Without this guard, importing the module (e.g. from the handoff precheck CLI

--- a/tests/unit/check-git-state-generated-protocol-docs.test.js
+++ b/tests/unit/check-git-state-generated-protocol-docs.test.js
@@ -1,0 +1,62 @@
+/**
+ * Regression: the handoff STEP-1 git-state check must not block on DB-generated protocol-doc
+ * regen drift.
+ *
+ * SD-REFILL-00HKPG2F: CLAUDE*.md / *_DIGEST.md / claude-generation-manifest.json are
+ * regenerated from leo_protocol_sections at session start and sit uncommitted on main, yet are
+ * uncommittable there (no-direct-commit pre-commit hook) with no maintenance branch. That drift
+ * tripped checkGitState (passed=false) for every worker, forcing a restore-to-HEAD that
+ * re-introduces DB drift. Fix excludes them from the blocking classification (mirrors
+ * isPerWorktreeMetadata / QF-20260529-729) without untracking them; DB-fidelity stays enforced
+ * independently by scripts/check-claude-md-drift.cjs.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { isGeneratedProtocolDoc } from '../../scripts/check-git-state.js';
+
+const srcPath = fileURLToPath(new URL('../../scripts/check-git-state.js', import.meta.url));
+
+describe('check-git-state exempts generated protocol-doc drift (SD-REFILL-00HKPG2F)', () => {
+  it('matches the DB-generated protocol docs (FR-1)', () => {
+    expect(isGeneratedProtocolDoc('CLAUDE.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('CLAUDE_CORE.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('CLAUDE_LEAD.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('CLAUDE_ADAM_DIGEST.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('CLAUDE_LEAD_DIGEST.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('CLAUDE_DIGEST.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('CLAUDE_COORDINATOR_DIGEST.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('claude-generation-manifest.json')).toBe(true);
+  });
+
+  it('matches on basename regardless of path prefix', () => {
+    expect(isGeneratedProtocolDoc('./CLAUDE.md')).toBe(true);
+    expect(isGeneratedProtocolDoc('some/nested/CLAUDE_PLAN.md')).toBe(true);
+  });
+
+  it('does NOT match authored / unrelated files (FR-1 narrowing)', () => {
+    expect(isGeneratedProtocolDoc('README.md')).toBe(false);
+    expect(isGeneratedProtocolDoc('CLAUDEX.md')).toBe(false);
+    expect(isGeneratedProtocolDoc('docs/claude-helper.md')).toBe(false);
+    expect(isGeneratedProtocolDoc('src/index.js')).toBe(false);
+    expect(isGeneratedProtocolDoc('claude-generation-manifest.json.bak')).toBe(false);
+    expect(isGeneratedProtocolDoc('')).toBe(false);
+    expect(isGeneratedProtocolDoc(null)).toBe(false);
+  });
+
+  it('the classification loop is actually wired to skip generated docs (QF-888 dead-code lesson, FR-2)', () => {
+    const src = readFileSync(srcPath, 'utf8');
+    // skip wired into the porcelain loop, accumulating into the transparency array
+    expect(src).toMatch(/if \(isGeneratedProtocolDoc\(file\)\) \{/);
+    expect(src).toMatch(/result\.details\.exemptedGeneratedDocs\.push\(file\)/);
+  });
+
+  it('emits a non-blocking transparency warning, never failing the gate (FR-3)', () => {
+    const src = readFileSync(srcPath, 'utf8');
+    expect(src).toMatch(/GENERATED_DOC_DRIFT_EXEMPTED/);
+    // the exempted-docs branch must not set passed=false
+    const exemptBlock = src.slice(src.indexOf('exemptedGeneratedDocs.length > 0'));
+    const warnBlock = exemptBlock.slice(0, exemptBlock.indexOf('console.log'));
+    expect(warnBlock).not.toMatch(/passed = false/);
+  });
+});


### PR DESCRIPTION
## What

`scripts/check-git-state.js` (the handoff STEP-1 git-state gate) blocked on **any** modified/staged tracked file. DB-generated protocol docs — `CLAUDE*.md`, `*_DIGEST.md`, `claude-generation-manifest.json` (all marked *"GENERATED FILE - DO NOT EDIT DIRECTLY"*, source: `leo_protocol_sections`) — are regenerated at session start and sit uncommitted on `main`, yet are **uncommittable** there (no-direct-commit pre-commit hook) with no maintenance branch. That regen drift failed the gate for every worker, forcing a restore-to-HEAD that re-introduces DB drift.

## Fix (SD-REFILL-00HKPG2F)

- Add `isGeneratedProtocolDoc(file)` predicate + exempt these docs from the blocking classification, mirroring the existing `isPerWorktreeMetadata` exemption (QF-20260529-729). **Does not untrack them.**
- Exempted drift is surfaced as a **non-blocking** `GENERATED_DOC_DRIFT_EXEMPTED` warning (visible, not silently masked).
- The exemption **narrows** the pass condition only — mixed authored+generated changes still block (`passed=false`).
- DB-fidelity remains independently enforced by `check-claude-md-drift.cjs` (unchanged).

## Tests

5 new unit tests + 3 existing regression = 11 green. Matcher true/false cases, basename matching, loop-wiring assertion (dead-code guard), and non-blocking-warning assertion.

LEO chain: LEAD-TO-PLAN 96 / PLAN-TO-EXEC 98 / EXEC-TO-PLAN 94. TESTING evidence PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)