### PR TITLE
fix(QF-20260627-531): merge-preserve metadata on session-capture upsert (2nd callsign-churn source)

### DIFF
--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -275,6 +275,16 @@ function findClaudeCodePid(entryPath = 'unknown') {
  * Still fail-soft after max retries: any final error is swallowed (or logged
  * with LEO_TELEMETRY_DEBUG=1). SessionStart never blocks on telemetry.
  */
+// QF-20260627-531: pure metadata merge for the session upsert. Spreads the existing row's
+// metadata first so coordinator-stamped fields (callsign, tier_rank, fleet_identity, …) survive,
+// then stamps the telemetry fields. Exported for unit testing.
+function buildSessionMetadata(existingMetadata, ccPid, source) {
+  const base = (existingMetadata && typeof existingMetadata === 'object' && !Array.isArray(existingMetadata))
+    ? existingMetadata
+    : {};
+  return { ...base, cc_pid: ccPid, source: source || 'unknown' };
+}
+
 async function upsertSessionRow(sessionId, ccPid, source) {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -290,13 +300,37 @@ async function upsertSessionRow(sessionId, ccPid, source) {
   const url = `${supabaseUrl.replace(/\/$/, '')}/rest/v1/claude_sessions`;
   const now = new Date().toISOString();
   const pidNum = Number(ccPid);
+
+  // QF-20260627-531: this is an UPSERT (Prefer: resolution=merge-duplicates), which REPLACES the
+  // whole jsonb `metadata` column on conflict. Writing a fresh { cc_pid, source } object blanked
+  // coordinator-stamped fields (callsign, tier_rank) on every SessionStart recapture — the 2nd
+  // callsign-churn source (sibling to QF-20260627-108). Read the existing metadata first and MERGE,
+  // so the stamped fields persist. Fail-open to {} (new session / GET error -> nothing to preserve).
+  let existingMetadata = {};
+  try {
+    const getCtrl = new AbortController();
+    const getTimer = setTimeout(() => getCtrl.abort(), 2000);
+    try {
+      const getRes = await fetch(`${url}?session_id=eq.${encodeURIComponent(sessionId)}&select=metadata`, {
+        method: 'GET',
+        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}`, Accept: 'application/json' },
+        signal: getCtrl.signal,
+      });
+      if (getRes.ok) {
+        const rows = await getRes.json();
+        const m = Array.isArray(rows) && rows[0] && rows[0].metadata;
+        if (m && typeof m === 'object' && !Array.isArray(m)) existingMetadata = m;
+      }
+    } finally { clearTimeout(getTimer); }
+  } catch { /* fail-open: new session / GET unavailable -> no existing fields to preserve */ }
+
   const body = JSON.stringify({
     session_id: sessionId,
     status: 'active',
     heartbeat_at: now,
     pid: Number.isFinite(pidNum) ? pidNum : null,
     hostname: require('os').hostname(),
-    metadata: { cc_pid: ccPid, source: source || 'unknown' },
+    metadata: buildSessionMetadata(existingMetadata, ccPid, source),
   });
 
   const MAX_ATTEMPTS = 3;
@@ -590,7 +624,7 @@ function main() {
 }
 
 // SD-LEO-INFRA-FIX-CLAUDE-CODE-001 (FR-5): expose pure helpers for unit tests.
-module.exports = { selectAncestorFromChain, findClaudeCodePid, upsertSessionRow };
+module.exports = { selectAncestorFromChain, findClaudeCodePid, upsertSessionRow, buildSessionMetadata };
 
 if (require.main === module) {
   main().then(() => process.exit(0)).catch(() => process.exit(0));

--- a/tests/unit/capture-session-id-metadata-merge.test.js
+++ b/tests/unit/capture-session-id-metadata-merge.test.js
@@ -1,0 +1,39 @@
+// QF-20260627-531: capture-session-id.cjs upserts claude_sessions with
+// Prefer: resolution=merge-duplicates, which REPLACES the whole jsonb metadata column on conflict.
+// Writing a fresh { cc_pid, source } object blanked coordinator-stamped fields (callsign, tier_rank)
+// on every SessionStart recapture — the 2nd callsign-churn source (sibling to QF-20260627-108).
+// buildSessionMetadata must spread the existing metadata first so those fields survive.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { buildSessionMetadata } = require('../../scripts/hooks/capture-session-id.cjs');
+
+describe('QF-20260627-531: buildSessionMetadata merge-preserves stamped fields', () => {
+  it('preserves coordinator-stamped callsign + tier_rank while stamping telemetry fields', () => {
+    const existing = { callsign: 'Golf', tier_rank: 2, fleet_identity: { callsign: 'Golf', color: 'blue' } };
+    const merged = buildSessionMetadata(existing, '12345', 'sessionstart');
+    expect(merged.callsign).toBe('Golf');
+    expect(merged.tier_rank).toBe(2);
+    expect(merged.fleet_identity).toEqual({ callsign: 'Golf', color: 'blue' });
+    expect(merged.cc_pid).toBe('12345');
+    expect(merged.source).toBe('sessionstart');
+  });
+
+  it('overwrites stale telemetry fields but keeps everything else', () => {
+    const existing = { callsign: 'Foxtrot', tier_rank: 3, cc_pid: 'OLD', source: 'old' };
+    const merged = buildSessionMetadata(existing, 'NEW', 'recapture');
+    expect(merged.cc_pid).toBe('NEW');
+    expect(merged.source).toBe('recapture');
+    expect(merged.callsign).toBe('Foxtrot');
+    expect(merged.tier_rank).toBe(3);
+  });
+
+  it('defaults source to "unknown" and tolerates missing/invalid existing metadata (new session)', () => {
+    expect(buildSessionMetadata(null, '9', undefined)).toEqual({ cc_pid: '9', source: 'unknown' });
+    expect(buildSessionMetadata(undefined, '9', '')).toEqual({ cc_pid: '9', source: 'unknown' });
+    // An array/other non-object is ignored (treated as empty base) — never spreads garbage.
+    expect(buildSessionMetadata(['x'], '9', 's')).toEqual({ cc_pid: '9', source: 's' });
+  });
+});


### PR DESCRIPTION
## QF-20260627-531 — session-capture upsert no longer blanks stamped metadata

Sibling to QF-20260627-108. `scripts/hooks/capture-session-id.cjs` upserts `claude_sessions` with `Prefer: resolution=merge-duplicates`, which **replaces the whole jsonb `metadata` column** on conflict. Writing a fresh `{ cc_pid, source }` object **blanked coordinator-stamped fields** (`callsign`, `tier_rank`) on every SessionStart recapture — observed live on 6bb29520 (Golf) + 8d35e499 (Foxtrot).

### Fix
- Read the existing row's `metadata` first (fail-open, 2s timeout) and **merge** via a pure, exported `buildSessionMetadata(existing, ccPid, source)` that spreads existing then stamps the telemetry fields — so `callsign`/`tier_rank`/`fleet_identity` survive.
- Pairs with QF-20260627-108 (`tier_rank` as source-of-truth).

### Tests
New unit test: preserves stamped fields, overwrites stale telemetry, tolerant of new-session/invalid base — **3 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)