### PR TITLE
feat(SD-REFILL-005M4BN9): reconcile fleet-dashboard P(alive) gauge with authoritative liveness

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -86,6 +86,29 @@ function pBar(p, width = 10) {
   return '\u2593'.repeat(filled) + '\u2591'.repeat(width - filled);
 }
 
+/**
+ * SD-REFILL-005M4BN9: the Monte-Carlo P(alive) gauge is computed from raw heartbeat-age only,
+ * so a worker in a legitimate armed-silence window (expected_silence_until in the future,
+ * running a long sub-agent op) or with a live PID shows P(alive)=0.00 \u2014 while the AUTHORITATIVE
+ * checks (stale-session-sweep PID/armed-silence + charter-audit DUTY-2) correctly count it ALIVE.
+ * That false 'dying worker' reading lures the coordinator into force-releasing a mid-operation
+ * worker. Reconcile the gauge with the SAME authoritative signals: short-circuit P(alive) to 1.0
+ * when PID-alive, a fresh process-tick, or within an armed-silence window. The override only ever
+ * RAISES a false-low reading for an authoritatively-alive worker \u2014 it never masks a real death
+ * (no authoritative signal => the raw MC estimate is preserved). Stamped + reasoned (auditable,
+ * not a silent fabrication). Pure/total: returns a NEW object, never mutates; null-safe.
+ *
+ * @param {{session_id?:string, p_alive?:number}|null} mcWorker
+ * @param {{pidAlive?:boolean, tickAlive?:boolean, silenceArmed?:boolean}} signals
+ * @returns {object|null}
+ */
+function reconcilePAliveWithLiveness(mcWorker, { pidAlive = false, tickAlive = false, silenceArmed = false } = {}) {
+  if (!mcWorker || typeof mcWorker !== 'object') return mcWorker;
+  if (!(pidAlive || tickAlive || silenceArmed)) return mcWorker;
+  const reason = pidAlive ? 'pid_alive' : tickAlive ? 'process_tick' : 'armed_silence';
+  return { ...mcWorker, p_alive: 1, p_alive_authoritative_override: true, p_alive_override_reason: reason };
+}
+
 function formatEtaTime(iso) {
   if (!iso) return '-';
   try {
@@ -290,6 +313,18 @@ async function loadData() {
   const mcByWorker = {};
   if (mc && Array.isArray(mc.workers)) {
     for (const w of mc.workers) mcByWorker[w.session_id] = w;
+    // SD-REFILL-005M4BN9: reconcile the raw-heartbeat P(alive) gauge with the SAME authoritative
+    // liveness signals the active/stale split uses, so an armed-silence / PID-alive worker is not
+    // shown as a false 'dying worker' (P(alive)=0.00) that lures a force-release.
+    for (const s of sessions) {
+      const w = mcByWorker[s.session_id];
+      if (!w) continue;
+      mcByWorker[s.session_id] = reconcilePAliveWithLiveness(w, {
+        pidAlive: hasPidAlive(s),
+        tickAlive: hasTickAlive(s),
+        silenceArmed: hasExpectedSilence(s),
+      });
+    }
   }
 
   // QF-20260525-836: surface open/in_progress QFs (aging ones went unseen). Degrade-safe.
@@ -1506,7 +1541,7 @@ async function main() {
 }
 
 // Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
-module.exports = { printFeedback };
+module.exports = { printFeedback, reconcilePAliveWithLiveness };
 
 // Only run the CLI when invoked directly, so requiring this module in a test does
 // not execute main() against the live database.

--- a/tests/unit/coordinator/fleet-dashboard-palive-liveness.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-palive-liveness.test.js
@@ -1,0 +1,69 @@
+/**
+ * SD-REFILL-005M4BN9 — fleet-dashboard P(alive) gauge must factor authoritative liveness
+ * (armed-silence / PID / process-tick) so a mid-operation worker is not shown as a false
+ * 'dying worker' (P(alive)=0.00) that lures the coordinator into a force-release.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { reconcilePAliveWithLiveness } = require('../../../scripts/fleet-dashboard.cjs');
+
+describe('reconcilePAliveWithLiveness() — FR-1/FR-3', () => {
+  const lowWorker = () => ({ session_id: 'w1', p_alive: 0.0 });
+
+  it('overrides P(alive) to 1.0 when within an armed-silence window', () => {
+    const r = reconcilePAliveWithLiveness(lowWorker(), { silenceArmed: true });
+    expect(r.p_alive).toBe(1);
+    expect(r.p_alive_authoritative_override).toBe(true);
+    expect(r.p_alive_override_reason).toBe('armed_silence');
+  });
+
+  it('overrides P(alive) to 1.0 when PID-alive', () => {
+    const r = reconcilePAliveWithLiveness(lowWorker(), { pidAlive: true });
+    expect(r.p_alive).toBe(1);
+    expect(r.p_alive_override_reason).toBe('pid_alive');
+  });
+
+  it('overrides P(alive) to 1.0 when a fresh process-tick is present', () => {
+    const r = reconcilePAliveWithLiveness(lowWorker(), { tickAlive: true });
+    expect(r.p_alive).toBe(1);
+    expect(r.p_alive_override_reason).toBe('process_tick');
+  });
+
+  it('FR-3: returns the worker UNCHANGED (raw p_alive preserved) when no authoritative signal', () => {
+    const w = lowWorker();
+    const r = reconcilePAliveWithLiveness(w, { pidAlive: false, tickAlive: false, silenceArmed: false });
+    expect(r).toBe(w); // same reference — no override object created
+    expect(r.p_alive).toBe(0.0);
+    expect(r.p_alive_authoritative_override).toBeUndefined();
+  });
+
+  it('does not mutate the input worker (returns a new object on override)', () => {
+    const w = lowWorker();
+    const r = reconcilePAliveWithLiveness(w, { pidAlive: true });
+    expect(w.p_alive).toBe(0.0); // original untouched
+    expect(r).not.toBe(w);
+  });
+
+  it('reason precedence: pid_alive > process_tick > armed_silence when several are true', () => {
+    expect(reconcilePAliveWithLiveness(lowWorker(), { pidAlive: true, tickAlive: true, silenceArmed: true }).p_alive_override_reason).toBe('pid_alive');
+    expect(reconcilePAliveWithLiveness(lowWorker(), { tickAlive: true, silenceArmed: true }).p_alive_override_reason).toBe('process_tick');
+    expect(reconcilePAliveWithLiveness(lowWorker(), { silenceArmed: true }).p_alive_override_reason).toBe('armed_silence');
+  });
+
+  it('null-safe: passes through null/undefined/non-object without throwing', () => {
+    expect(reconcilePAliveWithLiveness(null, { pidAlive: true })).toBe(null);
+    expect(reconcilePAliveWithLiveness(undefined, { pidAlive: true })).toBe(undefined);
+    expect(() => reconcilePAliveWithLiveness(null)).not.toThrow();
+  });
+
+  it('preserves other MC fields while overriding p_alive', () => {
+    const w = { session_id: 'w9', p_alive: 0.12, eta_minutes: 7, samples: 1000 };
+    const r = reconcilePAliveWithLiveness(w, { silenceArmed: true });
+    expect(r.session_id).toBe('w9');
+    expect(r.eta_minutes).toBe(7);
+    expect(r.samples).toBe(1000);
+    expect(r.p_alive).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
The fleet-dashboard Monte-Carlo **P(alive)** gauge is computed from **raw heartbeat-age only**. A worker in a legitimate **armed-silence** window (`expected_silence_until` in the future, running a long sub-agent op) or with a **live PID** shows `P(alive)=0.00` with a 14-20m stale heartbeat — even though the authoritative checks (`stale-session-sweep` PID/armed-silence + `coordinator-charter-audit` DUTY-2) correctly count it **ALIVE** and never release it. That false "dying worker" reading lures the coordinator into force-releasing/reviving a mid-operation worker.

Same gauge-ignores-authoritative-signal class as the charter-audit DUTY-3 FPs (#4778, #5090).

## Fix
- `reconcilePAliveWithLiveness(mcWorker, {pidAlive,tickAlive,silenceArmed})` — pure, null-safe; short-circuits `p_alive` to `1.0` and stamps `p_alive_authoritative_override` + `p_alive_override_reason` when authoritatively alive; returns the worker **unchanged** otherwise (raw MC estimate preserved — the override only ever *raises* a false-low reading, never masks a real death).
- Wired into the `mcByWorker` build using the dashboard's **existing** `hasPidAlive`/`hasTickAlive`/`hasExpectedSilence` helpers — the same signals the active/stale classification uses, so the gauge and the classification now agree.

## Tests
8 new unit tests (`fleet-dashboard-palive-liveness.test.js`): each signal overrides; no-signal returns the same reference (raw preserved); no-mutate; reason precedence; null-safe; other MC fields preserved. Existing `fleet-dashboard-feedback` 5/5 green. No DDL.

SD: SD-REFILL-005M4BN9

🤖 Generated with [Claude Code](https://claude.com/claude-code)