### PR TITLE
fix(SD-REFILL-001YZJNQ): premature-parent guard — WAIT when planned children exceed authored

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -127,6 +127,46 @@ export function createPrerequisiteCheckGate(supabase) {
 }
 
 /**
+ * SD-REFILL-001YZJNQ — premature-parent guard. A parent orchestrator auto-completes when all its
+ * CREATED children reach a terminal status, but the program plan may declare MORE children (waves)
+ * that were never authored as SD rows (witnessed on SD-LEO-ORCH-ADAM-PLAN-KEEPER-001: 6 created
+ * children all complete, Wave 2-4 ~SDs/QFs never created → counting only created children completed
+ * the parent prematurely). This decides whether an all-created-children-complete parent should still
+ * WAIT because more children are planned than authored.
+ *
+ * CONSERVATIVE / regression-free: returns wait=false UNLESS an EXPLICIT planned-children signal is
+ * present AND exceeds the created count AND decomposition is not explicitly marked complete. Parents
+ * without any planned signal behave exactly as before (no regression). decomposition_complete===true
+ * short-circuits to NO wait (author asserts the plan is fully decomposed / intentionally smaller).
+ * Planned count is taken from the first present of: metadata.planned_children_count (number) |
+ * metadata.planned_children (array length) | metadata.plan_content.planned_children_count (number).
+ * Free-form plan_content TEXT is NOT parsed — that would risk false WAITs blocking legitimate parents.
+ *
+ * @param {{parentMetadata?:object, createdChildCount:number}} args
+ * @returns {{wait:boolean, plannedCount:number|null, createdCount:number, reason:string}}
+ */
+export function evaluatePlannedDecomposition({ parentMetadata, createdChildCount } = {}) {
+  const md = parentMetadata && typeof parentMetadata === 'object' ? parentMetadata : {};
+  const created = Number.isFinite(createdChildCount) ? createdChildCount : 0;
+  if (md.decomposition_complete === true) {
+    return { wait: false, plannedCount: null, createdCount: created, reason: 'decomposition_complete=true (author marked the plan fully decomposed)' };
+  }
+  let planned = null;
+  if (Number.isFinite(md.planned_children_count)) planned = md.planned_children_count;
+  else if (Array.isArray(md.planned_children)) planned = md.planned_children.length;
+  else if (md.plan_content && typeof md.plan_content === 'object' && Number.isFinite(md.plan_content.planned_children_count)) planned = md.plan_content.planned_children_count;
+  if (!Number.isFinite(planned) || planned <= created) {
+    return { wait: false, plannedCount: Number.isFinite(planned) ? planned : null, createdCount: created, reason: 'no explicit planned-children signal exceeding the created count' };
+  }
+  return {
+    wait: true,
+    plannedCount: planned,
+    createdCount: created,
+    reason: `Parent program plan declares ${planned} child SD(s) but only ${created} have been authored — ${planned - created} planned child(ren) not yet created (premature-parent guard).`,
+  };
+}
+
+/**
  * Check if SD is a parent orchestrator with completed children
  *
  * @param {Object} supabase - Supabase client
@@ -174,6 +214,35 @@ async function checkParentOrchestrator(supabase, sdUuid, _ctx) {
           total_children: childSDs.length,
           completed_children: completedChildren.length,
           incomplete_children: incompleteList,
+        },
+      });
+    }
+
+    // SD-REFILL-001YZJNQ: all CREATED children are terminal — but guard against PREMATURE parent
+    // completion when the program plan declares MORE children than were authored as SD rows. The
+    // parent SD is ctx.sd (the row being handed off); read its metadata directly (no extra query).
+    // Only WAITs on an EXPLICIT planned-children signal (regression-free + fail-open: a thin context
+    // with no metadata degrades to today's behavior, never a false block).
+    const decomp = evaluatePlannedDecomposition({
+      parentMetadata: _ctx?.sd?.metadata,
+      createdChildCount: childSDs.length,
+    });
+    if (decomp.wait) {
+      console.log(`   ⏳ WAITING on un-authored planned children (${decomp.createdCount}/${decomp.plannedCount} authored) — not a failure (premature-parent guard):`);
+      console.log(`      ${decomp.reason}`);
+      return buildWaitResult({
+        score: 0,
+        max_score: 100,
+        wait_reason: decomp.reason,
+        issues: [],
+        warnings: [`WAIT: parent plan declares ${decomp.plannedCount} children but only ${decomp.createdCount} authored — decomposition incomplete`],
+        remediation: `Author the remaining ${decomp.plannedCount - decomp.createdCount} planned child SD(s), OR set metadata.decomposition_complete=true if the plan is intentionally smaller than declared. Then re-run PLAN-TO-LEAD.`,
+        details: {
+          is_parent_sd: true,
+          total_children: childSDs.length,
+          completed_children: completedChildren.length,
+          planned_children: decomp.plannedCount,
+          decomposition_incomplete: true,
         },
       });
     }

--- a/tests/unit/handoff/executors/plan-to-lead/premature-parent-guard.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/premature-parent-guard.test.js
@@ -1,0 +1,58 @@
+// SD-REFILL-001YZJNQ — premature-parent guard. A parent orchestrator auto-completed when all its
+// CREATED children finished, but the program plan declared MORE children (waves) never authored as
+// SD rows (witnessed SD-LEO-ORCH-ADAM-PLAN-KEEPER-001). evaluatePlannedDecomposition decides whether
+// an all-created-children-complete parent should still WAIT. It is CONSERVATIVE: wait=true ONLY on an
+// explicit planned-children signal exceeding the created count AND decomposition not marked complete
+// — so parents without a planned signal behave exactly as before (no regression).
+import { describe, it, expect } from 'vitest';
+import { evaluatePlannedDecomposition } from '../../../../../scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js';
+
+describe('evaluatePlannedDecomposition (SD-REFILL-001YZJNQ premature-parent guard)', () => {
+  it('WAITs when planned_children_count exceeds the created count', () => {
+    const r = evaluatePlannedDecomposition({ parentMetadata: { planned_children_count: 14 }, createdChildCount: 6 });
+    expect(r.wait).toBe(true);
+    expect(r.plannedCount).toBe(14);
+    expect(r.createdCount).toBe(6);
+    expect(r.reason).toMatch(/8 planned child/);
+  });
+
+  it('does NOT wait when created >= planned', () => {
+    expect(evaluatePlannedDecomposition({ parentMetadata: { planned_children_count: 6 }, createdChildCount: 6 }).wait).toBe(false);
+    expect(evaluatePlannedDecomposition({ parentMetadata: { planned_children_count: 4 }, createdChildCount: 6 }).wait).toBe(false);
+  });
+
+  it('decomposition_complete=true short-circuits to NO wait even if planned > created', () => {
+    const r = evaluatePlannedDecomposition({ parentMetadata: { decomposition_complete: true, planned_children_count: 14 }, createdChildCount: 6 });
+    expect(r.wait).toBe(false);
+    expect(r.reason).toMatch(/decomposition_complete/);
+  });
+
+  it('REGRESSION-FREE: no planned signal at all → no wait (behaves as today)', () => {
+    expect(evaluatePlannedDecomposition({ parentMetadata: {}, createdChildCount: 6 }).wait).toBe(false);
+    expect(evaluatePlannedDecomposition({ parentMetadata: undefined, createdChildCount: 6 }).wait).toBe(false);
+    expect(evaluatePlannedDecomposition({ parentMetadata: { plan_content: 'free-form prose with 4 waves' }, createdChildCount: 6 }).wait).toBe(false); // text not parsed
+  });
+
+  it('accepts a planned_children array length as the signal', () => {
+    const r = evaluatePlannedDecomposition({ parentMetadata: { planned_children: new Array(9).fill({}) }, createdChildCount: 3 });
+    expect(r.wait).toBe(true);
+    expect(r.plannedCount).toBe(9);
+  });
+
+  it('accepts a structured plan_content.planned_children_count', () => {
+    const r = evaluatePlannedDecomposition({ parentMetadata: { plan_content: { planned_children_count: 10 } }, createdChildCount: 2 });
+    expect(r.wait).toBe(true);
+    expect(r.plannedCount).toBe(10);
+  });
+
+  it('is total on odd input', () => {
+    expect(evaluatePlannedDecomposition().wait).toBe(false);
+    expect(evaluatePlannedDecomposition({ parentMetadata: 42, createdChildCount: NaN }).wait).toBe(false);
+    expect(evaluatePlannedDecomposition({ parentMetadata: { planned_children_count: 5 } }).createdCount).toBe(0);
+  });
+
+  it('precedence: explicit count wins over array, array over plan_content', () => {
+    const r = evaluatePlannedDecomposition({ parentMetadata: { planned_children_count: 12, planned_children: [{}], plan_content: { planned_children_count: 3 } }, createdChildCount: 1 });
+    expect(r.plannedCount).toBe(12);
+  });
+});


### PR DESCRIPTION
## SD-REFILL-001YZJNQ

The PLAN-TO-LEAD parent-orchestrator check passed a parent to final approval as soon as all its **created** children reached terminal status — counting only authored child rows. A parent whose program plan declares more children (waves) than were authored auto-completed **prematurely** (witnessed SD-LEO-ORCH-ADAM-PLAN-KEEPER-001: 6 created children done, Wave 2-4 ~9 SDs/5 QFs never created).

### Fix
- Pure `evaluatePlannedDecomposition()`: WAIT when an **explicit** planned-children signal (`metadata.planned_children_count` | `planned_children[]` | `plan_content.planned_children_count`) exceeds the created count AND `decomposition_complete !== true`.
- WAIT verdict (not FAIL) via the shared `buildWaitResult` — no retry/RCA burn, consistent with ORCH-PARENT-LIFECYCLE-001.
- **Conservative + regression-free**: parents with no planned signal behave exactly as before; reads `ctx.sd.metadata` (no extra query, fail-open on thin context). Free-form `plan_content` text is never parsed.

### Tests
- 8 new unit tests; existing parent-lifecycle TS-10 preserved; full handoff suite **727 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)