### PR TITLE
feat(SD-REFILL-00H0UNO7): reap expired-pending spawn requests so fleet revival is no longer permanently blocked

### DIFF
--- a/scripts/coordinator-revive.cjs
+++ b/scripts/coordinator-revive.cjs
@@ -52,9 +52,49 @@ async function findIdleCallsigns(supabase) {
 }
 
 /**
- * INSERT a single revival request. Returns { inserted, alreadyPending, error }.
+ * Pure predicate — is this a PENDING worker_spawn_requests row whose TTL has elapsed?
+ * SD-REFILL-00H0UNO7 (FR-3): an expired-but-still-'pending' row holds the partial unique
+ * index idx_wsr_unique_pending_callsign and thereby permanently blocks fresh revivals.
+ *
+ * Fail-safe: a missing / unparseable expires_at returns FALSE — we never reap a row whose
+ * TTL we cannot read, so a genuinely live request is never destroyed by a bad timestamp.
+ *
+ * @param {{status?:string, expires_at?:string}} row
+ * @param {number} nowMs
+ * @returns {boolean}
  */
-async function reviveOne(supabase, callsign, requestedBySessionId) {
+function isExpiredPendingRow(row, nowMs) {
+  if (!row || row.status !== 'pending') return false;
+  const exp = Date.parse(row.expires_at);
+  if (!Number.isFinite(exp)) return false; // fail-safe: unreadable TTL is treated as not-expired
+  return exp <= nowMs;
+}
+
+/**
+ * Reap (status: pending -> expired) every past-TTL pending request, optionally scoped to a
+ * single callsign. Flipping the row out of 'pending' frees the partial unique index so a
+ * fresh revival can be inserted. Returns the number of rows reaped.
+ * SD-REFILL-00H0UNO7 (FR-1, root cause 3).
+ *
+ * @returns {Promise<number>} rows reaped
+ */
+async function reapExpiredPendingRequests(supabase, { callsign = null, nowIso = new Date().toISOString() } = {}) {
+  let q = supabase
+    .from('worker_spawn_requests')
+    .update({ status: 'expired' })
+    .eq('status', 'pending')
+    .lte('expires_at', nowIso);
+  if (callsign) q = q.eq('requested_callsign', callsign);
+  const { data, error } = await q.select('id');
+  if (error) {
+    console.warn(`  [warn] reapExpiredPendingRequests failed: ${error.message}`);
+    return 0;
+  }
+  return (data || []).length;
+}
+
+/** Raw single-row insert + best-effort broadcast. Returns { inserted, alreadyPending, error, row }. */
+async function insertSpawnRequest(supabase, callsign, requestedBySessionId) {
   const { data, error } = await supabase
     .from('worker_spawn_requests')
     .insert({
@@ -87,6 +127,24 @@ async function reviveOne(supabase, callsign, requestedBySessionId) {
   });
 
   return { inserted: true, alreadyPending: false, error: null, row: data };
+}
+
+/**
+ * INSERT a single revival request. Returns { inserted, alreadyPending, error }.
+ * SD-REFILL-00H0UNO7 (FR-2): on an idempotency (23505) hit, the conflicting pending row may be
+ * EXPIRED (a zombie that never got consumed). Reap the callsign's expired-pending row and retry
+ * the insert ONCE — that unblocks revival. If nothing was reaped, a genuinely LIVE pending
+ * request exists, so we report alreadyPending=true exactly as before (idempotency preserved).
+ */
+async function reviveOne(supabase, callsign, requestedBySessionId) {
+  const first = await insertSpawnRequest(supabase, callsign, requestedBySessionId);
+  if (!first.alreadyPending) return first; // inserted, or a non-idempotency error
+
+  const reaped = await reapExpiredPendingRequests(supabase, { callsign });
+  if (reaped === 0) return first; // a live pending row blocks — correct idempotency skip
+
+  // An expired zombie was reaped; the unique index is now free. Retry once.
+  return insertSpawnRequest(supabase, callsign, requestedBySessionId);
 }
 
 async function main() {
@@ -153,7 +211,7 @@ async function main() {
 }
 
 // Export internal helpers for unit testing.
-module.exports = { NATO, findIdleCallsigns, reviveOne };
+module.exports = { NATO, findIdleCallsigns, reviveOne, insertSpawnRequest, isExpiredPendingRow, reapExpiredPendingRequests };
 
 // Only run main() when invoked as CLI (not when require'd by tests).
 if (require.main === module) {

--- a/tests/unit/coordinator-revive.test.js
+++ b/tests/unit/coordinator-revive.test.js
@@ -8,7 +8,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { NATO, findIdleCallsigns, reviveOne } = require('../../scripts/coordinator-revive.cjs');
+const { NATO, findIdleCallsigns, reviveOne, isExpiredPendingRow, reapExpiredPendingRequests } = require('../../scripts/coordinator-revive.cjs');
 
 describe('NATO roster', () => {
   it('contains the canonical 8 callsigns in order', () => {
@@ -16,7 +16,12 @@ describe('NATO roster', () => {
   });
 });
 
-function mockSupabase({ activeSessions = [], insertResult = null, insertError = null }) {
+// insertSequence (optional): array of {data,error} consumed one per insert() call (for the
+//   reap-then-retry path: first a 23505, then a success). Falls back to {insertResult,insertError}.
+// reapResult (optional): rows the update().select() returns (default [] = nothing reaped, so an
+//   idempotency hit stays alreadyPending — preserving the existing tests' expectation).
+function mockSupabase({ activeSessions = [], insertResult = null, insertError = null, insertSequence = null, reapResult = [], reapError = null }) {
+  let insertCalls = 0;
   return {
     from: (table) => {
       if (table === 'v_active_sessions') {
@@ -28,9 +33,25 @@ function mockSupabase({ activeSessions = [], insertResult = null, insertError = 
         return {
           insert: () => ({
             select: () => ({
-              single: () => Promise.resolve({ data: insertResult, error: insertError })
+              single: () => {
+                if (insertSequence) {
+                  const step = insertSequence[Math.min(insertCalls, insertSequence.length - 1)];
+                  insertCalls++;
+                  return Promise.resolve({ data: step.data ?? null, error: step.error ?? null });
+                }
+                return Promise.resolve({ data: insertResult, error: insertError });
+              }
             })
-          })
+          }),
+          // reap chain: update().eq('status').lte('expires_at').eq('requested_callsign').select('id')
+          update: () => {
+            const chain = {
+              eq: () => chain,
+              lte: () => chain,
+              select: () => Promise.resolve({ data: reapResult, error: reapError })
+            };
+            return chain;
+          }
         };
       }
       if (table === 'session_coordination') {
@@ -139,5 +160,77 @@ describe('reviveOne()', () => {
     const supabase = mockSupabase({ insertResult: row, insertError: null });
     const r = await reviveOne(supabase, 'Charlie', null);
     expect(r.inserted).toBe(true);
+  });
+});
+
+// SD-REFILL-00H0UNO7: fleet revival was broken because an expired-but-still-'pending'
+// worker_spawn_requests row holds the partial unique index and permanently blocks fresh revivals.
+describe('isExpiredPendingRow() — FR-3 pure predicate', () => {
+  const now = Date.parse('2026-06-23T12:00:00Z');
+  it('true for a pending row whose expires_at is in the past', () => {
+    expect(isExpiredPendingRow({ status: 'pending', expires_at: '2026-06-23T11:00:00Z' }, now)).toBe(true);
+  });
+  it('false for a pending row whose expires_at is in the future (live request)', () => {
+    expect(isExpiredPendingRow({ status: 'pending', expires_at: '2026-06-23T13:00:00Z' }, now)).toBe(false);
+  });
+  it('false for a non-pending row regardless of expiry (fulfilled/expired/cancelled)', () => {
+    expect(isExpiredPendingRow({ status: 'fulfilled', expires_at: '2026-06-23T11:00:00Z' }, now)).toBe(false);
+    expect(isExpiredPendingRow({ status: 'expired', expires_at: '2026-06-23T11:00:00Z' }, now)).toBe(false);
+    expect(isExpiredPendingRow({ status: 'cancelled', expires_at: '2026-06-23T11:00:00Z' }, now)).toBe(false);
+  });
+  it('FAIL-SAFE: false for a pending row with missing/unparseable expires_at (never reap an unreadable TTL)', () => {
+    expect(isExpiredPendingRow({ status: 'pending', expires_at: undefined }, now)).toBe(false);
+    expect(isExpiredPendingRow({ status: 'pending', expires_at: 'not-a-date' }, now)).toBe(false);
+    expect(isExpiredPendingRow({ status: 'pending' }, now)).toBe(false);
+  });
+  it('false for null/garbage input', () => {
+    expect(isExpiredPendingRow(null, now)).toBe(false);
+    expect(isExpiredPendingRow(undefined, now)).toBe(false);
+  });
+});
+
+describe('reapExpiredPendingRequests() — FR-1', () => {
+  it('returns the count of reaped rows', async () => {
+    const supabase = mockSupabase({ reapResult: [{ id: 'r1' }, { id: 'r2' }] });
+    const n = await reapExpiredPendingRequests(supabase, { callsign: 'Bravo' });
+    expect(n).toBe(2);
+  });
+  it('returns 0 when nothing is past-TTL', async () => {
+    const supabase = mockSupabase({ reapResult: [] });
+    const n = await reapExpiredPendingRequests(supabase, {});
+    expect(n).toBe(0);
+  });
+  it('fail-soft: returns 0 (not throw) on a DB error', async () => {
+    const supabase = mockSupabase({ reapResult: null, reapError: { message: 'boom' } });
+    const n = await reapExpiredPendingRequests(supabase, {});
+    expect(n).toBe(0);
+  });
+});
+
+describe('reviveOne() — FR-2 reap-then-retry vs idempotency preservation', () => {
+  it('reaps an EXPIRED zombie on a 23505 hit, then the retried insert SUCCEEDS (revival unblocked)', async () => {
+    const row = { id: 'fresh-1', requested_at: 't', expires_at: 't+1h' };
+    const supabase = mockSupabase({
+      insertSequence: [
+        { data: null, error: { code: '23505', message: 'duplicate key' } }, // 1st: blocked by zombie
+        { data: row, error: null }                                            // 2nd: after reap, succeeds
+      ],
+      reapResult: [{ id: 'zombie-1' }] // one expired row reaped → index freed
+    });
+    const r = await reviveOne(supabase, 'Bravo', 'session-123');
+    expect(r.inserted).toBe(true);
+    expect(r.row).toEqual(row);
+  });
+
+  it('PRESERVES idempotency: a LIVE pending row (nothing reaped) still reports alreadyPending, no duplicate', async () => {
+    const supabase = mockSupabase({
+      insertSequence: [
+        { data: null, error: { code: '23505', message: 'duplicate key' } } // blocked by a LIVE row
+      ],
+      reapResult: [] // nothing expired → reap is a no-op
+    });
+    const r = await reviveOne(supabase, 'Bravo', 'session-123');
+    expect(r.inserted).toBe(false);
+    expect(r.alreadyPending).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Fleet revival was found broken fleet-wide (2026-06-15): `worker_spawn_requests` had 8 zombie rows stuck `status=pending`, expired 7-18 days ago, none ever fulfilled. Two root causes:
1. The spawn-execution consumer (`scripts/fleet/worker-spawn-executor.cjs`) is env-gated behind `WORKER_SPAWN_EXECUTOR_LIVE` pending host-validation — **external deploy, out of code scope** (flagged as a completion item).
2. `coordinator-revive.cjs` idempotency relies on the partial unique index (`WHERE status='pending'`), so an **expired-but-still-pending** row triggered a `23505` that `reviveOne` reported as "already pending" — **permanently blocking** fresh revival for that callsign (silently defeated manual revives).
3. No reaper ever flipped past-TTL pending rows out of `pending`.

This fixes root causes **2 + 3** with one mechanism: reap expired-pending rows so the unique index frees up.

## Changes
- `isExpiredPendingRow(row, nowMs)` — pure predicate; **fail-safe** on missing/unparseable `expires_at` (never reaps an unreadable TTL). (FR-3)
- `reapExpiredPendingRequests()` — `UPDATE … SET status='expired' WHERE status='pending' AND expires_at<=now()`, optionally callsign-scoped; fail-soft. (FR-1)
- `reviveOne()` — on a `23505` hit, reap the callsign's expired zombie and **retry the insert once**; a genuinely **live** pending row still reports `alreadyPending` (idempotency preserved). (FR-2)

## Tests
20/20 (`tests/unit/coordinator-revive.test.js`): predicate both directions + fail-safe; reap count/fail-soft; reap-then-retry vs live-skip.
**Live-verified**: seeded an expired pending zombie → `reviveOne` reaped it (→`expired`) and inserted a fresh `pending` row (final `[expired, pending]`).

No DDL — `status='expired'` is already in the table CHECK constraint.

SD: SD-REFILL-00H0UNO7

🤖 Generated with [Claude Code](https://claude.com/claude-code)