### PR TITLE
fix(SD-LEO-INFRA-S16-PROFITABLE-RUNWAY-CONTRACT-001): profitable runway null sentinel + contract required:false

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -269,7 +269,8 @@ const STAGE_CONTRACTS = new Map([
       }},
     ],
     produces: {
-      runway_months: { type: 'number' },
+      runway_months: { type: 'number', required: false },
+      runway_unbounded: { type: 'boolean', required: false },
       promotion_gate: { type: 'object' },
     },
   }],
@@ -279,7 +280,7 @@ const STAGE_CONTRACTS = new Map([
     consumes: [
       { stage: 13, fields: { milestones: { type: 'array' } }},
       { stage: 14, fields: { layers: { type: 'object' }, risks: { type: 'array' } }},
-      { stage: 16, fields: { runway_months: { type: 'number' } }},
+      { stage: 16, fields: { runway_months: { type: 'number', required: false } }},
     ],
     produces: {
       decision: { type: 'string' },

--- a/lib/eva/contracts/stage-contracts.yaml
+++ b/lib/eva/contracts/stage-contracts.yaml
@@ -331,7 +331,8 @@ stages:
         fields:
           risks: { type: array, minItems: 1 }
     produces:
-      runway_months: { type: number }
+      runway_months: { type: number, required: false }
+      runway_unbounded: { type: boolean, required: false }
       promotion_gate: { type: object }
 
   17:
@@ -348,7 +349,7 @@ stages:
           risks: { type: array }
       - stage: 16
         fields:
-          runway_months: { type: number }
+          runway_months: { type: number, required: false }
     produces:
       checklist: { type: object }
       readiness_pct: { type: number }
@@ -474,7 +475,7 @@ stages:
           milestones: { type: array }
       - stage: 16
         fields:
-          runway_months: { type: number }
+          runway_months: { type: number, required: false }
       - stage: 23
         fields:
           incident_response_plan: { type: string, required: false }

--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -237,15 +237,28 @@ Output ONLY valid JSON.`;
   // ignored revenue AND the growing burn). Runway = the count of leading months whose running cash
   // balance stays >= 0 (i.e. months you can operate before insolvency). If the balance never goes
   // negative, runway >= the projection length — Infinity only when net burn over the period is non-negative.
+  // SD-LEO-INFRA-S16-PROFITABLE-RUNWAY-CONTRACT-001: profitable ventures emit null+runway_unbounded=true
+  // instead of Infinity — Infinity silently becomes null in JSON.stringify, losing the signal.
   let runway_months;
+  let runway_unbounded = false;
   if (revenue_projections.length === 0) {
-    runway_months = burn_rate > 0 ? Math.round((initial_capital / burn_rate) * 100) / 100 : (initial_capital > 0 ? Infinity : 0);
+    if (burn_rate > 0) {
+      runway_months = Math.round((initial_capital / burn_rate) * 100) / 100;
+    } else if (initial_capital > 0) {
+      runway_months = null;
+      runway_unbounded = true;
+    } else {
+      runway_months = 0;
+    }
   } else if (negativeMonth) {
     let positiveMonths = 0;
     for (const cb of cash_balance_end) { if (cb.balance >= 0) positiveMonths++; else break; }
     runway_months = positiveMonths;
+  } else if (net_total >= 0) {
+    runway_months = null;
+    runway_unbounded = true;
   } else {
-    runway_months = net_total >= 0 ? Infinity : revenue_projections.length;
+    runway_months = revenue_projections.length;
   }
 
   // Break-even month
@@ -320,7 +333,7 @@ Output ONLY valid JSON.`;
       consecutiveLoss = 0;
     }
   }
-  if (runway_months !== Infinity && runway_months < 6) {
+  if (!runway_unbounded && runway_months !== null && runway_months < 6) {
     viability_warnings.push(`Short runway: ${runway_months} months (recommended: >= 6)`);
   }
   if (break_even_month === null && revenue_projections.length > 0) {
@@ -353,6 +366,7 @@ Output ONLY valid JSON.`;
     total_projected_revenue,
     total_projected_costs,
     runway_months,
+    runway_unbounded,
     burn_rate,
     break_even_month,
     pnl,

--- a/tests/eva/stage-16-profitable-runway.test.js
+++ b/tests/eva/stage-16-profitable-runway.test.js
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for SD-LEO-INFRA-S16-PROFITABLE-RUNWAY-CONTRACT-001
+ *
+ * Verifies that the S16 post-stage contract validator:
+ * - ACCEPTS profitable ventures that emit { runway_months: null, runway_unbounded: true }
+ * - Does NOT regress on short-runway ventures with a finite runway_months value
+ */
+import { describe, it, expect } from 'vitest';
+import { validatePostStage } from '../../lib/eva/contracts/stage-contracts.js';
+
+const PROMOTION_GATE_STUB = {
+  decision: 'PROMOTE',
+  score: 85,
+};
+
+describe('S16 post-stage contract — profitable runway sentinel', () => {
+  it('accepts a profitable venture with null runway_months + runway_unbounded=true', () => {
+    const profitableOutput = {
+      runway_months: null,
+      runway_unbounded: true,
+      promotion_gate: PROMOTION_GATE_STUB,
+    };
+    const result = validatePostStage(16, profitableOutput);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('accepts a short-runway venture with finite runway_months (regression)', () => {
+    const shortRunwayOutput = {
+      runway_months: 4,
+      runway_unbounded: false,
+      promotion_gate: PROMOTION_GATE_STUB,
+    };
+    const result = validatePostStage(16, shortRunwayOutput);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects an S16 output missing promotion_gate entirely', () => {
+    const missingGate = {
+      runway_months: 12,
+      runway_unbounded: false,
+    };
+    const result = validatePostStage(16, missingGate);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('promotion_gate'))).toBe(true);
+  });
+
+  it('JSON round-trip: null runway is explicit, not a lost Infinity', () => {
+    const output = { runway_months: null, runway_unbounded: true };
+    const serialized = JSON.stringify(output);
+    const parsed = JSON.parse(serialized);
+    expect(parsed.runway_months).toBeNull();
+    expect(parsed.runway_unbounded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- S16 post-stage contract validator blocked every profitable venture: `runway_months=Infinity` was rejected by `Number.isFinite()` in the contract engine
- Producer now emits `{ runway_months: null, runway_unbounded: true }` sentinel — explicit null that survives JSON serialization (Infinity → null is silent lossy)
- S16 produces + S17/S25 consume contracts set `required: false` so null runway passes validation
- Short-runway warning guard updated from `!== Infinity` to `!runway_unbounded`
- 4 regression tests added, all passing

## Files changed
- `lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js` — sentinel emission + warning guard
- `lib/eva/contracts/stage-contracts.js` — S16 produces + S17 consumes `required: false`
- `lib/eva/contracts/stage-contracts.yaml` — YAML parity for S16/S17/S25
- `tests/eva/stage-16-profitable-runway.test.js` — regression tests (new)

## Test plan
- [ ] `npx vitest run tests/eva/stage-16-profitable-runway.test.js` — 4 tests pass
- [ ] Manual smoke: `validatePostStage(16, {runway_months:null, runway_unbounded:true, promotion_gate:{}})` → `valid: true errors: []`
- [ ] Regression: `validatePostStage(16, {runway_months:4, runway_unbounded:false, promotion_gate:{}})` → `valid: true errors: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)