### PR TITLE
feat(SD-LEO-INFRA-CI-BASELINE-ROT-DETECT-001): cumulative-rot detection (slow-decay blind spot)

### DIFF
--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -36,6 +36,22 @@ export const DEFAULT_NOISE_FLOOR = (() => {
 })();
 
 /**
+ * CUMULATIVE-ROT thresholds (SD-LEO-INFRA-CI-BASELINE-ROT-DETECT-001). decide()
+ * only fires on a CONFIRMED RISE above the settled median, so a slow climb that
+ * stays under the per-merge jump is absorbed into the creeping median and never
+ * trips (observed: 102 -> 134 over 13d). detectBaselineRot() below catches that
+ * blind spot. Both thresholds are env-overridable (mirrors DEFAULT_NOISE_FLOOR).
+ */
+export const DEFAULT_ROT_CEILING = (() => {
+  const n = Number(process.env.RED_MERGE_ROT_CEILING);
+  return Number.isFinite(n) && n > 0 ? n : 110;
+})();
+export const DEFAULT_TREND_DELTA = (() => {
+  const n = Number(process.env.RED_MERGE_TREND_DELTA);
+  return Number.isFinite(n) && n > 0 ? n : 15;
+})();
+
+/**
  * Does a QF description carry this exact signature? Delimiter-anchored so a sha-PREFIX cannot
  * collide (`:abc123` must not match a QF for `:abc123def456`). A match requires the char after the
  * signature to be end-of-string or a non-hex char (SHAs are [0-9a-f]). (SD-REFILL-00Z7INJF / RCA F2)
@@ -137,6 +153,75 @@ export function decide(snapshots = [], openRedMergeQfs = [], opts = {}) {
   };
 }
 
+/**
+ * Pure CUMULATIVE-ROT detector (SD-LEO-INFRA-CI-BASELINE-ROT-DETECT-001).
+ *
+ * decide() above fires only on a CONFIRMED RISE above the settled median, so a
+ * slow climb that stays under the per-merge jump (observed: 102 -> 134 over 13d)
+ * is absorbed into the creeping median and never trips. This catches that blind
+ * spot two ways, both with the same single-bounce immunity decide() uses (the
+ * latest TWO readings must qualify, so a lone flaky spike never fires):
+ *
+ *   • ABSOLUTE CEILING — the two most recent failed_counts both sit at/above an
+ *     absolute ceiling (the suite is simply too red, however it got there). This
+ *     is the rule that catches an ALREADY-rotted baseline whose window is flat.
+ *   • CUMULATIVE TREND — the median of the recent half of the window sits
+ *     >= trendDelta above the median of the older half (decay in progress), with
+ *     both latest readings above that older-half median.
+ *
+ * Pure + deterministic (no Date.now/Math.random); newest-first snapshots, same
+ * shape decide() consumes. Does NOT touch decide() — additive (TR-1).
+ *
+ * @param {Array<{findings: Array<{failed_count: number}>}>} snapshots newest-first
+ * @param {{ceiling?: number, trendDelta?: number}} [opts]
+ * @returns {{rotted: boolean, rule: 'absolute_ceiling'|'cumulative_trend'|null, reason: string, latest?: number, prev?: number, ceiling?: number, recentMedian?: number, olderMedian?: number}}
+ */
+export function detectBaselineRot(snapshots = [], opts = {}) {
+  const ceiling = Number.isFinite(opts.ceiling) ? opts.ceiling : DEFAULT_ROT_CEILING;
+  const trendDelta = Number.isFinite(opts.trendDelta) ? opts.trendDelta : DEFAULT_TREND_DELTA;
+  const f = (s) => (s && s.findings && s.findings[0]) || {};
+  const counts = snapshots.map((s) => Number(f(s).failed_count ?? NaN)).filter(Number.isFinite);
+  if (counts.length < 2) {
+    return { rotted: false, rule: null, reason: `insufficient history (${counts.length} reading(s); need >=2)` };
+  }
+  const [latest, prev] = counts;
+
+  // ABSOLUTE CEILING — persistence: the latest TWO both at/above the ceiling.
+  if (latest >= ceiling && prev >= ceiling) {
+    return {
+      rotted: true, rule: 'absolute_ceiling',
+      reason: `failed_count sustained at/above ceiling ${ceiling} (latest ${latest}, prev ${prev})`,
+      latest, prev, ceiling,
+    };
+  }
+
+  // CUMULATIVE TREND — needs >=4 readings to split into recent/older halves.
+  if (counts.length >= 4) {
+    const half = Math.floor(counts.length / 2);
+    const recentMedian = median(counts.slice(0, half));
+    const olderMedian = median(counts.slice(half));
+    // Single-bounce immunity: BOTH recent readings must sit a full trendDelta
+    // above the older-half median (a lone spike inflating recentMedian fails this).
+    if (
+      Number.isFinite(recentMedian) && Number.isFinite(olderMedian) &&
+      recentMedian - olderMedian >= trendDelta &&
+      latest >= olderMedian + trendDelta && prev >= olderMedian + trendDelta
+    ) {
+      return {
+        rotted: true, rule: 'cumulative_trend',
+        reason: `recent median ${recentMedian} is >= ${trendDelta} above older median ${olderMedian} (sustained climb)`,
+        latest, prev, recentMedian, olderMedian,
+      };
+    }
+  }
+
+  return {
+    rotted: false, rule: null,
+    reason: `no rot: latest ${latest}/prev ${prev} below ceiling ${ceiling}; no sustained ${trendDelta}+ climb`,
+    latest, prev, ceiling,
+  };
+}
+
 async function main() {
   const dryRun = process.argv.includes('--dry-run');
   const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -152,6 +237,22 @@ async function main() {
   // Pass a trailing WINDOW (not just 2) so decide() can compute a robust settled-median
   // baseline + confirm persistence — the flaky-bounce noise floor (SD-REFILL-00V2SADI).
   const mainSnaps = (snaps || []).filter((s) => (s.findings?.[0]?.branch || '') === 'main').slice(0, 8);
+
+  // CUMULATIVE-ROT check (SD-LEO-INFRA-CI-BASELINE-ROT-DETECT-001) — catches the
+  // slow decay decide() is blind to. Report-only mode; never files a QF here.
+  if (process.argv.includes('--rot-check')) {
+    const rot = detectBaselineRot(mainSnaps);
+    console.log(`[red-merge-detector] rot-check: ${rot.rotted ? 'BASELINE_ROT_DETECTED' : 'no rot'} — ${rot.reason}`);
+    if (rot.rotted && !dryRun) {
+      try {
+        await db.from('audit_log').insert({
+          event: 'BASELINE_ROT_DETECTED',
+          metadata: { rule: rot.rule, latest: rot.latest, prev: rot.prev, ceiling: rot.ceiling, recentMedian: rot.recentMedian, olderMedian: rot.olderMedian, reason: rot.reason },
+        });
+      } catch { /* best effort — never blocks */ }
+    }
+    return;
+  }
 
   const { data: openQfs } = await db
     .from('quick_fixes')

--- a/tests/unit/red-merge-baseline-rot.test.js
+++ b/tests/unit/red-merge-baseline-rot.test.js
@@ -1,0 +1,77 @@
+/**
+ * SD-LEO-INFRA-CI-BASELINE-ROT-DETECT-001 — cumulative-rot detection.
+ *
+ * Sample-first evidence (from Bravo's QF-20260612-915 verify-premise) locked in
+ * as tests: main's failure count rotted 102 -> 134 over 13d but decide() never
+ * fired because each step stayed under the median-jump trigger. These prove the
+ * new detectBaselineRot() catches that, stays immune to single flaky bounces,
+ * and that decide() itself is UNCHANGED (additive-only, TR-1).
+ */
+import { describe, it, expect } from 'vitest';
+import { detectBaselineRot, decide } from '../../scripts/ci/red-merge-detector.mjs';
+
+// newest-first snapshot in the shape decide()/detectBaselineRot() consume.
+const snap = (failed_count, commit_sha) => ({ findings: [{ failed_count, branch: 'main', commit_sha }] });
+const seq = (...counts) => counts.map((c) => snap(c));
+
+describe('detectBaselineRot — absolute ceiling', () => {
+  it('fires on an ALREADY-rotted flat window (~134, the real observed state)', () => {
+    const r = detectBaselineRot(seq(134, 134, 133, 140, 133, 134, 133, 140));
+    expect(r.rotted).toBe(true);
+    expect(r.rule).toBe('absolute_ceiling');
+  });
+
+  it('does NOT fire when only the latest single reading hits the ceiling (single-bounce immunity)', () => {
+    // latest spike 140, prior readings healthy ~100 → absolute needs BOTH recent readings
+    const r = detectBaselineRot(seq(140, 100, 99, 101, 100, 98));
+    expect(r.rotted).toBe(false);
+  });
+
+  it('respects an env-style ceiling override via opts', () => {
+    expect(detectBaselineRot(seq(105, 104, 100, 100), { ceiling: 200 }).rule).not.toBe('absolute_ceiling');
+    expect(detectBaselineRot(seq(105, 104, 100, 100), { ceiling: 103 }).rotted).toBe(true);
+  });
+});
+
+describe('detectBaselineRot — cumulative trend (slow decay decide() is blind to)', () => {
+  it('fires on a sustained climb where each step stays under the per-merge jump and below the ceiling', () => {
+    // recent half ~104, older half ~86 → +18 climb; both latest readings sustainedly elevated; all < ceiling 110
+    const r = detectBaselineRot(seq(105, 104, 103, 102, 88, 86, 85, 84), { ceiling: 200 });
+    expect(r.rotted).toBe(true);
+    expect(r.rule).toBe('cumulative_trend');
+  });
+
+  it('does NOT fire on a single flaky spike in the recent half (no false positive)', () => {
+    // a lone 140 spike inflates the recent median, but the OTHER recent reading is ~100 → not sustained
+    const r = detectBaselineRot(seq(140, 100, 99, 100, 98, 99), { ceiling: 200 });
+    expect(r.rotted).toBe(false);
+  });
+
+  it('does NOT fire on a flat healthy window', () => {
+    expect(detectBaselineRot(seq(84, 85, 86, 84, 85, 86), { ceiling: 200 }).rotted).toBe(false);
+  });
+});
+
+describe('detectBaselineRot — guards', () => {
+  it('returns not-rotted with <2 readings', () => {
+    expect(detectBaselineRot(seq(134)).rotted).toBe(false);
+    expect(detectBaselineRot([]).rotted).toBe(false);
+  });
+});
+
+describe('decide() regression guard — additive change must not alter it', () => {
+  it('still fires file_qf on a confirmed rise above the settled median', () => {
+    const v = decide(seq(105, 104, 100, 100, 100).map((s, i) => (i === 0 ? snap(105, 'abc1234567') : s)), []);
+    expect(v.action).toBe('file_qf');
+  });
+
+  it('still returns noop on a flat window (no confirmed rise)', () => {
+    const v = decide(seq(100, 100, 100, 100, 100), []);
+    expect(v.action).toBe('noop');
+  });
+
+  it('still returns noop on a single transient spike (persistence preserved)', () => {
+    const v = decide(seq(100, 118, 100, 100, 100), []);
+    expect(v.action).toBe('noop');
+  });
+});


### PR DESCRIPTION
## Summary
Closes the CI baseline-rot blind spot surfaced by Bravo's verify-premise on stale QF-20260612-915: main's unit-test failure count rotted ~102→134 over 13 days, but `scripts/ci/red-merge-detector.mjs` only fires on a confirmed rise *above the settled median*, so gradual decay was absorbed step-by-step and never tripped.

## What (Phase 1 / detection core — FR-1, FR-4, FR-5)
- New pure, additive `detectBaselineRot()`: **absolute_ceiling** (latest two failed_counts both ≥ `RED_MERGE_ROT_CEILING`, default 110) + **cumulative_trend** (recent-half median ≥ `RED_MERGE_TREND_DELTA` (15) above older-half median, both recent readings sustainedly elevated → single-bounce immune).
- Env-overridable thresholds (mirrors `RED_MERGE_NOISE_FLOOR`); `--rot-check` CLI mode reports + best-effort audit_logs `BASELINE_ROT_DETECTED`.
- Existing `decide()` **untouched** (TR-1, regression-guarded).
- 10 unit tests; verified live: `--rot-check` detects the real 134 state (latest 134, prev 137).

## Deferred follow-on (honest scope)
- **FR-2** S20 build-gate trustworthy-baseline halt — follow-up SD.
- **FR-3** remediation path for the ~134 failing tests (triage + downward target, no baseline reset) — follow-up SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)