### PR TITLE
feat(SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B): disposition-gated auto-mint (CHECK #11) — the churn fix

### DIFF
--- a/lib/integrations/roadmap-manager.js
+++ b/lib/integrations/roadmap-manager.js
@@ -7,6 +7,10 @@
  */
 
 import { validateTransition } from './roadmap-taxonomy.js';
+// SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (THE churn fix): disposition-gate the wave→SD
+// promoter in distilled-only mode so it mirrors the auto-refill funnel's CHECK #11.
+import { hasBuildDisposition } from '../sourcing-engine/refill-candidate-validity.js';
+import { isDistilledOnly } from '../sourcing-engine/refill-auto-promote.js';
 
 /**
  * Load enrichment data (enrichment_summary, chairman_intent, chairman_notes)
@@ -282,12 +286,20 @@ export async function promoteWaveToSDs(supabase, waveId) {
 
   // Skip items that already have an SD (promoted_to_sd_key) OR were brainstormed
   // (brainstorm_session_id exists — SD was created via brainstorm auto-chain)
+  // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: in distilled-only mode, skip items not
+  // dispositioned as buildable (mirrors CHECK #11). Default OFF -> filter unchanged. Read once per call.
+  const distilledOnly = isDistilledOnly();
+  let skippedUndisposed = 0;
   const unpromoted = (items || []).filter(i => {
     if (i.promoted_to_sd_key) return false; // already promoted
     if (i.brainstorm_session_id) return false; // SD created via brainstorm path
     if (i.item_disposition === 'dropped' || i.item_disposition === 'deferred') return false;
+    if (distilledOnly && !hasBuildDisposition(i)) { skippedUndisposed++; return false; } // churn fix
     return true;
   });
+  if (distilledOnly && skippedUndisposed > 0) {
+    console.log(`  ℹ️  ${skippedUndisposed} item(s) skipped — not build-dispositioned (SOURCING_AUTO_REFILL_DISTILLED_ONLY on)`);
+  }
   const brainstormed = (items || []).filter(i => i.brainstorm_session_id && !i.promoted_to_sd_key);
   if (brainstormed.length > 0) {
     console.log(`  ℹ️  ${brainstormed.length} item(s) skipped — already processed via brainstorm path`);

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -17,6 +17,20 @@
 import { randomUUID } from 'crypto';
 import { verifyStagedCandidates } from './refill-dry-run-verifier.js';
 import { buildTwoWayStamp, deriveSdFieldsFromRoadmapItem } from './register-first.js';
+// SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (THE churn fix): the disposition-gate helpers.
+import { hasBuildDisposition, REFILL_INVALID_REASONS } from './refill-candidate-validity.js';
+
+/**
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: is distilled-only auto-mint mode on? When ON, the
+ * auto-refill funnel promotes ONLY items dispositioned as buildable (the churn fix). Default OFF (env unset
+ * / any value != 'on') keeps the current behavior for a safe rollout. Reads the env at call time so the
+ * flag can flip without a process restart; injectable via `env` for tests.
+ * @param {Object} [env]
+ * @returns {boolean}
+ */
+export function isDistilledOnly(env = process.env) {
+  return (env && env.SOURCING_AUTO_REFILL_DISTILLED_ONLY) === 'on';
+}
 
 /** Default per-run promotion cap — a single run never promotes more than this onto the belt. */
 export const DEFAULT_REFILL_BATCH_LIMIT = 10;
@@ -42,7 +56,10 @@ const ALLOWED_SD_TYPES = new Set([
  */
 export function selectRefillBatch(rows, opts = {}) {
   const limit = Number.isInteger(opts.limit) && opts.limit > 0 ? opts.limit : DEFAULT_REFILL_BATCH_LIMIT;
-  const report = verifyStagedCandidates(rows, { shippedTitleSet: opts.shippedTitleSet });
+  // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: forward the distilled-only flag so the batch
+  // selector applies CHECK #11 (default OFF -> unchanged). Caller passes opts.distilledOnly (the cron
+  // derives it from isDistilledOnly()); verifyStagedCandidates forwards opts straight to the predicate.
+  const report = verifyStagedCandidates(rows, { shippedTitleSet: opts.shippedTitleSet, distilledOnly: opts.distilledOnly === true });
   return {
     batch: report.valid.slice(0, limit),
     validCount: report.validCount,
@@ -153,6 +170,16 @@ export async function promoteStagedCandidate(supabase, item, opts = {}) {
   const out = { promoted: false, dry_run: !apply, sd_key: null, reason: null };
   if (!item || !item.id) { out.reason = 'missing_item_id'; return out; }
   if (item.promoted_to_sd_key) { out.reason = 'already_promoted'; out.sd_key = item.promoted_to_sd_key; return out; }
+
+  // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (THE churn fix): in distilled-only mode, refuse to
+  // mint an SD for an item that is not dispositioned as buildable — a per-mint guard that mirrors CHECK #11
+  // so the gate holds even if a caller reaches promote without going through selectRefillBatch. Flag read
+  // at call time (injectable via opts.distilledOnly for tests); default OFF -> behavior unchanged.
+  const distilledOnly = opts.distilledOnly === undefined ? isDistilledOnly() : opts.distilledOnly === true;
+  if (distilledOnly && !hasBuildDisposition(item)) {
+    out.reason = REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD;
+    return out;
+  }
 
   const sdKey = buildRefillSdKey(item);
   out.sd_key = sdKey;

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -36,7 +36,33 @@ export const REFILL_INVALID_REASONS = Object.freeze({
   ALREADY_SHIPPED_LOOKALIKE: 'already_shipped_lookalike',
   // SD-LEO-INFRA-VDR-GAUGE-BELT-001 (FR-1) — a raw-label source_type that the GENERAL funnel must not promote.
   RAW_LABEL_SOURCE: 'raw_label_source',
+  // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (CHECK #11, THE churn fix) — when distilled-only
+  // mode is on, a staged item that has NOT been dispositioned as buildable (undispositioned, or a
+  // non-'build' disposition) must NOT be auto-minted. This is what stops the auto-refill from churning
+  // raw, un-reviewed brainstorm items onto the belt. Flag-gated (opts.distilledOnly) so it is inert until
+  // the operator turns SOURCING_AUTO_REFILL_DISTILLED_ONLY on — legacy items stay promotable until then.
+  UNDISPOSITIONED_OR_NON_BUILD: 'undispositioned_or_non_build',
 });
+
+// SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: the disposition value(s) that mark a staged item
+// as a chairman/distiller-approved BUILDABLE idea (set by the distiller -001-C / chairman queue -001-A).
+// Anything else — including an absent disposition (legacy/undistilled) — is NOT build-dispositioned.
+export const BUILD_DISPOSITIONS = new Set(['build']);
+
+/**
+ * Has this staged item been dispositioned as BUILDABLE? Reads the canonical `disposition` field (top-level,
+ * the shape the router/escalator/populator already stamp) with a `metadata.disposition` fallback. An absent
+ * or non-'build' disposition returns false (the safe default — undistilled items are not auto-buildable).
+ * PURE/TOTAL.
+ * @param {{ disposition?:string, metadata?:object }} item
+ * @returns {boolean}
+ */
+export function hasBuildDisposition(item) {
+  if (!item || typeof item !== 'object') return false;
+  const md = item.metadata && typeof item.metadata === 'object' ? item.metadata : {};
+  const raw = nonEmpty(item.disposition) ? item.disposition : (nonEmpty(md.disposition) ? md.disposition : '');
+  return BUILD_DISPOSITIONS.has(String(raw).trim().toLowerCase());
+}
 
 const nonEmpty = (v) => typeof v === 'string' && v.trim() !== '';
 
@@ -151,10 +177,13 @@ export function crossRefShippedTitleAdvisory(title, shippedTitleSet) {
  *
  * @param {{ item_disposition?:string, promoted_to_sd_key?:(string|null), title?:string,
  *           source_type?:string, source_id?:string, lane?:string }} item  a roadmap_wave_items row
- * @param {{ shippedTitleSet?:Set<string> }} [opts]  SD-LEO-INFRA-AUTO-REFILL-BELT-001 (FR-3): an OPTIONAL
- *        injected Set of normalizeTitleForCompare() keys of already-shipped/completed SD titles. Default
- *        empty -> the lookalike axis no-ops (backward compatible). The CALLER builds this once per <=10-row
- *        batch via a bounded query, keeping this predicate PURE and O(1) per item.
+ * @param {{ shippedTitleSet?:Set<string>, distilledOnly?:boolean }} [opts]  SD-LEO-INFRA-AUTO-REFILL-BELT-001
+ *        (FR-3): shippedTitleSet is an OPTIONAL injected Set of normalizeTitleForCompare() keys of
+ *        already-shipped/completed SD titles (default empty -> lookalike axis no-ops). The CALLER builds it
+ *        once per <=10-row batch via a bounded query, keeping this predicate PURE and O(1) per item.
+ *        SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: distilledOnly (default false) turns on CHECK
+ *        #11 — only build-dispositioned items pass (the churn fix); the caller maps the
+ *        SOURCING_AUTO_REFILL_DISTILLED_ONLY env flag to it.
  * @returns {{ valid:boolean, reason:(string|null) }}
  */
 export function evaluateRefillCandidate(item, opts = {}) {
@@ -199,6 +228,13 @@ export function evaluateRefillCandidate(item, opts = {}) {
   if (FIXTURE_TITLE_RE.test(item.title) ||
       (nonEmpty(item.source_id) && FIXTURE_KEY_RE.test(item.source_id))) {
     return { valid: false, reason: REFILL_INVALID_REASONS.TEST_FIXTURE };
+  }
+  // CHECK #11 (SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B, THE churn fix): in distilled-only
+  // mode, only an item dispositioned as buildable (by the distiller -001-C / chairman queue -001-A) may
+  // be auto-minted. Flag-gated via opts.distilledOnly so the predicate stays PURE (the caller reads the
+  // SOURCING_AUTO_REFILL_DISTILLED_ONLY env flag and passes it). Default OFF -> inert (legacy behavior).
+  if (opts && opts.distilledOnly === true && !hasBuildDisposition(item)) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD };
   }
   // Belt-quality axes (SD-LEO-INFRA-AUTO-REFILL-BELT-001), run LAST so a structurally-broken row still
   // reports its structural reason first. (1) substance: a 120-char truncation shell carries only a

--- a/tests/unit/refill-disposition-gate.test.js
+++ b/tests/unit/refill-disposition-gate.test.js
@@ -1,0 +1,105 @@
+// SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (THE churn fix) — disposition-gated auto-mint.
+// CHECK #11 UNDISPOSITIONED_OR_NON_BUILD blocks auto-minting un-reviewed brainstorm items when
+// distilled-only mode is on; default OFF keeps legacy behavior. These tests pair the FALSE-POSITIVE
+// proofs (a build-dispositioned item, and flag-OFF, still pass) with the RETAINED-TEETH proofs
+// (undispositioned + non-build items are blocked when the flag is on).
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateRefillCandidate,
+  hasBuildDisposition,
+  REFILL_INVALID_REASONS,
+} from '../../lib/sourcing-engine/refill-candidate-validity.js';
+import { isDistilledOnly, promoteStagedCandidate } from '../../lib/sourcing-engine/refill-auto-promote.js';
+
+// A structurally-VALID staged candidate (passes every pre-existing check) so CHECK #11 is the only
+// variable under test. disposition overrides per case.
+function validItem(extra = {}) {
+  return {
+    item_disposition: 'pending',
+    promoted_to_sd_key: null,
+    title: 'Wire the coordinator pending-proposals gauge into the belt-low forecast path',
+    source_type: 'feedback',
+    source_id: 'FB-12345',
+    ...extra,
+  };
+}
+
+describe('hasBuildDisposition', () => {
+  it('true only for a build disposition (top-level or metadata)', () => {
+    expect(hasBuildDisposition({ disposition: 'build' })).toBe(true);
+    expect(hasBuildDisposition({ disposition: 'BUILD' })).toBe(true);
+    expect(hasBuildDisposition({ metadata: { disposition: 'build' } })).toBe(true);
+  });
+  it('false for absent / non-build dispositions', () => {
+    expect(hasBuildDisposition({})).toBe(false);
+    expect(hasBuildDisposition({ disposition: 'defer' })).toBe(false);
+    expect(hasBuildDisposition({ disposition: 'decline' })).toBe(false);
+    expect(hasBuildDisposition({ disposition: '' })).toBe(false);
+    expect(hasBuildDisposition(null)).toBe(false);
+  });
+});
+
+describe('evaluateRefillCandidate CHECK #11 (FALSE-POSITIVE proofs)', () => {
+  it('flag OFF (default): an undispositioned item is STILL valid (legacy behavior preserved)', () => {
+    const v = evaluateRefillCandidate(validItem()); // no distilledOnly
+    expect(v.valid).toBe(true);
+  });
+  it('flag ON: a build-dispositioned item passes', () => {
+    const v = evaluateRefillCandidate(validItem({ disposition: 'build' }), { distilledOnly: true });
+    expect(v.valid).toBe(true);
+    expect(v.reason).toBeNull();
+  });
+  it('flag ON: a build disposition in metadata passes', () => {
+    const v = evaluateRefillCandidate(validItem({ metadata: { disposition: 'build' } }), { distilledOnly: true });
+    expect(v.valid).toBe(true);
+  });
+});
+
+describe('evaluateRefillCandidate CHECK #11 (RETAINED-TEETH proofs)', () => {
+  it('flag ON: an UNDISPOSITIONED item is blocked', () => {
+    const v = evaluateRefillCandidate(validItem(), { distilledOnly: true });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe(REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD);
+  });
+  it('flag ON: a NON-BUILD (defer) disposition is blocked', () => {
+    const v = evaluateRefillCandidate(validItem({ disposition: 'defer' }), { distilledOnly: true });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe(REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD);
+  });
+  it('lifecycle reasons still fire FIRST (CHECK #11 does not mask a structural failure)', () => {
+    // already-promoted should report ALREADY_PROMOTED, not the disposition reason.
+    const v = evaluateRefillCandidate(validItem({ promoted_to_sd_key: 'SD-X', disposition: 'defer' }), { distilledOnly: true });
+    expect(v.reason).toBe(REFILL_INVALID_REASONS.ALREADY_PROMOTED);
+  });
+});
+
+describe('isDistilledOnly flag', () => {
+  it('true only when SOURCING_AUTO_REFILL_DISTILLED_ONLY === "on"', () => {
+    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'on' })).toBe(true);
+    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'off' })).toBe(false);
+    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'true' })).toBe(false);
+    expect(isDistilledOnly({})).toBe(false);
+  });
+});
+
+describe('promoteStagedCandidate disposition guard (per-mint teeth)', () => {
+  // A supabase stub that would mint if reached; the guard must short-circuit BEFORE any DB call.
+  function mintingSb() {
+    return { from() { throw new Error('DB should not be touched when the disposition guard blocks'); } };
+  }
+
+  it('flag ON + undispositioned item → refuses to mint (no DB touch), reason UNDISPOSITIONED_OR_NON_BUILD', async () => {
+    const out = await promoteStagedCandidate(mintingSb(), { id: 'rw-1', ...validItem() }, { apply: true, distilledOnly: true });
+    expect(out.promoted).toBe(false);
+    expect(out.reason).toBe(REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD);
+  });
+
+  it('flag OFF (default opts) → guard inert (reaches the existence check)', async () => {
+    // With distilledOnly omitted and the env unset, the guard is inert; the existence query runs.
+    let queried = false;
+    const sb = { from() { queried = true; return { select: () => ({ eq: () => ({ limit: () => Promise.resolve({ data: [{ sd_key: 'SD-REFILL-X' }] }) }) }) }; } };
+    const out = await promoteStagedCandidate(sb, { id: 'rw-2', ...validItem() }, { apply: true, distilledOnly: false });
+    expect(queried).toBe(true);
+    expect(out.reason).not.toBe(REFILL_INVALID_REASONS.UNDISPOSITIONED_OR_NON_BUILD);
+  });
+});


### PR DESCRIPTION
## Summary
CHILD-B of the brainstorm-distillation orchestrator (first in B→C→A→D) — THE auto-refill churn fix. The funnel auto-minted SDs from any structurally-valid STAGED roadmap_wave_items row regardless of whether the idea was reviewed as buildable, churning raw un-distilled brainstorm items onto the belt.

## Changes
- **FR-1** `refill-candidate-validity.js`: CHECK #11 `UNDISPOSITIONED_OR_NON_BUILD` + pure `hasBuildDisposition` helper in `evaluateRefillCandidate`, gated on `opts.distilledOnly` (predicate stays pure; placed after lifecycle/structural/fixture checks).
- **FR-2** `refill-auto-promote.js`: `isDistilledOnly` flag (`SOURCING_AUTO_REFILL_DISTILLED_ONLY`, **default OFF**) + `selectRefillBatch` forward + per-mint guard in `promoteStagedCandidate` (refuses to mint pre-DB); `roadmap-manager.js` `promoteWaveToSDs` mirrors the skip.
- **FR-3** 11 paired false-positive + RETAINED-TEETH tests, all green. Testing-agent PASS 98.

Default OFF = current behavior byte-identical until an operator opts in. B keys on the existing `disposition` field — no dependency on -001-A's schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)