### PR TITLE
feat(SD-LEO-INFRA-ROLE-SESSION-NAMING-001): stable status-line name for role-sessions (Adam/Coordinator/Solomon)

### DIFF
--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -248,6 +248,13 @@ async function setActiveCoordinator(supabase, sessionId) {
     throw new Error('setActiveCoordinator: sessionId required');
   }
 
+  // SD-LEO-INFRA-ROLE-SESSION-NAMING-001: give this coordinator session a stable status-line NAME
+  // (covers both the flag-on and flag-off paths below). Fail-soft — never block coordinator startup.
+  try {
+    const { writeRoleStatusIdentity } = require('../fleet/role-status-identity.cjs');
+    writeRoleStatusIdentity({ sessionId, role: 'coordinator' });
+  } catch { /* status-line naming is best-effort */ }
+
   // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-A / FR-1: register-before-retire ordering.
   // Under flag-ON: (1) drain → (2) upsert NEW holder → (3) retire incumbents → (4) write pointer.
   // Under flag-OFF: legacy order is (1) write pointer → (2) drain → (3) upsert NEW holder.

--- a/lib/fleet/role-status-identity.cjs
+++ b/lib/fleet/role-status-identity.cjs
@@ -1,0 +1,66 @@
+// SD-LEO-INFRA-ROLE-SESSION-NAMING-001: stable status-line NAME for role-sessions (Adam,
+// Coordinator, future Solomon). Workers get a NATO callsign from the claim-gated 8-name pool
+// (worker-checkin → SET_IDENTITY → coordination-inbox writes .claude/fleet-identity-<csid>.json →
+// .claude/statusline.cjs renders it). Role-sessions are non_fleet and never hold a claim, so they
+// never draw a callsign and show NO name. This writes the same per-session identity file directly
+// at role startup, with a stable role name — no statusline change required.
+//
+// ROLE-AGNOSTIC / Solomon-inheritable: add a ROLE_IDENTITY entry + one writeRoleStatusIdentity call
+// in the new role's startup and it inherits naming.
+
+const fs = require('fs');
+const path = require('path');
+
+// repo-root/.claude (mirrors coordination-inbox.cjs IDENTITY_DIR and statusline.cjs read path).
+const IDENTITY_DIR = path.resolve(__dirname, '../../.claude');
+
+// Colors MUST be in .claude/statusline.cjs's FC map: red/blue/green/yellow/purple/orange/pink/cyan.
+// Role names are OUTSIDE the NATO worker callsign set, so they never collide with the worker pool.
+const ROLE_IDENTITY = Object.freeze({
+  adam: { callsign: 'Adam', color: 'cyan' },
+  coordinator: { callsign: 'Coordinator', color: 'purple' },
+  solomon: { callsign: 'Solomon', color: 'orange' },
+});
+
+// Mirrors the coordination-inbox.cjs M4 path-traversal guard.
+const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,128}$/;
+
+/** Stable identity for a role name (case-insensitive); null for an unknown role. */
+function roleIdentityFor(role) {
+  return ROLE_IDENTITY[String(role || '').trim().toLowerCase()] || null;
+}
+
+/**
+ * Write the per-session status-line identity file for a role-session, so .claude/statusline.cjs
+ * renders the role's stable name. Fail-soft: returns false (never throws) on an unknown role, an
+ * invalid/missing sessionId, or any fs error — a naming failure must never block role startup.
+ * @param {object} o
+ * @param {string} o.sessionId  the role session's CLAUDE_SESSION_ID
+ * @param {string} o.role       'adam' | 'coordinator' | 'solomon'
+ * @param {string} [o.nowIso]   injectable timestamp (defaults to now)
+ * @param {string} [o.dir]      identity dir (defaults to repo-root/.claude); injectable for tests
+ * @returns {boolean} true iff the file was written
+ */
+function writeRoleStatusIdentity({ sessionId, role, nowIso, dir = IDENTITY_DIR } = {}) {
+  const id = roleIdentityFor(role);
+  if (!id) return false;
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return false;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `fleet-identity-${sessionId}.json`),
+      JSON.stringify({
+        color: id.color,
+        callsign: id.callsign,
+        display_name: id.callsign,
+        role: true,
+        assigned_at: nowIso || new Date().toISOString(),
+      }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { ROLE_IDENTITY, roleIdentityFor, writeRoleStatusIdentity, IDENTITY_DIR };

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -267,6 +267,14 @@ async function main() {
     return shutdown(1);
   }
   const result = await registerAdam(supabase, sessionId);
+  // SD-LEO-INFRA-ROLE-SESSION-NAMING-001: give this Adam session a stable status-line NAME.
+  // Fail-soft — a naming failure must never block registration.
+  if (result.ok) {
+    try {
+      const { writeRoleStatusIdentity } = require('../lib/fleet/role-status-identity.cjs');
+      writeRoleStatusIdentity({ sessionId, role: ADAM_ROLE });
+    } catch { /* status-line naming is best-effort */ }
+  }
   const contractCheck = checkContractRead();
   console.log(JSON.stringify({ ...result, ...contractCheck }, null, 2));
   const banner = contractReadBanner(contractCheck);

--- a/tests/unit/role-status-identity.test.js
+++ b/tests/unit/role-status-identity.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-INFRA-ROLE-SESSION-NAMING-001 — role-sessions (Adam/Coordinator/Solomon) get a stable
+ * status-line name by writing the same per-session identity file the worker statusline reads.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { ROLE_IDENTITY, roleIdentityFor, writeRoleStatusIdentity, IDENTITY_DIR } = require('../../lib/fleet/role-status-identity.cjs');
+
+const STATUSLINE_COLORS = new Set(['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'pink', 'cyan']);
+
+describe('SD-LEO-INFRA-ROLE-SESSION-NAMING-001: role-status-identity', () => {
+  let dir;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'role-id-')); });
+  afterEach(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} });
+
+  it('ROLE_IDENTITY has stable Adam/Coordinator/Solomon names with statusline-valid colors', () => {
+    expect(ROLE_IDENTITY.adam.callsign).toBe('Adam');
+    expect(ROLE_IDENTITY.coordinator.callsign).toBe('Coordinator');
+    expect(ROLE_IDENTITY.solomon.callsign).toBe('Solomon');
+    for (const r of Object.values(ROLE_IDENTITY)) expect(STATUSLINE_COLORS.has(r.color)).toBe(true);
+    expect(IDENTITY_DIR.replace(/\\/g, '/')).toMatch(/\.claude$/);
+  });
+
+  it('roleIdentityFor is case-insensitive and null on unknown', () => {
+    expect(roleIdentityFor('COORDINATOR').callsign).toBe('Coordinator');
+    expect(roleIdentityFor(' Adam ').callsign).toBe('Adam');
+    expect(roleIdentityFor('nobody')).toBe(null);
+    expect(roleIdentityFor(null)).toBe(null);
+  });
+
+  it('writes fleet-identity-<sessionId>.json with the role name + color', () => {
+    const ok = writeRoleStatusIdentity({ sessionId: 'sess-abc_123', role: 'adam', nowIso: '2026-06-23T00:00:00Z', dir });
+    expect(ok).toBe(true);
+    const written = JSON.parse(fs.readFileSync(path.join(dir, 'fleet-identity-sess-abc_123.json'), 'utf8'));
+    expect(written).toMatchObject({ callsign: 'Adam', color: 'cyan', display_name: 'Adam', role: true, assigned_at: '2026-06-23T00:00:00Z' });
+  });
+
+  it('writes the coordinator identity', () => {
+    expect(writeRoleStatusIdentity({ sessionId: 's1', role: 'coordinator', dir })).toBe(true);
+    const w = JSON.parse(fs.readFileSync(path.join(dir, 'fleet-identity-s1.json'), 'utf8'));
+    expect(w.callsign).toBe('Coordinator');
+  });
+
+  it('does NOT write for an unknown role', () => {
+    expect(writeRoleStatusIdentity({ sessionId: 's1', role: 'ghost', dir })).toBe(false);
+    expect(fs.readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('does NOT write for an invalid/path-traversal sessionId (security)', () => {
+    expect(writeRoleStatusIdentity({ sessionId: '../../evil', role: 'adam', dir })).toBe(false);
+    expect(writeRoleStatusIdentity({ sessionId: '', role: 'adam', dir })).toBe(false);
+    expect(writeRoleStatusIdentity({ sessionId: null, role: 'adam', dir })).toBe(false);
+    expect(fs.readdirSync(dir)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Workers show NATO callsigns in the status line; Adam + the coordinator show **no name**. Root cause (chairman observation 2026-06-22, verified): `.claude/statusline.cjs` reads the displayed name from a local per-session file `.claude/fleet-identity-<csid>.json`, written by the coordination-inbox hook from a `SET_IDENTITY` message — which a session only receives when `worker-checkin` draws a callsign from the claim-gated 8-name worker pool **while holding an SD claim**. Adam + coordinator are `non_fleet` role-sessions that never claim → never get the file → no name. Structural omission.

## Changes
- **FR-1** `lib/fleet/role-status-identity.cjs` — `writeRoleStatusIdentity({sessionId, role})` writes `.claude/fleet-identity-<sessionId>.json` with the stable role name + a statusline-valid color, mirroring the worker identity-file shape (**no statusline change**). `ROLE_IDENTITY` map (adam=Adam/cyan, coordinator=Coordinator/purple, solomon=Solomon/orange); `roleIdentityFor()` case-insensitive. `sessionId` validated `/^[a-zA-Z0-9_-]{1,128}$/` (path-traversal safe); fail-soft.
- **FR-2** wired into Adam startup (`scripts/adam-register.cjs`, after a successful `role=adam` tag) and coordinator startup (`lib/coordinator/resolve.cjs` `setActiveCoordinator`, both flag paths). Both fail-soft — a naming failure never blocks startup.
- **FR-3** `tests/unit/role-status-identity.test.js` (6 tests): writes the right file per role; case-insensitive lookup; unknown role / invalid+path-traversal sessionId → no write; statusline-valid colors.

**Role-agnostic / Solomon-inheritable**: a future role adds one `ROLE_IDENTITY` entry + one startup call. Role names are outside the NATO worker set (no pool collision).

## Verification
6/6 tests pass; `node --check` clean on all 3 touched files. TESTING sub-agent verdict PASS (row `c3128061`). New lib reachable via the `adam:register` package.json entry + `resolve.cjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)