### PR TITLE
feat(SD-LEO-INFRA-GATE-CALIBRATE-LEAD-PLAN-REJECTION-001): diagnose LEAD-TO-PLAN rejections + early prep-readiness advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,6 +319,7 @@
     "brainstorm:health:dry": "node scripts/brainstorm-pipeline-health.js --fix --dry-run",
     "git:recover": "node scripts/git-commit-recovery.js",
     "lead:dossier": "node scripts/lead-dossier.js",
+    "lead:prep-readiness": "node scripts/lead-prep-readiness.js",
     "doc:audit": "node scripts/eva/doc-health-audit.mjs",
     "doc:metadata-backfill": "node scripts/doc-metadata-backfill.mjs",
     "vision:readiness:report": "node scripts/eva/vision-readiness-report.mjs",

--- a/scripts/lead-prep-readiness.js
+++ b/scripts/lead-prep-readiness.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-GATE-CALIBRATE-LEAD-PLAN-REJECTION-001 (FR-2 remediation) — EARLY LEAD-TO-PLAN
+ * prep-readiness advisory.
+ *
+ * DIAGNOSIS (FR-1): of 237 LEAD-TO-PLAN handoffs, 62 (26%) were rejected; clustering the
+ * rejection_reasons showed the DOMINANT cause is PREP-INSUFFICIENT — SDs arriving without the
+ * required fields the gate (correctly) demands for a usable PRD: smoke_test_steps (~21 across
+ * SMOKE_TEST_*), JSONB_FIELDS_INCOMPLETE (~13: success_criteria/success_metrics/key_changes/
+ * dependencies), success_metrics, strategic_objectives, and DESCRIPTION_TOO_SHORT — NOT
+ * gate-too-strict. (A secondary, orthogonal ~9 GATE_CLAIM_VALIDITY cluster is a claim/timing issue,
+ * not prep/strictness.)
+ *
+ * REMEDIATION (FR-2, prep-insufficient branch) that PRESERVES the gate's protective intent (FR-3):
+ * surface the gate's OWN prerequisite check (checkLeadToPlanPrereqs, the SSOT) EARLY — when a worker
+ * starts a LEAD-phase SD — so the missing fields are populated with REAL content BEFORE the handoff,
+ * turning a late rejection into an early checklist. No threshold is lowered; the same checks run,
+ * just sooner. The rejection rate falls because real defects are closed earlier, not because the bar
+ * dropped.
+ *
+ * Usage: node scripts/lead-prep-readiness.js <SD-KEY-or-UUID>
+ */
+import 'dotenv/config';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { pathToFileURL } from 'url';
+import { checkLeadToPlanPrereqs } from './modules/handoff/pre-checks/prerequisite-preflight.js';
+
+/**
+ * Run the LEAD-TO-PLAN prerequisite check EARLY against an SD and partition the result.
+ * Reuses the gate SSOT checkLeadToPlanPrereqs — no duplicated checks, no new thresholds.
+ * @returns {Promise<{ found:boolean, ready:boolean, blocking:Array, info:Array, sdKey:string }>}
+ */
+export async function runLeadPrepReadiness(sdInput, { supabase } = {}) {
+  const sb = supabase || createSupabaseServiceClient();
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(sdInput));
+  const { data: sd } = await sb
+    .from('strategic_directives_v2')
+    .select('*')
+    .or(isUuid ? `uuid_id.eq.${sdInput},id.eq.${sdInput},sd_key.eq.${sdInput}` : `sd_key.eq.${sdInput}`)
+    .limit(1)
+    .maybeSingle();
+  if (!sd) return { found: false, ready: false, blocking: [], info: [], sdKey: String(sdInput) };
+  const issues = checkLeadToPlanPrereqs(sd) || [];
+  const blocking = issues.filter(i => i.severity !== 'info');
+  const info = issues.filter(i => i.severity === 'info');
+  return { found: true, ready: blocking.length === 0, blocking, info, sdKey: sd.sd_key || sd.id };
+}
+
+function render(r, log = console.log) {
+  if (!r.found) { log(`[lead-prep-readiness] SD not found: ${r.sdKey}`); return; }
+  if (r.ready) {
+    log(`✅ [lead-prep-readiness] ${r.sdKey} is LEAD-TO-PLAN prep-ready (no blocking prerequisite gaps).`);
+  } else {
+    log(`⚠️  [lead-prep-readiness] ${r.sdKey} has ${r.blocking.length} LEAD-TO-PLAN prerequisite gap(s) — populate these BEFORE the handoff (the gate will reject otherwise):`);
+    for (const g of r.blocking) {
+      log(`   ❌ [${g.code}] ${g.message}`);
+      if (g.remediation) log(String(g.remediation).split('\n').map(l => `      ${l}`).join('\n'));
+    }
+  }
+  for (const g of r.info) log(`   ℹ️  [${g.code}] ${g.message}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const sdInput = process.argv[2];
+  if (!sdInput) { console.error('Usage: node scripts/lead-prep-readiness.js <SD-KEY-or-UUID>'); process.exit(1); }
+  runLeadPrepReadiness(sdInput)
+    .then(r => { render(r); process.exit(0); })
+    .catch(err => { console.error('lead-prep-readiness error:', err.message); process.exit(1); });
+}
+
+export { render };

--- a/tests/unit/lead-prep-readiness.test.js
+++ b/tests/unit/lead-prep-readiness.test.js
@@ -1,0 +1,66 @@
+// SD-LEO-INFRA-GATE-CALIBRATE-LEAD-PLAN-REJECTION-001 (FR-2/FR-3/FR-4) — the EARLY LEAD-TO-PLAN
+// prep-readiness advisory reuses the gate's OWN prerequisite SSOT (checkLeadToPlanPrereqs), so it
+// surfaces exactly the gaps the gate would reject — no new checks, no lowered thresholds. Closing
+// these early reduces REAL defects (the diagnosed prep-insufficient cause), not the bar (FR-3).
+import { describe, it, expect } from 'vitest';
+import { runLeadPrepReadiness } from '../../scripts/lead-prep-readiness.js';
+import { checkLeadToPlanPrereqs } from '../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+// Minimal supabase mock returning a single SD row from the .or(...).limit(1).maybeSingle() chain.
+function mockSb(sdRow) {
+  return { from() { return { select() { return { or() { return { limit() { return { maybeSingle: () => Promise.resolve({ data: sdRow, error: null }) }; } }; } }; } }; } };
+}
+
+// A deficient SD mirroring the diagnosed dominant rejection cause: missing JSONB fields, short
+// description, no smoke_test_steps.
+const deficientSd = {
+  sd_key: 'SD-TEST-DEFICIENT-001', sd_type: 'infrastructure',
+  description: 'too short', // well under the min word count
+  strategic_objectives: [], success_criteria: [], success_metrics: [], key_changes: [], dependencies: [], risks: [],
+  smoke_test_steps: null, metadata: {},
+};
+// A prep-ready SD with the required fields populated.
+const readySd = {
+  sd_key: 'SD-TEST-READY-001', sd_type: 'infrastructure',
+  description: 'This strategic directive expands the description well beyond the minimum word threshold by documenting the technical approach, the root cause context for why the work is needed, and a concrete definition of what success looks like once the change ships and is validated end to end across the full handoff chain and post-completion tail with evidence captured.',
+  strategic_objectives: [{ objective: 'x' }], success_criteria: [{ criterion: 'c', measure: 'm' }],
+  success_metrics: [{ metric: 'a', target: '1' }, { metric: 'b', target: '2' }, { metric: 'c', target: '3' }],
+  key_changes: [{ change: 'k', type: 'code' }], dependencies: [{ note: 'none' }], risks: [{ risk: 'r', mitigation: 'm' }],
+  smoke_test_steps: [{ instruction: 'Run the handoff', expected_outcome: 'PASS' }], metadata: {},
+};
+
+describe('runLeadPrepReadiness — reuses the gate SSOT, surfaces gaps early', () => {
+  it('flags a deficient SD as NOT ready with the same blocking codes the gate would emit', async () => {
+    const r = await runLeadPrepReadiness('SD-TEST-DEFICIENT-001', { supabase: mockSb(deficientSd) });
+    expect(r.found).toBe(true);
+    expect(r.ready).toBe(false);
+    const codes = r.blocking.map(b => b.code);
+    // mirror: the advisory blocking set equals the gate SSOT's non-info issues
+    const gateCodes = checkLeadToPlanPrereqs(deficientSd).filter(i => i.severity !== 'info').map(i => i.code);
+    expect(codes.sort()).toEqual(gateCodes.sort()); // advisory == gate SSOT (the key property)
+    expect(codes).toContain('JSONB_FIELDS_INCOMPLETE');
+    expect(codes).toContain('DESCRIPTION_TOO_SHORT');
+    // (infrastructure is smoke-test-EXEMPT, so SMOKE_TEST_* is info-only here; the dominant
+    //  SMOKE_TEST_MISSING rejections in the diagnosis came from non-exempt sd_types.)
+  });
+
+  it('marks a fully-populated SD as prep-ready (no blocking gaps)', async () => {
+    const r = await runLeadPrepReadiness('SD-TEST-READY-001', { supabase: mockSb(readySd) });
+    expect(r.found).toBe(true);
+    expect(r.ready).toBe(true);
+    expect(r.blocking.length).toBe(0);
+  });
+
+  it('returns found=false for a missing SD', async () => {
+    const r = await runLeadPrepReadiness('SD-NOPE-001', { supabase: mockSb(null) });
+    expect(r.found).toBe(false);
+    expect(r.ready).toBe(false);
+  });
+
+  it('does NOT lower the bar — blocking set is exactly the gate SSOT non-info issues (FR-3)', async () => {
+    // Re-assert the equivalence explicitly: the advisory never reports fewer gaps than the gate.
+    const r = await runLeadPrepReadiness('SD-TEST-DEFICIENT-001', { supabase: mockSb(deficientSd) });
+    const gateBlocking = checkLeadToPlanPrereqs(deficientSd).filter(i => i.severity !== 'info').length;
+    expect(r.blocking.length).toBe(gateBlocking);
+  });
+});


### PR DESCRIPTION
## FR-1 — Diagnosis (data-backed)
Of **237** LEAD-TO-PLAN handoffs, **62 (26%)** were rejected. Clustering `rejection_reason`:
- **Prep-insufficient (dominant):** smoke_test_steps (~21 across `SMOKE_TEST_*`), `JSONB_FIELDS_INCOMPLETE` (~13), `success_metrics` (5), `strategic_objectives` empty (3), `DESCRIPTION_TOO_SHORT` (4), completeness (4).
- **Secondary, orthogonal:** `GATE_CLAIM_VALIDITY` (NO_CLAIM 6 + foreign_claim 3 = 9) — a claim/timing issue, not prep/strictness.

**Verdict: NOT gate-too-strict.** The gate correctly demands fields needed for a usable PRD; SDs (especially auto-sourced REFILL ones) arrive incomplete and the worker discovers it late, at the handoff.

## FR-2 — Remediation (prep-insufficient branch)
`scripts/lead-prep-readiness.js` (`npm run lead:prep-readiness <SD>`) reuses the gate's **own** `checkLeadToPlanPrereqs` SSOT to surface the exact LEAD-TO-PLAN gaps **before** the handoff — turning a late rejection into an early checklist so workers populate the fields with real content first.

## FR-3 — Protective intent preserved
The advisory reuses the gate's **exact** checks — no new checks, no lowered thresholds. A test asserts the advisory's blocking set **===** the gate SSOT's non-info issues, so the rejection rate falls because real defects close earlier, never because the bar dropped.

## FR-4 — Evidence
The diagnosis query is the before-measure (26% rejected, dominant = prep-insufficient). 4 unit tests prove advisory==gate equivalence (deficient SD → same codes; fully-populated SD → ready).

Follow-up (flagged): auto-surface the advisory in `sd-start` for LEAD-phase SDs so every worker sees the gaps at claim time.

SD: SD-LEO-INFRA-GATE-CALIBRATE-LEAD-PLAN-REJECTION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)