### PR TITLE
feat(SD-REFILL-00BEALYD): SessionStart hook node_modules-wipe regression guard (store-wipe #3 audit)

### DIFF
--- a/lib/audit/session-hook-nodemodules-guard.mjs
+++ b/lib/audit/session-hook-nodemodules-guard.mjs
@@ -1,0 +1,78 @@
+/**
+ * SD-REFILL-00BEALYD — SessionStart hook node_modules-wipe regression guard.
+ *
+ * Store-wipe #3 diagnostic: node_modules was wiped during a fleet-DORMANT window. The worktree-reaper,
+ * scratch-sweep, and SD-completion teardown were exonerated by logs/timestamps. The 3 unaudited
+ * SessionStart hooks (session-start-loader.ps1, telemetry-auto-trigger.cjs, agent-compiler-hook.cjs)
+ * AND their spawned scripts were then audited and found to contain ZERO destructive node_modules
+ * operations — exonerating them too (narrowing the remaining suspect to an external OS agent /
+ * dormant-CC-crash, which the coordinator canary covers). This module makes that exoneration DURABLE:
+ * a pure scanner + a settings.json resolver so a guard test fails if any SessionStart hook script
+ * ever introduces a node_modules-wipe path. Recovery-side complement: the auto-heal SD-REFILL-00RXDLKM.
+ */
+
+// Strip comments so the guard flags EXECUTABLE destructive ops, not documentation. Without this, the
+// recovery auto-heal hook (node-modules-autoheal.cjs) false-positives on its own defensive comments
+// ("NEVER `npm ci` / `rm -rf node_modules`") while its actual code is additive (`npm install`).
+// Removes JS block (/* */) and line (//) comments and shell/PowerShell line (#) comments.
+export function stripComments(text) {
+  if (typeof text !== 'string') return '';
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')   // JS block comments
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1') // JS line comments (avoid http:// via the preceding-char guard)
+    .replace(/(^|\s)#[^\n]*/g, '$1');     // shell / PowerShell line comments
+}
+
+// Destructive node_modules operations a SessionStart hook must never contain (in executable code).
+// `npm ci` / `npm prune` are included because they `rm -rf node_modules` first.
+export const DESTRUCTIVE_PATTERNS = [
+  { label: 'rm-rf-node_modules', re: /\brm\s+-[a-zA-Z]*r[a-zA-Z]*\s+[^\n]*node_modules/ },
+  { label: 'powershell-remove-item-node_modules', re: /Remove-Item\b[^\n]*node_modules/i },
+  { label: 'rimraf-node_modules', re: /\brimraf\b[^\n]*node_modules/i },
+  { label: 'rmdir-node_modules', re: /\brmdir\b[^\n]*node_modules|\bdel\b[^\n]*node_modules/i },
+  { label: 'fs-rm-node_modules', re: /\bfs\.(rmSync|rmdirSync|rm|rmdir|unlinkSync)\s*\([^)]*node_modules/i },
+  { label: 'npm-ci-or-prune', re: /\bnpm\s+(ci|prune|clean)\b/i },
+];
+
+/**
+ * Pure: return the labels of any destructive node_modules operation found in a hook script's text.
+ * @param {string} text
+ * @returns {string[]} matched pattern labels (empty = clean)
+ */
+export function scanForDestructiveNodeModules(text) {
+  if (typeof text !== 'string' || !text) return [];
+  const code = stripComments(text); // guard executable code, not comments/docs
+  const hits = [];
+  for (const { label, re } of DESTRUCTIVE_PATTERNS) {
+    try { if (re.test(code)) hits.push(label); } catch { /* never throw */ }
+  }
+  return hits;
+}
+
+/**
+ * Pure: resolve the local script paths referenced by SessionStart hook commands in a settings object.
+ * Handles `node <path> [args]` and `powershell ... -File <path>` forms; expands ${CLAUDE_PROJECT_DIR}
+ * (and a leading ${VAR}) against `root`. Commands with no resolvable local .cjs/.js/.mjs/.ps1 script
+ * are skipped.
+ * @param {object} settings - parsed .claude/settings.json
+ * @param {string} root - project root for relative resolution
+ * @returns {string[]} resolved (or root-relative) script paths
+ */
+export function sessionStartHookScripts(settings, root = '.') {
+  const out = [];
+  const groups = settings?.hooks?.SessionStart;
+  if (!Array.isArray(groups)) return out;
+  const SCRIPT_RE = /([^\s"']+\.(?:cjs|mjs|js|ps1))/i;
+  for (const g of groups) {
+    for (const h of (g?.hooks || [])) {
+      const cmd = typeof h?.command === 'string' ? h.command : '';
+      if (!cmd) continue;
+      const m = cmd.match(SCRIPT_RE);
+      if (!m) continue;
+      let p = m[1].replace(/\$\{CLAUDE_PROJECT_DIR\}|\$\{[A-Z_]+\}/g, root).replace(/^["']|["']$/g, '');
+      // collapse a doubled root if the var already expanded to root
+      out.push(p);
+    }
+  }
+  return out;
+}

--- a/tests/unit/session-hook-nodemodules-guard.test.js
+++ b/tests/unit/session-hook-nodemodules-guard.test.js
@@ -1,0 +1,93 @@
+// SD-REFILL-00BEALYD — store-wipe #3 audit + regression guard. The 3 unaudited SessionStart hooks
+// (+ their spawns) contain ZERO destructive node_modules ops; this guard encodes that and fails if a
+// future SessionStart hook ever introduces a node_modules-wipe path. Recovery-side complement:
+// the auto-heal SD-REFILL-00RXDLKM.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  scanForDestructiveNodeModules,
+  sessionStartHookScripts,
+  DESTRUCTIVE_PATTERNS,
+} from '../../lib/audit/session-hook-nodemodules-guard.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('scanForDestructiveNodeModules (SD-REFILL-00BEALYD)', () => {
+  it('TS-1: detects rm -rf node_modules', () => {
+    expect(scanForDestructiveNodeModules('rm -rf node_modules/').length).toBeGreaterThan(0);
+    expect(scanForDestructiveNodeModules('rm -r ./node_modules').length).toBeGreaterThan(0);
+  });
+
+  it('TS-2: detects PowerShell Remove-Item node_modules', () => {
+    expect(scanForDestructiveNodeModules('Remove-Item -Recurse -Force node_modules').length).toBeGreaterThan(0);
+  });
+
+  it('TS-3: detects npm ci / prune (which wipe node_modules) + rimraf + fs.rmSync', () => {
+    expect(scanForDestructiveNodeModules('npm ci')).toContain('npm-ci-or-prune');
+    expect(scanForDestructiveNodeModules('rimraf node_modules')).toContain('rimraf-node_modules');
+    expect(scanForDestructiveNodeModules("fs.rmSync(path.join(root,'node_modules'),{recursive:true})")).toContain('fs-rm-node_modules');
+  });
+
+  it('TS-4: a clean hook body returns [] and never throws', () => {
+    expect(scanForDestructiveNodeModules('const x = require("path"); console.log("ok");')).toEqual([]);
+    expect(scanForDestructiveNodeModules('')).toEqual([]);
+    expect(scanForDestructiveNodeModules(null)).toEqual([]);
+  });
+
+  it('does NOT flag a benign node_modules mention (e.g. a resolve path)', () => {
+    expect(scanForDestructiveNodeModules("require.resolve('x',{paths:[join(root,'node_modules')]})")).toEqual([]);
+  });
+
+  it('guards CODE, not COMMENTS: a defensive comment is clean but the executable op flags', () => {
+    // The recovery auto-heal hook documents "NEVER npm ci / rm -rf node_modules" — comments must not flag.
+    expect(scanForDestructiveNodeModules('// additive only: NEVER `npm ci` or `rm -rf node_modules`')).toEqual([]);
+    expect(scanForDestructiveNodeModules('# PowerShell: do not Remove-Item node_modules here')).toEqual([]);
+    expect(scanForDestructiveNodeModules('/* never rm -rf node_modules */')).toEqual([]);
+    // but the real executable op still flags
+    expect(scanForDestructiveNodeModules('spawnSync("rm", ["-rf", "node_modules"]); rm -rf node_modules').length).toBeGreaterThan(0);
+  });
+});
+
+describe('sessionStartHookScripts (TS-5)', () => {
+  it('extracts node + powershell script paths and expands ${CLAUDE_PROJECT_DIR}', () => {
+    const settings = { hooks: { SessionStart: [
+      { hooks: [
+        { type: 'command', command: 'node ${CLAUDE_PROJECT_DIR}/scripts/hooks/foo.cjs' },
+        { type: 'command', command: 'powershell.exe -NoProfile -File ${CLAUDE_PROJECT_DIR}/scripts/hooks/bar.ps1' },
+        { type: 'command', command: 'echo no-script-here' },
+      ] },
+    ] } };
+    const scripts = sessionStartHookScripts(settings, '/root');
+    expect(scripts.some(p => p.endsWith('scripts/hooks/foo.cjs'))).toBe(true);
+    expect(scripts.some(p => p.endsWith('scripts/hooks/bar.ps1'))).toBe(true);
+    expect(scripts.length).toBe(2); // the echo command resolves no script
+  });
+
+  it('returns [] for malformed settings', () => {
+    expect(sessionStartHookScripts({}, '/root')).toEqual([]);
+    expect(sessionStartHookScripts(null, '/root')).toEqual([]);
+  });
+});
+
+describe('TS-6: live SessionStart hook scripts are all clean (audit encoded + regression guard)', () => {
+  it('no SessionStart-registered hook script contains a destructive node_modules op', () => {
+    const settingsPath = path.join(ROOT, '.claude', 'settings.json');
+    if (!fs.existsSync(settingsPath)) return; // no settings -> nothing to guard
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const scripts = sessionStartHookScripts(settings, ROOT);
+    const offenders = [];
+    for (const rel of scripts) {
+      const abs = path.isAbsolute(rel) ? rel : path.join(ROOT, rel);
+      if (!fs.existsSync(abs)) continue; // missing/unresolvable -> skip, not a failure
+      const hits = scanForDestructiveNodeModules(fs.readFileSync(abs, 'utf8'));
+      if (hits.length) offenders.push(`${rel}: ${hits.join(',')}`);
+    }
+    expect(offenders, `SessionStart hook(s) with a node_modules-wipe path: ${offenders.join(' | ')}`).toEqual([]);
+  });
+
+  it('DESTRUCTIVE_PATTERNS is non-empty (guard is armed)', () => {
+    expect(DESTRUCTIVE_PATTERNS.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
**Store-wipe #3 diagnostic.** node_modules was wiped during a fleet-**dormant** window (no builds/teardowns; `.worktrees` untouched), exonerating the worktree-reaper / scratch-sweep / SD-completion-teardown. This audits the **3 remaining unaudited SessionStart hooks** (`session-start-loader.ps1`, `telemetry-auto-trigger.cjs`, `agent-compiler-hook.cjs`) **and their spawned scripts** — **zero destructive node_modules ops → EXONERATED**. The remaining suspect is narrowed to an external OS agent (Storage Sense / AV) / a dormant-CC crash window (the coordinator's canary covers live catching).

## What it ships (makes the exoneration durable)
`lib/audit/session-hook-nodemodules-guard.mjs`:
- **`scanForDestructiveNodeModules(text)`** — flags `rm -rf node_modules` / `Remove-Item node_modules` / `rimraf` / `npm ci|prune` / `fs.rmSync(...node_modules)` in **executable code** (strips comments first, so the recovery auto-heal hook's defensive *"NEVER rm -rf"* comments don't false-positive).
- **`sessionStartHookScripts(settings, root)`** — resolves the live SessionStart hook scripts from `.claude/settings.json`.
- **Guard test** — every live SessionStart hook script is clean today; **fails if a future hook introduces a wipe path**.

Recovery-side complement: the auto-heal **SD-REFILL-00RXDLKM** (#5039).

## Testing
- 10 tests. The live-hooks scan **caught the auto-heal hook** on its defensive comments — exactly the false positive that drove the comment-strip design (now pinned by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)