### PR TITLE
feat(SD-LEO-INFRA-GATE2-BACKEND-FIDELITY-NA-001): exempt backend-API-serving-existing-UI from GATE2 Section A

### DIFF
--- a/scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js
+++ b/scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js
@@ -78,3 +78,47 @@ export function classifyBackendLeaf(sdType, scopeText, titleText) {
   }
   return { exempt: false, reason: 'no backend-leaf signal' };
 }
+
+// SD-LEO-INFRA-GATE2-BACKEND-FIDELITY-NA-001 — signals for a backend SD that SERVES an
+// EXISTING frontend caller (so it MENTIONS UI but ships none). These let the exemption fire
+// even when hasUISurface() is true (the classifyBackendLeaf fence above rejects such SDs).
+export const API_BUILD_RE =
+  /\/api\/|\b(POST|GET|PUT|PATCH|DELETE)\s+\/|\bapi\s+(route|endpoint|handler)\b/i;
+// References an EXISTING/already-wired UI caller — the discriminator vs an SD that BUILDS UI.
+export const SERVES_EXISTING_UI_RE =
+  /\balready\s+calls?\b|\b(operator\s+app|frontend|client|ui|component)\s+already\b|\b\S+\.(tsx|jsx)\s+(already|calls?|expects?)\b/i;
+// Generous "this SD BUILDS a UI surface" fence — keeps a genuine UI SD OUT of the exemption.
+export const BUILDS_NEW_UI_RE =
+  /\b(build|create|add|implement|render|design)\s+(\w+\s+){0,4}(component|page|form|view|dashboard|widget|modal|button|ui)\b/i;
+
+/**
+ * A backend API-endpoint SD that SERVES an EXISTING frontend caller ships NO new UI, but its
+ * scope necessarily NAMES that caller (e.g. ".../route that Stage24GoLive.tsx already calls"),
+ * tripping hasUISurface() — so classifyBackendLeaf's FENCE wrongly returns exempt:false and
+ * Section A false-blocks it (STAGE24 / SD-EHG-PRODUCT-STAGE24-GOLIVE-BACKEND-001 forced 3
+ * bypasses). This detects that precise false-positive: builds an API endpoint AND references an
+ * already-calling UI caller AND does NOT itself build a new UI surface. A real UI SD BUILDS the
+ * surface, so BUILDS_NEW_UI_RE fences it out — the exemption can never relax a genuine UI SD.
+ * Pure + synchronous + never throws.
+ *
+ * @param {string} sdType
+ * @param {string} scopeText
+ * @param {string} titleText
+ * @returns {{exempt: boolean, reason: string}}
+ */
+export function servesExistingUiBackend(sdType, scopeText, titleText) {
+  const t = String(sdType || '').trim().toLowerCase();
+  // Only the UI-capable types fall through to Section A enforcement; other types are already
+  // handled by the sd-type policy / classifyBackendLeaf, so scope this narrowly.
+  if (!BACKEND_CAPABLE_TYPES.includes(t)) {
+    return { exempt: false, reason: 'not a UI-capable type (handled by policy/classifyBackendLeaf)' };
+  }
+  const text = `${scopeText || ''} ${titleText || ''}`;
+  const buildsApi = API_BUILD_RE.test(text);
+  const servesUi = SERVES_EXISTING_UI_RE.test(text);
+  const buildsUi = BUILDS_NEW_UI_RE.test(text);
+  if (buildsApi && servesUi && !buildsUi) {
+    return { exempt: true, reason: 'backend API endpoint serving an existing UI caller - ships no new UI' };
+  }
+  return { exempt: false, reason: 'not a backend-serves-existing-UI leaf' };
+}

--- a/scripts/modules/implementation-fidelity/sections/design-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/design-fidelity.js
@@ -7,7 +7,7 @@
 
 import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 import { getSectionEnforcement } from '../sd-type-section-policy.js';
-import { classifyBackendLeaf, isEhgEngineerTarget } from './backend-leaf-detection.js';
+import { classifyBackendLeaf, isEhgEngineerTarget, servesExistingUiBackend } from './backend-leaf-detection.js';
 
 /**
  * Validate Design Implementation Fidelity
@@ -153,6 +153,25 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
           skipped: true,
           reason: 'EHG frontend lib-level feature with no DB/forms/UI by design (PAT-GATE2-LIBFEATURE-001)'
         };
+        return;
+      }
+    }
+
+    // SD-LEO-INFRA-GATE2-BACKEND-FIDELITY-NA-001 (PAT-GATE2-BACKEND-SERVES-UI-001):
+    // A backend API-endpoint SD that SERVES an EXISTING frontend caller ships NO new UI, but
+    // its scope necessarily NAMES that caller (e.g. "the POST /api/... route that
+    // Stage24GoLive.tsx already calls"), tripping hasUISurface() and disqualifying it from the
+    // classifyBackendLeaf fence below — so STAGE24 (SD-EHG-PRODUCT-STAGE24-GOLIVE-BACKEND-001)
+    // false-blocked Section A and forced 3 bypasses. Fires EVEN WHEN hasUIScope is true (like
+    // PAT-GATE2-LIBFEATURE-001), keyed on the precise false-positive; BUILDS_NEW_UI_RE fences a
+    // genuine UI SD out. Placed BEFORE classifyBackendLeaf since that block rejects on hasUISurface.
+    {
+      const servesUi = servesExistingUiBackend(sd?.sd_type, scopeToCheck, sd?.title);
+      if (servesUi.exempt) {
+        console.log(`   ✅ ${servesUi.reason} - Section A not applicable (25/25) [PAT-GATE2-BACKEND-SERVES-UI-001]`);
+        validation.score += 25;
+        validation.gate_scores.design_fidelity = 25;
+        validation.details.design_fidelity = { skipped: true, reason: `${servesUi.reason} (PAT-GATE2-BACKEND-SERVES-UI-001)` };
         return;
       }
     }

--- a/tests/unit/gate2-backend-serves-ui.test.js
+++ b/tests/unit/gate2-backend-serves-ui.test.js
@@ -1,0 +1,58 @@
+/**
+ * SD-LEO-INFRA-GATE2-BACKEND-FIDELITY-NA-001 — servesExistingUiBackend predicate.
+ *
+ * STAGE24 (SD-EHG-PRODUCT-STAGE24-GOLIVE-BACKEND-001) is a backend API SD ("Build the POST
+ * /api/stage24/{ventureId}/go-live route that Stage24GoLive.tsx already calls") that ships NO
+ * new UI, but its scope NAMES its frontend caller → hasUISurface() trips on "frontend"/".tsx"
+ * → all the !hasUISurface backend exemptions (incl. classifyBackendLeaf) reject it → Section A
+ * false-blocked it, forcing 3 bypasses. These tests pin the fix BIDIRECTIONALLY: the
+ * serves-existing-UI backend SD is exempt, while a genuine UI SD is NOT (BUILDS_NEW_UI_RE fence).
+ */
+import { describe, it, expect } from 'vitest';
+import { servesExistingUiBackend } from '../../scripts/modules/implementation-fidelity/sections/backend-leaf-detection.js';
+
+const STAGE24_SCOPE =
+  'Build the POST /api/stage24/{ventureId}/go-live route that Stage24GoLive.tsx already calls. ' +
+  'v1: (1) validate the Stage-23 launch-readiness gate before allowing go-live; (2) set ventures.deployment_url.';
+const STAGE24_TITLE = 'Implement the Stage-24 Go-Live API endpoint the operator app already calls';
+
+describe('servesExistingUiBackend — exempts a backend API serving an existing UI caller', () => {
+  it('exempts the STAGE24 shape (the false-block that forced 3 bypasses)', () => {
+    const r = servesExistingUiBackend('feature', STAGE24_SCOPE, STAGE24_TITLE);
+    expect(r.exempt).toBe(true);
+  });
+
+  it('exempts a bugfix backend endpoint serving an existing component', () => {
+    const r = servesExistingUiBackend('bugfix', 'Fix the GET /api/ventures/{id}/status handler that VentureStatus.tsx already calls', '');
+    expect(r.exempt).toBe(true);
+  });
+});
+
+describe('servesExistingUiBackend — does NOT exempt genuine UI work (BUILDS_NEW_UI fence)', () => {
+  it('does NOT exempt an SD that BUILDS the .tsx component (even if it calls an existing API)', () => {
+    const r = servesExistingUiBackend('feature', 'Build the Stage24GoLive.tsx component with a go-live button that calls the existing /api/stage24 endpoint', 'Stage24 Go-Live UI');
+    expect(r.exempt).toBe(false);
+  });
+
+  it('does NOT exempt an SD that builds a new dashboard wired to an already-calling API', () => {
+    const r = servesExistingUiBackend('feature', 'Create the new operator dashboard that already calls /api/metrics', 'Operator dashboard');
+    expect(r.exempt).toBe(false);
+  });
+});
+
+describe('servesExistingUiBackend — narrow scope (does not over-fire)', () => {
+  it('does NOT exempt a pure backend API SD with no existing-UI reference (classifyBackendLeaf handles those)', () => {
+    const r = servesExistingUiBackend('feature', 'Build the POST /api/ingest route for the distillation pipeline', '');
+    expect(r.exempt).toBe(false);
+  });
+
+  it('does NOT exempt non-UI-capable types (handled by the sd-type policy)', () => {
+    const r = servesExistingUiBackend('database', STAGE24_SCOPE, STAGE24_TITLE);
+    expect(r.exempt).toBe(false);
+  });
+
+  it('does NOT exempt a UI-referencing SD that builds no API endpoint', () => {
+    const r = servesExistingUiBackend('feature', 'Refactor the helper that Stage24GoLive.tsx already calls', '');
+    expect(r.exempt).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Stops the recurring GATE2 Section-A false-block on product BACKEND SDs (STAGE24 forced 3 bypasses).

## Verify-premise
The no-UI exemption machinery **already exists** (7 layers in design-fidelity.js + classifyBackendLeaf). The real gap is narrow: a backend API SD that **serves** an existing frontend must **name** its caller in scope (`'the POST /api/... route that Stage24GoLive.tsx already calls'`), tripping `hasUISurface()` on 'frontend'/'.tsx' → every `!hasUISurface` exemption rejects it. `hasUISurface` conflates *mentions/serves UI* with *builds UI*.

## Fix (additive — no rebuild, no composite re-weight)
New pure `servesExistingUiBackend()` in backend-leaf-detection.js: exempt iff **builds an API endpoint** AND **references an already-calling UI caller** AND **does NOT build a new UI surface** (`BUILDS_NEW_UI_RE` fence). Wired as a new exemption **before** the `classifyBackendLeaf` fence. A genuine UI SD builds the surface, so it can never satisfy the predicate — the exemption never relaxes a real UI SD.

The SD's FR-3 (composite re-weight) was **descoped as unnecessary** — exemptions return full 25/25 and exit early.

## Tests
7 new bidirectional tests (STAGE24 exempt; UI-building SDs NOT exempt; narrow scope). **All 76 implementation-fidelity tests pass** — no regression to classifyBackendLeaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)