### PR TITLE
feat(SD-REFILL-00V67JEB): emit runtime cross-stage contract-enforcement coverage signal (FR-1)

### DIFF
--- a/lib/eva/contracts/contract-coverage.js
+++ b/lib/eva/contracts/contract-coverage.js
@@ -1,0 +1,84 @@
+/**
+ * contract-coverage.js — runtime cross-stage contract-enforcement coverage signal.
+ *
+ * SD-REFILL-00V67JEB (FR-1): the cross-stage data-contract validators (validatePreStage /
+ * validatePostStage) are wired + enforced live in eva-orchestrator, but nothing PERSISTS the
+ * outcome of each enforced transition. The vision ordinal-19 "Cross-stage data contracts" gauge
+ * probe is therefore a code_grep (band-capped at 'partial' by the anti-inflation rule) and can
+ * never advance — there is no measurable signal of contracts being ENFORCED at runtime.
+ *
+ * This emits one append-only coverage row per enforced transition into the generic `audit_log`
+ * table (event_type='contract_coverage'), so a future count_ratio/row_predicate probe (FR-2,
+ * dependent follow-up — needs accumulated rows) can repoint ordinal-19 off code_grep onto a real
+ * enforcement-coverage ratio.
+ *
+ * FAIL-OPEN by contract: a coverage-write failure (or a missing client) NEVER throws and never
+ * affects the venture pipeline — coverage is observability, not a gate. audit_log only constrains
+ * `severity` (info/warning/error/critical); event_type is free.
+ */
+
+/**
+ * Derive the coverage shape from a validatePreStage/validatePostStage result.
+ * Exported pure for unit testing (no I/O).
+ * @param {{valid?: boolean, blocked?: boolean, errors?: any[], warnings?: any[]}} result
+ * @returns {{valid: boolean, blocked: boolean, error_count: number, warning_count: number}}
+ */
+export function summarizeContractResult(result) {
+  const r = result || {};
+  return {
+    valid: r.valid === true,
+    blocked: r.blocked === true,
+    error_count: Array.isArray(r.errors) ? r.errors.length : 0,
+    warning_count: Array.isArray(r.warnings) ? r.warnings.length : 0,
+  };
+}
+
+/**
+ * Build the audit_log row for a contract-coverage event. Exported pure for unit testing.
+ * severity: 'error' when blocked, 'warning' when invalid-but-not-blocked, else 'info'
+ * (all members of the audit_log severity CHECK set).
+ * @returns {object} an audit_log insert payload
+ */
+export function buildCoverageRow({ ventureId, stageNumber, phase, result, enforcementMode, createdBy = 'eva-contract-validator' }) {
+  const s = summarizeContractResult(result);
+  const severity = s.blocked ? 'error' : (s.valid ? 'info' : 'warning');
+  return {
+    event_type: 'contract_coverage',
+    entity_type: 'venture_stage_contract',
+    entity_id: `${ventureId ?? 'unknown'}:${stageNumber ?? '?'}:${phase ?? '?'}`,
+    new_value: { valid: s.valid, blocked: s.blocked },
+    metadata: {
+      venture_id: ventureId ?? null,
+      stage_number: stageNumber ?? null,
+      phase: phase ?? null,              // 'pre' | 'post'
+      valid: s.valid,
+      blocked: s.blocked,
+      error_count: s.error_count,
+      warning_count: s.warning_count,
+      enforcement_mode: enforcementMode ?? null,
+    },
+    severity,
+    created_by: createdBy,
+  };
+}
+
+/**
+ * Emit one contract-coverage row. FAIL-OPEN: returns {emitted:boolean, reason?:string} and never
+ * throws — a write failure or absent client is swallowed so the venture pipeline is never affected.
+ * @param {object} supabase - supabase client (may be null/undefined → no-op)
+ * @param {object} args - { ventureId, stageNumber, phase, result, enforcementMode }
+ * @returns {Promise<{emitted: boolean, reason?: string}>}
+ */
+export async function emitContractCoverage(supabase, args) {
+  try {
+    if (!supabase || typeof supabase.from !== 'function') {
+      return { emitted: false, reason: 'no_client' };
+    }
+    const row = buildCoverageRow(args || {});
+    const { error } = await supabase.from('audit_log').insert(row);
+    if (error) return { emitted: false, reason: error.message };
+    return { emitted: true };
+  } catch (e) {
+    return { emitted: false, reason: e && e.message ? e.message : String(e) };
+  }
+}

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -36,6 +36,8 @@ import { validateStageGate } from '../agents/modules/venture-state-machine/stage
 import { retrieveKnowledge } from './utils/knowledge-retriever.js';
 import { getTemplate } from './stage-templates/index.js';
 import { getContract, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
+// SD-REFILL-00V67JEB (FR-1): persist a runtime contract-enforcement coverage signal (fail-open).
+import { emitContractCoverage } from './contracts/contract-coverage.js';
 import { describeArtifactGap } from './contracts/describe-artifact-gap.js';
 import { recordTokenUsage, checkBudget, buildTokenSummary } from './utils/token-tracker.js';
 import { runRealityTracking } from './utils/assumption-reality-tracker.js';
@@ -341,6 +343,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       const preResult = validatePreStage(resolvedStage, upstreamMap, { logger, enforcement: enforcementMode });
       const preStatus = preResult.valid ? 'completed' : (preResult.blocked ? 'failed' : 'warning');
       tracer.endSpan(preSpan.spanId, { status: preStatus, metadata: { errors: preResult.errors.length, warnings: preResult.warnings.length } });
+      // SD-REFILL-00V67JEB (FR-1): record the enforced pre-stage transition (fail-open observability).
+      await emitContractCoverage(supabase, { ventureId, stageNumber: resolvedStage, phase: 'pre', result: preResult, enforcementMode });
 
       if (!preResult.valid && preResult.blocked) {
         // SD-LEO-INFRA-EVA-ANALYSIS-FIRST-001: Contract pre-validation failures are now
@@ -636,6 +640,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     const postResult = validatePostStage(resolvedStage, stageOutput, { logger, enforcement: enforcementMode });
     const postStatus = postResult.valid ? 'completed' : (postResult.blocked ? 'failed' : 'warning');
     tracer.endSpan(postSpan.spanId, { status: postStatus, metadata: { errors: postResult.errors.length } });
+    // SD-REFILL-00V67JEB (FR-1): record the enforced post-stage transition (fail-open observability).
+    await emitContractCoverage(supabase, { ventureId, stageNumber: resolvedStage, phase: 'post', result: postResult, enforcementMode });
 
     if (!postResult.valid && postResult.blocked) {
       // SD-LEO-INFRA-EVA-ANALYSIS-FIRST-001: Post-validation advisory, not blocking.

--- a/tests/unit/eva/contract-coverage.test.js
+++ b/tests/unit/eva/contract-coverage.test.js
@@ -1,0 +1,67 @@
+/**
+ * SD-REFILL-00V67JEB (FR-1): the runtime contract-enforcement coverage signal.
+ * emitContractCoverage appends one append-only audit_log row per enforced cross-stage transition,
+ * FAIL-OPEN — it must never throw or disturb the venture pipeline. summarizeContractResult /
+ * buildCoverageRow are pure and exercise the shape the (FR-2, follow-up) count_ratio probe will read.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  summarizeContractResult,
+  buildCoverageRow,
+  emitContractCoverage,
+} from '../../../lib/eva/contracts/contract-coverage.js';
+
+describe('summarizeContractResult', () => {
+  it('extracts valid/blocked + error/warning counts', () => {
+    expect(summarizeContractResult({ valid: true, blocked: false, errors: [], warnings: ['w'] }))
+      .toEqual({ valid: true, blocked: false, error_count: 0, warning_count: 1 });
+    expect(summarizeContractResult({ valid: false, blocked: true, errors: ['e1', 'e2'], warnings: [] }))
+      .toEqual({ valid: false, blocked: true, error_count: 2, warning_count: 0 });
+  });
+  it('is robust to a malformed/empty result (fail-open shape)', () => {
+    expect(summarizeContractResult(null)).toEqual({ valid: false, blocked: false, error_count: 0, warning_count: 0 });
+    expect(summarizeContractResult({})).toEqual({ valid: false, blocked: false, error_count: 0, warning_count: 0 });
+  });
+});
+
+describe('buildCoverageRow', () => {
+  it('builds an audit_log row with event_type=contract_coverage + the coverage metadata', () => {
+    const row = buildCoverageRow({ ventureId: 'v1', stageNumber: 5, phase: 'pre', result: { valid: true, errors: [], warnings: [] }, enforcementMode: 'BLOCKING' });
+    expect(row.event_type).toBe('contract_coverage');
+    expect(row.entity_type).toBe('venture_stage_contract');
+    expect(row.entity_id).toBe('v1:5:pre');
+    expect(row.metadata).toMatchObject({ venture_id: 'v1', stage_number: 5, phase: 'pre', valid: true, blocked: false, enforcement_mode: 'BLOCKING' });
+    expect(row.created_by).toBe('eva-contract-validator');
+  });
+  it('maps severity to a valid audit_log value: blocked→error, invalid→warning, valid→info', () => {
+    expect(buildCoverageRow({ result: { valid: true } }).severity).toBe('info');
+    expect(buildCoverageRow({ result: { valid: false, blocked: false } }).severity).toBe('warning');
+    expect(buildCoverageRow({ result: { valid: false, blocked: true } }).severity).toBe('error');
+  });
+});
+
+describe('emitContractCoverage (FAIL-OPEN)', () => {
+  it('inserts the coverage row when a client is provided', async () => {
+    const insert = vi.fn(async () => ({ error: null }));
+    const supabase = { from: vi.fn(() => ({ insert })) };
+    const res = await emitContractCoverage(supabase, { ventureId: 'v1', stageNumber: 3, phase: 'post', result: { valid: true, errors: [], warnings: [] }, enforcementMode: 'ADVISORY' });
+    expect(res).toEqual({ emitted: true });
+    expect(supabase.from).toHaveBeenCalledWith('audit_log');
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'contract_coverage', entity_id: 'v1:3:post' }));
+  });
+  it('no-ops (never throws) when the client is missing', async () => {
+    expect(await emitContractCoverage(null, {})).toEqual({ emitted: false, reason: 'no_client' });
+    expect(await emitContractCoverage({}, {})).toEqual({ emitted: false, reason: 'no_client' });
+  });
+  it('swallows an insert error (fail-open, returns reason — never throws)', async () => {
+    const supabase = { from: () => ({ insert: async () => ({ error: { message: 'boom' } }) }) };
+    const res = await emitContractCoverage(supabase, { ventureId: 'v', stageNumber: 1, phase: 'pre', result: {} });
+    expect(res).toEqual({ emitted: false, reason: 'boom' });
+  });
+  it('swallows a thrown client error (fail-open — pipeline never breaks)', async () => {
+    const supabase = { from: () => { throw new Error('client exploded'); } };
+    const res = await emitContractCoverage(supabase, { ventureId: 'v', stageNumber: 1, phase: 'pre', result: {} });
+    expect(res.emitted).toBe(false);
+    expect(res.reason).toBe('client exploded');
+  });
+});


### PR DESCRIPTION
## Summary
The cross-stage data-contract validators (`validatePreStage`/`validatePostStage`) run live in `eva-orchestrator` but nothing persisted each enforced transition, so the vision ordinal-19 *'Cross-stage data contracts'* VDR probe is a `code_grep` (capped at 'partial') with no enforcement signal to advance on.

**FR-1:** a fail-open `emitContractCoverage` helper appends one append-only `audit_log` row (`event_type='contract_coverage'`) per enforced pre/post transition, wired at the two live eva-orchestrator validation sites. **FAIL-OPEN** (3 layers: missing-client no-op, insert-error swallow, outer try/catch) — coverage is observability, never a gate; the venture pipeline is never affected. **No migration** (reuses `audit_log`; only its severity column is constrained).

## Verification
- 8/8 unit tests (pure builders + all fail-open paths); validation PASS-94 (premises + audit_log insert probed live); TESTING PASS-95

## Scope
**FR-2** — repoint the ordinal-19 probe from `code_grep` to a `count_ratio` over this signal — is a **dependent follow-up**: a ratio is meaningless until `contract_coverage` rows accumulate across live venture runs (temporal data dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)