### PR TITLE
fix(SD-REFILL-00EOAPP9): identity-drift-override audit writes the real audit_log schema

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -153,8 +153,11 @@ async function applyIdentityDriftOverride(supabase, { sdKey, operation, override
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const { count, error: countErr } = await supabase
     .from('audit_log')
+    // SD-REFILL-00EOAPP9: the live audit_log has NO `action` column (only event_type + a metadata
+    // jsonb), so the prior .eq('action', ...) filter errored at runtime and the override THREW here
+    // before it could ever run. Match on the real event_type column instead (mirrors the insert below).
     .select('id', { count: 'exact', head: true })
-    .eq('action', 'identity_drift_override')
+    .eq('event_type', 'identity_drift_override')
     .gte('created_at', since);
   if (countErr) {
     // Fail-closed: cannot verify rate-limit → deny override
@@ -165,18 +168,19 @@ async function applyIdentityDriftOverride(supabase, { sdKey, operation, override
   }
 
   // Audit row insert; identity-drift conflicts captured as JSON for forensics.
-  // NOTE (SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001): schema-lint flags audit_log.action
-  // and audit_log.details below — the live audit_log table has only a `metadata` jsonb
-  // column (no action/details), so this PRE-EXISTING identity-drift-override insert
-  // (SD-LEO-INFRA-SESSION-IDENTITY-RECONCILIATION-001) silently errors at runtime. Out
-  // of scope for this authz SD; logged as a latent-bug follow-up. Pragmas unblock the
-  // whole-file lint without touching the unrelated override path.
+  // SD-REFILL-00EOAPP9 (the latent-bug follow-up flagged by SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001):
+  // the live audit_log table has only event_type + a `metadata` jsonb (NO action/details columns), so
+  // the prior insert of {action, details} errored at runtime and threw below, breaking every override.
+  // Map onto the real schema: event_type = the action, and the forensic detail goes into metadata jsonb.
   const { error: insErr } = await supabase
     .from('audit_log')
-    .insert({ // schema-lint-disable-line — pre-existing phantom columns action/details (audit_log has only metadata jsonb); see note above
-      action: 'identity_drift_override',
+    .insert({
+      event_type: 'identity_drift_override',
+      entity_type: 'strategic_directive',
+      entity_id: sdKey,
       severity: 'warning',
-      details: {
+      metadata: {
+        action: 'identity_drift_override',
         sd_key: sdKey,
         operation,
         reason: overrideReason,

--- a/tests/unit/claim-validity-gate-identity-override.test.js
+++ b/tests/unit/claim-validity-gate-identity-override.test.js
@@ -122,11 +122,17 @@ describe('FR-2: IDENTITY_DRIFT_OVERRIDE in claim-validity-gate', () => {
     const result = await assertValidClaim(supabase, 'SD-AC22-001', { operation: 'test', allowMainRepoForAcquisition: true });
     expect(result.ownership).toBe('self');
     expect(calls.audit_insert).toBe(1);
+    // SD-REFILL-00EOAPP9: the live audit_log has only event_type + a metadata jsonb (NO action/details
+    // columns), so the audit row must map onto the REAL schema or the insert errors at runtime and the
+    // whole override path throws. event_type carries the action; the forensic detail lives in metadata.
     expect(insertedRows[0]).toMatchObject({
-      action: 'identity_drift_override',
+      event_type: 'identity_drift_override',
       severity: 'warning',
-      details: expect.objectContaining({ sd_key: 'SD-AC22-001', reason: 'test-recovery' }),
+      metadata: expect.objectContaining({ sd_key: 'SD-AC22-001', reason: 'test-recovery' }),
     });
+    // regression guard: must NOT reintroduce the phantom columns
+    expect(insertedRows[0].action).toBeUndefined();
+    expect(insertedRows[0].details).toBeUndefined();
     const stderrCalls = stderrSpy.mock.calls.map(c => c[0]).join('');
     expect(stderrCalls).toContain('identity.override.applied');
     stderrSpy.mockRestore();


### PR DESCRIPTION
## Problem (latent bug, flagged by SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001)
`lib/claim-validity-gate.js` `applyIdentityDriftOverride` used `audit_log.{action, details}`, but the live `audit_log` table has only `event_type` + a `metadata` jsonb (no action/details). So **both** the rate-limit count query (`.eq('action', ...)`) **and** the audit insert errored at runtime — and each path **throws fail-closed**, so the identity-drift-override escape hatch was fully broken whenever triggered. The prior fix only added schema-lint pragmas (silencing the lint, not the runtime error); this SD is that flagged follow-up.

## Fix
Map onto the real schema: `event_type='identity_drift_override'` (+ entity_type/entity_id), forensic detail (sd_key/operation/reason/conflicts/applied_at) in the `metadata` jsonb. The count query now filters `.eq('event_type', ...)`.

## Verification
**Live-verified against the real audit_log**: the new shape inserts OK, the old shape fails with *'Could not find the action column'*, and the event_type count query works. Updated the AC-2.2 unit assertion to the real shape + a regression guard against the phantom columns. **18 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)