### PR TITLE
fix(SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001): coordinator->Adam reply targets the live Adam + delivery verification

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S5-DEVILS-ADVOCATE-NOT-PRODUCED-001",
-  "createdAt": "2026-06-26T10:30:14.192Z",
+  "sdKey": "SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001",
+  "createdAt": "2026-06-26T11:55:40.875Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/coordinator/adam-identity.cjs
+++ b/lib/coordinator/adam-identity.cjs
@@ -127,6 +127,64 @@ async function countFreshAdams(supabase, opts = {}) {
 }
 
 /**
+ * SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001 (FR-1): resolve the reply-target Adam session
+ * for a coordinator->Adam reply. CONFIRMED root cause: the reply path targeted the advisory's
+ * ORIGINATING session (adv.sender_session) directly, so after a role-handoff / single-Adam guard
+ * retire-then-register the reply landed in the STALE Adam's inbox. Prefer the CURRENT live Adam
+ * (getActiveAdamId); fall back to the originator only when no live Adam resolves (FAIL-OPEN — a reply
+ * is never blocked). Adam is a singleton role, so re-pointing to the live Adam is correct by design.
+ * @returns {Promise<{target:string, live:(string|null), originator:string, retargeted:boolean}>}
+ */
+async function resolveAdamReplyTarget(supabase, originatorSession, opts = {}) {
+  let live = null;
+  try { live = await getActiveAdamId(supabase, opts); } catch { live = null; } // fail-open
+  const target = live || originatorSession;
+  return { target, live, originator: originatorSession, retargeted: Boolean(live && live !== originatorSession) };
+}
+
+/**
+ * FR-2: recover messages already stuck at a stale originator. Re-point any UNREAD coordinator->Adam
+ * rows still targeted at the stale originator to the current live Adam. Only unread rows move
+ * (acknowledged ones are settled). Best-effort + REPORTED — returns the re-targeted count; an error
+ * is surfaced, never silently swallowed. No-op when there is nothing to move.
+ * @returns {Promise<{retargeted:number, error:(string|null)}>}
+ */
+async function retargetStaleAdamInbound(supabase, { staleOriginator, liveAdam }) {
+  if (!staleOriginator || !liveAdam || staleOriginator === liveAdam) return { retargeted: 0, error: null };
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .update({ target_session: liveAdam })
+      .eq('target_session', staleOriginator)
+      .eq('sender_type', 'coordinator')
+      .is('acknowledged_at', null)
+      .select('id');
+    if (error) return { retargeted: 0, error: error.message };
+    return { retargeted: Array.isArray(data) ? data.length : 0, error: null };
+  } catch (e) {
+    return { retargeted: 0, error: e && e.message ? e.message : String(e) };
+  }
+}
+
+/**
+ * FR-3: verify a sent reply actually landed (send != delivered). Read the row back by id. Returns
+ * true only when the row is confirmable; FAIL-LOUD callers treat false as a delivery error.
+ * @returns {Promise<boolean>}
+ */
+async function verifyReplyDelivered(supabase, rowId) {
+  if (!rowId) return false;
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('id', rowId)
+      .maybeSingle();
+    if (error) return false;
+    return Boolean(data && data.id);
+  } catch { return false; }
+}
+
+/**
  * PURE single-Adam guard decision. The deliberate divergence from the coordinator clear-losers
  * pattern: PREFER refuse-new-on-fresh-prior over clear-prior — never clear a legitimately-restarting
  * Adam mid-canary; retire only STALE priors. Returns:
@@ -170,4 +228,7 @@ module.exports = {
   getActiveAdamId,
   countFreshAdams,
   decideSingleAdamGuard,
+  resolveAdamReplyTarget,
+  retargetStaleAdamInbound,
+  verifyReplyDelivered,
 };

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -21,6 +21,7 @@ const { isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 const { isFullUuid } = require('../lib/coordinator/dispatch.cjs');
 const { fetchAdvisory, stampActioned } = require('../lib/coordinator/adam-advisory-store.cjs');
 const { sendCoordinatorReply } = require('./coordinator-reply.cjs');
+const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered } = require('../lib/coordinator/adam-identity.cjs');
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -76,13 +77,25 @@ async function main() {
       process.exit(0);
     }
     if (!replyBody) { console.error('ERROR: --reply requires a body.'); process.exit(2); }
-    const adamSession = adv.sender_session;
+    const originator = adv.sender_session;
     const correlationId = adv.payload && adv.payload.correlation_id;
-    if (!isFullUuid(adamSession)) { console.error('ERROR: advisory sender_session is not a full UUID:', JSON.stringify(adamSession)); process.exit(1); }
+    if (!isFullUuid(originator)) { console.error('ERROR: advisory sender_session is not a full UUID:', JSON.stringify(originator)); process.exit(1); }
     if (!correlationId) { console.error('ERROR: advisory carries no payload.correlation_id (not replyable).'); process.exit(1); }
+    // FR-1: target the CURRENT live Adam, never a stale originating session.
+    const { target: adamSession, retargeted } = await resolveAdamReplyTarget(supabase, originator);
+    if (retargeted) {
+      console.log(`  ↻ re-targeted from stale originator ${originator} → live Adam ${adamSession}`);
+      // FR-2: recover any prior unread inbound stuck at the stale originator.
+      const rec = await retargetStaleAdamInbound(supabase, { staleOriginator: originator, liveAdam: adamSession });
+      if (rec.error) console.error('  WARN: stuck-inbound recovery error:', rec.error);
+      else if (rec.retargeted > 0) console.log(`  ↻ recovered ${rec.retargeted} prior unread message(s) to the live Adam`);
+    }
     const { data, error } = await sendCoordinatorReply(supabase, { coordinatorSession, workerSession: adamSession, correlationId, body: replyBody });
     if (error) { console.error('ERROR: failed to send reply:', error.message); process.exit(1); }
-    console.log('✓ Coordinator reply sent to Adam');
+    // FR-3: verify delivery (send != delivered) — fail loud if the row cannot be confirmed.
+    const delivered = await verifyReplyDelivered(supabase, data && data.id);
+    if (!delivered) { console.error('ERROR: reply send reported success but the row could not be confirmed (delivery NOT verified) — failing loud.'); process.exit(1); }
+    console.log('✓ Coordinator reply sent to Adam (delivery verified)');
     console.log('  reply_id:', data.id);
     console.log('  to_adam:', adamSession);
     console.log('  reply_to:', correlationId);

--- a/scripts/coordinator-reply.cjs
+++ b/scripts/coordinator-reply.cjs
@@ -20,6 +20,7 @@ const { createClient } = require('@supabase/supabase-js');
 const { isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 const { isFullUuid } = require('../lib/coordinator/dispatch.cjs');
 const { redact, BODY_HARD_CAP } = require('./worker-signal.cjs');
+const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered } = require('../lib/coordinator/adam-identity.cjs');
 
 // Default reply lifetime — comfortably exceeds the worker await window (30s) plus margin.
 const REPLY_DEFAULT_TTL_MS = 60 * 60_000;
@@ -124,15 +125,24 @@ async function main() {
       .maybeSingle();
     if (advErr) { console.error('ERROR: advisory lookup failed:', advErr.message); process.exit(1); }
     if (!adv) { console.error('ERROR: advisory not found:', advisoryId); process.exit(1); }
-    workerSession = adv.sender_session;
+    const originator = adv.sender_session;
     correlationId = (adv.payload && adv.payload.correlation_id) || correlationId;
     if (!correlationId) {
       console.error(`ERROR: advisory ${advisoryId} carries no payload.correlation_id (not replyable — re-send via the updated adam-advisory.cjs).`);
       process.exit(1);
     }
-    if (!isFullUuid(workerSession)) {
-      console.error(`ERROR: advisory ${advisoryId} sender_session is not a full UUID: ${JSON.stringify(workerSession)}`);
+    if (!isFullUuid(originator)) {
+      console.error(`ERROR: advisory ${advisoryId} sender_session is not a full UUID: ${JSON.stringify(originator)}`);
       process.exit(1);
+    }
+    // FR-1: target the CURRENT live Adam, never the (possibly stale) advisory originator.
+    const resolved = await resolveAdamReplyTarget(supabase, originator);
+    workerSession = resolved.target;
+    if (resolved.retargeted) {
+      console.log(`  ↻ re-targeted from stale originator ${originator} → live Adam ${workerSession}`);
+      const rec = await retargetStaleAdamInbound(supabase, { staleOriginator: originator, liveAdam: workerSession });
+      if (rec.error) console.error('  WARN: stuck-inbound recovery error:', rec.error);
+      else if (rec.retargeted > 0) console.log(`  ↻ recovered ${rec.retargeted} prior unread message(s) to the live Adam`);
     }
   }
 
@@ -144,8 +154,14 @@ async function main() {
     console.error('ERROR: failed to insert reply:', error.message);
     process.exit(1);
   }
+  // FR-3: verify delivery (send != delivered) — fail loud if the row cannot be confirmed.
+  const delivered = await verifyReplyDelivered(supabase, data && data.id);
+  if (!delivered) {
+    console.error('ERROR: reply send reported success but the row could not be confirmed (delivery NOT verified) — failing loud.');
+    process.exit(1);
+  }
 
-  console.log('✓ Coordinator reply sent');
+  console.log('✓ Coordinator reply sent (delivery verified)');
   console.log('  reply_id:', data.id);
   console.log('  to_worker:', workerSession);
   console.log('  reply_to:', correlationId);

--- a/tests/unit/coordinator/adam-reply-target-integrity.test.js
+++ b/tests/unit/coordinator/adam-reply-target-integrity.test.js
@@ -1,0 +1,106 @@
+/**
+ * SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001 — coordinator->Adam reply delivery integrity.
+ *
+ * CONFIRMED root cause: the reply path targeted the advisory's ORIGINATING session
+ * (adv.sender_session) directly, so after a role-handoff / single-Adam guard retire-then-register the
+ * reply landed in the STALE Adam's inbox (coordinator believes-sent, live Adam inbox empty). These
+ * tests lock the three fixes: FR-1 resolveAdamReplyTarget (live Adam, fail-open fallback), FR-2
+ * retargetStaleAdamInbound (recover unread stuck rows), FR-3 verifyReplyDelivered (fail-loud).
+ */
+import { describe, it, expect } from 'vitest';
+import adamIdentity from '../../../lib/coordinator/adam-identity.cjs';
+
+const { resolveAdamReplyTarget, retargetStaleAdamInbound, verifyReplyDelivered } = adamIdentity;
+
+// Minimal chainable supabase mock. claude_sessions reads return `freshAdams`; session_coordination
+// UPDATE...select('id') returns `retargetRows`; maybeSingle returns `verifyRow`.
+function makeSb({ freshAdams = [], retargetRows = [], retargetError = null, verifyRow = null } = {}) {
+  return {
+    from(table) {
+      let isUpdate = false;
+      const builder = {
+        select() { return builder; },
+        gte() { return builder; },
+        filter() { return builder; },
+        eq() { return builder; },
+        is() { return builder; },
+        update() { isUpdate = true; return builder; },
+        maybeSingle() { return Promise.resolve({ data: verifyRow, error: null }); },
+        then(resolve, reject) {
+          let result;
+          if (table === 'claude_sessions') result = { data: freshAdams, error: null };
+          else if (table === 'session_coordination') result = isUpdate ? { data: retargetRows, error: retargetError } : { data: [], error: null };
+          else result = { data: [], error: null };
+          return Promise.resolve(result).then(resolve, reject);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+const liveRow = (id, since = '2026-06-26T00:00:00.000Z') => ({ session_id: id, heartbeat_at: new Date().toISOString(), metadata: { role: 'adam', adam_since: since } });
+
+describe('FR-1 resolveAdamReplyTarget — re-route to the live Adam', () => {
+  it('re-routes a stale-originator reply to the CURRENT live Adam', async () => {
+    const sb = makeSb({ freshAdams: [liveRow('live-adam')] });
+    const r = await resolveAdamReplyTarget(sb, 'stale-originator');
+    expect(r.target).toBe('live-adam');
+    expect(r.retargeted).toBe(true);
+    expect(r.live).toBe('live-adam');
+  });
+
+  it('re-route is a no-op when the originator IS the live Adam', async () => {
+    const sb = makeSb({ freshAdams: [liveRow('same-adam')] });
+    const r = await resolveAdamReplyTarget(sb, 'same-adam');
+    expect(r.target).toBe('same-adam');
+    expect(r.retargeted).toBe(false);
+  });
+
+  it('fails OPEN: with no live Adam it falls back to the originator (reply never blocked)', async () => {
+    const sb = makeSb({ freshAdams: [] });
+    const r = await resolveAdamReplyTarget(sb, 'stale-originator');
+    expect(r.target).toBe('stale-originator');
+    expect(r.live).toBe(null);
+    expect(r.retargeted).toBe(false);
+  });
+});
+
+describe('FR-2 retargetStaleAdamInbound — recover stuck unread inbound', () => {
+  it('recovers unread coordinator rows from the stale originator and reports the count', async () => {
+    const sb = makeSb({ retargetRows: [{ id: 'm1' }, { id: 'm2' }] });
+    const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'stale', liveAdam: 'live' });
+    expect(r.retargeted).toBe(2);
+    expect(r.error).toBe(null);
+  });
+
+  it('is a no-op when originator === live Adam (nothing to recover)', async () => {
+    const sb = makeSb({ retargetRows: [{ id: 'm1' }] });
+    const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'x', liveAdam: 'x' });
+    expect(r.retargeted).toBe(0);
+  });
+
+  it('surfaces a recovery error (never silent)', async () => {
+    const sb = makeSb({ retargetError: { message: 'db down' } });
+    const r = await retargetStaleAdamInbound(sb, { staleOriginator: 'stale', liveAdam: 'live' });
+    expect(r.retargeted).toBe(0);
+    expect(r.error).toBe('db down');
+  });
+});
+
+describe('FR-3 verifyReplyDelivered — fail-loud delivery verification', () => {
+  it('confirms delivery when the inserted row reads back', async () => {
+    const sb = makeSb({ verifyRow: { id: 'reply-1' } });
+    expect(await verifyReplyDelivered(sb, 'reply-1')).toBe(true);
+  });
+
+  it('fail-loud signal: returns false when the row cannot be confirmed', async () => {
+    const sb = makeSb({ verifyRow: null });
+    expect(await verifyReplyDelivered(sb, 'reply-1')).toBe(false);
+  });
+
+  it('fail-loud signal: returns false for a missing row id', async () => {
+    const sb = makeSb({ verifyRow: { id: 'x' } });
+    expect(await verifyReplyDelivered(sb, null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the one-way coordinator→Adam comms delivery gap (coordinator believes-sent, Adam's inbox empty).

## Confirmed root cause (verify-premise, pinned to two lines)

The coordinator→Adam reply path targeted the advisory's **originating** session (`adv.sender_session`) directly — `scripts/coordinator-ack-adam.cjs:79` and `scripts/coordinator-reply.cjs:127`. After a role-handoff / single-Adam-guard retire-then-register, that originator is the **stale** Adam, so the reply landed in the stale inbox while the live Adam saw nothing. The canonical live-Adam resolver `getActiveAdamId` already existed in `lib/coordinator/adam-identity.cjs` — but neither send path called it.

## Fix

- **FR-1** `resolveAdamReplyTarget` (adam-identity.cjs): prefer the **current live Adam** (`getActiveAdamId`), fall back to the originator only when none resolves (**fail-open** — a reply is never blocked). Wired into both reply entry points. Adam is a singleton role, so re-pointing to the live Adam is correct by design.
- **FR-2** `retargetStaleAdamInbound`: on a re-targeted send, re-point prior **unread** coordinator→Adam rows from the stale originator to the live Adam (recovers already-lost messages); reports the count, surfaces errors (never silent).
- **FR-3** `verifyReplyDelivered`: read-back the inserted row; both senders **fail loud** (`process.exit(1)`) if it can't be confirmed (send ≠ delivered).

## Tests

`tests/unit/coordinator/adam-reply-target-integrity.test.js` (9): re-route to live Adam / no-op when originator is live / fail-open fallback; recovery of unread rows + error surfacing; fail-loud delivery verification. Coordinator suite **321 passing, 20 files, no regression** (the regression run explicitly includes the suites that mock `adam-identity`). testing-agent verdict PASS (evidence `8cb6e958`).

## Scope (relayed to coordinator, on record)

The SD draft framed a broad 5-FR scope. Verify-premise pinned the symptom to the single targeting bug (cause a), so this ships the **confirmed fix as one tighter SD**. **Deferred** (documented, pending evidence/coordinator confirmation): the SD's original Windows `UV_HANDLE_CLOSING` teardown FR (not evidenced by this symptom — cause-a fully explains it) and a deeper Adam-side `drainAdamOutbound` change (covered functionally by the coordinator-side FR-2 recovery). **Residual**: the helpers are unit-tested with an injected supabase mock; the two CLI entry-point wirings are verified by load + code inspection, not an end-to-end two-Adam role-handoff fixture (a follow-up).

SD: SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001 (campaign-mode; infrastructure, backend coordinator↔Adam path only — no client surface, no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
