### PR TITLE
fix(SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001): triage the deterministic-drift unit tests (batch 1)

### DIFF
--- a/scripts/__tests__/leo-create-sd-mapper.test.js
+++ b/scripts/__tests__/leo-create-sd-mapper.test.js
@@ -21,12 +21,13 @@ function probeMapper(userType) {
   const enumSrc = fs.readFileSync(
     path.resolve(__dirname, '../../lib/sd-type-enum.js')
   , 'utf8').replace(/\bexport\s+(const|function)\b/g, '$1');
-  const validMatch = src.match(/const VALID_DB_SD_TYPES = \[([\s\S]*?)\];/);
+  // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: VALID_DB_SD_TYPES was REMOVED from leo-create-sd.js —
+  // the canonical type list moved to lib/sd-type-enum.js (CANONICAL_SD_TYPES) and mapToDbType now
+  // validates via assertValidSdType. Extract only mapToDbType; the injected enumSrc supplies its deps.
   const fnMatch = src.match(/function mapToDbType\(userType\)\s*\{[\s\S]*?\n\}/);
-  if (!validMatch || !fnMatch) throw new Error('Could not extract mapper from script');
+  if (!fnMatch) throw new Error('Could not extract mapToDbType from script');
   const code =
     enumSrc + '\n' +
-    validMatch[0] + '\n' +
     fnMatch[0] + '\n' +
     'process.stdout.write(String(mapToDbType(' + JSON.stringify(userType) + ')));';
   const r = spawnSync('node', ['-e', code], { encoding: 'utf8' });
@@ -65,10 +66,13 @@ describe('QF-251 MAPPER-5: existing mappings preserved', () => {
   it('orch → orchestrator', () => { expect(probeMapper('orch')).toBe('orchestrator'); });
 });
 
-describe('QF-251 MAPPER-6: VALID_DB_SD_TYPES no longer contains stale qa/library/fix entries', () => {
-  it('list aligns with DB sd_type_check constraint', () => {
-    const src = require('node:fs').readFileSync(SCRIPT_PATH, 'utf8');
-    const m = src.match(/const VALID_DB_SD_TYPES = \[([\s\S]*?)\];/);
+describe('QF-251 MAPPER-6: the canonical sd_type list (now lib/sd-type-enum.js) excludes stale qa/library/fix', () => {
+  it('CANONICAL_SD_TYPES aligns with the DB sd_type_check constraint', () => {
+    // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: VALID_DB_SD_TYPES moved out of leo-create-sd.js into
+    // lib/sd-type-enum.js (_CANONICAL_SD_TYPES, the single validator of record). Assert against it.
+    const enumSrc = require('node:fs').readFileSync(
+      path.resolve(__dirname, '../../lib/sd-type-enum.js'), 'utf8');
+    const m = enumSrc.match(/_CANONICAL_SD_TYPES = new Set\(\[([\s\S]*?)\]\)/);
     expect(m).toBeTruthy();
     const listLiteral = m[1];
     // Stale entries — must NOT appear in current list

--- a/tests/unit/adam/exec-summary-html-parity.test.js
+++ b/tests/unit/adam/exec-summary-html-parity.test.js
@@ -65,14 +65,19 @@ describe('QF-20260621-379 exec-email HTML parity', () => {
     expect(h).toContain('EHG vision: 41% built (build-segmented detail unavailable)');
   });
 
-  it('SOURCE GUARD: the HTML assembly references each of the 5 parity lines', () => {
+  it('SOURCE GUARD: the HTML assembly references the current parity lines', () => {
+    // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001 (stale source-guard): the exec-email HTML was REDESIGNED
+    // by SD-LEO-INFRA-EXEC-EMAIL-STRATEGY-ALIGNED-001 — it now LEADS with the active-rung rollup, and
+    // the infra-build lines (buildLine/rungLine/forecastLine/operationalLine) were DELIBERATELY dropped
+    // from this render (see the in-source comment). Guard the CURRENT skeleton's lines instead. NOTE:
+    // the local htmlFragment replica + the old 5-line parity cases above now mirror a SUPERSEDED
+    // structure (self-consistent, still green) — a fuller parity rewrite is a residual follow-up.
     const here = dirname(fileURLToPath(import.meta.url));
     const src = readFileSync(resolve(here, '../../../scripts/adam-exec-summary.mjs'), 'utf8');
-    // Scope to the `const html = '<div...` assembly so we don't match the plaintext array.
     const start = src.indexOf("const html = '<div");
     expect(start).toBeGreaterThan(-1);
-    const htmlBlock = src.slice(start, src.indexOf('</div>\';', start));
-    for (const sym of ['buildLine', 'rungLine', 'rungRollupLine', 'forecastLine', 'forecastDegraded', 'FORECAST_DEGRADED_MARKER', 'operationalLine']) {
+    const htmlBlock = src.slice(start, src.indexOf('`;', start)); // first backtick-semicolon = end of the assembly
+    for (const sym of ['rungRollupLine', 'metaLine', 'distanceToQuitLine', 'watchdogLine']) {
       expect(htmlBlock, `HTML assembly must reference ${sym}`).toContain(sym);
     }
   });

--- a/tests/unit/claude-coordinator-generation.test.js
+++ b/tests/unit/claude-coordinator-generation.test.js
@@ -18,9 +18,12 @@ const MAPPING = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../script
 const DIGEST_MAPPING = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../scripts/section-file-mapping-digest.json'), 'utf8'));
 
 describe('section-file-mapping — CLAUDE_COORDINATOR.md routes to the governed section', () => {
-  it('maps CLAUDE_COORDINATOR.md -> [coordinator_role_contract]', () => {
+  it('maps CLAUDE_COORDINATOR.md -> [coordinator_role_contract, role_partnership_contract]', () => {
+    // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: section-file-mapping.json deliberately added
+    // 'role_partnership_contract' to the coordinator file (the coordinator's role includes the
+    // partnership contract). Updated the stale single-section assertion to the current config.
     expect(MAPPING['CLAUDE_COORDINATOR.md']).toBeTruthy();
-    expect(MAPPING['CLAUDE_COORDINATOR.md'].sections).toEqual(['coordinator_role_contract']);
+    expect(MAPPING['CLAUDE_COORDINATOR.md'].sections).toEqual(['coordinator_role_contract', 'role_partnership_contract']);
   });
   it('maps CLAUDE_COORDINATOR_DIGEST.md -> [coordinator_role_contract]', () => {
     expect(DIGEST_MAPPING['CLAUDE_COORDINATOR_DIGEST.md']).toBeTruthy();

--- a/tests/unit/fleet/sd-executable-here.test.js
+++ b/tests/unit/fleet/sd-executable-here.test.js
@@ -88,7 +88,11 @@ describe('classifyDispatchIneligibility (FR-2 — backward-compatible extension)
   it('with ctx: adds the fitness axes (unfit_<blockClass>)', () => {
     const ctx = { cwd: ENGINEER_CWD };
     expect(classifyDispatchIneligibility({ sd_key: 'SD-E', target_application: 'ehg', status: 'draft' }, ctx)).toBe('unfit_repo_mismatch');
-    expect(classifyDispatchIneligibility({ sd_key: 'SD-C', status: 'completed' }, ctx)).toBe('unfit_premise_closed');
+    // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: stale assertion. A completed/cancelled SD now
+    // short-circuits to the terminal-status verdict 'sd_terminal' (claim-eligibility.cjs:64,
+    // added by SD-FDBK-INFRA-STALE-SESSION-SWEEP-001) BEFORE the ctx/fitness axes — so a completed
+    // SD is classified terminal, not by a fitness blockClass. Updated test to the current behavior.
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-C', status: 'completed' }, ctx)).toBe('sd_terminal');
     // a fit SD with ctx is still eligible
     expect(classifyDispatchIneligibility({ sd_key: 'SD-A', target_application: 'EHG_Engineer', status: 'draft' }, ctx)).toBeNull();
   });

--- a/tests/unit/loops/loop-contract-registry.test.js
+++ b/tests/unit/loops/loop-contract-registry.test.js
@@ -34,8 +34,9 @@ describe('registry shape + invariants', () => {
     expect(Object.isFrozen(LOOP_CONTRACTS)).toBe(true);
   });
 
-  it('declares the 2 exemplars and every entry validates', () => {
-    expect(LOOP_CONTRACTS).toHaveLength(2);
+  it('declares the registered contracts and every entry validates', () => {
+    // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: a 3rd contract (LOOP-PROD-ERROR-SWEEP-001) was added.
+    expect(LOOP_CONTRACTS).toHaveLength(3);
     for (const c of LOOP_CONTRACTS) {
       expect(validateLoopContract(c)).toEqual({ valid: true, errors: [] });
     }
@@ -50,7 +51,7 @@ describe('registry shape + invariants', () => {
 
   it('list() returns id+name+cadence summaries', () => {
     const summaries = list();
-    expect(summaries).toHaveLength(2);
+    expect(summaries).toHaveLength(3); // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: 3rd contract added
     for (const s of summaries) {
       expect(typeof s.id).toBe('string');
       expect(typeof s.name).toBe('string');
@@ -74,7 +75,12 @@ describe('registry shape + invariants', () => {
 describe('exemplar goals are typed (FR-3)', () => {
   it('every exemplar goal is a typed object with a valid GOAL_TYPE (no bare strings remain)', () => {
     const validTypes = new Set(Object.values(GOAL_TYPE));
+    // SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001: LOOP-PROD-ERROR-SWEEP-001 DELIBERATELY keeps bare-string
+    // goals for now — the typed-goal migration is deferred until the loop runner accepts goal_type
+    // (see the in-source comment on PROD_ERROR_SWEEP_CONTRACT). Exempt it until that SD lands.
+    const TYPED_GOAL_DEFERRED = new Set(['LOOP-PROD-ERROR-SWEEP-001']);
     for (const c of LOOP_CONTRACTS) {
+      if (TYPED_GOAL_DEFERRED.has(c.id)) continue;
       for (const g of c.goals) {
         expect(typeof g, `${c.id} goal should be an object`).toBe('object');
         expect(validTypes.has(g.type), `${c.id} goal type ${g.type}`).toBe(true);


### PR DESCRIPTION
Fixes the **deterministic test debt** behind the unit-tier CI reds (the actual root cause, per the descoped UNIT-TEST-ISOLATION-POLLUTION-001 — these are stale assertions / source drift, not isolation pollution). Each verified **per-file** (read the test AND the source it guards) — stale-test vs source-regression, no blanket updates.

## Fixed (5 — all verified STALE-TEST, not regressions)
- **sd-executable-here**: a completed/cancelled SD now short-circuits to the `sd_terminal` verdict (claim-eligibility.cjs, SD-FDBK-INFRA-STALE-SESSION-SWEEP-001) before the fitness axes; updated the stale `unfit_premise_closed`.
- **leo-create-sd-mapper**: `VALID_DB_SD_TYPES` moved out of the script into `lib/sd-type-enum.js` (`_CANONICAL_SD_TYPES`); reworked the probe extraction + re-pointed the list check at the enum lib.
- **exec-summary-html-parity**: the exec-email HTML was redesigned (SD-LEO-INFRA-EXEC-EMAIL-STRATEGY-ALIGNED-001) to lead with the rung rollup, dropping the infra-build lines; updated the source-guard to the current skeleton's lines.
- **claude-coordinator-generation**: section-file-mapping.json deliberately added `role_partnership_contract`; updated the single-section assertion to the current 2-section config.
- **loop-contract-registry**: a 3rd contract with intentionally bare-string goals (typed-goal migration deferred per its in-source comment); updated counts 2 to 3 + exempted the deferred contract from the typed-goals invariant.

## Now pass, no fix (3)
branch-resolver, master-reset-validation, audit-log-emission-helper (the merged ISOLATION FR-1 per-test env-restore likely helped).

## Residuals to a follow-up (documented per FR-3; SD metadata.residual_note)
- **stage-execution-worker (+timing)**: the worker autonomy gate now blocks on the test's global checkAutonomy to require_approval mock before processStage; needs a per-test autonomy-mock rewrite (auto_approve for the proceed cases, require_approval for the block cases).
- **enforcement-worktree-hygiene**: env / integration-specific (the real hook run against a temp git repo produces empty output in the worktree-session context — env-suppression / branch-detection); needs env-robustification.
- **FR-2 git-state category** (protocol-file-read-gate / protocol-file-tracker / phantom-column, quarantined): git-tracked-state-specific; needs robustify + un-quarantine.

Recommend sourcing **UNIT-TEST-DEBT-TRIAGE-002** for the residuals.

SD: SD-LEO-INFRA-UNIT-TEST-DEBT-TRIAGE-001 (coordinator-routed from my ISOLATION verify-premise catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
