### PR TITLE
feat(SD-LEO-INFRA-ADAM-INBOX-KINDS-SOURCE-REQUEST-001): drain coordinator_source_request via the normal Adam lane

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-CLAIM-FITNESS-FAILOPEN-BYPASS-001",
-  "createdAt": "2026-06-30T12:02:28.345Z",
+  "sdKey": "SD-LEO-INFRA-ADAM-INBOX-KINDS-SOURCE-REQUEST-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-ADAM-INBOX-KINDS-SOURCE-REQUEST-001",
+  "createdAt": "2026-06-30T12:31:13.981Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -269,6 +269,12 @@ const ADAM_INBOX_KINDS = Object.freeze([
   'coordinator_adam_feedback',
   'assist_request',
   'reconcile_consult',
+  // SD-LEO-INFRA-ADAM-INBOX-KINDS-SOURCE-REQUEST-001: the coordinator's belt-low source-to-capacity
+  // handshake dispatches Adam a payload.kind='coordinator_source_request'. Without it in this allowlist,
+  // isAdamInboxRow returned false and the normal drain skipped it — it only reached Adam via the degraded
+  // orphan/visibility-recovery fallback. A coordinator->Adam directive-to-action (sibling of
+  // coordinator_advisory / coordinator_adam_feedback), so it belongs here, NOT in EXCLUDED_KINDS.
+  'coordinator_source_request',
 ]);
 
 /**

--- a/tests/unit/adam-inbox-coordinator-source-request.test.js
+++ b/tests/unit/adam-inbox-coordinator-source-request.test.js
@@ -1,0 +1,36 @@
+/**
+ * SD-LEO-INFRA-ADAM-INBOX-KINDS-SOURCE-REQUEST-001 — the coordinator belt-low source-to-capacity
+ * handshake (payload.kind='coordinator_source_request') must drain through the NORMAL Adam inbox lane,
+ * not the degraded orphan/visibility-recovery fallback. This pins the kind in the ADAM_INBOX_KINDS
+ * allowlist so a future edit cannot silently drop the lane.
+ */
+import { describe, it, expect } from 'vitest';
+import pkg from '../../scripts/adam-advisory.cjs';
+
+const { isAdamInboxRow, isOrphanedAdamRow, ADAM_INBOX_KINDS } = pkg;
+
+const row = (kind) => (kind === undefined ? { payload: {} } : { payload: { kind } });
+
+describe('Adam inbox drains coordinator_source_request (belt-low handshake)', () => {
+  it('coordinator_source_request is in the Adam-scoped allowlist', () => {
+    expect(ADAM_INBOX_KINDS).toContain('coordinator_source_request');
+  });
+
+  it('isAdamInboxRow classifies a coordinator_source_request row as drainable (typed lane)', () => {
+    expect(isAdamInboxRow(row('coordinator_source_request'))).toBe(true);
+  });
+
+  it('isOrphanedAdamRow is FALSE for it (consumed by the normal drain, NOT the orphan fallback)', () => {
+    expect(isOrphanedAdamRow(row('coordinator_source_request'))).toBe(false);
+  });
+
+  it('an unknown coordinator kind is still orphaned (the fix is scoped to this one kind)', () => {
+    expect(isAdamInboxRow(row('coordinator_unknown_kind'))).toBe(false);
+    expect(isOrphanedAdamRow(row('coordinator_unknown_kind'))).toBe(true);
+  });
+
+  it('still drains the sibling Adam-directed kinds (regression)', () => {
+    expect(isAdamInboxRow(row('coordinator_advisory'))).toBe(true);
+    expect(isAdamInboxRow(row('coordinator_adam_feedback'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The coordinator's belt-low source-to-capacity handshake dispatches Adam a `payload.kind='coordinator_source_request'`, but that kind was **not** in the typed `ADAM_INBOX_KINDS` allowlist — so `isAdamInboxRow` returned false and the normal drain skipped it; it only reached Adam via the degraded **orphan/visibility-recovery fallback**.

## Changes
- **FR-1**: add `'coordinator_source_request'` to `ADAM_INBOX_KINDS` (scripts/adam-advisory.cjs) — a coordinator→Adam directive-to-action sibling of `coordinator_advisory` / `coordinator_adam_feedback` (not `EXCLUDED_KINDS`, which is for handler-owned/terminal kinds).
- **FR-2**: `isOrphanedAdamRow` now returns false for it (consumed by the normal lane, not the orphan fallback).
- **FR-3**: `tests/unit/adam-inbox-coordinator-source-request.test.js` (5) pins the kind + asserts the typed-lane + non-orphan classification (an unknown coordinator kind is still orphaned — the fix is scoped to this one kind). **14/14** adam-inbox tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)