### PR TITLE
feat(SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001): run-stage writes venture_stage_work at daemon-parity (shared helper)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S7-FINANCIAL-MODELS-STALE-READ-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S7-FINANCIAL-MODELS-STALE-READ-001",
-  "createdAt": "2026-06-28T18:14:37.108Z",
+  "sdKey": "SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001",
+  "createdAt": "2026-06-28T19:33:35.244Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -9,6 +9,9 @@
 import { createSupabaseServiceClient } from '../supabase-client.js';
 import { writeArtifact, writeArtifactBatch } from './artifact-persistence-service.js';
 import { ARTIFACT_TYPE_BY_STAGE } from './artifact-types.js';
+// SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: daemon-parity venture_stage_work
+// write-through, shared with stage-execution-worker (the daemon parity reference).
+import { syncStageWork } from './stage-work-sync.js';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -629,6 +632,38 @@ export async function executeStage(options = {}) {
     }
     artifactId = await persistArtifact(supabase, ventureId, stageNumber, output, evaKeys);
     logger.log(`   Artifact persisted: ${artifactId}`);
+
+    // SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: daemon-parity persist. The
+    // daemon (stage-execution-worker) writes BOTH venture_artifacts AND the
+    // venture_stage_work row + advisory_data on completion; executeStage only
+    // wrote venture_artifacts, so the frontend (which reads advisory_data from
+    // venture_stage_work) showed nothing for run-stage-produced stages. Build the
+    // same { artifacts:[{artifactType,payload}] } shape the daemon passes and call
+    // the SHARED syncStageWork. Non-blocking; the UPSERT on (venture_id,
+    // lifecycle_stage) is idempotent (no double-write).
+    try {
+      const stageArtifacts = (output && Array.isArray(output.artifacts) && output.artifacts.length > 0)
+        ? output.artifacts.map((a) => ({ artifactType: a.artifactType, payload: a.payload }))
+        : [{
+            artifactType: ARTIFACT_TYPE_BY_STAGE[stageNumber]?.[0] || `stage_${stageNumber}_analysis`,
+            payload: output,
+          }];
+      await syncStageWork(supabase, {
+        ventureId,
+        stageNumber,
+        logger,
+        result: {
+          status: 'COMPLETED',
+          artifacts: stageArtifacts,
+          startedAt: new Date(startTime).toISOString(),
+          // Mirror the daemon's gate handling: a gate stage stays 'blocked' unless
+          // the chairman gate was approved (auto-approved at L2+ above).
+          _gateApproved: output?.chairmanGate?.status === 'approved',
+        },
+      });
+    } catch (stageWorkErr) {
+      logger.warn(`   ⚠️ venture_stage_work sync failed (non-blocking): ${stageWorkErr.message}`);
+    }
   }
 
   // 6.5. Capability Contribution Score — non-blocking post-analysis hook

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -39,6 +39,10 @@ import { hostname } from 'os';
 import { createServer } from 'http';
 import { OPERATING_MODES } from './gate-constants.js';
 import { getStageGovernance } from './stage-governance.js';
+// SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: the venture_stage_work write-through
+// + hard-gate check were extracted to a shared module so run-stage/executeStage
+// produce the SAME stage-completion records as this daemon (single source of truth).
+import { syncStageWork as syncStageWorkShared, isInHardGateStages as isInHardGateStagesShared } from './stage-work-sync.js';
 import { shouldOpenChairmanGate, canAdvancePastBuildCheckpoint } from './should-open-chairman-gate.js';
 import { toValidTransitionType } from './transition-type.js';
 // SD-LEO-INFRA-HARDEN-S19-S20-001 (FR-1): the single pure bridge-outcome classifier + S19
@@ -4324,121 +4328,17 @@ export class StageExecutionWorker {
    * Used alongside stage-governance.isBlocking() (kill/promotion from stage_config).
    */
   async _isInHardGateStages(stageNumber) {
-    try {
-      const { data } = await this._supabase
-        .from('chairman_dashboard_config')
-        .select('hard_gate_stages')
-        .eq('config_key', 'default')
-        .maybeSingle();
-      return (data?.hard_gate_stages || []).includes(stageNumber);
-    } catch {
-      return false;
-    }
+    // SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: delegate to the shared helper
+    // (single source of truth shared with run-stage/executeStage).
+    return isInHardGateStagesShared(this._supabase, stageNumber);
   }
 
   async _syncStageWork(ventureId, stageNumber, result) {
-    if (!result) return;
-
-    // Merge artifact payloads into a single advisory_data object
-    const advisoryData = {};
-    if (result.artifacts && Array.isArray(result.artifacts)) {
-      // QF-20260521-812: studio-style stages (e.g. S18 Marketing Copy Studio) read
-      // advisory_data[section] for per-section content and advisory_data.completedSections/
-      // totalSections for the counter. The legacy flat Object.assign collapses multiple
-      // typed artifacts whose payloads share keys (marketing sections all carry
-      // persona_target/text/...), so only the last survived and the counter read 0/9.
-      // Fix is ADDITIVE: keep the flat merge (back-compat for stages that read merged
-      // fields), AND expose each artifact under its prefix-stripped section key plus a
-      // populated-count summary. No-op for single-artifact / non-object-payload stages.
-      let populatedCount = 0;
-      for (const artifact of result.artifacts) {
-        const payload = artifact.payload || {};
-        // Flatten each artifact's payload into advisory_data (legacy, unchanged)
-        if (typeof payload === 'object' && !Array.isArray(payload)) {
-          Object.assign(advisoryData, payload);
-          // Per-section key derived from artifactType (strip the leading stage prefix,
-          // e.g. marketing_tagline -> tagline, blueprint_data_model -> data_model).
-          const sectionKey = typeof artifact.artifactType === 'string'
-            ? artifact.artifactType.replace(/^[a-z0-9]+_/, '')
-            : '';
-          if (sectionKey && sectionKey !== artifact.artifactType) {
-            advisoryData[sectionKey] = payload;
-          }
-          if (Object.keys(payload).length > 0) populatedCount++;
-        }
-      }
-      if (result.artifacts.length > 0) {
-        if (advisoryData.totalSections === undefined) advisoryData.totalSections = result.artifacts.length;
-        if (advisoryData.completedSections === undefined) advisoryData.completedSections = populatedCount;
-      }
-    }
-
-    // Determine stage_status from result
-    const resultStatus = (result.status || '').toUpperCase();
-    let stageStatus;
-    if (resultStatus === 'COMPLETED') stageStatus = 'completed';
-    else if (resultStatus === 'BLOCKED') stageStatus = 'blocked';
-    else if (resultStatus === 'FAILED') stageStatus = 'blocked'; // DB constraint only allows: not_started, in_progress, blocked, completed, skipped
-    // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: a HELD (route-to-review) stage is awaiting a
-    // chairman decision — map to the CHECK-valid 'blocked', NOT the default 'in_progress' (which
-    // would let the worker treat the held stage as still running).
-    else if (resultStatus === 'HELD') stageStatus = 'blocked';
-    else stageStatus = 'in_progress';
-
-    // For chairman gate stages AND review-mode stages, mark as blocked (awaiting chairman approval)
-    // Skip override when gate was already auto-approved (Bug 1 fix: QF-20260320-509)
-    // SD-LEO-INFRA-VENTURE-GATE-UNIFICATION-001: gate-set membership sourced from stage-governance.
-    const govForGateCheck = await getStageGovernance(this._supabase);
-    const isGateStage = govForGateCheck.isBlocking(stageNumber) || govForGateCheck.isReview(stageNumber) || await this._isInHardGateStages(stageNumber);
-    if (isGateStage && stageStatus === 'completed' && !result._gateApproved) {
-      stageStatus = 'blocked';
-    }
-
-    // Fetch work_type from lifecycle_stage_config (required NOT NULL column)
-    let workType = 'artifact_only'; // fallback
-    try {
-      const { data: cfg } = await this._supabase
-        .from('venture_stages') /* SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: unified superset */
-        .select('work_type')
-        .eq('stage_number', stageNumber)
-        .single();
-      if (cfg?.work_type) workType = cfg.work_type;
-    } catch { /* use fallback */ }
-
-    const now = new Date().toISOString();
-    const updateData = {
-      stage_status: stageStatus,
-      work_type: workType,
-      advisory_data: Object.keys(advisoryData).length > 0 ? advisoryData : null,
-      started_at: result.startedAt || now,
-      updated_at: now,
-    };
-
-    // Set completed_at and health_score for stages that completed
-    if (stageStatus === 'completed') {
-      updateData.completed_at = now;
-      // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-A: compute health score at sync time
-      try {
-        const { computeHealthScore } = await import('./health-score-computer.js');
-        updateData.health_score = computeHealthScore(
-          Object.keys(advisoryData).length > 0 ? advisoryData : null
-        );
-      } catch (_) { /* non-fatal */ }
-    }
-
-    const { error } = await this._supabase
-      .from('venture_stage_work')
-      .upsert({
-        venture_id: ventureId,
-        lifecycle_stage: stageNumber,
-        ...updateData,
-      }, { onConflict: 'venture_id,lifecycle_stage' });
-
-    if (error) {
-      this._logger.warn(`[Worker] venture_stage_work upsert failed for stage ${stageNumber}: ${error.message}`);
-    } else {
-      this._logger.log(`[Worker] venture_stage_work synced for stage ${stageNumber} (status: ${stageStatus}, advisory_data: ${Object.keys(advisoryData).length} keys)`);
-    }
+    // SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: delegate to the shared
+    // write-through so the daemon and run-stage/executeStage produce identical
+    // venture_stage_work records (single source of truth). This method body was
+    // extracted verbatim into lib/eva/stage-work-sync.js — see syncStageWork.
+    return syncStageWorkShared(this._supabase, { ventureId, stageNumber, result, logger: this._logger });
   }
 
   /**

--- a/lib/eva/stage-work-sync.js
+++ b/lib/eva/stage-work-sync.js
@@ -1,0 +1,151 @@
+/**
+ * Shared venture_stage_work write-through (daemon-parity).
+ *
+ * SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: extracted verbatim from
+ * StageExecutionWorker._syncStageWork (the daemon completion-persist, which is
+ * the parity reference) so BOTH the daemon AND run-stage/executeStage write the
+ * SAME stage-completion records — a single source of truth. Re-implementing this
+ * is how the artifact_type drift arose; share the helper instead.
+ *
+ * On stage completion this upserts the venture_stage_work row with
+ * advisory_data (the producer's stage-display output) at daemon parity:
+ * stage_status, work_type, health_score, started_at/completed_at. Idempotent —
+ * UPSERT on (venture_id, lifecycle_stage), so a re-run overwrites rather than
+ * double-writes.
+ *
+ * @module lib/eva/stage-work-sync
+ */
+
+import { getStageGovernance } from './stage-governance.js';
+
+/**
+ * Whether a stage is in the DB-configured hard-gate set (chairman_dashboard_config).
+ * Fail-soft: any read error → false.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {number} stageNumber
+ * @returns {Promise<boolean>}
+ */
+export async function isInHardGateStages(supabase, stageNumber) {
+  try {
+    const { data } = await supabase
+      .from('chairman_dashboard_config')
+      .select('hard_gate_stages')
+      .eq('config_key', 'default')
+      .maybeSingle();
+    return (data?.hard_gate_stages || []).includes(stageNumber);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write-through to venture_stage_work so the UI can display results. The
+ * producer (processStage / executeStage) writes venture_artifacts but not
+ * venture_stage_work, while the frontend reads advisory_data from
+ * venture_stage_work.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} args
+ * @param {string} args.ventureId
+ * @param {number} args.stageNumber
+ * @param {Object} args.result — { artifacts: [{artifactType, payload}], status, startedAt, _gateApproved }
+ * @param {{ log: Function, warn: Function }} [args.logger=console]
+ */
+export async function syncStageWork(supabase, { ventureId, stageNumber, result, logger = console }) {
+  if (!result) return;
+
+  // Merge artifact payloads into a single advisory_data object
+  const advisoryData = {};
+  if (result.artifacts && Array.isArray(result.artifacts)) {
+    // QF-20260521-812: studio-style stages (e.g. S18 Marketing Copy Studio) read
+    // advisory_data[section] for per-section content and advisory_data.completedSections/
+    // totalSections for the counter. The legacy flat Object.assign collapses multiple
+    // typed artifacts whose payloads share keys, so only the last survived and the
+    // counter read 0/9. Fix is ADDITIVE: keep the flat merge (back-compat), AND expose
+    // each artifact under its prefix-stripped section key plus a populated-count summary.
+    let populatedCount = 0;
+    for (const artifact of result.artifacts) {
+      const payload = artifact.payload || {};
+      if (typeof payload === 'object' && !Array.isArray(payload)) {
+        Object.assign(advisoryData, payload);
+        const sectionKey = typeof artifact.artifactType === 'string'
+          ? artifact.artifactType.replace(/^[a-z0-9]+_/, '')
+          : '';
+        if (sectionKey && sectionKey !== artifact.artifactType) {
+          advisoryData[sectionKey] = payload;
+        }
+        if (Object.keys(payload).length > 0) populatedCount++;
+      }
+    }
+    if (result.artifacts.length > 0) {
+      if (advisoryData.totalSections === undefined) advisoryData.totalSections = result.artifacts.length;
+      if (advisoryData.completedSections === undefined) advisoryData.completedSections = populatedCount;
+    }
+  }
+
+  // Determine stage_status from result
+  const resultStatus = (result.status || '').toUpperCase();
+  let stageStatus;
+  if (resultStatus === 'COMPLETED') stageStatus = 'completed';
+  else if (resultStatus === 'BLOCKED') stageStatus = 'blocked';
+  else if (resultStatus === 'FAILED') stageStatus = 'blocked'; // DB constraint: not_started, in_progress, blocked, completed, skipped
+  // SD-LEO-INFRA-KILLGATE-ROUTE-TO-REVIEW-HOLD-001: a HELD (route-to-review) stage maps to 'blocked'.
+  else if (resultStatus === 'HELD') stageStatus = 'blocked';
+  else stageStatus = 'in_progress';
+
+  // For chairman gate stages AND review-mode stages, mark as blocked (awaiting chairman approval),
+  // unless the gate was already auto-approved.
+  const govForGateCheck = await getStageGovernance(supabase);
+  const isGateStage = govForGateCheck.isBlocking(stageNumber) || govForGateCheck.isReview(stageNumber) || await isInHardGateStages(supabase, stageNumber);
+  if (isGateStage && stageStatus === 'completed' && !result._gateApproved) {
+    stageStatus = 'blocked';
+  }
+
+  // Fetch work_type from venture_stages (required NOT NULL column)
+  let workType = 'artifact_only'; // fallback
+  try {
+    const { data: cfg } = await supabase
+      .from('venture_stages') /* SD-LEO-INFRA-UNIFY-VENTURE-STAGE-001-B: unified superset */
+      .select('work_type')
+      .eq('stage_number', stageNumber)
+      .single();
+    if (cfg?.work_type) workType = cfg.work_type;
+  } catch { /* use fallback */ }
+
+  const now = new Date().toISOString();
+  const updateData = {
+    stage_status: stageStatus,
+    work_type: workType,
+    advisory_data: Object.keys(advisoryData).length > 0 ? advisoryData : null,
+    started_at: result.startedAt || now,
+    updated_at: now,
+  };
+
+  // Set completed_at and health_score for stages that completed
+  if (stageStatus === 'completed') {
+    updateData.completed_at = now;
+    // SD-MAN-FIX-PIPELINE-HEALTH-GAPS-ORCH-001-A: compute health score at sync time
+    try {
+      const { computeHealthScore } = await import('./health-score-computer.js');
+      updateData.health_score = computeHealthScore(
+        Object.keys(advisoryData).length > 0 ? advisoryData : null,
+      );
+    } catch (_) { /* non-fatal */ }
+  }
+
+  const { error } = await supabase
+    .from('venture_stage_work')
+    .upsert({
+      venture_id: ventureId,
+      lifecycle_stage: stageNumber,
+      ...updateData,
+    }, { onConflict: 'venture_id,lifecycle_stage' });
+
+  if (error) {
+    logger.warn(`[stage-work-sync] venture_stage_work upsert failed for stage ${stageNumber}: ${error.message}`);
+  } else {
+    logger.log(`[stage-work-sync] venture_stage_work synced for stage ${stageNumber} (status: ${stageStatus}, advisory_data: ${Object.keys(advisoryData).length} keys)`);
+  }
+}
+
+export default { syncStageWork, isInHardGateStages };

--- a/tests/unit/eva/stage-work-sync.test.js
+++ b/tests/unit/eva/stage-work-sync.test.js
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the shared venture_stage_work write-through.
+ *
+ * SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001: this helper was extracted from
+ * StageExecutionWorker._syncStageWork so the daemon AND run-stage/executeStage
+ * produce identical venture_stage_work records. These tests pin the contract:
+ * upserts the row with merged advisory_data, computes stage_status (incl. the
+ * gate override), and is keyed by (venture_id, lifecycle_stage).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Non-gate governance by default (overridden per-test).
+const gov = { isBlocking: vi.fn(() => false), isReview: vi.fn(() => false) };
+vi.mock('../../../lib/eva/stage-governance.js', () => ({
+  getStageGovernance: vi.fn(async () => gov),
+}));
+vi.mock('../../../lib/eva/health-score-computer.js', () => ({
+  computeHealthScore: vi.fn(() => 80),
+}));
+
+import { syncStageWork, isInHardGateStages } from '../../../lib/eva/stage-work-sync.js';
+
+function makeSupabase({ hardGateStages = [], workType = 'artifact_only', captureUpsert } = {}) {
+  return {
+    from: vi.fn((table) => {
+      if (table === 'chairman_dashboard_config') {
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { hard_gate_stages: hardGateStages } }) }) }) };
+      }
+      if (table === 'venture_stages') {
+        return { select: () => ({ eq: () => ({ single: async () => ({ data: { work_type: workType } }) }) }) };
+      }
+      if (table === 'venture_stage_work') {
+        return { upsert: (payload, opts) => { captureUpsert?.(payload, opts); return Promise.resolve({ error: null }); } };
+      }
+      return {};
+    }),
+  };
+}
+
+describe('syncStageWork (SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001)', () => {
+  beforeEach(() => {
+    gov.isBlocking.mockReturnValue(false);
+    gov.isReview.mockReturnValue(false);
+  });
+
+  it('upserts venture_stage_work with merged advisory_data + completed status for a non-gate stage', async () => {
+    let captured;
+    const supabase = makeSupabase({ captureUpsert: (p) => { captured = p; } });
+
+    await syncStageWork(supabase, {
+      ventureId: 'v1',
+      stageNumber: 2,
+      logger: { log() {}, warn() {} },
+      result: {
+        status: 'COMPLETED',
+        startedAt: '2026-06-28T00:00:00.000Z',
+        artifacts: [{ artifactType: 'truth_market', payload: { tam: 100, segment: 'smb' } }],
+      },
+    });
+
+    expect(captured.venture_id).toBe('v1');
+    expect(captured.lifecycle_stage).toBe(2);
+    expect(captured.stage_status).toBe('completed');
+    expect(captured.work_type).toBe('artifact_only');
+    // flat-merge + prefix-stripped section key ('truth_market' -> 'market')
+    expect(captured.advisory_data.tam).toBe(100);
+    expect(captured.advisory_data.market).toEqual({ tam: 100, segment: 'smb' });
+    expect(captured.advisory_data.totalSections).toBe(1);
+    expect(captured.completed_at).toBeTruthy();
+    expect(captured.health_score).toBe(80);
+  });
+
+  it('overrides to blocked for a gate stage that was NOT approved, and stays completed when approved', async () => {
+    gov.isReview.mockReturnValue(true); // make it a gate stage
+
+    let blockedPayload;
+    await syncStageWork(makeSupabase({ captureUpsert: (p) => { blockedPayload = p; } }), {
+      ventureId: 'v1', stageNumber: 13, logger: { log() {}, warn() {} },
+      result: { status: 'COMPLETED', artifacts: [{ artifactType: 'x_y', payload: { a: 1 } }] },
+    });
+    expect(blockedPayload.stage_status).toBe('blocked');
+
+    let approvedPayload;
+    await syncStageWork(makeSupabase({ captureUpsert: (p) => { approvedPayload = p; } }), {
+      ventureId: 'v1', stageNumber: 13, logger: { log() {}, warn() {} },
+      result: { status: 'COMPLETED', _gateApproved: true, artifacts: [{ artifactType: 'x_y', payload: { a: 1 } }] },
+    });
+    expect(approvedPayload.stage_status).toBe('completed');
+  });
+
+  it('isInHardGateStages reflects chairman_dashboard_config membership (fail-soft)', async () => {
+    expect(await isInHardGateStages(makeSupabase({ hardGateStages: [3, 5] }), 5)).toBe(true);
+    expect(await isInHardGateStages(makeSupabase({ hardGateStages: [3, 5] }), 7)).toBe(false);
+  });
+
+  it('no-ops on a null result', async () => {
+    let called = false;
+    await syncStageWork(makeSupabase({ captureUpsert: () => { called = true; } }), {
+      ventureId: 'v1', stageNumber: 2, logger: { log() {}, warn() {} }, result: null,
+    });
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001 — run-stage/executeStage writes `venture_stage_work` at daemon-parity

### Bug
On stage completion the **daemon** (`stage-execution-worker`) writes both `venture_artifacts` **and** the `venture_stage_work` row + `advisory_data`, but `executeStage` (the run-stage path) wrote **only** `venture_artifacts`. The frontend reads `advisory_data` from `venture_stage_work`, so run-stage-produced stages displayed nothing.

### Fix (backend-only, no schema)
- **Extracted** `StageExecutionWorker._syncStageWork` (the daemon parity reference) + `_isInHardGateStages` **verbatim** into a shared module `lib/eva/stage-work-sync.js` — single source of truth (re-implementing is how the prior artifact_type drift arose).
- **Daemon**: `_syncStageWork` / `_isInHardGateStages` are now thin wrappers over the shared helpers (behavior unchanged; all existing call sites preserved).
- **`executeStage`**: after `persistArtifact`, builds the same `{ artifacts:[{artifactType,payload}] }` shape the daemon passes and calls the shared `syncStageWork`. Mirrors the daemon's gate handling (`_gateApproved` from `output.chairmanGate`). Non-blocking; the UPSERT on `(venture_id, lifecycle_stage)` is idempotent.
- **Unit test** pins the contract (merged advisory_data + section keys, completed vs gate-blocked, hard-gate membership, null no-op).

### Verification
Live rolled-back DB harness: the shared helper writes the `venture_stage_work` row with correct `advisory_data`; gate-not-approved → `blocked`, gate-approved → `completed` (daemon parity). Unit test runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
