### PR TITLE
fix(SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001): S15 emits wireframe_screens pre-boundary

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -3085,6 +3085,23 @@ export class StageExecutionWorker {
     // generator reads this artifact directly for S17 design generation.
     const { writeArtifact } = await import('./artifact-persistence-service.js');
 
+    // SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001 (FR-1): the S15 producer now emits
+    // wireframe_screens in its typed batch (before the 15->16 boundary). This post-hook is now an
+    // IDEMPOTENT FALLBACK for legacy/orchestrator-direct ventures — if a current wireframe_screens
+    // already exists, skip (do not re-write / churn the row).
+    const { data: existingScreens } = await this._supabase
+      .from('venture_artifacts')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 15)
+      .eq('artifact_type', 'wireframe_screens')
+      .eq('is_current', true)
+      .maybeSingle();
+    if (existingScreens) {
+      this._logger.log('[Worker] S15 post-hook: wireframe_screens already current (producer-owned) — skipping fallback write');
+      return;
+    }
+
     // Read S15 data from venture_stage_work, falling back to venture_artifacts
     let s15Work = null;
     const { data: vsw } = await this._supabase
@@ -3120,28 +3137,11 @@ export class StageExecutionWorker {
 
     const advisoryData = s15Work.advisory_data;
 
-    // Extract screens from advisory_data — S15 stores them in different shapes
-    const rawScreens = advisoryData.screens
-      ?? advisoryData.wireframes?.screens
-      ?? advisoryData.ia_sitemap?.pages
-      ?? [];
-
-    // Normalize screen data for downstream consumption by archetype-generator
-    // SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: pass through surface when present
-    const surfaceAwareEnabled = process.env.EVA_SURFACE_AWARE_ENABLED === 'true';
-    const screens = rawScreens.map((screen, idx) => {
-      const normalized = {
-        screen_id: screen.screen_id ?? screen.id ?? `screen-${idx}`,
-        screen_name: screen.screen_name ?? screen.name ?? screen.title ?? `Screen ${idx + 1}`,
-        description: screen.description ?? screen.purpose ?? screen.prompt ?? screen.text ?? '',
-        deviceType: screen.deviceType ?? screen.device_type ?? 'DESKTOP',
-        page_type: screen.page_type ?? screen.pageType ?? null,
-      };
-      if (surfaceAwareEnabled && screen.surface) {
-        normalized.surface = screen.surface;
-      }
-      return normalized;
-    });
+    // SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001 (FR-1): shared normalizer — identical screen
+    // shape as the producer's typed-batch write, so the fallback can never drift from the primary path.
+    const { buildWireframeScreensPayload } = await import('./stage-templates/stage-15-screens.js');
+    const screensPayload = buildWireframeScreensPayload(advisoryData);
+    const { screens } = screensPayload;
 
     // Write wireframe_screens artifact for archetype-generator consumption
     await writeArtifact(this._supabase, {
@@ -3150,11 +3150,7 @@ export class StageExecutionWorker {
       artifactType: 'wireframe_screens',
       title: `Wireframe Screens (${screens.length} screens)`,
       content: JSON.stringify({ screens, source: 'S15_advisory_data' }),
-      artifactData: {
-        screens,
-        screenCount: screens.length,
-        ia_sitemap: advisoryData.ia_sitemap ?? null,
-      },
+      artifactData: screensPayload,
       qualityScore: 80,
       validationStatus: 'validated',
       source: 'stage-15-post-hook',
@@ -3164,7 +3160,7 @@ export class StageExecutionWorker {
       },
     });
 
-    this._logger.log(`[Worker] S15 post-hook: stored ${screens.length} wireframe screens as artifact (Stitch bypassed)`);
+    this._logger.log(`[Worker] S15 post-hook (fallback): stored ${screens.length} wireframe screens as artifact (Stitch bypassed)`);
   }
 
   async _postStageHook_S17_DocGen(ventureId) {

--- a/lib/eva/stage-templates/stage-15-screens.js
+++ b/lib/eva/stage-templates/stage-15-screens.js
@@ -1,0 +1,56 @@
+/**
+ * Shared wireframe_screens normalizer — SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001.
+ *
+ * The 15->16 boundary REQUIRES the `wireframe_screens` artifact. Historically it was written
+ * implicitly by the orchestrator's legacy single-artifact fallback (synchronously, BEFORE the
+ * boundary). SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 switched the S15 producer to the typed
+ * { artifacts:[...] } contract, which bypassed that fallback — so wireframe_screens then depended
+ * solely on the daemon's POST-ADVANCEMENT post-hook, creating a deadlock (boundary needs the
+ * artifact -> no advance -> hook never fires). RCA confidence 0.93.
+ *
+ * Fix: the producer now emits wireframe_screens in its typed batch (before the boundary), and the
+ * post-hook stays an idempotent fallback for legacy/orchestrator-direct ventures. BOTH call this
+ * shared normalizer so the screen payload shape can never drift between the two writers.
+ */
+
+// S15 stores screens in several shapes depending on the producing sub-step; accept all of them.
+export function extractRawScreens(source) {
+  const s = source || {};
+  return s.screens
+    ?? s.wireframes?.screens
+    ?? s.ia_sitemap?.pages
+    ?? [];
+}
+
+// Normalize a raw screen list for downstream consumption (archetype-generator / S17).
+// SD-SURFACEAWARE-WIREFRAME-GENERATION-MARKETING-ORCH-001-B: pass `surface` through when present
+// AND the surface-aware flag is enabled (env-gated, matched to the post-hook's prior behavior).
+export function normalizeWireframeScreens(rawScreens, { surfaceAwareEnabled = process.env.EVA_SURFACE_AWARE_ENABLED === 'true' } = {}) {
+  const list = Array.isArray(rawScreens) ? rawScreens : [];
+  return list.map((screen, idx) => {
+    const s = screen || {};
+    const normalized = {
+      screen_id: s.screen_id ?? s.id ?? `screen-${idx}`,
+      screen_name: s.screen_name ?? s.name ?? s.title ?? `Screen ${idx + 1}`,
+      description: s.description ?? s.purpose ?? s.prompt ?? s.text ?? '',
+      deviceType: s.deviceType ?? s.device_type ?? 'DESKTOP',
+      page_type: s.page_type ?? s.pageType ?? null,
+    };
+    if (surfaceAwareEnabled && s.surface) {
+      normalized.surface = s.surface;
+    }
+    return normalized;
+  });
+}
+
+// Build the canonical wireframe_screens artifact_data payload (what both writers persist).
+export function buildWireframeScreensPayload(source, opts = {}) {
+  const screens = normalizeWireframeScreens(extractRawScreens(source), opts);
+  return {
+    screens,
+    screenCount: screens.length,
+    ia_sitemap: (source && source.ia_sitemap) ?? null,
+  };
+}
+
+export default { extractRawScreens, normalizeWireframeScreens, buildWireframeScreensPayload };

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -18,6 +18,7 @@ import { analyzeStage15WireframeGenerator } from './analysis-steps/stage-15-wire
 import { analyzeStage19VisualConvergence } from './analysis-steps/stage-19-visual-convergence.js';
 import { generateUserStoryPack } from './analysis-steps/stage-15-user-story-pack.js';
 import { generateInformationArchitecture } from './analysis-steps/stage-15-ia-generator.js';
+import { buildWireframeScreensPayload } from './stage-15-screens.js';
 
 const wireframeGatingEnabled = process.env.EVA_WIREFRAME_GATING_ENABLED === 'true';
 
@@ -196,23 +197,23 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
     }
   }
 
-  // SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 (FR-1): persist the FULL canonical
-  // stage-15 artifact set per ARTIFACT_TYPE_BY_STAGE[15]. Previously this step
-  // returned only a plain object, so the orchestrator's legacy single-artifact
-  // persist never reliably wrote blueprint_user_story_pack / blueprint_wireframes
-  // (empirically only wireframe_screens was consistent — the S17 Devil's Advocate
-  // flags the missing user-story pack as a HIGH risk). Emit the two missing
-  // canonical types via the typed { artifacts:[...] } contract so persistArtifact's
-  // batch path writes them as is_current. wireframe_screens is intentionally NOT
-  // included here — the daemon's S15 post-hook (stage-execution-worker
-  // _postStageHook_S15) owns it (with surface/device normalization), so adding it
-  // here would create duplicate rows.
+  // SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 (FR-1): persist the FULL canonical stage-15 artifact
+  // set per ARTIFACT_TYPE_BY_STAGE[15] via the typed { artifacts:[...] } contract so persistArtifact's
+  // batch path writes each as is_current.
+  // SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001 (FR-1): wireframe_screens MUST be emitted here
+  // too. The 15->16 boundary requires it, and switching to the typed contract bypassed the orchestrator
+  // legacy fallback that used to write it synchronously BEFORE the boundary — leaving it only to the
+  // post-advancement post-hook, which deadlocks (boundary needs it -> no advance -> hook never fires).
+  // The producer now owns it (deduped per-type, written pre-boundary); the post-hook is an idempotent
+  // fallback. Both share buildWireframeScreensPayload so the screen shape never drifts. (RCA 0.93)
   const artifacts = [];
   if (userStoryResult) {
     artifacts.push({ artifactType: 'blueprint_user_story_pack', title: 'User Story Pack', payload: userStoryResult });
   }
   if (wireframeResult) {
     artifacts.push({ artifactType: 'blueprint_wireframes', title: 'Wireframes', payload: wireframeResult });
+    const screensPayload = buildWireframeScreensPayload({ screens: wireframeResult?.screens, wireframes: wireframeResult, ia_sitemap: iaResult });
+    artifacts.push({ artifactType: 'wireframe_screens', title: `Wireframe Screens (${screensPayload.screenCount} screens)`, payload: screensPayload });
   }
 
   return {

--- a/tests/unit/eva/stage-15-canonical-artifacts.test.js
+++ b/tests/unit/eva/stage-15-canonical-artifacts.test.js
@@ -1,11 +1,13 @@
 /**
  * Unit test for SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 (FR-1/FR-3).
  *
- * Stage 15 must emit the canonical blueprint_user_story_pack + blueprint_wireframes
- * artifacts (via the typed { artifacts:[...] } contract) so the orchestrator
- * persists the FULL canonical set — not just wireframe_screens. wireframe_screens
- * is owned by the daemon S15 post-hook, so it is intentionally NOT in the typed
- * set (avoids duplicate rows).
+ * Stage 15 must emit the FULL canonical set — blueprint_user_story_pack +
+ * blueprint_wireframes + wireframe_screens — via the typed { artifacts:[...] } contract.
+ *
+ * SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001: wireframe_screens MUST be in the typed set.
+ * The prior fix omitted it (assuming the daemon post-hook owned it), but that left it to a
+ * post-ADVANCEMENT hook while the 15->16 boundary requires it pre-advance — a deadlock. The producer
+ * now owns it (the post-hook is an idempotent fallback); this test guards against the omission.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -32,7 +34,7 @@ import TEMPLATE from '../../../lib/eva/stage-templates/stage-15.js';
 describe('Stage 15 canonical artifacts (SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('emits blueprint_user_story_pack + blueprint_wireframes as typed artifacts (not wireframe_screens)', async () => {
+  it('emits the FULL canonical set incl. wireframe_screens as typed artifacts, each exactly once', async () => {
     const ctx = {
       logger: { log() {}, warn() {}, error() {} },
       ventureId: 'v1',
@@ -46,13 +48,22 @@ describe('Stage 15 canonical artifacts (SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001
     const types = result.artifacts.map((a) => a.artifactType);
     expect(types).toContain('blueprint_user_story_pack');
     expect(types).toContain('blueprint_wireframes');
-    // wireframe_screens is owned by the daemon post-hook — must NOT be duplicated here
-    expect(types).not.toContain('wireframe_screens');
+    // SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001: wireframe_screens MUST be present (the
+    // 15->16 boundary requires it pre-advance; the producer owns it, post-hook is a fallback).
+    expect(types).toContain('wireframe_screens');
+    // each canonical type EXACTLY once (no double-emission)
+    for (const t of ['blueprint_user_story_pack', 'blueprint_wireframes', 'wireframe_screens']) {
+      expect(types.filter((x) => x === t)).toHaveLength(1);
+    }
 
     const pack = result.artifacts.find((a) => a.artifactType === 'blueprint_user_story_pack');
     expect(pack.payload).toEqual(userStoryResult);
     const wf = result.artifacts.find((a) => a.artifactType === 'blueprint_wireframes');
     expect(wf.payload).toEqual(wireframeResult);
+    const screens = result.artifacts.find((a) => a.artifactType === 'wireframe_screens');
+    expect(Array.isArray(screens.payload.screens)).toBe(true);
+    expect(screens.payload.screenCount).toBe(screens.payload.screens.length);
+    expect(screens.payload.screens.length).toBeGreaterThan(0);
 
     // back-compat fields preserved
     expect(result.user_story_pack).toEqual(userStoryResult);

--- a/tests/unit/eva/stage-15-screens.test.js
+++ b/tests/unit/eva/stage-15-screens.test.js
@@ -1,0 +1,42 @@
+/**
+ * SD-LEO-INFRA-S15-WIREFRAME-SCREENS-REGRESSION-001 — shared wireframe_screens normalizer.
+ * The producer (stage-15.js typed batch) and the daemon post-hook both call this, so the
+ * persisted screen shape can never drift between the two writers.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractRawScreens, normalizeWireframeScreens, buildWireframeScreensPayload } from '../../../lib/eva/stage-templates/stage-15-screens.js';
+
+describe('stage-15 wireframe_screens normalizer', () => {
+  it('extractRawScreens accepts the several S15 shapes (screens / wireframes.screens / ia_sitemap.pages)', () => {
+    expect(extractRawScreens({ screens: [{ id: 'a' }] })).toEqual([{ id: 'a' }]);
+    expect(extractRawScreens({ wireframes: { screens: [{ id: 'b' }] } })).toEqual([{ id: 'b' }]);
+    expect(extractRawScreens({ ia_sitemap: { pages: [{ name: 'Home' }] } })).toEqual([{ name: 'Home' }]);
+    expect(extractRawScreens(null)).toEqual([]);
+    expect(extractRawScreens({})).toEqual([]);
+  });
+
+  it('normalizeWireframeScreens fills canonical fields + defaults deviceType, tolerant of aliases', () => {
+    const out = normalizeWireframeScreens([{ id: 'x', title: 'Login', purpose: 'auth', device_type: 'MOBILE', pageType: 'auth' }]);
+    expect(out[0]).toEqual({ screen_id: 'x', screen_name: 'Login', description: 'auth', deviceType: 'MOBILE', page_type: 'auth' });
+    // missing fields get stable defaults
+    const def = normalizeWireframeScreens([{}]);
+    expect(def[0].screen_id).toBe('screen-0');
+    expect(def[0].screen_name).toBe('Screen 1');
+    expect(def[0].deviceType).toBe('DESKTOP');
+  });
+
+  it('surface passthrough is env-gated (opts override)', () => {
+    const withSurface = normalizeWireframeScreens([{ id: 's', surface: 'marketing' }], { surfaceAwareEnabled: true });
+    expect(withSurface[0].surface).toBe('marketing');
+    const without = normalizeWireframeScreens([{ id: 's', surface: 'marketing' }], { surfaceAwareEnabled: false });
+    expect(without[0].surface).toBeUndefined();
+  });
+
+  it('buildWireframeScreensPayload returns { screens, screenCount, ia_sitemap }', () => {
+    const p = buildWireframeScreensPayload({ screens: [{ id: 'a' }, { id: 'b' }], ia_sitemap: { pages: [] } }, { surfaceAwareEnabled: false });
+    expect(p.screenCount).toBe(2);
+    expect(p.screens).toHaveLength(2);
+    expect(p.ia_sitemap).toEqual({ pages: [] });
+    expect(buildWireframeScreensPayload(null).ia_sitemap).toBeNull();
+  });
+});


### PR DESCRIPTION
## S15 dropped wireframe_screens → 15→16 deadlock (regression from the user-story-pack fix)

**RCA (0.93):** SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001 switched the S15 producer to the typed `{ artifacts:[...] }` contract, which **bypassed the orchestrator legacy fallback** that used to write `wireframe_screens` *synchronously before* the 15→16 boundary. It then depended solely on the daemon **post-advancement** post-hook → **deadlock** (boundary requires it → no advance → hook never fires → `ARTIFACT_MISSING` hard-block). The reported "double-emission" was **re-execution churn** from the wedged venture, not a dedup defect (`writeArtifactBatch` supersedes per-type correctly — exactly 1 `is_current` each).

### Fix (Option A — producer owns it, post-hook is an idempotent fallback)
- **FR-1** `lib/eva/stage-templates/stage-15.js` — producer now emits `wireframe_screens` in its typed batch (pre-boundary, deduped per-type). New shared normalizer `lib/eva/stage-templates/stage-15-screens.js` (`buildWireframeScreensPayload`), **extracted from the post-hook** so the screen shape can't drift.
- **FR-1** `_postStageHook_S15_StitchProvision` → **idempotent fallback** (skips when a current `wireframe_screens` exists) for legacy/orchestrator-direct ventures; uses the shared normalizer.
- **FR-2** the 15→16 requirement (`venture_stages.required_artifacts`; no `gate_boundary_config` row) is now satisfied by the producer — kept requiring `wireframe_screens`.
- **FR-3** inverted the canonical-artifacts test (producer MUST emit `wireframe_screens`, each type exactly once) + new normalizer test. **6 tests pass.**

Wedged venture `886d2dc3` self-heals on its next poll once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)