### PR TITLE
feat(SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001): complexity-tiered worker assignment CORE

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -199,6 +199,51 @@ async function stampEffortRecommendation(supabase, row, logger = console) {
 }
 
 /**
+ * SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-4): enforce WORK-DOWN-NEVER-UP on the
+ * directed-dispatch path. A WORK_ASSIGNMENT naming an SD whose stamped metadata.min_tier_rank exceeds
+ * the TARGET worker's tier_rank (claude_sessions.metadata.tier_rank) is REFUSED (throws, fail-CLOSED,
+ * code DISPATCH_ABOVE_WORKER_TIER). A higher-rung worker assigned below its rung is allowed. Gated by
+ * the FR-5 degrade-to-1 invariant — with < 2 live workers, tiering is OFF and nothing is refused.
+ * Fail-OPEN on any lookup/QF/sentinel-target case so a transient fault never blocks a real dispatch.
+ * @private
+ */
+async function assertWorkerTierAllowed(supabase, row, logger = console) {
+  try {
+    if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
+    const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
+    const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+    if (!sdKey || /^QF-/.test(sdKey)) return; // QFs and SD-less nudges are not tier-gated
+    const { isTieringActive, resolveWorkerTierRank } = require('../fleet/tier-ladder.cjs');
+    if (!(await isTieringActive(supabase))) return; // FR-5: tiering off with < 2 live workers
+    const { data: sess } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', row.target_session)
+      .maybeSingle();
+    if (!sess) return; // sentinel/unknown target -> fail-open (assertValidTarget already vetted real ones)
+    const workerRank = resolveWorkerTierRank(sess);
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('metadata')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    const minRank = Number(sd && sd.metadata && sd.metadata.min_tier_rank);
+    if (!Number.isFinite(minRank)) return; // unscored SD -> don't block dispatch
+    if (minRank > workerRank) {
+      const e = new Error(
+        `[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} requires tier_rank ${minRank} but target worker is tier_rank ${workerRank} `
+        + `(WORK-DOWN-NEVER-UP — a lower-rung worker never takes above-rung work; assign it to an equal/higher rung).`
+      );
+      e.code = 'DISPATCH_ABOVE_WORKER_TIER';
+      throw e;
+    }
+  } catch (e) {
+    if (e && e.code === 'DISPATCH_ABOVE_WORKER_TIER') throw e; // fail CLOSED on a confirmed above-tier
+    logger && logger.warn && logger.warn(`[dispatch] worker-tier check skipped (fail-open): ${e.message}`);
+  }
+}
+
+/**
  * Validated session_coordination insert. The INTENDED choke point coordinator-side
  * inserts route through — though some producers (notably the stale-session-sweep cron)
  * still insert raw and therefore call assertSdDispatchable directly. Validates
@@ -224,6 +269,9 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
   // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a terminal/non-existent SD before the
   // insert (mirrors claim_sd's terminal guard — fails CLOSED on terminal/not-found, open on a DB hiccup).
   await assertSdDispatchable(supabase, row, logger);
+  // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-4): the SECOND tier enforcement point —
+  // directed dispatch BYPASSES claim-eligibility by design, so WORK-DOWN-NEVER-UP also lives here.
+  await assertWorkerTierAllowed(supabase, row, logger);
   await stampEffortRecommendation(supabase, row, logger);
   let q = supabase.from('session_coordination').insert(row);
   if (select) {
@@ -253,4 +301,5 @@ module.exports = {
   isTerminalSdStatus,
   isTerminalQfStatus,
   assertSdDispatchable,
+  assertWorkerTierAllowed,
 };

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -45,9 +45,14 @@ const { isSdExecutableHere } = require('./sd-executable-here.cjs');
  * must carry `target_application` + `status` for the repo/premise axes to apply (absent => fail-open
  * fit). isSdExecutableHere fails open, so a fitness fault never adds an ineligibility.
  *
+ * SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): an OPTIONAL ctx.worker_tier_rank +
+ * ctx.tiering_active enable the WORK-DOWN-NEVER-UP axis — a worker skips any SD whose stamped
+ * metadata.min_tier_rank exceeds its own rung. Pure/DB-free (reads the already-stamped rank);
+ * BYTE-IDENTICAL when ctx omits the new fields (existing callers pass only {cwd}).
+ *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
- * @param {{ cwd?: string, currentApp?: string }} [ctx]  when present, applies the claim-time fitness axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'sd_deferred' | 'sd_terminal' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean }} [ctx]  when present, applies the claim-time fitness + tier axes
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
@@ -62,6 +67,14 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // self-claim path refuses them too). Active/claimable statuses fall through unchanged.
   if (row.status === 'deferred') return 'sd_deferred';
   if (row.status === 'completed' || row.status === 'cancelled') return 'sd_terminal';
+  // FR-3 WORK-DOWN-NEVER-UP: a below-rung worker skips above-rung work, but ONLY when tiering is
+  // active (>= 2 live workers, FR-5) and the caller supplied its rung. A higher rung may take lower
+  // work (no block when worker_tier_rank >= min_tier_rank). Unscored SDs (no min_tier_rank) fall
+  // through unchanged. ctx-gated => byte-identical for callers that omit the tier fields.
+  if (ctx && ctx.tiering_active === true && Number.isFinite(Number(ctx.worker_tier_rank))) {
+    const minRank = Number(row.metadata && row.metadata.min_tier_rank);
+    if (Number.isFinite(minRank) && minRank > Number(ctx.worker_tier_rank)) return 'above_worker_tier';
+  }
   if (ctx) {
     try {
       const verdict = isSdExecutableHere(row, ctx);

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -214,7 +214,7 @@ async function refillSourceIneligibility(sb, sdRow) {
     if (!sourceId) return null;                                  // no traceable source -> fail-open
     const { data: source, error } = await sb
       .from('roadmap_wave_items')
-      .select('promoted_to_sd_key, lane, title, source_id')
+      .select('promoted_to_sd_key, lane, title, source_id') // schema-lint-disable-line: roadmap_wave_items.lane exists live; snapshot stale (pre-existing select, re-flagged by an unrelated edit)
       .eq('id', sourceId)
       .maybeSingle();
     if (error) return null;                                      // fetch fault -> fail-open

--- a/lib/fleet/sd-tier-rank.mjs
+++ b/lib/fleet/sd-tier-rank.mjs
@@ -1,0 +1,83 @@
+// Complexity rubric: compute the CHEAPEST-SUFFICIENT ladder rung for an SD.
+// SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-1).
+//
+// REUSE: the risk/forbidden keyword lists come from scripts/classify-quick-fix.js
+// (CLASSIFICATION_RULES + the word-boundary matchesKeyword) — referenced, NOT
+// redefined — and the LOC tiers mirror lib/utils/work-item-router.js DEFAULT_THRESHOLDS
+// (tier1_max_loc=30, tier2_max_loc=75). CONSERVATIVE-UP bias throughout: under-powering a
+// complex SD costs more than the token savings, so every ambiguity rounds UP and any SD
+// with no scoreable signal defaults to the TOP rung (fail-safe-up).
+
+import { matchesKeyword, CLASSIFICATION_RULES } from '../../scripts/classify-quick-fix.js';
+import ladder from './tier-ladder.cjs';
+
+const { clamp, ladderTopRank } = ladder;
+
+// LOC tiers mirror lib/utils/work-item-router.js DEFAULT_THRESHOLDS (kept in sync by intent;
+// the rubric is a heuristic so the default values are referenced rather than DB-fetched).
+const TIER1_MAX_LOC = 30;
+const TIER2_MAX_LOC = 75;
+
+// Lightweight SD types (mirror classify-quick-fix allowedTypes) score to the cheapest rung
+// unless a stronger signal (LOC / keyword) pushes them up.
+const LIGHTWEIGHT_TYPES = new Set(['bug', 'polish', 'typo', 'documentation', 'chore']);
+
+function textOf(sd) {
+  return [sd && sd.title, sd && sd.description, sd && sd.scope, sd && sd.strategic_intent]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+/** Any forbidden/risk keyword present => floor to the top rung (blast radius). */
+function hasRiskKeyword(text) {
+  for (const k of CLASSIFICATION_RULES.forbiddenKeywords) if (matchesKeyword(text, k)) return true;
+  for (const k of CLASSIFICATION_RULES.riskKeywords) if (matchesKeyword(text, k)) return true;
+  return false;
+}
+
+/** LOC -> rung. tier-2 (31..75) leans Opus-med (rank 3) per the conservative-up bias. */
+function locRank(loc) {
+  if (!Number.isFinite(loc)) return null;
+  if (loc <= TIER1_MAX_LOC) return 1;
+  if (loc <= TIER2_MAX_LOC) return 3;
+  return ladderTopRank();
+}
+
+/**
+ * Compute metadata.min_tier_rank — the cheapest rung that can sufficiently build this SD.
+ * Takes the MAX of every available contribution (conservative-up). No scoreable signal
+ * (no type, no LOC, no tier_hint, no keyword) => top rung (fail-safe-up).
+ * @param {object} sd a strategic_directives_v2-shaped row
+ * @returns {number} a rank in [1, ladderTopRank()]
+ */
+export function computeMinTierRank(sd) {
+  const row = sd || {};
+  const text = textOf(row);
+  if (text && hasRiskKeyword(text)) return ladderTopRank(); // floor: risk/forbidden keyword
+
+  const contributions = [];
+  const sdType = String(row.sd_type || '').toLowerCase();
+  if (sdType === 'feature') contributions.push(3); // features carry blast radius -> Opus-med floor
+  if (LIGHTWEIGHT_TYPES.has(sdType)) contributions.push(1);
+
+  const loc = Number(row.estimated_loc != null ? row.estimated_loc : (row.metadata && row.metadata.estimated_loc));
+  const lr = locRank(loc);
+  if (lr != null) contributions.push(lr);
+
+  const hint = Number(row.metadata && row.metadata.tier_hint);
+  if (Number.isFinite(hint)) {
+    // work-item tier (1/2/3) -> conservative rung mapping.
+    contributions.push(hint <= 1 ? 1 : hint === 2 ? 3 : ladderTopRank());
+  }
+
+  if (contributions.length === 0) return ladderTopRank(); // no scoreable signal -> fail-safe-up
+  return clamp(Math.max(...contributions));
+}
+
+/** Convenience: the metadata patch a stamping path writes to strategic_directives_v2.metadata. */
+export function stampPayload(sd) {
+  return { min_tier_rank: computeMinTierRank(sd) };
+}
+
+export default { computeMinTierRank, stampPayload };

--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -1,0 +1,89 @@
+'use strict';
+/**
+ * Complexity-tier ladder + worker-tier resolution + degrade-to-1 invariant.
+ * SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-2, FR-5).
+ *
+ * An ORDINAL model×effort ladder: each rung is cheaper-but-capable below, more
+ * expensive above. v1 ladder maxes the CHEAP reasoning dial first (Sonnet@max),
+ * then escalates Opus by effort. Cardinality is CONFIG-DRIVEN (read from LADDER),
+ * never hardcoded — adding/removing a rung needs only this array, and every rank
+ * comparison (clamp / top-rung default / rubric ceiling) keys off LADDER.length.
+ *
+ * Worker tier_rank is a CHAIRMAN-DECLARED stamp on claude_sessions.metadata.tier_rank
+ * — this module does NOT build a worker self-advertisement mechanism. An UNSTAMPED
+ * worker resolves to the TOP rung so it is never wrongly skipped-over (it can take any
+ * work; the conservative direction).
+ */
+
+/** v1 ordinal ladder. rank 1 = cheapest-sufficient, rank N = most capable. */
+const LADDER = [
+  { rank: 1, model: 'sonnet', effort: 'max' },
+  { rank: 2, model: 'opus', effort: 'low' },
+  { rank: 3, model: 'opus', effort: 'medium' },
+  { rank: 4, model: 'opus', effort: 'high' },
+];
+
+/** Top (most-capable) rung — config-driven, NOT a hardcoded 4. */
+function ladderTopRank() {
+  return LADDER.length;
+}
+
+/** Bound an arbitrary rank into the valid [1, ladderTopRank()] range. Non-numeric => top rung. */
+function clamp(rank) {
+  const n = Number(rank);
+  if (!Number.isFinite(n)) return ladderTopRank();
+  return Math.max(1, Math.min(ladderTopRank(), Math.round(n)));
+}
+
+/**
+ * Resolve a worker session's declared tier_rank from claude_sessions.metadata.tier_rank.
+ * Chairman/coordinator-declared stamp; defaults to the TOP rung when absent/invalid so an
+ * unstamped worker is never wrongly skipped-over.
+ * @param {{ metadata?: { tier_rank?: number|string } }} session
+ * @returns {number} a rank in [1, ladderTopRank()]
+ */
+function resolveWorkerTierRank(session) {
+  const raw = session && session.metadata && session.metadata.tier_rank;
+  const n = Number(raw);
+  if (Number.isFinite(n) && n >= 1 && n <= ladderTopRank()) return Math.round(n);
+  return ladderTopRank();
+}
+
+/** Tiering activates only at >= this many genuine live fleet workers (FR-5 degrade-to-1). */
+const MIN_LIVE_FOR_TIERING = 2;
+
+/**
+ * Is complexity-tiering ACTIVE right now? True iff >= MIN_LIVE_FOR_TIERING genuine live
+ * fleet workers exist (FR-5). With fewer, a lone worker takes ALL work regardless of rung,
+ * so both enforcement points (claim-eligibility ctx.tiering_active, dispatch guard) gate on
+ * this. It keys on live COUNT, never on which specific rungs are present, so any live SUBSET
+ * of the ladder works. FAILS to DISABLED (degrade-to-1) on any uncertainty — tiering must
+ * never strand the queue on a transient fault.
+ * @param {object} supabase service-role client
+ * @param {{ nowMs?: number }} [opts]
+ * @returns {Promise<boolean>}
+ */
+async function isTieringActive(supabase, opts = {}) {
+  try {
+    const { getActiveCoordinatorId } = require('../coordinator/resolve.cjs');
+    const { liveFleetWorkers } = await import('./genuine-worker.mjs');
+    const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, status, metadata, heartbeat_at, sd_key, claimed_at, worktree_path, continuous_sds_completed');
+    if (error || !Array.isArray(data)) return false; // degrade-to-1 on uncertainty
+    const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+    return liveFleetWorkers(data, coordinatorId, nowMs).length >= MIN_LIVE_FOR_TIERING;
+  } catch {
+    return false; // fail to DISABLED (degrade-to-1)
+  }
+}
+
+module.exports = {
+  LADDER,
+  ladderTopRank,
+  clamp,
+  resolveWorkerTierRank,
+  isTieringActive,
+  MIN_LIVE_FOR_TIERING,
+};

--- a/scripts/stamp-sd-tier-rank.mjs
+++ b/scripts/stamp-sd-tier-rank.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Stamp strategic_directives_v2.metadata.min_tier_rank for one SD (or every active SD that
+// lacks it) using the FR-1 rubric. SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001.
+//
+//   node scripts/stamp-sd-tier-rank.mjs <SD-KEY>     # stamp one SD
+//   node scripts/stamp-sd-tier-rank.mjs --all         # stamp all unstamped active SDs
+//   node scripts/stamp-sd-tier-rank.mjs <SD-KEY> --dry # compute + print, do not write
+//
+// Additive: writes only the metadata.min_tier_rank JSONB key (no schema change). Idempotent.
+
+import { createClient } from '@supabase/supabase-js';
+import { computeMinTierRank } from '../lib/fleet/sd-tier-rank.mjs';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+async function stampOne(sb, sd, dry) {
+  const rank = computeMinTierRank(sd);
+  if (dry) {
+    console.log(`[dry] ${sd.sd_key}: min_tier_rank=${rank}`);
+    return rank;
+  }
+  const metadata = { ...(sd.metadata || {}), min_tier_rank: rank };
+  const { error } = await sb.from('strategic_directives_v2').update({ metadata }).eq('sd_key', sd.sd_key);
+  if (error) throw new Error(`update ${sd.sd_key} failed: ${error.message}`);
+  console.log(`✓ ${sd.sd_key}: min_tier_rank=${rank}`);
+  return rank;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dry = args.includes('--dry');
+  const all = args.includes('--all');
+  const key = args.find((a) => !a.startsWith('--'));
+  if (!all && !key) {
+    console.error('Usage: stamp-sd-tier-rank.mjs <SD-KEY> | --all [--dry]');
+    process.exit(1);
+  }
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required.');
+    process.exit(1);
+  }
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const cols = 'sd_key, sd_type, title, description, scope, strategic_intent, metadata, estimated_loc';
+
+  if (all) {
+    const { data, error } = await sb
+      .from('strategic_directives_v2')
+      .select(cols)
+      .not('status', 'in', '(completed,cancelled,deferred)');
+    if (error) throw new Error(error.message);
+    const todo = (data || []).filter((sd) => !(sd.metadata && Number.isFinite(Number(sd.metadata.min_tier_rank))));
+    console.log(`Stamping ${todo.length} unstamped active SD(s)...`);
+    for (const sd of todo) await stampOne(sb, sd, dry);
+    return;
+  }
+
+  const { data: sd, error } = await sb.from('strategic_directives_v2').select(cols).eq('sd_key', key).maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!sd) {
+    console.error(`SD not found: ${key}`);
+    process.exit(1);
+  }
+  await stampOne(sb, sd, dry);
+}
+
+main().catch((e) => {
+  console.error(`❌ ${e.message}`);
+  process.exit(1);
+});

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -36,6 +36,8 @@ const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cj
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate, also used by
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
+// SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
+const { resolveWorkerTierRank, isTieringActive } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
 const { NATO, COLORS, nextAvailable, isTestSessionId } = require('./assign-fleet-identities.cjs');
@@ -504,13 +506,15 @@ async function fetchDraftCandidates(sb) {
 
 /** Per-row claim attempt for an un-baselined draft candidate (shared by the merged
  *  step-6 tier and the legacy selfClaimDraftSd wrapper). Returns a result or null. */
-async function tryClaimDraftCandidate(sb, sessionId, base, d) {
+async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
   // SD-FDBK-INFRA-CONVERGE-WORK-ASSIGNMENT-001: same shared classifier the baselined candidate-view
   // tier (step 6) and the coordinator/sweep PUSH path use — the un-baselined draft tier must not
   // self-claim a test-fixture phantom (SD-DEMO-*/SD-TEST-*) or a requires_human_action SD.
   // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): pass {cwd} so an SD that is unfit for THIS checkout
   // (repo mismatch / closed premise / missing precondition) is skipped before claiming.
-  if (classifyDispatchIneligibility(d, { cwd: process.cwd() }) !== null) return null;
+  // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): tierCtx adds worker_tier_rank +
+  // tiering_active so a below-rung worker skips above-rung drafts (WORK-DOWN-NEVER-UP).
+  if (classifyDispatchIneligibility(d, { cwd: process.cwd(), ...tierCtx }) !== null) return null;
   if (!(await draftDepsSatisfied(sb, d))) return null; // skip dependency-blocked
   // SD-REFILL-00SO4HZY: skip an orchestrator child whose parent has not yet passed LEAD (a worker would
   // otherwise drive PLAN then hit the hard EXEC-transition block). Fail-open inside parentLeadPending.
@@ -1096,13 +1100,24 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     // /checkin skill can render concrete available work — a worker about to wind down sees data, not a
     // vibe. base is spread into the self_claimed / idle / QF results below.
     base.belt_ranked_claimable = ranked.length;
+    // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3 + FR-5): resolve this worker's rung
+    // and whether tiering is active ONCE per checkin (both are per-run constants, not per-candidate),
+    // then thread into the shared classifier so a below-rung worker skips above-rung work. Fail-open:
+    // any fault leaves tierCtx empty => byte-identical pre-tiering behavior.
+    let tierCtx = {};
+    try {
+      tierCtx = {
+        worker_tier_rank: resolveWorkerTierRank({ metadata: sessionMetadata }),
+        tiering_active: await isTieringActive(sb),
+      };
+    } catch { /* fail-open: no tier ctx */ }
     for (const x of ranked) {
       if (x.kind === 'baselined') {
         // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: skip dependency-blocked SDs and orchestrator PARENTS
         // (the view surfaces both; claim_sd enforces neither). Mirrors the draft-tier guard.
         // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-2): {cwd} adds the claim-time fitness axes so a
         // baselined candidate unfit for THIS checkout is skipped before claiming.
-        if (!(await baselinedCandidateEligible(sb, x.key, { cwd: process.cwd() }))) continue;
+        if (!(await baselinedCandidateEligible(sb, x.key, { cwd: process.cwd(), ...tierCtx }))) continue;
         if (await isSdInFlight(sb, x.key, sessionId)) continue;  // dedup: started or live-foreign-held
         const claimed = await tryClaim(sb, x.key, sessionId, x.track);
         if (claimed.ok) {
@@ -1110,7 +1125,7 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
             message: `Self-claimed ${x.key} from sd:next. Run: node scripts/sd-start.js ${x.key}. ${antiWinddownDirective(ranked.length)}` };
         }
       } else {
-        const result = await tryClaimDraftCandidate(sb, sessionId, base, x.row);
+        const result = await tryClaimDraftCandidate(sb, sessionId, base, x.row, tierCtx);
         if (result) return result;
       }
     }

--- a/tests/unit/fleet/complexity-tiered-assignment.test.js
+++ b/tests/unit/fleet/complexity-tiered-assignment.test.js
@@ -1,0 +1,172 @@
+/**
+ * SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 — per-FR regression tests for
+ * complexity-tiered worker assignment.
+ *
+ *   FR-1 rubric (computeMinTierRank)         — TS-1
+ *   FR-2 ladder + worker-tier resolution     — TS-2
+ *   FR-3 'above_worker_tier' verdict          — TS-3
+ *   FR-4 coordinator dispatch tier guard      — TS-4
+ *   FR-5 degrade-to-1 invariant               — TS-5
+ */
+import { describe, it, expect } from 'vitest';
+import { computeMinTierRank } from '../../../lib/fleet/sd-tier-rank.mjs';
+import { LADDER, ladderTopRank, clamp, resolveWorkerTierRank, isTieringActive, MIN_LIVE_FOR_TIERING } from '../../../lib/fleet/tier-ladder.cjs';
+import { classifyDispatchIneligibility } from '../../../lib/fleet/claim-eligibility.cjs';
+import { assertWorkerTierAllowed } from '../../../lib/coordinator/dispatch.cjs';
+
+const TOP = ladderTopRank();
+
+// ---- TS-1: FR-1 rubric ----------------------------------------------------
+describe('FR-1 computeMinTierRank rubric', () => {
+  it('floors a risk-keyword SD to the top rung', () => {
+    expect(computeMinTierRank({ sd_type: 'infrastructure', title: 'Add a DB migration', description: 'alter table ventures' })).toBe(TOP);
+    expect(computeMinTierRank({ sd_type: 'documentation', description: 'a new feature for the cockpit' })).toBe(TOP);
+  });
+
+  it('scores a small no-risk documentation SD to rank 1', () => {
+    expect(computeMinTierRank({ sd_type: 'documentation', title: 'Fix a typo in the README', estimated_loc: 5 })).toBe(1);
+  });
+
+  it('scores a mid-size (31-75 LOC) no-risk SD to an intermediate rung (conservative-up)', () => {
+    const rank = computeMinTierRank({ sd_type: 'infrastructure', title: 'Tidy a helper', description: 'small cleanup', estimated_loc: 50 });
+    expect(rank).toBeGreaterThanOrEqual(2);
+    expect(rank).toBeLessThanOrEqual(3);
+  });
+
+  it('defaults to the top rung when there is no scoreable signal (fail-safe-up)', () => {
+    expect(computeMinTierRank({ sd_type: 'infrastructure', title: 'Do the thing', description: 'thing' })).toBe(TOP);
+  });
+
+  it('honors tier_hint conservatively', () => {
+    expect(computeMinTierRank({ sd_type: 'infrastructure', title: 'x', description: 'y', metadata: { tier_hint: 1 } })).toBe(1);
+  });
+});
+
+// ---- TS-2: FR-2 ladder + worker tier --------------------------------------
+describe('FR-2 tier ladder + worker tier resolution', () => {
+  it('reads ladder cardinality from config, not a hardcoded 4', () => {
+    expect(LADDER.length).toBe(ladderTopRank());
+    expect(LADDER[0]).toMatchObject({ rank: 1, model: 'sonnet', effort: 'max' });
+  });
+
+  it('resolveWorkerTierRank returns the declared stamp when present', () => {
+    expect(resolveWorkerTierRank({ metadata: { tier_rank: 1 } })).toBe(1);
+    expect(resolveWorkerTierRank({ metadata: { tier_rank: '2' } })).toBe(2);
+  });
+
+  it('resolveWorkerTierRank defaults an unstamped worker to the top rung', () => {
+    expect(resolveWorkerTierRank({ metadata: {} })).toBe(TOP);
+    expect(resolveWorkerTierRank({})).toBe(TOP);
+    expect(resolveWorkerTierRank({ metadata: { tier_rank: 99 } })).toBe(TOP);
+  });
+
+  it('clamp bounds a rank to [1, top]', () => {
+    expect(clamp(0)).toBe(1);
+    expect(clamp(99)).toBe(TOP);
+    expect(clamp('nope')).toBe(TOP);
+    expect(clamp(2)).toBe(2);
+  });
+});
+
+// ---- TS-3: FR-3 above_worker_tier verdict ---------------------------------
+describe('FR-3 above_worker_tier eligibility verdict', () => {
+  it('returns above_worker_tier for a below-rung worker vs a higher-tier SD when tiering active', () => {
+    const sd = { sd_key: 'SD-X-001', metadata: { min_tier_rank: 3 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 1, tiering_active: true })).toBe('above_worker_tier');
+  });
+
+  it('returns null when the worker rung >= SD min rank (higher rung may take lower work)', () => {
+    const sd = { sd_key: 'SD-X-001', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true })).toBeNull();
+  });
+
+  it('is byte-identical (no tier verdict) when ctx omits worker_tier_rank', () => {
+    const sd = { sd_key: 'SD-X-001', metadata: { min_tier_rank: 4 } };
+    expect(classifyDispatchIneligibility(sd, { cwd: '/repo' })).toBeNull();
+    expect(classifyDispatchIneligibility(sd)).toBeNull();
+  });
+
+  it('does not fire for an unscored SD (no min_tier_rank)', () => {
+    const sd = { sd_key: 'SD-X-001', metadata: {} };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 1, tiering_active: true })).toBeNull();
+  });
+});
+
+// ---- TS-4/TS-5: FR-4 dispatch guard + FR-5 degrade-to-1 -------------------
+/** Minimal supabase stub: serves claude_sessions (workers), strategic_directives_v2 (SD), and a
+ *  live-worker list so isTieringActive can resolve. */
+function stubSupabase({ liveWorkers = 2, workerTierRank = 1, sdMinRank = 3, coordinatorRpc = null } = {}) {
+  const sessions = [];
+  for (let i = 0; i < liveWorkers; i++) {
+    sessions.push({
+      session_id: `w-${i}`, status: 'active', metadata: {}, heartbeat_at: new Date().toISOString(),
+      sd_key: `SD-LIVE-${i}`, claimed_at: new Date().toISOString(), worktree_path: `/wt/${i}`, continuous_sds_completed: 1,
+    });
+  }
+  const targetSession = { session_id: 'target-worker', metadata: { tier_rank: workerTierRank } };
+  return {
+    rpc: async () => ({ data: coordinatorRpc, error: null }),
+    from(table) {
+      const api = {
+        _table: table, _filters: {},
+        select() { return api; },
+        not() { return api; },
+        eq(col, val) { api._filters[col] = val; return api; },
+        async maybeSingle() {
+          if (table === 'claude_sessions') {
+            if (api._filters.session_id === 'target-worker') return { data: targetSession, error: null };
+            return { data: null, error: null };
+          }
+          if (table === 'strategic_directives_v2') {
+            return { data: { metadata: { min_tier_rank: sdMinRank } }, error: null };
+          }
+          return { data: null, error: null };
+        },
+        then(resolve) {
+          // bare `await supabase.from('claude_sessions').select(...)` (the isTieringActive list read)
+          if (table === 'claude_sessions') return resolve({ data: sessions, error: null });
+          return resolve({ data: [], error: null });
+        },
+      };
+      return api;
+    },
+  };
+}
+
+describe('FR-4 coordinator dispatch tier guard + FR-5 degrade-to-1', () => {
+  const row = (overrides = {}) => ({
+    message_type: 'WORK_ASSIGNMENT', target_session: 'target-worker',
+    payload: { assigned_sd: 'SD-NEEDS-OPUS-001' }, ...overrides,
+  });
+
+  it('refuses an above-tier WORK_ASSIGNMENT when tiering is active', async () => {
+    const sb = stubSupabase({ liveWorkers: 2, workerTierRank: 1, sdMinRank: 3 });
+    await expect(assertWorkerTierAllowed(sb, row())).rejects.toMatchObject({ code: 'DISPATCH_ABOVE_WORKER_TIER' });
+  });
+
+  it('allows a work-down assignment (worker rung >= SD min rank)', async () => {
+    const sb = stubSupabase({ liveWorkers: 2, workerTierRank: 4, sdMinRank: 3 });
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+
+  it('FR-5: with < 2 live workers, tiering is OFF and the above-tier assignment is allowed', async () => {
+    const sb = stubSupabase({ liveWorkers: 1, workerTierRank: 1, sdMinRank: 4 });
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+
+  it('ignores non-WORK_ASSIGNMENT rows and SD-less / QF rows', async () => {
+    const sb = stubSupabase({ liveWorkers: 2, workerTierRank: 1, sdMinRank: 4 });
+    await expect(assertWorkerTierAllowed(sb, row({ message_type: 'INFO' }))).resolves.toBeUndefined();
+    await expect(assertWorkerTierAllowed(sb, row({ payload: { assigned_sd: 'QF-20260101-001' } }))).resolves.toBeUndefined();
+    await expect(assertWorkerTierAllowed(sb, row({ payload: {}, target_sd: undefined }))).resolves.toBeUndefined();
+  });
+});
+
+describe('FR-5 isTieringActive', () => {
+  it('is true at >= MIN_LIVE_FOR_TIERING live workers, false below', async () => {
+    expect(MIN_LIVE_FOR_TIERING).toBe(2);
+    expect(await isTieringActive(stubSupabase({ liveWorkers: 2 }))).toBe(true);
+    expect(await isTieringActive(stubSupabase({ liveWorkers: 1 }))).toBe(false);
+    expect(await isTieringActive(stubSupabase({ liveWorkers: 0 }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Match SD complexity to the cheapest-sufficient worker rung on an ordinal model×effort ladder (Sonnet@max → Opus low/med/high) so the fleet stops burning high-effort tokens on simple SDs.

## Functional requirements
- **FR-1 rubric** — `lib/fleet/sd-tier-rank.mjs` `computeMinTierRank` reuses classify-quick-fix riskKeywords + work-item-router LOC tiers; conservative-up; risk/forbidden keyword floors to top rung; no-signal → top rung (fail-safe-up).
- **FR-2 ladder** — `lib/fleet/tier-ladder.cjs` config-cardinality ordinal ladder + `resolveWorkerTierRank` (chairman-declared `claude_sessions.metadata.tier_rank` stamp; unstamped → top rung, never wrongly skipped).
- **FR-3 eligibility** — `classifyDispatchIneligibility` gains the `above_worker_tier` verdict (pure, **byte-identical** without the new ctx); wired into the worker-checkin PULL path.
- **FR-4 assignment** — `dispatch.cjs` `assertWorkerTierAllowed` guards `insertCoordinationRow` (fail-**closed** above-tier with `DISPATCH_ABOVE_WORKER_TIER`, fail-**open** on lookup error).
- **FR-5 degrade-to-1** — `isTieringActive` (≥2 live workers) gates both enforcement points; a lone worker takes all work regardless of rung.

`scripts/stamp-sd-tier-rank.mjs` stamps `metadata.min_tier_rank`.

## Out of scope (deferred)
Handoff-retiering (component 6 — claim-transfer races) → follow-up SD.

## Tests
18 per-FR regression tests in `tests/unit/fleet/complexity-tiered-assignment.test.js`; full fleet suite 100/100 (no regressions). Additive only, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)