### PR TITLE
feat(SD-LEO-INFRA-ROADMAP-TITLE-WRITEBACK-BACKFILL-001): roadmap title write-back + backfill

### DIFF
--- a/scripts/eva-intake-refine.js
+++ b/scripts/eva-intake-refine.js
@@ -28,7 +28,7 @@ import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import dotenv from 'dotenv';
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dedup, extractDedupContext } from '../lib/integrations/refine-dedup.js';
 import { reconcile, extractReconcileContext } from '../lib/integrations/refine-reconcile.js';
 import { score, extractScoringContext } from '../lib/integrations/refine-score.js';
@@ -340,6 +340,42 @@ async function runPromotion(waves, scoringResults) {
   return result;
 }
 
+// SD-LEO-INFRA-ROADMAP-TITLE-WRITEBACK-BACKFILL-001 FR-1: persist the refine scores into the
+// metadata JSONB column AND write a non-fallback source title back to the title column, so a
+// promoted SD carries a human/source title instead of a fallback. Extracted from main() as a pure,
+// exported function for unit-testability. Returns the count persisted (rows updated without error).
+export async function persistScores(waves, scoringResults, { supabase }) {
+  let persisted = 0;
+  for (const waveResult of (scoringResults || [])) {
+    const wave = (waves || []).find(w => w.id === waveResult.wave_id);
+    if (!wave) continue;
+    for (const s of waveResult.item_scores) {
+      const item = wave.items[s.item_index - 1];
+      if (!item || !item.id) continue;
+      const existingMeta = item.metadata || {};
+      const newMeta = {
+        ...existingMeta,
+        refine_composite_score: s.composite,
+        refine_recommendation: s.recommendation,
+        refine_persona_scores: s.persona_scores,
+        refine_method: waveResult.method || 'claude_inline',
+        refine_scored_at: new Date().toISOString(),
+      };
+      // Write back a real source title only — never the '(untitled)' fallback, so a human/source
+      // title is preserved and a fallback is never persisted to the title column.
+      const sourceTitle = (item.title && item.title !== '(untitled)') ? item.title : null;
+      const updatePayload = { metadata: newMeta };
+      if (sourceTitle) updatePayload.title = sourceTitle;
+      const { error } = await supabase
+        .from('roadmap_wave_items')
+        .update(updatePayload)
+        .eq('id', item.id);
+      if (!error) persisted++;
+    }
+  }
+  return persisted;
+}
+
 // ─── Main ──────────────────────────────────────────────────
 
 async function main() {
@@ -551,30 +587,8 @@ async function main() {
     writeFileSync(scorePath, JSON.stringify(scoringResults, null, 2));
     console.log('\n  Scoring results saved to scripts/temp/scoring-results.json');
 
-    // Persist scores into metadata JSONB column
-    let persisted = 0;
-    for (const waveResult of scoringResults) {
-      const wave = waves.find(w => w.id === waveResult.wave_id);
-      if (!wave) continue;
-      for (const s of waveResult.item_scores) {
-        const item = wave.items[s.item_index - 1];
-        if (!item || !item.id) continue;
-        const existingMeta = item.metadata || {};
-        const newMeta = {
-          ...existingMeta,
-          refine_composite_score: s.composite,
-          refine_recommendation: s.recommendation,
-          refine_persona_scores: s.persona_scores,
-          refine_method: waveResult.method || 'claude_inline',
-          refine_scored_at: new Date().toISOString(),
-        };
-        const { error } = await supabase
-          .from('roadmap_wave_items')
-          .update({ metadata: newMeta })
-          .eq('id', item.id);
-        if (!error) persisted++;
-      }
-    }
+    // Persist scores into metadata JSONB column (+ source title write-back, FR-1).
+    const persisted = await persistScores(waves, scoringResults, { supabase });
     console.log(`  Persisted ${persisted} scores to DB (metadata column)`);
   }
 
@@ -619,7 +633,11 @@ async function main() {
   console.log('');
 }
 
-main().catch(err => {
-  console.error('Refine error:', err.message);
-  process.exit(1);
-});
+// Main-guard (SD-LEO-INFRA-ROADMAP-TITLE-WRITEBACK-BACKFILL-001): run only as the CLI entrypoint, so
+// importing persistScores in a unit test does not execute main().
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    console.error('Refine error:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/one-off/backfill-roadmap-promote-titles.js
+++ b/scripts/one-off/backfill-roadmap-promote-titles.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// @wire-check-exempt — one-off backfill CLI (run manually, not imported)
+/**
+ * SD-LEO-INFRA-ROADMAP-TITLE-WRITEBACK-BACKFILL-001 FR-2 — one-time idempotent backfill of titles for
+ * the 'promote'-scored roadmap_wave_items that have no title (the ~67 promote items predating the
+ * FR-1 write-back). Mirrors the promoter's own skip filter (roadmap-manager.js:285-290) so the
+ * fable_gated / chairman_* / dropped / deferred items are naturally excluded.
+ *
+ * Per item: resolve the FLOOR title via source_type/source_id → eva_todoist_intake.title /
+ * eva_youtube_intake.title (both TEXT NOT NULL). Distillation of an SD-quality title from the persona
+ * reasoning is OPTIONAL and falls back to the floor title when unavailable (this run uses the floor
+ * title — a real human/source title, exactly what FR-1 preserves going forward).
+ *
+ * DRY-RUN by default (prints the plan); pass --apply to write. Idempotent: the UPDATE is guarded
+ * (title IS NULL AND promoted_to_sd_key IS NULL AND refine_recommendation='promote'), so re-running is
+ * a no-op for already-titled rows.
+ *
+ * Usage: node scripts/one-off/backfill-roadmap-promote-titles.js [--apply]
+ */
+import 'dotenv/config';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const INTAKE_TABLE = { todoist: 'eva_todoist_intake', youtube: 'eva_youtube_intake' };
+
+// Resolve the floor title for an item from its source intake table (fail-soft → null).
+async function resolveFloorTitle(supabase, item) {
+  const table = INTAKE_TABLE[item.source_type];
+  if (!table || !item.source_id) return null;
+  try {
+    const { data, error } = await supabase.from(table).select('title').eq('id', item.source_id).maybeSingle();
+    if (error || !data) return null;
+    const t = (data.title || '').trim();
+    return t && t !== '(untitled)' ? t : null;
+  } catch { return null; }
+}
+
+export async function runBackfill({ supabase, apply = false, log = console.log } = {}) {
+  // Selection mirrors the promoter's skip filter: promote-scored, untitled, not promoted, not a
+  // brainstorm child, not dropped/deferred.
+  const { data: rows, error } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, title, source_type, source_id, item_disposition, promoted_to_sd_key, brainstorm_session_id, metadata')
+    .is('title', null)
+    .is('promoted_to_sd_key', null)
+    .is('brainstorm_session_id', null)
+    .eq('metadata->>refine_recommendation', 'promote');
+  if (error) { log(`[backfill] query failed: ${error.message}`); return { selected: 0, titled: 0, skipped: 0, applied: apply }; }
+  const candidates = (rows || []).filter(r => !['dropped', 'deferred'].includes(r.item_disposition));
+
+  let titled = 0, skipped = 0;
+  for (const item of candidates) {
+    const floor = await resolveFloorTitle(supabase, item);
+    // (distillation hook: an SD-quality title could be distilled from
+    //  metadata.refine_persona_scores[*].reasoning + the floor title; unavailable in this one-off →
+    //  fall back to the floor title, per FR-2.)
+    const newTitle = floor;
+    if (!newTitle) { skipped++; log(`[backfill] SKIP ${item.id} (no resolvable source title for ${item.source_type}/${item.source_id})`); continue; }
+    if (!apply) { titled++; log(`[backfill] DRY-RUN would title ${item.id} → "${newTitle.slice(0, 80)}"`); continue; }
+    const { data: upd, error: uErr } = await supabase
+      .from('roadmap_wave_items')
+      .update({ title: newTitle })
+      .eq('id', item.id)
+      .is('title', null)                                   // idempotency guard
+      .is('promoted_to_sd_key', null)
+      .eq('metadata->>refine_recommendation', 'promote')
+      .select('id');
+    if (uErr) { skipped++; log(`[backfill] ERROR ${item.id}: ${uErr.message}`); continue; }
+    if (upd && upd.length) { titled++; log(`[backfill] titled ${item.id} → "${newTitle.slice(0, 80)}"`); }
+    else { skipped++; log(`[backfill] no-op ${item.id} (already titled/promoted — idempotent)`); }
+  }
+  log(`[backfill] ${apply ? 'APPLIED' : 'DRY-RUN'}: selected ${candidates.length}, titled ${titled}, skipped ${skipped}`);
+  return { selected: candidates.length, titled, skipped, applied: apply };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const apply = process.argv.includes('--apply');
+  runBackfill({ supabase: createSupabaseServiceClient(), apply })
+    .then(() => process.exit(0))
+    .catch(err => { console.error('backfill error:', err.message); process.exit(1); });
+}

--- a/tests/unit/eva/roadmap-title-writeback.test.js
+++ b/tests/unit/eva/roadmap-title-writeback.test.js
@@ -1,0 +1,91 @@
+// SD-LEO-INFRA-ROADMAP-TITLE-WRITEBACK-BACKFILL-001 — FR-1 persistScores title write-back +
+// FR-2 backfill dry-run. The write-back persists a NON-FALLBACK source title to the title column
+// (never '(untitled)' / missing), so a promoted SD carries a human/source title.
+import { describe, it, expect } from 'vitest';
+import { persistScores } from '../../../scripts/eva-intake-refine.js';
+import { runBackfill } from '../../../scripts/one-off/backfill-roadmap-promote-titles.js';
+
+function mockPersistSb() {
+  const updates = [];
+  return {
+    updates,
+    from() {
+      return { update(payload) { return { eq(_c, id) { updates.push({ id, payload }); return Promise.resolve({ error: null }); } }; } };
+    },
+  };
+}
+
+const waves = [{
+  id: 'w1',
+  items: [
+    { id: 'i1', title: 'Real Source Title', metadata: { x: 1 } },
+    { id: 'i2', title: '(untitled)', metadata: {} },
+    { id: 'i3', metadata: {} }, // no title
+  ],
+}];
+const scoringResults = [{
+  wave_id: 'w1',
+  method: 'claude_inline',
+  item_scores: [
+    { item_index: 1, composite: 80, recommendation: 'promote', persona_scores: [] },
+    { item_index: 2, composite: 40, recommendation: 'defer', persona_scores: [] },
+    { item_index: 3, composite: 60, recommendation: 'promote', persona_scores: [] },
+  ],
+}];
+
+describe('persistScores — FR-1 title write-back', () => {
+  it('includes title ONLY for a non-fallback source title; always writes metadata', async () => {
+    const sb = mockPersistSb();
+    const n = await persistScores(waves, scoringResults, { supabase: sb });
+    expect(n).toBe(3);
+    const byId = Object.fromEntries(sb.updates.map(u => [u.id, u.payload]));
+    expect(byId.i1.title).toBe('Real Source Title');         // real title → written
+    expect(byId.i1.metadata.refine_recommendation).toBe('promote');
+    expect('title' in byId.i2).toBe(false);                  // '(untitled)' → NOT written
+    expect('title' in byId.i3).toBe(false);                  // missing title → NOT written
+    expect(byId.i2.metadata).toBeDefined();                  // metadata still persisted
+    expect(byId.i3.metadata).toBeDefined();
+  });
+  it('preserves existing metadata keys when merging', async () => {
+    const sb = mockPersistSb();
+    await persistScores(waves, scoringResults, { supabase: sb });
+    const byId = Object.fromEntries(sb.updates.map(u => [u.id, u.payload]));
+    expect(byId.i1.metadata.x).toBe(1); // existing key preserved
+  });
+  it('handles empty/missing inputs without throwing', async () => {
+    const sb = mockPersistSb();
+    expect(await persistScores(undefined, undefined, { supabase: sb })).toBe(0);
+  });
+});
+
+describe('runBackfill — FR-2 dry-run (no writes)', () => {
+  function mockBackfillSb({ candidates, floorTitles }) {
+    return {
+      writes: 0,
+      from(table) {
+        if (table === 'roadmap_wave_items') {
+          // select(...).is().is().is().eq() → resolves to the candidate rows
+          const chain = { select() { return chain; }, is() { return chain; }, eq() { return chain; }, then(res) { return Promise.resolve({ data: candidates, error: null }).then(res); } };
+          return chain;
+        }
+        // intake table: select('title').eq('id', id).maybeSingle()
+        return { select() { return { eq(_c, id) { return { maybeSingle() { return Promise.resolve({ data: floorTitles[id] ? { title: floorTitles[id] } : null, error: null }); } }; } }; } };
+      },
+    };
+  }
+  it('counts titleable items via the floor title but writes nothing in dry-run', async () => {
+    const candidates = [
+      { id: 'a', source_type: 'todoist', source_id: 't1', item_disposition: null, metadata: {} },
+      { id: 'b', source_type: 'youtube', source_id: 'y1', item_disposition: null, metadata: {} },
+      { id: 'c', source_type: 'todoist', source_id: 'tX', item_disposition: null, metadata: {} }, // no floor title
+      { id: 'd', source_type: 'todoist', source_id: 't2', item_disposition: 'dropped', metadata: {} }, // filtered out
+    ];
+    const floorTitles = { t1: 'Todoist Task A', y1: 'YouTube Idea B' };
+    const sb = mockBackfillSb({ candidates, floorTitles });
+    const r = await runBackfill({ supabase: sb, apply: false, log: () => {} });
+    expect(r.applied).toBe(false);
+    expect(r.selected).toBe(3);  // 'd' (dropped) excluded
+    expect(r.titled).toBe(2);    // a + b have floor titles
+    expect(r.skipped).toBe(1);   // c has no resolvable source title
+  });
+});


### PR DESCRIPTION
## Summary
Roadmap wave items persisted refine scores into `metadata` but left the `title` column null, so promoted SDs lost the human/source title. Coordinator-assigned.

## FR-1 — durable persist write-back
Extracted the persist loop into an exported `persistScores(waves, scoringResults, {supabase})` and included `title` in the `.update()` when a **non-fallback** source title exists (never writes `'(untitled)'`). Added a main-guard so the module is import-safe for the test.

## FR-2 — one-time idempotent backfill
`scripts/one-off/backfill-roadmap-promote-titles.js` titles the promote-scored, untitled, un-promoted items via the **floor title** (`source_type`/`source_id` → `eva_todoist_intake`/`eva_youtube_intake.title`), distillation→floor fallback per spec. **Dry-run default, `--apply` gated, idempotent** (UPDATE guarded on `title IS NULL AND promoted_to_sd_key IS NULL AND refine_recommendation='promote'`). **APPLIED: 66 titled, 0 skipped**; re-run selected 0 (idempotent confirmed).

## Tests
4 unit tests: `persistScores` writes `title` only for a real source title (not `(untitled)`/missing) + preserves metadata; `runBackfill` dry-run counts floor-titleable items (dropped/deferred excluded) without writing.

SD: SD-LEO-INFRA-ROADMAP-TITLE-WRITEBACK-BACKFILL-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)