### PR TITLE
fix(QF-20260701-356): drop --passWithNoTests from scoped unit runs (gate-fail-open false-pass)

### DIFF
--- a/scripts/modules/complete-quick-fix/test-runner.js
+++ b/scripts/modules/complete-quick-fix/test-runner.js
@@ -25,10 +25,17 @@ export const WHOLE_SUITE_UNIT_COMMAND = 'npm run test:unit';
  * TARGETED run of explicit test-file paths does NOT build the full graph and is
  * clean/fast. So we resolve the QF's actual unit-test files (see
  * getScopedUnitTestFiles in git-operations.js) and run exactly those:
- *   `npx vitest run --project unit <testFiles> --passWithNoTests`
- * --passWithNoTests keeps an empty/already-filtered set a pass, not a hard fail
- * (FR-3). When no test files are supplied, fall back to the whole-suite command
- * (used only for the diff-unknown last-resort path; FR-1 backward-compat).
+ *   `npx vitest run --project unit <testFiles>`
+ * When no test files are supplied, fall back to the whole-suite command (used
+ * only for the diff-unknown last-resort path; FR-1 backward-compat).
+ *
+ * RCA a15122006891b019b (2026-07-01): --passWithNoTests was previously appended
+ * to the SCOPED branch too. When every resolved path is excluded by the unit
+ * project's own filters (quarantine manifest / SHARED_EXCLUDE / DB_INCLUDE),
+ * vitest finds zero test files but --passWithNoTests still exits 0 — a
+ * gate-fail-open false-verification-witness (tests_passing=true with zero
+ * tests ever executed). Dropped here; runTests() also asserts summary.total>0
+ * for scoped runs as defense-in-depth (see below).
  *
  * Pure (no side effects) for unit-testability (FR-5). Each path is double-quoted
  * so a path with a space — or a shell metacharacter — cannot break or inject.
@@ -47,7 +54,7 @@ export function buildUnitTestCommand(testFiles) {
   if (!quoted) {
     return WHOLE_SUITE_UNIT_COMMAND;
   }
-  return `npx vitest run --project unit ${quoted} --passWithNoTests`;
+  return `npx vitest run --project unit ${quoted}`;
 }
 
 /**
@@ -90,11 +97,22 @@ export function runTests(testType, options = {}) {
       cwd: testDir
     });
 
+    const summary = extractTestSummary(output, testType);
+    // RCA a15122006891b019b: a scoped unit run (explicit testFiles) that executes
+    // zero tests is NOT a pass, even though the process exited 0 — the scoped
+    // files were likely excluded by the unit project's own filters. Whole-suite
+    // runs (no testFiles) are unaffected.
+    const scopedZeroExecution =
+      testType === 'unit' && Array.isArray(options.testFiles) && options.testFiles.length > 0 && summary.total === 0;
+
     return {
-      passed: true,
+      passed: !scopedZeroExecution,
       output: output.substring(0, 2000),
       exitCode: 0,
-      summary: extractTestSummary(output, testType)
+      summary,
+      ...(scopedZeroExecution && {
+        falseVerificationGuard: 'scoped testFiles resolved to zero executed tests — treated as non-pass'
+      })
     };
   } catch (err) {
     const output = err.stdout?.toString() || err.stderr?.toString() || err.message;

--- a/tests/unit/complete-quick-fix/change-scope-test-gate.test.js
+++ b/tests/unit/complete-quick-fix/change-scope-test-gate.test.js
@@ -12,13 +12,20 @@
  * ERR_LOAD_URL during project-wide collection on a pre-existing baseline file —
  * the very baseline-poisoning this SD escapes. A targeted run avoids that graph.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import os from 'os';
 import path from 'path';
+
+let execSyncMock;
+vi.mock('child_process', () => ({
+  execSync: (...args) => execSyncMock(...args),
+}));
+
 import {
   buildUnitTestCommand,
   WHOLE_SUITE_UNIT_COMMAND,
+  runTests,
 } from '../../../scripts/modules/complete-quick-fix/test-runner.js';
 import {
   isFrontendPath,
@@ -37,7 +44,12 @@ describe('buildUnitTestCommand (FR-1, FR-3, FR-5)', () => {
     expect(cmd).not.toContain('--changed');
     expect(cmd).toContain('"tests/unit/foo.test.js"');
     expect(cmd).toContain('--project unit'); // FR-5: pin to no-DB unit project
-    expect(cmd).toContain('--passWithNoTests'); // FR-3: empty match is a pass
+    // RCA a15122006891b019b: --passWithNoTests on a scoped run masks a
+    // zero-tests-executed false-pass when every path is filtered out by the
+    // unit project's own excludes (quarantine manifest / SHARED_EXCLUDE /
+    // DB_INCLUDE). Dropped from the scoped branch; runTests() asserts
+    // summary.total>0 instead (see the runTests describe block below).
+    expect(cmd).not.toContain('--passWithNoTests');
     expect(cmd).not.toBe(WHOLE_SUITE_UNIT_COMMAND);
   });
 
@@ -176,5 +188,44 @@ describe('getScopedUnitTestFiles (FR-1, TR-2) — fs fixture', () => {
   it('does not include a candidate path that does not exist on disk', () => {
     // lib/foo.js sibling exists, but a non-existent source yields nothing
     expect(getScopedUnitTestFiles(['lib/nope.js'], dir)).toEqual([]);
+  });
+});
+
+describe('runTests — scoped zero-execution guard (RCA a15122006891b019b)', () => {
+  beforeEach(() => {
+    execSyncMock = vi.fn();
+  });
+
+  it('treats exit-0 with zero executed tests as non-pass when testFiles were scoped', () => {
+    // Simulates vitest exiting 0 with no "Tests: N passed" summary line at all
+    // (the false-pass this RCA closes, previously masked by --passWithNoTests).
+    execSyncMock.mockReturnValue('No test files found, exiting with code 0\n');
+    const result = runTests('unit', { testFiles: ['tests/unit/quarantined.test.js'] });
+    expect(result.passed).toBe(false);
+    expect(result.summary.total).toBe(0);
+    expect(result.falseVerificationGuard).toMatch(/zero executed tests/);
+  });
+
+  it('is a real pass when a scoped run actually executes tests', () => {
+    execSyncMock.mockReturnValue('Tests: 3 passed (3)\n');
+    const result = runTests('unit', { testFiles: ['tests/unit/real.test.js'] });
+    expect(result.passed).toBe(true);
+    expect(result.summary.total).toBe(3);
+    expect(result.falseVerificationGuard).toBeUndefined();
+  });
+
+  it('does not apply the guard to a whole-suite run (no testFiles)', () => {
+    // Zero executed tests with no scoped files is not this class of bug — leave as-is.
+    execSyncMock.mockReturnValue('No test files found, exiting with code 0\n');
+    const result = runTests('unit', {});
+    expect(result.passed).toBe(true);
+    expect(result.falseVerificationGuard).toBeUndefined();
+  });
+
+  it('does not apply the guard to e2e runs', () => {
+    execSyncMock.mockReturnValue('0 passed\n');
+    const result = runTests('e2e', { testFiles: ['tests/e2e/foo.spec.ts'] });
+    expect(result.passed).toBe(true);
+    expect(result.falseVerificationGuard).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- `buildUnitTestCommand()` appended `--passWithNoTests` even when explicit scoped `testFiles` were supplied, so `runTests('unit', ...)` reported `passed:true` purely from `exitCode===0` with **zero tests executed** whenever every scoped file resolved to the unit project's exclude set (quarantine manifest / `SHARED_EXCLUDE` / `DB_INCLUDE`) — a gate-fail-open false-verification-witness.
- Sharpest case: a QF whose entire purpose is fixing a currently-quarantined test could show `tests_passing=true` with the test never having run.
- RCA `a15122006891b019b` (deferred from `QF-20260701-104`, this session's own branch-resolver.test.js fix, which hit exactly this gap):
  1. Drop `--passWithNoTests` from the scoped-file branch of `buildUnitTestCommand()` — the whole-suite fallback branch never had it, so this makes the two branches consistent.
  2. `runTests()` additionally asserts `summary.total>0` for scoped unit runs as defense-in-depth, treating exit-0-with-zero-executed as non-pass.
- Not touching `vitest.config.js`'s `.worktrees` exclude glob — that was checked separately in this session and confirmed inert/correct (a different, already-signaled harness gotcha).

## Test plan
- [x] `node --check` + ESLint clean on both changed files
- [x] Updated the pre-existing test that asserted the old (buggy) `--passWithNoTests` presence
- [x] Added 4 new tests for `runTests()`'s zero-execution guard (scoped-zero-fails, scoped-real-pass, whole-suite-unaffected, e2e-unaffected)
- [x] Full `tests/unit/complete-quick-fix*` + `tests/unit/scripts/complete-quick-fix-*` suite: 25 test files / 305 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)