### PR TITLE
fix(SD-LEO-INFRA-RUN-STAGE-ENGINE-GATE-AUTONOMY-001): converge engine gate onto can_auto_advance (close S10 bypass)

### DIFF
--- a/lib/eva/governance/can-auto-advance.js
+++ b/lib/eva/governance/can-auto-advance.js
@@ -1,0 +1,60 @@
+/**
+ * can-auto-advance.js — the ONE shared gate-eligibility predicate
+ * (SD-LEO-INFRA-RUN-STAGE-ENGINE-GATE-AUTONOMY-001).
+ *
+ * The 4-layer governance logic (global_auto_proceed off → kill/promotion always-block → explicit
+ * pause → review default-pause + the hard-gate set) lives in the SECURITY-DEFINER RPC
+ * `can_auto_advance(p_stage_number)`. Both the EVA stage-execution WORKER and the stage-execution
+ * ENGINE (run-stage.js / executeStage) must consult the SAME predicate — the engine previously
+ * called checkAutonomy(ventureId, 'stage_gate') with a HARDCODED gateType + OMITTED stageNumber,
+ * which auto-approved review + HARD gates regardless of every flag (the S10 hard-gate bypass).
+ *
+ * This module is the worker's _canAutoAdvance wrapper, extracted verbatim so there is exactly ONE
+ * JS predicate, not two divergent ones. DEFAULT-BLOCK on any error/uncertainty. The [SAE]
+ * canAutoAdvance(N) log contract (REGRESSION REG-7) is preserved.
+ *
+ * @module lib/eva/governance/can-auto-advance
+ */
+
+/**
+ * @param {Object} params
+ * @param {Object} params.supabase - supabase client (service role)
+ * @param {number} params.stageNumber - the lifecycle stage to evaluate
+ * @param {Object} [params.logger=console] - logger (preserves the [SAE] log contract)
+ * @returns {Promise<boolean>} true iff the stage may auto-advance; false (BLOCK) on any error/uncertainty
+ */
+export async function canAutoAdvance({ supabase, stageNumber, logger = console }) {
+  try {
+    const { data, error } = await supabase
+      .rpc('can_auto_advance', { p_stage_number: stageNumber });
+
+    if (error || !Array.isArray(data) || data.length === 0) {
+      logger.warn(`[SAE] canAutoAdvance(${stageNumber}): RPC failed — ${error?.message || 'no rows'}, defaulting to block`);
+      return false;
+    }
+
+    const { can, reason, layer } = data[0];
+
+    // Preserve [SAE] log contract — REGRESSION REG-7
+    if (can) {
+      logger.log(`[SAE] canAutoAdvance(${stageNumber}): approved — all governance layers passed`);
+    } else {
+      const reasonLabel = {
+        global_off: 'global_auto_proceed=false',
+        kill_promotion_gate: 'kill/promotion gate (stage_config)',
+        explicit_pause: 'stage_override.auto_proceed=false',
+        review_default_pause: 'review-mode default-pause (no explicit opt-in)',
+        config_missing: 'config query failed',
+        stage_not_found: 'stage not found in stage_config',
+      }[reason] || `unknown (${reason})`;
+      logger.log(`[SAE] canAutoAdvance(${stageNumber}): blocked — ${reasonLabel} [layer=${layer}]`);
+    }
+
+    return !!can;
+  } catch (err) {
+    logger.warn(`[SAE] canAutoAdvance threw: ${err.message}`);
+    return false;
+  }
+}
+
+export default canAutoAdvance;

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -19,7 +19,7 @@ import { stageRegistry } from './stage-registry.js';
 import { CROSS_STAGE_DEPS, validatePreStage, validatePostStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
 import { waitForDecision } from './chairman-decision-watcher.js';
 import { maybeMintReviewGate } from './review-gate-mint.js';
-import { checkAutonomy } from './autonomy-model.js';
+import { canAutoAdvance } from './governance/can-auto-advance.js';
 import { checkExitGates } from './lifecycle/exit-gate-enforcer.js';
 
 dotenv.config();
@@ -555,20 +555,25 @@ export async function executeStage(options = {}) {
 
   // 4.5. Resolve chairman gate if onBeforeAnalysis created a pending decision
   if (beforeAnalysisContext.chairmanDecisionId && output) {
-    // Check autonomy level — L2+ auto-approves chairman gates
-    const autonomy = await checkAutonomy(ventureId, 'stage_gate', { supabase }).catch(() => ({ action: 'manual' }));
-    if (autonomy.action === 'auto_approve') {
+    // SD-LEO-INFRA-RUN-STAGE-ENGINE-GATE-AUTONOMY-001: converge the engine gate decision onto the
+    // ONE shared predicate the worker uses — canAutoAdvance(stageNumber) over the can_auto_advance
+    // RPC (global_auto_proceed, kill/promotion always-block, explicit pause, review default-pause +
+    // the hard-gate set), DEFAULT-BLOCK on error. The previous checkAutonomy(ventureId,'stage_gate')
+    // hardcoded the gateType + omitted the stageNumber, auto-approving review + HARD gates regardless
+    // of every flag (the S10 hard-gate bypass). Auto-approve ONLY when the shared predicate says so.
+    const autoApprove = await canAutoAdvance({ supabase, stageNumber, logger });
+    if (autoApprove) {
       // Auto-approve the pending decision in the database
       await supabase.from('chairman_decisions')
-        .update({ status: 'approved', decision: 'proceed', rationale: `Auto-approved (${autonomy.level} autonomy)` })
+        .update({ status: 'approved', decision: 'proceed', rationale: 'Auto-approved (can_auto_advance governance)' })
         .eq('id', beforeAnalysisContext.chairmanDecisionId)
         .eq('status', 'pending');
       output.chairmanGate = {
         status: 'approved',
-        rationale: `Auto-approved (${autonomy.level} autonomy)`,
+        rationale: 'Auto-approved (can_auto_advance governance)',
         decision_id: beforeAnalysisContext.chairmanDecisionId,
       };
-      logger.log(`   Chairman gate auto-approved (${autonomy.level})`);
+      logger.log('   Chairman gate auto-approved (can_auto_advance governance)');
     } else {
       try {
         const decisionResult = await waitForDecision({

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -51,6 +51,7 @@ import { classifyBridgeOutcome, shouldHoldAtS19, S19_BRIDGE_OUTCOME } from './br
 // SD-LEO-INFRA-VISION-GROUNDED-ACCEPTANCE-001 (FR-2): vision-grounded acceptance gate (pure decision).
 import { shouldHoldForVisionAcceptance, isVisionAcceptanceGateEnabled, isVisionAcceptanceStrict } from './bridge/vision-acceptance-gate.js';
 import { shouldHoldForVisionDrift, isVisionDriftGateEnabled, isVisionDriftStrict, DRIFT_HOLD_CAUSE } from './bridge/vision-drift-gate.js';
+import { canAutoAdvance } from './governance/can-auto-advance.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -4271,37 +4272,11 @@ export class StageExecutionWorker {
    * @returns {Promise<boolean>}
    */
   async _canAutoAdvance(stageNumber) {
-    try {
-      const { data, error } = await this._supabase
-        .rpc('can_auto_advance', { p_stage_number: stageNumber });
-
-      if (error || !Array.isArray(data) || data.length === 0) {
-        this._logger.warn(`[SAE] canAutoAdvance(${stageNumber}): RPC failed — ${error?.message || 'no rows'}, defaulting to block`);
-        return false;
-      }
-
-      const { can, reason, layer } = data[0];
-
-      // Preserve [SAE] log contract — REGRESSION REG-7
-      if (can) {
-        this._logger.log(`[SAE] canAutoAdvance(${stageNumber}): approved — all governance layers passed`);
-      } else {
-        const reasonLabel = {
-          global_off: 'global_auto_proceed=false',
-          kill_promotion_gate: 'kill/promotion gate (stage_config)',
-          explicit_pause: 'stage_override.auto_proceed=false',
-          review_default_pause: 'review-mode default-pause (no explicit opt-in)',
-          config_missing: 'config query failed',
-          stage_not_found: 'stage not found in stage_config',
-        }[reason] || `unknown (${reason})`;
-        this._logger.log(`[SAE] canAutoAdvance(${stageNumber}): blocked — ${reasonLabel} [layer=${layer}]`);
-      }
-
-      return !!can;
-    } catch (err) {
-      this._logger.warn(`[SAE] canAutoAdvance threw: ${err.message}`);
-      return false;
-    }
+    // SD-LEO-INFRA-RUN-STAGE-ENGINE-GATE-AUTONOMY-001: delegate to the ONE shared predicate so the
+    // worker and the engine path can never diverge (divergence was the root of the S10 hard-gate
+    // bypass). The shared helper carries this method's exact body — the [SAE] log contract (REG-7) +
+    // default-block-on-error behavior are preserved byte-for-byte.
+    return canAutoAdvance({ supabase: this._supabase, stageNumber, logger: this._logger });
   }
 
   /**

--- a/tests/unit/eva/governance/can-auto-advance.test.js
+++ b/tests/unit/eva/governance/can-auto-advance.test.js
@@ -1,0 +1,52 @@
+/**
+ * SD-LEO-INFRA-RUN-STAGE-ENGINE-GATE-AUTONOMY-001 — the ONE shared gate-eligibility predicate.
+ * Both the worker (_canAutoAdvance) and the engine (executeStage) delegate here, so the engine can
+ * no longer auto-approve review + HARD gates via a hardcoded checkAutonomy('stage_gate') call. The
+ * predicate wraps the can_auto_advance RPC and DEFAULTS TO BLOCK on any error.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { canAutoAdvance } from '../../../../lib/eva/governance/can-auto-advance.js';
+
+function sb(rpcResult) {
+  return { rpc: vi.fn(async () => rpcResult) };
+}
+const quietLogger = { log: () => {}, warn: () => {} };
+
+describe('canAutoAdvance — shared predicate over can_auto_advance RPC', () => {
+  it('returns true when the RPC verdict is can=true', async () => {
+    const supabase = sb({ data: [{ can: true, reason: null, layer: 0 }], error: null });
+    expect(await canAutoAdvance({ supabase, stageNumber: 5, logger: quietLogger })).toBe(true);
+    expect(supabase.rpc).toHaveBeenCalledWith('can_auto_advance', { p_stage_number: 5 });
+  });
+
+  it('returns false (HOLD) when the RPC verdict is can=false (review/hard/kill/promotion)', async () => {
+    for (const reason of ['review_default_pause', 'kill_promotion_gate', 'global_off', 'explicit_pause']) {
+      const supabase = sb({ data: [{ can: false, reason, layer: 1 }], error: null });
+      expect(await canAutoAdvance({ supabase, stageNumber: 10, logger: quietLogger }), reason).toBe(false);
+    }
+  });
+
+  it('DEFAULT-BLOCK on RPC error', async () => {
+    const supabase = sb({ data: null, error: { message: 'boom' } });
+    expect(await canAutoAdvance({ supabase, stageNumber: 8, logger: quietLogger })).toBe(false);
+  });
+
+  it('DEFAULT-BLOCK on empty rows', async () => {
+    const supabase = sb({ data: [], error: null });
+    expect(await canAutoAdvance({ supabase, stageNumber: 8, logger: quietLogger })).toBe(false);
+  });
+
+  it('DEFAULT-BLOCK when the RPC throws', async () => {
+    const supabase = { rpc: vi.fn(async () => { throw new Error('network'); }) };
+    expect(await canAutoAdvance({ supabase, stageNumber: 8, logger: quietLogger })).toBe(false);
+  });
+
+  it('preserves the [SAE] log contract (REG-7) on both verdicts', async () => {
+    const logs = [];
+    const logger = { log: (m) => logs.push(m), warn: (m) => logs.push(m) };
+    await canAutoAdvance({ supabase: sb({ data: [{ can: true }], error: null }), stageNumber: 3, logger });
+    await canAutoAdvance({ supabase: sb({ data: [{ can: false, reason: 'review_default_pause', layer: 4 }], error: null }), stageNumber: 8, logger });
+    expect(logs.some((m) => /\[SAE\] canAutoAdvance\(3\): approved/.test(m))).toBe(true);
+    expect(logs.some((m) => /\[SAE\] canAutoAdvance\(8\): blocked — review-mode default-pause/.test(m))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the **S10 hard-gate bypass** on the engine path. `stage-execution-engine.js executeStage` decided the chairman gate via `checkAutonomy(ventureId, 'stage_gate', {supabase})` — **gateType hardcoded, stageNumber omitted** — so it **auto-approved review + HARD gates** regardless of `global_auto_proceed` / kill-promotion / review-default-pause / the hard-gate set. The worker path already uses the unified 4-layer predicate (the `can_auto_advance` SECURITY-DEFINER RPC) via `_canAutoAdvance(stage)`.

## Fix — one shared predicate (divergence was the root)
- **`lib/eva/governance/can-auto-advance.js`** — the worker's `_canAutoAdvance` wrapper extracted verbatim: `canAutoAdvance({supabase, stageNumber, logger})`, calls the RPC, **DEFAULT-BLOCKs on any error**, preserves the `[SAE]` log contract (REG-7).
- **engine `executeStage`** — replace `checkAutonomy('stage_gate')` with `canAutoAdvance({supabase, stageNumber, logger})` using the **real** `stageNumber`; auto-approve **only** on a true verdict, else **HOLD** (`waitForDecision`). Dead `checkAutonomy` import removed.
- **worker `_canAutoAdvance`** — delegate to the shared helper; no parallel RPC call remains → engine + worker verdicts are **identical** for the same `(venture, stage)`.

## Test plan
- `tests/unit/eva/governance/can-auto-advance.test.js` (6) — true / false (review/hard/kill/promotion) / RPC-error→block / empty-rows→block / throw→block / `[SAE]` log contract
- Existing `tests/unit/eva/worker-can-auto-advance.test.js` stays **green after delegation** (18/18 with the new suite)

## Known pre-existing failure (NOT this change)
`tests/integration/eva/can-auto-advance-equivalence.test.js` has 3 `|db|` failures — the live `can_auto_advance` **RPC** `reason`/`layer` drifted from the frozen snapshot for S8/S11/S16. This PR touches only the JS layer (a wrapper + two call sites); the RPC and the snapshot are **untouched**, so the drift is independent of this change.

SD: SD-LEO-INFRA-RUN-STAGE-ENGINE-GATE-AUTONOMY-001 (the engine-side corollary to SD-LEO-INFRA-RESTART-RESPECTS-DAEMON-DOWN-WALK-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)