### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-MATERIALIZE-QUEUE-BEFORE-SOURCE-001): drain pending Adam proposals before sourcing

### DIFF
--- a/lib/coordinator/pending-proposals-gauge.mjs
+++ b/lib/coordinator/pending-proposals-gauge.mjs
@@ -1,0 +1,157 @@
+/**
+ * Pending-proposals gauge + drain (SD-LEO-INFRA-COORDINATOR-MATERIALIZE-QUEUE-BEFORE-SOURCE-001)
+ *
+ * The coordinator's belt-low DEFICIT path pings Adam for fresh work without first checking
+ * whether Adam ALREADY handed back un-materialized proposals (.prd-payloads/adam-prop-*.json
+ * whose proposed_sd_key is not yet in strategic_directives_v2). That produced a false-DEFICIT
+ * loop (~42min of source_request pings while 10 handed-back proposals sat idle, 2 workers idled).
+ *
+ * This module:
+ *   - scanPendingProposals(): counts un-materialized adam-prop proposals, classifying each
+ *     FRESH vs STALE by file mtime against a configurable freshness window (the stale-guard that
+ *     stops a mass-materialize of the full backlog).
+ *   - drainPendingProposals(): materializes the FRESH pending proposals via the canonical
+ *     idempotent leo-create-sd path (ingestProposalObject — keyExists skip reused verbatim).
+ *
+ * Mirrors scripts/lib/sourcing-engine-awareness.mjs. All FS/DB/create deps are injectable so
+ * the gauge + drain are unit-testable without real FS, DB, or SD creation. Fail-soft per file.
+ *
+ * FR-3 note: belt-low reachAdam already uses a TYPED kind (coordinator_request ∈ DIRECTIVE_KINDS);
+ * the genuinely-untyped payload.kind=null Adam-inbox consumer gap is a DISTINCT follow-up
+ * (ref SD-LEO-FEAT-ADAM-INBOX-CONSUMPTION-001) and is intentionally out of scope here.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join as joinPath } from 'node:path';
+
+export const DEFAULT_PROPOSALS_DIR = '.prd-payloads';
+export const DEFAULT_FRESHNESS_DAYS = Number(process.env.PENDING_PROPOSAL_FRESHNESS_DAYS) || 7;
+const ADAM_PROP_RE = /^adam-prop-.*\.json$/;
+
+/** Resolve the SD key a proposal would materialize as (proposed_sd_key, fallback sd_key). */
+function proposalKey(proposal) {
+  return proposal?.proposed_sd_key || proposal?.sd_key || null;
+}
+
+/**
+ * Scan .prd-payloads/adam-prop-*.json for proposals NOT yet materialized in
+ * strategic_directives_v2, classifying each pending proposal fresh/stale by mtime.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.dir] - directory to scan (default .prd-payloads)
+ * @param {number} [opts.freshnessMs] - freshness window in ms (default DEFAULT_FRESHNESS_DAYS)
+ * @param {Object} [opts.supabase] - client used to check which keys already exist
+ * @param {number} [opts.now] - current epoch ms (injectable for tests)
+ * @param {Object} [opts.fs] - { readdirSync, readFileSync, statSync } overrides for tests
+ * @returns {Promise<{pendingCount:number, pendingKeys:string[], freshKeys:string[], staleKeys:string[], scanned:number, freshProposals:Array}>}
+ */
+export async function scanPendingProposals(opts = {}) {
+  const {
+    dir = DEFAULT_PROPOSALS_DIR,
+    freshnessMs = DEFAULT_FRESHNESS_DAYS * 24 * 60 * 60 * 1000,
+    supabase = null,
+    now = Date.now(),
+    fs = { readdirSync, readFileSync, statSync },
+  } = opts;
+
+  let files = [];
+  try {
+    files = fs.readdirSync(dir).filter(f => ADAM_PROP_RE.test(f));
+  } catch {
+    return { pendingCount: 0, pendingKeys: [], freshKeys: [], staleKeys: [], scanned: 0, freshProposals: [] };
+  }
+
+  // Parse each proposal fail-soft; collect {key, file, path, mtimeMs, proposal, fresh}.
+  const parsed = [];
+  for (const f of files) {
+    const path = joinPath(dir, f);
+    try {
+      const proposal = JSON.parse(fs.readFileSync(path, 'utf8'));
+      const key = proposalKey(proposal);
+      if (!key) continue;
+      let mtimeMs = now;
+      try { mtimeMs = fs.statSync(path).mtimeMs; } catch { /* default to now (treat as fresh) */ }
+      parsed.push({ key, file: f, path, mtimeMs, proposal, fresh: (now - mtimeMs) <= freshnessMs });
+    } catch {
+      // malformed file — skip (fail-soft), do not halt the scan
+    }
+  }
+
+  // Which keys already exist in strategic_directives_v2? Only those NOT present are pending.
+  const existing = new Set();
+  const keys = [...new Set(parsed.map(p => p.key))];
+  if (supabase && keys.length > 0) {
+    try {
+      const { data } = await supabase.from('strategic_directives_v2').select('sd_key').in('sd_key', keys);
+      for (const r of (data || [])) existing.add(r.sd_key);
+    } catch {
+      // DB read failed — fail-soft: treat none as existing (the canonical keyExists guard in
+      // the drain still prevents double-create, so this only affects the gauge count).
+    }
+  }
+
+  const pending = parsed.filter(p => !existing.has(p.key));
+  const fresh = pending.filter(p => p.fresh);
+  const stale = pending.filter(p => !p.fresh);
+
+  return {
+    pendingCount: pending.length,
+    pendingKeys: pending.map(p => p.key),
+    freshKeys: fresh.map(p => p.key),
+    staleKeys: stale.map(p => p.key),
+    scanned: parsed.length,
+    freshProposals: fresh.map(p => ({ key: p.key, file: p.file, path: p.path, proposal: p.proposal })),
+  };
+}
+
+/**
+ * Materialize the FRESH pending proposals via the canonical idempotent create path.
+ * Reuses ingestProposalObject (keyExists skip verbatim) — no forked create logic. Fail-soft
+ * per proposal. Returns a tagged summary.
+ *
+ * @param {Object} opts
+ * @param {Array} opts.freshProposals - [{ key, file, path, proposal }] from scanPendingProposals
+ * @param {boolean} [opts.dryRun]
+ * @param {Object} [opts.deps] - { ingest } injectable; defaults to the real ingestProposalObject
+ * @returns {Promise<{scanned:number, materialized:number, skippedExisting:number, skippedStale:number, failed:number, results:Array}>}
+ */
+export async function drainPendingProposals(opts = {}) {
+  const { freshProposals = [], dryRun = false, deps = {} } = opts;
+  let ingest = deps.ingest;
+  if (!ingest) {
+    ({ ingestProposalObject: ingest } = await import('../../scripts/leo-create-sd.js'));
+  }
+
+  const summary = { scanned: freshProposals.length, materialized: 0, skippedExisting: 0, skippedStale: 0, failed: 0, results: [] };
+
+  for (const fp of freshProposals) {
+    try {
+      const res = await ingest(fp.proposal, fp.path, { dryRun, deps: deps.ingestDeps });
+      const action = res?.action;
+      if (action === 'created' || action === 'dry-run') summary.materialized++;
+      else if (action === 'skipped') summary.skippedExisting++;
+      else if (action === 'skipped-stale') summary.skippedStale++;
+      summary.results.push({ key: fp.key, action });
+    } catch (e) {
+      summary.failed++;
+      summary.results.push({ key: fp.key, action: 'failed', error: e?.message || String(e) });
+    }
+  }
+  return summary;
+}
+
+/**
+ * Belt-low decision: prefer MATERIALIZE over a fresh Adam source_request when FRESH
+ * un-materialized proposals already exist. (Stale-only pending does NOT suppress the ping —
+ * we don't want to sit on a dry belt because of an un-drainable stale backlog.)
+ */
+export function shouldMaterializeBeforeSource(scan) {
+  return (scan?.freshKeys?.length || 0) > 0;
+}
+
+/** One-line summary for the forecaster GAUGE/awareness output. */
+export function formatPendingSummary(scan) {
+  return `pending=${scan.pendingCount} (fresh ${scan.freshKeys.length}/stale ${scan.staleKeys.length}, scanned ${scan.scanned})`;
+}
+
+export default { scanPendingProposals, drainPendingProposals, shouldMaterializeBeforeSource, formatPendingSummary };

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -41,6 +41,9 @@ import { isLiveCountableWorker } from './lib/live-countable-worker.mjs';
 // flag state + unpromoted roadmap depth so a belt-low/DEFICIT ping says "engine OFF, N unpromoted
 // -> activate/distill" instead of only "source N candidates" (manual backfill is the anti-pattern).
 import { readSourcingEngineFlagsFromDb, formatSourcingAwareness } from './lib/sourcing-engine-awareness.mjs';
+// SD-LEO-INFRA-COORDINATOR-MATERIALIZE-QUEUE-BEFORE-SOURCE-001: prefer draining the un-materialized
+// adam-prop proposal queue (proposed_sd_key NOT IN strategic_directives_v2) over pinging Adam for more.
+import { scanPendingProposals, drainPendingProposals, shouldMaterializeBeforeSource, formatPendingSummary } from '../lib/coordinator/pending-proposals-gauge.mjs';
 // SD-LEO-FEAT-COORDINATOR-CAPACITY-FORECAST-001: stall detection is DELEGATED to the canonical
 // detectStalledLoop SSOT (lib/coordinator/detectors.cjs), the same detector coordinator-audit.mjs uses.
 // The forecast previously ran its own heartbeat-AGE rule (classifyIdleWorker, ttl 180s), but the worker
@@ -348,10 +351,33 @@ async function main() {
   const awareness = formatSourcingAwareness({ flags: sourcingFlags, unpromotedCount });
   console.log(`  SOURCING: ${awareness.line}`);
 
+  // SD-LEO-INFRA-COORDINATOR-MATERIALIZE-QUEUE-BEFORE-SOURCE-001 (FR-1): gauge the un-materialized
+  // Adam proposal queue at the same awareness seam. If belt-low supply already exists un-materialized,
+  // prefer MATERIALIZE over a fresh source_request (closes the false-DEFICIT ping loop).
+  let pendingScan = { pendingCount: 0, freshKeys: [], staleKeys: [], scanned: 0, freshProposals: [] };
+  try {
+    pendingScan = await scanPendingProposals({ supabase: sb });
+  } catch (e) {
+    console.log(`  PENDING: scan failed (non-blocking): ${e?.message || e}`);
+  }
+  console.log(`  PENDING: ${formatPendingSummary(pendingScan)}`);
+
   console.log(`  VERDICT: ${verdict}` + (deficit > 0 ? `  → belt short by ${deficit} — ${awareness.recommendation}` : ''));
 
   // ── proactive Adam reach-out on a forecast deficit ──
   if (verdict.startsWith('DEFICIT')) {
+    // SD-LEO-INFRA-COORDINATOR-MATERIALIZE-QUEUE-BEFORE-SOURCE-001 (FR-1/FR-2): drain BEFORE source.
+    // When un-materialized FRESH proposals already exist, materialize them via the canonical
+    // idempotent --from-proposal path and SUPPRESS the Adam ping (Adam already produced the supply;
+    // asking for more is the false-DEFICIT loop). Stale proposals are skipped, not mass-materialized.
+    if (shouldMaterializeBeforeSource(pendingScan)) {
+      if (!DISPATCH) {
+        console.log(`  ACTION: deficit, but ${pendingScan.freshKeys.length} FRESH un-materialized proposal(s) exist — run with --dispatch to MATERIALIZE the queue instead of pinging Adam (stale ${pendingScan.staleKeys.length} skipped).`);
+      } else {
+        const drain = await drainPendingProposals({ freshProposals: pendingScan.freshProposals });
+        console.log(`  ACTION: ✅ MATERIALIZE-before-source — drained pending queue: materialized ${drain.materialized}, skipped-existing ${drain.skippedExisting}, skipped-stale ${pendingScan.staleKeys.length}, failed ${drain.failed}. Adam ping SUPPRESSED; re-assess next tick.`);
+      }
+    } else {
     const cd = readCooldown();
     const since = cd ? (Date.now() - cd.at) / 60000 : Infinity;
     // SD-REFILL-00G39SZT: fingerprint the belt-dry state so an UNCHANGED deficit self-suppresses
@@ -369,6 +395,7 @@ async function main() {
       if (sent) { writeCooldown(currentFp); console.log('  ACTION: ✅ sourcing request dispatched to Adam (cooldown started).'); }
       else console.log('  ACTION: ⚠ no live Adam session found to reach — surface to operator.');
     }
+    } // end else (no fresh pending proposals → normal Adam-ping path)
   }
 
   // ── SD-FDBK-INFRA-STALL-AFTER-COMPLETION-001: masked-stall escalation ──

--- a/tests/unit/pending-proposals-gauge.test.js
+++ b/tests/unit/pending-proposals-gauge.test.js
@@ -1,0 +1,129 @@
+// SD-LEO-INFRA-COORDINATOR-MATERIALIZE-QUEUE-BEFORE-SOURCE-001 (FR-1/FR-2/FR-4) — the coordinator's
+// belt-low path should DRAIN un-materialized Adam proposals before pinging Adam for more. These tests
+// assert: detection counts only proposed_sd_key NOT IN strategic_directives_v2; the drain is idempotent
+// (reuses the canonical keyExists skip); reachAdam is suppressed when fresh pending exist; fail-soft on
+// a malformed file; and the stale-guard never auto-materializes a proposal outside the freshness window.
+import { describe, it, expect } from 'vitest';
+import {
+  scanPendingProposals,
+  drainPendingProposals,
+  shouldMaterializeBeforeSource,
+} from '../../lib/coordinator/pending-proposals-gauge.mjs';
+
+const NOW = Date.parse('2026-06-23T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+// In-memory fs double. files: { name: { content, mtimeMs } }
+function mockFs(files) {
+  return {
+    readdirSync: () => Object.keys(files),
+    readFileSync: (p) => {
+      const name = p.split(/[\\/]/).pop();
+      if (files[name]?.content === undefined) throw new Error('ENOENT');
+      return files[name].content;
+    },
+    statSync: (p) => {
+      const name = p.split(/[\\/]/).pop();
+      return { mtimeMs: files[name]?.mtimeMs ?? NOW };
+    },
+  };
+}
+
+// supabase double: strategic_directives_v2.select('sd_key').in('sd_key', keys) → rows for existingKeys
+function mockSb(existingKeys = []) {
+  return {
+    from() {
+      return { select: () => ({ in: (_c, keys) => Promise.resolve({ data: keys.filter(k => existingKeys.includes(k)).map(sd_key => ({ sd_key })), error: null }) }) };
+    },
+  };
+}
+
+function prop(key) { return JSON.stringify({ PROPOSAL: true, proposed_sd_key: key, title: 't', sd_type: 'infrastructure', priority: 'high' }); }
+
+describe('scanPendingProposals (FR-1)', () => {
+  it('counts only proposed_sd_key NOT IN strategic_directives_v2', async () => {
+    const fs = mockFs({
+      'adam-prop-a.json': { content: prop('SD-A'), mtimeMs: NOW },
+      'adam-prop-b.json': { content: prop('SD-B'), mtimeMs: NOW },
+      'adam-prop-c.json': { content: prop('SD-C'), mtimeMs: NOW },
+    });
+    const scan = await scanPendingProposals({ dir: '.prd-payloads', supabase: mockSb(['SD-B']), now: NOW, fs });
+    expect(scan.scanned).toBe(3);
+    expect(scan.pendingCount).toBe(2);
+    expect(scan.pendingKeys.sort()).toEqual(['SD-A', 'SD-C']);
+  });
+
+  it('ignores non adam-prop files and key-less payloads', async () => {
+    const fs = mockFs({
+      'adam-prop-a.json': { content: prop('SD-A'), mtimeMs: NOW },
+      'PRD-something.json': { content: prop('SD-X'), mtimeMs: NOW },        // not adam-prop-*
+      'adam-prop-nokey.json': { content: JSON.stringify({ PROPOSAL: true }), mtimeMs: NOW }, // no key
+    });
+    const scan = await scanPendingProposals({ supabase: mockSb([]), now: NOW, fs });
+    expect(scan.scanned).toBe(1);
+    expect(scan.pendingKeys).toEqual(['SD-A']);
+  });
+
+  it('stale-guard: a proposal older than the freshness window is classified stale, not fresh', async () => {
+    const fs = mockFs({
+      'adam-prop-fresh.json': { content: prop('SD-FRESH'), mtimeMs: NOW - 1 * DAY },
+      'adam-prop-stale.json': { content: prop('SD-STALE'), mtimeMs: NOW - 30 * DAY },
+    });
+    const scan = await scanPendingProposals({ freshnessMs: 7 * DAY, supabase: mockSb([]), now: NOW, fs });
+    expect(scan.freshKeys).toEqual(['SD-FRESH']);
+    expect(scan.staleKeys).toEqual(['SD-STALE']);
+    expect(scan.freshProposals.map(p => p.key)).toEqual(['SD-FRESH']);
+  });
+
+  it('fail-soft: a malformed adam-prop file does not halt the scan', async () => {
+    const fs = mockFs({
+      'adam-prop-good.json': { content: prop('SD-GOOD'), mtimeMs: NOW },
+      'adam-prop-bad.json': { content: '{ not json', mtimeMs: NOW },
+    });
+    const scan = await scanPendingProposals({ supabase: mockSb([]), now: NOW, fs });
+    expect(scan.pendingKeys).toEqual(['SD-GOOD']);
+  });
+});
+
+describe('drainPendingProposals (FR-2)', () => {
+  it('idempotent: an already-materialized key is skipped (no double-create)', async () => {
+    const calls = [];
+    const ingest = async (proposal, source) => {
+      calls.push(proposal.proposed_sd_key);
+      // mimic the canonical keyExists skip for SD-EXISTS
+      return { action: proposal.proposed_sd_key === 'SD-EXISTS' ? 'skipped' : 'created' };
+    };
+    const freshProposals = [
+      { key: 'SD-NEW', path: 'p1', proposal: { proposed_sd_key: 'SD-NEW' } },
+      { key: 'SD-EXISTS', path: 'p2', proposal: { proposed_sd_key: 'SD-EXISTS' } },
+    ];
+    const summary = await drainPendingProposals({ freshProposals, deps: { ingest } });
+    expect(summary.materialized).toBe(1);
+    expect(summary.skippedExisting).toBe(1);
+    expect(calls).toEqual(['SD-NEW', 'SD-EXISTS']);
+  });
+
+  it('fail-soft: a throwing create does not halt the drain', async () => {
+    const ingest = async (proposal) => {
+      if (proposal.proposed_sd_key === 'SD-BOOM') throw new Error('boom');
+      return { action: 'created' };
+    };
+    const freshProposals = [
+      { key: 'SD-BOOM', path: 'p1', proposal: { proposed_sd_key: 'SD-BOOM' } },
+      { key: 'SD-OK', path: 'p2', proposal: { proposed_sd_key: 'SD-OK' } },
+    ];
+    const summary = await drainPendingProposals({ freshProposals, deps: { ingest } });
+    expect(summary.failed).toBe(1);
+    expect(summary.materialized).toBe(1);
+  });
+});
+
+describe('shouldMaterializeBeforeSource (FR-4c — reachAdam suppression)', () => {
+  it('true when fresh pending exist → MATERIALIZE branch (reachAdam suppressed)', () => {
+    expect(shouldMaterializeBeforeSource({ freshKeys: ['SD-A'] })).toBe(true);
+  });
+  it('false when no fresh pending → normal Adam-ping path', () => {
+    expect(shouldMaterializeBeforeSource({ freshKeys: [], staleKeys: ['SD-OLD'] })).toBe(false);
+    expect(shouldMaterializeBeforeSource({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The coordinator belt-low DEFICIT path pinged Adam for fresh work without checking whether Adam ALREADY handed back un-materialized proposals (.prd-payloads/adam-prop-*.json whose proposed_sd_key is not yet in strategic_directives_v2). Witnessed 2026-06-23: ~42min of source_request pings while 10 handed-back proposals sat idle and 2 workers idled (false-DEFICIT loop); 45 such files sat un-materialized.

## Changes
- **FR-1** `lib/coordinator/pending-proposals-gauge.mjs` — `scanPendingProposals` counts un-materialized adam-prop keys (fresh/stale by mtime vs a configurable window) + `shouldMaterializeBeforeSource` + `formatPendingSummary`; wired into `coordinator-capacity-forecast.mjs` at the awareness seam (renders a PENDING gauge line).
- **FR-2** `drainPendingProposals` materializes FRESH pending via the canonical idempotent `ingestProposalObject` (keyExists skip reused verbatim — no forked create); on belt-low DEFICIT with fresh pending the forecaster takes the MATERIALIZE branch and SUPPRESSES `reachAdam`; stale proposals skipped, not mass-materialized; fail-soft per file.
- **FR-3** untyped-kind (payload.kind=null) consumer gap documented as a distinct follow-up (SD-LEO-FEAT-ADAM-INBOX-CONSUMPTION-001).
- **FR-4** 8 unit tests, all green. Testing-agent PASS 96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)