### PR TITLE
fix(QF-20260701-421): stop reentrant Realtime unsubscribe() recursion + orderly canary probe teardown

### DIFF
--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -61,7 +61,8 @@ async function _loadBoundaryFromDB(supabase, logger) {
         )
         .subscribe((status) => {
           if (status === 'CHANNEL_ERROR' || status === 'CLOSED' || status === 'TIMED_OUT') {
-            try { _boundaryRealtimeChannel?.unsubscribe?.(); } catch { /* swallow */ }
+            // QF-20260701-421: do NOT call unsubscribe() here — see stage-governance.js
+            // for the full explanation (re-entrant phoenix leave()->CLOSED recursion).
             _boundaryRealtimeChannel = null;
           }
         });

--- a/lib/eva/stage-governance.js
+++ b/lib/eva/stage-governance.js
@@ -102,8 +102,11 @@ function _ensureSubscription(supabase) {
       )
       .subscribe((status) => {
         if (status === 'CHANNEL_ERROR' || status === 'CLOSED' || status === 'TIMED_OUT') {
-          // Subscription failed; rely on TTL-only refresh.
-          try { _subscription?.unsubscribe?.(); } catch { /* swallow */ }
+          // QF-20260701-421: do NOT call unsubscribe() here. On a live channel,
+          // unsubscribe()'s phoenix leave() synchronously re-fires this callback
+          // with 'CLOSED', so re-unsubscribing recurses to a stack overflow.
+          // CLOSED/ERROR/TIMED_OUT already mean the channel is gone/dying —
+          // just drop the refs; rely on TTL-only refresh.
           _subscription = null;
           _subscriptionSupabase = null;
         }

--- a/scripts/canary/run-canary-probe.mjs
+++ b/scripts/canary/run-canary-probe.mjs
@@ -54,6 +54,17 @@ const supabase = createClient(
 
 const log = (...a) => { if (!AS_JSON) console.log(...a); };
 
+// QF-20260701-421: reality-gates.js and stage-governance.js each open a process-
+// lifetime Realtime channel on this same client; an abrupt exit with one still open
+// races Phoenix's phx_close teardown into mutual recursion (RangeError: Maximum call
+// stack size exceeded). Disconnect them in an orderly fashion before the exit backstop.
+async function disconnectRealtime() {
+  try {
+    await supabase.removeAllChannels();
+    await supabase.realtime.disconnect();
+  } catch { /* best-effort — never block exit on teardown */ }
+}
+
 async function flagEnabled() {
   const { data } = await supabase
     .from('leo_feature_flags')
@@ -209,6 +220,7 @@ const runId = buildRunId(startedAt, randomUUID().slice(0, 8));
 const admission = probeAdmission({ flagEnabled: await flagEnabled(), forceLocal: FORCE_LOCAL });
 if (!admission.allowed) {
   console.error(`canary-probe: refused — ${admission.reason}`);
+  await disconnectRealtime();
   await armCliTeardown(2); // SWEEP-CLI-EXIT-001 pattern: drain or backstop, never hang
 } else {
   log(`🐤 canary probe ${runId} (admission: ${admission.reason}; max-stages ${MAX_STAGES}; ${TEARDOWN ? 'teardown' : 'keep'})`);
@@ -336,5 +348,6 @@ if (!admission.allowed) {
   // The StageExecutionWorker holds heartbeats/subscriptions that block a
   // natural drain — arm the SWEEP-CLI-EXIT-001 teardown (undici close +
   // unref'd backstop) so the probe can never ride to an external SIGTERM.
+  await disconnectRealtime();
   await armCliTeardown(report.outcome === 'FAIL' ? 1 : 0);
 }


### PR DESCRIPTION
## Summary
- Canary Venture Probe CI has crashed with `RangeError: Maximum call stack size exceeded` on every flag-enabled run since 2026-06-21 (4 consecutive failures on main), always **after** the probe's own EVA-stage logic already succeeded.
- RCA (two rounds) root-caused two independent, mechanically-confirmed issues:
  1. `lib/eva/reality-gates.js` and `lib/eva/stage-governance.js` each open a process-lifetime Supabase Realtime channel and react to a `CLOSED` status by calling `unsubscribe()` on themselves — but `@supabase/phoenix`'s `leave()` (invoked by `unsubscribe()`) synchronously re-fires the same `CLOSED` callback before it settles, so the self-unsubscribe recurses unbounded until stack overflow. Fix: on a terminal status, just drop the local channel reference instead of re-triggering teardown.
  2. `scripts/canary/run-canary-probe.mjs`'s teardown (`armCliTeardown`) only closed undici HTTP sockets and never disconnected Realtime, so an abrupt process exit with a channel still open could trigger the same recursion class. Fix: disconnect Realtime in an orderly fashion (`removeAllChannels()` + `realtime.disconnect()`) before arming the exit backstop.
- Feedback row `6002064b-40d7-4939-a26b-b61e50716ad1` (category=ci_failure) tracks this.

## Test plan
- [x] `node --check` on all 3 changed files
- [x] ESLint clean (0 errors)
- [x] Existing unit tests for both touched modules pass: `tests/lib/eva/stage-governance.test.js`, `tests/unit/eva/reality-gates.test.js` (quarantined, pre-existing unrelated assertion-drift), `tests/unit/eva/stage-governance.test.js` — 41/44 passed, 3 skipped, 0 regressions
- [x] Reproduced the crash directly against a live Supabase project (`node scripts/canary/run-canary-probe.mjs --force-local --max-stages 3 --teardown`) — confirmed `RangeError` before the fix, confirmed **zero** `RangeError`/stack-overflow occurrences across 2 post-fix runs (remaining `exit 1`s are genuine, pre-existing, unrelated Gemini LLM-latency/timeout flakiness in stage-02 analysis, out of scope for this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)