### PR TITLE
feat(SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001): action-preview on flagship-mutation dry-runs + adversarial verify gate

### DIFF
--- a/lib/eva/eva-orchestrator-helpers.js
+++ b/lib/eva/eva-orchestrator-helpers.js
@@ -58,7 +58,7 @@ function selectAnalysisDepth(budgetStatus) {
 
 // ── Helper Functions ────────────────────────────────────────────
 
-function buildResult({ ventureId, stageId, startedAt, correlationId, status, artifacts = [], filterDecision = null, gateResults = [], nextStageId = null, errors = [], devilsAdvocateReview = null, knowledgeContext = [], traceId = null, tokenUsageSummary = null, postLifecycleResult = null }) {
+function buildResult({ ventureId, stageId, startedAt, correlationId, status, artifacts = [], filterDecision = null, gateResults = [], nextStageId = null, errors = [], devilsAdvocateReview = null, knowledgeContext = [], traceId = null, tokenUsageSummary = null, postLifecycleResult = null, actionPreview = null }) {
   const result = {
     ventureId,
     stageId,
@@ -75,11 +75,95 @@ function buildResult({ ventureId, stageId, startedAt, correlationId, status, art
     knowledgeContext,
     traceId,
     tokenUsageSummary,
+    // SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001: the would-be EXECUTION ACTION, surfaced on
+    // BOTH dry-run and real runs so a caller sees what WILL happen, not just the gate verdict.
+    action_preview: actionPreview,
   };
   if (postLifecycleResult) {
     result.postLifecycleResult = postLifecycleResult;
   }
   return result;
+}
+
+// ── Flagship-mutation action preview (SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001) ──
+// Generalizes SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: for a flagship/irreversible
+// venture mutation the dry-run (and the real run) must surface the would-be EXECUTION ACTION
+// — would-archive vs would-hold-for-review vs would-advance — not just the gate verdict, so an
+// operator/agent sees what WILL happen. The preview MIRRORS the same predicates the real
+// returns use (isRouteToReview / gateBlocked / filterDecision / autoProceed), and an adversarial
+// consistency check refutes any divergence before the irreversible side-effect runs.
+
+// The terminal status each action implies (used by the adversarial cross-check).
+const ACTION_IMPLIES_STATUS = Object.freeze({
+  'would-hold-for-review': STATUS.HELD,
+  'would-archive': STATUS.BLOCKED,
+  'would-fail': STATUS.BLOCKED,
+  'would-advance': STATUS.COMPLETED,
+  'would-complete': STATUS.COMPLETED,
+  'would-require-review': STATUS.COMPLETED,
+  'would-stop': STATUS.COMPLETED,
+});
+
+/**
+ * Compute the would-be EXECUTION ACTION for a flagship stage mutation. Pure/deterministic —
+ * reuses the caller's already-resolved predicates rather than re-deriving them (drift-safe).
+ *
+ * @param {Object} ctx
+ * @param {number} ctx.resolvedStage
+ * @param {boolean} [ctx.isRouteToReview]  route-to-review / HOLD (conditional_pass at a kill gate)
+ * @param {boolean} [ctx.gateBlocked]      a gate blocked the stage
+ * @param {Object}  [ctx.filterDecision]   { action } from the value filter (pass path)
+ * @param {boolean} [ctx.autoProceed=true] whether auto-advance is enabled
+ * @returns {{action:string, reason:string}}
+ */
+function computeActionPreview({ resolvedStage, isRouteToReview = false, gateBlocked = false, filterDecision = null, autoProceed = true } = {}) {
+  const atKillGateStage = resolvedStage === 3 || resolvedStage === 5;
+  if (isRouteToReview) {
+    return { action: 'would-hold-for-review', reason: `route-to-review HOLD at stage ${resolvedStage}: vision kept intact, pending chairman decision minted` };
+  }
+  if (gateBlocked) {
+    return atKillGateStage
+      ? { action: 'would-archive', reason: `kill at stage ${resolvedStage}: vision would be archived` }
+      : { action: 'would-fail', reason: `gate blocked at stage ${resolvedStage}` };
+  }
+  if (filterDecision) {
+    if (filterDecision.action === FILTER_ACTION.AUTO_PROCEED) {
+      return autoProceed
+        ? { action: 'would-advance', reason: `auto-proceed: venture would advance past stage ${resolvedStage}` }
+        : { action: 'would-complete', reason: `auto-proceed at stage ${resolvedStage} but advance suppressed (autoProceed=false)` };
+    }
+    if (filterDecision.action === FILTER_ACTION.REQUIRE_REVIEW) {
+      return { action: 'would-require-review', reason: `filter requires review at stage ${resolvedStage}` };
+    }
+    if (filterDecision.action === FILTER_ACTION.STOP) {
+      return { action: 'would-stop', reason: `filter stop at stage ${resolvedStage}` };
+    }
+  }
+  return { action: 'would-complete', reason: `stage ${resolvedStage} completed` };
+}
+
+/**
+ * Adversarial consistency cross-check + presence guard for a flagship mutation. Independently
+ * verifies the surfaced action_preview against the terminal status the result will carry, and
+ * fails loud (a) when no action_preview was surfaced (presence guard — 'dry-run clean' alone is
+ * insufficient to authorize a flagship mutation) or (b) when the previewed action contradicts the
+ * status (refute-it-is-safe). Pure/deterministic; call BEFORE the irreversible side-effect.
+ *
+ * @param {{action:string}|null|undefined} actionPreview
+ * @param {string} status  the terminal STATUS the flagship result carries
+ * @throws {Error} FLAGSHIP_MUTATION_NO_ACTION_PREVIEW | FLAGSHIP_ACTION_PREVIEW_INCONSISTENT
+ */
+function assertActionPreviewConsistent(actionPreview, status) {
+  if (!actionPreview || !actionPreview.action) {
+    throw new Error(`FLAGSHIP_MUTATION_NO_ACTION_PREVIEW: a flagship mutation (status ${status}) must surface a would-be action before executing`);
+  }
+  const implied = ACTION_IMPLIES_STATUS[actionPreview.action];
+  if (!implied) {
+    throw new Error(`FLAGSHIP_ACTION_PREVIEW_INCONSISTENT: unknown action_preview '${actionPreview.action}'`);
+  }
+  if (implied !== status) {
+    throw new Error(`FLAGSHIP_ACTION_PREVIEW_INCONSISTENT: action_preview '${actionPreview.action}' implies status ${implied} but the result carries ${status}`);
+  }
 }
 
 function mergeArtifactOutputs(artifacts, ventureContext) {
@@ -456,6 +540,8 @@ export {
   ANALYSIS_DEPTH,
   selectAnalysisDepth,
   buildResult,
+  computeActionPreview,
+  assertActionPreviewConsistent,
   mergeArtifactOutputs,
   loadStageTemplate,
   persistArtifacts,

--- a/lib/eva/eva-orchestrator-helpers.js
+++ b/lib/eva/eva-orchestrator-helpers.js
@@ -183,7 +183,7 @@ async function loadStageTemplate(supabase, stageId) {
   // Try DB-based templates first (future: venture_stage_templates table)
   try {
     const { data } = await supabase
-      .from('venture_stage_templates')
+      .from('venture_stage_templates') // schema-lint-disable-line: intentional future/optional table, try/catch falls through to JS templates when absent (pre-existing line shifted into this PR's diff)
       .select('template_data')
       .eq('lifecycle_stage', stageId)
       .eq('is_active', true)

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -50,6 +50,8 @@ import {
   ANALYSIS_DEPTH,
   selectAnalysisDepth,
   buildResult,
+  computeActionPreview,
+  assertActionPreviewConsistent,
   mergeArtifactOutputs,
   loadStageTemplate,
   persistArtifacts,
@@ -880,6 +882,10 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     && !hasHardNonFinancialBlock;
 
   if (isRouteToReview) {
+    // SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001: surface the would-be action and refute any
+    // inconsistency BEFORE the irreversible mint side-effect (a HOLD mints a pending decision).
+    const heldActionPreview = computeActionPreview({ resolvedStage, isRouteToReview: true });
+    assertActionPreviewConsistent(heldActionPreview, STATUS.HELD);
     // HOLD: keep the vision intact (NO archive), mint a pending chairman decision (non-null
     // health via resolveDecisionHealth / GATE-NULL-HEALTH-RESOLUTION-001), return HELD.
     if (!options.dryRun && supabase) {
@@ -906,10 +912,15 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       ventureId, stageId: resolvedStage, startedAt, correlationId,
       status: STATUS.HELD, artifacts, gateResults, devilsAdvocateReview,
       errors: [], // a HOLD is a review state, not an error
+      actionPreview: heldActionPreview,
     });
   }
 
   if (gateBlocked) {
+    // SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001: surface the would-be action (would-archive at
+    // a kill gate, else would-fail) and refute inconsistency BEFORE the irreversible vision archive.
+    const blockedActionPreview = computeActionPreview({ resolvedStage, gateBlocked: true });
+    assertActionPreviewConsistent(blockedActionPreview, STATUS.BLOCKED);
     // Archive vision record on kill at stages 3 or 5
     if ((resolvedStage === 3 || resolvedStage === 5) && visionKey && !options.dryRun) {
       try {
@@ -929,6 +940,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         code: g.type === 'stage_gate' ? 'STAGE_GATE_FAILED' : 'REALITY_GATE_FAILED',
         message: g.summary || g.error || 'Gate check failed',
       })),
+      actionPreview: blockedActionPreview,
     });
   }
 
@@ -997,6 +1009,12 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     filterDecision = { action: FILTER_ACTION.REQUIRE_REVIEW, reasons: [`Filter error: ${err.message}`] };
   }
   tracer.endSpan(filterSpan.spanId, { status: 'completed', metadata: { action: filterDecision.action } });
+
+  // SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001: on the COMPLETED/pass path, surface the would-be
+  // action (would-advance / would-complete / would-require-review / would-stop) and refute any
+  // inconsistency BEFORE the irreversible COMPLETED-path side-effects (vision activation, advanceStage).
+  const completedActionPreview = computeActionPreview({ resolvedStage, filterDecision, autoProceed });
+  assertActionPreviewConsistent(completedActionPreview, STATUS.COMPLETED);
 
   // ── 7. Artifacts already persisted in step 4d (before gate evaluation) ──
 
@@ -1150,6 +1168,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     status: STATUS.COMPLETED, artifacts, filterDecision, gateResults, nextStageId, devilsAdvocateReview,
     knowledgeContext,
     traceId: tracer.traceId, tokenUsageSummary,
+    actionPreview: completedActionPreview,
   });
 }
 
@@ -1245,6 +1264,8 @@ export async function run({ ventureId, options = {} }, deps = {}) {
 
 export const _internal = {
   buildResult,
+  computeActionPreview,
+  assertActionPreviewConsistent,
   mergeArtifactOutputs,
   loadStageTemplate,
   persistArtifacts,

--- a/tests/unit/eva/flagship-mutation-action-preview.test.js
+++ b/tests/unit/eva/flagship-mutation-action-preview.test.js
@@ -1,0 +1,153 @@
+/**
+ * Flagship-mutation action-preview verify gate
+ * SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001
+ *
+ * Generalizes the KILLGATE route-to-review fix: a flagship/irreversible venture mutation must
+ * surface the would-be EXECUTION ACTION (would-advance / would-hold-for-review / would-archive /
+ * would-fail) on its dry-run AND real result, and a consequential mutation must pass a
+ * deterministic adversarial consistency check (refute-it-is-safe) + a presence guard before
+ * executing. Pure helpers are tested directly; processStage dry-run surfacing reuses the
+ * killgate harness.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Transitive deps with shebangs / IO vitest can't transform (mirrors killgate-route-to-review.test.js)
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockReturnValue('SD-TEST-001'),
+  generateChildKey: vi.fn().mockReturnValue('SD-TEST-001-A'),
+  normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
+}));
+vi.mock('../../../lib/eva/stage-templates/index.js', () => ({ getTemplate: vi.fn().mockReturnValue(null) }));
+vi.mock('../../../lib/eva/dependency-manager.js', () => ({
+  checkDependencies: vi.fn().mockResolvedValue([]),
+  getDependencyGraph: vi.fn().mockResolvedValue({ dependsOn: [], providesTo: [] }),
+  wouldCreateCycle: vi.fn().mockResolvedValue(false),
+  addDependency: vi.fn(), resolveDependency: vi.fn(), removeDependency: vi.fn(), MODULE_VERSION: '1.0.0',
+}));
+vi.mock('../../../lib/eva/shared-services.js', async () => {
+  const actual = await vi.importActual('../../../lib/eva/shared-services.js');
+  return { ...actual, emit: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock('../../../lib/eva/devils-advocate.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isDevilsAdvocateGate: vi.fn().mockReturnValue({ isGate: false, gateType: null }),
+  getDevilsAdvocateReview: vi.fn(),
+  buildArtifactRecord: vi.fn().mockReturnValue({}),
+}));
+const { mintSpy } = vi.hoisted(() => ({ mintSpy: vi.fn() }));
+mintSpy.mockResolvedValue({ id: 'dec-hold-1', health_score: 'red' });
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({
+  createOrReusePendingDecision: mintSpy,
+  waitForDecision: vi.fn(),
+  createAdvisoryNotification: vi.fn(),
+}));
+
+import { processStage, _internal } from '../../../lib/eva/eva-orchestrator.js';
+const { STATUS, FILTER_ACTION, buildResult, computeActionPreview, assertActionPreviewConsistent } = _internal;
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function makeSupabase() {
+  const updates = [];
+  const ventureRow = { id: 'v-1', name: 'TestVenture', status: 'active', current_lifecycle_stage: 5, archetype: 'saas', created_at: '2026-01-01', autonomy_level: 'L0' };
+  const visionRow = { vision_key: 'VISION-TestVenture-L2-001', status: 'active' };
+  const from = (table) => {
+    const isVision = table === 'eva_vision_documents';
+    const b = {
+      select: () => b, eq: () => b, in: () => b, is: () => b, order: () => b, limit: () => b,
+      single: async () => ({ data: isVision ? visionRow : ventureRow, error: null }),
+      maybeSingle: async () => ({ data: isVision ? visionRow : ventureRow, error: null }),
+      insert: () => b, update: (payload) => { updates.push({ table, payload }); return b; },
+    };
+    return b;
+  };
+  return { client: { from: vi.fn(from) }, updates };
+}
+function templateWithDecision(decision) {
+  return { analysisSteps: [{ id: 'kill-gate-step', execute: async () => ({ artifactType: 'financial_model', payload: { decision, reasons: [{ message: 'demand unvalidated' }], remediationRoute: 'review' }, source: 'test' }) }] };
+}
+const baseDeps = (supabase) => ({
+  supabase, logger: silentLogger,
+  evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+  evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true, status: 'PASS' }),
+  validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+});
+
+describe('FR-1 computeActionPreview — mirrors the real decision branches', () => {
+  it('route-to-review -> would-hold-for-review', () => {
+    expect(computeActionPreview({ resolvedStage: 5, isRouteToReview: true }).action).toBe('would-hold-for-review');
+  });
+  it('gate-blocked at a kill stage -> would-archive', () => {
+    expect(computeActionPreview({ resolvedStage: 5, gateBlocked: true }).action).toBe('would-archive');
+    expect(computeActionPreview({ resolvedStage: 3, gateBlocked: true }).action).toBe('would-archive');
+  });
+  it('gate-blocked at a non-kill stage -> would-fail', () => {
+    expect(computeActionPreview({ resolvedStage: 12, gateBlocked: true }).action).toBe('would-fail');
+  });
+  it('auto-proceed pass -> would-advance (or would-complete when advance suppressed)', () => {
+    expect(computeActionPreview({ resolvedStage: 8, filterDecision: { action: FILTER_ACTION.AUTO_PROCEED }, autoProceed: true }).action).toBe('would-advance');
+    expect(computeActionPreview({ resolvedStage: 8, filterDecision: { action: FILTER_ACTION.AUTO_PROCEED }, autoProceed: false }).action).toBe('would-complete');
+  });
+  it('require-review / stop filter -> would-require-review / would-stop', () => {
+    expect(computeActionPreview({ resolvedStage: 8, filterDecision: { action: FILTER_ACTION.REQUIRE_REVIEW } }).action).toBe('would-require-review');
+    expect(computeActionPreview({ resolvedStage: 8, filterDecision: { action: FILTER_ACTION.STOP } }).action).toBe('would-stop');
+  });
+});
+
+describe('FR-3/FR-4 assertActionPreviewConsistent — adversarial cross-check + presence guard', () => {
+  it('passes when the previewed action matches the terminal status', () => {
+    expect(() => assertActionPreviewConsistent({ action: 'would-archive' }, STATUS.BLOCKED)).not.toThrow();
+    expect(() => assertActionPreviewConsistent({ action: 'would-hold-for-review' }, STATUS.HELD)).not.toThrow();
+    expect(() => assertActionPreviewConsistent({ action: 'would-advance' }, STATUS.COMPLETED)).not.toThrow();
+  });
+  it('refutes a contradiction (action implies a different status)', () => {
+    expect(() => assertActionPreviewConsistent({ action: 'would-advance' }, STATUS.BLOCKED)).toThrow(/INCONSISTENT/);
+    expect(() => assertActionPreviewConsistent({ action: 'would-archive' }, STATUS.COMPLETED)).toThrow(/INCONSISTENT/);
+  });
+  it('presence guard: a missing/empty action_preview is rejected (fail-loud)', () => {
+    expect(() => assertActionPreviewConsistent(null, STATUS.BLOCKED)).toThrow(/NO_ACTION_PREVIEW/);
+    expect(() => assertActionPreviewConsistent({}, STATUS.HELD)).toThrow(/NO_ACTION_PREVIEW/);
+  });
+  it('rejects an unknown action value', () => {
+    expect(() => assertActionPreviewConsistent({ action: 'would-teleport' }, STATUS.COMPLETED)).toThrow(/INCONSISTENT/);
+  });
+});
+
+describe('FR-2 buildResult carries action_preview (default null)', () => {
+  it('attaches action_preview when provided', () => {
+    const r = buildResult({ ventureId: 'v', stageId: 5, startedAt: 'now', correlationId: 'c', status: STATUS.HELD, actionPreview: { action: 'would-hold-for-review', reason: 'x' } });
+    expect(r.action_preview.action).toBe('would-hold-for-review');
+  });
+  it('defaults to null when omitted', () => {
+    const r = buildResult({ ventureId: 'v', stageId: 5, startedAt: 'now', correlationId: 'c', status: STATUS.COMPLETED });
+    expect(r.action_preview).toBeNull();
+  });
+});
+
+describe('FR-2 dry-run surfaces the would-be action (no side-effects)', () => {
+  it('route-to-review dry-run -> HELD + action_preview would-hold-for-review, no mint', async () => {
+    mintSpy.mockClear();
+    const { client, updates } = makeSupabase();
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { dryRun: true, stageTemplate: templateWithDecision('conditional_pass') } },
+      baseDeps(client),
+    );
+    expect(result.status).toBe(STATUS.HELD);
+    expect(result.action_preview.action).toBe('would-hold-for-review');
+    expect(mintSpy).not.toHaveBeenCalled();
+    expect(updates.some(u => u.table === 'eva_vision_documents' && u.payload?.status === 'archived')).toBe(false);
+  });
+
+  it('genuine kill dry-run -> BLOCKED + action_preview would-archive, no vision archive', async () => {
+    const { client, updates } = makeSupabase();
+    const deps = baseDeps(client);
+    deps.validateStageGateFn = vi.fn().mockResolvedValue({ passed: false, summary: 'financial viability fail' });
+    const result = await processStage(
+      { ventureId: 'v-1', stageId: 5, options: { dryRun: true, stageTemplate: templateWithDecision('kill') } },
+      deps,
+    );
+    expect(result.status).toBe(STATUS.BLOCKED);
+    expect(result.action_preview.action).toBe('would-archive');
+    expect(updates.some(u => u.table === 'eva_vision_documents' && u.payload?.status === 'archived')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Generalizes the KILLGATE route-to-review fix (SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001) into a reusable contract: a flagship/irreversible venture mutation must surface the **would-be EXECUTION ACTION** on its dry-run (and real) result — not just the gate verdict — and a consequential mutation must pass a deterministic adversarial consistency check + presence guard before executing.

Investigation (own Explore agent + DATABASE/TESTING/DESIGN sub-agents) confirmed every flagship mutation (gate-outcome decision, vision activate/archive, advance) funnels through `eva-orchestrator.processStage`/`buildResult` — so this is **one change at a single integration point**, not a decomposition (the SD's "Decompose-at-PLAN" hint is refuted by the call-site analysis).

## FRs
- **FR-1** `computeActionPreview()` (pure) reuses the caller's already-resolved predicates (`isRouteToReview`/`gateBlocked`/`filterDecision`/`autoProceed`) → `would-advance` / `would-hold-for-review` / `would-archive` / `would-fail` / `would-require-review` / `would-stop` / `would-complete`.
- **FR-2** `action_preview` threaded through `buildResult` and populated at the 3 flagship return sites → surfaced on **dry-run AND real** runs.
- **FR-3/FR-4** `assertActionPreviewConsistent()` — deterministic adversarial cross-check (refute when the previewed action contradicts the terminal status) + presence guard (a flagship mutation with no surfaced action fails loud). Runs **before** the irreversible side-effect (mint / vision archive / advanceStage). "Dry-run clean" alone is insufficient.
- **FR-5** 13 unit tests (helper branches, cross-check, presence guard, `buildResult` field, dry-run surfacing of would-hold vs would-archive). Killgate + orchestrator regression **36/36 green**.

Backend EVA only, additive + behavior-preserving, no UI, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)