### PR TITLE
feat(harness): blocked-claim coordinator escalation (park-blocked-claim) + Stop-hook guidance

### DIFF
--- a/scripts/__tests__/park-blocked-claim.test.js
+++ b/scripts/__tests__/park-blocked-claim.test.js
@@ -1,0 +1,75 @@
+// Tests for scripts/park-blocked-claim.cjs — the executable form of loop-rule 4b
+// (a worker that hits a blocker /signals the coordinator + parks the claim instead of
+// self-authorizing the irreversible action or silently re-arming a wakeup to retry it).
+// Pure core only (buildParkPatch + parseArgs) — no DB, unit tier.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const MOD = path.resolve(__dirname, '../park-blocked-claim.cjs'); // require.main guard → main() does NOT run
+const { buildParkPatch, parseArgs } = require(MOD);
+
+describe('park-blocked-claim — buildParkPatch (pure)', () => {
+  const base = {
+    sessionId: 'sess-A',
+    reason: 'migration must be applied by the database sub-agent, not a worker',
+    nowIso: '2026-06-24T12:00:00.000Z',
+  };
+
+  it('records the blocker under metadata.blocker (status open) and preserves existing metadata', () => {
+    const sd = { metadata: { target_application: 'EHG', pr_number: 713 }, claiming_session_id: 'sess-A' };
+    const { metadataPatch } = buildParkPatch({ ...base, sd });
+    expect(metadataPatch.target_application).toBe('EHG'); // preserved
+    expect(metadataPatch.pr_number).toBe(713);            // preserved
+    expect(metadataPatch.blocker).toMatchObject({
+      reason: base.reason, status: 'open', signalled_at: base.nowIso, parked_by: 'sess-A',
+    });
+  });
+
+  it('releases the claim ONLY when this session holds it', () => {
+    const mine = { metadata: {}, claiming_session_id: 'sess-A' };
+    const foreign = { metadata: {}, claiming_session_id: 'sess-B' };
+    const unclaimed = { metadata: {}, claiming_session_id: null };
+    expect(buildParkPatch({ ...base, sd: mine }).releaseClaim).toBe(true);
+    expect(buildParkPatch({ ...base, sd: foreign }).releaseClaim).toBe(false); // never clear a foreign claim
+    expect(buildParkPatch({ ...base, sd: unclaimed }).releaseClaim).toBe(false);
+  });
+
+  it('honors --no-release (releaseRequested=false) even when this session holds the claim', () => {
+    const sd = { metadata: {}, claiming_session_id: 'sess-A' };
+    expect(buildParkPatch({ ...base, sd, releaseRequested: false }).releaseClaim).toBe(false);
+  });
+
+  it('handles a missing metadata object without throwing', () => {
+    const sd = { claiming_session_id: 'sess-A' };
+    const { metadataPatch, releaseClaim } = buildParkPatch({ ...base, sd });
+    expect(metadataPatch.blocker.status).toBe('open');
+    expect(releaseClaim).toBe(true);
+  });
+
+  it('caps an over-long blocker reason at 1000 chars', () => {
+    const sd = { metadata: {}, claiming_session_id: 'sess-A' };
+    const long = 'x'.repeat(5000);
+    const { metadataPatch } = buildParkPatch({ ...base, sd, reason: long });
+    expect(metadataPatch.blocker.reason.length).toBe(1000);
+  });
+});
+
+describe('park-blocked-claim — parseArgs (pure)', () => {
+  it('defaults to signal=true, release=true, type=stuck, severity=high', () => {
+    const a = parseArgs(['SD-X-001', '--reason', 'blocked on prod migration']);
+    expect(a._[0]).toBe('SD-X-001');
+    expect(a.reason).toBe('blocked on prod migration');
+    expect(a).toMatchObject({ signal: true, release: true, type: 'stuck', severity: 'high' });
+  });
+
+  it('parses --no-signal / --no-release / --type / --severity', () => {
+    const a = parseArgs(['SD-X-001', '--reason', 'r', '--no-signal', '--no-release', '--type', 'gate-bug', '--severity', 'critical']);
+    expect(a.signal).toBe(false);
+    expect(a.release).toBe(false);
+    expect(a.type).toBe('gate-bug');
+    expect(a.severity).toBe('critical');
+  });
+});

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -106,6 +106,14 @@ const REMINDER = [
   '       /signal feedback "winding down — finished <SD>, anything queued for me? idling ~180s"',
   '  4. Arm a SHORT grace ScheduleWakeup (~180s); on that tick RE-CHECK your inbox for a coordinator reply',
   '     BEFORE settling into the ~1200s idle cadence. (Short delay if work is in-flight, ~20min if truly idle.)',
+  // SD-LEO-INFRA-BLOCKED-CLAIM-COORDINATOR-ESCALATION-001: a worker must NOT self-authorize an
+  // irreversible/gated action (apply a prod migration, flip a gov flag, merge a sensitive PR) nor
+  // silently re-arm a wakeup to RETRY a blocked claim ("the wakeup-bypasses-the-blocker hole").
+  // Authorization + blocker-resolution are the coordinator lane (it escalates to the chairman).
+  '  • If your claim is BLOCKED on authorization / a database-sub-agent migration / a chairman gate /',
+  '    an external dependency: do NOT self-authorize and do NOT re-arm a wakeup to retry it. Escalate +',
+  '    park in ONE step: `node scripts/park-blocked-claim.cjs <SD-KEY> --reason "<what is blocked>"`',
+  '    (signals the coordinator + releases the claim), then /checkin for a DIFFERENT unblocked SD.',
   "  • To legitimately END the loop instead, set claude_sessions.loop_state='exited' for your session.",
   '(This reminder fires once — if you stop again it will let you through.)',
 ].join('\n');

--- a/scripts/park-blocked-claim.cjs
+++ b/scripts/park-blocked-claim.cjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * park-blocked-claim.cjs — the correct, single-command response when a CLAIMED SD is
+ * BLOCKED on something a worker may NOT self-resolve (authorization for an irreversible
+ * action, a prod migration that belongs to the database sub-agent, a chairman gate, an
+ * external dependency, etc.).
+ *
+ * It makes loop-rule 4b executable in one step:
+ *   1) /signal the specific blocker to the active coordinator (canonical worker-signal),
+ *   2) record the blocker on the SD and RELEASE the claim (park — recoverable; push WIP first),
+ *   3) print next-step guidance (claim a DIFFERENT unblocked SD).
+ *
+ * Why this exists (the failure it prevents): a worker that hits a blocker must NOT
+ * self-authorize the irreversible action, and must NOT silently re-arm a ScheduleWakeup
+ * to retry the same blocked claim ("the wakeup-bypasses-the-blocker hole"). Authorization
+ * and blocker-resolution are the coordinator's lane (which escalates to the chairman) — a
+ * worker escalates, parks, and switches to buildable work.
+ *
+ * Usage:
+ *   node scripts/park-blocked-claim.cjs <SD-KEY> --reason "<what is blocked + why a worker can't resolve it>"
+ *       [--type stuck|spec-conflict|gate-bug|other]   (default: stuck)
+ *       [--severity low|medium|high|critical]         (default: high)
+ *       [--no-signal]    (skip the coordinator signal — record + release only)
+ *       [--no-release]   (record the blocker but KEEP the claim — rare; default releases)
+ *
+ * CLAUDE_SESSION_ID must be set (the SessionStart hook provides it). The claim is released
+ * only if THIS session holds it (claiming_session_id === CLAUDE_SESSION_ID).
+ */
+
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+/**
+ * Pure decision core (unit-tested): given the live SD row + this session + the blocker
+ * reason, produce the metadata patch and whether to release the claim.
+ *
+ * - The blocker is recorded under metadata.blocker so the SD carries WHY it parked.
+ * - The claim is released ONLY when this session actually holds it (never steal/clear a
+ *   foreign session's claim), and only when releaseRequested is true.
+ *
+ * @param {{ sd: {metadata?:object, claiming_session_id?:string|null}, sessionId: string,
+ *           reason: string, nowIso: string, releaseRequested?: boolean }} args
+ * @returns {{ metadataPatch: object, releaseClaim: boolean }}
+ */
+function buildParkPatch({ sd, sessionId, reason, nowIso, releaseRequested = true }) {
+  const existing = (sd && sd.metadata) || {};
+  const metadataPatch = {
+    ...existing,
+    blocker: {
+      reason: String(reason || '').slice(0, 1000),
+      status: 'open',
+      signalled_at: nowIso,
+      parked_by: sessionId || null,
+    },
+  };
+  const holdsClaim = Boolean(sessionId) && sd && sd.claiming_session_id === sessionId;
+  return { metadataPatch, releaseClaim: Boolean(releaseRequested) && holdsClaim };
+}
+
+function parseArgs(argv) {
+  const out = { _: [], type: 'stuck', severity: 'high', signal: true, release: true, reason: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--no-signal') out.signal = false;
+    else if (a === '--no-release') out.release = false;
+    else if (a === '--reason') out.reason = argv[++i];
+    else if (a === '--type') out.type = argv[++i];
+    else if (a === '--severity') out.severity = argv[++i];
+    else if (!a.startsWith('--')) out._.push(a);
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const sdKey = args._[0];
+  const reason = args.reason || args._.slice(1).join(' ');
+  if (!sdKey || !reason) {
+    console.error('Usage: node scripts/park-blocked-claim.cjs <SD-KEY> --reason "<blocker>" [--type <t>] [--severity <s>] [--no-signal] [--no-release]');
+    process.exit(2);
+  }
+  const sessionId = process.env.CLAUDE_SESSION_ID || '';
+  if (!sessionId) {
+    console.error('park-blocked-claim: CLAUDE_SESSION_ID not set — cannot identify the claiming session.');
+    process.exit(2);
+  }
+
+  require('dotenv').config();
+  const { createClient } = require('@supabase/supabase-js');
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  // Load the live SD row (resolve by sd_key OR id).
+  const { data: rows, error: selErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, status, claiming_session_id, metadata')
+    .or(`sd_key.eq.${sdKey},id.eq.${sdKey}`)
+    .limit(1);
+  if (selErr) { console.error('park-blocked-claim: SD lookup failed:', selErr.message); process.exit(1); }
+  const sd = rows && rows[0];
+  if (!sd) { console.error(`park-blocked-claim: SD not found: ${sdKey}`); process.exit(1); }
+
+  // 1) Signal the blocker to the coordinator (canonical worker-signal — fail-soft).
+  let signalled = false;
+  if (args.signal) {
+    try {
+      execFileSync('node', [
+        path.join(__dirname, 'worker-signal.cjs'), args.type, reason,
+        '--severity', args.severity, '--links-sd', sd.sd_key,
+      ], { stdio: 'inherit' });
+      signalled = true;
+    } catch (e) {
+      console.error(`park-blocked-claim: coordinator signal failed (continuing to park): ${e.message}`);
+    }
+  }
+
+  // 2) Record the blocker + release the claim (only if this session holds it).
+  const nowIso = new Date().toISOString();
+  const { metadataPatch, releaseClaim } = buildParkPatch({
+    sd, sessionId, reason, nowIso, releaseRequested: args.release,
+  });
+  const update = { metadata: metadataPatch };
+  if (releaseClaim) update.claiming_session_id = null;
+  const { error: updErr } = await supabase
+    .from('strategic_directives_v2').update(update).eq('id', sd.id);
+  if (updErr) { console.error('park-blocked-claim: SD update failed:', updErr.message); process.exit(1); }
+
+  // 3) Guidance.
+  console.log('');
+  console.log(`🅿️  Parked blocked claim: ${sd.sd_key}`);
+  console.log(`   blocker:   ${reason.slice(0, 200)}`);
+  console.log(`   signalled: ${signalled ? `yes (coordinator, ${args.type}/${args.severity})` : 'no'}`);
+  console.log(`   claim:     ${releaseClaim ? 'RELEASED (parked recoverable — ensure WIP is pushed)' : 'kept (not held by this session, or --no-release)'}`);
+  console.log('   next:      do NOT re-arm a wakeup to retry this SD. Run /checkin to claim a DIFFERENT unblocked SD.');
+  console.log('');
+}
+
+if (require.main === module) {
+  main().catch((e) => { console.error('park-blocked-claim UNHANDLED:', e.message || e); process.exit(1); });
+}
+
+module.exports = { buildParkPatch, parseArgs };


### PR DESCRIPTION
## Why
When a worker hits a blocker it may **not** self-resolve — authorization for an irreversible action, a prod migration that belongs to the **database sub-agent**, a chairman gate, an external dependency — the correct behavior (loop-rule **4b**) is: `/signal` the coordinator, **park** the claim, and switch to buildable work. The coordinator owns authorization/blocker-resolution and escalates to the chairman.

This was an observed live failure: a worker (me) hit a "migration not applied to a separate prod DB" blocker and, instead of escalating, **held the blocked claim and armed a `ScheduleWakeup` to retry it** — the *"wakeup-bypasses-the-blocker hole"*: the Stop hook's allow-path treats *any* armed wakeup as legitimate continuation, so re-arming against a blocked claim slips through.

## What
- **`scripts/park-blocked-claim.cjs`** — one command that makes 4b executable:
  1. `/signal`s the blocker to the active coordinator (canonical `worker-signal.cjs`),
  2. records `metadata.blocker` and **releases the claim** — *only if this session holds it* (never clears a foreign claim; `--no-release` to keep it),
  3. prints "claim a DIFFERENT unblocked SD" guidance.
  Pure core (`buildParkPatch` / `parseArgs`) is unit-tested.
- **`scripts/hooks/stop-loop-wakeup-reminder.cjs`** — the wind-down REMINDER now teaches the blocked-claim escalation path (point at `park-blocked-claim.cjs`) rather than only wakeup-arming.

## Tests
- 7 new unit tests (`scripts/__tests__/park-blocked-claim.test.js`).
- Existing stop-hook tests unchanged and green — **27 total pass** (`vitest --project unit`).

## Deliberately NOT done (no silent cap)
A fully-automatic Stop-hook detector for the **silent** case (worker knows it's blocked, records nothing, just re-arms) was **not** added: the obvious proxy — "no `sd_phase_handoffs` row since the last tick" — **false-positives on legitimate multi-tick EXEC builds** (EXEC can span many ticks with no phase handoff). A robust progress signal is a follow-up; forcing a fragile detector would trap honest long builds.

## Companion protocol-section text (for a reviewer to insert into `leo_protocol_sections`, source of truth for CLAUDE_CORE)
> **Blocked claim / needs-authorization → escalate, don't self-resolve.** A worker never self-authorizes an irreversible or gated action (applying a prod migration — that's the database sub-agent's lane — flipping a governance flag, merging a sensitive PR) and never silently re-arms a ScheduleWakeup to retry a blocked claim. When blocked on authorization or a dependency you can't resolve: `node scripts/park-blocked-claim.cjs <SD-KEY> --reason "<blocker>"` (signals the coordinator + parks the claim), then `/checkin` for different unblocked work. The coordinator holds or escalates to the chairman.

This is opened for review rather than self-merged — it changes an enforcement-path hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)