### PR TITLE
feat(SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001): clean-clone launch sets per-venture vision-repair override

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001",
-  "createdAt": "2026-06-29T15:37:24.185Z",
+  "sdKey": "SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001",
+  "createdAt": "2026-06-29T16:34:39.362Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/clean-clone/launch.js
+++ b/lib/eva/clean-clone/launch.js
@@ -59,6 +59,42 @@ export async function findExistingClone(supabase, sourceVentureId) {
  * @param {Function} deps.executeStageZero - the Stage-0 driver (injected; from lib/eva/stage-zero)
  * @returns {Promise<Object>} structured launch result
  */
+/**
+ * SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001 (FR-1): opt a freshly-launched clone into the
+ * vision-repair loop via the flag's DESIGNED per-venture override — the eva_venture_config key
+ * `venture:<id>:vision_repair_loop_enabled`=true that isRepairLoopEnabled (lib/eva/vision-repair-loop.js)
+ * already reads with precedence over the global flag. So a fresh clone (which structurally needs repair:
+ * 0/10 sections, no chairman) can repair its draft_seed vision at S19, while the global kill-switch stays
+ * default-off and real ventures are untouched. This is NOT a code bypass of isRepairLoopEnabled and NOT a
+ * global-flag flip (the #5237 kill-switch / #5235 backdoor-closure governance stays intact). Idempotent
+ * (onConflict 'key') and best-effort / non-fatal — the clone is already created, so a config-write
+ * failure logs and returns false rather than throwing up. Clone-only: called solely by launchCleanClone.
+ * @param {Object} supabase
+ * @param {string} ventureId - the new clone's venture UUID
+ * @param {Object} [logger=console]
+ * @returns {Promise<boolean>} true when the override row was written
+ */
+export async function setCloneVisionRepairOverride(supabase, ventureId, logger = console) {
+  if (!supabase || !ventureId) return false;
+  const key = `venture:${ventureId}:vision_repair_loop_enabled`;
+  try {
+    const { error } = await supabase
+      .from('eva_venture_config')
+      .upsert({
+        key,
+        value: true,
+        description: 'Per-venture vision-repair override set by clean-clone launch (SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001) so a fresh clone can repair its draft_seed vision at S19; global kill-switch stays off.',
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'key' });
+    if (error) throw new Error(error.message);
+    logger.log?.(`[CleanCloneLaunch] vision-repair per-venture override set: ${key}=true`);
+    return true;
+  } catch (e) {
+    logger.warn?.(`[CleanCloneLaunch] vision-repair override upsert failed (non-fatal): ${e.message}`);
+    return false;
+  }
+}
+
 export async function launchCleanClone(params = {}, deps = {}) {
   const {
     sourceVentureId = DEFAULT_SOURCE_VENTURE_ID,
@@ -98,6 +134,10 @@ export async function launchCleanClone(params = {}, deps = {}) {
   const newVentureId = stageZero?.record_id || stageZero?.venture_id || stageZero?.venture?.id || null;
   if (!dryRun && newVentureId) {
     logger.log(`[CleanCloneLaunch] LIVE clone created: ${newVentureId} — the daemon will advance it S0->S19`);
+    // SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001 (FR-1): opt the clone into vision repair via
+    // the designed per-venture override so it can promote its draft_seed vision at S19 (the global
+    // kill-switch stays off; real ventures untouched). Best-effort — the clone already exists.
+    await setCloneVisionRepairOverride(supabase, newVentureId, logger);
   }
   return {
     ok: stageZero?.success !== false,

--- a/tests/unit/eva/clone-launch-repair-override.test.js
+++ b/tests/unit/eva/clone-launch-repair-override.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-INFRA-CLONE-LAUNCH-ENABLES-REPAIR-OVERRIDE-001 (FR-2)
+ *
+ * Clean-clone launch opts a fresh clone into vision repair via the flag's DESIGNED per-venture override
+ * (eva_venture_config key venture:<id>:vision_repair_loop_enabled=true). This test drives the REAL
+ * override write (setCloneVisionRepairOverride — the same helper launchCleanClone calls) and the REAL
+ * isRepairLoopEnabled read — NOT a mock of the flag (closing the 2nd 'test doesn't exercise the real
+ * path' miss). The global kill-switch stays off; real ventures are unaffected.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setCloneVisionRepairOverride } from '../../../lib/eva/clean-clone/launch.js';
+import { isRepairLoopEnabled } from '../../../lib/eva/vision-repair-loop.js';
+
+// Faithful in-memory eva_venture_config double: implements exactly the chain isRepairLoopEnabled uses
+// (.from('eva_venture_config').select('value').eq('key',K).maybeSingle()) and the helper's upsert.
+function makeConfigStore(initial = {}) {
+  const rows = new Map(Object.entries(initial)); // key -> boolean value
+  return {
+    rows,
+    from(table) {
+      if (table !== 'eva_venture_config') throw new Error(`unexpected table: ${table}`);
+      let key = null;
+      return {
+        select() { return this; },
+        eq(col, val) { if (col === 'key') key = val; return this; },
+        async maybeSingle() {
+          return rows.has(key) ? { data: { value: rows.get(key) }, error: null } : { data: null, error: null };
+        },
+        async upsert(row) { rows.set(row.key, row.value); return { data: [row], error: null }; },
+      };
+    },
+  };
+}
+
+const CLONE = '11111111-1111-1111-1111-111111111111';
+const OTHER = '22222222-2222-2222-2222-222222222222';
+const silent = { log() {}, warn() {} };
+let savedEnv;
+
+beforeEach(() => { savedEnv = process.env.LEO_VISION_REPAIR_LOOP_ENABLED; delete process.env.LEO_VISION_REPAIR_LOOP_ENABLED; });
+afterEach(() => { if (savedEnv === undefined) delete process.env.LEO_VISION_REPAIR_LOOP_ENABLED; else process.env.LEO_VISION_REPAIR_LOOP_ENABLED = savedEnv; });
+
+describe('FR-2: clone repair override drives the REAL isRepairLoopEnabled', () => {
+  it('TS-1: after the override is set, the REAL isRepairLoopEnabled returns true for the clone (global off)', async () => {
+    const sb = makeConfigStore({ vision_repair_loop_enabled: false }); // global kill-switch OFF
+    const wrote = await setCloneVisionRepairOverride(sb, CLONE, silent);
+    expect(wrote).toBe(true);
+    expect(sb.rows.get(`venture:${CLONE}:vision_repair_loop_enabled`)).toBe(true);
+    // REAL predicate (not mocked)
+    expect(await isRepairLoopEnabled({ supabase: sb, ventureId: CLONE })).toBe(true);
+    // global stays false
+    expect(sb.rows.get('vision_repair_loop_enabled')).toBe(false);
+  });
+
+  it('TS-2: a venture NOT launched via clean-clone is unaffected (real isRepairLoopEnabled false)', async () => {
+    const sb = makeConfigStore({ vision_repair_loop_enabled: false });
+    await setCloneVisionRepairOverride(sb, CLONE, silent);
+    expect(await isRepairLoopEnabled({ supabase: sb, ventureId: OTHER })).toBe(false);
+  });
+
+  it('TS-3: the override helper is idempotent (re-run => still one row, still enabled)', async () => {
+    const sb = makeConfigStore({ vision_repair_loop_enabled: false });
+    await setCloneVisionRepairOverride(sb, CLONE, silent);
+    await setCloneVisionRepairOverride(sb, CLONE, silent);
+    const overrideRows = [...sb.rows.keys()].filter((k) => k === `venture:${CLONE}:vision_repair_loop_enabled`);
+    expect(overrideRows).toHaveLength(1);
+    expect(await isRepairLoopEnabled({ supabase: sb, ventureId: CLONE })).toBe(true);
+  });
+
+  it('TS-4: a config-write error is non-fatal (helper returns false, does not throw)', async () => {
+    const erroringSb = { from: () => ({ upsert: async () => ({ data: null, error: { message: 'boom' } }) }) };
+    await expect(setCloneVisionRepairOverride(erroringSb, CLONE, silent)).resolves.toBe(false);
+  });
+
+  it('guards: missing supabase / ventureId => false, no throw', async () => {
+    expect(await setCloneVisionRepairOverride(null, CLONE, silent)).toBe(false);
+    expect(await setCloneVisionRepairOverride(makeConfigStore(), '', silent)).toBe(false);
+  });
+
+  it('an explicit per-venture OFF override still beats the (off) global, and the clone override is independent', async () => {
+    const sb = makeConfigStore({ vision_repair_loop_enabled: false, [`venture:${OTHER}:vision_repair_loop_enabled`]: false });
+    await setCloneVisionRepairOverride(sb, CLONE, silent);
+    expect(await isRepairLoopEnabled({ supabase: sb, ventureId: CLONE })).toBe(true);   // clone opted in
+    expect(await isRepairLoopEnabled({ supabase: sb, ventureId: OTHER })).toBe(false);  // explicit off
+  });
+});


### PR DESCRIPTION
## Summary
Next layer after #5241: that PR made `_autoApproveCloneVision` reachable, but a fresh clone still returned `quality_not_checked` at S19 because vision repair is gated behind `isRepairLoopEnabled` + the global `vision_repair_loop_enabled` kill-switch (off since 2026-04-29). A code-bypass was (correctly) refused as conflicting with the #5237 kill-switch / #5235 backdoor-closure governance.

## Fix
- **FR-1:** clean-clone **launch** now sets the flag's **designed per-venture override** — `eva_venture_config` key `venture:<newVentureId>:vision_repair_loop_enabled=true` — at clone creation, via a new exported `setCloneVisionRepairOverride` helper (idempotent `onConflict 'key'`, best-effort/non-fatal, clone-only, `!dryRun`). `isRepairLoopEnabled` already reads this override with precedence over the global flag, so the clone opts into repair while the **global kill-switch stays off** and real ventures are untouched. **Not** a code bypass, **not** a global-flag flip — governance intact.
- **FR-2 (REAL-flag test):** drives the **real** override write + the **real** `isRepairLoopEnabled` (no `vi.mock` of the flag) via an in-memory `eva_venture_config` double that faithfully implements the exact query chain; clears `LEO_VISION_REPAIR_LOOP_ENABLED` so the per-venture DB path is genuinely exercised. Closes the 2× 'test doesn't exercise the real path' miss.

## End-to-end (FR-3)
With #5241 + this, a fresh clone reaching S19 has its per-venture repair override on → repair runs → `quality_checked` → vision goes active+approved → the lifecycle bridge creates the tree. No manual flag, no global flip, kill-switch intact.

## Verification
- 6 new + 20 regression tests green (clean-clone / clone-vision / vision-repair); `node --check` OK; testing-agent **PASS** (929598fb, independently confirmed no mock of `isRepairLoopEnabled`); retro PUBLISHED 100/100 (3f653362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)