### PR TITLE
fix(SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001): persist S7 derived unit-economics + resilient S9 reality gate

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
@@ -12,6 +12,7 @@
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { deriveUnitEconomics } from '../unit-economics.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 import { PRICING_MODELS } from '../stage-07.js';
@@ -228,6 +229,12 @@ Output ONLY valid JSON.`;
     }
   }
 
+  // SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001 (FR-1): compute + PERSIST the schema-declared
+  // derived unit-economics (ltv, cac_ltv_ratio, payback_months) into the engine_pricing_model
+  // artifact. Previously these were never computed (template computeDerived was dead), so the S9
+  // reality gate false-blocked Phase-2 on their absence. Pure + idempotent; zero-churn yields
+  // null-with-warning (true negative). Persisted as null (never omitted) for field-presence consumers.
+  const derived = deriveUnitEconomics({ arpa, gross_margin_pct, churn_rate_monthly, cac });
   logger.log('[Stage07] Analysis complete', { duration: Date.now() - startTime });
   return {
     pricing_model,
@@ -243,6 +250,10 @@ Output ONLY valid JSON.`;
     churn_rate_monthly,
     cac,
     arpa,
+    ltv: derived.ltv,
+    cac_ltv_ratio: derived.cac_ltv_ratio,
+    payback_months: derived.payback_months,
+    warnings: derived.warnings,
     rationale: String(parsed.rationale || ''),
     fourBuckets, usage, llmFallbackCount,
     financialModelId,

--- a/lib/eva/stage-templates/stage-07.js
+++ b/lib/eva/stage-templates/stage-07.js
@@ -17,6 +17,7 @@
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors, validateCrossStageContract } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage07 } from './analysis-steps/stage-07-pricing-strategy.js';
+import { deriveUnitEconomics } from './unit-economics.js';
 
 const BILLING_PERIODS = ['monthly', 'quarterly', 'annual'];
 const PRICING_MODELS = ['subscription', 'usage_based', 'tiered', 'freemium', 'enterprise', 'marketplace'];
@@ -147,8 +148,14 @@ const TEMPLATE = {
    * @returns {Object} Data with derived metrics
    */
   computeDerived(data, { logger: _logger = console } = {}) {
-    // Dead code: all derivations handled by analysisStep.
-    return { ...data };
+    // SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001: the analysisStep (analyzeStage07) is the
+    // primary path that computes + persists these derived metrics, so this method is not invoked
+    // when an analysisStep exists (see stage-execution-engine.js: analysisStep wins the if/else).
+    // Rewired from dead code to delegate to the SAME shared derivation so any future engine path
+    // that falls back to computeDerived stays consistent with the persisted artifact.
+    const d = deriveUnitEconomics(data || {});
+    const warnings = [...(Array.isArray(data?.warnings) ? data.warnings : []), ...d.warnings];
+    return { ...data, ltv: d.ltv, cac_ltv_ratio: d.cac_ltv_ratio, payback_months: d.payback_months, warnings };
   },
 };
 

--- a/lib/eva/stage-templates/stage-09.js
+++ b/lib/eva/stage-templates/stage-09.js
@@ -18,6 +18,7 @@ import { validateString, validateInteger, validateNumber, validateArray, collect
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { BMC_BLOCKS } from './stage-08.js';
 import { analyzeStage09 } from './analysis-steps/stage-09-exit-strategy.js';
+import { deriveUnitEconomics } from './unit-economics.js';
 
 const MIN_RISKS = 10;
 const MIN_ACQUIRERS = 3;
@@ -206,7 +207,9 @@ const TEMPLATE = {
  *
  * Pass requires:
  *   - Stage 06: >= 10 risks captured
- *   - Stage 07: >= 1 tier and non-null LTV and payback
+ *   - Stage 07: >= 1 tier and VIABLE unit-economics — LTV and payback either persisted or
+ *               computable from the raw inputs, with LTV >= CAC and payback > 0 (metric viability,
+ *               not mere field presence)
  *   - Stage 08: all 9 BMC blocks populated with items
  *
  * @param {{ stage06: Object, stage07: Object, stage08: Object }} prerequisites
@@ -229,13 +232,40 @@ export function evaluateRealityGate({ stage06, stage07, stage08 }) {
     blockers.push('No pricing tiers defined');
     required_next_actions.push('Define at least 1 pricing tier');
   }
-  if (stage07?.ltv === null || stage07?.ltv === undefined) {
-    blockers.push('LTV not computed (likely zero churn rate)');
-    required_next_actions.push('Set a non-zero monthly churn rate to compute LTV');
+  // SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001 (FR-2 resilient + teeth, FR-3 strings):
+  // RESILIENT — when S7 did not persist ltv/payback but the raw inputs are present, recompute
+  // them from the inputs so a single producer miss cannot false-fail Phase-2. TEETH — judge
+  // METRIC VIABILITY, not field presence: a venture that is non-computable from valid inputs,
+  // has payback<=0, or whose LTV is below CAC, still FAILS (the gate is not a rubber stamp).
+  const fallback = deriveUnitEconomics({
+    arpa: stage07?.arpa,
+    gross_margin_pct: stage07?.gross_margin_pct,
+    churn_rate_monthly: stage07?.churn_rate_monthly,
+    cac: stage07?.cac,
+  });
+  const ltv = stage07?.ltv ?? fallback.ltv;
+  const payback_months = stage07?.payback_months ?? fallback.payback_months;
+  const cac = Number(stage07?.cac);
+
+  if (ltv === null || ltv === undefined || !Number.isFinite(ltv)) {
+    const zeroChurn = Number(stage07?.churn_rate_monthly) <= 0;
+    blockers.push(zeroChurn
+      ? 'LTV is a true negative: monthly churn is zero (unbounded customer lifetime), not a viable lifetime value.'
+      : 'LTV not computable: ARPA, gross margin, or churn rate is missing/invalid in the pricing model (derived field not persisted and inputs insufficient).');
+    required_next_actions.push(zeroChurn
+      ? 'Set a realistic non-zero monthly churn rate so LTV is finite.'
+      : 'Ensure Stage 07 persists arpa, gross_margin_pct, and churn_rate_monthly so LTV can be derived.');
+  } else if (Number.isFinite(cac) && ltv < cac) {
+    blockers.push(`Unviable unit economics: LTV (${ltv.toFixed(2)}) is below CAC (${cac.toFixed(2)}).`);
+    required_next_actions.push('Improve pricing or retention so LTV exceeds CAC before exiting Phase 2.');
   }
-  if (stage07?.payback_months === null || stage07?.payback_months === undefined) {
-    blockers.push('Payback months not computed');
-    required_next_actions.push('Ensure ARPA and gross margin produce positive monthly profit');
+
+  if (payback_months === null || payback_months === undefined || !Number.isFinite(payback_months)) {
+    blockers.push('Payback months not computable: monthly gross profit (ARPA × gross margin) is zero or invalid.');
+    required_next_actions.push('Ensure ARPA and gross margin produce positive monthly profit.');
+  } else if (payback_months <= 0) {
+    blockers.push(`Unviable payback: payback_months (${payback_months.toFixed(2)}) is not positive.`);
+    required_next_actions.push('Ensure positive monthly gross profit so payback is a positive number of months.');
   }
 
   // Stage 08 check: all 9 blocks populated

--- a/lib/eva/stage-templates/unit-economics.js
+++ b/lib/eva/stage-templates/unit-economics.js
@@ -1,0 +1,65 @@
+/**
+ * Shared, PURE derivation of S7 unit-economics (LTV, CAC:LTV, payback months).
+ * SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001.
+ *
+ * Single source of truth reused by:
+ *   - the S7 persistence path (analysis-steps/stage-07-pricing-strategy.js) — FR-1
+ *   - the S9 reality gate fallback (stage-09.js evaluateRealityGate) — FR-2
+ * so persist-side and gate-side derivation can never drift.
+ *
+ * Formulas (canonical, per stage-07.js header):
+ *   LTV            = (ARPA * gross_margin_pct/100) / (churn_rate_monthly / 100)   // churn as decimal
+ *   cac_ltv_ratio  = CAC / LTV
+ *   payback_months = CAC / (ARPA * gross_margin_pct/100)                          // churn-independent
+ *
+ * Edge cases yield NULL metrics + a warning (a true negative — never coerced to 0/Infinity):
+ *   - churn <= 0 / non-finite  -> ltv = null (unbounded lifetime), cac_ltv_ratio = null
+ *   - monthly gross profit <= 0 / non-finite -> payback_months = null
+ *
+ * PURE over the four raw inputs only (never reads a prior ltv/payback) -> idempotent / retry-safe.
+ *
+ * @param {{ arpa?: number, gross_margin_pct?: number, churn_rate_monthly?: number, cac?: number }} inputs
+ * @returns {{ ltv: number|null, cac_ltv_ratio: number|null, payback_months: number|null, warnings: string[] }}
+ */
+export function deriveUnitEconomics({ arpa, gross_margin_pct, churn_rate_monthly, cac } = {}) {
+  const warnings = [];
+  const a = Number(arpa);
+  const gm = Number(gross_margin_pct);
+  const churn = Number(churn_rate_monthly);
+  const c = Number(cac);
+
+  // Monthly gross profit per account (ARPA × gross margin). Drives both payback and LTV.
+  const monthlyGrossProfit =
+    Number.isFinite(a) && Number.isFinite(gm) ? a * (gm / 100) : NaN;
+
+  let ltv = null;
+  let cac_ltv_ratio = null;
+  let payback_months = null;
+
+  // LTV depends on churn: average customer lifetime = 1 / churn_decimal months.
+  if (Number.isFinite(monthlyGrossProfit) && Number.isFinite(churn) && churn > 0) {
+    ltv = monthlyGrossProfit / (churn / 100);
+  } else if (Number.isFinite(churn) && churn <= 0) {
+    warnings.push(
+      'LTV not computed: monthly churn is zero — customer lifetime is unbounded, so LTV is a genuine null (true negative), not a missing field.'
+    );
+  } else {
+    warnings.push('LTV not computed: ARPA, gross margin, or churn rate is missing or invalid.');
+  }
+
+  // Payback depends only on monthly gross profit (independent of churn).
+  if (Number.isFinite(monthlyGrossProfit) && monthlyGrossProfit > 0 && Number.isFinite(c)) {
+    payback_months = c / monthlyGrossProfit;
+  } else {
+    warnings.push(
+      'Payback months not computed: monthly gross profit (ARPA × gross margin) is zero or invalid.'
+    );
+  }
+
+  // CAC:LTV ratio (lower is better; < 1 means LTV exceeds CAC).
+  if (ltv !== null && ltv > 0 && Number.isFinite(c)) {
+    cac_ltv_ratio = c / ltv;
+  }
+
+  return { ltv, cac_ltv_ratio, payback_months, warnings };
+}

--- a/tests/unit/eva/stage-templates/s7-derived-unit-econ.test.js
+++ b/tests/unit/eva/stage-templates/s7-derived-unit-econ.test.js
@@ -1,0 +1,83 @@
+// SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001 — derived unit-economics + resilient reality gate.
+import { describe, it, expect } from 'vitest';
+import { deriveUnitEconomics } from '../../../../lib/eva/stage-templates/unit-economics.js';
+import { evaluateRealityGate } from '../../../../lib/eva/stage-templates/stage-09.js';
+import { BMC_BLOCKS } from '../../../../lib/eva/stage-templates/stage-08.js';
+
+// Valid Stage 06 / Stage 08 so the gate verdict turns purely on the S7 unit-economics under test.
+const goodStage06 = { risks: Array.from({ length: 10 }, (_, i) => ({ id: i })) };
+const goodStage08 = Object.fromEntries(BMC_BLOCKS.map((b) => [b, { items: [{ x: 1 }] }]));
+const tiers = [{ name: 'Pro', price: 49 }];
+const gate = (stage07) => evaluateRealityGate({ stage06: goodStage06, stage07, stage08: goodStage08 });
+
+// Venture-1-style healthy inputs.
+const HEALTHY = { arpa: 29.01, gross_margin_pct: 75, churn_rate_monthly: 8, cac: 90 };
+
+describe('deriveUnitEconomics (FR-1 helper)', () => {
+  it('TS-1: healthy inputs yield finite ltv, cac_ltv_ratio, payback_months', () => {
+    const d = deriveUnitEconomics(HEALTHY);
+    // monthlyGrossProfit = 29.01 * 0.75 = 21.7575; ltv = 21.7575 / 0.08 ≈ 271.97
+    expect(d.ltv).toBeGreaterThan(250);
+    expect(d.ltv).toBeLessThan(290);
+    expect(d.payback_months).toBeGreaterThan(0);
+    expect(d.payback_months).toBeCloseTo(90 / 21.7575, 2);
+    expect(d.cac_ltv_ratio).toBeCloseTo(90 / d.ltv, 5);
+    expect(d.warnings).toEqual([]);
+  });
+
+  it('TS-2: zero-churn -> ltv & cac_ltv_ratio null with a true-negative warning; payback still finite (churn-independent)', () => {
+    const d = deriveUnitEconomics({ ...HEALTHY, churn_rate_monthly: 0 });
+    expect(d.ltv).toBeNull();
+    expect(d.cac_ltv_ratio).toBeNull();
+    expect(Number.isFinite(d.payback_months)).toBe(true); // payback does not depend on churn
+    expect(d.warnings.join(' ')).toMatch(/churn is zero/i);
+    expect(d.ltv).not.toBe(Infinity); // never coerced
+  });
+
+  it('TS-2b: zero monthly profit (arpa or margin 0) -> payback null with warning', () => {
+    const d = deriveUnitEconomics({ ...HEALTHY, arpa: 0 });
+    expect(d.payback_months).toBeNull();
+    expect(d.warnings.join(' ')).toMatch(/payback/i);
+  });
+
+  it('TS-3: idempotent — pure over raw inputs (two runs are deeply equal)', () => {
+    expect(deriveUnitEconomics(HEALTHY)).toEqual(deriveUnitEconomics(HEALTHY));
+    // never reads a prior ltv/payback: passing stale derived values does not change the result
+    const withStale = deriveUnitEconomics({ ...HEALTHY, ltv: 999999, payback_months: -5 });
+    expect(withStale).toEqual(deriveUnitEconomics(HEALTHY));
+  });
+});
+
+describe('evaluateRealityGate (FR-2 resilient + teeth, FR-3 strings)', () => {
+  it('TS-4: derived fields ABSENT but raw inputs present + healthy -> resilient PASS', () => {
+    const r = gate({ tiers, ...HEALTHY }); // no ltv / payback_months persisted
+    expect(r.pass).toBe(true);
+    expect(r.blockers).toEqual([]);
+  });
+
+  it('TS-4b: derived fields PRESENT + viable -> PASS (no regression)', () => {
+    const r = gate({ tiers, ltv: 272, payback_months: 4.13, cac: 90, ...HEALTHY });
+    expect(r.pass).toBe(true);
+  });
+
+  it('TS-5: TEETH — computable but LTV < CAC -> FAIL (not a rubber stamp)', () => {
+    // monthlyProfit = 10*0.5 = 5; ltv = 5/0.08 = 62.5; cac = 10000 -> unviable
+    const r = gate({ tiers, arpa: 10, gross_margin_pct: 50, churn_rate_monthly: 8, cac: 10000 });
+    expect(r.pass).toBe(false);
+    expect(r.blockers.join(' ')).toMatch(/below CAC/i);
+  });
+
+  it('TS-6: zero-churn -> FAIL with a TRUE-NEGATIVE string, not the misleading "LTV not computed"', () => {
+    const r = gate({ tiers, ...HEALTHY, churn_rate_monthly: 0 });
+    expect(r.pass).toBe(false);
+    const blockers = r.blockers.join(' ');
+    expect(blockers).toMatch(/true negative|churn is zero/i);
+    expect(blockers).not.toMatch(/LTV not computed \(likely zero churn rate\)/);
+  });
+
+  it('TS-6b: non-computable (no inputs, no derived) -> FAIL naming the missing-derived-field cause', () => {
+    const r = gate({ tiers, cac: 90 }); // no arpa/margin/churn, no ltv/payback
+    expect(r.pass).toBe(false);
+    expect(r.blockers.join(' ')).toMatch(/not computable|missing|invalid/i);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-S7-DERIVED-UNIT-ECON-PERSIST-001

A venture-1 factory root-fix (blocks-product cap, chairman root-cause-hunt). S7 declared `ltv`/`cac_ltv_ratio`/`payback_months` but never computed them (the template `computeDerived` was dead code; `analyzeStage07` returned only raw inputs), so the persisted `engine_pricing_model` omitted them and the **S9 reality gate false-blocked Phase-2** on their absence even when valid raw inputs were present.

### Changes (backend EVA only, 5 files)
- **Shared pure helper** `lib/eva/stage-templates/unit-economics.js` (`deriveUnitEconomics`) — one source of truth for the canonical formulas, reused by persist + gate so they can't drift; zero-churn / zero-profit → null metric + warning (true negative, never coerced); idempotent over the four raw inputs.
- **FR-1**: `analyzeStage07` computes + persists `ltv/cac_ltv_ratio/payback_months` (+warnings) into the artifact (null, not omitted); `stage-07` `computeDerived` rewired from dead code to delegate to the helper.
- **FR-2**: `evaluateRealityGate` is **resilient** (recomputes from raw inputs when derived absent) **with teeth** — metric viability, not field presence: non-computable / payback≤0 / LTV<CAC still **FAILS** (not a rubber stamp).
- **FR-3**: corrected the misleading blocker/required-action strings (missing-derived-field vs genuinely-zero-churn).

### Verification
6 scenarios in `s7-derived-unit-econ.test.js` (healthy derive, zero-churn null+warning, idempotency, resilient-pass, **TEETH unviable-fail**, corrected strings) + no regression in existing stage-07/09 suites — **37 tests green**. Deploy-safe: no in-flight venture to corrupt (venture-1 at stage 11); additive (`financial-contract.js` already reads `ltv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
