### PR TITLE
fix(SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-PRODUCT-PIVOT-001): sourcing-time critical-walk-blocker band outranks product-pivot

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S19-CLONE-VISION-PROMOTE-ORDER-001",
-  "createdAt": "2026-06-29T15:37:24.185Z",
+  "sdKey": "SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-PRODUCT-PIVOT-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-PRODUCT-PIVOT-001",
+  "createdAt": "2026-06-29T16:58:23.032Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -95,6 +95,19 @@ export function claimableDbFreeReason(d) {
 // metadata.fleet_critical===true marks work whose ABSENCE blocks ALL fleet progress. Exported pure so
 // the band ordering is unit-testable. STRICT === true so a stray truthy value can't silently enrol.
 export function isFleetCritical(d) { return (d && d.metadata || {}).fleet_critical === true; }
+// SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-PRODUCT-PIVOT-001 (FR-1/FR-3): the CRITICAL-WALK-BLOCKER
+// band predicate — a SUPERSET of isFleetCritical that also honors two DURABLE SOURCING-TIME signals an
+// Adam-sourced walk-blocker carries in its proposal metadata, so the coordinator no longer hand-sets
+// fleet_critical at runtime for each one:
+//   - fleet_critical          (legacy, coordinator-set; retained for the dispatch-lane audit/cap)
+//   - convergence_caught      (Adam sets at sourcing when the clone-convergence loop caught a blocker)
+//   - blocks_active_mission   (Adam sets at sourcing when the SD blocks the active fleet mission/walk)
+// STRICT === true on every key so a stray truthy value cannot silently enrol (anti-gaming, mirrors
+// isFleetCritical). Exported pure so the band ordering is unit-testable against real code.
+export function isCriticalWalkBlocker(d) {
+  const m = (d && d.metadata) || {};
+  return m.fleet_critical === true || m.convergence_caught === true || m.blocks_active_mission === true;
+}
 // SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001 (FR-3): product-vs-harness class detection for the
 // pivot-aware product-priority band. Pure + exported so the band ordering is unit-testable against
 // real code (like isFleetCritical). Classification is by sd_key prefix; an SD that is neither is
@@ -268,7 +281,11 @@ async function main() {
   // ABOVE unlock+needle so a fleet_critical SD reaches a worker WITHOUT polluting the gauge or
   // requiring a WORK_ASSIGNMENT. It stays BELOW the bare-shell/quarantine quality gates (a
   // fleet_critical stub still cannot pass LEAD). FR-3 anti-gaming: rationed + audited below.
-  const fleetCritical = isFleetCritical;   // module-level exported predicate (unit-tested)
+  const fleetCritical = isFleetCritical;   // narrower subset — used ONLY by the FR-3 audit/cap below
+  // SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-PRODUCT-PIVOT-001 (FR-1): the comparator BAND uses the
+  // generalized critical-walk-blocker predicate (fleet_critical | convergence_caught | blocks_active_mission)
+  // so a sourcing-time walk-blocker outranks the product-pivot band WITHOUT a runtime fleet_critical hand-set.
+  const criticalWalkBlocker = isCriticalWalkBlocker; // module-level exported predicate (unit-tested)
 
   // ── needle-movement context (FR-2) ── REUSE the FR-1 rollup for the active rung + per-rung progress,
   // and roadmap_wave_items→waves for each SD's rung. Best-effort: any failure leaves needle scores at 0
@@ -321,11 +338,15 @@ async function main() {
     if (bs !== 0) return bs;                                // authored (non-bare-shell) first
     const qa = quarantined(a) ? 1 : 0, qb = quarantined(b) ? 1 : 0;
     if (qa !== qb) return qa - qb;                          // human-authored first
-    // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-2): the fleet-critical operational band —
-    // ABOVE unlock+needle (so a needle-0 fleet-health SD outranks MED wave backlog without a fake
-    // rung or manual dispatch), BELOW the bare-shell/quarantine quality gates.
-    const fa = fleetCritical(a) ? 1 : 0, fb = fleetCritical(b) ? 1 : 0;
-    if (fa !== fb) return fb - fa;                          // fleet-critical first
+    // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-2) + SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-
+    // PRODUCT-PIVOT-001 (FR-1): the critical-walk-blocker operational band — ABOVE unlock+needle AND ABOVE
+    // the product-pivot band (so a HIGH critical walk-blocker outranks a MED product note without a runtime
+    // fleet_critical hand-set), BELOW the bare-shell/quarantine quality gates. The band predicate is the
+    // generalized critical-walk-blocker (fleet_critical | convergence_caught | blocks_active_mission, all
+    // sourcing-time). Routine (non-critical-walk-blocker) harness SDs are unaffected and keep the product-
+    // pivot ordering below.
+    const fa = criticalWalkBlocker(a) ? 1 : 0, fb = criticalWalkBlocker(b) ? 1 : 0;
+    if (fa !== fb) return fb - fa;                          // critical-walk-blocker first
     const ua = unlockScore(a.sd_key), ub = unlockScore(b.sd_key);
     if (ub !== ua) return ub - ua;
     // SD-LEO-INFRA-BELT-RANKER-PIVOT-AWARENESS-001 (FR-1): the pivot-aware product-priority band.

--- a/tests/unit/coordinator-backlog-rank-critical-walk-blocker.test.js
+++ b/tests/unit/coordinator-backlog-rank-critical-walk-blocker.test.js
@@ -1,0 +1,93 @@
+/**
+ * SD-LEO-INFRA-CRITICAL-WALK-BLOCKER-OUTRANKS-PRODUCT-PIVOT-001 (FR-1/FR-2/FR-3/FR-4)
+ *
+ * The backlog ranker's product-pivot band ranks ANY product-class SD above ANY harness-class SD when
+ * the pivot is active — so a thin MED product idea-note outranked a HIGH critical S19 walk-blocker, and
+ * the only override (the fleet-critical band) required a RUNTIME metadata.fleet_critical hand-set.
+ *
+ * The fix generalizes the band predicate to isCriticalWalkBlocker = STRICT-true on ANY of three DURABLE
+ * SOURCING-TIME signals (fleet_critical | convergence_caught | blocks_active_mission), so an Adam-sourced
+ * walk-blocker outranks the product-pivot band WITHOUT a runtime hand-set. The product-pivot bias is
+ * preserved for every NON-critical-walk-blocker SD.
+ *
+ * These tests lock down (a) the gating predicate and (b) the ordering contract: the critical-walk-blocker
+ * band sits ABOVE the product-pivot band, which sits ABOVE priority. The full comparator's placement
+ * (above unlock+needle, below the bare-shell/quarantine gates) is exercised live by the dry-run dogfood.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isCriticalWalkBlocker,
+  isFleetCritical,
+  productPivotCompare,
+  productPivotRank,
+} from '../../scripts/coordinator-backlog-rank.mjs';
+
+describe('SD-...-CRITICAL-WALK-BLOCKER: isCriticalWalkBlocker predicate', () => {
+  it('is true for fleet_critical===true (backward-compat: a superset of isFleetCritical)', () => {
+    const d = { metadata: { fleet_critical: true } };
+    expect(isCriticalWalkBlocker(d)).toBe(true);
+    expect(isFleetCritical(d)).toBe(true); // fleet_critical is still its own narrower predicate
+  });
+
+  it('is true for the new sourcing-time signals convergence_caught / blocks_active_mission ===true', () => {
+    expect(isCriticalWalkBlocker({ metadata: { convergence_caught: true } })).toBe(true);
+    expect(isCriticalWalkBlocker({ metadata: { blocks_active_mission: true } })).toBe(true);
+    // ...but these are NOT fleet_critical (so the dispatch-lane audit/cap only counts hand-set ones).
+    expect(isFleetCritical({ metadata: { convergence_caught: true } })).toBe(false);
+  });
+
+  it('is false for false / undefined / missing metadata', () => {
+    expect(isCriticalWalkBlocker({ metadata: { fleet_critical: false, convergence_caught: false } })).toBe(false);
+    expect(isCriticalWalkBlocker({ metadata: {} })).toBe(false);
+    expect(isCriticalWalkBlocker({})).toBe(false);
+    expect(isCriticalWalkBlocker({ metadata: null })).toBe(false);
+  });
+
+  it('is STRICT — a truthy-but-not-true value does NOT enrol (anti-gaming) on ANY key', () => {
+    for (const v of [1, 'true', 'yes', {}, []]) {
+      expect(isCriticalWalkBlocker({ metadata: { fleet_critical: v } })).toBe(false);
+      expect(isCriticalWalkBlocker({ metadata: { convergence_caught: v } })).toBe(false);
+      expect(isCriticalWalkBlocker({ metadata: { blocks_active_mission: v } })).toBe(false);
+    }
+  });
+});
+
+describe('SD-...-CRITICAL-WALK-BLOCKER: ordering contract (band above product-pivot above priority)', () => {
+  // Mirror the relevant slice of the real comparator: critical-walk-blocker band, then product-pivot
+  // band (when active), then priority. (Higher priority weight sorts earlier.)
+  const PW = { critical: 3, high: 2, medium: 1, med: 1, low: 0 };
+  const cmp = (a, b, pivotActive) => {
+    const fa = isCriticalWalkBlocker(a) ? 1 : 0, fb = isCriticalWalkBlocker(b) ? 1 : 0;
+    if (fa !== fb) return fb - fa;                 // critical-walk-blocker first
+    const pp = productPivotCompare(a, b, pivotActive);
+    if (pp !== 0) return pp;                        // then product-pivot band
+    return (PW[(b.priority || '').toLowerCase()] ?? 0) - (PW[(a.priority || '').toLowerCase()] ?? 0);
+  };
+
+  const harnessWalkBlocker = { sd_key: 'SD-LEO-INFRA-S19-PROMOTE-ORDER-001', priority: 'high', metadata: { convergence_caught: true } };
+  const productNote = { sd_key: 'SD-EHG-PRODUCT-IDEA-NOTE-001', priority: 'medium', metadata: {} };
+  const routineHarness = { sd_key: 'SD-LEO-INFRA-ROUTINE-001', priority: 'medium', metadata: {} };
+
+  it('FR-1/FR-3: a HIGH critical-walk-blocker (convergence_caught, sourcing-time) outranks a MED product note WITHOUT a runtime fleet_critical', () => {
+    expect(isFleetCritical(harnessWalkBlocker)).toBe(false); // no runtime hand-set
+    expect(cmp(harnessWalkBlocker, productNote, true)).toBeLessThan(0);   // walk-blocker first
+    expect(cmp(productNote, harnessWalkBlocker, true)).toBeGreaterThan(0);
+  });
+
+  it('FR-2: a routine MED harness SD still ranks BELOW a MED product SD (product bias preserved)', () => {
+    expect(productPivotRank(productNote)).toBe(0);     // product band first
+    expect(productPivotRank(routineHarness)).toBe(2);  // harness band last
+    expect(cmp(productNote, routineHarness, true)).toBeLessThan(0);       // product first
+    expect(cmp(routineHarness, productNote, true)).toBeGreaterThan(0);
+  });
+
+  it('the S19-PROMOTE-ORDER-style walk-blocker ranks #1 among {product note, routine harness} with the pivot active', () => {
+    const ranked = [productNote, routineHarness, harnessWalkBlocker].sort((a, b) => cmp(a, b, true));
+    expect(ranked[0]).toBe(harnessWalkBlocker);
+  });
+
+  it('fleet_critical===true still enrols the band (backward-compat with the dispatch-lane SD)', () => {
+    const legacy = { sd_key: 'SD-LEO-INFRA-LEGACY-001', priority: 'medium', metadata: { fleet_critical: true } };
+    expect(cmp(legacy, productNote, true)).toBeLessThan(0); // legacy fleet_critical still outranks product
+  });
+});


### PR DESCRIPTION
## Summary
The backlog ranker's product-pivot band ranks ANY product-class SD above ANY harness-class SD when the pivot is active — so a thin MED product idea-note outranked a HIGH critical S19 walk-blocker. The only override (the existing fleet-critical band, which already sits above the product-pivot band) required a **runtime** `metadata.fleet_critical` hand-set per walk-blocker.

## Changes
- **FR-1/FR-3**: generalize the band predicate to `isCriticalWalkBlocker` = STRICT-`true` on ANY of three **durable sourcing-time** signals — `fleet_critical` | `convergence_caught` | `blocks_active_mission`. An Adam-sourced walk-blocker carrying `convergence_caught`/`blocks_active_mission` at sourcing now outranks the product-pivot band **automatically** — no runtime hand-set. `isFleetCritical` is retained as the narrower predicate for the FLEET-CRITICAL-DISPATCH-LANE audit/cap.
- **FR-2**: the product-pivot bias is **preserved** for every non-critical-walk-blocker SD (routine MED harness still ranks below MED product; priority does not dominate wholesale).
- **FR-4**: `tests/unit/coordinator-backlog-rank-critical-walk-blocker.test.js` — predicate + ordering contract (walk-blocker > product note; routine harness < product; `fleet_critical` backward-compat; STRICT anti-gaming). **21/21 pass** incl. both existing band suites.

No DDL, no new flag, no runtime config — pure predicate + comparator change in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)