### PR TITLE
feat(SD-EHG-PRODUCT-OPERATOR-CASH-ATTEST-DTB-LIVE-001): chairman-attested --cash lights distance-to-broke

### DIFF
--- a/scripts/operator/feed-operator-cash-burn.mjs
+++ b/scripts/operator/feed-operator-cash-burn.mjs
@@ -38,6 +38,39 @@ const DRY_RUN = process.argv.includes('--dry-run');
 function log(step, msg) { console.log(`[operator-cash-burn] ${step}: ${msg}`); }
 function warn(step, msg) { console.warn(`[operator-cash-burn] ${step}: WARN ${msg}`); }
 
+/**
+ * SD-EHG-PRODUCT-OPERATOR-CASH-ATTEST-DTB-LIVE-001 (FR-1): parse the chairman-attested cash flag.
+ * Pure + DB-free (unit-testable). Supports `--cash <usd>` and `--cash=<usd>`.
+ *   - absent                  -> null (no attestation; the existing bank/stripe path runs)
+ *   - present but no value     -> THROW (an attestation must be intentional — never coerce to 0)
+ *   - NaN / Infinity / negative -> THROW naming the bad token
+ *   - finite >= 0              -> the number (0 is a valid floor). No rounding here.
+ * @param {string[]} argv
+ * @returns {number|null}
+ */
+export function parseCashFlag(argv = process.argv) {
+  let raw = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cash') { raw = argv[i + 1]; break; }
+    if (typeof a === 'string' && a.startsWith('--cash=')) { raw = a.slice('--cash='.length); break; }
+  }
+  if (raw === null || raw === undefined) {
+    // distinguish "flag absent" (null) from "flag present but no value" (throw)
+    const present = argv.includes('--cash') || argv.some((a) => typeof a === 'string' && a.startsWith('--cash='));
+    if (present) throw new Error('--cash requires a USD value (e.g. --cash 50000); refusing to attest an empty cash balance');
+    return null;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`--cash value must be a finite number >= 0 (got "${raw}")`);
+  }
+  return n;
+}
+
+// Parse once at load so a malformed flag fails fast before any DB work.
+const ATTESTED_CASH = parseCashFlag(process.argv);
+
 /** FR-2: rolling-30d AI spend (lower bound) from the cost report CLI. Returns number or null. */
 function readRolling30dAiSpend() {
   const r = spawnSync(process.execPath, [path.join(REPO_ROOT, 'scripts/llm-cost-report.mjs'), '--days', '30', '--json'], {
@@ -71,6 +104,15 @@ async function main() {
   // bank (FR-4), cash stays UNATTESTED and the gauge honestly shows 'awaiting cash source' rather
   // than a false near-zero. Fail-soft throughout: a failed pull preserves the prior value.
   try {
+    if (ATTESTED_CASH != null) {
+      // SD-EHG-PRODUCT-OPERATOR-CASH-ATTEST-DTB-LIVE-001 (FR-2): chairman-attested manual cash takes
+      // precedence — the bank/stripe readers are NOT consulted (no network/credential calls, no
+      // additive double-count). Cash-only: do not write other_burn_usd here.
+      const cashUsd = Number(ATTESTED_CASH.toFixed(2));
+      log('FR-cash', `cash-on-hand = $${cashUsd} (chairman-attested, manual)`);
+      if (!DRY_RUN) await upsertSubstrateInputs(periodMonth, { cash_usd: cashUsd }, supabase, nowIso);
+      result.cash = { written: !DRY_RUN, value_usd: cashUsd, sources: ['chairman_attested'] };
+    } else {
     const bankSlice = await readBankCashSlice();
     if (!bankSlice) {
       // Inert: no primary cash source yet. Peek Stripe for logging only; do NOT write cash.
@@ -89,6 +131,7 @@ async function main() {
         await upsertSubstrateInputs(periodMonth, fields, supabase, nowIso);
       }
       result.cash = { written: !DRY_RUN, value_usd: cashUsd, sources, other_burn_usd: otherBurn };
+    }
     }
   } catch (e) { warn('FR-cash', `failed (fail-soft): ${e.message}`); result.cash = { written: false, error: e.message }; }
 

--- a/tests/unit/operator/parse-cash-flag.test.js
+++ b/tests/unit/operator/parse-cash-flag.test.js
@@ -1,0 +1,35 @@
+// SD-EHG-PRODUCT-OPERATOR-CASH-ATTEST-DTB-LIVE-001 (FR-1) — pure parser for the chairman-attested
+// --cash flag. No DB. An attestation must be intentional + honest: never a silent 0.
+import { describe, it, expect } from 'vitest';
+import { parseCashFlag } from '../../../scripts/operator/feed-operator-cash-burn.mjs';
+
+describe('parseCashFlag', () => {
+  it('parses `--cash <usd>` and `--cash=<usd>`', () => {
+    expect(parseCashFlag(['node', 'feed.mjs', '--cash', '12345.67'])).toBe(12345.67);
+    expect(parseCashFlag(['node', 'feed.mjs', '--cash=9999'])).toBe(9999);
+  });
+
+  it('returns null when the flag is absent', () => {
+    expect(parseCashFlag(['node', 'feed.mjs'])).toBeNull();
+    expect(parseCashFlag(['node', 'feed.mjs', '--dry-run'])).toBeNull();
+  });
+
+  it('accepts 0 as a valid floor', () => {
+    expect(parseCashFlag(['node', 'feed.mjs', '--cash', '0'])).toBe(0);
+  });
+
+  it('coexists with --dry-run', () => {
+    expect(parseCashFlag(['node', 'feed.mjs', '--cash', '5000', '--dry-run'])).toBe(5000);
+    expect(parseCashFlag(['node', 'feed.mjs', '--dry-run', '--cash=5000'])).toBe(5000);
+  });
+
+  it('THROWS when present but missing a value (never coerce to 0)', () => {
+    expect(() => parseCashFlag(['node', 'feed.mjs', '--cash'])).toThrow(/requires a USD value/i);
+  });
+
+  it('THROWS on a non-numeric / negative / non-finite value', () => {
+    expect(() => parseCashFlag(['node', 'feed.mjs', '--cash', 'abc'])).toThrow(/finite number/i);
+    expect(() => parseCashFlag(['node', 'feed.mjs', '--cash', '-5'])).toThrow(/>= 0|finite number/i);
+    expect(() => parseCashFlag(['node', 'feed.mjs', '--cash', 'Infinity'])).toThrow(/finite number/i);
+  });
+});


### PR DESCRIPTION
## Summary
The operator **distance-to-broke / cash-runway** gauge (the #1 solo-operator survival number, a chairman-named pivot theme) is **built but dark**: `ai_burn_usd` and `revenue_usd` flow into `operator_cash_burn_monthly`, but `cash_usd` is never synced, so `distanceToBroke()` returns `awaiting_cash` and the gauge permanently reads *"awaiting cash source."* This adds a chairman-attested cash input so the gauge lights — **zero ehg-app changes, no migration**.

## Change (~22 LOC, single repo)
- **`parseCashFlag(argv)`** — pure, exported, DB-free parser for `--cash <usd>` / `--cash=<usd>`. Absent → `null`; present-but-no-value or NaN/Infinity/negative → **throws** (an attestation must be intentional — never a silent `0`); finite `>= 0` → the value.
- **`feed-operator-cash-burn.mjs`** — `ATTESTED_CASH` parsed once at load (fails fast on a bad flag). When present, an attested branch upserts `cash_usd` via the **existing** `upsertSubstrateInputs` writer (stamps `cash_last_synced_at=now`) and **short-circuits** the bank/Stripe readers (no network calls, no double-count, cash-only). When absent → **byte-identical** to today.

## Why it's safe / honest
- DATABASE sub-agent: `cash_usd` + `cash_last_synced_at` columns exist live (currently NULL); the writer already handles them; **no migration**. A fresh non-null cash flips `awaiting_cash → measurable` (net-burn is already live).
- The value is the chairman's **real, timestamped** attestation; the existing **36h** cash-liveness window (unchanged) still degrades a stale reading back to *"awaiting cash source."* No silent zero.
- The actual live attestation is the operator running `--cash <their real balance>` — I did **not** write a fabricated number.

## Tests
6 unit tests for `parseCashFlag` (both flag forms, absent→null, `0` floor, coexists with `--dry-run`, throws on missing-value/non-numeric/negative/Infinity). Dry-run verified end-to-end.

## Out of MVP scope (noted)
Widening the 36h cash-liveness window for manual cadence; a cockpit-native cash-entry UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)