### PR TITLE
fix(SD-REFILL-00VDVRYM): reconcile enforce_is_working_on_for_handoffs() repo migration to live SSOT

### DIFF
--- a/database/migrations/20260623_reconcile_enforce_is_working_on_ssot.sql
+++ b/database/migrations/20260623_reconcile_enforce_is_working_on_ssot.sql
@@ -1,0 +1,91 @@
+-- Migration: Reconcile enforce_is_working_on_for_handoffs() to the handoff_actor_policy() SSOT
+-- Date: 2026-06-23
+-- SD: SD-REFILL-00VDVRYM
+-- Purpose: REPO<->LIVE DRIFT FIX. The historical migration
+--   database/migrations/20260213_enforce_is_working_on_handoffs.sql defined this trigger with an
+--   INLINE actor-bypass list (NEW.created_by IN ('SYSTEM_MIGRATION','ADMIN_OVERRIDE',
+--   'ORCHESTRATOR_GUARDIAN','bypass_script','SYSTEM_AUTO_COMPLETE')). The LIVE function was later
+--   changed (UNIFIED-HANDOFF-SYSTEM) to delegate the trusted-actor skip to the handoff_actor_policy()
+--   SSOT. The repo file no longer matched live, so a future migration regenerated from the repo would
+--   have CLOBBERED the live SSOT delegation on a critical claim-enforcement trigger.
+--
+--   ⚠️ SSOT-MANAGED — DO NOT REGENERATE INLINE. The trusted-actor skip MUST come from
+--   handoff_actor_policy(NEW.created_by).skips_claim_check (the single source of truth shared with
+--   enforce_handoff_system). Never reintroduce a hardcoded `NEW.created_by IN (...)` actor list here.
+--   Guarded by tests/unit/migration-ssot-delegation-guard.test.js.
+--
+-- This is a behavior-preserving reconciliation: the body below is byte-equivalent in behavior to the
+-- current LIVE function (verified via pg_get_functiondef). Applying it is idempotent against live.
+
+CREATE OR REPLACE FUNCTION enforce_is_working_on_for_handoffs()
+RETURNS TRIGGER
+SET search_path TO 'public', 'extensions'
+AS $$
+DECLARE
+  v_is_working_on BOOLEAN;
+  v_sd_title TEXT;
+  v_bypass_value TEXT;
+BEGIN
+  -- Check session variable bypass (for admin scripts)
+  BEGIN
+    v_bypass_value := current_setting('leo.bypass_working_on_check', true);
+    IF v_bypass_value = 'true' THEN
+      RETURN NEW;
+    END IF;
+  EXCEPTION WHEN OTHERS THEN
+    NULL; -- Setting doesn't exist, continue with check
+  END;
+
+  -- SSOT: trusted system actors skip the claim check (single source of truth,
+  -- shared with enforce_handoff_system via handoff_actor_policy()).
+  IF (SELECT skips_claim_check FROM public.handoff_actor_policy(NEW.created_by)) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Allow failure/rejection documentation without claim
+  IF NEW.status IN ('rejected', 'error') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Look up is_working_on for the SD
+  SELECT is_working_on, title
+  INTO v_is_working_on, v_sd_title
+  FROM strategic_directives_v2
+  WHERE id = NEW.sd_id;
+
+  -- SD not found — let the FK constraint handle it
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  -- Enforce: is_working_on must be true
+  IF v_is_working_on IS NOT TRUE THEN
+    RAISE EXCEPTION
+      E'LEO Protocol Violation: Cannot create handoff for SD without active session claim\n\n'
+      'SD: % (%)\n'
+      'Handoff: %\n'
+      'is_working_on: %\n\n'
+      'ACTION REQUIRED:\n'
+      '1. Claim the SD first: npm run sd:start %\n'
+      '2. Or use created_by=''ADMIN_OVERRIDE'' for administrative operations\n'
+      '3. Or SET LOCAL leo.bypass_working_on_check = ''true'' in a transaction',
+      NEW.sd_id, COALESCE(v_sd_title, 'Unknown'),
+      NEW.handoff_type,
+      COALESCE(v_is_working_on::text, 'NULL'),
+      NEW.sd_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- The trigger binding is unchanged (defined in 20260213); re-assert idempotently for clarity.
+DROP TRIGGER IF EXISTS trg_enforce_is_working_on_handoffs ON sd_phase_handoffs;
+CREATE TRIGGER trg_enforce_is_working_on_handoffs
+  BEFORE INSERT ON sd_phase_handoffs
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_is_working_on_for_handoffs();
+
+-- Reconcile the function comment: trusted-actor skip is sourced from the SSOT, NOT a hardcoded list.
+COMMENT ON FUNCTION enforce_is_working_on_for_handoffs() IS
+  'Blocks handoff inserts when SD is_working_on=false. Trusted-actor skip is sourced from the handoff_actor_policy() SSOT (NOT a hardcoded created_by list) — shared with enforce_handoff_system. Also bypassed by rejected/error status, or SET LOCAL leo.bypass_working_on_check=true. SSOT-managed: do not regenerate with an inline created_by IN (...) actor list (SD-REFILL-00VDVRYM).';

--- a/tests/unit/migration-ssot-delegation-guard.test.js
+++ b/tests/unit/migration-ssot-delegation-guard.test.js
@@ -1,0 +1,65 @@
+/**
+ * SD-REFILL-00VDVRYM — guard against repo<->live drift on the enforce_is_working_on_for_handoffs()
+ * claim-enforcement trigger. The LIVE function delegates the trusted-actor skip to the
+ * handoff_actor_policy() SSOT; an older repo migration hardcoded an inline `created_by IN (...)`
+ * list. This test asserts the CANONICAL (latest) repo migration that (re)defines the function
+ * delegates to the SSOT and does NOT reintroduce the inline actor-bypass — so a future inline
+ * regeneration that would clobber the live SSOT is caught in CI before it merges.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const fs = require('fs');
+const path = require('path');
+
+const FUNC = 'enforce_is_working_on_for_handoffs';
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../database/migrations');
+
+/** All migration files that CREATE OR REPLACE the target function, sorted by filename (date prefix). */
+function migrationsDefiningFunc() {
+  const files = fs.readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'));
+  const defs = [];
+  for (const f of files) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, f), 'utf8');
+    if (new RegExp(`CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+${FUNC}\\b`, 'i').test(sql)) {
+      defs.push({ file: f, sql });
+    }
+  }
+  defs.sort((a, b) => a.file.localeCompare(b.file));
+  return defs;
+}
+
+/** The function-body slice of a migration (so trigger/comment text doesn't skew the inline-list check). */
+function funcBody(sql) {
+  const start = sql.search(new RegExp(`CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+${FUNC}\\b`, 'i'));
+  if (start < 0) return '';
+  // up to LANGUAGE plpgsql (end of the function definition)
+  const rest = sql.slice(start);
+  const end = rest.search(/LANGUAGE\s+plpgsql/i);
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
+describe('SD-REFILL-00VDVRYM: enforce_is_working_on_for_handoffs SSOT delegation guard', () => {
+  it('at least one migration defines the function', () => {
+    expect(migrationsDefiningFunc().length).toBeGreaterThan(0);
+  });
+
+  it('the CANONICAL (latest) migration delegates the actor-skip to handoff_actor_policy()', () => {
+    const defs = migrationsDefiningFunc();
+    const canonical = defs[defs.length - 1];
+    expect(canonical.sql).toMatch(/handoff_actor_policy\s*\(/i);
+  });
+
+  it('the CANONICAL migration body does NOT reintroduce the inline created_by IN (...) actor-bypass', () => {
+    const defs = migrationsDefiningFunc();
+    const body = funcBody(defs[defs.length - 1].sql);
+    // The drift landmine: a hardcoded actor list standing in for the SSOT skip.
+    expect(body).not.toMatch(/NEW\.created_by\s+IN\s*\(/i);
+  });
+
+  it('the CANONICAL migration preserves the session-var bypass and is_working_on enforcement', () => {
+    const body = funcBody(migrationsDefiningFunc().slice(-1)[0].sql);
+    expect(body).toMatch(/leo\.bypass_working_on_check/);
+    expect(body).toMatch(/is_working_on/i);
+  });
+});


### PR DESCRIPTION
## Summary
Repo↔live **drift** on a critical claim-enforcement trigger. The historical migration `20260213_enforce_is_working_on_handoffs.sql` defined `enforce_is_working_on_for_handoffs()` with an **inline** actor-bypass list (`NEW.created_by IN ('SYSTEM_MIGRATION','ADMIN_OVERRIDE','ORCHESTRATOR_GUARDIAN','bypass_script','SYSTEM_AUTO_COMPLETE')`). The **live** function was later changed (UNIFIED-HANDOFF-SYSTEM) to delegate the trusted-actor skip to the `handoff_actor_policy()` SSOT (verified via `pg_get_functiondef`). A future migration regenerated from the repo file would have **clobbered** the live SSOT delegation, silently reverting `skips_claim_check` semantics.

Surfaced as a Bravo RCA-incidental from SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001 (that SD shipped fine; this is the separate hygiene/drift finding).

## Changes
- **FR-1** `database/migrations/20260623_reconcile_enforce_is_working_on_ssot.sql`: forward (append-only) migration that `CREATE OR REPLACE`s the function with the **exact live SSOT-delegating body** (`handoff_actor_policy(NEW.created_by).skips_claim_check`), preserving the session-var bypass / rejected-error pass / `is_working_on` enforcement. **Behavior-preserving + idempotent** against live (repo-hygiene only — live is already correct). The historical migration is left unchanged.
- **FR-2** `tests/unit/migration-ssot-delegation-guard.test.js`: finds the canonical (latest) migration defining the function and asserts it delegates to `handoff_actor_policy` **and** omits the inline `created_by IN (...)` actor-bypass — so a future inline regen is caught in CI before it clobbers live.
- **FR-3** the migration re-sets `COMMENT ON FUNCTION` to name `handoff_actor_policy()` as the trusted-actor SSOT (the old comment enumerated the stale inline list).

## Verification
4/4 guard tests pass. No live behavior change. TESTING sub-agent verdict PASS (row `c56a9aaa`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)