### PR TITLE
feat(SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001): ranker+forecaster exclusion parity via shared SSOT predicate

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S15-WIREFRAME-LLM-UNPARSEABLE-001",
-  "createdAt": "2026-06-29T06:26:37.489Z",
+  "sdKey": "SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001",
+  "expectedBranch": "feat/SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001",
+  "createdAt": "2026-06-29T13:08:32.954Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -33,7 +33,7 @@ import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-
 // demotes bare-shell stubs. FIXTURE_RE catches epoch-stamped TEST-E2E keys; the
 // bare-shell demotion uses the shared bareShellLastCompare so the test suite
 // exercises the real comparator, not a re-implementation.
-import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispatchRank } from '../lib/coordinator/sd-exclusion.mjs';
+import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispatchRank, isUnactionableRemediationSd } from '../lib/coordinator/sd-exclusion.mjs';
 // SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001: resolve dependency keys via the canonical
 // blocker rule (the same SSOT coordinator-audit.mjs imports) so the ranker and the capacity
 // forecaster AGREE on the 'no dependencies' sentinel ({sd_key:'none'} / bare 'none') and on
@@ -78,6 +78,17 @@ export function claimableDbFreeReason(d) {
   if (d.claiming_session_id) return 'claimed';
   if (isStartedSd(d)) return 'in_flight';
   if (isFixtureSd(d.sd_key, d.metadata)) return 'fixture';
+  // SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001: an un-actionable auto-filed venture-remediation
+  // SD (SD-LEO-FIX-REMEDIATION-* targeting a venture repo, not EHG_Engineer) cannot be actioned by any
+  // fleet worker, so it must not earn a real dispatch_rank. The capacity-forecaster already excludes
+  // these from belt depth via isExcludedFromBelt -> isUnactionableRemediationSd; the ranker previously
+  // demoted ONLY bare-shell stubs (isBareShell), so a ~345-char remediation stub slipped through and
+  // even outranked a real walk-blocker. Calling the SAME shared predicate here makes the two belts agree
+  // by construction (SSOT, can't diverge). NOTE: FR-1 described a 'generated_by fr-c' criterion, but the
+  // forecaster's actual detector is this key-prefix+target predicate — parity (FR-4) requires the SAME
+  // predicate in both paths, so we reuse the existing SSOT rather than introduce a divergent new one
+  // (spec-conflict signaled 2cde0ce8).
+  if (isUnactionableRemediationSd(d)) return 'unactionable_venture_remediation';
   return classifyDispatchIneligibility(d); // null => eligible on the DB-free axes
 }
 // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-1): the narrow, explicit fleet-critical predicate.

--- a/tests/unit/coordinator-ranker-forecaster-exclusion-parity.test.js
+++ b/tests/unit/coordinator-ranker-forecaster-exclusion-parity.test.js
@@ -1,0 +1,82 @@
+/**
+ * SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001
+ *
+ * The backlog-ranker and the capacity-forecaster must AGREE on excluding an un-actionable auto-filed
+ * venture-remediation SD. Before this fix they used divergent detectors: the forecaster excluded via
+ * isExcludedFromBelt -> isUnactionableRemediationSd, while the ranker demoted ONLY bare-shell stubs
+ * (isBareShell), so a ~345-char SD-LEO-FIX-REMEDIATION-* stub targeting a venture earned a real
+ * dispatch_rank above a walk-blocker. The fix lifts the SAME shared predicate into the ranker's
+ * claimableDbFreeReason, so both paths exclude the same rows by construction (SSOT).
+ *
+ * NOTE (spec reconciliation, signal 2cde0ce8): the SD's FR-1 described a 'generated_by fr-c' criterion,
+ * but the forecaster's ACTUAL detector is the key-prefix + non-EHG_Engineer-target isUnactionableRemediationSd.
+ * Parity (FR-4) requires the SAME predicate in both paths, so this test pins parity on the existing
+ * shared predicate rather than a divergent new one.
+ */
+import { describe, it, expect } from 'vitest';
+import { claimableDbFreeReason } from '../../scripts/coordinator-backlog-rank.mjs';
+import { isExcludedFromBelt, isUnactionableRemediationSd, isBareShell } from '../../lib/coordinator/sd-exclusion.mjs';
+
+// An un-actionable auto-filed venture-remediation SD: canonical remediation key + a NON-EHG_Engineer
+// target (the venture repo). 345-char description => NOT bare-shell (that was the gap).
+const ventureRemediationStub = {
+  sd_key: 'SD-LEO-FIX-REMEDIATION-UNIT-TEST-006',
+  sd_type: 'infrastructure',
+  status: 'draft',
+  current_phase: 'LEAD',
+  claiming_session_id: null,
+  target_application: 'EHG',
+  description: 'x'.repeat(345),
+  title: 'Remediate unit_test findings',
+  metadata: {},
+};
+
+// A genuine scoped harness SD targeting the fleet's own checkout.
+const genuineScoped = {
+  sd_key: 'SD-LEO-INFRA-GENUINE-SCOPED-001',
+  sd_type: 'infrastructure',
+  status: 'draft',
+  current_phase: 'LEAD',
+  claiming_session_id: null,
+  target_application: 'EHG_Engineer',
+  description: 'A fully authored strategic directive with real scope and acceptance criteria.',
+  title: 'Genuine scoped SD',
+  metadata: {},
+};
+
+describe('FR-4: ranker + forecaster agree on un-actionable venture-remediation exclusion', () => {
+  it('the venture-remediation stub is excluded by BOTH paths (parity)', () => {
+    // forecaster path
+    expect(isExcludedFromBelt(ventureRemediationStub)).toBe(true);
+    // ranker path
+    expect(claimableDbFreeReason(ventureRemediationStub)).toBe('unactionable_venture_remediation');
+    // both via the same shared predicate
+    expect(isUnactionableRemediationSd(ventureRemediationStub)).toBe(true);
+  });
+
+  it('a genuine scoped SD is excluded by NEITHER path', () => {
+    expect(isExcludedFromBelt(genuineScoped)).toBe(false);
+    expect(claimableDbFreeReason(genuineScoped)).toBeNull();
+    expect(isUnactionableRemediationSd(genuineScoped)).toBe(false);
+  });
+
+  it('a remediation SD targeting EHG_Engineer (actionable) is NOT excluded', () => {
+    const selfTargeted = { ...ventureRemediationStub, sd_key: 'SD-LEO-FIX-REMEDIATION-LINT-009', target_application: 'EHG_Engineer' };
+    expect(isUnactionableRemediationSd(selfTargeted)).toBe(false);
+    expect(claimableDbFreeReason(selfTargeted)).toBeNull();
+    expect(isExcludedFromBelt(selfTargeted)).toBe(false);
+  });
+});
+
+describe('isBareShell behavior unchanged', () => {
+  it('empty description => bare-shell', () => {
+    expect(isBareShell({ description: '', title: 'T' })).toBe(true);
+  });
+  it('description equal to title => bare-shell', () => {
+    expect(isBareShell({ description: 'Same', title: 'Same' })).toBe(true);
+  });
+  it('authored description => NOT bare-shell (incl. the 345-char remediation stub)', () => {
+    expect(isBareShell(genuineScoped)).toBe(false);
+    expect(isBareShell(ventureRemediationStub)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
The coordinator's backlog-ranker and capacity-forecaster used DIVERGENT exclusion detectors. The ranker demoted only bare-shell stubs (`isBareShell`), so an un-actionable auto-filed venture-remediation SD (`SD-LEO-FIX-REMEDIATION-*` targeting a venture repo, ~345-char description) earned a real `dispatch_rank` — even outranking a HIGH walk-blocker — while the forecaster already excluded it via `isExcludedFromBelt` → `isUnactionableRemediationSd`.

## Fix
Lift the SAME shared predicate into the ranker: `coordinator-backlog-rank.mjs` `claimableDbFreeReason()` now returns `'unactionable_venture_remediation'` via the existing `isUnactionableRemediationSd`. Both belts exclude the same rows **by construction** (SSOT — can't diverge). The forecaster is **unchanged** (already calls `isExcludedFromBelt` → FR-2 behavior-preserving no-op). New parity test pins both paths on the shared predicate; `isBareShell` unchanged.

## Spec reconciliation (signal 2cde0ce8)
FR-1 asked to *create* a new `isUnactionableVentureRemediation` predicate with `generated_by fr-c + LEAD/draft + un-scoped` criteria — but the forecaster's **actual** detector is the existing key-prefix+target `isUnactionableRemediationSd`. Since FR-4 demands **parity**, both paths must call the **same** predicate; a new divergent-criteria predicate would re-introduce the very divergence the SD kills. Grounded in code, reused the existing SSOT, and signaled the co-authoring coordinator to correct the FR-1 framing.

## Verification
- 7 new + 119 regression tests green (9 coordinator suites); `node --check` OK; testing-agent **PASS** (c11c8543); retro PUBLISHED 100/100 (8204ec88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)