### PR TITLE
feat(SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001): expand S19 portfolio-default capabilities 2->7

### DIFF
--- a/lib/eva/config/venture-default-capabilities.js
+++ b/lib/eva/config/venture-default-capabilities.js
@@ -21,7 +21,9 @@
  * @module lib/eva/config/venture-default-capabilities
  */
 
-export const DEFAULT_CAPABILITIES_VERSION = '2026.04';
+// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001: bumped from '2026.04'
+// when the portfolio-default set grew from 2 to 7 capabilities.
+export const DEFAULT_CAPABILITIES_VERSION = '2026.06';
 
 export const EHG_VENTURE_DEFAULT_CAPABILITIES = Object.freeze([
   Object.freeze({
@@ -43,6 +45,60 @@ export const EHG_VENTURE_DEFAULT_CAPABILITIES = Object.freeze([
     acceptance_criteria: 'Sentry SDK initialized at app entrypoint; thrown errors arrive in central `feedback` table within 30s; PII (auth headers, cookies) redacted via beforeSend; SENTRY_DSN sourced from Replit Secrets; SIGTERM closes Sentry cleanly.',
     target_stack_components: ['business_logic', 'infrastructure'],
     vision_source_section: 'docs/reference/vision/quality-lifecycle-system.md — Multi-Venture Architecture / Per-venture deliverables (error capture)',
+  }),
+  // ── SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001 (FR-1..FR-5) ──
+  // Five capabilities the joint Adam<->coordinator assessment ranked as the
+  // recurring portfolio blind spots, ordered by what the fleet sees ventures
+  // consistently MISSING.
+  Object.freeze({
+    capability_id: 'cost-instrumentation',
+    name: 'Instrument Operating Cost into the Cash-Burn Feed',
+    description: 'Auto-instrument the venture\'s operating burn into the central cash-burn / distance-to-quit feed: emit the venture\'s rolling AI + infra burn into `income_capture.business_expenses` (and the substrate `ai_burn`) tagged source_application=<venture_slug>, so the north-star ($18k/mo-net) gauge stays accurate portfolio-wide instead of dark per new venture. Lower-bound, fail-soft (never blocks the app), mirroring the engineer-side feed-operator-cash-burn capture.',
+    story_points: 2,
+    priority: 'high',
+    acceptance_criteria: 'The venture writes its rolling-window operating burn to `income_capture.business_expenses`/`ai_burn` with source_application set to this venture; the distance-to-quit gauge reflects this venture\'s burn within one capture cycle; capture is fail-soft (a capture failure never throws into the request path); no hardcoded $0 (honest-NULL when a cost source is absent).',
+    target_stack_components: ['business_logic', 'data', 'infrastructure'],
+    vision_source_section: 'docs/reference/vision — distance-to-quit / cash-burn north-star (income_capture business_expenses / ai_burn)',
+  }),
+  Object.freeze({
+    capability_id: 'telemetry-analytics',
+    name: 'Wire Baseline Usage Telemetry/Analytics',
+    description: 'Wire a baseline usage-analytics layer (page/route views, key conversion events, active-user counts) so the Stage-25 post-launch review has real data to assess against rather than running blind. Privacy-respecting (no PII in event payloads); events land somewhere the post-launch review can query.',
+    story_points: 1,
+    priority: 'high',
+    acceptance_criteria: 'Page/route views and at least the venture\'s core conversion event are recorded; an active-user count is queryable for the Stage-25 window; event payloads carry no PII; the telemetry layer is initialized at app entrypoint and degrades silently if the sink is unreachable.',
+    target_stack_components: ['presentation', 'business_logic', 'data'],
+    vision_source_section: 'docs/reference/vision/quality-lifecycle-system.md — Stage-25 post-launch review data baseline',
+  }),
+  Object.freeze({
+    capability_id: 'calm-decision-card',
+    name: 'Standardize Chairman-Facing Decision Card',
+    description: 'Standardize the chairman-facing decision-card brief on every chairman-facing surface ONLY (not internal/agent surfaces): each decision card renders what / why / confidence / recommendation / alternatives / cost-of-delay, per the vision\'s calm-cockpit standard. Prevents the Stage-17 RED-on-green / empty-summary contradiction class by guaranteeing the brief is populated whenever a decision is surfaced to the chairman.',
+    story_points: 1,
+    priority: 'high',
+    acceptance_criteria: 'Every chairman-facing decision card exposes the six fields (what, why, confidence, recommendation, alternatives, cost-of-delay); a decision surfaced to the chairman never renders an empty summary or a health badge contradicting its underlying verdict; scope is limited to chairman-facing surfaces (internal/agent surfaces unchanged).',
+    target_stack_components: ['presentation'],
+    vision_source_section: 'docs/reference/vision — calm-cockpit decision-card doctrine (chairman-facing surfaces); fixes the Stage-17 health-provenance class',
+  }),
+  Object.freeze({
+    capability_id: 'health-uptime-probe',
+    name: 'Expose a Health/Uptime Liveness Probe',
+    description: 'Expose a basic liveness endpoint (e.g. GET /healthz returning 200 + minimal status JSON) so the factory can verify a deployed venture is actually running, closing the merged != running gap (deploy-verification). The endpoint is unauthenticated, dependency-light, and safe to poll frequently.',
+    story_points: 1,
+    priority: 'high',
+    acceptance_criteria: 'GET /healthz (or equivalent) returns HTTP 200 with a minimal status payload when the app is up; the endpoint requires no auth and does not depend on downstream services being healthy to answer liveness; the factory can poll it post-deploy to confirm the venture is running.',
+    target_stack_components: ['api', 'infrastructure'],
+    vision_source_section: 'docs/reference/vision — merged != running deploy-verification (liveness probe)',
+  }),
+  Object.freeze({
+    capability_id: 'operating-model-grounding',
+    name: 'Inherit the Operating-Model Grounding SSOT',
+    description: 'Inherit the operating-model SSOT (lib/eva/standards/operating-model.js) as a first-class grounding input — seeded at venture creation in lib/eva/bridge/venture-provisioner.js — rather than re-deriving generic-SaaS assumptions (solo chairman + all-AI labor, built-in hosting standard + GTM). This grounds, not re-derives, fixing the Stage-5/Stage-16 false-kill root where generic payroll/hosting assumptions kill viable agentic ventures. Verify INHERITANCE, not re-derivation.',
+    story_points: 1,
+    priority: 'high',
+    acceptance_criteria: 'The venture record is seeded at creation with a reference to the operating-model SSOT (lib/eva/standards/operating-model.js); downstream cost/financial stages (S5, S16) consume the inherited operating-model assumptions rather than generic-SaaS defaults; the inheritance is verifiable (the grounding input is present, not re-derived per stage).',
+    target_stack_components: ['business_logic', 'data'],
+    vision_source_section: 'lib/eva/standards/operating-model.js — operating-model SSOT (fixes S5/S16 generic-SaaS false-kill)',
   }),
 ]);
 

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -119,6 +119,15 @@ const MANDATORY_CAPABILITIES_BLOCK = EHG_VENTURE_DEFAULT_CAPABILITIES
      Acceptance criteria: ${c.acceptance_criteria}`)
   .join('\n');
 
+// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001 (FR-6): the reserve was a
+// hardcoded "~3 story points" that exactly matched the 2-capability sum — it drifted
+// the moment the default set grew (5 caps were added), under-scoping the sprint so the
+// new mandatory caps would ship DECLARED-BUT-UNBUILT. Derive the reserve from the actual
+// sum of mandatory capability story_points so it can never drift again, regardless of how
+// many capabilities the portfolio-default set carries.
+const MANDATORY_CAPABILITIES_RESERVE = EHG_VENTURE_DEFAULT_CAPABILITIES
+  .reduce((sum, c) => sum + (Number(c.story_points) || 0), 0);
+
 const SYSTEM_PROMPT = `You are EVA's Sprint Planning Engine. Generate a sprint plan with actionable items that bridge to the LEO Protocol SD system.
 
 You MUST output valid JSON with exactly this structure:
@@ -158,7 +167,7 @@ Rules:
 
 ${MANDATORY_CAPABILITIES_BLOCK}
 
-  Reserve ~3 story points for the mandatory items; size venture-specific feature items to fit the remaining sprint budget. These are portfolio-default capabilities (chairman-level cross-venture quality visibility) and are not optional except via authorized override. Use the exact "name" string for each item's title so downstream validation can identify them.`;
+  Reserve ~${MANDATORY_CAPABILITIES_RESERVE} story points for the mandatory items (the sum of their story points above); size venture-specific feature items to fit the remaining sprint budget. These are portfolio-default capabilities (chairman-level cross-venture quality visibility) and are not optional except via authorized override. Use the exact "name" string for each item's title so downstream validation can identify them.`;
 
 /**
  * Generate sprint plan from readiness + blueprint data.

--- a/tests/unit/eva/stage-19-sprint-planning.default-capabilities.test.js
+++ b/tests/unit/eva/stage-19-sprint-planning.default-capabilities.test.js
@@ -32,8 +32,21 @@ describe('Stage 19 SYSTEM_PROMPT — default-capabilities inclusion (FR-2)', () 
     expect(stage19Source).toMatch(/default_capabilities_override/);
   });
 
-  it('SYSTEM_PROMPT contains the story-point budget guidance', () => {
-    expect(stage19Source).toMatch(/Reserve ~3 story points for the mandatory items/);
+  it('SYSTEM_PROMPT contains the story-point budget guidance (dynamic reserve)', () => {
+    // SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001 (FR-6): the reserve is no longer
+    // a hardcoded "~3" — it is derived from the sum of mandatory capability story_points so
+    // it can never drift as the default set grows.
+    expect(stage19Source).toMatch(
+      /Reserve ~\$\{MANDATORY_CAPABILITIES_RESERVE\} story points for the mandatory items/
+    );
+  });
+
+  it('derives MANDATORY_CAPABILITIES_RESERVE from the sum of capability story_points', () => {
+    expect(stage19Source).toMatch(/const MANDATORY_CAPABILITIES_RESERVE\s*=/);
+    const expectedReserve = EHG_VENTURE_DEFAULT_CAPABILITIES
+      .reduce((sum, c) => sum + (Number(c.story_points) || 0), 0);
+    // The 7-capability default set sums to 9 story points (FR-6 budget contract).
+    expect(expectedReserve).toBe(9);
   });
 
   it('renders both capability names verbatim into the prompt block', () => {

--- a/tests/unit/eva/stage-templates/stage-19-architectureLayer-forwarding.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-architectureLayer-forwarding.test.js
@@ -5,13 +5,21 @@
  * back to all four architecture layers (the vacuous-decomposition root cause).
  */
 import { describe, it, expect, vi } from 'vitest';
+import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../../../lib/eva/config/venture-default-capabilities.js';
 
-// Mandatory portfolio-default capabilities analyzeStage19 validates for (feedback-widget +
-// error-capture-middleware); the planner throws MissingDefaultCapabilityError without them.
-const MANDATORY_ITEMS = [
-  { title: 'Integrate Feedback Widget', description: 'Add feedback widget', type: 'infra', priority: 'medium', estimatedLoc: 30, acceptanceCriteria: 'Widget visible', architectureLayer: 'frontend', milestoneRef: 'MVP' },
-  { title: 'Wire Error Capture Middleware', description: 'Add error capture', type: 'infra', priority: 'medium', estimatedLoc: 20, acceptanceCriteria: 'Errors captured', architectureLayer: 'backend', milestoneRef: 'MVP' },
-];
+// Mandatory portfolio-default capabilities analyzeStage19 validates for; the planner throws
+// MissingDefaultCapabilityError without them. SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001:
+// derive from the canonical config (was a hardcoded 2-item list that broke when the set grew to 7).
+const MANDATORY_ITEMS = EHG_VENTURE_DEFAULT_CAPABILITIES.map(c => ({
+  title: c.name,
+  description: c.description.slice(0, 60),
+  type: 'infra',
+  priority: 'medium',
+  estimatedLoc: 30,
+  acceptanceCriteria: 'Mandatory capability present',
+  architectureLayer: 'infrastructure',
+  milestoneRef: 'MVP',
+}));
 
 const mockComplete = vi.fn().mockResolvedValue(JSON.stringify({
   sprintGoal: 'Ship the landing experience',

--- a/tests/unit/eva/stage-templates/stage-19-build-brief-consumption.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-build-brief-consumption.test.js
@@ -6,11 +6,22 @@
  * LLM prompt and works correctly without it (backward compatibility).
  */
 import { describe, it, expect, vi } from 'vitest';
+import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../../../lib/eva/config/venture-default-capabilities.js';
 
-const MANDATORY_ITEMS = [
-  { title: 'Integrate Feedback Widget', description: 'Add feedback widget', type: 'infra', priority: 'medium', estimatedLoc: 30, acceptanceCriteria: 'Widget visible', architectureLayer: 'frontend', milestoneRef: 'MVP' },
-  { title: 'Wire Error Capture Middleware', description: 'Add error capture', type: 'infra', priority: 'medium', estimatedLoc: 20, acceptanceCriteria: 'Errors captured', architectureLayer: 'backend', milestoneRef: 'MVP' },
-];
+// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001: derive the mandatory mock items from
+// the canonical config (was a hardcoded 2-item list that broke when the default set grew to 7).
+// Each capability's exact `name` is the item title so validateVentureDefaultCapabilities matches
+// it via title-prefix; any mock spreading MANDATORY_ITEMS satisfies the constraint at any set size.
+const MANDATORY_ITEMS = EHG_VENTURE_DEFAULT_CAPABILITIES.map(c => ({
+  title: c.name,
+  description: c.description.slice(0, 60),
+  type: 'infra',
+  priority: 'medium',
+  estimatedLoc: 30,
+  acceptanceCriteria: 'Mandatory capability present',
+  architectureLayer: 'infrastructure',
+  milestoneRef: 'MVP',
+}));
 
 // Shared mock function to capture calls
 const mockComplete = vi.fn().mockResolvedValue(JSON.stringify({

--- a/tests/unit/eva/stage-templates/stage-19-context-enrichment.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-context-enrichment.test.js
@@ -7,11 +7,23 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EHG_VENTURE_DEFAULT_CAPABILITIES } from '../../../../lib/eva/config/venture-default-capabilities.js';
 
-const MANDATORY_ITEMS = [
-  { title: 'Integrate Feedback Widget', description: 'Add feedback widget', type: 'infra', priority: 'medium', estimatedLoc: 30, acceptanceCriteria: 'Widget visible', architectureLayer: 'frontend', milestoneRef: 'MVP Launch' },
-  { title: 'Wire Error Capture Middleware', description: 'Add error capture', type: 'infra', priority: 'medium', estimatedLoc: 20, acceptanceCriteria: 'Errors captured', architectureLayer: 'backend', milestoneRef: 'MVP Launch' },
-];
+// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001: derive the mandatory mock items
+// from the canonical config (was a hardcoded 2-item list that broke when the default set
+// grew to 7). Using each capability's exact `name` as the item title lets
+// validateVentureDefaultCapabilities recognize it via title-prefix match, so any mock
+// sprint plan that spreads MANDATORY_ITEMS satisfies the constraint regardless of set size.
+const MANDATORY_ITEMS = EHG_VENTURE_DEFAULT_CAPABILITIES.map(c => ({
+  title: c.name,
+  description: c.description.slice(0, 60),
+  type: 'infra',
+  priority: 'medium',
+  estimatedLoc: 30,
+  acceptanceCriteria: 'Mandatory capability present',
+  architectureLayer: 'infrastructure',
+  milestoneRef: 'MVP Launch',
+}));
 
 // Shared mock complete function so tests can inspect calls
 const mockComplete = vi.fn().mockResolvedValue(JSON.stringify({

--- a/tests/unit/eva/validate-venture-default-capabilities.test.js
+++ b/tests/unit/eva/validate-venture-default-capabilities.test.js
@@ -4,11 +4,24 @@ import {
   MissingDefaultCapabilityError,
 } from '../../../lib/eva/utils/validate-venture-default-capabilities.js';
 
+// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001: the mandatory set grew from 2 to 7.
+// The five capabilities added alongside feedback-widget + error-capture-middleware. Holding
+// these constant in every fixture keeps the "missing"/"override" assertions focused on the
+// SPECIFIC capability under test rather than tripping on the newly-mandatory ones.
+const NEW_CAP_ITEMS = [
+  { title: 'Instrument Operating Cost into the Cash-Burn Feed', priority: 'high' },
+  { title: 'Wire Baseline Usage Telemetry/Analytics', priority: 'high' },
+  { title: 'Standardize Chairman-Facing Decision Card', priority: 'high' },
+  { title: 'Expose a Health/Uptime Liveness Probe', priority: 'high' },
+  { title: 'Inherit the Operating-Model Grounding SSOT', priority: 'high' },
+];
+
 const happySprintPlan = {
   sprintItems: [
     { title: 'Build core ventureHealth dashboard', priority: 'high' },
     { title: 'Integrate Feedback Widget', priority: 'high' },
     { title: 'Wire Error Capture Middleware', priority: 'high' },
+    ...NEW_CAP_ITEMS,
   ],
 };
 
@@ -16,6 +29,7 @@ const missingFeedbackPlan = {
   sprintItems: [
     { title: 'Build core ventureHealth dashboard', priority: 'high' },
     { title: 'Wire Error Capture Middleware', priority: 'high' },
+    ...NEW_CAP_ITEMS,
   ],
 };
 
@@ -23,6 +37,7 @@ const missingBothPlan = {
   sprintItems: [
     { title: 'Build core ventureHealth dashboard', priority: 'high' },
     { title: 'Add user profile page', priority: 'medium' },
+    ...NEW_CAP_ITEMS,
   ],
 };
 
@@ -40,6 +55,7 @@ describe('validateVentureDefaultCapabilities', () => {
         sprintItems: [
           { title: 'integrate feedback widget into header' },
           { title: 'wire error capture middleware (Sentry)' },
+          ...NEW_CAP_ITEMS,
         ],
       };
       const result = validateVentureDefaultCapabilities(plan, {});
@@ -51,6 +67,7 @@ describe('validateVentureDefaultCapabilities', () => {
         sprintItems: [
           { title: 'Story XYZ — feedback-widget rollout' },
           { title: 'Setup error-capture-middleware' },
+          ...NEW_CAP_ITEMS,
         ],
       };
       const result = validateVentureDefaultCapabilities(plan, {});
@@ -149,16 +166,17 @@ describe('validateVentureDefaultCapabilities', () => {
         items: [
           { title: 'Integrate Feedback Widget' },
           { title: 'Wire Error Capture Middleware' },
+          ...NEW_CAP_ITEMS,
         ],
       };
       const result = validateVentureDefaultCapabilities(plan, {});
       expect(result.valid).toBe(true);
     });
 
-    it('treats missing sprintItems as empty array (both capabilities will fail)', () => {
+    it('treats missing sprintItems as empty array (all 7 capabilities will fail)', () => {
       const result = validateVentureDefaultCapabilities({}, {});
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(2);
+      expect(result.errors).toHaveLength(7);
     });
   });
 });

--- a/tests/unit/eva/venture-default-capabilities.test.js
+++ b/tests/unit/eva/venture-default-capabilities.test.js
@@ -5,15 +5,38 @@ import {
   DEFAULT_CAPABILITY_IDS,
 } from '../../../lib/eva/config/venture-default-capabilities.js';
 
+// SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001: the portfolio-default set grew
+// from 2 to 7 capabilities (FR-1..FR-5); the budget contract grew from 3 to 9 story points.
+const EXPECTED_CAPABILITY_IDS = [
+  'feedback-widget',
+  'error-capture-middleware',
+  'cost-instrumentation',
+  'telemetry-analytics',
+  'calm-decision-card',
+  'health-uptime-probe',
+  'operating-model-grounding',
+];
+
 describe('EHG_VENTURE_DEFAULT_CAPABILITIES — config well-formedness', () => {
-  it('exports an array of exactly 2 capabilities', () => {
+  it('exports an array of exactly 7 capabilities', () => {
     expect(Array.isArray(EHG_VENTURE_DEFAULT_CAPABILITIES)).toBe(true);
-    expect(EHG_VENTURE_DEFAULT_CAPABILITIES).toHaveLength(2);
+    expect(EHG_VENTURE_DEFAULT_CAPABILITIES).toHaveLength(7);
   });
 
-  it('contains feedback-widget and error-capture-middleware capability_ids', () => {
+  it('contains all 7 expected capability_ids in order', () => {
     const ids = EHG_VENTURE_DEFAULT_CAPABILITIES.map(c => c.capability_id);
-    expect(ids).toEqual(['feedback-widget', 'error-capture-middleware']);
+    expect(ids).toEqual(EXPECTED_CAPABILITY_IDS);
+  });
+
+  it('preserves the two original capabilities unchanged (feedback=2, error_capture=1)', () => {
+    const byId = Object.fromEntries(EHG_VENTURE_DEFAULT_CAPABILITIES.map(c => [c.capability_id, c]));
+    expect(byId['feedback-widget'].story_points).toBe(2);
+    expect(byId['feedback-widget'].name).toBe('Integrate Feedback Widget');
+    expect(byId['error-capture-middleware'].story_points).toBe(1);
+    expect(byId['error-capture-middleware'].name).toBe('Wire Error Capture Middleware');
+    // The two original entries still cite the quality-lifecycle vision doc.
+    expect(byId['feedback-widget'].vision_source_section).toMatch(/quality-lifecycle-system\.md/);
+    expect(byId['error-capture-middleware'].vision_source_section).toMatch(/quality-lifecycle-system\.md/);
   });
 
   it('each entry has all required keys with correct types', () => {
@@ -29,18 +52,22 @@ describe('EHG_VENTURE_DEFAULT_CAPABILITIES — config well-formedness', () => {
       expect(typeof cap.name).toBe('string');
       expect(typeof cap.description).toBe('string');
       expect(typeof cap.story_points).toBe('number');
+      expect(cap.story_points).toBeGreaterThan(0);
       expect(['critical', 'high', 'medium', 'low']).toContain(cap.priority);
       expect(typeof cap.acceptance_criteria).toBe('string');
+      expect(cap.acceptance_criteria.length).toBeGreaterThan(0);
       expect(Array.isArray(cap.target_stack_components)).toBe(true);
       expect(cap.target_stack_components.length).toBeGreaterThan(0);
       expect(typeof cap.vision_source_section).toBe('string');
-      expect(cap.vision_source_section).toMatch(/quality-lifecycle-system\.md/);
+      // Every entry must cite a vision/standard source; the 5 new caps cite vision
+      // sections or the operating-model SSOT rather than the quality-lifecycle doc.
+      expect(cap.vision_source_section.length).toBeGreaterThan(0);
     }
   });
 
-  it('total story_points equals 3 (budget contract — feedback=2, error_capture=1)', () => {
+  it('total story_points equals 9 (budget contract — original 3 + five new caps 6)', () => {
     const total = EHG_VENTURE_DEFAULT_CAPABILITIES.reduce((s, c) => s + c.story_points, 0);
-    expect(total).toBe(3);
+    expect(total).toBe(9);
   });
 
   it('outer array AND each entry are frozen (immutable at runtime)', () => {


### PR DESCRIPTION
@
## Summary
Expands the S19-enforced portfolio-default capability set from **2 to 7** (lib/eva/config/venture-default-capabilities.js), closing recurring portfolio blind spots ranked by the joint Adam↔coordinator assessment.

| FR | capability_id | pts | Closes |
|----|---------------|-----|--------|
| FR-1 | cost-instrumentation | 2 | venture burn → distance-to-quit / $18k-net north-star gauge |
| FR-2 | telemetry-analytics | 1 | Stage-25 post-launch review blind without usage data |
| FR-3 | calm-decision-card | 1 | Stage-17 RED-on-green / empty-summary contradiction |
| FR-4 | health-uptime-probe | 1 | merged != running (deploy-verification) |
| FR-5 | operating-model-grounding | 1 | S5/S16 generic-SaaS false-kill (inherit SSOT) |

**FR-6 (reserve budget):** the S19 reserve was a hardcoded `~3 story points` that exactly matched the old 2-cap sum and silently drifted when the set grew — under-scoping the sprint so new mandatory caps would ship *declared-but-unbuilt*. Replaced with a **dynamic** reserve = sum of mandatory capability story_points (now **9**), so it can never drift again. This supersedes the specs literal `~6-7` estimate, which was internally inconsistent with its own `~8-9pt new caps` sizing — flagged transparently rather than coded to a number that wouldnt fit.

## Invariants preserved
- `DEFAULT_CAPABILITIES_VERSION` 2026.04 → **2026.06**
- The two original capabilities are **byte-unchanged**
- `validateVentureDefaultCapabilities` iterates the set dynamically → enforcement auto-extends (omitting any new cap is rejected unless chairman-authorized override)

## Verification
- 73 unit tests pass (venture-default-capabilities, validate-venture-default-capabilities, stage-19 default-capabilities, stage-19 binding-contract, stage-13 roadmap)
- Audit script (`scripts/one-off/audit-venture-default-capabilities.mjs`) runs clean and surfaces **20 deviations across 4 in-flight sprint plans** — the re-evaluation surface
- Out of scope (per SD): building each capability inside ventures; the sibling build-SD review gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@