### PR TITLE
feat(SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-C): freeze venture-1 at S19 + accidental-resume guard

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -93,6 +93,22 @@ function formatDuration(ms) {
   return `${hours}h ${remainingMin}m`;
 }
 
+/**
+ * SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-C / FR-3: durable accidental-resume guard.
+ *
+ * A venture marked `metadata.frozen === true` is a dogfood-complete / superseded
+ * venture (e.g. venture-1, frozen at S19; the clean clone supersedes it). The
+ * stage-execution worker must NEVER advance it or unblock it, regardless of how
+ * its orchestrator_state churns. Null-safe: a missing/empty metadata object is
+ * NOT frozen, so normal ventures are unaffected.
+ *
+ * @param {{metadata?: Object}} venture
+ * @returns {boolean}
+ */
+export function isVentureFrozen(venture) {
+  return venture?.metadata?.frozen === true;
+}
+
 // ── StageExecutionWorker Class ──────────────────────────────
 
 export class StageExecutionWorker {
@@ -480,7 +496,7 @@ export class StageExecutionWorker {
     try {
       const { data, error } = await this._supabase
         .from('ventures')
-        .select('id, name, current_lifecycle_stage')
+        .select('id, name, current_lifecycle_stage, metadata')
         .eq('status', 'active')
         .eq('orchestrator_state', ORCHESTRATOR_STATES.IDLE)
         .lt('current_lifecycle_stage', MAX_STAGE)
@@ -491,7 +507,19 @@ export class StageExecutionWorker {
         return [];
       }
 
-      return data || [];
+      // SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-C / FR-3: never advance a frozen
+      // (dogfood-complete / superseded) venture. Filter in JS — a PostgREST
+      // neq on metadata->>frozen would also drop null-metadata rows. The frozen
+      // venture stays parked at its current stage forever.
+      const ready = (data || []).filter((v) => {
+        if (isVentureFrozen(v)) {
+          this._logger.log(`[Worker] Skipping frozen venture ${v.name || v.id} (dogfood-complete; not advanced)`);
+          return false;
+        }
+        return true;
+      });
+
+      return ready;
     } catch (err) {
       this._logger.error(`[Worker] Poll error: ${err.message}`);
       return [];
@@ -2226,13 +2254,21 @@ export class StageExecutionWorker {
     try {
       const { data: blocked } = await this._supabase
         .from('ventures')
-        .select('id, name, current_lifecycle_stage')
+        .select('id, name, current_lifecycle_stage, metadata')
         .eq('status', 'active')
         .eq('orchestrator_state', ORCHESTRATOR_STATES.BLOCKED);
 
       if (!blocked || blocked.length === 0) return;
 
       for (const venture of blocked) {
+        // SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-C / FR-3: a frozen venture must
+        // stay blocked — never resurface/unblock it even if its previous stage
+        // completed externally. This is the durable accidental-resume guard.
+        if (isVentureFrozen(venture)) {
+          this._logger.log(`[Worker] Keeping frozen venture ${venture.name || venture.id} blocked (dogfood-complete; not unblocked)`);
+          continue;
+        }
+
         const prevStage = venture.current_lifecycle_stage - 1;
         if (prevStage < 1) continue;
 

--- a/scripts/freeze-venture-1-disposition.mjs
+++ b/scripts/freeze-venture-1-disposition.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Freeze venture-1 disposition — SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-C
+ *
+ * Records the DURABLE chairman decision that venture-1 ("Market Modeling SaaS",
+ * 849cd2bd-cd6e-4a5e-870d-e21a47b71393) is dogfood-complete and FROZEN at
+ * lifecycle stage 19, superseded by the fully-grounded clean clone as the real
+ * build vehicle, and sets the durable freeze marker that the stage-execution
+ * worker honors (lib/eva/stage-execution-worker.js isVentureFrozen / FR-3) so
+ * the venture can never be accidentally advanced or unblocked past S19.
+ *
+ * IDEMPOTENT: safe to re-run. A second run does not create a duplicate
+ * venture_disposition decision and leaves the freeze marker correct.
+ *
+ *   node scripts/freeze-venture-1-disposition.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const VENTURE_ID = '849cd2bd-cd6e-4a5e-870d-e21a47b71393';
+const FROZEN_STAGE = 19;
+const SUPERSEDED_BY = 'SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001';
+const DISPOSITION_TYPE = 'venture_disposition';
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  // ── FR-1: durable chairman disposition decision (idempotent) ──
+  const { data: existing, error: exErr } = await supabase
+    .from('chairman_decisions')
+    .select('id, status')
+    .eq('venture_id', VENTURE_ID)
+    .eq('decision_type', DISPOSITION_TYPE)
+    .is('deleted_at', null)
+    .limit(1)
+    .maybeSingle();
+  if (exErr) throw new Error(`disposition lookup failed: ${exErr.message}`);
+
+  let decisionId = existing?.id || null;
+  if (existing) {
+    console.log(`✓ FR-1: venture_disposition decision already exists (${existing.id}, status=${existing.status}) — no duplicate created`);
+  } else {
+    const rationale =
+      'Venture-1 (Market Modeling SaaS) is dogfood-complete and FROZEN at Stage 19. '
+      + 'Its upstream S0-S15 predate the grounding fixes, so it advances no further; the '
+      + 'fully-grounded clean clone (SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001) supersedes it as '
+      + 'the real build vehicle. Recorded as a durable governance decision; the stage-execution '
+      + 'worker is guarded (metadata.frozen) against accidental resume past S19.';
+    const { data: created, error: insErr } = await supabase
+      .from('chairman_decisions')
+      .insert({
+        venture_id: VENTURE_ID,
+        lifecycle_stage: FROZEN_STAGE,
+        decision_type: DISPOSITION_TYPE,
+        decision: 'sunset',
+        status: 'approved',
+        decided_by: 'chairman',
+        blocking: false,
+        rationale,
+        summary: 'venture-1 dogfood-complete, frozen at S19; superseded by clean clone',
+      })
+      .select('id')
+      .single();
+    if (insErr) throw new Error(`disposition insert failed: ${insErr.message}`);
+    decisionId = created.id;
+    console.log(`✓ FR-1: recorded venture_disposition decision ${created.id} (decision=sunset, stage=19, status=approved)`);
+  }
+
+  // ── FR-2: durable freeze marker on venture-1 (additive merge, idempotent) ──
+  const { data: venture, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, name, metadata')
+    .eq('id', VENTURE_ID)
+    .single();
+  if (vErr) throw new Error(`venture fetch failed: ${vErr.message}`);
+
+  const prevMeta = venture.metadata || {};
+  const mergedMeta = {
+    ...prevMeta,
+    frozen: true,
+    frozen_reason: 'dogfood-complete; superseded by clean clone',
+    frozen_at: prevMeta.frozen_at || new Date().toISOString(),
+    frozen_at_stage: FROZEN_STAGE,
+    disposition: 'dogfood_complete',
+    superseded_by: SUPERSEDED_BY,
+    disposition_decision_id: decisionId,
+  };
+  const { error: upErr } = await supabase
+    .from('ventures')
+    .update({ metadata: mergedMeta })
+    .eq('id', VENTURE_ID);
+  if (upErr) throw new Error(`freeze marker update failed: ${upErr.message}`);
+
+  const preservedKeys = Object.keys(prevMeta).filter((k) => !['frozen', 'frozen_reason', 'frozen_at', 'frozen_at_stage', 'disposition', 'superseded_by', 'disposition_decision_id'].includes(k));
+  console.log(`✓ FR-2: venture-1 (${venture.name}) metadata.frozen=true set (preserved ${preservedKeys.length} existing key(s): ${preservedKeys.join(', ') || 'none'})`);
+  console.log('✅ venture-1 disposition complete — frozen at S19, accidental-resume guarded.');
+}
+
+main().catch((err) => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/tests/unit/eva/stage-execution-worker-freeze-guard.test.js
+++ b/tests/unit/eva/stage-execution-worker-freeze-guard.test.js
@@ -1,0 +1,138 @@
+/**
+ * Tests for the venture freeze guard — SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-C / FR-3
+ *
+ * A venture with metadata.frozen=true (dogfood-complete / superseded, e.g.
+ * venture-1 frozen at S19) must NEVER be advanced (_pollForWork) or unblocked
+ * (_checkResolvedBlocks) by the stage-execution worker, regardless of
+ * orchestrator_state. Non-frozen ventures must behave exactly as before.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StageExecutionWorker, isVentureFrozen } from '../../../lib/eva/stage-execution-worker.js';
+
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({ processStage: vi.fn() }));
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn().mockResolvedValue({ acquired: false }),
+  releaseProcessingLock: vi.fn().mockResolvedValue({}),
+  markCompleted: vi.fn().mockResolvedValue({}),
+  ORCHESTRATOR_STATES: { IDLE: 'idle', PROCESSING: 'processing', BLOCKED: 'blocked', FAILED: 'failed', COMPLETED: 'completed' },
+}));
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({
+  createOrReusePendingDecision: vi.fn(), waitForDecision: vi.fn(),
+}));
+vi.mock('../../../lib/eva/shared-services.js', () => ({ emit: vi.fn().mockResolvedValue(undefined) }));
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+// ── isVentureFrozen (pure) ───────────────────────────────────────────────────
+describe('isVentureFrozen', () => {
+  it('TS-3: true only when metadata.frozen === true', () => {
+    expect(isVentureFrozen({ metadata: { frozen: true } })).toBe(true);
+  });
+  it('TS-3: null-safe — false for missing/empty metadata', () => {
+    expect(isVentureFrozen({})).toBe(false);
+    expect(isVentureFrozen({ metadata: null })).toBe(false);
+    expect(isVentureFrozen({ metadata: {} })).toBe(false);
+    expect(isVentureFrozen(null)).toBe(false);
+    expect(isVentureFrozen(undefined)).toBe(false);
+  });
+  it('TS-3: not fooled by truthy non-true values', () => {
+    expect(isVentureFrozen({ metadata: { frozen: 'true' } })).toBe(false);
+    expect(isVentureFrozen({ metadata: { frozen: 1 } })).toBe(false);
+  });
+});
+
+// ── _pollForWork excludes frozen ventures ────────────────────────────────────
+describe('_pollForWork freeze guard', () => {
+  it('TS-1: excludes a frozen idle venture, keeps non-frozen idle ventures', async () => {
+    const rows = [
+      { id: 'v-frozen', name: 'venture-1', current_lifecycle_stage: 19, metadata: { frozen: true } },
+      { id: 'v-normal', name: 'fresh', current_lifecycle_stage: 3, metadata: {} },
+      { id: 'v-nullmeta', name: 'nullmeta', current_lifecycle_stage: 5, metadata: null },
+    ];
+    // chain ends in .order() returning {data,error}
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      lt: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+    const worker = new StageExecutionWorker({ supabase, logger: silentLogger });
+
+    const ready = await worker._pollForWork();
+    const ids = ready.map((v) => v.id);
+    expect(ids).toContain('v-normal');
+    expect(ids).toContain('v-nullmeta'); // null metadata is NOT frozen
+    expect(ids).not.toContain('v-frozen');
+  });
+});
+
+// ── _checkResolvedBlocks skips frozen ventures ───────────────────────────────
+describe('_checkResolvedBlocks freeze guard', () => {
+  function makeSupabase(blockedRows) {
+    const ventureUpdates = [];
+    const supabase = {
+      ventureUpdates,
+      from(table) {
+        if (table === 'ventures') {
+          let isUpdate = false;
+          const builder = {
+            select: vi.fn().mockReturnThis(),
+            update: vi.fn((payload) => { isUpdate = true; builder._payload = payload; return builder; }),
+            // select path: .eq('status').eq('orchestrator_state') is the awaited terminal
+            // update path: .eq('id').eq('orchestrator_state') returns {count}
+            eq: vi.fn(() => builder),
+            then: undefined,
+          };
+          // select terminal resolves the blocked list; update terminal resolves {count}
+          builder.eq = vi.fn(() => {
+            if (isUpdate) {
+              ventureUpdates.push(builder._payload);
+              return Promise.resolve({ count: 1, error: null });
+            }
+            return builder;
+          });
+          // Make the select chain awaitable (no .single) -> resolve blocked list
+          builder.then = (resolve) => resolve({ data: blockedRows, error: null });
+          return builder;
+        }
+        if (table === 'venture_stage_work') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { stage_status: 'completed' }, error: null }),
+          };
+        }
+        if (table === 'chairman_decisions') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }), // no pending decision
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      },
+    };
+    return supabase;
+  }
+
+  it('TS-2: a frozen blocked venture is NOT unblocked (no update)', async () => {
+    const supabase = makeSupabase([
+      { id: 'v-frozen', name: 'venture-1', current_lifecycle_stage: 19, metadata: { frozen: true } },
+    ]);
+    const worker = new StageExecutionWorker({ supabase, logger: silentLogger });
+    await worker._checkResolvedBlocks();
+    expect(supabase.ventureUpdates).toHaveLength(0); // never updated -> stays blocked
+  });
+
+  it('TS-2: a non-frozen blocked venture with completed prev stage IS unblocked', async () => {
+    const supabase = makeSupabase([
+      { id: 'v-normal', name: 'fresh', current_lifecycle_stage: 5, metadata: {} },
+    ]);
+    const worker = new StageExecutionWorker({ supabase, logger: silentLogger });
+    await worker._checkResolvedBlocks();
+    expect(supabase.ventureUpdates).toHaveLength(1);
+    expect(supabase.ventureUpdates[0]).toMatchObject({ orchestrator_state: 'idle' });
+  });
+});


### PR DESCRIPTION
## Summary
Child-C of the clean-clone launch plan. Venture-1 (Market Modeling SaaS, `849cd2bd`) is dogfood-complete and parked at lifecycle **stage 19**; the fully-grounded clean clone (siblings -A/-B) supersedes it as the real build vehicle. This SD records a **durable** disposition and **structurally prevents accidental resume** past S19.

## What & why
The only thing keeping venture-1 from advancing was its transient `orchestrator_state=blocked` + a fragile reliance on a pending chairman decision: the worker's `_checkResolvedBlocks()` flips a blocked venture back to `idle` once its previous stage completes (S18 is complete) and no pending decision exists, after which `_pollForWork()` would advance it.

## FRs
- **FR-1** — durable `chairman_decisions` row: `decision_type=venture_disposition`, `decision=sunset`, `lifecycle_stage=19`, `status=approved`.
- **FR-2** — durable `ventures.metadata.frozen` marker (+ `frozen_reason`/`frozen_at`/`disposition`/`superseded_by`), additive merge (8 existing keys preserved), idempotent.
- **FR-3** — `isVentureFrozen()` guard wired into **both** resume vectors in `stage-execution-worker.js`: `_pollForWork` excludes frozen ventures; `_checkResolvedBlocks` skips them (never flips blocked→idle). JS-side null-safe filter (a PostgREST `neq` on `metadata->>frozen` would wrongly drop null-metadata rows).

## Apply + tests
`scripts/freeze-venture-1-disposition.mjs` applies FR-1/FR-2 idempotently (no schema change) — **already run against live venture-1** (frozen=true, exactly 1 disposition decision, idempotent on re-run). 6 unit tests pass (`isVentureFrozen` null-safety, `_pollForWork` exclusion, `_checkResolvedBlocks` skip). Non-frozen ventures unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)