### PR TITLE
feat(SD-LEO-INFRA-S16-REVENUE-GROUNDING-001): ground S16 revenue in S7 unit-economics at the producer

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -595,7 +595,7 @@ export const CROSS_STAGE_DEPS = {
   13: [1, 5, 8, 9],          // Product roadmap: idea + economics + BMC + exit
   14: [1, 13],               // Technical architecture: idea + roadmap
   15: [1, 6, 10, 13, 14],    // Risk register + wireframes: idea + risk matrix + brand + roadmap + architecture
-  16: [1, 13, 14, 15],       // Financial projections (promotion gate): idea + roadmap + arch + risks
+  16: [1, 7, 13, 14, 15],    // Financial projections (promotion gate): idea + S7 unit-economics (revenue grounding) + roadmap + arch + risks
 
   // Phase 4.5: BLUEPRINT REVIEW GATE (Stage 17)
   17: [13, 14, 15, 16],      // Blueprint review: roadmap + arch + risks + financials

--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -19,7 +19,7 @@ import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 // SD-LEO-INFRA-S16-OPERATING-MODEL-COST-GROUNDING-001: ground cost assumptions in EHG's
 // operating model (zero human payroll, AI-ops cost, venture-hosting-standard, organic-first GTM,
 // solo $0-salary founder) instead of generic SaaS defaults that overstate burn 8-50x.
-import { getOperatingModelPromptBlock, groundCostBreakdown, OPERATING_MODEL } from '../../standards/operating-model.js';
+import { getOperatingModelPromptBlock, groundCostBreakdown, groundRevenue, OPERATING_MODEL, PROVENANCE } from '../../standards/operating-model.js';
 
 // NOTE: MIN_PROJECTION_MONTHS intentionally duplicated from stage-16.js
 // to avoid circular dependency — stage-16.js imports analyzeStage16 from this file,
@@ -96,7 +96,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Financial projections
  */
-export async function analyzeStage16({ stage1Data, stage13Data, stage14Data, stage15Data, ventureName, logger = console }) {
+export async function analyzeStage16({ stage1Data, stage7Data, stage13Data, stage14Data, stage15Data, ventureName, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage16] Starting analysis', { ventureName });
   if (!stage1Data?.description) {
@@ -151,6 +151,9 @@ Output ONLY valid JSON.`;
     throw new Error('Stage 16 financial projections: LLM returned no revenue projections');
   }
 
+  // SD-LEO-INFRA-S16-REVENUE-GROUNDING-001: carry the grounded customer count forward month-to-month
+  // so the S7-derived revenue follows a continuous adoption ramp instead of independent per-month guesses.
+  let priorCustomers = 0;
   const revenue_projections = parsed.revenue_projections.map((rp, i) => {
     const costs = Math.max(0, Number(rp.costs) || 0);
     const projection = {
@@ -158,6 +161,20 @@ Output ONLY valid JSON.`;
       revenue: Math.max(0, Number(rp.revenue) || 0),
       costs,
     };
+
+    // SD-LEO-INFRA-S16-REVENUE-GROUNDING-001: ground REVENUE in the S7 unit-economics (price DERIVED
+    // from the ratified S7 arpa; volume an explicit ESTIMATE) instead of accepting raw LLM-invented
+    // revenue. groundRevenue returns null when S7 has no usable arpa → keep the LLM revenue but tag it
+    // ESTIMATE (graceful degradation — never fabricate a DERIVED price).
+    const groundedRevenue = groundRevenue({ s7economics: stage7Data, month: projection.month, priorCustomers });
+    if (groundedRevenue) {
+      projection.revenue = groundedRevenue.revenue;
+      projection.customers = groundedRevenue.customers;
+      projection.revenue_provenance = groundedRevenue.provenance;
+      priorCustomers = groundedRevenue.customers;
+    } else {
+      projection.revenue_provenance = { price: PROVENANCE.ESTIMATE, volume: PROVENANCE.ESTIMATE };
+    }
 
     // Normalize cost_breakdown — SD-LEO-INFRA-S16-OPERATING-MODEL-COST-GROUNDING-001:
     // canonical key is ai_operations (NOT human "personnel"); add an explicit founder_salary line.

--- a/lib/eva/stage-templates/stage-16.js
+++ b/lib/eva/stage-templates/stage-16.js
@@ -24,6 +24,7 @@ import { REQUIRED_LAYERS } from './stage-14.js';
 import { MIN_RISKS } from './stage-14.js';
 // SD-LEO-FEAT-VENTURE-GROUNDED-STAGE-001 (Concern A): positioning-brief co-output.
 import { analyzeStage16PositioningBrief, POSITIONING_UPSTREAM_ARTIFACT_TYPES } from './analysis-steps/stage-16-positioning-brief.js';
+import { PROVENANCE } from '../standards/operating-model.js';
 
 const MIN_PROJECTION_MONTHS = 6;
 
@@ -199,7 +200,38 @@ export function assessFinancialGrounding(stage16 = {}) {
     const why = Number.isFinite(facts) ? '0 grounded facts (all-simulation/assumption)' : 'no four-buckets evidence to confirm grounding';
     return { grounded: false, status: 'ungrounded', review_required: true, reason: why };
   }
-  return { grounded: true, status: 'grounded', review_required: false, reason: `${facts} grounded fact(s)` };
+  // SD-LEO-INFRA-S16-REVENUE-GROUNDING-001: facts>0 alone is too coarse — grounded COST + fabricated
+  // REVENUE produces facts>0 and silently auto-passes. Require revenue-grounding specifically: if
+  // revenue projections exist but NONE carries an S7-DERIVED price, the revenue is LLM-invented →
+  // route to review (never auto-pass fabricated revenue). Absence of projections is left to the facts
+  // gate above + the producer's own "no projections" throw, so genuinely facts-grounded artifacts
+  // without a revenue array are unaffected.
+  const revenue = assessRevenueGrounding(stage16);
+  if (!revenue.grounded) {
+    return { grounded: false, status: 'ungrounded', review_required: true, reason: `revenue ungrounded — ${revenue.reason}` };
+  }
+  return { grounded: true, status: 'grounded', review_required: false, reason: `${facts} grounded fact(s); ${revenue.reason}` };
+}
+
+/**
+ * SD-LEO-INFRA-S16-REVENUE-GROUNDING-001 (FR-3) — PURE revenue-grounding assessment. Revenue is
+ * grounded only when at least one revenue projection carries an S7-DERIVED price
+ * (revenue_provenance.price === PROVENANCE.DERIVED, emitted by groundRevenue at the producer). When
+ * projections exist but all prices are LLM-estimated, the revenue is fabricated → not grounded. When
+ * NO projections are present there is nothing to assess here (the facts gate + the producer's
+ * no-projections throw cover absence), so this defers rather than downgrading.
+ * @param {Object} stage16 - the S16 producer artifact ({ revenue_projections: [{ revenue_provenance }] })
+ * @returns {{ grounded: boolean, reason: string }}
+ */
+export function assessRevenueGrounding(stage16 = {}) {
+  const projections = Array.isArray(stage16?.revenue_projections) ? stage16.revenue_projections : [];
+  if (projections.length === 0) {
+    return { grounded: true, reason: 'no revenue projections present to assess (deferred to facts gate)' };
+  }
+  const anyDerivedPrice = projections.some((p) => p?.revenue_provenance?.price === PROVENANCE.DERIVED);
+  return anyDerivedPrice
+    ? { grounded: true, reason: 'revenue price DERIVED from S7 unit-economics' }
+    : { grounded: false, reason: 'revenue price is LLM-estimated (no S7-derived price) — fabricated revenue cannot auto-pass' };
 }
 
 /**

--- a/lib/eva/standards/operating-model.js
+++ b/lib/eva/standards/operating-model.js
@@ -114,4 +114,45 @@ export function groundCostBreakdown({ month = 1, revenue = 0 } = {}) {
   return { breakdown, provenance, monthly_total };
 }
 
+/**
+ * Ground a monthly REVENUE figure in the S7 unit-economics (SD-LEO-INFRA-S16-REVENUE-GROUNDING-001),
+ * the revenue companion to groundCostBreakdown. The PRICE is the ratified S7 arpa (DERIVED); the
+ * customer VOLUME is a transparent, conservative adoption ramp (ESTIMATE) — NOT an LLM-invented
+ * trajectory. Each figure is epistemic-tagged so the evidence-gate can distinguish a grounded price
+ * from an estimated volume.
+ *
+ * Returns null when S7 has no usable arpa, so the caller keeps the LLM revenue tagged ESTIMATE rather
+ * than fabricating a DERIVED price. The volume is monotonic non-decreasing and bounded by an optional
+ * S7 funnel/SAM ceiling.
+ *
+ * @param {Object} opts
+ * @param {Object} [opts.s7economics] - persisted S7 unit-economics ({ arpa, funnel_ceiling|sam_customers, ... }).
+ * @param {number} [opts.month=1] - 1-based projection month.
+ * @param {number} [opts.priorCustomers=0] - prior month's customer count, carried forward for a continuous ramp.
+ * @returns {{ revenue:number, customers:number, provenance:{price:string, volume:string} } | null}
+ */
+export function groundRevenue({ s7economics = {}, month = 1, priorCustomers = 0 } = {}) {
+  const arpa = Number(s7economics?.arpa);
+  if (!Number.isFinite(arpa) || arpa <= 0) return null; // no ratified price → caller keeps the LLM ESTIMATE
+  const m = Math.max(1, Math.trunc(Number(month) || 1));
+  const SEED = 1;        // 1 customer in month 1 (early-stage realism)
+  const GROWTH = 0.30;   // +30%/mo nominal adoption (transparent, conservative — an ESTIMATE)
+  const ceilRaw = Number(s7economics?.funnel_ceiling ?? s7economics?.sam_customers);
+  const CEIL = Number.isFinite(ceilRaw) && ceilRaw > 0 ? ceilRaw : Infinity;
+  let customers;
+  if (priorCustomers > 0) {
+    // Continuous ramp: always grow by at least one customer so the curve never stalls on rounding.
+    customers = Math.max(priorCustomers + 1, Math.ceil(priorCustomers * (1 + GROWTH)));
+  } else {
+    customers = m <= 1 ? SEED : Math.max(SEED, Math.round(SEED * Math.pow(1 + GROWTH, m - 1)));
+  }
+  customers = Math.min(Math.max(0, customers), CEIL);
+  const revenue = Math.round(arpa * customers);
+  return {
+    revenue,
+    customers,
+    provenance: { price: PROVENANCE.DERIVED, volume: PROVENANCE.ESTIMATE },
+  };
+}
+
 export default OPERATING_MODEL;

--- a/tests/unit/eva/operating-model-revenue-grounding.test.js
+++ b/tests/unit/eva/operating-model-revenue-grounding.test.js
@@ -1,0 +1,53 @@
+/**
+ * SD-LEO-INFRA-S16-REVENUE-GROUNDING-001 — groundRevenue derives S16 revenue from S7 unit-economics:
+ * the PRICE is the ratified S7 arpa (DERIVED), the customer VOLUME is a transparent adoption ramp
+ * (ESTIMATE). Mirrors the cost-grounding test style (operating-model-cost-grounding.test.js).
+ */
+import { describe, it, expect } from 'vitest';
+import { groundRevenue, groundCostBreakdown, PROVENANCE } from '../../../lib/eva/standards/operating-model.js';
+
+describe('groundRevenue (FR-1)', () => {
+  it('derives revenue = S7 arpa * customers with price=DERIVED, volume=ESTIMATE', () => {
+    const r = groundRevenue({ s7economics: { arpa: 49 }, month: 1, priorCustomers: 0 });
+    expect(r).not.toBeNull();
+    expect(r.revenue).toBe(49 * r.customers);
+    expect(r.provenance.price).toBe(PROVENANCE.DERIVED);
+    expect(r.provenance.volume).toBe(PROVENANCE.ESTIMATE);
+  });
+
+  it('returns null when S7 has no usable arpa (caller keeps the LLM revenue tagged ESTIMATE)', () => {
+    expect(groundRevenue({ s7economics: {}, month: 1 })).toBeNull();
+    expect(groundRevenue({ s7economics: { arpa: 0 }, month: 1 })).toBeNull();
+    expect(groundRevenue({ s7economics: { arpa: NaN }, month: 1 })).toBeNull();
+    expect(groundRevenue({ s7economics: { arpa: -5 }, month: 1 })).toBeNull();
+  });
+
+  it('customer ramp is monotonic non-decreasing when carried forward (never stalls on rounding)', () => {
+    let prior = 0;
+    const counts = [];
+    for (let m = 1; m <= 12; m++) {
+      const r = groundRevenue({ s7economics: { arpa: 20 }, month: m, priorCustomers: prior });
+      counts.push(r.customers);
+      expect(r.customers).toBeGreaterThanOrEqual(prior); // non-decreasing
+      prior = r.customers;
+    }
+    // month 1 seeds small; the ramp grows over the year.
+    expect(counts[0]).toBe(1);
+    expect(counts[11]).toBeGreaterThan(counts[0]);
+  });
+
+  it('volume is bounded by an S7 funnel/SAM ceiling', () => {
+    // A tiny ceiling caps customers regardless of the ramp.
+    let prior = 100;
+    const r = groundRevenue({ s7economics: { arpa: 10, sam_customers: 50 }, month: 8, priorCustomers: prior });
+    expect(r.customers).toBeLessThanOrEqual(50);
+    expect(r.revenue).toBe(10 * r.customers);
+  });
+
+  it('does not touch the cost-grounding pattern (groundCostBreakdown still works, no personnel)', () => {
+    const { breakdown, provenance } = groundCostBreakdown({ month: 1, revenue: 0 });
+    expect(breakdown).not.toHaveProperty('personnel');
+    expect(breakdown).toHaveProperty('founder_salary', 0);
+    expect(provenance.ai_operations).toBe(PROVENANCE.DERIVED);
+  });
+});

--- a/tests/unit/eva/s16-revenue-evidence-gate.test.js
+++ b/tests/unit/eva/s16-revenue-evidence-gate.test.js
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-INFRA-S16-REVENUE-GROUNDING-001 (FR-3) — the evidence-gate now checks REVENUE grounding
+ * specifically. Previously a grounded COST + fabricated REVENUE produced facts>0 and silently
+ * auto-passed. assessRevenueGrounding + the AND-combination in assessFinancialGrounding close that.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  assessFinancialGrounding,
+  assessRevenueGrounding,
+  evaluatePromotionGate,
+} from '../../../lib/eva/stage-templates/stage-16.js';
+import { PROVENANCE } from '../../../lib/eva/standards/operating-model.js';
+
+const DERIVED_PROJ = { month: 1, revenue: 49, revenue_provenance: { price: PROVENANCE.DERIVED, volume: PROVENANCE.ESTIMATE } };
+const ESTIMATE_PROJ = { month: 1, revenue: 999999, revenue_provenance: { price: PROVENANCE.ESTIMATE, volume: PROVENANCE.ESTIMATE } };
+
+describe('assessRevenueGrounding (FR-3)', () => {
+  it('grounded when a projection has an S7-DERIVED price', () => {
+    expect(assessRevenueGrounding({ revenue_projections: [DERIVED_PROJ] }).grounded).toBe(true);
+  });
+  it('NOT grounded when projections exist but all prices are LLM-estimated (fabricated revenue)', () => {
+    expect(assessRevenueGrounding({ revenue_projections: [ESTIMATE_PROJ, ESTIMATE_PROJ] }).grounded).toBe(false);
+  });
+  it('defers (grounded:true) when no projections present (absence handled by the facts gate)', () => {
+    expect(assessRevenueGrounding({}).grounded).toBe(true);
+    expect(assessRevenueGrounding({ revenue_projections: [] }).grounded).toBe(true);
+  });
+});
+
+describe('assessFinancialGrounding — revenue AND-combined with facts (FR-3)', () => {
+  it('fabricated revenue + grounded cost (facts>0) NO LONGER silently passes — routes to review', () => {
+    const stage16 = { fourBuckets: { summary: { facts: 3 } }, financials_valid: true, revenue_projections: [ESTIMATE_PROJ] };
+    const g = assessFinancialGrounding(stage16);
+    expect(g.grounded).toBe(false);
+    expect(g.status).toBe('ungrounded');
+    expect(g.review_required).toBe(true);
+    expect(g.reason).toMatch(/revenue ungrounded/);
+  });
+
+  it('facts>0 + DERIVED-price revenue stays grounded (no false block)', () => {
+    const stage16 = { fourBuckets: { summary: { facts: 3 } }, financials_valid: true, revenue_projections: [DERIVED_PROJ] };
+    const g = assessFinancialGrounding(stage16);
+    expect(g.grounded).toBe(true);
+    expect(g.status).toBe('grounded');
+    expect(g.review_required).toBe(false);
+  });
+
+  it('REGRESSION: facts>0 with no revenue array still grounded (existing groundedValid fixture)', () => {
+    const g = assessFinancialGrounding({ fourBuckets: { summary: { facts: 3 } }, financials_valid: true });
+    expect(g.status).toBe('grounded');
+  });
+
+  it('financials_valid=false still short-circuits to invalid (unchanged)', () => {
+    const g = assessFinancialGrounding({ fourBuckets: { summary: { facts: 3 } }, financials_valid: false, revenue_projections: [DERIVED_PROJ] });
+    expect(g.status).toBe('invalid');
+  });
+});
+
+describe('evaluatePromotionGate — fabricated revenue is flagged ungrounded (FR-3)', () => {
+  it('attaches grounding_status=ungrounded for fabricated (ESTIMATE-price) revenue', () => {
+    const r = evaluatePromotionGate({
+      stage13: {}, stage14: {}, stage15: {},
+      stage16: { fourBuckets: { summary: { facts: 3 } }, financials_valid: true, revenue_projections: [ESTIMATE_PROJ] },
+    });
+    // applyEvidenceGate always attaches the grounding status; fabricated revenue => ungrounded.
+    expect(r.grounding_status).toBe('ungrounded');
+  });
+
+  it('attaches grounding_status=grounded for S7-DERIVED-price revenue', () => {
+    const r = evaluatePromotionGate({
+      stage13: {}, stage14: {}, stage15: {},
+      stage16: { fourBuckets: { summary: { facts: 3 } }, financials_valid: true, revenue_projections: [DERIVED_PROJ] },
+    });
+    expect(r.grounding_status).toBe('grounded');
+  });
+});


### PR DESCRIPTION
## Summary
Grounds S16 **revenue** in the ratified S7 unit-economics at the producer. Cost was already grounded (`groundCostBreakdown`), but revenue was still raw LLM-invented, and the evidence-gate's coarse `facts>0` check let fabricated revenue ride through on a grounded-cost fact (grounded cost + fabricated revenue = `facts>0` = silent pass).

## Changes
- **`operating-model.js` `groundRevenue`**: derives `revenue = S7 arpa × customers` with per-figure provenance `{price: DERIVED, volume: ESTIMATE}` — the **price** is grounded in S7, the customer **volume** is a transparent, bounded, monotonic adoption ramp honestly tagged ESTIMATE. Returns `null` when S7 has no usable `arpa`, so the producer keeps the LLM revenue tagged ESTIMATE (graceful degradation, never a fabricated DERIVED tag).
- **`stage-contracts.js`**: `CROSS_STAGE_DEPS[16]` gains stage 7 so S7 economics reach the producer via `upstreamData`.
- **`stage-16-financial-projections.js` `analyzeStage16`**: threads `stage7Data`, applies `groundRevenue` per projection (carrying customers forward for a continuous ramp), tags `revenue_provenance`. Cost grounding unchanged (no phantom human-team burn); payment-processing cost now uses the grounded revenue.
- **`stage-16.js` `assessRevenueGrounding`**: revenue grounded only when a projection carries an S7-DERIVED price; AND-combined into `assessFinancialGrounding` so fabricated (ESTIMATE-price) revenue + grounded cost **routes to review** instead of silently passing. Absence of projections is left to the facts gate, so genuinely facts-grounded artifacts without a revenue array are unaffected.

## Epistemic honesty
The split is the point: **price = DERIVED** (ratified S7), **volume = ESTIMATE** (the adoption ramp is not claimed as derived). The gate routes-to-review (chairman decision), it does not hard-kill.

## Test plan
- `operating-model-revenue-grounding.test.js` + `s16-revenue-evidence-gate.test.js` → green
- Existing `s16-evidence-gate.test.js` + `operating-model-cost-grounding.test.js` → **no regression** (31/31)

SD: SD-LEO-INFRA-S16-REVENUE-GROUNDING-001 · companion to SD-LEO-INFRA-S16-OPERATING-MODEL-COST-GROUNDING-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)