### PR TITLE
feat(SD-LEO-INFRA-PLANEXEC-USERSTORY-AC-CLARITY-001): type-aware fallback AC scaffold

### DIFF
--- a/lib/sub-agents/modules/stories/execute.js
+++ b/lib/sub-agents/modules/stories/execute.js
@@ -256,8 +256,21 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
   const codebasePatterns = await analyzeCodebasePatterns(sdId, prd, options);
   const createdStories = [];
 
+  // SD-LEO-INFRA-PLANEXEC-USERSTORY-AC-CLARITY-001 (FR-2): thread the SD type so the
+  // rule-based fallback emits system-level AC scaffolds for infrastructure/backend SDs
+  // instead of UI boilerplate. Fail-open: null type -> existing UI scaffold behavior.
+  let sdTypeForScaffold = null;
+  try {
+    const { data: sdTypeRow } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_type')
+      .eq('id', resolvedSdId)
+      .maybeSingle();
+    sdTypeForScaffold = sdTypeRow?.sd_type || null;
+  } catch { /* fail-open: leave null -> UI scaffold (no regression) */ }
+
   // Use batch LLM generation for efficiency
-  const batchResult = await generateStoriesBatch(prd.acceptance_criteria, prd, { sdKey });
+  const batchResult = await generateStoriesBatch(prd.acceptance_criteria, prd, { sdKey }, { sd_type: sdTypeForScaffold });
   console.log(`   Generation method: ${batchResult.generated_by}`);
 
   if (batchResult.gaps && batchResult.gaps.length > 0) {

--- a/lib/sub-agents/modules/stories/quality-generation.js
+++ b/lib/sub-agents/modules/stories/quality-generation.js
@@ -99,7 +99,7 @@ export function generateQualityStoryContent(criterion, prd, index, options = {})
   // Generate story components
   const userWant = generateUserWant(criterion);
   const userBenefit = generateUserBenefit(criterion, userRole);
-  const acceptanceCriteria = generateAcceptanceCriteria(criterion, index);
+  const acceptanceCriteria = generateAcceptanceCriteria(criterion, index, options.sdType);
   const storyPoints = calculateStoryPoints(criterion);
 
   return {
@@ -256,7 +256,62 @@ function extractCriterionParts(criterion) {
  * @param {number} index - Story index
  * @returns {Array} Acceptance criteria array
  */
-function generateAcceptanceCriteria(criterion, index) {
+// SD-LEO-INFRA-PLANEXEC-USERSTORY-AC-CLARITY-001 (FR-2): SD types whose stories are
+// system/backend work, not UI. For these the fallback scaffold must use system-level
+// testable language (logs / exit code / persisted state) — the UI-centric scaffold
+// ("visible in the UI", "navigated to the form") is contextually nonsensical and was
+// the dominant cause of genuinely-vague AC-clarity rejections.
+const SYSTEM_LEVEL_SD_TYPES = new Set([
+  'infrastructure', 'backend', 'api', 'database', 'refactor', 'performance', 'devops', 'security'
+]);
+
+/** True when the SD's work is system/backend (no UI surface). Unknown/feature -> false (UI scaffold). */
+export function isSystemLevelSdType(sdType) {
+  return typeof sdType === 'string' && SYSTEM_LEVEL_SD_TYPES.has(sdType.trim().toLowerCase());
+}
+
+/**
+ * System-level fallback ACs for infrastructure/backend SDs (no UI assumptions).
+ * Mirrors the 3-AC shape of the UI scaffold but with testable system-level then-clauses.
+ * is_boilerplate:true is retained so allAcsBoilerplate()->draft and the USER_STORY_QUALITY
+ * clarity gate still catch these (FR-3 retained teeth).
+ */
+function generateSystemLevelAcceptanceCriteria(criterion, index) {
+  const { action, subject } = extractCriterionParts(criterion);
+  return [
+    {
+      id: `AC-${index + 1}-1`,
+      scenario: `Successful ${action} of ${subject}`,
+      given: `The ${subject} ${action} operation runs with valid inputs/configuration`,
+      when: 'The operation executes',
+      then: `The operation completes successfully (process exits 0, no errors logged) and the resulting state (record/file/metric) reflects the ${action} as specified`,
+      is_boilerplate: true
+    },
+    {
+      id: `AC-${index + 1}-2`,
+      scenario: `Invalid input / failure handling for ${action} ${subject}`,
+      given: `The ${subject} operation receives missing or invalid input/configuration`,
+      when: 'The operation runs',
+      then: 'It fails fast with a specific logged error identifying the offending field/condition, and no partial or corrupt state is written',
+      is_boilerplate: true
+    },
+    {
+      id: `AC-${index + 1}-3`,
+      scenario: `Idempotency / retry safety for ${action} ${subject}`,
+      given: `The ${action} operation is re-run or retried after a transient failure (e.g. timeout)`,
+      when: 'The operation runs a second time',
+      then: 'The result is idempotent — no duplicate records or corrupted state — and logs show the retry outcome',
+      is_boilerplate: true
+    }
+  ];
+}
+
+export function generateAcceptanceCriteria(criterion, index, sdType = null) {
+  // FR-2: infrastructure/backend SDs get a system-level testable scaffold, not UI boilerplate.
+  if (isSystemLevelSdType(sdType)) {
+    return generateSystemLevelAcceptanceCriteria(criterion, index);
+  }
+
   const criteria = [];
   const { action, subject } = extractCriterionParts(criterion);
   const criterionLower = criterion.toLowerCase();
@@ -445,7 +500,7 @@ export async function generateQualityStoryContentWithLLM(criterion, prd, index, 
           user_role: userRole,
           user_want: llmResult.user_want || generateUserWant(criterion),
           user_benefit: llmResult.user_benefit || generateUserBenefit(criterion, userRole),
-          acceptance_criteria: llmResult.acceptance_criteria || generateAcceptanceCriteria(criterion, index),
+          acceptance_criteria: llmResult.acceptance_criteria || generateAcceptanceCriteria(criterion, index, normalizedContext?.sdType),
           story_points: llmResult.story_points || calculateStoryPoints(criterion),
           generated_by: 'LLM',
           gaps_detected: llmResult.gaps || [],
@@ -459,7 +514,7 @@ export async function generateQualityStoryContentWithLLM(criterion, prd, index, 
   }
 
   // Fall back to rule-based generation
-  const ruleBasedContent = generateQualityStoryContent(criterion, prd, index);
+  const ruleBasedContent = generateQualityStoryContent(criterion, prd, index, { sdType: normalizedContext?.sdType });
   return {
     ...ruleBasedContent,
     generated_by: 'RULE_BASED',
@@ -509,7 +564,7 @@ export async function generateStoriesBatch(acceptanceCriteria, prd, options = {}
   // Fall back to rule-based generation
   console.log('   [Stories] Using rule-based generation (LLM unavailable or failed)');
   const stories = acceptanceCriteria.map((criterion, idx) => {
-    const content = generateQualityStoryContent(criterion, prd, idx);
+    const content = generateQualityStoryContent(criterion, prd, idx, { sdType: normalizedContext?.sdType });
     return {
       ...content,
       criterion_index: idx,

--- a/tests/unit/ac-clarity-type-aware-scaffold.test.js
+++ b/tests/unit/ac-clarity-type-aware-scaffold.test.js
@@ -1,0 +1,83 @@
+/**
+ * SD-LEO-INFRA-PLANEXEC-USERSTORY-AC-CLARITY-001 — type-aware fallback AC scaffold.
+ *
+ * FR-1 verdict: userStoryQuality AC-clarity FAILs are genuinely-vague auto-generated
+ * boilerplate (UI-centric language on infra SDs); the gate is correct — don't loosen it.
+ * FR-2: infrastructure/backend SDs get system-level testable AC scaffolds.
+ * FR-3 (retained teeth): is_boilerplate:true preserved so allAcsBoilerplate()->draft and
+ * the clarity gate still catch vague ACs; feature/UI SDs unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  generateAcceptanceCriteria,
+  isSystemLevelSdType
+} from '../../lib/sub-agents/modules/stories/quality-generation.js';
+import { allAcsBoilerplate } from '../../scripts/modules/auto-trigger-stories.mjs';
+
+const UI_ONLY_PHRASES = [
+  'visible in the ui',
+  'navigated to the area',
+  'navigated to the',
+  'on the form',
+  'the form with required',
+  'page is refreshed',
+  'empty state'
+];
+const CRITERION = 'Reconcile the worker liveness gauge against the heartbeat source';
+
+function allText(criteria) {
+  return JSON.stringify(criteria).toLowerCase();
+}
+
+describe('SD-...-AC-CLARITY-001: type-aware AC scaffold', () => {
+  it('isSystemLevelSdType: true for system/backend types, false for feature/unknown', () => {
+    for (const t of ['infrastructure', 'backend', 'api', 'database', 'refactor', 'INFRASTRUCTURE', ' Infrastructure ']) {
+      expect(isSystemLevelSdType(t)).toBe(true);
+    }
+    for (const t of ['feature', 'ux_debt', null, undefined, '', 'documentation']) {
+      expect(isSystemLevelSdType(t)).toBe(false);
+    }
+  });
+
+  it('FR-2: infrastructure scaffold uses system-level testable language, no UI-only phrases', () => {
+    const acs = generateAcceptanceCriteria(CRITERION, 0, 'infrastructure');
+    expect(Array.isArray(acs)).toBe(true);
+    expect(acs.length).toBeGreaterThanOrEqual(3);
+    const text = allText(acs);
+    for (const phrase of UI_ONLY_PHRASES) {
+      expect(text).not.toContain(phrase);
+    }
+    // at least one concrete system-level testable signal
+    expect(text).toMatch(/exits 0|no errors logged|idempotent|no duplicate|logs show|persisted|partial or corrupt state/);
+  });
+
+  it('FR-3 retained teeth: infra scaffold ACs all carry is_boilerplate:true (still draft-defaulted)', () => {
+    const acs = generateAcceptanceCriteria(CRITERION, 0, 'infrastructure');
+    expect(acs.every(ac => ac.is_boilerplate === true)).toBe(true);
+    // the existing draft-defaulting predicate still fires on the new scaffold
+    expect(allAcsBoilerplate(acs)).toBe(true);
+  });
+
+  it('FR-3 regression guard: feature/default scaffold is unchanged (deep-equal) and still UI-phrased', () => {
+    const legacy = generateAcceptanceCriteria(CRITERION, 0);          // 2-arg legacy signature
+    const feature = generateAcceptanceCriteria(CRITERION, 0, 'feature');
+    expect(feature).toEqual(legacy);                                  // no regression for feature SDs
+    expect(allText(feature)).toContain('visible in the ui');          // UI scaffold retained where appropriate
+    expect(feature.every(ac => ac.is_boilerplate === true)).toBe(true);
+  });
+
+  it('AC ids and shape are preserved across both scaffolds', () => {
+    const infra = generateAcceptanceCriteria(CRITERION, 2, 'infrastructure');
+    const ui = generateAcceptanceCriteria(CRITERION, 2);
+    for (const set of [infra, ui]) {
+      expect(set.map(a => a.id)).toEqual(['AC-3-1', 'AC-3-2', 'AC-3-3']);
+      for (const ac of set) {
+        expect(ac).toHaveProperty('scenario');
+        expect(ac).toHaveProperty('given');
+        expect(ac).toHaveProperty('when');
+        expect(ac).toHaveProperty('then');
+        expect(ac).toHaveProperty('is_boilerplate', true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Diagnostic-first (FR-1)
Sampled the userStoryQuality AC-clarity FAILs (`ai_quality_assessments`, user_story band=FAIL). Verdict: the rejected ACs are **genuinely-vague auto-generated boilerplate** ('the result is visible in the UI, and data is persisted correctly' applied to infra SDs), **not** clear-but-mis-scored. So the gate is correct — **branch (b): strengthen authoring, do NOT loosen the gate.**

## Fix (FR-2)
`generateAcceptanceCriteria` (lib/sub-agents/modules/stories/quality-generation.js) is now **type-aware**: infrastructure/backend SDs get system-level testable AC scaffolds (logs / exit-code / metric / state) instead of UI boilerplate. `sdType` is threaded through `generateQualityStoryContent`, the LLM-fallback, the `generateStoriesBatch` rule-based path (the dominant LLM-off path — Design-agent catch), and `execute.js` (fail-open fetch).

## Retained teeth (FR-3)
`is_boilerplate:true` preserved on **all** fallback ACs so `allAcsBoilerplate()`→draft and the USER_STORY_QUALITY clarity gate still catch vague ACs; feature/UI scaffold unchanged. No gate threshold modified.

## Evidence
- 5/5 unit tests (`tests/unit/ac-clarity-type-aware-scaffold.test.js`)
- Sub-agents: Design 88, DB 98, Security 95, Stories 95, Testing(EXEC) 96
- Handoffs: LEAD-TO-PLAN 95, PLAN-TO-EXEC 97, EXEC-TO-PLAN 98, PLAN-TO-LEAD 96
- Meta-irony: the STORIES agent found this SD's OWN auto-generated stories were UI-boilerplate and rewrote them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)