### PR TITLE
fix(SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-A): bound isTieringActive() claude_sessions query

### DIFF
--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -68,11 +68,15 @@ async function isTieringActive(supabase, opts = {}) {
     const { getActiveCoordinatorId } = require('../coordinator/resolve.cjs');
     const { liveFleetWorkers } = await import('./genuine-worker.mjs');
     const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+    const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
     const { data, error } = await supabase
       .from('claude_sessions')
-      .select('session_id, status, metadata, heartbeat_at, sd_key, claimed_at, worktree_path, continuous_sds_completed');
+      .select('session_id, status, metadata, heartbeat_at, sd_key, claimed_at, worktree_path, continuous_sds_completed')
+      .in('status', ['active', 'idle'])
+      .gte('heartbeat_at', new Date(nowMs - 900000).toISOString())
+      .order('heartbeat_at', { ascending: false })
+      .limit(200);
     if (error || !Array.isArray(data)) return false; // degrade-to-1 on uncertainty
-    const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
     return liveFleetWorkers(data, coordinatorId, nowMs).length >= MIN_LIVE_FOR_TIERING;
   } catch {
     return false; // fail to DISABLED (degrade-to-1)

--- a/tests/unit/fleet/complexity-tiered-assignment.test.js
+++ b/tests/unit/fleet/complexity-tiered-assignment.test.js
@@ -95,7 +95,7 @@ describe('FR-3 above_worker_tier eligibility verdict', () => {
 // ---- TS-4/TS-5: FR-4 dispatch guard + FR-5 degrade-to-1 -------------------
 /** Minimal supabase stub: serves claude_sessions (workers), strategic_directives_v2 (SD), and a
  *  live-worker list so isTieringActive can resolve. */
-function stubSupabase({ liveWorkers = 2, workerTierRank = 1, sdMinRank = 3, coordinatorRpc = null } = {}) {
+function stubSupabase({ liveWorkers = 2, workerTierRank = 1, sdMinRank = 3, coordinatorRpc = null, extraSessions = [] } = {}) {
   const sessions = [];
   for (let i = 0; i < liveWorkers; i++) {
     sessions.push({
@@ -103,15 +103,25 @@ function stubSupabase({ liveWorkers = 2, workerTierRank = 1, sdMinRank = 3, coor
       sd_key: `SD-LIVE-${i}`, claimed_at: new Date().toISOString(), worktree_path: `/wt/${i}`, continuous_sds_completed: 1,
     });
   }
+  sessions.push(...extraSessions);
   const targetSession = { session_id: 'target-worker', metadata: { tier_rank: workerTierRank } };
+  const lastQuery = { in: null, gte: null, order: null, limit: null };
   return {
     rpc: async () => ({ data: coordinatorRpc, error: null }),
+    _lastQuery: lastQuery,
     from(table) {
       const api = {
         _table: table, _filters: {},
         select() { return api; },
         not() { return api; },
         eq(col, val) { api._filters[col] = val; return api; },
+        // FR-3 (SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-A): pass-through no-ops so the bounded
+        // isTieringActive() query chain (.in/.gte/.order/.limit) doesn't throw "api.X is not a
+        // function"; each call is recorded on lastQuery so tests can assert bounding shape.
+        in(col, vals) { lastQuery.in = { col, vals }; return api; },
+        gte(col, val) { lastQuery.gte = { col, val }; return api; },
+        order(col, opts) { lastQuery.order = { col, opts }; return api; },
+        limit(n) { lastQuery.limit = n; return api; },
         async maybeSingle() {
           if (table === 'claude_sessions') {
             if (api._filters.session_id === 'target-worker') return { data: targetSession, error: null };
@@ -168,5 +178,44 @@ describe('FR-5 isTieringActive', () => {
     expect(await isTieringActive(stubSupabase({ liveWorkers: 2 }))).toBe(true);
     expect(await isTieringActive(stubSupabase({ liveWorkers: 1 }))).toBe(false);
     expect(await isTieringActive(stubSupabase({ liveWorkers: 0 }))).toBe(false);
+  });
+});
+
+// ---- SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-A (FR-1: bounded live-worker query) ----
+describe('FR-1 isTieringActive() bounded claude_sessions query', () => {
+  it('detects >=2 live workers even with a >1000-row simulated claude_sessions page', async () => {
+    // Simulate the real-world shape the bug hit: a large table where the 2 genuinely live
+    // workers are not guaranteed to be at the front of an unbounded/unordered page. The stub
+    // itself doesn't truncate (no real pagination to model), so this also exercises the query
+    // being called with a bounding shape below, not just the raw count.
+    const staleFiller = Array.from({ length: 1200 }, (_, i) => ({
+      session_id: `stale-${i}`, status: 'released', metadata: {},
+      heartbeat_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+      sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0,
+    }));
+    const sb = stubSupabase({ liveWorkers: 2, extraSessions: staleFiller });
+    expect(await isTieringActive(sb)).toBe(true);
+  });
+
+  it('constructs a bounded query: status in active/idle, heartbeat >= now-15min, ordered desc, limit 200', async () => {
+    const nowMs = Date.now();
+    const sb = stubSupabase({ liveWorkers: 2 });
+    await isTieringActive(sb, { nowMs });
+    expect(sb._lastQuery.in).toMatchObject({ col: 'status', vals: ['active', 'idle'] });
+    expect(sb._lastQuery.gte.col).toBe('heartbeat_at');
+    expect(new Date(sb._lastQuery.gte.val).getTime()).toBe(nowMs - 900000);
+    expect(sb._lastQuery.order).toMatchObject({ col: 'heartbeat_at', opts: { ascending: false } });
+    expect(sb._lastQuery.limit).toBe(200);
+  });
+
+  it('inertness invariant (risk-agent GO-WITH-CONDITIONS): tiering active + all workers unstamped => zero above_worker_tier blocks', async () => {
+    const sb = stubSupabase({ liveWorkers: 2, workerTierRank: undefined, sdMinRank: 4 });
+    expect(await isTieringActive(sb)).toBe(true);
+    // An unstamped worker resolves to the TOP rung (resolveWorkerTierRank), and clamp() caps
+    // every SD's min_tier_rank at that same top rung — so above_worker_tier is unreachable.
+    const unstampedWorkerRank = resolveWorkerTierRank({ metadata: {} });
+    expect(unstampedWorkerRank).toBe(TOP);
+    const sd = { sd_key: 'SD-X-001', metadata: { min_tier_rank: clamp(999) } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: unstampedWorkerRank, tiering_active: true })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- isTieringActive() (lib/fleet/tier-ladder.cjs) ran a bare, unfiltered/unordered/unlimited claude_sessions select against a ~12,845-row table, so the returned page wasn't guaranteed to include live/recent workers — liveFleetWorkers() could undercount and isTieringActive() returned false fleet-wide even with live workers present.
- Fix: hoist nowMs above the query; add .in('status',['active','idle']).gte('heartbeat_at', now-15min).order('heartbeat_at' desc).limit(200) to the select chain, matching genuine-worker.mjs's own 15-min liveness window. genuine-worker.mjs is untouched.
- FR-1 (SHIP FIRST) child of orchestrator SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001 — the master gate; siblings B-E are inert until this lands.
- Extended tests/unit/fleet/complexity-tiered-assignment.test.js's stub with chainable .in/.gte/.order/.limit no-ops (call-shape recorded) + 3 new tests: query-bounding-shape assertion (genuine pre-fix regression guard), a large-page simulation, and an inertness-invariant test proving tiering_active=true + all-workers-unstamped yields zero above_worker_tier blocks (risk-agent's GO-WITH-CONDITIONS condition on the parent SD).

## Test plan
- [x] `npx vitest run tests/unit/fleet/complexity-tiered-assignment.test.js` — 21/21 pass
- [x] `npx vitest run tests/unit/fleet/ tests/unit/coordinator/` — 351/351 pass, zero regressions
- [x] `git diff --stat lib/fleet/genuine-worker.mjs` — empty (untouched)
- [x] TESTING, VALIDATION, REGRESSION sub-agents all PASS (evidence in sub_agent_execution_results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)