### PR TITLE
feat(SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001): kill-gate route-to-review HOLDs (not archive) + STATUS.HELD

### DIFF
--- a/lib/eva/eva-orchestrator-helpers.js
+++ b/lib/eva/eva-orchestrator-helpers.js
@@ -19,6 +19,10 @@ const STATUS = Object.freeze({
   COMPLETED: 'COMPLETED',
   BLOCKED: 'BLOCKED',
   FAILED: 'FAILED',
+  // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: a route-to-review / chairman HOLD at a
+  // kill-gate (conditional_pass) is NOT a hard kill — the vision stays intact, a pending
+  // chairman_decision is minted, and the stage is held for review (not archived/BLOCKED).
+  HELD: 'HELD',
 });
 
 const FILTER_ACTION = Object.freeze({

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -864,6 +864,51 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     } // close autonomy-bypass else (manual DA / mandatory kill-gate DA)
   }
 
+  // ── SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: distinguish a route-to-review / HOLD
+  // verdict from a genuine KILL. The kill-gate verdict is carried on stageOutput.decision
+  // (S5 evaluateKillGate emits 'conditional_pass' for a demand-unvalidated / route-to-review
+  // case; validateStageGate at S3/S5 does NOT carry it). A HOLD must NOT archive the vision and
+  // must NOT return BLOCKED: keep the vision intact, mint a pending chairman_decision (whose
+  // resolveDecisionHealth guarantees a non-null health_score), and return STATUS.HELD.
+  // A structural failure (reality-gate / gate-eval error) is NEVER downgraded to HOLD. ──
+  const atKillGateStage = (resolvedStage === 3 || resolvedStage === 5);
+  const hasHardNonFinancialBlock = gateResults.some(
+    g => g.passed === false && g.type !== 'stage_gate' && g.type !== 'autonomy_check'
+  );
+  const isRouteToReview = atKillGateStage
+    && stageOutput?.decision === 'conditional_pass'
+    && !hasHardNonFinancialBlock;
+
+  if (isRouteToReview) {
+    // HOLD: keep the vision intact (NO archive), mint a pending chairman decision (non-null
+    // health via resolveDecisionHealth / GATE-NULL-HEALTH-RESOLUTION-001), return HELD.
+    if (!options.dryRun && supabase) {
+      try {
+        await createOrReusePendingDecision({
+          ventureId,
+          stageNumber: resolvedStage,
+          decisionType: 'stage_gate',
+          briefData: {
+            decision: stageOutput.decision,
+            reasons: stageOutput.reasons || [],
+            remediationRoute: stageOutput.remediationRoute || null,
+            gateResults,
+          },
+          summary: `Route to review (HOLD) at stage ${resolvedStage}: ${stageOutput.reasons?.[0]?.message || 'conditional pass — chairman/demand review'}`,
+          supabase,
+          logger,
+        });
+      } catch (mintErr) {
+        logger.warn(`[Eva] HOLD pending-decision mint failed (non-fatal): ${mintErr.message}`);
+      }
+    }
+    return buildResult({
+      ventureId, stageId: resolvedStage, startedAt, correlationId,
+      status: STATUS.HELD, artifacts, gateResults, devilsAdvocateReview,
+      errors: [], // a HOLD is a review state, not an error
+    });
+  }
+
   if (gateBlocked) {
     // Archive vision record on kill at stages 3 or 5
     if ((resolvedStage === 3 || resolvedStage === 5) && visionKey && !options.dryRun) {
@@ -1131,7 +1176,9 @@ export async function run({ ventureId, options = {} }, deps = {}) {
     const result = await processStage({ ventureId, options }, deps);
     results.push(result);
 
-    if (result.status === STATUS.FAILED || result.status === STATUS.BLOCKED) {
+    if (result.status === STATUS.FAILED || result.status === STATUS.BLOCKED || result.status === STATUS.HELD) {
+      // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: HELD (route-to-review) is terminal for
+      // the loop — the venture awaits a chairman decision; the mint already happened in processStage.
       logger.log(`[Eva] Loop stopped: ${result.status} at stage ${result.stageId}`);
       break;
     }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1316,6 +1316,17 @@ export class StageExecutionWorker {
           }
         }
 
+        // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: a HELD (route-to-review) stage awaits a
+        // chairman decision. Unlike BLOCKED, it must NOT governance-auto-advance, and it must NOT
+        // fall through to the "completed" path below — stop here and hold (blocked) for review.
+        if (resultStatus === 'HELD') {
+          this._logger.log(`[Worker] Stage ${currentStage} HELD (route-to-review) for ${ventureId} — awaiting chairman decision`);
+          this._logStageTransition(ventureId, currentStage, 'blocked', stageDurationMs, result).catch(() => {});
+          await this._writeHealthScore(ventureId, currentStage); // ensure health_score on HELD exit
+          releaseState = ORCHESTRATOR_STATES.BLOCKED;
+          break;
+        }
+
         // Log successful stage transition
         this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
 
@@ -1762,9 +1773,11 @@ export class StageExecutionWorker {
           }
         );
 
-        // SUCCESS or BLOCKED — don't retry these (STATUS constants are uppercase)
+        // SUCCESS, BLOCKED, or HELD — don't retry these (STATUS constants are uppercase).
+        // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: HELD (route-to-review) is a terminal
+        // review state awaiting a chairman decision — it must NOT fall into the FAILED retry path.
         const s = (result.status || '').toUpperCase();
-        if (s === 'COMPLETED' || s === 'BLOCKED') {
+        if (s === 'COMPLETED' || s === 'BLOCKED' || s === 'HELD') {
           if (execId) {
             clearInterval(heartbeatTimer);
             await this._finalizeStageExecution(execId, 'succeeded', null);
@@ -4366,6 +4379,10 @@ export class StageExecutionWorker {
     if (resultStatus === 'COMPLETED') stageStatus = 'completed';
     else if (resultStatus === 'BLOCKED') stageStatus = 'blocked';
     else if (resultStatus === 'FAILED') stageStatus = 'blocked'; // DB constraint only allows: not_started, in_progress, blocked, completed, skipped
+    // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: a HELD (route-to-review) stage is awaiting a
+    // chairman decision — map to the CHECK-valid 'blocked', NOT the default 'in_progress' (which
+    // would let the worker treat the held stage as still running).
+    else if (resultStatus === 'HELD') stageStatus = 'blocked';
     else stageStatus = 'in_progress';
 
     // For chairman gate stages AND review-mode stages, mark as blocked (awaiting chairman approval)

--- a/tests/unit/eva/killgate-route-to-review.test.js
+++ b/tests/unit/eva/killgate-route-to-review.test.js
@@ -1,0 +1,178 @@
+/**
+ * Kill-gate route-to-review HOLD vs genuine KILL
+ * SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001
+ *
+ * Completes SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001's missing half: the orchestrator must
+ * EXECUTE a route-to-review verdict (stageOutput.decision==='conditional_pass') as a HOLD — keep the
+ * vision intact, mint a pending chairman_decision, return STATUS.HELD — NOT as a genuine KILL
+ * (archive vision + BLOCKED). A structural failure (reality gate) is never downgraded to HOLD.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Transitive deps with shebangs / IO that vitest can't transform (mirrors eva-orchestrator.test.js)
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockReturnValue('SD-TEST-001'),
+  generateChildKey: vi.fn().mockReturnValue('SD-TEST-001-A'),
+  normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
+}));
+vi.mock('../../../lib/eva/stage-templates/index.js', () => ({
+  getTemplate: vi.fn().mockReturnValue(null),
+}));
+vi.mock('../../../lib/eva/dependency-manager.js', () => ({
+  checkDependencies: vi.fn().mockResolvedValue([]),
+  getDependencyGraph: vi.fn().mockResolvedValue({ dependsOn: [], providesTo: [] }),
+  wouldCreateCycle: vi.fn().mockResolvedValue(false),
+  addDependency: vi.fn(),
+  resolveDependency: vi.fn(),
+  removeDependency: vi.fn(),
+  MODULE_VERSION: '1.0.0',
+}));
+vi.mock('../../../lib/eva/shared-services.js', async () => {
+  const actual = await vi.importActual('../../../lib/eva/shared-services.js');
+  return { ...actual, emit: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock('../../../lib/eva/devils-advocate.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isDevilsAdvocateGate: vi.fn().mockReturnValue({ isGate: false, gateType: null }),
+  getDevilsAdvocateReview: vi.fn(),
+  buildArtifactRecord: vi.fn().mockReturnValue({}),
+}));
+// The HOLD path mints via createOrReusePendingDecision — mock it to record the call.
+// vi.hoisted so the spy exists before the hoisted vi.mock factory runs.
+const { mintSpy } = vi.hoisted(() => ({ mintSpy: vi.fn() }));
+mintSpy.mockResolvedValue({ id: 'dec-hold-1', health_score: 'red' });
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({
+  createOrReusePendingDecision: mintSpy,
+  waitForDecision: vi.fn(),
+  createAdvisoryNotification: vi.fn(),
+}));
+
+import { processStage, _internal } from '../../../lib/eva/eva-orchestrator.js';
+const { STATUS } = _internal;
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// A table-aware mock supabase: returns a vision doc for eva_vision_documents (so visionKey resolves
+// at stage 5) and records every .update() payload so we can detect a vision archive.
+function makeSupabase() {
+  const updates = []; // { table, payload }
+  const inserts = [];
+  const ventureRow = {
+    id: 'v-1', name: 'TestVenture', status: 'active',
+    current_lifecycle_stage: 5, archetype: 'saas', created_at: '2026-01-01', autonomy_level: 'L0',
+  };
+  const visionRow = { vision_key: 'VISION-TestVenture-L2-001', status: 'active' };
+  const from = (table) => {
+    const isVision = table === 'eva_vision_documents';
+    const builder = {
+      select: () => builder,
+      eq: () => builder,
+      in: () => builder,
+      is: () => builder,
+      order: () => builder,
+      limit: () => builder,
+      single: async () => ({ data: isVision ? visionRow : ventureRow, error: null }),
+      maybeSingle: async () => ({ data: isVision ? visionRow : ventureRow, error: null }),
+      insert: (payload) => { inserts.push({ table, payload }); return builder; },
+      update: (payload) => { updates.push({ table, payload }); return builder; },
+    };
+    return builder;
+  };
+  return { client: { from: vi.fn(from) }, updates, inserts };
+}
+
+// Build options.stageTemplate whose single analysis step emits an artifact payload carrying the
+// kill-gate verdict (mergeArtifactOutputs spreads payload → stageOutput.decision).
+function templateWithDecision(decision) {
+  return {
+    analysisSteps: [
+      {
+        id: 'kill-gate-step',
+        execute: async () => ({
+          artifactType: 'financial_model',
+          payload: { decision, reasons: [{ message: 'demand unvalidated' }], remediationRoute: 'review' },
+          source: 'test-killgate',
+        }),
+      },
+    ],
+  };
+}
+
+function visionArchived(updates) {
+  return updates.some(u => u.table === 'eva_vision_documents' && u.payload && u.payload.status === 'archived');
+}
+
+const baseDeps = (supabase) => ({
+  supabase,
+  logger: silentLogger,
+  evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+  evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true, status: 'PASS' }),
+  validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+});
+
+describe('Kill-gate route-to-review HOLD (SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001)', () => {
+  it('exports STATUS.HELD', () => {
+    expect(STATUS.HELD).toBe('HELD');
+  });
+
+  it('route-to-review @ S5 → HELD, vision NOT archived, pending decision minted', async () => {
+    mintSpy.mockClear();
+    const { client, updates } = makeSupabase();
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { stageTemplate: templateWithDecision('conditional_pass') } },
+      baseDeps(client),
+    );
+    expect(result.status).toBe(STATUS.HELD);
+    expect(visionArchived(updates)).toBe(false);
+    expect(mintSpy).toHaveBeenCalledTimes(1);
+    expect(mintSpy.mock.calls[0][0]).toMatchObject({ stageNumber: 5, decisionType: 'stage_gate' });
+  });
+
+  it('genuine kill @ S5 (gate fails, not conditional_pass) → vision archived + BLOCKED', async () => {
+    const { client, updates } = makeSupabase();
+    const deps = baseDeps(client);
+    deps.validateStageGateFn = vi.fn().mockResolvedValue({ passed: false, summary: 'financial viability fail' });
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { stageTemplate: templateWithDecision('kill') } },
+      deps,
+    );
+    expect(result.status).toBe(STATUS.BLOCKED);
+    expect(visionArchived(updates)).toBe(true);
+  });
+
+  it('backward-compat: a normal pass → COMPLETED, no archive, no HOLD mint', async () => {
+    mintSpy.mockClear();
+    const { client, updates } = makeSupabase();
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { stageTemplate: templateWithDecision('pass') } },
+      baseDeps(client),
+    );
+    expect(result.status).toBe(STATUS.COMPLETED);
+    expect(visionArchived(updates)).toBe(false);
+    expect(mintSpy).not.toHaveBeenCalled();
+  });
+
+  it('HOLD respects dry-run: HELD with NO mint and NO vision update', async () => {
+    mintSpy.mockClear();
+    const { client, updates } = makeSupabase();
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { dryRun: true, stageTemplate: templateWithDecision('conditional_pass') } },
+      baseDeps(client),
+    );
+    expect(result.status).toBe(STATUS.HELD);
+    expect(mintSpy).not.toHaveBeenCalled();
+    expect(visionArchived(updates)).toBe(false);
+  });
+
+  it('mis-route guard: conditional_pass + reality-gate hard fail → BLOCKED + archived (not HELD)', async () => {
+    const { client, updates } = makeSupabase();
+    const deps = baseDeps(client);
+    deps.evaluateRealityGateFn = vi.fn().mockResolvedValue({ passed: false, error: 'artifacts missing' });
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { stageTemplate: templateWithDecision('conditional_pass') } },
+      deps,
+    );
+    expect(result.status).toBe(STATUS.BLOCKED);
+    expect(visionArchived(updates)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Completes **SD-LEO-INFRA-S5-KILL-GATE-DEMAND-FEASIBILITY-001**'s missing half. `evaluateKillGate` now returns `decision='conditional_pass'` (route-to-review) for demand-unvalidated ventures, but the orchestrator was **executing that as a genuine KILL** — the `gateBlocked` boolean conflated HOLD with KILL, so the blocked branch archived the vision (stages 3/5) and returned BLOCKED for both.

## Fix
`eva-orchestrator.js` distinguishes route-to-review from a genuine kill via **`stageOutput.decision`** (the verdict is NOT carried by `validateStageGate` at S3/S5 — the 5→6 gate is FINANCIAL_VIABILITY with only `{passed}`; confirmed by a code-grounded Plan-agent investigation).

- **HOLD** (`conditional_pass` + no hard non-stage_gate/reality-gate block): do NOT archive the vision, mint a pending `chairman_decision` (`createOrReusePendingDecision` → `resolveDecisionHealth` guarantees non-null health), keep the vision intact, return the new **`STATUS.HELD`**.
- **genuine KILL**: archive + BLOCKED (unchanged).
- **mis-route guard**: a reality-gate / gate-error structural failure is never downgraded to HOLD.
- **dry-run** HOLD returns HELD with zero side effects.

`STATUS.HELD` added and tolerated by the run-loop and the stage-execution-worker (no-retry terminal set + a dedicated HELD branch that holds-blocked **without** governance auto-advance + `stage_status → blocked`).

## Verification
- 6 new orchestrator tests: HOLD@S5→HELD+no-archive+mint, genuine-kill→archived+BLOCKED, pass→COMPLETED, dry-run HOLD→HELD no-side-effects, mis-route→BLOCKED+archived, STATUS.HELD export
- Existing 30 eva-orchestrator tests green
- The 7 stage-execution-worker failures are **pre-existing baseline rot** (identical count with my worker edit stashed; none mention HELD)
- +249 LOC, backend-only; no schema/UI change (worker maps HELD to the existing CHECK-valid `blocked`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
