### PR TITLE
fix(SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001): constrain S13 roadmap producer to exclude EHG portfolio default capabilities

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
@@ -16,12 +16,21 @@ import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 // stage-13.js imports analyzeStage13 from this file; this file imports evaluateKillGate back.
 import { evaluateKillGate } from '../stage-13.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../config/venture-default-capabilities.js';
 
 // NOTE: MIN_MILESTONES intentionally duplicated from stage-13.js to avoid circular dependency —
 // stage-13.js imports analyzeStage13 from this file, and SYSTEM_PROMPT uses ${MIN_MILESTONES}
 // at module-level evaluation.
 const MIN_MILESTONES = 3;
 const VALID_PRIORITIES = ['now', 'next', 'later'];
+
+// Render EHG_VENTURE_DEFAULT_CAPABILITIES as inline exclusion text. Imported from config so
+// updates flow from one source. SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001.
+// Inverse of the MANDATORY_CAPABILITIES_BLOCK in stage-19-sprint-planning.js: S19 mandates
+// presence; S13 mandates absence (these are standard auto-injected at S19, not bespoke milestones).
+const EXCLUDED_CAPABILITIES_BLOCK = EHG_VENTURE_DEFAULT_CAPABILITIES
+  .map((c, i) => `  ${i + 1}. "${c.name}" (capability_id: ${c.capability_id})\n     ${c.description}`)
+  .join('\n');
 
 const SYSTEM_PROMPT = `You are EVA's Product Roadmap Engine. Generate a structured product roadmap for a venture based on analysis from prior stages.
 
@@ -54,7 +63,13 @@ Rules:
 - Dates must span at least 3 months total
 - Use upstream financial/market/competitive data to inform priority
 - Milestones should be concrete and actionable, not vague
-- At least 1 phase grouping the milestones`;
+- At least 1 phase grouping the milestones
+
+EXCLUDED (EHG portfolio defaults — SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001): The following capabilities are standard EHG portfolio defaults auto-injected at Stage 19 Sprint Planning. They are NOT bespoke product work and must NOT appear as roadmap milestones:
+
+${EXCLUDED_CAPABILITIES_BLOCK}
+
+  Do NOT list any of the above as roadmap milestones. Focus milestones on venture-specific build priorities only.`;
 
 /**
  * Generate a product roadmap from upstream stage data.
@@ -114,7 +129,7 @@ Output ONLY valid JSON.`;
   }
 
   // Normalize milestones
-  const milestones = parsed.milestones.map((m, i) => ({
+  const normalizedMilestones = parsed.milestones.map((m, i) => ({
     name: String(m.name || `Milestone ${i + 1}`).substring(0, 200),
     date: String(m.date || ''),
     deliverables: Array.isArray(m.deliverables) && m.deliverables.length > 0
@@ -123,6 +138,18 @@ Output ONLY valid JSON.`;
     dependencies: Array.isArray(m.dependencies) ? m.dependencies.map(d => String(d)) : [],
     priority: VALID_PRIORITIES.includes(m.priority) ? m.priority : 'later',
   }));
+
+  // Belt-and-suspenders: strip any milestone that matches an EHG portfolio default
+  // capability (they are auto-injected at S19 and must not appear as bespoke milestones).
+  // SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001
+  const stripped = excludeDefaultCapabilityMilestones(normalizedMilestones);
+  if (stripped.length < normalizedMilestones.length) {
+    logger.warn('[Stage13] Stripped default-capability milestones from roadmap', {
+      count: normalizedMilestones.length - stripped.length,
+      ventureName,
+    });
+  }
+  const milestones = stripped;
 
   // Normalize phases
   const phases = Array.isArray(parsed.phases) && parsed.phases.length > 0
@@ -187,4 +214,43 @@ Output ONLY valid JSON.`;
 }
 
 
-export { MIN_MILESTONES, VALID_PRIORITIES };
+/**
+ * Return true if the milestone matches an EHG portfolio default capability.
+ * Uses the same permissive case-insensitive matching as isCapabilityPresent in
+ * validate-venture-default-capabilities.js, applied in the inverse direction.
+ *
+ * @param {Object} milestone - Normalized milestone object with .name
+ * @returns {boolean}
+ */
+function isDefaultCapabilityMilestone(milestone) {
+  const title = String(milestone.name || '').toLowerCase();
+  if (!title) return false;
+  for (const cap of EHG_VENTURE_DEFAULT_CAPABILITIES) {
+    const nameLower = String(cap.name || '').toLowerCase();
+    const idLower = String(cap.capability_id || '').toLowerCase();
+    const idNoHyphens = idLower.replace(/-/g, ' ');
+    if (
+      title.startsWith(nameLower) ||
+      title.includes(idLower) ||
+      title.includes(idNoHyphens) ||
+      nameLower.split(' ').slice(-2).every(w => title.includes(w))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Filter out any milestones that match EHG_VENTURE_DEFAULT_CAPABILITIES entries.
+ * These are auto-injected at Stage 19 and should not appear as bespoke roadmap milestones.
+ *
+ * @param {Array} milestones - Normalized milestone array
+ * @returns {Array} Milestones with default-capability entries removed
+ */
+export function excludeDefaultCapabilityMilestones(milestones) {
+  if (!Array.isArray(milestones)) return milestones;
+  return milestones.filter(m => !isDefaultCapabilityMilestone(m));
+}
+
+export { MIN_MILESTONES, VALID_PRIORITIES, EXCLUDED_CAPABILITIES_BLOCK };

--- a/tests/unit/eva/stage-13-roadmap-default-capabilities.test.js
+++ b/tests/unit/eva/stage-13-roadmap-default-capabilities.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../../lib/eva/config/venture-default-capabilities.js';
+
+const STAGE_13_PATH = resolve(
+  process.cwd(),
+  'lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js'
+);
+
+const stage13Source = readFileSync(STAGE_13_PATH, 'utf8');
+
+describe('Stage 13 — default-capabilities exclusion (SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001)', () => {
+  describe('Source structure', () => {
+    it('imports EHG_VENTURE_DEFAULT_CAPABILITIES from config (no string-literal duplication)', () => {
+      expect(stage13Source).toMatch(
+        /import\s*\{\s*EHG_VENTURE_DEFAULT_CAPABILITIES\s*\}\s*from\s*['"][^'"]*venture-default-capabilities/
+      );
+    });
+
+    it('SYSTEM_PROMPT contains the EXCLUDED constraint header', () => {
+      expect(stage13Source).toMatch(
+        /EXCLUDED \(EHG portfolio defaults/
+      );
+    });
+
+    it('SYSTEM_PROMPT references SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001', () => {
+      expect(stage13Source).toContain('SD-LEO-INFRA-S13-ROADMAP-DEFAULT-CAPABILITIES-CONSTRAINT-001');
+    });
+
+    it('renders all capability names and IDs into EXCLUDED_CAPABILITIES_BLOCK', () => {
+      // Load the module and verify the rendered block contains each capability
+      return import('../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js')
+        .then(({ EXCLUDED_CAPABILITIES_BLOCK }) => {
+          for (const cap of EHG_VENTURE_DEFAULT_CAPABILITIES) {
+            expect(EXCLUDED_CAPABILITIES_BLOCK).toContain(cap.name);
+            expect(EXCLUDED_CAPABILITIES_BLOCK).toContain(cap.capability_id);
+          }
+        });
+    });
+  });
+
+  describe('excludeDefaultCapabilityMilestones()', () => {
+    it('strips a milestone whose name matches the feedback-widget capability name (TS-1)', async () => {
+      const { excludeDefaultCapabilityMilestones } = await import(
+        '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js'
+      );
+      const feedbackCap = EHG_VENTURE_DEFAULT_CAPABILITIES.find(
+        c => c.capability_id === 'feedback-widget'
+      );
+      const milestones = [
+        { name: feedbackCap.name, date: '2026-07-01', deliverables: ['widget'], dependencies: [], priority: 'now' },
+        { name: 'Build AI market-modeling engine', date: '2026-08-01', deliverables: ['engine'], dependencies: [], priority: 'next' },
+      ];
+      const result = excludeDefaultCapabilityMilestones(milestones);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Build AI market-modeling engine');
+    });
+
+    it('strips a milestone whose name matches the error-capture capability name (TS-2)', async () => {
+      const { excludeDefaultCapabilityMilestones } = await import(
+        '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js'
+      );
+      const errorCap = EHG_VENTURE_DEFAULT_CAPABILITIES.find(
+        c => c.capability_id === 'error-capture-middleware'
+      );
+      const milestones = [
+        { name: errorCap.name, date: '2026-07-01', deliverables: ['middleware'], dependencies: [], priority: 'now' },
+        { name: 'Integrate Stripe billing', date: '2026-08-01', deliverables: ['billing'], dependencies: [], priority: 'next' },
+      ];
+      const result = excludeDefaultCapabilityMilestones(milestones);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Integrate Stripe billing');
+    });
+
+    it('preserves bespoke milestones with unrelated names (TS-3)', async () => {
+      const { excludeDefaultCapabilityMilestones } = await import(
+        '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js'
+      );
+      const milestones = [
+        { name: 'Launch MVP', date: '2026-07-01', deliverables: ['mvp'], dependencies: [], priority: 'now' },
+        { name: 'Integrate Stripe billing', date: '2026-08-01', deliverables: ['billing'], dependencies: [], priority: 'next' },
+        { name: 'Build AI market-modeling engine', date: '2026-09-01', deliverables: ['engine'], dependencies: [], priority: 'later' },
+      ];
+      const result = excludeDefaultCapabilityMilestones(milestones);
+      expect(result).toHaveLength(3);
+    });
+
+    it('strips milestone matching capability_id substring (TS-1 variant)', async () => {
+      const { excludeDefaultCapabilityMilestones } = await import(
+        '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js'
+      );
+      const milestones = [
+        { name: 'feedback-widget integration', date: '2026-07-01', deliverables: ['x'], dependencies: [], priority: 'now' },
+        { name: 'Unrelated milestone', date: '2026-08-01', deliverables: ['y'], dependencies: [], priority: 'next' },
+      ];
+      const result = excludeDefaultCapabilityMilestones(milestones);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Unrelated milestone');
+    });
+
+    it('handles empty milestones array gracefully', async () => {
+      const { excludeDefaultCapabilityMilestones } = await import(
+        '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js'
+      );
+      expect(excludeDefaultCapabilityMilestones([])).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The S13 roadmap LLM had no awareness of `EHG_VENTURE_DEFAULT_CAPABILITIES`, causing it to list `feedback-widget` and `error-capture-middleware` as bespoke roadmap milestones — duplicating capabilities auto-injected at S19 Sprint Planning
- Added `EXCLUDED_CAPABILITIES_BLOCK` (mirrors S19's `MANDATORY_CAPABILITIES_BLOCK` pattern in the inverse direction) injected into the S13 `SYSTEM_PROMPT`
- Added `excludeDefaultCapabilityMilestones()` post-parse filter that strips milestones matching any default capability by ID or name prefix
- 9 new unit tests; 6 pre-existing S13 tests unchanged

## Test plan

- [x] `npm run test -- tests/unit/eva/stage-13-roadmap-default-capabilities.test.js` — 9 tests pass
- [x] `npm run test -- tests/unit/eva/stage-templates/stage-13.test.js` — 6 tests pass (no regressions)
- [x] Source file imports `EHG_VENTURE_DEFAULT_CAPABILITIES` from config (no hardcoded strings)
- [x] `SYSTEM_PROMPT` contains `EXCLUDED` constraint block listing `feedback-widget` and `error-capture-middleware`
- [x] `excludeDefaultCapabilityMilestones()` exported for testing and future reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)