### PR TITLE
feat(SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001): gate S19 NC-7 escalation on classifyBridgeOutcome enum

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S19-DUPLICATE-ORCHESTRATOR-TREE-001",
-  "createdAt": "2026-06-29T20:19:52.978Z",
+  "sdKey": "SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001",
+  "createdAt": "2026-06-30T00:04:48.214Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -3722,8 +3722,20 @@ export class StageExecutionWorker {
       { supabase: this._supabase, logger: this._logger },
     );
 
+    // SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001 (FR-1): compute the canonical outcome
+    // BEFORE the branching so the NC-7 escalation gates on the SAME classifyBridgeOutcome enum every
+    // other S19 consumer uses — never an inline errors-text regex. The #5250 dedup returns errors:[],
+    // so the old `/already exists/i.test(JSON.stringify(errors))` never matched and a healthy NOOP_EXISTS
+    // re-run was mislabeled 'Bridge FAILED' + wrote a stale stage_status='blocked'/bridge_failed row.
+    const bridgeOutcome = classifyBridgeOutcome({
+      created: bridgeResult.created === true,
+      skipped: bridgeResult.skipped === true,
+      errors: bridgeResult.errors || bridgeResult.error || [],
+      orchestratorKey: bridgeResult.orchestratorKey || null,
+    }, sdBridgePayloads.length);
+
     if (bridgeResult.created) {
-      this._logger.log(`[Worker] S19 post-stage hook: Created orchestrator ${bridgeResult.orchestratorKey} with ${bridgeResult.childKeys.length} children`);
+      this._logger.log(`[Worker] S19 bridge: Created orchestrator ${bridgeResult.orchestratorKey} with ${bridgeResult.childKeys.length} children`);
 
       // Persist bridge result as artifact
       try {
@@ -3748,15 +3760,25 @@ export class StageExecutionWorker {
       // built out (V1/V2 boundary). This is NOT a bridge failure — do NOT log FAILED or escalate
       // the venture to S19 BLOCKED. The pilot advances through the pipeline without a build tree
       // (the PILOT_SKIPPED outcome makes shouldHoldAtS19 advance, like NOOP_EMPTY).
-      this._logger.log(`[Worker] S19 post-stage hook: venture ${ventureId} is a pilot/test-fixture — venture-build SD generation gated (${bridgeResult.reason || 'pilot/test-fixture'}). Not a failure.`);
+      this._logger.log(`[Worker] S19 bridge: venture ${ventureId} is a pilot/test-fixture — venture-build SD generation gated (${bridgeResult.reason || 'pilot/test-fixture'}). Not a failure.`);
     } else {
       const errors = bridgeResult.errors || bridgeResult.error || 'unknown';
-      this._logger.error(`[Worker] S19 post-stage hook: Bridge FAILED to create SDs for venture ${ventureId}. Errors: ${JSON.stringify(errors)}`);
-      // NC-7 anti-silent-no-op (RCA 813d4c3d CAPA): a leo_bridge venture with payloads that produced
-      // 0 SDs must NOT pass silently (the original drift). Escalate: mark S19 blocked with the reason
-      // so it surfaces on the dashboard instead of advancing un-built.
-      const alreadyExists = /already exists/i.test(JSON.stringify(errors));
-      if (!alreadyExists) {
+      // SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001 (FR-1): gate the NC-7 escalation on
+      // the canonical bridgeOutcome enum — NOT the dead `/already exists/i` errors-text regex. The #5250
+      // dedup returns errors:[], so the old regex never matched and a healthy idempotent NOOP_EXISTS
+      // re-run was mislabeled 'Bridge FAILED' + wrote a stale stage_status='blocked'/bridge_failed row.
+      // Escalate ONLY genuine failures (NC-7 anti-silent-no-op, RCA 813d4c3d CAPA: payloads-but-0-SDs,
+      // an infra throw, or a missing vision must surface on the dashboard rather than advance un-built).
+      // Idempotent / nothing-to-build outcomes (NOOP_EXISTS, NOOP_EMPTY) are NOT failures — info log,
+      // write NOTHING.
+      const isGenuineFailure =
+        bridgeOutcome === S19_BRIDGE_OUTCOME.ZERO_SDS_FAILURE ||
+        bridgeOutcome === S19_BRIDGE_OUTCOME.BRIDGE_THREW ||
+        bridgeOutcome === S19_BRIDGE_OUTCOME.VISION_MISSING;
+      if (!isGenuineFailure) {
+        this._logger.log(`[Worker] S19 bridge: venture ${ventureId} no-op (${bridgeOutcome}${bridgeResult.orchestratorKey ? `, existing tree ${bridgeResult.orchestratorKey}` : ''}) — not a failure, no escalation.`);
+      } else {
+        this._logger.error(`[Worker] S19 bridge: venture ${ventureId} ${bridgeOutcome}. Errors: ${JSON.stringify(errors)}`);
         try {
           await this._supabase.from('venture_stage_work').upsert({
             venture_id: ventureId,
@@ -3766,12 +3788,13 @@ export class StageExecutionWorker {
             advisory_data: {
               build_model: 'leo_bridge',
               bridge_failed: true,
+              bridge_outcome: bridgeOutcome,
               bridge_errors: errors,
               payload_count: sdBridgePayloads.length,
               escalated_at: new Date().toISOString(),
             },
           }, { onConflict: 'venture_id,lifecycle_stage' });
-          this._logger.error(`[Worker] S19 NC-7 escalation: marked venture ${ventureId} S19 BLOCKED (leo_bridge produced 0 SDs from ${sdBridgePayloads.length} payloads).`);
+          this._logger.error(`[Worker] S19 NC-7 escalation: marked venture ${ventureId} S19 BLOCKED (${bridgeOutcome}, ${sdBridgePayloads.length} payloads).`);
         } catch (escErr) {
           this._logger.warn(`[Worker] S19 NC-7 escalation upsert failed: ${escErr.message}`);
         }
@@ -3791,7 +3814,10 @@ export class StageExecutionWorker {
       orchestratorKey: bridgeResult.orchestratorKey || null,
       childKeys: bridgeResult.childKeys || [],
     };
-    result.outcome = classifyBridgeOutcome(result, sdBridgePayloads.length);
+    // SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001 (FR-1): reuse the outcome computed
+    // before branching — one classifyBridgeOutcome call drives both the escalation gate and this return,
+    // so the escalation decision and the reported outcome can never diverge.
+    result.outcome = bridgeOutcome;
     return result;
   }
 

--- a/tests/unit/eva/stage-execution-worker-s19-nc7-escalation.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-nc7-escalation.test.js
@@ -1,0 +1,141 @@
+/**
+ * SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001 (FR-4)
+ *
+ * The NC-7 escalation in _runS19Bridge must gate on the canonical classifyBridgeOutcome enum,
+ * NOT the dead `/already exists/i` errors-text regex. Follow-on to #5250: the dedup path now
+ * returns errors:[], so the old regex never matched and a healthy idempotent NOOP_EXISTS re-run was
+ * mislabeled 'Bridge FAILED' + wrote a stale stage_status='blocked'/bridge_failed venture_stage_work
+ * row. These tests exercise the REAL escalation decision: only the convertSprintToSDs dependency is
+ * stubbed; classifyBridgeOutcome is the genuine import (no test-masking-via-isolation), so the
+ * idempotent re-run must write NO blocked row while a genuine failure still escalates.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const convertSprintToSDs = vi.fn();
+vi.mock('../../../lib/eva/lifecycle-sd-bridge.js', () => ({
+  convertSprintToSDs: (...args) => convertSprintToSDs(...args),
+  buildBridgeArtifactRecord: vi.fn(() => ({ lifecycle_stage: 19, artifact_type: 'x', title: 't', content: {}, metadata: {} })),
+  sprintSignature: vi.fn(() => 'sigtest12'),
+}));
+vi.mock('../../../lib/eva/artifact-persistence-service.js', () => ({ writeArtifact: vi.fn() }));
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({ processStage: vi.fn() }));
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn(), releaseProcessingLock: vi.fn(), markCompleted: vi.fn(),
+  ORCHESTRATOR_STATES: { IDLE: 'idle', PROCESSING: 'processing', BLOCKED: 'blocked', FAILED: 'failed', KILLED_AT_REALITY_GATE: 'killed_at_reality_gate' },
+}));
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({ createOrReusePendingDecision: vi.fn(), waitForDecision: vi.fn() }));
+vi.mock('../../../lib/eva/shared-services.js', () => ({ emit: vi.fn().mockResolvedValue({}) }));
+vi.mock('../../../lib/eva/autonomy-model.js', () => ({ checkAutonomy: vi.fn().mockResolvedValue({ action: 'block', level: 'L0' }) }));
+vi.mock('../../../lib/eva/stage-governance.js', () => ({
+  getStageGovernance: vi.fn().mockResolvedValue({ isBlocking: () => false, isReview: () => false }),
+}));
+
+import { StageExecutionWorker } from '../../../lib/eva/stage-execution-worker.js';
+// REAL shared enum — NOT mocked. The escalation gate reads exactly this.
+import { S19_BRIDGE_OUTCOME } from '../../../lib/eva/bridge/s19-advance-decision.js';
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+function createMockSupabase({ ventureName = 'CronGenius', buildModel = 'leo_bridge', artifacts = [] } = {}) {
+  const upsertCalls = [];
+  const make = () => {
+    const chain = {
+      select: vi.fn(() => chain),
+      eq: vi.fn(() => chain),
+      neq: vi.fn(() => chain),
+      in: vi.fn(() => chain),
+      order: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      maybeSingle: vi.fn(),
+      single: vi.fn(),
+      upsert: vi.fn((payload) => { upsertCalls.push(payload); return Promise.resolve({ data: null, error: null }); }),
+      insert: vi.fn(() => chain),
+      update: vi.fn(() => chain),
+    };
+    return chain;
+  };
+  const from = vi.fn((table) => {
+    const chain = make();
+    if (table === 'ventures') {
+      chain.single.mockResolvedValue({ data: { name: ventureName }, error: null });
+      chain.maybeSingle.mockResolvedValue({ data: { name: ventureName, build_model: buildModel }, error: null });
+    } else if (table === 'venture_stage_work') {
+      chain.maybeSingle.mockResolvedValue({ data: { advisory_data: { build_method: null } }, error: null });
+    } else if (table === 'venture_artifacts') {
+      chain.limit.mockReturnValue(Promise.resolve({ data: artifacts, error: null }));
+    } else {
+      chain.maybeSingle.mockResolvedValue({ data: null, error: null });
+      chain.single.mockResolvedValue({ data: null, error: null });
+    }
+    return chain;
+  });
+  return { from, _upsertCalls: upsertCalls };
+}
+
+// A venture S19 with one sd_bridge_payload so _runS19Bridge reaches convertSprintToSDs.
+const ARTIFACTS_WITH_PAYLOAD = [
+  {
+    content: JSON.stringify({
+      sprint_name: 'Sprint 1', sprint_goal: 'g', sprint_duration_days: 14,
+      sd_bridge_payloads: [{ title: 'A', type: 'feature', description: 'd', scope: 's', success_criteria: 'sc' }],
+    }),
+    metadata: null,
+  },
+];
+
+const blockedUpserts = (supabase) => supabase._upsertCalls.filter((u) => u && u.stage_status === 'blocked');
+
+describe('_runS19Bridge NC-7 escalation gated on classifyBridgeOutcome (FR-1/FR-4)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('idempotent NOOP_EXISTS re-run → writes NO blocked row + outcome NOOP_EXISTS (the #5250 dedup shape)', async () => {
+    // The dedup return: existing orchestrator, created:false, errors:[] (errors-text regex never matches).
+    convertSprintToSDs.mockResolvedValue({
+      created: false, orchestratorKey: 'SD-LEO-ORCH-EXISTING', childKeys: ['c1'], grandchildKeys: [], errors: [],
+    });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+
+    expect(res.outcome).toBe(S19_BRIDGE_OUTCOME.NOOP_EXISTS);
+    // The bug: the old regex mislabeled this as a failure and wrote a stale blocked row. Must NOT happen.
+    expect(blockedUpserts(supabase)).toEqual([]);
+  });
+
+  it('genuine ZERO_SDS_FAILURE → still escalates (blocked + bridge_failed + bridge_outcome) + outcome ZERO_SDS_FAILURE', async () => {
+    // payloads present but 0 SDs produced, no orchestrator key — the schism that MUST surface.
+    convertSprintToSDs.mockResolvedValue({
+      created: false, orchestratorKey: null, childKeys: [], grandchildKeys: [], errors: [],
+    });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+
+    expect(res.outcome).toBe(S19_BRIDGE_OUTCOME.ZERO_SDS_FAILURE);
+    const blocked = blockedUpserts(supabase);
+    expect(blocked.length).toBe(1);
+    expect(blocked[0].lifecycle_stage).toBe(19);
+    expect(blocked[0].work_type).toBe('sd_required');
+    expect(blocked[0].advisory_data.bridge_failed).toBe(true);
+    expect(blocked[0].advisory_data.bridge_outcome).toBe(S19_BRIDGE_OUTCOME.ZERO_SDS_FAILURE);
+  });
+
+  it('genuine VISION_MISSING → still escalates (blocked row) + outcome VISION_MISSING', async () => {
+    convertSprintToSDs.mockResolvedValue({
+      created: false, orchestratorKey: null, childKeys: [], grandchildKeys: [],
+      errors: ['Venture CronGenius: no L2 vision document found.'],
+    });
+    const supabase = createMockSupabase({ artifacts: ARTIFACTS_WITH_PAYLOAD });
+    const worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 999999 });
+    worker._verifyAndProvisionVenture = vi.fn().mockResolvedValue(undefined);
+
+    const res = await worker._runS19Bridge('v-1');
+
+    expect(res.outcome).toBe(S19_BRIDGE_OUTCOME.VISION_MISSING);
+    expect(blockedUpserts(supabase).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
Follow-on to #5250 (cosmetic/data-hygiene). The S19 NC-7 escalation in `_runS19Bridge` used a dead errors-text regex `/already exists/i.test(JSON.stringify(errors))` to detect the idempotent path. Since #5250's dedup returns `errors:[]`, the regex never matched, so every idempotent **NOOP_EXISTS** re-run against an existing orchestrator tree was mislabeled 'Bridge FAILED to create SDs' and wrote a stale `venture_stage_work` row with `stage_status='blocked'` + `bridge_failed:true` — polluting the operator dashboard even though the venture held/advanced correctly (`shouldHoldAtS19` untouched).

## Changes
- **FR-1**: compute `bridgeOutcome = classifyBridgeOutcome(...)` **before** the branching; reuse for `result.outcome`; gate the NC-7 escalation on the enum — escalate **only** `ZERO_SDS_FAILURE | BRIDGE_THREW | VISION_MISSING`; `NOOP_EXISTS | NOOP_EMPTY` → info log, write nothing. Removed the dead regex (the exact divergent-re-derivation anti-pattern `classifyBridgeOutcome` exists to prevent).
- **FR-2**: genericized the misleading `'S19 post-stage hook:'` shared-callee log prefix.
- **FR-3**: deferred (optional dedup-errors marker — would change the `errors:[]` contract for no gain; FR-1 already classifies the path as NOOP_EXISTS).
- **FR-4**: new `tests/unit/eva/stage-execution-worker-s19-nc7-escalation.test.js` — `classifyBridgeOutcome` is the **real** import (no test-masking-via-isolation); idempotent NOOP_EXISTS writes no blocked row; ZERO_SDS_FAILURE + VISION_MISSING still escalate.

## Test
34 tests pass across 4 s19 suites (3 new FR-4 cases). testing-agent PASS, retro 100/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)