### PR TITLE
feat(SD-LEO-INFRA-PLANEXEC-PREFLIGHT-JSONB-PREP-001): early PLAN-TO-EXEC prep-readiness advisory (corrected to real gaps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,6 +319,7 @@
     "brainstorm:health:dry": "node scripts/brainstorm-pipeline-health.js --fix --dry-run",
     "git:recover": "node scripts/git-commit-recovery.js",
     "lead:dossier": "node scripts/lead-dossier.js",
+    "plan:prep-readiness": "node scripts/plan-prep-readiness.js",
     "lead:prep-readiness": "node scripts/lead-prep-readiness.js",
     "doc:audit": "node scripts/eva/doc-health-audit.mjs",
     "doc:metadata-backfill": "node scripts/doc-metadata-backfill.mjs",

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -488,7 +488,7 @@ export function checkLeadToPlanPrereqs(sd) {
  * PLAN-TO-EXEC: Check PRD exists + user stories exist
  * Catches: PAT-HF-PLANTOEXEC (PRD/stories missing)
  */
-async function checkPlanToExecPrereqs(supabase, sd, sdId) {
+export async function checkPlanToExecPrereqs(supabase, sd, sdId) {
   const issues = [];
 
   // Check PRD exists and is approved

--- a/scripts/plan-prep-readiness.js
+++ b/scripts/plan-prep-readiness.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-PLANEXEC-PREFLIGHT-JSONB-PREP-001 — EARLY PLAN-TO-EXEC prep-readiness advisory.
+ *
+ * FR-1 IDENTIFY (corrected from data): the SD's title guessed "JSONB fields", but a 21-day pull of
+ * PLAN-TO-EXEC handoffs (200 total, 20 rejected) shows JSONB_FIELDS_INCOMPLETE = 0 at this stage —
+ * that check belongs to LEAD-TO-PLAN (already remediated by SD-LEO-INFRA-GATE-CALIBRATE-LEAD-PLAN-
+ * REJECTION-001 / lead-prep-readiness). The ACTUAL PLAN-TO-EXEC prerequisite_preflight gaps are
+ * PRD-related (PRD_MISSING / PRD_NOT_APPROVED / PRD_SUMMARY_SHORT) and user-stories
+ * (USER_STORIES_MISSING). So this advisory targets those — the real EXEC-readiness fields.
+ *
+ * FR-2 STRENGTHEN PREP / FR-3 NO GATE CHANGE: surface the gate's OWN prerequisite check
+ * (checkPlanToExecPrereqs, the SSOT) EARLY — during PLAN, before the PLAN-TO-EXEC handoff — so the
+ * worker creates/approves the PRD and the user stories first. The advisory reuses the exact gate
+ * checks (no new checks, no lowered thresholds); the rejection cluster shrinks because real defects
+ * close earlier, never because the bar dropped.
+ *
+ * Usage: node scripts/plan-prep-readiness.js <SD-KEY-or-UUID>
+ */
+import 'dotenv/config';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { pathToFileURL } from 'url';
+import { checkPlanToExecPrereqs } from './modules/handoff/pre-checks/prerequisite-preflight.js';
+
+/**
+ * Run the PLAN-TO-EXEC prerequisite check EARLY against an SD and partition the result.
+ * Reuses the gate SSOT checkPlanToExecPrereqs — no duplicated checks, no new thresholds.
+ * @returns {Promise<{ found:boolean, ready:boolean, blocking:Array, info:Array, sdKey:string }>}
+ */
+export async function runPlanPrepReadiness(sdInput, { supabase } = {}) {
+  const sb = supabase || createSupabaseServiceClient();
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(sdInput));
+  const { data: sd } = await sb
+    .from('strategic_directives_v2')
+    .select('*')
+    .or(isUuid ? `uuid_id.eq.${sdInput},id.eq.${sdInput},sd_key.eq.${sdInput}` : `sd_key.eq.${sdInput}`)
+    .limit(1)
+    .maybeSingle();
+  if (!sd) return { found: false, ready: false, blocking: [], info: [], sdKey: String(sdInput) };
+  const issues = (await checkPlanToExecPrereqs(sb, sd, sd.sd_key || sd.id)) || [];
+  const blocking = issues.filter(i => i.severity !== 'info');
+  const info = issues.filter(i => i.severity === 'info');
+  return { found: true, ready: blocking.length === 0, blocking, info, sdKey: sd.sd_key || sd.id };
+}
+
+function render(r, log = console.log) {
+  if (!r.found) { log(`[plan-prep-readiness] SD not found: ${r.sdKey}`); return; }
+  if (r.ready) {
+    log(`✅ [plan-prep-readiness] ${r.sdKey} is PLAN-TO-EXEC prep-ready (PRD + user stories satisfy the prerequisite gate).`);
+  } else {
+    log(`⚠️  [plan-prep-readiness] ${r.sdKey} has ${r.blocking.length} PLAN-TO-EXEC prerequisite gap(s) — close these BEFORE the handoff (the gate will reject otherwise):`);
+    for (const g of r.blocking) {
+      log(`   ❌ [${g.code}] ${g.message}`);
+      if (g.remediation) log(String(g.remediation).split('\n').map(l => `      ${l}`).join('\n'));
+    }
+  }
+  for (const g of r.info) log(`   ℹ️  [${g.code}] ${g.message}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const sdInput = process.argv[2];
+  if (!sdInput) { console.error('Usage: node scripts/plan-prep-readiness.js <SD-KEY-or-UUID>'); process.exit(1); }
+  runPlanPrepReadiness(sdInput)
+    .then(r => { render(r); process.exit(0); })
+    .catch(err => { console.error('plan-prep-readiness error:', err.message); process.exit(1); });
+}
+
+export { render };

--- a/tests/unit/plan-prep-readiness.test.js
+++ b/tests/unit/plan-prep-readiness.test.js
@@ -1,0 +1,61 @@
+// SD-LEO-INFRA-PLANEXEC-PREFLIGHT-JSONB-PREP-001 (FR-2/FR-3/FR-4) — EARLY PLAN-TO-EXEC prep-readiness
+// advisory reuses the gate's OWN prerequisite SSOT (checkPlanToExecPrereqs: PRD exists/approved/
+// summary + user-stories). FR-1 data showed the real PLAN-TO-EXEC gaps are PRD/user-stories (not
+// JSONB — that is a LEAD-TO-PLAN concern). Closing these early reduces REAL defects, not the bar.
+import { describe, it, expect } from 'vitest';
+import { runPlanPrepReadiness } from '../../scripts/plan-prep-readiness.js';
+
+// Mock supabase: strategic_directives_v2 (.or().limit().maybeSingle()) returns the SD;
+// product_requirements_v2 (.eq().single()) returns the PRD; user_stories (.eq()) returns stories.
+function mockSb({ sd, prd, stories }) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return { select() { return { or() { return { limit() { return { maybeSingle: () => Promise.resolve({ data: sd, error: null }) }; } }; } }; } };
+      }
+      if (table === 'product_requirements_v2') {
+        return { select() { return { eq() { return { single: () => Promise.resolve({ data: prd, error: prd ? null : { message: 'no rows' } }) }; } }; } };
+      }
+      if (table === 'user_stories') {
+        return { select() { return { eq: () => Promise.resolve({ data: stories || [], error: null }) }; } };
+      }
+      return null;
+    },
+  };
+}
+
+const featureSd = { sd_key: 'SD-TEST-PE-001', id: 'uuid-pe-1', sd_type: 'feature' };
+
+describe('runPlanPrepReadiness — reuses the PLAN-TO-EXEC gate SSOT, surfaces gaps early', () => {
+  it('flags PRD_MISSING + USER_STORIES_MISSING for a feature SD with no PRD/stories', async () => {
+    const r = await runPlanPrepReadiness('SD-TEST-PE-001', { supabase: mockSb({ sd: featureSd, prd: null, stories: [] }) });
+    expect(r.found).toBe(true);
+    expect(r.ready).toBe(false);
+    const codes = r.blocking.map(b => b.code);
+    expect(codes).toContain('PRD_MISSING');
+    expect(codes).toContain('USER_STORIES_MISSING');
+  });
+
+  it('flags PRD_NOT_APPROVED when the PRD exists but is in draft', async () => {
+    const r = await runPlanPrepReadiness('SD-TEST-PE-001', {
+      supabase: mockSb({ sd: featureSd, prd: { id: 'prd-1', status: 'draft', executive_summary: 'x'.repeat(60) }, stories: [{ story_key: 'a' }] }),
+    });
+    expect(r.ready).toBe(false);
+    expect(r.blocking.map(b => b.code)).toContain('PRD_NOT_APPROVED');
+  });
+
+  it('marks an SD with an approved PRD + user stories as prep-ready', async () => {
+    const r = await runPlanPrepReadiness('SD-TEST-PE-001', {
+      supabase: mockSb({ sd: featureSd, prd: { id: 'prd-1', status: 'approved', executive_summary: 'x'.repeat(80) }, stories: [{ story_key: 'SD-TEST-PE-001:US-001' }] }),
+    });
+    expect(r.found).toBe(true);
+    expect(r.ready).toBe(true);
+    expect(r.blocking.length).toBe(0);
+  });
+
+  it('returns found=false for a missing SD', async () => {
+    const r = await runPlanPrepReadiness('SD-NOPE-001', { supabase: mockSb({ sd: null }) });
+    expect(r.found).toBe(false);
+    expect(r.ready).toBe(false);
+  });
+});


### PR DESCRIPTION
## FR-1 — Identify (corrected from data)
The SD title guessed *"JSONB fields"*, but a 21-day pull of PLAN-TO-EXEC handoffs (**200 total, 20 rejected**) shows **`JSONB_FIELDS_INCOMPLETE` = 0** at this stage — that check is LEAD-TO-PLAN (already remediated by `SD-LEO-INFRA-GATE-CALIBRATE-LEAD-PLAN-REJECTION-001` / `lead-prep-readiness`). The **actual** PLAN-TO-EXEC `prerequisite_preflight` gaps are **PRD** (`PRD_MISSING`/`PRD_NOT_APPROVED`/`PRD_SUMMARY_SHORT`, 6 rejections) + **user-stories** (`USER_STORIES_MISSING`), plus separate PRD-quality (6) and user-story-quality (5) gate clusters. Faithful to the SD's FR-1→FR-2 structure, the advisory targets the real EXEC-readiness fields.

## FR-2 / FR-3 — Strengthen prep, no gate change
`scripts/plan-prep-readiness.js` (`npm run plan:prep-readiness <SD>`) reuses the gate's **own** SSOT `checkPlanToExecPrereqs` (now exported) to surface the exact PLAN-TO-EXEC prerequisite gaps **early** — during PLAN, before the handoff — so the PRD is created/approved and user stories exist first. No new checks, no lowered thresholds.

## FR-4 — Evidence
The 21d cluster is the before-measure. 4 unit tests prove the advisory surfaces the same gate codes (`PRD_MISSING`, `PRD_NOT_APPROVED`, `USER_STORIES_MISSING`) and passes a complete SD — the PLAN-TO-EXEC analog of #5109.

Note: this corrects the SD's "JSONB" framing (FR-1 found PRD/user-stories). Follow-up (flagged): auto-surface in the PLAN flow + a PRD-quality/user-story-quality early signal.

SD: SD-LEO-INFRA-PLANEXEC-PREFLIGHT-JSONB-PREP-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)