### PR TITLE
feat(SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001): fix S12 GTM artifact-type mispersist + gate rationale + 12->13 boundary

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-LEO-STACK-PS-ENCODING-WALKMODE-FIX-001",
-  "createdAt": "2026-06-29T00:27:29.956Z",
+  "sdKey": "SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001",
+  "createdAt": "2026-06-29T00:49:34.954Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/gate-failure-recovery.js
+++ b/lib/eva/gate-failure-recovery.js
@@ -17,6 +17,28 @@ import { REASON_CODES } from './reality-gates.js';
 
 const MAX_RETRIES = 3;
 
+/**
+ * SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001 FR-2: serialize the structured `reasons` for a
+ * human-readable escalation rationale. `reasons` is an array of objects (e.g.
+ * { code, message, artifact_type, actual, required }); a bare `.join('; ')` stringified each object
+ * to '[object Object]', losing the real failure detail. Prefer message, then code, then a JSON dump;
+ * tolerate plain-string reasons too.
+ * @param {Array<{code?: string, message?: string}|string>} reasons
+ * @returns {string}
+ */
+export function formatReasons(reasons) {
+  if (!Array.isArray(reasons) || reasons.length === 0) return '(no reasons provided)';
+  return reasons
+    .map((r) => {
+      if (r == null) return 'unknown';
+      if (typeof r === 'string') return r;
+      if (r.message) return r.code ? `${r.code}: ${r.message}` : r.message;
+      if (r.code) return r.code;
+      try { return JSON.stringify(r); } catch { return String(r); }
+    })
+    .join('; ');
+}
+
 // US-001: Severity classification mapping
 const CRITICAL_REASON_CODES = new Set([
   REASON_CODES.ARTIFACT_MISSING,
@@ -207,7 +229,7 @@ export async function routeGateOutcome(ventureId, severity, context, deps) {
         decision: 'pending',
         status: 'pending',
         decision_type: 'gate_failure_escalation',  // SD-MAN-FIX-FIX-NULL-DECISION-001: was missing, caused NULL
-        rationale: `Gate failure escalation (${severity}): ${(reasons || []).join('; ')}`,
+        rationale: `Gate failure escalation (${severity}): ${formatReasons(reasons)}`,
         dfe_context: {
           source: 'gate_failure_recovery',
           decision_type: 'gate_failure_escalation',

--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -131,10 +131,16 @@ const BOUNDARY_CONFIG = Object.freeze({
   // Both gates must pass for the phase transition to succeed.
   '12->13': {
     description: 'IDENTITY → BLUEPRINT',
+    // SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001 FR-3: align this hardcoded fallback with the
+    // canonical DB gate_boundary_config['12->13'] row. The prior fallback demanded S14 blueprint
+    // artifacts (technical_architecture / project_plan) that don't exist at this boundary AND omitted
+    // identity_gtm_sales_strategy entirely — so when the DB row was unavailable the gate let a venture
+    // advance to 13 WITHOUT its S12 GTM artifact (the non-determinism in FR-3). Required set = the S12
+    // GTM strategy + the upstream re-verifications (business-model canvas + persona/brand).
     required_artifacts: [
       { artifact_type: ARTIFACT_TYPES.ENGINE_BUSINESS_MODEL_CANVAS, min_quality_score: 0.7, url_verification_required: false },
-      { artifact_type: ARTIFACT_TYPES.BLUEPRINT_TECHNICAL_ARCHITECTURE, min_quality_score: 0.6, url_verification_required: false },
-      { artifact_type: ARTIFACT_TYPES.BLUEPRINT_PROJECT_PLAN, min_quality_score: 0.5, url_verification_required: false },
+      { artifact_type: ARTIFACT_TYPES.IDENTITY_PERSONA_BRAND, min_quality_score: 0.5, url_verification_required: false },
+      { artifact_type: ARTIFACT_TYPES.IDENTITY_GTM_SALES_STRATEGY, min_quality_score: 0.6, url_verification_required: false },
     ],
   },
   '17->18': {

--- a/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
@@ -387,7 +387,7 @@ Output ONLY valid JSON.`;
   // QF-20260420-405: Removed direct writeArtifact call — orchestrator's persistArtifacts is the sole writer
   // (was dual-writing identity_gtm_sales_strategy, creating duplicate rows in venture_artifacts)
 
-  return {
+  const stage12Output = {
     marketTiers,
     channels,
     salesModel,
@@ -404,6 +404,20 @@ Output ONLY valid JSON.`;
     gtm_motion_provenance,
     operating_model_grounded: !gtm_paid_led,
     fourBuckets, usage, llmFallbackCount,
+  };
+
+  // SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001 FR-1: emit a TYPED artifact so the orchestrator
+  // persists this GTM/sales output deterministically as 'identity_gtm_sales_strategy'. Returning a
+  // typed `artifacts[]` sets stepProvidedTypedArtifacts=true in the orchestrator, which bypasses BOTH
+  // the requiredArtifacts[0] fallback (eva-orchestrator.js:513) and the multi-artifact relabel
+  // (eva-orchestrator.js:588-618). Without this, since venture_stages.required_artifacts[12][0] is the
+  // S10-deposited 'identity_brand_guidelines', the GTM output was mislabeled as brand_guidelines
+  // (a temporal regression after the 2026-06-10 STAGE-CONTRACT-REGISTRY repoint). The flat fields are
+  // ALSO returned (spread) for backward-compat with direct readers + existing unit tests; the
+  // orchestrator's mergeArtifactOutputs flattens the payload back into stageOutput either way.
+  return {
+    artifacts: [{ artifactType: 'identity_gtm_sales_strategy', payload: stage12Output, source: 'stage-12' }],
+    ...stage12Output,
   };
 }
 

--- a/tests/unit/eva/stage-12-artifact-type.test.js
+++ b/tests/unit/eva/stage-12-artifact-type.test.js
@@ -1,0 +1,114 @@
+/**
+ * SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001
+ *
+ * FR-1: analyzeStage12 must emit a TYPED artifact (identity_gtm_sales_strategy) so the orchestrator
+ *       persists the GTM output deterministically and never falls back to venture_stages
+ *       .required_artifacts[12][0] = 'identity_brand_guidelines'. Flat fields stay for back-compat.
+ * FR-2: gate-failure-recovery formatReasons serializes structured reasons (no '[object Object]').
+ * FR-3: the hardcoded reality-gates '12->13' fallback requires identity_gtm_sales_strategy (and no
+ *       longer demands the S14 blueprint artifacts), matching the canonical DB gate_boundary_config.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const h = vi.hoisted(() => ({ resp: {} }));
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({ complete: async () => ({ content: JSON.stringify(h.resp) }) }),
+}));
+vi.mock('../../../lib/eva/stage-templates/utils/web-search.js', () => ({
+  isSearchEnabled: () => false, searchBatch: async () => [], formatResultsForPrompt: () => '',
+}));
+
+import { analyzeStage12 } from '../../../lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js';
+import { formatReasons } from '../../../lib/eva/gate-failure-recovery.js';
+
+const silent = { log: () => {}, warn: () => {}, error: () => {} };
+const PARAMS = {
+  stage1Data: { description: 'self-serve analytics SaaS', targetMarket: 'SMBs', problemStatement: 'x' },
+  stage10Data: { customerPersonas: [{ name: 'SMB Owner', segment: 'SMB' }] },
+  stage11Data: { brandName: 'Acme' },
+  logger: silent,
+};
+const channels = Array.from({ length: 8 }, (_, i) => ({ name: `Organic ${i}`, channelType: 'organic', primaryTier: 'T1', monthly_budget: 0, expected_cac: 0, primary_kpi: 'signups' }));
+function run() {
+  h.resp = { marketTiers: [{ name: 'T1' }], channels, salesModel: 'self-serve', funnelStages: [], dealStages: [], customerJourney: [] };
+  return analyzeStage12(PARAMS);
+}
+
+// ── FR-1 ─────────────────────────────────────────────────────────────────────
+describe('FR-1: analyzeStage12 emits a typed identity_gtm_sales_strategy artifact', () => {
+  it('returns a typed artifacts[] entry with the canonical S12 type', async () => {
+    const r = await run();
+    expect(Array.isArray(r.artifacts)).toBe(true);
+    expect(r.artifacts).toHaveLength(1);
+    expect(r.artifacts[0].artifactType).toBe('identity_gtm_sales_strategy');
+    // never the S10-deposited brand type
+    expect(r.artifacts[0].artifactType).not.toBe('identity_brand_guidelines');
+  });
+
+  it('the typed payload carries the GTM data (so mergeArtifactOutputs flattens it back)', async () => {
+    const r = await run();
+    expect(r.artifacts[0].payload).toBeTruthy();
+    expect(r.artifacts[0].payload.marketTiers).toBeTruthy();
+    expect(r.artifacts[0].payload.channels).toBeTruthy();
+  });
+
+  it('preserves the flat top-level fields for back-compat with direct readers/tests', async () => {
+    const r = await run();
+    // these are read directly by existing tests (e.g. stage12-operating-model-grounding)
+    expect(r.marketTiers).toBeTruthy();
+    expect(r.channels).toBeTruthy();
+    expect(typeof r.operating_model_grounded).toBe('boolean');
+    expect(r.reality_gate).toBeTruthy();
+  });
+});
+
+// ── FR-2 ─────────────────────────────────────────────────────────────────────
+describe('FR-2: formatReasons serializes structured reasons (no [object Object])', () => {
+  it('renders code: message for structured reason objects', () => {
+    const out = formatReasons([{ code: 'ARTIFACT_MISSING', message: 'identity_gtm_sales_strategy not found' }]);
+    expect(out).toBe('ARTIFACT_MISSING: identity_gtm_sales_strategy not found');
+    expect(out).not.toContain('[object Object]');
+  });
+  it('joins multiple reasons and tolerates plain strings + code-only + null', () => {
+    const out = formatReasons([
+      { code: 'A', message: 'first' },
+      'a plain string reason',
+      { code: 'CODE_ONLY' },
+      null,
+    ]);
+    expect(out).toBe('A: first; a plain string reason; CODE_ONLY; unknown');
+    expect(out).not.toContain('[object Object]');
+  });
+  it('handles empty / non-array input', () => {
+    expect(formatReasons([])).toBe('(no reasons provided)');
+    expect(formatReasons(undefined)).toBe('(no reasons provided)');
+  });
+  it('falls back to JSON for an object with neither message nor code', () => {
+    expect(formatReasons([{ artifact_type: 'x', actual: 1 }])).toContain('"artifact_type"');
+  });
+});
+
+// ── FR-3 ─────────────────────────────────────────────────────────────────────
+describe('FR-3: reality-gates 12->13 fallback requires the GTM artifact', () => {
+  const src = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '../../../lib/eva/reality-gates.js'),
+    'utf8',
+  );
+  // isolate the '12->13' BOUNDARY_CONFIG block
+  const block = src.slice(src.indexOf("'12->13'"), src.indexOf("'17->18'"));
+
+  it('includes IDENTITY_GTM_SALES_STRATEGY', () => {
+    expect(block).toMatch(/IDENTITY_GTM_SALES_STRATEGY/);
+  });
+  it('no longer demands the S14 blueprint artifacts at this boundary', () => {
+    expect(block).not.toMatch(/BLUEPRINT_TECHNICAL_ARCHITECTURE/);
+    expect(block).not.toMatch(/BLUEPRINT_PROJECT_PLAN/);
+  });
+  it('re-verifies the upstream business-model + persona/brand artifacts', () => {
+    expect(block).toMatch(/ENGINE_BUSINESS_MODEL_CANVAS/);
+    expect(block).toMatch(/IDENTITY_PERSONA_BRAND/);
+  });
+});


### PR DESCRIPTION
## Summary
Stage 12's GTM output intermittently persisted as `identity_brand_guidelines` (an S10 type) instead of `identity_gtm_sales_strategy`, failing the 12->13 boundary; the escalation rationale rendered `[object Object]`; and the boundary was non-deterministic.

## Root cause (RCA, confidence 0.95, live-DB evidence)
TRUE mispersist, not a collision. `analyzeStage12` returned an **untyped** payload, so the orchestrator resolved the persist type from `venture_stages.required_artifacts[12][0] = identity_brand_guidelines` (the type the S10 worker **deposits** at lifecycle_stage 12 per SD-LEO-FIX-FIX-S10-WORKER-001) and the multi-artifact relabel forced it. Clean temporal regression: correct persists predate the 2026-06-10 STAGE-CONTRACT-REGISTRY repoint; wrong ones postdate it.

## Fixes
- **FR-1** `stage-12-gtm-sales.js`: `analyzeStage12` now emits a **typed** artifact `{ artifactType: 'identity_gtm_sales_strategy', payload, source }`, setting `stepProvidedTypedArtifacts=true` which bypasses both the `requiredArtifacts[0]` fallback (orchestrator:513) and the relabel (:588-618). Flat fields kept for back-compat (`mergeArtifactOutputs` flattens the payload either way).
- **FR-2** `gate-failure-recovery.js`: new `formatReasons()` serializes structured `{code,message}` reasons — no more `[object Object]`.
- **FR-3** `reality-gates.js`: hardcoded `12->13` fallback aligned to the canonical DB `gate_boundary_config` (require `identity_gtm_sales_strategy` + business-model canvas + persona/brand; dropped the wrong S14 blueprint artifacts that let a venture advance without the GTM artifact).
- **Corrective data repair** (sanctioned, one-off): re-typed 2 live mislabeled rows (`87c98db2`, `5b8ee0cc`) to `identity_gtm_sales_strategy` + restored the S10 brand-genome rows to `is_current`.

## Verification
- 10 new unit tests + 65 regression green; testing-agent **PASS** (8e895484); retro PUBLISHED 100/100 (8d629537).

## Follow-up flagged (not regressed here)
The S10 worker deposits the brand genome at `lifecycleStage=12` citing a non-existent `lifecycle_stage_config` row; canonically `identity_brand_guidelines` is an S10 type. Recommend a follow-up SD to relocate it to stage 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)