### PR TITLE
feat(SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001): fence non-clone convergence-subject build-trees off the belt

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001",
-  "createdAt": "2026-07-01T04:15:30.234Z",
+  "sdKey": "SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001",
+  "createdAt": "2026-07-01T04:49:44.738Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -76,6 +76,9 @@ import { emitFeedback } from '../governance/emit-feedback.js';
 // SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: second-party review of the build payloads,
 // POST-payload / PRE-INSERT. Advisory-first + fail-open (never wedges the build path).
 import { reviewBuildPayloads } from './build-sd-review-gate.js';
+// SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001: a NON-CLONE convergence subject's build-tree
+// is equally throwaway — read the same marker the S19 auto-approve carve-out uses to fence it off the belt.
+import { isConvergenceSubject } from './clean-clone/launch.js';
 
 // ── Amplification Caps (US-004) ─────────────────────────────────
 const MAX_CHILDREN_PER_ORCHESTRATOR = 10;
@@ -544,7 +547,18 @@ export async function convertSprintToSDs(params, deps = {}) {
   // persistent fetchVentureFlags fault, after retries) is also marked, so a DB fault can never leak an
   // unmarked clone tree onto the belt. The bidirectional reconciliation sweep (FR-2) un-marks a real
   // venture wrongly fail-closed-marked, using seeded_from_venture_id ground truth.
-  const cloneBuildTree = isCloneVenture(pilotFlags) || isUnresolvedFlags(pilotFlags);
+  // SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001: a NON-CLONE CONVERGENCE SUBJECT
+  // (isConvergenceSubject — the non-clone analogue of seeded_from_venture_id) spawns an equally
+  // throwaway build-tree. The clone path already fences its tree with metadata.test_clone_build_tree=true
+  // (the marker lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility + the belt gauge read to
+  // exclude a tree); the non-clone convergence path never set it, so 21 dummy SDs (run#3 ffc12de9) landed
+  // CLAIMABLE — inflating the belt gauge and risking a wasted worker cycle building throwaway scaffolding.
+  // REUSE the exact clone mechanism (test_clone_build_tree); the SD's dispatch_ineligible mention is a
+  // no-op label (read by no code) so we deliberately do NOT invent it. fail-CLOSED to false so a DB fault
+  // NEVER wrongly fences a real venture (isConvergenceSubject already fail-closes; the try/catch is belt-and-suspenders).
+  let convergenceSubject = false;
+  try { convergenceSubject = await isConvergenceSubject(supabase, ventureContext?.id); } catch { convergenceSubject = false; }
+  const throwawayBuildTree = isCloneVenture(pilotFlags) || isUnresolvedFlags(pilotFlags) || convergenceSubject;
 
   // Amplification cap: limit children (US-004)
   if (payloads.length > MAX_CHILDREN_PER_ORCHESTRATOR) {
@@ -654,7 +668,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           venture_id: ventureContext?.id,
           venture_name: ventureContext?.name,
           // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
-          ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
+          ...(throwawayBuildTree ? { test_clone_build_tree: true } : {}),
           sprint_name: sprintName,
           sprint_signature: sprintSig, // FR-2: deterministic dedup key (venture_id, sprint_signature)
           sprint_goal: sprintGoal,
@@ -777,7 +791,7 @@ export async function convertSprintToSDs(params, deps = {}) {
             venture_id: ventureContext?.id,
             venture_name: ventureContext?.name,
             // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
-            ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
+            ...(throwawayBuildTree ? { test_clone_build_tree: true } : {}),
             sprint_name: sprintName,
             sprint_item_index: i,
             dependencies: payload.dependencies || [],
@@ -822,7 +836,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           ventureContext,
           provenance,
           createdIds,
-          cloneBuildTree, // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: stamp grandchildren too
+          throwawayBuildTree, // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: stamp grandchildren too
         });
         grandchildKeys.push(...gcKeys);
       }
@@ -900,7 +914,7 @@ export async function convertSprintToSDs(params, deps = {}) {
 async function createGrandchildren({
   supabase, logger, parentChildId, parentChildKey,
   childPayload, ventureContext, provenance, createdIds,
-  cloneBuildTree = false, // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: clone-tree marker (default off)
+  throwawayBuildTree = false, // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: clone-tree marker (default off)
 }) {
   const gcKeys = [];
   // Determine which architecture layers apply based on payload hints
@@ -996,7 +1010,7 @@ async function createGrandchildren({
           created_via: 'lifecycle-sd-bridge',
           venture_id: ventureContext?.id,
           // SD-LEO-INFRA-CLONE-BUILD-TREE-BELT-EXCLUSION-001: mark a clone's tree at the source.
-          ...(cloneBuildTree ? { test_clone_build_tree: true } : {}),
+          ...(throwawayBuildTree ? { test_clone_build_tree: true } : {}),
           architecture_layer: layer.key,
           parent_child_key: parentChildKey,
           grandchild_index: j,

--- a/tests/unit/eva/convergence-buildtree-children-unmarked.test.js
+++ b/tests/unit/eva/convergence-buildtree-children-unmarked.test.js
@@ -1,0 +1,126 @@
+/**
+ * SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001 (FR-3) — NON-MOCKED regression.
+ *
+ * At S19 build-tree spawn, the CLONE path marks every spawned SD metadata.test_clone_build_tree=true (the
+ * marker lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility + the belt gauge read to exclude a
+ * throwaway tree), but the NON-CLONE CONVERGENCE-SUBJECT path (isConvergenceSubject) never set it — so 21
+ * dummy SDs (run#3 ffc12de9) landed CLAIMABLE, inflating the belt gauge. The fix ORs isConvergenceSubject
+ * into the throwaway-tree flag, reusing the SAME test_clone_build_tree marker.
+ *
+ * These drive REAL convertSprintToSDs + REAL isConvergenceSubject (only the DB seam is an in-memory double
+ * that CAPTURES inserted metadata) and the REAL classifyDispatchIneligibility. Anti-test-masking: the
+ * convergence-subject assertion fails if the union is removed (rows would carry no marker), and the
+ * real-venture assertion fails if the gate is not strict (a real tree wrongly fenced).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import { convertSprintToSDs } from '../../../lib/eva/lifecycle-sd-bridge.js';
+const require = createRequire(import.meta.url);
+const { classifyDispatchIneligibility } = require('../../../lib/fleet/claim-eligibility.cjs');
+
+const silent = { log() {}, warn() {}, error() {} };
+const CONVERGENCE_KEY = (vid) => `venture:${vid}:convergence_subject`;
+
+// Capturing in-memory Supabase double. Records every strategic_directives_v2 insert (so we can inspect the
+// spawned rows' metadata), serves the vision refusal-gate + ventures flags + eva_venture_config reads.
+function makeCapturingSb({ ventureId, convergenceSubject = false, seededFrom = null } = {}) {
+  const inserted = [];
+  const vision = { vision_key: 'VISION-TEST-L2-001', version: 'v1', content: 'x', updated_at: '2026-05-27', status: 'active', chairman_approved: true, level: 'L2' };
+  const from = (table) => {
+    if (table === 'eva_vision_documents') {
+      const c = { select: () => c, eq: () => c, in: () => c, order: () => c, limit: () => c, maybeSingle: async () => ({ data: vision, error: null }) };
+      return c;
+    }
+    if (table === 'ventures') {
+      const c = { select: () => c, eq: () => c, maybeSingle: async () => ({ data: { is_demo: false, is_scaffolding: false, seeded_from_venture_id: seededFrom }, error: null }) };
+      return c;
+    }
+    if (table === 'eva_venture_config') {
+      // isConvergenceSubject: .select('value').eq('key', CONVERGENCE_KEY).maybeSingle()
+      let wantKey = null;
+      const c = {
+        select: () => c,
+        eq: (col, val) => { if (col === 'key') wantKey = val; return c; },
+        maybeSingle: async () => {
+          if (convergenceSubject && wantKey === CONVERGENCE_KEY(ventureId)) return { data: { value: true }, error: null };
+          return { data: null, error: null };
+        },
+      };
+      return c;
+    }
+    if (table === 'strategic_directives_v2') {
+      const c = {
+        select: () => c, eq: () => c,
+        limit: async () => ({ data: [], error: null }),   // no existing orchestrator
+        order: async () => ({ data: [], error: null }),
+        insert: async (row) => { inserted.push(row); return { data: null, error: null }; },
+        update: () => c,
+        single: async () => ({ data: null, error: null }),
+      };
+      return c;
+    }
+    // default: benign
+    const c = { select: () => c, eq: () => c, in: () => c, order: () => c, limit: async () => ({ data: [], error: null }), maybeSingle: async () => ({ data: null, error: null }), insert: async () => ({ data: null, error: null }) };
+    return c;
+  };
+  return { sb: { from, rpc: async () => ({ data: { cancelled_sds: 0, cancelled_prds: 0 }, error: null }) }, inserted };
+}
+
+const sprintParams = (ventureId) => ({
+  stageOutput: {
+    sprint_name: 'Sprint 1', sprint_goal: 'Build',
+    sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'Desc', scope: 'Scope', success_criteria: 'sc' }],
+  },
+  ventureContext: { id: ventureId, name: 'ConvTest' },
+  options: { skipEnrichment: true, generateGrandchildren: true },
+});
+
+const markerOf = (row) => row?.metadata?.test_clone_build_tree === true;
+
+describe('convergence-subject build-tree fencing (SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001)', () => {
+  it('FR-1: a convergence subject stamps EVERY spawned SD (parent + child + grandchild) test_clone_build_tree=true', async () => {
+    const { sb, inserted } = makeCapturingSb({ ventureId: 'v-conv-1', convergenceSubject: true });
+    const res = await convertSprintToSDs(sprintParams('v-conv-1'), { supabase: sb, logger: silent });
+    expect(res.created).toBe(true);
+    expect(inserted.length).toBeGreaterThanOrEqual(3); // parent + >=1 child + >=1 grandchild
+    // EVERY inserted node carries the throwaway marker.
+    for (const row of inserted) expect(markerOf(row)).toBe(true);
+    // ...and the belt-exclusion predicate excludes EVERY node (non-null reason). The parent orchestrator
+    // is excluded as 'orchestrator_parent' (higher precedence, never dispatched anyway); every NON-parent
+    // node — the leaves/grandchildren that were the ones landing CLAIMABLE — is excluded specifically via
+    // the 'test_clone_build_tree' marker this fix adds.
+    for (const row of inserted) {
+      const reason = classifyDispatchIneligibility({ metadata: row.metadata, sd_type: row.sd_type, status: row.status }, {});
+      expect(reason).not.toBeNull(); // every node is belt-ineligible
+      if (reason !== 'orchestrator_parent') expect(reason).toBe('test_clone_build_tree');
+    }
+    // At least one node is excluded specifically by the new marker (a leaf) — proves it is load-bearing.
+    const byMarker = inserted.filter((row) =>
+      classifyDispatchIneligibility({ metadata: row.metadata, sd_type: row.sd_type, status: row.status }, {}) === 'test_clone_build_tree');
+    expect(byMarker.length).toBeGreaterThan(0);
+  });
+
+  it('FR-2: a REAL venture (not convergence, not clone) stamps NO marker — children stay belt-eligible', async () => {
+    const { sb, inserted } = makeCapturingSb({ ventureId: 'v-real-1', convergenceSubject: false, seededFrom: null });
+    const res = await convertSprintToSDs(sprintParams('v-real-1'), { supabase: sb, logger: silent });
+    expect(res.created).toBe(true);
+    expect(inserted.length).toBeGreaterThanOrEqual(3);
+    for (const row of inserted) expect(markerOf(row)).toBe(false);
+    // None is excluded via the clone marker (they remain claimable real work).
+    for (const row of inserted) {
+      expect(classifyDispatchIneligibility({ metadata: row.metadata, sd_type: row.sd_type, status: row.status }, {})).not.toBe('test_clone_build_tree');
+    }
+  });
+
+  it('FR-2b (clone parity preserved): a CLONE venture (seeded_from_venture_id set) still stamps the marker', async () => {
+    const { sb, inserted } = makeCapturingSb({ ventureId: 'v-clone-1', convergenceSubject: false, seededFrom: 'src-venture-9' });
+    const res = await convertSprintToSDs(sprintParams('v-clone-1'), { supabase: sb, logger: silent });
+    expect(res.created).toBe(true);
+    for (const row of inserted) expect(markerOf(row)).toBe(true); // clone path unchanged
+  });
+
+  it('FR-3: classifyDispatchIneligibility is the mechanism — marked row excluded, unmarked row not', () => {
+    expect(classifyDispatchIneligibility({ metadata: { test_clone_build_tree: true }, sd_type: 'feature', status: 'draft' }, {})).toBe('test_clone_build_tree');
+    expect(classifyDispatchIneligibility({ metadata: {}, sd_type: 'feature', status: 'draft' }, {})).not.toBe('test_clone_build_tree');
+  });
+});

--- a/tests/unit/lifecycle-sd-bridge.test.js
+++ b/tests/unit/lifecycle-sd-bridge.test.js
@@ -197,6 +197,20 @@ describe('convertSprintToSDs', () => {
             }),
           };
         }
+        // SD-LEO-INFRA-CONVERGENCE-BUILDTREE-CHILDREN-UNMARKED-001 added isConvergenceSubject
+        // (.from('eva_venture_config').select('value').eq('key').maybeSingle()) that runs BEFORE
+        // findExistingOrchestrator — table-aware here (like the ventures pilot fetch) so it does NOT
+        // consume the strategic_directives_v2 callCount sequence. Return null -> not a convergence
+        // subject -> real-venture behavior (no throwaway marker), which this idempotency test expects.
+        if (table === 'eva_venture_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }),
+            }),
+          };
+        }
         return {
           insert: vi.fn().mockResolvedValue({ error: null }),
           select: vi.fn().mockImplementation(() => {


### PR DESCRIPTION
## Summary
EIGHTH convergence defect (run#3 teardown). At S19 build-tree spawn (`lib/eva/lifecycle-sd-bridge.js` `convertSprintToSDs`) the **clone** path marks every spawned SD `metadata.test_clone_build_tree=true` — the marker `claim-eligibility.cjs` `classifyDispatchIneligibility` + the belt gauge read to exclude a throwaway tree. The **non-clone convergence-subject** path (`isConvergenceSubject`) never set it, so 21 dummy SDs (parent + 10 sub-orchestrators + 10 leaves) landed **claimable**: the belt gauge read 12 vs a real belt of 2 (masking a genuine belt-low), a worker could burn a cycle building throwaway scaffolding, and teardown required hand-fencing all 21 every run. Same clone-vs-non-clone gap class as #5284/#5287 (3rd occurrence).

## Changes
- **FR-1/FR-2**: import `isConvergenceSubject`; rename `cloneBuildTree`→`throwawayBuildTree = isCloneVenture || isUnresolvedFlags || isConvergenceSubject` (wrapped **fail-closed** so a DB fault never wrongly fences a real venture); thread through all **3 spawn sites** (parent orchestrator + children + grandchildren). Reuses the **exact clone marker** (`test_clone_build_tree`). The SD's `dispatch_ineligible` mention is a **no-op label read by 0 code** (verified) — deliberately not set (would be inventing a scheme the SD warned against); flagged for coordinator confirmation. Real ventures keep no marker → children stay claimable.
- **FR-3**: `tests/unit/eva/convergence-buildtree-children-unmarked.test.js` — **non-mocked** (real `convertSprintToSDs` + `isConvergenceSubject` + `classifyDispatchIneligibility`; only the DB seam captures inserts). Convergence subject → every node stamped + belt-excluded; real venture → none stamped (claimable); clone parity preserved.

## Test
4 new + 43 existing (lifecycle-sd-bridge + clone-tree-exclusion) = **47 pass**, no regression from the rename. testing-agent independent re-run: **47 pass, PASS**. retro 100/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)