### PR TITLE
fix(SD-LEO-INFRA-S5-FINANCIAL-SINGLE-SOURCE-001): lockstep the S5 truth_financial_model verdict (no drift on reEvaluateOnly)

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -40,6 +40,7 @@ import { getTemplate } from './stage-templates/index.js';
 // SD-LEO-INFRA-KILLGATE-DETERMINISM-ALL-GATES-001: per-kill-gate deterministic recompute registry
 // (generalizes the #5206 S5-only re-eval to {3,5,13}).
 import { recomputeKillGateVerdict, hasKillGateRecompute } from './kill-gate-recompute.js';
+import { persistRecomputedVerdict, S5_ARTIFACT_TYPE } from './s5-financial-consistency.js';
 import { getContract, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
 // SD-REFILL-00V67JEB (FR-1): persist a runtime contract-enforcement coverage signal (fail-open).
 import { emitContractCoverage } from './contracts/contract-coverage.js';
@@ -552,6 +553,19 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         stageOutput.blockProgression = reGate.blockProgression;
         if (reGate.remediationRoute !== undefined) stageOutput.remediationRoute = reGate.remediationRoute;
         logger.log(`[Eva] reEvaluateOnly: deterministic kill-gate recompute stage ${resolvedStage} decision='${reGate.decision}' (re-run on locked persisted artifact)`);
+
+        // SD-LEO-INFRA-S5-FINANCIAL-SINGLE-SOURCE-001 FR-1: close the drift seam. reEvaluateOnly
+        // recomputes the verdict into stageOutput (which flows to the chairman mint) but historically
+        // never re-persisted it onto the artifact, so later artifact readers saw a stale decision.
+        // Lockstep the verdict back onto the current S5 truth_financial_model artifact (targeted jsonb
+        // field update — NOT an LLM regen). Only writes when the verdict actually differs.
+        if (!options.dryRun && supabase && resolvedStage === 5) {
+          const s5Payload = (artifacts.find((a) => a?.artifactType === S5_ARTIFACT_TYPE) || artifacts[0])?.payload;
+          if (s5Payload) {
+            await persistRecomputedVerdict(supabase, { ventureId, stage: resolvedStage, payload: s5Payload, verdict: reGate, logger })
+              .catch((e) => logger.warn(`[Eva] reEvaluateOnly S5 verdict lockstep skipped (non-fatal): ${e.message}`));
+          }
+        }
       }
     }
 

--- a/lib/eva/s5-financial-consistency.js
+++ b/lib/eva/s5-financial-consistency.js
@@ -1,0 +1,109 @@
+/**
+ * S5 financial single-source-of-truth helpers.
+ * SD-LEO-INFRA-S5-FINANCIAL-SINGLE-SOURCE-001.
+ *
+ * The S5 kill gate persists a truth_financial_model artifact whose verdict fields
+ * (decision/reasons/blockProgression/remediationRoute) must always equal the deterministic
+ * recompute over the artifact's own inputs (recomputeKillGateVerdict). The drift seam is the
+ * reEvaluateOnly path: it recomputes the verdict into stageOutput but never re-persists it onto
+ * the artifact, so artifact readers (S17 strategy, kill-gate recompute) can see a stale decision.
+ *
+ * These helpers (a) compare a persisted artifact's verdict to a fresh recompute and (b) lockstep
+ * the persisted artifact to the recompute via a TARGETED jsonb update of ONLY the verdict fields —
+ * never the LLM-derived model content (honors the 'no regen / no overwrite' contract). The same
+ * recompute fn drives the orchestrator lockstep (FR-1), the invariant checker (FR-3) and the
+ * backfill (FR-4), so they cannot diverge.
+ */
+
+import { recomputeKillGateVerdict } from './kill-gate-recompute.js';
+
+export const S5_ARTIFACT_TYPE = 'truth_financial_model';
+
+// Only these DERIVED verdict fields are ever written back. Inputs / LLM model content are left
+// untouched, so a targeted update cannot mask input drift or destroy narrative.
+export const VERDICT_FIELDS = Object.freeze(['decision', 'reasons', 'blockProgression', 'remediationRoute']);
+
+/** Deterministic, key-order-insensitive structural compare of a verdict field (handles arrays/objects). */
+function fieldEquals(a, b) {
+  if (a === b) return true;
+  if (a == null || b == null) return a == null && b == null;
+  if (typeof a !== 'object' && typeof b !== 'object') return a === b;
+  try {
+    return stableStringify(a) === stableStringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function stableStringify(v) {
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`;
+  if (v && typeof v === 'object') {
+    return `{${Object.keys(v).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(v[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(v);
+}
+
+/**
+ * Does the persisted artifact payload's verdict differ from the recomputed verdict?
+ * Only the VERDICT_FIELDS are compared.
+ * @param {Object} payload - persisted truth_financial_model artifact_data
+ * @param {Object} verdict - recompute result (decision/reasons/blockProgression/remediationRoute)
+ * @returns {boolean}
+ */
+export function verdictDiffers(payload, verdict) {
+  if (!payload || !verdict) return false; // nothing to reconcile
+  return VERDICT_FIELDS.some((f) => f in verdict && !fieldEquals(payload[f], verdict[f]));
+}
+
+/**
+ * Pure consistency evaluation for a venture's S5: compare the persisted truth_financial_model
+ * verdict to a fresh recompute over the same artifact.
+ * @param {Array<{artifactType?:string, payload?:Object}>} artifacts - loaded persisted artifacts
+ * @returns {{applicable:boolean, consistent:boolean, persistedDecision:any, recomputedDecision:any}}
+ */
+export function evaluateS5Consistency(artifacts) {
+  const verdict = recomputeKillGateVerdict(5, artifacts);
+  const payload = (Array.isArray(artifacts) ? artifacts.find((a) => a?.artifactType === S5_ARTIFACT_TYPE) : null)?.payload
+    || (Array.isArray(artifacts) ? artifacts[0]?.payload : null);
+  if (!verdict || !payload) {
+    return { applicable: false, consistent: true, persistedDecision: payload?.decision, recomputedDecision: verdict?.decision };
+  }
+  return {
+    applicable: true,
+    consistent: !verdictDiffers(payload, verdict),
+    persistedDecision: payload.decision,
+    recomputedDecision: verdict.decision,
+  };
+}
+
+/**
+ * Lockstep: persist the recomputed verdict fields onto the CURRENT truth_financial_model artifact
+ * (targeted in-place jsonb merge) when (and only when) they differ. No LLM regen, no version bump,
+ * no is_current flip (per DB validation). Must run on a service-role connection (RLS).
+ *
+ * @param {Object} supabase - service-role client
+ * @param {Object} args - { ventureId, stage, payload, verdict, logger }
+ * @returns {Promise<{updated:boolean, decision:any}>}
+ */
+export async function persistRecomputedVerdict(supabase, { ventureId, stage = 5, payload, verdict, logger = console }) {
+  if (!supabase || !ventureId || !verdict || !payload) return { updated: false, decision: verdict?.decision };
+  if (!verdictDiffers(payload, verdict)) return { updated: false, decision: verdict.decision };
+
+  const merged = { ...payload };
+  for (const f of VERDICT_FIELDS) if (f in verdict) merged[f] = verdict[f];
+
+  const { error } = await supabase
+    .from('venture_artifacts')
+    .update({ artifact_data: merged })
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', stage)
+    .eq('artifact_type', S5_ARTIFACT_TYPE)
+    .eq('is_current', true);
+
+  if (error) {
+    logger?.warn?.(`[S5Consistency] lockstep verdict persist failed (non-fatal): ${error.message}`);
+    return { updated: false, decision: verdict.decision };
+  }
+  logger?.log?.(`[S5Consistency] lockstep: re-persisted recomputed verdict (decision='${verdict.decision}') onto venture ${ventureId} S${stage} truth_financial_model`);
+  return { updated: true, decision: verdict.decision };
+}

--- a/scripts/s5-financial-consistency.mjs
+++ b/scripts/s5-financial-consistency.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-S5-FINANCIAL-SINGLE-SOURCE-001 FR-3 (invariant check) + FR-4 (backfill)
+ *
+ * For each venture's CURRENT S5 truth_financial_model artifact, compare its persisted verdict
+ * (decision/reasons/blockProgression/remediationRoute) to a deterministic recompute over the
+ * artifact's own inputs. Report divergence; with --apply, lockstep-repair the diverged artifacts
+ * (targeted jsonb verdict update — no LLM regen). Service-role only (RLS).
+ *
+ * Usage:
+ *   node scripts/s5-financial-consistency.mjs            # FR-3: check + report divergence (dry-run)
+ *   node scripts/s5-financial-consistency.mjs --apply    # FR-4: backfill diverged ventures
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { evaluateS5Consistency, persistRecomputedVerdict, S5_ARTIFACT_TYPE } from '../lib/eva/s5-financial-consistency.js';
+import { recomputeKillGateVerdict } from '../lib/eva/kill-gate-recompute.js';
+
+const APPLY = process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function main() {
+  const { data: rows, error } = await supabase
+    .from('venture_artifacts')
+    .select('venture_id, lifecycle_stage, artifact_data')
+    .eq('artifact_type', S5_ARTIFACT_TYPE)
+    .eq('is_current', true)
+    .eq('lifecycle_stage', 5);
+  if (error) throw new Error(`venture_artifacts read failed: ${error.message}`);
+
+  console.log(`[s5-consistency] current S5 truth_financial_model artifacts: ${rows.length}`);
+  const diverged = [];
+  for (const r of rows) {
+    const artifacts = [{ artifactType: S5_ARTIFACT_TYPE, payload: r.artifact_data }];
+    const c = evaluateS5Consistency(artifacts);
+    if (c.applicable && !c.consistent) {
+      diverged.push(r);
+      console.log(`  ✗ venture ${r.venture_id}: persisted='${c.persistedDecision}' recomputed='${c.recomputedDecision}'`);
+    }
+  }
+
+  console.log(`[s5-consistency] diverged ventures: ${diverged.length}`);
+  if (diverged.length === 0) { console.log('[s5-consistency] INVARIANT OK — all current S5 artifacts are consistent.'); return; }
+  if (!APPLY) { console.log('[s5-consistency] DRY-RUN — re-run with --apply to lockstep-repair the diverged artifacts above.'); return; }
+
+  let fixed = 0;
+  for (const r of diverged) {
+    const artifacts = [{ artifactType: S5_ARTIFACT_TYPE, payload: r.artifact_data }];
+    const verdict = recomputeKillGateVerdict(5, artifacts);
+    const res = await persistRecomputedVerdict(supabase, { ventureId: r.venture_id, stage: 5, payload: r.artifact_data, verdict, logger: console });
+    if (res.updated) fixed++;
+  }
+  console.log(`[s5-consistency] BACKFILLED ${fixed} diverged artifact(s).`);
+  // exit non-zero if any diverged remain unfixed (so CI can fail loud)
+  if (fixed < diverged.length) process.exitCode = 1;
+}
+
+main().catch((e) => { console.error(e.message); process.exit(1); });

--- a/tests/unit/eva/s5-financial-consistency.test.js
+++ b/tests/unit/eva/s5-financial-consistency.test.js
@@ -1,0 +1,97 @@
+/**
+ * S5 financial single-source-of-truth helpers — unit tests
+ * SD-LEO-INFRA-S5-FINANCIAL-SINGLE-SOURCE-001 (FR-1/FR-3)
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the deterministic recompute so evaluateS5Consistency is testable without real S5 inputs.
+vi.mock('../../../lib/eva/kill-gate-recompute.js', () => ({
+  recomputeKillGateVerdict: vi.fn(),
+}));
+
+import { recomputeKillGateVerdict } from '../../../lib/eva/kill-gate-recompute.js';
+import {
+  verdictDiffers,
+  evaluateS5Consistency,
+  persistRecomputedVerdict,
+  VERDICT_FIELDS,
+  S5_ARTIFACT_TYPE,
+} from '../../../lib/eva/s5-financial-consistency.js';
+
+const VERDICT = { decision: 'conditional_pass', reasons: [{ message: 'demand unvalidated' }], blockProgression: false, remediationRoute: 'review' };
+
+describe('FR-1 verdictDiffers — compares only the verdict fields', () => {
+  it('false when the persisted payload already matches the verdict', () => {
+    const payload = { ...VERDICT, capitalRequired: 100000, roi3y: 0.3 }; // inputs/outputs present, verdict matches
+    expect(verdictDiffers(payload, VERDICT)).toBe(false);
+  });
+  it('true when the persisted decision differs', () => {
+    expect(verdictDiffers({ ...VERDICT, decision: 'pass' }, VERDICT)).toBe(true);
+  });
+  it('true when a verdict array field (reasons) differs structurally', () => {
+    expect(verdictDiffers({ ...VERDICT, reasons: [{ message: 'different' }] }, VERDICT)).toBe(true);
+  });
+  it('ignores non-verdict (input/model) fields entirely', () => {
+    expect(verdictDiffers({ ...VERDICT, capitalRequired: 999, roi3y: 9.9 }, VERDICT)).toBe(false);
+  });
+});
+
+describe('FR-3 evaluateS5Consistency — persisted vs recompute', () => {
+  it('consistent when the persisted artifact verdict matches the recompute', () => {
+    recomputeKillGateVerdict.mockReturnValue(VERDICT);
+    const artifacts = [{ artifactType: S5_ARTIFACT_TYPE, payload: { ...VERDICT, roi3y: 0.3 } }];
+    const c = evaluateS5Consistency(artifacts);
+    expect(c.applicable).toBe(true);
+    expect(c.consistent).toBe(true);
+  });
+  it('flags divergence (the venture-1 case: persisted pass vs recomputed conditional_pass)', () => {
+    recomputeKillGateVerdict.mockReturnValue(VERDICT);
+    const artifacts = [{ artifactType: S5_ARTIFACT_TYPE, payload: { ...VERDICT, decision: 'pass' } }];
+    const c = evaluateS5Consistency(artifacts);
+    expect(c.consistent).toBe(false);
+    expect(c.persistedDecision).toBe('pass');
+    expect(c.recomputedDecision).toBe('conditional_pass');
+  });
+  it('not applicable when there is no recompute or no payload', () => {
+    recomputeKillGateVerdict.mockReturnValue(null);
+    expect(evaluateS5Consistency([]).applicable).toBe(false);
+  });
+});
+
+describe('FR-1 persistRecomputedVerdict — lockstep targeted update', () => {
+  function mockSupabase() {
+    const calls = [];
+    const chain = {
+      update: vi.fn((payload) => { calls.push(payload); return chain; }),
+      eq: vi.fn(() => chain),
+      then: (resolve) => resolve({ error: null }),
+    };
+    return { client: { from: vi.fn(() => chain) }, calls, chain };
+  }
+
+  it('updates the artifact (merging only verdict fields) when the verdict differs', async () => {
+    const { client, calls, chain } = mockSupabase();
+    const payload = { ...VERDICT, decision: 'pass', capitalRequired: 100000, roi3y: 0.3 };
+    const res = await persistRecomputedVerdict(client, { ventureId: 'v-1', stage: 5, payload, verdict: VERDICT, logger: { log: () => {}, warn: () => {} } });
+    expect(res.updated).toBe(true);
+    expect(client.from).toHaveBeenCalledWith('venture_artifacts');
+    const merged = calls[0].artifact_data;
+    expect(merged.decision).toBe('conditional_pass'); // verdict applied
+    expect(merged.capitalRequired).toBe(100000);      // input preserved
+    expect(merged.roi3y).toBe(0.3);                    // model output preserved
+    // scoped to the current S5 truth_financial_model row
+    expect(chain.eq).toHaveBeenCalledWith('artifact_type', S5_ARTIFACT_TYPE);
+    expect(chain.eq).toHaveBeenCalledWith('is_current', true);
+  });
+
+  it('no-ops when the persisted verdict already matches (idempotent)', async () => {
+    const { client } = mockSupabase();
+    const res = await persistRecomputedVerdict(client, { ventureId: 'v-1', stage: 5, payload: { ...VERDICT }, verdict: VERDICT, logger: { log: () => {}, warn: () => {} } });
+    expect(res.updated).toBe(false);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('VERDICT_FIELDS is exactly the four derived verdict fields (never inputs)', () => {
+    expect([...VERDICT_FIELDS].sort()).toEqual(['blockProgression', 'decision', 'reasons', 'remediationRoute']);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the S5-financials drift seam. `reEvaluateOnly` recomputes the S5 kill-gate verdict into `stageOutput` (which flows to the chairman mint) but never re-persisted it onto the `truth_financial_model` artifact — so later artifact readers (S17 strategy, kill-gate recompute) saw a **stale decision**. The contract carries INPUTS while the artifact carries computed OUTPUTS+verdict (different shapes), so single-source-READ isn't possible — this implements the SD's stated option (b): **lockstep-WRITE**.

## FRs
- **FR-1** — `lib/eva/s5-financial-consistency.js` `persistRecomputedVerdict()`: a **targeted in-place jsonb update** of only the four derived verdict fields (`decision/reasons/blockProgression/remediationRoute`) onto the current artifact — no LLM regen, no version bump, no `is_current` flip (DB sub-agent validated). Wired into the orchestrator's `reEvaluateOnly` recompute branch; writes only when the verdict differs. The one pure `recomputeKillGateVerdict` drives persist + checker so they can't diverge.
- **FR-3** — `scripts/s5-financial-consistency.mjs` (dry-run) reports any current-S5 artifact whose persisted verdict ≠ its deterministic recompute. `evaluateS5Consistency()` is a pure checker.
- **FR-4** — same script `--apply` backfills diverged ventures (lockstep repair, RLS/FK-safe, service-role).
- **FR-5** — 10 unit tests; killgate/flagship/watcher regression **33/33** green.

## NOTE (deliberate scoping)
The dry-run found **1 diverged venture (venture-1: persisted `'pass'` vs recomputed `'conditional_pass'`)**. Per the SD's own note, the immediate run#2 reconcile (which set is canonical for the flagship dogfood venture) is a **separate chairman merit decision (emailed)** — so the `--apply` backfill is intentionally **not run here**; the mechanism is ready for when that decision lands. This SD prevents the divergence **going forward** (FR-1) and makes it **detectable** (FR-3).

Backend EVA only; no UI, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)