### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001): couple Solomon Mode-B to the Fable pin

### DIFF
--- a/docs/architecture/solomon-activation-runbook.md
+++ b/docs/architecture/solomon-activation-runbook.md
@@ -54,13 +54,18 @@ Confirm ALL before the first flip:
 
 ## 3. Graduated activation — "canary the canary"
 
-Do **not** switch fully on. Stage it, watching the advice-outcome ledger + accuracy review
-(agent-definition §11) between stages:
+Do **not** switch fully on. Stage it. The advice-outcome ledger + accuracy review (agent-definition
+§11) still inform the §6 success metrics, but — per the chairman decision 2026-07-01
+(SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001) — **Mode-B activation is now COUPLED to the Fable-5
+model-pin swap, not the ledger**: when Solomon's pin (`CLAUDE_MODEL_SOLOMON` /
+`MODEL_DEFAULTS.claude.solomon`) is a Fable id, the deep-sweep tick auto-detects it
+(`solomonSweepMode()` in `scripts/solomon-startup-check.mjs`) and flips from consult-only to
+proactive-sweep on the next tick — no ledger wait. The actual pin flip stays a chairman/operator action.
 
 | Stage | Flag action (Chairman) | What it enables | Gate to advance |
 |------|------------------------|-----------------|-----------------|
-| **A** | `SOLOMON_CONSULT_V1=on` | **Mode A only** — reactive consults (workers/Adam `solomon-consult`); Mode B stays gated | Mode-A advice demonstrably trusted + correct (uptake + accuracy hold) |
-| **B** | enable Mode-B sweeps | proactive backlog deep-sweeps — still quota- and `task_budget`-bounded | both modes stable |
+| **A** | `SOLOMON_CONSULT_V1=on` | **Mode A only** — reactive consults (workers/Adam `solomon-consult`); Mode B stays gated | **Solomon model pin swapped to a Fable id** (`CLAUDE_MODEL_SOLOMON` / `MODEL_DEFAULTS.claude.solomon`) — the deep-sweep tick auto-enables Mode-B; ledger accuracy is no longer the gate (override: `SOLOMON_SWEEP_MODE=proactive`) |
+| **B** | enable Mode-B sweeps (auto on the Fable pin) | proactive backlog deep-sweeps — one §4 item + ONE propose-only finding per tick, still quota- and `task_budget`-bounded, never executes (CONST-002) | both modes stable |
 | **C** | `ADAM_SOLOMON_TWOWAY_V1=on` | the Adam↔Solomon two-way channel (`-G`, ship-dormant follow-on) | — |
 
 **Observe activation on the dashboard:** `node scripts/fleet-dashboard.cjs solomon` (or the `all`

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -18,9 +18,31 @@ import 'dotenv/config';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { getClaudeModel } from '../lib/config/model-config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
+
+// SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001: deterministic deep-sweep mode trigger.
+// Chairman decision (2026-07-01): Mode-B (proactive backlog sweeps) activation is DECOUPLED from the
+// §11 advice-outcome ledger and COUPLED to the Fable-5 model-pin swap — when Solomon's model pin is a
+// Fable id, the deep-sweep tick flips from consult-only to proactive-sweep AT THE SAME TIME, no ledger
+// wait. The pin is resolved via getClaudeModel('solomon') (the canonical CLAUDE_MODEL_SOLOMON →
+// CLAUDE_MODEL → MODEL_DEFAULTS.claude.solomon chain — NOT re-implemented here). An explicit
+// SOLOMON_SWEEP_MODE env value ('proactive'|'consult') overrides the pin-derived result (a
+// deterministic escape hatch against a future Fable id that lacks the literal 'fable' substring).
+// Pure function of its argument + env; resolve it at TICK time so a mid-session pin swap takes effect
+// on the next tick without a code change. This gates ONLY which mode the tick runs — Solomon still
+// proposes and never executes in either mode (CONST-002 unchanged).
+export function solomonSweepMode(pin = getClaudeModel('solomon'), env = process.env) {
+  const override = String(env.SOLOMON_SWEEP_MODE || '').trim().toLowerCase();
+  if (override === 'proactive' || override === 'consult') return override;
+  return /fable/i.test(String(pin || '')) ? 'proactive' : 'consult';
+}
+
+export function isProactiveSweepEnabled(pin = getClaudeModel('solomon'), env = process.env) {
+  return solomonSweepMode(pin, env) === 'proactive';
+}
 
 // The Solomon role contract (durable). Loaded on /solomon startup; referenced here for the summary.
 export const ROLE_CONTEXT_DOC = 'CLAUDE_SOLOMON.md';
@@ -87,7 +109,10 @@ export const SOLOMON_LOOPS = [
     label: 'Solomon Mode-B deep-reasoning sweep (agent judgment; HARD task_budget at entry, before any Read/Grep)',
     script: null, // agent-prompt tick — the deep sweep is reasoning, not a script
     cron: '0 */6 * * *',
-    prompt: 'Solomon deep-sweep tick: FIRST enforce the per-sweep task_budget at ENTRY (node -e require("./scripts/solomon-advisory.cjs").enforceSweepBudget — count/wall-clock/token) BEFORE any Read/Grep; if over budget, STOP. Else drain the consult inbox and answer the highest-value open solomon_consult with deep analysis via node scripts/solomon-advisory.cjs send "<answer>" --reply-to <consult-correlation> (dedup + quota enforced). Propose, never execute.',
+    // SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001: the tick resolves its MODE at tick time from the
+    // LIVE Solomon pin (solomonSweepMode). Fable pin -> proactive backlog sweep; else -> consult-only
+    // (today's behavior). Mode-B activation is coupled to the Fable-5 pin swap, not the §11 ledger.
+    prompt: 'Solomon deep-sweep tick: (1) FIRST enforce the per-sweep task_budget at ENTRY (node -e require("./scripts/solomon-advisory.cjs").enforceSweepBudget — count/wall-clock/token) BEFORE any Read/Grep; if over budget, STOP. (2) Resolve the sweep MODE at TICK TIME from the LIVE Solomon model pin and log it: node -e "import(\'./scripts/solomon-startup-check.mjs\').then(m=>process.stdout.write(m.solomonSweepMode()))". (3a) If mode===proactive (Fable pin — SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001): pull ONE §4 backlog item, investigate the LIVE codebase with deep analysis, and surface EXACTLY ONE propose-only finding via node scripts/solomon-advisory.cjs send "<finding>" (dedup + quota + silence-by-default enforced). (3b) Else (consult mode, default): drain the consult inbox and answer the highest-value open solomon_consult with deep analysis via node scripts/solomon-advisory.cjs send "<answer>" --reply-to <consult-correlation> (dedup + quota enforced). Propose, NEVER execute/build in either mode (CONST-002).',
   },
 ];
 

--- a/tests/unit/solomon-startup-check.test.js
+++ b/tests/unit/solomon-startup-check.test.js
@@ -9,6 +9,7 @@ const require = createRequire(import.meta.url);
 import {
   SOLOMON_LOOPS, ROLE_CONTEXT_DOC, parseDurableDutyMarkers, missingDurableDuties,
   loopStatus, parseArmedSet, renderContractParity, slugifyDuty, wiredDutySlugs,
+  solomonSweepMode, isProactiveSweepEnabled,
 } from '../../scripts/solomon-startup-check.mjs';
 import { buildSelfAdherenceVerdict } from '../../scripts/solomon-self-adherence-review.mjs';
 
@@ -133,5 +134,28 @@ describe('retry-state-manager EXEMPT_PATTERNS includes the solomon inbox command
     const { isExempt } = require('../../scripts/hooks/retry-state-manager.cjs');
     expect(isExempt('node scripts/solomon-advisory.cjs inbox --quiet')).toBe(true);
     expect(isExempt('node scripts/solomon-advisory.cjs send "x"')).toBe(false); // only the inbox tick is exempt
+  });
+});
+
+describe('SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001: solomonSweepMode Fable-pin trigger', () => {
+  const noEnv = {}; // isolate from the ambient process.env override
+  it('a Fable pin flips the deep-sweep tick to proactive-sweep mode', () => {
+    expect(solomonSweepMode('claude-fable-5', noEnv)).toBe('proactive');
+    expect(isProactiveSweepEnabled('claude-fable-5', noEnv)).toBe(true);
+  });
+  it('the Opus 4.8 pin (and any non-Fable id) stays consult-only', () => {
+    expect(solomonSweepMode('claude-opus-4-8', noEnv)).toBe('consult');
+    expect(solomonSweepMode('claude-sonnet-5', noEnv)).toBe('consult');
+    expect(isProactiveSweepEnabled('claude-opus-4-8', noEnv)).toBe(false);
+  });
+  it('an empty/undefined pin fails safe to consult (Mode-B off)', () => {
+    expect(solomonSweepMode('', noEnv)).toBe('consult');
+    expect(solomonSweepMode(null, noEnv)).toBe('consult');
+  });
+  it('SOLOMON_SWEEP_MODE overrides the pin-derived result in BOTH directions', () => {
+    expect(solomonSweepMode('claude-opus-4-8', { SOLOMON_SWEEP_MODE: 'proactive' })).toBe('proactive');
+    expect(solomonSweepMode('claude-fable-5', { SOLOMON_SWEEP_MODE: 'consult' })).toBe('consult');
+    expect(solomonSweepMode('claude-opus-4-8', { SOLOMON_SWEEP_MODE: 'PROACTIVE' })).toBe('proactive'); // case-insensitive
+    expect(solomonSweepMode('claude-fable-5', { SOLOMON_SWEEP_MODE: 'garbage' })).toBe('proactive'); // invalid override ignored
   });
 });


### PR DESCRIPTION
## Summary
Chairman decision (2026-07-01): decouple Solomon **Mode-B** (proactive backlog sweeps) activation from the §11 advice-outcome ledger and couple it to the **Fable-5 model-pin swap** — when Solomon's pin swaps to a Fable id, Mode-B goes live on the next deep-sweep tick, no ledger wait.

## Changes
- **FR-1** `scripts/solomon-startup-check.mjs`: `solomonSweepMode(pin=getClaudeModel('solomon'), env)` → `'proactive'` for a Fable pin (`/fable/i`) else `'consult'`, with a `SOLOMON_SWEEP_MODE` override (deterministic escape against a future non-`fable` id). Reuses `getClaudeModel` — no pin-resolution duplication.
- **FR-2** the deep-sweep `SOLOMON_LOOPS` prompt resolves the mode **at tick time** (live pin) and branches: proactive (pull one §4 item, surface ONE propose-only finding, `enforceSweepBudget` at ENTRY) vs consult (today's behavior, byte-unchanged). Solomon never executes (**CONST-002**).
- **FR-3** `docs/architecture/solomon-activation-runbook.md`: Stage-B re-gated from the ledger-accuracy gate to the Fable-pin swap; §11 ledger retained for §6 metrics; pin flip stays an operator action.
- **FR-4** unit tests.

## Verification
- 18/18 `solomon-startup-check` tests green; lint clean; live smoke (default→consult, `CLAUDE_MODEL_SOLOMON=claude-fable-5`→proactive, override both ways).
- Default (non-Fable, current production) behavior byte-unchanged — proactive only activates on an operator pin-swap.
- Gates: LEAD-TO-PLAN 94 · PLAN-TO-EXEC 97 · EXEC-TO-PLAN 94 · PLAN-TO-LEAD 96. VALIDATION 95 · TESTING 95 · REGRESSION 92.

OUT OF SCOPE: the actual Fable pin flip (operator action); the §11 ledger subsystem (companion SD).

SD: SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)