### PR TITLE
fix(SD-REFILL-00NFWJ6M): sweep hard-cap pid-alive OS-truth fallback

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -320,6 +320,18 @@ function isProcessRunning(pid) {
   }
 }
 
+// SD-REFILL-00NFWJ6M: is ANY Claude Code process alive on this host? Used to gate the
+// hard-cap pid-alive OS-truth fallback against PID-recycling false-holds — if no claude.exe
+// exists at all, a "live" recycled PID is definitely NOT a worker. Cheap (single tasklist),
+// computed ONCE per sweep. Never throws (tasklist unavailable → false → no fallback, safe).
+function anyClaudeProcessRunning() {
+  try {
+    const { execSync } = require('child_process');
+    const out = execSync('tasklist /FI "IMAGENAME eq claude.exe" /NH 2>nul', { encoding: 'utf8', timeout: 5000 });
+    return out.includes('claude.exe');
+  } catch { return false; }
+}
+
 function bar(pct, width = 20) {
   const filled = Math.round((pct / 100) * width);
   return '\u2588'.repeat(filled) + '\u2591'.repeat(width - filled);
@@ -742,6 +754,8 @@ async function main() {
   // SD-LEO-INFRA-PARALLEL-AGENT-QUEUE-001: Virtual drain sessions use shorter thresholds
   const VIRTUAL_STALE_THRESHOLD = 180; // 3 minutes for virtual drain agents
   const VIRTUAL_VERY_STALE = VIRTUAL_STALE_THRESHOLD * 2; // 6 minutes = definitely dead
+  // SD-REFILL-00NFWJ6M: computed ONCE — gates the hard-cap pid-alive OS-truth fallback below.
+  const claudeProcRunningHost = anyClaudeProcessRunning();
   const classified = sessions.map(s => {
     const threshold = s.is_virtual ? VIRTUAL_STALE_THRESHOLD : STALE_THRESHOLD_SECONDS;
     const veryStaleThreshold = s.is_virtual ? VIRTUAL_VERY_STALE : VERY_STALE_SECONDS;
@@ -764,6 +778,15 @@ async function main() {
       const ccPid = resolveCcPidFromTerminalId(s.terminal_id, s.session_id);
       if (ccPid != null) {
         hasPidAlive = aliveCcPids.has(String(ccPid));
+        // SD-REFILL-00NFWJ6M: marker-vs-OS divergence — FR-4 deletes a live worker's pid-*.json
+        // marker aggressively, so a MISSING marker is NOT proof of death. A live worker deep in a
+        // >20min sub-agent run (no mid-Task heartbeat) was hard-cap-released because the marker set
+        // missed its still-running PID. Fall back to OS process truth when the marker set misses,
+        // GATED on a claude.exe existing on this host (guards PID-recycling false-holds: no claude.exe
+        // → a "live" PID is a recycled non-CC process). isProcessRunning uses process.kill(pid,0).
+        if (!hasPidAlive && claudeProcRunningHost && isProcessRunning(Number(ccPid))) {
+          hasPidAlive = true;
+        }
       }
     }
 
@@ -2478,6 +2501,9 @@ module.exports.INTENT_PAYLOAD_KEYS = INTENT_PAYLOAD_KEYS;
 // FR-3 predicate (pure): the reserved SD-TEST- fixture namespace check.
 module.exports.isTestFixtureSdKey = isTestFixtureSdKey;
 module.exports.TEST_FIXTURE_SD_KEY_LIKE = TEST_FIXTURE_SD_KEY_LIKE;
+// SD-REFILL-00NFWJ6M: hard-cap pid-alive OS-truth fallback helpers (test seam).
+module.exports.isProcessRunning = isProcessRunning;
+module.exports.anyClaudeProcessRunning = anyClaudeProcessRunning;
 // FR-1/FR-2: the fail-soft reset gate + a test-only seam to seed the lazily-imported
 // exec-context-guard cache (so tests can inject a mock assertSweepHandoffGate without
 // touching the live ESM module). Seeding the cache is exactly what the first real call

--- a/tests/unit/sweep-hardcap-pid-alive-os-fallback.test.js
+++ b/tests/unit/sweep-hardcap-pid-alive-os-fallback.test.js
@@ -1,0 +1,53 @@
+/**
+ * SD-REFILL-00NFWJ6M — SWEEP_HARD_CAP_20M false-released a PID-ALIVE worker.
+ *
+ * The hard-cap hold guard (WIP_GUARD_HARDCAP_PID_ALIVE) HOLDs release when hasPidAlive=true,
+ * but hasPidAlive was computed ONLY from .claude/session-identity/pid-*.json markers
+ * (aliveCcPids). FR-4 deletes a live worker's marker aggressively, so a MISSING marker was
+ * mis-read as death → a live worker deep in a >20min sub-agent run (no mid-Task heartbeat)
+ * got hard-cap-released every tick (marker-vs-OS divergence, same family as b340c2d8).
+ *
+ * Fix: when the marker set misses, fall back to OS process truth (isProcessRunning via
+ * process.kill(pid,0)), GATED on a claude.exe existing on this host (anyClaudeProcessRunning)
+ * to guard against PID-recycling false-holds.
+ *
+ * Static source assertions match this monolithic script's test convention
+ * (stale-sweep-qf211-claim-guards.test.js) + a behavioral check of the exported helpers.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/stale-session-sweep.cjs');
+const src = readFileSync(SCRIPT, 'utf8');
+const { isProcessRunning, anyClaudeProcessRunning } = require('../../scripts/stale-session-sweep.cjs');
+
+describe('SD-REFILL-00NFWJ6M: hard-cap pid-alive OS-truth fallback', () => {
+  it('falls back to OS process truth when the marker set misses (gated on claude.exe)', () => {
+    // the hasPidAlive computation must OR in the OS check, gated by the host-claude flag
+    expect(src).toMatch(/hasPidAlive\s*=\s*aliveCcPids\.has\(String\(ccPid\)\)/);
+    expect(src).toMatch(/!hasPidAlive\s*&&\s*claudeProcRunningHost\s*&&\s*isProcessRunning\(Number\(ccPid\)\)/);
+  });
+
+  it('computes the host-claude gate ONCE before the classification map', () => {
+    const gateIdx = src.indexOf('const claudeProcRunningHost = anyClaudeProcessRunning()');
+    const mapIdx = src.indexOf('const classified = sessions.map(');
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(mapIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(mapIdx); // computed once, before the per-session loop
+  });
+
+  it('isProcessRunning: current process is alive, an unused high PID is not', () => {
+    expect(isProcessRunning(process.pid)).toBe(true);
+    expect(isProcessRunning(2_000_000_000)).toBe(false); // implausible PID → ESRCH
+    expect(isProcessRunning(0)).toBe(false);
+    expect(isProcessRunning(null)).toBe(false);
+  });
+
+  it('anyClaudeProcessRunning returns a boolean and never throws', () => {
+    const r = anyClaudeProcessRunning();
+    expect(typeof r).toBe('boolean');
+  });
+});


### PR DESCRIPTION
## What

`SWEEP_HARD_CAP_20M` force-released claims held by **live** workers. The hold guard `WIP_GUARD_HARDCAP_PID_ALIVE` HOLDs release when `hasPidAlive=true`, but `hasPidAlive` came **only** from `.claude/session-identity/pid-*.json` markers. FR-4 deletes a live worker's marker aggressively, so a **missing marker was mis-read as death** — a worker deep in a >20min sub-agent run (no mid-Task heartbeat) got hard-cap-released every tick (witnessed: claim `53ddb29a` on `SD-LEO-INFRA-UNIFY-INTAKE-POOLS-001`, PID 39632 confirmed live). Same marker-vs-OS divergence family as `b340c2d8`.

## Fix

When the marker set misses, fall back to **OS process truth** (`isProcessRunning` → `process.kill(pid,0)`), **gated** on a `claude.exe` existing on the host (`anyClaudeProcessRunning`, computed once/sweep) to prevent **PID-recycling false-holds**. Additive — the marker path is unchanged and the fallback can only flip `false→true` (add a hold), never remove one.

**26/26 tests** (4 new + 22 existing sweep regression). Anti-recycling triple-gate verified.

LEO chain: LEAD-TO-PLAN (pass) / PLAN-TO-EXEC (pass). TESTING PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)