### PR TITLE
feat(SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001): canonical liveFleetSessions helpers + fix the 1000-row-cap liveness blind spot + a guard

### DIFF
--- a/.github/workflows/fleet-liveness-select-lint.yml
+++ b/.github/workflows/fleet-liveness-select-lint.yml
@@ -1,0 +1,41 @@
+name: Fleet Liveness Select Lint
+
+# SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-4)
+# Bans UNFILTERED claude_sessions / v_active_sessions selects (the PostgREST 1000-row-cap blind
+# spot: an unfiltered .select() returns the OLDEST 1000 rows and drops the newest live workers ->
+# liveness/count reads 0/undercount). A read is safe if it carries any server-side narrowing:
+# a filter, an .order() (order by heartbeat desc => newest 1000), a .limit(), a single-row read,
+# or a count-head query. Route liveness/count through lib/fleet/live-fleet-sessions.cjs
+# (liveFleetSessions / liveActiveSessionsView) or add a bound; or allowlist "<file>:<line>" with a
+# reason in scripts/lint/fleet-liveness-select-allowlist.json.
+#
+# ADVISORY-FIRST: the lint step is `continue-on-error: true` so it CANNOT turn an in-flight PR red
+# on day one. The report is always surfaced in the job log. Flip to blocking (run with --enforce
+# and drop continue-on-error) once the baseline has settled.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.mjs'
+      - '**/*.cjs'
+      - '**/*.ts'
+      - 'scripts/lint/fleet-liveness-select-lint.mjs'
+      - 'scripts/lint/fleet-liveness-select-allowlist.json'
+      - '.github/workflows/fleet-liveness-select-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fleet-liveness-select-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Detect unfiltered claude_sessions/v_active_sessions liveness selects (advisory)
+        continue-on-error: true
+        run: node scripts/lint/fleet-liveness-select-lint.mjs

--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -107,7 +107,11 @@ async function gatherDetectorInputs(supabase, opts) {
       .from('claude_sessions')
       // SD-FDBK-INFRA-DEPLOY-GAP-DETECTOR-001: + created_at (immutable session-start anchor for DEPLOY_GAP).
       // SD-LEO-INFRA-LOOP-LIVENESS-DETECTORS-001: + loop_state, expected_silence_until (loop-liveness detectors).
-      .select('session_id, sd_key, status, heartbeat_at, metadata, current_phase, created_at, loop_state, expected_silence_until');
+      .select('session_id, sd_key, status, heartbeat_at, metadata, current_phase, created_at, loop_state, expected_silence_until')
+      // ROWCAP-CANONICAL-001: order newest-first so the PostgREST 1000-row cap drops only the
+      // STALEST sessions — every derivation below is fresh()-gated, so this is behavior-preserving
+      // while ensuring the newest live/coordinator/adam sessions are never truncated out.
+      .order('heartbeat_at', { ascending: false });
     sessions = data || [];
   } catch (_) { sessions = []; }
 

--- a/lib/coordinator/fleet-quiescence.cjs
+++ b/lib/coordinator/fleet-quiescence.cjs
@@ -27,6 +27,7 @@
  */
 
 const { getAliveCcPids } = require('../fleet/cc-pid-liveness.cjs');
+const { liveActiveSessionsView } = require('../fleet/live-fleet-sessions.cjs');
 
 const FRESH_S = Number(process.env.QUIESCENCE_FRESH_SECONDS || 300);
 
@@ -71,10 +72,14 @@ async function assessFleetActivity(sb, opts) {
   const now = (opts && opts.now) || Date.now();
   const signals = { liveActiveWorkers: 0, inProgressBuilds: 0, recentTransitions: 0, error: null };
   try {
-    const { data: sessions, error: sErr } = await sb
-      .from('v_active_sessions')
-      .select('session_id, sd_key, heartbeat_age_seconds, computed_status, terminal_id');
-    if (sErr) throw sErr;
+    // ROWCAP-CANONICAL-001: bounded via the canonical view helper (.order(heartbeat_age_seconds
+    // asc).limit) so the freshest live sessions are always in the page — an unfiltered
+    // v_active_sessions select is PostgREST-capped at the oldest 1000 of >5.9k rows and dropped
+    // the newest live workers (a candidate cause of false quiescence). The helper THROWS on a
+    // query error, which the catch below turns into fail-OPEN-to-ACTIVE (the safe direction).
+    const sessions = await liveActiveSessionsView(sb, {
+      columns: 'session_id, sd_key, heartbeat_age_seconds, computed_status, terminal_id',
+    });
     // SD-REFILL-00IO6NQJ: PID-aliveness from the SessionStart markers, OR'd onto the
     // heartbeat window so a parked /loop worker (stale heartbeat, live CC process) still
     // counts. opts.aliveCcPids lets unit tests inject the set; otherwise read the markers.

--- a/lib/fleet/live-fleet-sessions.cjs
+++ b/lib/fleet/live-fleet-sessions.cjs
@@ -1,0 +1,115 @@
+'use strict';
+/**
+ * Canonical live-fleet-session query helpers — the SINGLE server-side-bounded path for
+ * "which claude_sessions rows are live fleet workers / how many". Generalizes the
+ * isTieringActive fix (#5303) so no caller re-implements the buggy pattern.
+ *
+ * THE BUG THIS CLOSES: an UNFILTERED `claude_sessions.select()` is capped by PostgREST at
+ * 1000 rows and returns the OLDEST 1000 of ~13k, so the NEWEST live workers are EXCLUDED and
+ * any liveness/count read returns 0 or undercounts (the false "0 LIVE workers" fleet-winddown
+ * alarm; a candidate cause of Adam's inbox-drain miss). Because these helpers order by
+ * heartbeat_at DESC, `.limit(N)` only ever truncates the STALEST rows — the newest live
+ * workers are ALWAYS in the returned page.
+ *
+ * Liveness SEMANTICS are NOT re-implemented here: the page is piped through the JS-side SSOT
+ * `liveFleetWorkers()` (lib/fleet/genuine-worker.mjs). This module only owns the bounded QUERY.
+ *
+ * Module is CommonJS and dynamic-import()s the ESM genuine-worker.mjs (same pattern as
+ * lib/fleet/tier-ladder.cjs) so both CJS (require) and ESM callers can use it.
+ *
+ * SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-1, FR-2).
+ */
+
+/**
+ * The claude_sessions columns liveFleetWorkers()/isFleetWorker()/everClaimed() require.
+ * Kept identical to the isTieringActive select (#5303) so the liveness SSOT gets every field.
+ */
+const LIVE_SESSION_COLUMNS =
+  'session_id, status, metadata, heartbeat_at, sd_key, claimed_at, worktree_path, continuous_sds_completed';
+
+/**
+ * Defaults. `limit` MUST exceed peak concurrent live-in-window; because rows are ordered
+ * heartbeat_at DESC the cap only ever drops the STALEST rows, so 200 (~22x the current ~9
+ * live) is safe headroom that also absorbs the belt-depth 3x-worker growth target. `windowMs`
+ * and `statuses` mirror the liveness SSOT (15-min window; active/idle are the live statuses).
+ */
+const LIVE_FLEET_DEFAULTS = Object.freeze({ windowMs: 900000, limit: 200, statuses: ['active', 'idle'] });
+
+/** Resolve the active coordinator id (excluded from the fleet) unless the caller supplied one. */
+async function resolveCoordinatorId(supabase, opts) {
+  if (opts.coordinatorId !== undefined) return opts.coordinatorId;
+  try {
+    const { getActiveCoordinatorId } = require('../coordinator/resolve.cjs');
+    return await getActiveCoordinatorId(supabase).catch(() => null);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Live genuine fleet workers from the claude_sessions BASE TABLE, server-side bounded.
+ * @param {object} supabase a supabase client (service-role preferred so reads aren't RLS-filtered)
+ * @param {{nowMs?:number, windowMs?:number, limit?:number, statuses?:string[], coordinatorId?:string|null}} [opts]
+ * @returns {Promise<Array<object>>} live genuine worker session rows ([] on query error — fail-closed)
+ */
+async function liveFleetSessions(supabase, opts = {}) {
+  const { liveFleetWorkers } = await import('./genuine-worker.mjs');
+  const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+  const windowMs = Number.isFinite(opts.windowMs) ? opts.windowMs : LIVE_FLEET_DEFAULTS.windowMs;
+  const limit = Number.isFinite(opts.limit) ? opts.limit : LIVE_FLEET_DEFAULTS.limit;
+  const statuses = Array.isArray(opts.statuses) ? opts.statuses : LIVE_FLEET_DEFAULTS.statuses;
+  const coordinatorId = await resolveCoordinatorId(supabase, opts);
+
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select(LIVE_SESSION_COLUMNS)
+    .in('status', statuses)
+    .gte('heartbeat_at', new Date(nowMs - windowMs).toISOString())
+    .order('heartbeat_at', { ascending: false })
+    .limit(limit);
+  if (error || !Array.isArray(data)) return []; // fail-closed: an error is not "0 live", but callers treat [] safely
+  return liveFleetWorkers(data, coordinatorId, nowMs, windowMs);
+}
+
+/** Convenience: the COUNT of live genuine fleet workers (what most gauges actually want). */
+async function liveFleetSessionCount(supabase, opts = {}) {
+  return (await liveFleetSessions(supabase, opts)).length;
+}
+
+/**
+ * Live rows from the v_active_sessions VIEW, server-side bounded. The base-table helper can't
+ * serve view consumers: v_active_sessions exposes computed-only columns (computed_status,
+ * heartbeat_age_seconds, ccPidAlive) absent from claude_sessions, and it too exceeds 1000 rows,
+ * so an unfiltered `.from('v_active_sessions').select()` is capped and drops the freshest.
+ * We bound it by `.order('heartbeat_age_seconds', asc).limit(N)` — freshest first, so the cap
+ * only drops the STALEST — and return the view rows unchanged (callers use the computed columns).
+ *
+ * FAIL DIRECTION — deliberately OPPOSITE to liveFleetSessions(): this helper PROPAGATES (throws)
+ * on a query error rather than returning []. Its safety-critical consumer is the quiescence
+ * gauge (assessFleetActivity), which must fail OPEN to ACTIVE — "never silence the fleet on a
+ * query error." Swallowing to [] here would read 0-live-and-quiescent on a transient error and
+ * could trigger a FALSE wind-down (the very class this SD closes). The caller's own try/catch
+ * decides the fail direction; do NOT swallow here.
+ * @param {object} supabase a supabase client
+ * @param {{limit?:number, columns?:string}} [opts]
+ * @returns {Promise<Array<object>>} the freshest live view rows (THROWS on query error)
+ */
+async function liveActiveSessionsView(supabase, opts = {}) {
+  const limit = Number.isFinite(opts.limit) ? opts.limit : LIVE_FLEET_DEFAULTS.limit;
+  const columns = typeof opts.columns === 'string' ? opts.columns : '*';
+  const { data, error } = await supabase
+    .from('v_active_sessions')
+    .select(columns)
+    .order('heartbeat_age_seconds', { ascending: true })
+    .limit(limit);
+  if (error) throw error; // fail-OPEN: let the caller's catch decide (quiescence fails to ACTIVE)
+  return Array.isArray(data) ? data : [];
+}
+
+module.exports = {
+  liveFleetSessions,
+  liveFleetSessionCount,
+  liveActiveSessionsView,
+  LIVE_FLEET_DEFAULTS,
+  LIVE_SESSION_COLUMNS,
+};

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "protocol:lint:review": "node scripts/protocol-lint/cli.mjs review",
     "lint:metadata-flags": "node scripts/lint/metadata-flag-lint.mjs",
     "lint:env-flags": "node scripts/lint/process-env-feature-flag-lint.mjs",
+    "lint:fleet-liveness-select": "node scripts/lint/fleet-liveness-select-lint.mjs",
     "lint:alter-defaults": "node scripts/lint/alter-default-override-lint.mjs",
     "lint:venture-artifacts": "node scripts/lint/venture-artifacts-write-lint.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",

--- a/scripts/coordinator-revive.cjs
+++ b/scripts/coordinator-revive.cjs
@@ -20,6 +20,7 @@ const { createClient } = require('@supabase/supabase-js');
 // (the SPAWN_REQUEST broadcast below uses the 'broadcast' sentinel, which the
 // guard short-circuits — exercising the sentinel-allowlist path).
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { liveActiveSessionsView } = require('../lib/fleet/live-fleet-sessions.cjs');
 
 const NATO = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
 
@@ -38,10 +39,12 @@ function getSupabase() {
  * @returns {Promise<string[]>} Sorted list of idle callsigns (subset of NATO).
  */
 async function findIdleCallsigns(supabase) {
-  const { data: sessions, error } = await supabase
-    .from('v_active_sessions')
-    .select('session_id, metadata, computed_status, heartbeat_age_seconds');
-  if (error) throw new Error(`v_active_sessions query failed: ${error.message}`);
+  // ROWCAP-CANONICAL-001: bounded via the canonical view helper (freshest-first + .limit) so the
+  // 1000-row cap can't hide the newest active callsigns. The helper throws on a query error,
+  // preserving the previous fail-loud behavior of this revival path.
+  const sessions = await liveActiveSessionsView(supabase, {
+    columns: 'session_id, metadata, computed_status, heartbeat_age_seconds',
+  });
 
   const activeCallsigns = new Set();
   for (const s of sessions || []) {

--- a/scripts/fleet/worker-spawn-executor.cjs
+++ b/scripts/fleet/worker-spawn-executor.cjs
@@ -117,11 +117,12 @@ async function loadPendingRequests(sb, nowIso) {
 
 /** Callsigns already backed by a live session (from claude_sessions.metadata.fleet_identity.callsign). */
 async function deriveLiveCallsigns(sb) {
+  const { liveActiveSessionsView } = require('../../lib/fleet/live-fleet-sessions.cjs');
   const set = new Set();
   try {
-    const { data } = await sb
-      .from('v_active_sessions')
-      .select('session_id, metadata, computed_status');
+    // ROWCAP-CANONICAL-001: bounded via the canonical view helper (freshest-first + .limit) so the
+    // 1000-row cap can't hide live callsigns. The helper throws on error -> caught below (fail-soft).
+    const data = await liveActiveSessionsView(sb, { columns: 'session_id, metadata, computed_status' });
     for (const s of data || []) {
       const cs = s && s.metadata && s.metadata.fleet_identity && s.metadata.fleet_identity.callsign;
       if (cs && s.computed_status === 'active') set.add(cs);

--- a/scripts/lint/fleet-liveness-select-allowlist.json
+++ b/scripts/lint/fleet-liveness-select-allowlist.json
@@ -1,0 +1,4 @@
+{
+  "_doc": "SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-4). Keys are '<repo-relative-file>:<line>' (or a bare '<file>' to exempt a whole file) for an UNBOUNDED claude_sessions/v_active_sessions multi-row select that is intentionally exempt from the 1000-row-cap guard. Every entry MUST carry a non-empty reason. Prefer FIXING (route through lib/fleet/live-fleet-sessions.cjs or add .gte(heartbeat_at)/.order+.limit) over allowlisting.",
+  "allow": {}
+}

--- a/scripts/lint/fleet-liveness-select-allowlist.json
+++ b/scripts/lint/fleet-liveness-select-allowlist.json
@@ -1,4 +1,6 @@
 {
   "_doc": "SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-4). Keys are '<repo-relative-file>:<line>' (or a bare '<file>' to exempt a whole file) for an UNBOUNDED claude_sessions/v_active_sessions multi-row select that is intentionally exempt from the 1000-row-cap guard. Every entry MUST carry a non-empty reason. Prefer FIXING (route through lib/fleet/live-fleet-sessions.cjs or add .gte(heartbeat_at)/.order+.limit) over allowlisting.",
-  "allow": {}
+  "allow": {
+    "tests/unit/lint/fleet-liveness-select-lint.test.js": "The guard's OWN unit test — it contains deliberately-buggy unfiltered-select string literals as fixtures to prove the extractor flags them. Not real queries; exempt so the guard does not flag its own test (important once the workflow flips to --enforce)."
+  }
 }

--- a/scripts/lint/fleet-liveness-select-lint.mjs
+++ b/scripts/lint/fleet-liveness-select-lint.mjs
@@ -1,0 +1,145 @@
+// fleet-liveness-select-lint.mjs — ban UNBOUNDED claude_sessions / v_active_sessions
+// multi-row selects (the PostgREST 1000-row-cap blind spot: an unfiltered .select() returns
+// the OLDEST 1000 rows and drops the newest live workers -> liveness/count reads 0/undercount).
+// SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-4). Mirrors the structure of
+// scripts/lint/process-env-feature-flag-lint.mjs (pure extractors + reason-required allowlist +
+// tree scan). ADVISORY-FIRST: exit 0 by default; pass --enforce for exit 1.
+//
+// A read is SAFE (not flagged) when ANY of:
+//   • it carries a server-side bound: `.gte('heartbeat_at', …)` OR (`.order(` AND `.limit(`)
+//     — ordering by heartbeat_at/heartbeat_age_seconds means the cap only drops the STALEST rows;
+//   • it is a single-row lookup: `.eq('session_id', …)` / `.single()` / `.maybeSingle()`;
+//   • it is an exact-count head query: `count:` + `head:`;
+//   • it routes through the canonical helper (lib/fleet/live-fleet-sessions.cjs — which is itself
+//     bound, so its own query is safe by the first rule).
+// Anything else is a latent cap victim; fix it (use liveFleetSessions/liveActiveSessionsView or add
+// a bound) or allowlist it with a reason (e.g. an intentional full-table sweep).
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join, extname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const SCAN_EXTS = new Set(['.js', '.mjs', '.cjs', '.ts']);
+const EXCLUDE = new Set(['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive']);
+const ALLOWLIST_PATH = resolve(ROOT, 'scripts/lint/fleet-liveness-select-allowlist.json');
+
+const TARGET_TABLES = ['claude_sessions', 'v_active_sessions'];
+
+/**
+ * Strip // line and block comments so commented-out queries do not register, PRESERVING line
+ * count (block comments become the same newlines they spanned; line comments keep their newline)
+ * so reported line numbers match the original source (allowlist keys are "<file>:<line>").
+ */
+export function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (_m, p1) => p1);
+}
+
+/**
+ * Is this claude_sessions/v_active_sessions read SAFE from the 1000-row cap? This guard targets the
+ * exact pattern the SD names — an UNFILTERED select (like assessFleetActivity's original bare
+ * `.from('v_active_sessions').select(cols)`), which PostgREST caps at the OLDEST 1000 rows. A read
+ * is SAFE when it carries ANY server-side narrowing/paging: any filter, an `.order()` (ordering by
+ * heartbeat desc returns the NEWEST 1000), a `.limit()`, a single-row read, or a count-head query.
+ * (Status-filtered-but-unbounded scans, e.g. `.in('status',[active,idle])` with no limit, are a
+ * broader latent class the SD scopes OUT — they filter server-side and are safe at today's < 1000
+ * active; a follow-up may tighten them. This guard prevents the UNFILTERED regression.)
+ */
+function isSafeChain(chain) {
+  if (/\.limit\(/.test(chain)) return true;
+  if (/\.order\(/.test(chain)) return true; // order(heartbeat desc) => newest 1000 in the page
+  if (/\.maybeSingle\(\)|\.single\(\)/.test(chain)) return true;
+  // ANY server-side narrowing filter means it is not the "unfiltered" pattern.
+  if (/\.(eq|in|not|filter|gt|gte|lt|lte|is|like|ilike|neq|contains|match|or|overlaps)\(/.test(chain)) return true;
+  // exact-count head query (server computes the count; no rows paged).
+  if (/count\s*:/.test(chain) && /head\s*:/.test(chain)) return true;
+  return false;
+}
+
+/**
+ * Find UNBOUNDED multi-row reads on the target tables. Returns [{table, line, snippet}].
+ * For each `.from('<table>')` that is part of a `.select(` read, we inspect the query chain from
+ * that `.from(` up to the statement end (next ';' or a char cap) and flag it if no bound/exemption
+ * is present in that window. Pure + string-only so it is unit-testable.
+ * @param {string} src
+ * @returns {Array<{table:string, line:number, snippet:string}>}
+ */
+export function extractUnboundedLivenessSelects(src) {
+  const clean = stripComments(src);
+  const findings = [];
+  const fromRe = /\.from\(\s*['"](claude_sessions|v_active_sessions)['"]\s*\)/g;
+  let m;
+  while ((m = fromRe.exec(clean)) !== null) {
+    const table = m[1];
+    const start = m.index;
+    // Chain window: from `.from(` to the FIRST of {next ';' (statement end), the next `.from(`
+    // (a following query), start+500} — so the window never bleeds into an adjacent statement.
+    const semi = clean.indexOf(';', start);
+    const nextFrom = clean.indexOf('.from(', start + 6);
+    const bounds = [semi, nextFrom, start + 500, clean.length].filter((n) => n !== -1 && n > start);
+    const end = Math.min(...bounds);
+    const chain = clean.slice(start, end);
+    if (!/\.select\(/.test(chain)) continue; // not a read (insert/update/delete/upsert)
+    if (isSafeChain(chain)) continue;
+    const line = clean.slice(0, start).split('\n').length;
+    findings.push({ table, line, snippet: chain.replace(/\s+/g, ' ').slice(0, 120) });
+  }
+  return findings;
+}
+
+export function loadAllowlist(path = ALLOWLIST_PATH) {
+  let raw;
+  try { raw = readFileSync(path, 'utf8'); } catch { return {}; }
+  let json;
+  try { json = JSON.parse(raw); } catch (e) { throw new Error(`Invalid allowlist JSON at ${path}: ${e.message}`); }
+  const entries = json.allow || json;
+  for (const [k, v] of Object.entries(entries)) {
+    if (!v || typeof v !== 'string' || !v.trim()) throw new Error(`Allowlist entry '${k}' must have a non-empty reason string`);
+  }
+  return entries;
+}
+
+const relOf = (full) => full.replace(ROOT, '').replace(/\\/g, '/').replace(/^\//, '');
+
+export function scanTree(root = ROOT) {
+  const hits = []; // { file, table, line, snippet }
+  const walk = (dir) => {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const e of entries) {
+      if (EXCLUDE.has(e)) continue;
+      const full = join(dir, e);
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) { walk(full); continue; }
+      if (!SCAN_EXTS.has(extname(e))) continue;
+      let src;
+      try { src = readFileSync(full, 'utf8'); } catch { continue; }
+      for (const f of extractUnboundedLivenessSelects(src)) {
+        hits.push({ file: relOf(full), ...f });
+      }
+    }
+  };
+  walk(root);
+  return hits;
+}
+
+async function main() {
+  const enforce = process.argv.includes('--enforce');
+  const allow = loadAllowlist();
+  const hits = scanTree();
+  const ungoverned = hits.filter((h) => !(`${h.file}:${h.line}` in allow) && !(h.file in allow));
+  console.log(`[FLEET-LIVENESS-LINT] scanned tree; ${hits.length} unbounded ${TARGET_TABLES.join('/')} select(s); ${ungoverned.length} ungoverned.`);
+  if (ungoverned.length) {
+    console.log('  Unbounded liveness/count selects (use liveFleetSessions()/liveActiveSessionsView() or add .gte(heartbeat_at)/.order+.limit; or allowlist "<file>:<line>" with a reason):');
+    for (const u of ungoverned) console.log(`   • ${u.file}:${u.line} [${u.table}] ${u.snippet}`);
+  } else {
+    console.log('  All liveness/count selects are server-side bounded or allowlisted. 0 ungoverned.');
+  }
+  if (enforce && ungoverned.length) process.exitCode = 1;
+}
+
+if (process.argv[1] && /fleet-liveness-select-lint\.mjs$/.test(process.argv[1].replace(/\\/g, '/'))) {
+  main();
+}

--- a/tests/unit/coordinator-revive.test.js
+++ b/tests/unit/coordinator-revive.test.js
@@ -25,8 +25,17 @@ function mockSupabase({ activeSessions = [], insertResult = null, insertError = 
   return {
     from: (table) => {
       if (table === 'v_active_sessions') {
+        // ROWCAP-CANONICAL-001: findIdleCallsigns now routes through liveActiveSessionsView(),
+        // which chains .select().order().limit(); make the mock chainable + awaitable.
         return {
-          select: () => Promise.resolve({ data: activeSessions, error: null })
+          select: () => {
+            const chain = {
+              order: () => chain,
+              limit: () => chain,
+              then: (resolve) => resolve({ data: activeSessions, error: null }),
+            };
+            return chain;
+          },
         };
       }
       if (table === 'worker_spawn_requests') {

--- a/tests/unit/fleet-quiescence-pid-liveness.test.js
+++ b/tests/unit/fleet-quiescence-pid-liveness.test.js
@@ -20,6 +20,8 @@ function makeSb(resolver) {
       eq(col, val) { ctx.filters.push(['eq', col, val]); return b; },
       gte(col, val) { ctx.filters.push(['gte', col, val]); return b; },
       in(col, val) { ctx.filters.push(['in', col, val]); return b; },
+      order(col, opts) { ctx.filters.push(['order', col, opts]); return b; },
+      limit(n) { ctx.filters.push(['limit', n]); return b; },
       then(onF, onR) {
         let result;
         try { result = resolver(ctx); } catch (e) { return Promise.resolve().then(() => { throw e; }).then(onF, onR); }

--- a/tests/unit/fleet-quiescence-recent-transition.test.js
+++ b/tests/unit/fleet-quiescence-recent-transition.test.js
@@ -26,6 +26,8 @@ function makeSb(resolver) {
       eq(col, val) { ctx.filters.push(['eq', col, val]); return b; },
       gte(col, val) { ctx.filters.push(['gte', col, val]); return b; },
       in(col, val) { ctx.filters.push(['in', col, val]); return b; },
+      order(col, opts) { ctx.filters.push(['order', col, opts]); return b; },
+      limit(n) { ctx.filters.push(['limit', n]); return b; },
       then(onF, onR) {
         let result;
         try { result = resolver(ctx); } catch (e) { return Promise.resolve().then(function () { throw e; }).then(onF, onR); }

--- a/tests/unit/fleet/live-fleet-sessions.test.js
+++ b/tests/unit/fleet/live-fleet-sessions.test.js
@@ -1,0 +1,120 @@
+// SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-1, FR-2, FR-5).
+// Proves the canonical helpers bound the query SERVER-SIDE so the newest live workers are in
+// the returned page even past PostgREST's 1000-row cap — and that the old unfiltered
+// fetch-1000-then-filter pattern returns 0/undercount for the same fixture.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  liveFleetSessions,
+  liveFleetSessionCount,
+  liveActiveSessionsView,
+  LIVE_FLEET_DEFAULTS,
+} = require('../../../lib/fleet/live-fleet-sessions.cjs');
+const { liveFleetWorkers } = await import('../../../lib/fleet/genuine-worker.mjs');
+
+/** A live genuine-worker row (passes isFleetWorker + everClaimed + heartbeat window). */
+function liveRow(i, heartbeatIso) {
+  return {
+    session_id: `w-${i}`, status: 'active', metadata: {},
+    heartbeat_at: heartbeatIso || new Date().toISOString(),
+    sd_key: `SD-LIVE-${i}`, claimed_at: new Date().toISOString(),
+    worktree_path: `/wt/${i}`, continuous_sds_completed: 1,
+  };
+}
+/** A stale/released ghost row (fails liveness). */
+function staleRow(i) {
+  return {
+    session_id: `stale-${i}`, status: 'released', metadata: {},
+    heartbeat_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0,
+  };
+}
+
+/**
+ * Minimal supabase stub. `pageByTable[table]` is the data the bounded query returns; `errByTable`
+ * injects a query error. Records the last query chain per table on `_last[table]`.
+ */
+function stubSupabase({ pageByTable = {}, errByTable = {} } = {}) {
+  const _last = {};
+  return {
+    _last,
+    from(table) {
+      const q = { table, in: null, gte: null, order: null, limit: null };
+      _last[table] = q;
+      const api = {
+        select() { return api; },
+        in(col, vals) { q.in = { col, vals }; return api; },
+        gte(col, val) { q.gte = { col, val }; return api; },
+        order(col, opts) { q.order = { col, opts }; return api; },
+        limit(n) { q.limit = n; return api; },
+        then(resolve) {
+          return resolve({ data: pageByTable[table] ?? [], error: errByTable[table] ?? null });
+        },
+      };
+      return api;
+    },
+  };
+}
+
+describe('liveFleetSessions() — canonical base-table helper (FR-1)', () => {
+  it('constructs a bounded query: status in [active,idle], heartbeat >= now-window, ordered desc, limit>=200', async () => {
+    const nowMs = 1_800_000_000_000;
+    const sb = stubSupabase({ pageByTable: { claude_sessions: [liveRow(0)] } });
+    await liveFleetSessions(sb, { nowMs, coordinatorId: null });
+    const q = sb._last.claude_sessions;
+    expect(q.in).toMatchObject({ col: 'status', vals: ['active', 'idle'] });
+    expect(q.gte.col).toBe('heartbeat_at');
+    expect(new Date(q.gte.val).getTime()).toBe(nowMs - LIVE_FLEET_DEFAULTS.windowMs);
+    expect(q.order).toMatchObject({ col: 'heartbeat_at', opts: { ascending: false } });
+    expect(q.limit).toBe(LIVE_FLEET_DEFAULTS.limit);
+  });
+
+  it('returns the newest live workers even when they sit past row 1000 (the bounded page contains them)', async () => {
+    // The server-side .order(desc).limit(N) means the page the DB returns is exactly the newest
+    // N rows — the live workers — NOT the oldest 1000. We model that: the bounded page holds the
+    // 3 live workers (what the DB returns AFTER order+limit), even though the table has >1000 rows.
+    const page = [liveRow(0), liveRow(1), liveRow(2)];
+    const sb = stubSupabase({ pageByTable: { claude_sessions: page } });
+    const live = await liveFleetSessions(sb, { coordinatorId: null });
+    expect(live.map((s) => s.session_id).sort()).toEqual(['w-0', 'w-1', 'w-2']);
+    expect(await liveFleetSessionCount(sb, { coordinatorId: null })).toBe(3);
+  });
+
+  it('CONTRAST: the naive unfiltered fetch-1000-then-filter path returns 0 for the same >1000-row table', async () => {
+    // The old bug: an unbounded/unordered select returns the OLDEST 1000 rows — all stale ghosts,
+    // none of the recent live workers. Filtering that page in JS yields 0 live workers.
+    const oldest1000 = Array.from({ length: 1000 }, (_, i) => staleRow(i));
+    expect(liveFleetWorkers(oldest1000, null, Date.now()).length).toBe(0);
+  });
+
+  it('fail-CLOSED: returns [] on a query error (a gauge reading 0 on error is harmless)', async () => {
+    const sb = stubSupabase({ errByTable: { claude_sessions: { message: 'boom' } } });
+    expect(await liveFleetSessions(sb, { coordinatorId: null })).toEqual([]);
+  });
+});
+
+describe('liveActiveSessionsView() — canonical view helper (FR-2)', () => {
+  it('bounds the v_active_sessions query: order(heartbeat_age_seconds asc).limit(N), returns rows', async () => {
+    const rows = [{ session_id: 'a', computed_status: 'active', heartbeat_age_seconds: 5 }];
+    const sb = stubSupabase({ pageByTable: { v_active_sessions: rows } });
+    const out = await liveActiveSessionsView(sb, { columns: 'session_id, computed_status, heartbeat_age_seconds' });
+    expect(out).toEqual(rows);
+    const q = sb._last.v_active_sessions;
+    expect(q.order).toMatchObject({ col: 'heartbeat_age_seconds', opts: { ascending: true } });
+    expect(q.limit).toBe(LIVE_FLEET_DEFAULTS.limit);
+  });
+
+  it('fail-OPEN: THROWS on a query error so the quiescence caller fails to ACTIVE (never silent-quiescent)', async () => {
+    const sb = stubSupabase({ errByTable: { v_active_sessions: { message: 'view boom' } } });
+    await expect(liveActiveSessionsView(sb)).rejects.toMatchObject({ message: 'view boom' });
+  });
+});
+
+describe('LIVE_FLEET_DEFAULTS invariant (FR-1/TR-2)', () => {
+  it('limit is generous (>=200) so the cap only ever drops the stalest, never a live worker', () => {
+    expect(LIVE_FLEET_DEFAULTS.limit).toBeGreaterThanOrEqual(200);
+    expect(LIVE_FLEET_DEFAULTS.statuses).toEqual(['active', 'idle']);
+    expect(LIVE_FLEET_DEFAULTS.windowMs).toBe(900000);
+  });
+});

--- a/tests/unit/lint/fleet-liveness-select-lint.test.js
+++ b/tests/unit/lint/fleet-liveness-select-lint.test.js
@@ -1,0 +1,73 @@
+// SD-LEO-INFRA-LIVE-FLEET-SESSIONS-ROWCAP-CANONICAL-001 (FR-4).
+// The guard flags UNFILTERED claude_sessions/v_active_sessions selects (the 1000-row-cap shape)
+// and leaves any server-side-narrowed/bounded/scoped read alone.
+import { describe, it, expect } from 'vitest';
+import { extractUnboundedLivenessSelects, stripComments, loadAllowlist } from '../../../scripts/lint/fleet-liveness-select-lint.mjs';
+
+describe('extractUnboundedLivenessSelects', () => {
+  it('FLAGS a bare unfiltered v_active_sessions select (the assessFleetActivity-class bug)', () => {
+    const src = `const { data } = await sb.from('v_active_sessions').select('session_id, computed_status');`;
+    const hits = extractUnboundedLivenessSelects(src);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].table).toBe('v_active_sessions');
+  });
+
+  it('FLAGS a bare unfiltered claude_sessions select', () => {
+    const src = `await supabase.from("claude_sessions").select('session_id, status, heartbeat_at, metadata');`;
+    expect(extractUnboundedLivenessSelects(src)).toHaveLength(1);
+  });
+
+  it('does NOT flag a select bounded by .order() (newest-first => cap drops only the stalest)', () => {
+    const src = `await sb.from('claude_sessions').select('session_id').order('heartbeat_at', { ascending: false });`;
+    expect(extractUnboundedLivenessSelects(src)).toHaveLength(0);
+  });
+
+  it('does NOT flag a select bounded by .gte(heartbeat_at) or .limit()', () => {
+    const gte = `await sb.from('claude_sessions').select('*').gte('heartbeat_at', since);`;
+    const lim = `await sb.from('v_active_sessions').select('*').limit(200);`;
+    expect(extractUnboundedLivenessSelects(gte)).toHaveLength(0);
+    expect(extractUnboundedLivenessSelects(lim)).toHaveLength(0);
+  });
+
+  it('does NOT flag a status-filtered select (out of scope — filtered, not the unfiltered bug)', () => {
+    const src = `await sb.from('v_active_sessions').select('session_id').in('computed_status', ['active','idle']);`;
+    expect(extractUnboundedLivenessSelects(src)).toHaveLength(0);
+  });
+
+  it('does NOT flag a single-session lookup or a count-head query', () => {
+    const single = `await sb.from('claude_sessions').select('metadata').eq('session_id', id).maybeSingle();`;
+    const count = `await sb.from('claude_sessions').select('session_id', { count: 'exact', head: true }).eq('status','active');`;
+    expect(extractUnboundedLivenessSelects(single)).toHaveLength(0);
+    expect(extractUnboundedLivenessSelects(count)).toHaveLength(0);
+  });
+
+  it('does NOT flag a non-read (insert/update/delete) on the table', () => {
+    const src = `await sb.from('claude_sessions').update({ status: 'released' }).eq('session_id', id);`;
+    expect(extractUnboundedLivenessSelects(src)).toHaveLength(0);
+  });
+
+  it('reports the ORIGINAL source line (stripComments preserves line count)', () => {
+    const src = [
+      "// line 1 comment",
+      "/* a",
+      "   multi-line block comment",
+      "*/",
+      "await sb.from('v_active_sessions').select('session_id, computed_status');",
+    ].join('\n');
+    const hits = extractUnboundedLivenessSelects(src);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].line).toBe(5);
+  });
+
+  it('does NOT flag a commented-out query', () => {
+    const src = `// await sb.from('claude_sessions').select('session_id');`;
+    expect(extractUnboundedLivenessSelects(stripComments(src))).toHaveLength(0);
+  });
+});
+
+describe('loadAllowlist', () => {
+  it('loads the real allowlist and enforces the non-empty-reason contract', () => {
+    // The shipped allowlist is valid (each entry, if any, has a reason). Should not throw.
+    expect(() => loadAllowlist()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Chairman-directed (2026-07-01: *"Adam cannot see beyond 1000 records"*), fleet_critical. PostgREST caps an **unfiltered** `claude_sessions`/`v_active_sessions` `.select()` at 1000 rows and returns the **oldest** 1000 of ~13k — so the newest live workers are excluded and liveness/count reads 0/undercount. This produced a false **"0 LIVE workers"** wind-down alarm (6 were live).

## What shipped (3 commits)
- **FR-1** `lib/fleet/live-fleet-sessions.cjs` — `liveFleetSessions()`: server-side bounded base-table query (`.in(status,[active,idle]).gte(heartbeat_at,now-window).order(heartbeat_at,desc).limit(200)`) piped through the `liveFleetWorkers()` SSOT. **Fail-CLOSED** (`[]`) — a gauge reading 0 on a transient error is harmless.
- **FR-2** `liveActiveSessionsView()` — bounds the `v_active_sessions` view (`.order(heartbeat_age_seconds,asc).limit`) for consumers whose computed columns the base table lacks. **Fail-OPEN** (throws) — its consumer `assessFleetActivity` must fail to ACTIVE, never silent-quiescent (that would re-create the wind-down bug). Migrated `assessFleetActivity` (the actual current-bug site, on the coordinator's own quiescence path) onto it, preserving fail-open-to-ACTIVE.
- **FR-3** — the FR-4 guard **surfaced 3 more real unfiltered cap-victims** the manual scope missed, all fixed: `coordinator-revive.findIdleCallsigns` (fail-loud) + `worker-spawn-executor.deriveLiveCallsigns` (fail-soft) → the view helper; `coordination-events` → added `.order(heartbeat_at,desc)`. Already-bounded gauges are **grandfathered** (cap-safe; the guard enforces boundedness) — the "migrate all onto the live-only helper" premise didn't fit multi-window/multi-column sites; design fork signaled to the coordinator.
- **FR-4** `scripts/lint/fleet-liveness-select-lint.mjs` — bans **unfiltered** liveness selects (safe = any filter / `.order` / `.limit` / single-row / count-head). Reason-required allowlist, advisory-first workflow, `npm run lint:fleet-liveness-select`. Reports **0 ungoverned**; `--enforce` exits 0.
- **FR-5** row-cap regression test (bounded-query shape, tail-live-workers-past-cap contrast, fail-direction) + guard unit test.

## Fail-direction design (deliberate, documented, tested)
`liveFleetSessions` fail-CLOSED (gauges) vs `liveActiveSessionsView` fail-OPEN (quiescence). Getting the error direction right on the safety gauge matters as much as the query fix.

## Verification
- **437/437** affected tests green (fleet + lint + coordinator + quiescence, 35 files).
- TESTING (EXEC) PASS; VALIDATION + REGRESSION (PLAN_VERIFICATION) PASS — all 3 fail-directions (open/loud/soft) confirmed preserved; retro quality 90.
- No schema change.

## Follow-up (VALIDATION LOW note)
Optional future SD to tighten status-filtered-but-unbounded selects if active/idle sessions ever approach 1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)