### PR TITLE
feat(SD-REFILL-00YJS6VB): silence Adam inbox-monitor no-op ticks (--quiet)

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -305,7 +305,7 @@ function isOrphanedAdamRow(r) {
  * DELIVERED-but-unacked directive stays recoverable via scripts/read-adam-directives.cjs (the
  * acknowledged_at IS NULL tier) until Adam genuinely acts.
  */
-async function drainInbox(supabase, sessionId) {
+async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
   const { data: allRows, error } = await supabase
     .from('session_coordination')
     .select('id, sender_session, sender_type, message_type, subject, body, payload, created_at')
@@ -336,7 +336,12 @@ async function drainInbox(supabase, sessionId) {
     console.warn('  → these target the Adam session but match no drain lane; fix the producer to use a typed ADAM_INBOX_KINDS kind, or read via the durable reader.');
   }
 
-  if (rows.length === 0) { console.log('(no unread directed inbox rows — replies or directed classes)'); return; }
+  // SD-REFILL-00YJS6VB: the recurring inbox-monitor tick fires every few minutes and was a
+  // no-op narration line ("(no unread...)") when the lane is empty — churn during quiescent /
+  // chairman-attached work. With --quiet (the recurring tick), stay SILENT on a fully-empty lane
+  // (mirrors the belt-countdown/offer-help silence-by-default). Manual `inbox` keeps the
+  // confirmation line. Orphaned-row WARNINGs above are NEVER suppressed (real unread deliveries).
+  if (rows.length === 0) { if (!quiet) console.log('(no unread directed inbox rows — replies or directed classes)'); return; }
 
   console.log(`${rows.length} inbox row${rows.length === 1 ? '' : 's'} (full lane — replies + all directed classes):`);
   const ids = [];
@@ -385,7 +390,7 @@ async function main() {
   // if the env var didn't propagate; falls back to the env sessionId.
   if (mode === 'inbox') {
     const adamId = (await resolveAdamSessionId(supabase)) || sessionId;
-    await drainInbox(supabase, adamId);
+    await drainInbox(supabase, adamId, { quiet: argv.includes('--quiet') });
     return;
   }
 

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -58,7 +58,10 @@ export const ADAM_LOOPS = [
     label: 'Adam inbox — drain ALL coordinator-directed kinds (full-lane reader)',
     script: 'adam-advisory.cjs',
     cron: '*/15 * * * *',
-    prompt: 'node scripts/adam-advisory.cjs inbox',
+    // SD-REFILL-00YJS6VB: --quiet suppresses the no-op "(no unread...)" line on a fully-empty
+    // lane so the recurring tick is SILENT when there's nothing to drain (real rows + orphaned
+    // WARNINGs still surface). Reduces narration churn during quiescent/chairman-attached work.
+    prompt: 'node scripts/adam-advisory.cjs inbox --quiet',
   },
   {
     key: 'offer-help',

--- a/tests/unit/adam-inbox-quiet-suppression.test.js
+++ b/tests/unit/adam-inbox-quiet-suppression.test.js
@@ -1,0 +1,49 @@
+/**
+ * SD-REFILL-00YJS6VB — Adam inbox-monitor no-op tick suppression.
+ *
+ * The recurring inbox-monitor tick (every 15 min) ran `adam-advisory.cjs inbox` and printed a
+ * "(no unread...)" line every fire even when the lane was empty — narration churn during
+ * quiescent / chairman-attached work. The --quiet flag (used only by the recurring tick)
+ * makes drainInbox SILENT on a fully-empty lane while preserving the confirmation line for
+ * manual use; orphaned-row WARNINGs (real unread deliveries) are never suppressed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { drainInbox } = require('../../scripts/adam-advisory.cjs');
+
+// Minimal chainable supabase mock: from().select().eq().is().order().limit() -> {data, error}
+function makeSupabase(rows) {
+  const q = {
+    select: () => q, eq: () => q, is: () => q, order: () => q,
+    limit: () => Promise.resolve({ data: rows, error: null }),
+  };
+  return { from: () => q };
+}
+
+describe('Adam inbox --quiet no-op suppression (SD-REFILL-00YJS6VB)', () => {
+  let logSpy, warnSpy;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => { logSpy.mockRestore(); warnSpy.mockRestore(); });
+
+  it('quiet: empty lane prints NOTHING (silent no-op tick)', async () => {
+    await drainInbox(makeSupabase([]), 'adam-sid', { quiet: true });
+    const noUnread = logSpy.mock.calls.flat().some((a) => String(a).includes('no unread'));
+    expect(noUnread).toBe(false);
+  });
+
+  it('non-quiet (manual): empty lane prints the confirmation line', async () => {
+    await drainInbox(makeSupabase([]), 'adam-sid', { quiet: false });
+    const noUnread = logSpy.mock.calls.flat().some((a) => String(a).includes('no unread'));
+    expect(noUnread).toBe(true);
+  });
+
+  it('default (no opts) behaves like non-quiet — backward compatible', async () => {
+    await drainInbox(makeSupabase([]), 'adam-sid');
+    const noUnread = logSpy.mock.calls.flat().some((a) => String(a).includes('no unread'));
+    expect(noUnread).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adam's recurring **inbox-monitor** tick (every 15 min) printed a `(no unread...)` line on every fire even when the lane was empty — narration churn during quiescent / chairman-attached work (dozens of silent no-op ticks/session). The other two Adam ticks (belt-countdown, offer-help) already self-suppress; inbox-monitor was the lone no-op narrator.

## Fix (the SD's "OR auto-suppress no-op ticks" arm)

`drainInbox({quiet})` stays **silent on a fully-empty lane** when `--quiet`, wired into the `ADAM_LOOPS` inbox-monitor prompt. Manual `adam-advisory.cjs inbox` keeps the confirmation line (default = non-quiet, backward compatible). **Orphaned-row WARNINGs and real rows are never suppressed.** 3 unit tests.

The harder **quiescent-mode tick-frequency reduction** arm (conditional cron throttling) is deferred as a follow-up (needs a chairman/Adam policy decision; cron is static).

LEO chain: LEAD-TO-PLAN 96 / PLAN-TO-EXEC (pass). TESTING PASS 98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)