### PR TITLE
fix(SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001): drop redundant venture_name UNIQUE + orphaned-provisioning reaper (S19 run#10 blocker)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S19-NC7-ESCALATION-DIVERGENT-REDERIVATION-001",
-  "createdAt": "2026-06-30T00:04:48.214Z",
+  "sdKey": "SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001",
+  "createdAt": "2026-06-30T00:48:55.822Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260630_vps_drop_venture_name_unique.sql
+++ b/database/migrations/20260630_vps_drop_venture_name_unique.sql
@@ -1,0 +1,26 @@
+-- Migration: drop the redundant UNIQUE(venture_name) on venture_provisioning_state
+-- SD: SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001 (FR-1)
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- ROOT CAUSE (run#10 S19 HARD BLOCKER): venture_provisioning_state has
+--   venture_id  UUID PRIMARY KEY        -- per-venture uniqueness ALREADY enforced here
+--   venture_name TEXT NOT NULL UNIQUE   -- REDUNDANT + WRONG: names legitimately repeat
+-- The clone name generator reuses names (run#10 'MarketLens' == cancelled run#4 'MarketLens'),
+-- so the provisioning writer's INSERT hits the venture_name UNIQUE constraint -> S19 bridge can't
+-- create the venture tree -> the venture loops stuck at S19.
+--
+-- FIX: DROP the redundant venture_name UNIQUE constraint. venture_id (PK) remains the sole, correct
+-- uniqueness key. NO data migration is needed: the PK already prevents venture_id dupes, and
+-- venture_name dupes cannot pre-exist while this very constraint stands. The idx_vps_venture_name
+-- lookup index is left in place (it is a plain, NON-unique index — created separately at table
+-- creation, NOT backed by this constraint), so name lookups are unaffected.
+--
+-- Low-risk + reversible: dropping a redundant UNIQUE constraint (re-add with
+--   ALTER TABLE venture_provisioning_state ADD CONSTRAINT venture_provisioning_state_venture_name_key UNIQUE (venture_name);
+-- if ever needed). Brief ACCESS EXCLUSIVE lock to drop the constraint.
+
+ALTER TABLE venture_provisioning_state
+  DROP CONSTRAINT IF EXISTS venture_provisioning_state_venture_name_key;
+
+COMMENT ON COLUMN venture_provisioning_state.venture_name IS
+  'Human-readable venture name (NOT unique — names legitimately repeat across ventures, e.g. a clone reusing a cancelled venture''s name). Per-venture uniqueness is enforced by the venture_id PRIMARY KEY. SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001.';

--- a/lib/eva/bridge/provisioning-state.js
+++ b/lib/eva/bridge/provisioning-state.js
@@ -48,9 +48,13 @@ export async function getState(ventureId) {
       retry_count: 0,
     };
 
+    // SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001 (FR-1): upsert on venture_id (the PK), not a
+    // bare INSERT. Per-venture uniqueness is the PK; venture_name is no longer UNIQUE (names legitimately
+    // repeat across ventures — a clone may reuse a cancelled venture's name). onConflict:'venture_id' makes
+    // a concurrent auto-create race idempotent on the PK instead of failing.
     const { data: created, error: createErr } = await supabase
       .from('venture_provisioning_state')
-      .insert(newState)
+      .upsert(newState, { onConflict: 'venture_id' })
       .select('*')
       .single();
 

--- a/lib/eva/bridge/reap-orphaned-provisioning.js
+++ b/lib/eva/bridge/reap-orphaned-provisioning.js
@@ -1,0 +1,91 @@
+/**
+ * Orphaned-provisioning reaper.
+ * SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001 (FR-2 + FR-3, unified).
+ *
+ * For every venture whose ventures.status IN ('cancelled','killed'), this reaper:
+ *   1. DELETEs the stale venture_provisioning_state row (keyed on venture_id — the PK), and
+ *   2. TERMINALIZEs the venture's orphaned orchestrator SD tree in strategic_directives_v2
+ *      (every SD with metadata.venture_id == the venture, still in a non-terminal status)
+ *      by setting status='cancelled' + the cancellation_reason COLUMN (NOT metadata — per the
+ *      coordinator's harness_backlog 3b5d63a4: SD cancel uses the cancellation_reason column).
+ *
+ * This single mechanism is BOTH the on-cancel cascade cleanup (invoke it from the cancel flow)
+ * and the periodic defense-in-depth reaper (run it on a schedule). dryRun=true by default — it
+ * reports counts without mutating. Fail-soft per item; idempotent (terminal rows are skipped).
+ */
+
+const TERMINAL_SD_STATUSES = ['completed', 'cancelled', 'archived'];
+const REAPABLE_VENTURE_STATUSES = ['cancelled', 'killed'];
+
+/**
+ * @param {object} opts
+ * @param {import('@supabase/supabase-js').SupabaseClient} opts.supabase
+ * @param {boolean} [opts.dryRun=true]
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {Promise<{ dryRun: boolean, ventures: number, rowsReaped: number, treesTerminalized: number, sdsTerminalized: number, errors: string[] }>}
+ */
+export async function reapOrphanedProvisioning({ supabase, dryRun = true, log = () => {} } = {}) {
+  const summary = { dryRun, ventures: 0, rowsReaped: 0, treesTerminalized: 0, sdsTerminalized: 0, errors: [] };
+  if (!supabase) { summary.errors.push('no_supabase'); return summary; }
+
+  // The set of cancelled/killed venture ids whose artifacts are reapable.
+  const { data: deadVentures, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, name, status')
+    .in('status', REAPABLE_VENTURE_STATUSES);
+  if (vErr) { summary.errors.push(`ventures_read: ${vErr.message}`); return summary; }
+
+  const deadIds = new Set((deadVentures || []).map((v) => v.id));
+  summary.ventures = deadIds.size;
+  if (deadIds.size === 0) { log('[reaper] no cancelled/killed ventures — nothing to reap'); return summary; }
+
+  // 1. Stale venture_provisioning_state rows for those ventures.
+  const { data: staleRows, error: psErr } = await supabase
+    .from('venture_provisioning_state')
+    .select('venture_id, venture_name')
+    .in('venture_id', Array.from(deadIds));
+  if (psErr) summary.errors.push(`provisioning_read: ${psErr.message}`);
+
+  for (const row of (staleRows || [])) {
+    log(`[reaper] ${dryRun ? 'WOULD delete' : 'deleting'} provisioning_state for venture ${row.venture_id} (${row.venture_name})`);
+    if (!dryRun) {
+      const { error } = await supabase.from('venture_provisioning_state').delete().eq('venture_id', row.venture_id);
+      if (error) { summary.errors.push(`delete ${row.venture_id}: ${error.message}`); continue; }
+    }
+    summary.rowsReaped++;
+  }
+
+  // 2. Orphaned orchestrator SD trees for those ventures (non-terminal SDs carrying the venture_id).
+  for (const ventureId of deadIds) {
+    const { data: sds, error: sdErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, status')
+      .eq('metadata->>venture_id', ventureId)
+      .not('status', 'in', `(${TERMINAL_SD_STATUSES.join(',')})`);
+    if (sdErr) { summary.errors.push(`sd_read ${ventureId}: ${sdErr.message}`); continue; }
+    if (!sds || sds.length === 0) continue;
+
+    let terminalizedAny = false;
+    for (const sd of sds) {
+      log(`[reaper] ${dryRun ? 'WOULD cancel' : 'cancelling'} SD ${sd.sd_key} (orphaned tree of cancelled venture ${ventureId})`);
+      if (!dryRun) {
+        const { error } = await supabase
+          .from('strategic_directives_v2')
+          .update({
+            status: 'cancelled',
+            cancellation_reason: `Orphaned orchestrator tree of cancelled/killed venture ${ventureId} — reaped by SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001 reaper`,
+          })
+          .eq('id', sd.id);
+        if (error) { summary.errors.push(`cancel ${sd.sd_key}: ${error.message}`); continue; }
+      }
+      summary.sdsTerminalized++;
+      terminalizedAny = true;
+    }
+    if (terminalizedAny) summary.treesTerminalized++;
+  }
+
+  log(`[reaper] ${dryRun ? '(dry-run) ' : ''}ventures=${summary.ventures} rowsReaped=${summary.rowsReaped} treesTerminalized=${summary.treesTerminalized} sdsTerminalized=${summary.sdsTerminalized} errors=${summary.errors.length}`);
+  return summary;
+}
+
+export default { reapOrphanedProvisioning };

--- a/scripts/eva/reap-orphaned-provisioning.mjs
+++ b/scripts/eva/reap-orphaned-provisioning.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Periodic orphaned-provisioning reaper (FR-3, defense-in-depth).
+ * SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001.
+ *
+ * Thin CLI over lib/eva/bridge/reap-orphaned-provisioning.js — single source of truth (no
+ * duplicated logic). DRY-RUN BY DEFAULT; pass --apply to actually delete/terminalize.
+ *
+ *   node scripts/eva/reap-orphaned-provisioning.mjs           # dry-run: report counts only
+ *   node scripts/eva/reap-orphaned-provisioning.mjs --apply   # delete stale rows + cancel orphaned trees
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { reapOrphanedProvisioning } from '../../lib/eva/bridge/reap-orphaned-provisioning.js';
+
+const APPLY = process.argv.includes('--apply');
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+  const summary = await reapOrphanedProvisioning({ supabase, dryRun: !APPLY, log: (m) => console.log(m) });
+  console.log(`\n=== reap-orphaned-provisioning ${APPLY ? '(APPLIED)' : '(dry-run — pass --apply to mutate)'} ===`);
+  console.log(JSON.stringify(summary, null, 2));
+  if (summary.errors.length) process.exitCode = 1;
+}
+
+main().catch((e) => { console.error('reaper failed:', e?.message || e); process.exitCode = 1; });

--- a/tests/unit/eva/reap-orphaned-provisioning.test.js
+++ b/tests/unit/eva/reap-orphaned-provisioning.test.js
@@ -1,0 +1,116 @@
+/**
+ * SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001 (FR-4) — orphaned-provisioning reaper.
+ *
+ * Pure unit coverage of the reaper logic against a mock supabase: it deletes a cancelled/killed
+ * venture's venture_provisioning_state row, terminalizes the venture's non-terminal orchestrator SD
+ * tree via the cancellation_reason COLUMN, honors dryRun (report-only), and is idempotent.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { reapOrphanedProvisioning } from '../../../lib/eva/bridge/reap-orphaned-provisioning.js';
+
+// Chainable mock: SELECTs resolve from `cfg`; DELETE/UPDATE are recorded in `mutations`.
+function makeSb(cfg) {
+  const mutations = [];
+  const sb = {
+    mutations,
+    from(table) {
+      const ctx = { table, op: 'select', filters: {}, notIn: null, inVals: null, payload: null };
+      const builder = {
+        select() { ctx.op = 'select'; return builder; },
+        update(payload) { ctx.op = 'update'; ctx.payload = payload; return builder; },
+        delete() { ctx.op = 'delete'; return builder; },
+        eq(col, val) { ctx.filters[col] = val; return builder; },
+        in(col, vals) { ctx.inVals = { col, vals }; return builder; },
+        not(col, _op, vals) { ctx.notIn = { col, vals }; return builder; },
+        then(resolve) {
+          if (ctx.op === 'select') return resolve({ data: cfg.resolve(ctx), error: null });
+          mutations.push({ table: ctx.table, op: ctx.op, filters: ctx.filters, payload: ctx.payload });
+          return resolve({ error: null });
+        },
+      };
+      return builder;
+    },
+  };
+  return sb;
+}
+
+const silent = () => {};
+
+const DEAD_VENTURE = { id: 'v-dead-1', name: 'MarketLens', status: 'cancelled' };
+const LIVE_VENTURE = { id: 'v-live-1', name: 'Acme', status: 'active' };
+
+function baseCfg({ provisioningRows = [], orphanSds = [] } = {}) {
+  return {
+    resolve(ctx) {
+      if (ctx.table === 'ventures') return [DEAD_VENTURE]; // .in('status', [cancelled,killed])
+      if (ctx.table === 'venture_provisioning_state') return provisioningRows;
+      if (ctx.table === 'strategic_directives_v2') return orphanSds;
+      return [];
+    },
+  };
+}
+
+describe('reapOrphanedProvisioning', () => {
+  it('dryRun (default) reports counts WITHOUT mutating', async () => {
+    const sb = makeSb(baseCfg({
+      provisioningRows: [{ venture_id: 'v-dead-1', venture_name: 'MarketLens' }],
+      orphanSds: [{ id: 'sd-1', sd_key: 'SD-X-ORCH', status: 'in_progress' }],
+    }));
+    const r = await reapOrphanedProvisioning({ supabase: sb, log: silent }); // dryRun defaults true
+    expect(r.dryRun).toBe(true);
+    expect(r.rowsReaped).toBe(1);
+    expect(r.sdsTerminalized).toBe(1);
+    expect(r.treesTerminalized).toBe(1);
+    expect(sb.mutations).toHaveLength(0); // NOTHING mutated on dry-run
+  });
+
+  it('apply: deletes the stale provisioning row + cancels the orphaned tree via cancellation_reason COLUMN', async () => {
+    const sb = makeSb(baseCfg({
+      provisioningRows: [{ venture_id: 'v-dead-1', venture_name: 'MarketLens' }],
+      orphanSds: [
+        { id: 'sd-1', sd_key: 'SD-X-ORCH', status: 'in_progress' },
+        { id: 'sd-2', sd_key: 'SD-X-CHILD', status: 'draft' },
+      ],
+    }));
+    const r = await reapOrphanedProvisioning({ supabase: sb, dryRun: false, log: silent });
+    expect(r.rowsReaped).toBe(1);
+    expect(r.sdsTerminalized).toBe(2);
+    expect(r.treesTerminalized).toBe(1);
+
+    const del = sb.mutations.find((m) => m.table === 'venture_provisioning_state' && m.op === 'delete');
+    expect(del).toBeTruthy();
+    expect(del.filters.venture_id).toBe('v-dead-1');
+
+    const cancels = sb.mutations.filter((m) => m.table === 'strategic_directives_v2' && m.op === 'update');
+    expect(cancels).toHaveLength(2);
+    for (const c of cancels) {
+      expect(c.payload.status).toBe('cancelled');
+      // cancellation_reason is a COLUMN (not metadata) — harness_backlog 3b5d63a4
+      expect(typeof c.payload.cancellation_reason).toBe('string');
+      expect(c.payload.cancellation_reason).toMatch(/cancelled\/killed venture/);
+      expect(c.payload.metadata).toBeUndefined();
+    }
+  });
+
+  it('idempotent: no stale rows + no non-terminal SDs -> zero mutations', async () => {
+    const sb = makeSb(baseCfg({ provisioningRows: [], orphanSds: [] }));
+    const r = await reapOrphanedProvisioning({ supabase: sb, dryRun: false, log: silent });
+    expect(r.rowsReaped).toBe(0);
+    expect(r.sdsTerminalized).toBe(0);
+    expect(sb.mutations).toHaveLength(0);
+  });
+
+  it('no cancelled/killed ventures -> early return, nothing read/mutated', async () => {
+    const sb = makeSb({ resolve: (ctx) => (ctx.table === 'ventures' ? [] : []) });
+    const r = await reapOrphanedProvisioning({ supabase: sb, dryRun: false, log: silent });
+    expect(r.ventures).toBe(0);
+    expect(r.rowsReaped).toBe(0);
+    expect(sb.mutations).toHaveLength(0);
+  });
+
+  it('missing supabase -> safe no-op with error', async () => {
+    const r = await reapOrphanedProvisioning({ supabase: null, log: silent });
+    expect(r.rowsReaped).toBe(0);
+    expect(r.errors).toContain('no_supabase');
+  });
+});


### PR DESCRIPTION
## Summary
S19 HARD BLOCKER (run#10): `venture_provisioning_state` has `venture_id UUID PRIMARY KEY` (per-venture uniqueness already enforced) **plus a redundant** `venture_name TEXT NOT NULL UNIQUE`. The clone name generator reuses names (run#10 'MarketLens' == cancelled run#4 'MarketLens'), so the provisioning writer's INSERT hits the `venture_name` UNIQUE → the S19 bridge can't create the venture tree → the venture loops stuck at S19.

**Root-cause insight:** `venture_id` is already the PK, so the fix is **not** swap-UNIQUE — it's just **DROP the redundant `venture_name` UNIQUE** (names legitimately repeat). No data de-dup needed.

## Changes
- **FR-1**: `database/migrations/20260630_vps_drop_venture_name_unique.sql` drops the redundant constraint (PK stays the sole key; non-unique `idx_vps_venture_name` untouched). Writer `provisioning-state.js getState` now **upserts on `venture_id`** (race-safe). Migration is **chairman-apply pre-staged** (`requires_chairman_apply`) — low-risk, reversible, rolled-back-transaction-tested.
- **FR-2 + FR-3 (unified)**: `lib/eva/bridge/reap-orphaned-provisioning.js` — for ventures `status IN (cancelled,killed)`, deletes stale `venture_provisioning_state` rows and terminalizes orphaned orchestrator SD trees (`metadata.venture_id` match) via the **`cancellation_reason` COLUMN** (not metadata — harness_backlog 3b5d63a4). `dryRun`-default, fail-soft, idempotent. `scripts/eva/reap-orphaned-provisioning.mjs` is the periodic CLI (dry-run default, `--apply`).
- **FR-4**: `tests/unit/eva/reap-orphaned-provisioning.test.js` (5/5). Same-name regression validated end-to-end via the DATABASE sub-agent rolled-back-transaction test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)