### PR TITLE
fix(SD-REFILL-00MFWEGZ): backlog-rank excludes orchestrator children whose parent has not passed LEAD

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -41,6 +41,9 @@ import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispa
 // handling both the [{sd_id}]/[{sd_key}] object and raw-string shapes the old hand-rolled
 // resolver coerced, while correctly dropping the sentinel the hand-rolled one mis-counted.
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
+// SD-REFILL-00MFWEGZ: reuse the canonical parent-LEAD-pass dispatch gate so the ranking surface
+// mirrors what claim-eligibility actually blocks (no drift between rank-vs-claim).
+import { parentLeadPending } from '../lib/fleet/claim-eligibility.cjs';
 // SD-REFILL-00AH2L4Q: honor the SAME canonical metadata blocker key (metadata.blocked_by_sd_key)
 // that dependency-resolver + worker-checkin enforce, so the dispatch ranker does not keep a
 // metadata-blocked SD on the claimable belt (the convention was inconsistently enforced fleet-wide).
@@ -79,7 +82,9 @@ async function main() {
   const { data: sds, error } = await sb.from('strategic_directives_v2')
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + title, description to classify bare-shell stubs.
     // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + current_phase for the in-flight (started) guard.
-    .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata')
+    // SD-REFILL-00MFWEGZ: + parent_sd_id so parentLeadPending can exclude an orchestrator child
+    // whose parent has not yet passed LEAD (else the field is undefined → the gate silently no-ops).
+    .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata, parent_sd_id')
     .not('status', 'in', '("completed","cancelled","deferred")');
   if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return; }
 
@@ -141,6 +146,15 @@ async function main() {
     const unmet = blockerKeysFor(d)
       .filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
     if (unmet.length) continue;
+    // SD-REFILL-00MFWEGZ: an orchestrator child whose PARENT has not passed LEAD is not yet
+    // dispatchable (claim-eligibility blocks it via the same gate, and it would hit the hard
+    // parent-LEAD EXEC-transition block) — exclude it from fresh ranking so the ranked belt
+    // matches the actually-claimable set. parentLeadPending early-returns false for parentless
+    // SDs (no fetch) and fail-opens on error (never strands a child).
+    if (await parentLeadPending(sb, d)) {
+      console.log(`  [skip] parent not past LEAD — child not yet dispatchable: ${d.sd_key}`);
+      continue;
+    }
     claimable.push(d);
   }
   if (fixtureSkips) console.log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);

--- a/tests/unit/backlog-rank-parent-lead-pending.test.js
+++ b/tests/unit/backlog-rank-parent-lead-pending.test.js
@@ -1,0 +1,61 @@
+/**
+ * SD-REFILL-00MFWEGZ — coordinator-backlog-rank now excludes an orchestrator child whose PARENT
+ * has not passed LEAD, by reusing the canonical parentLeadPending gate (lib/fleet/claim-eligibility.cjs).
+ * This pins that gate's contract so the ranking surface stays in lockstep with the claim surface:
+ * a child is dispatchable only once its parent passes LEAD-TO-PLAN (or is completed / has no parent).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parentLeadPending } = require('../../lib/fleet/claim-eligibility.cjs');
+
+/** Mock sb whose strategic_directives_v2 lookup resolves to a given parent row (or error). */
+function sbWithParent(parentRow, err = null) {
+  return {
+    from() {
+      return {
+        select() {
+          return {
+            or() {
+              return { maybeSingle: () => Promise.resolve({ data: parentRow, error: err }) };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('SD-REFILL-00MFWEGZ: parentLeadPending (backlog-rank child exclusion gate)', () => {
+  it('returns false (rankable) for an SD with no parent_sd_id — no fetch', async () => {
+    let fetched = false;
+    const sb = { from() { fetched = true; return {}; } };
+    expect(await parentLeadPending(sb, { sd_key: 'SD-X-001' })).toBe(false);
+    expect(fetched).toBe(false);
+  });
+
+  it('returns true (excluded) when the parent is in LEAD', async () => {
+    const sb = sbWithParent({ status: 'draft', current_phase: 'LEAD' });
+    expect(await parentLeadPending(sb, { sd_key: 'SD-A1', parent_sd_id: 'SD-A' })).toBe(true);
+  });
+
+  it('returns true (excluded) when the parent is in LEAD_APPROVAL', async () => {
+    const sb = sbWithParent({ status: 'pending_approval', current_phase: 'LEAD_APPROVAL' });
+    expect(await parentLeadPending(sb, { sd_key: 'SD-B1', parent_sd_id: 'SD-B' })).toBe(true);
+  });
+
+  it('returns false (rankable) when the parent has passed LEAD (e.g. EXEC)', async () => {
+    const sb = sbWithParent({ status: 'in_progress', current_phase: 'EXEC' });
+    expect(await parentLeadPending(sb, { sd_key: 'SD-C1', parent_sd_id: 'SD-C' })).toBe(false);
+  });
+
+  it('returns false (rankable) when the parent is completed', async () => {
+    const sb = sbWithParent({ status: 'completed', current_phase: 'COMPLETED' });
+    expect(await parentLeadPending(sb, { sd_key: 'SD-D1', parent_sd_id: 'SD-D' })).toBe(false);
+  });
+
+  it('fail-opens to false (rankable) when the parent lookup errors or returns nothing', async () => {
+    expect(await parentLeadPending(sbWithParent(null, { message: 'boom' }), { sd_key: 'SD-E1', parent_sd_id: 'SD-E' })).toBe(false);
+    expect(await parentLeadPending(sbWithParent(null), { sd_key: 'SD-F1', parent_sd_id: 'SD-F' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`coordinator-backlog-rank.mjs` ranked orchestrator-child leaves as claimable even when their **parent** orchestrator had not passed LEAD. Its filter checked claim/orchestrator/in-flight/fixture/dep-blockers but **not** the parent-chain state — so a grandchild leaf (CRONGENIUS `A1`-`E1`) got ranked 1-5 while its parent (`A`-`E`) was a draft in LEAD.

The **claim** path already blocks dispatching such a child (`parentLeadPending`, SD-REFILL-00SO4HZY), so the ranked-but-unclaimable leaves only **polluted the ranked belt + belt-depth signal** (and a worker reaching EXEC would hit the hard parent-LEAD activation block).

## Changes
- **FR-1** add `parent_sd_id` to the `strategic_directives_v2` select (the `parentLeadPending` input-column contract).
- **FR-2** import `parentLeadPending` from `lib/fleet/claim-eligibility.cjs` and exclude a child whose parent is pre-LEAD-pass from the claimable filter — **reusing the canonical gate** so the ranking surface mirrors the claim surface (no drift). Early-returns false for parentless SDs (no fetch); fail-opens on error. *(Note: the SD framed it as "parent in EXEC", but the authoritative shipped gate is "parent past LEAD" — a child can do its own LEAD+PLAN once the parent passes LEAD-TO-PLAN.)*
- **FR-3** `tests/unit/backlog-rank-parent-lead-pending.test.js` (6 tests): parent LEAD/LEAD_APPROVAL excluded; parent EXEC/completed/no-parent ranked; fail-open.

## Verification
6/6 tests pass; `node --check` clean. TESTING sub-agent verdict PASS (row `c6e51ad4`). Aligns the ranked belt with the actually-claimable set so capacity/belt-depth signals aren't inflated by blocked children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)