### PR TITLE
feat(SD-LEO-INFRA-FROM-PROPOSAL-METADATA-PRESERVE-001): preserve proposal metadata + translate target_repos

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2340,7 +2340,40 @@ export function validateProposalShape(proposal, filePath) {
  * sourced_by. Those historical rows are still counted by FR-1b as-is; this stamp makes the
  * proposal-based routes the durable, code-enforced producer going forward. No retroactive change.
  */
+// SD-LEO-INFRA-FROM-PROPOSAL-METADATA-PRESERVE-001 (FR-1): keys DELIBERATELY excluded from the
+// preserved proposal metadata, for two reasons:
+//   (a) LEAK-GUARD — arch_key/vision_key drive enrichFromVisionArch's orphan-FK re-activation
+//       (see mapProposalToCreateArgs header + the createSD vision/arch enrichment path).
+//   (b) CANONICAL-AUTHORITATIVE — these keys have dedicated, guarded handling below that must
+//       stay the single source of truth. The review-attestation flags (migration_reviewed /
+//       security_reviewed) are security-sensitive: they may appear ONLY on an explicit `=== true`,
+//       so a preserved raw `false`/`null`/object value must NOT leak through. target_repos is
+//       translated to target_application + a normalized list; depends_on is normalized into the
+//       canonical dependencies column + a back-compat metadata copy.
+const PROPOSAL_META_DROP_KEYS = new Set([
+  'arch_key', 'vision_key',
+  'migration_reviewed', 'security_reviewed',
+  'target_repos', 'depends_on',
+]);
+
 export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {}) {
+  // FR-1: preserve the proposal's full metadata object (merge with canonical defaults rather than
+  // replacing), MINUS the leak-guard keys. This carries Adam-sourcing keys (min_tier_rank,
+  // requires_human_action, deferred/deferred_until, etc.) that the old closed whitelist dropped.
+  const preservedProposalMeta = {};
+  if (proposal.metadata && typeof proposal.metadata === 'object' && !Array.isArray(proposal.metadata)) {
+    for (const [k, v] of Object.entries(proposal.metadata)) {
+      if (!PROPOSAL_META_DROP_KEYS.has(k)) preservedProposalMeta[k] = v;
+    }
+  }
+
+  // FR-2/FR-4: translate metadata.target_repos -> canonical target_application (first repo is the
+  // primary; the full list stays in metadata.target_repos). Reuse the --target-repos validator
+  // (parseTargetReposArg validates against ALLOWED_REPOS and exits(1) on an invalid value).
+  const proposalTargetRepos = Array.isArray(proposal.metadata?.target_repos) && proposal.metadata.target_repos.length > 0
+    ? parseTargetReposArg(proposal.metadata.target_repos.join(','))
+    : null;
+
   return {
     sdKey: normalized.sdKey,
     title: normalized.title,
@@ -2368,7 +2401,13 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
     ...(normalizeDependsOn(proposal.metadata?.depends_on).length > 0
       ? { dependencies: normalizeDependsOn(proposal.metadata?.depends_on) }
       : {}),
+    // FR-2: the primary target repo becomes the canonical top-level target_application that the
+    // branch-resolver / gate / repo-path resolution read (mirrors the --target-repos flag path).
+    ...(proposalTargetRepos ? { target_application: proposalTargetRepos[0] } : {}),
     metadata: {
+      // FR-1: full proposal metadata preserved (minus leak-guard keys), then canonical defaults
+      // below WIN over any same-named proposal key (source, provenance, validated target_repos, …).
+      ...preservedProposalMeta,
       source: 'proposal',
       proposal_file_path: filePath || null,
       proposal_provenance: proposal.provenance || null,
@@ -2418,6 +2457,9 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
       ...(proposal.metadata?.architecture_plan_ref ? { architecture_plan_ref: proposal.metadata.architecture_plan_ref } : {}),
       ...(proposal.metadata?.arch_plan_key ? { arch_plan_key: proposal.metadata.arch_plan_key } : {}),
       ...(proposal.metadata?.architecture_plan ? { architecture_plan: proposal.metadata.architecture_plan } : {}),
+      // FR-2: keep the NORMALIZED/validated target_repos in metadata (overrides the raw preserved
+      // value), parallel to the --target-repos flag path which stamps metadata.target_repos.
+      ...(proposalTargetRepos ? { target_repos: proposalTargetRepos } : {}),
     },
   };
 }

--- a/tests/unit/leo-create-sd-proposal-metadata-preserve.test.js
+++ b/tests/unit/leo-create-sd-proposal-metadata-preserve.test.js
@@ -1,0 +1,104 @@
+/**
+ * --from-proposal metadata preservation — SD-LEO-INFRA-FROM-PROPOSAL-METADATA-PRESERVE-001
+ *
+ * The proposal-ingest mapper previously used a CLOSED whitelist that dropped custom
+ * metadata keys (min_tier_rank, requires_human_action, deferred/_until) and never
+ * translated metadata.target_repos -> canonical target_application. These tests assert
+ * the new preserve-all-minus-leak-guard behavior + target translation.
+ *
+ * Pattern mirrors tests/unit/leo-create-sd-from-proposal.test.js (pure exported mapper).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { validateProposalShape, mapProposalToCreateArgs } from '../../scripts/leo-create-sd.js';
+
+function validProposal(overrides = {}) {
+  return {
+    PROPOSAL: true,
+    status_intended: 'draft',
+    proposed_sd_key: 'SD-LEO-INFRA-EXAMPLE-001',
+    title: 'Example proposal',
+    sd_type: 'infrastructure',
+    priority: 'high',
+    rationale: 'because the belt needs refilling',
+    scope: 'DOES: x. DOES NOT: y.',
+    ...overrides,
+  };
+}
+
+function mapped(proposal) {
+  const n = validateProposalShape(proposal, 'p.json');
+  return mapProposalToCreateArgs(n, proposal, 'p.json');
+}
+
+describe('FR-1/FR-3: preserve Adam-sourcing metadata keys', () => {
+  it('carries min_tier_rank, requires_human_action, deferred/deferred_until onto the SD metadata', () => {
+    const args = mapped(validProposal({
+      sourced_by: 'adam',
+      metadata: { min_tier_rank: 3, requires_human_action: true, deferred: true, deferred_until: '2026-07-01' },
+    }));
+    expect(args.metadata.min_tier_rank).toBe(3);
+    expect(args.metadata.requires_human_action).toBe(true);
+    expect(args.metadata.deferred).toBe(true);
+    expect(args.metadata.deferred_until).toBe('2026-07-01');
+  });
+
+  it('preserves arbitrary custom keys (no longer whitelisted away)', () => {
+    const args = mapped(validProposal({ metadata: { custom_flag: 'keep-me', nested: { a: 1 } } }));
+    expect(args.metadata.custom_flag).toBe('keep-me');
+    expect(args.metadata.nested).toEqual({ a: 1 });
+  });
+
+  it('canonical source still wins over a same-named proposal metadata key', () => {
+    const args = mapped(validProposal({ metadata: { source: 'evil-override' } }));
+    expect(args.metadata.source).toBe('proposal');
+  });
+
+  it('still DROPS the leak-guard keys arch_key / vision_key', () => {
+    const args = mapped(validProposal({ metadata: { arch_key: 'ARCH-1', vision_key: 'VIS-1', keep: 1 } }));
+    expect(args.metadata).not.toHaveProperty('arch_key');
+    expect(args.metadata).not.toHaveProperty('vision_key');
+    expect(args.metadata.keep).toBe(1);
+  });
+});
+
+describe('FR-2/FR-4: translate target_repos -> target_application (validated)', () => {
+  it('sets canonical target_application from the first repo and keeps normalized metadata.target_repos', () => {
+    const args = mapped(validProposal({ metadata: { target_repos: ['EHG'] } }));
+    expect(args.target_application).toBe('EHG');
+    expect(args.metadata.target_repos).toEqual(['EHG']);
+  });
+
+  it('normalizes case/dedup via the shared validator', () => {
+    const args = mapped(validProposal({ metadata: { target_repos: ['ehg', 'EHG', 'ehg_engineer'] } }));
+    expect(args.target_application).toBe('EHG');
+    expect(args.metadata.target_repos).toEqual(['EHG', 'EHG_Engineer']);
+  });
+
+  it('exits(1) on an invalid target_repos value (reuses ALLOWED_REPOS validator)', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new Error(`process.exit(${code})`); });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => mapped(validProposal({ metadata: { target_repos: ['NotARepo'] } }))).toThrow(/process\.exit\(1\)/);
+    expect(errorSpy.mock.calls.flat().join(' ')).toMatch(/INVALID_TARGET_REPOS/);
+    exitSpy.mockRestore(); errorSpy.mockRestore();
+  });
+
+  it('no target_repos -> no target_application override (createSD keeps its default)', () => {
+    const args = mapped(validProposal({ metadata: { min_tier_rank: 2 } }));
+    expect(args).not.toHaveProperty('target_application');
+    expect(args.metadata).not.toHaveProperty('target_repos');
+  });
+});
+
+describe('END-TO-END regression (SD spec scenario)', () => {
+  it('proposal with {min_tier_rank, requires_human_action, target_repos:[EHG]} yields the full canonical mapping', () => {
+    const args = mapped(validProposal({
+      sourced_by: 'adam',
+      metadata: { min_tier_rank: 3, requires_human_action: true, target_repos: ['EHG'] },
+    }));
+    expect(args.metadata.min_tier_rank).toBe(3);
+    expect(args.metadata.requires_human_action).toBe(true);
+    expect(args.target_application).toBe('EHG');
+    expect(args.metadata.target_repos).toEqual(['EHG']);
+    expect(args.metadata.sourced_by).toBe('adam');
+  });
+});


### PR DESCRIPTION
## Summary
The `leo-create-sd.js --from-proposal` ingest built SD metadata from a **closed whitelist**, silently dropping Adam-sourcing keys (`min_tier_rank`, `requires_human_action`, `deferred`/`deferred_until`) and never translating `metadata.target_repos` into the canonical `target_application`. That broke tier-routing and non-claimable governance off a freshly-ingested SD.

- **FR-1:** `mapProposalToCreateArgs` now merges the **full** proposal metadata (canonical defaults win) instead of whitelisting.
- **FR-2/FR-4:** `target_repos[0]` → top-level `target_application` + normalized `metadata.target_repos`, validated via the existing `--target-repos` `ALLOWED_REPOS` check.
- **FR-3:** sourcing keys persist → `requires_human_action` makes the SD non-claimable; `min_tier_rank` routes by tier.
- **Security preserved:** `arch_key`/`vision_key` still dropped (orphan-FK leak-guard); `migration_reviewed`/`security_reviewed` keep their `=== true`-only handling (a preserved `false` cannot leak the flag); `depends_on` keeps its canonical normalization.

## Verification
9 new regression tests + all 96 existing proposal-ingest tests pass (no regression — the drop-set keeps the guarded keys authoritative).

SD: SD-LEO-INFRA-FROM-PROPOSAL-METADATA-PRESERVE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)