### PR TITLE
fix(QF-20260701-485): branch-resolver file-op tests use HEAD instead of main

### DIFF
--- a/scripts/lib/branch-resolver.test.js
+++ b/scripts/lib/branch-resolver.test.js
@@ -216,26 +216,29 @@ describe('Branch Resolver - Discovery Domain Logic', () => {
 });
 
 describe('Branch Resolver - File Operations Domain Logic', () => {
+  // QF-20260701-485: use HEAD, not 'main' - feature-branch CI checkouts have
+  // no local 'main' ref, and these tests exercise the generic file-op
+  // functions rather than main-specific resolution.
   it('should read existing file from main branch', () => {
-    const result = readFileFromBranch(repoPath, 'main', 'package.json');
+    const result = readFileFromBranch(repoPath, 'HEAD', 'package.json');
     expect(result.success).toBe(true);
     expect(result.content).toContain('name');
   });
 
   it('should fail for non-existent file', () => {
-    const result = readFileFromBranch(repoPath, 'main', 'non-existent-file-xyz.txt');
+    const result = readFileFromBranch(repoPath, 'HEAD', 'non-existent-file-xyz.txt');
     expect(result.success).toBe(false);
     expect(result.error).toContain('File not found');
   });
 
   it('should list files matching pattern', () => {
-    const files = listFilesFromBranch(repoPath, 'main', '\\.js$');
+    const files = listFilesFromBranch(repoPath, 'HEAD', '\\.js$');
     expect(Array.isArray(files)).toBe(true);
     expect(files.length).toBeGreaterThan(0);
   });
 
   it('should check file existence on branch', () => {
-    expect(fileExistsOnBranch(repoPath, 'main', 'package.json')).toBe(true);
-    expect(fileExistsOnBranch(repoPath, 'main', 'non-existent-xyz.txt')).toBe(false);
+    expect(fileExistsOnBranch(repoPath, 'HEAD', 'package.json')).toBe(true);
+    expect(fileExistsOnBranch(repoPath, 'HEAD', 'non-existent-xyz.txt')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/lib/branch-resolver.test.js` File Operations Domain Logic tests hardcoded branch `'main'` when calling `readFileFromBranch`/`listFilesFromBranch`/`fileExistsOnBranch`
- These functions shell out to `git show`/`git ls-tree`/`git cat-file -e`, which require `main` to resolve as a local git ref
- On CI checkouts of feature branches (no local `main` ref fetched), these 3 assertions fail while passing on main-branch CI runs
- Fix: use `HEAD` instead, which always resolves to the checked-out commit regardless of which branch CI checked out — these tests exercise the generic file-op functions, not main-specific resolution

## Test plan
- [x] Verified locally: reverted to `'main'`, ran `npx vitest run scripts/lib/branch-resolver.test.js` → 26/26 pass (baseline, since local main ref trivially exists)
- [x] Applied `HEAD` fix, re-ran same suite → 26/26 pass (no behavior change when main ref is present)
- [x] `complete-quick-fix.js` runs full unit + e2e smoke + typecheck verification before merge

QF-20260701-485

🤖 Generated with [Claude Code](https://claude.com/claude-code)