### PR TITLE
fix(SD-REFILL-00KUKQVS): clear stale .git/index.lock in safe-root-resync

### DIFF
--- a/lib/git/clear-stale-index-lock.mjs
+++ b/lib/git/clear-stale-index-lock.mjs
@@ -1,0 +1,57 @@
+/**
+ * clear-stale-index-lock.mjs — SD-REFILL-00KUKQVS
+ *
+ * A RECURRING stale `.git/index.lock` in the SHARED main checkout (coordinator + Adam both
+ * run there, unlike workers which have isolated worktrees) silently froze the checkout behind
+ * origin/main: a crashed/concurrent git index op left a `.git/index.lock` that then blocked
+ * fetch/merge/commit, so the checkout drifted (the Adam-not-in-sync incident — 125 commits
+ * behind from a 25h-stale lock; a NEW 0-byte lock re-appeared within ~5min).
+ *
+ * This pure helper removes the lock ONLY when it is STALE:
+ *   - 0-byte  → a real in-progress git op writes content into index.lock; a 0-byte lock is a
+ *               crash-orphaned remnant.
+ *   - OR mtime older than maxAgeMs → git index ops complete in milliseconds; a lock older than
+ *               the (generous) threshold is orphaned.
+ * A FRESH, non-empty lock (age < maxAgeMs) is an ACTIVE op and is NEVER removed (removing a
+ * live lock would corrupt the concurrent op). Pure + injectable (fs, now) for tests; never throws.
+ */
+import path from 'node:path';
+import realFs from 'node:fs';
+
+export const DEFAULT_STALE_LOCK_MAX_AGE_MS = 120_000; // 2 min — git index ops are sub-second; this is generous
+
+/**
+ * @param {object} opts
+ * @param {string} opts.repoRoot - the SHARED checkout root (where `.git` is a DIRECTORY)
+ * @param {number} [opts.maxAgeMs=DEFAULT_STALE_LOCK_MAX_AGE_MS]
+ * @param {object} [opts.fs] - injectable fs (statSync/unlinkSync)
+ * @param {number} [opts.now] - injectable clock (ms)
+ * @returns {{cleared:boolean, reason:string, ageMs?:number, size?:number, error?:string}}
+ */
+export function clearStaleGitIndexLock(opts = {}) {
+  const { repoRoot, maxAgeMs = DEFAULT_STALE_LOCK_MAX_AGE_MS, fs = realFs, now = Date.now() } = opts;
+  if (!repoRoot) return { cleared: false, reason: 'no_repo_root' };
+  const lockPath = path.join(repoRoot, '.git', 'index.lock');
+
+  let stat;
+  try {
+    stat = fs.statSync(lockPath);
+  } catch {
+    return { cleared: false, reason: 'absent' }; // no lock → nothing to do (the common case)
+  }
+
+  const ageMs = now - stat.mtimeMs;
+  const isZeroByte = stat.size === 0;
+
+  // FRESH + non-empty = an active git op. NEVER touch it.
+  if (!isZeroByte && ageMs < maxAgeMs) {
+    return { cleared: false, reason: 'fresh_active', ageMs, size: stat.size };
+  }
+
+  try {
+    fs.unlinkSync(lockPath);
+    return { cleared: true, reason: isZeroByte ? 'zero_byte' : 'stale_mtime', ageMs, size: stat.size };
+  } catch (e) {
+    return { cleared: false, reason: 'unlink_failed', error: (e && e.message) || String(e) };
+  }
+}

--- a/scripts/safe-root-resync.mjs
+++ b/scripts/safe-root-resync.mjs
@@ -316,6 +316,29 @@ export async function safeRootResync(opts = {}) {
   }
   // gitKind === 'directory' → shared root → proceed
 
+  // ── STEP 1.5 (SD-REFILL-00KUKQVS): clear a STALE .git/index.lock before any index op ──
+  // A crash-orphaned/concurrent .git/index.lock in the SHARED checkout silently froze it
+  // behind origin/main (the Adam-not-in-sync incident: 125 behind from a 25h-stale lock; a
+  // 0-byte lock re-appeared within minutes). This recovery command must clear a STALE lock
+  // first — otherwise the very lock we're recovering from blocks our own fetch/merge. Only a
+  // STALE lock is removed (0-byte, or mtime older than the threshold); a FRESH non-empty lock
+  // (an active git op) is left untouched. We only reach here when .git is a DIRECTORY (shared
+  // root, guarded above), so we never touch a worktree's lock.
+  try {
+    const { clearStaleGitIndexLock } = await import('../lib/git/clear-stale-index-lock.mjs');
+    const lockResult = clearStaleGitIndexLock({ repoRoot: cwd, fs: fsMod });
+    if (lockResult.cleared) {
+      process.stderr.write(
+        `[safe-root-resync] cleared STALE .git/index.lock (${lockResult.reason}, age ${Math.round((lockResult.ageMs || 0) / 1000)}s) — unblocking index ops\n`
+      );
+    } else if (lockResult.reason === 'fresh_active') {
+      process.stderr.write('[safe-root-resync] .git/index.lock is FRESH (active git op) — NOT clearing\n');
+    }
+  } catch (e) {
+    // Fail-open: a stale-lock check failure must never abort the resync.
+    process.stderr.write(`[safe-root-resync] stale-lock check skipped (non-fatal): ${e && e.message || e}\n`);
+  }
+
   // ── STEP 2: Fetch origin/main ─────────────────────────────────────────────
   try {
     await exec(['fetch', 'origin', 'main', '--quiet']);

--- a/tests/unit/clear-stale-index-lock.test.js
+++ b/tests/unit/clear-stale-index-lock.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-REFILL-00KUKQVS — stale .git/index.lock auto-clear (the silent origin/main drift root).
+ *
+ * Removes the SHARED checkout's .git/index.lock ONLY when stale (0-byte crash-orphan, or
+ * mtime older than the threshold); a FRESH non-empty lock (an active git op) is NEVER removed.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { clearStaleGitIndexLock, DEFAULT_STALE_LOCK_MAX_AGE_MS } from '../../lib/git/clear-stale-index-lock.mjs';
+
+const NOW = 1_000_000_000_000;
+function fakeFs({ size, mtimeMs, unlinkThrows = false } = {}) {
+  const calls = { unlinked: 0 };
+  return {
+    calls,
+    statSync: () => {
+      if (size === undefined) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }
+      return { size, mtimeMs };
+    },
+    unlinkSync: () => { calls.unlinked++; if (unlinkThrows) throw new Error('EBUSY'); },
+  };
+}
+
+describe('clearStaleGitIndexLock (SD-REFILL-00KUKQVS)', () => {
+  it('absent lock → no-op (the common case)', () => {
+    const fs = fakeFs({}); // statSync throws ENOENT
+    const r = clearStaleGitIndexLock({ repoRoot: '/repo', fs, now: NOW });
+    expect(r.cleared).toBe(false);
+    expect(r.reason).toBe('absent');
+    expect(fs.calls.unlinked).toBe(0);
+  });
+
+  it('0-byte lock → cleared even if fresh (crash-orphan signal)', () => {
+    const fs = fakeFs({ size: 0, mtimeMs: NOW - 1000 }); // 1s old but 0-byte
+    const r = clearStaleGitIndexLock({ repoRoot: '/repo', fs, now: NOW });
+    expect(r.cleared).toBe(true);
+    expect(r.reason).toBe('zero_byte');
+    expect(fs.calls.unlinked).toBe(1);
+  });
+
+  it('old non-empty lock (mtime > threshold) → cleared', () => {
+    const fs = fakeFs({ size: 41, mtimeMs: NOW - (DEFAULT_STALE_LOCK_MAX_AGE_MS + 5000) });
+    const r = clearStaleGitIndexLock({ repoRoot: '/repo', fs, now: NOW });
+    expect(r.cleared).toBe(true);
+    expect(r.reason).toBe('stale_mtime');
+    expect(fs.calls.unlinked).toBe(1);
+  });
+
+  it('FRESH non-empty lock (active git op) → NEVER removed', () => {
+    const fs = fakeFs({ size: 41, mtimeMs: NOW - 2000 }); // 2s old, has content
+    const r = clearStaleGitIndexLock({ repoRoot: '/repo', fs, now: NOW });
+    expect(r.cleared).toBe(false);
+    expect(r.reason).toBe('fresh_active');
+    expect(fs.calls.unlinked).toBe(0);
+  });
+
+  it('unlink failure → fail-soft (cleared:false, reason unlink_failed, never throws)', () => {
+    const fs = fakeFs({ size: 0, mtimeMs: NOW - 1000, unlinkThrows: true });
+    const r = clearStaleGitIndexLock({ repoRoot: '/repo', fs, now: NOW });
+    expect(r.cleared).toBe(false);
+    expect(r.reason).toBe('unlink_failed');
+  });
+
+  it('no repoRoot → no-op', () => {
+    expect(clearStaleGitIndexLock({}).cleared).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

A recurring stale `.git/index.lock` in the **shared main checkout** (coordinator + Adam both run there; workers are isolated) silently froze it behind `origin/main` — the **Adam-not-in-sync incident** (125 commits behind from a 25h-stale lock; a 0-byte lock re-appeared within minutes). The documented recovery (`npm run resync:safe`) was **itself blocked** by the very lock it's meant to clear.

## Fix (option (b) auto-clear, recovery path)

New pure helper `lib/git/clear-stale-index-lock.mjs` removes `.git/index.lock` **only when STALE** — 0-byte (crash-orphan; a real op writes content) or mtime older than 120s (git index ops are sub-second). A **fresh non-empty lock (active op) is never removed.** Wired into `safe-root-resync` STEP 1.5 — after the worktree guard confirms the shared root (so a worktree's lock is never touched), before fetch, fail-open. 6 unit tests.

**Deeper follow-ups flagged:** proactive SessionStart clear, the lock-leaving producer fix, and option (a) Adam's own worktree.

TESTING PASS (6/6). Clean 3-file delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)