### PR TITLE
fix(QF-20260701-510): remaining .catch() calls on PostgREST-builder thenables in error-recovery-orchestrator.js

### DIFF
--- a/lib/eva/error-recovery-orchestrator.js
+++ b/lib/eva/error-recovery-orchestrator.js
@@ -35,7 +35,7 @@ export async function withCircuitBreaker(supabase, serviceName, fn) {
     .select('circuit_breaker_state, failure_count, last_failure_at')
     .eq('service_name', serviceName)
     .single()
-    .catch(() => ({ data: null }));
+    .then(r => r, () => ({ data: null }));
 
   const state = data?.circuit_breaker_state || 'CLOSED';
   const RECOVERY_WINDOW_MS = 60 * 60 * 1000;
@@ -58,7 +58,7 @@ export async function withCircuitBreaker(supabase, serviceName, fn) {
       circuit_breaker_state: 'CLOSED',
       failure_count: 0,
       last_success_at: new Date().toISOString(),
-    }, { onConflict: 'service_name' }).catch(() => {});
+    }, { onConflict: 'service_name' }).then(r => r, () => {});
     return result;
   } catch (err) {
     // Record failure
@@ -69,7 +69,7 @@ export async function withCircuitBreaker(supabase, serviceName, fn) {
       circuit_breaker_state: newState,
       failure_count: newCount,
       last_failure_at: new Date().toISOString(),
-    }, { onConflict: 'service_name' }).catch(() => {});
+    }, { onConflict: 'service_name' }).then(r => r, () => {});
     throw err;
   }
 }
@@ -93,7 +93,7 @@ export async function recoverEventFailure({ supabase, eventId, eventType, payloa
     .select('id, replayed')
     .eq('original_event_id', eventId)
     .single()
-    .catch(() => ({ data: null }));
+    .then(r => r, () => ({ data: null }));
 
   if (dlqEntry && !dlqEntry.replayed) {
     try {

--- a/tests/unit/eva/error-recovery-orchestrator.test.js
+++ b/tests/unit/eva/error-recovery-orchestrator.test.js
@@ -91,6 +91,52 @@ describe('withCircuitBreaker', () => {
   });
 });
 
+describe('withCircuitBreaker / recoverEventFailure — no .catch on the PostgREST builder (QF-20260701-510)', () => {
+  // A faithful stand-in for a real PostgREST query builder: has .then (it's a thenable) but
+  // NO .catch method at all — calling .catch(fn) on it throws
+  // "TypeError: ...catch is not a function" synchronously, regardless of whether the
+  // underlying query would have succeeded or failed. The old `.upsert(fn).catch(fn)`) /
+  // `.single().catch(fn)` code shape crashed on every real invocation. This mock has no
+  // `catch` property defined anywhere, so it fails loud if the fix regresses.
+  function faithfulChain({ singleResult, upsertResult } = {}) {
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn(() => ({ then: (onF) => Promise.resolve(singleResult ?? { data: null }).then(onF) })),
+      upsert: vi.fn(() => ({ then: (onF) => Promise.resolve(upsertResult ?? { data: null, error: null }).then(onF) })),
+    };
+  }
+
+  it('withCircuitBreaker success path does not throw on a real (no-.catch) builder', async () => {
+    const supabase = {
+      from: vi.fn(() => faithfulChain({
+        singleResult: { data: { circuit_breaker_state: 'CLOSED', failure_count: 0 } },
+      })),
+    };
+    const result = await withCircuitBreaker(supabase, 'test-service', async () => 'ok');
+    expect(result).toBe('ok');
+  });
+
+  it('withCircuitBreaker failure path does not throw on a real (no-.catch) builder', async () => {
+    const supabase = {
+      from: vi.fn(() => faithfulChain({
+        singleResult: { data: { circuit_breaker_state: 'CLOSED', failure_count: 0 } },
+      })),
+    };
+    await expect(withCircuitBreaker(supabase, 'test-service', async () => {
+      throw new Error('service down');
+    })).rejects.toThrow('service down'); // the ORIGINAL error, not a TypeError from a bad .catch
+  });
+
+  it('recoverEventFailure does not throw on a real (no-.catch) builder', async () => {
+    const supabase = { from: vi.fn(() => faithfulChain({ singleResult: { data: null } })) };
+    const result = await recoverEventFailure({
+      supabase, eventId: 'evt-1', eventType: 'test.event', payload: {}, error: new Error('test'),
+    });
+    expect(result.outcome).toBe('escalated');
+  });
+});
+
 describe('recoverEventFailure', () => {
   it('should attempt DLQ replay when entry exists', async () => {
     const supabase = createMockSupabase({


### PR DESCRIPTION
## Summary
- Follow-up to QF-20260630-POSTGREST-CATCH (which fixed `getRecoveryStatus`'s 3 sites). The referenced `.premerge-stash-backup.patch` stash targeted those same already-fixed lines and no longer applies to origin/main.
- Re-derived against the current file: found 5 total `.catch()` call sites. 4 are genuine PostgREST-builder thenables (`withCircuitBreaker`'s initial read + both upserts, `recoverEventFailure`'s DLQ read) — these TypeError on a real Supabase builder, which has `.then` but no `.catch`. The 5th (`saga.persistLog(...).catch()`) is a call on a real `async function`'s Promise and does **not** need to change — left untouched.
- Fixed the 4 genuine sites: `.catch(fn)` → `.then(r => r, fn)`, matching the pattern already used at `getRecoveryStatus`'s 3 sites.

## Test plan
- [x] Added 3 faithful-mock regression tests (a chain with `.then` but explicitly no `.catch` method — matching the real PostgREST builder shape) covering both `withCircuitBreaker`'s success/failure paths and `recoverEventFailure`.
- [x] Verified these 3 tests **fail with the exact `TypeError: ...catch is not a function`** against the pre-fix code via a negative-control revert-and-retest before shipping. Also discovered the existing `withCircuitBreaker` failure-path test defined a `catch` property directly on the mock chain object (not on `.upsert()`'s return value), so it never actually exercised the real bug — a mock-fidelity gap, not a code issue in that test's scope.
- [x] `npx vitest run tests/unit/eva/error-recovery-orchestrator.test.js` — 11/11 passing with the fix restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)