### PR TITLE
fix(SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001): close the #5249 belt-exclusion fail-open leak

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-TIER-RANK-STARVATION-DURABLE-FIX-001",
-  "createdAt": "2026-06-30T05:25:26.434Z",
+  "sdKey": "SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001",
+  "createdAt": "2026-06-30T05:54:35.410Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/coordinator/reconcile-clone-tree-exclusion.js
+++ b/lib/coordinator/reconcile-clone-tree-exclusion.js
@@ -1,0 +1,84 @@
+/**
+ * Bidirectional clone-tree-exclusion reconciliation.
+ * SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001 (FR-2).
+ *
+ * Reconciles strategic_directives_v2.metadata.test_clone_build_tree against the
+ * ventures.seeded_from_venture_id GROUND TRUTH for every SD that carries a metadata.venture_id:
+ *   (a) a CLONE venture (seeded_from_venture_id NOT NULL) whose SD is UNMARKED  -> MARK it
+ *       (catches a tree that leaked onto the belt before the FR-1 fix, or via any other path), and
+ *   (b) a REAL venture (seeded_from_venture_id IS NULL) whose SD is MARKED      -> UN-MARK it
+ *       (corrects an FR-1 fail-closed false-positive so a real venture is not stranded out of
+ *       worker self-claim).
+ *
+ * dryRun=true by default — reports counts without mutating. Fail-soft per item; idempotent (a row
+ * already in the correct state is a no-op).
+ */
+
+const TERMINAL_SD_STATUSES = ['completed', 'cancelled', 'archived'];
+
+const isMarked = (sd) => (sd && sd.metadata && sd.metadata.test_clone_build_tree) === true;
+
+/**
+ * @param {object} opts
+ * @param {import('@supabase/supabase-js').SupabaseClient} opts.supabase
+ * @param {boolean} [opts.dryRun=true]
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {Promise<{ dryRun: boolean, scanned: number, marked: number, unmarked: number, errors: string[] }>}
+ */
+export async function reconcileCloneTreeExclusion({ supabase, dryRun = true, log = () => {} } = {}) {
+  const summary = { dryRun, scanned: 0, marked: 0, unmarked: 0, errors: [] };
+  if (!supabase) { summary.errors.push('no_supabase'); return summary; }
+
+  // SDs that carry a venture_id and are not terminal (terminal SDs need no belt reconciliation).
+  const { data: sds, error: sdErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, status, metadata')
+    .not('metadata->>venture_id', 'is', null)
+    .not('status', 'in', `(${TERMINAL_SD_STATUSES.join(',')})`);
+  if (sdErr) { summary.errors.push(`sd_read: ${sdErr.message}`); return summary; }
+  if (!sds || sds.length === 0) { log('[reconcile] no venture-linked SDs to reconcile'); return summary; }
+
+  // Ground truth: seeded_from_venture_id per venture_id (a single batched read).
+  const ventureIds = [...new Set(sds.map((sd) => sd.metadata && sd.metadata.venture_id).filter(Boolean))];
+  const { data: ventures, error: vErr } = await supabase
+    .from('ventures')
+    .select('id, seeded_from_venture_id')
+    .in('id', ventureIds);
+  if (vErr) { summary.errors.push(`ventures_read: ${vErr.message}`); return summary; }
+  const isClone = new Map((ventures || []).map((v) => [v.id, v.seeded_from_venture_id != null]));
+
+  for (const sd of sds) {
+    const ventureId = sd.metadata && sd.metadata.venture_id;
+    if (!isClone.has(ventureId)) continue; // venture row missing -> leave the marker untouched (no ground truth)
+    summary.scanned++;
+    const clone = isClone.get(ventureId);
+    const marked = isMarked(sd);
+
+    if (clone && !marked) {
+      // leaked clone tree -> mark + exclude
+      log(`[reconcile] ${dryRun ? 'WOULD mark' : 'marking'} ${sd.sd_key} (clone venture ${ventureId}, was unmarked)`);
+      if (!dryRun) {
+        const meta = { ...(sd.metadata || {}), test_clone_build_tree: true };
+        const { error } = await supabase.from('strategic_directives_v2').update({ metadata: meta }).eq('id', sd.id);
+        if (error) { summary.errors.push(`mark ${sd.sd_key}: ${error.message}`); continue; }
+      }
+      summary.marked++;
+    } else if (!clone && marked) {
+      // real venture wrongly marked (FR-1 fail-closed false-positive) -> un-mark + restore claimability
+      log(`[reconcile] ${dryRun ? 'WOULD un-mark' : 'un-marking'} ${sd.sd_key} (real venture ${ventureId}, was marked)`);
+      if (!dryRun) {
+        const meta = { ...(sd.metadata || {}) };
+        delete meta.test_clone_build_tree;
+        const { error } = await supabase.from('strategic_directives_v2').update({ metadata: meta }).eq('id', sd.id);
+        if (error) { summary.errors.push(`unmark ${sd.sd_key}: ${error.message}`); continue; }
+      }
+      summary.unmarked++;
+    }
+    // else: already in the correct state -> no-op (idempotent)
+  }
+
+  log(`[reconcile] ${dryRun ? '(dry-run) ' : ''}scanned=${summary.scanned} marked=${summary.marked} unmarked=${summary.unmarked} errors=${summary.errors.length}`);
+  return summary;
+}
+
+export default { reconcileCloneTreeExclusion };

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -338,18 +338,48 @@ export function isPilotFixtureVenture(flags) {
  * @param {string} ventureId
  * @returns {Promise<{is_scaffolding:boolean, is_demo:boolean, seeded_from_venture_id:(string|null)}|null>}
  */
-export async function fetchVentureFlags(supabase, ventureId) {
+export async function fetchVentureFlags(supabase, ventureId, opts = {}) {
   if (!ventureId) return null;
-  try {
-    const { data } = await supabase
-      .from('ventures')
-      // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: + seeded_from_venture_id so a CLONE venture
-      // (seeded_from_venture_id NOT NULL) can be detected once here and have its build-tree marked.
-      .select('is_demo, is_scaffolding, seeded_from_venture_id')
-      .eq('id', ventureId)
-      .maybeSingle();
-    return data ? { is_demo: data.is_demo === true, is_scaffolding: data.is_scaffolding === true, seeded_from_venture_id: data.seeded_from_venture_id ?? null } : null;
-  } catch { return null; }
+  // SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001 (FR-1): retry a transient DB fault, then, if STILL
+  // unresolved, return the {unresolved:true} SENTINEL — DISTINCT from null (a genuinely-missing venture).
+  // The clone-exclusion decision FAILS CLOSED on the sentinel (isUnresolvedFlags) so a DB fault can never
+  // leak an UNMARKED clone build-tree onto the belt. backoffMs is deps-injectable for fast tests.
+  const backoffMs = Array.isArray(opts.backoffMs) ? opts.backoffMs : [50, 150];
+  const retries = Number.isInteger(opts.retries) ? opts.retries : backoffMs.length;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const { data, error } = await supabase
+        .from('ventures')
+        // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: + seeded_from_venture_id so a CLONE venture
+        // (seeded_from_venture_id NOT NULL) can be detected once here and have its build-tree marked.
+        .select('is_demo, is_scaffolding, seeded_from_venture_id')
+        .eq('id', ventureId)
+        .maybeSingle();
+      if (!error) {
+        // Resolved: a row (flags) or a genuinely-missing venture (null, not a fault -> not a clone).
+        return data ? { is_demo: data.is_demo === true, is_scaffolding: data.is_scaffolding === true, seeded_from_venture_id: data.seeded_from_venture_id ?? null } : null;
+      }
+    } catch { /* fall through to retry / unresolved */ }
+    if (attempt < retries) {
+      const ms = backoffMs[attempt] ?? backoffMs[backoffMs.length - 1] ?? 150;
+      await new Promise((r) => setTimeout(r, ms));
+    }
+  }
+  return { unresolved: true };
+}
+
+/**
+ * SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001 (FR-1): the clone-exclusion decision FAILS CLOSED
+ * when a venture's flags could not be resolved (a persistent DB fault). An unresolved venture is treated
+ * as a possible clone — its build-tree is marked test_clone_build_tree (excluded from WORKER self-claim,
+ * NOT un-built; clone trees build via the orchestrator) rather than leaking onto the belt. A wrongly
+ * fail-closed real venture is corrected by the bidirectional reconciliation sweep (FR-2). The pilot-skip
+ * guard (isPilotFixtureVenture) is unaffected — the sentinel carries no is_demo/is_scaffolding.
+ * @param {object|null} flags
+ * @returns {boolean}
+ */
+export function isUnresolvedFlags(flags) {
+  return !!(flags && flags.unresolved === true);
 }
 
 /**
@@ -485,7 +515,11 @@ export async function convertSprintToSDs(params, deps = {}) {
   // that is NOT a pilot still generates its tree, but every node is marked test_clone_build_tree=true so
   // the shared claim-eligibility predicate + belt SSOT exclude the throwaway test-clone MVP at the source
   // (no per-clone manual deferral). Computed ONCE from the same pilotFlags fetch. Real ventures => false.
-  const cloneBuildTree = isCloneVenture(pilotFlags);
+  // SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001 (FR-1): FAIL CLOSED — an UNRESOLVED venture (a
+  // persistent fetchVentureFlags fault, after retries) is also marked, so a DB fault can never leak an
+  // unmarked clone tree onto the belt. The bidirectional reconciliation sweep (FR-2) un-marks a real
+  // venture wrongly fail-closed-marked, using seeded_from_venture_id ground truth.
+  const cloneBuildTree = isCloneVenture(pilotFlags) || isUnresolvedFlags(pilotFlags);
 
   // Amplification cap: limit children (US-004)
   if (payloads.length > MAX_CHILDREN_PER_ORCHESTRATOR) {

--- a/scripts/coordinator/reconcile-clone-tree-exclusion.mjs
+++ b/scripts/coordinator/reconcile-clone-tree-exclusion.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Periodic clone-tree-exclusion reconciliation runner (FR-2 CLI).
+ * SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001.
+ *
+ * Thin CLI over lib/coordinator/reconcile-clone-tree-exclusion.js (single source of truth).
+ * DRY-RUN BY DEFAULT; pass --apply to mutate.
+ *
+ *   node scripts/coordinator/reconcile-clone-tree-exclusion.mjs           # report counts only
+ *   node scripts/coordinator/reconcile-clone-tree-exclusion.mjs --apply   # mark leaked clones + un-mark wrongly-marked real ventures
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { reconcileCloneTreeExclusion } from '../../lib/coordinator/reconcile-clone-tree-exclusion.js';
+
+const APPLY = process.argv.includes('--apply');
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+  const summary = await reconcileCloneTreeExclusion({ supabase, dryRun: !APPLY, log: (m) => console.log(m) });
+  console.log(`\n=== reconcile-clone-tree-exclusion ${APPLY ? '(APPLIED)' : '(dry-run — pass --apply to mutate)'} ===`);
+  console.log(JSON.stringify(summary, null, 2));
+  if (summary.errors.length) process.exitCode = 1;
+}
+
+main().catch((e) => { console.error('reconcile failed:', e?.message || e); process.exitCode = 1; });

--- a/tests/unit/eva/clone-tree-exclusion-fail-open.test.js
+++ b/tests/unit/eva/clone-tree-exclusion-fail-open.test.js
@@ -1,0 +1,155 @@
+/**
+ * SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001 (FR-4) — the #5249 belt-exclusion fail-open leak.
+ *
+ * FR-1: fetchVentureFlags retries a transient DB fault and, when STILL unresolved, returns {unresolved:true}
+ *       (distinct from null=genuinely-missing); the clone decision fails CLOSED (isUnresolvedFlags) so a DB
+ *       fault can never leak an UNMARKED clone tree onto the belt. isCloneVenture is unchanged.
+ * FR-2: the bidirectional reconciliation marks a leaked unmarked clone AND un-marks a wrongly-marked real
+ *       venture (ground truth = seeded_from_venture_id); dry-run reports without mutating; idempotent.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  fetchVentureFlags,
+  isUnresolvedFlags,
+  isCloneVenture,
+} from '../../../lib/eva/lifecycle-sd-bridge.js';
+import { reconcileCloneTreeExclusion } from '../../../lib/coordinator/reconcile-clone-tree-exclusion.js';
+
+// ── FR-1: fetchVentureFlags fail-closed semantics ──
+
+function flagsClient(behavior) {
+  // behavior: { error?:object, data?:object } per-attempt array, OR a single shape applied every call.
+  let call = 0;
+  return {
+    calls: () => call,
+    from() {
+      return {
+        select() { return this; },
+        eq() { return this; },
+        async maybeSingle() {
+          const step = Array.isArray(behavior) ? (behavior[Math.min(call, behavior.length - 1)]) : behavior;
+          call++;
+          if (step.throw) throw new Error('db down');
+          return { data: step.data ?? null, error: step.error ?? null };
+        },
+      };
+    },
+  };
+}
+
+const fast = { backoffMs: [0, 0], retries: 2 };
+
+describe('FR-1: fetchVentureFlags fails CLOSED on a persistent fault', () => {
+  it('resolves the flags on a clean read (no retry needed)', async () => {
+    const c = flagsClient({ data: { is_demo: false, is_scaffolding: false, seeded_from_venture_id: 'src-1' } });
+    const f = await fetchVentureFlags(c, 'v1', fast);
+    expect(isUnresolvedFlags(f)).toBe(false);
+    expect(isCloneVenture(f)).toBe(true);
+    expect(c.calls()).toBe(1);
+  });
+
+  it('a TRANSIENT error then success resolves normally (retry worked)', async () => {
+    const c = flagsClient([{ error: { message: 'timeout' } }, { data: { seeded_from_venture_id: null } }]);
+    const f = await fetchVentureFlags(c, 'v1', fast);
+    expect(isUnresolvedFlags(f)).toBe(false);
+    expect(isCloneVenture(f)).toBe(false); // resolved real venture
+    expect(c.calls()).toBe(2);
+  });
+
+  it('a PERSISTENT error returns {unresolved:true} (NOT null) -> clone decision fails CLOSED', async () => {
+    const c = flagsClient({ error: { message: 'db down' } });
+    const f = await fetchVentureFlags(c, 'v1', fast);
+    expect(isUnresolvedFlags(f)).toBe(true);
+    // the bridge marks cloneBuildTree = isCloneVenture(f) || isUnresolvedFlags(f) -> TRUE (no leak)
+    expect(isCloneVenture(f) || isUnresolvedFlags(f)).toBe(true);
+    expect(c.calls()).toBe(1 + fast.retries);
+  });
+
+  it('a genuinely-missing venture (no error, null data) returns null (not a clone, not unresolved)', async () => {
+    const c = flagsClient({ data: null, error: null });
+    const f = await fetchVentureFlags(c, 'v1', fast);
+    expect(f).toBeNull();
+    expect(isUnresolvedFlags(f)).toBe(false);
+    expect(isCloneVenture(f)).toBe(false);
+  });
+
+  it('a thrown read also fails closed to {unresolved:true}', async () => {
+    const c = flagsClient({ throw: true });
+    const f = await fetchVentureFlags(c, 'v1', fast);
+    expect(isUnresolvedFlags(f)).toBe(true);
+  });
+});
+
+// ── FR-2: bidirectional reconciliation ──
+
+function reconcileClient({ sds, ventures }) {
+  const updates = [];
+  return {
+    updates,
+    from(table) {
+      const ctx = { table, op: 'select', payload: null, idEq: null };
+      const builder = {
+        select() { ctx.op = 'select'; return builder; },
+        update(payload) { ctx.op = 'update'; ctx.payload = payload; return builder; },
+        not() { return builder; },
+        in() { return builder; },
+        eq(col, val) { ctx.idEq = val; return builder; },
+        then(resolve) {
+          if (ctx.op === 'update') { updates.push({ table: ctx.table, id: ctx.idEq, payload: ctx.payload }); return resolve({ error: null }); }
+          return resolve({ data: ctx.table === 'strategic_directives_v2' ? sds : ventures, error: null });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+const silent = () => {};
+
+describe('FR-2: bidirectional clone-tree reconciliation', () => {
+  const sds = [
+    { id: 'sd-leaked', sd_key: 'SD-LEAKED', status: 'draft', metadata: { venture_id: 'v-clone' } },             // clone, unmarked -> MARK
+    { id: 'sd-wrong', sd_key: 'SD-WRONG', status: 'draft', metadata: { venture_id: 'v-real', test_clone_build_tree: true } }, // real, marked -> UNMARK
+    { id: 'sd-ok-clone', sd_key: 'SD-OKC', status: 'draft', metadata: { venture_id: 'v-clone2', test_clone_build_tree: true } }, // clone, marked -> no-op
+    { id: 'sd-ok-real', sd_key: 'SD-OKR', status: 'draft', metadata: { venture_id: 'v-real2' } },               // real, unmarked -> no-op
+  ];
+  const ventures = [
+    { id: 'v-clone', seeded_from_venture_id: 'src-1' },
+    { id: 'v-real', seeded_from_venture_id: null },
+    { id: 'v-clone2', seeded_from_venture_id: 'src-2' },
+    { id: 'v-real2', seeded_from_venture_id: null },
+  ];
+
+  it('dry-run reports the corrections WITHOUT mutating', async () => {
+    const c = reconcileClient({ sds, ventures });
+    const r = await reconcileCloneTreeExclusion({ supabase: c, log: silent }); // dryRun defaults true
+    expect(r.dryRun).toBe(true);
+    expect(r.marked).toBe(1);
+    expect(r.unmarked).toBe(1);
+    expect(c.updates).toHaveLength(0);
+  });
+
+  it('apply marks the leaked clone + un-marks the wrongly-marked real venture (idempotent on the OK rows)', async () => {
+    const c = reconcileClient({ sds, ventures });
+    const r = await reconcileCloneTreeExclusion({ supabase: c, dryRun: false, log: silent });
+    expect(r.marked).toBe(1);
+    expect(r.unmarked).toBe(1);
+    expect(c.updates).toHaveLength(2);
+
+    const mark = c.updates.find((u) => u.id === 'sd-leaked');
+    expect(mark.payload.metadata.test_clone_build_tree).toBe(true);
+
+    const unmark = c.updates.find((u) => u.id === 'sd-wrong');
+    expect('test_clone_build_tree' in unmark.payload.metadata).toBe(false); // marker removed
+
+    // the already-correct rows (clone-marked, real-unmarked) are NOT touched
+    expect(c.updates.find((u) => u.id === 'sd-ok-clone')).toBeUndefined();
+    expect(c.updates.find((u) => u.id === 'sd-ok-real')).toBeUndefined();
+  });
+
+  it('missing supabase -> safe no-op with error', async () => {
+    const r = await reconcileCloneTreeExclusion({ supabase: null, log: silent });
+    expect(r.marked).toBe(0);
+    expect(r.errors).toContain('no_supabase');
+  });
+});

--- a/tests/unit/eva/pilot-venture-guard.test.js
+++ b/tests/unit/eva/pilot-venture-guard.test.js
@@ -66,10 +66,16 @@ describe('fetchVentureFlags', () => {
     expect(flags).toBeNull();
     expect(client.from).not.toHaveBeenCalled();
   });
-  it('returns null (fail-safe) when the query throws', async () => {
+  // SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001 (FR-1): a persistent query fault now FAILS CLOSED.
+  // It used to return null ('not a clone' -> a clone tree leaked onto the belt on a DB fault). It now
+  // retries and, when STILL unresolved, returns the {unresolved:true} sentinel so the bridge clone decision
+  // marks the tree (excluded) instead of leaking it. The pilot-skip guard is UNAFFECTED (the sentinel has
+  // no is_demo/is_scaffolding, so isPilotFixtureVenture stays false -> a real venture is never un-built).
+  it('returns the {unresolved:true} sentinel (fail-CLOSED) when the query persistently throws', async () => {
     const throwingClient = { from: () => { throw new Error('db down'); } };
-    const flags = await fetchVentureFlags(throwingClient, 'v-err');
-    expect(flags).toBeNull();
+    const flags = await fetchVentureFlags(throwingClient, 'v-err', { backoffMs: [0, 0], retries: 2 });
+    expect(flags).toEqual({ unresolved: true });
+    expect(isPilotFixtureVenture(flags)).toBe(false); // pilot-skip guard unaffected by the sentinel
   });
 });
 


### PR DESCRIPTION
## Summary
#5249 **failed open**: `fetchVentureFlags` returned `null` on any DB fault → `isCloneVenture(null)===false` → `cloneBuildTree===false` → the clone build-tree was created **without** the `test_clone_build_tree` marker → it leaked onto the belt as claimable → a worker self-claims a throwaway test-clone MVP and burns tokens building it. (The marker only gates **worker self-claim** — clone trees build via the orchestrator — so a fail-closed mis-mark is **recoverable**.)

## Changes
- **FR-1**: `fetchVentureFlags` now **retries** a transient error and, when still unresolved, returns an `{unresolved:true}` sentinel (distinct from `null`=genuinely-missing). New `isUnresolvedFlags()`. The bridge clone decision **fails closed**: `cloneBuildTree = isCloneVenture(flags) || isUnresolvedFlags(flags)` — an unresolved venture's tree is marked (excluded), never leaked. The pilot-skip guard is unaffected (the sentinel has no `is_demo`/`is_scaffolding`).
- **FR-2**: `lib/coordinator/reconcile-clone-tree-exclusion.js` — **bidirectional** sweep keyed on `ventures.seeded_from_venture_id` ground truth: marks a leaked unmarked clone AND un-marks a wrongly-marked real venture (corrects an FR-1 false-positive). Dry-run-default CLI.
- **FR-3**: at-creation marking (#5249) intact, now fed by the fail-closed `cloneBuildTree` (defense-in-depth).
- **FR-4**: `tests/unit/eva/clone-tree-exclusion-fail-open.test.js` (8). 44/44 existing bridge tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)