### PR TITLE
chore(SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-C): register eva:distill-brainstorm npm entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "llm:canary:history": "node scripts/llm-canary-control.js history",
     "separability:delta": "node scripts/separability-delta.js",
     "eva:health": "node scripts/eva-health-check.cjs",
+    "eva:distill-brainstorm": "node scripts/eva-distill-brainstorm.js",
     "eva:run": "node scripts/eva-run.js",
     "eva:stage": "node scripts/eva/run-stage.js",
     "eva:retire-pilot-ventures": "node scripts/eva/retire-pilot-ventures.mjs",

--- a/scripts/eva-distill-brainstorm.js
+++ b/scripts/eva-distill-brainstorm.js
@@ -1,8 +1,4 @@
 #!/usr/bin/env node
-// @wire-check-exempt: operator/chairman-invoked CLI (node scripts/eva-distill-brainstorm.js), the
-// chairman quality-validation entry point for FR-4. Defaults to --dry-run (zero DB writes); imports
-// the distiller core (lib/integrations/distill-brainstorm.js) and the idx-0 queue writer. Unit-tested
-// (tests/unit/eva/distill-brainstorm.test.js + eva-distill-brainstorm-cli.test.js).
 /**
  * eva-distill-brainstorm.js — chairman-validation CLI for the brainstorm distiller.
  *


### PR DESCRIPTION
Follow-up to PR #5117. Registers `eva:distill-brainstorm` in package.json so the distiller CLI is a discovered wire-check entry point, making `lib/integrations/distill-brainstorm.js` reachable on main via its import (and removes the now-unneeded @wire-check-exempt marker on the CLI). The entry-point fix was added after #5117 squash-merged, so this lands it on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)