### PR TITLE
fix(SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001): S16 financial correctness — trough runway + symbolic cross-checks + bottom-up capital

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-STAGE-WORKER-RELIABILITY-001",
-  "createdAt": "2026-06-26T13:24:35.201Z",
+  "sdKey": "SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001",
+  "createdAt": "2026-06-26T14:03:57.405Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -197,10 +197,34 @@ Output ONLY valid JSON.`;
   // Compute derived fields (these live in computeDerived but that path is dead code when analysisStep exists)
   const total_projected_revenue = revenue_projections.reduce((sum, rp) => sum + rp.revenue, 0);
   const total_projected_costs = revenue_projections.reduce((sum, rp) => sum + rp.costs, 0);
+  const net_total = total_projected_revenue - total_projected_costs;
   const burn_rate = monthly_burn_rate;
-  const runway_months = burn_rate > 0
-    ? Math.round((initial_capital / burn_rate) * 100) / 100
-    : initial_capital > 0 ? Infinity : 0;
+
+  // Running cash balance — computed BEFORE runway because runway is derived from this trough (FR-1).
+  // SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001 also tracks the deepest trough for bottom-up capital sizing (FR-3).
+  let runningBalance = initial_capital;
+  let minRunningBalance = initial_capital;
+  const cash_balance_end = revenue_projections.map(rp => {
+    runningBalance += (rp.revenue - rp.costs);
+    if (runningBalance < minRunningBalance) minRunningBalance = runningBalance;
+    return { month: rp.month, balance: Math.round(runningBalance * 100) / 100 };
+  });
+  const negativeMonth = cash_balance_end.find(cb => cb.balance < 0);
+
+  // FR-1: runway from the cash-balance TROUGH, not the flat initial_capital/monthly_burn_rate (which
+  // ignored revenue AND the growing burn). Runway = the count of leading months whose running cash
+  // balance stays >= 0 (i.e. months you can operate before insolvency). If the balance never goes
+  // negative, runway >= the projection length — Infinity only when net burn over the period is non-negative.
+  let runway_months;
+  if (revenue_projections.length === 0) {
+    runway_months = burn_rate > 0 ? Math.round((initial_capital / burn_rate) * 100) / 100 : (initial_capital > 0 ? Infinity : 0);
+  } else if (negativeMonth) {
+    let positiveMonths = 0;
+    for (const cb of cash_balance_end) { if (cb.balance >= 0) positiveMonths++; else break; }
+    runway_months = positiveMonths;
+  } else {
+    runway_months = net_total >= 0 ? Infinity : revenue_projections.length;
+  }
 
   // Break-even month
   let cumulative = -initial_capital;
@@ -222,14 +246,42 @@ Output ONLY valid JSON.`;
       : 0,
   };
 
-  // Running cash balance
-  let runningBalance = initial_capital;
-  const cash_balance_end = revenue_projections.map(rp => {
-    runningBalance += (rp.revenue - rp.costs);
-    return { month: rp.month, balance: Math.round(runningBalance * 100) / 100 };
-  });
+  // FR-3: bottom-up capital sizing. The capital needed to keep the running balance >= 0 across the
+  // projection covers the deepest cumulative deficit: required = initial_capital - min(trough) when the
+  // trough dipped below 0. DERIVED + surfaced — NOT silently overwriting the LLM's initial_capital.
+  const recommended_initial_capital = minRunningBalance < 0
+    ? Math.round((initial_capital - minRunningBalance) * 100) / 100
+    : initial_capital;
+  const UNDERCAP_RATIO = 0.9;
+  const under_capitalized = recommended_initial_capital > 0 && initial_capital < recommended_initial_capital * UNDERCAP_RATIO;
 
-  // Viability warnings
+  // FR-2: deterministic symbolic cross-checks — REJECT + flag (never silently auto-correct a mismatch).
+  const COST_SUM_ABS_TOL = 1;       // currency rounding tolerance
+  const COST_SUM_REL_TOL = 0.01;    // 1% relative tolerance
+  const validation_errors = [];
+  for (const rp of revenue_projections) {
+    if (rp.cost_breakdown && typeof rp.cost_breakdown === 'object') {
+      const cb = rp.cost_breakdown;
+      const sum = (cb.personnel || 0) + (cb.infrastructure || 0) + (cb.marketing || 0) + (cb.other || 0);
+      const tol = COST_SUM_ABS_TOL + Math.abs(rp.costs) * COST_SUM_REL_TOL;
+      if (Math.abs(sum - rp.costs) > tol) {
+        validation_errors.push(`Month ${rp.month}: cost_breakdown components sum to ${Math.round(sum)} but costs=${Math.round(rp.costs)} (must reconcile)`);
+      }
+    }
+  }
+  if (Math.round(pnl.netIncome) !== Math.round(pnl.grossRevenue - pnl.totalCosts)) {
+    validation_errors.push(`P&L identity broken: netIncome ${pnl.netIncome} != grossRevenue - totalCosts (${pnl.grossRevenue - pnl.totalCosts})`);
+  }
+  if (cash_balance_end.length > 0) {
+    const expectedLast = Math.round((initial_capital + net_total) * 100) / 100;
+    const actualLast = cash_balance_end[cash_balance_end.length - 1].balance;
+    if (Math.abs(actualLast - expectedLast) > COST_SUM_ABS_TOL) {
+      validation_errors.push(`Cash identity broken: ending balance ${actualLast} != initial_capital + net (${expectedLast})`);
+    }
+  }
+  const financials_valid = validation_errors.length === 0;
+
+  // Viability warnings (re-derived against the corrected runway + the new rigor signals)
   const viability_warnings = [];
   let consecutiveLoss = 0;
   for (const rp of revenue_projections) {
@@ -249,9 +301,14 @@ Output ONLY valid JSON.`;
   if (break_even_month === null && revenue_projections.length > 0) {
     viability_warnings.push(`No break-even within ${revenue_projections.length}-month projection period`);
   }
-  const negativeMonth = cash_balance_end.find(cb => cb.balance < 0);
   if (negativeMonth) {
     viability_warnings.push(`Cash balance goes negative in month ${negativeMonth.month}`);
+  }
+  if (under_capitalized) {
+    viability_warnings.push(`Under-capitalized: initial_capital ${initial_capital} is below the bottom-up recommended ${recommended_initial_capital} needed to fund the cash trough`);
+  }
+  if (!financials_valid) {
+    viability_warnings.push(`Financial cross-check FAILED (${validation_errors.length} error(s)) — financials are not internally consistent`);
   }
 
   // Evaluate Phase 4→5 Promotion Gate
@@ -275,6 +332,11 @@ Output ONLY valid JSON.`;
     break_even_month,
     pnl,
     cash_balance_end,
+    // SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001 (FR-3): rigor signals the deferred evidence-gate child consumes.
+    recommended_initial_capital,
+    under_capitalized,
+    validation_errors,
+    financials_valid,
     viability_warnings,
     promotion_gate,
     llmFallbackCount,

--- a/tests/unit/eva/stage16-financial-rigor.test.js
+++ b/tests/unit/eva/stage16-financial-rigor.test.js
@@ -1,0 +1,103 @@
+/**
+ * SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001 (FR-3 objective correctness) — the EVA S16 producer.
+ *
+ * RCA: runway_months = initial_capital / monthly_burn_rate (flat month-1 burn, ignoring revenue + the
+ * growing burn); cost breakdowns never validated to sum to costs; capital taken verbatim from the LLM.
+ * This locks: trough-based runway, deterministic symbolic cross-checks (validation_errors +
+ * financials_valid), and bottom-up recommended_initial_capital + under-capitalization warning.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ fin: {} }));
+vi.mock('../../../lib/llm/client-factory.js', () => ({
+  getLLMClient: () => ({ complete: async () => ({ content: JSON.stringify(h.fin) }) }),
+}));
+
+import { analyzeStage16 } from '../../../lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const stage1 = { description: 'A SaaS venture', targetMarket: 'SMBs', problemStatement: 'manual ops' };
+
+function runWith(fin) {
+  h.fin = fin;
+  return analyzeStage16({ stage1Data: stage1, stage13Data: {}, stage14Data: {}, stage15Data: {}, ventureName: 'T', logger: silent });
+}
+
+const cb = (total) => ({ personnel: total * 0.6, infrastructure: total * 0.2, marketing: total * 0.1, other: total * 0.1 });
+
+describe('FR-1 runway is trough-based, not the flat month-1 burn', () => {
+  it('runway reflects the cash-balance trough (growing burn) — shorter than initial_capital/burn_rate', async () => {
+    // initial 50000, flat burn 8000 -> flat runway would be 6.25. Growing costs drive cash negative in month 3.
+    const fin = {
+      initial_capital: 50000,
+      monthly_burn_rate: 8000,
+      revenue_projections: [
+        { month: 1, revenue: 1000, costs: 15000, cost_breakdown: cb(15000) }, // bal 36000
+        { month: 2, revenue: 1500, costs: 18000, cost_breakdown: cb(18000) }, // bal 19500
+        { month: 3, revenue: 2000, costs: 22000, cost_breakdown: cb(22000) }, // bal -500 -> negative
+        { month: 4, revenue: 2500, costs: 24000, cost_breakdown: cb(24000) },
+      ],
+    };
+    const r = await runWith(fin);
+    expect(r.runway_months).toBe(2); // two months of non-negative cash before insolvency
+    expect(r.runway_months).toBeLessThan(50000 / 8000); // strictly shorter than the old flat calc (6.25)
+  });
+});
+
+describe('FR-2 symbolic cross-checks reject + flag inconsistent financials', () => {
+  it('a cost_breakdown that does not sum to costs records a validation_error + financials_valid=false', async () => {
+    const fin = {
+      initial_capital: 100000, monthly_burn_rate: 5000,
+      revenue_projections: [
+        { month: 1, revenue: 4000, costs: 15000, cost_breakdown: { personnel: 5000, infrastructure: 2000, marketing: 1000, other: 1000 } }, // sums to 9000 != 15000
+      ],
+    };
+    const r = await runWith(fin);
+    expect(r.financials_valid).toBe(false);
+    expect(r.validation_errors.length).toBeGreaterThan(0);
+    expect(r.validation_errors[0]).toMatch(/cost_breakdown/i);
+  });
+
+  it('a reconciling breakdown yields financials_valid=true and no validation_errors', async () => {
+    const fin = {
+      initial_capital: 100000, monthly_burn_rate: 5000,
+      revenue_projections: [
+        { month: 1, revenue: 4000, costs: 15000, cost_breakdown: cb(15000) },
+        { month: 2, revenue: 6000, costs: 14000, cost_breakdown: cb(14000) },
+      ],
+    };
+    const r = await runWith(fin);
+    expect(r.financials_valid).toBe(true);
+    expect(r.validation_errors).toEqual([]);
+  });
+});
+
+describe('FR-3 capital is sized bottom-up with an under-capitalization warning', () => {
+  it('recommended_initial_capital covers the cash trough; an LLM capital below it warns', async () => {
+    // initial 10000 but the cumulative deficit needs far more -> under-capitalized.
+    const fin = {
+      initial_capital: 10000, monthly_burn_rate: 9000,
+      revenue_projections: [
+        { month: 1, revenue: 500, costs: 12000, cost_breakdown: cb(12000) }, // bal -1500
+        { month: 2, revenue: 800, costs: 13000, cost_breakdown: cb(13000) }, // bal -13700
+        { month: 3, revenue: 1200, costs: 14000, cost_breakdown: cb(14000) }, // bal -26500 (trough)
+      ],
+    };
+    const r = await runWith(fin);
+    expect(r.recommended_initial_capital).toBeGreaterThan(r.initial_capital);
+    expect(r.under_capitalized).toBe(true);
+    expect(r.viability_warnings.some(w => /under-capitalized/i.test(w))).toBe(true);
+  });
+
+  it('an adequately capitalized venture is NOT flagged under-capitalized', async () => {
+    const fin = {
+      initial_capital: 200000, monthly_burn_rate: 8000,
+      revenue_projections: [
+        { month: 1, revenue: 5000, costs: 12000, cost_breakdown: cb(12000) },
+        { month: 2, revenue: 9000, costs: 12000, cost_breakdown: cb(12000) },
+      ],
+    };
+    const r = await runWith(fin);
+    expect(r.under_capitalized).toBe(false);
+  });
+});


### PR DESCRIPTION
Ships the parent SD's **FR-3 = objective, producer-confined financial correctness** for the EVA S16 producer. The gate-policy FRs (evidence-gate/abstention, provenance-lock + epistemic tagging) are **deferred to follow-up children** — they change how the autonomous factory decides financial GO/KILL (chairman-reserved policy), relayed to the coordinator for a possible design steer.

## Confirmed root cause (verify-premise)

`lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js` computed `runway_months = initial_capital / monthly_burn_rate` — a **flat month-1 burn** that ignored revenue and the growing burn — even though `cash_balance_end` (the running-balance trough) was *already computed*. Cost breakdowns were normalized but never validated to sum to costs, and `initial_capital` was taken verbatim from the LLM.

## Fix (objective correctness only)

- **FR-1** — runway is derived from the cash-balance **trough** (count of leading non-negative months), not the flat calc. Cash balance computed before runway.
- **FR-2** — deterministic **symbolic cross-checks** (cost_breakdown components sum to costs; P&L + cash identities) record `validation_errors[]` + set `financials_valid=false` on violation — **never silently auto-corrected** (the silent-gap-fill = disqualifying principle).
- **FR-3** — `recommended_initial_capital` sized **bottom-up** from the cumulative-net trough + an `under_capitalized` warning when the LLM capital is materially below it (surfaced + warned, **not** overwritten).
- The artifact gains `recommended_initial_capital` / `under_capitalized` / `validation_errors` / `financials_valid` (additive) — exactly the signals the **deferred evidence-gate child** will consume, so the deferral isn't a dead-end.

## Tests

`tests/unit/eva/stage16-financial-rigor.test.js` (5, via a `vi.hoisted` LLM mock: trough runway / cross-check violation+reconcile / bottom-up capital + under-cap). Existing `stage-16.test.js` (6) green — no regression. testing-agent verdict **PASS** (evidence `86198b0e`, 11/11).

## Deferred (relayed to coordinator)

The parent SD's **FR-1** (evidence-gate / abstention — wire four-buckets as a *gate input* + S16 gate fail-loud/route-to-review on 0-facts) and **FR-2** (provenance-lock + FACT/DERIVED/ESTIMATE/ASSUMPTION tagging + upstream-economics threading) change the GO/KILL gate-evaluation path — chairman-reserved territory. Follow-up children; this SD lays their foundation (the validation signals) without unilaterally changing the gate policy.

SD: SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001 (campaign-mode, gold-origin from the venture-1 first-run hunt; infrastructure, backend `lib/eva` only — no client surface, no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
