### PR TITLE
fix(SD-REFILL-00RMNAS7): trust terminal SD status as authoritative ship-evidence in the reaper

### DIFF
--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -411,8 +411,21 @@ function decideShippedStaleAction(wt, shipped, ctx) {
     };
   }
   // git cherry "absorbed" with zero merged PRs is known-unreliable under
-  // squash merges — advisory-only, never stage1 authority on its own.
+  // squash merges — advisory-only, never stage1 authority on its own…
   if ((shipped?.evidence?.merged_pr_count ?? 0) === 0) {
+    // …EXCEPT when the SD/QF is TERMINAL in the DB (completed/cancelled/archived). That is
+    // AUTHORITATIVE ship-evidence — in LEO, status=completed implies the PR merged — so it overrides
+    // the unreliable cherry heuristic. Without this, squash-merged completed worktrees were kept
+    // advisory-only and ACCUMULATED toward the DUTY-1 pool stall (live 2026-06-15: 16/20 with 4
+    // completed SDs held as keep/no_match). The claim-held / non-terminal / active guards above ran
+    // first (terminalSet ⟂ activeSet), so a terminal key reaching here holds NO active claim.
+    // SD-REFILL-00RMNAS7.
+    const isTerminalShipped = isQf
+      ? Boolean(ctx.terminalQfSet && ctx.terminalQfSet.has(key))
+      : Boolean(ctx.terminalSdSet && ctx.terminalSdSet.has(key));
+    if (isTerminalShipped) {
+      return { protect: false, advisory: false, key, reason: 'terminal-status authoritative ship-evidence (completion implies merge; cherry-heuristic overridden)' };
+    }
     return { protect: false, advisory: true, key, reason: 'absorbed_no_pr cherry heuristic is advisory-only (unreliable under squash merges)' };
   }
   return { protect: false, advisory: false, key, reason: 'merged-pr-backed' };

--- a/tests/unit/worktree-reaper-live-claim-guard.test.js
+++ b/tests/unit/worktree-reaper-live-claim-guard.test.js
@@ -77,4 +77,37 @@ describe('decideShippedStaleAction (stage1 authority)', () => {
     const wt = { path: 'C:/r/.worktrees/qf/QF-20260612-999', branch: 'qf/QF-20260612-999' };
     expect(decideShippedStaleAction(wt, shippedWithPr, ctx).protect).toBe(true);
   });
+
+  // SD-REFILL-00RMNAS7: a TERMINAL-status SD under SQUASH merge (absorbed_no_pr, merged_pr_count=0)
+  // is now an AUTHORITATIVE stage1 reclaim (DB status overrides the unreliable cherry heuristic),
+  // instead of being kept advisory-only and accumulating toward the DUTY-1 pool stall.
+  it('terminal SD with absorbed_no_pr (squash merge) is now stage1, NOT advisory', () => {
+    const ctx = ctxWith({ sdMap: new Set(['SD-DONE-001']), terminalSdSet: new Set(['SD-DONE-001']) });
+    const wt = { path: 'C:/r/.worktrees/SD-DONE-001', branch: 'feat/SD-DONE-001' };
+    const a = decideShippedStaleAction(wt, shippedNoPr, ctx);
+    expect(a.protect).toBe(false);
+    expect(a.advisory).toBe(false);
+    expect(a.reason).toMatch(/terminal-status authoritative/);
+  });
+
+  it('terminal QF with absorbed_no_pr (squash merge) is also stage1', () => {
+    const ctx = ctxWith({ qfMap: new Set(['QF-20260612-777']), terminalQfSet: new Set(['QF-20260612-777']) });
+    const wt = { path: 'C:/r/.worktrees/qf/QF-20260612-777', branch: 'qf/QF-20260612-777' };
+    const a = decideShippedStaleAction(wt, shippedNoPr, ctx);
+    expect(a.protect).toBe(false);
+    expect(a.advisory).toBe(false);
+    expect(a.reason).toMatch(/terminal-status authoritative/);
+  });
+
+  it('SAFETY: a claim-held terminal SD is STILL protected (claim guard wins over terminal reclaim)', () => {
+    const ctx = ctxWith({
+      claimedKeySet: new Set(['SD-DONE-002']),
+      sdMap: new Set(['SD-DONE-002']),
+      terminalSdSet: new Set(['SD-DONE-002']),
+    });
+    const wt = { path: 'C:/r/.worktrees/SD-DONE-002', branch: 'feat/SD-DONE-002' };
+    const a = decideShippedStaleAction(wt, shippedNoPr, ctx);
+    expect(a.protect).toBe(true);
+    expect(a.reason).toBe('claim-held');
+  });
 });


### PR DESCRIPTION
## SD-REFILL-00RMNAS7

`worktree-reaper.mjs` did **not** reclaim `status=completed` SD worktrees under **squash** merges: the git-cherry shipped-stale match self-labels `absorbed_no_pr` (advisory-only, unreliable under squash), so completed worktrees were kept (`keep/no_match`) and **accumulated** toward the DUTY-1 20/20 pool stall (live 2026-06-15: 16/20 with 4 completed SDs held). The Stage-0 terminal reclaim existed but is **opt-in** (`--stage0`), so the routine run never caught them.

### Fix
- In `decideShippedStaleAction`, inside the `absorbed_no_pr` branch, **upgrade a terminal SD/QF (completed/cancelled/archived) to a stage1 reclaim** — DB completion is authoritative ship-evidence (completion ⇒ merged in LEO), overriding the unreliable cherry heuristic.
- **Surgical + safe**: the claim-held / non-terminal / active guards run **first** (terminalSet ⟂ activeSet), so a live/claimed worktree is never removed; `merged-pr-backed` is unchanged.

### Tests
- 3 new regression tests incl. a **claim-held-terminal SAFETY pin**; claim-guard suite 11/11; reaper-pools + active-sd guards 25/25 (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)