### PR TITLE
fix(SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001): freeze an active+approved L2 vision — stop the per-tick S19 clobber

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001",
-  "createdAt": "2026-07-01T01:41:34.540Z",
+  "sdKey": "SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001",
+  "createdAt": "2026-07-01T04:15:30.234Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -799,9 +799,21 @@ export async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureI
 
   const { data: existing } = await supabase
     .from('eva_vision_documents')
-    .select('id, version, addendums, extracted_dimensions')
+    .select('id, version, addendums, extracted_dimensions, status, chairman_approved')
     .eq('vision_key', visionKey)
     .single();
+
+  // SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001: IDEMPOTENCY guard. A venture HELD at S19
+  // (hold-until-build-complete) re-fires this synthesis on EVERY poll tick. Re-synthesizing an
+  // already-ACTIVE+APPROVED L2 vision re-parses the sparse source artifacts back to ~3/10 sections and
+  // UPDATEs content/sections — trg_auto_validate_vision_quality then recomputes quality_checked=false
+  // (the row stays active but degrades 10/10 -> 3/10 every tick; a repaired vision is clobbered). Once
+  // the vision is active+chairman_approved it is FROZEN: skip the re-synthesis write entirely (do NOT
+  // even append an addendum — the held-state ticks would grow it unbounded). Any pre-active shape
+  // (draft/draft_seed) still synthesizes/updates normally, so the going-forward path is unchanged.
+  if (existing && existing.status === 'active' && existing.chairman_approved === true) {
+    return;
+  }
 
   // SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001: populate sections (deterministic, always)
   // and extracted_dimensions (LLM, extract-once + fail-soft) so the vision passes the active-rich

--- a/tests/unit/eva/eager-synthesis-vision-dims.test.js
+++ b/tests/unit/eva/eager-synthesis-vision-dims.test.js
@@ -103,3 +103,31 @@ describe('Eager-synthesis vision dims (SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-
   // fail-soft at source and never throws) — asserted above. The writer additionally wraps the call
   // in try/catch as defense-in-depth against an unexpected throw (verified by code inspection).
 });
+
+describe('SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001: idempotency guard (no clobber of an active+approved vision)', () => {
+  beforeEach(() => extractSpy.mockReset());
+
+  it('SKIPS the re-synthesis write for an already active+chairman_approved vision (the held-S19 clobber)', async () => {
+    extractSpy.mockResolvedValue(DIMS);
+    const a = makeSupabase({ id: 'x', version: 5, addendums: [], extracted_dimensions: DIMS, status: 'active', chairman_approved: true });
+    await upsertEvaVisionFromArtifacts(a.client, 'VISION-TEST-L2-001', 'v-1', 19);
+    expect(a.updates).toHaveLength(0);   // NO update -> content/sections not clobbered back to 3/10
+    expect(a.inserts).toHaveLength(0);
+    expect(extractSpy).not.toHaveBeenCalled(); // no wasted LLM extraction on the held tick
+  });
+
+  it('STILL updates a pre-active (draft) vision — the going-forward synthesis path is unchanged', async () => {
+    extractSpy.mockResolvedValue(DIMS);
+    const d = makeSupabase({ id: 'x', version: 2, addendums: [], extracted_dimensions: DIMS, status: 'draft', chairman_approved: false });
+    await upsertEvaVisionFromArtifacts(d.client, 'VISION-TEST-L2-001', 'v-1', 15);
+    expect(d.updates).toHaveLength(1);   // draft still synthesizes/updates normally
+    expect(d.updates[0].content).toBeTruthy();
+  });
+
+  it('STILL updates an active-but-UNapproved vision (only a fully activated vision is frozen)', async () => {
+    extractSpy.mockResolvedValue(DIMS);
+    const u = makeSupabase({ id: 'x', version: 3, addendums: [], extracted_dimensions: DIMS, status: 'active', chairman_approved: false });
+    await upsertEvaVisionFromArtifacts(u.client, 'VISION-TEST-L2-001', 'v-1', 17);
+    expect(u.updates).toHaveLength(1);   // active+UNapproved is not yet the frozen final state
+  });
+});


### PR DESCRIPTION
## Summary
The **#5287 follow-on**. A venture HELD at S19 (hold-until-build-complete) re-fires its whole S19 write flow every poll tick. The load-bearing defect: `upsertEvaVisionFromArtifacts` (the eager-synthesis writer) re-parses the sparse source artifacts back to ~3/10 sections and UPDATEs content/sections **unconditionally** — it never read `status`/`chairman_approved`. `trg_auto_validate_vision_quality` then recomputes `quality_checked=false` on the content change, so an already-active+approved **10/10 vision degraded to 3/10 every tick** (the repaired vision was clobbered; churn + a repair loop when the clobber left a non-active shape).

**Fix (idempotency, minimal):** widen the `existing` select to read `status` + `chairman_approved`, and **skip the re-synthesis write entirely** once the L2 vision is `status=active` AND `chairman_approved=true` (the frozen final state) — no content/sections/dims re-write, no addendum append, no wasted LLM extraction. Any pre-active shape (draft/draft_seed/active-unapproved) **still synthesizes/updates normally** — the going-forward path is byte-unchanged.

`_autoApproveCloneVision` needs **no change** — Case A already returns `already_approved` for an active+approved doc (verified); the churn originated entirely in the clobber writer.

## Tests
`eager-synthesis-vision-dims.test.js` **+3** (active+approved → NO update/extraction; draft → still updates; active-but-unapproved → still updates). **26** artifact-persistence tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)