### PR TITLE
fix(SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001): launchNonCloneDummy defaults to discovery_mode (blueprint_browse needs non-existent blueprints)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SOLOMON-CONSULT-001E-B",
-  "expectedBranch": "feat/SD-LEO-INFRA-SOLOMON-CONSULT-001E-B",
-  "createdAt": "2026-06-30T17:03:51.657Z",
+  "sdKey": "SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001",
+  "createdAt": "2026-06-30T19:43:10.342Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/clean-clone/launch.js
+++ b/lib/eva/clean-clone/launch.js
@@ -30,6 +30,14 @@ export const SEEDED_FROM_VENTURE_PATH = 'seeded_from_venture';
  *  ENTRY_PATHS.BLUEPRINT_BROWSE) used for the NON-CLONE convergence dummy subject — NOT the
  *  seeded-from-venture reseed path, so the created venture has seeded_from_venture_id=NULL. */
 export const BLUEPRINT_BROWSE_PATH = 'blueprint_browse';
+// SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001: the DEFAULT non-clone create path. blueprint_browse
+// requires a curated blueprint to exist (0 do, so create always failed 'No blueprints available');
+// discovery_mode + a strategy generates a from-scratch venture with NO pre-seeded data — the
+// semantically-correct path for a convergence subject that has no curated thesis.
+export const DISCOVERY_MODE_PATH = 'discovery_mode';
+// A from-scratch discovery strategy present in FALLBACK_STRATEGIES (lib/eva/stage-zero/strategy-loader.js),
+// so it works even with no discovery_strategies rows seeded.
+export const DEFAULT_NONCLONE_STRATEGY = 'capability_overhang';
 
 /**
  * Find an existing non-cancelled venture seeded from the source (idempotency).
@@ -172,21 +180,36 @@ export async function launchCleanClone(params = {}, deps = {}) {
  * provide a vision-approval path for the subject (extend the auto-promote to a convergence-subject marker,
  * or approve its L2 vision at creation) BEFORE Phase-A run #1.
  *
- * @param {{ blueprintId?:(string|null), category?:(string|null), dryRun?:boolean }} params
+ * @param {{ path?:string, strategy?:string, blueprintId?:(string|null), category?:(string|null), dryRun?:boolean }} params
+ *   path defaults to discovery_mode (from-scratch, no pre-seeded data); strategy defaults to
+ *   capability_overhang. Pass path=blueprint_browse + blueprintId to use a curated blueprint instead.
  * @param {{ supabase:object, logger?:object, executeStageZero:Function }} deps
  * @returns {Promise<{ ok:boolean, stage:string, dryRun:boolean, stageZero:object, newVentureId:(string|null), venture?:object }>}
  */
 export async function launchNonCloneDummy(params = {}, deps = {}) {
-  const { blueprintId = null, category = null, dryRun = true } = params;
+  const {
+    // SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001: default to discovery_mode + a from-scratch
+    // strategy so a non-clone subject is actually creatable with NO pre-seeded data. blueprint_browse
+    // (which needs a curated blueprint to exist — 0 do) stays reachable via params.path for a caller
+    // that has seeded one.
+    path = DISCOVERY_MODE_PATH,
+    strategy = DEFAULT_NONCLONE_STRATEGY,
+    blueprintId = null,
+    category = null,
+    dryRun = true,
+  } = params;
   const { supabase, logger = console, executeStageZero } = deps;
   if (!supabase) throw new Error('supabase client is required');
   if (typeof executeStageZero !== 'function') throw new Error('executeStageZero dependency is required');
 
-  logger.log(`[NonCloneDummy] ${dryRun ? 'DRY-RUN' : 'LIVE'} create a non-clone convergence subject via the REAL S0 path (${BLUEPRINT_BROWSE_PATH}) — NOT the seeded reseed path`);
+  // Build the path-specific params: discovery_mode generates from-scratch (strategy); blueprint_browse
+  // selects a curated blueprint (blueprintId/category). The discovery default never trips 'No blueprints'.
+  const pathParams = path === BLUEPRINT_BROWSE_PATH ? { blueprintId, category } : { strategy };
+  logger.log(`[NonCloneDummy] ${dryRun ? 'DRY-RUN' : 'LIVE'} create a non-clone convergence subject via the REAL S0 path (${path}${path === DISCOVERY_MODE_PATH ? `, strategy=${strategy}` : ''}) — NOT the seeded reseed path`);
   const stageZero = await executeStageZero(
     {
-      path: BLUEPRINT_BROWSE_PATH,
-      pathParams: { blueprintId, category },
+      path,
+      pathParams,
       options: { nonInteractive: true, dryRun },
     },
     { supabase, logger },

--- a/tests/unit/eva/convergence-non-clone-subject.test.js
+++ b/tests/unit/eva/convergence-non-clone-subject.test.js
@@ -4,7 +4,7 @@
  * surfaced finding that it BLOCKS at the S19 vision_approval gate (the clone auto-promote is clone-only).
  */
 import { describe, it, expect, vi } from 'vitest';
-import { launchNonCloneDummy, BLUEPRINT_BROWSE_PATH, SEEDED_FROM_VENTURE_PATH } from '../../../lib/eva/clean-clone/launch.js';
+import { launchNonCloneDummy, BLUEPRINT_BROWSE_PATH, DISCOVERY_MODE_PATH, DEFAULT_NONCLONE_STRATEGY, SEEDED_FROM_VENTURE_PATH } from '../../../lib/eva/clean-clone/launch.js';
 import { isCloneVenture, isPilotFixtureVenture } from '../../../lib/eva/lifecycle-sd-bridge.js';
 
 const silent = { log() {}, warn() {}, error() {} };
@@ -24,16 +24,43 @@ function makeSb(ventureRow) {
 }
 
 describe('FR-1: launchNonCloneDummy creates via the REAL S0 path (not the reseed path)', () => {
-  it('routes executeStageZero to the blueprint_browse path, NOT seeded_from_venture', async () => {
+  // SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001: the DEFAULT path is now discovery_mode (a real
+  // from-scratch S0 create with NO pre-seeded data), NOT blueprint_browse (which needs a curated
+  // blueprint to exist — 0 do, so the old default always failed 'No blueprints available').
+  it('routes executeStageZero to discovery_mode with a valid strategy by DEFAULT (not blueprint_browse, not seeded)', async () => {
     const executeStageZero = vi.fn(async () => ({ success: true, venture_id: null }));
-    const r = await launchNonCloneDummy({ blueprintId: 'bp-1', dryRun: true }, { supabase: makeSb(null), logger: silent, executeStageZero });
+    const r = await launchNonCloneDummy({ dryRun: true }, { supabase: makeSb(null), logger: silent, executeStageZero });
     expect(executeStageZero).toHaveBeenCalledTimes(1);
     const [arg] = executeStageZero.mock.calls[0];
-    expect(arg.path).toBe(BLUEPRINT_BROWSE_PATH);
-    expect(arg.path).not.toBe(SEEDED_FROM_VENTURE_PATH);
+    expect(arg.path).toBe(DISCOVERY_MODE_PATH);
+    expect(arg.path).not.toBe(BLUEPRINT_BROWSE_PATH);   // the old default that always failed
+    expect(arg.path).not.toBe(SEEDED_FROM_VENTURE_PATH); // not a clone reseed
+    expect(arg.pathParams.strategy).toBe(DEFAULT_NONCLONE_STRATEGY); // a FALLBACK_STRATEGIES value -> no 'No blueprints'
     expect(arg.options.dryRun).toBe(true);
     expect(r.dryRun).toBe(true);
     expect(r.stage).toBe('created');
+  });
+
+  it('the default create produces ok:true on a clean from-scratch create (no pre-seeded data needed)', async () => {
+    // mock executeStageZero as a successful from-scratch discovery create (no "No blueprints available")
+    const executeStageZero = vi.fn(async () => ({ success: true, venture_id: 'v-discovery' }));
+    const sb = makeSb({ seeded_from_venture_id: null, is_demo: false, is_scaffolding: false });
+    const r = await launchNonCloneDummy({ dryRun: false }, { supabase: sb, logger: silent, executeStageZero });
+    expect(r.ok).toBe(true);
+    expect(r.newVentureId).toBe('v-discovery');
+    expect(executeStageZero.mock.calls[0][0].path).toBe(DISCOVERY_MODE_PATH);
+  });
+
+  it('a custom strategy is threaded through; path=blueprint_browse is still reachable for a seeded caller', async () => {
+    const exec1 = vi.fn(async () => ({ success: true, venture_id: null }));
+    await launchNonCloneDummy({ dryRun: true, strategy: 'trend_scanner' }, { supabase: makeSb(null), logger: silent, executeStageZero: exec1 });
+    expect(exec1.mock.calls[0][0].pathParams.strategy).toBe('trend_scanner');
+
+    const exec2 = vi.fn(async () => ({ success: true, venture_id: null }));
+    await launchNonCloneDummy({ dryRun: true, path: BLUEPRINT_BROWSE_PATH, blueprintId: 'bp-1', category: 'saas' }, { supabase: makeSb(null), logger: silent, executeStageZero: exec2 });
+    const [arg2] = exec2.mock.calls[0];
+    expect(arg2.path).toBe(BLUEPRINT_BROWSE_PATH);                 // override still works
+    expect(arg2.pathParams).toEqual({ blueprintId: 'bp-1', category: 'saas' });
   });
 
   it('dry-run does NOT run the non-clone-invariant DB read / persist', async () => {


### PR DESCRIPTION
## Summary
`launchNonCloneDummy` hardcoded `BLUEPRINT_BROWSE_PATH`, but **0 curated blueprints exist**, so a live create always failed `No blueprints available` — the non-clone convergence subject could never be created from scratch. (Defect in the Child-A `launchNonCloneDummy`.)

- **FR-1** default the create path to `discovery_mode` + a from-scratch strategy (`capability_overhang`, a `FALLBACK_STRATEGIES` value that validates with **no** `discovery_strategies` rows seeded). Adds `DISCOVERY_MODE_PATH` + `DEFAULT_NONCLONE_STRATEGY` exports; `params` now take `path` (default discovery_mode) + `strategy` (default capability_overhang); `pathParams` is built per-path. The default produces a working create with **zero pre-seeded data**.
- **FR-2** preserve the non-clone invariant assertion (seeded NULL / demo / scaffolding → ok:false) and the `BLUEPRINT_BROWSE_PATH` export (a seeded caller can still pass `path=blueprint_browse` with `{blueprintId,category}`).
- **FR-3** `tests/unit/eva/convergence-non-clone-subject.test.js`: the default-path test now asserts discovery_mode + a valid strategy (no 'No blueprints'); + a from-scratch `ok:true` guard test; + a strategy-threading / blueprint_browse-override test. **10/10 pass.**

> Decision (per the SD): discovery (idea generation) is the semantically-correct path for a convergence subject with no curated thesis — seeding a dummy blueprint would exercise the wrong path and leave catalog cruft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)