### PR TITLE
fix(coordinator): worker-signal inbox drain-on-display — gate on acknowledged_at not read_at

### DIFF
--- a/scripts/coordinator-ack-signal.cjs
+++ b/scripts/coordinator-ack-signal.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * coordinator-ack-signal.cjs — coordinator-side ACK for WORKER /signal friction signals.
+ * SD-LEO-INFRA-SIGNAL-INBOX-DRAIN-ON-DISPLAY-001 (RCA 2026-06-24).
+ *
+ * Back-ports the proven Adam-advisory receipt model (coordinator-ack-adam.cjs +
+ * QF-20260621-174) to the worker-signal lane. Root cause fixed: printInbox() in
+ * fleet-dashboard.cjs used to mark a worker signal read_at ON RENDER and re-query on
+ * read_at IS NULL, so a single filtered/skimmed/parked-cron render permanently retired
+ * the signal — high-severity consults were silently lost. After the fix, printInbox
+ * stamps read_at (DELIVERED) on render but the SELECT gates on acknowledged_at IS NULL
+ * (ACTIONED), so a signal RE-SURFACES until the coordinator explicitly acks it here.
+ *
+ * `--signal <id>` stamps the top-level `acknowledged_at` column (the SAME ACTIONED marker
+ * the FR-4 signal-router `ackAndRouteLoneSignal` already writes) — the ONLY thing that
+ * retires the signal. Optional `--reply "<body>"` ALSO sends a coordinator_reply to the
+ * worker's sender_session + correlation_id (reusing coordinator-reply.cjs), gated behind
+ * COORDINATOR_TWOWAY_V2=on; the ack-stamp works regardless.
+ *
+ * Usage:
+ *   node scripts/coordinator-ack-signal.cjs --signal <id>
+ *   node scripts/coordinator-ack-signal.cjs --signal <id> --reply "<reply body>"
+ */
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
+const { isFullUuid } = require('../lib/coordinator/dispatch.cjs');
+const { sendCoordinatorReply } = require('./coordinator-reply.cjs');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--signal' || a === '--reply') {
+      flags[a.slice(2)] = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : true;
+    } else if (a.startsWith('--')) {
+      flags[a.slice(2)] = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : true;
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+async function main() {
+  const { flags, positional } = parseArgs(process.argv);
+  const signalId = typeof flags.signal === 'string' ? flags.signal : null;
+  if (!signalId) {
+    console.error('Usage: node scripts/coordinator-ack-signal.cjs --signal <id> [--reply "<reply body>"]');
+    process.exit(2);
+  }
+  const wantsReply = flags.reply !== undefined;
+  const replyBody = typeof flags.reply === 'string'
+    ? [flags.reply, ...positional].join(' ').trim()
+    : positional.join(' ').trim();
+
+  const coordinatorSession = process.env.CLAUDE_SESSION_ID;
+  if (!coordinatorSession) { console.error('ERROR: CLAUDE_SESSION_ID required (SessionStart hook).'); process.exit(1); }
+
+  let supabase;
+  try { supabase = createSupabaseServiceClient(); }
+  catch (e) { console.error('ERROR: supabase client unavailable:', e.message); process.exit(1); }
+
+  const { data: sig, error: fErr } = await supabase
+    .from('session_coordination')
+    .select('id, sender_session, payload, acknowledged_at')
+    .eq('id', signalId)
+    .maybeSingle();
+  if (fErr) { console.error('ERROR: signal lookup failed:', fErr.message); process.exit(1); }
+  if (!sig) { console.error('ERROR: signal not found:', signalId); process.exit(1); }
+
+  // Stamp acknowledged_at — the only thing that retires the signal from the inbox (idempotent).
+  const nowIso = new Date().toISOString();
+  if (!sig.acknowledged_at) {
+    const { error: sErr } = await supabase
+      .from('session_coordination')
+      .update({ acknowledged_at: nowIso })
+      .eq('id', signalId);
+    if (sErr) { console.error('ERROR: failed to stamp acknowledged_at:', sErr.message); process.exit(1); }
+  }
+  console.log('✓ Signal acknowledged (retired from inbox)');
+  console.log('  signal_id:', signalId);
+  console.log('  acknowledged_at:', sig.acknowledged_at || nowIso);
+
+  if (wantsReply) {
+    if (!isTwoWayV2Enabled()) {
+      console.error('NOTE: --reply skipped — COORDINATOR_TWOWAY_V2 is OFF (signal was still acked).');
+      process.exit(0);
+    }
+    if (!replyBody) { console.error('ERROR: --reply requires a body.'); process.exit(2); }
+    const workerSession = sig.sender_session;
+    const correlationId = sig.payload && sig.payload.correlation_id;
+    if (!isFullUuid(workerSession)) { console.error('ERROR: signal sender_session is not a full UUID:', JSON.stringify(workerSession)); process.exit(1); }
+    if (!correlationId) { console.error('ERROR: signal carries no payload.correlation_id (not replyable).'); process.exit(1); }
+    const { data, error } = await sendCoordinatorReply(supabase, { coordinatorSession, workerSession, correlationId, body: replyBody });
+    if (error) { console.error('ERROR: failed to send reply:', error.message); process.exit(1); }
+    console.log('✓ Coordinator reply sent to worker');
+    console.log('  reply_id:', data.id);
+    console.log('  to_worker:', workerSession);
+    console.log('  reply_to:', correlationId);
+  }
+}
+
+module.exports = { parseArgs };
+
+if (require.main === module) {
+  main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });
+}

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1092,8 +1092,13 @@ const { getActiveCoordinatorId: _getActiveCoordinatorIdForInbox } = require('../
 // ── Section: Worker-Signal Inbox (FR-3a) ──
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001
 // CRITICAL: filter on payload->>signal_type IS NOT NULL — relying on message_type=INFO
-// alone would surface 105+ unrelated INFO rows already in production. After surfacing,
-// mark read_at so signals do not re-appear next render.
+// alone would surface 105+ unrelated INFO rows already in production.
+// RECEIPT MODEL (RCA 2026-06-24, SD-LEO-INFRA-SIGNAL-INBOX-DRAIN-ON-DISPLAY-001): stamp
+// read_at on render = DELIVERED, but gate the SELECT on acknowledged_at IS NULL = ACTIONED.
+// A signal re-surfaces every render until the coordinator explicitly acks it via
+// coordinator-ack-signal.cjs (stamps acknowledged_at). The prior code marked read_at on
+// render AND queried read_at IS NULL — so one filtered/parked render silently lost the
+// signal (high-sev consults were missed). Mirrors the Adam-lane fix (QF-20260621-174).
 async function printInbox() {
   const getActiveCoordinatorId = _getActiveCoordinatorIdForInbox;
 
@@ -1107,12 +1112,20 @@ async function printInbox() {
     return;
   }
 
+  // RCA 2026-06-24 (SD-LEO-INFRA-SIGNAL-INBOX-DRAIN-ON-DISPLAY-001): gate on the ACTIONED
+  // marker (acknowledged_at IS NULL), NOT read_at — so a filtered/skimmed/parked-cron render
+  // can no longer silently retire a signal; it re-surfaces until coordinator-ack-signal.cjs
+  // stamps acknowledged_at. Mirrors the Adam-lane DELIVERED/ACTIONED decouple (QF-20260621-174).
+  // The created_at recency window is a flood-guard against the pre-fix historical backlog
+  // (hundreds of rows accumulated read-but-never-acked under the old drain-on-display bug).
+  const signalSince = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const { data: signals, error } = await supabase
     .from('session_coordination')
     .select('id, sender_session, sender_type, subject, body, payload, created_at')
     .eq('target_session', coordinatorId)
     .not('payload->>signal_type', 'is', null)
-    .is('read_at', null)
+    .is('acknowledged_at', null)
+    .gte('created_at', signalSince)
     .order('created_at', { ascending: false })
     .limit(20);
 
@@ -1145,7 +1158,10 @@ async function printInbox() {
     ids.push(s.id);
   }
 
-  // Mark all surfaced rows as read so they don't re-surface on next /coordinator inbox.
+  // Stamp read_at = DELIVERED (transport-level "the coordinator rendered it"), but NEVER
+  // acknowledged_at — the signal is retired ONLY by coordinator-ack-signal.cjs (ACTIONED).
+  // So a filtered/skimmed/parked-cron render can no longer silently hide an unacked signal;
+  // it re-surfaces (SELECT gates on acknowledged_at IS NULL) until explicitly acked.
   if (ids.length > 0) {
     await supabase
       .from('session_coordination')


### PR DESCRIPTION
## Root cause (chairman-directed RCA, 2026-06-24)

The coordinator worker-signal inbox (`printInbox` in `fleet-dashboard.cjs`) used **at-most-once drain-on-display** semantics: it stamped `read_at` on render and re-queried `read_at IS NULL`. Any render the coordinator did not fully act on — filtered through grep, skimmed, or fired by a parked cron tick — **permanently retired the signal**. High-severity worker consults were silently lost (Bravo FIRSTREV consult missed ~28m then escalated to Adam; ~56 signals hidden over one session). The identical fix already shipped on the structurally-identical **Adam-advisory lane** (QF-20260621-174) and was never back-ported.

## Fix
- `printInbox` SELECT gates on `acknowledged_at IS NULL` (ACTIONED) instead of `read_at IS NULL`, + a 7d flood-guard window.
- Still stamps `read_at` on render (DELIVERED) so a signal is not noisy every poll, but it **re-surfaces until explicitly acked**.
- New `scripts/coordinator-ack-signal.cjs` stamps `acknowledged_at` to retire a signal (mirrors `coordinator-ack-adam.cjs`), optional `--reply`.

## Verification
Persistence test: rendered the inbox twice → same 20 signals in both renders (old bug: 20 then 0). Acking clears a signal.

## Follow-ups (per RCA, deferred)
Sweep-driven escalation timer for aged unacked high/critical signals; twin-lane invariant test; PAT-PROCESS-DRAIN-ON-DISPLAY-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)