### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-CONSULT-001B): Solomon triage SSOT — isSolomonEligible() pure predicate

### DIFF
--- a/lib/coordinator/solomon-triage.cjs
+++ b/lib/coordinator/solomon-triage.cjs
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * SD-LEO-INFRA-SOLOMON-CONSULT-001B — Solomon triage SSOT (pure counter-gated
+ * eligibility predicate over retry-state-manager counters).
+ *
+ * Cognitive ladder: local reasoning → rca-agent → Solomon → Chairman.
+ *
+ * This module is PURE and TOTAL — it never throws, never performs DB/IO of any
+ * kind, and always returns a fully-populated result object. Persistence of
+ * triage_score + reason for auditability is the CALLER's responsibility
+ * (implemented in Phase D), keeping this module side-effect-free and trivially
+ * testable.
+ */
+
+const RCA_THRESHOLD = 2;
+const GATE_FAIL_THRESHOLD = 3;
+
+/**
+ * Coerce a value to a non-negative integer. Returns 0 for anything
+ * non-numeric, non-finite, or NaN.
+ * @param {*} v
+ * @returns {number}
+ */
+function toInt(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
+}
+
+/**
+ * Evaluate whether the current friction state meets the Solomon triage bar.
+ *
+ * PURE + TOTAL: never throws regardless of input shape. All numeric fields are
+ * coerced via toInt(); non-object state/context are treated as empty.
+ *
+ * @param {string} signature - Tool/gate signature (informational; not used in
+ *   computation but carried for caller context and future audit logging).
+ * @param {object} [state={}]
+ *   @param {number} [state.toolAttempts=0] - Count of the SAME gate/test failing
+ *     past the 2 auto-retries (Canonical Pause-Point #3 accumulator).
+ *   @param {number} [state.rcaCount=0] - Count of rca-agent runs on the same
+ *     symptom without an actionable root cause.
+ *   @param {boolean} [state.selfResolutionAttemptLogged=false] - True when the
+ *     worker has already logged a self-resolution attempt for the current issue.
+ * @param {object} [context={}]
+ *   @param {string} [context.type] - Issue type, e.g. 'spec-conflict' or
+ *     'arch-ambiguity'.
+ * @returns {{ eligible: boolean, triage_score: number, reason: string }}
+ */
+function evaluateSolomonTriage(signature, state, context) {
+  // Defensive normalisation — both arguments are optional and may be garbage.
+  const s = (state !== null && typeof state === 'object') ? state : {};
+  const ctx = (context !== null && typeof context === 'object') ? context : {};
+
+  const rcaCount = toInt(s.rcaCount);
+  const toolAttempts = toInt(s.toolAttempts);
+  const selfResolutionAttemptLogged = s.selfResolutionAttemptLogged === true;
+  const type = typeof ctx.type === 'string' ? ctx.type : undefined;
+
+  // ── Decision logic (counter-gated, strict priority order) ─────────────────
+
+  // 1. RCA escalation — rca-agent ran >=2x without an actionable root cause.
+  if (rcaCount >= RCA_THRESHOLD) {
+    return {
+      eligible: true,
+      triage_score: 90,
+      reason: 'rca-agent ran >=2x on the same symptom without an actionable root cause (cognitive-ladder escalation)',
+    };
+  }
+
+  // 2. Gate/test hard-stuck — Canonical Pause-Point #3 exhausted.
+  if (toolAttempts >= GATE_FAIL_THRESHOLD) {
+    return {
+      eligible: true,
+      triage_score: 85,
+      reason: 'the same gate/test failed >=3x — Canonical Pause-Point-#3 exhausted',
+    };
+  }
+
+  // 3. Counter-exception: spec-conflict / arch-ambiguity WITH a logged worker
+  //    self-resolution attempt. selfResolutionAttemptLogged=false (the default)
+  //    must produce eligible=false — the false-eligible trap.
+  if ((type === 'spec-conflict' || type === 'arch-ambiguity') && selfResolutionAttemptLogged) {
+    return {
+      eligible: true,
+      triage_score: 75,
+      reason: `first-encounter ${type} WITH a logged worker self-resolution attempt (counter-exception)`,
+    };
+  }
+
+  // 4. Not eligible — compute a proximity score and produce a specific reason.
+  const rawScore = (rcaCount * 20) + (toolAttempts * 10);
+  const triage_score = Math.min(50, rawScore);
+
+  let reason;
+  if ((type === 'spec-conflict' || type === 'arch-ambiguity') && !selfResolutionAttemptLogged) {
+    // Spec says: mention which threshold is unmet AND that a logged
+    // self-resolution attempt is required for this issue type.
+    reason =
+      `first-encounter ${type} WITHOUT a logged worker self-resolution attempt — ` +
+      `selfResolutionAttemptLogged must be true before Solomon escalation is eligible ` +
+      `(rcaCount ${rcaCount}/${RCA_THRESHOLD}, toolAttempts ${toolAttempts}/${GATE_FAIL_THRESHOLD} — neither threshold cleared)`;
+  } else {
+    reason =
+      `not eligible: rcaCount ${rcaCount} has not reached threshold ${RCA_THRESHOLD} and ` +
+      `toolAttempts ${toolAttempts} has not reached threshold ${GATE_FAIL_THRESHOLD} — ` +
+      `no escalation trigger cleared`;
+  }
+
+  return { eligible: false, triage_score, reason };
+}
+
+/**
+ * Boolean convenience wrapper — returns the eligible field from
+ * evaluateSolomonTriage without exposing the full result object.
+ *
+ * @param {string} signature
+ * @param {object} [state={}]
+ * @param {object} [context={}]
+ * @returns {boolean}
+ */
+function isSolomonEligible(signature, state, context) {
+  return evaluateSolomonTriage(signature, state, context).eligible;
+}
+
+module.exports = { evaluateSolomonTriage, isSolomonEligible, RCA_THRESHOLD, GATE_FAIL_THRESHOLD };

--- a/tests/unit/solomon-triage.test.js
+++ b/tests/unit/solomon-triage.test.js
@@ -1,0 +1,249 @@
+/**
+ * solomon-triage.test.js — SD-LEO-INFRA-SOLOMON-CONSULT-001B (Solomon Phase B)
+ *
+ * Network-free unit tests for lib/coordinator/solomon-triage.cjs.
+ * Covers:
+ *   - TRUE eligibility: rcaCount>=2, toolAttempts>=3, rcaCount=5
+ *   - FALSE eligibility: first encounter, sub-threshold values
+ *   - ADVERSARIAL (false-eligible trap): spec-conflict/arch-ambiguity without
+ *     selfResolutionAttemptLogged must be ineligible; WITH it must be eligible
+ *   - BOUNDARY: exactly at threshold values (inclusive)
+ *   - AUDITABILITY: triage_score (number 0-100) + non-empty reason always
+ *     present for both eligible AND rejected results
+ *   - TOTALITY: never throws on undefined/null/NaN/no-arg input
+ *   - isSolomonEligible: boolean wrapper matches evaluateSolomonTriage.eligible
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  evaluateSolomonTriage,
+  isSolomonEligible,
+  RCA_THRESHOLD,
+  GATE_FAIL_THRESHOLD,
+} = require('../../lib/coordinator/solomon-triage.cjs');
+
+// ── TRUE eligibility ──────────────────────────────────────────────────────────
+
+describe('evaluateSolomonTriage — TRUE eligibility', () => {
+  it('rcaCount=2 → eligible (RCA_THRESHOLD reached, score=90)', () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: 2 });
+    expect(result.eligible).toBe(true);
+    expect(result.triage_score).toBe(90);
+  });
+
+  it('rcaCount=5 → eligible (above RCA_THRESHOLD, score=90)', () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: 5 });
+    expect(result.eligible).toBe(true);
+    expect(result.triage_score).toBe(90);
+  });
+
+  it('toolAttempts=3 → eligible (GATE_FAIL_THRESHOLD reached, score=85)', () => {
+    const result = evaluateSolomonTriage('sig', { toolAttempts: 3 });
+    expect(result.eligible).toBe(true);
+    expect(result.triage_score).toBe(85);
+  });
+});
+
+// ── FALSE eligibility ─────────────────────────────────────────────────────────
+
+describe('evaluateSolomonTriage — FALSE eligibility', () => {
+  it('first encounter {toolAttempts:0, rcaCount:0} → NOT eligible', () => {
+    const result = evaluateSolomonTriage('sig', { toolAttempts: 0, rcaCount: 0 });
+    expect(result.eligible).toBe(false);
+  });
+
+  it('rcaCount=1 → NOT eligible (one below RCA_THRESHOLD)', () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: 1 });
+    expect(result.eligible).toBe(false);
+  });
+
+  it('toolAttempts=2 → NOT eligible (one below GATE_FAIL_THRESHOLD)', () => {
+    const result = evaluateSolomonTriage('sig', { toolAttempts: 2 });
+    expect(result.eligible).toBe(false);
+  });
+});
+
+// ── ADVERSARIAL — the false-eligible trap ─────────────────────────────────────
+
+describe('evaluateSolomonTriage — ADVERSARIAL (false-eligible trap)', () => {
+  it('spec-conflict WITHOUT selfResolutionAttemptLogged=false → NOT eligible', () => {
+    const result = evaluateSolomonTriage(
+      'sig',
+      { toolAttempts: 0, rcaCount: 0, selfResolutionAttemptLogged: false },
+      { type: 'spec-conflict' }
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toContain('spec-conflict');
+    expect(result.reason).toContain('selfResolutionAttemptLogged');
+  });
+
+  it('spec-conflict WITH selfResolutionAttemptLogged=true → eligible (score=75)', () => {
+    const result = evaluateSolomonTriage(
+      'sig',
+      { toolAttempts: 0, rcaCount: 0, selfResolutionAttemptLogged: true },
+      { type: 'spec-conflict' }
+    );
+    expect(result.eligible).toBe(true);
+    expect(result.triage_score).toBe(75);
+  });
+
+  it('arch-ambiguity WITHOUT selfResolutionAttemptLogged → NOT eligible', () => {
+    const result = evaluateSolomonTriage(
+      'sig',
+      { toolAttempts: 0, rcaCount: 0, selfResolutionAttemptLogged: false },
+      { type: 'arch-ambiguity' }
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toContain('arch-ambiguity');
+    expect(result.reason).toContain('selfResolutionAttemptLogged');
+  });
+
+  it('arch-ambiguity WITH selfResolutionAttemptLogged=true → eligible (score=75)', () => {
+    const result = evaluateSolomonTriage(
+      'sig',
+      { toolAttempts: 0, rcaCount: 0, selfResolutionAttemptLogged: true },
+      { type: 'arch-ambiguity' }
+    );
+    expect(result.eligible).toBe(true);
+    expect(result.triage_score).toBe(75);
+  });
+
+  it('spec-conflict without selfResolutionAttemptLogged (omitted, not false) → NOT eligible', () => {
+    // selfResolutionAttemptLogged absent (undefined) must also be false-eligible-safe
+    const result = evaluateSolomonTriage('sig', {}, { type: 'spec-conflict' });
+    expect(result.eligible).toBe(false);
+  });
+});
+
+// ── BOUNDARY ──────────────────────────────────────────────────────────────────
+
+describe('evaluateSolomonTriage — BOUNDARY (inclusive at threshold)', () => {
+  it(`exactly rcaCount=${RCA_THRESHOLD} → eligible`, () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: RCA_THRESHOLD });
+    expect(result.eligible).toBe(true);
+  });
+
+  it(`exactly toolAttempts=${GATE_FAIL_THRESHOLD} → eligible`, () => {
+    const result = evaluateSolomonTriage('sig', { toolAttempts: GATE_FAIL_THRESHOLD });
+    expect(result.eligible).toBe(true);
+  });
+
+  it(`rcaCount=${RCA_THRESHOLD - 1} → NOT eligible (one below boundary)`, () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: RCA_THRESHOLD - 1 });
+    expect(result.eligible).toBe(false);
+  });
+
+  it(`toolAttempts=${GATE_FAIL_THRESHOLD - 1} → NOT eligible (one below boundary)`, () => {
+    const result = evaluateSolomonTriage('sig', { toolAttempts: GATE_FAIL_THRESHOLD - 1 });
+    expect(result.eligible).toBe(false);
+  });
+});
+
+// ── AUDITABILITY ──────────────────────────────────────────────────────────────
+
+describe('evaluateSolomonTriage — AUDITABILITY', () => {
+  it('eligible result carries a numeric triage_score (0-100) and non-empty reason', () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: 2 });
+    expect(result.eligible).toBe(true);
+    expect(typeof result.triage_score).toBe('number');
+    expect(result.triage_score).toBeGreaterThanOrEqual(0);
+    expect(result.triage_score).toBeLessThanOrEqual(100);
+    expect(typeof result.reason).toBe('string');
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+
+  it('rejected result carries a numeric triage_score (0-100) and non-empty reason', () => {
+    const result = evaluateSolomonTriage('sig', { toolAttempts: 0, rcaCount: 0 });
+    expect(result.eligible).toBe(false);
+    expect(typeof result.triage_score).toBe('number');
+    expect(result.triage_score).toBeGreaterThanOrEqual(0);
+    expect(result.triage_score).toBeLessThanOrEqual(100);
+    expect(typeof result.reason).toBe('string');
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+
+  it('rejected spec-conflict reason explicitly mentions the missing self-resolution requirement', () => {
+    const result = evaluateSolomonTriage(
+      'sig',
+      { selfResolutionAttemptLogged: false },
+      { type: 'spec-conflict' }
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toMatch(/selfResolutionAttemptLogged/);
+    expect(result.reason).toMatch(/spec-conflict/);
+  });
+
+  it('rejected generic case reason mentions both threshold values', () => {
+    const result = evaluateSolomonTriage('sig', { rcaCount: 1, toolAttempts: 1 });
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toMatch(/rcaCount/);
+    expect(result.reason).toMatch(/toolAttempts/);
+  });
+});
+
+// ── TOTALITY — never throws on garbage input ──────────────────────────────────
+
+describe('evaluateSolomonTriage — TOTALITY (never throws)', () => {
+  it('no arguments at all → does not throw, returns eligible=false', () => {
+    expect(() => evaluateSolomonTriage()).not.toThrow();
+    const result = evaluateSolomonTriage();
+    expect(result.eligible).toBe(false);
+    expect(typeof result.triage_score).toBe('number');
+    expect(typeof result.reason).toBe('string');
+  });
+
+  it('undefined state → does not throw, returns eligible=false', () => {
+    expect(() => evaluateSolomonTriage('sig', undefined)).not.toThrow();
+    expect(evaluateSolomonTriage('sig', undefined).eligible).toBe(false);
+  });
+
+  it('{toolAttempts:NaN} → coerces to 0, does not throw, returns eligible=false', () => {
+    expect(() => evaluateSolomonTriage('sig', { toolAttempts: NaN })).not.toThrow();
+    const result = evaluateSolomonTriage('sig', { toolAttempts: NaN });
+    expect(result.eligible).toBe(false);
+  });
+
+  it('null state → does not throw, returns eligible=false', () => {
+    expect(() => evaluateSolomonTriage('sig', null)).not.toThrow();
+    expect(evaluateSolomonTriage('sig', null).eligible).toBe(false);
+  });
+
+  it('null context → does not throw, returns eligible=false', () => {
+    expect(() => evaluateSolomonTriage('sig', {}, null)).not.toThrow();
+    expect(evaluateSolomonTriage('sig', {}, null).eligible).toBe(false);
+  });
+});
+
+// ── isSolomonEligible — boolean convenience wrapper ───────────────────────────
+
+describe('isSolomonEligible', () => {
+  it('returns true when evaluateSolomonTriage would return eligible=true', () => {
+    expect(isSolomonEligible('sig', { rcaCount: 2 })).toBe(true);
+    expect(isSolomonEligible('sig', { rcaCount: 2 })).toBe(
+      evaluateSolomonTriage('sig', { rcaCount: 2 }).eligible
+    );
+  });
+
+  it('returns false when evaluateSolomonTriage would return eligible=false', () => {
+    expect(isSolomonEligible('sig', { rcaCount: 0 })).toBe(false);
+    expect(isSolomonEligible('sig', { rcaCount: 0 })).toBe(
+      evaluateSolomonTriage('sig', { rcaCount: 0 }).eligible
+    );
+  });
+
+  it('matches evaluateSolomonTriage on the adversarial spec-conflict without self-resolution', () => {
+    const eligible = isSolomonEligible('sig', {}, { type: 'spec-conflict' });
+    const full = evaluateSolomonTriage('sig', {}, { type: 'spec-conflict' });
+    expect(eligible).toBe(full.eligible);
+    expect(eligible).toBe(false);
+  });
+
+  it('matches evaluateSolomonTriage on spec-conflict WITH self-resolution', () => {
+    const eligible = isSolomonEligible('sig', { selfResolutionAttemptLogged: true }, { type: 'spec-conflict' });
+    const full = evaluateSolomonTriage('sig', { selfResolutionAttemptLogged: true }, { type: 'spec-conflict' });
+    expect(eligible).toBe(full.eligible);
+    expect(eligible).toBe(true);
+  });
+});


### PR DESCRIPTION
## Phase B of the Solomon oracle build (parent SD-LEO-INFRA-SOLOMON-CONSULT-001)

Pure, total, counter-gated triage predicate. **Ships dormant** (the Phase-D caller is flag-gated; this module is pure/no-IO).

- `lib/coordinator/solomon-triage.cjs` — `evaluateSolomonTriage()` → {eligible, triage_score, reason}; `isSolomonEligible()` wrapper. Counter gates: rcaCount≥2 | toolAttempts≥3 (Pause-Point-#3) | spec-conflict/arch-ambiguity WITH a logged self-resolution attempt.
- **False-eligible trap closed**: first-encounter spec-conflict WITHOUT a logged attempt → NOT eligible (strict `=== true`). Verified: node check prints `true false true`.
- `tests/unit/solomon-triage.test.js` — 28 tests (true/false/boundary/adversarial/auditability/totality). All pass.

Cognitive ladder: local reasoning → rca-agent → Solomon → Chairman. Persistence of triage_score+reason is the caller's job (Phase D), keeping this module pure.

Handoffs: LEAD-TO-PLAN 95 · PLAN-TO-EXEC 98 · PLAN-TO-LEAD 97. TESTING evidence d6bd3676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)