### PR TITLE
fix(QF-20260627-861): commit prod-applied seeded_from_venture migrations (run#3 clone durability gap)

### DIFF
--- a/database/migrations/20260627_venture_briefs_origin_type_check_add_seeded_from_venture.sql
+++ b/database/migrations/20260627_venture_briefs_origin_type_check_add_seeded_from_venture.sql
@@ -1,0 +1,31 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: add 'seeded_from_venture' to the venture_briefs.origin_type CHECK constraint
+--   (the SIBLING of the venture_origin_type enum drift).
+--
+-- Root cause: venture_briefs_origin_type_check = CHECK (origin_type = ANY (ARRAY[
+--   'competitor_teardown','competitor_clone','blueprint','discovery','manual'])) — missing
+--   'seeded_from_venture'. So the Stage-0 brief INSERT for the clean clone (origin_type=
+--   'seeded_from_venture') failed -> clone 091f2889 has 0 venture_briefs rows. (The
+--   venture_origin_type ENUM was already fixed in 20260627_venture_origin_type_add_seeded_from_venture.sql;
+--   this same value is gated by a SECOND object — this CHECK on venture_briefs.)
+--
+-- Authorization: chairman GO via Adam (Option A: Residual-1 fix + HOLD), recorded on parent
+--   metadata.chairman_enum_migration_authorization. SCOPE = add 'seeded_from_venture' as a SUPERSET
+--   (existing 5 values preserved + the new one); no existing row violates the superset, so re-ADD is safe.
+--   synthetic_pipeline is also absent from this check but is OUT OF SCOPE here (separate follow-up).
+--
+-- Apply note: DROP + re-ADD a CHECK constraint is transaction-safe (default tx; no --no-tx needed).
+--
+-- SD: SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B (brief-constraint sibling-drift unblock)
+
+ALTER TABLE public.venture_briefs DROP CONSTRAINT IF EXISTS venture_briefs_origin_type_check;
+
+ALTER TABLE public.venture_briefs ADD CONSTRAINT venture_briefs_origin_type_check
+  CHECK (origin_type = ANY (ARRAY[
+    'competitor_teardown'::text,
+    'competitor_clone'::text,
+    'blueprint'::text,
+    'discovery'::text,
+    'manual'::text,
+    'seeded_from_venture'::text
+  ]));

--- a/database/migrations/20260627_venture_origin_type_add_seeded_from_venture.sql
+++ b/database/migrations/20260627_venture_origin_type_add_seeded_from_venture.sql
@@ -1,0 +1,22 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: add 'seeded_from_venture' label to the venture_origin_type enum.
+--
+-- Root cause (code-ahead-of-schema): lib/eva/stage-zero/paths/venture-reseeding.js:67
+--   (also path-router.js:26, lib/eva/clean-clone/launch.js:27) sets
+--   origin_type='seeded_from_venture', but the enum never received that label.
+--   Migration 20260627_ventures_seeded_from_venture_id.sql added the seeded_from_venture_id
+--   COLUMN but not the matching enum LABEL -> the clean-clone launch ventures INSERT throws
+--   'invalid input value for enum venture_origin_type: "seeded_from_venture"' and no
+--   venture persists (the original CLONE-B NOOP-complete root, confirmed live).
+--
+-- Authorization: chairman GO via Adam (clone re-launch), recorded on parent
+--   metadata.chairman_enum_migration_authorization.
+-- SCOPE: seeded_from_venture ONLY. nursery_reeval (interfaces.js:46 validOrigins) is
+--   likewise absent from the enum but is a SEPARATE verify-then-fix follow-up — NOT bundled here.
+--
+-- Apply note: ALTER TYPE ... ADD VALUE cannot run inside a transaction block, so this is
+--   applied with --no-tx --i-know. Idempotent via IF NOT EXISTS (safe to re-run).
+--
+-- SD: SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B (enum-drift unblock)
+
+ALTER TYPE venture_origin_type ADD VALUE IF NOT EXISTS 'seeded_from_venture';


### PR DESCRIPTION
## Summary
Two migrations were applied **live to prod** during the clean-clone run but their FILES were git-untracked, so a fresh-DB clone re-hits the bugs at launch. Re-creates both files **verbatim** so the repo matches prod.

- `20260627_venture_origin_type_add_seeded_from_venture.sql` — `ALTER TYPE venture_origin_type ADD VALUE IF NOT EXISTS 'seeded_from_venture'` (the clone-launch `ventures` INSERT enum drift).
- `20260627_venture_briefs_origin_type_check_add_seeded_from_venture.sql` — DROP + re-ADD `venture_briefs_origin_type_check` as a superset including `seeded_from_venture` (the Stage-0 brief INSERT sibling drift).

**Additive/idempotent + already prod-applied** (`IF NOT EXISTS` enum add; superset CHECK re-ADD) — committing only makes the repo replayable on a fresh env; no schema change executes on merge. Do NOT re-apply to prod.

run#3 seed-cluster MUST-LAND. SD: SD-LEO-INFRA-CLEAN-CLONE-LAUNCH-001-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)