### PR TITLE
feat(SD-REFILL-00306WTS): exclude un-actionable venture remediation SDs from belt depth

### DIFF
--- a/lib/coordinator/sd-exclusion.mjs
+++ b/lib/coordinator/sd-exclusion.mjs
@@ -85,9 +85,37 @@ export function isBareShell(sd) {
  * @param {{sd_key?: string, metadata?: object, description?: string, title?: string}} sd
  * @returns {boolean} true when the SD must be excluded from belt depth
  */
+/**
+ * SD-REFILL-00306WTS: an auto-filed venture-quality-loop remediation SD that NO fleet worker can
+ * action. The Stage-20 quality loop auto-files SD-LEO-FIX-REMEDIATION-* findings (npm_audit / lint /
+ * unit_test) against a VENTURE repo (target_application e.g. 'EHG') with only an ephemeral sandbox
+ * evidence pointer (an ephemeral "Temp/ehg-s20-..." sandbox dir, torn down by remediation time). A fleet worker can only
+ * remediate target_application='EHG_Engineer' (the fleet's own checkout) — so these rows get
+ * claimed+released every cycle and inflate capacity-forecast belt-depth into a FALSE 'SURPLUS' that
+ * suppresses belt-low→Adam sourcing. Exclude them from belt depth.
+ *
+ * CONSERVATIVE: requires BOTH the canonical remediation key prefix AND a non-EHG_Engineer
+ * target_application (the venture). A remediation SD that genuinely targets EHG_Engineer (or has no
+ * target) stays on the belt — only un-actionable venture findings are excluded. FAIL-OPEN.
+ *
+ * @param {{sd_key?: string, metadata?: object, target_application?: string}} sd
+ * @returns {boolean} true when the SD is an un-actionable auto-filed venture remediation finding
+ */
+export function isUnactionableRemediationSd(sd) {
+  try {
+    if (!sd || typeof sd !== 'object' || typeof sd.sd_key !== 'string') return false; // fail-open
+    if (!/^SD-LEO-FIX-REMEDIATION-/.test(sd.sd_key)) return false;
+    const md = sd.metadata || {};
+    const target = sd.target_application || md.target_application;
+    return typeof target === 'string' && target !== '' && target !== 'EHG_Engineer';
+  } catch {
+    return false; // fail-open: a classifier error keeps the SD on the belt
+  }
+}
+
 export function isExcludedFromBelt(sd) {
   if (!sd || typeof sd !== 'object') return false; // fail-open
-  return isFixtureSd(sd.sd_key, sd.metadata) || isBareShell(sd);
+  return isFixtureSd(sd.sd_key, sd.metadata) || isBareShell(sd) || isUnactionableRemediationSd(sd);
 }
 
 /**

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -139,7 +139,9 @@ async function main() {
     sb.from('strategic_directives_v2')
       // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + metadata (is_fixture marker) and
       // title/description (bare-shell detection) so excluded rows do not inflate belt depth.
-      .select('sd_key, title, description, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies, metadata')
+      // SD-REFILL-00306WTS: + target_application so un-actionable auto-filed venture remediation
+      // SDs (target_application != EHG_Engineer) are excluded from belt depth (false-SURPLUS fix).
+      .select('sd_key, title, description, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies, metadata, target_application')
       .not('status', 'in', '("completed","cancelled","deferred")'),
     // Open QFs are claimable belt too (a worker can claim a QF) — counting only SDs
     // under-reports belt depth and over-reports deficit (workers self-claim QFs).
@@ -173,7 +175,7 @@ async function main() {
     const unmet = parseSdDependencies(d.dependencies).filter(k => depStatus[k] !== 'completed');
     if (unmet.length === 0) claimable.push(d);
   }
-  if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell) excluded from belt depth`);
+  if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell/un-actionable-venture-remediation) excluded from belt depth`);
 
   // ── classify live workers (exclude coordinator + adam + non_fleet + fixtures + released) ──
   // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: use the canonical isDispatchableFleetMember

--- a/scripts/vision/build-completion-forecast.mjs
+++ b/scripts/vision/build-completion-forecast.mjs
@@ -59,7 +59,9 @@ async function gatherInputs() {
     velocityPerDay = (completed?.length || 0) / windowDays;
 
     const { data: live } = await sb.from('strategic_directives_v2')
-      .select('sd_key, title, description, status, sd_type, created_at, claiming_session_id, dependencies, metadata')
+      // SD-REFILL-00306WTS: + target_application so isExcludedFromBelt drops un-actionable
+      // auto-filed venture remediation SDs from sourcing-rate + queue depth.
+      .select('sd_key, title, description, status, sd_type, created_at, claiming_session_id, dependencies, metadata, target_application')
       .not('status', 'in', '("completed","cancelled","deferred")');
     const rows = Array.isArray(live) ? live : [];
 

--- a/tests/unit/coordinator-sd-exclusion.test.js
+++ b/tests/unit/coordinator-sd-exclusion.test.js
@@ -19,6 +19,7 @@ import {
   isFixtureSd,
   isBareShell,
   isExcludedFromBelt,
+  isUnactionableRemediationSd,
   bareShellLastCompare,
   isStartedSd,
   stripDispatchRank,
@@ -164,6 +165,41 @@ describe('isExcludedFromBelt — the REAL forecaster belt predicate', () => {
 });
 
 // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug d5e59236): in-flight (started) guard.
+describe('isUnactionableRemediationSd — SD-REFILL-00306WTS venture-remediation belt exclusion', () => {
+  it('excludes an auto-filed remediation SD targeting a VENTURE (target_application != EHG_Engineer)', () => {
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-LEO-FIX-REMEDIATION-UNIT-TEST-005', target_application: 'EHG' })).toBe(true);
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-LEO-FIX-REMEDIATION-NPM-AUDIT-003', target_application: 'EHG' })).toBe(true);
+    // target_application can also arrive via metadata
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-004', metadata: { target_application: 'EHG' } })).toBe(true);
+  });
+
+  it('does NOT exclude a remediation SD that genuinely targets the fleet repo (EHG_Engineer)', () => {
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-001', target_application: 'EHG_Engineer' })).toBe(false);
+  });
+
+  it('does NOT exclude a remediation SD with no target (cannot prove un-actionable → stays on belt)', () => {
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-002', metadata: {} })).toBe(false);
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-003' })).toBe(false);
+  });
+
+  it('does NOT exclude a non-remediation SD even when it targets a venture (prefix-gated)', () => {
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-EHG-COCKPIT-DTQ-001', target_application: 'EHG' })).toBe(false);
+    expect(isUnactionableRemediationSd({ sd_key: 'SD-REFILL-00306WTS', target_application: 'EHG' })).toBe(false);
+  });
+
+  it('fail-open on malformed input', () => {
+    expect(isUnactionableRemediationSd(null)).toBe(false);
+    expect(isUnactionableRemediationSd('x')).toBe(false);
+    expect(isUnactionableRemediationSd({})).toBe(false);
+  });
+
+  it('isExcludedFromBelt folds in the venture-remediation exclusion', () => {
+    expect(isExcludedFromBelt({ sd_key: 'SD-LEO-FIX-REMEDIATION-UNIT-TEST-005', target_application: 'EHG', title: 'x', description: 'a genuine description distinct from title', metadata: {} })).toBe(true);
+    // a fleet-targeted remediation SD with real substance still passes
+    expect(isExcludedFromBelt({ sd_key: 'SD-LEO-FIX-REMEDIATION-X-001', target_application: 'EHG_Engineer', title: 'x', description: 'a genuine description distinct from title', metadata: {} })).toBe(false);
+  });
+});
+
 describe('isStartedSd — the REAL ranker in-flight guard', () => {
   it('flags an SD past the initial LEAD draft as started (must not be fresh-ranked)', () => {
     expect(isStartedSd({ current_phase: 'PLAN_PRD' })).toBe(true);


### PR DESCRIPTION
## Summary
The Stage-20 venture-quality-loop auto-files `SD-LEO-FIX-REMEDIATION-*` findings against a **venture** repo (`target_application='EHG'`) with only an ephemeral sandbox evidence pointer. No fleet worker can remediate them (the fleet only actions `target_application='EHG_Engineer'`), so they get claimed+released every cycle and inflate capacity-forecast belt-depth into a **false 'SURPLUS'** that suppresses the belt-low→Adam sourcing alert. (Verified live: 17/18 such SDs target EHG; one was auto-filed today.)

**Fix (option c):** new pure `isUnactionableRemediationSd(sd)` (REMEDIATION key prefix **AND** non-EHG_Engineer target) folded into the shared `isExcludedFromBelt` SSOT, so both `coordinator-capacity-forecast` and `build-completion-forecast` exclude them. `+target_application` added to both selects.

## Verification
- 39/39 `coordinator-sd-exclusion` tests green (6 new cases); TESTING sub-agent PASS
- Conservative: fleet-targeted remediation, no-target, and non-remediation venture SDs are **not** excluded

## Scope
Deeper fixes — (a) auto-filer persists evidence, (b) stop filing ephemeral-sandbox findings — are EVA Stage-20 pipeline changes, **descoped to follow-ups**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)