### PR TITLE
feat(SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B): model×effort strength-engine tier ladder + --model/--effort self-report capture

### DIFF
--- a/.claude/commands/checkin.md
+++ b/.claude/commands/checkin.md
@@ -47,6 +47,22 @@ node scripts/worker-checkin.cjs
 
 The CLI prints **one JSON object** describing the resolved action. It does the whole handshake itself: resolve the active coordinator (`lib/coordinator/resolve.cjs`), confirm callsign, register availability with an idempotent `payload.kind=roll_call` row (off the friction channel), then resolve work.
 
+### `--model` / `--effort` (SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B)
+
+Self-report your model/effort at check-in so the fleet's automatic tier ladder can rank
+you against the live fleet:
+
+```bash
+node scripts/worker-checkin.cjs --model sonnet --effort xhigh
+```
+
+- `--model`: one of `haiku`, `sonnet`, `opus`, `fable` (unrecognized values map conservative-UP to `fable`).
+- `--effort`: one of `low`, `medium`, `high`, `xhigh` (the legacy `max` spelling is folded into `xhigh`; unrecognized values map conservative-UP to `xhigh`).
+- Both flags are **optional** — omitting either (or both) is byte-identical to running `worker-checkin.cjs` with no flags at all (no-op).
+- The merge is **idempotent**: running the same flags again produces the same `metadata.model`/`metadata.effort`/`metadata.tier_rank`, not a duplicate or drifted value.
+- A chairman/coordinator-set `metadata.effort_source` (anything other than `worker_self_report`) **always wins** over your `--effort` flag — effort is not reliably self-detectable by the worker LLM, so an authoritative external stamp is never silently overwritten. `--model` has no equivalent protection (models ARE reliably self-reportable).
+- `metadata.model` is also captured automatically at `SessionStart` (a secondary, lower-priority auto-source) — `--model` at check-in is the more explicit, authoritative signal.
+
 ## Act on the result (NEVER stop to ask the human)
 
 | `action` | What the CLI did | What you do next | Then |

--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -2,20 +2,45 @@
 /**
  * Complexity-tier ladder + worker-tier resolution + degrade-to-1 invariant.
  * SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-2, FR-5).
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-1..FR-4): strength-engine rewrite.
  *
- * An ORDINAL model×effort ladder: each rung is cheaper-but-capable below, more
- * expensive above. v1 ladder maxes the CHEAP reasoning dial first (Sonnet@max),
- * then escalates Opus by effort. Cardinality is CONFIG-DRIVEN (read from LADDER),
- * never hardcoded — adding/removing a rung needs only this array, and every rank
- * comparison (clamp / top-rung default / rubric ceiling) keys off LADDER.length.
+ * A model×effort STRENGTH ENGINE replaces the old static 4-rung ladder. Each worker's
+ * capabilityScore is model-dominant (any stronger model outranks any weaker model
+ * regardless of effort); tier_rank is the DENSE RANK of capabilityScore among the
+ * DISTINCT scores present in a live fleet snapshot, mapped to 1..K. K is CACHED
+ * (lastKnownTopRank) and refreshed only when a live fleet is actually observed, so
+ * argument-free callers (clamp/ladderTopRank/resolveWorkerTierRank and their consumers
+ * lib/fleet/sd-tier-rank.mjs, lib/fleet/tier-claimable.cjs, lib/coordinator/dispatch.cjs)
+ * keep working unmodified against a safe default of K=4.
  *
- * Worker tier_rank is a CHAIRMAN-DECLARED stamp on claude_sessions.metadata.tier_rank
- * — this module does NOT build a worker self-advertisement mechanism. An UNSTAMPED
- * worker resolves to the TOP rung so it is never wrongly skipped-over (it can take any
- * work; the conservative direction).
+ * Worker tier_rank is still ultimately a stamp on claude_sessions.metadata.tier_rank —
+ * this module derives what that stamp SHOULD be; the write path is
+ * scripts/worker-checkin.cjs. An UNSTAMPED worker resolves to the TOP rung so it is
+ * never wrongly skipped-over (it can take any work; the conservative direction) — the
+ * same rule extends to normalizeModel/normalizeEffort: an unrecognized value maps UP
+ * to the strongest known value, never down.
  */
 
-/** v1 ordinal ladder. rank 1 = cheapest-sufficient, rank N = most capable. */
+/** Model strength, weakest to strongest. */
+const MODEL_STRENGTH = Object.freeze({ haiku: 0, sonnet: 1, opus: 2, fable: 3 });
+
+/** Effort strength, weakest to strongest. 'xhigh' is the canonical top spelling. */
+const EFFORT_STRENGTH = Object.freeze({ low: 0, medium: 1, high: 2, xhigh: 3 });
+
+/** Legacy effort spellings folded into the canonical set (conservative-UP). */
+const EFFORT_SYNONYMS = Object.freeze({ max: 'xhigh' });
+
+/** Width of the effort dimension — capabilityScore = model * EFFORT_SPAN + effort. */
+const EFFORT_SPAN = Math.max(...Object.values(EFFORT_STRENGTH)) + 1;
+
+const STRONGEST_MODEL = Object.keys(MODEL_STRENGTH).reduce(
+  (a, b) => (MODEL_STRENGTH[b] > MODEL_STRENGTH[a] ? b : a)
+);
+const STRONGEST_EFFORT = Object.keys(EFFORT_STRENGTH).reduce(
+  (a, b) => (EFFORT_STRENGTH[b] > EFFORT_STRENGTH[a] ? b : a)
+);
+
+/** v1 static ladder — the SAFE DEFAULT (K=4) before any live fleet has been observed. */
 const LADDER = [
   { rank: 1, model: 'sonnet', effort: 'max' },
   { rank: 2, model: 'opus', effort: 'low' },
@@ -23,9 +48,61 @@ const LADDER = [
   { rank: 4, model: 'opus', effort: 'high' },
 ];
 
-/** Top (most-capable) rung — config-driven, NOT a hardcoded 4. */
+/** Cached top rank. Starts at the static default; refreshed by deriveLiveLadder. */
+let lastKnownTopRank = LADDER.length;
+
+/**
+ * Unknown/missing model maps conservative-UP to the strongest known model — never
+ * silently down to the weakest, so an unrecognized-but-possibly-powerful worker is
+ * never under-restricted.
+ * @param {string} [model]
+ * @returns {string} a key of MODEL_STRENGTH
+ */
+function normalizeModel(model) {
+  const key = typeof model === 'string' ? model.toLowerCase().trim() : '';
+  return Object.prototype.hasOwnProperty.call(MODEL_STRENGTH, key) ? key : STRONGEST_MODEL;
+}
+
+/**
+ * Unknown/missing effort (including legacy 'max') maps conservative-UP to the
+ * strongest known effort ('xhigh') — never silently down to the weakest.
+ * @param {string} [effort]
+ * @returns {string} a key of EFFORT_STRENGTH
+ */
+function normalizeEffort(effort) {
+  const raw = typeof effort === 'string' ? effort.toLowerCase().trim() : '';
+  const key = EFFORT_SYNONYMS[raw] || raw;
+  return Object.prototype.hasOwnProperty.call(EFFORT_STRENGTH, key) ? key : STRONGEST_EFFORT;
+}
+
+/**
+ * Model-dominant capability score: any stronger model outranks any weaker model
+ * regardless of effort. Normalizes both inputs first (unknown => strongest).
+ * @param {string} [model]
+ * @param {string} [effort]
+ * @returns {number}
+ */
+function capabilityScore(model, effort) {
+  return MODEL_STRENGTH[normalizeModel(model)] * EFFORT_SPAN + EFFORT_STRENGTH[normalizeEffort(effort)];
+}
+
+/**
+ * Reverse lookup: the GLOBAL dense rank of a (model, effort) pair across the full
+ * theoretical model×effort lattice (independent of any live fleet). Since
+ * capabilityScore is injective over the lattice, this is simply score + 1 (1-indexed).
+ * Callers that need a value bounded by the current live ladder should pass this
+ * through clamp() (e.g. scripts/worker-checkin.cjs).
+ * @param {string} [model]
+ * @param {string} [effort]
+ * @returns {number}
+ */
+function rankForModelEffort(model, effort) {
+  return capabilityScore(model, effort) + 1;
+}
+
+/** Top (most-capable) rung — cached, refreshed only by deriveLiveLadder. */
 function ladderTopRank() {
-  return LADDER.length;
+  return lastKnownTopRank;
 }
 
 /** Bound an arbitrary rank into the valid [1, ladderTopRank()] range. Non-numeric => top rung. */
@@ -37,8 +114,9 @@ function clamp(rank) {
 
 /**
  * Resolve a worker session's declared tier_rank from claude_sessions.metadata.tier_rank.
- * Chairman/coordinator-declared stamp; defaults to the TOP rung when absent/invalid so an
- * unstamped worker is never wrongly skipped-over.
+ * SINGLE-ARG, unchanged signature (lib/coordinator/dispatch.cjs:238 and
+ * scripts/worker-checkin.cjs call this argument-free-of-live-fleet). Defaults to the
+ * TOP rung when absent/invalid so an unstamped worker is never wrongly skipped-over.
  * @param {{ metadata?: { tier_rank?: number|string } }} session
  * @returns {number} a rank in [1, ladderTopRank()]
  */
@@ -47,6 +125,49 @@ function resolveWorkerTierRank(session) {
   const n = Number(raw);
   if (Number.isFinite(n) && n >= 1 && n <= ladderTopRank()) return Math.round(n);
   return ladderTopRank();
+}
+
+/**
+ * Build a dense-ranked ladder from a live fleet snapshot ([{model, effort}, ...]).
+ * Dense-ranks the DISTINCT capabilityScores actually present, 1..K, and REFRESHES the
+ * cached lastKnownTopRank to K (only when the fleet is non-empty — an empty fleet
+ * leaves the cache untouched, degrading safely to the prior/default K).
+ * @param {Array<{model?: string, effort?: string}>} liveFleet
+ * @returns {{ rankByScore: Map<number, number>, topRank: number, entries: Array<object> }}
+ */
+function deriveLiveLadder(liveFleet) {
+  const list = Array.isArray(liveFleet) ? liveFleet : [];
+  const scored = list.map((w) => ({
+    model: normalizeModel(w && w.model),
+    effort: normalizeEffort(w && w.effort),
+    score: capabilityScore(w && w.model, w && w.effort),
+  }));
+  const distinctScores = [...new Set(scored.map((s) => s.score))].sort((a, b) => a - b);
+  const rankByScore = new Map(distinctScores.map((score, i) => [score, i + 1]));
+  const topRank = distinctScores.length > 0 ? distinctScores.length : lastKnownTopRank;
+  if (distinctScores.length > 0) lastKnownTopRank = topRank;
+  const entries = scored.map((s) => ({ ...s, rank: rankByScore.get(s.score) }));
+  return { rankByScore, topRank, entries };
+}
+
+/**
+ * Two-arg tier-rank resolution: prefers the live-fleet-derived dense rank for this
+ * worker's model/effort when a live fleet is supplied; falls back to the single-arg
+ * resolveWorkerTierRank behavior otherwise. Does NOT replace resolveWorkerTierRank —
+ * added alongside it so existing single-arg callers are untouched.
+ * @param {{ metadata?: { tier_rank?: number|string, model?: string, effort?: string } }} session
+ * @param {Array<{model?: string, effort?: string}>} [liveFleet]
+ * @returns {number}
+ */
+function deriveWorkerTierRank(session, liveFleet) {
+  const model = session && session.metadata && session.metadata.model;
+  const effort = session && session.metadata && session.metadata.effort;
+  if (model && effort && Array.isArray(liveFleet) && liveFleet.length > 0) {
+    const { rankByScore } = deriveLiveLadder(liveFleet);
+    const rank = rankByScore.get(capabilityScore(model, effort));
+    if (Number.isFinite(rank)) return rank;
+  }
+  return resolveWorkerTierRank(session);
 }
 
 /** Tiering activates only at >= this many genuine live fleet workers (FR-5 degrade-to-1). */
@@ -83,6 +204,15 @@ async function isTieringActive(supabase, opts = {}) {
   }
 }
 
+/**
+ * Test-only: reset the cached lastKnownTopRank back to the static default (LADDER.length).
+ * lastKnownTopRank is module-level mutable state, so tests that call deriveLiveLadder must
+ * reset it (e.g. in beforeEach) to avoid leaking a cached K across unrelated test cases.
+ */
+function __resetLadderCacheForTests() {
+  lastKnownTopRank = LADDER.length;
+}
+
 module.exports = {
   LADDER,
   ladderTopRank,
@@ -90,4 +220,14 @@ module.exports = {
   resolveWorkerTierRank,
   isTieringActive,
   MIN_LIVE_FOR_TIERING,
+  MODEL_STRENGTH,
+  EFFORT_STRENGTH,
+  EFFORT_SPAN,
+  capabilityScore,
+  rankForModelEffort,
+  normalizeModel,
+  normalizeEffort,
+  deriveLiveLadder,
+  deriveWorkerTierRank,
+  __resetLadderCacheForTests,
 };

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -278,14 +278,20 @@ function findClaudeCodePid(entryPath = 'unknown') {
 // QF-20260627-531: pure metadata merge for the session upsert. Spreads the existing row's
 // metadata first so coordinator-stamped fields (callsign, tier_rank, fleet_identity, …) survive,
 // then stamps the telemetry fields. Exported for unit testing.
-function buildSessionMetadata(existingMetadata, ccPid, source) {
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-8): also persists `model` (previously written
+// only to the local marker file, never the DB) as a secondary auto-source alongside the
+// worker-checkin.cjs --model self-report. get-then-merge (base spread first) means an
+// already-DB-stamped metadata.model is never clobbered by an absent/null model here.
+function buildSessionMetadata(existingMetadata, ccPid, source, model) {
   const base = (existingMetadata && typeof existingMetadata === 'object' && !Array.isArray(existingMetadata))
     ? existingMetadata
     : {};
-  return { ...base, cc_pid: ccPid, source: source || 'unknown' };
+  const merged = { ...base, cc_pid: ccPid, source: source || 'unknown' };
+  if (model) merged.model = model;
+  return merged;
 }
 
-async function upsertSessionRow(sessionId, ccPid, source) {
+async function upsertSessionRow(sessionId, ccPid, source, model) {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !supabaseKey) {
@@ -330,7 +336,7 @@ async function upsertSessionRow(sessionId, ccPid, source) {
     heartbeat_at: now,
     pid: Number.isFinite(pidNum) ? pidNum : null,
     hostname: require('os').hostname(),
-    metadata: buildSessionMetadata(existingMetadata, ccPid, source),
+    metadata: buildSessionMetadata(existingMetadata, ccPid, source, model),
   });
 
   const MAX_ATTEMPTS = 3;
@@ -560,7 +566,7 @@ function main() {
         // silently no-ops and the identity chain between env var, markers, and DB
         // breaks. Insert-if-not-exists here so tick has a target. Uses PostgREST
         // directly (no supabase-js dep) to match session-tick.cjs pattern.
-        await upsertSessionRow(sessionId, ccPid, data.source);
+        await upsertSessionRow(sessionId, ccPid, data.source, data.model);
 
         // ── SD-LEO-INFRA-WORKER-SOURCE-SIDE-001: spawn detached session-tick ──
         // Writes process_alive_at every 30s until the parent CC exits.

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -23,6 +23,12 @@
  *
  * Usage: node scripts/worker-checkin.cjs            (CLAUDE_SESSION_ID from env)
  *        node scripts/worker-checkin.cjs --json      (same; JSON is the default)
+ *        node scripts/worker-checkin.cjs --model <haiku|sonnet|opus|fable> --effort <low|medium|high|xhigh>
+ *          (SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B FR-3: self-report model/effort at
+ *          check-in; merged into claude_sessions.metadata and used to derive tier_rank for
+ *          THIS check-in call. No-op — byte-identical to today — when both flags are absent.
+ *          A chairman/coordinator-set metadata.effort_source='chairman' always wins over a
+ *          worker's own --effort self-report.)
  */
 
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
@@ -37,7 +43,8 @@ const { ensureActiveBaseline } = require('../lib/fleet/ensure-active-baseline.cj
 // scripts/stale-session-sweep.cjs CLAIM_FIX (closes the self_claim-vs-sweep writer-consumer-asymmetry).
 const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligibility, parentLeadPending } = require('../lib/fleet/claim-eligibility.cjs');
 // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
-const { resolveWorkerTierRank, isTieringActive } = require('../lib/fleet/tier-ladder.cjs');
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): --model/--effort capture at check-in.
+const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, clamp: clampTierRank } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): tier-aware "claimable-to-MY-rung" rollup.
 const { claimableForTier } = require('../lib/fleet/tier-claimable.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
@@ -949,7 +956,60 @@ async function runCheckin(sb, sessionId, opts = {}) {
   return result;
 }
 
-async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordinatorId } = {}) {
+/**
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3, FR-7): read-modify-merge a worker's
+ * --model/--effort self-report into its session metadata. Pure (no I/O) — the caller
+ * persists the result. Returns { metadata, changed } where `changed` is false (and
+ * `metadata` is the UNTOUCHED input) when both cliModel and cliEffort are absent (TR-2:
+ * byte-identical no-op) OR when the merge would not actually alter any field (idempotent
+ * diff-guard — a repeated identical call never re-writes the same values).
+ *
+ * effort_source='chairman' (or any coordinator-stamped source other than the worker's own
+ * self-report) WINS over a worker's --effort flag — effort is not reliably self-detectable
+ * by the worker LLM, so an authoritative external stamp is never silently overwritten.
+ * Self-report only fills metadata.effort when effort_source is unset or already
+ * 'worker_self_report'. model has no analogous protection (models ARE reliably
+ * self-reportable).
+ *
+ * @param {object|null} sessionMetadata current claude_sessions.metadata (may be null)
+ * @param {{ model?: string|null, effort?: string|null }} cli parsed --model/--effort
+ * @returns {{ metadata: object|null, changed: boolean }}
+ */
+function mergeCheckinModelEffort(sessionMetadata, { model: cliModel = null, effort: cliEffort = null } = {}) {
+  if (!cliModel && !cliEffort) return { metadata: sessionMetadata, changed: false }; // TR-2 no-op
+
+  const current = sessionMetadata || {};
+  const next = { ...current };
+  let changed = false;
+
+  if (cliModel) {
+    const normalized = normalizeModel(cliModel);
+    if (next.model !== normalized) { next.model = normalized; changed = true; }
+  }
+
+  if (cliEffort) {
+    const effortSource = current.effort_source;
+    const chairmanWins = effortSource && effortSource !== 'worker_self_report';
+    if (!chairmanWins) {
+      const normalized = normalizeEffort(cliEffort);
+      if (next.effort !== normalized) { next.effort = normalized; changed = true; }
+      if (next.effort_source !== 'worker_self_report') { next.effort_source = 'worker_self_report'; changed = true; }
+    }
+  }
+
+  if (changed) {
+    const finalModel = next.model || current.model;
+    const finalEffort = next.effort || current.effort;
+    if (finalModel && finalEffort) {
+      const rank = clampTierRank(rankForModelEffort(finalModel, finalEffort));
+      if (next.tier_rank !== rank) next.tier_rank = rank;
+    }
+  }
+
+  return changed ? { metadata: next, changed: true } : { metadata: sessionMetadata, changed: false };
+}
+
+async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordinatorId, model: cliModel = null, effort: cliEffort = null } = {}) {
   // 1. resolve coordinator (fail-open to null -> broadcast)
   let coordinatorId = null;
   try { coordinatorId = await getCoordinator(sb); } catch { coordinatorId = null; }
@@ -967,6 +1027,18 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       sessionRole = (data.metadata && data.metadata.role) || null;
     }
   } catch { /* fail-open */ }
+
+  // 2c. SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): merge --model/--effort into
+  // sessionMetadata BEFORE it is used below (tierCtx.worker_tier_rank at the resolveWorkerTierRank
+  // call further down reads sessionMetadata, so this call's own fresh values must land here first).
+  // Fail-open: a persist error never blocks the check-in itself.
+  try {
+    const { metadata: mergedMetadata, changed } = mergeCheckinModelEffort(sessionMetadata, { model: cliModel, effort: cliEffort });
+    if (changed) {
+      sessionMetadata = mergedMetadata;
+      await sb.from('claude_sessions').update({ metadata: mergedMetadata }).eq('session_id', sessionId);
+    }
+  } catch { /* fail-open: check-in proceeds with whatever metadata was already read */ }
 
   // 2b. FR-2: re-hydrate callsign from the durable SET_IDENTITY row if metadata lost it (survives
   // release/sweep). Runs BEFORE registerRollCall so the re-hydrated callsign flows into the roll-call
@@ -1320,12 +1392,30 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   };
 }
 
+/**
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): parse --model <value> / --effort <value>
+ * from argv. Pure, no validation beyond presence — normalizeModel/normalizeEffort in
+ * mergeCheckinModelEffort handle unknown-value conservative-UP mapping. Absent flags
+ * resolve to null (the TR-2 no-op signal). Exported for tests.
+ * @param {string[]} argv process.argv.slice(2)
+ * @returns {{ model: string|null, effort: string|null }}
+ */
+function parseCheckinArgs(argv) {
+  const args = Array.isArray(argv) ? argv : [];
+  const get = (flag) => {
+    const i = args.indexOf(flag);
+    return i >= 0 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : null;
+  };
+  return { model: get('--model'), effort: get('--effort') };
+}
+
 async function main() {
   const sessionId = process.env.CLAUDE_SESSION_ID;
   if (!sessionId) {
     console.log(JSON.stringify({ ok: false, action: 'error', error: 'CLAUDE_SESSION_ID env var required (set by the SessionStart hook).' }, null, 2));
     process.exit(1);
   }
+  const { model: cliModel, effort: cliEffort } = parseCheckinArgs(process.argv.slice(2));
   let sb;
   try {
     sb = ws.getServiceClient();
@@ -1333,11 +1423,11 @@ async function main() {
     console.log(JSON.stringify({ ok: false, action: 'error', error: `supabase client unavailable: ${e.message}` }, null, 2));
     process.exit(1);
   }
-  const result = await runCheckin(sb, sessionId);
+  const result = await runCheckin(sb, sessionId, { model: cliModel, effort: cliEffort });
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/capture-session-id-metadata-merge.test.js
+++ b/tests/unit/capture-session-id-metadata-merge.test.js
@@ -36,4 +36,28 @@ describe('QF-20260627-531: buildSessionMetadata merge-preserves stamped fields',
     // An array/other non-object is ignored (treated as empty base) — never spreads garbage.
     expect(buildSessionMetadata(['x'], '9', 's')).toEqual({ cc_pid: '9', source: 's' });
   });
+
+  // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-8): persist model to the DB, not just the
+  // local marker file.
+  it('FR-8: persists model into metadata when provided', () => {
+    const merged = buildSessionMetadata({}, '9', 'sessionstart', 'sonnet');
+    expect(merged.model).toBe('sonnet');
+  });
+
+  it('FR-8: omitting model (4th arg absent) does NOT add a model key — backward compatible with pre-FR-8 call sites', () => {
+    const merged = buildSessionMetadata({}, '9', 'sessionstart');
+    expect(merged).not.toHaveProperty('model');
+  });
+
+  it('FR-8: an already-DB-stamped metadata.model is never clobbered by an absent/null model this call', () => {
+    const existing = { model: 'opus', callsign: 'Golf' };
+    const merged = buildSessionMetadata(existing, '9', 'recapture', null);
+    expect(merged.model).toBe('opus'); // preserved, not overwritten by the null 4th arg
+  });
+
+  it('FR-8: a fresh model self-report DOES update a previously-stamped model', () => {
+    const existing = { model: 'opus' };
+    const merged = buildSessionMetadata(existing, '9', 'sessionstart', 'fable');
+    expect(merged.model).toBe('fable');
+  });
 });

--- a/tests/unit/fleet/complexity-tiered-assignment.test.js
+++ b/tests/unit/fleet/complexity-tiered-assignment.test.js
@@ -46,6 +46,11 @@ describe('FR-1 computeMinTierRank rubric', () => {
 describe('FR-2 tier ladder + worker tier resolution', () => {
   it('reads ladder cardinality from config, not a hardcoded 4', () => {
     expect(LADDER.length).toBe(ladderTopRank());
+    // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B: LADDER is now the static SAFE-DEFAULT
+    // ladder (K=4 before any live fleet is observed) rather than the sole ranking source
+    // -- a live fleet's dense rank comes from deriveLiveLadder/deriveWorkerTierRank
+    // instead (see tests/unit/fleet/tier-ladder-strength-engine.test.js). LADDER[0] itself
+    // is unchanged by the rewrite, so this shape assertion still holds by design.
     expect(LADDER[0]).toMatchObject({ rank: 1, model: 'sonnet', effort: 'max' });
   });
 

--- a/tests/unit/fleet/tier-ladder-strength-engine.test.js
+++ b/tests/unit/fleet/tier-ladder-strength-engine.test.js
@@ -1,0 +1,148 @@
+/**
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-1..FR-4) — tier-ladder.cjs strength
+ * engine: model×effort capabilityScore, dense-rank live-fleet derivation, conservative-UP
+ * normalization, and backward compatibility with the argument-free consumer contract
+ * (lib/fleet/sd-tier-rank.mjs, lib/fleet/tier-claimable.cjs, lib/coordinator/dispatch.cjs).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  MODEL_STRENGTH,
+  capabilityScore,
+  rankForModelEffort,
+  normalizeModel,
+  normalizeEffort,
+  deriveLiveLadder,
+  deriveWorkerTierRank,
+  resolveWorkerTierRank,
+  ladderTopRank,
+  clamp,
+  LADDER,
+  __resetLadderCacheForTests,
+} from '../../../lib/fleet/tier-ladder.cjs';
+
+beforeEach(() => {
+  __resetLadderCacheForTests();
+});
+
+describe('FR-1: normalizeModel / normalizeEffort — conservative-UP on unknown', () => {
+  it('normalizeEffort maps the legacy "max" spelling to the canonical "xhigh"', () => {
+    expect(normalizeEffort('max')).toBe('xhigh');
+  });
+
+  it('TS-3: an unrecognized model maps to the strongest known model, not the weakest', () => {
+    expect(normalizeModel('some-unknown-future-model')).toBe('fable');
+    expect(MODEL_STRENGTH[normalizeModel('some-unknown-future-model')]).toBe(MODEL_STRENGTH.fable);
+  });
+
+  it('an unrecognized effort maps to the strongest known effort, not the weakest', () => {
+    expect(normalizeEffort('ultracode')).toBe('xhigh');
+    expect(normalizeEffort(undefined)).toBe('xhigh');
+  });
+
+  it('recognized values pass through unchanged (case-insensitive)', () => {
+    expect(normalizeModel('OPUS')).toBe('opus');
+    expect(normalizeEffort('Medium')).toBe('medium');
+  });
+});
+
+describe('FR-1: capabilityScore — model-dominant ordering', () => {
+  it('any opus score outranks any sonnet score regardless of effort', () => {
+    const weakestOpus = capabilityScore('opus', 'low');
+    const strongestSonnet = capabilityScore('sonnet', 'xhigh');
+    expect(weakestOpus).toBeGreaterThan(strongestSonnet);
+  });
+
+  it('rankForModelEffort is a numeric reverse lookup consistent with capabilityScore ordering', () => {
+    const opusXhigh = rankForModelEffort('opus', 'xhigh');
+    const sonnetLow = rankForModelEffort('sonnet', 'low');
+    expect(typeof opusXhigh).toBe('number');
+    expect(opusXhigh).toBeGreaterThan(sonnetLow);
+    // legacy 'max' resolves through normalizeEffort before scoring
+    expect(rankForModelEffort('sonnet', 'max')).toBe(rankForModelEffort('sonnet', 'xhigh'));
+  });
+});
+
+describe('FR-2: deriveLiveLadder — dense rank among DISTINCT live scores', () => {
+  it('TS-1: a fleet with 2 distinct scores dense-ranks to K=2, model-dominant order preserved', () => {
+    const live = deriveLiveLadder([
+      { model: 'sonnet', effort: 'xhigh' },
+      { model: 'opus', effort: 'low' },
+    ]);
+    expect(live.topRank).toBe(2);
+    const sonnetRank = live.rankByScore.get(capabilityScore('sonnet', 'xhigh'));
+    const opusRank = live.rankByScore.get(capabilityScore('opus', 'low'));
+    expect(opusRank).toBeGreaterThan(sonnetRank);
+  });
+
+  it('TS-2: a homogeneous fleet collapses to K=1 (legitimate no-op)', () => {
+    const live = deriveLiveLadder([
+      { model: 'opus', effort: 'high' },
+      { model: 'opus', effort: 'high' },
+      { model: 'opus', effort: 'high' },
+    ]);
+    expect(live.topRank).toBe(1);
+    expect(ladderTopRank()).toBe(1); // cache refreshed
+  });
+
+  it('refreshes the cached lastKnownTopRank as a side effect, readable via argument-free ladderTopRank()', () => {
+    expect(ladderTopRank()).toBe(LADDER.length); // default before any live fleet
+    deriveLiveLadder([
+      { model: 'haiku', effort: 'low' },
+      { model: 'sonnet', effort: 'medium' },
+      { model: 'opus', effort: 'xhigh' },
+    ]);
+    expect(ladderTopRank()).toBe(3);
+    expect(clamp(99)).toBe(3); // clamp() picks up the refreshed cache
+  });
+
+  it('an empty live fleet leaves the cache untouched (degrades safely to the prior/default K)', () => {
+    const before = ladderTopRank();
+    const live = deriveLiveLadder([]);
+    expect(live.topRank).toBe(before);
+    expect(ladderTopRank()).toBe(before);
+  });
+});
+
+describe('FR-3/FR-4: deriveWorkerTierRank — live-fleet-aware, falls back to single-arg behavior', () => {
+  it('resolves via the live dense rank when a live fleet + session model/effort are present', () => {
+    const liveFleet = [
+      { model: 'sonnet', effort: 'xhigh' },
+      { model: 'opus', effort: 'low' },
+    ];
+    const session = { metadata: { model: 'opus', effort: 'low' } };
+    expect(deriveWorkerTierRank(session, liveFleet)).toBe(2); // opus/low is the stronger of the 2 distinct scores
+  });
+
+  it('falls back to resolveWorkerTierRank when no live fleet is supplied', () => {
+    const session = { metadata: { tier_rank: 2 } };
+    expect(deriveWorkerTierRank(session)).toBe(resolveWorkerTierRank(session));
+    expect(deriveWorkerTierRank(session)).toBe(2);
+  });
+
+  it('falls back to resolveWorkerTierRank when the session has no model/effort even with a live fleet', () => {
+    const session = { metadata: { tier_rank: 3 } };
+    const liveFleet = [{ model: 'opus', effort: 'xhigh' }];
+    expect(deriveWorkerTierRank(session, liveFleet)).toBe(3);
+  });
+});
+
+describe('TS-7: backward compatibility — argument-free consumer contract unchanged', () => {
+  it('ladderTopRank() and clamp() remain callable with zero arguments', () => {
+    expect(ladderTopRank()).toBe(4);
+    expect(clamp(2)).toBe(2);
+    expect(clamp(99)).toBe(4);
+  });
+
+  it('resolveWorkerTierRank(session) remains single-arg and unchanged', () => {
+    expect(resolveWorkerTierRank({ metadata: { tier_rank: 1 } })).toBe(1);
+    expect(resolveWorkerTierRank({})).toBe(4);
+  });
+
+  it('module.exports still exposes clamp and ladderTopRank (sd-tier-rank.mjs ESM-default-imports + destructures these)', async () => {
+    // Mirrors sd-tier-rank.mjs's own import shape: `import ladder from '.../tier-ladder.cjs'`
+    // then destructuring named exports off the CJS module.exports default.
+    const ladderDefault = (await import('../../../lib/fleet/tier-ladder.cjs')).default;
+    expect(typeof ladderDefault.clamp).toBe('function');
+    expect(typeof ladderDefault.ladderTopRank).toBe('function');
+  });
+});

--- a/tests/unit/worker-checkin-model-effort-capture.test.js
+++ b/tests/unit/worker-checkin-model-effort-capture.test.js
@@ -1,0 +1,106 @@
+/**
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3, FR-7): --model/--effort capture at
+ * worker check-in. Pure-function coverage of parseCheckinArgs and mergeCheckinModelEffort
+ * (no DB, no network).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { parseCheckinArgs, mergeCheckinModelEffort } = require('../../scripts/worker-checkin.cjs');
+
+describe('FR-3: parseCheckinArgs', () => {
+  it('parses --model and --effort from argv', () => {
+    expect(parseCheckinArgs(['--model', 'sonnet', '--effort', 'xhigh'])).toEqual({ model: 'sonnet', effort: 'xhigh' });
+  });
+
+  it('returns null for absent flags', () => {
+    expect(parseCheckinArgs([])).toEqual({ model: null, effort: null });
+    expect(parseCheckinArgs(['--json'])).toEqual({ model: null, effort: null });
+  });
+
+  it('does not treat the next flag as a value', () => {
+    expect(parseCheckinArgs(['--model', '--effort', 'xhigh'])).toEqual({ model: null, effort: 'xhigh' });
+  });
+
+  it('supports either flag alone', () => {
+    expect(parseCheckinArgs(['--model', 'opus'])).toEqual({ model: 'opus', effort: null });
+    expect(parseCheckinArgs(['--effort', 'high'])).toEqual({ model: null, effort: 'high' });
+  });
+});
+
+describe('TS-4/TR-2: mergeCheckinModelEffort — no-op when both flags absent', () => {
+  it('returns the SAME metadata object reference, changed=false, when neither flag is passed', () => {
+    const original = { foo: 'bar', tier_rank: 2 };
+    const result = mergeCheckinModelEffort(original, {});
+    expect(result.changed).toBe(false);
+    expect(result.metadata).toBe(original); // byte-identical -- same reference, not a copy
+  });
+
+  it('is a no-op for a null starting metadata too', () => {
+    const result = mergeCheckinModelEffort(null, { model: null, effort: null });
+    expect(result.changed).toBe(false);
+    expect(result.metadata).toBeNull();
+  });
+});
+
+describe('FR-3: mergeCheckinModelEffort — fresh capture sets model/effort/tier_rank', () => {
+  it('sets metadata.model, metadata.effort, effort_source, and a numeric tier_rank from unset state', () => {
+    const result = mergeCheckinModelEffort(null, { model: 'sonnet', effort: 'xhigh' });
+    expect(result.changed).toBe(true);
+    expect(result.metadata.model).toBe('sonnet');
+    expect(result.metadata.effort).toBe('xhigh');
+    expect(result.metadata.effort_source).toBe('worker_self_report');
+    expect(typeof result.metadata.tier_rank).toBe('number');
+  });
+
+  it('normalizes model/effort through the tier-ladder normalizer (e.g. legacy "max" -> "xhigh")', () => {
+    const result = mergeCheckinModelEffort(null, { model: 'opus', effort: 'max' });
+    expect(result.metadata.effort).toBe('xhigh');
+  });
+
+  it('preserves unrelated pre-existing metadata fields', () => {
+    const result = mergeCheckinModelEffort({ role: 'worker', callsign: 'Delta' }, { model: 'sonnet', effort: 'high' });
+    expect(result.metadata.role).toBe('worker');
+    expect(result.metadata.callsign).toBe('Delta');
+  });
+});
+
+describe('TS-5: mergeCheckinModelEffort — idempotent repeated calls', () => {
+  it('a second identical call produces changed=false and the SAME metadata reference (no drift, no duplicate work)', () => {
+    const first = mergeCheckinModelEffort(null, { model: 'sonnet', effort: 'xhigh' });
+    expect(first.changed).toBe(true);
+    const second = mergeCheckinModelEffort(first.metadata, { model: 'sonnet', effort: 'xhigh' });
+    expect(second.changed).toBe(false);
+    expect(second.metadata).toBe(first.metadata);
+    expect(second.metadata).toEqual(first.metadata);
+  });
+});
+
+describe('TS-6/FR-7: mergeCheckinModelEffort — chairman-set effort_source wins over self-report', () => {
+  it('given effort_source=chairman with effort already set, --effort self-report does NOT overwrite it', () => {
+    const chairmanStamped = { effort: 'high', effort_source: 'chairman' };
+    const result = mergeCheckinModelEffort(chairmanStamped, { model: null, effort: 'xhigh' });
+    expect(result.metadata.effort).toBe('high'); // unchanged -- chairman wins
+    expect(result.metadata.effort_source).toBe('chairman');
+  });
+
+  it('a --model self-report is NOT blocked by a chairman-set effort_source (only effort is protected)', () => {
+    const chairmanStamped = { effort: 'high', effort_source: 'chairman' };
+    const result = mergeCheckinModelEffort(chairmanStamped, { model: 'opus', effort: null });
+    expect(result.changed).toBe(true);
+    expect(result.metadata.model).toBe('opus');
+    expect(result.metadata.effort).toBe('high'); // still untouched
+  });
+
+  it('self-report DOES fill effort when effort_source is unset (no prior chairman stamp)', () => {
+    const result = mergeCheckinModelEffort({}, { model: null, effort: 'xhigh' });
+    expect(result.metadata.effort).toBe('xhigh');
+    expect(result.metadata.effort_source).toBe('worker_self_report');
+  });
+
+  it('self-report CAN update effort when the prior source was itself a worker self-report', () => {
+    const priorSelfReport = { effort: 'high', effort_source: 'worker_self_report' };
+    const result = mergeCheckinModelEffort(priorSelfReport, { model: null, effort: 'xhigh' });
+    expect(result.metadata.effort).toBe('xhigh');
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrites `lib/fleet/tier-ladder.cjs`'s static 4-rung LADDER into a model×effort strength engine: `capabilityScore(model, effort)` (model-dominant ordering), `deriveLiveLadder(liveFleet)` (dense-rank over the live fleet's distinct scores), conservative-UP normalization for unknown models/efforts. All existing argument-free exports (`LADDER`, `ladderTopRank()`, `clamp()`, `resolveWorkerTierRank(session)`, `isTieringActive`, `MIN_LIVE_FOR_TIERING`) remain backward-compatible for unmodified consumers (`sd-tier-rank.mjs`, `tier-claimable.cjs`, `dispatch.cjs`).
- Wires `--model`/`--effort` self-report flags into `scripts/worker-checkin.cjs` (idempotent merge, chairman-wins-over-self-report precedence for effort, no-op when flags absent).
- Adds a secondary `model` auto-source into `scripts/hooks/capture-session-id.cjs`'s SessionStart hook (backward compatible, optional 4th param).
- Deletes the now-superseded `scripts/worker-report-identity.cjs` stopgap script.

## Test plan
- [x] 15 test files / 146 tests pass (unit) via the documented `**/.worktrees/**` vitest-exclude workaround
- [x] REGRESSION sub-agent: 156/156 tests pass across directly-touched + consumer-adjacent files; API signatures of all 6 preserved exports unchanged; CJS `require()` + ESM default-import both resolve cleanly; cache-mutation cross-consumer risk assessed as theoretical (no production caller reaches `deriveLiveLadder`)
- [x] VALIDATION sub-agent: all 9 FRs verified against committed code; scope boundary confirmed clean (no edits to sibling-owned `assign-fleet-identities.cjs` / `sd-tier-rank.mjs` / `claim-eligibility.cjs`)
- [x] ESLint clean (0 errors) on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)