### PR TITLE
feat(SD-REFILL-00LHUVME): extend retention policy to eva_scheduler_metrics

### DIFF
--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -40,6 +40,10 @@ export const RETENTION_POLICIES = [
   { table: 'validation_audit_log', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
   { table: 'model_usage_log',      timestampColumn: 'captured_at', hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
   { table: 'permission_audit_log', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  // SD-REFILL-00LHUVME: eva_scheduler_metrics was unbounded (140,302 rows / 12d at authoring,
+  // x1.63 in 24h per row-growth-snapshot.cjs) and uncovered by RETENTION-POLICY-UNBOUNDED-001.
+  // created_at verified on live schema (occurred_at also exists); 0 triggers/FKs/inbound-FKs.
+  { table: 'eva_scheduler_metrics', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
 ];
 
 /**

--- a/tests/unit/retention/retention-policy.test.js
+++ b/tests/unit/retention/retention-policy.test.js
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../../');
 
 describe('policy registry (TS-1)', () => {
-  it('registers all 6 unbounded tables with the VERIFIED timestamp columns', () => {
+  it('registers all 7 unbounded tables with the VERIFIED timestamp columns', () => {
     const m = Object.fromEntries(RETENTION_POLICIES.map((p) => [p.table, p.timestampColumn]));
     expect(m).toEqual({
       workflow_trace_log: 'created_at',
@@ -24,7 +24,20 @@ describe('policy registry (TS-1)', () => {
       validation_audit_log: 'created_at',
       model_usage_log: 'captured_at',
       permission_audit_log: 'created_at',
+      // SD-REFILL-00LHUVME: eva_scheduler_metrics retention coverage
+      eva_scheduler_metrics: 'created_at',
     });
+  });
+
+  it('eva_scheduler_metrics policy uses the safe defaults (SD-REFILL-00LHUVME)', () => {
+    const p = RETENTION_POLICIES.find((x) => x.table === 'eva_scheduler_metrics');
+    expect(p).toBeDefined();
+    expect(p.timestampColumn).toBe('created_at');
+    expect(p.mode).toBe('archive');
+    expect(effectiveHotDays(p, {})).toBe(DEFAULT_HOT_DAYS);
+    // floor still protects readers
+    expect(() => effectiveHotDays(p, { RETENTION_HOT_DAYS_EVA_SCHEDULER_METRICS: '30' }))
+      .toThrow(/below the MIN_HOT_DAYS floor/);
   });
 
   it('default window is 90d (3x the 30d longest consumer lookback)', () => {


### PR DESCRIPTION
## Summary
Closes an SRE row-growth gap: `eva_scheduler_metrics` was unbounded (140,302 rows / 49 MB over 12 days, ~+14k rows/day). The completed retention work (SD-LEO-INFRA-RETENTION-POLICY-UNBOUNDED-001) covered 6 audit/trace tables but NOT this metrics table.

## Change (registry-only — no migration)
- Add `eva_scheduler_metrics` to `RETENTION_POLICIES` in `lib/retention/policies.js`: `{ timestampColumn:'created_at', hotDays: DEFAULT_HOT_DAYS (90), mode:'archive', perRunCap: DEFAULT_PER_RUN_CAP }`.
- Update `tests/unit/retention/retention-policy.test.js` to assert 7 tables + a defaults/floor assertion. **15/15 pass.**

## Why safe
- The `retention_archive` substrate is generic/table-agnostic — no DDL needed.
- Keyed on `created_at` (insert-time, 0 nulls), consistent with sibling policies; `occurred_at` (event-time) deliberately not used.
- Sole reader of `eva_scheduler_metrics` (`lib/eva/operations/index.js:67`) is latest-5/point-in-time — a 90-day window (3x the 45-day floor) cannot strand any reader.
- Enforcement (`scripts/retention-enforce.js`) stays chairman-gated / dry-run-by-default; this PR only registers coverage.

## Evidence
VALIDATION 95 (duplicate-clear), TESTING 96 (15/15 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)