### PR TITLE
fix(QF-20260701-848): isolate chairman-decision-api test from shared-prod-DB TOCTOU

### DIFF
--- a/tests/integration/chairman-decision-api.test.js
+++ b/tests/integration/chairman-decision-api.test.js
@@ -10,6 +10,7 @@
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import 'dotenv/config';
+import { randomUUID } from 'node:crypto';
 import { createOrReusePendingDecision, waitForDecision } from '../../lib/eva/chairman-decision-watcher.js';
 
 const supabase = createSupabaseServiceClient();
@@ -21,57 +22,67 @@ const HAS_REAL_DB = process.env.SUPABASE_URL
   && process.env.SUPABASE_SERVICE_ROLE_KEY
   && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
 
-// Use an existing venture from the database (FK constraints make test venture creation complex)
+// QF-20260701-848: use an EPHEMERAL, per-run venture (created in beforeAll) instead
+// of scanning for a shared "clean" existing venture. The old scan-25/find-clean
+// approach was a TOCTOU on the shared prod DB — a concurrent CI job or the live
+// production chairman-decision pipeline could insert a pending row at the same
+// (venture, stage) between the clean-check and createOrReusePendingDecision, so the
+// call reused it (isNew:false) and the assertions below failed. A dedicated venture
+// has zero pre-existing pending decisions, so `isNew:true` holds deterministically.
+// (2nd occurrence after QF-20260612-258, which was itself a shared-DB false-positive.)
+// Verified live: bare {name, problem_statement} insert succeeds (triggers default
+// stage/tier/status); deleting the venture cascades to eva_ventures (no orphans).
 let testVentureId = null;
 let testDecisionId = null;
 const createdDecisionIds = [];
 const testLogger = { log: () => {}, warn: () => {}, error: console.error };
 
+// Per-run marker so the crash-safety sweep in afterAll only ever reaps THIS suite's
+// aborted ventures, never a real one. Name need not be unique (each insert yields a
+// distinct venture id); the marker just scopes the age-bounded straggler sweep.
+const RUN_MARKER = `__citest_chairman__:${process.env.GITHUB_RUN_ID ?? randomUUID().slice(0, 8)}`;
+
 // Quick-fix QF-20260612-258: stage 0 is not a decision-creating stage per the
 // stage_creates_decision RPC (createOrReusePendingDecision returns {id:null,skipped}),
-// and real PENDING decisions now exist on live ventures since the chairman decision
-// queue went live (2026-06-11), so reuse-vs-create assertions collide with prod data.
-// Use gate stages (3/10/22) and a venture with no pending decisions.
+// so use gate stages (3/10/22) which have creates_decision=true.
 const STAGE_A = 3; // kill gate — creates_decision=true
 const STAGE_B = 10; // promotion gate — creates_decision=true
 
 describe.skipIf(!HAS_REAL_DB)('Chairman Decision API', () => {
   beforeAll(async () => {
-    // Find an existing venture with NO pending chairman decisions, so the
-    // reuse/create assertions below are not affected by live pending rows.
-    const { data: ventures } = await supabase
+    // Create a dedicated, ephemeral venture this suite exclusively owns, so no
+    // concurrent writer can pre-populate a pending decision at our (venture, stage).
+    const { data, error } = await supabase
       .from('ventures')
-      .select('id, name')
-      .limit(25);
-
-    const { data: pendingRows } = await supabase
-      .from('chairman_decisions')
-      .select('venture_id')
-      .eq('status', 'pending');
-    const pendingVentureIds = new Set((pendingRows ?? []).map((r) => r.venture_id));
-    const cleanVenture = (ventures ?? []).find((v) => !pendingVentureIds.has(v.id));
-
-    if (cleanVenture) {
-      testVentureId = cleanVenture.id;
-    } else {
-      // Skip all tests if no usable venture exists
-      console.warn('No venture without pending decisions found, skipping integration tests');
+      .insert({ name: RUN_MARKER, problem_statement: RUN_MARKER })
+      .select('id')
+      .single();
+    if (error) {
+      // Seed failed → leave testVentureId null; every test's `if (!testVentureId) return`
+      // guard skips gracefully rather than asserting against unowned data.
+      console.warn('Could not create ephemeral test venture, skipping integration tests:', error.message);
       return;
     }
-
-    // Clean up any stale test decisions from prior runs
-    await supabase
-      .from('chairman_decisions')
-      .delete()
-      .eq('venture_id', testVentureId)
-      .like('summary', '%Test decision%');
+    testVentureId = data.id;
   });
 
   afterAll(async () => {
-    // Clean up all test decisions we created
-    for (const id of createdDecisionIds) {
-      await supabase.from('chairman_decisions').delete().eq('id', id);
+    // Scope cleanup to THIS run's venture. Deleting the venture cascades to its
+    // chairman_decisions and eva_ventures (verified live), so this removes every
+    // row the suite created — createdDecisionIds are all on testVentureId.
+    if (testVentureId) {
+      await supabase.from('chairman_decisions').delete().eq('venture_id', testVentureId);
+      await supabase.from('ventures').delete().eq('id', testVentureId);
     }
+    // Crash-safety: reap ephemeral ventures from ABORTED prior runs that never
+    // reached this afterAll. Age-bounded (>1h) so a concurrent run's in-flight
+    // venture (same GITHUB_RUN_ID marker) is never deleted out from under it.
+    const cutoff = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    await supabase
+      .from('ventures')
+      .delete()
+      .like('name', '__citest_chairman__:%')
+      .lt('created_at', cutoff);
   });
 
   describe('createOrReusePendingDecision', () => {


### PR DESCRIPTION
## Quick-Fix QF-20260701-848

The red-merge-detector auto-filed a "+2 unit-failure regression (105→107)" and blamed #5313. **RCA verdict: misattribution.** Neither `chairman-decision-api.test.js` nor its code-under-test changed in the blame window (`git log ae499d9957..f4d6b3249a` is empty for both). The 2 failures (lines 91/137, `expect(result.isNew).toBe(true)`) are a **shared-prod-DB integration-test TOCTOU** — the 2nd occurrence of this test's isolation defect (prior QF-20260612-258).

### Root cause
`beforeAll` selected a "clean" existing venture deterministically (`ventures.limit(25).find(no-pending)`). On the shared prod DB every concurrent CI job **and the live production chairman-decision pipeline** funnel onto the same `(venture, stage)` space. A single competing writer inserting a pending row between the clean-check and `createOrReusePendingDecision` makes it **reuse** (`isNew:false`) → assertion fails. `isNew:false` (not a ≥2-row `.single()` throw) proves exactly one competing writer won the race. Sustained-then-self-clears = a contention episode, not logic rot (currently green).

### Fix (test-only, +11 net LOC)
Give the suite a **dedicated ephemeral venture** (`beforeAll` inserts, `afterAll` deletes — cascades to `chairman_decisions` + `eva_ventures`, verified live). Nothing else writes to it, so `isNew:true` holds deterministically — this **strengthens** the assertions, it does **not** absorb the baseline snapshot. Crash-safety sweep is age-bounded (>1h) so it never reaps a concurrent run's in-flight venture.

### Verification (live prod DB)
- Bare `{name, problem_statement}` insert succeeds under prod triggers (stage0-origin/eva-sync); delete leaves **zero** orphans.
- Test **11/11 green ×2**; **zero** leftover `__citest_chairman__` ventures after runs.

### Follow-up (signaled to coordinator, harness-bug bc7dfbf4)
`red-merge-detector.mjs` should cross-check the blamed SHA actually touched the failing test or its transitive deps before filing a regression QF — otherwise it manufactures spurious QFs whenever a merge-train burst overlaps a shared-DB flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)