### PR TITLE
fix(SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001): structural fix for RCA false-positive on read-only/idempotent loops

### DIFF
--- a/lib/hooks/auto-signal-threshold.cjs
+++ b/lib/hooks/auto-signal-threshold.cjs
@@ -23,13 +23,21 @@
  * Fires EXACTLY ONCE per signature escalation — on the 2nd-attempt crossing (the warn tier). The
  * 3rd attempt hard-blocks (handled by the hook) and must NOT re-signal (dedupe by exact ===2).
  *
- * @param {{ attempts:number, sessionId?:string, env?:object }} opts
+ * SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 3): re-scope the emit to genuine
+ * no-progress. The caller computes `progressStalled` (phase/percent unchanged across the
+ * repetition) from the already-loaded unified-session-state — this module stays PURE (no I/O).
+ * When `progressStalled === false` (the session is demonstrably advancing) the signal is
+ * suppressed even at the ===2 crossing; `undefined` preserves the prior fire-on-crossing
+ * behavior (back-compat) so a caller that cannot compute progress is unaffected.
+ *
+ * @param {{ attempts:number, sessionId?:string, progressStalled?:boolean, env?:object }} opts
  * @returns {boolean}
  */
-function shouldEmitAutoSignal({ attempts, sessionId, env = process.env } = {}) {
+function shouldEmitAutoSignal({ attempts, sessionId, progressStalled, env = process.env } = {}) {
   if (env && env.LEO_AUTO_SIGNAL === 'off') return false;        // kill-switch
   if (!sessionId || sessionId === 'unknown') return false;       // need a real worker identity
   if (!Number.isInteger(attempts)) return false;
+  if (progressStalled === false) return false;                   // Control 3: real progress → not stuck
   return attempts === 2;                                          // once, on the crossing (not >=2)
 }
 

--- a/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
+++ b/scripts/hooks/__tests__/post-tool-rca-outcome.test.js
@@ -63,6 +63,47 @@ describe('L4 — post-tool-rca-outcome.cjs', () => {
     expect(written.stderr_sha).toBe(expectedSha);
   });
 
+  it('TS-5 (Control 4): a SUCCESS payload (no exit_code, no stderr) records exit_code 0', () => {
+    // Claude Code Bash tool_response carries NO exit_code; success was previously skipped.
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/my-idempotent-tick.js' },
+      tool_response: { stdout: 'ok', stderr: '' },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: { ...process.env, CLAUDE_TOOL_NAME: 'Bash', CLAUDE_SESSION_ID: SESSION_ID, LEO_RETRY_STATE_DIR: tmpDir },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    expect(fs.existsSync(outFile)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    expect(written.exit_code).toBe(0);              // success inferred from absence of failure
+    expect(written.stderr_sha).toBe('');
+    expect(written.command_sha).toMatch(/^[0-9a-f]{16}$/); // captured so the poll exemption can scope
+  });
+
+  it('TS-5b (Control 4 — strict/teeth): an interrupted call is NOT recorded as success', () => {
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/hangs.js' },
+      tool_response: { stdout: '', stderr: '', interrupted: true },
+    });
+    const result = spawnSync('node', [HOOK_PATH], {
+      input: payload,
+      env: { ...process.env, CLAUDE_TOOL_NAME: 'Bash', CLAUDE_SESSION_ID: SESSION_ID, LEO_RETRY_STATE_DIR: tmpDir },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    // No success signal recorded (would otherwise wrongly exempt a hung/interrupted command).
+    const outFile = path.join(tmpDir, `last-outcome-${SESSION_ID}.json`);
+    if (fs.existsSync(outFile)) {
+      const written = JSON.parse(fs.readFileSync(outFile, 'utf8'));
+      expect(written.exit_code).not.toBe(0);
+    }
+  });
+
   it('TS-18: malformed stdin → exit 0, no crash, no file written', () => {
     const result = spawnSync('node', [HOOK_PATH], {
       input: 'not-json-at-all',

--- a/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager-coordinator-loops.test.js
@@ -1,9 +1,13 @@
-// QF-20260610-626 — exempt the remaining canonical coordinator cron loops from the
-// RCA tiered-enforcement counter. The loops exit 0 by design on fixed intervals; the
-// consecutive-attempt counter misread the cron cadence as a stuck retry loop because
-// the exit-0 exemption's single per-session lastOutcome file is clobbered under
-// interleaved loops (residual after SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001).
-// Closes feedback ids d89abebc + c86d5027.
+// SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 — structural replacement of the reactive
+// EXEMPT_PATTERNS allowlist (formerly QF-20260610-626 et al). The RCA recurrence detector
+// false-blocked read-only/idempotent loops because successful Bash carried no exit signal
+// (post-tool-rca-outcome.cjs skipped the write) → the per-signature counter accumulated.
+// These tests pin the STRUCTURAL fix: (1) a succeeding poll (prior SAME command exit 0, now
+// reliably captured by Control 4) never accumulates; (2) a FAILING loop STILL accumulates
+// (teeth); (3) the absence-of-failure exemption is conjunctive with a deny-by-default
+// read-only classifier; (4) the classifier rejects compound/mutating shapes; (5) a no-SD-claim
+// session can reset via the session-scoped marker (R5); (6) the Control-3 progress fingerprint
+// is returned so the caller can suppress a spurious auto-signal.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
@@ -17,98 +21,160 @@ function loadFresh() {
   return require(MODULE_PATH);
 }
 
-// FR-1/2/3 — the full canonical coordinator-loop command set.
-const LOOP_COMMANDS = [
-  'node scripts/coordinator-self-review.mjs',                                  // loop 8, */5
-  'node scripts/coordinator-audit.mjs',                                        // loop 5, */15
-  'node scripts/coordinator-email-summary.mjs',                                // loop 6, */30
-  'node scripts/coordinator-startup-check.mjs',                                // startup probe
-  // Step-0 keepalive: node -e inline (no script path) — matched on stable tokens.
-  'node -e "const { setActiveCoordinator } = require(\'./lib/coordinator/resolve.cjs\'); setActiveCoordinator(process.env.CLAUDE_SESSION_ID).then(...)"',
-  'node -e "require(\'./lib/coordinator/resolve.cjs\').setActiveCoordinator(id)"',
-  // SD-REFILL-00D2CC0B — two more recurring coordinator crons (false-blocked during fleet
-  // re-engagement churn; coordinator Kamo 2026-06-15).
-  'node scripts/coordinator-backlog-rank.mjs',                                  // per-sourced-SD + interval
-  'node scripts/coordinator-capacity-forecast.mjs',                            // periodic capacity probe
-];
+const NO_RCA = { rcaCheck: async () => null };
 
-describe('QF-626 isExempt: canonical coordinator cron loops', () => {
-  const { isExempt } = loadFresh();
+describe('Control 2 — isReadOnlyCommand (deny-by-default classifier)', () => {
+  const { isReadOnlyCommand } = loadFresh();
 
-  for (const cmd of LOOP_COMMANDS) {
-    it(`exempts: ${cmd.slice(0, 60)}`, () => {
-      expect(isExempt(cmd)).toBe(true);
-    });
-  }
-
-  it('still exempts with ./ prefix and windows separators', () => {
-    expect(isExempt('node ./scripts/coordinator-self-review.mjs')).toBe(true);
-    expect(isExempt('node scripts\\coordinator-audit.mjs')).toBe(true);
+  it('classifies provably read-only single commands as read-only', () => {
+    for (const c of ['git status', 'git log --oneline -5', 'ls -la', 'pwd', 'cat package.json',
+                     'grep -r foo src', 'rg pattern', 'find . -name x', 'echo hi', 'stat file']) {
+      expect(isReadOnlyCommand(c)).toBe(true);
+    }
   });
 
-  // SD-REFILL-00D2CC0B — the two newly-whitelisted recurring crons, both separators.
-  it('exempts coordinator-backlog-rank.mjs and coordinator-capacity-forecast.mjs', () => {
-    expect(isExempt('node scripts/coordinator-backlog-rank.mjs')).toBe(true);
-    expect(isExempt('node ./scripts/coordinator-backlog-rank.mjs --apply')).toBe(true);
-    expect(isExempt('node scripts\\coordinator-capacity-forecast.mjs')).toBe(true);
+  it('DENY-BY-DEFAULT: unknown / script-invoking commands are NOT read-only', () => {
+    for (const c of ['node scripts/worker-checkin.cjs', 'node scripts/coordinator-audit.mjs',
+                     'npm run build', 'rm -rf x', 'git commit -m x', 'psql -c "UPDATE t SET a=1"']) {
+      expect(isReadOnlyCommand(c)).toBe(false);
+    }
   });
 
-  // FR-5 — anchoring: unrelated coordinator-* scripts stay RCA-gated.
-  it('does NOT exempt arbitrary or unrelated coordinator-* commands', () => {
-    expect(isExempt('node scripts/leo-create-sd.js')).toBe(false);
-    expect(isExempt('node scripts/coordinator-revive.cjs')).toBe(false);
-    expect(isExempt('node scripts/coordinator-self-review-helper.mjs')).toBe(false);
+  it('rejects compound/redirecting shapes even with a read-only leading verb (R1)', () => {
+    for (const c of ['git status && rm -rf x', 'cat f | tee g', 'ls > out.txt',
+                     'echo $(rm x)', 'grep x f; touch y']) {
+      expect(isReadOnlyCommand(c)).toBe(false);
+    }
   });
 
-  // FR-5 — fail-open input handling preserved.
-  it('returns false for non-string/empty input', () => {
-    expect(isExempt(null)).toBe(false);
-    expect(isExempt(undefined)).toBe(false);
-    expect(isExempt('')).toBe(false);
+  it('fail-open input handling preserved', () => {
+    expect(isReadOnlyCommand(null)).toBe(false);
+    expect(isReadOnlyCommand(undefined)).toBe(false);
+    expect(isReadOnlyCommand('')).toBe(false);
   });
 });
 
-describe('QF-626 recordAndCount: loop commands never accumulate attempts', () => {
+describe('TS-1 — succeeding poll (prior SAME command exit 0) never accumulates', () => {
   let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-fp-')); process.env.LEO_RETRY_STATE_DIR = tmpDir; });
+  afterEach(() => { delete process.env.LEO_RETRY_STATE_DIR; fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf626-'));
-    process.env.LEO_RETRY_STATE_DIR = tmpDir;
-  });
-
-  afterEach(() => {
-    delete process.env.LEO_RETRY_STATE_DIR;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  for (const cmd of LOOP_COMMANDS.slice(0, 4)) {
-    it(`attempts stays 0 across 4 consecutive runs: ${cmd.slice(5, 50)}`, async () => {
-      const { recordAndCount } = loadFresh();
-      const opts = { rcaCheck: async () => null };
-      for (let i = 0; i < 4; i++) {
-        const r = await recordAndCount('qf626-sess', null, 'Bash', { command: cmd }, opts);
-        expect(r.attempts).toBe(0);
-      }
-    });
-  }
-
-  it('the Step-0 keepalive inline command also stays at 0', async () => {
-    const { recordAndCount } = loadFresh();
-    const opts = { rcaCheck: async () => null };
-    for (let i = 0; i < 4; i++) {
-      const r = await recordAndCount('qf626-sess', null, 'Bash', { command: LOOP_COMMANDS[4] }, opts);
+  it('a non-allowlisted succeeding tick (Control 4 exit-0 capture) stays at attempts 0 across 5 ticks', async () => {
+    const { recordAndCount, bashCmdHash } = loadFresh();
+    // NOT in EXEMPT_PATTERNS — exemption here is driven purely by the captured exit_code 0.
+    const cmd = 'node scripts/my-idempotent-tick.js';
+    const lastOutcome = { exit_code: 0, command_sha: bashCmdHash(cmd), stderr_sha: '' };
+    for (let i = 0; i < 5; i++) {
+      const r = await recordAndCount('sess-poll', null, 'Bash', { command: cmd }, { ...NO_RCA, lastOutcome });
       expect(r.attempts).toBe(0);
     }
   });
 
-  it('non-loop command still accumulates 1..4 (3-strikes machinery untouched)', async () => {
+  it('a pure read-only command with NO prior outcome stays at 0 (Control 1 + classifier)', async () => {
     const { recordAndCount } = loadFresh();
-    const opts = { rcaCheck: async () => null };
+    for (let i = 0; i < 5; i++) {
+      const r = await recordAndCount('sess-ro', null, 'Bash', { command: 'git status' }, NO_RCA);
+      expect(r.attempts).toBe(0);
+    }
+  });
+});
+
+describe('TS-2 — TEETH: a FAILING loop still accumulates to the hard-block', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-fp-')); process.env.LEO_RETRY_STATE_DIR = tmpDir; });
+  afterEach(() => { delete process.env.LEO_RETRY_STATE_DIR; fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('a non-read-only retry loop accumulates 1..4 (3-strikes machinery intact)', async () => {
+    const { recordAndCount } = loadFresh();
     const counts = [];
     for (let i = 0; i < 4; i++) {
-      const r = await recordAndCount('qf626-throttle', null, 'Bash', { command: 'node scripts/some-retry-loop.js' }, opts);
+      const r = await recordAndCount('sess-fail', null, 'Bash', { command: 'node scripts/flaky.js' }, NO_RCA);
       counts.push(r.attempts);
     }
     expect(counts).toEqual([1, 2, 3, 4]);
+  });
+
+  it('a FAILING read-only loop (prior exit non-zero) still accumulates', async () => {
+    const { recordAndCount, bashCmdHash } = loadFresh();
+    const cmd = 'grep needle haystack';
+    const lastOutcome = { exit_code: 1, command_sha: bashCmdHash(cmd), stderr_sha: 'abc123' };
+    const counts = [];
+    for (let i = 0; i < 3; i++) {
+      const r = await recordAndCount('sess-rofail', null, 'Bash', { command: cmd }, { ...NO_RCA, lastOutcome });
+      counts.push(r.attempts);
+    }
+    expect(counts).toEqual([1, 2, 3]);
+  });
+});
+
+describe('TS-3 — conjunction: success ALONE or read-only ALONE does not over-exempt', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-fp-')); process.env.LEO_RETRY_STATE_DIR = tmpDir; });
+  afterEach(() => { delete process.env.LEO_RETRY_STATE_DIR; fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('read-only command WITH a failure outcome is NOT exempted by the Control-1 path', async () => {
+    const { recordAndCount } = loadFresh();
+    // read-only verb but the prior outcome shows a failure (stderr present) → must accumulate.
+    const lastOutcome = { exit_code: null, command_sha: 'deadbeef', stderr_sha: 'eee111' };
+    const r1 = await recordAndCount('sess-c1', null, 'Bash', { command: 'git status' }, { ...NO_RCA, lastOutcome });
+    const r2 = await recordAndCount('sess-c1', null, 'Bash', { command: 'git status' }, { ...NO_RCA, lastOutcome });
+    expect(r2.attempts).toBe(2);
+  });
+
+  it('non-read-only command with absence-of-failure is NOT exempted by the Control-1 path', async () => {
+    const { recordAndCount } = loadFresh();
+    // no prior outcome (absence of failure) but the command is not provably read-only → accumulate.
+    const r1 = await recordAndCount('sess-c2', null, 'Bash', { command: 'node scripts/mutator.js' }, NO_RCA);
+    const r2 = await recordAndCount('sess-c2', null, 'Bash', { command: 'node scripts/mutator.js' }, NO_RCA);
+    expect(r2.attempts).toBe(2);
+  });
+});
+
+describe('TS-7 — R5: no-SD-claim session can reset via the session-scoped marker', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-fp-')); process.env.LEO_RETRY_STATE_DIR = tmpDir; });
+  afterEach(() => { delete process.env.LEO_RETRY_STATE_DIR; fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('writeSessionRcaReset clears the counter for a sdKey=null session', async () => {
+    const { recordAndCount, writeSessionRcaReset } = loadFresh();
+    const cmd = 'node scripts/flaky.js';
+    const a = await recordAndCount('sess-r5', null, 'Bash', { command: cmd }, NO_RCA);
+    const b = await recordAndCount('sess-r5', null, 'Bash', { command: cmd }, NO_RCA);
+    expect(b.attempts).toBe(2);
+    // A no-claim (coordinator/Adam) session drops the marker — newer than reset_at.
+    writeSessionRcaReset('sess-r5', new Date(Date.now() + 1000).toISOString());
+    const c = await recordAndCount('sess-r5', null, 'Bash', { command: cmd }, NO_RCA);
+    expect(c.rcaResetApplied).toBe(true);
+    expect(c.attempts).toBe(1); // counter reset, this call is the first post-reset
+  });
+});
+
+describe('Control 3 — progress fingerprint drives progressStalled', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rca-fp-')); process.env.LEO_RETRY_STATE_DIR = tmpDir; });
+  afterEach(() => { delete process.env.LEO_RETRY_STATE_DIR; fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('unchanged fingerprint across the repetition → progressStalled true', async () => {
+    const { recordAndCount } = loadFresh();
+    const cmd = 'node scripts/flaky.js';
+    await recordAndCount('sess-p1', null, 'Bash', { command: cmd }, { ...NO_RCA, progressFingerprint: 'sd:EXEC:40' });
+    const r2 = await recordAndCount('sess-p1', null, 'Bash', { command: cmd }, { ...NO_RCA, progressFingerprint: 'sd:EXEC:40' });
+    expect(r2.attempts).toBe(2);
+    expect(r2.progressStalled).toBe(true);
+  });
+
+  it('changed fingerprint (session advanced) → progressStalled false', async () => {
+    const { recordAndCount } = loadFresh();
+    const cmd = 'node scripts/flaky.js';
+    await recordAndCount('sess-p2', null, 'Bash', { command: cmd }, { ...NO_RCA, progressFingerprint: 'sd:EXEC:40' });
+    const r2 = await recordAndCount('sess-p2', null, 'Bash', { command: cmd }, { ...NO_RCA, progressFingerprint: 'sd:EXEC:55' });
+    expect(r2.attempts).toBe(2);
+    expect(r2.progressStalled).toBe(false);
+  });
+
+  it('no fingerprint supplied → progressStalled undefined (back-compat)', async () => {
+    const { recordAndCount } = loadFresh();
+    const r = await recordAndCount('sess-p3', null, 'Bash', { command: 'node scripts/flaky.js' }, NO_RCA);
+    expect(r.progressStalled).toBeUndefined();
   });
 });

--- a/scripts/hooks/__tests__/retry-state-manager.test.js
+++ b/scripts/hooks/__tests__/retry-state-manager.test.js
@@ -1,5 +1,7 @@
 // QF-20260504-830 — exempt /coordinator monitoring scripts from RCA-TIERED dedup.
 // Closes feedback id=57c7873e-09ff-4259-8761-7b6ebbf5d74b.
+// SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 — allowlist RETAINED as the interleaving-safe
+// backstop; structural read-only classifier + Control-4 exit-0 capture added alongside it.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
@@ -14,7 +16,7 @@ function loadFresh() {
   return require(MODULE_PATH);
 }
 
-describe('QF-830 isExempt: known-idempotent /coordinator monitoring scripts', () => {
+describe('QF-830 isExempt: known-idempotent /coordinator monitoring scripts (allowlist backstop)', () => {
   const { isExempt } = loadFresh();
 
   it('exempts stale-session-sweep.cjs', () => {
@@ -53,6 +55,28 @@ describe('QF-830 isExempt: known-idempotent /coordinator monitoring scripts', ()
   });
 });
 
+describe('Control 2 isReadOnlyCommand: structural read-only classifier (deny-by-default)', () => {
+  const { isReadOnlyCommand } = loadFresh();
+
+  it('exempts provably read-only single commands (the coordinator monitoring loop)', () => {
+    expect(isReadOnlyCommand('git status')).toBe(true);
+    expect(isReadOnlyCommand('cat package.json')).toBe(true);
+    expect(isReadOnlyCommand('ls -la src')).toBe(true);
+  });
+
+  it('deny-by-default: script invocations / mutating / compound shapes are NOT read-only', () => {
+    expect(isReadOnlyCommand('node scripts/leo-create-sd.js')).toBe(false);
+    expect(isReadOnlyCommand('git commit -m x')).toBe(false);
+    expect(isReadOnlyCommand('git status && rm x')).toBe(false);
+    expect(isReadOnlyCommand('cat f > g')).toBe(false);
+  });
+
+  it('returns false for non-string / empty input', () => {
+    expect(isReadOnlyCommand(null)).toBe(false);
+    expect(isReadOnlyCommand('')).toBe(false);
+  });
+});
+
 describe('QF-830 recordAndCount: exempt commands skip record AND count', () => {
   let tmpDir;
 
@@ -66,21 +90,19 @@ describe('QF-830 recordAndCount: exempt commands skip record AND count', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('returns count=0 across 4 successive exempt invocations and writes nothing', async () => {
+  it('allowlisted command returns count=0 across 4 successive invocations and writes nothing', async () => {
     const { recordAndCount } = loadFresh();
     const sessionId = 'qf830-exempt';
-    const sdKey = 'SD-FAKE';
     const input = { command: 'node scripts/stale-session-sweep.cjs' };
     const opts = { rcaCheck: async () => null };
 
     for (let i = 0; i < 4; i++) {
-      const r = await recordAndCount(sessionId, sdKey, 'Bash', input, opts);
+      const r = await recordAndCount(sessionId, 'SD-FAKE', 'Bash', input, opts);
       expect(r.attempts).toBe(0);
       expect(r.rcaResetApplied).toBe(false);
       expect(r.signature).toMatch(/^Bash:/);
     }
 
-    // No state file should have been written for the exempt signature.
     const stateFile = path.join(tmpDir, `retry-state-${sessionId}.json`);
     if (fs.existsSync(stateFile)) {
       const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
@@ -88,16 +110,23 @@ describe('QF-830 recordAndCount: exempt commands skip record AND count', () => {
     }
   });
 
-  it('returns counts 1,2,3,4 for non-exempt signature (existing behavior preserved)', async () => {
+  it('a provably read-only command (no prior outcome) also returns count=0 (Control 2)', async () => {
     const { recordAndCount } = loadFresh();
-    const sessionId = 'qf830-throttled';
-    const sdKey = 'SD-FAKE';
+    const opts = { rcaCheck: async () => null };
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount('qf830-ro', 'SD-FAKE', 'Bash', { command: 'git status' }, opts);
+      expect(r.attempts).toBe(0);
+    }
+  });
+
+  it('returns counts 1,2,3,4 for non-exempt signature (existing behavior preserved — teeth)', async () => {
+    const { recordAndCount } = loadFresh();
     const input = { command: 'node scripts/leo-create-sd.js --foo' };
     const opts = { rcaCheck: async () => null };
 
     const counts = [];
     for (let i = 0; i < 4; i++) {
-      const r = await recordAndCount(sessionId, sdKey, 'Bash', input, opts);
+      const r = await recordAndCount('qf830-throttled', 'SD-FAKE', 'Bash', input, opts);
       counts.push(r.attempts);
     }
     expect(counts).toEqual([1, 2, 3, 4]);

--- a/scripts/hooks/post-tool-rca-outcome.cjs
+++ b/scripts/hooks/post-tool-rca-outcome.cjs
@@ -111,7 +111,7 @@ function digestStderr(stderr) {
     // For other tools, outcome capture is unnecessary (signatures are file_path-keyed).
     if (toolName !== 'Bash') return;
 
-    const exitCode =
+    const numericExit =
       typeof resp.exit_code === 'number'
         ? resp.exit_code
         : typeof resp.code === 'number'
@@ -127,7 +127,29 @@ function digestStderr(stderr) {
           : '';
     const stderrSha = digestStderr(stderr);
 
-    // Skip writes that would yield no signal (no exit code AND no stderr).
+    // SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 4 — exit-code capture).
+    // Claude Code's Bash tool_response carries NO numeric exit_code, so a SUCCESSFUL
+    // command previously hit the `exitCode===null && !stderrSha` skip below and wrote no
+    // last-outcome file → the next PreToolUse signature collapsed to command-only (zero
+    // entropy) → identical read-only/idempotent ticks accumulated to the 3-strikes
+    // hard-block (43 false 'stuck' signals in 26h). FIX: infer success from ABSENCE OF
+    // FAILURE and record exit_code 0 so the succeeding-poll exemption in recordAndCount
+    // can fire. STRICT (R2/R3): never infer success when a numeric non-zero code is
+    // present, when stderr/error is non-empty, or when the call was interrupted/flagged —
+    // those keep accumulating (teeth preserved). When numericExit is a number it is used
+    // verbatim (0 = success, non-zero = failure).
+    const failureFlag =
+      resp.is_error === true ||
+      resp.isError === true ||
+      resp.interrupted === true ||
+      (resp.error != null && resp.error !== '');
+    let exitCode = numericExit;
+    if (exitCode === null && !stderrSha && !failureFlag) {
+      exitCode = 0; // no failure signal of any kind → record success
+    }
+
+    // Skip only when there is STILL no usable signal (e.g. a bare failure flag with no
+    // detail) — accumulation/teeth for genuine failures are preserved by NOT exempting.
     if (exitCode === null && !stderrSha) return;
 
     // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: capture command_sha so the next PreToolUse

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1139,6 +1139,7 @@ async function main() {
       // st.sd?.sd_key (string). sub_agent_execution_results.sd_id is UUID-typed;
       // stateMgr.fetchRcaInvocationSince now also UUID-resolves as a safety net.
       let claimedSdKey = null;
+      let progressFingerprint; // Control 3: phase/percent snapshot for auto-signal re-scope
       try {
         const fs2 = require('fs');
         const path2 = require('path');
@@ -1146,6 +1147,11 @@ async function main() {
         if (fs2.existsSync(stateFile)) {
           const st = JSON.parse(fs2.readFileSync(stateFile, 'utf8'));
           claimedSdKey = st.sd?.id || st.sd?.sd_key || null;
+          // SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 3): a stable progress
+          // fingerprint (claimed SD + phase + percent), already on disk so no extra I/O.
+          // recordAndCount compares it across the repetition; a change means the session is
+          // advancing → the auto-signal is suppressed (not a stuck loop).
+          progressFingerprint = `${claimedSdKey || ''}:${st.sd?.phase ?? ''}:${st.sd?.progress ?? ''}`;
         }
       } catch {
         // Missing state file is not fatal — reset lookup simply no-ops.
@@ -1172,8 +1178,8 @@ async function main() {
         // Missing/malformed outcome file → fall through to command-only signature (back-compat).
       }
 
-      const { attempts, signature, rcaResetApplied } = await stateMgr.recordAndCount(
-        _SESSION_ID, claimedSdKey, TOOL_NAME, input, { lastOutcome }
+      const { attempts, signature, rcaResetApplied, progressStalled } = await stateMgr.recordAndCount(
+        _SESSION_ID, claimedSdKey, TOOL_NAME, input, { lastOutcome, progressFingerprint }
       );
 
       if (signature && attempts >= 2) {
@@ -1213,7 +1219,7 @@ async function main() {
         // FAIL-OPEN (any error swallowed — auto-signal must NEVER block or slow a tool call).
         try {
           const { shouldEmitAutoSignal, buildAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
-          if (shouldEmitAutoSignal({ attempts, sessionId: _SESSION_ID, env: process.env })) {
+          if (shouldEmitAutoSignal({ attempts, sessionId: _SESSION_ID, progressStalled, env: process.env })) {
             const path = require('path');
             const { spawn } = require('child_process');
             const args = buildAutoSignalArgs({ toolName: TOOL_NAME, signature, attempts, sdKey: claimedSdKey });

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -35,51 +35,35 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 const _sdKeyToUuidCache = new Map(); // key -> { uuid: string|null, expires_at: number }
 const SD_KEY_CACHE_TTL_MS = 60 * 1000;
 
-// QF-20260504-830 — known-idempotent monitoring commands are exempt from
-// signature dedup. RCA-TIERED ENFORCEMENT was tripping the 4th invocation of
-// /coordinator periodic probes (all exit 0) the same way it gates retry loops.
-// Patterns are matched against the raw Bash command string.
+// QF-20260504-830 / SD-FDBK-INFRA-RCA-TIERED-ENFORCEMENT-001 — known-idempotent monitoring
+// commands are exempt from signature dedup. RETAINED as the INTERLEAVING-SAFE backstop:
+// these MUTATING scheduled scripts (worker-checkin, coordinator-*) cannot be covered by the
+// read-only classifier below, and the exit-0 succeeding-poll exemption keys on a single
+// per-session last-outcome file that interleaved loops CLOBBER (so a recurring command rarely
+// matches its own prior outcome). isExempt short-circuits recordAndCount BEFORE the counter
+// accrues, so the exemption holds under interleaving with no reliance on lastOutcome. Full
+// removal of this allowlist requires per-command outcome storage (clobber-proof) — tracked as
+// a follow-up; SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 stops the arms-race GROWTH via
+// Control 4 (reliable exit-0 capture) + the read-only classifier, not by deleting these.
 const EXEMPT_PATTERNS = [
   /\bscripts[/\\]stale-session-sweep\.cjs\b/,
   /\bscripts[/\\]fleet-dashboard\.cjs\b/,
   /\bscripts[/\\]assign-fleet-identities\.cjs\b/,
   /[/\\]?\.claude[/\\]tmp[/\\]coord-[\w-]+\.(?:cjs|mjs)\b/,
-  // QF-20260610-626 — the remaining canonical coordinator cron loops (coordinator.md
-  // Step 0/5). All exit 0 by design on a fixed interval; the consecutive-attempt counter
-  // misreads the cron cadence as a stuck retry loop (the SD-FDBK-FIX-RCA-TIERED-
-  // ENFORCEMENT-001 exit-0 exemption keys on a single per-session lastOutcome file that
-  // interleaved loops clobber, so it never matches for them). Each pattern is anchored
-  // to the specific script basename — unrelated coordinator-* scripts stay RCA-gated.
   /\bscripts[/\\]coordinator-self-review\.mjs\b/,           // loop 8, */5
   /\bscripts[/\\]coordinator-audit\.mjs\b/,                 // loop 5, */15
   /\bscripts[/\\]coordinator-email-summary\.mjs\b/,         // loop 6, */30
   /\bscripts[/\\]coordinator-startup-check\.mjs\b/,         // startup probe
-  // Step-0 keepalive: a `node -e` inline script (no script path) that re-asserts the
-  // active coordinator ~every 2 min — match its stable tokens, not a path.
   /\bsetActiveCoordinator\b/,
   /\bcoordinator[/\\]resolve\.cjs\b/,
-  // SD-FDBK-INFRA-RCA-TIERED-ENFORCEMENT-001 — two more SCHEDULED, idempotent, succeeding ticks
-  // that the exit-0 exemption can't reliably catch (it keys on the single per-session last-outcome
-  // file, which interleaved loops in a busy session clobber — see the coordinator-cron note above).
-  //   adam-advisory.cjs inbox — the Adam inbox drain (~every 15min + on-demand). Scoped to the
-  //     `inbox` subcommand so a genuinely-failing OTHER adam-advisory subcommand stays RCA-gated.
   /\bscripts[/\\]adam-advisory\.cjs\b[^\n]*\binbox\b/,
-  //   worker-checkin.cjs — the /loop worker check-in tick (each pass; observed blocked at the 3rd
-  //     invocation this session, forcing EMERGENCY_RCA_BYPASS). It always exits 0 on a fixed cadence.
   /\bscripts[/\\]worker-checkin\.cjs\b/,
-  // SD-REFILL-00D2CC0B — two more canonical recurring coordinator crons the exit-0 exemption can't
-  // reliably catch (interleaved loops clobber the single per-session last-outcome file). Each is a
-  // SCHEDULED, idempotent, succeeding tick that the 3x-same-target counter misreads as a stuck retry;
-  // they false-blocked normal fleet re-engagement churn (Adam sourcing multiple V1 SDs rapidly →
-  // coordinator ranks each), forcing EMERGENCY_RCA_BYPASS (witnessed by coordinator Kamo 2026-06-15).
-  //   coordinator-backlog-rank.mjs — re-ranks the dispatch belt; runs per new sourced SD + on interval.
   /\bscripts[/\\]coordinator-backlog-rank\.mjs\b/,
-  //   coordinator-capacity-forecast.mjs — periodic fleet capacity/forecast probe.
   /\bscripts[/\\]coordinator-capacity-forecast\.mjs\b/,
 ];
 
 /**
- * Whether a Bash command should bypass invocation tracking entirely.
+ * Whether a Bash command should bypass invocation tracking entirely (allowlist backstop).
  * Returns false for any non-string input.
  * @param {string} commandStr
  * @returns {boolean}
@@ -87,6 +71,93 @@ const EXEMPT_PATTERNS = [
 function isExempt(commandStr) {
   if (typeof commandStr !== 'string' || !commandStr) return false;
   return EXEMPT_PATTERNS.some(rx => rx.test(commandStr));
+}
+
+// SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 2 — structural read-only
+// classifier). COMPLEMENTS the allowlist above and fixes the SD's primary symptom: the
+// coordinator's READ-ONLY monitoring loop (status/query Bash, never in the script allowlist)
+// false-blocked at the 3-strikes guard. Exemption is structural:
+//   (a) the succeeding-poll exemption in recordAndCount() — prior SAME command exited 0, now
+//       RELIABLY captured by post-tool-rca-outcome.cjs Control 4 — covers non-interleaved ticks;
+//   (b) this DENY-BY-DEFAULT classifier — covers provably READ-ONLY Bash even with no exit code.
+// A FAILING loop (non-zero exit / stderr) still accumulates under every path — teeth preserved.
+
+// Shell metacharacters that could chain or redirect into a mutation. Their presence means we
+// cannot prove the command is read-only, so it is NOT classified read-only.
+const MUTATION_OPERATOR_RE = /[;&|`]|>>?|\$\(|<\(/;
+
+// Provably read-only leading verbs (anchored at the start of the trimmed command).
+const READ_ONLY_LEADING_RE =
+  /^(?:git\s+(?:status|log|diff|show|branch|rev-parse|describe|remote(?:\s+-v)?|config\s+--get|cat-file|ls-files|for-each-ref)\b|ls|ll|pwd|cat|head|tail|grep|rg|find|wc|stat|echo|whoami|date|env|printenv|which|type|node\s+--version|npm\s+(?:run\s+)?(?:ls|list|view|outdated)\b)/i;
+
+/**
+ * Structurally classify a Bash command as provably read-only / non-mutating.
+ * DENY-BY-DEFAULT: returns true ONLY for a single simple command whose leading verb is
+ * provably read-only AND which contains no chaining/redirection/mutation operators. Any
+ * non-string, compound, or unknown command returns false (it still accumulates toward the
+ * 3-strikes guard — an unknown shape is never silently exempted).
+ * @param {string} commandStr
+ * @returns {boolean}
+ */
+function isReadOnlyCommand(commandStr) {
+  if (typeof commandStr !== 'string' || !commandStr) return false;
+  const c = commandStr.trim();
+  if (!c) return false;
+  if (MUTATION_OPERATOR_RE.test(c)) return false; // cannot prove read-only
+  return READ_ONLY_LEADING_RE.test(c);
+}
+
+/**
+ * Resolve the on-disk session-scoped RCA-reset marker path.
+ * @param {string} sessionId
+ * @returns {string}
+ */
+function sessionRcaResetMarkerPath(sessionId) {
+  const override = process.env.LEO_RETRY_STATE_DIR;
+  const dir = override ? path.resolve(override) : path.resolve(__dirname, '../../.claude');
+  return path.join(dir, `rca-reset-${sessionId}.json`);
+}
+
+/**
+ * R5 (SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001): drop a session-scoped RCA-reset
+ * marker. Reachable by ANY session — including coordinator/Adam sessions with no claimed SD,
+ * for which the SD-scoped RCA-row reset (fetchRcaInvocationSince) is structurally
+ * unavailable (it returns null when sdKey is falsy), leaving only EMERGENCY_RCA_BYPASS.
+ * recordAndCount honors this marker when sdKey is falsy. Swallows errors (fail-open).
+ * @param {string} sessionId
+ * @param {string} [atIso] ISO timestamp (defaults to now)
+ * @returns {string|null} the reset timestamp written, or null on failure
+ */
+function writeSessionRcaReset(sessionId, atIso) {
+  if (!sessionId) return null;
+  const at = atIso || new Date().toISOString();
+  try {
+    const fp = sessionRcaResetMarkerPath(sessionId);
+    fs.mkdirSync(path.dirname(fp), { recursive: true });
+    const tmp = `${fp}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify({ reset_at: at }), 'utf8');
+    fs.renameSync(tmp, fp);
+    return at;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the session-scoped RCA-reset marker timestamp, or null on absence/error.
+ * @param {string} sessionId
+ * @returns {string|null}
+ */
+function readSessionRcaReset(sessionId) {
+  if (!sessionId) return null;
+  try {
+    const fp = sessionRcaResetMarkerPath(sessionId);
+    if (!fs.existsSync(fp)) return null;
+    const parsed = JSON.parse(fs.readFileSync(fp, 'utf8'));
+    return parsed && typeof parsed.reset_at === 'string' ? parsed.reset_at : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -280,6 +351,8 @@ function pruneStale(state, nowMs) {
     const ts = state.invocations[sig].filter(t => nowMs - t <= RETRY_WINDOW_MS);
     if (ts.length === 0) {
       delete state.invocations[sig];
+      // Drop the matching Control-3 progress fingerprint so it cannot leak past the window.
+      if (state.progress && typeof state.progress === 'object') delete state.progress[sig];
     } else {
       state.invocations[sig] = ts;
     }
@@ -356,27 +429,45 @@ async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) 
     return { attempts: 0, signature: null, rcaResetApplied: false };
   }
 
-  if (toolName === 'Bash' && isExempt(toolInput && toolInput.command)) {
-    return { attempts: 0, signature, rcaResetApplied: false };
-  }
-
-  // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001: a blind retry is, by definition, re-running
-  // a FAILED command. If the immediately-prior invocation of THIS SAME command exited 0,
-  // this is a succeeding poll (e.g. a recurring monitor cron), not a retry — do not
-  // accumulate toward the 3-strikes guard. COMMAND-SCOPED: lastOutcome.command_sha must
-  // match the current command's hash, so an interleaved success of a DIFFERENT command
-  // can never exempt a genuine failure loop. STRICT: only exit_code 0/'0' exempts;
-  // null/undefined/non-zero codes still accumulate. FAIL-OPEN/back-compat: a legacy
-  // lastOutcome without command_sha (or a non-Bash tool) never exempts.
   if (toolName === 'Bash') {
     const lo = opts.lastOutcome;
     const cmd = typeof (toolInput && toolInput.command) === 'string' ? toolInput.command : '';
+
+    // QF-20260504-830 allowlist backstop (interleaving-safe): mutating idempotent scheduled
+    // ticks short-circuit BEFORE the counter accrues, independent of lastOutcome — see the
+    // EXEMPT_PATTERNS note above for why the exit-0/classifier paths cannot cover them.
+    if (isExempt(cmd)) {
+      return { attempts: 0, signature, rcaResetApplied: false, progressStalled: undefined };
+    }
+
+    // SD-FDBK-FIX-RCA-TIERED-ENFORCEMENT-001 + Control 4: a blind retry is, by definition,
+    // re-running a FAILED command. If the immediately-prior invocation of THIS SAME command
+    // exited 0 (now RELIABLY captured by post-tool-rca-outcome.cjs Control 4), this is a
+    // succeeding poll (a recurring monitor/scheduled cron), not a retry — do not accumulate.
+    // COMMAND-SCOPED: lastOutcome.command_sha must match the current command's hash, so an
+    // interleaved success of a DIFFERENT command can never exempt a genuine failure loop.
+    // STRICT: only exit_code 0/'0' exempts; non-zero codes still accumulate.
     if (
       lo && typeof lo === 'object' && cmd &&
       lo.command_sha === bashCmdHash(cmd) &&
       (lo.exit_code === 0 || lo.exit_code === '0')
     ) {
-      return { attempts: 0, signature, rcaResetApplied: false };
+      return { attempts: 0, signature, rcaResetApplied: false, progressStalled: undefined };
+    }
+
+    // SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 1 + Control 2): absence-of-
+    // failure on a PROVABLY READ-ONLY command. When there is no failure signal — no prior
+    // outcome at all, OR the prior outcome has a null/undefined exit_code AND empty stderr —
+    // AND the command is structurally read-only/non-mutating, it cannot be a blind-retry
+    // FAILURE loop, so it does not accumulate. CONJUNCTION (R1): read-only ALONE (without
+    // absence-of-failure) or absence-of-failure ALONE (without read-only) does NOT exempt —
+    // a FAILING read-only loop (non-null non-zero exit, or stderr) still accumulates.
+    const noFailureSignal =
+      !lo ||
+      ((lo.exit_code === null || lo.exit_code === undefined) &&
+        !(typeof lo.stderr_sha === 'string' && lo.stderr_sha));
+    if (cmd && isReadOnlyCommand(cmd) && noFailureSignal) {
+      return { attempts: 0, signature, rcaResetApplied: false, progressStalled: undefined };
     }
   }
 
@@ -391,6 +482,7 @@ async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) 
     const rcaAt = await rcaCheck(sdKey, state.reset_at);
     if (rcaAt) {
       state.invocations = {};
+      state.progress = {};
       state.reset_at = rcaAt;
       rcaResetApplied = true;
     }
@@ -398,13 +490,49 @@ async function recordAndCount(sessionId, sdKey, toolName, toolInput, opts = {}) 
     // Fail-open: don't block on reset-check errors.
   }
 
+  // R5 (SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001): no-SD-claim sessions (coordinator/
+  // Adam) cannot use the SD-scoped RCA-row reset above (fetchRcaInvocationSince returns null
+  // when sdKey is falsy), leaving only EMERGENCY_RCA_BYPASS. Honor a session-scoped reset
+  // marker any such session can drop via writeSessionRcaReset(sessionId).
+  if (!rcaResetApplied && !sdKey) {
+    try {
+      const marker = readSessionRcaReset(sessionId);
+      if (marker && (!state.reset_at || marker > state.reset_at)) {
+        state.invocations = {};
+        state.progress = {};
+        state.reset_at = marker;
+        rcaResetApplied = true;
+      }
+    } catch {
+      // Fail-open.
+    }
+  }
+
   const existing = Array.isArray(state.invocations[signature]) ? state.invocations[signature] : [];
+
+  // Control 3 support: track a per-signature progress fingerprint so the caller can suppress
+  // a spurious auto-signal. progressStalled === true means the session showed NO progress
+  // (phase/percent unchanged) since this signature first repeated; undefined when the caller
+  // supplies no fingerprint (back-compat — the auto-signal then fires on the ===2 crossing
+  // as before).
+  let progressStalled;
+  if (typeof opts.progressFingerprint === 'string') {
+    if (!state.progress || typeof state.progress !== 'object') state.progress = {};
+    const firstFp = state.progress[signature];
+    if (firstFp === undefined) {
+      state.progress[signature] = opts.progressFingerprint; // baseline on first sighting
+      progressStalled = true;
+    } else {
+      progressStalled = firstFp === opts.progressFingerprint;
+    }
+  }
+
   existing.push(now);
   state.invocations[signature] = existing;
 
   writeState(sessionId, state);
 
-  return { attempts: existing.length, signature, rcaResetApplied };
+  return { attempts: existing.length, signature, rcaResetApplied, progressStalled };
 }
 
 module.exports = {
@@ -417,6 +545,10 @@ module.exports = {
   pruneStale,
   stateFilePath,
   isExempt,
+  isReadOnlyCommand,
+  writeSessionRcaReset,
+  readSessionRcaReset,
+  sessionRcaResetMarkerPath,
   bashCmdHash,
   RETRY_WINDOW_MS,
   UUID_REGEX,

--- a/tests/unit/auto-signal-threshold.test.js
+++ b/tests/unit/auto-signal-threshold.test.js
@@ -43,6 +43,25 @@ describe('shouldEmitAutoSignal (FR-1)', () => {
   });
 });
 
+describe('shouldEmitAutoSignal — Control 3 progress re-scope (SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001)', () => {
+  it('SUPPRESSES the signal when the session is demonstrably progressing (progressStalled=false)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: false, env: {} })).toBe(false);
+  });
+
+  it('still fires at the ===2 crossing when progress is stalled (progressStalled=true)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: true, env: {} })).toBe(true);
+  });
+
+  it('preserves prior fire-on-crossing behavior when progress is unknown (progressStalled=undefined)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: {} })).toBe(true);
+  });
+
+  it('kill-switch and dedupe still win over progressStalled=true', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: true, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, progressStalled: true, env: {} })).toBe(false);
+  });
+});
+
 describe('buildAutoSignalArgs (FR-1)', () => {
   it('builds a stuck/high signal with a single-line bounded body referencing the SD', () => {
     const args = buildAutoSignalArgs({ toolName: 'Bash', signature: 'git reset --hard', attempts: 2, sdKey: 'SD-X-001' });


### PR DESCRIPTION
## SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001

Structural fix for the RCA tiered-enforcement recurrence detector false-blocking read-only/idempotent loops (43 false "stuck" auto-signals in 26h; the coordinator monitoring loop was hard-blocked). Chairman-authorized as a bounded "keep-the-line-running" exception to the product pivot.

### Root cause
Successful Bash carries no `exit_code`, so `post-tool-rca-outcome.cjs` skipped the last-outcome write → the next PreToolUse signature collapsed to command-only (zero entropy) → identical ticks accumulated to the 3-strikes hard-block.

### Four controls (LEAD-locked build order 4 → 1 → 2 → 3+R5), teeth preserved
- **Control 4** (`post-tool-rca-outcome.cjs`): infer success from **absence of failure** and record `exit_code 0` so the succeeding-poll exemption can fire. Strict — never infer success on a numeric non-zero code, stderr, error, or `interrupted`.
- **Control 1** (`retry-state-manager.cjs`): absence-of-failure exemption, **conjoined** with
- **Control 2**: a **deny-by-default** `isReadOnlyCommand` classifier that fixes the SD's primary symptom (the coordinator **read-only** monitoring loop). It **complements** (does not delete) the `EXEMPT_PATTERNS` allowlist, retained as the **interleaving-safe backstop** for mutating scheduled ticks. Full removal needs clobber-proof per-command outcome storage → follow-up.
- **Control 3** (`auto-signal-threshold.cjs` + `pre-tool-enforce.cjs`): emit `stuck` only on genuine no-progress via a `progressStalled` fingerprint computed in the caller; the decision module stays pure.
- **R5**: a session-scoped RCA-reset marker reachable by no-SD-claim coordinator/Adam sessions (`writeSessionRcaReset`), closing the `EMERGENCY_RCA_BYPASS`-only gap.

### Verification
Structural seam `retry-state-manager-coordinator-loops.test.js` (TS-1..TS-7 incl. **TEETH**, conjunction, R5, progress) + Control 4 capture in post-tool tests + Control 3 suppression in auto-signal tests. **70 tests green.** The teeth case (a *failing* read-only loop still accumulates to the hard-block) and the conjunction gate (success-alone / read-only-alone do not over-exempt) are explicitly pinned, proving the false-positive fix did not weaken genuine blind-retry detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
