### PR TITLE
feat(SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001): set new-venture autonomy default L2->L1

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-AI-FINANCIAL-RIGOR-CONTROLS-001",
-  "createdAt": "2026-06-26T14:03:57.405Z",
+  "sdKey": "SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001",
+  "createdAt": "2026-06-26T15:08:47.218Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260626_venture_autonomy_default_l1.sql
+++ b/database/migrations/20260626_venture_autonomy_default_l1.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- Set the new-venture autonomy DEFAULT from L2 -> L1
+-- SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001  (chairman-decided)
+-- ============================================================================
+-- RATIONALE:
+--   The chairman decided new ventures should default to autonomy level L1.
+--   This SUPERSEDES the deferred FR-5 "L2 -> L0 revert" — the default moves to
+--   L1 (one step below the prior L2), not back to L0.
+--
+--   Mirrors 20260601_venture_build_autonomy_default_l2.sql (which set BOTH
+--   defaults to L2). As verified there against live schema dedlbzhpgkmetvhbkyzq:
+--     * eva_ventures and ventures are SEPARATE base tables (NOT a view).
+--     * checkAutonomy() reads eva_ventures.autonomy_level (enum eva_autonomy_level).
+--     * sync_ventures_to_eva_ventures_insert() OMITS autonomy_level, so the
+--       eva_ventures COLUMN DEFAULT is what applies for trigger-synced rows ->
+--       the default MUST be set on eva_ventures (read side) AND ventures (write).
+--
+--   NO code change: the reserved-gates backstop and the gate matrix already
+--   handle L1 correctly. NO setter change: set_venture_autonomy_level() is
+--   level-agnostic (single-step over L0..L4) and is unaffected.
+--
+-- NON-RETROACTIVE: only the DEFAULT changes. Existing rows are NOT updated.
+--   venture-1 is already L1. No backfill.
+-- Rollback notes at bottom.
+-- ============================================================================
+-- @approved-by: codestreetlabs@gmail.com
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. DEFAULT change on the gate-READ table (eva_ventures: enum eva_autonomy_level)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.eva_ventures
+  ALTER COLUMN autonomy_level SET DEFAULT 'L1'::eva_autonomy_level;
+
+-- ---------------------------------------------------------------------------
+-- 2. DEFAULT change on the source/write table (ventures: text, CHECK L0..L4)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.ventures
+  ALTER COLUMN autonomy_level SET DEFAULT 'L1';
+
+-- NOTE: NO UPDATE statements. Existing rows are unchanged by design
+-- (column-default changes are non-retroactive).
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (manual, if ever needed) — restores the prior L2 default:
+--   ALTER TABLE public.eva_ventures ALTER COLUMN autonomy_level SET DEFAULT 'L2'::eva_autonomy_level;
+--   ALTER TABLE public.ventures     ALTER COLUMN autonomy_level SET DEFAULT 'L2';
+-- ============================================================================

--- a/tests/ci/venture-autonomy-default-l1.test.js
+++ b/tests/ci/venture-autonomy-default-l1.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+// SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001 (chairman-decided): new-venture autonomy
+// default is L1. This guards the migration so a silent revert to L2 fails CI.
+const REPO_ROOT = join(fileURLToPath(import.meta.url), '..', '..', '..');
+const MIGRATION = join(
+  REPO_ROOT,
+  'database',
+  'migrations',
+  '20260626_venture_autonomy_default_l1.sql'
+);
+
+function strip(sql) {
+  return sql.replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('Venture autonomy default is L1 (SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001)', () => {
+  const sql = strip(readFileSync(MIGRATION, 'utf8'));
+
+  it('sets ventures.autonomy_level DEFAULT to L1 (write/source table)', () => {
+    expect(sql).toMatch(
+      /ALTER\s+TABLE\s+public\.ventures\s+ALTER\s+COLUMN\s+autonomy_level\s+SET\s+DEFAULT\s+'L1'/i
+    );
+  });
+
+  it('sets eva_ventures.autonomy_level DEFAULT to L1 (gate-read table)', () => {
+    expect(sql).toMatch(
+      /ALTER\s+TABLE\s+public\.eva_ventures\s+ALTER\s+COLUMN\s+autonomy_level\s+SET\s+DEFAULT\s+'L1'::eva_autonomy_level/i
+    );
+  });
+
+  it('does not re-default either table to L2 (no silent revert)', () => {
+    expect(sql).not.toMatch(/SET\s+DEFAULT\s+'L2'/i);
+  });
+
+  it('is non-retroactive: no UPDATE backfill of existing rows', () => {
+    expect(sql).not.toMatch(/\bUPDATE\s+public\.(ventures|eva_ventures)\b/i);
+  });
+});


### PR DESCRIPTION
## Summary
Chairman-decided: change the new-venture autonomy COLUMN DEFAULT from L2 to L1 on both `ventures.autonomy_level` (text source/write) and `eva_ventures.autonomy_level` (enum `eva_autonomy_level`, gate-read). Supersedes the deferred FR-5 L0-revert.

- Single non-retroactive migration mirroring `20260601_venture_build_autonomy_default_l2.sql`; no UPDATE/backfill (venture-1 already L1).
- No code change — the reserved-gates backstop + gate matrix already handle L1.
- Static migration-guard test (`tests/ci/venture-autonomy-default-l1.test.js`) fails if either default silently reverts to L2.

## Verification
Applied to live DB; `information_schema` confirms both defaults are now `L1`. New test 4/4 green.

SD: SD-LEO-INFRA-AUTONOMY-DEFAULT-L1-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)