### PR TITLE
fix(SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001): promote clone vision at every _runS19Bridge entry point

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-AUTO-REFILL-READ-DB-ACTIVATION-FLAG-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-AUTO-REFILL-READ-DB-ACTIVATION-FLAG-001",
-  "createdAt": "2026-06-29T13:39:14.702Z",
+  "sdKey": "SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001",
+  "createdAt": "2026-06-29T15:37:24.185Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/docs/reference/infrastructure-hardening-patterns.md
+++ b/docs/reference/infrastructure-hardening-patterns.md
@@ -597,6 +597,31 @@ return await validator(context);
 
 ---
 
+## Pattern: Wire a per-stage precondition at the SHARED CALLEE, not one call site (PAT-EVA-S19-PROMOTE-ORDER-001)
+
+**Symptom**: A per-stage promote/approve/normalize helper added before a shared callee runs covers
+only the entry path it was wired into, and silently misses the callee's other entry points.
+
+**Root cause (SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001)**: `_autoApproveCloneVision` (promote a
+clone's L2 vision so it passes the S19 vision gate) was invoked at ONLY the synchronous S19 entry gate.
+`_runS19Bridge` has four entry points — the entry-gate fast-path/primary, the S19 hard-gate
+run-then-recheck, and the fire-and-forget `_postStageHook_S19_Bridge`. A clone reaching the bridge via
+the hard-gate or post-hook path hit `assertVentureVisionReady` un-promoted → blocked on `vision_missing`.
+
+**Fix**: move the precondition to the TOP of the shared callee (`_runS19Bridge`) so every entry inherits
+it; delete the redundant single-site call. (Distinct from #5237, which fixed the promote's *internals*
+and deliberately kept the `isRepairLoopEnabled` kill-switch — call-ordering was a separate gap.)
+
+### PR-review checklist line
+
+> When a PR adds a per-stage promote/approve/normalize step **before** a shared callee runs, verify it
+> is wired at the **top of that shared callee** (so ALL entry points inherit it), not at a single caller.
+> Enumerate every call site of the callee (grep the method name) — especially fire-and-forget hooks and
+> hard-gate recheck paths that bypass the primary gate — and confirm a reachability test exercises an
+> entry path the original single call site did NOT cover (it must FAIL on the pre-fix ordering).
+
+---
+
 ## Cross-References
 
 - **Database Patterns**: [database-agent-patterns.md](./database-agent-patterns.md)

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1442,12 +1442,10 @@ export class StageExecutionWorker {
             // swallow it and the venture silently advance past S19 un-built.
             const advisory = s19Work?.advisory_data || {};
 
-            // SD-LEO-INFRA-CLONE-SEED-L2-VISION-PROMOTE-001: clone-scoped auto-promotion of an enriched
-            // L2 vision to active+approved (testing_agent) BEFORE the bridge's vision check, so a CLONE
-            // (which has no chairman to approve its vision) can pass the S19 vision_approval gate. No-op
-            // for real ventures (seeded_from_venture_id IS NULL) — their chairman-manual approval and the
-            // assertVentureVisionReady/shouldHoldAtS19 guard are untouched. Idempotent + fail-soft.
-            await this._autoApproveCloneVision(ventureId);
+            // SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001 (FR-1): the clone-vision auto-promote
+            // formerly invoked here now runs at the TOP of _runS19Bridge (the shared callee) so ALL
+            // bridge entry points promote first, not just this sync-gate path. Removed to avoid a
+            // redundant double-invocation (it is idempotent regardless).
 
             // Chairman override escape hatch: an operator can force advancement past S19.
             if (advisory.chairman_override === true) {
@@ -3560,6 +3558,18 @@ export class StageExecutionWorker {
    * @returns {Promise<{ created: boolean, errors: any, orchestratorKey: string|null, childKeys: string[] }>}
    */
   async _runS19Bridge(ventureId) {
+    // SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001 (FR-1): clone-scoped auto-promotion of an
+    // enriched L2 vision to active+chairman_approved (testing_agent) BEFORE the bridge's vision
+    // check (assertVentureVisionReady) — at the TOP of the SHARED callee so EVERY entry point
+    // inherits it: the S19 hard-gate run-then-recheck (~L690), the sync-gate fast-path/primary
+    // (~L1479/L1500), and the fire-and-forget _postStageHook_S19_Bridge (~L3424). The prior
+    // single call site (the sync entry gate only) left a clone arriving via the hard-gate or
+    // post-hook path un-promoted → it blocked on vision_missing. No-op + fail-soft for REAL
+    // ventures (early-returns 'real_venture' on seeded_from_venture_id IS NULL); idempotent once
+    // approved. Does NOT change the promote's internals — the #5237 isRepairLoopEnabled
+    // kill-switch and #5235 force-approve-backdoor closure are preserved.
+    await this._autoApproveCloneVision(ventureId);
+
     const { data: ventureRow } = await this._supabase
       .from('ventures').select('name').eq('id', ventureId).single();
 

--- a/tests/unit/eva/stage-execution-worker-s19-clone-vision-flow.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-clone-vision-flow.test.js
@@ -1,0 +1,143 @@
+/**
+ * SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001 (FR-2) — call-ordering reachability.
+ *
+ * A clone's enriched L2 vision must be auto-promoted to active+chairman_approved BEFORE the S19
+ * bridge evaluates vision readiness. The promote (_autoApproveCloneVision) used to be invoked at
+ * ONLY ONE of _runS19Bridge's four entry points — the synchronous S19 entry gate (~L1450), which
+ * precedes the fast-path/primary bridge runs. A clone arriving via the OTHER bridge entry points —
+ * the S19 hard-gate run-then-recheck (~L690) or the fire-and-forget _postStageHook_S19_Bridge
+ * (~L3424) — reached _runS19Bridge WITHOUT the promote and blocked on vision_missing.
+ *
+ * FR-1 moves the promote to the TOP of _runS19Bridge (the shared callee) so EVERY entry point
+ * inherits it. This test asserts _runS19Bridge invokes _autoApproveCloneVision FIRST, before any
+ * bridge DB op — which FAILS against the pre-FR-1 code (the bridge never called the promote) and
+ * PASSES after. The post-hook (_postStageHook_S19_Bridge) is a thin wrapper around _runS19Bridge,
+ * so covering the callee covers that entry path too. A companion test confirms a REAL venture is
+ * byte-unchanged (the real promote early-returns real_venture, no vision UPDATE).
+ *
+ * @module tests/unit/eva/stage-execution-worker-s19-clone-vision-flow.test
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const repairMocks = vi.hoisted(() => ({
+  isRepairLoopEnabled: vi.fn(),
+  repairVision: vi.fn(),
+}));
+vi.mock('../../../lib/eva/vision-repair-loop.js', () => ({
+  isRepairLoopEnabled: repairMocks.isRepairLoopEnabled,
+  repairVision: repairMocks.repairVision,
+}));
+
+const { StageExecutionWorker } = await import('../../../lib/eva/stage-execution-worker.js');
+const runS19Bridge = StageExecutionWorker.prototype._runS19Bridge;
+const postStageHook = StageExecutionWorker.prototype._postStageHook_S19_Bridge;
+const autoApproveReal = StageExecutionWorker.prototype._autoApproveCloneVision;
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+/**
+ * Mock supabase that drives _runS19Bridge down its seeded_repo EARLY-RETURN path (no
+ * convertSprintToSDs / _verifyAndProvisionVenture), recording the order of `from(table)` calls in
+ * `calls` so we can assert the promote ran before any bridge DB op. Also serves the queries the
+ * REAL _autoApproveCloneVision issues (ventures / eva_vision_documents) for the companion test.
+ */
+function makeBridgeSb({ calls, venture, activeL2 = null, draftSeed = null, updates = [] }) {
+  const sb = {
+    from(table) {
+      calls.push(`from:${table}`);
+      const ctx = { table, op: 'select', filters: {}, payload: null };
+      const builder = {
+        select() { ctx.op = 'select'; return builder; },
+        update(payload) { ctx.op = 'update'; ctx.payload = payload; return builder; },
+        eq(col, val) { ctx.filters[col] = val; return builder; },
+        order() { return builder; },
+        limit() { return builder; },
+        async upsert() { return { error: null }; },
+        async single() { return { data: resolve(ctx), error: null }; },
+        async maybeSingle() { return { data: resolve(ctx), error: null }; },
+        then(res) {
+          if (ctx.op === 'update') { updates.push({ table: ctx.table, payload: ctx.payload }); res({ error: null }); }
+          else res({ data: resolve(ctx), error: null });
+        },
+      };
+      return builder;
+    },
+  };
+  function resolve(ctx) {
+    if (ctx.table === 'ventures') {
+      // ventureRow (select name) | ventureBM2 (select build_model) | _autoApproveCloneVision (id, seeded_from_venture_id)
+      return { name: 'TestVenture', build_model: 'seeded_repo', ...venture };
+    }
+    if (ctx.table === 'venture_stage_work') return { advisory_data: {} };
+    if (ctx.table === 'eva_vision_documents') {
+      if (ctx.filters.status === 'active') return activeL2;
+      if (ctx.filters.status === 'draft_seed') return draftSeed;
+    }
+    return null;
+  }
+  return sb;
+}
+
+beforeEach(() => {
+  repairMocks.isRepairLoopEnabled.mockReset();
+  repairMocks.repairVision.mockReset();
+});
+
+describe('FR-1/FR-2: _runS19Bridge promotes a clone vision at the TOP (before any bridge DB op)', () => {
+  it('invokes _autoApproveCloneVision FIRST — fails pre-FR-1 (bridge never called the promote)', async () => {
+    const calls = [];
+    const autoApproveSpy = vi.fn(async () => { calls.push('autoApprove'); });
+    const ctx = {
+      _supabase: makeBridgeSb({ calls, venture: { id: 'clone-1', seeded_from_venture_id: 'src-1' } }),
+      _logger: silentLogger,
+      _autoApproveCloneVision: autoApproveSpy,
+      _verifyAndProvisionVenture: vi.fn(),
+    };
+
+    const result = await runS19Bridge.call(ctx, 'clone-1');
+
+    // The promote ran exactly once, and BEFORE any bridge DB access (calls[0]).
+    expect(autoApproveSpy).toHaveBeenCalledTimes(1);
+    expect(autoApproveSpy).toHaveBeenCalledWith('clone-1');
+    expect(calls[0]).toBe('autoApprove');
+    // Bridge still took its normal seeded_repo early-return (CREATED), promote did not change the outcome.
+    expect(result.created).toBe(true);
+  });
+
+  it('the _postStageHook_S19_Bridge entry path also promotes first (thin wrapper over the callee)', async () => {
+    const calls = [];
+    const autoApproveSpy = vi.fn(async () => { calls.push('autoApprove'); });
+    const ctx = {
+      _supabase: makeBridgeSb({ calls, venture: { id: 'clone-2', seeded_from_venture_id: 'src-2' } }),
+      _logger: silentLogger,
+      _autoApproveCloneVision: autoApproveSpy,
+      _runS19Bridge: runS19Bridge,
+      _verifyAndProvisionVenture: vi.fn(),
+    };
+
+    await postStageHook.call(ctx, 'clone-2');
+
+    expect(autoApproveSpy).toHaveBeenCalledTimes(1);
+    expect(calls[0]).toBe('autoApprove');
+  });
+
+  it('companion: REAL venture (seeded_from_venture_id NULL) is byte-unchanged — real promote no-ops, no vision UPDATE', async () => {
+    const calls = [];
+    const updates = [];
+    const ctx = {
+      _supabase: makeBridgeSb({ calls, venture: { id: 'real-1', seeded_from_venture_id: null }, updates }),
+      _logger: silentLogger,
+      _autoApproveCloneVision: autoApproveReal, // the REAL promote, bound via call below
+      _verifyAndProvisionVenture: vi.fn(),
+    };
+
+    const result = await runS19Bridge.call(ctx, 'real-1');
+
+    // The real promote was reached (it runs for every venture) but early-returned real_venture:
+    // no eva_vision_documents UPDATE, and the bridge proceeded unchanged.
+    const visionUpdates = updates.filter((u) => u.table === 'eva_vision_documents');
+    expect(visionUpdates).toHaveLength(0);
+    expect(result.created).toBe(true);
+    expect(repairMocks.repairVision).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
A clone's enriched L2 vision is auto-promoted (via `_autoApproveCloneVision`) so it passes the S19 vision gate. That promote was invoked at ONLY one of `_runS19Bridge`'s four entry points — the synchronous S19 entry gate. A clone reaching the bridge via the **S19 hard-gate run-then-recheck** (~L690) or the **fire-and-forget `_postStageHook_S19_Bridge`** (~L3424) hit `assertVentureVisionReady` un-promoted and blocked on `vision_missing`. PR #5237 fixed the promote's *internals* (dims preservation, repair-before-promote) but left this **call-ordering gap**.

## Changes (FR-1)
- Move `_autoApproveCloneVision(ventureId)` to the **top of `_runS19Bridge`** (the shared callee) so every entry point inherits it; delete the redundant single-site call.
- No-op + fail-soft for REAL ventures (early-returns `real_venture`); idempotent once approved.
- **Does NOT change the promote internals** — the #5237 `isRepairLoopEnabled` kill-switch and #5235 force-approve-backdoor closure are preserved. The original draft FR-1b (bypass the flag for clones) was **dropped** as a direct conflict with both shipped governance decisions.

## Tests (FR-2)
- `tests/unit/eva/stage-execution-worker-s19-clone-vision-flow.test.js`: asserts `_runS19Bridge` invokes the promote **first** (before any bridge DB op) and the post-hook path too; companion asserts a REAL venture is byte-unchanged. **Fails on the pre-FR-1 ordering (2/3), passes after.**

## Pattern (FR-3)
- `PAT-EVA-S19-PROMOTE-ORDER-001` recorded in `issue_patterns` + a PR-review checklist line in `docs/reference/infrastructure-hardening-patterns.md`: wire a per-stage precondition at the shared callee, not one call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)