### PR TITLE
fix(SD-REFILL-00FKX3W0): display-vs-navigation awareness in design workflow scorer

### DIFF
--- a/lib/sub-agents/design/workflow-scoring.js
+++ b/lib/sub-agents/design/workflow-scoring.js
@@ -243,6 +243,16 @@ export function shouldFlag(issue, context = {}) {
     return false;
   }
 
+  // SD-REFILL-00FKX3W0: display-vs-navigation awareness. A READ-ONLY display surface
+  // (e.g. a status gauge honestly showing "awaiting cash source") that is NOT on a
+  // required/critical path is an honest terminal DISPLAY state, not a navigation
+  // dead-end — flagging it as one false-fails the design gate on genuine read-only UI.
+  // Required/critical read paths still flag (calculateSeverity escalates dead_end +
+  // isRequiredPath to CRITICAL), so this never suppresses a real blocker.
+  if (issue.type === 'dead_end' && context.isReadOnly && !context.isRequiredPath) {
+    return false;
+  }
+
   // Flag everything else
   return true;
 }

--- a/tests/unit/design-workflow-scoring-readonly-deadend.test.js
+++ b/tests/unit/design-workflow-scoring-readonly-deadend.test.js
@@ -1,0 +1,44 @@
+/**
+ * SD-REFILL-00FKX3W0 — display-vs-navigation awareness in the design workflow scorer.
+ *
+ * Sub-problem 2: a READ-ONLY display surface honestly showing a terminal state (e.g. a
+ * status gauge reading "awaiting cash source") was flagged as a navigation dead_end,
+ * false-failing the EXEC-TO-PLAN design gate on genuine read-only UI. The existing
+ * dead_end suppression only matched terminal GOAL labels (success/complete/...), not
+ * honest read-only DISPLAY states. Fix: suppress dead_end for isReadOnly && !isRequiredPath,
+ * while genuine required/critical read paths still flag (calculateSeverity escalates those).
+ *
+ * (Sub-problem 1 — cross-repo files_analyzed:0 — was already fixed in design/utils.js
+ * getGitDiffFiles base..HEAD + resolveDesignRepo target-app-aware; not re-addressed here.)
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldFlag } from '../../lib/sub-agents/design/workflow-scoring.js';
+
+describe('shouldFlag — read-only display vs navigation dead-end (SD-REFILL-00FKX3W0)', () => {
+  it('does NOT flag a dead_end on a read-only, non-required display state', () => {
+    const issue = { type: 'dead_end', label: 'awaiting cash source' };
+    expect(shouldFlag(issue, { isReadOnly: true, isRequiredPath: false })).toBe(false);
+  });
+
+  it('STILL flags a dead_end on a read-only REQUIRED/critical path (real blocker)', () => {
+    const issue = { type: 'dead_end', label: 'awaiting cash source' };
+    expect(shouldFlag(issue, { isReadOnly: true, isRequiredPath: true })).toBe(true);
+  });
+
+  it('STILL flags a dead_end on an interactive (non-read-only) state', () => {
+    const issue = { type: 'dead_end', label: 'order pending' };
+    expect(shouldFlag(issue, { isReadOnly: false, isRequiredPath: false })).toBe(true);
+  });
+
+  it('preserves the existing terminal-goal-state suppression (label match)', () => {
+    const issue = { type: 'dead_end', label: 'Success! Order complete' };
+    // suppressed by the terminal-goal-state rule regardless of read-only context
+    expect(shouldFlag(issue, { isReadOnly: false, isRequiredPath: false })).toBe(false);
+  });
+
+  it('does not over-suppress unrelated issue types on read-only content', () => {
+    // a non-dead_end issue is unaffected by the new clause
+    const issue = { type: 'circular_flow', label: 'loop' };
+    expect(shouldFlag(issue, { isReadOnly: true, isRequiredPath: false })).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

The EXEC-TO-PLAN **DESIGN gate false-failed EHG-frontend SDs** whose UI has honest read-only display surfaces: `shouldFlag()` in `lib/sub-agents/design/workflow-scoring.js` flagged a read-only terminal DISPLAY state (e.g. a status gauge reading *"awaiting cash source"*) as a navigation `dead_end`. The existing dead_end suppression only matched terminal GOAL labels (`success|complete|...`); `isReadOnly` was computed but unused for dead_end (it's already used for `error_recovery` + `accessibility`).

## Fix

Add one clause to `shouldFlag()`: suppress `dead_end` when `isReadOnly && !isRequiredPath` — an honest read-only display isn't a nav dead-end. **Required/critical read paths still flag** (`calculateSeverity` escalates `dead_end + isRequiredPath` → CRITICAL), and interactive dead-ends still flag. Narrows, never widens.

5 unit tests (read-only non-required suppressed; read-only required still flagged; interactive still flagged; terminal-goal preserved; non-dead_end unaffected).

## Scope note (verify-the-premise)

The SD's **other** sub-problem — cross-repo `files_analyzed:0` (path-normalization) — was **already fixed** in `lib/sub-agents/design/utils.js` (`getGitDiffFiles` uses `origin/main..HEAD` with a target-application-aware `repoPath` from `resolveDesignRepo→resolveRepoPath`). Verified, not re-addressed.

LEO chain: LEAD-TO-PLAN 96 / PLAN-TO-EXEC 98. TESTING PASS (95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)