### PR TITLE
feat(SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001): fleet-critical dispatch band

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -54,6 +54,10 @@ export function blockerKeysFor(d) {
   if (blockerSdKey) keys.push(blockerSdKey);
   return keys;
 }
+// SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-1): the narrow, explicit fleet-critical predicate.
+// metadata.fleet_critical===true marks work whose ABSENCE blocks ALL fleet progress. Exported pure so
+// the band ordering is unit-testable. STRICT === true so a stray truthy value can't silently enrol.
+export function isFleetCritical(d) { return (d && d.metadata || {}).fleet_critical === true; }
 // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-2): needle-movement prioritization.
 // Reuse FR-1's rollup (active rung + per-rung progress) and the pure needle scorer to order remaining
 // work active-rung-first among same-unlock candidates. Loaded fail-soft — any read error leaves the
@@ -168,6 +172,17 @@ async function main() {
     const m = d.metadata || {};
     return m.source === 'proposal' && !!m.roadmap_phase;
   };
+  // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-1/FR-2): the fleet-critical operational band.
+  // metadata.fleet_critical===true is a NARROW, EXPLICIT signal — set ONLY for work whose ABSENCE
+  // blocks ALL fleet progress (the worker-engagement cluster, the comms-guard, the env-fix class).
+  // A fleet-health SD is correctly needle-0 (it is NOT a gauge cap — wave-stuffing it would POLLUTE
+  // the VDR gauge), so under the gauge-needle sort it sinks below every MED wave-promoted REFILL and
+  // gets buried, forcing manual coordinator hand-dispatch. This band is OPERATIONAL urgency —
+  // ORTHOGONAL to gauge-needle (a separate axis, not a needle hack / fake rung) — and is applied
+  // ABOVE unlock+needle so a fleet_critical SD reaches a worker WITHOUT polluting the gauge or
+  // requiring a WORK_ASSIGNMENT. It stays BELOW the bare-shell/quarantine quality gates (a
+  // fleet_critical stub still cannot pass LEAD). FR-3 anti-gaming: rationed + audited below.
+  const fleetCritical = isFleetCritical;   // module-level exported predicate (unit-tested)
 
   // ── needle-movement context (FR-2) ── REUSE the FR-1 rollup for the active rung + per-rung progress,
   // and roadmap_wave_items→waves for each SD's rung. Best-effort: any failure leaves needle scores at 0
@@ -205,6 +220,11 @@ async function main() {
     if (bs !== 0) return bs;                                // authored (non-bare-shell) first
     const qa = quarantined(a) ? 1 : 0, qb = quarantined(b) ? 1 : 0;
     if (qa !== qb) return qa - qb;                          // human-authored first
+    // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-2): the fleet-critical operational band —
+    // ABOVE unlock+needle (so a needle-0 fleet-health SD outranks MED wave backlog without a fake
+    // rung or manual dispatch), BELOW the bare-shell/quarantine quality gates.
+    const fa = fleetCritical(a) ? 1 : 0, fb = fleetCritical(b) ? 1 : 0;
+    if (fa !== fb) return fb - fa;                          // fleet-critical first
     const ua = unlockScore(a.sd_key), ub = unlockScore(b.sd_key);
     if (ub !== ua) return ub - ua;
     // FR-2 needle-movement: among same-unlock candidates, order active-rung-first, then highest-impact-
@@ -223,6 +243,21 @@ async function main() {
 
   const now = new Date().toISOString();
   console.log(`[BACKLOG-RANK] ${now}${DRY ? ' (dry-run)' : ''} — ${claimable.length} claimable leaf SD(s) ranked`);
+
+  // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-3): anti-gaming audit. The fleet-critical band
+  // is powerful (it jumps the whole gauge-needle backlog), so it MUST stay rationed or it becomes the
+  // new "everything is HIGH" cry-wolf failure. We AUDIT every claimable member of the band (who set it
+  // + why, from metadata.fleet_critical_by / _reason) and WARN past a small cap so over-stamping is
+  // visible to the coordinator. Advisory-only — never alters the ranking (the band already applied).
+  const FLEET_CRITICAL_CAP = 6;
+  const fleetCriticalMembers = claimable.filter(fleetCritical);
+  if (fleetCriticalMembers.length) {
+    console.log(`[BACKLOG-RANK] fleet_critical band (${fleetCriticalMembers.length}): ` +
+      fleetCriticalMembers.map(d => `${d.sd_key}[by=${(d.metadata||{}).fleet_critical_by || '?'}; why=${((d.metadata||{}).fleet_critical_reason || '?').slice(0, 40)}]`).join('; '));
+    if (fleetCriticalMembers.length > FLEET_CRITICAL_CAP) {
+      console.log(`[BACKLOG-RANK] ⚠️  fleet_critical OVER CAP (${fleetCriticalMembers.length} > ${FLEET_CRITICAL_CAP}) — priority-inflation / cry-wolf risk. The band is for work whose ABSENCE blocks ALL fleet progress; audit + demote over-stamped rows (clear metadata.fleet_critical).`);
+    }
+  }
 
   // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2: guard rank WRITES only
   // (the SELECT/ranking reads above are always allowed). Skip the write if this session

--- a/tests/unit/coordinator-backlog-rank-fleet-critical.test.js
+++ b/tests/unit/coordinator-backlog-rank-fleet-critical.test.js
@@ -1,0 +1,40 @@
+/**
+ * SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-1/FR-2): the fleet-critical operational band.
+ * isFleetCritical is the NARROW, EXPLICIT predicate (metadata.fleet_critical === true) used by the
+ * backlog ranker to lift a needle-0 fleet-health SD above the gauge-needle backlog WITHOUT a fake
+ * rung or manual dispatch. STRICT === true so it cannot be enrolled by a stray truthy value.
+ * The band-ordering itself (fleet-critical above unlock+needle, below the quality gates) is exercised
+ * live by the FR-4 dogfood (stamp + backlog-rank --dry-run); here we lock down the gating predicate
+ * and the band-comparator contract.
+ */
+import { describe, it, expect } from 'vitest';
+import { isFleetCritical } from '../../scripts/coordinator-backlog-rank.mjs';
+
+describe('SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001: isFleetCritical', () => {
+  it('is true ONLY for metadata.fleet_critical === true', () => {
+    expect(isFleetCritical({ metadata: { fleet_critical: true } })).toBe(true);
+  });
+
+  it('is false for false / undefined / missing metadata (default: not fleet-critical)', () => {
+    expect(isFleetCritical({ metadata: { fleet_critical: false } })).toBe(false);
+    expect(isFleetCritical({ metadata: {} })).toBe(false);
+    expect(isFleetCritical({})).toBe(false);
+    expect(isFleetCritical({ metadata: null })).toBe(false);
+  });
+
+  it('is STRICT — a truthy-but-not-true value does NOT enrol (anti-gaming: no accidental floats)', () => {
+    for (const v of [1, 'true', 'yes', {}, []]) {
+      expect(isFleetCritical({ metadata: { fleet_critical: v } })).toBe(false);
+    }
+  });
+
+  it('band-comparator contract: a fleet_critical SD sorts BEFORE a non-critical one (even higher-unlock)', () => {
+    // Mirrors the 2-line band in the ranker (applied above unlock+needle): fleet-critical first.
+    const band = (a, b) => (isFleetCritical(b) ? 1 : 0) - (isFleetCritical(a) ? 1 : 0);
+    const critical = { metadata: { fleet_critical: true } };
+    const backlog = { metadata: {} };
+    expect(band(critical, backlog)).toBeLessThan(0);   // critical ranks first
+    expect(band(backlog, critical)).toBeGreaterThan(0);
+    expect(band(critical, critical)).toBe(0);          // ties fall through to unlock/needle/priority
+  });
+});


### PR DESCRIPTION
## Root issue (chairman 'fix root not workaround')
coordinator-backlog-rank sorts unlock → needle(rung) → priority → age, so **gauge-needle dominates priority**. A HIGH-priority fleet-health SD is correctly needle-0 (it's NOT a gauge cap — wave-stuffing it would pollute the VDR gauge), so it sinks below every MED wave-promoted REFILL and gets buried, forcing manual coordinator hand-dispatch. Hit twice (the VDR gauge SDs; the worker-engagement cluster).

## Fix
- **FR-1** `isFleetCritical(d)` — a narrow, STRICT predicate (`metadata.fleet_critical===true`) for work whose **absence blocks ALL fleet progress**. Not a broad 'HIGH floats above MED' rule (that re-introduces priority inflation).
- **FR-2** a fleet-critical **band** in the comparator, applied **above unlock+needle** (a needle-0 fleet-health SD outranks MED backlog without a fake rung / gauge pollution / manual dispatch) and **below** the bare-shell/quarantine quality gates. Propagates to workers via the persisted `dispatch_rank` (single point).
- **FR-3** anti-gaming — audit every band member (by + why) and **WARN past a cap (6)** so over-stamping (the new 'everything is HIGH') is visible. Advisory-only.
- **FR-4** dogfooded — stamped `fleet_critical` on the live worker-engagement SD (+ this SD); `--dry-run` confirms the band fires on 2 members under cap, audited.

`isFleetCritical` exported + pure; **4 unit tests (+5 existing backlog-rank green, no regression).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)