### PR TITLE
fix(SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001): exclude post-completion-tail workers from detectStalledLoop

### DIFF
--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -276,6 +276,20 @@ const LOOP_ACTIVE_STATES = Object.freeze(['active', 'awaiting_tick']);
 const DEFAULT_LOOP_EXPIRY_WARN_MS = 6 * 24 * 60 * 60 * 1000;
 /** Default STALLED_LOOP freshness window (ms): a heartbeat within 10 min "looks alive". */
 const DEFAULT_STALLED_LOOP_FRESH_MS = 10 * 60 * 1000;
+/**
+ * SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001: a worker that JUST shipped an SD releases its
+ * claim (released_reason='completed') but keeps running its post-completion tail
+ * (document/heal/learn/capture-flags) with loop_state still 'active' and a fresh heartbeat. That is
+ * legitimately FINISHING a just-shipped SD, NOT a parked stall. Exclude it for a short grace window
+ * after the release (matches the fresh-heartbeat window). A worker still claimless past the grace is
+ * re-flagged on the next sweep, so genuine post-completion stalls are not masked.
+ */
+const DEFAULT_COMPLETION_GRACE_MS = 10 * 60 * 1000;
+const COMPLETION_RELEASE_REASONS = Object.freeze(['completed', 'qf_completed']);
+/** True when a release reason denotes a real SD/QF completion (case-insensitive). */
+function isCompletionRelease(reason) {
+  return typeof reason === 'string' && COMPLETION_RELEASE_REASONS.includes(reason.trim().toLowerCase());
+}
 
 /**
  * LOOP_EXPIRY_WARNING — a /loop session (worker or coordinator cron) approaching the verified
@@ -322,12 +336,16 @@ function detectLoopExpiry(data, opts) {
  * no-claim sessions). PURE — no I/O. Fail-open: skips sessions with no usable heartbeat; never
  * throws. Excludes legitimately-parked sessions: loop_state 'awaiting_tick' is not flagged, and a
  * future-dated expected_silence_until suppresses the flag (no false-positive on parked workers).
- * @param {{ sessions?: Array, unclaimedItems?: number, now?: number, freshMs?: number }} data
+ * Also excludes a worker in its POST-COMPLETION TAIL (released_reason='completed'/'qf_completed' with
+ * a released_at inside the completion-grace window) — it shipped an SD and is legitimately running
+ * document/heal/learn/capture-flags, not stalled (SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001).
+ * @param {{ sessions?: Array, unclaimedItems?: number, now?: number, freshMs?: number, completionGraceMs?: number }} data
  * @returns {{ matched: boolean, reason: string, evidence: object }}
  */
 function detectStalledLoop(data) {
   const now = (data && data.now) ?? Date.now();
   const freshMs = (data && data.freshMs) ?? DEFAULT_STALLED_LOOP_FRESH_MS;
+  const graceMs = (data && data.completionGraceMs) ?? DEFAULT_COMPLETION_GRACE_MS;
   const unclaimed = Number((data && data.unclaimedItems) ?? 0);
   if (unclaimed <= 0) {
     return { matched: false, reason: 'no_unclaimed_work', evidence: { unclaimed_items: unclaimed } };
@@ -336,6 +354,15 @@ function detectStalledLoop(data) {
   for (const s of ((data && data.sessions) || [])) {
     if (!s || s.loop_state !== 'active') continue;       // only actively-looping (parked awaiting_tick excluded)
     if (s.sd_key) continue;                               // holds a claim → not stalled (detectStuckWorker covers it)
+    // SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001: a just-shipped worker running its
+    // post-completion tail (claim released_reason='completed', loop_state still 'active', fresh hb,
+    // belt deep) is FINISHING, not stalled — exclude within the grace window after release. Fail-open:
+    // a completion release with no usable released_at is NOT excluded (still flagged), and a release
+    // older than graceMs is still flagged, so genuine post-completion stalls are not masked.
+    if (isCompletionRelease(s.released_reason)) {
+      const releasedAtMs = toMs(s.released_at);
+      if (releasedAtMs && (now - releasedAtMs) <= graceMs) continue;
+    }
     const silenceUntil = toMs(s.expected_silence_until);
     if (silenceUntil && silenceUntil > now) continue;     // legitimately parked with a future silence window
     const hbMs = toMs(s.heartbeat_at);

--- a/scripts/coordinator-audit.mjs
+++ b/scripts/coordinator-audit.mjs
@@ -68,7 +68,9 @@ const stuck = unclaimed.filter(s => s.status === 'in_progress');
 // audit's FLOW/LIVENESS gauges stop over-counting Adam / non_fleet / released / never-claimed
 // (ghost) sessions. Previously this only excluded `me` and any heartbeat <15m.
 // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: + created_at, expected_silence_until for the loop-liveness gauges.
-const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state,status,metadata,claimed_at,worktree_path,continuous_sds_completed,created_at,expected_silence_until').order('heartbeat_at', { ascending: false }).limit(60);
+// SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001: + released_reason,released_at so detectStalledLoop
+// can exclude a worker running its post-completion tail (replicate the detector input-column contract).
+const { data: sessRaw } = await db.from('claude_sessions').select('session_id,heartbeat_at,sd_key,loop_state,status,metadata,claimed_at,worktree_path,continuous_sds_completed,created_at,expected_silence_until,released_reason,released_at').order('heartbeat_at', { ascending: false }).limit(60);
 const live = liveFleetWorkers(sessRaw, me, t);
 const builders = live.filter(s => s.sd_key).length;
 const liveIdle = live.filter(s => !s.sd_key).length;

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -134,7 +134,10 @@ async function main() {
       // SD-FDBK-INFRA-STALL-AFTER-COMPLETION-001: + process_alive_at — the authoritative tick-liveness
       // signal (written every 30s by the detached session-tick). detectMaskedStall uses it to tell a
       // CONFIRMED dead loop (live parent / fresh heartbeat but dead tick) from a momentarily-idle one.
-      .select('session_id, terminal_id, sd_key, heartbeat_at, process_alive_at, loop_state, expected_silence_until, metadata, status')
+      // SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001: + released_reason,released_at so detectStalledLoop
+      // excludes a worker running its post-completion tail (else the per-session stalled mark over-escalates
+      // a fleet-down false alarm to the operator). Replicate the detector input-column contract.
+      .select('session_id, terminal_id, sd_key, heartbeat_at, process_alive_at, loop_state, expected_silence_until, metadata, status, released_reason, released_at')
       .gte('heartbeat_at', liveCutoff),
     sb.from('strategic_directives_v2')
       // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + metadata (is_fixture marker) and

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -157,6 +157,28 @@ describe('detectStalledLoop', () => {
     ];
     expect(detectStalledLoop({ sessions, unclaimedItems: 5, now: NOW }).matched).toBe(false);
   });
+
+  // SD-LEO-INFRA-STALLED-POSTCOMPLETION-TAIL-FP-001: post-completion-tail exclusion
+  it('excludes a worker running its post-completion tail (completed + recent released_at)', () => {
+    const tail = { ...stalled, session_id: 'tail', released_reason: 'completed', released_at: minsAgo(3) };
+    expect(detectStalledLoop({ sessions: [tail], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('excludes a qf_completed tail within the grace window', () => {
+    const tail = { ...stalled, session_id: 'qf-tail', released_reason: 'QF_COMPLETED', released_at: minsAgo(1) };
+    expect(detectStalledLoop({ sessions: [tail], unclaimedItems: 5, now: NOW }).matched).toBe(false);
+  });
+  it('STILL flags a completion release with no released_at (fail-open, no mask)', () => {
+    const noTs = { ...stalled, session_id: 'no-ts', released_reason: 'completed', released_at: null };
+    expect(detectStalledLoop({ sessions: [noTs], unclaimedItems: 5, now: NOW }).matched).toBe(true);
+  });
+  it('STILL flags when released_at is older than the grace window', () => {
+    const old = { ...stalled, session_id: 'old-rel', released_reason: 'completed', released_at: minsAgo(20) };
+    expect(detectStalledLoop({ sessions: [old], unclaimedItems: 5, now: NOW }).matched).toBe(true);
+  });
+  it('STILL flags a non-completion release (e.g. stale_cleanup) with a recent released_at', () => {
+    const other = { ...stalled, session_id: 'other-rel', released_reason: 'stale_cleanup', released_at: minsAgo(2) };
+    expect(detectStalledLoop({ sessions: [other], unclaimedItems: 5, now: NOW }).matched).toBe(true);
+  });
 });
 
 describe('stalledLoopSessionIds (SD-LEO-FEAT-COORDINATOR-CAPACITY-FORECAST-001)', () => {


### PR DESCRIPTION
## Summary
`detectStalledLoop` flagged a session STALLED on five conditions (`loop_state=active`, no claim, fresh heartbeat, no future `expected_silence_until`, belt has claimable work). A worker in its **post-completion tail** (document/heal/learn/capture-flags after LEAD-FINAL-APPROVAL) meets all five — it released the completed claim (`released_reason=completed`) but is legitimately *finishing* a just-shipped SD, not stalled.

**Witnessed 2026-06-23**: worker Alpha flagged STALLED 3 min into its tail, which drove the capacity-forecast to over-escalate a **fleet-down false alarm to the operator overnight** (a false wake-up for a sleeping chairman). The coordinator caught it manually, but the detector would keep mis-firing every time a worker ships and runs its tail.

## Changes
- **FR-1** completion-grace exclusion in the pure `detectStalledLoop` (`lib/coordinator/detectors.cjs`): skip a session whose `released_reason` is a completion (`completed`/`qf_completed`) and whose `released_at` is within `DEFAULT_COMPLETION_GRACE_MS` (~10min). **Fail-open / no-mask**: a completion release with no `released_at` is still flagged, and a release older than the grace is still flagged — genuine post-completion stalls aren't masked. `now`/`graceMs` injected (stays pure); `stalledLoopSessionIds` inherits the fix.
- **FR-2** add `released_reason`+`released_at` to the `claude_sessions` selects in `coordinator-audit.mjs` and `coordinator-capacity-forecast.mjs` (replicate the detector input-column contract; `liveFleetWorkers` is a pure filter that preserves the fields) — else the exclusion is silently inert.
- **FR-3** 5 new tests (tail excluded; `qf_completed` excluded; missing `released_at` still flagged; stale `released_at` still flagged; non-completion release still flagged).

## Verification
38/38 tests pass (5 new + no regression). `node --check` clean on all 3 touched non-test files. TESTING sub-agent verdict PASS (row `187ba79a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)