### PR TITLE
feat(SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001): deterministic Adam chairman-escalation email

### DIFF
--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -19,7 +19,71 @@
  *     only set when the value is one of the allowed enums.
  */
 
+import { spawn as nodeSpawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
 const COLUMN_RECOMMENDATIONS = new Set(['proceed', 'pivot', 'fix', 'kill', 'pause']);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ADAM_EXEC_SUMMARY = resolve(__dirname, '../../scripts/adam-exec-summary.mjs');
+
+/**
+ * SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 FR-1 — PURE, deterministic predicate: should recording
+ * this decision IMMEDIATELY fire the standout chairman-escalation email? True only for a genuine Adam
+ * escalation: raisedBy==='adam' AND (a routed stuck-question OR an Adam-flagged blocking decision).
+ * Deliberately structural — there is NO 'is the chairman in-session' input, so the email no longer
+ * depends on in-session judgment or the hourly cron. Exported for unit testing.
+ * @param {{decisionType?:string, blocking?:boolean, raisedBy?:string}} o
+ * @returns {boolean}
+ */
+export function shouldAutoEscalate({ decisionType, blocking, raisedBy } = {}) {
+  if (raisedBy !== 'adam') return false;
+  return decisionType === 'session_question' || blocking === true;
+}
+
+/**
+ * Default fire-and-forget spawn of the standout escalation email (adam-exec-summary.mjs --force).
+ * Detached + unref'd so it never blocks the caller; stdio ignored. Fail-soft — the email is a nudge,
+ * the durable decision row is the source of truth.
+ */
+function defaultSpawnEscalationEmail() {
+  const child = nodeSpawn('node', [ADAM_EXEC_SUMMARY, '--force'], { detached: true, stdio: 'ignore' });
+  child.on('error', () => { /* fail-soft: the email is best-effort */ });
+  if (typeof child.unref === 'function') child.unref();
+}
+
+/**
+ * FR-2/FR-3 — escalate a recorded chairman decision: fire the standout email ONCE (dedup on
+ * brief_data.escalation_email_sent_at), then stamp the marker so a re-call is a no-op. Fail-soft:
+ * any read/spawn/update error is swallowed so escalation never breaks the durable record. The
+ * timeout watchdog is the EXISTING checkAndEscalateTimeouts poller (lib/eva/chairman-decision-timeout.js)
+ * — the pending row this stamps is already tracked by it, so no new daemon is armed here.
+ * @param {Object} supabase
+ * @param {string} decisionId
+ * @param {{spawn?:Function}} [opts] - inject spawn for tests
+ * @returns {Promise<{escalated:boolean, deduped?:boolean, error?:string}>}
+ */
+export async function escalateChairmanDecision(supabase, decisionId, { spawn = defaultSpawnEscalationEmail } = {}) {
+  if (!supabase || !decisionId) return { escalated: false, error: 'supabase and decisionId required' };
+  try {
+    // Dedup: one email per decision. Re-read the live marker before sending.
+    const { data: live } = await supabase
+      .from('chairman_decisions')
+      .select('brief_data')
+      .eq('id', decisionId)
+      .maybeSingle();
+    if (live?.brief_data?.escalation_email_sent_at) {
+      return { escalated: false, deduped: true };
+    }
+    spawn(); // fire-and-forget standout email
+    const merged = { ...(live?.brief_data || {}), escalation_email_sent_at: new Date().toISOString() };
+    await supabase.from('chairman_decisions').update({ brief_data: merged }).eq('id', decisionId);
+    return { escalated: true };
+  } catch (e) {
+    return { escalated: false, error: e?.message || String(e) };
+  }
+}
 
 /**
  * Record a pending chairman decision.
@@ -32,7 +96,9 @@ const COLUMN_RECOMMENDATIONS = new Set(['proceed', 'pivot', 'fix', 'kill', 'paus
  * @param {boolean} [opts.blocking=false]
  * @param {string} [opts.ventureId] - optional; session questions are ventureless
  * @param {number} [opts.lifecycleStage=0] - 0 = not a venture lifecycle decision
- * @returns {Promise<{recorded: boolean, id?: string, error?: string}>}
+ * @param {string} [opts.raisedBy] - who raised it; 'adam' triggers the deterministic escalation email
+ * @param {Function} [opts._spawnEscalation] - test seam: inject the email-spawn
+ * @returns {Promise<{recorded: boolean, id?: string, error?: string, escalated?: boolean}>}
  */
 export async function recordPendingDecision(supabase, {
   title,
@@ -42,6 +108,8 @@ export async function recordPendingDecision(supabase, {
   blocking = false,
   ventureId = null,
   lifecycleStage = 0,
+  raisedBy = null,
+  _spawnEscalation,
 } = {}) {
   if (!supabase) return { recorded: false, error: 'supabase client is required' };
   if (!title) return { recorded: false, error: 'title is required' };
@@ -49,6 +117,7 @@ export async function recordPendingDecision(supabase, {
   const briefData = {
     title,
     ...(recommendation ? { recommendation } : {}),
+    ...(raisedBy ? { raised_by: raisedBy } : {}),
     context: context ?? null,
     recorded_via: 'record-pending-decision',
   };
@@ -71,5 +140,15 @@ export async function recordPendingDecision(supabase, {
   if (res.error) {
     return { recorded: false, error: res.error.message };
   }
-  return { recorded: true, id: res.data?.[0]?.id };
+  const id = res.data?.[0]?.id;
+
+  // FR-2: DETERMINISTIC escalation — an Adam session_question/blocking decision fires the standout
+  // [ACTION NEEDED - ADAM] email IMMEDIATELY on creation, no in-session/availability gate and no
+  // waiting for the hourly cron. Fail-soft: an escalation error never fails the durable record.
+  let escalated = false;
+  if (id && shouldAutoEscalate({ decisionType, blocking, raisedBy })) {
+    const r = await escalateChairmanDecision(supabase, id, _spawnEscalation ? { spawn: _spawnEscalation } : {});
+    escalated = r.escalated === true;
+  }
+  return { recorded: true, id, escalated };
 }

--- a/tests/unit/chairman/record-pending-decision-escalation.test.js
+++ b/tests/unit/chairman/record-pending-decision-escalation.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 — the chairman-escalation email is now DETERMINISTIC:
+ * an Adam session_question/blocking decision fires the standout email immediately on creation, with no
+ * in-session gate, deduped to one email per decision, fail-soft.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  shouldAutoEscalate,
+  escalateChairmanDecision,
+  recordPendingDecision,
+} from '../../../lib/chairman/record-pending-decision.mjs';
+
+/** Minimal supabase stub: insert returns an id; select reads back a row's brief_data; update records. */
+function makeSupabase({ briefData = null } = {}) {
+  const state = { briefData, updates: [] };
+  return {
+    state,
+    from() {
+      const ctx = {};
+      const api = {
+        insert() { ctx.op = 'insert'; return api; },
+        update(vals) { ctx.op = 'update'; state.updates.push(vals); return api; },
+        select() { ctx.op = ctx.op || 'select'; return api; },
+        eq() { return api; },
+        async maybeSingle() { return { data: state.briefData === null ? null : { brief_data: state.briefData } }; },
+        then(resolve) { // insert(...).select('id') is awaited directly
+          resolve({ data: [{ id: 'dec-1' }], error: null });
+        },
+      };
+      return api;
+    },
+  };
+}
+
+describe('shouldAutoEscalate (FR-1)', () => {
+  it('adam + session_question => true', () => {
+    expect(shouldAutoEscalate({ decisionType: 'session_question', raisedBy: 'adam' })).toBe(true);
+  });
+  it('adam + blocking => true', () => {
+    expect(shouldAutoEscalate({ decisionType: 'stage_gate', blocking: true, raisedBy: 'adam' })).toBe(true);
+  });
+  it('non-adam => false regardless of type/blocking', () => {
+    expect(shouldAutoEscalate({ decisionType: 'session_question', raisedBy: 'coordinator' })).toBe(false);
+    expect(shouldAutoEscalate({ blocking: true, raisedBy: null })).toBe(false);
+  });
+  it('adam but neither session_question nor blocking => false', () => {
+    expect(shouldAutoEscalate({ decisionType: 'stage_gate', blocking: false, raisedBy: 'adam' })).toBe(false);
+  });
+  it('has no chairman-availability/in-session parameter', () => {
+    // The signature is purely structural — passing an "inSession" flag has no effect.
+    expect(shouldAutoEscalate({ decisionType: 'session_question', raisedBy: 'adam', inSession: false })).toBe(true);
+  });
+});
+
+describe('escalateChairmanDecision (FR-2/FR-3)', () => {
+  it('fires the email once and stamps escalation_email_sent_at', async () => {
+    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const spawn = vi.fn();
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
+    expect(r.escalated).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(sb.state.updates[0].brief_data.escalation_email_sent_at).toBeTruthy();
+  });
+
+  it('dedup: a row already stamped does NOT spawn again', async () => {
+    const sb = makeSupabase({ briefData: { title: 'q', escalation_email_sent_at: '2026-06-28T00:00:00Z' } });
+    const spawn = vi.fn();
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
+    expect(r.deduped).toBe(true);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft: a spawn throw is swallowed (escalated:false, no throw)', async () => {
+    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const spawn = vi.fn(() => { throw new Error('spawn boom'); });
+    const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
+    expect(r.escalated).toBe(false);
+    expect(r.error).toMatch(/boom/);
+  });
+});
+
+describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)', () => {
+  it('an adam session_question record fires exactly one email spawn, no in-session gate', async () => {
+    const sb = makeSupabase({ briefData: { title: 'Adam needs a call' } });
+    const spawn = vi.fn();
+    const r = await recordPendingDecision(sb, { title: 'Adam needs a call', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: spawn });
+    expect(r.recorded).toBe(true);
+    expect(r.escalated).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-adam record does NOT fire the email', async () => {
+    const sb = makeSupabase({ briefData: { title: 'routine' } });
+    const spawn = vi.fn();
+    const r = await recordPendingDecision(sb, { title: 'routine', raisedBy: 'coordinator', decisionType: 'session_question', _spawnEscalation: spawn });
+    expect(r.recorded).toBe(true);
+    expect(r.escalated).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('persists raised_by in brief_data for escalation provenance', async () => {
+    // The insert path builds brief_data with raised_by; assert recordPendingDecision still records.
+    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const r = await recordPendingDecision(sb, { title: 'q', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: vi.fn() });
+    expect(r.recorded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Makes Adam's standout `[ACTION NEEDED - ADAM]` chairman-escalation email **deterministic** — it now fires immediately when an Adam session_question/blocking decision is recorded, instead of waiting for the hourly cron or an in-session judgment call (which could leave a blocking question unsent).

## Changes (lib/chairman/record-pending-decision.mjs)
- **`shouldAutoEscalate({decisionType, blocking, raisedBy})`** — pure structural predicate, true only for `raisedBy='adam'` AND (`session_question` OR `blocking`). **No** in-session/chairman-availability input → deterministic and testable.
- **`escalateChairmanDecision(supabase, id, {spawn})`** — fires the standout email once (dedup on `brief_data.escalation_email_sent_at`), stamps the marker, fail-soft. Fire-and-forget detached spawn of `adam-exec-summary.mjs --force` so it never blocks the caller.
- **`recordPendingDecision`** — new `raisedBy` param (persisted as `brief_data.raised_by`); after a successful insert, escalates immediately when the predicate is true, **never failing the durable record** on an email error. The timeout watchdog is the existing `checkAndEscalateTimeouts` poller (recording the pending row arms it — no new daemon). `lifecycle_stage`/title flow through so the subject is informative, not the masked Stage 0 default.

## Scope note
The email body/subject logic is unchanged — only the **trigger** becomes deterministic. Strictly scoped to genuine Adam escalations, so routine decisions and email volume are unaffected.

## Test plan
- `record-pending-decision-escalation.test.js` → 11 passed (predicate truth table, deterministic send, dedup, fail-soft, non-adam no-fire)
- No existing tests/callers regress (the new `escalated` return field is additive; existing callers pass no `raisedBy` so nothing fires)

SD: SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 · relates to QF-20260627-338

🤖 Generated with [Claude Code](https://claude.com/claude-code)