### PR TITLE
fix(QF-20260701-062): Adam + Solomon inbox-monitor baseline 15min -> 5min durable

### DIFF
--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -57,7 +57,9 @@ export const ADAM_LOOPS = [
     key: 'inbox-monitor',
     label: 'Adam inbox — drain ALL coordinator-directed kinds (full-lane reader)',
     script: 'adam-advisory.cjs',
-    cron: '*/15 * * * *',
+    // QF-20260701-062: chairman-directed 15min -> 5min durable baseline (tighter comms
+    // responsiveness on the advisory lane). Off-round minutes avoid fleet-wide :00/:05 collision.
+    cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *',
     // SD-REFILL-00YJS6VB: --quiet suppresses the no-op "(no unread...)" line on a fully-empty
     // lane so the recurring tick is SILENT when there's nothing to drain (real rows + orphaned
     // WARNINGs still surface). Reduces narration churn during quiescent/chairman-attached work.

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -68,7 +68,9 @@ export const SOLOMON_LOOPS = [
     key: 'inbox-monitor',
     label: 'Solomon inbox — drain solomon_consult + coordinator-directed kinds (full-lane reader)',
     script: 'solomon-advisory.cjs',
-    cron: '*/15 * * * *',
+    // QF-20260701-062: chairman-directed 15min -> 5min durable baseline (tighter comms
+    // responsiveness on the advisory lane). Off-round minutes avoid fleet-wide :00/:05 collision.
+    cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *',
     prompt: 'node scripts/solomon-advisory.cjs inbox --quiet',
   },
   {

--- a/tests/unit/adam/adam-machinery-consumer-invariant.test.js
+++ b/tests/unit/adam/adam-machinery-consumer-invariant.test.js
@@ -22,7 +22,8 @@ const { selectUnactionedAdvisories } = require('../../../lib/coordinator/adam-ad
 
 // Real-cadence constants (from the live system, cited inline):
 const SWEEP_CADENCE_MS = 5 * 60_000;       // cleanup_expired_coordination runs ~every 5 min (stale-session-sweep.cjs)
-const COORDINATOR_POLL_MS = 15 * 60_000;   // inbox-monitor cron '*/15 * * * *' (adam-startup-check.mjs)
+// QF-20260701-062: chairman-directed 15min -> 5min durable baseline (adam-startup-check.mjs inbox-monitor).
+const COORDINATOR_POLL_MS = 5 * 60_000;
 
 // Minimal thenable supabase stub that records the query chain (mirrors resilient-symmetric-adam.test.js).
 function makeSupabase(result, captured) {
@@ -85,8 +86,8 @@ describe('FR1+FR3 round-trip: a sent advisory survives a coordinator poll-gap un
   // Producer writes the row with the REAL TTL helper.
   const advisory = { id: 'adv-1', expires_at: advisoryExpiresAt(now0), payload: { kind: 'adam_advisory' } };
 
-  it('is NOT swept and IS returned by the reader after a >15min poll-gap', () => {
-    const atPoll = now0 + COORDINATOR_POLL_MS + 1; // coordinator's next poll, just past 15 min
+  it('is NOT swept and IS returned by the reader after a >1-poll-gap', () => {
+    const atPoll = now0 + COORDINATOR_POLL_MS + 1; // coordinator's next poll, just past one interval
     expect(sweptAway(advisory, atPoll)).toBe(false);
     expect(readerReturns(advisory, atPoll)).toBe(true);
   });
@@ -101,8 +102,11 @@ describe('FR1+FR3 round-trip: a sent advisory survives a coordinator poll-gap un
   it('COUNTERFACTUAL: the OLD request-mode TTL (now+timeoutMs+5min) WAS swept before the poll (the bug)', () => {
     const oldTtlMs = 30_000 + 5 * 60_000; // default timeoutMs(30s) + 5min ≈ 5.5min
     const oldRow = { id: 'adv-old', expires_at: new Date(now0 + oldTtlMs).toISOString(), payload: { kind: 'adam_advisory' } };
-    const atPoll = now0 + COORDINATOR_POLL_MS + 1;
-    expect(sweptAway(oldRow, atPoll)).toBe(true);       // deleted ~9.5 min before the 15-min poll
+    // QF-20260701-062: the poll cadence tightened to 5min, so the old ~5.5min TTL now
+    // outlives a SINGLE poll interval — poll 2 cycles out to keep demonstrating the bug
+    // (the old TTL is still far too short to survive to any poll a coordinator missed one tick on).
+    const atPoll = now0 + 2 * COORDINATOR_POLL_MS + 1;
+    expect(sweptAway(oldRow, atPoll)).toBe(true);       // deleted well before the 2nd poll
     expect(readerReturns(oldRow, atPoll)).toBe(false);  // gone — the exact loss this SD fixes
   });
 });
@@ -115,7 +119,9 @@ describe('FR1+FR3 round-trip: a sent advisory survives a coordinator poll-gap un
 // actual function returns exactly the surviving, unactioned advisories.
 describe('FR1+FR3 end-to-end: the REAL selectUnactionedAdvisories returns only surviving, unactioned advisories', () => {
   const now0 = 1_000_000_000_000;
-  const atPoll = now0 + COORDINATOR_POLL_MS + 1;
+  // QF-20260701-062: 2 poll cycles out, so the 'old-swept' seed row's ~5.5min old-style TTL
+  // (line below) is reliably expired regardless of the tightened 5min poll cadence.
+  const atPoll = now0 + 2 * COORDINATOR_POLL_MS + 1;
   const seed = [
     { id: 'fresh', expires_at: advisoryExpiresAt(now0), payload: { kind: 'adam_advisory' } },                                              // durable TTL, unactioned → survives + returned
     { id: 'actioned', expires_at: advisoryExpiresAt(now0), payload: { kind: 'adam_advisory', actioned_at: new Date(atPoll).toISOString() } }, // durable but actioned → gated out

--- a/tests/unit/solomon-startup-check.test.js
+++ b/tests/unit/solomon-startup-check.test.js
@@ -14,10 +14,11 @@ import {
 import { buildSelfAdherenceVerdict } from '../../scripts/solomon-self-adherence-review.mjs';
 
 describe('SOLOMON_LOOPS shape', () => {
-  it('declares inbox-monitor (solomon-advisory.cjs inbox, */15) + self-adherence (*/12h) + deep-sweep', () => {
+  it('declares inbox-monitor (solomon-advisory.cjs inbox, 5min) + self-adherence (*/12h) + deep-sweep', () => {
     const byKey = Object.fromEntries(SOLOMON_LOOPS.map((l) => [l.key, l]));
     expect(byKey['inbox-monitor'].script).toBe('solomon-advisory.cjs');
-    expect(byKey['inbox-monitor'].cron).toBe('*/15 * * * *');
+    // QF-20260701-062: chairman-directed 15min -> 5min durable baseline.
+    expect(byKey['inbox-monitor'].cron).toBe('3,8,13,18,23,28,33,38,43,48,53,58 * * * *');
     expect(byKey['inbox-monitor'].prompt).toMatch(/solomon-advisory\.cjs inbox/);
     expect(byKey['self-adherence'].script).toBe('solomon-self-adherence-review.mjs');
     expect(byKey['self-adherence'].cron).toBe('0 */12 * * *');


### PR DESCRIPTION
## Summary
- Chairman-directed 2026-07-01: change the durable inbox-monitor cadence for both Adam (`scripts/adam-startup-check.mjs`) and Solomon (`scripts/solomon-startup-check.mjs`) from `*/15 * * * *` to an off-round 5-min cadence (`3,8,13,18,23,28,33,38,43,48,53,58 * * * *`), so every future `/adam`/`/solomon` session arms the tighter cadence durably, not just the ephemeral per-session cron the chairman set this session.
- Off-round minutes avoid a fleet-wide `:00`/`:05` collision. Coordinator inbox is already `*/2` and is left unchanged.
- Pure cadence change, no logic change to the loops themselves.

## Downstream test fixes (discovered, not scope creep)
- `tests/unit/solomon-startup-check.test.js` asserted the literal old cron string — updated to the new one.
- `tests/unit/adam/adam-machinery-consumer-invariant.test.js`'s COUNTERFACTUAL and end-to-end tests modeled an old ~5.5min buggy TTL against a single poll interval, which only reliably exceeded the *old* 15-min interval — with the cadence now at 5min, the old TTL (5.5min) would outlive a single interval, silently flipping those assertions. Adjusted to poll 2 cycles out so the tests still correctly demonstrate the old TTL was too short, regardless of cadence.

## Test plan
- [x] `npx vitest run --project unit tests/unit/adam/adam-machinery-consumer-invariant.test.js tests/unit/solomon-startup-check.test.js` — 26/26 pass
- [x] `npx vitest run --project unit tests/unit/coordinator/quiet-tick-loop-parity.test.js tests/unit/coord-adam-comms-resilient.test.js` — 41/41 pass (adjacent files, confirmed no hidden breakage)
- [x] `schema-reference-lint --diff` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)