### PR TITLE
feat(SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001): eager-synthesis writer populates vision dims+sections (extract-once, fail-soft)

### DIFF
--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -15,6 +15,10 @@ import { persistADRs } from './adr-extractor.js';
 import { isValidArtifactType } from './artifact-types.js';
 import { checkExitGates } from './lifecycle/exit-gate-enforcer.js';
 import { classifyGateRow } from './gate-enforcement.js';
+// SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001: populate extracted_dimensions + sections so
+// eager-synthesized visions pass eva_vision_documents_active_rich_check on promotion.
+import { parseMarkdownToSections, buildDefaultMapping } from '../../scripts/eva/markdown-to-sections-parser.mjs';
+import { extractDimensions } from './vision-dimensions-extractor.js';
 
 /**
  * Write a venture artifact with dual-write (content TEXT + artifact_data JSONB).
@@ -779,7 +783,9 @@ function deriveContent(artifactData) {
  * Fetches all current artifacts with matching supports_vision_key, synthesizes
  * structured content, and upserts the vision record (incrementing version).
  */
-async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, triggerStage) {
+// Exported for unit testing (SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001); still invoked
+// internally by the artifact-write path.
+export async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, triggerStage) {
   const { data: artifacts } = await supabase
     .from('venture_artifacts')
     .select('lifecycle_stage, artifact_type, content, quality_score')
@@ -793,9 +799,31 @@ async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, trig
 
   const { data: existing } = await supabase
     .from('eva_vision_documents')
-    .select('id, version, addendums')
+    .select('id, version, addendums, extracted_dimensions')
     .eq('vision_key', visionKey)
     .single();
+
+  // SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001: populate sections (deterministic, always)
+  // and extracted_dimensions (LLM, extract-once + fail-soft) so the vision passes the active-rich
+  // CHECK on promotion. synthesizeFromArtifacts already emits ## headings → parseMarkdownToSections.
+  let sections = null;
+  try {
+    sections = parseMarkdownToSections(synthesized, buildDefaultMapping());
+  } catch (sErr) {
+    console.warn(`[artifact-persistence-service] section parse failed (${visionKey}): ${sErr.message}`);
+  }
+  // Extract dimensions at most ONCE per vision: on insert (no existing), or on update only when the
+  // existing row still lacks them. Fail-soft: a null/failed extraction never blocks the content write.
+  const existingHasDims = Array.isArray(existing?.extracted_dimensions) && existing.extracted_dimensions.length > 0;
+  let extractedDimensions = null;
+  if (!existingHasDims) {
+    try {
+      extractedDimensions = await extractDimensions(synthesized);
+    } catch (dErr) {
+      console.warn(`[artifact-persistence-service] dimension extraction failed (${visionKey}): ${dErr.message}`);
+      extractedDimensions = null;
+    }
+  }
 
   // SD-LEO-FIX-FIX-PHANTOM-COLUMN-002: eva_vision_documents has NO metadata column —
   // the addendums entries already carry evidence_count/stage_number for HEAL traceability.
@@ -813,6 +841,9 @@ async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, trig
       content: synthesized,
       version: newVersion,
       addendums,
+      ...(sections ? { sections } : {}),
+      // Only write dims when we newly extracted them (existing lacked them); never clobber with null.
+      ...(extractedDimensions ? { extracted_dimensions: extractedDimensions } : {}),
       updated_at: new Date().toISOString(),
     }).eq('vision_key', visionKey);
     if (updateError) console.warn(`[artifact-persistence-service] eva_vision_documents update failed (${visionKey}): ${updateError.message}`);
@@ -825,6 +856,8 @@ async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, trig
       version: 1,
       status: 'draft',
       created_by: 'eager-synthesis',
+      ...(sections ? { sections } : {}),
+      ...(extractedDimensions ? { extracted_dimensions: extractedDimensions } : {}),
       addendums: [{ stage_number: triggerStage, artifact_count: artifacts.length, evidence_count: artifacts.length, timestamp: new Date().toISOString() }],
     });
     if (insertError) console.warn(`[artifact-persistence-service] eva_vision_documents insert failed (${visionKey}): ${insertError.message}`);

--- a/lib/eva/vision-dimensions-extractor.js
+++ b/lib/eva/vision-dimensions-extractor.js
@@ -1,0 +1,77 @@
+/**
+ * Canonical vision dimension extractor.
+ * SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001
+ *
+ * Relocated verbatim from scripts/eva/vision-command.mjs (extractDimensions) so the ONE canonical
+ * LLM extractor can be reused by both the CLI (vision-command.mjs) and the eager-synthesis writer
+ * (lib/eva/artifact-persistence-service.js upsertEvaVisionFromArtifacts) — which previously wrote
+ * visions with NULL extracted_dimensions, failing eva_vision_documents_active_rich_check on promotion.
+ *
+ * Importing this module has NO CLI/argv side effects.
+ *
+ * @module lib/eva/vision-dimensions-extractor
+ */
+import { getValidationClient } from '../llm/client-factory.js';
+
+// Cap content sent to the LLM (token/cost guard). Matches the original CLI constant.
+export const MAX_LLM_CONTENT_CHARS = 15000;
+
+/**
+ * Extract 6-10 weighted scoring dimensions from a vision document via the validation LLM.
+ * Fail-soft: returns null after one retry rather than throwing, so callers never lose the write.
+ *
+ * @param {string} content - the vision markdown content
+ * @param {number} [retryCount=0] - internal retry counter
+ * @returns {Promise<Array<{name:string,weight:number,description:string,source_section?:string}>|null>}
+ */
+export async function extractDimensions(content, retryCount = 0) {
+  if (content.length > MAX_LLM_CONTENT_CHARS) {
+    console.warn(`\n   ⚠️  Content truncated from ${content.length.toLocaleString()} to ${MAX_LLM_CONTENT_CHARS.toLocaleString()} chars for LLM extraction`);
+  }
+  const truncated = content.length > MAX_LLM_CONTENT_CHARS
+    ? content.slice(0, MAX_LLM_CONTENT_CHARS) + '\n...[truncated for dimension extraction]'
+    : content;
+
+  const prompt = `You are analyzing a strategic vision document. Extract 6-10 key scoring dimensions that represent the major requirements, principles, or goals of this vision. These dimensions will be used to score whether built software aligns with this vision.
+
+For each dimension, provide:
+- name: short identifier (e.g., "chairman_governance", "stage_completeness")
+- weight: relative importance 0.0-1.0 (all weights should sum to approximately 1.0)
+- description: one sentence explaining what this dimension measures
+- source_section: which section or principle in the doc this comes from
+
+Return ONLY a valid JSON array of objects with these exact fields. No explanation text.
+
+Document:
+${truncated}`;
+
+  try {
+    const client = getValidationClient();
+    const systemPrompt = 'You are a document analyst. Extract structured scoring dimensions from strategic documents. Return only valid JSON arrays.';
+    const response = await client.complete(systemPrompt, prompt);
+    const text = typeof response === 'string' ? response : response?.content || response?.text || JSON.stringify(response);
+
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) throw new Error('No JSON array found in LLM response');
+
+    const dimensions = JSON.parse(jsonMatch[0]);
+    if (!Array.isArray(dimensions) || dimensions.length < 1) throw new Error('LLM returned empty dimensions');
+
+    for (const dim of dimensions) {
+      if (!dim.name || typeof dim.weight !== 'number' || !dim.description) {
+        throw new Error(`Invalid dimension shape: ${JSON.stringify(dim)}`);
+      }
+    }
+
+    return dimensions;
+  } catch (err) {
+    if (retryCount === 0) {
+      console.warn(`\n   ⚠️  LLM extraction failed (attempt 1): ${err.message}`);
+      console.warn('   Retrying...');
+      return extractDimensions(content, 1);
+    }
+    console.warn(`\n   ⚠️  LLM extraction failed after 2 attempts: ${err.message}`);
+    console.warn('   Storing null extracted_dimensions — can be re-extracted later by scorer.');
+    return null;
+  }
+}

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -36,7 +36,9 @@ import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
-import { getValidationClient } from '../../lib/llm/client-factory.js';
+// SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001: extractDimensions relocated to a shared lib
+// module so the eager-synthesis writer can reuse the ONE canonical extractor.
+import { extractDimensions } from '../../lib/eva/vision-dimensions-extractor.js';
 import { parseMarkdownToSections, buildDefaultMapping } from './markdown-to-sections-parser.mjs';
 import { buildSectionKeyMapping, getSectionSchema, validateSections } from './document-section-registry.mjs';
 import { renderSectionsToMarkdown, renderSectionsSummary } from './sections-to-markdown-renderer.mjs';
@@ -44,7 +46,6 @@ import { readStdin } from '../../lib/utils/read-stdin.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../');
-const MAX_LLM_CONTENT_CHARS = 15000;
 
 // B2 (SD-LEO-INFRA-LEO-UPSTREAM-DECISION-001): Testable Success Criteria heuristic
 // Extracted to lib/eva/testable-criteria-heuristic.js for reuse and testability.
@@ -70,60 +71,9 @@ function parseArgs(argv) {
 }
 
 // ============================================================================
-// LLM dimension extraction (reused from seed-l1-vision.js)
+// LLM dimension extraction relocated to lib/eva/vision-dimensions-extractor.js
+// (SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001) — imported above.
 // ============================================================================
-
-async function extractDimensions(content, retryCount = 0) {
-  if (content.length > MAX_LLM_CONTENT_CHARS) {
-    console.warn(`\n   ⚠️  Content truncated from ${content.length.toLocaleString()} to ${MAX_LLM_CONTENT_CHARS.toLocaleString()} chars for LLM extraction`);
-  }
-  const truncated = content.length > MAX_LLM_CONTENT_CHARS
-    ? content.slice(0, MAX_LLM_CONTENT_CHARS) + '\n...[truncated for dimension extraction]'
-    : content;
-
-  const prompt = `You are analyzing a strategic vision document. Extract 6-10 key scoring dimensions that represent the major requirements, principles, or goals of this vision. These dimensions will be used to score whether built software aligns with this vision.
-
-For each dimension, provide:
-- name: short identifier (e.g., "chairman_governance", "stage_completeness")
-- weight: relative importance 0.0-1.0 (all weights should sum to approximately 1.0)
-- description: one sentence explaining what this dimension measures
-- source_section: which section or principle in the doc this comes from
-
-Return ONLY a valid JSON array of objects with these exact fields. No explanation text.
-
-Document:
-${truncated}`;
-
-  try {
-    const client = getValidationClient();
-    const systemPrompt = 'You are a document analyst. Extract structured scoring dimensions from strategic documents. Return only valid JSON arrays.';
-    const response = await client.complete(systemPrompt, prompt);
-    const text = typeof response === 'string' ? response : response?.content || response?.text || JSON.stringify(response);
-
-    const jsonMatch = text.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) throw new Error('No JSON array found in LLM response');
-
-    const dimensions = JSON.parse(jsonMatch[0]);
-    if (!Array.isArray(dimensions) || dimensions.length < 1) throw new Error('LLM returned empty dimensions');
-
-    for (const dim of dimensions) {
-      if (!dim.name || typeof dim.weight !== 'number' || !dim.description) {
-        throw new Error(`Invalid dimension shape: ${JSON.stringify(dim)}`);
-      }
-    }
-
-    return dimensions;
-  } catch (err) {
-    if (retryCount === 0) {
-      console.warn(`\n   ⚠️  LLM extraction failed (attempt 1): ${err.message}`);
-      console.warn('   Retrying...');
-      return extractDimensions(content, 1);
-    }
-    console.warn(`\n   ⚠️  LLM extraction failed after 2 attempts: ${err.message}`);
-    console.warn('   Storing null extracted_dimensions — can be re-extracted later by scorer.');
-    return null;
-  }
-}
 
 // ============================================================================
 // Subcommands

--- a/scripts/one-off/backfill-eager-synthesis-vision-dims.mjs
+++ b/scripts/one-off/backfill-eager-synthesis-vision-dims.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Backfill extracted_dimensions + sections for eager-synthesis visions that have NULL dims.
+ * SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001 (FR-3).
+ *
+ * The eager-synthesis writer (upsertEvaVisionFromArtifacts) historically wrote visions WITHOUT
+ * extracted_dimensions/sections, so they fail eva_vision_documents_active_rich_check on promotion.
+ * The writer is now fixed going forward; this repairs the existing rows from their own content.
+ *
+ * Idempotent: only touches created_by='eager-synthesis' rows whose extracted_dimensions is null/empty.
+ * The clean-clone vision (already hand-repaired) and any non-eager-synthesis vision are untouched.
+ *
+ * Usage: node scripts/one-off/backfill-eager-synthesis-vision-dims.mjs [--dry-run]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { parseMarkdownToSections, buildDefaultMapping } from '../eva/markdown-to-sections-parser.mjs';
+import { extractDimensions } from '../../lib/eva/vision-dimensions-extractor.js';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: rows, error } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key, content, extracted_dimensions')
+    .eq('created_by', 'eager-synthesis');
+  if (error) { console.error('Query failed:', error.message); process.exit(1); }
+
+  const targets = (rows || []).filter(
+    r => !Array.isArray(r.extracted_dimensions) || r.extracted_dimensions.length === 0
+  );
+  console.log(`[backfill] eager-synthesis visions: ${rows?.length || 0} | NULL-dims targets: ${targets.length}${DRY_RUN ? ' (dry-run)' : ''}`);
+
+  let repaired = 0;
+  for (const r of targets) {
+    if (!r.content || r.content.length < 1) { console.warn(`[backfill] skip ${r.vision_key}: empty content`); continue; }
+    let sections = null;
+    try { sections = parseMarkdownToSections(r.content, buildDefaultMapping()); }
+    catch (e) { console.warn(`[backfill] ${r.vision_key} section parse failed: ${e.message}`); }
+    const dims = await extractDimensions(r.content); // fail-soft: returns null on LLM failure
+    if (!dims && !sections) { console.warn(`[backfill] ${r.vision_key}: nothing to write (no dims, no sections)`); continue; }
+    if (DRY_RUN) { console.log(`[backfill] would update ${r.vision_key}: dims=${dims ? dims.length : 0}, sections=${sections ? 'yes' : 'no'}`); continue; }
+    const update = { updated_at: new Date().toISOString() };
+    if (dims) update.extracted_dimensions = dims;
+    if (sections) update.sections = sections;
+    const { error: upErr } = await supabase.from('eva_vision_documents').update(update).eq('vision_key', r.vision_key);
+    if (upErr) { console.warn(`[backfill] ${r.vision_key} update failed: ${upErr.message}`); continue; }
+    console.log(`[backfill] repaired ${r.vision_key}: dims=${dims ? dims.length : 0}, sections=${sections ? 'yes' : 'no'}`);
+    repaired++;
+  }
+  console.log(`[backfill] done: ${DRY_RUN ? 0 : repaired} repaired of ${targets.length} target(s)`);
+  process.exit(0);
+}
+
+main();

--- a/tests/unit/eva/eager-synthesis-vision-dims.test.js
+++ b/tests/unit/eva/eager-synthesis-vision-dims.test.js
@@ -1,0 +1,105 @@
+/**
+ * Eager-synthesis vision writer populates extracted_dimensions + sections
+ * SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001
+ *
+ * upsertEvaVisionFromArtifacts historically wrote visions WITHOUT extracted_dimensions/sections,
+ * failing eva_vision_documents_active_rich_check on promotion. It now populates sections
+ * (deterministic, always) and extracted_dimensions (LLM, extract-once + fail-soft).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the shared dimension extractor (the LLM call) so tests are deterministic + offline.
+const { extractSpy } = vi.hoisted(() => ({ extractSpy: vi.fn() }));
+vi.mock('../../../lib/eva/vision-dimensions-extractor.js', () => ({
+  extractDimensions: extractSpy,
+  MAX_LLM_CONTENT_CHARS: 15000,
+}));
+
+import {
+  upsertEvaVisionFromArtifacts,
+  synthesizeFromArtifacts,
+} from '../../../lib/eva/artifact-persistence-service.js';
+import { extractDimensions, MAX_LLM_CONTENT_CHARS } from '../../../lib/eva/vision-dimensions-extractor.js';
+
+const ARTIFACTS = [
+  { lifecycle_stage: 1, artifact_type: 'problem_statement', content: 'A real problem worth solving for the market.', quality_score: 80 },
+  { lifecycle_stage: 2, artifact_type: 'solution_design', content: 'A concrete solution approach with clear value.', quality_score: 85 },
+];
+const DIMS = [{ name: 'd1', weight: 0.5, description: 'first' }, { name: 'd2', weight: 0.5, description: 'second' }];
+
+// Table+method-aware mock supabase. `existing` controls insert vs update path.
+function makeSupabase(existing) {
+  const inserts = [];
+  const updates = [];
+  const from = (table) => {
+    if (table === 'venture_artifacts') {
+      const b = { select: () => b, eq: () => b, order: async () => ({ data: ARTIFACTS, error: null }) };
+      return b;
+    }
+    // eva_vision_documents
+    const b = {
+      select: () => b,
+      eq: () => b,
+      single: async () => ({ data: existing, error: existing ? null : { code: 'PGRST116' } }),
+      insert: (payload) => { inserts.push(payload); return b; },
+      update: (payload) => { updates.push(payload); return { eq: () => ({ error: null }) }; },
+    };
+    return b;
+  };
+  return { client: { from }, inserts, updates };
+}
+
+describe('Eager-synthesis vision dims (SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001)', () => {
+  beforeEach(() => extractSpy.mockReset());
+
+  it('shared module exports extractDimensions + MAX_LLM_CONTENT_CHARS', () => {
+    expect(typeof extractDimensions).toBe('function');
+    expect(MAX_LLM_CONTENT_CHARS).toBe(15000);
+  });
+
+  it('synthesizeFromArtifacts emits ## headings (so sections parse non-empty)', () => {
+    const md = synthesizeFromArtifacts(ARTIFACTS, 'vision');
+    expect(md).toMatch(/^##\s+/m);
+  });
+
+  it('insert path populates sections AND extracted_dimensions', async () => {
+    extractSpy.mockResolvedValue(DIMS);
+    const { client, inserts } = makeSupabase(null);
+    await upsertEvaVisionFromArtifacts(client, 'VISION-TEST-L2-001', 'v-1', 2);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].extracted_dimensions).toEqual(DIMS);
+    expect(inserts[0].sections).toBeTruthy();
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('update path EXTRACT-ONCE: re-extracts dims only when existing lacks them', async () => {
+    extractSpy.mockResolvedValue(DIMS);
+    // existing has dims → extractor NOT called; sections still refreshed
+    const a = makeSupabase({ id: 'x', version: 1, addendums: [], extracted_dimensions: [{ name: 'old', weight: 1, description: 'x' }] });
+    await upsertEvaVisionFromArtifacts(a.client, 'VISION-TEST-L2-001', 'v-1', 3);
+    expect(extractSpy).not.toHaveBeenCalled();
+    expect(a.updates[0].sections).toBeTruthy();
+    expect(a.updates[0].extracted_dimensions).toBeUndefined(); // not clobbered
+
+    extractSpy.mockClear();
+    // existing lacks dims → extractor called
+    const b = makeSupabase({ id: 'x', version: 1, addendums: [], extracted_dimensions: null });
+    await upsertEvaVisionFromArtifacts(b.client, 'VISION-TEST-L2-001', 'v-1', 3);
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+    expect(b.updates[0].extracted_dimensions).toEqual(DIMS);
+  });
+
+  it('fail-soft: extractor returns null → write still succeeds with sections, no dims', async () => {
+    extractSpy.mockResolvedValue(null); // LLM failed (extractor is fail-soft, returns null)
+    const { client, inserts } = makeSupabase(null);
+    await upsertEvaVisionFromArtifacts(client, 'VISION-TEST-L2-001', 'v-1', 2);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].extracted_dimensions).toBeUndefined(); // not written when null
+    expect(inserts[0].sections).toBeTruthy();
+    expect(inserts[0].content).toBeTruthy(); // the synthesized content write is never lost
+  });
+
+  // Note: the canonical fail-soft path is "extractDimensions returns null" (the real extractor is
+  // fail-soft at source and never throws) — asserted above. The writer additionally wraps the call
+  // in try/catch as defense-in-depth against an unexpected throw (verified by code inspection).
+});


### PR DESCRIPTION
## Summary
`upsertEvaVisionFromArtifacts` (eager-synthesis vision writer) synthesized deterministic content but **never populated `extracted_dimensions`/`sections`**, so auto-launched ventures' visions failed `eva_vision_documents_active_rich_check` (`status!='active' OR extracted_dimensions IS NOT NULL`) on promotion — venture-1 had to hand-seed dims. The canonical `extractDimensions` lived only inside `scripts/eva/vision-command.mjs` (non-exported, CLI-main on import) so it could not be reused.

## Fix
- **Relocated** `extractDimensions` → new shared `lib/eva/vision-dimensions-extractor.js` (no CLI side effects); re-pointed `vision-command.mjs` to it (no behavior change; still loads + runs).
- The writer now populates **`sections`** via deterministic `parseMarkdownToSections` (always, cheap) and **`extracted_dimensions`** via the shared extractor **extract-once** (insert, or update only when existing lacks dims) + **fail-soft** (a null/failed extraction never loses the write; never clobbers existing dims). `synthesizeFromArtifacts` unchanged. → LLM cost bounded to ~1 call/vision (the co-author concern).
- **Idempotent backfill** (`scripts/one-off/backfill-eager-synthesis-vision-dims.mjs`) repaired the remaining NULL-dims eager-synthesis vision (`VISION-CANARY-VENTURE-PROBE-L2-001`: dims=6, sections=yes); re-run is a no-op.

## Verification
- 5 unit tests: module export, synthesized `##` headings, insert sets dims+sections, update extract-once-when-missing, fail-soft returns-null
- `vision-command.mjs` loads + prints usage post-relocation (no regression); markdown-to-sections parser test green
- +279 LOC, backend-only; columns already exist (no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
