### PR TITLE
fix(SD-LEO-INFRA-VISION-REPAIR-NO-FORCE-APPROVE-001): vision repair → quality DRAFT, not silent chairman approval

### DIFF
--- a/lib/eva/__tests__/vision-repair-loop.test.js
+++ b/lib/eva/__tests__/vision-repair-loop.test.js
@@ -25,6 +25,9 @@ import {
   routeRepairPrompt,
   __test__,
 } from '../vision-repair-loop.js';
+// SD-LEO-INFRA-VISION-REPAIR-NO-FORCE-APPROVE-001 (FR-2/FR-4): the deliberate
+// chairman gate is the ONLY path that yields active+chairman_approved.
+import { upsertVision } from '../vision-upsert.js';
 
 // Reset env vars between tests so flag state never leaks
 function clearEnv() {
@@ -36,7 +39,7 @@ function clearEnv() {
  * Build a Supabase mock that returns a sequence of upsert results.
  * Each call to upsert() consumes one entry from upsertSequence.
  */
-function mockSupabase({ upsertSequence = [], configRows = {} } = {}) {
+function mockSupabase({ upsertSequence = [], configRows = {}, captureUpserts = null } = {}) {
   let upsertIdx = 0;
   return {
     from: vi.fn((table) => ({
@@ -51,15 +54,21 @@ function mockSupabase({ upsertSequence = [], configRows = {} } = {}) {
           }),
         })),
       })),
-      upsert: vi.fn(() => ({
-        select: vi.fn(() => ({
-          single: vi.fn(async () => {
-            const next = upsertSequence[upsertIdx] || upsertSequence[upsertSequence.length - 1];
-            upsertIdx += 1;
-            return next || { data: null, error: { message: 'no upsert result configured' } };
-          }),
-        })),
-      })),
+      // SD-LEO-INFRA-VISION-REPAIR-NO-FORCE-APPROVE-001 (FR-4): capture the upsert
+      // record so a test can assert what upsertVision wrote (status/chairman_approved
+      // derived from the `approved` option the repair loop passes).
+      upsert: vi.fn((record) => {
+        if (captureUpserts) captureUpserts.push(record);
+        return {
+          select: vi.fn(() => ({
+            single: vi.fn(async () => {
+              const next = upsertSequence[upsertIdx] || upsertSequence[upsertSequence.length - 1];
+              upsertIdx += 1;
+              return next || { data: null, error: { message: 'no upsert result configured' } };
+            }),
+          })),
+        };
+      }),
     })),
   };
 }
@@ -172,6 +181,41 @@ describe('vision-repair-loop / repairVision', () => {
     expect(result.tokensUsed).toBe(8000);
     expect(result.finalQualityChecked).toBe(true);
     expect(regenerate).toHaveBeenCalledTimes(1);
+  });
+
+  // SD-LEO-INFRA-VISION-REPAIR-NO-FORCE-APPROVE-001 (FR-1/FR-4): a repair must NOT
+  // silently grant chairman approval. The repair loop passes approved:false to
+  // upsertVision, so the repaired vision is written as a quality-repaired DRAFT
+  // (status='draft', chairman_approved=false) — activation/approval stays the
+  // separate deliberate chairman gate. Assert via the captured upsert record.
+  test('FR-1: repair writes a quality DRAFT (approved:false → status=draft, chairman_approved=false)', async () => {
+    clearEnv();
+    const captureUpserts = [];
+    const supabase = mockSupabase({ upsertSequence: [{ data: PASSING_DATA, error: null }], captureUpserts });
+    const regenerate = vi.fn(async () => ({
+      sections: { executive_summary: 'A'.repeat(5500) },
+      content: 'B'.repeat(5500),
+      tokensUsed: 8000,
+    }));
+
+    await repairVision({
+      supabase,
+      visionKey: 'V-1',
+      qualityIssues: FAILING_DATA_CONTENT_LENGTH.quality_issues,
+      sections: { executive_summary: 'short' },
+      content: 'short',
+      ventureId: 'venture-real-1',
+      createdBy: 'stage-17-doc-generation',
+      regenerate,
+      logger: { log: () => {}, warn: () => {} },
+    });
+
+    // upsertVision derives status + chairman_approved from `approved` — the repaired
+    // vision must be a DRAFT, never auto-activated/approved.
+    expect(captureUpserts.length).toBeGreaterThan(0);
+    const record = captureUpserts[captureUpserts.length - 1];
+    expect(record.status).toBe('draft');
+    expect(record.chairman_approved).toBe(false);
   });
 
   test('TS-2: success on second regen [AC-1, AC-2]', async () => {
@@ -393,5 +437,46 @@ describe('vision-repair-loop / __test__ exports', () => {
   test('default constants are sensible', () => {
     expect(__test__.DEFAULT_ATTEMPT_CAP).toBe(2);
     expect(__test__.DEFAULT_TOKEN_BUDGET).toBe(540800);
+  });
+});
+
+// SD-LEO-INFRA-VISION-REPAIR-NO-FORCE-APPROVE-001 (FR-2/FR-4): the `approved`
+// option is the single lever for activation. Repair passes approved:false (DRAFT);
+// the deliberate chairman gate (vision-command.mjs) passes approved:true (active +
+// chairman_approved). Confirm the matrix so a repaired vision is gated, never
+// silently activated.
+describe('vision-upsert / deliberate approval matrix', () => {
+  test('approved:false → status=draft + chairman_approved=false (the repair path)', async () => {
+    const captureUpserts = [];
+    const supabase = mockSupabase({ upsertSequence: [{ data: PASSING_DATA, error: null }], captureUpserts });
+    await upsertVision({
+      supabase,
+      visionKey: 'V-1',
+      content: 'x'.repeat(100),
+      sections: { executive_summary: 'x' },
+      ventureId: 'venture-real-1',
+      createdBy: 'vision-repair-loop',
+      approved: false,
+    });
+    const record = captureUpserts[captureUpserts.length - 1];
+    expect(record.status).toBe('draft');
+    expect(record.chairman_approved).toBe(false);
+  });
+
+  test('approved:true → status=active + chairman_approved=true (the deliberate chairman gate)', async () => {
+    const captureUpserts = [];
+    const supabase = mockSupabase({ upsertSequence: [{ data: PASSING_DATA, error: null }], captureUpserts });
+    await upsertVision({
+      supabase,
+      visionKey: 'V-1',
+      content: 'x'.repeat(100),
+      sections: { executive_summary: 'x' },
+      ventureId: 'venture-real-1',
+      createdBy: 'eva-vision-command',
+      approved: true,
+    });
+    const record = captureUpserts[captureUpserts.length - 1];
+    expect(record.status).toBe('active');
+    expect(record.chairman_approved).toBe(true);
   });
 });

--- a/lib/eva/vision-repair-loop.js
+++ b/lib/eva/vision-repair-loop.js
@@ -300,6 +300,17 @@ export async function repairVision({
       ventureId,
       brainstormId,
       createdBy,
+      // SD-LEO-INFRA-VISION-REPAIR-NO-FORCE-APPROVE-001 (FR-1): a repair is a
+      // quality/content fix, NOT a chairman-approval. Pass approved:false so the
+      // repaired vision is written as a quality-repaired DRAFT (status=draft,
+      // chairman_approved=false; quality_checked may flip true). Activation +
+      // chairman approval stays the SEPARATE deliberate gate
+      // (scripts/eva/vision-command.mjs --approved) — repair must not be a
+      // backdoor that silently activates + approves a real-venture vision.
+      // Clone auto-promote is unaffected: _autoApproveCloneVision
+      // (stage-execution-worker.js) explicitly re-activates clone visions AFTER
+      // repair (real-venture carve-out preserved).
+      approved: false,
     });
 
     logger.log('[vision-repair-loop] attempt_complete', {


### PR DESCRIPTION
## Summary
Vision repair silently granted chairman approval on every attempt: `vision-repair-loop.js` called `upsertVision` without `approved`, so `vision-upsert.js`'s `approved=true` default force-set `status='active'` + `chairman_approved=true` — a backdoor around the deliberate vision-approval gate, including for REAL ventures.

## Changes
- **FR-1**: repair-loop passes `approved:false` → repaired vision is a quality DRAFT (`status='draft'`, `chairman_approved=false`; `quality_checked` may flip true). Activation/approval stays the separate deliberate gate.
- **FR-2/FR-3 (guardrail trace, no code change)**: real-venture activation only via the deliberate chairman gate (`vision-command.mjs --approved`); S19 `assertVentureVisionReady` still requires active+chairman_approved and correctly BLOCKS a repaired-draft vision until approved; `_autoApproveCloneVision` still re-activates CLONE visions after repair (real-venture carve-out preserved) — nothing stranded.
- **FR-4**: tests — repair writes a DRAFT; deliberate-gate matrix (approved:false→draft, approved:true→active+approved). **22/22 pass.**

## Follow-up (out of scope)
`stage-17-doc-generation.js:264` also force-approves on its first `upsertVision` (no `approved`) — same governance class, separate SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)