### PR TITLE
feat(SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001): capture WHY a worker winds down, surface on re-engage, aggregate fleet-wide

### DIFF
--- a/.claude/commands/checkin.md
+++ b/.claude/commands/checkin.md
@@ -62,6 +62,8 @@ The CLI prints **one JSON object** describing the resolved action. It does the w
 
 This is an autonomous-fleet contract: a `/loop` worker must keep moving. Decide from the JSON, act, and proceed. Never end a check-in by asking the operator what to do (no human watches the loop window).
 
+**Prior wind-down (SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001):** when the JSON carries a non-null `prior_wind_down` (`{reason, at, had_claim}` — captured by the Stop hook when you last stopped: `signaled` | `second_stop` | `no_claim_idle`), briefly surface it before acting, e.g. *"you previously stopped because `<reason>` at `<at>` — confirm or correct"*. If the inferred reason is wrong, send the correction via `/signal feedback "wind-down reason was actually <X>, not <reason>"` so the fleet-wide stop-reason data (feedback `category='wind_down_survey'`) stays accurate. This is a one-line surface, not a pause — proceed to act on `action` in the same turn.
+
 **The cycle never terminates on its own.** For `resume` / `resume_final` / `resume_orphan` / `claimed_assignment` /
 `self_claimed`: build the SD through completion (for `resume_final`, just run the final
 LEAD-FINAL-APPROVAL handoff + post-completion tail), then **re-run `/checkin`** to pull the next

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -142,6 +142,63 @@ async function parkSessionRecoverable(sessionId) {
   }
 }
 
+/**
+ * SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a): classify WHY a worker is winding down at the
+ * allow/park path, for the metadata.wind_down capture + fleet-wide aggregation. Pure/total.
+ *   - 'signaled'     — the worker announced a wind-down via /signal (windDownSignaled)
+ *   - 'second_stop'  — the Stop hook's second-stop allow-path (stop_hook_active)
+ *   - 'no_claim_idle'— neither, but a looping worker is parking with no live claim
+ * @param {{ windDownSignaled?:boolean, stopHookActive?:boolean }} args
+ * @returns {'signaled'|'second_stop'|'no_claim_idle'}
+ */
+function classifyWindDownReason({ windDownSignaled, stopHookActive } = {}) {
+  if (windDownSignaled) return 'signaled';
+  if (stopHookActive) return 'second_stop';
+  return 'no_claim_idle';
+}
+
+/**
+ * SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a)+(c): record WHY this worker wound down.
+ * (a) merge claude_sessions.metadata.wind_down = {reason, at, had_claim} (read-modify-merge,
+ *     preserving sibling metadata keys), surfaced at re-engage by worker-checkin.
+ * (c) mirror to the feedback table (category='wind_down_survey') via the canonical emitFeedback
+ *     writer for fleet-wide stop-reason aggregation.
+ * Best-effort / fail-open — any failure is logged and never blocks the stop.
+ */
+async function recordWindDown(supabase, sessionId, { reason, hadClaim } = {}) {
+  const at = new Date().toISOString();
+  // (a) metadata.wind_down merge — preserve existing metadata keys.
+  try {
+    const { data: row } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    const metadata = { ...(row && row.metadata ? row.metadata : {}) };
+    metadata.wind_down = { reason, at, had_claim: !!hadClaim };
+    await supabase.from('claude_sessions').update({ metadata }).eq('session_id', sessionId);
+  } catch (e) {
+    process.stderr.write(`[stop-loop-wakeup-reminder] wind_down metadata (non-fatal): ${e.message}\n`);
+  }
+  // (c) fleet-wide aggregation mirror — canonical feedback writer (ESM; dynamic-import from CJS).
+  try {
+    const { emitFeedback } = await import('../../lib/governance/emit-feedback.js');
+    await emitFeedback({
+      supabase,
+      title: `Worker wind-down (${reason})`,
+      description: `Worker session ${sessionId} wound down: reason=${reason}, had_claim=${!!hadClaim}.`,
+      category: 'wind_down_survey',
+      severity: 'low',
+      source_type: 'wind_down_survey',
+      metadata: { session_id: sessionId, reason, had_claim: !!hadClaim, at },
+      // One row per session per minute-bucket per reason — idempotent if the hook fires twice.
+      dedup_key: `wind_down::${sessionId}::${reason}::${at.slice(0, 16)}`,
+    });
+  } catch (e) {
+    process.stderr.write(`[stop-loop-wakeup-reminder] wind_down feedback mirror (non-fatal): ${e.message}\n`);
+  }
+}
+
 const REMINDER = [
   'Worker stopping with NO ScheduleWakeup armed — you will go INCOGNITO and strand your claimed SD',
   '(the worktree then gets reaped by the claim-sweep). Run the WIND-DOWN HANDSHAKE before you stop:',
@@ -248,6 +305,12 @@ async function main() {
     // coordinator-revival / orphan-adoption re-engages it, instead of a cold-exit to zero workers.
     if (shouldParkRecoverable({ loopState, hasActiveClaim, windDownSignaled })) {
       await parkSessionRecoverable(sessionId);
+      // SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a)+(c): capture WHY this worker wound down
+      // (same worker-gate as the park, so no false telemetry on a non-worker operator session).
+      await recordWindDown(supabase, sessionId, {
+        reason: classifyWindDownReason({ windDownSignaled, stopHookActive }),
+        hadClaim: hasActiveClaim,
+      });
     }
     return shutdown();
   } catch (e) {
@@ -265,4 +328,4 @@ if (require.main === module) {
   main().catch(() => shutdown());
 }
 
-module.exports = { shouldRemind, shouldParkRecoverable, parkSessionRecoverable, isFlagEnabled, REMINDER };
+module.exports = { shouldRemind, shouldParkRecoverable, parkSessionRecoverable, classifyWindDownReason, recordWindDown, isFlagEnabled, REMINDER };

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -846,6 +846,11 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
 
   const base = { ok: true, callsign, coordinator: coordinatorId, roll_call_id: rollCall.id, two_way: process.env.COORDINATOR_TWOWAY_V2 === 'on' };
 
+  // SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (b): surface the prior wind-down reason captured by the
+  // Stop hook (claude_sessions.metadata.wind_down) so the /checkin skill can render "you previously
+  // stopped because X — confirm/correct" and the worker can correct the inferred reason at re-engage.
+  base.prior_wind_down = (sessionMetadata && sessionMetadata.wind_down) ? sessionMetadata.wind_down : null;
+
   // FR-1/FR-3: surface UNCONSUMED coordinator->worker push as coordinator_messages[] on the `base`
   // object so EVERY return path (resume / idle / self_claimed / self_claimed_qf) carries it — a busy
   // claim-holder AND an idle worker both see coordinator coaching. Non-draining + bounded (see fn).

--- a/tests/unit/hooks/stop-loop-park-recoverable.test.js
+++ b/tests/unit/hooks/stop-loop-park-recoverable.test.js
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { shouldParkRecoverable, shouldRemind } = require('../../../scripts/hooks/stop-loop-wakeup-reminder.cjs');
+const { shouldParkRecoverable, shouldRemind, classifyWindDownReason } = require('../../../scripts/hooks/stop-loop-wakeup-reminder.cjs');
 
 describe('shouldParkRecoverable (SD-LEO-INFRA-WORKER-ENGAGEMENT-ARM-PARK-001)', () => {
   it('PARKS a claim-holding worker on an allow-path (the keystone-unblock strand case)', () => {
@@ -45,5 +45,21 @@ describe('shouldRemind allow-paths still allow (then the caller parks)', () => {
   });
   it('a still-active loop worker (no wind-down, first stop) is BLOCKED (not yet an allow-path)', () => {
     expect(shouldRemind({ flagEnabled: true, stopHookActive: false, hasActiveClaim: false, loopState: 'active', windDownSignaled: false })).toBe(true);
+  });
+});
+
+// SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a): classify WHY a worker is winding down at the park path.
+describe('classifyWindDownReason (SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001)', () => {
+  it("'signaled' when the worker announced a wind-down (wins over second-stop)", () => {
+    expect(classifyWindDownReason({ windDownSignaled: true, stopHookActive: false })).toBe('signaled');
+    expect(classifyWindDownReason({ windDownSignaled: true, stopHookActive: true })).toBe('signaled');
+  });
+  it("'second_stop' on the second-stop allow-path when not signaled", () => {
+    expect(classifyWindDownReason({ windDownSignaled: false, stopHookActive: true })).toBe('second_stop');
+  });
+  it("'no_claim_idle' when neither signaled nor second-stop (a looping worker parking)", () => {
+    expect(classifyWindDownReason({ windDownSignaled: false, stopHookActive: false })).toBe('no_claim_idle');
+    expect(classifyWindDownReason({})).toBe('no_claim_idle');
+    expect(classifyWindDownReason()).toBe('no_claim_idle');
   });
 });

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -59,7 +59,7 @@ describe('extractDirectedSd — structured directed fields only (finding #2)', (
 
 // resolveCheckin seam 1 — fake sb: session holds mySd; an unread WORK_ASSIGNMENT targets a
 // different SD. The assignment must surface on the resume result without dropping the claim.
-function fakeSb({ heldSd, assignmentSd }) {
+function fakeSb({ heldSd, assignmentSd, windDown }) {
   return {
     rpc: () => Promise.resolve({ data: { success: true }, error: null }),
     from(table) {
@@ -67,7 +67,7 @@ function fakeSb({ heldSd, assignmentSd }) {
         _t: table, select() { return this; }, eq() { return this; }, gte() { return this; },
         order() { return this; }, limit() { return this; },
         maybeSingle() {
-          if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: heldSd }, error: null });
+          if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker', ...(windDown ? { wind_down: windDown } : {}) }, sd_key: heldSd }, error: null });
           if (table === 'strategic_directives_v2') return Promise.resolve({ data: { status: 'in_progress' }, error: null });
           return Promise.resolve({ data: null, error: null });
         },
@@ -108,6 +108,35 @@ describe('resolveCheckin — surface pending WORK_ASSIGNMENT on resume (seam 1)'
       const res = await resolveCheckin(sb, 'sess-busy', { getCoordinator: async () => null });
       expect(res.action).toBe('resume');
       expect(res.pending_work_assignment).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  // SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (b): the prior wind-down captured by the Stop hook
+  // (claude_sessions.metadata.wind_down) is surfaced as base.prior_wind_down at re-engage.
+  it('surfaces prior_wind_down from metadata.wind_down at re-engage', async () => {
+    const wind = { reason: 'no_claim_idle', at: '2026-06-23T07:00:00.000Z', had_claim: false };
+    const sb = fakeSb({ heldSd: 'SD-CURRENT-001', assignmentSd: null, windDown: wind });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [];
+    try {
+      const res = await resolveCheckin(sb, 'sess-busy', { getCoordinator: async () => null });
+      expect(res.prior_wind_down).toEqual(wind);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('prior_wind_down is null when no wind_down was recorded', async () => {
+    const sb = fakeSb({ heldSd: 'SD-CURRENT-001', assignmentSd: null });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [];
+    try {
+      const res = await resolveCheckin(sb, 'sess-busy', { getCoordinator: async () => null });
+      expect(res.prior_wind_down).toBe(null);
     } finally {
       ws.getMessagesForSession = orig;
     }


### PR DESCRIPTION
## Summary
The fleet repeatedly cold-wound-down with **no data on WHY**. This adds the missing WHY capture (chairman directive). Pairs with WORKER-ENGAGEMENT-ARM-PARK-001 (the fix).

## Changes
- **(a)** Stop hook: pure `classifyWindDownReason` (`signaled`|`second_stop`|`no_claim_idle`) + `recordWindDown` merges `claude_sessions.metadata.wind_down={reason,at,had_claim}`. Gated on `shouldParkRecoverable` (no operator telemetry).
- **(b)** `worker-checkin` `resolveCheckin` surfaces `base.prior_wind_down`; `.claude/commands/checkin.md` renders confirm/correct (correctable via `/signal`).
- **(c)** mirrors each wind-down to `feedback` (`category='wind_down_survey'`) via canonical `emitFeedback` for fleet-wide aggregation.

All DB writes best-effort/**fail-open**. No DDL.

## Tests
27/27. TESTING PASS (id 3e90ac3c).

SD: SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)