### PR TITLE
feat(SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C): dynamic tier-band callsigns + coordinator tier_rank writer

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -15,22 +15,56 @@
 const COLORS = ['blue', 'green', 'purple', 'orange', 'cyan', 'pink', 'yellow', 'red'];
 const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
 
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C (FR-4): this file used to carry its OWN
+// hardcoded 4-rung TIER_CALLSIGNS map + a tierRankOf() that defaulted any unrecognized
+// value to 4 — a THIRD independent hardcoded-4-rung assumption alongside tier-ladder.cjs's
+// LADDER and sd-tier-rank.mjs's rung literals. Both are now derived from the shared
+// lib/fleet/tier-ladder.cjs module so K (ladderTopRank()) is never assumed to be 4.
+const { resolveWorkerTierRank, ladderTopRank, deriveWorkerTierRank } = require('../lib/fleet/tier-ladder.cjs');
+
 // QF-20260627-108 (FR-1): the chairman effort-encoded callsign scheme. A worker's callsign is
 // derived from its metadata.tier_rank (the source-of-truth), NOT flat first-available NATO order —
-// otherwise the 5-min cron re-clobbers the effort names every pass. tier4=high, tier3=medium,
-// tier2=low, tier1=sonnet/max. Shared by the cron AND worker-checkin self-assign so both honor it.
-const TIER_CALLSIGNS = {
-  4: ['Alpha', 'Bravo', 'Charlie'],
-  3: ['Delta', 'Echo', 'Foxtrot'],
-  2: ['Golf'],
-  1: ['Hotel'],
-};
+// otherwise the 5-min cron re-clobbers the effort names every pass. Shared by the cron AND
+// worker-checkin self-assign so both honor it.
+//
+// buildTierCallsignBands(topRank) partitions the fixed 8-letter NATO pool into `topRank` bands,
+// top-heavy: the bottom floor(K/2) bands get 1 letter each (reserved from the END of the pool,
+// so the LOWEST rank gets the LAST letter), and the remaining upper bands split what's left as
+// evenly as possible (extra letters going to the TOP band(s) first). At K=4 this reproduces the
+// legacy map byte-for-byte: {4:[Alpha,Bravo,Charlie], 3:[Delta,Echo,Foxtrot], 2:[Golf], 1:[Hotel]}.
+// Every band is guaranteed >=1 letter (cycling the pool) even when K exceeds the pool size.
+function buildTierCallsignBands(topRank) {
+  const K = Math.max(1, Math.trunc(Number(topRank)) || 1);
+  const bands = {};
+  const lowerCount = Math.floor(K / 2);
+  const upperCount = K - lowerCount;
+  const pool = NATO.slice();
+  const reserved = lowerCount > 0 ? pool.splice(pool.length - lowerCount, lowerCount) : [];
+  const base = Math.floor(pool.length / upperCount);
+  let remainder = pool.length % upperCount;
+  let idx = 0;
+  for (let rank = K; rank > lowerCount; rank--) {
+    let size = base + (remainder > 0 ? 1 : 0);
+    if (remainder > 0) remainder--;
+    bands[rank] = pool.slice(idx, idx + size);
+    idx += size;
+  }
+  for (let i = 0; i < lowerCount; i++) {
+    bands[i + 1] = [reserved[lowerCount - 1 - i]];
+  }
+  // Safety floor: K > NATO.length can leave a band empty (e.g. upperCount > pool.length).
+  // pickCallsignForTier/callsignInTierBand index pool[0], so an empty band must never occur.
+  for (let rank = 1; rank <= K; rank++) {
+    if (!bands[rank] || bands[rank].length === 0) bands[rank] = [NATO[(rank - 1) % NATO.length]];
+  }
+  return bands;
+}
 
-// Resolve a worker's effort tier from metadata.tier_rank. Default 4 (top band) for an unstamped
-// worker — matches the conservative-UP dispatch default (workers default to the top rung).
+// Resolve a worker's tier rank from metadata.tier_rank, delegating to the shared
+// lib/fleet/tier-ladder.cjs resolver (bounds against the CURRENT ladderTopRank(), defaults an
+// unstamped/invalid value to the top rung — conservative-UP, matching dispatch's default).
 function tierRankOf(worker) {
-  const t = worker?.metadata?.tier_rank;
-  return (t === 1 || t === 2 || t === 3 || t === 4) ? t : 4;
+  return resolveWorkerTierRank(worker);
 }
 
 // SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 (FR-3): deterministic + unique + logged pool extension.
@@ -50,8 +84,12 @@ function extendCallsign(base, usedSet, poolLabel) {
 
 // Pick the first FREE callsign within the worker's tier band (effort-encoded SoT), wrapping with a
 // numeric suffix only when the band is exhausted. Drop-in replacement for nextAvailable(NATO, ...).
+// Bands are computed fresh from the CURRENT ladderTopRank() on every call (SD-LEO-INFRA-AUTO-TIERING-
+// ACTIVATION-001-C) so a live fleet resize (K != 4) is picked up without a code change here.
 function pickCallsignForTier(tierRank, usedSet) {
-  const pool = TIER_CALLSIGNS[tierRank] || TIER_CALLSIGNS[4];
+  const topRank = ladderTopRank();
+  const bands = buildTierCallsignBands(topRank);
+  const pool = bands[tierRank] || bands[topRank];
   for (const c of pool) {
     if (!usedSet.has(c)) return c;
   }
@@ -63,7 +101,9 @@ function pickCallsignForTier(tierRank, usedSet) {
 // "Bravo") returns false → it is re-derived, so the chairman scheme self-heals.
 function callsignInTierBand(callsign, tierRank) {
   if (!callsign) return false;
-  const pool = TIER_CALLSIGNS[tierRank] || TIER_CALLSIGNS[4];
+  const topRank = ladderTopRank();
+  const bands = buildTierCallsignBands(topRank);
+  const pool = bands[tierRank] || bands[topRank];
   const base = String(callsign).split('-')[0];
   return pool.includes(base);
 }
@@ -292,6 +332,30 @@ async function main() {
     }
   }
 
+  // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C (FR-4): this cron is the only reader that sees the
+  // WHOLE live fleet, so it is the authoritative writer of the fleet-relative dense tier_rank. A
+  // lone worker's own check-in self-report (worker-checkin.cjs mergeCheckinModelEffort) only knows
+  // its own capabilityScore against a cached ladder; this refresh corrects every worker to the true
+  // 1..K dense rank across all CURRENTLY live workers, before tierRankOf()/callsignInTierBand() below
+  // read it for banding decisions.
+  const liveFleet = uniqueWorkers.map(w => ({ model: w.metadata?.model, effort: w.metadata?.effort }));
+  for (const worker of uniqueWorkers) {
+    const freshRank = deriveWorkerTierRank(worker, liveFleet);
+    if (worker.metadata?.tier_rank !== freshRank) {
+      const metadata = { ...(worker.metadata || {}), tier_rank: freshRank };
+      const { error: rankErr } = await supabase
+        .from('claude_sessions')
+        .update({ metadata })
+        .eq('session_id', worker.session_id);
+
+      if (rankErr) {
+        console.error(`  Failed to refresh tier_rank for ${worker.session_id.substring(0, 12)}: ${rankErr.message}`);
+      } else {
+        worker.metadata = metadata; // keep in-memory copy fresh for this run's banding decisions
+      }
+    }
+  }
+
   // Separate workers into already-assigned and new
   const assignedRaw = [];
   const needsAssignment = [];
@@ -470,7 +534,7 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, TIER_CALLSIGNS, tierRankOf, pickCallsignForTier, callsignInTierBand };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/assign-fleet-identities-tier-callsign.test.js
+++ b/tests/unit/assign-fleet-identities-tier-callsign.test.js
@@ -3,13 +3,19 @@
 // 5-min assign-fleet-identities cron re-clobbers the effort names every pass. tier4=Alpha/
 // Bravo/Charlie, tier3=Delta/Echo/Foxtrot, tier2=Golf, tier1=Hotel. The picker is shared with
 // worker-checkin.cjs so both writers honor the scheme identically.
+//
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C: the static TIER_CALLSIGNS map was replaced with
+// buildTierCallsignBands(topRank), derived dynamically from lib/fleet/tier-ladder.cjs's
+// ladderTopRank() so the band count is never assumed to be 4. At the default K=4 it must
+// reproduce the legacy split byte-for-byte (assertions below); at other K it must still
+// produce exactly K non-empty bands.
 
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const {
-  TIER_CALLSIGNS,
+  buildTierCallsignBands,
   tierRankOf,
   pickCallsignForTier,
   callsignInTierBand,
@@ -19,11 +25,12 @@ const {
 } = require('../../scripts/assign-fleet-identities.cjs');
 
 describe('QF-20260627-108: tier-encoded callsign assignment', () => {
-  it('maps each tier to its effort-encoded band', () => {
-    expect(TIER_CALLSIGNS[4]).toEqual(['Alpha', 'Bravo', 'Charlie']);
-    expect(TIER_CALLSIGNS[3]).toEqual(['Delta', 'Echo', 'Foxtrot']);
-    expect(TIER_CALLSIGNS[2]).toEqual(['Golf']);
-    expect(TIER_CALLSIGNS[1]).toEqual(['Hotel']);
+  it('buildTierCallsignBands(4) reproduces the legacy effort-encoded band map', () => {
+    const bands = buildTierCallsignBands(4);
+    expect(bands[4]).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(bands[3]).toEqual(['Delta', 'Echo', 'Foxtrot']);
+    expect(bands[2]).toEqual(['Golf']);
+    expect(bands[1]).toEqual(['Hotel']);
   });
 
   it('tierRankOf reads metadata.tier_rank and defaults unstamped workers to tier 4', () => {
@@ -81,5 +88,35 @@ describe('SD-LEO-INFRA-CHECKIN-NAME-ON-ARRIVAL-001 FR-3: deterministic pool exha
     expect(nextAvailable(NATO, used)).toBe('Alpha-2');
     // And it skips an already-used extended suffix rather than colliding.
     expect(nextAvailable(NATO, new Set([...NATO, 'Alpha-2']))).toBe('Alpha-3');
+  });
+});
+
+describe('SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C: dynamic band count (K != 4)', () => {
+  it('a K=2 fleet produces exactly 2 callsign bands, not 4', () => {
+    const bands = buildTierCallsignBands(2);
+    expect(Object.keys(bands).sort((a, b) => a - b)).toEqual(['1', '2']);
+    expect(bands[1]).toEqual(['Hotel']);
+    expect(bands[2]).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf']);
+  });
+
+  it('a K=1 fleet produces exactly 1 band covering the whole pool', () => {
+    const bands = buildTierCallsignBands(1);
+    expect(Object.keys(bands)).toEqual(['1']);
+    expect(bands[1]).toEqual(NATO);
+  });
+
+  it('every band is non-empty even when K exceeds the NATO pool size (safety floor)', () => {
+    const bands = buildTierCallsignBands(10);
+    for (let rank = 1; rank <= 10; rank += 1) {
+      expect(bands[rank]).toBeDefined();
+      expect(bands[rank].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('bands partition the pool with no overlap at K=3', () => {
+    const bands = buildTierCallsignBands(3);
+    expect(Object.keys(bands).sort((a, b) => a - b)).toEqual(['1', '2', '3']);
+    const flat = [...bands[1], ...bands[2], ...bands[3]];
+    expect(new Set(flat).size).toBe(flat.length); // no duplicates across bands
   });
 });

--- a/tests/unit/fleet/tier-aware-claimable.test.js
+++ b/tests/unit/fleet/tier-aware-claimable.test.js
@@ -14,11 +14,11 @@
  *   (e) an otherwise-ineligible SD (deferred / orchestrator / fixture / bare-shell) is excluded
  *       regardless of tier.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { claimableForTier, tierClaimableBreakdown, isBaseEligible, sdMinTierRank } = require('../../../lib/fleet/tier-claimable.cjs');
-const { ladderTopRank } = require('../../../lib/fleet/tier-ladder.cjs');
+const { ladderTopRank, deriveLiveLadder, __resetLadderCacheForTests } = require('../../../lib/fleet/tier-ladder.cjs');
 
 const TOP = ladderTopRank(); // 4
 
@@ -146,5 +146,64 @@ describe('preFiltered passthrough', () => {
     const pool = [sd('A', 1), sd('DEF', 1, { status: 'deferred' })];
     expect(tierClaimableBreakdown(pool, { tieringActive: true, preFiltered: true }).aggregate).toBe(2);
     expect(tierClaimableBreakdown(pool, { tieringActive: true, preFiltered: false }).aggregate).toBe(1);
+  });
+});
+
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C: tier-claimable.cjs already reads ladderTopRank()
+// dynamically (never hardcoded 4), but no prior test exercised K != 4. These prove the
+// partition/cumulative invariants hold when a live fleet resizes the ladder, and that the
+// module-level ladder cache is restored afterward so it doesn't leak into other test files.
+describe('K != 4 — invariants hold when the live fleet resizes the ladder (FR-4)', () => {
+  afterEach(() => {
+    __resetLadderCacheForTests();
+  });
+
+  it('a 2-distinct-score live fleet resizes ladderTopRank() to 2, and breakdown invariants still hold', () => {
+    const { topRank } = deriveLiveLadder([
+      { model: 'sonnet', effort: 'max' },
+      { model: 'opus', effort: 'high' },
+    ]);
+    expect(topRank).toBe(2);
+    expect(ladderTopRank()).toBe(2);
+
+    const pool = [sd('A', 1), sd('B', 2), sd('U')]; // 1 unscored
+    const bd = tierClaimableBreakdown(pool, { tieringActive: true });
+    expect(bd.aggregate).toBe(3);
+    const partitionSum = bd.unscored + bd.aboveTop + Object.values(bd.exact).reduce((a, b) => a + b, 0);
+    expect(partitionSum).toBe(bd.aggregate);
+    expect(bd.partitionSumsToAggregate).toBe(true);
+
+    let running = bd.unscored;
+    for (let r = 1; r <= 2; r += 1) {
+      running += bd.exact[r];
+      expect(bd.cumulative[r]).toBe(running);
+      expect(claimableForTier(pool, { workerTierRank: r, tieringActive: true })).toHaveLength(running);
+    }
+    expect(bd.cumulative[2]).toBe(bd.aggregate);
+  });
+
+  it('a 6-distinct-score live fleet resizes ladderTopRank() to 6, and a rank-6 SD is claimable only at the top rung', () => {
+    const { topRank } = deriveLiveLadder([
+      { model: 'sonnet', effort: 'low' },
+      { model: 'sonnet', effort: 'medium' },
+      { model: 'sonnet', effort: 'high' },
+      { model: 'sonnet', effort: 'max' },
+      { model: 'opus', effort: 'high' },
+      { model: 'opus', effort: 'max' },
+    ]);
+    expect(topRank).toBe(6);
+    expect(ladderTopRank()).toBe(6);
+
+    const pool = [sd('A', 1), sd('F', 6), sd('U')];
+    expect(keys(claimableForTier(pool, { workerTierRank: 5, tieringActive: true }))).toBe('A,U');
+    expect(keys(claimableForTier(pool, { workerTierRank: 6, tieringActive: true }))).toBe('A,F,U');
+
+    const bd = tierClaimableBreakdown(pool, { tieringActive: true });
+    expect(bd.partitionSumsToAggregate).toBe(true);
+    expect(bd.cumulative[6]).toBe(bd.aggregate);
+  });
+
+  it('restores the default K=4 ladder after the cache reset (no cross-test leakage)', () => {
+    expect(ladderTopRank()).toBe(TOP);
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/assign-fleet-identities.cjs` replaces the hardcoded 4-band `TIER_CALLSIGNS` map + default-4 `tierRankOf()` with dynamic band derivation from `lib/fleet/tier-ladder.cjs` (`buildTierCallsignBands`, `resolveWorkerTierRank`, `ladderTopRank`).
- The coordinator cron is now the authoritative writer of each worker's fleet-relative `metadata.tier_rank`, computed via `deriveWorkerTierRank(worker, liveFleet)` before callsign banding runs.
- `worker-checkin.cjs`'s existing single-arg call sites are unaffected (unchanged signatures).

## Test plan
- [x] `npx vitest run tests/unit/assign-fleet-identities-tier-callsign.test.js tests/unit/fleet/tier-aware-claimable.test.js tests/unit/assign-fleet-identities-coordinator-filter.test.js tests/unit/worker-checkin-fleet-critical-window.test.js` — 70/70 pass
- [x] `buildTierCallsignBands(4)` hand-verified + adversarially re-verified (TESTING sub-agent) byte-identical to the legacy static map
- [x] New regression coverage for K=1/K=2/K=3/K=10 (callsign bands) and K=2/K=6 (`tierClaimableBreakdown` partition invariant via `deriveLiveLadder`)

SD: SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-C (child of SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001, FR-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)