### PR TITLE
fix(SD-LEO-INFRA-CORPUS-PROMOTE-ONLY-VIA-DISTILL-001): raw corpus never auto-promotes (fail-closed)

### DIFF
--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -29,7 +29,13 @@ import { hasBuildDisposition, REFILL_INVALID_REASONS } from './refill-candidate-
  * @returns {boolean}
  */
 export function isDistilledOnly(env = process.env) {
-  return (env && env.SOURCING_AUTO_REFILL_DISTILLED_ONLY) === 'on';
+  // SD-LEO-INFRA-CORPUS-PROMOTE-ONLY-VIA-DISTILL-001 (chairman-authoritative ROOT-CAUSE fix): raw
+  // Todoist/corpus items must NEVER auto-promote to the SD queue — the ONLY corpus->SD path is the
+  // deliberate /distill review. So the gate is now FAIL-CLOSED BY DEFAULT: distilled-only is enforced
+  // unless an operator sets an EXPLICIT break-glass escape (SOURCING_AUTO_REFILL_DISTILLED_ONLY=off).
+  // With /distill not running (no item carries a build disposition), the engine therefore promotes
+  // NOTHING. (Was opt-in '=on' for the original safe rollout — the rollout is now complete + mandated.)
+  return (env && env.SOURCING_AUTO_REFILL_DISTILLED_ONLY) !== 'off';
 }
 
 /** Default per-run promotion cap — a single run never promotes more than this onto the belt. */

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -20,7 +20,7 @@
  * not merely reachable (per the INVOCATION-PATH-PROOF lesson). Mirrors the sibling -B CLI refill-verify.mjs.
  */
 import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
-import { selectRefillBatch, promoteStagedCandidate } from '../../lib/sourcing-engine/refill-auto-promote.js';
+import { selectRefillBatch, promoteStagedCandidate, isDistilledOnly } from '../../lib/sourcing-engine/refill-auto-promote.js';
 import { pathToFileURL } from 'node:url';
 import { normalizeTitleForCompare, crossRefShippedTitleAdvisory } from '../../lib/sourcing-engine/refill-candidate-validity.js';
 import { readSourcingEngineFlagsFromDb } from '../lib/sourcing-engine-awareness.mjs';
@@ -114,7 +114,10 @@ async function main() {
     shippedTitleSet = new Set((shipped || []).map((s) => normalizeTitleForCompare(s.title)).filter(Boolean));
   } catch { /* fail-open: empty set -> lookalike axis no-ops */ }
 
-  const sel = selectRefillBatch(rows || [], { limit, shippedTitleSet });
+  // SD-LEO-INFRA-CORPUS-PROMOTE-ONLY-VIA-DISTILL-001 (FR-2): forward the distilled-only flag so the
+  // batch selector applies CHECK #11 — only /distill build-dispositioned items promote. Now fail-closed
+  // by default (isDistilledOnly), so an un-distilled raw corpus item is never minted onto the belt.
+  const sel = selectRefillBatch(rows || [], { limit, shippedTitleSet, distilledOnly: isDistilledOnly() });
   const results = [];
   // SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001 (Phase 1 — ADVISORY): wire the exported-but-unused
   // crossRefShippedTitleAdvisory into the live promotion caller (its only production call site). It

--- a/tests/unit/refill-disposition-gate.test.js
+++ b/tests/unit/refill-disposition-gate.test.js
@@ -9,7 +9,7 @@ import {
   hasBuildDisposition,
   REFILL_INVALID_REASONS,
 } from '../../lib/sourcing-engine/refill-candidate-validity.js';
-import { isDistilledOnly, promoteStagedCandidate } from '../../lib/sourcing-engine/refill-auto-promote.js';
+import { isDistilledOnly, promoteStagedCandidate, selectRefillBatch } from '../../lib/sourcing-engine/refill-auto-promote.js';
 
 // A structurally-VALID staged candidate (passes every pre-existing check) so CHECK #11 is the only
 // variable under test. disposition overrides per case.
@@ -73,12 +73,34 @@ describe('evaluateRefillCandidate CHECK #11 (RETAINED-TEETH proofs)', () => {
   });
 });
 
-describe('isDistilledOnly flag', () => {
-  it('true only when SOURCING_AUTO_REFILL_DISTILLED_ONLY === "on"', () => {
+describe('isDistilledOnly flag (SD-LEO-INFRA-CORPUS-PROMOTE-ONLY-VIA-DISTILL-001: FAIL-CLOSED by default)', () => {
+  it('defaults to TRUE (distilled-only enforced); only an explicit "off" break-glass disables it', () => {
+    // chairman-authoritative: raw corpus must NEVER auto-promote — so unset/anything-but-"off" enforces.
+    expect(isDistilledOnly({})).toBe(true);                                         // unset -> enforced
     expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'on' })).toBe(true);
-    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'off' })).toBe(false);
-    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'true' })).toBe(false);
-    expect(isDistilledOnly({})).toBe(false);
+    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'true' })).toBe(true);
+    expect(isDistilledOnly({ SOURCING_AUTO_REFILL_DISTILLED_ONLY: 'off' })).toBe(false); // explicit escape only
+  });
+});
+
+describe('FR-2 cron wiring: the batch selector enforces distilled-only by default', () => {
+  it('an UNDISTILLED raw-corpus item is excluded from the promote batch while a build-dispositioned one passes', () => {
+    const undistilled = validItem({ source_id: 'rw-undistilled', title: 'Track P-Doom calculation methods for AI opportunities' });
+    const built = validItem({ source_id: 'rw-built', disposition: 'build', title: 'Wire the pending-proposals gauge into the belt-low forecast path' });
+    // the cron now passes distilledOnly: isDistilledOnly() (default true)
+    const sel = selectRefillBatch([undistilled, built], { distilledOnly: isDistilledOnly({}) });
+    const ids = sel.batch.map((b) => b.source_id);
+    expect(ids).toContain('rw-built');
+    expect(ids).not.toContain('rw-undistilled');
+  });
+
+  it('with /distill off (no build-dispositioned items), the engine promotes NOTHING', () => {
+    const rows = [
+      validItem({ source_id: 'a', title: 'See how we can use Mercury for banking' }),
+      validItem({ source_id: 'b', title: 'Anticipate legal attacks and be prepared' }),
+    ];
+    const sel = selectRefillBatch(rows, { distilledOnly: isDistilledOnly({}) });
+    expect(sel.batch).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Belt ROOT CAUSE (chairman-authoritative): Todoist/corpus must never auto-promote — only via /distill

The auto-refill engine promoted **raw corpus** items (bare Todoist titles, no spec — e.g. a session URL, "See how we can use Mercury for banking") onto the SD queue, bypassing **/distill** (the only sanctioned corpus→SD path). This is the root defect behind all the SD-REFILL-* belt noise.

The disposition gate (CHECK #11 / distilled-only mode, from SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B) **already existed but was inert**: `isDistilledOnly` defaulted OFF (opt-in `=on`) and `refill-cron.mjs` never passed the flag to the batch selector.

### Fix
- **FR-1/FR-2** — `isDistilledOnly` is now **fail-closed by default**: distilled-only is enforced unless an operator sets an explicit break-glass `SOURCING_AUTO_REFILL_DISTILLED_ONLY=off`. `refill-cron.mjs` now forwards `distilledOnly: isDistilledOnly()` to `selectRefillBatch` so CHECK #11 activates at the batch level (the per-mint guard in `promoteStagedCandidate` also fail-closes via the new default). **With /distill not running, the engine promotes nothing.** No schema migration (`hasBuildDisposition` already reads `metadata.disposition`).
- **FR-4** — updated the `isDistilledOnly` test to fail-closed + added FR-2 cron-wiring tests (undistilled excluded; build-dispositioned passes; /distill-off ⇒ promotes nothing). **42 tests pass.**
- **FR-3 (operational)** — the existing SD-REFILL-* Todoist SDs that bypassed /distill are being deferred (4 already this session); the gate prevents new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)