### PR TITLE
fix(SD-REFILL-00D2CC0B): whitelist 2 recurring coordinator crons in RCA retry guard

### DIFF
--- a/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
@@ -26,6 +26,10 @@ const LOOP_COMMANDS = [
   // Step-0 keepalive: node -e inline (no script path) — matched on stable tokens.
   'node -e "const { setActiveCoordinator } = require(\'./lib/coordinator/resolve.cjs\'); setActiveCoordinator(process.env.CLAUDE_SESSION_ID).then(...)"',
   'node -e "require(\'./lib/coordinator/resolve.cjs\').setActiveCoordinator(id)"',
+  // SD-REFILL-00D2CC0B — two more recurring coordinator crons (false-blocked during fleet
+  // re-engagement churn; coordinator Kamo 2026-06-15).
+  'node scripts/coordinator-backlog-rank.mjs',                                  // per-sourced-SD + interval
+  'node scripts/coordinator-capacity-forecast.mjs',                            // periodic capacity probe
 ];
 
 describe('QF-626 isExempt: canonical coordinator cron loops', () => {
@@ -40,6 +44,13 @@ describe('QF-626 isExempt: canonical coordinator cron loops', () => {
   it('still exempts with ./ prefix and windows separators', () => {
     expect(isExempt('node ./scripts/coordinator-self-review.mjs')).toBe(true);
     expect(isExempt('node scripts\\coordinator-audit.mjs')).toBe(true);
+  });
+
+  // SD-REFILL-00D2CC0B — the two newly-whitelisted recurring crons, both separators.
+  it('exempts coordinator-backlog-rank.mjs and coordinator-capacity-forecast.mjs', () => {
+    expect(isExempt('node scripts/coordinator-backlog-rank.mjs')).toBe(true);
+    expect(isExempt('node ./scripts/coordinator-backlog-rank.mjs --apply')).toBe(true);
+    expect(isExempt('node scripts\\coordinator-capacity-forecast.mjs')).toBe(true);
   });
 
   // FR-5 — anchoring: unrelated coordinator-* scripts stay RCA-gated.

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -67,6 +67,15 @@ const EXEMPT_PATTERNS = [
   //   worker-checkin.cjs — the /loop worker check-in tick (each pass; observed blocked at the 3rd
   //     invocation this session, forcing EMERGENCY_RCA_BYPASS). It always exits 0 on a fixed cadence.
   /\bscripts[/\\]worker-checkin\.cjs\b/,
+  // SD-REFILL-00D2CC0B — two more canonical recurring coordinator crons the exit-0 exemption can't
+  // reliably catch (interleaved loops clobber the single per-session last-outcome file). Each is a
+  // SCHEDULED, idempotent, succeeding tick that the 3x-same-target counter misreads as a stuck retry;
+  // they false-blocked normal fleet re-engagement churn (Adam sourcing multiple V1 SDs rapidly →
+  // coordinator ranks each), forcing EMERGENCY_RCA_BYPASS (witnessed by coordinator Kamo 2026-06-15).
+  //   coordinator-backlog-rank.mjs — re-ranks the dispatch belt; runs per new sourced SD + on interval.
+  /\bscripts[/\\]coordinator-backlog-rank\.mjs\b/,
+  //   coordinator-capacity-forecast.mjs — periodic fleet capacity/forecast probe.
+  /\bscripts[/\\]coordinator-capacity-forecast\.mjs\b/,
 ];
 
 /**


### PR DESCRIPTION
## SD-REFILL-00D2CC0B

RCA tiered-enforcement (the 3x-same-target/10min retry heuristic in `retry-state-manager.cjs` EXEMPT_PATTERNS) false-blocked the recurring crons `coordinator-backlog-rank.mjs` and `coordinator-capacity-forecast.mjs`, forcing EMERGENCY_RCA_BYPASS during normal fleet re-engagement churn (Adam sources V1 SDs rapidly → coordinator ranks each; every invocation **exits 0** — not a stuck retry). Witnessed by coordinator Kamo 2026-06-15.

### Fix
- Append both anchored basenames to `EXEMPT_PATTERNS` (mirroring the existing coordinator-self-review/audit/worker-checkin entries).
- Anchoring preserved → unrelated `coordinator-*` scripts stay RCA-gated.

### Tests
- +3 assertions (both separators + `--apply` arg); coordinator-loops suite **18/18** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)