### PR TITLE
feat(SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-B): fifth self-claim candidate source for ranked-but-windowed-out SDs

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -598,6 +598,40 @@ async function fetchFleetCriticalCandidates(sb) {
     .sort((a, b) => (PRIORITY_RANK[a.priority] ?? 9) - (PRIORITY_RANK[b.priority] ?? 9));
 }
 
+/**
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-B (FR-1): a FIFTH self-claim candidate source.
+ * sortByDispatchRank/orderByFleetCriticalThenRank can only REORDER an item already in the merged
+ * pool — it cannot inject one. A claimable SD the coordinator HAS ranked (metadata.dispatch_rank
+ * set) but that sits outside every existing window (not in the baselined view, not in the oldest-10
+ * or newest-10 draft windows, not fleet_critical) is therefore invisible to self-claim even though
+ * it is ranked — the coordinator's own ranking work (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-A)
+ * is wasted for it. This source fetches UNCLAIMED SDs directly by "has a dispatch_rank", bypassing
+ * the age windows, mirroring fetchFleetCriticalCandidates's shape.
+ *
+ * The `.not(...)` filter is a DB-side hint only (Postgres/PostgREST honors it; some in-memory test
+ * doubles no-op unimplemented filters) — the JS-side `!= null` re-filter below is authoritative,
+ * matching this file's established fleet_critical-source pattern. Numeric dispatch_rank sort is
+ * done in JS (not via DB `.order()`) because ordering a jsonb/text extraction lexically would sort
+ * "10" before "2" — the DB `.order('created_at')` below is only a deterministic tiebreak hint.
+ */
+async function fetchRankedCandidates(sb) {
+  const { data: rows } = await sb
+    .from('strategic_directives_v2')
+    .select('sd_key, status, sd_type, priority, created_at, dependencies, metadata, target_application, parent_sd_id')
+    .not('metadata->dispatch_rank', 'is', null)               // DB-side hint: has a dispatch_rank
+    .in('status', ['draft', 'active'])                        // POSITIVE allowlist (never a denylist)
+    .is('claiming_session_id', null)
+    .neq('sd_type', 'orchestrator')
+    .order('created_at', { ascending: true })                 // deterministic tiebreak — never a silent truncation
+    .limit(DRAFT_CANDIDATE_LIMIT);
+  // Authoritative JS filter (mirrors the fleet_critical source's DB-hint + JS-authoritative pattern):
+  // keep only rows with a real dispatch_rank, then sort numerically ascending (lowest rank first).
+  return (rows || [])
+    .filter((r) => r.metadata && r.metadata.dispatch_rank != null)
+    .slice()
+    .sort((a, b) => Number(a.metadata.dispatch_rank) - Number(b.metadata.dispatch_rank));
+}
+
 /** Per-row claim attempt for an un-baselined draft candidate (shared by the merged
  *  step-6 tier and the legacy selfClaimDraftSd wrapper). Returns a result or null. */
 async function tryClaimDraftCandidate(sb, sessionId, base, d, tierCtx = {}) {
@@ -1271,6 +1305,11 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     // reorder. Placed here, inside the step-6 try and downstream of ALL acquisition guards (4.5/5.7/5.8/5.9).
     let fcRows = [];
     try { fcRows = await fetchFleetCriticalCandidates(sb); } catch { /* fail-open: window-only behavior */ }
+    // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-B (FR-1/FR-2): a FIFTH source for SDs the
+    // coordinator has ranked (metadata.dispatch_rank set) that sit OUTSIDE every window above, so a
+    // ranked-but-not-fleet_critical, middle-of-the-backlog SD is not wasted ranking work.
+    let rankedRows = [];
+    try { rankedRows = await fetchRankedCandidates(sb); } catch { /* fail-open: window-only behavior */ }
 
     const seen = new Set();
     const merged = [];
@@ -1295,6 +1334,13 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     // (strict-boolean fleet_critical) to the front of the merged pool.
     for (const f of fcRows) {
       if (f.sd_key && !seen.has(f.sd_key)) { seen.add(f.sd_key); merged.push({ kind: 'baselined', key: f.sd_key }); }
+    }
+    // FR-2 (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-B): union the ranked-direct source LAST so
+    // an SD already surfaced by any prior source keeps its existing entry (SAME seen-set dedup).
+    // kind:'baselined' routes each injected entry through baselinedCandidateEligible -> the COMPLETE
+    // eligibility SSOT, exactly like the fleet_critical union above — no eligibility/claim bypass.
+    for (const r of rankedRows) {
+      if (r.sd_key && !seen.has(r.sd_key)) { seen.add(r.sd_key); merged.push({ kind: 'baselined', key: r.sd_key }); }
     }
 
     // duty-6: honor the coordinator's fresh dispatch_rank across the WHOLE pool (fail-open).
@@ -1460,7 +1506,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { extractSdFromAssignment, extractDirectedSd, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isSdInFlight, selfHealStaleClaim, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/worker-checkin-ranked-window.test.js
+++ b/tests/unit/worker-checkin-ranked-window.test.js
@@ -1,0 +1,235 @@
+// SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-B (FR-1/FR-2) — NON-MOCKED regression through real
+// runCheckin(). sortByDispatchRank/orderByFleetCriticalThenRank can only REORDER an item already in
+// the merged pool, never inject one. A claimable SD the coordinator HAS ranked (metadata.dispatch_rank
+// set) but that sits outside every existing window (baselined view, oldest-10 draft, newest-10 draft,
+// fleet_critical-direct) is therefore invisible to self-claim. The fix adds a FIFTH source
+// (fetchRankedCandidates) unioned into the merged step-6 pool.
+//
+// These tests drive the REAL runCheckin(): orderByFleetCriticalThenRank, sortByDispatchRank,
+// baselinedCandidateEligible, classifyDispatchIneligibility, isSdInFlight and tryClaim all run for
+// real — ONLY the DB seam (an in-memory Supabase fixture) and the coordinator resolver are stubbed.
+// T1 is inherently anti-test-masking: SD-RANKED-ONLY is reachable ONLY via the new source, so
+// removing the union makes runCheckin claim a filler and the assertion fails.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { runCheckin } = require('../../scripts/worker-checkin.cjs');
+
+const SESSION = 'test-session-ranked-1';
+const NO_COORD = { getCoordinator: async () => null }; // bypass coordinator resolution (broadcast)
+
+// ── In-memory Supabase fixture (mirrors tests/unit/worker-checkin-fleet-critical-window.test.js) ──
+// `.not()` is intentionally a no-op passthrough here (the real DB-side filter is a hint per this
+// file's own established pattern) — fetchRankedCandidates' JS-side re-filter is what these tests
+// actually exercise, exactly mirroring the production authoritative-JS-filter design.
+function makeStub(tables, { onClaim } = {}) {
+  const db = {};
+  for (const k of Object.keys(tables)) db[k] = tables[k].map((r) => ({ ...r }));
+  let idc = 1;
+
+  const getCol = (row, col) => {
+    if (typeof col === 'string' && col.includes('->>')) {
+      const [base, rawKey] = col.split('->>');
+      const key = rawKey.replace(/['"]/g, '').trim();
+      const container = row[base.trim()];
+      const v = container ? container[key] : undefined;
+      return v === undefined || v === null ? null : String(v);
+    }
+    return row[col];
+  };
+
+  function query(table) {
+    let mode = 'select';
+    let payload = null;
+    const preds = [];
+    const orders = [];
+    let limitN = null;
+
+    const read = () => {
+      let rows = (db[table] || []).filter((r) => preds.every((p) => p(r)));
+      for (const o of orders.slice().reverse()) {
+        rows = rows.slice().sort((a, b) => {
+          const av = a[o.col], bv = b[o.col];
+          if (av === bv) return 0;
+          if (av == null) return 1;
+          if (bv == null) return -1;
+          return (av < bv ? -1 : 1) * (o.asc ? 1 : -1);
+        });
+      }
+      if (limitN != null) rows = rows.slice(0, limitN);
+      return rows;
+    };
+
+    const resolve = () => {
+      if (mode === 'insert') {
+        const arr = Array.isArray(payload) ? payload : [payload];
+        const inserted = arr.map((r) => ({ id: `gen-${idc++}`, ...r }));
+        db[table] = (db[table] || []).concat(inserted);
+        return { data: inserted, error: null };
+      }
+      if (mode === 'update') {
+        const matched = (db[table] || []).filter((r) => preds.every((p) => p(r)));
+        for (const r of matched) Object.assign(r, payload);
+        return { data: matched, error: null };
+      }
+      if (mode === 'delete') {
+        db[table] = (db[table] || []).filter((r) => !preds.every((p) => p(r)));
+        return { data: null, error: null };
+      }
+      return { data: read(), error: null };
+    };
+
+    const b = {
+      select() { return b; },
+      insert(p) { mode = 'insert'; payload = p; return b; },
+      update(p) { mode = 'update'; payload = p; return b; },
+      upsert(p) { mode = 'insert'; payload = p; return b; },
+      delete() { mode = 'delete'; return b; },
+      eq(c, v) { preds.push((r) => getCol(r, c) === v); return b; },
+      neq(c, v) { preds.push((r) => getCol(r, c) !== v); return b; },
+      is(c, v) { preds.push((r) => (v === null ? getCol(r, c) == null : getCol(r, c) === v)); return b; },
+      in(c, arr) { preds.push((r) => Array.isArray(arr) && arr.includes(getCol(r, c))); return b; },
+      gte(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) >= v); return b; },
+      lte(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) <= v); return b; },
+      gt(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) > v); return b; },
+      lt(c, v) { preds.push((r) => getCol(r, c) != null && getCol(r, c) < v); return b; },
+      not() { return b; },                                   // DB-hint no-op — JS-side filter is authoritative
+      or() { return b; },
+      order(c, opts) { orders.push({ col: c, asc: !(opts && opts.ascending === false) }); return b; },
+      limit(n) { limitN = n; return b; },
+      range() { return b; },
+      maybeSingle() { const r = resolve(); const a = r.data || []; return Promise.resolve({ data: a.length ? a[0] : null, error: r.error }); },
+      single() { const r = resolve(); const a = r.data || []; return Promise.resolve({ data: a.length ? a[0] : null, error: a.length ? r.error : { message: 'no rows' } }); },
+      then(onF, onR) { return Promise.resolve(resolve()).then(onF, onR); },
+    };
+    return b;
+  }
+
+  const sb = {
+    from(t) { return query(t); },
+    rpc(fn, args = {}) {
+      if (fn === 'claim_sd') {
+        const row = (db.strategic_directives_v2 || []).find((r) => r.sd_key === args.p_sd_id);
+        if (!row) return Promise.resolve({ data: { success: false, error: 'not_found' }, error: null });
+        if (row.claiming_session_id && row.claiming_session_id !== args.p_session_id) {
+          return Promise.resolve({ data: { success: false, claimed_by: row.claiming_session_id }, error: null });
+        }
+        if (['completed', 'cancelled', 'deferred'].includes(row.status)) {
+          return Promise.resolve({ data: { success: false, error: 'terminal' }, error: null });
+        }
+        row.claiming_session_id = args.p_session_id;
+        row.is_working_on = true;
+        if (onClaim) onClaim(args.p_sd_id);
+        return Promise.resolve({ data: { success: true }, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+  };
+  return { sb, db };
+}
+
+let seq = 0;
+const ts = (n) => `2026-01-${String(n).padStart(2, '0')}T00:00:00.000Z`;
+const sd = (key, extra = {}) => ({
+  id: `id-${++seq}`, sd_key: key, status: 'draft', sd_type: 'infrastructure', priority: 'high',
+  current_phase: 'LEAD', created_at: ts(seq), dependencies: [], metadata: {}, target_application: null,
+  parent_sd_id: null, claiming_session_id: null, is_working_on: false, ...extra,
+});
+const rankedSd = (key, rank, extra = {}) =>
+  sd(key, { metadata: { dispatch_rank: rank, dispatch_rank_at: new Date().toISOString() }, ...extra });
+const sessionRow = () => ({ session_id: SESSION, metadata: {}, sd_key: null, heartbeat_at: ts(1) });
+const viewRow = (key) => ({ sd_id: key, track: 'STANDALONE', status: 'draft', priority: 'high' });
+
+describe('ranked-SD reachability via the fifth source (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-B)', () => {
+  it('T1: a ranked SD present ONLY in the new source is self_claimed past equally-claimable fillers', async () => {
+    seq = 0;
+    // 12 fillers saturate BOTH the oldest-10 and newest-10 draft windows once the ranked SD sits
+    // in the middle of the age range (created between filler #6 and filler #7 by construction below).
+    const oldFillers = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-OLD-${i + 1}`));
+    const rankedOnly = rankedSd('SD-RANKED-ONLY-001', 1, { created_at: ts(11) }); // middle age position
+    const newFillers = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-NEW-${i + 1}`, { created_at: ts(100 + i) }));
+    const all = [...oldFillers, rankedOnly, ...newFillers];
+    const view = oldFillers.slice(0, 5).map((d) => viewRow(d.sd_key)); // baselined view: only old fillers
+    const { sb, db } = makeStub({
+      strategic_directives_v2: all,
+      v_sd_next_candidates: view,
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toBe('SD-RANKED-ONLY-001'); // reachable ONLY via fetchRankedCandidates + lifted by its rank
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-RANKED-ONLY-001').claiming_session_id).toBe(SESSION);
+  });
+
+  it('T2 (control): with NO ranked SD outside the windows, a filler is claimed — proving the ranked SD was reachable ONLY via the new source', async () => {
+    seq = 0;
+    const oldFillers = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-OLD-${i + 1}`));
+    const newFillers = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-NEW-${i + 1}`, { created_at: ts(100 + i) }));
+    const view = oldFillers.slice(0, 5).map((d) => viewRow(d.sd_key));
+    const { sb } = makeStub({
+      strategic_directives_v2: [...oldFillers, ...newFillers], // no ranked SD at all
+      v_sd_next_candidates: view,
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toMatch(/^SD-DRAFT-/); // a filler, not the (absent) ranked SD
+  });
+
+  it('T3: an unranked SD (no metadata.dispatch_rank) outside the windows is NOT surfaced or claimed', async () => {
+    seq = 0;
+    const oldFillers = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-OLD-${i + 1}`));
+    const newFillers = Array.from({ length: 10 }, (_, i) => sd(`SD-DRAFT-NEW-${i + 1}`, { created_at: ts(100 + i) }));
+    const unranked = sd('SD-UNRANKED-MID-001', { created_at: ts(11) }); // middle age, no dispatch_rank
+    const view = oldFillers.slice(0, 5).map((d) => viewRow(d.sd_key));
+    const { sb, db } = makeStub({
+      strategic_directives_v2: [...oldFillers, unranked, ...newFillers],
+      v_sd_next_candidates: view,
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.sd).not.toBe('SD-UNRANKED-MID-001');
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-UNRANKED-MID-001').claiming_session_id).toBeNull();
+  });
+
+  it('T4: dedup — a ranked SD ALSO in the oldest-10 window is claimed once, not double-entered', async () => {
+    seq = 0;
+    const rankedInWindow = rankedSd('SD-RANKED-INWINDOW-001', 0); // oldest -> already in fetchDraftCandidates
+    const otherOld = Array.from({ length: 9 }, (_, i) => sd(`SD-DRAFT-OLD-${i + 1}`));
+    const { sb, db } = makeStub({
+      strategic_directives_v2: [rankedInWindow, ...otherOld],
+      v_sd_next_candidates: [],
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.action).toBe('self_claimed');
+    expect(res.sd).toBe('SD-RANKED-INWINDOW-001'); // lifted by its rank regardless of which source surfaced it
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-RANKED-INWINDOW-001').claiming_session_id).toBe(SESSION);
+  });
+
+  it('a ranked SD in a NON-allowlist status (pending_approval) is NOT surfaced or claimed', async () => {
+    seq = 0;
+    const pending = rankedSd('SD-RANKED-PENDING-001', 0, { status: 'pending_approval', created_at: ts(11) });
+    const drafts = Array.from({ length: 4 }, (_, i) => sd(`SD-DRAFT-P-${i + 1}`));
+    const { sb, db } = makeStub({
+      strategic_directives_v2: [...drafts, pending],
+      v_sd_next_candidates: drafts.map((d) => viewRow(d.sd_key)),
+      claude_sessions: [sessionRow()],
+    });
+    const res = await runCheckin(sb, SESSION, NO_COORD);
+    expect(res.sd).not.toBe('SD-RANKED-PENDING-001');
+    expect(db.strategic_directives_v2.find((r) => r.sd_key === 'SD-RANKED-PENDING-001').claiming_session_id).toBeNull();
+  });
+});
+
+describe('FR-1/FR-2 source-pinned wiring (the union exists and routes through the SSOT)', () => {
+  it('runCheckin fetches the ranked-direct source and unions it as kind:baselined via the seen-set', async () => {
+    const { readFileSync } = await import('fs');
+    const src = readFileSync(new URL('../../scripts/worker-checkin.cjs', import.meta.url), 'utf8');
+    const body = src.slice(src.indexOf('async function runCheckin'), src.indexOf('async function main'));
+    expect(body).toMatch(/fetchRankedCandidates\(sb\)/);                 // the fifth source is called
+    expect(body).toMatch(/for \(const r of rankedRows\)/);               // unioned into the merged pool
+    expect(body).toMatch(/seen\.has\(r\.sd_key\)/);                      // SAME seen-set dedup
+    expect(body).toMatch(/kind: 'baselined', key: r\.sd_key/);          // routes through the full SSOT
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/worker-checkin.cjs`: adds `fetchRankedCandidates(sb)`, a fifth self-claim candidate source mirroring `fetchFleetCriticalCandidates`'s shape but keyed on "has a `metadata.dispatch_rank`" instead of the `fleet_critical` flag.
- Closes a discovery gap: the existing rank-based reorder (`sortByDispatchRank`/`orderByFleetCriticalThenRank`) can only lift an item already present in the merged pool — it cannot inject one. A claimable, non-fleet_critical, non-baselined SD the coordinator has ranked but that sits outside both the oldest-10 and newest-10 age windows was invisible to self-claim, wasting the coordinator's ranking work (this orchestrator's sibling child A).
- Unioned into the merged pool with the same seen-set dedup, routing through the complete eligibility SSOT — additive-only, no changes to eligibility gates or claim semantics.

Child of SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001 (parent orchestrator, FR-3).

## Test plan
- [x] New `tests/unit/worker-checkin-ranked-window.test.js` — 6/6 passing (non-mocked `runCheckin()` regression: reachable-only-via-new-source with a positive+negative control, dedup against an already-windowed SD, non-allowlist-status exclusion, unranked-SD exclusion, wiring-pinned source-call assertions)
- [x] `npx vitest run tests/unit/worker-checkin*.test.js` — 80/80 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)