### PR TITLE
feat(SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B): prereq-gated, idempotent clean-clone launcher

### DIFF
--- a/lib/eva/clean-clone/launch.js
+++ b/lib/eva/clean-clone/launch.js
@@ -1,0 +1,111 @@
+/**
+ * Clean-clone launcher — SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B / FR-2, FR-3
+ *
+ * Orchestrates the clean-clone launch by composing the EXISTING Stage-0 seed
+ * mechanism shipped by sibling -A (executeVentureReseeding / the
+ * SEEDED_FROM_VENTURE path / persistVentureBrief, driven by executeStageZero).
+ * This module adds NO seed logic — it adds the prereq gate, the idempotency
+ * guard, and the dry-run/live wiring.
+ *
+ * Flow:
+ *   1. verifyPrereqsMerged — abort (fail-loud) if any FR-2 prereq is not merged.
+ *   2. idempotency — if a non-cancelled venture already seeded_from the source
+ *      exists, report it and do NOT create a duplicate.
+ *   3. executeStageZero({ path: seeded_from_venture, source_venture_id }) — dry-run
+ *      validates without persisting; live persists a fresh active venture the
+ *      stage-execution daemon then advances S0->S19.
+ *
+ * @module lib/eva/clean-clone/launch
+ */
+
+import { verifyPrereqsMerged, PREREQ_SD_KEYS } from './prereq-verifier.js';
+
+/** venture-1 ("Market Modeling SaaS") — the dogfood-complete source thesis (frozen at S19). */
+export const DEFAULT_SOURCE_VENTURE_ID = '849cd2bd-cd6e-4a5e-870d-e21a47b71393';
+
+/** Stage-0 entry path key for reseeding (mirrors path-router ENTRY_PATHS.SEEDED_FROM_VENTURE). */
+export const SEEDED_FROM_VENTURE_PATH = 'seeded_from_venture';
+
+/**
+ * Find an existing non-cancelled venture seeded from the source (idempotency).
+ * Checks both the seeded_from_venture_id column and metadata.seeded_from_venture_id.
+ *
+ * @returns {Promise<{id:string,name:string,status:string}|null>}
+ */
+export async function findExistingClone(supabase, sourceVentureId) {
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('id, name, status, seeded_from_venture_id, metadata')
+    .or(`seeded_from_venture_id.eq.${sourceVentureId},metadata->>seeded_from_venture_id.eq.${sourceVentureId}`)
+    .neq('status', 'cancelled');
+  if (error) throw new Error(`idempotency check failed: ${error.message}`);
+  const rows = (data || []).filter(
+    (v) => v.seeded_from_venture_id === sourceVentureId
+      || v.metadata?.seeded_from_venture_id === sourceVentureId,
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Launch (or dry-run) the clean clone.
+ *
+ * @param {Object} params
+ * @param {string} [params.sourceVentureId=DEFAULT_SOURCE_VENTURE_ID]
+ * @param {boolean} [params.dryRun=true] - dry-run validates without persisting (safe default)
+ * @param {string[]} [params.prereqKeys=PREREQ_SD_KEYS]
+ * @param {Object} deps
+ * @param {Object} deps.supabase
+ * @param {Object} [deps.logger]
+ * @param {Function} deps.executeStageZero - the Stage-0 driver (injected; from lib/eva/stage-zero)
+ * @returns {Promise<Object>} structured launch result
+ */
+export async function launchCleanClone(params = {}, deps = {}) {
+  const {
+    sourceVentureId = DEFAULT_SOURCE_VENTURE_ID,
+    dryRun = true,
+    prereqKeys = PREREQ_SD_KEYS,
+  } = params;
+  const { supabase, logger = console, executeStageZero } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+  if (typeof executeStageZero !== 'function') throw new Error('executeStageZero dependency is required');
+
+  // 1. Prereq gate (fail-loud)
+  const prereqs = await verifyPrereqsMerged(supabase, prereqKeys);
+  if (!prereqs.ok) {
+    logger.error(`[CleanCloneLaunch] ABORT — prereqs not merged: ${prereqs.missing.join(', ')}`);
+    return { ok: false, stage: 'prereq', prereqs, seeded: false };
+  }
+  logger.log(`[CleanCloneLaunch] Prereqs verified merged (${prereqKeys.length} SD(s))`);
+
+  // 2. Idempotency
+  const existing = await findExistingClone(supabase, sourceVentureId);
+  if (existing) {
+    logger.log(`[CleanCloneLaunch] Clone already exists (${existing.id}, status=${existing.status}) — not duplicating`);
+    return { ok: true, skipped: true, stage: 'idempotent', prereqs, existing, seeded: false };
+  }
+
+  // 3. Seed via the existing Stage-0 mechanism
+  logger.log(`[CleanCloneLaunch] ${dryRun ? 'DRY-RUN' : 'LIVE'} seed from venture ${sourceVentureId} via ${SEEDED_FROM_VENTURE_PATH}`);
+  const stageZero = await executeStageZero(
+    {
+      path: SEEDED_FROM_VENTURE_PATH,
+      pathParams: { source_venture_id: sourceVentureId },
+      options: { nonInteractive: true, dryRun },
+    },
+    { supabase, logger },
+  );
+
+  const newVentureId = stageZero?.record_id || stageZero?.venture_id || stageZero?.venture?.id || null;
+  if (!dryRun && newVentureId) {
+    logger.log(`[CleanCloneLaunch] LIVE clone created: ${newVentureId} — the daemon will advance it S0->S19`);
+  }
+  return {
+    ok: stageZero?.success !== false,
+    stage: 'seeded',
+    dryRun,
+    prereqs,
+    stageZero,
+    newVentureId,
+    seeded: !dryRun && Boolean(newVentureId),
+  };
+}

--- a/lib/eva/clean-clone/launch.js
+++ b/lib/eva/clean-clone/launch.js
@@ -35,7 +35,7 @@ export const SEEDED_FROM_VENTURE_PATH = 'seeded_from_venture';
 export async function findExistingClone(supabase, sourceVentureId) {
   const { data, error } = await supabase
     .from('ventures')
-    .select('id, name, status, seeded_from_venture_id, metadata')
+    .select('id, name, status, seeded_from_venture_id, metadata') // schema-lint-disable-line: seeded_from_venture_id is a real uuid column added by sibling -A (CLEAN-CLONE-LAUNCH-001-A); lint snapshot is stale (verified live in information_schema)
     .or(`seeded_from_venture_id.eq.${sourceVentureId},metadata->>seeded_from_venture_id.eq.${sourceVentureId}`)
     .neq('status', 'cancelled');
   if (error) throw new Error(`idempotency check failed: ${error.message}`);

--- a/lib/eva/clean-clone/prereq-verifier.js
+++ b/lib/eva/clean-clone/prereq-verifier.js
@@ -1,0 +1,55 @@
+/**
+ * Clean-clone launch prereq verifier — SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B / FR-1
+ *
+ * The clean-clone launch must not seed a fresh venture until the FR-2 grounding
+ * prereqs are actually MERGED (status='completed'). This module is the fail-loud
+ * gate: it reads the live status of each prereq SD and reports which (if any) are
+ * not yet merged. house-tech-stack is enforced in-lib (lib/eva/config/house-tech-stack.js)
+ * and has no SD gate, so it is intentionally not in this list.
+ *
+ * @module lib/eva/clean-clone/prereq-verifier
+ */
+
+/** The grounding prereqs that must be MERGED before a clean clone may be seeded. */
+export const PREREQ_SD_KEYS = Object.freeze([
+  'SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001',
+  'SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-A',
+  'SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-B',
+  'SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-C',
+  'SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-D',
+  'SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001',
+]);
+
+/** A prereq SD counts as merged only when its lifecycle status is 'completed'. */
+export const MERGED_STATUS = 'completed';
+
+/**
+ * Verify every prereq SD is merged (status='completed').
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string[]} [prereqKeys=PREREQ_SD_KEYS]
+ * @returns {Promise<{ok: boolean, statuses: Object<string,string|null>, missing: string[]}>}
+ *   ok=true only when ALL prereqs are completed. `statuses` maps each key to its
+ *   live status (null if the SD row is absent). `missing` lists keys that are not
+ *   completed (including absent ones).
+ */
+export async function verifyPrereqsMerged(supabase, prereqKeys = PREREQ_SD_KEYS) {
+  if (!supabase) throw new Error('supabase client is required');
+  const keys = Array.isArray(prereqKeys) && prereqKeys.length ? prereqKeys : PREREQ_SD_KEYS;
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status')
+    .in('sd_key', keys);
+  if (error) throw new Error(`prereq verification query failed: ${error.message}`);
+
+  const byKey = new Map((data || []).map((r) => [r.sd_key, r.status]));
+  const statuses = {};
+  const missing = [];
+  for (const key of keys) {
+    const status = byKey.has(key) ? byKey.get(key) : null;
+    statuses[key] = status;
+    if (status !== MERGED_STATUS) missing.push(key);
+  }
+  return { ok: missing.length === 0, statuses, missing };
+}

--- a/scripts/launch-clean-clone.mjs
+++ b/scripts/launch-clean-clone.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Clean-clone launcher CLI — SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B
+ *
+ * Seeds a fresh, fully-grounded venture from venture-1's durable thesis so it
+ * re-runs S0->S19 with current grounding (Cloudflare-default + operating-model
+ * SSOT), replacing dogfood-complete venture-1 (frozen at S19).
+ *
+ *   node scripts/launch-clean-clone.mjs --dry-run            # validate, persist NOTHING
+ *   node scripts/launch-clean-clone.mjs                      # LIVE: persist + activate (cost-bearing)
+ *   node scripts/launch-clean-clone.mjs --source <venture-id>
+ *
+ * --dry-run is the safe path. LIVE activation is a flagship/irreversible
+ * cost-bearing op (the daemon then autonomously runs S0->S19) and should be
+ * fired only under explicit Adam/chairman authorization.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { executeStageZero } from '../lib/eva/stage-zero/index.js';
+import { launchCleanClone, DEFAULT_SOURCE_VENTURE_ID } from '../lib/eva/clean-clone/launch.js';
+
+function parseArgs(argv) {
+  const args = { dryRun: false, source: DEFAULT_SOURCE_VENTURE_ID };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--dry-run') args.dryRun = true;
+    else if (argv[i] === '--source') args.source = argv[++i];
+  }
+  return args;
+}
+
+async function main() {
+  const { dryRun, source } = parseArgs(process.argv.slice(2));
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  console.log(`\n=== Clean-clone launch (${dryRun ? 'DRY-RUN' : 'LIVE'}) ===`);
+  if (!dryRun) {
+    console.log('⚠️  LIVE mode: this persists + activates a fresh venture; the daemon will autonomously run S0->S19 (cost-bearing).');
+  }
+
+  const result = await launchCleanClone(
+    { sourceVentureId: source, dryRun },
+    { supabase, logger: console, executeStageZero },
+  );
+
+  console.log('\n--- Result ---');
+  console.log(JSON.stringify({
+    ok: result.ok,
+    stage: result.stage,
+    dryRun: result.dryRun,
+    seeded: result.seeded,
+    newVentureId: result.newVentureId || null,
+    skipped: result.skipped || false,
+    existing: result.existing ? { id: result.existing.id, status: result.existing.status } : null,
+    prereqsMissing: result.prereqs?.missing || [],
+  }, null, 2));
+
+  if (!result.ok) {
+    console.error('\n❌ Launch did not proceed (see result above).');
+    process.exit(1);
+  }
+  console.log(`\n✅ ${dryRun ? 'Dry-run validated' : (result.skipped ? 'Idempotent — existing clone' : 'Clone launched')}.`);
+}
+
+main().catch((err) => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/tests/unit/eva/clean-clone-launch.test.js
+++ b/tests/unit/eva/clean-clone-launch.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for the clean-clone launcher — SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B
+ *
+ * Covers the prereq-merge gate (FR-1), idempotency + seed wiring (FR-2), and the
+ * dry-run executeStageZero call (FR-3). executeStageZero is injected (spy) so the
+ * real Stage-0 pipeline never runs and no live DB writes occur.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { verifyPrereqsMerged, PREREQ_SD_KEYS } from '../../../lib/eva/clean-clone/prereq-verifier.js';
+import { launchCleanClone, DEFAULT_SOURCE_VENTURE_ID, SEEDED_FROM_VENTURE_PATH } from '../../../lib/eva/clean-clone/launch.js';
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+/**
+ * Table-routed mock supabase.
+ * @param {Object} cfg
+ * @param {Array} cfg.sdRows  - rows returned for strategic_directives_v2 (.in)
+ * @param {Array} cfg.ventureRows - rows returned for ventures (.or/.neq)
+ */
+function mockSupabase({ sdRows = [], ventureRows = [] } = {}) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        const b = {
+          select: () => b,
+          in: () => Promise.resolve({ data: sdRows, error: null }),
+        };
+        return b;
+      }
+      if (table === 'ventures') {
+        const b = {
+          select: () => b,
+          or: () => b,
+          neq: () => Promise.resolve({ data: ventureRows, error: null }),
+        };
+        return b;
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+const allCompleted = PREREQ_SD_KEYS.map((sd_key) => ({ sd_key, status: 'completed' }));
+
+// ── FR-1: prereq verifier ────────────────────────────────────────────────────
+describe('verifyPrereqsMerged', () => {
+  it('TS-1: ok=true when every prereq is completed', async () => {
+    const r = await verifyPrereqsMerged(mockSupabase({ sdRows: allCompleted }));
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+  it('TS-2: ok=false naming a non-completed prereq', async () => {
+    const rows = allCompleted.map((r, i) => (i === 0 ? { ...r, status: 'in_progress' } : r));
+    const r = await verifyPrereqsMerged(mockSupabase({ sdRows: rows }));
+    expect(r.ok).toBe(false);
+    expect(r.missing).toContain(PREREQ_SD_KEYS[0]);
+  });
+  it('TS-2: an absent prereq row counts as missing (status null)', async () => {
+    const rows = allCompleted.slice(1); // drop the first key entirely
+    const r = await verifyPrereqsMerged(mockSupabase({ sdRows: rows }));
+    expect(r.ok).toBe(false);
+    expect(r.missing).toContain(PREREQ_SD_KEYS[0]);
+    expect(r.statuses[PREREQ_SD_KEYS[0]]).toBeNull();
+  });
+});
+
+// ── FR-2 / FR-3: launcher orchestration ──────────────────────────────────────
+describe('launchCleanClone', () => {
+  it('TS-2: aborts before seeding when a prereq is not merged', async () => {
+    const rows = allCompleted.map((r, i) => (i === 0 ? { ...r, status: 'draft' } : r));
+    const spy = vi.fn();
+    const r = await launchCleanClone(
+      { dryRun: true },
+      { supabase: mockSupabase({ sdRows: rows }), logger: silentLogger, executeStageZero: spy },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.stage).toBe('prereq');
+    expect(spy).not.toHaveBeenCalled(); // never seeds
+  });
+
+  it('TS-3: idempotent skip when a clone already exists', async () => {
+    const spy = vi.fn();
+    const existing = { id: 'clone-1', name: 'x (clean clone)', status: 'active', seeded_from_venture_id: DEFAULT_SOURCE_VENTURE_ID, metadata: {} };
+    const r = await launchCleanClone(
+      { dryRun: true },
+      { supabase: mockSupabase({ sdRows: allCompleted, ventureRows: [existing] }), logger: silentLogger, executeStageZero: spy },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.skipped).toBe(true);
+    expect(r.existing.id).toBe('clone-1');
+    expect(spy).not.toHaveBeenCalled(); // no duplicate seed
+  });
+
+  it('TS-4: clean state + dry-run calls executeStageZero with the seed path and dryRun=true', async () => {
+    const spy = vi.fn().mockResolvedValue({ success: true });
+    const r = await launchCleanClone(
+      { dryRun: true },
+      { supabase: mockSupabase({ sdRows: allCompleted, ventureRows: [] }), logger: silentLogger, executeStageZero: spy },
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [callParams] = spy.mock.calls[0];
+    expect(callParams.path).toBe(SEEDED_FROM_VENTURE_PATH);
+    expect(callParams.pathParams.source_venture_id).toBe(DEFAULT_SOURCE_VENTURE_ID);
+    expect(callParams.options.dryRun).toBe(true);
+    expect(r.seeded).toBe(false); // dry-run never persists
+  });
+
+  it('live mode reports the new venture id from executeStageZero', async () => {
+    const spy = vi.fn().mockResolvedValue({ success: true, record_id: 'new-venture-99' });
+    const r = await launchCleanClone(
+      { dryRun: false },
+      { supabase: mockSupabase({ sdRows: allCompleted, ventureRows: [] }), logger: silentLogger, executeStageZero: spy },
+    );
+    expect(spy.mock.calls[0][0].options.dryRun).toBe(false);
+    expect(r.newVentureId).toBe('new-venture-99');
+    expect(r.seeded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Final child of the clean-clone launch plan. Seeds a fresh, fully-grounded venture from venture-1's durable thesis so it re-runs **S0→S19** with current grounding (Cloudflare-default + operating-model SSOT), replacing dogfood-complete venture-1 (frozen at S19 by sibling -C). Composes the seed mechanism shipped by sibling -A — adds no seed logic, only the gate, idempotency, and dry-run/live wiring.

## FRs
- **FR-1** `lib/eva/clean-clone/prereq-verifier.js` — fail-loud gate: refuses to seed unless all FR-2 prereqs are `status='completed'` (Cloudflare-default family + health-provenance; house-tech-stack is in-lib, no SD gate).
- **FR-2** `lib/eva/clean-clone/launch.js` `launchCleanClone()` — verify → idempotency (no duplicate clone via `seeded_from_venture_id`/metadata) → `executeStageZero` with the `SEEDED_FROM_VENTURE` path. `executeStageZero` injected (unit-testable, no live writes).
- **FR-3** `scripts/launch-clean-clone.mjs` CLI (`--dry-run`/`--source`). Dry-run validates end-to-end without persisting; **LIVE activation is a flagship/irreversible cost-bearing op gated on Adam/chairman authorization** (not auto-fired here).

## Validation
Live `--dry-run` ran against venture-1: prereqs pass, thesis reseeded through synthesis/forecast/moat/chairman-review, persistence skipped, **0 clones created**. 7 unit tests pass (prereq pass/fail/absent, idempotent skip, dry-run + live seed wiring).

## Note on the live fire
This SD ships the launcher dry-run-validated. The actual live clone activation (which the daemon then autonomously runs S0→S19) is a one-command follow-up (`node scripts/launch-clean-clone.mjs`) to be fired under explicit Adam/chairman authorization — a signal was sent (correlation 98cd79f7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)