### PR TITLE
fix(SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001): decision_rubric measures CURRENT adherence

### DIFF
--- a/lib/adam/adherence-probes.js
+++ b/lib/adam/adherence-probes.js
@@ -20,11 +20,34 @@
 // structured gates from its signal set and routes its verdict through classifyDecision,
 // so there is a single source of truth for "Adam's to take vs the chairman's".
 import { classifyDecision, gatesFromSignals, VERDICT as DECISION_VERDICT } from './execute-vs-escalate.js';
+import crypto from 'node:crypto';
 
 const VERDICT = Object.freeze({ PASS: 'pass', FAIL: 'fail', UNKNOWN: 'unknown' });
 
 /** A resolved fact is "unresolved" when it is null or undefined (resolver failed / no data). */
 const unresolved = (v) => v === null || v === undefined;
+
+// SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001: a STABLE per-over-ask fingerprint (hash of the
+// whitespace-normalized body) so a RESOLVED/REMEDIATED over-ask can be excluded from later runs instead
+// of being re-counted forever (perpetual decision_rubric=fail). 12 hex chars is ample for a 1-day corpus.
+export function fingerprintOverAsk(body) {
+  const norm = String(body == null ? '' : body).replace(/\s+/g, ' ').trim().toLowerCase();
+  return crypto.createHash('sha256').update(norm).digest('hex').slice(0, 12);
+}
+
+// The decision_rubric ledger row encodes the run's over-ask fingerprints as a machine-readable tail
+// `::fps=a,b,c` on `detail` (the ledger has no jsonb column). Once that row gets a remediation_ref,
+// the next run reads these as RESOLVED and excludes them. encode/parse are a matched pair.
+const FPS_TAIL_RE = /::fps=([0-9a-f,]*)/i;
+export function encodeFingerprintsTail(fingerprints = []) {
+  const list = Array.isArray(fingerprints) ? fingerprints.filter(Boolean) : [];
+  return list.length ? ` ::fps=${list.join(',')}` : '';
+}
+export function parseFingerprintsTail(detail) {
+  const m = FPS_TAIL_RE.exec(String(detail == null ? '' : detail));
+  if (!m || !m[1]) return [];
+  return m[1].split(',').map((s) => s.trim()).filter(Boolean);
+}
 
 function bar(probe, duty, verdict, detail) {
   return { probe, duty, verdict, detail };
@@ -233,14 +256,26 @@ export function probeDecisionRubric(facts = {}) {
   if (unresolved(items) || !Array.isArray(items)) {
     return bar('decision_rubric', duty, VERDICT.UNKNOWN, 'adamChairmanDecisionQuestionsInWindow unresolved — cannot assess over-asks (not a pass)');
   }
+  // SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001: measure CURRENT adherence. The corpus is the
+  // in-window message set the resolver supplies (windowBasis reported for interpretability); over-asks
+  // already surfaced + remediated (their fingerprints in resolvedOverAskFingerprints, from prior ledger
+  // rows that carry a remediation_ref) are EXCLUDED so a resolved/historical over-ask never re-fails.
+  const windowBasis = facts.decisionRubricWindowBasis || `${facts.windowDays ?? 1}-day rolling window`;
+  const resolved = new Set(Array.isArray(facts.resolvedOverAskFingerprints) ? facts.resolvedOverAskFingerprints : []);
   const overAsks = items
-    .map((it) => ({ it, c: classifyDecisionQuestion(it && it.body) }))
+    .map((it) => ({ it, c: classifyDecisionQuestion(it && it.body), fp: fingerprintOverAsk(it && it.body) }))
     .filter((x) => x.c.overAsk);
-  if (overAsks.length === 0) {
-    return bar('decision_rubric', duty, VERDICT.PASS, `${items.length} Adam->chairman decision-question(s) examined — 0 likely over-asks`);
+  const fpsTail = encodeFingerprintsTail(overAsks.map((x) => x.fp));   // persisted so a later remediation resolves them
+  const fresh = overAsks.filter((x) => !resolved.has(x.fp));
+  const excluded = overAsks.length - fresh.length;
+  const exclNote = excluded > 0 ? `, ${excluded} excluded as already-remediated` : '';
+  if (fresh.length === 0) {
+    return bar('decision_rubric', duty, VERDICT.PASS,
+      `${items.length} decision-question(s) examined in ${windowBasis} — 0 NEW over-asks${exclNote}${fpsTail}`);
   }
-  const sample = String(overAsks[0].it && overAsks[0].it.body || '').slice(0, 120);
-  return bar('decision_rubric', duty, VERDICT.FAIL, `${overAsks.length} likely over-ask(s) of ${items.length} — Adam asked the chairman to ratify an already-determined, reversible decision matching no COMES-TO-HIM trigger (e.g. "${sample}…")`);
+  const sample = String(fresh[0].it && fresh[0].it.body || '').slice(0, 120);
+  return bar('decision_rubric', duty, VERDICT.FAIL,
+    `${fresh.length} NEW likely over-ask(s) of ${items.length} in ${windowBasis}${exclNote} — Adam asked the chairman to ratify an already-determined, reversible decision matching no COMES-TO-HIM trigger (e.g. "${sample}…")${fpsTail}`);
 }
 
 /** The canonical probe set (each defined once). The review script (FR-3) resolves facts + runs these. */

--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -22,7 +22,7 @@
 import 'dotenv/config';
 import crypto from 'node:crypto';
 import { createClient } from '@supabase/supabase-js';
-import { runAdherenceProbes, hasDrift } from '../lib/adam/adherence-probes.js';
+import { runAdherenceProbes, hasDrift, parseFingerprintsTail } from '../lib/adam/adherence-probes.js';
 
 const WINDOW_DAYS = 1;
 const REMEDIATION_CATEGORY = 'adam_adherence_drift';
@@ -172,6 +172,31 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
       }));
     }
   } catch { /* leave null -> unknown */ }
+
+  // SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001 (b): RESOLVED-EXCLUSION. Load the over-ask
+  // fingerprints from PRIOR decision_rubric ledger rows that already carry a remediation_ref (an
+  // over-ask that was surfaced + remediated). probeDecisionRubric excludes these so a resolved/historical
+  // over-ask never re-fails — the verdict reflects only NEW, un-remediated over-asks. (a) report the
+  // window basis so a fail is interpretable. Fail-soft: a query error leaves the set empty (no exclusion,
+  // never a fabricated pass). Look back further than the corpus window so remediations stay honored.
+  facts.windowDays = windowDays;
+  facts.decisionRubricWindowBasis = `${windowDays}-day rolling window (cross-session)`;
+  try {
+    const ledgerLookback = windowStart(Math.max(windowDays, 30), nowMs);
+    const { data: resolvedRows } = await supabase
+      .from('adam_adherence_ledger')
+      .select('detail, remediation_ref, created_at')
+      .eq('probe', 'decision_rubric')
+      .not('remediation_ref', 'is', null)
+      .gte('created_at', ledgerLookback);
+    const resolvedFps = new Set();
+    for (const row of (resolvedRows || [])) {
+      for (const fp of parseFingerprintsTail(row && row.detail)) resolvedFps.add(fp);
+    }
+    facts.resolvedOverAskFingerprints = [...resolvedFps];
+  } catch {
+    facts.resolvedOverAskFingerprints = []; // fail-soft: no exclusion, but never a fabricated pass
+  }
 
   return facts;
 }

--- a/tests/unit/adam/decision-rubric-probe.test.js
+++ b/tests/unit/adam/decision-rubric-probe.test.js
@@ -7,7 +7,7 @@
  * is advisory + fail-loud (null fact -> UNKNOWN). No DB / no IO.
  */
 import { describe, it, expect } from 'vitest';
-import { classifyDecisionQuestion, probeDecisionRubric, VERDICT } from '../../../lib/adam/adherence-probes.js';
+import { classifyDecisionQuestion, probeDecisionRubric, VERDICT, fingerprintOverAsk, parseFingerprintsTail, encodeFingerprintsTail } from '../../../lib/adam/adherence-probes.js';
 
 describe('classifyDecisionQuestion — rubric', () => {
   it('flags an over-ask: a reversible, already-determined question matching no COMES-TO-HIM trigger', () => {
@@ -94,5 +94,45 @@ describe('probeDecisionRubric — verdict', () => {
   it('is advisory + fail-loud: a null fact yields UNKNOWN, never a silent pass', () => {
     expect(probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: null }).verdict).toBe(VERDICT.UNKNOWN);
     expect(probeDecisionRubric({}).verdict).toBe(VERDICT.UNKNOWN);
+  });
+});
+
+// SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001: resolved/historical over-asks must be EXCLUDED
+// so the probe reflects CURRENT adherence (no perpetual fail). The over-ask fingerprint is persisted on
+// the ledger detail and read back once remediated.
+describe('decision_rubric resolved-exclusion (SD-LEO-INFRA-ADAM-DECISION-RUBRIC-PROBE-HYGIENE-001)', () => {
+  const OVER_ASK = 'Worker Delta finished its in-flight SD. I recommend we defer the stale fleet_retro P3 items to the backlog — should I proceed?';
+
+  it('fingerprint is stable + whitespace/case-insensitive, and round-trips through the ledger detail tail', () => {
+    const a = fingerprintOverAsk(OVER_ASK);
+    const b = fingerprintOverAsk('  ' + OVER_ASK.toUpperCase() + '  ');
+    expect(a).toBe(b);
+    expect(parseFingerprintsTail('some detail' + encodeFingerprintsTail([a, 'deadbeef0000']))).toEqual([a, 'deadbeef0000']);
+    expect(parseFingerprintsTail('no tail here')).toEqual([]);
+  });
+
+  it('FAILS on a NEW over-ask and emits its fingerprint on the detail tail', () => {
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }], windowDays: 1 });
+    expect(r.verdict).toBe(VERDICT.FAIL);
+    expect(parseFingerprintsTail(r.detail)).toEqual([fingerprintOverAsk(OVER_ASK)]);
+    expect(r.detail).toMatch(/NEW/);
+    expect(r.detail).toMatch(/rolling window/);
+  });
+
+  it('PASSES when the only over-ask was already remediated (its fingerprint is in resolvedOverAskFingerprints)', () => {
+    const fp = fingerprintOverAsk(OVER_ASK);
+    const r = probeDecisionRubric({ adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }], resolvedOverAskFingerprints: [fp], windowDays: 1 });
+    expect(r.verdict).toBe(VERDICT.PASS);
+    expect(r.detail).toMatch(/0 NEW over-asks/);
+    expect(r.detail).toMatch(/1 excluded as already-remediated/);
+  });
+
+  it('still FAILS on a NEW over-ask even when a DIFFERENT historical over-ask is resolved (improving-but-not-clean)', () => {
+    const r = probeDecisionRubric({
+      adamChairmanDecisionQuestionsInWindow: [{ body: OVER_ASK }],
+      resolvedOverAskFingerprints: ['someotherfp01'],
+      windowDays: 1,
+    });
+    expect(r.verdict).toBe(VERDICT.FAIL);
   });
 });


### PR DESCRIPTION
## decision_rubric over-ask probe re-flagged RESOLVED over-asks → perpetual fail

The probe re-counted resolved/historical over-asks every run (no resolved-exclusion), so `decision_rubric=fail` could never reflect current adherence.

### Fix
- **(b) Resolved-exclusion** — each over-ask gets a stable `fingerprintOverAsk` (sha256 of the whitespace/case-normalized body). `probeDecisionRubric` persists the run's fingerprints on the ledger `detail` tail (`::fps=…`, the ledger has no jsonb column) and **excludes** any whose fingerprint appears in a prior `decision_rubric` ledger row that already carries a `remediation_ref`. A resolved over-ask never re-fails; only **NEW** over-asks fail.
- **(a) Interpretability** — the verdict reports the window basis + NEW-vs-excluded counts. `resolveFacts` loads the resolved fingerprints (30-day ledger lookback, fail-soft to empty — never a fabricated pass).
- **(c) Siblings** — `propose_only`/`belt_starvation`/`dispatch_boundary` read `unknown` from an **attribution** gap (resolver returns null), **not** a cross-session re-count gap, so no re-count fix is needed (documented).

### Tests
Stable/case-insensitive fingerprint + ledger-tail round-trip; FAIL on a NEW over-ask (emits fingerprint); PASS when the only over-ask is already remediated; still FAIL on a NEW one while a different historical over-ask is resolved. **23 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)