### PR TITLE
fix(SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001): S5 financial gate recognizes truth_financial_model

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001.json
@@ -1,0 +1,98 @@
+{
+  "executive_summary": "The S5->S6 financial-viability exit gate (validateFinancialViabilityGate in lib/agents/modules/venture-state-machine/stage-gates.js) structurally fails at S5 because it checks ONLY two FUTURE-stage artifacts — engine_pricing_model (produced at S7) and engine_business_model_canvas (S8). At S5 neither exists yet, so passedChecks=0 and the gate returns passed=false, blocking a venture that legitimately has its S5 financial artifact (truth_financial_model). This SD adds recognition of the S5-appropriate truth_financial_model artifact so the gate passes when it (or any future artifact) is present, and fails only when NO financial artifact of any kind exists — honoring the gate's stated lenient intent. Backend gate change + unit tests; no UI. A sibling-gate sweep confirms the bug is isolated to the financial gate (validateUATSignoffGate and validateDeploymentHealthGate check stage-appropriate artifacts).",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Recognize the S5 truth_financial_model artifact as a passing check",
+      "description": "In validateFinancialViabilityGate (lib/agents/modules/venture-state-machine/stage-gates.js ~880-952), add a check that queries venture_artifacts for ARTIFACT_TYPES.TRUTH_FINANCIAL_MODEL (is_current=true, no lifecycle_stage filter, newest first) and pushes a passing check when present. The pass predicate must be: gate passes if the S5 truth_financial_model exists OR any future-stage artifact (engine_pricing_model / engine_business_model_canvas) exists; it fails ONLY when NO financial artifact of any kind exists. Preserve the existing lenient behavior (future-stage artifacts still count when present) and the revenue-streams sub-check on the pricing artifact. Use the already-imported ARTIFACT_TYPES constant.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Gate queries venture_artifacts for truth_financial_model and records a passing check when present",
+        "Venture at S5 with truth_financial_model and no future artifacts -> gate.passed === true",
+        "Venture with no financial artifact of any kind -> gate.passed === false",
+        "Venture with future-stage artifacts present -> gate.passed === true (lenient intent preserved)",
+        "Gate details message reflects which artifact(s) satisfied the gate"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Unit tests for the three guardrail states",
+      "description": "Add unit tests (extend tests/unit/stage-gates-ext.test.js or a new sibling) that mock the supabase venture_artifacts query and assert validateFinancialViabilityGate across: (a) S5 truth_financial_model only -> PASS; (b) no financial artifact at all -> FAIL; (c) future-stage engine_pricing_model/engine_business_model_canvas present -> PASS. Tests must run under the existing unit runner.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Test asserts PASS for truth_financial_model-only at S5",
+        "Test asserts FAIL when no financial artifact exists",
+        "Test asserts PASS when future-stage artifacts are present",
+        "All new tests green"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Regression confirmation + isolated-scope sibling-gate sweep",
+      "description": "Confirm via the code whether the future-stage-only checks were a regression (the CronPulse RCA #2B comment shows the gate was already aware S7/S8 artifacts don't exist at S5 but never added the S5 artifact). Sweep the other exit-gate validators in stage-gates.js (validateUATSignoffGate S22->23, validateDeploymentHealthGate) for the same future-stage-artifact-check class. Document the finding: the bug is ISOLATED to the financial gate (the UAT and deployment gates check stage-appropriate artifacts), so no sibling fix is required.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "Sweep result documented: bug isolated to validateFinancialViabilityGate",
+        "No other gate found checking only future-stage artifacts"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Single-file gate change, additive",
+      "description": "Change confined to lib/agents/modules/venture-state-machine/stage-gates.js (the financial gate function) plus a unit test file. No schema change, no UI. Reuse the already-imported ARTIFACT_TYPES."
+    },
+    {
+      "id": "TR-2",
+      "title": "No decomposition required",
+      "description": "Although the SD noted 'decompose-at-PLAN', the fix is a ~20-30 LOC single-gate change with tests; an orchestrator/children split would add overhead without value. Built as a single SD."
+    }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "S5 truth_financial_model only", "type": "unit", "expected": "gate.passed === true" },
+    { "id": "TS-2", "scenario": "No financial artifact at all", "type": "unit", "expected": "gate.passed === false, message 'No financial artifacts found'" },
+    { "id": "TS-3", "scenario": "Future-stage artifacts present", "type": "unit", "expected": "gate.passed === true" }
+  ],
+  "acceptance_criteria": [
+    "S5 financial-viability gate passes for a venture with a valid truth_financial_model and no future-stage artifacts",
+    "Gate still fails when no financial artifact exists and still passes when future artifacts are present",
+    "Unit tests cover all three states; sibling-gate sweep documented as isolated"
+  ],
+  "risks": [
+    {
+      "risk": "Loosening the gate could let a venture with a malformed/empty truth_financial_model pass",
+      "mitigation": "The gate's existing revenue-streams sub-check on the pricing artifact is preserved; truth_financial_model presence + is_current is the S5-appropriate bar (deeper financial validation is the golden-nugget validator's job, not this advance gate). The FAIL-when-empty case is explicitly tested.",
+      "severity": "low"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": ["validateStageGate (stage-gates.js) — the S5->S6 advance path", "EVA venture-state-machine stage advance"],
+    "dependencies": ["lib/eva/artifact-types.js (ARTIFACT_TYPES.TRUTH_FINANCIAL_MODEL)", "venture_artifacts table"],
+    "data_contracts": ["venture_artifacts (read-only: truth_financial_model / engine_pricing_model / engine_business_model_canvas)"],
+    "runtime_config": ["none"],
+    "observability_rollout": ["gate.checks[] now includes a truth_financial_model_exists entry; unit tests in CI prove the three states"]
+  },
+  "system_architecture": {
+    "summary": "Add the S5 financial artifact to the financial-viability gate's check set and broaden the pass predicate to any-financial-artifact-present.",
+    "components": [
+      { "name": "lib/agents/modules/venture-state-machine/stage-gates.js", "change": "add truth_financial_model check + broaden pass predicate in validateFinancialViabilityGate" },
+      { "name": "tests/unit/stage-gates-ext.test.js", "change": "add 3 financial-gate state tests" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Single-gate fix + tests; no schema/UI.",
+    "steps": [
+      "Add a truth_financial_model query+check to validateFinancialViabilityGate",
+      "Broaden pass predicate: pass if S5 artifact OR any future artifact; fail only if none",
+      "Add the 3-state unit tests",
+      "Run sibling-gate sweep, document isolation"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run validateFinancialViabilityGate for a venture at S5 with a truth_financial_model artifact and NO future-stage artifacts", "expected_outcome": "gate.passed === true — S5 financial artifact satisfies the gate" },
+    { "step_number": 2, "instruction": "Run the gate for a venture with NO financial artifact of any kind", "expected_outcome": "gate.passed === false with message 'No financial artifacts found'" },
+    { "step_number": 3, "instruction": "Run the gate for a venture with engine_pricing_model / engine_business_model_canvas present", "expected_outcome": "gate.passed === true — future artifacts still count when present" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001" }
+}

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-D",
-  "expectedBranch": "feat/SD-LEO-INFRA-VENTURE-CLOUDFLARE-DEFAULT-001-D",
-  "createdAt": "2026-06-27T16:56:58.651Z",
+  "sdKey": "SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001",
+  "createdAt": "2026-06-28T02:39:30.528Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -887,6 +887,29 @@ async function validateFinancialViabilityGate(supabase, ventureId) {
     details: {}
   };
 
+  // Check 0: S5-appropriate financial artifact exists (truth_financial_model).
+  // SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001: the gate runs at
+  // S5→S6 but previously checked ONLY future-stage artifacts (engine_pricing_model
+  // S7 / engine_business_model_canvas S8), so a venture at S5 with a valid
+  // truth_financial_model (the S5 artifact) structurally failed. Recognize the
+  // S5 artifact so its presence passes the gate; future-stage artifacts still
+  // count when present, and the gate fails ONLY when NO financial artifact exists.
+  const { data: financialModelArtifact, error: financialModelError } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_data, created_at')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', ARTIFACT_TYPES.TRUTH_FINANCIAL_MODEL)
+    .eq('is_current', true)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (financialModelError || !financialModelArtifact) {
+    gateResult.checks.push({ check: 'financial_model_exists', passed: false, reason: 'No S5 financial model (truth_financial_model) artifact found' });
+  } else {
+    gateResult.checks.push({ check: 'financial_model_exists', passed: true });
+  }
+
   // Check 1: pricing_model artifact exists
   // CronPulse RCA #2B: Gate runs at S5→S6 but S7/S8 artifacts don't exist yet.
   // Query without lifecycle_stage filter — these artifacts may be created at any stage.
@@ -938,16 +961,18 @@ async function validateFinancialViabilityGate(supabase, ventureId) {
     }
   }
 
-  // Pass if at least one core artifact exists (don't block on future-stage artifacts)
+  // Pass if at least one financial artifact exists — the S5 truth_financial_model
+  // OR a future-stage artifact (pricing/BMC). Fail ONLY when none exist.
   const passedChecks = gateResult.checks.filter(c => c.passed).length;
   gateResult.passed = passedChecks > 0;
   gateResult.details = {
+    financial_model_artifact_date: financialModelArtifact?.created_at || null,
     pricing_artifact_date: pricingArtifact?.created_at || null,
     bmc_artifact_date: bmcArtifact?.created_at || null,
     message: gateResult.passed ? 'Financial viability gate passed' : 'No financial artifacts found'
   };
 
-  console.log('   Financial Viability Gate PASSED');
+  console.log(`   Financial Viability Gate ${gateResult.passed ? 'PASSED' : 'FAILED'}`);
   return gateResult;
 }
 

--- a/tests/unit/stage-gates-ext.test.js
+++ b/tests/unit/stage-gates-ext.test.js
@@ -665,8 +665,59 @@ describe('Existing Gate Preservation (FR-4)', () => {
     const result = await validateFinancialViabilityGate(supabase, 'v1');
     expect(result.passed).toBe(false);
     expect(result.gate_name).toBe('FINANCIAL_VIABILITY');
-    expect(result.checks[0].check).toBe('pricing_model_exists');
+    // SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001: the first check is
+    // now the S5-appropriate financial_model_exists (truth_financial_model).
+    expect(result.checks[0].check).toBe('financial_model_exists');
     expect(result.checks[0].passed).toBe(false);
+  });
+
+  // SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001: the S5 financial gate
+  // must pass on the S5 truth_financial_model alone (not require S7/S8 artifacts),
+  // still pass when future-stage artifacts are present, and fail only when NO
+  // financial artifact exists. Build a venture_artifacts mock that resolves
+  // per artifact_type via the .eq('artifact_type', T) filter.
+  function financialArtifactsMock(present) {
+    return {
+      venture_artifacts: {
+        _type: null,
+        select() { return this; },
+        eq(col, val) { if (col === 'artifact_type') this._type = val; return this; },
+        order() { return this; },
+        limit() { return this; },
+        maybeSingle() {
+          const has = present.includes(this._type);
+          this._type = null;
+          return Promise.resolve({
+            data: has ? { artifact_data: { revenueStreams: [{ name: 'r1' }] }, created_at: '2026-01-01T00:00:00Z' } : null,
+            error: null,
+          });
+        },
+      },
+    };
+  }
+
+  it('Financial Viability Gate PASSES at S5 with only truth_financial_model (no future artifacts)', async () => {
+    const { validateFinancialViabilityGate } = _internal;
+    const supabase = createMockSupabase(financialArtifactsMock(['truth_financial_model']));
+    const result = await validateFinancialViabilityGate(supabase, 'v1');
+    expect(result.passed).toBe(true);
+    expect(result.checks.find(c => c.check === 'financial_model_exists')?.passed).toBe(true);
+  });
+
+  it('Financial Viability Gate FAILS when NO financial artifact of any kind exists', async () => {
+    const { validateFinancialViabilityGate } = _internal;
+    const supabase = createMockSupabase(financialArtifactsMock([]));
+    const result = await validateFinancialViabilityGate(supabase, 'v1');
+    expect(result.passed).toBe(false);
+    expect(result.details.message).toBe('No financial artifacts found');
+  });
+
+  it('Financial Viability Gate PASSES when future-stage artifacts are present (lenient intent preserved)', async () => {
+    const { validateFinancialViabilityGate } = _internal;
+    const supabase = createMockSupabase(financialArtifactsMock(['engine_pricing_model', 'engine_business_model_canvas']));
+    const result = await validateFinancialViabilityGate(supabase, 'v1');
+    expect(result.passed).toBe(true);
+    expect(result.checks.find(c => c.check === 'pricing_model_exists')?.passed).toBe(true);
   });
 
   it('UAT Signoff Gate returns correct structure on missing artifact', async () => {


### PR DESCRIPTION
## SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001 — S5 financial gate recognizes the S5 artifact

### Bug
`validateFinancialViabilityGate` (the S5→S6 financial-viability exit gate, `lib/agents/modules/venture-state-machine/stage-gates.js`) checked **only** future-stage artifacts — `engine_pricing_model` (S7) and `engine_business_model_canvas` (S8). At S5 neither exists yet, so `passedChecks=0` → `passed=false`, **structurally failing** a venture that legitimately has its S5 financial artifact (`truth_financial_model`).

### Fix
- **FR-1** — added a `financial_model_exists` check for `truth_financial_model`. The gate now passes if the S5 artifact **or** any future-stage artifact is present, and fails **only** when no financial artifact of any kind exists. Lenient intent and the revenue-streams sub-check preserved. Also fixed a log line that unconditionally printed `PASSED`.
- **FR-2** — unit tests for the three states (S5-only → PASS, none → FAIL, future → PASS); updated the existing missing-artifact assertion (`checks[0]` is now `financial_model_exists`).
- **FR-3** — sibling-gate sweep: the future-stage-artifact-check bug is **isolated** to the financial gate (`validateUATSignoffGate` / `validateDeploymentHealthGate` check stage-appropriate artifacts).

### Verification
All three states verified via a standalone harness (ALL PASS). Vitest cases run in CI (the file is excluded only under `.worktrees`).

Single-file gate change + tests; no schema, no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
