### PR TITLE
fix(QF-20260701-683): WIRE_CHECK gates use execFileSync instead of execSync shell-string interpolation

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/wire-check-advisory.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/wire-check-advisory.js
@@ -25,7 +25,7 @@
  * Phase: EXEC-TO-PLAN (advisory)
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { buildCallGraph } from '../../../../../../lib/static-analysis/call-graph-builder.js';
@@ -94,8 +94,12 @@ export function createWireCheckAdvisoryGate(_supabase) {
       const mainRef = refResult.ref;
       let newFiles = [];
       try {
-        const diff = execSync(
-          `git diff --name-only --diff-filter=A ${mainRef}...HEAD -- "*.js" "*.mjs" "*.cjs"`,
+        // harness_backlog 7967256e: execFileSync (argv array, no shell) instead of
+        // execSync with a template-string command -- defense-in-depth even though
+        // mainRef is always one of getMainRef()'s fixed literal refs today.
+        const diff = execFileSync(
+          'git',
+          ['diff', '--name-only', '--diff-filter=A', `${mainRef}...HEAD`, '--', '*.js', '*.mjs', '*.cjs'],
           { encoding: 'utf8', cwd: rootDir, timeout: 10000 }
         );
         newFiles = diff

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -8,7 +8,7 @@
  * Phase: LEAD-FINAL-APPROVAL
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -171,14 +171,13 @@ export function discoverEntryPoints(rootDir) {
   const normalize = (p) => p.replace(/\\/g, '/');
 
   // 1. Extract script targets from package.json
+  // harness_backlog 7967256e (security-agent, 2026-07-01): this previously shelled
+  // out to `node -e "...readFileSync('${path}')..."` via execSync with string
+  // interpolation -- a command-injection smell even though pkgPath is not currently
+  // attacker-controlled. Read the file directly; no subprocess needed at all.
   try {
     const pkgPath = path.join(rootDir, 'package.json');
-    const pkg = JSON.parse(
-      execSync(`node -e "process.stdout.write(require('fs').readFileSync('${normalize(pkgPath)}','utf8'))"`, {
-        encoding: 'utf8',
-        timeout: 5000,
-      })
-    );
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 
     if (pkg.scripts) {
       for (const cmd of Object.values(pkg.scripts)) {
@@ -310,8 +309,12 @@ export function createWireCheckGate(_supabase) {
       const mainRef = refResult.ref;
       const refWarnings = refResult.warning ? [refResult.warning] : [];
       try {
-        const diff = execSync(
-          `git diff --name-only --diff-filter=A ${mainRef}...HEAD -- "*.js" "*.mjs" "*.cjs"`,
+        // harness_backlog 7967256e: execFileSync (argv array, no shell) instead of
+        // execSync with a template-string command -- defense-in-depth even though
+        // mainRef is always one of getMainRef()'s fixed literal refs today.
+        const diff = execFileSync(
+          'git',
+          ['diff', '--name-only', '--diff-filter=A', `${mainRef}...HEAD`, '--', '*.js', '*.mjs', '*.cjs'],
           { encoding: 'utf8', cwd: rootDir, timeout: 10000 }
         );
         newFiles = diff


### PR DESCRIPTION
## Summary
- `wire-check-gate.js` and `wire-check-advisory.js` built shell command strings via template literals and passed them to `execSync` (which spawns a shell to parse them) — flagged by the security-agent while reviewing `SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001` as a command-injection smell (out of that SD's scope).
- On inspection, neither interpolated value is currently attacker-controlled (`pkgPath` is a fixed `rootDir/package.json` path; `mainRef` is always one of `getMainRef()`'s 3 hardcoded literal refs), so this is **defensive hardening**, not an active-exploit fix.
- Replaced the `node -e "readFileSync(...)"` subprocess hack for reading `package.json` with a direct `fs.readFileSync` call (`fs` was already imported — no subprocess needed at all).
- Converted the git-diff `execSync` template-string calls in both gate files to `execFileSync` with argv arrays, matching the established `execFileSync` convention elsewhere in the codebase (e.g. `lib/eva/bridge/ensure-venture-clone.js`).
- Left the already-static (non-interpolated) `execSync` calls in `wire-check-gate.js` (`git ls-files`, `git rev-parse`) untouched — out of scope for this targeted fix.

## Test plan
- [x] `node --check` + ESLint clean on both changed files
- [x] All 3 existing wire-check test suites pass unchanged: `tests/unit/gates/wire-check-gate.test.js`, `tests/unit/gates/wire-check-advisory.test.js`, `tests/unit/handoff/wire-check-gate.test.js` — 64/64 tests, 0 regressions (none mock `execSync` or assert the literal command string — all run against the real repo and assert functional output)
- [x] Live sanity check against the real repo confirms `discoverEntryPoints` still correctly parses `package.json` scripts (365 entry points discovered, matching prior behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)