### PR TITLE
feat(SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001): stage 15 persists canonical user-story pack + wireframes

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001.json
@@ -1,0 +1,94 @@
+{
+  "executive_summary": "Stage 15 (Design Studio: User Stories + Wireframes) reliably persists only the wireframe_screens artifact and omits the canonical blueprint_user_story_pack + blueprint_wireframes artifacts that artifact-types.js ARTIFACT_TYPE_BY_STAGE[15] declares. The Stage-17 Devil's Advocate flags the missing user-story pack as a HIGH risk (development stalls / rework). It is non-blocking at the 15->16 boundary so it slips through silently. Empirically (venture_artifacts, lifecycle_stage=15): wireframe_screens 6/6 current, blueprint_wireframes 2 current, blueprint_user_story_pack 2 current — i.e. the pack/wireframes are inconsistent. Root cause: the stage15 analysisStep (lib/eva/stage-templates/stage-15.js:92 stage15DesignStudio) returns a PLAIN object { wireframes, wireframe_convergence, user_story_pack, ia_sitemap } (NOT the typed { artifacts:[...] } contract), and the daemon (lib/eva/stage-execution-worker.js:3146) special-cases stage 15 to write ONLY wireframe_screens — so the user_story_pack and wireframes are never reliably persisted as their canonical types. This SD makes stage 15 persist the FULL canonical set and makes the 15->16 boundary contract explicit about the user-story pack. Backend-only; no UI.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Stage 15 persists the full canonical artifact set (user_story_pack + wireframes + wireframe_screens)",
+      "description": "Make stage 15 persist all three canonical types per ARTIFACT_TYPE_BY_STAGE[15] (blueprint_user_story_pack, blueprint_wireframes, wireframe_screens) as is_current rows. Preferred mechanism: have the stage15 analysisStep return the typed { artifacts:[{artifactType, payload}] } contract — { artifactType:'blueprint_user_story_pack', payload:userStoryResult }, { artifactType:'blueprint_wireframes', payload:wireframeResult }, { artifactType:'wireframe_screens', payload:{screens:...} } — so persistArtifact's typed-array branch (stage-execution-engine.js / writeArtifactBatch) writes all three. Reconcile with the daemon's stage-15 wireframe_screens special-case (stage-execution-worker.js:3146) so wireframe_screens is written exactly once (no duplicate rows). Preserve the existing back-compat fields the analysisStep returns. Reproduce + confirm the omission first (the consistent wireframe_screens-only persist).",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "A stage-15 run persists blueprint_user_story_pack + blueprint_wireframes + wireframe_screens (is_current)",
+        "No duplicate wireframe_screens rows (daemon special-case reconciled)",
+        "Persisted set == ARTIFACT_TYPE_BY_STAGE[15] canonical set",
+        "Existing back-compat return fields preserved"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Make the 15->16 boundary contract explicit about blueprint_user_story_pack",
+      "description": "Decide and encode whether the 15->16 boundary REQUIRES blueprint_user_story_pack (so the omission stops being silent) or is acceptably optional, aligned with the registry + the S17 Devil's-Advocate HIGH risk weighting. If required, add it to the boundary's required-artifact check (the same mechanism that gates other boundaries); if optional, document why and ensure S17's DA risk surfaces it. Either way the contract is explicit, not implicit.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "The 15->16 boundary contract explicitly states whether blueprint_user_story_pack is required",
+        "Decision aligns with the artifact registry + the S17 DA risk weighting",
+        "The omission is no longer silent"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Tests + audit",
+      "description": "Add a test asserting a stage-15 run persists all three canonical types (is_current) and that the boundary contract is explicit. Document the RCA (analysisStep returns a plain object; daemon special-cases wireframe_screens-only) and confirm this is the artifact-completeness class also seen in S12-GTM (#5229) / S14 (SD-LEO-FIX-S14-WORKER-OMITS-001).",
+      "priority": "high",
+      "acceptance_criteria": [
+        "Test asserts all three stage-15 canonical types persisted is_current",
+        "Test/contract asserts the boundary requirement is explicit",
+        "RCA documented; class linkage noted"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Backend-only, reconcile producer + daemon persist paths",
+      "description": "Changes in lib/eva/stage-templates/stage-15.js (typed-artifacts return) + reconcile lib/eva/stage-execution-worker.js stage-15 wireframe_screens special-case, plus the boundary contract + a test. No schema change (the artifact types + venture_artifacts already exist). No UI."
+    }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "stage-15 persists all 3 canonical types", "type": "integration", "expected": "blueprint_user_story_pack + blueprint_wireframes + wireframe_screens is_current, no dup wireframe_screens" },
+    { "id": "TS-2", "scenario": "15->16 boundary contract explicit on user_story_pack", "type": "unit", "expected": "required/optional decision encoded + asserted" }
+  ],
+  "acceptance_criteria": [
+    "Stage 15 persists the full canonical artifact set (user_story_pack + wireframes + wireframe_screens)",
+    "The 15->16 boundary contract is explicit about the user-story pack",
+    "The silent omission the S17 DA flags is closed"
+  ],
+  "risks": [
+    {
+      "risk": "Adding typed-artifact persistence could duplicate wireframe_screens (daemon special-case already writes it)",
+      "mitigation": "Reconcile the two paths so wireframe_screens is written exactly once (drop the daemon special-case OR exclude wireframe_screens from the typed set). Verified by the no-duplicate acceptance criterion.",
+      "severity": "medium"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": ["S17 Devil's Advocate (reads the user-story pack)", "S18+ read-time consumers of wireframe_screens", "the 15->16 boundary contract"],
+    "dependencies": ["artifact-types.js ARTIFACT_TYPE_BY_STAGE[15]", "persistArtifact / writeArtifactBatch", "stage-execution-worker stage-15 special-case"],
+    "data_contracts": ["venture_artifacts: blueprint_user_story_pack + blueprint_wireframes + wireframe_screens (is_current) — no schema change"],
+    "runtime_config": ["EVA_WIREFRAME_GATING_ENABLED (existing) unaffected"],
+    "observability_rollout": ["test + live venture_artifacts query confirms all 3 types present per venture"]
+  },
+  "system_architecture": {
+    "summary": "Return the typed artifacts contract from the stage-15 analysisStep so all canonical types persist, and reconcile the daemon's wireframe_screens special-case to avoid duplicates.",
+    "components": [
+      { "name": "lib/eva/stage-templates/stage-15.js", "change": "return typed { artifacts:[...] } with all 3 canonical types" },
+      { "name": "lib/eva/stage-execution-worker.js", "change": "reconcile the stage-15 wireframe_screens special-case (no duplicate)" },
+      { "name": "the 15->16 boundary contract", "change": "explicit user_story_pack requirement (FR-2)" },
+      { "name": "tests/...stage-15...", "change": "NEW — canonical-set + boundary tests" }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Confirm omission -> typed-artifacts return -> reconcile daemon -> boundary contract -> test.",
+    "steps": [
+      "Reproduce the wireframe_screens-only persist (venture_artifacts query done: 6/6 vs 2/2)",
+      "Return the typed { artifacts:[...] } contract (all 3 canonical types) from stage15DesignStudio",
+      "Reconcile the daemon stage-15 wireframe_screens special-case (write once)",
+      "Make the 15->16 boundary contract explicit about user_story_pack",
+      "Add the test + document the RCA"
+    ]
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run stage 15 for a venture and inspect its venture_artifacts rows", "expected_outcome": "is_current rows for ALL three canonical types — blueprint_user_story_pack + blueprint_wireframes + wireframe_screens — not just wireframe_screens" },
+    { "step_number": 2, "instruction": "Compare the stage-15 canonical set (ARTIFACT_TYPE_BY_STAGE[15]) to what stage 15 persists", "expected_outcome": "Persisted set == canonical set" },
+    { "step_number": 3, "instruction": "Check the 15->16 boundary contract for blueprint_user_story_pack", "expected_outcome": "Contract is explicit about whether it is required (no longer silent)" }
+  ],
+  "metadata": { "sd_key": "SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001" }
+}

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S12-GTM-ARTIFACT-TYPE-MISPERSIST-001",
-  "createdAt": "2026-06-29T00:49:34.954Z",
+  "sdKey": "SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001",
+  "createdAt": "2026-06-29T02:38:39.977Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260629_s15_require_user_story_pack.sql
+++ b/database/migrations/20260629_s15_require_user_story_pack.sql
@@ -1,0 +1,30 @@
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- 20260629_s15_require_user_story_pack.sql
+-- SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 (FR-2)
+--
+-- Make the 15->16 boundary contract EXPLICIT about the user-story pack. Stage 15
+-- required_artifacts was ['wireframe_screens'] only, so the missing canonical
+-- blueprint_user_story_pack was non-blocking and slipped through silently — even
+-- though the S17 Devil's Advocate flags its absence as a HIGH risk (development
+-- stalls / rework). FR-1 now persists blueprint_user_story_pack on every stage-15
+-- run (it is generated unconditionally, unlike wireframes which are conditional
+-- on S10 brand data), so requiring it at the boundary is safe and closes the
+-- silent gap.
+--
+-- blueprint_wireframes is intentionally NOT required here — wireframe generation
+-- is conditionally skipped when S10 brand data is unavailable, so requiring it
+-- would wrongly block those ventures. The DA still surfaces it as advisory.
+--
+-- Additive + idempotent. Rollback:
+--   UPDATE venture_stages SET required_artifacts = array_remove(required_artifacts, 'blueprint_user_story_pack') WHERE stage_number = 15;
+
+BEGIN;
+
+UPDATE venture_stages
+SET required_artifacts = array_append(required_artifacts, 'blueprint_user_story_pack'),
+    updated_at = now()
+WHERE stage_number = 15
+  AND NOT ('blueprint_user_story_pack' = ANY (required_artifacts));
+
+COMMIT;

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -196,7 +196,32 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     }
   }
 
-  return { wireframes: wireframeResult, wireframe_convergence: convergenceResult, user_story_pack: userStoryResult, ia_sitemap: iaResult };
+  // SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 (FR-1): persist the FULL canonical
+  // stage-15 artifact set per ARTIFACT_TYPE_BY_STAGE[15]. Previously this step
+  // returned only a plain object, so the orchestrator's legacy single-artifact
+  // persist never reliably wrote blueprint_user_story_pack / blueprint_wireframes
+  // (empirically only wireframe_screens was consistent — the S17 Devil's Advocate
+  // flags the missing user-story pack as a HIGH risk). Emit the two missing
+  // canonical types via the typed { artifacts:[...] } contract so persistArtifact's
+  // batch path writes them as is_current. wireframe_screens is intentionally NOT
+  // included here — the daemon's S15 post-hook (stage-execution-worker
+  // _postStageHook_S15) owns it (with surface/device normalization), so adding it
+  // here would create duplicate rows.
+  const artifacts = [];
+  if (userStoryResult) {
+    artifacts.push({ artifactType: 'blueprint_user_story_pack', title: 'User Story Pack', payload: userStoryResult });
+  }
+  if (wireframeResult) {
+    artifacts.push({ artifactType: 'blueprint_wireframes', title: 'Wireframes', payload: wireframeResult });
+  }
+
+  return {
+    artifacts,
+    wireframes: wireframeResult,
+    wireframe_convergence: convergenceResult,
+    user_story_pack: userStoryResult,
+    ia_sitemap: iaResult,
+  };
 };
 
 ensureOutputSchema(TEMPLATE);

--- a/tests/unit/eva/stage-15-canonical-artifacts.test.js
+++ b/tests/unit/eva/stage-15-canonical-artifacts.test.js
@@ -1,0 +1,70 @@
+/**
+ * Unit test for SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 (FR-1/FR-3).
+ *
+ * Stage 15 must emit the canonical blueprint_user_story_pack + blueprint_wireframes
+ * artifacts (via the typed { artifacts:[...] } contract) so the orchestrator
+ * persists the FULL canonical set — not just wireframe_screens. wireframe_screens
+ * is owned by the daemon S15 post-hook, so it is intentionally NOT in the typed
+ * set (avoids duplicate rows).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const userStoryResult = { epics: [{ id: 'E1', stories: [{ id: 'S1' }] }] };
+const iaResult = { pages: [{ name: 'Home' }], user_flows: [] };
+const wireframeResult = { screens: [{ name: 'Home', deviceType: 'DESKTOP' }] };
+
+vi.mock('../../../lib/eva/stage-templates/analysis-steps/stage-15-user-story-pack.js', () => ({
+  generateUserStoryPack: vi.fn(async () => userStoryResult),
+}));
+vi.mock('../../../lib/eva/stage-templates/analysis-steps/stage-15-ia-generator.js', () => ({
+  generateInformationArchitecture: vi.fn(async () => iaResult),
+}));
+vi.mock('../../../lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js', () => ({
+  analyzeStage15WireframeGenerator: vi.fn(async () => wireframeResult),
+}));
+vi.mock('../../../lib/eva/stage-templates/analysis-steps/stage-19-visual-convergence.js', () => ({
+  analyzeStage19VisualConvergence: vi.fn(async () => ({ overall_score: 80, verdict: 'pass' })),
+}));
+
+import TEMPLATE from '../../../lib/eva/stage-templates/stage-15.js';
+
+describe('Stage 15 canonical artifacts (SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('emits blueprint_user_story_pack + blueprint_wireframes as typed artifacts (not wireframe_screens)', async () => {
+    const ctx = {
+      logger: { log() {}, warn() {}, error() {} },
+      ventureId: 'v1',
+      // S10 brand data present so the wireframe sub-step runs
+      stage10Data: { customerPersonas: [{ id: 'p1' }], brandGenome: { palette: [] } },
+    };
+
+    const result = await TEMPLATE.analysisStep(ctx);
+
+    expect(Array.isArray(result.artifacts)).toBe(true);
+    const types = result.artifacts.map((a) => a.artifactType);
+    expect(types).toContain('blueprint_user_story_pack');
+    expect(types).toContain('blueprint_wireframes');
+    // wireframe_screens is owned by the daemon post-hook — must NOT be duplicated here
+    expect(types).not.toContain('wireframe_screens');
+
+    const pack = result.artifacts.find((a) => a.artifactType === 'blueprint_user_story_pack');
+    expect(pack.payload).toEqual(userStoryResult);
+    const wf = result.artifacts.find((a) => a.artifactType === 'blueprint_wireframes');
+    expect(wf.payload).toEqual(wireframeResult);
+
+    // back-compat fields preserved
+    expect(result.user_story_pack).toEqual(userStoryResult);
+    expect(result.wireframes).toEqual(wireframeResult);
+  });
+
+  it('omits the wireframes artifact when S10 brand data is unavailable (still emits the user-story pack)', async () => {
+    const ctx = { logger: { log() {}, warn() {}, error() {} }, ventureId: 'v1', stage10Data: {} };
+    const result = await TEMPLATE.analysisStep(ctx);
+    const types = result.artifacts.map((a) => a.artifactType);
+    expect(types).toContain('blueprint_user_story_pack');
+    // wireframes skipped -> no blueprint_wireframes artifact (conditional, not required at boundary)
+    expect(types).not.toContain('blueprint_wireframes');
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 — stage 15 persists the canonical user-story pack + wireframes

### Bug
Stage 15 (Design Studio) reliably persisted only `wireframe_screens` and omitted the canonical `blueprint_user_story_pack` + `blueprint_wireframes` declared by `ARTIFACT_TYPE_BY_STAGE[15]`. The S17 Devil's Advocate flags the missing user-story pack as a **HIGH** risk; it was non-blocking at the 15→16 boundary so it slipped silently. Empirically (`venture_artifacts`, S15): `wireframe_screens` 6/6 current, `blueprint_wireframes` 2, `blueprint_user_story_pack` 2.

**Root cause:** `stage15DesignStudio` returned a *plain* object `{ wireframes, user_story_pack, ia_sitemap }`, so the orchestrator's legacy single-artifact persist never reliably wrote the pack/wireframes; the daemon (`_postStageHook_S15`) special-cases only `wireframe_screens`.

### Fix (backend-only)
- **FR-1** — `stage15DesignStudio` now returns the typed `{ artifacts:[...] }` contract with `blueprint_user_story_pack` + `blueprint_wireframes`, so `persistArtifact`'s batch path writes them `is_current`. `wireframe_screens` is intentionally **not** in the typed set (the daemon post-hook owns it with surface/device normalization) → no duplicate. Back-compat return fields preserved.
- **FR-2** — migration adds `blueprint_user_story_pack` to `venture_stages.required_artifacts` for stage 15 (additive, idempotent) → the 15→16 boundary is **explicit**, the omission no longer silent. `blueprint_wireframes` stays optional (wireframes are conditionally skipped without S10 brand data).
- **FR-3** — unit test asserts the typed artifacts (pack + wireframes, not `wireframe_screens`) and the wireframes-skipped path; migration verified idempotent in a rolled-back tx.

Same artifact-completeness class as S12-GTM (#5229) / S14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
