### PR TITLE
fix(SD-REFILL-00AH2L4Q): dispatch ranker honors metadata.blocked_by_sd_key

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -24,6 +24,7 @@
  * Read-only with --dry-run. Fail-soft per item: a row that errors is skipped, never kills the pass.
  */
 import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: single-writer mutation guard.
 import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-guard.mjs';
@@ -40,6 +41,19 @@ import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispa
 // handling both the [{sd_id}]/[{sd_key}] object and raw-string shapes the old hand-rolled
 // resolver coerced, while correctly dropping the sentinel the hand-rolled one mis-counted.
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
+// SD-REFILL-00AH2L4Q: honor the SAME canonical metadata blocker key (metadata.blocked_by_sd_key)
+// that dependency-resolver + worker-checkin enforce, so the dispatch ranker does not keep a
+// metadata-blocked SD on the claimable belt (the convention was inconsistently enforced fleet-wide).
+import { checkMetadataDependency } from './modules/sd-next/dependency-resolver.js';
+
+// Collect every blocker sd_key for an SD: the `dependencies` column PLUS the canonical
+// metadata.blocked_by_sd_key. ONE predicate, shared by depKeys collection and the unmet check.
+export function blockerKeysFor(d) {
+  const keys = parseSdDependencies(d.dependencies);
+  const { blockerSdKey } = checkMetadataDependency(d.metadata);
+  if (blockerSdKey) keys.push(blockerSdKey);
+  return keys;
+}
 // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-2): needle-movement prioritization.
 // Reuse FR-1's rollup (active rung + per-rung progress) and the pure needle scorer to order remaining
 // work active-rung-first among same-unlock candidates. Loaded fail-soft — any read error leaves the
@@ -68,7 +82,7 @@ async function main() {
   // ── dependency graph: edges dep -> dependents (over non-terminal set + completed deps resolved) ──
   const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
   const depKeys = new Set();
-  (sds || []).forEach(d => parseSdDependencies(d.dependencies).forEach(k => depKeys.add(k)));
+  (sds || []).forEach(d => blockerKeysFor(d).forEach(k => depKeys.add(k)));
   let depStatus = {};
   if (depKeys.size) {
     const { data: deps } = await sb.from('strategic_directives_v2').select('sd_key,status').in('sd_key', Array.from(depKeys));
@@ -77,7 +91,7 @@ async function main() {
   // dependents[dep] = [sd_keys that list dep and are not terminal]
   const dependents = new Map();
   for (const d of (sds || [])) {
-    for (const k of parseSdDependencies(d.dependencies)) {
+    for (const k of blockerKeysFor(d)) {
       if (!dependents.has(k)) dependents.set(k, []);
       dependents.get(k).push(d.sd_key);
     }
@@ -118,7 +132,9 @@ async function main() {
       console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
       continue;
     }
-    const unmet = parseSdDependencies(d.dependencies)
+    // SD-REFILL-00AH2L4Q: include metadata.blocked_by_sd_key (via blockerKeysFor) so a metadata-blocked
+    // SD whose blocker is not yet completed is NOT ranked/dispatched — matching worker-checkin's claim guard.
+    const unmet = blockerKeysFor(d)
       .filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
     if (unmet.length) continue;
     claimable.push(d);
@@ -270,5 +286,11 @@ async function main() {
   console.log(`[BACKLOG-RANK] done — ${DRY ? 'no writes (dry-run)' : `${writes} rank(s) written, ${clears} stale rank(s) cleared`}`);
 }
 
-main().then(() => { /* natural drain; no process.exit (Windows undici abort) */ })
-  .catch(e => { console.error('[BACKLOG-RANK] error:', e.message); });
+// SD-REFILL-00AH2L4Q: guard the entrypoint so the module is importable for unit tests
+// (e.g. blockerKeysFor) without running the DB-touching pass. Direct `node ...mjs` still runs main().
+// process.argv[1] is undefined under `node -e`/some loaders, so guard it before pathToFileURL.
+const invokedDirectly = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().then(() => { /* natural drain; no process.exit (Windows undici abort) */ })
+    .catch(e => { console.error('[BACKLOG-RANK] error:', e.message); });
+}

--- a/tests/unit/coordinator-backlog-rank-metadata-blocker.test.js
+++ b/tests/unit/coordinator-backlog-rank-metadata-blocker.test.js
@@ -1,0 +1,46 @@
+/**
+ * SD-REFILL-00AH2L4Q: the dispatch ranker (coordinator-backlog-rank.mjs) must honor the SAME
+ * canonical metadata blocker key (metadata.blocked_by_sd_key) that dependency-resolver + worker-checkin
+ * enforce — otherwise a metadata-blocked SD stays on the claimable belt (gets a dispatch_rank) even
+ * though worker-checkin would refuse to claim it. blockerKeysFor() unifies the two readers on the
+ * SAME predicate (the dependencies column PLUS metadata.blocked_by_sd_key).
+ *
+ * Also asserts the module is import-safe (the entrypoint is guarded), so importing it for this test
+ * does NOT run the DB-touching backlog pass.
+ */
+import { describe, it, expect } from 'vitest';
+import { blockerKeysFor } from '../../scripts/coordinator-backlog-rank.mjs';
+
+describe('SD-REFILL-00AH2L4Q: backlog-rank honors metadata.blocked_by_sd_key (blockerKeysFor)', () => {
+  it('no dependencies and no metadata blocker -> no blockers (claimable leaf)', () => {
+    expect(blockerKeysFor({ dependencies: null, metadata: null })).toEqual([]);
+    expect(blockerKeysFor({ dependencies: [], metadata: {} })).toEqual([]);
+  });
+
+  it('metadata.blocked_by_sd_key IS treated as a blocker (the bug: it used to be ignored by the ranker)', () => {
+    const keys = blockerKeysFor({ dependencies: null, metadata: { blocked_by_sd_key: 'SD-BLOCKER-001' } });
+    expect(keys).toContain('SD-BLOCKER-001');
+  });
+
+  it('combines the dependencies column AND metadata.blocked_by_sd_key', () => {
+    const keys = blockerKeysFor({
+      dependencies: ['SD-DEP-001'],
+      metadata: { blocked_by_sd_key: 'SD-BLOCKER-002' },
+    });
+    expect(keys).toContain('SD-DEP-001');
+    expect(keys).toContain('SD-BLOCKER-002');
+  });
+
+  it('metadata without blocked_by_sd_key contributes no extra blocker (only the dependencies column)', () => {
+    const keys = blockerKeysFor({
+      dependencies: ['SD-DEP-003'],
+      metadata: { blocked_by: ['SD-LOOSE-001'], some_other: true }, // blocked_by array is NOT the enforced key
+    });
+    expect(keys).toEqual(['SD-DEP-003']);
+  });
+
+  it('module imported without running the DB pass (entrypoint guard) — reaching here proves it', () => {
+    // If main() had run on import, this suite would have errored/hung on a DB call before asserting.
+    expect(typeof blockerKeysFor).toBe('function');
+  });
+});


### PR DESCRIPTION
## Problem
The metadata blocking convention is inconsistently enforced fleet-wide — a metadata-blocked SD stays on the claimable belt. `worker-checkin` + `dependency-resolver` enforce `metadata.blocked_by_sd_key`, but `coordinator-backlog-rank.mjs` computed claimability from **only** the `dependencies` column, so a blocked SD still got a `dispatch_rank`. A worker would then try to claim it and be refused → churn.

## Fix
A shared `blockerKeysFor(d)` helper returns the `dependencies` column **plus** the canonical `metadata.blocked_by_sd_key` (reusing dependency-resolver's `checkMetadataDependency` — one predicate, no drift). All three blocker-consumption sites route through it:
- depKeys collection (so the blocker's status is fetched)
- the unlock-score `dependents` graph (blocker gets unblock credit)
- the claimable-leaf `unmet` check (a metadata-blocked SD whose blocker isn't `completed` is excluded from fresh ranking)

Also guards the `main()` entrypoint (robust to undefined `process.argv[1]`) so the module is importable for unit tests without running the DB pass. **5 unit tests green.**

## Deliberately deferred (flagged in completion)
- `metadata.blocked_by` (array) remains a non-enforced writer convention — unifying on it is a fleet-wide behavior-change/data-migration decision.
- The `sd-next.js` **display** may still list metadata-blocked SDs (cosmetic vs the substantive dispatch fix here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)