### PR TITLE
feat(SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001): belt-depth reporting == claim-eligibility SSOT

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -43,7 +43,7 @@ import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispa
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
 // SD-REFILL-00MFWEGZ: reuse the canonical parent-LEAD-pass dispatch gate so the ranking surface
 // mirrors what claim-eligibility actually blocks (no drift between rank-vs-claim).
-import { parentLeadPending } from '../lib/fleet/claim-eligibility.cjs';
+import { parentLeadPending, classifyDispatchIneligibility } from '../lib/fleet/claim-eligibility.cjs';
 // SD-REFILL-00AH2L4Q: honor the SAME canonical metadata blocker key (metadata.blocked_by_sd_key)
 // that dependency-resolver + worker-checkin enforce, so the dispatch ranker does not keep a
 // metadata-blocked SD on the claimable belt (the convention was inconsistently enforced fleet-wide).
@@ -56,6 +56,29 @@ export function blockerKeysFor(d) {
   const { blockerSdKey } = checkMetadataDependency(d.metadata);
   if (blockerSdKey) keys.push(blockerSdKey);
   return keys;
+}
+
+/**
+ * SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the DB-FREE claimable gate for the ranker,
+ * composed so the ranked belt matches the actually-claimable set the worker resolver enforces. Returns
+ * null when the SD passes every DB-free claimable axis, or a reason string when it must be excluded:
+ *   - 'claimed'  — a live session already holds it (claiming_session_id set)
+ *   - 'in_flight' — started/mid-build past LEAD draft (resumed via resume_orphan, never fresh-ranked)
+ *   - 'fixture'  — backlog-rank's BROADER fixture detection (epoch TEST-E2E keys / metadata.is_fixture)
+ *   - else the SHARED claim-eligibility reason: 'orchestrator_parent' | 'human_action_required' |
+ *     'co_author_pending' | 'sd_deferred' | 'sd_terminal' | 'test_fixture_key'.
+ * The shared predicate (classifyDispatchIneligibility) is the SSOT — re-implementing it is exactly how
+ * the requires_human_action skip drifted out of the ranker. Pure; the DB-backed axes (dependency/metadata
+ * blockers, parent-LEAD-pending) remain in the async claim loop. Exported for unit testing.
+ * @param {object} d - an SD row (sd_key, sd_type, status, current_phase, claiming_session_id, metadata)
+ * @returns {null|string}
+ */
+export function claimableDbFreeReason(d) {
+  if (!d) return 'missing';
+  if (d.claiming_session_id) return 'claimed';
+  if (isStartedSd(d)) return 'in_flight';
+  if (isFixtureSd(d.sd_key, d.metadata)) return 'fixture';
+  return classifyDispatchIneligibility(d); // null => eligible on the DB-free axes
 }
 // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-1): the narrow, explicit fleet-critical predicate.
 // metadata.fleet_critical===true marks work whose ABSENCE blocks ALL fleet progress. Exported pure so
@@ -139,33 +162,41 @@ async function main() {
   let fixtureSkips = 0;
   let inFlightSkips = 0;
   let awaitingConvergenceSkips = 0;
+  let humanActionSkips = 0;
+  let ineligibleSkips = 0;
   for (const d of (sds || [])) {
-    if (d.claiming_session_id) continue;
-    if (d.sd_type === 'orchestrator') continue;          // parents are never dispatched
-    // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001 (bug d5e59236): a started/mid-build SD past the
-    // initial LEAD draft (current_phase != 'LEAD') must NOT be ranked for FRESH dispatch even
-    // when momentarily unclaimed (e.g. reaped mid-build) — it is resumed via worker-checkin's
-    // resume_orphan path, not re-claimed from the backlog. Mirrors isSdInFlight's (a) branch.
-    if (isStartedSd(d)) {                                 // in-flight SD is resumed, never fresh-ranked
-      inFlightSkips++;
-      console.log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
-      continue;
-    }
-    // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: fixtures (epoch-stamped TEST-E2E keys or
-    // metadata.is_fixture) are never ranked — they get no dispatch_rank at all.
-    if (isFixtureSd(d.sd_key, d.metadata)) {             // test fixtures are never ranked
-      fixtureSkips++;
-      console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
-      continue;
-    }
-    // SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001: a co-authored SD awaiting convergence is
-    // NON-CLAIMABLE (it would let a parked worker write the PRD before the co-author input lands).
-    // Surface it as AWAITING-CONVERGENCE — explicitly NOT idle-belt depth, so the capacity forecaster
-    // does not read it as claimable. Mirrors classifyDispatchIneligibility's co_author_pending gate so
-    // the ranked belt matches the actually-claimable set. Flips to claimable when co_author_pending=false.
-    if ((d.metadata || {}).co_author_pending === true) {
-      awaitingConvergenceSkips++;
-      console.log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
+    // SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the DB-free claimable axes (claimed /
+    // in-flight / fixture / the SHARED claim-eligibility predicate) are computed by one pure helper so
+    // the ranked belt matches the actually-claimable set the worker resolver enforces. The shared
+    // predicate (classifyDispatchIneligibility) closes the drift that was missing the requires_human_action
+    // skip — RHA-held SDs were leaking onto 'claimable', inflating belt depth and masking genuine
+    // starvation behind a deliberate all-held state.
+    const dbFreeSkip = claimableDbFreeReason(d);
+    if (dbFreeSkip) {
+      switch (dbFreeSkip) {
+        case 'claimed': break;                              // claimed by a live session — silent (not a skip-log)
+        case 'in_flight':
+          inFlightSkips++;
+          console.log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
+          break;
+        case 'fixture':
+          fixtureSkips++;
+          console.log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
+          break;
+        case 'co_author_pending':
+          // NOT idle-belt depth: a co-authored SD awaiting convergence would let a parked worker write
+          // the PRD before the co-author input lands (SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001).
+          awaitingConvergenceSkips++;
+          console.log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
+          break;
+        case 'human_action_required':
+          humanActionSkips++;
+          console.log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key}`);
+          break;
+        default:
+          ineligibleSkips++;
+          console.log(`  [skip] dispatch-ineligible (${dbFreeSkip}): ${d.sd_key}`);
+      }
       continue;
     }
     // SD-REFILL-00AH2L4Q: include metadata.blocked_by_sd_key (via blockerKeysFor) so a metadata-blocked
@@ -187,6 +218,8 @@ async function main() {
   if (fixtureSkips) console.log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
   if (inFlightSkips) console.log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
   if (awaitingConvergenceSkips) console.log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
+  if (humanActionSkips) console.log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
+  if (ineligibleSkips) console.log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
   // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs (empty/title-only description)
   // cannot pass LEAD-TO-PLAN; log them so the demote-to-last below is auditable. The sort
   // below (bareShellLastCompare as the dominant key) is what actually places them last.

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -32,6 +32,11 @@ import { dirname, join } from 'path';
 // fixtures AND bare-shell stubs (neither can pass LEAD-TO-PLAN) never inflate belt depth —
 // counting them as claimable over-reports capacity and suppresses the deficit/Adam alert.
 import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
+// SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the forecaster builds its OWN claimable
+// belt (it does not read the ranker's dispatch_rank), so it must apply the SAME shared claim-eligibility
+// predicate the worker resolver uses — else RHA-held / co_author_pending SDs inflate belt depth and the
+// forecaster emits false belt-low DEFICITs (the exact masked-starvation symptom this SD targets).
+import { classifyDispatchIneligibility } from '../lib/fleet/claim-eligibility.cjs';
 // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: the pure live-worker predicate. It wraps the
 // canonical isDispatchableFleetMember SSOT the dashboard uses (so the forecaster AGREES with
 // fleet-dashboard.cjs on coordinator/adam/non_fleet/fixture exclusion) and ADDS a released-status
@@ -239,20 +244,32 @@ async function main() {
   const claimable = [];
   const claimsBySession = {};
   let beltExcludes = 0;
+  let ineligibleExcludes = 0;
   for (const d of (sds || [])) {
     if (d.claiming_session_id) {
       (claimsBySession[d.claiming_session_id] ||= []).push(d);
       continue;
     }
-    if (d.sd_type === 'orchestrator') continue; // parents auto-complete; never dispatch
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: fixtures and bare-shell stubs are not real
     // belt — neither can pass LEAD-TO-PLAN. Excluding them keeps beltDepth honest so a
     // forecast deficit (and the proactive Adam reach-out) is not masked by non-distributable rows.
     if (isExcludedFromBelt(d)) { beltExcludes++; continue; }
+    // SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: apply the SHARED claim-eligibility
+    // predicate (the SSOT the worker resolver uses) so belt depth == actually-claimable depth. Catches
+    // orchestrator_parent, human_action_required (the previously-missing axis), co_author_pending,
+    // sd_deferred, sd_terminal, test_fixture_key. Without this the forecaster over-counted RHA-held +
+    // co-author-pending SDs and fired false belt-low DEFICITs that masked genuine starvation.
+    const ineligible = classifyDispatchIneligibility(d);
+    if (ineligible) {
+      ineligibleExcludes++;
+      console.log(`  [belt-skip] ${ineligible} (not worker-claimable): ${d.sd_key}`);
+      continue;
+    }
     const unmet = parseSdDependencies(d.dependencies).filter(k => depStatus[k] !== 'completed');
     if (unmet.length === 0) claimable.push(d);
   }
   if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell/un-actionable-venture-remediation) excluded from belt depth`);
+  if (ineligibleExcludes) console.log(`[CAPACITY-FORECAST] ${ineligibleExcludes} dispatch-ineligible SD(s) (human-action/orchestrator/co-author-pending/deferred/terminal) excluded from belt depth (claim-eligibility SSOT)`);
 
   // ── classify live workers (exclude coordinator + adam + non_fleet + fixtures + released) ──
   // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: use the canonical isDispatchableFleetMember

--- a/tests/unit/coordinator-backlog-rank-claimable-eligibility.test.js
+++ b/tests/unit/coordinator-backlog-rank-claimable-eligibility.test.js
@@ -1,0 +1,71 @@
+/**
+ * SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001
+ *
+ * The ranker's 'claimable' depth must match the actually-claimable set the worker resolver enforces.
+ * Before this fix, coordinator-backlog-rank.mjs re-implemented a LOOSER filter that was MISSING the
+ * requires_human_action skip — so RHA-held SDs (and, defensively, deferred/terminal) leaked onto
+ * 'claimable', inflating belt depth and masking genuine starvation behind a deliberate all-held state.
+ * The fix routes the DB-free axes through the SHARED claim-eligibility predicate
+ * (classifyDispatchIneligibility) via the pure exported helper claimableDbFreeReason().
+ *
+ * Importing the module must NOT run the DB-touching backlog pass (entrypoint guard).
+ */
+import { describe, it, expect } from 'vitest';
+import { claimableDbFreeReason } from '../../scripts/coordinator-backlog-rank.mjs';
+import { classifyDispatchIneligibility } from '../../lib/fleet/claim-eligibility.cjs';
+
+const cleanLeaf = (sd_key) => ({
+  sd_key, sd_type: 'infrastructure', status: 'draft', current_phase: 'LEAD',
+  claiming_session_id: null, metadata: {},
+});
+
+describe('claimableDbFreeReason — ranker claimable depth == worker claim-eligibility', () => {
+  it('a genuinely-claimable draft leaf IS claimable (reason null)', () => {
+    expect(claimableDbFreeReason(cleanLeaf('SD-LEO-INFRA-CLEAN-001'))).toBeNull();
+  });
+
+  it('THE FIX: requires_human_action=true is NOT claimable (was the leaking axis)', () => {
+    const d = { ...cleanLeaf('SD-EHG-VENTURE1-X'), metadata: { requires_human_action: true } };
+    expect(claimableDbFreeReason(d)).toBe('human_action_required');
+  });
+
+  it('co_author_pending=true is NOT claimable (awaiting convergence)', () => {
+    const d = { ...cleanLeaf('SD-LEO-INFRA-CO-001'), metadata: { co_author_pending: true } };
+    expect(claimableDbFreeReason(d)).toBe('co_author_pending');
+  });
+
+  it('an orchestrator parent is NOT claimable', () => {
+    const d = { ...cleanLeaf('SD-EHG-PRODUCT-UIUX-REMEDIATION-001'), sd_type: 'orchestrator' };
+    expect(claimableDbFreeReason(d)).toBe('orchestrator_parent');
+  });
+
+  it('a claimed SD (live session) is excluded', () => {
+    const d = { ...cleanLeaf('SD-X'), claiming_session_id: 'sess-123' };
+    expect(claimableDbFreeReason(d)).toBe('claimed');
+  });
+
+  it('an in-flight SD (started past LEAD draft) is excluded from FRESH ranking', () => {
+    const d = { ...cleanLeaf('SD-Y'), current_phase: 'EXEC' };
+    expect(claimableDbFreeReason(d)).toBe('in_flight');
+  });
+
+  it('belt depth == claim-eligibility-claimable depth (parity over a mixed set)', () => {
+    const rows = [
+      cleanLeaf('SD-CLEAN-A'),                                                              // claimable
+      cleanLeaf('SD-CLEAN-B'),                                                              // claimable
+      { ...cleanLeaf('SD-RHA'), metadata: { requires_human_action: true } },               // NOT
+      { ...cleanLeaf('SD-CO'), metadata: { co_author_pending: true } },                    // NOT
+      { ...cleanLeaf('SD-ORCH'), sd_type: 'orchestrator' },                                // NOT
+    ];
+    // Ranker's DB-free claimable set:
+    const rankerClaimable = rows.filter((d) => claimableDbFreeReason(d) === null).map((d) => d.sd_key);
+    // The worker resolver's DB-free eligibility over the SAME unclaimed/non-in-flight rows:
+    const resolverClaimable = rows.filter((d) => classifyDispatchIneligibility(d) === null).map((d) => d.sd_key);
+    expect(rankerClaimable).toEqual(['SD-CLEAN-A', 'SD-CLEAN-B']);
+    expect(rankerClaimable).toEqual(resolverClaimable); // depths agree — no over-count
+  });
+
+  it('module imported without running the DB pass (entrypoint guard)', () => {
+    expect(typeof claimableDbFreeReason).toBe('function');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001 — belt-depth reporting == claim-eligibility SSOT

Coordinator belt-depth reporting computed `'claimable'` with a **looser** predicate than the authoritative worker claim-eligibility resolver (`lib/fleet/claim-eligibility.cjs` `classifyDispatchIneligibility`), **missing the `requires_human_action` skip**. So RHA-held SDs (and, defensively, deferred/terminal) leaked onto `'claimable'` — inflating belt depth and **masking genuine starvation behind a deliberate all-held state**. Live evidence: a worker saw ~15 idle ticks where the belt reported 4–7 claimable while the resolver had nothing claimable.

### FR-1 — ranker (`coordinator-backlog-rank.mjs`)
Import `classifyDispatchIneligibility`; route the DB-free claimable axes through a new **pure exported** `claimableDbFreeReason(d)` = `claimed → in_flight → fixture(broader) → classifyDispatchIneligibility(d)`. The shared predicate is the SSOT — re-implementing it is exactly how the drift arose. DB-backed axes (blockers, parent-LEAD-pending) stay in the async loop. **Verified live** via `--dry-run`: `VENTURE1-MARKET-MODELING` + `FINANCIAL-TIER2` (RHA) + `PRODUCT-UIUX-REMEDIATION` (orchestrator) now excluded → **0 claimable**, matching the worker resolver.

### FR-2 — capacity forecaster (`coordinator-capacity-forecast.mjs`)
LEAD validation found the forecaster does **not** read the ranker output — it builds its **own** claimable belt and also omitted `requires_human_action` + `co_author_pending`, making **it** the actual source of the false belt-low DEFICITs. Apply the same shared-predicate guard to its loop so belt depth == worker-claimable depth. (`fleet-dashboard.cjs` is a liveness surface, not a claimable-count consumer — no change.)

### FR-3 — tests
`tests/unit/coordinator-backlog-rank-claimable-eligibility.test.js`: rha/co_author/orchestrator/claimed/in-flight exclusions + a **belt-depth parity** assertion (`claimableDbFreeReason===null` set == `classifyDispatchIneligibility===null` set). Validated via a node harness (8/8) + the live `--dry-run`. **CI runs the real vitest from `main`** (vitest excludes `**/.worktrees/**`).

No migration, no UI. Co-authored with the coordinator (it owns the forecaster and felt the drift). Provenance: this fix originated from a worker's candid feedback to the coordinator's every-8-SDs review — a closed worker→coordinator→Adam→SD→worker loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
