### PR TITLE
feat(SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001): ground downstream stages in the operating-model SSOT

### DIFF
--- a/lib/eva/decision-filter-engine.js
+++ b/lib/eva/decision-filter-engine.js
@@ -168,6 +168,13 @@ export function evaluateDecision(input = {}, options = {}) {
   // PRESENT_TO_CHAIRMAN notification but does NOT halt the pipeline.
   // This prevents hard-blocking on budget limits; the Chairman is informed
   // and can intervene if needed.
+  // SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-2: operating-model reconciliation.
+  // EHG ventures (solo + AI-agent, organic GTM, venture-hosting-standard) run at ~$150-900/mo burn —
+  // far below the cost_threshold default ($10k). This trigger is ADVISORY (severity MEDIUM, pipeline
+  // continues), NOT a kill, so S24 already cannot FALSE-KILL an EHG venture on cost. Keep the threshold
+  // comfortably above the operating-model burn bands; do NOT lower it toward generic-SaaS assumptions.
+  // (The deeper design question — whether S24 should weigh cost at all vs. being a pure operational
+  // gate — is escalated to chairman, NOT silently re-classified here.)
   if (input.cost != null) {
     const costMax = getPref(PREFERENCE_KEYS.cost_threshold);
     if (typeof input.cost === 'number' && input.cost > costMax.value) {

--- a/lib/eva/exit/separability-scorer.js
+++ b/lib/eva/exit/separability-scorer.js
@@ -60,23 +60,31 @@ async function scoreIPClarity(ventureId, { supabase }) {
   return { score: Math.min(100, count * 20 + 20), reasoning: `${count} IP assets documented` };
 }
 
+// SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-3 (CRITICAL inversion fix):
+// EHG ventures are solo-founder + ALL-AI-agent labor. For separability/peel-off, the ABSENCE of a
+// human team is the DESIGN GOAL — a zero-team venture is maximally separable / spinout-ready, NOT a
+// risk. The prior scoring REWARDED team presence (hasProfile + contracts), inverting the signal for
+// EHG's operating model and PENALIZING the very design we want. Reframed to OPERATIONAL
+// SELF-SUFFICIENCY: a self-sufficient (AI-agent-run, no human-retention lock-in) venture scores HIGH;
+// human-retention dependencies (contracts/partnerships that lock value to specific people) REDUCE it.
 async function scoreTeamDependency(ventureId, { supabase }) {
-  const { data: profile } = await supabase
-    .from('venture_exit_profiles')
-    .select('notes')
-    .eq('venture_id', ventureId)
-    .eq('is_current', true)
-    .single();
-
   const { data: contracts } = await supabase
     .from('venture_asset_registry')
     .select('asset_type')
     .eq('venture_id', ventureId)
     .in('asset_type', ['contract', 'partnership']);
 
-  const hasProfile = profile ? 30 : 0;
-  const contractCount = (contracts || []).length;
-  return { score: Math.min(100, hasProfile + contractCount * 20 + 20), reasoning: `Profile: ${!!profile}, ${contractCount} contracts` };
+  const humanDependencyCount = (contracts || []).length;
+  // Base 90: a solo + AI-agent venture is operationally self-sufficient by design (no team to retain).
+  // Each human-retention dependency shaves separability; floor at 40 so heavy people-lock-in is
+  // penalized but a documented dependency is never zeroed.
+  const score = Math.max(40, 90 - humanDependencyCount * 15);
+  return {
+    score,
+    reasoning: humanDependencyCount === 0
+      ? 'Operationally self-sufficient: solo + AI-agent run, zero human-team retention dependency — maximally separable / peel-off-ready'
+      : `${humanDependencyCount} human-retention dependency(ies) reduce separability`,
+  };
 }
 
 async function scoreOperationalAutonomy(ventureId, { supabase }) {

--- a/lib/eva/stage-templates/analysis-steps/stage-09-exit-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-09-exit-strategy.js
@@ -59,7 +59,11 @@ Rules:
 - multipleLow < multipleBase < multipleHigh
 - Use Stage 5 revenue projections for revenueBase
 - Milestones should be concrete and time-bound
-- exit_thesis must be specific to this venture, not generic`;
+- exit_thesis must be specific to this venture, not generic
+
+EXIT VALUATION FRAMING (EHG operating model — solo founder + ALL-AI-agent labor):
+- These are SOLO + AI-agent ventures with NO human team to retain. Value the exit on SOFTWARE IP + DATA ASSETS + peel-off/spinout economics, NOT on team-retention multiples or acqui-hire value.
+- The exit_thesis should emphasize separability/peel-off readiness (transferable software, data, and automated operations), not a team that must be retained. Low human-team dependency is a STRENGTH for acquirability here, not a risk.`;
 
 /**
  * Generate exit strategy with valuation and Reality Gate.

--- a/lib/eva/stage-templates/analysis-steps/stage-18-build-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-build-readiness.js
@@ -13,6 +13,9 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+// SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-5: reframe team_readiness as
+// build-infrastructure readiness (exclude human-team assessment).
+import { getOperatingModelPromptBlock } from '../../standards/operating-model.js';
 
 // NOTE: These constants intentionally duplicated from stage-18.js
 // to avoid circular dependency — stage-18.js imports analyzeStage18 from this file,
@@ -104,6 +107,12 @@ ${roadmapContext}
 ${archContext}
 ${riskContext}
 ${financialContext}
+
+${getOperatingModelPromptBlock()}
+
+READINESS FRAMING (EHG operating model — solo founder + ALL-AI-agent labor):
+- The "team_readiness" category means BUILD-INFRASTRUCTURE readiness: architecture, tooling, environment, and the venture-hosting-standard stack (Replit/Neon/Clerk/Gemini/Sentry) — NOT human-team hiring, staffing, or role assignment.
+- Do NOT assess or require human team members, hiring, or roles. The "team" is AI agents + the solo founder; treat readiness as whether the build infrastructure/tooling/env is provisioned.
 
 Output ONLY valid JSON.`;
 

--- a/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js
@@ -18,6 +18,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+// SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-1: organic-first GTM grounding.
+import { getOperatingModelPromptBlock } from '../../standards/operating-model.js';
 // SD-LEO-FEAT-POST-BUILD-LIFECYCLE-001-D (FR-004): pre-launch Growth Playbook co-output.
 import { runPrelaunchGrowthCoOutput } from './prelaunch-growth-playbook.js';
 import { describeArtifactGap } from '../../contracts/describe-artifact-gap.js';
@@ -77,8 +79,14 @@ Rules:
 - Configure at least 3 channels as active
 - Each active channel must have ad copy and targeting
 - Email sequences should reference the S18 copy (welcome, onboarding, re-engagement)
-- Budget allocation based on GTM strategy channel priorities
-- Targeting should use persona demographics (age, interests, pain points)`;
+- Targeting should use persona demographics (age, interests, pain points)
+
+${getOperatingModelPromptBlock()}
+
+DISTRIBUTION RULES (EHG operating model — organic-first GTM, solo + AI-agent):
+- ORGANIC channels (twitter_x/X, Bluesky, blog_seo + Stage-18 AI-generated copy, email) are the PRIMARY/default at launch.
+- PAID channels (google_ads, facebook_instagram) are SECONDARY — a later-stage opt-in, with $0 budget at launch.
+- budget_allocation at launch should be ~$0 paid: weight organic. Total monthly should reflect the operating-model marketing band ($0-200/mo), NOT a generic paid-ads budget.`;
 
 /**
  * Pure helper. Normalizes worker-provided upstream params into the bespoke
@@ -186,6 +194,22 @@ export function validateChannelCoverage(channels) {
   return true;
 }
 
+// SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-1: flag (advisory, non-blocking) when
+// PAID channels (google_ads/facebook_instagram) exceed 20% of the budget allocation — EHG's GTM is
+// organic-first, so heavy paid spend at launch contradicts the operating model. Pure + exported.
+const PAID_CHANNELS = ['google_ads', 'facebook_instagram', 'paid_search', 'paid_social'];
+export function paidBudgetAdvisory(budgetAllocation) {
+  const byChannel = (budgetAllocation && budgetAllocation.by_channel) || {};
+  const pct = (v) => { const n = parseFloat(String(v).replace('%', '').trim()); return Number.isFinite(n) ? n : 0; };
+  const paidPct = Object.entries(byChannel)
+    .filter(([ch]) => PAID_CHANNELS.includes(String(ch).toLowerCase()))
+    .reduce((sum, [, v]) => sum + pct(v), 0);
+  if (paidPct > 20) {
+    return { flagged: true, paid_pct: paidPct, message: `Paid channels are ${paidPct}% of budget (>20%) — EHG GTM is organic-first; paid is a later-stage opt-in. Re-weight toward organic.` };
+  }
+  return { flagged: false, paid_pct: paidPct };
+}
+
 /**
  * Pure helper. Splits the LLM result object into the canonical pair payloads.
  */
@@ -200,6 +224,9 @@ export function splitArtifacts(result) {
     total_channels: channels.length,
     active_channels: channels.filter(ch => (typeof ch.enabled === 'boolean' ? ch.enabled : ch.status === 'active')).length,
     budget_allocation: result.budget_allocation || {},
+    // SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-1: advisory when paid spend exceeds
+    // the organic-first default. Non-blocking — surfaces over-reliance on paid acquisition at launch.
+    paid_budget_advisory: paidBudgetAdvisory(result.budget_allocation),
   };
   const adCopy = {
     channels_with_copy: channels

--- a/lib/eva/stage-templates/analysis-steps/stage-26-growth-playbook.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-26-growth-playbook.js
@@ -37,6 +37,9 @@
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { ARTIFACT_TYPES } from '../../artifact-types.js';
+// SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-4: ground growth scaling in EHG's
+// operating model (solo + AI-agent labor) and FORBID human hiring/headcount scenarios.
+import { getOperatingModelPromptBlock } from '../../standards/operating-model.js';
 
 const POSTLAUNCH_ARTIFACT_KEYS = [
   ARTIFACT_TYPES.LAUNCH_POSTLAUNCH_ASSUMPTIONS_VS_REALITY,
@@ -64,7 +67,14 @@ Output valid JSON:
     "month_2": "Focus area",
     "month_3": "Focus area"
   }
-}`;
+}
+
+${getOperatingModelPromptBlock()}
+
+CONSTRAINTS (EHG operating model — solo founder + ALL-AI-agent labor, ZERO human team):
+- scaling_priorities MUST be limited to: infrastructure, product/features, and data.
+- DO NOT propose hiring, headcount growth, team buildout, recruiting, or any human-team scaling.
+- "Scale" means more compute/automation/AI-agent capacity and product surface — never more people.`;
 
 /**
  * Determine no-data reason given upstream stage availability + venture state.

--- a/tests/unit/eva/downstream-operating-model-propagation.test.js
+++ b/tests/unit/eva/downstream-operating-model-propagation.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 regression tests for the code-level
+// invariants (the prompt-injection FRs are verified by inspection / the producers' own suites).
+
+describe('FR-3: S25 separability — zero-team venture is NOT penalized (inversion fixed)', () => {
+  // Complete supabase stub: `.in()` resolves contract rows (terminal), `.single()` resolves a row
+  // (terminal for eva_ventures + the persist .select().single()).
+  function makeSupabase(contractRows) {
+    return {
+      from() {
+        const b = {
+          select() { return b; },
+          eq() { return b; },
+          insert() { return b; },
+          in() { return Promise.resolve({ data: contractRows, error: null }); },
+          single() { return Promise.resolve({ data: { id: 'row1', status: 'active' }, error: null }); },
+        };
+        return b;
+      },
+    };
+  }
+  async function teamDep(contractRows) {
+    const mod = await import('../../../lib/eva/exit/separability-scorer.js');
+    const result = await mod.computeSeparabilityScore('v1', { supabase: makeSupabase(contractRows), logger: { warn() {}, error() {}, info() {} } });
+    return { score: result.team_dependency, reasoning: result.metadata.reasoning.team_dependency };
+  }
+
+  it('zero human-retention dependency scores HIGH (self-sufficient, peel-off ready)', async () => {
+    const { score, reasoning } = await teamDep([]);
+    expect(score).toBe(90);
+    expect(reasoning).toMatch(/self-sufficient|maximally separable|peel-off/i);
+  });
+
+  it('human-retention dependencies REDUCE the score (but never zero it)', async () => {
+    const { score } = await teamDep([{ asset_type: 'contract' }, { asset_type: 'partnership' }]);
+    expect(score).toBe(60); // 90 - 2*15
+  });
+
+  it('floors at 40 under heavy people-lock-in (no longer rewards team presence)', async () => {
+    const many = Array.from({ length: 10 }, () => ({ asset_type: 'contract' }));
+    const { score } = await teamDep(many);
+    expect(score).toBe(40);
+  });
+});
+
+describe('FR-1: S22 paid-budget advisory', () => {
+  it('flags when paid channels exceed 20% of budget', async () => {
+    const { paidBudgetAdvisory } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js');
+    const r = paidBudgetAdvisory({ by_channel: { google_ads: '40%', facebook_instagram: '35%', twitter_x: '15%', blog_seo: '10%' } });
+    expect(r.flagged).toBe(true);
+    expect(r.paid_pct).toBe(75);
+  });
+
+  it('does NOT flag an organic-first allocation (paid <= 20%)', async () => {
+    const { paidBudgetAdvisory } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js');
+    const r = paidBudgetAdvisory({ by_channel: { twitter_x: '50%', blog_seo: '40%', google_ads: '10%' } });
+    expect(r.flagged).toBe(false);
+    expect(r.paid_pct).toBe(10);
+  });
+
+  it('treats $0 paid (organic-only) as not flagged', async () => {
+    const { paidBudgetAdvisory } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-22-distribution-setup.js');
+    const r = paidBudgetAdvisory({ by_channel: { twitter_x: '60%', email: '40%' } });
+    expect(r.flagged).toBe(false);
+    expect(r.paid_pct).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
EHG ventures are solo-founder + ALL-AI-agent labor (zero human team). The downstream EVA producers still assumed human teams / paid ads / generic SaaS cost — most critically the **S25 exit/separability scorer PENALIZED EHG's zero-team design**. This propagates the operating-model SSOT (from #5158) downstream.

- **FR-3 (CRITICAL):** S25 `scoreTeamDependency` inversion **FIXED** — reframed to operational self-sufficiency; a zero-human-team venture now scores HIGH (maximally separable / peel-off ready) instead of being penalized.
- **FR-1:** S22 distribution — organic-first GTM (X/Bluesky + Stage-18 copy) PRIMARY, paid SECONDARY ($0 launch); `paidBudgetAdvisory` flags paid >20%.
- **FR-4:** S26 growth — forbid hiring/headcount; constrain scaling to infra/product/data.
- **FR-5:** S18 — reframe `team_readiness` as build-infrastructure readiness (key kept for compat → zero fixture churn).
- **FR-6:** S09 — value exit on software IP + data + peel-off economics, not team-retention multiples.
- **FR-2:** S24 cost — documented operating-model reconciliation. The cost trigger is already **advisory** (not a kill) and the threshold sits far above EHG burn, so S24 cannot false-kill on cost; the deeper 'should S24 weigh cost at all' design question is **escalated to chairman, NOT silently re-classified**.

## Verification
6 new regression tests (S25 inversion: 90/zero-team, 60/2-deps, 40-floor; S22 advisory) + existing producer/separability tests pass; all 6 edited files pass `node --check`.

SD: SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)