### PR TITLE
fix(SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001): non-clone convergence subject vision activatable at S19

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-NONCLONE-DUMMY-S0-PATH-DISCOVERY-001",
-  "createdAt": "2026-06-30T19:43:10.342Z",
+  "sdKey": "SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001",
+  "createdAt": "2026-06-30T22:49:32.203Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/clean-clone/launch.js
+++ b/lib/eva/clean-clone/launch.js
@@ -108,6 +108,51 @@ export async function setCloneVisionRepairOverride(supabase, ventureId, logger =
   }
 }
 
+// SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001: per-venture eva_venture_config marker
+// identifying a NON-CLONE CONVERGENCE SUBJECT (a real-shaped throwaway created by launchNonCloneDummy).
+// It is the non-clone analogue of seeded_from_venture_id: the S19 auto-approve carve-out
+// (_autoApproveCloneVision) reads it so a convergence subject's quality-passed L2 vision is ACTIVATED on
+// the normal path (a real venture, lacking both this marker AND a clone origin, stays chairman-manual).
+// No migration (reuses eva_venture_config); idempotent; best-effort / non-fatal.
+export const CONVERGENCE_SUBJECT_CONFIG_KEY = (ventureId) => `venture:${ventureId}:convergence_subject`;
+
+export async function setConvergenceSubjectMarker(supabase, ventureId, logger = console) {
+  if (!supabase || !ventureId) return false;
+  const key = CONVERGENCE_SUBJECT_CONFIG_KEY(ventureId);
+  try {
+    const { error } = await supabase
+      .from('eva_venture_config')
+      .upsert({
+        key,
+        value: true,
+        description: 'Marks a non-clone convergence subject (launchNonCloneDummy) as auto-approve-eligible at S19 (SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001).',
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'key' });
+    if (error) throw new Error(error.message);
+    logger.log?.(`[NonCloneDummy] convergence-subject marker set: ${key}=true`);
+    return true;
+  } catch (e) {
+    logger.warn?.(`[NonCloneDummy] convergence-subject marker upsert failed (non-fatal): ${e.message}`);
+    return false;
+  }
+}
+
+/** Read the convergence-subject marker for a venture. Returns true only on an explicit value===true.
+ *  Fail-closed to false on any error (a real venture must never be mistaken for an auto-approvable subject). */
+export async function isConvergenceSubject(supabase, ventureId) {
+  if (!supabase || !ventureId) return false;
+  try {
+    const { data } = await supabase
+      .from('eva_venture_config')
+      .select('value')
+      .eq('key', CONVERGENCE_SUBJECT_CONFIG_KEY(ventureId))
+      .maybeSingle();
+    return data?.value === true;
+  } catch {
+    return false;
+  }
+}
+
 export async function launchCleanClone(params = {}, deps = {}) {
   const {
     sourceVentureId = DEFAULT_SOURCE_VENTURE_ID,
@@ -231,6 +276,14 @@ export async function launchNonCloneDummy(params = {}, deps = {}) {
       return { ok: false, stage: 'verify_non_clone', dryRun, stageZero, newVentureId, venture: v };
     }
     logger.log(`[NonCloneDummy] LIVE non-clone subject created: ${newVentureId} (seeded_from_venture_id=NULL) — the daemon will advance it S0->S19`);
+    // SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001: make the subject's L2 vision ACTIVATABLE on
+    // the normal path. (a) repair-eligibility (mirrors the clone override) so the un-clone-gated S17
+    // repair site populates the subject's sparse vision to >=8/10 sections + quality_checked=true before
+    // S19; (b) the convergence-subject marker so the S19 auto-approve carve-out (_autoApproveCloneVision)
+    // activates the quality-passed vision for this non-clone subject (a real venture stays chairman-manual).
+    // Both are best-effort/non-fatal — a config-write failure logs but does not fail the create.
+    await setCloneVisionRepairOverride(supabase, newVentureId, logger);
+    await setConvergenceSubjectMarker(supabase, newVentureId, logger);
   }
 
   return { ok: stageZero?.success !== false, stage: 'created', dryRun, stageZero, newVentureId };

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -57,6 +57,10 @@ import { canAutoAdvance } from './governance/can-auto-advance.js';
 // quality_checked=true BEFORE the status='active' promote (which trg_enforce_vision_quality_advancement
 // otherwise blocks). Re-uses the existing loop; does NOT re-implement repair.
 import { repairVision, isRepairLoopEnabled } from './vision-repair-loop.js';
+// SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001: a non-clone CONVERGENCE SUBJECT is auto-approve-
+// eligible at S19 (the non-clone analogue of a clone origin) so its quality-passed vision activates on the
+// normal path; a real venture (neither clone nor convergence subject) stays chairman-manual.
+import { isConvergenceSubject } from './clean-clone/launch.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -3451,8 +3455,15 @@ export class StageExecutionWorker {
       const { data: venture } = await this._supabase
         .from('ventures').select('id, seeded_from_venture_id').eq('id', ventureId).maybeSingle();
       if (!venture) return { promoted: false, reason: 'venture_not_found' };
-      // Column-level carve-out: a REAL venture is never auto-approved (chairman-manual preserved).
-      if (!venture.seeded_from_venture_id) return { promoted: false, reason: 'real_venture' };
+      // Carve-out: only an AUTO-APPROVE-ELIGIBLE venture is auto-approved (a REAL venture stays
+      // chairman-manual). Eligible = a CLONE (seeded_from_venture_id) OR a non-clone CONVERGENCE SUBJECT
+      // (SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001 — marked by launchNonCloneDummy). The
+      // convergence-subject read runs ONLY for non-clones (the clone fast-path is unchanged).
+      if (!venture.seeded_from_venture_id) {
+        const convergenceSubject = await isConvergenceSubject(this._supabase, ventureId);
+        if (!convergenceSubject) return { promoted: false, reason: 'real_venture' };
+        this._logger?.log?.(`[Worker] S19: non-clone CONVERGENCE SUBJECT ${ventureId} is auto-approve-eligible (convergence_subject marker) — activating its quality-passed vision on the normal path`);
+      }
 
       // Case A — an ACTIVE L2 already exists (eager-synthesis going-forward shape).
       const { data: active } = await this._supabase

--- a/tests/unit/eva/nonclone-vision-s19-activation.test.js
+++ b/tests/unit/eva/nonclone-vision-s19-activation.test.js
@@ -1,0 +1,120 @@
+/**
+ * SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001 — make a non-clone CONVERGENCE SUBJECT's L2
+ * vision ACTIVATABLE on the normal path. Two coupled halves, both pinned here (no live daemon needed):
+ *   (A) launchNonCloneDummy sets the repair-eligibility flag + the convergence-subject marker at creation;
+ *   (B) the S19 auto-approve carve-out (_autoApproveCloneVision) ADMITS a convergence-subject non-clone
+ *       (a real venture, lacking both clone-origin AND the marker, stays chairman-manual).
+ * The repair/quality half is the SHARED clone path already covered by clone-vision-autoapprove.test.js;
+ * the convergence subject is simply admitted into it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const repairMocks = vi.hoisted(() => ({ isRepairLoopEnabled: vi.fn(), repairVision: vi.fn() }));
+vi.mock('../../../lib/eva/vision-repair-loop.js', () => ({
+  isRepairLoopEnabled: repairMocks.isRepairLoopEnabled,
+  repairVision: repairMocks.repairVision,
+}));
+
+const { StageExecutionWorker } = await import('../../../lib/eva/stage-execution-worker.js');
+const { launchNonCloneDummy, isConvergenceSubject, setConvergenceSubjectMarker, CONVERGENCE_SUBJECT_CONFIG_KEY } =
+  await import('../../../lib/eva/clean-clone/launch.js');
+const autoApprove = StageExecutionWorker.prototype._autoApproveCloneVision;
+const silent = { log() {}, warn() {}, error() {} };
+
+// A supabase mock that records eva_venture_config upserts and resolves selects from `config`.
+// config: { venture, activeL2, draftSeed, convergenceMarker(bool) }
+function makeSb(config = {}) {
+  const upserts = [];
+  const resolveSelect = (ctx) => {
+    if (ctx.table === 'ventures') return config.venture || null;
+    if (ctx.table === 'eva_vision_documents') {
+      if (ctx.filters.status === 'active') return config.activeL2 || null;
+      if (ctx.filters.status === 'draft_seed') return config.draftSeed || null;
+    }
+    if (ctx.table === 'eva_venture_config') {
+      // the convergence-subject marker read
+      return config.convergenceMarker ? { value: true } : null;
+    }
+    return null;
+  };
+  const sb = {
+    upserts,
+    from(table) {
+      const ctx = { table, op: null, filters: {}, payload: null };
+      const b = {
+        select() { ctx.op = 'select'; return b; },
+        update(p) { ctx.op = 'update'; ctx.payload = p; return b; },
+        upsert(p) { ctx.op = 'upsert'; upserts.push({ table, payload: p }); return b; },
+        eq(c, v) { ctx.filters[c] = v; return b; },
+        order() { return b; },
+        limit() { return b; },
+        async maybeSingle() { return { data: resolveSelect(ctx), error: null }; },
+        then(resolve) {
+          if (ctx.op === 'upsert') resolve({ error: null });
+          else if (ctx.op === 'update') resolve({ error: null });
+          else resolve({ data: resolveSelect(ctx), error: null });
+        },
+      };
+      return b;
+    },
+  };
+  return sb;
+}
+
+beforeEach(() => { repairMocks.isRepairLoopEnabled.mockReset(); repairMocks.repairVision.mockReset(); });
+
+describe('(A) launchNonCloneDummy sets repair-eligibility + the convergence-subject marker at LIVE create', () => {
+  it('writes BOTH eva_venture_config flags for the new subject', async () => {
+    const sb = makeSb({ venture: { seeded_from_venture_id: null, is_demo: false, is_scaffolding: false } });
+    const executeStageZero = vi.fn(async () => ({ success: true, venture_id: 'v-sub' }));
+    const r = await launchNonCloneDummy({ dryRun: false }, { supabase: sb, logger: silent, executeStageZero });
+    expect(r.ok).toBe(true);
+    const keys = sb.upserts.filter((u) => u.table === 'eva_venture_config').map((u) => u.payload.key);
+    expect(keys).toContain('venture:v-sub:vision_repair_loop_enabled'); // repair-eligible
+    expect(keys).toContain(CONVERGENCE_SUBJECT_CONFIG_KEY('v-sub'));     // convergence-subject marker
+  });
+
+  it('dry-run sets NO flags (no persist)', async () => {
+    const sb = makeSb();
+    const executeStageZero = vi.fn(async () => ({ success: true, venture_id: 'v-dry' }));
+    await launchNonCloneDummy({ dryRun: true }, { supabase: sb, logger: silent, executeStageZero });
+    expect(sb.upserts.filter((u) => u.table === 'eva_venture_config')).toHaveLength(0);
+  });
+});
+
+describe('isConvergenceSubject reads the marker (fail-closed)', () => {
+  it('true only on an explicit value===true; false when absent', async () => {
+    expect(await isConvergenceSubject(makeSb({ convergenceMarker: true }), 'v')).toBe(true);
+    expect(await isConvergenceSubject(makeSb({ convergenceMarker: false }), 'v')).toBe(false);
+    expect(await isConvergenceSubject(null, 'v')).toBe(false);
+  });
+});
+
+describe('(B) S19 auto-approve carve-out ADMITS a convergence-subject non-clone', () => {
+  it('non-clone WITH the convergence-subject marker -> NOT real_venture (proceeds into the promote path)', async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(true);
+    repairMocks.repairVision.mockResolvedValue({ finalQualityChecked: true, attempts: 1 });
+    const sb = makeSb({
+      venture: { id: 'v-sub', seeded_from_venture_id: null }, // NON-clone
+      convergenceMarker: true,                                // but a convergence subject
+      activeL2: null,
+      draftSeed: { vision_key: 'V', extracted_dimensions: { a: 1 }, content: 'x'.repeat(600), quality_checked: false, quality_issues: [{ check: 'section_coverage' }], sections: {} },
+    });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silent }, 'v-sub');
+    expect(r.reason).not.toBe('real_venture');   // the carve-out admitted it
+    expect(r.promoted).toBe(true);               // repaired (quality) then promoted (activation)
+  });
+
+  it('non-clone WITHOUT the marker (a REAL venture) -> real_venture, chairman-manual preserved', async () => {
+    const sb = makeSb({ venture: { id: 'v-real', seeded_from_venture_id: null }, convergenceMarker: false });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silent }, 'v-real');
+    expect(r.reason).toBe('real_venture');
+    expect(repairMocks.repairVision).not.toHaveBeenCalled();
+  });
+
+  it('a CLONE still works unchanged (no convergence read needed on the clone fast-path)', async () => {
+    const sb = makeSb({ venture: { id: 'v-clone', seeded_from_venture_id: 'src-1' }, activeL2: { vision_key: 'V', chairman_approved: true } });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silent }, 'v-clone');
+    expect(r.reason).toBe('already_approved'); // clone path intact
+  });
+});


### PR DESCRIPTION
## Summary
A non-clone convergence subject reached S19 with an **un-activatable** L2 vision (3/10 sections, quality_checked=false) and the repair-loop default-OFF, so `assertVentureVisionReady` hard-blocked it at the S19 vision_approval gate (the FR-2 blocker surfaced in Child A). Durable fix = the well-precedented **repair-eligibility** angle (mirrors the clone repair-override), in two coupled halves:

- **QUALITY (FR-1)** — `launchNonCloneDummy` sets the per-venture repair-eligibility flag (reused `setCloneVisionRepairOverride`) so the **un-clone-gated S17 repair site** repairs the subject's sparse vision to ≥8/10 sections + quality_checked=true **before** S19 — without weakening the ≥8-section gate.
- **ACTIVATION (FR-2)** — the S19 auto-approve carve-out (`_autoApproveCloneVision`) was clone-gated (early-returns `real_venture` for a non-clone). `launchNonCloneDummy` now sets a **convergence-subject marker** (`eva_venture_config venture:<id>:convergence_subject=true`, no migration), and the carve-out admits a convergence-subject non-clone **in addition to** a clone.
- **SAFETY** — a **real venture** (neither clone-origin nor the marker) stays chairman-manual; the marker is set **only** by `launchNonCloneDummy`; `isConvergenceSubject` is fail-closed; the convergence read runs **only** for non-clones (clone fast-path unchanged). The ≥8-section quality gate + `trg_enforce_vision_quality_advancement` are untouched — the fix makes the vision **pass**, not bypass.

## Tests
`tests/unit/eva/nonclone-vision-s19-activation.test.js` (**6**): both flags set at create / none at dry-run, `isConvergenceSubject` fail-closed, carve-out admits a marked non-clone, real venture → `real_venture`, clone unchanged. **+20** existing clone/convergence vision tests **+18** S19/clean-clone tests green (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)