### PR TITLE
feat(SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001): content-substance promotion gate (stop belt pollution)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-AUTO-REFILL-READ-DB-ACTIVATION-FLAG-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-AUTO-REFILL-READ-DB-ACTIVATION-FLAG-001",
-  "createdAt": "2026-06-29T13:39:14.702Z",
+  "sdKey": "SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001",
+  "createdAt": "2026-06-29T15:42:48.745Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/sourcing-engine/refill-candidate-validity.js
+++ b/lib/sourcing-engine/refill-candidate-validity.js
@@ -42,6 +42,11 @@ export const REFILL_INVALID_REASONS = Object.freeze({
   // raw, un-reviewed brainstorm items onto the belt. Flag-gated (opts.distilledOnly) so it is inert until
   // the operator turns SOURCING_AUTO_REFILL_DISTILLED_ONLY on — legacy items stay promotable until then.
   UNDISPOSITIONED_OR_NON_BUILD: 'undispositioned_or_non_build',
+  // SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001 (FR-1) — a CONTENTLESS raw-reference capture: a
+  // bare-URL / whole-title markdown-link title (youtube/claude.ai reference) with no recovered body, OR
+  // a refine layer grade other than 'promote' (review/defer = raw reference / not-ready, not buildable).
+  // Distinct from the length-based substance_thin (a bare URL can be short yet carry zero requirement).
+  CONTENT_SUBSTANCE: 'content_substance',
 });
 
 // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: the disposition value(s) that mark a staged item
@@ -117,6 +122,21 @@ export function hasRecoveredSubstance(item) {
   // A "description" that is itself a 120-char truncation shell is not recovered substance.
   if (isSubstanceThinTitle(d)) return false;
   return true;
+}
+
+// SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001 (FR-1): a CONTENTLESS title is a bare URL or a
+// whole-title markdown link [label](http(s)://...) — a raw youtube/claude.ai reference, NOT a buildable
+// spec. Distinct from substance_thin (length-based): a bare URL can be well under the 120-char cap yet
+// carry zero requirement. Matches truncated links too (the L3 backfill cut many mid-URL with no closing
+// paren). Conservative: only fires when the WHOLE (trimmed) title is the URL/link, not a title that
+// merely CONTAINS a URL. PURE/TOTAL.
+export const BARE_URL_TITLE_RE = /^\s*https?:\/\/\S+\s*$/i;
+export const MARKDOWN_LINK_ONLY_TITLE_RE = /^\s*\[[^\]]*\]\(\s*https?:\/\/[^)]*\)?\s*$/i;
+export function isBareUrlOrLinkOnlyTitle(title) {
+  if (typeof title !== 'string') return false;
+  const t = title.trim();
+  if (t === '') return false;
+  return BARE_URL_TITLE_RE.test(t) || MARKDOWN_LINK_ONLY_TITLE_RE.test(t);
 }
 
 /**
@@ -247,6 +267,17 @@ export function evaluateRefillCandidate(item, opts = {}) {
   // part-1 rejected. This only LOOSENS the part-1 reject; a full-length title was never thin anyway.
   if (isSubstanceThinTitle(item.title) && !hasRecoveredSubstance(item)) {
     return { valid: false, reason: REFILL_INVALID_REASONS.SUBSTANCE_THIN };
+  }
+  // SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001 (FR-1): content-substance axis. Reject a raw
+  // reference capture: (a) a bare-URL / whole-title markdown-link title (youtube/claude.ai link) with no
+  // recovered substantive body — softened by hasRecoveredSubstance so an enriched capture still promotes;
+  // OR (b) a refine layer grade other than 'promote' (review/defer = raw reference / not-ready). promote
+  // ONLY refine_recommendation='promote' (live grades: promote/review/defer). Sub-axis (b) fires only on
+  // an EXPLICIT non-promote value, so legacy items with no refine_recommendation flow through unchanged.
+  const refineRec = (item.metadata && typeof item.metadata === 'object') ? item.metadata.refine_recommendation : undefined;
+  if ((isBareUrlOrLinkOnlyTitle(item.title) && !hasRecoveredSubstance(item)) ||
+      (nonEmpty(refineRec) && String(refineRec).trim().toLowerCase() !== 'promote')) {
+    return { valid: false, reason: REFILL_INVALID_REASONS.CONTENT_SUBSTANCE };
   }
   const shippedTitleSet = opts && opts.shippedTitleSet;
   if (shippedTitleSet && typeof shippedTitleSet.has === 'function' &&

--- a/tests/unit/sourcing-engine/refill-content-substance-gate.test.js
+++ b/tests/unit/sourcing-engine/refill-content-substance-gate.test.js
@@ -1,0 +1,102 @@
+/**
+ * SD-LEO-INFRA-AUTO-REFILL-CONTENT-SUBSTANCE-GATE-001 (FR-1/FR-3)
+ *
+ * The auto-refill engine (live post-#5238) promoted RAW todoist-corpus captures as un-buildable
+ * SD-REFILL-* stubs: bare-URL / markdown-link-only titles (youtube/claude.ai references) and
+ * refine_recommendation='review' idea bookmarks. The new CONTENT_SUBSTANCE axis in
+ * evaluateRefillCandidate rejects both classes — distinct from the length-based substance_thin.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateRefillCandidate,
+  REFILL_INVALID_REASONS,
+  isBareUrlOrLinkOnlyTitle,
+} from '../../../lib/sourcing-engine/refill-candidate-validity.js';
+
+// Mirror the existing well-formed staged candidate (passes every OTHER axis).
+const validItem = (over = {}) => ({
+  item_disposition: 'pending',
+  promoted_to_sd_key: null,
+  title: 'Harden the worktree reaper',
+  source_type: 'conversion_ledger',
+  source_id: '11111111-1111-1111-1111-111111111111',
+  lane: 'belt',
+  ...over,
+});
+
+// The 4 contentless captures that polluted the belt (live titles).
+const CONTENTLESS_CAPTURES = {
+  '00BUV1PE': '[How Top Engineers Stop AI Agents From Writing Slop](https://youtu.be/88FC685v7ac?si=dxKybO1s85mGnR1p)',
+  '00C2EY90': '[Interactive session | Claude Code](https://claude.ai/code/session_01AD1Fex5StWuzbHTXoLjm43)',
+  '00HTVYPZ': '[How I Built The PERFECT AI Agent In 1 Week (And Why I CANT Release It)](https://youtu.be/_h2EnRfxMQE?si=kIbvXr0J5dUGNOcI)',
+  '00J2VGQI': '[Google Gemini’s NEW Upgrades Are MIND BLOWING (New Use Cases)](https://youtu.be/QsqSXIz-nX4?si=wMbfIFIp-581HGJj)',
+};
+
+describe('isBareUrlOrLinkOnlyTitle (FR-1 predicate)', () => {
+  it('TS-1: a bare URL title is contentless', () => {
+    expect(isBareUrlOrLinkOnlyTitle('https://claude.ai/code/session_01AD1Fex5StWuzbHTXoLjm43')).toBe(true);
+    expect(isBareUrlOrLinkOnlyTitle('  http://youtu.be/abc  ')).toBe(true);
+  });
+  it('TS-2: a whole-title markdown link is contentless (incl. truncated, no closing paren)', () => {
+    expect(isBareUrlOrLinkOnlyTitle('[Some Video](https://youtu.be/x)')).toBe(true);
+    expect(isBareUrlOrLinkOnlyTitle('[Truncated Title](https://youtu.be/x9gHaJ')).toBe(true); // truncated
+  });
+  it('all 4 live contentless captures match', () => {
+    for (const [id, title] of Object.entries(CONTENTLESS_CAPTURES)) {
+      expect(isBareUrlOrLinkOnlyTitle(title), id).toBe(true);
+    }
+  });
+  it('a substantive title (even one CONTAINING a url) is NOT contentless', () => {
+    expect(isBareUrlOrLinkOnlyTitle('Harden the worktree reaper')).toBe(false);
+    expect(isBareUrlOrLinkOnlyTitle('Fix the dashboard at https://app.example.com to show belt depth')).toBe(false);
+    expect(isBareUrlOrLinkOnlyTitle('')).toBe(false);
+    expect(isBareUrlOrLinkOnlyTitle(null)).toBe(false);
+  });
+});
+
+describe('evaluateRefillCandidate — CONTENT_SUBSTANCE axis', () => {
+  it('TS-1/TS-2: a bare-URL / markdown-link-only title is rejected', () => {
+    expect(evaluateRefillCandidate(validItem({ title: 'https://claude.ai/code/session_01AD' })).reason)
+      .toBe(REFILL_INVALID_REASONS.CONTENT_SUBSTANCE);
+    expect(evaluateRefillCandidate(validItem({ title: '[Some Video](https://youtu.be/x)' })).reason)
+      .toBe(REFILL_INVALID_REASONS.CONTENT_SUBSTANCE);
+  });
+
+  it('TS-6: all 4 live contentless captures are rejected by CONTENT_SUBSTANCE', () => {
+    for (const [id, title] of Object.entries(CONTENTLESS_CAPTURES)) {
+      const r = evaluateRefillCandidate(validItem({ title }));
+      expect(r.valid, id).toBe(false);
+      expect(r.reason, id).toBe(REFILL_INVALID_REASONS.CONTENT_SUBSTANCE);
+    }
+  });
+
+  it('TS-3: refine_recommendation review/defer is rejected (promote only "promote")', () => {
+    expect(evaluateRefillCandidate(validItem({ metadata: { refine_recommendation: 'review' } })).reason)
+      .toBe(REFILL_INVALID_REASONS.CONTENT_SUBSTANCE);
+    expect(evaluateRefillCandidate(validItem({ metadata: { refine_recommendation: 'defer' } })).reason)
+      .toBe(REFILL_INVALID_REASONS.CONTENT_SUBSTANCE);
+  });
+
+  it('TS-4: refine_recommendation=promote + substantive title PASSES', () => {
+    expect(evaluateRefillCandidate(validItem({ metadata: { refine_recommendation: 'promote' } })))
+      .toEqual({ valid: true, reason: null });
+  });
+
+  it('TS-5: a substantive idea-note with NO refine_recommendation still promotes', () => {
+    expect(evaluateRefillCandidate(validItem({ title: 'Add a per-capability vision gauge to the dashboard' })))
+      .toEqual({ valid: true, reason: null });
+  });
+
+  it('a contentless link with a recovered substantive body is NOT rejected (enrichment path)', () => {
+    const enriched = validItem({
+      title: '[Some Video](https://youtu.be/x)',
+      metadata: { description: 'Extracted spec: add a retry-with-backoff wrapper to the promotion path so transient DB errors do not drop a candidate; cover with a unit test.' },
+    });
+    // softened by hasRecoveredSubstance — only the bare-link sub-axis is bypassed; no non-promote grade here
+    expect(evaluateRefillCandidate(enriched)).toEqual({ valid: true, reason: null });
+  });
+
+  it('legacy item with no refine_recommendation + substantive title is unaffected', () => {
+    expect(evaluateRefillCandidate(validItem())).toEqual({ valid: true, reason: null });
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #5238 (which unblocked the auto-refill engine). Once live, the engine promoted **raw todoist-corpus captures** as un-buildable `SD-REFILL-*` stubs: (a) contentless **bare-URL / whole-title markdown-link** titles (youtube/claude.ai links whose backfilled title IS the URL — they passed `missing_title` but carried no spec), and (b) `refine_recommendation='review'` raw-reference items. I LEAD-rejected 4 polluted stubs this session; Golf+Foxtrot also deferred the class.

## Fix (FR-1)
New **`CONTENT_SUBSTANCE`** belt-quality axis in `evaluateRefillCandidate` (`lib/sourcing-engine/refill-candidate-validity.js`): rejects (a) a bare-URL / whole-title markdown-link title (softened by `hasRecoveredSubstance` so an *enriched* capture still promotes) **and** (b) any `refine_recommendation` other than `'promote'` (`review`/`defer` rejected). **Distinct** from the length-based `substance_thin` (a bare URL can be short yet contentless). Pure + conservative: an absent recommendation + substantive title still pass; a title merely *containing* a URL is not rejected.

Ground-truth note: the converged scope said "promote only build/approved", but the live `refine_recommendation` distribution is `promote=21 / review=160 / defer=19` — `build`/`approved` don't exist, so the gate keys on `'promote'`.

## Verification
- 11 new unit tests incl. the **4 live contentless captures** (00BUV1PE/00C2EY90/00HTVYPZ/00J2VGQI) as fixtures; **252 sourcing tests green** (24 suites); `node --check` OK; testing-agent **PASS** (c4f3713f); retro PUBLISHED 100/100 (be3b4562).

## Deferred (flagged)
**FR-2 enrich-before-promote** (extract a video/page into a real spec) is a larger LLM-enrichment effort — deferred; FR-1 stops the pollution at the source now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)