### PR TITLE
fix(SD-LEO-INFRA-RUN-STAGE-CANONICAL-ARTIFACT-TYPE-001): canonical artifact_type at the legacy persist path

### DIFF
--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -8,6 +8,7 @@
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
 import { writeArtifact, writeArtifactBatch } from './artifact-persistence-service.js';
+import { ARTIFACT_TYPE_BY_STAGE } from './artifact-types.js';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -381,13 +382,22 @@ export async function persistArtifact(supabase, ventureId, stageNumber, artifact
     return ids[0];
   }
 
-  // Legacy single-artifact path — preserved unchanged for stages that don't
-  // emit a typed-array contract.
+  // Legacy single-artifact path — for stages whose producer returns a single object (not the
+  // typed-array contract). SD-LEO-INFRA-RUN-STAGE-CANONICAL-ARTIFACT-TYPE-001: resolve the CANONICAL
+  // artifact_type from the registry (ARTIFACT_TYPE_BY_STAGE[stage][0]) so e.g. an S8 business-model
+  // canvas persists as 'engine_business_model_canvas' (readable by the UI/downstream) instead of the
+  // non-canonical 'stage_8_analysis'. Fall back to the generic type ONLY when the registry has no
+  // entry for the stage (logged, since that is the exception, not the default).
+  const canonicalArtifactType = ARTIFACT_TYPE_BY_STAGE[stageNumber]?.[0];
+  const resolvedArtifactType = canonicalArtifactType || `stage_${stageNumber}_analysis`;
+  if (!canonicalArtifactType) {
+    console.warn(`[stage-execution-engine] No canonical artifact_type registered for stage ${stageNumber}; falling back to generic '${resolvedArtifactType}'`);
+  }
   const artifactId = await writeArtifact(supabase, {
     ventureId,
     lifecycleStage: stageNumber,
-    artifactType: `stage_${stageNumber}_analysis`,
-    title: `Stage ${stageNumber} Analysis`,
+    artifactType: resolvedArtifactType,
+    title: canonicalArtifactType ? `Stage ${stageNumber} ${resolvedArtifactType}` : `Stage ${stageNumber} Analysis`,
     artifactData: typeof artifactData === 'object' ? artifactData : null,
     content: typeof artifactData === 'string' ? artifactData : null,
     source: 'stage-execution-engine',
@@ -407,7 +417,7 @@ export async function persistArtifact(supabase, ventureId, stageNumber, artifact
       event_data: {
         stage_number: stageNumber,
         artifact_id: data.id,
-        artifact_type: `stage_${stageNumber}_analysis`,
+        artifact_type: resolvedArtifactType,
       },
       chairman_flagged: false,
     });

--- a/tests/unit/eva/stage-execution-engine-persist-artifact.test.js
+++ b/tests/unit/eva/stage-execution-engine-persist-artifact.test.js
@@ -124,8 +124,10 @@ describe('FR-001/FR-004: persistArtifact typed-array detection branch', () => {
 
     const [, opts] = writeArtifact.mock.calls[0];
     expect(opts.lifecycleStage).toBe(7);
-    expect(opts.artifactType).toBe('stage_7_analysis');
-    expect(opts.title).toBe('Stage 7 Analysis');
+    // SD-LEO-INFRA-RUN-STAGE-CANONICAL-ARTIFACT-TYPE-001: stage 7 has a registry entry, so the
+    // legacy single-artifact path now resolves the CANONICAL type (was the non-canonical 'stage_7_analysis').
+    expect(opts.artifactType).toBe('engine_pricing_model');
+    expect(opts.title).toBe('Stage 7 engine_pricing_model');
 
     expect(id).toBe('legacy-artifact-id');
 
@@ -215,6 +217,34 @@ describe('FR-001/FR-004: persistArtifact typed-array detection branch', () => {
     expect(events).toHaveLength(1);
     expect(events[0].event_type).toBe('stage_analysis_completed');
     expect(events[0].event_data.stage_number).toBe(5);
-    expect(events[0].event_data.artifact_type).toBe('stage_5_analysis');
+    // SD-LEO-INFRA-RUN-STAGE-CANONICAL-ARTIFACT-TYPE-001: event_type follows the resolved canonical
+    // type (stage 5 -> truth_financial_model), not the non-canonical stage_5_analysis.
+    expect(events[0].event_data.artifact_type).toBe('truth_financial_model');
+  });
+
+  // SD-LEO-INFRA-RUN-STAGE-CANONICAL-ARTIFACT-TYPE-001 FR-1/FR-3
+  it('FR-1: single-object stage persists under the CANONICAL registry type (S8 -> engine_business_model_canvas)', async () => {
+    writeArtifact.mockResolvedValue('s8-id');
+    const supabase = createMockSupabase();
+    await persistArtifact(supabase, 'v1', 8, { canvas: { segments: [] } }, {}); // single object, no .artifacts
+
+    const [, opts] = writeArtifact.mock.calls[0];
+    expect(opts.artifactType).toBe('engine_business_model_canvas');
+    expect(opts.title).toBe('Stage 8 engine_business_model_canvas');
+    const ev = supabase._insertedEvents.find((e) => e.event_type === 'stage_analysis_completed');
+    expect(ev.event_data.artifact_type).toBe('engine_business_model_canvas');
+  });
+
+  it('FR-2: an unregistered stage falls back to the generic type and warns', async () => {
+    writeArtifact.mockResolvedValue('generic-id');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const supabase = createMockSupabase();
+    await persistArtifact(supabase, 'v1', 99, { foo: 'bar' }, {}); // no registry entry for stage 99
+
+    const [, opts] = writeArtifact.mock.calls[0];
+    expect(opts.artifactType).toBe('stage_99_analysis');
+    expect(opts.title).toBe('Stage 99 Analysis');
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/No canonical artifact_type registered for stage 99/));
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
The legacy single-artifact persist path in `stage-execution-engine.js` hardcoded `artifact_type='stage_${N}_analysis'` for any single-object-returning producer (e.g. S8 business-model canvas), so those artifacts landed under a **non-canonical** type the UI/downstream don't read. Fixed at the **persist layer** (covers all single-object stages at once).

## FRs
- **FR-1** — resolve `canonicalArtifactType = ARTIFACT_TYPE_BY_STAGE[stage][0]` (`artifact-types.js`) for the `writeArtifact` artifactType + title and the `eva_orchestration_events` event_type (S8 → `engine_business_model_canvas`, S7 → `engine_pricing_model`, S5 → `truth_financial_model`).
- **FR-2** — generic `stage_${N}_analysis` fallback **only** when the stage is unregistered, with a `console.warn` (the exception, not the default).
- **FR-3** — tests: S8 single-object → canonical type + event_type; unregistered stage 99 → fallback + warn; flipped the 2 pre-existing assertions that codified the non-canonical types. Typed-array batch path unchanged. **9/9 green**.

Backend EVA only; no UI, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)