### PR TITLE
feat(SD-LEO-INFRA-WORKER-REVIVAL-GOLIVE-READINESS-001-D): spawn-executor ops wiring (CHILD C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -282,3 +282,17 @@ STRIPE_SECRET_KEY=sk_test_your-stripe-test-secret-key      # sk_test_ for fleet/
 STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-signing-secret
 # STRIPE_RAIL_LIVE_MODE=false                               # chairman-only TEST->LIVE switch (default off)
 # STRIPE_API_VERSION=                                       # optional pin; blank uses SDK default
+
+# ==============================================================================
+# Fleet worker-spawn executor (scripts/fleet/worker-spawn-executor.cjs)
+# ==============================================================================
+# OPERATOR GATE — do NOT enable autonomously. The executor spawns OS-level
+# Claude Code worker processes (high blast radius: duplicate/runaway sessions
+# burn the shared usage quota). With WORKER_SPAWN_EXECUTOR_LIVE unset/false the
+# daemon is DRY-RUN: it logs the spawn command it WOULD run and launches nothing.
+# Before flipping to true, an operator must HOST-VALIDATE buildSpawnInvocation()
+# and register the external scheduler that runs the daemon. See
+# docs/protocol/coordinator-worker-revival.md. The launch model itself
+# (interactive-TTY vs stateless-runner) is still pending CHILD A's decision.
+# WORKER_SPAWN_EXECUTOR_LIVE=false                          # default off; live OS spawn (operator-gated)
+# WORKER_SPAWN_EXECUTOR_PER_TICK_CAP=2                      # max spawns per executor tick (default 2)

--- a/docs/protocol/coordinator-worker-revival.md
+++ b/docs/protocol/coordinator-worker-revival.md
@@ -117,6 +117,65 @@ This SD does not pick a spawn-execution layer. Trade-offs for future implementer
 
 The `revival_pending` section of `fleet-dashboard.cjs` displays open requests with age + expires-in. It is hidden when zero rows are pending.
 
+## Ops Wiring & Validation (CHILD C — launch-shape-independent)
+
+> Added by SD-LEO-INFRA-WORKER-REVIVAL-GOLIVE-READINESS-001-D. These steps are
+> **independent of the spawn launch model**. The launch model itself
+> (interactive-TTY persistent `/loop` vs stateless per-turn runner) is
+> **DEFERRED to CHILD A** (SD-...-001-B) — a chairman-routed architecture
+> decision. Do NOT infer a launch model from this section.
+
+### Executor (dry-run by default)
+
+```bash
+npm run fleet:spawn-executor          # DRY-RUN unless WORKER_SPAWN_EXECUTOR_LIVE=true
+```
+
+Gate flags (documented in `.env.example`, both default-safe):
+- `WORKER_SPAWN_EXECUTOR_LIVE` (default off) — the live OS-spawn gate; **operator-gated**, never enable autonomously.
+- `WORKER_SPAWN_EXECUTOR_PER_TICK_CAP` (default 2) — max spawns per executor tick.
+
+### Supersede expired-pending spawn requests (idempotent)
+
+A pending `worker_spawn_request` past its `expires_at` keeps the
+partial-unique-index `idx_wsr_unique_pending_callsign` (UNIQUE per callsign
+WHERE `status='pending'`) occupied, blocking a fresh revival re-file for that
+callsign. There is **no always-on DB-side sweeper** (per the
+SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001 contract) — run the operator step:
+
+```bash
+npm run fleet:supersede-expired-spawns
+```
+
+It flips `pending AND expires_at<=now()` rows to `expired` (a live pending row,
+`expires_at` in the future, is never touched) and is **idempotent** — a second
+run supersedes 0 rows. It is a thin wrapper around the canonical reaper
+`reapExpiredPendingRequests` (`scripts/coordinator-revive.cjs`).
+
+### Validation: fulfilled-with-live-session vs fulfilled-but-dead
+
+A request marked `fulfilled` only delivered persistent capacity if its session
+is actually alive. Partition fulfilled requests using the **authoritative**
+liveness surface `v_active_sessions` (same basis the executor's
+`deriveLiveCallsigns` uses) — never raw row age:
+
+```sql
+SELECT
+  wsr.id,
+  wsr.requested_callsign,
+  wsr.fulfilled_by_session_id,
+  CASE WHEN vas.session_id IS NOT NULL AND vas.computed_status = 'active'
+       THEN 'fulfilled_live' ELSE 'fulfilled_dead' END AS liveness
+FROM worker_spawn_requests wsr
+LEFT JOIN v_active_sessions vas
+  ON vas.session_id = wsr.fulfilled_by_session_id
+WHERE wsr.status = 'fulfilled'
+ORDER BY liveness, wsr.requested_callsign;
+```
+
+`fulfilled_dead` rows are the signal that a "revival" produced no persistent
+worker — the exact failure mode CHILD A's launch-model decision must close.
+
 ## Cross-References
 
 - [Pre-Claim Cadence Gate](./cadence-gate.md) — sibling protocol contract, similar shape

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eva:scheduler:watch:cron": "node scripts/cron/eva-scheduler-watcher.mjs --once",
     "adam:exec:email:cron": "node scripts/adam-exec-summary.mjs",
     "fleet:spawn-executor": "node scripts/fleet/worker-spawn-executor.cjs",
+    "fleet:supersede-expired-spawns": "node scripts/fleet/supersede-expired-spawn-requests.mjs",
     "fleet:pulse": "node scripts/fleet-worker-pulse.mjs",
     "fleet:pulse:cron": "node scripts/fleet-worker-pulse.mjs",
     "fleet:down-alert": "node scripts/fleet-down-alert.mjs",

--- a/scripts/fleet/supersede-expired-spawn-requests.mjs
+++ b/scripts/fleet/supersede-expired-spawn-requests.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-WORKER-REVIVAL-GOLIVE-READINESS-001-D (CHILD C / FR-3)
+ *
+ * Single-purpose operator runbook step: supersede EXPIRED-but-pending
+ * worker_spawn_requests (flip status pending -> expired) so the
+ * partial-unique-index `idx_wsr_unique_pending_callsign` (UNIQUE per callsign
+ * WHERE status='pending') stops blocking a fresh revival re-file.
+ *
+ * This is a thin, idempotent wrapper around the EXISTING canonical reaper
+ * `reapExpiredPendingRequests` (scripts/coordinator-revive.cjs, shipped by
+ * SD-REFILL-00H0UNO7) — it adds NO new DB logic, only an ops entrypoint the
+ * runbook can call directly. There is NO always-on DB-side sweeper (per the
+ * SD-LEO-INFRA-WORKER-EXTERNAL-REVIVAL-001 contract); this is operator-run.
+ *
+ * Idempotent: the reaper filters status='pending' AND expires_at<=now(), so a
+ * live pending row (expires_at in the future) is never touched, and a second
+ * run reaps 0 rows. Fail-soft: a reaper warning never throws here.
+ *
+ * Usage:  node scripts/fleet/supersede-expired-spawn-requests.mjs
+ *         npm run fleet:supersede-expired-spawns
+ */
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { reapExpiredPendingRequests } = require('../coordinator-revive.cjs');
+const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+
+async function main() {
+  const sb = createSupabaseServiceClient();
+  const before = await sb
+    .from('worker_spawn_requests')
+    .select('id', { count: 'exact', head: true })
+    .eq('status', 'pending')
+    .lte('expires_at', new Date().toISOString());
+  const candidates = before.count ?? 0;
+  const reaped = await reapExpiredPendingRequests(sb);
+  const n = Array.isArray(reaped) ? reaped.length : (reaped ?? 0);
+  console.log(`[supersede-expired-spawns] expired-pending candidates: ${candidates}; superseded: ${n} (idempotent — a re-run supersedes 0).`);
+}
+
+main().catch((e) => {
+  console.error(`[supersede-expired-spawns] failed: ${e.message}`);
+  process.exit(1);
+});

--- a/tests/unit/worker-revival-golive-d.test.js
+++ b/tests/unit/worker-revival-golive-d.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-INFRA-WORKER-REVIVAL-GOLIVE-READINESS-001-D (CHILD C) — ops wiring.
+ * Locks the launch-shape-INDEPENDENT deliverables. The launch model itself is
+ * deferred to CHILD A and is intentionally NOT asserted here.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const repo = path.resolve(__dirname, '..', '..');
+const read = (p) => fs.readFileSync(path.join(repo, p), 'utf8');
+
+describe('SD-...-001-D: worker-revival go-live ops wiring', () => {
+  it('FR-1: fleet:spawn-executor npm script is present (assert-present, not re-add)', () => {
+    const pkg = require(path.join(repo, 'package.json'));
+    expect(pkg.scripts['fleet:spawn-executor']).toBe('node scripts/fleet/worker-spawn-executor.cjs');
+  });
+
+  it('FR-2: .env.example documents both executor flags with safe defaults + operator gate', () => {
+    const env = read('.env.example');
+    expect(env).toMatch(/WORKER_SPAWN_EXECUTOR_LIVE=false/);
+    expect(env).toMatch(/WORKER_SPAWN_EXECUTOR_PER_TICK_CAP=2/);
+    expect(env).toMatch(/OPERATOR GATE/);
+  });
+
+  it('FR-3: supersede npm script wired and wraps the canonical reaper (no duplicate DB logic)', () => {
+    const pkg = require(path.join(repo, 'package.json'));
+    expect(pkg.scripts['fleet:supersede-expired-spawns']).toBe('node scripts/fleet/supersede-expired-spawn-requests.mjs');
+    const src = read('scripts/fleet/supersede-expired-spawn-requests.mjs');
+    expect(src).toMatch(/reapExpiredPendingRequests/);
+    expect(src).toMatch(/coordinator-revive\.cjs/);
+    // must NOT hand-roll its own UPDATE — it reuses the canonical reaper
+    expect(src).not.toMatch(/\.update\(\s*\{\s*status:\s*['"]expired['"]/);
+  });
+
+  it('FR-3: the canonical reaper is exported and idempotently scoped to expired-pending', () => {
+    const revive = require(path.join(repo, 'scripts/coordinator-revive.cjs'));
+    expect(typeof revive.reapExpiredPendingRequests).toBe('function');
+    const src = read('scripts/coordinator-revive.cjs');
+    expect(src).toMatch(/\.eq\('status',\s*'pending'\)/);
+    expect(src).toMatch(/\.lte\('expires_at'/);
+  });
+
+  it('FR-4: doc carries the fulfilled-live-vs-dead validation query on the authoritative liveness surface', () => {
+    const doc = read('docs/protocol/coordinator-worker-revival.md');
+    expect(doc).toMatch(/fulfilled_live/);
+    expect(doc).toMatch(/fulfilled_dead/);
+    expect(doc).toMatch(/v_active_sessions/);
+    expect(doc).not.toMatch(/age\s*[<>]=?\s*\d+\s*(?:second|minute|hour)/i); // not row-age based
+  });
+
+  it('FR-5: doc marks the launch model DEFERRED to CHILD A (no launch-model commitment here)', () => {
+    const doc = read('docs/protocol/coordinator-worker-revival.md');
+    expect(doc).toMatch(/DEFERRED to CHILD A/);
+    expect(doc).toMatch(/fleet:supersede-expired-spawns/);
+  });
+});


### PR DESCRIPTION
CHILD C of the worker-revival go-live orchestrator (SD-LEO-INFRA-WORKER-REVIVAL-GOLIVE-READINESS-001). **Launch-shape-independent ops wiring only** — the launch model (interactive-TTY vs stateless-runner) stays DEFERRED to CHILD A, which is chairman-routed.

## Deliverables
- **FR-1** assert `fleet:spawn-executor` npm script present (verify-premise: already on main — not re-added)
- **FR-2** `.env.example` documents `WORKER_SPAWN_EXECUTOR_LIVE` (default off) + `WORKER_SPAWN_EXECUTOR_PER_TICK_CAP` (default 2) with the operator-gate warning
- **FR-3** `fleet:supersede-expired-spawns` npm script — thin idempotent wrapper around the canonical `reapExpiredPendingRequests` (no new DB logic, no sweeper)
- **FR-4** fulfilled-live-vs-dead validation query in the runbook (authoritative `v_active_sessions` liveness, not row age)
- **FR-5** `coordinator-worker-revival.md` ops section; launch model marked DEFERRED to CHILD A

## Evidence
- 6/6 unit tests green (`tests/unit/worker-revival-golive-d.test.js`)
- PLAN sub-agents: DB PASS(96), Security PASS(95), Stories PASS(92), Design CONDITIONAL_PASS(82)
- Testing-agent EXEC: PASS(96)
- Handoffs: LEAD-TO-PLAN 95, PLAN-TO-EXEC 99, EXEC-TO-PLAN 95, PLAN-TO-LEAD 97

🤖 Generated with [Claude Code](https://claude.com/claude-code)