### PR TITLE
feat(SD-LEO-INFRA-ADAPTIVE-COMMS-CADENCE-SHARED-PROTOCOL-001): shared adaptive comms cadence helper

### DIFF
--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -133,3 +133,41 @@ It stamps `payload.dead_letter=true` (+ `dead_letter_at`, `dead_letter_reason`,
 `original_target`), stamps `read_at` (drain marker), and backfills `expires_at = now+7d`
 when NULL so the audit trail is reaped after a week. Surfaced by the coordinator inbox
 section 'DEAD-LETTERED (24h)' — re-send to the successor session if still relevant.
+
+## Adaptive comms cadence — a SHARED protocol capability
+
+`lib/coordinator/adaptive-comms-cadence.cjs` (SD-LEO-INFRA-ADAPTIVE-COMMS-CADENCE-SHARED-PROTOCOL-001)
+is the single shared decision any session (Adam, coordinator, Solomon, or an opted-in worker)
+calls to compute its own next self-scheduled check-in interval, instead of always waiting a
+full fixed baseline tick even during a live back-and-forth:
+
+- `computeAdaptiveCadence({ sentPendingReply, receivedUnactioned, lastActivityMs, threadOpenedAtMs, nowMs, opts })`
+  — PURE, no I/O. Returns `{ intervalMs, reason, tight }`: **TIGHT** (default 2.5min) while a
+  thread is genuinely open, **BASELINE** (default 15min) when quiet. A hard **CAP** (default
+  30min) forces a fallback to baseline once a thread has been open longer than that, so a
+  never-resolving thread can't pin a session in tight-poll forever (defeats cycle-down).
+- `getCommsActivitySignals(supabase, sessionId, opts)` — the companion I/O helper. Detects: a
+  sent `payload.reply_requested=true` row with no later row echoing `payload.reply_to` back to
+  it (sentPendingReply); a received row with `acknowledged_at IS NULL` inside the recent window
+  (receivedUnactioned); the most recent bidirectional activity timestamp. **Fail-open**: any
+  query error resolves to signals that compute to baseline — never blocks the caller's tick,
+  never accidentally pins a session tight on an error.
+
+**Tightening is SELF-SCHEDULED RE-CHECK, not a retuned cron.** A `CronCreate`-armed cadence
+can't be retuned mid-flight from Node, so each consumer reads the recommendation and re-arms
+its own next wakeup on top of its existing baseline-armed tick — this is layered on, not a
+replacement for, the documented `*/15` inbox-monitor cadence.
+
+**Wired consumers:**
+- `scripts/worker-checkin.cjs` (live, opt-in): the idle-path `recommended_wakeup_seconds` the
+  `/checkin` skill reads for its `ScheduleWakeup` tightens when this worker's own session has an
+  active reply-pending thread — e.g. awaiting a coordinator reply on a blocked-item question.
+  **Additive only**: never loosens the existing belt/claim-driven recommendation, never touches
+  claim acquisition or heartbeat cadence.
+- Adam's / Solomon's inbox-monitor ticks and the coordinator's own comms loop are documented
+  consumers of the same shared helper — each self-schedules a tighter re-check on top of its
+  baseline-armed cron while a thread is open, using the identical `computeAdaptiveCadence` +
+  `getCommsActivitySignals` pair (never a per-role reimplementation).
+
+**Preserves silence-by-default**: the helper computes an interval only — it never itself sends
+a message, so message volume/chattiness is completely unaffected; only receipt latency changes.

--- a/lib/coordinator/adaptive-comms-cadence.cjs
+++ b/lib/coordinator/adaptive-comms-cadence.cjs
@@ -1,0 +1,155 @@
+'use strict';
+
+/**
+ * Shared adaptive communication cadence — SD-LEO-INFRA-ADAPTIVE-COMMS-CADENCE-SHARED-PROTOCOL-001.
+ *
+ * Role-sessions (Adam, coordinator, Solomon) and workers drain their inboxes / re-check on a
+ * FIXED cadence. That's fine when quiet, but during a live back-and-forth it adds one full
+ * baseline interval of latency PER hop. This module is the single shared, pure decision that
+ * ANY session calls to compute its own next self-scheduled check-in interval: TIGHT while a
+ * thread is genuinely open, BASELINE when quiet, capped so a never-resolving thread can't pin a
+ * session in tight-poll forever (defeating cycle-down).
+ *
+ * Pattern mirrors lib/hooks/auto-signal-threshold.cjs: a PURE decision function (no I/O,
+ * unit-testable in isolation) plus a companion I/O helper that gathers the signals. Tightening
+ * happens via SELF-SCHEDULED RE-CHECK (each caller reads the recommendation and re-arms its own
+ * next wakeup) — a CronCreate-armed cadence can't be retuned mid-flight from Node, so this is
+ * layered on top of the baseline-armed cron, not a replacement for it.
+ */
+
+const DEFAULT_TIGHT_MS = 150000; // 2.5 min
+const DEFAULT_BASELINE_MS = 900000; // 15 min
+const DEFAULT_CAP_MS = 1800000; // 30 min — hard ceiling on how long tight-poll can persist
+const DEFAULT_RECENT_ACTIVITY_WINDOW_MS = 300000; // 5 min
+
+/**
+ * PURE: compute the next check-in interval from pre-gathered signals.
+ * @param {object} o
+ * @param {boolean} [o.sentPendingReply] - this session sent a reply_requested=true message with no reply yet
+ * @param {boolean} [o.receivedUnactioned] - a message awaiting this session's response arrived recently
+ * @param {number} [o.lastActivityMs] - timestamp (ms) of the most recent bidirectional activity
+ * @param {number} [o.threadOpenedAtMs] - timestamp (ms) the active thread first opened (for cap enforcement)
+ * @param {number} [o.nowMs] - current time in ms (defaults to Date.now())
+ * @param {{ tightIntervalMs?: number, baselineIntervalMs?: number, capMs?: number, recentActivityWindowMs?: number }} [o.opts]
+ * @returns {{ intervalMs: number, reason: string, tight: boolean }}
+ */
+function computeAdaptiveCadence({
+  sentPendingReply = false,
+  receivedUnactioned = false,
+  lastActivityMs,
+  threadOpenedAtMs,
+  nowMs,
+  opts = {},
+} = {}) {
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const tightMs = Number.isFinite(opts.tightIntervalMs) ? opts.tightIntervalMs : DEFAULT_TIGHT_MS;
+  const baselineMs = Number.isFinite(opts.baselineIntervalMs) ? opts.baselineIntervalMs : DEFAULT_BASELINE_MS;
+  const capMs = Number.isFinite(opts.capMs) ? opts.capMs : DEFAULT_CAP_MS;
+  const recentWindowMs = Number.isFinite(opts.recentActivityWindowMs)
+    ? opts.recentActivityWindowMs
+    : DEFAULT_RECENT_ACTIVITY_WINDOW_MS;
+
+  const recentActivity = Number.isFinite(lastActivityMs) && now - lastActivityMs < recentWindowMs;
+  const hasActiveSignal = sentPendingReply || receivedUnactioned || recentActivity;
+
+  if (!hasActiveSignal) {
+    return { intervalMs: baselineMs, reason: 'no_active_thread', tight: false };
+  }
+
+  // Cap enforcement: a thread open longer than capMs falls back to baseline regardless of the
+  // active signal, so a never-resolving thread can't pin a session in tight-poll indefinitely.
+  const openedAt = Number.isFinite(threadOpenedAtMs) ? threadOpenedAtMs : now;
+  if (now - openedAt >= capMs) {
+    return { intervalMs: baselineMs, reason: 'cap_exceeded', tight: false };
+  }
+
+  const reason = sentPendingReply
+    ? 'sent_pending_reply'
+    : receivedUnactioned
+      ? 'received_unactioned'
+      : 'recent_activity';
+  return { intervalMs: tightMs, reason, tight: true };
+}
+
+/**
+ * Gather the live session_coordination signals computeAdaptiveCadence expects. FAIL-OPEN: any
+ * DB error resolves to signals that compute to BASELINE — a query failure must never pin a
+ * session in tight-poll, and must never throw into the caller's tick.
+ * @param {object} supabase - service-role client
+ * @param {string} sessionId - this session's id
+ * @param {{ nowMs?: number, recentActivityWindowMs?: number }} [opts]
+ * @returns {Promise<{ sentPendingReply: boolean, receivedUnactioned: boolean, lastActivityMs: number|undefined, threadOpenedAtMs: number|undefined }>}
+ */
+async function getCommsActivitySignals(supabase, sessionId, opts = {}) {
+  const fallback = { sentPendingReply: false, receivedUnactioned: false, lastActivityMs: undefined, threadOpenedAtMs: undefined };
+  if (!supabase || !sessionId) return fallback;
+
+  const now = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+  const windowMs = Number.isFinite(opts.recentActivityWindowMs) ? opts.recentActivityWindowMs : DEFAULT_RECENT_ACTIVITY_WINDOW_MS;
+  const sinceIso = new Date(now - windowMs).toISOString();
+
+  try {
+    const [sentRes, receivedRes] = await Promise.all([
+      supabase
+        .from('session_coordination')
+        .select('id, created_at, payload')
+        .eq('sender_session', sessionId)
+        .order('created_at', { ascending: false })
+        .limit(20),
+      supabase
+        .from('session_coordination')
+        .select('id, created_at')
+        .eq('target_session', sessionId)
+        .is('acknowledged_at', null)
+        .gte('created_at', sinceIso)
+        .order('created_at', { ascending: false })
+        .limit(1),
+    ]);
+
+    if (sentRes.error || receivedRes.error) return fallback;
+
+    const sentRows = Array.isArray(sentRes.data) ? sentRes.data : [];
+    const repliedToIds = new Set(
+      sentRows
+        .map((r) => r && r.payload && r.payload.reply_to)
+        .filter((v) => typeof v === 'string')
+    );
+    const pendingSent = sentRows.find(
+      (r) => r && r.payload && r.payload.reply_requested === true && !repliedToIds.has(r.id)
+    );
+
+    const receivedRows = Array.isArray(receivedRes.data) ? receivedRes.data : [];
+    const receivedUnactioned = receivedRows.length > 0;
+
+    const timestamps = []
+      .concat(sentRows.slice(0, 1).map((r) => r.created_at))
+      .concat(receivedRows.map((r) => r.created_at))
+      .filter(Boolean)
+      .map((t) => new Date(t).getTime());
+    const lastActivityMs = timestamps.length ? Math.max(...timestamps) : undefined;
+
+    const threadOpenedAtMs = pendingSent
+      ? new Date(pendingSent.created_at).getTime()
+      : receivedUnactioned
+        ? new Date(receivedRows[receivedRows.length - 1].created_at).getTime()
+        : undefined;
+
+    return {
+      sentPendingReply: Boolean(pendingSent),
+      receivedUnactioned,
+      lastActivityMs,
+      threadOpenedAtMs,
+    };
+  } catch {
+    return fallback; // fail-open
+  }
+}
+
+module.exports = {
+  computeAdaptiveCadence,
+  getCommsActivitySignals,
+  DEFAULT_TIGHT_MS,
+  DEFAULT_BASELINE_MS,
+  DEFAULT_CAP_MS,
+  DEFAULT_RECENT_ACTIVITY_WINDOW_MS,
+};

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -32,6 +32,7 @@
  */
 
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const { getCommsActivitySignals, computeAdaptiveCadence } = require('../lib/coordinator/adaptive-comms-cadence.cjs');
 const ws = require('../lib/fleet/worker-status.cjs');
 const { stampClaim } = require('../lib/fleet/claim-stamp.cjs');
 // SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001: acquisition-time guard so a propose-only
@@ -1384,11 +1385,27 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
         ? ` (${rankedAgnostic} ranked, but 0 claimable at your tier — all above your rung; a higher-tier worker must take them.)`
         : ` (${rankedAgnostic} ranked, but 0 claimable by any worker — they are orchestrator parents / clone build-trees / human-action / held, not tier-blocked.)`)
     : '';
+  // SD-LEO-INFRA-ADAPTIVE-COMMS-CADENCE-SHARED-PROTOCOL-001 (FR-6): opt-in tightening. A worker
+  // idling on the belt but awaiting a reply on a live comms thread (e.g. a blocked-item question
+  // to the coordinator) shouldn't wait a full baseline interval to notice the reply. ADDITIVE
+  // ONLY — never loosens the existing belt-driven recommendation, never touches claim/heartbeat.
+  // Fail-open: any error here falls through to the unchanged baseline recommendation.
+  let idleWakeupSeconds = DEFAULT_IDLE_WAKEUP_SECONDS;
+  let adaptiveCadenceNote = '';
+  try {
+    const signals = await getCommsActivitySignals(sb, sessionId);
+    const cadence = computeAdaptiveCadence(signals);
+    if (cadence.tight && cadence.intervalMs / 1000 < idleWakeupSeconds) {
+      idleWakeupSeconds = Math.round(cadence.intervalMs / 1000);
+      adaptiveCadenceNote = ` (tightened to ${idleWakeupSeconds}s — live comms thread: ${cadence.reason})`;
+    }
+  } catch { /* fail-open: keep the baseline recommendation */ }
+
   return {
     ...base,
     action: 'idle',
-    recommended_wakeup_seconds: DEFAULT_IDLE_WAKEUP_SECONDS,
-    message: `No assignment and nothing claimable. IDLE.${tierNote} The /checkin skill must now call ScheduleWakeup(~${DEFAULT_IDLE_WAKEUP_SECONDS}s) and proceed — never wait on a human.`,
+    recommended_wakeup_seconds: idleWakeupSeconds,
+    message: `No assignment and nothing claimable. IDLE.${tierNote} The /checkin skill must now call ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed — never wait on a human.`,
   };
 }
 

--- a/tests/unit/adaptive-comms-cadence.test.js
+++ b/tests/unit/adaptive-comms-cadence.test.js
@@ -1,0 +1,168 @@
+/**
+ * SD-LEO-INFRA-ADAPTIVE-COMMS-CADENCE-SHARED-PROTOCOL-001 — the shared adaptive-cadence helper.
+ * Pattern mirrors tests/unit/auto-signal-threshold.test.js: pure decision function tests plus
+ * signal-gathering tests against a stub supabase client.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  computeAdaptiveCadence,
+  getCommsActivitySignals,
+  DEFAULT_TIGHT_MS,
+  DEFAULT_BASELINE_MS,
+  DEFAULT_CAP_MS,
+} = require('../../lib/coordinator/adaptive-comms-cadence.cjs');
+
+const NOW = 1_000_000_000_000;
+
+describe('computeAdaptiveCadence (FR-1)', () => {
+  it('returns baseline when there is no active signal', () => {
+    const r = computeAdaptiveCadence({ nowMs: NOW });
+    expect(r.tight).toBe(false);
+    expect(r.intervalMs).toBe(DEFAULT_BASELINE_MS);
+    expect(r.reason).toBe('no_active_thread');
+  });
+
+  it('returns tight when a sent reply is pending', () => {
+    const r = computeAdaptiveCadence({ sentPendingReply: true, threadOpenedAtMs: NOW - 60000, nowMs: NOW });
+    expect(r.tight).toBe(true);
+    expect(r.intervalMs).toBe(DEFAULT_TIGHT_MS);
+    expect(r.reason).toBe('sent_pending_reply');
+  });
+
+  it('returns tight when a received message is unactioned', () => {
+    const r = computeAdaptiveCadence({ receivedUnactioned: true, threadOpenedAtMs: NOW - 60000, nowMs: NOW });
+    expect(r.tight).toBe(true);
+    expect(r.reason).toBe('received_unactioned');
+  });
+
+  it('returns tight on recent bidirectional activity within the recency window', () => {
+    const r = computeAdaptiveCadence({ lastActivityMs: NOW - 60000, nowMs: NOW });
+    expect(r.tight).toBe(true);
+    expect(r.reason).toBe('recent_activity');
+  });
+
+  it('does NOT tighten on activity outside the recency window', () => {
+    const r = computeAdaptiveCadence({ lastActivityMs: NOW - 600000, nowMs: NOW }); // 10min ago, default window 5min
+    expect(r.tight).toBe(false);
+  });
+
+  it('CAP: falls back to baseline once the thread has been open longer than capMs, even with an active signal', () => {
+    const r = computeAdaptiveCadence({
+      sentPendingReply: true,
+      threadOpenedAtMs: NOW - (DEFAULT_CAP_MS + 1000),
+      nowMs: NOW,
+    });
+    expect(r.tight).toBe(false);
+    expect(r.intervalMs).toBe(DEFAULT_BASELINE_MS);
+    expect(r.reason).toBe('cap_exceeded');
+  });
+
+  it('CAP: stays tight just under the cap boundary', () => {
+    const r = computeAdaptiveCadence({
+      sentPendingReply: true,
+      threadOpenedAtMs: NOW - (DEFAULT_CAP_MS - 1000),
+      nowMs: NOW,
+    });
+    expect(r.tight).toBe(true);
+  });
+
+  it('respects opts overrides', () => {
+    const r = computeAdaptiveCadence({
+      sentPendingReply: true,
+      threadOpenedAtMs: NOW,
+      nowMs: NOW,
+      opts: { tightIntervalMs: 5000, baselineIntervalMs: 60000, capMs: 100000 },
+    });
+    expect(r.intervalMs).toBe(5000);
+  });
+
+  it('is pure: identical inputs always produce identical output', () => {
+    const input = { sentPendingReply: true, threadOpenedAtMs: NOW - 1000, nowMs: NOW };
+    expect(computeAdaptiveCadence(input)).toEqual(computeAdaptiveCadence(input));
+  });
+});
+
+// ---- getCommsActivitySignals (FR-2) --------------------------------------
+function stubSupabase({ sentRows = [], receivedRows = [], sentError = null, receivedError = null } = {}) {
+  return {
+    from(table) {
+      const api = {
+        _filters: {},
+        select() { return api; },
+        eq() { return api; },
+        is() { return api; },
+        gte() { return api; },
+        order() { return api; },
+        limit() {
+          // Distinguish sent vs received query by which filter chain was used — simplify by
+          // returning based on presence of receivedRows/sentRows via a marker set on `from`.
+          return api;
+        },
+        then(resolve) {
+          if (api._kind === 'received') return resolve({ data: receivedRows, error: receivedError });
+          return resolve({ data: sentRows, error: sentError });
+        },
+      };
+      // Mark the query kind based on call order isn't reliable with this stub shape, so instead
+      // key off table name + a per-call flag set by the FIRST distinguishing method call.
+      api.is = (...args) => { api._kind = 'received'; return api; };
+      return api;
+    },
+  };
+}
+
+describe('getCommsActivitySignals (FR-2)', () => {
+  it('detects a sent reply-pending thread with no reply yet', async () => {
+    const sb = stubSupabase({
+      sentRows: [{ id: 'msg-1', created_at: new Date(NOW - 30000).toISOString(), payload: { reply_requested: true } }],
+      receivedRows: [],
+    });
+    const r = await getCommsActivitySignals(sb, 'sess-1', { nowMs: NOW });
+    expect(r.sentPendingReply).toBe(true);
+  });
+
+  it('does NOT flag a sent message that already has a reply (repliedToIds)', async () => {
+    const sb = stubSupabase({
+      sentRows: [
+        { id: 'msg-1', created_at: new Date(NOW - 30000).toISOString(), payload: { reply_requested: true } },
+        { id: 'msg-2', created_at: new Date(NOW - 10000).toISOString(), payload: { reply_to: 'msg-1' } },
+      ],
+      receivedRows: [],
+    });
+    const r = await getCommsActivitySignals(sb, 'sess-1', { nowMs: NOW });
+    expect(r.sentPendingReply).toBe(false);
+  });
+
+  it('detects a received unactioned message within the recent window', async () => {
+    const sb = stubSupabase({
+      sentRows: [],
+      receivedRows: [{ id: 'msg-3', created_at: new Date(NOW - 20000).toISOString() }],
+    });
+    const r = await getCommsActivitySignals(sb, 'sess-1', { nowMs: NOW });
+    expect(r.receivedUnactioned).toBe(true);
+  });
+
+  it('fail-open: resolves to no-signal on a query error, never throws', async () => {
+    const sb = stubSupabase({ sentError: { message: 'boom' } });
+    const r = await getCommsActivitySignals(sb, 'sess-1', { nowMs: NOW });
+    expect(r.sentPendingReply).toBe(false);
+    expect(r.receivedUnactioned).toBe(false);
+    const cadence = computeAdaptiveCadence({ ...r, nowMs: NOW });
+    expect(cadence.tight).toBe(false);
+  });
+
+  it('fail-open: resolves to no-signal on a thrown exception, never throws', async () => {
+    const sb = { from() { throw new Error('boom'); } };
+    await expect(getCommsActivitySignals(sb, 'sess-1', { nowMs: NOW })).resolves.toMatchObject({
+      sentPendingReply: false,
+      receivedUnactioned: false,
+    });
+  });
+
+  it('returns no-signal defaults for missing supabase/sessionId (never throws)', async () => {
+    await expect(getCommsActivitySignals(null, 'sess-1')).resolves.toMatchObject({ sentPendingReply: false });
+    await expect(getCommsActivitySignals({}, null)).resolves.toMatchObject({ sentPendingReply: false });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `lib/coordinator/adaptive-comms-cadence.cjs`: a pure `computeAdaptiveCadence` decision function + fail-open `getCommsActivitySignals` DB-signal reader, the single shared helper any session (Adam/coordinator/Solomon/opted-in worker) uses to tighten its self-scheduled re-check interval (~2.5min) while a comms thread is genuinely open, relax to baseline (~15min) when quiet, with a hard 30min CAP so a never-resolving thread can't pin a session tight forever.
- Wire it live (additive-only, fail-open) into `scripts/worker-checkin.cjs`'s idle-path `recommended_wakeup_seconds`.
- Document the shared contract and the (doc-only, by design) wiring pattern for Adam/coordinator/Solomon in `docs/protocol/coordinator-adam-comms.md`.
- 15 new unit tests.

## Test plan
- [x] `tests/unit/adaptive-comms-cadence.test.js` — 15/15 pass
- [x] Full `worker-checkin` test suite unchanged/passing (byte-identical pre-existing files)
- [x] VALIDATION sub-agent: PASS (92%) — all 8 FRs traced to file:line, no duplicate cadence logic found
- [x] REGRESSION sub-agent: PASS (95%) — additive/tighten-only invariant confirmed by trace, negligible perf impact

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>