### PR TITLE
feat(SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-C): pilot ADKAR tagging + fixture validation

### DIFF
--- a/docs/protocol/adkar-pilot-worked-example.md
+++ b/docs/protocol/adkar-pilot-worked-example.md
@@ -1,0 +1,45 @@
+# ADKAR Worked Example — Adam PM-Tools Pilot
+
+**SD:** SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-C
+
+Companion to the ADKAR change-adoption framework (SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001,
+child A — `docs/protocol/adkar-change-adoption-framework.md`). Kept as a separate file rather than
+appended to that doc, since Child A and Child C build concurrently on independent sessions and a
+shared target file would create an avoidable merge conflict.
+
+## The pilot
+
+`SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001` (chairman-directed) was designated the
+first `requires_adoption`-tagged SD at sourcing time. It is a parent orchestrator decomposed into 3
+children:
+
+- **-A**: hierarchical `adam_task_ledger` (parent_id + status/blocker rollup) + CRUD + rehydration
+  module + `/adam` startup rehydrate hook.
+- **-B**: board↔reality reconcile in the Adam tick, stall-alert escalation, chairman-curated view,
+  `ADAM_LOOPS` entry + `CLAUDE_ADAM.md` durable-duty marker + RESPONSIBILITIES landing.
+- **-C**: `probePmBoard` self-adherence probe (`lib/adam/adherence-probes.js`) — FAILs on
+  regression-to-non-use (board stale / open threads not progressing), enforcing adoption-is-acceptance.
+
+## The mapping
+
+| ADKAR stage | Evidence | Citation |
+|---|---|---|
+| Awareness | evidenced | -B's role-contract + `ADAM_LOOPS` wiring surfaces the change to affected live sessions |
+| Desire | evidenced | The pilot SD's own rationale (`key_risk` + `adam_stall_alert` metadata) documents the why/benefit |
+| Knowledge | evidenced | -B's `CLAUDE_ADAM.md` durable-duty marker + RESPONSIBILITIES landing documents the how |
+| Ability | evidenced | -A's task-ledger + CRUD + rehydration makes the board actually usable/consumed |
+| Reinforcement | evidenced | -C's self-adherence probe catches regression-to-non-use |
+
+This mapping was applied to the pilot SD's `strategic_directives_v2.metadata` as
+`requires_adoption: true` + `adkar_checklist: {...}` (see SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-C
+FR-1), via an additive-only update verified by before/after diff — no other metadata field on the
+live pilot SD was touched. `tests/unit/adkar-pilot-evidence-fixture.test.js` proves this exact mapping
+satisfies the documented ADKAR completion contract using a fixture, independent of the pilot's own
+completion timing (which is owned by another session and outside this SD's control).
+
+## Why the pilot itself, not just its children
+
+The pilot's -A/-B/-C children were scoped and named *before* the ADKAR framework existed — they were
+not built "for" ADKAR. The point of this worked example is exactly that: ADKAR formalizes work LEO
+was already doing implicitly (durable rehydration = Ability, self-adherence probes = Reinforcement),
+rather than demanding new adoption ceremony bolted onto every change.

--- a/tests/unit/adkar-pilot-evidence-fixture.test.js
+++ b/tests/unit/adkar-pilot-evidence-fixture.test.js
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-C (FR-2)
+ *
+ * Proves the pilot's ADKAR evidence mapping (applied to
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001's metadata by this SD, see FR-1)
+ * satisfies the documented completion contract from the parent PRD's FR-2 — WITHOUT depending
+ * on sibling Child B's actual gate implementation, which lands independently and did not exist
+ * in this worktree at build time (Child B was still in LEAD phase, unclaimed code, when this
+ * child was built — the two children are concurrency-safe by design, not sequenced).
+ *
+ * `evaluateAdkarChecklist` below is a small, self-contained validator implementing the EXACT
+ * documented contract (parent PRD FR-2 / docs/protocol/adkar-change-adoption-framework.md once
+ * Child A lands): no-op pass if !metadata.requires_adoption; else every one of the 5 stages
+ * (awareness/desire/knowledge/ability/reinforcement) must be present with either
+ * `evidenced:true`+`citation` or `waived:true`+`reason`. When sibling Child B's real gate
+ * lands, it should implement this SAME contract — this test is the executable specification,
+ * not a substitute for Child B's own gate + its own tests.
+ */
+import { describe, it, expect } from 'vitest';
+
+const ADKAR_STAGES = ['awareness', 'desire', 'knowledge', 'ability', 'reinforcement'];
+
+/** Mirrors the documented ADKAR completion-gate contract (parent PRD FR-2). Pure, no I/O. */
+function evaluateAdkarChecklist(metadata) {
+  if (!metadata || metadata.requires_adoption !== true) {
+    return { passed: true, applicable: false, missingStages: [] };
+  }
+  const checklist = metadata.adkar_checklist || {};
+  const missingStages = ADKAR_STAGES.filter((stage) => {
+    const entry = checklist[stage];
+    if (!entry) return true;
+    const hasEvidence = entry.evidenced === true && typeof entry.citation === 'string' && entry.citation.length > 0;
+    const hasWaiver = entry.waived === true && typeof entry.reason === 'string' && entry.reason.length > 0;
+    return !hasEvidence && !hasWaiver;
+  });
+  return { passed: missingStages.length === 0, applicable: true, missingStages };
+}
+
+describe('evaluateAdkarChecklist — documented contract (parent PRD FR-2)', () => {
+  it('is a no-op pass when requires_adoption is not set', () => {
+    const result = evaluateAdkarChecklist({});
+    expect(result).toEqual({ passed: true, applicable: false, missingStages: [] });
+  });
+
+  it('fails and names every missing stage when requires_adoption=true with no checklist', () => {
+    const result = evaluateAdkarChecklist({ requires_adoption: true });
+    expect(result.passed).toBe(false);
+    expect(result.applicable).toBe(true);
+    expect(result.missingStages.sort()).toEqual([...ADKAR_STAGES].sort());
+  });
+
+  it('fails naming only the incomplete stages', () => {
+    const result = evaluateAdkarChecklist({
+      requires_adoption: true,
+      adkar_checklist: {
+        awareness: { evidenced: true, citation: 'x' },
+        desire: { waived: true, reason: 'n/a for this change' },
+        // knowledge, ability, reinforcement missing
+      },
+    });
+    expect(result.passed).toBe(false);
+    expect(result.missingStages.sort()).toEqual(['ability', 'knowledge', 'reinforcement'].sort());
+  });
+
+  it('passes when every stage is evidenced or waived-with-reason', () => {
+    const result = evaluateAdkarChecklist({
+      requires_adoption: true,
+      adkar_checklist: {
+        awareness: { evidenced: true, citation: 'x' },
+        desire: { waived: true, reason: 'n/a' },
+        knowledge: { evidenced: true, citation: 'y' },
+        ability: { evidenced: true, citation: 'z' },
+        reinforcement: { evidenced: true, citation: 'w' },
+      },
+    });
+    expect(result).toEqual({ passed: true, applicable: true, missingStages: [] });
+  });
+});
+
+describe('the pilot mapping (SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001) satisfies the contract', () => {
+  // Fixture, NOT a live query — exact shape applied to the pilot SD's metadata by this SD's
+  // FR-1 (verified separately via a before/after DB diff, not by this test). Kept in sync by
+  // hand; if the real applied shape ever drifts, TS-1/TS-2 (the DB-level acceptance criteria)
+  // are the source of truth, not this fixture.
+  const pilotFixtureMetadata = {
+    requires_adoption: true,
+    adkar_checklist: {
+      awareness: { evidenced: true, citation: 'SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B — role-contract + ADAM_LOOPS wiring surfaces the reconcile/stall-alert change to affected live sessions' },
+      desire: { evidenced: true, citation: 'Pilot SD rationale (existing Why-style justification): key_risk field documents cross-session persistence motivation; adam_stall_alert documents the chairman-directed benefit' },
+      knowledge: { evidenced: true, citation: 'SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B — CLAUDE_ADAM.md durable-duty marker + RESPONSIBILITIES landing documents the how' },
+      ability: { evidenced: true, citation: 'SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A — hierarchical adam_task_ledger + CRUD + rehydration module makes the board actually usable/consumed' },
+      reinforcement: { evidenced: true, citation: 'SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-C — probePmBoard self-adherence probe FAILs on regression-to-non-use (board stale / threads not progressing)' },
+    },
+  };
+
+  it('evaluates as fully passing', () => {
+    const result = evaluateAdkarChecklist(pilotFixtureMetadata);
+    expect(result).toEqual({ passed: true, applicable: true, missingStages: [] });
+  });
+
+  it('each stage cites a real pilot child sd_key or the pilot SD itself', () => {
+    for (const stage of ADKAR_STAGES) {
+      const entry = pilotFixtureMetadata.adkar_checklist[stage];
+      expect(entry.citation).toMatch(/SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001|Pilot SD rationale/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Tags `SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001` (the designated ADKAR pilot, an active parent orchestrator on another live session) with `metadata.requires_adoption=true` and `metadata.adkar_checklist` mapping its 3 planned children to the 5 ADKAR stages.
- Applied via an additive-only read-modify-write, verified by before/after diff — only the 2 new metadata keys changed, zero other fields on the live pilot SD were touched (confirmed live during EXEC, not just asserted).
- New `tests/unit/adkar-pilot-evidence-fixture.test.js`: a self-contained validator implementing the documented ADKAR completion contract (parent PRD FR-2), proving the pilot's mapping satisfies it via a fixture — intentionally decoupled from sibling Child B's actual gate implementation, which was still unclaimed/unbuilt at build time (children build concurrently, not sequenced).
- New `docs/protocol/adkar-pilot-worked-example.md`: kept as a standalone companion file rather than appended to sibling Child A's in-flight target doc, to avoid an avoidable merge conflict between concurrently-building siblings.

Child of SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001 (parent orchestrator, FR-3).

## Test plan
- [x] `npx vitest run tests/unit/adkar-pilot-evidence-fixture.test.js` — 6/6 passing
- [x] Live before/after diff of the pilot SD's metadata confirms additive-only change (only `requires_adoption` + `adkar_checklist` added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)