### PR TITLE
feat(SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001): second-party review gate for auto-generated S19 build SDs

### DIFF
--- a/lib/eva/build-sd-review-gate.js
+++ b/lib/eva/build-sd-review-gate.js
@@ -1,0 +1,301 @@
+/**
+ * Build-SD Review Gate
+ *
+ * SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001
+ *
+ * Second-party review of EVA Stage-19 build payloads (the sd_bridge_payloads),
+ * run POST-payload / PRE-INSERT by lib/eva/lifecycle-sd-bridge.js — i.e. BEFORE
+ * any build SD exists, while issues are still cheap to fix. Without this gate the
+ * Stage-19 bridge emits build SDs to the belt unilaterally (the unreviewed
+ * auto-generation risk class — same as the reserved-gate bypass).
+ *
+ * Four review dimensions:
+ *   (a) vision-alignment      — each payload overlaps the chairman-approved vision themes
+ *   (b) standards-completeness — the build set covers the mandatory default-capabilities
+ *   (c) tier-coherence         — each payload maps to exactly one worker tier
+ *   (d) gaps/dupes             — no payload duplicates an existing SD
+ *
+ * Hybrid ownership (FR-3): the coordinator owns (c)+(d) — cheap deterministic
+ * DB/heuristic queries run IN-PROCESS here so the whole review never bottlenecks
+ * on the live coordinator. (a)+(b) are the institutional-knowledge dimensions
+ * (Adam / a sub-agent panel); for this advisory-first cut they run as in-process
+ * heuristics, with the live multi-agent PANEL dispatch a documented follow-on.
+ *
+ * Advisory-first + FAIL-OPEN (FR-4): defaults to ADVISORY (flag + log, never
+ * block). ENFORCING mode (config flag, default off) holds flagged build SDs
+ * pre-claim (requires_human_action=true) with a MANDATORY timeout->proceed
+ * escape — a dead/slow reviewer must NEVER wedge the build path (the S19 bridge
+ * wedged once already on the stack_descriptor incident). The whole review is
+ * wrapped in a try/catch + timeout race; any error/timeout => proceed_failopen,
+ * no hold.
+ *
+ * The authoritative mandatory-capability LIST is deliberately NOT defined here —
+ * it is owned by the sibling SD (SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-
+ * EXPAND-001) and INJECTED as `mandatoryCapabilities`. When absent, dimension (b)
+ * is a fail-safe no-op pass (never flag against an undefined standard).
+ *
+ * @module lib/eva/build-sd-review-gate
+ */
+
+export const DEFAULT_REVIEW_TIMEOUT_MS = 20000;
+
+/** Resolve advisory|enforcing from env (BUILD_SD_REVIEW_MODE) then config; default advisory. */
+export function resolveReviewMode({ env = process.env, config = null } = {}) {
+  const raw = (env?.BUILD_SD_REVIEW_MODE || config?.build_sd_review_mode || 'advisory')
+    .toString().trim().toLowerCase();
+  return raw === 'enforcing' ? 'enforcing' : 'advisory';
+}
+
+/** Lowercase, collapse non-alphanumerics to single spaces — for token/dup comparison. */
+export function normalizeReviewKey(s) {
+  return (s == null ? '' : String(s)).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'that', 'this', 'from', 'into', 'onto',
+  'venture', 'vision', 'build', 'feature', 'system', 'support', 'enable',
+]);
+
+/** Collect significant (>=4 char, non-stopword) lowercase tokens from the curated vision dimensions. */
+export function extractVisionTerms(canonicalVision) {
+  if (!canonicalVision) return [];
+  const dims = canonicalVision.extracted_dimensions
+    ?? canonicalVision.metadata?.extracted_dimensions
+    ?? null;
+  const collected = [];
+  const pushFrom = (v) => {
+    if (v == null) return;
+    if (typeof v === 'string') { collected.push(v); return; }
+    if (Array.isArray(v)) { v.forEach(pushFrom); return; }
+    if (typeof v === 'object') {
+      for (const key of ['name', 'dimension', 'theme', 'label', 'value', 'title']) {
+        if (typeof v[key] === 'string') { collected.push(v[key]); break; }
+      }
+      // a map of theme -> detail: the (non-numeric) keys are themselves themes
+      for (const k of Object.keys(v)) { if (Number.isNaN(Number(k))) collected.push(k); }
+    }
+  };
+  pushFrom(dims);
+  const out = new Set();
+  for (const term of collected) {
+    for (const tok of normalizeReviewKey(term).split(' ')) {
+      if (tok.length >= 4 && !STOPWORDS.has(tok)) out.add(tok);
+    }
+  }
+  return [...out];
+}
+
+function payloadText(p) {
+  return normalizeReviewKey([p?.title, p?.scope, p?.description].filter(Boolean).join(' '));
+}
+
+// ── Dimension (a): vision-alignment ─────────────────────────────────────────
+export function reviewVisionAlignment(payloads, canonicalVision) {
+  const flags = [];
+  const terms = extractVisionTerms(canonicalVision);
+  if (!terms.length) {
+    return {
+      dimension: 'vision_alignment', owner: 'panel', ran: true, skipped: true,
+      reason: 'no curated vision themes available (fail-safe pass)', flags,
+    };
+  }
+  payloads.forEach((p, index) => {
+    const hay = payloadText(p);
+    const aligned = terms.some((t) => t && hay.includes(t));
+    if (!aligned) {
+      flags.push({
+        dimension: 'vision_alignment', index, title: p?.title || null,
+        reason: 'no overlap with the chairman-approved vision themes',
+      });
+    }
+  });
+  return { dimension: 'vision_alignment', owner: 'panel', ran: true, skipped: false, flags };
+}
+
+// ── Dimension (b): standards-completeness ───────────────────────────────────
+// `mandatoryCapabilities`: array of strings, or { name, keywords?: string[] }.
+// The build SET must collectively cover each required capability. The LIST is
+// injected (owned by the sibling SD); absent => fail-safe no-op pass.
+export function reviewStandardsCompleteness(payloads, mandatoryCapabilities) {
+  const flags = [];
+  const required = Array.isArray(mandatoryCapabilities)
+    ? mandatoryCapabilities.filter(Boolean) : [];
+  if (!required.length) {
+    return {
+      dimension: 'standards_completeness', owner: 'panel', ran: true, skipped: true,
+      reason: 'no mandatory-capability list configured (fail-safe pass; list owned by sibling SD)',
+      flags,
+    };
+  }
+  const haystack = payloads.map(payloadText).join(' ');
+  for (const cap of required) {
+    const name = typeof cap === 'string' ? cap : (cap.name || cap.capability || '');
+    const keywords = (typeof cap === 'object' && Array.isArray(cap.keywords) && cap.keywords.length)
+      ? cap.keywords : [name];
+    const present = keywords.some((kw) => {
+      const k = normalizeReviewKey(kw);
+      return k && haystack.includes(k);
+    });
+    if (!present) {
+      flags.push({
+        dimension: 'standards_completeness', capability: name || String(cap),
+        reason: 'no build payload covers this mandatory default-capability',
+      });
+    }
+  }
+  return { dimension: 'standards_completeness', owner: 'panel', ran: true, skipped: false, flags };
+}
+
+// ── Dimension (c): tier-coherence ───────────────────────────────────────────
+// Reuses the bridge's sprintItemLayerRank (injected as `layerRank`). A payload is
+// incoherent if it supplies NO layer-bearing field (so the bridge silently
+// defaults its tier) OR its present layer fields disagree on rank (claims >1 tier).
+export function reviewTierCoherence(payloads, layerRank) {
+  const flags = [];
+  if (typeof layerRank !== 'function') {
+    return {
+      dimension: 'tier_coherence', owner: 'coordinator', ran: true, skipped: true,
+      reason: 'no layerRank classifier injected (fail-safe pass)', flags,
+    };
+  }
+  const LAYER_FIELDS = ['architecture_layer', 'scope', 'type'];
+  payloads.forEach((p, index) => {
+    const present = LAYER_FIELDS.filter((f) => p && p[f]);
+    if (present.length === 0) {
+      flags.push({
+        dimension: 'tier_coherence', index, title: p?.title || null,
+        reason: 'no architecture_layer/scope/type — cannot map to a single worker tier (silent default)',
+      });
+      return;
+    }
+    const ranks = new Set(present.map((f) => layerRank({ [f]: p[f] })));
+    if (ranks.size > 1) {
+      flags.push({
+        dimension: 'tier_coherence', index, title: p?.title || null,
+        reason: `conflicting layer signals across fields — maps to multiple tiers (${[...ranks].join(',')})`,
+      });
+    }
+  });
+  return { dimension: 'tier_coherence', owner: 'coordinator', ran: true, skipped: false, flags };
+}
+
+// ── Dimension (d): gaps/dupes ───────────────────────────────────────────────
+// Normalized-title belt scan of non-cancelled SDs. Throws on DB error so the
+// caller's fail-open path handles it (never silently swallow).
+export async function reviewGapsDupes(payloads, { supabase, logger = console } = {}) {
+  const flags = [];
+  if (!supabase) {
+    return {
+      dimension: 'gaps_dupes', owner: 'coordinator', ran: true, skipped: true,
+      reason: 'no supabase client (fail-safe pass)', flags,
+    };
+  }
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key,title,status')
+    .neq('status', 'cancelled')
+    .limit(5000);
+  if (error) {
+    throw new Error(`gaps_dupes belt scan failed: ${error.message}`);
+  }
+  const existing = new Map();
+  for (const row of (data || [])) {
+    const key = normalizeReviewKey(row.title);
+    if (key && !existing.has(key)) existing.set(key, row.sd_key);
+  }
+  payloads.forEach((p, index) => {
+    const key = normalizeReviewKey(p?.title);
+    if (key && existing.has(key)) {
+      flags.push({
+        dimension: 'gaps_dupes', index, title: p?.title || null,
+        existing_sd: existing.get(key),
+        reason: `duplicate of existing SD ${existing.get(key)}`,
+      });
+    }
+  });
+  return { dimension: 'gaps_dupes', owner: 'coordinator', ran: true, skipped: false, flags };
+}
+
+function withTimeout(promise, ms) {
+  if (!ms || ms <= 0) return promise;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`build-sd review timeout after ${ms}ms`)), ms);
+    Promise.resolve(promise).then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}
+
+/**
+ * Review a set of Stage-19 build payloads PRE-INSERT.
+ *
+ * @param {Object} input
+ * @param {Array}  input.payloads               - sd_bridge_payloads (sprint items)
+ * @param {Object} [input.ventureContext]       - { id, name } (for logging)
+ * @param {Object} [input.canonicalVision]      - the chairman-approved L2 vision row (extracted_dimensions)
+ * @param {Array}  [input.mandatoryCapabilities]- injected default-capability list (sibling SD owns it)
+ * @param {('advisory'|'enforcing')} [input.mode] - overrides config resolution
+ * @param {number} [input.timeoutMs]            - fail-open timeout (default 20s)
+ * @param {Object} [deps]
+ * @param {Object} [deps.supabase]              - dup belt scan client
+ * @param {Object} [deps.logger]                - logger (default console)
+ * @param {Function} [deps.layerRank]           - sprintItemLayerRank (tier-coherence)
+ * @param {Object} [deps.env]                   - env source (default process.env)
+ * @param {Object} [deps.config]                - chairman_dashboard_config row
+ * @returns {Promise<{verdict, mode, dimensions, flags, hold, failOpen, error?}>}
+ *   verdict ∈ 'pass' | 'flagged' | 'proceed_failopen'. `hold` is true ONLY when
+ *   mode='enforcing' AND verdict='flagged' (caller applies requires_human_action).
+ */
+export async function reviewBuildPayloads(input = {}, deps = {}) {
+  const {
+    payloads = [],
+    ventureContext = null,
+    canonicalVision = null,
+    mandatoryCapabilities = null,
+    mode: modeIn = null,
+    timeoutMs = DEFAULT_REVIEW_TIMEOUT_MS,
+  } = input;
+  const { supabase = null, logger = console, layerRank = null, env = process.env, config = null } = deps;
+  const mode = modeIn || resolveReviewMode({ env, config });
+
+  const runReview = async () => {
+    const dimensions = {
+      vision_alignment: reviewVisionAlignment(payloads, canonicalVision),
+      standards_completeness: reviewStandardsCompleteness(payloads, mandatoryCapabilities),
+      tier_coherence: reviewTierCoherence(payloads, layerRank),
+      gaps_dupes: await reviewGapsDupes(payloads, { supabase, logger }),
+    };
+    const flags = Object.values(dimensions).flatMap((d) => d.flags || []);
+    const verdict = flags.length ? 'flagged' : 'pass';
+    return {
+      verdict, mode, dimensions, flags,
+      hold: mode === 'enforcing' && verdict === 'flagged',
+      failOpen: false,
+      reviewed_at: new Date().toISOString(),
+    };
+  };
+
+  try {
+    const result = await withTimeout(runReview(), timeoutMs);
+    if (result.flags.length) {
+      logger.warn(
+        `[BuildSDReviewGate] ${result.verdict} (${mode}) for venture ${ventureContext?.name || ventureContext?.id || '?'}: `
+        + `${result.flags.length} flag(s) — ${result.flags.map((f) => f.dimension).join(', ')}`,
+      );
+    }
+    return result;
+  } catch (err) {
+    // FAIL-OPEN: a down/slow/throwing reviewer must NEVER wedge the build path.
+    logger.warn(
+      `[BuildSDReviewGate] FAIL-OPEN: review error/timeout (${err.message}) — proceeding without hold (mode=${mode})`,
+    );
+    return {
+      verdict: 'proceed_failopen', mode, dimensions: {}, flags: [],
+      hold: false, failOpen: true, error: err.message,
+      reviewed_at: new Date().toISOString(),
+    };
+  }
+}
+
+export default reviewBuildPayloads;

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -56,6 +56,9 @@ import { getTargetApplicationCapabilities } from './config/target-application-ca
 import { getActiveSDFilter } from '../sd/active-sd-predicate.js';
 import { normalizeVentureName } from './bridge/venture-routing-error.js';
 import { emitFeedback } from '../governance/emit-feedback.js';
+// SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: second-party review of the build payloads,
+// POST-payload / PRE-INSERT. Advisory-first + fail-open (never wedges the build path).
+import { reviewBuildPayloads } from './build-sd-review-gate.js';
 
 // ── Amplification Caps (US-004) ─────────────────────────────────
 const MAX_CHILDREN_PER_ORCHESTRATOR = 10;
@@ -479,6 +482,27 @@ export async function convertSprintToSDs(params, deps = {}) {
     // (incl. extracted_dimensions) so enrichment can ground on it without a second fetch.
     const canonicalVision = await assertVentureVisionReady(supabase, ventureContext?.id, ventureContext?.name);
 
+    // ── SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: second-party review (PRE-INSERT) ──
+    // Review the build payloads BEFORE any SD exists, on four dimensions (vision-
+    // alignment, standards-completeness, tier-coherence, gaps/dupes). ADVISORY-first
+    // (flag + log, never block) and FAIL-OPEN by construction — reviewBuildPayloads
+    // wraps itself in a try/catch + timeout race, so a down/slow reviewer yields
+    // proceed_failopen and the build proceeds (the S19 bridge must never wedge).
+    // `holdForReview` is true ONLY in enforcing mode with a flagged verdict; it is
+    // threaded into the insert rows as a pre-claim hold (requires_human_action),
+    // cleared by chairman review or — on fail-open/timeout — never applied at all.
+    // The mandatory-capability LIST is owned by the sibling SD
+    // (SD-LEO-INFRA-VENTURE-DEFAULT-CAPABILITIES-EXPAND-001); injected as null here
+    // until that lands => dimension (b) is a fail-safe no-op pass for now.
+    const buildReview = await reviewBuildPayloads(
+      { payloads, ventureContext, canonicalVision, mandatoryCapabilities: deps.mandatoryCapabilities || null },
+      { supabase, logger, layerRank: sprintItemLayerRank, config: deps.chairmanConfig || null },
+    );
+    const holdForReview = buildReview.hold === true;
+    const reviewHoldReason = holdForReview
+      ? `BUILD_SD_REVIEW hold (enforcing): ${buildReview.flags.map((f) => `${f.dimension}:${f.reason}`).join('; ')}`
+      : null;
+
     // Generate orchestrator SD key
     const orchestratorKey = await generateSDKey({
       source: 'LEO',
@@ -533,6 +557,20 @@ export async function convertSprintToSDs(params, deps = {}) {
           sprint_duration_days: sprintDuration,
           vision_key: evaKeys.vision_key || null,
           plan_key: evaKeys.plan_key || null,
+          // SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: pre-claim hold (enforcing + flagged
+          // only). metadata.requires_human_action is the proven non-claimable mechanism
+          // — lib/fleet/claim-eligibility.cjs reads it and returns 'human_action_required'.
+          requires_human_action: holdForReview,
+          // SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: persist the review verdict for audit.
+          build_sd_review: {
+            verdict: buildReview.verdict,
+            mode: buildReview.mode,
+            fail_open: buildReview.failOpen === true,
+            flag_count: buildReview.flags.length,
+            flags: buildReview.flags,
+            reviewed_at: buildReview.reviewed_at,
+          },
+          review_hold_reason: reviewHoldReason,
           created_at: new Date().toISOString(),
         },
       });
@@ -641,6 +679,11 @@ export async function convertSprintToSDs(params, deps = {}) {
             plan_key: evaKeys.plan_key || null,
             artifact_references: childArtifactRefs,
             extracted_context: enrichment?.extractedContext || null,
+            // SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: pre-claim hold + reason (enforcing +
+            // flagged only). metadata.requires_human_action blocks the claim via
+            // lib/fleet/claim-eligibility.cjs -> 'human_action_required'.
+            requires_human_action: holdForReview,
+            review_hold_reason: reviewHoldReason,
             created_at: new Date().toISOString(),
           },
         });
@@ -719,6 +762,8 @@ export async function convertSprintToSDs(params, deps = {}) {
       childKeys,
       grandchildKeys,
       errors,
+      // SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: surface the review verdict for downstream verification.
+      buildReview,
     };
   } catch (err) {
     logger.error(`[LifecycleSDBridge] Hierarchy creation failed: ${err.message}`);

--- a/tests/eva/build-sd-review-gate.test.js
+++ b/tests/eva/build-sd-review-gate.test.js
@@ -1,0 +1,272 @@
+/**
+ * Tests for lib/eva/build-sd-review-gate.js — the second-party review of EVA
+ * Stage-19 build payloads (POST-payload / PRE-INSERT, advisory-first, fail-open).
+ *
+ * SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001
+ * Covers the three regression smoke scenarios (TS-1..TS-3), the pre-claim hold
+ * (TS-4), gaps/dupes (TS-5), plus per-dimension unit behavior and fail-open.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  reviewBuildPayloads,
+  reviewVisionAlignment,
+  reviewStandardsCompleteness,
+  reviewTierCoherence,
+  reviewGapsDupes,
+  resolveReviewMode,
+  extractVisionTerms,
+} from '../../lib/eva/build-sd-review-gate.js';
+import { sprintItemLayerRank } from '../../lib/eva/lifecycle-sd-bridge.js';
+
+// ── Test doubles ────────────────────────────────────────────────────────────
+const silentLogger = { warn() {}, log() {}, error() {} };
+
+/** Supabase double whose .from().select().neq().limit() resolves to {data,error}. */
+function mockSupabase({ rows = [], error = null, hang = false } = {}) {
+  const builder = {
+    select() { return builder; },
+    neq() { return builder; },
+    limit() {
+      if (hang) return new Promise(() => {}); // never resolves -> exercises timeout
+      return Promise.resolve({ data: rows, error });
+    },
+  };
+  return { from() { return builder; } };
+}
+
+const VISION = { extracted_dimensions: ['developer productivity', 'code review automation'] };
+
+function alignedPayloads() {
+  return [
+    { title: 'Code review automation API', scope: 'backend', description: 'automate review' },
+    { title: 'Developer productivity dashboard', scope: 'frontend', description: 'productivity metrics' },
+  ];
+}
+
+// ── resolveReviewMode ───────────────────────────────────────────────────────
+describe('resolveReviewMode', () => {
+  it('defaults to advisory with no env/config', () => {
+    expect(resolveReviewMode({ env: {}, config: null })).toBe('advisory');
+  });
+  it('honors BUILD_SD_REVIEW_MODE=enforcing', () => {
+    expect(resolveReviewMode({ env: { BUILD_SD_REVIEW_MODE: 'enforcing' } })).toBe('enforcing');
+  });
+  it('falls back to config when env unset', () => {
+    expect(resolveReviewMode({ env: {}, config: { build_sd_review_mode: 'enforcing' } })).toBe('enforcing');
+  });
+  it('treats any non-enforcing value as advisory', () => {
+    expect(resolveReviewMode({ env: { BUILD_SD_REVIEW_MODE: 'banana' } })).toBe('advisory');
+  });
+});
+
+// ── extractVisionTerms ──────────────────────────────────────────────────────
+describe('extractVisionTerms', () => {
+  it('pulls significant tokens from extracted_dimensions (array of strings)', () => {
+    const terms = extractVisionTerms(VISION);
+    expect(terms).toContain('developer');
+    expect(terms).toContain('automation');
+    expect(terms).not.toContain('the'); // stopword filtered
+  });
+  it('returns [] when no curated dimensions exist (fail-safe input)', () => {
+    expect(extractVisionTerms(null)).toEqual([]);
+    expect(extractVisionTerms({})).toEqual([]);
+  });
+  it('handles dimensions given as objects with a name field', () => {
+    const terms = extractVisionTerms({ extracted_dimensions: [{ name: 'Observability tooling' }] });
+    expect(terms).toContain('observability');
+  });
+});
+
+// ── Dimension (a): vision-alignment ─────────────────────────────────────────
+describe('reviewVisionAlignment', () => {
+  it('flags a payload with no overlap with the vision themes', () => {
+    const r = reviewVisionAlignment(
+      [{ title: 'Pet grooming scheduler', scope: 'backend', description: 'book appointments' }],
+      VISION,
+    );
+    expect(r.flags).toHaveLength(1);
+    expect(r.flags[0].dimension).toBe('vision_alignment');
+  });
+  it('passes aligned payloads with zero flags', () => {
+    const r = reviewVisionAlignment(alignedPayloads(), VISION);
+    expect(r.flags).toHaveLength(0);
+  });
+  it('fail-safe no-op pass when no vision themes are available', () => {
+    const r = reviewVisionAlignment([{ title: 'anything' }], null);
+    expect(r.skipped).toBe(true);
+    expect(r.flags).toHaveLength(0);
+  });
+});
+
+// ── Dimension (b): standards-completeness ───────────────────────────────────
+describe('reviewStandardsCompleteness', () => {
+  const caps = [
+    { name: 'auth', keywords: ['auth', 'authentication', 'login'] },
+    { name: 'monitoring', keywords: ['monitor', 'observability', 'sentry'] },
+  ];
+  it('flags a mandatory capability not covered by any payload', () => {
+    const r = reviewStandardsCompleteness(
+      [{ title: 'Login and authentication service', scope: 'backend' }],
+      caps,
+    );
+    expect(r.flags).toHaveLength(1);
+    expect(r.flags[0].capability).toBe('monitoring');
+  });
+  it('passes when the build set collectively covers all capabilities', () => {
+    const r = reviewStandardsCompleteness(
+      [
+        { title: 'Authentication service', scope: 'backend' },
+        { title: 'Sentry observability wiring', scope: 'integration' },
+      ],
+      caps,
+    );
+    expect(r.flags).toHaveLength(0);
+  });
+  it('fail-safe no-op pass when no mandatory-capability list is configured', () => {
+    const r = reviewStandardsCompleteness([{ title: 'x' }], null);
+    expect(r.skipped).toBe(true);
+    expect(r.flags).toHaveLength(0);
+  });
+  it('supports bare-string capabilities', () => {
+    const r = reviewStandardsCompleteness([{ title: 'no match here' }], ['telemetry']);
+    expect(r.flags).toHaveLength(1);
+    expect(r.flags[0].capability).toBe('telemetry');
+  });
+});
+
+// ── Dimension (c): tier-coherence (reuses the bridge classifier) ────────────
+describe('reviewTierCoherence', () => {
+  it('flags a payload with no layer-bearing field', () => {
+    const r = reviewTierCoherence([{ title: 'Untyped item' }], sprintItemLayerRank);
+    expect(r.flags).toHaveLength(1);
+    expect(r.flags[0].reason).toMatch(/single worker tier/);
+  });
+  it('flags a payload whose layer fields conflict across tiers', () => {
+    const r = reviewTierCoherence(
+      [{ title: 'Conflicted', architecture_layer: 'backend', scope: 'frontend' }],
+      sprintItemLayerRank,
+    );
+    expect(r.flags).toHaveLength(1);
+    expect(r.flags[0].reason).toMatch(/multiple tiers/);
+  });
+  it('passes a coherently-tiered payload', () => {
+    const r = reviewTierCoherence([{ title: 'Backend only', scope: 'backend' }], sprintItemLayerRank);
+    expect(r.flags).toHaveLength(0);
+  });
+  it('fail-safe no-op pass when no classifier is injected', () => {
+    const r = reviewTierCoherence([{ title: 'x' }], null);
+    expect(r.skipped).toBe(true);
+    expect(r.flags).toHaveLength(0);
+  });
+});
+
+// ── Dimension (d): gaps/dupes ───────────────────────────────────────────────
+describe('reviewGapsDupes', () => {
+  it('flags a payload duplicating an existing SD title', async () => {
+    const supabase = mockSupabase({ rows: [{ sd_key: 'SD-OLD-1', title: 'Existing Thing', status: 'draft' }] });
+    const r = await reviewGapsDupes([{ title: 'Existing Thing' }, { title: 'Brand New' }], { supabase, logger: silentLogger });
+    expect(r.flags).toHaveLength(1);
+    expect(r.flags[0].existing_sd).toBe('SD-OLD-1');
+  });
+  it('throws on DB error so the caller can fail open', async () => {
+    const supabase = mockSupabase({ error: { message: 'boom' } });
+    await expect(reviewGapsDupes([{ title: 'x' }], { supabase, logger: silentLogger })).rejects.toThrow(/boom/);
+  });
+  it('fail-safe no-op pass with no supabase client', async () => {
+    const r = await reviewGapsDupes([{ title: 'x' }], { logger: silentLogger });
+    expect(r.skipped).toBe(true);
+    expect(r.flags).toHaveLength(0);
+  });
+});
+
+// ── reviewBuildPayloads — end-to-end verdict + hold + fail-open ──────────────
+describe('reviewBuildPayloads', () => {
+  const baseDeps = (overrides = {}) => ({
+    supabase: mockSupabase({ rows: [] }),
+    logger: silentLogger,
+    layerRank: sprintItemLayerRank,
+    env: {},
+    ...overrides,
+  });
+
+  it('TS-3: a clean payload passes with zero flags and no hold', async () => {
+    const r = await reviewBuildPayloads(
+      { payloads: alignedPayloads(), canonicalVision: VISION, mode: 'enforcing' },
+      baseDeps(),
+    );
+    expect(r.verdict).toBe('pass');
+    expect(r.flags).toHaveLength(0);
+    expect(r.hold).toBe(false);
+  });
+
+  it('TS-1: advisory + missing mandatory capability => flagged but NOT held', async () => {
+    const r = await reviewBuildPayloads(
+      {
+        payloads: alignedPayloads(),
+        canonicalVision: VISION,
+        mandatoryCapabilities: [{ name: 'monitoring', keywords: ['observability', 'sentry'] }],
+        mode: 'advisory',
+      },
+      baseDeps(),
+    );
+    expect(r.verdict).toBe('flagged');
+    expect(r.flags.some((f) => f.dimension === 'standards_completeness')).toBe(true);
+    expect(r.hold).toBe(false); // advisory never holds
+  });
+
+  it('TS-4: enforcing + flagged => hold=true (pre-claim hold)', async () => {
+    const r = await reviewBuildPayloads(
+      {
+        payloads: alignedPayloads(),
+        canonicalVision: VISION,
+        mandatoryCapabilities: [{ name: 'monitoring', keywords: ['observability', 'sentry'] }],
+        mode: 'enforcing',
+      },
+      baseDeps(),
+    );
+    expect(r.verdict).toBe('flagged');
+    expect(r.hold).toBe(true);
+  });
+
+  it('TS-5: enforcing + duplicate title => flagged under gaps_dupes', async () => {
+    const supabase = mockSupabase({ rows: [{ sd_key: 'SD-DUP-9', title: 'Code review automation API', status: 'draft' }] });
+    const r = await reviewBuildPayloads(
+      { payloads: alignedPayloads(), canonicalVision: VISION, mode: 'enforcing' },
+      baseDeps({ supabase }),
+    );
+    expect(r.flags.some((f) => f.dimension === 'gaps_dupes')).toBe(true);
+  });
+
+  it('TS-2: reviewer error => proceed_failopen with NO hold (no wedge)', async () => {
+    const supabase = mockSupabase({ error: { message: 'db down' } });
+    const r = await reviewBuildPayloads(
+      { payloads: alignedPayloads(), canonicalVision: VISION, mode: 'enforcing' },
+      baseDeps({ supabase }),
+    );
+    expect(r.verdict).toBe('proceed_failopen');
+    expect(r.failOpen).toBe(true);
+    expect(r.hold).toBe(false);
+  });
+
+  it('TS-2 (timeout): a hung reviewer times out and proceeds without a hold', async () => {
+    const supabase = mockSupabase({ hang: true });
+    const r = await reviewBuildPayloads(
+      { payloads: alignedPayloads(), canonicalVision: VISION, mode: 'enforcing', timeoutMs: 50 },
+      baseDeps({ supabase }),
+    );
+    expect(r.verdict).toBe('proceed_failopen');
+    expect(r.hold).toBe(false);
+  });
+
+  it('records per-dimension results in the verdict', async () => {
+    const r = await reviewBuildPayloads(
+      { payloads: alignedPayloads(), canonicalVision: VISION },
+      baseDeps(),
+    );
+    expect(Object.keys(r.dimensions)).toEqual(
+      expect.arrayContaining(['vision_alignment', 'standards_completeness', 'tier_coherence', 'gaps_dupes']),
+    );
+    expect(r.dimensions.tier_coherence.owner).toBe('coordinator');
+    expect(r.dimensions.vision_alignment.owner).toBe('panel');
+  });
+});


### PR DESCRIPTION
## Summary
Adds a lightweight, **advisory-first, fail-open** review checkpoint that runs **POST-S19-payload / PRE-INSERT** in the lifecycle-sd-bridge. EVA Stage 19 currently emits venture build SDs via a raw idempotent insert with no second-party review — auto-generated build SDs reach the belt unilaterally (the same unreviewed-auto-generation risk class as the reserved-gate bypass). This gate reviews the `sd_bridge_payloads` BEFORE any build SD exists, while issues are still cheap to fix.

## Four review dimensions
- **(a) vision-alignment** — each payload overlaps the chairman-approved vision themes
- **(b) standards-completeness** — the build set covers the mandatory default-capabilities (list **injected**, owned by sibling SD; absent ⇒ fail-safe no-op pass)
- **(c) tier-coherence** — each payload maps to exactly one worker tier (reuses `sprintItemLayerRank`)
- **(d) gaps/dupes** — normalized-title belt scan flags duplicates of existing SDs

## FRs
- **FR-1** `lib/eva/build-sd-review-gate.js` `reviewBuildPayloads()` — deterministic, deps-injectable, structured verdict.
- **FR-2** Pre-claim hold (enforcing + flagged only) via `metadata.requires_human_action` (the proven claim-eligibility mechanism) with a **mandatory timeout→proceed escape** — a dead/slow reviewer never wedges the build path (the S19 bridge wedged once already).
- **FR-3** Hybrid ownership — coordinator owns tier-coherence + gaps/dupes (in-process); panel owns vision-alignment + standards-completeness (live panel dispatch deferred, documented follow-on).
- **FR-4** Defaults to **advisory** (flag + log, never block); fail-open by construction (try/catch + timeout race ⇒ `proceed_failopen`, no hold). Verdict stamped on orchestrator `metadata.build_sd_review` + surfaced on bridge return.

## Scope boundary
Out of scope (sibling SDs): the standards LIST itself (`...VENTURE-DEFAULT-CAPABILITIES-EXPAND-001`), and the SD↔PRD drift gate (already shipped). Clean payloads pass byte-unchanged.

## Tests
28 unit tests (`tests/eva/build-sd-review-gate.test.js`) — all dimensions, the three regression smoke scenarios, the pre-claim hold, fail-open, and timeout. **28/28 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)