### PR TITLE
fix(SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001): thread real purpose + MAX_TOKENS cache guard + fail-loud truncation

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-COORD-ADAM-COMMS-DELIVERY-INTEGRITY-001",
-  "createdAt": "2026-06-26T11:55:40.875Z",
+  "sdKey": "SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001",
+  "createdAt": "2026-06-26T12:48:06.054Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/utils/parse-json.js
+++ b/lib/eva/utils/parse-json.js
@@ -60,21 +60,26 @@ function repairJSON(text) {
  * (with .content property). When an adapter response is passed,
  * the .content field is extracted for parsing.
  *
- * Three-layer parse strategy:
+ * Parse strategy (SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001 FR-3 — docstring de-drifted; the
+ * former Layer-3 claim of a relaxed/lenient third parser never existed in the code — Layer 3 throws):
  *   1. Direct JSON.parse (fast path)
- *   2. Repair layer (fix common LLM anti-patterns)
- *   3. JSON5 relaxed parse (handles trailing commas, unquoted keys, etc.)
+ *   2. Repair layer (fix common LLM anti-patterns), then JSON.parse the repaired text
+ *   3. On failure, throw with full context — and when the response was TRUNCATED at the token ceiling
+ *      (finishReason==='MAX_TOKENS'), surface an actionable truncation message instead of the
+ *      misleading "Failed to parse ... as JSON" (truncation is a token-ceiling problem, NOT a
+ *      JSON-robustness one — that misdirection sent the original venture-1 diagnosis down the wrong path).
  *
- * @param {string|Object} textOrResponse - Raw text or adapter response { content, usage, ... }
+ * @param {string|Object} textOrResponse - Raw text or adapter response { content, usage, finishReason, ... }
  * @param {Object} [options] - Parse options
  * @param {boolean} [options.strict=false] - When true, throw on failure instead of returning null
  * @returns {Object} Parsed JSON object
  */
 export function parseJSON(textOrResponse, options = {}) {
   // Handle adapter response objects (from client.complete())
-  const text = typeof textOrResponse === 'object' && textOrResponse !== null && typeof textOrResponse.content === 'string'
-    ? textOrResponse.content
-    : String(textOrResponse);
+  const isResponseObj = typeof textOrResponse === 'object' && textOrResponse !== null && typeof textOrResponse.content === 'string';
+  const text = isResponseObj ? textOrResponse.content : String(textOrResponse);
+  // FR-3: read the truncation signal from the adapter response (when one was passed).
+  const truncated = isResponseObj && textOrResponse.finishReason === 'MAX_TOKENS';
 
   // Strip markdown code fences if present
   const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
@@ -94,11 +99,10 @@ export function parseJSON(textOrResponse, options = {}) {
     // Fall through to error
   }
 
-  // Layer 3: Throw with full context (or return null for non-strict callers)
-  const errorMsg = `Failed to parse LLM response as JSON: ${cleaned.substring(0, 200)}`;
-  if (options.strict) {
-    throw new Error(errorMsg);
-  }
+  // Layer 3: Throw with full context. FR-3 fail-loud: name the real cause when truncated.
+  const errorMsg = truncated
+    ? `LLM response truncated at token ceiling (finishReason=MAX_TOKENS) — increase maxOutputTokens / thread the call purpose (e.g. purpose:'content-generation' → 16384). Raw head: ${cleaned.substring(0, 200)}`
+    : `Failed to parse LLM response as JSON: ${cleaned.substring(0, 200)}`;
   throw new Error(errorMsg);
 }
 

--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -419,7 +419,7 @@ export function getLLMClient(options = {}) {
  * @param {Object} options - Original getLLMClient options
  * @returns {Object} Wrapped adapter
  */
-function _wrapAdapter(adapter, options = {}) {
+export function _wrapAdapter(adapter, options = {}) {
   if (!adapter || !adapter.complete) return adapter;
 
   const originalComplete = adapter.complete.bind(adapter);
@@ -434,7 +434,10 @@ function _wrapAdapter(adapter, options = {}) {
     // Check cache (skip if TTL explicitly set to 0)
     if (effectiveCacheTTL !== 0) {
       const cached = responseCache.get(systemPrompt, userPrompt, modelName);
-      if (cached) {
+      // SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001 FR-2 (defense-in-depth): never REPLAY a
+      // truncated response — a cached finishReason==='MAX_TOKENS' entry is treated as a miss so the
+      // call is re-made (with the correct ceiling) instead of returning a guaranteed-unparseable body.
+      if (cached && cached.finishReason !== 'MAX_TOKENS') {
         logUsage({
           model: modelName,
           provider: cached.provider || 'cache',
@@ -450,13 +453,21 @@ function _wrapAdapter(adapter, options = {}) {
       }
     }
 
-    // Call the real LLM
+    // Call the real LLM.
+    // SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001 FR-1 (ROOT FIX): thread the client's REAL
+    // purpose into the adapter options so the per-purpose maxOutputTokens (16384 for
+    // content-generation) is applied instead of the 4096 default that truncated venture-1's
+    // S16-financial JSON. Only a real purpose category is forwarded (NOT the 'unknown'/subAgent-only
+    // fallback, which never triggers the ceiling) and an explicit per-call callOptions.purpose WINS.
+    const realPurpose = (options.purpose && options.purpose !== 'unknown') ? options.purpose : null;
+    const completeOptions = realPurpose ? { purpose: realPurpose, ...callOptions } : callOptions;
     const startMs = Date.now();
-    const result = await originalComplete(systemPrompt, userPrompt, callOptions);
+    const result = await originalComplete(systemPrompt, userPrompt, completeOptions);
     const durationMs = Date.now() - startMs;
 
-    // Cache the result (skip if TTL explicitly set to 0)
-    if (effectiveCacheTTL !== 0 && result) {
+    // Cache the result (skip if TTL explicitly set to 0).
+    // FR-2: do NOT cache a MAX_TOKENS (truncated) response — it must never be replayed on retry.
+    if (effectiveCacheTTL !== 0 && result && result.finishReason !== 'MAX_TOKENS') {
       responseCache.set(systemPrompt, userPrompt, modelName, result, effectiveCacheTTL);
     }
 

--- a/tests/unit/llm/purpose-threading-truncation.test.js
+++ b/tests/unit/llm/purpose-threading-truncation.test.js
@@ -1,0 +1,97 @@
+/**
+ * SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001 — _wrapAdapter purpose threading + MAX_TOKENS
+ * cache guard, and parseJSON truncation-aware fail-loud.
+ *
+ * ROOT CAUSE: _wrapAdapter dropped the client's `purpose`, so the per-purpose content-generation
+ * ceiling (16384) collapsed to the 4096 default → MAX_TOKENS truncation → unparseable JSON, and the
+ * misleading "Failed to parse ... as JSON" sent the diagnosis down a JSON-robustness path.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { _wrapAdapter } from '../../../lib/llm/client-factory.js';
+import responseCache from '../../../lib/llm/response-cache.js';
+import { parseJSON } from '../../../lib/eva/utils/parse-json.js';
+
+function fakeAdapter(result = { content: '{}', finishReason: 'STOP' }) {
+  const calls = [];
+  return {
+    model: 'fake-model',
+    calls,
+    complete: async (_sys, _user, opts = {}) => { calls.push(opts); return result; },
+  };
+}
+
+describe('FR-1 _wrapAdapter forwards purpose into the adapter call', () => {
+  it('forwards purpose: a REAL client purpose reaches originalComplete (so the 16384 ceiling applies)', async () => {
+    const a = fakeAdapter();
+    const wrapped = _wrapAdapter(a, { purpose: 'content-generation', cacheTTLMs: 0 });
+    await wrapped.complete('sys-fr1-a', 'user-fr1-a', {});
+    expect(a.calls[0].purpose).toBe('content-generation');
+  });
+
+  it('forwards purpose: an explicit per-call callOptions.purpose WINS over the client purpose', async () => {
+    const a = fakeAdapter();
+    const wrapped = _wrapAdapter(a, { purpose: 'content-generation', cacheTTLMs: 0 });
+    await wrapped.complete('sys-fr1-b', 'user-fr1-b', { purpose: 'fast' });
+    expect(a.calls[0].purpose).toBe('fast');
+  });
+
+  it('forwards purpose: a subAgent-only / unknown client purpose is NOT threaded (callOptions passed through)', async () => {
+    const a = fakeAdapter();
+    const wrapped = _wrapAdapter(a, { subAgent: 'SECURITY', cacheTTLMs: 0 }); // no real purpose
+    await wrapped.complete('sys-fr1-c', 'user-fr1-c', {});
+    expect(a.calls[0].purpose).toBeUndefined();
+  });
+});
+
+describe('FR-2 a MAX_TOKENS (truncated) response is never cached or replayed', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('truncated result is NOT written to the cache', async () => {
+    const setSpy = vi.spyOn(responseCache, 'set').mockImplementation(() => {});
+    vi.spyOn(responseCache, 'get').mockReturnValue(undefined);
+    const a = fakeAdapter({ content: '{"partial":', finishReason: 'MAX_TOKENS' });
+    const wrapped = _wrapAdapter(a, { purpose: 'content-generation' });
+    await wrapped.complete('sys-fr2-a', 'user-fr2-a', {});
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('a non-truncated result IS cached (no regression)', async () => {
+    const setSpy = vi.spyOn(responseCache, 'set').mockImplementation(() => {});
+    vi.spyOn(responseCache, 'get').mockReturnValue(undefined);
+    const a = fakeAdapter({ content: '{}', finishReason: 'STOP' });
+    const wrapped = _wrapAdapter(a, { purpose: 'content-generation' });
+    await wrapped.complete('sys-fr2-b', 'user-fr2-b', {});
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a cached MAX_TOKENS entry is NOT replayed — the adapter is re-called', async () => {
+    vi.spyOn(responseCache, 'get').mockReturnValue({ content: '{"old":', finishReason: 'MAX_TOKENS' });
+    vi.spyOn(responseCache, 'set').mockImplementation(() => {});
+    const a = fakeAdapter({ content: '{"fresh":true}', finishReason: 'STOP' });
+    const wrapped = _wrapAdapter(a, { purpose: 'content-generation' });
+    const result = await wrapped.complete('sys-fr2-c', 'user-fr2-c', {});
+    expect(a.calls.length).toBe(1); // re-called, not replayed
+    expect(result.finishReason).toBe('STOP');
+  });
+});
+
+describe('FR-3 parseJSON truncation fail-loud + docstring de-drift', () => {
+  it('fail-loud: a MAX_TOKENS response surfaces the actionable truncation message', () => {
+    expect(() => parseJSON({ content: '{"partial":', finishReason: 'MAX_TOKENS' }, { strict: true }))
+      .toThrow(/truncated at token ceiling/i);
+  });
+
+  it('fail-loud: genuinely malformed (non-truncated) JSON still throws the generic parse-failure message', () => {
+    expect(() => parseJSON({ content: 'not json at all', finishReason: 'STOP' }, { strict: true }))
+      .toThrow(/Failed to parse LLM response as JSON/);
+  });
+
+  it('the source no longer advertises a non-existent JSON5 Layer 3 (docstring de-drift)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, resolve } = await import('node:path');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, '../../../lib/eva/utils/parse-json.js'), 'utf8');
+    expect(src).not.toMatch(/JSON5 relaxed parse/);
+  });
+});


### PR DESCRIPTION
RCA + fix for the bug that froze venture-1 at S16: `getLLMClient({purpose})` had its `purpose` **dropped** by `_wrapAdapter` when calling the underlying adapter, so the content-generation `maxOutputTokens` ceiling (16384) collapsed to the 4096 default → `MAX_TOKENS` truncation → unparseable JSON. The misleading `Failed to parse LLM response as JSON` error then sent the routed diagnosis down a JSON-robustness path instead of the real token-ceiling cause.

## Fix

- **FR-1 (root)** — `lib/llm/client-factory.js` `_wrapAdapter` now threads the client's **real** purpose into `originalComplete` so the per-purpose ceiling applies. Only a real category is forwarded (not the `unknown`/subAgent-only fallback, which never triggers the ceiling anyway), and an explicit per-call `callOptions.purpose` **wins**. Restores the 16384 ceiling across all producers in one place.
- **FR-2 (amplifier)** — never cache a `finishReason==='MAX_TOKENS'` result, and skip (don't replay) a cached `MAX_TOKENS` entry. A truncated response can't be retried into success, so it must never be replayed.
- **FR-3 (diagnostic)** — `lib/eva/utils/parse-json.js` surfaces an actionable truncation message (`LLM response truncated at token ceiling … increase maxOutputTokens / thread purpose`) when `finishReason==='MAX_TOKENS'`, instead of the misleading parse-failure. Also fixed the docstring drift: it advertised a `Layer 3: JSON5 relaxed parse` that never existed in the code (Layer 3 throws) — corrected and locked with a source-guard test.

`provider-adapters.js` (listed in the SD) needed **no change** — it already applies the 16384 content-generation ceiling and returns `finishReason`.

## Tests

`tests/unit/llm/purpose-threading-truncation.test.js` (9, mapped 1:1 to FR-1/2/3): purpose forwarded + precedence + no-thread; MAX_TOKENS not cached/replayed + non-truncated still caches; truncation fail-loud message vs generic + docstring de-drift guard. llm + eva consumers **5245 passing** — the only reds are the pre-existing `stage-execution-worker` test debt (UNIT-TEST-DEBT-TRIAGE-002), unrelated to these files. testing-agent verdict PASS (evidence `cfb8ea6b`).

## Verify-premise note

FR-1's root fix existed in the main **working tree** as a chairman-authorized operational hot-patch (uncommitted); the worktree (clean branch from HEAD) did not have it — so this SD **formalizes** it as a committed change with tests, plus completes FR-2/FR-3.

SD: SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001 (campaign-mode, gold-origin from the venture-1 first-run hunt; infrastructure, backend `lib/llm` + `lib/eva/utils` only — no client/UI surface, no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
