### PR TITLE
feat(SD-LEO-INFRA-S16-FINANCIAL-GROUNDING-EVIDENCE-GATE-001): FR-A grounding — thread ratified S7 economics into the S16 producer

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -94,14 +94,71 @@ Rules:
  * @param {Object} [params.stage14Data] - Stage 14 technical architecture
  * @param {Object} [params.stage15Data] - Stage 15 risk register
  * @param {string} [params.ventureName]
+ * @param {Object} [params.stage7Economics] - SD-...-GROUNDING-EVIDENCE-GATE-001 FR-A: ratified S7 unit-economics
  * @returns {Promise<Object>} Financial projections
  */
-export async function analyzeStage16({ stage1Data, stage7Data, stage13Data, stage14Data, stage15Data, ventureName, logger = console }) {
+
+/**
+ * FR-A: normalize the threaded S7 economics into a verified-inputs block, or null when absent/invalid.
+ * A valid block requires the load-bearing facts (cac, arpa) to be finite positive numbers.
+ */
+export function buildVerifiedInputs(stage7Economics) {
+  const e = stage7Economics;
+  if (!e || typeof e !== 'object') return null;
+  const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
+  const cac = num(e.cac);
+  const arpa = num(e.arpa);
+  if (!(cac > 0) || !(arpa > 0)) return null; // not groundable without the core unit economics
+  return {
+    cac,
+    arpa,
+    churn_rate_monthly: num(e.churn_rate_monthly),
+    gross_margin_pct: num(e.gross_margin_pct),
+    ltv: num(e.ltv),
+    tiers: Array.isArray(e.tiers) ? e.tiers : null,
+    source: 'engine_pricing_model (S7)',
+  };
+}
+
+/**
+ * FR-A/FR-B: register the verified inputs as FACT classifications in fourBuckets (so summary.facts > 0)
+ * and compute DERIVED grounded figures (LTV, LTV:CAC, monthly gross profit per customer). PURE-ish
+ * (mutates the passed fourBuckets). Returns the derived economics for the artifact.
+ */
+export function groundVerifiedFacts(fourBuckets, vi) {
+  if (!fourBuckets || typeof fourBuckets !== 'object') return null;
+  if (!Array.isArray(fourBuckets.classifications)) fourBuckets.classifications = [];
+  if (!fourBuckets.summary) fourBuckets.summary = { facts: 0, assumptions: 0, simulations: 0, unknowns: 0 };
+  const addFact = (claim, evidence) => {
+    fourBuckets.classifications.push({ claim, bucket: 'fact', evidence });
+    fourBuckets.summary.facts = (fourBuckets.summary.facts || 0) + 1;
+  };
+  addFact(`CAC = $${vi.cac}`, 'ratified S7 unit-economics (engine_pricing_model)');
+  addFact(`ARPA = $${vi.arpa}/mo`, 'ratified S7 unit-economics (engine_pricing_model)');
+  if (vi.churn_rate_monthly != null) addFact(`Monthly churn = ${vi.churn_rate_monthly}%`, 'ratified S7 unit-economics');
+  if (vi.gross_margin_pct != null) addFact(`Gross margin = ${vi.gross_margin_pct}%`, 'ratified S7 unit-economics');
+  // DERIVED (FR-B = DERIVED): LTV = ARPA*margin / churn (monthly), LTV:CAC, monthly gross profit/customer.
+  const marginFrac = vi.gross_margin_pct != null ? vi.gross_margin_pct / 100 : null;
+  const churnFrac = vi.churn_rate_monthly != null ? vi.churn_rate_monthly / 100 : null;
+  const monthly_gross_profit_per_customer = marginFrac != null ? Math.round(vi.arpa * marginFrac * 100) / 100 : null;
+  const ltv_derived = (marginFrac != null && churnFrac > 0)
+    ? Math.round((vi.arpa * marginFrac / churnFrac) * 100) / 100
+    : (vi.ltv ?? null);
+  const ltv_cac_ratio = (ltv_derived != null && vi.cac > 0) ? Math.round((ltv_derived / vi.cac) * 100) / 100 : null;
+  return { monthly_gross_profit_per_customer, ltv_derived, ltv_cac_ratio };
+}
+
+export async function analyzeStage16({ stage1Data, stage7Data, stage13Data, stage14Data, stage15Data, stage7Economics, ventureName, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage16] Starting analysis', { ventureName });
   if (!stage1Data?.description) {
     throw new Error('Stage 16 financial projections requires Stage 1 data with description');
   }
+
+  // SD-LEO-INFRA-S16-FINANCIAL-GROUNDING-EVIDENCE-GATE-001 FR-A: GROUND the financials in the ratified
+  // upstream S7 unit-economics (engine_pricing_model artifact, threaded via onBeforeAnalysis). These are
+  // VERIFIED FACTS — the producer must TRANSFORM/aggregate them, not invent different unit economics.
+  const verifiedInputs = buildVerifiedInputs(stage7Economics);
 
   const client = getLLMClient({ purpose: 'content-generation' });
 
@@ -117,6 +174,16 @@ export async function analyzeStage16({ stage1Data, stage7Data, stage13Data, stag
     ? `Risks: ${stage15Data.total_risks || stage15Data.risks.length} identified (${stage15Data.severity_breakdown?.critical || 0} critical, ${stage15Data.severity_breakdown?.high || 0} high)`
     : 'No risk register available';
 
+  // FR-A: a VERIFIED-INPUTS block the producer must transform, not override.
+  const economicsContext = verifiedInputs
+    ? `VERIFIED UNIT-ECONOMICS (RATIFIED — from the upstream S7 pricing strategy; these are FACTS you MUST use, not invent):
+- CAC (customer acquisition cost): $${verifiedInputs.cac}
+- ARPA (avg revenue per account / month): $${verifiedInputs.arpa}
+- Monthly churn: ${verifiedInputs.churn_rate_monthly}%
+- Gross margin: ${verifiedInputs.gross_margin_pct}%${verifiedInputs.ltv != null ? `\n- LTV: $${verifiedInputs.ltv}` : ''}${Array.isArray(verifiedInputs.tiers) && verifiedInputs.tiers.length ? `\n- Pricing tiers: ${verifiedInputs.tiers.map(t => `${t.name || t.target_segment || 'tier'} $${t.price}`).join(', ')}` : ''}
+CONSTRAINT: derive revenue from ARPA × the customer count you project; derive acquisition costs from CAC × new customers; apply the ${verifiedInputs.churn_rate_monthly}% monthly churn to retention and the ${verifiedInputs.gross_margin_pct}% gross margin. Do NOT introduce different unit economics from memory. Only the customer-GROWTH trajectory and operating-expense lines are yours to estimate.`
+    : 'No verified upstream unit-economics available — estimate conservatively and flag as simulation.';
+
   const userPrompt = `Generate financial projections for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
@@ -129,6 +196,7 @@ ${archContext}
 ${riskContext}
 
 ${getOperatingModelPromptBlock()}
+${economicsContext}
 
 Output ONLY valid JSON.`;
 
@@ -137,6 +205,11 @@ Output ONLY valid JSON.`;
   const usage = extractUsage(response);
   const parsed = parseJSON(response);
   const fourBuckets = parseFourBuckets(parsed, { logger });
+
+  // FR-A: deterministically register the VERIFIED upstream economics as FACT classifications so a
+  // grounded S16 has fourBuckets.summary.facts > 0 — the (merged) evidence-gate then treats it as
+  // grounded instead of all-simulation. Without verified inputs, facts stay LLM-derived (likely 0).
+  const derivedEconomics = verifiedInputs ? groundVerifiedFacts(fourBuckets, verifiedInputs) : null;
 
   // Validate initial_capital
   const initial_capital = Math.max(0, Number(parsed.initial_capital) || 0);
@@ -395,6 +468,20 @@ Output ONLY valid JSON.`;
     financials_valid,
     viability_warnings,
     promotion_gate,
+    // SD-...-GROUNDING-EVIDENCE-GATE-001 FR-A/FR-B: grounding provenance.
+    verified_inputs: verifiedInputs,                 // the ratified S7 facts the producer transformed
+    grounded: Boolean(verifiedInputs),               // true when financials are grounded in real economics
+    grounding_source: verifiedInputs ? verifiedInputs.source : null,
+    derived_economics: derivedEconomics,             // DERIVED grounded figures (LTV, LTV:CAC, gross profit/customer)
+    epistemic_tags: {                                // FR-B: epistemic status of the key figure classes
+      cac: verifiedInputs ? 'FACT' : 'ESTIMATE',
+      arpa: verifiedInputs ? 'FACT' : 'ESTIMATE',
+      churn_rate_monthly: verifiedInputs && verifiedInputs.churn_rate_monthly != null ? 'FACT' : 'ESTIMATE',
+      gross_margin_pct: verifiedInputs && verifiedInputs.gross_margin_pct != null ? 'FACT' : 'ESTIMATE',
+      ltv: derivedEconomics && derivedEconomics.ltv_derived != null ? 'DERIVED' : 'ESTIMATE',
+      revenue_projections: 'ESTIMATE',               // customer-growth trajectory is the producer's estimate
+      recommended_initial_capital: 'DERIVED',        // bottom-up from the (grounded) cash trough
+    },
     llmFallbackCount,
     fourBuckets, usage,
   };

--- a/lib/eva/stage-templates/stage-16.js
+++ b/lib/eva/stage-templates/stage-16.js
@@ -411,8 +411,26 @@ TEMPLATE.onBeforeAnalysis = async (supabase, ventureId) => {
     // positioning co-output. The orchestrator/engine also wrap this in try/catch.
     console.warn?.(`[Stage16-PositioningBrief] co-output persist failed (non-blocking): ${err?.message || err}`);
   }
-  // Return {} — do NOT thread positioning data into the financial analysisStep.
-  return {};
+  // SD-...-GROUNDING-EVIDENCE-GATE-001 FR-A: thread the RATIFIED S7 unit-economics into the financial
+  // analysisStep so analyzeStage16 grounds the financials (transform-not-invent) instead of inventing
+  // numbers. Fetch the engine_pricing_model artifact (stage 7) + return it as stage7Economics. Fail-safe:
+  // any error degrades to {} (ungrounded → the merged evidence-gate routes it to review). We do NOT thread
+  // positioning data (the brief is a side-effect above).
+  try {
+    if (!supabase || !ventureId) return {};
+    const { data: s7 } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data, content')
+      .eq('venture_id', ventureId)
+      .eq('is_current', true)
+      .eq('artifact_type', 'engine_pricing_model')
+      .maybeSingle();
+    const stage7Economics = s7 ? (s7.artifact_data ?? s7.content ?? null) : null;
+    return stage7Economics ? { stage7Economics } : {};
+  } catch (e) {
+    console.warn?.(`[Stage16] S7 economics fetch for grounding failed (non-blocking, ungrounded): ${e?.message || e}`);
+    return {};
+  }
 };
 
 ensureOutputSchema(TEMPLATE);

--- a/tests/unit/eva/stage16-grounding.test.js
+++ b/tests/unit/eva/stage16-grounding.test.js
@@ -1,0 +1,80 @@
+/**
+ * SD-LEO-INFRA-S16-FINANCIAL-GROUNDING-EVIDENCE-GATE-001 FR-A/FR-B — ground the S16 producer in the
+ * ratified upstream S7 unit-economics, transform-not-invent, with epistemic tags + facts>0.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ fin: {} }));
+vi.mock('../../../lib/llm/client-factory.js', () => ({
+  getLLMClient: () => ({ complete: async () => ({ content: JSON.stringify(h.fin) }) }),
+}));
+
+import {
+  analyzeStage16,
+  buildVerifiedInputs,
+  groundVerifiedFacts,
+} from '../../../lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const stage1 = { description: 'Market modeling SaaS', targetMarket: 'consultants', problemStatement: 'manual WTP research' };
+// venture-1's real ratified S7 economics
+const S7 = { cac: 800, arpa: 449, churn_rate_monthly: 4, gross_margin_pct: 80, ltv: null, tiers: [{ name: 'Pro', price: 449 }] };
+const cb = (t) => ({ personnel: t * 0.6, infrastructure: t * 0.2, marketing: t * 0.1, other: t * 0.1 });
+const FIN = {
+  initial_capital: 200000, monthly_burn_rate: 30000,
+  revenue_projections: [
+    { month: 1, revenue: 4490, costs: 30000, cost_breakdown: cb(30000) },
+    { month: 2, revenue: 8980, costs: 32000, cost_breakdown: cb(32000) },
+  ],
+};
+
+function run(stage7Economics) {
+  h.fin = FIN;
+  return analyzeStage16({ stage1Data: stage1, stage13Data: {}, stage14Data: {}, stage15Data: {}, stage7Economics, ventureName: 'V1', logger: silent });
+}
+
+describe('FR-A buildVerifiedInputs', () => {
+  it('builds a verified block from ratified S7 economics', () => {
+    const vi2 = buildVerifiedInputs(S7);
+    expect(vi2).not.toBeNull();
+    expect(vi2.cac).toBe(800);
+    expect(vi2.arpa).toBe(449);
+  });
+  it('returns null without the core unit economics (cac/arpa)', () => {
+    expect(buildVerifiedInputs({ churn_rate_monthly: 4 })).toBeNull();
+    expect(buildVerifiedInputs(null)).toBeNull();
+  });
+});
+
+describe('FR-A/FR-B groundVerifiedFacts', () => {
+  it('registers verified inputs as FACTS (facts count rises) and derives LTV + LTV:CAC', () => {
+    const fb = { classifications: [], summary: { facts: 0, assumptions: 0, simulations: 0, unknowns: 0 } };
+    const derived = groundVerifiedFacts(fb, buildVerifiedInputs(S7));
+    expect(fb.summary.facts).toBeGreaterThan(0);
+    // LTV = ARPA*margin/churn = 449*0.8/0.04 = 8980
+    expect(derived.ltv_derived).toBeCloseTo(8980, 0);
+    expect(derived.ltv_cac_ratio).toBeCloseTo(11.225, 1); // 8980/800
+  });
+});
+
+describe('analyzeStage16 grounding (end-to-end with mocked LLM)', () => {
+  it('GROUNDED: with S7 economics -> grounded=true, facts>0, verified_inputs + DERIVED + tags present', async () => {
+    const r = await run(S7);
+    expect(r.grounded).toBe(true);
+    expect(r.fourBuckets.summary.facts).toBeGreaterThan(0);
+    expect(r.verified_inputs.cac).toBe(800);
+    expect(r.verified_inputs.arpa).toBe(449);
+    expect(r.derived_economics.ltv_derived).toBeCloseTo(8980, 0);
+    expect(r.epistemic_tags.cac).toBe('FACT');
+    expect(r.epistemic_tags.ltv).toBe('DERIVED');
+    expect(r.grounding_source).toMatch(/S7/);
+  });
+
+  it('UNGROUNDED: without S7 economics -> grounded=false, no injected facts', async () => {
+    const r = await run(undefined);
+    expect(r.grounded).toBe(false);
+    expect(r.verified_inputs).toBeNull();
+    // no verified-fact injection; facts stay whatever the LLM produced (0 for our fixture)
+    expect(r.fourBuckets.summary.facts).toBe(0);
+  });
+});


### PR DESCRIPTION
Folds the parent's **actual GROUNDING goal into this SD** (per chairman directive — not a follow-up child). The merged evidence-gate (#5155) only *routes* ungrounded numbers to review; this makes the numbers **grounded**.

## Change
- **`onBeforeAnalysis`** (stage-16.js): fetch the ratified S7 unit-economics (`engine_pricing_model` artifact) + thread it into `analyzeStage16` as `stage7Economics` (fail-safe → ungrounded routes to review).
- **FR-A** (stage-16-financial-projections.js): `buildVerifiedInputs` normalizes the S7 facts; the LLM prompt carries a **VERIFIED UNIT-ECONOMICS** block with a **transform-not-invent** constraint (revenue from ARPA×customers, acquisition from CAC×new, apply churn + margin).
- **facts>0**: `groundVerifiedFacts` deterministically registers the verified inputs as FACT classifications (`fourBuckets.summary.facts>0`) and derives grounded figures (LTV=ARPA·margin/churn, LTV:CAC, gross profit/customer).
- **FR-B**: `epistemic_tags` (FACT/DERIVED/ESTIMATE) + `verified_inputs` + `grounding_source` + `derived_economics` on the artifact.

## venture-1 grounded re-run (compute-only, this branch)
`onBeforeAnalysis` threaded the real S7 (CAC $800 / ARPA $449 / churn 4% / margin 80%) → **grounded=true, facts=5**, LTV **$8,980**, LTV:CAC **11.2**, `recommended_initial_capital` **$107,430** (DERIVED bottom-up). The grounded projection's `financials_valid=false` (LLM cost-breakdown/identity cross-check failed) → gate **ROUTE_TO_REVIEW** — the full ground→validate→gate pipeline working as intended.

## Tests
`tests/unit/eva/stage16-grounding.test.js` (5) + 21 sibling eva tests green (stage-16 / financial-rigor / evidence-gate). No regression.

SD stays OPEN — this is FR-A of the grounding SD (folded in, not spun out). Builds on the evidence-gate (#5155) + the financial-rigor signals (#5148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
