### PR TITLE
feat(SD-REFILL-00XK256L): 2-hypothesis-bar gate on Adam urgent model-availability broadcasts

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -58,6 +58,25 @@ function advisoryExpiresAt(nowMs) {
   return new Date(base + ADVISORY_TTL_MS).toISOString();
 }
 
+// SD-REFILL-00XK256L: the 2-hypothesis-bar guard for Adam urgent operational broadcasts. Adam's web-
+// research sweep has TWICE (2026-06-11 stall misdiagnosis; 2026-06-13 advisory 4f6082eb) produced a
+// HALLUCINATED fleet-wide operational alarm — a fabricated "model cutoff" naming a NON-EXISTENT model
+// ("Mythos 5") with invented anthropic.com/CNBC citations — broadcast BEFORE running the cheap
+// discriminating observable (is the fleet completing work right now?). This PURE detector trips on the
+// ALARM SHAPE only — an urgent MODEL-AVAILABILITY claim — the class that MUST clear the bar (a
+// discriminator run + a real-model-name/citation sanity check) before broadcast. It flags the shape,
+// not every advisory that merely mentions a model. Exported for tests.
+const MODEL_AVAILABILITY_ALARM_RE = /\b(cut[-\s]?off|disabled|deprecat\w*|unavailable|shut[-\s]?down|revoked|killed|export[-\s]?control\w*|sunset\w*|discontinu\w*)\b/i;
+const MODEL_TOKEN_RE = /\b(models?|fable|opus|sonnet|haiku|claude|gpt|llm|mythos)\b/i;
+function sanityCheckUrgentAdvisory(body) {
+  const text = String(body || '');
+  const reasons = [];
+  const modelRef = MODEL_TOKEN_RE.test(text);
+  if (MODEL_AVAILABILITY_ALARM_RE.test(text) && modelRef) reasons.push('urgent model-availability / cutoff claim');
+  if (/\bfleet[-\s]?wide\b/i.test(text) && modelRef) reasons.push('fleet-wide model-impact claim');
+  return { tripped: reasons.length > 0, reasons };
+}
+
 function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo }) {
   const payload = {
     kind: PAYLOAD_KINDS.ADAM_ADVISORY,
@@ -427,6 +446,25 @@ async function main() {
   // FR-1: scope-tag the advisory from the sending repo (reuse-first, fail-soft).
   const { scopeKey, reuseClass, appliesToScopes } = await resolveScopeForSend(supabase, process.cwd());
   const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo });
+  // SD-REFILL-00XK256L: the 2-hypothesis-bar GATE. Block an UNATTESTED urgent model-availability
+  // broadcast — Adam's research sweep has twice fabricated a fleet-wide "model cutoff" and broadcast it
+  // before running the cheap discriminator. The sender attests the bar was cleared with --alarm-verified.
+  const alarmCheck = sanityCheckUrgentAdvisory(payload.body);
+  const alarmAttested = argv.includes('--alarm-verified') || process.env.ADAM_ALARM_VERIFIED === '1';
+  if (alarmCheck.tripped && !alarmAttested) {
+    console.error(
+      `\n[adam-advisory] ⛔ 2-HYPOTHESIS BAR (SD-REFILL-00XK256L): this advisory makes an urgent ` +
+      `${alarmCheck.reasons.join(' + ')}. Adam's research sweep has TWICE broadcast a HALLUCINATED fleet-wide ` +
+      `"model cutoff" (a non-existent model + fabricated citations) BEFORE checking the cheap discriminator.\n` +
+      `Before broadcasting, CLEAR THE BAR:\n` +
+      `  (a) DISCRIMINATING OBSERVABLE — is the fleet COMPLETING work right now? A fresh sd_phase_handoffs / LFA in the\n` +
+      `      last ~90min FALSIFIES a "fleet-wide model cutoff".\n` +
+      `  (b) CITATION/MODEL SANITY — every model name must be REAL (Fable 5 / Opus 4.x / Sonnet 4.x / Haiku 4.x — NOT a\n` +
+      `      hallucinated name like "Mythos 5") and every citation must resolve to a real source.\n` +
+      `Then re-send with --alarm-verified (or ADAM_ALARM_VERIFIED=1) to attest the bar was cleared.\n`
+    );
+    process.exit(3);
+  }
   const subject = `[ADAM_ADVISORY] ${payload.body.slice(0, 80)}`;
   // SD-LEO-INFRA-ADAM-ADVISORY-COMMS-001 (RCA 076cf785): expires_at is the DURABLE delivery TTL
   // (how long the row stays discoverable / survives the expired-row sweep) and is decoupled from
@@ -504,7 +542,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/tests/unit/adam-advisory-two-hypothesis-bar.test.js
+++ b/tests/unit/adam-advisory-two-hypothesis-bar.test.js
@@ -1,0 +1,56 @@
+/**
+ * SD-REFILL-00XK256L: the 2-hypothesis-bar guard for Adam urgent operational broadcasts.
+ * Adam's research sweep twice fabricated a fleet-wide "model cutoff" alarm (a non-existent model +
+ * invented citations) and broadcast it BEFORE running the cheap discriminating observable.
+ * sanityCheckUrgentAdvisory(body) trips on the ALARM SHAPE — an urgent model-availability claim —
+ * so the send path can block it unless the sender attests the bar was cleared (--alarm-verified).
+ * It must trip on the fabrication class WITHOUT flagging ordinary advisories that mention a model.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { sanityCheckUrgentAdvisory } = require('../../scripts/adam-advisory.cjs');
+
+describe('SD-REFILL-00XK256L: sanityCheckUrgentAdvisory', () => {
+  it('TRIPS on the witnessed fabrication (fleet-wide model cutoff naming a non-existent model)', () => {
+    const r = sanityCheckUrgentAdvisory('LIKELY FLEET-WIDE MODEL CUTOFF: US export-control disabled Fable 5 and Mythos 5 for all customers at 5:21 PM ET');
+    expect(r.tripped).toBe(true);
+    expect(r.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('TRIPS on cutoff/disabled/deprecated/revoked/sunset language paired with a model token', () => {
+    for (const body of [
+      'the opus model was disabled',
+      'claude is unavailable fleet-wide',
+      'sonnet 4.6 deprecated effective immediately',
+      'all LLM access revoked',
+      'haiku model sunset announced',
+      'export-controlled: claude shut down',
+    ]) {
+      expect(sanityCheckUrgentAdvisory(body).tripped, body).toBe(true);
+    }
+  });
+
+  it('does NOT trip on ordinary advisories that merely mention a model (no alarm shape)', () => {
+    for (const body of [
+      'switched the sub-agent to Opus 4.8 for the review',
+      'the gauge SD needs a Sonnet pass for the design doc',
+      'fleet completed 21 SDs tonight',
+      'claude code session arming a wakeup',
+      'recommend using Haiku for the cheap classification step',
+    ]) {
+      expect(sanityCheckUrgentAdvisory(body).tripped, body).toBe(false);
+    }
+  });
+
+  it('does NOT trip on cutoff/availability language with NO model token (different domain)', () => {
+    expect(sanityCheckUrgentAdvisory('the Supabase pooler was unavailable for 5 minutes').tripped).toBe(false);
+    expect(sanityCheckUrgentAdvisory('the worktree archive prune was disabled overnight').tripped).toBe(false);
+  });
+
+  it('handles empty / non-string input safely', () => {
+    expect(sanityCheckUrgentAdvisory('').tripped).toBe(false);
+    expect(sanityCheckUrgentAdvisory(null).tripped).toBe(false);
+    expect(sanityCheckUrgentAdvisory(undefined).tripped).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem (2nd witness)
Adam's 9-agent web-research sweep has **twice** produced a HALLUCINATED fleet-wide operational alarm — a fabricated 'model cutoff' naming a **non-existent model** ('Mythos 5') with invented anthropic.com/CNBC citations — and broadcast it **before** running the cheap discriminating observable. The 2026-06-13 alarm (4f6082eb) was falsified by a trivial check: the fleet completed 21 SDs that evening, all after the claimed cutoff.

## Fix (the enforceable half, at the broadcast choke point)
- pure `sanityCheckUrgentAdvisory(body)` trips on the **alarm shape only** — an urgent model-availability/cutoff claim (cutoff/disabled/deprecated/revoked/sunset/export-control + a model token, or fleet-wide + a model token) — not every advisory that mentions a model.
- the send path **blocks** an unattested tripped advisory (exit 3) with the 2-hypothesis-bar guidance: (a) run the discriminating observable, (b) verify every model name is real and every citation resolves. The sender attests with `--alarm-verified` (or `ADAM_ALARM_VERIFIED=1`) — enforcing the bar without brittly false-blocking normal sends.

`sanityCheckUrgentAdvisory` exported + pure; **5 unit tests** (trips on the witnessed fabrication + variants; no false-positive on ordinary model mentions / non-model availability). **22 adam-advisory tests green.**

## Deferred (flagged)
The **behavioral half** — Adam's research skill should *run* the discriminator + citation check proactively, not just be gated at send — belongs in the Adam skill prompt. This SD ships the code-side gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)