### PR TITLE
feat(SD-LEO-INFRA-FLEET-HIBERNATION-001): charter-audit quiescence-awareness (linchpin)

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -412,7 +412,15 @@ export function foundationalQueryError(error, table) {
  * coordinator_request / adam_advisory sourcing-ping row exists). Belt-low alone is NOT a violation.
  * @param {{ claimableBelt?: number|null, idleWorkers?: number|null, sourceRequestedRecently?: boolean|null, beltLowThreshold?: number }} facts
  */
-export function detectSourceToCapacity({ claimableBelt, idleWorkers, sourceRequestedRecently, beltLowThreshold = 1 } = {}) {
+export function detectSourceToCapacity({ claimableBelt, idleWorkers, sourceRequestedRecently, beltLowThreshold = 1, quiescent = false } = {}) {
+  // SD-LEO-INFRA-FLEET-HIBERNATION-001 FR-3 (LINCHPIN): when the fleet is QUIESCENT (the line is
+  // genuinely stopped per assessFleetActivity — no workers building, no deficit, no venture-1 decision
+  // pending), a low belt + idle worker is NOT a charter violation. There is nothing to source for while
+  // quiesced, so the chairman's drive-to-0 directive must not force a sourcing-handshake re-send. The
+  // belt-low handshake only matters when there IS demand. (Chairman-blessed via this SD.)
+  if (quiescent === true) {
+    return { violation: false, detail: `fleet QUIESCENT — belt=${claimableBelt}, idle=${idleWorkers}: belt-low source-to-capacity handshake suppressed (nothing to source while the line is stopped)`, remediation: null };
+  }
   // Fail-loud: an unresolved input is reported, never silently treated as healthy.
   if (claimableBelt == null || idleWorkers == null || sourceRequestedRecently == null) {
     return { violation: true, detail: 'SOURCE-TO-CAPACITY inputs unresolved (belt/idle/sourceRequested) — cannot confirm the handshake (fail-loud)', remediation: 'ACTION: resolve the belt/idle/source-request facts before trusting the handshake' };

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -51,6 +51,9 @@ import { findLeadAgingDrafts } from '../lib/coordinator/lead-aging-detector.mjs'
 import { isDispatchableFleetMember } from '../lib/fleet/session-predicates.mjs';
 
 const require = createRequire(import.meta.url);
+// SD-LEO-INFRA-FLEET-HIBERNATION-001 FR-2/FR-3: the SINGLE 'line stopped' signal, consumed here so the
+// charter-audit does not register a belt-low source-to-capacity violation while the fleet is quiesced.
+const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs');
 const { isWithinArmedSilenceWindow } = require('../lib/fleet/silence-cap.cjs');
 const { classifyDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-FDBK-INFRA-FLEET-SELF-CLAIM-001: appOfCwd derives a checkout's repo-app (it already strips a
@@ -226,6 +229,18 @@ async function main() {
     if (!se) promotableCount = verifyStagedCandidates(staged || []).validCount;
   } catch { /* fail-open → promotableCount stays 0, no advisory */ }
 
+  // SD-LEO-INFRA-FLEET-HIBERNATION-001 FR-2/FR-3: assess fleet quiescence (the shared 'line stopped'
+  // gate). Fails OPEN to active on any error (never silences the fleet), so an assessment hiccup keeps
+  // the belt-low detector live. When quiescent, the source-to-capacity detector is suppressed below.
+  let fleetQuiescent = false;
+  try {
+    const q = await assessFleetActivity(db, { now: nowMs });
+    fleetQuiescent = q.quiescent === true;
+    console.log(`[COORD-CHARTER-AUDIT] fleet quiescence: ${q.reason}`);
+  } catch (e) {
+    console.error('[COORD-CHARTER-AUDIT] WARN: quiescence assessment failed (fail-active): ' + e.message);
+  }
+
   // ── run the pure detectors ──
   const D = {
     pool: detectWorktreePool({ count: wtCount, max: MAX_WORKTREE_COUNT }),
@@ -240,7 +255,7 @@ async function main() {
     quiet: detectQuietTickUnverified({ coordinatorReviews: reviews || [] }),
     // FR-3 coordinator mirror — added only when their facts resolved (skip-on-error, no spam).
     ...(adamAlive !== null ? { d3lean: detectCoordinatorWithoutAdam({ coordinatorAlive: true, adamAlive }) } : {}),
-    ...(sourceReqRecently !== null ? { srcCap: detectSourceToCapacity({ claimableBelt: claimable.length, idleWorkers: idleWorkerCount, sourceRequestedRecently: sourceReqRecently }) } : {}),
+    ...(sourceReqRecently !== null ? { srcCap: detectSourceToCapacity({ claimableBelt: claimable.length, idleWorkers: idleWorkerCount, sourceRequestedRecently: sourceReqRecently, quiescent: fleetQuiescent }) } : {}),
     // SD-LEO-INFRA-SILENT-STALL-PREVENTION-001: drafts stranded with a null vision_score (silent stall).
     // Advisory remediation count only — summarizeViolations never drives a process.exit (foundational-query
     // failures are the ONLY hard exits), so a stalled draft surfaces a remediation action, never a hard fail.

--- a/tests/unit/coordinator/fleet-hibernation-quiescence-suppression.test.js
+++ b/tests/unit/coordinator/fleet-hibernation-quiescence-suppression.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { detectSourceToCapacity } from '../../../lib/coordinator/charter-audit-detectors.mjs';
+
+// SD-LEO-INFRA-FLEET-HIBERNATION-001 FR-3 (LINCHPIN): the belt-low source-to-capacity charter
+// violation must be SUPPRESSED while the fleet is quiescent — there is nothing to source for while
+// the line is genuinely stopped, so the chairman's drive-to-0 has no belt-low violation to force a
+// handshake re-send for.
+
+describe('FR-3: detectSourceToCapacity quiescence-awareness', () => {
+  const beltLowIdle = { claimableBelt: 0, idleWorkers: 1, sourceRequestedRecently: false };
+
+  it('FIRES a violation when belt-low + idle + no source request AND NOT quiescent (unchanged)', () => {
+    const r = detectSourceToCapacity({ ...beltLowIdle, quiescent: false });
+    expect(r.violation).toBe(true);
+    expect(r.remediation).toMatch(/ping Adam|source/i);
+  });
+
+  it('SUPPRESSES the violation when quiescent (the linchpin)', () => {
+    const r = detectSourceToCapacity({ ...beltLowIdle, quiescent: true });
+    expect(r.violation).toBe(false);
+    expect(r.remediation).toBeNull();
+    expect(r.detail).toMatch(/quiescent/i);
+  });
+
+  it('quiescent suppresses even with unresolved inputs (no fail-loud spam while the line is stopped)', () => {
+    const r = detectSourceToCapacity({ claimableBelt: null, idleWorkers: null, sourceRequestedRecently: null, quiescent: true });
+    expect(r.violation).toBe(false);
+  });
+
+  it('default (quiescent omitted) preserves the prior fail-loud-on-unresolved behavior', () => {
+    const r = detectSourceToCapacity({ claimableBelt: null, idleWorkers: 1, sourceRequestedRecently: false });
+    expect(r.violation).toBe(true);
+    expect(r.detail).toMatch(/unresolved/i);
+  });
+
+  it('a recent source request clears the violation regardless (unchanged path)', () => {
+    const r = detectSourceToCapacity({ claimableBelt: 0, idleWorkers: 1, sourceRequestedRecently: true, quiescent: false });
+    expect(r.violation).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
While the fleet is genuinely **quiescent**, the coordinator charter-audit still registered a belt-low / idle-no-recent-source **CHARTER violation** — so the chairman's drive-violations-to-0 directive forced a sourcing-handshake re-send every cycle even though there was nothing to source. This ships the **linchpin**:

- **FR-3 (LINCHPIN):** `detectSourceToCapacity` now **suppresses** the belt-low source-to-capacity violation when `quiescent===true`. When NOT quiescent, behavior is unchanged.
- **FR-2:** `coordinator-charter-audit.mjs` calls the existing shared quiescence gate (`lib/coordinator/fleet-quiescence.cjs assessFleetActivity`) — the single 'line stopped' signal — and threads `quiescent` into the detector. **Fails OPEN to active** on any assessment error (never silences the fleet).

**Scope:** ships the load-bearing FR-2/FR-3 linchpin (the SD's lead regression — '0 violations while quiesced without a forced handshake re-send'). The larger hibernation machinery — **FR-1** quiet-tick aggregator, **FR-4** cross-party ping suppression, **FR-5/FR-6** adaptive self-pacing cadence + event-wake, and the **Adam-side** quiet-tick — is **deferred as a flagged follow-on** (substantial new-script work).

## Verification
5 new unit tests + existing 58 detector tests green; both edited files `node --check` clean.

SD: SD-LEO-INFRA-FLEET-HIBERNATION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)