### PR TITLE
feat(SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001): DB source-of-truth for sourcing-engine flag state

### DIFF
--- a/database/migrations/20260623_sourcing_engine_activation_state.sql
+++ b/database/migrations/20260623_sourcing_engine_activation_state.sql
@@ -1,0 +1,46 @@
+-- Migration: sourcing_engine_activation_state — DB source-of-truth for sourcing-engine arm activation
+-- SD: SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001 (FR-1/FR-3)
+--
+-- Why: the coordinator capacity-forecaster read the sourcing arm flags from its LOCAL process.env, but
+-- SOURCING_GAUGE_GAP_MINER_V1 / SOURCING_DEFERRED_WATCHER_V1 live only as GitHub-Actions JOB-scoped env
+-- in the cron ymls — absent from the coordinator process — so the forecaster read undefined → false and
+-- printed a FALSE "engine DORMANT → ACTIVATE" readout while the crons were in fact running. This table is
+-- the durable source of truth: each sourcing arm's on/off, written when an arm is activated/deactivated,
+-- read by readSourcingEngineFlagsFromDb (workflow-yml presence != enabled; gh-run-state is rate-limited).
+--
+-- Keyed by `arm` (the awareness-registry label: gauge-gap-miner | deferred-watcher | auto-refill).
+
+CREATE TABLE IF NOT EXISTS sourcing_engine_activation_state (
+  arm TEXT PRIMARY KEY,
+  enabled BOOLEAN NOT NULL DEFAULT false,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by TEXT
+);
+
+COMMENT ON TABLE sourcing_engine_activation_state IS
+  'DB source-of-truth for sourcing-engine arm activation (SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001). One row per arm; readSourcingEngineFlagsFromDb derives the forecaster awareness from this, not coordinator process.env.';
+
+-- FR-3: seed the currently-live arms ON so the forecaster reads true-ON immediately on ship.
+-- Idempotent (ON CONFLICT DO NOTHING) — re-running the migration never clobbers an operator toggle.
+INSERT INTO sourcing_engine_activation_state (arm, enabled, updated_by) VALUES
+  ('gauge-gap-miner', true, 'migration:20260623_seed'),
+  ('deferred-watcher', true, 'migration:20260623_seed'),
+  ('auto-refill',     true, 'migration:20260623_seed')
+ON CONFLICT (arm) DO NOTHING;
+
+-- RLS: defense-in-depth; service_role retains full access (matches the operational pattern).
+ALTER TABLE sourcing_engine_activation_state ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'sourcing_engine_activation_state' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY service_role_all ON sourcing_engine_activation_state
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -40,7 +40,7 @@ import { isLiveCountableWorker } from './lib/live-countable-worker.mjs';
 // SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): surface the sourcing-engine
 // flag state + unpromoted roadmap depth so a belt-low/DEFICIT ping says "engine OFF, N unpromoted
 // -> activate/distill" instead of only "source N candidates" (manual backfill is the anti-pattern).
-import { readSourcingEngineFlags, formatSourcingAwareness } from './lib/sourcing-engine-awareness.mjs';
+import { readSourcingEngineFlagsFromDb, formatSourcingAwareness } from './lib/sourcing-engine-awareness.mjs';
 // SD-LEO-FEAT-COORDINATOR-CAPACITY-FORECAST-001: stall detection is DELEGATED to the canonical
 // detectStalledLoop SSOT (lib/coordinator/detectors.cjs), the same detector coordinator-audit.mjs uses.
 // The forecast previously ran its own heartbeat-AGE rule (classifyIdleWorker, ttl 180s), but the worker
@@ -262,7 +262,10 @@ async function main() {
 
   // SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): sourcing-engine awareness — flag
   // state + unpromoted roadmap depth so belt-low is read as "activate/distill" before "hand-ask Adam".
-  const sourcingFlags = readSourcingEngineFlags(process.env);
+  // SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001 (FR-1): derive arm state from the DB
+  // source-of-truth (the actual deployment), not the coordinator's local process.env — which is
+  // blind to the GitHub-Actions job-scoped sourcing flags. The reader fails open to env on error.
+  const sourcingFlags = await readSourcingEngineFlagsFromDb(sb, process.env);
   const unpromotedCount = await countUnpromotedRoadmapItems(sb);
   const awareness = formatSourcingAwareness({ flags: sourcingFlags, unpromotedCount });
   console.log(`  SOURCING: ${awareness.line}`);

--- a/scripts/lib/sourcing-engine-awareness.mjs
+++ b/scripts/lib/sourcing-engine-awareness.mjs
@@ -16,10 +16,16 @@
 // The canonical sourcing-engine activation flags (mirrors the per-module isXxxFlagEnabled helpers:
 // lib/sourcing-engine/gauge-gap-miner.js, lib/sourcing-engine/deferred-watcher.js). Add new
 // sourcing-engine flags here as they ship so the forecaster surfaces them automatically.
+// SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001 (FR-2): all THREE live sourcing arms.
+// `label` is also the primary key (`arm`) in sourcing_engine_activation_state.
 export const SOURCING_ENGINE_FLAGS = Object.freeze([
   Object.freeze({ env: 'SOURCING_GAUGE_GAP_MINER_V1', label: 'gauge-gap-miner' }),
   Object.freeze({ env: 'SOURCING_DEFERRED_WATCHER_V1', label: 'deferred-watcher' }),
+  Object.freeze({ env: 'SOURCING_AUTO_REFILL_V1', label: 'auto-refill' }),
 ]);
+
+// SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001 (FR-1): the DB source-of-truth table.
+export const SOURCING_ACTIVATION_TABLE = 'sourcing_engine_activation_state';
 
 // Same truthiness convention the per-module helpers use: 'on' | '1' | 'true' (case-insensitive).
 export function isSourcingFlagOn(value) {
@@ -31,6 +37,61 @@ export function isSourcingFlagOn(value) {
 export function readSourcingEngineFlags(env = process.env) {
   const e = env || {};
   return SOURCING_ENGINE_FLAGS.map((f) => ({ env: f.env, label: f.label, enabled: isSourcingFlagOn(e[f.env]) }));
+}
+
+/**
+ * SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001 (FR-1): derive each arm's on/off from the DB
+ * activation-state row (the actual deployment) instead of the coordinator's LOCAL process.env — which
+ * is blind to the GitHub-Actions JOB-scoped sourcing flags and falsely read every arm OFF.
+ *
+ * Returns the SAME [{ env, label, enabled }] shape as readSourcingEngineFlags (FR-4 contract). An arm
+ * with no row reads enabled=false. FAIL-OPEN: on any query error (incl. the table not existing yet,
+ * pre-migration), fall back to the env-based reader so shipping this before the governed prod-apply
+ * degrades to today's behavior rather than throwing in the forecaster.
+ *
+ * @param {object} supabase - service-role client
+ * @param {object} [env=process.env] - fallback env-like object
+ * @returns {Promise<Array<{env:string,label:string,enabled:boolean}>>}
+ */
+export async function readSourcingEngineFlagsFromDb(supabase, env = process.env) {
+  try {
+    const { data, error } = await supabase.from(SOURCING_ACTIVATION_TABLE).select('arm, enabled');
+    if (error) throw new Error(error.message);
+    const byArm = new Map((data || []).map((r) => [r.arm, r.enabled === true]));
+    return SOURCING_ENGINE_FLAGS.map((f) => ({ env: f.env, label: f.label, enabled: byArm.get(f.label) === true }));
+  } catch (e) {
+    if (typeof process !== 'undefined' && process.stderr) {
+      process.stderr.write(`[sourcing-awareness] DB flag read failed (${e.message}); falling back to env.\n`);
+    }
+    return readSourcingEngineFlags(env);
+  }
+}
+
+/**
+ * SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001 (FR-3): idempotent reconcile — upsert the
+ * given arm→enabled state so the DB re-derives from the actual deployment. Pass the live arms on
+ * activation/deactivation. Best-effort; returns the count upserted (0 on error).
+ *
+ * @param {object} supabase - service-role client
+ * @param {Record<string,boolean>} stateByArm - e.g. {'gauge-gap-miner':true,'auto-refill':true}
+ * @param {string} [updatedBy='reconcile']
+ * @returns {Promise<number>}
+ */
+export async function reconcileSourcingArmState(supabase, stateByArm = {}, updatedBy = 'reconcile') {
+  const rows = Object.entries(stateByArm || {}).map(([arm, enabled]) => ({
+    arm, enabled: enabled === true, updated_at: new Date().toISOString(), updated_by: updatedBy,
+  }));
+  if (!rows.length) return 0;
+  try {
+    const { data, error } = await supabase.from(SOURCING_ACTIVATION_TABLE).upsert(rows, { onConflict: 'arm' }).select('arm');
+    if (error) throw new Error(error.message);
+    return (data || []).length;
+  } catch (e) {
+    if (typeof process !== 'undefined' && process.stderr) {
+      process.stderr.write(`[sourcing-awareness] reconcile upsert failed (${e.message}).\n`);
+    }
+    return 0;
+  }
 }
 
 /**

--- a/tests/unit/sourcing-engine-awareness.test.js
+++ b/tests/unit/sourcing-engine-awareness.test.js
@@ -7,8 +7,22 @@ import {
   SOURCING_ENGINE_FLAGS,
   isSourcingFlagOn,
   readSourcingEngineFlags,
+  readSourcingEngineFlagsFromDb,
+  reconcileSourcingArmState,
   formatSourcingAwareness,
 } from '../../scripts/lib/sourcing-engine-awareness.mjs';
+
+// Minimal supabase mock: from().select() -> {data,error}; from().upsert().select() -> {data,error}.
+function fakeSb({ rows = [], selectError = null, upsertError = null } = {}) {
+  return {
+    from() {
+      return {
+        select: () => Promise.resolve({ data: selectError ? null : rows, error: selectError }),
+        upsert: () => ({ select: () => Promise.resolve({ data: upsertError ? null : rows, error: upsertError }) }),
+      };
+    },
+  };
+}
 
 describe('isSourcingFlagOn', () => {
   it('treats on/1/true (case-insensitive) as enabled', () => {
@@ -95,5 +109,69 @@ describe('formatSourcingAwareness — belt-low remediation framing', () => {
     const r = formatSourcingAwareness();
     expect(r.countStr).toBe('unknown');
     expect(r.flagStr).toBe('none');
+  });
+});
+
+// SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001
+describe('SOURCING_ENGINE_FLAGS — FR-2 registers all three arms', () => {
+  it('includes gauge-gap-miner, deferred-watcher, AND auto-refill', () => {
+    const labels = SOURCING_ENGINE_FLAGS.map((f) => f.label);
+    expect(labels).toContain('gauge-gap-miner');
+    expect(labels).toContain('deferred-watcher');
+    expect(labels).toContain('auto-refill');
+    const autoRefill = SOURCING_ENGINE_FLAGS.find((f) => f.label === 'auto-refill');
+    expect(autoRefill.env).toBe('SOURCING_AUTO_REFILL_V1');
+  });
+});
+
+describe('readSourcingEngineFlagsFromDb — FR-1/FR-5 (DB source of truth, independent of process.env)', () => {
+  it('derives ON for an arm whose activation-state row is enabled, OFF when disabled — IGNORING process.env', async () => {
+    // process.env says everything OFF; the DB says gauge-gap-miner ON, deferred-watcher OFF.
+    const env = { SOURCING_GAUGE_GAP_MINER_V1: 'off', SOURCING_DEFERRED_WATCHER_V1: 'off', SOURCING_AUTO_REFILL_V1: 'off' };
+    const sb = fakeSb({ rows: [
+      { arm: 'gauge-gap-miner', enabled: true },
+      { arm: 'deferred-watcher', enabled: false },
+      { arm: 'auto-refill', enabled: true },
+    ] });
+    const flags = await readSourcingEngineFlagsFromDb(sb, env);
+    const byLabel = Object.fromEntries(flags.map((f) => [f.label, f.enabled]));
+    expect(byLabel['gauge-gap-miner']).toBe(true);   // DB-on despite env-off
+    expect(byLabel['deferred-watcher']).toBe(false); // DB-off
+    expect(byLabel['auto-refill']).toBe(true);
+    expect(flags.length).toBe(SOURCING_ENGINE_FLAGS.length);
+  });
+
+  it('an arm with NO row reads OFF', async () => {
+    const sb = fakeSb({ rows: [{ arm: 'gauge-gap-miner', enabled: true }] });
+    const flags = await readSourcingEngineFlagsFromDb(sb, {});
+    const byLabel = Object.fromEntries(flags.map((f) => [f.label, f.enabled]));
+    expect(byLabel['gauge-gap-miner']).toBe(true);
+    expect(byLabel['deferred-watcher']).toBe(false);
+    expect(byLabel['auto-refill']).toBe(false);
+  });
+
+  it('FAIL-OPEN: on a query error (e.g. table absent pre-migration) falls back to the env reader', async () => {
+    const env = { SOURCING_GAUGE_GAP_MINER_V1: 'on', SOURCING_DEFERRED_WATCHER_V1: 'off', SOURCING_AUTO_REFILL_V1: 'off' };
+    const sb = fakeSb({ selectError: { message: 'relation "sourcing_engine_activation_state" does not exist' } });
+    const flags = await readSourcingEngineFlagsFromDb(sb, env);
+    const byLabel = Object.fromEntries(flags.map((f) => [f.label, f.enabled]));
+    expect(byLabel['gauge-gap-miner']).toBe(true);  // from env fallback
+    expect(byLabel['deferred-watcher']).toBe(false);
+  });
+});
+
+describe('reconcileSourcingArmState — FR-3 idempotent upsert', () => {
+  it('upserts the given arm→enabled map and returns the count', async () => {
+    const sb = fakeSb({ rows: [{ arm: 'gauge-gap-miner' }, { arm: 'auto-refill' }] });
+    const n = await reconcileSourcingArmState(sb, { 'gauge-gap-miner': true, 'auto-refill': true });
+    expect(n).toBe(2);
+  });
+  it('returns 0 for an empty map (no write)', async () => {
+    const sb = fakeSb({ rows: [] });
+    expect(await reconcileSourcingArmState(sb, {})).toBe(0);
+  });
+  it('fail-soft: returns 0 on an upsert error (does not throw)', async () => {
+    const sb = fakeSb({ upsertError: { message: 'boom' } });
+    expect(await reconcileSourcingArmState(sb, { 'auto-refill': true })).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
The capacity-forecaster read sourcing arm flags from its **local `process.env`**, but `SOURCING_GAUGE_GAP_MINER_V1` / `SOURCING_DEFERRED_WATCHER_V1` exist only as GitHub-Actions **job-scoped** env in the cron ymls — absent from the coordinator process. So it read `undefined → false` and printed a **false "engine DORMANT → ACTIVATE"** readout while the crons were actually running overnight, mis-directing belt-low remediation. Extends the completed parent SOURCING-ENGINE-AWARENESS-001.

## Fix
- **FR-1**: new table `sourcing_engine_activation_state` (arm PK, enabled, updated_at/by) + async `readSourcingEngineFlagsFromDb(sb, env)` deriving on/off from the row. **Fail-open** to the env reader on any query error (incl. table-absent pre-apply). The sync `readSourcingEngineFlags` + `isSourcingFlagOn` + `formatSourcingAwareness` are **unchanged** (FR-4 contract).
- **FR-2**: register the 3rd live arm — `auto-refill` (`SOURCING_AUTO_REFILL_V1`).
- **FR-3**: migration seeds all three arms ON (idempotent) + `reconcileSourcingArmState()` idempotent upsert.
- **FR-5**: tests prove DB-derived ON/OFF **independent of `process.env`** + fail-open fallback + 3-arm registry. 18/18.
- `coordinator-capacity-forecast.mjs` swaps to the DB reader (`sb` already in scope).

## ⚠️ Governed prod-apply
Applying the migration to prod is gated behind `MIGRATION_APPLY_TOKEN` / Adam — **not performed from this worker session**. Until applied, the reader fails open to env (today's behavior). Flagged for the gated deploy.

SD: SD-LEO-INFRA-SOURCING-FLAG-STATE-FROM-DEPLOYMENT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)