### PR TITLE
feat(SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001): name workers on check-in arrival

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -33,6 +33,21 @@ function tierRankOf(worker) {
   return (t === 1 || t === 2 || t === 3 || t === 4) ? t : 4;
 }
 
+// SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 (FR-3): deterministic + unique + logged pool extension.
+// The old `base + '-' + (usedSet.size + 1)` seeded the suffix from set CARDINALITY, which is neither
+// unique nor deterministic vs existing suffixes — two concurrent exhausted picks both returned e.g.
+// "Golf-6", and used={Golf,Golf-3} regenerated the already-present "Golf-3" (the Alpha-6/Alpha-7
+// artifact). Instead pick the FIRST FREE `base-N` (N>=2) not in usedSet, and LOG so pool exhaustion is
+// visible, never silent. Shared by BOTH allocators below so pickCallsignForTier and nextAvailable stay
+// byte-identical in format (or dedupeAssignedCallsigns string-equality stops reconciling duplicates).
+function extendCallsign(base, usedSet, poolLabel) {
+  let n = 2;
+  while (usedSet.has(`${base}-${n}`)) n++;
+  const extended = `${base}-${n}`;
+  console.error(`[fleet-identity] ${poolLabel} pool exhausted — extended deterministically to ${extended}`);
+  return extended;
+}
+
 // Pick the first FREE callsign within the worker's tier band (effort-encoded SoT), wrapping with a
 // numeric suffix only when the band is exhausted. Drop-in replacement for nextAvailable(NATO, ...).
 function pickCallsignForTier(tierRank, usedSet) {
@@ -40,7 +55,7 @@ function pickCallsignForTier(tierRank, usedSet) {
   for (const c of pool) {
     if (!usedSet.has(c)) return c;
   }
-  return pool[0] + '-' + (usedSet.size + 1);
+  return extendCallsign(pool[0], usedSet, `tier-${tierRank}`);
 }
 
 // True when a callsign already belongs to the worker's correct tier band, so the cron KEEPS it
@@ -61,8 +76,9 @@ function nextAvailable(pool, usedSet) {
   for (const item of pool) {
     if (!usedSet.has(item)) return item;
   }
-  // All used — wrap around with suffix
-  return pool[0] + '-' + (usedSet.size + 1);
+  // All used — extend deterministically (SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 FR-3):
+  // first FREE base-N, identical format to pickCallsignForTier so both writers reconcile.
+  return extendCallsign(pool[0], usedSet, 'nato');
 }
 
 // QF-20260508-648: writer/consumer asymmetry — lib/coordinator/resolve.cjs
@@ -454,7 +470,7 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, TIER_CALLSIGNS, tierRankOf, pickCallsignForTier, callsignInTierBand };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, TIER_CALLSIGNS, tierRankOf, pickCallsignForTier, callsignInTierBand };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -860,6 +860,18 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
       .select('metadata').eq('session_id', sessionId).maybeSingle();
     const myMeta = (cur && cur.metadata) || {};
     if (myMeta.is_coordinator === true) return null; // coordinators stay nameless in the worker pool (QF-20260508-648)
+    // SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 (FR-4): role sessions (Adam/Solomon) run the fleet but
+    // are NOT worker-pool members. Adam short-circuits to action=idle — exactly what the FR-1-relaxed
+    // gate now names — so exclude them here at the authoritative metadata read too.
+    if (myMeta.role === 'adam' || myMeta.role === 'solomon') return null;
+    // FR-4: widen the ghost guard to the shared isFixtureSession superset so *-probe-* / QF-TEST-*
+    // sessions (which the narrow isTestSessionId prefix list misses, bug 7b59dac8) never burn a pool
+    // slot on an idle check-in. Fail-open: if the .mjs import fails, the gate's isTestSessionId
+    // pre-filter + the role/coordinator guards above still apply — naming NEVER becomes action=error.
+    try {
+      const { isFixtureSession } = await import('../lib/fleet/session-predicates.mjs');
+      if (isFixtureSession(sessionId)) return null;
+    } catch { /* superset unavailable — retained isTestSessionId pre-filter still guards */ }
     const existing = myMeta.fleet_identity;
     // QF-20260627-108: idempotent ONLY when the existing callsign is in this worker's tier band
     // (effort-encoded SoT). A wrong-band callsign (e.g. a tier-2 worker still holding "Bravo") falls
@@ -910,26 +922,27 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
   } catch { return null; }
 }
 
-// SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: actions whose result carries a freshly-held claim — every
-// path where a worker ends a check-in owning work and therefore deserves a name NOW.
-const CLAIMED_CHECKIN_ACTIONS = new Set(['resume', 'resume_final', 'resume_orphan', 'claimed_assignment', 'self_claimed', 'self_claimed_qf']);
-
-// Public check-in entrypoint: resolve the action, then name a freshly-claimed, identity-less worker
-// before returning so the SAME response reports the callsign. Naming is a thin fail-open wrapper over
-// the resolution logic (resolveCheckin) so it covers ALL claim paths (resume / assignment / self-claim
-// SD / self-claim draft / self-claim QF) at one site, without threading naming through each return.
+// Public check-in entrypoint: resolve the action, then name an identity-less worker before returning
+// so the SAME response reports the callsign. Naming is a thin fail-open wrapper over resolveCheckin so
+// it covers ALL paths at one site, without threading naming through each return.
+//
+// SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 (FR-1): name a worker on ARRIVAL — every SUCCESSFUL
+// (non-error) check-in INCLUDING action=idle — not only when it holds a claim. Naming is an arrival
+// property of a fleet member, not a reward for holding work (a freshly-swapped fleet was looking
+// half-anonymous). Idempotent via !result.callsign; the coordinator / role (adam|solomon) / fixture
+// exclusions live in the isTestSessionId pre-filter + assignFleetIdentityAtCheckin. claimedId is null
+// for an idle arrival and flows through cleanly (SET_IDENTITY target_sd becomes null).
 async function runCheckin(sb, sessionId, opts = {}) {
   const result = await resolveCheckin(sb, sessionId, opts);
   try {
-    const claimedId = result && (result.sd || result.qf); // SD actions carry .sd; a QF self-claim carries .qf
+    const claimedId = result && (result.sd || result.qf); // SD actions carry .sd; a QF self-claim carries .qf; null when idle
     if (
       result &&
-      CLAIMED_CHECKIN_ACTIONS.has(result.action) &&
-      claimedId &&
+      result.action !== 'error' &&        // FR-1: name on any SUCCESSFUL action (incl. idle)
       !result.callsign &&                 // already named -> nothing to do (idempotent)
-      !isTestSessionId(sessionId)         // ghost/test sessions never burn the 8-name pool (QF-20260528-581)
+      !isTestSessionId(sessionId)         // cheap ghost/test pre-filter (QF-20260528-581); helper widens to isFixtureSession
     ) {
-      const assigned = await assignFleetIdentityAtCheckin(sb, sessionId, claimedId);
+      const assigned = await assignFleetIdentityAtCheckin(sb, sessionId, claimedId || null);
       if (assigned && assigned.callsign) result.callsign = assigned.callsign;
     }
   } catch { /* fail-open: naming must NEVER turn a check-in into action=error */ }

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-const { extractSdFromAssignment, runCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
+const { extractSdFromAssignment, runCheckin, isAutoStartableQF, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSdInFlight, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS } = require('./worker-checkin.cjs');
 
 describe('FR-2: extractSdFromAssignment', () => {
   it('prefers payload.sd_key', () => {
@@ -812,11 +812,45 @@ describe('SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: runCheckin names a freshly-cla
     expect(r.callsign).toBe('Alpha'); // named immediately on first claim, not one cycle later
   });
 
-  it('does NOT assign a name when the worker idles (no claim -> no pool burn)', async () => {
+  it('names a worker on ARRIVAL even when it idles (SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 FR-1)', async () => {
     const sb = makeStub({ session: { metadata: {}, sd_key: null }, messages: [], candidates: [] });
     const r = await runCheckin(sb, 'sess-1', noCoord);
     expect(r.action).toBe('idle');
-    expect(r.callsign).toBeFalsy(); // idle/never-claimed sessions are never named at check-in
+    expect(r.callsign).toBe('Alpha'); // FR-1: naming is an arrival property, not a reward for holding a claim
+  });
+});
+
+describe('SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001: name on arrival + preserved exclusions', () => {
+  it('FR-2: an already-named idle worker keeps its name (idempotent, no rename)', async () => {
+    const sb = makeStub({ session: { metadata: { fleet_identity: { callsign: 'Delta', color: 'red' } }, sd_key: null }, messages: [], candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+    expect(r.callsign).toBe('Delta'); // surfaced by resolveCheckin -> naming branch skipped
+  });
+
+  it('FR-4: a coordinator session stays nameless on an idle check-in', async () => {
+    const sb = makeStub({ session: { metadata: { is_coordinator: true }, sd_key: null }, messages: [], candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.action).toBe('idle');
+    expect(r.callsign).toBeFalsy(); // coordinators never join the worker name pool
+  });
+
+  it('FR-4: an Adam role session stays nameless on an idle check-in', async () => {
+    const sb = makeStub({ session: { metadata: { role: 'adam' }, sd_key: null }, messages: [], candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.callsign).toBeFalsy(); // role sessions run the fleet; they are not worker-pool members
+  });
+
+  it('FR-4: a Solomon role session stays nameless on an idle check-in', async () => {
+    const sb = makeStub({ session: { metadata: { role: 'solomon' }, sd_key: null }, messages: [], candidates: [] });
+    const r = await runCheckin(sb, 'sess-1', noCoord);
+    expect(r.callsign).toBeFalsy();
+  });
+
+  it('FR-4: a probe fixture id the narrow isTestSessionId misses stays nameless (isFixtureSession superset)', async () => {
+    const sb = makeStub({ session: { metadata: {}, sd_key: null }, messages: [], candidates: [] });
+    const r = await runCheckin(sb, 'qf-route-probe-A', noCoord);
+    expect(r.callsign).toBeFalsy(); // *-probe-* is caught by the shared isFixtureSession superset, not isTestSessionId
   });
 });
 

--- a/tests/unit/assign-fleet-identities-tier-callsign.test.js
+++ b/tests/unit/assign-fleet-identities-tier-callsign.test.js
@@ -39,9 +39,13 @@ describe('QF-20260627-108: tier-encoded callsign assignment', () => {
     expect(pickCallsignForTier(4, new Set(['Alpha', 'Bravo']))).toBe('Charlie');
   });
 
-  it('wraps with a numeric suffix only when the band is exhausted', () => {
-    const used = new Set(['Golf']);
-    expect(pickCallsignForTier(2, used)).toBe('Golf-' + (used.size + 1)); // tier-2 band has one slot
+  it('wraps to the first FREE numeric suffix only when the band is exhausted (SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 FR-3)', () => {
+    // tier-2 band has one slot (Golf); exhaustion extends deterministically to the first free base-N (N>=2).
+    expect(pickCallsignForTier(2, new Set(['Golf']))).toBe('Golf-2');
+    // Collision honesty: never re-issue an already-used suffix — skip Golf-2, return Golf-3.
+    expect(pickCallsignForTier(2, new Set(['Golf', 'Golf-2']))).toBe('Golf-3');
+    // A vacated mid-index (Golf-2 free but Golf-3 used) is filled first, NOT re-colliding Golf-3.
+    expect(pickCallsignForTier(2, new Set(['Golf', 'Golf-3']))).toBe('Golf-2');
   });
 
   it('callsignInTierBand detects a wrong-band callsign so the cron self-heals it', () => {

--- a/tests/unit/assign-fleet-identities-tier-callsign.test.js
+++ b/tests/unit/assign-fleet-identities-tier-callsign.test.js
@@ -4,7 +4,7 @@
 // Bravo/Charlie, tier3=Delta/Echo/Foxtrot, tier2=Golf, tier1=Hotel. The picker is shared with
 // worker-checkin.cjs so both writers honor the scheme identically.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -13,6 +13,9 @@ const {
   tierRankOf,
   pickCallsignForTier,
   callsignInTierBand,
+  nextAvailable,
+  extendCallsign,
+  NATO,
 } = require('../../scripts/assign-fleet-identities.cjs');
 
 describe('QF-20260627-108: tier-encoded callsign assignment', () => {
@@ -55,5 +58,28 @@ describe('QF-20260627-108: tier-encoded callsign assignment', () => {
     expect(callsignInTierBand('Alpha', 4)).toBe(true);
     expect(callsignInTierBand('Golf-2', 2)).toBe(true); // suffix-wrapped still in band
     expect(callsignInTierBand(null, 2)).toBe(false);
+  });
+});
+
+describe('SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 FR-3: deterministic pool exhaustion', () => {
+  it('extendCallsign returns the first FREE base-N (>=2) and never an already-used suffix', () => {
+    expect(extendCallsign('Alpha', new Set(['Alpha']), 't')).toBe('Alpha-2');
+    expect(extendCallsign('Alpha', new Set(['Alpha', 'Alpha-2', 'Alpha-3']), 't')).toBe('Alpha-4');
+    expect(extendCallsign('Alpha', new Set(['Alpha', 'Alpha-3']), 't')).toBe('Alpha-2'); // fill vacated
+  });
+
+  it('logs a deterministic "pool exhausted" line on extension (never silent)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    extendCallsign('Golf', new Set(['Golf']), 'tier-2');
+    expect(spy).toHaveBeenCalledWith(expect.stringMatching(/pool exhausted.*Golf-2/));
+    spy.mockRestore();
+  });
+
+  it('nextAvailable shares the identical first-free format so both writers reconcile in lockstep', () => {
+    // NATO pool fully used -> extend deterministically, matching pickCallsignForTier's format.
+    const used = new Set(NATO);
+    expect(nextAvailable(NATO, used)).toBe('Alpha-2');
+    // And it skips an already-used extended suffix rather than colliding.
+    expect(nextAvailable(NATO, new Set([...NATO, 'Alpha-2']))).toBe('Alpha-3');
   });
 });


### PR DESCRIPTION
## Summary
Name a fleet worker on its FIRST `/checkin` (arrival), not only when it holds a claim. A worker whose check-in resolved to `action=idle` was never named until a later claiming check-in, so a freshly-swapped fleet looked half-anonymous (chairman: "only one worker has a name"; the inbox showed the Alpha-6/Alpha-7 collision artifact). Naming is an **arrival property** of a fleet member, not a reward for holding work.

## Changes
- **FR-1** `scripts/worker-checkin.cjs`: relax the `runCheckin` naming gate to fire on every successful (non-error) action incl. `idle`; pass a null claim through; remove the now-unused `CLAIMED_CHECKIN_ACTIONS`.
- **FR-4** `assignFleetIdentityAtCheckin`: add a `role in (adam,solomon)` exclusion (Adam short-circuits to `idle` — exactly what FR-1 now names) and widen the fixture guard to the shared `isFixtureSession` superset (catches `*-probe-*`/`QF-TEST-*` the narrow `isTestSessionId` missed); fail-open.
- **FR-3** `scripts/assign-fleet-identities.cjs`: shared `extendCallsign` (first-free `base-N` + log) used by **both** `pickCallsignForTier` AND `nextAvailable` in lockstep — the old `usedSet.size+1` could re-issue an already-used `Alpha-N` (the Alpha-6/Alpha-7 collision).
- **FR-2**: idempotent re-check-in preserved (already-named worker keeps its callsign).

## Verification
- 122 unit tests green (idle-named / role+coordinator+probe-nameless / exhaustion collision-skip / nextAvailable lockstep); lint clean; live smoke confirmed.
- Adversarial 6-agent review of this fleet-critical diff: 4 findings, **0 confirmed**.
- Gates: LEAD-TO-PLAN 93 · PLAN-TO-EXEC 94 · EXEC-TO-PLAN 94 · PLAN-TO-LEAD 96. VALIDATION 94 · TESTING 92 · REGRESSION engineering-PASS.

SD: SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)