### PR TITLE
chore(SD-LEO-INFRA-CASCADE-KR-RECOMPUTE-GOV31-001): wire gov:recompute-cascade-kr npm entry (WIRE_CHECK_GATE)

### DIFF
--- a/lib/governance/cascade-layer-health.js
+++ b/lib/governance/cascade-layer-health.js
@@ -1,0 +1,193 @@
+/**
+ * Cascade-layer health recomputer (SD-LEO-INFRA-CASCADE-KR-RECOMPUTE-GOV31-001)
+ *
+ * KR-GOV-3.1 ("Governance cascade layers operational: 6 of 6") was frozen at a dead 2026-02
+ * bootstrap current_value=2/6 (last_updated_by=null) — no recompute job existed, so the number
+ * never reflected reality. This module derives the value HONESTLY from a per-layer operational
+ * predicate and writes it via the canonical key_results update.
+ *
+ * Per-layer health predicate (ALL THREE conjuncts must be POSITIVELY true for a layer to pass):
+ *   1. dataRows       — every backing table for the layer has >0 active rows
+ *   2. cliResolves    — the layer's canonical management CLI script exists on disk
+ *   3. validatorReads — cascade-validator.js reads/validates the layer (its marker is in the source)
+ *
+ * ANTI-INFLATION BY CONSTRUCTION: a layer passes ONLY on all-three-positive; any missing signal
+ * (no rows / missing CLI / absent validator marker / a query error) FAILS the layer. So the
+ * recomputer can only ever report FEWER-OR-EQUAL passing layers than reality — it can never inflate.
+ * It writes 6 only when all 6 layers independently pass.
+ *
+ * PURE-CORE: checkLayerHealth/computeCascadeHealth/recomputeKrGov31 take injectable deps
+ * (supabase, fileExists, validatorSource, currentYear, now) so the predicate + recomputer are
+ * deterministically unit-testable without DB/fs/clock.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join as joinPath } from 'node:path';
+
+export const KR_CODE = 'KR-GOV-3.1';
+export const TARGET_LAYERS = 6;
+export const RECOMPUTE_WRITER = 'CASCADE-RECOMPUTE';
+
+// Repo root (lib/governance/<file> → up two). Used only by the default (non-injected) dep loaders.
+const REPO_ROOT = joinPath(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const VALIDATOR_REL = 'scripts/modules/governance/cascade-validator.js';
+
+/**
+ * The 6 governance-cascade layers, each with its backing table(s) + active filter, its canonical
+ * management CLI (existence = the "CLI resolves" signal), and the marker proving cascade-validator.js
+ * reads the layer. Multi-table layers (constitution, okr) require BOTH tables to have rows.
+ * Verified against scripts/modules/governance/cascade-validator.js + scripts/eva/*-command.mjs.
+ */
+export const CASCADE_LAYERS = [
+  {
+    key: 'mission',
+    tables: [{ table: 'missions', filter: (q) => q.eq('status', 'active') }],
+    cli: 'scripts/eva/mission-command.mjs',
+    validatorMarker: "layer: 'mission'",
+  },
+  {
+    key: 'constitution',
+    tables: [
+      { table: 'aegis_constitutions', filter: (q) => q.eq('is_active', true) },
+      { table: 'aegis_rules', filter: (q) => q.eq('is_active', true) },
+    ],
+    cli: 'scripts/eva/constitution-command.mjs',
+    validatorMarker: "layer: 'constitution'",
+  },
+  {
+    key: 'vision',
+    tables: [{ table: 'eva_vision_documents', filter: (q) => q.eq('status', 'active') }],
+    cli: 'scripts/eva/vision-command.mjs',
+    validatorMarker: "layer: 'vision'",
+  },
+  {
+    key: 'strategy',
+    tables: [{ table: 'strategic_themes', filter: (q, year) => q.eq('status', 'active').eq('year', year) }],
+    cli: 'scripts/eva/strategy-command.mjs',
+    validatorMarker: "layer: 'strategy'",
+  },
+  {
+    key: 'okr',
+    tables: [
+      { table: 'objectives', filter: (q) => q.eq('is_active', true) },
+      { table: 'key_results', filter: (q) => q.eq('is_active', true) },
+    ],
+    cli: 'scripts/eva/okr-command.mjs',
+    validatorMarker: "layer: 'okr'",
+  },
+  {
+    key: 'sd',
+    // The SD layer is the corpus itself; any row means the layer is populated. The validator reads
+    // strategic_directives_v2 in validateCascadeAtHandoff (parent-SD cascade), so the table name is
+    // the read marker.
+    tables: [{ table: 'strategic_directives_v2', filter: null }],
+    cli: 'scripts/leo-create-sd.js',
+    validatorMarker: 'strategic_directives_v2',
+  },
+];
+
+/** Count rows for a table with an optional active filter. Any error → {ok:false} (fails the layer). */
+async function countRows(supabase, table, applyFilter, currentYear) {
+  try {
+    let q = supabase.from(table).select('id', { count: 'exact', head: true });
+    if (applyFilter) q = applyFilter(q, currentYear);
+    const { count, error } = await q;
+    if (error) return { ok: false, count: 0 };
+    return { ok: true, count: count || 0 };
+  } catch {
+    return { ok: false, count: 0 };
+  }
+}
+
+/**
+ * Compute the 3-conjunct health predicate for one layer. ALL THREE must be positively true to pass.
+ * @param {Object} layer - a CASCADE_LAYERS entry
+ * @param {{supabase:Object, fileExists:Function, validatorSource:string, currentYear:number}} deps
+ * @returns {Promise<{layer:string, dataRows:boolean, cliResolves:boolean, validatorReads:boolean, pass:boolean}>}
+ */
+export async function checkLayerHealth(layer, deps) {
+  const { supabase, fileExists, validatorSource, currentYear } = deps;
+
+  // (1) data rows: EVERY backing table must have >0 active rows (conservative AND).
+  let dataRows = true;
+  for (const t of layer.tables) {
+    const r = await countRows(supabase, t.table, t.filter, currentYear);
+    if (!r.ok || r.count <= 0) { dataRows = false; break; }
+  }
+
+  // (2) the layer's canonical CLI exists on disk.
+  const cliResolves = typeof fileExists === 'function' ? !!fileExists(layer.cli) : false;
+
+  // (3) cascade-validator reads the layer (its marker is present in the validator source).
+  const validatorReads = typeof validatorSource === 'string' && validatorSource.includes(layer.validatorMarker);
+
+  return { layer: layer.key, dataRows, cliResolves, validatorReads, pass: dataRows && cliResolves && validatorReads };
+}
+
+/** Default fileExists: resolve a repo-root-relative path on disk. */
+function defaultFileExists(relPath) {
+  return existsSync(joinPath(REPO_ROOT, relPath));
+}
+
+/** Default validator source loader (empty string on read failure → validatorReads false, conservative). */
+function defaultValidatorSource() {
+  try { return readFileSync(joinPath(REPO_ROOT, VALIDATOR_REL), 'utf8'); }
+  catch { return ''; }
+}
+
+/**
+ * Compute health for all 6 cascade layers. passingCount = number of layers passing all 3 conjuncts.
+ * @param {{supabase:Object, fileExists?:Function, validatorSource?:string, currentYear?:number}} deps
+ * @returns {Promise<{layers:Array, passingCount:number}>}
+ */
+export async function computeCascadeHealth(deps) {
+  const resolved = {
+    supabase: deps.supabase,
+    fileExists: deps.fileExists || defaultFileExists,
+    validatorSource: deps.validatorSource !== undefined ? deps.validatorSource : defaultValidatorSource(),
+    currentYear: deps.currentYear,
+  };
+  const layers = [];
+  for (const layer of CASCADE_LAYERS) layers.push(await checkLayerHealth(layer, resolved));
+  return { layers, passingCount: layers.filter((l) => l.pass).length };
+}
+
+/**
+ * Derive KR-GOV-3.1 current_value from honest per-layer health and (when apply) write it via the
+ * canonical key_results update (mirrors lib/eva/kr-reality-checker.js attemptKRUpdate). Dry-run by
+ * default (no write). Idempotent: a re-run writes the same derived value.
+ *
+ * @param {{supabase:Object, apply?:boolean, now?:string, fileExists?:Function, validatorSource?:string, currentYear?:number}} opts
+ * @returns {Promise<{before:(number|null), passingCount:number, status:string, perLayer:Array, wrote:boolean}>}
+ */
+export async function recomputeKrGov31(opts) {
+  const { supabase, apply = false } = opts;
+  const currentYear = opts.currentYear !== undefined ? opts.currentYear : new Date().getFullYear();
+  const now = opts.now || new Date().toISOString();
+
+  const health = await computeCascadeHealth({ supabase, fileExists: opts.fileExists, validatorSource: opts.validatorSource, currentYear });
+  const passingCount = health.passingCount;
+  // ANTI-INFLATION: status 'achieved' requires the FULL target; anything less is 'at_risk'.
+  const status = passingCount >= TARGET_LAYERS ? 'achieved' : 'at_risk';
+
+  let before = null;
+  try {
+    const { data } = await supabase.from('key_results').select('current_value').eq('code', KR_CODE).maybeSingle();
+    before = data ? data.current_value : null;
+  } catch { before = null; }
+
+  let wrote = false;
+  if (apply) {
+    const { error } = await supabase
+      .from('key_results')
+      .update({ current_value: passingCount, status, last_updated_by: RECOMPUTE_WRITER, updated_at: now })
+      .eq('code', KR_CODE);
+    if (error) throw new Error(`KR-GOV-3.1 write failed: ${error.message}`);
+    wrote = true;
+  }
+
+  return { before, passingCount, status, perLayer: health.layers, wrote };
+}
+
+export default { CASCADE_LAYERS, checkLayerHealth, computeCascadeHealth, recomputeKrGov31, KR_CODE, TARGET_LAYERS };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "fleet:down-alert:cron": "node scripts/fleet-down-alert.mjs",
     "cascade:status": "node scripts/cron/cascade-status.mjs",
     "cascade:snapshot:capture": "node scripts/test-helpers/capture-crongenius-snapshot.mjs",
+    "gov:recompute-cascade-kr": "node scripts/governance/recompute-cascade-kr.mjs",
     "backfill:pr-tracking": "node scripts/backfill-pr-tracking.js",
     "test-database": "node scripts/test-database.js",
     "new-sd": "node scripts/new-strategic-directive.js",

--- a/scripts/governance/recompute-cascade-kr.mjs
+++ b/scripts/governance/recompute-cascade-kr.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Recompute KR-GOV-3.1 from honest per-layer cascade health.
+ * (SD-LEO-INFRA-CASCADE-KR-RECOMPUTE-GOV31-001)
+ *
+ * Usage:
+ *   node scripts/governance/recompute-cascade-kr.mjs            # dry-run (default): report, NO write
+ *   node scripts/governance/recompute-cascade-kr.mjs --apply    # governed write to key_results
+ *   node scripts/governance/recompute-cascade-kr.mjs --json     # machine-readable
+ *
+ * main-guarded so recomputeKrGov31/computeCascadeHealth stay unit-testable.
+ */
+import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
+import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
+import { recomputeKrGov31, TARGET_LAYERS, KR_CODE } from '../../lib/governance/cascade-layer-health.js';
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const json = process.argv.includes('--json');
+  const supabase = createSupabaseServiceClient();
+
+  const result = await recomputeKrGov31({ supabase, apply });
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(0);
+  }
+
+  console.log('');
+  console.log('='.repeat(64));
+  console.log(`  CASCADE KR RECOMPUTE — ${KR_CODE} (${apply ? 'APPLY' : 'DRY-RUN'})`);
+  console.log('='.repeat(64));
+  const icon = (b) => (b ? '+' : 'X');
+  console.log('  Layer         | data | cli | validator | PASS');
+  console.log('  ' + '-'.repeat(50));
+  for (const l of result.perLayer) {
+    console.log(`  ${l.layer.padEnd(13)} |  ${icon(l.dataRows)}   |  ${icon(l.cliResolves)}  |     ${icon(l.validatorReads)}     |  ${l.pass ? 'PASS' : 'fail'}`);
+  }
+  console.log('  ' + '-'.repeat(50));
+  console.log(`  Derived value: ${result.passingCount}/${TARGET_LAYERS}  (was ${result.before === null ? 'null' : result.before})  status=${result.status}`);
+  console.log(`  ${apply ? (result.wrote ? '✅ written to key_results (last_updated_by=CASCADE-RECOMPUTE)' : '⚠ not written') : 'ℹ dry-run — no write (use --apply)'}`);
+  console.log('='.repeat(64));
+  process.exit(0);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => { console.error('recompute-cascade-kr failed:', err?.message || err); process.exit(1); });
+}

--- a/tests/unit/cascade-layer-health.test.js
+++ b/tests/unit/cascade-layer-health.test.js
@@ -1,0 +1,136 @@
+// SD-LEO-INFRA-CASCADE-KR-RECOMPUTE-GOV31-001 — honest per-layer cascade health + KR-GOV-3.1 recompute.
+// MANDATORY anti-inflation property: the recomputer writes 6 ONLY when all 6 layers pass all three
+// conjuncts (data rows AND CLI exists AND validator reads the layer); any forced failure — in ANY of
+// the three dimensions — keeps the derived value < 6. It can only ever under-report, never inflate.
+import { describe, it, expect } from 'vitest';
+import {
+  computeCascadeHealth,
+  recomputeKrGov31,
+  CASCADE_LAYERS,
+  KR_CODE,
+  RECOMPUTE_WRITER,
+} from '../../lib/governance/cascade-layer-health.js';
+
+const YEAR = 2026;
+const ALL_MARKERS = ["layer: 'mission'", "layer: 'constitution'", "layer: 'vision'", "layer: 'strategy'", "layer: 'okr'", 'strategic_directives_v2'].join('\n');
+// Every backing table populated → the data-rows conjunct passes for all 6 layers.
+const FULL_COUNTS = {
+  missions: 1, aegis_constitutions: 1, aegis_rules: 2, eva_vision_documents: 1,
+  strategic_themes: 11, objectives: 3, key_results: 5, strategic_directives_v2: 100,
+};
+
+// Mock supabase: count queries (head:true) resolve to {count} per table; key_results read returns
+// krBefore; key_results update captures the payload. 'ERR' count sentinel → a query error.
+function mockSb({ counts = FULL_COUNTS, krBefore = 2, updateError = null, onUpdate } = {}) {
+  return {
+    from(table) {
+      return {
+        select(_cols, opts) {
+          if (opts && opts.head) {
+            const builder = {
+              eq() { return builder; },
+              then(resolve) {
+                const c = counts[table];
+                resolve(c === 'ERR' ? { count: 0, error: { message: 'boom' } } : { count: c ?? 0, error: null });
+              },
+            };
+            return builder;
+          }
+          // key_results current_value read
+          return { eq() { return { maybeSingle: () => Promise.resolve({ data: { current_value: krBefore }, error: null }) }; } };
+        },
+        update(payload) {
+          return { eq(col, val) { if (onUpdate) onUpdate({ payload, col, val }); return Promise.resolve({ error: updateError }); } };
+        },
+      };
+    },
+  };
+}
+
+const fullDeps = (over = {}) => ({
+  supabase: mockSb(over.sb || {}),
+  fileExists: over.fileExists || (() => true),
+  validatorSource: over.validatorSource !== undefined ? over.validatorSource : ALL_MARKERS,
+  currentYear: YEAR,
+});
+
+describe('computeCascadeHealth — all 6 layers pass', () => {
+  it('passingCount = 6 when every layer has data + CLI + validator marker', async () => {
+    const { layers, passingCount } = await computeCascadeHealth(fullDeps());
+    expect(passingCount).toBe(6);
+    expect(layers.every((l) => l.pass)).toBe(true);
+    expect(layers.map((l) => l.layer)).toEqual(['mission', 'constitution', 'vision', 'strategy', 'okr', 'sd']);
+  });
+});
+
+describe('ANTI-INFLATION — a forced failure in ANY conjunct keeps the value < 6', () => {
+  it('(data rows) an empty table fails its layer → passingCount = 5', async () => {
+    const { layers, passingCount } = await computeCascadeHealth(fullDeps({ sb: { counts: { ...FULL_COUNTS, missions: 0 } } }));
+    expect(passingCount).toBe(5);
+    expect(layers.find((l) => l.layer === 'mission').dataRows).toBe(false);
+    expect(layers.find((l) => l.layer === 'mission').pass).toBe(false);
+  });
+
+  it('(data rows) a query ERROR fails its layer (conservative) → < 6', async () => {
+    const { passingCount } = await computeCascadeHealth(fullDeps({ sb: { counts: { ...FULL_COUNTS, eva_vision_documents: 'ERR' } } }));
+    expect(passingCount).toBe(5);
+  });
+
+  it('(data rows) a multi-table layer fails when EITHER table is empty (okr: key_results=0)', async () => {
+    const { layers, passingCount } = await computeCascadeHealth(fullDeps({ sb: { counts: { ...FULL_COUNTS, key_results: 0 } } }));
+    expect(passingCount).toBe(5);
+    expect(layers.find((l) => l.layer === 'okr').pass).toBe(false);
+  });
+
+  it('(cli) a missing CLI script fails its layer → < 6', async () => {
+    const missionCli = CASCADE_LAYERS.find((l) => l.key === 'mission').cli;
+    const { layers, passingCount } = await computeCascadeHealth(fullDeps({ fileExists: (p) => p !== missionCli }));
+    expect(passingCount).toBe(5);
+    expect(layers.find((l) => l.layer === 'mission').cliResolves).toBe(false);
+  });
+
+  it('(validator) an absent validator marker fails its layer → < 6', async () => {
+    const noOkr = ALL_MARKERS.replace("layer: 'okr'", '');
+    const { layers, passingCount } = await computeCascadeHealth(fullDeps({ validatorSource: noOkr }));
+    expect(passingCount).toBe(5);
+    expect(layers.find((l) => l.layer === 'okr').validatorReads).toBe(false);
+  });
+
+  it('empty validator source fails ALL layers → 0', async () => {
+    const { passingCount } = await computeCascadeHealth(fullDeps({ validatorSource: '' }));
+    expect(passingCount).toBe(0);
+  });
+});
+
+describe('recomputeKrGov31 — write semantics', () => {
+  it('apply=false (dry-run): NO write, returns the would-be value', async () => {
+    let wrote = false;
+    const supabase = mockSb({ onUpdate: () => { wrote = true; } });
+    const r = await recomputeKrGov31({ supabase, apply: false, now: '2026-06-23T00:00:00Z', validatorSource: ALL_MARKERS, currentYear: YEAR });
+    expect(wrote).toBe(false);
+    expect(r.wrote).toBe(false);
+    expect(r.passingCount).toBe(6);
+    expect(r.before).toBe(2);
+  });
+
+  it('apply=true: writes current_value=passingCount to KR-GOV-3.1 with last_updated_by set', async () => {
+    let captured = null;
+    const supabase = mockSb({ onUpdate: (u) => { captured = u; } });
+    const r = await recomputeKrGov31({ supabase, apply: true, now: '2026-06-23T00:00:00Z', validatorSource: ALL_MARKERS, currentYear: YEAR });
+    expect(r.wrote).toBe(true);
+    expect(captured.col).toBe('code');
+    expect(captured.val).toBe(KR_CODE);
+    expect(captured.payload.current_value).toBe(6);
+    expect(captured.payload.status).toBe('achieved');
+    expect(captured.payload.last_updated_by).toBe(RECOMPUTE_WRITER);
+  });
+
+  it('apply=true with a failing layer: writes < 6 and status at_risk (anti-inflation end-to-end)', async () => {
+    let captured = null;
+    const supabase = mockSb({ counts: { ...FULL_COUNTS, missions: 0 }, onUpdate: (u) => { captured = u; } });
+    const r = await recomputeKrGov31({ supabase, apply: true, now: '2026-06-23T00:00:00Z', validatorSource: ALL_MARKERS, currentYear: YEAR });
+    expect(r.passingCount).toBe(5);
+    expect(captured.payload.current_value).toBe(5);
+    expect(captured.payload.status).toBe('at_risk');
+  });
+});


### PR DESCRIPTION
Follow-up to PR #5119: adds the package.json `gov:recompute-cascade-kr` script entry so the recomputer CLI + its imported lib are reachable from an entry point (WIRE_CHECK_GATE at LEAD-FINAL). One-line scripts addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)