### PR TITLE
fix(SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001): unstale 2 Unit-Tier test files (fleet-wide red main)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-VENTURE-PROVISIONING-NAME-COLLISION-001",
-  "createdAt": "2026-06-30T00:48:55.822Z",
+  "sdKey": "SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001",
+  "createdAt": "2026-06-30T01:49:28.659Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/tests/unit/audit-log-emission-helper.test.js
+++ b/tests/unit/audit-log-emission-helper.test.js
@@ -53,7 +53,11 @@ describe('emitValidationAuditLog FAIL-CLOSED-WITH-RETRY', () => {
     const elapsed = Date.now() - start;
     expect(res.id).toBe('audit-row-id');
     expect(mock.callCount()).toBe(3);
-    expect(elapsed).toBeGreaterThanOrEqual(30); // 10 + 20 between retries
+    // SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001 (FR-2): callCount===3 already proves the two
+    // retries occurred; this line only needs to prove meaningful backoff was applied. The exact 30ms
+    // boundary (10+20) flaked when a timer fired ~1ms early (29 < 30). Use a tolerant bound that still
+    // rejects a near-zero / no-backoff path but survives sub-millisecond timer imprecision.
+    expect(elapsed).toBeGreaterThanOrEqual(25); // ~30ms expected (10+20), minus a small timer-slop tolerance
   });
 
   it('THROWS after 3 retry exhaustion — caller MUST rollback (FAIL-CLOSED)', async () => {

--- a/tests/unit/sourcing-engine/refill-auto-promote.test.js
+++ b/tests/unit/sourcing-engine/refill-auto-promote.test.js
@@ -8,6 +8,13 @@ import {
 } from '../../../lib/sourcing-engine/refill-auto-promote.js';
 
 // A valid staged candidate per the -A predicate (pending, unpromoted, titled, traceable, non-fixture).
+// SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001 (FR-1): disposition:'build' so the candidate also
+// PASSES the #5245 distilled-only gate (hasBuildDisposition true). promoteStagedCandidate now enforces
+// that gate via isDistilledOnly() (the SOURCING_AUTO_REFILL_DISTILLED_ONLY env flag, currently ON), so a
+// fixture with no build disposition would hit UNDISPOSITIONED_OR_NON_BUILD before the promote-path
+// assertions. Build-dispositioning the base fixture makes the promote-path tests env-flag-independent;
+// the selectRefillBatch invalid-row tests fail on OTHER axes (not_staged / already_promoted /
+// missing_title / test_fixture), which a build disposition does not change.
 const validRow = (over = {}) => ({
   id: 'rwi-1',
   title: 'Real candidate',
@@ -16,6 +23,7 @@ const validRow = (over = {}) => ({
   item_disposition: 'pending',
   promoted_to_sd_key: null,
   lane: 'belt',
+  disposition: 'build',
   ...over,
 });
 
@@ -222,5 +230,18 @@ describe('promoteStagedCandidate (only writer)', () => {
     const r = await promoteStagedCandidate(client, {}, { apply: true });
     expect(r.promoted).toBe(false);
     expect(r.reason).toBe('missing_item_id');
+  });
+
+  // SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001 (FR-1): the #5245 fail-closed contract — when
+  // distilled-only mode is on, a candidate NOT dispositioned as buildable is refused with zero writes.
+  // Covers the gate explicitly (distilledOnly injected true so the test is env-flag-independent), not
+  // just the happy path the build-dispositioned fixture restores.
+  it('fail-closed: a non-build-dispositioned candidate + distilledOnly is refused (undispositioned_or_non_build, zero writes)', async () => {
+    const { client, writes } = makeStub();
+    const r = await promoteStagedCandidate(client, validRow({ disposition: null }), { apply: true, distilledOnly: true });
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('undispositioned_or_non_build');
+    expect(writes.inserts).toHaveLength(0);
+    expect(writes.updates).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
Red main is **not** a node_modules/CI-infra outage — `npm ci` works and the suite passes. The Unit Tier check is red from two **real stale tests**, which has been forcing admin-merges on every PR:

- **FR-1** `tests/unit/sourcing-engine/refill-auto-promote.test.js`: the #5245 fail-closed disposition gate (`promoteStagedCandidate` enforces `distilledOnly` via `isDistilledOnly()` — the `SOURCING_AUTO_REFILL_DISTILLED_ONLY` env flag, now ON) makes the 3 promote-path tests' fixture `validRow()` (no build disposition) hit `UNDISPOSITIONED_OR_NON_BUILD` before their asserted branches. **Fix:** add `disposition:'build'` to `validRow()` (env-flag-independent; the `selectRefillBatch` invalid-row tests fail on other axes, unaffected). **Added** a fail-closed test (non-build-dispositioned + `distilledOnly` → `promoted:false`, `undispositioned_or_non_build`, zero writes) so the #5245 contract is **covered**, not just restored.
- **FR-2** `tests/unit/audit-log-emission-helper.test.js:56`: a brittle wall-clock assertion (`elapsed >= 30` for a `[10,20]` backoff) flaked 29-vs-30 on a ~1ms timer early-fire. `callCount()===3` already proves the retries; **hardened** to a tolerant bound (`>=25`) that still rejects a no-backoff path but survives timer slop.

**Test-only** — no production code change (#5245 and the audit-log retry/backoff are correct). 23/23 pass across both files. The `[safe-root-resync]` log lines are expected test output, not infra failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)