### PR TITLE
feat(SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001): widen Solomon hourly refresher to C/M/V foundations

### DIFF
--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -17,6 +17,12 @@
  * role='adam', fresh heartbeat_at) and dispatches via the validated dispatch guard —
  * NO hardcoded UUID, so it survives Adam restarts and silently skips when Adam is absent.
  *
+ * SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001: the Solomon leg's re-affirmation SET is
+ * {role contract, Constitution, Mission/Vision, operating model} — not just the role contract — via
+ * buildFoundationsPointer(), which POINTS at the canonical sources (protocol_constitution table,
+ * docs/vision/ehg-mission-vision-canonical.md, eva_vision_documents, the two operating-model docs) rather
+ * than embedding a paraphrase, so the grounding is first-hand + current.
+ *
  * Flags:
  *   --dry-run   assess + print, but do NOT dispatch to Adam (for arming/testing).
  *
@@ -58,12 +64,46 @@ const SOLOMON_REMINDER =
   'solomon_consult only — do not poll for problems), the per-sweep task_budget at ENTRY before any Read/Grep, ' +
   'and your 5-dim self-rubric. Stay silent unless you have a deep, defensible oracle answer.';
 
+// SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001: widens the Solomon re-affirmation SET from
+// {role contract} to {role contract, Constitution, Mission/Vision, operating model}. This POINTS Solomon at
+// the CANONICAL sources rather than embedding a paraphrase — Solomon's higher-order-framing and Adam-
+// grounding-completeness duties both require FIRST-HAND, CURRENT grounding, not a copy baked into this
+// script that goes stale the moment the Constitution/Vision changes. Kept CHEAP: a single lightweight
+// protocol_constitution row-count query (fail-open to a static pointer) + fixed, small doc paths — no full
+// text is fetched or embedded. Exported for tests.
+const CANONICAL_CONSTITUTION_TABLE = 'protocol_constitution';
+const CANONICAL_MISSION_VISION_DOC = 'docs/vision/ehg-mission-vision-canonical.md';
+const CANONICAL_OPERATING_MODEL_DOCS = [
+  'docs/03_protocols_and_standards/venture-hosting-standard.md',
+  'docs/03_protocols_and_standards/only-the-chairman-can.md',
+];
+
+async function buildFoundationsPointer(sb) {
+  let constPart = 'Constitution: re-read ' + CANONICAL_CONSTITUTION_TABLE + ' (CONST-001..014) directly.';
+  try {
+    const { data } = await sb.from(CANONICAL_CONSTITUTION_TABLE).select('rule_code').order('rule_code');
+    const codes = (data || []).map(function (r) { return r.rule_code; }).filter(Boolean);
+    if (codes.length > 0) {
+      constPart = 'Constitution: re-read ' + CANONICAL_CONSTITUTION_TABLE + ' — ' + codes.length +
+        ' live rule(s) (' + codes[0] + '..' + codes[codes.length - 1] + ').';
+    }
+  } catch (e) {
+    // fail-open to the static pointer above — a foundations refresh must never block the reminder
+  }
+  return (
+    constPart + ' ' +
+    'Mission/Vision: re-read ' + CANONICAL_MISSION_VISION_DOC + ' (chairman-approved canonical) plus your ' +
+    'current eva_vision_documents entries. ' +
+    'Operating model: re-read ' + CANONICAL_OPERATING_MODEL_DOCS.join(' and ') + '.'
+  );
+}
+
 // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: the Solomon leg — mirrors the Adam leg but resolves the
 // live Solomon via getActiveSolomonId (no hardcoded UUID), reuses the SAME hourly cadence, dispatch guard,
 // and cycle-down gate (the caller checks assessFleetActivity ONCE before invoking this). Self-contained
 // (returns a verdict; does NOT exit main) so it composes alongside the Adam leg. Fail-open / non-fatal.
 // Exported for tests. @returns {Promise<{dispatched:boolean, reason?:string, target?:string}>}
-async function dispatchSolomonReminder(sb, { dryRun = DRY_RUN, resolveSolomon = getActiveSolomonId, insert = insertCoordinationRow } = {}) {
+async function dispatchSolomonReminder(sb, { dryRun = DRY_RUN, resolveSolomon = getActiveSolomonId, insert = insertCoordinationRow, buildFoundations = buildFoundationsPointer } = {}) {
   try {
     const solomonId = await resolveSolomon(sb);
     if (!solomonId) {
@@ -74,13 +114,19 @@ async function dispatchSolomonReminder(sb, { dryRun = DRY_RUN, resolveSolomon = 
       console.log('\n[HOURLY-REVIEW] Solomon: would dispatch reminder to ' + String(solomonId).slice(0, 8) + '. [dry-run, not sent]');
       return { dispatched: false, reason: 'dry_run', target: solomonId };
     }
+    // SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001: only build the foundations pointer on the
+    // real-dispatch path (not on the no-Solomon / dry-run early returns) — cheap, and "re-read only when
+    // not idle" per the SD's cycle-down preservation requirement.
+    const foundationsPointer = await buildFoundations(sb);
+    const body = SOLOMON_REMINDER + '\n\nAlso re-affirm the FOUNDATIONS first-hand (your higher-order-' +
+      'framing and Adam-grounding-completeness duties require current C/M/V grounding): ' + foundationsPointer;
     const row = {
       sender_session: process.env.CLAUDE_SESSION_ID || null,
       sender_type: 'coordinator',
       target_session: solomonId,
       message_type: 'INFO',
       subject: 'Hourly: review your Solomon responsibilities',
-      body: SOLOMON_REMINDER,
+      body: body,
       payload: { kind: 'coordinator_reminder', topic: 'solomon_responsibilities', sent_at: new Date().toISOString() },
       expires_at: new Date(Date.now() + 90 * 60 * 1000).toISOString(),
     };
@@ -195,4 +241,4 @@ if (require.main === module) {
   main().catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
 }
 
-module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER };
+module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer };

--- a/tests/unit/coordinator-hourly-review-solomon-leg.test.js
+++ b/tests/unit/coordinator-hourly-review-solomon-leg.test.js
@@ -5,42 +5,54 @@
  * (returns a verdict, does NOT exit main), dry-run-safe, fail-open. Deps (resolveSolomon/insert) are
  * injectable so the test drives the leg without a live DB. The cycle-down gate is the caller's
  * (assessFleetActivity, checked once) — a quiescent fleet never reaches this leg.
+ *
+ * SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001: the dispatched body now also carries a
+ * FOUNDATIONS pointer (buildFoundationsPointer) — Constitution + Mission/Vision + operating model —
+ * widening the re-affirmation set beyond the role contract. buildFoundations is injectable so these
+ * tests stay DB-free; buildFoundationsPointer itself is unit-tested separately below (fail-open path).
  */
 import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { dispatchSolomonReminder, SOLOMON_REMINDER } = require('../../scripts/coordinator-hourly-review.cjs');
+const { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer } = require('../../scripts/coordinator-hourly-review.cjs');
 
 const sb = {};
 
 describe('dispatchSolomonReminder — the Solomon hourly leg', () => {
-  it('dispatches a coordinator_reminder (topic=solomon_responsibilities) to the LIVE Solomon', async () => {
+  it('dispatches a coordinator_reminder (topic=solomon_responsibilities) to the LIVE Solomon, body = role reminder + foundations pointer', async () => {
     const insert = vi.fn(async () => ({ data: { id: 'row-1' }, error: null }));
-    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => 'solomon-sess-123', insert });
+    const buildFoundations = vi.fn(async () => 'FOUNDATIONS-POINTER-STUB');
+    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => 'solomon-sess-123', insert, buildFoundations });
     expect(r.dispatched).toBe(true);
     expect(r.target).toBe('solomon-sess-123');
+    expect(buildFoundations).toHaveBeenCalledWith(sb);
     const [, row] = insert.mock.calls[0];
     expect(row.target_session).toBe('solomon-sess-123');
     expect(row.payload.kind).toBe('coordinator_reminder');
     expect(row.payload.topic).toBe('solomon_responsibilities'); // mirrors adam_responsibilities
     expect(row.sender_type).toBe('coordinator');
-    expect(row.body).toBe(SOLOMON_REMINDER);
+    expect(row.body).toContain(SOLOMON_REMINDER); // role contract still present
+    expect(row.body).toContain('FOUNDATIONS-POINTER-STUB'); // widened set present
   });
 
   it('skips (no dispatch) when there is no live Solomon — itself a cycle-down', async () => {
     const insert = vi.fn();
-    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => null, insert });
+    const buildFoundations = vi.fn();
+    const r = await dispatchSolomonReminder(sb, { dryRun: false, resolveSolomon: async () => null, insert, buildFoundations });
     expect(r.dispatched).toBe(false);
     expect(r.reason).toBe('no_live_solomon');
     expect(insert).not.toHaveBeenCalled();
+    expect(buildFoundations).not.toHaveBeenCalled(); // no wasted foundations read on a no-Solomon cycle
   });
 
-  it('dry-run: resolves the live Solomon but does NOT dispatch', async () => {
+  it('dry-run: resolves the live Solomon but does NOT dispatch, and does NOT read foundations', async () => {
     const insert = vi.fn();
-    const r = await dispatchSolomonReminder(sb, { dryRun: true, resolveSolomon: async () => 'solomon-sess-123', insert });
+    const buildFoundations = vi.fn();
+    const r = await dispatchSolomonReminder(sb, { dryRun: true, resolveSolomon: async () => 'solomon-sess-123', insert, buildFoundations });
     expect(r.dispatched).toBe(false);
     expect(r.reason).toBe('dry_run');
     expect(insert).not.toHaveBeenCalled();
+    expect(buildFoundations).not.toHaveBeenCalled(); // "re-read only when not idle" — dry-run never dispatches
   });
 
   it('fail-open: a resolve/dispatch error returns a non-dispatched verdict (never throws)', async () => {
@@ -53,5 +65,28 @@ describe('dispatchSolomonReminder — the Solomon hourly leg', () => {
     expect(SOLOMON_REMINDER).toMatch(/CONST-002/);
     expect(SOLOMON_REMINDER).toMatch(/consult triage gate/i);
     expect(SOLOMON_REMINDER).toMatch(/task_budget/);
+  });
+});
+
+describe('buildFoundationsPointer — SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001', () => {
+  it('points at the canonical Constitution, Mission/Vision, and operating-model sources — never embeds full text', async () => {
+    const fakeSb = { from: () => ({ select: () => ({ order: async () => ({ data: [{ rule_code: 'CONST-001' }, { rule_code: 'CONST-014' }] }) }) }) };
+    const pointer = await buildFoundationsPointer(fakeSb);
+    expect(pointer).toMatch(/protocol_constitution/);
+    expect(pointer).toMatch(/CONST-001\.\.CONST-014/);
+    expect(pointer).toMatch(/docs\/vision\/ehg-mission-vision-canonical\.md/);
+    expect(pointer).toMatch(/eva_vision_documents/);
+    expect(pointer).toMatch(/venture-hosting-standard\.md/);
+    expect(pointer).toMatch(/only-the-chairman-can\.md/);
+    // cheap: no full rule/doc text embedded, just pointers + a count
+    expect(pointer.length).toBeLessThan(600);
+  });
+
+  it('fail-open: a DB error still returns a usable static pointer (never throws)', async () => {
+    const throwingSb = { from: () => { throw new Error('db down'); } };
+    const pointer = await buildFoundationsPointer(throwingSb);
+    expect(pointer).toMatch(/protocol_constitution/);
+    expect(pointer).toMatch(/CONST-001\.\.014/);
+    expect(pointer).toMatch(/docs\/vision\/ehg-mission-vision-canonical\.md/);
   });
 });


### PR DESCRIPTION
## Summary
- `scripts/coordinator-hourly-review.cjs` gains `buildFoundationsPointer(sb)`: a cheap, fail-open helper that points Solomon's hourly reminder at the canonical Constitution (`protocol_constitution`, live CONST rule-code range), Mission/Vision (`docs/vision/ehg-mission-vision-canonical.md` + `eva_vision_documents`), and operating-model docs — never embedding full text, so grounding stays first-hand.
- `dispatchSolomonReminder` now composes `body = SOLOMON_REMINDER + foundations pointer`, but only on the real-dispatch path (never on no-Solomon or `--dry-run`), preserving cycle-down + "re-read only when not idle" cost discipline.
- `SOLOMON_REMINDER` itself is unchanged (role-contract text untouched).

## Test plan
- [x] `npx vitest run tests/unit/coordinator-hourly-review-solomon-leg.test.js` — 7/7 pass (updated dispatch tests + new `buildFoundationsPointer` coverage, no live DB required)
- [x] Live-verified `buildFoundationsPointer` against real DB: 378-char pointer, live CONST-001..CONST-014 count, all 4 canonical sources referenced
- [x] `node scripts/coordinator-hourly-review.cjs --dry-run` — clean exit, no dispatch, foundations builder not invoked on dry-run path
- [x] Independently re-verified by TESTING sub-agent (evidence row `d8d33d91`)

SD: SD-LEO-INFRA-SOLOMON-REFRESHER-FOUNDATIONS-EXTENSION-001 (chairman-directed extension of SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)