### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001): chairman reject terminates venture (paired unblock + kill-consumer)

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001.json
@@ -1,0 +1,101 @@
+{
+  "executive_summary": "When a chairman decision is made via fn_chairman_decide, the 'rejected' branch only updates chairman_decisions.status='rejected' and never touches the venture — so the venture stays status='active', orchestrator_state='blocked'. The trg_chairman_decision_unblock trigger currently fires ONLY on 'approved', so a rejected venture is stuck at blocked. If the trigger were simply broadened to also fire on 'rejected' (closing that stuck gap), a rejected venture would unblock -> become idle -> be re-picked by the worker (_pollForWork: status='active' AND orchestrator_state='idle' AND stage<26) -> re-mint a fresh pending gate = RESURRECT the killed gate and DISCARD the chairman's reject. This SD ships the PAIRED fix (both or neither): (a) broaden the unblock trigger to fire on 'rejected' too, AND (b) make fn_chairman_decide's 'rejected' branch set the venture TERMINAL (ventures.status='cancelled', mirroring reject_chairman_decision's terminal semantics) so the worker re-pick predicate excludes it. Net: a rejected venture becomes terminal + unblocked + NOT re-picked + NO new gate minted + the reject preserved. Approved decisions still advance normally (no regression vs RESOLVE-CANONICAL-001). FLAGSHIP-ADJACENT: fn_chairman_decide can now terminate ventures — gets its own DATABASE/SECURITY sub-agent gate review via the LEO pipeline.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Broaden trg_chairman_decision_unblock to fire on 'rejected' as well as 'approved'",
+      "description": "Recreate the trigger trg_chairman_decision_unblock (AFTER UPDATE ON chairman_decisions) so its WHEN clause is (new.status IN ('approved','rejected') AND old.status IS DISTINCT FROM new.status), and update its function trg_chairman_approval_unblock_orchestrator() so its internal guard unblocks (sets ventures.orchestrator_state='idle' WHERE orchestrator_state='blocked') on BOTH 'approved' and 'rejected'. This closes the rejected-stuck-at-blocked gap. PAIRED with FR-2 — must ship together (both or neither).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Trigger WHEN clause includes status='rejected' (and still 'approved')",
+        "Trigger function unblocks (orchestrator_state idle) on a 'rejected' transition from a distinct prior status",
+        "A 'rejected' decision on a blocked venture leaves orchestrator_state='idle'"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "fn_chairman_decide 'rejected' branch sets the venture TERMINAL (status='cancelled')",
+      "description": "In fn_chairman_decide, after the chairman_decisions UPDATE to status='rejected' succeeds, add a branch: IF p_action='rejected' THEN UPDATE ventures SET status='cancelled', updated_at=now() WHERE id = v_decision.venture_id. This mirrors reject_chairman_decision's terminal status (the non-kill-gate branch sets status='cancelled') and makes the venture a terminal status that the worker re-pick predicate (status='active') excludes. The 'approved' path is unchanged. PAIRED with FR-1.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "fn_chairman_decide('rejected') sets ventures.status='cancelled' for the decision's venture",
+        "fn_chairman_decide('approved') leaves ventures.status='active' (unchanged)",
+        "The reject is preserved (chairman_decisions.status='rejected'); no resurrection"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Verify re-pick predicate + gate-mint path exclude the terminal status; regression test",
+      "description": "Confirm the worker re-pick predicate (_pollForWork in lib/eva/stage-execution-worker.js: .eq('status','active').eq('orchestrator_state','idle').lt('current_lifecycle_stage',26)) excludes a status='cancelled' venture, and that the gate-mint path only runs on a picked venture (so a cancelled venture mints no new pending gate). Add integration tests: (a) a 'rejected' decision -> venture terminal (status='cancelled') + unblocked (orchestrator_state='idle') + NOT returned by the re-pick predicate + NO new pending chairman_decision minted + reject preserved; (b) an 'approved' decision -> venture unblocks, stays active, advances normally (no regression). Tests run in a rolled-back transaction so no prod state changes.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Documented: _pollForWork excludes status='cancelled' (status='active' filter)",
+        "Documented: no independent gate-mint path runs for an unpicked venture",
+        "Test asserts rejected -> terminal+unblocked+not-repicked+no-new-gate+reject-preserved",
+        "Test asserts approved -> unblock+advance (no regression)"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Single additive migration, paired both-or-neither",
+      "description": "One database/migrations/*.sql file with CREATE OR REPLACE FUNCTION for trg_chairman_approval_unblock_orchestrator + fn_chairman_decide and a DROP/CREATE TRIGGER for trg_chairman_decision_unblock (WHEN clause change requires recreate). Rollback recreates the prior definitions. No schema/column changes."
+    },
+    {
+      "id": "TR-2",
+      "title": "Flagship-adjacent — own gate review",
+      "description": "fn_chairman_decide can now terminate ventures (status='cancelled'). The change goes through the LEO DATABASE + SECURITY sub-agent gate review. Co-author convergence (coordinator) + Charlie DATABASE review (CONDITIONAL_PASS 88) already recorded on the SD."
+    }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "rejected -> terminal + unblocked + not re-picked + no new gate", "type": "integration", "expected": "ventures.status='cancelled', orchestrator_state='idle', excluded by re-pick predicate, no new pending decision, reject preserved" },
+    { "id": "TS-2", "scenario": "approved -> unblock + advance (regression)", "type": "integration", "expected": "orchestrator_state='idle', status stays 'active', advances normally" }
+  ],
+  "acceptance_criteria": [
+    "A chairman 'rejected' decision via fn_chairman_decide makes the venture terminal and unblocked, and it is never re-picked or re-minted",
+    "The reject sticks (governance: a chairman KILL/reject must STICK, never be resurrectable)",
+    "Approved decisions are unaffected (no regression)"
+  ],
+  "risks": [
+    {
+      "risk": "fn_chairman_decide now terminates ventures (status='cancelled') — a wrong reject is venture-stopping",
+      "mitigation": "fn_chairman_decide only acts on an already-pending decision the chairman explicitly decides; the terminal status mirrors the existing reject_chairman_decision path (same blast radius, now made consistent). Paired both-or-neither prevents the worse resurrection bug. DATABASE/SECURITY gate review + co-author convergence already done. Migration is reversible (rollback recreates prior defs).",
+      "severity": "medium"
+    },
+    {
+      "risk": "Shipping FR-1 without FR-2 (or vice-versa) would either leave rejected-stuck OR cause gate resurrection",
+      "mitigation": "Both ship in ONE migration; the PRD and migration are explicitly paired (both-or-neither).",
+      "severity": "high"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": ["fn_chairman_decide RPC (chairman gate decisions)", "trg_chairman_decision_unblock (venture unblock)", "stage-execution-worker _pollForWork (re-pick)", "chairman gate-mint path"],
+    "dependencies": ["reject_chairman_decision (terminal-semantics reference)", "ventures.status / orchestrator_state", "chairman_decisions.status"],
+    "data_contracts": ["ventures.status (set to 'cancelled' on reject)", "chairman_decisions.status='rejected'", "no schema change"],
+    "runtime_config": ["none"],
+    "observability_rollout": ["Integration tests prove the rejected/approved paths; migration dry-run then gated prod-apply (flagship-adjacent — apply is the controlled step)"]
+  },
+  "system_architecture": {
+    "summary": "Pair the unblock trigger (now fires on rejected) with a terminal venture status set by fn_chairman_decide's rejected branch, so a rejected venture is unblocked but excluded from re-pick.",
+    "components": [
+      { "name": "database/migrations/<new>_chairman_reject_unblock_terminal.sql", "change": "NEW — broaden trigger + terminal-on-reject in fn_chairman_decide" },
+      { "name": "tests/integration/chairman-reject-terminal.test.js", "change": "NEW — rejected/approved integration tests (rolled-back tx)" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "One paired migration + integration tests; flagship-adjacent gate review via pipeline.",
+    "steps": [
+      "Write the migration: broaden trg_chairman_decision_unblock (recreate WHEN) + its function; add terminal-on-reject to fn_chairman_decide",
+      "Dry-run the migration",
+      "Add integration tests for rejected (terminal/unblocked/not-repicked/no-new-gate) and approved (regression)",
+      "Run DATABASE + SECURITY sub-agents; ship via gated handoffs"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Call fn_chairman_decide(decision_id, 'rejected', decider, rationale) for a venture blocked at a chairman gate", "expected_outcome": "chairman_decisions.status=rejected (preserved) AND ventures.status=cancelled (terminal) AND orchestrator_state=idle (unblocked) — one transaction" },
+    { "step_number": 2, "instruction": "Run the worker re-pick predicate (status=active AND orchestrator_state=idle AND current_lifecycle_stage<26) after the reject", "expected_outcome": "Rejected venture NOT returned (status=cancelled); no new pending decision minted; reject not resurrected" },
+    { "step_number": 3, "instruction": "Call fn_chairman_decide(decision_id, 'approved', ...) for a blocked venture", "expected_outcome": "orchestrator_state=idle, status stays active, advances normally — no regression" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001" }
+}

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S5-FINANCIAL-GATE-FUTURE-ARTIFACT-BUG-001",
-  "createdAt": "2026-06-28T02:39:30.528Z",
+  "sdKey": "SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001",
+  "createdAt": "2026-06-28T17:05:30.586Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260628_chairman_reject_unblock_terminal.sql
+++ b/database/migrations/20260628_chairman_reject_unblock_terminal.sql
@@ -1,0 +1,165 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260628_chairman_reject_unblock_terminal.sql
+-- SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001 (FR-1 + FR-2, PAIRED)
+--
+-- A chairman 'rejected' decision must TERMINATE the venture (kill-consumer)
+-- when the unblock trigger broadens to fire on 'rejected'. PAIRED change
+-- (both or neither):
+--   (a) FR-1: broaden trg_chairman_decision_unblock to fire on 'rejected' too
+--       (closing the rejected-stuck-at-blocked gap), and unblock on both
+--       'approved' and 'rejected' in its function.
+--   (b) FR-2: make fn_chairman_decide's 'rejected' branch set the venture
+--       TERMINAL (ventures.status='cancelled', mirroring reject_chairman_decision's
+--       non-kill-gate terminal status) — a terminal status the worker re-pick
+--       predicate (_pollForWork: status='active') excludes.
+--
+-- WHY PAIRED: with (a) alone, a rejected venture would unblock -> orchestrator
+-- idle -> re-picked by the worker (status='active' AND orchestrator_state='idle'
+-- AND current_lifecycle_stage<26) -> re-mint a fresh pending gate = RESURRECT
+-- the killed gate and DISCARD the chairman's reject. (b) makes the venture
+-- terminal (status='cancelled') so _pollForWork excludes it: not re-picked, no
+-- new gate minted, reject preserved. Governance: a chairman KILL/reject must
+-- STICK (terminal), never be resurrectable.
+--
+-- FLAGSHIP-ADJACENT: fn_chairman_decide can now terminate ventures. Co-author
+-- convergence (coordinator) + Charlie DATABASE review (CONDITIONAL_PASS 88)
+-- recorded on the SD; ships through the LEO DATABASE/SECURITY gate review.
+--
+-- Rollback: restore the prior definitions —
+--   - recreate trg_chairman_approval_unblock_orchestrator() with the
+--     approved-only guard;
+--   - recreate trigger trg_chairman_decision_unblock WHEN (new.status='approved'
+--     AND old.status IS DISTINCT FROM new.status);
+--   - recreate fn_chairman_decide WITHOUT the IF p_action='rejected' venture
+--     terminal branch.
+
+BEGIN;
+
+-- FR-1a: unblock on BOTH 'approved' and 'rejected'.
+CREATE OR REPLACE FUNCTION public.trg_chairman_approval_unblock_orchestrator()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+BEGIN
+  -- SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001 (FR-1): fire on a decided
+  -- transition to EITHER 'approved' OR 'rejected'. For 'rejected', fn_chairman_decide
+  -- has already set the venture terminal (status='cancelled'), so unblocking it here
+  -- is safe — the worker re-pick predicate excludes status<>'active'.
+  IF NEW.status IN ('approved', 'rejected') AND (OLD.status IS DISTINCT FROM NEW.status) THEN
+    UPDATE ventures
+    SET orchestrator_state = 'idle'
+    WHERE id = NEW.venture_id
+      AND orchestrator_state = 'blocked';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- FR-1b: broaden the trigger WHEN clause (recreate — a WHEN change requires it).
+DROP TRIGGER IF EXISTS trg_chairman_decision_unblock ON public.chairman_decisions;
+CREATE TRIGGER trg_chairman_decision_unblock
+  AFTER UPDATE ON public.chairman_decisions
+  FOR EACH ROW
+  WHEN (((new.status = ANY (ARRAY['approved'::text, 'rejected'::text]))
+         AND (old.status IS DISTINCT FROM new.status)))
+  EXECUTE FUNCTION trg_chairman_approval_unblock_orchestrator();
+
+-- FR-2: fn_chairman_decide's 'rejected' branch sets the venture TERMINAL.
+-- Identical to the live definition EXCEPT for the new terminal-on-reject block
+-- inserted after the concurrent-modification check (marked FR-2).
+CREATE OR REPLACE FUNCTION public.fn_chairman_decide(p_decision_id uuid, p_action text, p_decided_by text, p_rationale text DEFAULT NULL::text, p_force_stale boolean DEFAULT false)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_decision RECORD;
+  v_venture RECORD;
+  v_rows_updated INT;
+BEGIN
+  IF p_action NOT IN ('approved', 'rejected') THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Invalid action. Must be approved or rejected.',
+      'code', 'INVALID_ACTION'
+    );
+  END IF;
+  SELECT cd.*, v.updated_at AS venture_updated_at, v.name AS venture_name
+  INTO v_decision
+  FROM chairman_decisions cd
+  JOIN ventures v ON v.id = cd.venture_id
+  WHERE cd.id = p_decision_id
+  FOR UPDATE OF cd;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision not found.',
+      'code', 'NOT_FOUND'
+    );
+  END IF;
+  IF v_decision.status != 'pending' THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Decision already %s by %s at %s.',
+        v_decision.status,
+        COALESCE(v_decision.decided_by, 'unknown'),
+        v_decision.updated_at
+      ),
+      'code', 'ALREADY_DECIDED',
+      'current_status', v_decision.status,
+      'decided_by', v_decision.decided_by,
+      'decided_at', v_decision.updated_at
+    );
+  END IF;
+  IF NOT p_force_stale AND v_decision.venture_updated_at > v_decision.created_at THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Venture "%s" state has changed since this decision was created. Review updated state before deciding.', v_decision.venture_name),
+      'code', 'STALE_CONTEXT',
+      'decision_created_at', v_decision.created_at,
+      'venture_updated_at', v_decision.venture_updated_at,
+      'venture_name', v_decision.venture_name
+    );
+  END IF;
+  UPDATE chairman_decisions
+  SET
+    status = p_action,
+    decided_by = p_decided_by,
+    rationale = COALESCE(p_rationale, rationale)
+  WHERE id = p_decision_id
+    AND status = 'pending';  -- Second safety check
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+  IF v_rows_updated = 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision was modified by another session.',
+      'code', 'CONCURRENT_MODIFICATION'
+    );
+  END IF;
+
+  -- SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001 (FR-2): a 'rejected'
+  -- decision must terminate the venture. Set it to the terminal status
+  -- 'cancelled' (mirrors reject_chairman_decision's non-kill-gate branch) so
+  -- the broadened unblock trigger does NOT resurrect it: the worker re-pick
+  -- predicate (status='active') excludes a cancelled venture, so it is never
+  -- re-picked and no new pending gate is minted. The reject is preserved.
+  IF p_action = 'rejected' THEN
+    UPDATE ventures
+    SET status = 'cancelled',
+        updated_at = now()
+    WHERE id = v_decision.venture_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'action', p_action,
+    'decided_by', p_decided_by,
+    'venture_name', v_decision.venture_name
+  );
+END;
+$function$;
+
+COMMIT;

--- a/tests/integration/chairman-reject-terminal.test.js
+++ b/tests/integration/chairman-reject-terminal.test.js
@@ -1,0 +1,123 @@
+/**
+ * Integration tests for SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001.
+ *
+ * Verifies the PAIRED fix:
+ *   FR-1: trg_chairman_decision_unblock fires on 'rejected' (unblocks).
+ *   FR-2: fn_chairman_decide's 'rejected' branch sets the venture TERMINAL
+ *         (ventures.status='cancelled'), so the worker re-pick predicate
+ *         (status='active' AND orchestrator_state='idle' AND stage<26) excludes
+ *         it — no re-pick, no new gate minted, reject preserved.
+ *   Regression: an 'approved' decision still unblocks + stays active.
+ *
+ * FULLY ISOLATED: applies the new function/trigger defs (from the migration)
+ * and exercises throwaway rows inside a single transaction that is ALWAYS
+ * rolled back — nothing persists to the database. Safe for the flagship factory.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+import 'dotenv/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION = path.join(__dirname, '../../database/migrations/20260628_chairman_reject_unblock_terminal.sql');
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+// Strip the outer BEGIN/COMMIT so the defs run inside our own test transaction.
+function migrationBody() {
+  const raw = fs.readFileSync(MIGRATION, 'utf8');
+  return raw
+    .split('\n')
+    .filter((l) => !/^\s*(BEGIN|COMMIT)\s*;\s*$/i.test(l))
+    .join('\n');
+}
+
+// A direct ventures INSERT trips a company-access trigger, so (like
+// kill-venture-rpc.test.js) we force an EXISTING venture into the blocked
+// shape inside the rolled-back transaction instead.
+async function blockedVenture(client, stage = 5) {
+  const v = await client.query('SELECT id FROM ventures ORDER BY created_at DESC LIMIT 1');
+  const id = v.rows[0].id;
+  await client.query(
+    `UPDATE ventures SET status='active', orchestrator_state='blocked', current_lifecycle_stage=$2 WHERE id=$1`,
+    [id, stage],
+  );
+  return id;
+}
+
+// High, distinct attempt_number to avoid the (venture_id,lifecycle_stage,
+// attempt_number) unique constraint with any pre-existing decision.
+let nextAttempt = 9001;
+async function insertPendingDecision(client, ventureId, stage = 5) {
+  const r = await client.query(
+    `INSERT INTO chairman_decisions (venture_id, lifecycle_stage, decision, decision_type, status, attempt_number)
+     VALUES ($1, $2, 'review', 'stage_gate', 'pending', $3) RETURNING id`,
+    [ventureId, stage, nextAttempt++],
+  );
+  return r.rows[0].id;
+}
+
+describe.skipIf(!HAS_REAL_DB)('chairman reject -> terminal venture (SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001)', () => {
+  let client;
+
+  beforeAll(async () => {
+    client = await createDatabaseClient('ehg');
+    await client.query('BEGIN');
+    // Apply the new defs inside the rolled-back transaction.
+    await client.query(migrationBody());
+  });
+
+  afterAll(async () => {
+    if (client) {
+      await client.query('ROLLBACK'); // nothing persists
+      await client.end();
+    }
+  });
+
+  it("FR-1+FR-2: a 'rejected' decision makes the venture terminal + unblocked + not re-picked + reject preserved", async () => {
+    const ventureId = await blockedVenture(client);
+    const decisionId = await insertPendingDecision(client, ventureId);
+
+    const res = await client.query(
+      `SELECT fn_chairman_decide($1, 'rejected', 'test-decider', 'integration reject', true) AS r`,
+      [decisionId],
+    );
+    expect(res.rows[0].r.success).toBe(true);
+
+    const v = await client.query('SELECT status, orchestrator_state FROM ventures WHERE id=$1', [ventureId]);
+    expect(v.rows[0].status).toBe('cancelled');        // FR-2: terminal
+    expect(v.rows[0].orchestrator_state).toBe('idle');  // FR-1: unblocked
+
+    const d = await client.query('SELECT status FROM chairman_decisions WHERE id=$1', [decisionId]);
+    expect(d.rows[0].status).toBe('rejected');          // reject preserved
+
+    // Worker re-pick predicate must NOT return the cancelled venture.
+    const repick = await client.query(
+      `SELECT id FROM ventures
+       WHERE id=$1 AND status='active' AND orchestrator_state='idle' AND current_lifecycle_stage < 26`,
+      [ventureId],
+    );
+    expect(repick.rows.length).toBe(0);                 // not re-picked -> no new gate minted
+  });
+
+  it("regression: an 'approved' decision unblocks the venture and keeps it active", async () => {
+    const ventureId = await blockedVenture(client);
+    const decisionId = await insertPendingDecision(client, ventureId);
+
+    const res = await client.query(
+      `SELECT fn_chairman_decide($1, 'approved', 'test-decider', 'integration approve', true) AS r`,
+      [decisionId],
+    );
+    expect(res.rows[0].r.success).toBe(true);
+
+    const v = await client.query('SELECT status, orchestrator_state FROM ventures WHERE id=$1', [ventureId]);
+    expect(v.rows[0].orchestrator_state).toBe('idle');  // unblocked
+    expect(v.rows[0].status).toBe('active');            // NOT terminal -> advances normally
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-CHAIRMAN-REJECT-UNBLOCK-TERMINAL-001 — a chairman 'rejected' decision must terminate the venture

### Bug (governance-critical)
`fn_chairman_decide`'s `'rejected'` branch only updated `chairman_decisions.status` and never touched the venture, while `trg_chairman_decision_unblock` fired **only on `'approved'`** → a rejected venture was stuck at `orchestrator_state='blocked'`. Merely broadening the trigger to `'rejected'` would unblock it → idle → the worker re-picks it (`status='active' AND orchestrator_state='idle' AND stage<26`) → **re-mints a fresh pending gate = resurrects the killed gate and discards the chairman's reject.** Governance: *a chairman KILL/reject must STICK (terminal).*

### Paired fix (one migration, both-or-neither)
- **FR-1** — broaden `trg_chairman_decision_unblock` + its function to fire on `'rejected'` as well as `'approved'`.
- **FR-2** — `fn_chairman_decide`'s `'rejected'` branch sets `ventures.status='cancelled'` (terminal, mirroring `reject_chairman_decision`) so the worker re-pick predicate excludes it → not re-picked, no new gate minted, reject preserved.
- **FR-3** — verified `_pollForWork` (`lib/eva/stage-execution-worker.js`) filters `status='active'`; integration test (rolled-back tx that applies the new defs) covers rejected → cancelled/idle/rejected/not-repicked and approved → active/idle (no regression).

### Verification
Live rolled-back-transaction harness: **ALL PASS** (rejected → cancelled+idle+rejected+repick=0; approved → active+idle).

### Flagship-adjacency
`fn_chairman_decide` now terminates ventures. Co-author convergence (coordinator) + Charlie DATABASE review (CONDITIONAL_PASS 88) recorded on the SD; ships through the LEO DATABASE/SECURITY gate review. Migration is reversible (rollback recreates prior defs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
