### PR TITLE
feat(SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001): leo-stack restart respects a daemon-down controlled walk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,6 @@ scripts/cron/eva-watcher-task.cmd
 # SD-LEO-INFRA-FLEET-HIBERNATION-MECHANISM-001 quiet-tick runtime last-state files
 .coord-quiet-tick-last.json
 .adam-quiet-tick-last.json
+
+# SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001: leo-stack daemon-down controlled-walk sentinel (operator runtime marker)
+.leo-stack-walk-mode

--- a/docs/06_deployment/leo-stack-walk-mode.md
+++ b/docs/06_deployment/leo-stack-walk-mode.md
@@ -1,0 +1,53 @@
+# leo-stack daemon-down "controlled walk" (walk-mode)
+
+**SD:** SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001
+
+## Why
+
+`leo-stack restart` starts every enabled worker in `config/workers.json` via `Start-Workers`/`start_workers`.
+Those registry workers are the **EVA stage-execution daemon** (`stage-zero-queue-processor`,
+`start-stage-worker`/`stage-execution-worker`, `eva-master-scheduler`, `subagent-worker`,
+`lib/eva/workers`). So a `restart` during a deliberately **daemon-down** period silently revived the
+daemon — which then auto-advanced a venture past a chairman review (S8) and a HARD gate (S10).
+
+## The sentinel
+
+A controlled walk is marked by a sentinel file at the repo root:
+
+```
+.leo-stack-walk-mode
+```
+
+It is an operator runtime marker (gitignored). While it is present, `leo-stack restart`/`start`:
+
+- brings up the **web servers** normally, and
+- leaves the **EVA stage workers STOPPED**, printing a `[WALK-MODE]` notice per skipped worker.
+
+Remove the sentinel and restart to resume the daemon normally. With the sentinel absent, behavior is
+unchanged.
+
+## Enter / exit a walk
+
+```bash
+# enter a controlled walk (daemon stays down across restarts)
+touch .leo-stack-walk-mode
+node scripts/cross-platform-run.js leo-stack restart   # web up, EVA stage workers stay stopped
+
+# exit
+rm .leo-stack-walk-mode
+node scripts/cross-platform-run.js leo-stack restart   # daemon resumes
+```
+
+## How it works
+
+The decision is owned by one unit-tested module — `lib/leo-stack/walk-mode.cjs`:
+
+- `isWalkModeActive(repoRoot)` — sentinel present?
+- `isEvaStageWorker(worker)` — is this registry worker part of the daemon set? (patterns mirror the
+  existing orphan/stale-worker regex in `leo-stack.ps1`)
+- `shouldStartWorker(worker, walkActive)` — start unless it's an EVA worker during a walk.
+- CLI `node lib/leo-stack/walk-mode.cjs skip-ids` — the worker IDs to skip (empty when no walk).
+
+`leo-stack.ps1` and `leo-stack.sh` call `skip-ids` once and skip those workers. **Fail-closed:** if the
+sentinel is present but the helper returns nothing, the scripts fall back to the EVA regex and skip the
+whole daemon set — a present walk sentinel never silently revives the daemon.

--- a/lib/leo-stack/walk-mode.cjs
+++ b/lib/leo-stack/walk-mode.cjs
@@ -1,0 +1,103 @@
+/**
+ * walk-mode.cjs — single source of truth for the leo-stack daemon-down "controlled walk"
+ * (SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001).
+ *
+ * Incident: `leo-stack restart` unconditionally re-enabled the EVA stage-execution workers via
+ * Start-Workers (config/workers.json), silently reviving a deliberately-down daemon — which then
+ * auto-advanced a venture past a chairman review (S8) and a HARD gate (S10).
+ *
+ * Fix: an operator-set sentinel file (.leo-stack-walk-mode) marks an active controlled walk. When it
+ * is present, leo-stack restart must leave the EVA stage workers STOPPED (web servers still come up).
+ * This module owns both the sentinel check and the EVA-worker classification so leo-stack.ps1 and
+ * leo-stack.sh stay consistent and the daemon set is unit-tested.
+ *
+ * @module lib/leo-stack/walk-mode
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WALK_SENTINEL_FILE = '.leo-stack-walk-mode';
+
+// The EVA stage-execution daemon set. Patterns mirror the orphan/stale regex already in
+// leo-stack.ps1 so the daemon is identified consistently everywhere. Matched against worker.command.
+const EVA_STAGE_WORKER_PATTERNS = [
+  /stage-zero-queue-processor/,
+  /start-stage-worker/,
+  /stage-execution-worker/,
+  /eva-master-scheduler/,
+  /subagent-worker/,
+  /lib[\\/]eva[\\/]workers/,
+];
+
+/** Is a daemon-down controlled walk active? (sentinel file present in repoRoot) */
+function isWalkModeActive(repoRoot = process.cwd()) {
+  try {
+    return fs.existsSync(path.join(repoRoot, WALK_SENTINEL_FILE));
+  } catch {
+    return false;
+  }
+}
+
+/** Is this registry worker part of the EVA stage-execution daemon set? */
+function isEvaStageWorker(worker) {
+  const cmd = String((worker && (worker.command || worker.cmd)) || '');
+  const id = String((worker && (worker.id || worker.name || worker.display_name)) || '');
+  return EVA_STAGE_WORKER_PATTERNS.some((re) => re.test(cmd) || re.test(id));
+}
+
+/**
+ * Should leo-stack start this worker given the current walk state? An EVA stage worker is held
+ * stopped only while a walk is active; everything else (e.g. web servers, were they ever in the
+ * registry) starts normally.
+ */
+function shouldStartWorker(worker, walkActive) {
+  return !(walkActive && isEvaStageWorker(worker));
+}
+
+/** Read the worker registry (config/workers.json) from repoRoot; [] on any error. */
+function readWorkerRegistry(repoRoot = process.cwd()) {
+  try {
+    const raw = fs.readFileSync(path.join(repoRoot, 'config', 'workers.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : (parsed.workers || []);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The worker IDs leo-stack must SKIP for the current state: empty when no walk is active, otherwise
+ * every EVA stage worker in the registry. Used by the shell scripts via the `skip-ids` CLI.
+ */
+function skipWorkerIds(repoRoot = process.cwd()) {
+  if (!isWalkModeActive(repoRoot)) return [];
+  return readWorkerRegistry(repoRoot)
+    .filter((w) => isEvaStageWorker(w))
+    .map((w) => String(w.id || w.name || w.display_name || '').trim())
+    .filter(Boolean);
+}
+
+module.exports = {
+  WALK_SENTINEL_FILE,
+  EVA_STAGE_WORKER_PATTERNS,
+  isWalkModeActive,
+  isEvaStageWorker,
+  shouldStartWorker,
+  readWorkerRegistry,
+  skipWorkerIds,
+};
+
+// CLI: `node lib/leo-stack/walk-mode.cjs skip-ids` → newline-separated worker IDs to skip (cwd repo).
+//      `node lib/leo-stack/walk-mode.cjs active` → exit 0 if a walk is active, 1 otherwise.
+if (require.main === module) {
+  const cmd = process.argv[2];
+  if (cmd === 'skip-ids') {
+    process.stdout.write(skipWorkerIds(process.cwd()).join('\n'));
+    process.exit(0);
+  } else if (cmd === 'active') {
+    process.exit(isWalkModeActive(process.cwd()) ? 0 : 1);
+  } else {
+    process.stderr.write('usage: walk-mode.cjs <skip-ids|active>\n');
+    process.exit(2);
+  }
+}

--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -264,10 +264,39 @@ function Start-Workers {
     $workers = Get-WorkerRegistry
     if ($workers.Count -eq 0) { return }
 
+    # SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001: respect an active daemon-down controlled
+    # walk. When the .leo-stack-walk-mode sentinel is present, the EVA stage-execution workers stay
+    # STOPPED across a restart (web servers still come up) so the daemon cannot silently revive and
+    # auto-advance a venture past a chairman review (S8) / a HARD gate (S10). The skip set + the EVA
+    # classification live in lib/leo-stack/walk-mode.cjs (the single, unit-tested source of truth).
+    $walkSentinel = Join-Path $EngineerDir ".leo-stack-walk-mode"
+    $walkActive = Test-Path $walkSentinel
+    $skipWorkerIds = @()
+    if ($walkActive) {
+        try {
+            $skipRaw = & node (Join-Path $EngineerDir "lib\leo-stack\walk-mode.cjs") "skip-ids" 2>$null
+            $skipWorkerIds = @($skipRaw | Where-Object { $_ -and $_.Trim() } | ForEach-Object { $_.Trim() })
+        } catch {
+            $skipWorkerIds = @()
+        }
+        # FAIL-CLOSED for the daemon set: a present sentinel + a helper that returned nothing must NOT
+        # silently revive the daemon — fall back to the EVA regex and skip all of them.
+        if ($skipWorkerIds.Count -eq 0) {
+            $evaRe = 'stage-zero-queue-processor|start-stage-worker|stage-execution-worker|eva-master-scheduler|subagent-worker|lib[\\/]eva[\\/]workers'
+            $skipWorkerIds = @($workers | Where-Object { ($_.command -match $evaRe) -or ($_.id -match $evaRe) } | ForEach-Object { $_.id })
+        }
+        Write-Log "WARN" "[WALK-MODE] Daemon-down controlled walk active (.leo-stack-walk-mode) — leaving EVA stage workers STOPPED. Remove the sentinel + restart to resume the daemon." "Yellow"
+    }
+
     Write-Log "INFO" "[WORKERS] Starting enabled workers..." "Blue"
 
     foreach ($worker in $workers) {
         if (-not $worker.enabled) { continue }
+
+        if ($walkActive -and ($skipWorkerIds -contains $worker.id)) {
+            Write-Log "WARN" "[WALK-MODE] Skipping $($worker.display_name) — daemon-down controlled walk." "Yellow"
+            continue
+        }
 
         $pidFile = Join-Path $PidDir $worker.pid_file
 

--- a/scripts/leo-stack.sh
+++ b/scripts/leo-stack.sh
@@ -217,11 +217,34 @@ get_workers() {
 start_workers() {
     if [ ! -f "$WORKER_REGISTRY" ]; then return; fi
 
+    # SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001: respect an active daemon-down controlled
+    # walk. With the .leo-stack-walk-mode sentinel present, the EVA stage workers stay STOPPED across
+    # a restart (web servers still come up) so the daemon can't silently revive and auto-advance a
+    # venture past S8 / S10. Shared classification + skip set: lib/leo-stack/walk-mode.cjs.
+    local walk_active=0
+    local skip_ids=""
+    if [ -f "$ENGINEER_DIR/.leo-stack-walk-mode" ]; then
+        walk_active=1
+        skip_ids=$(node "$ENGINEER_DIR/lib/leo-stack/walk-mode.cjs" skip-ids 2>/dev/null || true)
+        # FAIL-CLOSED for the daemon set: a present sentinel + empty helper output must NOT revive
+        # the daemon — fall back to the EVA regex over the registry.
+        if [ -z "$skip_ids" ]; then
+            skip_ids=$(get_workers | while IFS= read -r wj; do node -e 'const w=JSON.parse(process.argv[1]); const re=/stage-zero-queue-processor|start-stage-worker|stage-execution-worker|eva-master-scheduler|subagent-worker|lib[\\/]eva[\\/]workers/; if(re.test(w.command||"")||re.test(w.id||"")) console.log(w.id)' "$wj"; done)
+        fi
+        log "WARN" "${YELLOW}[WALK-MODE] Daemon-down controlled walk active (.leo-stack-walk-mode) — leaving EVA stage workers STOPPED. Remove the sentinel + restart to resume the daemon.${NC}"
+    fi
+
     log "INFO" "${BLUE}[WORKERS] Starting enabled workers...${NC}"
 
     get_workers | while IFS= read -r worker_json; do
         local enabled=$(node -e "console.log(JSON.parse(process.argv[1]).enabled)" "$worker_json")
         if [ "$enabled" != "true" ]; then continue; fi
+
+        local wid=$(node -e "console.log(JSON.parse(process.argv[1]).id || '')" "$worker_json")
+        if [ "$walk_active" = "1" ] && printf '%s\n' "$skip_ids" | grep -qxF "$wid"; then
+            log "WARN" "${YELLOW}[WALK-MODE] Skipping $wid — daemon-down controlled walk.${NC}"
+            continue
+        fi
 
         local name=$(node -e "console.log(JSON.parse(process.argv[1]).display_name)" "$worker_json")
         local command=$(node -e "console.log(JSON.parse(process.argv[1]).command)" "$worker_json")

--- a/tests/unit/leo-stack/walk-mode.test.js
+++ b/tests/unit/leo-stack/walk-mode.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001 — leo-stack must respect an active daemon-down
+ * controlled walk: the sentinel holds the EVA stage workers stopped across a restart so the daemon
+ * can't auto-advance a venture past S8 / S10. This pins the decision helper both shell scripts share.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const require = createRequire(import.meta.url);
+const wm = require('../../../lib/leo-stack/walk-mode.cjs');
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+describe('isEvaStageWorker — classifies the real registry as the daemon set', () => {
+  it('every worker in the live config/workers.json is an EVA stage worker', () => {
+    const workers = wm.readWorkerRegistry(REPO_ROOT);
+    expect(workers.length).toBeGreaterThan(0);
+    for (const w of workers) {
+      expect(wm.isEvaStageWorker(w), `${w.id || w.command} should classify as EVA`).toBe(true);
+    }
+  });
+
+  it('a synthetic non-EVA worker (e.g. a web server) is NOT an EVA stage worker', () => {
+    expect(wm.isEvaStageWorker({ id: 'engineer-web', command: 'node server.js' })).toBe(false);
+    expect(wm.isEvaStageWorker({ id: 'app', command: 'npm run dev' })).toBe(false);
+  });
+});
+
+describe('shouldStartWorker — gate only the daemon set, only during a walk', () => {
+  const eva = { id: 'stage-execution-worker', command: 'node scripts/start-stage-worker.js' };
+  const web = { id: 'engineer-web', command: 'node server.js' };
+
+  it('EVA worker is held stopped only when a walk is active', () => {
+    expect(wm.shouldStartWorker(eva, true)).toBe(false);
+    expect(wm.shouldStartWorker(eva, false)).toBe(true);
+  });
+  it('non-EVA worker always starts, even during a walk', () => {
+    expect(wm.shouldStartWorker(web, true)).toBe(true);
+    expect(wm.shouldStartWorker(web, false)).toBe(true);
+  });
+});
+
+describe('isWalkModeActive + skipWorkerIds — sentinel-driven', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(join(os.tmpdir(), 'walkmode-'));
+    fs.mkdirSync(join(tmp, 'config'));
+    fs.writeFileSync(join(tmp, 'config', 'workers.json'), JSON.stringify([
+      { id: 'stage-zero-processor', command: 'node scripts/stage-zero-queue-processor.js', enabled: true },
+      { id: 'stage-execution-worker', command: 'node scripts/start-stage-worker.js', enabled: true },
+      { id: 'eva-master-scheduler', command: 'node lib/eva/eva-master-scheduler.js', enabled: false },
+      { id: 'web-server', command: 'node server.js', enabled: true },
+    ]));
+  });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('inactive without the sentinel → skip-ids is empty', () => {
+    expect(wm.isWalkModeActive(tmp)).toBe(false);
+    expect(wm.skipWorkerIds(tmp)).toEqual([]);
+  });
+
+  it('active with the sentinel → skip-ids lists the EVA workers, NOT the web server', () => {
+    fs.writeFileSync(join(tmp, wm.WALK_SENTINEL_FILE), '');
+    expect(wm.isWalkModeActive(tmp)).toBe(true);
+    const skip = wm.skipWorkerIds(tmp);
+    expect(skip).toContain('stage-zero-processor');
+    expect(skip).toContain('stage-execution-worker');
+    expect(skip).toContain('eva-master-scheduler');
+    expect(skip).not.toContain('web-server');
+  });
+});


### PR DESCRIPTION
## Summary
`leo-stack restart` started **every** `config/workers.json` worker — and those registry workers **are** the EVA stage-execution daemon. So a `restart` during a deliberately daemon-down "controlled walk" silently revived the daemon, which then auto-advanced a venture past a **chairman review (S8)** and a **HARD gate (S10)**.

## Fix
- **`lib/leo-stack/walk-mode.cjs`** — single, unit-tested source of truth: sentinel check (`.leo-stack-walk-mode`), EVA-worker classification (patterns mirror the existing orphan/stale regex in `leo-stack.ps1`), `shouldStartWorker`, and a `skip-ids` CLI.
- **`leo-stack.ps1` + `leo-stack.sh`** `Start-Workers`/`start_workers`: call `skip-ids` once and leave the EVA stage workers **STOPPED** while the sentinel is present (web servers still come up), with a clear `[WALK-MODE]` notice. **Sentinel-absent path is unchanged.**
- **Fail-closed** for the daemon set: a present sentinel + empty helper output falls back to the EVA regex — a walk never silently revives the daemon.
- `.gitignore`'d the sentinel; **`docs/06_deployment/leo-stack-walk-mode.md`** documents entering/exiting a controlled walk across restarts.

## Test plan
- `npx vitest run tests/unit/leo-stack/walk-mode.test.js` → 6 passed (sentinel detect; **every live `config/workers.json` worker classifies as EVA**; `shouldStartWorker` truth table; `skip-ids` both states)
- `bash -n scripts/leo-stack.sh` clean; CLI verified: empty without sentinel, lists all 5 EVA workers with it

SD: SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001 (incident: daemon revived on restart bypassed S8/S10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)