### PR TITLE
feat(SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001): re-arm S5 kill-gate with demand/acquisition feasibility

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -17,7 +17,7 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
-import { evaluateKillGate } from '../stage-05.js';
+import { evaluateKillGate, DEMAND_CAC_STRESS_MULTIPLIER } from '../stage-05.js';
 // SD-LEO-INFRA-UPSTREAM-OPERATING-MODEL-PROPAGATION-001 (FR-1/FR-2): the operating-model SSOT — so S5
 // (the first authoritative KILL gate) models opex/CAC under EHG's solo-chairman + all-AI economics
 // (zero human payroll, venture-hosting-standard, organic GTM) instead of generic human-team burn that
@@ -229,12 +229,28 @@ Output ONLY valid JSON.`;
     optimistic: rawBands[2],
   };
 
+  // SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001: derive the demand/acquisition-feasibility
+  // signal so the kill gate weighs DEMAND, not just (now cost-grounded, near-zero) cost. The
+  // organic-acquisition assumption is stress-tested: stress CAC upward by the gate's multiplier
+  // and recompute LTV/CAC. A pass that survives this stress reflects robust unit economics
+  // (acquisition is genuinely viable); a pass that only holds at the optimistic CAC is demand-
+  // unvalidated and the gate downgrades it to demand review. hasEvidence stays false until a
+  // real demand/conversion-evidence input exists (no such field is produced today).
+  const stressedLtvCacRatio = cac > 0
+    ? ltv / (cac * DEMAND_CAC_STRESS_MULTIPLIER)
+    : 0;
+  const demandFeasibility = {
+    hasEvidence: false,
+    stressedLtvCacRatio,
+  };
+
   // Canonical 3-way kill gate (pass / conditional_pass / kill)
   const { decision, blockProgression, reasons, remediationRoute } = evaluateKillGate({
     roi3y,
     breakEvenMonth,
     ltvCacRatio,
     paybackMonths,
+    demandFeasibility,
   });
 
   // Set canonical financial contract for downstream validation

--- a/lib/eva/stage-templates/stage-05.js
+++ b/lib/eva/stage-templates/stage-05.js
@@ -32,6 +32,15 @@ const PAYBACK_THRESHOLD = 18;
 // Conditional pass supplementary thresholds
 const CONDITIONAL_LTV_CAC_THRESHOLD = 3;
 const CONDITIONAL_PAYBACK_THRESHOLD = 12;
+// SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001: demand/acquisition-feasibility test.
+// After operating-model cost-grounding collapsed venture burn, a near-zero-cost venture
+// yields a huge roi3y + breakeven month 1 and passes every COST check trivially — turning
+// S5 into a false-pass rubber-stamp that no longer tests the venture's real risk: DEMAND.
+// A full PASS must therefore ALSO survive a CAC sensitivity stress (the organic-acquisition
+// assumption stressed upward) OR carry explicit demand evidence; otherwise the cost-only
+// pass is DOWNGRADED to conditional_pass (chairman/demand review), never silently rubber-stamped.
+const DEMAND_CAC_STRESS_MULTIPLIER = 3;
+const DEMAND_STRESSED_LTV_CAC_THRESHOLD = 2;
 
 
 const TEMPLATE = {
@@ -208,7 +217,7 @@ const TEMPLATE = {
  * @param {{ roi3y: number, breakEvenMonth: number|null, ltvCacRatio: number|null, paybackMonths: number }} params
  * @returns {{ decision: string, blockProgression: boolean, reasons: Object[], remediationRoute: string|null }}
  */
-export function evaluateKillGate({ roi3y, breakEvenMonth, ltvCacRatio, paybackMonths }) {
+export function evaluateKillGate({ roi3y, breakEvenMonth, ltvCacRatio, paybackMonths, demandFeasibility = null }) {
   const reasons = [];
   let remediationRoute = null;
 
@@ -296,6 +305,31 @@ export function evaluateKillGate({ roi3y, breakEvenMonth, ltvCacRatio, paybackMo
     return { decision: 'kill', blockProgression: true, reasons, remediationRoute };
   }
 
+  // SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001: demand/acquisition-feasibility test.
+  // The cost checks above passed. Before granting a FULL pass, require the organic-acquisition
+  // assumption to be validated — either explicit demand evidence OR a CAC sensitivity band that
+  // survives (stressed LTV/CAC ≥ threshold). Absent both, a cost-only pass is unvalidated and is
+  // DOWNGRADED to conditional_pass (chairman/demand review). Backward-compatible: when
+  // demandFeasibility is not supplied, the demand test is skipped and prior behavior is preserved.
+  if (demandFeasibility != null) {
+    const hasEvidence = demandFeasibility.hasEvidence === true;
+    const stressed = demandFeasibility.stressedLtvCacRatio;
+    const cacSensitivityPass =
+      typeof stressed === 'number' && Number.isFinite(stressed) &&
+      stressed >= DEMAND_STRESSED_LTV_CAC_THRESHOLD;
+
+    if (!hasEvidence && !cacSensitivityPass) {
+      reasons.push({
+        type: 'demand_unvalidated',
+        message: `Cost metrics pass, but the organic-acquisition assumption is unvalidated: no demand evidence and stressed LTV/CAC (${typeof stressed === 'number' ? stressed.toFixed(2) : 'N/A'} at ${DEMAND_CAC_STRESS_MULTIPLIER}× CAC) is below ${DEMAND_STRESSED_LTV_CAC_THRESHOLD}. Routing to demand review rather than auto-pass.`,
+        threshold: DEMAND_STRESSED_LTV_CAC_THRESHOLD,
+        actual: typeof stressed === 'number' ? stressed : null,
+      });
+      remediationRoute = 'Validate demand/acquisition: provide conversion/CAC evidence or improve unit economics so they survive a CAC stress';
+      return { decision: 'conditional_pass', blockProgression: true, reasons, remediationRoute: null };
+    }
+  }
+
   return { decision: 'pass', blockProgression: false, reasons: [], remediationRoute: null };
 }
 
@@ -311,5 +345,7 @@ export {
   PAYBACK_THRESHOLD,
   CONDITIONAL_LTV_CAC_THRESHOLD,
   CONDITIONAL_PAYBACK_THRESHOLD,
+  DEMAND_CAC_STRESS_MULTIPLIER,
+  DEMAND_STRESSED_LTV_CAC_THRESHOLD,
 };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/stage-05.test.js
+++ b/tests/unit/eva/stage-templates/stage-05.test.js
@@ -7,6 +7,8 @@ import TEMPLATE, {
   PAYBACK_THRESHOLD,
   CONDITIONAL_LTV_CAC_THRESHOLD,
   CONDITIONAL_PAYBACK_THRESHOLD,
+  DEMAND_CAC_STRESS_MULTIPLIER,
+  DEMAND_STRESSED_LTV_CAC_THRESHOLD,
   evaluateKillGate,
 } from '../../../../lib/eva/stage-templates/stage-05.js';
 
@@ -45,5 +47,74 @@ describe('stage-05 — Kill Gate (Financial)', () => {
 
   it('exports evaluateKillGate as a function', () => {
     expect(typeof evaluateKillGate).toBe('function');
+  });
+});
+
+// SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001: the demand/acquisition-feasibility
+// dimension re-arms S5 after cost-grounding turned a near-zero-cost venture into a
+// false-pass rubber-stamp (clone S5: roi3y 217, breakeven month 1 — passes every cost
+// check). A full PASS must now ALSO survive a CAC sensitivity stress OR carry demand
+// evidence; otherwise the cost-only pass is downgraded to demand review.
+describe('stage-05 — Demand/acquisition-feasibility dimension', () => {
+  // Strong cost metrics that pass every prior check (the near-zero-cost false-pass shape).
+  const strongCost = { roi3y: 2.17, breakEvenMonth: 1, ltvCacRatio: 5, paybackMonths: 2 };
+
+  it('exports the demand thresholds as numbers', () => {
+    expect(typeof DEMAND_CAC_STRESS_MULTIPLIER).toBe('number');
+    expect(typeof DEMAND_STRESSED_LTV_CAC_THRESHOLD).toBe('number');
+  });
+
+  it('downgrades a cost-only pass with no demand evidence and a weak CAC stress to conditional_pass', () => {
+    const r = evaluateKillGate({
+      ...strongCost,
+      demandFeasibility: { hasEvidence: false, stressedLtvCacRatio: 1.67 },
+    });
+    expect(r.decision).toBe('conditional_pass');
+    expect(r.blockProgression).toBe(true);
+    expect(r.reasons.some((x) => x.type === 'demand_unvalidated')).toBe(true);
+  });
+
+  it('grants a full pass when the CAC sensitivity band survives the stress', () => {
+    const r = evaluateKillGate({
+      ...strongCost,
+      demandFeasibility: { hasEvidence: false, stressedLtvCacRatio: DEMAND_STRESSED_LTV_CAC_THRESHOLD },
+    });
+    expect(r.decision).toBe('pass');
+  });
+
+  it('grants a full pass when demand evidence is present even if the stressed band is weak', () => {
+    const r = evaluateKillGate({
+      ...strongCost,
+      demandFeasibility: { hasEvidence: true, stressedLtvCacRatio: 0.1 },
+    });
+    expect(r.decision).toBe('pass');
+  });
+
+  it('is backward-compatible: omitting demandFeasibility preserves the prior full pass', () => {
+    const r = evaluateKillGate(strongCost);
+    expect(r.decision).toBe('pass');
+    expect(r.reasons).toEqual([]);
+  });
+
+  it('a genuine cost KILL still kills regardless of strong demand', () => {
+    const r = evaluateKillGate({
+      roi3y: 0.05,
+      breakEvenMonth: 30,
+      ltvCacRatio: 5,
+      paybackMonths: 2,
+      demandFeasibility: { hasEvidence: true, stressedLtvCacRatio: 9 },
+    });
+    expect(r.decision).toBe('kill');
+  });
+
+  it('reproduces the clone S5 false-pass scenario routing to demand review (cac fallback 100, ltv 500)', () => {
+    // Producer computes stressedLtvCacRatio = ltv / (cac * multiplier) = 500 / (100*3) = 1.67 < 2.
+    const stressed = 500 / (100 * DEMAND_CAC_STRESS_MULTIPLIER);
+    const r = evaluateKillGate({
+      ...strongCost,
+      demandFeasibility: { hasEvidence: false, stressedLtvCacRatio: stressed },
+    });
+    expect(r.decision).toBe('conditional_pass');
+    expect(r.reasons.some((x) => x.type === 'demand_unvalidated')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Re-arms the S5 financial kill-gate (`evaluateKillGate`, lib/eva/stage-templates/stage-05.js) with a **demand/acquisition-feasibility** dimension.

**Problem:** operating-model cost-grounding correctly collapsed venture burn ($0 payroll, ~$2,640/yr opex). A near-zero-cost venture then yields a huge `roi3y` + breakeven month 1 and passes every COST check trivially — turning S5 (the first authoritative GO/KILL gate) into a **false-pass rubber-stamp** (clone S5 venture 091f2889: roi3y 217, breakeven month 1) that no longer tests the real risk: **demand / acquisition**.

**Fix:** a full PASS must now ALSO survive a CAC sensitivity stress (`stressed LTV/CAC = ltv/(cac×3) ≥ 2`) **OR** carry explicit demand evidence. Otherwise the cost-only pass is **downgraded to `conditional_pass`** (chairman/demand review) with a `demand_unvalidated` reason — never silently rubber-stamped. The producer `analyzeStage05` derives + passes the stressed band.

## Invariants
- **Cost-grounding preserved** — no phantom human-team burn re-introduced (operating-model-grounding regression test still green)
- **Backward-compatible** — omitting `demandFeasibility` keeps prior PASS/CONDITIONAL/KILL decisions
- A genuine cost KILL still kills regardless of demand

## Verification
- 40 tests pass: 7 new demand-dimension cases (cost-only downgrade, CAC-band pass, evidence pass, backward-compat, cost-kill, clone-repro) + 33 existing kill-gate tests
- +125 LOC across the gate, the producer, and tests; backend-only, no UI/schema/migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
