### PR TITLE
fix(SD-REFILL-00IO6NQJ): wire coordinator standing-report liveness to CC-PID source (SSOT)

### DIFF
--- a/lib/coordinator/fleet-quiescence.cjs
+++ b/lib/coordinator/fleet-quiescence.cjs
@@ -7,13 +7,15 @@
  * coordinator or Adam of their roles if everything is suddenly slowed down and
  * stopped." This is the reusable element that can gate ANY repeating item.
  *
- * Liveness source = v_active_sessions (heartbeat_age_seconds + computed_status),
- * the SAME view scripts/fleet-dashboard.cjs uses — NOT claude_sessions.last_heartbeat
- * (that column does not exist; the real column is heartbeat_at). Using the dashboard's
- * own signal guarantees this gate AGREES with what the operator sees on screen.
+ * Liveness source = v_active_sessions (heartbeat_age_seconds + computed_status) PLUS
+ * CC-PID aliveness from the SessionStart markers — the SAME two signals
+ * scripts/fleet-dashboard.cjs uses (SD-REFILL-00IO6NQJ). Heartbeat alone is BLIND to a
+ * parked /loop worker (stale DB heartbeat but a live CC process), which produced false
+ * "quiescent / 0 workers" reports while 3-4 workers were live; OR-ing in PID-aliveness
+ * makes this gate AGREE with the dashboard's worker count.
  *
  * QUIESCENT (cycle down) iff ALL of:
- *   - no live worker (heartbeat < FRESH_S) with computed_status='active' holding a claim
+ *   - no live worker (heartbeat < FRESH_S OR CC PID alive) with computed_status='active' holding a claim
  *   - no in_progress SD (a build mid-flight, even if between heartbeats)
  *   - no SD reached completed/pending_approval in the last RECENT_MIN minutes (hysteresis)
  *
@@ -23,6 +25,8 @@
  *
  * @module lib/coordinator/fleet-quiescence
  */
+
+const { getAliveCcPids } = require('../fleet/cc-pid-liveness.cjs');
 
 const FRESH_S = Number(process.env.QUIESCENCE_FRESH_SECONDS || 300);
 
@@ -69,13 +73,22 @@ async function assessFleetActivity(sb, opts) {
   try {
     const { data: sessions, error: sErr } = await sb
       .from('v_active_sessions')
-      .select('session_id, sd_key, heartbeat_age_seconds, computed_status');
+      .select('session_id, sd_key, heartbeat_age_seconds, computed_status, terminal_id');
     if (sErr) throw sErr;
+    // SD-REFILL-00IO6NQJ: PID-aliveness from the SessionStart markers, OR'd onto the
+    // heartbeat window so a parked /loop worker (stale heartbeat, live CC process) still
+    // counts. opts.aliveCcPids lets unit tests inject the set; otherwise read the markers.
+    // Off-box (no local markers) → empty set → degrades to heartbeat-only behavior, never worse.
+    const aliveCcPids = (opts && opts.aliveCcPids) || getAliveCcPids();
+    const ccPidAlive = function (s) {
+      if (!s.terminal_id) return false;
+      const parts = String(s.terminal_id).split('-');
+      return aliveCcPids.has(parts[parts.length - 1]);
+    };
     signals.liveActiveWorkers = (sessions || []).filter(function (s) {
-      return s.heartbeat_age_seconds != null &&
-        s.heartbeat_age_seconds < FRESH_S &&
-        s.computed_status === 'active' &&
-        s.sd_key; // holding a claim, not idle-between-tasks
+      return s.computed_status === 'active' &&
+        s.sd_key && // holding a claim, not idle-between-tasks
+        ((s.heartbeat_age_seconds != null && s.heartbeat_age_seconds < FRESH_S) || ccPidAlive(s));
     }).length;
 
     const { data: builds, error: bErr } = await sb

--- a/lib/fleet/cc-pid-liveness.cjs
+++ b/lib/fleet/cc-pid-liveness.cjs
@@ -1,0 +1,65 @@
+// SD-REFILL-00IO6NQJ: SSOT for Claude-Code PID liveness from SessionStart markers.
+//
+// Extracted from scripts/fleet-dashboard.cjs so the coordinator standing-report
+// (lib/coordinator/fleet-quiescence.cjs assessFleetActivity) and the fleet
+// dashboard read PID-aliveness from ONE source. A parked /loop worker has a stale
+// DB heartbeat but a LIVE CC process; keying liveness on the heartbeat window alone
+// produced false "quiescent / 0 workers" reports while 3-4 workers were live.
+//
+// Liveness uses Node's process.kill(pid, 0) — NEVER `bash kill -0`, which returns a
+// false-NEGATIVE on this Windows/git-bash box (reports live PIDs as dead).
+
+const fs = require('fs');
+const path = require('path');
+
+// Repo-root/.claude/session-identity — resolved from this module's location
+// (lib/fleet → ../../), matching the directory fleet-dashboard.cjs historically used
+// (scripts → ../). Both resolve to the same repo-root marker dir.
+const MARKER_DIR = path.resolve(__dirname, '../../.claude/session-identity');
+
+/**
+ * True iff `pid` is a running process. Treats EPERM as alive (the process exists but
+ * is owned by another user). Uses process.kill(pid, 0); does not shell out.
+ * @param {number} pid
+ * @returns {boolean}
+ */
+function isProcessRunning(pid) {
+  if (!pid || typeof pid !== 'number') return false;
+  try { process.kill(pid, 0); return true; }
+  catch (err) { return err.code === 'EPERM'; }
+}
+
+/**
+ * Read the SessionStart pid-*.json markers, returning a map of
+ * session_id -> { claude_session_id, pid, alive }. Unreadable markers are skipped.
+ * @param {string} [markerDir] override (defaults to repo-root/.claude/session-identity)
+ * @returns {Object<string, {claude_session_id: (string|null), pid: number, alive: boolean}>}
+ */
+function getMarkerSessionIds(markerDir = MARKER_DIR) {
+  if (!fs.existsSync(markerDir)) return {};
+  const map = {};
+  for (const f of fs.readdirSync(markerDir).filter(f => /^pid-\d+\.json$/.test(f))) {
+    try {
+      const pid = Number(f.match(/^pid-(\d+)\.json$/)[1]);
+      const data = JSON.parse(fs.readFileSync(path.join(markerDir, f), 'utf8'));
+      if (data.session_id) map[data.session_id] = { claude_session_id: data.claude_session_id || null, pid, alive: isProcessRunning(pid) };
+    } catch { /* skip unreadable markers */ }
+  }
+  return map;
+}
+
+/**
+ * Set of alive CC PIDs (as strings) from the marker files.
+ * @param {string} [markerDir]
+ * @returns {Set<string>}
+ */
+function getAliveCcPids(markerDir = MARKER_DIR) {
+  const markers = getMarkerSessionIds(markerDir);
+  const alive = new Set();
+  for (const info of Object.values(markers)) {
+    if (info.alive) alive.add(String(info.pid));
+  }
+  return alive;
+}
+
+module.exports = { isProcessRunning, getMarkerSessionIds, getAliveCcPids, MARKER_DIR };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -35,36 +35,10 @@ const FLEET_MC_ENABLED = (process.env.FLEET_MC_ENABLED ?? 'true').toLowerCase() 
 
 const supabase = createSupabaseServiceClient();
 
-function isProcessRunning(pid) {
-  if (!pid || typeof pid !== 'number') return false;
-  try { process.kill(pid, 0); return true; }
-  catch (err) { return err.code === 'EPERM'; }
-}
-
-// Read CLAUDE_SESSION_ID from marker files for disambiguation + PID liveness
-function getMarkerSessionIds() {
-  const markerDir = path.resolve(__dirname, '../.claude/session-identity');
-  if (!fs.existsSync(markerDir)) return {};
-  const map = {};
-  for (const f of fs.readdirSync(markerDir).filter(f => /^pid-\d+\.json$/.test(f))) {
-    try {
-      const pid = Number(f.match(/^pid-(\d+)\.json$/)[1]);
-      const data = JSON.parse(fs.readFileSync(path.join(markerDir, f), 'utf8'));
-      if (data.session_id) map[data.session_id] = { claude_session_id: data.claude_session_id || null, pid, alive: isProcessRunning(pid) };
-    } catch { /* skip unreadable markers */ }
-  }
-  return map;
-}
-
-// Returns a Set of alive CC PIDs (as strings) from marker files
-function getAliveCcPids() {
-  const markers = getMarkerSessionIds();
-  const alive = new Set();
-  for (const info of Object.values(markers)) {
-    if (info.alive) alive.add(String(info.pid));
-  }
-  return alive;
-}
+// SD-REFILL-00IO6NQJ: PID-liveness now lives in a shared SSOT module so the
+// coordinator standing-report (fleet-quiescence) and this dashboard read it from
+// one source. Behavior-identical to the prior local copies.
+const { isProcessRunning, getMarkerSessionIds, getAliveCcPids } = require('../lib/fleet/cc-pid-liveness.cjs');
 
 const STALE_THRESHOLD = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS, 10) || 300;
 

--- a/tests/unit/cc-pid-liveness.test.js
+++ b/tests/unit/cc-pid-liveness.test.js
@@ -1,0 +1,36 @@
+/**
+ * SD-REFILL-00IO6NQJ — the shared CC-PID liveness SSOT.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { isProcessRunning, getAliveCcPids, getMarkerSessionIds, MARKER_DIR } = require('../../lib/fleet/cc-pid-liveness.cjs');
+
+describe('SD-REFILL-00IO6NQJ: cc-pid-liveness', () => {
+  it('isProcessRunning is true for the current process', () => {
+    expect(isProcessRunning(process.pid)).toBe(true);
+  });
+
+  it('isProcessRunning is false for invalid pids', () => {
+    expect(isProcessRunning(0)).toBe(false);
+    expect(isProcessRunning(null)).toBe(false);
+    expect(isProcessRunning(undefined)).toBe(false);
+    expect(isProcessRunning('123')).toBe(false); // non-number
+  });
+
+  it('isProcessRunning is false for a pid that does not exist', () => {
+    // 2^30 is well above any live PID on these boxes → ESRCH (not EPERM).
+    expect(isProcessRunning(1073741823)).toBe(false);
+  });
+
+  it('getMarkerSessionIds / getAliveCcPids return safe empties for a missing marker dir', () => {
+    expect(getMarkerSessionIds('/no/such/marker/dir/xyz')).toEqual({});
+    expect(getAliveCcPids('/no/such/marker/dir/xyz')).toBeInstanceOf(Set);
+    expect(getAliveCcPids('/no/such/marker/dir/xyz').size).toBe(0);
+  });
+
+  it('exposes the canonical marker dir', () => {
+    expect(typeof MARKER_DIR).toBe('string');
+    expect(MARKER_DIR.replace(/\\/g, '/')).toMatch(/\.claude\/session-identity$/);
+  });
+});

--- a/tests/unit/fleet-quiescence-pid-liveness.test.js
+++ b/tests/unit/fleet-quiescence-pid-liveness.test.js
@@ -1,0 +1,97 @@
+/**
+ * SD-REFILL-00IO6NQJ — assessFleetActivity.liveActiveWorkers must count a PID-alive
+ * parked /loop worker (stale DB heartbeat, live CC process), not just heartbeat-fresh
+ * sessions. The coordinator standing-report was reporting false "quiescent / 0 workers"
+ * while 3-4 workers were live. PID-aliveness is OR'd onto the heartbeat window and is
+ * injectable via opts.aliveCcPids for hermetic testing.
+ */
+import { describe, it, expect } from 'vitest';
+import fleetQuiescence from '../../lib/coordinator/fleet-quiescence.cjs';
+
+const { assessFleetActivity } = fleetQuiescence;
+
+// Chainable Supabase mock: builder methods return the builder; awaiting resolves to
+// resolver({table, columns, filters}). resolver may throw to simulate a query error.
+function makeSb(resolver) {
+  function builder(table) {
+    const ctx = { table, columns: null, filters: [] };
+    const b = {
+      select(cols) { ctx.columns = cols; return b; },
+      eq(col, val) { ctx.filters.push(['eq', col, val]); return b; },
+      gte(col, val) { ctx.filters.push(['gte', col, val]); return b; },
+      in(col, val) { ctx.filters.push(['in', col, val]); return b; },
+      then(onF, onR) {
+        let result;
+        try { result = resolver(ctx); } catch (e) { return Promise.resolve().then(() => { throw e; }).then(onF, onR); }
+        return Promise.resolve(result).then(onF, onR);
+      },
+    };
+    return b;
+  }
+  return { from: (table) => builder(table) };
+}
+
+// Sessions come from v_active_sessions; everything else (builds, handoffs) is empty so
+// only liveActiveWorkers varies. recentTransitions stays 0 (no handoffs in-window).
+function sbWithSessions(sessions) {
+  return makeSb((ctx) => {
+    if (ctx.table === 'v_active_sessions') return { data: sessions, error: null };
+    if (ctx.table === 'sd_phase_handoffs') return { data: [], error: null };
+    if (ctx.table === 'strategic_directives_v2') return { data: [], error: null };
+    throw new Error('unexpected table ' + ctx.table);
+  });
+}
+
+const TERM = (ccPid) => `win-cc-5000-${ccPid}`;
+
+describe('SD-REFILL-00IO6NQJ: liveActiveWorkers PID-aliveness', () => {
+  it('counts a PID-alive claim-holder with a STALE heartbeat', async () => {
+    const sb = sbWithSessions([
+      { session_id: 's1', sd_key: 'SD-X-001', heartbeat_age_seconds: 9999, computed_status: 'active', terminal_id: TERM('12345') },
+    ]);
+    const r = await assessFleetActivity(sb, { now: Date.now(), aliveCcPids: new Set(['12345']) });
+    expect(r.signals.liveActiveWorkers).toBe(1);
+    expect(r.quiescent).toBe(false);
+  });
+
+  it('still counts a heartbeat-fresh claim-holder even with no alive PIDs (no regression)', async () => {
+    const sb = sbWithSessions([
+      { session_id: 's1', sd_key: 'SD-X-001', heartbeat_age_seconds: 10, computed_status: 'active', terminal_id: TERM('99999') },
+    ]);
+    const r = await assessFleetActivity(sb, { now: Date.now(), aliveCcPids: new Set() });
+    expect(r.signals.liveActiveWorkers).toBe(1);
+  });
+
+  it('does NOT count a stale-heartbeat claim-holder whose PID is dead', async () => {
+    const sb = sbWithSessions([
+      { session_id: 's1', sd_key: 'SD-X-001', heartbeat_age_seconds: 9999, computed_status: 'active', terminal_id: TERM('77777') },
+    ]);
+    const r = await assessFleetActivity(sb, { now: Date.now(), aliveCcPids: new Set(['12345']) });
+    expect(r.signals.liveActiveWorkers).toBe(0);
+    expect(r.quiescent).toBe(true);
+  });
+
+  it('does NOT count a PID-alive session that holds NO claim (idle between tasks)', async () => {
+    const sb = sbWithSessions([
+      { session_id: 's1', sd_key: null, heartbeat_age_seconds: 9999, computed_status: 'active', terminal_id: TERM('12345') },
+    ]);
+    const r = await assessFleetActivity(sb, { now: Date.now(), aliveCcPids: new Set(['12345']) });
+    expect(r.signals.liveActiveWorkers).toBe(0);
+  });
+
+  it('does NOT count a PID-alive claim-holder whose computed_status is not active', async () => {
+    const sb = sbWithSessions([
+      { session_id: 's1', sd_key: 'SD-X-001', heartbeat_age_seconds: 9999, computed_status: 'idle', terminal_id: TERM('12345') },
+    ]);
+    const r = await assessFleetActivity(sb, { now: Date.now(), aliveCcPids: new Set(['12345']) });
+    expect(r.signals.liveActiveWorkers).toBe(0);
+  });
+
+  it('off-box (empty alive set) degrades to heartbeat-only: stale worker not counted', async () => {
+    const sb = sbWithSessions([
+      { session_id: 's1', sd_key: 'SD-X-001', heartbeat_age_seconds: 9999, computed_status: 'active', terminal_id: TERM('12345') },
+    ]);
+    const r = await assessFleetActivity(sb, { now: Date.now(), aliveCcPids: new Set() });
+    expect(r.signals.liveActiveWorkers).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
The coordinator standing-report path (`coordinator-hourly-review.cjs` → `fleet-quiescence.assessFleetActivity`) derived `liveActiveWorkers` purely from `v_active_sessions.heartbeat_age_seconds < FRESH_S` — **blind to PID-alive parked /loop workers** (stale DB heartbeat, live CC process). Result: repeated false **"quiescent / 0 workers"** reports while 3-4 workers were in fact live (witnessed 2026-06-14 via `wf_c60b90f7`, PID verified via `process.kill`).

`fleet-dashboard` already cross-referenced PID-marker liveness (`getAliveCcPids` + `hasPidAlive`, added by SD-LEO-INFRA-WORKER-SOURCE-SIDE-001), so its `printHealth` "Active: N workers" headline was **already** PID-aware — but that helper was private to `fleet-dashboard.cjs` and the standing report was never wired to it (the self-contradiction this SD calls out).

## Changes
- **FR-1**: extract `isProcessRunning` / `getMarkerSessionIds` / `getAliveCcPids` into a shared `lib/fleet/cc-pid-liveness.cjs` (SSOT). Liveness uses Node `process.kill(pid,0)` — **never** `bash kill -0` (false-negative on this Windows/git-bash box).
- **FR-2**: rewire `scripts/fleet-dashboard.cjs` to require the shared helper (behavior-identical).
- **FR-3**: `fleet-quiescence.liveActiveWorkers` now counts a claim-holding, `computed_status=active` session when **heartbeat-fresh OR its CC PID** (last segment of `terminal_id`) is alive. Additive — off-box (no markers) degrades to heartbeat-only, never stricter; fail-OPEN-to-active unchanged. `opts.aliveCcPids` injects the set for hermetic tests.
- **FR-4**: `tests/unit/fleet-quiescence-pid-liveness.test.js` (6) + `cc-pid-liveness.test.js` (5).

## Tests
23 unit tests pass (6 PID-liveness + 5 shared-helper + 6 recent-transition + 6 loop-resume regression). `node --check` clean on both touched scripts. TESTING sub-agent verdict PASS (row `2bf03a3c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)