### PR TITLE
fix(SD-FDBK-FIX-EVA-STAGE-GOVERNANCE-001): eliminate re-entrant channel-teardown RangeError in stage-governance/reality-gates

### DIFF
--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -16,6 +16,7 @@
 
 import { ARTIFACT_TYPES } from './artifact-types.js';
 import { describeArtifactGap } from './contracts/describe-artifact-gap.js';
+import { safeRemoveChannel } from './realtime-channel-utils.js';
 
 const MODULE_VERSION = '1.0.0';
 
@@ -61,8 +62,10 @@ async function _loadBoundaryFromDB(supabase, logger) {
         )
         .subscribe((status) => {
           if (status === 'CHANNEL_ERROR' || status === 'CLOSED' || status === 'TIMED_OUT') {
-            try { _boundaryRealtimeChannel?.unsubscribe?.(); } catch { /* swallow */ }
-            _boundaryRealtimeChannel = null;
+            // SD-FDBK-FIX-EVA-STAGE-GOVERNANCE-001: safeRemoveChannel() (not
+            // unsubscribe()) avoids the vendored phoenix.cjs.js Channel.trigger/
+            // onClose infinite recursion when this callback re-fires re-entrantly.
+            _boundaryRealtimeChannel = safeRemoveChannel(supabase, _boundaryRealtimeChannel);
           }
         });
     } catch {

--- a/lib/eva/realtime-channel-utils.js
+++ b/lib/eva/realtime-channel-utils.js
@@ -1,0 +1,33 @@
+/**
+ * Shared safe teardown for Supabase Realtime channel subscriptions.
+ *
+ * SD-FDBK-FIX-EVA-STAGE-GOVERNANCE-001: calling a channel's own `unsubscribe()`
+ * re-entrantly from inside that channel's `.subscribe()` status callback (on
+ * CHANNEL_ERROR/CLOSED/TIMED_OUT) can trigger the vendored phoenix.cjs.js
+ * client's Channel.trigger/onClose to recurse infinitely (RangeError: Maximum
+ * call stack size exceeded). `supabase.removeChannel()` does not have this
+ * problem. This mirrors the pattern already shipped and tested in
+ * lib/eva/chairman-decision-watcher.js (SD-FDBK-ENH-CANARY-VENTURE-PROBE-001).
+ *
+ * @module lib/eva/realtime-channel-utils
+ */
+
+/**
+ * Tears down a Supabase Realtime channel subscription safely.
+ * Use this instead of calling `channelRef.unsubscribe()` directly, especially
+ * from inside the channel's own `.subscribe()` status callback.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {object|null|undefined} channelRef
+ * @returns {null} always returns null, for convenient reassignment:
+ *   `ref = safeRemoveChannel(supabase, ref)`
+ */
+export function safeRemoveChannel(supabase, channelRef) {
+  if (!channelRef) return null;
+  try {
+    supabase?.removeChannel?.(channelRef);
+  } catch {
+    // Best-effort teardown -- the reference is discarded either way.
+  }
+  return null;
+}

--- a/lib/eva/stage-governance.js
+++ b/lib/eva/stage-governance.js
@@ -27,6 +27,7 @@
  */
 
 import { RESERVED_CHAIRMAN_STAGES } from './autonomy-model.js';
+import { safeRemoveChannel } from './realtime-channel-utils.js';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -103,8 +104,10 @@ function _ensureSubscription(supabase) {
       .subscribe((status) => {
         if (status === 'CHANNEL_ERROR' || status === 'CLOSED' || status === 'TIMED_OUT') {
           // Subscription failed; rely on TTL-only refresh.
-          try { _subscription?.unsubscribe?.(); } catch { /* swallow */ }
-          _subscription = null;
+          // SD-FDBK-FIX-EVA-STAGE-GOVERNANCE-001: safeRemoveChannel() (not
+          // unsubscribe()) avoids the vendored phoenix.cjs.js Channel.trigger/
+          // onClose infinite recursion when this callback re-fires re-entrantly.
+          _subscription = safeRemoveChannel(supabase, _subscription);
           _subscriptionSupabase = null;
         }
       });

--- a/tests/lib/eva/stage-governance.test.js
+++ b/tests/lib/eva/stage-governance.test.js
@@ -222,3 +222,81 @@ describe('stage-governance — cache behavior', () => {
     expect(callCount).toBe(2);
   });
 });
+
+describe('stage-governance — Realtime channel teardown safety (SD-FDBK-FIX-EVA-STAGE-GOVERNANCE-001)', () => {
+  function makeMockSupabaseWithChannelSpy(rows = STAGE_FIXTURE) {
+    let capturedStatusCallback = null;
+    const unsubscribeSpy = vi.fn();
+    const removeChannelSpy = vi.fn();
+    const channelMock = {
+      on: function () { return this; },
+      subscribe: function (cb) { capturedStatusCallback = cb; return this; },
+      unsubscribe: unsubscribeSpy,
+    };
+    const sb = {
+      from: () => ({ select: () => ({ order: () => Promise.resolve({ data: rows, error: null }) }) }),
+      channel: () => channelMock,
+      removeChannel: removeChannelSpy,
+    };
+    return { sb, unsubscribeSpy, removeChannelSpy, getStatusCallback: () => capturedStatusCallback, channelMock };
+  }
+
+  it('CHANNEL_ERROR/CLOSED/TIMED_OUT status tears down via supabase.removeChannel(), never via channel.unsubscribe()', async () => {
+    const mod = await import('../../../lib/eva/stage-governance.js');
+    mod._resetCacheForTest();
+    const { sb, unsubscribeSpy, removeChannelSpy, getStatusCallback, channelMock } = makeMockSupabaseWithChannelSpy();
+
+    await mod.getStageGovernance(sb);
+    const statusCallback = getStatusCallback();
+    expect(statusCallback).toBeTypeOf('function');
+
+    statusCallback('CHANNEL_ERROR');
+
+    expect(removeChannelSpy).toHaveBeenCalledTimes(1);
+    expect(removeChannelSpy).toHaveBeenCalledWith(channelMock);
+    expect(unsubscribeSpy).not.toHaveBeenCalled();
+  });
+
+  it('a second (re-entrant) status callback firing after teardown does not re-invoke removeChannel or throw', async () => {
+    const mod = await import('../../../lib/eva/stage-governance.js');
+    mod._resetCacheForTest();
+    const { sb, removeChannelSpy, getStatusCallback } = makeMockSupabaseWithChannelSpy();
+
+    await mod.getStageGovernance(sb);
+    const statusCallback = getStatusCallback();
+
+    expect(() => {
+      statusCallback('CLOSED');
+      statusCallback('CLOSED');
+    }).not.toThrow();
+
+    // Reference is nulled after the first teardown, so the second firing is a safe no-op.
+    expect(removeChannelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a channel whose unsubscribe() recursively re-invokes its own status callback would previously overflow the stack -- proves removeChannel() is used instead', async () => {
+    const mod = await import('../../../lib/eva/stage-governance.js');
+    mod._resetCacheForTest();
+
+    let capturedStatusCallback = null;
+    let unsubscribeCallCount = 0;
+    const recursiveChannelMock = {
+      on: function () { return this; },
+      subscribe: function (cb) { capturedStatusCallback = cb; return this; },
+      unsubscribe: function () {
+        unsubscribeCallCount++;
+        if (unsubscribeCallCount > 100) throw new Error('unsubscribe recursion guard tripped -- test itself would overflow');
+        capturedStatusCallback?.('CLOSED'); // simulates phoenix's synchronous re-entrant trigger(close)
+      },
+    };
+    const sb = {
+      from: () => ({ select: () => ({ order: () => Promise.resolve({ data: STAGE_FIXTURE, error: null }) }) }),
+      channel: () => recursiveChannelMock,
+      removeChannel: () => { /* real removeChannel is terminal -- does not re-trigger the callback */ },
+    };
+
+    await mod.getStageGovernance(sb);
+    expect(() => capturedStatusCallback('TIMED_OUT')).not.toThrow();
+    expect(unsubscribeCallCount).toBe(0); // fixed code never calls channel.unsubscribe() from the callback
+  });
+});

--- a/tests/unit/eva/reality-gates.test.js
+++ b/tests/unit/eva/reality-gates.test.js
@@ -12,6 +12,7 @@ import {
   REASON_CODES,
   MODULE_VERSION,
   _internal,
+  _resetBoundaryCacheForTest,
 } from '../../../lib/eva/reality-gates.js';
 
 function createMockDb(artifacts = []) {
@@ -308,6 +309,109 @@ describe('RealityGates', () => {
 
     it('should export all REASON_CODES', () => {
       expect(Object.keys(REASON_CODES)).toHaveLength(6);
+    });
+  });
+
+  describe('Realtime channel teardown safety (SD-FDBK-FIX-EVA-STAGE-GOVERNANCE-001)', () => {
+    function makeMockDbWithChannelSpy() {
+      let capturedStatusCallback = null;
+      const unsubscribeSpy = vi.fn();
+      const removeChannelSpy = vi.fn();
+      const channelMock = {
+        on: function () { return this; },
+        subscribe: function (cb) { capturedStatusCallback = cb; return this; },
+        unsubscribe: unsubscribeSpy,
+      };
+      const sb = {
+        from: vi.fn(() => ({ select: () => Promise.resolve({ data: [], error: null }) })),
+        channel: () => channelMock,
+        removeChannel: removeChannelSpy,
+      };
+      return { sb, unsubscribeSpy, removeChannelSpy, getStatusCallback: () => capturedStatusCallback, channelMock };
+    }
+
+    it('CHANNEL_ERROR/CLOSED/TIMED_OUT status tears down via supabase.removeChannel(), never via channel.unsubscribe()', async () => {
+      _resetBoundaryCacheForTest();
+      const { sb, unsubscribeSpy, removeChannelSpy, getStatusCallback, channelMock } = makeMockDbWithChannelSpy();
+
+      // Unconfigured transition (999->1000) -- evaluateRealityGate returns NOT_APPLICABLE
+      // immediately after _loadBoundaryFromDB runs, isolating the channel-teardown path
+      // from unrelated artifact-lookup logic.
+      await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 999,
+        toStage: 1000,
+        supabase: sb,
+        logger: silentLogger,
+      });
+
+      const statusCallback = getStatusCallback();
+      expect(statusCallback).toBeTypeOf('function');
+
+      statusCallback('CHANNEL_ERROR');
+
+      expect(removeChannelSpy).toHaveBeenCalledTimes(1);
+      expect(removeChannelSpy).toHaveBeenCalledWith(channelMock);
+      expect(unsubscribeSpy).not.toHaveBeenCalled();
+
+      _resetBoundaryCacheForTest();
+    });
+
+    it('a second (re-entrant) status callback firing after teardown does not re-invoke removeChannel or throw', async () => {
+      _resetBoundaryCacheForTest();
+      const { sb, removeChannelSpy, getStatusCallback } = makeMockDbWithChannelSpy();
+
+      await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 999,
+        toStage: 1000,
+        supabase: sb,
+        logger: silentLogger,
+      });
+
+      const statusCallback = getStatusCallback();
+      expect(() => {
+        statusCallback('CLOSED');
+        statusCallback('CLOSED');
+      }).not.toThrow();
+
+      // Reference is nulled after the first teardown, so the second firing is a safe no-op.
+      expect(removeChannelSpy).toHaveBeenCalledTimes(1);
+
+      _resetBoundaryCacheForTest();
+    });
+
+    it('a channel whose unsubscribe() recursively re-invokes its own status callback would previously overflow the stack -- proves removeChannel() is used instead', async () => {
+      _resetBoundaryCacheForTest();
+      let capturedStatusCallback = null;
+      let unsubscribeCallCount = 0;
+      const recursiveChannelMock = {
+        on: function () { return this; },
+        subscribe: function (cb) { capturedStatusCallback = cb; return this; },
+        unsubscribe: function () {
+          unsubscribeCallCount++;
+          if (unsubscribeCallCount > 100) throw new Error('unsubscribe recursion guard tripped -- test itself would overflow');
+          capturedStatusCallback?.('CLOSED'); // simulates phoenix's synchronous re-entrant trigger(close)
+        },
+      };
+      const sb = {
+        from: vi.fn(() => ({ select: () => Promise.resolve({ data: [], error: null }) })),
+        channel: () => recursiveChannelMock,
+        removeChannel: () => { /* real removeChannel is terminal -- does not re-trigger the callback */ },
+      };
+
+      await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 999,
+        toStage: 1000,
+        supabase: sb,
+        logger: silentLogger,
+      });
+
+      expect(() => capturedStatusCallback('TIMED_OUT')).not.toThrow();
+      expect(unsubscribeCallCount).toBe(0);
+
+      _resetBoundaryCacheForTest();
     });
   });
 });


### PR DESCRIPTION
## Summary
- `lib/eva/stage-governance.js` and `lib/eva/reality-gates.js` both called `channel.unsubscribe()` from inside their own `.subscribe()` status callback on `CHANNEL_ERROR`/`CLOSED`/`TIMED_OUT` — the vendored `@supabase/phoenix` client's synchronous `leave()`/`trigger(close)` dispatch re-invokes that same callback, causing unbounded recursion (`RangeError: Maximum call stack size exceeded`)
- This is the confirmed live-reproducing sibling defect of SD-FDBK-ENH-CANARY-VENTURE-PROBE-001 (which fixed the same anti-pattern in `chairman-decision-watcher.js`) — a post-merge re-run of the Canary Venture Probe workflow reproduced the identical crash from these two different call sites (RCA agentId `a04185a286a623cf2`)
- Extracts the already-proven fix (`supabase.removeChannel()` instead of `channel.unsubscribe()`) into a new shared `lib/eva/realtime-channel-utils.js` helper (`safeRemoveChannel`), applied to both confirmed call sites
- VALIDATION sub-agent (agentId `ae9b0e1672505c7f3`) independently read `s20-pause-controller.js` and `venture-monitor.js` and confirmed they do NOT share this defect (already tear down channels correctly from outside their callbacks) — left untouched
- 6 new regression tests (3 per file) simulate a channel whose `unsubscribe()` recursively re-invokes its own status callback, proving `removeChannel()` breaks the chain

## Test plan
- [x] 6 new unit tests (`tests/lib/eva/stage-governance.test.js`, `tests/unit/eva/reality-gates.test.js`) pass
- [x] Full dependent-module regression suite (18 test files / 185 tests) passes with 0 regressions
- [x] Structural check: no remaining bare `.unsubscribe()` call inside either file's own `.subscribe()` status callback
- [ ] Post-merge: re-run `gh workflow run "Canary Venture Probe" --ref main` and confirm no `RangeError` in the logs (the same real-world verification that surfaced this defect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)