### PR TITLE
fix(SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001): close the tier-rank starvation chain (3 durable guards)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-UNIT-TIER-STALE-TEST-REGRESSION-001",
-  "createdAt": "2026-06-30T01:49:28.659Z",
+  "sdKey": "SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001",
+  "createdAt": "2026-06-30T05:25:26.434Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2026,6 +2026,20 @@ async function createSD(options) {
     console.warn(`   ⚠️  structured FR derivation skipped (non-blocking): ${frErr.message}`);
   }
 
+  // SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001 (FR-3): stamp metadata.min_tier_rank at CREATION so
+  // every new SD is born tiered. Previously new SDs came out UNDEFINED (the creation path never stamped),
+  // depending on the out-of-band stamp-sd-tier-rank.mjs — and when that stamper broke (estimated_loc
+  // phantom column), the whole fleet starved on "unclaimable" unstamped work. GAP-FILL only: never
+  // overwrite an Adam-sourced / child-inherited finite rank. Non-fatal (mirrors the FR derivation guard).
+  try {
+    if (!Number.isFinite(Number(sdData.metadata?.min_tier_rank))) {
+      const { stampPayload } = await import('../lib/fleet/sd-tier-rank.mjs');
+      sdData.metadata = { ...sdData.metadata, ...stampPayload(sdData) };
+    }
+  } catch (tierErr) {
+    console.warn(`   ⚠️  min_tier_rank stamp skipped (non-blocking): ${tierErr.message}`);
+  }
+
   // CONST-014 Enforcement: Decomposition check at creation time
   // SDs with 3+ phases or 8+ FRs must use orchestrator pattern
   if (!parentId) {

--- a/scripts/stamp-sd-tier-rank.mjs
+++ b/scripts/stamp-sd-tier-rank.mjs
@@ -9,7 +9,17 @@
 // Additive: writes only the metadata.min_tier_rank JSONB key (no schema change). Idempotent.
 
 import { createClient } from '@supabase/supabase-js';
+import { pathToFileURL } from 'url';
 import { computeMinTierRank } from '../lib/fleet/sd-tier-rank.mjs';
+
+// SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001 (FR-1): the SELECT columns for the stamper.
+// estimated_loc is NOT a column on strategic_directives_v2 — selecting it errored on EVERY SD (PostgREST
+// "column does not exist"), so no SD ever got stamped -> min_tier_rank=UNDEFINED -> the 6cf5c558 tier-idle
+// bug treated every SD as above-rung -> the fleet starved on unclaimable work (RCA: Adam 47b15430).
+// computeMinTierRank already falls back to metadata.estimated_loc (sd-tier-rank.mjs:64), so the LOC
+// contribution still works for SDs that carry it in metadata. Exported so a regression test can pin it to
+// real columns and fail loudly if a phantom column is ever re-added.
+export const STAMP_SELECT_COLS = 'sd_key, sd_type, title, description, scope, strategic_intent, metadata';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -41,7 +51,7 @@ async function main() {
     process.exit(1);
   }
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
-  const cols = 'sd_key, sd_type, title, description, scope, strategic_intent, metadata, estimated_loc';
+  const cols = STAMP_SELECT_COLS;
 
   if (all) {
     const { data, error } = await sb
@@ -64,7 +74,12 @@ async function main() {
   await stampOne(sb, sd, dry);
 }
 
-main().catch((e) => {
-  console.error(`❌ ${e.message}`);
-  process.exit(1);
-});
+// SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001 (FR-1): run main() ONLY when invoked directly, so a
+// test can import STAMP_SELECT_COLS (and the helpers) without triggering a DB run / process.exit.
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((e) => {
+    console.error(`❌ ${e.message}`);
+    process.exit(1);
+  });
+}

--- a/tests/unit/fleet/tier-rank-starvation-durable-fix.test.js
+++ b/tests/unit/fleet/tier-rank-starvation-durable-fix.test.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001 (FR-4) — regression tests for the three durable
+ * guards that close the tier-rank starvation chain (6cf5c558 / RCA Adam 47b15430):
+ *   FR-1  the stamper SELECT carries no phantom column (estimated_loc is NOT a strategic_directives_v2
+ *         column; selecting it errored on every run -> nothing stamped -> fleet starved).
+ *   FR-2  the tier-gate FAILS OPEN on an UNDEFINED/non-finite min_tier_rank (an unstamped SD is
+ *         claimable-by-any-tier, never silently above-rung), while a FINITE above-rung rank is blocked.
+ *   FR-3  stamp-at-creation: stampPayload yields a finite rank, and the createSD gap-fill preserves an
+ *         already-present (Adam-sourced/inherited) rank.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import { STAMP_SELECT_COLS } from '../../../scripts/stamp-sd-tier-rank.mjs';
+import { computeMinTierRank, stampPayload } from '../../../lib/fleet/sd-tier-rank.mjs';
+
+const require = createRequire(import.meta.url);
+const { classifyDispatchIneligibility } = require('../../../lib/fleet/claim-eligibility.cjs');
+const { claimableForTier } = require('../../../lib/fleet/tier-claimable.cjs');
+
+// The real, current columns on strategic_directives_v2 the stamper is allowed to SELECT.
+const REAL_SD_COLUMNS = new Set([
+  'sd_key', 'sd_type', 'title', 'description', 'scope', 'strategic_intent', 'metadata',
+]);
+
+describe('FR-1: stamper SELECT carries no phantom column', () => {
+  it('STAMP_SELECT_COLS lists only real strategic_directives_v2 columns (no estimated_loc)', () => {
+    const cols = STAMP_SELECT_COLS.split(',').map((c) => c.trim()).filter(Boolean);
+    expect(cols.length).toBeGreaterThan(0);
+    expect(cols).not.toContain('estimated_loc'); // the phantom column that broke every stamp
+    for (const c of cols) expect(REAL_SD_COLUMNS.has(c)).toBe(true);
+  });
+
+  it('still selects metadata (computeMinTierRank falls back to metadata.estimated_loc)', () => {
+    expect(STAMP_SELECT_COLS).toContain('metadata');
+  });
+});
+
+describe('FR-2: the tier-gate fails OPEN on an undefined min_tier_rank', () => {
+  const unscored = { sd_key: 'SD-U', metadata: {} };               // no min_tier_rank
+  const nonFinite = { sd_key: 'SD-NF', metadata: { min_tier_rank: 'x' } };
+  const ranked4 = { sd_key: 'SD-R4', metadata: { min_tier_rank: 4 } };
+
+  it('classifyDispatchIneligibility does NOT block an undefined-rank SD (claimable by any rung incl. tier-1)', () => {
+    for (const rung of [1, 2, 3, 4]) {
+      expect(classifyDispatchIneligibility(unscored, { tiering_active: true, worker_tier_rank: rung }))
+        .not.toBe('above_worker_tier');
+      expect(classifyDispatchIneligibility(nonFinite, { tiering_active: true, worker_tier_rank: rung }))
+        .not.toBe('above_worker_tier');
+    }
+  });
+
+  it('still blocks a FINITE min_tier_rank that exceeds the worker rung (WORK-DOWN-NEVER-UP preserved)', () => {
+    expect(classifyDispatchIneligibility(ranked4, { tiering_active: true, worker_tier_rank: 3 }))
+      .toBe('above_worker_tier');
+    // a worker at/above the rank is NOT blocked
+    expect(classifyDispatchIneligibility(ranked4, { tiering_active: true, worker_tier_rank: 4 }))
+      .not.toBe('above_worker_tier');
+  });
+
+  it('claimableForTier includes an unscored SD for every rung, excludes a finite-above-rung one', () => {
+    const pool = [unscored, ranked4];
+    // preFiltered: true -> exercise the TIER axis only (these minimal stubs are not full base-eligible rows).
+    const keys = (rung) => claimableForTier(pool, { workerTierRank: rung, tieringActive: true, preFiltered: true }).map((s) => s.sd_key);
+    expect(keys(1)).toContain('SD-U');   // unscored reachable by tier-1
+    expect(keys(3)).toContain('SD-U');
+    expect(keys(3)).not.toContain('SD-R4'); // rank-4 above a tier-3 worker
+    expect(keys(4)).toContain('SD-R4');     // reachable by tier-4
+  });
+});
+
+describe('FR-3: stamp-at-creation yields a finite rank + gap-fill preserves an existing one', () => {
+  it('stampPayload returns a finite min_tier_rank for a typical SD', () => {
+    const sd = { sd_type: 'infrastructure', title: 'X', description: 'Y', metadata: {} };
+    const { min_tier_rank } = stampPayload(sd);
+    expect(Number.isFinite(min_tier_rank)).toBe(true);
+    expect(min_tier_rank).toBe(computeMinTierRank(sd));
+  });
+
+  it('the createSD gap-fill guard preserves an already-present finite rank (never overwrites)', () => {
+    // Mirror the createSD FR-3 gap-fill predicate: only stamp when no finite rank exists.
+    const gapFill = (metadata) => {
+      if (!Number.isFinite(Number(metadata?.min_tier_rank))) {
+        return { ...metadata, ...stampPayload({ sd_type: 'bug', metadata }) };
+      }
+      return metadata;
+    };
+    // existing Adam-sourced rank is preserved
+    expect(gapFill({ min_tier_rank: 2 }).min_tier_rank).toBe(2);
+    // unstamped -> gets a finite rank
+    expect(Number.isFinite(gapFill({}).min_tier_rank)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The 6cf5c558 tier-idle bug (RCA Adam 47b15430) silently starved the fleet: `stamp-sd-tier-rank.mjs` SELECTed `estimated_loc` (**not** a `strategic_directives_v2` column) → a PostgREST error on every run → nothing stamped → `min_tier_rank=UNDEFINED` → the tier-gate treated every SD as above-rung → workers idled on 'unclaimable' work. (This is the exact bug behind my own false-idles + signal this session.)

## Three durable guards (defense-in-depth)
- **FR-1**: drop `estimated_loc` from the stamper SELECT (exported as `STAMP_SELECT_COLS`; `computeMinTierRank` still falls back to `metadata.estimated_loc`) + a main()-only-when-invoked-directly guard so a test can import the cols. Regression test pins the cols to real columns (fails loudly if a phantom column returns).
- **FR-2**: the tier-gate already **fails open** on a non-finite `min_tier_rank` (claim-eligibility blocks only a FINITE rank > rung) — locked in with a regression test (an unstamped SD is claimable-by-any-tier incl. tier-1; a finite-above-rung rank is still blocked, WORK-DOWN-NEVER-UP preserved).
- **FR-3**: `createSD` now **stamps `min_tier_rank` at insert** via the existing `stampPayload` (GAP-FILL only — never overwrites an Adam-sourced/inherited rank; non-fatal), so new SDs are born tiered and don't depend on the out-of-band stamper.

## Tests
`tests/unit/fleet/tier-rank-starvation-durable-fix.test.js` (8) + existing tier-aware/claim-eligibility suites: **47/47 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)