### PR TITLE
fix(SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001): claim-fitness guard fails CLOSED (builder-vs-promise .catch bug)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-CONVERGENCE-CIRCUIT-BREAKERS-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-CONVERGENCE-CIRCUIT-BREAKERS-001",
-  "createdAt": "2026-06-30T10:50:33.497Z",
+  "sdKey": "SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001",
+  "createdAt": "2026-06-30T12:02:28.345Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/fleet/best-effort-release.mjs
+++ b/lib/fleet/best-effort-release.mjs
@@ -1,0 +1,43 @@
+/**
+ * best-effort-release — release a claim back to the queue WITHOUT ever throwing.
+ * SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001 (FR-1/FR-3).
+ *
+ * THE BUG IT REPLACES: `await supabase.rpc('release_sd', {...}).catch(() => {})`. The PostgREST query
+ * builder returned by .rpc() is THENABLE (it has .then) but is NOT a Promise — it has NO .catch. So
+ * `.catch(() => {})` threw a SYNCHRONOUS `TypeError: ....catch is not a function` BEFORE the blocking
+ * `process.exit(1)` that followed it. The surrounding try/catch swallowed that TypeError as a
+ * 'fail-open' skip, so a POSITIVELY-determined UNFIT (e.g. wrong-target_application) SD got CLAIMED
+ * anyway — the worker then could not build it from the wrong checkout.
+ *
+ * THE CONTRACT: await the builder INSIDE a try/catch so a release failure (or a builder without .catch)
+ * can never break the caller's control flow. The release is BEST-EFFORT cleanup; the caller's claim
+ * block + process.exit(1) must be UNCONDITIONAL (called regardless of the result here).
+ *
+ * @param {{ rpc: Function }} supabase
+ * @param {string} sessionId
+ * @param {string} [reason]
+ * @param {(msg: string) => void} [log]
+ * @returns {Promise<{ released: boolean, error: (string|null) }>}  NEVER throws.
+ */
+export async function bestEffortReleaseSd(supabase, sessionId, reason = 'manual', log = console.error) {
+  try {
+    if (!supabase || typeof supabase.rpc !== 'function') {
+      return { released: false, error: 'no_supabase' };
+    }
+    const res = await supabase.rpc('release_sd', { p_session_id: sessionId, p_reason: reason });
+    if (res && res.error) {
+      const msg = res.error.message || String(res.error);
+      log(`   ⚠ release_sd returned an error (best-effort cleanup; claim block still enforced): ${msg}`);
+      return { released: false, error: msg };
+    }
+    return { released: true, error: null };
+  } catch (e) {
+    // A rejected await, OR a builder that lacks .catch and threw — either way, swallow it here so the
+    // CALLER's unconditional block/exit proceeds (fail-CLOSED on the claim, best-effort on the cleanup).
+    const msg = e && e.message ? e.message : String(e);
+    log(`   ⚠ release_sd threw (best-effort cleanup; claim block still enforced): ${msg}`);
+    return { released: false, error: msg };
+  }
+}
+
+export default { bestEffortReleaseSd };

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -14,6 +14,10 @@
 
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import { execSync } from 'child_process';
+// SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001 (FR-1): no-throw best-effort claim release. Replaces the
+// `await supabase.rpc('release_sd', {...}).catch(() => {})` calls — the PostgREST builder has no .catch, so
+// that .catch threw a TypeError before the blocking process.exit(1) and the outer catch swallowed it (fail-OPEN).
+import { bestEffortReleaseSd } from '../lib/fleet/best-effort-release.mjs';
 // SD-LEO-FIX-SESSION-LIFECYCLE-HYGIENE-001 (FR5): getRepoRoot resolves the
 // canonical main repo regardless of cwd; isInsideWorktree is used as an
 // early guard to prevent nested-worktree creation when sd-start is
@@ -1376,10 +1380,10 @@ async function main() {
     if (crosscheck.verdict === 'BLOCK') {
       console.error(`${colors.red}   ❌  Cross-check BLOCK: refusing worktree creation.${colors.reset}`);
       console.error(`${colors.dim}   Fix: correct target_application or revise SD scope text.${colors.reset}`);
-      await supabase.rpc('release_sd', {
-        p_session_id: session.session_id,
-        p_reason: 'manual'
-      }).catch(() => {});
+      // SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001 (FR-1/FR-3): best-effort release (never throws),
+      // then UNCONDITIONALLY block the claim. (Was `.rpc(...).catch(() => {})` — the .catch threw on the
+      // non-.catch-able builder before this exit, and the outer catch swallowed it as fail-open.)
+      await bestEffortReleaseSd(supabase, session.session_id);
       process.exit(1);
     }
   } catch (ccErr) {
@@ -1413,15 +1417,23 @@ async function main() {
           }
         }
       } catch { /* triage is advisory — never block the release on it */ }
-      await supabase.rpc('release_sd', {
-        p_session_id: session.session_id,
-        p_reason: 'manual'
-      }).catch(() => {});
+      // SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001 (FR-1): best-effort release (never throws), then
+      // UNCONDITIONALLY block the claim + exit. The prior `.rpc(...).catch(() => {})` threw on the
+      // non-.catch-able PostgREST builder BEFORE this exit, the outer catch swallowed it as 'fail-open',
+      // and a positively-determined UNFIT (e.g. wrong-target_application) SD got claimed anyway.
+      await bestEffortReleaseSd(supabase, session.session_id);
       process.exit(1);
     }
   } catch (fitErr) {
-    // Non-blocking — fitness fail-fast is defense-in-depth and must fail open.
-    console.log(`${colors.dim}[fitness] skipped (fail-open): ${fitErr.message}${colors.reset}`);
+    // SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001 (FR-2): FAIL CLOSED on an UNEXPECTED error in the
+    // fitness path — never fall through to claim an SD we could not confirm is fit. This is SAFE because
+    // the predicate isSdExecutableHere (lib/fleet/sd-executable-here.cjs) is fail-open INTERNALLY: any
+    // internal error or indeterminate signal (e.g. absent target_application) returns fit:true and it
+    // NEVER throws, so that fail-open is the fleet-wide-stall guard. This outer catch therefore only fires
+    // on a truly-novel error, where blocking the claim (not silently claiming wrong work) is correct.
+    console.error(`${colors.red}   ❌ [fitness] UNEXPECTED error — failing CLOSED (blocking the claim): ${fitErr.message}${colors.reset}`);
+    await bestEffortReleaseSd(supabase, session.session_id);
+    process.exit(1);
   }
 
   // 4.5. Resolve worktree (creates if needed in claim mode)

--- a/tests/unit/fleet/best-effort-release.test.js
+++ b/tests/unit/fleet/best-effort-release.test.js
@@ -1,0 +1,55 @@
+/**
+ * SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001 (FR-4) — bestEffortReleaseSd no-throw contract.
+ *
+ * The bug: `await supabase.rpc('release_sd', {...}).catch(() => {})` — a PostgREST builder is THENABLE
+ * but has NO .catch, so `.catch` threw a TypeError BEFORE the blocking process.exit(1), and the outer
+ * catch swallowed it as fail-OPEN -> an UNFIT (wrong-target_application) SD got claimed anyway. The
+ * helper awaits the builder inside try/catch and NEVER throws, so the caller's unconditional block/exit
+ * always proceeds (fail-CLOSED on the claim, best-effort on the cleanup).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { bestEffortReleaseSd } from '../../../lib/fleet/best-effort-release.mjs';
+
+const silent = () => {};
+
+describe('bestEffortReleaseSd', () => {
+  it('REPRO: a PostgREST builder is thenable but has NO .catch (calling .catch on it throws)', () => {
+    const builder = { then: (resolve) => resolve({ data: null, error: null }) }; // no .catch
+    expect(typeof builder.then).toBe('function');
+    expect(builder.catch).toBeUndefined();
+    // The OLD code did `builder.catch(() => {})` -> TypeError. Confirm the repro:
+    expect(() => builder.catch(() => {})).toThrow(TypeError);
+  });
+
+  it('resolves {released:true} when .rpc returns a thenable-only builder (no throw — the bug is gone)', async () => {
+    const supabase = { rpc: () => ({ then: (resolve) => resolve({ data: { released_sd: 'X' }, error: null }) }) };
+    const r = await bestEffortReleaseSd(supabase, 'sess-1', 'manual', silent);
+    expect(r.released).toBe(true);
+    expect(r.error).toBeNull();
+  });
+
+  it('resolves {released:false} (no throw) when the rpc REJECTS', async () => {
+    const supabase = { rpc: vi.fn(async () => { throw new Error('db down'); }) };
+    const r = await bestEffortReleaseSd(supabase, 'sess-1', 'manual', silent);
+    expect(r.released).toBe(false);
+    expect(r.error).toMatch(/db down/);
+  });
+
+  it('resolves {released:false} (no throw) when the rpc returns an {error}', async () => {
+    const supabase = { rpc: async () => ({ data: null, error: { message: 'rls denied' } }) };
+    const r = await bestEffortReleaseSd(supabase, 'sess-1', 'manual', silent);
+    expect(r.released).toBe(false);
+    expect(r.error).toMatch(/rls denied/);
+  });
+
+  it('resolves {released:false, error:no_supabase} when supabase is missing (no throw)', async () => {
+    expect(await bestEffortReleaseSd(null, 's', 'manual', silent)).toEqual({ released: false, error: 'no_supabase' });
+    expect(await bestEffortReleaseSd({}, 's', 'manual', silent)).toEqual({ released: false, error: 'no_supabase' });
+  });
+
+  it('passes the session id + reason to release_sd', async () => {
+    const rpc = vi.fn(async () => ({ data: {}, error: null }));
+    await bestEffortReleaseSd({ rpc }, 'sess-9', 'unfit_repo_mismatch', silent);
+    expect(rpc).toHaveBeenCalledWith('release_sd', { p_session_id: 'sess-9', p_reason: 'unfit_repo_mismatch' });
+  });
+});


### PR DESCRIPTION
## Summary
The `sd-start` claim-time fitness guard **failed open**: the UNFIT branch did `await supabase.rpc('release_sd', {...}).catch(() => {})`, but a PostgREST builder is **thenable yet has no `.catch`** — so `.catch` threw a synchronous `TypeError` **before** the blocking `process.exit(1)`, the outer try/catch swallowed it as 'fail-open', and a positively-determined **UNFIT (wrong-target_application) SD got claimed anyway**. The worker then couldn't build it from the wrong checkout. The same bug existed a **second time** in the target-application crosscheck BLOCK.

## Changes
- **FR-1/FR-3**: `lib/fleet/best-effort-release.mjs` — `bestEffortReleaseSd` awaits the builder **inside try/catch** and never throws. Both release sites (fitness UNFIT + crosscheck BLOCK) use it + an **unconditional** `process.exit(1)`: release is best-effort cleanup, the block/exit is unconditional. Audit (single + multiline) confirms **0 remaining** `.rpc(...).catch(` / `.from(...).catch(` in code.
- **FR-2**: the fitness outer catch now **fails closed** (block + exit). Safe because `isSdExecutableHere` is fail-open **internally** (any internal error / indeterminate signal → `fit:true`, never throws) — that internal fail-open is the fleet-wide-stall guard, so the outer catch only fires on a truly-novel error, where blocking an unconfirmable claim is correct.
- **FR-4**: `tests/unit/fleet/best-effort-release.test.js` (6) — the builder-without-`.catch` repro + the no-throw contract. **147/147** fleet regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)