### PR TITLE
feat(SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B): convergence sandbox repo lifecycle + deterministic teardown

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SELF-CLAIM-WINDOW-FLEET-CRITICAL-001",
-  "createdAt": "2026-06-30T14:01:12.367Z",
+  "sdKey": "SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B",
+  "expectedBranch": "feat/SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B",
+  "createdAt": "2026-06-30T14:37:46.851Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/clean-clone/convergence-sandbox.js
+++ b/lib/eva/clean-clone/convergence-sandbox.js
@@ -1,0 +1,139 @@
+/**
+ * SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B — convergence SANDBOX GITHUB REPO lifecycle +
+ * DETERMINISTIC TEARDOWN for the throwaway "convergence subject" sibling Child A creates via
+ * launchNonCloneDummy. This module provisions a PRIVATE sandbox repo (recording its identity on the
+ * convergence ledger run's sandbox_repo column) and tears it down deterministically/idempotently.
+ *
+ * Every irreversible gh operation goes through an INJECTABLE `run` exec seam (deps.run, default
+ * execFileSync — NEVER a shell), mirroring lib/eva/bridge/ensure-venture-clone.js, so unit tests inject
+ * a spy and real gh is NEVER called in CI. The destructive guards are REUSED from lib/deleteVentureFully.js
+ * (parseRepoSlug / isProtectedRepo / PROTECTED_REPOS) so the protected-set + injection-safe slug regex
+ * have a single source of truth and cannot drift.
+ */
+import { execFileSync } from 'child_process';
+import { parseRepoSlug, isProtectedRepo } from '../../deleteVentureFully.js';
+import { startRun, getActiveRun, endRun } from '../../coordinator/convergence-ledger.js';
+
+const GH_TIMEOUT_MS = 30000;
+const REPO_VISIBILITY = '--private'; // fixed — a convergence sandbox repo is NEVER public
+
+/** Default exec seam: execFileSync (no shell), matching ensure-venture-clone.js. */
+const defaultRun = (cmd, args) => execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', timeout: GH_TIMEOUT_MS });
+
+/** A gh/git result is "already gone" when the repo does not exist (idempotent teardown -> success). */
+function isAlreadyGone(err) {
+  const msg = String((err && (err.stderr || err.message)) || err || '').toLowerCase();
+  return err?.code === 'ENOENT'
+    || msg.includes('not found')
+    || msg.includes('could not resolve')
+    || msg.includes('does not exist')
+    || msg.includes('no such repository');
+}
+
+/**
+ * FR-1: provision a PRIVATE sandbox repo for the convergence subject and record it on the ledger.
+ * @param {{ventureId?:string, repoName?:string, slug?:string, dryRun?:boolean}} params
+ * @param {{run?:Function, log?:Function, supabase?:object}} deps
+ * @returns {Promise<{ok:boolean, stage:string, dryRun:boolean, slug?:string, runId?:string, reason?:string}>}
+ */
+export async function provisionSandboxRepo(params = {}, deps = {}) {
+  const { ventureId = null, repoName = null, slug: explicitSlug = null, dryRun = true } = params;
+  const run = deps.run || defaultRun;
+  const log = deps.log || (() => {});
+  const supabase = deps.supabase || null;
+
+  // Resolve + validate the owner/repo slug via the canonical guard (reused, never re-declared).
+  const rawSlug = explicitSlug || repoName;
+  const { slug, valid } = parseRepoSlug(rawSlug || '');
+  if (!valid) {
+    log(`provision refused: invalid slug ${JSON.stringify(rawSlug)}`);
+    return { ok: false, stage: 'validate_slug', dryRun, reason: 'invalid_slug' };
+  }
+  // A provision must NEVER target a protected repo (defense-in-depth; a sandbox is always throwaway).
+  if (isProtectedRepo(slug)) {
+    log(`provision refused: protected repo ${slug}`);
+    return { ok: false, stage: 'guard_refused', dryRun, slug, reason: 'protected_repo' };
+  }
+
+  if (dryRun) {
+    log(`[dry-run] would create private sandbox repo ${slug}`);
+    return { ok: true, stage: 'provisioned', dryRun: true, slug };
+  }
+
+  run('gh', ['repo', 'create', slug, REPO_VISIBILITY, '--description', `convergence sandbox (${ventureId || 'subject'})`]);
+  log(`created private sandbox repo ${slug}`);
+
+  // Record the sandbox repo identity on the convergence ledger so deterministic teardown can find it.
+  let runId;
+  if (supabase) {
+    const started = await startRun(supabase, { subject_venture_id: ventureId, dummy_kind: 'convergence_subject', sandbox_repo: slug });
+    runId = started.run_id;
+  }
+  return { ok: true, stage: 'provisioned', dryRun: false, slug, runId };
+}
+
+/**
+ * FR-2: deterministically + idempotently tear down the convergence sandbox repo.
+ * Resolves the slug from params or the active ledger run, HARD-GUARDS against protected/malformed slugs
+ * (fail-loud, no delete), deletes via the injected run, classifies already-gone as success, closes the run.
+ * @param {{ventureId?:string, repoSlug?:string, dryRun?:boolean}} params
+ * @param {{run?:Function, log?:Function, supabase?:object}} deps
+ * @returns {Promise<{ok:boolean, stage:string, dryRun:boolean, slug?:string, reason?:string}>}
+ */
+export async function teardownSandboxRepo(params = {}, deps = {}) {
+  const { repoSlug = null, dryRun = true } = params;
+  const run = deps.run || defaultRun;
+  const log = deps.log || (() => {});
+  const supabase = deps.supabase || null;
+
+  // Resolve the slug: explicit param wins, else read sandbox_repo off the active ledger run.
+  let rawSlug = repoSlug;
+  let activeRun = null;
+  if (!rawSlug && supabase) {
+    activeRun = await getActiveRun(supabase);
+    rawSlug = activeRun && activeRun.sandbox_repo;
+  }
+  if (!rawSlug) {
+    log('teardown skipped: no sandbox repo on the active run');
+    return { ok: false, stage: 'no_sandbox', dryRun, reason: 'no_sandbox_repo' };
+  }
+
+  // HARD GUARD (fail-loud, NO delete): a malformed/unsafe slug or a protected repo must never be deleted.
+  const { slug, valid } = parseRepoSlug(rawSlug);
+  if (!valid) {
+    log(`teardown REFUSED: invalid/unsafe slug ${JSON.stringify(rawSlug)}`);
+    return { ok: false, stage: 'guard_refused', dryRun, reason: 'invalid_slug' };
+  }
+  if (isProtectedRepo(slug)) {
+    log(`teardown REFUSED: protected repo ${slug}`);
+    return { ok: false, stage: 'guard_refused', dryRun, slug, reason: 'protected_repo' };
+  }
+
+  if (dryRun) {
+    log(`[dry-run] would delete sandbox repo ${slug}`);
+    return { ok: true, stage: 'torn_down', dryRun: true, slug };
+  }
+
+  let stage = 'torn_down';
+  try {
+    run('gh', ['repo', 'delete', '--yes', '--', slug]);
+    log(`deleted sandbox repo ${slug}`);
+  } catch (err) {
+    if (isAlreadyGone(err)) {
+      stage = 'already_gone'; // idempotent: an already-deleted repo is a successful teardown
+      log(`sandbox repo ${slug} already gone (idempotent success)`);
+    } else {
+      log(`teardown FAILED for ${slug}: ${err && err.message}`);
+      return { ok: false, stage: 'delete_failed', dryRun: false, slug, reason: (err && err.message) || 'delete_failed' };
+    }
+  }
+
+  // Close the ledger run (the sandbox is gone; the run is complete).
+  if (supabase) {
+    const runId = activeRun ? activeRun.run_id : (await getActiveRun(supabase))?.run_id;
+    if (runId) await endRun(supabase, runId, 'clean');
+  }
+  return { ok: true, stage, dryRun: false, slug };
+}
+
+export default { provisionSandboxRepo, teardownSandboxRepo };

--- a/tests/unit/eva/convergence-sandbox.test.js
+++ b/tests/unit/eva/convergence-sandbox.test.js
@@ -1,0 +1,134 @@
+/**
+ * SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B (FR-3) — sandbox repo lifecycle + deterministic
+ * teardown. Tests inject a fake `run` spy so REAL gh is NEVER called; the destructive guards
+ * (parseRepoSlug / isProtectedRepo) run for real (reused from lib/deleteVentureFully.js).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { provisionSandboxRepo, teardownSandboxRepo } from '../../../lib/eva/clean-clone/convergence-sandbox.js';
+
+const silent = () => {};
+// assertNoDelete-style invariant: NO gh 'repo delete' was ever invoked through the run spy.
+const noDelete = (run) => run.mock.calls.every(([cmd, args]) => !(cmd === 'gh' && Array.isArray(args) && args[0] === 'repo' && args[1] === 'delete'));
+
+// Minimal supabase stub for the ledger writes/reads used by the module.
+function makeLedgerStub({ activeRun = null } = {}) {
+  const calls = { inserted: [], updated: [] };
+  const sb = {
+    from() {
+      const b = {
+        insert(row) { calls.inserted.push(row); return b; },
+        update(row) { calls.updated.push(row); return b; },
+        select() { return b; },
+        eq() { return b; },
+        order() { return b; },
+        limit() { return b; },
+        single: async () => ({ data: { run_id: 'run-1' }, error: null }),
+        maybeSingle: async () => ({ data: activeRun, error: null }),
+      };
+      return b;
+    },
+  };
+  return { sb, calls };
+}
+
+describe('FR-1: provisionSandboxRepo', () => {
+  it('creates a PRIVATE repo via the injected run and records sandbox_repo on the ledger', async () => {
+    const run = vi.fn(() => '');
+    const { sb, calls } = makeLedgerStub();
+    const r = await provisionSandboxRepo(
+      { ventureId: 'v-1', repoName: 'rickfelix/conv-sandbox-1', dryRun: false },
+      { run, log: silent, supabase: sb }
+    );
+    expect(r.ok).toBe(true);
+    expect(r.stage).toBe('provisioned');
+    expect(r.slug).toBe('rickfelix/conv-sandbox-1');
+    const [cmd, args] = run.mock.calls[0];
+    expect(cmd).toBe('gh');
+    expect(args.slice(0, 4)).toEqual(['repo', 'create', 'rickfelix/conv-sandbox-1', '--private']);
+    expect(calls.inserted[0].sandbox_repo).toBe('rickfelix/conv-sandbox-1'); // ledger recorded
+  });
+
+  it('refuses an invalid/unsafe slug WITHOUT invoking run', async () => {
+    const run = vi.fn(() => '');
+    const r = await provisionSandboxRepo({ repoName: 'not a/valid slug; rm -rf', dryRun: false }, { run, log: silent });
+    expect(r.ok).toBe(false);
+    expect(r.stage).toBe('validate_slug');
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('dry-run performs NO run invocation and no ledger mutation', async () => {
+    const run = vi.fn(() => '');
+    const { sb, calls } = makeLedgerStub();
+    const r = await provisionSandboxRepo({ repoName: 'rickfelix/conv-sandbox-2', dryRun: true }, { run, log: silent, supabase: sb });
+    expect(r.ok).toBe(true);
+    expect(r.dryRun).toBe(true);
+    expect(run).not.toHaveBeenCalled();
+    expect(calls.inserted).toHaveLength(0);
+  });
+});
+
+describe('FR-2: teardownSandboxRepo', () => {
+  it('deletes a valid sandbox repo via the injected run and closes the ledger run', async () => {
+    const run = vi.fn(() => '');
+    const { sb, calls } = makeLedgerStub({ activeRun: { run_id: 'run-1', sandbox_repo: 'rickfelix/conv-sandbox-1' } });
+    const r = await teardownSandboxRepo({ dryRun: false }, { run, log: silent, supabase: sb });
+    expect(r.ok).toBe(true);
+    expect(r.stage).toBe('torn_down');
+    const [cmd, args] = run.mock.calls[0];
+    expect(cmd).toBe('gh');
+    expect(args).toEqual(['repo', 'delete', '--yes', '--', 'rickfelix/conv-sandbox-1']);
+    expect(calls.updated.some((u) => u.status === 'clean' && u.ended_at)).toBe(true); // run closed
+  });
+
+  it('is idempotent: an already-gone (ENOENT) repo is classified SUCCESS', async () => {
+    const run = vi.fn(() => { const e = new Error('not found'); e.code = 'ENOENT'; throw e; });
+    const { sb } = makeLedgerStub({ activeRun: { run_id: 'run-1', sandbox_repo: 'rickfelix/conv-gone' } });
+    const r = await teardownSandboxRepo({ repoSlug: 'rickfelix/conv-gone', dryRun: false }, { run, log: silent, supabase: sb });
+    expect(r.ok).toBe(true);
+    expect(r.stage).toBe('already_gone');
+  });
+
+  it('REFUSES a PROTECTED repo fail-loud with NO delete invoked', async () => {
+    const run = vi.fn(() => '');
+    const r = await teardownSandboxRepo({ repoSlug: 'rickfelix/EHG_Engineer', dryRun: false }, { run, log: silent });
+    expect(r.ok).toBe(false);
+    expect(r.stage).toBe('guard_refused');
+    expect(r.reason).toBe('protected_repo');
+    expect(run).not.toHaveBeenCalled();
+    expect(noDelete(run)).toBe(true);
+  });
+
+  it('REFUSES a malformed/unsafe slug fail-loud with NO delete invoked', async () => {
+    const run = vi.fn(() => '');
+    const r = await teardownSandboxRepo({ repoSlug: '-rf/--no-preserve-root', dryRun: false }, { run, log: silent });
+    expect(r.ok).toBe(false);
+    expect(r.stage).toBe('guard_refused');
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('resolves the slug from the active ledger run when not passed', async () => {
+    const run = vi.fn(() => '');
+    const { sb } = makeLedgerStub({ activeRun: { run_id: 'run-1', sandbox_repo: 'rickfelix/conv-from-ledger' } });
+    const r = await teardownSandboxRepo({ dryRun: false }, { run, log: silent, supabase: sb });
+    expect(r.slug).toBe('rickfelix/conv-from-ledger');
+    expect(run.mock.calls[0][1]).toEqual(['repo', 'delete', '--yes', '--', 'rickfelix/conv-from-ledger']);
+  });
+
+  it('dry-run performs NO delete', async () => {
+    const run = vi.fn(() => '');
+    const r = await teardownSandboxRepo({ repoSlug: 'rickfelix/conv-sandbox-1', dryRun: true }, { run, log: silent });
+    expect(r.ok).toBe(true);
+    expect(r.dryRun).toBe(true);
+    expect(run).not.toHaveBeenCalled();
+    expect(noDelete(run)).toBe(true);
+  });
+
+  it('returns no_sandbox when there is no slug and no active run', async () => {
+    const run = vi.fn(() => '');
+    const { sb } = makeLedgerStub({ activeRun: null });
+    const r = await teardownSandboxRepo({ dryRun: false }, { run, log: silent, supabase: sb });
+    expect(r.ok).toBe(false);
+    expect(r.stage).toBe('no_sandbox');
+    expect(run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Child B of the convergence dummy-subject lifecycle orchestrator (parent SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001) — the sandbox GitHub repo lifecycle + deterministic teardown for the throwaway subject sibling Child A creates via `launchNonCloneDummy`.

- **FR-1** `lib/eva/clean-clone/convergence-sandbox.js` `provisionSandboxRepo` — creates a **private** sandbox repo behind an **injectable `run` exec seam** (`deps.run`, default `execFileSync` — never a shell), validates the slug via the canonical `parseRepoSlug`, records `sandbox_repo` onto the convergence ledger run, dry-run-default.
- **FR-2** `teardownSandboxRepo` — **deterministic + idempotent** teardown: resolves the slug from the active ledger run, **hard-guards** via `isProtectedRepo` + `parseRepoSlug.valid` (a protected or malformed slug is **refused fail-loud**, never a real-repo delete), runs `gh repo delete --yes -- <slug>` through the same injected `run`, classifies an already-gone (ENOENT) repo as **success**, then closes the run.
- Reuses the `lib/deleteVentureFully.js` destructive guards (`parseRepoSlug` / `isProtectedRepo` / `PROTECTED_REPOS`) so the protected-set + injection-safe slug regex **never drift**; mirrors the `ensure-venture-clone.js` injectable-run convention + `venture-provisioner.js` create shape.
- **FR-3** `tests/unit/eva/convergence-sandbox.test.js` (**10**) inject a `run` spy — real gh is never called: create args + ledger record, idempotent already-gone success, protected + unsafe-slug refusal (no-delete invariant), slug resolution from the ledger, dry-run no-op.

## Tests
**10/10** pass; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)