### PR TITLE
feat(SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001): fix #5226 PS-encoding + inert walk-mode skip

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-MIGRATION-READINESS-CHAIRMAN-GATED-EXEMPT-001",
-  "createdAt": "2026-06-28T21:09:37.336Z",
+  "sdKey": "SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001",
+  "createdAt": "2026-06-29T00:27:29.956Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/leo-stack/walk-mode.cjs
+++ b/lib/leo-stack/walk-mode.cjs
@@ -73,7 +73,10 @@ function skipWorkerIds(repoRoot = process.cwd()) {
   if (!isWalkModeActive(repoRoot)) return [];
   return readWorkerRegistry(repoRoot)
     .filter((w) => isEvaStageWorker(w))
-    .map((w) => String(w.id || w.name || w.display_name || '').trim())
+    // SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001 FR-2: prefer `name` — config/workers.json
+    // has no `id` field, and the leo-stack.ps1/.sh consumers compare against worker.name. Keeping the
+    // helper output and the comparison key on the SAME field is what makes the skip actually fire.
+    .map((w) => String(w.name || w.id || w.display_name || '').trim())
     .filter(Boolean);
 }
 

--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -78,7 +78,7 @@ function Write-Log {
 # Function to check if port is in use
 function Test-PortInUse {
     param([int]$Port)
-    # Only check Listen state — TimeWait/CloseWait are stale sockets that will clear on their own
+    # Only check Listen state - TimeWait/CloseWait are stale sockets that will clear on their own
     $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
     return $null -ne $connection
 }
@@ -208,7 +208,7 @@ function Start-App {
         }
     }
 
-    # No auto git-pull here — keeps parity with leo-stack.sh and avoids clobbering peer-worktree state.
+    # No auto git-pull here - keeps parity with leo-stack.sh and avoids clobbering peer-worktree state.
 
     # Auto-install if node_modules missing (fleet ops can clobber them)
     $viteBin = Join-Path $AppDir "node_modules\.bin\vite.cmd"
@@ -280,12 +280,16 @@ function Start-Workers {
             $skipWorkerIds = @()
         }
         # FAIL-CLOSED for the daemon set: a present sentinel + a helper that returned nothing must NOT
-        # silently revive the daemon — fall back to the EVA regex and skip all of them.
+        # silently revive the daemon - fall back to the EVA regex and skip all of them.
+        # SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001 FR-2: match on $_.name (config/workers.json
+        # has NO `id` field) so the skip set agrees with walk-mode.cjs skipWorkerIds, which emits name.
         if ($skipWorkerIds.Count -eq 0) {
             $evaRe = 'stage-zero-queue-processor|start-stage-worker|stage-execution-worker|eva-master-scheduler|subagent-worker|lib[\\/]eva[\\/]workers'
-            $skipWorkerIds = @($workers | Where-Object { ($_.command -match $evaRe) -or ($_.id -match $evaRe) } | ForEach-Object { $_.id })
+            $skipWorkerIds = @($workers | Where-Object { ($_.command -match $evaRe) -or ($_.name -match $evaRe) } | ForEach-Object { $_.name })
         }
-        Write-Log "WARN" "[WALK-MODE] Daemon-down controlled walk active (.leo-stack-walk-mode) — leaving EVA stage workers STOPPED. Remove the sentinel + restart to resume the daemon." "Yellow"
+        # FR-4: the canonical controlled walk is daemon-UP + global_auto_proceed=false (the worker honors
+        # the flag); this sentinel is the restart-time backstop that keeps the EVA daemon set STOPPED.
+        Write-Log "WARN" "[WALK-MODE] Daemon-down controlled walk active (.leo-stack-walk-mode) - holding EVA stage workers STOPPED. Remove the sentinel + restart to resume the daemon." "Yellow"
     }
 
     Write-Log "INFO" "[WORKERS] Starting enabled workers..." "Blue"
@@ -293,8 +297,8 @@ function Start-Workers {
     foreach ($worker in $workers) {
         if (-not $worker.enabled) { continue }
 
-        if ($walkActive -and ($skipWorkerIds -contains $worker.id)) {
-            Write-Log "WARN" "[WALK-MODE] Skipping $($worker.display_name) — daemon-down controlled walk." "Yellow"
+        if ($walkActive -and ($skipWorkerIds -contains $worker.name)) {
+            Write-Log "WARN" "[WALK-MODE] Skipping $($worker.display_name) - daemon-down controlled walk." "Yellow"
             continue
         }
 
@@ -352,7 +356,7 @@ function Stop-Workers {
 
     # SD-LEO-INFRA-REVIVE-EVA-HOST-AND-ARM-001 FR-5: when the EVA scheduler is hosted as a
     # registered Windows scheduled task ('EHG EVA Scheduler Watcher'), the watcher cron owns the
-    # daemon's lifecycle — a leo-stack stop/restart must NOT reap it as an orphan (doing so kills
+    # daemon's lifecycle - a leo-stack stop/restart must NOT reap it as an orphan (doing so kills
     # the deliberately-hosted daemon every restart; the watcher would revive it within 5 min, but
     # that is churn, not correctness). On hosts WITHOUT the task, a stray eva-master-scheduler is a
     # genuine session orphan and is still swept. schtasks /Query exits 0 iff the task exists.
@@ -411,7 +415,7 @@ function Stop-Server {
             $process = Get-Process -Id $pidValue -ErrorAction SilentlyContinue
             if ($process) {
                 Write-Log "INFO" "Stopping $Name (PID: $pidValue)..." "Yellow"
-                # Use taskkill /T to kill entire process tree (cmd → node supervisor → forked child)
+                # Use taskkill /T to kill entire process tree (cmd -> node supervisor -> forked child)
                 # Stop-Process only kills the target PID; child processes become orphans on Windows
                 $taskKillResult = & taskkill /T /F /PID $pidValue 2>&1
                 Write-Log "INFO" "   taskkill: $taskKillResult" "Gray"
@@ -558,13 +562,13 @@ function Test-StackHealth {
     }
 }
 
-# Git freshness — ensure a repo serves the latest origin/main before the server
+# Git freshness - ensure a repo serves the latest origin/main before the server
 # starts. leo-stack restart restarts the *processes* but historically never pulled,
 # so the dev servers served whatever the local working tree happened to be on. That
 # is why merged work could be invisible in the running app (e.g. CronLinter showed
 # the retired Stage-19 build-method UI because the ehg tree was behind the commit
 # that removed it). Fast-forward only when safely on a clean `main`; otherwise warn
-# and serve local — never clobber a feature branch or uncommitted work. Opt out via
+# and serve local - never clobber a feature branch or uncommitted work. Opt out via
 # LEO_STACK_NO_PULL=1.
 function Sync-Repo {
     param([string]$Dir, [string]$Name)
@@ -585,16 +589,16 @@ function Sync-Repo {
         }
         # Only pull a genuinely-idle primary tree. Three layers:
         #  (1) skip if there are uncommitted *tracked* changes beyond the auto-churn
-        #      safelist (.claude/.protocol-sync) — protects a session actively editing
+        #      safelist (.claude/.protocol-sync) - protects a session actively editing
         #      in the primary tree, without the safelisted file blocking every pull.
         #      Untracked files are ignored: ff-only can't harm them and the tree
         #      always carries many (scripts/one-off/, etc.).
-        #  (2) skip if another live Claude Code session is on this branch — a clean
+        #  (2) skip if another live Claude Code session is on this branch - a clean
         #      tree can still have a session reading/about-to-edit it, and ff-merge
         #      rewrites tracked files under it (the concurrent-session corruption
         #      class). safe-to-pull-tree.mjs prints BUSY/IDLE; key on the token so a
         #      crash/missing-creds prints neither and fails OPEN to ff-only safety.
-        #  (3) `merge --ff-only` as the backstop — never clobbers; aborts on conflict.
+        #  (3) `merge --ff-only` as the backstop - never clobbers; aborts on conflict.
         git fetch origin main --quiet 2>$null
         $behind = (git rev-list --count HEAD..origin/main 2>$null)
         if (-not ($behind -match '^\d+$' -and [int]$behind -gt 0)) {

--- a/scripts/leo-stack.sh
+++ b/scripts/leo-stack.sh
@@ -227,11 +227,15 @@ start_workers() {
         walk_active=1
         skip_ids=$(node "$ENGINEER_DIR/lib/leo-stack/walk-mode.cjs" skip-ids 2>/dev/null || true)
         # FAIL-CLOSED for the daemon set: a present sentinel + empty helper output must NOT revive
-        # the daemon — fall back to the EVA regex over the registry.
+        # the daemon - fall back to the EVA regex over the registry.
+        # SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001 FR-2: match/emit w.name (config/workers.json
+        # has NO id field) so this agrees with walk-mode.cjs skipWorkerIds, which emits name.
         if [ -z "$skip_ids" ]; then
-            skip_ids=$(get_workers | while IFS= read -r wj; do node -e 'const w=JSON.parse(process.argv[1]); const re=/stage-zero-queue-processor|start-stage-worker|stage-execution-worker|eva-master-scheduler|subagent-worker|lib[\\/]eva[\\/]workers/; if(re.test(w.command||"")||re.test(w.id||"")) console.log(w.id)' "$wj"; done)
+            skip_ids=$(get_workers | while IFS= read -r wj; do node -e 'const w=JSON.parse(process.argv[1]); const re=/stage-zero-queue-processor|start-stage-worker|stage-execution-worker|eva-master-scheduler|subagent-worker|lib[\\/]eva[\\/]workers/; if(re.test(w.command||"")||re.test(w.name||"")) console.log(w.name)' "$wj"; done)
         fi
-        log "WARN" "${YELLOW}[WALK-MODE] Daemon-down controlled walk active (.leo-stack-walk-mode) — leaving EVA stage workers STOPPED. Remove the sentinel + restart to resume the daemon.${NC}"
+        # FR-4: canonical controlled walk is daemon-UP + global_auto_proceed=false; this sentinel is the
+        # restart-time backstop that holds the EVA daemon set STOPPED.
+        log "WARN" "${YELLOW}[WALK-MODE] Daemon-down controlled walk active (.leo-stack-walk-mode) - holding EVA stage workers STOPPED. Remove the sentinel + restart to resume the daemon.${NC}"
     fi
 
     log "INFO" "${BLUE}[WORKERS] Starting enabled workers...${NC}"
@@ -240,7 +244,7 @@ start_workers() {
         local enabled=$(node -e "console.log(JSON.parse(process.argv[1]).enabled)" "$worker_json")
         if [ "$enabled" != "true" ]; then continue; fi
 
-        local wid=$(node -e "console.log(JSON.parse(process.argv[1]).id || '')" "$worker_json")
+        local wid=$(node -e "console.log(JSON.parse(process.argv[1]).name || '')" "$worker_json")
         if [ "$walk_active" = "1" ] && printf '%s\n' "$skip_ids" | grep -qxF "$wid"; then
             log "WARN" "${YELLOW}[WALK-MODE] Skipping $wid — daemon-down controlled walk.${NC}"
             continue

--- a/tests/unit/leo-stack/leo-stack-script-integrity.test.js
+++ b/tests/unit/leo-stack/leo-stack-script-integrity.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001 FR-3.
+ *
+ * #5226 shipped a PowerShell parse-breaking glyph because the PR validated ONLY leo-stack.sh
+ * (bash -n) and never parsed leo-stack.ps1 — so the em-dash that takes the whole stack down on
+ * Windows PowerShell 5.1 (no-BOM file -> CP1252 -> runaway string) shipped undetected.
+ *
+ * This closes that gap with a guard that runs on ANY CI runner:
+ *  - TS-1 (deterministic, primary): scripts/leo-stack.ps1 is ASCII-only. This is the reliable guard
+ *    for the encoding class — pwsh 7 on ubuntu defaults to UTF-8 and would NOT reproduce the WinPS-5.1
+ *    CP1252 break, so a parse-only check could pass while the file is still broken on Windows.
+ *  - TS-2 (best-effort): when pwsh is on PATH, parse leo-stack.ps1 with the PowerShell language parser
+ *    and assert zero parse errors. Skipped (logged) when pwsh is absent.
+ *  - TS-3 (best-effort): when bash is on PATH, `bash -n scripts/leo-stack.sh`. Skipped when absent.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const PS1 = join(REPO_ROOT, 'scripts', 'leo-stack.ps1');
+const SH = join(REPO_ROOT, 'scripts', 'leo-stack.sh');
+
+function onPath(cmd) {
+  const probe = spawnSync(cmd, ['--version'], { encoding: 'utf8' });
+  return !probe.error;
+}
+
+describe('leo-stack.ps1 ASCII safety (FR-1/FR-3 guard)', () => {
+  it('TS-1: contains no non-ASCII byte (prevents the WinPS-5.1 CP1252 parse break)', () => {
+    const buf = readFileSync(PS1);
+    const offenders = [];
+    for (let i = 0; i < buf.length; i++) {
+      if (buf[i] > 0x7f) {
+        offenders.push(`byte 0x${buf[i].toString(16)} at offset ${i}`);
+        if (offenders.length >= 5) break;
+      }
+    }
+    expect(offenders, `leo-stack.ps1 must be ASCII-only; found: ${offenders.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('leo-stack.ps1 PowerShell parse (FR-3, best-effort)', () => {
+  it('TS-2: parses with no errors under pwsh when available', () => {
+    if (!onPath('pwsh')) {
+      console.log('[skip] pwsh not on PATH — ASCII guard (TS-1) still enforces the encoding class');
+      return;
+    }
+    const script = `$errors = $null; [void][System.Management.Automation.Language.Parser]::ParseFile('${PS1.replace(/\\/g, '\\\\')}', [ref]$null, [ref]$errors); if ($errors -and $errors.Count -gt 0) { $errors | ForEach-Object { Write-Output $_.Message }; exit 3 } else { exit 0 }`;
+    const r = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-Command', script], { encoding: 'utf8' });
+    expect(r.status, `pwsh parse errors:\n${r.stdout || ''}${r.stderr || ''}`).toBe(0);
+  });
+});
+
+describe('leo-stack.sh bash syntax (FR-3, best-effort)', () => {
+  it('TS-3: passes `bash -n` when bash is available', () => {
+    if (!onPath('bash')) {
+      console.log('[skip] bash not on PATH');
+      return;
+    }
+    const r = spawnSync('bash', ['-n', SH], { encoding: 'utf8' });
+    expect(r.status, `bash -n errors:\n${r.stderr || ''}`).toBe(0);
+  });
+});

--- a/tests/unit/leo-stack/walk-mode.test.js
+++ b/tests/unit/leo-stack/walk-mode.test.js
@@ -48,11 +48,15 @@ describe('isWalkModeActive + skipWorkerIds — sentinel-driven', () => {
   beforeEach(() => {
     tmp = fs.mkdtempSync(join(os.tmpdir(), 'walkmode-'));
     fs.mkdirSync(join(tmp, 'config'));
+    // SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001 FR-2: the REAL config/workers.json keys on
+    // `name` (there is NO `id` field). The prior fixture used `id:`, which made skipWorkerIds return the
+    // id and hid that the leo-stack.ps1/.sh consumers compared the non-existent worker.id (the skip was
+    // inert in production while this test stayed green). Mirror the production schema here.
     fs.writeFileSync(join(tmp, 'config', 'workers.json'), JSON.stringify([
-      { id: 'stage-zero-processor', command: 'node scripts/stage-zero-queue-processor.js', enabled: true },
-      { id: 'stage-execution-worker', command: 'node scripts/start-stage-worker.js', enabled: true },
-      { id: 'eva-master-scheduler', command: 'node lib/eva/eva-master-scheduler.js', enabled: false },
-      { id: 'web-server', command: 'node server.js', enabled: true },
+      { name: 'stage-zero-processor', command: 'node scripts/stage-zero-queue-processor.js', enabled: true },
+      { name: 'stage-execution-worker', command: 'node scripts/start-stage-worker.js', enabled: true },
+      { name: 'eva-master-scheduler', command: 'node lib/eva/eva-master-scheduler.js', enabled: false },
+      { name: 'web-server', command: 'node server.js', enabled: true },
     ]));
   });
   afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });


### PR DESCRIPTION
## Summary
leo-stack is the canonical control plane (web servers + EVA stage-execution daemon). PR #5226 shipped two defects — both because it validated only `leo-stack.sh` (`bash -n`) and **never parsed the PowerShell script**.

## Defects fixed
- **FR-1 (stack hard-down on Windows):** a UTF-8 em-dash (U+2014) inside a double-quoted WARN string in `scripts/leo-stack.ps1`. On a no-BOM file Windows PowerShell 5.1 decodes CP1252, turning it into a runaway string that ate the following lines' braces (PSParser jumped L287}->L299}) — a parse error that took the **entire stack + EVA daemon down** (no start/restart/status). Fixed: `leo-stack.ps1` is now **ASCII-only** (em-dash/arrow -> ASCII). Verified it parses under real Windows PowerShell 5.1 (PSParser, 0 errors, 0 non-ASCII bytes).
- **FR-2 (walk-mode skip inert):** `lib/leo-stack/walk-mode.cjs` emits each EVA worker's **name** (`config/workers.json` has **no `id`** field), but `leo-stack.ps1` (L286/L296) and `leo-stack.sh` (L232/L243) compared the non-existent `worker.id` (null) — so the skip **never matched** and the EVA workers started anyway after logging "leaving stopped" (false confidence). Fixed: align all three on `worker.name`. Also fixed the **false-green** `walk-mode.test.js` fixture (used `id:`; real schema is `name:`) so the test now exercises the production contract.
- **FR-3 (CI gap):** new `tests/unit/leo-stack/leo-stack-script-integrity.test.js` — asserts `leo-stack.ps1` is ASCII-only (deterministic, runner-agnostic guard; pwsh-7-on-ubuntu would *not* reproduce the WinPS-5.1 CP1252 break) + best-effort `pwsh` parse + `bash -n`. Closes the "never parsed the PS script" gap.
- **FR-4:** accurate WALK-MODE WARN + a note that the canonical controlled walk is daemon-UP + `global_auto_proceed=false`; the now-reliable sentinel is the restart-time backstop.

## Verification
- 9/9 unit tests pass (`tests/unit/leo-stack/`); `leo-stack.ps1` parses under WinPS 5.1 (0 errors); 0 non-ASCII bytes.
- testing-agent **PASS** (row 5db925a5); retro PUBLISHED 100/100 (42c85d1c).

## Scope
5 files, cohesive #5226-regression fix. No schema change. Co-authored with the coordinator (owns leo-stack + the EVA daemon lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)