### PR TITLE
feat(SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001): blast-radius consumer-impact tool (Phase 1)

### DIFF
--- a/lib/static-analysis/ast-parse.js
+++ b/lib/static-analysis/ast-parse.js
@@ -1,0 +1,37 @@
+/**
+ * Shared hardened AST parse helper — Blast-Radius Consumer Analysis
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Parser configuration is hardcoded here rather than resolved from the
+ * repo's own build/lint config files: config resolution can execute
+ * arbitrary code, unlike @babel/parser's static tokenizer (SECURITY finding,
+ * agentId a997e58734a1fe858). Analyzed files and their configs are only ever
+ * read as plain text, never dynamically loaded or executed.
+ */
+
+import * as parser from '@babel/parser';
+
+/** Per-file byte cap: skip minified/generated/oversized files (DoS hardening). */
+export const MAX_ANALYZABLE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Parse JS/TS source into a Babel AST using a fixed, hardcoded plugin set.
+ *
+ * @param {string} content - File source text
+ * @param {string} filePath - Path (only used to decide JSX/TS plugin flags)
+ * @returns {Object} Babel File AST node
+ */
+export function parseSource(content, filePath) {
+  const isTypeScript = /\.tsx?$/.test(filePath);
+  return parser.parse(content, {
+    sourceType: 'module',
+    plugins: [
+      'jsx',
+      isTypeScript && 'typescript',
+      'classProperties',
+      'dynamicImport',
+      'optionalChaining',
+      'nullishCoalescingOperator',
+    ].filter(Boolean),
+  });
+}

--- a/lib/static-analysis/blast-radius.js
+++ b/lib/static-analysis/blast-radius.js
@@ -1,0 +1,137 @@
+/**
+ * Blast Radius — Blast-Radius Consumer Analysis (Phase 1)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Given a diff, finds every cross-file consumer of modified/removed exported
+ * symbols and flags any consumer not touched in the same diff. Recomputes the
+ * consumer index fresh on every call (no persistent cache) -- matching
+ * wire-check-gate.js's proven freshness pattern -- since a stale cache would
+ * reintroduce the exact "wrong blast-radius" defect class this tool exists to
+ * prevent.
+ */
+
+import { execFileSync } from 'child_process';
+import path from 'path';
+import { buildConsumerIndex, findConsumers } from './consumer-index.js';
+import { detectModifiedExports } from './symbol-diff.js';
+
+const TRACKED_EXTENSIONS_RE = /\.(js|mjs|cjs|ts|tsx)$/;
+/** Scope matches wire-check-gate.js's convention for this repo's backend/harness source tree. */
+const TRACKED_SCOPE = ['lib/', 'scripts/', 'server/'];
+
+function getChangedFiles(mainRef, rootDir) {
+  const out = execFileSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACMR', `${mainRef}...HEAD`, '--'],
+    { cwd: rootDir, encoding: 'utf-8', timeout: 10000, maxBuffer: 10 * 1024 * 1024 }
+  );
+  return out.split('\n').map((f) => f.trim()).filter(Boolean).map((f) => f.replace(/\\/g, '/'));
+}
+
+/**
+ * Discover all git-tracked source files in scope, fresh, every invocation.
+ * @param {string} rootDir - Project root
+ * @returns {string[]} Absolute paths (forward slashes)
+ */
+export function discoverTrackedSourceFiles(rootDir) {
+  const out = execFileSync('git', ['ls-files', '--', ...TRACKED_SCOPE], {
+    cwd: rootDir,
+    encoding: 'utf-8',
+    timeout: 15000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return out
+    .split('\n')
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .filter((f) => TRACKED_EXTENSIONS_RE.test(f))
+    .map((f) => path.resolve(rootDir, f).replace(/\\/g, '/'));
+}
+
+/**
+ * Compute the blast radius of a diff: every modified/removed export's
+ * consumers, with untouched (same-diff) consumers flagged.
+ *
+ * @param {string} mainRef - Base git ref (e.g. 'origin/main')
+ * @param {string} rootDir - Project root
+ * @returns {{
+ *   report: Array<{file: string, exportName: string, changeType: string, consumers: object[], untouchedConsumers: object[]}>,
+ *   warnings: string[],
+ *   changedFiles: string[],
+ * }}
+ */
+export function computeBlastRadius(mainRef, rootDir) {
+  const warnings = [];
+  const changedFiles = getChangedFiles(mainRef, rootDir);
+
+  const { modifiedExports, warnings: diffWarnings } = detectModifiedExports(mainRef, changedFiles, rootDir);
+  warnings.push(...diffWarnings);
+
+  const relevant = modifiedExports.filter((e) => e.changeType !== 'added');
+  if (relevant.length === 0) {
+    return { report: [], warnings, changedFiles };
+  }
+
+  const allFiles = discoverTrackedSourceFiles(rootDir);
+  const { index, warnings: indexWarnings } = buildConsumerIndex(allFiles, rootDir);
+  warnings.push(...indexWarnings);
+
+  const changedFilesSet = new Set(changedFiles);
+
+  const report = relevant.map(({ file, exportName, changeType }) => {
+    const definingFileAbs = path.resolve(rootDir, file).replace(/\\/g, '/');
+    const consumers = findConsumers(index, definingFileAbs, exportName).map((c) => ({
+      ...c,
+      touchedInDiff: changedFilesSet.has(c.file),
+    }));
+
+    return {
+      file,
+      exportName,
+      changeType,
+      consumers,
+      untouchedConsumers: consumers.filter((c) => !c.touchedInDiff),
+    };
+  });
+
+  return { report, warnings, changedFiles };
+}
+
+/**
+ * Render a human-readable report for CLI output.
+ * @param {Array} report - `report` array from computeBlastRadius
+ * @param {string} mainRef
+ * @param {string[]} changedFiles
+ * @returns {string}
+ */
+export function formatReport(report, mainRef, changedFiles) {
+  const lines = [];
+  lines.push(`Blast-radius analysis vs ${mainRef} (${changedFiles.length} file(s) changed)`);
+  lines.push('');
+
+  if (report.length === 0) {
+    lines.push('No modified or removed exported symbols detected. Nothing to review.');
+    return lines.join('\n');
+  }
+
+  for (const entry of report) {
+    lines.push(`${entry.file} :: ${entry.exportName} (${entry.changeType})`);
+    if (entry.consumers.length === 0) {
+      lines.push('  No consumers found in tracked source tree.');
+    } else {
+      lines.push(`  Consumed by ${entry.consumers.length} site(s):`);
+      for (const c of entry.consumers) {
+        const flag = c.touchedInDiff ? '' : '  <-- NOT touched in this diff, verify intended';
+        lines.push(`    - ${c.file}:${c.line} [${c.kind}]${flag}`);
+      }
+    }
+    lines.push('');
+  }
+
+  const totalUntouched = report.reduce((sum, e) => sum + e.untouchedConsumers.length, 0);
+  lines.push(totalUntouched > 0
+    ? `${totalUntouched} consumer(s) across ${report.length} changed symbol(s) were NOT touched in this diff — review before merging.`
+    : 'All consumers of modified/removed symbols were touched in this diff.');
+
+  return lines.join('\n');
+}

--- a/lib/static-analysis/consumer-index.js
+++ b/lib/static-analysis/consumer-index.js
@@ -12,9 +12,15 @@
 
 import fs from 'fs';
 import path from 'path';
-import traverse from '@babel/traverse';
+import traverseImport from '@babel/traverse';
 import { parseSource, MAX_ANALYZABLE_BYTES } from './ast-parse.js';
 import { resolveModulePath } from './module-resolver.js';
+
+// @babel/traverse's default export is wrapped differently under plain Node
+// ESM (traverseImport.default is the callable) vs. bundler/test-runner CJS
+// interop (traverseImport itself is already callable) -- same fallback used
+// by scripts/modules/handoff/validation/oiv/OIVVerifier.js.
+const traverse = traverseImport.default || traverseImport;
 
 /**
  * @typedef {Object} Consumer

--- a/lib/static-analysis/consumer-index.js
+++ b/lib/static-analysis/consumer-index.js
@@ -1,0 +1,125 @@
+/**
+ * Consumer Index — Blast-Radius Consumer Analysis (Phase 1)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Builds a REVERSE index (definingFile+exportName -> consumer sites) from a
+ * single forward AST pass over the repo's tracked source files. Extends the
+ * existing dependency-analyzer.js forward pass by also capturing WHICH named
+ * specifiers each import statement pulls in (that pass only recorded the
+ * module source, never the imported names) -- this is what makes reverse
+ * lookup possible without a second parse.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import traverse from '@babel/traverse';
+import { parseSource, MAX_ANALYZABLE_BYTES } from './ast-parse.js';
+import { resolveModulePath } from './module-resolver.js';
+
+/**
+ * @typedef {Object} Consumer
+ * @property {string} file - Consumer file, relative to rootDir (forward slashes)
+ * @property {number} line - 1-based source line of the import/require site
+ * @property {string} kind - 'named' | 'default' | 'namespace' | 'require' | 'side-effect'
+ */
+
+/**
+ * Build the reverse consumer index.
+ *
+ * @param {string[]} filePaths - Absolute paths of files to analyze
+ * @param {string} rootDir - Project root (for relative-path reporting)
+ * @returns {{ index: { named: Map<string, Map<string, Consumer[]>>, wholeModule: Map<string, Consumer[]> }, warnings: string[] }}
+ */
+export function buildConsumerIndex(filePaths, rootDir) {
+  const named = new Map();
+  const wholeModule = new Map();
+  const warnings = [];
+
+  const addNamed = (definingFile, exportName, consumer) => {
+    if (!named.has(definingFile)) named.set(definingFile, new Map());
+    const byName = named.get(definingFile);
+    if (!byName.has(exportName)) byName.set(exportName, []);
+    byName.get(exportName).push(consumer);
+  };
+
+  const addWhole = (definingFile, consumer) => {
+    if (!wholeModule.has(definingFile)) wholeModule.set(definingFile, []);
+    wholeModule.get(definingFile).push(consumer);
+  };
+
+  for (const filePath of filePaths) {
+    // Per-file isolation (TR-2): one malformed/oversized file must not abort
+    // the whole index build.
+    try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile()) continue;
+      if (stat.size > MAX_ANALYZABLE_BYTES) {
+        warnings.push(`Skipped ${filePath}: exceeds ${MAX_ANALYZABLE_BYTES}-byte analysis cap`);
+        continue;
+      }
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const ast = parseSource(content, filePath);
+      const relFile = path.relative(rootDir, filePath).replace(/\\/g, '/');
+
+      traverse(ast, {
+        ImportDeclaration(nodePath) {
+          const source = nodePath.node.source.value;
+          const definingFile = resolveModulePath(source, filePath, rootDir);
+          if (!definingFile) return; // external package or unresolved specifier
+          const line = nodePath.node.loc?.start?.line ?? 0;
+
+          for (const spec of nodePath.node.specifiers) {
+            if (spec.type === 'ImportSpecifier') {
+              addNamed(definingFile, spec.imported.name, { file: relFile, line, kind: 'named' });
+            } else if (spec.type === 'ImportDefaultSpecifier') {
+              addNamed(definingFile, 'default', { file: relFile, line, kind: 'default' });
+            } else if (spec.type === 'ImportNamespaceSpecifier') {
+              addWhole(definingFile, { file: relFile, line, kind: 'namespace' });
+            }
+          }
+
+          if (nodePath.node.specifiers.length === 0) {
+            addWhole(definingFile, { file: relFile, line, kind: 'side-effect' });
+          }
+        },
+        CallExpression(nodePath) {
+          if (
+            nodePath.node.callee.name === 'require' &&
+            nodePath.node.arguments.length > 0 &&
+            nodePath.node.arguments[0].type === 'StringLiteral'
+          ) {
+            const source = nodePath.node.arguments[0].value;
+            const definingFile = resolveModulePath(source, filePath, rootDir);
+            if (!definingFile) return;
+            const line = nodePath.node.loc?.start?.line ?? 0;
+            addWhole(definingFile, { file: relFile, line, kind: 'require' });
+          }
+        },
+      });
+    } catch (err) {
+      warnings.push(`Failed to analyze ${filePath}: ${err.message}`);
+    }
+  }
+
+  return { index: { named, wholeModule }, warnings };
+}
+
+/**
+ * Find all consumers of a given export from a given defining file.
+ *
+ * Includes whole-module consumers (namespace/require/side-effect imports)
+ * conservatively, since such a consumer MAY reference any export of the
+ * module and static analysis cannot rule it out without deeper (non-Phase-1)
+ * property-access tracing.
+ *
+ * @param {{named: Map, wholeModule: Map}} index - Index from buildConsumerIndex
+ * @param {string} definingFile - Absolute path (forward slashes) of the defining file
+ * @param {string} exportName - Exported symbol name (or 'default')
+ * @returns {Consumer[]}
+ */
+export function findConsumers(index, definingFile, exportName) {
+  const named = index.named.get(definingFile)?.get(exportName) || [];
+  const whole = index.wholeModule.get(definingFile) || [];
+  return [...named, ...whole];
+}

--- a/lib/static-analysis/module-resolver.js
+++ b/lib/static-analysis/module-resolver.js
@@ -9,9 +9,9 @@ import fs from 'fs';
 import path from 'path';
 
 /** Extensions to try when resolving bare specifiers */
-const EXTENSIONS = ['.js', '.mjs', '.cjs'];
+const EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.tsx'];
 /** Index files to try when resolving directory imports */
-const INDEX_FILES = ['index.js', 'index.mjs'];
+const INDEX_FILES = ['index.js', 'index.mjs', 'index.ts', 'index.tsx'];
 
 /**
  * Resolve a module specifier to an absolute file path.

--- a/lib/static-analysis/symbol-diff.js
+++ b/lib/static-analysis/symbol-diff.js
@@ -46,6 +46,10 @@ function getContentAtRef(ref, relPath, rootDir) {
       encoding: 'utf-8',
       timeout: 10000,
       maxBuffer: MAX_ANALYZABLE_BYTES,
+      // A new file not existing at `ref` is an EXPECTED, handled outcome (caught
+      // below), not a real error -- suppress git's own "fatal: path ... not in
+      // <ref>" stderr so it doesn't read as a crash in handoff/gate logs.
+      stdio: ['ignore', 'pipe', 'ignore'],
     });
     return normalizeLineEndings(content);
   } catch {

--- a/lib/static-analysis/symbol-diff.js
+++ b/lib/static-analysis/symbol-diff.js
@@ -12,10 +12,27 @@
 import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import traverse from '@babel/traverse';
+import traverseImport from '@babel/traverse';
 import { parseSource, MAX_ANALYZABLE_BYTES } from './ast-parse.js';
 
+// See consumer-index.js for why this fallback is required (@babel/traverse
+// ESM/CJS interop wrapping differs between plain Node and bundler/test runners).
+const traverse = traverseImport.default || traverseImport;
+
 const SOURCE_FILE_RE = /\.(js|mjs|cjs|jsx|ts|tsx)$/;
+
+/**
+ * `git show` reads straight from git's object store, which is always
+ * LF-normalized text (git internally stores LF regardless of autocrlf);
+ * `fs.readFileSync` reads the checked-out working-tree file, which on a
+ * Windows checkout with core.autocrlf=true has CRLF line endings. Comparing
+ * those two forms of the SAME logical content byte-for-byte would flag every
+ * multi-line export as "modified" on every Windows checkout, regardless of
+ * any real change. Normalize both sides to LF before span comparison.
+ */
+function normalizeLineEndings(content) {
+  return content === null ? null : content.replace(/\r\n/g, '\n');
+}
 
 /**
  * Read a file's content at a given git ref via argv-array execFileSync
@@ -24,12 +41,13 @@ const SOURCE_FILE_RE = /\.(js|mjs|cjs|jsx|ts|tsx)$/;
  */
 function getContentAtRef(ref, relPath, rootDir) {
   try {
-    return execFileSync('git', ['show', `${ref}:${relPath}`], {
+    const content = execFileSync('git', ['show', `${ref}:${relPath}`], {
       cwd: rootDir,
       encoding: 'utf-8',
       timeout: 10000,
       maxBuffer: MAX_ANALYZABLE_BYTES,
     });
+    return normalizeLineEndings(content);
   } catch {
     return null;
   }
@@ -39,7 +57,7 @@ function getWorkingTreeContent(absPath) {
   try {
     const stat = fs.statSync(absPath);
     if (stat.size > MAX_ANALYZABLE_BYTES) return { content: null, oversized: true };
-    return { content: fs.readFileSync(absPath, 'utf-8'), oversized: false };
+    return { content: normalizeLineEndings(fs.readFileSync(absPath, 'utf-8')), oversized: false };
   } catch {
     return { content: null, oversized: false }; // deleted file
   }

--- a/lib/static-analysis/symbol-diff.js
+++ b/lib/static-analysis/symbol-diff.js
@@ -1,0 +1,142 @@
+/**
+ * Symbol Diff — Blast-Radius Consumer Analysis (Phase 1)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Detects which EXPORTED symbols changed between a base ref and the current
+ * working tree, via AST-identified declaration boundaries rather than a
+ * whole-file line diff. Comparing only each export's own source-text span
+ * means an unrelated formatting change elsewhere in the file (e.g. a comment
+ * reformatted above a different function) never flags an untouched export.
+ */
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import traverse from '@babel/traverse';
+import { parseSource, MAX_ANALYZABLE_BYTES } from './ast-parse.js';
+
+const SOURCE_FILE_RE = /\.(js|mjs|cjs|jsx|ts|tsx)$/;
+
+/**
+ * Read a file's content at a given git ref via argv-array execFileSync
+ * (never shell-string interpolation, per SECURITY TR-1). Returns null when
+ * the path did not exist at that ref (new file) or git show otherwise fails.
+ */
+function getContentAtRef(ref, relPath, rootDir) {
+  try {
+    return execFileSync('git', ['show', `${ref}:${relPath}`], {
+      cwd: rootDir,
+      encoding: 'utf-8',
+      timeout: 10000,
+      maxBuffer: MAX_ANALYZABLE_BYTES,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function getWorkingTreeContent(absPath) {
+  try {
+    const stat = fs.statSync(absPath);
+    if (stat.size > MAX_ANALYZABLE_BYTES) return { content: null, oversized: true };
+    return { content: fs.readFileSync(absPath, 'utf-8'), oversized: false };
+  } catch {
+    return { content: null, oversized: false }; // deleted file
+  }
+}
+
+/**
+ * Extract each exported symbol's own source-text span, keyed by export name.
+ * @returns {Map<string, string>}
+ */
+function extractExportSpans(ast, source) {
+  const spans = new Map();
+
+  traverse(ast, {
+    ExportNamedDeclaration(nodePath) {
+      const node = nodePath.node;
+      if (node.declaration) {
+        const decl = node.declaration;
+        if (decl.declarations) {
+          // export const foo = ..., bar = ...
+          for (const d of decl.declarations) {
+            if (d.id?.name) spans.set(d.id.name, source.slice(d.start, d.end));
+          }
+        } else if (decl.id?.name) {
+          // export function foo() {} / export class Foo {}
+          spans.set(decl.id.name, source.slice(decl.start, decl.end));
+        }
+      } else if (node.specifiers?.length) {
+        // export { foo, bar as baz }
+        for (const spec of node.specifiers) {
+          spans.set(spec.exported.name, source.slice(spec.start, spec.end));
+        }
+      }
+    },
+    ExportDefaultDeclaration(nodePath) {
+      const decl = nodePath.node.declaration;
+      spans.set('default', source.slice(decl.start, decl.end));
+    },
+  });
+
+  return spans;
+}
+
+function safeExtractSpans(source, relPath, warnings) {
+  if (source === null) return new Map();
+  try {
+    return extractExportSpans(parseSource(source, relPath), source);
+  } catch (err) {
+    warnings.push(`Failed to parse ${relPath}: ${err.message}`);
+    return new Map();
+  }
+}
+
+/**
+ * Detect modified/removed/added exported symbols across a set of changed files.
+ *
+ * @param {string} mainRef - Base git ref (e.g. 'origin/main')
+ * @param {string[]} changedFiles - Repo-relative paths (forward slashes) of changed files
+ * @param {string} rootDir - Project root
+ * @returns {{ modifiedExports: Array<{file: string, exportName: string, changeType: 'modified'|'removed'|'added'}>, warnings: string[] }}
+ */
+export function detectModifiedExports(mainRef, changedFiles, rootDir) {
+  const results = [];
+  const warnings = [];
+
+  for (const relPath of changedFiles) {
+    if (!SOURCE_FILE_RE.test(relPath)) continue;
+
+    try {
+      const absPath = path.resolve(rootDir, relPath);
+      const beforeSource = getContentAtRef(mainRef, relPath, rootDir);
+      const { content: afterSource, oversized } = getWorkingTreeContent(absPath);
+
+      if (oversized) {
+        warnings.push(`Skipped ${relPath}: exceeds ${MAX_ANALYZABLE_BYTES}-byte analysis cap`);
+        continue;
+      }
+
+      const beforeSpans = safeExtractSpans(beforeSource, relPath, warnings);
+      const afterSpans = safeExtractSpans(afterSource, relPath, warnings);
+
+      const allNames = new Set([...beforeSpans.keys(), ...afterSpans.keys()]);
+      for (const name of allNames) {
+        const beforeText = beforeSpans.get(name);
+        const afterText = afterSpans.get(name);
+
+        if (beforeText !== undefined && afterText === undefined) {
+          results.push({ file: relPath, exportName: name, changeType: 'removed' });
+        } else if (beforeText === undefined && afterText !== undefined) {
+          results.push({ file: relPath, exportName: name, changeType: 'added' });
+        } else if (beforeText !== afterText) {
+          results.push({ file: relPath, exportName: name, changeType: 'modified' });
+        }
+      }
+    } catch (err) {
+      warnings.push(`Failed to diff ${relPath}: ${err.message}`);
+    }
+  }
+
+  return { modifiedExports: results, warnings };
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pattern:port-isol-persist": "node scripts/insert-pat-port-isol-001.mjs",
     "hook:rca-outcome": "node scripts/hooks/post-tool-rca-outcome.cjs",
     "audit:codeguardian-mock": "node scripts/audit/codeguardian-mock-disposition.mjs",
+    "blast-radius": "node scripts/blast-radius.js",
     "quality:aggregate": "node scripts/aggregate-quality-findings.js",
     "quality:aggregate:cron": "node scripts/cron/quality-findings-aggregator.mjs",
     "cascade:watch:cron": "node scripts/cron/cascade-watcher.mjs --once",

--- a/scripts/blast-radius.js
+++ b/scripts/blast-radius.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Blast-Radius CLI — first-party PR-review consumer-impact tool (Phase 1)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Given a diff, finds every cross-file consumer of modified/removed exported
+ * symbols and flags any consumer not touched in the same diff.
+ *
+ * Usage:
+ *   node scripts/blast-radius.js [--ref <gitRef>] [--json]
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { computeBlastRadius, formatReport } from '../lib/static-analysis/blast-radius.js';
+import { getMainRef } from './modules/handoff/shared-git-context.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const args = { json: false, ref: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--json') args.json = true;
+    else if (argv[i] === '--ref') args.ref = argv[++i];
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const mainRef = args.ref || getMainRef({ cwd: ROOT_DIR }).ref;
+
+  const { report, warnings, changedFiles } = computeBlastRadius(mainRef, ROOT_DIR);
+
+  if (args.json) {
+    console.log(JSON.stringify({ report, warnings, changedFiles, mainRef }, null, 2));
+  } else {
+    console.log(formatReport(report, mainRef, changedFiles));
+    if (warnings.length > 0) {
+      console.log('\nWarnings:');
+      for (const w of warnings) console.log(`  - ${w}`);
+    }
+  }
+
+  const hasUntouched = report.some((e) => e.untouchedConsumers.length > 0);
+  process.exitCode = hasUntouched ? 1 : 0;
+}
+
+main();

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/consumer-impact-gate.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/consumer-impact-gate.js
@@ -1,0 +1,104 @@
+/**
+ * CONSUMER_IMPACT_ADVISORY — Blast-radius consumer-impact check (Phase 1)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Given the diff for this handoff, finds every cross-file consumer of
+ * modified/removed exported symbols and warns when a consumer was NOT
+ * touched in the same diff -- surfacing likely-missed call sites during
+ * PR review. Advisory only (required:false, always returns passed:true):
+ * a false-positive here must never block a handoff. Mirrors the
+ * WIRE_CHECK_ADVISORY / WIRE_CHECK_GATE pairing pattern (freshness,
+ * venture opt-out, fail-open on tool errors).
+ *
+ * Phase: EXEC-TO-PLAN (advisory)
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { computeBlastRadius, formatReport } from '../../../../../../lib/static-analysis/blast-radius.js';
+import { getMainRef } from '../../../shared-git-context.js';
+import { isVentureRepo } from '../../../../../../lib/repo-paths.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '../../../../../../');
+
+const GATE_NAME = 'CONSUMER_IMPACT_ADVISORY';
+
+/**
+ * Create the advisory consumer-impact gate for EXEC-TO-PLAN.
+ *
+ * Always non-blocking: required:false (BaseExecutor will not block) and the
+ * validator always returns passed:true (double-safe, same convention as
+ * WIRE_CHECK_ADVISORY). Findings surface via console output + warnings[].
+ *
+ * @param {Object} _supabase - Supabase client (unused; kept for gate interface consistency)
+ * @returns {Object} Gate definition
+ */
+export function createConsumerImpactGate(_supabase) {
+  return {
+    name: GATE_NAME,
+    required: false, // ADVISORY — never blocks the handoff
+    validator: async (ctx) => {
+      console.log('\n🎯 GATE: Consumer Impact (ADVISORY — blast-radius of modified exports)');
+      console.log('-'.repeat(50));
+
+      const cleanPass = (warnings = []) => ({
+        passed: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings,
+      });
+
+      // Venture opt-out parity with WIRE_CHECK_ADVISORY: this repo's own
+      // lib/scripts/server scope isn't meaningful for a separate venture repo.
+      const sd = ctx?.sd || {};
+      if (isVentureRepo(sd.target_application) && sd?.metadata?.wiring_required !== true) {
+        console.log(`   ⏭️  Venture SD (target_application=${sd.target_application}) — consumer-impact check skipped.`);
+        return cleanPass();
+      }
+
+      const rootDir = ROOT_DIR;
+      const refResult = getMainRef({ cwd: rootDir });
+      const mainRef = refResult.ref;
+
+      let result;
+      try {
+        result = computeBlastRadius(mainRef, rootDir);
+      } catch (err) {
+        // ADVISORY: a tool failure must never block — surface it and pass.
+        const message = err?.message || String(err);
+        console.log(`   ⚠️  Could not compute blast radius vs ${mainRef}: ${message} (advisory — passing)`);
+        return cleanPass([`CONSUMER_IMPACT_ADVISORY could not compute blast radius vs ${mainRef}: ${message}`]);
+      }
+
+      const { report, warnings: analysisWarnings, changedFiles } = result;
+
+      if (report.length === 0) {
+        console.log('   No modified/removed exported symbols detected — nothing to advise.');
+        return cleanPass(analysisWarnings);
+      }
+
+      const totalUntouched = report.reduce((sum, e) => sum + e.untouchedConsumers.length, 0);
+      console.log(formatReport(report, mainRef, changedFiles));
+
+      if (totalUntouched === 0) {
+        console.log('   ✅ All consumers of modified/removed symbols were touched in this diff.');
+        return cleanPass(analysisWarnings);
+      }
+
+      const flaggedLines = report
+        .filter((e) => e.untouchedConsumers.length > 0)
+        .flatMap((e) => e.untouchedConsumers.map(
+          (c) => `  - ${e.file}::${e.exportName} (${e.changeType}) consumed by ${c.file}:${c.line} [${c.kind}], not touched in this diff`
+        ));
+
+      return cleanPass([
+        `${totalUntouched} consumer(s) of modified/removed exported symbols were NOT touched in this diff — review before merging:`,
+        ...flaggedLines,
+        ...analysisWarnings,
+      ]);
+    },
+  };
+}

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
@@ -43,6 +43,11 @@ export { createWiringValidationGate } from './wiring-validation.js';
 // new CLIs at EXEC-TO-PLAN so they are fixed before the blocking final gate.
 export { createWireCheckAdvisoryGate } from './wire-check-advisory.js';
 
+// Consumer Impact advisory (SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001)
+// Blast-radius of modified/removed exported symbols — flags consumers not
+// touched in the same diff. Advisory only, never blocks the handoff.
+export { createConsumerImpactGate } from './consumer-impact-gate.js';
+
 // UI Interactivity Check (SD-MAN-INFRA-LEO-GATE-IMPROVEMENTS-001)
 export { createUiInteractivityCheckGate } from './ui-interactivity-check.js';
 

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -37,6 +37,8 @@ import {
   createWiringValidationGate,
   // Advisory wire-reachability check (SD-FDBK-ENH-WIRE-CHECK-GATE-002)
   createWireCheckAdvisoryGate,
+  // Consumer Impact advisory (SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001)
+  createConsumerImpactGate,
   // UI Interactivity Check (SD-MAN-INFRA-LEO-GATE-IMPROVEMENTS-001)
   createUiInteractivityCheckGate
 } from './gates/index.js';
@@ -355,6 +357,11 @@ export class ExecToPlanExecutor extends BaseExecutor {
     // wiring it sees the gap here (and can fix it in the same PR) instead of being
     // blocked at the FINAL handoff and forced to open a 2nd PR.
     gates.push(createWireCheckAdvisoryGate(this.supabase));
+
+    // Consumer Impact advisory (SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001)
+    // Non-blocking (required:false): blast-radius of modified/removed exported
+    // symbols, flags any consumer not touched in the same diff for PR review.
+    gates.push(createConsumerImpactGate(this.supabase));
 
     // UI Interactivity Check (SD-MAN-INFRA-LEO-GATE-IMPROVEMENTS-001)
     // Blocks display-only EHG frontend components — must have onClick/onSubmit

--- a/tests/unit/gates/consumer-impact-gate.test.js
+++ b/tests/unit/gates/consumer-impact-gate.test.js
@@ -1,0 +1,87 @@
+/**
+ * CONSUMER_IMPACT_ADVISORY — Unit Tests (TS-6)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Mirrors tests/unit/gates/wire-check-advisory.test.js: pins the advisory
+ * contract (never blocks handoffs, required:false) and runs the gate against
+ * the live repo since ROOT_DIR is resolved from the module's own location,
+ * matching the established convention for this gate family.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const GATE_FILE = path.resolve(
+  __dirname,
+  '../../../scripts/modules/handoff/executors/exec-to-plan/gates/consumer-impact-gate.js'
+);
+const GATE_INDEX_FILE = path.resolve(
+  __dirname,
+  '../../../scripts/modules/handoff/executors/exec-to-plan/gates/index.js'
+);
+const EXEC_TO_PLAN_INDEX_FILE = path.resolve(
+  __dirname,
+  '../../../scripts/modules/handoff/executors/exec-to-plan/index.js'
+);
+
+describe('consumer-impact-gate (CONSUMER_IMPACT_ADVISORY, TS-6)', () => {
+  let createConsumerImpactGate;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mod = await import(
+      '../../../scripts/modules/handoff/executors/exec-to-plan/gates/consumer-impact-gate.js'
+    );
+    createConsumerImpactGate = mod.createConsumerImpactGate;
+  });
+
+  it('has the correct name, is NOT required (advisory), and exposes a validator fn', () => {
+    const gate = createConsumerImpactGate(null);
+    expect(gate.name).toBe('CONSUMER_IMPACT_ADVISORY');
+    expect(gate.required).toBe(false);
+    expect(typeof gate.validator).toBe('function');
+  });
+
+  it('always returns passed:true with a valid gate shape (never blocks)', async () => {
+    const gate = createConsumerImpactGate(null);
+    const result = await gate.validator({ sd: { id: 'test', target_application: 'EHG_Engineer' } });
+
+    expect(result).toHaveProperty('passed', true);
+    expect(typeof result.score).toBe('number');
+    expect(Array.isArray(result.issues)).toBe(true);
+    expect(Array.isArray(result.warnings)).toBe(true);
+    expect(result.issues).toEqual([]);
+  }, 30000);
+
+  it('returns passed:true even when ctx has no sd', async () => {
+    const gate = createConsumerImpactGate(null);
+    const result = await gate.validator({});
+    expect(result.passed).toBe(true);
+    expect(result.issues).toEqual([]);
+  }, 30000);
+
+  it('skips analysis for venture-targeted SDs unless wiring_required is set (source pin)', () => {
+    const source = fs.readFileSync(GATE_FILE, 'utf8');
+    expect(source).toMatch(/isVentureRepo/);
+    expect(source).toMatch(/wiring_required/);
+  });
+
+  it('declares required:false so BaseExecutor never blocks on it (source pin)', () => {
+    const source = fs.readFileSync(GATE_FILE, 'utf8');
+    expect(source).toMatch(/required:\s*false/);
+  });
+
+  it('is registered in gates/index.js and exec-to-plan/index.js (wiring pin)', () => {
+    const indexSource = fs.readFileSync(GATE_INDEX_FILE, 'utf8');
+    expect(indexSource).toMatch(/export\s*\{\s*createConsumerImpactGate\s*\}\s*from\s*['"]\.\/consumer-impact-gate\.js['"]/);
+
+    const execToPlanSource = fs.readFileSync(EXEC_TO_PLAN_INDEX_FILE, 'utf8');
+    expect(execToPlanSource).toMatch(/createConsumerImpactGate/);
+    expect(execToPlanSource).toMatch(/gates\.push\(createConsumerImpactGate\(/);
+  });
+});

--- a/tests/unit/gates/wire-check-gate.test.js
+++ b/tests/unit/gates/wire-check-gate.test.js
@@ -67,6 +67,22 @@ describe('module-resolver', () => {
     const result = resolveModulePath('acorn', fromFile, tmpDir);
     expect(result).toBeNull();
   });
+
+  // SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001 (FR-5): .ts/.tsx resolution
+  it('should resolve .ts extension', () => {
+    fs.writeFileSync(path.join(tmpDir, 'baz.ts'), 'export default 4;');
+    const fromFile = path.join(tmpDir, 'entry.js');
+    const result = resolveModulePath('./baz', fromFile, tmpDir);
+    expect(result).toBe(path.join(tmpDir, 'baz.ts').replace(/\\/g, '/'));
+  });
+
+  it('should resolve directory with index.ts', () => {
+    fs.mkdirSync(path.join(tmpDir, 'sub-ts'));
+    fs.writeFileSync(path.join(tmpDir, 'sub-ts', 'index.ts'), 'export default 5;');
+    const fromFile = path.join(tmpDir, 'entry.js');
+    const result = resolveModulePath('./sub-ts', fromFile, tmpDir);
+    expect(result).toBe(path.join(tmpDir, 'sub-ts', 'index.ts').replace(/\\/g, '/'));
+  });
 });
 
 // ─── Call Graph Builder ──────────────────────────────────────────────

--- a/tests/unit/static-analysis/blast-radius.test.js
+++ b/tests/unit/static-analysis/blast-radius.test.js
@@ -1,0 +1,108 @@
+/**
+ * Blast Radius — Unit Tests
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001 (TS-3)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { computeBlastRadius, formatReport } from '../../../lib/static-analysis/blast-radius.js';
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+function initRepo(tmpDir) {
+  git(['init', '-q'], tmpDir);
+  git(['config', 'user.email', 'test@example.com'], tmpDir);
+  git(['config', 'user.name', 'Test'], tmpDir);
+}
+
+describe('blast-radius', () => {
+  let tmpDir;
+  let libDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'blast-radius-test-'));
+    initRepo(tmpDir);
+    // discoverTrackedSourceFiles is scoped to lib/, scripts/, server/ (this repo's convention).
+    libDir = path.join(tmpDir, 'lib');
+    fs.mkdirSync(libDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('flags a consumer not touched in the same diff, distinct from one that was updated (TS-3)', () => {
+    fs.writeFileSync(path.join(libDir, 'lib-a.js'), 'export function doThing() { return 1; }\n');
+    fs.writeFileSync(path.join(libDir, 'consumer1.js'), "import { doThing } from './lib-a.js';\ndoThing();\n");
+    fs.writeFileSync(path.join(libDir, 'consumer2.js'), "import { doThing } from './lib-a.js';\ndoThing();\n");
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    // Change doThing's behavior. Update consumer1 in the same diff; leave consumer2 untouched.
+    fs.writeFileSync(path.join(libDir, 'lib-a.js'), 'export function doThing() { return 2; }\n');
+    fs.writeFileSync(path.join(libDir, 'consumer1.js'), "import { doThing } from './lib-a.js';\ndoThing(); // updated for new behavior\n");
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'change doThing'], tmpDir);
+
+    const { report, warnings, changedFiles } = computeBlastRadius(baseRef, tmpDir);
+    expect(warnings).toEqual([]);
+    expect(changedFiles.sort()).toEqual(['lib/consumer1.js', 'lib/lib-a.js']);
+
+    expect(report).toHaveLength(1);
+    const entry = report[0];
+    expect(entry.file).toBe('lib/lib-a.js');
+    expect(entry.exportName).toBe('doThing');
+    expect(entry.changeType).toBe('modified');
+
+    const consumerFiles = entry.consumers.map((c) => c.file).sort();
+    expect(consumerFiles).toEqual(['lib/consumer1.js', 'lib/consumer2.js']);
+
+    expect(entry.untouchedConsumers).toHaveLength(1);
+    expect(entry.untouchedConsumers[0].file).toBe('lib/consumer2.js');
+
+    const rendered = formatReport(report, baseRef, changedFiles);
+    expect(rendered).toContain('lib/consumer2.js');
+    expect(rendered).toContain('NOT touched in this diff');
+  });
+
+  it('returns an empty report when no exported symbols changed', () => {
+    fs.writeFileSync(path.join(libDir, 'lib-a.js'), 'export function doThing() { return 1; }\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    // Non-export-affecting change: add an internal (non-exported) helper.
+    fs.writeFileSync(
+      path.join(libDir, 'lib-a.js'),
+      'function helper() { return 0; }\nexport function doThing() { return 1; }\n'
+    );
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'internal change'], tmpDir);
+
+    const { report } = computeBlastRadius(baseRef, tmpDir);
+    expect(report).toEqual([]);
+  });
+
+  it('flags removed-export consumers as blast radius too', () => {
+    fs.writeFileSync(path.join(libDir, 'lib-a.js'), 'export function doThing() { return 1; }\n');
+    fs.writeFileSync(path.join(libDir, 'consumer1.js'), "import { doThing } from './lib-a.js';\ndoThing();\n");
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    fs.writeFileSync(path.join(libDir, 'lib-a.js'), '// doThing removed\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'remove doThing'], tmpDir);
+
+    const { report } = computeBlastRadius(baseRef, tmpDir);
+    expect(report).toHaveLength(1);
+    expect(report[0].changeType).toBe('removed');
+    expect(report[0].untouchedConsumers.map((c) => c.file)).toEqual(['lib/consumer1.js']);
+  });
+});

--- a/tests/unit/static-analysis/consumer-index.test.js
+++ b/tests/unit/static-analysis/consumer-index.test.js
@@ -1,0 +1,111 @@
+/**
+ * Consumer Index — Unit Tests
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001 (TS-1, TS-4)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { buildConsumerIndex, findConsumers } from '../../../lib/static-analysis/consumer-index.js';
+
+describe('consumer-index', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'consumer-index-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function write(relPath, content) {
+    const abs = path.join(tmpDir, relPath);
+    fs.writeFileSync(abs, content);
+    return abs;
+  }
+
+  it('resolves named-import consumers across a multi-file fixture (TS-1)', () => {
+    const libA = write('lib-a.js', [
+      'export function foo() { return 1; }',
+      'export const bar = 2;',
+      'export default function baz() { return 3; }',
+    ].join('\n'));
+    const consumerNamed = write('consumer-named.js', "import { foo } from './lib-a.js';\nfoo();\n");
+    const consumerNamespace = write('consumer-namespace.js', "import * as A from './lib-a.js';\nA.bar;\n");
+    const consumerRequire = write('consumer-require.js', "const libA = require('./lib-a.js');\n");
+    write('consumer-unrelated.js', "import { unrelated } from './other.js';\n");
+
+    const filePaths = [libA, consumerNamed, consumerNamespace, consumerRequire,
+      path.join(tmpDir, 'consumer-unrelated.js')];
+    const { index, warnings } = buildConsumerIndex(filePaths, tmpDir);
+    expect(warnings).toEqual([]);
+
+    const libAAbs = libA.replace(/\\/g, '/');
+    const fooConsumers = findConsumers(index, libAAbs, 'foo');
+    const fooFiles = fooConsumers.map((c) => c.file);
+
+    expect(fooFiles).toContain('consumer-named.js');
+    // Whole-module (namespace/require) consumers are conservatively included
+    // for every export of the module, since they could reference anything.
+    expect(fooFiles).toContain('consumer-namespace.js');
+    expect(fooFiles).toContain('consumer-require.js');
+    expect(fooFiles).not.toContain('consumer-unrelated.js');
+
+    const namedConsumer = fooConsumers.find((c) => c.file === 'consumer-named.js');
+    expect(namedConsumer.kind).toBe('named');
+    expect(namedConsumer.line).toBe(1);
+  });
+
+  it('captures namespace/import-star/require consumers in the whole-module bucket', () => {
+    const libA = write('lib-a.js', 'export const x = 1;\n');
+    write('ns.js', "import * as A from './lib-a.js';\n");
+    write('req.js', "require('./lib-a.js');\n");
+
+    const filePaths = [libA, path.join(tmpDir, 'ns.js'), path.join(tmpDir, 'req.js')];
+    const { index } = buildConsumerIndex(filePaths, tmpDir);
+    const libAAbs = libA.replace(/\\/g, '/');
+
+    const wholeModuleConsumers = index.wholeModule.get(libAAbs) || [];
+    const kinds = wholeModuleConsumers.map((c) => c.kind).sort();
+    expect(kinds).toEqual(['namespace', 'require']);
+  });
+
+  it('does not resolve external/bare package specifiers into the index', () => {
+    const consumer = write('consumer.js', "import { readFile } from 'fs/promises';\n");
+    const { index, warnings } = buildConsumerIndex([consumer], tmpDir);
+    expect(warnings).toEqual([]);
+    expect(index.named.size).toBe(0);
+    expect(index.wholeModule.size).toBe(0);
+  });
+
+  it('skips an oversized file and still indexes the others (TS-4)', () => {
+    const libA = write('lib-a.js', 'export const x = 1;\n');
+    const oversized = path.join(tmpDir, 'huge.js');
+    // 2MB cap + 1 byte over
+    fs.writeFileSync(oversized, `// ${'a'.repeat(2 * 1024 * 1024 + 1)}\n`);
+    const consumer = write('consumer.js', "import { x } from './lib-a.js';\n");
+
+    const { index, warnings } = buildConsumerIndex([libA, oversized, consumer], tmpDir);
+
+    expect(warnings.some((w) => w.includes('huge.js') && w.includes('cap'))).toBe(true);
+    const libAAbs = libA.replace(/\\/g, '/');
+    expect(findConsumers(index, libAAbs, 'x').map((c) => c.file)).toContain('consumer.js');
+  });
+
+  it('isolates a malformed file with a syntax error and continues indexing others', () => {
+    const libA = write('lib-a.js', 'export const x = 1;\n');
+    write('broken.js', 'export const = = = syntax error {{{');
+    const consumer = write('consumer.js', "import { x } from './lib-a.js';\n");
+
+    const { index, warnings } = buildConsumerIndex(
+      [libA, path.join(tmpDir, 'broken.js'), consumer],
+      tmpDir
+    );
+
+    expect(warnings.some((w) => w.includes('broken.js'))).toBe(true);
+    const libAAbs = libA.replace(/\\/g, '/');
+    expect(findConsumers(index, libAAbs, 'x').map((c) => c.file)).toContain('consumer.js');
+  });
+});

--- a/tests/unit/static-analysis/security-hardening.test.js
+++ b/tests/unit/static-analysis/security-hardening.test.js
@@ -1,0 +1,57 @@
+/**
+ * Security Hardening — Static Checks (TS-5)
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001
+ *
+ * Per SECURITY sub-agent finding (agentId a997e58734a1fe858, TR-1): all git
+ * subprocess calls in this SD's new modules must use execFile/spawn with an
+ * argv array, never shell-string interpolation. This test statically greps
+ * the source of the new modules so a future edit that reintroduces execSync
+ * or a shell:true call fails CI instead of being silently merged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const NEW_MODULE_PATHS = [
+  'lib/static-analysis/consumer-index.js',
+  'lib/static-analysis/symbol-diff.js',
+  'lib/static-analysis/blast-radius.js',
+  'lib/static-analysis/ast-parse.js',
+  'scripts/blast-radius.js',
+];
+
+const ROOT_DIR = path.resolve(__dirname, '../../../');
+
+describe('security-hardening: blast-radius modules use argv-array subprocess calls', () => {
+  for (const relPath of NEW_MODULE_PATHS) {
+    it(`${relPath} never uses execSync or shell:true`, () => {
+      const source = fs.readFileSync(path.join(ROOT_DIR, relPath), 'utf-8');
+      expect(source).not.toMatch(/\bexecSync\s*\(/);
+      expect(source).not.toMatch(/shell\s*:\s*true/);
+    });
+  }
+
+  it('every git invocation uses execFileSync with an argv array (not a shell string)', () => {
+    const gitInvokingFiles = [
+      'lib/static-analysis/symbol-diff.js',
+      'lib/static-analysis/blast-radius.js',
+    ];
+    for (const relPath of gitInvokingFiles) {
+      const source = fs.readFileSync(path.join(ROOT_DIR, relPath), 'utf-8');
+      const gitCalls = source.match(/execFileSync\(\s*'git'\s*,\s*\[/g) || [];
+      expect(gitCalls.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('none of the new modules require/import a repo config file (babel.config, tsconfig, eslint) or call eval', () => {
+    // Matches actual LOAD call sites, not prose (e.g. a comment explaining why
+    // config auto-load is deliberately avoided must not self-trip this check).
+    const loadPattern = /(require|import)\s*\(\s*[^)]*(babel\.config|tsconfig|\.eslintrc)[^)]*\)/;
+    for (const relPath of NEW_MODULE_PATHS) {
+      const source = fs.readFileSync(path.join(ROOT_DIR, relPath), 'utf-8');
+      expect(source).not.toMatch(loadPattern);
+      expect(source).not.toMatch(/\beval\s*\(/);
+    }
+  });
+});

--- a/tests/unit/static-analysis/symbol-diff.test.js
+++ b/tests/unit/static-analysis/symbol-diff.test.js
@@ -117,6 +117,27 @@ describe('symbol-diff', () => {
     expect(modifiedExports).toEqual([{ file: 'brand-new.js', exportName: 'created', changeType: 'added' }]);
   });
 
+  it('does not flag a export as modified when only line-ending style differs (CRLF working tree vs LF git-show)', () => {
+    // git show reads LF-normalized content straight from the object store;
+    // a real Windows checkout (core.autocrlf=true) writes CRLF to the working
+    // tree. Reproduce that mismatch directly without depending on this test
+    // runner's own autocrlf setting.
+    const filePath = path.join(tmpDir, 'a.js');
+    const lfContent = 'export function foo() {\n  return 1;\n}\n';
+    fs.writeFileSync(filePath, lfContent);
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    // Same logical content, CRLF line endings — simulates a checked-out
+    // working tree on Windows with autocrlf=true.
+    fs.writeFileSync(filePath, lfContent.replace(/\n/g, '\r\n'));
+
+    const { modifiedExports, warnings } = detectModifiedExports(baseRef, ['a.js'], tmpDir);
+    expect(warnings).toEqual([]);
+    expect(modifiedExports).toEqual([]);
+  });
+
   it('skips an oversized working-tree file without throwing (TS-4)', () => {
     const filePath = path.join(tmpDir, 'a.js');
     fs.writeFileSync(filePath, 'export function foo() { return 1; }\n');

--- a/tests/unit/static-analysis/symbol-diff.test.js
+++ b/tests/unit/static-analysis/symbol-diff.test.js
@@ -1,0 +1,134 @@
+/**
+ * Symbol Diff — Unit Tests
+ * SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001 (TS-2, TS-4)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { detectModifiedExports } from '../../../lib/static-analysis/symbol-diff.js';
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+function initRepo(tmpDir) {
+  git(['init', '-q'], tmpDir);
+  git(['config', 'user.email', 'test@example.com'], tmpDir);
+  git(['config', 'user.name', 'Test'], tmpDir);
+}
+
+describe('symbol-diff', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'symbol-diff-test-'));
+    initRepo(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('identifies a changed export via AST comparison, ignoring unrelated formatting elsewhere (TS-2)', () => {
+    const filePath = path.join(tmpDir, 'a.js');
+    fs.writeFileSync(filePath, [
+      'export function foo() {',
+      '  return 1;',
+      '}',
+      '',
+      '// a comment above bar',
+      'export function bar() {',
+      '  return 2;',
+      '}',
+    ].join('\n'));
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    // Modify foo's body AND reformat the comment above bar (unrelated to bar's own span).
+    fs.writeFileSync(filePath, [
+      'export function foo() {',
+      '  return 100;',
+      '}',
+      '',
+      '// a COMPLETELY REWORDED comment above bar',
+      'export function bar() {',
+      '  return 2;',
+      '}',
+    ].join('\n'));
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'change'], tmpDir);
+
+    const { modifiedExports, warnings } = detectModifiedExports(baseRef, ['a.js'], tmpDir);
+    expect(warnings).toEqual([]);
+
+    const names = modifiedExports.map((e) => `${e.exportName}:${e.changeType}`);
+    expect(names).toContain('foo:modified');
+    expect(names).not.toContain('bar:modified');
+  });
+
+  it('flags a removed export as changeType removed', () => {
+    const filePath = path.join(tmpDir, 'a.js');
+    fs.writeFileSync(filePath, 'export function foo() { return 1; }\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    fs.writeFileSync(filePath, '// foo removed\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'remove foo'], tmpDir);
+
+    const { modifiedExports } = detectModifiedExports(baseRef, ['a.js'], tmpDir);
+    expect(modifiedExports).toEqual([{ file: 'a.js', exportName: 'foo', changeType: 'removed' }]);
+  });
+
+  it('flags a brand-new export as changeType added, not modified', () => {
+    const filePath = path.join(tmpDir, 'a.js');
+    fs.writeFileSync(filePath, 'export function foo() { return 1; }\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    fs.writeFileSync(filePath, 'export function foo() { return 1; }\nexport function newFn() { return 2; }\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'add newFn'], tmpDir);
+
+    const { modifiedExports } = detectModifiedExports(baseRef, ['a.js'], tmpDir);
+    expect(modifiedExports).toEqual([{ file: 'a.js', exportName: 'newFn', changeType: 'added' }]);
+  });
+
+  it('treats a brand-new file as all-added exports (no prior version to diff against)', () => {
+    const filePath = path.join(tmpDir, 'empty.js');
+    fs.writeFileSync(filePath, '// nothing yet\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    const newFilePath = path.join(tmpDir, 'brand-new.js');
+    fs.writeFileSync(newFilePath, 'export function created() { return 1; }\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'new file'], tmpDir);
+
+    const { modifiedExports, warnings } = detectModifiedExports(baseRef, ['brand-new.js'], tmpDir);
+    expect(warnings).toEqual([]);
+    expect(modifiedExports).toEqual([{ file: 'brand-new.js', exportName: 'created', changeType: 'added' }]);
+  });
+
+  it('skips an oversized working-tree file without throwing (TS-4)', () => {
+    const filePath = path.join(tmpDir, 'a.js');
+    fs.writeFileSync(filePath, 'export function foo() { return 1; }\n');
+    git(['add', '.'], tmpDir);
+    git(['commit', '-q', '-m', 'base'], tmpDir);
+    const baseRef = git(['rev-parse', 'HEAD'], tmpDir).trim();
+
+    fs.writeFileSync(filePath, `// ${'a'.repeat(2 * 1024 * 1024 + 1)}\nexport function foo() { return 1; }\n`);
+
+    expect(() => {
+      const { warnings } = detectModifiedExports(baseRef, ['a.js'], tmpDir);
+      expect(warnings.some((w) => w.includes('a.js') && w.includes('cap'))).toBe(true);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
First-party (no third-party pre-built binary) codebase structural-analysis tool for the LEO harness. Phase 1 scope: given a PR diff, find all cross-file consumers of modified/removed exported symbols and flag any not touched in the same diff.

- `lib/static-analysis/consumer-index.js` — reverse (symbol → consumer) index built from a single AST pass, extending the existing forward-edge pass with named-import-specifier capture
- `lib/static-analysis/symbol-diff.js` — git-show-based before/after export-span comparison (AST boundaries, not line-diff), with CRLF/LF normalization
- `lib/static-analysis/blast-radius.js` — combines both into the PR-review report, fresh every invocation (no persistent cache)
- `lib/static-analysis/module-resolver.js` — extended to resolve `.ts`/`.tsx`
- `scripts/blast-radius.js` — CLI entry point (`npm run blast-radius`)
- `scripts/modules/handoff/executors/exec-to-plan/gates/consumer-impact-gate.js` — new advisory (`required:false`) `CONSUMER_IMPACT_ADVISORY` gate wired into EXEC-TO-PLAN, mirroring `WIRE_CHECK_ADVISORY`'s pattern

Security hardening (SECURITY sub-agent, PLAN + EXEC-TO-PLAN review, PASS 95%): all git subprocess calls use `execFileSync` with argv arrays (never shell-string interpolation), per-file size caps + isolated try/catch (DoS hardening), hardcoded parser config (never auto-loads the repo's babel/tsconfig/eslint config). Zero new npm dependencies.

Two real bugs were found and fixed via live dogfooding (running the CLI directly against this repo, not just the Vitest-transformed unit tests): a `@babel/traverse` ESM/CJS-interop mismatch, and a CRLF/LF false-positive (`git show` returns LF-normalized content; a Windows checkout with `core.autocrlf=true` has CRLF in the working tree — every multi-line export would have shown as spuriously "modified"). Both have regression tests.

Note on size: production diff is ~525 LOC across 4 tightly-coupled new modules + a CLI + a gate — over the 400 LOC PR-size exception ceiling. Justification: this is a single cohesive subsystem (DESIGN sub-agent explicitly recommended against further decomposition — an "integration-only-at-end" anti-pattern for a pipeline this size); splitting further would fragment code that only makes sense reviewed together. ~450 lines of test coverage accompany it.

## Sub-agent evidence
- LEAD-TO-PLAN: PASS 96% | PLAN-TO-EXEC: PASS 97% (DESIGN/DEPENDENCY/SECURITY all PASS with concrete architecture)
- EXEC-TO-PLAN: PASS 93% (TESTING 88%, SECURITY 95%)
- PLAN-TO-LEAD: PASS 97% (VALIDATION 96%, REGRESSION 95%, retrospective quality 100)

## Test plan
- [x] `npx vitest run --project unit tests/unit/static-analysis/ tests/unit/gates/` — 27+6 new tests passing, 0 regressions across 93 files / 974 tests in gates+static-analysis+handoff suites
- [x] Live dogfood: `node scripts/blast-radius.js` run directly against this repo on win32 — correct output, no crash, no false positives
- [x] `security-hardening.test.js` statically pins the execFileSync/argv-array requirement as a CI regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)