### PR TITLE
feat(SD-LEO-INFRA-PROPOSAL-INGEST-ARCHPLAN-WHITELIST-001): propagate orchestrator arch-plan keys through proposal-ingest whitelist

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2403,6 +2403,20 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
       // FALSE block (an already-reviewed proposal), it does NOT weaken the review gate.
       ...(proposal.metadata?.migration_reviewed === true || opts.migrationReviewed === true ? { migration_reviewed: true } : {}),
       ...(proposal.metadata?.security_reviewed === true || opts.securityReviewed === true ? { security_reviewed: true } : {}),
+      // SD-LEO-INFRA-PROPOSAL-INGEST-ARCHPLAN-WHITELIST-001: propagate the orchestrator arch-plan
+      // PRESENCE keys so GR-ORCHESTRATOR-ARCH-PLAN (a presence check on architecture_plan_ref ||
+      // arch_plan_key || arch_key, guardrail-registry.js) passes for an orchestrator proposal that
+      // carries a real plan. Without this the closed whitelist stripped them and the guardrail read
+      // undefined → BLOCKED, so NO orchestrator proposal could materialize via --from-proposal (parity
+      // gap vs the direct-args route + the review flags above). architecture_plan_ref / arch_plan_key /
+      // architecture_plan are PURE metadata consumed by the guardrail + reporting — NOT routing keys.
+      // CRITICAL: arch_key (and vision_key) are still DELIBERATELY dropped — they drive
+      // enrichFromVisionArch's orphan-FK re-activation (see this fn's header + line ~2169); the two
+      // ref/plan keys already satisfy the guardrail WITHOUT that risk, so the leak guard is preserved.
+      // Each key appears ONLY when the proposal declares it (no coercion/defaulting).
+      ...(proposal.metadata?.architecture_plan_ref ? { architecture_plan_ref: proposal.metadata.architecture_plan_ref } : {}),
+      ...(proposal.metadata?.arch_plan_key ? { arch_plan_key: proposal.metadata.arch_plan_key } : {}),
+      ...(proposal.metadata?.architecture_plan ? { architecture_plan: proposal.metadata.architecture_plan } : {}),
     },
   };
 }

--- a/tests/unit/leo-create-sd-from-proposal.test.js
+++ b/tests/unit/leo-create-sd-from-proposal.test.js
@@ -180,6 +180,39 @@ describe('mapProposalToCreateArgs (pure field mapping)', () => {
     expect(args.metadata.source).toBe('proposal'); // only the closed whitelist survives
   });
 
+  // SD-LEO-INFRA-PROPOSAL-INGEST-ARCHPLAN-WHITELIST-001: an orchestrator proposal's arch-plan
+  // presence keys must flow through the whitelist so GR-ORCHESTRATOR-ARCH-PLAN passes — WITHOUT
+  // re-leaking the arch_key/vision_key routing keys the leak guard protects.
+  it('propagates arch-plan presence keys (architecture_plan_ref / arch_plan_key / architecture_plan)', () => {
+    const p = validProposal({ metadata: {
+      architecture_plan_ref: 'ARCH-PLAN-REF-001', arch_plan_key: 'APK-001', architecture_plan: 'x'.repeat(2052),
+    } });
+    const args = mapProposalToCreateArgs(normalized, p, 'p.json');
+    expect(args.metadata.architecture_plan_ref).toBe('ARCH-PLAN-REF-001');
+    expect(args.metadata.arch_plan_key).toBe('APK-001');
+    expect(args.metadata.architecture_plan).toHaveLength(2052);
+    // the GR-ORCHESTRATOR-ARCH-PLAN presence check (architecture_plan_ref || arch_plan_key || arch_key) now passes
+    expect(args.metadata.architecture_plan_ref || args.metadata.arch_plan_key || args.metadata.arch_key).toBeTruthy();
+  });
+
+  it('arch-plan propagation does NOT re-leak arch_key/vision_key (leak guard preserved)', () => {
+    // A proposal carrying BOTH the safe ref AND the dangerous routing keys: ref flows, routing keys drop.
+    const p = validProposal({ metadata: {
+      architecture_plan_ref: 'ARCH-PLAN-REF-002', arch_key: 'ARCH-EVIL', vision_key: 'VIS-EVIL',
+    } });
+    const args = mapProposalToCreateArgs(normalized, p, 'p.json');
+    expect(args.metadata.architecture_plan_ref).toBe('ARCH-PLAN-REF-002');
+    expect(args.metadata.arch_key).toBeUndefined();   // routing key still dropped (enrichFromVisionArch orphan-FK guard)
+    expect(args.metadata.vision_key).toBeUndefined();
+  });
+
+  it('omits the arch-plan keys when the proposal does not declare them (no coercion)', () => {
+    const args = mapProposalToCreateArgs(normalized, validProposal(), 'p.json');
+    expect(args.metadata.architecture_plan_ref).toBeUndefined();
+    expect(args.metadata.arch_plan_key).toBeUndefined();
+    expect(args.metadata.architecture_plan).toBeUndefined();
+  });
+
   // SD-LEO-INFRA-ADAM-SELF-AUDIT-RESOLVERS-001 (FR-1a, load-bearing): the canonical Adam-origin
   // marker metadata.sourced_by='adam' is stamped ONLY for an explicit Adam-origin proposal, and
   // is ABSENT for any non-Adam proposal (so non-Adam creation paths are unchanged).


### PR DESCRIPTION
## Summary
`mapProposalToCreateArgs`' closed metadata whitelist propagated the review flags but **dropped the orchestrator arch-plan keys**. So an orchestrator proposal carrying `metadata.architecture_plan_ref` had it stripped → `GR-ORCHESTRATOR-ARCH-PLAN` (presence check on `architecture_plan_ref || arch_plan_key || arch_key`) read undefined and **BLOCKED** → no orchestrator proposal could materialize via `--from-proposal` (witnessed blocking SD-LEO-INFRA-WORKER-REVIVAL-GOLIVE-READINESS-001 F3). Same parity class as the review-flags fix.

**Fix:** propagate `architecture_plan_ref` + `arch_plan_key` + `architecture_plan` (pure metadata the guardrail + reporting consume). **CRITICAL:** `arch_key`/`vision_key` remain deliberately **dropped** — they drive `enrichFromVisionArch`'s orphan-FK re-activation; the ref/plan keys already satisfy the guardrail without that risk, so the leak guard (+ its test) is preserved.

## Verification
- 45/45 tests incl. a **leak-guard-retention** case (ref flows, routing keys drop); validation PASS-95 (leak-guard independently verified); TESTING PASS-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)