### PR TITLE
feat(SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001): manual path mints review chairman_decision at daemon-parity

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001",
-  "createdAt": "2026-06-28T19:33:35.244Z",
+  "sdKey": "SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001",
+  "createdAt": "2026-06-28T20:15:38.027Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/review-gate-mint.js
+++ b/lib/eva/review-gate-mint.js
@@ -1,0 +1,97 @@
+/**
+ * Review-gate mint — daemon-parity for the MANUAL stage-execution path.
+ *
+ * SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001
+ *
+ * The EVA stage-execution DAEMON (lib/eva/stage-execution-worker.js ~1129-1157) mints a
+ * pending review chairman_decision when it completes a review stage, so that
+ * fn_advance_venture_stage can only advance past the stage once the chairman approves it
+ * (otherwise it returns `review_gate_blocked`).
+ *
+ * The MANUAL path (scripts/eva/run-stage.js -> executeStage() in stage-execution-engine.js)
+ * did NOT mint that decision, so a manual advance past a review stage was permanently
+ * blocked. This helper closes the parity gap by reusing the SAME shared helper the daemon
+ * uses (createOrReusePendingDecision from chairman-decision-watcher.js) — never a
+ * hand-rolled INSERT — so the minted decision inherits the full daemon shape
+ * (resolveDecisionHealth's non-null health_score + recordForwardGateScore advisory).
+ *
+ * The review-stage set comes from the canonical source the daemon reads
+ * (getStageGovernance().isReview, backed by venture_stages.review_mode='review') — never a
+ * hardcoded [7,8,9,11]. The mint is idempotent (the shared helper reuses an existing pending
+ * decision), scoped (review stage + valid + non-dryRun), and FAIL-SOFT: any error is logged
+ * and swallowed — the mint is a parity side-effect, never the stage's product, so it MUST
+ * NEVER break the run. Deps are injectable for unit testing without a live DB.
+ */
+import { getStageGovernance as defaultGetStageGovernance } from './stage-governance.js';
+import { createOrReusePendingDecision as defaultCreateOrReusePendingDecision } from './chairman-decision-watcher.js';
+
+/**
+ * Mint (or reuse) the pending review chairman_decision for a just-completed stage, mirroring
+ * the daemon. Fail-soft — returns a `{minted, reason?}` result and never throws.
+ *
+ * @param {object} params
+ * @param {object} params.supabase           Supabase client (required to do anything).
+ * @param {string} params.ventureId          Venture id.
+ * @param {number} params.stageNumber         Stage that just completed.
+ * @param {boolean} params.validationValid    Whether the stage's validation passed.
+ * @param {boolean} params.dryRun             Dry-run runs never mint.
+ * @param {object} [params.logger=console]    Logger.
+ * @param {object} [deps]                     Injectable deps (getStageGovernance, createOrReusePendingDecision).
+ * @returns {Promise<{minted:boolean, decisionId?:string, isNew?:boolean, reason?:string, error?:string}>}
+ */
+export async function maybeMintReviewGate(
+  { supabase, ventureId, stageNumber, validationValid, dryRun, logger = console },
+  deps = {},
+) {
+  const getStageGovernance = deps.getStageGovernance || defaultGetStageGovernance;
+  const createOrReusePendingDecision = deps.createOrReusePendingDecision || defaultCreateOrReusePendingDecision;
+
+  // Scope: only a non-dryRun, valid completion with a live client is eligible.
+  if (dryRun) return { minted: false, reason: 'dry_run' };
+  if (!validationValid) return { minted: false, reason: 'invalid_validation' };
+  if (!supabase) return { minted: false, reason: 'no_supabase' };
+
+  // Canonical review-stage source (the same one the daemon reads).
+  let gov;
+  try {
+    gov = await getStageGovernance(supabase);
+  } catch (govErr) {
+    logger.warn?.(`[StageEngine] review-gate governance unavailable (non-fatal): ${govErr.message}`);
+    return { minted: false, reason: 'governance_unavailable', error: govErr.message };
+  }
+
+  // Mirror the daemon gate: review stage AND not a blocking (hard) gate.
+  const isReview = typeof gov?.isReview === 'function' && gov.isReview(stageNumber);
+  const isBlocking = typeof gov?.isBlocking === 'function' && gov.isBlocking(stageNumber);
+  if (!isReview || isBlocking) return { minted: false, reason: 'not_review_stage' };
+
+  // Best-effort venture name for the decision brief (parity with the daemon's briefData).
+  let ventureName = null;
+  try {
+    const { data } = await supabase.from('ventures').select('name').eq('id', ventureId).single();
+    ventureName = data?.name || null;
+  } catch {
+    // non-fatal — the brief just omits the name
+  }
+
+  try {
+    const res = await createOrReusePendingDecision({
+      ventureId,
+      stageNumber,
+      decisionType: 'review',
+      briefData: { stage: stageNumber, ventureName },
+      summary: `Review: Stage ${stageNumber} complete for ${ventureName || ventureId}`,
+      supabase,
+      logger,
+    });
+    logger.log?.(
+      `[StageEngine] review-gate decision ${res?.isNew ? 'minted' : 'reused'} (${res?.id}) for stage ${stageNumber}`,
+    );
+    return { minted: true, decisionId: res?.id, isNew: res?.isNew };
+  } catch (mintErr) {
+    logger.warn?.(`[StageEngine] review-gate mint failed (non-fatal): ${mintErr.message}`);
+    return { minted: false, reason: 'mint_error', error: mintErr.message };
+  }
+}
+
+export default { maybeMintReviewGate };

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -18,6 +18,7 @@ import { dirname, join } from 'path';
 import { stageRegistry } from './stage-registry.js';
 import { CROSS_STAGE_DEPS, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
 import { waitForDecision } from './chairman-decision-watcher.js';
+import { maybeMintReviewGate } from './review-gate-mint.js';
 import { checkAutonomy } from './autonomy-model.js';
 import { checkExitGates } from './lifecycle/exit-gate-enforcer.js';
 
@@ -713,6 +714,20 @@ export async function executeStage(options = {}) {
   // (no advanceStage RPC call). Stage 26 (Growth Playbook) is the first emitter.
   // SD-LEO-FEAT-STAGE-GROWTH-PLAYBOOK-001 FR-4 (orchestrator side).
   await processLifecycleTerminal({ supabase, ventureId, stageNumber, output, validation, dryRun, logger });
+
+  // 6.9. Review-gate mint (daemon-parity). When the manual path completes a review stage,
+  // mint the pending review chairman_decision via the SAME shared helper the daemon uses, so
+  // fn_advance_venture_stage can later advance once the chairman approves (else it returns
+  // review_gate_blocked). Fail-soft: a mint failure is logged and never breaks the run.
+  // SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001.
+  await maybeMintReviewGate({
+    supabase,
+    ventureId,
+    stageNumber,
+    validationValid: validation?.valid === true,
+    dryRun,
+    logger,
+  });
 
   // 7. SD-MAN-GEN-CORRECTIVE-VISION-GAP-013 (A04): Require artifact output for non-dry-run
   if (!dryRun && !artifactId) {

--- a/tests/unit/eva/review-gate-mint.test.js
+++ b/tests/unit/eva/review-gate-mint.test.js
@@ -1,0 +1,156 @@
+/**
+ * Tests for the manual-path review-gate mint (daemon-parity).
+ * SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001
+ *
+ * TS-1 review stage + valid + non-dryRun => mint with daemon-shape args
+ * TS-2 non-review stage => no mint
+ * TS-3 dryRun or invalid validation => no mint
+ * TS-4 blocking review stage => no mint (mirrors daemon !isBlocking)
+ * TS-5 mint/gov error is non-fatal
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { maybeMintReviewGate } from '../../../lib/eva/review-gate-mint.js';
+
+// A supabase double whose ventures lookup returns a name.
+function makeSupabase(ventureName = 'Acme Venture') {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { name: ventureName }, error: null }),
+        }),
+      }),
+    }),
+  };
+}
+
+const gov = (overrides = {}) => ({
+  isReview: (n) => (overrides.reviewStages || [7, 8, 9, 11]).includes(n),
+  isBlocking: (n) => (overrides.blockingStages || []).includes(n),
+});
+
+const baseParams = {
+  supabase: makeSupabase(),
+  ventureId: 'venture-1',
+  stageNumber: 7,
+  validationValid: true,
+  dryRun: false,
+  logger: { log: () => {}, warn: () => {} },
+};
+
+describe('maybeMintReviewGate', () => {
+  // ── TS-1 ───────────────────────────────────────────────────────────────────
+  it('mints at a review stage with the daemon-shape args', async () => {
+    const mint = vi.fn(async () => ({ id: 'dec-1', isNew: true }));
+    const r = await maybeMintReviewGate(baseParams, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+
+    expect(r.minted).toBe(true);
+    expect(r.decisionId).toBe('dec-1');
+    expect(r.isNew).toBe(true);
+    expect(mint).toHaveBeenCalledTimes(1);
+    const args = mint.mock.calls[0][0];
+    expect(args).toMatchObject({
+      ventureId: 'venture-1',
+      stageNumber: 7,
+      decisionType: 'review',
+      briefData: { stage: 7, ventureName: 'Acme Venture' },
+    });
+    expect(args.summary).toContain('Stage 7');
+    expect(args.supabase).toBeDefined();
+  });
+
+  it('reports reuse (isNew=false) without minting a duplicate', async () => {
+    const mint = vi.fn(async () => ({ id: 'dec-1', isNew: false }));
+    const r = await maybeMintReviewGate(baseParams, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(true);
+    expect(r.isNew).toBe(false);
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  // ── TS-2 ───────────────────────────────────────────────────────────────────
+  it('does NOT mint at a non-review stage', async () => {
+    const mint = vi.fn();
+    const r = await maybeMintReviewGate({ ...baseParams, stageNumber: 5 }, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('not_review_stage');
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  // ── TS-3 ───────────────────────────────────────────────────────────────────
+  it('does NOT mint on a dry run', async () => {
+    const mint = vi.fn();
+    const r = await maybeMintReviewGate({ ...baseParams, dryRun: true }, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('dry_run');
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it('does NOT mint when validation is invalid', async () => {
+    const mint = vi.fn();
+    const r = await maybeMintReviewGate({ ...baseParams, validationValid: false }, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('invalid_validation');
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  // ── TS-4 ───────────────────────────────────────────────────────────────────
+  it('does NOT mint at a blocking (hard-gate) review stage (mirrors daemon !isBlocking)', async () => {
+    const mint = vi.fn();
+    const r = await maybeMintReviewGate(baseParams, {
+      getStageGovernance: async () => gov({ blockingStages: [7] }),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('not_review_stage');
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  // ── TS-5 ───────────────────────────────────────────────────────────────────
+  it('is non-fatal when governance load throws', async () => {
+    const mint = vi.fn();
+    const r = await maybeMintReviewGate(baseParams, {
+      getStageGovernance: async () => { throw new Error('gov down'); },
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('governance_unavailable');
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it('is non-fatal when the mint helper throws', async () => {
+    const mint = vi.fn(async () => { throw new Error('insert failed'); });
+    const r = await maybeMintReviewGate(baseParams, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('mint_error');
+    expect(r.error).toContain('insert failed');
+  });
+
+  it('does NOT throw and skips when supabase is absent', async () => {
+    const mint = vi.fn();
+    const r = await maybeMintReviewGate({ ...baseParams, supabase: null }, {
+      getStageGovernance: async () => gov(),
+      createOrReusePendingDecision: mint,
+    });
+    expect(r.minted).toBe(false);
+    expect(r.reason).toBe('no_supabase');
+    expect(mint).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
The EVA stage-execution **daemon** mints a pending review `chairman_decision` when it completes a review stage, so `fn_advance_venture_stage` advances only after the chairman approves (else `review_gate_blocked`). The **manual** path (`scripts/eva/run-stage.js` -> `executeStage` in `lib/eva/stage-execution-engine.js`) did **not** mint it, so a manual advance past a review stage was permanently blocked — broken daemon-parity.

## Change
- **NEW `lib/eva/review-gate-mint.js`** — `maybeMintReviewGate()` reuses the daemon's **shared** helper `createOrReusePendingDecision` (from `chairman-decision-watcher.js`) — **not** a hand-rolled INSERT — so the minted decision inherits the full daemon shape (`resolveDecisionHealth` non-null health_score + `recordForwardGateScore`). Review-stage set comes from the canonical `getStageGovernance().isReview` (`venture_stages.review_mode`), never a hardcoded `[7,8,9,11]`. Idempotent, scoped (review + valid + non-dryRun + `!isBlocking`), **fail-soft** (a mint failure logs and never breaks the run). Deps injectable for testing.
- **`lib/eva/stage-execution-engine.js`** — calls `maybeMintReviewGate` at the `executeStage` completion seam (after `processLifecycleTerminal`).
- **NEW `tests/unit/eva/review-gate-mint.test.js`** — 9 unit tests (mint shape, reuse-no-dup, non-review/dryRun/invalid/blocking skips, non-fatal gov+mint errors, no-supabase skip).

## Verification
- 9/9 new unit tests pass; 38/38 regression (lifecycle-terminal, persist-artifact, chairman-decision-watcher, stage-governance); `node --check` + ESM import OK.
- testing-agent verdict **PASS** (row 654c1090); retro PUBLISHED 100/100 (f99b79d5).

## Scope notes
BACKEND-ONLY, no schema/UI. Pairs with the separate `SD-LEO-INFRA-RUN-STAGE-FAITHFUL-PERSIST-001` (#5218, merged) and `#5216` artifact_type parity SDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)