### PR TITLE
feat(SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001): auto-exclude clone build-trees from the belt

### DIFF
--- a/lib/coordinator/sd-exclusion.mjs
+++ b/lib/coordinator/sd-exclusion.mjs
@@ -113,9 +113,27 @@ export function isUnactionableRemediationSd(sd) {
   }
 }
 
+/**
+ * SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a CLONE venture's build-tree node (orchestrator /
+ * child / grandchild) carries metadata.test_clone_build_tree=true, stamped at creation by
+ * lib/eva/lifecycle-sd-bridge.js convertSprintToSDs. These are throwaway test-clone MVPs that must not
+ * count as belt depth nor be ranked — else the forecaster over-reports capacity and the ranker surfaces
+ * them as claimable. Strict === true so a coincidentally-truthy value never demotes real work. FAIL-OPEN.
+ *
+ * @param {{metadata?: object}} sd
+ * @returns {boolean}
+ */
+export function isCloneBuildTreeSd(sd) {
+  try {
+    return !!(sd && typeof sd === 'object' && sd.metadata && sd.metadata.test_clone_build_tree === true);
+  } catch {
+    return false; // fail-open: a classifier error keeps the SD on the belt
+  }
+}
+
 export function isExcludedFromBelt(sd) {
   if (!sd || typeof sd !== 'object') return false; // fail-open
-  return isFixtureSd(sd.sd_key, sd.metadata) || isBareShell(sd) || isUnactionableRemediationSd(sd);
+  return isFixtureSd(sd.sd_key, sd.metadata) || isBareShell(sd) || isUnactionableRemediationSd(sd) || isCloneBuildTreeSd(sd);
 }
 
 /**

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -319,18 +319,32 @@ export function isPilotFixtureVenture(flags) {
  *
  * @param {object} supabase
  * @param {string} ventureId
- * @returns {Promise<{is_scaffolding:boolean, is_demo:boolean}|null>}
+ * @returns {Promise<{is_scaffolding:boolean, is_demo:boolean, seeded_from_venture_id:(string|null)}|null>}
  */
 export async function fetchVentureFlags(supabase, ventureId) {
   if (!ventureId) return null;
   try {
     const { data } = await supabase
       .from('ventures')
-      .select('is_demo, is_scaffolding')
+      // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: + seeded_from_venture_id so a CLONE venture
+      // (seeded_from_venture_id NOT NULL) can be detected once here and have its build-tree marked.
+      .select('is_demo, is_scaffolding, seeded_from_venture_id')
       .eq('id', ventureId)
       .maybeSingle();
-    return data ? { is_demo: data.is_demo === true, is_scaffolding: data.is_scaffolding === true } : null;
+    return data ? { is_demo: data.is_demo === true, is_scaffolding: data.is_scaffolding === true, seeded_from_venture_id: data.seeded_from_venture_id ?? null } : null;
   } catch { return null; }
+}
+
+/**
+ * SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a venture is a CLONE when it was seeded from another
+ * venture (ventures.seeded_from_venture_id IS NOT NULL). Its build-tree is a throwaway test-clone MVP —
+ * the convergence milestone is tree CREATION (proving the bridge works), not BUILD — so the tree must be
+ * marked test_clone_build_tree so the shared claim-eligibility predicate + belt SSOT exclude it.
+ * @param {{seeded_from_venture_id?:(string|null)}|null} flags
+ * @returns {boolean}
+ */
+export function isCloneVenture(flags) {
+  return !!(flags && flags.seeded_from_venture_id != null);
 }
 
 /**
@@ -445,6 +459,12 @@ export async function convertSprintToSDs(params, deps = {}) {
     };
   }
 
+  // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a CLONE venture (seeded_from_venture_id NOT NULL)
+  // that is NOT a pilot still generates its tree, but every node is marked test_clone_build_tree=true so
+  // the shared claim-eligibility predicate + belt SSOT exclude the throwaway test-clone MVP at the source
+  // (no per-clone manual deferral). Computed ONCE from the same pilotFlags fetch. Real ventures => false.
+  const cloneBuildTree = isCloneVenture(pilotFlags);
+
   // Amplification cap: limit children (US-004)
   if (payloads.length > MAX_CHILDREN_PER_ORCHESTRATOR) {
     logger.warn(`[LifecycleSDBridge] Amplification cap hit: requested ${payloads.length} children, capped at ${MAX_CHILDREN_PER_ORCHESTRATOR}`);
@@ -552,6 +572,8 @@ export async function convertSprintToSDs(params, deps = {}) {
           created_via: 'lifecycle-sd-bridge',
           venture_id: ventureContext?.id,
           venture_name: ventureContext?.name,
+          // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
+          ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
           sprint_name: sprintName,
           sprint_goal: sprintGoal,
           sprint_duration_days: sprintDuration,
@@ -672,6 +694,8 @@ export async function convertSprintToSDs(params, deps = {}) {
             created_via: 'lifecycle-sd-bridge',
             venture_id: ventureContext?.id,
             venture_name: ventureContext?.name,
+            // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
+            ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
             sprint_name: sprintName,
             sprint_item_index: i,
             dependencies: payload.dependencies || [],
@@ -716,6 +740,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           ventureContext,
           provenance,
           createdIds,
+          cloneBuildTree, // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: stamp grandchildren too
         });
         grandchildKeys.push(...gcKeys);
       }
@@ -793,6 +818,7 @@ export async function convertSprintToSDs(params, deps = {}) {
 async function createGrandchildren({
   supabase, logger, parentChildId, parentChildKey,
   childPayload, ventureContext, provenance, createdIds,
+  cloneBuildTree = false, // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: clone-tree marker (default off)
 }) {
   const gcKeys = [];
   // Determine which architecture layers apply based on payload hints
@@ -887,6 +913,8 @@ async function createGrandchildren({
           ...provenance,
           created_via: 'lifecycle-sd-bridge',
           venture_id: ventureContext?.id,
+          // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
+          ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
           architecture_layer: layer.key,
           parent_child_key: parentChildKey,
           grandchild_index: j,

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -52,7 +52,7 @@ const { isSdExecutableHere } = require('./sd-executable-here.cjs');
  *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
  * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean }} [ctx]  when present, applies the claim-time fitness + tier axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'co_author_pending' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'co_author_pending' | 'test_clone_build_tree' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
@@ -66,6 +66,14 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // flag (converged or non-co-authored) falls through unchanged. Shared SSOT: the self-claim (draft +
   // baselined) and stale-session-sweep paths all route through this predicate, so they exclude it too.
   if (row.metadata && row.metadata.co_author_pending === true) return 'co_author_pending';
+  // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a CLONE venture's build-tree (orchestrator +
+  // children + grandchildren, stamped metadata.test_clone_build_tree=true at creation by
+  // lib/eva/lifecycle-sd-bridge.js convertSprintToSDs) is a throwaway test-clone MVP that must never
+  // reach a worker belt — else the fleet builds it unless the coordinator manually defers every clone.
+  // DB-free marker (strict === true), read here so BOTH the self_claim and stale-session-sweep paths
+  // exclude it. The clone determination happens ONCE at bridge creation (where the ventures query
+  // already runs); a venture->clone JOIN deliberately stays OUT of this pure/synchronous/DB-free predicate.
+  if (row.metadata && row.metadata.test_clone_build_tree === true) return 'test_clone_build_tree';
   // SD-FDBK-INFRA-STALE-SESSION-SWEEP-001: a DEFERRED SD is parked off the belt (coordinator/Adam
   // deferral) and must NEVER be re-dispatched — without this the sweep CLAIM_FIX re-asserted a
   // deferred SD's claim onto a worker with a live worktree every tick, defeating the deferral and

--- a/tests/unit/eva/pilot-venture-guard.test.js
+++ b/tests/unit/eva/pilot-venture-guard.test.js
@@ -52,7 +52,9 @@ describe('fetchVentureFlags', () => {
 
   it('returns normalized booleans for a venture row', async () => {
     const flags = await fetchVentureFlags(flagsClient({ is_demo: true, is_scaffolding: false }), 'v-1');
-    expect(flags).toEqual({ is_demo: true, is_scaffolding: false });
+    // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: fetchVentureFlags now also surfaces
+    // seeded_from_venture_id (null here — this row carries no seed) for clone detection.
+    expect(flags).toEqual({ is_demo: true, is_scaffolding: false, seeded_from_venture_id: null });
   });
   it('returns null when the venture row is absent', async () => {
     const flags = await fetchVentureFlags(flagsClient(null), 'v-missing');

--- a/tests/unit/fleet/clone-build-tree-belt-exclusion.test.js
+++ b/tests/unit/fleet/clone-build-tree-belt-exclusion.test.js
@@ -1,0 +1,100 @@
+/**
+ * SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001 (FR-3)
+ *
+ * A CLONE venture's build-tree must be auto-excluded from claim-eligibility AND the belt. The mechanism
+ * is a DB-FREE marker (metadata.test_clone_build_tree=true) stamped at the source by the leo_bridge for
+ * clone ventures (seeded_from_venture_id NOT NULL) and read by the two shared predicates. These tests
+ * exercise the REAL predicates + the REAL bridge clone-detection/flag-fetch (no re-implementation).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { classifyDispatchIneligibility } = require('../../../lib/fleet/claim-eligibility.cjs');
+import { isExcludedFromBelt, isCloneBuildTreeSd } from '../../../lib/coordinator/sd-exclusion.mjs';
+import { isCloneVenture, fetchVentureFlags } from '../../../lib/eva/lifecycle-sd-bridge.js';
+
+const sd = (extra = {}) => ({ sd_key: 'SD-CLONE-TREE-001', sd_type: 'feature', status: 'draft', title: 'Clone tree node', description: 'A real description distinct from the title.', metadata: {}, ...extra });
+
+describe('FR-1: claim-eligibility excludes a marked clone build-tree node', () => {
+  it("returns 'test_clone_build_tree' when metadata.test_clone_build_tree === true", () => {
+    expect(classifyDispatchIneligibility(sd({ metadata: { test_clone_build_tree: true } }))).toBe('test_clone_build_tree');
+  });
+  it('is unaffected (null) for an unmarked SD', () => {
+    expect(classifyDispatchIneligibility(sd())).toBeNull();
+  });
+  it('strict === true: a truthy non-boolean marker does NOT exclude', () => {
+    expect(classifyDispatchIneligibility(sd({ metadata: { test_clone_build_tree: 'yes' } }))).toBeNull();
+    expect(classifyDispatchIneligibility(sd({ metadata: { test_clone_build_tree: 1 } }))).toBeNull();
+  });
+  it('composes with existing axes (orchestrator still wins where it applies; marker excludes a plain feature)', () => {
+    // a marked plain feature is excluded by the marker...
+    expect(classifyDispatchIneligibility(sd({ sd_type: 'feature', metadata: { test_clone_build_tree: true } }))).toBe('test_clone_build_tree');
+    // ...and an orchestrator parent is still caught by its own (earlier) axis
+    expect(classifyDispatchIneligibility(sd({ sd_type: 'orchestrator', metadata: { test_clone_build_tree: true } }))).toBe('orchestrator_parent');
+  });
+});
+
+describe('FR-1: belt-exclusion SSOT excludes a marked clone build-tree node', () => {
+  it('isCloneBuildTreeSd true only for strict === true marker', () => {
+    expect(isCloneBuildTreeSd(sd({ metadata: { test_clone_build_tree: true } }))).toBe(true);
+    expect(isCloneBuildTreeSd(sd({ metadata: { test_clone_build_tree: false } }))).toBe(false);
+    expect(isCloneBuildTreeSd(sd({ metadata: {} }))).toBe(false);
+    expect(isCloneBuildTreeSd(sd({ metadata: { test_clone_build_tree: 'true' } }))).toBe(false);
+    expect(isCloneBuildTreeSd(null)).toBe(false);
+  });
+  it('isExcludedFromBelt true for a marked node, false for an unmarked real SD', () => {
+    expect(isExcludedFromBelt(sd({ metadata: { test_clone_build_tree: true } }))).toBe(true);
+    expect(isExcludedFromBelt(sd())).toBe(false);
+  });
+});
+
+describe('FR-2: isCloneVenture (clone detection from venture flags)', () => {
+  it('true iff seeded_from_venture_id is non-null', () => {
+    expect(isCloneVenture({ seeded_from_venture_id: 'src-1' })).toBe(true);
+    expect(isCloneVenture({ seeded_from_venture_id: null })).toBe(false);
+    expect(isCloneVenture({ is_demo: false, is_scaffolding: false })).toBe(false);
+    expect(isCloneVenture(null)).toBe(false);
+    expect(isCloneVenture(undefined)).toBe(false);
+  });
+});
+
+describe('FR-2: fetchVentureFlags returns seeded_from_venture_id', () => {
+  const flagsClient = (row) => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: row, error: null })),
+        })),
+      })),
+    })),
+  });
+
+  it('surfaces seeded_from_venture_id for a clone venture row', async () => {
+    const flags = await fetchVentureFlags(flagsClient({ is_demo: false, is_scaffolding: false, seeded_from_venture_id: 'src-9' }), 'v-clone');
+    expect(flags).toEqual({ is_demo: false, is_scaffolding: false, seeded_from_venture_id: 'src-9' });
+    expect(isCloneVenture(flags)).toBe(true);
+  });
+  it('normalizes a real venture (no seed) to seeded_from_venture_id null', async () => {
+    const flags = await fetchVentureFlags(flagsClient({ is_demo: false, is_scaffolding: false }), 'v-real');
+    expect(flags.seeded_from_venture_id).toBeNull();
+    expect(isCloneVenture(flags)).toBe(false);
+  });
+  it('returns null (fail-safe) when the venture row is absent', async () => {
+    expect(await fetchVentureFlags(flagsClient(null), 'v-missing')).toBeNull();
+  });
+});
+
+describe('FR-2 end-to-end intent: a clone flag drives an excludable marker', () => {
+  it('isCloneVenture(true) -> the node the bridge stamps is excluded by both predicates', () => {
+    // The bridge stamps metadata.test_clone_build_tree=true exactly when isCloneVenture(flags) is true
+    // (verified above). A node so stamped is excluded by BOTH shared predicates:
+    const flags = { is_demo: false, is_scaffolding: false, seeded_from_venture_id: 'src-1' };
+    const node = sd({ metadata: isCloneVenture(flags) ? { test_clone_build_tree: true } : {} });
+    expect(classifyDispatchIneligibility(node)).toBe('test_clone_build_tree');
+    expect(isExcludedFromBelt(node)).toBe(true);
+    // a real venture's node carries no marker and stays claimable
+    const realNode = sd({ metadata: isCloneVenture({ seeded_from_venture_id: null }) ? { test_clone_build_tree: true } : {} });
+    expect(classifyDispatchIneligibility(realNode)).toBeNull();
+    expect(isExcludedFromBelt(realNode)).toBe(false);
+  });
+});


### PR DESCRIPTION
## SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001

A test-clone venture clearing S19 has `leo_bridge` build a ~40-SD tree (orchestrator + children + grandchildren) that the worker belt did NOT auto-exclude — so the fleet would build a throwaway test-clone MVP unless the coordinator manually defers the tree every clone.

### Changes
- **FR-1** — DB-FREE marker (`metadata.test_clone_build_tree===true`, strict) excluded by both shared predicates: `claim-eligibility.cjs` `classifyDispatchIneligibility` (new reason `test_clone_build_tree` → self_claim + sweep skip it) and `sd-exclusion.mjs` `isExcludedFromBelt` via new `isCloneBuildTreeSd` (forecaster + ranker drop it from belt depth/deficit). The venture→clone JOIN stays out of the pure/DB-free predicate by design.
- **FR-2** — `lifecycle-sd-bridge.js` stamps the marker at the **source**: `fetchVentureFlags` now returns `seeded_from_venture_id`; new `isCloneVenture(flags)`; `convertSprintToSDs` computes `cloneBuildTree` once and stamps all **three** tiers (orchestrator/child/grandchild, threaded into `createGrandchildren`). Real ventures get no marker. Mirrors the `isPilotFixtureVenture` precedent but MARKS rather than SKIPS (convergence milestone is tree CREATION, not BUILD).
- **FR-3** — `tests/unit/fleet/clone-build-tree-belt-exclusion.test.js` (predicate + SSOT strict-marker, `isCloneVenture`, `fetchVentureFlags` seed, end-to-end intent); pilot-guard test updated for the additive shape.

### Verification
- 189 tests green (11 new + 178 regression across claim-eligibility / sd-exclusion / lifecycle-sd-bridge / ranker-forecaster / backlog / forecast). Caught + fixed a self-regression (grandchild `cloneBuildTree` scope ReferenceError). No schema change.
- Per LEAD DB audit there's no current claimable footgun (existing clone SDs already excluded via terminal/deferred/orchestrator axes); this prevents the NEXT clone leaking a buildable tree. Backfill + venture-JOIN scoped out as redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
