### PR TITLE
chore(SD-REFILL-00LTDQZ5): wire-check-exempt the one-off backfill CLI

### DIFF
--- a/scripts/backfill-canonical-lfa-from-executions.mjs
+++ b/scripts/backfill-canonical-lfa-from-executions.mjs
@@ -1,3 +1,6 @@
+// @wire-check-exempt: one-off, gated completion-integrity backfill CLI — dry-run by default, the
+// --apply (123 corroborated ghosts) is run manually under human/coordinator review (no production
+// caller by design). The pure logic (buildCanonicalLfaRow, isBackfillable) is unit-tested.
 /**
  * SD-REFILL-00LTDQZ5 — backfill the canonical sd_phase_handoffs LEAD-FINAL-APPROVAL accept row for
  * COMPLETION GHOSTS whose approval genuinely ran.


### PR DESCRIPTION
Follow-up to #5062: the wire-check gate flagged the one-off backfill script as an unreachable new file. It is a deliberate gated, dry-run-default backfill CLI (no production caller by design); add the documented `// @wire-check-exempt` mechanism. Pure logic remains unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)