### PR TITLE
feat(SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001): enforce needs_coordinator_review hold on both acquisition paths

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B",
-  "expectedBranch": "feat/SD-LEO-INFRA-CONVERGENCE-SUBJECT-LIFECYCLE-001-B",
-  "createdAt": "2026-06-30T14:37:46.851Z",
+  "sdKey": "SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001",
+  "createdAt": "2026-06-30T15:04:49.190Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -123,16 +123,18 @@ async function assertSdDispatchable(supabase, row, logger = console) {
   const sdKey = row.target_sd || payload.sd_key || payload.current_sd || payload.assigned_sd || null;
   if (!sdKey) return; // a WORK_ASSIGNMENT with no named SD (e.g. a generic nudge) — nothing to check
   const isQf = /^QF-/.test(sdKey);
-  let status, found;
+  let status, found, metadata;
   try {
     if (isQf) {
       const { data, error } = await supabase.from('quick_fixes').select('status').eq('id', sdKey).maybeSingle();
       if (error) throw error;
       found = !!data; status = data && data.status;
     } else {
-      const { data, error } = await supabase.from('strategic_directives_v2').select('status').eq('sd_key', sdKey).maybeSingle();
+      // SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001: also fetch metadata so the review-hold check
+      // below runs in the SAME lookup (no extra query path).
+      const { data, error } = await supabase.from('strategic_directives_v2').select('status, metadata').eq('sd_key', sdKey).maybeSingle();
       if (error) throw error;
-      found = !!data; status = data && data.status;
+      found = !!data; status = data && data.status; metadata = data && data.metadata;
     }
   } catch (e) {
     // FAIL-OPEN on a transient lookup error: do not wedge dispatch; claim_sd still guards at claim time.
@@ -149,6 +151,17 @@ async function assertSdDispatchable(supabase, row, logger = console) {
   if (terminal) {
     const e = new Error(`[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} is in terminal status '${status}' — refusing to dispatch a finished/cancelled SD (claim_sd would reject it as sd_terminal_status).`);
     e.code = 'DISPATCH_SD_TERMINAL';
+    logger && logger.error && logger.error(e.message);
+    throw e;
+  }
+  // SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001 (FR-2): the directed-dispatch path does NOT route
+  // through classifyDispatchIneligibility (only terminal + tier), so it would otherwise BYPASS the
+  // needs_coordinator_review hold and defeat the SD. Mirror the self-claim classifier axis here: a
+  // review-pending SD is REFUSED (fail-CLOSED) until the coordinator clears the flag. Strict === true so a
+  // false/absent flag dispatches normally; a transient lookup error already failed OPEN above.
+  if (!isQf && metadata && metadata.needs_coordinator_review === true) {
+    const e = new Error(`[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} is review-pending (metadata.needs_coordinator_review) — the coordinator must review + clear the flag before dispatch (the clear IS the authorization).`);
+    e.code = 'DISPATCH_SD_REVIEW_PENDING';
     logger && logger.error && logger.error(e.message);
     throw e;
   }

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -66,6 +66,16 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // flag (converged or non-co-authored) falls through unchanged. Shared SSOT: the self-claim (draft +
   // baselined) and stale-session-sweep paths all route through this predicate, so they exclude it too.
   if (row.metadata && row.metadata.co_author_pending === true) return 'co_author_pending';
+  // SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001: a review-pending SD (metadata.needs_coordinator_review
+  // === true) is NON-CLAIMABLE until the coordinator REVIEWS it — the coordinator clearing the flag
+  // (set false / remove) IS the dispatch authorization (no separate approval artifact). This is the SHARED
+  // authoritative gate the worker self-claim path (baselined + draft) and the stale-session-sweep consult,
+  // so the hold holds across all of them. Strict === true so a false/absent flag falls through unchanged.
+  // The DIRECTED-ASSIGN path does NOT route through this classifier (lib/coordinator/dispatch.cjs
+  // assertSdDispatchable checks terminal+tier only), so it carries a mirrored check — see that file.
+  // Composition: the SELF-CLAIM-WINDOW fetchFleetCriticalCandidates union routes through this classifier,
+  // so a fleet_critical-AND-review-pending SD is correctly surfaced-then-EXCLUDED (the hold wins).
+  if (row.metadata && row.metadata.needs_coordinator_review === true) return 'needs_coordinator_review';
   // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: a CLONE venture's build-tree (orchestrator +
   // children + grandchildren, stamped metadata.test_clone_build_tree=true at creation by
   // lib/eva/lifecycle-sd-bridge.js convertSprintToSDs) is a throwaway test-clone MVP that must never

--- a/tests/unit/needs-coordinator-review-hold.test.js
+++ b/tests/unit/needs-coordinator-review-hold.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-INFRA-NEEDS-COORDINATOR-REVIEW-HOLD-001 (FR-3) — enforce the needs_coordinator_review hold on
+ * BOTH acquisition paths. Non-mocked: the REAL classifyDispatchIneligibility / baselinedCandidateEligible
+ * (self-claim) and assertSdDispatchable (directed) run; only the DB seam is a small in-memory stub.
+ * Removing the gate axis makes these fail (the SD becomes claimable/dispatchable) — anti test-masking.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { classifyDispatchIneligibility, baselinedCandidateEligible } = require('../../lib/fleet/claim-eligibility.cjs');
+const { assertSdDispatchable } = require('../../lib/coordinator/dispatch.cjs');
+
+// Minimal chainable supabase stub: from(t).select().eq().maybeSingle() resolves a single seeded row.
+function makeSb(rowByKey) {
+  return {
+    from() {
+      let key = null;
+      const b = {
+        select() { return b; },
+        eq(_col, val) { key = val; return b; },
+        in() { return b; },
+        async maybeSingle() { return { data: rowByKey[key] || null, error: null }; },
+      };
+      return b;
+    },
+  };
+}
+// A supabase stub whose SD lookup THROWS (transient error) — for the directed-path fail-open assertion.
+function makeThrowingSb() {
+  return { from() { const b = { select() { return b; }, eq() { return b; }, async maybeSingle() { throw new Error('db hiccup'); } }; return b; } };
+}
+
+const reviewPending = (key) => ({ sd_key: key, status: 'draft', sd_type: 'infrastructure', metadata: { needs_coordinator_review: true }, dependencies: [] });
+const cleared = (key) => ({ sd_key: key, status: 'draft', sd_type: 'infrastructure', metadata: { needs_coordinator_review: false }, dependencies: [] });
+
+describe('FR-1: classifyDispatchIneligibility needs_coordinator_review axis', () => {
+  it("returns 'needs_coordinator_review' for a review-pending SD", () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: { needs_coordinator_review: true } })).toBe('needs_coordinator_review');
+  });
+  it('returns null when the flag is false / absent', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: { needs_coordinator_review: false } })).toBeNull();
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: {} })).toBeNull();
+  });
+  it('is strict === true (a string "true" is NOT a hold)', () => {
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: { needs_coordinator_review: 'true' } })).toBeNull();
+  });
+  it('the hold wins even when the SD is fleet_critical (surfaced-then-excluded composition)', () => {
+    // The SELF-CLAIM-WINDOW fix surfaces a fleet_critical SD into the pool, but it still routes through
+    // this classifier — so a fleet_critical + review-pending SD is excluded (the hold wins).
+    expect(classifyDispatchIneligibility({ sd_key: 'SD-X', metadata: { fleet_critical: true, needs_coordinator_review: true } })).toBe('needs_coordinator_review');
+  });
+});
+
+describe('FR-1: self-claim path (baselinedCandidateEligible) excludes a review-pending SD', () => {
+  it('is NOT eligible while review-pending, and becomes eligible once cleared', async () => {
+    const held = await baselinedCandidateEligible(makeSb({ 'SD-HOLD-1': reviewPending('SD-HOLD-1') }), 'SD-HOLD-1', { cwd: process.cwd() });
+    expect(held).toBe(false);
+    const ok = await baselinedCandidateEligible(makeSb({ 'SD-HOLD-1': cleared('SD-HOLD-1') }), 'SD-HOLD-1', { cwd: process.cwd() });
+    expect(ok).toBe(true); // the clear IS the dispatch authorization
+  });
+  it('a fleet_critical + review-pending SD is still excluded on the self-claim path', async () => {
+    const row = { sd_key: 'SD-FC-HOLD', status: 'draft', sd_type: 'infrastructure', metadata: { fleet_critical: true, needs_coordinator_review: true }, dependencies: [] };
+    expect(await baselinedCandidateEligible(makeSb({ 'SD-FC-HOLD': row }), 'SD-FC-HOLD', { cwd: process.cwd() })).toBe(false);
+  });
+});
+
+describe('FR-2: directed-assign path (assertSdDispatchable) refuses a review-pending SD', () => {
+  const assignment = (sdKey) => ({ message_type: 'WORK_ASSIGNMENT', target_sd: sdKey, payload: {} });
+
+  it('throws DISPATCH_SD_REVIEW_PENDING for a review-pending SD', async () => {
+    const sb = makeSb({ 'SD-HOLD-2': reviewPending('SD-HOLD-2') });
+    await expect(assertSdDispatchable(sb, assignment('SD-HOLD-2'), { warn() {}, error() {} }))
+      .rejects.toMatchObject({ code: 'DISPATCH_SD_REVIEW_PENDING' });
+  });
+  it('dispatches normally once the flag is cleared', async () => {
+    const sb = makeSb({ 'SD-HOLD-2': cleared('SD-HOLD-2') });
+    await expect(assertSdDispatchable(sb, assignment('SD-HOLD-2'), { warn() {}, error() {} })).resolves.toBeUndefined();
+  });
+  it('FAILS OPEN on a transient lookup error (never wedges dispatch)', async () => {
+    await expect(assertSdDispatchable(makeThrowingSb(), assignment('SD-HOLD-2'), { warn() {}, error() {} })).resolves.toBeUndefined();
+  });
+  it('does not review-gate a QF (the flag is an SD governance axis)', async () => {
+    const sb = makeSb({ 'QF-20260630-001': { status: 'open' } });
+    await expect(assertSdDispatchable(sb, assignment('QF-20260630-001'), { warn() {}, error() {} })).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
A review-pending SD (`metadata.needs_coordinator_review === true`) must be **un-claimable** until the coordinator clears the flag — the clear **is** the dispatch authorization (no separate approval artifact).

- **FR-1** add a strict-boolean `needs_coordinator_review` axis to `classifyDispatchIneligibility` (`lib/fleet/claim-eligibility.cjs`), next to `co_author_pending`. This is the **shared authoritative gate** the worker **self-claim** path (baselined + draft) and the stale-session-sweep consult. **Composition**: the just-shipped SELF-CLAIM-WINDOW `fetchFleetCriticalCandidates` union routes through this classifier, so a fleet_critical-AND-review-pending SD is **surfaced-then-excluded** (the hold wins).
- **FR-2** the **directed-assign** path (`lib/coordinator/dispatch.cjs` `assertSdDispatchable`) does **not** route through the classifier (terminal + tier only) — per the coordinator review **NOTE 1** it would otherwise **bypass** the hold. Add a mirrored check: extend the SD lookup to select `metadata` and throw `DISPATCH_SD_REVIEW_PENDING` (fail-**closed**); a cleared flag dispatches normally; a transient lookup error still fails **open**; QFs are not review-gated.
- **FR-3** `tests/unit/needs-coordinator-review-hold.test.js` (**10**) — **non-mocked**: the real `classifyDispatchIneligibility` / `baselinedCandidateEligible` (self-claim) and `assertSdDispatchable` (directed) run, only the DB seam is stubbed. Covers the classifier axis (strict `===true`), self-claim exclusion + the fleet_critical surfaced-then-excluded composition, the directed-path refusal + clear + fail-open + QF-exemption. Removing the axis fails the tests.

## Tests
**10 new** + **352 existing** fleet/coordinator/merged-pool tests green; `node --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)