### PR TITLE
feat(SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001): tier-aware claimable depth on belt + forecast

### DIFF
--- a/lib/fleet/tier-claimable.cjs
+++ b/lib/fleet/tier-claimable.cjs
@@ -1,0 +1,124 @@
+'use strict';
+/**
+ * Shared tier-aware claimable rollup (SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001).
+ *
+ * THE BUG THIS FIXES: a tier-3 worker sees the belt report N "ranked claimable" SDs but can claim 0 of
+ * them (they all require a higher rung), so it idles for hours. The per-SD tier gate already exists
+ * (claim-eligibility.cjs classifyDispatchIneligibility returns 'above_worker_tier' when a finite
+ * metadata.min_tier_rank exceeds the worker's rung, given tier ctx), but the two surfaces a worker reads
+ * are tier-blind: worker-checkin.cjs counts the FULL ranked pool and coordinator-capacity-forecast.mjs
+ * reports a single aggregate. This module is the ONE rollup both surfaces consume.
+ *
+ * REUSE, DON'T RE-IMPLEMENT (TR-1, the sibling SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001 lesson):
+ * the tier comparison + the base exclusion axes are NOT re-derived here — they delegate to
+ * classifyDispatchIneligibility (base axes without ctx; tier axis with ctx) and isExcludedFromBelt, so a
+ * third drift surface cannot open against the gate.
+ *
+ * TWO SUBTLETIES (from the LEAD validation of this SD):
+ *   - UNSCORED bucket: the gate only blocks a FINITE min_tier_rank > rung. An unscored SD (no finite
+ *     min_tier_rank) is reachable by EVERY tier. It is counted once in the aggregate and appears in every
+ *     tier's cumulative claimable-to-tier-N, so summing the EXACT-rank partition does not double-count it.
+ *   - TIERING-OFF (degrade-to-1): with < MIN_LIVE_FOR_TIERING live workers the tier axis is inert
+ *     (classifyDispatchIneligibility only applies it when ctx.tiering_active===true). claimableForTier
+ *     mirrors that — every tier's claimable == the full eligible aggregate when tieringActive !== true.
+ *
+ * @module lib/fleet/tier-claimable
+ */
+
+const { classifyDispatchIneligibility } = require('./claim-eligibility.cjs');
+// require-of-ESM: Node >= 22.12 (this fleet runs Node 24) loads a synchronous ESM module from CJS.
+// sd-exclusion.mjs is a pure, top-level-await-free classifier module, so this is safe.
+const { isExcludedFromBelt } = require('../coordinator/sd-exclusion.mjs');
+const { ladderTopRank } = require('./tier-ladder.cjs');
+
+/** The stamped min-tier-rank the gate itself reads; null when unscored / non-finite (grouping only —
+ *  the claim DECISION still goes through classifyDispatchIneligibility, never this reader). */
+function sdMinTierRank(sd) {
+  // NB: read via a ternary, not `Number(sd && sd.metadata && ...)` — a falsy chain yields `null`, and
+  // Number(null) === 0 would masquerade as a finite rank 0 (an unscored SD read as "rank 0").
+  const raw = sd && sd.metadata ? sd.metadata.min_tier_rank : undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Base (tier-agnostic) eligibility — mirrors the forecaster's aggregate loop: not belt-excluded AND the
+ * shared gate returns null on the DB-free axes (orchestrator/fixture/human-action/co-author/deferred/
+ * terminal). An optional depSatisfied(sd)=>bool adds the dependency axis when the caller has dep state.
+ * @param {object} sd
+ * @param {{ depSatisfied?: (sd:object)=>boolean }} [opts]
+ * @returns {boolean}
+ */
+function isBaseEligible(sd, opts = {}) {
+  if (!sd) return false;
+  try { if (isExcludedFromBelt(sd)) return false; } catch { /* fail-open: classifier fault never excludes */ }
+  if (classifyDispatchIneligibility(sd) !== null) return false;
+  if (typeof opts.depSatisfied === 'function' && !opts.depSatisfied(sd)) return false;
+  return true;
+}
+
+/** Does the tier axis block this SD for the given rung? Delegates to the gate (reuse, not re-derive).
+ *  Inert when tiering is off — matching the gate's ctx.tiering_active===true guard. */
+function tierBlocks(sd, workerTierRank, tieringActive) {
+  if (tieringActive !== true) return false;
+  return classifyDispatchIneligibility(sd, { worker_tier_rank: workerTierRank, tiering_active: true }) === 'above_worker_tier';
+}
+
+/**
+ * The subset of `pool` claimable AT workerTierRank: base-eligible AND tier-reachable. With tiering off,
+ * returns the full base-eligible aggregate (tier axis inert). Pass preFiltered:true when `pool` is already
+ * base-eligible (e.g. the forecaster's `claimable`) to skip the re-filter.
+ * @param {object[]} pool
+ * @param {{ workerTierRank?: number, tieringActive?: boolean, preFiltered?: boolean, depSatisfied?: Function }} opts
+ * @returns {object[]}
+ */
+function claimableForTier(pool, opts = {}) {
+  const { workerTierRank, tieringActive, preFiltered = false, depSatisfied } = opts;
+  const base = preFiltered ? (pool || []).slice() : (pool || []).filter((sd) => isBaseEligible(sd, { depSatisfied }));
+  if (tieringActive !== true) return base;
+  return base.filter((sd) => !tierBlocks(sd, workerTierRank, true));
+}
+
+/**
+ * Full per-tier breakdown for the capacity forecast. Returns the EXACT-rank partition (each base-eligible
+ * SD in exactly one bucket — rank 1..top, plus `unscored`, plus `aboveTop` for a defensive finite rank >
+ * top that no rung can claim) and the CUMULATIVE claimable-to-tier-N (what a tier-N worker can actually
+ * reach = unscored + sum of exact ranks 1..N). Self-checking invariant: aggregate === unscored + aboveTop
+ * + sum(exact). When tieringActive !== true, cumulative is the full aggregate for every rung.
+ * @param {object[]} pool
+ * @param {{ tieringActive?: boolean, preFiltered?: boolean, depSatisfied?: Function }} opts
+ * @returns {{ aggregate:number, top:number, exact:Object, unscored:number, aboveTop:number, cumulative:Object, tieringActive:boolean, partitionSumsToAggregate:boolean }}
+ */
+function tierClaimableBreakdown(pool, opts = {}) {
+  const { tieringActive, preFiltered = false, depSatisfied } = opts;
+  const base = preFiltered ? (pool || []).slice() : (pool || []).filter((sd) => isBaseEligible(sd, { depSatisfied }));
+  const top = ladderTopRank();
+  const exact = {};
+  for (let r = 1; r <= top; r += 1) exact[r] = 0;
+  let unscored = 0;
+  let aboveTop = 0;
+  for (const sd of base) {
+    const r = sdMinTierRank(sd);
+    if (r === null || r < 1) unscored += 1;            // unscored / nonsensical => reachable by all rungs
+    else if (r > top) aboveTop += 1;                    // defensive: a finite rank no rung can satisfy
+    else exact[r] += 1;
+  }
+  const cumulative = {};
+  let running = unscored;
+  for (let r = 1; r <= top; r += 1) {
+    running += exact[r];
+    // tiering OFF => the tier axis is inert => every rung can claim the full aggregate.
+    cumulative[r] = tieringActive === true ? running : base.length;
+  }
+  const aggregate = base.length;
+  const partitionSumsToAggregate = (unscored + aboveTop + Object.values(exact).reduce((a, b) => a + b, 0)) === aggregate;
+  return { aggregate, top, exact, unscored, aboveTop, cumulative, tieringActive: tieringActive === true, partitionSumsToAggregate };
+}
+
+module.exports = {
+  sdMinTierRank,
+  isBaseEligible,
+  tierBlocks,
+  claimableForTier,
+  tierClaimableBreakdown,
+};

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -37,6 +37,9 @@ import { isExcludedFromBelt } from '../lib/coordinator/sd-exclusion.mjs';
 // predicate the worker resolver uses — else RHA-held / co_author_pending SDs inflate belt depth and the
 // forecaster emits false belt-low DEFICITs (the exact masked-starvation symptom this SD targets).
 import { classifyDispatchIneligibility } from '../lib/fleet/claim-eligibility.cjs';
+// SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-3): per-tier claimable depth (not a single aggregate).
+import { tierClaimableBreakdown } from '../lib/fleet/tier-claimable.cjs';
+import { isTieringActive } from '../lib/fleet/tier-ladder.cjs';
 // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: the pure live-worker predicate. It wraps the
 // canonical isDispatchableFleetMember SSOT the dashboard uses (so the forecaster AGREES with
 // fleet-dashboard.cjs on coordinator/adam/non_fleet/fixture exclusion) and ADDS a released-status
@@ -357,6 +360,29 @@ async function main() {
   }
   console.log(`  BELT: ${beltDepth} claimable (${claimable.length} SD + ${openQfCount} QF)  |  DEMAND(soon): ${demandSoon} (idle ${idleNow} + freeing-soon ${freeingSoon})  |  buffer ${BELT_BUFFER}`);
   if (claimable.length) console.log(`        claimable SDs: ${claimable.map(d => d.sd_key.replace('SD-LEO-INFRA-', '')).join(', ')}`);
+
+  // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-3): TRUE per-tier claimable depth so a tier-specific
+  // deficit (e.g. "tier-3 claimable: 0") is explicit, not masked by the aggregate above. `claimable` is
+  // already base-eligible => preFiltered. The exact-rank partition (incl. unscored / above-top) sums to the
+  // aggregate as a self-check; the cumulative is what a worker AT that rung can actually claim. Fail-open
+  // (non-blocking) so a tier-rollup fault never breaks the forecast. Counts SDs only (QFs are tier-agnostic).
+  try {
+    const tieringActive = await isTieringActive(sb);
+    const bd = tierClaimableBreakdown(claimable, { tieringActive, preFiltered: true });
+    const exactStr = Object.keys(bd.exact).map((r) => `T${r}:${bd.exact[r]}`).join(' ');
+    const cumStr = Object.keys(bd.cumulative).map((r) => `≤T${r}:${bd.cumulative[r]}`).join(' ');
+    console.log(`  BELT-BY-TIER: ${tieringActive ? 'tiering ON' : 'tiering OFF (degrade-to-1: every rung sees the full aggregate)'}`);
+    console.log(`        exact-rank partition: ${exactStr}${bd.unscored ? ` unscored:${bd.unscored}` : ''}${bd.aboveTop ? ` above-top:${bd.aboveTop}` : ''}  (sum=${bd.aggregate}${bd.partitionSumsToAggregate ? ' ✓' : ' ✗DRIFT'})`);
+    console.log(`        claimable-to-tier (cumulative): ${cumStr}`);
+    if (tieringActive) {
+      const zeroTiers = Object.keys(bd.cumulative).filter((r) => bd.cumulative[r] === 0);
+      if (zeroTiers.length && bd.aggregate > 0) {
+        console.log(`        ⚠ tier deficit: rung(s) ${zeroTiers.map((r) => `T${r}`).join(', ')} have 0 claimable — a worker at that rung idles while belt shows ${bd.aggregate}`);
+      }
+    }
+  } catch (e) {
+    console.log(`  BELT-BY-TIER: unavailable (non-blocking): ${e?.message || e}`);
+  }
 
   // SD-LEO-INFRA-COORDINATOR-SOURCING-ENGINE-AWARENESS-001 (FR-2): sourcing-engine awareness — flag
   // state + unpromoted roadmap depth so belt-low is read as "activate/distill" before "hand-ask Adam".

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -38,6 +38,8 @@ const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cj
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
 const { resolveWorkerTierRank, isTieringActive } = require('../lib/fleet/tier-ladder.cjs');
+// SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): tier-aware "claimable-to-MY-rung" rollup.
+const { claimableForTier } = require('../lib/fleet/tier-claimable.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
 const { NATO, COLORS, nextAvailable, isTestSessionId, tierRankOf, pickCallsignForTier, callsignInTierBand } = require('./assign-fleet-identities.cjs');
@@ -1115,6 +1117,25 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
         tiering_active: await isTieringActive(sb),
       };
     } catch { /* fail-open: no tier ctx */ }
+    // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): belt_ranked_claimable above is the
+    // tier-AGNOSTIC ranked pool — a below-rung worker sees it non-zero even when every ranked SD is
+    // above its rung, then idles for hours on false "ranked" hope. Expose belt_claimable_at_my_tier:
+    // of the ranked pool, how many are base-eligible AND reachable at THIS worker's rung (shared
+    // tier-claimable rollup, reusing the gate). One batched fetch supplies the metadata the view-sourced
+    // baselined candidates lack. Fail-open to the agnostic count so a fault never under-reports.
+    base.belt_claimable_at_my_tier = base.belt_ranked_claimable;
+    try {
+      const ids = ranked.filter((x) => x.kind === 'baselined').map((x) => x.key);
+      const keys = ranked.filter((x) => x.kind === 'draft').map((x) => x.key);
+      const cols = 'sd_key,id,sd_type,status,description,title,metadata,target_application';
+      const pool = [];
+      if (ids.length) { const { data } = await sb.from('strategic_directives_v2').select(cols).in('id', ids); pool.push(...(data || [])); }
+      if (keys.length) { const { data } = await sb.from('strategic_directives_v2').select(cols).in('sd_key', keys); pool.push(...(data || [])); }
+      base.belt_claimable_at_my_tier = claimableForTier(pool, {
+        workerTierRank: tierCtx.worker_tier_rank,
+        tieringActive: tierCtx.tiering_active === true,
+      }).length;
+    } catch { /* fail-open: keep the agnostic count */ }
     for (const x of ranked) {
       if (x.kind === 'baselined') {
         // SD-FDBK-FIX-WORKER-SELF-CLAIM-001: skip dependency-blocked SDs and orchestrator PARENTS
@@ -1143,11 +1164,19 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   if (qfClaimed) return qfClaimed;
 
   // 7. idle -> recommend a wakeup (ScheduleWakeup is a HARNESS tool, not Node-callable)
+  // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): when the ranked pool is non-empty but NONE of
+  // it is claimable at this worker's rung, say so explicitly — otherwise the agnostic count reads as
+  // "work exists for me" and the idle looks like a bug rather than a tier deficit.
+  const rankedAgnostic = base.belt_ranked_claimable ?? 0;
+  const claimableAtTier = base.belt_claimable_at_my_tier ?? rankedAgnostic;
+  const tierNote = (rankedAgnostic > 0 && claimableAtTier === 0)
+    ? ` (${rankedAgnostic} ranked, but 0 claimable at your tier — all above your rung; a higher-tier worker must take them.)`
+    : '';
   return {
     ...base,
     action: 'idle',
     recommended_wakeup_seconds: DEFAULT_IDLE_WAKEUP_SECONDS,
-    message: `No assignment and nothing claimable. IDLE. The /checkin skill must now call ScheduleWakeup(~${DEFAULT_IDLE_WAKEUP_SECONDS}s) and proceed — never wait on a human.`,
+    message: `No assignment and nothing claimable. IDLE.${tierNote} The /checkin skill must now call ScheduleWakeup(~${DEFAULT_IDLE_WAKEUP_SECONDS}s) and proceed — never wait on a human.`,
   };
 }
 

--- a/tests/unit/fleet/tier-aware-claimable.test.js
+++ b/tests/unit/fleet/tier-aware-claimable.test.js
@@ -1,0 +1,150 @@
+/**
+ * SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-4) — tier-aware claimable rollup.
+ *
+ * Pure-function unit tests on lib/fleet/tier-claimable.cjs. The helper delegates the tier comparison +
+ * exclusion to the REAL gate (classifyDispatchIneligibility) and the REAL belt-exclusion SSOT
+ * (isExcludedFromBelt), so these tests exercise the genuine wiring, not a re-implementation. No Supabase.
+ *
+ * Invariants under test:
+ *   (a) a tier-N worker's claimable set excludes finite-rank > N SDs, includes rank<=N AND unscored;
+ *   (b) the unscored bucket is reachable by every tier and counted exactly once in the aggregate;
+ *   (c) aggregate === sum of the exact-rank partition (incl. unscored/above-top) — no double-count —
+ *       and cumulative claimable-to-tier-N === unscored + sum of exact ranks 1..N;
+ *   (d) tiering-OFF (degrade-to-1) => every tier's claimable === the full aggregate;
+ *   (e) an otherwise-ineligible SD (deferred / orchestrator / fixture / bare-shell) is excluded
+ *       regardless of tier.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { claimableForTier, tierClaimableBreakdown, isBaseEligible, sdMinTierRank } = require('../../../lib/fleet/tier-claimable.cjs');
+const { ladderTopRank } = require('../../../lib/fleet/tier-ladder.cjs');
+
+const TOP = ladderTopRank(); // 4
+
+// A well-formed, base-eligible SD (real description so it is NOT a bare-shell). rank=undefined => unscored.
+const sd = (sd_key, rank, extra = {}) => ({
+  sd_key,
+  sd_type: 'infrastructure',
+  status: 'draft',
+  title: `${sd_key} title`,
+  description: `A substantive description for ${sd_key} that is not equal to the title.`,
+  metadata: rank === undefined ? {} : { min_tier_rank: rank },
+  ...extra,
+});
+
+const keys = (arr) => arr.map((x) => x.sd_key).sort().join(',');
+
+describe('claimableForTier — WORK-DOWN-NEVER-UP per rung (FR-4a/b)', () => {
+  const pool = [sd('A', 1), sd('B', 2), sd('C', 3), sd('D', 4), sd('E', 4), sd('U')]; // U unscored
+
+  it('tier-3 worker: includes rank<=3 and unscored, excludes rank-4', () => {
+    expect(keys(claimableForTier(pool, { workerTierRank: 3, tieringActive: true }))).toBe('A,B,C,U');
+  });
+
+  it('tier-1 worker: only rank-1 and unscored', () => {
+    expect(keys(claimableForTier(pool, { workerTierRank: 1, tieringActive: true }))).toBe('A,U');
+  });
+
+  it('top-tier worker: everything (unscored reachable by all)', () => {
+    expect(claimableForTier(pool, { workerTierRank: TOP, tieringActive: true })).toHaveLength(6);
+  });
+
+  it('unscored SD is reachable at EVERY rung', () => {
+    for (let r = 1; r <= TOP; r += 1) {
+      expect(claimableForTier(pool, { workerTierRank: r, tieringActive: true }).some((x) => x.sd_key === 'U')).toBe(true);
+    }
+  });
+});
+
+describe('tierClaimableBreakdown — partition + cumulative invariants (FR-4c)', () => {
+  const pool = [sd('A', 1), sd('B', 2), sd('C', 3), sd('D', 4), sd('E', 4), sd('U'), sd('V')]; // 2 unscored
+
+  it('exact-rank partition sums to the aggregate (no double-count)', () => {
+    const bd = tierClaimableBreakdown(pool, { tieringActive: true });
+    expect(bd.aggregate).toBe(7);
+    expect(bd.unscored).toBe(2);
+    const partitionSum = bd.unscored + bd.aboveTop + Object.values(bd.exact).reduce((a, b) => a + b, 0);
+    expect(partitionSum).toBe(bd.aggregate);
+    expect(bd.partitionSumsToAggregate).toBe(true);
+  });
+
+  it('cumulative claimable-to-tier-N === unscored + sum of exact ranks 1..N', () => {
+    const bd = tierClaimableBreakdown(pool, { tieringActive: true });
+    let running = bd.unscored;
+    for (let r = 1; r <= TOP; r += 1) {
+      running += bd.exact[r];
+      expect(bd.cumulative[r]).toBe(running);
+      // and it must equal what claimableForTier returns for that rung
+      expect(claimableForTier(pool, { workerTierRank: r, tieringActive: true })).toHaveLength(running);
+    }
+  });
+
+  it('top rung cumulative === aggregate', () => {
+    const bd = tierClaimableBreakdown(pool, { tieringActive: true });
+    expect(bd.cumulative[TOP]).toBe(bd.aggregate);
+  });
+
+  it('defensive: a finite rank > top lands in aboveTop (in aggregate, in no cumulative rung)', () => {
+    const bd = tierClaimableBreakdown([sd('A', 1), sd('X', TOP + 1)], { tieringActive: true });
+    expect(bd.aboveTop).toBe(1);
+    expect(bd.aggregate).toBe(2);
+    expect(bd.partitionSumsToAggregate).toBe(true);
+    expect(bd.cumulative[TOP]).toBe(1); // only A (rank 1); X reachable by no rung
+  });
+});
+
+describe('tiering OFF — degrade-to-1 (FR-4d)', () => {
+  const pool = [sd('A', 1), sd('D', 4), sd('U')];
+
+  it('claimableForTier returns the full aggregate for every rung when tiering is off', () => {
+    for (let r = 1; r <= TOP; r += 1) {
+      expect(claimableForTier(pool, { workerTierRank: r, tieringActive: false })).toHaveLength(3);
+    }
+  });
+
+  it('breakdown cumulative is the full aggregate for every rung when tiering is off', () => {
+    const bd = tierClaimableBreakdown(pool, { tieringActive: false });
+    for (let r = 1; r <= TOP; r += 1) expect(bd.cumulative[r]).toBe(bd.aggregate);
+    // the exact partition is still computed (informational) and still sums to the aggregate
+    expect(bd.partitionSumsToAggregate).toBe(true);
+  });
+});
+
+describe('gate reuse — ineligible SDs excluded regardless of tier (FR-4e)', () => {
+  it('a deferred SD is not base-eligible', () => {
+    expect(isBaseEligible(sd('DEF', 1, { status: 'deferred' }))).toBe(false);
+  });
+  it('an orchestrator parent is not base-eligible', () => {
+    expect(isBaseEligible(sd('ORCH', 1, { sd_type: 'orchestrator' }))).toBe(false);
+  });
+  it('a bare-shell (description === title) is not base-eligible', () => {
+    expect(isBaseEligible({ sd_key: 'BARE', sd_type: 'infrastructure', status: 'draft', title: 'Same', description: 'Same', metadata: { min_tier_rank: 1 } })).toBe(false);
+  });
+  it('a fixture key is not base-eligible', () => {
+    expect(isBaseEligible(sd('SD-TEST-FOO', 1))).toBe(false);
+  });
+  it('ineligible SDs are dropped from claimableForTier AND the breakdown aggregate', () => {
+    const pool = [sd('A', 1), sd('DEF', 1, { status: 'deferred' }), sd('ORCH', 2, { sd_type: 'orchestrator' })];
+    expect(keys(claimableForTier(pool, { workerTierRank: TOP, tieringActive: true }))).toBe('A');
+    expect(tierClaimableBreakdown(pool, { tieringActive: true }).aggregate).toBe(1);
+  });
+});
+
+describe('sdMinTierRank reader', () => {
+  it('reads a finite stamped rank; null when unscored/non-finite', () => {
+    expect(sdMinTierRank(sd('A', 3))).toBe(3);
+    expect(sdMinTierRank(sd('U'))).toBeNull();
+    expect(sdMinTierRank({ metadata: { min_tier_rank: 'nope' } })).toBeNull();
+    expect(sdMinTierRank(null)).toBeNull();
+  });
+});
+
+describe('preFiltered passthrough', () => {
+  it('skips re-filtering when the pool is already base-eligible', () => {
+    // a deferred SD passed with preFiltered:true is trusted (counted) — caller asserts base eligibility
+    const pool = [sd('A', 1), sd('DEF', 1, { status: 'deferred' })];
+    expect(tierClaimableBreakdown(pool, { tieringActive: true, preFiltered: true }).aggregate).toBe(2);
+    expect(tierClaimableBreakdown(pool, { tieringActive: true, preFiltered: false }).aggregate).toBe(1);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001

A tier-3 worker saw the belt report N "ranked claimable" SDs but could claim 0 (all above its rung) and idled for hours. The per-SD tier gate already existed (`classifyDispatchIneligibility` → `above_worker_tier`), but the two surfaces a worker reads were tier-blind: `worker-checkin.cjs` counted the FULL ranked pool and the capacity forecast reported a single aggregate.

### Changes
- **FR-1** `lib/fleet/tier-claimable.cjs` (NEW) — `claimableForTier` + `tierClaimableBreakdown`. **Reuses** the gate (`classifyDispatchIneligibility`, with/without tier ctx) and the belt-exclusion SSOT (`isExcludedFromBelt`) — no re-implemented comparison (the third-drift-surface the sibling RANKER-FORECAST-PARITY SD prevents). Models the **unscored bucket** (reachable by every tier, counted once) and the **tiering-OFF degrade-to-1** path (every rung sees the full aggregate).
- **FR-2** `scripts/worker-checkin.cjs` — exposes `belt_claimable_at_my_tier` (one batched metadata fetch); idle message says "N ranked, but 0 claimable at your tier"; fail-open to the agnostic count.
- **FR-3** `scripts/coordinator-capacity-forecast.mjs` — prints `BELT-BY-TIER`: exact-rank partition (sum==aggregate self-check) + cumulative claimable-to-tier-N, surfacing a tier deficit explicitly.
- **FR-4** `tests/unit/fleet/tier-aware-claimable.test.js` (17 cases) — per-rung filtering, unscored-once, partition==aggregate (no double-count), cumulative==unscored+ranks 1..N, tiering-OFF==full-aggregate, gate reuse.

### Verification
- Live forecast renders the partition with a passing sum-check ✓. 82 tests green (17 new + 41 tier/eligibility + regression), 0 regressions.
- Node-24 require-of-ESM lets the CJS helper reuse the ESM exclusion SSOT. No schema change; `belt_ranked_claimable` kept for back-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
