### PR TITLE
feat(SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001): deterministic 3-gate execute-vs-escalate classifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 5e4a39c11b1d8ab3 -->
+<!-- file_content_hash: 3343600d3763a89e -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-23 2:23:35 AM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-06-28 10:59:48 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 1555d3f7e8db0433 -->
+<!-- file_content_hash: 677388743eb8b096 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-28 10:49:32 PM
+**Generated**: 2026-06-28 10:59:48 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: ebbcbbe6a12992f9 -->
+<!-- file_content_hash: 1555d3f7e8db0433 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-23 2:23:35 AM
+**Generated**: 2026-06-28 10:49:32 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -80,6 +80,39 @@
 - **LIVE STATE LIVES IN THE DB, NOT MEMORY (handoff rule)**: experiment arm state (e.g. effort-tier `metadata.arms_log`), open-watch lists, and queue state must be re-read LIVE at session start; memory files are point-in-time and go stale within hours on an active fleet. A fresh Adam asserting experiment/queue state from memory without a live DB read is a D4 (verify-before-certainty) failure.
 
 - **CHAIRMAN PHONE-NOTIFY (urgent action-items + decisions) — SD-LEO-INFRA-CHAIRMAN-NOTIFY-CAPABILITY-001**: Adam tracks chairman HUMAN action-items in `.adam-chairman-decisions.json` (surfaced in the hourly exec email NEEDS-YOU section) AND, for anything genuinely URGENT / time-critical, routes it to the chairman PHONE via the shared `notifyChairman({title, description, priority, dueDatetime?})` helper (`lib/integrations/todoist/chairman-notify.js`, or `npm run chairman:notify --title "..."`). The helper adds a Todoist task + an EXPLICIT verified v1 push reminder — the @doist SDK is BLIND to reminders (Sync-API-only), and dueDatetime / the `!` quick-add syntax attach 0 reminders and never push, so only the explicit `reminder_add` buzzes the phone. This is a phone-push LAYER on top of the coordinator decision-queue / `fn_chairman_decide`, NOT a replacement. Use it SPARINGLY (urgent only — never spam the chairman). The coordinator uses the SAME helper for urgent gate decisions; never re-implement the v1 `reminder_add` POST anywhere.
+
+## Blocked-claim escalation relay — Adam is the SECOND tier (chairman directive 2026-06-24)
+
+In the blocked-claim resolution chain (COORDINATOR -> ADAM -> CHAIRMAN) you are the second tier, not the first or last. The worker coordinates its block with the COORDINATOR, who does due diligence and decides/approves within its lane (e.g. approving a worker to apply a verified-additive migration). The coordinator escalates to YOU only when it genuinely cannot resolve the block (insufficient authority/information); you provide guidance/direction. Escalate to the CHAIRMAN only when YOU cannot resolve it. Do NOT accept a block the coordinator should own (operational / pre-authorized steps belong to the coordinator), and do NOT bypass yourself when something does need the chairman.
+
+Canonical SSOT: docs/protocol/fleet-coordinator-and-worker-behavior.md ("Blocked-claim resolution protocol").
+
+
+## Chairman escalation rubric — DECIDE-and-INFORM vs ESCALATE (chairman directive 2026-06-25)
+
+Adam is the chairman's escalation **filter**: the chairman interfaces only with Adam, so Adam's core function is to triage what actually reaches him. Adam's **default is decide-and-inform, NOT ask.** Over-asking is confirmation-fishing — the same failure CLAUDE.md's AUTO-PROCEED forbids ("when in doubt, pick the highest-value option, state it, and execute"). Before bringing ANY decision to the chairman, run the one-line test:
+
+> **Is the answer already determined — by something the chairman ratified, a standing authorization, the vision/strategy/mission, or memory? → DECIDE and INFORM. Is it a genuinely NEW policy call, a kill/major reserved gate, a ratified-deviation, or irreversible/external/high-blast-radius? → it COMES TO HIM.** Genuinely 50/50 **and** consequential → bring a recommendation **with a default Adam will execute unless the chairman objects** (decision-with-default, never an open question).
+
+**COMES TO THE CHAIRMAN:**
+- New **strategy/policy** not yet ratified (pricing philosophy, segment strategy, stack direction, risk tolerance, kill-gate policy, autonomy posture).
+- **Kill/major venture gates** (S3/S5/S10/S17/S18/S19) + any gate output that **deviates** from a ratified decision (the deviation-tripwire).
+- **Irreversible / external / real-money / high-blast-radius** actions (real brand name at launch, live Stripe, gov-flag flips, destructive ops).
+- A ratified decision that **proved wrong**, or two ratified decisions **in conflict**.
+
+**ADAM DECIDES + INFORMS (does NOT ask):**
+- Faithful **implementation** of an already-ratified decision (e.g. threading a ratified autonomy level into the factory-read field).
+- **Sourcing** gold root-fixes under the standing blocks-product cap (a DRAFT is a CONST-002-safe proposal).
+- **Reversible dispositions that preserve a future chairman decision** (defer, park, working-title).
+- Belt / queue / coordinator hygiene; verifying **green non-kill review gates**.
+- Anything the **vision/strategy/mission + a ratified decision + memory** already determine.
+
+Distinguish **serious** from **needs-his-decision**: a governance breach (e.g. a reserved gate auto-skipping) merits an **alert** (he must KNOW), but its remediation is usually already determined — *alert + decide*, don't ask. **USE MEMORY before asking** — the answer is often already there.
+
+**Solomon (future):** when the Fable-based Solomon oracle ships (pre-work parked until Fable), Solomon becomes Adam's first consult for the genuinely-50/50-and-consequential tier (the reasoning-depth axis) — deepening what Adam decides for itself and shrinking what reaches the chairman further. This rubric is the interim filter until Solomon is the reasoning aid.
+
+(Chairman-directed 2026-06-25. Enforcement probe tracked as SD-LEO-INFRA-ADAM-DECISION-RUBRIC-ENFORCE-001 so the self-adherence loop auto-flags over-asking, not just documents the rule.)
+
 
 ## SOURCING SSOT — order of operations
 
@@ -169,6 +202,18 @@ Sourcing is not finished when a candidate clears the bar — it is finished when
 - **Advancement**: a DRAFT SD advances through the per-SD LEAD Pre-Approval Gate when **any self-claiming worker** runs `node scripts/handoff.js execute LEAD-TO-PLAN <key>`, ordered by the coordinator's `metadata.dispatch_rank` — there is no dedicated "LEAD-role" worker. Adam-sourced vision-loop drafts (`metadata.source='proposal'` + a `roadmap_phase`) get a dispatch-rank nudge so the gauge-driven / weakest-capability work reaches a worker sooner (`scripts/coordinator-backlog-rank.mjs`).
 - **Escalation (the dispatch gap)**: a scored, UNCLAIMED Adam vision draft that ages at `current_phase='LEAD'` past the threshold is surfaced by the coordinator charter-audit **DUTY-9 LEAD-AGING** detector (`lib/coordinator/lead-aging-detector.mjs`) with a re-rank/dispatch remediation — so a sourced draft never parks indefinitely between "Adam sourced it" and "a worker advanced it". It is DISJOINT from DUTY-7 (unscored silent-stall) and DUTY-8 (claimed progress-stall).
 
+### Decision Rubric — Execute vs Escalate (canonical 3-gate)
+
+Before ANY chairman-ask, Adam runs the deterministic 3-gate classifier (canonical impl: `lib/adam/execute-vs-escalate.js` `classifyDecision`; SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001):
+
+> **EXECUTE-AND-REPORT iff (reversible AND in-role AND NOT flagship/governance/data-loss); otherwise ESCALATE to the chairman.**
+
+- **Gate 1 — reversible**: the action can be cleanly undone. CONSERVATIVE: if reversibility is UNCERTAIN, treat it as NOT reversible → escalate.
+- **Gate 2 — in-role**: the decision is within Adam’s standing authority (CONST-002 propose-only). Uncertain role → escalate.
+- **Gate 3 — NOT flagship / governance / data-loss**: not a flagship/irreversible venture op, not new strategy/policy or a reserved kill/major gate or a ratified-decision deviation, and not a destructive/data-loss mutation. Any of these → escalate.
+
+It guards two opposed failure modes, both probed by the self-adherence review (`scripts/adam-self-adherence-review.mjs`, probe `decision_rubric`): **over-ask** (Adam asked when the rubric says execute) and **under-escalate** (Adam executed when the rubric says escalate). The over-ask text-classifier (`classifyDecisionQuestion`) routes its verdict through `classifyDecision` so the 3-gate rubric is the single authority.
+
 ## Adam Self-Adherence Loop (recurring audit + propose-only remediation)
 
 ## Adam Self-Adherence Loop (SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001)
@@ -203,6 +248,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-06-23*
+*Generated from database: 2026-06-28*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: a27f1c430819e661 -->
+<!-- file_content_hash: 1495690934452e60 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 3e6625172bb00b48 -->
+<!-- file_content_hash: 8c6acb75da5dee81 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-23 2:23:35 AM
+**Generated**: 2026-06-28 10:59:48 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -48,6 +48,15 @@ Operating a fleet of *AI agents* (not humans) requires supervisor-process duties
 
 **Relationship to sibling SDs (complementary, no duplication):** this charter is the **ongoing-operations** duty set. The one-time **startup ritual** is SD-LEO-INFRA-COORDINATOR-STARTUP-ONBOARDING-001; **self-sustaining loop-wake** is SD-LEO-INFRA-FLEET-WAKE-UNDER-001; the **worktree pool watchdog mechanics** live in SD-MAN-INFRA-COORDINATOR-WORKTREE-POOL-001 (this charter only references it).
 
+## Blocked-claim resolution — the coordinator OWNS resolving worker blocks (chairman directive 2026-06-24)
+
+When a worker signals a BLOCKED claim (a dependency / credential / gate / migration step it cannot self-complete), the worker STAYS on that SD and coordinates with YOU — it does NOT hop to a different SD. You own resolving the block:
+1. DUE DILIGENCE FIRST — read the PR / migration SQL / gate output / dependency state yourself; gather whatever you need.
+2. DECIDE + APPROVE within your lane — tell the worker how to proceed and give EXPLICIT approval. For a MIGRATION: verify it is safe — e.g. purely ADDITIVE (CREATE-only; no ALTER/DROP/data-mutation of existing objects) — then APPROVE the worker to apply it themselves. The worker applies WITH your sign-off; you never blind-approve without the read, and you do NOT apply a prod migration yourself in the worker place.
+3. ESCALATE ONLY what you genuinely cannot resolve, and via the chain COORDINATOR -> ADAM -> CHAIRMAN. Never skip to the chairman: a pre-authorized / operational step (e.g. an additive migration) is YOURS to approve after due diligence, not a chairman question. The chairman is the last resort, reached only through Adam.
+
+Canonical SSOT: docs/protocol/fleet-coordinator-and-worker-behavior.md ("Blocked-claim resolution protocol"). Worker side: fleet-worker-loop-directive.md loop-rule 4b. Adam relay: adam_role_contract.
+
 ## Coordinator → Adam comms MUST be typed (payload.kind) — untyped is silently skipped
 
 ## Coordinator → Adam messages MUST carry a recognized payload.kind
@@ -68,6 +77,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-06-23*
+*Generated from database: 2026-06-28*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 06043575f86efefc -->
+<!-- file_content_hash: 3e492bb8ed5d7024 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 783c89f1541719a0 -->
+<!-- file_content_hash: 363d88b8419e9305 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-23 2:23:35 AM
+**Generated**: 2026-06-28 10:59:48 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1280,6 +1280,8 @@ For SQL migrations, use the Supabase CLI or dashboard SQL editor:
 
 The WORKER analog of CLAUDE.md "Canonical Pause Points — THE ONLY REASONS TO STOP". An autonomous fleet worker in a /loop must NEVER exit prematurely: the enumerated stops below are the ONLY legitimate exits; every other condition re-arms a ScheduleWakeup and re-enters the loop.
 
+**THE LOOP'S UNIT IS ONE COMPLETE WORK ITEM** — an SD driven through ALL its handoffs (LEAD→PLAN→EXEC→PLAN_VERIFICATION→LEAD_FINAL) to completion, OR a quick fix worked to completion — NEVER a single handoff or phase. Under AUTO-PROCEED you flow from each handoff straight into the next IN THE SAME TURN: a phase boundary is NOT an iteration boundary and is NOT a pause point. The "re-arm a ScheduleWakeup" rule governs the boundary BETWEEN iterations (item complete / blocked claim / genuine idle / waiting on an external event such as CI or a coordinator reply) — it does NOT apply BETWEEN the handoffs of an active item. Do NOT arm a ScheduleWakeup, and do NOT end your turn, while you hold a claimed item with an immediately-actionable next handoff. ScheduleWakeup is an idle/wait mechanism, never a pacing mechanism for active work.
+
 **THE ONLY legitimate stops (the allow-path):**
 1. The operator tells you to stop / wind down.
 2. A canonical pause point is reached.
@@ -1287,8 +1289,8 @@ The WORKER analog of CLAUDE.md "Canonical Pause Points — THE ONLY REASONS TO S
 
 **Every other condition is a CONTINUE — re-arm a ScheduleWakeup and re-run the loop. Four enforced exit-modes:**
 - **(4a) Post-ship**: you just shipped an SD → /signal a fleet-retro → /checkin → claim the next workable SD (READY > EXEC > PLANNING > DRAFT) in the SAME turn. Shipping is the START of the next iteration, not the end of the loop (the #1 wrong-stop).
-- **(4b) Blocked claim**: your SD hit a chairman gate/blocker while unblocked belt work exists → build what IS buildable, /signal the specific blocker, PARK that SD (push WIP), and claim a DIFFERENT unblocked SD. Never idle holding a blocked claim.
-- **(4c) No wind-down handshake**: never exit silently → /signal feedback "winding down — finished <SD>, anything queued? idling ~180s", arm a SHORT (~180s) grace ScheduleWakeup, re-check the inbox on that tick, THEN settle into the ~1200s idle cadence.
+- **(4b) Blocked claim**: your SD hit a chairman gate/blocker while unblocked belt work exists → STAY on that SD, park WIP (push the branch + set metadata.blocker.status), /signal the specific blocker, and COORDINATE with the coordinator to RESOLVE the block (via /signal, re-poll session_coordination by correlation_id on each wakeup; the bare two-way request lane has no coordinator inbox surface yet, so use /signal until that ships) — do NOT hop to a different SD. The coordinator does due diligence, then decides + approves how you proceed; for a migration you MAY apply it yourself ONLY after explicit coordinator sign-off (never self-apply a prod migration without it). Never idle silently. Escalation runs Coordinator -> Adam -> chairman. (chairman directive 2026-06-24; canonical: docs/protocol/fleet-coordinator-and-worker-behavior.md "Blocked-claim resolution protocol".)
+- **(4c) No wind-down handshake**: never exit silently → /signal feedback "winding down — finished <SD>, anything queued? idling ~180s", arm a SHORT (~180s) grace ScheduleWakeup, re-check the inbox on that tick, THEN settle into the ~300s idle cadence.
 - **(4d) Transient error**: a connectivity/API/tool blip is NOT a stop → re-arm a ScheduleWakeup and resume (retry ≤2, then invoke the RCA sub-agent). Never treat a transient error as terminal.
 
 **ENFORCEMENT (the teeth):** the Stop hook `scripts/hooks/stop-loop-wakeup-reminder.cjs` BLOCKS a premature stop (emits `{decision:"block"}` + re-prompts you to push WIP and arm a wakeup) UNLESS you took the allow-path (operator-stop / canonical pause point / an announced /signal wind-down detected in session_coordination). Gated by `LEO_LOOP_WAKEUP_REMINDER`; fail-open + single-fire (blocks at most once per turn) so a legitimate stop is never trapped.
@@ -1678,7 +1680,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-23*
+*Generated from database: 2026-06-28*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 75d319a7a238c932 -->
+<!-- file_content_hash: 1a198a875cc5a592 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -100,7 +100,7 @@ Every sub-agent invocation MUST include these five elements:
 
 ## Friction signaling
 
-Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001. Questions/decisions → relay to the coordinator (never block on a human or decide unilaterally; it resolves or escalates upward).
 
 ## Global Negative Constraints
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-23 2:23:35 AM*
+*DIGEST generated: 2026-06-28 10:59:48 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 8b5f63b1ce8f0db3 -->
+<!-- file_content_hash: c851c936470e6132 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-23 2:23:35 AM*
+*DIGEST generated: 2026-06-28 10:59:48 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 5a89810fa3af7fdb -->
+<!-- file_content_hash: 979238366cf3fe79 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-23 2:23:35 AM
+**Generated**: 2026-06-28 10:59:48 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -49,6 +49,8 @@ Resolve root causes so they do not happen again in the future. Update processes,
 ## Friction signaling
 
 **Send `/signal <type> "<body>"`** for recurrence (gate 2× / RCA 2× / tool 3× / phase >2× type-bucket median), about-to-bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), protocol-spec friction, recognized harness bug, or memory-trend match. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Source-of-truth: CLAUDE_CORE.md "Signaling friction to the coordinator" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+
+**Questions or decisions → relay to the coordinator.** If you have any questions or decisions needed, relay those to the coordinator — do not block on a human or decide unilaterally. The coordinator resolves what it can and escalates anything beyond its authority upward.
 
 ## 🚨 EXEC Agent Implementation Requirements
 
@@ -1758,6 +1760,8 @@ See: `/runtime-audit` skill for full template
 
 The WORKER analog of CLAUDE.md "Canonical Pause Points — THE ONLY REASONS TO STOP". An autonomous fleet worker in a /loop must NEVER exit prematurely: the enumerated stops below are the ONLY legitimate exits; every other condition re-arms a ScheduleWakeup and re-enters the loop.
 
+**THE LOOP'S UNIT IS ONE COMPLETE WORK ITEM** — an SD driven through ALL its handoffs (LEAD→PLAN→EXEC→PLAN_VERIFICATION→LEAD_FINAL) to completion, OR a quick fix worked to completion — NEVER a single handoff or phase. Under AUTO-PROCEED you flow from each handoff straight into the next IN THE SAME TURN: a phase boundary is NOT an iteration boundary and is NOT a pause point. The "re-arm a ScheduleWakeup" rule governs the boundary BETWEEN iterations (item complete / blocked claim / genuine idle / waiting on an external event such as CI or a coordinator reply) — it does NOT apply BETWEEN the handoffs of an active item. Do NOT arm a ScheduleWakeup, and do NOT end your turn, while you hold a claimed item with an immediately-actionable next handoff. ScheduleWakeup is an idle/wait mechanism, never a pacing mechanism for active work.
+
 **THE ONLY legitimate stops (the allow-path):**
 1. The operator tells you to stop / wind down.
 2. A canonical pause point is reached.
@@ -1765,8 +1769,8 @@ The WORKER analog of CLAUDE.md "Canonical Pause Points — THE ONLY REASONS TO S
 
 **Every other condition is a CONTINUE — re-arm a ScheduleWakeup and re-run the loop. Four enforced exit-modes:**
 - **(4a) Post-ship**: you just shipped an SD → /signal a fleet-retro → /checkin → claim the next workable SD (READY > EXEC > PLANNING > DRAFT) in the SAME turn. Shipping is the START of the next iteration, not the end of the loop (the #1 wrong-stop).
-- **(4b) Blocked claim**: your SD hit a chairman gate/blocker while unblocked belt work exists → build what IS buildable, /signal the specific blocker, PARK that SD (push WIP), and claim a DIFFERENT unblocked SD. Never idle holding a blocked claim.
-- **(4c) No wind-down handshake**: never exit silently → /signal feedback "winding down — finished <SD>, anything queued? idling ~180s", arm a SHORT (~180s) grace ScheduleWakeup, re-check the inbox on that tick, THEN settle into the ~1200s idle cadence.
+- **(4b) Blocked claim**: your SD hit a chairman gate/blocker while unblocked belt work exists → STAY on that SD, park WIP (push the branch + set metadata.blocker.status), /signal the specific blocker, and COORDINATE with the coordinator to RESOLVE the block (via /signal, re-poll session_coordination by correlation_id on each wakeup; the bare two-way request lane has no coordinator inbox surface yet, so use /signal until that ships) — do NOT hop to a different SD. The coordinator does due diligence, then decides + approves how you proceed; for a migration you MAY apply it yourself ONLY after explicit coordinator sign-off (never self-apply a prod migration without it). Never idle silently. Escalation runs Coordinator -> Adam -> chairman. (chairman directive 2026-06-24; canonical: docs/protocol/fleet-coordinator-and-worker-behavior.md "Blocked-claim resolution protocol".)
+- **(4c) No wind-down handshake**: never exit silently → /signal feedback "winding down — finished <SD>, anything queued? idling ~180s", arm a SHORT (~180s) grace ScheduleWakeup, re-check the inbox on that tick, THEN settle into the ~300s idle cadence.
 - **(4d) Transient error**: a connectivity/API/tool blip is NOT a stop → re-arm a ScheduleWakeup and resume (retry ≤2, then invoke the RCA sub-agent). Never treat a transient error as terminal.
 
 **ENFORCEMENT (the teeth):** the Stop hook `scripts/hooks/stop-loop-wakeup-reminder.cjs` BLOCKS a premature stop (emits `{decision:"block"}` + re-prompts you to push WIP and arm a wakeup) UNLESS you took the allow-path (operator-stop / canonical pause point / an announced /signal wind-down detected in session_coordination). Gated by `LEO_LOOP_WAKEUP_REMINDER`; fail-open + single-fire (blocks at most once per turn) so a legitimate stop is never trapped.
@@ -2116,6 +2120,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-06-23*
+*Generated from database: 2026-06-28*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 6abe71635e798191 -->
+<!-- file_content_hash: f9b91c158573bd20 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -15,7 +15,7 @@
 
 ## Friction signaling
 
-Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001. Questions/decisions → relay to the coordinator (never block on a human or decide unilaterally; it resolves or escalates upward).
 
 ## 🚨 EXEC Agent Implementation Requirements
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-23 2:23:35 AM*
+*DIGEST generated: 2026-06-28 10:59:48 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: fe05b8f2e9668212 -->
+<!-- file_content_hash: 1f7f59d6e89a57c0 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-23 2:23:35 AM
+**Generated**: 2026-06-28 10:59:48 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -86,6 +86,8 @@ security, testing, performance, database, documentation, accessibility, code_qua
 ## Friction signaling
 
 **Send `/signal <type> "<body>"`** for recurrence (gate 2× / RCA 2× / tool 3× / phase >2× type-bucket median), about-to-bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), protocol-spec friction, recognized harness bug, or memory-trend match. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Source-of-truth: CLAUDE_CORE.md "Signaling friction to the coordinator" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+
+**Questions or decisions → relay to the coordinator.** If you have any questions or decisions needed, relay those to the coordinator — do not block on a human or decide unilaterally. The coordinator resolves what it can and escalates anything beyond its authority upward.
 
 ## 🔍 Explore Before Validation (LEAD Phase)
 
@@ -1582,6 +1584,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-23*
+*Generated from database: 2026-06-28*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: b2703af81bb83269 -->
+<!-- file_content_hash: 05d94bbb02978a54 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -15,7 +15,7 @@
 
 ## Friction signaling
 
-Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001. Questions/decisions → relay to the coordinator (never block on a human or decide unilaterally; it resolves or escalates upward).
 
 ## 6-Step SD Evaluation Checklist
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-23 2:23:35 AM*
+*DIGEST generated: 2026-06-28 10:59:48 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 821a7c82f2c58e6a -->
+<!-- file_content_hash: 2c6d619544c57250 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-23 2:23:35 AM
+**Generated**: 2026-06-28 10:59:48 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -141,6 +141,8 @@ Do NOT launch 3 agents for every task—that wastes time on simple decisions.
 ## Friction signaling
 
 **Send `/signal <type> "<body>"`** for recurrence (gate 2× / RCA 2× / tool 3× / phase >2× type-bucket median), about-to-bypass (`--no-verify` / 3rd-bypass-quota / mock-not-fix), protocol-spec friction, recognized harness bug, or memory-trend match. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Source-of-truth: CLAUDE_CORE.md "Signaling friction to the coordinator" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a.
+
+**Questions or decisions → relay to the coordinator.** If you have any questions or decisions needed, relay those to the coordinator — do not block on a human or decide unilaterally. The coordinator resolves what it can and escalates anything beyond its authority upward.
 
 ## Branch Creation (Automated at LEAD-TO-PLAN)
 
@@ -2441,6 +2443,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-23*
+*Generated from database: 2026-06-28*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-23T06:23:35.319Z -->
-<!-- git_commit: edb8b1ea -->
+<!-- generated_at: 2026-06-28T02:59:48.751Z -->
+<!-- git_commit: 4a9d6c8b -->
 <!-- db_snapshot_hash: 5ac65ccd27ca615f -->
-<!-- file_content_hash: 3e430d913959dc0c -->
+<!-- file_content_hash: 1648bf14f8ccf757 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -15,7 +15,7 @@
 
 ## Friction signaling
 
-Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
+Recurrence / about-to-bypass / spec friction / harness bug / memory-trend → `/signal <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. CLAUDE_CORE.md "Signaling friction" / SD-LEO-INFRA-TWO-WAY-COORDINATOR-001. Questions/decisions → relay to the coordinator (never block on a human or decide unilaterally; it resolves or escalates upward).
 
 ## PLAN Phase Negative Constraints
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-23 2:23:35 AM*
+*DIGEST generated: 2026-06-28 10:59:48 PM*
 *Protocol: 4.4.1*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,109 +1,109 @@
 {
-  "generated_at": "2026-06-23T06:23:35.319Z",
-  "git_commit": "edb8b1ea",
+  "generated_at": "2026-06-28T02:59:48.751Z",
+  "git_commit": "4a9d6c8b",
   "db_snapshot_hash": "5ac65ccd27ca615f",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 19368,
-      "estimated_tokens": 4842,
-      "content_hash": "e634b191bbcec3e3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE.md"
+      "chars": 19369,
+      "estimated_tokens": 4843,
+      "content_hash": "adb936bc22f44c8c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 83518,
-      "estimated_tokens": 20880,
-      "content_hash": "2e233e5e33d27b6e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_CORE.md"
+      "chars": 84991,
+      "estimated_tokens": 21248,
+      "content_hash": "e967f71783d34eb7",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 65128,
-      "estimated_tokens": 16282,
-      "content_hash": "8e9914ed56ca48ee",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_LEAD.md"
+      "chars": 65402,
+      "estimated_tokens": 16351,
+      "content_hash": "4cfb27a026a362f7",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 90830,
-      "estimated_tokens": 22708,
-      "content_hash": "6a02a534deccaeae",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_PLAN.md"
+      "chars": 91104,
+      "estimated_tokens": 22776,
+      "content_hash": "f6fe37e99c4b8554",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 84821,
-      "estimated_tokens": 21206,
-      "content_hash": "1b0cfa94e766095a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_EXEC.md"
+      "chars": 86567,
+      "estimated_tokens": 21642,
+      "content_hash": "149f9ffa7776cc7c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 43574,
-      "estimated_tokens": 10894,
-      "content_hash": "8efab0f6cf5c310b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_ADAM.md"
+      "chars": 48788,
+      "estimated_tokens": 12197,
+      "content_hash": "0936bbebaf2818ca",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 19523,
-      "estimated_tokens": 4881,
-      "content_hash": "7f8c07947b5c334b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_COORDINATOR.md"
+      "chars": 20930,
+      "estimated_tokens": 5233,
+      "content_hash": "b0b8dc4bc4c28caf",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 9611,
+      "chars": 9612,
       "estimated_tokens": 2403,
-      "content_hash": "4eb2f97a6bec33f4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_DIGEST.md"
+      "content_hash": "0ecfbd0c1adb25bf",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 11535,
-      "estimated_tokens": 2884,
-      "content_hash": "0f4954cd17c054a2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_CORE_DIGEST.md"
+      "chars": 11665,
+      "estimated_tokens": 2917,
+      "content_hash": "73d42face7c36a4f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 5422,
-      "estimated_tokens": 1356,
-      "content_hash": "83381b2416ce2ebf",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_LEAD_DIGEST.md"
+      "chars": 5552,
+      "estimated_tokens": 1388,
+      "content_hash": "26551c97d0b1ad1a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 8412,
-      "estimated_tokens": 2103,
-      "content_hash": "f275dbda594507e6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_PLAN_DIGEST.md"
+      "chars": 8542,
+      "estimated_tokens": 2136,
+      "content_hash": "d6496bce87228249",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 10835,
-      "estimated_tokens": 2709,
-      "content_hash": "40ff20f1aacaf4f1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_EXEC_DIGEST.md"
+      "chars": 10965,
+      "estimated_tokens": 2742,
+      "content_hash": "61ed9aca0b86c3b5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "664f1f243c171ce4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "50db89aafb13ea0b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 5270,
       "estimated_tokens": 1318,
-      "content_hash": "b9ec760bae0d7d74",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-REFILL-00A3H5FN\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "ba702735fb9537f7",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001\\CLAUDE_COORDINATOR_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "44bd4d5b81deb655",
+    "global": "2eea516afe62b4c5",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -354,14 +354,14 @@
       "593": "5aa3c836ecc1752c",
       "594": "ac4c90927e1cff29",
       "595": "b99d7c14d039c4be",
-      "596": "bf95e6419e99aee7",
-      "597": "8220a84f943767a6",
+      "596": "0251044882a17550",
+      "597": "ca5efc991922f3b8",
       "599": "7ddd3e2178799aa8",
-      "601": "24938018ba30efd6",
+      "601": "dfd9cf3b3baa2531",
       "602": "ad0aecae8cdc6cb3",
-      "603": "ca922c736e8d8ed3",
-      "604": "afa021c204fc90e4",
-      "605": "17f0a232fa1fada1",
+      "603": "ea1eddc2cef94c83",
+      "604": "a35e66b64599f81d",
+      "605": "a2c192531833423f",
       "606": "25aa68b575c66d07",
       "607": "82e04c0cc0ffb28f",
       "608": "7f99a4321502367e",

--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -15,6 +15,12 @@
  */
 'use strict';
 
+// SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001: the canonical deterministic
+// 3-gate execute-vs-escalate authority. The over-ask text-classifier below derives the
+// structured gates from its signal set and routes its verdict through classifyDecision,
+// so there is a single source of truth for "Adam's to take vs the chairman's".
+import { classifyDecision, gatesFromSignals, VERDICT as DECISION_VERDICT } from './execute-vs-escalate.js';
+
 const VERDICT = Object.freeze({ PASS: 'pass', FAIL: 'fail', UNKNOWN: 'unknown' });
 
 /** A resolved fact is "unresolved" when it is null or undefined (resolver failed / no data). */
@@ -204,8 +210,13 @@ export function classifyDecisionQuestion(body) {
   const escalationWarranted = trigger !== null;
   const alreadyDetermined = ADAM_DECIDES.test(text);
   const proximate = isDecisionQuestion && alreadyDetermined && within(text, DECISION_ASK, ADAM_DECIDES, OVER_ASK_PROXIMITY_CHARS);
-  const overAsk = !escalationWarranted && proximate;
-  return { isDecisionQuestion, escalationWarranted, trigger, alreadyDetermined, overAsk };
+  // SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001: route the execute/escalate
+  // judgment through the canonical deterministic 3-gate classifier. The over-ask SHAPE
+  // (a stated default sitting proximate to a decision-ask) is still required; the SHAPE is
+  // only an over-ask when the 3-gate rubric says the decision was Adam's to EXECUTE.
+  const decision = classifyDecision(gatesFromSignals({ trigger, alreadyDetermined }));
+  const overAsk = proximate && decision.verdict === DECISION_VERDICT.EXECUTE;
+  return { isDecisionQuestion, escalationWarranted, trigger, alreadyDetermined, overAsk, decision };
 }
 
 /**

--- a/lib/adam/execute-vs-escalate.js
+++ b/lib/adam/execute-vs-escalate.js
@@ -1,0 +1,114 @@
+/**
+ * Adam execute-vs-escalate classifier — SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001
+ *
+ * The canonical, deterministic 3-gate decision rubric Adam runs BEFORE any
+ * chairman-ask (CLAUDE_ADAM.md decision_rubric, CONST-002 boundary):
+ *
+ *   EXECUTE-AND-REPORT  iff  (reversible AND in-role AND NOT flagship/governance/data-loss)
+ *   otherwise           ->   ESCALATE to the chairman
+ *
+ * CONSERVATIVE by construction: when reversibility or in-role is UNCERTAIN
+ * (null/undefined), the gate fails and the decision escalates — "if you are not
+ * sure it is reversible, treat it as not reversible". flagship / governance /
+ * data-loss escalate only on an explicit true (they default to absent), so an
+ * unknown blast-radius gate never fabricates a flag.
+ *
+ * It guards two opposed failure modes:
+ *   - OVER-ASK:        Adam asked the chairman when the rubric says EXECUTE.
+ *   - UNDER-ESCALATE:  Adam executed when the rubric says ESCALATE.
+ *
+ * Pure + deterministic + no I/O.
+ *
+ * @module lib/adam/execute-vs-escalate
+ */
+
+export const VERDICT = Object.freeze({ EXECUTE: 'execute', ESCALATE: 'escalate' });
+
+/** The three gates, in evaluation order. */
+export const GATES = Object.freeze(['reversible', 'inRole', 'blastRadius']);
+
+/**
+ * Classify a decision as execute-and-report vs escalate.
+ *
+ * @param {Object} input
+ * @param {boolean|null} [input.reversible]  - true only if the action can be cleanly undone. null/undefined = uncertain => escalate.
+ * @param {boolean|null} [input.inRole]      - true only if the decision is within Adam's standing authority. null/undefined = uncertain => escalate.
+ * @param {boolean} [input.flagship]         - true if it touches a flagship/irreversible venture op.
+ * @param {boolean} [input.governance]       - true if it is a new strategy/policy, a reserved kill/major gate, or a ratified-decision deviation.
+ * @param {boolean} [input.dataLoss]         - true if it risks data loss / destructive mutation.
+ * @returns {{ verdict: string, reasons: string[], gates: Object }}
+ *   verdict ∈ VERDICT. reasons[] names each FAILED gate. gates echoes the resolved inputs.
+ */
+export function classifyDecision(input = {}) {
+  const { reversible, inRole, flagship = false, governance = false, dataLoss = false } = input;
+  const reasons = [];
+
+  // Gate 1 — reversible (conservative on uncertainty)
+  if (reversible !== true) {
+    reasons.push(reversible === false ? 'irreversible' : 'reversibility-uncertain');
+  }
+  // Gate 2 — in-role (conservative on uncertainty)
+  if (inRole !== true) {
+    reasons.push(inRole === false ? 'out-of-role' : 'role-uncertain');
+  }
+  // Gate 3 — NOT flagship/governance/data-loss (explicit-true only)
+  if (flagship === true) reasons.push('flagship');
+  if (governance === true) reasons.push('governance');
+  if (dataLoss === true) reasons.push('data-loss');
+
+  return {
+    verdict: reasons.length ? VERDICT.ESCALATE : VERDICT.EXECUTE,
+    reasons,
+    gates: { reversible, inRole, flagship, governance, dataLoss },
+  };
+}
+
+/** Convenience: true iff the decision is Adam's to execute-and-report. */
+export function shouldExecute(input = {}) {
+  return classifyDecision(input).verdict === VERDICT.EXECUTE;
+}
+
+/**
+ * Map the adherence-probe text-classifier's signals onto the structured 3 gates,
+ * so the regex over-ask detector routes its verdict through the single canonical
+ * authority (classifyDecision) instead of a parallel boolean.
+ *
+ * @param {Object} signals
+ * @param {string|null} [signals.trigger]      - a COMES_TO_HIM trigger name, or null if none fired.
+ * @param {boolean} [signals.alreadyDetermined]- an ADAM-DECIDES signal (e.g. "I recommend", "reversible", "per the ratified decision") is present.
+ * @returns {{ reversible: (boolean|null), inRole: (boolean|null), flagship: boolean, governance: boolean, dataLoss: boolean }}
+ */
+export function gatesFromSignals({ trigger = null, alreadyDetermined = false } = {}) {
+  // No COMES-TO-HIM trigger: the decision is presumptively Adam's (in-role); it is
+  // reversible only when an ADAM-DECIDES signal asserts a reversible/already-determined
+  // disposition, else reversibility is uncertain (=> conservative escalate).
+  const gates = {
+    reversible: alreadyDetermined ? true : null,
+    inRole: true,
+    flagship: false,
+    governance: false,
+    dataLoss: false,
+  };
+  switch (trigger) {
+    case 'new-strategy-or-policy':
+      gates.governance = true;
+      gates.inRole = false;
+      break;
+    case 'reserved-kill-gate':
+      gates.governance = true;
+      gates.flagship = true;
+      break;
+    case 'ratified-deviation':
+      gates.governance = true;
+      break;
+    case 'irreversible-or-external':
+      gates.reversible = false;
+      gates.flagship = true;
+      break;
+    default:
+      break;
+  }
+  return gates;
+}
+
+export default classifyDecision;

--- a/tests/unit/adam/execute-vs-escalate.test.js
+++ b/tests/unit/adam/execute-vs-escalate.test.js
@@ -1,0 +1,114 @@
+/**
+ * Tests for the Adam execute-vs-escalate 3-gate classifier.
+ * SD-LEO-INFRA-ADAM-EXECUTE-VS-ESCALATE-CLASSIFIER-001
+ *
+ * TS-1 classifyDecision truth table (+ conservative uncertainty)
+ * TS-2 gatesFromSignals trigger mapping
+ * TS-3 classifyDecisionQuestion over-ask via the classifier
+ * TS-4 probeDecisionRubric end-to-end PASS/FAIL/UNKNOWN
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyDecision, gatesFromSignals, shouldExecute, VERDICT } from '../../../lib/adam/execute-vs-escalate.js';
+import { classifyDecisionQuestion, probeDecisionRubric } from '../../../lib/adam/adherence-probes.js';
+
+// ── TS-1: classifyDecision truth table ───────────────────────────────────────
+describe('classifyDecision', () => {
+  const clear = { reversible: true, inRole: true, flagship: false, governance: false, dataLoss: false };
+
+  it('executes only when all gates clear', () => {
+    const r = classifyDecision(clear);
+    expect(r.verdict).toBe(VERDICT.EXECUTE);
+    expect(r.reasons).toEqual([]);
+    expect(shouldExecute(clear)).toBe(true);
+  });
+
+  it('escalates with the correct reason for each blast-radius gate', () => {
+    expect(classifyDecision({ ...clear, flagship: true }).reasons).toContain('flagship');
+    expect(classifyDecision({ ...clear, governance: true }).reasons).toContain('governance');
+    expect(classifyDecision({ ...clear, dataLoss: true }).reasons).toContain('data-loss');
+    expect(classifyDecision({ ...clear, flagship: true }).verdict).toBe(VERDICT.ESCALATE);
+  });
+
+  it('is conservative: uncertain reversibility/role escalates', () => {
+    expect(classifyDecision({ ...clear, reversible: null }).verdict).toBe(VERDICT.ESCALATE);
+    expect(classifyDecision({ ...clear, reversible: null }).reasons).toContain('reversibility-uncertain');
+    expect(classifyDecision({ ...clear, inRole: undefined }).reasons).toContain('role-uncertain');
+    // missing inputs entirely => both uncertain => escalate
+    expect(classifyDecision({}).verdict).toBe(VERDICT.ESCALATE);
+  });
+
+  it('distinguishes false (explicit) from uncertain (null) reasons', () => {
+    expect(classifyDecision({ ...clear, reversible: false }).reasons).toContain('irreversible');
+    expect(classifyDecision({ ...clear, inRole: false }).reasons).toContain('out-of-role');
+  });
+
+  it('lists every failed gate together', () => {
+    const r = classifyDecision({ reversible: false, inRole: false, flagship: true, governance: true, dataLoss: true });
+    expect(r.reasons).toEqual(expect.arrayContaining(['irreversible', 'out-of-role', 'flagship', 'governance', 'data-loss']));
+    expect(r.verdict).toBe(VERDICT.ESCALATE);
+  });
+});
+
+// ── TS-2: gatesFromSignals trigger mapping ───────────────────────────────────
+describe('gatesFromSignals', () => {
+  it('no trigger + already-determined => reversible+in-role, gates clear (execute)', () => {
+    const g = gatesFromSignals({ trigger: null, alreadyDetermined: true });
+    expect(g).toMatchObject({ reversible: true, inRole: true, flagship: false, governance: false, dataLoss: false });
+    expect(classifyDecision(g).verdict).toBe(VERDICT.EXECUTE);
+  });
+
+  it('no trigger + NOT already-determined => reversibility uncertain (escalate)', () => {
+    const g = gatesFromSignals({ trigger: null, alreadyDetermined: false });
+    expect(g.reversible).toBeNull();
+    expect(classifyDecision(g).verdict).toBe(VERDICT.ESCALATE);
+  });
+
+  it('maps each COMES_TO_HIM trigger to the documented gate(s) => escalate', () => {
+    expect(gatesFromSignals({ trigger: 'new-strategy-or-policy', alreadyDetermined: true })).toMatchObject({ governance: true, inRole: false });
+    expect(gatesFromSignals({ trigger: 'reserved-kill-gate', alreadyDetermined: true })).toMatchObject({ governance: true, flagship: true });
+    expect(gatesFromSignals({ trigger: 'ratified-deviation', alreadyDetermined: true })).toMatchObject({ governance: true });
+    expect(gatesFromSignals({ trigger: 'irreversible-or-external', alreadyDetermined: true })).toMatchObject({ reversible: false, flagship: true });
+    for (const t of ['new-strategy-or-policy', 'reserved-kill-gate', 'ratified-deviation', 'irreversible-or-external']) {
+      expect(classifyDecision(gatesFromSignals({ trigger: t, alreadyDetermined: true })).verdict).toBe(VERDICT.ESCALATE);
+    }
+  });
+});
+
+// ── TS-3: classifyDecisionQuestion over-ask via the classifier ───────────────
+describe('classifyDecisionQuestion (routed through the 3-gate classifier)', () => {
+  it('flags an over-ask: reversible, already-determined default + proximate ask, no trigger', () => {
+    const r = classifyDecisionQuestion('I recommend we defer this reversible disposition — should I proceed?');
+    expect(r.overAsk).toBe(true);
+    expect(r.decision.verdict).toBe(VERDICT.EXECUTE);
+  });
+
+  it('does NOT flag when a COMES-TO-HIM trigger fires (escalation warranted)', () => {
+    const r = classifyDecisionQuestion('This is an irreversible production deploy with external spend — should I proceed?');
+    expect(r.escalationWarranted).toBe(true);
+    expect(r.overAsk).toBe(false);
+    expect(r.decision.verdict).toBe(VERDICT.ESCALATE);
+  });
+
+  it('does NOT flag a pure status line (no decision-ask)', () => {
+    const r = classifyDecisionQuestion('Sourced 3 SDs under the standing cap; all reversible dispositions.');
+    expect(r.overAsk).toBe(false);
+  });
+});
+
+// ── TS-4: probeDecisionRubric end-to-end ─────────────────────────────────────
+describe('probeDecisionRubric', () => {
+  it('PASS when there are zero over-asks', () => {
+    const facts = { adamChairmanDecisionQuestionsInWindow: [{ body: 'Irreversible launch — your call?' }] };
+    expect(probeDecisionRubric(facts).verdict).toBe('pass');
+  });
+
+  it('FAIL when an over-ask is present', () => {
+    const facts = { adamChairmanDecisionQuestionsInWindow: [{ body: 'I recommend we shelve this reversible item — should I proceed?' }] };
+    expect(probeDecisionRubric(facts).verdict).toBe('fail');
+  });
+
+  it('UNKNOWN when facts are unresolved (fail-loud, never a silent pass)', () => {
+    expect(probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: null }).verdict).toBe('unknown');
+    expect(probeDecisionRubric({}).verdict).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
Codifies Adam's execute-vs-escalate boundary as a **deterministic, conservative 3-gate classifier** (the canonical `decision_rubric`) to stop over-asking and under-escalating.

> **EXECUTE-AND-REPORT iff (reversible AND in-role AND NOT flagship/governance/data-loss); otherwise ESCALATE.**

## FRs
- **FR-1** `lib/adam/execute-vs-escalate.js` — `classifyDecision()` (pure, deterministic). CONSERVATIVE: uncertain reversibility/role (`null`) escalates; flagship/governance/data-loss escalate only on explicit `true`. + `gatesFromSignals()` mapping the existing COMES_TO_HIM triggers onto the structured gates.
- **FR-2** `lib/adam/adherence-probes.js` — `classifyDecisionQuestion` now derives its over-ask verdict via `classifyDecision(gatesFromSignals(...))`, making the 3-gate rubric the single authority. `probeDecisionRubric` contract unchanged (PASS/FAIL/UNKNOWN).
- **FR-3** `CLAUDE_ADAM.md` documents the canonical decision_rubric (3 gates, conservative reversibility, both failure modes) via DB section 604 (`leo_protocol_sections`) regenerated.

## Tests
14 new unit tests (truth table + signal→gate mapping + over-ask routing + probe e2e). Existing adherence-probes + decision-rubric-probe suites (19) still pass — **33/33, no regression**. The self-adherence review runs the probe (honest UNKNOWN on unresolved facts).

## Deferred (flagged, not dropped)
The **under-escalate** executed-action self-adherence wiring is deferred — no executed-action fact source with gate attributes exists yet. The primitive supports the direction (returns escalate); the probe wiring is a follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)