### PR TITLE
feat(SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001): S15 wireframe parse observability + robustness + fail-fast + clone vision_id

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S15-USER-STORY-PACK-GAP-001",
-  "createdAt": "2026-06-29T02:38:39.977Z",
+  "sdKey": "SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001",
+  "createdAt": "2026-06-29T06:26:37.489Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -905,8 +905,30 @@ async function upsertEvaArchFromArtifacts(supabase, planKey, ventureId, triggerS
     }).eq('plan_key', planKey);
     if (updateError) console.warn(`[artifact-persistence-service] eva_architecture_plans update failed (${planKey}): ${updateError.message}`);
   } else {
+    // SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001 FR-4: eva_architecture_plans.vision_id is NOT NULL
+    // (FK -> eva_vision_documents.id). This eager-synthesis INSERT previously OMITTED vision_id, so it
+    // failed silently (insertError swallowed) for EVERY venture, and for a vision=none clone there is no
+    // vision document at all (ARCH-MARKETLENS-001). Resolve the venture's current vision document; when
+    // none exists (vision=none), SKIP arch-plan synthesis rather than attempt a NOT NULL-violating insert.
+    let visionId = null;
+    try {
+      const { data: vdoc } = await supabase
+        .from('eva_vision_documents')
+        .select('id')
+        .eq('venture_id', ventureId)
+        .order('version', { ascending: false })
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      visionId = vdoc?.id || null;
+    } catch { /* fall through to skip */ }
+    if (!visionId) {
+      console.warn(`[artifact-persistence-service] eva_architecture_plans insert skipped (${planKey}): no vision document for venture ${ventureId} (vision=none) — arch-plan synthesis requires a vision (FR-4).`);
+      return;
+    }
     const { error: insertError } = await supabase.from('eva_architecture_plans').insert({
       plan_key: planKey,
+      vision_id: visionId,
       venture_id: ventureId,
       content: synthesized,
       version: 1,

--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -506,7 +506,12 @@ Output ONLY valid JSON.`;
       // Last attempt — use whatever we got
       parsed = parsed || {};
     } catch (parseErr) {
-      logger.warn(`[Stage15-WF] LLM JSON parse failed (attempt ${attempt}/${LLM_MAX_RETRIES}): ${parseErr.message.substring(0, 100)}`);
+      // SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001 FR-1: surface the FULL failure signal
+      // (finishReason, outputTokens, content length) + the un-truncated parse error (which now carries
+      // body HEAD+TAIL) so the exact sub-cause is captured on the next run — the prior 100-char clip
+      // hid both the truncation tail and the structural break that caused the unparseable JSON.
+      logger.warn(`[Stage15-WF] LLM JSON parse failed (attempt ${attempt}/${LLM_MAX_RETRIES}) ` +
+        `[finishReason=${response?.finishReason ?? 'n/a'} outputTokens=${usage?.outputTokens ?? 'n/a'} contentLength=${response?.content?.length ?? 'n/a'}]: ${parseErr.message}`);
       if (attempt >= LLM_MAX_RETRIES) {
         throw new Error(`[Stage15-WF] Wireframe LLM failed after ${LLM_MAX_RETRIES} attempts: ${parseErr.message}`);
       }

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -166,7 +166,14 @@ TEMPLATE.analysisStep = async function stage15DesignStudio(ctx) {
         if (attempt < MAX_WIREFRAME_RETRIES) {
           logger.warn(`[Stage15-DesignStudio] Wireframe generation failed (attempt ${attempt}/${MAX_WIREFRAME_RETRIES}), retrying...`, { error: err.message });
         } else {
-          logger.warn(`[Stage15-DesignStudio] Wireframe generation failed after ${MAX_WIREFRAME_RETRIES} attempts (non-fatal)`, { error: err.message });
+          // SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001 FR-3: wireframe_screens is a
+          // BOUNDARY-MANDATORY artifact for the 15->16 reality gate. The prior "non-fatal" warn-and-
+          // proceed silently dropped it, so the failure only surfaced downstream as a generic
+          // ARTIFACT_MISSING -> killed_at_reality_gate with NO real cause. Fail-fast with the REAL
+          // generation cause (now carrying FR-1 diagnostics) so it propagates into the
+          // gate_failure_escalation reason instead of a misleading generic missing-artifact kill.
+          logger.error(`[Stage15-DesignStudio] Wireframe generation failed after ${MAX_WIREFRAME_RETRIES} attempts — failing fast (wireframe_screens is boundary-mandatory for 15->16)`, { error: err.message });
+          throw new Error(`[Stage15] Wireframe generation failed (boundary-mandatory wireframe_screens): ${err.message}`);
         }
       }
     }

--- a/lib/eva/utils/parse-json.js
+++ b/lib/eva/utils/parse-json.js
@@ -34,9 +34,19 @@ function repairJSON(text) {
       continue;
     }
     if (ch === '"') {
-      inString = !inString;
-      result += ch;
-      continue;
+      if (!inString) { inString = true; result += ch; continue; }
+      // SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001 FR-2.2: distinguish a real closing quote from a
+      // stray UNESCAPED inner double-quote (the likely S15 wireframe cause). A real closing quote is
+      // followed (after optional whitespace) by a JSON structural delimiter (, } ] :) or end-of-input;
+      // anything else means we're still inside the string value, so escape the quote instead of
+      // mis-closing the string (which cascades into a parse failure for the whole document).
+      let j = i + 1;
+      while (j < repaired.length && (repaired[j] === ' ' || repaired[j] === '\t' || repaired[j] === '\n' || repaired[j] === '\r')) j++;
+      const next = j < repaired.length ? repaired[j] : '';
+      if (next === '' || next === ',' || next === '}' || next === ']' || next === ':') {
+        inString = false; result += ch; continue; // real closing quote
+      }
+      result += '\\"'; continue; // stray inner quote → escape it
     }
     if (inString) {
       if (ch === '\n') { result += '\\n'; continue; }
@@ -80,6 +90,13 @@ export function parseJSON(textOrResponse, options = {}) {
   const text = isResponseObj ? textOrResponse.content : String(textOrResponse);
   // FR-3: read the truncation signal from the adapter response (when one was passed).
   const truncated = isResponseObj && textOrResponse.finishReason === 'MAX_TOKENS';
+  // SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001 FR-2.3: any non-STOP finishReason (SAFETY,
+  // RECITATION, OTHER, length, content_filter, ...) is an abnormal-termination signal — classify it as
+  // a truncation-class cause so the failure message names the real reason instead of the generic
+  // "Failed to parse" misdirection. Success values (STOP/stop/end_turn/COMPLETE/empty) are NOT abnormal.
+  const finishReason = isResponseObj ? textOrResponse.finishReason : undefined;
+  const SUCCESS_FINISH = new Set(['STOP', 'stop', 'end_turn', 'COMPLETE', 'complete', '']);
+  const abnormalFinish = finishReason != null && finishReason !== '' && !SUCCESS_FINISH.has(finishReason);
 
   // Strip markdown code fences if present
   const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
@@ -100,9 +117,23 @@ export function parseJSON(textOrResponse, options = {}) {
   }
 
   // Layer 3: Throw with full context. FR-3 fail-loud: name the real cause when truncated.
-  const errorMsg = truncated
-    ? `LLM response truncated at token ceiling (finishReason=MAX_TOKENS) — increase maxOutputTokens / thread the call purpose (e.g. purpose:'content-generation' → 16384). Raw head: ${cleaned.substring(0, 200)}`
-    : `Failed to parse LLM response as JSON: ${cleaned.substring(0, 200)}`;
+  // SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001 FR-1: attach full diagnostics (finishReason,
+  // outputTokens, content length, and body HEAD+TAIL — not just the first 200 chars) so the exact
+  // sub-cause is visible on the next run instead of being guessed. HEAD+TAIL matters because a
+  // truncation shows in the tail and an unescaped-quote/structural break often shows mid/late.
+  const len = cleaned.length;
+  const head = cleaned.substring(0, 300);
+  const tail = len > 600 ? cleaned.substring(len - 300) : '';
+  const usage = extractUsage(textOrResponse);
+  const diag = `[finishReason=${finishReason ?? 'n/a'} outputTokens=${usage?.outputTokens ?? 'n/a'} contentLength=${len}]`;
+  let errorMsg;
+  if (truncated) {
+    errorMsg = `LLM response truncated at token ceiling (finishReason=MAX_TOKENS) — increase maxOutputTokens / thread the call purpose (e.g. purpose:'content-generation' → 16384). ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
+  } else if (abnormalFinish) {
+    errorMsg = `LLM response abnormally terminated (finishReason=${finishReason}, non-STOP) — treat as a truncation-class failure, not a JSON-robustness one. ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
+  } else {
+    errorMsg = `Failed to parse LLM response as JSON ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
+  }
   throw new Error(errorMsg);
 }
 

--- a/tests/unit/eva/utils/parse-json-robustness.test.js
+++ b/tests/unit/eva/utils/parse-json-robustness.test.js
@@ -1,0 +1,124 @@
+/**
+ * SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001
+ *
+ * FR-2.2: repairJSON recovers UNESCAPED inner double-quotes (the likely S15 wireframe cause) without
+ *         regressing the known-good corpus.
+ * FR-2.3: a non-STOP finishReason is classified as an abnormal-termination (truncation-class) cause.
+ * FR-1:   parse-failure errors carry full diagnostics (finishReason, outputTokens, contentLength, HEAD+TAIL).
+ * FR-3/FR-4: source-level assertions that stage-15 fails fast on the boundary-mandatory artifact and the
+ *         arch-plan insert resolves/guards vision_id.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { parseJSON } from '../../../../lib/eva/utils/parse-json.js';
+
+const root = (p) => resolve(dirname(fileURLToPath(import.meta.url)), '../../../..', p);
+
+// ── FR-2.2: unescaped inner quotes ───────────────────────────────────────────
+describe('FR-2.2: repairJSON recovers unescaped inner double-quotes', () => {
+  it('recovers a single inner unescaped quote pair in a value', () => {
+    const r = parseJSON('{"desc": "a "quoted" word here"}');
+    expect(r.desc).toBe('a "quoted" word here');
+  });
+
+  it('recovers an inner quote followed immediately by other text', () => {
+    const r = parseJSON('{"label": "click "Save" now"}');
+    expect(r.label).toBe('click "Save" now');
+  });
+
+  it('recovers inside a nested array of objects (wireframe-shaped)', () => {
+    const raw = '{"screens":[{"name":"Home","note":"the "primary" CTA"}]}';
+    const r = parseJSON(raw);
+    expect(r.screens[0].name).toBe('Home');
+    expect(r.screens[0].note).toBe('the "primary" CTA');
+  });
+});
+
+// ── FR-2.2 regression: the known-good corpus must still parse ─────────────────
+describe('FR-2.2 regression: known-good corpus unaffected', () => {
+  const corpus = [
+    ['plain object', '{"a":1,"b":"two","c":true,"d":null}'],
+    ['empty strings', '{"a":"","b":""}'],
+    ['adjacent array strings', '{"arr":["x","y","z"]}'],
+    ['empty key', '{"":"v"}'],
+    ['nested', '{"o":{"p":{"q":[1,2,3]}}}'],
+    ['markdown-fenced', '```json\n{"x":42}\n```'],
+    ['trailing comma', '{"a":1,"b":2,}'],
+    ['smart quotes', '{“key”:“value”}'],
+    ['url value with colon', '{"href":"https://example.com/x"}'],
+  ];
+  for (const [name, input] of corpus) {
+    it(`parses: ${name}`, () => {
+      expect(() => parseJSON(input)).not.toThrow();
+    });
+  }
+
+  it('literal newline inside a string still repairs', () => {
+    const r = parseJSON('{"text":"line1\nline2"}');
+    expect(r.text).toContain('line1');
+    expect(r.text).toContain('line2');
+  });
+
+  it('a url value followed by a structural delimiter keeps the colon', () => {
+    const r = parseJSON('{"href":"https://example.com","n":1}');
+    expect(r.href).toBe('https://example.com');
+    expect(r.n).toBe(1);
+  });
+});
+
+// ── FR-2.3: non-STOP finishReason classification ─────────────────────────────
+describe('FR-2.3: non-STOP finishReason is a truncation-class cause', () => {
+  it('MAX_TOKENS => token-ceiling message', () => {
+    expect(() => parseJSON({ content: 'not json {', finishReason: 'MAX_TOKENS' }))
+      .toThrow(/truncated at token ceiling/);
+  });
+  it('SAFETY (non-STOP) => abnormally terminated message', () => {
+    expect(() => parseJSON({ content: 'not json {', finishReason: 'SAFETY' }))
+      .toThrow(/abnormally terminated.*finishReason=SAFETY/);
+  });
+  it('RECITATION (non-STOP) => abnormally terminated', () => {
+    expect(() => parseJSON({ content: '{bad', finishReason: 'RECITATION' }))
+      .toThrow(/abnormally terminated/);
+  });
+  it('STOP (success) on unparseable => generic parse-failure, NOT abnormal', () => {
+    expect(() => parseJSON({ content: 'not json {', finishReason: 'STOP' }))
+      .toThrow(/Failed to parse LLM response as JSON/);
+  });
+});
+
+// ── FR-1: rich diagnostics on parse failure ──────────────────────────────────
+describe('FR-1: parse-failure error carries full diagnostics', () => {
+  it('includes finishReason, outputTokens, and contentLength', () => {
+    const resp = { content: 'not valid json at all {{{', finishReason: 'STOP', usage: { outputTokens: 123 } };
+    expect(() => parseJSON(resp)).toThrow(/finishReason=STOP/);
+    expect(() => parseJSON(resp)).toThrow(/outputTokens=123/);
+    expect(() => parseJSON(resp)).toThrow(/contentLength=/);
+  });
+  it('includes a TAIL section for long unparseable bodies', () => {
+    const long = '{' + 'x'.repeat(800); // >600 chars, unparseable
+    expect(() => parseJSON({ content: long, finishReason: 'STOP' })).toThrow(/TAIL:/);
+  });
+});
+
+// ── FR-3 / FR-4: source assertions ───────────────────────────────────────────
+describe('FR-3: stage-15 fails fast on the boundary-mandatory wireframe artifact', () => {
+  const src = readFileSync(root('lib/eva/stage-templates/stage-15.js'), 'utf8');
+  it('throws (no silent non-fatal proceed) after the last wireframe retry', () => {
+    // the last-attempt branch must throw with the real cause, not just warn "non-fatal"
+    expect(src).toMatch(/boundary-mandatory wireframe_screens/);
+    expect(src).toMatch(/throw new Error\(`\[Stage15\] Wireframe generation failed \(boundary-mandatory/);
+  });
+});
+
+describe('FR-4: arch-plan insert resolves vision_id and skips when vision=none', () => {
+  const src = readFileSync(root('lib/eva/artifact-persistence-service.js'), 'utf8');
+  it('resolves the venture vision document and sets vision_id on insert', () => {
+    expect(src).toMatch(/from\('eva_vision_documents'\)/);
+    expect(src).toMatch(/vision_id: visionId/);
+  });
+  it('skips the insert when no vision document exists (vision=none)', () => {
+    expect(src).toMatch(/insert skipped.*vision=none/);
+  });
+});


### PR DESCRIPTION
## Summary
Stage 15 wireframe generation intermittently produced no `wireframe_screens`, failing the 15->16 boundary (ARTIFACT_MISSING -> killed_at_reality_gate, run#4 escalation b29cb0b2). rca-agent result **e17931a3** OVERTURNED the token-limit guess: the wireframe LLM emits **unparseable JSON** (no response_format; likely unescaped inner double-quotes) and a **non-fatal silent-proceed** dropped the boundary-mandatory artifact with near-zero observability.

## Fixes (RCA-ranked: observability first, generation robustness, fail-fast)
- **FR-1 observability:** `parse-json.js` Layer-3 error + the S15 generator log now carry `finishReason`, `usage.outputTokens`, content length, and body **HEAD+TAIL** (not a 100-200 char clip) — so the exact sub-cause is captured on the next run.
- **FR-2.2 repair:** `repairJSON` recovers **unescaped inner double-quotes** via a delimiter-lookahead (a real closing quote is followed by `, } ] :` or EOF; otherwise escape it). Guarded by a 10-case known-good corpus so it can't regress valid/recoverable inputs.
- **FR-2.3 classification:** any **non-STOP** finishReason is treated as an abnormal-termination (truncation-class) cause, not the generic "Failed to parse" misdirection.
- **FR-3 fail-fast:** `stage-15.js` now **throws with the real cause** on the boundary-mandatory `wireframe_screens` after retries, instead of warn-and-proceed (the silent drop that became a generic downstream ARTIFACT_MISSING).
- **FR-4 clone vision_id:** the eager-synthesis `eva_architecture_plans` INSERT omitted the **NOT NULL `vision_id`** and was failing silently for **every** venture (0 of 235 rows created by eager-synthesis). It now resolves the venture's vision document id and **skips** synthesis when vision=none (clone) instead of a NOT NULL violation.

## Deferred (flagged, RCA-aligned)
**FR-2.1 JSON mode / FR-2.4 maxTokens** require threading `response_format`/`generationConfig` through the **shared** LLM client (`client.complete` has no options arg today; broad blast radius across all stages), and the RCA says confirm the exact cause via FR-1 on the next live run first. The self-contained fixes already convert the silent kill into a loud, real-cause failure.

## Verification
- 23 new + 67 regression tests green; `node --check` OK; testing-agent **PASS** (de2c9565); retro PUBLISHED 100/100 (0bb9cfb3).

Walk-blocker for run#4; run#5 verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)