### PR TITLE
feat(SD-LEO-INFRA-EVA-RESERVED-GATES-ENFORCEMENT-001): enforce chairman-reserved EVA gates as always-manual

### DIFF
--- a/lib/eva/autonomy-model.js
+++ b/lib/eva/autonomy-model.js
@@ -45,6 +45,12 @@ export const GATE_BEHAVIOR_MATRIX = {
   L4: { stage_gate: 'auto_approve', kill_gate: 'manual', promotion_gate: 'auto_approve', reality_gate: 'auto_approve', devils_advocate: 'skip' },
 };
 
+// SD-LEO-INFRA-EVA-RESERVED-GATES-ENFORCEMENT-001 (chairman ruling 3/3): the stages the chairman
+// has RESERVED as always-manual. A reserved stage must NEVER auto-approve regardless of autonomy
+// level (L0-L4), gate-type classification, or chairman autonomy override. This set is the durable,
+// classification-INDEPENDENT backstop — FR-3's gate-type correction is defense-in-depth behind it.
+export const RESERVED_CHAIRMAN_STAGES = new Set([3, 5, 10, 17, 18, 19]);
+
 /**
  * Check autonomy level for a venture and determine gate action.
  *
@@ -53,7 +59,13 @@ export const GATE_BEHAVIOR_MATRIX = {
  * @param {object} deps - { supabase }
  * @returns {Promise<{action: string, level: string, reason: string}>}
  */
-export async function checkAutonomy(ventureId, gateType, { supabase }) {
+export async function checkAutonomy(ventureId, gateType, { supabase }, stageNumber = null) {
+  // FR-1: a chairman-reserved stage is ALWAYS manual — fires before the eva_ventures fetch and the
+  // GATE_BEHAVIOR_MATRIX lookup, so no autonomy level (L0-L4) and no gate-type can auto-approve it.
+  if (stageNumber != null && RESERVED_CHAIRMAN_STAGES.has(stageNumber)) {
+    return { action: 'manual', level: 'reserved', reserved: true, reason: `Reserved chairman stage ${stageNumber} — always manual` };
+  }
+
   const { data, error } = await supabase
     .from('eva_ventures')
     .select('autonomy_level')
@@ -106,7 +118,15 @@ export async function getAutonomyOverride(ventureId, { chairmanPreferenceStore }
  * @param {object} deps - { supabase, chairmanPreferenceStore? }
  * @returns {Promise<{action: string, level: string, reason: string, overridden: boolean}>}
  */
-export async function autonomyPreCheck(ventureId, gateType, deps) {
+export async function autonomyPreCheck(ventureId, gateType, deps, stageNumber = null) {
+  // FR-1: reserved-stage check fires BEFORE getAutonomyOverride, so no chairman autonomy override
+  // (e.g. L4) can downgrade a reserved gate. checkAutonomy applies the same classification-
+  // independent rule; we surface it here as the authoritative, non-overridable result.
+  if (stageNumber != null && RESERVED_CHAIRMAN_STAGES.has(stageNumber)) {
+    const result = await checkAutonomy(ventureId, gateType, deps, stageNumber);
+    return { ...result, overridden: false };
+  }
+
   const override = await getAutonomyOverride(ventureId, deps);
   if (override) {
     const matrix = GATE_BEHAVIOR_MATRIX[override];

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -551,9 +551,12 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
 
   // ── 4a.2. Resolve chairman gate from onBeforeAnalysis (autonomy-aware) ──
   if (hookContext.chairmanDecisionId && stageOutput) {
-    // FR-2: thread resolvedStage so the FR-1 reserved-stage backstop fires (a reserved stage is
-    // manual regardless of the gateType passed). FR-2b (true gate type via stage-governance) is layered next.
-    const autonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage).catch(() => ({ action: 'manual' }));
+    // FR-2: thread resolvedStage (so the FR-1 reserved backstop fires) + resolve the stage's TRUE
+    // autonomy gate type from stage-governance (FR-2b) so non-reserved promotion stages honor
+    // promotion semantics instead of the hardcoded 'stage_gate'. Reserved stages are manual anyway.
+    const govA = await import('./stage-governance.js').then(m => m.getStageGovernance(supabase)).catch(() => null);
+    const gateTypeA = govA?.gateTypeForAutonomy?.(resolvedStage) ?? 'stage_gate';
+    const autonomy = await autonomyPreCheck(ventureId, gateTypeA, { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage).catch(() => ({ action: 'manual' }));
     if (autonomy.action === 'auto_approve') {
       await supabase.from('chairman_decisions')
         .update({ status: 'approved', decision: 'proceed', rationale: `Auto-approved (${autonomy.level} autonomy)` })
@@ -689,8 +692,10 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
 
   try {
     // Autonomy pre-check for stage gates
-    const stageAutonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
-    gateResults.push({ type: 'autonomy_check', gateType: 'stage_gate', passed: true, ...stageAutonomy });
+    const govS = await import('./stage-governance.js').then(m => m.getStageGovernance(supabase)).catch(() => null);
+    const gateTypeS = govS?.gateTypeForAutonomy?.(resolvedStage) ?? 'stage_gate'; // FR-2b: true gate type
+    const stageAutonomy = await autonomyPreCheck(ventureId, gateTypeS, { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
+    gateResults.push({ type: 'autonomy_check', gateType: gateTypeS, passed: true, ...stageAutonomy });
 
     let stageGateResult;
     if (stageAutonomy.action === 'auto_approve') {

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -551,7 +551,9 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
 
   // ── 4a.2. Resolve chairman gate from onBeforeAnalysis (autonomy-aware) ──
   if (hookContext.chairmanDecisionId && stageOutput) {
-    const autonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }).catch(() => ({ action: 'manual' }));
+    // FR-2: thread resolvedStage so the FR-1 reserved-stage backstop fires (a reserved stage is
+    // manual regardless of the gateType passed). FR-2b (true gate type via stage-governance) is layered next.
+    const autonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage).catch(() => ({ action: 'manual' }));
     if (autonomy.action === 'auto_approve') {
       await supabase.from('chairman_decisions')
         .update({ status: 'approved', decision: 'proceed', rationale: `Auto-approved (${autonomy.level} autonomy)` })
@@ -687,7 +689,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
 
   try {
     // Autonomy pre-check for stage gates
-    const stageAutonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore });
+    const stageAutonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
     gateResults.push({ type: 'autonomy_check', gateType: 'stage_gate', passed: true, ...stageAutonomy });
 
     let stageGateResult;
@@ -707,7 +709,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     if (!stageGateResult.passed) gateBlocked = true;
 
     // Autonomy pre-check for reality gates
-    const realityAutonomy = await autonomyPreCheck(ventureId, 'reality_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore });
+    const realityAutonomy = await autonomyPreCheck(ventureId, 'reality_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
     gateResults.push({ type: 'autonomy_check', gateType: 'reality_gate', passed: true, ...realityAutonomy });
 
     let realityGateResult;
@@ -789,7 +791,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   let devilsAdvocateReview = null;
   if (hasDAGate) {
     // Autonomy pre-check for devil's advocate
-    const daAutonomy = await autonomyPreCheck(ventureId, 'devils_advocate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore });
+    const daAutonomy = await autonomyPreCheck(ventureId, 'devils_advocate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
     if (daAutonomy.action === 'skip') {
       gateResults.push({ type: 'devils_advocate', passed: true, summary: `Skipped at ${daAutonomy.level}`, autonomyAction: 'skip' });
     } else if (daAutonomy.action === 'auto_approve') {

--- a/lib/eva/stage-governance.js
+++ b/lib/eva/stage-governance.js
@@ -26,7 +26,22 @@
  *   - If realtime subscription fails, falls back to TTL-only refresh.
  */
 
+import { RESERVED_CHAIRMAN_STAGES } from './autonomy-model.js';
+
 const CACHE_TTL_MS = 60_000;
+
+// SD-LEO-INFRA-EVA-RESERVED-GATES-ENFORCEMENT-001 FR-3: map a stage's row gate_type to the
+// autonomy gate-behavior vocabulary. This is SEPARATE from the canonical work_type-driven
+// kill/promotion DECISION sets (deliberately work_type-based, SD-LEO-REFAC-CANONICALIZE-STAGE-
+// CONFIG-001) — it answers "how should the autonomy matrix treat this gate?" so S18/S19
+// (gate_type='promotion' but artifact_only/sd_required work_type) no longer fall into the
+// stage_gate catch-all. Reserved stages are independently forced manual by FR-1.
+function _autonomyGateType(row) {
+  const gt = row?.gate_type;
+  if (gt === 'kill') return 'kill_gate';
+  if (gt === 'promotion') return 'promotion_gate';
+  return 'stage_gate';
+}
 
 let _cache = null;
 let _subscription = null;
@@ -112,6 +127,11 @@ function _publicView(c) {
     isReview: (n) => c.reviewStages.has(n),
     isBlocking: (n) => c.blockingStages.has(n),
     getStage: (n) => c.stages.get(n) || null,
+    // FR-3: reserved-chairman-stage awareness + autonomy gate-type resolution (additive; does not
+    // alter the canonical work_type-driven kill/promotion decision sets above).
+    reservedStages: new Set(RESERVED_CHAIRMAN_STAGES),
+    isReserved: (n) => RESERVED_CHAIRMAN_STAGES.has(n),
+    gateTypeForAutonomy: (n) => _autonomyGateType(c.stages.get(n)),
   };
 }
 

--- a/tests/unit/eva/autonomy-reserved-gates.test.js
+++ b/tests/unit/eva/autonomy-reserved-gates.test.js
@@ -12,6 +12,7 @@ import {
   checkAutonomy,
   autonomyPreCheck,
 } from '../../../lib/eva/autonomy-model.js';
+import { getStageGovernance, _resetCacheForTest } from '../../../lib/eva/stage-governance.js';
 
 // Minimal supabase mock: eva_ventures.autonomy_level read returns the given level.
 function mockSb(level) {
@@ -88,5 +89,49 @@ describe('autonomyPreCheck reserved beats chairman override (FR-1)', () => {
     const r = await autonomyPreCheck('v1', 'kill_gate', overrideDeps);
     expect(r.action).toBe('manual'); // kill_gate is manual at every level
     expect(r.overridden).toBe(true);
+  });
+});
+
+describe('stage-governance gate-type resolution (FR-2b / FR-3)', () => {
+  // Real venture_stages classification (verified against the DB): S18 is artifact_only + promotion,
+  // S19 is sd_required + promotion — both excluded from the work_type-driven promotionStages, so
+  // they previously fell into the stage_gate catch-all. gateTypeForAutonomy keys on the row gate_type.
+  const ROWS = [
+    { stage_number: 3, gate_type: 'kill', work_type: 'decision_gate', review_mode: 'auto' },
+    { stage_number: 5, gate_type: 'kill', work_type: 'decision_gate', review_mode: 'auto' },
+    { stage_number: 16, gate_type: 'promotion', work_type: 'decision_gate', review_mode: 'auto' },
+    { stage_number: 18, gate_type: 'promotion', work_type: 'artifact_only', review_mode: 'auto' },
+    { stage_number: 19, gate_type: 'promotion', work_type: 'sd_required', review_mode: 'auto' },
+    { stage_number: 22, gate_type: 'none', work_type: 'artifact_only', review_mode: 'review' },
+  ];
+  function mockGovSb(rows) {
+    return { from: () => ({ select: () => ({ order: () => ({ data: rows, error: null }) }) }) };
+  }
+
+  it('gate-type: S18/S19 resolve to promotion_gate (no longer the stage_gate catch-all)', async () => {
+    _resetCacheForTest();
+    const gov = await getStageGovernance(mockGovSb(ROWS));
+    expect(gov.gateTypeForAutonomy(18)).toBe('promotion_gate');
+    expect(gov.gateTypeForAutonomy(19)).toBe('promotion_gate');
+    // ...but the canonical work_type-driven decision sets are unchanged (additive fix):
+    expect(gov.isPromotion(18)).toBe(false);
+    expect(gov.isPromotion(19)).toBe(false);
+  });
+
+  it('gate-type: kill stages → kill_gate, decision promotion → promotion_gate, non-gate → stage_gate', async () => {
+    _resetCacheForTest();
+    const gov = await getStageGovernance(mockGovSb(ROWS));
+    expect(gov.gateTypeForAutonomy(3)).toBe('kill_gate');
+    expect(gov.gateTypeForAutonomy(16)).toBe('promotion_gate');
+    expect(gov.gateTypeForAutonomy(22)).toBe('stage_gate');
+    expect(gov.gateTypeForAutonomy(999)).toBe('stage_gate'); // unknown stage
+  });
+
+  it('gate-type: reserved-stage awareness is exposed', async () => {
+    _resetCacheForTest();
+    const gov = await getStageGovernance(mockGovSb(ROWS));
+    expect(gov.isReserved(18)).toBe(true);
+    expect(gov.isReserved(16)).toBe(false);
+    expect([...gov.reservedStages].sort((a, b) => a - b)).toEqual([3, 5, 10, 17, 18, 19]);
   });
 });

--- a/tests/unit/eva/autonomy-reserved-gates.test.js
+++ b/tests/unit/eva/autonomy-reserved-gates.test.js
@@ -1,0 +1,92 @@
+/**
+ * FR-1 — chairman-reserved EVA gates are ALWAYS manual
+ * SD-LEO-INFRA-EVA-RESERVED-GATES-ENFORCEMENT-001
+ *
+ * GATE_BEHAVIOR_MATRIX has no stage-number awareness, so at L2+ a reserved stage classified as
+ * anything but kill_gate would auto-approve. RESERVED_CHAIRMAN_STAGES is the durable backstop:
+ * it fires before the matrix lookup (checkAutonomy) and before override resolution (autonomyPreCheck).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RESERVED_CHAIRMAN_STAGES,
+  checkAutonomy,
+  autonomyPreCheck,
+} from '../../../lib/eva/autonomy-model.js';
+
+// Minimal supabase mock: eva_ventures.autonomy_level read returns the given level.
+function mockSb(level) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: level == null ? null : { autonomy_level: level }, error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+const RESERVED = [3, 5, 10, 17, 18, 19];
+
+describe('RESERVED_CHAIRMAN_STAGES (FR-1)', () => {
+  it('contains exactly the chairman-reserved stages 3,5,10,17,18,19', () => {
+    expect([...RESERVED_CHAIRMAN_STAGES].sort((a, b) => a - b)).toEqual(RESERVED);
+  });
+});
+
+describe('checkAutonomy reserved-stage backstop (FR-1)', () => {
+  for (const stage of RESERVED) {
+    it(`reserved stage ${stage} is manual even at L4 (matrix would auto_approve)`, async () => {
+      const r = await checkAutonomy('v1', 'stage_gate', { supabase: mockSb('L4') }, stage);
+      expect(r.action).toBe('manual');
+      expect(r.reserved).toBe(true);
+    });
+  }
+
+  it('reserved stage is manual for ANY gateType (classification-independent)', async () => {
+    for (const gt of ['stage_gate', 'promotion_gate', 'reality_gate', 'devils_advocate']) {
+      const r = await checkAutonomy('v1', gt, { supabase: mockSb('L4') }, 18);
+      expect(r.action).toBe('manual');
+      expect(r.reserved).toBe(true);
+    }
+  });
+
+  it('non-reserved stage 16 at L4 is unaffected (normal matrix → auto_approve)', async () => {
+    const r = await checkAutonomy('v1', 'stage_gate', { supabase: mockSb('L4') }, 16);
+    expect(r.action).toBe('auto_approve');
+    expect(r.reserved).toBeUndefined();
+  });
+
+  it('backward-compatible: omitting stageNumber preserves exact matrix behavior', async () => {
+    const r = await checkAutonomy('v1', 'stage_gate', { supabase: mockSb('L2') });
+    expect(r.action).toBe('auto_approve'); // L2 stage_gate = auto_approve, unchanged
+    expect(r.reserved).toBeUndefined();
+  });
+});
+
+describe('autonomyPreCheck reserved beats chairman override (FR-1)', () => {
+  // chairmanPreferenceStore returning an L4 autonomy_override.
+  const overrideDeps = {
+    supabase: mockSb('L0'),
+    chairmanPreferenceStore: { getPreference: async () => ({ value: 'L4' }) },
+  };
+
+  it('a reserved stage stays manual even with a chairman L4 override (override cannot downgrade)', async () => {
+    const r = await autonomyPreCheck('v1', 'stage_gate', overrideDeps, 19);
+    expect(r.action).toBe('manual');
+    expect(r.reserved).toBe(true);
+    expect(r.overridden).toBe(false);
+  });
+
+  it('a non-reserved stage still honors the chairman override', async () => {
+    const r = await autonomyPreCheck('v1', 'stage_gate', overrideDeps, 16);
+    expect(r.action).toBe('auto_approve'); // L4 override → stage_gate auto_approve
+    expect(r.overridden).toBe(true);
+  });
+
+  it('backward-compatible: omitting stageNumber preserves override/precheck behavior', async () => {
+    const r = await autonomyPreCheck('v1', 'kill_gate', overrideDeps);
+    expect(r.action).toBe('manual'); // kill_gate is manual at every level
+    expect(r.overridden).toBe(true);
+  });
+});


### PR DESCRIPTION
Chairman ruling 3/3 — chairman-reserved EVA gates (stages 3,5,10,17,18,19) must NEVER auto-approve. The fix that lets venture-1 safely advance past S13.

**Root cause:** GATE_BEHAVIOR_MATRIX (autonomy-model.js) has no stage-number awareness — at L2+, any reserved stage classified as anything but kill_gate returns auto_approve. checkAutonomy/autonomyPreCheck just do matrix[gateType].

**FR-1 (the guarantee, classification-independent):** `RESERVED_CHAIRMAN_STAGES = Set([3,5,10,17,18,19])` + optional `stageNumber` param on checkAutonomy/autonomyPreCheck. A reserved stage returns `{action:'manual', reserved:true}` **before** the matrix lookup and **before** getAutonomyOverride — no autonomy level (L0-L4) and no chairman override can downgrade it. Param is optional/defaulted (backward-compatible).

**FR-2:** thread `resolvedStage` into all 4 eva-orchestrator autonomyPreCheck call sites (so FR-1 fires on every gate path); the two stage_gate sites now resolve the **true** gate type via stage-governance instead of hardcoding 'stage_gate', so non-reserved promotion stages (S16/S24) honor promotion semantics.

**FR-3 (additive):** stage-governance `gateTypeForAutonomy(n)` keyed on the row gate_type + `reservedStages`/`isReserved`. DB-verified: S18 (artifact_only) + S19 (sd_required) both have gate_type='promotion' but were excluded from the work_type-driven promotionStages → they fell into the stage_gate catch-all. Now they resolve to promotion_gate. The canonical work_type-driven decision sets are unchanged.

**Tests:** 16 new (reserved/override/backward-compat/gate-type) + 66 existing stage-governance/orchestrator/autonomy tests pass (0 regressions). No migration needed.

SD: SD-LEO-INFRA-EVA-RESERVED-GATES-ENFORCEMENT-001 (chairman ruling 3/3; coordinator-authorized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)