### PR TITLE
feat(SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001): agentic-fit venture-selection lens

### DIFF
--- a/database/migrations/20260627_agentic_fit_weight.sql
+++ b/database/migrations/20260627_agentic_fit_weight.sql
@@ -1,0 +1,24 @@
+-- SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4 / FR-6)
+-- Add the agentic_fit weight + multiplier params to evaluation_profiles so the
+-- agentic-fit lens is a weighted COMPONENT of the Stage-0 venture_score, and the
+-- (deferred) calibration loop can re-tune the weight/params without a code edit.
+--
+-- v1 ratified starting hypothesis: weight 0.10 (additive to existing components;
+-- the weighted score sums contributions, it does not require weights to total 1.0).
+-- Multiplier params live alongside the weights as a config SSOT.
+-- Idempotent: only sets agentic_fit when it is not already present.
+
+UPDATE public.evaluation_profiles
+SET weights = weights || '{"agentic_fit": 0.10}'::jsonb,
+    updated_at = now()
+WHERE NOT (weights ? 'agentic_fit');
+
+-- Machine-improvement multiplier params (config SSOT; jsonb column added if absent).
+ALTER TABLE public.evaluation_profiles
+  ADD COLUMN IF NOT EXISTS agentic_fit_params jsonb
+  DEFAULT '{"multiplier_max_bonus": 0.5, "agent_leverage_floor": 30}'::jsonb;
+
+UPDATE public.evaluation_profiles
+SET agentic_fit_params = '{"multiplier_max_bonus": 0.5, "agent_leverage_floor": 30}'::jsonb,
+    updated_at = now()
+WHERE agentic_fit_params IS NULL;

--- a/database/migrations/20260627_agentic_fit_weight.sql
+++ b/database/migrations/20260627_agentic_fit_weight.sql
@@ -1,19 +1,15 @@
 -- SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4 / FR-6)
--- Add the agentic_fit weight + multiplier params to evaluation_profiles so the
--- agentic-fit lens is a weighted COMPONENT of the Stage-0 venture_score, and the
--- (deferred) calibration loop can re-tune the weight/params without a code edit.
+-- Make agentic_fit a weighted COMPONENT of the Stage-0 venture_score and store the
+-- machine-improvement multiplier params in the evaluation_profiles config SSOT so the
+-- (deferred) calibration loop can re-tune them without a code edit.
 --
--- v1 ratified starting hypothesis: weight 0.10 (additive to existing components;
--- the weighted score sums contributions, it does not require weights to total 1.0).
--- Multiplier params live alongside the weights as a config SSOT.
--- Idempotent: only sets agentic_fit when it is not already present.
+-- IMPORTANT: calculateWeightedScore() does NOT normalize by the weight sum, so the weights
+-- must keep totalling ~1.0 (venture_score stays 0-100). agentic_fit takes a 0.10 budget and
+-- the pre-existing component weights are rescaled to total 0.90 (relative ordering preserved).
+-- This migration applies that rebalance per profile (idempotent — skips profiles already
+-- carrying agentic_fit).
 
-UPDATE public.evaluation_profiles
-SET weights = weights || '{"agentic_fit": 0.10}'::jsonb,
-    updated_at = now()
-WHERE NOT (weights ? 'agentic_fit');
-
--- Machine-improvement multiplier params (config SSOT; jsonb column added if absent).
+-- Multiplier params (config SSOT; jsonb column added if absent).
 ALTER TABLE public.evaluation_profiles
   ADD COLUMN IF NOT EXISTS agentic_fit_params jsonb
   DEFAULT '{"multiplier_max_bonus": 0.5, "agent_leverage_floor": 30}'::jsonb;
@@ -22,3 +18,30 @@ UPDATE public.evaluation_profiles
 SET agentic_fit_params = '{"multiplier_max_bonus": 0.5, "agent_leverage_floor": 30}'::jsonb,
     updated_at = now()
 WHERE agentic_fit_params IS NULL;
+
+-- Rebalance: rescale every existing weight to total 0.90, then add agentic_fit = 0.10.
+-- Done in PL/pgSQL so the rescale handles each profile's own current weight map.
+DO $$
+DECLARE
+  p RECORD;
+  k TEXT;
+  v NUMERIC;
+  others_sum NUMERIC;
+  scale NUMERIC;
+  new_w JSONB;
+BEGIN
+  FOR p IN SELECT id, weights FROM public.evaluation_profiles WHERE NOT (weights ? 'agentic_fit') LOOP
+    others_sum := 0;
+    FOR k, v IN SELECT key, value::numeric FROM jsonb_each_text(p.weights) LOOP
+      others_sum := others_sum + v;
+    END LOOP;
+    IF others_sum <= 0 THEN CONTINUE; END IF;
+    scale := 0.90 / others_sum;
+    new_w := '{}'::jsonb;
+    FOR k, v IN SELECT key, value::numeric FROM jsonb_each_text(p.weights) LOOP
+      new_w := new_w || jsonb_build_object(k, round(v * scale, 3));
+    END LOOP;
+    new_w := new_w || '{"agentic_fit": 0.10}'::jsonb;
+    UPDATE public.evaluation_profiles SET weights = new_w, updated_at = now() WHERE id = p.id;
+  END LOOP;
+END $$;

--- a/lib/eva/stage-templates/stage-03.js
+++ b/lib/eva/stage-templates/stage-03.js
@@ -22,6 +22,7 @@
 import { validateInteger, validateString, validateEnum, collectErrors, validateCrossStageContract } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage03 } from './analysis-steps/stage-03-hybrid-scoring.js';
+import { buildAgenticFitAdvisory } from '../stage-zero/synthesis/agentic-fit.js';
 
 const METRICS = [
   'marketFit',
@@ -178,10 +179,15 @@ const TEMPLATE = {
  * @param {{ overallScore: number, metrics: Object }} params
  * @returns {{ decision: 'pass'|'revise'|'kill', blockProgression: boolean, reasons: Object[] }}
  */
-export function evaluateKillGate({ overallScore, metrics }) {
+export function evaluateKillGate({ overallScore, metrics, agenticFit }) {
   const reasons = [];
   const metricValues = Object.values(metrics);
   const maxMetric = metricValues.length ? Math.max(...metricValues) : 0;
+
+  // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4 secondary): surface agentic_fit as an
+  // ADVISORY signal at S3 — never a kill, never affects blockProgression or thresholds.
+  // S5 stays the first authoritative economic kill.
+  const agenticAdvisory = buildAgenticFitAdvisory(agenticFit);
 
   // KILL — catastrophic only: overall below the floor AND no redeeming dimension (FR-1/FR-2).
   if (overallScore < S3_CATASTROPHIC_OVERALL && maxMetric < S3_CATASTROPHIC_METRIC_FLOOR) {
@@ -196,7 +202,7 @@ export function evaluateKillGate({ overallScore, metrics }) {
 
   // PASS — strong composite (a weak single metric is absorbed by the whole).
   if (overallScore >= PASS_THRESHOLD) {
-    return { decision: 'pass', blockProgression: false, reasons: [] };
+    return { decision: 'pass', blockProgression: false, reasons: agenticAdvisory ? [agenticAdvisory] : [] };
   }
 
   // REVISE — advisory. Sub-threshold metrics are surfaced as ADVISORY context only (they do NOT kill, FR-1).
@@ -217,6 +223,7 @@ export function evaluateKillGate({ overallScore, metrics }) {
     threshold: PASS_THRESHOLD,
     actual: overallScore,
   });
+  if (agenticAdvisory) reasons.push(agenticAdvisory);
   return { decision: 'revise', blockProgression: true, reasons };
 }
 

--- a/lib/eva/stage-zero/profile-service.js
+++ b/lib/eva/stage-zero/profile-service.js
@@ -24,6 +24,10 @@ const LEGACY_WEIGHTS = {
   build_cost: 0.10,
   virality: 0.13,
   tech_trajectory: 0.05,
+  // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4): agentic-fit is an additive weighted
+  // component of the Stage-0 venture_score. v1 ratified starting weight; re-tunable via the
+  // evaluation_profiles config SSOT (this is only the legacy fallback).
+  agentic_fit: 0.10,
 };
 
 /**
@@ -242,6 +246,10 @@ function extractComponentScore(component, result) {
       return clamp(result.virality_score ?? 0, 0, 100);
     case 'tech_trajectory':
       return clamp(result.trajectory_score ?? 0, 0, 100);
+    case 'agentic_fit':
+      // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4): the post-multiplier/disadvantage
+      // 0-100 agentic_fit_score feeds the weighted venture_score component.
+      return clamp(result.agentic_fit_score ?? 0, 0, 100);
     default:
       return 0;
   }

--- a/lib/eva/stage-zero/profile-service.js
+++ b/lib/eva/stage-zero/profile-service.js
@@ -13,21 +13,22 @@
  * Default legacy weights used when no profile is available.
  * These match the original hardcoded behavior before profiles were introduced.
  */
+// SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4): agentic-fit joins the weighted Stage-0
+// venture_score. calculateWeightedScore does NOT normalize by the weight sum, so the weights
+// must still total ~1.0 to keep venture_score in 0-100. agentic_fit takes a 0.10 budget; the
+// pre-existing 10 weights are scaled by 0.9 (relative ordering preserved) to make room.
 const LEGACY_WEIGHTS = {
-  cross_reference: 0.10,
-  portfolio_evaluation: 0.10,
-  problem_reframing: 0.05,
-  moat_architecture: 0.13,
-  chairman_constraints: 0.14,
-  time_horizon: 0.10,
-  archetypes: 0.10,
-  build_cost: 0.10,
-  virality: 0.13,
-  tech_trajectory: 0.05,
-  // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4): agentic-fit is an additive weighted
-  // component of the Stage-0 venture_score. v1 ratified starting weight; re-tunable via the
-  // evaluation_profiles config SSOT (this is only the legacy fallback).
-  agentic_fit: 0.10,
+  cross_reference: 0.09,
+  portfolio_evaluation: 0.09,
+  problem_reframing: 0.045,
+  moat_architecture: 0.117,
+  chairman_constraints: 0.126,
+  time_horizon: 0.09,
+  archetypes: 0.09,
+  build_cost: 0.09,
+  virality: 0.117,
+  tech_trajectory: 0.045,
+  agentic_fit: 0.10, // v1 ratified starting weight; re-tunable via the evaluation_profiles SSOT
 };
 
 /**

--- a/lib/eva/stage-zero/synthesis/agentic-fit.js
+++ b/lib/eva/stage-zero/synthesis/agentic-fit.js
@@ -1,0 +1,307 @@
+/**
+ * Synthesis Component: Agentic-Fit Venture-Selection Lens
+ *
+ * Scores ideas on EHG's unfair-advantage axis — can an AI-agent fleet do most of the
+ * work, does it compound, can demand be validated cheaply/fast, and does it need chairman
+ * taste only at gates. A SEPARATE machine-improvement multiplier lets a factory-improving
+ * venture jump the queue even with middling per-venture fit. A disadvantage filter SOFT
+ * down-weights + prominently FLAGS structurally-hard idea types (never a hard auto-kill —
+ * matches soft-early-gate calibration + preserves chairman override).
+ *
+ * Four fit dimensions (0-100 each), weights from the config SSOT (evaluation_profiles):
+ *  - agent_leverage    0.35  can AI agents do most of the work (incl. standardizable workflow)
+ *  - compounding       0.25  reusable assets + a template for future ventures
+ *  - kill_speed        0.20  cheap/fast demand validation (portfolio throughput)
+ *  - attention_economy 0.20  needs chairman taste only at gates
+ *
+ * agentic_fit is a weighted COMPONENT of the Stage-0 venture_score (primary insertion) and
+ * an ADVISORY signal at S3 (NOT a kill — S5 stays the first authoritative economic kill).
+ *
+ * Part of SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001
+ */
+
+import { getValidationClient } from '../../../llm/client-factory.js';
+import { extractUsage } from '../../utils/parse-json.js';
+
+// ---------------------------------------------------------------------------
+// Config SSOT v1 (ratified starting hypothesis). The CANONICAL re-tunable copy
+// lives in evaluation_profiles.weights / .agentic_fit_params (so the deferred
+// calibration loop can re-tune without a code edit); these are the defaults +
+// fallback when no profile value is present.
+// ---------------------------------------------------------------------------
+export const AF_WEIGHTS = {
+  agent_leverage: 0.35,
+  compounding: 0.25,
+  kill_speed: 0.20,
+  attention_economy: 0.20,
+};
+
+export const AF_DIMENSIONS = Object.keys(AF_WEIGHTS);
+
+// Near-threshold: a very low agent_leverage must SINK the composite (the
+// standardizable-workflow axis dominates — a venture agents cannot run is not a fit
+// no matter how strong the other dimensions). Below the floor, the composite is scaled
+// down proportionally (leverage/floor), so leverage=0 → composite 0.
+export const AGENT_LEVERAGE_FLOOR = 30;
+
+// Machine-improvement multiplier params: a bonus of up to MAX_BONUS applied on TOP of the
+// fit composite (NOT a 5th weighted dimension), so a high-machine-improvement venture can
+// outrank an equal-fit peer (queue jump).
+export const AF_MULTIPLIER_PARAMS = {
+  max_bonus: 0.5, // a machine_improvement of 100 adds +50% to the composite
+};
+
+// Disadvantage types: SOFT down-weight + prominent flag. NEVER a hard auto-kill.
+// The two structurally-un-agent-able subtypes are flagged HARDEST for chairman review.
+export const DISADVANTAGE_FACTORS = {
+  capital_heavy: 0.85,
+  human_trust_dependent: 0.85,
+  deep_rd_moat: 0.85,
+  winner_take_all: 0.9,
+  // hardest — structurally un-agent-able; heavier soft down-weight + chairman_review flag
+  requires_regulatory_permission: 0.7,
+  requires_large_upfront_capital: 0.7,
+};
+
+export const HARDEST_DISADVANTAGES = ['requires_regulatory_permission', 'requires_large_upfront_capital'];
+
+export const AGENTIC_FIT_BANDS = [
+  { min: 0, max: 24, band: 'AF-Low', interpretation: 'Weak agentic fit — agents cannot run most of the work' },
+  { min: 25, max: 49, band: 'AF-Moderate', interpretation: 'Partial agentic fit — meaningful human/leverage gaps' },
+  { min: 50, max: 74, band: 'AF-High', interpretation: 'Strong agentic fit — agent-runnable and compounding' },
+  { min: 75, max: 100, band: 'AF-Strong', interpretation: 'Exceptional agentic fit — agent-native, compounding, chairman-light' },
+];
+
+function clamp(value, min, max) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, n));
+}
+
+/**
+ * Compute the 0-100 agentic-fit COMPOSITE (the four weighted fit dimensions, with the
+ * near-threshold agent_leverage rule). Multiplier + disadvantage filter are applied
+ * separately by scoreAgenticFit — this is the pure fit composite.
+ * @param {{agent_leverage,compounding,kill_speed,attention_economy}} dims  0-100 each
+ * @param {object} [weights=AF_WEIGHTS]  config-driven weights (SSOT)
+ * @returns {number} 0-100
+ */
+export function computeAgenticFitScore(dims, weights = AF_WEIGHTS) {
+  if (!dims) return 0;
+  const w = weights || AF_WEIGHTS;
+  const leverage = clamp(dims.agent_leverage ?? 0, 0, 100);
+  const weighted =
+    leverage * (w.agent_leverage ?? AF_WEIGHTS.agent_leverage) +
+    clamp(dims.compounding ?? 0, 0, 100) * (w.compounding ?? AF_WEIGHTS.compounding) +
+    clamp(dims.kill_speed ?? 0, 0, 100) * (w.kill_speed ?? AF_WEIGHTS.kill_speed) +
+    clamp(dims.attention_economy ?? 0, 0, 100) * (w.attention_economy ?? AF_WEIGHTS.attention_economy);
+
+  // Near-threshold sink: below the agent_leverage floor, scale the composite down
+  // proportionally so a structurally un-agent-able idea cannot ride high on the other dims.
+  const sink = leverage < AGENT_LEVERAGE_FLOOR ? leverage / AGENT_LEVERAGE_FLOOR : 1;
+  return Math.round(clamp(weighted, 0, 100) * sink);
+}
+
+/**
+ * Apply the machine-improvement MULTIPLIER on top of the fit composite (separate from the
+ * weighted dimensions, so a high-machine-improvement venture can jump the queue).
+ * @param {number} composite  0-100 fit composite
+ * @param {number} machineImprovement  0-100
+ * @param {object} [params=AF_MULTIPLIER_PARAMS]
+ * @returns {{score:number, bonus:number}} score is NOT clamped to 100 — a queue-jumper may exceed 100
+ */
+export function applyMachineImprovementMultiplier(composite, machineImprovement, params = AF_MULTIPLIER_PARAMS) {
+  const p = params || AF_MULTIPLIER_PARAMS;
+  const mi = clamp(machineImprovement ?? 0, 0, 100);
+  const bonus = (mi / 100) * (p.max_bonus ?? AF_MULTIPLIER_PARAMS.max_bonus);
+  return { score: Math.round(clamp(composite, 0, 100) * (1 + bonus)), bonus };
+}
+
+/**
+ * Classify disadvantage flags into a SOFT down-weight factor + prominent flags. Never a
+ * hard auto-kill. The hardest (un-agent-able) subtypes set chairman_review_required.
+ * @param {string[]} flags  e.g. ['capital_heavy','requires_large_upfront_capital']
+ * @returns {{downWeightFactor:number, flags:string[], chairman_review_required:boolean, hardest_flags:string[]}}
+ */
+export function classifyDisadvantages(flags) {
+  const list = Array.isArray(flags) ? flags.filter((f) => typeof f === 'string') : [];
+  let factor = 1;
+  const recognized = [];
+  const hardest = [];
+  for (const f of list) {
+    if (Object.prototype.hasOwnProperty.call(DISADVANTAGE_FACTORS, f)) {
+      factor *= DISADVANTAGE_FACTORS[f];
+      recognized.push(f);
+      if (HARDEST_DISADVANTAGES.includes(f)) hardest.push(f);
+    }
+  }
+  return {
+    downWeightFactor: factor,
+    flags: recognized,
+    hardest_flags: hardest,
+    chairman_review_required: hardest.length > 0,
+  };
+}
+
+/** Map a 0-100 agentic-fit score to a governance band. */
+export function classifyAgenticFitBand(score) {
+  const s = clamp(Math.round(score), 0, 100);
+  for (const b of AGENTIC_FIT_BANDS) if (s >= b.min && s <= b.max) return { band: b.band, interpretation: b.interpretation };
+  return { band: 'AF-Strong', interpretation: AGENTIC_FIT_BANDS[AGENTIC_FIT_BANDS.length - 1].interpretation };
+}
+
+/**
+ * Full agentic-fit scoring: composite -> machine-improvement multiplier -> soft disadvantage
+ * down-weight, recording every sub-score/flag for chairman explainability (FR-5).
+ * @param {object} input
+ * @param {object} input.dimensions  {agent_leverage,compounding,kill_speed,attention_economy} 0-100
+ * @param {number} [input.machine_improvement=0]  0-100
+ * @param {string[]} [input.disadvantage_flags=[]]
+ * @param {object} [config]  {weights, multiplier_params} config-SSOT overrides
+ * @returns {object} the full transparent record
+ */
+export function scoreAgenticFit(input, config = {}) {
+  const dims = (input && input.dimensions) || {};
+  const weights = config.weights || AF_WEIGHTS;
+  const multParams = config.multiplier_params || AF_MULTIPLIER_PARAMS;
+
+  const fit_composite = computeAgenticFitScore(dims, weights);
+  const { score: afterMultiplier, bonus } = applyMachineImprovementMultiplier(
+    fit_composite,
+    input?.machine_improvement ?? 0,
+    multParams,
+  );
+  const disadvantage = classifyDisadvantages(input?.disadvantage_flags ?? []);
+  const agentic_fit_score = Math.round(clamp(afterMultiplier * disadvantage.downWeightFactor, 0, 100));
+  const { band, interpretation } = classifyAgenticFitBand(agentic_fit_score);
+
+  return {
+    component: 'agentic_fit',
+    agentic_fit_score, // 0-100 final (clamped) — what feeds the Stage-0 weighted component
+    fit_composite, // 0-100 pre-multiplier/disadvantage
+    queue_jump_score: afterMultiplier, // may exceed 100 — used for cross-venture ranking
+    dimension_scores: {
+      agent_leverage: clamp(dims.agent_leverage ?? 0, 0, 100),
+      compounding: clamp(dims.compounding ?? 0, 0, 100),
+      kill_speed: clamp(dims.kill_speed ?? 0, 0, 100),
+      attention_economy: clamp(dims.attention_economy ?? 0, 0, 100),
+    },
+    machine_improvement: clamp(input?.machine_improvement ?? 0, 0, 100),
+    machine_improvement_bonus: bonus,
+    disadvantage_flags: disadvantage.flags,
+    disadvantage_down_weight: disadvantage.downWeightFactor,
+    hardest_disadvantage_flags: disadvantage.hardest_flags,
+    chairman_review_required: disadvantage.chairman_review_required,
+    af_band: band,
+    af_interpretation: interpretation,
+  };
+}
+
+/**
+ * Build an ADVISORY (non-kill) S3 signal from an agentic-fit record (FR-4 secondary).
+ * Returns null when there is no record (so callers can skip). NEVER carries a kill verdict —
+ * S5 stays the first authoritative economic kill; this only surfaces the agentic-fit read +
+ * any chairman-review disadvantage flags as advisory context at S3.
+ * @param {object} record  a scoreAgenticFit() result (or the persisted agentic_fit snapshot)
+ * @returns {{type:string, message:string, agentic_fit_score:number, af_band:string, chairman_review_required:boolean, disadvantage_flags:string[]}|null}
+ */
+export function buildAgenticFitAdvisory(record) {
+  if (!record || typeof record !== 'object') return null;
+  const score = clamp(record.agentic_fit_score ?? 0, 0, 100);
+  const flags = Array.isArray(record.disadvantage_flags) ? record.disadvantage_flags : [];
+  const review = record.chairman_review_required === true;
+  const flagNote = flags.length ? ` Disadvantage flags: ${flags.join(', ')}.` : '';
+  const reviewNote = review ? ' Flagged for explicit chairman review (structurally un-agent-able).' : '';
+  return {
+    type: 'agentic_fit_advisory',
+    message: `Agentic-fit ${score}/100 (${record.af_band ?? 'AF-Unknown'}) — advisory only, does not kill.${flagNote}${reviewNote}`,
+    agentic_fit_score: score,
+    af_band: record.af_band ?? 'AF-Unknown',
+    chairman_review_required: review,
+    disadvantage_flags: flags,
+  };
+}
+
+/**
+ * LLM entrypoint: derive the four dimensions + machine_improvement + disadvantage flags from
+ * a venture candidate, then score them. Mirrors analyzeAttentionCapital. Fails soft to a
+ * zero-fit advisory record (never throws into the synthesis runner).
+ * @param {Object} pathOutput
+ * @param {Object} deps  {logger, llmClient}
+ */
+export async function analyzeAgenticFit(pathOutput, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+  logger.log('   Analyzing agentic fit...');
+
+  const prompt = `You are an EHG agentic-fit analyst. EHG's unfair advantage is an AI-agent fleet that builds ventures with near-zero human labor. Score whether THIS venture fits that advantage.
+
+VENTURE:
+Name: ${pathOutput?.suggested_name ?? ''}
+Problem: ${pathOutput?.suggested_problem ?? ''}
+Solution: ${pathOutput?.suggested_solution ?? ''}
+Market: ${pathOutput?.target_market ?? ''}
+
+Score each dimension 0-100:
+- agent_leverage: can AI agents do MOST of the work, including a standardizable workflow? (a venture needing heavy bespoke human labor scores LOW)
+- compounding: does it produce reusable assets + a template that speeds FUTURE ventures?
+- kill_speed: can demand be validated cheaply and fast (so we kill losers quickly)?
+- attention_economy: does it need chairman taste only at gates (not constant human attention)?
+
+Also score:
+- machine_improvement (0-100): does this venture improve the FACTORY itself — train the assumption engine, improve agent performance, yield a reusable playbook, or reveal a repeatable niche?
+
+And flag any structural disadvantages (array of: capital_heavy, human_trust_dependent, deep_rd_moat, winner_take_all, requires_regulatory_permission, requires_large_upfront_capital).
+
+Return JSON ONLY: {"agent_leverage":N,"compounding":N,"kill_speed":N,"attention_economy":N,"machine_improvement":N,"disadvantage_flags":[...],"confidence":0-1,"summary":"..."}`;
+
+  try {
+    const response = await client.complete({ prompt, temperature: 0.2, maxTokens: 600 });
+    const text = typeof response === 'string' ? response : (response?.text ?? response?.content ?? '');
+    const match = text.match(/\{[\s\S]*\}/);
+    const analysis = match ? JSON.parse(match[0]) : {};
+    const scored = scoreAgenticFit(
+      {
+        dimensions: {
+          agent_leverage: analysis.agent_leverage,
+          compounding: analysis.compounding,
+          kill_speed: analysis.kill_speed,
+          attention_economy: analysis.attention_economy,
+        },
+        machine_improvement: analysis.machine_improvement,
+        disadvantage_flags: analysis.disadvantage_flags,
+      },
+      deps.config || {},
+    );
+    return {
+      ...scored,
+      confidence: clamp(analysis.confidence ?? 0.5, 0, 1),
+      summary: analysis.summary ?? '',
+      usage: extractUsage ? extractUsage(response) : undefined,
+    };
+  } catch (err) {
+    logger.warn?.(`   Agentic-fit analysis failed: ${err.message}`);
+    return {
+      ...scoreAgenticFit({ dimensions: {}, machine_improvement: 0, disadvantage_flags: [] }),
+      confidence: 0,
+      confidence_caveat: 'Analysis failed.',
+      summary: `Failed: ${err.message}`,
+    };
+  }
+}
+
+export default {
+  AF_WEIGHTS,
+  AF_DIMENSIONS,
+  AGENT_LEVERAGE_FLOOR,
+  AF_MULTIPLIER_PARAMS,
+  DISADVANTAGE_FACTORS,
+  HARDEST_DISADVANTAGES,
+  computeAgenticFitScore,
+  applyMachineImprovementMultiplier,
+  classifyDisadvantages,
+  classifyAgenticFitBand,
+  scoreAgenticFit,
+  buildAgenticFitAdvisory,
+  analyzeAgenticFit,
+};

--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -58,6 +58,7 @@ import { evaluateDesignPotential } from './design-evaluation.js';
 import { analyzeNarrativeRisk } from './narrative-risk.js';
 import { analyzeTechTrajectory } from './tech-trajectory.js';
 import { analyzeAttentionCapital } from './attention-capital.js';
+import { analyzeAgenticFit } from './agentic-fit.js';
 import { runMentalModelAnalysis } from './mental-model-analysis.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 
@@ -86,7 +87,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   // Run all 10 components - grouped by dependency
   // Group 1 (no inter-dependencies): components 1-4, 6-10
   // Group 2 (depends on nothing but run separately): component 5 (chairman constraints)
-  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory, attentionCapital, mentalModelAnalysis] = await Promise.all([
+  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory, attentionCapital, agenticFit, mentalModelAnalysis] = await Promise.all([
     crossReferenceIntellectualCapital(pathOutput, deps).catch(err => {
       logger.warn(`   Warning: Cross-reference failed: ${err.message}`);
       return { component: 'cross_reference', matches: [], lessons: [], relevance_score: 0, summary: `Failed: ${err.message}` };
@@ -135,6 +136,11 @@ export async function runSynthesis(pathOutput, deps = {}) {
       logger.warn(`   Warning: Attention capital analysis failed: ${err.message}`);
       return { component: 'attention_capital', ac_score: 0, ac_band: 'AC-Unknown', ac_interpretation: 'Analysis unavailable', component_scores: { organic_search_momentum: 0, engagement_depth: 0, earned_media_ratio: 0, advocacy_signal: 0, return_engagement: 0 }, confidence: 0, confidence_caveat: 'Analysis failed.', summary: `Failed: ${err.message}` };
     }),
+    // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: agentic-fit lens (weighted Stage-0 component + S3 advisory)
+    analyzeAgenticFit(pathOutput, deps).catch(err => {
+      logger.warn(`   Warning: Agentic-fit analysis failed: ${err.message}`);
+      return { component: 'agentic_fit', agentic_fit_score: 0, fit_composite: 0, queue_jump_score: 0, dimension_scores: { agent_leverage: 0, compounding: 0, kill_speed: 0, attention_economy: 0 }, machine_improvement: 0, machine_improvement_bonus: 0, disadvantage_flags: [], disadvantage_down_weight: 1, hardest_disadvantage_flags: [], chairman_review_required: false, af_band: 'AF-Unknown', af_interpretation: 'Analysis unavailable', confidence: 0, confidence_caveat: 'Analysis failed.', summary: `Failed: ${err.message}` };
+    }),
     runMentalModelAnalysis({
       venture: pathOutput,
       stage: 0,
@@ -170,6 +176,8 @@ export async function runSynthesis(pathOutput, deps = {}) {
     virality: virality,
     design_evaluation: design,
     tech_trajectory: techTrajectory,
+    // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-4 primary): weighted Stage-0 component
+    agentic_fit: agenticFit,
   };
 
   let profileMetadata = null;
@@ -188,7 +196,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   }
 
   // Aggregate token usage from all components
-  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory, attentionCapital, mentalModelAnalysis]
+  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory, attentionCapital, agenticFit, mentalModelAnalysis]
     .filter(c => c != null)
     .map(c => c.usage)
     .filter(Boolean);
@@ -241,11 +249,14 @@ export async function runSynthesis(pathOutput, deps = {}) {
         narrative_risk: narrativeRisk,
         tech_trajectory: techTrajectory,
         attention_capital: attentionCapital,
+        // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001 (FR-5): record the full agentic-fit record
+        // (4 dimension sub-scores + disadvantage flags + multiplier) for chairman explainability.
+        agentic_fit: agenticFit,
         advisory: {
           mental_model_analysis: mentalModelAnalysis,
         },
-        components_run: 14,
-        components_total: 14,
+        components_run: 15,
+        components_total: 15,
         profile: profileMetadata,
         weighted_score: weightedScore,
       },

--- a/tests/eva/stage-zero/synthesis/agentic-fit.test.js
+++ b/tests/eva/stage-zero/synthesis/agentic-fit.test.js
@@ -1,0 +1,167 @@
+/**
+ * Unit Tests for the Agentic-Fit Venture-Selection Lens
+ * Part of SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001
+ *
+ * FR-1 computeAgenticFitScore (4 config-weighted dims + near-threshold rule)
+ * FR-2 applyMachineImprovementMultiplier (separate, queue-jumping)
+ * FR-3 classifyDisadvantages (soft down-weight + flag, never auto-kill)
+ * FR-4 integration: agentic_fit as a weighted Stage-0 venture_score component
+ * FR-5 transparency: scoreAgenticFit records sub-scores + flags + multiplier
+ * FR-6 config-SSOT: weights/params overridable
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  AF_WEIGHTS,
+  AGENT_LEVERAGE_FLOOR,
+  computeAgenticFitScore,
+  applyMachineImprovementMultiplier,
+  classifyDisadvantages,
+  scoreAgenticFit,
+  buildAgenticFitAdvisory,
+} from '../../../../lib/eva/stage-zero/synthesis/agentic-fit.js';
+import { calculateWeightedScore } from '../../../../lib/eva/stage-zero/profile-service.js';
+import { evaluateKillGate } from '../../../../lib/eva/stage-templates/stage-03.js';
+
+const HIGH_FIT = { agent_leverage: 90, compounding: 85, kill_speed: 80, attention_economy: 80 };
+const LOW_LEVERAGE = { agent_leverage: 10, compounding: 90, kill_speed: 90, attention_economy: 90 };
+
+describe('FR-1 computeAgenticFitScore', () => {
+  it('weights the four dimensions and clamps to 0-100', () => {
+    const score = computeAgenticFitScore(HIGH_FIT);
+    expect(score).toBeGreaterThan(80);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('a high-agent-leverage compounding idea outranks a high-market low-fit idea', () => {
+    const highFit = computeAgenticFitScore(HIGH_FIT);
+    const lowFit = computeAgenticFitScore({ agent_leverage: 20, compounding: 30, kill_speed: 40, attention_economy: 35 });
+    expect(highFit).toBeGreaterThan(lowFit);
+  });
+
+  it('a very low agent_leverage sinks the composite (near-threshold rule)', () => {
+    // Below the floor: composite is scaled by leverage/floor even though other dims are 90.
+    const sunk = computeAgenticFitScore(LOW_LEVERAGE);
+    const unscaled = Math.round(
+      10 * AF_WEIGHTS.agent_leverage + 90 * AF_WEIGHTS.compounding + 90 * AF_WEIGHTS.kill_speed + 90 * AF_WEIGHTS.attention_economy,
+    );
+    expect(sunk).toBeLessThan(unscaled); // sink applied
+    expect(sunk).toBe(Math.round(unscaled * (10 / AGENT_LEVERAGE_FLOOR)));
+  });
+
+  it('reads weights from the config argument (SSOT), not hardcoded', () => {
+    const custom = computeAgenticFitScore({ agent_leverage: 50, compounding: 50, kill_speed: 50, attention_economy: 50 }, { agent_leverage: 1, compounding: 0, kill_speed: 0, attention_economy: 0 });
+    expect(custom).toBe(50); // only agent_leverage counted
+  });
+
+  it('clamps out-of-range dimension inputs', () => {
+    const s = computeAgenticFitScore({ agent_leverage: 999, compounding: -50, kill_speed: 50, attention_economy: 50 });
+    expect(s).toBeGreaterThanOrEqual(0);
+    expect(s).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('FR-2 applyMachineImprovementMultiplier', () => {
+  it('applies as a multiplier on top of the composite, not a 5th dimension', () => {
+    const { score, bonus } = applyMachineImprovementMultiplier(60, 100);
+    expect(bonus).toBeCloseTo(0.5); // max bonus at machine_improvement=100
+    expect(score).toBe(90); // 60 * 1.5
+  });
+
+  it('lets a high-machine-improvement venture jump the queue past an equal-fit peer', () => {
+    const composite = 60;
+    const plain = applyMachineImprovementMultiplier(composite, 0).score;
+    const jumper = applyMachineImprovementMultiplier(composite, 90).score;
+    expect(jumper).toBeGreaterThan(plain);
+  });
+
+  it('honors config multiplier params (SSOT)', () => {
+    const { bonus } = applyMachineImprovementMultiplier(60, 100, { max_bonus: 1.0 });
+    expect(bonus).toBeCloseTo(1.0);
+  });
+});
+
+describe('FR-3 classifyDisadvantages', () => {
+  it('soft down-weights and flags, never returns a hard kill', () => {
+    const r = classifyDisadvantages(['capital_heavy']);
+    expect(r.downWeightFactor).toBeLessThan(1);
+    expect(r.downWeightFactor).toBeGreaterThan(0);
+    expect(r.flags).toContain('capital_heavy');
+    expect(r).not.toHaveProperty('kill');
+  });
+
+  it('flags the structurally-un-agent-able subtypes hardest for chairman review', () => {
+    const r = classifyDisadvantages(['requires_large_upfront_capital']);
+    expect(r.chairman_review_required).toBe(true);
+    expect(r.hardest_flags).toContain('requires_large_upfront_capital');
+    expect(r.downWeightFactor).toBeLessThan(0.85); // heavier than a normal disadvantage
+  });
+
+  it('a capital-heavy idea is down-weighted + flagged, not killed (scoreAgenticFit)', () => {
+    const clean = scoreAgenticFit({ dimensions: HIGH_FIT, machine_improvement: 0, disadvantage_flags: [] });
+    const heavy = scoreAgenticFit({ dimensions: HIGH_FIT, machine_improvement: 0, disadvantage_flags: ['capital_heavy'] });
+    expect(heavy.agentic_fit_score).toBeLessThan(clean.agentic_fit_score);
+    expect(heavy.agentic_fit_score).toBeGreaterThan(0); // not killed
+    expect(heavy.disadvantage_flags).toContain('capital_heavy');
+  });
+
+  it('ignores unknown flags', () => {
+    const r = classifyDisadvantages(['not_a_real_flag']);
+    expect(r.downWeightFactor).toBe(1);
+    expect(r.flags).toHaveLength(0);
+  });
+});
+
+describe('FR-4 integration: agentic_fit as a weighted Stage-0 component', () => {
+  it('contributes to the weighted venture_score via its profile weight', () => {
+    const synthesisResults = { agentic_fit: scoreAgenticFit({ dimensions: HIGH_FIT }) };
+    const result = calculateWeightedScore(synthesisResults, { agentic_fit: 1.0 });
+    const af = result.breakdown.find((b) => b.component === 'agentic_fit');
+    expect(af).toBeTruthy();
+    expect(af.raw_score).toBeGreaterThan(80);
+    expect(result.total_score).toBeGreaterThan(80);
+  });
+});
+
+describe('FR-4 secondary: S3 advisory signal (non-kill)', () => {
+  it('surfaces agentic_fit as an advisory reason at S3 without killing', () => {
+    const record = scoreAgenticFit({ dimensions: HIGH_FIT, disadvantage_flags: ['requires_large_upfront_capital'] });
+    const gate = evaluateKillGate({ overallScore: 80, metrics: { marketFit: 80 }, agenticFit: record });
+    expect(gate.decision).toBe('pass'); // agentic-fit never forces a kill
+    expect(gate.blockProgression).toBe(false);
+    const advisory = gate.reasons.find((r) => r.type === 'agentic_fit_advisory');
+    expect(advisory).toBeTruthy();
+    expect(advisory.chairman_review_required).toBe(true);
+  });
+
+  it('buildAgenticFitAdvisory returns null for a missing record', () => {
+    expect(buildAgenticFitAdvisory(null)).toBeNull();
+  });
+
+  it('does not change the kill decision for a catastrophic score', () => {
+    const record = scoreAgenticFit({ dimensions: HIGH_FIT });
+    const gate = evaluateKillGate({ overallScore: 10, metrics: { marketFit: 10 }, agenticFit: record });
+    expect(gate.decision).toBe('kill'); // agentic-fit advisory never blocks a real kill path
+  });
+});
+
+describe('FR-5 transparency + FR-6 config', () => {
+  it('records every dimension sub-score, flags, and the multiplier', () => {
+    const r = scoreAgenticFit({ dimensions: HIGH_FIT, machine_improvement: 70, disadvantage_flags: ['deep_rd_moat'] });
+    expect(r.dimension_scores).toEqual({ agent_leverage: 90, compounding: 85, kill_speed: 80, attention_economy: 80 });
+    expect(r.machine_improvement).toBe(70);
+    expect(r.machine_improvement_bonus).toBeGreaterThan(0);
+    expect(r.disadvantage_flags).toContain('deep_rd_moat');
+    expect(r.fit_composite).toBeGreaterThan(0);
+    expect(r).toHaveProperty('agentic_fit_score');
+    expect(r).toHaveProperty('af_band');
+  });
+
+  it('honors config weights + multiplier params overrides', () => {
+    const r = scoreAgenticFit(
+      { dimensions: { agent_leverage: 50, compounding: 50, kill_speed: 50, attention_economy: 50 }, machine_improvement: 100 },
+      { weights: { agent_leverage: 1, compounding: 0, kill_speed: 0, attention_economy: 0 }, multiplier_params: { max_bonus: 0 } },
+    );
+    expect(r.fit_composite).toBe(50);
+    expect(r.machine_improvement_bonus).toBe(0); // multiplier disabled via config
+  });
+});

--- a/tests/unit/eva/stage-zero/counterfactual-engine.test.js
+++ b/tests/unit/eva/stage-zero/counterfactual-engine.test.js
@@ -40,6 +40,8 @@ const LEGACY_WEIGHTS = {
   build_cost: 0.10,
   virality: 0.13,
   tech_trajectory: 0.05,
+  // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: 11th weighted component
+  agentic_fit: 0.10,
 };
 
 const AGGRESSIVE_WEIGHTS = {
@@ -82,17 +84,20 @@ describe('counterfactual-engine', () => {
       expect(result.delta).toBe(result.counterfactual_score - result.original_score);
     });
 
-    it('breakdown contains all 10 components', () => {
+    it('breakdown contains all LEGACY_WEIGHTS components', () => {
       const result = generateCounterfactual({
         synthesisResults: MOCK_RESULTS,
         currentWeights: LEGACY_WEIGHTS,
         scenarioWeights: AGGRESSIVE_WEIGHTS,
       });
 
-      expect(result.breakdown).toHaveLength(10);
+      // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: agentic_fit is now an 11th weighted
+      // component, so the breakdown length tracks Object.keys(LEGACY_WEIGHTS).
+      expect(result.breakdown).toHaveLength(Object.keys(LEGACY_WEIGHTS).length);
       const components = result.breakdown.map(b => b.component);
       expect(components).toContain('moat_architecture');
       expect(components).toContain('virality');
+      expect(components).toContain('agentic_fit');
     });
 
     it('breakdown is sorted by absolute contribution delta', () => {

--- a/tests/unit/eva/stage-zero/profile-service.test.js
+++ b/tests/unit/eva/stage-zero/profile-service.test.js
@@ -188,7 +188,7 @@ describe('calculateWeightedScore', () => {
     const result = calculateWeightedScore({}, LEGACY_WEIGHTS);
 
     expect(result.total_score).toBe(0);
-    expect(result.breakdown).toHaveLength(10);
+    expect(result.breakdown).toHaveLength(11); // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: + agentic_fit
     result.breakdown.forEach(b => expect(b.raw_score).toBe(0));
   });
 
@@ -264,13 +264,14 @@ describe('calculateWeightedScore', () => {
 });
 
 describe('VALID_COMPONENTS', () => {
-  test('contains all 10 synthesis components', () => {
-    expect(VALID_COMPONENTS).toHaveLength(10);
+  test('contains all 11 synthesis components', () => {
+    expect(VALID_COMPONENTS).toHaveLength(11); // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: + agentic_fit
     expect(VALID_COMPONENTS).toContain('virality');
     expect(VALID_COMPONENTS).toContain('moat_architecture');
     expect(VALID_COMPONENTS).toContain('tech_trajectory');
     expect(VALID_COMPONENTS).toContain('build_cost');
     expect(VALID_COMPONENTS).toContain('chairman_constraints');
+    expect(VALID_COMPONENTS).toContain('agentic_fit');
   });
 });
 

--- a/tests/unit/eva/stage-zero/sensitivity-analysis.test.js
+++ b/tests/unit/eva/stage-zero/sensitivity-analysis.test.js
@@ -49,6 +49,8 @@ const EQUAL_WEIGHTS = {
   build_cost: 1 / 10,
   virality: 1 / 10,
   tech_trajectory: 1 / 10,
+  // SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: 11th weighted component
+  agentic_fit: 1 / 10,
 };
 
 const LEGACY_WEIGHTS = {
@@ -62,14 +64,15 @@ const LEGACY_WEIGHTS = {
   build_cost: 0.10,
   virality: 0.13,
   tech_trajectory: 0.05,
+  agentic_fit: 0.10,
 };
 
 describe('sensitivity-analysis', () => {
   describe('runSensitivityAnalysis', () => {
-    it('returns ranked array of 10 components with influence scores', () => {
+    it('returns ranked array of 11 components with influence scores', () => {
       const result = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
 
-      expect(result).toHaveLength(10);
+      expect(result).toHaveLength(11);
       expect(result[0]).toHaveProperty('component');
       expect(result[0]).toHaveProperty('influence_score');
       expect(result[0]).toHaveProperty('elasticity');
@@ -106,15 +109,15 @@ describe('sensitivity-analysis', () => {
       const small = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS, { delta: 0.01 });
       const large = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS, { delta: 0.10 });
 
-      // Both should return 10 components
-      expect(small).toHaveLength(10);
-      expect(large).toHaveLength(10);
+      // Both should return 11 components
+      expect(small).toHaveLength(11);
+      expect(large).toHaveLength(11);
     });
 
     it('returns zero influence for null inputs', () => {
       const result = runSensitivityAnalysis(null, null);
 
-      expect(result).toHaveLength(10);
+      expect(result).toHaveLength(11);
       for (const r of result) {
         expect(r.influence_score).toBe(0);
         expect(r.elasticity).toBe(0);
@@ -130,7 +133,7 @@ describe('sensitivity-analysis', () => {
       const result = runSensitivityAnalysis(MOCK_RESULTS, zeroWeights);
 
       // With zero weights, perturbing upward from 0 should still detect influence
-      expect(result).toHaveLength(10);
+      expect(result).toHaveLength(11);
       // At least some components should have non-zero influence since we perturb up from 0
       const totalInfluence = result.reduce((acc, r) => acc + r.influence_score, 0);
       expect(totalInfluence).toBeCloseTo(1.0, 2);
@@ -145,7 +148,7 @@ describe('sensitivity-analysis', () => {
 
       const result = runSensitivityAnalysis(MOCK_RESULTS, dominantWeights);
 
-      expect(result).toHaveLength(10);
+      expect(result).toHaveLength(11);
       // moat_architecture should have significant influence
       const moat = result.find(r => r.component === 'moat_architecture');
       expect(moat).toBeDefined();
@@ -177,7 +180,7 @@ describe('sensitivity-analysis', () => {
       const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
       const drivers = identifyKeyDrivers(ranking, 1.0);
 
-      expect(drivers.length).toBe(10);
+      expect(drivers.length).toBe(11);
     });
 
     it('returns empty array for null ranking', () => {

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -51,6 +51,11 @@ vi.mock('../../../../../lib/eva/stage-zero/synthesis/narrative-risk.js', () => (
 vi.mock('../../../../../lib/eva/stage-zero/synthesis/tech-trajectory.js', () => ({
   analyzeTechTrajectory: vi.fn().mockResolvedValue({ component: 'tech_trajectory', trajectory_score: 67, axes: { reasoning_autonomy: { current: 65, bull_6m: 85, base_6m: 75, bear_6m: 68, venture_impact: 'test' }, cost_deflation: { current: 50, bull_6m: 80, base_6m: 65, bear_6m: 45, venture_impact: 'test' }, multimodal_expansion: { current: 40, bull_6m: 70, base_6m: 55, bear_6m: 42, venture_impact: 'test' } }, competitive_timing: { signal: 'opening', confidence: 0.7, window_months: 6, rationale: 'test' }, next_disruption_event: { event: 'Test', estimated_months: 4, invalidation_scope: 'test' }, gap_windows: [], confidence_caveat: 'Test caveat', summary: 'ok', data_feed_active: false }),
 }));
+// SD-EHG-FACTORY-AGENTIC-FIT-SELECTION-001: 15th synthesis component
+vi.mock('../../../../../lib/eva/stage-zero/synthesis/agentic-fit.js', () => ({
+  analyzeAgenticFit: vi.fn().mockResolvedValue({ component: 'agentic_fit', agentic_fit_score: 72, fit_composite: 70, queue_jump_score: 80, dimension_scores: { agent_leverage: 80, compounding: 70, kill_speed: 65, attention_economy: 60 }, machine_improvement: 40, machine_improvement_bonus: 0.2, disadvantage_flags: [], disadvantage_down_weight: 1, hardest_disadvantage_flags: [], chairman_review_required: false, af_band: 'AF-High', af_interpretation: 'ok', confidence: 0.7, summary: 'ok' }),
+  buildAgenticFitAdvisory: vi.fn().mockReturnValue(null),
+}));
 vi.mock('../../../../../lib/eva/stage-zero/profile-service.js', () => ({
   resolveProfile: vi.fn().mockResolvedValue(null),
   calculateWeightedScore: vi.fn().mockReturnValue({ total_score: 75, breakdown: {} }),
@@ -99,7 +104,7 @@ beforeEach(() => {
 });
 
 describe('runSynthesis', () => {
-  test('runs all 14 synthesis components', async () => {
+  test('runs all 15 synthesis components', async () => {
     const result = await runSynthesis(validPathOutput, { logger: silentLogger });
 
     expect(crossReferenceIntellectualCapital).toHaveBeenCalledWith(validPathOutput, expect.anything());
@@ -115,8 +120,8 @@ describe('runSynthesis', () => {
     expect(analyzeNarrativeRisk).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(analyzeTechTrajectory).toHaveBeenCalledWith(validPathOutput, expect.anything());
 
-    expect(result.metadata.synthesis.components_run).toBe(14);
-    expect(result.metadata.synthesis.components_total).toBe(14);
+    expect(result.metadata.synthesis.components_run).toBe(15);
+    expect(result.metadata.synthesis.components_total).toBe(15);
   });
 
   test('handles component failure gracefully', async () => {


### PR DESCRIPTION
## Summary
Score Stage-0 ideas on EHG's unfair-advantage axis — agent-leverage (0.35), compounding (0.25), kill-speed (0.20), attention-economy (0.20) — plus a separate machine-improvement multiplier and soft disadvantage flags. Backend only (lib/eva/stage-zero + stage-templates).

## Functional requirements
- **FR-1** `agentic-fit.js computeAgenticFitScore`: 4 config-weighted dims with a near-threshold agent_leverage sink; weights from the `evaluation_profiles` SSOT.
- **FR-2** `applyMachineImprovementMultiplier`: a separate multiplier (not a buried 5th dimension) so a factory-improving venture jumps the queue past an equal-fit peer.
- **FR-3** `classifyDisadvantages`: soft down-weight + prominent flag, **never** an auto-kill; the two structurally-un-agent-able subtypes (`requires_regulatory_permission`, `requires_large_upfront_capital`) flagged hardest for chairman review.
- **FR-4** wired as a weighted **component** of the Stage-0 venture_score (profile-service + synthesis runner) **and** an **advisory** (non-kill) signal at S3 (`evaluateKillGate`); S3/S5 thresholds unchanged.
- **FR-5** every dimension sub-score + flags + multiplier recorded in the stage_zero synthesis snapshot for chairman explainability.
- **FR-6** weights + multiplier params in the `evaluation_profiles` config SSOT (migration + seeded across all profiles).

## Out of scope (deferred)
Calibration loop + UI surfacing of the scores.

## Tests
18 regression tests (FR-1..FR-6 + S3 advisory); stage-03 (14/14) + synthesis suites green, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)