### PR TITLE
feat(SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001): deterministic S19 sprint + payload-signature dedup (kill duplicate build trees)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-FORECASTER-DISTILL-GATE-AWARENESS-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-FORECASTER-DISTILL-GATE-AWARENESS-001",
-  "createdAt": "2026-06-29T17:29:34.933Z",
+  "sdKey": "SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001",
+  "createdAt": "2026-06-29T20:19:52.978Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -31,7 +31,24 @@
 
 import { ServiceError } from './shared-services.js';
 import { createClient } from '@supabase/supabase-js';
-import { randomUUID } from 'crypto';
+import { randomUUID, createHash } from 'crypto';
+
+/**
+ * SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-2): a stable, order-independent signature over a
+ * sprint's sd_bridge_payload SET (each payload's title|type). The S19 orchestrator is deduped on
+ * (venture_id, signature) instead of a free-text sprint_name that could drift to 'unknown' across
+ * re-invocations and mint a DUPLICATE build tree. Genuinely-distinct sprints (different payload sets)
+ * produce different signatures and are preserved (not collapsed). PURE/TOTAL — '' for empty/odd input.
+ * @param {Array<{title?:string,type?:string,sd_type?:string}>} payloads
+ * @returns {string} 12-char hex signature (or '' when there are no payloads)
+ */
+export function sprintSignature(payloads) {
+  if (!Array.isArray(payloads) || payloads.length === 0) return '';
+  const tokens = payloads
+    .map((p) => `${String(p?.title ?? '').trim().toLowerCase()}|${String(p?.type ?? p?.sd_type ?? '').trim().toLowerCase()}`)
+    .sort();
+  return createHash('sha256').update(tokens.join('\n')).digest('hex').slice(0, 12);
+}
 // SD-LEO-INFRA-VENTURE-BUILD-EXEC-001 FR-1: venture SDs are created with full LEO
 // rigor (NO bypass_governance) — this helper supplies the de-bypassed provenance.
 import { ventureGovernanceMetadata } from './bridge/venture-governance-metadata.js';
@@ -439,6 +456,11 @@ export async function convertSprintToSDs(params, deps = {}) {
     return { created: false, orchestratorKey: null, childKeys: [], grandchildKeys: [], errors: ['No sprint items to convert'] };
   }
 
+  // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-2): the deterministic payload signature backs
+  // the orchestrator dedup (venture_id, signature) so a sprint_name that drifted to 'unknown' on a
+  // re-invocation can no longer mint a duplicate tree; distinct payload sets keep distinct signatures.
+  const sprintSig = sprintSignature(payloads);
+
   // SD-LEO-INFRA-PILOT-VENTURE-GUARD-001: pilot/test-fixture ventures exist ONLY to
   // exercise the V1 pipeline/UI — they must NEVER auto-spawn a venture-build SD tree
   // (V2 work that burns tokens on a throwaway). Skip BEFORE any DB write / idempotency
@@ -476,7 +498,7 @@ export async function convertSprintToSDs(params, deps = {}) {
     : null;
 
   // Idempotency check: look for existing orchestrator for this venture+sprint
-  const existing = await findExistingOrchestrator(supabase, ventureContext?.id, sprintName);
+  const existing = await findExistingOrchestrator(supabase, ventureContext?.id, sprintName, sprintSig);
   if (existing) {
     logger.log(`[LifecycleSDBridge] Orchestrator already exists: ${existing.orchestratorKey}`);
     return {
@@ -575,6 +597,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
           ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
           sprint_name: sprintName,
+          sprint_signature: sprintSig, // FR-2: deterministic dedup key (venture_id, sprint_signature)
           sprint_goal: sprintGoal,
           sprint_duration_days: sprintDuration,
           vision_key: evaKeys.vision_key || null,
@@ -1269,20 +1292,29 @@ export async function convertExpansionToSD(params, deps = {}) {
 /**
  * Check if an orchestrator SD already exists for this venture+sprint combination.
  */
-async function findExistingOrchestrator(supabase, ventureId, sprintName) {
-  if (!ventureId || !sprintName) return null;
+async function findExistingOrchestrator(supabase, ventureId, sprintName, sprintSig) {
+  if (!ventureId) return null;
 
-  const { data, error } = await supabase
+  // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-2): dedup PRIMARILY on the deterministic payload
+  // signature so an identical-payload re-invocation finds the existing tree even if the free-text
+  // sprint_name drifted (the 'unknown' duplicate-tree bug). Fall back to the sprint_name match for legacy
+  // orchestrators created before sprint_signature was stored, so existing trees still dedup.
+  const base = () => supabase
     .from('strategic_directives_v2')
     .select('id, sd_key')
     .eq('sd_type', 'orchestrator')
-    .eq('metadata->>venture_id', ventureId)
-    .eq('metadata->>sprint_name', sprintName)
-    .limit(1);
+    .eq('metadata->>venture_id', ventureId);
 
-  if (error || !data?.length) return null;
-
-  const orchestrator = data[0];
+  let orchestrator = null;
+  if (sprintSig) {
+    const { data } = await base().eq('metadata->>sprint_signature', sprintSig).limit(1);
+    if (data?.length) orchestrator = data[0];
+  }
+  if (!orchestrator && sprintName) {
+    const { data } = await base().eq('metadata->>sprint_name', sprintName).limit(1);
+    if (data?.length) orchestrator = data[0];
+  }
+  if (!orchestrator) return null;
 
   // Find children
   const { data: children } = await supabase

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -3620,17 +3620,27 @@ export class StageExecutionWorker {
     await this._verifyAndProvisionVenture(ventureId, ventureRow?.name);
 
     // Fetch sd_bridge_payloads from S19 artifacts (fallback to S18 for legacy data)
+    // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-1a): EXCLUDE the bridge's OWN output
+    // (artifact_type='lifecycle_sd_bridge'). The bridge writes its own is_current artifact, so on a
+    // re-invocation artifacts[0] used to be that output (carrying no sprint_name) -> sprint_name='unknown'
+    // -> a divergent SPRINT-UNKNOWN orchestrator that evaded dedup -> a DUPLICATE build tree.
     const { data: artifacts } = await this._supabase
       .from('venture_artifacts')
       .select('content, metadata')
       .eq('venture_id', ventureId)
       .in('lifecycle_stage', [19, 18])
       .eq('is_current', true)
+      .neq('artifact_type', 'lifecycle_sd_bridge')
       .order('lifecycle_stage', { ascending: false })
       .order('created_at', { ascending: false })
       .limit(10);
 
     let sdBridgePayloads = [];
+    // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-1b): capture the content+meta of the SAME
+    // artifact that supplied the payloads, so sprint_name/goal/duration derive from the real sprint plan
+    // (deterministic across re-invocations) instead of artifacts[0] (which could be a different/own row).
+    let sprintSourceContent = {};
+    let sprintSourceMeta = {};
     for (const art of (artifacts || [])) {
       // SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001: content column is TEXT — parse if needed
       let content = art.content;
@@ -3648,6 +3658,8 @@ export class StageExecutionWorker {
         || content?.stage19_data?.sd_bridge_payloads;
       if (payloads?.length > 0) {
         sdBridgePayloads = payloads;
+        sprintSourceContent = content || {};
+        sprintSourceMeta = meta || {};
         break;
       }
     }
@@ -3685,24 +3697,18 @@ export class StageExecutionWorker {
       .limit(1)
       .maybeSingle();
 
-    const { convertSprintToSDs, buildBridgeArtifactRecord } = await import('./lifecycle-sd-bridge.js');
+    const { convertSprintToSDs, buildBridgeArtifactRecord, sprintSignature } = await import('./lifecycle-sd-bridge.js');
     const { writeArtifact } = await import('./artifact-persistence-service.js');
 
-    const firstArt = artifacts[0] || {};
-    let firstContent = firstArt.content;
-    if (typeof firstContent === 'string') {
-      try { firstContent = JSON.parse(firstContent); } catch { firstContent = {}; }
-    }
-    let firstMeta = firstArt.metadata;
-    if (typeof firstMeta === 'string') {
-      try { firstMeta = JSON.parse(firstMeta); } catch { firstMeta = {}; }
-    }
-
+    // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-1c/FR-3): build the sprint meta from the
+    // payload-SOURCE artifact (captured above), NOT artifacts[0]. The fallback when the source carries no
+    // sprint_name is a DETERMINISTIC, payload-derived label (sprint-<signature>) — never the literal
+    // 'unknown', which used to mint a divergent SPRINT-UNKNOWN key + a duplicate build tree.
     const stageOutput = {
       sd_bridge_payloads: sdBridgePayloads,
-      sprint_name: firstContent?.sprint_name || firstMeta?.sprint_name || 'unknown',
-      sprint_goal: firstContent?.sprint_goal || firstMeta?.sprint_goal || '',
-      sprint_duration_days: firstContent?.sprint_duration_days || firstMeta?.sprint_duration_days || 14,
+      sprint_name: sprintSourceContent?.sprint_name || sprintSourceMeta?.sprint_name || `sprint-${sprintSignature(sdBridgePayloads)}`,
+      sprint_goal: sprintSourceContent?.sprint_goal || sprintSourceMeta?.sprint_goal || '',
+      sprint_duration_days: sprintSourceContent?.sprint_duration_days || sprintSourceMeta?.sprint_duration_days || 14,
     };
 
     const ventureContext = { id: ventureId, name: ventureRow?.name };

--- a/tests/unit/eva/s19-duplicate-orchestrator-dedup.test.js
+++ b/tests/unit/eva/s19-duplicate-orchestrator-dedup.test.js
@@ -1,0 +1,119 @@
+/**
+ * SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001 (FR-5)
+ *
+ * RCA 0.97: _runS19Bridge read sprint_name from artifacts[0] = its own re-written output -> 'unknown'
+ * -> a divergent SPRINT-UNKNOWN orchestrator that evaded dedup -> a DUPLICATE build tree. The fix makes
+ * sprint_name deterministic (exclude own output + read the payload-source artifact; signature fallback)
+ * and backs findExistingOrchestrator's dedup with a stable payload signature. These tests prove the
+ * dedup + signature behavior on a fake supabase, and assert the worker no longer reads its own output.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { sprintSignature, _internal } from '../../../lib/eva/lifecycle-sd-bridge.js';
+
+const { findExistingOrchestrator } = _internal;
+
+// ── FR-2: signature stability ────────────────────────────────────────────────
+describe('sprintSignature', () => {
+  const a = { title: 'Build the API', type: 'backend' };
+  const b = { title: 'Wire the UI', type: 'frontend' };
+  it('is stable + order-independent over the payload SET', () => {
+    expect(sprintSignature([a, b])).toBe(sprintSignature([b, a]));
+    expect(sprintSignature([a, b])).toMatch(/^[0-9a-f]{12}$/);
+  });
+  it('distinct payload sets => distinct signatures (genuinely-distinct sprints preserved)', () => {
+    expect(sprintSignature([a, b])).not.toBe(sprintSignature([a]));
+    expect(sprintSignature([a])).not.toBe(sprintSignature([b]));
+  });
+  it('empty / odd input => empty string (total)', () => {
+    expect(sprintSignature([])).toBe('');
+    expect(sprintSignature(undefined)).toBe('');
+    expect(sprintSignature(null)).toBe('');
+  });
+});
+
+// In-memory supabase double for the orchestrator dedup query + children query.
+function makeSb(orchestrators = [], children = []) {
+  return {
+    from() {
+      const filters = {};
+      let parentId; // set only on the children query
+      const builder = {
+        select() { return builder; },
+        eq(col, val) { if (col === 'parent_sd_id') parentId = val; else filters[col] = val; return builder; },
+        order() { return builder; },
+        is(col, val) { filters[`is:${col}`] = val; return builder; },
+        async limit() {
+          const rows = orchestrators.filter((o) =>
+            (filters['sd_type'] === undefined || o.sd_type === filters['sd_type']) &&
+            (filters['metadata->>venture_id'] === undefined || o.metadata?.venture_id === filters['metadata->>venture_id']) &&
+            (filters['metadata->>sprint_signature'] === undefined || o.metadata?.sprint_signature === filters['metadata->>sprint_signature']) &&
+            (filters['metadata->>sprint_name'] === undefined || o.metadata?.sprint_name === filters['metadata->>sprint_name']),
+          );
+          return { data: rows.slice(0, 1), error: null };
+        },
+        // children query is awaited directly (no .limit) → thenable
+        then(res) { res({ data: children.filter((c) => c.parent_sd_id === parentId).map((c) => ({ sd_key: c.sd_key })), error: null }); },
+      };
+      return builder;
+    },
+  };
+}
+
+// ── FR-1/FR-2: idempotent dedup even when sprint_name drifted to 'unknown' ────
+describe('findExistingOrchestrator — dedup', () => {
+  const VID = 'venture-1';
+  const PAYLOADS = [{ title: 'Build the API', type: 'backend' }, { title: 'Wire the UI', type: 'frontend' }];
+  const SIG = sprintSignature(PAYLOADS);
+  const existing = { id: 'orch-1', sd_key: 'SD-LEO-ORCH-SPRINT-DATADISTILL-001', sd_type: 'orchestrator', metadata: { venture_id: VID, sprint_signature: SIG, sprint_name: 'DataDistill 06-01' } };
+
+  it('TS-1: a re-invocation whose sprint_name drifted to "unknown" STILL finds the tree via the signature (no duplicate)', async () => {
+    const sb = makeSb([existing]);
+    const r = await findExistingOrchestrator(sb, VID, 'unknown', SIG);
+    expect(r).not.toBeNull();
+    expect(r.orchestratorKey).toBe('SD-LEO-ORCH-SPRINT-DATADISTILL-001');
+  });
+
+  it('TS-2: a genuinely-distinct sprint (different payloads => different signature) is NOT collapsed', async () => {
+    const sb = makeSb([existing]);
+    const otherSig = sprintSignature([{ title: 'SaaS billing', type: 'backend' }]);
+    expect(await findExistingOrchestrator(sb, VID, 'DataDistill 06-02-SaaS', otherSig)).toBeNull();
+  });
+
+  it('legacy orchestrator with no stored signature still dedups via the sprint_name fallback', async () => {
+    const legacy = { id: 'orch-0', sd_key: 'SD-LEO-ORCH-SPRINT-LEGACY-001', sd_type: 'orchestrator', metadata: { venture_id: VID, sprint_name: 'Legacy Sprint' } };
+    const sb = makeSb([legacy]);
+    const r = await findExistingOrchestrator(sb, VID, 'Legacy Sprint', sprintSignature(PAYLOADS));
+    expect(r?.orchestratorKey).toBe('SD-LEO-ORCH-SPRINT-LEGACY-001');
+  });
+
+  it('returns the children of the matched orchestrator', async () => {
+    const sb = makeSb([existing], [{ parent_sd_id: 'orch-1', sd_key: 'SD-LEO-ORCH-SPRINT-DATADISTILL-001-01' }]);
+    const r = await findExistingOrchestrator(sb, VID, 'DataDistill 06-01', SIG);
+    expect(r.childKeys).toEqual(['SD-LEO-ORCH-SPRINT-DATADISTILL-001-01']);
+  });
+
+  it('no match => null; missing ventureId => null', async () => {
+    expect(await findExistingOrchestrator(makeSb([]), VID, 'x', 'deadbeef')).toBeNull();
+    expect(await findExistingOrchestrator(makeSb([existing]), null, 'x', SIG)).toBeNull();
+  });
+});
+
+// ── FR-1/FR-3: the worker no longer reads its own output / no literal 'unknown' ──
+describe('FR-1/FR-3 source guarantees (stage-execution-worker _runS19Bridge)', () => {
+  const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../../lib/eva/stage-execution-worker.js'), 'utf8');
+  const block = src.slice(src.indexOf('Fetch sd_bridge_payloads from S19 artifacts'), src.indexOf('const ventureContext = { id: ventureId'));
+  it("excludes the bridge's own output (artifact_type lifecycle_sd_bridge) from the read", () => {
+    expect(block).toMatch(/\.neq\(\s*'artifact_type'\s*,\s*'lifecycle_sd_bridge'\s*\)/);
+  });
+  it('derives sprint_name from the payload-source artifact, not artifacts[0]/firstArt', () => {
+    expect(block).toMatch(/sprint_name:\s*sprintSourceContent\?\.sprint_name/);
+    expect(block).not.toMatch(/firstContent|firstArt/);
+  });
+  it("the fallback is a deterministic signature label, never the literal 'unknown'", () => {
+    expect(block).toMatch(/`sprint-\$\{sprintSignature\(sdBridgePayloads\)\}`/);
+    expect(block).not.toMatch(/\|\|\s*'unknown'/);
+  });
+});

--- a/tests/unit/eva/stage-execution-worker-s19-gate.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-gate.test.js
@@ -15,6 +15,9 @@ const convertSprintToSDs = vi.fn();
 vi.mock('../../../lib/eva/lifecycle-sd-bridge.js', () => ({
   convertSprintToSDs: (...args) => convertSprintToSDs(...args),
   buildBridgeArtifactRecord: vi.fn(() => ({ lifecycle_stage: 19, artifact_type: 'x', title: 't', content: {}, metadata: {} })),
+  // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001: _runS19Bridge now imports sprintSignature for the
+  // deterministic sprint_name fallback (replacing the literal 'unknown').
+  sprintSignature: vi.fn(() => 'sigtest12'),
 }));
 vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({ writeArtifact: vi.fn() }));
 
@@ -49,6 +52,7 @@ function createMockSupabase({ ventureName = 'CronGenius', buildModel = 'leo_brid
     const chain = {
       select: vi.fn(() => chain),
       eq: vi.fn((col, val) => { eqArgs.push({ col, val }); return chain; }),
+      neq: vi.fn(() => chain), // SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001: bridge excludes its own output
       in: vi.fn(() => chain),
       order: vi.fn(() => chain),
       limit: vi.fn(() => chain),


### PR DESCRIPTION
## Summary
**RCA 0.97 (fa84f5a1):** `_runS19Bridge` read `sprint_name` from `artifacts[0]`, but the bridge **writes its own** `is_current` `lifecycle_sd_bridge` artifact (`writeArtifact` dedups per `artifact_type`, never clears the sprint plan). On **re-invocation** `artifacts[0]` was its own output (no `sprint_name`) → `sprint_name='unknown'` → a divergent `SPRINT-UNKNOWN` orchestrator that **evaded the (venture_id, sprint_name) dedup** → a full **duplicate build tree (2× build)** on real ventures (CronGenius/DataDistill) + clones.

## Fix
- **FR-1:** `_runS19Bridge` now (a) **excludes the bridge's own output** (`.neq('artifact_type','lifecycle_sd_bridge')`) and (b) derives `sprint_name`/goal/duration from the **same artifact that supplied the payloads** (not `artifacts[0]`) → deterministic across re-invocations.
- **FR-2:** new exported pure `sprintSignature(payloads)` = stable order-independent `sha256(sorted title|type)[:12]`; stored as `metadata.sprint_signature`; `findExistingOrchestrator` dedups **primarily on (venture_id, sprint_signature)** with a **sprint_name fallback for legacy rows**. Distinct payload sets keep distinct signatures (genuine sprints preserved).
- **FR-3:** the literal `'unknown'` fallback is replaced by a deterministic `sprint-<signature>` label.
- **FR-4:** verified — **0 non-terminal** `%-LEO-ORCH-SPRINT-UNKNOWN-%` trees remain (Adam already confirmed-cancelled all 85).

## Verification
- 11 new + 120 regression = **131 tests green** (testing-agent verified 235 across the broader EVA suites, **0 regressions**); `node --check` OK; testing-agent **PASS** (55a95af8); retro PUBLISHED 100/100 (745e5bd8).
- The optional unique partial index (DDL) is deferred — FR-1's determinism + FR-2's code dedup fix the bug without a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)