### PR TITLE
fix(SD-LEO-FIX-GUARD-UNGUARDED-UUID-001): guard pack for 4 unguarded SD-completion AFTER triggers

### DIFF
--- a/database/migrations/20260701_guard_orchestrator_auto_complete_exception.sql
+++ b/database/migrations/20260701_guard_orchestrator_auto_complete_exception.sql
@@ -1,0 +1,87 @@
+-- SD-LEO-FIX-GUARD-UNGUARDED-UUID-001 (F-9): add the non-blocking EXCEPTION guard to
+-- try_auto_complete_parent_orchestrator.
+--
+-- Root cause (verified live via pg_get_functiondef 2026-07-01): the parent-orchestrator
+-- auto-complete AFTER trigger has a bare BEGIN...END with NO EXCEPTION handler. It fires on
+-- every child SD's transition to 'completed' and calls complete_orchestrator_sd(v_parent_id).
+-- Any error raised inside that call chain (or the child-count SELECT) propagates and ABORTS
+-- the child's own SD-completion UPDATE — a side-effect trigger blocking the completion write
+-- it is only meant to observe. This is the same hazard the sibling completion-path triggers
+-- were guarded against: fn_auto_close_feedback_on_sd_completion (20260621), and the
+-- fn_auto_close_quick_fixes / fn_auto_close_deliverables pair already end with
+-- `EXCEPTION WHEN OTHERS THEN RAISE WARNING ...; RETURN NEW;`. Completion writes are sacred
+-- (ROOT-FIX-TRG doctrine) — a side-effect trigger must never block them.
+--
+-- This migration CREATE OR REPLACEs the function with a BYTE-IDENTICAL body (reproduced verbatim
+-- from the live definition) plus the sibling guard appended before the final END. The trigger
+-- binding, signature, SECURITY DEFINER, and search_path are unchanged. Reversible via the _DOWN
+-- migration.
+
+CREATE OR REPLACE FUNCTION public.try_auto_complete_parent_orchestrator()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_parent_id VARCHAR;
+  v_is_orchestrator BOOLEAN;
+  v_total_children INT;
+  v_completed_children INT;
+  v_result JSONB;
+BEGIN
+  IF NEW.status != 'completed' THEN
+    RETURN NEW;
+  END IF;
+  IF OLD.status = 'completed' THEN
+    RETURN NEW;
+  END IF;
+  v_parent_id := NEW.parent_sd_id;
+  IF v_parent_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+  v_is_orchestrator := is_orchestrator_sd(v_parent_id);
+  IF NOT v_is_orchestrator THEN
+    RETURN NEW;
+  END IF;
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status = 'completed')
+  INTO v_total_children, v_completed_children
+  FROM strategic_directives_v2
+  WHERE parent_sd_id = v_parent_id;
+  IF v_completed_children = v_total_children AND v_total_children > 0 THEN
+    RAISE NOTICE 'FIX 4: All % children completed for parent %. Attempting auto-complete...',
+      v_total_children, v_parent_id;
+    v_result := complete_orchestrator_sd(v_parent_id);
+    IF (v_result->>'success')::boolean THEN
+      RAISE NOTICE 'FIX 4: Parent orchestrator % auto-completed successfully', v_parent_id;
+    ELSE
+      RAISE NOTICE 'FIX 4: Parent orchestrator % not auto-completed: %',
+        v_parent_id, v_result->>'error';
+    END IF;
+  ELSE
+    RAISE NOTICE 'FIX 4: Parent % has %/% children completed - waiting for all',
+      v_parent_id, v_completed_children, v_total_children;
+  END IF;
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Non-blocking: log warning but never prevent the child SD's completion (parity with the sibling
+  -- auto-close triggers; ROOT-FIX-TRG doctrine — completion writes are sacred). SD-LEO-FIX-GUARD-UNGUARDED-UUID-001 F-9.
+  RAISE WARNING 'try_auto_complete_parent_orchestrator failed for SD %: %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$function$;
+
+-- ----------------------------------------------------------------------------
+-- Self-verification: the re-created function now carries the outer EXCEPTION guard.
+-- Fails the migration loudly if the guard is missing (e.g. a bad copy of the body).
+-- ----------------------------------------------------------------------------
+DO $verify$
+BEGIN
+  IF pg_get_functiondef('public.try_auto_complete_parent_orchestrator()'::regprocedure)
+       NOT ILIKE '%EXCEPTION WHEN OTHERS THEN%' THEN
+    RAISE EXCEPTION 'VERIFY FAILED: try_auto_complete_parent_orchestrator has no EXCEPTION guard';
+  END IF;
+  RAISE NOTICE 'VERIFY OK: try_auto_complete_parent_orchestrator re-created with non-blocking EXCEPTION guard';
+END $verify$;

--- a/database/migrations/20260701_guard_orchestrator_auto_complete_exception_DOWN.sql
+++ b/database/migrations/20260701_guard_orchestrator_auto_complete_exception_DOWN.sql
@@ -1,0 +1,56 @@
+-- DOWN for SD-LEO-FIX-GUARD-UNGUARDED-UUID-001 (F-9): restore try_auto_complete_parent_orchestrator
+-- to its prior (un-guarded) definition — a bare BEGIN...END with no EXCEPTION handler. Byte-identical
+-- to the pre-migration live definition (pg_get_functiondef 2026-07-01). Reverting re-introduces the
+-- hazard where an error inside complete_orchestrator_sd (or the child-count SELECT) aborts the child
+-- SD's completion write; only run this to roll back.
+
+CREATE OR REPLACE FUNCTION public.try_auto_complete_parent_orchestrator()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_parent_id VARCHAR;
+  v_is_orchestrator BOOLEAN;
+  v_total_children INT;
+  v_completed_children INT;
+  v_result JSONB;
+BEGIN
+  IF NEW.status != 'completed' THEN
+    RETURN NEW;
+  END IF;
+  IF OLD.status = 'completed' THEN
+    RETURN NEW;
+  END IF;
+  v_parent_id := NEW.parent_sd_id;
+  IF v_parent_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+  v_is_orchestrator := is_orchestrator_sd(v_parent_id);
+  IF NOT v_is_orchestrator THEN
+    RETURN NEW;
+  END IF;
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status = 'completed')
+  INTO v_total_children, v_completed_children
+  FROM strategic_directives_v2
+  WHERE parent_sd_id = v_parent_id;
+  IF v_completed_children = v_total_children AND v_total_children > 0 THEN
+    RAISE NOTICE 'FIX 4: All % children completed for parent %. Attempting auto-complete...',
+      v_total_children, v_parent_id;
+    v_result := complete_orchestrator_sd(v_parent_id);
+    IF (v_result->>'success')::boolean THEN
+      RAISE NOTICE 'FIX 4: Parent orchestrator % auto-completed successfully', v_parent_id;
+    ELSE
+      RAISE NOTICE 'FIX 4: Parent orchestrator % not auto-completed: %',
+        v_parent_id, v_result->>'error';
+    END IF;
+  ELSE
+    RAISE NOTICE 'FIX 4: Parent % has %/% children completed - waiting for all',
+      v_parent_id, v_completed_children, v_total_children;
+  END IF;
+  RETURN NEW;
+END;
+$function$;

--- a/package.json
+++ b/package.json
@@ -557,6 +557,7 @@
     "check:external-status": "node scripts/check-external-status.mjs",
     "check:workflow-yaml": "node scripts/check-workflow-yaml.mjs",
     "validate:capability-trigger": "node scripts/validate-capability-lifecycle-trigger.mjs --live",
+    "validate:trigger-guard-pack": "node scripts/validate-trigger-guard-pack.mjs",
     "qf:create": "node scripts/create-quick-fix.js",
     "migration:apply-state": "node scripts/verify-migration-apply-state.mjs",
     "retention:check": "node scripts/retention-enforce.js",

--- a/scripts/validate-trigger-guard-pack.mjs
+++ b/scripts/validate-trigger-guard-pack.mjs
@@ -1,0 +1,194 @@
+// SD-LEO-FIX-GUARD-UNGUARDED-UUID-001: BEGIN...ROLLBACK round-trip validation of
+// the 4 SD-completion AFTER triggers guarded by this SD's migrations:
+//   record_mttr_on_sd_completion, fn_emit_sd_completed_event (F-1, safe_uuid),
+//   fn_auto_close_feedback_on_sd_completion (F-2, outer EXCEPTION guard),
+//   try_auto_complete_parent_orchestrator (F-9, outer EXCEPTION guard).
+//
+// Exercises malformed-metadata / forced-failure conditions against temp SD rows
+// inside a single transaction, asserts each completion UPDATE succeeds (instead
+// of raising), then ROLLS BACK — zero persistent writes. Proves reversibility via
+// a per-function md5 fingerprint before/after.
+//
+// Modes:
+//   --live or SKIP_FN_APPLY=1 (post-apply verification): validates the LIVE functions as deployed.
+//   default: CREATE OR REPLACEs all 3 migrations' functions inside the txn first
+//       (pre-apply validation of the migrations themselves, before chairman approval).
+//
+// Usage: npm run validate:trigger-guard-pack            (pre-apply mode)
+//        npm run validate:trigger-guard-pack -- --live   (post-apply mode)
+//
+// Requires SUPABASE_POOLER_URL. Exits non-zero on assertion failure or fingerprint drift.
+import { Client } from 'pg';
+import { readFileSync } from 'node:fs';
+import { config } from 'dotenv';
+config();
+
+const MIGRATIONS = [
+  'database/migrations/20260619_uuid_cast_guard_sd_completion.sql',
+  'database/migrations/20260621_auto_close_feedback_exception_guard.sql',
+  'database/migrations/20260701_guard_orchestrator_auto_complete_exception.sql',
+];
+
+const FUNCTIONS = [
+  'safe_uuid',
+  'record_mttr_on_sd_completion',
+  'fn_emit_sd_completed_event',
+  'fn_auto_close_feedback_on_sd_completion',
+  'try_auto_complete_parent_orchestrator',
+];
+
+function extractCreateStatements(sql) {
+  const statements = [];
+  let idx = 0;
+  while (true) {
+    const start = sql.indexOf('CREATE OR REPLACE FUNCTION', idx);
+    if (start < 0) break;
+    // Function bodies are $function$ or $safe_uuid$ tagged; find the matching close tag.
+    const tagMatch = sql.slice(start).match(/AS \$(\w*)\$/);
+    if (!tagMatch) throw new Error('could not find dollar-quote tag after ' + sql.slice(start, start + 80));
+    const tag = tagMatch[1];
+    const closeMarker = `$${tag}$;`;
+    const bodyStart = start + tagMatch.index + tagMatch[0].length;
+    const end = sql.indexOf(closeMarker, bodyStart);
+    if (end < 0) throw new Error('could not find closing tag $' + tag + '$;');
+    statements.push(sql.slice(start, end + closeMarker.length));
+    idx = end + closeMarker.length;
+  }
+  return statements;
+}
+
+const c = new Client({ connectionString: process.env.SUPABASE_POOLER_URL });
+c.on('notice', n => console.log('   [pg notice]', n.message));
+await c.connect();
+
+async function fingerprint(fnName) {
+  const { rows } = await c.query(
+    `SELECT md5(pg_get_functiondef(p.oid)) AS h FROM pg_proc p WHERE p.proname = $1`,
+    [fnName]
+  );
+  return rows[0]?.h ?? null;
+}
+
+const before = {};
+for (const fn of FUNCTIONS) before[fn] = await fingerprint(fn);
+console.log('fingerprints BEFORE:', before);
+
+let failed = false;
+try {
+  await c.query('BEGIN');
+  await c.query("SET LOCAL lock_timeout = '5s'");
+  await c.query("SET LOCAL statement_timeout = '60s'");
+  await c.query("SET LOCAL leo.bypass_completion_check = 'true'");
+
+  const live = process.env.SKIP_FN_APPLY === '1' || process.argv.includes('--live');
+  if (live) {
+    console.log('--live — validating the LIVE functions as deployed (post-apply mode)');
+  } else {
+    for (const path of MIGRATIONS) {
+      const statements = extractCreateStatements(readFileSync(path, 'utf8'));
+      for (const stmt of statements) await c.query(stmt);
+      console.log(`applied ${statements.length} function(s) from ${path} inside txn`);
+    }
+  }
+
+  // TS-1: record_mttr_on_sd_completion with a malformed proposal_id.
+  const SD1 = 'SD-TEST-GUARDPACK-ROUNDTRIP-001';
+  await c.query(
+    `INSERT INTO strategic_directives_v2
+       (id, sd_key, title, description, rationale, status, sd_type, category, priority, scope, target_application, metadata)
+     VALUES (gen_random_uuid()::text, $1, 'guard-pack round-trip fixture 1', 'fixture', 'fixture', 'active', 'bugfix', 'quality_assurance', 'low', 'test',
+        'EHG_Engineer', jsonb_build_object('proposal_id', 'not-a-uuid'))`,
+    [SD1]
+  );
+  await c.query(`UPDATE strategic_directives_v2 SET status='completed', progress=100, completion_date=NOW() WHERE sd_key=$1`, [SD1]);
+  console.log('TS-1: record_mttr_on_sd_completion — malformed proposal_id did not abort completion ✔');
+
+  // TS-2: fn_emit_sd_completed_event with a malformed venture_id.
+  const SD2 = 'SD-TEST-GUARDPACK-ROUNDTRIP-002';
+  await c.query(
+    `INSERT INTO strategic_directives_v2
+       (id, sd_key, title, description, rationale, status, sd_type, category, priority, scope, target_application, metadata)
+     VALUES (gen_random_uuid()::text, $1, 'guard-pack round-trip fixture 2', 'fixture', 'fixture', 'active', 'bugfix', 'quality_assurance', 'low', 'test',
+        'EHG_Engineer', jsonb_build_object('venture_id', 'also-not-a-uuid'))`,
+    [SD2]
+  );
+  await c.query(`UPDATE strategic_directives_v2 SET status='completed', progress=100, completion_date=NOW() WHERE sd_key=$1`, [SD2]);
+  console.log('TS-2: fn_emit_sd_completed_event — malformed venture_id did not abort completion ✔');
+
+  // TS-5: safe_uuid direct unit assertions.
+  const { rows: su } = await c.query(
+    `SELECT public.safe_uuid('not-a-uuid') AS bad,
+            public.safe_uuid(repeat('-', 36)) AS dashes,
+            public.safe_uuid('00000000-0000-0000-0000-000000000000') AS valid`
+  );
+  if (su[0].bad !== null) throw new Error('safe_uuid did not NULL a malformed value');
+  if (su[0].dashes !== null) throw new Error('safe_uuid accepted a 36-dash string');
+  if (su[0].valid !== '00000000-0000-0000-0000-000000000000') throw new Error('safe_uuid did not pass through a valid UUID');
+  console.log('TS-5: safe_uuid unit assertions ✔');
+
+  // TS-3: fn_auto_close_feedback_on_sd_completion — force a failure inside the guarded
+  // UPDATE by temporarily dropping the feedback table's expected column via a savepoint,
+  // then confirm the SD completion itself still succeeds (only the trigger's inner UPDATE fails).
+  const SD3 = 'SD-TEST-GUARDPACK-ROUNDTRIP-003';
+  await c.query(
+    `INSERT INTO strategic_directives_v2
+       (id, sd_key, title, description, rationale, status, sd_type, category, priority, scope, target_application)
+     VALUES (gen_random_uuid()::text, $1, 'guard-pack round-trip fixture 3', 'fixture', 'fixture', 'active', 'bugfix', 'quality_assurance', 'low', 'test', 'EHG_Engineer')`,
+    [SD3]
+  );
+  await c.query('SAVEPOINT before_break_feedback');
+  await c.query(`ALTER TABLE feedback RENAME COLUMN status TO status_renamed_for_test`);
+  await c.query(`UPDATE strategic_directives_v2 SET status='completed', progress=100, completion_date=NOW() WHERE sd_key=$1`, [SD3]);
+  console.log('TS-3: fn_auto_close_feedback_on_sd_completion — forced UPDATE failure (renamed column) did not abort completion ✔');
+  await c.query('ROLLBACK TO SAVEPOINT before_break_feedback');
+
+  // TS-4: try_auto_complete_parent_orchestrator — force complete_orchestrator_sd() to
+  // raise by pointing a child at a non-existent parent_sd_id that satisfies
+  // is_orchestrator_sd() via a throwaway orchestrator fixture, then break the RPC path
+  // by renaming it away transactionally, confirming the CHILD's own completion still succeeds.
+  const PARENT = 'SD-TEST-GUARDPACK-ROUNDTRIP-PARENT';
+  const CHILD = 'SD-TEST-GUARDPACK-ROUNDTRIP-CHILD';
+  await c.query(
+    `INSERT INTO strategic_directives_v2
+       (id, sd_key, title, description, rationale, status, sd_type, category, priority, scope, target_application, current_phase)
+     VALUES (gen_random_uuid()::text, $1, 'guard-pack parent fixture', 'fixture', 'fixture', 'active', 'orchestrator', 'quality_assurance', 'low', 'test', 'EHG_Engineer', 'EXEC')`,
+    [PARENT]
+  );
+  const { rows: prow } = await c.query(`SELECT id FROM strategic_directives_v2 WHERE sd_key=$1`, [PARENT]);
+  // Parent is in EXEC (past LEAD_APPROVAL), so enforce_child_creation_timing allows the
+  // child to be inserted directly as 'active' — no intermediate draft->active transition
+  // (which would double-fire the handoff-logging trigger within the same millisecond).
+  await c.query(
+    `INSERT INTO strategic_directives_v2
+       (id, sd_key, title, description, rationale, status, sd_type, category, priority, scope, target_application, parent_sd_id, relationship_type)
+     VALUES (gen_random_uuid()::text, $1, 'guard-pack child fixture', 'fixture', 'fixture', 'active', 'bugfix', 'quality_assurance', 'low', 'test', 'EHG_Engineer', $2, 'child')`,
+    [CHILD, prow[0].id]
+  );
+  await c.query('SAVEPOINT before_break_orchestrator_rpc');
+  await c.query(`ALTER FUNCTION complete_orchestrator_sd(varchar) RENAME TO complete_orchestrator_sd_renamed_for_test`);
+  await c.query(`UPDATE strategic_directives_v2 SET status='completed', progress=100, completion_date=NOW() WHERE sd_key=$1`, [CHILD]);
+  console.log('TS-4: try_auto_complete_parent_orchestrator — forced complete_orchestrator_sd() failure did not abort child completion ✔');
+  await c.query('ROLLBACK TO SAVEPOINT before_break_orchestrator_rpc');
+} catch (e) {
+  failed = true;
+  console.error('ROUND-TRIP FAILED:', e.message);
+} finally {
+  await c.query('ROLLBACK');
+  console.log('rolled back');
+}
+
+const after = {};
+for (const fn of FUNCTIONS) after[fn] = await fingerprint(fn);
+console.log('fingerprints AFTER :', after);
+
+let drift = false;
+for (const fn of FUNCTIONS) {
+  if (before[fn] !== after[fn]) {
+    console.error(`✗ FINGERPRINT CHANGED for ${fn} — INVESTIGATE`);
+    drift = true;
+  }
+}
+if (!drift) console.log('reversibility ✔ (all fingerprints byte-identical, pre/post-rollback)');
+
+await c.end();
+if (failed || drift) process.exitCode = 1;

--- a/tests/unit/database/trigger-guard-pack.test.js
+++ b/tests/unit/database/trigger-guard-pack.test.js
@@ -1,0 +1,117 @@
+/**
+ * SD-LEO-FIX-GUARD-UNGUARDED-UUID-001 — guard pack for 4 SD-completion AFTER
+ * triggers with no outer exception guard (F-1, F-2, F-9 per
+ * docs/audits/SD-LEO-INFRA-TRIGGER-ESTATE-AUDIT-001.md).
+ *
+ * Hermetic source-assertions on the 3 migration files (no DB connection).
+ * Live behavioral proof is scripts/validate-trigger-guard-pack.mjs — a
+ * BEGIN...ROLLBACK round-trip exercising all 4 functions, run pre-apply
+ * (functions applied in-txn from these same files) and re-run post-apply
+ * once the chairman approves the TIER-2 migration.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function loadMigration(name) {
+  return readFileSync(path.resolve(process.cwd(), 'database/migrations', name), 'utf8');
+}
+
+const uuidGuard = loadMigration('20260619_uuid_cast_guard_sd_completion.sql');
+const feedbackGuard = loadMigration('20260621_auto_close_feedback_exception_guard.sql');
+const feedbackGuardDown = loadMigration('20260621_auto_close_feedback_exception_guard_DOWN.sql');
+const orchestratorGuard = loadMigration('20260701_guard_orchestrator_auto_complete_exception.sql');
+const orchestratorGuardDown = loadMigration('20260701_guard_orchestrator_auto_complete_exception_DOWN.sql');
+
+describe('F-1: safe_uuid guard (record_mttr_on_sd_completion, fn_emit_sd_completed_event)', () => {
+  it('defines a format-guarded safe_uuid(text) helper', () => {
+    expect(uuidGuard).toMatch(/CREATE OR REPLACE FUNCTION public\.safe_uuid\(p_text text\)/);
+    expect(uuidGuard).toMatch(/RETURNS uuid/);
+    expect(uuidGuard).toMatch(/RETURN NULL;/);
+  });
+
+  it('record_mttr_on_sd_completion calls safe_uuid instead of a raw ::UUID cast', () => {
+    const fnStart = uuidGuard.indexOf('CREATE OR REPLACE FUNCTION public.record_mttr_on_sd_completion');
+    const fnEnd = uuidGuard.indexOf('$function$;', fnStart);
+    const body = uuidGuard.slice(fnStart, fnEnd);
+    expect(body).toMatch(/public\.safe_uuid\(NEW\.metadata->>'proposal_id'\)/);
+    expect(body).not.toMatch(/\(NEW\.metadata->>'proposal_id'\)::UUID/);
+  });
+
+  it('fn_emit_sd_completed_event calls safe_uuid instead of a raw ::UUID cast', () => {
+    const fnStart = uuidGuard.indexOf('CREATE OR REPLACE FUNCTION public.fn_emit_sd_completed_event');
+    const fnEnd = uuidGuard.indexOf('$function$;', fnStart);
+    const body = uuidGuard.slice(fnStart, fnEnd);
+    expect(body).toMatch(/public\.safe_uuid\(NEW\.metadata->>'venture_id'\)/);
+    expect(body).not.toMatch(/\(NEW\.metadata->>'venture_id'\)::UUID/);
+  });
+
+  it('carries a self-verification block asserting safe_uuid behavior', () => {
+    expect(uuidGuard).toMatch(/DO \$verify\$/);
+    expect(uuidGuard).toMatch(/safe_uuid\('not-a-uuid'\) IS NOT NULL/);
+  });
+});
+
+describe('F-2: outer exception guard on fn_auto_close_feedback_on_sd_completion', () => {
+  it('preserves the two feedback UPDATE statements byte-identically', () => {
+    expect(feedbackGuard).toMatch(/WHERE strategic_directive_id = NEW\.id/);
+    expect(feedbackGuard).toMatch(/WHERE resolution_sd_id = NEW\.id/);
+  });
+
+  it('appends the sibling EXCEPTION WHEN OTHERS guard, returning NEW', () => {
+    expect(feedbackGuard).toMatch(/EXCEPTION WHEN OTHERS THEN/);
+    expect(feedbackGuard).toMatch(/RAISE WARNING 'fn_auto_close_feedback_on_sd_completion failed for SD %: %', NEW\.id, SQLERRM;/);
+    const guardIdx = feedbackGuard.indexOf('EXCEPTION WHEN OTHERS THEN');
+    expect(feedbackGuard.slice(guardIdx)).toMatch(/RETURN NEW;/);
+  });
+
+  it('ships a paired DOWN migration to restore the unguarded body', () => {
+    expect(feedbackGuardDown).toMatch(/CREATE OR REPLACE FUNCTION public\.fn_auto_close_feedback_on_sd_completion/);
+    expect(feedbackGuardDown).not.toMatch(/EXCEPTION WHEN OTHERS THEN/);
+  });
+});
+
+describe('F-9: outer exception guard on try_auto_complete_parent_orchestrator', () => {
+  it('preserves the child-count / complete_orchestrator_sd() call chain byte-identically', () => {
+    expect(orchestratorGuard).toMatch(/v_result := complete_orchestrator_sd\(v_parent_id\);/);
+    expect(orchestratorGuard).toMatch(/COUNT\(\*\) FILTER \(WHERE status = 'completed'\)/);
+  });
+
+  it('appends the sibling EXCEPTION WHEN OTHERS guard, returning NEW', () => {
+    expect(orchestratorGuard).toMatch(/EXCEPTION WHEN OTHERS THEN/);
+    expect(orchestratorGuard).toMatch(/RAISE WARNING 'try_auto_complete_parent_orchestrator failed for SD %: %', NEW\.id, SQLERRM;/);
+    const guardIdx = orchestratorGuard.indexOf('EXCEPTION WHEN OTHERS THEN');
+    expect(orchestratorGuard.slice(guardIdx)).toMatch(/RETURN NEW;/);
+  });
+
+  it('carries a self-verification block asserting the guard is present', () => {
+    expect(orchestratorGuard).toMatch(/DO \$verify\$/);
+    expect(orchestratorGuard).toMatch(/pg_get_functiondef\('public\.try_auto_complete_parent_orchestrator\(\)'::regprocedure\)/);
+  });
+
+  it('ships a paired DOWN migration to restore the unguarded body', () => {
+    expect(orchestratorGuardDown).toMatch(/CREATE OR REPLACE FUNCTION public\.try_auto_complete_parent_orchestrator/);
+    expect(orchestratorGuardDown).not.toMatch(/EXCEPTION WHEN OTHERS THEN/);
+  });
+});
+
+describe('TIER-2 chairman-gate compliance', () => {
+  it('all 3 migrations are CREATE OR REPLACE FUNCTION (never auto-applied per CLAUDE_CORE.md tiered policy)', () => {
+    for (const sql of [uuidGuard, feedbackGuard, orchestratorGuard]) {
+      expect(sql).toMatch(/CREATE OR REPLACE FUNCTION/);
+    }
+  });
+});
+
+describe('validator wiring (live round-trip reachability)', () => {
+  it('validate:trigger-guard-pack npm script points at the round-trip validator', () => {
+    const pkg = JSON.parse(readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf8'));
+    expect(pkg.scripts['validate:trigger-guard-pack']).toMatch(/validate-trigger-guard-pack\.mjs/);
+  });
+
+  it('the validator script exists and rolls back (no persistent writes)', () => {
+    const v = readFileSync(path.resolve(process.cwd(), 'scripts/validate-trigger-guard-pack.mjs'), 'utf8');
+    expect(v).toMatch(/ROLLBACK/);
+    expect(v).toMatch(/SD-TEST-GUARDPACK-ROUNDTRIP/);
+  });
+});


### PR DESCRIPTION
## Summary
- Two of four unguarded SD-completion AFTER triggers already had correct, self-verified migrations sitting unapplied from two predecessor SDs falsely marked "completed" (SD-LEO-INFRA-UUID-CAST-GUARD-SD-COMPLETION-001, SD-REFILL-003T5I5M) -- reused verbatim here.
- Authors + validates the one genuinely new migration for `try_auto_complete_parent_orchestrator` (F-9), using the identical `EXCEPTION WHEN OTHERS` guard pattern already proven on sibling functions.
- All 3 migrations are TIER-2 chairman-gated (`CREATE OR REPLACE FUNCTION`) per CLAUDE_CORE.md's tiered auto-apply policy -- **not applied to production in this PR**. Application requires the chairman 3-factor gate (`node scripts/apply-migration.js <path> --prod-deploy`).

## Test plan
- [x] `npx vitest run tests/unit/database/trigger-guard-pack.test.js` -- 14/14 hermetic source-assertion tests pass
- [x] `npm run validate:trigger-guard-pack` -- live BEGIN...ROLLBACK round-trip applies all 3 migrations transactionally, exercises TS-1..TS-5 (malformed proposal_id, malformed venture_id, forced feedback-UPDATE failure, forced complete_orchestrator_sd() failure, safe_uuid unit assertions), confirms each completion UPDATE now succeeds instead of aborting, rolls back with byte-identical function fingerprints (zero persistent writes, zero schema drift)
- [ ] Chairman TIER-2 sign-off + `apply-migration.js --prod-deploy` for all 3 migration files (tracked separately, out of code-review scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)