### PR TITLE
feat(SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001): deterministic S5 kill-gate re-eval + DA route-to-review

### DIFF
--- a/lib/eva/devils-advocate.js
+++ b/lib/eva/devils-advocate.js
@@ -63,6 +63,29 @@ export function isKillGateFailLoud(gateType) {
 }
 
 /**
+ * SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-2): is this DA verdict a STRONG challenge
+ * that should ROUTE a kill gate to review (downgrade a numeric 'pass' to HELD) rather than stay
+ * advisory-only? Scoped/thresholded so a weak or uncertain DA does not over-trigger:
+ *   - a degraded fallback review (e.g. no API key, isFallback:true) is EXCLUDED;
+ *   - overallAssessment must be 'challenge' (the enum is challenge|concern|support — 'challenge'
+ *     is the sole adverse verdict; there is NO 'kill' value);
+ *   - at least `minHighSeverityRisks` (default 2) risks at severity 'high'.
+ * Pure — no I/O — so it is unit-testable and reusable across kill gates (3/5/13/24).
+ *
+ * @param {Object|null} review - the devil's advocate review object
+ * @param {number} [minHighSeverityRisks=2]
+ * @returns {boolean}
+ */
+export function isStrongDevilsAdvocateChallenge(review, minHighSeverityRisks = 2) {
+  if (!review || review.isFallback === true) return false;
+  if (review.overallAssessment !== 'challenge') return false;
+  const highSeverityCount = Array.isArray(review.risks)
+    ? review.risks.filter(r => r?.severity === 'high').length
+    : 0;
+  return highSeverityCount >= minHighSeverityRisks;
+}
+
+/**
  * Get adversarial review from Devil's Advocate.
  *
  * @param {Object} params

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -22,7 +22,7 @@ import { ChairmanPreferenceStore } from './chairman-preference-store.js';
 import { evaluateDecision } from './decision-filter-engine.js';
 import { evaluateRealityGate, isGatedBoundary } from './reality-gates.js';
 import { attemptGateRecovery } from './gate-failure-recovery.js';
-import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord, mustProduceDevilsAdvocate, isKillGateFailLoud } from './devils-advocate.js';
+import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord, mustProduceDevilsAdvocate, isKillGateFailLoud, isStrongDevilsAdvocateChallenge } from './devils-advocate.js';
 // convertSprintToSDs + buildBridgeArtifactRecord moved to post-approval hook in stage-execution-worker.js
 import { writeArtifact, recordGateResult, advanceStage } from './artifact-persistence-service.js';
 import { ARTIFACT_TYPE_BY_STAGE } from './artifact-types.js';
@@ -35,6 +35,9 @@ import { VentureStateMachine } from '../agents/venture-state-machine.js';
 import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
 import { retrieveKnowledge } from './utils/knowledge-retriever.js';
 import { getTemplate } from './stage-templates/index.js';
+// SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-1): pure, deterministic re-gate of the
+// LOCKED persisted truth_financial_model (reEvaluateOnly path — no LLM regen, no overwrite).
+import { reEvaluateKillGateFromArtifact } from './stage-templates/stage-05.js';
 import { getContract, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
 // SD-REFILL-00V67JEB (FR-1): persist a runtime contract-enforcement coverage signal (fail-open).
 import { emitContractCoverage } from './contracts/contract-coverage.js';
@@ -385,15 +388,56 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   let stageOutput = {};
   const stageTokenUsages = [];
   let hookContext = { visionKey, planKey };
+  // SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-1): when true, this run re-gated the
+  // LOCKED persisted artifact instead of regenerating via the producer — the producer step.execute
+  // loop, the producing onBeforeAnalysis hook, multi-artifact extraction, and persistArtifacts are
+  // all skipped so the verdict is reproducible AND the persisted model is never overwritten.
+  let producedFromPersisted = false;
   const templateSpan = tracer.startSpan('template_execution');
   try {
     const template = options.stageTemplate || await loadStageTemplate(supabase, resolvedStage);
     const steps = template?.analysisSteps || [];
 
+    // ── 4a.0. Deterministic re-evaluate-only path (FR-1) ──
+    // An opt-in re-gate of a held/re-run venture: read the LOCKED persisted artifact(s) for this
+    // stage and run ONLY the gate chain against them — no LLM regen, no overwrite. Regenerate stays
+    // the explicit default: if NO current artifact exists (first run), fall through to production.
+    if (options.reEvaluateOnly) {
+      try {
+        const { data: persistedRows } = await supabase
+          .from('venture_artifacts')
+          .select('artifact_type, artifact_data, created_at')
+          .eq('venture_id', ventureId)
+          .eq('lifecycle_stage', resolvedStage)
+          .eq('is_current', true)
+          .neq('artifact_type', 'system_devils_advocate_review')
+          .order('created_at', { ascending: true });
+        const loaded = (persistedRows || []).filter(
+          r => r.artifact_data && typeof r.artifact_data === 'object' && Object.keys(r.artifact_data).length > 0
+        );
+        if (loaded.length > 0) {
+          artifacts = loaded.map(r => ({
+            artifactType: r.artifact_type,
+            stageId: resolvedStage,
+            createdAt: r.created_at,
+            payload: r.artifact_data,
+            source: 'persisted-reeval',
+          }));
+          producedFromPersisted = true;
+          logger.log(`[Eva] reEvaluateOnly: re-gating stage ${resolvedStage} against ${loaded.length} LOCKED persisted artifact(s) — no LLM regen, no overwrite`);
+        } else {
+          logger.warn(`[Eva] reEvaluateOnly: no current persisted artifact for stage ${resolvedStage} — generating fresh (first run)`);
+        }
+      } catch (reEvalErr) {
+        logger.warn(`[Eva] reEvaluateOnly load failed (${reEvalErr.message}) — generating fresh`);
+      }
+    }
+
     // ── 4a. Run onBeforeAnalysis hook from JS stage template ──
+    // FR-1: skip the producing hook on a re-gate-only run (it is a producer-side side effect).
     try {
       const jsTemplate = getTemplate(resolvedStage);
-      if (jsTemplate?.onBeforeAnalysis) {
+      if (!producedFromPersisted && jsTemplate?.onBeforeAnalysis) {
         const hookResult = await jsTemplate.onBeforeAnalysis(supabase, ventureContext?.id || ventureId);
         if (hookResult) {
           hookContext = hookResult;
@@ -415,6 +459,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     //      Both conditions MUST hold; non-array `stepResult` (or empty array) takes
     //      the legacy path so existing stages 13/15/16/etc. continue unchanged.
     let stepProvidedTypedArtifacts = false;
+    // FR-1: on a re-gate-only run, the artifacts are the LOCKED persisted ones — skip the producer.
+    if (!producedFromPersisted)
     for (const step of steps) {
       try {
         const stepResult = typeof step.execute === 'function'
@@ -490,6 +536,22 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
 
     stageOutput = mergeArtifactOutputs(artifacts, ventureContext);
 
+    // ── 4a.0b. Deterministic kill-gate recompute (FR-1) ──
+    // On a re-gate-only run at S5, re-run the PURE kill gate on the LOCKED persisted financial
+    // model so the verdict is reproducible (same persisted inputs -> same decision). This overwrites
+    // any stale `decision` merged from the artifact payload with the freshly-computed, deterministic one.
+    if (producedFromPersisted && resolvedStage === 5) {
+      const truth = artifacts.find(a => a.artifactType === 'truth_financial_model') || artifacts[0];
+      if (truth?.payload) {
+        const reGate = reEvaluateKillGateFromArtifact(truth.payload);
+        stageOutput.decision = reGate.decision;
+        stageOutput.reasons = reGate.reasons;
+        stageOutput.blockProgression = reGate.blockProgression;
+        stageOutput.remediationRoute = reGate.remediationRoute;
+        logger.log(`[Eva] reEvaluateOnly: deterministic S5 kill-gate decision='${reGate.decision}' (re-run on locked truth_financial_model)`);
+      }
+    }
+
     // ── 4a.1. Multi-artifact extraction ──
     // For stages with multiple required_artifacts, split the merged output
     // by ## headings and create one artifact per required type.
@@ -506,7 +568,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     // single legitimate artifact (first in the required list) and log a loud
     // warning. Reality gates downstream will accurately detect missing types
     // instead of passing on duplicated garbage data.
-    if (!stepProvidedTypedArtifacts && requiredArtifacts.length > 1) {
+    if (!producedFromPersisted && !stepProvidedTypedArtifacts && requiredArtifacts.length > 1) {
       try {
         // SD-ARTIFACT-ORCH-001-A: Query existing artifacts for dedup
         const { data: existingRows } = await supabase
@@ -609,8 +671,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   if (isFinalStage(resolvedStage)) {
     logger.log(`[Eva] Final stage ${resolvedStage} reached for venture ${ventureId} — invoking post-lifecycle handler`);
 
-    // Persist artifacts before handing off
-    if (!options.dryRun) {
+    // Persist artifacts before handing off (FR-1: never re-persist on a re-gate-only run)
+    if (!options.dryRun && !producedFromPersisted) {
       await persistArtifacts(supabase, ventureId, resolvedStage, artifacts, options.idempotencyKey, { visionKey, planKey });
     }
 
@@ -658,8 +720,10 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   }
 
   // ── 4d. Persist artifacts (before gate evaluation so reality gates can query DB) ──
+  // FR-1: a re-gate-only run reads already-persisted artifacts — never re-persist (no overwrite of
+  // the LOCKED truth_financial_model; preserves its created_at/identity).
   const earlyPersistSpan = tracer.startSpan('artifact_persistence_early');
-  if (!options.dryRun) {
+  if (!options.dryRun && !producedFromPersisted) {
     try {
       const persistedIds = await persistArtifacts(supabase, ventureId, resolvedStage, artifacts, options.idempotencyKey, { visionKey, planKey });
       artifacts = artifacts.map((a, i) => ({ ...a, id: persistedIds[i] }));
@@ -670,7 +734,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, artifacts, errors: [{ code: 'ARTIFACT_PERSIST_FAILED', message: err.message }], traceId: tracer.traceId });
     }
   } else {
-    tracer.endSpan(earlyPersistSpan.spanId, { status: 'skipped', metadata: { reason: 'dry_run' } });
+    tracer.endSpan(earlyPersistSpan.spanId, { status: 'skipped', metadata: { reason: producedFromPersisted ? 're_evaluate_only' : 'dry_run' } });
   }
 
   // ── 4e. Stage 14 ADR extraction (post-artifact persistence) ──
@@ -877,9 +941,21 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   const hasHardNonFinancialBlock = gateResults.some(
     g => g.passed === false && g.type !== 'stage_gate' && g.type !== 'autonomy_check'
   );
+  // SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-2): a STRONG Devil's-Advocate challenge at a
+  // kill gate is load-bearing — it must be able to route a numeric 'pass' to review (HELD), not stay
+  // advisory-only. Scoped/thresholded so a weak/uncertain DA does not over-trigger: the DA enum is
+  // challenge|concern|support (NO 'kill' — corrected at LEAD validation), so 'challenge' is the sole
+  // adverse verdict; a degraded fallback review is EXCLUDED; require >=2 high-severity risks.
+  const daHighSeverityRiskCount = Array.isArray(devilsAdvocateReview?.risks)
+    ? devilsAdvocateReview.risks.filter(r => r?.severity === 'high').length
+    : 0;
+  const strongDevilsAdvocateChallenge = isStrongDevilsAdvocateChallenge(devilsAdvocateReview);
+  // Route to review when the kill gate itself downgraded to conditional_pass (#5189/#5194) OR when a
+  // numeric 'pass' is overridden by a strong DA challenge (even if the LTV-CAC sensitivity did not flip).
   const isRouteToReview = atKillGateStage
-    && stageOutput?.decision === 'conditional_pass'
-    && !hasHardNonFinancialBlock;
+    && !hasHardNonFinancialBlock
+    && (stageOutput?.decision === 'conditional_pass'
+      || (stageOutput?.decision === 'pass' && strongDevilsAdvocateChallenge));
 
   if (isRouteToReview) {
     // SD-LEO-INFRA-FLAGSHIP-MUTATION-VERIFY-GATE-001: surface the would-be action and refute any
@@ -888,6 +964,12 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     assertActionPreviewConsistent(heldActionPreview, STATUS.HELD);
     // HOLD: keep the vision intact (NO archive), mint a pending chairman decision (non-null
     // health via resolveDecisionHealth / GATE-NULL-HEALTH-RESOLUTION-001), return HELD.
+    // FR-2: when a numeric 'pass' is routed to review by a strong DA challenge, record the DA-driven
+    // reason (a 'pass' carries no kill-gate reasons) so the chairman brief is accurate.
+    const daDrivenRoute = stageOutput?.decision === 'pass' && strongDevilsAdvocateChallenge;
+    const routeSummary = daDrivenRoute
+      ? `numeric pass overridden by a strong Devil's-Advocate challenge (${daHighSeverityRiskCount} high-severity risks): ${devilsAdvocateReview?.summary || 'adversarial review recommends reconsideration'}`
+      : (stageOutput.reasons?.[0]?.message || 'conditional pass — chairman/demand review');
     if (!options.dryRun && supabase) {
       try {
         await createOrReusePendingDecision({
@@ -899,8 +981,15 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
             reasons: stageOutput.reasons || [],
             remediationRoute: stageOutput.remediationRoute || null,
             gateResults,
+            ...(daDrivenRoute ? {
+              devilsAdvocate: {
+                overallAssessment: devilsAdvocateReview.overallAssessment,
+                highSeverityRiskCount: daHighSeverityRiskCount,
+                summary: devilsAdvocateReview.summary || null,
+              },
+            } : {}),
           },
-          summary: `Route to review (HOLD) at stage ${resolvedStage}: ${stageOutput.reasons?.[0]?.message || 'conditional pass — chairman/demand review'}`,
+          summary: `Route to review (HOLD) at stage ${resolvedStage}: ${routeSummary}`,
           supabase,
           logger,
         });

--- a/lib/eva/stage-templates/stage-05.js
+++ b/lib/eva/stage-templates/stage-05.js
@@ -333,6 +333,51 @@ export function evaluateKillGate({ roi3y, breakEvenMonth, ltvCacRatio, paybackMo
   return { decision: 'pass', blockProgression: false, reasons: [], remediationRoute: null };
 }
 
+/**
+ * SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-1): deterministic re-evaluation.
+ *
+ * Re-run the PURE kill gate against a LOCKED, persisted truth_financial_model artifact
+ * payload (no LLM, no I/O) so a re-gate of a held venture is reproducible: same persisted
+ * payload -> identical decision, every time. Reconstructs the gate inputs from the payload
+ * that `analyzeStage05` persists. Note the persisted payload carries `unitEconomics`
+ * (cac/ltv/ltvCacRatio/paybackMonths) but NOT `demandFeasibility` (it is derived, not stored),
+ * so the stressed LTV/CAC band is reconstructed from cac/ltv exactly as the producer derives it
+ * — this reproduces the #5189 demand-feasibility decision deterministically.
+ *
+ * @param {Object} payload - persisted truth_financial_model artifact_data
+ * @returns {{ decision: string, blockProgression: boolean, reasons: Object[], remediationRoute: string|null }}
+ */
+export function reEvaluateKillGateFromArtifact(payload) {
+  const p = payload || {};
+  const ue = p.unitEconomics || {};
+  const cac = Number(ue.cac);
+  const ltv = Number(ue.ltv);
+  // Prefer the precise ratio from cac/ltv (the stored ltvCacRatio is rounded to 2 decimals);
+  // fall back to the stored value, then null — evaluateKillGate is null-tolerant.
+  const ltvCacRatio = (Number.isFinite(cac) && cac > 0 && Number.isFinite(ltv))
+    ? ltv / cac
+    : (typeof ue.ltvCacRatio === 'number' ? ue.ltvCacRatio : null);
+  const roi3y = Number(p.roi3y);
+  const breakEvenMonth = (p.breakEvenMonth === null || p.breakEvenMonth === undefined)
+    ? null
+    : Number(p.breakEvenMonth);
+  const paybackMonths = Number(ue.paybackMonths);
+  // Reconstruct the demand-feasibility signal the producer derives (it is not persisted):
+  // hasEvidence stays false (no demand-evidence field exists) and the stressed band is
+  // recomputed from cac/ltv with the same multiplier the producer used.
+  const stressedLtvCacRatio = (Number.isFinite(cac) && cac > 0 && Number.isFinite(ltv))
+    ? ltv / (cac * DEMAND_CAC_STRESS_MULTIPLIER)
+    : 0;
+  const demandFeasibility = { hasEvidence: false, stressedLtvCacRatio };
+  return evaluateKillGate({
+    roi3y: Number.isFinite(roi3y) ? roi3y : 0,
+    breakEvenMonth,
+    ltvCacRatio,
+    paybackMonths: Number.isFinite(paybackMonths) ? paybackMonths : 0,
+    demandFeasibility,
+  });
+}
+
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage05;
 ensureOutputSchema(TEMPLATE);

--- a/tests/unit/eva/s5-killgate-deterministic-eval.test.js
+++ b/tests/unit/eva/s5-killgate-deterministic-eval.test.js
@@ -1,0 +1,162 @@
+/**
+ * SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-3)
+ *
+ * Tests for the deterministic S5 kill-gate re-evaluation (FR-1) and the strong
+ * Devil's-Advocate route-to-review predicate (FR-2).
+ *
+ * FR-1: reEvaluateKillGateFromArtifact runs the PURE kill gate against a LOCKED
+ *       persisted truth_financial_model payload — same payload -> same decision, every time.
+ * FR-2: isStrongDevilsAdvocateChallenge gates a numeric 'pass' to review (HELD) only for a
+ *       non-fallback 'challenge' verdict with >=2 high-severity risks (no over-trigger).
+ *
+ * Honors the #5189 demand-feasibility and #5194 route-to-review-HOLD contracts.
+ */
+import { describe, it, expect } from 'vitest';
+import { reEvaluateKillGateFromArtifact } from '../../../lib/eva/stage-templates/stage-05.js';
+import { isStrongDevilsAdvocateChallenge } from '../../../lib/eva/devils-advocate.js';
+
+// A representative persisted truth_financial_model payload (shape produced by analyzeStage05).
+// Strong economics: ROI >= 0.25, break-even <= 24, ltvCac >= 2, payback <= 18, and the stressed
+// LTV/CAC (ltv/(cac*3)) survives the demand stress -> full PASS.
+function passPayload() {
+  return {
+    roi3y: 0.9,
+    breakEvenMonth: 8,
+    unitEconomics: { cac: 1000, ltv: 9000, ltvCacRatio: 9, paybackMonths: 6 },
+  };
+}
+
+describe('FR-1: reEvaluateKillGateFromArtifact — deterministic re-evaluation', () => {
+  it('returns an IDENTICAL decision across N=5 evaluations of the same persisted payload', () => {
+    const payload = passPayload();
+    const decisions = [];
+    for (let i = 0; i < 5; i++) {
+      decisions.push(reEvaluateKillGateFromArtifact(payload).decision);
+    }
+    expect(new Set(decisions).size).toBe(1); // no run-to-run flip
+    expect(decisions[0]).toBe('pass');
+  });
+
+  it('does not mutate the input payload (pure)', () => {
+    const payload = passPayload();
+    const snapshot = JSON.stringify(payload);
+    reEvaluateKillGateFromArtifact(payload);
+    expect(JSON.stringify(payload)).toBe(snapshot);
+  });
+
+  it('reconstructs the demand-stress band from cac/ltv: a cost-pass that fails the stress -> conditional_pass (#5189)', () => {
+    // ltvCac = 2.4 (>=2 cost pass) but stressed ltv/(cac*3) = 0.8 (<2) and no demand evidence
+    // -> the demand-feasibility downgrade fires deterministically -> route-to-review.
+    const payload = {
+      roi3y: 0.9,
+      breakEvenMonth: 8,
+      unitEconomics: { cac: 1000, ltv: 2400, ltvCacRatio: 2.4, paybackMonths: 6 },
+    };
+    const r1 = reEvaluateKillGateFromArtifact(payload);
+    const r2 = reEvaluateKillGateFromArtifact(payload);
+    expect(r1.decision).toBe('conditional_pass');
+    expect(r2.decision).toBe(r1.decision); // deterministic
+  });
+
+  it('reproduces a KILL deterministically (ROI below the kill threshold)', () => {
+    const payload = {
+      roi3y: 0.05, // < 0.15 kill threshold
+      breakEvenMonth: 30,
+      unitEconomics: { cac: 1000, ltv: 1200, ltvCacRatio: 1.2, paybackMonths: 30 },
+    };
+    expect(reEvaluateKillGateFromArtifact(payload).decision).toBe('kill');
+    expect(reEvaluateKillGateFromArtifact(payload).decision).toBe('kill');
+  });
+
+  it('recomputes the precise ltv/cac (ignores the rounded stored ltvCacRatio) deterministically', () => {
+    // True ltv/cac = 1.998 (< LTV_CAC threshold 2) but the stored, rounded ratio is 2.0. The helper
+    // recomputes from cac/ltv, so the precise sub-threshold ratio is honored — and the verdict is
+    // reproducible. (Asserts determinism without coupling to the exact threshold value.)
+    const payload = {
+      roi3y: 0.9,
+      breakEvenMonth: 8,
+      unitEconomics: { cac: 1000, ltv: 1998, ltvCacRatio: 2.0, paybackMonths: 6 },
+    };
+    const a = reEvaluateKillGateFromArtifact(payload).decision;
+    const b = reEvaluateKillGateFromArtifact(payload).decision;
+    expect(a).toBe(b);
+  });
+});
+
+describe('FR-2: isStrongDevilsAdvocateChallenge — route-to-review predicate', () => {
+  const twoHighRisks = [
+    { risk: 'demand unvalidated', severity: 'high' },
+    { risk: 'inflated economics', severity: 'high' },
+    { risk: 'minor', severity: 'low' },
+  ];
+
+  it('is TRUE for a non-fallback challenge with >=2 high-severity risks', () => {
+    expect(isStrongDevilsAdvocateChallenge({
+      overallAssessment: 'challenge', isFallback: false, risks: twoHighRisks,
+    })).toBe(true);
+  });
+
+  it('is FALSE for a fallback (degraded) review even if it says challenge', () => {
+    expect(isStrongDevilsAdvocateChallenge({
+      overallAssessment: 'challenge', isFallback: true, risks: twoHighRisks,
+    })).toBe(false);
+  });
+
+  it('is FALSE for concern / support assessments', () => {
+    expect(isStrongDevilsAdvocateChallenge({ overallAssessment: 'concern', risks: twoHighRisks })).toBe(false);
+    expect(isStrongDevilsAdvocateChallenge({ overallAssessment: 'support', risks: twoHighRisks })).toBe(false);
+  });
+
+  it('is FALSE for a challenge with only ONE high-severity risk (no over-trigger)', () => {
+    expect(isStrongDevilsAdvocateChallenge({
+      overallAssessment: 'challenge',
+      risks: [{ risk: 'one', severity: 'high' }, { risk: 'two', severity: 'medium' }],
+    })).toBe(false);
+  });
+
+  it('is FALSE for a null/absent review', () => {
+    expect(isStrongDevilsAdvocateChallenge(null)).toBe(false);
+    expect(isStrongDevilsAdvocateChallenge(undefined)).toBe(false);
+  });
+});
+
+describe('FR-2: composed route-to-review decision (mirrors eva-orchestrator isRouteToReview)', () => {
+  // The orchestrator computes:
+  //   atKillGateStage && !hasHardNonFinancialBlock &&
+  //   (decision === 'conditional_pass' || (decision === 'pass' && strongDA))
+  function isRouteToReview({ stage, decision, hasHardBlock, review }) {
+    const atKillGateStage = (stage === 3 || stage === 5);
+    return atKillGateStage
+      && !hasHardBlock
+      && (decision === 'conditional_pass'
+        || (decision === 'pass' && isStrongDevilsAdvocateChallenge(review)));
+  }
+
+  const strongDA = {
+    overallAssessment: 'challenge', isFallback: false,
+    risks: [{ severity: 'high' }, { severity: 'high' }],
+  };
+  const weakDA = { overallAssessment: 'concern', risks: [{ severity: 'high' }] };
+
+  it('routes a numeric PASS to review when a strong DA challenges it at S5', () => {
+    expect(isRouteToReview({ stage: 5, decision: 'pass', hasHardBlock: false, review: strongDA })).toBe(true);
+  });
+
+  it('does NOT route a numeric PASS when the DA is weak/fallback/absent', () => {
+    expect(isRouteToReview({ stage: 5, decision: 'pass', hasHardBlock: false, review: weakDA })).toBe(false);
+    expect(isRouteToReview({ stage: 5, decision: 'pass', hasHardBlock: false, review: null })).toBe(false);
+  });
+
+  it('still routes a conditional_pass regardless of the DA (the #5189/#5194 path is unchanged)', () => {
+    expect(isRouteToReview({ stage: 5, decision: 'conditional_pass', hasHardBlock: false, review: null })).toBe(true);
+  });
+
+  it('never routes when a structural (hard non-financial) block is present', () => {
+    expect(isRouteToReview({ stage: 5, decision: 'conditional_pass', hasHardBlock: true, review: strongDA })).toBe(false);
+    expect(isRouteToReview({ stage: 5, decision: 'pass', hasHardBlock: true, review: strongDA })).toBe(false);
+  });
+
+  it('does not apply at non-kill-gate stages', () => {
+    expect(isRouteToReview({ stage: 7, decision: 'pass', hasHardBlock: false, review: strongDA })).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 — S5 kill-gate: deterministic re-eval + DA route-to-review

S5 is EVA's first authoritative KILL gate and the active-rung V1 clone is HELD on it — but the verdict was a **coin-flip** (the producer regenerated the financial model via LLM every run, so `pass` vs `conditional_pass` flipped run-to-run on the same venture state, and a re-run silently overwrote the locked model). Separately, the Devil's-Advocate that ran at this kill gate returned a strong challenge but was **advisory-only** — `evaluateKillGate` keyed solely on the LTV-CAC sensitivity.

### FR-1 — Deterministic re-evaluation (no LLM regen, no overwrite)
- New **pure** helper `reEvaluateKillGateFromArtifact(payload)` (`stage-05.js`): reconstructs the gate inputs from a persisted `truth_financial_model` payload and runs the already-pure `evaluateKillGate` → same persisted inputs ⇒ same decision, every time. The `#5189` demand-stress band is reconstructed from `cac/ltv` (it is derived, not persisted).
- `eva-orchestrator.processStage` gains an opt-in `options.reEvaluateOnly` path: loads the **LOCKED** persisted artifact(s) from `venture_artifacts` (not `financial_models`), **skips** the producer `step.execute` loop, the producing `onBeforeAnalysis` hook, multi-artifact extraction, and `persistArtifacts` (no overwrite). Regenerate stays the explicit default — with no current artifact (first run) it falls through to normal generation.

### FR-2 — A strong Devil's-Advocate challenge routes-to-review
- New **pure** predicate `isStrongDevilsAdvocateChallenge(review)` (`devils-advocate.js`): non-fallback + `overallAssessment === 'challenge'` (the enum is `challenge|concern|support` — there is **no** `kill` value; corrected at LEAD validation) + ≥2 high-severity risks.
- `isRouteToReview` now OR-s this with the existing `conditional_pass` case, so a numeric `pass` at the kill gate is routed to **HELD** (via the existing #5194 path) even when LTV-CAC sensitivity does not flip. Structural (hard non-financial) blocks are still **never** downgraded to HOLD. The HELD chairman brief records the DA-driven route reason + high-severity risk count.

### FR-3 — Tests
`tests/unit/eva/s5-killgate-deterministic-eval.test.js`: deterministic N=5 re-run, purity, demand→`conditional_pass`, low-ROI→`kill`, precise-ratio determinism, the strong-DA predicate truth table, and the composed route-to-review logic. Validated via a standalone node harness (18/18) since vitest excludes `**/.worktrees/**`; **CI runs the real suite from `main`.**

### Scope
LEAD-scoped to the S5 clone-blocker. Extending FR-2 DA-routes-review to the other kill gates (S3/S13/S24) is deferred to a follow-on SD (`SD-LEO-INFRA-KILLGATE-DA-ROUTE-EXTEND-S3-S13-S24-001`). Honors the `#5189` (demand-feasibility) and `#5194` (STATUS.HELD route-to-review) contracts.

Unblocks the chairman's iterate-clones-to-zero strategy: clone `091f2889` (held@S5) can now get a reproducible, reviewable kill-gate verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
