### PR TITLE
feat(SD-LEO-INFRA-SD-PRD-DRIFT-GATE-001): SD↔PRD drift guard at PLAN→EXEC

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.js
@@ -1,0 +1,204 @@
+/**
+ * SD↔PRD Drift Gate (PLAN→EXEC)
+ * Part of SD-LEO-INFRA-SD-PRD-DRIFT-GATE-001
+ *
+ * Late SD-scope edits (a new FR, or a chairman-gated precondition added AFTER the PRD was
+ * written) can be silently dropped because nothing compares the SD's functional requirements
+ * against the PRD that EXEC actually implements. This gate detects that drift.
+ *
+ * FR-1 drift detector: extract SD FRs (metadata.functional_requirements, else FR-N prose) +
+ *      PRD functional_requirements; flag any material SD FR absent from the PRD.
+ * FR-2 false-positive guard: match by FR IDENTITY (FR-key first, keyword-similarity fallback) —
+ *      NOT exact string equality — so a reworded-but-present FR does not false-block.
+ * FR-3 actionable output: name exactly which SD FRs are missing + route to a PRD re-sync.
+ * FR-4 gov-precondition enforcement: a chairman-gated precondition on the SD
+ *      (metadata.chairman_decision_required) must be reflected in the PRD or blessed via an
+ *      approved chairman_decision before the handoff passes.
+ * FR-5 advisory→enforcing: advisory by default (warn, passed=true — never wedges); flip to
+ *      enforcing (block) via SD_PRD_DRIFT_ENFORCING=true.
+ */
+
+import { extractKeywords, calculateSimilarity } from '../../../validation/scope-similarity.js';
+
+// FR-2: keyword-similarity threshold for the no-key-match fallback. Jaccard over FR text.
+const SIMILARITY_THRESHOLD = 0.18;
+// Minimum SD-FR text length to bother similarity-matching (skip empty/degenerate FRs).
+const MIN_FR_TEXT = 8;
+
+/** Inline array-normalizer (prd-quality-validation.js's normalizeToArray is not exported). */
+function normalizeToArray(value) {
+  if (Array.isArray(value)) return value;
+  if (!value) return [];
+  if (typeof value === 'string') {
+    try { const parsed = JSON.parse(value); if (Array.isArray(parsed)) return parsed; } catch { /* not JSON */ }
+    return [];
+  }
+  if (typeof value === 'object') return [value];
+  return [];
+}
+
+/**
+ * Extract the SD's FR list. Prefers structured metadata.functional_requirements; falls back to
+ * parsing FR-N keys + the following prose from description + scope.
+ * @returns {Array<{id:string, text:string}>}
+ */
+export function extractSdFrs(sd) {
+  if (!sd) return [];
+  const structured = normalizeToArray(sd.metadata?.functional_requirements);
+  if (structured.length > 0) {
+    return structured
+      .map((f, i) => ({
+        id: String(f.id || f.fr_key || `FR-${i + 1}`).toUpperCase(),
+        text: [f.title, f.description].filter(Boolean).join(' ').trim(),
+      }))
+      .filter((f) => f.id);
+  }
+  // Prose fallback: split description+scope on FR-N markers, keep the text until the next FR-N.
+  const prose = [sd.description, sd.scope].filter(Boolean).join('\n');
+  const frs = [];
+  const re = /\bFR-(\d+)\b[:.\s-]*/gi;
+  let m;
+  const marks = [];
+  while ((m = re.exec(prose)) !== null) marks.push({ id: `FR-${m[1]}`, start: m.index, textStart: re.lastIndex });
+  for (let i = 0; i < marks.length; i++) {
+    const end = i + 1 < marks.length ? marks[i + 1].start : prose.length;
+    const text = prose.slice(marks[i].textStart, end).trim();
+    // dedup repeated FR-N markers (description + scope often duplicate); keep the longest text.
+    const existing = frs.find((f) => f.id === marks[i].id.toUpperCase());
+    if (existing) { if (text.length > existing.text.length) existing.text = text; }
+    else frs.push({ id: marks[i].id.toUpperCase(), text });
+  }
+  return frs;
+}
+
+/** Extract the PRD's FR list as {id, text}. */
+export function extractPrdFrs(prd) {
+  const arr = normalizeToArray(prd?.functional_requirements);
+  return arr.map((f, i) => ({
+    id: String(f.id || f.fr_key || `FR-${i + 1}`).toUpperCase(),
+    text: [f.title, f.description].filter(Boolean).join(' ').trim(),
+  }));
+}
+
+/**
+ * FR-1 + FR-2: is this SD FR present in the PRD? Identity match — FR-key first, then a keyword
+ * similarity fallback over the FR text (so reworded-but-present FRs are recognized).
+ */
+export function sdFrPresentInPrd(sdFr, prdFrs) {
+  if (prdFrs.some((p) => p.id && p.id === sdFr.id)) return true; // key match
+  if (!sdFr.text || sdFr.text.length < MIN_FR_TEXT) return true; // too thin to assert drift — don't false-block
+  const sdKw = extractKeywords(sdFr.text);
+  return prdFrs.some((p) => calculateSimilarity(sdKw, extractKeywords(p.text)) >= SIMILARITY_THRESHOLD);
+}
+
+/** FR-3: the SD FRs absent from the PRD (by identity). */
+export function findDriftedFrs(sdFrs, prdFrs) {
+  return sdFrs.filter((f) => !sdFrPresentInPrd(f, prdFrs));
+}
+
+/**
+ * FR-4: is a chairman-gated precondition recorded on the SD, and is it reflected in the
+ * PRD/EXEC contract (or blessed via an approved chairman_decision)?
+ * @returns {Promise<{required:boolean, satisfied:boolean, marker:string|null}>}
+ */
+export async function checkGovPrecondition(sd, prd, supabase) {
+  const marker = sd?.metadata?.chairman_decision_required;
+  if (!marker) return { required: false, satisfied: true, marker: null };
+  // (a) reflected in the PRD: any FR/AC/technical_requirement text references a chairman bless/decision precondition.
+  const haystack = JSON.stringify({
+    fr: prd?.functional_requirements, ac: prd?.acceptance_criteria, tr: prd?.technical_requirements,
+  }).toLowerCase();
+  const reflected = /chairman|bless|gov-?precondition|must not cut over|approval required|decision required/.test(haystack);
+  if (reflected) return { required: true, satisfied: true, marker: String(marker) };
+  // (b) blessed via an approved chairman_decision for this SD.
+  try {
+    const sdId = sd.id || sd.sd_key;
+    const { data } = await supabase
+      .from('chairman_decisions')
+      .select('id,status')
+      .or(`context->>sd_id.eq.${sdId},context->>sd_key.eq.${sd.sd_key || sdId}`)
+      .in('status', ['approved', 'reviewed', 'APPROVED', 'REVIEWED'])
+      .limit(1);
+    if (data && data.length > 0) return { required: true, satisfied: true, marker: String(marker) };
+  } catch { /* fail toward surfacing: treat as unsatisfied (advisory by default) */ }
+  return { required: true, satisfied: false, marker: String(marker) };
+}
+
+async function fetchPrd(ctx) {
+  if (ctx?._prd) return ctx._prd;
+  const sb = ctx?.supabase;
+  const sd = ctx?.sd || {};
+  if (!sb) return null;
+  // product_requirements_v2.directive_id holds the sd_key; id is PRD-<sdkey>.
+  const key = sd.sd_key || sd.id || ctx.sdId;
+  try {
+    const { data } = await sb
+      .from('product_requirements_v2')
+      .select('functional_requirements, acceptance_criteria, technical_requirements')
+      .or(`directive_id.eq.${key},id.eq.PRD-${key}`)
+      .limit(1)
+      .maybeSingle();
+    return data;
+  } catch { return null; }
+}
+
+/**
+ * Create the SD_PRD_DRIFT gate.
+ * @param {Object} [supabaseOverride] optional supabase (else ctx.supabase)
+ */
+export function createSDPRDDriftGate(supabaseOverride) {
+  const enforcing = String(process.env.SD_PRD_DRIFT_ENFORCING || '').toLowerCase() === 'true';
+  return {
+    name: 'SD_PRD_DRIFT',
+    // FR-5: advisory-first — the gate is non-required (advisory) unless enforcing is enabled.
+    required: enforcing,
+    validator: async (ctx) => {
+      console.log('\n🔀 SD↔PRD DRIFT GATE (SD-LEO-INFRA-SD-PRD-DRIFT-GATE-001)');
+      console.log('-'.repeat(50));
+      const sd = ctx?.sd || {};
+      const supabase = supabaseOverride || ctx?.supabase;
+      const prd = await fetchPrd({ ...ctx, supabase });
+
+      const sdFrs = extractSdFrs(sd);
+      const prdFrs = extractPrdFrs(prd);
+
+      // No extractable SD FRs (or no PRD) → cannot reliably assert drift; no-op (advisory pass).
+      if (sdFrs.length === 0 || !prd) {
+        console.log(`   ℹ️  No comparable FRs (sdFrs=${sdFrs.length}, prd=${prd ? 'yes' : 'no'}) — drift check skipped.`);
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details: { skipped: true, sdFrCount: sdFrs.length, prdFrCount: prdFrs.length } };
+      }
+
+      const drifted = findDriftedFrs(sdFrs, prdFrs);
+      const gov = await checkGovPrecondition(sd, prd, supabase);
+
+      const problems = [];
+      for (const f of drifted) problems.push(`SD ${f.id} is absent from the PRD: "${(f.text || '').slice(0, 60)}…"`);
+      if (gov.required && !gov.satisfied) {
+        problems.push(`Chairman-gated precondition (metadata.chairman_decision_required=${gov.marker}) is NOT reflected in the PRD and has no approved chairman_decision`);
+      }
+
+      const remediation = 'PRD re-sync: add the named SD FR(s)/precondition to product_requirements_v2.functional_requirements (and reflect any chairman precondition), then re-validate the PRD before re-running PLAN→EXEC.';
+      const details = {
+        sdFrCount: sdFrs.length, prdFrCount: prdFrs.length,
+        missing_frs: drifted.map((f) => ({ id: f.id, label: (f.text || '').slice(0, 80) })),
+        gov_precondition: gov,
+        enforcing,
+      };
+
+      if (problems.length === 0) {
+        console.log(`   ✅ No SD↔PRD drift (${sdFrs.length} SD FR(s) all reflected; gov-precondition ${gov.required ? 'satisfied' : 'n/a'}).`);
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [], details };
+      }
+
+      // FR-3 + FR-5: name the drift; advisory => warnings+pass, enforcing => issues+block.
+      console.log(`   ${enforcing ? '❌' : '⚠️'} SD↔PRD drift (${problems.length}) [${enforcing ? 'ENFORCING' : 'ADVISORY'}]:`);
+      for (const p of problems) console.log(`      - ${p}`);
+      if (enforcing) {
+        return { passed: false, score: 0, max_score: 100, issues: problems, warnings: [], remediation, details };
+      }
+      return { passed: true, score: 100, max_score: 100, issues: [], warnings: [...problems, `(advisory — set SD_PRD_DRIFT_ENFORCING=true to block) ${remediation}`], details };
+    },
+  };
+}
+
+export default { createSDPRDDriftGate, extractSdFrs, extractPrdFrs, sdFrPresentInPrd, findDriftedFrs, checkGovPrecondition };

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.test.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.test.js
@@ -1,0 +1,157 @@
+/**
+ * SD↔PRD Drift Gate — regression tests
+ * SD-LEO-INFRA-SD-PRD-DRIFT-GATE-001 (FR-1..FR-5)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createSDPRDDriftGate,
+  extractSdFrs,
+  extractPrdFrs,
+  findDriftedFrs,
+  checkGovPrecondition,
+} from './sd-prd-drift.js';
+
+/** Minimal supabase stub: serves a PRD by directive_id/id and chairman_decisions. */
+function stubSupabase({ prd = null, decisions = [] } = {}) {
+  return {
+    from(table) {
+      const api = {
+        select() { return api; },
+        or() { return api; },
+        eq() { return api; },
+        in() { return api; },
+        limit() { return api; },
+        async maybeSingle() { return { data: table === 'product_requirements_v2' ? prd : null, error: null }; },
+        then(resolve) { return resolve({ data: table === 'chairman_decisions' ? decisions : [], error: null }); },
+      };
+      return api;
+    },
+  };
+}
+
+const SD_PROSE = {
+  sd_key: 'SD-X-001', id: 'uuid-x',
+  description: 'FR-1 the detector compares SD and PRD. FR-2 false-positive guard via identity match. FR-3 actionable output naming missing FRs. FR-4 governance precondition enforcement.',
+  scope: '',
+  metadata: {},
+};
+
+describe('FR-1 SD/PRD FR extraction + drift detection', () => {
+  it('extracts SD FRs from prose FR-N markers', () => {
+    const frs = extractSdFrs(SD_PROSE);
+    expect(frs.map((f) => f.id)).toEqual(['FR-1', 'FR-2', 'FR-3', 'FR-4']);
+    expect(frs[0].text).toMatch(/compares SD and PRD/);
+  });
+
+  it('prefers structured metadata.functional_requirements when present', () => {
+    const frs = extractSdFrs({ metadata: { functional_requirements: [{ id: 'FR-1', title: 'A', description: 'a' }, { id: 'FR-2', title: 'B' }] } });
+    expect(frs.map((f) => f.id)).toEqual(['FR-1', 'FR-2']);
+  });
+
+  it('extracts PRD FRs from a JSONB array and a JSON string', () => {
+    expect(extractPrdFrs({ functional_requirements: [{ id: 'FR-1', title: 'x' }] }).length).toBe(1);
+    expect(extractPrdFrs({ functional_requirements: JSON.stringify([{ id: 'FR-1' }, { id: 'FR-2' }]) }).length).toBe(2);
+  });
+
+  it('detects an SD FR absent from the PRD', () => {
+    const sdFrs = extractSdFrs(SD_PROSE);
+    const prdFrs = [{ id: 'FR-1', text: 'detector' }, { id: 'FR-2', text: 'guard' }, { id: 'FR-4', text: 'governance' }];
+    const drift = findDriftedFrs(sdFrs, prdFrs);
+    expect(drift.map((f) => f.id)).toEqual(['FR-3']);
+  });
+});
+
+describe('FR-2 false-positive guard (identity match, not string equality)', () => {
+  it('treats a key-matched FR as present regardless of text', () => {
+    const drift = findDriftedFrs([{ id: 'FR-1', text: 'totally different words here' }], [{ id: 'FR-1', text: 'unrelated prd prose' }]);
+    expect(drift).toHaveLength(0);
+  });
+
+  it('treats a reworded-but-similar FR (no key match) as present via similarity', () => {
+    const sdFrs = [{ id: 'FR-9', text: 'detector compares functional requirements between directive and product document' }];
+    const prdFrs = [{ id: 'FR-A', text: 'the detector compares functional requirements across the directive and product requirements' }];
+    expect(findDriftedFrs(sdFrs, prdFrs)).toHaveLength(0);
+  });
+
+  it('flags a genuinely-absent FR with no key match and low similarity', () => {
+    const sdFrs = [{ id: 'FR-9', text: 'enforce spend guardrails with hard dollar caps for billing safety' }];
+    const prdFrs = [{ id: 'FR-A', text: 'render a marketing roadmap timeline component on the dashboard' }];
+    expect(findDriftedFrs(sdFrs, prdFrs).map((f) => f.id)).toEqual(['FR-9']);
+  });
+});
+
+describe('FR-4 governance-precondition enforcement', () => {
+  it('skips when the SD carries no chairman precondition', async () => {
+    const r = await checkGovPrecondition({ metadata: {} }, {}, stubSupabase());
+    expect(r).toEqual({ required: false, satisfied: true, marker: null });
+  });
+
+  it('passes when the precondition is reflected in the PRD', async () => {
+    const sd = { sd_key: 'SD-X', metadata: { chairman_decision_required: true } };
+    const prd = { functional_requirements: [{ id: 'FR-1', description: 'must not cut over until chairman bless is recorded' }] };
+    const r = await checkGovPrecondition(sd, prd, stubSupabase());
+    expect(r.required).toBe(true);
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('passes when blessed via an approved chairman_decision', async () => {
+    const sd = { sd_key: 'SD-X', id: 'uuid', metadata: { chairman_decision_required: true } };
+    const prd = { functional_requirements: [{ id: 'FR-1', description: 'unrelated' }] };
+    const r = await checkGovPrecondition(sd, prd, stubSupabase({ decisions: [{ id: 'd1', status: 'approved' }] }));
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('flags an unreflected, unblessed precondition', async () => {
+    const sd = { sd_key: 'SD-X', id: 'uuid', metadata: { chairman_decision_required: true } };
+    const prd = { functional_requirements: [{ id: 'FR-1', description: 'unrelated prose' }] };
+    const r = await checkGovPrecondition(sd, prd, stubSupabase({ decisions: [] }));
+    expect(r.required).toBe(true);
+    expect(r.satisfied).toBe(false);
+  });
+});
+
+describe('FR-5 advisory vs enforcing + gate shape', () => {
+  const prdMissingFr3 = { functional_requirements: [{ id: 'FR-1', title: 'detector' }, { id: 'FR-2', title: 'guard' }, { id: 'FR-4', title: 'governance' }] };
+
+  afterEach(() => { delete process.env.SD_PRD_DRIFT_ENFORCING; });
+
+  it('gate has the standard shape', () => {
+    const gate = createSDPRDDriftGate(stubSupabase());
+    expect(gate.name).toBe('SD_PRD_DRIFT');
+    expect(typeof gate.validator).toBe('function');
+  });
+
+  it('advisory (default): drift yields warnings + passed=true (never wedges)', async () => {
+    delete process.env.SD_PRD_DRIFT_ENFORCING;
+    const gate = createSDPRDDriftGate(stubSupabase({ prd: prdMissingFr3 }));
+    const r = await gate.validator({ sd: SD_PROSE, sdId: 'uuid-x', supabase: stubSupabase({ prd: prdMissingFr3 }) });
+    expect(r.passed).toBe(true);
+    expect(r.warnings.some((w) => /FR-3/.test(w))).toBe(true);
+    expect(r.details.missing_frs.map((f) => f.id)).toContain('FR-3');
+  });
+
+  it('enforcing: drift yields issues + passed=false naming the missing FR', async () => {
+    process.env.SD_PRD_DRIFT_ENFORCING = 'true';
+    const gate = createSDPRDDriftGate(stubSupabase({ prd: prdMissingFr3 }));
+    expect(gate.required).toBe(true);
+    const r = await gate.validator({ sd: SD_PROSE, sdId: 'uuid-x', supabase: stubSupabase({ prd: prdMissingFr3 }) });
+    expect(r.passed).toBe(false);
+    expect(r.issues.some((i) => /FR-3/.test(i))).toBe(true);
+    expect(r.remediation).toMatch(/re-sync/i);
+  });
+
+  it('passes (no drift) when all SD FRs are reflected in the PRD', async () => {
+    const fullPrd = { functional_requirements: [{ id: 'FR-1' }, { id: 'FR-2' }, { id: 'FR-3' }, { id: 'FR-4' }] };
+    const gate = createSDPRDDriftGate(stubSupabase({ prd: fullPrd }));
+    const r = await gate.validator({ sd: SD_PROSE, sdId: 'uuid-x', supabase: stubSupabase({ prd: fullPrd }) });
+    expect(r.passed).toBe(true);
+    expect(r.details.missing_frs).toHaveLength(0);
+  });
+
+  it('no-ops (advisory pass) when there is no PRD or no extractable SD FRs', async () => {
+    const gate = createSDPRDDriftGate(stubSupabase({ prd: null }));
+    const r = await gate.validator({ sd: SD_PROSE, sdId: 'uuid-x', supabase: stubSupabase({ prd: null }) });
+    expect(r.passed).toBe(true);
+    expect(r.details.skipped).toBe(true);
+  });
+});

--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -49,6 +49,8 @@ import { createSdStartGate } from '../../gates/core-protocol-gate.js';
 
 // DFE Escalation Gate (SD-MAN-GEN-CORRECTIVE-VISION-GAP-003)
 import { createDFEEscalationGate } from '../../gates/dfe-escalation-gate.js';
+// SD-LEO-INFRA-SD-PRD-DRIFT-GATE-001: SD↔PRD FR/gov-precondition drift guard (advisory-first)
+import { createSDPRDDriftGate } from './gates/sd-prd-drift.js';
 
 // Sub-Agent Evidence Gate (SD-LEO-INFRA-OPUS-MODULE-SUB-001) — Module C DB-enforced evidence
 import { createSubagentEvidenceGate } from '../../gates/subagent-evidence-gate.js';
@@ -192,6 +194,11 @@ export class PlanToExecExecutor extends BaseExecutor {
 
       // Contract Compliance
       gates.push(createContractComplianceGate(this.prdRepo, sd));
+
+      // SD↔PRD Drift (SD-LEO-INFRA-SD-PRD-DRIFT-GATE-001): an SD FR or chairman-gated
+      // precondition absent from the PRD that EXEC implements. Advisory-first (warn, never
+      // wedges) unless SD_PRD_DRIFT_ENFORCING=true. PRD exists by this point.
+      gates.push(createSDPRDDriftGate(this.supabase));
 
       // Planning Completeness
       gates.push(createPlanningCompletenessGate(this.supabase, sd));


### PR DESCRIPTION
## Summary
Late SD-scope edits (a new FR, or a chairman-gated precondition added **after** the PRD was written) could be silently dropped — nothing compared the SD's functional requirements against the PRD that EXEC implements. New **advisory-first** PLAN→EXEC gate `SD_PRD_DRIFT`.

## FRs
- **FR-1** extracts SD FRs (`metadata.functional_requirements` else FR-N prose) + PRD `functional_requirements`; detects any SD FR absent from the PRD.
- **FR-2** matches by FR **identity** (FR-key first, keyword-similarity fallback via the existing `scope-similarity`) — not string equality — so a reworded-but-present FR does **not** false-block.
- **FR-3** names exactly which SD FRs drifted + routes to a PRD re-sync (structured `details`).
- **FR-4** enforces a chairman-gated precondition (`metadata.chairman_decision_required`) is reflected in the PRD or blessed via an approved `chairman_decision` (the ship-without-bless gap class).
- **FR-5** advisory-first (warn, `passed=true`, never wedges); `SD_PRD_DRIFT_ENFORCING=true` flips to block. Registered in `getRequiredGates`.

## Tests
16 regression tests (all 5 FRs + the 3 smoke scenarios). Additive (new gate + one registration line); fail-safe-to-advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)