### PR TITLE
fix(SD-REFILL-00SO4HZY): gate orchestrator children off the belt until parent passes LEAD

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -110,6 +110,37 @@ async function draftDepsSatisfied(sb, sd, { throwOnError = false } = {}) {
   }
 }
 
+// Phases at/before LEAD-TO-PLAN — a parent here has NOT yet passed LEAD.
+const PRE_LEAD_PASS_PHASES = new Set(['LEAD', 'LEAD_APPROVAL']);
+
+/**
+ * SD-REFILL-00SO4HZY: an orchestrator CHILD must not be dispatched until its PARENT passes LEAD
+ * (LEAD-TO-PLAN accepted). Before that, the child is claimable+buildable through PLAN, then hits a
+ * hard EXEC-transition block (a child cannot enter EXEC until the parent completes LEAD) — wasting
+ * PLAN cycles + churn. This re-fetches the parent and reports whether it is still pre-LEAD-pass.
+ *   true  -> parent exists and is NOT past LEAD (status != completed AND current_phase in {LEAD,LEAD_APPROVAL}) -> child NOT dispatchable.
+ *   false -> no parent / parent past LEAD / completed -> not blocked on this axis.
+ * Fail-open on any query fault or missing parent (never strand a child on a transient error); the
+ * caller composes this with the other eligibility axes.
+ * @returns {Promise<boolean>} true when the child is blocked by a parent that has not yet passed LEAD.
+ */
+async function parentLeadPending(sb, sd) {
+  const parentRef = sd && sd.parent_sd_id;
+  if (!parentRef) return false;                                  // not an orchestrator child
+  try {
+    const { data, error } = await sb
+      .from('strategic_directives_v2')
+      .select('status, current_phase')
+      .or(`id.eq.${parentRef},sd_key.eq.${parentRef}`)           // parent_sd_id references the parent id (== sd_key here)
+      .maybeSingle();
+    if (error || !data) return false;                            // fail-open: can't confirm -> don't strand the child
+    if (data.status === 'completed') return false;               // parent done -> children fully workable
+    return PRE_LEAD_PASS_PHASES.has(String(data.current_phase || '').toUpperCase());
+  } catch {
+    return false;                                                // fail-open
+  }
+}
+
 /**
  * Evaluate whether an SD may be dispatched/claimed onto a worker. Returns a discriminated verdict
  * so callers can distinguish CONFIRMED-ineligible from a query error:
@@ -123,7 +154,9 @@ async function evaluateDispatchEligibility(sb, sdKey, ctx) {
     .from('strategic_directives_v2')
     // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): target_application + status added so the optional
     // claim-time fitness axes (repo-match / premise-open) have the fields they need when ctx is passed.
-    .select('sd_key, sd_type, dependencies, metadata, target_application, status')
+    // SD-REFILL-00SO4HZY: + parent_sd_id so the parent-LEAD gate (below) can see if this is an
+    // orchestrator child whose parent has not yet passed LEAD.
+    .select('sd_key, sd_type, dependencies, metadata, target_application, status, parent_sd_id')
     .eq('sd_key', sdKey)
     .maybeSingle();
   if (error) throw error;                                       // uncertain -> caller decides
@@ -133,6 +166,9 @@ async function evaluateDispatchEligibility(sb, sdKey, ctx) {
   // passed sdKey separately.
   const ineligible = classifyDispatchIneligibility({ ...data, sd_key: data.sd_key || sdKey }, ctx);
   if (ineligible) return { eligible: false, reason: ineligible };
+  // SD-REFILL-00SO4HZY: a child of an orchestrator parent that has not yet passed LEAD is NOT
+  // dispatchable — claiming it now only burns PLAN cycles before the hard EXEC-transition block.
+  if (await parentLeadPending(sb, data)) return { eligible: false, reason: 'parent_lead_pending' };
   // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-D: claim-time source-integrity guard for auto-refilled
   // SDs only. -C enforces candidate-validity at PROMOTION time; this re-consults the SOURCE row at CLAIM
   // time so a source that was declined/deleted/unlinked AFTER promotion no longer routes onto a worker.
@@ -191,4 +227,4 @@ async function baselinedCandidateEligible(sb, sdKey, ctx) {
   }
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE };
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending, TEST_FIXTURE_KEY_RE };

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -35,7 +35,7 @@ const { isBuildForbiddenSession } = require('../lib/claim/build-forbidden-sessio
 const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cjs');
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
-const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
+const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
 const { NATO, COLORS, nextAvailable, isTestSessionId } = require('./assign-fleet-identities.cjs');
@@ -427,7 +427,9 @@ async function fetchDraftCandidates(sb) {
     // metadata feeds the shared classifyDispatchIneligibility gate (the requires_human_action axis);
     // sd_type already selected for the existing orchestrator exclusion. target_application added for
     // the SD-LEO-INFRA-WORKER-CLAIM-TIME-001 claim-time repo-match fitness axis.
-    .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata, target_application')
+    // SD-REFILL-00SO4HZY: + parent_sd_id so the draft self-claim path can apply the parent-LEAD gate
+    // (an orchestrator child whose parent has not passed LEAD must not be claimed -> wasted PLAN cycles).
+    .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata, target_application, parent_sd_id')
     .in('status', ['draft', 'active'])
     .is('claiming_session_id', null)
     .neq('sd_type', 'orchestrator')
@@ -449,6 +451,9 @@ async function tryClaimDraftCandidate(sb, sessionId, base, d) {
   // (repo mismatch / closed premise / missing precondition) is skipped before claiming.
   if (classifyDispatchIneligibility(d, { cwd: process.cwd() }) !== null) return null;
   if (!(await draftDepsSatisfied(sb, d))) return null; // skip dependency-blocked
+  // SD-REFILL-00SO4HZY: skip an orchestrator child whose parent has not yet passed LEAD (a worker would
+  // otherwise drive PLAN then hit the hard EXEC-transition block). Fail-open inside parentLeadPending.
+  if (await parentLeadPending(sb, d)) return null;
   if (await isSdInFlight(sb, d.sd_key, sessionId)) return null; // dedup: started or live-foreign-held
   const claimed = await tryClaim(sb, d.sd_key, sessionId);
   if (claimed.ok) {

--- a/tests/unit/claim-eligibility-parent-lead-gate.test.js
+++ b/tests/unit/claim-eligibility-parent-lead-gate.test.js
@@ -1,0 +1,57 @@
+/**
+ * SD-REFILL-00SO4HZY: an orchestrator CHILD must not be dispatched until its PARENT passes LEAD.
+ * parentLeadPending(sb, sd) is the shared gate (used by evaluateDispatchEligibility for baselined
+ * candidates and by worker-checkin's draft self-claim path). It returns true ONLY when the parent
+ * exists, is not completed, and is still in a pre-LEAD-pass phase (LEAD / LEAD_APPROVAL). Fail-open.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parentLeadPending } = require('../../lib/fleet/claim-eligibility.cjs');
+
+// Mock supabase: .from(...).select(...).or(...).maybeSingle() resolves to { data, error }.
+function mkSb(result) {
+  return {
+    from() {
+      const q = {
+        select() { return q; },
+        or() { return q; },
+        maybeSingle() { return Promise.resolve(result); },
+      };
+      return q;
+    },
+  };
+}
+
+describe('SD-REFILL-00SO4HZY: parentLeadPending', () => {
+  it('returns false for an SD with no parent (not an orchestrator child)', async () => {
+    const sb = mkSb({ data: null, error: null });
+    expect(await parentLeadPending(sb, { parent_sd_id: null })).toBe(false);
+    expect(await parentLeadPending(sb, {})).toBe(false);
+  });
+
+  it('returns TRUE when the parent is pre-LEAD-pass (draft @ LEAD) — child must NOT be claimed', async () => {
+    const sb = mkSb({ data: { status: 'draft', current_phase: 'LEAD' }, error: null });
+    expect(await parentLeadPending(sb, { parent_sd_id: 'SD-PARENT-001' })).toBe(true);
+  });
+
+  it('returns TRUE for a parent at LEAD_APPROVAL (case-insensitive)', async () => {
+    const sb = mkSb({ data: { status: 'draft', current_phase: 'lead_approval' }, error: null });
+    expect(await parentLeadPending(sb, { parent_sd_id: 'SD-PARENT-001' })).toBe(true);
+  });
+
+  it('returns false once the parent has PASSED LEAD (current_phase = PLAN)', async () => {
+    const sb = mkSb({ data: { status: 'in_progress', current_phase: 'PLAN' }, error: null });
+    expect(await parentLeadPending(sb, { parent_sd_id: 'SD-PARENT-001' })).toBe(false);
+  });
+
+  it('returns false when the parent is completed (children fully workable)', async () => {
+    const sb = mkSb({ data: { status: 'completed', current_phase: 'COMPLETED' }, error: null });
+    expect(await parentLeadPending(sb, { parent_sd_id: 'SD-PARENT-001' })).toBe(false);
+  });
+
+  it('fail-open: a query error or missing parent never strands the child', async () => {
+    expect(await parentLeadPending(mkSb({ data: null, error: { message: 'boom' } }), { parent_sd_id: 'SD-X' })).toBe(false);
+    expect(await parentLeadPending(mkSb({ data: null, error: null }), { parent_sd_id: 'SD-GONE' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
Orchestrator children were dispatchable/claimable **before** their parent passed LEAD: a worker claims the child, drives PLAN (PRD created, PLAN-TO-EXEC scored), then hits the hard EXEC-transition block (a child cannot enter EXEC until the parent completes LEAD) — wasted PLAN cycles + churn. `classifyDispatchIneligibility` gated orchestrator **parents** but never a child against its parent's LEAD state.

## Fix
A shared, fail-open `parentLeadPending(sb, sd)` (lib/fleet/claim-eligibility.cjs) re-fetches the parent and returns true only when it exists, is not completed, and is still pre-LEAD-pass (`current_phase` in {LEAD, LEAD_APPROVAL}). Wired into **both** fresh-claim vectors:
- `evaluateDispatchEligibility` (baselined candidates) → reason `parent_lead_pending`
- `tryClaimDraftCandidate` (draft self-claim) → skip

Both candidate queries now select `parent_sd_id`. The orphan-adoption path is **deliberately not** gated — an `in_progress` child implies its parent already passed LEAD (resume, not premature claim). `parentLeadPending` is exported + fail-open (never strands a child on a transient error). **6 new unit tests; 36 claim-eligibility/worker-checkin tests green.**

## Deliberately deferred (flagged)
backlog-rank ranking + the sd-next **display** may still surface children pre-LEAD-pass (a consistency follow-up, like the metadata-blocker SD). The claim gate is the substantive 'workers claim them' fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)