### PR TITLE
feat(SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001): block completion when deferred work has no home SD

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -45,6 +45,10 @@ import { createPhantomTestAuditGate } from './gates/phantom-test-audit-gate.js';
 export { createPhantomTestAuditGate };
 import { createLearningOrBypassResolvedGate } from './gates/learning-or-bypass-resolved-gate.js';
 export { createLearningOrBypassResolvedGate };
+// SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001: block completion when declared deferred
+// follow-up work has no live home SD (stop deferred scope from evaporating).
+import { createDeferredFollowupsGate } from './gates/deferred-followups-gate.js';
+export { createDeferredFollowupsGate };
 
 // Cross-SD File-Overlap Temporal Gate — SHIP oracle (SD-LEO-INFRA-CROSS-FILE-OVERLAP-001 FR-2b)
 import { createCrossSdFileOverlapTemporalShipGate } from './gates/cross-sd-file-overlap-temporal-ship.js';
@@ -1219,6 +1223,12 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   // set ENFORCE_LEARNING_GATE=true to block.
   gates.push(createLearningOrBypassResolvedGate(supabase));
 
+  // Deferred-Followups Home — SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001
+  // Blocks completion when metadata.deferred_followups[] references a follow-up SD that does
+  // not exist (or is cancelled). Heuristic-warns on unstructured deferral phrases. Blocking by
+  // default; set DEFERRED_HOME_GATE_DISABLED=true for a byte-identical pass-through.
+  gates.push(createDeferredFollowupsGate(supabase));
+
   // Cross-SD File-Overlap Temporal Gate — SHIP oracle (FR-2b)
   // Compares this PR's diff against the merge-commit diffs of SDs shipped
   // within the configured window. High-risk = FAIL, medium = WARN unless ack'd.
@@ -1253,6 +1263,7 @@ export default {
   createWireCheckGate,
   createPhantomTestAuditGate,
   createLearningOrBypassResolvedGate,
+  createDeferredFollowupsGate,
   createCrossSdFileOverlapTemporalShipGate,
   createActivationInvariantGate,
   getRequiredGates

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/deferred-followups-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/deferred-followups-gate.js
@@ -1,0 +1,150 @@
+/**
+ * DEFERRED_FOLLOWUPS_HOME — LEAD-FINAL-APPROVAL completion-integrity gate
+ * SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001
+ *
+ * Problem: an SD can be marked COMPLETE while declaring deferred follow-up work that has
+ * no actual home — the deferred scope then evaporates (nobody sources the child).
+ *
+ * This gate runs at LEAD-FINAL-APPROVAL and enforces:
+ *   FR-1 (contract): deferred scope is declared structurally in
+ *     metadata.deferred_followups[] = { description, follow_up_sd_key }.
+ *   FR-2 (block): for each declared follow-up, the referenced SD must EXIST
+ *     (sd_key present, status != 'cancelled'). A declared deferral with no live home
+ *     BLOCKS completion with a loud, actionable message.
+ *   FR-3 (heuristic warn): if completion text (notes/description) contains a deferral
+ *     phrase ("deferred to follow-up", "follow-up child", "out of scope, later SD", …)
+ *     but metadata.deferred_followups has no matching entry, WARN the operator
+ *     (non-blocking — avoids false positives on incidental prose).
+ *
+ * Rollout: blocking by default (FR-2). Set DEFERRED_HOME_GATE_DISABLED=true to make the
+ * gate a no-op pass-through (ranking/completion byte-identical to pre-change behavior).
+ *
+ * Phase: LEAD-FINAL-APPROVAL
+ */
+
+const GATE_NAME = 'DEFERRED_FOLLOWUPS_HOME';
+
+// FR-3 deferral phrases — lowercase substrings. Intentionally narrow to limit false positives.
+const DEFERRAL_PHRASES = [
+  'deferred to follow-up',
+  'deferred to a follow-up',
+  'follow-up child',
+  'followup child',
+  'out of scope, later sd',
+  'out of scope; later sd',
+  'deferred to a later sd',
+  'deferred to follow up',
+];
+
+/** Parse a value that may be a JSONB array or a JSON string into an array. */
+export function parseDeferredFollowups(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; }
+    catch { return []; }
+  }
+  return [];
+}
+
+/** Collect free-text fields where an unstructured deferral phrase might appear. */
+export function gatherCompletionText(sd) {
+  const m = sd?.metadata || {};
+  return [
+    sd?.description,
+    sd?.scope,
+    m.completion_notes,
+    m.completion_summary,
+    typeof m.completion_flags === 'string' ? m.completion_flags : JSON.stringify(m.completion_flags || ''),
+  ].filter(t => typeof t === 'string' && t.length).join('\n').toLowerCase();
+}
+
+/**
+ * Create the deferred-followups-home gate.
+ * @param {object} supabase - Supabase client (queries strategic_directives_v2 for follow-up existence)
+ * @returns {Object} Gate definition
+ */
+export function createDeferredFollowupsGate(supabase) {
+  return {
+    name: GATE_NAME,
+    required: true,
+    validator: async (ctx) => {
+      console.log('\n🔗 GATE: Deferred-Followups Home (completion integrity)');
+      console.log('-'.repeat(50));
+
+      // Rollout escape hatch: disabled => byte-identical pass-through.
+      if (process.env.DEFERRED_HOME_GATE_DISABLED === 'true') {
+        console.log('   DEFERRED_HOME_GATE_DISABLED=true — gate skipped (pass-through)');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Deferred-home gate disabled via env'] };
+      }
+
+      const sd = ctx?.sd;
+      const sdId = sd?.id || ctx?.sdId;
+      if (!sd || !sdId) {
+        return { passed: true, score: 80, max_score: 100, issues: [], warnings: ['No sd in context — gate skipped'] };
+      }
+
+      const deferred = parseDeferredFollowups(sd?.metadata?.deferred_followups);
+      const warnings = [];
+
+      // FR-3 heuristic: deferral phrase present but no structured declaration.
+      if (deferred.length === 0) {
+        const text = gatherCompletionText(sd);
+        const hit = DEFERRAL_PHRASES.find(p => text.includes(p));
+        if (hit) {
+          warnings.push(
+            `Completion text mentions deferred work ("${hit}") but metadata.deferred_followups is empty — ` +
+            `declare it as {description, follow_up_sd_key} (and create the home SD) or fold the work in before completing.`
+          );
+          console.log(`   ⚠️  Unstructured deferral phrase detected ("${hit}") — heuristic warn (non-blocking).`);
+        } else {
+          console.log('   No deferred followups declared and no deferral phrases — gate passes.');
+        }
+        return { passed: true, score: warnings.length ? 85 : 100, max_score: 100, issues: [], warnings };
+      }
+
+      // FR-2: each declared follow-up SD must exist and not be cancelled.
+      const issues = [];
+      const missing = [];
+      for (const f of deferred) {
+        const key = f && (f.follow_up_sd_key || f.sd_key);
+        if (!key || typeof key !== 'string') {
+          issues.push(`A deferred_followups entry is missing follow_up_sd_key (description: ${(f && f.description) || '?'}) — declare the home SD key.`);
+          continue;
+        }
+        const { data: row, error } = await supabase
+          .from('strategic_directives_v2')
+          .select('sd_key, status')
+          .eq('sd_key', key)
+          .maybeSingle();
+        if (error || !row) {
+          issues.push(`Deferred follow-up SD '${key}' does NOT exist — create it (or fold the work in) before completing.`);
+          missing.push(key);
+        } else if (String(row.status).toLowerCase() === 'cancelled') {
+          issues.push(`Deferred follow-up SD '${key}' is CANCELLED — its deferred work has no live home; re-source it or fold it in before completing.`);
+          missing.push(key);
+        } else {
+          console.log(`   ✓ Follow-up '${key}' exists (status: ${row.status}).`);
+        }
+      }
+
+      if (issues.length) {
+        console.log(`   ❌ ${issues.length} unresolved deferred follow-up(s) — BLOCKING completion.`);
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues,
+          warnings,
+          remediation:
+            'Deferred work was declared with no live home SD. Create the follow-up SD(s) — ' +
+            `${missing.join(', ') || '(see issues)'} — or fold the work into this SD, then re-run completion.`,
+        };
+      }
+
+      console.log(`   ✅ All ${deferred.length} deferred follow-up(s) have a live home SD.`);
+      return { passed: true, score: 100, max_score: 100, issues: [], warnings };
+    },
+  };
+}
+
+export default createDeferredFollowupsGate;

--- a/tests/unit/handoff/lead-final-approval-deferred-followups.test.js
+++ b/tests/unit/handoff/lead-final-approval-deferred-followups.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createDeferredFollowupsGate,
+  parseDeferredFollowups,
+  gatherCompletionText,
+} from '../../../scripts/modules/handoff/executors/lead-final-approval/gates/deferred-followups-gate.js';
+
+// SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001: completion-integrity gate unit tests.
+
+// Minimal Supabase stub: maps sd_key -> {sd_key,status} (or null = not found).
+function makeSupabase(rowsByKey) {
+  return {
+    from() {
+      let _key = null;
+      const builder = {
+        select() { return builder; },
+        eq(_col, val) { _key = val; return builder; },
+        async maybeSingle() {
+          const row = rowsByKey[_key];
+          return { data: row || null, error: null };
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('parseDeferredFollowups', () => {
+  it('parses array, JSON string, and falls back to []', () => {
+    expect(parseDeferredFollowups([{ follow_up_sd_key: 'SD-X-001' }])).toHaveLength(1);
+    expect(parseDeferredFollowups('[{"follow_up_sd_key":"SD-X-001"}]')).toHaveLength(1);
+    expect(parseDeferredFollowups('not json')).toEqual([]);
+    expect(parseDeferredFollowups(undefined)).toEqual([]);
+  });
+});
+
+describe('DEFERRED_FOLLOWUPS_HOME gate', () => {
+  let restoreEnv;
+  beforeEach(() => {
+    const prev = process.env.DEFERRED_HOME_GATE_DISABLED;
+    restoreEnv = () => { process.env.DEFERRED_HOME_GATE_DISABLED = prev; };
+    delete process.env.DEFERRED_HOME_GATE_DISABLED;
+  });
+
+  it('FR-2: BLOCKS when a declared follow-up SD does not exist', async () => {
+    const gate = createDeferredFollowupsGate(makeSupabase({}));
+    const ctx = { sd: { id: 'id-1', metadata: { deferred_followups: [{ description: 'x', follow_up_sd_key: 'SD-MISSING-001' }] } } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(false);
+    expect(r.issues[0]).toMatch(/SD-MISSING-001.*does NOT exist/);
+    restoreEnv();
+  });
+
+  it('FR-2: BLOCKS when the declared follow-up SD is cancelled', async () => {
+    const gate = createDeferredFollowupsGate(makeSupabase({ 'SD-DEAD-001': { sd_key: 'SD-DEAD-001', status: 'cancelled' } }));
+    const ctx = { sd: { id: 'id-1', metadata: { deferred_followups: [{ follow_up_sd_key: 'SD-DEAD-001' }] } } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(false);
+    expect(r.issues[0]).toMatch(/cancelled/i);
+    restoreEnv();
+  });
+
+  it('FR-2: PASSES when every declared follow-up SD exists and is live', async () => {
+    const gate = createDeferredFollowupsGate(makeSupabase({ 'SD-HOME-001': { sd_key: 'SD-HOME-001', status: 'draft' } }));
+    const ctx = { sd: { id: 'id-1', metadata: { deferred_followups: [{ follow_up_sd_key: 'SD-HOME-001' }] } } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(true);
+    expect(r.issues).toEqual([]);
+    restoreEnv();
+  });
+
+  it('BLOCKS when a deferred entry has no follow_up_sd_key', async () => {
+    const gate = createDeferredFollowupsGate(makeSupabase({}));
+    const ctx = { sd: { id: 'id-1', metadata: { deferred_followups: [{ description: 'orphan deferral' }] } } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(false);
+    expect(r.issues[0]).toMatch(/missing follow_up_sd_key/);
+    restoreEnv();
+  });
+
+  it('no-deferral SD passes cleanly (byte-identical to today)', async () => {
+    const gate = createDeferredFollowupsGate(makeSupabase({}));
+    const ctx = { sd: { id: 'id-1', metadata: {}, description: 'a normal SD' } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(true);
+    expect(r.issues).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    restoreEnv();
+  });
+
+  it('FR-3: heuristic-WARNS (non-blocking) on an unstructured deferral phrase with no declaration', async () => {
+    const gate = createDeferredFollowupsGate(makeSupabase({}));
+    const ctx = { sd: { id: 'id-1', metadata: { completion_notes: 'The X feature was deferred to follow-up.' } } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(true);            // non-blocking
+    expect(r.warnings.join(' ')).toMatch(/deferred to follow-up/);
+    restoreEnv();
+  });
+
+  it('FR-4: DEFERRED_HOME_GATE_DISABLED=true => pass-through even with a missing home', async () => {
+    process.env.DEFERRED_HOME_GATE_DISABLED = 'true';
+    const gate = createDeferredFollowupsGate(makeSupabase({}));
+    const ctx = { sd: { id: 'id-1', metadata: { deferred_followups: [{ follow_up_sd_key: 'SD-MISSING-001' }] } } };
+    const r = await gate.validator(ctx);
+    expect(r.passed).toBe(true);
+    restoreEnv();
+  });
+
+  it('gathers completion text from multiple metadata fields', () => {
+    const text = gatherCompletionText({ description: 'A', metadata: { completion_notes: 'B', completion_summary: 'C' } });
+    expect(text).toContain('a');
+    expect(text).toContain('b');
+    expect(text).toContain('c');
+  });
+});


### PR DESCRIPTION
## Summary
Adds a LEAD-FINAL-APPROVAL completion-integrity gate (`DEFERRED_FOLLOWUPS_HOME`) so deferred follow-up work can't silently evaporate.

- **FR-1:** structured contract — `metadata.deferred_followups[] = {description, follow_up_sd_key}`.
- **FR-2:** at completion, each referenced follow-up SD must EXIST and not be `cancelled` — otherwise completion is **BLOCKED** with an actionable message naming the missing key(s).
- **FR-3:** heuristic **WARN** (non-blocking) when completion text contains a deferral phrase but no structured declaration.
- **FR-4:** blocking by default; `DEFERRED_HOME_GATE_DISABLED=true` ⇒ byte-identical pass-through.

Mirrors the existing `learning-or-bypass-resolved` gate pattern. No DDL. Out of scope: auto-creating the missing child (human/Adam sources it).

Origin: adam-sourced; directly addresses the failure mode where an SD's completion-flags declare deferred items with no home.

## Verification
9/9 unit tests pass; `gates.js` imports cleanly with the gate registered.

SD: SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)