### PR TITLE
fix(SD-LEO-INFRA-S15-WIREFRAME-CONSTRAINED-JSON-001): constrain S15 wireframe JSON + never hard-block

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js
@@ -487,7 +487,19 @@ Output ONLY valid JSON.`;
   let usage = {};
   const LLM_MAX_RETRIES = 2;
   for (let attempt = 1; attempt <= LLM_MAX_RETRIES; attempt++) {
-    const response = await client.complete(SYSTEM_PROMPT, userPrompt, { timeout: 120000 });
+    // SD-LEO-INFRA-S15-WIREFRAME-CONSTRAINED-JSON-001 (FR-1): the wireframe call previously ran in
+    // UNCONSTRAINED free-text mode, so dense design prose malformed mid-body JSON that post-hoc repair
+    // can't fix (RCA 0.85 — a syntax failure, not truncation). Run Gemini in JSON mode
+    // (response_format:json_object -> responseMimeType=application/json, which the GoogleAdapter already
+    // translates) at a low temperature so the decoder is constrained to emit syntactically valid JSON.
+    // (A structural responseSchema is a deferred follow-up — the existing S15_WIREFRAME_SCHEMA is a
+    // validation shape, not Gemini's responseSchema format, and ascii_layout's string-vs-array shape is
+    // ambiguous; JSON mode fixes the actual syntax root cause, and FR-2's fallback guarantees no hard-block.)
+    const response = await client.complete(SYSTEM_PROMPT, userPrompt, {
+      timeout: 120000,
+      response_format: { type: 'json_object' },
+      temperature: 0.1,
+    });
     usage = extractUsage(response);
     try {
       parsed = parseJSON(response);
@@ -513,7 +525,26 @@ Output ONLY valid JSON.`;
       logger.warn(`[Stage15-WF] LLM JSON parse failed (attempt ${attempt}/${LLM_MAX_RETRIES}) ` +
         `[finishReason=${response?.finishReason ?? 'n/a'} outputTokens=${usage?.outputTokens ?? 'n/a'} contentLength=${response?.content?.length ?? 'n/a'}]: ${parseErr.message}`);
       if (attempt >= LLM_MAX_RETRIES) {
-        throw new Error(`[Stage15-WF] Wireframe LLM failed after ${LLM_MAX_RETRIES} attempts: ${parseErr.message}`);
+        // SD-LEO-INFRA-S15-WIREFRAME-CONSTRAINED-JSON-001 (FR-2): DO NOT throw on a total parse failure
+        // — that hard-blocked S15 (~50% of clones). Fall through with an empty result so the deterministic
+        // boundary fallback below (persona/IA-sitemap screen synthesis, >=MIN_SCREENS) runs, so S15 is
+        // NEVER hard-blocked even on total LLM failure.
+        logger.warn('[Stage15-WF] Exhausted LLM retries — falling back to deterministic screen synthesis (no hard-block)');
+        // SD-LEO-INFRA-S15-WIREFRAME-CONSTRAINED-JSON-001 (FR-3): dump the FULL raw response to a temp
+        // file (path logged) so the exact malformation byte is captured next time — the shared parser
+        // only surfaces HEAD+TAIL 300 chars. Fail-soft: a dump error never affects the fallback.
+        try {
+          const fsSync = await import('node:fs');
+          const os = await import('node:os');
+          const pathMod = await import('node:path');
+          const dumpDir = pathMod.join(os.tmpdir(), 'ehg-s15-wireframe-parse-failures');
+          fsSync.mkdirSync(dumpDir, { recursive: true });
+          const dumpFile = pathMod.join(dumpDir, `s15-wf-parsefail-${ventureId ?? 'unknown'}-${usage?.outputTokens ?? 'na'}.txt`);
+          fsSync.writeFileSync(dumpFile, String(response?.content ?? ''), 'utf8');
+          logger.warn(`[Stage15-WF] full raw wireframe response dumped to ${dumpFile} (contentLength=${response?.content?.length ?? 0})`);
+        } catch { /* fail-soft: observability dump must never affect the fallback */ }
+        parsed = {};
+        break;
       }
     }
   }

--- a/tests/unit/stage-15-wireframe-generator.test.js
+++ b/tests/unit/stage-15-wireframe-generator.test.js
@@ -58,6 +58,9 @@ import {
   buildUserStoryContext,
   buildIASitemapContext,
 } from '../../lib/eva/stage-templates/analysis-steps/stage-15-wireframe-generator.js';
+// SD-LEO-INFRA-S15-WIREFRAME-CONSTRAINED-JSON-001 (FR-2): the mocked parseJSON, so a test can force a
+// TOTAL parse failure and assert S15 falls back deterministically instead of hard-blocking.
+import { parseJSON } from '../../lib/eva/utils/parse-json.js';
 
 // ── Test Helpers ────────────────────────────────────────────────────
 
@@ -967,5 +970,34 @@ describe('Stage 15 Wireframe Generator', () => {
       expect(userPrompt).toContain('Signup');
       expect(userPrompt).toContain('User Acquisition');
     });
+  });
+});
+
+// ── SD-LEO-INFRA-S15-WIREFRAME-CONSTRAINED-JSON-001 (FR-2) ───────────
+describe('FR-2: total wireframe-LLM parse failure never hard-blocks (deterministic fallback)', () => {
+  beforeEach(() => {
+    // restore the pass-through parser after the override tests
+    parseJSON.mockImplementation((response) => (response && response._parsed) ? response._parsed : response);
+  });
+
+  it('does NOT throw and synthesizes >=MIN_SCREENS screens when the LLM JSON fails to parse on every attempt', async () => {
+    const stage10Data = createMockStage10Data();
+    mockComplete.mockResolvedValue({ content: '{"screens":[{"name":"Home", malformed mid body...' });
+    parseJSON.mockImplementation(() => { throw new Error('Failed to parse LLM response as JSON (malformed mid-body)'); });
+
+    const result = await analyzeStage15WireframeGenerator({
+      ventureId: 'venture-parsefail',
+      stage10Data,
+      stage14Data: createMockStage14Data(),
+      ventureName: 'ParseFailVenture',
+      logger: silentLogger,
+    });
+
+    // never hard-blocks: a valid result with the deterministic fallback screens
+    expect(Array.isArray(result.screens)).toBe(true);
+    expect(result.screens.length).toBeGreaterThanOrEqual(MIN_SCREENS);
+    // mandatory acquisition screens are still present (Landing + Signup)
+    expect(result.screens.some((s) => /landing|home\s*page/i.test(s.name))).toBe(true);
+    expect(result.screens.some((s) => /sign\s*up|register/i.test(s.name))).toBe(true);
   });
 });


### PR DESCRIPTION
## S15 wireframe hard-blocked ~50% of clones (unconstrained JSON)

The wireframe Gemini call ran **unconstrained free-text** (no JSON mode), so dense design prose malformed mid-body JSON the post-hoc repair couldn't fix → S15 hard-blocked ~50% of clones (RCA 0.85 — a **syntax** failure, not truncation).

### Fix
- **FR-1** — run the wireframe call in Gemini **JSON mode** (`response_format:{type:'json_object'}` → `responseMimeType=application/json`, already translated by the GoogleAdapter) at **temperature 0.1**, constraining the decoder to emit syntactically valid JSON. No adapter change needed (it already supports `response_format` + `temperature`). A structural `responseSchema` is **deferred** — `S15_WIREFRAME_SCHEMA` is a validation shape, not Gemini's responseSchema format, and `ascii_layout`'s string-vs-array shape is ambiguous; JSON mode fixes the actual syntax root cause.
- **FR-2** — on a **total** parse failure (after retries), stop throwing: fall through (`parsed={}`) so the existing deterministic boundary fallback (persona + IA-sitemap synthesis, ≥MIN_SCREENS) runs → S15 is **never hard-blocked** even on total LLM failure.
- **FR-3** — on final parse failure, dump the **full** raw `response.content` to a temp file (path logged), S15-scoped (avoids changing the shared `parse-json.js` used by every caller). Fail-soft.

### Tests
New FR-2 regression test (total parse failure ⇒ no throw, ≥MIN_SCREENS synthesized, Landing+Signup present). **53 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)