### PR TITLE
feat(SD-LEO-INFRA-FLEET-CRITICAL-CLAIM-PATH-001): propagate fleet_critical to worker self-claim

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -372,7 +372,32 @@ function orderByRankMap(items, keyOf, rankMap) {
     (rankMap.get(keyOf(a)) ?? Infinity) - (rankMap.get(keyOf(b)) ?? Infinity));
 }
 
-/** Fetch fresh dispatch_ranks for the candidate keys and order by them. Fail-open. */
+/**
+ * Pure: stable-sort so fleet_critical=true items come FIRST (STALE-PROOF — independent of the
+ * dispatch_rank TTL), then by the dispatch rank map (lower first), then input order.
+ * SD-LEO-INFRA-FLEET-CRITICAL-CLAIM-PATH-001: propagates fleet_critical to the WORKER self-claim
+ * decision. #5063 ranked fleet_critical SDs correctly coordinator-side (the WRITER), but this worker
+ * claim path only honored dispatch_rank (and only while fresh), so a fleet_critical SD whose
+ * dispatch_rank was stale/absent stayed buried under lower-ranked REFILLs across idle-worker cycles.
+ */
+function orderByFleetCriticalThenRank(items, keyOf, rankMap, fleetCriticalSet) {
+  const fc = fleetCriticalSet instanceof Set ? fleetCriticalSet : new Set();
+  const rm = rankMap instanceof Map ? rankMap : new Map();
+  if (fc.size === 0 && rm.size === 0) return items;
+  return items.slice().sort((a, b) => {
+    const af = fc.has(keyOf(a)) ? 0 : 1;
+    const bf = fc.has(keyOf(b)) ? 0 : 1;
+    if (af !== bf) return af - bf;                       // fleet_critical first (stale-proof)
+    return (rm.get(keyOf(a)) ?? Infinity) - (rm.get(keyOf(b)) ?? Infinity); // then dispatch_rank
+  });
+}
+
+/**
+ * Fetch the coordinator's dispatch signals for the candidate keys and order by them. Fail-open.
+ * Honors BOTH metadata.fleet_critical (STALE-PROOF top priority — SD-LEO-INFRA-FLEET-CRITICAL-CLAIM-
+ * PATH-001) and a fresh metadata.dispatch_rank (TTL-bounded tie-break). Both live in the SAME single
+ * metadata read, so honoring fleet_critical adds NO extra query.
+ */
 async function sortByDispatchRank(sb, items, keyOf) {
   try {
     const keys = (items || []).map(keyOf).filter(Boolean);
@@ -380,15 +405,19 @@ async function sortByDispatchRank(sb, items, keyOf) {
     const { data } = await sb.from('strategic_directives_v2')
       .select('sd_key, metadata').in('sd_key', keys);
     const rankMap = new Map();
+    const fleetCriticalSet = new Set();
     const now = Date.now();
     for (const r of (data || [])) {
       const m = r.metadata || {};
+      // fleet_critical is a STALE-PROOF claim signal: it lifts the SD to the top of the worker pool
+      // regardless of dispatch_rank freshness, so a fleet_critical SD is never buried by REFILLs.
+      if (m.fleet_critical === true) fleetCriticalSet.add(r.sd_key);
       if (m.dispatch_rank != null && m.dispatch_rank_at
           && (now - new Date(m.dispatch_rank_at).getTime()) < DISPATCH_RANK_TTL_MS) {
         rankMap.set(r.sd_key, Number(m.dispatch_rank));
       }
     }
-    return orderByRankMap(items, keyOf, rankMap);
+    return orderByFleetCriticalThenRank(items, keyOf, rankMap, fleetCriticalSet);
   } catch { return items || []; } // fail-open: ordering must never break self-claim
 }
 const PRIORITY_RANK = { critical: 0, high: 1, medium: 2, low: 3 };
@@ -1076,7 +1105,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, sortByDispatchRank, DISPATCH_RANK_TTL_MS, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-fleet-critical-claim.test.js
+++ b/tests/unit/worker-checkin-fleet-critical-claim.test.js
@@ -1,0 +1,62 @@
+// SD-LEO-INFRA-FLEET-CRITICAL-CLAIM-PATH-001 — fleet_critical must propagate to the WORKER
+// self-claim ordering. #5063 ranked fleet_critical SDs correctly coordinator-side (the WRITER), but
+// the worker merge-pool ordering (sortByDispatchRank → orderByFleetCriticalThenRank) only honored
+// metadata.dispatch_rank (and only while fresh, <1h TTL). A fleet_critical SD whose dispatch_rank was
+// stale/absent stayed buried under lower-ranked REFILLs across idle-worker cycles (witnessed:
+// EXTERNAL-REVIVAL rank-1 fleet_critical draft skipped for REFILLs by win-11808/win-13452).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { orderByFleetCriticalThenRank } = require('../../scripts/worker-checkin.cjs');
+
+const key = (x) => x.key;
+const keys = (arr) => arr.map((x) => x.key);
+const items = (...ks) => ks.map((k) => ({ key: k }));
+
+describe('orderByFleetCriticalThenRank (SD-LEO-INFRA-FLEET-CRITICAL-CLAIM-PATH-001)', () => {
+  it('lifts a fleet_critical SD to the FRONT even with NO dispatch_rank (stale-proof)', () => {
+    const pool = items('SD-REFILL-A', 'SD-REFILL-B', 'SD-FLEET-CRIT');
+    const ordered = orderByFleetCriticalThenRank(pool, key, new Map(), new Set(['SD-FLEET-CRIT']));
+    expect(keys(ordered)[0]).toBe('SD-FLEET-CRIT');
+  });
+
+  it('keeps fleet_critical first even when a REFILL has a fresher (lower) dispatch_rank', () => {
+    const pool = items('SD-REFILL-A', 'SD-FLEET-CRIT');
+    const rankMap = new Map([['SD-REFILL-A', 0], ['SD-FLEET-CRIT', 5]]); // REFILL outranks on dispatch_rank
+    const ordered = orderByFleetCriticalThenRank(pool, key, rankMap, new Set(['SD-FLEET-CRIT']));
+    expect(keys(ordered)[0]).toBe('SD-FLEET-CRIT'); // fleet_critical is stale-proof top priority
+  });
+
+  it('orders MULTIPLE fleet_critical SDs among themselves by dispatch_rank', () => {
+    const pool = items('SD-FC-HI', 'SD-REFILL', 'SD-FC-LO');
+    const rankMap = new Map([['SD-FC-HI', 9], ['SD-FC-LO', 1]]);
+    const ordered = orderByFleetCriticalThenRank(pool, key, rankMap, new Set(['SD-FC-HI', 'SD-FC-LO']));
+    expect(keys(ordered).slice(0, 2)).toEqual(['SD-FC-LO', 'SD-FC-HI']); // both first; lower rank wins
+    expect(keys(ordered)[2]).toBe('SD-REFILL');
+  });
+
+  it('falls back to pure dispatch_rank ordering when nothing is fleet_critical', () => {
+    const pool = items('SD-A', 'SD-B', 'SD-C');
+    const rankMap = new Map([['SD-C', 0], ['SD-A', 1], ['SD-B', 2]]);
+    const ordered = orderByFleetCriticalThenRank(pool, key, rankMap, new Set());
+    expect(keys(ordered)).toEqual(['SD-C', 'SD-A', 'SD-B']);
+  });
+
+  it('is a no-op (preserves input order) when there is no signal at all', () => {
+    const pool = items('SD-A', 'SD-B', 'SD-C');
+    const ordered = orderByFleetCriticalThenRank(pool, key, new Map(), new Set());
+    expect(keys(ordered)).toEqual(['SD-A', 'SD-B', 'SD-C']); // baselined-first precedence preserved
+  });
+
+  it('is stable for fleet_critical ties without a rank (input order preserved)', () => {
+    const pool = items('SD-FC-1', 'SD-REFILL', 'SD-FC-2');
+    const ordered = orderByFleetCriticalThenRank(pool, key, new Map(), new Set(['SD-FC-1', 'SD-FC-2']));
+    expect(keys(ordered)).toEqual(['SD-FC-1', 'SD-FC-2', 'SD-REFILL']); // both first, original order; REFILL last
+  });
+
+  it('is total / fail-safe on odd args (non-Map rankMap, non-Set set)', () => {
+    const pool = items('SD-A', 'SD-B');
+    expect(keys(orderByFleetCriticalThenRank(pool, key, null, null))).toEqual(['SD-A', 'SD-B']);
+    expect(keys(orderByFleetCriticalThenRank(pool, key, undefined, ['SD-B']))).toEqual(['SD-A', 'SD-B']); // array (not Set) ignored
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-FLEET-CRITICAL-CLAIM-PATH-001 (fleet-critical)

`FLEET-CRITICAL-DISPATCH-LANE` (#5063) ranked fleet_critical SDs first **coordinator-side** — but only modified the WRITER. The **worker** self-claim merge-pool ranks via `sortByDispatchRank`, which honored **only** `metadata.dispatch_rank` (and only while fresh, <1h TTL). So a fleet_critical SD with a stale/absent dispatch_rank stayed buried under lower-ranked REFILLs across idle cycles (witnessed: win-11808/win-13452 claimed REFILLs over the rank-1 fleet_critical EXTERNAL-REVIVAL draft).

### Fix
- New pure `orderByFleetCriticalThenRank()`: `metadata.fleet_critical=true` sorts **first, stale-proof** (independent of the dispatch_rank TTL), then by dispatch_rank, then input order.
- `sortByDispatchRank` builds the fleet-critical set from the **same** metadata query — no extra query. Fail-open preserved.
- **FR-0 verified live**: `v_sd_next_candidates` orders by readiness_priority/sequence_rank (no fleet_critical); the worker merges that pool with drafts and ranks via the shared function — so the fix belongs there, not the view.

### Tests
- 7 new unit tests; existing worker-checkin suite (20) green, no regression.

This unblocks fleet_critical SDs (EXTERNAL-REVIVAL, ARM-PARK) becoming self-claimable without manual coordinator dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)