### PR TITLE
feat(SD-LEO-INFRA-S7-ACQUISITION-TIER-RUBRIC-001): derive S7 acquisition-tier from segment/GTM motion

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
@@ -19,6 +19,122 @@ import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 
 const POSITIONING_VALUES = ['premium', 'parity', 'discount'];
 
+// ── Acquisition-tier rubric (SD-LEO-INFRA-S7-ACQUISITION-TIER-RUBRIC-001) ──────────────
+// DERIVE the top-of-funnel (free/teaser vs trial) decision from the venture's segment + GTM
+// motion instead of leaving it to LLM discretion. ADD-only: competitor-anchoring is untouched.
+const SELF_SERVE_PATTERNS = /\b(self[\s-]?serve|plg|product[\s-]?led|freemium|free[\s-]?trial|bottoms?[\s-]?up|prosumer|individuals?|smb|small[\s-]?business|developers?|indie|volume|consumer|d2c|b2c)\b/i;
+const HIGH_ACV_PATTERNS = /\b(enterprise|sales[\s-]?led|high[\s-]?acv|high[\s-]?touch|fortune[\s-]?\d*|mid[\s-]?market|account[\s-]?based|abm|complex[\s-]?sale|procurement|rfp|top[\s-]?down|large[\s-]?organi[sz]ations?)\b/i;
+
+function classifyMotion(text) {
+  const t = String(text || '');
+  return { selfServe: SELF_SERVE_PATTERNS.test(t), highAcv: HIGH_ACV_PATTERNS.test(t) };
+}
+
+function segmentText(sz) {
+  if (!sz) return '';
+  if (typeof sz === 'string') return sz;
+  if (typeof sz === 'object') {
+    const parts = [sz.segment, sz.name, sz.motion, sz.gtm, sz.gtm_motion, sz.description].filter(Boolean);
+    return parts.length ? parts.join(' ') : JSON.stringify(sz);
+  }
+  return String(sz);
+}
+
+/**
+ * FR-2 — derive normalized segment/GTM signals from inputs already available to analyzeStage07.
+ * Pure (no I/O). A ratified stage_zero segment is authoritative and overrides weaker keyword signals.
+ * @param {{stage1Data?:Object, stage4Data?:Object, stageZeroSegment?:(string|Object|null)}} params
+ * @returns {{selfServe:boolean, highAcv:boolean, dual:boolean, source:string}}
+ */
+export function extractSegmentGtmSignals({ stage1Data = {}, stage4Data = {}, stageZeroSegment = null } = {}) {
+  // Ratified stage_zero segment is the highest-trust signal — overrides conflicting weaker hits.
+  if (stageZeroSegment) {
+    const sz = classifyMotion(segmentText(stageZeroSegment));
+    if (sz.selfServe || sz.highAcv) {
+      return { selfServe: sz.selfServe, highAcv: sz.highAcv, dual: sz.selfServe && sz.highAcv, source: 'stage_zero' };
+    }
+  }
+  // Fall back to weaker keyword signals from Stage-1 concept + Stage-4 competitive GTM patterns.
+  const pm = stage4Data?.stage5Handoff?.pricingModels;
+  const texts = [
+    stage1Data?.targetMarket,
+    stage1Data?.archetype,
+    stage1Data?.description,
+    Array.isArray(pm) && pm.length ? pm.join(' ') : null,
+  ].filter(Boolean).map(String);
+  let selfServe = false, highAcv = false;
+  for (const t of texts) {
+    const c = classifyMotion(t);
+    selfServe = selfServe || c.selfServe;
+    highAcv = highAcv || c.highAcv;
+  }
+  return { selfServe, highAcv, dual: selfServe && highAcv, source: (selfServe || highAcv) ? 'stage1' : 'none' };
+}
+
+/**
+ * FR-1 — map segment/GTM signals to an acquisition-tier recommendation. Pure.
+ * @param {{selfServe?:boolean, highAcv?:boolean, dual?:boolean}} signals
+ * @returns {{recommendation:string, tierType:string, permanentFree:boolean, rationale:string}}
+ */
+export function deriveAcquisitionTier(signals = {}) {
+  const selfServe = !!signals.selfServe;
+  const highAcv = !!signals.highAcv;
+  const dual = signals.dual ?? (selfServe && highAcv);
+  if (dual) {
+    return { recommendation: 'dual', tierType: 'freemium', permanentFree: true,
+      rationale: 'Dual-segment: free/freemium teaser for the self-serve segment + paid tiers for the high-ACV segment.' };
+  }
+  if (selfServe) {
+    return { recommendation: 'free_teaser', tierType: 'freemium', permanentFree: true,
+      rationale: 'Self-serve/PLG/volume segment: include a free/freemium acquisition (teaser) tier.' };
+  }
+  if (highAcv) {
+    return { recommendation: 'trial_demo', tierType: 'trial', permanentFree: false,
+      rationale: 'High-ACV/enterprise/sales-led segment: time-limited trial or demo, no permanent free tier.' };
+  }
+  // Conservative default: with no self-serve signal, never auto-grant a permanent free tier.
+  return { recommendation: 'trial_demo', tierType: 'trial', permanentFree: false,
+    rationale: 'Insufficient segment signal: conservative default (time-limited trial, no permanent free tier).' };
+}
+
+/**
+ * FR-3 — apply the acquisition-tier recommendation to a normalized tiers array. Pure (returns a
+ * NEW array). Additive: never removes or reprices the competitor-anchored paid tiers.
+ * @returns {{tiers:Array, added:boolean, converted:boolean}}
+ */
+export function applyAcquisitionTier(tiers, rec, { selfServeSegment = 'Self-serve' } = {}) {
+  const out = Array.isArray(tiers) ? tiers.map(t => ({ ...t })) : [];
+  let added = false, converted = false;
+  const hasFreeTier = out.some(t => Number(t.price) === 0);
+
+  if (rec && rec.permanentFree) {
+    // self-serve / dual: ensure a free/freemium teaser exists (additive; paid tiers untouched).
+    if (!hasFreeTier) {
+      out.unshift({
+        name: rec.tierType === 'free' ? 'Free' : 'Freemium',
+        price: 0,
+        billing_period: 'monthly',
+        target_segment: selfServeSegment,
+        included_units: 'Free acquisition (teaser) tier',
+        acquisition_tier: true,
+      });
+      added = true;
+    }
+  } else {
+    // enterprise-only / conservative: NO permanent free tier — convert any permanent price-0 tier
+    // into a time-limited trial flag rather than keeping a permanent free tier.
+    for (const t of out) {
+      if (Number(t.price) === 0) {
+        t.trial = true;
+        t.trial_days = 14;
+        t.included_units = `Time-limited ${rec && rec.tierType ? rec.tierType : 'trial'} (no permanent free tier)`;
+        converted = true;
+      }
+    }
+  }
+  return { tiers: out, added, converted };
+}
+
 const SYSTEM_PROMPT = `You are EVA's Revenue Architecture Engine. Generate a pricing strategy for a venture.
 
 You MUST output valid JSON with exactly this structure:
@@ -68,7 +184,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Pricing strategy with tiers and unit economics
  */
-export async function analyzeStage07({ stage1Data, stage4Data, stage5Data, stage6Data, ventureName, ventureId, supabase, logger = console }) {
+export async function analyzeStage07({ stage1Data, stage4Data, stage5Data, stage6Data, stageZeroSegment = null, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage07] Starting analysis', { ventureName });
   if (!stage1Data?.description) {
@@ -118,6 +234,14 @@ export async function analyzeStage07({ stage1Data, stage4Data, stage5Data, stage
     ? `Risk Profile: ${stage6Data.totalRisks} risks, ${stage6Data.highRiskCount} high-risk (score >= 15)`
     : '';
 
+  // Acquisition-tier rubric (SD-LEO-INFRA-S7-ACQUISITION-TIER-RUBRIC-001): DERIVE the top-of-funnel
+  // motion from segment/GTM signals. FR-4 nudges the LLM; FR-3 post-processing is authoritative.
+  const acqSignals = extractSegmentGtmSignals({ stage1Data, stage4Data, stageZeroSegment });
+  const acqRec = deriveAcquisitionTier(acqSignals);
+  const acquisitionMotionLine = acqRec.permanentFree
+    ? `Acquisition motion: INCLUDE a free/freemium teaser tier for the self-serve segment (${acqRec.recommendation}).`
+    : `Acquisition motion: time-limited trial/demo only, NO permanent free tier (${acqRec.recommendation}).`;
+
   // Web-grounded search for pricing intelligence
   let webContext = '';
   if (isSearchEnabled()) {
@@ -142,6 +266,7 @@ ${competitiveContext}
 ${financialContext}
 
 ${riskContext}
+${acquisitionMotionLine}
 ${webContext}
 Output ONLY valid JSON.`;
 
@@ -170,6 +295,10 @@ Output ONLY valid JSON.`;
     included_units: String(t.included_units || 'Standard features'),
   })) : [];
 
+  // FR-3: capture the competitor-anchored paid price BEFORE adding any acquisition teaser, so
+  // unit-economics (arpa) and priceAnchor stay anchored to the paid tier, not a price-0 teaser.
+  const paidAnchorPrice = tiers.find(t => Number(t.price) > 0)?.price || tiers[0]?.price || 0;
+
   // Seed unit economics from Stage 5 if available
   const s5GrossMargin = (stage5Data?.grossProfitY1 && stage5Data?.year1?.revenue)
     ? (stage5Data.grossProfitY1 / stage5Data.year1.revenue) * 100
@@ -192,11 +321,18 @@ Output ONLY valid JSON.`;
   const gross_margin_pct = clamp(rawGrossMargin ?? s5GrossMargin, 0, 100, logger, 'unitEconomics.gross_margin_pct');
   const churn_rate_monthly = clamp(rawChurnMonthly ?? s5Churn, 0, 100, logger, 'unitEconomics.churn_rate_monthly');
   const cac = Math.max(0, Number(rawCac ?? stage5Data?.unitEconomics?.cac ?? 100));
-  const arpa = Math.max(0, Number(rawArpa ?? (tiers[0]?.price || 49)));
+  const arpa = Math.max(0, Number(rawArpa ?? (paidAnchorPrice || 49)));
 
   if (llmFallbackCount > 0) {
     logger.warn('[Stage07] LLM fallback fields detected', { llmFallbackCount });
   }
+
+  // FR-3: apply the derived acquisition-tier recommendation (additive; competitor-anchored paid
+  // tiers untouched). Mutates `tiers` in place to the post-processed array.
+  const acqApplied = applyAcquisitionTier(tiers, acqRec, { selfServeSegment: stage1Data?.targetMarket || 'Self-serve' });
+  tiers.length = 0;
+  tiers.push(...acqApplied.tiers);
+  logger.log('[Stage07] Acquisition tier applied', { recommendation: acqRec.recommendation, added: acqApplied.added, converted: acqApplied.converted });
 
   // Enrich financial_models with pricing data (dual-write: advisory_data preserved by engine)
   if (supabase && financialModelId && financialModelRecord) {
@@ -208,7 +344,7 @@ Output ONLY valid JSON.`;
           tiers,
           priceAnchor: {
             competitorAvg: Math.max(0, Number(parsed.priceAnchor?.competitorAvg) || 0),
-            proposedPrice: Math.max(0, Number(parsed.priceAnchor?.proposedPrice) || tiers[0]?.price || 0),
+            proposedPrice: Math.max(0, Number(parsed.priceAnchor?.proposedPrice) || paidAnchorPrice || 0),
             positioning,
           },
           gross_margin_pct,
@@ -239,6 +375,7 @@ Output ONLY valid JSON.`;
       positioning,
     },
     tiers,
+    acquisitionTier: { ...acqRec, signals: acqSignals, teaserAdded: acqApplied.added, permanentFreeConverted: acqApplied.converted },
     gross_margin_pct,
     churn_rate_monthly,
     cac,

--- a/tests/unit/eva/stage-07-acquisition-tier.test.js
+++ b/tests/unit/eva/stage-07-acquisition-tier.test.js
@@ -1,0 +1,123 @@
+/**
+ * FR-1/FR-2/FR-3 — S7 acquisition-tier rubric
+ * SD-LEO-INFRA-S7-ACQUISITION-TIER-RUBRIC-001
+ *
+ * DERIVE the top-of-funnel decision from segment/GTM motion instead of LLM discretion.
+ * Root-cause: venture-1 S7 produced no free teaser and the chairman restored it manually.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractSegmentGtmSignals,
+  deriveAcquisitionTier,
+  applyAcquisitionTier,
+} from '../../../lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js';
+
+describe('deriveAcquisitionTier (FR-1)', () => {
+  it('self-serve segment -> free/freemium teaser, permanentFree true', () => {
+    const rec = deriveAcquisitionTier({ selfServe: true });
+    expect(rec.recommendation).toBe('free_teaser');
+    expect(rec.permanentFree).toBe(true);
+    expect(['free', 'freemium']).toContain(rec.tierType);
+  });
+
+  it('enterprise / high-ACV segment -> trial/demo, NO permanent free tier', () => {
+    const rec = deriveAcquisitionTier({ highAcv: true });
+    expect(rec.recommendation).toBe('trial_demo');
+    expect(rec.permanentFree).toBe(false);
+    expect(['trial', 'demo']).toContain(rec.tierType);
+  });
+
+  it('dual-segment -> dual recommendation, permanentFree true', () => {
+    const rec = deriveAcquisitionTier({ selfServe: true, highAcv: true });
+    expect(rec.recommendation).toBe('dual');
+    expect(rec.permanentFree).toBe(true);
+  });
+
+  it('unknown / insufficient signal -> conservative default (no permanent free tier)', () => {
+    const rec = deriveAcquisitionTier({});
+    expect(rec.recommendation).toBe('trial_demo');
+    expect(rec.permanentFree).toBe(false);
+  });
+});
+
+describe('extractSegmentGtmSignals (FR-2)', () => {
+  it('self-serve language in targetMarket yields selfServe:true', () => {
+    const s = extractSegmentGtmSignals({ stage1Data: { targetMarket: 'Self-serve PLG tool for indie developers' } });
+    expect(s.selfServe).toBe(true);
+    expect(s.highAcv).toBe(false);
+    expect(s.source).toBe('stage1');
+  });
+
+  it('enterprise / sales-led language yields highAcv:true', () => {
+    const s = extractSegmentGtmSignals({ stage1Data: { targetMarket: 'Enterprise, sales-led with procurement and RFP cycles' } });
+    expect(s.highAcv).toBe(true);
+    expect(s.selfServe).toBe(false);
+  });
+
+  it('both self-serve and enterprise signals present yields dual:true', () => {
+    const s = extractSegmentGtmSignals({ stage1Data: { targetMarket: 'SMB self-serve plus enterprise sales-led accounts' } });
+    expect(s.dual).toBe(true);
+    expect(s.selfServe).toBe(true);
+    expect(s.highAcv).toBe(true);
+  });
+
+  it('ratified stage_zero segment overrides a conflicting weaker keyword signal', () => {
+    // stage1 keyword says self-serve, but the ratified stage_zero segment says enterprise -> enterprise wins.
+    const s = extractSegmentGtmSignals({
+      stage1Data: { targetMarket: 'self-serve developers' },
+      stageZeroSegment: 'Enterprise sales-led accounts',
+    });
+    expect(s.source).toBe('stage_zero');
+    expect(s.highAcv).toBe(true);
+    expect(s.selfServe).toBe(false);
+  });
+});
+
+describe('applyAcquisitionTier (FR-3)', () => {
+  const paidTiers = [
+    { name: 'Pro', price: 49, billing_period: 'monthly', target_segment: 'Teams' },
+    { name: 'Business', price: 199, billing_period: 'monthly', target_segment: 'Orgs' },
+  ];
+
+  it('self-serve recommendation adds a teaser tier and leaves paid tiers byte-identical', () => {
+    const rec = deriveAcquisitionTier({ selfServe: true });
+    const { tiers, added } = applyAcquisitionTier(paidTiers, rec);
+    expect(added).toBe(true);
+    // teaser prepended
+    expect(tiers[0].price).toBe(0);
+    expect(tiers[0].acquisition_tier).toBe(true);
+    // competitor-anchored paid tiers unchanged (name + price byte-identical)
+    const pro = tiers.find(t => t.name === 'Pro');
+    const biz = tiers.find(t => t.name === 'Business');
+    expect(pro.price).toBe(49);
+    expect(biz.price).toBe(199);
+    // original input array not mutated (pure function)
+    expect(paidTiers).toHaveLength(2);
+  });
+
+  it('dual-segment recommendation adds a teaser AND retains the paid tiers', () => {
+    const rec = deriveAcquisitionTier({ selfServe: true, highAcv: true });
+    const { tiers, added } = applyAcquisitionTier(paidTiers, rec);
+    expect(added).toBe(true);
+    expect(tiers).toHaveLength(3);
+    expect(tiers.filter(t => t.price > 0).map(t => t.name)).toEqual(['Pro', 'Business']);
+  });
+
+  it('enterprise recommendation does not leave a permanent free tier (converts price-0 to trial)', () => {
+    const rec = deriveAcquisitionTier({ highAcv: true });
+    const withFree = [{ name: 'Free', price: 0 }, ...paidTiers];
+    const { tiers, added, converted } = applyAcquisitionTier(withFree, rec);
+    expect(added).toBe(false);
+    expect(converted).toBe(true);
+    const free = tiers.find(t => Number(t.price) === 0);
+    expect(free.trial).toBe(true); // no longer a permanent free tier
+  });
+
+  it('does not add a second teaser when a free tier already exists (self-serve)', () => {
+    const rec = deriveAcquisitionTier({ selfServe: true });
+    const withFree = [{ name: 'Free', price: 0 }, ...paidTiers];
+    const { tiers, added } = applyAcquisitionTier(withFree, rec);
+    expect(added).toBe(false);
+    expect(tiers.filter(t => Number(t.price) === 0)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a segment/GTM-driven **acquisition-tier (top-of-funnel) rubric** to the S7 pricing engine so the free-teaser-vs-trial decision is DERIVED, not left to LLM discretion.

Root-cause (venture-1 S7): the pricing engine required >=2 tiers + competitor anchors but had no rule for an acquisition tier — no free teaser was produced and the chairman restored it manually. A free top-of-funnel is right for self-serve/PLG but wrong for pure enterprise/sales-led.

## Changes (`lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js`)
- **FR-1 `deriveAcquisitionTier(signals)`** — self-serve/PLG → free/freemium teaser; high-ACV/enterprise/sales-led → time-limited trial/demo (NO permanent free); dual-segment → teaser for self-serve + paid for high-ACV; conservative default (no permanent free without a self-serve signal).
- **FR-2 `extractSegmentGtmSignals()`** — classifies Stage-1 concept/target-market/archetype + Stage-4 competitive GTM patterns; a ratified `stage_zero` segment is authoritative and overrides weaker keyword signals.
- **FR-3 `applyAcquisitionTier()`** — additive post-processing after tiers normalization. Competitor-anchored paid tiers, `priceAnchor`, and `arpa` are anchored to the paid price (unchanged); enterprise price-0 tiers convert to time-limited trial.
- **FR-4** — derived acquisition-motion nudge added to the user prompt; the static `SYSTEM_PROMPT` is byte-unchanged (post-processing is authoritative).
- Exposes `acquisitionTier` on the `analyzeStage07` result for observability.

## Tests
- `tests/unit/eva/stage-07-acquisition-tier.test.js` — **12/12 pass**: all branches (self-serve / enterprise / dual / default), stage_zero override, FR-3 teaser-add + enterprise conversion, anchoring-unchanged, pure-function no-mutation.
- 811 stage tests green (no regression).

SD: SD-LEO-INFRA-S7-ACQUISITION-TIER-RUBRIC-001 (chairman-approved 2026-06-25; coordinator-directed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)