### PR TITLE
fix(SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-OVERFIRE-001): stop STUCK auto-signal over-fire

### DIFF
--- a/lib/hooks/auto-signal-threshold.cjs
+++ b/lib/hooks/auto-signal-threshold.cjs
@@ -20,25 +20,33 @@
 
 /**
  * Should the enforcement layer auto-emit a /signal at this RCA recurrence attempt?
- * Fires EXACTLY ONCE per signature escalation — on the 2nd-attempt crossing (the warn tier). The
- * 3rd attempt hard-blocks (handled by the hook) and must NOT re-signal (dedupe by exact ===2).
+ * Fires EXACTLY ONCE per signature escalation — on the 3rd SAME-signature repeat (a genuine
+ * stuck-retry at the hard-block). The per-signature counter (retry-state-manager) means this is the
+ * same command tried 3 times, NOT 3 distinct commands — so dedupe is by exact ===3.
+ *
+ * SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-OVERFIRE-001 (a): raised the threshold from ===2 to ===3. The
+ * 2nd-crossing emit OVER-FIRED — a single recurrence is one repeat from a hard block, not yet a stuck
+ * loop — flooding the coordinator inbox and drowning real signals. (b): coordinator / Adam /
+ * monitoring-cadence sessions benignly re-run the same script every tick and trip the counter; they
+ * must NEVER auto-signal STUCK. The caller classifies the session (is_coordinator / role=adam /
+ * known cadence script) and passes `isCoordinatorSession`; this module stays PURE (no I/O).
  *
  * SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001 (Control 3): re-scope the emit to genuine
  * no-progress. The caller computes `progressStalled` (phase/percent unchanged across the
- * repetition) from the already-loaded unified-session-state — this module stays PURE (no I/O).
- * When `progressStalled === false` (the session is demonstrably advancing) the signal is
- * suppressed even at the ===2 crossing; `undefined` preserves the prior fire-on-crossing
- * behavior (back-compat) so a caller that cannot compute progress is unaffected.
+ * repetition) from the already-loaded unified-session-state. When `progressStalled === false`
+ * (the session is demonstrably advancing) the signal is suppressed even at the crossing;
+ * `undefined` preserves the fire-on-crossing behavior (back-compat).
  *
- * @param {{ attempts:number, sessionId?:string, progressStalled?:boolean, env?:object }} opts
+ * @param {{ attempts:number, sessionId?:string, progressStalled?:boolean, isCoordinatorSession?:boolean, env?:object }} opts
  * @returns {boolean}
  */
-function shouldEmitAutoSignal({ attempts, sessionId, progressStalled, env = process.env } = {}) {
+function shouldEmitAutoSignal({ attempts, sessionId, progressStalled, isCoordinatorSession, env = process.env } = {}) {
   if (env && env.LEO_AUTO_SIGNAL === 'off') return false;        // kill-switch
   if (!sessionId || sessionId === 'unknown') return false;       // need a real worker identity
+  if (isCoordinatorSession === true) return false;               // (b) exempt coordinator/Adam/cadence
   if (!Number.isInteger(attempts)) return false;
   if (progressStalled === false) return false;                   // Control 3: real progress → not stuck
-  return attempts === 2;                                          // once, on the crossing (not >=2)
+  return attempts === 3;                                          // (a) once, on the 3rd same-signature repeat
 }
 
 /**

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1192,6 +1192,34 @@ async function main() {
           { attempts, signature, sd_key: claimedSdKey, rca_reset_applied: rcaResetApplied, bypassed }
         );
 
+        // SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-OVERFIRE-001 (a): AUTO-EMIT a /signal at the 3rd
+        // same-signature repeat (a genuine stuck-retry), not the 2nd crossing (which over-fired and
+        // drowned real signals). This MUST run BEFORE the attempts>=3 hard-block exit below, else the
+        // signal would never fire. (b): exempt the coordinator session (local active-coordinator marker)
+        // so its own monitoring loops never flood its inbox; named cadence scripts are already exempt
+        // from counting (retry-state-manager EXEMPT_PATTERNS). FIRE-AND-FORGET, env-disableable
+        // (LEO_AUTO_SIGNAL=off), FAIL-OPEN (any error swallowed — auto-signal must never block a tool call).
+        try {
+          const { shouldEmitAutoSignal, buildAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
+          let isCoordinatorSession = false;
+          try {
+            const coordRaw = require('fs').readFileSync(require('path').resolve(__dirname, '../../.claude/active-coordinator.json'), 'utf8');
+            const coord = JSON.parse(coordRaw);
+            if (coord && coord.session_id && coord.session_id === _SESSION_ID) isCoordinatorSession = true;
+          } catch { /* no marker / unreadable → treat as worker (fail-open, never suppress a real worker signal) */ }
+          if (shouldEmitAutoSignal({ attempts, sessionId: _SESSION_ID, progressStalled, isCoordinatorSession, env: process.env })) {
+            const path = require('path');
+            const { spawn } = require('child_process');
+            const args = buildAutoSignalArgs({ toolName: TOOL_NAME, signature, attempts, sdKey: claimedSdKey });
+            const child = spawn(
+              process.execPath,
+              [path.join(__dirname, '..', 'worker-signal.cjs'), ...args],
+              { detached: true, stdio: 'ignore', env: { ...process.env, CLAUDE_SESSION_ID: _SESSION_ID } }
+            );
+            child.unref();
+          }
+        } catch { /* fail-open: auto-signal must never block tool execution */ }
+
         if (attempts >= 3 && !bypassed) {
           process.stderr.write(
             `\nRCA TIERED ENFORCEMENT (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129):\n` +
@@ -1211,26 +1239,6 @@ async function main() {
           `next repeat ${bypassed ? '(bypass active)' : 'will be blocked'}. ` +
           `Consider invoking rca-agent if this indicates a persistent failure.`
         );
-
-        // SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-001 (FR-1): at the RCA recurrence threshold, AUTO-EMIT a
-        // /signal to the coordinator instead of relying on worker discretion (workers under-escalate
-        // because the threshold is prompt-advisory). Fires ONCE per signature (===2 crossing),
-        // FIRE-AND-FORGET (detached + unref, never awaited), env-disableable (LEO_AUTO_SIGNAL=off),
-        // FAIL-OPEN (any error swallowed — auto-signal must NEVER block or slow a tool call).
-        try {
-          const { shouldEmitAutoSignal, buildAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
-          if (shouldEmitAutoSignal({ attempts, sessionId: _SESSION_ID, progressStalled, env: process.env })) {
-            const path = require('path');
-            const { spawn } = require('child_process');
-            const args = buildAutoSignalArgs({ toolName: TOOL_NAME, signature, attempts, sdKey: claimedSdKey });
-            const child = spawn(
-              process.execPath,
-              [path.join(__dirname, '..', 'worker-signal.cjs'), ...args],
-              { detached: true, stdio: 'ignore', env: { ...process.env, CLAUDE_SESSION_ID: _SESSION_ID } }
-            );
-            child.unref();
-          }
-        } catch { /* fail-open: auto-signal must never block tool execution */ }
       }
     }
   } catch (rcaErr) {

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1913,6 +1913,46 @@ async function main() {
     warnings.push('WORK_ASSIGNMENT_TERMINAL_DRAIN: skipped due to error: ' + (e && e.message ? e.message : e));
   }
 
+  // SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-OVERFIRE-001 (c): AUTO-DRAIN stale STUCK auto-signals so the
+  // coordinator inbox doesn't accumulate a flood that drowns real signals. A STUCK signal is drained
+  // (acknowledged_at stamped) when it is >1h old OR its sender session is dead/released (no fresh
+  // heartbeat). Coordinator-inbox mutation → gated on _coordMutationAllowed like the drain above.
+  if (!_coordMutationAllowed) {
+    // not the canonical coordinator — skip (role already logged by the WORK_ASSIGNMENT skip above)
+  } else try {
+    const stuckAgeCutoff = new Date(nowMs - 60 * 60_000).toISOString();   // >1h old → stale
+    const liveCutoff = new Date(nowMs - 10 * 60_000).toISOString();       // fresh heartbeat ≤10min → alive
+    const { data: stuckSignals } = await supabase
+      .from('session_coordination')
+      .select('id, sender_session, created_at')
+      .eq('payload->>signal_type', 'stuck')
+      .is('acknowledged_at', null);
+    const stuck = stuckSignals || [];
+    let liveSenders = new Set();
+    const senderIds = [...new Set(stuck.map(s => s.sender_session).filter(Boolean))];
+    if (senderIds.length > 0) {
+      const { data: liveRows } = await supabase
+        .from('claude_sessions')
+        .select('session_id')
+        .in('session_id', senderIds)
+        .neq('status', 'terminated')
+        .gte('heartbeat_at', liveCutoff);
+      liveSenders = new Set((liveRows || []).map(r => r.session_id));
+    }
+    const drainStuckIds = stuck
+      .filter(s => s.created_at < stuckAgeCutoff || !s.sender_session || !liveSenders.has(s.sender_session))
+      .map(s => s.id);
+    for (let i = 0; i < drainStuckIds.length; i += 50) {
+      const batch = drainStuckIds.slice(i, i + 50);
+      await supabase.from('session_coordination').update({ acknowledged_at: now.toISOString() }).in('id', batch);
+    }
+    if (drainStuckIds.length > 0) {
+      actions.push('CLEANUP: drained ' + drainStuckIds.length + ' stale/dead-sender STUCK signal(s) (acknowledged_at stamped)');
+    }
+  } catch (e) {
+    warnings.push('STUCK_SIGNAL_DRAIN: skipped due to error: ' + (e && e.message ? e.message : e));
+  }
+
   // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-B / FR-2 (Finding 3): the WORK_ASSIGNMENT
   // dispatch is the EXACT double-dispatch FR-2 names first — a lingering OLD coordinator's
   // sweep would re-insert a WORK_ASSIGNMENT (sender_type:'sweep') to every active worker every

--- a/tests/unit/auto-signal-threshold.test.js
+++ b/tests/unit/auto-signal-threshold.test.js
@@ -14,27 +14,31 @@ const { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, bui
 
 const SID = '11111111-2222-4333-8444-555555555555';
 
-describe('shouldEmitAutoSignal (FR-1)', () => {
-  it('fires exactly on the 2nd-attempt crossing', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: {} })).toBe(true);
+describe('shouldEmitAutoSignal (FR-1; threshold raised to ===3 by SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-OVERFIRE-001)', () => {
+  it('fires exactly on the 3rd same-signature repeat (genuine stuck-retry)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, env: {} })).toBe(true);
+  });
+
+  it('does NOT fire on the 2nd attempt (over-fire fixed — one recurrence is not yet a stuck loop)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: {} })).toBe(false);
   });
 
   it('does NOT fire on the 1st attempt (no recurrence yet)', () => {
     expect(shouldEmitAutoSignal({ attempts: 1, sessionId: SID, env: {} })).toBe(false);
   });
 
-  it('does NOT re-fire on the 3rd+ attempt (dedupe — 3rd hard-blocks, already signalled at 2)', () => {
-    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, env: {} })).toBe(false);
+  it('does NOT re-fire on the 4th+ attempt (dedupe — fires once at 3)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 4, sessionId: SID, env: {} })).toBe(false);
     expect(shouldEmitAutoSignal({ attempts: 5, sessionId: SID, env: {} })).toBe(false);
   });
 
   it('respects the LEO_AUTO_SIGNAL=off kill-switch', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
   });
 
   it('does not fire without a real session identity', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: undefined, env: {} })).toBe(false);
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: 'unknown', env: {} })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: undefined, env: {} })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: 'unknown', env: {} })).toBe(false);
   });
 
   it('ignores non-integer attempts (fail-safe)', () => {
@@ -43,22 +47,37 @@ describe('shouldEmitAutoSignal (FR-1)', () => {
   });
 });
 
+describe('shouldEmitAutoSignal — coordinator/Adam exemption (SD-LEO-INFRA-THRESHOLD-AUTO-SIGNAL-OVERFIRE-001 (b))', () => {
+  it('does NOT fire from a coordinator/Adam session even at the ===3 threshold', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, isCoordinatorSession: true, env: {} })).toBe(false);
+  });
+
+  it('still fires from a normal worker session at ===3 (isCoordinatorSession false/absent)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, isCoordinatorSession: false, env: {} })).toBe(true);
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, env: {} })).toBe(true);
+  });
+
+  it('the exemption wins over progressStalled=true', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, isCoordinatorSession: true, progressStalled: true, env: {} })).toBe(false);
+  });
+});
+
 describe('shouldEmitAutoSignal — Control 3 progress re-scope (SD-LEO-INFRA-RCA-AUTOSIGNAL-FALSE-POSITIVE-001)', () => {
   it('SUPPRESSES the signal when the session is demonstrably progressing (progressStalled=false)', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: false, env: {} })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, progressStalled: false, env: {} })).toBe(false);
   });
 
-  it('still fires at the ===2 crossing when progress is stalled (progressStalled=true)', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: true, env: {} })).toBe(true);
+  it('still fires at the ===3 threshold when progress is stalled (progressStalled=true)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, progressStalled: true, env: {} })).toBe(true);
   });
 
-  it('preserves prior fire-on-crossing behavior when progress is unknown (progressStalled=undefined)', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, env: {} })).toBe(true);
+  it('preserves fire-on-threshold behavior when progress is unknown (progressStalled=undefined)', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, env: {} })).toBe(true);
   });
 
-  it('kill-switch and dedupe still win over progressStalled=true', () => {
-    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: true, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
-    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, progressStalled: true, env: {} })).toBe(false);
+  it('kill-switch and below-threshold still win over progressStalled=true', () => {
+    expect(shouldEmitAutoSignal({ attempts: 3, sessionId: SID, progressStalled: true, env: { LEO_AUTO_SIGNAL: 'off' } })).toBe(false);
+    expect(shouldEmitAutoSignal({ attempts: 2, sessionId: SID, progressStalled: true, env: {} })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## STUCK auto-signal over-fire → coordinator inbox flood

THRESHOLD-AUTO-SIGNAL-001 escalated a STUCK signal on the **2nd** same-signature repeat and from **coordinator/Adam/cadence** sessions, flooding the coordinator inbox and drowning real signals.

### Fix
- **FR-a (threshold)** — `shouldEmitAutoSignal` now fires on the **3rd** same-signature repeat (`===3`, a genuine stuck-retry), not the 2nd crossing. The per-signature counter means this is the *same* command tried 3×, not 3 distinct commands. **Relocated** the emit in `pre-tool-enforce.cjs` to run *before* the `attempts>=3` hard-block exit (else it could never fire at 3).
- **FR-b (exemption)** — exempt the **coordinator session** via the local `.claude/active-coordinator.json` marker (fail-open to worker — never suppress a real worker signal). Named cadence scripts are already exempt from counting (`retry-state-manager` EXEMPT_PATTERNS).
- **FR-c (auto-drain)** — `stale-session-sweep.cjs` drains STUCK signals (`acknowledged_at` stamped) that are **>1h old OR** whose sender session is **dead/released**, coordinator-gated like the existing WORK_ASSIGNMENT drain.

### Tests
`auto-signal-threshold.test.js` updated to `===3` + a coordinator-exemption suite — **26 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)