### PR TITLE
fix(SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001): reach out-of-window fleet_critical SDs via a third candidate source

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-A",
-  "expectedBranch": "feat/SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-A",
-  "createdAt": "2026-06-30T13:01:21.820Z",
+  "sdKey": "SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001",
+  "createdAt": "2026-06-30T14:01:12.367Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -506,6 +506,52 @@ async function fetchDraftCandidates(sb) {
   );
 }
 
+/**
+ * SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001 (FR-1): a THIRD self-claim candidate source.
+ * The fleet_critical reorder (sortByDispatchRank -> orderByFleetCriticalThenRank) can only LIFT a
+ * fleet_critical SD that is already in the merged step-6 pool — but that pool is built from two
+ * fleet_critical-BLIND windows: v_sd_next_candidates (SELF_CLAIM_CANDIDATE_LIMIT, no fleet-aware order)
+ * and fetchDraftCandidates (created_at-ASC, DRAFT_CANDIDATE_LIMIT, draft/active). A claimable
+ * fleet_critical SD sitting OUTSIDE both windows (witnessed live at view position 20 + draft 13/13) is
+ * never in the pool, so the reorder has nothing to lift and the SD starves. This source fetches
+ * UNCLAIMED fleet_critical SDs DIRECTLY by metadata flag, bypassing the view + both windows.
+ *
+ * Hard requirements (each guards a re-seeded bug class):
+ *  - POSITIVE status allowlist status IN ('draft','active') mirroring fetchDraftCandidates:498 — NOT a
+ *    negative denylist (a .not(status,in,(completed,cancelled,deferred)) denylist admits
+ *    blocked/archived/superseded/pending_approval, which neither classifyDispatchIneligibility nor the
+ *    claim_sd terminal guard reject -> a pending_approval fleet_critical SD that never passed LEAD would
+ *    be surfaced, pass eligibility, pass claim_sd, and wrongly start EXEC).
+ *  - DETERMINISTIC .order(priority then created_at) so the bounded fetch is never a SILENT truncation
+ *    (the very no-order-limit class this SD fixes).
+ *  - STRICT-boolean predicate (FR-3): the DB-side metadata->>fleet_critical text-match returns 'true'
+ *    for BOTH a JSON boolean true AND a JSON string 'true', but the lift (sortByDispatchRank) only
+ *    lifts strict m.fleet_critical === true. JS-filter to === true so a string 'true' is not
+ *    surfaced-but-not-lifted (in the pool yet never fleet-prioritized).
+ * Selects the same columns as fetchDraftCandidates so an injected entry carries what the downstream
+ * eligibility gates read. Never claims here — the caller unions these into the merged pool so each
+ * routes through the COMPLETE eligibility SSOT + claim path. Exported for the FR-4 regression tests.
+ */
+async function fetchFleetCriticalCandidates(sb) {
+  const { data: rows } = await sb
+    .from('strategic_directives_v2')
+    .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata, target_application, parent_sd_id')
+    .eq('metadata->>fleet_critical', 'true')                 // DB text-match: admits boolean true AND string 'true'
+    .in('status', ['draft', 'active'])                       // POSITIVE allowlist (never a denylist)
+    .is('claiming_session_id', null)
+    .neq('sd_type', 'orchestrator')
+    .order('priority', { ascending: true })                  // deterministic — never a silent truncation
+    .order('created_at', { ascending: true })
+    .limit(DRAFT_CANDIDATE_LIMIT);
+  // FR-3 reconcile: keep only STRICT boolean true so a string 'true' is not surfaced-but-not-lifted
+  // (matches the lift's `m.fleet_critical === true` in sortByDispatchRank), then priority-first stable
+  // sort mirroring fetchDraftCandidates (the DB order is a hint; the JS sort is authoritative).
+  return (rows || [])
+    .filter((r) => r.metadata && r.metadata.fleet_critical === true)
+    .slice()
+    .sort((a, b) => (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9));
+}
+
 /** Per-row claim attempt for an un-baselined draft candidate (shared by the merged
  *  step-6 tier and the legacy selfClaimDraftSd wrapper). Returns a result or null. */
 async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
@@ -1090,6 +1136,11 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       .limit(SELF_CLAIM_CANDIDATE_LIMIT);
     let draftRows = [];
     try { draftRows = await fetchDraftCandidates(sb); } catch { /* fail-open: drafts absent */ }
+    // SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001 (FR-2): a THIRD source for fleet_critical SDs
+    // that sit OUTSIDE both windows above, so the downstream fleet_critical lift has them in the pool to
+    // reorder. Placed here, inside the step-6 try and downstream of ALL acquisition guards (4.5/5.7/5.8/5.9).
+    let fcRows = [];
+    try { fcRows = await fetchFleetCriticalCandidates(sb); } catch { /* fail-open: window-only behavior */ }
 
     const seen = new Set();
     const merged = [];
@@ -1098,6 +1149,15 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     }
     for (const d of draftRows) {
       if (d.sd_key && !seen.has(d.sd_key)) { seen.add(d.sd_key); merged.push({ kind: 'draft', key: d.sd_key, row: d }); }
+    }
+    // FR-2: union the fleet_critical source LAST so an SD already surfaced by the view/draft windows keeps
+    // its existing entry (dedup via the SAME seen-set). kind:'baselined' routes each injected entry through
+    // baselinedCandidateEligible -> the COMPLETE eligibility SSOT (classifyDispatchIneligibility incl. the
+    // WORK-DOWN-NEVER-UP tier axis + parentLeadPending + refillSourceIneligibility + draftDepsSatisfied),
+    // then isSdInFlight, then tryClaim — NO eligibility/claim bypass. sortByDispatchRank then lifts these
+    // (strict-boolean fleet_critical) to the front of the merged pool.
+    for (const f of fcRows) {
+      if (f.sd_key && !seen.has(f.sd_key)) { seen.add(f.sd_key); merged.push({ kind: 'baselined', key: f.sd_key }); }
     }
 
     // duty-6: honor the coordinator's fresh dispatch_rank across the WHOLE pool (fail-open).
@@ -1217,7 +1277,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, fetchFleetCriticalCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-fleet-critical-window.test.js
+++ b/tests/unit/worker-checkin-fleet-critical-window.test.js
@@ -1,0 +1,256 @@
+// SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001 (FR-4) — NON-MOCKED regression through real
+// runCheckin(). The fleet_critical reorder runs DOWNSTREAM of two fleet_critical-BLIND candidate
+// windows (v_sd_next_candidates limit-5 + fetchDraftCandidates created_at-ASC limit-10), so a
+// claimable fleet_critical SD OUTSIDE both windows never enters the pool to be lifted. The fix adds a
+// THIRD source (fetchFleetCriticalCandidates) unioned into the merged step-6 pool.
+//
+// These tests drive the REAL runCheckin(): orderByFleetCriticalThenRank, sortByDispatchRank,
+// baselinedCandidateEligible, classifyDispatchIneligibility, isSdInFlight and tryClaim all run for
+// real — ONLY the DB seam (an in-memory Supabase fixture) and the coordinator resolver are stubbed.
+// T1/T4 are inherently anti-test-masking: SD-FC-ONLY is reachable ONLY via the new source, so removing
+// the union makes runCheckin claim a filler and the assertions fail (the smoke step-4 removal check).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { runCheckin } = require('../../scripts/worker-checkin.cjs');
+
+// A ghost-prefixed session id (assign-fleet-identities GHOST_SESSION_ID_PREFIXES) so the post-claim
+// fleet-naming path is skipped (it never burns the 8-name pool for test sessions).
+const SESSION = 'test-session-fleetcrit-1';
+const NO_COORD = { getCoordinator: async () => null }; // bypass coordinator resolution (broadcast)
+
+// ── In-memory Supabase fixture (the ONLY stubbed seam) ──────────────────────────────────────────────
+// A faithful-enough PostgREST query builder: chainable filters + order + limit, terminal
+// maybeSingle/single, thenable resolution, insert/update, and the claim_sd RPC. JSON `->>'k'` extraction
+// stringifies the value (so eq('metadata->>fleet_critical','true') admits BOTH a boolean true and a
+// string 'true' — exactly the surfaced-but-not-lifted hazard the strict-boolean filter (FR-3) closes).
+function makeStub(tables, { onClaim } = {}) {
+  const db = {};
+  for (const k of Object.keys(tables)) db[k] = tables[k].map((r) => ({ ...r }));
+  let idc = 1;
+
+  const getCol = (row, col) => {
+    if (typeof col === 'string' && col.includes('->>')) {
+      const [base, rawKey] = col.split('->>');
+      const key = rawKey.replace(/['"]/g, '').trim();
+      const container = row[base.trim()];
+      const v = container ? container[key] : undefined;
+      return v === undefined || v === null ? null : String(v); // PostgREST text extraction
+    }
+    return row[col];
+  };
+
+  function query(table) {
+    let mode = 'select';
+    let payload = null;
+    const preds = [];
+    const orders = [];
+    let limitN = null;
+
+    const read = () => {
+      let rows = (db[table] || []).filter((r) => preds.every((p) => p(r)));
+      for (const o of orders.slice().reverse()) {
+        rows = rows.slice().sort((a, b) => {
+          const av = a[o.col], bv = b[o.col];
+          if (av === bv) return 0;
+          if (av == null) return 1;
+          if (bv == null) return -1;
+          return (av < bv ? -1 : 1) * (o.asc ? 1 : -1);
+        });
+      }
+      if (limitN != null) rows = rows.slice(0, limitN);
+      return rows;
+    };
+
+    const resolve = () => {
+      if (mode === 'insert') {
+        const arr = Array.isArray(payload) ? payload : [payload];
+        const inserted = arr.map((r) => ({ id: `gen-${idc++}`, ...r }));
+        db[table] = (db[table] || []).concat(inserted);
+        return { data: inserted, error: null };
+      }
+      if (mode === 'update') {
+        const matched = (db[table] || []).filter((r) => preds.every((p) => p(r)));
+        for (const r of matched) Object.assign(r, payload);
+        return { data: matched, error: null };
+      }
+      if (mode === 'delete') {
+        db[table] = (db[table] || []).filter((r) => !preds.every((p) => p(r)));
+        return { data: null, error: null };
+      }
+      return { data: read(), error: null };
+    };
+
+    const b = {
+      select() { return b; },
+      insert(p) { mode = 'insert'; payload = p; return b; },
+      update(p) { mode = 'update'; payload = p; return b; },
+      upsert(p) { mode = 'insert'; payload = p; return b; },
+      delete() { mode = 'delete'; return b; },
+      eq(c, v) { preds.push((r) => getCol(r, c) === v); return b; },
+      neq(c, v) { preds.push((r) => getCol(r, c) !== v); return b; },
+      is(c, v) { preds.push((r) => (v === null ? getCol(r, c) == null : getCol(r, c) === v)); return b; },
+      in(c, arr) { preds.push((r) => Array.isArray(arr) && arr.includes(getCol(r, c))); return b; },
+      gte(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) >= v); return b; },
+      lte(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) <= v); return b; },
+      gt(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) > v); return b; },
+      lt(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) < v); return b; },
+      not() { return b; },                                   // not exercised on the claim path
+      or() { return b; },                                    // parentLeadPending short-circuits before .or
+      order(c, opts) { orders.push({ col: c, asc: !(opts && opts.ascending === false) }); return b; },
+      limit(n) { limitN = n; return b; },
+      range() { return b; },
+      maybeSingle() { const r = resolve(); const a = r.data || []; return Promise.resolve({ data: a.length ? a[0] : null, error: r.error }); },
+      single() { const r = resolve(); const a = r.data || []; return Promise.resolve({ data: a.length ? a[0] : null, error: a.length ? r.error : { message: 'no rows' } }); },
+      then(onF, onR) { return Promise.resolve(resolve()).then(onF, onR); },
+    };
+    return b;
+  }
+
+  const sb = {
+    from(t) { return query(t); },
+    rpc(fn, args = {}) {
+      if (fn === 'claim_sd') {
+        const row = (db.strategic_directives_v2 || []).find((r) => r.sd_key === args.p_sd_id);
+        if (!row) return Promise.resolve({ data: { success: false, error: 'not_found' }, error: null });
+        if (row.claiming_session_id && row.claiming_session_id !== args.p_session_id) {
+          return Promise.resolve({ data: { success: false, claimed_by: row.claiming_session_id }, error: null });
+        }
+        if (['completed', 'cancelled', 'deferred'].includes(row.status)) {
+          return Promise.resolve({ data: { success: false, error: 'terminal' }, error: null });
+        }
+        row.claiming_session_id = args.p_session_id;
+        row.is_working_on = true;
+        if (onClaim) onClaim(args.p_sd_id);
+        return Promise.resolve({ data: { success: true }, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+  };
+  return { sb, db };
+}
+
+// ── Seed builders ───────────────────────────────────────────────────────────────────────────────────
+let seq = 0;
+const ts = (n) => `2026-01-${String(n).padStart(2, '0')}T00:00:00.000Z`;
+// A plain, fully-eligible draft SD (no target_application -> repo-fit; no human-action / co-author /
+// clone-tree markers; current_phase LEAD -> not in-flight; status draft -> claimable).
+const sd = (key, extra = {}) => ({
+  id: `id-${++seq}`, sd_key: key, status: 'draft', sd_type: 'infrastructure', priority: 'high',
+  current_phase: 'LEAD', created_at: ts(seq), dependencies: [], metadata: {}, target_application: null,
+  parent_sd_id: null, claiming_session_id: null, is_working_on: false, ...extra,
+});
+const fleetCriticalSd = (key, extra = {}) => sd(key, { metadata: { fleet_critical: true }, ...extra });
+const sessionRow = () => ({ session_id: SESSION, metadata: {}, sd_key: null, heartbeat_at: ts(1) });
+// v_sd_next_candidates row (the view exposes sd_id = the sd_key STRING).
+const viewRow = (key) => ({ sd_id: key, track: 'STANDALONE', status: 'draft', priority: 'high' });
+
+describe('fleet_critical reachability via the new third source (SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001)', () => {
+  it('T1: a fleet_critical SD present ONLY in the new source is self_claimed past equally-claimable fillers', async () => {
+    seq = 0;
+    // 10 draft fillers (older) saturate the limit-10 draft window; 5 of them also populate the limit-5 view.
+    const drafts = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-FILL-${i + 1}`));
+    const fcOnly = fleetCriticalSd('SD-FC-ONLY-001', { created_at: ts(99) }); // NEWEST -> outside the draft window
+    const all = [...drafts, fcOnly];
+    const view = drafts.slice(0, 5).map((d) => viewRow(d.sd_key)); // limit-5 view: only fillers, never FC
+    const { sb, db } = makeStub({
+      strategic_directives_v2: all,
+      v_sd_next_candidates: view,
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toBe('SD-FC-ONLY-001'); // lifted above every filler
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-FC-ONLY-001').claiming_session_id).toBe(SESSION);
+  });
+
+  it('T2 (control): with NO fleet_critical SD, a filler is claimed — proving FC was reachable ONLY via the new source', async () => {
+    seq = 0;
+    const drafts = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-FILL-${i + 1}`));
+    const view = drafts.slice(0, 5).map((d) => viewRow(d.sd_key));
+    const { sb } = makeStub({
+      strategic_directives_v2: [...drafts], // no fleet_critical SD at all
+      v_sd_next_candidates: view,
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toMatch(/^SD-DRAFT-FILL-/); // a filler, not FC
+  });
+
+  it('T3: fleet_critical beats a fresher dispatch_rank at full-runCheckin level (stale-proof)', async () => {
+    seq = 0;
+    // A filler with a FRESH (lower) dispatch_rank that would otherwise win the ordering.
+    const fresh = sd('SD-FRESH-RANK-001', { metadata: { dispatch_rank: 0, dispatch_rank_at: new Date().toISOString() } });
+    const fc = fleetCriticalSd('SD-FC-STALEPROOF-001', { created_at: ts(99) }); // no dispatch_rank
+    const { sb } = makeStub({
+      strategic_directives_v2: [fresh, fc],
+      v_sd_next_candidates: [viewRow('SD-FRESH-RANK-001')],
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toBe('SD-FC-STALEPROOF-001'); // fleet_critical lift beats the fresher rank
+  });
+
+  it('T4: the NEWEST-draft fleet_critical SD (overflowing the limit-10 draft window) is surfaced', async () => {
+    seq = 0;
+    const drafts = Array.from({ length: 12 }, (_, i) => sd(`SD-DRAFT-OVF-${i + 1}`)); // 12 > limit-10
+    const fcNewest = fleetCriticalSd('SD-FC-NEWEST-001', { created_at: ts(99) }); // position 13 by age
+    const { sb } = makeStub({
+      strategic_directives_v2: [...drafts, fcNewest],
+      v_sd_next_candidates: drafts.slice(0, 5).map((d) => viewRow(d.sd_key)),
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toBe('SD-FC-NEWEST-001');
+  });
+
+  it('FR-3: a string "true" fleet_critical is surfaced-but-not-lifted hazard — NOT treated as fleet_critical', async () => {
+    seq = 0;
+    // metadata.fleet_critical = the STRING 'true'. The DB text-match (metadata->>fleet_critical) would
+    // admit it, but the strict-boolean JS filter excludes it (it would otherwise be in the pool yet never
+    // lifted by sortByDispatchRank's `=== true` check). With it excluded and outside both windows, the
+    // claim falls to a real filler.
+    const strung = sd('SD-FC-STRING-001', { metadata: { fleet_critical: 'true' }, created_at: ts(99) });
+    const drafts = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-S-${i + 1}`));
+    const { sb, db } = makeStub({
+      strategic_directives_v2: [...drafts, strung],
+      v_sd_next_candidates: drafts.slice(0, 5).map((d) => viewRow(d.sd_key)),
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).not.toBe('SD-FC-STRING-001');         // string 'true' is NOT fleet_critical
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-FC-STRING-001').claiming_session_id).toBeNull();
+  });
+
+  it('a fleet_critical SD in a NON-allowlist status (pending_approval) is NOT surfaced or claimed', async () => {
+    seq = 0;
+    // Positive allowlist status IN (draft,active): a pending_approval fleet_critical SD that never passed
+    // LEAD must never be surfaced (a negative denylist would have admitted it -> wrong EXEC start).
+    const pending = fleetCriticalSd('SD-FC-PENDING-001', { status: 'pending_approval', created_at: ts(99) });
+    const drafts = Array.from({ length: 4 }, (_, i) => sd(`SD-DRAFT-P-${i + 1}`));
+    const { sb, db } = makeStub({
+      strategic_directives_v2: [...drafts, pending],
+      v_sd_next_candidates: drafts.map((d) => viewRow(d.sd_key)),
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.sd).not.toBe('SD-FC-PENDING-001');
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-FC-PENDING-001').claiming_session_id).toBeNull();
+  });
+});
+
+describe('FR-2/FR-5 source-pinned wiring (the union exists and routes through the SSOT)', () => {
+  it('runCheckin fetches the fleet_critical source and unions it as kind:baselined via the seen-set', async () => {
+    const { readFileSync } = await import('fs');
+    const src = readFileSync(new URL('../../scripts/worker-checkin.cjs', import.meta.url), 'utf8');
+    const body = src.slice(src.indexOf('async function runCheckin'), src.indexOf('async function main'));
+    expect(body).toMatch(/fetchFleetCriticalCandidates\(sb\)/);          // the third source is called
+    expect(body).toMatch(/for \(const f of fcRows\)/);                   // unioned into the merged pool
+    expect(body).toMatch(/seen\.has\(f\.sd_key\)/);                      // SAME seen-set dedup
+    expect(body).toMatch(/kind: 'baselined', key: f\.sd_key/);          // routes through the full SSOT
+  });
+});


### PR DESCRIPTION
## Summary
The fleet_critical reorder (`sortByDispatchRank` → `orderByFleetCriticalThenRank`) can only **lift** a fleet_critical SD that is **already in** the merged step-6 pool — but that pool was built from two fleet_critical-**blind** windows: `v_sd_next_candidates` (limit-5, no fleet-aware order) and `fetchDraftCandidates` (created_at-ASC, limit-10). A claimable fleet_critical SD **outside both windows** (witnessed live at view position 20 + draft 13/13) never entered the pool, so the reorder had nothing to lift and the SD **starved**.

## Changes (`scripts/worker-checkin.cjs`)
- **FR-1** `fetchFleetCriticalCandidates(sb)` — a **third** candidate source fetching UNCLAIMED fleet_critical SDs **directly by metadata flag**, bypassing the view + both windows. **Positive** status allowlist `status IN ('draft','active')` (never a denylist that would admit `blocked`/`pending_approval`/`superseded`), **deterministic** `.order(priority, created_at)` (never a silent truncation), **strict-boolean** predicate.
- **FR-2** union `fcRows` into the merged step-6 pool via the **same seen-set** as `kind:'baselined'`, inside the step-6 try downstream of all acquisition guards → each injected entry routes through the **complete eligibility SSOT** (`baselinedCandidateEligible` → `classifyDispatchIneligibility` incl. WORK-DOWN-NEVER-UP + `parentLeadPending` + `refillSourceIneligibility` + `draftDepsSatisfied`), then `isSdInFlight`, then `tryClaim`.
- **FR-3** strict `m.fleet_critical === true` JS filter reconciles the DB text-match (`metadata->>fleet_critical` admits a string `'true'`) with the lift's strict-boolean check — no surfaced-but-not-lifted.
- **FR-4** **non-mocked** regression tests drive **real `runCheckin()`** against an in-memory Supabase fixture (`makeStub`); only the DB seam + coordinator resolver are stubbed. T1 (new-source-only FC self_claimed past fillers), T2 (control claims a filler), T3 (stale-proof beats fresher dispatch_rank), T4 (newest-draft FC surfaced) + FR-3 string-'true' exclusion + non-allowlist-status exclusion. **T1/T4 are inherently anti-test-masking.**
- **FR-5** additive only — ordering helpers + acquisition-guard ordering unchanged.

## Tests
**7 new** + **172 existing** worker-checkin/fleet tests green. `node --check` clean.

> Note: the line count is dominated by the FR-4-mandated non-mocked `makeStub` fixture; the production change is ~50 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)