### PR TITLE
feat(SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001): generalize kill-gate determinism to all gates

### DIFF
--- a/lib/eva/devils-advocate.js
+++ b/lib/eva/devils-advocate.js
@@ -17,8 +17,10 @@
 
 import { OpenAIAdapter } from '../sub-agents/vetting/provider-adapters.js';
 
-// Gates where Devil's Advocate is invoked
-const KILL_GATES = [3, 5, 13, 24];
+// Gates where Devil's Advocate is invoked.
+// SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001: exported as the single source of truth so the
+// orchestrator's atKillGateStage / isRouteToReview predicates cover ALL kill gates (not a local literal).
+export const KILL_GATES = [3, 5, 13, 24];
 const PROMOTION_GATES = [17, 18, 23];
 const ALL_GATES = [...KILL_GATES, ...PROMOTION_GATES];
 
@@ -188,6 +190,38 @@ export function buildArtifactRecord(ventureId, review) {
     is_current: true,
     source: 'devils-advocate',
   };
+}
+
+/**
+ * SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001 (FR-3): load the LOCKED persisted Devil's-Advocate
+ * review for a stage so a re-eval REUSES it instead of regenerating the §5b DA via LLM (which would
+ * make the gate non-deterministic even with a deterministic kill verdict). writeArtifact persists the
+ * review object into `artifact_data` (it parses buildArtifactRecord's JSON content), so the row's
+ * artifact_data IS the review (overallAssessment, risks, isFallback, ...). Returns null when absent →
+ * the caller falls back to the existing generate path (first-run behavior unchanged). Fail-soft.
+ * @param {Object} supabase
+ * @param {string} ventureId
+ * @param {number} stageId
+ * @returns {Promise<Object|null>} the persisted review object, or null
+ */
+export async function loadPersistedDevilsAdvocate(supabase, ventureId, stageId) {
+  if (!supabase || !ventureId || stageId == null) return null;
+  try {
+    const { data, error } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', stageId)
+      .eq('artifact_type', 'system_devils_advocate_review')
+      .eq('is_current', true)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) return null;
+    const review = data && data[0] && data[0].artifact_data;
+    return (review && typeof review === 'object' && review.overallAssessment) ? review : null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Internal Helpers ────────────────────────────────────────────

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -22,7 +22,7 @@ import { ChairmanPreferenceStore } from './chairman-preference-store.js';
 import { evaluateDecision } from './decision-filter-engine.js';
 import { evaluateRealityGate, isGatedBoundary } from './reality-gates.js';
 import { attemptGateRecovery } from './gate-failure-recovery.js';
-import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord, mustProduceDevilsAdvocate, isKillGateFailLoud, isStrongDevilsAdvocateChallenge } from './devils-advocate.js';
+import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord, mustProduceDevilsAdvocate, isKillGateFailLoud, isStrongDevilsAdvocateChallenge, KILL_GATES, loadPersistedDevilsAdvocate } from './devils-advocate.js';
 // convertSprintToSDs + buildBridgeArtifactRecord moved to post-approval hook in stage-execution-worker.js
 import { writeArtifact, recordGateResult, advanceStage } from './artifact-persistence-service.js';
 import { ARTIFACT_TYPE_BY_STAGE } from './artifact-types.js';
@@ -37,7 +37,9 @@ import { retrieveKnowledge } from './utils/knowledge-retriever.js';
 import { getTemplate } from './stage-templates/index.js';
 // SD-LEO-INFRA-S5-KILLGATE-DETERMINISTIC-EVAL-001 (FR-1): pure, deterministic re-gate of the
 // LOCKED persisted truth_financial_model (reEvaluateOnly path — no LLM regen, no overwrite).
-import { reEvaluateKillGateFromArtifact } from './stage-templates/stage-05.js';
+// SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001: per-kill-gate deterministic recompute registry
+// (generalizes the #5206 S5-only re-eval to {3,5,13}).
+import { recomputeKillGateVerdict, hasKillGateRecompute } from './kill-gate-recompute.js';
 import { getContract, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
 // SD-REFILL-00V67JEB (FR-1): persist a runtime contract-enforcement coverage signal (fail-open).
 import { emitContractCoverage } from './contracts/contract-coverage.js';
@@ -536,19 +538,20 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
 
     stageOutput = mergeArtifactOutputs(artifacts, ventureContext);
 
-    // ── 4a.0b. Deterministic kill-gate recompute (FR-1) ──
-    // On a re-gate-only run at S5, re-run the PURE kill gate on the LOCKED persisted financial
-    // model so the verdict is reproducible (same persisted inputs -> same decision). This overwrites
-    // any stale `decision` merged from the artifact payload with the freshly-computed, deterministic one.
-    if (producedFromPersisted && resolvedStage === 5) {
-      const truth = artifacts.find(a => a.artifactType === 'truth_financial_model') || artifacts[0];
-      if (truth?.payload) {
-        const reGate = reEvaluateKillGateFromArtifact(truth.payload);
+    // ── 4a.0b. Deterministic kill-gate recompute (FR-1/FR-2) ──
+    // SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001: on a re-gate-only run at ANY kill gate with an
+    // artifact evaluator (per-gate recompute registry {3,5,13}; S5 was #5206), re-run the PURE kill
+    // gate on the LOCKED persisted artifact so the verdict is reproducible (same persisted inputs ->
+    // same decision). This overwrites any stale `decision` merged from the artifact payload with the
+    // freshly-computed, deterministic one. Generalizes the prior S5-only path (resolvedStage===5).
+    if (producedFromPersisted && hasKillGateRecompute(resolvedStage)) {
+      const reGate = recomputeKillGateVerdict(resolvedStage, artifacts);
+      if (reGate) {
         stageOutput.decision = reGate.decision;
         stageOutput.reasons = reGate.reasons;
         stageOutput.blockProgression = reGate.blockProgression;
-        stageOutput.remediationRoute = reGate.remediationRoute;
-        logger.log(`[Eva] reEvaluateOnly: deterministic S5 kill-gate decision='${reGate.decision}' (re-run on locked truth_financial_model)`);
+        if (reGate.remediationRoute !== undefined) stageOutput.remediationRoute = reGate.remediationRoute;
+        logger.log(`[Eva] reEvaluateOnly: deterministic kill-gate recompute stage ${resolvedStage} decision='${reGate.decision}' (re-run on locked persisted artifact)`);
       }
     }
 
@@ -867,6 +870,27 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   let devilsAdvocateReview = null;
   if (hasDAGate) {
     const isKillGate = isKillGateFailLoud(daGateType);
+    // SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001 (FR-3): on a re-eval, REUSE the locked persisted
+    // Devil's-Advocate review instead of regenerating it via LLM — otherwise the gate stays
+    // non-deterministic via the DA path even with a deterministic kill verdict. Fail-soft: an absent
+    // persisted DA falls through to the existing generate path (first-run behavior unchanged).
+    if (producedFromPersisted) {
+      const persistedDA = await loadPersistedDevilsAdvocate(supabase, ventureId, resolvedStage);
+      if (persistedDA) {
+        devilsAdvocateReview = persistedDA;
+        gateResults.push({
+          type: 'devils_advocate',
+          passed: true,
+          assessment: persistedDA.overallAssessment,
+          counterArguments: Array.isArray(persistedDA.counterArguments) ? persistedDA.counterArguments.length : 0,
+          isFallback: persistedDA.isFallback || false,
+          reusedFromPersisted: true,
+          ...(isKillGate ? { mandatoryKillGateReview: true } : {}),
+        });
+        logger.log(`[Eva] reEvaluateOnly: reusing PERSISTED Devil's-Advocate for stage ${resolvedStage} (no LLM regen)`);
+      }
+    }
+    if (!devilsAdvocateReview) {
     // Autonomy pre-check for devil's advocate
     const daAutonomy = await autonomyPreCheck(ventureId, 'devils_advocate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage);
     // Promotion gates may legitimately bypass on autonomy; KILL gates NEVER do — production is mandatory.
@@ -928,6 +952,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       gateResults.push({ type: 'devils_advocate', passed: true, error: err.message });
     }
     } // close autonomy-bypass else (manual DA / mandatory kill-gate DA)
+    } // close FR-3 if(!devilsAdvocateReview) — skip generate when a persisted DA was reused
   }
 
   // ── SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: distinguish a route-to-review / HOLD
@@ -937,7 +962,10 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   // must NOT return BLOCKED: keep the vision intact, mint a pending chairman_decision (whose
   // resolveDecisionHealth guarantees a non-null health_score), and return STATUS.HELD.
   // A structural failure (reality-gate / gate-eval error) is NEVER downgraded to HOLD. ──
-  const atKillGateStage = (resolvedStage === 3 || resolvedStage === 5);
+  // SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001 (FR-2): cover ALL kill gates [3,5,13,24] (the
+  // canonical devils-advocate.js KILL_GATES), not just 3||5, so the route-to-review/HELD path applies
+  // uniformly at every kill gate (S13/S24 previously fell through to a plain pass/kill).
+  const atKillGateStage = KILL_GATES.includes(resolvedStage);
   const hasHardNonFinancialBlock = gateResults.some(
     g => g.passed === false && g.type !== 'stage_gate' && g.type !== 'autonomy_check'
   );

--- a/lib/eva/kill-gate-recompute.js
+++ b/lib/eva/kill-gate-recompute.js
@@ -1,0 +1,59 @@
+/**
+ * Kill-gate deterministic recompute registry.
+ * SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001 (generalizes #5206 from S5-only)
+ *
+ * On a re-eval (run #2 re-traversing an already-decided kill gate), the orchestrator must recompute
+ * the gate verdict from the stage's LOCKED persisted artifact with NO LLM — so the same persisted
+ * inputs always yield the same decision. #5206 hardcoded this for S5; this registry generalizes it
+ * to every authoritative kill gate that has an artifact-based evaluator: {3, 5, 13}.
+ *
+ * S24 is intentionally absent: it has no artifact evaluateKillGate — its verdict derives from S23's
+ * persisted verdict (already gate-deterministic, no LLM), so it needs no artifact recompute. The
+ * orchestrator's kill-gate PREDICATES still cover S24 via devils-advocate.js KILL_GATES; only the
+ * artifact-recompute is scoped to {3,5,13}. A dedicated S24 recompute is a documented follow-on.
+ *
+ * Each entry is a PURE function (artifacts[]) -> verdict | null. It selects the relevant locked
+ * artifact and calls that stage's existing evaluateKillGate via its reEvaluateKillGateFromArtifact
+ * wrapper — the verdict logic itself is unchanged, only the artifact->args extraction is added.
+ *
+ * @module lib/eva/kill-gate-recompute
+ */
+
+import { reEvaluateKillGateFromArtifact as reEvalS3 } from './stage-templates/stage-03.js';
+import { reEvaluateKillGateFromArtifact as reEvalS5 } from './stage-templates/stage-05.js';
+import { reEvaluateKillGateFromArtifact as reEvalS13 } from './stage-templates/stage-13.js';
+
+/** Pick a persisted artifact payload: prefer `preferType`, else the first (primary) artifact. */
+function pickPayload(artifacts, preferType = null) {
+  if (!Array.isArray(artifacts) || artifacts.length === 0) return null;
+  const sel = (preferType && artifacts.find((a) => a?.artifactType === preferType)) || artifacts[0];
+  return sel?.payload || null;
+}
+
+/**
+ * The recompute registry: kill stage -> pure re-eval over its locked persisted artifact(s).
+ * Stage 5 selects its truth_financial_model artifact (matching the #5206 behavior); S3/S13 are
+ * single-primary-artifact stages so they read the first persisted artifact.
+ */
+export const KILL_GATE_RECOMPUTE = Object.freeze({
+  3: (artifacts) => { const p = pickPayload(artifacts); return p ? reEvalS3(p) : null; },
+  5: (artifacts) => { const p = pickPayload(artifacts, 'truth_financial_model'); return p ? reEvalS5(p) : null; },
+  13: (artifacts) => { const p = pickPayload(artifacts); return p ? reEvalS13(p) : null; },
+});
+
+/** True iff `stage` has a deterministic artifact recompute (3/5/13). */
+export function hasKillGateRecompute(stage) {
+  return Object.prototype.hasOwnProperty.call(KILL_GATE_RECOMPUTE, stage);
+}
+
+/**
+ * Recompute a kill gate's verdict deterministically from its locked persisted artifacts.
+ * @param {number} stage - resolved lifecycle stage
+ * @param {Array<{artifactType?:string, payload?:Object}>} artifacts - loaded persisted artifacts
+ * @returns {{decision:string, blockProgression:boolean, reasons:Object[], remediationRoute?:string|null}|null}
+ *   null when the stage has no recompute or no usable artifact (caller keeps the merged verdict).
+ */
+export function recomputeKillGateVerdict(stage, artifacts) {
+  const fn = KILL_GATE_RECOMPUTE[stage];
+  return fn ? fn(artifacts) : null;
+}

--- a/lib/eva/stage-templates/stage-03.js
+++ b/lib/eva/stage-templates/stage-03.js
@@ -227,6 +227,22 @@ export function evaluateKillGate({ overallScore, metrics, agenticFit }) {
   return { decision: 'revise', blockProgression: true, reasons };
 }
 
+/**
+ * SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001: deterministic re-eval over the LOCKED persisted
+ * Stage-3 artifact. Extracts the evaluator args from the persisted payload and runs the SAME pure
+ * evaluateKillGate (no LLM, no verdict-logic change) so a re-gate reproduces the original verdict.
+ * @param {Object} payload - the persisted Stage-3 artifact data (overallScore, metrics, agenticFit)
+ * @returns {{ decision: string, blockProgression: boolean, reasons: Object[] }}
+ */
+export function reEvaluateKillGateFromArtifact(payload) {
+  const p = payload || {};
+  return evaluateKillGate({
+    overallScore: Number.isFinite(Number(p.overallScore)) ? Number(p.overallScore) : 0,
+    metrics: (p.metrics && typeof p.metrics === 'object') ? p.metrics : {},
+    agenticFit: p.agenticFit,
+  });
+}
+
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage03;
 ensureOutputSchema(TEMPLATE);

--- a/lib/eva/stage-templates/stage-13.js
+++ b/lib/eva/stage-templates/stage-13.js
@@ -186,6 +186,22 @@ export function evaluateKillGate({ milestone_count, milestones, timeline_months 
   };
 }
 
+/**
+ * SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001: deterministic re-eval over the LOCKED persisted
+ * Stage-13 roadmap artifact. Extracts the evaluator args from the persisted payload and runs the
+ * SAME pure evaluateKillGate (no LLM, no verdict-logic change) so a re-gate (run #2) reproduces the
+ * original verdict — this is the run #2 blocker the SD prioritizes.
+ * @param {Object} payload - the persisted Stage-13 artifact data (milestones, timeline_months, milestone_count)
+ * @returns {{ decision: string, blockProgression: boolean, reasons: Object[] }}
+ */
+export function reEvaluateKillGateFromArtifact(payload) {
+  const p = payload || {};
+  const milestones = Array.isArray(p.milestones) ? p.milestones : [];
+  const milestone_count = Number.isFinite(Number(p.milestone_count)) ? Number(p.milestone_count) : milestones.length;
+  const timeline_months = Number.isFinite(Number(p.timeline_months)) ? Number(p.timeline_months) : 0;
+  return evaluateKillGate({ milestone_count, milestones, timeline_months });
+}
+
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage13;
 ensureOutputSchema(TEMPLATE);

--- a/tests/unit/eva/killgate-determinism.test.js
+++ b/tests/unit/eva/killgate-determinism.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests for kill-gate verdict determinism across ALL kill gates.
+ * SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001 (generalizes #5206 S5-only).
+ *
+ * TS-1 per-gate determinism (3/5/13) ; TS-2 registry dispatch ; TS-3 predicates broadened ;
+ * TS-4 S13 recompute from artifact (run#2 blocker) ; TS-5 DA persisted-read + strong-challenge.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  KILL_GATE_RECOMPUTE,
+  hasKillGateRecompute,
+  recomputeKillGateVerdict,
+} from '../../../lib/eva/kill-gate-recompute.js';
+import { KILL_GATES, isStrongDevilsAdvocateChallenge, loadPersistedDevilsAdvocate } from '../../../lib/eva/devils-advocate.js';
+
+// ── Fixtures: persisted artifacts shaped like each stage's locked output ─────
+const s3Pass = [{ artifactType: 'stage_3_analysis', payload: { overallScore: 82, metrics: { a: 80, b: 75, c: 70 } } }];
+const s3Kill = [{ artifactType: 'stage_3_analysis', payload: { overallScore: 20, metrics: { a: 40, b: 30, c: 25 } } }];
+const s5Pass = [{ artifactType: 'truth_financial_model', payload: { roi3y: 0.35, breakEvenMonth: 12, unitEconomics: { cac: 100, ltv: 500, paybackMonths: 8 } } }];
+const s13Pass = [{ artifactType: 'product_roadmap', payload: {
+  milestone_count: 3, timeline_months: 6,
+  milestones: [
+    { name: 'M1', deliverables: ['d1'], priority: 'now' },
+    { name: 'M2', deliverables: ['d2'], priority: 'next' },
+    { name: 'M3', deliverables: ['d3'], priority: 'later' },
+  ],
+} }];
+const s13Kill = [{ artifactType: 'product_roadmap', payload: {
+  milestone_count: 1, timeline_months: 1, milestones: [{ name: 'M1', deliverables: [], priority: 'later' }],
+} }];
+
+// ── TS-2: registry dispatch ──────────────────────────────────────────────────
+describe('kill-gate recompute registry', () => {
+  it('has recompute for kill gates with artifact evaluators (3/5/13), not others', () => {
+    expect(hasKillGateRecompute(3)).toBe(true);
+    expect(hasKillGateRecompute(5)).toBe(true);
+    expect(hasKillGateRecompute(13)).toBe(true);
+    expect(hasKillGateRecompute(24)).toBe(false); // no artifact evaluator (derives from S23)
+    expect(hasKillGateRecompute(7)).toBe(false);
+    expect(Object.keys(KILL_GATE_RECOMPUTE).map(Number).sort((a, b) => a - b)).toEqual([3, 5, 13]);
+  });
+  it('returns null for a stage with no recompute', () => {
+    expect(recomputeKillGateVerdict(7, [{ payload: {} }])).toBeNull();
+  });
+  it('returns null when no usable artifact is present', () => {
+    expect(recomputeKillGateVerdict(13, [])).toBeNull();
+    expect(recomputeKillGateVerdict(13, [{ artifactType: 'x' }])).toBeNull();
+  });
+});
+
+// ── TS-1: per-gate determinism ───────────────────────────────────────────────
+describe('per-gate determinism (same artifact -> identical verdict)', () => {
+  for (const [label, stage, arts] of [
+    ['S3 pass', 3, s3Pass], ['S3 kill', 3, s3Kill],
+    ['S5 pass', 5, s5Pass],
+    ['S13 pass', 13, s13Pass], ['S13 kill', 13, s13Kill],
+  ]) {
+    it(`${label} is deterministic across repeated recompute`, () => {
+      const a = recomputeKillGateVerdict(stage, arts);
+      const b = recomputeKillGateVerdict(stage, arts);
+      const c = recomputeKillGateVerdict(stage, arts);
+      expect(a).not.toBeNull();
+      expect(a).toEqual(b);
+      expect(b).toEqual(c);
+      expect(['pass', 'kill', 'revise', 'conditional_pass']).toContain(a.decision);
+    });
+  }
+});
+
+// ── TS-4: S13 recompute from artifact (the run#2 blocker) ────────────────────
+describe('S13 verdict recompute from persisted roadmap artifact', () => {
+  it('a complete roadmap (>=3 milestones, deliverables, timeline, now-priority) => pass', () => {
+    expect(recomputeKillGateVerdict(13, s13Pass).decision).toBe('pass');
+  });
+  it('an incomplete roadmap (<3 milestones / no deliverables / short timeline) => kill', () => {
+    const v = recomputeKillGateVerdict(13, s13Kill);
+    expect(v.decision).toBe('kill');
+    expect(v.blockProgression).toBe(true);
+    expect(v.reasons.length).toBeGreaterThan(0);
+  });
+});
+
+describe('S3 recompute from persisted scorecard artifact', () => {
+  it('strong composite => pass; catastrophic => kill', () => {
+    expect(recomputeKillGateVerdict(3, s3Pass).decision).toBe('pass');
+    expect(recomputeKillGateVerdict(3, s3Kill).decision).toBe('kill');
+  });
+});
+
+// ── TS-3: kill-gate predicates broadened to the full KILL_GATES set ──────────
+describe('KILL_GATES (single source of truth)', () => {
+  it('covers all four kill gates', () => {
+    expect(KILL_GATES).toEqual([3, 5, 13, 24]);
+    for (const g of [3, 5, 13, 24]) expect(KILL_GATES.includes(g)).toBe(true);
+    expect(KILL_GATES.includes(7)).toBe(false);
+  });
+});
+
+// ── TS-5: DA persisted-read + strong-challenge predicate ─────────────────────
+function mockSupabaseDA(artifactData) {
+  const b = {
+    select: () => b, eq: () => b, order: () => b,
+    limit: () => Promise.resolve({ data: artifactData === undefined ? [] : [{ artifact_data: artifactData }], error: null }),
+  };
+  return { from: () => b };
+}
+
+describe('loadPersistedDevilsAdvocate (FR-3 determinism)', () => {
+  it('returns the persisted review object (artifact_data IS the review)', async () => {
+    const review = { overallAssessment: 'challenge', risks: [{ severity: 'high' }, { severity: 'high' }], isFallback: false, counterArguments: ['c1'] };
+    const got = await loadPersistedDevilsAdvocate(mockSupabaseDA(review), 'v1', 13);
+    expect(got).toEqual(review);
+  });
+  it('a persisted strong-challenge review trips isStrongDevilsAdvocateChallenge (deterministic route-to-review)', async () => {
+    const review = { overallAssessment: 'challenge', risks: [{ severity: 'high' }, { severity: 'high' }], isFallback: false };
+    const got = await loadPersistedDevilsAdvocate(mockSupabaseDA(review), 'v1', 5);
+    expect(isStrongDevilsAdvocateChallenge(got)).toBe(true);
+  });
+  it('returns null when no persisted DA exists (falls back to generate)', async () => {
+    expect(await loadPersistedDevilsAdvocate(mockSupabaseDA(undefined), 'v1', 3)).toBeNull();
+  });
+  it('returns null on a malformed/empty artifact_data', async () => {
+    expect(await loadPersistedDevilsAdvocate(mockSupabaseDA({}), 'v1', 3)).toBeNull();
+    expect(await loadPersistedDevilsAdvocate(null, 'v1', 3)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
PR #5206 fixed kill-gate verdict non-determinism for **S5 only** (hardcoded `resolvedStage===5`). Every other kill gate still re-ran its LLM producer on a re-eval, so a **run #2 re-traversal diverges — imminently at S13**. This generalizes the fix to all kill gates.

## FRs
- **FR-1** — NEW `lib/eva/kill-gate-recompute.js`: a per-kill-gate recompute registry `{3,5,13}` mapping each stage to a pure `reEvaluateKillGateFromArtifact` over its LOCKED persisted artifact (no LLM). `stage-03` + `stage-13` gain wrappers around their existing `evaluateKillGate` (verdict logic unchanged — only artifact→args extraction). S5 reused as-is.
- **FR-2** — `eva-orchestrator` broadens the re-eval gate from `resolvedStage===5` to `hasKillGateRecompute()`, and `atKillGateStage`/`isRouteToReview` from `(3||5)` to the canonical `KILL_GATES [3,5,13,24]` (now exported from `devils-advocate.js` as the single source of truth) → route-to-review/HELD applies at every gate.
- **FR-3** — on a re-eval the orchestrator **READS** the locked persisted Devil's-Advocate artifact (`loadPersistedDevilsAdvocate`) instead of regenerating it via LLM, closing the DA non-determinism hole. Fail-soft: absent persisted DA → existing generate path (first-run unchanged).

## Scope note
S24 has no artifact `evaluateKillGate` (its verdict derives from S23's persisted verdict — already gate-deterministic, no LLM); it's covered by the predicate-broadening + DA-read but not the recompute registry. A dedicated S24 artifact-recompute is a documented follow-on.

## Tests
16 new unit tests (determinism for 3/5/13, registry dispatch, KILL_GATES, S13 recompute, DA persisted-read). **94/94 across 6 suites** (new + devils-advocate + kill-gate + orchestrator), no regression. First-run behavior unchanged (additive). **S13 prioritized — the run #2 blocker.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)