### PR TITLE
feat(SD-REFILL-00GN7D8S): make GR-DELETION-SAFEGUARD destroy-keyword context-aware

### DIFF
--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -259,7 +259,13 @@ const DEFAULT_GUARDRAILS = [
     description: 'Prevents SDs involving destructive deletion operations without explicit backup plan',
     check: (sdData) => {
       const scope = (sdData.scope || '').toLowerCase();
-      const hasDestructiveOps = /\b(drop\s*table|delete\s*(all|from|records|data)|truncate|purge|destroy|remove\s*(all|data|records))\b/.test(scope);
+      // SD-REFILL-00GN7D8S: bare `destroy` keyword-matched non-destructive code phrasing
+      // ("close/destroy the DB handles") and false-blocked a legitimate SD. Mirror the data-object
+      // qualification the sibling verbs already require (drop TABLE, delete ALL/FROM/records/data,
+      // remove ALL/data/records): `destroy` now must be followed (within a few words) by a
+      // destructive-data noun, so colloquial "destroy the handles/instance/connection" no longer
+      // trips while real data destruction ("destroy all data", "destroy the database") still does.
+      const hasDestructiveOps = /\b(drop\s*table|delete\s*(all|from|records|data)|truncate|purge|destroy\s+(?:\w+\s+){0,3}?(?:data|databases?|records?|tables?|rows?|schemas?)|remove\s*(all|data|records))\b/.test(scope);
       const hasBackupPlan = sdData.metadata?.backup_plan === true
         || sdData.metadata?.deletion_approved === true;
 

--- a/tests/unit/governance/guardrail-registry.test.js
+++ b/tests/unit/governance/guardrail-registry.test.js
@@ -485,6 +485,32 @@ describe('Guardrail Registry - GR-DELETION-SAFEGUARD', () => {
     const violation = result.violations.find((v) => v.guardrail === 'GR-DELETION-SAFEGUARD');
     expect(violation).toBeUndefined();
   });
+
+  // SD-REFILL-00GN7D8S: bare `destroy` must not false-trip on non-destructive code phrasing.
+  it('does NOT block on a colloquial/code "destroy" without a data object (false-positive fix)', () => {
+    for (const scope of [
+      'Close/destroy the DB handles on shutdown so the process can exit cleanly',
+      'Refactor the destroy() method on the connection pool',
+      'Tear down and destroy the test fixture instance after each run',
+    ]) {
+      const result = check({ scope, strategic_objectives: ['OKR-1'] });
+      const violation = result.violations.find((v) => v.guardrail === 'GR-DELETION-SAFEGUARD');
+      expect(violation, `should not block: ${scope}`).toBeUndefined();
+    }
+  });
+
+  it('STILL blocks genuine data destruction phrased with "destroy" (no weakened teeth)', () => {
+    for (const scope of [
+      'Destroy all data in the staging tables',
+      'destroy the database and recreate from scratch',
+      'Job to destroy old customer records nightly',
+    ]) {
+      const result = check({ scope, strategic_objectives: ['OKR-1'] });
+      const violation = result.violations.find((v) => v.guardrail === 'GR-DELETION-SAFEGUARD');
+      expect(violation, `should block: ${scope}`).toBeDefined();
+      expect(violation.severity).toBe('critical');
+    }
+  });
 });
 
 describe('Guardrail Registry - GR-DEPLOY-WINDOW', () => {


### PR DESCRIPTION
## Summary
The GR-DELETION-SAFEGUARD guardrail (BLOCKING) matched bare `destroy` — unlike its sibling verbs (`drop TABLE`, `delete ALL/FROM/records/data`, `remove ALL/data/records`) which all require a data object. So non-destructive code phrasing in an SD scope (`close/destroy the DB handles`, a `destroy()` method) **false-blocked a legitimate SD**, forcing a reword.

**Fix:** qualify `destroy` to require a destructive-data noun (`data|database|records|tables|rows|schema`) within a few words. Colloquial `destroy the handles/instance/connection` no longer trips; real data destruction (`destroy all data`, `destroy the database`) **still blocks at critical** — teeth preserved.

## Verification
- 58/58 tests incl. a **retained-teeth** case (genuine destruction still blocks) + a false-positive case; validation PASS-95 (teeth verified independently); TESTING PASS-98

## Scope
Flagged follow-ups (out of scope): (1) dry-run/real guardrail parity (`leo-create-sd --dry-run` returns before the createSD guardrail check → false confidence); (2) same bare-verb qualification for `purge`/`truncate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)