### PR TITLE
feat(SD-LEO-INFRA-DECISION-FILTER-ENFORCE-MODE-001): staged enforce-mode canary (stage 1)

### DIFF
--- a/lib/eva/forward-gate.js
+++ b/lib/eva/forward-gate.js
@@ -23,6 +23,46 @@ import { evaluateDecision } from './decision-filter-engine.js';
 export const FORWARD_GATE_EVENT = 'chairman_forward_gate_score';
 const FORWARD_GATE_ENTITY = 'chairman_decision';
 
+// SD-LEO-INFRA-DECISION-FILTER-ENFORCE-MODE-001 (chairman ruling 2026-06-22, authority item 2/3):
+// STAGED enforce-mode. Stage 1 = the canary/shadow layer below. Resolved from
+// DECISION_FILTER_ENFORCE_MODE (default 'advisory'); 'enforce-canary' records a `would_hold` shadow
+// verdict (the data a future accuracy gate + the V1 decision-filter cap consume) WITHOUT touching
+// chairman_decisions and WITHOUT any actual pause. Per the chairman ruling: enforce = auto-HOLD-for-
+// confirm (reversible, one-click logged override), NEVER a hard veto, fail-OPEN always. The actual
+// auto-HOLD pause-wiring (stage 3) and the accuracy-gate computation (stage 2) are explicit follow-ups.
+export const ENFORCE_MODE_ADVISORY = 'advisory';
+export const ENFORCE_MODE_CANARY = 'enforce-canary';
+
+/** Resolve the configured enforce mode (opts override -> env -> advisory default). */
+export function resolveEnforceMode(opt) {
+  const raw = opt ?? process.env.DECISION_FILTER_ENFORCE_MODE;
+  return raw === ENFORCE_MODE_CANARY ? ENFORCE_MODE_CANARY : ENFORCE_MODE_ADVISORY;
+}
+
+/**
+ * Pure: build the enforce-mode metadata merged into the advisory audit row. `advisory: true` is
+ * ALWAYS set (chairman authority provably untouched). In 'enforce-canary' mode it additionally
+ * records `would_hold` (the engine recommends NOT auto-proceeding) plus a reversible/override marker
+ * — SHADOW ONLY, no pause. Any unknown mode resolves to advisory (fail-safe toward not-enforcing).
+ *
+ * @param {Object} verdict - evaluateDecision() output (auto_proceed, recommendation, ...)
+ * @param {string} mode - ENFORCE_MODE_ADVISORY | ENFORCE_MODE_CANARY
+ * @returns {Object} metadata fragment
+ */
+export function buildEnforceMetadata(verdict = {}, mode = ENFORCE_MODE_ADVISORY) {
+  if (mode !== ENFORCE_MODE_CANARY) {
+    return { advisory: true, mode: ENFORCE_MODE_ADVISORY };
+  }
+  return {
+    advisory: true, // authority untouched: the canary records, it does not pause
+    mode: ENFORCE_MODE_CANARY,
+    would_hold: verdict.auto_proceed === false,
+    hold_reason: verdict.recommendation ?? null,
+    reversible: true,
+    override: 'one-click-logged (stage: shadow — records only, no pause)',
+  };
+}
+
 /**
  * Adapt a chairman_decisions row into an evaluateDecision() input.
  * Honest mapping: only fields that genuinely exist on the decision are passed;
@@ -86,7 +126,7 @@ export async function hasForwardGateScore(decisionId, supabase) {
  * @param {Object} [opts.preferences] - chairman preference map (advisory)
  * @returns {Promise<{logged: boolean, skipped?: boolean, verdict?: Object, reason?: string}>}
  */
-export async function recordForwardGateScore(decision, { supabase, logger = console, preferences } = {}) {
+export async function recordForwardGateScore(decision, { supabase, logger = console, preferences, enforceMode } = {}) {
   try {
     if (!decision || !decision.id || !supabase) {
       return { logged: false, reason: 'missing decision.id or supabase' };
@@ -102,13 +142,17 @@ export async function recordForwardGateScore(decision, { supabase, logger = cons
     const verdict = evaluateDecision(input, { preferences, logger: { info() {}, debug() {} } });
 
     // ADVISORY record — audit_log ONLY. entity_id + severity satisfy live constraints.
+    // SD-LEO-INFRA-DECISION-FILTER-ENFORCE-MODE-001: merge the staged enforce-mode shadow metadata.
+    // In 'enforce-canary' this records would_hold; it STILL writes only audit_log, never
+    // chairman_decisions, and the path remains fail-open. Default (flag unset) stays advisory.
+    const mode = resolveEnforceMode(enforceMode);
     const { error } = await supabase.from('audit_log').insert({
       event_type: FORWARD_GATE_EVENT,
       entity_type: FORWARD_GATE_ENTITY,
       entity_id: decision.id,
       severity: 'info',
       metadata: {
-        advisory: true,
+        ...buildEnforceMetadata(verdict, mode),
         const_002: 'log-only; chairman authority unchanged',
         auto_proceed: verdict.auto_proceed,
         recommendation: verdict.recommendation,

--- a/tests/unit/eva/forward-gate-enforce-mode.test.js
+++ b/tests/unit/eva/forward-gate-enforce-mode.test.js
@@ -1,0 +1,64 @@
+// SD-LEO-INFRA-DECISION-FILTER-ENFORCE-MODE-001 (chairman ruling 2026-06-22, stage 1 = canary):
+// the staged enforce-mode canary records a `would_hold` shadow verdict but NEVER touches chairman
+// authority — advisory:true is always set, it only records, and an unknown mode fails safe toward
+// advisory (never enforces by accident). These pin the pure helpers.
+import { describe, it, expect } from 'vitest';
+import {
+  buildEnforceMetadata,
+  resolveEnforceMode,
+  ENFORCE_MODE_ADVISORY,
+  ENFORCE_MODE_CANARY,
+} from '../../../lib/eva/forward-gate.js';
+
+describe('buildEnforceMetadata (SD-LEO-INFRA-DECISION-FILTER-ENFORCE-MODE-001)', () => {
+  const holdVerdict = { auto_proceed: false, recommendation: 'review: high cost' };
+  const proceedVerdict = { auto_proceed: true, recommendation: 'auto-proceed' };
+
+  it('TS-1: advisory mode -> {advisory:true, mode:advisory}, no would_hold', () => {
+    const m = buildEnforceMetadata(holdVerdict, ENFORCE_MODE_ADVISORY);
+    expect(m).toEqual({ advisory: true, mode: ENFORCE_MODE_ADVISORY });
+    expect(m.would_hold).toBeUndefined();
+  });
+
+  it('TS-2: enforce-canary + auto_proceed===false -> would_hold:true with hold_reason', () => {
+    const m = buildEnforceMetadata(holdVerdict, ENFORCE_MODE_CANARY);
+    expect(m.mode).toBe(ENFORCE_MODE_CANARY);
+    expect(m.would_hold).toBe(true);
+    expect(m.hold_reason).toBe('review: high cost');
+    expect(m.reversible).toBe(true);
+  });
+
+  it('TS-3: enforce-canary + auto_proceed===true -> would_hold:false', () => {
+    expect(buildEnforceMetadata(proceedVerdict, ENFORCE_MODE_CANARY).would_hold).toBe(false);
+  });
+
+  it('TS-4: an unknown mode resolves to advisory (fail-safe, never enforces)', () => {
+    expect(buildEnforceMetadata(holdVerdict, 'block-everything')).toEqual({ advisory: true, mode: ENFORCE_MODE_ADVISORY });
+  });
+
+  it('TS-5: advisory:true is set in EVERY mode (chairman authority untouched)', () => {
+    expect(buildEnforceMetadata(holdVerdict, ENFORCE_MODE_ADVISORY).advisory).toBe(true);
+    expect(buildEnforceMetadata(holdVerdict, ENFORCE_MODE_CANARY).advisory).toBe(true);
+  });
+
+  it('missing recommendation -> hold_reason null (no crash)', () => {
+    expect(buildEnforceMetadata({ auto_proceed: false }, ENFORCE_MODE_CANARY).hold_reason).toBeNull();
+  });
+});
+
+describe('resolveEnforceMode', () => {
+  it('explicit opt wins', () => {
+    expect(resolveEnforceMode(ENFORCE_MODE_CANARY)).toBe(ENFORCE_MODE_CANARY);
+    expect(resolveEnforceMode('nonsense')).toBe(ENFORCE_MODE_ADVISORY);
+  });
+
+  it('undefined opt + no env -> advisory default', () => {
+    const prev = process.env.DECISION_FILTER_ENFORCE_MODE;
+    delete process.env.DECISION_FILTER_ENFORCE_MODE;
+    try {
+      expect(resolveEnforceMode(undefined)).toBe(ENFORCE_MODE_ADVISORY);
+    } finally {
+      if (prev !== undefined) process.env.DECISION_FILTER_ENFORCE_MODE = prev;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Chairman ruling 2026-06-22 (authority item 2 of 3): move the decision-filter forward gate from advisory-only toward a **STAGED** enforce-mode. CONST-002 forbade a blocking mode without chairman policy — now ruled: enforce = **auto-HOLD-for-confirm** (a reversible speed bump with one-click logged override), **never a hard veto**, **fail-OPEN always**, accuracy-gated canary.

This PR ships **stage 1 — the canary/shadow layer**.

## What it does
- **`buildEnforceMetadata(verdict, mode)`** (pure): `advisory` (default) → `{advisory:true, mode:advisory}`; `enforce-canary` → `{advisory:true, mode:enforce-canary, would_hold: auto_proceed===false, hold_reason, reversible, override}`. `advisory:true` is **always** set; an unknown mode → advisory (fail-safe, never enforces by accident).
- **`resolveEnforceMode(opt)`** reads `DECISION_FILTER_ENFORCE_MODE` (default `advisory`).
- **`recordForwardGateScore`** merges the shadow metadata into the existing `audit_log` row. It **still writes only `audit_log`** — **never `chairman_decisions`** — and the path stays **absolutely fail-open**. The canary **records** `would_hold`; it does **not** pause/hold any decision.

## Why this scope
The ruling explicitly says **STAGED + accuracy-gated canary**. Stage 1 builds the canary/shadow layer that the future accuracy gate (stage 2) and the actual auto-HOLD pause (stage 3) require — and it's safe by construction (records only, authority untouched, fail-open). It produces the `would_hold` shadow data and drives the V1 *'live decision-filter engine gating chairman decisions'* cap off its 0.5 grep floor.

## Follow-ups (explicit)
- **Stage 2:** accuracy-gate computation (engine recommendation vs chairman's actual action) to arm enforcement only when proven accurate.
- **Stage 3:** the actual auto-HOLD-for-confirm pause-wiring + one-click override, fail-open.

## Testing
- 8 new unit tests (both modes, would_hold true/false, fail-safe unknown mode, advisory-always).
- 12 existing forward-gate tests green (advisory contract preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)