### PR TITLE
feat(SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001): exempt chairman-gated migrations from drift-fail

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-RUN-STAGE-MINT-REVIEW-GATES-001",
-  "createdAt": "2026-06-28T20:15:38.027Z",
+  "sdKey": "SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001",
+  "createdAt": "2026-06-28T21:09:37.336Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/check-migration-readiness.mjs
+++ b/scripts/check-migration-readiness.mjs
@@ -14,9 +14,20 @@
  * Outcome markers:
  *   [MIGRATION_READINESS_PASS]                     — all declared objects new or matching
  *   [MIGRATION_READINESS_PASS_NO_MIGRATIONS]       — no migration files in scope
+ *   [MIGRATION_READINESS_PASS_CHAIRMAN_GATED_PENDING] — body diverges, but the migration is an
+ *                                                    intentionally chairman-gated staged-not-applied
+ *                                                    migration (advisory, exit 0) (CHAIRMAN-GATED-EXEMPT-001)
  *   [MIGRATION_READINESS_FAIL_DRIFT_DETECTED]      — CREATE OR REPLACE body diverges from live (R2)
  *   [MIGRATION_READINESS_FAIL_CONFLICTING_DECLARATION] — CREATE (no OR REPLACE) on existing object (R5)
  *   [MIGRATION_READINESS_INFRA_ERROR]              — DB unreachable / secret missing
+ *
+ * SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001: a chairman-gated DB-function SD ships
+ * its migration STAGED and defers the apply to a separate chairman GO (the requires_chairman_apply
+ * convention), so live != migration is the EXPECTED state at merge time, not drift. When a migration
+ * is chairman-gated — detected via the SD's metadata.requires_chairman_apply=true OR a dedicated
+ * in-file header marker (-- @chairman-gated / -- requires-chairman-apply) — its body divergence is
+ * downgraded to an advisory EXPECTED_PENDING (exit 0). Real-drift detection for every other migration
+ * is UNCHANGED (still exit 1), and CONFLICTING is never exempted.
  */
 
 import { readFileSync, existsSync } from 'node:fs';
@@ -26,21 +37,43 @@ import { createDatabaseClient } from './lib/supabase-connection.js';
 const OUTCOME = {
   PASS: 'MIGRATION_READINESS_PASS',
   PASS_NO_MIGRATIONS: 'MIGRATION_READINESS_PASS_NO_MIGRATIONS',
+  PASS_CHAIRMAN_GATED_PENDING: 'MIGRATION_READINESS_PASS_CHAIRMAN_GATED_PENDING',
   FAIL_DRIFT: 'MIGRATION_READINESS_FAIL_DRIFT_DETECTED',
   FAIL_CONFLICTING: 'MIGRATION_READINESS_FAIL_CONFLICTING_DECLARATION',
   INFRA_ERROR: 'MIGRATION_READINESS_INFRA_ERROR'
 };
 
+/**
+ * SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001:
+ * Detect a DEDICATED chairman-gated header marker on its own (near-bare) comment line.
+ * Accepts `-- @chairman-gated`, `-- requires-chairman-apply`, `-- requires_chairman_apply`
+ * (case-insensitive, leading whitespace tolerated). Deliberately does NOT match the broad
+ * `-- @approved-by` marker (present on every prod migration) and does NOT match the tokens when
+ * they merely appear inside prose/description sentences — the marker must be essentially the whole
+ * comment line, so a normal migration cannot accidentally exempt its own drift.
+ * @param {string} sql
+ * @returns {boolean}
+ */
+export function parseChairmanGatedMarker(sql) {
+  if (!sql) return false;
+  // A comment line whose payload is just the marker token (optional trailing ':'/'=' + value),
+  // e.g. "-- @chairman-gated", "-- requires-chairman-apply: codestreetlabs@gmail.com".
+  const re = /^\s*--\s*(@chairman-gated|requires[-_]chairman[-_]apply)\b\s*[:=]?.*$/im;
+  return re.test(sql);
+}
+
 const MIGRATION_PATH_RE = /(^|\/)database\/migrations\/[^/]+\.sql$/;
 
 function parseArgs(argv) {
-  const opts = { pr: null, files: null };
+  const opts = { pr: null, files: null, sd: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--pr') opts.pr = argv[++i];
     else if (a.startsWith('--pr=')) opts.pr = a.slice('--pr='.length);
     else if (a === '--files') opts.files = argv[++i];
     else if (a.startsWith('--files=')) opts.files = a.slice('--files='.length);
+    else if (a === '--sd') opts.sd = argv[++i];
+    else if (a.startsWith('--sd=')) opts.sd = a.slice('--sd='.length);
   }
   return opts;
 }
@@ -65,6 +98,50 @@ export function listMigrationFiles({ pr, files, env = process.env }) {
   const r = spawnSync('git', ['diff', 'origin/main...HEAD', '--name-only'], { encoding: 'utf-8' });
   if (r.status !== 0) return [];
   return r.stdout.split('\n').map(s => s.trim()).filter(p => MIGRATION_PATH_RE.test(p));
+}
+
+/**
+ * CHAIRMAN-GATED-EXEMPT-001: best-effort resolve the SD key for this run. An explicit `--sd <key>`
+ * wins; otherwise infer a `SD-*` key from the head branch (GITHUB_HEAD_REF / GITHUB_REF_NAME, or the
+ * current git branch — branches are `feat/SD-...`). Returns null when nothing resolves — the gate
+ * then falls back to the in-file header marker only.
+ * @returns {string|null}
+ */
+export function inferSdKey({ sd, env = process.env } = {}) {
+  if (sd) return sd.trim();
+  const candidates = [env.GITHUB_HEAD_REF, env.GITHUB_REF_NAME];
+  if (!candidates.some(Boolean)) {
+    const r = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf-8' });
+    if (r.status === 0) candidates.push(r.stdout.trim());
+  }
+  for (const c of candidates) {
+    if (!c) continue;
+    const m = /\b(SD-[A-Z0-9][A-Z0-9-]*)\b/i.exec(c);
+    if (m) return m[1].toUpperCase();
+  }
+  return null;
+}
+
+/**
+ * CHAIRMAN-GATED-EXEMPT-001: best-effort read of strategic_directives_v2.metadata.requires_chairman_apply
+ * for the resolved SD. Any failure (no key, unreadable, missing row) returns false and is non-fatal —
+ * the gate never errors on SD resolution; the header-marker path still applies per-file.
+ * @returns {Promise<boolean>}
+ */
+export async function resolveSdGated({ sdKey, client }) {
+  if (!sdKey || !client) return false;
+  try {
+    const r = await client.query(
+      `SELECT (metadata->>'requires_chairman_apply') AS flag
+         FROM strategic_directives_v2
+        WHERE sd_key = $1
+        LIMIT 1`,
+      [sdKey]
+    );
+    return r.rows[0]?.flag === 'true' || r.rows[0]?.flag === true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -191,12 +268,17 @@ export function shortDiff(a, b, lines = 6) {
   return out.join('\n');
 }
 
-export async function evaluateMigration({ filePath, sql, client }) {
+export async function evaluateMigration({ filePath, sql, client, chairmanGated = false }) {
   const declared = parseDeclaredObjects(sql);
   // SD-REFILL-00EAHZRZ: a `DROP ... IF EXISTS <name>` ahead of a bare CREATE of the same object
   // makes that CREATE idempotent — treat it like CREATE OR REPLACE (status IDEMPOTENT, not CONFLICTING).
   const droppedIfExists = parseDropIfExists(sql);
   const isIdempotentRecreate = (obj) => droppedIfExists.has(`${obj.kind}:${obj.name}`);
+  // CHAIRMAN-GATED-EXEMPT-001: this migration is gated if the SD requires a chairman apply OR the
+  // file carries the dedicated header marker. When gated, a diverged CREATE OR REPLACE FUNCTION body
+  // is EXPECTED (staged-not-applied), so it is downgraded to EXPECTED_PENDING. CONFLICTING is a real
+  // declaration error and is NEVER exempted.
+  const gated = chairmanGated || parseChairmanGatedMarker(sql);
   const findings = [];
   for (const obj of declared) {
     if (obj.kind === 'function') {
@@ -209,7 +291,9 @@ export async function evaluateMigration({ filePath, sql, client }) {
         findings.push({ ...obj, status: isIdempotentRecreate(obj) ? 'IDEMPOTENT' : 'CONFLICTING' });
         continue;
       }
-      findings.push({ ...obj, status: compareBodies(obj.body, live) ? 'MATCHES' : 'DIVERGED', live });
+      const matches = compareBodies(obj.body, live);
+      const divergedStatus = gated ? 'EXPECTED_PENDING' : 'DIVERGED';
+      findings.push({ ...obj, status: matches ? 'MATCHES' : divergedStatus, live });
     } else if (obj.kind === 'trigger') {
       const exists = await queryLiveTrigger(client, obj.name);
       if (!exists) findings.push({ ...obj, status: 'NEW' });
@@ -220,15 +304,19 @@ export async function evaluateMigration({ filePath, sql, client }) {
   return { filePath, declared, findings };
 }
 
-function classifyOutcome(reports) {
+export function classifyOutcome(reports) {
   if (reports.length === 0) return OUTCOME.PASS_NO_MIGRATIONS;
-  let hasDrift = false, hasConflict = false;
+  let hasDrift = false, hasConflict = false, hasExpectedPending = false;
   for (const r of reports) for (const f of r.findings) {
     if (f.status === 'DIVERGED') hasDrift = true;
     if (f.status === 'CONFLICTING') hasConflict = true;
+    if (f.status === 'EXPECTED_PENDING') hasExpectedPending = true;
   }
+  // Priority: a real declaration error or genuine (non-gated) drift always dominates a gated
+  // advisory — a mixed PR with any non-gated DIVERGED still red-blocks (CHAIRMAN-GATED-EXEMPT-001).
   if (hasConflict) return OUTCOME.FAIL_CONFLICTING;
   if (hasDrift) return OUTCOME.FAIL_DRIFT;
+  if (hasExpectedPending) return OUTCOME.PASS_CHAIRMAN_GATED_PENDING;
   return OUTCOME.PASS;
 }
 
@@ -266,12 +354,18 @@ async function main() {
     process.exit(2);
   }
 
+  // CHAIRMAN-GATED-EXEMPT-001: resolve the SD-level chairman-apply flag once (best-effort, non-fatal).
+  // A true flag gates ALL of this PR's migrations; each file is ALSO gated individually if it carries
+  // the in-file header marker (handled inside evaluateMigration).
+  const sdKey = inferSdKey({ sd: opts.sd });
+  const sdGated = await resolveSdGated({ sdKey, client });
+
   const reports = [];
   try {
     for (const filePath of files) {
       if (!existsSync(filePath)) continue;
       const sql = readFileSync(filePath, 'utf-8');
-      reports.push(await evaluateMigration({ filePath, sql, client }));
+      reports.push(await evaluateMigration({ filePath, sql, client, chairmanGated: sdGated }));
     }
   } finally {
     await client.end().catch(() => {});
@@ -285,13 +379,19 @@ async function main() {
         console.error(`[${OUTCOME.FAIL_DRIFT}] ${r.filePath} ${tag}\n${shortDiff(f.live, f.body)}`);
       } else if (f.status === 'CONFLICTING') {
         console.error(`[${OUTCOME.FAIL_CONFLICTING}] ${r.filePath} ${tag} — CREATE without OR REPLACE on existing object`);
+      } else if (f.status === 'EXPECTED_PENDING') {
+        // Advisory (NOT a failure): body diverges from live because the chairman-gated apply is
+        // deferred to a separate GO. Stated clearly so a green-with-advisory is not read as applied.
+        console.log(`[${OUTCOME.PASS_CHAIRMAN_GATED_PENDING}] ${r.filePath} ${tag} — expected-pending: chairman-gated apply deferred (live differs from migration BY DESIGN)`);
       } else {
         console.log(`[${outcome}] ${r.filePath} ${tag} (${f.status})`);
       }
     }
   }
-  console.log(JSON.stringify({ outcome, files: reports.map(r => ({ filePath: r.filePath, findings: r.findings.map(f => ({ kind: f.kind, schema: f.schema, name: f.name, status: f.status })) })) }));
-  process.exit(outcome === OUTCOME.PASS || outcome === OUTCOME.PASS_NO_MIGRATIONS ? 0 : 1);
+  if (sdGated) console.log(`[${OUTCOME.PASS_CHAIRMAN_GATED_PENDING}] SD ${sdKey} metadata.requires_chairman_apply=true — body divergence treated as expected-pending`);
+  console.log(JSON.stringify({ outcome, sdKey, sdGated, files: reports.map(r => ({ filePath: r.filePath, findings: r.findings.map(f => ({ kind: f.kind, schema: f.schema, name: f.name, status: f.status })) })) }));
+  const passing = outcome === OUTCOME.PASS || outcome === OUTCOME.PASS_NO_MIGRATIONS || outcome === OUTCOME.PASS_CHAIRMAN_GATED_PENDING;
+  process.exit(passing ? 0 : 1);
 }
 
 export { OUTCOME };

--- a/tests/migration-readiness/check-migration-readiness-chairman-gated.test.js
+++ b/tests/migration-readiness/check-migration-readiness-chairman-gated.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for the chairman-gated migration-readiness exemption.
+ * SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001
+ *
+ * TS-1 parseChairmanGatedMarker (dedicated marker; NOT @approved-by / prose)
+ * TS-2 gated diverged function => EXPECTED_PENDING => PASS_CHAIRMAN_GATED_PENDING (exit-0 outcome)
+ * TS-3 non-gated diverged function => DIVERGED => FAIL_DRIFT
+ * TS-4 gated migration after apply (matches live) => MATCHES (clean PASS)
+ * TS-5 mixed PR (gated-diverged + non-gated-diverged) => FAIL_DRIFT (non-gated dominates)
+ * TS-6 gated CONFLICTING still fails (never exempted)
+ * TS-7 inferSdKey resolution
+ * TS-8 resolveSdGated reads metadata.requires_chairman_apply (best-effort, non-fatal)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseChairmanGatedMarker,
+  evaluateMigration,
+  classifyOutcome,
+  inferSdKey,
+  resolveSdGated,
+  OUTCOME,
+} from '../../scripts/check-migration-readiness.mjs';
+
+const FN = (body) => `
+CREATE OR REPLACE FUNCTION public.fn_chairman_decide() RETURNS void AS $$
+BEGIN
+  ${body}
+END;
+$$ LANGUAGE plpgsql;
+`;
+
+// A CREATE FUNCTION without OR REPLACE on an EXISTING object => CONFLICTING.
+const FN_BARE = `
+CREATE FUNCTION public.fn_chairman_decide() RETURNS void AS $$
+BEGIN
+  PERFORM 1;
+END;
+$$ LANGUAGE plpgsql;
+`;
+
+const MARKER = '-- @chairman-gated\n';
+
+// Mock client: state.functions maps "schema.name" -> live body.
+function makeMockClient(state) {
+  return {
+    async query(sql, params) {
+      if (/pg_proc/.test(sql)) {
+        const [schema, name] = params;
+        const body = state.functions[`${schema}.${name}`];
+        return { rows: body === undefined ? [] : [{ body }], rowCount: body === undefined ? 0 : 1 };
+      }
+      if (/strategic_directives_v2/.test(sql)) {
+        const [sdKey] = params;
+        const flag = state.sdFlags?.[sdKey];
+        return { rows: flag === undefined ? [] : [{ flag }], rowCount: flag === undefined ? 0 : 1 };
+      }
+      if (/pg_trigger/.test(sql)) return { rowCount: 0, rows: [] };
+      throw new Error('unexpected query: ' + sql);
+    },
+    async end() {},
+  };
+}
+
+// ── TS-1: marker parser ──────────────────────────────────────────────────────
+describe('parseChairmanGatedMarker', () => {
+  it('matches each dedicated marker line', () => {
+    expect(parseChairmanGatedMarker('-- @chairman-gated')).toBe(true);
+    expect(parseChairmanGatedMarker('-- requires-chairman-apply')).toBe(true);
+    expect(parseChairmanGatedMarker('-- requires_chairman_apply')).toBe(true);
+    expect(parseChairmanGatedMarker('  --   @chairman-gated: codestreetlabs@gmail.com')).toBe(true);
+    expect(parseChairmanGatedMarker('-- REQUIRES-CHAIRMAN-APPLY')).toBe(true);
+  });
+
+  it('does NOT match the broad @approved-by marker', () => {
+    expect(parseChairmanGatedMarker('-- @approved-by: codestreetlabs@gmail.com')).toBe(false);
+  });
+
+  it('does NOT match a prose mention of the convention', () => {
+    expect(parseChairmanGatedMarker(
+      '-- This migration follows the requires_chairman_apply convention adopted by Adam.'
+    )).toBe(false);
+    expect(parseChairmanGatedMarker('SELECT 1; -- defer to chairman-gated apply later')).toBe(false);
+  });
+
+  it('finds the marker among other header lines', () => {
+    expect(parseChairmanGatedMarker(`-- @approved-by: x@y.com\n-- @chairman-gated\n${FN('PERFORM 1;')}`)).toBe(true);
+  });
+
+  it('returns false for empty / null', () => {
+    expect(parseChairmanGatedMarker('')).toBe(false);
+    expect(parseChairmanGatedMarker(null)).toBe(false);
+  });
+});
+
+// ── TS-2 / TS-3 / TS-4: gated vs non-gated divergence ────────────────────────
+describe('evaluateMigration chairman-gated exemption', () => {
+  const live = { functions: { 'public.fn_chairman_decide': 'BEGIN\n  PERFORM 99;\nEND;' } };
+
+  it('TS-2: gated (via marker) diverged function => EXPECTED_PENDING', async () => {
+    const sql = MARKER + FN('PERFORM 1;'); // body differs from live (99)
+    const r = await evaluateMigration({ filePath: 'm.sql', sql, client: makeMockClient(live) });
+    expect(r.findings[0].status).toBe('EXPECTED_PENDING');
+    expect(classifyOutcome([r])).toBe(OUTCOME.PASS_CHAIRMAN_GATED_PENDING);
+  });
+
+  it('TS-2b: gated via the SD-level flag (chairmanGated=true), no in-file marker', async () => {
+    const sql = FN('PERFORM 1;');
+    const r = await evaluateMigration({ filePath: 'm.sql', sql, client: makeMockClient(live), chairmanGated: true });
+    expect(r.findings[0].status).toBe('EXPECTED_PENDING');
+    expect(classifyOutcome([r])).toBe(OUTCOME.PASS_CHAIRMAN_GATED_PENDING);
+  });
+
+  it('TS-3: non-gated diverged function => DIVERGED => FAIL_DRIFT', async () => {
+    const sql = FN('PERFORM 1;');
+    const r = await evaluateMigration({ filePath: 'm.sql', sql, client: makeMockClient(live) });
+    expect(r.findings[0].status).toBe('DIVERGED');
+    expect(classifyOutcome([r])).toBe(OUTCOME.FAIL_DRIFT);
+  });
+
+  it('TS-4: gated migration after apply (body matches live) => MATCHES, clean PASS', async () => {
+    const matchingLive = { functions: { 'public.fn_chairman_decide': 'BEGIN\n  PERFORM 1;\nEND;' } };
+    const sql = MARKER + FN('PERFORM 1;');
+    const r = await evaluateMigration({ filePath: 'm.sql', sql, client: makeMockClient(matchingLive) });
+    expect(r.findings[0].status).toBe('MATCHES');
+    expect(classifyOutcome([r])).toBe(OUTCOME.PASS);
+  });
+
+  it('TS-6: gated CONFLICTING is NEVER exempted', async () => {
+    const sql = MARKER + FN_BARE; // bare CREATE on existing object
+    const r = await evaluateMigration({ filePath: 'm.sql', sql, client: makeMockClient(live), chairmanGated: true });
+    expect(r.findings[0].status).toBe('CONFLICTING');
+    expect(classifyOutcome([r])).toBe(OUTCOME.FAIL_CONFLICTING);
+  });
+});
+
+// ── TS-5: mixed PR — non-gated drift dominates ───────────────────────────────
+describe('classifyOutcome priority (mixed PR)', () => {
+  it('TS-5: a gated EXPECTED_PENDING + a non-gated DIVERGED => FAIL_DRIFT', () => {
+    const reports = [
+      { filePath: 'gated.sql', findings: [{ kind: 'function', name: 'a', status: 'EXPECTED_PENDING' }] },
+      { filePath: 'plain.sql', findings: [{ kind: 'function', name: 'b', status: 'DIVERGED' }] },
+    ];
+    expect(classifyOutcome(reports)).toBe(OUTCOME.FAIL_DRIFT);
+  });
+
+  it('CONFLICTING outranks both DRIFT and EXPECTED_PENDING', () => {
+    const reports = [
+      { filePath: 'g.sql', findings: [{ status: 'EXPECTED_PENDING' }] },
+      { filePath: 'd.sql', findings: [{ status: 'DIVERGED' }] },
+      { filePath: 'c.sql', findings: [{ status: 'CONFLICTING' }] },
+    ];
+    expect(classifyOutcome(reports)).toBe(OUTCOME.FAIL_CONFLICTING);
+  });
+
+  it('only-gated divergence => PASS_CHAIRMAN_GATED_PENDING', () => {
+    const reports = [{ filePath: 'g.sql', findings: [{ status: 'EXPECTED_PENDING' }] }];
+    expect(classifyOutcome(reports)).toBe(OUTCOME.PASS_CHAIRMAN_GATED_PENDING);
+  });
+});
+
+// ── TS-7: SD key inference ───────────────────────────────────────────────────
+describe('inferSdKey', () => {
+  it('prefers an explicit --sd value', () => {
+    expect(inferSdKey({ sd: 'SD-LEO-INFRA-FOO-001', env: {} })).toBe('SD-LEO-INFRA-FOO-001');
+  });
+  it('infers from a feat/SD-* branch in GITHUB_HEAD_REF', () => {
+    expect(inferSdKey({ env: { GITHUB_HEAD_REF: 'feat/SD-LEO-INFRA-BAR-002' } })).toBe('SD-LEO-INFRA-BAR-002');
+  });
+  it('infers from GITHUB_REF_NAME and uppercases the key', () => {
+    expect(inferSdKey({ env: { GITHUB_REF_NAME: 'feat/SD-ABC-003-extra' } })).toBe('SD-ABC-003-EXTRA');
+  });
+  it('returns null when nothing resolves (no git, no env)', () => {
+    // env has no branch hints; git inference may or may not match, so only assert non-throwing string|null
+    const r = inferSdKey({ env: { GITHUB_HEAD_REF: 'main', GITHUB_REF_NAME: 'main' } });
+    expect(r === null || typeof r === 'string').toBe(true);
+  });
+});
+
+// ── TS-8: SD metadata read ───────────────────────────────────────────────────
+describe('resolveSdGated', () => {
+  it('returns true when metadata.requires_chairman_apply is "true"', async () => {
+    const client = makeMockClient({ functions: {}, sdFlags: { 'SD-X-001': 'true' } });
+    expect(await resolveSdGated({ sdKey: 'SD-X-001', client })).toBe(true);
+  });
+  it('returns false when the flag is absent/false', async () => {
+    const client = makeMockClient({ functions: {}, sdFlags: { 'SD-X-001': 'false' } });
+    expect(await resolveSdGated({ sdKey: 'SD-X-001', client })).toBe(false);
+    expect(await resolveSdGated({ sdKey: 'SD-MISSING', client })).toBe(false);
+  });
+  it('is non-fatal: no key or no client => false, never throws', async () => {
+    expect(await resolveSdGated({ sdKey: null, client: makeMockClient({ functions: {} }) })).toBe(false);
+    expect(await resolveSdGated({ sdKey: 'SD-X', client: null })).toBe(false);
+  });
+  it('swallows a query error and returns false', async () => {
+    const throwing = { async query() { throw new Error('db down'); }, async end() {} };
+    expect(await resolveSdGated({ sdKey: 'SD-X', client: throwing })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
`scripts/check-migration-readiness.mjs` (a required pre-merge gate) flagged `MIGRATION_READINESS_FAIL_DRIFT_DETECTED` (exit 1) whenever a `CREATE OR REPLACE FUNCTION` body diverged from live. But a **chairman-gated** DB-function SD intentionally ships its migration **staged-not-applied** (apply deferred to a separate chairman GO via the `requires_chairman_apply` convention), so `live != migration` at merge time is the **expected** state, not drift. The gate couldn't tell intended-pending from accidental drift, so it **false-blocked every such PR** — forcing admin-merge and eroding the gate's signal (the chairman-gated-DDL analog of the baseline-rot merge-gate tax). It hit #5212 and #5220, both admin-merged. Surfaced by worker Delta (gate-bug 543fd245), co-authored with the coordinator.

## Change
- **Detection (two inputs):** a dedicated in-file header marker `parseChairmanGatedMarker` (`-- @chairman-gated` / `-- requires-chairman-apply` / `-- requires_chairman_apply` — **not** the broad `@approved-by`, **not** prose mentions) **OR** the SD's `metadata.requires_chairman_apply=true` resolved via `inferSdKey` (`--sd` arg or `feat/SD-*` branch) + `resolveSdGated` (best-effort, non-fatal).
- **Behavior:** when gated, a diverged function body becomes `EXPECTED_PENDING`; `classifyOutcome` returns the new `OUTCOME.PASS_CHAIRMAN_GATED_PENDING` (exit 0) with a clear *expected-pending: chairman-gated apply deferred* advisory.
- **Safety preserved:** non-gated `DIVERGED` still `FAIL_DRIFT` (exit 1); `CONFLICTING` is **never** exempted; a mixed PR with any non-gated drift still fails (non-gated drift dominates by outcome priority). Backward-compatible (`chairmanGated` defaults false).

## Verification
- 21 new unit tests + 21 regression = **42/42 green**; `node --check` OK.
- testing-agent **PASS** (row 3b713ee1); retro PUBLISHED 100/100 (ec77de98).

## Scope
Single-file logic + tests. No schema, no new secret, no CI-workflow change (the gate already passes `--pr`, from which the SD/branch is inferable). Pairs with BASELINE-QUARANTINE-SWEEP as the second merge-gate-tax fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)