### PR TITLE
feat(SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001): pivot-aware product-priority band in dispatch ranker

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -61,6 +61,22 @@ export function blockerKeysFor(d) {
 // metadata.fleet_critical===true marks work whose ABSENCE blocks ALL fleet progress. Exported pure so
 // the band ordering is unit-testable. STRICT === true so a stray truthy value can't silently enrol.
 export function isFleetCritical(d) { return (d && d.metadata || {}).fleet_critical === true; }
+// SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001 (FR-3): product-vs-harness class detection for the
+// pivot-aware product-priority band. Pure + exported so the band ordering is unit-testable against
+// real code (like isFleetCritical). Classification is by sd_key prefix; an SD that is neither is
+// NEUTRAL and the band never reorders it relative to its own class.
+const PRODUCT_CLASS_RE = /^SD-EHG-PRODUCT/i;
+const HARNESS_CLASS_RE = /^(SD-LEO-INFRA|SD-MAN-INFRA|SD-LEARN-FIX|QF-)/i;
+export function isProductClass(d) { return PRODUCT_CLASS_RE.test((d && d.sd_key) || ''); }
+export function isHarnessClass(d) { return HARNESS_CLASS_RE.test((d && d.sd_key) || ''); }
+// Band rank: product first (0), neutral middle (1), harness last (2). Lower sorts earlier.
+export function productPivotRank(d) { return isProductClass(d) ? 0 : isHarnessClass(d) ? 2 : 1; }
+// SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001 (FR-1/FR-4): the band comparator. INERT (returns 0,
+// ranking unchanged) unless the product pivot is active — fail-soft default OFF lives at the call site.
+export function productPivotCompare(a, b, active) {
+  if (!active) return 0;
+  return productPivotRank(a) - productPivotRank(b);
+}
 // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-2): needle-movement prioritization.
 // Reuse FR-1's rollup (active rung + per-rung progress) and the pure needle scorer to order remaining
 // work active-rung-first among same-unlock candidates. Loaded fail-soft — any read error leaves the
@@ -225,6 +241,21 @@ async function main() {
   }
   const needleOf = (d) => needleScore(sdRungMap[d.sd_key], { activeRungKey, rungProgressByKey: progByKey });
 
+  // SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001 (FR-2/FR-4): read the product-pivot governance flag
+  // ONCE before sorting and thread the boolean into the (synchronous) comparator. Fail-soft: any read
+  // error or a disabled/missing flag leaves productPivotActive=false, so the band is inert and ranking
+  // is byte-identical to pre-change behavior. The flag is a leo_feature_flags row (no DDL).
+  let productPivotActive = false;
+  try {
+    const { isEnabled } = await import('../lib/feature-flags/evaluator.js');
+    productPivotActive = await isEnabled('product_pivot_active');
+  } catch (e) {
+    console.log(`[BACKLOG-RANK] product-pivot flag read failed (fail-soft, band inert): ${e?.message || e}`);
+  }
+  if (productPivotActive) {
+    console.log('[BACKLOG-RANK] product-pivot band ACTIVE — product-class SDs ranked above harness-class (below gates/quarantine/fleet_critical/unlock).');
+  }
+
   claimable.sort((a, b) => {
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs sort below EVERY
     // authored SD (rank-last), so a worker never self-claims a stub that cannot pass
@@ -241,6 +272,12 @@ async function main() {
     if (fa !== fb) return fb - fa;                          // fleet-critical first
     const ua = unlockScore(a.sd_key), ub = unlockScore(b.sd_key);
     if (ub !== ua) return ub - ua;
+    // SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001 (FR-1): the pivot-aware product-priority band.
+    // When the product pivot is active, product-class SDs outrank harness-class SDs. Placed AFTER
+    // unlock (never strands a critical-path unlocker) and the bare-shell/quarantine/fleet_critical
+    // quality gates, and BEFORE needle/vision/priority/age. Inert (returns 0) when the pivot is off.
+    const pp = productPivotCompare(a, b, productPivotActive);
+    if (pp !== 0) return pp;
     // FR-2 needle-movement: among same-unlock candidates, order active-rung-first, then highest-impact-
     // on-rung-completion-first (the completion bonus). Applied AFTER unlock (never overrides critical-path
     // unlocking) and BEFORE the vision-loop nudge/priority/age. Unknown-rung SDs score 0 (neutral).

--- a/tests/unit/coordinator-backlog-rank-pivot-band.test.js
+++ b/tests/unit/coordinator-backlog-rank-pivot-band.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isProductClass,
+  isHarnessClass,
+  productPivotRank,
+  productPivotCompare,
+  isFleetCritical,
+} from '../../scripts/coordinator-backlog-rank.mjs';
+
+// SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001: unit-test the pivot-aware product-priority band
+// against the REAL exported comparator helpers (not a re-implementation).
+const product = { sd_key: 'SD-EHG-PRODUCT-DASHBOARD-001' };
+const harnessInfra = { sd_key: 'SD-LEO-INFRA-FOO-001' };
+const harnessMan = { sd_key: 'SD-MAN-INFRA-BAR-001' };
+const harnessLearn = { sd_key: 'SD-LEARN-FIX-BAZ-001' };
+const harnessQf = { sd_key: 'QF-20260626-001' };
+const neutral = { sd_key: 'SD-EHG-VENTURE1-MARKET-MODELING-001' };
+
+describe('class detection (FR-3)', () => {
+  it('classifies product-class by SD-EHG-PRODUCT prefix', () => {
+    expect(isProductClass(product)).toBe(true);
+    expect(isProductClass(harnessInfra)).toBe(false);
+    expect(isProductClass(neutral)).toBe(false);
+  });
+
+  it('classifies harness-class by SD-LEO-INFRA / SD-MAN-INFRA / SD-LEARN-FIX / QF prefixes', () => {
+    for (const h of [harnessInfra, harnessMan, harnessLearn, harnessQf]) {
+      expect(isHarnessClass(h)).toBe(true);
+    }
+    expect(isHarnessClass(product)).toBe(false);
+    expect(isHarnessClass(neutral)).toBe(false);
+  });
+
+  it('ranks product(0) < neutral(1) < harness(2)', () => {
+    expect(productPivotRank(product)).toBe(0);
+    expect(productPivotRank(neutral)).toBe(1);
+    expect(productPivotRank(harnessInfra)).toBe(2);
+  });
+});
+
+describe('productPivotCompare band (FR-1)', () => {
+  it('when active, product sorts before harness', () => {
+    expect(productPivotCompare(product, harnessInfra, true)).toBeLessThan(0);
+    expect(productPivotCompare(harnessInfra, product, true)).toBeGreaterThan(0);
+  });
+
+  it('when active, product sorts before neutral and neutral before harness', () => {
+    expect(productPivotCompare(product, neutral, true)).toBeLessThan(0);
+    expect(productPivotCompare(neutral, harnessInfra, true)).toBeLessThan(0);
+  });
+
+  it('when active, same-class is a tie (0) — defers to downstream comparators', () => {
+    expect(productPivotCompare(harnessInfra, harnessMan, true)).toBe(0);
+    expect(productPivotCompare(product, { sd_key: 'SD-EHG-PRODUCT-OTHER-001' }, true)).toBe(0);
+  });
+});
+
+describe('inert when pivot inactive (FR-4)', () => {
+  it('returns 0 for any pair when active=false', () => {
+    expect(productPivotCompare(product, harnessInfra, false)).toBe(0);
+    expect(productPivotCompare(harnessInfra, product, false)).toBe(0);
+    expect(productPivotCompare(neutral, harnessInfra, false)).toBe(0);
+  });
+
+  it('treats undefined active as inactive (fail-soft default)', () => {
+    expect(productPivotCompare(product, harnessInfra, undefined)).toBe(0);
+  });
+});
+
+describe('band composes below the higher-precedence bands', () => {
+  // The product band runs AFTER unlock and the fleet_critical/quarantine/bare-shell gates in the
+  // real comparator. This asserts the band itself never claims to outrank those (it only breaks ties
+  // at its own level): a fleet_critical harness SD is still fleet_critical regardless of class.
+  it('class detection does not alter fleet_critical detection', () => {
+    const fcHarness = { sd_key: 'SD-LEO-INFRA-FC-001', metadata: { fleet_critical: true } };
+    expect(isFleetCritical(fcHarness)).toBe(true);
+    expect(isHarnessClass(fcHarness)).toBe(true);
+    // The comparator applies fleet_critical BEFORE productPivotCompare, so this harness SD still
+    // wins its fleet_critical tier — the band cannot demote it below product at that earlier stage.
+  });
+});


### PR DESCRIPTION
## Summary
Adds a pivot-aware product-priority band to the coordinator backlog ranker so the dispatch layer enforces the product pivot (workers stop being served harness work).

When the `product_pivot_active` governance flag (a `leo_feature_flags` row — **no DDL**) is enabled, product-class SDs (`SD-EHG-PRODUCT-*`) rank **above** harness-class SDs (`SD-LEO-INFRA`/`SD-MAN-INFRA`/`SD-LEARN-FIX`/`QF-`). The band sits **below** the bare-shell/quarantine quality gates, the `fleet_critical` band, and unlock scoring (never strands a critical-path unlocker or quality gate), and **above** needle/vision/priority/age — mirroring the existing `fleet_critical` band.

- **Fail-soft:** flag disabled/missing/unreadable ⇒ ranking byte-identical to before. Flag read once before sort; comparator stays synchronous on the captured boolean.
- Exported pure comparator helpers (`isProductClass`/`isHarnessClass`/`productPivotRank`/`productPivotCompare`) + 9 unit tests against the real code.
- **Flag ships DISABLED** — enabling live dispatch behavior is the coordinator's governance call.

Origin: worker /signal `belt-serves-harness-against-pivot` → coordinator-assigned SD (dispatch_rank 4, sourced_by adam).

## Verification
9/9 new unit tests pass; 51 existing backlog-rank tests still green (no regression).

SD: SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)