### PR TITLE
feat(SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001): propagate the operating-model SSOT to all 5 upstream stages

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S16-FINANCIAL-GROUNDING-EVIDENCE-GATE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S16-FINANCIAL-GROUNDING-EVIDENCE-GATE-001",
-  "createdAt": "2026-06-26T17:12:16.122Z",
+  "sdKey": "SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001",
+  "createdAt": "2026-06-26T21:19:53.844Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
@@ -15,6 +15,10 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+// SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-2): the ops-realist persona scores resource
+// feasibility (-> S3 executionFeasibility). Give it the operating-model context so it scores AI-NATIVE
+// (AI-agent labor, not hired human teams) instead of penalizing ventures for a team they never need.
+import { getOperatingModelPromptBlock } from '../../standards/operating-model.js';
 
 /**
  * Persona definitions aligned to Stage 3 kill-gate metrics.
@@ -122,9 +126,15 @@ Problem Statement: ${sanitizeForPrompt(stage1Data.problemStatement || 'Not speci
   const LLM_EXPECTED_FIELDS = ['summary', 'score', 'strengths', 'risks'];
 
   for (const persona of PERSONAS) {
+    // FR-2: the ops-realist persona evaluates resource feasibility — ground it in the operating model so
+    // it scores AI-native (no hired-team requirement). Other personas are unchanged (this is the only one
+    // whose resource/cost assumptions feed a cost/feasibility metric).
+    const operatingModelContext = persona.id === 'ops-realist'
+      ? `\nOPERATING MODEL (score resource feasibility against THIS, not a traditional hired team):\n${getOperatingModelPromptBlock()}\n- Labor is AI agents (Claude Code + LEO Protocol orchestration), NOT a hired human team. Do NOT penalize the venture for needing engineers/ops staff it will not hire. Organic-first GTM. Judge feasibility by AI-buildability + token/hosting cost, not headcount.\n`
+      : '';
     const userPrompt = `Evaluate this venture as the "${persona.name}" persona.
 Your focus area: ${persona.focus}
-
+${operatingModelContext}
 ${ventureContext}
 
 Output ONLY valid JSON.`;
@@ -220,6 +230,9 @@ Output ONLY valid JSON.`;
     compositeScore,
     critiques, // preserve raw data for downstream
     fourBuckets,
+    // SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-2): the ops-realist persona scored resource
+    // feasibility against the operating model (AI-native), not a traditional hired team.
+    ops_realist_operating_model_grounded: true,
     llmFallbackCount,
     usage,
   };

--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -18,6 +18,11 @@ import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 import { evaluateKillGate } from '../stage-05.js';
+// SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-1/FR-2): the operating-model SSOT — so S5
+// (the first authoritative KILL gate) models opex/CAC under EHG's solo-chairman + all-AI economics
+// (zero human payroll, venture-hosting-standard, organic GTM) instead of generic human-team burn that
+// false-KILLs viable ventures. Mirrors the proven S16 grounding.
+import { getOperatingModelPromptBlock, groundCostBreakdown } from '../../standards/operating-model.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 import { setContract } from '../../contracts/financial-contract.js';
 
@@ -113,7 +118,8 @@ ${stage4Data?.competitors ? `Number of competitors: ${stage4Data.competitors.len
 ${webContext}
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  // FR-1: inject the operating-model SSOT so opex/CAC reflect EHG economics, not generic human-team burn.
+  const response = await client.complete(SYSTEM_PROMPT + '\n\n' + getOperatingModelPromptBlock() + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
   const usage = extractUsage(response);
   const parsed = parseJSON(response);
   const fourBuckets = parseFourBuckets(parsed, { logger });
@@ -125,6 +131,38 @@ Output ONLY valid JSON.`;
     year2: normalizeYear(parsed.year2, logger, 'year2'),
     year3: normalizeYear(parsed.year3, logger, 'year3'),
   };
+
+  // FR-2: ground annual opex in the operating model when it shows the PHANTOM-HUMAN-BURN signature.
+  // S5's opex is a single annual number (no cost breakdown to surgically strip a personnel line), so the
+  // signal must be conservative to avoid erasing LEGITIMATE costs: ground only when opex is MISSING (<=0)
+  // OR EXCEEDS REVENUE (llmOpex > revenue). Under EHG's lean AI-ops operating model a software venture's
+  // opex never exceeds its revenue — opex > revenue is the signature of an invented human-team payroll
+  // (e.g. venture-1's $1.2M opex on $120k revenue). A legitimate opex < revenue is PRESERVED (e.g. $80k
+  // opex on $200k revenue stays). The grounded annual opex = sum of 12 operating-model monthly breakdowns.
+  const opex_provenance = {};
+  for (const yr of ['year1', 'year2', 'year3']) {
+    const yIdx = { year1: 0, year2: 1, year3: 2 }[yr];
+    const annualRevenue = Math.max(0, Number(model[yr].revenue) || 0);
+    let groundedAnnualOpex = 0;
+    for (let m = 1; m <= 12; m++) {
+      const { monthly_total } = groundCostBreakdown({ month: yIdx * 12 + m, revenue: annualRevenue / 12 });
+      groundedAnnualOpex += monthly_total;
+    }
+    groundedAnnualOpex = Math.round(groundedAnnualOpex);
+    const llmOpex = Number(model[yr].opex);
+    const missing = !Number.isFinite(llmOpex) || llmOpex <= 0;
+    // exceeds-revenue: only meaningful when there is revenue; a pre-revenue year (revenue 0) is grounded
+    // when its opex is human-scale (> the grounded AI-ops band) since AI-ops opex is tiny pre-revenue.
+    const exceedsRevenue = !missing && ((annualRevenue > 0 && llmOpex > annualRevenue) ||
+      (annualRevenue === 0 && groundedAnnualOpex > 0 && llmOpex > groundedAnnualOpex));
+    if (missing || exceedsRevenue) {
+      model[yr].opex = groundedAnnualOpex;
+      opex_provenance[yr] = 'DERIVED-from-operating-model';
+      logger.warn(`[Stage05] ${yr} opex grounded to operating model: ${missing ? 'missing' : `opex $${llmOpex} exceeds revenue $${annualRevenue} — phantom human-team burn`} -> $${groundedAnnualOpex}`);
+    } else {
+      opex_provenance[yr] = 'ESTIMATE';
+    }
+  }
 
   // Compute derived fields (same as stage-05 template)
   const grossProfitY1 = model.year1.revenue - model.year1.cogs;
@@ -290,6 +328,9 @@ Output ONLY valid JSON.`;
     },
     roiBands,
     assumptions: Array.isArray(parsed.assumptions) ? parsed.assumptions : [],
+    // SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-3): operating-model grounding provenance.
+    operating_model_grounded: Object.values(opex_provenance).some((p) => p === 'DERIVED-from-operating-model'),
+    opex_provenance,                                  // per-year: DERIVED-from-operating-model | ESTIMATE
     fourBuckets, usage, llmFallbackCount,
   };
 

--- a/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
@@ -13,6 +13,13 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { deriveUnitEconomics } from '../unit-economics.js';
+// SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-4): the operating-model SSOT — so S7's
+// unit-economics defaults reflect EHG economics (organic-first $0 CAC, lean-AI-ops high margin) instead
+// of the generic-SaaS $100 CAC / 70% margin that travel downstream into S16 + the S5/kill gates.
+import { getOperatingModelPromptBlock, OPERATING_MODEL } from '../../standards/operating-model.js';
+// Lean AI-ops gross margin: COGS is essentially payment processing (~2.9%) + minimal hosting -> ~90%+,
+// NOT the generic-SaaS 70%. Conservative operating-model default applied only when the LLM omits it.
+const OPERATING_MODEL_GROSS_MARGIN_PCT = Math.max(0, Math.min(100, Math.round(100 - OPERATING_MODEL.other.payment_processing_pct - 7)));
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 import { PRICING_MODELS } from '../stage-07.js';
@@ -271,7 +278,8 @@ ${acquisitionMotionLine}
 ${webContext}
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  // FR-4: inject the operating-model SSOT so the LLM prices under EHG economics (organic-first, lean margin).
+  const response = await client.complete(SYSTEM_PROMPT + '\n\n' + getOperatingModelPromptBlock() + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
   const usage = extractUsage(response);
   const parsed = parseJSON(response);
   const fourBuckets = parseFourBuckets(parsed, { logger });
@@ -318,10 +326,22 @@ Output ONLY valid JSON.`;
   if (rawCac === undefined) llmFallbackCount++;
   if (rawArpa === undefined) llmFallbackCount++;
 
-  // Flat unit economics fields matching template schema
-  const gross_margin_pct = clamp(rawGrossMargin ?? s5GrossMargin, 0, 100, logger, 'unitEconomics.gross_margin_pct');
+  // FR-4: operating-model-grounded defaults (applied ONLY when the LLM omits the value — a provided
+  // value is preserved). Margin defaults to the lean-AI-ops band (~90%) not generic 70%; CAC defaults to
+  // $0 organic-first (paid acquisition is an explicit opt-in, only when a high-ACV signal warrants it).
+  const econ_provenance = {};
+  // Preserve a real upstream margin (LLM, or a stage5-computed margin from actual revenue); ground to the
+  // operating-model band ONLY when the value is truly absent (the bare generic 70% default) — don't override.
+  const s5HasMargin = !!(stage5Data?.year1?.revenue);
+  const marginSource = rawGrossMargin ?? (s5HasMargin ? s5GrossMargin : OPERATING_MODEL_GROSS_MARGIN_PCT);
+  const gross_margin_pct = clamp(marginSource, 0, 100, logger, 'unitEconomics.gross_margin_pct');
+  econ_provenance.gross_margin_pct = (rawGrossMargin === undefined && !s5HasMargin) ? 'DERIVED-from-operating-model' : 'ESTIMATE';
   const churn_rate_monthly = clamp(rawChurnMonthly ?? s5Churn, 0, 100, logger, 'unitEconomics.churn_rate_monthly');
-  const cac = Math.max(0, Number(rawCac ?? stage5Data?.unitEconomics?.cac ?? 100));
+  // organic-first: default CAC to $0 unless a high-ACV (paid sales motion) signal is present.
+  const cacOmitted = rawCac === undefined && (stage5Data?.unitEconomics?.cac === undefined || stage5Data?.unitEconomics?.cac === null);
+  const organicDefaultCac = acqSignals.highAcv ? 100 : 0; // high-ACV warrants a paid motion; else organic $0
+  const cac = Math.max(0, Number(rawCac ?? stage5Data?.unitEconomics?.cac ?? organicDefaultCac));
+  econ_provenance.cac = cacOmitted ? 'DERIVED-from-operating-model' : 'ESTIMATE';
   const arpa = Math.max(0, Number(rawArpa ?? (paidAnchorPrice || 49)));
 
   if (llmFallbackCount > 0) {
@@ -392,6 +412,9 @@ Output ONLY valid JSON.`;
     payback_months: derived.payback_months,
     warnings: derived.warnings,
     rationale: String(parsed.rationale || ''),
+    // SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-4): operating-model grounding provenance.
+    econ_provenance,                                  // { gross_margin_pct, cac }: DERIVED-from-operating-model | ESTIMATE
+    operating_model_grounded: Object.values(econ_provenance).some((p) => p === 'DERIVED-from-operating-model'),
     fourBuckets, usage, llmFallbackCount,
     financialModelId,
   };

--- a/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
@@ -18,6 +18,10 @@ import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../util
 // stage-12.js imports analyzeStage12 from this file; this file imports evaluateRealityGate back.
 import { evaluateRealityGate } from '../stage-12.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+// SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-5): the operating-model SSOT — so GTM
+// defaults organic-first ($0 paid budget early); a paid-led plan is flagged as an EXPLICIT override
+// that contradicts the operating model (not silently accepted, not silently rewritten).
+import { getOperatingModelPromptBlock } from '../../standards/operating-model.js';
 
 // Duplicated from stage-12.js to avoid circular dependency at module-level evaluation.
 const SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
@@ -173,7 +177,8 @@ IMPORTANT: Market tiers MUST reference Stage 10 personas by name. Channels shoul
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  // FR-5: inject the operating-model SSOT so the GTM plan defaults organic-first ($0 paid budget early).
+  const response = await client.complete(SYSTEM_PROMPT + '\n\n' + getOperatingModelPromptBlock() + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
   const usage = extractUsage(response);
   const parsed = parseJSON(response);
   const fourBuckets = parseFourBuckets(parsed, { logger });
@@ -325,6 +330,19 @@ Output ONLY valid JSON.`;
     ? Math.round(cacValues.reduce((sum, ch) => sum + ch.expected_cac, 0) / cacValues.length * 100) / 100
     : 0;
 
+  // FR-5: flag a PAID-LED plan as an explicit override of the operating model (organic-first). Detection:
+  // paid channels carry a positive budget AND paid budget is the majority of total spend. The plan is NOT
+  // rewritten (the LLM may have a legitimate paid rationale) — it is SURFACED so the contradiction is visible
+  // to the gate/reviewer rather than silently accepted.
+  const paidBudget = channels.filter((ch) => ch.channelType === 'paid').reduce((s, ch) => s + ch.monthly_budget, 0);
+  const gtm_paid_led = paidBudget > 0 && total_monthly_budget > 0 && paidBudget >= total_monthly_budget * 0.5;
+  const gtm_motion_provenance = gtm_paid_led
+    ? 'PAID-LED-OVERRIDE (contradicts the operating-model organic-first default — explicit choice, surfaced)'
+    : 'DERIVED-from-operating-model (organic-first)';
+  if (gtm_paid_led) {
+    logger.warn(`[Stage12] GTM is PAID-LED ($${paidBudget}/mo paid of $${total_monthly_budget}/mo total) — overrides the operating-model organic-first default; surfaced, not rewritten.`);
+  }
+
   // Economy check: pipeline metrics for Reality Gate
   const totalPipelineValue = funnel_stages.reduce((sum, fs) => sum + fs.target_value, 0);
   const avgConversionRate = (() => {
@@ -381,6 +399,10 @@ Output ONLY valid JSON.`;
     reality_gate,
     total_monthly_budget,
     avg_cac,
+    // SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-5): GTM motion grounding.
+    gtm_paid_led,
+    gtm_motion_provenance,
+    operating_model_grounded: !gtm_paid_led,
     fourBuckets, usage, llmFallbackCount,
   };
 }

--- a/lib/eva/stage-zero/synthesis/build-cost-estimation.js
+++ b/lib/eva/stage-zero/synthesis/build-cost-estimation.js
@@ -13,6 +13,10 @@
 
 import { getValidationClient } from '../../../llm/client-factory.js';
 import { extractUsage } from '../../utils/parse-json.js';
+// SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-1): inject the operating-model SSOT at the
+// FIRST point cost is estimated (Stage-0) so burn is born zero-payroll / venture-hosting-standard /
+// organic-GTM — the wrong assumptions never enter the pipeline. Mirrors the proven S5/S7/S16 grounding.
+import { getOperatingModelPromptBlock, groundCostBreakdown } from '../../standards/operating-model.js';
 
 const COMPLEXITY_LEVELS = ['trivial', 'simple', 'moderate', 'complex', 'massive'];
 
@@ -76,7 +80,8 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
+    // FR-1: the operating-model SSOT is the SYSTEM prompt (was empty) so the estimate is born grounded.
+    const response = await client.complete(getOperatingModelPromptBlock(), prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
@@ -86,16 +91,29 @@ Return JSON:
         ? analysis.complexity
         : 'moderate';
 
+      const infrastructure = analysis.infrastructure || { required: [], optional: [], estimated_monthly_cost: 0 };
+      // FR-1: ground the monthly infra cost to the operating-model hosting band when the LLM omits/zeroes it
+      // (a missing infra cost would otherwise read as $0 burn downstream). A provided value is preserved.
+      let infra_cost_provenance = 'ESTIMATE';
+      if (!(Number(infrastructure.estimated_monthly_cost) > 0)) {
+        const { breakdown } = groundCostBreakdown({ month: 1, revenue: 0 });
+        infrastructure.estimated_monthly_cost = breakdown.infrastructure;
+        infra_cost_provenance = 'DERIVED-from-operating-model';
+      }
+
       return {
         component: 'build_cost',
         complexity,
         loc_estimate: analysis.loc_estimate || { min: 0, max: 0, breakdown: {} },
         sd_count: analysis.sd_count || { min: 0, max: 0, breakdown: {} },
-        infrastructure: analysis.infrastructure || { required: [], optional: [], estimated_monthly_cost: 0 },
+        infrastructure,
         token_budget: analysis.token_budget || { development_tokens_monthly: 0, production_tokens_monthly: 0, estimated_monthly_cost: 0 },
         timeline_weeks: analysis.timeline_weeks || { optimistic: 0, realistic: 0, pessimistic: 0 },
         risk_factors: analysis.risk_factors || [],
         summary: analysis.summary || '',
+        // FR-1: operating-model grounding provenance.
+        infra_cost_provenance,
+        operating_model_grounded: infra_cost_provenance === 'DERIVED-from-operating-model',
         usage,
       };
     }

--- a/tests/unit/eva/stage-zero/build-cost-operating-model-grounding.test.js
+++ b/tests/unit/eva/stage-zero/build-cost-operating-model-grounding.test.js
@@ -1,0 +1,45 @@
+/**
+ * SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-1) — ground the Stage-0 build-cost producer
+ * in the operating model at the FIRST point cost is estimated, so burn is born zero-payroll /
+ * venture-hosting-standard. Prevents the wrong cost assumptions from entering the pipeline upstream.
+ */
+import { describe, it, expect } from 'vitest';
+import { estimateBuildCost } from '../../../../lib/eva/stage-zero/synthesis/build-cost-estimation.js';
+import { getOperatingModelPromptBlock } from '../../../../lib/eva/standards/operating-model.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const pathOutput = { suggested_name: 'V1', suggested_problem: 'p', suggested_solution: 's', target_market: 'm' };
+
+// injectable LLM client that captures the SYSTEM prompt + returns a controllable analysis JSON
+function makeClient(analysis) {
+  const calls = [];
+  return {
+    calls,
+    complete: async (systemPrompt, userPrompt) => { calls.push({ systemPrompt, userPrompt }); return { content: JSON.stringify(analysis) }; },
+  };
+}
+
+describe('FR-1 Stage-0 build-cost grounding', () => {
+  it('injects the operating-model block as the SYSTEM prompt (was empty)', async () => {
+    const client = makeClient({ complexity: 'moderate', infrastructure: { estimated_monthly_cost: 40 } });
+    await estimateBuildCost(pathOutput, { logger: silent, llmClient: client });
+    expect(client.calls[0].systemPrompt).toBe(getOperatingModelPromptBlock());
+    expect(client.calls[0].systemPrompt).toMatch(/AI operations|payroll/i);
+  });
+
+  it('grounds an omitted/zero infra monthly cost to the operating-model hosting band (DERIVED)', async () => {
+    const client = makeClient({ complexity: 'moderate', infrastructure: { required: ['supabase'], estimated_monthly_cost: 0 } });
+    const r = await estimateBuildCost(pathOutput, { logger: silent, llmClient: client });
+    expect(r.infrastructure.estimated_monthly_cost).toBeGreaterThan(0); // grounded, not $0 phantom-free burn
+    expect(r.infra_cost_provenance).toBe('DERIVED-from-operating-model');
+    expect(r.operating_model_grounded).toBe(true);
+  });
+
+  it('preserves a provided infra monthly cost (ESTIMATE, not over-grounded)', async () => {
+    const client = makeClient({ complexity: 'simple', infrastructure: { estimated_monthly_cost: 40 } });
+    const r = await estimateBuildCost(pathOutput, { logger: silent, llmClient: client });
+    expect(r.infrastructure.estimated_monthly_cost).toBe(40);
+    expect(r.infra_cost_provenance).toBe('ESTIMATE');
+    expect(r.operating_model_grounded).toBe(false);
+  });
+});

--- a/tests/unit/eva/stage02-operating-model-grounding.test.js
+++ b/tests/unit/eva/stage02-operating-model-grounding.test.js
@@ -1,0 +1,48 @@
+/**
+ * SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-2) — give the S2 ops-realist persona the
+ * operating-model context so its resource-feasibility score (-> S3 executionFeasibility) is AI-native
+ * (AI-agent labor, not a hired team), instead of penalizing ventures for a team they never need.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const h = vi.hoisted(() => ({ capturedPrompts: [] }));
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({
+    complete: async (_sys, userPrompt) => {
+      h.capturedPrompts.push(userPrompt);
+      return { content: JSON.stringify({ score: 75, confidence: 'high', summary: 's', strengths: ['a'], concerns: ['b'], reasoning: 'r' }) };
+    },
+  }),
+}));
+
+import { analyzeStage02 } from '../../../lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const stage1 = { description: 'AI-native analytics SaaS', targetMarket: 'SMBs', problemStatement: 'manual reporting' };
+
+describe('FR-2 ops-realist persona operating-model grounding', () => {
+  it('source: only the ops-realist persona gets the operating-model context block', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, '../../../lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js'), 'utf8');
+    expect(src).toMatch(/persona\.id === 'ops-realist'[\s\S]*getOperatingModelPromptBlock\(\)/);
+    expect(src).toMatch(/AI agents|not a hired human team/i);
+  });
+
+  it('the ops-realist persona prompt carries the AI-native resource framing (not other personas)', async () => {
+    h.capturedPrompts = [];
+    await analyzeStage02({ stage1Data: stage1, ventureName: 'V1', logger: silent });
+    const opsPrompts = h.capturedPrompts.filter((p) => /OPERATING MODEL|AI agents.*NOT a hired/i.test(p));
+    expect(opsPrompts.length).toBe(1); // exactly the ops-realist persona, not all 7
+    // a non-ops persona prompt should NOT carry the operating-model resource framing
+    const nonOps = h.capturedPrompts.filter((p) => /Operations Realist/.test(p) === false && /OPERATING MODEL/i.test(p));
+    expect(nonOps.length).toBe(0);
+  });
+
+  it('the artifact flags the ops-realist grounding', async () => {
+    const r = await analyzeStage02({ stage1Data: stage1, ventureName: 'V1', logger: silent });
+    expect(r.ops_realist_operating_model_grounded).toBe(true);
+  });
+});

--- a/tests/unit/eva/stage05-operating-model-grounding.test.js
+++ b/tests/unit/eva/stage05-operating-model-grounding.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-1/2/3) — ground the S5 financial KILL gate
+ * in the operating-model SSOT so it stops false-KILLing viable ventures on phantom human-team burn.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const h = vi.hoisted(() => ({ model: {} }));
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({ complete: async () => ({ content: JSON.stringify(h.model) }) }),
+}));
+// keep S5's optional web-search + persistence inert
+vi.mock('../../../lib/eva/stage-templates/utils/web-search.js', () => ({
+  isSearchEnabled: () => false, searchBatch: async () => [], formatResultsForPrompt: () => '',
+}));
+
+import { analyzeStage05 } from '../../../lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js';
+import { getOperatingModelPromptBlock } from '../../../lib/eva/standards/operating-model.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const stage1 = { description: 'AI-native market modeling SaaS', targetMarket: 'consultants', problemStatement: 'manual WTP' };
+
+// a model with a PHANTOM human-team payroll opex (~$1.2M/yr) that would false-KILL on burn
+const phantomBurnModel = {
+  initialInvestment: 50000,
+  year1: { revenue: 120000, cogs: 12000, opex: 1200000 }, // phantom human-team payroll
+  year2: { revenue: 400000, cogs: 40000, opex: 1500000 },
+  year3: { revenue: 900000, cogs: 90000, opex: 1800000 },
+  unitEconomics: { cac: 800, ltv: 8980, paybackMonths: 6, churnRate: 4 },
+};
+// a model with operating-model-consistent (lean) opex
+const leanModel = {
+  initialInvestment: 5000,
+  year1: { revenue: 120000, cogs: 12000, opex: 6000 },
+  year2: { revenue: 400000, cogs: 40000, opex: 12000 },
+  year3: { revenue: 900000, cogs: 90000, opex: 20000 },
+  unitEconomics: { cac: 0, ltv: 8980, paybackMonths: 3, churnRate: 4 },
+};
+
+function run(model) {
+  h.model = model;
+  return analyzeStage05({ stage1Data: stage1, stage3Data: {}, stage4Data: {}, ventureName: 'V1', logger: silent });
+}
+
+describe('FR-1 prompt — S5 injects the operating-model block', () => {
+  it('the producer source assembles getOperatingModelPromptBlock into the client.complete call', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, '../../../lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js'), 'utf8');
+    expect(src).toMatch(/client\.complete\([^)]*getOperatingModelPromptBlock\(\)/s);
+    // sanity: the block actually carries the zero-payroll / AI-ops constraint
+    expect(getOperatingModelPromptBlock()).toMatch(/personnel|payroll|AI operations/i);
+  });
+});
+
+describe('FR-2 fallback — phantom burn grounded; lean opex preserved', () => {
+  it('grounds an implausibly-high (phantom human-team) opex to the operating model', async () => {
+    const r = await run(phantomBurnModel);
+    expect(r.operating_model_grounded).toBe(true);
+    expect(r.opex_provenance.year1).toBe('DERIVED-from-operating-model');
+    expect(r.opex_provenance.year2).toBe('DERIVED-from-operating-model');
+    expect(r.opex_provenance.year3).toBe('DERIVED-from-operating-model');
+  });
+
+  it('preserves an operating-model-consistent (lean) LLM opex (not over-grounded)', async () => {
+    const r = await run(leanModel);
+    expect(r.opex_provenance.year1).toBe('ESTIMATE');
+    expect(r.operating_model_grounded).toBe(false);
+  });
+});
+
+describe('FR-3 provenance — per-year tags present', () => {
+  it('emits opex_provenance per year (DERIVED-from-operating-model | ESTIMATE)', async () => {
+    const r = await run(phantomBurnModel);
+    expect(Object.keys(r.opex_provenance)).toEqual(['year1', 'year2', 'year3']);
+    for (const yr of ['year1', 'year2', 'year3']) {
+      expect(['DERIVED-from-operating-model', 'ESTIMATE']).toContain(r.opex_provenance[yr]);
+    }
+  });
+});

--- a/tests/unit/eva/stage07-operating-model-grounding.test.js
+++ b/tests/unit/eva/stage07-operating-model-grounding.test.js
@@ -1,0 +1,67 @@
+/**
+ * SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-4) — ground the S7 pricing/unit-economics
+ * producer in the operating model: organic-first $0 CAC + lean-AI-ops margin (not generic $100 / 70%),
+ * with provenance tags. These economics flow downstream into S16 + the S5/kill gates.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const h = vi.hoisted(() => ({ resp: {} }));
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({ complete: async () => ({ content: JSON.stringify(h.resp) }) }),
+}));
+vi.mock('../../../lib/eva/stage-templates/utils/web-search.js', () => ({
+  isSearchEnabled: () => false, searchBatch: async () => [], formatResultsForPrompt: () => '',
+}));
+
+import { analyzeStage07 } from '../../../lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+// a self-serve (NOT high-ACV) concept -> organic-first default applies
+const stage1 = { description: 'self-serve AI tool for solo consultants', targetMarket: 'consultants', problemStatement: 'x' };
+const baseResp = (ue) => ({
+  pricing_model: 'subscription',
+  tiers: [{ name: 'Pro', price: 449, billing_period: 'monthly' }],
+  priceAnchor: { competitorAvg: 500, proposedPrice: 449, positioning: 'premium' },
+  unitEconomics: ue,
+  rationale: 'r',
+});
+
+function run(ue) {
+  h.resp = baseResp(ue);
+  return analyzeStage07({ stage1Data: stage1, stage4Data: {}, stage5Data: {}, stage6Data: {}, ventureName: 'V1', logger: silent });
+}
+
+describe('FR-4 prompt — S7 injects the operating-model block', () => {
+  it('the producer source assembles getOperatingModelPromptBlock into the client.complete call', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, '../../../lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js'), 'utf8');
+    expect(src).toMatch(/client\.complete\([^)]*getOperatingModelPromptBlock\(\)/s);
+  });
+});
+
+describe('FR-4 grounded defaults (omitted -> operating model; provided -> preserved)', () => {
+  it('omitted gross_margin -> lean operating-model margin (~90%, not 70), tagged DERIVED', async () => {
+    const r = await run({ cac: 200, churn_rate_monthly: 4, arpa: 449 }); // gross_margin omitted
+    expect(r.gross_margin_pct).toBeGreaterThan(80);
+    expect(r.econ_provenance.gross_margin_pct).toBe('DERIVED-from-operating-model');
+    expect(r.operating_model_grounded).toBe(true);
+  });
+
+  it('omitted CAC on a non-high-ACV concept -> $0 organic-first, tagged DERIVED', async () => {
+    const r = await run({ gross_margin_pct: 88, churn_rate_monthly: 4, arpa: 449 }); // cac omitted
+    expect(r.cac).toBe(0);
+    expect(r.econ_provenance.cac).toBe('DERIVED-from-operating-model');
+  });
+
+  it('LLM-provided gross_margin + cac are PRESERVED (tagged ESTIMATE, not over-grounded)', async () => {
+    const r = await run({ gross_margin_pct: 72, cac: 350, churn_rate_monthly: 4, arpa: 449 });
+    expect(r.gross_margin_pct).toBe(72);
+    expect(r.cac).toBe(350);
+    expect(r.econ_provenance.gross_margin_pct).toBe('ESTIMATE');
+    expect(r.econ_provenance.cac).toBe('ESTIMATE');
+    expect(r.operating_model_grounded).toBe(false);
+  });
+});

--- a/tests/unit/eva/stage12-operating-model-grounding.test.js
+++ b/tests/unit/eva/stage12-operating-model-grounding.test.js
@@ -1,0 +1,70 @@
+/**
+ * SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-5) — ground S12 GTM in the operating model:
+ * organic-first ($0 paid budget early); a paid-led plan is FLAGGED as an explicit override (surfaced,
+ * not silently accepted, not rewritten).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const h = vi.hoisted(() => ({ resp: {} }));
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({ complete: async () => ({ content: JSON.stringify(h.resp) }) }),
+}));
+vi.mock('../../../lib/eva/stage-templates/utils/web-search.js', () => ({
+  isSearchEnabled: () => false, searchBatch: async () => [], formatResultsForPrompt: () => '',
+}));
+
+import { analyzeStage12 } from '../../../lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const PARAMS = {
+  stage1Data: { description: 'self-serve analytics SaaS', targetMarket: 'SMBs', problemStatement: 'x' },
+  stage10Data: { customerPersonas: [{ name: 'SMB Owner', segment: 'SMB' }] },
+  stage11Data: { brandName: 'Acme' },
+  logger: silent,
+};
+
+// 8 channels (REQUIRED_CHANNELS); helper to build a GTM response with a given channel mix
+function gtm(channels) {
+  return {
+    marketTiers: [{ name: 'T1' }],
+    channels,
+    salesModel: 'self-serve',
+    funnelStages: [], dealStages: [], customerJourney: [],
+  };
+}
+const organicChannels = Array.from({ length: 8 }, (_, i) => ({ name: `Organic ${i}`, channelType: 'organic', primaryTier: 'T1', monthly_budget: 0, expected_cac: 0, primary_kpi: 'signups' }));
+const paidLedChannels = [
+  { name: 'Paid Search', channelType: 'paid', primaryTier: 'T1', monthly_budget: 8000, expected_cac: 200, primary_kpi: 'leads' },
+  ...Array.from({ length: 7 }, (_, i) => ({ name: `Organic ${i}`, channelType: 'organic', primaryTier: 'T1', monthly_budget: 0, expected_cac: 0, primary_kpi: 'signups' })),
+];
+
+function run(channels) { h.resp = gtm(channels); return analyzeStage12(PARAMS); }
+
+describe('FR-5 prompt — S12 injects the operating-model block', () => {
+  it('the producer source assembles getOperatingModelPromptBlock into the client.complete call', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, '../../../lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js'), 'utf8');
+    expect(src).toMatch(/client\.complete\([^)]*getOperatingModelPromptBlock\(\)/s);
+  });
+});
+
+describe('FR-5 paid-led flag', () => {
+  it('an organic-first plan is NOT flagged (operating_model_grounded)', async () => {
+    const r = await run(organicChannels);
+    expect(r.gtm_paid_led).toBe(false);
+    expect(r.operating_model_grounded).toBe(true);
+    expect(r.gtm_motion_provenance).toMatch(/organic-first/i);
+  });
+
+  it('a paid-led plan is FLAGGED as an explicit operating-model override (surfaced, not rewritten)', async () => {
+    const r = await run(paidLedChannels);
+    expect(r.gtm_paid_led).toBe(true);
+    expect(r.operating_model_grounded).toBe(false);
+    expect(r.gtm_motion_provenance).toMatch(/PAID-LED-OVERRIDE/);
+    // not rewritten — the paid channel + its budget are preserved
+    expect(r.total_monthly_budget).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Propagates the operating-model SSOT (`lib/eva/standards/operating-model.js` — the proven S16 cost-SSOT pattern) into **all 5 upstream producers**, so wrong cost/CAC/resource assumptions can't be **born upstream** and false-KILL viable ventures. S16 grounding alone was too late — the kill decisions happen earlier.

## The 5 stages grounded

- **FR-1 — Stage-0 build-cost** (`35f3ed0f`): inject the operating model as the SYSTEM prompt (was empty) + ground infra cost to the hosting band when omitted. *Cost is born grounded at the first estimate.*
- **FR-2 — S2 ops-realist persona** (`8f88ef4e`): give **only** the ops-realist persona operating-model context so its resource-feasibility score (→ S3 executionFeasibility) is **AI-native** (AI-agent labor, not hired teams) — stops penalizing ventures for a team they never hire.
- **FR-3 — S5 financial kill gate** (`5e1494e8`): the **critical** one — inject the operating model + ground opex on the **phantom-human-burn signature** (opex MISSING or EXCEEDS REVENUE), so the *first authoritative kill gate* stops false-KILLing on phantom payroll.
- **FR-4 — S6/S7 pricing** (`803d4475`): ground the `gross_margin` (70% → lean-AI-ops ~90%) and `CAC` ($100 → $0 organic-first) **defaults**; preserve real upstream/LLM values.
- **FR-5 — S12 GTM** (`9edb158d`): default organic-first; **flag** a paid-led plan as an explicit operating-model override (surfaced, not rewritten).

## Conservative grounding (the load-bearing discipline)

Every stage **preserves** real LLM/upstream values and grounds **only** the bare/phantom default — verified by the existing-stage regression suite. Two over-grounding bugs were caught + fixed *before merge* by that net: S5's first threshold (3× the AI-ops band) over-grounded legitimate opex → corrected to the phantom signature (opex > revenue); S7's margin override broke the seed-from-stage5 feature → corrected to ground only when no real upstream margin exists.

## Tests

**153 passing, 0 failures** — 17 new grounding tests (one per stage) + 136 existing-stage regression tests. All 5 modules load. testing-agent verdict **PASS** (evidence `7158bfaf`).

## Scope discipline

The SD's headline was all 5 stages. Built S5 (critical) first, then **resisted completing the SD on the S5 slice alone** — held it open + routed the completion-scope decision to the coordinator + **folded all 5 stages in** (fold-in, not a vague follow-up child). **Honest residual:** per-producer unit tests use mocked LLMs; an end-to-end venture run verifying the assumptions propagate + a previously-false-KILLed venture now passes S5 is the integration follow-up.

SD: SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (campaign-mode, Adam-sourced; infrastructure, backend `lib/eva` only — no client surface, no schema change). Builds on the S16 grounding (#5156) + evidence-gate (#5155) + financial-rigor (#5148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
