### PR TITLE
feat(SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001): read-time session-liveness SSOT (isSessionAlive) + route the P(alive) gauge

### DIFF
--- a/lib/fleet/session-liveness.cjs
+++ b/lib/fleet/session-liveness.cjs
@@ -1,0 +1,96 @@
+// SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001 — single READ-TIME session-liveness SSOT.
+//
+// claude_sessions.is_alive is a RAW STORED boolean written only by heartbeat-manager
+// (true@start / false@stop) + the sweep's release. The heartbeat interval is UNREF'd so a
+// parked worker (long ScheduleWakeup / awaiting_tick) stops firing it and is_alive FREEZES at
+// its last value while the OS process is still alive — a false-negative that has driven false
+// "fleet down" / "orphaned SD" verdicts FOUR times (P(alive) gauge #5095, charter-audit DUTY-3,
+// ghost-detector #5090, and the 2026-06-23 near-reap). A correct write-time fix is infeasible
+// (the staleness arises AFTER the last write), so the only durable root fix is this: reconcile
+// the raw flag against AUTHORITATIVE signals at READ time, used by EVERY consumer.
+//
+// ONE-DIRECTIONAL CONTRACT: isSessionAlive can only ever read MORE-alive than the raw flag — it
+// treats raw is_alive===true as a live signal, so it NEVER downgrades a worker the raw flag calls
+// alive (never masks a real death). It only UPGRADES a parked-alive worker (raw says dead/frozen
+// but an authoritative signal says alive) to alive, with a stamped reason.
+//
+// CJS so it can require() cc-pid-liveness.cjs and be require()'d by the CJS consumers
+// (fleet-dashboard.cjs, worker-checkin.cjs); ESM consumers (claim-validity-gate.js,
+// ownership-detection.js) load it via createRequire / import interop.
+
+const { getAliveCcPids } = require('./cc-pid-liveness.cjs');
+
+const LIVENESS_HEARTBEAT_SEC = 300;        // heartbeat fresher than 5min → alive
+const TICK_FRESH_MS = 90 * 1000;           // process_alive_at within 90s → alive
+const ARMED_SILENCE_MAX_MS = 30 * 60 * 1000; // expected_silence_until within 30min → parked-alive
+
+function _ageMs(ts, nowMs) {
+  if (ts == null) return Infinity;
+  const t = typeof ts === 'number' ? ts : Date.parse(ts);
+  if (!Number.isFinite(t)) return Infinity;
+  return nowMs - t;
+}
+
+// Heartbeat fresher than LIVENESS_HEARTBEAT_SEC. Accepts heartbeat_at | last_heartbeat | heartbeat_age_seconds.
+function hasFreshHeartbeat(session, nowMs) {
+  if (!session) return false;
+  if (typeof session.heartbeat_age_seconds === 'number') return session.heartbeat_age_seconds < LIVENESS_HEARTBEAT_SEC;
+  const ts = session.heartbeat_at ?? session.last_heartbeat;
+  return _ageMs(ts, nowMs) < LIVENESS_HEARTBEAT_SEC * 1000;
+}
+
+// Fresh process tick (the source-side liveness stamp), within TICK_FRESH_MS.
+function hasTickAlive(session, nowMs) {
+  if (!session || !session.process_alive_at) return false;
+  return _ageMs(session.process_alive_at, nowMs) <= TICK_FRESH_MS;
+}
+
+// Inside an armed expected_silence_until window (future, but capped at ARMED_SILENCE_MAX_MS out).
+function hasExpectedSilence(session, nowMs) {
+  if (!session || !session.expected_silence_until) return false;
+  const delta = (typeof session.expected_silence_until === 'number'
+    ? session.expected_silence_until
+    : Date.parse(session.expected_silence_until)) - nowMs;
+  return Number.isFinite(delta) && delta > 0 && delta <= ARMED_SILENCE_MAX_MS;
+}
+
+// Live OS process via the SessionStart PID markers. terminal_id format "win-cc-{port}-{ccPid}".
+// aliveCcPids may be injected (Set of alive cc pid strings); otherwise read fresh (host-local).
+function hasPidAlive(session, aliveCcPids) {
+  if (!session || !session.terminal_id) return false;
+  const pids = aliveCcPids || getAliveCcPids();
+  const parts = String(session.terminal_id).split('-');
+  return pids.has(parts[parts.length - 1]);
+}
+
+/**
+ * The READ-TIME liveness SSOT. Returns { alive, reason }.
+ * alive = raw is_alive===true OR fresh heartbeat OR live PID OR fresh tick OR armed-silence.
+ * One-directional: a raw-alive session is always alive (reason 'raw_is_alive'); a parked session
+ * the raw flag froze to false is UPGRADED to alive iff an authoritative signal fires (with that
+ * signal as the reason). Never returns alive=false for a session the raw flag calls alive.
+ *
+ * @param {object|null} session - a claude_sessions-shaped row (or v_active_sessions row)
+ * @param {{nowMs?:number, aliveCcPids?:Set<string>}} [opts]
+ * @returns {{alive:boolean, reason:(string|null)}}
+ */
+function isSessionAlive(session, { nowMs = Date.now(), aliveCcPids = null } = {}) {
+  if (!session) return { alive: false, reason: null };
+  if (session.is_alive === true) return { alive: true, reason: 'raw_is_alive' };
+  if (hasFreshHeartbeat(session, nowMs)) return { alive: true, reason: 'fresh_heartbeat' };
+  if (hasPidAlive(session, aliveCcPids)) return { alive: true, reason: 'pid_alive' };
+  if (hasTickAlive(session, nowMs)) return { alive: true, reason: 'process_tick' };
+  if (hasExpectedSilence(session, nowMs)) return { alive: true, reason: 'armed_silence' };
+  return { alive: false, reason: null };
+}
+
+module.exports = {
+  isSessionAlive,
+  hasFreshHeartbeat,
+  hasTickAlive,
+  hasExpectedSilence,
+  hasPidAlive,
+  LIVENESS_HEARTBEAT_SEC,
+  TICK_FRESH_MS,
+  ARMED_SILENCE_MAX_MS,
+};

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -8,6 +8,9 @@ const crypto = require('crypto');
 const util = require('util');
 const { spawnSync } = require('child_process');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+// SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001 (FR-2): the read-time liveness SSOT — the gauge reconcile
+// wraps isSessionAlive so the P(alive) override and the authoritative-liveness definition can never diverge.
+const { isSessionAlive } = require('../lib/fleet/session-liveness.cjs');
 
 // Idle-fleet diff suppression — coordinator was generating ~120 identical
 // dashboard renders overnight. After N consecutive identical renders, emit a
@@ -102,10 +105,16 @@ function pBar(p, width = 10) {
  * @param {{pidAlive?:boolean, tickAlive?:boolean, silenceArmed?:boolean}} signals
  * @returns {object|null}
  */
-function reconcilePAliveWithLiveness(mcWorker, { pidAlive = false, tickAlive = false, silenceArmed = false } = {}) {
+// SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001 (FR-2): thin wrapper over the shared isSessionAlive SSOT.
+// Upgrades the raw-heartbeat MC P(alive) to 1.0 (stamped + reasoned) when the SESSION is alive by any
+// authoritative signal — one-directional (never downgrades). Delegating to isSessionAlive means the
+// gauge override and the fleet-wide liveness definition can never drift apart (no 'three local copies').
+function reconcilePAliveWithLiveness(mcWorker, session, { nowMs = Date.now(), aliveCcPids = null } = {}) {
   if (!mcWorker || typeof mcWorker !== 'object') return mcWorker;
-  if (!(pidAlive || tickAlive || silenceArmed)) return mcWorker;
-  const reason = pidAlive ? 'pid_alive' : tickAlive ? 'process_tick' : 'armed_silence';
+  const { alive, reason } = isSessionAlive(session || {}, { nowMs, aliveCcPids });
+  // A raw-heartbeat-fresh worker already reads a high p_alive from the MC engine; only stamp an
+  // override when liveness comes from a PARKED-alive authoritative signal (the false-DORMANT case).
+  if (!alive || reason === 'raw_is_alive' || reason === 'fresh_heartbeat') return mcWorker;
   return { ...mcWorker, p_alive: 1, p_alive_authoritative_override: true, p_alive_override_reason: reason };
 }
 
@@ -316,14 +325,12 @@ async function loadData() {
     // SD-REFILL-005M4BN9: reconcile the raw-heartbeat P(alive) gauge with the SAME authoritative
     // liveness signals the active/stale split uses, so an armed-silence / PID-alive worker is not
     // shown as a false 'dying worker' (P(alive)=0.00) that lures a force-release.
+    const _gaugeNowMs = Date.now();
     for (const s of sessions) {
       const w = mcByWorker[s.session_id];
       if (!w) continue;
-      mcByWorker[s.session_id] = reconcilePAliveWithLiveness(w, {
-        pidAlive: hasPidAlive(s),
-        tickAlive: hasTickAlive(s),
-        silenceArmed: hasExpectedSilence(s),
-      });
+      // FR-2: reconcile via the shared SSOT (session-based), passing the already-loaded aliveCcPids Set.
+      mcByWorker[s.session_id] = reconcilePAliveWithLiveness(w, s, { nowMs: _gaugeNowMs, aliveCcPids });
     }
   }
 

--- a/tests/unit/coordinator/fleet-dashboard-palive-liveness.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-palive-liveness.test.js
@@ -1,7 +1,9 @@
 /**
- * SD-REFILL-005M4BN9 — fleet-dashboard P(alive) gauge must factor authoritative liveness
- * (armed-silence / PID / process-tick) so a mid-operation worker is not shown as a false
- * 'dying worker' (P(alive)=0.00) that lures the coordinator into a force-release.
+ * SD-REFILL-005M4BN9 + SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001 (FR-2) — the fleet-dashboard P(alive)
+ * gauge must factor authoritative liveness (armed-silence / PID / process-tick) so a mid-operation
+ * worker is not shown as a false 'dying worker' (P(alive)=0.00) that lures a force-release. The
+ * reconcile is now a THIN WRAPPER over the shared isSessionAlive SSOT (session-based signature), so
+ * the gauge override and the fleet-wide liveness definition can never diverge.
  */
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'module';
@@ -9,58 +11,65 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { reconcilePAliveWithLiveness } = require('../../../scripts/fleet-dashboard.cjs');
 
-describe('reconcilePAliveWithLiveness() — FR-1/FR-3', () => {
-  const lowWorker = () => ({ session_id: 'w1', p_alive: 0.0 });
+const NOW = 1_000_000_000_000;
+const lowWorker = () => ({ session_id: 'w1', p_alive: 0.0 });
 
+describe('reconcilePAliveWithLiveness() — SSOT-backed gauge override', () => {
   it('overrides P(alive) to 1.0 when within an armed-silence window', () => {
-    const r = reconcilePAliveWithLiveness(lowWorker(), { silenceArmed: true });
+    const session = { expected_silence_until: new Date(NOW + 10 * 60 * 1000).toISOString() };
+    const r = reconcilePAliveWithLiveness(lowWorker(), session, { nowMs: NOW });
     expect(r.p_alive).toBe(1);
     expect(r.p_alive_authoritative_override).toBe(true);
     expect(r.p_alive_override_reason).toBe('armed_silence');
   });
 
-  it('overrides P(alive) to 1.0 when PID-alive', () => {
-    const r = reconcilePAliveWithLiveness(lowWorker(), { pidAlive: true });
+  it('overrides P(alive) to 1.0 when PID-alive (injected aliveCcPids)', () => {
+    const session = { terminal_id: 'win-cc-1234-99999' };
+    const r = reconcilePAliveWithLiveness(lowWorker(), session, { nowMs: NOW, aliveCcPids: new Set(['99999']) });
     expect(r.p_alive).toBe(1);
     expect(r.p_alive_override_reason).toBe('pid_alive');
   });
 
   it('overrides P(alive) to 1.0 when a fresh process-tick is present', () => {
-    const r = reconcilePAliveWithLiveness(lowWorker(), { tickAlive: true });
+    const session = { process_alive_at: new Date(NOW - 10 * 1000).toISOString() };
+    const r = reconcilePAliveWithLiveness(lowWorker(), session, { nowMs: NOW });
     expect(r.p_alive).toBe(1);
     expect(r.p_alive_override_reason).toBe('process_tick');
   });
 
-  it('FR-3: returns the worker UNCHANGED (raw p_alive preserved) when no authoritative signal', () => {
+  it('returns the worker UNCHANGED (raw p_alive preserved) when no authoritative signal', () => {
     const w = lowWorker();
-    const r = reconcilePAliveWithLiveness(w, { pidAlive: false, tickAlive: false, silenceArmed: false });
+    const r = reconcilePAliveWithLiveness(w, {}, { nowMs: NOW });
     expect(r).toBe(w); // same reference — no override object created
     expect(r.p_alive).toBe(0.0);
     expect(r.p_alive_authoritative_override).toBeUndefined();
   });
 
+  it('does NOT stamp an override when liveness is raw is_alive or fresh heartbeat (gauge already high)', () => {
+    const rawAlive = reconcilePAliveWithLiveness(lowWorker(), { is_alive: true }, { nowMs: NOW });
+    expect(rawAlive.p_alive_authoritative_override).toBeUndefined();
+    const freshHb = reconcilePAliveWithLiveness(lowWorker(), { heartbeat_age_seconds: 5 }, { nowMs: NOW });
+    expect(freshHb.p_alive_authoritative_override).toBeUndefined();
+  });
+
   it('does not mutate the input worker (returns a new object on override)', () => {
     const w = lowWorker();
-    const r = reconcilePAliveWithLiveness(w, { pidAlive: true });
+    const session = { expected_silence_until: new Date(NOW + 60 * 1000).toISOString() };
+    const r = reconcilePAliveWithLiveness(w, session, { nowMs: NOW });
     expect(w.p_alive).toBe(0.0); // original untouched
     expect(r).not.toBe(w);
   });
 
-  it('reason precedence: pid_alive > process_tick > armed_silence when several are true', () => {
-    expect(reconcilePAliveWithLiveness(lowWorker(), { pidAlive: true, tickAlive: true, silenceArmed: true }).p_alive_override_reason).toBe('pid_alive');
-    expect(reconcilePAliveWithLiveness(lowWorker(), { tickAlive: true, silenceArmed: true }).p_alive_override_reason).toBe('process_tick');
-    expect(reconcilePAliveWithLiveness(lowWorker(), { silenceArmed: true }).p_alive_override_reason).toBe('armed_silence');
-  });
-
   it('null-safe: passes through null/undefined/non-object without throwing', () => {
-    expect(reconcilePAliveWithLiveness(null, { pidAlive: true })).toBe(null);
-    expect(reconcilePAliveWithLiveness(undefined, { pidAlive: true })).toBe(undefined);
+    expect(reconcilePAliveWithLiveness(null, {}, { nowMs: NOW })).toBe(null);
+    expect(reconcilePAliveWithLiveness(undefined, {}, { nowMs: NOW })).toBe(undefined);
     expect(() => reconcilePAliveWithLiveness(null)).not.toThrow();
   });
 
   it('preserves other MC fields while overriding p_alive', () => {
     const w = { session_id: 'w9', p_alive: 0.12, eta_minutes: 7, samples: 1000 };
-    const r = reconcilePAliveWithLiveness(w, { silenceArmed: true });
+    const session = { expected_silence_until: new Date(NOW + 60 * 1000).toISOString() };
+    const r = reconcilePAliveWithLiveness(w, session, { nowMs: NOW });
     expect(r.session_id).toBe('w9');
     expect(r.eta_minutes).toBe(7);
     expect(r.samples).toBe(1000);

--- a/tests/unit/fleet/session-liveness.test.js
+++ b/tests/unit/fleet/session-liveness.test.js
@@ -1,0 +1,84 @@
+// SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001 (FR-1) — the read-time session-liveness SSOT.
+// isSessionAlive reconciles the raw is_alive flag against authoritative signals; it is
+// ONE-DIRECTIONAL (only upgrades a parked-alive worker to alive, never downgrades a worker the
+// raw flag calls alive — never masks a real death).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  isSessionAlive, hasFreshHeartbeat, hasTickAlive, hasExpectedSilence, hasPidAlive,
+} = require('../../../lib/fleet/session-liveness.cjs');
+
+const NOW = 1_000_000_000_000;
+const iso = (ms) => new Date(ms).toISOString();
+
+describe('isSessionAlive — read-time liveness SSOT (FR-1)', () => {
+  it('raw is_alive===true → alive (one-directional: never downgrades a raw-alive worker)', () => {
+    // stale heartbeat, no pid/tick/silence — but raw flag says alive → stays alive
+    const r = isSessionAlive({ is_alive: true, heartbeat_age_seconds: 9999 }, { nowMs: NOW });
+    expect(r.alive).toBe(true);
+    expect(r.reason).toBe('raw_is_alive');
+  });
+
+  it('UPGRADES a parked worker the raw flag froze to false: pid-alive → alive', () => {
+    const s = { is_alive: false, heartbeat_age_seconds: 9999, terminal_id: 'win-cc-1234-77777' };
+    const r = isSessionAlive(s, { nowMs: NOW, aliveCcPids: new Set(['77777']) });
+    expect(r.alive).toBe(true);
+    expect(r.reason).toBe('pid_alive');
+  });
+
+  it('UPGRADES on armed-silence (raw false, stale heartbeat, future expected_silence_until)', () => {
+    const s = { is_alive: false, heartbeat_age_seconds: 9999, expected_silence_until: iso(NOW + 10 * 60 * 1000) };
+    expect(isSessionAlive(s, { nowMs: NOW }).reason).toBe('armed_silence');
+  });
+
+  it('UPGRADES on a fresh process tick', () => {
+    const s = { is_alive: false, heartbeat_age_seconds: 9999, process_alive_at: iso(NOW - 10 * 1000) };
+    expect(isSessionAlive(s, { nowMs: NOW }).reason).toBe('process_tick');
+  });
+
+  it('fresh heartbeat alone → alive', () => {
+    expect(isSessionAlive({ heartbeat_age_seconds: 30 }, { nowMs: NOW }).reason).toBe('fresh_heartbeat');
+    expect(isSessionAlive({ heartbeat_at: iso(NOW - 60 * 1000) }, { nowMs: NOW }).reason).toBe('fresh_heartbeat');
+  });
+
+  it('GENUINELY DEAD (raw false, stale heartbeat, no pid, no tick, no silence) → dead (no real-death masking)', () => {
+    const s = {
+      is_alive: false, heartbeat_age_seconds: 9999, terminal_id: 'win-cc-1234-55555',
+      process_alive_at: iso(NOW - 10 * 60 * 1000), expected_silence_until: iso(NOW - 60 * 1000),
+    };
+    const r = isSessionAlive(s, { nowMs: NOW, aliveCcPids: new Set(['00000']) }); // pid 55555 NOT alive
+    expect(r.alive).toBe(false);
+    expect(r.reason).toBe(null);
+  });
+
+  it('null/garbage → dead, no throw', () => {
+    expect(isSessionAlive(null).alive).toBe(false);
+    expect(isSessionAlive(undefined).alive).toBe(false);
+  });
+});
+
+describe('authoritative predicates', () => {
+  it('hasFreshHeartbeat honors heartbeat_age_seconds and heartbeat_at/last_heartbeat', () => {
+    expect(hasFreshHeartbeat({ heartbeat_age_seconds: 100 }, NOW)).toBe(true);
+    expect(hasFreshHeartbeat({ heartbeat_age_seconds: 400 }, NOW)).toBe(false);
+    expect(hasFreshHeartbeat({ heartbeat_at: iso(NOW - 120 * 1000) }, NOW)).toBe(true);
+    expect(hasFreshHeartbeat({ last_heartbeat: iso(NOW - 600 * 1000) }, NOW)).toBe(false);
+  });
+  it('hasTickAlive within 90s only', () => {
+    expect(hasTickAlive({ process_alive_at: iso(NOW - 80 * 1000) }, NOW)).toBe(true);
+    expect(hasTickAlive({ process_alive_at: iso(NOW - 100 * 1000) }, NOW)).toBe(false);
+    expect(hasTickAlive({}, NOW)).toBe(false);
+  });
+  it('hasExpectedSilence: future and within 30min only', () => {
+    expect(hasExpectedSilence({ expected_silence_until: iso(NOW + 5 * 60 * 1000) }, NOW)).toBe(true);
+    expect(hasExpectedSilence({ expected_silence_until: iso(NOW + 40 * 60 * 1000) }, NOW)).toBe(false); // too far out
+    expect(hasExpectedSilence({ expected_silence_until: iso(NOW - 1000) }, NOW)).toBe(false); // past
+  });
+  it('hasPidAlive parses the trailing cc pid from terminal_id', () => {
+    expect(hasPidAlive({ terminal_id: 'win-cc-1234-42' }, new Set(['42']))).toBe(true);
+    expect(hasPidAlive({ terminal_id: 'win-cc-1234-42' }, new Set(['99']))).toBe(false);
+    expect(hasPidAlive({}, new Set(['42']))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`is_alive` is a **raw stored boolean** that freezes once a parked worker's UNREF'd heartbeat interval stops firing — a false-negative that drove false "fleet down"/"orphaned SD" verdicts **four times** (#5095 gauge, charter-audit DUTY-3, ghost #5090, the 2026-06-23 near-reap). A write-time fix is infeasible (staleness arises *after* the last write). Chairman directive: kill it at the source. This establishes a single **read-time** liveness SSOT.

## Delivered (FR-1 + FR-2)
- **FR-1** `lib/fleet/session-liveness.cjs`: `isSessionAlive(session,{nowMs,aliveCcPids})` + the 3 authoritative predicates (`hasPidAlive`/`hasTickAlive`/`hasExpectedSilence`) extracted from the dashboard. **One-directional**: raw `is_alive===true` is itself a live signal, so it never downgrades a worker the raw flag calls alive (never masks a real death); it only **upgrades** a parked-alive worker (pid / fresh-tick / armed-silence / fresh-heartbeat) with a stamped reason. Reuses `cc-pid-liveness.cjs`.
- **FR-2** `fleet-dashboard` `reconcilePAliveWithLiveness` is now a **thin wrapper** over `isSessionAlive` — closing the "three local copies" divergence risk between the gauge and the SSOT.

19 tests: SSOT (raw-alive-never-downgraded, each upgrade signal, **genuinely-dead-still-dead**); gauge (SSOT-backed override, no-stamp on raw/heartbeat, null-safe).

## ⚠️ Decomposed — FR-3/FR-4 → follow-up child
Routing the **claim-safety core** consumers (`worker-checkin` isSdInFlight/foreign-holder, `claim-validity-gate` `ownerIsDeadByLiveness`, `ownership-detection` `deriveHoldingStatus`) through `isSessionAlive` + their regression tests is filed as a follow-up child. That half overlaps the existing **#5087 PID-escape** (`shouldReleaseStaleOwner`) and deserves focused review separate from the SSOT extraction — building it in the same PR would risk a hard-to-review claim-safety diff. The SSOT now exists for that child to route into.

SD: SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)