### PR TITLE
Class-guard the removeChannel/unsubscribe-in-subscribe-callback recursion anti-pattern

### DIFF
--- a/.github/workflows/realtime-subscribe-teardown-recursion-lint.yml
+++ b/.github/workflows/realtime-subscribe-teardown-recursion-lint.yml
@@ -1,0 +1,43 @@
+name: Realtime Subscribe Teardown Recursion Lint
+
+# SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001
+#
+# Blocks any PR that (re)introduces a proven, recurring crash class: calling
+# <ref>.removeChannel(...) or <ref>.unsubscribe() synchronously from inside the
+# callback passed to a .subscribe(...) call. Supabase's vendored phoenix client
+# re-fires that same callback from inside Channel.leave(), so a teardown call
+# made there recurses unboundedly -> RangeError: Maximum call stack size
+# exceeded. Fixed independently 3x (ae499d9957/QF-709, PR #5305/QF-762) before
+# this class-guard existed — each fix's own regression test mocked the
+# teardown call as a no-op, so the anti-pattern shipped green through the full
+# LEO gate pipeline every time.
+#
+# GENUINELY BLOCKING (no continue-on-error): this repo's `npm run lint`
+# (eslint.config.js flat-config run) is not invoked by any other CI workflow,
+# so registering the rule only in eslint.config.js would not actually enforce
+# anything — this dedicated workflow is the real enforcement mechanism.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/**/*.{js,mjs,cjs,ts,tsx}'
+      - 'server/**/*.{js,mjs,cjs,ts,tsx}'
+      - 'eslint-rules/no-realtime-teardown-in-subscribe-callback.js'
+      - 'scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs'
+      - '.github/workflows/realtime-subscribe-teardown-recursion-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  realtime-subscribe-teardown-recursion-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Detect removeChannel/unsubscribe called inside a .subscribe() callback
+        run: node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs

--- a/eslint-rules/no-realtime-teardown-in-subscribe-callback.js
+++ b/eslint-rules/no-realtime-teardown-in-subscribe-callback.js
@@ -1,0 +1,231 @@
+/**
+ * ESLint Rule: no-realtime-teardown-in-subscribe-callback
+ *
+ * Flags `<ref>.removeChannel(...)` (any host object — e.g. `supabase.removeChannel`)
+ * or `<ref>.unsubscribe()` called SYNCHRONOUSLY from inside the callback passed to
+ * a `.subscribe(...)` call. This is the recursion-causing shape behind a proven,
+ * recurring crash class: Supabase's vendored phoenix client's `Channel.leave()`
+ * (invoked by both `removeChannel()` and `unsubscribe()` — removeChannel wraps
+ * unsubscribe internally) synchronously re-fires the SAME status callback before
+ * settling, so a teardown call made from inside that callback recurses unbounded
+ * -> `RangeError: Maximum call stack size exceeded`.
+ *
+ * Proven 3x independently: ae499d9957 / QF-20260701-709 (reality-gates.js,
+ * stage-governance.js), then PR #5305 / QF-20260701-762 (chairman-decision-watcher.js).
+ * Each time, a mock that didn't reproduce the re-fire let the anti-pattern ship
+ * green through the full LEO gate pipeline. SD-LEO-INFRA-REALTIME-REMOVECHANNEL-
+ * RECURSION-CLASSGUARD-001 — this rule is the structural guard against a 4th.
+ *
+ * Correct pattern: null the local channel reference inside the callback; defer
+ * the actual removeChannel()/unsubscribe() call to OUTSIDE the callback (a
+ * separate cleanup() path invoked on resolution/timeout, never from the status
+ * handler itself).
+ *
+ * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
+ *
+ *   // eslint-disable-next-line no-realtime-teardown-in-subscribe-callback -- <REASON>
+ *   channel.unsubscribe();
+ *
+ * Detection scope: walks the callback body passed to any `.subscribe(fn)` call
+ * (fn must be a FunctionExpression/ArrowFunctionExpression), recursing into
+ * blocks/if-else/switch/try but NOT into nested function boundaries (a call
+ * inside a nested closure is not synchronously-within-the-subscribe-invocation
+ * itself). Matches by property name only (`removeChannel` / `unsubscribe`),
+ * independent of the host object's identifier name, since the client variable
+ * name varies across call sites (`supabase`, `client`, `this.supabase`, ...).
+ *
+ * @module eslint-rules/no-realtime-teardown-in-subscribe-callback
+ */
+
+const RULE_NAME = 'no-realtime-teardown-in-subscribe-callback';
+const TEARDOWN_METHOD_NAMES = new Set(['removeChannel', 'unsubscribe']);
+
+// Detects `eslint-disable-next-line [<prefix>/]no-realtime-teardown-in-subscribe-callback`
+// and captures the trailing text on the same line, mirroring the pragma contract
+// established by eslint-rules/no-process-cwd-in-sub-agents.js.
+const PRAGMA_DETECT_RE = new RegExp(
+  String.raw`eslint-disable-next-line\s+(?:[^,\n]*,\s*)*(?:[\w@-]+(?:[/][\w@-]+)*/)?` +
+    RULE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+    String.raw`(?:\s*,[^\n]*)?(.*)$`
+);
+
+/**
+ * Is this call expression `.subscribe(fn)` where fn is an inline function?
+ *
+ * @param {import('estree').Node} node
+ * @returns {{ callback: import('estree').Node } | null}
+ */
+function matchSubscribeCall(node) {
+  if (!node || node.type !== 'CallExpression') return null;
+  const callee = node.callee;
+  if (!callee || callee.type !== 'MemberExpression') return null;
+  if (callee.computed) return null;
+  if (!callee.property || callee.property.type !== 'Identifier' || callee.property.name !== 'subscribe') {
+    return null;
+  }
+  const callback = node.arguments && node.arguments[0];
+  if (!callback) return null;
+  if (callback.type !== 'FunctionExpression' && callback.type !== 'ArrowFunctionExpression') return null;
+  return { callback };
+}
+
+/**
+ * Is this call expression `<ref>.removeChannel(...)` or `<ref>.unsubscribe()`?
+ *
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isTeardownCall(node) {
+  if (!node || node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  if (!callee || callee.type !== 'MemberExpression') return false;
+  if (callee.computed) return false;
+  if (!callee.property || callee.property.type !== 'Identifier') return false;
+  return TEARDOWN_METHOD_NAMES.has(callee.property.name);
+}
+
+/**
+ * Classify a pragma comment targeting this rule.
+ *
+ * @param {string} commentValue
+ * @returns {{ targets: false } | { targets: true, hasMarker: boolean, reason: string }}
+ */
+function classifyPragma(commentValue) {
+  if (!commentValue) return { targets: false };
+  const match = commentValue.match(PRAGMA_DETECT_RE);
+  if (!match) return { targets: false };
+  const suffix = match[1] || '';
+  const markerIdx = suffix.indexOf('--');
+  if (markerIdx === -1) {
+    return { targets: true, hasMarker: false, reason: '' };
+  }
+  const reason = suffix.slice(markerIdx + 2).trim();
+  return { targets: true, hasMarker: true, reason };
+}
+
+/**
+ * Return the rule-targeting pragma comment directly above `node`, or null.
+ *
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {import('estree').Node} node
+ * @returns {import('estree').Comment | null}
+ */
+function getDisablePragmaCommentAbove(sourceCode, node) {
+  const comments = sourceCode.getCommentsBefore(node);
+  if (!comments || comments.length === 0) return null;
+  const last = comments[comments.length - 1];
+  if (!last || (last.type !== 'Line' && last.type !== 'Block')) return null;
+  if (last.loc && node.loc && last.loc.end.line < node.loc.start.line - 1) return null;
+  const verdict = classifyPragma(last.value);
+  return verdict.targets ? last : null;
+}
+
+/**
+ * Walk statement/expression nodes reachable synchronously from `root` WITHOUT
+ * crossing into a nested function boundary, invoking `visit` on every
+ * CallExpression found.
+ *
+ * @param {import('estree').Node} root
+ * @param {(node: import('estree').Node) => void} visit
+ */
+function walkSynchronousBody(root, visit) {
+  const stack = [root];
+  const seen = new Set();
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node || typeof node !== 'object' || seen.has(node)) continue;
+    seen.add(node);
+
+    if (node.type === 'CallExpression') visit(node);
+
+    // Do not descend into nested function boundaries — a call inside a nested
+    // closure does not execute synchronously as part of THIS callback invocation.
+    if (
+      node !== root &&
+      (node.type === 'FunctionExpression' ||
+        node.type === 'ArrowFunctionExpression' ||
+        node.type === 'FunctionDeclaration')
+    ) {
+      continue;
+    }
+
+    for (const key of Object.keys(node)) {
+      if (key === 'parent' || key === 'loc' || key === 'range') continue;
+      const value = node[key];
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (item && typeof item.type === 'string') stack.push(item);
+        }
+      } else if (value && typeof value.type === 'string') {
+        stack.push(value);
+      }
+    }
+  }
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow removeChannel()/unsubscribe() called synchronously inside a .subscribe(status => {...}) callback — causes unbounded recursion via phoenix Channel.leave() re-firing the same callback',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://github.com/rickfelix/EHG_Engineer/blob/main/eslint-rules/no-realtime-teardown-in-subscribe-callback.js',
+    },
+    messages: {
+      noTeardownInCallback:
+        '{{method}}() called inside a .subscribe() callback recurses unboundedly (phoenix Channel.leave() re-fires this same callback) -> RangeError: Maximum call stack size exceeded. ' +
+        'Null the local channel reference here instead; defer the actual teardown to OUTSIDE the callback. ' +
+        'To override: // eslint-disable-next-line no-realtime-teardown-in-subscribe-callback -- <reason>',
+      pragmaMissingReason:
+        'eslint-disable-next-line no-realtime-teardown-in-subscribe-callback requires a non-empty REASON after `--`. ' +
+        'Example: // eslint-disable-next-line no-realtime-teardown-in-subscribe-callback -- channel is a DIFFERENT, unrelated subscription',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    const pragmaHandled = new Set();
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments();
+        for (const comment of comments) {
+          if (comment.type !== 'Line' && comment.type !== 'Block') continue;
+          const verdict = classifyPragma(comment.value);
+          if (!verdict.targets) continue;
+
+          pragmaHandled.add(comment.range && comment.range[0]);
+
+          if (!verdict.hasMarker) {
+            context.report({ loc: comment.loc, messageId: 'noTeardownInCallback', data: { method: 'removeChannel/unsubscribe' } });
+          } else if (verdict.reason.length === 0) {
+            context.report({ loc: comment.loc, messageId: 'pragmaMissingReason' });
+          }
+        }
+      },
+
+      CallExpression(node) {
+        const match = matchSubscribeCall(node);
+        if (!match) return;
+
+        walkSynchronousBody(match.callback.body, (callNode) => {
+          if (!isTeardownCall(callNode)) return;
+
+          const above = getDisablePragmaCommentAbove(sourceCode, callNode);
+          if (above && pragmaHandled.has(above.range && above.range[0])) {
+            return;
+          }
+
+          context.report({
+            node: callNode,
+            messageId: 'noTeardownInCallback',
+            data: { method: callNode.callee.property.name },
+          });
+        });
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "lint:env-flags": "node scripts/lint/process-env-feature-flag-lint.mjs",
     "lint:alter-defaults": "node scripts/lint/alter-default-override-lint.mjs",
     "lint:venture-artifacts": "node scripts/lint/venture-artifacts-write-lint.mjs",
+    "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",

--- a/scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs
+++ b/scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Realtime removeChannel/unsubscribe-in-subscribe-callback Recursion Lint
+ * SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001 FR-1 / FR-3
+ *
+ * Scans lib/** + server/** for the proven, recurring crash class: calling
+ * <ref>.removeChannel(...) or <ref>.unsubscribe() synchronously from inside the
+ * callback passed to a .subscribe(...) call. Reuses the SAME detection logic as
+ * eslint-rules/no-realtime-teardown-in-subscribe-callback.js (via ESLint's
+ * Linter API) so there is exactly one implementation of the anti-pattern shape,
+ * not a second grep/regex detector that could drift out of sync.
+ *
+ * Usage:
+ *   node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs [--json] [--root <dir>]
+ *   npm run lint:realtime-teardown
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Linter } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import rule from '../../eslint-rules/no-realtime-teardown-in-subscribe-callback.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const SCAN_DIRS = ['lib', 'server'];
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx']);
+const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage'];
+const EXCLUDE_FILE_RE = /(\.test\.|\.spec\.|\.d\.ts$|\.min\.js$)/i;
+
+const RULE_ID = 'realtime-teardown/no-realtime-teardown-in-subscribe-callback';
+
+const FLAT_CONFIG = {
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: {
+      console: 'readonly', process: 'readonly', require: 'readonly', module: 'readonly',
+      exports: 'readonly', __dirname: 'readonly', __filename: 'readonly', Buffer: 'readonly',
+      setTimeout: 'readonly', setInterval: 'readonly', clearTimeout: 'readonly', clearInterval: 'readonly',
+    },
+  },
+  plugins: {
+    'realtime-teardown': { rules: { 'no-realtime-teardown-in-subscribe-callback': rule } },
+  },
+  rules: {
+    [RULE_ID]: 'error',
+  },
+};
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (EXCLUDE_DIR_SEGMENTS.includes(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name)) && !EXCLUDE_FILE_RE.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+function lintFile(linter, absPath) {
+  const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+  let code;
+  try {
+    code = fs.readFileSync(absPath, 'utf8');
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Could not read file: ${err.message}` }];
+  }
+  const isTypeScript = path.extname(absPath) === '.ts' || path.extname(absPath) === '.tsx';
+  const config = {
+    ...FLAT_CONFIG,
+    languageOptions: {
+      ...FLAT_CONFIG.languageOptions,
+      ...(isTypeScript ? { parser: typescriptParser } : {}),
+    },
+  };
+  let messages;
+  try {
+    messages = linter.verify(code, config, { filename: absPath });
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Parse error: ${err.message}` }];
+  }
+  return messages
+    .filter((m) => m.ruleId === RULE_ID)
+    .map((m) => ({ filePath: relPath, line: m.line, column: m.column, message: m.message }));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const rootIdx = args.indexOf('--root');
+  const scanRoot = rootIdx !== -1 && args[rootIdx + 1] ? path.resolve(args[rootIdx + 1]) : REPO_ROOT;
+
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(scanRoot, dir), files);
+  }
+
+  // Flat-config ESLint requires an explicit cwd to resolve absolute filenames
+  // passed to verify() — without it, config resolution either throws
+  // ("Resolved a relative path without a current working directory") or
+  // silently no-ops with "No matching configuration found", both observed
+  // empirically while validating this script against a scratch fixture root.
+  const linter = new Linter({ cwd: scanRoot });
+  const violations = files.flatMap((f) => lintFile(linter, f));
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ scanned: files.length, violations }, null, 2));
+  } else if (violations.length === 0) {
+    console.log(`✅ realtime-subscribe-teardown-recursion-lint: 0 violations across ${files.length} file(s) scanned (lib/**, server/**)`);
+  } else {
+    console.error(`❌ realtime-subscribe-teardown-recursion-lint: ${violations.length} violation(s) across ${files.length} file(s) scanned\n`);
+    for (const v of violations) {
+      console.error(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+    }
+    console.error('\nFix: null the local channel reference inside the .subscribe() callback; defer removeChannel()/unsubscribe() to a separate cleanup path OUTSIDE the callback.');
+  }
+
+  process.exit(violations.length > 0 ? 1 : 0);
+}
+
+main();

--- a/tests/helpers/faithful-supabase-realtime-mock.js
+++ b/tests/helpers/faithful-supabase-realtime-mock.js
@@ -1,0 +1,88 @@
+/**
+ * Faithful Supabase Realtime channel mock — shared across all consumers.
+ * SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001 FR-2.
+ *
+ * Real behavior being reproduced: `@supabase/phoenix`'s `Channel.leave()` (invoked
+ * by BOTH `channel.unsubscribe()` and `supabase.removeChannel(channel)` — the
+ * latter wraps the former internally) synchronously re-fires the channel's
+ * `.subscribe(status => {...})` status callback with 'CLOSED' before settling.
+ * A consumer that calls a teardown method FROM INSIDE that same status callback
+ * therefore recurses unboundedly -> RangeError: Maximum call stack size exceeded.
+ *
+ * A mock whose `unsubscribe()`/`removeChannel()` are simple no-ops (the pattern
+ * that shipped 3x independently — ae499d9957/QF-709, PR #5305/QF-762 — before
+ * this class-guard existed) CANNOT catch a regression: the recursion never has
+ * a chance to start, so the test passes whether or not the code under test is
+ * correct. This helper re-fires the callback, so a test written against it
+ * genuinely reproduces the crash on the anti-pattern and only passes on the
+ * correct fix (null the local reference; defer teardown outside the callback).
+ *
+ * Usage:
+ *   import { createFaithfulRealtimeChannelMock } from '../../helpers/faithful-supabase-realtime-mock.js';
+ *   const { channelMock, removeChannel, getStatusCallback, getUnsubscribeCallCount, getRemoveChannelCallCount } =
+ *     createFaithfulRealtimeChannelMock();
+ *   const supabase = {
+ *     ...yourOwnFromMock,
+ *     channel: () => channelMock,
+ *     removeChannel,
+ *   };
+ *
+ * @module tests/helpers/faithful-supabase-realtime-mock
+ */
+
+/**
+ * @param {object} [options]
+ * @param {number} [options.recursionGuardLimit] — throws once a teardown method's
+ *   own re-fire loop exceeds this count, so a genuinely-broken test (not the code
+ *   under test) fails loudly instead of hanging/overflowing the real call stack.
+ * @returns {{
+ *   channelMock: { on: Function, subscribe: Function, unsubscribe: Function },
+ *   removeChannel: Function,
+ *   getStatusCallback: () => Function | null,
+ *   getUnsubscribeCallCount: () => number,
+ *   getRemoveChannelCallCount: () => number,
+ * }}
+ */
+export function createFaithfulRealtimeChannelMock(options = {}) {
+  const recursionGuardLimit = options.recursionGuardLimit ?? 100;
+
+  let capturedStatusCallback = null;
+  let unsubscribeCallCount = 0;
+  let removeChannelCallCount = 0;
+
+  const channelMock = {
+    on() {
+      return channelMock;
+    },
+    subscribe(cb) {
+      capturedStatusCallback = cb;
+      return channelMock;
+    },
+    unsubscribe() {
+      unsubscribeCallCount++;
+      if (unsubscribeCallCount > recursionGuardLimit) {
+        throw new Error('unsubscribe recursion guard tripped -- test itself would overflow');
+      }
+      // Simulates phoenix's synchronous Channel.leave() re-firing the same status callback.
+      capturedStatusCallback?.('CLOSED');
+    },
+  };
+
+  function removeChannel() {
+    removeChannelCallCount++;
+    if (removeChannelCallCount > recursionGuardLimit) {
+      throw new Error('removeChannel recursion guard tripped -- test itself would overflow');
+    }
+    // Mirrors the real RealtimeClient.removeChannel() -> Channel.leave() relationship:
+    // removeChannel() calls unsubscribe() internally, it does not recurse independently.
+    channelMock.unsubscribe();
+  }
+
+  return {
+    channelMock,
+    removeChannel,
+    getStatusCallback: () => capturedStatusCallback,
+    getUnsubscribeCallCount: () => unsubscribeCallCount,
+    getRemoveChannelCallCount: () => removeChannelCallCount,
+  };
+}

--- a/tests/unit/eslint-rules/no-realtime-teardown-in-subscribe-callback.test.js
+++ b/tests/unit/eslint-rules/no-realtime-teardown-in-subscribe-callback.test.js
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for ESLint rule `no-realtime-teardown-in-subscribe-callback`.
+ *
+ * SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001 FR-1.
+ *
+ * Covers: correct pattern (teardown outside the callback), the anti-pattern
+ * (removeChannel/unsubscribe called synchronously inside the callback, incl.
+ * nested in a conditional branch), the function-boundary exemption (deferred
+ * teardown inside a nested closure is NOT synchronous-within-callback), and
+ * the escape-hatch pragma contract (mirrors no-process-cwd-in-sub-agents.js).
+ *
+ * @module tests/unit/eslint-rules/no-realtime-teardown-in-subscribe-callback.test.js
+ */
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../../../eslint-rules/no-realtime-teardown-in-subscribe-callback.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const RULE_ID = 'rule-to-test/no-realtime-teardown-in-subscribe-callback';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: { setTimeout: 'readonly' },
+  },
+});
+
+ruleTester.run('no-realtime-teardown-in-subscribe-callback', rule, {
+  valid: [
+    // TS-1: correct pattern — null the ref inside the callback, teardown lives
+    // in a separate cleanup() function invoked outside the callback.
+    {
+      code: `
+        let subscription = channel.subscribe((status) => {
+          if (status === 'CHANNEL_ERROR' || status === 'CLOSED') {
+            subscription = null;
+            startPolling();
+          }
+        });
+        function cleanup() {
+          if (subscription) {
+            supabase.removeChannel(subscription);
+            subscription = null;
+          }
+        }
+      `,
+    },
+    // No teardown call anywhere in the callback at all.
+    {
+      code: `
+        channel.subscribe((status) => {
+          console.log('status', status);
+        });
+      `,
+    },
+    // Deferred teardown inside a nested closure (e.g. setTimeout) is NOT
+    // synchronous-within-the-callback-invocation — function-boundary exempt.
+    {
+      code: `
+        channel.subscribe((status) => {
+          if (status === 'CLOSED') {
+            setTimeout(() => {
+              supabase.removeChannel(channel);
+            }, 0);
+          }
+        });
+      `,
+    },
+    // .subscribe() with a non-function argument (e.g. an options object) —
+    // rule only activates on inline function callbacks.
+    {
+      code: `emitter.subscribe(handlerRef);`,
+    },
+    // Pragma with full REASON — valid suppression.
+    {
+      code: `
+        channel.subscribe((status) => {
+          if (status === 'CLOSED') {
+            // eslint-disable-next-line ${RULE_ID} -- channel is a DIFFERENT, unrelated one-shot subscription
+            channel.unsubscribe();
+          }
+        });
+      `,
+    },
+  ],
+
+  invalid: [
+    // TS-2: supabase.removeChannel(ref) called directly inside the callback.
+    {
+      code: `
+        const subscription = channel.subscribe((status) => {
+          if (status === 'CHANNEL_ERROR') {
+            supabase.removeChannel(subscription);
+          }
+        });
+      `,
+      errors: [{ messageId: 'noTeardownInCallback' }],
+    },
+    // TS-3: <ref>.unsubscribe() called directly inside the callback.
+    {
+      code: `
+        channel.subscribe((status) => {
+          if (status === 'TIMED_OUT') {
+            channel.unsubscribe();
+          }
+        });
+      `,
+      errors: [{ messageId: 'noTeardownInCallback' }],
+    },
+    // TS-4: nested inside an if/else status branch — still detected.
+    {
+      code: `
+        channel.subscribe((status) => {
+          if (status === 'SUBSCRIBED') {
+            console.log('ok');
+          } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT' || status === 'CLOSED') {
+            if (isVerbose) {
+              console.log('tearing down');
+            }
+            supabase.removeChannel(channel);
+          }
+        });
+      `,
+      errors: [{ messageId: 'noTeardownInCallback' }],
+    },
+    // Arrow function with expression body (no block) — still detected.
+    {
+      code: `channel.subscribe((status) => status === 'CLOSED' && supabase.removeChannel(channel));`,
+      errors: [{ messageId: 'noTeardownInCallback' }],
+    },
+    // Both removeChannel and unsubscribe present — two separate violations.
+    {
+      code: `
+        channel.subscribe((status) => {
+          if (status === 'CLOSED') {
+            supabase.removeChannel(channel);
+          }
+          if (status === 'TIMED_OUT') {
+            channel.unsubscribe();
+          }
+        });
+      `,
+      errors: [{ messageId: 'noTeardownInCallback' }, { messageId: 'noTeardownInCallback' }],
+    },
+    // Pragma present but missing the `--` REASON marker entirely.
+    {
+      code: `
+        channel.subscribe((status) => {
+          // eslint-disable-next-line ${RULE_ID}
+          channel.unsubscribe();
+        });
+      `,
+      errors: [{ messageId: 'noTeardownInCallback' }],
+    },
+    // Pragma present with `--` marker but an empty REASON body.
+    {
+      code: `
+        channel.subscribe((status) => {
+          // eslint-disable-next-line ${RULE_ID} --   \n          channel.unsubscribe();
+        });
+      `,
+      errors: [{ messageId: 'pragmaMissingReason' }],
+    },
+  ],
+});

--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFaithfulRealtimeChannelMock } from '../../helpers/faithful-supabase-realtime-mock.js';
 
 // Mock shared-services
 vi.mock('../../../lib/eva/shared-services.js', () => ({
@@ -82,19 +83,13 @@ describe('waitForDecision', () => {
   // reproducing the identical RangeError: Maximum call stack size exceeded (proven by
   // ae499d9957 / QF-20260701-709 on the sibling reality-gates.js/stage-governance.js
   // channels). The correct fix drops the local reference only and calls NEITHER
-  // unsubscribe() NOR removeChannel() from inside the callback. These tests use a mock
-  // whose removeChannel() WOULD recursively re-invoke the callback (reproducing the
-  // real vendored-client behavior) and assert it is never called.
+  // unsubscribe() NOR removeChannel() from inside the callback. These tests use the
+  // shared faithful mock (tests/helpers/faithful-supabase-realtime-mock.js), whose
+  // removeChannel() WOULD recursively re-invoke the callback (reproducing the real
+  // vendored-client behavior), and assert it is never called.
   function makeMockSupabaseWithRecursiveTeardown(singleResults) {
-    let capturedStatusCallback = null;
-    let removeChannelCallCount = 0;
-    const channelMock = {
-      on: vi.fn().mockReturnThis(),
-      subscribe: vi.fn((cb) => {
-        capturedStatusCallback = cb;
-        return channelMock;
-      }),
-    };
+    const { channelMock, removeChannel, getStatusCallback, getRemoveChannelCallCount } =
+      createFaithfulRealtimeChannelMock();
     const singleMock = vi.fn();
     singleResults.forEach((r) => singleMock.mockResolvedValueOnce(r));
     singleMock.mockResolvedValue(singleResults[singleResults.length - 1]);
@@ -105,18 +100,12 @@ describe('waitForDecision', () => {
         single: singleMock,
       }),
       channel: vi.fn().mockReturnValue(channelMock),
-      removeChannel: vi.fn(() => {
-        removeChannelCallCount++;
-        if (removeChannelCallCount > 100) {
-          throw new Error('removeChannel recursion guard tripped -- test itself would overflow');
-        }
-        capturedStatusCallback?.('CLOSED'); // simulates phoenix's synchronous Channel.leave() re-fire
-      }),
+      removeChannel: vi.fn(removeChannel),
     };
     return {
       supabase,
-      getStatusCallback: () => capturedStatusCallback,
-      getRemoveChannelCallCount: () => removeChannelCallCount,
+      getStatusCallback,
+      getRemoveChannelCallCount,
     };
   }
 

--- a/tests/unit/eva/reality-gates.test.js
+++ b/tests/unit/eva/reality-gates.test.js
@@ -14,6 +14,7 @@ import {
   _internal,
   _resetBoundaryCacheForTest,
 } from '../../../lib/eva/reality-gates.js';
+import { createFaithfulRealtimeChannelMock } from '../../helpers/faithful-supabase-realtime-mock.js';
 
 function createMockDb(artifacts = []) {
   return {
@@ -323,34 +324,22 @@ describe('RealityGates', () => {
     // the callback. These tests use a mock whose unsubscribe()/removeChannel() WOULD
     // recursively re-invoke the callback (reproducing the real vendored-client
     // behavior) and assert neither is ever called -- proving the recursion never gets
-    // a chance to start.
+    // a chance to start. Uses the shared faithful mock
+    // (tests/helpers/faithful-supabase-realtime-mock.js), wrapped with this file's own
+    // `from()` shape.
     function makeMockDbWithRecursiveTeardown() {
-      let capturedStatusCallback = null;
-      let unsubscribeCallCount = 0;
-      let removeChannelCallCount = 0;
-      const channelMock = {
-        on: function () { return this; },
-        subscribe: function (cb) { capturedStatusCallback = cb; return this; },
-        unsubscribe: function () {
-          unsubscribeCallCount++;
-          if (unsubscribeCallCount > 100) throw new Error('unsubscribe recursion guard tripped -- test itself would overflow');
-          capturedStatusCallback?.('CLOSED'); // simulates phoenix's synchronous Channel.leave() re-firing CLOSED
-        },
-      };
+      const { channelMock, removeChannel, getStatusCallback, getUnsubscribeCallCount, getRemoveChannelCallCount } =
+        createFaithfulRealtimeChannelMock();
       const sb = {
         from: vi.fn(() => ({ select: () => Promise.resolve({ data: [], error: null }) })),
         channel: () => channelMock,
-        removeChannel: function () {
-          removeChannelCallCount++;
-          if (removeChannelCallCount > 100) throw new Error('removeChannel recursion guard tripped -- test itself would overflow');
-          channelMock.unsubscribe(); // real RealtimeClient.removeChannel() calls channel.unsubscribe() internally
-        },
+        removeChannel,
       };
       return {
         sb,
-        getStatusCallback: () => capturedStatusCallback,
-        getUnsubscribeCallCount: () => unsubscribeCallCount,
-        getRemoveChannelCallCount: () => removeChannelCallCount,
+        getStatusCallback,
+        getUnsubscribeCallCount,
+        getRemoveChannelCallCount,
       };
     }
 

--- a/tests/unit/eva/stage-governance.test.js
+++ b/tests/unit/eva/stage-governance.test.js
@@ -11,6 +11,7 @@
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getStageGovernance, _resetCacheForTest } from '../../../lib/eva/stage-governance.js';
+import { createFaithfulRealtimeChannelMock } from '../../helpers/faithful-supabase-realtime-mock.js';
 
 // venture_stages rows carry gate_type + work_type + review_mode together.
 // work_type='decision_gate' is required for kill/promotion classification;
@@ -128,6 +129,42 @@ describe('stage-governance', () => {
     const gov = await getStageGovernance(supabase);
     expect(gov.isKill(3)).toBe(true);
     expect(gov.isReview(8)).toBe(true);
+  });
+
+  // SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001 FR-2: this file's
+  // mockSupabase() only ever fires 'SUBSCRIBED' (line 52), so the CHANNEL_ERROR/
+  // CLOSED/TIMED_OUT branch (line 104 of stage-governance.js) was never actually
+  // exercised by a faithful mock, despite that branch being the exact null-only fix
+  // shipped in ae499d9957/QF-20260701-709. Uses the shared faithful mock (whose
+  // unsubscribe()/removeChannel() WOULD recursively re-invoke the callback) to prove
+  // the fixed code never calls either teardown method from inside the callback.
+  test('Realtime channel teardown safety: CHANNEL_ERROR/CLOSED/TIMED_OUT drops the reference without calling unsubscribe()/removeChannel() (both would recurse)', async () => {
+    const { channelMock, removeChannel, getStatusCallback, getUnsubscribeCallCount, getRemoveChannelCallCount } =
+      createFaithfulRealtimeChannelMock();
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          order: vi.fn(async () => ({ data: VENTURE_STAGES_FIXTURE, error: null })),
+        })),
+      })),
+      channel: vi.fn(() => channelMock),
+      removeChannel,
+    };
+
+    const gov = await getStageGovernance(supabase);
+    expect(gov.isKill(3)).toBe(true);
+
+    const statusCallback = getStatusCallback();
+    expect(statusCallback).toBeTypeOf('function');
+
+    expect(() => {
+      statusCallback('CHANNEL_ERROR');
+      statusCallback('CLOSED');
+      statusCallback('TIMED_OUT');
+    }).not.toThrow();
+
+    expect(getUnsubscribeCallCount()).toBe(0);
+    expect(getRemoveChannelCallCount()).toBe(0);
   });
 
   test('propagates DB read errors instead of returning empty sets', async () => {


### PR DESCRIPTION
## Summary
- FR-1: `eslint-rules/no-realtime-teardown-in-subscribe-callback.js` (AST rule + RuleTester test) reused by `scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs` (ESLint Linter API) wired into a dedicated, genuinely-blocking GH Actions workflow — `npm run lint` itself is not invoked by any existing CI workflow in this repo, so a standalone script + dedicated workflow is the only mechanism that actually enforces anything (verified by direct grep).
- FR-2: extracted `tests/helpers/faithful-supabase-realtime-mock.js` (built for QF-20260701-762) as the single shared, canonical mock; migrated `chairman-decision-watcher.test.js` and `reality-gates.test.js` off their local duplicate mocks, and added a new regression test to `stage-governance.test.js` (whose mock never exercised the error/teardown path despite carrying the same fix).
- FR-3: ran the new tool as the audit over `lib/`+`server/` (1566 files) — zero violations; all 6 known `.subscribe()` sites cross-checked.

## Context
Three independent RCA cycles (`ae499d9957`/QF-709, then PR #5305/QF-762) fixed the same Supabase Realtime recursion crash one file at a time — each time, the regression test mocked `removeChannel()` as a no-op that never re-fires the callback, so the anti-pattern shipped green through the full LEO pipeline. This SD is the structural class-guard: SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001.

## Test plan
- [x] RuleTester unit test: 12/12 passing (valid/invalid/nested/pragma cases)
- [x] `tests/unit/eva/` full suite (424 files): 5611 passed, 19 skipped, 0 failed
- [x] Negative control: reverted `stage-governance.js`'s fix, confirmed the new faithful-mock test fails (recursion reproduced); restored, confirmed it passes; zero net diff on the production file
- [x] CI script negative control: ran against a deliberate anti-pattern fixture (exit 1, correct file:line), and against the real `lib/+server/` tree (exit 0)
- [x] GH Actions workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)