### PR TITLE
fix(SD-REFILL-00C7GXJS): PID-alive escape — don't reclaim a busy worker's claim mid-sub-agent-review

### DIFF
--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -19,8 +19,14 @@
 import path from 'path';
 import { realpathSync, existsSync, readdirSync } from 'fs';
 import { execSync } from 'child_process';
+import { createRequire } from 'module';
 import { resolveOwnSession } from './resolve-own-session.js';
 import sessionIdentitySot from './session-identity-sot.js';
+
+// SD-REFILL-00C7GXJS: host-local PID-liveness is lazy-required (not a top-level import) so this
+// FAIL-CLOSED gate can never fail to load on a transitive cc-pid-liveness issue; the consumer
+// isOwnerProcessAlive() is fully fail-open.
+const _require = createRequire(import.meta.url);
 // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 FR-2: sd_key drift fallthrough mirrors
 // the same-host stale-heartbeat auto-release pattern at this file's lines 250-277.
 import { detectSdKeyDrift } from './claim-lifecycle-release.mjs';
@@ -255,6 +261,36 @@ export function ownerIsDeadByLiveness(owner, nowMs, ttlMs = CLAIM_TTL_MS) {
   return false;
 }
 
+/**
+ * SD-REFILL-00C7GXJS: pure release decision for a peer that finds a FOREIGN claim. A worker running a
+ * long Task()/Agent sub-agent review (e.g. 2 parallel reviews ~15min) emits NO heartbeat — sub-agents
+ * don't heartbeat — so within the ~15min claim TTL its heartbeat goes stale AND a sweep may flip
+ * is_alive=false, making a LIVE worker look dead (ownerIsDead=true). Reaping its claim mid-build caused
+ * GATE_CLAIM_VALIDITY_FAILED + deconfliction churn (hit 2x this session). The PID-ALIVE escape fixes it:
+ * if the owner's PROCESS is verifiably running (host-local marker), it is NOT reaped regardless of the
+ * heartbeat/is_alive lag — process liveness is the strongest signal. sd_key DRIFT is orthogonal (a real
+ * release signal) and always releases. Armed-silence and PID-alive only ADD protection; an unresolvable
+ * PID (cross-host / no marker) → ownerPidAlive=false → today's behavior (fail-open, no regression).
+ * @param {{ownerHasSdKeyDrifted?:boolean, ownerIsDead?:boolean, ownerIsSilenced?:boolean, ownerPidAlive?:boolean}} args
+ * @returns {boolean} true ⇒ release/reclaim the foreign claim; false ⇒ yield (owner keeps it).
+ */
+export function shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive } = {}) {
+  if (ownerHasSdKeyDrifted) return true;                       // sd_key moved away — a real release signal
+  return Boolean(ownerIsDead) && !ownerIsSilenced && !ownerPidAlive;
+}
+
+/** Host-local: is the owner session's Claude Code PROCESS still running? Best-effort / fail-open
+ *  (any error, an unknown session, or a cross-host owner → false → no added protection). */
+function isOwnerProcessAlive(ownerSessionId) {
+  if (!ownerSessionId) return false;
+  try {
+    const { getMarkerSessionIds } = _require('./fleet/cc-pid-liveness.cjs');
+    const map = getMarkerSessionIds();
+    const entry = map && map[ownerSessionId];
+    return Boolean(entry && entry.alive);
+  } catch { return false; }
+}
+
 function explainRemediation(reason) {
   switch (reason) {
     case 'ambiguous':
@@ -438,6 +474,12 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
     // signal) and is NOT suppressed. Fail-open: an absent/expired/beyond-cap window => not silenced
     // => today's release behavior (the guard only ADDS protection).
     const ownerIsSilenced = isWithinArmedSilenceWindow(owner?.expected_silence_until, Date.now());
+    // SD-REFILL-00C7GXJS: PID-ALIVE escape — a worker mid long Task()/Agent sub-agent review emits no
+    // heartbeat (sub-agents don't heartbeat) so its claim can look dead within the ~15min TTL, but its
+    // PROCESS is still running. If the owner's process is verifiably alive (host-local marker), do NOT
+    // reap its claim — this stops the recurring mid-build reclaim + deconfliction churn. Fail-open: an
+    // unresolvable/cross-host owner → false → today's behavior.
+    const ownerPidAlive = isOwnerProcessAlive(sd.claiming_session_id);
     // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 FR-2: sd_key drift fallthrough — when
     // owner's sd_key has drifted away from sdKey (or is null), treat as same-class
     // as ownerIsDead. detectSdKeyDrift returns 'drift'|'aligned'|'unknown'.
@@ -446,7 +488,7 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
 
     // SEAM 1: drift always releases; a dead-looking owner releases ONLY if not within an armed
     // silence window (a within-cap silenced holder yields to foreign_claim instead of being reaped).
-    if (ownerHasSdKeyDrifted || (ownerIsDead && !ownerIsSilenced)) {
+    if (shouldReleaseStaleOwner({ ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive })) {
       // Idempotent canonical claim-release — WHERE-clause restricts to the orphan pair so a fresh claim
       // acquired between detection and write cannot be overwritten.
       await supabase

--- a/tests/unit/claim-validity-gate-sd-key-drift.test.js
+++ b/tests/unit/claim-validity-gate-sd-key-drift.test.js
@@ -46,12 +46,16 @@ describe('FR-2 fallthrough: sd_key drift triggers auto-release alongside ownerIs
     expect(src).toMatch(/ownerHasSdKeyDrifted\s*=\s*sdKeyDriftVerdict\s*===\s*['"]drift['"]/);
   });
 
-  it('auto-release condition includes both ownerIsDead AND ownerHasSdKeyDrifted', () => {
+  it('auto-release decision goes through shouldReleaseStaleOwner with drift + dead + silence + pid-alive', () => {
     // SD-LEO-INFRA-CLAIM-SILENCE-CONSUME-VERIFY-001 (SEAM 1) gated the dead-owner arm on
-    // !ownerIsSilenced (drift still releases unconditionally). Both conditions still appear.
-    expect(src).toMatch(/if\s*\(\s*ownerHasSdKeyDrifted\s*\|\|\s*\(\s*ownerIsDead\s*&&\s*!ownerIsSilenced\s*\)\s*\)/);
-    expect(src).toMatch(/ownerIsDead/);
-    expect(src).toMatch(/ownerHasSdKeyDrifted/);
+    // !ownerIsSilenced (drift still releases unconditionally). SD-REFILL-00C7GXJS refactored the
+    // inline condition into the pure shouldReleaseStaleOwner() and ADDED the !ownerPidAlive escape
+    // (a busy worker mid Task() sub-agent call has a live PID and must not be reaped). The release is
+    // now driven by that helper; the pure function still encodes drift-always / (dead && !silenced && !pid-alive).
+    expect(src).toMatch(/if\s*\(\s*shouldReleaseStaleOwner\(\s*\{\s*ownerHasSdKeyDrifted,\s*ownerIsDead,\s*ownerIsSilenced,\s*ownerPidAlive\s*\}\s*\)\s*\)/);
+    expect(src).toMatch(/function shouldReleaseStaleOwner/);
+    expect(src).toMatch(/if\s*\(\s*ownerHasSdKeyDrifted\s*\)\s*return true/);
+    expect(src).toMatch(/Boolean\(ownerIsDead\)\s*&&\s*!ownerIsSilenced\s*&&\s*!ownerPidAlive/);
   });
 
   it('release reason is "sd_key_drift" when drift triggers (NOT stale/released/missing)', () => {

--- a/tests/unit/claim-validity-isalive-lag.test.js
+++ b/tests/unit/claim-validity-isalive-lag.test.js
@@ -9,7 +9,7 @@
  * (b) a live-but-lagging owner (is_alive=false BUT fresh heartbeat) is NOT reaped (thrash stops).
  */
 import { describe, it, expect } from 'vitest';
-import { ownerIsDeadByLiveness, isHeartbeatStale, CLAIM_TTL_MS } from '../../lib/claim-validity-gate.js';
+import { ownerIsDeadByLiveness, isHeartbeatStale, CLAIM_TTL_MS, shouldReleaseStaleOwner } from '../../lib/claim-validity-gate.js';
 
 const NOW = 1_700_000_000_000;
 const minsAgo = (m) => NOW - m * 60_000;
@@ -78,5 +78,32 @@ describe('ownerIsDeadByLiveness — both mandatory directions (FR-2)', () => {
   });
   it('is_alive=true with a stale heartbeat is still NOT dead (only is_alive=false consults heartbeat; no regression)', () => {
     expect(ownerIsDeadByLiveness({ is_alive: true, heartbeat_at: minsAgo(999) }, NOW)).toBe(false);
+  });
+});
+
+describe('shouldReleaseStaleOwner — PID-alive escape stops mid-build reclaim (SD-REFILL-00C7GXJS)', () => {
+  it('RELEASES a genuinely-dead owner (dead, not silenced, PID not alive) — no claim held forever', () => {
+    expect(shouldReleaseStaleOwner({ ownerIsDead: true, ownerIsSilenced: false, ownerPidAlive: false })).toBe(true);
+  });
+
+  it('does NOT release a dead-LOOKING owner whose PROCESS is alive (busy in a Task() sub-agent — the bug)', () => {
+    expect(shouldReleaseStaleOwner({ ownerIsDead: true, ownerIsSilenced: false, ownerPidAlive: true })).toBe(false);
+  });
+
+  it('does NOT release a within-armed-silence owner (existing protection preserved)', () => {
+    expect(shouldReleaseStaleOwner({ ownerIsDead: true, ownerIsSilenced: true, ownerPidAlive: false })).toBe(false);
+  });
+
+  it('sd_key DRIFT always releases — even with a live PID (drift is a real release signal)', () => {
+    expect(shouldReleaseStaleOwner({ ownerHasSdKeyDrifted: true, ownerIsDead: false, ownerPidAlive: true })).toBe(true);
+  });
+
+  it('does NOT release a live owner (not dead) regardless of PID/silence', () => {
+    expect(shouldReleaseStaleOwner({ ownerIsDead: false, ownerIsSilenced: false, ownerPidAlive: false })).toBe(false);
+  });
+
+  it('is total on empty/odd input (fail-open: do not release)', () => {
+    expect(shouldReleaseStaleOwner()).toBe(false);
+    expect(shouldReleaseStaleOwner({})).toBe(false);
   });
 });


### PR DESCRIPTION
## SD-REFILL-00C7GXJS

The claim TTL (15min) is shorter than a worker tick running parallel `Task()`/Agent sub-agent reviews. Sub-agents emit **no heartbeat**, so within a tick the owner's heartbeat goes stale AND a sweep flips `is_alive=false` → a **live** worker reads as dead → a peer reclaims the claim **mid-build** → `GATE_CLAIM_VALIDITY_FAILED` + forced deconflict (hit 2x this session).

### Fix
- **PID-alive escape**: refactor the inline release condition into pure `shouldReleaseStaleOwner({ownerHasSdKeyDrifted, ownerIsDead, ownerIsSilenced, ownerPidAlive})` and add `!ownerPidAlive`. If the owner's **process is verifiably running** (host-local SessionStart markers via `cc-pid-liveness.cjs`), its claim is **not** reaped — process liveness is the strongest signal.
- sd_key **drift** still releases unconditionally; **armed-silence** preserved; **lazy-require** keeps the fail-closed gate load-safe; **fail-open** on unresolvable/cross-host owners (no regression).

### Tests
- 6 new pure tests + updated the sd-key-drift source-pin; claim-validity suites **36/36**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)