### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001): canonical chairman-decision resolve path (FR-1/3/4/6; FR-2 split)

### DIFF
--- a/database/migrations/20260628_chairman_decision_canonical_resolve.sql
+++ b/database/migrations/20260628_chairman_decision_canonical_resolve.sql
@@ -13,15 +13,18 @@
 -- decision values are members of the LIVE chairman_decisions_decision_check (30 values incl
 -- proceed/kill) — deliberately NOT narrowed (the 6-value set was stale migration 20251206).
 --
--- FIX (FR-2): the auto-unblock trigger previously fired ONLY on status->'approved', so a
--- rejected/terminal resolve of a BLOCKING decision left the venture stuck at orchestrator_state
--- ='blocked'. The trigger now fires on approved OR rejected (any terminal resolve releases the
--- venture so the orchestrator can act on the decision). Unblock stays daemon-independent and in
--- ONE place (the trigger) — the function does NOT also write orchestrator_state (no double-fire).
+-- FR-2 (trigger-broaden to release rejected/terminal ventures) was SPLIT OUT to a follow-up SD
+-- (coordinator decision 2026-06-28): broadening trg_chairman_decision_unblock to fire on
+-- 'rejected' is UNSAFE without a paired kill-consumer — chairman REJECT routes through
+-- fn_chairman_decide(action='rejected') which does NOT set ventures.status terminal, so an
+-- unblocked rejected venture is re-picked by the worker and re-mints a fresh pending gate,
+-- resurrecting the killed gate and discarding the chairman's reject (DATABASE review cc6de94c).
+-- The rejected-stuck-at-blocked gap is PRE-EXISTING, so leaving the trigger approved-only here
+-- is zero-regression. The safe form (fn rejected-branch sets the venture terminal) ships in the
+-- follow-up SD.
 --
--- Additive + idempotent: CREATE OR REPLACE for the functions; DROP/CREATE for the trigger (its
--- WHEN clause must broaden). No data migration here (a separate one-time backfill handles existing
--- contradictory rows).
+-- Additive + idempotent: CREATE OR REPLACE for the function. No trigger change. No data migration
+-- here (a separate one-time backfill handles existing contradictory rows).
 
 -- ── FR-1: canonical resolve function writes the full triple ──
 CREATE OR REPLACE FUNCTION public.fn_chairman_decide(
@@ -121,30 +124,7 @@ BEGIN
 END;
 $function$;
 
--- ── FR-2: broaden the unblock trigger function to cover terminal rejected resolves ──
-CREATE OR REPLACE FUNCTION public.trg_chairman_approval_unblock_orchestrator()
-RETURNS trigger
-LANGUAGE plpgsql
-SET search_path TO 'public', 'extensions'
-AS $function$
-BEGIN
-  -- Fire on any TERMINAL resolve (approved OR rejected) — both release the venture from 'blocked'
-  -- so the orchestrator can act on the decision. Previously fired only on 'approved', leaving a
-  -- rejected blocking decision's venture stuck at orchestrator_state='blocked'.
-  IF NEW.status IN ('approved', 'rejected') AND (OLD.status IS DISTINCT FROM NEW.status) THEN
-    UPDATE ventures
-    SET orchestrator_state = 'idle'
-    WHERE id = NEW.venture_id
-      AND orchestrator_state = 'blocked';
-  END IF;
-  RETURN NEW;
-END;
-$function$;
-
--- The trigger WHEN clause also restricted firing to status='approved'; broaden it to match.
-DROP TRIGGER IF EXISTS trg_chairman_decision_unblock ON public.chairman_decisions;
-CREATE TRIGGER trg_chairman_decision_unblock
-  AFTER UPDATE ON public.chairman_decisions
-  FOR EACH ROW
-  WHEN (NEW.status IN ('approved', 'rejected') AND (OLD.status IS DISTINCT FROM NEW.status))
-  EXECUTE FUNCTION public.trg_chairman_approval_unblock_orchestrator();
+-- NOTE: trg_chairman_decision_unblock is intentionally LEFT UNCHANGED (fires on status->'approved'
+-- only). The approved path here still sets status='approved', so the existing trigger continues to
+-- release the venture exactly as before — no regression. FR-2's rejected-release is deferred to the
+-- follow-up SD (see header).

--- a/database/migrations/20260628_chairman_decision_canonical_resolve.sql
+++ b/database/migrations/20260628_chairman_decision_canonical_resolve.sql
@@ -25,6 +25,11 @@
 --
 -- Additive + idempotent: CREATE OR REPLACE for the function. No trigger change. No data migration
 -- here (a separate one-time backfill handles existing contradictory rows).
+--
+-- Chairman authorization: session_question decision 73e04cc2 APPROVED (decision=go), 2026-06-28 —
+-- "Proceed with your recommendation based on your rationale." Applied via the governed
+-- apply-migration.js --prod-deploy path by the coordinator (CONST-002).
+-- @approved-by: codestreetlabs@gmail.com
 
 -- ── FR-1: canonical resolve function writes the full triple ──
 CREATE OR REPLACE FUNCTION public.fn_chairman_decide(

--- a/database/migrations/20260628_chairman_decision_canonical_resolve.sql
+++ b/database/migrations/20260628_chairman_decision_canonical_resolve.sql
@@ -1,0 +1,150 @@
+-- SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001
+-- Canonical chairman-decision resolve path.
+--
+-- PROBLEM: fn_chairman_decide (migration 20260213) set status + decided_by + rationale ONLY,
+-- leaving decision='pending' under status='approved' (a contradictory "lying" decision field on
+-- an approved gate). The dashboard + coordinator CLI route through this RPC and inherited the bug,
+-- while the autonomous worker/orchestrator paths hand-wrote their own divergent field sets.
+--
+-- FIX (FR-1): the canonical resolve writes the COMPLETE, consistent (status, decision, blocking)
+-- triple for every action — never leaving decision='pending' under a non-pending status.
+--   approved -> (status='approved', decision='proceed', blocking=false)
+--   rejected -> (status='rejected', decision='kill',    blocking=false)
+-- decision values are members of the LIVE chairman_decisions_decision_check (30 values incl
+-- proceed/kill) — deliberately NOT narrowed (the 6-value set was stale migration 20251206).
+--
+-- FIX (FR-2): the auto-unblock trigger previously fired ONLY on status->'approved', so a
+-- rejected/terminal resolve of a BLOCKING decision left the venture stuck at orchestrator_state
+-- ='blocked'. The trigger now fires on approved OR rejected (any terminal resolve releases the
+-- venture so the orchestrator can act on the decision). Unblock stays daemon-independent and in
+-- ONE place (the trigger) — the function does NOT also write orchestrator_state (no double-fire).
+--
+-- Additive + idempotent: CREATE OR REPLACE for the functions; DROP/CREATE for the trigger (its
+-- WHEN clause must broaden). No data migration here (a separate one-time backfill handles existing
+-- contradictory rows).
+
+-- ── FR-1: canonical resolve function writes the full triple ──
+CREATE OR REPLACE FUNCTION public.fn_chairman_decide(
+  p_decision_id uuid,
+  p_action text,
+  p_decided_by text,
+  p_rationale text DEFAULT NULL::text,
+  p_force_stale boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_decision RECORD;
+  v_rows_updated INT;
+  v_decision_value TEXT;
+BEGIN
+  IF p_action NOT IN ('approved', 'rejected') THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Invalid action. Must be approved or rejected.',
+      'code', 'INVALID_ACTION'
+    );
+  END IF;
+
+  -- Canonical (status, decision) mapping. decision is a member of chairman_decisions_decision_check.
+  -- This is the single source of truth for what a resolved decision's decision field becomes.
+  v_decision_value := CASE p_action
+    WHEN 'approved' THEN 'proceed'
+    WHEN 'rejected' THEN 'kill'
+  END;
+
+  SELECT cd.*, v.updated_at AS venture_updated_at, v.name AS venture_name
+  INTO v_decision
+  FROM chairman_decisions cd
+  JOIN ventures v ON v.id = cd.venture_id
+  WHERE cd.id = p_decision_id
+  FOR UPDATE OF cd;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Decision not found.', 'code', 'NOT_FOUND');
+  END IF;
+
+  IF v_decision.status != 'pending' THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Decision already %s by %s at %s.',
+        v_decision.status, COALESCE(v_decision.decided_by, 'unknown'), v_decision.updated_at),
+      'code', 'ALREADY_DECIDED',
+      'current_status', v_decision.status,
+      'decided_by', v_decision.decided_by,
+      'decided_at', v_decision.updated_at
+    );
+  END IF;
+
+  -- Stale-context guard (FR-4): protects human/dashboard resolves against acting on stale venture
+  -- state. Autonomous same-tick resolves pass p_force_stale=true (they create/observe the decision
+  -- and resolve it in the same pass — never stale) so the guard does not false-block them.
+  IF NOT p_force_stale AND v_decision.venture_updated_at > v_decision.created_at THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Venture "%s" state has changed since this decision was created. Review updated state before deciding.', v_decision.venture_name),
+      'code', 'STALE_CONTEXT',
+      'decision_created_at', v_decision.created_at,
+      'venture_updated_at', v_decision.venture_updated_at,
+      'venture_name', v_decision.venture_name
+    );
+  END IF;
+
+  -- FR-1: write the COMPLETE triple — status AND decision AND blocking — never leaving
+  -- decision='pending' under a non-pending status.
+  UPDATE chairman_decisions
+  SET
+    status = p_action,
+    decision = v_decision_value,
+    blocking = false,
+    decided_by = p_decided_by,
+    rationale = COALESCE(p_rationale, rationale)
+  WHERE id = p_decision_id
+    AND status = 'pending';  -- second safety check
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+  IF v_rows_updated = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Decision was modified by another session.', 'code', 'CONCURRENT_MODIFICATION');
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'action', p_action,
+    'decision', v_decision_value,
+    'blocking', false,
+    'decided_by', p_decided_by,
+    'venture_name', v_decision.venture_name
+  );
+END;
+$function$;
+
+-- ── FR-2: broaden the unblock trigger function to cover terminal rejected resolves ──
+CREATE OR REPLACE FUNCTION public.trg_chairman_approval_unblock_orchestrator()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'extensions'
+AS $function$
+BEGIN
+  -- Fire on any TERMINAL resolve (approved OR rejected) — both release the venture from 'blocked'
+  -- so the orchestrator can act on the decision. Previously fired only on 'approved', leaving a
+  -- rejected blocking decision's venture stuck at orchestrator_state='blocked'.
+  IF NEW.status IN ('approved', 'rejected') AND (OLD.status IS DISTINCT FROM NEW.status) THEN
+    UPDATE ventures
+    SET orchestrator_state = 'idle'
+    WHERE id = NEW.venture_id
+      AND orchestrator_state = 'blocked';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- The trigger WHEN clause also restricted firing to status='approved'; broaden it to match.
+DROP TRIGGER IF EXISTS trg_chairman_decision_unblock ON public.chairman_decisions;
+CREATE TRIGGER trg_chairman_decision_unblock
+  AFTER UPDATE ON public.chairman_decisions
+  FOR EACH ROW
+  WHEN (NEW.status IN ('approved', 'rejected') AND (OLD.status IS DISTINCT FROM NEW.status))
+  EXECUTE FUNCTION public.trg_chairman_approval_unblock_orchestrator();

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -622,10 +622,16 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     const gateTypeA = govA?.gateTypeForAutonomy?.(resolvedStage) ?? 'stage_gate';
     const autonomy = await autonomyPreCheck(ventureId, gateTypeA, { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore }, resolvedStage).catch(() => ({ action: 'manual' }));
     if (autonomy.action === 'auto_approve') {
-      await supabase.from('chairman_decisions')
-        .update({ status: 'approved', decision: 'proceed', rationale: `Auto-approved (${autonomy.level} autonomy)` })
-        .eq('id', hookContext.chairmanDecisionId)
-        .eq('status', 'pending');
+      // SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001: resolve via the canonical path
+      // (fn_chairman_decide) so all paths write the identical (status, decision, blocking) triple.
+      // p_force_stale=true — fresh same-pass autonomous resolve.
+      await supabase.rpc('fn_chairman_decide', {
+        p_decision_id: hookContext.chairmanDecisionId,
+        p_action: 'approved',
+        p_decided_by: `auto-orchestrator-${autonomy.level}`,
+        p_rationale: `Auto-approved (${autonomy.level} autonomy)`,
+        p_force_stale: true,
+      });
       stageOutput.chairmanGate = {
         status: 'approved',
         rationale: `Auto-approved (${autonomy.level} autonomy)`,

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -835,10 +835,20 @@ export class StageExecutionWorker {
               this._logger.log(
                 `[Worker] Stage ${currentStage} pending decision ${pendingDecision.id} — auto-approving (global_auto_proceed=true)`
               );
-              await this._supabase
-                .from('chairman_decisions')
-                .update({ status: 'approved', decision: 'proceed', blocking: false, updated_at: new Date().toISOString() })
-                .eq('id', pendingDecision.id);
+              // SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001: resolve via the canonical
+              // path (fn_chairman_decide) so dashboard/worker/coordinator all write the identical
+              // (status, decision, blocking) triple. p_force_stale=true — fresh same-pass
+              // autonomous resolve (never stale), so the guard does not false-block it.
+              const { error: _approveErr } = await this._supabase.rpc('fn_chairman_decide', {
+                p_decision_id: pendingDecision.id,
+                p_action: 'approved',
+                p_decided_by: 'auto-proceed-worker',
+                p_rationale: 'Auto-approved (global_auto_proceed=true)',
+                p_force_stale: true,
+              });
+              if (_approveErr) {
+                this._logger.warn(`[Worker] Stage ${currentStage} canonical auto-approve failed (non-fatal): ${_approveErr.message}`);
+              }
 
               // Enrich existing artifact with promotion_gate if missing (build-loop stages).
               // The pending-decision shortcut skips processStage(), so promotion_gate
@@ -3934,16 +3944,29 @@ export class StageExecutionWorker {
    */
   async _resolveVisionPendingDecision(ventureId) {
     try {
-      const { error } = await this._supabase
+      // SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001: resolve via the canonical path
+      // (fn_chairman_decide) instead of a hand-written UPDATE. Select the pending vision_approval
+      // decision id, then call the canonical resolve with p_force_stale=true (fresh autonomous
+      // resolve). Idempotent: no-ops when no pending row exists. updated_at is trigger-maintained.
+      const { data: _pendingVision } = await this._supabase
         .from('chairman_decisions')
-        // SD-REFILL-007PVF5E: dropped phantom resolved_at (no such column live); updated_at is
-        // trigger-maintained. status+decision are the intended resolution effect.
-        .update({ status: 'approved', decision: 'proceed' })
+        .select('id')
         .eq('venture_id', ventureId)
         .eq('lifecycle_stage', 19)
         .eq('status', 'pending')
-        .eq('decision_type', 'vision_approval');
-      if (error) this._logger.warn(`[Worker] S19 vision decision resolve failed (non-fatal): ${error.message}`);
+        .eq('decision_type', 'vision_approval')
+        .limit(1)
+        .maybeSingle();
+      if (_pendingVision?.id) {
+        const { error } = await this._supabase.rpc('fn_chairman_decide', {
+          p_decision_id: _pendingVision.id,
+          p_action: 'approved',
+          p_decided_by: 'auto-proceed-worker-s19-vision',
+          p_rationale: 'S19 vision gate proceeded',
+          p_force_stale: true,
+        });
+        if (error) this._logger.warn(`[Worker] S19 vision decision resolve failed (non-fatal): ${error.message}`);
+      }
     } catch (err) {
       this._logger.warn(`[Worker] S19 vision decision resolve failed (non-fatal): ${err.message}`);
     }

--- a/tests/unit/eva/chairman-decision-canonical-resolve.test.js
+++ b/tests/unit/eva/chairman-decision-canonical-resolve.test.js
@@ -1,0 +1,87 @@
+// SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001
+// Locks the canonical chairman-decision resolve path:
+//   FR-1 (migration): fn_chairman_decide writes the full (status, decision, blocking) triple —
+//         approved->proceed, rejected->kill, blocking=false — never decision='pending'.
+//   FR-3 (refactor): the 3 autonomous resolve sites call fn_chairman_decide via RPC instead of
+//         hand-writing the triple onto chairman_decisions.
+//   FR-4 (guard): the autonomous (fresh same-pass) resolves pass p_force_stale=true.
+//
+// These are source-level invariant tests (per FR-3's acceptance criterion: "a grep/AST check finds
+// no remaining direct .update({status/decision/blocking}) on chairman_decisions in the in-scope
+// paths"). They are robust to the worker's heavy runtime deps (which make behavioral mocking
+// brittle) and lock the exact refactor + migration contract this SD delivers.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const read = (rel) => readFileSync(resolve(repoRoot, rel), 'utf8');
+
+const WORKER = 'lib/eva/stage-execution-worker.js';
+const ORCH = 'lib/eva/eva-orchestrator.js';
+const MIGRATION = 'database/migrations/20260628_chairman_decision_canonical_resolve.sql';
+
+describe('FR-3: autonomous resolve sites call the canonical fn_chairman_decide RPC', () => {
+  const worker = read(WORKER);
+  const orch = read(ORCH);
+
+  it('the worker no longer hand-writes a status=approved resolve onto chairman_decisions', () => {
+    // The old hand-write pattern: .update({ status: 'approved', decision: 'proceed', ... })
+    // Match a .update({...}) object literal that sets status to a terminal value (the resolve).
+    const handWriteResolve = /\.update\(\{[^}]*status:\s*['"](approved|rejected)['"][^}]*\}\)/g;
+    expect(worker.match(handWriteResolve)).toBeNull();
+    expect(orch.match(handWriteResolve)).toBeNull();
+  });
+
+  it('the worker calls fn_chairman_decide via RPC for both resolve sites (auto-approve + S19 vision)', () => {
+    const rpcCalls = worker.match(/rpc\(\s*['"]fn_chairman_decide['"]/g) || [];
+    expect(rpcCalls.length).toBeGreaterThanOrEqual(2); // :840 auto-approve + :3941 S19 vision
+  });
+
+  it('the orchestrator auto-approve calls fn_chairman_decide via RPC', () => {
+    expect(orch).toMatch(/rpc\(\s*['"]fn_chairman_decide['"]/);
+  });
+
+  it('FR-4: every canonical resolve from an autonomous path passes p_force_stale: true', () => {
+    // Each fn_chairman_decide RPC call in these autonomous files is a fresh same-pass resolve and
+    // must opt out of the stale-context guard.
+    for (const [name, src] of [['worker', worker], ['orchestrator', orch]]) {
+      const calls = src.split(/rpc\(\s*['"]fn_chairman_decide['"]/).slice(1);
+      for (const tail of calls) {
+        const argBlock = tail.slice(0, 400); // the args object follows the rpc name
+        expect(argBlock, `${name} fn_chairman_decide call must pass p_force_stale: true`).toMatch(/p_force_stale:\s*true/);
+        expect(argBlock, `${name} fn_chairman_decide call must pass p_action: 'approved'`).toMatch(/p_action:\s*['"]approved['"]/);
+      }
+    }
+  });
+});
+
+describe('FR-1: the migration makes fn_chairman_decide write the full consistent triple', () => {
+  const sql = read(MIGRATION);
+
+  it('maps approved->proceed and rejected->kill (decision values, not pending)', () => {
+    expect(sql).toMatch(/WHEN\s+'approved'\s+THEN\s+'proceed'/i);
+    expect(sql).toMatch(/WHEN\s+'rejected'\s+THEN\s+'kill'/i);
+  });
+
+  it('the UPDATE sets decision AND blocking (not status-only)', () => {
+    const updateBlock = sql.slice(sql.indexOf('UPDATE chairman_decisions'));
+    expect(updateBlock).toMatch(/decision\s*=\s*v_decision_value/);
+    expect(updateBlock).toMatch(/blocking\s*=\s*false/);
+    expect(updateBlock).toMatch(/status\s*=\s*p_action/);
+  });
+
+  it('FR-2 was split out: the migration does NOT alter the unblock trigger', () => {
+    // FR-2 (broaden trg_chairman_decision_unblock to rejected) was proven unsafe and deferred.
+    expect(sql).not.toMatch(/CREATE\s+TRIGGER\s+trg_chairman_decision_unblock/i);
+    expect(sql).not.toMatch(/DROP\s+TRIGGER\s+IF\s+EXISTS\s+trg_chairman_decision_unblock/i);
+  });
+
+  it('is a single declared object: only fn_chairman_decide (CREATE OR REPLACE FUNCTION)', () => {
+    const createFns = sql.match(/CREATE\s+OR\s+REPLACE\s+FUNCTION/gi) || [];
+    expect(createFns.length).toBe(1);
+    expect(sql).toMatch(/CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.fn_chairman_decide/i);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-CHAIRMAN-DECISION-RESOLVE-CANONICAL-001

Establishes ONE canonical chairman-decision resolve path. The bug: `fn_chairman_decide` (migration 20260213) wrote `status`+`decided_by`+`rationale` only, leaving **`decision='pending'` under `status='approved'`** — a contradictory "lying" decision field on an approved gate. Dashboard + coordinator CLI inherited it via the RPC; the autonomous worker/orchestrator paths hand-wrote their own divergent field sets.

### Shipped (coordinator-confirmed scope)
- **FR-1** `database/migrations/20260628_chairman_decision_canonical_resolve.sql` — `fn_chairman_decide` now writes the full `(status, decision, blocking)` triple: `approved→proceed`, `rejected→kill`, `blocking=false`. Decision values verified against the **live 30-value** `chairman_decisions_decision_check` (not the stale 20251206 narrow set).
- **FR-3** refactored the 3 autonomous resolve sites (`stage-execution-worker.js:840` auto-approve, `:3941` S19 vision, `eva-orchestrator.js:626`) to call `fn_chairman_decide` via RPC instead of hand-writing the triple.
- **FR-4** autonomous (fresh same-pass) resolves pass `p_force_stale=true` so the stale-context guard protects human/dashboard resolves without false-blocking them.
- **FR-6** 8 source-level invariant tests (`tests/unit/eva/chairman-decision-canonical-resolve.test.js`), all passing.

### Deferred / split out
- **FR-2** (broaden `trg_chairman_decision_unblock` to fire on `rejected`) was **proven unsafe** by the DATABASE sub-agent review and split to a follow-up SD: with no symmetric kill-consumer, and chairman REJECT routing through `fn_chairman_decide(action='rejected')` (which doesn't set the venture terminal), broadening the trigger would unblock a rejected venture → worker re-mints a fresh pending gate → **resurrects the killed gate, discarding the chairman's reject**. The rejected-stuck gap is pre-existing, so leaving the trigger approved-only is zero-regression.
- **FR-5** `venture-monitor.js:510` `status='processed'` enum drift flagged separately (harness_backlog `48bd91de`).

### ⚠️ Migration apply is CHAIRMAN-GATED
`CREATE OR REPLACE FUNCTION` is not Adam-delegatable (function DDL is out of delegation scope). The migration is committed + dry-run-clean (sha `34fb85e9`) but **must be applied by the chairman** (add `-- @approved-by: <chairman>` + `apply-migration.js --prod-deploy`). The JS refactors are safe against the old function meanwhile (no breakage; the fix simply isn't live until applied).

### Evidence
DATABASE review `cc6de94c` (caught the FR-2 hazard) · TESTING `204905e9` (8/8) · retro `24b73bc3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
