### PR TITLE
feat(SD-REFILL-00229BH8): lead sourced-SD description with the objective, not provenance

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2345,7 +2345,13 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
     title: normalized.title,
     type: normalized.type,
     priority: normalized.priority,
-    description: proposal.rationale || proposal.scope || proposal.title,
+    // SD-REFILL-00229BH8: lead the DESCRIPTION with the OBJECTIVE (scope), not the rationale.
+    // proposal.rationale frequently carries provenance boilerplate ("Materialized from coordinator
+    // proposal (idle-fleet vision-aligned design work)") whose purpose is the LEAD evaluator, NOT a
+    // description — when it led the description, the substantive ~1500ch scope was buried and workers
+    // mis-flagged the SD as an 8-word stub. scope (the objective) is preferred; rationale is the
+    // fallback only when scope is absent. Provenance still lives in `rationale` + metadata below.
+    description: proposal.scope || proposal.rationale || proposal.title,
     // Sibling parity: UAT/learn/feedback/QF/plan/child all set an explicit rationale
     // (used by the LEAD evaluator). Fall back to a provenance line when absent.
     rationale: proposal.rationale || `Materialized from proposal ${filePath || 'unknown'}`,

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -131,9 +131,29 @@ describe('mapProposalToCreateArgs (pure field mapping)', () => {
     expect(args.success_criteria).toEqual(['criterion a']);
   });
 
-  it('description falls back rationale -> scope -> title', () => {
-    expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined }), 'p.json').description).toBe('DOES: x. DOES NOT: y.');
-    expect(mapProposalToCreateArgs(normalized, validProposal({ rationale: undefined, scope: undefined }), 'p.json').description).toBe('Example proposal');
+  // SD-REFILL-00229BH8: description LEADS with the OBJECTIVE (scope), falling back scope -> rationale -> title.
+  it('description prefers scope (objective), then rationale, then title', () => {
+    // scope present → description is the scope (the objective), even when a rationale exists
+    expect(mapProposalToCreateArgs(normalized, validProposal(), 'p.json').description).toBe('DOES: x. DOES NOT: y.');
+    // no scope → falls back to rationale
+    expect(mapProposalToCreateArgs(normalized, validProposal({ scope: undefined }), 'p.json').description).toBe('because the belt needs refilling');
+    // neither scope nor rationale → title
+    expect(mapProposalToCreateArgs(normalized, validProposal({ scope: undefined, rationale: undefined }), 'p.json').description).toBe('Example proposal');
+  });
+
+  // SD-REFILL-00229BH8 (regression): the witnessed bug — a proposal whose rationale is PROVENANCE
+  // boilerplate must NOT lead the description with it; the substantive scope wins. Provenance is
+  // preserved only in the rationale field (for the LEAD evaluator), never as the description.
+  it('provenance-boilerplate rationale does NOT bury the scope in the description', () => {
+    const p = validProposal({
+      rationale: 'Materialized from coordinator proposal (idle-fleet vision-aligned design work).',
+      scope: 'Produce a reviewable Phase-0 design spec for the operator-cockpit distance-to-quit gauge.',
+    });
+    const args = mapProposalToCreateArgs(normalized, p, 'p.json');
+    expect(args.description).toBe('Produce a reviewable Phase-0 design spec for the operator-cockpit distance-to-quit gauge.');
+    expect(args.description).not.toContain('Materialized from coordinator proposal');
+    // provenance is still retained in the rationale field (sibling parity / LEAD evaluator)
+    expect(args.rationale).toBe('Materialized from coordinator proposal (idle-fleet vision-aligned design work).');
   });
 
   it('sets a rationale (sibling parity): proposal rationale, else a provenance fallback', () => {


### PR DESCRIPTION
## Summary
`mapProposalToCreateArgs` set the sourced-SD `description` to `rationale || scope || title`. For coordinator-sourced proposals `rationale` is often provenance boilerplate ("Materialized from coordinator proposal (idle-fleet vision-aligned design work)"), so the description led with provenance and buried the substantive ~1500ch scope — workers mis-flagged buildable sourced design SDs (DTQ/VENTPERF Phase-0) as 8-word stubs.

**Fix (FR-1):** prefer scope (the objective): `description: proposal.scope || proposal.rationale || proposal.title`. Provenance stays in the `rationale` field + `metadata.proposal_provenance`.

## Verification
- 1-line code change + 1 updated test + 1 new provenance-boilerplate regression test
- `tests/unit/leo-create-sd-from-proposal.test.js`: **42/42 green**; TESTING sub-agent PASS-100
- No regression for proposals without scope (fall through to rationale)

## Scope
FR-2 of the source signal (coordinator verifies actual SD content vs the sourcing agent's self-report before ranking) is a separate ranking locus — **descoped to a follow-up**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)