### PR TITLE
fix(QF-20260629-047): belt_claimable_at_my_tier excludes other-session claims

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1131,9 +1131,16 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // strings => 0 rows => baselined candidates dropped from the tier pool => belt_claimable_at_my_tier
       // under-counted to 0. One fetch keyed by sd_key is correct for both kinds.
       const allKeys = ranked.map((x) => x.key).filter(Boolean);
-      const cols = 'sd_key,id,sd_type,status,description,title,metadata,target_application';
+      const cols = 'sd_key,id,sd_type,status,description,title,metadata,target_application,claiming_session_id';
       let pool = [];
-      if (allKeys.length) { const { data } = await sb.from('strategic_directives_v2').select(cols).in('sd_key', allKeys); pool = data || []; }
+      if (allKeys.length) {
+        const { data } = await sb.from('strategic_directives_v2').select(cols).in('sd_key', allKeys);
+        // QF-20260629-047: drop SDs already claimed by ANOTHER session — they are not claimable-to-me, so
+        // counting them inflates belt_claimable_at_my_tier and suppresses the tier-deficit idle message
+        // (which only fires at 0). Mirrors the forecaster's `if (d.claiming_session_id) continue;`. Keep
+        // rows claimed by THIS session (resume) and unclaimed rows.
+        pool = (data || []).filter((r) => !r.claiming_session_id || r.claiming_session_id === sessionId);
+      }
       base.belt_claimable_at_my_tier = claimableForTier(pool, {
         workerTierRank: tierCtx.worker_tier_rank,
         tieringActive: tierCtx.tiering_active === true,


### PR DESCRIPTION
## QF-20260629-047 — exclude SDs claimed by other sessions from belt_claimable_at_my_tier

FR-2 of SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 counted an SD as claimable-at-my-tier even when **another session already held it** — `isBaseEligible`/`claimableForTier` never checked `claiming_session_id`, unlike the forecaster's claimable loop (`if (d.claiming_session_id) continue;`).

**Observed live:** `belt_claimable_at_my_tier=1` while `action=idle`, because the lone tier-reachable SD was held by another session. The over-count suppressed the tier-deficit idle message (which only fires at 0).

**Fix:** select `claiming_session_id` and drop pool rows claimed by another session (keep this session's own claims for resume). Verified live: count **1 → 0**, matching the authoritative idle state. 84 worker-checkin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
