### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-CONSULT-001C): Solomon correctness fixes — sentinel + model-purpose triple-update

### DIFF
--- a/lib/config/model-config.js
+++ b/lib/config/model-config.js
@@ -45,6 +45,7 @@ const MODEL_DEFAULTS = {
     fast: 'claude-haiku-4-5-20251001',
     vision: 'claude-haiku-4-5-20251001',
     reasoning: 'claude-sonnet-4-6',    // Reserved deep-reasoning tier (security/critical)
+    solomon: 'claude-opus-4-8',        // Solomon oracle pin (SD-LEO-INFRA-SOLOMON-CONSULT-001C): Opus 4.8 default, Fable-swappable via CLAUDE_MODEL_SOLOMON. NO Fable dependency.
   },
   google: {
     // COST CONTROL (2026-06-05, SD-LEO-INFRA Gemini cost-reduction):
@@ -82,6 +83,7 @@ const ENV_VARS = {
     fast: 'CLAUDE_MODEL_FAST',
     vision: 'CLAUDE_MODEL_VISION',
     reasoning: 'CLAUDE_MODEL_REASONING',
+    solomon: 'CLAUDE_MODEL_SOLOMON',
   },
   google: {
     default: 'GEMINI_MODEL',
@@ -97,7 +99,7 @@ const ENV_VARS = {
 /**
  * Valid model purposes for validation
  */
-const VALID_PURPOSES = ['validation', 'classification', 'generation', 'fast', 'vision', 'reasoning'];
+const VALID_PURPOSES = ['validation', 'classification', 'generation', 'fast', 'vision', 'reasoning', 'solomon'];
 
 /**
  * Models that do NOT support temperature parameter (only support temperature=1)

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -22,9 +22,10 @@
 const FULL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Documented non-UUID targets that are intentionally allowed. broadcast =
-// coordinator→all; broadcast-coordinator = worker→coordinator. Sentinels
-// short-circuit the live-session lookup (they are not a single session row).
-const SENTINEL_TARGETS = Object.freeze(['broadcast', 'broadcast-coordinator']);
+// coordinator→all; broadcast-coordinator = worker→coordinator; broadcast-solomon =
+// worker/Adam→Solomon consult lane (SD-LEO-INFRA-SOLOMON-CONSULT-001C — inert until
+// SOLOMON_CONSULT_V1). Sentinels short-circuit the live-session lookup (not a single row).
+const SENTINEL_TARGETS = Object.freeze(['broadcast', 'broadcast-coordinator', 'broadcast-solomon']);
 const SENTINEL_SET = new Set(SENTINEL_TARGETS);
 
 /** Pure: true iff s is a full 8-4-4-4-12 hex UUID. */

--- a/tests/unit/solomon-correctness-fixes.test.js
+++ b/tests/unit/solomon-correctness-fixes.test.js
@@ -1,0 +1,79 @@
+/**
+ * solomon-correctness-fixes.test.js — SD-LEO-INFRA-SOLOMON-CONSULT-001C
+ *
+ * Pins the Phase-C round-trip correctness fixes (panel-verified) so a PARTIAL change
+ * cannot pass CI:
+ *   - dispatch.cjs SENTINEL_TARGETS includes 'broadcast-solomon' (else the buffered-ask
+ *     consult path dead-letters via DISPATCH_TARGET_INVALID).
+ *   - model-config.js TRIPLE-update — VALID_PURPOSES + MODEL_DEFAULTS.claude.solomon +
+ *     ENV_VARS.claude.solomon — all three together. A partial update either THROWS on the
+ *     unknown purpose, or silently IGNORES the CLAUDE_MODEL_SOLOMON override.
+ *   - The pin defaults to Opus 4.8 (claude-opus-4-8) with ZERO Fable dependency, and is
+ *     swappable via CLAUDE_MODEL_SOLOMON.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const dispatch = require('../../lib/coordinator/dispatch.cjs');
+const modelConfig = require('../../lib/config/model-config.js');
+
+describe('Phase C — broadcast-solomon sentinel (dispatch.cjs)', () => {
+  it('SENTINEL_TARGETS includes broadcast-solomon', () => {
+    expect(dispatch.SENTINEL_TARGETS).toContain('broadcast-solomon');
+  });
+
+  it('isSentinelTarget recognises broadcast-solomon (when exported)', () => {
+    if (typeof dispatch.isSentinelTarget === 'function') {
+      expect(dispatch.isSentinelTarget('broadcast-solomon')).toBe(true);
+      expect(dispatch.isSentinelTarget('definitely-not-a-sentinel')).toBe(false);
+    }
+  });
+
+  it('no regression — pre-existing sentinels still present', () => {
+    expect(dispatch.SENTINEL_TARGETS).toContain('broadcast');
+    expect(dispatch.SENTINEL_TARGETS).toContain('broadcast-coordinator');
+  });
+});
+
+describe('Phase C — solomon model purpose triple-update (model-config.js)', () => {
+  const { VALID_PURPOSES, MODEL_DEFAULTS, ENV_VARS, getClaudeModel } = modelConfig;
+
+  it('VALID_PURPOSES includes solomon', () => {
+    expect(VALID_PURPOSES).toContain('solomon');
+  });
+
+  it('MODEL_DEFAULTS.claude.solomon is the Opus 4.8 pin (no Fable dependency)', () => {
+    expect(MODEL_DEFAULTS.claude.solomon).toBe('claude-opus-4-8');
+  });
+
+  it('ENV_VARS.claude.solomon is CLAUDE_MODEL_SOLOMON', () => {
+    expect(ENV_VARS.claude.solomon).toBe('CLAUDE_MODEL_SOLOMON');
+  });
+
+  it('getClaudeModel("solomon") does not throw and defaults to Opus 4.8', () => {
+    const origPurpose = process.env.CLAUDE_MODEL_SOLOMON;
+    const origDefault = process.env.CLAUDE_MODEL;
+    delete process.env.CLAUDE_MODEL_SOLOMON;
+    delete process.env.CLAUDE_MODEL; // clear the generic default override too
+    try {
+      expect(() => getClaudeModel('solomon')).not.toThrow();
+      expect(getClaudeModel('solomon')).toBe('claude-opus-4-8');
+    } finally {
+      if (origPurpose !== undefined) process.env.CLAUDE_MODEL_SOLOMON = origPurpose;
+      if (origDefault !== undefined) process.env.CLAUDE_MODEL = origDefault;
+    }
+  });
+
+  it('getClaudeModel("solomon") honours CLAUDE_MODEL_SOLOMON (proves ENV_VARS wiring, not just MODEL_DEFAULTS)', () => {
+    const origPurpose = process.env.CLAUDE_MODEL_SOLOMON;
+    process.env.CLAUDE_MODEL_SOLOMON = 'claude-fable-5-when-cleared';
+    try {
+      expect(getClaudeModel('solomon')).toBe('claude-fable-5-when-cleared');
+    } finally {
+      if (origPurpose === undefined) delete process.env.CLAUDE_MODEL_SOLOMON;
+      else process.env.CLAUDE_MODEL_SOLOMON = origPurpose;
+    }
+  });
+});


### PR DESCRIPTION
## Phase C of the Solomon oracle build (parent SD-LEO-INFRA-SOLOMON-CONSULT-001)

The round-trip correctness fixes (panel-verified). **Live but inert** — no Solomon code calls these until Phases D/E; no behavior change today.

- `lib/coordinator/dispatch.cjs` — add `broadcast-solomon` to the frozen `SENTINEL_TARGETS` (else the buffered-ask consult path dead-letters via `DISPATCH_TARGET_INVALID`).
- `lib/config/model-config.js` — the **triple-update** (all three together): `VALID_PURPOSES += 'solomon'`; `MODEL_DEFAULTS.claude.solomon = 'claude-opus-4-8'` (Opus 4.8 pin, **no Fable dependency**); `ENV_VARS.claude.solomon = 'CLAUDE_MODEL_SOLOMON'` (Fable-swappable later). A partial update would throw on the unknown purpose or silently ignore the env override.
- `tests/unit/solomon-correctness-fixes.test.js` — 8 tests pinning the sentinel + all three model-config edits so a partial change can't pass CI.

Reply path reuses the existing `adam_advisory` kind — **no new reply kind**. Verified: `getClaudeModel('solomon')` = `claude-opus-4-8`, `CLAUDE_MODEL_SOLOMON` override honored, sentinel present. **60 existing dispatch/model-config tests still pass (zero regression).**

Handoffs: LEAD-TO-PLAN 96 · PLAN-TO-EXEC 98 · PLAN-TO-LEAD 97. TESTING evidence 79f84841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)