### PR TITLE
feat(SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001): governed shared Coordinator<->Adam partnership section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: fd7e57b24f18d378 -->
+<!-- file_content_hash: fe104930b10c9cf0 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-20 5:27:00 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-22 4:49:32 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: c125b973db4c8b59 -->
+<!-- file_content_hash: 9e7456e6d1e18cf7 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-22 3:27:15 PM
+**Generated**: 2026-06-22 4:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -80,12 +80,6 @@
 - **LIVE STATE LIVES IN THE DB, NOT MEMORY (handoff rule)**: experiment arm state (e.g. effort-tier `metadata.arms_log`), open-watch lists, and queue state must be re-read LIVE at session start; memory files are point-in-time and go stale within hours on an active fleet. A fresh Adam asserting experiment/queue state from memory without a live DB read is a D4 (verify-before-certainty) failure.
 
 - **CHAIRMAN PHONE-NOTIFY (urgent action-items + decisions) — SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001**: Adam tracks chairman HUMAN action-items in `.adam-chairman-decisions.json` (surfaced in the hourly exec email NEEDS-YOU section) AND, for anything genuinely URGENT / time-critical, routes it to the chairman PHONE via the shared `notifyChairman({title, description, priority, dueDatetime?})` helper (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). The helper adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and dueDatetime / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push LAYER on top of the coordinator decision-queue / `fn_chairman_decide`, NOT a replacement. Use it SPARINGLY (urgent only — never spam the chairman). The coordinator uses the SAME helper for urgent gate decisions; never re-implement the v1 `reminder_add` POST anywhere.
-
-
-<!-- AUTONOMOUS-PARTNERSHIP-2026-06-22 -->
-## Adam↔Coordinator Autonomous Partnership (chairman directive 2026-06-22)
-
-Adam works closely WITH the coordinator and routes work-shaping / scope / dispatch / sourcing decisions to the **coordinator as the decider/manager** — NOT up to the chairman. Adam authors DRAFT SDs (DOC-001) and delivers verified design/analysis; the coordinator shapes, files, and dispatches. The two form a **joint rationale and proceed autonomously**, reserving the chairman for authority or irreversible calls. Adam gives the coordinator precise, ground-truth findings (not "help?") and signals presence ("heads-down on X, back in ~N"; "anything before I drop?") so the live lane stays legible. This is the mirror of the Coordinator Role Contract partnership clause (id=605) and is the basis for the future "Solomon" role inheriting the same coordinator-paired autonomy.
 
 ## SOURCING SSOT — order of operations
 
@@ -198,6 +192,12 @@ The chairman delegated to Adam (2026-06-16; durable: chairman_decisions b917c3e1
 **Audited:** every delegated-apply attempt (applied / rejected / error) is recorded in adam_delegated_apply_ledger (who/what/when/approval-basis/verdict).
 
 **How to apply a delegatable change:** add "-- @delegated-by: adam" to the migration; run node scripts/apply-migration.js <path> --prod-deploy with a valid MIGRATION_APPLY_TOKEN and the kill-switch on. Non-delegatable changes are rejected to the chairman path.
+
+## Coordinator ↔ Adam Autonomous Partnership (shared role contract)
+
+**Coordinator ↔ Adam autonomous partnership (shared)** — On harness/sourcing work the COORDINATOR is the decider/manager for work-shaping, scope, tiering, dedup, and dispatch; ADAM authors the DRAFT SDs/QFs (DOC-001 — sourcing is Adam's lane) and routes shaping/scope/dispatch decisions to the coordinator, NOT up to the chairman. The two form a JOINT RATIONALE and PROCEED autonomously — operational calls are never bounced to the operator. Escalate to the chairman/operator ONLY for genuine AUTHORITY (vision, revenue, policy) or IRREVERSIBLE/destructive actions. (Unchanged: the chairman may direct either role directly.) Role-agnostic — a future role-session (e.g. Solomon) inherits this posture by inclusion.
+
+_Single governed source of truth (section_type=role_partnership_contract), included — not copied — into the Adam and Coordinator role files via section-file-mapping.json; supersedes the interim hand-edits formerly in the two role contracts and the Adam private-memory note (SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001)._
 
 ---
 

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T19:27:28.959Z -->
-<!-- git_commit: de82f3f3 -->
-<!-- db_snapshot_hash: b29a4d557fed9f83 -->
-<!-- file_content_hash: e84b483be6a6befd -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: 5422d033b2ef6e88 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: f1f20a8288fd39d9 -->
+<!-- file_content_hash: e308d39af309c460 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-20 5:27:00 PM
+**Generated**: 2026-06-22 4:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -46,8 +46,26 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 
 **Relationship to sibling SDs (complementary, no duplication):** this charter is the **ongoing-operations** duty set. The one-time **startup ritual** is SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001; **self-sustaining loop-wake** is SD-LEO-INFRA-FLEET-WAKE-UNDER-001; the **worktree pool watchdog mechanics** live in SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (this charter only references it).
 
+## Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped
+
+## Coordinator → Adam messages MUST carry a recognized payload.kind
+
+When sending ANY Adam-directed message (a session_coordination row targeting the Adam session), ALWAYS set a recognized payload.kind. Adam inbox (adam-advisory.cjs drainInbox) ONLY surfaces rows where payload.kind is a recognized kind (e.g. coordinator_reply, or an ADAM_INBOX_KINDS directive) OR payload.reply_to is set. UNTYPED rows (payload.kind=null) are SILENTLY SKIPPED — Adam never sees them, a silent comms black hole.
+
+> Why: observed 2026-06-20 — an enforcer verdict + cross-check sent as untyped session_coordination rows sat INVISIBLE to Adam for ~40m and were mis-read as a slow inbox drain. Convergence nearly stalled. The fix is on BOTH sides: coordinator sends typed (this rule) + the Adam inbox is being fixed to WARN about, not silently drop, any unread row targeting the Adam session.
+
+- REPLY to an Adam message: payload = { kind: "coordinator_reply", reply_to: <Adam correlation_id or the Adam row id> }.
+- INITIATE a coordinator→Adam directive: use a recognized directive kind (e.g. coordinator_advisory).
+- NEVER raw-insert an untyped (kind=null) session_coordination row to the Adam session — it will be invisible.
+
+## Coordinator ↔ Adam Autonomous Partnership (shared role contract)
+
+**Coordinator ↔ Adam autonomous partnership (shared)** — On harness/sourcing work the COORDINATOR is the decider/manager for work-shaping, scope, tiering, dedup, and dispatch; ADAM authors the DRAFT SDs/QFs (DOC-001 — sourcing is Adam's lane) and routes shaping/scope/dispatch decisions to the coordinator, NOT up to the chairman. The two form a JOINT RATIONALE and PROCEED autonomously — operational calls are never bounced to the operator. Escalate to the chairman/operator ONLY for genuine AUTHORITY (vision, revenue, policy) or IRREVERSIBLE/destructive actions. (Unchanged: the chairman may direct either role directly.) Role-agnostic — a future role-session (e.g. Solomon) inherits this posture by inclusion.
+
+_Single governed source of truth (section_type=role_partnership_contract), included — not copied — into the Adam and Coordinator role files via section-file-mapping.json; supersedes the interim hand-edits formerly in the two role contracts and the Adam private-memory note (SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001)._
+
 ---
 
-*Generated from database: 2026-06-20*
+*Generated from database: 2026-06-22*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: facfcc333c2283c4 -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: a7dd556dfae5c6c9 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 
@@ -33,6 +33,18 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 3. **Flow + silent-failure detection.** Track SD cycle-time / stuck-aging, enforce WIP limits, and detect incognito / repeated-gate-fail / dead-letter workers from telemetry — then intervene. *Why:* agents do not raise their hand; a stuck SD or a worker polling a dead-lettered inbox stays invisible until someone looks. *Mechanism:* `stale-session-sweep.cjs` (`WIP_GUARD`, `WORKER_STRUGGLING` for `handoff_fa
 
 *...truncated. Read full file for complete section.*
+
+## Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped
+
+## Coordinator → Adam messages MUST carry a recognized payload.kind
+
+When sending ANY Adam-directed message (a session_coordination row targeting the Adam session), ALWAYS set a recognized payload.kind. Adam inbox (adam-advisory.cjs drainInbox) ONLY surfaces rows where payload.kind is a recognized kind (e.g. coordinator_reply, or an ADAM_INBOX_KINDS directive) OR payload.reply_to is set. UNTYPED rows (payload.kind=null) are SILENTLY SKIPPED — Adam never sees them, a silent comms black hole.
+
+> Why: observed 2026-06-20 — an enforcer verdict + cross-check sent as untyped session_coordination rows sat INVISIBLE to Adam for ~40m and were mis-read as a slow inbox drain. Convergence nearly stalled. The fix is on BOTH sides: coordinator sends typed (this rule) + the Adam inbox is being fixed to WARN about, not silently drop, any unread row targeting the Adam session.
+
+- REPLY to an Adam message: payload = { kind: "coordinator_reply", reply_to: <Adam correlation_id or the Adam row id> }.
+- INITIATE a coordinator→Adam directive: use a recognized directive kind (e.g. coordinator_advisory).
+- NEVER raw-insert an untyped (kind=null) session_coordination row to the Adam session — it will be invisible.
 
 ---
 *The coordinator is NOT a worker and NOT Adam. Full contract in CLAUDE_COORDINATOR.md.*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 0ae26b2a604ec74f -->
+<!-- file_content_hash: 9fbe9463eac07950 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-20 5:27:00 PM
+**Generated**: 2026-06-22 4:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1678,7 +1678,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-20*
+*Generated from database: 2026-06-22*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: 2970d1a1c0d94919 -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: 40daea8d2fa264cc -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-20 5:27:00 PM*
+*DIGEST generated: 2026-06-22 4:49:32 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: 4265d04751458621 -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: 6d43903442f65066 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-20 5:27:00 PM*
+*DIGEST generated: 2026-06-22 4:49:32 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 710af571c047af82 -->
+<!-- file_content_hash: 50e4a60b1e95711c -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-20 5:27:00 PM
+**Generated**: 2026-06-22 4:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2116,6 +2116,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-06-20*
+*Generated from database: 2026-06-22*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: 63ddaac0d277d0e2 -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: 16cf4e5be4f36e58 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-20 5:27:00 PM*
+*DIGEST generated: 2026-06-22 4:49:32 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 700e96f0c5996022 -->
+<!-- file_content_hash: a532608edeef35da -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-20 5:27:00 PM
+**Generated**: 2026-06-22 4:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1582,6 +1582,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-20*
+*Generated from database: 2026-06-22*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: e66cec116279187b -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: c47365f1cd7e6522 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-20 5:27:00 PM*
+*DIGEST generated: 2026-06-22 4:49:32 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: af7745fe03e07537 -->
+<!-- file_content_hash: 6440661ff08dd580 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-20 5:27:00 PM
+**Generated**: 2026-06-22 4:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2441,6 +2441,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-20*
+*Generated from database: 2026-06-22*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-20T21:27:00.825Z -->
-<!-- git_commit: dc94cf45 -->
-<!-- db_snapshot_hash: c834d15d81f97da8 -->
-<!-- file_content_hash: 606ead4b8fd4fb7e -->
+<!-- generated_at: 2026-06-22T20:49:32.789Z -->
+<!-- git_commit: a2729e8d -->
+<!-- db_snapshot_hash: 5ac65ccd27ca615f -->
+<!-- file_content_hash: 8f997c96693e2f3b -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-20 5:27:00 PM*
+*DIGEST generated: 2026-06-22 4:49:32 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,18 +1,109 @@
 {
-  "generated_at": "2026-06-22T19:27:28.959Z",
-  "git_commit": "de82f3f3",
-  "db_snapshot_hash": "b29a4d557fed9f83",
+  "generated_at": "2026-06-22T20:49:32.789Z",
+  "git_commit": "a2729e8d",
+  "db_snapshot_hash": "5ac65ccd27ca615f",
   "files": {
+    "CLAUDE.md": {
+      "type": "full",
+      "chars": 19368,
+      "estimated_tokens": 4842,
+      "content_hash": "7a293020f0a83bda",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE.md"
+    },
+    "CLAUDE_CORE.md": {
+      "type": "full",
+      "chars": 83518,
+      "estimated_tokens": 20880,
+      "content_hash": "0b9219a1772c753d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_CORE.md"
+    },
+    "CLAUDE_LEAD.md": {
+      "type": "full",
+      "chars": 65128,
+      "estimated_tokens": 16282,
+      "content_hash": "b66f8ff083b928e8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_LEAD.md"
+    },
+    "CLAUDE_PLAN.md": {
+      "type": "full",
+      "chars": 90830,
+      "estimated_tokens": 22708,
+      "content_hash": "9b788eb39b64f5a0",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_PLAN.md"
+    },
+    "CLAUDE_EXEC.md": {
+      "type": "full",
+      "chars": 84821,
+      "estimated_tokens": 21206,
+      "content_hash": "9ee02541a271a776",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_EXEC.md"
+    },
+    "CLAUDE_ADAM.md": {
+      "type": "full",
+      "chars": 42502,
+      "estimated_tokens": 10626,
+      "content_hash": "3e44d51e9cb4bb75",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_ADAM.md"
+    },
+    "CLAUDE_COORDINATOR.md": {
+      "type": "full",
+      "chars": 19020,
+      "estimated_tokens": 4755,
+      "content_hash": "f297be69287cb113",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_COORDINATOR.md"
+    },
+    "CLAUDE_DIGEST.md": {
+      "type": "digest",
+      "chars": 9611,
+      "estimated_tokens": 2403,
+      "content_hash": "b0e50390821da3f1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_DIGEST.md"
+    },
+    "CLAUDE_CORE_DIGEST.md": {
+      "type": "digest",
+      "chars": 11535,
+      "estimated_tokens": 2884,
+      "content_hash": "47dcdbc6751e6ee3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_CORE_DIGEST.md"
+    },
+    "CLAUDE_LEAD_DIGEST.md": {
+      "type": "digest",
+      "chars": 5422,
+      "estimated_tokens": 1356,
+      "content_hash": "8d0a8f878037c400",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_LEAD_DIGEST.md"
+    },
+    "CLAUDE_PLAN_DIGEST.md": {
+      "type": "digest",
+      "chars": 8412,
+      "estimated_tokens": 2103,
+      "content_hash": "a156ae984a30bb92",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_PLAN_DIGEST.md"
+    },
+    "CLAUDE_EXEC_DIGEST.md": {
+      "type": "digest",
+      "chars": 10835,
+      "estimated_tokens": 2709,
+      "content_hash": "fb5f74bcdac6e783",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_EXEC_DIGEST.md"
+    },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "8ad4165b9dcde20a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-002WZAV0\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "7537b69cb0502e96",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
+    },
+    "CLAUDE_COORDINATOR_DIGEST.md": {
+      "type": "digest",
+      "chars": 5270,
+      "estimated_tokens": 1318,
+      "content_hash": "962b68718a153589",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "f2a046173800e258",
+    "global": "d19f07d9278f1ce5",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -266,15 +357,16 @@
       "596": "bf95e6419e99aee7",
       "597": "8220a84f943767a6",
       "599": "7ddd3e2178799aa8",
-      "601": "d8c30ec186c358a5",
+      "601": "24938018ba30efd6",
       "602": "ad0aecae8cdc6cb3",
       "603": "ca922c736e8d8ed3",
       "604": "67885bf567384f02",
-      "605": "eb981dea8abe023c",
+      "605": "19e13f356fce24ab",
       "606": "25aa68b575c66d07",
       "607": "82e04c0cc0ffb28f",
       "608": "7f99a4321502367e",
-      "609": "9790a74a362ff0ca"
+      "609": "9790a74a362ff0ca",
+      "610": "fb3813fc42f32f3a"
     },
     "meta": {
       "94": {
@@ -1581,6 +1673,11 @@
         "section_type": "coordinator_role_contract",
         "target_file": "CLAUDE_COORDINATOR.md",
         "title": "Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped"
+      },
+      "610": {
+        "section_type": "role_partnership_contract",
+        "target_file": null,
+        "title": "Coordinator ↔ Adam Autonomous Partnership (shared role contract)"
       }
     }
   }

--- a/scripts/one-off/_role-partnership-contract-section.mjs
+++ b/scripts/one-off/_role-partnership-contract-section.mjs
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001 — codify the Coordinator<->Adam autonomous
+ * partnership ONCE as a governed shared leo_protocol_sections row (section_type=
+ * 'role_partnership_contract'), and REMOVE the interim AUTONOMOUS-PARTNERSHIP-2026-06-22
+ * hand-edit blocks from sections 601 (adam_role_contract) + 605 (coordinator_role_contract).
+ *
+ * DRY-RUN by default (prints the plan, mutates nothing). Pass --apply to execute.
+ * Reversible: the interim block text is printed before removal; the new row is removable by
+ * section_type. Idempotent: skips the INSERT if a role_partnership_contract row already exists,
+ * and skips the strip if the marker is already absent.
+ *
+ * DB writes use the supabase SERVICE client (MCP apply_migration is read-only; the service
+ * client writes leo_protocol_sections like any table — same path used for strategic_directives_v2).
+ */
+import dotenv from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+const APPLY = process.argv.includes('--apply');
+const MARKER = 'AUTONOMOUS-PARTNERSHIP-2026-06-22';
+const MARKER_COMMENT = `<!-- ${MARKER} -->`;
+
+const PARTNERSHIP_TITLE = 'Coordinator ↔ Adam Autonomous Partnership (shared role contract)';
+const PARTNERSHIP_CONTENT =
+  "**Coordinator ↔ Adam autonomous partnership (shared)** — On harness/sourcing work the " +
+  "COORDINATOR is the decider/manager for work-shaping, scope, tiering, dedup, and dispatch; " +
+  "ADAM authors the DRAFT SDs/QFs (DOC-001 — sourcing is Adam's lane) and routes shaping/scope/" +
+  "dispatch decisions to the coordinator, NOT up to the chairman. The two form a JOINT RATIONALE " +
+  "and PROCEED autonomously — operational calls are never bounced to the operator. Escalate to " +
+  "the chairman/operator ONLY for genuine AUTHORITY (vision, revenue, policy) or IRREVERSIBLE/" +
+  "destructive actions. (Unchanged: the chairman may direct either role directly.) Role-agnostic — " +
+  "a future role-session (e.g. Solomon) inherits this posture by inclusion.\n\n" +
+  "_Single governed source of truth (section_type=role_partnership_contract), included — not " +
+  "copied — into the Adam and Coordinator role files via section-file-mapping.json; supersedes " +
+  "the interim hand-edits formerly in the two role contracts and the Adam private-memory note " +
+  "(SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001)._";
+
+function stripInterim(content) {
+  const pos = content.indexOf(MARKER_COMMENT);
+  if (pos === -1) return { changed: false, next: content, removed: '' };
+  const next = content.slice(0, pos).replace(/\s+$/, '');
+  return { changed: true, next, removed: content.slice(pos) };
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY'); process.exit(1); }
+  const s = createClient(url, key);
+
+  console.log(`\n=== role_partnership_contract section ${APPLY ? '(APPLY)' : '(DRY-RUN — pass --apply to execute)'} ===\n`);
+
+  // ── FR-1: INSERT the shared section (idempotent) ──
+  const { data: existing, error: exErr } = await s
+    .from('leo_protocol_sections').select('id').eq('section_type', 'role_partnership_contract');
+  if (exErr) { console.error('lookup failed:', exErr.message); process.exit(1); }
+
+  if (existing && existing.length > 0) {
+    console.log(`FR-1: role_partnership_contract already exists (id=${existing.map(r => r.id).join(',')}) — skip INSERT.`);
+  } else {
+    // id is hand-assigned on this table (no usable default → pkey collision on bare insert).
+    const { data: maxRow, error: maxErr } = await s
+      .from('leo_protocol_sections').select('id').order('id', { ascending: false }).limit(1).single();
+    if (maxErr) { console.error('max(id) lookup failed:', maxErr.message); process.exit(1); }
+    const nextId = maxRow.id + 1;
+    const row = {
+      id: nextId,
+      section_type: 'role_partnership_contract',
+      title: PARTNERSHIP_TITLE,
+      content: PARTNERSHIP_CONTENT,
+      protocol_id: 'leo-v4-3-3-ui-parity',
+      context_tier: 'REFERENCE',
+      order_index: 2630,
+      priority: 'STANDARD',
+      target_file: null,
+      metadata: { shared: true, sd: 'SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001', supersedes: ['interim blocks in 601+605', 'memory feedback-adam-lean-on-coordinator-not-chairman'] },
+    };
+    console.log('FR-1: INSERT row =>', JSON.stringify({ ...row, content: row.content.slice(0, 80) + '…' }, null, 2));
+    if (APPLY) {
+      const { data, error } = await s.from('leo_protocol_sections').insert(row).select('id').single();
+      if (error) { console.error('INSERT failed:', error.message); process.exit(1); }
+      console.log(`  ✓ inserted id=${data.id}`);
+    }
+  }
+
+  // ── FR-3: strip interim blocks from 601 + 605 ──
+  for (const id of [601, 605]) {
+    const { data, error } = await s.from('leo_protocol_sections').select('content').eq('id', id).single();
+    if (error) { console.error(`read ${id} failed:`, error.message); process.exit(1); }
+    const { changed, next, removed } = stripInterim(data.content);
+    if (!changed) { console.log(`FR-3: id=${id} — no ${MARKER} block (already clean).`); continue; }
+    console.log(`FR-3: id=${id} — strip ${removed.length} chars (len ${data.content.length} -> ${next.length}). Removed head: ${removed.slice(0, 90).replace(/\n/g, ' ')}…`);
+    if (APPLY) {
+      const { error: upErr } = await s.from('leo_protocol_sections').update({ content: next }).eq('id', id);
+      if (upErr) { console.error(`update ${id} failed:`, upErr.message); process.exit(1); }
+      console.log(`  ✓ stripped id=${id}`);
+    }
+  }
+
+  console.log(`\n${APPLY ? '✅ APPLIED' : 'DRY-RUN complete — re-run with --apply'}\n`);
+}
+
+main().catch((e) => { console.error('FATAL', e.message); process.exit(1); });

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -169,13 +169,15 @@
     "description": "Adam role contract (~2-3k chars) — Chairman-attached advisory/analysis role. Loaded by the /adam skill exactly as workers load CLAUDE_CORE.",
     "sections": [
       "adam_role_contract",
-      "adam_self_adherence_loop"
+      "adam_self_adherence_loop",
+      "role_partnership_contract"
     ]
   },
   "CLAUDE_COORDINATOR.md": {
     "description": "Coordinator role contract + SRE charter — fleet supervisor/orchestration role. Loaded by the /coordinator skill or when orienting a fleet-coordinator session, as workers load CLAUDE_CORE.",
     "sections": [
-      "coordinator_role_contract"
+      "coordinator_role_contract",
+      "role_partnership_contract"
     ]
   },
   "SHARED": {


### PR DESCRIPTION
## What (chairman directive 2026-06-22)

Codifies the Coordinator↔Adam autonomous-partnership posture as a **single governed shared section** instead of Adam private-memory + gate-bypassing interim hand-edits duplicated across `leo_protocol_sections` 601 + 605.

- **FR-1**: new `section_type='role_partnership_contract'` (id 610) — canonical bilateral clause (coordinator = decider/manager for shaping/scope/dispatch; Adam authors DRAFTs + routes to coordinator; joint rationale + proceed autonomously; escalate only authority/irreversible). Role-agnostic → inheritable by a future Solomon role.
- **FR-2**: `section-file-mapping.json` includes the section in **both** CLAUDE_ADAM.md and CLAUDE_COORDINATOR.md (include-not-copy = DRY).
- **FR-3**: removed the `AUTONOMOUS-PARTNERSHIP-2026-06-22` interim blocks from 601 + 605 (no double-codify).
- **FR-4**: regenerated all CLAUDE_*.md; `check-claude-md-drift.cjs` passes (committed == DB). Committing the regen on a feature branch is the sanctioned path flagged by SD-REFILL-00HKPG2F — and also syncs pre-existing on-main generated-doc drift.

DB writes via the supabase service client through a dry-runnable, reversible one-off script.

## Verification (TESTING PASS, 95)

section renders in both role files (1/1); interim marker gone from docs **and** DB (0/0/0 rows); drift-check clean; exactly one `role_partnership_contract` row.

LEO chain: LEAD-TO-PLAN 95 / PLAN-TO-EXEC 96 / EXEC-TO-PLAN 94.

> Note: the bulk of the diff is DB-derived generated-doc regen (sanctioned generated-file exception); the hand-authored change is the mapping (6 lines) + the DB-mutation script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)