### PR TITLE
feat(SD-LEO-INFRA-S0-S18-STACK-GROUNDING-001): ground S0+S18 venture-stack prompts to Cloudflare-default SSOT

### DIFF
--- a/lib/eva/config/house-tech-stack.js
+++ b/lib/eva/config/house-tech-stack.js
@@ -60,3 +60,22 @@ export const HOUSE_STACK_LAYER_NAMES = Object.freeze([
   'data',
   'infrastructure',
 ]);
+
+/**
+ * SD-LEO-INFRA-S0-S18-STACK-GROUNDING-001: a concise, single-line summary of the canonical
+ * venture stack, rendered FROM the structured SSOT (EHG_HOUSE_TECH_STACK + EHG_HOUSE_AUTH_STRATEGY)
+ * so it can never drift from the policy. Producer prompts (Stage-0 cost estimation, Stage-18 build
+ * readiness) inject this instead of hardcoding a stale stack string (the bug this fixes: S18
+ * hardcoded 'Replit/Neon/Clerk/Gemini/Sentry'; S0 hardcoded 'Supabase + Vercel' — Supabase being
+ * forbidden for ventures). Replit stays a prototyping opt-in selected by descriptor — it is neither
+ * re-locked as the default nor named here.
+ *
+ * @returns {string} e.g. "Cloudflare Pages/Workers + R2 + D1→Neon (infrastructure), Cloudflare D1 → Neon (data), REST via Cloudflare Workers (api), Clerk auth"
+ */
+export function getHouseStackSummary() {
+  const infra = EHG_HOUSE_TECH_STACK.infrastructure.technology;
+  const data = EHG_HOUSE_TECH_STACK.data.technology;
+  const api = EHG_HOUSE_TECH_STACK.api.technology;
+  const auth = EHG_HOUSE_AUTH_STRATEGY.technology;
+  return `${infra} (infrastructure), ${data} (data), ${api} (api), ${auth} auth`;
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-18-build-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-build-readiness.js
@@ -16,6 +16,9 @@ import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 // SD-LEO-INFRA-DOWNSTREAM-OPERATING-MODEL-PROPAGATION-001 FR-5: reframe team_readiness as
 // build-infrastructure readiness (exclude human-team assessment).
 import { getOperatingModelPromptBlock } from '../../standards/operating-model.js';
+// SD-LEO-INFRA-S0-S18-STACK-GROUNDING-001: source the venture stack from the house-tech-stack
+// SSOT instead of hardcoding a stale Replit-era venture-stack string.
+import { getHouseStackSummary } from '../../config/house-tech-stack.js';
 
 // NOTE: These constants intentionally duplicated from stage-18.js
 // to avoid circular dependency — stage-18.js imports analyzeStage18 from this file,
@@ -111,7 +114,7 @@ ${financialContext}
 ${getOperatingModelPromptBlock()}
 
 READINESS FRAMING (EHG operating model — solo founder + ALL-AI-agent labor):
-- The "team_readiness" category means BUILD-INFRASTRUCTURE readiness: architecture, tooling, environment, and the venture-hosting-standard stack (Replit/Neon/Clerk/Gemini/Sentry) — NOT human-team hiring, staffing, or role assignment.
+- The "team_readiness" category means BUILD-INFRASTRUCTURE readiness: architecture, tooling, environment, and the canonical venture-hosting-standard stack (${getHouseStackSummary()}; Replit remains a prototyping opt-in) — NOT human-team hiring, staffing, or role assignment.
 - Do NOT assess or require human team members, hiring, or roles. The "team" is AI agents + the solo founder; treat readiness as whether the build infrastructure/tooling/env is provisioned.
 
 Output ONLY valid JSON.`;

--- a/lib/eva/stage-zero/synthesis/build-cost-estimation.js
+++ b/lib/eva/stage-zero/synthesis/build-cost-estimation.js
@@ -17,6 +17,9 @@ import { extractUsage } from '../../utils/parse-json.js';
 // FIRST point cost is estimated (Stage-0) so burn is born zero-payroll / venture-hosting-standard /
 // organic-GTM — the wrong assumptions never enter the pipeline. Mirrors the proven S5/S7/S16 grounding.
 import { getOperatingModelPromptBlock, groundCostBreakdown } from '../../standards/operating-model.js';
+// SD-LEO-INFRA-S0-S18-STACK-GROUNDING-001: ground the Stage-0 cost estimate on the canonical
+// venture stack (was a stale non-canonical infra assumption that named forbidden-for-ventures tech).
+import { getHouseStackSummary } from '../../config/house-tech-stack.js';
 
 const COMPLEXITY_LEVELS = ['trivial', 'simple', 'moderate', 'complex', 'massive'];
 
@@ -47,7 +50,7 @@ EHG CONTEXT:
 - Development uses AI-assisted coding (2-5x faster than traditional)
 - LEO Protocol manages work via Strategic Directives (SDs)
 - Each SD is ~50-400 lines of code
-- Infrastructure is Supabase (Postgres + auth + storage) + Vercel/Node.js
+- Infrastructure is the canonical EHG venture-hosting standard: ${getHouseStackSummary()} (Replit is a prototyping opt-in). NEVER Supabase for ventures.
 - Token budget = LLM API costs for the venture's AI features
 
 Estimate the build cost:
@@ -65,8 +68,8 @@ Return JSON:
   "loc_estimate": {"min": 2000, "max": 5000, "breakdown": {"backend": 2000, "frontend": 1500, "design": 500, "tests": 1000, "config": 500}},
   "sd_count": {"min": 8, "max": 15, "breakdown": {"infrastructure": 3, "core_features": 6, "testing": 3, "documentation": 2}},
   "infrastructure": {
-    "required": ["supabase", "vercel"],
-    "optional": ["redis", "s3"],
+    "required": ["cloudflare-workers", "cloudflare-d1", "clerk"],
+    "optional": ["cloudflare-r2", "neon"],
     "estimated_monthly_cost": 50
   },
   "token_budget": {

--- a/tests/unit/eva/house-tech-stack.test.js
+++ b/tests/unit/eva/house-tech-stack.test.js
@@ -3,12 +3,18 @@
  * SD-LEO-ENH-CONSTRAIN-STAGE-EHG-001
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import {
   EHG_HOUSE_TECH_STACK,
   EHG_HOUSE_AUTH_STRATEGY,
   HOUSE_STACK_LAYER_NAMES,
   HOUSE_STACK_VERSION,
+  getHouseStackSummary,
 } from '../../../lib/eva/config/house-tech-stack.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 describe('EHG_HOUSE_TECH_STACK', () => {
   it('has all 5 required layers', () => {
@@ -52,5 +58,50 @@ describe('EHG_HOUSE_TECH_STACK', () => {
     expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).toMatch(/Cloudflare/);
     expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).not.toMatch(/AWS/);
     expect(EHG_HOUSE_TECH_STACK.infrastructure.technology).not.toMatch(/Supabase/);
+  });
+});
+
+// SD-LEO-INFRA-S0-S18-STACK-GROUNDING-001: the S0 (build-cost) and S18 (build-readiness)
+// producer prompts hardcoded stale stacks ('Supabase + Vercel' / 'Replit/Neon/Clerk/Gemini/Sentry')
+// that contradict the Cloudflare-default SSOT. They now inject getHouseStackSummary().
+describe('getHouseStackSummary — SSOT-grounded venture-stack summary', () => {
+  it('renders the Cloudflare-default stack with no forbidden/stale tech', () => {
+    const s = getHouseStackSummary();
+    expect(typeof s).toBe('string');
+    expect(s).toMatch(/Cloudflare/);
+    expect(s).toMatch(/Clerk/);
+    expect(s).not.toMatch(/Supabase/i);
+    expect(s).not.toMatch(/Vercel/i);
+  });
+
+  it('is derived from the structured SSOT (tracks EHG_HOUSE_TECH_STACK, not a second hardcode)', () => {
+    const s = getHouseStackSummary();
+    expect(s).toContain(EHG_HOUSE_TECH_STACK.infrastructure.technology);
+    expect(s).toContain(EHG_HOUSE_TECH_STACK.data.technology);
+    expect(s).toContain(EHG_HOUSE_AUTH_STRATEGY.technology);
+  });
+});
+
+describe('S0 + S18 producer prompts are SSOT-grounded (no hardcoded stale stack)', () => {
+  const s18 = readFileSync(
+    resolve(REPO_ROOT, 'lib/eva/stage-templates/analysis-steps/stage-18-build-readiness.js'),
+    'utf8',
+  );
+  const s0 = readFileSync(
+    resolve(REPO_ROOT, 'lib/eva/stage-zero/synthesis/build-cost-estimation.js'),
+    'utf8',
+  );
+
+  it('S18 sources the house-stack summary and no longer hardcodes Replit/Neon/Clerk/Gemini/Sentry', () => {
+    expect(s18).toMatch(/getHouseStackSummary\(\)/);
+    expect(s18).not.toContain('Replit/Neon/Clerk/Gemini/Sentry');
+  });
+
+  it('S0 sources the house-stack summary and no longer asserts Supabase/Vercel venture infra', () => {
+    expect(s0).toMatch(/getHouseStackSummary\(\)/);
+    // The stale positive assertion is gone (a "NEVER Supabase" prohibition is allowed).
+    expect(s0).not.toMatch(/Infrastructure is Supabase/);
+    expect(s0).not.toMatch(/"required":\s*\[\s*"supabase"/);
+    expect(s0).not.toMatch(/\bVercel\b/);
   });
 });


### PR DESCRIPTION
## Summary
Grounds the **S0 (build-cost)** and **S18 (build-readiness)** EVA producer prompts to the Cloudflare-default venture-stack SSOT, replacing hardcoded stale stacks.

| Stage | Was (hardcoded) | Now |
|-------|-----------------|-----|
| S18 | `Replit/Neon/Clerk/Gemini/Sentry` | injected `getHouseStackSummary()` |
| S0 | infra is `Supabase + Vercel`, `required:[supabase,vercel]` | injected SSOT summary + Cloudflare-default components |

Supabase is **forbidden for ventures** (venture-stack-policy `FORBIDDEN`), so S0 was grounding cost on a forbidden + stale stack.

**Fix:** new drift-proof `getHouseStackSummary()` on `house-tech-stack.js`, rendered from the structured SSOT (`EHG_HOUSE_TECH_STACK` + `EHG_HOUSE_AUTH_STRATEGY` → Cloudflare Pages/Workers + R2, Cloudflare D1→Neon, Clerk). Both prompts inject it. **Replit stays a prototyping opt-in — not re-locked.** Prompt-text only; no schema/UI/producer-contract change.

## Verification
- 26 house-stack tests: helper shape, drift guard (tracks `EHG_HOUSE_TECH_STACK`), and S0/S18 prompt-source assertions (no Supabase/Vercel, `getHouseStackSummary()` injected)
- 414 analysis-steps tests + the S0 operating-model grounding test all green
- +80 LOC, backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
