### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-CONSULT-001F): Solomon docs, dashboard PENDING_SOLOMON, chairman-gated flip-prep

### DIFF
--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 363d88b8419e9305 -->
+<!-- file_content_hash: 6433a25fb3e9f0e7 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-28 10:59:48 PM
+**Generated**: 2026-06-30 2:22:05 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1470,6 +1470,34 @@ Workers signal mid-execution friction back to the active coordinator via session
 
 **How to send:** `/signal <type> "<body>"` slash command — see /signal --help. Or directly: `node scripts/worker-signal.cjs <type> "<body>"`. Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. SD-LEO-INFRA-TWO-WAY-COORDINATOR-001.
 
+## Solomon Consultation Protocol
+
+**Solomon Consultation Protocol** — the deep-reasoning oracle on the cognitive ladder.
+
+> Discoverability: when local reasoning AND the rca-agent are exhausted on a genuinely hard
+> *cognitive* problem, escalate to **Solomon** (the propose-only deep-reasoning oracle) — do not
+> spin. Solomon advises; you remain the actor. **Dormant by default** behind `SOLOMON_CONSULT_V1`
+> (flag-off = byte-identical; the flip is chairman-only).
+
+**Cognitive escalation ladder:** local reasoning → rca-agent → **Solomon** → Chairman.
+Solomon sits between Canonical Pause Point #3 (RCA after 2 retries) and human escalation.
+
+**How to consult** (flag-gated, dormant until `SOLOMON_CONSULT_V1=on`):
+```bash
+node scripts/worker-signal.cjs solomon-consult "<packet>" --severity high \
+  --rca-count <N> --tool-attempts <N> [--type spec-conflict] [--await]
+```
+Counter-gated by the triage SSOT (`lib/coordinator/solomon-triage.cjs` `isSolomonEligible`): eligible
+only when rca-agent ran ≥2× OR a gate failed ≥3× (Pause-Point-#3 exhausted), or a first-encounter
+spec-conflict/arch-ambiguity WITH a logged self-resolution attempt. Flag OFF → prints
+"Solomon dormant — handle locally" and inserts nothing. The reply returns under the existing
+`adam_advisory` kind (+`oracle:true`). Solomon is propose-only: it NEVER claims, edits, gates, or sources.
+
+**Observe pending consults:** `node scripts/fleet-dashboard.cjs solomon` (PENDING SOLOMON CONSULTS).
+**Model:** Opus 4.8 (`claude-opus-4-8`) at high effort; no Fable dependency (Fable-swappable later).
+**Activation:** chairman-gated, graduated (Mode A reactive consults, then Mode B sweeps) —
+see `docs/architecture/solomon-activation-runbook.md`.
+
 ## Strategic Governance Hierarchy
 
 The EHG platform operates under a 7-layer strategic governance stack. Each layer has a database table, CLI command, and clear purpose.
@@ -1680,7 +1708,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-28*
+*Generated from database: 2026-06-30*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/docs/architecture/solomon-activation-runbook.md
+++ b/docs/architecture/solomon-activation-runbook.md
@@ -1,0 +1,95 @@
+<!-- SD-LEO-INFRA-SOLOMON-CONSULT-001F (Phase F — docs / dashboard / chairman-gated flip-prep).
+     This runbook PREPARES Solomon's activation. It does NOT flip SOLOMON_CONSULT_V1 — the flip is
+     a chairman-only action (see "The flip is chairman-only" below). Companion specs:
+     docs/architecture/solomon-oracle.md §8 (staged-activation) and
+     docs/architecture/solomon-agent-definition.md §10–11 (degradation / success metrics). -->
+
+# Solomon Activation Runbook (chairman-gated, graduated)
+
+**Status:** flip-prep. Solomon ships **DORMANT** behind `SOLOMON_CONSULT_V1` (default OFF). Everything
+A–F is built and inert; nothing claims, fires, or spends tokens until the Chairman flips the flag.
+This runbook is the readiness checklist + the staged-activation sequence the Chairman follows when
+ready. **Running this build does NOT activate Solomon.**
+
+> **Model:** Solomon runs on **Opus 4.8** (`claude-opus-4-8`) at high effort / ultracode by default —
+> there is **no Fable dependency**. The model is a swappable config pin
+> (`MODEL_DEFAULTS.claude.solomon` / `CLAUDE_MODEL_SOLOMON`); swap to a Fable id later only if/when
+> Fable clears restriction and the cost/capability justifies it for the deepest duties.
+
+---
+
+## 0. The flip is chairman-only
+
+`SOLOMON_CONSULT_V1=on` is a **Chairman action**, never performed by any build SD (including this one)
+or by any worker/coordinator. Flag-off is byte-identical to today. Until the flip:
+
+- `worker-signal.cjs solomon-consult` prints `Solomon dormant — handle locally` and inserts nothing.
+- No `solomon_consult` rows are ever written, so the dashboard `PENDING SOLOMON CONSULTS` surface
+  (this SD) renders `(no pending Solomon consults)`.
+- The triage gate short-circuits to "no oracle"; consults fall through to RCA + asker judgment.
+
+## 1. Pre-flip readiness checklist
+
+Confirm ALL before the first flip:
+
+- [ ] Children A–F all `status='completed'` (foundation, triage SSOT, correctness fixes, worker CLI,
+      the Solomon session E, and this docs/dashboard/flip-prep F).
+- [ ] The atomic flag migration `set_solomon_flag` / `clear_solomon_flag` (Child A) is **applied**
+      (it is Tier-2 chairman-gated — `node scripts/apply-migration.js <path> --prod-deploy`; the JS
+      register fail-softs until then).
+- [ ] `node -e "require('./lib/config/model-config.js').getClaudeModel('solomon')"` → `claude-opus-4-8`.
+- [ ] `CLAUDE_SOLOMON.md` + `CLAUDE_SOLOMON_DIGEST.md` regenerate cleanly from the seeded
+      `solomon_role_contract` section (`node scripts/generate-claude-md-from-db.js`).
+- [ ] `'broadcast-solomon'` is in `dispatch.cjs SENTINEL_TARGETS`; `solomon-advisory.cjs inbox` is in
+      `retry-state-manager.cjs EXEMPT_PATTERNS`.
+- [ ] Max-plan auth confirmed for the Solomon session (`/status` shows the subscription, NOT the
+      `ANTHROPIC_API_KEY`) — otherwise Opus usage bills as pay-as-you-go API.
+
+## 2. Launch the standing session
+
+1. Set the pin: `CLAUDE_MODEL_SOLOMON=claude-opus-4-8` (default).
+2. `claude --model claude-opus-4-8` → run `/solomon` (reads `CLAUDE_SOLOMON.md`, registers via
+   `solomon:register`, arms the inbox-monitor + self-adherence ticks).
+3. Verify the singleton: exactly one live `role='solomon'` session (`getActiveSolomonId`).
+
+## 3. Graduated activation — "canary the canary"
+
+Do **not** switch fully on. Stage it, watching the advice-outcome ledger + accuracy review
+(agent-definition §11) between stages:
+
+| Stage | Flag action (Chairman) | What it enables | Gate to advance |
+|------|------------------------|-----------------|-----------------|
+| **A** | `SOLOMON_CONSULT_V1=on` | **Mode A only** — reactive consults (workers/Adam `solomon-consult`); Mode B stays gated | Mode-A advice demonstrably trusted + correct (uptake + accuracy hold) |
+| **B** | enable Mode-B sweeps | proactive backlog deep-sweeps — still quota- and `task_budget`-bounded | both modes stable |
+| **C** | `ADAM_SOLOMON_TWOWAY_V1=on` | the Adam↔Solomon two-way channel (`-G`, ship-dormant follow-on) | — |
+
+**Observe activation on the dashboard:** `node scripts/fleet-dashboard.cjs solomon` (or the `all`
+view) renders `PENDING SOLOMON CONSULTS` — pending, un-actioned consults targeted at the live Solomon
+or the `broadcast-solomon` buffer. The surface is **pure-read** (it never stamps `read_at`, so it
+cannot hide a consult from the oracle's own `solomon-advisory.cjs inbox` drain).
+
+## 4. Degradation (Solomon is advisory, never a critical path)
+
+- **Opus 4.8 available:** Solomon runs normally.
+- **A Fable swap requested but Fable unavailable:** the pin stays on Opus 4.8 — only the few duties
+  that *want* Fable depth run at Opus depth. A graceful quality degradation on a subset, never an
+  outage.
+- **`SOLOMON_CONSULT_V1` OFF (default):** no Solomon session; the triage gate short-circuits to
+  "no oracle"; consults resolve at RCA + asker judgment. Nothing blocks (Solomon never gates).
+- **Gated on but session down:** consults emit an "oracle unavailable — proceed on best reasoning"
+  marker and route past Solomon.
+
+**Governing invariant:** Solomon improves outcomes when present and is invisible when absent. No part
+of the harness takes a hard dependency on Solomon's advice.
+
+## 5. Rollback
+
+Flip `SOLOMON_CONSULT_V1=off`. Mode B never runs while dormant; in-flight consults fall through to the
+next-best resolution. No data migration to undo (the flag is the entire kill switch).
+
+## 6. Success metrics (keep / expand / kill — agent-definition §11)
+
+advice-uptake (`applied`/total) · advice-accuracy (`worked`/`applied`) · systemic yield (findings that
+became shipped fixes) · escalations-avoided (resolved at the Solomon rung that would have reached the
+Chairman) · cost-per-accepted-proposal. A cluster consistently declined/inaccurate or with
+unjustifiable cost-per-accepted-proposal is a candidate to drop — Solomon earns scope empirically.

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1275,6 +1275,81 @@ async function printAdamInbox() {
   console.log('');
 }
 
+// ── Section: PENDING SOLOMON CONSULTS (SD-LEO-INFRA-SOLOMON-CONSULT-001F) ──
+// Read-only dashboard surface for the Solomon oracle consult lane
+// (payload.kind='solomon_consult'). Mirrors printAdamInbox's intent but is
+// deliberately PURE-READ — it does NOT stamp read_at. Why: solomon-advisory.cjs
+// drainInbox filters on `read_at IS NULL` and stamps read_at on delivery, so a
+// dashboard render that stamped read_at would HIDE an unactioned consult from the
+// oracle's own inbox drain (the parked-render-hides-consult bug class the Adam lane
+// fixed by gating re-surfacing on actioned state, not read_at). We therefore gate
+// on `acknowledged_at IS NULL` (the ACTIONED signal — a consult is retired only when
+// the oracle answers it) so this view shows genuinely-pending consults regardless of
+// delivery, and never perturbs the oracle's drain. Dormant-safe: when
+// SOLOMON_CONSULT_V1 is off no solomon_consult rows are ever written, so this renders
+// "(no pending Solomon consults)" silently.
+async function printSolomonInbox() {
+  console.log('PENDING SOLOMON CONSULTS');
+  console.log('─'.repeat(72));
+
+  let solomonId = null;
+  try {
+    const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+    solomonId = await getActiveSolomonId(supabase);
+  } catch { solomonId = null; } // fail-open: identity resolver unavailable → buffer view only
+
+  // Consults target the live Solomon when one is registered, else buffer to the
+  // 'broadcast-solomon' sentinel (drained on /solomon register). Surface both.
+  const targets = ['broadcast-solomon'];
+  if (solomonId) targets.push(solomonId);
+
+  let rows = [];
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id, payload, body, sender_session, created_at')
+      .in('target_session', targets)
+      .eq('message_type', 'INFO')
+      .is('acknowledged_at', null) // pending = not yet actioned/answered (survives the read_at stamp)
+      .order('created_at', { ascending: false })
+      .limit(50);
+    if (error) {
+      console.log('  (solomon consult query failed: ' + error.message + ')');
+      console.log('');
+      return;
+    }
+    // payload.kind discriminates the consult lane from any other broadcast-solomon row.
+    rows = (data || []).filter((r) => r.payload && r.payload.kind === 'solomon_consult');
+  } catch (e) {
+    console.log('  (solomon consult query failed: ' + (e && e.message ? e.message : e) + ')');
+    console.log('');
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log('  (no pending Solomon consults)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + rows.length + ' pending consult(s)' +
+    (solomonId ? '' : ' — no live Solomon (buffered to broadcast-solomon, drains on /solomon register)'));
+  console.log('');
+  console.log('  ' + pad('Callsign', 12) + pad('Severity', 10) + pad('Age', 8) + 'Body');
+  console.log('  ' + '─'.repeat(68));
+
+  for (const r of rows) {
+    const callsign = r.payload?.sender_callsign || '(none)';
+    const severity = r.payload?.severity || 'medium';
+    const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    const bodyPreview = (r.body || r.payload?.body || '').replace(/\n/g, ' ').substring(0, 32);
+    console.log('  ' + pad(callsign, 12) + pad(severity, 10) + pad(ageStr, 8) + bodyPreview);
+  }
+  // PURE READ — intentionally no read_at/acknowledged_at mutation here (see header).
+  console.log('');
+}
+
 // ── Section: Working context (FR-3, SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001) ──
 // Dual-render of both operators' standing working_context (claude_sessions.metadata.working_context)
 // so neither Adam nor the coordinator mistakes the other's heads-down silence for being ignored.
@@ -1511,6 +1586,7 @@ async function main() {
       await printAdamInbox();
     },
     adam:          async () => await printAdamInbox(), // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B
+    solomon:       async () => await printSolomonInbox(), // SD-LEO-INFRA-SOLOMON-CONSULT-001F — Solomon oracle consult lane
     context:       async () => await printWorkingContext(), // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3)
     feedback:      async () => await printFeedback(d), // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001
     team:          () => printTeam(d), // SD-MULTISESSION-EXECUTION-TEAM-COMMAND-ORCH-001-B
@@ -1528,6 +1604,7 @@ async function main() {
       await printUndeliveredOutbound(); // FR-2 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
+      await printSolomonInbox(); // SD-LEO-INFRA-SOLOMON-CONSULT-001F — Solomon oracle consult lane (dormant until SOLOMON_CONSULT_V1)
       await printWorkingContext(); // SD-LEO-INFRA-ADAM-COORDINATOR-INTERFACE-001 (FR-3) — standing context dual-render
       await printFeedback(d); // SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001 — feedback work-store
       await printCoaching(d);
@@ -1541,7 +1618,7 @@ async function main() {
   const fn = sections[section];
   if (!fn) {
     console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
-    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, context, feedback, team, all');
+    console.log('Sections: workers, orchestrator, available, quickfixes, coordination, coaching, health, qa, forecast, predictions, inbox, adam, solomon, context, feedback, team, all');
     process.exit(1);
   }
 

--- a/tests/unit/fleet-dashboard-solomon-inbox.test.js
+++ b/tests/unit/fleet-dashboard-solomon-inbox.test.js
@@ -1,0 +1,78 @@
+/**
+ * fleet-dashboard-solomon-inbox.test.js — SD-LEO-INFRA-SOLOMON-CONSULT-001F
+ *
+ * Source-level pins for the PENDING SOLOMON CONSULTS dashboard surface. Network-free
+ * (no supabase client, no DB) — it reads the script source and asserts the structural
+ * + correctness invariants so a future edit can't silently regress them:
+ *   - printSolomonInbox exists and is wired into the `all` view, a `solomon` command,
+ *     and the usage list.
+ *   - It gates on `acknowledged_at IS NULL` (the ACTIONED signal), NOT read_at.
+ *   - It is PURE-READ: the function body never stamps read_at/acknowledged_at — so a
+ *     dashboard render can NEVER hide an unactioned consult from solomon-advisory.cjs
+ *     drainInbox (which filters on read_at IS NULL). This is the parked-render-hides-
+ *     consult bug class; the test locks the fix in.
+ *   - It discriminates the lane on payload.kind === 'solomon_consult'.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(resolve(__dirname, '../../scripts/fleet-dashboard.cjs'), 'utf8');
+
+// Extract just the printSolomonInbox function body (from its declaration to the next
+// top-level `async function`/`function` declaration) so body-scoped assertions are exact.
+function printSolomonInboxBody() {
+  const start = SRC.indexOf('async function printSolomonInbox(');
+  expect(start).toBeGreaterThan(-1);
+  const rest = SRC.slice(start + 1);
+  const nextFn = rest.search(/\n(?:async function|function) /);
+  return nextFn === -1 ? rest : rest.slice(0, nextFn);
+}
+
+describe('Phase F — printSolomonInbox dashboard surface', () => {
+  it('printSolomonInbox is defined', () => {
+    expect(SRC).toMatch(/async function printSolomonInbox\s*\(/);
+  });
+
+  it('is wired into the `all` view, a `solomon` command, and the usage list', () => {
+    // dedicated command alias
+    expect(SRC).toMatch(/solomon:\s*async \(\) => await printSolomonInbox\(\)/);
+    // present in the `all` aggregate render
+    const allIdx = SRC.indexOf('all:');
+    expect(allIdx).toBeGreaterThan(-1);
+    expect(SRC.indexOf('await printSolomonInbox()', allIdx)).toBeGreaterThan(allIdx);
+    // discoverable in the usage string
+    expect(SRC).toMatch(/Sections:[^\n]*\bsolomon\b/);
+  });
+
+  it('gates pending on acknowledged_at IS NULL (the actioned signal), not read_at', () => {
+    const body = printSolomonInboxBody();
+    expect(body).toMatch(/\.is\(\s*['"]acknowledged_at['"]\s*,\s*null\s*\)/);
+  });
+
+  it('is PURE-READ — never stamps read_at or acknowledged_at (cannot hide a consult from the oracle drain)', () => {
+    const body = printSolomonInboxBody();
+    // No mutation of delivery/ack columns anywhere in the render.
+    expect(body).not.toMatch(/\.update\(\s*\{[^}]*read_at/);
+    expect(body).not.toMatch(/\.update\(\s*\{[^}]*acknowledged_at/);
+    // Blanket guard: a pure-read render has NO reason to upsert/rpc/update at all,
+    // so any write form (not just .update({read_at})) is a regression of the invariant.
+    expect(body).not.toMatch(/\.upsert\(/);
+    expect(body).not.toMatch(/\.rpc\(/);
+    expect(body).not.toMatch(/\.update\(/);
+  });
+
+  it('discriminates the lane on payload.kind === "solomon_consult"', () => {
+    const body = printSolomonInboxBody();
+    expect(body).toMatch(/kind\s*===\s*['"]solomon_consult['"]/);
+  });
+
+  it('resolves the live Solomon and falls back to the broadcast-solomon buffer', () => {
+    const body = printSolomonInboxBody();
+    expect(body).toMatch(/getActiveSolomonId/);
+    expect(body).toMatch(/broadcast-solomon/);
+  });
+});


### PR DESCRIPTION
## Phase F (final child) of the Solomon oracle build (parent SD-LEO-INFRA-SOLOMON-CONSULT-001)

Flip-PREP only — does **NOT** flip `SOLOMON_CONSULT_V1` (chairman-only). Ships dormant.

- `scripts/fleet-dashboard.cjs` — `printSolomonInbox`: read-only **PENDING SOLOMON CONSULTS** surface over `payload.kind='solomon_consult'` (live Solomon | `broadcast-solomon` buffer). **PURE-READ**, gated on `acknowledged_at IS NULL` (not `read_at`) so it can never hide an unactioned consult from `solomon-advisory.cjs` `drainInbox` (which filters `read_at IS NULL`). Wired into the `all` view + a `solomon` command + usage. Fail-open on `getActiveSolomonId`.
- `CLAUDE_CORE.md` — 'Solomon Consultation Protocol' section (cognitive ladder local→rca-agent→Solomon→Chairman; how to consult; dormant note; discoverability). Seeded `leo_protocol_sections` id=612 under the existing `signaling_friction` section_type — **no `section-file-mapping.json` edit** (that file is owned by the E-B PR #5279).
- `docs/architecture/solomon-activation-runbook.md` — chairman-gated graduated-activation runbook (Mode A→B→twoway, readiness, degradation, rollback, metrics).
- `tests/unit/fleet-dashboard-solomon-inbox.test.js` — 6 source-pin tests locking pure-read + the `acknowledged_at` gate + kind filter + dispatch wiring.

Adversarially reviewed (7/7 invariants hold). 19 fleet-dashboard tests pass; db-guards 0 new. Conflict-free with the in-flight #5279 (no shared files). Handoffs: LEAD-TO-PLAN 96 · PLAN-TO-EXEC 99 · PLAN-TO-LEAD 99. TESTING evidence 8e4b0558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)