### PR TITLE
fix(SD-REFILL-00CAKXC2): auto-extract-patterns reads retrospectives with the service client

### DIFF
--- a/scripts/auto-extract-patterns-from-retro.js
+++ b/scripts/auto-extract-patterns-from-retro.js
@@ -12,13 +12,18 @@
  * - Adds resolution_date and resolution_notes support
  */
 
-import { createSupabaseClient } from '../lib/supabase-client.js';
+// SD-REFILL-00CAKXC2: read with the SERVICE client, not the ANON client. retrospectives is
+// RLS-protected and rows are written by the service role, so an anon read returns zero rows →
+// the script threw 'Retrospective not found' for EVERY generated retro and silently skipped
+// pattern extraction (witnessed: retro 66938c8b on SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001).
+// This is a server-side batch script (no end-user context), so the service role is correct.
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { IssueKnowledgeBase } from '../lib/learning/issue-knowledge-base.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
 
-const supabase = createSupabaseClient();
+const supabase = createSupabaseServiceClient();
 
 const kb = new IssueKnowledgeBase();
 

--- a/tests/unit/auto-extract-patterns-service-client.test.js
+++ b/tests/unit/auto-extract-patterns-service-client.test.js
@@ -1,0 +1,37 @@
+/**
+ * SD-REFILL-00CAKXC2 — auto-extract-patterns-from-retro.js must read retrospectives with the
+ * SERVICE client, not the ANON client.
+ *
+ * retrospectives is RLS-protected and rows are written by the service role. With the anon
+ * client the read returned zero rows, so the script threw 'Retrospective not found' for EVERY
+ * generated retro and silently skipped pattern extraction (witnessed: retro 66938c8b).
+ *
+ * Static source assertions (the module creates its supabase client at top-level load, which
+ * needs the service-role env, so importing it in a test is unsafe — assert the source instead;
+ * matches the project convention for scripts, e.g. stale-sweep / check-git-state tests).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/auto-extract-patterns-from-retro.js');
+const src = readFileSync(SCRIPT, 'utf8');
+
+describe('auto-extract-patterns-from-retro uses the SERVICE client (SD-REFILL-00CAKXC2)', () => {
+  it('imports createSupabaseServiceClient', () => {
+    expect(src).toMatch(/import\s*\{\s*createSupabaseServiceClient\s*\}\s*from\s*['"]\.\.\/lib\/supabase-client\.js['"]/);
+  });
+
+  it('constructs the supabase client from the SERVICE factory', () => {
+    expect(src).toMatch(/const\s+supabase\s*=\s*createSupabaseServiceClient\(\)/);
+  });
+
+  it('no longer uses the anon createSupabaseClient (the RLS-blind bug)', () => {
+    // word-boundary so it does not match createSupabaseServiceClient
+    expect(src).not.toMatch(/\bcreateSupabaseClient\b/);
+  });
+
+  it('still reads the RLS-protected retrospectives table', () => {
+    expect(src).toMatch(/\.from\(\s*['"]retrospectives['"]\s*\)/);
+  });
+});


### PR DESCRIPTION
## What

`scripts/auto-extract-patterns-from-retro.js` read the **RLS-protected** `retrospectives` table with the **anon** client. Rows are written by the service role, so the anon read returned zero rows → the script threw `Retrospective not found` for **every generated retrospective** and silently skipped pattern extraction fleet-wide (witnessed: retro `66938c8b` on `SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001`).

## Fix

Swap the client factory `createSupabaseClient` → `createSupabaseServiceClient` (import + the top-level `const supabase`). Correct for a server-side batch script with no end-user context. Two-line change; behavior otherwise unchanged (still reads `retrospectives`, main() guard intact).

4 static regression tests (service import + usage, no anon ref, still reads retrospectives). TESTING PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)