### PR TITLE
fix(SD-REFILL-00XE6T7E): claimable-work ignores non-SD-key prose deps (consolidate onto canonical resolver)

### DIFF
--- a/lib/coordinator/claimable-work.cjs
+++ b/lib/coordinator/claimable-work.cjs
@@ -35,19 +35,23 @@ function isTerminalStatus(status) {
   return TERMINAL_STATUSES.includes(status);
 }
 
+const { parseSdDependencies } = require('../utils/parse-sd-dependencies.cjs');
+
 /**
- * Extract dependency blocker keys from an SD row. Tolerant of the three shapes the
- * `dependencies` JSONB can take ({sd_id}, {sd_key}, or a bare string) — identical to
- * coordinator-audit.mjs's depOf().
+ * Extract dependency blocker SD-KEYS from an SD row, via the CANONICAL resolver
+ * (lib/utils/parse-sd-dependencies.cjs — the SSOT also used by coordinator-audit.mjs and
+ * stale-session-sweep.cjs). It tolerates the three `dependencies` shapes ({sd_id}, {sd_key},
+ * bare string) AND — critically — applies the /^SD-[A-Z0-9-]+/ filter, so conceptual-input
+ * PROSE that workers mis-file into dependencies (table lists, file refs, "Chairman approval
+ * CONST-002") is DROPPED rather than treated as a never-resolvable blocker key.
+ * SD-REFILL-00XE6T7E: the old local copy lacked that filter (it returned any non-empty string),
+ * so prose deps phantom-blocked an SD out of the claimable belt via isClaimableSd. dependencies[]
+ * is for SD-key graph edges only — conceptual inputs belong in scope or metadata.inputs.
  * @param {object} sd - strategic_directives_v2 row (needs `dependencies`)
  * @returns {string[]}
  */
 function parseDeps(sd) {
-  const d = sd && sd.dependencies;
-  if (!Array.isArray(d)) return [];
-  // Only string keys survive: a malformed entry (e.g. {} with no sd_id/sd_key) is
-  // dropped rather than mapped to a never-resolvable object key.
-  return d.map((x) => x && (x.sd_id || x.sd_key || x)).filter((k) => typeof k === 'string' && k.length > 0);
+  return parseSdDependencies(sd && sd.dependencies);
 }
 
 /**

--- a/lib/coordinator/claimable-work.test.js
+++ b/lib/coordinator/claimable-work.test.js
@@ -26,9 +26,12 @@ describe('isTerminalStatus', () => {
   });
 });
 
+// SD-REFILL-00XE6T7E: parseDeps now delegates to the canonical /^SD-/ resolver, so dependency
+// fixtures must be real SD-keys (non-SD-key prose is intentionally dropped — see claimable-work.test
+// in tests/unit/coordinator/ for the prose-filter cases).
 describe('parseDeps — tolerant of the three dependency shapes', () => {
-  it('extracts sd_id, sd_key, and bare-string deps; ignores empties', () => {
-    expect(parseDeps({ dependencies: [{ sd_id: 'A' }, { sd_key: 'B' }, 'C', null, {}] })).toEqual(['A', 'B', 'C']);
+  it('extracts sd_id, sd_key, and bare-string SD-key deps; ignores empties + non-SD-key strings', () => {
+    expect(parseDeps({ dependencies: [{ sd_id: 'SD-A-001' }, { sd_key: 'SD-B-001' }, 'SD-C-001', null, {}] })).toEqual(['SD-A-001', 'SD-B-001', 'SD-C-001']);
     expect(parseDeps({ dependencies: null })).toEqual([]);
     expect(parseDeps({})).toEqual([]);
     expect(parseDeps(null)).toEqual([]);
@@ -38,11 +41,11 @@ describe('parseDeps — tolerant of the three dependency shapes', () => {
 describe('dependencyKeys — dedup across rows', () => {
   it('returns the distinct set of dependency keys', () => {
     const rows = [
-      { dependencies: [{ sd_id: 'A' }, { sd_key: 'B' }] },
-      { dependencies: ['B', 'C'] },
+      { dependencies: [{ sd_id: 'SD-A-001' }, { sd_key: 'SD-B-001' }] },
+      { dependencies: ['SD-B-001', 'SD-C-001'] },
       { dependencies: [] },
     ];
-    expect(dependencyKeys(rows).sort()).toEqual(['A', 'B', 'C']);
+    expect(dependencyKeys(rows).sort()).toEqual(['SD-A-001', 'SD-B-001', 'SD-C-001']);
     expect(dependencyKeys([])).toEqual([]);
   });
 });
@@ -58,17 +61,17 @@ describe('isClaimableSd — the RAG fix', () => {
   });
 
   it('EXCLUDES a child with an unmet (non-terminal) dependency', () => {
-    const child = { sd_type: 'feature', dependencies: [{ sd_id: 'BLOCKER' }] };
-    expect(isClaimableSd(child, { BLOCKER: 'in_progress' })).toBe(false);
+    const child = { sd_type: 'feature', dependencies: [{ sd_id: 'SD-BLOCKER-001' }] };
+    expect(isClaimableSd(child, { 'SD-BLOCKER-001': 'in_progress' })).toBe(false);
   });
 
   it('INCLUDES a child whose dependencies are all terminal', () => {
-    const child = { sd_type: 'feature', dependencies: [{ sd_id: 'A' }, { sd_key: 'B' }] };
-    expect(isClaimableSd(child, { A: 'completed', B: 'cancelled' })).toBe(true);
+    const child = { sd_type: 'feature', dependencies: [{ sd_id: 'SD-A-001' }, { sd_key: 'SD-B-001' }] };
+    expect(isClaimableSd(child, { 'SD-A-001': 'completed', 'SD-B-001': 'cancelled' })).toBe(true);
   });
 
-  it('EXCLUDES a child whose dependency status is UNKNOWN (conservative)', () => {
-    const child = { sd_type: 'feature', dependencies: ['MISSING'] };
+  it('EXCLUDES a child whose (real SD-key) dependency status is UNKNOWN (conservative)', () => {
+    const child = { sd_type: 'feature', dependencies: ['SD-MISSING-001'] };
     expect(isClaimableSd(child, {})).toBe(false);
   });
 
@@ -78,11 +81,11 @@ describe('isClaimableSd — the RAG fix', () => {
   });
 
   it('models the false-RED scenario: only the claimable SD counts as remaining', () => {
-    const depStatus = { FOUND: 'in_progress' }; // a blocker that is NOT done
+    const depStatus = { 'SD-FOUND-001': 'in_progress' }; // a blocker that is NOT done
     const rows = [
       { sd_key: 'BUILDING', sd_type: 'bugfix', dependencies: [] },          // claimable (a worker is on it)
       { sd_key: 'PARENT', sd_type: 'orchestrator', dependencies: [] },      // excluded — parent
-      { sd_key: 'CHILD', sd_type: 'feature', dependencies: [{ sd_id: 'FOUND' }] }, // excluded — blocked
+      { sd_key: 'CHILD', sd_type: 'feature', dependencies: [{ sd_id: 'SD-FOUND-001' }] }, // excluded — blocked
     ];
     const claimable = rows.filter(s => isClaimableSd(s, depStatus)).map(r => r.sd_key);
     expect(claimable).toEqual(['BUILDING']); // parent + blocked child no longer inflate `remaining`

--- a/tests/unit/coordinator/claimable-work.test.js
+++ b/tests/unit/coordinator/claimable-work.test.js
@@ -1,0 +1,52 @@
+/**
+ * SD-REFILL-00XE6T7E — claimable-work must ignore conceptual-input PROSE mis-filed into
+ * strategic_directives_v2.dependencies (table lists, file refs, "Chairman approval CONST-002").
+ * Before this fix, parseDeps returned any non-empty string, so a prose dep had no status row and
+ * isClaimableSd treated it as an UNMET blocker -> the SD was phantom-excluded from the claimable
+ * belt. parseDeps now delegates to the canonical /^SD-/ resolver (parse-sd-dependencies.cjs SSOT).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parseDeps, dependencyKeys, isClaimableSd } = require('../../../lib/coordinator/claimable-work.cjs');
+
+const PROSE = [
+  'objectives / strategic_vision / key_results (the scattered substrate inventoried).',
+  'lib/vision/vdr-registry.js — the ord 11 probe.',
+  'Chairman approval of the north-star definition (CONST-002) — gates the follow-on build SD.',
+];
+
+describe('SD-REFILL-00XE6T7E: claimable-work ignores non-SD-key prose dependencies', () => {
+  it('parseDeps drops prose entries, keeping only /^SD-/ keys', () => {
+    expect(parseDeps({ dependencies: PROSE })).toEqual([]);
+    expect(parseDeps({ dependencies: [...PROSE, 'SD-X-001'] })).toEqual(['SD-X-001']);
+    expect(parseDeps({ dependencies: [{ sd_key: 'SD-Y-002' }, { sd_id: 'SD-Z-003' }] })).toEqual(['SD-Y-002', 'SD-Z-003']);
+  });
+
+  it('isClaimableSd is TRUE for an SD whose deps are only prose (no longer phantom-blocked)', () => {
+    expect(isClaimableSd({ sd_type: 'feature', dependencies: PROSE }, {})).toBe(true);
+  });
+
+  it('isClaimableSd still BLOCKS on a real SD-key dependency that is non-terminal', () => {
+    expect(isClaimableSd({ sd_type: 'feature', dependencies: ['SD-X-001'] }, { 'SD-X-001': 'draft' })).toBe(false);
+  });
+
+  it('isClaimableSd is TRUE when a real SD-key dependency is terminal', () => {
+    expect(isClaimableSd({ sd_type: 'feature', dependencies: ['SD-X-001'] }, { 'SD-X-001': 'completed' })).toBe(true);
+  });
+
+  it('isClaimableSd drops prose and gates only on the real SD-key (mixed deps)', () => {
+    const sd = { sd_type: 'feature', dependencies: [...PROSE, 'SD-Y-002'] };
+    expect(isClaimableSd(sd, { 'SD-Y-002': 'completed' })).toBe(true);
+    expect(isClaimableSd(sd, { 'SD-Y-002': 'in_progress' })).toBe(false);
+  });
+
+  it('orchestrator parents are never claimable', () => {
+    expect(isClaimableSd({ sd_type: 'orchestrator', dependencies: [] }, {})).toBe(false);
+  });
+
+  it('dependencyKeys excludes prose across a batch', () => {
+    const rows = [{ dependencies: PROSE }, { dependencies: ['SD-A-001', 'some prose'] }];
+    expect(dependencyKeys(rows)).toEqual(['SD-A-001']);
+  });
+});


### PR DESCRIPTION
## Summary
Workers mis-file conceptual-input **prose** into `strategic_directives_v2.dependencies` (table lists, file refs, `Chairman approval of the north-star definition (CONST-002)`). The canonical resolver `lib/utils/parse-sd-dependencies.cjs` filters to `/^SD-/`, and `coordinator-audit.mjs` + `stale-session-sweep.cjs` + charter-audit already use it. But `lib/coordinator/claimable-work.cjs` kept its **own** `parseDeps` that returned *any* non-empty string — its comment wrongly claimed it was "identical to the canonical predicate" (it lacked the `/^SD-/` filter).

So a prose dep became a "dependency key" with no status row, and `isClaimableSd`'s `parseDeps(sd).every(k => isTerminalStatus(map[k]))` treated it as an **unmet blocker** → the SD was **phantom-excluded from the claimable belt** (workers couldn't claim it). `claimable-work` gates the belt, so this was the most impactful instance of the bug class. (Witnessed shape: `SD-EHG-FOUNDATION-NORTHSTAR-CONTRACT-DESIGN-001` carries exactly these prose deps.)

## Changes
- **FR-1** `parseDeps` now delegates to `parseSdDependencies` (SSOT + the `/^SD-/` filter). Prose entries are dropped; real SD-key deps are preserved and still gate conservatively (unmet=blocked).
- **FR-3** corrected the misleading "identical to canonical" comment; noted `dependencies[]` is for SD-key graph edges only (conceptual inputs belong in `scope`/`metadata.inputs`).
- **FR-2** `tests/unit/coordinator/claimable-work.test.js` (7 tests): prose-only → claimable; unmet/terminal SD-key deps gate correctly; mixed deps drop prose; `dependencyKeys` excludes prose; orchestrator parent not claimable.

## Verification
7/7 tests pass. `node --check` clean. TESTING sub-agent verdict PASS (row `bb68a50e`). No data change — prose already in existing rows is simply ignored (it was never a valid graph edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)