### PR TITLE
fix(SD-LEO-INFRA-RESERVED-GATE-BYPASS-001): mint-and-block on chairman-reserved promotion gates

### DIFF
--- a/lib/eva/reconcile-gate-decisions.mjs
+++ b/lib/eva/reconcile-gate-decisions.mjs
@@ -1,0 +1,52 @@
+// SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-3): reconciliation guard.
+// For every gated (decision-creating) stage a venture has PASSED, a corresponding
+// chairman_decision row MUST exist. A venture past a gated stage with no decision is a
+// SILENT BYPASS — surface it so it cannot recur unnoticed.
+//
+// Pure helper (findGateDecisionViolations) is unit-testable with in-memory fixtures; the
+// CLI wrapper (scripts/reconcile-gate-decisions.mjs) runs it against the live DB.
+
+import { FALLBACK_DECISION_CREATING_STAGES } from './chairman-decision-watcher.js';
+
+/**
+ * Pure violation finder. A violation = a venture whose current_lifecycle_stage is PAST a
+ * decision-creating stage for which NO chairman_decision row exists.
+ *
+ * @param {Array<{id:string, current_lifecycle_stage:number}>} ventures
+ * @param {Array<{venture_id:string, lifecycle_stage:number}>} decisions  any chairman_decision rows
+ * @param {Iterable<number>} [gatedStages=FALLBACK_DECISION_CREATING_STAGES] decision-creating stages
+ * @returns {Array<{venture_id:string, stage:number}>} violations (gated stage passed, no decision)
+ */
+export function findGateDecisionViolations(ventures, decisions, gatedStages = FALLBACK_DECISION_CREATING_STAGES) {
+  const gated = [...gatedStages].sort((a, b) => a - b);
+  const haveDecision = new Set((decisions || []).map((d) => `${d.venture_id}:${d.lifecycle_stage}`));
+  const violations = [];
+  for (const v of ventures || []) {
+    const cur = Number(v.current_lifecycle_stage);
+    if (!Number.isFinite(cur)) continue;
+    for (const stage of gated) {
+      if (stage >= cur) break; // only stages strictly PASSED (current is still in progress / at the gate)
+      if (!haveDecision.has(`${v.id}:${stage}`)) violations.push({ venture_id: v.id, stage });
+    }
+  }
+  return violations;
+}
+
+/**
+ * DB-backed reconciliation across all ventures. Returns { violations, checked }.
+ * @param {object} supabase service-role client
+ */
+export async function reconcileGateDecisions(supabase) {
+  const { data: ventures, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, current_lifecycle_stage');
+  if (vErr) throw new Error(`ventures read failed: ${vErr.message}`);
+  const { data: decisions, error: dErr } = await supabase
+    .from('chairman_decisions')
+    .select('venture_id, lifecycle_stage');
+  if (dErr) throw new Error(`chairman_decisions read failed: ${dErr.message}`);
+  const violations = findGateDecisionViolations(ventures || [], decisions || []);
+  return { violations, checked: (ventures || []).length };
+}
+
+export default { findGateDecisionViolations, reconcileGateDecisions };

--- a/lib/eva/should-open-chairman-gate.js
+++ b/lib/eva/should-open-chairman-gate.js
@@ -17,13 +17,39 @@
  * unchanged.
  *
  * @param {object} args
+ * SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-1): a stage that MINTS a chairman decision
+ * (stage_creates_decision / isDecisionCreatingStage — e.g. S18, a gate_type='promotion'
+ * stage with work_type='artifact_only') was SILENTLY BYPASSED because the gate-open test
+ * keyed only on isHardGate (isBlocking || hard_gate_stages), which excludes artifact_only
+ * promotion gates. `isDecisionGate` makes such a stage open the chairman gate too. The
+ * content-less-failed-stage guard is unchanged, so a FAILED stage still never opens a gate.
+ * `isDecisionGate` is OPTIONAL (default false) so existing callers are byte-identical.
+ *
+ * @param {object} args
  * @param {boolean} args.isHardGate - stage is a hardcoded or dynamic hard gate
  * @param {boolean} args.stageFailed - processStage returned FAILED or produced no result
  * @param {boolean} args.canGovernanceOverrideFailed - build-loop (17-22) FAILED stage that governance auto-advances
+ * @param {boolean} [args.isDecisionGate=false] - stage mints a chairman decision (stage_creates_decision)
  * @returns {boolean} true if a chairman gate should be opened for this stage
  */
-export function shouldOpenChairmanGate({ isHardGate, stageFailed, canGovernanceOverrideFailed }) {
-  if (!isHardGate) return false;
+export function shouldOpenChairmanGate({ isHardGate, stageFailed, canGovernanceOverrideFailed, isDecisionGate = false }) {
+  if (!isHardGate && !isDecisionGate) return false;
   if (stageFailed && !canGovernanceOverrideFailed) return false;
   return true;
+}
+
+/**
+ * SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-2): the S19 BUILD-CHECKPOINT hard invariant.
+ * A venture must NOT advance past S19 / into pipeline_mode='building' on the leo_bridge
+ * build-readiness check ALONE — that is a technical readiness gate, NOT the chairman's
+ * go/no-go. BOTH must hold: the build is ready AND the chairman approved the S19
+ * build-checkpoint decision. Pure + fail-closed on the chairman approval.
+ *
+ * @param {object} args
+ * @param {boolean} args.buildComplete - leo_bridge build-readiness gate passed
+ * @param {boolean} args.hasApprovedChairmanDecision - an APPROVED S19 chairman_decision exists
+ * @returns {boolean} true only when BOTH conditions hold
+ */
+export function canAdvancePastBuildCheckpoint({ buildComplete, hasApprovedChairmanDecision }) {
+  return buildComplete === true && hasApprovedChairmanDecision === true;
 }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -28,6 +28,7 @@ import {
 import {
   createOrReusePendingDecision,
   waitForDecision,
+  isDecisionCreatingStage,
 } from './chairman-decision-watcher.js';
 import { emit } from './shared-services.js';
 import { checkAutonomy } from './autonomy-model.js';
@@ -37,7 +38,7 @@ import { hostname } from 'os';
 import { createServer } from 'http';
 import { OPERATING_MODES } from './gate-constants.js';
 import { getStageGovernance } from './stage-governance.js';
-import { shouldOpenChairmanGate } from './should-open-chairman-gate.js';
+import { shouldOpenChairmanGate, canAdvancePastBuildCheckpoint } from './should-open-chairman-gate.js';
 import { toValidTransitionType } from './transition-type.js';
 // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the single pure bridge-outcome classifier + S19
 // hold/advance decision shared by every S19 gate consumer (closes RCA 7610876f schism).
@@ -668,6 +669,37 @@ export class StageExecutionWorker {
               break;
             }
           }
+          // SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-2): the BUILD-CHECKPOINT hard invariant —
+          // the leo_bridge build-readiness gate (above) is NOT the chairman's go/no-go. On a
+          // RE-ENTRY where S19 has already produced an artifact, refuse to advance past S19 unless
+          // an APPROVED S19 chairman_decision also exists (fail-CLOSED on the chairman approval).
+          // Gated on an existing artifact so a first arrival still runs its producer + mints the
+          // pending gate via FR-1 (never a content-less gate).
+          {
+            const { data: s19Art } = await this._supabase
+              .from('venture_artifacts')
+              .select('id').eq('venture_id', ventureId).eq('lifecycle_stage', 19).eq('is_current', true).limit(1);
+            if (s19Art && s19Art.length > 0) {
+              const { data: s19Approved } = await this._supabase
+                .from('chairman_decisions')
+                .select('id').eq('venture_id', ventureId).eq('lifecycle_stage', 19)
+                .eq('status', 'approved').neq('decision_type', 'advisory').limit(1).maybeSingle();
+              const buildComplete = (await this._isLeoBridgeBuildComplete(ventureId)) !== false;
+              if (!canAdvancePastBuildCheckpoint({ buildComplete, hasApprovedChairmanDecision: !!s19Approved })) {
+                this._logger.warn(
+                  `[Worker] S19 BUILD-CHECKPOINT (SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 FR-2): refusing to advance venture ${ventureId} past Stage 19 — approved S19 chairman build-checkpoint decision required (buildComplete=${buildComplete}, approved=${!!s19Approved}). The leo_bridge readiness gate is not a substitute for the chairman go/no-go.`
+                );
+                await createOrReusePendingDecision({
+                  ventureId, stageNumber: 19, decisionType: 'stage_gate',
+                  summary: 'S19 build-checkpoint — chairman go/no-go required before BUILD mode',
+                  supabase: this._supabase, logger: this._logger,
+                }).catch((e) => this._logger.warn(`[Worker] S19 build-checkpoint mint skipped (non-fatal): ${e.message}`));
+                releaseState = ORCHESTRATOR_STATES.BLOCKED;
+                lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 's19_build_checkpoint_chairman' };
+                break;
+              }
+            }
+          }
         }
 
         // P0 UNIVERSAL pre-execution guard: check for approved decisions at ANY stage
@@ -731,7 +763,12 @@ export class StageExecutionWorker {
               // a configured hard_gate_stage; treating only isBlocking() as authoritative let S19
               // pre_exec_skip-advance (RCA a14ff698). Hard-gate stages must fall through to the
               // side-effect-aware gate-specific guard below (matching this block's own comment).
-              const isBlockingGate = govEarly.isBlocking(currentStage) || await this._isInHardGateStages(currentStage);
+              // SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-1c): a decision-creating stage (e.g. S18
+              // promotion/artifact_only) must NOT blind skip-and-advance — it must route through the
+              // decision-aware guard below so a chairman_decision is recorded (createOrReusePendingDecision
+              // reuses an already-approved row, so an approved gate still advances, but never silently).
+              const createsDecisionEarly = (await isDecisionCreatingStage(currentStage, this._supabase, { logger: this._logger })).creates_decision;
+              const isBlockingGate = govEarly.isBlocking(currentStage) || await this._isInHardGateStages(currentStage) || createsDecisionEarly;
               if (!isBlockingGate) {
                 // Non-BLOCKING stages: just advance (no vision side-effects needed)
                 this._logger.log(
@@ -1132,7 +1169,13 @@ export class StageExecutionWorker {
           && currentStage >= 17 && currentStage <= 22
           && await this._canAutoAdvance(currentStage);
 
-        if (shouldOpenChairmanGate({ isHardGate: isHardcodedGate || isDynamicHardGate, stageFailed, canGovernanceOverrideFailed })) {
+        // SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-1b): a stage that MINTS a chairman decision
+        // (stage_creates_decision — e.g. S18 promotion/artifact_only) must open the chairman gate
+        // too, not only hardcoded/dynamic hard gates. Without this, S18 ran its producer, isHardGate
+        // was false, and the venture advanced UNREVIEWED. Fail-safe toward gating: isDecisionCreatingStage
+        // falls back to FALLBACK_DECISION_CREATING_STAGES (S18 included) on RPC error.
+        const isDecisionGate = (await isDecisionCreatingStage(currentStage, this._supabase, { logger: this._logger })).creates_decision;
+        if (shouldOpenChairmanGate({ isHardGate: isHardcodedGate || isDynamicHardGate, stageFailed, canGovernanceOverrideFailed, isDecisionGate })) {
           const gateResult = await this._handleChairmanGate(ventureId, currentStage);
           if (gateResult.blocked) {
             // Only revert current_lifecycle_stage when actually blocked for

--- a/package.json
+++ b/package.json
@@ -336,6 +336,8 @@
     "signal": "node scripts/worker-signal.cjs",
     "checkin": "node scripts/worker-checkin.cjs",
     "stamp:tier-rank": "node scripts/stamp-sd-tier-rank.mjs",
+    "reconcile:gate-decisions": "node scripts/reconcile-gate-decisions.mjs",
+    "backfill:gate-decisions": "node scripts/retro-backfill-gate-decisions.mjs",
     "retro:generate": "node scripts/generate-retrospective.js",
     "invocation:check": "node scripts/invocation-check.mjs",
     "canary:sweep": "node scripts/canary-trigger-sweep.mjs",

--- a/scripts/reconcile-gate-decisions.mjs
+++ b/scripts/reconcile-gate-decisions.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-3): CLI reconciliation guard.
+// Lists every (venture, gated-stage) the venture has PASSED with no chairman_decision row —
+// a silent promotion-gate bypass. Exit 1 when violations exist (CI-friendly).
+//
+//   node scripts/reconcile-gate-decisions.mjs
+//   npm run reconcile:gate-decisions
+
+import { createClient } from '@supabase/supabase-js';
+import { reconcileGateDecisions } from '../lib/eva/reconcile-gate-decisions.mjs';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required.');
+  process.exit(1);
+}
+
+const supabase = createClient(url, key);
+
+reconcileGateDecisions(supabase)
+  .then(({ violations, checked }) => {
+    if (violations.length === 0) {
+      console.log(`✓ Gate-decision reconciliation: ${checked} venture(s) checked, 0 violations.`);
+      process.exit(0);
+    }
+    console.error(`❌ Gate-decision reconciliation: ${violations.length} silent-bypass violation(s) across ${checked} venture(s):`);
+    for (const v of violations) console.error(`   - venture ${v.venture_id} passed gated stage ${v.stage} with NO chairman_decision`);
+    process.exit(1);
+  })
+  .catch((e) => {
+    console.error(`❌ ${e.message}`);
+    process.exit(1);
+  });

--- a/scripts/retro-backfill-gate-decisions.mjs
+++ b/scripts/retro-backfill-gate-decisions.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 (FR-4): retroactive backfill.
+// For ventures that already PASSED a gated stage with no chairman_decision (a silent bypass),
+// mint the proper pending chairman gate decision via the canonical createOrReusePendingDecision
+// (idempotent — reuses an existing row). Targets all violations by default; pass a venture id to
+// scope to one (e.g. venture-1).
+//
+//   node scripts/retro-backfill-gate-decisions.mjs           # all violations
+//   node scripts/retro-backfill-gate-decisions.mjs <ventureId>
+//   node scripts/retro-backfill-gate-decisions.mjs --dry     # show, do not write
+//   npm run backfill:gate-decisions
+
+import { createClient } from '@supabase/supabase-js';
+import { reconcileGateDecisions } from '../lib/eva/reconcile-gate-decisions.mjs';
+import { createOrReusePendingDecision } from '../lib/eva/chairman-decision-watcher.js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required.');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const dry = args.includes('--dry');
+const onlyVenture = args.find((a) => !a.startsWith('--'));
+const supabase = createClient(url, key);
+
+(async () => {
+  const { violations } = await reconcileGateDecisions(supabase);
+  const target = onlyVenture ? violations.filter((v) => v.venture_id === onlyVenture) : violations;
+  if (target.length === 0) {
+    console.log('✓ No gate-decision violations to backfill.');
+    return;
+  }
+  console.log(`Backfilling ${target.length} gate-decision violation(s)${dry ? ' [dry-run]' : ''}...`);
+  for (const v of target) {
+    if (dry) {
+      console.log(`[dry] would mint pending chairman_decision: venture ${v.venture_id} stage ${v.stage}`);
+      continue;
+    }
+    const r = await createOrReusePendingDecision({
+      ventureId: v.venture_id, stageNumber: v.stage, decisionType: 'stage_gate',
+      summary: `Retroactive gate decision for stage ${v.stage} (silent-bypass remediation)`,
+      supabase, logger: console,
+    });
+    console.log(`${r.skipped ? '∅ skipped (non-gate)' : r.isNew ? '✓ minted' : '↺ reused'}: venture ${v.venture_id} stage ${v.stage}${r.id ? ` (decision ${r.id})` : ''}`);
+  }
+})().catch((e) => {
+  console.error(`❌ ${e.message}`);
+  process.exit(1);
+});

--- a/tests/unit/eva/reserved-gate-bypass.test.js
+++ b/tests/unit/eva/reserved-gate-bypass.test.js
@@ -1,0 +1,79 @@
+/**
+ * SD-LEO-INFRA-RESERVED-GATE-BYPASS-001 — regression tests.
+ *
+ * FR-1 shouldOpenChairmanGate isDecisionGate (decision-creating stage opens the gate)
+ * FR-2 canAdvancePastBuildCheckpoint (S19 build-checkpoint hard invariant)
+ * FR-3 findGateDecisionViolations (reconciliation guard)
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldOpenChairmanGate, canAdvancePastBuildCheckpoint } from '../../../lib/eva/should-open-chairman-gate.js';
+import { findGateDecisionViolations } from '../../../lib/eva/reconcile-gate-decisions.mjs';
+
+describe('FR-1 shouldOpenChairmanGate — decision-creating gate', () => {
+  it('opens for a decision-creating stage even when it is not a hard gate', () => {
+    // S18-shaped: artifact_only promotion gate -> isHardGate false but isDecisionGate true
+    expect(shouldOpenChairmanGate({ isHardGate: false, isDecisionGate: true, stageFailed: false, canGovernanceOverrideFailed: false })).toBe(true);
+  });
+
+  it('still does NOT open for a failed stage with no governance override (no content-less gate)', () => {
+    expect(shouldOpenChairmanGate({ isHardGate: false, isDecisionGate: true, stageFailed: true, canGovernanceOverrideFailed: false })).toBe(false);
+  });
+
+  it('is byte-identical for callers that omit isDecisionGate (backward compatible)', () => {
+    // old behavior: opens only for hard gates
+    expect(shouldOpenChairmanGate({ isHardGate: true, stageFailed: false, canGovernanceOverrideFailed: false })).toBe(true);
+    expect(shouldOpenChairmanGate({ isHardGate: false, stageFailed: false, canGovernanceOverrideFailed: false })).toBe(false);
+  });
+
+  it('opens for a hard gate regardless of isDecisionGate', () => {
+    expect(shouldOpenChairmanGate({ isHardGate: true, isDecisionGate: false, stageFailed: false, canGovernanceOverrideFailed: false })).toBe(true);
+  });
+});
+
+describe('FR-2 canAdvancePastBuildCheckpoint — S19 hard invariant', () => {
+  it('refuses to advance on the leo_bridge build-readiness gate alone (no chairman approval)', () => {
+    expect(canAdvancePastBuildCheckpoint({ buildComplete: true, hasApprovedChairmanDecision: false })).toBe(false);
+  });
+
+  it('refuses when chairman approved but build not ready', () => {
+    expect(canAdvancePastBuildCheckpoint({ buildComplete: false, hasApprovedChairmanDecision: true })).toBe(false);
+  });
+
+  it('advances only when BOTH build-ready AND chairman-approved', () => {
+    expect(canAdvancePastBuildCheckpoint({ buildComplete: true, hasApprovedChairmanDecision: true })).toBe(true);
+  });
+});
+
+describe('FR-3 findGateDecisionViolations — reconciliation guard', () => {
+  const GATED = [18, 19];
+
+  it('flags a venture past a gated stage with no chairman_decision', () => {
+    const ventures = [{ id: 'v1', current_lifecycle_stage: 20 }]; // passed 18 and 19
+    const decisions = [{ venture_id: 'v1', lifecycle_stage: 19 }]; // has 19 but NOT 18
+    const violations = findGateDecisionViolations(ventures, decisions, GATED);
+    expect(violations).toEqual([{ venture_id: 'v1', stage: 18 }]);
+  });
+
+  it('reports zero for a venture with all gate decisions present', () => {
+    const ventures = [{ id: 'v1', current_lifecycle_stage: 20 }];
+    const decisions = [{ venture_id: 'v1', lifecycle_stage: 18 }, { venture_id: 'v1', lifecycle_stage: 19 }];
+    expect(findGateDecisionViolations(ventures, decisions, GATED)).toEqual([]);
+  });
+
+  it('does not flag a gated stage the venture is still AT or before (not yet passed)', () => {
+    const ventures = [{ id: 'v1', current_lifecycle_stage: 18 }]; // at 18, has not passed it
+    expect(findGateDecisionViolations(ventures, [], GATED)).toEqual([]);
+  });
+
+  it('handles multiple ventures and multiple gated stages', () => {
+    const ventures = [
+      { id: 'a', current_lifecycle_stage: 21 }, // passed 18 + 19
+      { id: 'b', current_lifecycle_stage: 19 }, // passed 18 only
+    ];
+    const decisions = [{ venture_id: 'a', lifecycle_stage: 18 }]; // a missing 19; b missing 18
+    const violations = findGateDecisionViolations(ventures, decisions, GATED);
+    expect(violations).toContainEqual({ venture_id: 'a', stage: 19 });
+    expect(violations).toContainEqual({ venture_id: 'b', stage: 18 });
+    expect(violations).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
Chairman-RESERVED promotion gates (notably **S18** marketing/GTM) were **silently bypassed**: the worker's gate-open test keyed only on `isHardGate` (`isBlocking || hard_gate_stages`), which excludes a `gate_type='promotion'` stage with `work_type='artifact_only'` (S18). So S18 ran its producer, minted **no** `chairman_decision`, and the venture auto-advanced unreviewed — the flagship reached BUILD-mode without an S19 build-checkpoint.

## Fix (reuse-heavy — the canonical `stage_creates_decision` predicate already existed)
- **FR-1**: `shouldOpenChairmanGate` gains an optional `isDecisionGate` (open when `isHardGate || isDecisionGate`; content-less-failed-stage guard unchanged; backward-compatible). Wired at the **post-exec gate handler** and the **pre-exec skip-and-advance guard** via `isDecisionCreatingStage` (S18 in the fallback set, fail-safe-to-gating).
- **FR-2**: `canAdvancePastBuildCheckpoint` hard invariant — a venture cannot advance past S19 on the leo_bridge **build-readiness** gate alone; an **approved S19 chairman build-checkpoint** decision is also required (fail-closed). Wired as a re-entry guard (gated on an existing S19 artifact, so first arrival still mints the pending gate — never content-less).
- **FR-3**: `reconcile-gate-decisions` (pure `findGateDecisionViolations` + DB wrapper + CLI) flags any venture past a gated stage with no decision. `npm run reconcile:gate-decisions`.
- **FR-4**: `retro-backfill-gate-decisions` idempotently mints pending decisions for already-bypassed gates (venture-1 S18/S19). `npm run backfill:gate-decisions`.

## Tests
11 new regression tests (FR-1/FR-2/FR-3). **No new regressions** — the 7 pre-existing `stage-execution-worker.test.js` failures are baseline rot (identical with my changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)