### PR TITLE
fix(SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001): gate RCA hard-block on progress-stall, not bare repetition

### DIFF
--- a/lib/hooks/auto-signal-threshold.cjs
+++ b/lib/hooks/auto-signal-threshold.cjs
@@ -103,4 +103,31 @@ function buildGateAutoSignalArgs({ gateName, sdKey, retryCount } = {}) {
   return ['stuck', body, '--severity', 'high'];
 }
 
-module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs };
+/**
+ * Should ENFORCEMENT 11 (RCA tiered enforcement) hard-block this tool call?
+ * SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: the hard block previously
+ * gated on bare `attempts >= 3` alone, so a repeated command that was demonstrably making
+ * progress (a different migration file each time, an advancing session phase/percent) got
+ * hard-blocked exactly like a genuine stuck retry-loop. `progressStalled` (already computed by
+ * retry-state-manager's Control 3 fingerprint and already used to suppress the AUTO-SIGNAL
+ * above) is now also consulted for the block itself: `progressStalled === false` (the session
+ * is demonstrably advancing) suppresses the hard block even at attempts>=3 — the repetition
+ * falls through to the existing Tier-1 advisory warning instead of exit(2). `true` or
+ * `undefined` (no fingerprint available — fail-closed, same as every other uncertain-state path
+ * in this hook) preserves the exact pre-existing block behavior, so a real stuck loop is never
+ * let through.
+ *
+ * PURE (no I/O) — kept alongside shouldEmitAutoSignal so it's unit-testable without executing
+ * the hook, per this module's existing pattern.
+ *
+ * @param {{ attempts:number, bypassed?:boolean, progressStalled?:boolean }} opts
+ * @returns {boolean}
+ */
+function shouldHardBlock({ attempts, bypassed, progressStalled } = {}) {
+  if (!Number.isInteger(attempts) || attempts < 3) return false;
+  if (bypassed === true) return false;
+  if (progressStalled === false) return false; // demonstrably advancing → not a stuck loop
+  return true;
+}
+
+module.exports = { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs, shouldHardBlock };

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1184,7 +1184,11 @@ async function main() {
 
       if (signature && attempts >= 2) {
         const bypassed = process.env.EMERGENCY_RCA_BYPASS === 'true';
-        const outcome = attempts >= 3 && !bypassed ? 'block' : 'warn';
+        // SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: the audit-log outcome
+        // label must match the actual block decision below (shouldHardBlock), else a
+        // progressStalled===false suppression (tool proceeds) gets mis-recorded as outcome='block'.
+        const { shouldHardBlock } = require('../../lib/hooks/auto-signal-threshold.cjs');
+        const outcome = shouldHardBlock({ attempts, bypassed, progressStalled }) ? 'block' : 'warn';
         const auditPromise = auditPermissionDecision(
           _SESSION_ID, TOOL_NAME, 'RCA-TIERED-ENFORCEMENT',
           'Repeated tool invocation without intervening RCA',
@@ -1221,11 +1225,9 @@ async function main() {
         } catch { /* fail-open: auto-signal must never block tool execution */ }
 
         // SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: gate the hard block on
-        // PROGRESS-STALL, not bare repetition count. progressStalled===false (the session is
-        // demonstrably advancing — different migration file, advancing phase/percent, etc.)
-        // suppresses the block; true/undefined preserves the exact pre-existing behavior.
-        const { shouldHardBlock } = require('../../lib/hooks/auto-signal-threshold.cjs');
-        if (shouldHardBlock({ attempts, bypassed, progressStalled })) {
+        // PROGRESS-STALL, not bare repetition count (reuses the same shouldHardBlock() verdict
+        // already computed above for the audit-log outcome label, so the two never diverge).
+        if (outcome === 'block') {
           process.stderr.write(
             `\nRCA TIERED ENFORCEMENT (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129):\n` +
             `  Blocked: ${TOOL_NAME} invoked ${attempts}x on the same target within 10 minutes.\n` +

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -1220,7 +1220,12 @@ async function main() {
           }
         } catch { /* fail-open: auto-signal must never block tool execution */ }
 
-        if (attempts >= 3 && !bypassed) {
+        // SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: gate the hard block on
+        // PROGRESS-STALL, not bare repetition count. progressStalled===false (the session is
+        // demonstrably advancing — different migration file, advancing phase/percent, etc.)
+        // suppresses the block; true/undefined preserves the exact pre-existing behavior.
+        const { shouldHardBlock } = require('../../lib/hooks/auto-signal-threshold.cjs');
+        if (shouldHardBlock({ attempts, bypassed, progressStalled })) {
           process.stderr.write(
             `\nRCA TIERED ENFORCEMENT (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-129):\n` +
             `  Blocked: ${TOOL_NAME} invoked ${attempts}x on the same target within 10 minutes.\n` +

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -395,7 +395,7 @@ function extractTableName(command) {
 }
 
 /**
- * QF-20260609-547: split a command into per-`.from('table')` segments so column checks are scoped
+ * QF-20260609-547: split a command into per-`.from('table')` segments so column checks are scoped (schema-lint-disable-line: doc comment, not a real table reference)
  * to the NEAREST preceding `.from()`. Previously a compound `node -e` touching two tables attributed
  * every extracted column to ONE table → cross-table false blocks (e.g. user_stories columns blamed
  * on product_requirements_v2). Falls back to extractTableName (rpc / other Supabase patterns) when no

--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -61,6 +61,12 @@ const EXEMPT_PATTERNS = [
   /\bscripts[/\\]worker-checkin\.cjs\b/,
   /\bscripts[/\\]coordinator-backlog-rank\.mjs\b/,
   /\bscripts[/\\]coordinator-capacity-forecast\.mjs\b/,
+  // SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: apply-migration.js is one
+  // invocation PER migration file — legitimately repeated (3 migrations applied in a row is
+  // progress, not a stuck loop), but that per-file progress isn't visible to the SD-level
+  // phase/percent progressFingerprint (Control 3), so it needs this allowlist backstop the same
+  // way the other mutating-but-idempotent scheduled scripts above do.
+  /\bscripts[/\\]apply-migration\.js\b/,
 ];
 
 /**

--- a/tests/unit/auto-signal-threshold.test.js
+++ b/tests/unit/auto-signal-threshold.test.js
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs } = require('../../lib/hooks/auto-signal-threshold.cjs');
+const { shouldEmitAutoSignal, buildAutoSignalArgs, shouldEmitGateAutoSignal, buildGateAutoSignalArgs, shouldHardBlock } = require('../../lib/hooks/auto-signal-threshold.cjs');
 
 const SID = '11111111-2222-4333-8444-555555555555';
 
@@ -104,6 +104,39 @@ describe('buildAutoSignalArgs (FR-1)', () => {
   it('omits the SD clause when no sdKey is known', () => {
     const args = buildAutoSignalArgs({ toolName: 'Bash', signature: 'sig', attempts: 2 });
     expect(args[1]).not.toContain('(SD ');
+  });
+});
+
+// SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: the hard-block decision must
+// gate on PROGRESS-STALL, not bare repetition count.
+describe('shouldHardBlock (SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001)', () => {
+  it('blocks at attempts>=3 when progress is unknown (progressStalled=undefined, fail-closed — pre-existing behavior preserved)', () => {
+    expect(shouldHardBlock({ attempts: 3 })).toBe(true);
+    expect(shouldHardBlock({ attempts: 5 })).toBe(true);
+  });
+
+  it('blocks at attempts>=3 when progress is genuinely stalled (progressStalled=true)', () => {
+    expect(shouldHardBlock({ attempts: 3, progressStalled: true })).toBe(true);
+  });
+
+  it('does NOT block at attempts>=3 when the session is demonstrably advancing (progressStalled=false)', () => {
+    expect(shouldHardBlock({ attempts: 3, progressStalled: false })).toBe(false);
+    expect(shouldHardBlock({ attempts: 5, progressStalled: false })).toBe(false);
+  });
+
+  it('never blocks below the attempts>=3 threshold, regardless of progressStalled', () => {
+    expect(shouldHardBlock({ attempts: 2, progressStalled: true })).toBe(false);
+    expect(shouldHardBlock({ attempts: 1 })).toBe(false);
+  });
+
+  it('the EMERGENCY_RCA_BYPASS override still wins over a stalled/unknown progress state', () => {
+    expect(shouldHardBlock({ attempts: 3, bypassed: true })).toBe(false);
+    expect(shouldHardBlock({ attempts: 3, bypassed: true, progressStalled: true })).toBe(false);
+  });
+
+  it('ignores non-integer attempts (fail-safe — never blocks on a malformed count)', () => {
+    expect(shouldHardBlock({ attempts: NaN })).toBe(false);
+    expect(shouldHardBlock({ attempts: undefined })).toBe(false);
   });
 });
 

--- a/tests/unit/retry-state-exempt-apply-migration.test.js
+++ b/tests/unit/retry-state-exempt-apply-migration.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001 — exempt apply-migration.js.
+ *
+ * apply-migration.js is one invocation PER migration file — applying 3 migrations in a row is
+ * progress, not a stuck loop. But each invocation targets a DIFFERENT migration file, so the
+ * SD-level phase/percent progressFingerprint (Control 3) can't observe that per-file progress.
+ * A chairman-approved prod migration apply was hard-blocked on Echo by the bare-repetition
+ * 3-strikes guard before this fix landed. Backstop: add to EXEMPT_PATTERNS (same precedent as
+ * the other mutating-but-idempotent scheduled scripts already there).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const { isExempt, recordAndCount } = require('../../scripts/hooks/retry-state-manager.cjs');
+
+describe('isExempt — apply-migration.js', () => {
+  it('exempts apply-migration.js regardless of arguments', () => {
+    expect(isExempt('node scripts/apply-migration.js database/migrations/20260619_a.sql')).toBe(true);
+    expect(isExempt('node scripts/apply-migration.js database/migrations/20260701_b.sql --prod-deploy')).toBe(true);
+    expect(isExempt('node scripts\\apply-migration.js database\\migrations\\c.sql')).toBe(true); // windows path sep
+  });
+
+  it('does not exempt an unrelated migration-adjacent script (scoped match)', () => {
+    expect(isExempt('node scripts/generate-migration.js')).toBe(false);
+    expect(isExempt('node scripts/migration-readiness-check.js')).toBe(false);
+  });
+});
+
+describe('recordAndCount honors the apply-migration.js exemption across different migration files', () => {
+  let tmpDir;
+  const SESSION = 'sess-exempt-migrations';
+  const noReset = async () => null;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-exempt-migration-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+  });
+  afterEach(() => {
+    delete process.env.LEO_RETRY_STATE_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('applying 3 DIFFERENT migration files in a row never accumulates (the Echo repro)', async () => {
+    const files = [
+      'database/migrations/20260619_guard_a.sql',
+      'database/migrations/20260621_guard_b.sql',
+      'database/migrations/20260701_guard_c.sql',
+    ];
+    for (let i = 0; i < files.length; i++) {
+      const cmd = `node scripts/apply-migration.js ${files[i]} --prod-deploy`;
+      const r = await recordAndCount(SESSION, null, 'Bash', { command: cmd }, { rcaCheck: noReset, now: 1000 + i * 1000 });
+      expect(r.attempts).toBe(0);
+    }
+  });
+
+  it('re-applying the SAME migration file repeatedly (e.g. a retried apply) also never accumulates', async () => {
+    const cmd = 'node scripts/apply-migration.js database/migrations/20260701_guard_c.sql --prod-deploy';
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount(SESSION, null, 'Bash', { command: cmd }, { rcaCheck: noReset, now: 1000 + i * 1000 });
+      expect(r.attempts).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- ENFORCEMENT 11's hard block (scripts/hooks/pre-tool-enforce.cjs) gated purely on `attempts>=3`, ignoring the already-computed `progressStalled` fingerprint (Control 3) that already suppressed the AUTO-SIGNAL but was never consulted for the block itself.
- Hard-blocked a chairman-approved GUARD prod-migration apply on session Echo (3 different migration files applied in a row, each a legitimately different command) — 2/3 migrations left unapplied until EMERGENCY_RCA_BYPASS was manually supplied. Also false-positived on Alpha and Foxtrot.
- Fix: new pure `shouldHardBlock({attempts, bypassed, progressStalled})` in lib/hooks/auto-signal-threshold.cjs (mirrors the existing `shouldEmitAutoSignal`). `progressStalled===false` suppresses the block even at attempts>=3; `true`/`undefined` preserves the exact pre-existing fail-closed behavior — genuine stuck loops still block.
- Added `scripts/apply-migration.js` to `EXEMPT_PATTERNS` as a backstop (per-migration-file progress isn't visible to the SD-level phase/percent fingerprint).
- Follow-up fix: the audit-log `outcome` label was still computed separately via the old inline logic, so a suppressed block could be mis-recorded as `outcome='block'`. Now computed once via `shouldHardBlock()` and reused for both the audit label and the actual block decision — they can't diverge.

## Test plan
- [x] `npx vitest run tests/unit/auto-signal-threshold.test.js tests/unit/retry-state-exempt-apply-migration.test.js scripts/hooks/__tests__/` — 312+ tests pass, zero regressions
- [x] Live subprocess smoke: 3x identical Edit, no progress fingerprint → still blocks (exit 2), baseline preserved
- [x] Live subprocess smoke: 3x apply-migration.js on different files → never blocks (exit 0), the Echo repro fixed
- [x] Live subprocess smoke: 3x identical Edit with advancing SD phase/progress → progressStalled=false → block suppressed
- [x] TESTING (96%), VALIDATION (PASS), REGRESSION (PASS) sub-agents all passed with independent re-verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)