### PR TITLE
feat(SD-LEO-INFRA-LEAN-DECISION-EMAIL-001): lean, decision-specific on-demand chairman email

### DIFF
--- a/lib/chairman/decision-layman.mjs
+++ b/lib/chairman/decision-layman.mjs
@@ -273,3 +273,82 @@ export function renderDecisionLines(rows, now = new Date()) {
     lines: items.map((it) => renderItem(it, now)),
   };
 }
+
+// ── SD-LEO-INFRA-LEAN-DECISION-EMAIL-001 ─────────────────────────────────────
+// The LEAN, decision-SPECIFIC on-demand email renderer. Unlike renderDecisionLines (which reads the
+// chairman_pending_decisions VIEW that HARDCODES decision_type='chairman_approval', sets
+// title='Stage N Chairman Approval', and DROPS brief_data — so a session_question is mis-rendered as a
+// venture sign-off), these helpers read the BASE chairman_decisions row shape: the REAL decision_type,
+// `summary`, `brief_data.{title,recommendation,context}`, `lifecycle_stage`, `blocking`, `venture_id`.
+// PURE — no IO/DB/LLM. The thin IO shell (scripts/adam-decision-email.mjs) reads the base rows + sends.
+
+/** brief_data is jsonb (object) on the base table, but tolerate a stringified value. */
+function briefOf(row) {
+  const b = row?.brief_data;
+  if (!b) return {};
+  if (typeof b === 'string') { try { return JSON.parse(b) || {}; } catch { return {}; } }
+  return typeof b === 'object' ? b : {};
+}
+
+/**
+ * Render ONE base chairman_decisions row into a plain, decision-SPECIFIC action line, by its REAL type.
+ *  - A true venture approval (chairman_approval/gate_decision/stage_gate WITH a venture_id) keeps the
+ *    venture/stage framing.
+ *  - Everything else (session_question / operational / governance / escalation / …) renders as its
+ *    QUESTION (brief_data.title || summary) + context + the free-text recommendation — NEVER as a
+ *    "venture waiting for sign-off (Stage X)". Ends with the REAL `decision_type:id` ref.
+ * @param {object} baseRow - a chairman_decisions row (base table, not the view)
+ * @param {Date} now
+ * @returns {string}
+ */
+export function renderLeanDecision(baseRow, now = new Date()) {
+  const r = baseRow || {};
+  const bd = briefOf(r);
+  const dt = r.decision_type || 'session_question';
+  const id = r.id;
+  const ref = `[ref ${dt}:${id}]`;
+  const age = formatAge(r.created_at, now);
+  const title = cleanText(bd.title || r.summary || 'a pending decision', 200);
+  // The free-text recommendation lives in brief_data (the column only allows proceed/pivot/fix/kill/pause).
+  const rec = bd.recommendation || (typeof r.recommendation === 'string' ? r.recommendation : '');
+  const recLine = rec ? ` Recommendation: ${cleanText(rec, 160)}.` : '';
+
+  const isVentureApproval =
+    (dt === 'chairman_approval' || dt === 'gate_decision' || dt === 'stage_gate') && !!r.venture_id;
+
+  if (isVentureApproval) {
+    const stage = (r.lifecycle_stage != null) ? `Stage ${r.lifecycle_stage}` : 'its current stage';
+    const blocking = r.blocking ? ' (blocking the venture)' : '';
+    return `Approve the venture to move past ${stage}${blocking} (waiting ${age}): “${title}”.${recLine} ` +
+      `Show it to me and walk me through the call. ${ref}`;
+  }
+
+  // Non-venture decision — render the ACTUAL question + context + recommendation.
+  let ctx = bd.context;
+  if (ctx && typeof ctx !== 'string') { try { ctx = JSON.stringify(ctx); } catch { ctx = ''; } }
+  const ctxLine = ctx ? ` Context: ${cleanText(ctx, 220)}.` : '';
+  return `Decide: “${title}” (waiting ${age}).${ctxLine}${recLine} ${ref}`;
+}
+
+/**
+ * Render the LEAN on-demand decision email for a set of BASE chairman_decisions rows. The escalated
+ * decision (primaryId) leads; the subject is the standout '[ACTION NEEDED - ADAM] <decision title>'.
+ * Returns the pure pieces; the script assembles text/html + sends. NO status block is produced here.
+ * @param {object[]} baseRows
+ * @param {Date} now
+ * @param {{primaryId?: string}} [opts]
+ * @returns {{subject: string, lines: string[], primary: object|null}}
+ */
+export function renderLeanDecisionEmail(baseRows, now = new Date(), { primaryId } = {}) {
+  const rows = (Array.isArray(baseRows) ? baseRows : []).filter(Boolean);
+  const primary = (primaryId && rows.find((r) => r.id === primaryId)) || rows[0] || null;
+  const bd = primary ? briefOf(primary) : {};
+  const subjTitle = primary
+    ? cleanText(bd.title || primary.summary || 'chairman decision needed', 80)
+    : 'chairman decision needed';
+  const extra = rows.length > 1 ? ` (+${rows.length - 1} more)` : '';
+  const subject = `[ACTION NEEDED - ADAM] ${subjTitle}${extra}`;
+  const ordered = primary ? [primary, ...rows.filter((r) => r !== primary)] : rows;
+  const lines = ordered.map((r) => renderLeanDecision(r, now));
+  return { subject, lines, primary };
+}

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -26,7 +26,10 @@ import { dirname, resolve } from 'node:path';
 const COLUMN_RECOMMENDATIONS = new Set(['proceed', 'pivot', 'fix', 'kill', 'pause']);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ADAM_EXEC_SUMMARY = resolve(__dirname, '../../scripts/adam-exec-summary.mjs');
+// SD-LEO-INFRA-LEAN-DECISION-EMAIL-001: the on-demand escalation now sends the LEAN, decision-specific
+// email (the decision's real title/context/recommendation, no hourly status block) — NOT the full
+// exec-summary. adam-exec-summary.mjs remains the hourly/scheduled summary path.
+const ADAM_DECISION_EMAIL = resolve(__dirname, '../../scripts/adam-decision-email.mjs');
 
 /**
  * SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 FR-1 — PURE, deterministic predicate: should recording
@@ -43,12 +46,16 @@ export function shouldAutoEscalate({ decisionType, blocking, raisedBy } = {}) {
 }
 
 /**
- * Default fire-and-forget spawn of the standout escalation email (adam-exec-summary.mjs --force).
+ * Default fire-and-forget spawn of the standout LEAN decision email (adam-decision-email.mjs --decision <id>).
  * Detached + unref'd so it never blocks the caller; stdio ignored. Fail-soft — the email is a nudge,
- * the durable decision row is the source of truth.
+ * the durable decision row is the source of truth. The decisionId leads the email so it carries THE
+ * decision the chairman is being asked to make (not a generic 'approve N ventures').
+ * @param {string} [decisionId]
  */
-function defaultSpawnEscalationEmail() {
-  const child = nodeSpawn('node', [ADAM_EXEC_SUMMARY, '--force'], { detached: true, stdio: 'ignore' });
+function defaultSpawnEscalationEmail(decisionId) {
+  const args = [ADAM_DECISION_EMAIL];
+  if (decisionId) args.push('--decision', decisionId);
+  const child = nodeSpawn('node', args, { detached: true, stdio: 'ignore' });
   child.on('error', () => { /* fail-soft: the email is best-effort */ });
   if (typeof child.unref === 'function') child.unref();
 }
@@ -76,7 +83,7 @@ export async function escalateChairmanDecision(supabase, decisionId, { spawn = d
     if (live?.brief_data?.escalation_email_sent_at) {
       return { escalated: false, deduped: true };
     }
-    spawn(); // fire-and-forget standout email
+    spawn(decisionId); // fire-and-forget standout LEAN decision email (leads with this decision)
     const merged = { ...(live?.brief_data || {}), escalation_email_sent_at: new Date().toISOString() };
     await supabase.from('chairman_decisions').update({ brief_data: merged }).eq('id', decisionId);
     return { escalated: true };

--- a/scripts/adam-decision-email.mjs
+++ b/scripts/adam-decision-email.mjs
@@ -1,0 +1,88 @@
+// adam-decision-email.mjs — SD-LEO-INFRA-LEAN-DECISION-EMAIL-001
+//
+// The LEAN, on-demand chairman DECISION email. The chairman disabled the hourly exec-summary and now
+// relies on on-demand decision emails as his assurance + action channel — so this email carries the
+// DECISION (its real title/context/recommendation, rendered by the decision's ACTUAL type), NOT the
+// hourly status block (workers / build-% / rung / meta-ratio / distance-to-quit / in-progress SDs).
+//
+// It reads the BASE chairman_decisions table (the chairman_pending_decisions VIEW hardcodes
+// decision_type='chairman_approval', titles it 'Stage N Chairman Approval', and drops brief_data —
+// so a session_question is mis-rendered as a venture sign-off). Spawned by escalateChairmanDecision
+// (lib/chairman/record-pending-decision.mjs) with --decision <id>. Fail-soft; --dry-run prints only.
+// No emojis (chairman directive).
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { pathToFileURL } from 'url';
+import { resolve } from 'path';
+import { renderLeanDecisionEmail } from '../lib/chairman/decision-layman.mjs';
+
+const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const DRY = !!process.env.ADAM_EMAIL_DRYRUN || process.argv.includes('--dry-run');
+const EM = '—';
+
+// --decision <id>: the escalated decision to lead with (and include other pending decisions too).
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+const primaryId = argValue('--decision');
+
+// ── Read the BASE chairman_decisions table (real decision_type + brief_data) ──
+const COLS = 'id,decision_type,summary,brief_data,lifecycle_stage,blocking,venture_id,recommendation,status,created_at';
+let rows = [];
+try {
+  const { data, error } = await db.from('chairman_decisions')
+    .select(COLS).eq('status', 'pending').order('created_at', { ascending: false }).limit(50);
+  if (error) throw error;
+  rows = data || [];
+  // Ensure the escalated decision is present even if a race left it just outside the pending window.
+  if (primaryId && !rows.some((r) => r.id === primaryId)) {
+    const { data: one } = await db.from('chairman_decisions').select(COLS).eq('id', primaryId).maybeSingle();
+    if (one) rows = [one, ...rows];
+  }
+} catch (e) {
+  console.warn('[adam-decision-email] base read failed (fail-soft): ' + (e?.message || e));
+}
+
+if (rows.length === 0) {
+  console.log('[adam-decision-email] no pending decisions — nothing to send');
+  process.exit(0);
+}
+
+const { subject, lines } = renderLeanDecisionEmail(rows, new Date(), { primaryId });
+
+// ── Body: the DECISION content + the copy-paste-to-Claude-Code action block. NO status block. ──
+const LEAD_IN = "I have received the following executive decision(s) via email and I'm ready to address them:";
+const numbered = lines.map((l, i) => `${i + 1}. ${l}`);
+const copyBlock = [LEAD_IN, '', ...numbered].join('\n');
+const n = lines.length;
+const when = new Date().toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
+
+const text = [
+  `${n} decision${n === 1 ? '' : 's'} need${n === 1 ? 's' : ''} you.`,
+  '   Press and hold the text below, Select All, Copy — then paste it into Claude Code.',
+  '──────────────────────────────────────────────',
+  '',
+  copyBlock,
+  '',
+  `as of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor`,
+].join('\n');
+
+const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
+  `<p style="font-size:14px;margin:0 0 2px"><b>${n} decision${n === 1 ? '' : 's'} need${n === 1 ? 's' : ''} you.</b></p>` +
+  `<p style="font-size:12px;color:#888;margin:0 0 6px">On your phone, press and hold the box below, tap "Select All", then "Copy" — then paste it into Claude Code.</p>` +
+  `<pre style="font-size:13px;background:#f6f8fa;border:1px solid #e1e4e8;border-radius:4px;padding:12px;white-space:pre-wrap;margin:0;font-family:ui-monospace,Menlo,Consolas,monospace;-webkit-user-select:all;user-select:all">${esc(copyBlock)}</pre>` +
+  `<p style="font-size:11px;color:#999;margin:14px 0 0">as of ${esc(when)} ET ${EM} Adam ${EM} LEO Fleet Advisor</p></div>`;
+
+if (DRY) {
+  console.log('=== [ADAM DECISION EMAIL — DRY RUN] no email sent ===\nSUBJECT: ' + subject + '\n---\n' + text + '\n---');
+} else {
+  try {
+    const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
+    const r = await mod.sendEmail({ from: 'Adam ' + EM + ' LEO Fleet Advisor <onboarding@resend.dev>', to: process.env.CLAUDE_NOTIFY_EMAIL, subject, html, text });
+    console.log('ADAM-DECISION-EMAIL', JSON.stringify(r));
+  } catch (e) {
+    console.warn('[adam-decision-email] send failed (fail-soft): ' + (e?.message || e));
+  }
+}

--- a/tests/unit/chairman-decision-layman.test.js
+++ b/tests/unit/chairman-decision-layman.test.js
@@ -6,6 +6,8 @@ import {
   refTag,
   renderItem,
   renderDecisionLines,
+  renderLeanDecision,
+  renderLeanDecisionEmail,
   GROUPABLE_TYPES,
 } from '../../lib/chairman/decision-layman.mjs';
 
@@ -132,5 +134,81 @@ describe('renderDecisionLines — integration', () => {
     const rows = [approval('a1', 19, 'Alpha', 21), flag('f1', 'x', 8)];
     const { lines } = renderDecisionLines(rows, NOW);
     for (const l of lines) expect(l).toMatch(/\[refs? \w+:/);
+  });
+});
+
+// ── SD-LEO-INFRA-LEAN-DECISION-EMAIL-001: lean, decision-specific on-demand email ──
+// These read the BASE chairman_decisions row shape (real decision_type + brief_data), NOT the lossy view.
+const baseSessionQuestion = (id, ageDays, brief = {}) => ({
+  id, decision_type: 'session_question', summary: brief.title || 'a question',
+  brief_data: brief, lifecycle_stage: 0, blocking: false, venture_id: null, created_at: D(ageDays),
+});
+const baseVentureApproval = (id, stage, ageDays, brief = {}) => ({
+  id, decision_type: 'chairman_approval', summary: `Stage ${stage} approval`,
+  brief_data: brief, lifecycle_stage: stage, blocking: false, venture_id: `v-${id}`, created_at: D(ageDays),
+});
+
+describe('renderLeanDecision (FR-1)', () => {
+  it('renders a session_question as its QUESTION + recommendation, NOT a venture sign-off', () => {
+    const row = baseSessionQuestion('dq1', 1, {
+      title: 'Decide canonical S5 financial truth: contract 7.7:1 vs artifact 38.17:1',
+      recommendation: 'use the contract',
+      context: 'the artifact and the contract disagree',
+    });
+    const line = renderLeanDecision(row, NOW);
+    expect(line).toContain('Decide canonical S5 financial truth');
+    expect(line).toContain('Recommendation: use the contract');
+    expect(line).toContain('Context: the artifact and the contract disagree');
+    expect(line).not.toMatch(/waiting for (your )?sign-off/i);
+    expect(line).not.toMatch(/Stage 0/);
+    expect(line).toContain('[ref session_question:dq1]'); // REAL type in the ref
+  });
+
+  it('keeps venture/stage framing for a true chairman_approval with a venture', () => {
+    const row = baseVentureApproval('va1', 12, 2, { title: 'Approve Acme past Stage 12', recommendation: 'proceed' });
+    const line = renderLeanDecision(row, NOW);
+    expect(line).toMatch(/move past Stage 12/);
+    expect(line).toContain('[ref chairman_approval:va1]');
+  });
+
+  it('omits the recommendation line when none is present', () => {
+    const line = renderLeanDecision(baseSessionQuestion('dq2', 1, { title: 'open question' }), NOW);
+    expect(line).not.toMatch(/Recommendation:/);
+    expect(line).toContain('open question');
+  });
+});
+
+describe('renderLeanDecisionEmail (FR-2/FR-3)', () => {
+  it('subject is the standout [ACTION NEEDED - ADAM] + the decision title; primary leads', () => {
+    const rows = [
+      baseVentureApproval('va1', 12, 5, { title: 'Approve Acme' }),
+      baseSessionQuestion('dq1', 1, { title: 'Decide S5 financial truth', recommendation: 'contract' }),
+    ];
+    const { subject, lines } = renderLeanDecisionEmail(rows, NOW, { primaryId: 'dq1' });
+    expect(subject).toBe('[ACTION NEEDED - ADAM] Decide S5 financial truth (+1 more)');
+    expect(lines[0]).toContain('Decide S5 financial truth'); // primary first
+    expect(lines.length).toBe(2);
+  });
+
+  it('each pending decision renders by its ACTUAL type (mixed set)', () => {
+    const rows = [
+      baseSessionQuestion('dq1', 1, { title: 'a governance question' }),
+      baseVentureApproval('va1', 7, 3, { title: 'Approve Beta' }),
+    ];
+    const { lines } = renderLeanDecisionEmail(rows, NOW, { primaryId: 'dq1' });
+    const joined = lines.join('\n');
+    expect(joined).toContain('Decide: “a governance question”');     // session_question framing
+    expect(joined).toMatch(/move past Stage 7/);                      // venture framing
+    expect(joined).toContain('[ref session_question:dq1]');
+    expect(joined).toContain('[ref chairman_approval:va1]');
+  });
+
+  it('the rendered lines carry NONE of the hourly status-block markers', () => {
+    const rows = [baseSessionQuestion('dq1', 1, { title: 'q', recommendation: 'r' })];
+    const { subject, lines } = renderLeanDecisionEmail(rows, NOW, { primaryId: 'dq1' });
+    const blob = subject + '\n' + lines.join('\n');
+    for (const marker of ['Workers:', 'rung', 'meta', 'distance-to-quit', 'built', 'active idle']) {
+      expect(blob.toLowerCase()).not.toContain(marker.toLowerCase());
+    }
   });
 });


### PR DESCRIPTION
## SD-LEO-INFRA-LEAN-DECISION-EMAIL-001 — lean, decision-specific on-demand chairman email

The chairman disabled the hourly exec-summary and relies on **on-demand decision emails** as his assurance + action channel. But the escalation path (`recordPendingDecision` → `escalateChairmanDecision`) spawned `adam-exec-summary.mjs --force` — sending the **entire summary** (workers / build-% / rung / meta-ratio status block) plus a generic *"Approve the N ventures waiting for your sign-off (Stage 0-12)"* line. A `session_question` the chairman emailed himself arrived mislabeled as a venture sign-off, with its real title/context/recommendation nowhere in the email.

### Root cause (found at LEAD validation): a lossy VIEW, not the renderer
`chairman_pending_decisions` **hardcodes** `decision_type='chairman_approval'`, retitles every row `"Stage N Chairman Approval"`, and **drops `brief_data`**. So the rendering bug was really a data-contract bug. The fix reads the **base `chairman_decisions` table** by the escalation's `decisionId` — surgical, **no migration**.

### FR-1 — pure, decision-specific renderers (`lib/chairman/decision-layman.mjs`)
`renderLeanDecision(baseRow)` / `renderLeanDecisionEmail(baseRows, {primaryId})` read the base row shape (real `decision_type`, `summary`, `brief_data.{title,recommendation,context}`, `lifecycle_stage`, `blocking`, `venture_id`). A true venture approval keeps the venture/stage framing; **everything else** (`session_question` / operational / governance / escalation) renders as its **question + context + recommendation**, ending with the real `decision_type:id` ref.

### FR-2 — lean email, status block omitted (`scripts/adam-decision-email.mjs`)
New thin script reads the base table (the escalated `--decision <id>` + other pending), renders via the pure helpers, builds the standout subject `[ACTION NEEDED - ADAM] <decision title>` + the copy-paste-to-Claude-Code action block, sends via the same `resend-adapter`, and **omits** the hourly status block. `escalateChairmanDecision` now spawns this lean script with the `decisionId` instead of `adam-exec-summary.mjs --force`. The hourly summary path and the view are **unchanged**.

### FR-3 — tests
`tests/unit/chairman-decision-layman.test.js`: `session_question` → question+recommendation (not a venture sign-off); venture keeps stage framing; standout subject = decision title; mixed types each render by real type; lean body omits the status-block markers; the existing view-path `renderDecisionLines` stays green. Validated via a node harness (16/16) + a live `--dry-run` (rendered 6 real pending decisions). **CI runs the real vitest suite from `main`** (vitest excludes `**/.worktrees/**`).

Restores the chairman's chosen channel: the on-demand email now shows **what he is deciding + the recommendation**, by real type, without the status block he disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
