### PR TITLE
fix(SD-LEO-INFRA-CI-UNIT-TIER-INSTALL-CASCADE-001): quarantine DB-dependent test + add install probe to unit-tier CI

### DIFF
--- a/.github/workflows/unit-tier.yml
+++ b/.github/workflows/unit-tier.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Verify node_modules health (@supabase probe)
+        # SD-LEO-INFRA-CI-UNIT-TIER-INSTALL-CASCADE-001: exit 2 (INFRA_ERROR) if the
+        # install is broken so a cascade of fake test failures is never mistaken for
+        # real regressions. Exit 2 distinguishes infra failure from test failure (exit 1).
+        run: |
+          node -e "require.resolve('@supabase/supabase-js')" 2>/dev/null || {
+            echo "[UNIT_TIER_INFRA_ERROR] node_modules broken: @supabase/supabase-js not resolvable. Re-run the job or run npm ci locally."; exit 2; }
+
       - name: Run unit project (manifest exclusions applied)
         run: npx vitest run --project unit
 

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -1354,6 +1354,14 @@
       "linked_ref": "sd:SD-LEO-INFRA-BASELINE-QUARANTINE-SWEEP-001",
       "quarantined_at": "2026-06-28T21:15:00.000Z",
       "quarantined_by": "4a712a71-88c5-4e2b-b26d-8829f036991e"
+    },
+    {
+      "file": "tests/unit/cleanup/master-reset-validation.test.js",
+      "reason_class": "missing-fixture",
+      "error_signature": "Error: connect ECONNREFUSED ::1:5432 — test imports pg and calls client.connect() unconditionally in beforeAll; unit-tier CI runner has no PostgreSQL database fixture",
+      "linked_ref": "sd:SD-LEO-INFRA-CI-UNIT-TIER-INSTALL-CASCADE-001",
+      "quarantined_at": "2026-06-28T22:30:00.000Z",
+      "quarantined_by": "4a712a71-88c5-4e2b-b26d-8829f036991e"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Quarantines `tests/unit/cleanup/master-reset-validation.test.js` (reason: `missing-fixture` — imports pg, calls client.connect() unconditionally in beforeAll, ECONNREFUSED ::1:5432 in no-DB CI runner)
- Adds `@supabase/supabase-js` node_modules health probe step to `unit-tier.yml` between `npm ci` and `npx vitest`; exits INFRA_ERROR (exit 2) on broken install so cascade fake failures are distinguishable from real test regressions

This is the 3rd + final fix in the CI unit-tier health trio (#5223 assertion-drift quarantine, #5224 chairman-gated migration exempt, **this PR**).

## Test plan
- [x] `npx vitest run tests/unit/quarantine-manifest.test.js` — 6/6 pass (schema validation)
- [x] YAML parsed successfully (js-yaml.load)
- [x] 16 LOC total across 2 files — within ≤30 LOC target
- [ ] CI unit-tier gate turns green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)