### PR TITLE
feat(SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D): eligible-but-unranked-leaf-count invariant gauge

### DIFF
--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -141,7 +141,16 @@ const sb = createClient(
   process.env.SUPABASE_SERVICE_ROLE_KEY,
 );
 
-async function main() {
+/**
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D (FR-4): the claimable-leaf computation, extracted
+ * out of main() so the eligible-but-unranked-leaf-count gauge (scripts/gauge-unranked-claimable-leaves.mjs)
+ * reuses the SAME claimable set the ranker itself acts on — never a second re-derivation that could drift
+ * from what the ranker (and therefore worker-checkin) actually considers claimable. main() below is
+ * byte-identical in behavior; it now calls this function instead of inlining the fetch+filter.
+ * @param {object} sb - supabase service-role client
+ * @returns {Promise<{ error?: object, sds: object[], byKey: Map, depStatus: object, claimable: object[] }>}
+ */
+export async function computeClaimableLeaves(sb) {
   const { data: sds, error } = await sb.from('strategic_directives_v2')
     // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + title, description to classify bare-shell stubs.
     // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + current_phase for the in-flight (started) guard.
@@ -149,7 +158,7 @@ async function main() {
     // whose parent has not yet passed LEAD (else the field is undefined → the gate silently no-ops).
     .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata, parent_sd_id')
     .not('status', 'in', '("completed","cancelled","deferred")');
-  if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return; }
+  if (error) { console.error('[BACKLOG-RANK] load failed:', error.message); return { error, sds: [], byKey: new Map(), depStatus: {}, claimable: [] }; }
 
   // ── dependency graph: edges dep -> dependents (over non-terminal set + completed deps resolved) ──
   const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
@@ -159,26 +168,6 @@ async function main() {
   if (depKeys.size) {
     const { data: deps } = await sb.from('strategic_directives_v2').select('sd_key,status').in('sd_key', Array.from(depKeys));
     (deps || []).forEach(d => { depStatus[d.sd_key] = d.status; });
-  }
-  // dependents[dep] = [sd_keys that list dep and are not terminal]
-  const dependents = new Map();
-  for (const d of (sds || [])) {
-    for (const k of blockerKeysFor(d)) {
-      if (!dependents.has(k)) dependents.set(k, []);
-      dependents.get(k).push(d.sd_key);
-    }
-  }
-  // unlock score: transitive count of non-terminal SDs downstream of key (DFS, cycle-safe)
-  function unlockScore(key) {
-    const seen = new Set();
-    const stack = [...(dependents.get(key) || [])];
-    while (stack.length) {
-      const k = stack.pop();
-      if (seen.has(k) || k === key) continue;
-      seen.add(k);
-      stack.push(...(dependents.get(k) || []));
-    }
-    return seen.size;
   }
 
   // ── claimable leaves ──
@@ -244,6 +233,33 @@ async function main() {
   if (awaitingConvergenceSkips) console.log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
   if (humanActionSkips) console.log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
   if (ineligibleSkips) console.log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
+  return { sds, byKey, depStatus, claimable };
+}
+
+async function main() {
+  const { error, sds, byKey, depStatus, claimable } = await computeClaimableLeaves(sb);
+  if (error) return;
+  // dependents[dep] = [sd_keys that list dep and are not terminal]
+  const dependents = new Map();
+  for (const d of (sds || [])) {
+    for (const k of blockerKeysFor(d)) {
+      if (!dependents.has(k)) dependents.set(k, []);
+      dependents.get(k).push(d.sd_key);
+    }
+  }
+  // unlock score: transitive count of non-terminal SDs downstream of key (DFS, cycle-safe)
+  function unlockScore(key) {
+    const seen = new Set();
+    const stack = [...(dependents.get(key) || [])];
+    while (stack.length) {
+      const k = stack.pop();
+      if (seen.has(k) || k === key) continue;
+      seen.add(k);
+      stack.push(...(dependents.get(k) || []));
+    }
+    return seen.size;
+  }
+
   // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: bare-shell stubs (empty/title-only description)
   // cannot pass LEAD-TO-PLAN; log them so the demote-to-last below is auditable. The sort
   // below (bareShellLastCompare as the dominant key) is what actually places them last.

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -62,6 +62,11 @@ export const COMPOSED_CORES = [
   // wakes and self-claims — skipping it here left claimable-but-unranked SDs stuck whenever this
   // tick's STANDARD_LOOPS sibling cron was also unarmed (coordinator teardown-discipline gap).
   { key: 'backlog-rank', script: 'coordinator-backlog-rank.mjs', args: ['scripts/coordinator-backlog-rank.mjs'], quiescentSkip: false },
+  // NOT quiescentSkip (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D): observability for the
+  // belt-and-suspenders above — cheap (reuses backlog-rank's own claimable computation), and most
+  // valuable exactly when the fleet is quiet (a parked fleet is when rank-on-transition gaps and
+  // periodic-cron lag are most likely to have gone unnoticed).
+  { key: 'unranked-gauge', script: 'gauge-unranked-claimable-leaves.mjs', args: ['scripts/gauge-unranked-claimable-leaves.mjs'], quiescentSkip: false },
   { key: 'audit', script: 'coordinator-audit.mjs', args: ['scripts/coordinator-audit.mjs'], quiescentSkip: true },
 ];
 

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -90,6 +90,13 @@ export const STANDARD_LOOPS = [
   // by default, not correction-by-dispatch.
   { key: 'backlog-rank', label: 'Backlog prioritization pass (dispatch_rank for self-claim ordering)', script: 'coordinator-backlog-rank.mjs', cron: '6,21,36,51 * * * *',
     prompt: 'node scripts/coordinator-backlog-rank.mjs' },
+  // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D: the observability leg for the belt-and-suspenders
+  // above (rank-on-transition + this cron + the worker-checkin pool-window fix) — counts claimable leaf
+  // SDs with no fresh dispatch_rank right now (>0 = drift: the guarantees above didn't hold). Cheap
+  // (reuses backlog-rank's own claimable computation); offset from backlog-rank's own cadence so it
+  // always observes a just-refreshed rank rather than racing it.
+  { key: 'unranked-gauge', label: 'Eligible-but-unranked-leaf-count invariant gauge', script: 'gauge-unranked-claimable-leaves.mjs', cron: '9,24,39,54 * * * *',
+    prompt: 'node scripts/gauge-unranked-claimable-leaves.mjs' },
   // SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (FR-2a): restore the worker fleet-retro to a schedule
   // (it had drifted to manual — last ran ~2.5d ago). Re-arms the existing, idempotent capture/
   // synthesis script (reuses the feedback/issue_patterns pipeline; dedups on metadata.retro_key).

--- a/scripts/gauge-unranked-claimable-leaves.mjs
+++ b/scripts/gauge-unranked-claimable-leaves.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * gauge-unranked-claimable-leaves.mjs — eligible-but-unranked-leaf-count invariant gauge
+ * (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D, FR-4).
+ *
+ * Guarantee-every-claimable-SD-is-ranked (parent SD) ships belt-and-suspenders: rank-on-transition
+ * (-C) + a hardened periodic rank cron (-A) + a worker-checkin pool-window fix (-B). This gauge is
+ * the OBSERVABILITY leg — it answers "did the belt-and-suspenders actually hold?" by counting how
+ * many currently-claimable leaf SDs have NO fresh dispatch_rank right now. A non-zero count is DRIFT:
+ * either rank-on-transition missed a gap, or the periodic cron has not caught up yet.
+ *
+ * STANDALONE by design (parent SD scope: "the broader coordinator-Solomon invariant-gauges
+ * FRAMEWORK does not exist as code yet ... ship this as a standalone gauge that a future framework
+ * SD can adopt/wrap"). No new schema, no new registration mechanism — just a machine-readable GAUGE
+ * line, matching the existing convention (coordinator-capacity-forecast.mjs's GAUGE line).
+ *
+ * REUSE, do not re-derive: the claimable set comes from coordinator-backlog-rank.mjs's
+ * computeClaimableLeaves() (the SAME function the ranker itself acts on), and "fresh" uses the SAME
+ * DISPATCH_RANK_TTL_MS worker-checkin.cjs already enforces when deciding whether to trust a rank.
+ *
+ * Usage: node scripts/gauge-unranked-claimable-leaves.mjs [--json]
+ */
+import 'dotenv/config';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { computeClaimableLeaves } from './coordinator-backlog-rank.mjs';
+
+const require = createRequire(import.meta.url);
+const { DISPATCH_RANK_TTL_MS } = require('./worker-checkin.cjs');
+
+const JSON_MODE = process.argv.includes('--json');
+
+const sb = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+/**
+ * Is this claimable SD's dispatch_rank fresh enough for worker-checkin to actually trust it?
+ * Mirrors worker-checkin.cjs's own freshness check verbatim (same field names, same TTL) so the
+ * gauge can never disagree with what the consumer actually honors.
+ * @param {{ metadata?: { dispatch_rank?: number, dispatch_rank_at?: string } }} sd
+ * @param {number} nowMs
+ * @returns {boolean}
+ */
+export function isFreshlyRanked(sd, nowMs) {
+  const m = (sd && sd.metadata) || {};
+  return !!(m.dispatch_rank != null && m.dispatch_rank_at
+    && (nowMs - new Date(m.dispatch_rank_at).getTime()) < DISPATCH_RANK_TTL_MS);
+}
+
+/**
+ * The gauge itself: of the given claimable leaves, how many lack a fresh dispatch_rank right now?
+ * Pure/sync — exported for unit testing without a DB round-trip.
+ * @param {object[]} claimable
+ * @param {number} nowMs
+ * @returns {{ count: number, keys: string[] }}
+ */
+export function countUnrankedClaimableLeaves(claimable, nowMs) {
+  const unranked = (claimable || []).filter((sd) => !isFreshlyRanked(sd, nowMs));
+  return { count: unranked.length, keys: unranked.map((sd) => sd.sd_key) };
+}
+
+async function main() {
+  const nowMs = Date.now();
+  const { error, claimable } = await computeClaimableLeaves(sb);
+  if (error) {
+    console.error('[UNRANKED-GAUGE] load failed:', error.message);
+    process.exitCode = 0; // advisory gauge: never fail the tick over a transient read error
+    return;
+  }
+  const { count, keys } = countUnrankedClaimableLeaves(claimable, nowMs);
+  if (JSON_MODE) {
+    console.log(JSON.stringify({ gauge: 'unranked_claimable_leaves', value: count, drift: count > 0, keys }));
+    return;
+  }
+  if (count > 0) {
+    console.log(`[UNRANKED-GAUGE] DRIFT: ${count} claimable leaf SD(s) have no fresh dispatch_rank: ${keys.join(', ')}`);
+  } else {
+    console.log('[UNRANKED-GAUGE] clean: every claimable leaf SD has a fresh dispatch_rank');
+  }
+  console.log(`GAUGE unranked_claimable_leaves=${count}`);
+}
+
+// process.argv[1] is undefined under `node -e`/some loaders, so guard it before pathToFileURL.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -25,9 +25,10 @@ test('STANDARD_LOOPS has the expected standard loops with the expected keys', ()
   // SD-LEO-INFRA-SCRIPTS-ESTATE-RECONCILIATION-001 (FR-1) added the weekly scripts-reachability gauge.
   // SD-MAN-INFRA-RETENTION-OPS-FINISHER-001 added 'retention' (this pin had drifted — it was never added here).
   // SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001 added the durable charter-compliance self-audit (after 'audit').
-  assert.equal(STANDARD_LOOPS.length, 16);
+  // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D added the unranked-claimable-leaf-count gauge (after 'backlog-rank').
+  assert.equal(STANDARD_LOOPS.length, 17);
   const keys = STANDARD_LOOPS.map((l) => l.key);
-  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention']);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention']);
 });
 
 test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
@@ -95,7 +96,7 @@ test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboa
 test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
   const none = parseArmedSet([], {});
   const out = renderLoops(none);
-  assert.match(out, /STANDARD CRON LOOPS \(16\)/);
+  assert.match(out, /STANDARD CRON LOOPS \(17\)/);
   // All prompts emitted as CronCreate specs when nothing is armed
   for (const loop of STANDARD_LOOPS) {
     assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
@@ -113,7 +114,7 @@ test('renderLoops reports all-armed cleanly when every loop is armed', () => {
   ];
   const armed = parseArmedSet(['--armed', armedTokens.join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 16 standard loops armed/);
+  assert.match(out, /All 17 standard loops armed/);
 });
 
 test('buildReport combines responsibilities + loop sections', () => {

--- a/tests/unit/gauge-unranked-claimable-leaves.test.js
+++ b/tests/unit/gauge-unranked-claimable-leaves.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D (FR-4)
+ *
+ * The eligible-but-unranked-leaf-count invariant gauge: of the SDs coordinator-backlog-rank.mjs's
+ * own claimable-leaf computation (computeClaimableLeaves) considers claimable, how many lack a
+ * dispatch_rank fresh enough for worker-checkin.cjs to actually honor (DISPATCH_RANK_TTL_MS)?
+ * >0 = drift — the rank-on-transition + periodic-cron belt-and-suspenders did not hold.
+ *
+ * Importing either module must NOT run a DB-touching pass (entrypoint guard).
+ */
+import { describe, it, expect } from 'vitest';
+import { isFreshlyRanked, countUnrankedClaimableLeaves } from '../../scripts/gauge-unranked-claimable-leaves.mjs';
+import { computeClaimableLeaves } from '../../scripts/coordinator-backlog-rank.mjs';
+import { DISPATCH_RANK_TTL_MS } from '../../scripts/worker-checkin.cjs';
+
+const NOW = 1_800_000_000_000; // fixed reference instant
+
+const leaf = (sd_key, metadataOverrides = {}) => ({ sd_key, metadata: { ...metadataOverrides } });
+
+describe('isFreshlyRanked', () => {
+  it('is fresh when dispatch_rank + dispatch_rank_at are set within the TTL', () => {
+    const sd = leaf('SD-A', { dispatch_rank: 1, dispatch_rank_at: new Date(NOW - 1000).toISOString() });
+    expect(isFreshlyRanked(sd, NOW)).toBe(true);
+  });
+
+  it('is NOT fresh when dispatch_rank_at is older than DISPATCH_RANK_TTL_MS', () => {
+    const sd = leaf('SD-B', { dispatch_rank: 1, dispatch_rank_at: new Date(NOW - DISPATCH_RANK_TTL_MS - 1000).toISOString() });
+    expect(isFreshlyRanked(sd, NOW)).toBe(false);
+  });
+
+  it('is NOT fresh when dispatch_rank is absent entirely (never ranked)', () => {
+    expect(isFreshlyRanked(leaf('SD-C'), NOW)).toBe(false);
+  });
+
+  it('is NOT fresh when dispatch_rank is set but dispatch_rank_at is missing (malformed stamp)', () => {
+    const sd = leaf('SD-D', { dispatch_rank: 1 });
+    expect(isFreshlyRanked(sd, NOW)).toBe(false);
+  });
+
+  it('handles a missing metadata object without throwing', () => {
+    expect(isFreshlyRanked({ sd_key: 'SD-E' }, NOW)).toBe(false);
+  });
+});
+
+describe('countUnrankedClaimableLeaves', () => {
+  it('counts zero when every claimable leaf is freshly ranked (the healthy/clean state)', () => {
+    const claimable = [
+      leaf('SD-A', { dispatch_rank: 1, dispatch_rank_at: new Date(NOW - 1000).toISOString() }),
+      leaf('SD-B', { dispatch_rank: 2, dispatch_rank_at: new Date(NOW - 2000).toISOString() }),
+    ];
+    expect(countUnrankedClaimableLeaves(claimable, NOW)).toEqual({ count: 0, keys: [] });
+  });
+
+  it('counts and names each claimable leaf lacking a fresh rank (the drift state)', () => {
+    const claimable = [
+      leaf('SD-A', { dispatch_rank: 1, dispatch_rank_at: new Date(NOW - 1000).toISOString() }), // fresh
+      leaf('SD-B'), // never ranked
+      leaf('SD-C', { dispatch_rank: 3, dispatch_rank_at: new Date(NOW - DISPATCH_RANK_TTL_MS - 1000).toISOString() }), // stale
+    ];
+    expect(countUnrankedClaimableLeaves(claimable, NOW)).toEqual({ count: 2, keys: ['SD-B', 'SD-C'] });
+  });
+
+  it('handles an empty claimable pool', () => {
+    expect(countUnrankedClaimableLeaves([], NOW)).toEqual({ count: 0, keys: [] });
+  });
+
+  it('handles a null/undefined claimable pool without throwing', () => {
+    expect(countUnrankedClaimableLeaves(undefined, NOW)).toEqual({ count: 0, keys: [] });
+  });
+});
+
+describe('reuse, not re-derivation', () => {
+  it('coordinator-backlog-rank.mjs exports computeClaimableLeaves for the gauge to reuse', () => {
+    expect(typeof computeClaimableLeaves).toBe('function');
+  });
+
+  it('both modules import cleanly without running a DB pass (entrypoint guard)', () => {
+    expect(typeof isFreshlyRanked).toBe('function');
+    expect(typeof countUnrankedClaimableLeaves).toBe('function');
+  });
+});

--- a/tests/unit/gauge-unranked-claimable-leaves.test.js
+++ b/tests/unit/gauge-unranked-claimable-leaves.test.js
@@ -37,6 +37,16 @@ describe('isFreshlyRanked', () => {
     expect(isFreshlyRanked(sd, NOW)).toBe(false);
   });
 
+  it('is NOT fresh at exactly the TTL boundary (strict <, not <=) — fails toward drift, not silence', () => {
+    const sd = leaf('SD-F', { dispatch_rank: 1, dispatch_rank_at: new Date(NOW - DISPATCH_RANK_TTL_MS).toISOString() });
+    expect(isFreshlyRanked(sd, NOW)).toBe(false);
+  });
+
+  it('an invalid dispatch_rank_at string is treated as NOT fresh (fails toward drift, never masks it)', () => {
+    const sd = leaf('SD-G', { dispatch_rank: 1, dispatch_rank_at: 'not-a-timestamp' });
+    expect(isFreshlyRanked(sd, NOW)).toBe(false);
+  });
+
   it('handles a missing metadata object without throwing', () => {
     expect(isFreshlyRanked({ sd_key: 'SD-E' }, NOW)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- FR-4 of guarantee-every-claimable-SD-is-ranked (belt-and-suspenders: rank-on-transition + hardened periodic cron + worker-checkin pool-window fix already shipped by siblings -A/-B/-C). This child ships the **observability leg**.
- `scripts/coordinator-backlog-rank.mjs`: extracted the claimable-leaf computation into an exported `computeClaimableLeaves(sb)`, reused by both `main()` (byte-identical behavior) and the new gauge — never a second re-derivation.
- `scripts/gauge-unranked-claimable-leaves.mjs` (new): counts claimable leaf SDs lacking a fresh `dispatch_rank` (using `worker-checkin.cjs`'s own `DISPATCH_RANK_TTL_MS`, imported not re-declared). Emits a `GAUGE unranked_claimable_leaves=<n>` line (+ `--json` mode). Live run against production data correctly detected 2 SDs that had drifted stale (`UPSCALE`, `ADKAR`).
- Wired into `coordinator-quiet-tick.mjs` (not quiescent-skipped) and registered in `coordinator-startup-check.mjs`'s `STANDARD_LOOPS` master registry.
- Standalone by design (no new schema/registration framework) — a future invariant-gauges framework SD can adopt/wrap this.

## Test plan
- [x] New `tests/unit/gauge-unranked-claimable-leaves.test.js` (11 tests): freshness logic, counting, entrypoint guards.
- [x] Existing `coordinator-backlog-rank*` suite (40 tests) stays green after the extraction refactor.
- [x] `tests/unit/coordinator/quiet-tick-loop-parity.test.js` (6 tests) confirms the new core maps to a real `STANDARD_LOOPS` entry.
- [x] `tests/unit/coordinator-startup-check.test.mjs` (`node:test`, 10 tests) updated pins (17 loops) — all pass.
- [x] Live CLI run against production data confirmed correct drift detection.
- [x] `node --check` + `eslint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)