### PR TITLE
feat(SD-LEO-INFRA-STRUCTURED-SD-FR-FIELD-001): structured FR source on SDs feeding the PRD-writer + drift gate

### DIFF
--- a/lib/sd/derive-functional-requirements.js
+++ b/lib/sd/derive-functional-requirements.js
@@ -1,0 +1,77 @@
+/**
+ * Derive a structured functional-requirements array from an SD's prose.
+ * SD-LEO-INFRA-STRUCTURED-SD-FR-FIELD-001 (FR-1).
+ *
+ * Produces strategic_directives_v2.metadata.functional_requirements — a JSONB array mirroring
+ * product_requirements_v2.functional_requirements ({id, title, description, ...}). This is the
+ * canonical structured FR source the PRD-writer (FR-3) and the SD<->PRD drift gate
+ * (scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.js extractSdFrs) prefer.
+ *
+ * The prose-extraction MUST stay aligned with that gate's `extractSdFrs` prose fallback
+ * (same FR-N regex + dedup-longest), so structured<->structured diffing is exact: the gate's
+ * structured branch reads {id, title, description} and joins [title, description] back into the
+ * text it would otherwise have parsed from prose. We split each FR's prose into title +
+ * description so the joined text reconstructs the original (round-trip parity) while giving the
+ * PRD a usable title/description pair.
+ */
+
+// FR-N marker: same pattern the drift gate uses. Keep in sync.
+const FR_MARKER = /\bFR-(\d+)\b[:.\s-]*/gi;
+// Title is the FR's first sentence (or a bounded lead when there is no sentence terminator).
+const TITLE_MAX = 120;
+
+/** Split FR prose into {title, description} whose join reconstructs the original text. */
+function splitTitleDescription(raw) {
+  const t = String(raw || '').replace(/\s+/g, ' ').trim();
+  if (!t) return { title: '', description: '' };
+  const sentence = t.match(/^(.{0,120}?[.!?])\s+([\s\S]+)$/);
+  if (sentence) return { title: sentence[1].trim(), description: sentence[2].trim() };
+  if (t.length > TITLE_MAX) return { title: t.slice(0, TITLE_MAX).trimEnd(), description: t.slice(TITLE_MAX).trim() };
+  return { title: t, description: '' };
+}
+
+/**
+ * Parse FR-N markers from `prose`, keeping the text from each marker until the next one.
+ * Dedups repeated FR-N (description + scope often duplicate) keeping the longest text —
+ * identical contract to the drift gate's prose fallback.
+ * @returns {Array<{id:string, text:string}>}
+ */
+function parseFrProse(prose) {
+  const text = String(prose || '');
+  const marks = [];
+  let m;
+  FR_MARKER.lastIndex = 0;
+  while ((m = FR_MARKER.exec(text)) !== null) {
+    marks.push({ id: `FR-${m[1]}`.toUpperCase(), start: m.index, textStart: FR_MARKER.lastIndex });
+  }
+  const frs = [];
+  for (let i = 0; i < marks.length; i++) {
+    const end = i + 1 < marks.length ? marks[i + 1].start : text.length;
+    const body = text.slice(marks[i].textStart, end).trim();
+    const existing = frs.find((f) => f.id === marks[i].id);
+    if (existing) { if (body.length > existing.text.length) existing.text = body; }
+    else frs.push({ id: marks[i].id, text: body });
+  }
+  return frs;
+}
+
+/**
+ * Derive the structured functional_requirements array for an SD from its description + scope
+ * prose. Returns [] when no FR-N markers are present (graceful fallback — FR-4: callers omit
+ * the field rather than writing an empty array).
+ *
+ * @param {{description?:string, scope?:string}} sd
+ * @returns {Array<{id:string, title:string, description:string}>}
+ */
+export function deriveSdFunctionalRequirements(sd) {
+  if (!sd) return [];
+  const prose = [sd.description, sd.scope].filter(Boolean).join('\n');
+  return parseFrProse(prose)
+    .filter((f) => f.text && f.text.length > 0)
+    .map((f) => {
+      const { title, description } = splitTitleDescription(f.text);
+      return description ? { id: f.id, title, description } : { id: f.id, title };
+    });
+}
+
+export default { deriveSdFunctionalRequirements };

--- a/lib/sd/derive-functional-requirements.test.js
+++ b/lib/sd/derive-functional-requirements.test.js
@@ -1,0 +1,93 @@
+/**
+ * Structured SD functional-requirements derivation — regression tests
+ * SD-LEO-INFRA-STRUCTURED-SD-FR-FIELD-001 (FR-1..FR-5)
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveSdFunctionalRequirements } from './derive-functional-requirements.js';
+import { buildPRDGenerationContext } from '../../scripts/prd/llm-generator.js';
+import { extractSdFrs } from '../../scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.js';
+
+const SD_PROSE = {
+  description:
+    'FR-1 the detector compares SD and PRD. It flags any drift. ' +
+    'FR-2 false-positive guard via identity match. ' +
+    'FR-3 actionable output naming missing FRs.',
+  scope: 'FR-4 governance precondition enforcement before the handoff passes.',
+};
+
+describe('FR-1 deriveSdFunctionalRequirements — prose -> structured', () => {
+  it('extracts FR-N markers from description + scope into structured objects', () => {
+    const frs = deriveSdFunctionalRequirements(SD_PROSE);
+    expect(frs.map((f) => f.id)).toEqual(['FR-1', 'FR-2', 'FR-3', 'FR-4']);
+    expect(frs[0].title).toMatch(/compares SD and PRD/);
+  });
+
+  it('splits the first sentence into title and the rest into description (round-trip text)', () => {
+    const fr = deriveSdFunctionalRequirements(SD_PROSE).find((f) => f.id === 'FR-1');
+    expect(fr.title).toBe('the detector compares SD and PRD.');
+    expect(fr.description).toMatch(/flags any drift/);
+    // Joined title+description reconstructs the original prose (parity with extractSdFrs).
+    expect([fr.title, fr.description].join(' ')).toContain('It flags any drift');
+  });
+
+  it('FR-4: returns [] when the prose carries no FR-N markers', () => {
+    expect(deriveSdFunctionalRequirements({ description: 'no markers here', scope: '' })).toEqual([]);
+    expect(deriveSdFunctionalRequirements(null)).toEqual([]);
+  });
+
+  it('emits canonical uppercase FR-N ids (cheap key-match path for the drift gate)', () => {
+    const frs = deriveSdFunctionalRequirements({ description: 'fr-7 lowercase marker text here.' });
+    expect(frs[0].id).toBe('FR-7');
+  });
+
+  it('omits an empty description rather than writing a blank field', () => {
+    const frs = deriveSdFunctionalRequirements({ description: 'FR-1 short single clause' });
+    expect(frs[0]).toEqual({ id: 'FR-1', title: 'FR-1 short single clause'.replace('FR-1 ', '') });
+    expect('description' in frs[0]).toBe(false);
+  });
+});
+
+describe('FR-5 drift-gate shape consumption (structured<->structured parity)', () => {
+  it('extractSdFrs consumes the derived shape and yields matching FR ids', () => {
+    const derived = deriveSdFunctionalRequirements(SD_PROSE);
+    const sdViaStructured = extractSdFrs({ metadata: { functional_requirements: derived } });
+    expect(sdViaStructured.map((f) => f.id)).toEqual(['FR-1', 'FR-2', 'FR-3', 'FR-4']);
+    // The structured-branch text (title+description joined) carries the FR prose.
+    expect(sdViaStructured[0].text).toMatch(/compares SD and PRD/);
+  });
+
+  it('structured path and prose-fallback path agree on FR ids', () => {
+    const derived = deriveSdFunctionalRequirements(SD_PROSE);
+    const viaStructured = extractSdFrs({ metadata: { functional_requirements: derived } }).map((f) => f.id);
+    const viaProse = extractSdFrs(SD_PROSE).map((f) => f.id);
+    expect(viaStructured).toEqual(viaProse);
+  });
+});
+
+describe('FR-3 PRD context builder reads the structured source', () => {
+  it('renders a Structured Functional Requirements section when present', () => {
+    const ctx = buildPRDGenerationContext({
+      sd_key: 'SD-X', title: 'X', description: 'd',
+      metadata: { functional_requirements: deriveSdFunctionalRequirements(SD_PROSE) },
+    });
+    expect(ctx).toMatch(/Structured Functional Requirements/);
+    expect(ctx).toMatch(/\*\*FR-1\*\*/);
+    expect(ctx).toMatch(/\*\*FR-4\*\*/);
+  });
+
+  it('FR-4: omits the section entirely when the SD has no structured FRs', () => {
+    const ctx = buildPRDGenerationContext({ sd_key: 'SD-X', title: 'X', description: 'd', metadata: {} });
+    expect(ctx).not.toMatch(/Structured Functional Requirements/);
+  });
+});
+
+describe('FR-2 gap-fill-not-overwrite semantics (helper layer guard)', () => {
+  // The createSD call-site only derives when metadata.functional_requirements is absent/empty.
+  // This asserts the invariant at the layer a unit test can exercise: a supplied array is the
+  // authoritative source and derivation is never asked to overwrite it.
+  it('a supplied structured array is preserved by extractSdFrs verbatim (no re-derive)', () => {
+    const supplied = [{ id: 'FR-99', title: 'authoritative', description: 'kept as-is' }];
+    const out = extractSdFrs({ metadata: { functional_requirements: supplied }, description: 'FR-1 prose that must NOT win' });
+    expect(out.map((f) => f.id)).toEqual(['FR-99']);
+  });
+});

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -58,6 +58,7 @@ import { trackWriteSource } from '../lib/eva/cli-write-gate.js';
 // shared no-venture classifier — guards the applications auto-register AND the venture-prefix
 // resolver so engineering/governance work never inherits a spurious venture prefix.
 import { isLegitimateNoVenture } from '../lib/eva/bridge/sd-router.js';
+import { deriveSdFunctionalRequirements } from '../lib/sd/derive-functional-requirements.js';
 import { validateSDFields } from './modules/validate-sd-fields.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 // SD-LEO-INFRA-SOURCING-ENGINE-REGISTER-FIRST-001: pure register-first helpers (FR-1 roadmap-item
@@ -2005,6 +2006,25 @@ async function createSD(options) {
       target_application_explicit: Boolean(explicitTargetApp || process.env.VENTURE)
     }
   };
+
+  // SD-LEO-INFRA-STRUCTURED-SD-FR-FIELD-001 (FR-2): populate the structured FR source at the
+  // single createSD convergence point (covers --from-proposal, --from-plan, --child, interactive).
+  // Gap-fill ONLY: an already-supplied structured array (proposal-carried / child-inherited) is
+  // preserved verbatim — never overwritten. Derivation parses FR-N prose from description+scope
+  // into the {id,title,description} shape the PRD-writer (FR-3) and drift gate's extractSdFrs read.
+  try {
+    const existingFrs = sdData.metadata?.functional_requirements;
+    const hasStructured = Array.isArray(existingFrs) && existingFrs.length > 0;
+    if (!hasStructured) {
+      const derived = deriveSdFunctionalRequirements(sdData);
+      if (derived.length > 0) {
+        sdData.metadata = { ...sdData.metadata, functional_requirements: derived };
+      }
+    }
+  } catch (frErr) {
+    // Non-fatal: structured-FR derivation must never block SD creation (FR-4 graceful fallback).
+    console.warn(`   ⚠️  structured FR derivation skipped (non-blocking): ${frErr.message}`);
+  }
 
   // CONST-014 Enforcement: Decomposition check at creation time
   // SDs with 3+ phases or 8+ FRs must use orchestrator pattern

--- a/scripts/prd/llm-generator.js
+++ b/scripts/prd/llm-generator.js
@@ -322,6 +322,17 @@ export function buildPRDGenerationContext(sd, context = {}) {
   if (sd.success_criteria?.length) sdLines.push(`\n### Success Criteria\n${formatArrayField(sd.success_criteria, 'criterion')}`);
   if (sd.key_changes?.length) sdLines.push(`\n### Key Changes\n${formatArrayField(sd.key_changes, 'change')}`);
   if (sd.success_metrics?.length) sdLines.push(`\n### Success Metrics\n${formatArrayField(sd.success_metrics, 'metric')}`);
+  // SD-LEO-INFRA-STRUCTURED-SD-FR-FIELD-001 (FR-3): read the SD's structured FR source canonically
+  // so the generated PRD's functional_requirements INHERIT these instead of being re-derived from
+  // prose. Omitted entirely when absent (FR-4 graceful fallback to the prose Description/Scope).
+  if (Array.isArray(sd.metadata?.functional_requirements) && sd.metadata.functional_requirements.length > 0) {
+    const frLines = sd.metadata.functional_requirements.map((f, i) => {
+      const id = String(f.id || f.fr_key || `FR-${i + 1}`).toUpperCase();
+      const body = [f.title, f.description].filter(Boolean).join(' — ');
+      return `- **${id}**: ${body || '(no text)'}`;
+    });
+    sdLines.push(`\n### Structured Functional Requirements (canonical — the PRD MUST cover each)\n${frLines.join('\n')}`);
+  }
   if (sd.dependencies?.length) sdLines.push(`\n### Dependencies\n${formatArrayField(sd.dependencies, 'dependency')}`);
   if (sd.risks?.length) sdLines.push(`\n### Risks\n${formatRisks(sd.risks)}`);
   sections.push(sdLines.join('\n'));


### PR DESCRIPTION
## Summary
Adds `strategic_directives_v2.metadata.functional_requirements` as a structured JSONB source (mirroring `product_requirements_v2.functional_requirements`) so the PRD-writer inherits canonical FRs instead of re-deriving from prose, and the SD↔PRD drift gate (#5173) can diff structured↔structured exactly. **Additive, NO DDL.**

This is the foundation complementing the just-shipped drift gate — that gate already *prefers* `metadata.functional_requirements` via `extractSdFrs`; nothing populated it until now.

## FRs
- **FR-1** `lib/sd/derive-functional-requirements.js` — pure `deriveSdFunctionalRequirements(sd)` parsing FR-N prose (description+scope) into `{id,title,description}`, aligned to the drift gate's `extractSdFrs` prose contract (same FR-N regex + dedup-longest); title/description split round-trips to the original text.
- **FR-2** Populate at the single `createSD` convergence point in `leo-create-sd.js` (covers `--from-proposal`/`--from-plan`/`--child`/interactive). **Gap-fill only** — a supplied structured array (proposal-carried/child-inherited) is preserved verbatim, never overwritten. Non-fatal on error.
- **FR-3** `buildPRDGenerationContext` reads `sd.metadata.functional_requirements` into a "Structured Functional Requirements" context section so the PRD covers each.
- **FR-4** Graceful fallback — `[]` when no FR-N markers, field omitted, legacy prose path unchanged.
- **FR-5** Foundation for exact structured↔structured drift diffing (consumed by `extractSdFrs`).

## Tests
- 10 new unit tests: derivation, split parity, drift-gate shape consumption, structured-vs-prose id agreement, PRD-context section present/absent, gap-fill-not-overwrite.
- Drift-gate suite 16/16 still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)