### PR TITLE
feat(SD-REFILL-00A3H5FN): encode DECOMPOSE-WEAKEST-LAYER classify-each-capability refinement (board verdict 2026-06-16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: fe104930b10c9cf0 -->
+<!-- file_content_hash: 5e4a39c11b1d8ab3 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-22 4:49:32 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-23 2:23:35 AM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 9e7456e6d1e18cf7 -->
+<!-- file_content_hash: ebbcbbe6a12992f9 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-22 4:49:32 PM
+**Generated**: 2026-06-23 2:23:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -145,6 +145,8 @@ The result is a DRAFT SD that enters the belt correctly-typed, correctly-keyed, 
 
 **DECOMPOSE-WEAKEST-LAYER — parallelize sourcing across the whole weak layer, sized to idle capacity (chairman directive 2026-06-16).** When the VDR build-% gauge's **weakest LAYER** holds N weak (unbuilt/partial) capabilities — e.g. the application/cockpit layer with ~7 — do **not** source one monolithic SD for the belt-low cycle. Instead source up to **N parallel** design/spec SDs, **one per capability**, each a distinct **conflict-free write-surface**, right-sized (a Phase-0 design/spec pass, not a build) — and cap the count at the coordinator's stated **live idle-worker capacity** (the SOURCE-TO-CAPACITY handshake in the coordinator contract). This keeps the whole weak layer moving in parallel, one-capability-per-worker, instead of serializing it behind a single SD.
 
+**CLASSIFY each weak capability BEFORE sourcing it (Adam board-of-directors verdict 2026-06-16) — do NOT blindly source 1 design SD per capability.** A live-grounded board pass found the naive "one tile per capability" framing can yield ZERO valid SDs. For EACH weak capability, classify it FIRST: (a) **genuine leaf** → a Phase-0 design/spec SD (the default above); (b) **foundation / data-contract** — an upstream target-of-record that build SDs depend on (e.g. an ord-11 north-star contract) → **sequence it AHEAD of the builds it gates**, not as a parallel tile; (c) **already-built but reading low ONLY from a STALE/manual KR** (e.g. an ord-7 capability whose breakage-catch is live but the gauge reads ~0% off a manual KR) → a governed **KR RE-MEASURE / repoint-to-live-derivation**, NOT a new build SD; (d) **mis-bucketed** (wrong layer / registry entry) → a **registry fix**. Only (a) becomes a parallel design SD; (b)/(c)/(d) are different work — and the coordinator must VERIFY the per-capability gauge gap is REAL (not a stale-KR artifact) before dispatching.
+
 ### C. The BUILD-% GAUGE duty (THE VISIBLE GAUGE, above)
 
 Adam's exec summaries carry numbers Adam must be able to RECONSTRUCT, not merely echo:
@@ -201,6 +203,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-06-22*
+*Generated from database: 2026-06-23*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 5422d033b2ef6e88 -->
+<!-- file_content_hash: a27f1c430819e661 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: e308d39af309c460 -->
+<!-- file_content_hash: 3e6625172bb00b48 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-22 4:49:32 PM
+**Generated**: 2026-06-23 2:23:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -36,6 +36,8 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 **Belt-low → REACH OUT TO ADAM via the inbox (DEFAULT, ongoing — not a last resort).** The moment the belt thins — only a couple of active builds with the rest of the queue gated/blocked/parked, or idle workers with no claimable work — your default first move is to message **Adam** requesting a sourcing shortlist. Adam is your **standing sourcing assistant** (augmentation lane): he grooms the harness backlog + scans cross-program/board and proposes a shortlist of CONFLICT-FREE, non-gated, draft-SD candidates (propose-only per CONST-002; *you* dispatch). Reach out as the belt thins, do **not** wait for full idle. Mechanics: resolve the live Adam session (`claude_sessions` metadata `role=adam`, freshest `heartbeat_at`) and dispatch via the validated guard (`lib/coordinator/dispatch.cjs` `insertCoordinationRow`) with `payload.kind='coordinator_request'`, `topic='source_work'`, `expects_reply` + a `correlation_id`; Adam replies via `adam-advisory`. *(Chairman directive 2026-06-09: make belt-low→ask-Adam a standing default.)*
 
 **SOURCE-TO-CAPACITY — size the ask to live idle capacity, dispatch one capability per worker (chairman directive 2026-06-16).** The belt-low ping to Adam (above) MUST include the **live idle-worker count** — resolve it from the roll-call / `claude_sessions` (idle-alive `loop_state`, fresh `heartbeat_at`), not a guess. Adam sizes the returned shortlist to ~that many **conflict-free** candidates (he pairs this with DECOMPOSE-WEAKEST-LAYER in his own contract). You then **rank the shortlist by gauge-weakness** (weakest VDR-layer capability first) and **dispatch one capability per idle worker**, so the whole weak layer is worked in parallel rather than as one monolithic SD per belt-low cycle. KPI corollary: an idle worker while a weak-layer capability remains unsourced = a sizing failure.
+
+**VERIFY each weak-layer capability’s gauge gap is REAL before dispatching it as a design SD (Adam board verdict 2026-06-16).** A capability that reads low ONLY from a stale/manual KR needs a governed KR re-measure, not a new SD; a foundation/data-contract capability must be sequenced AHEAD of the builds it gates, not dispatched as a parallel tile. This pairs with Adam’s CLASSIFY-each-capability rule in the SD-creation contract — do not dispatch a capability the gauge only *appears* to flag weak.
 3. **ASSIGN to live roll-callers and keep the belt at SURPLUS** so a self-claiming worker never finds it empty. **KPI: an idle worker while sourceable work exists = failure.** *(Active form of "Maximize utilization without conflict" above; complements QF-20260607-583; the one-time startup ritual is SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001.)*
 
 **Reach the chairman for URGENT decisions — `notifyChairman` phone-push (SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001).** When a blocking gate decision or an acceptance-sitting deadline is genuinely time-critical and the chairman is away from the dashboard, escalate to the chairman's PHONE via the shared helper `notifyChairman({title, description, priority, dueDatetime?})` (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). It adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and `dueDatetime` / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push **LAYER on top of** the decision-queue / `fn_chairman_decide`, **NOT a replacement**: file the formal decision as usual, then use `notifyChairman` only when it must be seen NOW. Use it **SPARINGLY — urgent only, never spam the chairman**. It is the SAME shared helper Adam uses for chairman action-items; never re-implement the v1 `reminder_add` POST anywhere. *(memory: chairman directive 2026-06-13.)*
@@ -66,6 +68,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-06-22*
+*Generated from database: 2026-06-23*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: a7dd556dfae5c6c9 -->
+<!-- file_content_hash: 06043575f86efefc -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 9fbe9463eac07950 -->
+<!-- file_content_hash: 783c89f1541719a0 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-22 4:49:32 PM
+**Generated**: 2026-06-23 2:23:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1678,7 +1678,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-22*
+*Generated from database: 2026-06-23*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 40daea8d2fa264cc -->
+<!-- file_content_hash: 75d319a7a238c932 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-22 4:49:32 PM*
+*DIGEST generated: 2026-06-23 2:23:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 6d43903442f65066 -->
+<!-- file_content_hash: 8b5f63b1ce8f0db3 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-22 4:49:32 PM*
+*DIGEST generated: 2026-06-23 2:23:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 50e4a60b1e95711c -->
+<!-- file_content_hash: 5a89810fa3af7fdb -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-22 4:49:32 PM
+**Generated**: 2026-06-23 2:23:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2116,6 +2116,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-06-22*
+*Generated from database: 2026-06-23*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 16cf4e5be4f36e58 -->
+<!-- file_content_hash: 6abe71635e798191 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-22 4:49:32 PM*
+*DIGEST generated: 2026-06-23 2:23:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: a532608edeef35da -->
+<!-- file_content_hash: fe05b8f2e9668212 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-22 4:49:32 PM
+**Generated**: 2026-06-23 2:23:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1582,6 +1582,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-22*
+*Generated from database: 2026-06-23*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: c47365f1cd7e6522 -->
+<!-- file_content_hash: b2703af81bb83269 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-22 4:49:32 PM*
+*DIGEST generated: 2026-06-23 2:23:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 6440661ff08dd580 -->
+<!-- file_content_hash: 821a7c82f2c58e6a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-22 4:49:32 PM
+**Generated**: 2026-06-23 2:23:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2441,6 +2441,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-22*
+*Generated from database: 2026-06-23*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-22T20:49:32.789Z -->
-<!-- git_commit: a2729e8d -->
+<!-- generated_at: 2026-06-23T06:23:35.319Z -->
+<!-- git_commit: edb8b1ea -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 8f997c96693e2f3b -->
+<!-- file_content_hash: 3e430d913959dc0c -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-22 4:49:32 PM*
+*DIGEST generated: 2026-06-23 2:23:35 AM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,109 @@
 {
-  "generated_at": "2026-06-22T20:49:32.789Z",
-  "git_commit": "a2729e8d",
+  "generated_at": "2026-06-23T06:23:35.319Z",
+  "git_commit": "edb8b1ea",
   "db_snapshot_hash": "5ac65ccd27ca615f",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19368,
       "estimated_tokens": 4842,
-      "content_hash": "7a293020f0a83bda",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE.md"
+      "content_hash": "e634b191bbcec3e3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 83518,
       "estimated_tokens": 20880,
-      "content_hash": "0b9219a1772c753d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_CORE.md"
+      "content_hash": "2e233e5e33d27b6e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65128,
       "estimated_tokens": 16282,
-      "content_hash": "b66f8ff083b928e8",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_LEAD.md"
+      "content_hash": "8e9914ed56ca48ee",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 90830,
       "estimated_tokens": 22708,
-      "content_hash": "9b788eb39b64f5a0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_PLAN.md"
+      "content_hash": "6a02a534deccaeae",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 84821,
       "estimated_tokens": 21206,
-      "content_hash": "9ee02541a271a776",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_EXEC.md"
+      "content_hash": "1b0cfa94e766095a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 42502,
-      "estimated_tokens": 10626,
-      "content_hash": "3e44d51e9cb4bb75",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_ADAM.md"
+      "chars": 43574,
+      "estimated_tokens": 10894,
+      "content_hash": "8efab0f6cf5c310b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 19020,
-      "estimated_tokens": 4755,
-      "content_hash": "f297be69287cb113",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_COORDINATOR.md"
+      "chars": 19523,
+      "estimated_tokens": 4881,
+      "content_hash": "7f8c07947b5c334b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "b0e50390821da3f1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_DIGEST.md"
+      "content_hash": "4eb2f97a6bec33f4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11535,
       "estimated_tokens": 2884,
-      "content_hash": "47dcdbc6751e6ee3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "0f4954cd17c054a2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5422,
       "estimated_tokens": 1356,
-      "content_hash": "8d0a8f878037c400",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "83381b2416ce2ebf",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8412,
       "estimated_tokens": 2103,
-      "content_hash": "a156ae984a30bb92",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "f275dbda594507e6",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10835,
       "estimated_tokens": 2709,
-      "content_hash": "fb5f74bcdac6e783",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "40ff20f1aacaf4f1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "7537b69cb0502e96",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "664f1f243c171ce4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 5270,
       "estimated_tokens": 1318,
-      "content_hash": "962b68718a153589",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-PARTNERSHIP-CONTRACT-001\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "b9ec760bae0d7d74",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "d19f07d9278f1ce5",
+    "global": "44bd4d5b81deb655",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -360,8 +360,8 @@
       "601": "24938018ba30efd6",
       "602": "ad0aecae8cdc6cb3",
       "603": "ca922c736e8d8ed3",
-      "604": "67885bf567384f02",
-      "605": "19e13f356fce24ab",
+      "604": "afa021c204fc90e4",
+      "605": "17f0a232fa1fada1",
       "606": "25aa68b575c66d07",
       "607": "82e04c0cc0ffb28f",
       "608": "7f99a4321502367e",

--- a/scripts/one-off/encode-classify-weakest-layer-rule.mjs
+++ b/scripts/one-off/encode-classify-weakest-layer-rule.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * SD-REFILL-00A3H5FN — encode the DECOMPOSE-WEAKEST-LAYER *classify-each-capability* refinement
+ * (Adam board-of-directors verdict 2026-06-16) into the governed leo_protocol_sections SSOT:
+ *   - id=604 (adam_role_contract)        → CLASSIFY-each-capability rule (a/b/c/d) in the Adam block
+ *   - id=605 (coordinator_role_contract) → VERIFY-per-capability-gap-is-real line on dispatch
+ *
+ * Idempotent + additive: it only appends after a unique anchor and is a no-op if the marker
+ * is already present. After running, regenerate the docs:  node scripts/generate-claude-md-from-db.js
+ *
+ * Usage:  node scripts/one-off/encode-classify-weakest-layer-rule.mjs
+ */
+import 'dotenv/config';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+
+const MARKER_604 = 'CLASSIFY each weak capability BEFORE sourcing it (Adam board-of-directors verdict 2026-06-16)';
+const ANCHOR_604 = 'one-capability-per-worker, instead of serializing it behind a single SD.';
+const CLASSIFY_604 = '\n\n**' + MARKER_604 + ' — do NOT blindly source 1 design SD per capability.** A live-grounded board pass found the naive "one tile per capability" framing can yield ZERO valid SDs. For EACH weak capability, classify it FIRST: (a) **genuine leaf** → a Phase-0 design/spec SD (the default above); (b) **foundation / data-contract** — an upstream target-of-record that build SDs depend on (e.g. an ord-11 north-star contract) → **sequence it AHEAD of the builds it gates**, not as a parallel tile; (c) **already-built but reading low ONLY from a STALE/manual KR** (e.g. an ord-7 capability whose breakage-catch is live but the gauge reads ~0% off a manual KR) → a governed **KR RE-MEASURE / repoint-to-live-derivation**, NOT a new build SD; (d) **mis-bucketed** (wrong layer / registry entry) → a **registry fix**. Only (a) becomes a parallel design SD; (b)/(c)/(d) are different work — and the coordinator must VERIFY the per-capability gauge gap is REAL (not a stale-KR artifact) before dispatching.';
+
+const MARKER_605 = 'VERIFY each weak-layer capability’s gauge gap is REAL before dispatching it as a design SD (Adam board verdict 2026-06-16)';
+const ANCHOR_605 = 'an idle worker while a weak-layer capability remains unsourced = a sizing failure.';
+const VERIFY_605 = '\n\n**' + MARKER_605 + '.** A capability that reads low ONLY from a stale/manual KR needs a governed KR re-measure, not a new SD; a foundation/data-contract capability must be sequenced AHEAD of the builds it gates, not dispatched as a parallel tile. This pairs with Adam’s CLASSIFY-each-capability rule in the SD-creation contract — do not dispatch a capability the gauge only *appears* to flag weak.';
+
+async function editSection(sb, id, marker, anchor, insertion) {
+  const { data, error } = await sb.from('leo_protocol_sections').select('content').eq('id', id).maybeSingle();
+  if (error) throw new Error(`read ${id}: ${error.message}`);
+  const content = data?.content || '';
+  if (content.includes(marker)) { console.log(`  [${id}] already encoded — no-op`); return false; }
+  const idx = content.indexOf(anchor);
+  if (idx < 0) throw new Error(`anchor not found in section ${id}`);
+  const at = idx + anchor.length;
+  const next = content.slice(0, at) + insertion + content.slice(at);
+  const { error: uErr } = await sb.from('leo_protocol_sections').update({ content: next }).eq('id', id);
+  if (uErr) throw new Error(`update ${id}: ${uErr.message}`);
+  console.log(`  [${id}] inserted classify/verify refinement (+${insertion.length} chars)`);
+  return true;
+}
+
+async function main() {
+  const sb = createSupabaseServiceClient();
+  await editSection(sb, 604, MARKER_604, ANCHOR_604, CLASSIFY_604);
+  await editSection(sb, 605, MARKER_605, ANCHOR_605, VERIFY_605);
+  console.log('Done. Regenerate docs: node scripts/generate-claude-md-from-db.js');
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error('FATAL:', e.message); process.exit(1); });

--- a/tests/unit/decompose-weakest-classify-rule.test.js
+++ b/tests/unit/decompose-weakest-classify-rule.test.js
@@ -1,0 +1,41 @@
+/**
+ * SD-REFILL-00A3H5FN — guard that the DECOMPOSE-WEAKEST-LAYER classify-each-capability refinement
+ * (Adam board verdict 2026-06-16) survives in the generated role docs. The rule lives in the
+ * leo_protocol_sections DB SSOT (id=604 adam_role_contract / id=605 coordinator_role_contract) and
+ * is rendered into CLAUDE_ADAM.md / CLAUDE_COORDINATOR.md by generate-claude-md-from-db.js. This
+ * test fails if a future regen drops it (or the section is reverted), so the fleet keeps classifying
+ * weak capabilities (leaf / foundation-contract / already-built-stale-KR / mis-bucketed) before
+ * blindly sourcing one design SD per capability.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const read = (f) => fs.readFileSync(path.join(ROOT, f), 'utf8');
+
+describe('SD-REFILL-00A3H5FN: DECOMPOSE-WEAKEST-LAYER classify-each-capability rule', () => {
+  const adam = read('CLAUDE_ADAM.md');
+  const coord = read('CLAUDE_COORDINATOR.md');
+
+  it('CLAUDE_ADAM.md carries the CLASSIFY-each-capability rule', () => {
+    expect(adam).toMatch(/CLASSIFY each weak capability BEFORE sourcing/i);
+    expect(adam).toMatch(/board-of-directors verdict 2026-06-16/i);
+  });
+
+  it('the rule lists all four capability classifications', () => {
+    // (a) leaf, (b) foundation/data-contract, (c) already-built-stale-KR, (d) mis-bucketed
+    expect(adam).toMatch(/genuine leaf/i);
+    expect(adam).toMatch(/foundation \/ data-contract/i);
+    expect(adam).toMatch(/already-built but reading low ONLY from a STALE/i);
+    expect(adam).toMatch(/KR RE-MEASURE/i);
+    expect(adam).toMatch(/mis-bucketed/i);
+  });
+
+  it('CLAUDE_COORDINATOR.md requires verifying the per-capability gauge gap is real', () => {
+    expect(coord).toMatch(/VERIFY each weak-layer capability.{0,4}s gauge gap is REAL/i);
+    expect(coord).toMatch(/stale\/manual KR needs a governed KR re-measure/i);
+  });
+});


### PR DESCRIPTION
## Summary
`SD-LEO-INFRA-SOURCING-CAPACITY-CANONICALIZE-001` (completed) encoded the **base** DECOMPOSE-WEAKEST-LAYER + SOURCE-TO-CAPACITY rules into `leo_protocol_sections` 604/605. But the Adam board refinement — **CLASSIFY each weak capability BEFORE sourcing**, do NOT blindly source 1 design SD per capability — was not encoded (the SD said "fold into" that SD, but it's already completed, so this encodes it directly into the same governed sections).

The live-grounded board (2026-06-16) found the naive "one tile per capability" framing yields **zero valid SDs**: ord-11 north-star is a **foundation data contract** (prerequisite, not a tile); ord-7 is **already built** and reads ~0% only from a **stale KR** (→ a re-measure, not a new SD).

## Changes
- **FR-1** section 604 (`adam_role_contract`) DECOMPOSE-WEAKEST-LAYER block now classifies each weak capability: (a) genuine leaf → design SD; (b) foundation/data-contract → sequence ahead of the builds it gates; (c) already-built-but-stale-KR → governed KR re-measure, not a new SD; (d) mis-bucketed → registry fix.
- **FR-2** section 605 (`coordinator_role_contract`) now requires verifying the per-capability gauge gap is **real** (not a stale-KR artifact) before dispatching.
- **FR-3** regenerated `CLAUDE_ADAM.md` + `CLAUDE_COORDINATOR.md` (+ family) from the DB SSOT; guard test `tests/unit/decompose-weakest-classify-rule.test.js` pins the rule.

Section edits applied idempotently via `scripts/one-off/encode-classify-weakest-layer-rule.mjs`. The 2 gauge defects this SD also logged (KR-2026-07-05 double-count; ord-7 manual-KR drift) are **already fixed** in `lib/vision/vdr-registry.js` (verified) — out of scope here.

## Verification
3/3 guard tests pass. TESTING sub-agent verdict PASS (row `a208e6db`). The doc diff is DB-generated regen (CLAUDE_* family) — the non-ADAM/COORDINATOR files churn only the regen header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)