### PR TITLE
feat(SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001): co-authored SDs non-claimable until convergence

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -52,13 +52,20 @@ const { isSdExecutableHere } = require('./sd-executable-here.cjs');
  *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
  * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean }} [ctx]  when present, applies the claim-time fitness + tier axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'co_author_pending' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
   if (row.sd_type === 'orchestrator') return 'orchestrator_parent';
   if (typeof row.sd_key === 'string' && TEST_FIXTURE_KEY_RE.test(row.sd_key)) return 'test_fixture_key';
   if (row.metadata && row.metadata.requires_human_action) return 'human_action_required';
+  // SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001: a co-authored DRAFT SD is NON-CLAIMABLE
+  // until co-author convergence — else a parked worker claims it and writes the PRD before the
+  // co-author input lands, so the late co-author FRs never reach EXEC (the PRD-drift-after-co-author
+  // race, [[reference-sd-scope-edits-after-prd-dont-reach-exec]]). Strict === true so a false/absent
+  // flag (converged or non-co-authored) falls through unchanged. Shared SSOT: the self-claim (draft +
+  // baselined) and stale-session-sweep paths all route through this predicate, so they exclude it too.
+  if (row.metadata && row.metadata.co_author_pending === true) return 'co_author_pending';
   // SD-FDBK-INFRA-STALE-SESSION-SWEEP-001: a DEFERRED SD is parked off the belt (coordinator/Adam
   // deferral) and must NEVER be re-dispatched — without this the sweep CLAIM_FIX re-asserted a
   // deferred SD's claim onto a worker with a live worktree every tick, defeating the deferral and

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -138,6 +138,7 @@ async function main() {
   const claimable = [];
   let fixtureSkips = 0;
   let inFlightSkips = 0;
+  let awaitingConvergenceSkips = 0;
   for (const d of (sds || [])) {
     if (d.claiming_session_id) continue;
     if (d.sd_type === 'orchestrator') continue;          // parents are never dispatched
@@ -155,6 +156,16 @@ async function main() {
     if (isFixtureSd(d.sd_key, d.metadata)) {             // test fixtures are never ranked
       fixtureSkips++;
       console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
+      continue;
+    }
+    // SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001: a co-authored SD awaiting convergence is
+    // NON-CLAIMABLE (it would let a parked worker write the PRD before the co-author input lands).
+    // Surface it as AWAITING-CONVERGENCE — explicitly NOT idle-belt depth, so the capacity forecaster
+    // does not read it as claimable. Mirrors classifyDispatchIneligibility's co_author_pending gate so
+    // the ranked belt matches the actually-claimable set. Flips to claimable when co_author_pending=false.
+    if ((d.metadata || {}).co_author_pending === true) {
+      awaitingConvergenceSkips++;
+      console.log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
       continue;
     }
     // SD-REFILL-00AH2L4Q: include metadata.blocked_by_sd_key (via blockerKeysFor) so a metadata-blocked
@@ -175,6 +186,7 @@ async function main() {
   }
   if (fixtureSkips) console.log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
   if (inFlightSkips) console.log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
+  if (awaitingConvergenceSkips) console.log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
   // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs (empty/title-only description)
   // cannot pass LEAD-TO-PLAN; log them so the demote-to-last below is auditable. The sort
   // below (bareShellLastCompare as the dominant key) is what actually places them last.

--- a/tests/unit/claim-eligibility.test.js
+++ b/tests/unit/claim-eligibility.test.js
@@ -50,7 +50,7 @@ function makeSbForEligibility(sdRows, opts = {}) {
                 maybeSingle: async () => {
                   if (opts.errorOnSingle) return { data: null, error: { message: 'single boom' } };
                   const row = sdRows[val];
-                  return { data: row ? { sd_type: row.sd_type, dependencies: row.dependencies || [] } : null, error: null };
+                  return { data: row ? { sd_type: row.sd_type, dependencies: row.dependencies || [], metadata: row.metadata || {}, status: row.status } : null, error: null };
                 },
               };
             },
@@ -140,5 +140,31 @@ describe('baselinedCandidateEligible (boolean wrapper; false-on-error = worker-c
   it('deps-query error -> false (conservative skip)', async () => {
     const sb = makeSbForEligibility({ 'SD-C': { sd_type: 'bugfix', dependencies: [{ sd_key: 'SD-DEP' }] } }, { errorOnIn: true });
     expect(await baselinedCandidateEligible(sb, 'SD-C')).toBe(false);
+  });
+});
+
+// SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001: a co-authored DRAFT SD is NON-CLAIMABLE until
+// co-author convergence (metadata.co_author_pending===true), so a parked worker can't claim it and
+// write the PRD before the co-author input lands. Flips to claimable when co_author_pending=false.
+describe('co_author_pending gate (SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001)', () => {
+  it('co_author_pending:true -> ineligible(co_author_pending)', async () => {
+    const sb = makeSbForEligibility({ 'SD-COAUTH-001': { sd_type: 'feature', dependencies: [], metadata: { co_author_pending: true } } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-COAUTH-001')).toEqual({ eligible: false, reason: 'co_author_pending' });
+  });
+  it('co_author_pending:false (converged) -> eligible', async () => {
+    const sb = makeSbForEligibility({ 'SD-COAUTH-DONE': { sd_type: 'feature', dependencies: [], metadata: { co_author_pending: false } } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-COAUTH-DONE')).toEqual({ eligible: true });
+  });
+  it('co_author_pending absent (non-co-author DRAFT) -> eligible (no coercion / no regression)', async () => {
+    const sb = makeSbForEligibility({ 'SD-PLAIN': { sd_type: 'bugfix', dependencies: [] } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-PLAIN')).toEqual({ eligible: true });
+  });
+  it('a stray truthy (non-true) value does NOT enroll the SD — strict === true only', async () => {
+    const sb = makeSbForEligibility({ 'SD-STRAY': { sd_type: 'feature', dependencies: [], metadata: { co_author_pending: 'yes' } } });
+    expect(await evaluateDispatchEligibility(sb, 'SD-STRAY')).toEqual({ eligible: true });
+  });
+  it('baselinedCandidateEligible: co_author_pending:true -> false (self-claim baselined path excludes it)', async () => {
+    const sb = makeSbForEligibility({ 'SD-COAUTH-002': { sd_type: 'feature', dependencies: [], metadata: { co_author_pending: true } } });
+    expect(await baselinedCandidateEligible(sb, 'SD-COAUTH-002')).toBe(false);
   });
 });


### PR DESCRIPTION
## Close the PRD-drift-after-co-author race

A parked worker could claim a **co-authored DRAFT SD** and write its PRD *before* the co-author input converged — so the late co-author FRs never reached EXEC (grounded in `reference-sd-scope-edits-after-prd-dont-reach-exec`). This makes such SDs non-claimable until convergence.

### Changes
- **FR-1** `lib/fleet/claim-eligibility.cjs` — `classifyDispatchIneligibility` returns `'co_author_pending'` when `metadata.co_author_pending === true` (strict). It's the shared SSOT predicate, so the self-claim (draft + baselined) and `stale-session-sweep` CLAIM_FIX paths exclude it automatically — no duplicated logic.
- **FR-2** `scripts/coordinator-backlog-rank.mjs` — filters `co_author_pending` SDs from the ranked claimable set, logging them as **awaiting-convergence** (explicitly *not* idle-belt depth) so the capacity forecaster doesn't read them as claimable.
- **FR-3** `tests/unit/claim-eligibility.test.js` — pending⇒ineligible, converged⇒eligible, non-co-author unaffected, stray-truthy not enrolled (strict `===true`), baselined path excludes pending. Stub now passes `metadata`. **23 tests pass.**

When `co_author_pending` flips to false (convergence), the SD becomes claimable and dispatches/ranks normally. Backend + tests only; no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)