### PR TITLE
fix(SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001): staleness-based startup recovery + fail-loud

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001",
-  "createdAt": "2026-06-26T12:48:06.054Z",
+  "sdKey": "SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001",
+  "createdAt": "2026-06-26T13:24:35.201Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -2082,29 +2082,46 @@ export class StageExecutionWorker {
   }
 
   /**
-   * SD-FIX-WORKER-STARTUP-LOCK-RECOVERY-001: Reset ventures stuck in processing
-   * state from previous worker instances. Called once at startup before the first
-   * poll tick. Only resets ventures whose lock_id does not match this worker.
+   * Reset ventures stuck in processing state from previous (dead) worker instances. Called once at
+   * startup before the first poll tick.
+   *
+   * SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001 (FR-1): recover by LOCK STALENESS, mirroring the proven
+   * periodic stale-lock sweep (_releaseStaleLocks). The prior implementation compared the UUID column
+   * orchestrator_lock_id (acquireProcessingLock writes randomUUID()) against this._workerId (a
+   * `sew-host-pid` STRING) — a uuid-vs-string cast error that the catch swallowed, so recovery silently
+   * no-op'd and venture-1 froze twice. Staleness correctly identifies dead-instance locks (heartbeat
+   * older than the threshold) WITHOUT a schema migration and without stealing a live worker's fresh lock.
+   * NOTE: the staleness logic intentionally parallels _releaseStaleLocks; a future refactor could share
+   * a helper (and update the resilience test that asserts the sweep's exact message).
    */
   async _onStartupRecovery() {
     try {
+      const cutoff = new Date(Date.now() - this._staleLockThresholdMs).toISOString();
       const { data: orphaned, error } = await this._supabase
         .from('ventures')
-        .select('id, name, orchestrator_lock_id')
+        .select('id, name, orchestrator_lock_acquired_at')
         .eq('orchestrator_state', ORCHESTRATOR_STATES.PROCESSING)
-        .neq('orchestrator_lock_id', this._workerId);
+        .lt('orchestrator_lock_acquired_at', cutoff);
 
       if (error) {
-        this._logger.warn(`[Worker] Startup recovery query failed: ${error.message}`);
-        return;
+        // FR-2: FAIL-LOUD — a recovery-query error must NOT be silently swallowed (the prior `warn` +
+        // return is exactly what masked the uuid-cast bug). Log at ERROR and emit a diagnostic event.
+        this._logger.error(`[Worker] Startup recovery query failed (FAIL-LOUD): ${error.message}`);
+        await emit(this._supabase, 'startup_recovery_query_failed', {
+          error: error.message,
+          workerId: this._workerId,
+        }, 'stage-execution-worker').catch(() => {});
+        return; // non-fatal: worker startup continues, but the failure is now observable
       }
 
       if (!orphaned || orphaned.length === 0) return;
 
+      let resetCount = 0;
       for (const venture of orphaned) {
+        const lockAge = Date.now() - new Date(venture.orchestrator_lock_acquired_at).getTime();
         this._logger.warn(
           `[Worker] Startup recovery: resetting ${venture.name || venture.id} ` +
-          `(stale lock_id=${venture.orchestrator_lock_id})`
+          `(stale lock locked ${Math.round(lockAge / 1000)}s ago, threshold ${this._staleLockThresholdMs / 1000}s)`
         );
 
         const { error: resetError } = await this._supabase
@@ -2120,16 +2137,17 @@ export class StageExecutionWorker {
         if (resetError) {
           this._logger.error(`[Worker] Startup recovery reset failed for ${venture.id}: ${resetError.message}`);
         } else {
+          resetCount++;
           await emit(this._supabase, 'startup_recovery_lock_released', {
             ventureId: venture.id,
             ventureName: venture.name,
-            staleLockId: venture.orchestrator_lock_id,
+            lockAge,
             releasedBy: this._workerId,
           }, 'stage-execution-worker').catch(() => {});
         }
       }
 
-      this._logger.log(`[Worker] Startup recovery complete: ${orphaned.length} venture(s) reset`);
+      this._logger.log(`[Worker] Startup recovery complete: ${resetCount} venture(s) reset`);
     } catch (err) {
       this._logger.error(`[Worker] Startup recovery error: ${err.message}`);
     }

--- a/tests/unit/eva/stage-execution-worker.test.js
+++ b/tests/unit/eva/stage-execution-worker.test.js
@@ -566,28 +566,23 @@ describe('StageExecutionWorker', () => {
       worker = new StageExecutionWorker({ supabase, logger });
     });
 
-    it('resets ventures with foreign lock_id on startup', async () => {
+    it('resets ventures with a STALE lock on startup (SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001 FR-1)', async () => {
+      // FR-1: recovery is now STALENESS-based (.lt orchestrator_lock_acquired_at), not the broken
+      // uuid-vs-string .neq(orchestrator_lock_id, workerId) comparison.
       const orphaned = [
-        { id: 'v1', name: 'Venture A', orchestrator_lock_id: 'old-worker-1' },
+        { id: 'v1', name: 'Venture A', orchestrator_lock_acquired_at: new Date(Date.now() - 999_999).toISOString() },
       ];
-      const chain = {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        neq: vi.fn().mockReturnThis(),
-        update: vi.fn().mockReturnThis(),
-        then: vi.fn(),
-      };
       // First from('ventures') call: select query returns orphaned
       // Second from('ventures') call: update succeeds
       let callCount = 0;
       supabase.from.mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          // SELECT query chain
+          // SELECT query chain (.eq state, .lt stale-cutoff)
           return {
             select: vi.fn().mockReturnValue({
               eq: vi.fn().mockReturnValue({
-                neq: vi.fn().mockResolvedValue({ data: orphaned, error: null }),
+                lt: vi.fn().mockResolvedValue({ data: orphaned, error: null }),
               }),
             }),
           };
@@ -612,11 +607,11 @@ describe('StageExecutionWorker', () => {
       );
     });
 
-    it('does nothing when no orphaned ventures exist', async () => {
+    it('does nothing when no stale-locked ventures exist', async () => {
       supabase.from.mockImplementation(() => ({
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
-            neq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            lt: vi.fn().mockResolvedValue({ data: [], error: null }),
           }),
         }),
       }));
@@ -626,19 +621,20 @@ describe('StageExecutionWorker', () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
 
-    it('continues worker startup on query error', async () => {
+    it('FAILS LOUD (logs error, does not throw) on a recovery query error (FR-2)', async () => {
       supabase.from.mockImplementation(() => ({
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
-            neq: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB down' } }),
+            lt: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB down' } }),
           }),
         }),
       }));
 
       await worker._onStartupRecovery();
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Startup recovery query failed: DB down'),
+      // FR-2: the prior silent `warn` + return is replaced by a loud error log (the swallow masked the bug).
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Startup recovery query failed (FAIL-LOUD): DB down'),
       );
       // Worker should not throw — start() continues
     });

--- a/tests/unit/eva/stage-worker-startup-recovery.test.js
+++ b/tests/unit/eva/stage-worker-startup-recovery.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001 — startup recovery is staleness-based + fail-loud.
+ *
+ * RCA: _onStartupRecovery compared the UUID column orchestrator_lock_id (acquireProcessingLock writes
+ * randomUUID()) against this._workerId (a `sew-host-pid` STRING) — a uuid-vs-string cast error the
+ * catch swallowed, so recovery silently no-op'd and venture-1 froze twice. The fix recovers by LOCK
+ * STALENESS (the same proven mechanism as the periodic stale-lock sweep), with NO schema migration.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+
+const STALE_MS = 120_000;
+
+// Build a worker whose first supabase.from() (the recovery SELECT) returns `selectResult` and captures
+// the .lt(column, value) staleness filter; later from() calls (UPDATE / emit) are inert.
+function makeWorker({ selectResult, captureLt, captureNeq }) {
+  const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  let call = 0;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return {
+          select: () => ({
+            eq: () => ({
+              lt: (col, val) => { if (captureLt) captureLt(col, val); return Promise.resolve(selectResult); },
+              // the OLD broken comparison — present only so a regression that re-introduces it is caught
+              neq: (col, val) => { if (captureNeq) captureNeq(col, val); return Promise.resolve(selectResult); },
+            }),
+          }),
+        };
+      }
+      // UPDATE chain (and anything else) — inert success
+      return { update: () => ({ eq: () => ({ eq: () => Promise.resolve({ error: null }) }) }), insert: () => Promise.resolve({ error: null }) };
+    }),
+  };
+  const worker = new StageExecutionWorker({ supabase, logger, staleLockThresholdMs: STALE_MS });
+  return { worker, logger, supabase };
+}
+
+describe('startup recovery — staleness-based (FR-1)', () => {
+  it('recovers a stale-locked venture on startup (resets it, no uuid cast error, no silent no-op)', async () => {
+    const stale = [{ id: 'v1', name: 'Frozen Venture', orchestrator_lock_acquired_at: new Date(Date.now() - 10 * STALE_MS).toISOString() }];
+    const { worker, logger } = makeWorker({ selectResult: { data: stale, error: null } });
+    await worker._onStartupRecovery();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Startup recovery: resetting Frozen Venture'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('1 venture(s) reset'));
+  });
+
+  it('queries by staleness cutoff (fresh locks are excluded) and NEVER the broken workerId comparison', async () => {
+    let ltCol = null, ltVal = null, neqUsed = false;
+    const { worker } = makeWorker({
+      selectResult: { data: [], error: null },
+      captureLt: (col, val) => { ltCol = col; ltVal = val; },
+      captureNeq: () => { neqUsed = true; },
+    });
+    await worker._onStartupRecovery();
+    // staleness filter: orchestrator_lock_acquired_at < cutoff (≈ now - threshold) — so a FRESH lock
+    // (acquired_at newer than the cutoff) is never returned, hence never reset.
+    expect(ltCol).toBe('orchestrator_lock_acquired_at');
+    const cutoffMs = new Date(ltVal).getTime();
+    expect(Date.now() - cutoffMs).toBeGreaterThanOrEqual(STALE_MS - 5_000);
+    expect(neqUsed).toBe(false); // the uuid-vs-string comparison must be gone
+  });
+
+  it('fail-loud: a recovery query error logs at ERROR and does not throw or silently swallow', async () => {
+    const { worker, logger } = makeWorker({ selectResult: { data: null, error: { message: 'DB down' } } });
+    await expect(worker._onStartupRecovery()).resolves.toBeUndefined(); // non-fatal
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Startup recovery query failed (FAIL-LOUD): DB down'));
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('query failed')); // not the old silent warn
+  });
+});


### PR DESCRIPTION
RCA + fix for the bug that froze venture-1 **twice**: the Stage Execution Worker's startup recovery silently no-ops, so a restarted worker never reclaims ventures orphaned by a dead instance.

## Confirmed root cause (verify-premise)

`_onStartupRecovery` (`lib/eva/stage-execution-worker.js`) queried `.neq('orchestrator_lock_id', this._workerId)` — but `acquireProcessingLock` writes `orchestrator_lock_id = randomUUID()` (a **UUID**) while `this._workerId = sew-${hostname}-${pid}` (a **string**). Comparing the UUID column to a non-UUID string throws a cast error, which the catch swallowed as a `warn` + return → recovery never reset anything.

## Fix

- **FR-1** — recover by **lock staleness**: `.lt('orchestrator_lock_acquired_at', cutoff)` against a `now − staleThreshold` cutoff, mirroring the **already-correct** periodic stale-lock sweep (`_releaseStaleLocks`). This resets dead-instance locks without a schema migration and never steals a live worker's fresh-heartbeat lock. The broken `.neq(orchestrator_lock_id, workerId)` comparison is removed.
- **FR-2** — a recovery-query error now **fails loud** (`log.error` + a `startup_recovery_query_failed` event) instead of the silent `warn` + return that *masked* the cast bug. (The swallow was the meta-cause.)
- **FR-3** — `tests/unit/eva/stage-worker-startup-recovery.test.js` (3: recovers a stale lock / queries by staleness-cutoff-not-workerId / fail-loud) + updated the in-file `_onStartupRecovery` block (3) to the new behavior.

## Verify-premise note

The SD offered option-(a): make `orchestrator_lock_id` a **TEXT column** — a destructive schema migration. Grounding the code showed a *correct staleness-based sweep already exists in the same file*, so the fix just aligns startup recovery to that proven pattern — **no migration**, lower blast radius.

## Tests

testing-agent verdict **PASS** (evidence `45c337f0`): the 3 dedicated + 3 in-file `_onStartupRecovery` tests pass; **0 new failures**. The 7 reds in `stage-execution-worker.test.js` are the pre-existing autonomy-mock debt (UNIT-TEST-DEBT-TRIAGE-002), unrelated to this change. `_releaseStaleLocks` (and its quarantined resilience test) untouched.

## Deferred (relayed to coordinator)

The SD's worker-death **crash-resilience watchdog / supervised-restart** FR is a separate larger reliability feature — deferred to a follow-up child. FR-1/FR-2 close the confirmed froze-twice recovery bug. Also noted: the sweep + recovery should share a helper (deferred only because an existing resilience test asserts the sweep's exact message).

SD: SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001 (campaign-mode, gold-origin from the venture-1 first-run hunt; infrastructure, backend `lib/eva` only — no client surface, no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
