### PR TITLE
fix(SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-A): close backlog-rank quiescent-skip + coordinator-teardown deadlock

### DIFF
--- a/.github/workflows/backlog-rank-cron.yml
+++ b/.github/workflows/backlog-rank-cron.yml
@@ -1,0 +1,54 @@
+name: "Backlog rank (cron)"
+
+# SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-A (FR-2) — durable, coordinator-independent
+# net for coordinator-backlog-rank.mjs (persists metadata.dispatch_rank that worker self-claim
+# ordering honors). The ONLY other paths that run this script are (a) coordinator-quiet-tick.mjs's
+# composed core and (b) a harness-level CronCreate loop armed by a LIVE coordinator session — both
+# of which can go dark together (quiescent skip + the coordinator's own teardown-discipline
+# CronDelete sweep). This workflow runs in always-on GitHub Actions (mirroring
+# fleet-down-alert-cron.yml), independent of any coordinator session or CronCreate arming state, so
+# a claimable-but-unranked SD is never stuck for longer than one ~15min run.
+#
+# coordinator-backlog-rank.mjs fail-opens its mutation guard when no session id is resolvable (see
+# lib/coordinator-mutation-guard.mjs assertCanonicalCoordinator: no_session_id_fail_open), so this
+# workflow needs no CLAUDE_SESSION_ID to write ranks.
+
+on:
+  schedule:
+    # Every 15 minutes, offset to dodge the other ~15min crons (fleet-down-alert 11,26,41,56;
+    # coordinator STANDARD_LOOPS backlog-rank 6,21,36,51; charter-audit 8,23,38,53).
+    - cron: '9,24,39,54 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  rank:
+    name: Rank the claimable backlog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Rank the claimable backlog
+        run: node scripts/coordinator-backlog-rank.mjs

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -57,7 +57,11 @@ export const COMPOSED_CORES = [
   { key: 'inbox', script: 'fleet-dashboard.cjs', args: ['scripts/fleet-dashboard.cjs', 'inbox'], quiescentSkip: false, safety: true },
   { key: 'charter-audit', script: 'coordinator-charter-audit.mjs', args: ['scripts/coordinator-charter-audit.mjs'], quiescentSkip: true },
   { key: 'capacity-forecast', script: 'coordinator-capacity-forecast.mjs', args: ['scripts/coordinator-capacity-forecast.mjs', '--dispatch'], quiescentSkip: true },
-  { key: 'backlog-rank', script: 'coordinator-backlog-rank.mjs', args: ['scripts/coordinator-backlog-rank.mjs'], quiescentSkip: true },
+  // NOT quiescentSkip (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-A): a cheap single-table
+  // scan+write, and exactly the state where a fresh draft SD needs a rank before the next worker
+  // wakes and self-claims — skipping it here left claimable-but-unranked SDs stuck whenever this
+  // tick's STANDARD_LOOPS sibling cron was also unarmed (coordinator teardown-discipline gap).
+  { key: 'backlog-rank', script: 'coordinator-backlog-rank.mjs', args: ['scripts/coordinator-backlog-rank.mjs'], quiescentSkip: false },
   { key: 'audit', script: 'coordinator-audit.mjs', args: ['scripts/coordinator-audit.mjs'], quiescentSkip: true },
 ];
 

--- a/tests/unit/coordinator/quiet-tick-loop-parity.test.js
+++ b/tests/unit/coordinator/quiet-tick-loop-parity.test.js
@@ -22,22 +22,26 @@ describe('coordinator quiet-tick — folded-core accounting', () => {
     }
   });
 
-  it('expensive cores are quiescent-skipped; safety cores always run', () => {
+  it('expensive cores are quiescent-skipped; safety + backlog-rank always run', () => {
     const byKey = Object.fromEntries(COORD_CORES.map((c) => [c.key, c]));
     // Claim-reaping + inbox arrival must never be suppressed by quiescence.
     expect(byKey.sweep.quiescentSkip).toBe(false);
     expect(byKey.inbox.quiescentSkip).toBe(false);
+    // backlog-rank (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-A): cheap, and exactly the
+    // state where a fresh draft SD needs a rank before the next worker self-claims — must not
+    // be quiescent-skipped like the genuinely expensive predictive/audit cores below.
+    expect(byKey['backlog-rank'].quiescentSkip).toBe(false);
     // Expensive predictive/audit cores skip when nothing is moving.
     expect(byKey['charter-audit'].quiescentSkip).toBe(true);
     expect(byKey['capacity-forecast'].quiescentSkip).toBe(true);
-    expect(byKey['backlog-rank'].quiescentSkip).toBe(true);
     expect(byKey.audit.quiescentSkip).toBe(true);
   });
 
-  it('buildCores(quiescent=true) skips exactly the expensive cores', () => {
+  it('buildCores(quiescent=true) skips the expensive cores but keeps backlog-rank running', () => {
     const cores = buildCoordCores(true);
     const skipped = cores.filter((c) => c.skip).map((c) => c.key).sort();
-    expect(skipped).toEqual(['audit', 'backlog-rank', 'capacity-forecast', 'charter-audit']);
+    expect(skipped).toEqual(['audit', 'capacity-forecast', 'charter-audit']);
+    expect(cores.find((c) => c.key === 'backlog-rank').skip).toBe(false);
   });
 
   it('buildCores(quiescent=false) runs the full set (no skips)', () => {


### PR DESCRIPTION
## Summary
- `scripts/coordinator-quiet-tick.mjs`: backlog-rank core is no longer `quiescentSkip:true` — it's a cheap single-table scan/write and exactly the state where a fresh draft SD needs a rank before the next worker wakes and self-claims.
- New `.github/workflows/backlog-rank-cron.yml`: a durable, coordinator-session-independent ~15min GitHub Actions net (mirrors the proven `fleet-down-alert-cron.yml` pattern), closing the gap where the coordinator's own teardown-discipline (`CronDelete` all loops on sustained idle) deletes the only other trigger for `coordinator-backlog-rank.mjs`.
- Verified `coordinator-backlog-rank.mjs`'s mutation guard fail-opens with no `CLAUDE_SESSION_ID` set (`assertCanonicalCoordinator`'s `no_session_id_fail_open` path) — no code change required for the GHA-triggered sessionless case.

Child of SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001 (parent orchestrator, FR-2).

## Test plan
- [x] `npx vitest run tests/unit/coordinator/quiet-tick-loop-parity.test.js tests/unit/coordinator/quiet-tick.test.js` — 19/19 passed (updated the loop-parity test's quiescent-skip assertions to match the new behavior)
- [x] `npx vitest run tests/unit/coordinator/` — 201/201 passed, no regressions
- [x] `node scripts/coordinator-quiet-tick.mjs --dry-run --json` — backlog-rank executes cleanly in the composed tick
- [x] `CLAUDE_SESSION_ID= node scripts/coordinator-backlog-rank.mjs --dry-run` — completes successfully with no session set, confirming the new GHA workflow's sessionless invocation will work
- [x] New workflow YAML validated for syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)