### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001): correct gate-decision health + populate review basis

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -216,6 +216,50 @@ export async function waitForDecision({ decisionId, supabase, logger = console, 
  * @param {Object} [options.logger] - Logger instance
  * @returns {Promise<{id: string, isNew: boolean}>}
  */
+// SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-3: extract the gate's quality breakdown
+// from a stage's advisory_data so the chairman decision's brief_data carries the REVIEW BASIS
+// (quality score, completeness %, critical gaps, gate rationale) instead of an empty header. Tolerates
+// the several shapes producers use (top-level or nested under quality/gate). Pure + exported.
+export function extractGateQuality(advisoryData) {
+  const a = (advisoryData && typeof advisoryData === 'object') ? advisoryData : {};
+  const q = (a.quality && typeof a.quality === 'object') ? a.quality : a;
+  const gate = (a.gate && typeof a.gate === 'object') ? a.gate : a;
+  const num = (...vals) => { for (const v of vals) { const n = Number(v); if (Number.isFinite(n)) return n; } return null; };
+  const gaps = a.critical_gaps ?? q.critical_gaps ?? gate.critical_gaps;
+  const out = {
+    quality_score: num(a.quality_score, q.quality_score, q.overall_quality, a.overall_quality),
+    completeness_pct: num(a.completeness_pct, q.completeness_pct, a.completeness, q.completeness),
+    critical_gaps: Array.isArray(gaps) ? gaps : (typeof gaps === 'number' ? gaps : (gaps != null ? [gaps] : [])),
+    gate_rationale: a.gate_rationale ?? q.gate_rationale ?? gate.rationale ?? a.gate_recommendation ?? null,
+  };
+  // Only include keys that resolved to something — keep brief_data clean.
+  const cleaned = {};
+  for (const [k, v] of Object.entries(out)) {
+    if (v === null) continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    cleaned[k] = v;
+  }
+  return cleaned;
+}
+
+// SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-1: read the health_score for THIS stage
+// only (scoped lookup), so a chairman decision never inherits a different stage's verdict. Returns
+// the traffic-light string ('green'|'yellow'|'red') or null if the current stage has no health yet.
+// Fail-open: any read error returns null (non-fatal — better unknown than a wrong inherited value).
+export async function readCurrentStageHealth(supabase, ventureId, stageNumber) {
+  try {
+    const { data } = await supabase
+      .from('venture_stage_work')
+      .select('health_score')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', stageNumber)
+      .maybeSingle();
+    return data?.health_score || null;
+  } catch (_) {
+    return null;
+  }
+}
+
 export async function createOrReusePendingDecision({
   ventureId,
   stageNumber,
@@ -249,11 +293,18 @@ export async function createOrReusePendingDecision({
     .single();
 
   if (existing) {
-    // Update brief_data if newer data provided
-    if (briefData) {
+    // SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-1/FR-2: refresh health_score on REUSE
+    // too. A reused PENDING decision previously kept its original (possibly stale/wrong) health_score
+    // forever — so a re-grounded/approved stage that flipped GREEN still showed RED. Re-read the
+    // CURRENT stage's health and update it alongside brief_data.
+    const refreshedHealth = await readCurrentStageHealth(supabase, ventureId, stageNumber);
+    if (briefData || refreshedHealth !== null) {
+      const update = {};
+      if (briefData) { update.brief_data = briefData; update.summary = summary; }
+      if (refreshedHealth !== null) update.health_score = refreshedHealth;
       await supabase
         .from('chairman_decisions')
-        .update({ brief_data: briefData, summary })
+        .update(update)
         .eq('id', existing.id);
     }
     logger.log(`   Reusing existing PENDING decision: ${existing.id}`);
@@ -265,19 +316,11 @@ export async function createOrReusePendingDecision({
     return { id: existing.id, isNew: false };
   }
 
-  // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-A: Populate health_score from latest stage
-  let healthScore = null;
-  try {
-    const { data: latestStage } = await supabase
-      .from('venture_stage_work')
-      .select('health_score')
-      .eq('venture_id', ventureId)
-      .not('health_score', 'is', null)
-      .order('lifecycle_stage', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    healthScore = latestStage?.health_score || null;
-  } catch (_) { /* non-fatal */ }
+  // SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-1: the decision's health_score must
+  // reflect the CURRENT stage's verdict — NOT the latest-across-stages value. The prior lookup used
+  // ORDER BY lifecycle_stage DESC LIMIT 1 with no stage filter, so it inherited a different stage's
+  // health (chairman saw RED on a GREEN-passing gate). Scope the lookup to THIS stage.
+  const healthScore = await readCurrentStageHealth(supabase, ventureId, stageNumber);
 
   // Create new PENDING decision — always set decision_type to avoid NULL
   // (SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: NULL decision_type breaks .neq filters)

--- a/lib/eva/health-score-computer.js
+++ b/lib/eva/health-score-computer.js
@@ -20,8 +20,25 @@
  * @param {object|null} advisoryData - The venture_stage_work.advisory_data JSONB
  * @returns {string} 'green' (score >= 60), 'yellow' (30-59), 'red' (< 30)
  */
+// SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-2: recognize a skip/structural stub so it
+// is never scored as a RED failure. The stage worker marks skipped pre-exec stages with one of these
+// flags rather than producing a real artifact. Exported pure for unit testing.
+export function isSkipStub(advisoryData) {
+  if (!advisoryData || typeof advisoryData !== 'object') return false;
+  if (advisoryData.pre_exec_skip === true) return true;
+  if (advisoryData.skipped === true || advisoryData.skip === true) return true;
+  const status = String(advisoryData.status || advisoryData.stage_status || '').toLowerCase();
+  return status === 'skipped' || status === 'pre_exec_skip';
+}
+
 export function computeHealthScore(advisoryData) {
   if (!advisoryData || typeof advisoryData !== 'object') return 0;
+
+  // SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-2: a pre_exec_skip (or otherwise
+  // skipped/structural) advisory_data stub is NOT unhealthy — it is a deliberate skip with no
+  // substantive artifact to score. Scoring it RED made the chairman see a false failure. Treat such
+  // stubs as NEUTRAL ('yellow'), never RED. (Detected via the skip markers the worker writes.)
+  if (isSkipStub(advisoryData)) return 'yellow';
 
   let score = 0;
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -28,6 +28,7 @@ import {
 import {
   createOrReusePendingDecision,
   waitForDecision,
+  extractGateQuality,
 } from './chairman-decision-watcher.js';
 import { emit } from './shared-services.js';
 import { checkAutonomy } from './autonomy-model.js';
@@ -1958,10 +1959,25 @@ export class StageExecutionWorker {
         .eq('id', ventureId)
         .single();
 
+      // SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-3: carry the gate's quality breakdown
+      // (quality score, completeness %, critical gaps, gate rationale) into brief_data so the chairman
+      // 'Blueprint Quality Summary' renders the review basis instead of an empty header. Sourced from
+      // the current stage's advisory_data in venture_stage_work. Fail-open — never block the gate.
+      let gateQuality = {};
+      try {
+        const { data: stageWork } = await this._supabase
+          .from('venture_stage_work')
+          .select('advisory_data')
+          .eq('venture_id', ventureId)
+          .eq('lifecycle_stage', stageNumber)
+          .maybeSingle();
+        gateQuality = extractGateQuality(stageWork?.advisory_data);
+      } catch (_) { /* non-fatal */ }
+
       const { id: decisionId, isNew } = await createOrReusePendingDecision({
         ventureId,
         stageNumber,
-        briefData: { stage: stageNumber, ventureName: venture?.name },
+        briefData: { stage: stageNumber, ventureName: venture?.name, ...gateQuality },
         summary: `Chairman gate: Stage ${stageNumber} review for ${venture?.name || ventureId}`,
         supabase: this._supabase,
         logger: this._logger,

--- a/tests/unit/eva/chairman-decision-health-provenance.test.js
+++ b/tests/unit/eva/chairman-decision-health-provenance.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { computeHealthScore, isSkipStub } from '../../../lib/eva/health-score-computer.js';
+import { extractGateQuality, readCurrentStageHealth } from '../../../lib/eva/chairman-decision-watcher.js';
+
+// SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 regression tests.
+
+describe('FR-2: pre_exec_skip stub is NEUTRAL, not RED', () => {
+  it('isSkipStub detects the skip markers', () => {
+    expect(isSkipStub({ pre_exec_skip: true })).toBe(true);
+    expect(isSkipStub({ skipped: true })).toBe(true);
+    expect(isSkipStub({ status: 'skipped' })).toBe(true);
+    expect(isSkipStub({ analysis: 'real work' })).toBe(false);
+    expect(isSkipStub(null)).toBe(false);
+  });
+
+  it('computeHealthScore returns yellow (neutral) for a pre_exec_skip stub, NOT red', () => {
+    expect(computeHealthScore({ pre_exec_skip: true, reason: 'no_change' })).toBe('yellow');
+    expect(computeHealthScore({ status: 'skipped' })).toBe('yellow');
+  });
+
+  it('still scores a substantive artifact green and an empty object red (unchanged)', () => {
+    const rich = { analysis: 'x'.repeat(50), summary: { a: 1, b: 2 }, findings: ['f1', 'f2'], recommendation: 'go', results: {} };
+    expect(computeHealthScore(rich)).toBe('green');
+    expect(computeHealthScore({})).toBe('red');
+  });
+});
+
+describe('FR-1: readCurrentStageHealth scopes to the CURRENT stage', () => {
+  function makeSupabase(capture) {
+    return {
+      from() {
+        const filters = {};
+        const b = {
+          select() { return b; },
+          eq(col, val) { filters[col] = val; return b; },
+          maybeSingle() { capture.filters = filters; return Promise.resolve({ data: { health_score: 'green' } }); },
+        };
+        return b;
+      },
+    };
+  }
+
+  it('queries venture_stage_work filtered by venture_id AND lifecycle_stage (no cross-stage DESC)', async () => {
+    const capture = {};
+    const health = await readCurrentStageHealth(makeSupabase(capture), 'v1', 16);
+    expect(health).toBe('green');
+    expect(capture.filters.venture_id).toBe('v1');
+    expect(capture.filters.lifecycle_stage).toBe(16);
+  });
+
+  it('fail-open returns null on error', async () => {
+    const throwing = { from() { throw new Error('boom'); } };
+    expect(await readCurrentStageHealth(throwing, 'v1', 16)).toBeNull();
+  });
+});
+
+describe('FR-3: extractGateQuality populates the review basis', () => {
+  it('pulls quality_score / completeness / critical_gaps / gate_rationale from advisory_data', () => {
+    const out = extractGateQuality({
+      quality_score: 87,
+      completeness_pct: 92,
+      critical_gaps: ['missing risk register'],
+      gate_rationale: 'PASS — all phases above threshold',
+    });
+    expect(out.quality_score).toBe(87);
+    expect(out.completeness_pct).toBe(92);
+    expect(out.critical_gaps).toEqual(['missing risk register']);
+    expect(out.gate_rationale).toMatch(/PASS/);
+  });
+
+  it('tolerates nested quality/gate shapes and overall_quality alias', () => {
+    const out = extractGateQuality({ quality: { overall_quality: 75, completeness: 80 }, gate: { rationale: 'CONDITIONAL' } });
+    expect(out.quality_score).toBe(75);
+    expect(out.completeness_pct).toBe(80);
+    expect(out.gate_rationale).toBe('CONDITIONAL');
+  });
+
+  it('returns an empty object (no junk keys) when nothing is present', () => {
+    expect(extractGateQuality({ unrelated: 1 })).toEqual({});
+    expect(extractGateQuality(null)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
The chairman gate-decision surface showed **RED health on a GREEN-passing gate** with an **empty review summary**. Three root causes fixed:

- **FR-1 (health provenance):** `chairman_decision.health_score` was read with an unscoped `ORDER BY lifecycle_stage DESC LIMIT 1`, inheriting a prior stage's value, and was never refreshed on decision reuse. New `readCurrentStageHealth()` scopes the lookup to the **current** stage, and the reuse branch now refreshes health — so a re-grounded/approved stage that flipped GREEN no longer stays RED.
- **FR-2 (false-RED):** `computeHealthScore` now treats a `pre_exec_skip`/skipped advisory_data stub as **neutral (yellow)**, not RED (`isSkipStub`).
- **FR-3 (review basis):** `brief_data` now carries the gate quality breakdown (quality_score, completeness %, critical_gaps, gate_rationale) via `extractGateQuality` from the stage's existing `advisory_data`, so the 'Blueprint Quality Summary' renders instead of an empty header.

**No DDL** — quality data is read from existing `advisory_data`. Applies to ALL ventures/gates.

## Verification
8 new unit tests (skip→neutral, stage-scoped health lookup, brief_data extraction) + existing health-score/chairman-decision tests green; 3 edited files pass `node --check`.

SD: SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)