### PR TITLE
feat(SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-B): FR-2/FR-5 — Cloudflare-default venture-hosting standard (SSOT rewrite)

### DIFF
--- a/docs/03_protocols_and_standards/venture-hosting-standard.md
+++ b/docs/03_protocols_and_standards/venture-hosting-standard.md
@@ -7,62 +7,67 @@ last_updated: 2026-06-03
 tags: [protocol, protocols-and-standards]
 ---
 
-# Venture Hosting Standard (Replit)
+# Venture Hosting Standard (Cloudflare-default)
 
-**Status:** Active standard — chairman directive, 2026-06-02 (auth corrected to **Clerk** 2026-06-03).
+**Status:** Active standard — chairman directive, 2026-06-02; **Cloudflare-default re-instated 2026-06-27** (decision `CD30_stack_cloudflare`, which supersedes CD-15's accidental Replit re-lock and re-instates the 2026-06-14 ratified Cloudflare-default standard). Auth = **Clerk** (2026-06-03).
 **Applies to:** ALL EHG **portfolio ventures** (the products built via the venture-build / leo_bridge pipeline — e.g. DataDistill, CronGenius).
 **Does NOT apply to:** the **platform** — `EHG_Engineer` (LEO orchestrator) and the `EHG` management app — which remain on **Supabase**. This standard governs ventures, not the platform.
 
 > **⭐ Source of truth (do not let this doc drift again).** The authoritative, machine-enforced
-> standard lives in CODE, not in this prose: the per-venture build context written by
-> **`lib/eva/bridge/claude-md-writer.js`** (lines ~48-62) + **`lib/eva/bridge/build-tasks-writer.js`**,
-> re-expressed as structured data in **`lib/eva/standards/venture-stack-policy.js`** and enforced by
-> the fail-closed scanner **`lib/eva/standards/venture-stack-compliance.js`**. This document MIRRORS
-> those files; if they ever disagree, **the code wins** and a `policy-consistency` test reds. (Wired by
-> SD-LEO-INFRA-VENTURE-STACK-STANDARDS-001 after a hand-authored "Replit Auth" entry here drifted from
-> the code and propagated into a venture build.)
+> standard lives in CODE, not in this prose: the structured policy in
+> **`lib/eva/standards/venture-stack-policy.js`**, enforced by the fail-closed scanner
+> **`lib/eva/standards/venture-stack-compliance.js`**, and the per-venture build context written by the
+> descriptor-aware **`lib/eva/bridge/build-tasks-writer.js`** + **`lib/eva/bridge/replit-config-writer.js`**.
+> The **default deployment target** is selected by descriptor at venture creation
+> (`lib/venture-deploy/stack-descriptor.js` + the default-seeding in the venture provisioner); the
+> `deployTargetFamily()` fail-safe remains the guard for genuinely invalid/malformed descriptors only.
+> This document MIRRORS those files; if they ever disagree, **the code wins** and a `policy-consistency`
+> test reds. (Cloudflare-default wired by SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001 after CD-15
+> accidentally inherited the un-updated Replit standard; originally guarded by
+> SD-LEO-INFRA-VENTURE-STACK-STANDARDS-001 after a hand-authored "Replit Auth" entry drifted.)
 
 ## The standard
 
-Every EHG venture is hosted on **Replit** using the **Replit-native stack**:
+Every EHG venture defaults to **Cloudflare** hosting (descriptor-driven). **Replit** remains a supported **explicit opt-in for prototyping** (set `deployment_target: 'replit-autoscale'` in the venture's stack descriptor):
 
-| Concern | Standard | Not |
-|---|---|---|
-| **Hosting** | Replit Deployments — **Autoscale** (web apps / control planes), **Reserved VM** (always-on / background workers), **Scheduled** (cron, ≤11h timeout). Claude Code builds; Replit hosts — **not** the Replit Agent. | — |
-| **Frontend** | **TanStack Start + React 19 + Vite + TypeScript (strict) + Tailwind** (package manager: bun) | ~~react-router-dom~~ |
-| **Database** | **Replit Postgres** (Neon/Helium-backed) via `DATABASE_URL`; typed client (Drizzle or `pg`) | ~~Supabase~~ |
-| **Auth** | **Clerk** via `@clerk/tanstack-react-start` (clerk.com-hosted). Secret is `VITE_CLERK_PUBLISHABLE_KEY` (VITE-prefixed) passed explicitly to `clerkMiddleware({ publishableKey })` + `<ClerkProvider publishableKey>`; `CLERK_SECRET_KEY` server-only; on first sign-in upsert a local `users` row keyed by `clerk_user_id`. | ~~Replit Auth~~ (Agent-only), ~~Supabase Auth~~ |
-| **File storage** | **Replit Object Storage** — sign object URLs via the Replit sidecar (`POST http://127.0.0.1:1106/object-storage/signed-object-url`) | ~~`@google-cloud/storage` local `getSignedUrl()`~~ |
-| **AI images** | **Google Gemini** (`gemini-2.5-flash-image` via raw `fetch`, `GEMINI_API_KEY`) | ~~OpenAI / Replicate (without chairman sign-off)~~ |
-| **Errors** | **Sentry** (no-ops gracefully when DSN absent) | — |
-| **Secrets / credentials** | **Replit Secrets** / env vars only (never hardcode) | ~~Supabase Vault~~ |
+| Concern | Standard (Cloudflare-default) | Replit opt-in (prototyping) | Not |
+|---|---|---|---|
+| **Hosting** | **Cloudflare Pages** (static web apps / control planes) + **Cloudflare Workers** (server runtime, background/cron via Workers + Cron Triggers). **Google Cloud Run** only when a full long-running Node runtime is required. Claude Code builds; Cloudflare hosts. | Replit Deployments — Autoscale (web), Reserved VM (workers), Scheduled (cron ≤11h). | — |
+| **Frontend** | **TanStack Start + React 19 + Vite + TypeScript (strict) + Tailwind** (package manager: bun) | same | ~~react-router-dom~~ |
+| **Database** | **Cloudflare D1 by default → graduate to Neon Postgres** on the `stakes-router` triggers (`lib/venture-deploy/stakes-router.js`); typed client (Drizzle or `pg`) | Replit Postgres (Neon-backed) via `DATABASE_URL` | ~~Supabase~~ |
+| **Auth** | **Clerk** via `@clerk/tanstack-react-start` (clerk.com-hosted). Secret is `VITE_CLERK_PUBLISHABLE_KEY` (VITE-prefixed) passed explicitly to `clerkMiddleware({ publishableKey })` + `<ClerkProvider publishableKey>`; `CLERK_SECRET_KEY` server-only; on first sign-in upsert a local `users` row keyed by `clerk_user_id`. | same | ~~Replit Auth~~ (Agent-only), ~~Supabase Auth~~ |
+| **File storage** | **Cloudflare R2** (S3-compatible; sign object URLs via the Workers R2 binding) | Replit Object Storage — sign via the Replit sidecar (`POST http://127.0.0.1:1106/object-storage/signed-object-url`) | ~~Supabase Storage~~ |
+| **AI images** | **Google Gemini** (`gemini-2.5-flash-image` via raw `fetch`, `GEMINI_API_KEY`) | same | ~~OpenAI / Replicate (without chairman sign-off)~~ |
+| **Errors** | **Sentry** (no-ops gracefully when DSN absent) | same | — |
+| **Secrets / credentials** | **Cloudflare Workers secrets / env vars** (or Replit Secrets on the opt-in path); never hardcode | Replit Secrets | ~~Supabase Vault~~ |
+| **Spend guardrails** | The 8-point spend-guardrail policy (`lib/venture-deploy/spend-guardrails.js`) is a **hard precondition** before a Cloudflare-default venture goes live (D1 has no hard dollar cap — runaway-invoice risk). | n/a | — |
 
 ## Conditional sub-pattern — data-sensitive ventures
 
 A venture that processes **sensitive EXTERNAL data** (e.g. a customer's *production* database) MUST build its heavy data-plane worker as a **portable worker** (connection-string + config in → result out) so the *same* worker can run:
 
-- on a Replit **Reserved-VM background worker** for the MVP/demo (against own / non-sensitive data), **and**
-- as a **customer-side agent/container** (in the customer's own VPC) for real sensitive data — which resolves the trust barrier, egress/static-IP constraints, and Replit's long-job limits **with zero rewrite**.
+- on a **Cloudflare Worker / Cloud Run background worker** (or a Replit Reserved-VM on the opt-in path) for the MVP/demo (against own / non-sensitive data), **and**
+- as a **customer-side agent/container** (in the customer's own VPC) for real sensitive data — which resolves the trust barrier, egress/static-IP constraints, and serverless long-job limits **with zero rewrite**.
 
-The **product remains the Replit-hosted SaaS control plane**; the agent is a *data-plane deployment unit*, **not** a CLI product. (First venture applying this: DataDistill — see `docs/` / the venture's vision.)
+The **product remains the hosted SaaS control plane** (Cloudflare-default); the agent is a *data-plane deployment unit*, **not** a CLI product. (First venture applying this: DataDistill — see `docs/` / the venture's vision.)
 
 ## Rationale
 
-- Replit is the portfolio's standard build/host platform; one stack removes per-venture stack debates and lets ventures reuse Replit-native primitives (Autoscale, Postgres, Auth, Secrets).
-- Replit Autoscale fits request-driven web apps; Reserved VM fits workers; the customer-side-agent sub-pattern covers what Replit-hosted compute can't safely do (long jobs, customer-prod-data trust, stable egress).
+- Cloudflare is the portfolio's default build/host platform: ~$5/mo vs ~$55/mo on Replit at portfolio scale, and — unlike Replit — it does **not** run vendor AI agents/telemetry on deployed venture infra (the chairman's standing objection). One default stack removes per-venture stack debates and lets ventures reuse Cloudflare primitives (Pages, Workers, R2, D1→Neon).
+- Cloudflare Pages fits request-driven web apps; Workers (+ Cron Triggers) fit background/cron; Cloud Run covers full long-running Node runtimes; the customer-side-agent sub-pattern covers what serverless compute can't safely do (long jobs, customer-prod-data trust, stable egress). Replit stays available as an explicit opt-in for fast prototyping.
 
 ## Enforcement
 
 - **Architecture plans** (EVA `archplan` / `/brainstorm` Step 9.5C "Stack & Repository Decisions") for any venture MUST specify this stack. A venture arch plan defaulting to Supabase/other hosting is non-conformant.
 - **Fail-closed S19 stack QA/QC gate (SD-LEO-INFRA-VENTURE-STACK-STANDARDS-001):** the leo_bridge build consumer (`lib/eva/bridge/venture-build-consumer.js`) scans a venture's `is_current` artifacts against the canonical policy before driving any build leaf; a venture whose artifacts positively specify a forbidden stack (Supabase / Replit Auth / CLI-as-product) is **HELD at Stage 19** (`skipped='stack_noncompliant'`, never advanced). On-demand: `node lib/eva/bridge/venture-build-consumer.js --check-venture <id>`. The post-provisioning conformance checker (`scripts/venture-conformance-check.js`) was reconciled to stop mandating the forbidden `@supabase/supabase-js` / `react-router-dom` / `supabase/` dir.
 - **Per-venture stack-enforcing CI, MANDATED by the build pipeline (SD-LEO-INFRA-REQUIRE-STACK-ENFORCING-001):** the build-infra writers (`lib/eva/bridge/build-tasks-writer.js` + `lib/eva/bridge/claude-md-writer.js`) now require every venture to ship committed, **required** CI that runs a venture-stack compliance **code-scan** + build on every PR — the per-PR (per-leaf) code gate the artifact-level S19 gate cannot provide (it scans artifacts, not repo code; how DataDistill's B1 shipped hand-rolled Replit Auth with no flagged dependency). A reusable, dependency-free scanner ships at `lib/eva/bridge/templates/venture-stack-scan.js` (+ drop-in `lib/eva/bridge/templates/venture-stack-compliance.test.template.js`); it reads **imports + file paths**, not just `package.json`. DataDistill is the enforced pilot (committed CI + branch protection requiring the `test` check).
-- **(Planned, not yet wired):** record `hosting_platform=replit` per venture in the applications registry; add a venture-stack protocol section to the DB (`leo_protocol_sections`) so it regenerates into `CLAUDE_PLAN.md`; teach the S19 sprint planner / lifecycle-sd-bridge to seed the Replit stack into generated venture SDs; a **runtime LEO-side check that each venture repo actually HAS the mandated stack-CI** (the mandate + reusable scanner shipped in SD-LEO-INFRA-REQUIRE-STACK-ENFORCING-001; verifying per-venture adoption at the build gate is the remaining follow-on).
+- **(Planned, not yet wired):** record `hosting_platform` per venture in the applications registry (default `cloudflare`, or `replit` on the opt-in path); add a venture-stack protocol section to the DB (`leo_protocol_sections`) so it regenerates into `CLAUDE_PLAN.md`; teach the S19 sprint planner / lifecycle-sd-bridge to seed the **Cloudflare-default** stack into generated venture SDs; a **runtime LEO-side check that each venture repo actually HAS the mandated stack-CI** (the mandate + reusable scanner shipped in SD-LEO-INFRA-REQUIRE-STACK-ENFORCING-001; verifying per-venture adoption at the build gate is the remaining follow-on).
 
 ## Companion standard
 
-- **Venture metrics** (`docs/03_protocols_and_standards/venture-metrics-standard.md`, SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001): every Replit-hosted venture exposes an authenticated, **aggregates-only** `GET /v1/metrics` that the platform PULLs one-way for portfolio analysis — the platform never opens a venture database. This is how cross-venture portfolio data is gathered despite per-venture isolation.
+- **Venture metrics** (`docs/03_protocols_and_standards/venture-metrics-standard.md`, SD-LEO-INFRA-PORTFOLIO-PRODUCT-KPI-001): every venture (Cloudflare-default or Replit opt-in) exposes an authenticated, **aggregates-only** `GET /v1/metrics` that the platform PULLs one-way for portfolio analysis — the platform never opens a venture database. This is how cross-venture portfolio data is gathered despite per-venture isolation.
 
 ## Scope boundary (explicit)
 
 - **Platform** (`EHG_Engineer`, `EHG` app): **Supabase** — unchanged, NOT migrated.
-- **Ventures**: **Replit stack** per this document.
+- **Ventures**: **Cloudflare-default stack** per this document (Replit available as an explicit prototyping opt-in).

--- a/lib/eva/config/house-tech-stack.js
+++ b/lib/eva/config/house-tech-stack.js
@@ -18,7 +18,7 @@
  * @module lib/eva/config/house-tech-stack
  */
 
-export const HOUSE_STACK_VERSION = '2026.04';
+export const HOUSE_STACK_VERSION = '2026.06';
 
 export const EHG_HOUSE_TECH_STACK = Object.freeze({
   presentation: Object.freeze({
@@ -27,9 +27,9 @@ export const EHG_HOUSE_TECH_STACK = Object.freeze({
     rationale: 'Already used in EHG; shared design tokens; low cold-start',
   }),
   api: Object.freeze({
-    technology: 'REST via Vercel Functions',
+    technology: 'REST via Cloudflare Workers',
     components_hint: ['endpoint groups', 'middleware', 'route handlers'],
-    rationale: 'Standard, debuggable; no GraphQL operational burden',
+    rationale: 'Standard, debuggable; no GraphQL operational burden; runs on the Cloudflare-default venture stack (Workers; Cloud Run only for full Node runtimes)',
   }),
   business_logic: Object.freeze({
     technology: 'Node.js (TypeScript)',
@@ -37,20 +37,20 @@ export const EHG_HOUSE_TECH_STACK = Object.freeze({
     rationale: 'Single-language portfolio reduces context-switching for chairman/operators',
   }),
   data: Object.freeze({
-    technology: 'PostgreSQL via Supabase',
-    components_hint: ['tables', 'views', 'RLS policies'],
-    rationale: 'Already used by EHG_Engineer; built-in auth and RLS',
+    technology: 'Cloudflare D1 → Neon (graduate)',
+    components_hint: ['tables', 'views', 'migrations'],
+    rationale: 'Cloudflare-default venture DB: cheap D1 by default, graduate to Neon Postgres on the stakes-router triggers. NEVER Supabase for ventures (Supabase is platform-only).',
   }),
   infrastructure: Object.freeze({
-    technology: 'Vercel + Replit + Supabase',
+    technology: 'Cloudflare Pages/Workers + R2 + D1→Neon',
     components_hint: ['hosting', 'CDN', 'background workers'],
-    rationale: 'Replit Agent friendly for MVP scaffolding; Vercel for production web; no AWS operational tax',
+    rationale: 'Cloudflare-default venture-hosting standard (CD30_stack_cloudflare): ~$5/mo, no vendor AI agents on deployed infra; Cloud Run only for full Node runtimes; Replit is a prototyping opt-in.',
   }),
 });
 
 export const EHG_HOUSE_AUTH_STRATEGY = Object.freeze({
-  technology: 'Supabase Auth',
-  rationale: 'SSO across portfolio possible; magic-link and social OAuth ready',
+  technology: 'Clerk',
+  rationale: 'Canonical venture auth (@clerk/tanstack-react-start); SSO across portfolio possible; magic-link and social OAuth ready. NEVER Supabase Auth / Replit Auth for ventures.',
 });
 
 export const HOUSE_STACK_LAYER_NAMES = Object.freeze([

--- a/lib/eva/standards/operating-model.js
+++ b/lib/eva/standards/operating-model.js
@@ -5,7 +5,8 @@
  * WHY: generic SaaS cost defaults (human payroll, $1.5–5.5k hosting, paid-ads marketing)
  * overstate EHG venture burn 8–50x and INVERT GO/KILL decisions. EHG's real operating model is:
  *   - ZERO human payroll — work is done by AI agents; the only "labor" cost is LLM/compute.
- *   - Hosting on the chairman-ratified venture-hosting-standard stack (Replit/Neon/Clerk/Gemini/Sentry).
+ *   - Hosting on the chairman-ratified venture-hosting-standard stack — Cloudflare-default
+ *     (Cloudflare Pages/Workers + R2 + D1→Neon / Clerk / Gemini / Sentry; Replit is a prototyping opt-in).
  *   - Organic-first GTM (X/Bluesky + Stage-18 AI copy), paid acquisition is a later opt-in.
  *   - Solo $0-salary founder (sweat equity) early.
  *
@@ -32,11 +33,11 @@ export const OPERATING_MODEL = Object.freeze({
     basis: 'Variable LLM/compute cost (token usage via model_usage_log + lib/cost/llm-pricing.js). NO human payroll.',
     provenance: PROVENANCE.DERIVED,
   }),
-  // FR-2: hosting grounded in the venture-hosting-standard stack.
+  // FR-2: hosting grounded in the venture-hosting-standard stack (Cloudflare-default).
   hosting: Object.freeze({
-    monthly_usd_band: [25, 85],
-    stack: Object.freeze(['Replit', 'Neon', 'Clerk', 'Gemini', 'Sentry']),
-    basis: 'Chairman-ratified venture-hosting-standard stack with stage-based bands (early ~$25, scaling ~$85+).',
+    monthly_usd_band: [5, 50],
+    stack: Object.freeze(['Cloudflare', 'D1->Neon', 'Clerk', 'Gemini', 'Sentry']),
+    basis: 'Chairman-ratified Cloudflare-default venture-hosting-standard stack (Pages/Workers + R2 + D1->Neon) — ~$5/mo early (vs ~$55/mo on Replit), scaling ~$50 as Neon graduates and Workers usage grows. Replit is a prototyping opt-in. See CD30_stack_cloudflare.',
     provenance: PROVENANCE.DERIVED,
   }),
   // FR-3: organic-first GTM. Paid acquisition is an explicit later-stage opt-in, NOT the default.

--- a/lib/eva/standards/venture-stack-policy.js
+++ b/lib/eva/standards/venture-stack-policy.js
@@ -10,9 +10,15 @@
  * (venture-stack-compliance.test.js) binds this module to the rendered writer output: if a writer
  * is edited to positively describe a forbidden stack, the test goes RED.
  *
- * Chairman standard (2026-06-03): Replit-native hosting; Clerk auth; Replit Postgres; Replit Object
- * Storage; Google Gemini images; Sentry errors. NEVER Supabase. NEVER "Replit Auth" (Agent-only).
- * Authoritative prose source: lib/eva/bridge/claude-md-writer.js lines ~48-62.
+ * Chairman standard (CD30_stack_cloudflare, 2026-06-27 — re-instates the 2026-06-14 ratified
+ * Cloudflare-default standard and supersedes CD-15's accidental Replit re-lock): **Cloudflare-default**
+ * hosting (Cloudflare Pages/Workers; Google Cloud Run only for full Node runtimes); Cloudflare R2
+ * object storage; Cloudflare D1-default → Neon-graduate database (via lib/venture-deploy/stakes-router.js);
+ * Clerk auth; Google Gemini images; Sentry errors. **Replit** remains an explicit opt-in for prototyping
+ * (descriptor `deployment_target: 'replit-autoscale'`). NEVER Supabase. NEVER "Replit Auth" (Agent-only).
+ * Authoritative prose mirror: docs/03_protocols_and_standards/venture-hosting-standard.md. The default
+ * deployment target is selected by descriptor (lib/venture-deploy/stack-descriptor.js + provisioner seeding);
+ * the per-venture build context is rendered by the descriptor-aware build-tasks-writer.js / replit-config-writer.js.
  */
 
 /**
@@ -67,11 +73,11 @@ export const REQUIRED = Object.freeze([
     why: 'Canonical auth provider for ventures.',
   },
   {
-    id: 'replit_postgres',
-    label: 'Replit Postgres',
+    id: 'venture_database',
+    label: 'Cloudflare D1 → Neon (default) or Replit Postgres (opt-in)',
     kind: 'data',
-    patterns: [/\bReplit\s+Postgres\b/i, /\bDATABASE_URL\b/],
-    why: 'Canonical database for ventures.',
+    patterns: [/\bCloudflare\s+D1\b/i, /\bD1\s+database\b/i, /\bd1_databases\b/i, /\bNeon\b/i, /\bReplit\s+Postgres\b/i, /\bDATABASE_URL\b/],
+    why: 'Canonical venture database: Cloudflare D1-default graduating to Neon (stakes-router), or Replit Postgres on the Replit opt-in path.',
   },
 ]);
 

--- a/tests/unit/eva/house-tech-stack.test.js
+++ b/tests/unit/eva/house-tech-stack.test.js
@@ -48,8 +48,9 @@ describe('EHG_HOUSE_TECH_STACK', () => {
     expect(Object.isFrozen(HOUSE_STACK_LAYER_NAMES)).toBe(true);
   });
 
-  it('infrastructure layer reflects Vercel + Replit + Supabase choice (not AWS)', () => {
-    expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).toMatch(/Vercel/);
+  it('infrastructure layer reflects the Cloudflare-default venture stack (not AWS, not Supabase)', () => {
+    expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).toMatch(/Cloudflare/);
     expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).not.toMatch(/AWS/);
+    expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).not.toMatch(/Supabase/);
   });
 });

--- a/tests/unit/eva/operating-model-cost-grounding.test.js
+++ b/tests/unit/eva/operating-model-cost-grounding.test.js
@@ -11,8 +11,8 @@ import {
 describe('OPERATING_MODEL SSOT', () => {
   it('encodes EHG operating-model assumptions (zero payroll, hosting-standard, organic GTM, $0 founder)', () => {
     expect(OPERATING_MODEL.ai_operations.monthly_usd_band[0]).toBeGreaterThanOrEqual(0);
-    expect(OPERATING_MODEL.hosting.stack).toEqual(expect.arrayContaining(['Replit', 'Neon', 'Clerk', 'Gemini', 'Sentry']));
-    expect(OPERATING_MODEL.hosting.monthly_usd_band).toEqual([25, 85]);
+    expect(OPERATING_MODEL.hosting.stack).toEqual(expect.arrayContaining(['Cloudflare', 'D1->Neon', 'Clerk', 'Gemini', 'Sentry']));
+    expect(OPERATING_MODEL.hosting.monthly_usd_band).toEqual([5, 50]);
     expect(OPERATING_MODEL.marketing.monthly_usd_band[0]).toBe(0);
     expect(OPERATING_MODEL.founder_salary.monthly_usd).toBe(0);
     expect(OPERATING_MODEL.other.payment_processing_pct).toBeCloseTo(2.9);
@@ -57,8 +57,8 @@ describe('groundCostBreakdown', () => {
     const early = groundCostBreakdown({ month: 1, revenue: 0 }).breakdown.infrastructure;
     const later = groundCostBreakdown({ month: 13, revenue: 0 }).breakdown.infrastructure;
     expect(later).toBeGreaterThanOrEqual(early);
-    expect(early).toBe(OPERATING_MODEL.hosting.monthly_usd_band[0]);     // $25 floor early
-    expect(later).toBe(OPERATING_MODEL.hosting.monthly_usd_band[1]);     // $85 ceiling later
+    expect(early).toBe(OPERATING_MODEL.hosting.monthly_usd_band[0]);     // $5 floor early (Cloudflare-default)
+    expect(later).toBe(OPERATING_MODEL.hosting.monthly_usd_band[1]);     // $50 ceiling later
   });
 
   it('includes payment processing (~2.9% of revenue) in other', () => {


### PR DESCRIPTION
## FR-2 + FR-5 Standard/SSOT rewrite (child of SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001)

Makes **Cloudflare** the conformant default venture-hosting stack across the authoritative SSOT surfaces; demotes Replit to an explicit prototyping opt-in. Enacts the corrected decision **CD30_stack_cloudflare** (shipped as governance record in child -A, PR #5172).

### Surfaces updated
- `docs/03_protocols_and_standards/venture-hosting-standard.md` — Cloudflare-default prose rewrite (Pages/Workers + R2 + D1→Neon + Clerk/Gemini/Sentry), descriptor-driven, Replit opt-in column, spend-guardrail precondition noted.
- `lib/eva/standards/venture-stack-policy.js` — chairman-standard comment → Cloudflare-default + CD30 anchor (FR-5); the DB REQUIRED entry now recognizes D1/Neon, not only Replit Postgres.
- `lib/eva/standards/operating-model.js` — hosting stack → Cloudflare; cost band lowered `[25,85]` → `[5,50]` (~$5/mo vs ~$55 on Replit).
- `lib/eva/config/house-tech-stack.js` — api→Workers, data→D1→Neon, auth→Clerk, infra→Cloudflare; version 2026.04→2026.06.
- Tests updated to the Cloudflare-default assertions (operating-model + house-tech-stack); policy-consistency + venture-stack-compliance tests stay green (29 passed).

### Scope guard (FR-2c)
Deliberately **unchanged**: `deployTargetFamily()` fail-safe (`stack-descriptor.js:215`) and `claude-md-writer.js` — the runtime default arrives via descriptor-seeding in **child -C**, not by flipping the invalid-descriptor fail-safe. Provisioner seeding (-C) and spend-guardrails (-D) are the remaining siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)