### PR TITLE
feat(SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-C): FR-3 — default Cloudflare descriptor seeding + descriptor-aware claude-md-writer

### DIFF
--- a/lib/eva/bridge/claude-md-writer.js
+++ b/lib/eva/bridge/claude-md-writer.js
@@ -18,6 +18,14 @@
  * venture-data fetch + file write happen in Child B inside seedRepo().
  */
 
+// SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-C (FR-3b): descriptor-aware backend prose.
+// Mirrors the dispatch lib/eva/bridge/build-tasks-writer.js already uses.
+import {
+  deployTargetFamily,
+  resolveDbLabel,
+  resolveStorageLabel,
+} from '../../venture-deploy/stack-descriptor.js';
+
 const DEFAULT_STACK =
   'TanStack Start + React 19 + Vite + TypeScript (strict) + Tailwind. Package manager: bun.';
 const DEFAULT_RUN = 'bun run dev';
@@ -34,21 +42,59 @@ export function buildClaudeMd(ctx = {}) {
   const stack = (ctx.stack && String(ctx.stack).trim()) || DEFAULT_STACK;
   const runCommand = (ctx.runCommand && String(ctx.runCommand).trim()) || DEFAULT_RUN;
 
+  // FR-3b: descriptor-aware dispatch. No descriptor (or replit-autoscale) → byte-identical
+  // Replit-native prose (backward-compat). A cloud-family descriptor → Cloudflare/Cloud prose.
+  const sd = ctx.stackDescriptor || null;
+  const family = deployTargetFamily(sd);
+  const useCloud = family !== 'replit';
+  const platformLabel = family === 'cloud-run' ? 'Google Cloud Run' : 'Cloudflare';
+  const dbLabel = resolveDbLabel(sd);
+  const storageLabel = resolveStorageLabel(sd);
+
+  const winsClause = useCloud
+    ? 'If anything here conflicts with a generated `replit.md`, **this file wins**.'
+    : 'If anything here conflicts with `replit.md` (which the Replit Agent may have written and is stale on the backend), **this file wins**.';
+
+  const hostLine = useCloud
+    ? `**You (Claude Code) build the features here, in this repo**, and commit/push to GitHub. **${platformLabel} hosts** the result (it builds from GitHub).`
+    : '**You (Claude Code) build the features here, in this repo**, and commit/push to GitHub. **Replit hosts** the result (it pulls from GitHub). Do **not** rely on the Replit AI Agent — it is metered, undoes Claude Code\'s work, and has removed load-bearing packages it deemed "orphaned." Keep it OFF this repo.';
+
+  const backendHead = useCloud
+    ? `## Backend: ${platformLabel}-native ONLY — never Supabase
+This venture runs on the **${platformLabel} stack**. If the Replit Agent ever wired Supabase, that is technical debt to remove, not a pattern to extend.
+- **Data** → **${dbLabel}**. Cloudflare **D1** is the default (cheap, serverless SQLite); it graduates to **Neon Postgres** automatically on the stakes-router triggers. Bind D1 to your Worker (\`wrangler d1\` + a \`[[d1_databases]]\` binding) or connect to Neon via \`DATABASE_URL\`; use a typed client (Drizzle or \`pg\`).
+- **File storage** → **${storageLabel}** (Cloudflare **R2**, S3-compatible). Sign object URLs via the Workers **R2 binding** (\`env.<BUCKET>\`), **never** a local \`@google-cloud/storage\` signer.`
+    : `## Backend: Replit-native ONLY — never Supabase
+This venture runs on **Replit's native stack**. If the Replit Agent ever wired Supabase, that is technical debt to remove, not a pattern to extend.
+- **Data** → **Replit Postgres** (Neon-backed, scale-to-zero). Connect via \`DATABASE_URL\` (Replit injects it once you provision Postgres in the Replit **Database** panel). Use a typed client (Drizzle or \`pg\`). Note: the dev Postgres is Repl-scoped — not reachable from a laptop, so typecheck locally and run/test in Replit.
+- **File storage** → **Replit Object Storage** (provisioned via the Object Storage UI panel — one auto-ID'd bucket in \`DEFAULT_OBJECT_STORAGE_BUCKET_ID\`; namespace by key **prefix**, you cannot name buckets). **Sign object URLs via the Replit sidecar** (\`POST http://127.0.0.1:1106/object-storage/signed-object-url\`), **never** the \`@google-cloud/storage\` client's local \`getSignedUrl()\` — the sidecar credentials have no \`client_email\`, so local signing throws *"Cannot sign data without client_email"*. (This applies to BOTH uploads and downloads.)`;
+
+  const restartClause = useCloud
+    ? `Dev: \`${runCommand}\`. After pulling new code/deps OR changing a secret, **restart the dev server / redeploy the Worker** (a running dev server won't pick up a new package or a changed secret).`
+    : `Dev: \`${runCommand}\`. After pulling new code/deps OR changing a Secret, **restart** the Repl (a running dev server won't pick up a new package or a changed Secret).`;
+
+  const hostingSection = useCloud
+    ? `## Hosting (${platformLabel})
+${platformLabel} builds from this GitHub repo (Pages for the web app, Workers for the server runtime — configured via \`wrangler.toml\`). To go live: provision **D1 + R2 + Clerk**, set **Workers secrets** (\`wrangler secret put\`), then \`wrangler deploy\`. Your commits to GitHub flow into ${platformLabel}.`
+    : `## Hosting (Replit, no Agent)
+Replit imports this GitHub repo and runs the dev/start command (see \`.replit\`). To go live: provision Postgres + Object Storage + Clerk in Replit's UI panels (one-click each — **not** the Agent), then publish. Your commits to GitHub flow into Replit.`;
+
+  const ciStackLine = useCloud
+    ? 'asserts the REQUIRED stack (Clerk + Cloudflare D1/Neon) is present'
+    : 'asserts the REQUIRED stack (Clerk + Replit Postgres) is present';
+
   return `# CLAUDE.md — ${name}
 
-> Build instructions for **Claude Code**. This file is read automatically every session and is the **authoritative** build context for this repo. If anything here conflicts with \`replit.md\` (which the Replit Agent may have written and is stale on the backend), **this file wins**.
+> Build instructions for **Claude Code**. This file is read automatically every session and is the **authoritative** build context for this repo. ${winsClause}
 
 ## Build model (READ THIS)
-- **You (Claude Code) build the features here, in this repo**, and commit/push to GitHub. **Replit hosts** the result (it pulls from GitHub). Do **not** rely on the Replit AI Agent — it is metered, undoes Claude Code's work, and has removed load-bearing packages it deemed "orphaned." Keep it OFF this repo.
+- ${hostLine}
 - Work through **\`docs/build-tasks.md\`** in order (orchestrator → children → grandchildren); do one grandchild task at a time, commit, move on. Lead task is always "discover current state" — do not assume the repo is unbuilt.
 - **Building an additional page?** Follow **\`docs/design-prompts.md\`**: use **Prompt 1** (it inherits the landing page's design system from \`src/routes/index.tsx\`) to create the page, then run **Prompts 2-4** (typography, layout, and build-quality audits). The landing page was built by Lovable — do **not** rebuild it.
 - **Every venture ships a Feedback page.** Build the \`/feedback\` page with **Prompt 5** in \`docs/design-prompts.md\` and wire the landing footer "Feedback" link to it.
 - Keep changes **additive and scoped**; match the existing design system and conventions.
 
-## Backend: Replit-native ONLY — never Supabase
-This venture runs on **Replit's native stack**. If the Replit Agent ever wired Supabase, that is technical debt to remove, not a pattern to extend.
-- **Data** → **Replit Postgres** (Neon-backed, scale-to-zero). Connect via \`DATABASE_URL\` (Replit injects it once you provision Postgres in the Replit **Database** panel). Use a typed client (Drizzle or \`pg\`). Note: the dev Postgres is Repl-scoped — not reachable from a laptop, so typecheck locally and run/test in Replit.
-- **File storage** → **Replit Object Storage** (provisioned via the Object Storage UI panel — one auto-ID'd bucket in \`DEFAULT_OBJECT_STORAGE_BUCKET_ID\`; namespace by key **prefix**, you cannot name buckets). **Sign object URLs via the Replit sidecar** (\`POST http://127.0.0.1:1106/object-storage/signed-object-url\`), **never** the \`@google-cloud/storage\` client's local \`getSignedUrl()\` — the sidecar credentials have no \`client_email\`, so local signing throws *"Cannot sign data without client_email"*. (This applies to BOTH uploads and downloads.)
+${backendHead}
 - **Auth** → **Clerk** via \`@clerk/tanstack-react-start\` (clerk.com hosted — NOT a Replit integration; do NOT use "Replit Auth", which is Agent-only and signs users in with Replit accounts). **#1 gotcha:** Clerk's Vite SDK resolves the **publishable** key via \`import.meta.env\` (VITE_-prefixed ONLY). Name the secret **\`VITE_CLERK_PUBLISHABLE_KEY\`** AND pass it explicitly: \`clerkMiddleware({ publishableKey: process.env.VITE_CLERK_PUBLISHABLE_KEY })\` + \`<ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>\`. Keep \`CLERK_SECRET_KEY\` server-only (do NOT pass \`secretKey\` to clerkMiddleware). On first sign-in, upsert a local \`users\` row keyed by \`clerk_user_id\`; ownership checks are app-level \`where user_id = <clerkUserId>\`.
 - **AI images** → **Google Gemini** image editing (\`gemini-2.5-flash-image\` via the Gemini API, raw \`fetch\`, no SDK dep), reads \`GEMINI_API_KEY\` (or \`GOOGLE_API_KEY\`); model id overridable via \`GEMINI_IMAGE_MODEL\`. Chairman-chosen provider — do **NOT** switch to OpenAI/Replicate/etc. without asking. Gemini image output generally needs billing enabled on the Google AI project.
 - **Errors** → **Sentry**, no-ops gracefully when its DSN is absent.
@@ -56,10 +102,9 @@ This venture runs on **Replit's native stack**. If the Replit Agent ever wired S
 
 ## Stack & commands
 - ${stack}
-- Dev: \`${runCommand}\`. After pulling new code/deps OR changing a Secret, **restart** the Repl (a running dev server won't pick up a new package or a changed Secret).
+- ${restartClause}
 
-## Hosting (Replit, no Agent)
-Replit imports this GitHub repo and runs the dev/start command (see \`.replit\`). To go live: provision Postgres + Object Storage + Clerk in Replit's UI panels (one-click each — **not** the Agent), then publish. Your commits to GitHub flow into Replit.
+${hostingSection}
 
 ## Conventions
 - TypeScript strict; proper error handling on all async/IO; responsive (mobile-first); semantic HTML + ARIA.
@@ -67,7 +112,7 @@ Replit imports this GitHub repo and runs the dev/start command (see \`.replit\`)
 - After each grandchild task: a quick build/typecheck, then commit with a clear message.
 
 ## CI must enforce this stack (REQUIRED)
-- Commit a CI workflow that runs on **every PR to main** and is a **required status check** (so it BLOCKS merge): it runs (a) a venture-stack compliance test — \`tests/stack-compliance.test.js\`, which scans \`src/\` and fails on forbidden tech — no \`@supabase\`, no Replit Auth / OIDC, no CLI-as-product framing — and asserts the REQUIRED stack (Clerk + Replit Postgres) is present — AND (b) the build. Vendor the dependency-free test from \`venture-stack-compliance.test.template.js\` (runs under \`node --test\`, any toolchain). Without this, off-stack code merges unseen: the platform's stage-19 gate scans planning artifacts, **not** your repo code.
+- Commit a CI workflow that runs on **every PR to main** and is a **required status check** (so it BLOCKS merge): it runs (a) a venture-stack compliance test — \`tests/stack-compliance.test.js\`, which scans \`src/\` and fails on forbidden tech — no \`@supabase\`, no Replit Auth / OIDC, no CLI-as-product framing — and ${ciStackLine} — AND (b) the build. Vendor the dependency-free test from \`venture-stack-compliance.test.template.js\` (runs under \`node --test\`, any toolchain). Without this, off-stack code merges unseen: the platform's stage-19 gate scans planning artifacts, **not** your repo code.
 `;
 }
 

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -232,15 +232,39 @@ const DEFAULT_STEPS = [
       // WEDGED provisioning -> the S19 bridge mislabelled it vision_pending and hard-looped every 30s.
       // DEGRADE to the legacy no-descriptor path on 42703 instead of throwing; still fail-loud on any
       // other (genuine) read error.
+      let stackDescriptorColumnAbsent = false;
       if (vErr && (vErr.code === '42703' || /column .*stack_descriptor.* does not exist/i.test(vErr.message || ''))) {
+        stackDescriptorColumnAbsent = true;
         ctx.log('[schema_created] WARN: ventures.stack_descriptor column absent (unapplied migration) — DEGRADING to legacy no-descriptor path (stakes-routing skipped)');
       } else if (vErr) {
         // fail-loud: cannot read the venture row to make a DB decision.
         throw new Error(`[schema_created] cannot read ventures.stack_descriptor: ${vErr.message}`);
       }
-      const descriptor = vRow?.stack_descriptor;
-      const hasDescriptor = descriptor && typeof descriptor === 'object' && !Array.isArray(descriptor)
+      let descriptor = vRow?.stack_descriptor;
+      let hasDescriptor = descriptor && typeof descriptor === 'object' && !Array.isArray(descriptor)
         && Object.keys(descriptor).length > 0;
+
+      // SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-C (FR-3): seed the Cloudflare-default
+      // stack_descriptor for a NEW venture that has none yet, so the stakes-router yields
+      // D1-default→Neon-graduate automatically and the descriptor-aware writers take the
+      // Cloudflare path. This is cleaner + safer than flipping deployTargetFamily()'s
+      // invalid-descriptor fail-safe (which stays the genuinely-malformed guard). Skipped
+      // when the column is absent (cannot persist) — that path stays legacy. Fail-soft:
+      // a seed write error never breaks provisioning.
+      if (!hasDescriptor && !stackDescriptorColumnAbsent) {
+        const seeded = { db_provider: 'd1', deployment_target: 'cloudflare-pages', storage: 'r2' };
+        const { error: seedErr } = await sb
+          .from('ventures')
+          .update({ stack_descriptor: seeded })
+          .eq('id', ctx.ventureId);
+        if (seedErr) {
+          ctx.log(`[schema_created] WARN: failed to seed default Cloudflare stack_descriptor: ${seedErr.message} — falling back to legacy path`);
+        } else {
+          descriptor = seeded;
+          hasDescriptor = true;
+          ctx.log('[schema_created] Seeded default Cloudflare stack_descriptor {d1, cloudflare-pages, r2} (D1-default→Neon-graduate)');
+        }
+      }
 
       if (!hasDescriptor) {
         // Backward-compat: legacy ventures predate the Cloudflare retarget. Stakes-

--- a/tests/unit/eva/bridge/claude-md-writer.test.js
+++ b/tests/unit/eva/bridge/claude-md-writer.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildClaudeMd } from '../../../../lib/eva/bridge/claude-md-writer.js';
+
+// SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-C (FR-3b): claude-md-writer is now descriptor-aware.
+// A cloud-family stack_descriptor emits Cloudflare/Cloud-native backend prose; no descriptor (or an
+// explicit Replit opt-in) keeps the byte-identical Replit-native prose for backward-compat.
+
+const CF_DESCRIPTOR = { db_provider: 'd1', deployment_target: 'cloudflare-pages', storage: 'r2' };
+
+describe('buildClaudeMd — descriptor-aware (FR-3b)', () => {
+  it('emits Cloudflare-native backend when a cloudflare descriptor is present', () => {
+    const out = buildClaudeMd({ name: 'VentureX', stackDescriptor: CF_DESCRIPTOR });
+    expect(out).toMatch(/Cloudflare/);
+    expect(out).toMatch(/\bD1\b/);
+    expect(out).toMatch(/R2/);
+    // The Cloudflare backend section must NOT hardcode the Replit-native database / object storage.
+    expect(out).not.toMatch(/Replit Postgres/);
+    expect(out).not.toMatch(/Replit Object Storage/);
+    // Hosting section is Cloudflare, not "Hosting (Replit, no Agent)".
+    expect(out).toMatch(/## Hosting \(Cloudflare\)/);
+  });
+
+  it('emits the unchanged Replit-native backend when no descriptor (backward-compat)', () => {
+    const out = buildClaudeMd({ name: 'VentureX' });
+    expect(out).toMatch(/## Backend: Replit-native ONLY/);
+    expect(out).toMatch(/Replit Postgres/);
+    expect(out).toMatch(/Replit Object Storage/);
+    expect(out).toMatch(/## Hosting \(Replit, no Agent\)/);
+    // No descriptor must not leak Cloudflare backend prose.
+    expect(out).not.toMatch(/Cloudflare \*\*R2\*\*/);
+  });
+
+  it('treats an explicit replit-autoscale descriptor as the Replit path (opt-in)', () => {
+    const out = buildClaudeMd({ name: 'VentureX', stackDescriptor: { deployment_target: 'replit-autoscale' } });
+    expect(out).toMatch(/## Backend: Replit-native ONLY/);
+    expect(out).not.toMatch(/## Hosting \(Cloudflare\)/);
+  });
+
+  it('keeps the stack-agnostic rules (Clerk, Gemini, Sentry, never Supabase) on both paths', () => {
+    for (const sd of [CF_DESCRIPTOR, null]) {
+      const out = buildClaudeMd({ name: 'V', stackDescriptor: sd });
+      expect(out).toMatch(/Clerk/);
+      expect(out).toMatch(/Gemini/);
+      expect(out).toMatch(/Sentry/);
+      expect(out).toMatch(/NEVER\*\* add `@supabase\/supabase-js`/);
+    }
+  });
+});


### PR DESCRIPTION
## FR-3 Default-seeding code (child of SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001)

Makes Cloudflare the **runtime** default for new ventures, completing the standard child -B made authoritative.

### Changes
- `lib/eva/bridge/venture-provisioner.js` — in the `schema_created` step, seed `ventures.stack_descriptor = {db_provider:'d1', deployment_target:'cloudflare-pages', storage:'r2'}` for a NEW venture with no descriptor (when the column exists), so `stakes-router` yields **D1-default→Neon-graduate** automatically and the descriptor-aware writers take the Cloudflare path. Fail-soft on seed error; column-absent legacy degrade preserved.
- `lib/eva/bridge/claude-md-writer.js` — now descriptor-aware (mirrors `build-tasks-writer.js`'s `deployTargetFamily`/`resolveDbLabel`/`resolveStorageLabel` dispatch). A cloud-family descriptor emits Cloudflare/D1/R2 backend + `## Hosting (Cloudflare)`; **no descriptor / replit-autoscale stays byte-identical Replit-native** (backward-compat).
- New `tests/unit/eva/bridge/claude-md-writer.test.js` (both paths); existing `build-tasks-writer-descriptor` stays green (32 passed).

### Scope guard (FR-3c)
`deployTargetFamily()` (`stack-descriptor.js`) is **unchanged** — verified `seeded ⇒ cloudflare`, `absent/malformed ⇒ replit`. The new default arrives via seeded data, not a flipped fail-safe. Spend-guardrails are sibling **-D**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)