### PR TITLE
feat(SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001): spawn-execution consumer for worker_spawn_requests (inert dry-run by default)

### DIFF
--- a/lib/fleet/spawn-executor-core.cjs
+++ b/lib/fleet/spawn-executor-core.cjs
@@ -1,0 +1,53 @@
+// SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001 (FR-1): PURE spawn-decision logic for the
+// worker-spawn-executor daemon. No DB, no process spawn, no ambient clock — every input is
+// injected so this is fully unit-testable and deterministic.
+//
+// Given the pending worker_spawn_requests rows + the set of callsigns already backed by a
+// live session, decide which requests to spawn this tick and which to skip (and why). The
+// daemon (scripts/fleet/worker-spawn-executor.cjs) handles the actual I/O and the
+// default-OFF live spawn; this module just makes the decision.
+
+/**
+ * @param {object} input
+ * @param {Array<{id:string, requested_callsign:string, status:string, requested_at:string, expires_at:string}>} input.pendingRequests
+ * @param {Set<string>|Array<string>} input.liveCallsigns - callsigns already backed by a live session
+ * @param {number} input.nowMs - injected clock
+ * @param {number} input.perTickCap - max spawns to authorize this tick (>=0)
+ * @returns {{toSpawn: Array<object>, skipped: Array<{request: object, reason: string}>}}
+ */
+function resolveSpawnDecisions({ pendingRequests, liveCallsigns, nowMs, perTickCap } = {}) {
+  const requests = Array.isArray(pendingRequests) ? pendingRequests : [];
+  const live = liveCallsigns instanceof Set ? liveCallsigns : new Set(liveCallsigns || []);
+  const cap = Number.isFinite(perTickCap) && perTickCap >= 0 ? Math.floor(perTickCap) : 0;
+  const now = Number.isFinite(nowMs) ? nowMs : 0;
+
+  const skipped = [];
+  // Stable order: oldest requested_at first, so dedup keeps the oldest and the cap is fair.
+  const ordered = requests.slice().sort((a, b) => {
+    const ta = Date.parse(a && a.requested_at) || 0;
+    const tb = Date.parse(b && b.requested_at) || 0;
+    return ta - tb;
+  });
+
+  const eligible = [];
+  const seenCallsign = new Set();
+  for (const r of ordered) {
+    if (!r || typeof r !== 'object') { continue; }
+    if (r.status !== 'pending') { skipped.push({ request: r, reason: 'not_pending' }); continue; }
+    const exp = Date.parse(r.expires_at);
+    if (Number.isFinite(exp) && exp <= now) { skipped.push({ request: r, reason: 'expired' }); continue; }
+    const callsign = r.requested_callsign;
+    if (!callsign) { skipped.push({ request: r, reason: 'no_callsign' }); continue; }
+    if (live.has(callsign)) { skipped.push({ request: r, reason: 'already_live' }); continue; }
+    if (seenCallsign.has(callsign)) { skipped.push({ request: r, reason: 'duplicate_callsign' }); continue; }
+    seenCallsign.add(callsign);
+    eligible.push(r);
+  }
+
+  const toSpawn = eligible.slice(0, cap);
+  for (const r of eligible.slice(cap)) { skipped.push({ request: r, reason: 'cap_exceeded' }); }
+
+  return { toSpawn, skipped };
+}
+
+module.exports = { resolveSpawnDecisions };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "leo:build:start:cron": "node scripts/cron/leo-build-starter.mjs --once",
     "eva:scheduler:watch:cron": "node scripts/cron/eva-scheduler-watcher.mjs --once",
     "adam:exec:email:cron": "node scripts/adam-exec-summary.mjs",
+    "fleet:spawn-executor": "node scripts/fleet/worker-spawn-executor.cjs",
     "fleet:pulse": "node scripts/fleet-worker-pulse.mjs",
     "fleet:pulse:cron": "node scripts/fleet-worker-pulse.mjs",
     "fleet:down-alert": "node scripts/fleet-down-alert.mjs",

--- a/scripts/fleet/worker-spawn-executor.cjs
+++ b/scripts/fleet/worker-spawn-executor.cjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001 (FR-2/FR-3): the missing spawn-execution
+// consumer for worker_spawn_requests. coordinator-revive.cjs WRITES revival requests but
+// nothing CONSUMED them, so worker revival was inert (fulfilled_at stayed NULL) — a
+// usage-limit outage that killed a worker's re-arming /loop turn left it dead with no
+// external restart.
+//
+// SAFETY — STAGED / INERT BY DEFAULT:
+//   The live deliverable spawns OS processes (fresh background claude CC workers), which is
+//   high blast radius (duplicate/runaway sessions burn the shared usage quota). So the real
+//   spawn is DEFAULT-OFF behind WORKER_SPAWN_EXECUTOR_LIVE. With the flag unset this daemon is
+//   a DRY-RUN: it reads pending requests, logs the spawn command it WOULD run, and launches
+//   NOTHING — leaving rows pending so the INERT_WORKER detector keeps surfacing them.
+//
+//   ⚠️ OPERATOR GATE (Stage 2, do NOT enable autonomously): before setting
+//   WORKER_SPAWN_EXECUTOR_LIVE=true, an operator must HOST-VALIDATE buildSpawnInvocation()
+//   below (the exact `claude` background-launch command for this host) AND register the
+//   external scheduler (Windows Task / cron) that runs this daemon on a wall-clock cadence.
+//   Those two steps are the keystone's activation and are intentionally out of scope here.
+
+const { resolveSpawnDecisions } = require('../../lib/fleet/spawn-executor-core.cjs');
+
+const PER_TICK_CAP_DEFAULT = 2;
+
+/** Resolve the per-tick spawn cap from env (bounded, safe default). */
+function resolvePerTickCap(env = process.env) {
+  const n = parseInt(env.WORKER_SPAWN_EXECUTOR_PER_TICK_CAP, 10);
+  return Number.isFinite(n) && n >= 0 ? n : PER_TICK_CAP_DEFAULT;
+}
+
+/** True only when the operator has explicitly enabled the live OS spawn. */
+function isLiveEnabled(env = process.env) {
+  return String(env.WORKER_SPAWN_EXECUTOR_LIVE || '').toLowerCase() === 'true';
+}
+
+/**
+ * Build the host command that WOULD launch a fresh background claude CC worker seeded with
+ * the fleet-worker /loop prompt. Returns a structured command; NEVER executes it here.
+ * ⚠️ The exact program/args are HOST-SPECIFIC and must be operator-validated before the live
+ * flag is flipped. This default is a best-effort, documented starting point only.
+ */
+function buildSpawnInvocation(callsign, prompt) {
+  return {
+    program: 'claude',
+    // -p / --print runs headlessly with the prompt; the operator may need a different form
+    // (detached terminal, wrapper script, env seeding) on this host — hence the operator gate.
+    args: ['-p', prompt],
+    env: { FLEET_WORKER_CALLSIGN: callsign || '' },
+  };
+}
+
+/**
+ * PURE-ish orchestration of one executor tick. All I/O is injected so this is unit-testable
+ * with zero blast radius. Decides what to spawn (resolveSpawnDecisions), then either logs the
+ * dry-run decision (live=false) or invokes the injected spawner + stamps fulfillment (live=true).
+ *
+ * @param {object} o
+ * @param {Array} o.pendingRequests
+ * @param {Set<string>} o.liveCallsigns
+ * @param {number} o.nowMs
+ * @param {number} o.perTickCap
+ * @param {boolean} o.live
+ * @param {(invocation:object, request:object)=>Promise<void>} o.spawner  invoked only when live
+ * @param {(request:object)=>Promise<void>} o.stampFulfilled              invoked only after a live spawn succeeds
+ * @param {string} o.prompt
+ * @param {(msg:string)=>void} [o.log]
+ * @returns {Promise<{dryRun:boolean, spawned:number, errors:number, skipped:number, decisions:object}>}
+ */
+async function runExecutor(o) {
+  const log = o.log || (() => {});
+  const decisions = resolveSpawnDecisions({
+    pendingRequests: o.pendingRequests,
+    liveCallsigns: o.liveCallsigns,
+    nowMs: o.nowMs,
+    perTickCap: o.perTickCap,
+  });
+
+  for (const s of decisions.skipped) {
+    log(`[spawn-exec] skip ${s.request && s.request.requested_callsign} (${s.request && s.request.id}): ${s.reason}`);
+  }
+
+  let spawned = 0;
+  let errors = 0;
+  for (const req of decisions.toSpawn) {
+    const invocation = buildSpawnInvocation(req.requested_callsign, o.prompt);
+    if (!o.live) {
+      log(`[spawn-exec] DRY-RUN would spawn ${req.requested_callsign} (${req.id}): ${invocation.program} ${(invocation.args || []).join(' ').slice(0, 40)}… — row left pending (set WORKER_SPAWN_EXECUTOR_LIVE=true after host-validation to enable)`);
+      continue;
+    }
+    try {
+      await o.spawner(invocation, req);
+      await o.stampFulfilled(req);
+      spawned++;
+      log(`[spawn-exec] spawned + fulfilled ${req.requested_callsign} (${req.id})`);
+    } catch (e) {
+      errors++;
+      log(`[spawn-exec] spawn FAILED for ${req.requested_callsign} (${req.id}): ${e && e.message} — row left pending`);
+    }
+  }
+
+  return { dryRun: !o.live, spawned, errors, skipped: decisions.skipped.length, decisions };
+}
+
+// ── I/O helpers (best-effort; not unit-tested — the decision/spawn logic above is) ──
+
+/** Pending, non-expired spawn requests, oldest first. */
+async function loadPendingRequests(sb, nowIso) {
+  const { data, error } = await sb
+    .from('worker_spawn_requests')
+    .select('id, requested_callsign, status, requested_at, expires_at, payload')
+    .eq('status', 'pending')
+    .gt('expires_at', nowIso)
+    .order('requested_at', { ascending: true });
+  if (error) throw error;
+  return data || [];
+}
+
+/** Callsigns already backed by a live session (from claude_sessions.metadata.fleet_identity.callsign). */
+async function deriveLiveCallsigns(sb) {
+  const set = new Set();
+  try {
+    const { data } = await sb
+      .from('v_active_sessions')
+      .select('session_id, metadata, computed_status');
+    for (const s of data || []) {
+      const cs = s && s.metadata && s.metadata.fleet_identity && s.metadata.fleet_identity.callsign;
+      if (cs && s.computed_status === 'active') set.add(cs);
+    }
+  } catch { /* fail-soft: empty set (dry-run logs all; live is still bounded by cap + operator gate) */ }
+  return set;
+}
+
+async function main() {
+  const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+  const { FLEET_WORKER_STARTUP_PROMPT } = require('../../lib/coordinator/coordination-events.cjs');
+  const { spawn } = require('child_process');
+  const sb = createSupabaseServiceClient();
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  const [pendingRequests, liveCallsigns] = await Promise.all([
+    loadPendingRequests(sb, nowIso),
+    deriveLiveCallsigns(sb),
+  ]);
+
+  const live = isLiveEnabled();
+  const result = await runExecutor({
+    pendingRequests,
+    liveCallsigns,
+    nowMs,
+    perTickCap: resolvePerTickCap(),
+    live,
+    prompt: FLEET_WORKER_STARTUP_PROMPT,
+    log: (m) => console.log(m),
+    // Real spawn — only ever reached when live=true (operator-gated).
+    spawner: (invocation) => new Promise((resolve, reject) => {
+      try {
+        const child = spawn(invocation.program, invocation.args, {
+          detached: true,
+          stdio: 'ignore',
+          env: { ...process.env, ...(invocation.env || {}) },
+        });
+        child.on('error', reject);
+        child.unref();
+        resolve();
+      } catch (e) { reject(e); }
+    }),
+    stampFulfilled: async (req) => {
+      await sb.from('worker_spawn_requests')
+        .update({ status: 'fulfilled', fulfilled_at: new Date().toISOString(), fulfilled_by_session_id: process.env.CLAUDE_SESSION_ID || 'spawn-executor' })
+        .eq('id', req.id);
+    },
+  });
+
+  console.log(`[spawn-exec] tick done: dryRun=${result.dryRun} spawned=${result.spawned} errors=${result.errors} skipped=${result.skipped} pending=${pendingRequests.length}`);
+}
+
+if (require.main === module) {
+  main().then(() => process.exit(0)).catch((e) => { console.error('[spawn-exec] fatal:', e && e.message); process.exit(1); });
+}
+
+module.exports = { runExecutor, buildSpawnInvocation, resolvePerTickCap, isLiveEnabled, loadPendingRequests, deriveLiveCallsigns };

--- a/tests/unit/fleet/worker-spawn-executor.test.js
+++ b/tests/unit/fleet/worker-spawn-executor.test.js
@@ -1,0 +1,138 @@
+/**
+ * SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001 — the spawn-execution consumer.
+ * Verifies the pure decision core (resolveSpawnDecisions) and the daemon's dry-run vs live
+ * behavior (runExecutor) with an injected spawner — zero blast radius, no real process spawn.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveSpawnDecisions } = require('../../../lib/fleet/spawn-executor-core.cjs');
+const { runExecutor, buildSpawnInvocation, resolvePerTickCap, isLiveEnabled } = require('../../../scripts/fleet/worker-spawn-executor.cjs');
+
+const NOW = 1_000_000_000_000;
+const future = () => new Date(NOW + 60 * 60 * 1000).toISOString();
+const past = () => new Date(NOW - 1000).toISOString();
+function req(id, callsign, over = {}) {
+  return { id, requested_callsign: callsign, status: 'pending', requested_at: new Date(NOW - 1000).toISOString(), expires_at: future(), ...over };
+}
+
+describe('resolveSpawnDecisions (FR-1, pure)', () => {
+  it('skips expired and non-pending requests', () => {
+    const r = resolveSpawnDecisions({
+      pendingRequests: [req('a', 'Echo', { expires_at: past() }), req('b', 'Bravo', { status: 'fulfilled' })],
+      liveCallsigns: [], nowMs: NOW, perTickCap: 5,
+    });
+    expect(r.toSpawn).toHaveLength(0);
+    expect(r.skipped.map(s => s.reason).sort()).toEqual(['expired', 'not_pending']);
+  });
+
+  it('skips a callsign already backed by a live session', () => {
+    const r = resolveSpawnDecisions({ pendingRequests: [req('a', 'Echo')], liveCallsigns: ['Echo'], nowMs: NOW, perTickCap: 5 });
+    expect(r.toSpawn).toHaveLength(0);
+    expect(r.skipped[0].reason).toBe('already_live');
+  });
+
+  it('dedups multiple pending for the same callsign, keeping the oldest', () => {
+    const older = req('a', 'Echo', { requested_at: new Date(NOW - 5000).toISOString() });
+    const newer = req('b', 'Echo', { requested_at: new Date(NOW - 1000).toISOString() });
+    const r = resolveSpawnDecisions({ pendingRequests: [newer, older], liveCallsigns: [], nowMs: NOW, perTickCap: 5 });
+    expect(r.toSpawn).toHaveLength(1);
+    expect(r.toSpawn[0].id).toBe('a');
+    expect(r.skipped.find(s => s.request.id === 'b').reason).toBe('duplicate_callsign');
+  });
+
+  it('caps the result at perTickCap, marking overflow cap_exceeded', () => {
+    const r = resolveSpawnDecisions({
+      pendingRequests: [req('a', 'Echo'), req('b', 'Bravo'), req('c', 'Delta')],
+      liveCallsigns: [], nowMs: NOW, perTickCap: 2,
+    });
+    expect(r.toSpawn).toHaveLength(2);
+    expect(r.skipped.filter(s => s.reason === 'cap_exceeded')).toHaveLength(1);
+  });
+
+  it('perTickCap=0 spawns nothing', () => {
+    const r = resolveSpawnDecisions({ pendingRequests: [req('a', 'Echo')], liveCallsigns: [], nowMs: NOW, perTickCap: 0 });
+    expect(r.toSpawn).toHaveLength(0);
+    expect(r.skipped[0].reason).toBe('cap_exceeded');
+  });
+});
+
+describe('runExecutor (FR-2, dry-run vs live)', () => {
+  it('DRY-RUN: never calls the spawner and never stamps fulfillment', async () => {
+    const spawner = vi.fn();
+    const stampFulfilled = vi.fn();
+    const r = await runExecutor({
+      pendingRequests: [req('a', 'Echo'), req('b', 'Bravo')],
+      liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+      live: false, spawner, stampFulfilled, prompt: 'PROMPT',
+    });
+    expect(spawner).not.toHaveBeenCalled();
+    expect(stampFulfilled).not.toHaveBeenCalled();
+    expect(r.dryRun).toBe(true);
+    expect(r.spawned).toBe(0);
+  });
+
+  it('LIVE: calls the spawner and stamps fulfillment for each toSpawn', async () => {
+    const spawner = vi.fn().mockResolvedValue(undefined);
+    const stampFulfilled = vi.fn().mockResolvedValue(undefined);
+    const r = await runExecutor({
+      pendingRequests: [req('a', 'Echo'), req('b', 'Bravo')],
+      liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+      live: true, spawner, stampFulfilled, prompt: 'PROMPT',
+    });
+    expect(spawner).toHaveBeenCalledTimes(2);
+    expect(stampFulfilled).toHaveBeenCalledTimes(2);
+    expect(r.spawned).toBe(2);
+    expect(r.errors).toBe(0);
+  });
+
+  it('LIVE: a spawner error leaves the row un-fulfilled (no false fulfillment)', async () => {
+    const spawner = vi.fn().mockRejectedValue(new Error('spawn boom'));
+    const stampFulfilled = vi.fn().mockResolvedValue(undefined);
+    const r = await runExecutor({
+      pendingRequests: [req('a', 'Echo')],
+      liveCallsigns: new Set(), nowMs: NOW, perTickCap: 5,
+      live: true, spawner, stampFulfilled, prompt: 'PROMPT',
+    });
+    expect(spawner).toHaveBeenCalledTimes(1);
+    expect(stampFulfilled).not.toHaveBeenCalled();
+    expect(r.spawned).toBe(0);
+    expect(r.errors).toBe(1);
+  });
+
+  it('LIVE: respects already-live dedup (does not spawn a live callsign)', async () => {
+    const spawner = vi.fn().mockResolvedValue(undefined);
+    const stampFulfilled = vi.fn().mockResolvedValue(undefined);
+    await runExecutor({
+      pendingRequests: [req('a', 'Echo')],
+      liveCallsigns: new Set(['Echo']), nowMs: NOW, perTickCap: 5,
+      live: true, spawner, stampFulfilled, prompt: 'PROMPT',
+    });
+    expect(spawner).not.toHaveBeenCalled();
+  });
+});
+
+describe('config + invocation helpers (FR-3)', () => {
+  it('isLiveEnabled is false unless the flag is exactly true', () => {
+    expect(isLiveEnabled({})).toBe(false);
+    expect(isLiveEnabled({ WORKER_SPAWN_EXECUTOR_LIVE: 'false' })).toBe(false);
+    expect(isLiveEnabled({ WORKER_SPAWN_EXECUTOR_LIVE: '1' })).toBe(false);
+    expect(isLiveEnabled({ WORKER_SPAWN_EXECUTOR_LIVE: 'true' })).toBe(true);
+    expect(isLiveEnabled({ WORKER_SPAWN_EXECUTOR_LIVE: 'TRUE' })).toBe(true);
+  });
+
+  it('resolvePerTickCap defaults to 2 and honors a valid override', () => {
+    expect(resolvePerTickCap({})).toBe(2);
+    expect(resolvePerTickCap({ WORKER_SPAWN_EXECUTOR_PER_TICK_CAP: '5' })).toBe(5);
+    expect(resolvePerTickCap({ WORKER_SPAWN_EXECUTOR_PER_TICK_CAP: '0' })).toBe(0);
+    expect(resolvePerTickCap({ WORKER_SPAWN_EXECUTOR_PER_TICK_CAP: 'x' })).toBe(2);
+  });
+
+  it('buildSpawnInvocation returns a structured command without executing it', () => {
+    const inv = buildSpawnInvocation('Echo', 'PROMPT');
+    expect(inv.program).toBe('claude');
+    expect(Array.isArray(inv.args)).toBe(true);
+    expect(inv.args).toContain('PROMPT');
+    expect(inv.env.FLEET_WORKER_CALLSIGN).toBe('Echo');
+  });
+});


### PR DESCRIPTION
## Summary
`coordinator-revive.cjs` **wrote** `worker_spawn_requests` but **nothing consumed them**, so worker revival was inert (`fulfilled_at` stayed NULL) — a usage-limit outage that killed a worker's re-arming `/loop` turn left it dead with no external restart (the coordinator + Adam survive because they revive from external durable schedulers). This builds the missing consumer.

## Staged for safety — inert by default
The live deliverable spawns OS processes (fresh background `claude` workers) — high blast radius (duplicate/runaway sessions burn the shared usage quota). So the real spawn is **DEFAULT-OFF** behind `WORKER_SPAWN_EXECUTOR_LIVE`:
- **FR-1** `lib/fleet/spawn-executor-core.cjs`: pure `resolveSpawnDecisions` (expiry / not-pending / already-live / duplicate-callsign / per-tick cap). No DB, no spawn, injected clock.
- **FR-2** `scripts/fleet/worker-spawn-executor.cjs`: consumer daemon. Flag unset (default) → **dry-run**: reads pending requests, logs the spawn it *would* run (reusing `FLEET_WORKER_STARTUP_PROMPT`), launches **nothing**, leaves rows pending so the INERT detector keeps surfacing them. `runExecutor` takes an injected spawner + `stampFulfilled` (fully testable).
- **FR-3** `buildSpawnInvocation`: structured host command, executed only behind the flag.
- **FR-4** `tests/unit/fleet/worker-spawn-executor.test.js`: 12 tests.

## ⚠️ Operator-gated activation (Stage 2 — NOT enabled here)
Before flipping `WORKER_SPAWN_EXECUTOR_LIVE=true`, an operator must **host-validate** the `claude` background-launch command in `buildSpawnInvocation()` AND register the external scheduler (Windows Task / cron) that runs this daemon. Those are the keystone's activation and are intentionally out of scope.

## Verification
12/12 unit tests pass; dry-run smoke confirms zero blast radius (`dryRun=true spawned=0`, no process launched). `node --check` clean on both new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)