### PR TITLE
feat(SD-LEO-INFRA-CONVERGENCE-LEDGER-001): convergence ledger (runs + per-stage) SSOT

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-CLONE-TREE-EXCLUSION-FAIL-OPEN-LEAK-001",
-  "createdAt": "2026-06-30T05:54:35.410Z",
+  "sdKey": "SD-LEO-INFRA-CONVERGENCE-LEDGER-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CONVERGENCE-LEDGER-001",
+  "createdAt": "2026-06-30T06:30:29.951Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260630_convergence_ledger.sql
+++ b/database/migrations/20260630_convergence_ledger.sql
@@ -1,0 +1,89 @@
+-- Migration: convergence ledger (runs + per-stage rows)
+-- SD: SD-LEO-INFRA-CONVERGENCE-LEDGER-001 (FR-1, FR-2)
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- The durable SSOT for every S19->S26 convergence-walk run and its per-stage progression. The 4
+-- convergence circuit-breakers (SD-LEO-INFRA-CONVERGENCE-CIRCUIT-BREAKERS-001) read their thresholds
+-- from here: the per-stage churn cap reads convergence_ledger_stages.fix_cycle_count; the total/daily
+-- fix-SD budget reads the aggregate; the issues-per-run trend (churn-abort) reads issues_found per run.
+-- Additive (two new tables) — no change to existing tables. Chairman-gated apply (requires_chairman_apply).
+
+-- ============================================================================
+-- Table: convergence_ledger_runs — one row per walk run
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS convergence_ledger_runs (
+    run_id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subject_venture_id  UUID,
+    -- the walk subject: a non-clone dummy (the convergence harness) or a clone build-tree.
+    dummy_kind          TEXT CHECK (dummy_kind IS NULL OR dummy_kind IN ('non_clone', 'clone')),
+    sandbox_repo        TEXT,
+    started_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ended_at            TIMESTAMPTZ,
+    status              TEXT NOT NULL DEFAULT 'active'
+                          CHECK (status IN ('active', 'paused', 'aborted', 'clean')),
+    -- FR-5: run-end DUAL-PURPOSE harvest — both factory defects AND process lessons.
+    harvest             JSONB,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_clr_status ON convergence_ledger_runs(status);
+CREATE INDEX IF NOT EXISTS idx_clr_subject_venture ON convergence_ledger_runs(subject_venture_id) WHERE subject_venture_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_clr_started_at ON convergence_ledger_runs(started_at DESC);
+
+COMMENT ON TABLE convergence_ledger_runs IS 'Convergence-walk run ledger (SD-LEO-INFRA-CONVERGENCE-LEDGER-001): one row per S19->S26 walk run. The SSOT the convergence circuit-breakers + dashboards read.';
+
+-- ============================================================================
+-- Table: convergence_ledger_stages — one row per (run, stage)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS convergence_ledger_stages (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id              UUID NOT NULL REFERENCES convergence_ledger_runs(run_id) ON DELETE CASCADE,
+    stage               INTEGER NOT NULL CHECK (stage >= 0 AND stage <= 26),
+    entered_at          TIMESTAMPTZ,
+    -- the per-stage churn cap (breaker #2) reads fix_cycle_count; the total/daily fix-SD budget the aggregate.
+    fix_cycle_count     INTEGER NOT NULL DEFAULT 0,
+    issues_found        INTEGER NOT NULL DEFAULT 0,
+    issues_resolved     INTEGER NOT NULL DEFAULT 0,
+    stage_status        TEXT CHECK (stage_status IS NULL OR stage_status IN ('clean', 'churning', 'escalated')),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- one row per stage per run, so the churn cap reads exactly one row and upserts are deterministic.
+    UNIQUE (run_id, stage)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cls_run ON convergence_ledger_stages(run_id);
+
+COMMENT ON TABLE convergence_ledger_stages IS 'Per-stage convergence-walk progression (SD-LEO-INFRA-CONVERGENCE-LEDGER-001): UNIQUE(run_id, stage 0..26). fix_cycle_count feeds the per-stage churn cap breaker.';
+
+-- ============================================================================
+-- RLS (mirrors venture_provisioning_state): service_role manage, authenticated select
+-- ============================================================================
+ALTER TABLE convergence_ledger_runs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS manage_convergence_ledger_runs ON convergence_ledger_runs;
+CREATE POLICY manage_convergence_ledger_runs ON convergence_ledger_runs FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS select_convergence_ledger_runs ON convergence_ledger_runs;
+CREATE POLICY select_convergence_ledger_runs ON convergence_ledger_runs FOR SELECT TO authenticated USING (true);
+
+ALTER TABLE convergence_ledger_stages ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS manage_convergence_ledger_stages ON convergence_ledger_stages;
+CREATE POLICY manage_convergence_ledger_stages ON convergence_ledger_stages FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS select_convergence_ledger_stages ON convergence_ledger_stages;
+CREATE POLICY select_convergence_ledger_stages ON convergence_ledger_stages FOR SELECT TO authenticated USING (true);
+
+-- ============================================================================
+-- updated_at triggers
+-- ============================================================================
+CREATE OR REPLACE FUNCTION trg_convergence_ledger_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_clr_updated ON convergence_ledger_runs;
+CREATE TRIGGER trg_clr_updated BEFORE UPDATE ON convergence_ledger_runs FOR EACH ROW EXECUTE FUNCTION trg_convergence_ledger_updated_at();
+
+DROP TRIGGER IF EXISTS trg_cls_updated ON convergence_ledger_stages;
+CREATE TRIGGER trg_cls_updated BEFORE UPDATE ON convergence_ledger_stages FOR EACH ROW EXECUTE FUNCTION trg_convergence_ledger_updated_at();

--- a/lib/coordinator/convergence-ledger.js
+++ b/lib/coordinator/convergence-ledger.js
@@ -1,0 +1,160 @@
+/**
+ * Convergence ledger — the SSOT read/write helpers for the S19->S26 convergence-walk ledger.
+ * SD-LEO-INFRA-CONVERGENCE-LEDGER-001 (FR-3..FR-6).
+ *
+ * Tables (database/migrations/20260630_convergence_ledger.sql):
+ *   convergence_ledger_runs    (run_id PK, subject_venture_id, dummy_kind, sandbox_repo, started_at,
+ *                               ended_at, status, harvest jsonb)
+ *   convergence_ledger_stages  (UNIQUE(run_id, stage 0..26), fix_cycle_count, issues_found,
+ *                               issues_resolved, stage_status)
+ *
+ * The 4 convergence circuit-breakers (SD-LEO-INFRA-CONVERGENCE-CIRCUIT-BREAKERS-001) read EXCLUSIVELY
+ * through the getters here (getActiveRun / getStageChurn / getWalkSpawnedCount / getIssuesPerRunTrend),
+ * so the breakers + dashboards share one SSOT and never touch raw rows.
+ *
+ * FR-3 walk-spawned-SD tagging is a strategic_directives_v2.metadata.convergence_walk_run_id marker
+ * (NO schema change) — getWalkSpawnedCount queries it so walk-spawned SDs are cleanly separable from
+ * organic infra SDs. The launcher (in the circuit-breakers SD) stamps the marker at spawn.
+ */
+
+export const RUNS_TABLE = 'convergence_ledger_runs';
+export const STAGES_TABLE = 'convergence_ledger_stages';
+export const WALK_RUN_MARKER = 'convergence_walk_run_id';
+
+// ── pure helpers (DB-free, deterministic) ──────────────────────────────────
+
+/**
+ * FR-4: is the issues-per-run series trending DOWN? The churn-abort escalates+STOPs when this is FALSE
+ * (issues are not converging). A series is trending down when its last value is strictly below its first
+ * AND no later value exceeds an earlier one by the monotonic-decrease test (non-increasing, strictly
+ * lower end). 0- or 1-length series are treated as "not enough evidence of churn" => trending down (true).
+ * PURE/TOTAL.
+ * @param {number[]} series  issues-per-run, oldest -> newest
+ * @returns {boolean}
+ */
+export function isTrendingDown(series) {
+  if (!Array.isArray(series)) return true;
+  const xs = series.filter((n) => Number.isFinite(n));
+  if (xs.length <= 1) return true;
+  for (let i = 1; i < xs.length; i++) {
+    if (xs[i] > xs[i - 1]) return false; // a later run had MORE issues than the prior -> not converging
+  }
+  return xs[xs.length - 1] < xs[0]; // and the end is strictly below the start
+}
+
+// ── write helpers ──────────────────────────────────────────────────────────
+
+/** Start a run. Returns { run_id } (or { error }). */
+export async function startRun(supabase, { subject_venture_id = null, dummy_kind = null, sandbox_repo = null } = {}) {
+  if (!supabase) return { error: 'no_supabase' };
+  const { data, error } = await supabase
+    .from(RUNS_TABLE)
+    .insert({ subject_venture_id, dummy_kind, sandbox_repo, status: 'active' })
+    .select('run_id')
+    .single();
+  return error ? { error: error.message } : { run_id: data.run_id };
+}
+
+/** Upsert a per-stage row (one per run_id+stage). Pass deltas/values to set. */
+export async function upsertStage(supabase, runId, stage, fields = {}) {
+  if (!supabase) return { error: 'no_supabase' };
+  const row = { run_id: runId, stage, ...fields };
+  const { error } = await supabase.from(STAGES_TABLE).upsert(row, { onConflict: 'run_id,stage' });
+  return error ? { error: error.message } : { ok: true };
+}
+
+/** FR-5: write the run-end dual-purpose harvest ({ defects, lessons }) + close the run. */
+export async function recordHarvest(supabase, runId, harvest, { status = 'clean' } = {}) {
+  if (!supabase) return { error: 'no_supabase' };
+  const { error } = await supabase
+    .from(RUNS_TABLE)
+    .update({ harvest, status, ended_at: new Date().toISOString() })
+    .eq('run_id', runId);
+  return error ? { error: error.message } : { ok: true };
+}
+
+/** End a run with a terminal status (no harvest). */
+export async function endRun(supabase, runId, status = 'clean') {
+  if (!supabase) return { error: 'no_supabase' };
+  const { error } = await supabase
+    .from(RUNS_TABLE)
+    .update({ status, ended_at: new Date().toISOString() })
+    .eq('run_id', runId);
+  return error ? { error: error.message } : { ok: true };
+}
+
+// ── read SSOT (consumed by the circuit-breakers + dashboards) ───────────────
+
+/** The current active run (most recent status='active'), or null. */
+export async function getActiveRun(supabase) {
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from(RUNS_TABLE)
+    .select('*')
+    .eq('status', 'active')
+    .order('started_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return error ? null : (data || null);
+}
+
+/** Breaker #2 input: the fix_cycle_count for (run_id, stage). 0 when no row. */
+export async function getStageChurn(supabase, runId, stage) {
+  if (!supabase) return 0;
+  const { data, error } = await supabase
+    .from(STAGES_TABLE)
+    .select('fix_cycle_count')
+    .eq('run_id', runId)
+    .eq('stage', stage)
+    .maybeSingle();
+  return error || !data ? 0 : (Number(data.fix_cycle_count) || 0);
+}
+
+/**
+ * Breakers #3/#4 input: count of walk-spawned fix-SDs, by run_id OR by day (UTC, default today).
+ * Reads the strategic_directives_v2.metadata.convergence_walk_run_id marker.
+ * @param {object} opts { run_id?:string, sinceIso?:string }  run_id scopes to one run; sinceIso scopes by created_at>=.
+ */
+export async function getWalkSpawnedCount(supabase, opts = {}) {
+  if (!supabase) return 0;
+  let q = supabase
+    .from('strategic_directives_v2')
+    .select('id', { count: 'exact', head: true })
+    .not(`metadata->>${WALK_RUN_MARKER}`, 'is', null);
+  if (opts.run_id) q = q.eq(`metadata->>${WALK_RUN_MARKER}`, opts.run_id);
+  if (opts.sinceIso) q = q.gte('created_at', opts.sinceIso);
+  const { count, error } = await q;
+  return error ? 0 : (count || 0);
+}
+
+/**
+ * FR-4: issues-per-run series over the last K runs (oldest -> newest), for the churn-abort.
+ * Each run's issues = SUM(issues_found) across its stages. Returns number[].
+ */
+export async function getIssuesPerRunTrend(supabase, k = 5) {
+  if (!supabase) return [];
+  const { data: runs, error: rErr } = await supabase
+    .from(RUNS_TABLE)
+    .select('run_id, started_at')
+    .order('started_at', { ascending: false })
+    .limit(k);
+  if (rErr || !runs || runs.length === 0) return [];
+  const ordered = [...runs].reverse(); // oldest -> newest
+  const series = [];
+  for (const run of ordered) {
+    const { data: stages, error: sErr } = await supabase
+      .from(STAGES_TABLE)
+      .select('issues_found')
+      .eq('run_id', run.run_id);
+    if (sErr) { series.push(0); continue; }
+    series.push((stages || []).reduce((sum, s) => sum + (Number(s.issues_found) || 0), 0));
+  }
+  return series;
+}
+
+export default {
+  RUNS_TABLE, STAGES_TABLE, WALK_RUN_MARKER,
+  isTrendingDown,
+  startRun, upsertStage, recordHarvest, endRun,
+  getActiveRun, getStageChurn, getWalkSpawnedCount, getIssuesPerRunTrend,
+};

--- a/tests/unit/coordinator/convergence-ledger.test.js
+++ b/tests/unit/coordinator/convergence-ledger.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-INFRA-CONVERGENCE-LEDGER-001 (FR-7) — convergence ledger read SSOT + pure trend.
+ *
+ * Pure isTrendingDown coverage + the read helpers (getActiveRun / getStageChurn / getWalkSpawnedCount /
+ * getIssuesPerRunTrend) against a mock supabase. The table DDL is validated separately by the DATABASE
+ * sub-agent via a rolled-back transaction.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isTrendingDown,
+  getActiveRun,
+  getStageChurn,
+  getWalkSpawnedCount,
+  getIssuesPerRunTrend,
+  RUNS_TABLE,
+  STAGES_TABLE,
+} from '../../../lib/coordinator/convergence-ledger.js';
+
+describe('FR-4: isTrendingDown (pure)', () => {
+  it('true for a strictly decreasing series', () => {
+    expect(isTrendingDown([10, 7, 4, 1])).toBe(true);
+  });
+  it('false for a non-decreasing (flat or rising) series', () => {
+    expect(isTrendingDown([5, 5, 5])).toBe(false);  // flat -> not converging
+    expect(isTrendingDown([3, 4, 2])).toBe(false);  // a later run rose above the prior
+    expect(isTrendingDown([1, 2, 3])).toBe(false);  // rising
+  });
+  it('true (not enough evidence) for 0- or 1-length / non-array input', () => {
+    expect(isTrendingDown([])).toBe(true);
+    expect(isTrendingDown([7])).toBe(true);
+    expect(isTrendingDown(null)).toBe(true);
+  });
+  it('non-increasing with a strictly-lower end is trending down', () => {
+    expect(isTrendingDown([8, 8, 5])).toBe(true);   // never rises, ends below start
+    expect(isTrendingDown([8, 8, 8])).toBe(false);  // never drops
+  });
+});
+
+// Mock supabase: per-table canned reads + a count head-query for walk-spawned.
+function makeSb(cfg) {
+  return {
+    from(table) {
+      const ctx = { table, filters: {}, count: false };
+      const builder = {
+        select(_cols, opts) { if (opts && opts.count) ctx.count = true; return builder; },
+        eq(col, val) { ctx.filters[col] = val; return builder; },
+        not() { return builder; },
+        gte(col, val) { ctx.filters[`gte:${col}`] = val; return builder; },
+        order() { return builder; },
+        limit() { return builder; },
+        async maybeSingle() { return { data: cfg.resolve(ctx), error: null }; },
+        then(resolve) {
+          if (ctx.count) return resolve({ count: cfg.count(ctx), error: null });
+          return resolve({ data: cfg.resolve(ctx), error: null });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('read SSOT helpers (mock supabase)', () => {
+  it('getActiveRun returns the active run row', async () => {
+    const sb = makeSb({ resolve: (ctx) => (ctx.table === RUNS_TABLE && ctx.filters.status === 'active' ? { run_id: 'r1', status: 'active' } : null), count: () => 0 });
+    const run = await getActiveRun(sb);
+    expect(run.run_id).toBe('r1');
+  });
+
+  it('getStageChurn returns fix_cycle_count for (run_id, stage); 0 when absent', async () => {
+    const sb = makeSb({ resolve: (ctx) => (ctx.table === STAGES_TABLE && ctx.filters.run_id === 'r1' && ctx.filters.stage === 19 ? { fix_cycle_count: 4 } : null), count: () => 0 });
+    expect(await getStageChurn(sb, 'r1', 19)).toBe(4);
+    expect(await getStageChurn(sb, 'r1', 5)).toBe(0); // no row -> 0
+  });
+
+  it('getWalkSpawnedCount counts walk-tagged SDs (by run_id), isolating organic SDs via the head count', async () => {
+    const sb = makeSb({ resolve: () => null, count: (ctx) => (ctx.filters['metadata->>convergence_walk_run_id'] === 'r1' ? 3 : 7) });
+    expect(await getWalkSpawnedCount(sb, { run_id: 'r1' })).toBe(3);
+    expect(await getWalkSpawnedCount(sb, {})).toBe(7); // all walk-tagged (any run)
+  });
+
+  it('getIssuesPerRunTrend sums issues_found per run, oldest -> newest', async () => {
+    const runs = [{ run_id: 'r-new', started_at: '2026-06-30T02:00:00Z' }, { run_id: 'r-old', started_at: '2026-06-30T01:00:00Z' }];
+    const stagesByRun = { 'r-old': [{ issues_found: 6 }, { issues_found: 4 }], 'r-new': [{ issues_found: 2 }, { issues_found: 1 }] };
+    const sb = makeSb({
+      resolve: (ctx) => (ctx.table === RUNS_TABLE ? runs : (stagesByRun[ctx.filters.run_id] || [])),
+      count: () => 0,
+    });
+    const series = await getIssuesPerRunTrend(sb, 2);
+    expect(series).toEqual([10, 3]); // oldest (r-old=10) -> newest (r-new=3)
+    expect(isTrendingDown(series)).toBe(true);
+  });
+
+  it('helpers fail safe without supabase', async () => {
+    expect(await getActiveRun(null)).toBeNull();
+    expect(await getStageChurn(null, 'r', 1)).toBe(0);
+    expect(await getWalkSpawnedCount(null)).toBe(0);
+    expect(await getIssuesPerRunTrend(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
The durable SSOT for every S19→S26 convergence-walk run + per-stage progression that the 4 convergence circuit-breakers (SD-LEO-INFRA-CONVERGENCE-CIRCUIT-BREAKERS-001) read their thresholds from.

## Changes
- **FR-1/FR-2**: `database/migrations/20260630_convergence_ledger.sql` — `convergence_ledger_runs` (run_id PK, dummy_kind clone|non_clone, status active|paused|aborted|clean, `harvest` jsonb) + `convergence_ledger_stages` (UNIQUE(run_id, stage 0..26), `fix_cycle_count`, issues_found/resolved, stage_status; FK CASCADE). RLS + updated_at triggers mirror `venture_provisioning_state`. **Additive; chairman-apply pre-staged** (`requires_chairman_apply`), rolled-back-transaction-validated.
- **FR-3**: walk-spawned-SD tagging = `strategic_directives_v2.metadata.convergence_walk_run_id` (no schema change); `getWalkSpawnedCount` queries it to isolate walk SDs from organic SDs.
- **FR-4/FR-5/FR-6**: `lib/coordinator/convergence-ledger.js` — the read SSOT (`getActiveRun` / `getStageChurn` / `getWalkSpawnedCount` / `getIssuesPerRunTrend`) + pure `isTrendingDown` (churn-abort) + write helpers (`startRun` / `upsertStage` / `recordHarvest` / `endRun` + harvest slot).
- **FR-7**: `tests/unit/coordinator/convergence-ledger.test.js` (9). DDL validated by the DATABASE sub-agent via a rolled-back transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)