### PR TITLE
feat(SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-D): disposition-coverage probe + <=50 batch clamp + isolation tests

### DIFF
--- a/scripts/eva-distill-brainstorm.js
+++ b/scripts/eva-distill-brainstorm.js
@@ -32,12 +32,25 @@ dotenv.config();
 
 const SOURCE_TABLES = { todoist: 'eva_todoist_intake', youtube: 'eva_youtube_intake' };
 
+// SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-D (FR-2): hard batch ceiling.
+// A scale-up over the ~429 unpromoted roadmap_wave_items must stay cost-bounded —
+// at most MAX_BATCH distilled per invocation regardless of --top. SSOT constant.
+export const MAX_BATCH = 50;
+
+/** Clamp a requested batch size into [1, MAX_BATCH], coercing NaN/garbage to the default 20. */
+export function clampBatch(topN) {
+  return Math.min(MAX_BATCH, Math.max(1, Number(topN) || 20));
+}
+
 /**
  * Load the top-N wave items by refine_composite_score, newest-safe.
  * Fetches the scored set and sorts client-side (PostgREST JSONB ordering is unreliable),
- * applying NULLS LAST then taking the top N.
+ * applying NULLS LAST then taking the top N. The batch is clamped to <=MAX_BATCH (FR-2)
+ * here — the shared DB-fetch chokepoint reached by both run() and main() — so the
+ * programmatic run({topN}) path is bounded, not just the CLI arg parse.
  */
 export async function loadTopWaveItems(supabase, topN = 20) {
+  const n = clampBatch(topN);
   const { data, error } = await supabase
     .from('roadmap_wave_items')
     .select('id, wave_id, source_type, source_id, title, metadata, item_disposition')
@@ -49,7 +62,36 @@ export async function loadTopWaveItems(supabase, topN = 20) {
       typeof r.metadata?.refine_composite_score === 'number' ? r.metadata.refine_composite_score : null,
   }));
   scored.sort((a, b) => (b.refine_composite_score ?? -1) - (a.refine_composite_score ?? -1));
-  return scored.slice(0, topN);
+  return scored.slice(0, n);
+}
+
+/**
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-D (FR-1): disposition-coverage probe.
+ * Standalone count_ratio over roadmap_wave_items: actively-dispositioned (item_disposition
+ * <> 'pending') / total. NOT a VDR vision-ladder capability — the "Backlog distilled and
+ * dispositioned" ladder label is already bound to sd_backlog_map and adding a new capability
+ * without a matching vision_ladder_criteria row would break the gauge-coherence invariant.
+ * Read-only. Returns { value, status, numerator, denominator, detail }.
+ */
+export async function dispositionCoverage(supabase) {
+  const { count: denom, error: dErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id', { count: 'exact', head: true });
+  if (dErr) return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: `denom error: ${dErr.message}` };
+  const { count: numer, error: nErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id', { count: 'exact', head: true })
+    .neq('item_disposition', 'pending');
+  if (nErr) return { value: null, status: 'unknown', numerator: 0, denominator: denom || 0, detail: `numer error: ${nErr.message}` };
+  if (!denom) return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: 'empty corpus (0 items)' };
+  const value = (numer || 0) / denom;
+  return {
+    value,
+    status: 'ok',
+    numerator: numer || 0,
+    denominator: denom,
+    detail: `${numer || 0}/${denom} actively-dispositioned (item_disposition <> 'pending')`
+  };
 }
 
 /** Enrich a wave item from its source intake table (mirrors eva-intake-refine.js). */
@@ -108,6 +150,15 @@ async function main() {
     process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.SUPABASE_SERVICE_ROLE_KEY,
   );
+
+  // FR-1: read-only disposition-coverage probe (no distillation, no writes).
+  if (args.includes('--coverage')) {
+    const cov = await dispositionCoverage(supabase);
+    console.log(`\n── Brainstorm corpus disposition coverage ──`);
+    console.log(`   ${cov.detail}`);
+    console.log(`   coverage: ${cov.value === null ? 'unknown' : (cov.value * 100).toFixed(2) + '%'} (status=${cov.status})`);
+    return;
+  }
 
   console.log(`\n── Brainstorm Distiller ${apply ? '(APPLY — writing to chairman review queue)' : '(DRY-RUN — zero DB writes)'} ──`);
   console.log(`   top ${topN} by refine_composite_score\n`);

--- a/tests/unit/eva/distill-brainstorm-isolation.test.js
+++ b/tests/unit/eva/distill-brainstorm-isolation.test.js
@@ -1,0 +1,108 @@
+/**
+ * SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-D — observability + bounded scale-up + isolation.
+ * FR-1 dispositionCoverage probe, FR-2 <=50 batch clamp, FR-3 dry-run/apply isolation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the distiller core + queue writer so run() is testable without a live DB / LLM.
+vi.mock('../../../lib/integrations/distill-brainstorm.js', () => ({
+  distillItem: vi.fn(async () => ({ payload: { title: 'x', sd_type: 'infrastructure', confidence_tier: 'low' }, method: 'keyword' })),
+  toQueueCandidate: vi.fn((payload, id, score) => ({ payload, id, score })),
+}));
+vi.mock('../../../lib/eva/consultant/distillation-queue-writer.js', () => ({
+  enqueueDistilledCandidate: vi.fn(async () => ({ ok: true })),
+}));
+
+import { run, loadTopWaveItems, clampBatch, MAX_BATCH, dispositionCoverage } from '../../../scripts/eva-distill-brainstorm.js';
+import { enqueueDistilledCandidate } from '../../../lib/eva/consultant/distillation-queue-writer.js';
+
+// Mock supabase: loadTopWaveItems (.from().select().not()) + enrichWaveItem (.from().select().eq().maybeSingle()).
+function mockSupabase(waveItemCount) {
+  const items = Array.from({ length: waveItemCount }, (_, i) => ({
+    id: `wi-${i}`, wave_id: 'w', source_type: 'todoist', source_id: `s-${i}`,
+    title: `item ${i}`, metadata: { refine_composite_score: 1 - i / 1000 }, item_disposition: 'pending',
+  }));
+  return {
+    from(table) {
+      return {
+        select() {
+          return {
+            not: async () => ({ data: items, error: null }),
+            eq() { return { maybeSingle: async () => ({ data: null }) }; },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('SD-...-001-D: distiller observability + bounds + isolation', () => {
+  beforeEach(() => { enqueueDistilledCandidate.mockClear(); });
+
+  it('FR-2: clampBatch coerces into [1, MAX_BATCH] with NaN -> default 20', () => {
+    expect(MAX_BATCH).toBe(50);
+    expect(clampBatch(100)).toBe(50);
+    expect(clampBatch(50)).toBe(50);
+    expect(clampBatch(20)).toBe(20);
+    expect(clampBatch(1)).toBe(1);
+    expect(clampBatch(0)).toBe(20);   // 0 is falsy -> treated as unset -> default 20
+    expect(clampBatch(-5)).toBe(1);   // -5 truthy -> floored to 1
+    expect(clampBatch(NaN)).toBe(20);
+    expect(clampBatch(undefined)).toBe(20);
+    expect(clampBatch('abc')).toBe(20);
+  });
+
+  it('FR-2: loadTopWaveItems caps at MAX_BATCH even when topN exceeds it', async () => {
+    const sb = mockSupabase(120);
+    expect((await loadTopWaveItems(sb, 100)).length).toBe(50);
+    expect((await loadTopWaveItems(sb, 10)).length).toBe(10);
+  });
+
+  it('FR-3: run({apply:false}) performs ZERO enqueue calls (dry-run never writes)', async () => {
+    const sb = mockSupabase(5);
+    const results = await run({ supabase: sb, apply: false, topN: 5 });
+    expect(results.length).toBe(5);
+    expect(results.every(r => r.enqueued === false)).toBe(true);
+    expect(enqueueDistilledCandidate).toHaveBeenCalledTimes(0);
+  });
+
+  it('FR-3: run({apply:true}) enqueues one candidate per item', async () => {
+    const sb = mockSupabase(4);
+    const results = await run({ supabase: sb, apply: true, topN: 4 });
+    expect(results.every(r => r.enqueued === true)).toBe(true);
+    expect(enqueueDistilledCandidate).toHaveBeenCalledTimes(4);
+  });
+
+  it('FR-2+FR-3: run({topN:100}) processes at most 50 (clamp via loadTopWaveItems)', async () => {
+    const sb = mockSupabase(120);
+    const results = await run({ supabase: sb, apply: false, topN: 100 });
+    expect(results.length).toBe(50);
+  });
+
+  it('FR-1: dispositionCoverage = (item_disposition <> pending) / total', async () => {
+    // count probe mock: head/count select; .neq() narrows the numerator
+    const sb = {
+      from() {
+        let neq = false;
+        const chain = {
+          select() { return chain; },
+          neq() { neq = true; return chain; },
+          then(resolve) { resolve({ count: neq ? 33 : 741, error: null }); },
+        };
+        return chain;
+      },
+    };
+    const cov = await dispositionCoverage(sb);
+    expect(cov.denominator).toBe(741);
+    expect(cov.numerator).toBe(33);
+    expect(cov.value).toBeCloseTo(33 / 741, 5);
+    expect(cov.status).toBe('ok');
+  });
+
+  it('FR-1: dispositionCoverage returns status=unknown on empty corpus', async () => {
+    const sb = { from() { const c = { select() { return c; }, neq() { return c; }, then(r) { r({ count: 0, error: null }); } }; return c; } };
+    const cov = await dispositionCoverage(sb);
+    expect(cov.status).toBe('unknown');
+    expect(cov.value).toBe(null);
+  });
+});


### PR DESCRIPTION
idx-3 (observability + bounded scale-up + isolation safety) of the Brainstorm Distillation Pipeline orchestrator. Builds on CHILD C's distiller (PR #5117).

## FR-1 — disposition-coverage probe (standalone)
`dispositionCoverage(supabase)`: count_ratio over roadmap_wave_items (`item_disposition <> 'pending'` / total → the real ~4.45% baseline). **Deliberately NOT a VDR vision-ladder capability** — the 'Backlog distilled and dispositioned' ladder label is already bound to `sd_backlog_map`, and adding a new capability without a matching `vision_ladder_criteria` row would break the gauge-coherence invariant (withholds the whole gauge). Read-only; `--coverage` CLI flag.

## FR-2 — bounded scale-up
`MAX_BATCH=50` SSOT + `clampBatch()` (NaN-coerced); clamp lives in `loadTopWaveItems` (the shared DB-fetch chokepoint) so `run({topN})` is bounded, not just CLI arg parse.

## FR-3 — dry-run/apply isolation
7 unit tests: `run({apply:false})` → 0 `enqueueDistilledCandidate` calls; `run({apply:true})` → enqueues per item; `topN:100` → ≤50.

## Verify-the-premise wins (sub-agent catches)
- DB agent: `item_disposition` DEFAULTs to 'pending' (never null) → 'IS NOT NULL' would be a meaningless 100%; corrected to '<> pending'.
- Design agent: the vision-gauge coherence trap → FR-1 implemented standalone.

## Evidence
- 7/7 unit tests; Design CONDITIONAL_PASS, DB CONDITIONAL_PASS, Security 95, Stories 95, Testing(EXEC) 98
- Handoffs: LEAD-TO-PLAN 95, EXEC-TO-PLAN 98, PLAN-TO-LEAD 100
- No vdr-registry change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)