### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001): add a Solomon leg to coordinator-hourly-review

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SOLOMON-STARTUP-PARITY-RECALIBRATE-001",
-  "createdAt": "2026-06-30T23:21:32.847Z",
+  "sdKey": "SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001",
+  "createdAt": "2026-06-30T23:44:33.011Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -26,6 +26,9 @@ require('dotenv').config();
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+// SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: resolve the LIVE Solomon session at fire time
+// (metadata.role='solomon', fresh heartbeat) via the canonical resolver — NO hardcoded UUID.
+const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const ADAM_FRESH_S = Number(process.env.ADAM_FRESH_SECONDS || 600);
@@ -46,6 +49,49 @@ const ADAM_REMINDER =
   'Hourly responsibilities review: re-read your role contract — CONST-002 (PROPOSE, never execute/accept/graduate), ' +
   'silence-by-default, one-advisory-per-tick, the hard rationale bar (cite a LIVE KR + counterfactual + dedup + CONST self-check), ' +
   'and your 8-dim self-rubric (D1_proactive_sourcing..D8_interface_clarity). Stay silent unless you have ONE ranked, defensible advisory.';
+
+// SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: Solomon role-contract reminder — mirrors CLAUDE_SOLOMON.md
+// / CONST-002 propose-only, silence-by-default, the consult triage gate, and Solomon's 5-dim self-rubric.
+const SOLOMON_REMINDER =
+  'Hourly responsibilities review: re-read your Solomon role contract (CLAUDE_SOLOMON.md) — CONST-002 ' +
+  '(PROPOSE, never execute/accept/graduate), silence-by-default, the consult triage gate (answer routed ' +
+  'solomon_consult only — do not poll for problems), the per-sweep task_budget at ENTRY before any Read/Grep, ' +
+  'and your 5-dim self-rubric. Stay silent unless you have a deep, defensible oracle answer.';
+
+// SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: the Solomon leg — mirrors the Adam leg but resolves the
+// live Solomon via getActiveSolomonId (no hardcoded UUID), reuses the SAME hourly cadence, dispatch guard,
+// and cycle-down gate (the caller checks assessFleetActivity ONCE before invoking this). Self-contained
+// (returns a verdict; does NOT exit main) so it composes alongside the Adam leg. Fail-open / non-fatal.
+// Exported for tests. @returns {Promise<{dispatched:boolean, reason?:string, target?:string}>}
+async function dispatchSolomonReminder(sb, { dryRun = DRY_RUN, resolveSolomon = getActiveSolomonId, insert = insertCoordinationRow } = {}) {
+  try {
+    const solomonId = await resolveSolomon(sb);
+    if (!solomonId) {
+      console.log('\n[HOURLY-REVIEW] Solomon: no live session — skipping Solomon reminder (itself a cycle-down).');
+      return { dispatched: false, reason: 'no_live_solomon' };
+    }
+    if (dryRun) {
+      console.log('\n[HOURLY-REVIEW] Solomon: would dispatch reminder to ' + String(solomonId).slice(0, 8) + '. [dry-run, not sent]');
+      return { dispatched: false, reason: 'dry_run', target: solomonId };
+    }
+    const row = {
+      sender_session: process.env.CLAUDE_SESSION_ID || null,
+      sender_type: 'coordinator',
+      target_session: solomonId,
+      message_type: 'INFO',
+      subject: 'Hourly: review your Solomon responsibilities',
+      body: SOLOMON_REMINDER,
+      payload: { kind: 'coordinator_reminder', topic: 'solomon_responsibilities', sent_at: new Date().toISOString() },
+      expires_at: new Date(Date.now() + 90 * 60 * 1000).toISOString(),
+    };
+    await insert(sb, row, { logger: console });
+    console.log('\n[HOURLY-REVIEW] Solomon: reminder dispatched to ' + String(solomonId).slice(0, 8) + '.');
+    return { dispatched: true, target: solomonId };
+  } catch (e) {
+    console.log('[HOURLY-REVIEW] Solomon reminder skipped (non-fatal): ' + e.message);
+    return { dispatched: false, reason: 'error' };
+  }
+}
 
 async function resolveLiveAdam(sb, freshS) {
   // Filter role=adam SERVER-SIDE + order by heartbeat — an unfiltered select hits
@@ -78,6 +124,10 @@ async function main() {
   console.log('[HOURLY-REVIEW] fleet ' + activity.reason + ' — running reminders.' + (DRY_RUN ? ' (dry-run)' : ''));
   console.log('\n-- Coordinator responsibilities (SRE charter) --');
   COORDINATOR_DUTIES.forEach(function (d, i) { console.log('  ' + (i + 1) + '. ' + d); });
+
+  // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: the Solomon leg runs BEFORE the Adam leg because the
+  // Adam leg `return`s from main on no-Adam/dry-run; the cycle-down gate above already guards both legs.
+  await dispatchSolomonReminder(sb);
 
   // Adam leg
   try {
@@ -139,4 +189,10 @@ async function main() {
   }
 }
 
-main().catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
+// SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: guard the main() invocation so the Solomon leg can be
+// imported + unit-tested without running the whole hourly review.
+if (require.main === module) {
+  main().catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
+}
+
+module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER };

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -31,6 +31,10 @@ export const RESPONSIBILITIES = [
   'Self-LIMIT: a HARD per-sweep task_budget (count/wall-clock/token) at sweep ENTRY before any Read/Grep; per-SD + per-day quota; dedup (never re-answer the same consult).',
   'Recurring SELF-adherence audit: probe own role-contract duties, ledger findings, propose-only remediation on drift (never build).',
   'Max-plan pin: run on the Opus-4.8 model pin, on the Max plan (not API billing) — verify via /status before any sweep.',
+  // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: the coordinator dispatches an hourly coordinator_reminder
+  // (topic=solomon_responsibilities) into Solomon's inbox (cycle-down-gated). It is COORDINATOR-DRIVEN (mirrors
+  // the Adam hourly reminder) — NOT a Solomon-armed cron — so re-read your role contract when one arrives.
+  'Hourly refresher: the coordinator sends an hourly coordinator_reminder (solomon_responsibilities) when the fleet is active — re-read your role contract on receipt.',
 ];
 
 // Solomon's recurring tick. Each loop is one CronCreate spec the /solomon agent arms idempotently.

--- a/tests/unit/coordinator-hourly-review-solomon-leg.test.js
+++ b/tests/unit/coordinator-hourly-review-solomon-leg.test.js
@@ -1,0 +1,57 @@
+/**
+ * SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001 — the SOLOMON leg of coordinator-hourly-review.cjs
+ * mirrors the Adam leg: resolve the live Solomon (getActiveSolomonId, no hardcoded UUID) and dispatch a
+ * coordinator_reminder (topic=solomon_responsibilities) via the validated dispatch guard. Self-contained
+ * (returns a verdict, does NOT exit main), dry-run-safe, fail-open. Deps (resolveSolomon/insert) are
+ * injectable so the test drives the leg without a live DB. The cycle-down gate is the caller's
+ * (assessFleetActivity, checked once) — a quiescent fleet never reaches this leg.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { dispatchSolomonReminder, SOLOMON_REMINDER } = require('../../scripts/coordinator-hourly-review.cjs');
+
+const sb = {};
+
+describe('dispatchSolomonReminder — the Solomon hourly leg', () => {
+  it('dispatches a coordinator_reminder (topic=solomon_responsibilities) to the LIVE Solomon', async () => {
+    const insert = vi.fn(async () => ({ data: { id: 'row-1' }, error: null }));
+    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => 'solomon-sess-123', insert });
+    expect(r.dispatched).toBe(true);
+    expect(r.target).toBe('solomon-sess-123');
+    const [, row] = insert.mock.calls[0];
+    expect(row.target_session).toBe('solomon-sess-123');
+    expect(row.payload.kind).toBe('coordinator_reminder');
+    expect(row.payload.topic).toBe('solomon_responsibilities'); // mirrors adam_responsibilities
+    expect(row.sender_type).toBe('coordinator');
+    expect(row.body).toBe(SOLOMON_REMINDER);
+  });
+
+  it('skips (no dispatch) when there is no live Solomon — itself a cycle-down', async () => {
+    const insert = vi.fn();
+    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => null, insert });
+    expect(r.dispatched).toBe(false);
+    expect(r.reason).toBe('no_live_solomon');
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('dry-run: resolves the live Solomon but does NOT dispatch', async () => {
+    const insert = vi.fn();
+    const r = await dispatchSolomonReminder(sb, { dryRun: true, resolveSolomon: async () => 'solomon-sess-123', insert });
+    expect(r.dispatched).toBe(false);
+    expect(r.reason).toBe('dry_run');
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('fail-open: a resolve/dispatch error returns a non-dispatched verdict (never throws)', async () => {
+    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => { throw new Error('db down'); }, insert: vi.fn() });
+    expect(r.dispatched).toBe(false);
+    expect(r.reason).toBe('error');
+  });
+
+  it('SOLOMON_REMINDER references CONST-002 + the consult triage gate + the task_budget', () => {
+    expect(SOLOMON_REMINDER).toMatch(/CONST-002/);
+    expect(SOLOMON_REMINDER).toMatch(/consult triage gate/i);
+    expect(SOLOMON_REMINDER).toMatch(/task_budget/);
+  });
+});


### PR DESCRIPTION
## Summary
Add a **Solomon leg** to `coordinator-hourly-review.cjs` mirroring the Adam leg: resolve the live Solomon via `getActiveSolomonId()` (no hardcoded UUID) and dispatch a `coordinator_reminder` (topic=`solomon_responsibilities`) into Solomon's inbox — reusing the **same** hourly cadence (no new scheduler), the **same** validated dispatch guard, and the **same** cycle-down gate (`assessFleetActivity`, checked once; a quiescent fleet never reaches the leg).

- **FR-1/2** `SOLOMON_REMINDER` + `dispatchSolomonReminder(sb, {dryRun, resolveSolomon, insert})` — self-contained (returns a verdict, does **not** exit main, so it composes alongside the early-returning Adam leg), dry-run-safe, fail-open, deps-injectable. `main()` guarded by `require.main===module`; exports the leg. **The Adam + coordinator legs are unchanged.**
- **FR-3** `solomon-startup-check.mjs` RESPONSIBILITIES gains an awareness line.

> **Documented deviation:** the SD asked for a SOLOMON_LOOPS hourly-review entry, but a SOLOMON_LOOPS entry is armed as a Solomon **cron** (`renderLoops` emits CronCreate per entry) — that would wrongly arm a **duplicate** cron for a coordinator-driven reminder (the Adam analog is likewise **not** in ADAM_LOOPS). The correct mirror is the RESPONSIBILITIES awareness line.

## Tests
`tests/unit/coordinator-hourly-review-solomon-leg.test.js` (**5**): dispatch to live Solomon, skip when absent, dry-run no-send, fail-open, reminder content. **+14** solomon-startup tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)