### PR TITLE
fix(SD-LEO-INFRA-CONVERGENCE-DUMMYKIND-CHECK-DIVERGENCE-001): pass dummy_kind='non_clone' to convergence ledger startRun

### DIFF
--- a/lib/eva/clean-clone/convergence-sandbox.js
+++ b/lib/eva/clean-clone/convergence-sandbox.js
@@ -66,7 +66,7 @@ export async function provisionSandboxRepo(params = {}, deps = {}) {
   // Record the sandbox repo identity on the convergence ledger so deterministic teardown can find it.
   let runId;
   if (supabase) {
-    const started = await startRun(supabase, { subject_venture_id: ventureId, dummy_kind: 'convergence_subject', sandbox_repo: slug });
+    const started = await startRun(supabase, { subject_venture_id: ventureId, dummy_kind: 'non_clone', sandbox_repo: slug });
     runId = started.run_id;
   }
   return { ok: true, stage: 'provisioned', dryRun: false, slug, runId };

--- a/tests/unit/eva/convergence-sandbox.test.js
+++ b/tests/unit/eva/convergence-sandbox.test.js
@@ -48,6 +48,18 @@ describe('FR-1: provisionSandboxRepo', () => {
     expect(calls.inserted[0].sandbox_repo).toBe('rickfelix/conv-sandbox-1'); // ledger recorded
   });
 
+  it('FR-3 (SD-LEO-INFRA-CONVERGENCE-DUMMYKIND-CHECK-DIVERGENCE-001): ledger startRun receives dummy_kind non_clone, not convergence_subject', async () => {
+    const run = vi.fn(() => '');
+    const { sb, calls } = makeLedgerStub();
+    await provisionSandboxRepo(
+      { ventureId: 'v-2', repoName: 'rickfelix/conv-dummykind-test', dryRun: false },
+      { run, log: silent, supabase: sb }
+    );
+    const inserted = calls.inserted[0];
+    expect(inserted.dummy_kind).toBe('non_clone');
+    expect(inserted.dummy_kind).not.toBe('convergence_subject');
+  });
+
   it('refuses an invalid/unsafe slug WITHOUT invoking run', async () => {
     const run = vi.fn(() => '');
     const r = await provisionSandboxRepo({ repoName: 'not a/valid slug; rm -rf', dryRun: false }, { run, log: silent });


### PR DESCRIPTION
## Summary

- **Root cause**: `convergence-sandbox.js` was passing `dummy_kind='convergence_subject'` to `startRun()`, violating the `convergence_ledger_runs` CHECK constraint (`dummy_kind IN ('non_clone','clone')` or NULL). Every sandbox run insert was silently rejected, leaving `run_id` undefined.
- **Fix**: Changed the single caller to pass `dummy_kind='non_clone'` (1 LOC change).
- **Test**: Added FR-3 unit test asserting `startRun` receives `dummy_kind='non_clone'` (not `'convergence_subject'`).

## Changes

- `lib/eva/clean-clone/convergence-sandbox.js`: 1-LOC fix
- `tests/unit/eva/convergence-sandbox.test.js`: +11 LOC (FR-3 test)

## Test plan

- [x] `npx vitest run tests/unit/eva/convergence-sandbox.test.js` — 11/11 pass
- [x] Full unit suite — 18,408 pass; 6 pre-existing failures unrelated to this change
- [x] FR-2 audit: `startRun()` has only one call site (this file); no other invalid dummy_kind values
- [x] VALIDATION sub-agent: 4/4 acceptance criteria PASS
- [x] REGRESSION sub-agent: 0 regressions; API signatures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)