### PR TITLE
fix(SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001): _autoApproveCloneVision Case B matches the non-clone draft doc-shape (#5284 reachability follow-up)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001",
-  "createdAt": "2026-06-30T23:44:33.011Z",
+  "sdKey": "SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001",
+  "createdAt": "2026-07-01T01:41:34.540Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -3483,11 +3483,18 @@ export class StageExecutionWorker {
         return { promoted: true, vision_key: active.vision_key, mode: 'approve_active' };
       }
 
-      // Case B — no active L2: promote the enriched draft_seed (older S17 seed shape).
+      // Case B — no active L2: promote the enriched pre-active L2. The eligible venture's L2 doc lands in
+      // one of TWO pre-active shapes: 'draft_seed' (the older S17 auto-draft seed shape, clones) OR 'draft'
+      // (the from-scratch eager-synthesis shape a NON-CLONE convergence subject actually produces —
+      // SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001, the #5284 reachability follow-up). Matching
+      // ONLY 'draft_seed' let a convergence subject's 'draft' doc fall through to no_l2_vision, so the repair
+      // never fired and S19 still stalled though eligibility was fixed. Match BOTH; the freshest wins. This
+      // runs ONLY for an auto-approve-ELIGIBLE venture (clone OR convergence subject — the real_venture gate
+      // above is unchanged), so a REAL venture's draft L2 is never touched (chairman-manual preserved).
       const { data: seed } = await this._supabase
         .from('eva_vision_documents')
-        .select('vision_key, extracted_dimensions, content, quality_checked, quality_issues, sections, source_brainstorm_id')
-        .eq('venture_id', ventureId).eq('level', 'L2').eq('status', 'draft_seed')
+        .select('vision_key, status, extracted_dimensions, content, quality_checked, quality_issues, sections, source_brainstorm_id')
+        .eq('venture_id', ventureId).eq('level', 'L2').in('status', ['draft_seed', 'draft'])
         .order('updated_at', { ascending: false }).limit(1).maybeSingle();
       if (!seed) return { promoted: false, reason: 'no_l2_vision' };
       // Must already pass active_rich_check (eager-synthesis enriched it) or the UPDATE violates the CHECK.
@@ -3547,7 +3554,7 @@ export class StageExecutionWorker {
         .update({ status: 'active', chairman_approved: true, chairman_approved_at: new Date().toISOString(), created_by: 'testing-agent-clone-autoapprove' })
         .eq('vision_key', seed.vision_key).eq('level', 'L2');
       if (error) { this._logger?.warn?.(`[Worker] clone vision auto-promote failed (non-fatal): ${error.message}`); return { promoted: false, reason: 'update_failed', error: error.message }; }
-      this._logger?.log?.(`[Worker] S19: clone vision auto-promoted (testing_agent): venture ${ventureId} ${seed.vision_key} draft_seed -> active+approved`);
+      this._logger?.log?.(`[Worker] S19: vision auto-promoted (testing_agent): venture ${ventureId} ${seed.vision_key} ${seed.status} -> active+approved`);
       return { promoted: true, vision_key: seed.vision_key, mode: 'promote_draft' };
     } catch (e) {
       this._logger?.warn?.(`[Worker] _autoApproveCloneVision error (non-fatal): ${e?.message || e}`);

--- a/tests/unit/eva/clone-vision-autoapprove.test.js
+++ b/tests/unit/eva/clone-vision-autoapprove.test.js
@@ -29,9 +29,16 @@ function makeSb(config) {
   const resolveSelect = (ctx) => {
     if (ctx.table === 'ventures') return config.venture || null;
     if (ctx.table === 'eva_vision_documents') {
-      if (ctx.filters.status === 'active') return config.activeL2 || null;
-      if (ctx.filters.status === 'draft_seed') return config.draftSeed || null;
+      const st = ctx.filters.status;
+      if (st === 'active') return config.activeL2 || null;
+      // SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001: Case B now queries .in('status',
+      // ['draft_seed','draft']); return the configured pre-active doc (draftSeed = the clone seed shape,
+      // draftDoc = a non-clone convergence subject's 'draft' eager-synthesis shape).
+      if (Array.isArray(st) && (st.includes('draft_seed') || st.includes('draft'))) return config.draftSeed || config.draftDoc || null;
+      if (st === 'draft_seed') return config.draftSeed || null; // back-compat
     }
+    // the convergence-subject marker read (isConvergenceSubject) — a non-clone with the marker is eligible.
+    if (ctx.table === 'eva_venture_config') return config.convergenceMarker ? { value: true } : null;
     return null;
   };
   const sb = {
@@ -42,6 +49,7 @@ function makeSb(config) {
         select() { ctx.op = 'select'; return builder; },
         update(payload) { ctx.op = 'update'; ctx.payload = payload; return builder; },
         eq(col, val) { ctx.filters[col] = val; return builder; },
+        in(col, arr) { ctx.filters[col] = arr; return builder; },
         order() { return builder; },
         limit() { return builder; },
         async maybeSingle() { return { data: resolveSelect(ctx), error: null }; },
@@ -128,6 +136,52 @@ describe('_autoApproveCloneVision (QUALITY-REPAIR FR-1): repair-then-promote', (
     expect(r.reason).toBe('quality_not_checked');
     expect(repairMocks.repairVision).not.toHaveBeenCalled();
     expect(sb.updates).toHaveLength(0);
+  });
+});
+
+describe('SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001: the non-clone convergence subject draft doc-shape', () => {
+  // The from-scratch pipeline produces a NON-CLONE convergence subject's L2 as status='draft' (not
+  // draft_seed). Before this fix, Case B queried only draft_seed -> the draft doc fell through to
+  // no_l2_vision -> repair never fired -> S19 stalled (eligibility fixed in #5284, reachability not).
+  const convergenceVenture = { id: 'venture-conv', seeded_from_venture_id: null }; // NON-clone
+  const draftDoc = (extra = {}) => ({ vision_key: 'V-conv', status: 'draft', extracted_dimensions: { a: 1 }, content: 'x'.repeat(600), ...extra });
+
+  it("a convergence subject's status='draft' L2 is FOUND (not no_l2_vision) and promoted", async () => {
+    const sb = makeSb({ venture: convergenceVenture, convergenceMarker: true, activeL2: null, draftDoc: draftDoc({ quality_checked: true }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-conv');
+    expect(r.reason).not.toBe('no_l2_vision');   // the doc-shape is now matched
+    expect(r.reason).not.toBe('real_venture');   // eligibility carve-out (#5284) admits it
+    expect(r.promoted).toBe(true);
+    expect(r.mode).toBe('promote_draft');
+    expect(sb.updates[0].payload.status).toBe('active');
+    expect(sb.updates[0].payload.chairman_approved).toBe(true);
+  });
+
+  it("a convergence subject's under-quality 'draft' L2 REPAIRS (flag on) then promotes", async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(true);
+    repairMocks.repairVision.mockResolvedValue({ finalQualityChecked: true, attempts: 1 });
+    const sb = makeSb({ venture: convergenceVenture, convergenceMarker: true, activeL2: null, draftDoc: draftDoc({ quality_checked: false, quality_issues: [{ check: 'section_coverage' }], sections: {} }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-conv');
+    expect(repairMocks.repairVision).toHaveBeenCalledTimes(1); // repair NOW fires for the draft shape
+    expect(r.promoted).toBe(true);
+  });
+
+  it("a REAL venture's status='draft' L2 still returns real_venture (chairman-manual preserved; no marker)", async () => {
+    const sb = makeSb({ venture: { id: 'venture-real', seeded_from_venture_id: null }, convergenceMarker: false, activeL2: null, draftDoc: draftDoc({ quality_checked: true }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-real');
+    expect(r.reason).toBe('real_venture');       // NOT reached Case B — the real_venture gate holds
+    expect(sb.updates).toHaveLength(0);
+    expect(repairMocks.repairVision).not.toHaveBeenCalled();
+  });
+
+  it("repair EXHAUSTS on a 'draft' doc -> NO promote, falls through (no force-approve backdoor)", async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(true);
+    repairMocks.repairVision.mockResolvedValue({ finalQualityChecked: false, attempts: 2, exitReason: 'attempt_cap' });
+    const sb = makeSb({ venture: convergenceVenture, convergenceMarker: true, activeL2: null, draftDoc: draftDoc({ quality_checked: false, quality_issues: [{ check: 'section_coverage' }], sections: {} }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-conv');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('repair_exhausted_quality');
+    expect(sb.updates).toHaveLength(0); // no bad 'active' row
   });
 });
 

--- a/tests/unit/eva/nonclone-vision-s19-activation.test.js
+++ b/tests/unit/eva/nonclone-vision-s19-activation.test.js
@@ -28,8 +28,11 @@ function makeSb(config = {}) {
   const resolveSelect = (ctx) => {
     if (ctx.table === 'ventures') return config.venture || null;
     if (ctx.table === 'eva_vision_documents') {
-      if (ctx.filters.status === 'active') return config.activeL2 || null;
-      if (ctx.filters.status === 'draft_seed') return config.draftSeed || null;
+      const st = ctx.filters.status;
+      if (st === 'active') return config.activeL2 || null;
+      // SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001: Case B now .in('status',['draft_seed','draft']).
+      if (Array.isArray(st) && (st.includes('draft_seed') || st.includes('draft'))) return config.draftSeed || config.draftDoc || null;
+      if (st === 'draft_seed') return config.draftSeed || null; // back-compat
     }
     if (ctx.table === 'eva_venture_config') {
       // the convergence-subject marker read
@@ -46,6 +49,7 @@ function makeSb(config = {}) {
         update(p) { ctx.op = 'update'; ctx.payload = p; return b; },
         upsert(p) { ctx.op = 'upsert'; upserts.push({ table, payload: p }); return b; },
         eq(c, v) { ctx.filters[c] = v; return b; },
+        in(c, arr) { ctx.filters[c] = arr; return b; },
         order() { return b; },
         limit() { return b; },
         async maybeSingle() { return { data: resolveSelect(ctx), error: null }; },


### PR DESCRIPTION
## Summary
**#5284 reachability follow-up.** #5284 fixed the **eligibility** carve-out (a convergence subject is admitted past the `real_venture` gate), but `_autoApproveCloneVision` Case B queried **only** `status='draft_seed'` (the clone seed shape). A non-clone convergence subject's from-scratch pipeline produces a `status='draft'` L2 doc → matched neither Case A (active) nor Case B → fell through to `no_l2_vision` → the repair loop **never fired** → S19 still stalled (eligibility fixed, **reachability not**).

**Fix (minimal, surgical):** Case B now queries `.in('status', ['draft_seed','draft'])` so the convergence subject's `draft` doc is found; the freshest wins; the **existing** enriched-check + `repairVision` + promote chain is reused unchanged.

**Hard constraints preserved:**
- Case B runs **only** for an auto-approve-eligible venture (clone OR convergence subject) — the `real_venture` gate (unchanged) returns before Case B, so a **real venture's** draft L2 is never touched (chairman-manual preserved).
- The ≥8-of-10-sections quality trigger / `active_rich_check` / active-L2 unique index are **untouched** — repair makes the doc **pass**, not bypass.
- **No force-approve backdoor** — repair-exhausted returns `repair_exhausted_quality` and falls through (no bad `active` row).

## Tests
`clone-vision-autoapprove.test.js` **+4** draft-shape tests (found+promoted, under-quality repairs, real-venture preserved, repair-exhausted falls through) + mock `.in()`/marker support. **30** vision + **15** S19 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)