### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-CONSULT-001A): Solomon foundation — singleton identity, register, atomic flag migration

### DIFF
--- a/database/migrations/20260630_role_handoff_atomic_solomon_flag.sql
+++ b/database/migrations/20260630_role_handoff_atomic_solomon_flag.sql
@@ -1,0 +1,113 @@
+-- SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of 20260615_role_handoff_atomic_adam_flag.sql
+--
+-- The Solomon-singleton mirror of 20260614_role_handoff_atomic_coordinator_flag.sql (sibling A). The
+-- Solomon tag lives on claude_sessions.metadata as { role:'solomon', solomon_since:<ts>, non_fleet:true }.
+-- solomon-register.cjs today does a JS read-merge-write of the WHOLE metadata object (registerSolomon:74
+-- `update({ metadata: merged })`) — the lost-update race the atomic-coordinator-flag RPCs fixed for
+-- the coordinator. These two SECURITY DEFINER RPCs perform an ATOMIC in-DB jsonb mutation (single
+-- statement; Postgres row-lock serializes concurrent mutations; `||`/`-` operate on the LIVE row,
+-- never a stale JS snapshot), preserving all sibling metadata keys.
+--
+-- DATA-SAFETY: additive. Applying creates two functions and modifies NO real rows (the DO $verify$
+-- block seeds + deletes a synthetic session inside the transaction). Reversible via DROP FUNCTION
+-- (see the _DOWN companion). Chairman-gated for prod-apply (NO -- @approved-by): the JS writer
+-- (Phase A) fail-softs when the RPC is absent, so the feature is dormant-but-safe until apply.
+
+-- ── clear_solomon_flag ───────────────────────────────────────────────────────────────────────────
+-- Atomically remove the Solomon tag keys from one session's metadata. Sibling keys (callsign,
+-- fleet_identity, claim flags, etc.) are preserved — `-` drops only the three named keys.
+CREATE OR REPLACE FUNCTION clear_solomon_flag(p_session_id TEXT)
+RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  -- Drop solomon_since + non_fleet always; drop the GENERIC 'role' key ONLY when it is 'solomon' (never
+  -- strip a legitimate role='worker'/'coordinator' tag — review finding: 'role' is not Solomon-exclusive).
+  UPDATE claude_sessions
+  SET metadata = CASE
+                   WHEN COALESCE(metadata, '{}'::jsonb)->>'role' = 'solomon'
+                     THEN COALESCE(metadata, '{}'::jsonb) - 'role' - 'solomon_since' - 'non_fleet'
+                   ELSE COALESCE(metadata, '{}'::jsonb) - 'solomon_since' - 'non_fleet'
+                 END
+  WHERE session_id = p_session_id;
+$$;
+
+COMMENT ON FUNCTION clear_solomon_flag(TEXT) IS
+  'SD-LEO-INFRA-SOLOMON-CONSULT-001A: atomically drop the Solomon tag (role + solomon_since + non_fleet) from a session''s metadata (jsonb `-`), preserving all sibling keys. Race-safe retire path for a stale prior Solomon.';
+
+-- ── set_solomon_flag ─────────────────────────────────────────────────────────────────────────────
+-- Atomically stamp role=solomon + a fresh solomon_since + non_fleet onto a session's metadata, bump
+-- heartbeat_at + status, and CREATE the row if absent (mirrors the JS register's create-if-absent
+-- intent). `||` merges onto the LIVE row value so concurrent writers never clobber sibling keys.
+CREATE OR REPLACE FUNCTION set_solomon_flag(p_session_id TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO claude_sessions (session_id, metadata, heartbeat_at, status, created_at, updated_at)
+  VALUES (
+    p_session_id,
+    jsonb_build_object('role', 'solomon', 'solomon_since', now()::text, 'non_fleet', true),
+    now(),
+    'active',
+    now(),
+    now()
+  )
+  ON CONFLICT (session_id) DO UPDATE SET
+    metadata = COALESCE(claude_sessions.metadata, '{}'::jsonb)
+               || jsonb_build_object('role', 'solomon', 'solomon_since', now()::text, 'non_fleet', true),
+    heartbeat_at = now(),
+    status = 'active',
+    updated_at = now();
+END;
+$$;
+
+COMMENT ON FUNCTION set_solomon_flag(TEXT) IS
+  'SD-LEO-INFRA-SOLOMON-CONSULT-001A: atomically register a session as Solomon (role=solomon + fresh solomon_since + non_fleet via jsonb `||`), bump heartbeat_at + status=active, create the row if absent. Race-safe replacement for the JS read-merge-write register path.';
+
+-- ── In-migration self-verification ───────────────────────────────────────────────────────────
+-- Runs inside apply-migration's transaction; fleet-safe (unique synthetic session id, cleaned up
+-- before COMMIT). Proves: set stamps the Solomon tag + preserves a sibling key; a re-set re-stamps;
+-- clear drops only the Solomon keys + preserves the sibling; create-if-absent works.
+DO $verify$
+DECLARE
+  v_meta JSONB;
+  v_sid  TEXT := 'verify-role-handoff-atomic-solomon-' || gen_random_uuid()::text;
+BEGIN
+  -- Seed a session with a sibling key that MUST survive.
+  INSERT INTO claude_sessions (session_id, metadata, heartbeat_at, status, created_at, updated_at)
+  VALUES (v_sid, '{"claim_flag": "held"}'::jsonb, now(), 'active', now(), now());
+
+  -- set on the EXISTING row stamps the Solomon tag + keeps the sibling.
+  PERFORM set_solomon_flag(v_sid);
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+  ASSERT v_meta->>'role' = 'solomon', 'ROLE-HANDOFF-ATOMIC-SOLOMON: set_solomon_flag did not set role=solomon';
+  ASSERT v_meta ? 'solomon_since', 'ROLE-HANDOFF-ATOMIC-SOLOMON: set_solomon_flag did not stamp solomon_since';
+  ASSERT (v_meta->>'non_fleet')::boolean = true, 'ROLE-HANDOFF-ATOMIC-SOLOMON: set_solomon_flag did not set non_fleet';
+  ASSERT v_meta->>'claim_flag' = 'held', 'ROLE-HANDOFF-ATOMIC-SOLOMON: set_solomon_flag clobbered the sibling claim_flag';
+
+  -- clear drops only the Solomon keys, preserving the sibling.
+  PERFORM clear_solomon_flag(v_sid);
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+  ASSERT NOT (v_meta ? 'role'), 'ROLE-HANDOFF-ATOMIC-SOLOMON: clear_solomon_flag left role behind';
+  ASSERT NOT (v_meta ? 'solomon_since'), 'ROLE-HANDOFF-ATOMIC-SOLOMON: clear_solomon_flag left solomon_since behind';
+  ASSERT NOT (v_meta ? 'non_fleet'), 'ROLE-HANDOFF-ATOMIC-SOLOMON: clear_solomon_flag left non_fleet behind';
+  ASSERT v_meta->>'claim_flag' = 'held', 'ROLE-HANDOFF-ATOMIC-SOLOMON: clear_solomon_flag wiped the sibling claim_flag (used `-` wrong)';
+
+  -- create-if-absent: set on a NON-EXISTENT session registers a fresh row.
+  DELETE FROM claude_sessions WHERE session_id = v_sid;
+  PERFORM set_solomon_flag(v_sid);
+  SELECT metadata INTO v_meta FROM claude_sessions WHERE session_id = v_sid;
+  ASSERT v_meta->>'role' = 'solomon', 'ROLE-HANDOFF-ATOMIC-SOLOMON: set_solomon_flag did not CREATE a missing row';
+
+  -- Cleanup so nothing leaks past COMMIT.
+  DELETE FROM claude_sessions WHERE session_id = v_sid;
+  RAISE NOTICE 'ROLE-HANDOFF-ATOMIC-SOLOMON verify OK: set stamps + preserves siblings, clear drops only Solomon keys, create-if-absent works.';
+END
+$verify$;
+
+-- ROLLBACK: DROP FUNCTION clear_solomon_flag(TEXT); DROP FUNCTION set_solomon_flag(TEXT);
+-- (see the _DOWN companion). Additive + fully reversible — no data migration to undo.

--- a/database/migrations/20260630_role_handoff_atomic_solomon_flag_DOWN.sql
+++ b/database/migrations/20260630_role_handoff_atomic_solomon_flag_DOWN.sql
@@ -1,0 +1,8 @@
+-- SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of 20260615_role_handoff_atomic_adam_flag_DOWN.sql
+-- Reverses 20260630_role_handoff_atomic_solomon_flag.sql by dropping the two atomic Solomon-flag RPCs.
+-- Additive migration → clean reversal, no data to restore. After this DOWN runs, the Phase A
+-- solomon-register writer falls back to its fail-open JS path (the .rpc() call errors → fail-soft),
+-- so registration still works (just without the atomic-merge race protection).
+
+DROP FUNCTION IF EXISTS clear_solomon_flag(TEXT);
+DROP FUNCTION IF EXISTS set_solomon_flag(TEXT);

--- a/lib/coordinator/solomon-identity.cjs
+++ b/lib/coordinator/solomon-identity.cjs
@@ -1,0 +1,234 @@
+'use strict';
+/**
+ * solomon-identity.cjs — SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-identity.cjs
+ *
+ * The Solomon-singleton half of the role-session handoff protocol — a MIRROR of the shipped
+ * coordinator election (lib/coordinator/resolve.cjs:62-164 pickCanonicalCoordinator /
+ * electCoordinatorFromDb / getActiveCoordinatorId) keyed on metadata.role='solomon' +
+ * metadata.solomon_since. Sibling A delivered the coordinator half; this composes the same
+ * deterministic-election + freshness pattern for Solomon (no reinvention).
+ *
+ * INVARIANTS:
+ *  - Deterministic election: canonical Solomon = solomon_since DESC NULLS LAST, then session_id ASC.
+ *  - FAIL-OPEN: every DB-backed resolver returns null/empty on error and NEVER throws (a resolution
+ *    fault must never block the caller — mirrors the coordinator resolver's GG-5 contract).
+ *  - The single-Solomon GUARD's deliberate divergence from the coordinator clear-losers pattern:
+ *    PREFER refuse-new-on-fresh-prior over clear-prior, so a legitimately-restarting Solomon is never
+ *    cleared mid-canary; only a STALE prior is retired.
+ *
+ * Pure functions (pickCanonicalSolomon, decideSingleSolomonGuard) are injectable/testable with no DB.
+ * Identity WRITES (set/clear solomon flag) go through the atomic set_solomon_flag/clear_solomon_flag RPCs
+ * (Phase A migration) — never a JS read-modify-write — and live in scripts/solomon-register.cjs (Phase A);
+ * this module owns the read/election/decision layer.
+ */
+
+const SOLOMON_ROLE = 'solomon';
+/** Freshness window: a Solomon session whose heartbeat is within this is "live". Matches the
+ *  coordinator/detector 10-min convention (detectors.cjs DEFAULT_COORDINATOR_FRESH_MS). */
+const SOLOMON_FRESH_MS = 10 * 60 * 1000;
+
+/** Parse a timestamp to ms, treating naive (no-TZ) strings as UTC (PostgREST returns naive). 0 if unusable. */
+function toMs(ts) {
+  if (!ts) return 0;
+  if (ts instanceof Date) return ts.getTime();
+  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(String(ts));
+  const n = new Date(hasTZ ? ts : ts + 'Z').getTime();
+  return Number.isFinite(n) ? n : 0;
+}
+
+function isFresh(heartbeatAt, nowMs, freshMs) {
+  const hb = toMs(heartbeatAt);
+  if (!hb) return false;
+  return (nowMs - hb) <= freshMs;
+}
+
+/**
+ * PURE deterministic single-winner election over candidate Solomon rows. Mirrors
+ * pickCanonicalCoordinator: canonical = solomon_since DESC (NULLS LAST), then session_id ASC (a stable
+ * tiebreak so resolution never flaps). Returns { session_id, since } or null.
+ */
+function pickCanonicalSolomon(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const candidates = rows
+    .filter((r) => r && typeof r.session_id === 'string')
+    .map((r) => ({
+      session_id: r.session_id,
+      since: (r.metadata && typeof r.metadata.solomon_since === 'string') ? r.metadata.solomon_since : null,
+    }));
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    if (a.since !== null || b.since !== null) {
+      if (a.since === null) return 1;
+      if (b.since === null) return -1;
+      if (a.since !== b.since) return a.since > b.since ? -1 : 1;
+    }
+    if (a.session_id < b.session_id) return -1;
+    if (a.session_id > b.session_id) return 1;
+    return 0;
+  });
+  return candidates[0];
+}
+
+/** Fetch fresh role=solomon sessions (heartbeat within freshMs). Fail-open: [] on error. async I/O. */
+async function fetchFreshSolomons(supabase, { nowMs = Date.now(), freshMs = SOLOMON_FRESH_MS } = {}) {
+  if (!supabase) return [];
+  try {
+    const cutoff = new Date(nowMs - freshMs).toISOString();
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, heartbeat_at, metadata')
+      .gte('heartbeat_at', cutoff)
+      .filter('metadata->>role', 'eq', SOLOMON_ROLE);
+    if (error || !Array.isArray(data)) return [];
+    return data;
+  } catch {
+    return [];
+  }
+}
+
+/** Fetch ALL role=solomon sessions (NO freshness filter) so the single-Solomon guard can classify
+ *  fresh-vs-stale itself (fetchFreshSolomons pre-filters to fresh, which would hide stale priors the
+ *  guard must retire). Fail-open: [] on error. async I/O. */
+async function fetchAllSolomons(supabase) {
+  if (!supabase) return [];
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, heartbeat_at, metadata')
+      .filter('metadata->>role', 'eq', SOLOMON_ROLE);
+    if (error || !Array.isArray(data)) return [];
+    return data;
+  } catch {
+    return [];
+  }
+}
+
+/** Elect the single canonical Solomon session_id from the DB, or null. Fail-open (never throws). */
+async function electSolomonFromDb(supabase, opts = {}) {
+  try {
+    const rows = await fetchFreshSolomons(supabase, opts);
+    if (!rows.length) return null;
+    const winner = pickCanonicalSolomon(rows);
+    return winner ? winner.session_id : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the active Solomon session_id (DB-canonical election). Fail-open null. */
+async function getActiveSolomonId(supabase, opts = {}) {
+  return electSolomonFromDb(supabase, opts);
+}
+
+/** Count fresh Solomons (for the multi-Solomon detector's I/O feed). Fail-open 0. */
+async function countFreshSolomons(supabase, opts = {}) {
+  const rows = await fetchFreshSolomons(supabase, opts);
+  return rows.length;
+}
+
+/**
+ * SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-identity.cjs (FR-1): resolve the reply-target Solomon session
+ * for a coordinator->Solomon reply. CONFIRMED root cause: the reply path targeted the advisory's
+ * ORIGINATING session (adv.sender_session) directly, so after a role-handoff / single-Solomon guard
+ * retire-then-register the reply landed in the STALE Solomon's inbox. Prefer the CURRENT live Solomon
+ * (getActiveSolomonId); fall back to the originator only when no live Solomon resolves (FAIL-OPEN — a reply
+ * is never blocked). Solomon is a singleton role, so re-pointing to the live Solomon is correct by design.
+ * @returns {Promise<{target:string, live:(string|null), originator:string, retargeted:boolean}>}
+ */
+async function resolveSolomonReplyTarget(supabase, originatorSession, opts = {}) {
+  let live = null;
+  try { live = await getActiveSolomonId(supabase, opts); } catch { live = null; } // fail-open
+  const target = live || originatorSession;
+  return { target, live, originator: originatorSession, retargeted: Boolean(live && live !== originatorSession) };
+}
+
+/**
+ * FR-2: recover messages already stuck at a stale originator. Re-point any UNREAD coordinator->Solomon
+ * rows still targeted at the stale originator to the current live Solomon. Only unread rows move
+ * (acknowledged ones are settled). Best-effort + REPORTED — returns the re-targeted count; an error
+ * is surfaced, never silently swallowed. No-op when there is nothing to move.
+ * @returns {Promise<{retargeted:number, error:(string|null)}>}
+ */
+async function retargetStaleSolomonInbound(supabase, { staleOriginator, liveSolomon }) {
+  if (!staleOriginator || !liveSolomon || staleOriginator === liveSolomon) return { retargeted: 0, error: null };
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .update({ target_session: liveSolomon })
+      .eq('target_session', staleOriginator)
+      .eq('sender_type', 'coordinator')
+      .is('acknowledged_at', null)
+      .select('id');
+    if (error) return { retargeted: 0, error: error.message };
+    return { retargeted: Array.isArray(data) ? data.length : 0, error: null };
+  } catch (e) {
+    return { retargeted: 0, error: e && e.message ? e.message : String(e) };
+  }
+}
+
+/**
+ * FR-3: verify a sent reply actually landed (send != delivered). Read the row back by id. Returns
+ * true only when the row is confirmable; FAIL-LOUD callers treat false as a delivery error.
+ * @returns {Promise<boolean>}
+ */
+async function verifyReplyDelivered(supabase, rowId) {
+  if (!rowId) return false;
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('id', rowId)
+      .maybeSingle();
+    if (error) return false;
+    return Boolean(data && data.id);
+  } catch { return false; }
+}
+
+/**
+ * PURE single-Solomon guard decision. The deliberate divergence from the coordinator clear-losers
+ * pattern: PREFER refuse-new-on-fresh-prior over clear-prior — never clear a legitimately-restarting
+ * Solomon mid-canary; retire only STALE priors. Returns:
+ *   { action: 'register' | 'refuse' | 'retire_stale_then_register', retire: string[], reason, freshPriors }
+ *   - 'refuse'  : a FRESH prior Solomon exists (not self) — do NOT register, do NOT clear it.
+ *   - 'retire_stale_then_register' : only STALE prior(s) exist — clear them, then register self.
+ *   - 'register': no other Solomon — register self.
+ * @param {{ priorSolomons: Array<{session_id,heartbeat_at,metadata?}>, selfSessionId: string, nowMs?: number, freshMs?: number }} p
+ */
+function decideSingleSolomonGuard({ priorSolomons, selfSessionId, nowMs = Date.now(), freshMs = SOLOMON_FRESH_MS }) {
+  const others = (Array.isArray(priorSolomons) ? priorSolomons : []).filter(
+    (a) => a && typeof a.session_id === 'string' && a.session_id !== selfSessionId,
+  );
+  const fresh = others.filter((a) => isFresh(a.heartbeat_at, nowMs, freshMs));
+  if (fresh.length > 0) {
+    return {
+      action: 'refuse',
+      retire: [],
+      reason: 'a fresh prior Solomon exists — refusing to register a 2nd (avoid clearing a restarting Solomon mid-canary)',
+      freshPriors: fresh.map((a) => a.session_id),
+    };
+  }
+  const staleRetire = others.map((a) => a.session_id); // all others are stale here
+  return {
+    action: staleRetire.length ? 'retire_stale_then_register' : 'register',
+    retire: staleRetire,
+    reason: staleRetire.length ? 'only stale prior Solomon(s) — retire then register self' : 'no other Solomon — register self',
+    freshPriors: [],
+  };
+}
+
+module.exports = {
+  SOLOMON_ROLE,
+  SOLOMON_FRESH_MS,
+  toMs,
+  isFresh,
+  pickCanonicalSolomon,
+  fetchFreshSolomons,
+  fetchAllSolomons,
+  electSolomonFromDb,
+  getActiveSolomonId,
+  countFreshSolomons,
+  decideSingleSolomonGuard,
+  resolveSolomonReplyTarget,
+  retargetStaleSolomonInbound,
+  verifyReplyDelivered,
+};

--- a/package.json
+++ b/package.json
@@ -360,6 +360,7 @@
     "stage-contracts:check": "node scripts/validate-stage-contract-connectivity.mjs",
     "fr:descope": "node scripts/record-fr-descope.js",
     "adam:register": "node scripts/adam-register.cjs",
+    "solomon:register": "node scripts/solomon-register.cjs",
     "adam:restart": "node scripts/adam-restart.cjs",
     "adam:advisory": "node scripts/adam-advisory.cjs",
     "working-context": "node scripts/working-context.cjs",

--- a/scripts/solomon-register.cjs
+++ b/scripts/solomon-register.cjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * Solomon role register/verify
+ * SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-register.cjs
+ *
+ * Idempotently tags the CURRENT session in claude_sessions.metadata with
+ * role=solomon and non_fleet=true, so the coordinator's fleet accounting (worker
+ * counts, ETA math, revival requests, claim-sweep targeting) excludes this
+ * heartbeating-but-non-fleet advisory/analysis session.
+ *
+ * VERIFY-FIRST: the live Solomon session already carried the tag set ad-hoc, so a
+ * blind write would be wrong — we read current metadata and only update on diff,
+ * otherwise report "verified" (no-op). JSONB merge preserves existing keys
+ * (callsign, fleet_identity, etc.). No migration — metadata is free-form JSONB.
+ *
+ * Self-env-loading (reuses lib/supabase-client.cjs ancestor .env walk) so /solomon
+ * works without `node --env-file=.env`.
+ *
+ * Usage: node scripts/solomon-register.cjs            (CLAUDE_SESSION_ID from env)
+ *        npm run solomon:register
+ * Output: one JSON object { ok, action: tagged|verified|error, ... }.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
+// SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-register.cjs: single-Solomon guard + atomic write.
+// fetchAllSolomons (not fetchFreshSolomons) so the guard sees stale priors too and classifies fresh-vs-
+// stale itself (fresh => refuse; stale-only => retire).
+const { fetchAllSolomons, decideSingleSolomonGuard, isFresh } = require('../lib/coordinator/solomon-identity.cjs');
+// Phase E (not yet shipped): drainSolomonOutbound will live in scripts/solomon-advisory.cjs.
+// Loaded lazily at the call site so this module loads without solomon-advisory.cjs present.
+
+const SOLOMON_ROLE = 'solomon';
+const CONTRACT_FILE = 'CLAUDE_SOLOMON.md';
+
+/** Phase A flag (default-OFF): when 'on', the single-Solomon guard + atomic set_solomon_flag write-path runs.
+ *  OFF => the legacy computeSolomonTag + JS-merge register path is BYTE-IDENTICAL to before. */
+function isSolomonHandoffV1Enabled() {
+  return process.env.ROLE_HANDOFF_SOLOMON_V1 === 'on';
+}
+
+/** Postgres/PostgREST signal that an RPC is not defined (the chairman-gated migration is unapplied). */
+function isMissingFunctionError(error) {
+  if (!error) return false;
+  if (error.code === '42883' || error.code === 'PGRST202') return true;
+  const msg = String(error.message || error.hint || '').toLowerCase();
+  return /(set_solomon_flag|clear_solomon_flag)/.test(msg) && /not (found|exist)/.test(msg);
+}
+
+/** Atomic Solomon-flag write via the RPC; fail-soft result (NEVER throws). */
+async function writeSolomonFlagViaRpc(supabase, sessionId) {
+  let res;
+  try { res = await supabase.rpc('set_solomon_flag', { p_session_id: sessionId }); }
+  catch (e) { return isMissingFunctionError(e) ? { persisted: false, reason: 'rpc_absent' } : { persisted: false, reason: 'error', error: e && e.message }; }
+  const error = res && res.error;
+  if (error) return isMissingFunctionError(error) ? { persisted: false, reason: 'rpc_absent' } : { persisted: false, reason: 'error', error: error.message };
+  return { persisted: true };
+}
+
+/**
+ * Pure: given current metadata, decide whether a write is needed and produce the
+ * merged metadata. Exported for unit testing (no DB).
+ * @param {object|null} current - existing claude_sessions.metadata
+ * @returns {{ alreadyTagged: boolean, merged: object }}
+ */
+function computeSolomonTag(current) {
+  const meta = (current && typeof current === 'object' && !Array.isArray(current)) ? current : {};
+  const alreadyTagged = meta.role === SOLOMON_ROLE && meta.non_fleet === true;
+  const merged = { ...meta, role: SOLOMON_ROLE, non_fleet: true };
+  return { alreadyTagged, merged };
+}
+
+/**
+ * Register/verify the Solomon tag for a session. Injectable supabase for tests.
+ * Never throws — returns a structured result object.
+ */
+async function registerSolomon(supabase, sessionId, opts = {}) {
+  if (!sessionId) {
+    return { ok: false, action: 'error', error: 'CLAUDE_SESSION_ID env var required (set by the SessionStart hook).' };
+  }
+  let row;
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id, metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) return { ok: false, action: 'error', error: error.message };
+    row = data;
+  } catch (e) {
+    return { ok: false, action: 'error', error: e.message };
+  }
+  if (!row) {
+    return { ok: false, action: 'error', error: `session ${sessionId} not found in claude_sessions (is the SessionStart register hook run?).` };
+  }
+
+  // SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-register.cjs: flag-ON runs the single-Solomon guard +
+  // atomic set_solomon_flag write-path. Flag-OFF falls through to the legacy path below (byte-identical).
+  if (isSolomonHandoffV1Enabled()) {
+    const nowMs = (opts && Number.isFinite(opts.nowMs)) ? opts.nowMs : Date.now();
+    const priorSolomons = await fetchAllSolomons(supabase); // ALL solomons (incl. stale) so the guard classifies
+    const decision = decideSingleSolomonGuard({ priorSolomons, selfSessionId: sessionId, nowMs });
+    if (decision.action === 'refuse') {
+      // A FRESH prior Solomon holds the singleton — do NOT register a 2nd and do NOT clear the prior
+      // (the deliberate divergence: never kill a legitimately-restarting Solomon mid-canary).
+      return { ok: false, action: 'refused', session_id: sessionId, fresh_priors: decision.freshPriors,
+        message: `Refused: a fresh prior Solomon (${decision.freshPriors.join(', ')}) holds the singleton — not registering a 2nd. ${decision.reason}` };
+    }
+    // REGISTER-BEFORE-RETIRE (mirror sibling A's coordinator setActiveCoordinator ordering): claim the
+    // singleton FIRST so there is never a zero-Solomon window, THEN retire stale priors.
+    const wrote = await writeSolomonFlagViaRpc(supabase, sessionId);
+    let action = null;
+    let fallbackReason = null;
+    if (wrote.persisted) {
+      action = 'tagged';
+    } else {
+      // Fail-soft: the chairman-gated migration is unapplied (or a transient RPC error). Fall back
+      // to the legacy JS merge (+ solomon_since) — no worse than flag-OFF; atomic safety lands on apply.
+      const mergedSolomon = { ...((row.metadata && typeof row.metadata === 'object') ? row.metadata : {}), role: SOLOMON_ROLE, non_fleet: true, solomon_since: new Date(nowMs).toISOString() };
+      try {
+        const { error } = await supabase.from('claude_sessions').update({ metadata: mergedSolomon }).eq('session_id', sessionId);
+        if (error) return { ok: false, action: 'error', error: error.message };
+      } catch (e) { return { ok: false, action: 'error', error: e.message }; }
+      action = 'tagged_fallback';
+      fallbackReason = wrote.reason;
+    }
+    // Retire stale priors — but RE-VALIDATE freshness right before clearing each, so a prior that
+    // became fresh since the decision (a racing restart) is NEVER cleared (the deliberate divergence
+    // holds even under a race). Residual: two simultaneous STALE restarts can both register briefly
+    // — surfaced by the MULTIPLE_SOLOMONS detector + refused on the next register (eventual convergence).
+    const retired = [];
+    if (decision.retire.length) {
+      const nowMs2 = Date.now();
+      const current = await fetchAllSolomons(supabase);
+      const freshNow = new Set(current.filter((a) => isFresh(a.heartbeat_at, nowMs2)).map((a) => a.session_id));
+      for (const sid of decision.retire) {
+        if (freshNow.has(sid)) continue; // became fresh since the decision — do NOT clear a restarting Solomon
+        const r = await supabase.rpc('clear_solomon_flag', { p_session_id: sid }).then((x) => x, (e) => ({ error: e }));
+        if (!(r && r.error)) retired.push(sid); // best-effort: a failed stale-clear is swept later
+      }
+    }
+    if (retired.length) action = action === 'tagged_fallback' ? 'tagged_after_retire_fallback' : 'tagged_after_retire';
+    // Phase E: re-target the retired prior Solomon(s)' unread inbound to this new session (comms survive
+    // the handoff). Fail-open + idempotent; a drain error never fails the registration.
+    // solomon-advisory.cjs ships in Phase E; drain is best-effort until then.
+    let drained = 0;
+    if (retired.length) {
+      try {
+        const { drainSolomonOutbound } = require('./solomon-advisory.cjs');
+        const d = await drainSolomonOutbound(supabase, { newSessionId: sessionId, oldSessionIds: retired });
+        drained = (d && d.moved) || 0;
+      } catch { /* solomon-advisory.cjs ships in Phase E; drain is best-effort until then */ }
+    }
+    return { ok: true, action, session_id: sessionId, role: SOLOMON_ROLE, non_fleet: true, retired, drained,
+      message: `Registered as the single Solomon${retired.length ? ` (retired stale prior(s): ${retired.join(', ')}; re-targeted ${drained} inbound row(s))` : ''}${fallbackReason ? ` — fail-soft JS merge (set_solomon_flag RPC ${fallbackReason}; apply the chairman-gated migration for atomic writes)` : ' via atomic set_solomon_flag'}.` };
+  }
+
+  const { alreadyTagged, merged } = computeSolomonTag(row.metadata);
+  if (alreadyTagged) {
+    return { ok: true, action: 'verified', session_id: sessionId, role: SOLOMON_ROLE, non_fleet: true, message: 'Session already tagged role=solomon, non_fleet=true (verified, no change).' };
+  }
+  try {
+    const { error } = await supabase.from('claude_sessions').update({ metadata: merged }).eq('session_id', sessionId);
+    if (error) return { ok: false, action: 'error', error: error.message };
+  } catch (e) {
+    return { ok: false, action: 'error', error: e.message };
+  }
+  return { ok: true, action: 'tagged', session_id: sessionId, role: SOLOMON_ROLE, non_fleet: true, message: 'Session tagged role=solomon, non_fleet=true (excluded from fleet accounting).' };
+}
+
+/**
+ * Contract-read verification (chairman directive 2026-06-10): confirm CLAUDE_SOLOMON.md
+ * was read THIS session, via the same session-state the protocol-file-tracker hook
+ * writes for CLAUDE_LEAD/PLAN/EXEC (CLAUDE_SOLOMON.md is in its PROTOCOL_FILES list).
+ * NEVER blocks the tag write — an untagged Solomon re-enters fleet accounting (worker
+ * counts, revival pings, claim-sweep targeting), which is the worse failure mode.
+ * The verdict rides the JSON output; the banner makes the obligation loud.
+ * Pure file-reads, never throws. Exported for tests.
+ * @param {string} [projectDir]
+ * @returns {{ contract_file: string, contract_exists: boolean, contract_read: boolean,
+ *             contract_read_partial: boolean, contract_last_read_at: string|null }}
+ */
+function checkContractRead(projectDir) {
+  const result = {
+    contract_file: CONTRACT_FILE,
+    contract_exists: false,
+    contract_read: false,
+    contract_read_partial: false,
+    contract_last_read_at: null,
+  };
+  try {
+    const root = projectDir || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+    result.contract_exists = fs.existsSync(path.join(root, CONTRACT_FILE));
+    const statePath = resolveStateReadPath(root);
+    if (!fs.existsSync(statePath)) return result;
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8').replace(/^﻿/, ''));
+    const status = state.protocolFileReadStatus && state.protocolFileReadStatus[CONTRACT_FILE];
+    if (status && status.readCount > 0) {
+      result.contract_read = true;
+      result.contract_read_partial = status.lastReadWasPartial === true;
+      result.contract_last_read_at = status.lastReadAt || null;
+    } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(CONTRACT_FILE)) {
+      result.contract_read = true; // legacy-array fallback (pre-FR-2 state shape)
+    }
+  } catch { /* fail-open: tracking unavailable must never break role activation */ }
+  return result;
+}
+
+/**
+ * Pure: the stderr banner for a missing/partial contract read, or null when satisfied.
+ * @param {ReturnType<typeof checkContractRead>} check
+ * @returns {string|null}
+ */
+function contractReadBanner(check) {
+  if (check.contract_read && !check.contract_read_partial) return null;
+  const lines = ['═══ SOLOMON ROLE CONTRACT — READ REQUIRED ═══'];
+  if (!check.contract_exists) {
+    lines.push(`  ✗ ${CONTRACT_FILE} not found — regenerate: node scripts/generate-claude-md-from-db.js`);
+  } else if (!check.contract_read) {
+    lines.push(`  ✗ No record of ${CONTRACT_FILE} being read this session.`);
+  } else {
+    lines.push(`  ⚠ Last read of ${CONTRACT_FILE} was PARTIAL (offset/limit used).`);
+  }
+  lines.push(`  → Read ${CONTRACT_FILE} IN FULL (Read tool, no offset/limit) BEFORE any Solomon work.`);
+  lines.push('  (Registration is not blocked — the tag must always land — but the contract read is mandatory.)');
+  return lines.join('\n');
+}
+
+// Phase E (SD-LEO-INFRA-SOLOMON-CONSULT-001A): the consume-reply mirror printed on
+// /solomon startup so Solomon discovers the durable reply path without reverse-engineering the
+// channel. Mirrors the coordinator-side renderSolomonLane() in coordinator-startup-check.mjs.
+// Printed to STDERR so the stdout JSON contract stays pure. Pure + exported for tests.
+function solomonReplyMirror() {
+  return [
+    '═══ SOLOMON ↔ COORDINATOR COMMS (consume-reply path) ═══',
+    '  • SEND advisory (fire-and-forget, replyable):  node scripts/solomon-advisory.cjs send "<body>"',
+    '  • REQUEST (await a sync reply):  node scripts/solomon-advisory.cjs request "<question>" [--timeout <ms>]',
+    '  • DRAIN your full inbox (replies + coordinator directives):  node scripts/solomon-advisory.cjs inbox',
+    '  (solomon-advisory.cjs ships in Phase E; canonical doc: docs/protocol/coordinator-solomon-comms.md)',
+  ].join('\n');
+}
+
+// ── Clean shutdown — Windows libuv UV_HANDLE_CLOSING avoidance ────────────────
+// registerSolomon opens an undici/fetch keep-alive socket (Supabase). Calling
+// process.exit() afterward aborts on Windows ("Assertion failed: !(handle->flags &
+// UV_HANDLE_CLOSING), src\win\async.c:76") — empirically even after a deferred
+// exit or dispatcher.close() followed by exit(). The only reliable avoidance is to
+// NOT call process.exit(): set process.exitCode, close undici's sockets, and let
+// the event loop drain. Same contract as the Stop hooks (see
+// scripts/hooks/__tests__/stop-hook-uv-handle-closing.test.js).
+let _shuttingDown = false;
+async function shutdown(code) {
+  if (_shuttingDown) return;
+  _shuttingDown = true;
+  process.exitCode = code;
+  // Backstop only: unref'd so it never delays a clean natural exit.
+  setTimeout(() => process.exit(code), 8000).unref();
+  try { await require('undici').getGlobalDispatcher().close(); } catch { /* undici absent/already closed */ }
+  // Deliberately NO process.exit() — returning lets Node exit once the loop drains.
+}
+
+async function main() {
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  let supabase;
+  try {
+    supabase = createSupabaseServiceClient();
+  } catch (e) {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: `supabase client unavailable: ${e.message}` }, null, 2));
+    return shutdown(1);
+  }
+  const result = await registerSolomon(supabase, sessionId);
+  // SD-LEO-INFRA-SOLOMON-CONSULT-001A: give this Solomon session a stable status-line NAME.
+  // Fail-soft — a naming failure must never block registration.
+  if (result.ok) {
+    try {
+      const { writeRoleStatusIdentity } = require('../lib/fleet/role-status-identity.cjs');
+      writeRoleStatusIdentity({ sessionId, role: SOLOMON_ROLE });
+    } catch { /* status-line naming is best-effort */ }
+  }
+  const contractCheck = checkContractRead();
+  console.log(JSON.stringify({ ...result, ...contractCheck }, null, 2));
+  const banner = contractReadBanner(contractCheck);
+  if (banner) console.error(banner);
+  console.error(solomonReplyMirror());
+  return shutdown(result.ok ? 0 : 1);
+}
+
+module.exports = { computeSolomonTag, registerSolomon, solomonReplyMirror, checkContractRead, contractReadBanner, SOLOMON_ROLE, CONTRACT_FILE, isSolomonHandoffV1Enabled, isMissingFunctionError, writeSolomonFlagViaRpc };
+
+if (require.main === module) {
+  main().catch(err => {
+    console.log(JSON.stringify({ ok: false, action: 'error', error: err.message || String(err) }, null, 2));
+    shutdown(1);
+  });
+}

--- a/tests/unit/solomon-identity.test.js
+++ b/tests/unit/solomon-identity.test.js
@@ -1,0 +1,270 @@
+/**
+ * solomon-identity.test.js — SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation)
+ *
+ * Network-free unit tests for lib/coordinator/solomon-identity.cjs.
+ * Covers:
+ *   - pickCanonicalSolomon: deterministic election (solomon_since DESC NULLS LAST, session_id ASC tiebreak)
+ *   - decideSingleSolomonGuard: refuse / retire_stale_then_register / register / self-exclusion
+ *   - isFresh / toMs: freshness window, naive-UTC parse, unusable input
+ *   - getActiveSolomonId: FAIL-OPEN — returns null on null supabase or thrown query
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  pickCanonicalSolomon,
+  decideSingleSolomonGuard,
+  isFresh,
+  toMs,
+  getActiveSolomonId,
+  SOLOMON_FRESH_MS,
+} = require('../../lib/coordinator/solomon-identity.cjs');
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000; // fixed injected clock (ms)
+const FRESH_HB = new Date(NOW - 60_000).toISOString(); // 1 min ago — within SOLOMON_FRESH_MS
+const STALE_HB = new Date(NOW - SOLOMON_FRESH_MS - 1).toISOString(); // just past the window
+
+// ── pickCanonicalSolomon ──────────────────────────────────────────────────────
+
+describe('pickCanonicalSolomon', () => {
+  it('returns null on empty array', () => {
+    expect(pickCanonicalSolomon([])).toBeNull();
+  });
+
+  it('returns null on non-array input', () => {
+    expect(pickCanonicalSolomon(null)).toBeNull();
+    expect(pickCanonicalSolomon(undefined)).toBeNull();
+    expect(pickCanonicalSolomon('string')).toBeNull();
+  });
+
+  it('returns null when no row has a valid session_id string', () => {
+    expect(pickCanonicalSolomon([{ session_id: 123 }, { session_id: null }])).toBeNull();
+  });
+
+  it('returns the only candidate when there is exactly one valid row', () => {
+    const rows = [{ session_id: 'solo', metadata: { solomon_since: '2026-06-01T10:00:00Z' } }];
+    const winner = pickCanonicalSolomon(rows);
+    expect(winner).not.toBeNull();
+    expect(winner.session_id).toBe('solo');
+  });
+
+  it('elects the row with the LATER solomon_since (DESC ordering)', () => {
+    const rows = [
+      { session_id: 'older', metadata: { solomon_since: '2026-06-01T08:00:00Z' } },
+      { session_id: 'newer', metadata: { solomon_since: '2026-06-01T10:00:00Z' } },
+    ];
+    expect(pickCanonicalSolomon(rows).session_id).toBe('newer');
+  });
+
+  it('uses session_id ASC as a stable tiebreak when solomon_since is identical', () => {
+    const rows = [
+      { session_id: 'zzz-session', metadata: { solomon_since: '2026-06-01T10:00:00Z' } },
+      { session_id: 'aaa-session', metadata: { solomon_since: '2026-06-01T10:00:00Z' } },
+    ];
+    expect(pickCanonicalSolomon(rows).session_id).toBe('aaa-session');
+  });
+
+  it('places rows without solomon_since (NULLS LAST) after rows that have one', () => {
+    const rows = [
+      { session_id: 'no-since', metadata: {} },
+      { session_id: 'has-since', metadata: { solomon_since: '2026-06-01T10:00:00Z' } },
+    ];
+    expect(pickCanonicalSolomon(rows).session_id).toBe('has-since');
+  });
+
+  it('is stable: same output on repeated calls with the same input', () => {
+    const rows = [
+      { session_id: 'b-session', metadata: { solomon_since: '2026-06-01T09:00:00Z' } },
+      { session_id: 'a-session', metadata: { solomon_since: '2026-06-01T10:00:00Z' } },
+      { session_id: 'c-session', metadata: {} },
+    ];
+    const first = pickCanonicalSolomon(rows);
+    const second = pickCanonicalSolomon(rows);
+    expect(first.session_id).toBe(second.session_id);
+    expect(first.session_id).toBe('a-session'); // latest solomon_since
+  });
+});
+
+// ── decideSingleSolomonGuard ──────────────────────────────────────────────────
+
+describe('decideSingleSolomonGuard', () => {
+  it('returns action=register when there are no other solomons', () => {
+    const result = decideSingleSolomonGuard({ priorSolomons: [], selfSessionId: 'me', nowMs: NOW });
+    expect(result.action).toBe('register');
+    expect(result.retire).toEqual([]);
+    expect(result.freshPriors).toEqual([]);
+  });
+
+  it('returns action=refuse when a FRESH prior solomon exists (not self)', () => {
+    const priorSolomons = [
+      { session_id: 'other', heartbeat_at: FRESH_HB },
+    ];
+    const result = decideSingleSolomonGuard({ priorSolomons, selfSessionId: 'me', nowMs: NOW });
+    expect(result.action).toBe('refuse');
+    expect(result.freshPriors).toContain('other');
+    expect(result.retire).toEqual([]);
+  });
+
+  it('returns action=retire_stale_then_register when only STALE priors exist', () => {
+    const priorSolomons = [
+      { session_id: 'stale-one', heartbeat_at: STALE_HB },
+      { session_id: 'stale-two', heartbeat_at: STALE_HB },
+    ];
+    const result = decideSingleSolomonGuard({ priorSolomons, selfSessionId: 'me', nowMs: NOW });
+    expect(result.action).toBe('retire_stale_then_register');
+    expect(result.retire).toContain('stale-one');
+    expect(result.retire).toContain('stale-two');
+    expect(result.freshPriors).toEqual([]);
+  });
+
+  it('excludes the self session_id from prior consideration', () => {
+    // Self appears in the list — it must be treated as if absent
+    const priorSolomons = [
+      { session_id: 'me', heartbeat_at: FRESH_HB },
+    ];
+    const result = decideSingleSolomonGuard({ priorSolomons, selfSessionId: 'me', nowMs: NOW });
+    // Only self in list → no others → register (not refuse)
+    expect(result.action).toBe('register');
+  });
+
+  it('refuses when a fresh OTHER exists even though self is also in the list', () => {
+    const priorSolomons = [
+      { session_id: 'me', heartbeat_at: FRESH_HB },
+      { session_id: 'other-fresh', heartbeat_at: FRESH_HB },
+    ];
+    const result = decideSingleSolomonGuard({ priorSolomons, selfSessionId: 'me', nowMs: NOW });
+    expect(result.action).toBe('refuse');
+    expect(result.freshPriors).toContain('other-fresh');
+    expect(result.freshPriors).not.toContain('me');
+  });
+
+  it('prefers refuse over retire when one prior is fresh and another is stale', () => {
+    const priorSolomons = [
+      { session_id: 'fresh-other', heartbeat_at: FRESH_HB },
+      { session_id: 'stale-other', heartbeat_at: STALE_HB },
+    ];
+    const result = decideSingleSolomonGuard({ priorSolomons, selfSessionId: 'me', nowMs: NOW });
+    expect(result.action).toBe('refuse');
+  });
+});
+
+// ── isFresh / toMs ────────────────────────────────────────────────────────────
+
+describe('isFresh', () => {
+  it('returns true when the heartbeat is within SOLOMON_FRESH_MS', () => {
+    expect(isFresh(FRESH_HB, NOW, SOLOMON_FRESH_MS)).toBe(true);
+  });
+
+  it('returns false when the heartbeat is outside SOLOMON_FRESH_MS', () => {
+    expect(isFresh(STALE_HB, NOW, SOLOMON_FRESH_MS)).toBe(false);
+  });
+
+  it('returns false when heartbeat_at is null', () => {
+    expect(isFresh(null, NOW, SOLOMON_FRESH_MS)).toBe(false);
+  });
+
+  it('returns false when heartbeat_at is undefined', () => {
+    expect(isFresh(undefined, NOW, SOLOMON_FRESH_MS)).toBe(false);
+  });
+
+  it('returns false when heartbeat_at is an unparseable string', () => {
+    expect(isFresh('not-a-date', NOW, SOLOMON_FRESH_MS)).toBe(false);
+  });
+});
+
+describe('toMs', () => {
+  it('returns 0 for null/undefined', () => {
+    expect(toMs(null)).toBe(0);
+    expect(toMs(undefined)).toBe(0);
+  });
+
+  it('returns 0 for an unusable string', () => {
+    expect(toMs('garbage')).toBe(0);
+  });
+
+  it('parses a UTC ISO string (with Z suffix) correctly', () => {
+    const iso = '2026-06-01T10:00:00.000Z';
+    expect(toMs(iso)).toBe(new Date(iso).getTime());
+  });
+
+  it('parses a naive (no-TZ) timestamp as UTC — PostgREST convention', () => {
+    const naive = '2026-06-01T10:00:00'; // no Z
+    const withZ = '2026-06-01T10:00:00Z';
+    expect(toMs(naive)).toBe(new Date(withZ).getTime());
+  });
+
+  it('returns the ms value of a Date object directly', () => {
+    const d = new Date('2026-06-01T10:00:00Z');
+    expect(toMs(d)).toBe(d.getTime());
+  });
+});
+
+// ── getActiveSolomonId (FAIL-OPEN) ────────────────────────────────────────────
+
+describe('getActiveSolomonId', () => {
+  it('returns null when supabase is null (fail-open)', async () => {
+    const result = await getActiveSolomonId(null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the supabase query throws (fail-open)', async () => {
+    const throwingSupabase = {
+      from: () => { throw new Error('DB is unreachable'); },
+    };
+    const result = await getActiveSolomonId(throwingSupabase);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the query returns an error object', async () => {
+    const errorSupabase = {
+      from: () => ({
+        select: () => ({
+          gte: () => ({
+            filter: () => Promise.resolve({ data: null, error: { message: 'query failed' } }),
+          }),
+        }),
+      }),
+    };
+    const result = await getActiveSolomonId(errorSupabase);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the query returns an empty result set', async () => {
+    const emptySupabase = {
+      from: () => ({
+        select: () => ({
+          gte: () => ({
+            filter: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+      }),
+    };
+    const result = await getActiveSolomonId(emptySupabase);
+    expect(result).toBeNull();
+  });
+
+  it('returns the canonical session_id from a fresh result set', async () => {
+    const freshHb = new Date(Date.now() - 60_000).toISOString();
+    const stubSupabase = {
+      from: () => ({
+        select: () => ({
+          gte: () => ({
+            filter: () =>
+              Promise.resolve({
+                data: [
+                  { session_id: 'sol-a', heartbeat_at: freshHb, metadata: { solomon_since: '2026-06-01T09:00:00Z' } },
+                  { session_id: 'sol-b', heartbeat_at: freshHb, metadata: { solomon_since: '2026-06-01T10:00:00Z' } },
+                ],
+                error: null,
+              }),
+          }),
+        }),
+      }),
+    };
+    const result = await getActiveSolomonId(stubSupabase);
+    expect(result).toBe('sol-b'); // later solomon_since wins
+  });
+});


### PR DESCRIPTION
## Phase A of the Solomon oracle build (orchestrator SD-LEO-INFRA-SOLOMON-CONSULT-001)

Faithful copy-rename of the proven **Adam** role-session foundation. **Ships dormant** — flag-off is byte-identical to today (nothing imports these files until Phases D/E wire them; `ROLE_HANDOFF_SOLOMON_V1` defaults OFF).

### Deliverables
- `lib/coordinator/solomon-identity.cjs` — `getActiveSolomonId` (fail-open), `decideSingleSolomonGuard` (refuse-new-on-fresh-prior), `pickCanonicalSolomon` over `metadata.solomon_since`. Copy-rename of `adam-identity.cjs`.
- `scripts/solomon-register.cjs` — idempotent `role='solomon'`/`non_fleet=true` tag via the `set_solomon_flag` RPC, `ROLE_HANDOFF_SOLOMON_V1`-gated (flag-off = byte-identical legacy JS path), lazy-guarded Phase-E drain.
- `database/migrations/20260630_role_handoff_atomic_solomon_flag.sql` (+`_DOWN`) — additive `set/clear_solomon_flag` SECURITY DEFINER RPCs + in-migration `DO $verify$` block. **Tier-2 chairman-gated apply (NOT auto-applied)**; the JS register fail-softs while unapplied.
- `tests/unit/solomon-identity.test.js` — **29 tests** (election determinism, refuse-on-fresh-prior guard, freshness, fail-open). All pass.

### Verification
- Unit: 29/29 pass. E2E: N/A (backend-only identity module; EHG_Engineer = backend tests only).
- TESTING evidence: row `66918b4f-167b-45d3-aff6-fd0ab99dcc29` (PASS, 98).
- Handoffs: LEAD-TO-PLAN 96 · PLAN-TO-EXEC 98 · PLAN-TO-LEAD 97.

### LOC
923 lines, ~640 verbatim copy-rename of proven Adam files + 270 test; net-new logic ≈ 0. Cohesive foundation unit per the spec's phased decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)