### PR TITLE
fix(SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001): kill gates deterministically produce + persist the adversarial review

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-ADAM-DECISION-RUBRIC-ENFORCE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-ADAM-DECISION-RUBRIC-ENFORCE-001",
-  "createdAt": "2026-06-26T09:07:54.822Z",
+  "sdKey": "SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001",
+  "createdAt": "2026-06-26T10:30:14.192Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/devils-advocate.js
+++ b/lib/eva/devils-advocate.js
@@ -37,6 +37,32 @@ export function isDevilsAdvocateGate(stageId) {
 }
 
 /**
+ * SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001: a KILL gate must ALWAYS produce + persist its
+ * adversarial review, regardless of the autonomy action — a kill gate must never silently proceed with
+ * no recorded adversarial input. Only PROMOTION gates may bypass production on skip/auto_approve.
+ * Pure decision used by the EVA orchestrator's §5b branch (and unit-tested directly).
+ * @param {'kill'|'promotion'|null} gateType
+ * @param {string} autonomyAction - 'skip' | 'auto_approve' | 'manual' | ...
+ * @returns {boolean} true when the orchestrator must produce + persist the review
+ */
+export function mustProduceDevilsAdvocate(gateType, autonomyAction) {
+  if (gateType === 'kill') return true; // kill gates are unconditional
+  if (gateType !== 'promotion') return false; // non-gate stages never produce
+  const bypass = autonomyAction === 'skip' || autonomyAction === 'auto_approve';
+  return !bypass; // promotion gates produce unless autonomy legitimately bypasses
+}
+
+/**
+ * A kill-gate produce/persist failure must FAIL LOUD (the orchestrator throws/blocks rather than
+ * swallowing it into a passed gate result). Promotion-gate failures stay non-fatal (advisory).
+ * @param {'kill'|'promotion'|null} gateType
+ * @returns {boolean}
+ */
+export function isKillGateFailLoud(gateType) {
+  return gateType === 'kill';
+}
+
+/**
  * Get adversarial review from Devil's Advocate.
  *
  * @param {Object} params

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -22,7 +22,7 @@ import { ChairmanPreferenceStore } from './chairman-preference-store.js';
 import { evaluateDecision } from './decision-filter-engine.js';
 import { evaluateRealityGate, isGatedBoundary } from './reality-gates.js';
 import { attemptGateRecovery } from './gate-failure-recovery.js';
-import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord } from './devils-advocate.js';
+import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord, mustProduceDevilsAdvocate, isKillGateFailLoud } from './devils-advocate.js';
 // convertSprintToSDs + buildBridgeArtifactRecord moved to post-approval hook in stage-execution-worker.js
 import { writeArtifact, recordGateResult, advanceStage } from './artifact-persistence-service.js';
 import { ARTIFACT_TYPE_BY_STAGE } from './artifact-types.js';
@@ -792,15 +792,20 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   }
 
   // ── 5b. Devil's Advocate (autonomy-aware adversarial review) ──
+  // SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001: a KILL gate must NEVER silently proceed with no
+  // recorded adversarial input. The autonomy matrix sets devils_advocate to 'auto_approve' (L2) / 'skip'
+  // (L3/L4) and BOTH branches previously produced NO artifact — so a non-reserved kill gate (13/24) at
+  // high autonomy emitted nothing. Kill gates now DETERMINISTICALLY produce + persist the review
+  // regardless of autonomy, and FAIL LOUD if the persist fails. Promotion gates keep autonomy-aware bypass.
   const { isGate: hasDAGate, gateType: daGateType } = isDevilsAdvocateGate(resolvedStage);
   let devilsAdvocateReview = null;
   if (hasDAGate) {
+    const isKillGate = isKillGateFailLoud(daGateType);
     // Autonomy pre-check for devil's advocate
     const daAutonomy = await autonomyPreCheck(ventureId, 'devils_advocate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
-    if (daAutonomy.action === 'skip') {
-      gateResults.push({ type: 'devils_advocate', passed: true, summary: `Skipped at ${daAutonomy.level}`, autonomyAction: 'skip' });
-    } else if (daAutonomy.action === 'auto_approve') {
-      gateResults.push({ type: 'devils_advocate', passed: true, summary: `Auto-approved at ${daAutonomy.level}`, autonomyAction: 'auto_approve' });
+    // Promotion gates may legitimately bypass on autonomy; KILL gates NEVER do — production is mandatory.
+    if (!mustProduceDevilsAdvocate(daGateType, daAutonomy.action)) {
+      gateResults.push({ type: 'devils_advocate', passed: true, summary: `${daAutonomy.action} at ${daAutonomy.level}`, autonomyAction: daAutonomy.action });
     } else {
     try {
       const primaryGateResult = gateResults.find(g => g.type === 'stage_gate') || {};
@@ -812,7 +817,9 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         stageOutput,
       }, { logger });
 
-      // Persist DA review as venture artifact via unified service
+      // Persist DA review as venture artifact via unified service. A fallback review (e.g. no
+      // OPENAI_API_KEY) is a RECORDED degradation (isFallback:true) and is persisted normally — that
+      // is still adversarial input on the record. Only an actual persist failure is fatal for a kill gate.
       if (!options.dryRun && supabase) {
         try {
           const artifactRow = buildArtifactRecord(ventureId, devilsAdvocateReview);
@@ -830,6 +837,10 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
             planKey,
           });
         } catch (daErr) {
+          // FAIL-LOUD for kill gates: a kill gate must not proceed with no PERSISTED adversarial review.
+          if (isKillGate) {
+            throw new Error(`[Eva] KILL-gate stage ${resolvedStage} adversarial review could not be persisted — failing loud (a kill gate must never silently proceed with no recorded adversarial input): ${daErr.message}`);
+          }
           logger.warn(`[Eva] DA artifact persist failed: ${daErr.message}`);
         }
       }
@@ -840,12 +851,17 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         assessment: devilsAdvocateReview.overallAssessment,
         counterArguments: devilsAdvocateReview.counterArguments?.length || 0,
         isFallback: devilsAdvocateReview.isFallback || false,
+        autonomyAction: daAutonomy.action,
+        ...(isKillGate ? { mandatoryKillGateReview: true } : {}),
       });
     } catch (err) {
+      // FAIL-LOUD for kill gates: re-throw so the orchestrator cannot silently treat a kill gate as
+      // reviewed when production/persistence failed. Promotion gates remain non-fatal (advisory).
+      if (isKillGate) throw err;
       logger.warn(`[Eva] Devil's Advocate failed (non-fatal): ${err.message}`);
       gateResults.push({ type: 'devils_advocate', passed: true, error: err.message });
     }
-    } // close autonomy else (manual DA)
+    } // close autonomy-bypass else (manual DA / mandatory kill-gate DA)
   }
 
   if (gateBlocked) {

--- a/tests/unit/eva/devils-advocate-kill-gate-deterministic.test.js
+++ b/tests/unit/eva/devils-advocate-kill-gate-deterministic.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001 — kill gates deterministically produce + persist
+ * their adversarial review, and fail loud if they cannot.
+ *
+ * RCA: the EVA orchestrator (§5b) gated devil's-advocate PRODUCTION on autonomyPreCheck — the
+ * GATE_BEHAVIOR_MATRIX sets devils_advocate='auto_approve' (L2) / 'skip' (L3/L4) and BOTH branches
+ * produced NO artifact, so a non-reserved kill gate (13/24) at high autonomy emitted nothing. The fix
+ * makes the production decision a pure rule (mustProduceDevilsAdvocate) that is unconditional for kill
+ * gates, plus a fail-loud predicate (isKillGateFailLoud). These tests lock both, sourced from the same
+ * KILL_GATES set the orchestrator uses (via isDevilsAdvocateGate), so they stay in sync if it changes.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isDevilsAdvocateGate,
+  mustProduceDevilsAdvocate,
+  isKillGateFailLoud,
+  _internal,
+} from '../../../lib/eva/devils-advocate.js';
+
+const { KILL_GATES, PROMOTION_GATES } = _internal;
+// The full autonomy action space; the two that previously caused a silent skip are skip + auto_approve.
+const AUTONOMY_ACTIONS = ['skip', 'auto_approve', 'manual'];
+
+describe('kill gates produce the adversarial review under EVERY autonomy action', () => {
+  for (const stage of KILL_GATES) {
+    it(`stage ${stage} is a kill gate and produces its review under skip/auto_approve/manual`, () => {
+      const { isGate, gateType } = isDevilsAdvocateGate(stage);
+      expect(isGate).toBe(true);
+      expect(gateType).toBe('kill');
+      for (const action of AUTONOMY_ACTIONS) {
+        // The exact regression: skip/auto_approve must NOT bypass production for a kill gate.
+        expect(mustProduceDevilsAdvocate(gateType, action), `kill stage ${stage} under ${action}`).toBe(true);
+      }
+    });
+  }
+
+  it('covers all four canonical kill gates [3,5,13,24]', () => {
+    expect([...KILL_GATES].sort((a, b) => a - b)).toEqual([3, 5, 13, 24]);
+  });
+});
+
+describe('kill-gate fail-loud: a produce/persist failure must never be swallowed', () => {
+  it('isKillGateFailLoud is true for kill gates, false for promotion gates', () => {
+    expect(isKillGateFailLoud('kill')).toBe(true);
+    expect(isKillGateFailLoud('promotion')).toBe(false);
+    expect(isKillGateFailLoud(null)).toBe(false);
+  });
+
+  it('every KILL_GATES stage classifies as fail-loud (kill)', () => {
+    for (const stage of KILL_GATES) {
+      expect(isKillGateFailLoud(isDevilsAdvocateGate(stage).gateType)).toBe(true);
+    }
+  });
+});
+
+describe('promotion gates retain autonomy-aware bypass (no regression)', () => {
+  for (const stage of PROMOTION_GATES) {
+    it(`promotion stage ${stage} bypasses on skip/auto_approve, produces on manual`, () => {
+      const { gateType } = isDevilsAdvocateGate(stage);
+      expect(gateType).toBe('promotion');
+      expect(mustProduceDevilsAdvocate(gateType, 'skip')).toBe(false);
+      expect(mustProduceDevilsAdvocate(gateType, 'auto_approve')).toBe(false);
+      expect(mustProduceDevilsAdvocate(gateType, 'manual')).toBe(true); // manual still produces
+      expect(isKillGateFailLoud(gateType)).toBe(false); // and stays non-fatal
+    });
+  }
+
+  it('a non-gate stage never produces and is never fail-loud', () => {
+    const { isGate, gateType } = isDevilsAdvocateGate(7); // not a DA gate
+    expect(isGate).toBe(false);
+    expect(mustProduceDevilsAdvocate(gateType, 'manual')).toBe(false);
+    expect(isKillGateFailLoud(gateType)).toBe(false);
+  });
+});

--- a/tests/unit/eva/eva-orchestrator.test.js
+++ b/tests/unit/eva/eva-orchestrator.test.js
@@ -34,7 +34,11 @@ vi.mock('../../../lib/eva/shared-services.js', async () => {
   };
 });
 
-vi.mock('../../../lib/eva/devils-advocate.js', () => ({
+// SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001: spread importOriginal so the real PURE decision
+// helpers (mustProduceDevilsAdvocate / isKillGateFailLoud) the orchestrator §5b now calls are present;
+// only the IO-ish exports are stubbed.
+vi.mock('../../../lib/eva/devils-advocate.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   isDevilsAdvocateGate: vi.fn().mockReturnValue({ isGate: false, gateType: null }),
   getDevilsAdvocateReview: vi.fn(),
   buildArtifactRecord: vi.fn().mockReturnValue({}),
@@ -500,53 +504,82 @@ describe('EvaOrchestrator', () => {
       isDevilsAdvocateGate.mockReturnValue({ isGate: false, gateType: null });
     });
 
-    it('should still pass DA gate when getDevilsAdvocateReview throws', async () => {
+    // SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001: DA stays fully advisory (a production failure
+    // is swallowed, never blocks) ONLY for PROMOTION gates now. KILL gates fail loud — see the kill-gate
+    // test below. These two were 'kill' previously, encoding the silent-swallow behavior this SD removes.
+    it('should still pass DA gate when getDevilsAdvocateReview throws (promotion gate stays advisory)', async () => {
       const mockSupabase = createMockSupabase();
-      isDevilsAdvocateGate.mockReturnValue({ isGate: true, gateType: 'kill' });
+      isDevilsAdvocateGate.mockReturnValue({ isGate: true, gateType: 'promotion' });
       getDevilsAdvocateReview.mockRejectedValue(new Error('GPT-4o unavailable'));
 
-      const result = await processStage(
-        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
-        {
-          supabase: mockSupabase,
-          logger: silentLogger,
-          evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
-          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
-          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
-        },
-      );
+      try {
+        const result = await processStage(
+          { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+          {
+            supabase: mockSupabase,
+            logger: silentLogger,
+            evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+            evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+            validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          },
+        );
 
-      const daGate = result.gateResults.find(g => g.type === 'devils_advocate');
-      expect(daGate).toBeDefined();
-      expect(daGate.passed).toBe(true);
-      expect(daGate.error).toBe('GPT-4o unavailable');
-
-      // Restore default mock
-      isDevilsAdvocateGate.mockReturnValue({ isGate: false, gateType: null });
+        const daGate = result.gateResults.find(g => g.type === 'devils_advocate');
+        expect(daGate).toBeDefined();
+        expect(daGate.passed).toBe(true);
+        expect(daGate.error).toBe('GPT-4o unavailable');
+      } finally {
+        isDevilsAdvocateGate.mockReturnValue({ isGate: false, gateType: null });
+      }
     });
 
-    it('should never set status to BLOCKED when only DA fails', async () => {
+    it('should never set status to BLOCKED when only DA fails (promotion gate)', async () => {
+      const mockSupabase = createMockSupabase();
+      isDevilsAdvocateGate.mockReturnValue({ isGate: true, gateType: 'promotion' });
+      getDevilsAdvocateReview.mockRejectedValue(new Error('DA service down'));
+
+      try {
+        const result = await processStage(
+          { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+          {
+            supabase: mockSupabase,
+            logger: silentLogger,
+            evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+            evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+            validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          },
+        );
+
+        // A promotion-gate DA failure should NOT block the stage
+        expect(result.status).toBe(STATUS.COMPLETED);
+        expect(result.status).not.toBe(STATUS.BLOCKED);
+      } finally {
+        isDevilsAdvocateGate.mockReturnValue({ isGate: false, gateType: null });
+      }
+    });
+
+    // SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001 (FR-2, orchestrator-level): a KILL gate must
+    // FAIL LOUD when its adversarial review cannot be produced — it must NOT silently proceed with no
+    // recorded adversarial input. This is the exact silent-skip the SD removes.
+    it('should FAIL LOUD (throw) at a kill gate when the adversarial review cannot be produced', async () => {
       const mockSupabase = createMockSupabase();
       isDevilsAdvocateGate.mockReturnValue({ isGate: true, gateType: 'kill' });
       getDevilsAdvocateReview.mockRejectedValue(new Error('DA service down'));
 
-      const result = await processStage(
-        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
-        {
-          supabase: mockSupabase,
-          logger: silentLogger,
-          evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
-          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
-          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
-        },
-      );
-
-      // DA failure should NOT block the stage
-      expect(result.status).toBe(STATUS.COMPLETED);
-      expect(result.status).not.toBe(STATUS.BLOCKED);
-
-      // Restore default mock
-      isDevilsAdvocateGate.mockReturnValue({ isGate: false, gateType: null });
+      try {
+        await expect(processStage(
+          { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+          {
+            supabase: mockSupabase,
+            logger: silentLogger,
+            evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+            evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+            validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          },
+        )).rejects.toThrow(/DA service down/);
+      } finally {
+        isDevilsAdvocateGate.mockReturnValue({ isGate: false, gateType: null });
+      }
     });
   });
 


### PR DESCRIPTION
RCA + fix for a governance defect: a **KILL gate can silently proceed with no persisted adversarial (devil's-advocate) review**, so the chairman decides a financial kill gate with no adversarial framing.

## Root cause (verified in code)

The EVA orchestrator (`lib/eva/eva-orchestrator.js` §5b) gated devil's-advocate **production** on `autonomyPreCheck`. The `GATE_BEHAVIOR_MATRIX` (`lib/eva/autonomy-model.js`) sets `devils_advocate` = `auto_approve` at L2 and `skip` at L3/L4, and **both branches pushed a passed gate result while producing no artifact**. So a non-reserved kill gate (stages **13/24**) at L2+ autonomy emitted no `system_devils_advocate_review` at all.

Reserved kill gates (3/5) are now force-manual by the `RESERVED_CHAIRMAN_STAGES` backstop — which was recent/unmerged when venture-1 ran S5 (the original miss) — but they remained exposed to two further silent holes: a `writeArtifact` persist failure swallowed as a `warn`, and any DA error swallowed into `passed: true`.

## Fix

- **FR-1** — pure helper `mustProduceDevilsAdvocate(gateType, autonomyAction)` in `lib/eva/devils-advocate.js`: **kill gates are unconditional**, promotion gates retain `skip`/`auto_approve` bypass. The orchestrator §5b delegates to it, so kill gates **always produce + persist** the review regardless of autonomy. This decouples *"autonomy auto-approves the gate decision"* from *"the adversarial artifact must still be produced."*
- **FR-2** — `isKillGateFailLoud(gateType)`: a kill-gate persist/produce failure now **throws** (and re-throws in the outer catch) instead of being swallowed to `passed: true`. A fallback review (no `OPENAI_API_KEY`) persists normally as a *recorded degradation* (`isFallback: true`) — only an actual persist failure is fatal.
- **FR-3** — `tests/unit/eva/devils-advocate-kill-gate-deterministic.test.js` (11 tests), sourced from the `KILL_GATES` set so it stays in sync if the kill-gate set changes.

## Tests

- 11 new + 34 sibling (`devils-advocate.test.js`, `autonomy-reserved-gates.test.js`) = **45 passing, no regression**. Orchestrator imports clean. testing-agent verdict PASS (evidence `7faaa042`).

**Honest residual** (follow-up, flagged): the helpers are directly unit-tested but the full §5b wiring (`autonomyPreCheck → produce → persist → throw`) is not exercised end-to-end (would need a live OPENAI key + DB persistence harness). Acceptable given the decision seam is thin, but a future §5b refactor could regress the plumbing with unit tests still green — an integration harness + a runtime monitor for any kill gate completing with no persisted review are noted as action items.

SD: SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001 (campaign-mode, gold-origin from the venture-1 first-run hunt; infrastructure, backend `lib/eva` only — no client surface, no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
