### PR TITLE
fix(QF-20260627-108): assign fleet callsigns by tier_rank (effort-encoded), not flat NATO

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -15,6 +15,44 @@
 const COLORS = ['blue', 'green', 'purple', 'orange', 'cyan', 'pink', 'yellow', 'red'];
 const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
 
+// QF-20260627-108 (FR-1): the chairman effort-encoded callsign scheme. A worker's callsign is
+// derived from its metadata.tier_rank (the source-of-truth), NOT flat first-available NATO order —
+// otherwise the 5-min cron re-clobbers the effort names every pass. tier4=high, tier3=medium,
+// tier2=low, tier1=sonnet/max. Shared by the cron AND worker-checkin self-assign so both honor it.
+const TIER_CALLSIGNS = {
+  4: ['Alpha', 'Bravo', 'Charlie'],
+  3: ['Delta', 'Echo', 'Foxtrot'],
+  2: ['Golf'],
+  1: ['Hotel'],
+};
+
+// Resolve a worker's effort tier from metadata.tier_rank. Default 4 (top band) for an unstamped
+// worker — matches the conservative-UP dispatch default (workers default to the top rung).
+function tierRankOf(worker) {
+  const t = worker?.metadata?.tier_rank;
+  return (t === 1 || t === 2 || t === 3 || t === 4) ? t : 4;
+}
+
+// Pick the first FREE callsign within the worker's tier band (effort-encoded SoT), wrapping with a
+// numeric suffix only when the band is exhausted. Drop-in replacement for nextAvailable(NATO, ...).
+function pickCallsignForTier(tierRank, usedSet) {
+  const pool = TIER_CALLSIGNS[tierRank] || TIER_CALLSIGNS[4];
+  for (const c of pool) {
+    if (!usedSet.has(c)) return c;
+  }
+  return pool[0] + '-' + (usedSet.size + 1);
+}
+
+// True when a callsign already belongs to the worker's correct tier band, so the cron KEEPS it
+// instead of reclobbering. A callsign from the wrong band (e.g. a tier-2 worker still holding
+// "Bravo") returns false → it is re-derived, so the chairman scheme self-heals.
+function callsignInTierBand(callsign, tierRank) {
+  if (!callsign) return false;
+  const pool = TIER_CALLSIGNS[tierRank] || TIER_CALLSIGNS[4];
+  const base = String(callsign).split('-')[0];
+  return pool.includes(base);
+}
+
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: hoisted to module scope (was nested in main())
 // and exported so scripts/worker-checkin.cjs can self-assign an identity at check-in using the
 // SAME pool/picker — both writers must allocate identically (including the wrap-suffix format),
@@ -244,7 +282,11 @@ async function main() {
 
   for (const worker of uniqueWorkers) {
     const identity = worker.metadata?.fleet_identity;
-    if (identity?.callsign && identity?.color && !forceReassign) {
+    // QF-20260627-108 (FR-1): a worker is "assigned" ONLY if its callsign is in its tier band
+    // (effort-encoded SoT). A callsign from the wrong band (e.g. a tier-2 worker still holding
+    // "Bravo") is re-derived, so the chairman scheme self-heals instead of being preserved-wrong.
+    if (identity?.callsign && identity?.color && !forceReassign
+        && callsignInTierBand(identity.callsign, tierRankOf(worker))) {
       assignedRaw.push(worker);
     } else {
       needsAssignment.push(worker);
@@ -356,7 +398,7 @@ async function main() {
   // Assign new workers
   let newCount = 0;
   for (const worker of needsAssignment) {
-    const callsign = nextAvailable(NATO, usedCallsigns);
+    const callsign = pickCallsignForTier(tierRankOf(worker), usedCallsigns);
     const color = nextAvailable(COLORS, usedColors);
     usedCallsigns.add(callsign);
     usedColors.add(color);
@@ -412,7 +454,7 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, TIER_CALLSIGNS, tierRankOf, pickCallsignForTier, callsignInTierBand };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -40,7 +40,7 @@ const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligib
 const { resolveWorkerTierRank, isTieringActive } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
-const { NATO, COLORS, nextAvailable, isTestSessionId } = require('./assign-fleet-identities.cjs');
+const { NATO, COLORS, nextAvailable, isTestSessionId, tierRankOf, pickCallsignForTier, callsignInTierBand } = require('./assign-fleet-identities.cjs');
 
 const ROLL_CALL_TTL_MS = 60 * 60 * 1000;     // availability row lives 1h
 const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (idempotency)
@@ -779,8 +779,12 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
     const myMeta = (cur && cur.metadata) || {};
     if (myMeta.is_coordinator === true) return null; // coordinators stay nameless in the worker pool (QF-20260508-648)
     const existing = myMeta.fleet_identity;
-    if (existing && existing.callsign && existing.color) {
-      return { callsign: existing.callsign, color: existing.color }; // complete identity already present -> idempotent
+    // QF-20260627-108: idempotent ONLY when the existing callsign is in this worker's tier band
+    // (effort-encoded SoT). A wrong-band callsign (e.g. a tier-2 worker still holding "Bravo") falls
+    // through to re-derive, so check-in self-heals to the scheme just like the cron.
+    if (existing && existing.callsign && existing.color
+        && callsignInTierBand(existing.callsign, tierRankOf({ metadata: myMeta }))) {
+      return { callsign: existing.callsign, color: existing.color };
     }
     // Seed used-sets from currently-live assigned identities so we pick a FREE slot (not blindly Alpha).
     const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
@@ -795,7 +799,7 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
       if (id && id.callsign) usedCallsigns.add(id.callsign);
       if (id && id.color) usedColors.add(id.color);
     }
-    const callsign = nextAvailable(NATO, usedCallsigns);
+    const callsign = pickCallsignForTier(tierRankOf({ metadata: myMeta }), usedCallsigns);
     const color = nextAvailable(COLORS, usedColors);
     // display_name parity with the cron: assign-fleet-identities.cjs labels with `worker.sd_id`, a
     // column that does NOT exist on claude_sessions (it selects sd_key), so its label is ALWAYS

--- a/tests/unit/assign-fleet-identities-tier-callsign.test.js
+++ b/tests/unit/assign-fleet-identities-tier-callsign.test.js
@@ -1,0 +1,55 @@
+// QF-20260627-108: the chairman effort-encoded callsign scheme must be derived from
+// metadata.tier_rank (source-of-truth) instead of flat first-available NATO order, or the
+// 5-min assign-fleet-identities cron re-clobbers the effort names every pass. tier4=Alpha/
+// Bravo/Charlie, tier3=Delta/Echo/Foxtrot, tier2=Golf, tier1=Hotel. The picker is shared with
+// worker-checkin.cjs so both writers honor the scheme identically.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  TIER_CALLSIGNS,
+  tierRankOf,
+  pickCallsignForTier,
+  callsignInTierBand,
+} = require('../../scripts/assign-fleet-identities.cjs');
+
+describe('QF-20260627-108: tier-encoded callsign assignment', () => {
+  it('maps each tier to its effort-encoded band', () => {
+    expect(TIER_CALLSIGNS[4]).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(TIER_CALLSIGNS[3]).toEqual(['Delta', 'Echo', 'Foxtrot']);
+    expect(TIER_CALLSIGNS[2]).toEqual(['Golf']);
+    expect(TIER_CALLSIGNS[1]).toEqual(['Hotel']);
+  });
+
+  it('tierRankOf reads metadata.tier_rank and defaults unstamped workers to tier 4', () => {
+    expect(tierRankOf({ metadata: { tier_rank: 2 } })).toBe(2);
+    expect(tierRankOf({ metadata: { tier_rank: 1 } })).toBe(1);
+    expect(tierRankOf({ metadata: {} })).toBe(4);     // unstamped -> top band
+    expect(tierRankOf({ metadata: { tier_rank: 9 } })).toBe(4); // invalid -> top band
+    expect(tierRankOf(null)).toBe(4);
+  });
+
+  it('pickCallsignForTier picks from the tier band, not flat NATO order', () => {
+    expect(pickCallsignForTier(2, new Set())).toBe('Golf');       // low effort -> Golf
+    expect(pickCallsignForTier(1, new Set())).toBe('Hotel');
+    expect(pickCallsignForTier(4, new Set())).toBe('Alpha');
+    expect(pickCallsignForTier(4, new Set(['Alpha']))).toBe('Bravo');
+    expect(pickCallsignForTier(4, new Set(['Alpha', 'Bravo']))).toBe('Charlie');
+  });
+
+  it('wraps with a numeric suffix only when the band is exhausted', () => {
+    const used = new Set(['Golf']);
+    expect(pickCallsignForTier(2, used)).toBe('Golf-' + (used.size + 1)); // tier-2 band has one slot
+  });
+
+  it('callsignInTierBand detects a wrong-band callsign so the cron self-heals it', () => {
+    // The exact bug: a tier-2 worker still holding a tier-4 "Bravo" must be re-derived.
+    expect(callsignInTierBand('Bravo', 2)).toBe(false);
+    expect(callsignInTierBand('Golf', 2)).toBe(true);
+    expect(callsignInTierBand('Alpha', 4)).toBe(true);
+    expect(callsignInTierBand('Golf-2', 2)).toBe(true); // suffix-wrapped still in band
+    expect(callsignInTierBand(null, 2)).toBe(false);
+  });
+});


### PR DESCRIPTION
## QF-20260627-108 — fleet identity assignment honors the effort-encoded scheme

`assign-fleet-identities.cjs` (coordinator cron, every 5 min) + `worker-checkin.cjs` self-assign picked the **first-available NATO** letter and preserved any stored callsign regardless of tier, so the chairman effort-encoded scheme got **re-clobbered every pass** (a tier-2 worker meant to be Golf kept getting reassigned/kept as Bravo).

### Fix
- **FR-1** — derive the callsign from `metadata.tier_rank` via a shared **`pickCallsignForTier`** (bands: tier4=Alpha/Bravo/Charlie, tier3=Delta/Echo/Foxtrot, tier2=Golf, tier1=Hotel) instead of `nextAvailable(NATO, …)`.
- **FR-2** — treat `metadata.tier_rank` as source-of-truth: a callsign **outside** the worker's tier band (`callsignInTierBand`) is re-derived, so the scheme **self-heals** instead of being preserved-wrong.
- The shared picker is exported and consumed by **both** the cron and `worker-checkin.cjs` so naming is identical (the NOTE in the QF).

### Tests
New unit test (bands, picker, default-to-tier-4, suffix wrap, wrong-band self-heal); existing coordinator-filter test green — **36 passed**. Verified live: `pickCallsignForTier(2)=Golf`, `callsignInTierBand('Bravo',2)=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)