### PR TITLE
fix(SD-FDBK-ENH-CANARY-VENTURE-PROBE-001): remove errored Realtime channel before polling fallback

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -151,6 +151,13 @@ export async function waitForDecision({ decisionId, supabase, logger = console, 
             logger.log(`   Realtime subscription active for decision ${decisionId}`);
           } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
             logger.warn(`   Realtime unavailable (${status}), using polling fallback`);
+            // SD-FDBK-ENH-CANARY-VENTURE-PROBE-001: tear down the errored channel before
+            // falling back to polling. Leaving it subscribed-but-errored is what triggers
+            // the vendored phoenix.cjs.js Channel.trigger/onClose infinite recursion crash.
+            if (subscription) {
+              supabase.removeChannel(subscription);
+              subscription = null;
+            }
             startPolling();
           }
         });

--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -74,6 +74,88 @@ describe('waitForDecision', () => {
       waitForDecision({ decisionId: 'd1', supabase, logger, timeoutMs: 50 }),
     ).rejects.toThrow('timed out');
   }, 5000);
+
+  // SD-FDBK-ENH-CANARY-VENTURE-PROBE-001: CHANNEL_ERROR/TIMED_OUT must tear down the
+  // errored channel via removeChannel before polling starts, or the vendored phoenix
+  // client's Channel.trigger/onClose can recurse into a stack-overflow crash.
+  it('removes the errored channel before falling back to polling on CHANNEL_ERROR, with no duplicate removeChannel when later resolved via polling', async () => {
+    vi.useFakeTimers();
+    try {
+      const channelMock = { on: vi.fn().mockReturnThis() };
+      channelMock.subscribe = vi.fn((cb) => {
+        setTimeout(() => cb('CHANNEL_ERROR'), 0);
+        return channelMock;
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn()
+            .mockResolvedValueOnce({ data: { status: 'pending' } })
+            .mockResolvedValue({ data: { status: 'approved', rationale: null, decision: 'approve' } }),
+        }),
+        channel: vi.fn().mockReturnValue(channelMock),
+        removeChannel: vi.fn(),
+      };
+      const logger = createMockLogger();
+
+      const promise = waitForDecision({ decisionId: 'd1', supabase, logger });
+
+      // Let the deferred CHANNEL_ERROR callback fire (subscription is already assigned by now).
+      await vi.advanceTimersByTimeAsync(0);
+      expect(supabase.removeChannel).toHaveBeenCalledTimes(1);
+      expect(supabase.removeChannel).toHaveBeenCalledWith(channelMock);
+
+      // Advance past the polling interval so the decision resolves via the fallback.
+      await vi.advanceTimersByTimeAsync(10_000);
+      const result = await promise;
+
+      expect(result.status).toBe('approved');
+      // cleanup() must not double-remove — subscription was already nulled by the error branch.
+      expect(supabase.removeChannel).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('removes the errored channel on TIMED_OUT as well as CHANNEL_ERROR', async () => {
+    vi.useFakeTimers();
+    try {
+      const channelMock = { on: vi.fn().mockReturnThis() };
+      channelMock.subscribe = vi.fn((cb) => {
+        setTimeout(() => cb('TIMED_OUT'), 0);
+        return channelMock;
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { status: 'pending' } }),
+        }),
+        channel: vi.fn().mockReturnValue(channelMock),
+        removeChannel: vi.fn(),
+      };
+      const logger = createMockLogger();
+
+      // 3000ms deliberately avoids colliding with waitForDecision's own 5000ms polling
+      // safety-net setTimeout, which would otherwise also fire in the same timer flush.
+      const promise = waitForDecision({ decisionId: 'd1', supabase, logger, timeoutMs: 3000 });
+      // Attach the rejection expectation immediately so it isn't flagged as briefly
+      // unhandled once fake-timer advancement causes the promise to actually reject.
+      const rejection = expect(promise).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(supabase.removeChannel).toHaveBeenCalledTimes(1);
+      expect(supabase.removeChannel).toHaveBeenCalledWith(channelMock);
+
+      await vi.advanceTimersByTimeAsync(3000);
+      await rejection;
+      // cleanup() from the timeout handler must not double-remove the already-nulled subscription.
+      expect(supabase.removeChannel).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('createOrReusePendingDecision', () => {


### PR DESCRIPTION
## Summary
- `waitForDecision()`'s Realtime `.subscribe()` status callback fell straight to `startPolling()` on `CHANNEL_ERROR`/`TIMED_OUT` without ever tearing down the errored channel via `supabase.removeChannel()`
- That still-subscribed-but-errored channel is the confirmed trigger for the vendored `@supabase/realtime-js` phoenix client's `Channel.trigger`/`onClose` to recurse infinitely, overflowing the stack and crashing the worker process — reproduced twice in the Canary Venture Probe GitHub Actions workflow (runs 28315363368, 28517279441)
- Fix: call `supabase.removeChannel(subscription)` and null the reference in that branch, before `startPolling()`. The existing `cleanup()` guard (`if (subscription)`) then naturally skips a redundant second `removeChannel` call once the decision resolves via polling
- Backend-only change (`EHG_Engineer`), no UI/schema/dependency changes

## Test plan
- [x] 16/16 unit tests pass in `tests/unit/eva/chairman-decision-watcher.test.js`, including 2 new fake-timer regression tests covering `CHANNEL_ERROR`, `TIMED_OUT`, and the no-double-`removeChannel` invariant
- [x] TESTING sub-agent independently verified (PASS, 92% confidence)
- [ ] Post-merge: re-run the Canary Venture Probe GitHub Actions workflow to confirm the real crash no longer reproduces (`gh workflow run "Canary Venture Probe" --ref main`)

SD-FDBK-ENH-CANARY-VENTURE-PROBE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)