### PR TITLE
feat(SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E): FR-6 backlog-gated downward claims

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -218,7 +218,18 @@ async function stampEffortRecommendation(supabase, row, logger = console) {
  * the TARGET worker's tier_rank (claude_sessions.metadata.tier_rank) is REFUSED (throws, fail-CLOSED,
  * code DISPATCH_ABOVE_WORKER_TIER). A higher-rung worker assigned below its rung is allowed. Gated by
  * the FR-5 degrade-to-1 invariant — with < 2 live workers, tiering is OFF and nothing is refused.
- * Fail-OPEN on any lookup/QF/sentinel-target case so a transient fault never blocks a real dispatch.
+ *
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): this is the SECOND independent tier-enforcement
+ * site (the self-claim/pull path is lib/fleet/claim-eligibility.cjs classifyDispatchIneligibility) —
+ * risk-agent flagged that shipping the backlog-reservation gate only in the self-claim path would let
+ * a worker correctly reserved-and-idle there still receive a directed WORK_ASSIGNMENT for the SAME
+ * lower-tier work. So a downward assignment (minRank < workerRank) is ALSO refused (fail-CLOSED, code
+ * DISPATCH_RESERVED_NO_LOWER_BACKLOG) unless that lower tier is genuinely backlogged. Uses the SAME
+ * fetchLowerTierBacklogData/lowerTierBacklog helpers as the self-claim path (never a second
+ * re-derivation) — an assignment AT the worker's own rung is always allowed, unaffected.
+ *
+ * Fail-OPEN on any lookup/QF/sentinel-target/backlog-data-fetch fault so a transient fault never
+ * blocks a real dispatch; fail-CLOSED only once a violation is CONFIRMED against live data.
  * @private
  */
 async function assertWorkerTierAllowed(supabase, row, logger = console) {
@@ -251,8 +262,23 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
       e.code = 'DISPATCH_ABOVE_WORKER_TIER';
       throw e;
     }
+    if (minRank < workerRank) {
+      const { lowerTierBacklog, fetchLowerTierBacklogData } = require('../fleet/tier-backlog.cjs');
+      const backlogData = await fetchLowerTierBacklogData(supabase);
+      // No backlog data -> fail-open (byte-identical WORK-DOWN-ALWAYS); backlog data present but
+      // lowerTierBacklog returns false -> CONFIRMED reserved, refuse.
+      if (backlogData && !lowerTierBacklog(minRank, backlogData)) {
+        const e = new Error(
+          `[dispatch] REFUSED WORK_ASSIGNMENT: ${sdKey} (tier_rank ${minRank}) has no backlog at/below that `
+          + `tier — target worker (tier_rank ${workerRank}) would be reserving capability on ungenuine cheap `
+          + `work; assign it to an at-or-below-rung worker instead, or wait for a genuine backlog.`
+        );
+        e.code = 'DISPATCH_RESERVED_NO_LOWER_BACKLOG';
+        throw e;
+      }
+    }
   } catch (e) {
-    if (e && e.code === 'DISPATCH_ABOVE_WORKER_TIER') throw e; // fail CLOSED on a confirmed above-tier
+    if (e && (e.code === 'DISPATCH_ABOVE_WORKER_TIER' || e.code === 'DISPATCH_RESERVED_NO_LOWER_BACKLOG')) throw e; // fail CLOSED on a confirmed violation
     logger && logger.warn && logger.warn(`[dispatch] worker-tier check skipped (fail-open): ${e.message}`);
   }
 }

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -32,6 +32,10 @@ const TEST_FIXTURE_KEY_RE = /^SD-(DEMO|TEST)\b/;
 // preconditions), composed here so the same gate that excludes orchestrator parents / fixtures /
 // human-action SDs also excludes work that is unfit for the CURRENT checkout. Fail-open by design.
 const { isSdExecutableHere } = require('./sd-executable-here.cjs');
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): pure, synchronous backlog comparator for the
+// downward-claim reservation branch below. lowerTierBacklog does NOT touch the DB itself — the
+// caller precomputes ctx.lower_tier_backlog_data once per tick (see tier-backlog.cjs docstring).
+const { lowerTierBacklog } = require('./tier-backlog.cjs');
 
 /**
  * PURE, synchronous, DB-free dispatch-ineligibility classifier for the non-dependency axes.
@@ -51,8 +55,8 @@ const { isSdExecutableHere } = require('./sd-executable-here.cjs');
  * BYTE-IDENTICAL when ctx omits the new fields (existing callers pass only {cwd}).
  *
  * @param {{ sd_key?: string, sd_type?: string, metadata?: object, target_application?: string, status?: string }} sdRow
- * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean }} [ctx]  when present, applies the claim-time fitness + tier axes
- * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'co_author_pending' | 'test_clone_build_tree' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
+ * @param {{ cwd?: string, currentApp?: string, worker_tier_rank?: number, tiering_active?: boolean, lower_tier_backlog_data?: object }} [ctx]  when present, applies the claim-time fitness + tier axes
+ * @returns {null | 'orchestrator_parent' | 'test_fixture_key' | 'human_action_required' | 'co_author_pending' | 'test_clone_build_tree' | 'sd_deferred' | 'sd_terminal' | 'above_worker_tier' | 'reserved_no_lower_backlog' | 'unfit_repo_mismatch' | 'unfit_premise_closed' | 'unfit_missing_precondition'}
  */
 function classifyDispatchIneligibility(sdRow, ctx) {
   const row = sdRow || {};
@@ -97,8 +101,19 @@ function classifyDispatchIneligibility(sdRow, ctx) {
   // work (no block when worker_tier_rank >= min_tier_rank). Unscored SDs (no min_tier_rank) fall
   // through unchanged. ctx-gated => byte-identical for callers that omit the tier fields.
   if (ctx && ctx.tiering_active === true && Number.isFinite(Number(ctx.worker_tier_rank))) {
+    const workerRank = Number(ctx.worker_tier_rank);
     const minRank = Number(row.metadata && row.metadata.min_tier_rank);
-    if (Number.isFinite(minRank) && minRank > Number(ctx.worker_tier_rank)) return 'above_worker_tier';
+    if (Number.isFinite(minRank) && minRank > workerRank) return 'above_worker_tier';
+    // FR-6 WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED: a worker claims AT its own rung
+    // unconditionally (minRank === workerRank falls through unchanged); claiming a STRICTLY
+    // LOWER rung is gated on that lower tier having a genuine backlog, reserving capability
+    // otherwise. ctx.lower_tier_backlog_data is OPTIONAL and precomputed by the caller once per
+    // tick (lowerTierBacklog's inputs are DB-dependent, so they cannot be computed inside this
+    // pure/sync classifier) — omitted => byte-identical pre-FR-6 WORK-DOWN-ALWAYS behavior for
+    // any caller that has not wired it yet.
+    if (Number.isFinite(minRank) && minRank < workerRank && ctx.lower_tier_backlog_data) {
+      if (!lowerTierBacklog(minRank, ctx.lower_tier_backlog_data)) return 'reserved_no_lower_backlog';
+    }
   }
   if (ctx) {
     try {

--- a/lib/fleet/tier-backlog.cjs
+++ b/lib/fleet/tier-backlog.cjs
@@ -1,0 +1,132 @@
+'use strict';
+/**
+ * Backlog-gated downward-claim helpers (SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E, FR-6).
+ *
+ * Chairman directive: classifyDispatchIneligibility's tier axis was WORK-DOWN-ALWAYS (a worker
+ * at tier R could freely claim any SD at or below R). This module implements
+ * WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED: a worker still claims AT its own tier freely, but
+ * claiming a STRICTLY LOWER tier's work is gated on that lower tier having a genuine backlog
+ * (unclaimed claimable work reachable at/below it exceeds the idle capacity of workers at/below
+ * it) — otherwise the worker should idle and reserve its capability for its own-tier work.
+ *
+ * Both halves are DB-dependent (live worker census, claimable SD pool), so — matching the
+ * existing worker_tier_rank/tiering_active pattern in claim-eligibility.cjs — the CALLER
+ * precomputes them ONCE per check-in tick (or per dispatch decision) via tierClaimableBreakdown()
+ * (reused verbatim, not re-derived) and idleWorkerCensusByTier() below, then passes the pair
+ * through classifyDispatchIneligibility's ctx.lower_tier_backlog_data. lowerTierBacklog() itself
+ * stays pure/synchronous so it can run inside the classifier.
+ *
+ * @module lib/fleet/tier-backlog
+ */
+
+const { resolveWorkerTierRank, ladderTopRank } = require('./tier-ladder.cjs');
+// NB: tier-claimable.cjs is required LAZILY inside fetchLowerTierBacklogData below, not at module
+// top level. claim-eligibility.cjs top-level-requires this module, and tier-claimable.cjs
+// top-level-requires claim-eligibility.cjs — a top-level require here would complete the cycle
+// (claim-eligibility -> tier-backlog -> tier-claimable -> claim-eligibility) and hand
+// tier-claimable.cjs an incomplete claim-eligibility exports object at load time.
+
+/**
+ * Bucket already-IDLE, already-LIVE worker sessions by resolveWorkerTierRank. Idle/live
+ * determination is the CALLER's job (worker-checkin.cjs / dispatch.cjs each already have their
+ * own live-worker + claim-status joins — see coordinator-capacity-forecast.mjs's claimsBySession
+ * join for the canonical "idle" definition, which is claiming_session_id-based, NOT
+ * claude_sessions.sd_key, since the latter is not reliably cleared on release). This function is
+ * a pure bucketing primitive only, so it stays reusable across both call sites without forcing a
+ * second idle-determination implementation.
+ * @param {Array<{ metadata?: { tier_rank?: number|string } }>} idleLiveWorkers
+ * @returns {{ exact: Object<number,number>, cumulative: Object<number,number>, top: number }}
+ */
+function idleWorkerCensusByTier(idleLiveWorkers) {
+  const top = ladderTopRank();
+  const exact = {};
+  for (let r = 1; r <= top; r += 1) exact[r] = 0;
+  for (const w of (idleLiveWorkers || [])) {
+    const rank = resolveWorkerTierRank(w);
+    const r = Math.max(1, Math.min(top, Math.round(Number(rank)) || top));
+    exact[r] += 1;
+  }
+  const cumulative = {};
+  let running = 0;
+  for (let r = 1; r <= top; r += 1) {
+    running += exact[r];
+    cumulative[r] = running;
+  }
+  return { exact, cumulative, top };
+}
+
+/**
+ * Is the tier at/below `minTierRank` genuinely BACKLOGGED? True iff the claimable work reachable
+ * by a worker at that rung (tierClaimableBreakdown's cumulative[minTierRank] — unscored + every
+ * exact rank 1..minTierRank) exceeds the idle capacity of workers native to that rung or below
+ * (idleWorkerCensusByTier's cumulative[minTierRank]). Both halves are CUMULATIVE, matching FR-6's
+ * own definition ("... exceeds the idle capacity of workers at/below that tier").
+ *
+ * Pure/synchronous — `data` must already carry the precomputed breakdown + census (see module
+ * docstring). Missing/malformed data resolves to `true` (treat as backlogged => admit the
+ * downward claim) rather than `false` (reserve) — fail-OPEN, matching this codebase's dominant
+ * philosophy of never stranding claimable work over a transient/missing-data fault; the
+ * reservation is a utilization optimization, not a safety gate, so uncertainty must not block a
+ * claim that would otherwise proceed under pre-FR-6 (WORK-DOWN-ALWAYS) behavior.
+ * @param {number} minTierRank
+ * @param {{ claimableBreakdown?: { cumulative?: Object<number,number> }, idleCensus?: { cumulative?: Object<number,number> } }} data
+ * @returns {boolean}
+ */
+function lowerTierBacklog(minTierRank, data) {
+  const r = Number(minTierRank);
+  if (!Number.isFinite(r) || r < 1) return true; // unscored/invalid rank -> nothing to reserve against
+  const claimable = data && data.claimableBreakdown && data.claimableBreakdown.cumulative
+    ? Number(data.claimableBreakdown.cumulative[r]) : NaN;
+  const idle = data && data.idleCensus && data.idleCensus.cumulative
+    ? Number(data.idleCensus.cumulative[r]) : NaN;
+  if (!Number.isFinite(claimable) || !Number.isFinite(idle)) return true; // fail-open: missing data never reserves
+  return claimable > idle;
+}
+
+/**
+ * Shared async fetcher: builds ctx.lower_tier_backlog_data from live DB state. ONE fleet-wide
+ * SD scan + ONE live-session scan, reused by BOTH enforcement sites (worker-checkin.cjs self-claim
+ * loop AND dispatch.cjs assertWorkerTierAllowed) so the backlog verdict can never drift between
+ * the pull path and the directed-dispatch path — a worker correctly reserved-and-idle under
+ * self-claim must see the SAME verdict if a WORK_ASSIGNMENT tries to hand it the same lower-tier
+ * work (risk-agent LEAD-phase finding). Fail-open: any query fault returns null, and callers
+ * treat a null return as "no backlog data" (byte-identical pre-FR-6 fallback).
+ * @param {object} supabase service-role client
+ * @returns {Promise<{ claimableBreakdown: object, idleCensus: object }|null>}
+ */
+async function fetchLowerTierBacklogData(supabase) {
+  try {
+    const { tierClaimableBreakdown } = require('./tier-claimable.cjs');
+    const { liveFleetWorkers } = await import('./genuine-worker.mjs');
+    const { getActiveCoordinatorId } = require('../coordinator/resolve.cjs');
+    const liveCutoffIso = new Date(Date.now() - 900000).toISOString();
+    const [{ data: fleetSds }, { data: fleetSessions }] = await Promise.all([
+      supabase.from('strategic_directives_v2')
+        .select('sd_key, sd_type, status, description, title, metadata, target_application, claiming_session_id')
+        .not('status', 'in', '("completed","cancelled","deferred")'),
+      supabase.from('claude_sessions')
+        .select('session_id, status, metadata, heartbeat_at, sd_key, claimed_at, worktree_path, continuous_sds_completed')
+        .in('status', ['active', 'idle'])
+        .gte('heartbeat_at', liveCutoffIso)
+        .limit(200),
+    ]);
+    const claimedSessionIds = new Set(
+      (fleetSds || []).filter((d) => d.claiming_session_id).map((d) => d.claiming_session_id)
+    );
+    const claimablePool = (fleetSds || []).filter((d) => !d.claiming_session_id);
+    const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+    const live = liveFleetWorkers(fleetSessions || [], coordinatorId, Date.now());
+    // "idle" = no active SD claim ANYWHERE on the fleet, per claiming_session_id (mirrors
+    // coordinator-capacity-forecast.mjs's claimsBySession join) — not claude_sessions.sd_key,
+    // which is not reliably cleared on release.
+    const idleWorkers = live.filter((w) => !claimedSessionIds.has(w.session_id));
+    return {
+      claimableBreakdown: tierClaimableBreakdown(claimablePool, { tieringActive: true }),
+      idleCensus: idleWorkerCensusByTier(idleWorkers),
+    };
+  } catch {
+    return null; // fail-open: caller treats null as "no backlog data"
+  }
+}
+
+module.exports = { idleWorkerCensusByTier, lowerTierBacklog, fetchLowerTierBacklogData };

--- a/lib/fleet/tier-backlog.cjs
+++ b/lib/fleet/tier-backlog.cjs
@@ -108,6 +108,10 @@ async function fetchLowerTierBacklogData(supabase) {
         .select('session_id, status, metadata, heartbeat_at, sd_key, claimed_at, worktree_path, continuous_sds_completed')
         .in('status', ['active', 'idle'])
         .gte('heartbeat_at', liveCutoffIso)
+        // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-A hardened isTieringActive's identical bounded
+        // query with this ordering after an unordered LIMIT silently dropped the 2 genuinely-live
+        // workers behind a >1000-row stale-session page; mirrored here for the same reason.
+        .order('heartbeat_at', { ascending: false })
         .limit(200),
     ]);
     const claimedSessionIds = new Set(

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -48,6 +48,10 @@ const { draftDepsSatisfied, baselinedCandidateEligible, classifyDispatchIneligib
 const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, clamp: clampTierRank } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): tier-aware "claimable-to-MY-rung" rollup.
 const { claimableForTier } = require('../lib/fleet/tier-claimable.cjs');
+// SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): backlog-gated downward claims. The fetcher is
+// SHARED with lib/coordinator/dispatch.cjs's assertWorkerTierAllowed so the pull path (here) and
+// the directed-dispatch path compute an IDENTICAL backlog verdict — never two re-derivations.
+const { fetchLowerTierBacklogData } = require('../lib/fleet/tier-backlog.cjs');
 // SD-LEO-INFRA-ASSIGN-FLEET-IDENTITY-001: reuse the coordinator cron's pool + picker + ghost guard so
 // check-in-time self-assign and the 5-min cron allocate identities identically (see assignFleetIdentityAtCheckin).
 const { NATO, COLORS, nextAvailable, isTestSessionId, tierRankOf, pickCallsignForTier, callsignInTierBand } = require('./assign-fleet-identities.cjs');
@@ -1310,6 +1314,18 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
         tiering_active: await isTieringActive(sb),
       };
     } catch { /* fail-open: no tier ctx */ }
+    // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): precompute the backlog verdict inputs ONCE
+    // per tick — lowerTierBacklog() itself is pure/sync (runs inside classifyDispatchIneligibility),
+    // but its two halves (claimable-by-tier, idle-by-tier) are DB-dependent, so fetchLowerTierBacklogData
+    // does the fetch here and the result is threaded into tierCtx.lower_tier_backlog_data. Only when
+    // tiering is active (mirrors every other tier-axis fetch in this function) — with < 2 live workers
+    // the whole tier axis, including this gate, must stay inert (degrade-to-1). Fail-open: a null
+    // return leaves the field unset, which is the classifier's documented byte-identical
+    // WORK-DOWN-ALWAYS fallback.
+    if (tierCtx.tiering_active === true) {
+      const backlogData = await fetchLowerTierBacklogData(sb);
+      if (backlogData) tierCtx.lower_tier_backlog_data = backlogData;
+    }
     // QF-20260630-761: snapshot whether tiering is active so the idle message (below, outside this
     // scope) only attributes a 0-claimable belt to TIER when tiering is actually on. With tiering off
     // the 0 is non-tier ineligibility (orchestrator parents / clone trees / human-action / held).

--- a/tests/unit/fleet/complexity-tiered-assignment.test.js
+++ b/tests/unit/fleet/complexity-tiered-assignment.test.js
@@ -138,8 +138,26 @@ function stubSupabase({ liveWorkers = 2, workerTierRank = 1, sdMinRank = 3, coor
           return { data: null, error: null };
         },
         then(resolve) {
-          // bare `await supabase.from('claude_sessions').select(...)` (the isTieringActive list read)
+          // bare `await supabase.from('claude_sessions').select(...)` (the isTieringActive list read,
+          // and SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E's fetchLowerTierBacklogData live-session read).
           if (table === 'claude_sessions') return resolve({ data: sessions, error: null });
+          // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): fetchLowerTierBacklogData's bulk
+          // strategic_directives_v2 read (the claimable-pool half of the backlog gate). A single
+          // generic unclaimed row at sdMinRank keeps every pre-FR-6 test in this file's original
+          // above/below-tier intent unaffected (none of these auto-generated sessions are stamped
+          // at sdMinRank, so claimable > idle at that rank -> backlogged=true -> admit, matching
+          // the pre-FR-6 WORK-DOWN-ALWAYS expectation these tests assert). Tests targeting the
+          // reservation behavior itself live in tier-backlog-reservation.test.js.
+          if (table === 'strategic_directives_v2') {
+            return resolve({
+              data: [{
+                sd_key: 'SD-BACKLOG-FILLER-001', sd_type: 'infrastructure', status: 'in_progress',
+                title: 'Filler backlog SD', description: 'Keeps pre-FR-6 dispatch tests admitting downward claims.',
+                metadata: { min_tier_rank: sdMinRank }, target_application: 'EHG_Engineer', claiming_session_id: null,
+              }],
+              error: null,
+            });
+          }
           return resolve({ data: [], error: null });
         },
       };

--- a/tests/unit/fleet/tier-backlog-reservation.test.js
+++ b/tests/unit/fleet/tier-backlog-reservation.test.js
@@ -1,0 +1,312 @@
+/**
+ * SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E — FR-6 backlog-gated downward claims.
+ *
+ *   idleWorkerCensusByTier / lowerTierBacklog (pure helpers)         — TS-1
+ *   classifyDispatchIneligibility 'reserved_no_lower_backlog' branch — TS-2
+ *   worker-checkin.cjs self-claim wiring (fetchLowerTierBacklogData) — TS-3
+ *   dispatch.cjs assertWorkerTierAllowed downward-claim gate         — TS-4
+ *   degrade-to-1 + unscored-SD invariants across both sites          — TS-5
+ */
+import { describe, it, expect } from 'vitest';
+import { ladderTopRank } from '../../../lib/fleet/tier-ladder.cjs';
+import { idleWorkerCensusByTier, lowerTierBacklog, fetchLowerTierBacklogData } from '../../../lib/fleet/tier-backlog.cjs';
+import { classifyDispatchIneligibility } from '../../../lib/fleet/claim-eligibility.cjs';
+import { assertWorkerTierAllowed } from '../../../lib/coordinator/dispatch.cjs';
+
+const TOP = ladderTopRank();
+
+// ---- TS-1: pure helpers -----------------------------------------------------
+describe('FR-6 idleWorkerCensusByTier / lowerTierBacklog (pure)', () => {
+  it('buckets idle live workers by resolveWorkerTierRank into exact + cumulative', () => {
+    const census = idleWorkerCensusByTier([
+      { metadata: { tier_rank: 1 } },
+      { metadata: { tier_rank: 1 } },
+      { metadata: { tier_rank: 2 } },
+    ]);
+    expect(census.exact[1]).toBe(2);
+    expect(census.exact[2]).toBe(1);
+    expect(census.cumulative[1]).toBe(2);
+    expect(census.cumulative[2]).toBe(3); // cumulative includes rank 1
+    expect(census.top).toBe(TOP);
+  });
+
+  it('an unstamped worker is bucketed at the top rung (conservative-up, matches resolveWorkerTierRank)', () => {
+    const census = idleWorkerCensusByTier([{ metadata: {} }]);
+    expect(census.exact[TOP]).toBe(1);
+  });
+
+  it('empty input -> all-zero census', () => {
+    const census = idleWorkerCensusByTier([]);
+    expect(Object.values(census.exact).every((n) => n === 0)).toBe(true);
+    expect(Object.values(census.cumulative).every((n) => n === 0)).toBe(true);
+  });
+
+  it('lowerTierBacklog: claimable > idle (cumulative) -> backlogged (true)', () => {
+    const data = { claimableBreakdown: { cumulative: { 1: 5 } }, idleCensus: { cumulative: { 1: 2 } } };
+    expect(lowerTierBacklog(1, data)).toBe(true);
+  });
+
+  it('lowerTierBacklog: claimable <= idle (cumulative) -> not backlogged (false, reserve)', () => {
+    expect(lowerTierBacklog(1, { claimableBreakdown: { cumulative: { 1: 2 } }, idleCensus: { cumulative: { 1: 2 } } })).toBe(false);
+    expect(lowerTierBacklog(1, { claimableBreakdown: { cumulative: { 1: 0 } }, idleCensus: { cumulative: { 1: 3 } } })).toBe(false);
+  });
+
+  it('lowerTierBacklog fails OPEN (true) on missing/malformed data, never blocking on uncertainty', () => {
+    expect(lowerTierBacklog(1, undefined)).toBe(true);
+    expect(lowerTierBacklog(1, {})).toBe(true);
+    expect(lowerTierBacklog(1, { claimableBreakdown: {}, idleCensus: {} })).toBe(true);
+    expect(lowerTierBacklog(NaN, { claimableBreakdown: { cumulative: { 1: 0 } }, idleCensus: { cumulative: { 1: 0 } } })).toBe(true);
+  });
+});
+
+// ---- TS-2: classifier branch -------------------------------------------------
+describe("FR-6 classifyDispatchIneligibility 'reserved_no_lower_backlog' branch", () => {
+  const backlogPresent = { claimableBreakdown: { cumulative: { 1: 5 } }, idleCensus: { cumulative: { 1: 1 } } };
+  const noBacklog = { claimableBreakdown: { cumulative: { 1: 1 } }, idleCensus: { cumulative: { 1: 1 } } };
+
+  it('admits a downward claim when the lower tier is genuinely backlogged', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true, lower_tier_backlog_data: backlogPresent })).toBeNull();
+  });
+
+  it('reserves (blocks) a downward claim when the lower tier has no backlog', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true, lower_tier_backlog_data: noBacklog }))
+      .toBe('reserved_no_lower_backlog');
+  });
+
+  it('never reserves a claim AT the worker\'s own tier, regardless of backlog data', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 3 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true, lower_tier_backlog_data: noBacklog })).toBeNull();
+  });
+
+  it('above_worker_tier still takes precedence over the backlog axis', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 4 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true, lower_tier_backlog_data: backlogPresent }))
+      .toBe('above_worker_tier');
+  });
+
+  it('unscored SDs are unaffected (no min_tier_rank -> no gate at all)', () => {
+    const sd = { sd_key: 'SD-X', metadata: {} };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true, lower_tier_backlog_data: noBacklog })).toBeNull();
+  });
+
+  it('is byte-identical WORK-DOWN-ALWAYS when ctx omits lower_tier_backlog_data (pre-FR-6 callers)', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: true })).toBeNull();
+  });
+
+  it('degrade-to-1: the whole axis (including the new gate) is inert when tiering_active is not true', () => {
+    const sd = { sd_key: 'SD-X', metadata: { min_tier_rank: 1 } };
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, tiering_active: false, lower_tier_backlog_data: noBacklog })).toBeNull();
+    expect(classifyDispatchIneligibility(sd, { worker_tier_rank: 3, lower_tier_backlog_data: noBacklog })).toBeNull();
+  });
+});
+
+// ---- Shared stub supabase for the two DB-dependent enforcement sites --------
+/**
+ * Serves the two queries fetchLowerTierBacklogData issues (strategic_directives_v2 bulk fetch,
+ * claude_sessions bulk fetch) plus the single-row lookups assertWorkerTierAllowed itself needs
+ * (target session by id, SD by sd_key). getActiveCoordinatorId's internal queries (file-first +
+ * DB-fallback coordinator scan) are tolerated defensively (`.filter()` no-op, `.maybeSingle()`
+ * returns null) — fetchLowerTierBacklogData wraps that resolution in `.catch(() => null)`, so
+ * whatever it resolves to never matches a synthetic `w-N` / `target-worker` session id here.
+ */
+function stubSupabase({ liveWorkers = [], sds = [], targetSession = null, targetSd = null } = {}) {
+  return {
+    from(table) {
+      let usedFilter = false;
+      const api = {
+        _table: table, _filters: {},
+        select() { return api; },
+        not() { return api; },
+        in() { return api; },
+        gte() { return api; },
+        order() { return api; },
+        limit() { return api; },
+        filter() { usedFilter = true; return api; },
+        eq(col, val) { api._filters[col] = val; return api; },
+        async maybeSingle() {
+          if (table === 'claude_sessions') {
+            if (targetSession && api._filters.session_id === targetSession.session_id) {
+              return { data: targetSession, error: null };
+            }
+            return { data: null, error: null }; // getActiveCoordinatorId file-first probe: no match
+          }
+          if (table === 'strategic_directives_v2') {
+            if (targetSd && api._filters.sd_key === targetSd.sd_key) return { data: targetSd, error: null };
+            return { data: null, error: null };
+          }
+          return { data: null, error: null };
+        },
+        then(resolve) {
+          if (table === 'claude_sessions') {
+            // queryDbForCoordinator's bulk scan uses .filter(); the census fetch never does.
+            return resolve(usedFilter ? { data: [], error: null } : { data: liveWorkers, error: null });
+          }
+          if (table === 'strategic_directives_v2') return resolve({ data: sds, error: null });
+          return resolve({ data: [], error: null });
+        },
+      };
+      return api;
+    },
+  };
+}
+
+function liveWorker(sessionId, { claimed = false, tierRank = null } = {}) {
+  return {
+    session_id: sessionId, status: 'active', metadata: tierRank ? { tier_rank: tierRank } : {},
+    heartbeat_at: new Date().toISOString(),
+    sd_key: claimed ? 'SD-SOMETHING' : null, claimed_at: claimed ? new Date().toISOString() : null,
+    worktree_path: `/wt/${sessionId}`, continuous_sds_completed: 1,
+  };
+}
+
+// The directed-dispatch target must ALSO satisfy isFleetWorker/everClaimed (status + heartbeat_at +
+// worktree_path) so it counts toward isTieringActive's live-fleet total AND fetchLowerTierBacklogData's
+// idle census — a minimal { session_id, metadata } shape silently drops out of both live-fleet filters,
+// making isTieringActive() under-count and mask the very branch these tests exist to exercise.
+function targetWorkerSession(tierRank) {
+  return {
+    session_id: 'target-worker', status: 'active', metadata: { tier_rank: tierRank },
+    heartbeat_at: new Date().toISOString(), sd_key: null, claimed_at: null,
+    worktree_path: '/wt/target-worker', continuous_sds_completed: 1,
+  };
+}
+
+function sdRow(key, minTierRank, { claimingSessionId = null } = {}) {
+  return {
+    sd_key: key, sd_type: 'infrastructure', status: 'in_progress', title: `Real SD ${key}`,
+    description: 'A real description of reasonable length for belt-eligibility checks.',
+    metadata: { min_tier_rank: minTierRank }, target_application: 'EHG_Engineer',
+    claiming_session_id: claimingSessionId,
+  };
+}
+
+// ---- TS-3: fetchLowerTierBacklogData (shared fetcher) -----------------------
+describe('FR-6 fetchLowerTierBacklogData (shared DB-dependent fetcher)', () => {
+  it('computes claimable-by-tier and idle-by-tier from live DB state', async () => {
+    const liveWorkers = [
+      liveWorker('w-1'), // idle, everyClaimed via worktree_path so it counts as genuine
+      liveWorker('w-2', { claimed: true }),
+    ];
+    const sds = [sdRow('SD-A', 1), sdRow('SD-B', 1, { claimingSessionId: 'w-2' })];
+    const sb = stubSupabase({ liveWorkers, sds });
+    const result = await fetchLowerTierBacklogData(sb);
+    expect(result).not.toBeNull();
+    // SD-B is claimed (excluded from the claimable pool); only SD-A (rank 1) is claimable.
+    expect(result.claimableBreakdown.cumulative[1]).toBe(1);
+    // w-2 has an active claim (SD-B) so it is NOT idle; w-1 is idle.
+    expect(result.idleCensus.cumulative[TOP]).toBe(1);
+  });
+
+  it('fails open (returns null) on a query fault, never throwing', async () => {
+    const broken = { from() { throw new Error('boom'); } };
+    await expect(fetchLowerTierBacklogData(broken)).resolves.toBeNull();
+  });
+});
+
+// ---- TS-4/TS-5: dispatch.cjs assertWorkerTierAllowed downward-claim gate ----
+describe('FR-6 dispatch.cjs assertWorkerTierAllowed downward-claim (backlog) gate', () => {
+  const row = () => ({
+    message_type: 'WORK_ASSIGNMENT', target_session: 'target-worker',
+    payload: { assigned_sd: 'SD-LOWER-001' },
+  });
+
+  it('refuses a downward WORK_ASSIGNMENT when the lower tier has no backlog (reserve)', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = sdRow('SD-LOWER-001', 1);
+    // w-1 is idle AND native to rank 1 -> its idle capacity at/below rank 1 already covers the
+    // one claimable rank-1 SD, so rank 1 is NOT backlogged -> the tier-4 target should reserve.
+    const liveWorkers = [liveWorker('w-1', { tierRank: 1 }), targetSession];
+    const sds = [targetSd];
+    const sb = stubSupabase({ liveWorkers, sds, targetSession, targetSd });
+    await expect(assertWorkerTierAllowed(sb, row())).rejects.toMatchObject({ code: 'DISPATCH_RESERVED_NO_LOWER_BACKLOG' });
+  });
+
+  it('allows a downward WORK_ASSIGNMENT when the lower tier IS backlogged', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = sdRow('SD-LOWER-001', 1);
+    // Two live workers total (tiering active), but NO idle worker at all -> any claimable
+    // work at rank 1 is unabsorbed -> genuinely backlogged.
+    const liveWorkers = [liveWorker('w-1', { claimed: true }), targetSession];
+    const sds = [targetSd, sdRow('SD-W1', 4, { claimingSessionId: 'w-1' })];
+    const sb = stubSupabase({ liveWorkers, sds, targetSession, targetSd });
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+
+  it('never gates an at-own-tier WORK_ASSIGNMENT on backlog', async () => {
+    const targetSession = targetWorkerSession(1);
+    const targetSd = sdRow('SD-LOWER-001', 1);
+    const liveWorkers = [liveWorker('w-1'), liveWorker('w-2'), targetSession];
+    const sds = [targetSd];
+    const sb = stubSupabase({ liveWorkers, sds, targetSession, targetSd });
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+
+  it('fails open (allows) when fetchLowerTierBacklogData cannot resolve backlog data', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = sdRow('SD-LOWER-001', 1);
+    // A supabase whose claude_sessions single-row + bulk queries work (so isTieringActive() itself
+    // resolves true, actually reaching the downward-claim branch) but whose strategic_directives_v2
+    // BULK read throws (breaks fetchLowerTierBacklogData specifically, not the outer tiering check).
+    const sb = {
+      from(table) {
+        const api = {
+          select() { return api; }, not() { return api; }, in() { return api; },
+          gte() { return api; }, order() { return api; }, limit() { return api; }, filter() { return api; },
+          eq(col, val) { api._filters = { ...(api._filters || {}), [col]: val }; return api; },
+          async maybeSingle() {
+            if (table === 'claude_sessions' && api._filters?.session_id === 'target-worker') return { data: targetSession, error: null };
+            if (table === 'strategic_directives_v2' && api._filters?.sd_key === 'SD-LOWER-001') return { data: targetSd, error: null };
+            return { data: null, error: null };
+          },
+          then(resolve) {
+            if (table === 'claude_sessions') return resolve({ data: [liveWorker('w-1'), targetSession], error: null });
+            throw new Error('strategic_directives_v2 bulk fetch broken');
+          },
+        };
+        return api;
+      },
+    };
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+
+  it('degrade-to-1: with < 2 live workers the backlog gate is inert, downward assignment allowed', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = sdRow('SD-LOWER-001', 1);
+    const liveWorkers = [targetSession]; // only 1 live worker -> isTieringActive() false
+    const sds = [targetSd];
+    const sb = stubSupabase({ liveWorkers, sds, targetSession, targetSd });
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+
+  it('unscored SD (no min_tier_rank) is unaffected by the backlog gate', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = { sd_key: 'SD-LOWER-001', metadata: {} };
+    const liveWorkers = [liveWorker('w-1'), liveWorker('w-2'), targetSession];
+    const sb = stubSupabase({ liveWorkers, sds: [], targetSession, targetSd });
+    await expect(assertWorkerTierAllowed(sb, row())).resolves.toBeUndefined();
+  });
+});
+
+// ---- TS-5b: both-enforcement-sites-consistent -------------------------------
+describe('FR-6 both-enforcement-sites-consistent: same backlog data, same verdict', () => {
+  it('classifyDispatchIneligibility and assertWorkerTierAllowed agree given the same fetched backlog data', async () => {
+    const targetSession = targetWorkerSession(4);
+    const targetSd = sdRow('SD-LOWER-001', 1);
+    const liveWorkers = [liveWorker('w-1', { tierRank: 1 }), targetSession]; // w-1 idle -> absorbs the one rank-1 SD
+    const sds = [targetSd];
+    const sb = stubSupabase({ liveWorkers, sds, targetSession, targetSd });
+
+    const backlogData = await fetchLowerTierBacklogData(sb);
+    const selfClaimVerdict = classifyDispatchIneligibility(targetSd, {
+      worker_tier_rank: 4, tiering_active: true, lower_tier_backlog_data: backlogData,
+    });
+    expect(selfClaimVerdict).toBe('reserved_no_lower_backlog');
+    // The directed-dispatch path, using the SAME fetcher, must reach the SAME confirmed refusal.
+    await expect(assertWorkerTierAllowed(sb, {
+      message_type: 'WORK_ASSIGNMENT', target_session: 'target-worker', payload: { assigned_sd: 'SD-LOWER-001' },
+    })).rejects.toMatchObject({ code: 'DISPATCH_RESERVED_NO_LOWER_BACKLOG' });
+  });
+});


### PR DESCRIPTION
## Summary
- Changes `classifyDispatchIneligibility`'s tier axis from WORK-DOWN-ALWAYS to WORK-DOWN-ONLY-WHEN-LOWER-TIER-BACKLOGGED (chairman directive): a worker claims AT its own tier freely, but claims a strictly lower tier's work only when that tier is genuinely backlogged.
- New `lib/fleet/tier-backlog.cjs`: `idleWorkerCensusByTier`, `lowerTierBacklog` (pure, fail-open), and `fetchLowerTierBacklogData` (shared async fetcher used by both enforcement sites).
- `lib/fleet/claim-eligibility.cjs`: new `reserved_no_lower_backlog` classifier branch, gated behind an optional precomputed `ctx.lower_tier_backlog_data` (byte-identical WORK-DOWN-ALWAYS fallback when omitted).
- `scripts/worker-checkin.cjs`: self-claim loop precomputes the backlog verdict once per tick.
- `lib/coordinator/dispatch.cjs`: `assertWorkerTierAllowed` (the second, independent directed-dispatch enforcement site) extended to honor the same gate, so self-claim and directed dispatch can never disagree.
- Degrade-to-1 (FR-5) preserved unconditionally across both sites.

Fifth and final child of `SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001` (orchestrator), ships last per `metadata.ships=last`.

## Test plan
- [x] `tests/unit/fleet/tier-backlog-reservation.test.js` (new, 22 tests): pure helpers, classifier branch, shared fetcher, dispatch guard, both-sites-consistency, degrade-to-1, unscored-SD invariants.
- [x] `tests/unit/fleet/complexity-tiered-assignment.test.js` extended (shared stub now serves the new bulk queries) — all pre-existing FR-3/FR-4/FR-5 assertions still green.
- [x] Full `tests/unit/fleet/` suite green (194/194).
- [x] Broader worker-checkin/claim-eligibility/dispatch test sweep green (165+137 tests).
- [x] `node --check` + `eslint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)