### PR TITLE
fix(SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001): root-fix the NULL-health class + stop phantom future-stage rows

### DIFF
--- a/lib/adam/briefings/venture.js
+++ b/lib/adam/briefings/venture.js
@@ -9,12 +9,18 @@
  * (health + advisory_data), venture_separability_scores, L2 eva_vision_documents.
  * Empty tables = "no signal", not "missing".
  */
-export function summarizeVenture({ ventureId, competitors = [], stageWork = [], separability = [], visionDocs = [] } = {}) {
-  const blocked = stageWork.filter((w) => w && (w.stage_status === 'blocked' || w.health_score === 'red'));
+export function summarizeVenture({ ventureId, competitors = [], stageWork = [], separability = [], visionDocs = [], currentStage = null } = {}) {
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-3: ignore phantom future-stage rows
+  // (lifecycle_stage > the venture's current_lifecycle_stage) so a held-below-stage venture's
+  // health rollup is not poisoned. Defensive: rows without a lifecycle_stage are kept.
+  const scopedStageWork = currentStage == null
+    ? stageWork
+    : stageWork.filter((w) => w && (w.lifecycle_stage == null || w.lifecycle_stage <= currentStage));
+  const blocked = scopedStageWork.filter((w) => w && (w.stage_status === 'blocked' || w.health_score === 'red'));
   const hasL2Vision = visionDocs.some((v) => v && v.level === 'L2' && v.chairman_approved);
   const signals = {
     competitors: competitors.length,
-    stage_work_rows: stageWork.length,
+    stage_work_rows: scopedStageWork.length,
     blocked_or_red: blocked.length,
     separability_scored: separability.length,
     l2_vision_present: hasL2Vision,
@@ -55,14 +61,22 @@ export async function briefVenture(supabase, ventureId) {
   const competitors = await safe(async () =>
     (await supabase.from('competitors').select('id').eq('venture_id', ventureId)).data
   );
-  const stageWork = await safe(async () =>
-    (await supabase.from('venture_stage_work').select('stage_status, health_score').eq('venture_id', ventureId)).data
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-3: bound the stage-work read to stages the venture
+  // has actually reached, so phantom future-stage rows can never enter the rollup.
+  const ventureRow = await safe(async () =>
+    [(await supabase.from('ventures').select('current_lifecycle_stage').eq('id', ventureId).maybeSingle()).data]
   );
+  const currentStage = ventureRow?.[0]?.current_lifecycle_stage ?? null;
+  const stageWork = await safe(async () => {
+    let q = supabase.from('venture_stage_work').select('lifecycle_stage, stage_status, health_score').eq('venture_id', ventureId);
+    if (currentStage != null) q = q.lte('lifecycle_stage', currentStage);
+    return (await q).data;
+  });
   const separability = await safe(async () =>
     (await supabase.from('venture_separability_scores').select('overall_score').eq('venture_id', ventureId).order('scored_at', { ascending: false }).limit(1)).data
   );
   const visionDocs = await safe(async () =>
     (await supabase.from('eva_vision_documents').select('level, chairman_approved').eq('venture_id', ventureId).eq('level', 'L2')).data
   );
-  return summarizeVenture({ ventureId, competitors, stageWork, separability, visionDocs });
+  return summarizeVenture({ ventureId, competitors, stageWork, separability, visionDocs, currentStage });
 }

--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -295,12 +295,27 @@ export async function resolveDecisionHealth(supabase, ventureId, stageNumber, lo
   }
 }
 
+// SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-2: a kill-gate HOLD / route-to-review is NOT a
+// failure — the gate verdict ('pass' = numeric pass routed for review, 'conditional_pass' =
+// pass-with-review) must drive the held venture's health, not the sparse advisory_data which would
+// otherwise resolve to a blanket RED. Map the gate decision to a traffic-light; return null for a
+// genuine fail / unknown so the normal advisory-derived resolution still applies.
+export function gateDecisionToHealth(decision) {
+  if (decision === 'pass') return 'green';
+  if (decision === 'conditional_pass') return 'yellow';
+  return null;
+}
+
 export async function createOrReusePendingDecision({
   ventureId,
   stageNumber,
   briefData = null,
   summary = null,
   decisionType = 'stage_gate',
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-2: when the caller knows the authoritative gate
+  // verdict (e.g. a route-to-review HOLD), it supplies the gate-derived health here; it takes
+  // precedence over resolveDecisionHealth so a numeric-PASS HOLD is not stamped RED.
+  healthOverride = null,
   supabase,
   logger = console,
 }) {
@@ -332,7 +347,7 @@ export async function createOrReusePendingDecision({
     // too. A reused PENDING decision previously kept its original (possibly stale/wrong) health_score
     // forever — so a re-grounded/approved stage that flipped GREEN still showed RED. Re-read the
     // CURRENT stage's health and update it alongside brief_data.
-    const refreshedHealth = await resolveDecisionHealth(supabase, ventureId, stageNumber, logger);
+    const refreshedHealth = healthOverride != null ? healthOverride : await resolveDecisionHealth(supabase, ventureId, stageNumber, logger);
     if (briefData || refreshedHealth !== null) {
       const update = {};
       if (briefData) { update.brief_data = briefData; update.summary = summary; }
@@ -358,7 +373,7 @@ export async function createOrReusePendingDecision({
   // SD-LEO-INFRA-GATE-NULL-HEALTH-RESOLUTION-001: resolveDecisionHealth never returns null for a
   // first-visit clone stage — it falls back to the current stage's advisory_data so the mint can be
   // resolved by the auto-gate instead of wedging on a NULL health_score.
-  const healthScore = await resolveDecisionHealth(supabase, ventureId, stageNumber, logger);
+  const healthScore = healthOverride != null ? healthOverride : await resolveDecisionHealth(supabase, ventureId, stageNumber, logger);
 
   // Create new PENDING decision — always set decision_type to avoid NULL
   // (SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: NULL decision_type breaks .neq filters)

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -28,7 +28,7 @@ import { writeArtifact, recordGateResult, advanceStage } from './artifact-persis
 import { ARTIFACT_TYPE_BY_STAGE } from './artifact-types.js';
 import { extractAndPersistADRs } from './adr-extractor.js';
 import { handlePostLifecycleDecision, isFinalStage } from './post-lifecycle-decisions.js';
-import { createOrReusePendingDecision, waitForDecision, createAdvisoryNotification } from './chairman-decision-watcher.js';
+import { createOrReusePendingDecision, waitForDecision, createAdvisoryNotification, gateDecisionToHealth } from './chairman-decision-watcher.js';
 import { OrchestratorTracer } from './observability.js';
 import { autonomyPreCheck } from './autonomy-model.js';
 import { VentureStateMachine } from '../agents/venture-state-machine.js';
@@ -990,6 +990,10 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
             } : {}),
           },
           summary: `Route to review (HOLD) at stage ${resolvedStage}: ${routeSummary}`,
+          // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-2: a HOLD on a numeric/conditional PASS must
+          // reflect the gate verdict (pass->green, conditional_pass->yellow), not a blanket RED derived
+          // from sparse advisory_data. Null for any other decision falls back to normal resolution.
+          healthOverride: gateDecisionToHealth(stageOutput.decision),
           supabase,
           logger,
         });

--- a/lib/eva/event-bus/handlers/sd-completed.js
+++ b/lib/eva/event-bus/handlers/sd-completed.js
@@ -227,10 +227,28 @@ export async function handleSdCompleted(payload, context) {
     (stageStatus === 'completed' ? ' - SPRINT COMPLETE' : ''),
   );
 
-  // When all siblings reach terminal state, write Stage 20 (QA) and Stage 21 (Integration) data
+  // When all siblings reach terminal state, write Stage 20 (QA) and Stage 21 (Integration) data.
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-3: gate the writes on the venture's
+  // current_lifecycle_stage — NEVER write a future-stage venture_stage_work row (a venture held
+  // below S20/S21, e.g. route-to-review at S5, must not get phantom S20/S21 rows that then poison
+  // the health rollup). Only write a stage row when the venture has actually reached that stage.
   if (allTerminal && totalTasks > 0) {
-    await writeStage20QAData(supabase, ventureId, tasks, failedSiblings, completedTasks, totalTasks, completionPct);
-    await writeStage21IntegrationData(supabase, ventureId, tasks, siblings, failedSiblings, completedTasks, totalTasks);
+    const { data: vRow } = await supabase
+      .from('ventures')
+      .select('current_lifecycle_stage')
+      .eq('id', ventureId)
+      .maybeSingle();
+    const currentStage = vRow?.current_lifecycle_stage ?? 0;
+    if (currentStage >= 20) {
+      await writeStage20QAData(supabase, ventureId, tasks, failedSiblings, completedTasks, totalTasks, completionPct);
+    } else {
+      console.log(`[SdCompleted] Skipping Stage 20 write for venture ${ventureId}: current_lifecycle_stage=${currentStage} (< 20) — no phantom future-stage row`);
+    }
+    if (currentStage >= 21) {
+      await writeStage21IntegrationData(supabase, ventureId, tasks, siblings, failedSiblings, completedTasks, totalTasks);
+    } else {
+      console.log(`[SdCompleted] Skipping Stage 21 write for venture ${ventureId}: current_lifecycle_stage=${currentStage} (< 21) — no phantom future-stage row`);
+    }
   }
 
   return {

--- a/lib/eva/health-score-computer.js
+++ b/lib/eva/health-score-computer.js
@@ -32,7 +32,11 @@ export function isSkipStub(advisoryData) {
 }
 
 export function computeHealthScore(advisoryData) {
-  if (!advisoryData || typeof advisoryData !== 'object') return 0;
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-1 (ROOT): never return a numeric 0 / NULL —
+  // venture_stage_work.health_score has a CHECK IN ('green','yellow','red'), so a numeric 0 is a
+  // latent constraint violation and the source of the whole NULL-health class. No advisory =
+  // no artifact to pass = fail-closed 'red' (a deterministic non-null verdict the gate can act on).
+  if (!advisoryData || typeof advisoryData !== 'object') return 'red';
 
   // SD-LEO-INFRA-CHAIRMAN-DECISION-HEALTH-PROVENANCE-001 FR-2: a pre_exec_skip (or otherwise
   // skipped/structural) advisory_data stub is NOT unhealthy — it is a deliberate skip with no

--- a/scripts/cleanup-phantom-future-stage-rows.mjs
+++ b/scripts/cleanup-phantom-future-stage-rows.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-4
+ *
+ * One-time (idempotent) data sweep: delete phantom future-stage venture_stage_work rows —
+ * rows whose lifecycle_stage exceeds the venture's current_lifecycle_stage. These were written
+ * by the (now-gated, FR-3) sd-completed.js S20/S21 writer for ventures held below those stages,
+ * and they poison the health rollup. Scoped strictly to lifecycle_stage > current_lifecycle_stage,
+ * so no legitimate at-or-below-current row is ever touched.
+ *
+ * Usage:
+ *   node scripts/cleanup-phantom-future-stage-rows.mjs          # dry-run (default) — reports only
+ *   node scripts/cleanup-phantom-future-stage-rows.mjs --apply  # perform the scoped delete
+ *
+ * The correlated predicate (lifecycle_stage > ventures.current_lifecycle_stage) is computed in JS
+ * (the Supabase JS client can't express the cross-table comparison), then rows are deleted by id.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function main() {
+  const { data: ventures, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, name, current_lifecycle_stage');
+  if (vErr) throw new Error(`ventures read failed: ${vErr.message}`);
+  const currentByVenture = new Map(ventures.map((v) => [v.id, v.current_lifecycle_stage ?? 0]));
+
+  const { data: rows, error: wErr } = await supabase
+    .from('venture_stage_work')
+    .select('id, venture_id, lifecycle_stage');
+  if (wErr) throw new Error(`venture_stage_work read failed: ${wErr.message}`);
+
+  const phantom = rows.filter((r) => {
+    const cur = currentByVenture.get(r.venture_id);
+    return cur != null && r.lifecycle_stage != null && r.lifecycle_stage > cur;
+  });
+
+  console.log(`[cleanup] total venture_stage_work rows: ${rows.length}`);
+  console.log(`[cleanup] phantom future-stage rows (lifecycle_stage > current_lifecycle_stage): ${phantom.length}`);
+  for (const p of phantom) {
+    const v = ventures.find((x) => x.id === p.venture_id);
+    console.log(`  - venture "${v?.name || p.venture_id}" current=${currentByVenture.get(p.venture_id)} phantom stage=${p.lifecycle_stage} (row ${p.id})`);
+  }
+
+  if (phantom.length === 0) {
+    console.log('[cleanup] nothing to delete.');
+    return;
+  }
+  if (!APPLY) {
+    console.log('[cleanup] DRY-RUN — re-run with --apply to delete the rows above.');
+    return;
+  }
+
+  const ids = phantom.map((p) => p.id);
+  const { error: dErr, count } = await supabase
+    .from('venture_stage_work')
+    .delete({ count: 'exact' })
+    .in('id', ids);
+  if (dErr) throw new Error(`delete failed: ${dErr.message}`);
+  console.log(`[cleanup] DELETED ${count ?? ids.length} phantom future-stage row(s).`);
+}
+
+main().catch((e) => { console.error(e.message); process.exit(1); });

--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -236,6 +236,34 @@ describe('createOrReusePendingDecision', () => {
     );
   });
 
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-2: a healthOverride (gate-derived health for a
+  // route-to-review HOLD) takes precedence over the advisory-derived resolveDecisionHealth, so a
+  // numeric-PASS HOLD is stamped green, not a blanket red.
+  it('stamps healthOverride on the minted decision when provided', async () => {
+    const insertFn = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: { id: 'new-id' }, error: null }),
+      }),
+    });
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null }), // No existing
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+        insert: insertFn,
+      }),
+    };
+
+    await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 5, healthOverride: 'green', supabase, logger,
+    });
+
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({ health_score: 'green' }),
+    );
+  });
+
   // SD-MAN-FIX-FIX-DUPLICATE-ARTIFACTS-001: custom decision_type is preserved
   it('uses custom decision_type when provided', async () => {
     const insertFn = vi.fn().mockReturnValue({

--- a/tests/unit/eva/health-rollup-correctness.test.js
+++ b/tests/unit/eva/health-rollup-correctness.test.js
@@ -1,0 +1,58 @@
+/**
+ * Health-rollup correctness — FR-2 + FR-3 unit tests
+ * SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001
+ */
+import { describe, it, expect } from 'vitest';
+import { gateDecisionToHealth } from '../../../lib/eva/chairman-decision-watcher.js';
+import { summarizeVenture } from '../../../lib/adam/briefings/venture.js';
+
+describe('FR-2 gateDecisionToHealth — held-venture health from the gate verdict', () => {
+  it('numeric pass -> green (a HOLD on a PASS is not RED)', () => {
+    expect(gateDecisionToHealth('pass')).toBe('green');
+  });
+  it('conditional_pass -> yellow', () => {
+    expect(gateDecisionToHealth('conditional_pass')).toBe('yellow');
+  });
+  it('a genuine fail / unknown -> null (fall back to normal advisory resolution)', () => {
+    expect(gateDecisionToHealth('fail')).toBeNull();
+    expect(gateDecisionToHealth('kill')).toBeNull();
+    expect(gateDecisionToHealth(undefined)).toBeNull();
+  });
+});
+
+describe('FR-3 summarizeVenture — ignores phantom future-stage rows', () => {
+  const ventureId = 'v-1';
+
+  it('excludes rows with lifecycle_stage > currentStage from the rollup', () => {
+    const stageWork = [
+      { lifecycle_stage: 5, stage_status: 'completed', health_score: 'green' },
+      { lifecycle_stage: 20, stage_status: 'completed', health_score: 'red' }, // phantom (venture held@5)
+      { lifecycle_stage: 21, stage_status: 'blocked', health_score: 'red' },   // phantom
+    ];
+    const out = summarizeVenture({ ventureId, stageWork, currentStage: 5 });
+    expect(out.signals.stage_work_rows).toBe(1); // only the in-range S5 row
+    expect(out.signals.blocked_or_red).toBe(0);  // phantom red rows excluded
+  });
+
+  it('counts a real in-range red row', () => {
+    const stageWork = [{ lifecycle_stage: 5, stage_status: 'completed', health_score: 'red' }];
+    const out = summarizeVenture({ ventureId, stageWork, currentStage: 5 });
+    expect(out.signals.blocked_or_red).toBe(1);
+  });
+
+  it('keeps rows without a lifecycle_stage (defensive)', () => {
+    const stageWork = [{ stage_status: 'blocked', health_score: 'red' }];
+    const out = summarizeVenture({ ventureId, stageWork, currentStage: 5 });
+    expect(out.signals.blocked_or_red).toBe(1);
+  });
+
+  it('no filtering when currentStage is null (back-compat)', () => {
+    const stageWork = [
+      { lifecycle_stage: 5, health_score: 'green' },
+      { lifecycle_stage: 20, health_score: 'red' },
+    ];
+    const out = summarizeVenture({ ventureId, stageWork });
+    expect(out.signals.stage_work_rows).toBe(2);
+    expect(out.signals.blocked_or_red).toBe(1);
+  });
+});

--- a/tests/unit/eva/killgate-route-to-review.test.js
+++ b/tests/unit/eva/killgate-route-to-review.test.js
@@ -41,7 +41,10 @@ vi.mock('../../../lib/eva/devils-advocate.js', async (importOriginal) => ({
 // vi.hoisted so the spy exists before the hoisted vi.mock factory runs.
 const { mintSpy } = vi.hoisted(() => ({ mintSpy: vi.fn() }));
 mintSpy.mockResolvedValue({ id: 'dec-hold-1', health_score: 'red' });
-vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', async (importOriginal) => ({
+  // Spread the real module so pure helpers (e.g. gateDecisionToHealth — SD-LEO-INFRA-HEALTH-ROLLUP-
+  // CORRECTNESS-001 FR-2) keep their real impl; only the side-effecting fns are mocked.
+  ...(await importOriginal()),
   createOrReusePendingDecision: mintSpy,
   waitForDecision: vi.fn(),
   createAdvisoryNotification: vi.fn(),

--- a/tests/unit/health-score-computer.test.js
+++ b/tests/unit/health-score-computer.test.js
@@ -7,9 +7,20 @@ import { describe, it, expect } from 'vitest';
 import { computeHealthScore } from '../../lib/eva/health-score-computer.js';
 
 describe('computeHealthScore', () => {
-  it('returns 0 for null input', () => {
-    expect(computeHealthScore(null)).toBe(0);
-    expect(computeHealthScore(undefined)).toBe(0);
+  // SD-LEO-INFRA-HEALTH-ROLLUP-CORRECTNESS-001 FR-1: the ROOT fix — invalid/missing advisory must
+  // yield a valid health STRING ('red'), never numeric 0 (which violates the health_score CHECK).
+  it('returns "red" (never numeric 0) for null/invalid input', () => {
+    expect(computeHealthScore(null)).toBe('red');
+    expect(computeHealthScore(undefined)).toBe('red');
+    expect(computeHealthScore(42)).toBe('red');
+    expect(computeHealthScore('not-an-object')).toBe('red');
+  });
+
+  it('never returns a non-string for any input', () => {
+    for (const input of [null, undefined, 0, 42, 'x', [], {}, { status: 'ok' }, { a: 1, b: 2, c: { d: 3 } }]) {
+      expect(typeof computeHealthScore(input)).toBe('string');
+      expect(['red', 'yellow', 'green']).toContain(computeHealthScore(input));
+    }
   });
 
   it('returns red for empty object', () => {


### PR DESCRIPTION
## Summary
Fixes the health-rollup correctness class at its root + two downstream leaks (one cohesive change — the SD's "Decompose-at-PLAN" hint is refuted by the call-site analysis). Exact line refs found by investigation + the DATABASE/TESTING/DESIGN sub-agents.

## FRs
- **FR-1 (ROOT)** — `health-score-computer.js` `computeHealthScore` returns `'red'` (not numeric `0`) for null/invalid advisory. `0` violated the `venture_stage_work.health_score` CHECK (`IN ('green','yellow','red')`) and was the source of the whole NULL-health class. Flipped the bug-codifying test.
- **FR-2** — kill-gate HOLD / route-to-review health now derives from the **gate verdict**, not sparse advisory. New pure `gateDecisionToHealth(decision)` (pass→green, conditional_pass→yellow, else null) + a `healthOverride` param on `createOrReusePendingDecision` that takes precedence over `resolveDecisionHealth`; the orchestrator passes it at the HOLD mint, so a numeric-PASS HOLD is no longer a blanket RED.
- **FR-3** — `sd-completed.js` S20/S21 writer gated on `ventures.current_lifecycle_stage` (never writes a future-stage row); `lib/adam/briefings/venture.js` bounds its stage-work read + `summarizeVenture` filters `lifecycle_stage <= current` so phantom rows can't poison the rollup.
- **FR-4** — `scripts/cleanup-phantom-future-stage-rows.mjs` (dry-run default, `--apply`): scoped sweep of rows where `lifecycle_stage > current_lifecycle_stage`. **Applied: 9 phantom rows deleted, 0 remain** (incl. Canvas AI/CronLinter @19, Market Modeling SaaS clean-clone @7). FK-safe per the DATABASE sub-agent (capital_transactions `ON DELETE SET NULL`, 0 refs).
- **FR-5** — 14 new/updated unit tests. Affected suites **42/42** + killgate/flagship **19/19** green.

Backend EVA + a bounded one-time data sweep; no UI, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)