### PR TITLE
fix(QF-20260627-273): DUTY-4 dep-resolver treats co_author_pending hold as BLOCKED not ANOMALY

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -36,6 +36,14 @@ export function extractDepKey(dep) {
   return m ? m[1] : null;
 }
 
+// QF-20260627-273: the interim co_author_pending hold is a sentinel dependency whose key contains
+// CO-AUTHOR-CONVERGENCE-PENDING (it intentionally does not resolve to an SD row). It is a legitimate
+// hold (non-claimable until convergence), NOT a dep-resolver staleness anomaly — so the dep-health
+// detector must treat it as BLOCKED, matching claim-eligibility.draftDepsSatisfied.
+export function isCoAuthorHoldKey(k) {
+  return typeof k === 'string' && /CO-AUTHOR-CONVERGENCE-PENDING/i.test(k);
+}
+
 /**
  * Classify a worker's liveness using AUTHORITATIVE signals, NOT heartbeat-age alone: a fresh heartbeat OR an
  * in-window armed-silence (expected_silence_until) OR a live resolved PID => ALIVE. So a long-EXEC-run /
@@ -107,10 +115,16 @@ export function detectDependencyHealth({ sds = [], statusByKey = {}, terminalSet
   for (const s of sds) {
     const deps = depOf(s);
     if (!deps.length) continue;
-    const unknown = deps.filter((k) => !Object.prototype.hasOwnProperty.call(statusByKey, k));
+    // QF-20260627-273: a co_author_pending interim hold is encoded as a sentinel dependency
+    // (key contains CO-AUTHOR-CONVERGENCE-PENDING) that intentionally does not resolve to an SD row.
+    // claim-eligibility draftDepsSatisfied already treats it as BLOCKED (non-claimable); DUTY-4 must
+    // agree — count it as a legitimate hold (BLOCKED), NOT a dep-resolver ANOMALY/violation.
+    const realDeps = deps.filter((k) => !isCoAuthorHoldKey(k));
+    const hasCoAuthorHold = realDeps.length !== deps.length;
+    const unknown = realDeps.filter((k) => !Object.prototype.hasOwnProperty.call(statusByKey, k));
     if (unknown.length) { anomalies.push({ sd: s.sd_key, unknownDeps: unknown }); continue; } // ANOMALY, not BLOCKED
-    const unmet = deps.filter((k) => !isTerminal(statusByKey[k]));
-    if (unmet.length) { blocked++; continue; }
+    const unmet = realDeps.filter((k) => !isTerminal(statusByKey[k]));
+    if (hasCoAuthorHold || unmet.length) { blocked++; continue; } // co_author hold = held/blocked, not anomaly
     ready++;
     if (!s.claiming_session_id && s.updated_at && (nowMs - new Date(s.updated_at).getTime()) >= DAY_MS) staleBlocked.push(s.sd_key);
   }

--- a/tests/unit/coordinator/charter-audit-detectors.test.js
+++ b/tests/unit/coordinator/charter-audit-detectors.test.js
@@ -217,6 +217,25 @@ describe('detectDependencyHealth — completed-dep NO-false-block (FR-5)', () =>
     const r = detectDependencyHealth({ sds, statusByKey: { 'SD-DEP1-001': 'in_progress' }, terminalSet: TERMINAL, nowMs: NOW });
     expect(r.blocked).toBe(1);
   });
+
+  // QF-20260627-273: a co_author_pending interim hold (sentinel dep) is a legitimate hold (BLOCKED,
+  // matching claim-eligibility.draftDepsSatisfied), NOT a dep-resolver ANOMALY/violation.
+  it('a co_author_pending hold sentinel is BLOCKED, not an ANOMALY/violation', () => {
+    const sentinel = 'SD-CO-AUTHOR-CONVERGENCE-PENDING interim hold (coordinator) — REMOVE on co_author convergence';
+    const sds = [{ sd_key: 'SD-C-001', dependencies: [sentinel] }];
+    const r = detectDependencyHealth({ sds, statusByKey: {}, terminalSet: TERMINAL, nowMs: NOW });
+    expect(r.blocked).toBe(1);
+    expect(r.anomalies).toHaveLength(0);
+    expect(r.violation).toBe(false);
+  });
+  it('a co_author hold alongside a genuinely-missing real dep still flags the real dep ANOMALY', () => {
+    const sentinel = 'SD-CO-AUTHOR-CONVERGENCE-PENDING interim hold';
+    const sds = [{ sd_key: 'SD-C-001', dependencies: [sentinel, 'SD-MISSING-001'] }];
+    const r = detectDependencyHealth({ sds, statusByKey: {}, terminalSet: TERMINAL, nowMs: NOW });
+    expect(r.anomalies).toHaveLength(1);
+    expect(r.anomalies[0].unknownDeps).toEqual(['SD-MISSING-001']); // hold excluded, real-missing flagged
+    expect(r.violation).toBe(true);
+  });
 });
 
 describe('detectWorktreePool — DUTY-1 fail-loud (FR-3)', () => {


### PR DESCRIPTION
## Summary
Charter **DUTY-4** dep-health detector flagged the `co_author_pending` interim hold (a sentinel dependency whose key contains `CO-AUTHOR-CONVERGENCE-PENDING`, intentionally not resolving to an SD row) as a dep-resolver **ANOMALY/violation**, while claim-eligibility `draftDepsSatisfied` treats the same hold as **BLOCKED** (non-claimable). They disagreed.

`detectDependencyHealth` now recognizes the co-author hold sentinel (`isCoAuthorHoldKey`) and counts it as a legitimate hold (BLOCKED), matching claim-eligibility. A genuinely-missing **real** dep still flags an anomaly.

Fast-follow to SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001. **60 detector tests pass** (2 new). ~20 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)