### PR TITLE
chore(SD-REFILL-00BEALYD): wire-check-exempt the audit-guard library

### DIFF
--- a/lib/audit/session-hook-nodemodules-guard.mjs
+++ b/lib/audit/session-hook-nodemodules-guard.mjs
@@ -1,3 +1,5 @@
+// @wire-check-exempt: audit-guard library — its consumer is the regression test
+// (tests/unit/session-hook-nodemodules-guard.test.js), not production runtime, by design.
 /**
  * SD-REFILL-00BEALYD — SessionStart hook node_modules-wipe regression guard.
  *


### PR DESCRIPTION
Follow-up to #5070: the wire-check gate flagged the audit-guard module as unreachable (imported only by its regression test, not production runtime — by design). Add the documented `// @wire-check-exempt` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)