### PR TITLE
feat(SD-LEO-INFRA-UNIT-TEST-ISOLATION-POLLUTION-001): unit-test isolation hardening (DESCOPED)

### DIFF
--- a/scripts/test-isolation-order-gate.mjs
+++ b/scripts/test-isolation-order-gate.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * test-isolation-order-gate.mjs — SD-LEO-INFRA-UNIT-TEST-ISOLATION-POLLUTION-001 FR-4
+ *
+ * Order-independence regression gate (preventive hardening). Runs the unit project under TWO
+ * distinct fork configurations and asserts the SET of failing test files is IDENTICAL. If a future
+ * change introduces fork-distribution-dependent shared-state leakage (the class this SD originally
+ * suspected — found to be absent today; the current unit-tier reds are DETERMINISTIC test debt,
+ * routed to UNIT-TEST-DEBT-TRIAGE-001), the two configs will diverge and this gate fails LOUDLY.
+ *
+ * It does NOT assert the suite is GREEN (the deterministic test-debt failures are expected until the
+ * triage SD lands) — it asserts the failing set is STABLE across fork distributions = no order/
+ * isolation pollution. Pairs with tests/setup.unit.js's per-test process.env restore (FR-1).
+ *
+ * Usage:
+ *   node scripts/test-isolation-order-gate.mjs                 # full unit project
+ *   node scripts/test-isolation-order-gate.mjs <fileGlob...>   # a subset (fast local check)
+ */
+import { spawnSync } from 'node:child_process';
+
+const targets = process.argv.slice(2);
+
+// Extract the set of failing test FILES from a vitest text run (reporter-agnostic, matches the
+// "FAIL  <path>" and "❯ <path> (.. failed)" lines vitest prints).
+function failingFiles(stdout) {
+  const set = new Set();
+  const re = /(?:FAIL|❯)\s+(?:\|unit\|\s+)?([^\s]+\.test\.js)/g;
+  let m;
+  while ((m = re.exec(stdout)) !== null) {
+    // Only count a "❯ <file> (.. failed)" line as a failure, not a passing "✓" summary line.
+    const line = stdout.slice(stdout.lastIndexOf('\n', m.index) + 1, stdout.indexOf('\n', m.index));
+    if (/FAIL/.test(line) || /failed\)/.test(line)) set.add(m[1].replace(/\\/g, '/'));
+  }
+  return set;
+}
+
+function runUnit(extraArgs, label) {
+  const args = ['vitest', 'run', '--project', 'unit', ...extraArgs, ...targets];
+  process.stderr.write(`[order-gate] run ${label}: npx ${args.join(' ')}\n`);
+  const res = spawnSync('npx', args, { encoding: 'utf8', shell: true, maxBuffer: 64 * 1024 * 1024 });
+  return failingFiles((res.stdout || '') + (res.stderr || ''));
+}
+
+// Config A: default multi-fork distribution. Config B: single-fork sequential (strongest sharing).
+const a = runUnit([], 'A (multi-fork default)');
+const b = runUnit(['--no-file-parallelism'], 'B (single-fork sequential)');
+
+const onlyA = [...a].filter((f) => !b.has(f)).sort();
+const onlyB = [...b].filter((f) => !a.has(f)).sort();
+
+if (onlyA.length === 0 && onlyB.length === 0) {
+  process.stdout.write(`[order-gate] PASS — failing set is IDENTICAL across fork configs (${a.size} file(s)); no order/isolation pollution.\n`);
+  process.exit(0);
+}
+process.stdout.write('[order-gate] FAIL — fork-distribution-DEPENDENT failures detected (isolation pollution):\n');
+if (onlyA.length) process.stdout.write(`  fail only under multi-fork: ${onlyA.join(', ')}\n`);
+if (onlyB.length) process.stdout.write(`  fail only under single-fork: ${onlyB.join(', ')}\n`);
+process.exit(1);

--- a/tests/setup.unit.js
+++ b/tests/setup.unit.js
@@ -7,7 +7,7 @@
 //
 // Host-shell env vars still take precedence via ||= (CI workflows that
 // deliberately pass secrets — e.g. protected-unit-suites.yml — keep working).
-import { vi } from 'vitest';
+import { vi, beforeEach, afterEach } from 'vitest';
 
 // Synthetic env defaults so module-load createSupabaseServiceClient() factories
 // don't throw during vitest collection in environments without real credentials
@@ -26,3 +26,23 @@ global.console = {
   info: vi.fn(),
   debug: vi.fn(),
 };
+
+// SD-LEO-INFRA-UNIT-TEST-ISOLATION-POLLUTION-001 FR-1: per-test process.env snapshot/restore.
+// pool:'forks' runs MULTIPLE test files in one process; vitest's module isolation gives each file a
+// fresh module registry but does NOT reset process.env (process-global). So a test that mutates
+// process.env (directly or via vi.stubEnv) bleeds into sibling files sharing the fork, and the
+// non-deterministic fork DISTRIBUTION (worker-count-dependent: CI vs local) makes the unit-tier
+// failing SET vary run-to-run. Snapshotting + restoring process.env per test is a non-aggressive,
+// catch-all fix for env leakage regardless of HOW the test mutated it. The synthetic test.invalid
+// defaults set above (module load) are captured in the first snapshot and therefore preserved.
+let __envSnapshot;
+beforeEach(() => { __envSnapshot = { ...process.env }; });
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const k of Object.keys(process.env)) {
+    if (!(k in __envSnapshot)) delete process.env[k];          // drop keys the test ADDED
+  }
+  for (const k of Object.keys(__envSnapshot)) {
+    if (process.env[k] !== __envSnapshot[k]) process.env[k] = __envSnapshot[k]; // restore CHANGED/DELETED
+  }
+});

--- a/tests/unit/setup/env-isolation-guard.test.js
+++ b/tests/unit/setup/env-isolation-guard.test.js
@@ -1,0 +1,36 @@
+/**
+ * SD-LEO-INFRA-UNIT-TEST-ISOLATION-POLLUTION-001 FR-1
+ * Proves the setup.unit.js per-test process.env snapshot/restore: a test that mutates process.env
+ * must NOT leak into the next test. This is the mechanism that stops cross-file env pollution under
+ * pool:'forks' (the run-to-run-varying failing set this SD fixes).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+describe('FR-1 env isolation guard (per-test process.env reset)', () => {
+  it('case A mutates process.env (direct + vi.stubEnv)', () => {
+    process.env.__LEAK_PROBE_DIRECT__ = 'leaked';
+    vi.stubEnv('__LEAK_PROBE_STUB__', 'stubbed');
+    expect(process.env.__LEAK_PROBE_DIRECT__).toBe('leaked');
+    expect(process.env.__LEAK_PROBE_STUB__).toBe('stubbed');
+  });
+
+  it('case B must see NEITHER probe — env was restored after case A', () => {
+    expect(process.env.__LEAK_PROBE_DIRECT__).toBeUndefined();
+    expect(process.env.__LEAK_PROBE_STUB__).toBeUndefined();
+  });
+
+  it('the synthetic test.invalid default survives the per-test restore', () => {
+    expect(process.env.SUPABASE_URL).toBe('https://test.invalid.local');
+  });
+
+  it('a DELETED env key is restored for the next test', () => {
+    // SUPABASE_URL exists (synthetic default). Delete it here; the afterEach must put it back,
+    // which the previous test already proved — assert the delete worked within this test.
+    delete process.env.SUPABASE_URL;
+    expect(process.env.SUPABASE_URL).toBeUndefined();
+  });
+
+  it('SUPABASE_URL is back after the delete in the prior test (restore on delete)', () => {
+    expect(process.env.SUPABASE_URL).toBe('https://test.invalid.local');
+  });
+});

--- a/tests/unit/setup/env-isolation-guard.test.js
+++ b/tests/unit/setup/env-isolation-guard.test.js
@@ -20,17 +20,17 @@ describe('FR-1 env isolation guard (per-test process.env reset)', () => {
   });
 
   it('the synthetic test.invalid default survives the per-test restore', () => {
-    expect(process.env.SUPABASE_URL).toBe('https://test.invalid.local');
+    expect(process.env['SUPABASE_URL']).toBe('https://test.invalid.local');
   });
 
   it('a DELETED env key is restored for the next test', () => {
     // SUPABASE_URL exists (synthetic default). Delete it here; the afterEach must put it back,
     // which the previous test already proved — assert the delete worked within this test.
-    delete process.env.SUPABASE_URL;
-    expect(process.env.SUPABASE_URL).toBeUndefined();
+    delete process.env['SUPABASE_URL'];
+    expect(process.env['SUPABASE_URL']).toBeUndefined();
   });
 
   it('SUPABASE_URL is back after the delete in the prior test (restore on delete)', () => {
-    expect(process.env.SUPABASE_URL).toBe('https://test.invalid.local');
+    expect(process.env['SUPABASE_URL']).toBe('https://test.invalid.local');
   });
 });


### PR DESCRIPTION
**DESCOPED** (coordinator-authorized) after an EXEC verify-premise catch disproved the SD's central premise.

## The catch
The SD premised the unit-tier CI reds on *fork-distribution-dependent shared-state leakage*. Measurement disproved it: the locally-failing files fail **identically in isolation** (no polluter present), and FR-1's per-test process.env restore changed the failing set by **zero**. The failures are **deterministic test debt** — stale assertions / source drift from evolved code (`leo-create-sd-mapper` extraction regex, `sd-executable-here` verdict, mock-arg drift, `exec-summary-html-parity` buildLine). The earlier 'CI-vs-local different set' was quarantine churn + a git-tracked-state CI category, not run-to-run pollution. The **real fix** (test-debt triage of ~8 drifted files) is routed to **SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001** (Adam, to decompose).

## What ships (preventive isolation HARDENING / defense-in-depth)
- **FR-1** `tests/setup.unit.js`: per-test process.env snapshot/restore (+ vi.unstubAllEnvs) so a future env mutation cannot leak across files sharing a fork. Guard test 5/5.
- **FR-4** `scripts/test-isolation-order-gate.mjs`: runs the unit project under multi-fork vs single-fork and asserts the failing FILE set is **identical** — a future fork-distribution-dependent leak fails it loudly. Verified: PASS (set identical = no order-dependence today).
- **FR-2 / FR-3 descoped** (isolate/pool config wasn't the root; there are no leakers).

Does NOT assert the unit-tier is green — that's the descoped triage SD's job.

SD: SD-LEO-INFRA-UNIT-TEST-ISOLATION-POLLUTION-001 (coordinator-authorized descope; 2nd-order verify-premise catch correcting an earlier diagnosis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)