### PR TITLE
feat(SD-REFILL-0093WRCJ): validate design-only SD stories before the deliverable-completeness skip

### DIFF
--- a/scripts/auto-validate-user-stories-on-exec-complete.js
+++ b/scripts/auto-validate-user-stories-on-exec-complete.js
@@ -207,18 +207,24 @@ async function autoValidateUserStories(sdId, sbClient) {
     return { validated: true, count: 0, message: 'No user stories' };
   }
 
+  // SD-REFILL-0093WRCJ: design-only SDs are validated against the SPEC quality bar
+  // (validateDesignOnlyStories: >=2 substantive ACs), NOT deliverable completion_status. Doc/spec
+  // deliverables have no code-artifact completer to flip them to 'completed', so gating the
+  // design-only branch behind allDeliverablesComplete left these SDs stuck at the
+  // 'Deliverables not all complete' skip below — the residual of #4838, which placed the design-only
+  // branch AFTER that skip. Route design-only SDs to their spec-quality validation FIRST so they no
+  // longer require a manual user_stories status/validation_status edit to pass USER_STORY_COVERAGE.
+  // FR-2: only stories meeting the bar are promoted/validated; thin/boilerplate stories are surfaced.
+  if (designOnly) {
+    return await validateDesignOnlyStories(supabase, resolvedSdId, stories);
+  }
+
   const allDeliverablesComplete = deliverables && deliverables.length > 0 &&
     deliverables.every(d => d.completion_status === 'completed');
 
   if (!allDeliverablesComplete) {
     console.log('⏸️  Deliverables not all complete, skipping auto-validation');
     return { validated: false, message: 'Deliverables incomplete' };
-  }
-
-  // FR-2: design-only SDs get a tailored quality check — only stories meeting the bar against the
-  // spec are promoted/validated; thin/boilerplate stories are surfaced, not rubber-stamped.
-  if (designOnly) {
-    return await validateDesignOnlyStories(supabase, resolvedSdId, stories);
   }
 
   // ── default path (code-bearing SDs): the existing universal promotion + validation ──

--- a/tests/unit/auto-validate-user-stories-draft.test.js
+++ b/tests/unit/auto-validate-user-stories-draft.test.js
@@ -209,6 +209,42 @@ test('design-only branch: good story validated, thin story surfaced (advisory, n
   assert.deepEqual(recorded.validatedIds, ['g1'], 'only the good story is validated');
 });
 
+test('SD-REFILL-0093WRCJ: design-only SD with an INCOMPLETE deliverable still validates (not skipped)', async () => {
+  // The bug: the design-only branch sat AFTER the allDeliverablesComplete skip, so a design-only
+  // SD whose doc/spec deliverable was not completion_status='completed' (docs have no code-artifact
+  // completer) hit "Deliverables not all complete, skipping" and its stories were never validated —
+  // forcing a manual user_stories status/validation_status edit to pass USER_STORY_COVERAGE.
+  // The fix routes design-only SDs to the spec-quality validation BEFORE that skip.
+  const stories = [
+    { id: 'g1', title: 'Good', status: 'ready', validation_status: 'pending',
+      acceptance_criteria: ['The spec documents the gauge purpose and data source clearly.', 'The spec lists open questions for the chairman.'] },
+  ];
+  const { client, recorded } = makeClient({
+    uuid: '99999999-9999-9999-9999-999999999999',
+    sdRow: { metadata: { design_only: true } },
+    stories,
+    deliverables: [{ deliverable_name: 'docs/04_features/spec.md', completion_status: 'pending' }],
+  });
+  const res = await autoValidateUserStories('99999999-9999-9999-9999-999999999999', client);
+  assert.equal(res.designOnly, true, 'must take the design-only branch, NOT the deliverables-incomplete skip');
+  assert.notEqual(res.message, 'Deliverables incomplete', 'must NOT hit the allDeliverablesComplete skip');
+  assert.equal(res.validated, true, 'the good story validates against the spec despite the incomplete deliverable');
+  assert.deepEqual(recorded.validatedIds, ['g1'], 'the good story is validated (no manual edit needed)');
+});
+
+test('SD-REFILL-0093WRCJ: a CODE SD with an incomplete deliverable is STILL skipped (no behavior change)', async () => {
+  // Guard: the reorder must not let code-bearing SDs bypass the deliverable-completeness gate.
+  const stories = [{ id: 's1', title: 'Story 1', status: 'draft', validation_status: 'pending' }];
+  const { client } = makeClient({
+    uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    stories,
+    deliverables: [{ deliverable_name: 'src/foo.ts', completion_status: 'pending' }],
+  });
+  const res = await autoValidateUserStories('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', client);
+  assert.equal(res.validated, false);
+  assert.equal(res.message, 'Deliverables incomplete', 'code SD with incomplete deliverable still hits the skip');
+});
+
 test('FR-3: a design-only SD with a spec deliverable but ZERO stories is surfaced, not auto-passed', async () => {
   const { client } = makeClient({
     uuid: '88888888-8888-8888-8888-888888888888',


### PR DESCRIPTION
## Summary
#4838 added the design-only story-validation branch but placed it **after** the `allDeliverablesComplete` skip. Doc/spec deliverables have no code-artifact completer to flip `completion_status` to `completed`, so a design-only SD whose deliverable stayed `pending` hit *'Deliverables not all complete, skipping'* and its stories were never validated — forcing a manual `user_stories` status/validation_status edit to pass USER_STORY_COVERAGE at EXEC-TO-PLAN.

**Fix:** route `if (designOnly) return validateDesignOnlyStories(...)` **before** the `allDeliverablesComplete` check. `validateDesignOnlyStories` enforces a spec-quality bar (≥2 substantive ACs) independent of deliverable status — not a rubber-stamp; thin stories are surfaced. Code SDs are unchanged.

## Verification
- 16/16 `node --test` cases green (+2 regression: design-only incomplete-deliverable validates; code SD still skips)
- Validation PASS-95 (faithfulness verified via git diff vs #4838 — pure reorder); TESTING PASS-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)