### PR TITLE
feat(SD-LEO-INFRA-WORKER-ANTI-PREMATURE-WINDDOWN-001): anti-wind-down directive in the check-in payload (Mode B fix)

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -48,6 +48,19 @@ const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (ide
 // chatter — but each idle check is a cheap idempotent roll_call (5m dedup), so the cost is
 // small. NOT applied to the propose-only idle branch below, which keeps its own 1200 literal.
 const DEFAULT_IDLE_WAKEUP_SECONDS = 600;      // ~10m, matches the tightened fleet idle cadence
+
+// SD-LEO-INFRA-WORKER-ANTI-PREMATURE-WINDDOWN-001 (Mode B, the DOMINANT wind-down failure 3/4):
+// the enforceable lever. When a worker holds/just-claimed RANKED claimable work, this directive
+// rides the check-in payload to kill the false "drained" feeling with data and to surface — AT the
+// wind-down decision point — CLAUDE.md's already-FORBIDDEN non-pause-triggers. RELEASING claimable
+// ranked work is NOT a valid wind-down; a too-large/design-heavy SD is DECOMPOSED (orchestrator
+// path), never released; only a GENUINELY-BLOCKED SD may be deferred WITH A LOGGED REASON (the
+// guardrail that preserves legitimate defer — e.g. a verified spec-conflict, never "scope/context").
+function antiWinddownDirective(beltRankedClaimable) {
+  const n = Number.isFinite(beltRankedClaimable) ? beltRankedClaimable : null;
+  const depth = n && n > 0 ? `The belt has ${n} ranked claimable SD(s).` : 'You hold ranked claimable work.';
+  return `ANTI-WIND-DOWN (Mode B): ${depth} Releasing claimable RANKED work to wind down is FORBIDDEN — "scope size / design-heaviness / chairman-gated / context length / session-tail / felt drained" are CLAUDE.md's explicitly-forbidden non-pause-triggers, NOT reasons to release. Build this SD; if it is too large/design-heavy, DECOMPOSE it into children (orchestrator path) — do not release. Only a GENUINELY-BLOCKED SD may be deferred, and only with a logged blocker reason (e.g. a verified spec-conflict). Otherwise keep working.`;
+}
 const SELF_CLAIM_CANDIDATE_LIMIT = 5;
 const QF_CANDIDATE_LIMIT = 25;               // open quick_fixes to consider for self-claim
 const STALE_QF_DAYS = Number(process.env.SD_NEXT_QF_STALE_DAYS) || 3;  // verify-first freshness boundary (shared with sd-next display)
@@ -443,7 +456,10 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d) {
       ...base,
       action: 'self_claimed',
       sd: d.sd_key,
-      message: `Self-claimed ${d.sd_key} (un-baselined draft) from the SD belt. Run: node scripts/sd-start.js ${d.sd_key}`,
+      // FR-1: a draft claim is still ranked claimable work — carry the anti-wind-down directive so the
+      // worker builds/decomposes it rather than rationalizing a release (base.belt_ranked_claimable was
+      // set by the step-6 merged pool before this is called; default 0 if the draft path ran standalone).
+      message: `Self-claimed ${d.sd_key} (un-baselined draft) from the SD belt. Run: node scripts/sd-start.js ${d.sd_key}. ${antiWinddownDirective(base.belt_ranked_claimable)}`,
     };
   }
   return null;
@@ -931,7 +947,7 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
           const effortRec = assignment.payload?.effort_recommendation || null;
           return { ...base, action: 'claimed_assignment', sd: sdKey,
             ...(effortRec ? { effort_recommendation: effortRec, effort_recommendation_reason: assignment.payload?.effort_recommendation_reason || null } : {}),
-            message: `Claimed assigned ${sdKey} via claim_sd.${effortRec ? ` Recommended effort: ${effortRec} (advisory).` : ''} Run: node scripts/sd-start.js ${sdKey}` };
+            message: `Claimed assigned ${sdKey} via claim_sd.${effortRec ? ` Recommended effort: ${effortRec} (advisory).` : ''} Run: node scripts/sd-start.js ${sdKey}. ${antiWinddownDirective(base.belt_ranked_claimable)}` };
         }
         // could not claim the assigned SD -> fall through to self-claim
         base.assignment_claim_error = claimed.error;
@@ -998,6 +1014,10 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
 
     // duty-6: honor the coordinator's fresh dispatch_rank across the WHOLE pool (fail-open).
     const ranked = await sortByDispatchRank(sb, merged, (x) => x.key);
+    // FR-1 (anti-premature-winddown): expose the ranked claimable belt depth on EVERY result so the
+    // /checkin skill can render concrete available work — a worker about to wind down sees data, not a
+    // vibe. base is spread into the self_claimed / idle / QF results below.
+    base.belt_ranked_claimable = ranked.length;
     for (const x of ranked) {
       if (x.kind === 'baselined') {
         // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: skip dependency-blocked SDs and orchestrator PARENTS
@@ -1008,7 +1028,8 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
         if (await isSdInFlight(sb, x.key, sessionId)) continue;  // dedup: started or live-foreign-held
         const claimed = await tryClaim(sb, x.key, sessionId, x.track);
         if (claimed.ok) {
-          return { ...base, action: 'self_claimed', sd: x.key, track: x.track, message: `Self-claimed ${x.key} from sd:next. Run: node scripts/sd-start.js ${x.key}` };
+          return { ...base, action: 'self_claimed', sd: x.key, track: x.track,
+            message: `Self-claimed ${x.key} from sd:next. Run: node scripts/sd-start.js ${x.key}. ${antiWinddownDirective(ranked.length)}` };
         }
       } else {
         const result = await tryClaimDraftCandidate(sb, sessionId, base, x.row);
@@ -1050,7 +1071,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, sortByDispatchRank, DISPATCH_RANK_TTL_MS, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, sortByDispatchRank, DISPATCH_RANK_TTL_MS, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-anti-winddown.test.js
+++ b/tests/unit/worker-checkin-anti-winddown.test.js
@@ -1,0 +1,51 @@
+/**
+ * SD-LEO-INFRA-WORKER-ANTI-PREMATURE-WINDDOWN-001 (FR-1): the enforceable lever.
+ * The check-in payload must carry an anti-wind-down directive when a worker holds/just-claimed
+ * RANKED claimable work, encoding CLAUDE.md's forbidden non-pause-triggers (FR-2 no-release-while-
+ * claimable), the decompose-don't-release norm (FR-3), and the legitimate-defer guardrail (FR-4).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { antiWinddownDirective } = require('../../scripts/worker-checkin.cjs');
+
+describe('SD-LEO-INFRA-WORKER-ANTI-PREMATURE-WINDDOWN-001 FR-1: antiWinddownDirective', () => {
+  it('renders the ranked belt depth when N > 0 (kills the "drained" vibe with data)', () => {
+    const d = antiWinddownDirective(7);
+    expect(d).toMatch(/belt has 7 ranked claimable/i);
+  });
+
+  it('falls back to a generic "you hold ranked claimable work" when the count is unknown/zero', () => {
+    for (const v of [0, null, undefined, NaN]) {
+      const d = antiWinddownDirective(v);
+      expect(d).toMatch(/you hold ranked claimable work/i);
+      expect(d).not.toMatch(/belt has 0/i);
+    }
+  });
+
+  it('FR-2: names the forbidden non-pause-triggers and forbids releasing claimable ranked work', () => {
+    const d = antiWinddownDirective(3);
+    expect(d).toMatch(/FORBIDDEN/);
+    expect(d).toMatch(/scope size/i);
+    expect(d).toMatch(/context length/i);
+    expect(d).toMatch(/session-tail/i);
+    expect(d).toMatch(/drained/i);
+    expect(d).toMatch(/releasing claimable ranked work/i);
+  });
+
+  it('FR-3: surfaces decompose-don\'t-release for a too-large/design-heavy SD', () => {
+    const d = antiWinddownDirective(3);
+    expect(d).toMatch(/DECOMPOSE/);
+    expect(d).toMatch(/do not release/i);
+  });
+
+  it('FR-4: preserves legitimate defer — only a genuinely-blocked SD, with a logged reason', () => {
+    const d = antiWinddownDirective(3);
+    expect(d).toMatch(/genuinely-blocked/i);
+    expect(d).toMatch(/logged blocker reason/i);
+  });
+
+  it('module is import-safe (require.main guard) — requiring it for this test did not run the check-in', () => {
+    expect(typeof antiWinddownDirective).toBe('function');
+  });
+});


### PR DESCRIPTION
## Problem (chairman directive via the coordinator wind-down survey, 4 worker responses)
The DOMINANT wind-down failure (3/4) is **Mode B**: a worker ARMS a wakeup but **releases claimable RANKED SDs** and winds down by rationalizing CLAUDE.md's explicitly-forbidden non-pause-triggers ('felt drained', SD 'too large/design-heavy/chairman-gated/session-tail', 'context long → fresh context'). The rules are documented, but Opus rationalizes around them at the wind-down decision point.

## Fix — FR-1, the enforceable lever
`worker-checkin.cjs` now computes the ranked claimable belt depth (`base.belt_ranked_claimable`) and rides an `antiWinddownDirective()` on **every** claim result (baselined self-claim, draft self-claim, claimed_assignment). The directive surfaces, at the wind-down decision point:
- **FR-2**: releasing claimable RANKED work is FORBIDDEN — names the forbidden non-pause-triggers (scope/design-heaviness/chairman-gated/context-length/session-tail/drained).
- **FR-3**: a too-large/design-heavy SD is **DECOMPOSED** (orchestrator path), not released.
- **FR-4 (guardrail)**: ONLY a genuinely-blocked SD may be deferred, and only with a logged blocker reason (preserves legitimate defer, e.g. a verified spec-conflict).

The `/checkin` skill renders this `message`, killing the false 'drained' feeling with data. `antiWinddownDirective` is exported + pure; the module stays import-safe (require.main guard). **6 unit tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)