### PR TITLE
fix(SD-REFILL-00SLQCLH): exclude Claude Code release changelogs from the idea estate drain

### DIFF
--- a/lib/intake/estate-disposition-helpers.js
+++ b/lib/intake/estate-disposition-helpers.js
@@ -13,6 +13,16 @@ export function estateAlreadyDrained(row) {
   return !!(rd && typeof rd === 'object' && rd.conversion_ledger_id);
 }
 
+/**
+ * SD-REFILL-00SLQCLH: an eva_claude_code_intake row that carries a github_release_id is a Claude Code
+ * RELEASE CHANGELOG (titles like v2.1.123 with 'What changed' notes), NOT an idea. The estate drain
+ * routed these into the idea estate (conversion_ledger source_pool=estate_corpus), polluting the
+ * gauge/estate-driven backlog with 20 tool-changelog rows. Exclude them from the drain. PURE/total.
+ */
+export function isToolChangelogIntakeRow(row) {
+  return row != null && row.github_release_id != null;
+}
+
 /** Todoist priority (4=urgent … 1=normal) → normalized_priority text. */
 export function todoistPriorityToText(p) {
   const n = Number(p);

--- a/scripts/intake/drain-intake.mjs
+++ b/scripts/intake/drain-intake.mjs
@@ -28,7 +28,7 @@ import { registerItem, setDisposition, recordVerdict, backlogDepth } from '../..
 // SD-LEO-INFRA-ESTATE-DISPOSITION-001 (FR-2): pure 0-3 compounding score captured at disposition time.
 import { computeCompoundingScore } from '../../lib/intake/compounding-score.js';
 // SD-LEO-INFRA-ESTATE-DISPOSITION-001: pure, unit-tested estate-disposition helpers.
-import { estateAlreadyDrained, todoistPriorityToText, classifyEstateItem, buildEstateMarkOff } from '../../lib/intake/estate-disposition-helpers.js';
+import { estateAlreadyDrained, todoistPriorityToText, classifyEstateItem, buildEstateMarkOff, isToolChangelogIntakeRow } from '../../lib/intake/estate-disposition-helpers.js';
 
 const APPLY = process.argv.includes('--apply');
 const DRY_RUN = !APPLY; // dry-run is the default
@@ -153,6 +153,9 @@ const ESTATE_SOURCES = [
     map: (r) => ({ source_external_id: r.youtube_video_id || null, normalized_priority: normalizePriorityScore(r.confidence_score) }) },
   { table: 'eva_claude_code_intake', pool: 'estate_corpus',
     select: 'id, title, description, relevance_score, github_release_id, status, raw_data, created_at',
+    // SD-REFILL-00SLQCLH: release-changelog rows (github_release_id set, titles v2.1.x) are tool
+    // changelogs, NOT ideas — exclude them so they never reach the idea estate (estate_corpus).
+    exclude: isToolChangelogIntakeRow,
     map: (r) => ({ source_external_id: r.github_release_id ? String(r.github_release_id) : null, normalized_priority: normalizePriorityScore(r.relevance_score) }) },
 ];
 
@@ -163,6 +166,9 @@ async function loadEstate(sb, src) {
   if (error) throw new Error(`loadEstate(${src.table}): ${error.message}`);
   return (data || [])
     .filter((r) => !estateAlreadyDrained(r))
+    // SD-REFILL-00SLQCLH: per-source exclude predicate (e.g. tool-changelog releases) — drops the row
+    // from the drain entirely so it never registers in the conversion ledger as an idea.
+    .filter((r) => !(typeof src.exclude === 'function' && src.exclude(r)))
     .map((r) => ({
       source_pool: src.pool,
       source_id: r.id,

--- a/tests/unit/intake/estate-disposition.test.js
+++ b/tests/unit/intake/estate-disposition.test.js
@@ -10,6 +10,7 @@ import {
   classifyEstateItem,
   buildEstateMarkOff,
   isEstateIdeaShipped,
+  isToolChangelogIntakeRow,
 } from '../../../lib/intake/estate-disposition-helpers.js';
 
 describe('computeCompoundingScore — 0-3, deterministic, varies by signal (FR-2)', () => {
@@ -103,5 +104,23 @@ describe('todoistPriorityToText', () => {
     expect(todoistPriorityToText(2)).toBe('medium');
     expect(todoistPriorityToText(1)).toBe('low');
     expect(todoistPriorityToText(null)).toBe('low');
+  });
+});
+
+describe('isToolChangelogIntakeRow — exclude tool changelogs from the idea estate (SD-REFILL-00SLQCLH)', () => {
+  it('flags an eva_claude_code_intake row that carries a github_release_id (a release changelog)', () => {
+    expect(isToolChangelogIntakeRow({ title: 'v2.1.123', github_release_id: 188044299 })).toBe(true);
+    expect(isToolChangelogIntakeRow({ github_release_id: '188044299' })).toBe(true);
+  });
+
+  it('does NOT flag a genuine idea row (no github_release_id)', () => {
+    expect(isToolChangelogIntakeRow({ title: 'Add a fleet dashboard', github_release_id: null })).toBe(false);
+    expect(isToolChangelogIntakeRow({ title: 'Improve sourcing dedup' })).toBe(false);
+  });
+
+  it('is total on odd input', () => {
+    expect(isToolChangelogIntakeRow(null)).toBe(false);
+    expect(isToolChangelogIntakeRow(undefined)).toBe(false);
+    expect(isToolChangelogIntakeRow({})).toBe(false);
   });
 });


### PR DESCRIPTION
## SD-REFILL-00SLQCLH

The estate drain (`drain-intake.mjs` `eva_claude_code_intake` → `estate_corpus`) routed **all** `eva_claude_code_intake` rows into `conversion_ledger` as ideas — including 20 Claude Code **release changelog** rows (`github_release_id` set, titles v2.1.100..v2.1.126). These are tool changelogs, not ideas, and polluted the gauge/estate-driven backlog.

### Fix
- Pure `isToolChangelogIntakeRow(r)` (`github_release_id != null`) in the unit-tested estate-disposition-helpers.
- Wired as a per-source `exclude` on the `eva_claude_code_intake` config; `loadEstate` drops excluded rows before they register in the ledger.
- Forward-fix: future/re-drained changelog rows never reach the idea estate (existing 20 are already-drained + now excluded).

### Tests
- 3 new unit tests (estate-disposition suite **15/15**); drain dry-run confirms **0** `estate_corpus` changelog noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)