### PR TITLE
fix(SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001): recalibrate solomon-startup-check contract-parity

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001",
-  "createdAt": "2026-06-30T22:49:32.203Z",
+  "sdKey": "SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001",
+  "createdAt": "2026-06-30T23:21:32.847Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -47,6 +47,10 @@ export const SOLOMON_LOOPS = [
   },
   {
     key: 'self-adherence',
+    // SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001: the contract marker is "SOLOMON SELF-ADHERENCE
+    // DUTY (durable)" -> slug 'solomon-self-adherence'; alias it to this loop key so parity reconciles
+    // (the 1 prior cry-wolf false positive — the loop IS armed).
+    aliases: ['solomon-self-adherence'],
     label: 'Solomon self-adherence audit (role-contract probes -> propose-only remediation)',
     script: 'solomon-self-adherence-review.mjs',
     cron: '0 */12 * * *',
@@ -54,6 +58,28 @@ export const SOLOMON_LOOPS = [
   },
   {
     key: 'deep-sweep',
+    // SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001: the single deep-sweep tick SUBSUMES the Mode-B
+    // deep-reasoning duties by contract design (§3/§4) rather than materializing each as its own cron.
+    // It DECLARES them here via covers[] so the contract↔tooling parity check counts them as wired (the
+    // prior ~7 blind/cry-wolf duties). Adding a duty to the contract requires adding its slug here.
+    covers: [
+      'harness-improvement-depth-sweep',
+      'self-improvement-of-the-self-improvement-loop',
+      'coordination-loop-observation',
+      'adam-grounding-completeness-oversight',
+      'adam-autonomy-oversight-reporting',
+      'retro-learn-integration',
+      'reinforcement-learning-signal',
+      'deep-architecture-review',
+      'deep-thinking-target-scan',
+      'taste-judgement',
+      'flaky-test-deep-rca',
+      'dedup-unification-sweep',
+      'autonomy-support',
+      'reality-simulation',
+      'model-effort-evaluation',
+      'higher-order-effort-distribution-tier-design',
+    ],
     label: 'Solomon Mode-B deep-reasoning sweep (agent judgment; HARD task_budget at entry, before any Read/Grep)',
     script: null, // agent-prompt tick — the deep sweep is reasoning, not a script
     cron: '0 */6 * * *',
@@ -76,24 +102,56 @@ export function parseArmedSet(argv = [], env = {}) {
   return { provided, set };
 }
 
-// Parse the contract's DURABLE recurring-duty markers from CLAUDE_SOLOMON.md. A durable duty is
-// bolded as `**<NAME> DUTY (durable)**`; the captured NAME is slugged (lowercase, spaces→hyphens)
-// so it can be matched against a SOLOMON_LOOPS key. Forgiving regex (a false negative = an
-// unenforced duty, the exact failure this guards). Pure; no I/O. Mirrors adam-startup-check.
+// Slug a duty NAME deterministically: lowercase, collapse every run of non-alphanumerics (spaces,
+// '&', '/', '(', ')', backticks, punctuation) to a single hyphen, trim leading/trailing hyphens. So
+// "ADAM AUTONOMY OVERSIGHT & REPORTING" -> "adam-autonomy-oversight-reporting" and
+// "HARNESS-IMPROVEMENT (DEPTH) SWEEP" -> "harness-improvement-depth-sweep". Pure.
+export function slugifyDuty(name) {
+  return String(name || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+// Parse the contract's DURABLE recurring-duty markers from CLAUDE_SOLOMON.md. A durable duty is bolded
+// as `**<NAME> DUTY (durable[; <qualifier>])**`. SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001:
+// the regex is BROADENED so a false-negative (an unenforced duty silently dropped — the exact failure
+// this guards) cannot happen on a real contract marker:
+//   - the NAME accepts ANY non-`*` chars (so '(DEPTH)', '&', '/', '`/learn`' qualifiers are captured),
+//     lazily up to ' DUTY (durable';
+//   - the qualifier accepts `(durable; ...)` / `(durable, ...)` / `(durable)` (content after 'durable').
+// The captured NAME is slugified via slugifyDuty. Pure; no I/O.
 export function parseDurableDutyMarkers(markdown) {
   const slugs = new Set();
-  const re = /\*\*\s*([A-Za-z0-9][A-Za-z0-9 -]*?)\s+DUTY\s*\(\s*durable\s*\)\s*\*\*/gi;
+  const re = /\*\*\s*([^*]+?)\s+DUTY\s*\(\s*durable\b[^)]*\)\s*\*\*/gi;
   let m;
   while ((m = re.exec(String(markdown || ''))) !== null) {
-    slugs.add(m[1].trim().toLowerCase().replace(/\s+/g, '-'));
+    const slug = slugifyDuty(m[1]);
+    if (slug) slugs.add(slug);
   }
   return [...slugs];
 }
 
-// Which contract-named durable duties are MISSING from SOLOMON_LOOPS. [] === parity holds.
+// SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001: the set of duty slugs a loop registry WIRES.
+// A duty is "wired" if it is a loop KEY, an alias of a loop (loop.aliases — e.g. the contract slug
+// 'solomon-self-adherence' aliases loop key 'self-adherence'), OR a declared COVER of a loop
+// (loop.covers — the Mode-B duties the single deep-sweep tick subsumes by contract design §3/§4, rather
+// than materializing each as its own cron). Pure.
+export function wiredDutySlugs(loops = SOLOMON_LOOPS) {
+  const wired = new Set();
+  for (const l of loops) {
+    if (l.key) wired.add(slugifyDuty(l.key));
+    for (const a of (Array.isArray(l.aliases) ? l.aliases : [])) wired.add(slugifyDuty(a));
+    for (const c of (Array.isArray(l.covers) ? l.covers : [])) wired.add(slugifyDuty(c));
+  }
+  return wired;
+}
+
+// Which contract-named durable duties are MISSING from the loop registry. [] === parity holds.
+// Parity is now loopKeys ∪ aliases ∪ covers >= durable-markers (a duty is wired if it is a key OR an
+// alias OR a declared cover of a loop) — so the single deep-sweep tick that subsumes the Mode-B duties
+// no longer reads as ~7 unwired duties (cry-wolf), and the 'solomon-self-adherence' marker reconciles
+// with loop key 'self-adherence' via the alias (the 1 prior false positive).
 export function missingDurableDuties(markdown, loops = SOLOMON_LOOPS) {
-  const keys = new Set(loops.map((l) => l.key));
-  return parseDurableDutyMarkers(markdown).filter((slug) => !keys.has(slug));
+  const wired = wiredDutySlugs(loops);
+  return parseDurableDutyMarkers(markdown).filter((slug) => !wired.has(slug));
 }
 
 // A loop is "armed" when an armed-set was provided AND it contains the loop's KEY, full prompt, or

--- a/tests/unit/solomon-startup-check.test.js
+++ b/tests/unit/solomon-startup-check.test.js
@@ -8,7 +8,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 import {
   SOLOMON_LOOPS, ROLE_CONTEXT_DOC, parseDurableDutyMarkers, missingDurableDuties,
-  loopStatus, parseArmedSet, renderContractParity,
+  loopStatus, parseArmedSet, renderContractParity, slugifyDuty, wiredDutySlugs,
 } from '../../scripts/solomon-startup-check.mjs';
 import { buildSelfAdherenceVerdict } from '../../scripts/solomon-self-adherence-review.mjs';
 
@@ -52,6 +52,57 @@ describe('contract↔tooling parity (fails loud on a missing durable duty)', () 
     // renderContractParity is fail-open when the contract file is absent (ships before E-B seeds it).
     const out = renderContractParity('/no/such/root');
     expect(out).toMatch(/parity check skipped \(fail-open\)/);
+  });
+});
+
+describe('SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001: recalibrated parity (no cry-wolf, no blindness)', () => {
+  it('broadened regex parses qualified/punctuated markers the old regex was BLIND to', () => {
+    // (DEPTH) parens in the name, '&' and '/' in the name, and a '(durable; ...)' qualifier.
+    const md = [
+      '**HARNESS-IMPROVEMENT (DEPTH) SWEEP DUTY (durable)**',
+      '**ADAM AUTONOMY OVERSIGHT & REPORTING DUTY (durable; chairman-directed 2026-06-30)**',
+      '**RETRO / `/learn` INTEGRATION DUTY (durable)**',
+    ].join('\n');
+    const slugs = parseDurableDutyMarkers(md);
+    expect(slugs).toContain('harness-improvement-depth-sweep');
+    expect(slugs).toContain('adam-autonomy-oversight-reporting'); // '&' collapsed, qualifier ignored
+    expect(slugs).toContain('retro-learn-integration');           // '/' + backticks collapsed
+  });
+
+  it('slugifyDuty collapses non-alphanumerics to single hyphens', () => {
+    expect(slugifyDuty('ADAM AUTONOMY OVERSIGHT & REPORTING')).toBe('adam-autonomy-oversight-reporting');
+    expect(slugifyDuty('HARNESS-IMPROVEMENT (DEPTH) SWEEP')).toBe('harness-improvement-depth-sweep');
+  });
+
+  it('covers[]: a Mode-B duty the deep-sweep tick SUBSUMES is wired (not cry-wolf)', () => {
+    const wired = wiredDutySlugs(SOLOMON_LOOPS);
+    expect(wired.has('deep-architecture-review')).toBe(true);   // a declared deep-sweep cover
+    expect(wired.has('taste-judgement')).toBe(true);
+    // and it is NOT reported missing when the contract declares it
+    expect(missingDurableDuties('**DEEP ARCHITECTURE REVIEW DUTY (durable)**', SOLOMON_LOOPS)).toEqual([]);
+  });
+
+  it('alias: the "SOLOMON SELF-ADHERENCE" marker reconciles with loop key self-adherence (the 1 false positive)', () => {
+    expect(wiredDutySlugs(SOLOMON_LOOPS).has('solomon-self-adherence')).toBe(true);
+    expect(missingDurableDuties('**SOLOMON SELF-ADHERENCE DUTY (durable)**', SOLOMON_LOOPS)).toEqual([]);
+  });
+
+  it('parity HOLDS against the full real contract marker set (0 missing)', () => {
+    // the 17 durable markers from the live CLAUDE_SOLOMON.md
+    const realMarkers = [
+      'HARNESS-IMPROVEMENT (DEPTH) SWEEP', 'SELF-IMPROVEMENT-OF-THE-SELF-IMPROVEMENT-LOOP',
+      'COORDINATION-LOOP OBSERVATION', 'ADAM GROUNDING-COMPLETENESS OVERSIGHT',
+      'ADAM AUTONOMY OVERSIGHT & REPORTING', 'RETRO / `/learn` INTEGRATION', 'REINFORCEMENT-LEARNING SIGNAL',
+      'DEEP ARCHITECTURE REVIEW', 'DEEP-THINKING TARGET SCAN', 'TASTE & JUDGEMENT', 'FLAKY-TEST DEEP-RCA',
+      'DEDUP / UNIFICATION SWEEP', 'AUTONOMY-SUPPORT', 'REALITY-SIMULATION', 'MODEL/EFFORT EVALUATION',
+      'HIGHER-ORDER EFFORT-DISTRIBUTION TIER DESIGN', 'SOLOMON SELF-ADHERENCE',
+    ].map((n) => `**${n} DUTY (durable)**`).join('\n');
+    expect(parseDurableDutyMarkers(realMarkers)).toHaveLength(17);
+    expect(missingDurableDuties(realMarkers, SOLOMON_LOOPS)).toEqual([]); // no cry-wolf, no blindness
+  });
+
+  it('a genuinely-unwired NEW duty IS still reported (the guard is not defanged)', () => {
+    expect(missingDurableDuties('**SOME BRAND NEW DUTY (durable)**', SOLOMON_LOOPS)).toEqual(['some-brand-new']);
   });
 });
 


### PR DESCRIPTION
## Summary
The contract↔tooling parity check in `solomon-startup-check.mjs` (Phase E-C) **cried wolf** on the Mode-B duties subsumed by the single deep-sweep tick AND was **blind** to ~7 durable markers it could not parse, plus 1 false positive. Verified against the **live CLAUDE_SOLOMON.md (17 markers): parity now holds (0 missing)**.

- **FR-1** `covers[]` on the deep-sweep loop declares the 16 Mode-B deep-reasoning duties it subsumes (by contract design §3/§4, not as standalone crons); new `wiredDutySlugs()` = loopKeys ∪ aliases ∪ covers; `missingDurableDuties` = markers − wired.
- **FR-2** self-adherence **alias** (`solomon-self-adherence` marker → loop key `self-adherence`) — the 1 prior false positive.
- **FR-3** broadened `parseDurableDutyMarkers` (name accepts `(DEPTH)`/`&`/`/`; qualifier accepts `(durable; ...)`) + robust `slugifyDuty`.
- **FR-4** the guard is **not defanged** — a genuinely-unwired new duty is still reported (pinned by a test).

Pure functions; **no change to the actual loops/duties**.

## Tests
`tests/unit/solomon-startup-check.test.js` **+6** (broadened regex, slugifyDuty, covers union, alias, full-real-contract 0-missing, unwired-still-reported). **14/14 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)