### PR TITLE
feat(SD-REFILL-00N8J6HV): suppress DUTY-3 false idle-worker flag for never-claimed registration ghosts

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -74,8 +74,14 @@ export function detectIdleWithWork({ liveSessions = [], unclaimedCount = 0, pend
   const isParked = (s) =>
     s.loop_state === 'awaiting_tick' ||
     !!(isWithinArmedSilence && isWithinArmedSilence(s.expected_silence_until, nowMs));
+  // A never-claimed registration ghost (e.g. source:'startup', loop_state:'unknown', fresh
+  // heartbeat) has sd_key=null but has never participated in the fleet — it is NOT an idle
+  // worker that can be assigned work. Require evidence of prior participation (a claim, a
+  // worktree, or a completed-SD counter) before counting a session as idle-with-work.
+  const everParticipated = (s) =>
+    !!(s.claimed_at || s.worktree_path || (s.continuous_sds_completed > 0));
   const idleEligible = liveSessions.filter((s) =>
-    s && !s.sd_key && !pendingAssignmentSessionIds.has(s.session_id) && !isParked(s));
+    s && !s.sd_key && !pendingAssignmentSessionIds.has(s.session_id) && !isParked(s) && everParticipated(s));
   const violation = idleEligible.length > 0 && unclaimedCount > 0;
   return {
     violation,

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -110,7 +110,7 @@ async function main() {
 
   // Defense-in-depth: exclude lifecycle-terminated sessions server-side (classifyLiveness also guards this).
   const { data: sessRows, error: sessErr } = await db.from('claude_sessions')
-    .select('session_id,terminal_id,heartbeat_at,sd_key,loop_state,expected_silence_until,status,metadata,worktree_path')
+    .select('session_id,terminal_id,heartbeat_at,sd_key,loop_state,expected_silence_until,status,metadata,worktree_path,claimed_at,continuous_sds_completed')
     .not('status', 'in', '(released,stale,ended)')
     .order('heartbeat_at', { ascending: false }).limit(80);
   const sessMarker = foundationalQueryError(sessErr, 'claude_sessions');

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -107,7 +107,7 @@ describe('extractDepKey — object-sentinel parity (FR-5)', () => {
 
 describe('detectIdleWithWork — DUTY-3 + pending-assignment suppression (FR-3/FR-5)', () => {
   it('idle live worker + unclaimed work -> violation', () => {
-    const r = detectIdleWithWork({ liveSessions: [{ session_id: 'w1', sd_key: null }], unclaimedCount: 2 });
+    const r = detectIdleWithWork({ liveSessions: [{ session_id: 'w1', sd_key: null, worktree_path: '/repo/.worktrees/SD-X' }], unclaimedCount: 2 });
     expect(r.violation).toBe(true);
     expect(r.remediation).toMatch(/assign/i);
   });
@@ -139,11 +139,37 @@ describe('detectIdleWithWork — DUTY-3 + pending-assignment suppression (FR-3/F
     const nowMs = 1_000_000;
     const isWithinArmedSilence = (until, now) => !!until && new Date(until).getTime() > now;
     const r = detectIdleWithWork({
-      liveSessions: [{ session_id: 'w1', sd_key: null, loop_state: 'active', expected_silence_until: null }],
+      liveSessions: [{ session_id: 'w1', sd_key: null, loop_state: 'active', expected_silence_until: null, worktree_path: '/repo/.worktrees/SD-X' }],
       unclaimedCount: 2, nowMs, isWithinArmedSilence,
     });
     expect(r.violation).toBe(true);
     expect(r.detail).toMatch(/parked/);
+  });
+
+  // SD-REFILL-00N8J6HV: a never-claimed registration ghost (source:'startup', loop_state:'unknown',
+  // fresh heartbeat) has sd_key=null but has never participated — it must NOT be flagged as idle-with-work
+  // (the recurring DUTY-3 false positive). everParticipated requires a claim/worktree/completed-counter.
+  it('a never-claimed startup ghost (loop_state=unknown, no worktree/claim) is NOT flagged', () => {
+    const r = detectIdleWithWork({
+      liveSessions: [{ session_id: '0462ea61', sd_key: null, loop_state: 'unknown', expected_silence_until: null, worktree_path: null, claimed_at: null }],
+      unclaimedCount: 2, nowMs: 1_000_000,
+    });
+    expect(r.violation).toBe(false);
+    expect(r.idleCount).toBe(0);
+  });
+  it('a just-finished idle worker (everParticipated via worktree_path, not parked) IS still flagged', () => {
+    const r = detectIdleWithWork({
+      liveSessions: [{ session_id: 'w-finished', sd_key: null, loop_state: 'active', expected_silence_until: null, worktree_path: '/repo/.worktrees/SD-X', claimed_at: null }],
+      unclaimedCount: 2, nowMs: 1_000_000,
+    });
+    expect(r.violation).toBe(true);
+  });
+  it('a worker that has completed SDs (continuous_sds_completed>0) but released its claim IS flagged', () => {
+    const r = detectIdleWithWork({
+      liveSessions: [{ session_id: 'w-veteran', sd_key: null, loop_state: 'active', worktree_path: null, claimed_at: null, continuous_sds_completed: 3 }],
+      unclaimedCount: 1, nowMs: 1_000_000,
+    });
+    expect(r.violation).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
DUTY-3 (`detectIdleWithWork`) flagged "idle worker while unclaimed work exists" for any live session with `sd_key=null` — including never-claimed registration ghosts (`source:'startup'`, `loop_state:'unknown'`, fresh heartbeat) that have never participated in the fleet. The coordinator cannot remediate a ghost, so the flag was pure recurring noise (live: session `0462ea61`).

This adds an `everParticipated` guard: a session must show prior participation (a claim, a worktree, or a completed-SD counter) before it counts as an idle worker.

## Changes
- `lib/coordinator/charter-audit-detectors.mjs`: `everParticipated(s) = claimed_at || worktree_path || continuous_sds_completed>0`, AND-ed into the `idleEligible` filter (after parked/pending guards).
- `scripts/coordinator-charter-audit.mjs`: SELECT `claimed_at,continuous_sds_completed` from `claude_sessions`.
- `tests/unit/coordinator/charter-audit-detectors.test.js`: 3 new pinning tests (ghost not flagged; finished worker still flagged; veteran still flagged) + 2 existing DUTY-3 fixtures gain `worktree_path`.

## Safe direction
Missing/null participation columns → falsy → ghost suppressed (conservative). A freshly-spawned real worker is at worst briefly not-yet-flagged until it claims/worktrees on its next `/checkin`; DUTY-3 is a steady-state alarm, not a sub-second SLA.

## Tests
`charter-audit-detectors` suite: 58/58 passing.

SD: SD-REFILL-00N8J6HV (RCA-validated root cause; never-claimed ghost leaks via `isDispatchableFleetMember` omitting everClaimed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)