### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-CONSULT-001D): Solomon worker consult CLI (flag-gated, dormant)

### DIFF
--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -63,6 +63,7 @@ const PAYLOAD_KINDS = Object.freeze({
   WORK_ASSIGNMENT: 'work_assignment',
   ADAM_ADVISORY: 'adam_advisory',     // SD-...-001-B: Adam advisory clean lane (off friction router)
   CANARY_REQUEST: 'canary_request',   // SD-LEO-INFRA-CANARY-SUPPORT-TRIGGER-RELIABILITY-001: durable Adam canary-verification request (advisory; excluded from the Adam generic inbox drain — owned by the canary responder)
+  SOLOMON_CONSULT: 'solomon_consult', // SD-LEO-INFRA-SOLOMON-CONSULT-001D: worker/Adam→Solomon oracle consult (off friction router; reply travels under adam_advisory+oracle:true; intentionally NOT a DIRECTIVE_KIND)
 });
 
 // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): payload.kind values that are

--- a/scripts/worker-signal.cjs
+++ b/scripts/worker-signal.cjs
@@ -19,6 +19,10 @@ require('dotenv').config();
 const crypto = require('crypto');
 const { createClient } = require('@supabase/supabase-js');
 const { getActiveCoordinatorId, isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
+// SD-LEO-INFRA-SOLOMON-CONSULT-001D: Solomon oracle consult lane (flag-gated, dormant by default).
+const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+const { evaluateSolomonTriage } = require('../lib/coordinator/solomon-triage.cjs');
+const { PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
 
 // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-4): 'unfit' — a worker reporting an assignment it cannot
 // execute HERE/NOW (repo mismatch / closed premise / missing input precondition). Replaces the
@@ -412,12 +416,168 @@ async function requestMain(flags, positional) {
   console.log('  reply:', (result.reply.payload && result.reply.payload.body) || result.reply.body || '(empty)');
 }
 
+// ============================================================================
+// SD-LEO-INFRA-SOLOMON-CONSULT-001D — worker→Solomon oracle consult lane.
+// DORMANT by default behind SOLOMON_CONSULT_V1 (read IN-BODY, never at module
+// scope, so flag-off is byte-identical and tests can toggle it). The consult is
+// counter-gated by the Phase-B triage SSOT (isSolomonEligible) — the worker must
+// have exhausted the cheaper tiers — and the reply travels back under the EXISTING
+// adam_advisory kind (+oracle:true), matched by awaitCoordinatorReply's allowlist.
+// Targets the live Solomon, else buffers to the 'broadcast-solomon' sentinel.
+// ============================================================================
+
+/** In-body flag read (NEVER module scope): dormant unless SOLOMON_CONSULT_V1==='on'. */
+function isSolomonConsultEnabled() {
+  return process.env.SOLOMON_CONSULT_V1 === 'on';
+}
+
+/** Pure + exported: the exact consult payload the worker emits. */
+function buildSolomonConsultPayload({ correlationId, body, senderCallsign, repo, severity, sdKey, triageScore, triageReason }) {
+  const payload = {
+    kind: PAYLOAD_KINDS.SOLOMON_CONSULT,   // 'solomon_consult' (SSOT constant, never a literal)
+    correlation_id: correlationId,
+    expects_reply: true,
+    sender_callsign: senderCallsign || null,
+    repo: repo || null,
+    severity: severity || 'medium',
+    sd_key: sdKey || null,
+    triage_score: (typeof triageScore === 'number') ? triageScore : null,
+    triage_reason: triageReason || null,
+    oracle_consult: true
+  };
+  if (body) payload.body = redact(String(body)).slice(0, BODY_HARD_CAP);
+  // INVARIANT: no signal_type / no intent_action on consult rows (off the friction router + intent sweep).
+  return payload;
+}
+
+// Usage: node scripts/worker-signal.cjs solomon-consult "<packet>" [--severity high]
+//        [--rca-count N] [--tool-attempts N] [--self-resolution-logged] [--type spec-conflict]
+//        [--sd-key SD-XXX] [--await] [--timeout <ms>]
+async function solomonConsultMain(flags, positional) {
+  // FLAG-GATE (in-body): dormant by default — insert NOTHING, byte-identical to today.
+  if (!isSolomonConsultEnabled()) {
+    console.log('Solomon dormant — handle locally (SOLOMON_CONSULT_V1 is off).');
+    process.exit(0);
+  }
+
+  const body = positional.slice(1).join(' ').trim();
+  if (!body) {
+    console.error('ERROR: solomon-consult requires a "<packet>" body.');
+    console.error('Usage: node scripts/worker-signal.cjs solomon-consult "<packet>" [--severity high] [--rca-count N] [--tool-attempts N] [--self-resolution-logged] [--type spec-conflict] [--await]');
+    process.exit(2);
+  }
+
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!sessionId) {
+    console.error('ERROR: CLAUDE_SESSION_ID env var required (set by SessionStart hook).');
+    process.exit(1);
+  }
+
+  // TRIAGE GATE (Phase-B SSOT): counter-gated eligibility. The worker supplies its
+  // ladder evidence via flags (it has already exhausted local reasoning + rca-agent).
+  const state = {
+    rcaCount: Number(flags['rca-count']) || 0,
+    toolAttempts: Number(flags['tool-attempts']) || 0,
+    selfResolutionAttemptLogged: flags['self-resolution-logged'] === true || flags['self-resolution-logged'] === 'true',
+  };
+  const context = { type: flags.type || undefined };
+  const signature = flags.signature || `${flags.type || 'consult'}:${sessionId}`;
+  const triage = evaluateSolomonTriage(signature, state, context);
+  if (!triage.eligible) {
+    // Not an error — the cognitive ladder simply is not exhausted yet.
+    console.log(`Not eligible for Solomon — continue the ladder / handle locally: ${triage.reason}`);
+    console.log(`  triage_score: ${triage.triage_score}`);
+    process.exit(0);
+  }
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+
+  // Resolve the live Solomon, else buffer to the sentinel (drained on /solomon register).
+  let solomonId = null;
+  try { solomonId = await getActiveSolomonId(supabase); } catch { solomonId = null; }
+  const target = solomonId || 'broadcast-solomon';
+
+  let senderCallsign = null;
+  try {
+    const { data: senderRow } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    senderCallsign = senderRow?.metadata?.fleet_identity?.callsign || null;
+  } catch { /* best-effort */ }
+
+  const correlationId = crypto.randomUUID();
+  const timeoutMs = Number(flags.timeout) > 0 ? Number(flags.timeout) : REQUEST_DEFAULT_TIMEOUT_MS;
+  const payload = buildSolomonConsultPayload({
+    correlationId, body, senderCallsign, repo: process.cwd(),
+    severity: flags.severity, sdKey: flags['sd-key'],
+    triageScore: triage.triage_score, triageReason: triage.reason
+  });
+  const subject = `[SOLOMON_CONSULT] ${payload.body.slice(0, 80)}`;
+  const expiresAt = new Date(Date.now() + timeoutMs + 5 * 60_000).toISOString();
+
+  const { error: insErr } = await supabase
+    .from('session_coordination')
+    .insert({
+      sender_session: sessionId,
+      sender_type: 'worker',
+      target_session: target,
+      message_type: 'INFO',
+      subject,
+      body: payload.body,
+      payload,
+      expires_at: expiresAt
+    });
+  if (insErr) {
+    console.error('ERROR: failed to insert solomon-consult:', insErr.message);
+    process.exit(1);
+  }
+
+  console.log('✓ Solomon consult sent (oracle is propose-only; you remain the actor)');
+  console.log('  correlation_id:', correlationId);
+  console.log('  target:', target);
+  console.log('  triage_score:', triage.triage_score);
+
+  // Fire-and-forget by default (the worker keeps working, drains the reply later).
+  // --await opts into a synchronous wait. The reply arrives under adam_advisory+oracle:true,
+  // which awaitCoordinatorReply's allowlist already accepts.
+  if (!flags.await) {
+    console.log('  (fire-and-forget — drain the reply later; pass --await to block.)');
+    process.exit(0);
+  }
+  const result = await awaitCoordinatorReply(supabase, { sessionId, correlationId, timeoutMs });
+  if (result.timedOut) {
+    console.log('⌛ No oracle reply within timeout; it will arrive later as an adam_advisory (oracle:true) row.');
+    process.exit(0);
+  }
+  try {
+    await supabase
+      .from('session_coordination')
+      .update({ read_at: new Date().toISOString(), acknowledged_at: new Date().toISOString() })
+      .eq('id', result.reply.id);
+  } catch { /* best-effort */ }
+  console.log('✓ Oracle reply received');
+  console.log('  reply:', (result.reply.payload && result.reply.payload.body) || result.reply.body || '(empty)');
+}
+
 async function main() {
   const { flags, positional } = parseArgs(process.argv);
 
   // FR-1: route the `intent` subcommand before the legacy signal path.
   if (positional[0] === 'intent') {
     return intentMain(flags, positional);
+  }
+
+  // SD-LEO-INFRA-SOLOMON-CONSULT-001D: route the `solomon-consult` subcommand (flag-gated dormant).
+  if (positional[0] === 'solomon-consult') {
+    return solomonConsultMain(flags, positional);
   }
 
   // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-7: route the `request` subcommand
@@ -551,7 +711,9 @@ module.exports = {
   // FR-1 (SD-FDBK-INFRA-CROSS-SESSION-CONFLICTION-001)
   INTENT_ACTIONS, INTENT_PAYLOAD_KEYS, buildIntentPayload, DECONFLICTION_ENABLED,
   // FR-7 (SD-LEO-INFRA-COMPLETE-TWO-WAY-001) — request/await round-trip
-  buildRequestPayload, awaitCoordinatorReply, REQUEST_DEFAULT_TIMEOUT_MS, REQUEST_DEFAULT_POLL_MS
+  buildRequestPayload, awaitCoordinatorReply, REQUEST_DEFAULT_TIMEOUT_MS, REQUEST_DEFAULT_POLL_MS,
+  // SD-LEO-INFRA-SOLOMON-CONSULT-001D — Solomon oracle consult lane (flag-gated dormant)
+  isSolomonConsultEnabled, buildSolomonConsultPayload, solomonConsultMain
 };
 
 if (require.main === module) {

--- a/tests/unit/worker-signal-solomon-consult.test.js
+++ b/tests/unit/worker-signal-solomon-consult.test.js
@@ -1,0 +1,109 @@
+/**
+ * worker-signal-solomon-consult.test.js — SD-LEO-INFRA-SOLOMON-CONSULT-001D
+ *
+ * Pins the Phase-D worker→Solomon consult lane:
+ *   - BYTE-IDENTICAL FLAG-OFF: with SOLOMON_CONSULT_V1 unset, the subcommand prints the
+ *     dormant message and exits 0 WITHOUT touching the DB (it short-circuits before reading
+ *     SUPABASE creds / creating a client — proven by exiting cleanly with NO supabase env).
+ *   - in-body flag read (isSolomonConsultEnabled toggles with process.env).
+ *   - payload shape: kind === PAYLOAD_KINDS.SOLOMON_CONSULT (SSOT constant, not a literal),
+ *     oracle_consult:true, body redacted+capped, NO signal_type / NO intent_action.
+ *   - source uses the PAYLOAD_KINDS.SOLOMON_CONSULT constant, never a bare string literal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '../../scripts/worker-signal.cjs');
+
+const ws = require('../../scripts/worker-signal.cjs');
+const { PAYLOAD_KINDS } = require('../../lib/fleet/worker-status.cjs');
+
+describe('Phase D — PAYLOAD_KINDS.SOLOMON_CONSULT SSOT', () => {
+  it('PAYLOAD_KINDS.SOLOMON_CONSULT === "solomon_consult"', () => {
+    expect(PAYLOAD_KINDS.SOLOMON_CONSULT).toBe('solomon_consult');
+  });
+
+  it('SOLOMON_CONSULT is NOT in DIRECTIVE_KINDS (it is a consult, not a directive)', () => {
+    const { DIRECTIVE_KINDS } = require('../../lib/fleet/worker-status.cjs');
+    expect(DIRECTIVE_KINDS).not.toContain('solomon_consult');
+  });
+});
+
+describe('Phase D — isSolomonConsultEnabled (in-body flag read)', () => {
+  it('reflects SOLOMON_CONSULT_V1 at call time', () => {
+    const orig = process.env.SOLOMON_CONSULT_V1;
+    try {
+      process.env.SOLOMON_CONSULT_V1 = 'on';
+      expect(ws.isSolomonConsultEnabled()).toBe(true);
+      process.env.SOLOMON_CONSULT_V1 = 'off';
+      expect(ws.isSolomonConsultEnabled()).toBe(false);
+      delete process.env.SOLOMON_CONSULT_V1;
+      expect(ws.isSolomonConsultEnabled()).toBe(false);
+    } finally {
+      if (orig === undefined) delete process.env.SOLOMON_CONSULT_V1;
+      else process.env.SOLOMON_CONSULT_V1 = orig;
+    }
+  });
+});
+
+describe('Phase D — buildSolomonConsultPayload shape', () => {
+  it('kind is the PAYLOAD_KINDS.SOLOMON_CONSULT constant', () => {
+    const p = ws.buildSolomonConsultPayload({ correlationId: 'c1', body: 'hello' });
+    expect(p.kind).toBe(PAYLOAD_KINDS.SOLOMON_CONSULT);
+    expect(p.kind).toBe('solomon_consult');
+  });
+
+  it('sets oracle_consult:true, expects_reply, and carries triage fields', () => {
+    const p = ws.buildSolomonConsultPayload({ correlationId: 'c1', body: 'x', triageScore: 90, triageReason: 'rca>=2' });
+    expect(p.oracle_consult).toBe(true);
+    expect(p.expects_reply).toBe(true);
+    expect(p.triage_score).toBe(90);
+    expect(p.triage_reason).toBe('rca>=2');
+  });
+
+  it('carries NO signal_type and NO intent_action (off the friction router + intent sweep)', () => {
+    const p = ws.buildSolomonConsultPayload({ correlationId: 'c1', body: 'x' });
+    expect(p.signal_type).toBeUndefined();
+    expect(p.intent_action).toBeUndefined();
+  });
+
+  it('caps the body at BODY_HARD_CAP after redaction', () => {
+    const big = 'a'.repeat(ws.BODY_HARD_CAP + 500);
+    const p = ws.buildSolomonConsultPayload({ correlationId: 'c1', body: big });
+    expect(p.body.length).toBe(ws.BODY_HARD_CAP);
+  });
+});
+
+describe('Phase D — BYTE-IDENTICAL flag-off inertness (subprocess)', () => {
+  it('flag OFF: prints the dormant message, exits 0, and never touches the DB (no SUPABASE env needed)', () => {
+    // Deliberately run WITHOUT SUPABASE creds: if the flag-gate did not short-circuit first,
+    // the command would proceed to createClient and behave differently. Exiting 0 with the
+    // dormant message and no supabase env proves the branch is inert before any DB access.
+    const env = { ...process.env };
+    delete env.SOLOMON_CONSULT_V1;
+    delete env.SUPABASE_URL;
+    delete env.NEXT_PUBLIC_SUPABASE_URL;
+    delete env.SUPABASE_SERVICE_ROLE_KEY;
+    env.CLAUDE_SESSION_ID = 'test-session-flagoff';
+
+    let stdout = '';
+    let code = 0;
+    try {
+      stdout = execFileSync('node', [SCRIPT, 'solomon-consult', 'inert smoke packet'], {
+        env, encoding: 'utf8', timeout: 30000
+      });
+    } catch (e) {
+      code = e.status != null ? e.status : 1;
+      stdout = (e.stdout || '') + (e.stderr || '');
+    }
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/Solomon dormant/i);
+  });
+});


### PR DESCRIPTION
## Phase D of the Solomon oracle build (parent SD-LEO-INFRA-SOLOMON-CONSULT-001)

Worker→Solomon consult lane. **Ships dormant** behind `SOLOMON_CONSULT_V1` (read **in-body**, never module scope → flag-off byte-identical; tests can toggle).

- `scripts/worker-signal.cjs` — `solomon-consult` subcommand. Counter-gated by the Phase-B triage SSOT (`evaluateSolomonTriage`); targets `getActiveSolomonId() || 'broadcast-solomon'`; reuses `redact`/`BODY_HARD_CAP`/`awaitCoordinatorReply`. Reply travels under the **existing `adam_advisory` kind (+`oracle:true`)** — matched by the unchanged allowlist; **no new reply kind**. Fire-and-forget default, `--await` opt-in.
- `lib/fleet/worker-status.cjs` — `PAYLOAD_KINDS.SOLOMON_CONSULT = 'solomon_consult'` (SSOT discriminator; intentionally **not** a `DIRECTIVE_KIND`).
- `tests/unit/worker-signal-solomon-consult.test.js` — 8 tests. The flag-off **subprocess** test runs the CLI with `SOLOMON_CONSULT_V1` unset AND no SUPABASE env → exits 0 with the dormant message, proving the branch short-circuits before any DB access.

**70 existing worker-signal/worker-status/coord-adam tests still pass (zero regression).**

Handoffs: LEAD-TO-PLAN 95 · PLAN-TO-EXEC 98 · PLAN-TO-LEAD 97. TESTING evidence c0611d93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)