### PR TITLE
feat(SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C): LLM brainstorm distiller + default-dry-run CLI

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C.json
@@ -1,0 +1,100 @@
+{
+  "executive_summary": "Child idx 2 of the Brainstorm Distillation Pipeline orchestrator (FR-1/FR-4). Builds the LLM brainstorm distiller that turns a raw roadmap_wave_items brainstorm row into a structured, chairman-reviewable distilled SD payload, plus a CLI that DEFAULTS to a zero-DB-write top-20 dry-run so the chairman can quality-validate distillation before any scale-up. Hard dependency (child idx-0: lib/eva/consultant/distillation-queue-writer.js enqueueDistilledCandidate + eva_consultant_recommendations.distilled_sd_payload column) is COMPLETE and merged (PR #5112; branch rebased onto origin/main). The soft sequencing dependency on the disposition gate (idx-1, in-flight by another worker) is non-blocking because the distiller NEVER mints — it defaults to dry-run and, under --apply, writes only to the chairman review queue (promotion is gated separately by idx-1). LEAD validation (evidence bd00ce8a, confidence 92) confirmed the reuse contract: getClassificationClient() -> client.complete(systemPrompt, userPrompt, {maxTokens}) wrapped in Promise.race timeout; complete() returns string OR {content}; deterministic keyword fallback fires on stub/timeout/parse-fail; ordering field is roadmap_wave_items.metadata->>'refine_composite_score' (DESC NULLS LAST). Files are disjoint from idx-1.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Pure LLM distiller core (distill-brainstorm.js)",
+      "description": "lib/integrations/distill-brainstorm.js: buildDistillPrompt(item) -> distillItem(item, {client}) -> parseDistillResponse(text) with a deterministic keywordDistill(item) fallback. distillItem reuses the refine-score.js pattern: getClassificationClient(); Promise.race([client.complete(system, user, {maxTokens}), timeout]); accept response as string OR {content}; JSON.parse; on stub/timeout/parse-fail use keywordDistill. Output payload shape: {title, description, scope, rationale, sd_type, confidence_tier}. Pure (client injectable) for testability.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "distillItem returns a valid {title,description,scope,rationale,sd_type,confidence_tier} payload from a raw brainstorm row via the LLM path",
+        "keyword fallback fires on stub/timeout/parse-fail and returns a valid payload (method='keyword')",
+        "complete() string OR {content} both handled; client is injectable"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Distiller CLI with default dry-run (eva-distill-brainstorm.js)",
+      "description": "scripts/eva-distill-brainstorm.js: load the top-20 roadmap_wave_items by metadata.refine_composite_score (DESC, NULLS LAST), distill each via the core, and DEFAULT to --dry-run: write a temp-file report + console summary, ZERO DB writes. Only with --apply does it enqueue each distilled payload to the chairman review queue via the idx-0 writer enqueueDistilledCandidate(supabase, {sourceWaveItemId, distilledPayload, title, description, confidenceTier}). import.meta.url main-guard so the module is import-safe.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Default run is --dry-run: temp-file + console report, ZERO DB writes",
+        "Top-20 ordered by metadata.refine_composite_score DESC NULLS LAST",
+        "--apply maps the distilled payload into enqueueDistilledCandidate; import.meta.url main-guard present"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Pure distiller-schema unit tests",
+      "description": "tests/unit covering: AI-path payload shape (fake client returning JSON), keyword-fallback payload shape (client throws/stub), dry-run performs no insert, and the payload->enqueueDistilledCandidate field mapping. Fake client + fake supabase; no live LLM/DB.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "Test: AI-path returns a valid payload from a fake client",
+        "Test: keyword fallback returns a valid payload when the client throws/stub",
+        "Test: dry-run path performs zero inserts; --apply mapping is correct"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Chairman validation checkpoint (no-mint guarantee)",
+      "description": "The distiller MUST NOT mint SDs. Its dry-run default opens no churn window; --apply writes only to the chairman review queue (eva_consultant_recommendations, status pending), and promotion to the belt remains gated by the idx-1 disposition gate. This guarantee is encoded by the dry-run default + the writer-only --apply path (no call into any mint/promote function).",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "No code path in the distiller calls a mint/promote function",
+        "Dry-run default; --apply writes only via enqueueDistilledCandidate"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {"requirement": "Reuse refine-score.js LLM pattern: getClassificationClient + client.complete(system,user,{maxTokens}) + Promise.race timeout + keyword fallback; handle string OR {content}", "type": "code"},
+    {"requirement": "Order by roadmap_wave_items.metadata->>'refine_composite_score' DESC NULLS LAST (JSONB key); fetch + numeric sort if PostgREST JSONB ordering is unreliable", "type": "constraint"},
+    {"requirement": "--apply target is the idx-0 writer enqueueDistilledCandidate (already on origin/main; branch rebased)", "type": "constraint"},
+    {"requirement": "Distiller NEVER mints — dry-run default + writer-only --apply; promotion gated by idx-1", "type": "constraint"}
+  ],
+  "test_scenarios": [
+    {"scenario": "fake client returns JSON payload", "type": "unit", "expected": "distillItem returns the parsed {title,...} payload, method='ai'"},
+    {"scenario": "client throws / inline stub / unparseable", "type": "unit", "expected": "keyword fallback returns a valid payload, method='keyword'"},
+    {"scenario": "dry-run default", "type": "unit", "expected": "no supabase insert called; report produced"},
+    {"scenario": "--apply mapping", "type": "unit", "expected": "enqueueDistilledCandidate called with {sourceWaveItemId, distilledPayload, title, description, confidenceTier}"}
+  ],
+  "acceptance_criteria": [
+    "Distiller core produces valid payloads via LLM and via deterministic keyword fallback",
+    "CLI defaults to a zero-DB-write top-20 dry-run; --apply enqueues to the review queue only",
+    "No mint path; unit tests green"
+  ],
+  "risks": [
+    {"risk": "Cloud LLM unavailable", "mitigation": "Deterministic keyword fallback fires on stub/timeout/parse-fail; tests cover it", "severity": "low"},
+    {"risk": "Opening a churn window before the idx-1 gate lands", "mitigation": "Dry-run default + writer-only --apply (review queue, not belt); distiller never mints", "severity": "low"},
+    {"risk": "JSONB ordering quirk on metadata->>refine_composite_score", "mitigation": "Fetch + client-side numeric sort with NULLS LAST if PostgREST ordering is unreliable", "severity": "low"}
+  ],
+  "integration_operationalization": {
+    "consumers": ["chairman review of distilled candidates in eva_consultant_recommendations", "downstream idx-3 gauge + scale-up (consumes distillation coverage)", "npm/eva distillation tooling"],
+    "dependencies": ["lib/eva/consultant/distillation-queue-writer.js enqueueDistilledCandidate (idx-0, merged)", "lib/integrations/refine-score.js (LLM pattern)", "lib/llm/client-factory.js getClassificationClient", "roadmap_wave_items.metadata.refine_composite_score"],
+    "data_contracts": ["Reads roadmap_wave_items; under --apply writes eva_consultant_recommendations via the idx-0 writer (distilled_sd_payload jsonb). No schema change in this child."],
+    "runtime_config": ["--dry-run (default) / --apply flag"],
+    "observability_rollout": ["dry-run report is the chairman validation artifact before any scale-up (FR-4)"]
+  },
+  "system_architecture": {
+    "summary": "One pure distiller core module + one CLI (default dry-run) + unit tests. Reuses the refine-score.js LLM scaffold and the idx-0 queue writer. No schema change; no mint path.",
+    "components": [
+      {"name": "lib/integrations/distill-brainstorm.js", "change": "pure distiller core (LLM + keyword fallback)"},
+      {"name": "scripts/eva-distill-brainstorm.js", "change": "default --dry-run top-20 CLI; --apply enqueues via idx-0 writer; main-guard"},
+      {"name": "tests/unit distiller tests", "change": "AI-path + fallback + dry-run-no-write + apply-mapping"}
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Build the pure distiller core mirroring refine-score.js; build the dry-run-default CLI ordering by refine_composite_score and enqueuing via the idx-0 writer only on --apply; add unit tests with fake client + fake supabase; dry-run smoke.",
+    "steps": [
+      "Add distill-brainstorm.js (buildDistillPrompt/distillItem/parseDistillResponse/keywordDistill)",
+      "Add eva-distill-brainstorm.js (top-20 by refine_composite_score, default dry-run, --apply via enqueueDistilledCandidate, main-guard)",
+      "Add unit tests (AI-path, fallback, dry-run no-write, apply-mapping)",
+      "Run unit suite + dry-run smoke (zero DB writes)"
+    ]
+  },
+  "smoke_test_steps": [
+    {"step_number": 1, "instruction": "npx vitest run the distiller unit test file", "expected_outcome": "all green"},
+    {"step_number": 2, "instruction": "node scripts/eva-distill-brainstorm.js (default)", "expected_outcome": "top-20 dry-run report prints, ZERO DB writes"},
+    {"step_number": 3, "instruction": "node -c lib/integrations/distill-brainstorm.js && node -c scripts/eva-distill-brainstorm.js", "expected_outcome": "both parse OK"}
+  ],
+  "metadata": {"sd_key": "SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C", "parent_sd": "SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001", "child_index": 2, "lead_evidence_id": "bd00ce8a", "ordering_field": "roadmap_wave_items.metadata->>refine_composite_score (DESC NULLS LAST)", "apply_target": "lib/eva/consultant/distillation-queue-writer.js enqueueDistilledCandidate"}
+}

--- a/lib/integrations/distill-brainstorm.js
+++ b/lib/integrations/distill-brainstorm.js
@@ -1,0 +1,189 @@
+/**
+ * LLM brainstorm distiller.
+ *
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C (FR-1/FR-4), child idx 2 of
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001.
+ *
+ * Turns a raw (enriched) brainstorm item into a STRUCTURED distilled SD payload that the chairman
+ * can review: {title, description, scope, rationale, sd_type, confidence_tier}. The downstream
+ * disposition gate (child idx 1) controls whether such a candidate may ever auto-mint — this
+ * module NEVER mints. It only produces a payload; the CLI writes it to the chairman review queue.
+ *
+ * Reuses the refine-score.js LLM pattern: getClassificationClient() -> client.complete(system,user,
+ * {maxTokens}) wrapped in a Promise.race timeout; complete() may return a string OR {content};
+ * a deterministic keyword/heuristic fallback fires on stub/timeout/parse-fail so there is no hard
+ * dependency on cloud LLM availability.
+ */
+
+import { getClassificationClient } from '../llm/client-factory.js';
+
+export const DISTILL_CONFIG = {
+  AI_TIMEOUT_MS: 90_000,
+  MAX_TOKENS: 2048,
+  SD_TYPES: ['feature', 'infrastructure', 'bugfix', 'refactor', 'documentation', 'discovery_spike'],
+  CONFIDENCE_TIERS: ['high', 'medium', 'low'],
+};
+
+/**
+ * Normalize an enriched wave item into the fields the distiller reasons over.
+ * (Mirrors scripts/eva-intake-refine.js enrichment shape.)
+ */
+function normalizeItem(item = {}) {
+  return {
+    wave_item_id: item.wave_item_id || item.id || null,
+    title: item.title || '(untitled)',
+    description: item.description || '',
+    target_application: item.target_application || '',
+    target_aspects: Array.isArray(item.target_aspects) ? item.target_aspects : [],
+    chairman_intent: item.chairman_intent || '',
+    refine_composite_score:
+      item.refine_composite_score ?? item.metadata?.refine_composite_score ?? null,
+  };
+}
+
+/**
+ * Build the distillation prompt for a single enriched item. Pure.
+ */
+export function buildDistillPrompt(item) {
+  const n = normalizeItem(item);
+  return [
+    'Distill the following raw brainstorm capture into a single buildable Strategic Directive.',
+    'Respond with ONLY valid JSON of shape:',
+    '{"title": string (<=120 chars, imperative), "description": string (2-4 sentences, what+why),',
+    ' "scope": string (concrete deliverables + boundaries), "rationale": string (why it matters now),',
+    ` "sd_type": one of ${JSON.stringify(DISTILL_CONFIG.SD_TYPES)},`,
+    ` "confidence_tier": one of ${JSON.stringify(DISTILL_CONFIG.CONFIDENCE_TIERS)} (how build-ready/clear this is)}`,
+    '',
+    'Raw capture:',
+    `- title: ${n.title}`,
+    `- description: ${n.description}`,
+    `- chairman_intent: ${n.chairman_intent}`,
+    `- target_application: ${n.target_application}`,
+    `- target_aspects: ${JSON.stringify(n.target_aspects)}`,
+  ].join('\n');
+}
+
+/**
+ * Parse the LLM distillation response into a validated payload, or null on failure. Pure.
+ */
+export function parseDistillResponse(response) {
+  try {
+    const text = typeof response === 'string' ? response : response?.content;
+    if (!text) return null;
+    const cleaned = text.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+    return coercePayload(parsed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Coerce/validate a raw object into the distilled payload contract, or null if unusable. Pure.
+ */
+export function coercePayload(obj) {
+  if (!obj || typeof obj !== 'object') return null;
+  const title = typeof obj.title === 'string' ? obj.title.trim().slice(0, 120) : '';
+  if (!title) return null;
+  const sd_type = DISTILL_CONFIG.SD_TYPES.includes(obj.sd_type) ? obj.sd_type : 'feature';
+  const confidence_tier = DISTILL_CONFIG.CONFIDENCE_TIERS.includes(obj.confidence_tier)
+    ? obj.confidence_tier
+    : 'medium';
+  return {
+    title,
+    description: typeof obj.description === 'string' ? obj.description.trim() : '',
+    scope: typeof obj.scope === 'string' ? obj.scope.trim() : '',
+    rationale: typeof obj.rationale === 'string' ? obj.rationale.trim() : '',
+    sd_type,
+    confidence_tier,
+  };
+}
+
+/**
+ * Deterministic keyword/heuristic distillation — the fallback when the LLM is a stub,
+ * times out, or returns unparseable output. Pure, no I/O.
+ */
+export function keywordDistill(item) {
+  const n = normalizeItem(item);
+  const baseTitle = (n.title && n.title !== '(untitled)' ? n.title : n.description || 'Untitled brainstorm capture')
+    .toString()
+    .trim()
+    .slice(0, 120);
+
+  // sd_type heuristic from intent + aspects/app.
+  const hay = `${n.chairman_intent} ${n.target_application} ${n.target_aspects.join(' ')} ${n.description}`.toLowerCase();
+  let sd_type = 'feature';
+  if (/\b(infra|infrastructure|pipeline|gate|engine|coordinator|fleet)\b/.test(hay)) sd_type = 'infrastructure';
+  else if (/\b(bug|fix|broken|regression)\b/.test(hay)) sd_type = 'bugfix';
+  else if (/\b(refactor|cleanup|simplif)\b/.test(hay)) sd_type = 'refactor';
+  else if (/\b(doc|documentation|guide)\b/.test(hay)) sd_type = 'documentation';
+  else if (/\b(spike|research|investigate|explore)\b/.test(hay)) sd_type = 'discovery_spike';
+
+  // confidence tier from the refine composite score, when present.
+  const score = typeof n.refine_composite_score === 'number' ? n.refine_composite_score : null;
+  let confidence_tier = 'low';
+  if (score != null && score >= 70) confidence_tier = 'high';
+  else if (score != null && score >= 50) confidence_tier = 'medium';
+
+  return {
+    title: baseTitle,
+    description: n.description || `Distilled from a ${n.target_application || 'brainstorm'} capture (intent: ${n.chairman_intent || 'unspecified'}).`,
+    scope: `Deliver: ${baseTitle}. Boundaries: keep to the captured intent; defer adjacent ideas.`,
+    rationale: `Surfaced from the brainstorm corpus${score != null ? ` with a refine score of ${score}` : ''}; kept for chairman review (keyword-distilled, LLM unavailable).`,
+    sd_type,
+    confidence_tier,
+  };
+}
+
+/**
+ * Distill a single enriched item into a payload.
+ * @param {Object} item   enriched wave item ({title, description, chairman_intent, target_application, target_aspects, refine_composite_score, wave_item_id})
+ * @param {Object} [opts]
+ * @param {Object} [opts.client]  injectable classification client (defaults to getClassificationClient())
+ * @returns {Promise<{payload: Object, method: 'ai'|'keyword'}>}
+ */
+export async function distillItem(item, opts = {}) {
+  let client = opts.client;
+  try {
+    if (!client) client = await getClassificationClient();
+    if (client && client.isInlineOnly) {
+      // Inline stub cannot produce JSON reliably → deterministic fallback.
+      return { payload: keywordDistill(item), method: 'keyword' };
+    }
+    const prompt = buildDistillPrompt(item);
+    let timeoutId;
+    const response = await Promise.race([
+      client.complete(
+        'You are an SD distiller. Turn a raw brainstorm capture into one buildable Strategic Directive. Respond with only valid JSON.',
+        prompt,
+        { maxTokens: DISTILL_CONFIG.MAX_TOKENS },
+      ),
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('AI timeout')), DISTILL_CONFIG.AI_TIMEOUT_MS);
+        if (timeoutId.unref) timeoutId.unref();
+      }),
+    ]);
+    if (timeoutId) clearTimeout(timeoutId);
+
+    const payload = parseDistillResponse(response);
+    if (payload) return { payload, method: 'ai' };
+  } catch {
+    // fall through to keyword fallback
+  }
+  return { payload: keywordDistill(item), method: 'keyword' };
+}
+
+/**
+ * Map a distilled payload + source wave item into the chairman-review-queue writer contract
+ * (lib/eva/consultant/distillation-queue-writer.js enqueueDistilledCandidate). Pure.
+ */
+export function toQueueCandidate(payload, sourceWaveItemId, confidenceScore = null) {
+  return {
+    sourceWaveItemId,
+    distilledPayload: payload,
+    title: payload.title,
+    description: payload.description,
+    confidenceTier: payload.confidence_tier,
+    ...(confidenceScore != null ? { priorityScore: confidenceScore } : {}),
+  };
+}

--- a/scripts/eva-distill-brainstorm.js
+++ b/scripts/eva-distill-brainstorm.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// @wire-check-exempt: operator/chairman-invoked CLI (node scripts/eva-distill-brainstorm.js), the
+// chairman quality-validation entry point for FR-4. Defaults to --dry-run (zero DB writes); imports
+// the distiller core (lib/integrations/distill-brainstorm.js) and the idx-0 queue writer. Unit-tested
+// (tests/unit/eva/distill-brainstorm.test.js + eva-distill-brainstorm-cli.test.js).
+/**
+ * eva-distill-brainstorm.js — chairman-validation CLI for the brainstorm distiller.
+ *
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C (FR-2/FR-4).
+ *
+ * Loads the top-20 roadmap_wave_items by metadata.refine_composite_score (DESC, NULLS LAST),
+ * enriches each from its source intake table (mirrors scripts/eva-intake-refine.js), distills each
+ * into a structured SD payload, and DEFAULTS to --dry-run: a temp-file + console report with ZERO
+ * DB writes, so the chairman can validate distillation quality BEFORE any scale-up.
+ *
+ * Only with --apply does it enqueue each distilled payload to the chairman review queue via the
+ * child idx-0 writer (lib/eva/consultant/distillation-queue-writer.js enqueueDistilledCandidate).
+ * It NEVER mints an SD — promotion to the belt is gated separately by the disposition gate (idx-1).
+ *
+ * Usage:
+ *   node scripts/eva-distill-brainstorm.js            # dry-run (default), top 20, no DB writes
+ *   node scripts/eva-distill-brainstorm.js --apply    # enqueue distilled candidates to the review queue
+ *   node scripts/eva-distill-brainstorm.js --top 10   # limit
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { distillItem, toQueueCandidate } from '../lib/integrations/distill-brainstorm.js';
+import { enqueueDistilledCandidate } from '../lib/eva/consultant/distillation-queue-writer.js';
+
+dotenv.config();
+
+const SOURCE_TABLES = { todoist: 'eva_todoist_intake', youtube: 'eva_youtube_intake' };
+
+/**
+ * Load the top-N wave items by refine_composite_score, newest-safe.
+ * Fetches the scored set and sorts client-side (PostgREST JSONB ordering is unreliable),
+ * applying NULLS LAST then taking the top N.
+ */
+export async function loadTopWaveItems(supabase, topN = 20) {
+  const { data, error } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, wave_id, source_type, source_id, title, metadata, item_disposition')
+    .not('metadata->refine_composite_score', 'is', null);
+  if (error) throw new Error(`loadTopWaveItems: ${error.message}`);
+  const scored = (data || []).map((r) => ({
+    ...r,
+    refine_composite_score:
+      typeof r.metadata?.refine_composite_score === 'number' ? r.metadata.refine_composite_score : null,
+  }));
+  scored.sort((a, b) => (b.refine_composite_score ?? -1) - (a.refine_composite_score ?? -1));
+  return scored.slice(0, topN);
+}
+
+/** Enrich a wave item from its source intake table (mirrors eva-intake-refine.js). */
+export async function enrichWaveItem(supabase, item) {
+  let sourceData = null;
+  const table = SOURCE_TABLES[item.source_type];
+  if (table && item.source_id) {
+    const { data } = await supabase
+      .from(table)
+      .select('title, description, target_application, target_aspects, chairman_intent')
+      .eq('id', item.source_id)
+      .maybeSingle();
+    sourceData = data;
+  }
+  return {
+    wave_item_id: item.id,
+    title: sourceData?.title || item.title || '(untitled)',
+    description: sourceData?.description || '',
+    target_application: sourceData?.target_application || '',
+    target_aspects: sourceData?.target_aspects || [],
+    chairman_intent: sourceData?.chairman_intent || '',
+    refine_composite_score: item.refine_composite_score,
+  };
+}
+
+export async function run({ supabase, apply = false, topN = 20, client = undefined } = {}) {
+  const items = await loadTopWaveItems(supabase, topN);
+  const results = [];
+  for (const item of items) {
+    const enriched = await enrichWaveItem(supabase, item);
+    const { payload, method } = await distillItem(enriched, { client });
+    let enqueued = false;
+    if (apply) {
+      const candidate = toQueueCandidate(payload, enriched.wave_item_id, enriched.refine_composite_score);
+      await enqueueDistilledCandidate(supabase, candidate); // surfaces errors
+      enqueued = true;
+    }
+    results.push({
+      wave_item_id: enriched.wave_item_id,
+      refine_composite_score: enriched.refine_composite_score,
+      method,
+      payload,
+      enqueued,
+    });
+  }
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes('--apply');
+  const topIdx = args.indexOf('--top');
+  const topN = topIdx !== -1 && args[topIdx + 1] ? parseInt(args[topIdx + 1], 10) : 20;
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  console.log(`\n── Brainstorm Distiller ${apply ? '(APPLY — writing to chairman review queue)' : '(DRY-RUN — zero DB writes)'} ──`);
+  console.log(`   top ${topN} by refine_composite_score\n`);
+
+  const results = await run({ supabase, apply, topN });
+
+  const aiCount = results.filter((r) => r.method === 'ai').length;
+  for (const r of results) {
+    console.log(`  [${r.method}] score=${r.refine_composite_score ?? '—'} :: ${r.payload.title} (${r.payload.sd_type}/${r.payload.confidence_tier})${r.enqueued ? ' [enqueued]' : ''}`);
+  }
+  console.log(`\n  ${results.length} distilled (${aiCount} AI / ${results.length - aiCount} keyword).`);
+
+  if (!apply) {
+    const out = join(tmpdir(), `distill-brainstorm-dryrun-${results.length}.json`);
+    writeFileSync(out, JSON.stringify(results, null, 2));
+    console.log(`  DRY-RUN report: ${out}`);
+    console.log('  No DB writes. Re-run with --apply to enqueue to the chairman review queue.');
+  } else {
+    console.log(`  Enqueued ${results.filter((r) => r.enqueued).length} candidate(s) to the chairman review queue.`);
+  }
+}
+
+const invokedDirectly = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('eva-distill-brainstorm failed:', err.message);
+    process.exit(1);
+  });
+}

--- a/tests/unit/eva/distill-brainstorm.test.js
+++ b/tests/unit/eva/distill-brainstorm.test.js
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the LLM brainstorm distiller.
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C (FR-3).
+ *
+ * Fake client + fake supabase — no live LLM/DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildDistillPrompt,
+  parseDistillResponse,
+  coercePayload,
+  keywordDistill,
+  distillItem,
+  toQueueCandidate,
+  DISTILL_CONFIG,
+} from '../../../lib/integrations/distill-brainstorm.js';
+
+const ITEM = {
+  wave_item_id: 'wave-1',
+  title: 'Few-shot example libraries for EVA decision gates',
+  description: 'Curate good/bad examples per decision point to improve EVA judgment consistency.',
+  chairman_intent: 'idea',
+  target_application: 'ehg_engineer',
+  target_aspects: ['eva', 'decision-quality'],
+  refine_composite_score: 78,
+};
+
+function fakeClient(jsonOrObj, { asContent = false, throws = false, inlineOnly = false } = {}) {
+  return {
+    isInlineOnly: inlineOnly,
+    async complete() {
+      if (throws) throw new Error('boom');
+      const text = typeof jsonOrObj === 'string' ? jsonOrObj : JSON.stringify(jsonOrObj);
+      return asContent ? { content: text } : text;
+    },
+  };
+}
+
+const GOOD_PAYLOAD = {
+  title: 'Add few-shot example libraries for EVA decision gates',
+  description: 'Curate exemplar good/bad decisions per gate.',
+  scope: 'Build example libraries for each EVA/LEO gate; exclude runtime tuning.',
+  rationale: 'Improves decision consistency.',
+  sd_type: 'infrastructure',
+  confidence_tier: 'high',
+};
+
+describe('buildDistillPrompt', () => {
+  it('includes the enriched fields and the JSON contract', () => {
+    const p = buildDistillPrompt(ITEM);
+    expect(p).toContain('Few-shot example libraries');
+    expect(p).toContain('chairman_intent: idea');
+    expect(p).toContain('sd_type');
+  });
+});
+
+describe('coercePayload / parseDistillResponse', () => {
+  it('coerces a valid object and clamps unknown sd_type/tier to defaults', () => {
+    const out = coercePayload({ ...GOOD_PAYLOAD, sd_type: 'nonsense', confidence_tier: 'weird' });
+    expect(out.sd_type).toBe('feature');
+    expect(out.confidence_tier).toBe('medium');
+    expect(DISTILL_CONFIG.SD_TYPES).toContain(out.sd_type);
+  });
+  it('returns null when title is missing', () => {
+    expect(coercePayload({ description: 'x' })).toBeNull();
+  });
+  it('parses a fenced ```json block', () => {
+    const out = parseDistillResponse('```json\n' + JSON.stringify(GOOD_PAYLOAD) + '\n```');
+    expect(out.title).toBe(GOOD_PAYLOAD.title);
+  });
+  it('returns null on unparseable text', () => {
+    expect(parseDistillResponse('not json at all')).toBeNull();
+  });
+  it('accepts a {content} response shape', () => {
+    const out = parseDistillResponse({ content: JSON.stringify(GOOD_PAYLOAD) });
+    expect(out.sd_type).toBe('infrastructure');
+  });
+});
+
+describe('keywordDistill (deterministic fallback)', () => {
+  it('produces a valid payload from intent/aspects with tier from score', () => {
+    const out = keywordDistill(ITEM);
+    expect(out.title.length).toBeGreaterThan(0);
+    expect(out.sd_type).toBe('feature'); // no infra keyword present (eva/decision aren't infra; 'engineer' != 'engine')
+    expect(out.confidence_tier).toBe('high'); // score 78 >= 70
+  });
+  it('classifies infra keywords as infrastructure', () => {
+    const out = keywordDistill({ ...ITEM, description: 'build a sourcing pipeline gate', target_aspects: [] });
+    expect(out.sd_type).toBe('infrastructure');
+  });
+  it('defaults tier to low when no score', () => {
+    const out = keywordDistill({ ...ITEM, refine_composite_score: null });
+    expect(out.confidence_tier).toBe('low');
+  });
+});
+
+describe('distillItem', () => {
+  it('uses the AI path when the client returns valid JSON', async () => {
+    const { payload, method } = await distillItem(ITEM, { client: fakeClient(GOOD_PAYLOAD) });
+    expect(method).toBe('ai');
+    expect(payload.title).toBe(GOOD_PAYLOAD.title);
+  });
+  it('handles a {content} response', async () => {
+    const { payload, method } = await distillItem(ITEM, { client: fakeClient(GOOD_PAYLOAD, { asContent: true }) });
+    expect(method).toBe('ai');
+    expect(payload.confidence_tier).toBe('high');
+  });
+  it('falls back to keyword when the client throws', async () => {
+    const { method } = await distillItem(ITEM, { client: fakeClient(null, { throws: true }) });
+    expect(method).toBe('keyword');
+  });
+  it('falls back to keyword for an inline-only stub', async () => {
+    const { method } = await distillItem(ITEM, { client: fakeClient(GOOD_PAYLOAD, { inlineOnly: true }) });
+    expect(method).toBe('keyword');
+  });
+  it('falls back to keyword on unparseable AI output', async () => {
+    const { method } = await distillItem(ITEM, { client: fakeClient('garbage') });
+    expect(method).toBe('keyword');
+  });
+});
+
+describe('toQueueCandidate', () => {
+  it('maps a payload + source id into the enqueue contract', () => {
+    const c = toQueueCandidate(GOOD_PAYLOAD, 'wave-1', 78);
+    expect(c.sourceWaveItemId).toBe('wave-1');
+    expect(c.distilledPayload).toEqual(GOOD_PAYLOAD);
+    expect(c.title).toBe(GOOD_PAYLOAD.title);
+    expect(c.confidenceTier).toBe('high');
+    expect(c.priorityScore).toBe(78);
+  });
+  it('omits priorityScore when no score', () => {
+    const c = toQueueCandidate(GOOD_PAYLOAD, 'wave-1', null);
+    expect('priorityScore' in c).toBe(false);
+  });
+});

--- a/tests/unit/eva/eva-distill-brainstorm-cli.test.js
+++ b/tests/unit/eva/eva-distill-brainstorm-cli.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the distiller CLI run() — dry-run no-write guarantee + apply mapping.
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C (FR-2/FR-3/FR-4).
+ */
+import { describe, it, expect } from 'vitest';
+import { run, loadTopWaveItems } from '../../../scripts/eva-distill-brainstorm.js';
+
+const WAVE_ROWS = [
+  { id: 'w-low', source_type: 'todoist', source_id: 's-low', title: null, metadata: { refine_composite_score: 40 }, item_disposition: 'pending' },
+  { id: 'w-high', source_type: 'todoist', source_id: 's-high', title: null, metadata: { refine_composite_score: 90 }, item_disposition: 'pending' },
+  { id: 'w-mid', source_type: 'youtube', source_id: 's-mid', title: null, metadata: { refine_composite_score: 70 }, item_disposition: 'pending' },
+];
+
+const INTAKE = {
+  's-high': { title: 'High idea', description: 'do high', target_application: 'ehg_engineer', target_aspects: [], chairman_intent: 'idea' },
+  's-mid': { title: 'Mid idea', description: 'do mid', target_application: 'ehg_app', target_aspects: [], chairman_intent: 'value' },
+  's-low': { title: 'Low idea', description: 'do low', target_application: '', target_aspects: [], chairman_intent: 'question' },
+};
+
+function makeFakeSupabase() {
+  const inserts = [];
+  return {
+    inserts,
+    from(table) {
+      if (table === 'roadmap_wave_items') {
+        return { select() { return { not() { return Promise.resolve({ data: WAVE_ROWS, error: null }); } }; } };
+      }
+      if (table === 'eva_todoist_intake' || table === 'eva_youtube_intake') {
+        return {
+          select() {
+            return {
+              eq(_col, id) {
+                return { async maybeSingle() { return { data: INTAKE[id] || null, error: null }; } };
+              },
+            };
+          },
+        };
+      }
+      if (table === 'eva_consultant_recommendations') {
+        return {
+          insert(row) {
+            inserts.push(row);
+            return { select() { return { async single() { return { data: { id: 'rec-x', ...row }, error: null }; } }; } };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+// Force the keyword path deterministically (no live LLM): inline-only stub client.
+const STUB = { isInlineOnly: true, async complete() { return ''; } };
+
+describe('loadTopWaveItems', () => {
+  it('orders by refine_composite_score DESC and applies topN', async () => {
+    const sb = makeFakeSupabase();
+    const top2 = await loadTopWaveItems(sb, 2);
+    expect(top2.map((r) => r.id)).toEqual(['w-high', 'w-mid']);
+  });
+});
+
+describe('run (dry-run default)', () => {
+  it('performs ZERO DB writes in dry-run', async () => {
+    const sb = makeFakeSupabase();
+    const results = await run({ supabase: sb, apply: false, client: STUB });
+    expect(sb.inserts.length).toBe(0);
+    expect(results.length).toBe(3);
+    expect(results.every((r) => r.enqueued === false)).toBe(true);
+    expect(results[0].id !== undefined || results[0].wave_item_id !== undefined).toBe(true);
+  });
+});
+
+describe('run (--apply)', () => {
+  it('enqueues each distilled candidate via the writer with correct mapping', async () => {
+    const sb = makeFakeSupabase();
+    const results = await run({ supabase: sb, apply: true, client: STUB });
+    expect(sb.inserts.length).toBe(3);
+    expect(results.every((r) => r.enqueued === true)).toBe(true);
+    // mapping: writer row carries source_wave_item_id + distilled_sd_payload
+    const highInsert = sb.inserts.find((i) => i.source_wave_item_id === 'w-high');
+    expect(highInsert).toBeTruthy();
+    expect(highInsert.distilled_sd_payload).toBeTruthy();
+    expect(highInsert.status).toBe('pending');
+  });
+});


### PR DESCRIPTION
Child idx 2 of the Brainstorm Distillation Pipeline orchestrator (SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001).

## What
- **distiller core** `lib/integrations/distill-brainstorm.js`: turns a raw (enriched) brainstorm row into a structured `{title,description,scope,rationale,sd_type,confidence_tier}` SD payload. Reuses the refine-score.js LLM scaffold (getClassificationClient + client.complete + Promise.race timeout; string OR {content}); deterministic keyword fallback on stub/timeout/parse-fail. **Never mints.**
- **CLI** `scripts/eva-distill-brainstorm.js`: top-N `roadmap_wave_items` by `metadata.refine_composite_score` (DESC NULLS LAST), enriched from `eva_todoist_intake`/`eva_youtube_intake`; **defaults to `--dry-run` (zero DB writes)**; `--apply` enqueues to the chairman review queue via the idx-0 writer `enqueueDistilledCandidate`. main-guard + `@wire-check-exempt`.
- **19 unit tests** (AI-path, {content}, fallback triggers, dry-run no-write, --apply mapping, ordering).

## Why
The distillation half of the durable belt-supply lever: raw todoist/youtube captures become clean, chairman-reviewable SD candidates instead of belt noise. Dry-run smoke turned 5 raw captures into buildable SD titles (5/5 via LLM, 0 writes).

## Safety
No mint path (dry-run default + writer-only --apply → review queue, not belt; promotion gated by the disposition gate, idx-1). Builds safely in parallel with the in-flight idx-1.

LEAD val PASS (92) · testing PASS (92, 19/19) · retro 90 · handoffs LEAD-TO-PLAN 96 / PLAN-TO-EXEC 99 / EXEC-TO-PLAN 95 / PLAN-TO-LEAD 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)