### PR TITLE
feat(SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C): event-driven dispatch_rank stamping at the claimable moment

### DIFF
--- a/lib/coordinator/clear-coordinator-review.js
+++ b/lib/coordinator/clear-coordinator-review.js
@@ -1,0 +1,73 @@
+/**
+ * lib/coordinator/clear-coordinator-review.js — SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-2)
+ *
+ * FIRST canonical write-site for strategic_directives_v2.metadata.needs_coordinator_review.
+ * Today only 2 READ sites exist (lib/fleet/claim-eligibility.cjs:82, lib/coordinator/dispatch.cjs:163,
+ * both strict `=== true` checks) — clearing the flag to false IS the coordinator's dispatch
+ * authorization (CLAUDE_ADAM.md). No production write path existed before this.
+ *
+ * Uses an ATOMIC JSONB partial merge (`metadata || '{"needs_coordinator_review": false}'::jsonb`)
+ * via the raw pg Client, NOT a supabase-js read-then-spread-then-write of the whole metadata blob.
+ * A read-modify-write here would be silently reverted by a concurrent coordinator-backlog-rank.mjs
+ * pass that read a stale snapshot before this write landed (database-agent finding, PLAN phase) —
+ * re-blocking a just-authorized SD with no error. supabase-js's `.update()` cannot express a JSONB
+ * `||` merge directly, so this goes through scripts/lib/supabase-connection.js::createDatabaseClient
+ * instead (service-role Postgres connection — RLS on strategic_directives_v2 restricts anon/
+ * authenticated writes via venture_update_strategic_directives_v2).
+ *
+ * After the atomic clear, fires an event-driven rank pass (fire-and-forget) so the newly-authorized
+ * SD is ranked promptly instead of waiting for the next 15-min cron tick.
+ */
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+import { triggerRankPass } from './trigger-rank-pass.mjs';
+
+/**
+ * buildClearReviewQuery — pure helper: the exact atomic-merge SQL/params. Extracted for
+ * unit testing without a live pg connection.
+ * @param {string} sdKey
+ * @returns {{sql: string, params: any[]}}
+ */
+export function buildClearReviewQuery(sdKey) {
+  return {
+    sql: "UPDATE strategic_directives_v2 SET metadata = metadata || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1",
+    params: [sdKey],
+  };
+}
+
+/**
+ * clearCoordinatorReview — clear metadata.needs_coordinator_review to false for one SD via
+ * an atomic JSONB merge, then trigger an event-driven rank pass.
+ *
+ * @param {string} sdKey
+ * @param {object} [opts]
+ * @param {Function} [opts.createClientFn] test-injection seam (defaults to createDatabaseClient)
+ * @param {Function} [opts.triggerFn] test-injection seam (defaults to triggerRankPass)
+ * @returns {Promise<{cleared: boolean, sdKey: string, error?: string}>}
+ */
+export async function clearCoordinatorReview(sdKey, opts = {}) {
+  if (!sdKey || typeof sdKey !== 'string') {
+    throw new Error('clearCoordinatorReview: sdKey is required');
+  }
+  const { createClientFn = createDatabaseClient, triggerFn = triggerRankPass } = opts;
+
+  let client;
+  try {
+    client = await createClientFn('engineer', { verify: false });
+  } catch (connErr) {
+    return { cleared: false, sdKey, error: `db_connect_failed: ${connErr.message}` };
+  }
+
+  try {
+    const { sql, params } = buildClearReviewQuery(sdKey);
+    const result = await client.query(sql, params);
+    const cleared = result.rowCount > 0;
+    if (cleared) {
+      triggerFn({ reason: 'clear_coordinator_review', sdKey });
+    }
+    return { cleared, sdKey, ...(cleared ? {} : { error: 'no_matching_row' }) };
+  } catch (queryErr) {
+    return { cleared: false, sdKey, error: queryErr.message };
+  } finally {
+    try { await client.end(); } catch { /* best-effort close */ }
+  }
+}

--- a/lib/coordinator/clear-coordinator-review.js
+++ b/lib/coordinator/clear-coordinator-review.js
@@ -28,8 +28,12 @@ import { triggerRankPass } from './trigger-rank-pass.mjs';
  * @returns {{sql: string, params: any[]}}
  */
 export function buildClearReviewQuery(sdKey) {
+  // Adversarial review (ship gate): NULL::jsonb || '{...}'::jsonb evaluates to NULL in Postgres —
+  // an unguarded merge on a row whose metadata is ever SQL NULL would silently WIPE the entire
+  // blob while still reporting success. metadata is nullable (default '{}'::jsonb); COALESCE
+  // makes the merge safe regardless of the column's current value.
   return {
-    sql: "UPDATE strategic_directives_v2 SET metadata = metadata || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1",
+    sql: "UPDATE strategic_directives_v2 SET metadata = COALESCE(metadata, '{}'::jsonb) || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1",
     params: [sdKey],
   };
 }

--- a/lib/coordinator/trigger-rank-pass.mjs
+++ b/lib/coordinator/trigger-rank-pass.mjs
@@ -1,0 +1,112 @@
+/**
+ * lib/coordinator/trigger-rank-pass.mjs — SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-1/FR-4)
+ *
+ * Shared fire-and-forget trigger for an event-driven belt-wide rank pass, invoked at 3
+ * transition points (SD creation, needs_coordinator_review clearance, predecessor
+ * completion) so a freshly-claimable SD is never invisible to a parked worker for up to
+ * the 15-min coordinator-backlog-rank.mjs cron window.
+ *
+ * Debounced via a filesystem lockfile (mirrors lib/npm-install-lock.js's Windows-safe
+ * 'wx'-flag atomic-create + stale-age pattern — NOT in-memory, since the 3 call sites run
+ * in 3 separate OS processes). Spawns the EXISTING coordinator-backlog-rank.mjs verbatim
+ * (reuses its ranking algorithm, never reimplements it) with RANK_EVENT_TRIGGER=1 scoped
+ * ONLY to the spawned child's env — this bypasses the coordinator-vs-coordinator mutation
+ * guard for this one invocation (a full re-rank is idempotent/deterministic, unlike the
+ * stateful duties that guard protects). Never set on process.env directly: an interactive
+ * coordinator session inheriting this var would skip its OWN single-writer guard.
+ */
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RANKER_SCRIPT = path.resolve(__dirname, '../../scripts/coordinator-backlog-rank.mjs');
+const DEFAULT_LOCK_PATH = path.resolve(__dirname, '../../node_modules/.rank-pass-trigger.lock');
+export const DEBOUNCE_MS = 30 * 1000;
+
+function isProcessRunning(pid) {
+  if (!pid || typeof pid !== 'number') return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM'; // exists but no permission -> still running
+  }
+}
+
+/**
+ * acquireDebounceLock — true if this call may proceed (no fresh lock held by a live process).
+ * Mirrors lib/npm-install-lock.js's acquireLock() stale/dead-holder handling.
+ * @param {string} [lockPath] test-injectable lock file path (defaults to the real shared lock)
+ * @returns {boolean}
+ */
+export function acquireDebounceLock(lockPath = DEFAULT_LOCK_PATH) {
+  if (fs.existsSync(lockPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+      const age = Date.now() - data.timestamp;
+      if (age > DEBOUNCE_MS) {
+        fs.unlinkSync(lockPath); // stale — fall through to re-acquire
+      } else if (data.pid && !isProcessRunning(data.pid)) {
+        fs.unlinkSync(lockPath); // dead holder — fall through to re-acquire
+      } else {
+        return false; // fresh lock, live holder — debounced
+      }
+    } catch {
+      try { fs.unlinkSync(lockPath); } catch { /* best-effort cleanup of a corrupt lock */ }
+    }
+  }
+
+  const dir = path.dirname(lockPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  try {
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, timestamp: Date.now() }), { flag: 'wx' });
+    return true;
+  } catch (err) {
+    // EEXIST: another process won the race between our check and write — debounced.
+    // Any other error: don't let lock machinery block the actual trigger.
+    return err.code !== 'EEXIST';
+  }
+}
+
+/**
+ * triggerRankPass — fire-and-forget event-driven rank pass. Never throws; a failure here
+ * must never block SD creation, review clearance, or SD completion.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.reason] human-readable trigger source, for logging
+ * @param {string} [opts.sdKey] the SD that triggered this pass, for logging
+ * @param {Function} [opts.spawnFn] test-injection seam (defaults to node:child_process.spawn)
+ * @param {string} [opts.lockPath] test-injection seam for the debounce lock file path
+ * @returns {{triggered: boolean, reason: string}}
+ */
+export function triggerRankPass(opts = {}) {
+  const { reason = 'event', sdKey, spawnFn = spawn, lockPath = DEFAULT_LOCK_PATH } = opts;
+
+  try {
+    if (!acquireDebounceLock(lockPath)) {
+      return { triggered: false, reason: 'debounced' };
+    }
+  } catch (lockErr) {
+    // Lock machinery itself must never block the trigger — fail OPEN (proceed to spawn).
+    console.warn(`   [rank-pass-trigger] debounce lock check failed (non-blocking): ${lockErr.message}`);
+  }
+
+  try {
+    const child = spawnFn('node', [RANKER_SCRIPT], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env, RANK_EVENT_TRIGGER: '1' },
+    });
+    child.on('error', (err) => {
+      console.warn(`   [rank-pass-trigger] spawn failed for ${reason}${sdKey ? ` (${sdKey})` : ''} (non-blocking): ${err.message}`);
+    });
+    if (typeof child.unref === 'function') child.unref();
+    return { triggered: true, reason };
+  } catch (spawnErr) {
+    console.warn(`   [rank-pass-trigger] spawn threw for ${reason}${sdKey ? ` (${sdKey})` : ''} (non-blocking): ${spawnErr.message}`);
+    return { triggered: false, reason: 'spawn_error' };
+  }
+}

--- a/scripts/clear-coordinator-review.mjs
+++ b/scripts/clear-coordinator-review.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * scripts/clear-coordinator-review.mjs — CLI wrapper for lib/coordinator/clear-coordinator-review.js
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-2)
+ *
+ * CLAUDE_ADAM.md:109 documents the mechanic ("that clear IS the coordinator's dispatch
+ * authorization") but no callable path existed — a review-pending SD could only be cleared
+ * by hand-editing the DB. This gives the coordinator role a real, audited entrypoint.
+ *
+ * Usage: node scripts/clear-coordinator-review.mjs <SD-KEY>
+ */
+import 'dotenv/config';
+import { clearCoordinatorReview } from '../lib/coordinator/clear-coordinator-review.js';
+
+const sdKey = process.argv[2];
+if (!sdKey) {
+  console.error('Usage: node scripts/clear-coordinator-review.mjs <SD-KEY>');
+  process.exit(1);
+}
+
+const result = await clearCoordinatorReview(sdKey);
+if (result.cleared) {
+  console.log(`✅ ${sdKey}: metadata.needs_coordinator_review cleared to false — dispatch authorized.`);
+} else {
+  console.error(`❌ ${sdKey}: not cleared (${result.error})`);
+  process.exit(1);
+}

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -130,8 +130,12 @@ export function buildRankPatch(rank, nowIso, sessionId) {
   return { dispatch_rank: rank, dispatch_rank_at: nowIso, dispatch_rank_by: sessionId };
 }
 export function buildRankMergeQuery(rankPatch, sdKey) {
+  // Adversarial review (ship gate): NULL::jsonb || '{...}'::jsonb evaluates to NULL in Postgres —
+  // an unguarded merge on a row whose metadata is ever SQL NULL would silently WIPE the entire
+  // blob while still reporting success. metadata is nullable (default '{}'::jsonb); COALESCE
+  // makes the merge safe regardless of the column's current value.
   return {
-    sql: 'UPDATE strategic_directives_v2 SET metadata = metadata || $1::jsonb WHERE sd_key = $2',
+    sql: 'UPDATE strategic_directives_v2 SET metadata = COALESCE(metadata, \'{}\'::jsonb) || $1::jsonb WHERE sd_key = $2',
     params: [JSON.stringify(rankPatch), sdKey],
   };
 }
@@ -449,15 +453,16 @@ async function main() {
   // metadata key on the same row during that window was silently clobbered by this pass's stale
   // snapshot (database-agent finding, PLAN phase). A `metadata || '{...}'::jsonb` merge touches
   // only the 3 dispatch_rank* keys, so it can no longer clobber a concurrent unrelated write.
-  // Falls back to the legacy full-blob write if the pg Client cannot connect — never lets a
-  // DB-connectivity issue hard-fail the whole ranking pass.
+  // If the pg Client cannot connect, per-row writes are SKIPPED below (not degraded to the
+  // legacy full-blob write — that would silently reintroduce the exact race this closes;
+  // adversarial review, ship gate) — never lets a DB-connectivity issue hard-fail the whole pass.
   let pgClient = null;
   if (!DRY) {
     try {
       const { createDatabaseClient } = await import('./lib/supabase-connection.js');
       pgClient = await createDatabaseClient('engineer', { verify: false });
     } catch (connErr) {
-      console.error(`[BACKLOG-RANK] ! atomic-merge DB client unavailable, falling back to full-blob writes: ${connErr.message}`);
+      console.error(`[BACKLOG-RANK] ! atomic-merge DB client unavailable, writes will be skipped this pass: ${connErr.message}`);
     }
   }
 
@@ -474,10 +479,13 @@ async function main() {
         await pgClient.query(sql, params);
         writes++;
       } else {
-        const meta = { ...(d.metadata || {}), ...rankPatch };
-        const { error: e } = await sb.from('strategic_directives_v2').update({ metadata: meta }).eq('sd_key', d.sd_key);
-        if (e) console.error(`  ! write failed for ${d.sd_key}: ${e.message}`);
-        else writes++;
+        // Adversarial review (ship gate): the previous fallback here was the original
+        // read-spread-write full-blob update — it silently reintroduced the exact
+        // stale-snapshot race this SD closes (a concurrent clearCoordinatorReview() write
+        // landing in this window would be clobbered back). SKIPPING is the safe fail-soft
+        // choice: this row simply misses a rank refresh this pass and is picked up by the
+        // next cron tick or event trigger, rather than corrupting concurrent state.
+        console.error(`  ! skipped ${d.sd_key}: no atomic-merge DB client available (would reintroduce a stale-write race)`);
       }
     } catch (e) { console.error(`  ! ${d.sd_key}: ${e.message}`); } // fail-soft per item
   }

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -124,6 +124,17 @@ export function productPivotCompare(a, b, active) {
   if (!active) return 0;
   return productPivotRank(a) - productPivotRank(b);
 }
+// SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: pure helpers for the atomic JSONB merge
+// write path. Extracted so the query shape is unit-testable without a live pg connection.
+export function buildRankPatch(rank, nowIso, sessionId) {
+  return { dispatch_rank: rank, dispatch_rank_at: nowIso, dispatch_rank_by: sessionId };
+}
+export function buildRankMergeQuery(rankPatch, sdKey) {
+  return {
+    sql: 'UPDATE strategic_directives_v2 SET metadata = metadata || $1::jsonb WHERE sd_key = $2',
+    params: [JSON.stringify(rankPatch), sdKey],
+  };
+}
 // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-C (FR-2): needle-movement prioritization.
 // Reuse FR-1's rollup (active rung + per-rung progress) and the pure needle scorer to order remaining
 // work active-rung-first among same-unlock candidates. Loaded fail-soft — any read error leaves the
@@ -407,12 +418,46 @@ async function main() {
   // (the SELECT/ranking reads above are always allowed). Skip the write if this session
   // is not the canonical coordinator. Fail-open on resolver error / no session_id.
   // Finding 1: env-first with disk-pointer fallback so an out-of-band run still resolves.
+  //
+  // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: RANK_EVENT_TRIGGER=1 (set ONLY on the
+  // spawned child's env by lib/coordinator/trigger-rank-pass.mjs, never on an interactive
+  // process.env) bypasses this guard entirely. The guard exists to stop a rogue NON-canonical
+  // coordinator daemon from double-acting on STATEFUL duties; this pass is a deterministic,
+  // idempotent full re-rank, so redundant concurrent runs converge to the same output instead
+  // of corrupting state. Without this bypass, an event-triggered run from a worker session is
+  // blocked whenever ANY coordinator is live — the normal fleet state, not an edge case
+  // (prospective testing-agent finding, PLAN phase).
   const me = resolveOwnSessionId();
+  const eventTriggered = process.env.RANK_EVENT_TRIGGER === '1';
   if (!DRY) {
-    const _rankGuard = await guardMutation(sb, me, 'coordinator-backlog-rank');
-    if (!_rankGuard.allowed) {
-      console.log('[BACKLOG-RANK] mutation blocked by coordinator guard — not the canonical coordinator; skipping writes.');
-      return;
+    if (eventTriggered) {
+      console.log('[BACKLOG-RANK] event-triggered invocation (RANK_EVENT_TRIGGER=1) — bypassing coordinator mutation guard.');
+    } else {
+      const _rankGuard = await guardMutation(sb, me, 'coordinator-backlog-rank');
+      if (!_rankGuard.allowed) {
+        console.log('[BACKLOG-RANK] mutation blocked by coordinator guard — not the canonical coordinator; skipping writes.');
+        return;
+      }
+    }
+  }
+
+  // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: an atomic JSONB partial-merge pg Client,
+  // used below instead of supabase-js's read-spread-write full-blob update. The prior pattern
+  // (`{ ...(d.metadata||{}), dispatch_rank, ... }` then `.update({metadata: meta})`) read the
+  // whole table once at the top of this function, then wrote a full metadata blob per row —
+  // any OTHER writer (e.g. lib/coordinator/clear-coordinator-review.js) that changed a different
+  // metadata key on the same row during that window was silently clobbered by this pass's stale
+  // snapshot (database-agent finding, PLAN phase). A `metadata || '{...}'::jsonb` merge touches
+  // only the 3 dispatch_rank* keys, so it can no longer clobber a concurrent unrelated write.
+  // Falls back to the legacy full-blob write if the pg Client cannot connect — never lets a
+  // DB-connectivity issue hard-fail the whole ranking pass.
+  let pgClient = null;
+  if (!DRY) {
+    try {
+      const { createDatabaseClient } = await import('./lib/supabase-connection.js');
+      pgClient = await createDatabaseClient('engineer', { verify: false });
+    } catch (connErr) {
+      console.error(`[BACKLOG-RANK] ! atomic-merge DB client unavailable, falling back to full-blob writes: ${connErr.message}`);
     }
   }
 
@@ -422,13 +467,21 @@ async function main() {
     const rank = i + 1;
     console.log(`  #${String(rank).padStart(2)}  unlocks=${String(unlockScore(d.sd_key)).padStart(2)}  ${String(d.priority || '-').padEnd(8)} ${d.sd_key}`);
     if (DRY) continue;
+    const rankPatch = buildRankPatch(rank, now, process.env.CLAUDE_SESSION_ID || 'coordinator');
     try {
-      const meta = { ...(d.metadata || {}), dispatch_rank: rank, dispatch_rank_at: now, dispatch_rank_by: process.env.CLAUDE_SESSION_ID || 'coordinator' };
-      const { error: e } = await sb.from('strategic_directives_v2').update({ metadata: meta }).eq('sd_key', d.sd_key);
-      if (e) console.error(`  ! write failed for ${d.sd_key}: ${e.message}`);
-      else writes++;
+      if (pgClient) {
+        const { sql, params } = buildRankMergeQuery(rankPatch, d.sd_key);
+        await pgClient.query(sql, params);
+        writes++;
+      } else {
+        const meta = { ...(d.metadata || {}), ...rankPatch };
+        const { error: e } = await sb.from('strategic_directives_v2').update({ metadata: meta }).eq('sd_key', d.sd_key);
+        if (e) console.error(`  ! write failed for ${d.sd_key}: ${e.message}`);
+        else writes++;
+      }
     } catch (e) { console.error(`  ! ${d.sd_key}: ${e.message}`); } // fail-soft per item
   }
+  if (pgClient) { try { await pgClient.end(); } catch { /* best-effort close */ } }
 
   // ── clear stale ranks on rows no longer claimable (claimed/blocked now) ──
   if (!DRY) {
@@ -463,6 +516,20 @@ async function main() {
     } catch { /* fail-soft: terminal-sweep query error never kills the pass */ }
   }
   console.log(`[BACKLOG-RANK] done — ${DRY ? 'no writes (dry-run)' : `${writes} rank(s) written, ${clears} stale rank(s) cleared`}`);
+
+  // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-4d): event-triggered runs are spawned
+  // detached with stdio:'ignore' (trigger-rank-pass.mjs), so child.on('error') only catches
+  // spawn-level failures — an internal failure mid-pass would otherwise be silently invisible.
+  // One fail-soft appended line closes that gap without changing the fire-and-forget contract.
+  if (eventTriggered) {
+    try {
+      const fs = await import('node:fs');
+      const logDir = new URL('../logs/', import.meta.url);
+      fs.mkdirSync(logDir, { recursive: true });
+      fs.appendFileSync(new URL('rank-pass-events.log', logDir),
+        `${JSON.stringify({ at: now, writes, clears, dry: DRY })}\n`);
+    } catch { /* observability line must never fail the pass */ }
+  }
 }
 
 // SD-REFILL-00AH2L4Q: guard the entrypoint so the module is importable for unit tests

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -2160,6 +2160,17 @@ async function createSD(options) {
     });
   } catch { /* CLI tracking is fire-and-forget */ }
 
+  // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-1): trigger an event-driven rank pass so
+  // this freshly-created SD gets metadata.dispatch_rank within seconds instead of waiting for the
+  // next 15-min coordinator-backlog-rank.mjs cron tick. Mirrors the min_tier_rank stamp above —
+  // fire-and-forget, never blocks SD creation.
+  try {
+    const { triggerRankPass } = await import('../lib/coordinator/trigger-rank-pass.mjs');
+    triggerRankPass({ reason: 'sd_created', sdKey: data.sd_key });
+  } catch (rankTriggerErr) {
+    console.warn(`   ⚠️  rank-pass trigger skipped (non-blocking): ${rankTriggerErr.message}`);
+  }
+
   // FR-005 (SD-LEO-INFRA-BRAINSTORM-SD-PIPELINE-001): Backfill brainstorm_sessions.created_sd_id
   // When an SD is created with a vision_key from a brainstorm, link it back to the originating session
   if (metadata?.vision_key) {

--- a/scripts/modules/handoff/executors/lead-final-approval/hooks/rank-on-completion-hook.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/hooks/rank-on-completion-hook.js
@@ -1,0 +1,22 @@
+/**
+ * rank-on-completion-hook — SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-3)
+ *
+ * After an SD completes, any dependent/child SD it was blocking may have just become
+ * claimable. Trigger an event-driven rank pass so that dependent gets a fresh
+ * metadata.dispatch_rank within seconds instead of waiting for the next 15-min
+ * coordinator-backlog-rank.mjs cron tick. Fire-and-forget — a failure here must never
+ * block or fail the SD completion itself.
+ */
+import { triggerRankPass } from '../../../../../../lib/coordinator/trigger-rank-pass.mjs';
+
+/**
+ * @param {object} sd the completed SD row (has sd_key/id)
+ * @param {object} supabase unused directly (trigger-rank-pass spawns its own connection) —
+ *   accepted for signature parity with the other lead-final-approval hooks.
+ * @returns {Promise<{outcome: string}>}
+ */
+export async function runRankOnCompletionHook(sd, supabase) { // eslint-disable-line no-unused-vars
+  const sdKey = sd?.sd_key || sd?.id;
+  const result = triggerRankPass({ reason: 'sd_completed', sdKey });
+  return { outcome: result.triggered ? 'triggered' : result.reason };
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -620,6 +620,17 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       console.warn(`   ⚠️  QF resolution-link advisory failed (non-blocking): ${qfAdvisoryError.message}`);
     }
 
+    // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-3): trigger an event-driven rank
+    // pass so any dependent/child SD newly unblocked by this completion gets ranked within
+    // seconds instead of waiting for the next 15-min cron tick. Fire-and-forget, never blocks.
+    try {
+      const { runRankOnCompletionHook } = await import('./hooks/rank-on-completion-hook.js');
+      const rankResult = await runRankOnCompletionHook(sd, this.supabase);
+      console.log(`   [rank-on-completion] ${rankResult.outcome}`);
+    } catch (rankHookError) {
+      console.warn(`   ⚠️  Rank-on-completion hook failed (non-blocking): ${rankHookError.message}`);
+    }
+
     // SD-LEO-INFRA-PROGRAMMATIC-TOOL-CALLING-001: Auto-populate retrospective via programmatic scorer.
     // Generates SD-specific insights with real file references — avoids RETROSPECTIVE_QUALITY_GATE failures.
     // Fail-safe: non-blocking, never prevents SD completion.

--- a/tests/unit/coordinator-backlog-rank-merge-write.test.js
+++ b/tests/unit/coordinator-backlog-rank-merge-write.test.js
@@ -1,0 +1,65 @@
+/**
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-5): the atomic JSONB merge write path
+ * that replaced coordinator-backlog-rank.mjs's read-spread-write full-metadata-blob update.
+ *
+ * buildRankPatch/buildRankMergeQuery are pure — extracted so the query shape (and, critically,
+ * that it touches ONLY the 3 dispatch_rank* keys via a `||` merge) is provable without a live
+ * pg connection. TS-3's concurrency claim ("neither writer's output is lost") reduces to a pure
+ * structural fact once both writers use `||`-merge semantics instead of full-blob overwrites —
+ * that structural proof is what the "simulated concurrency" test below encodes.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildRankPatch, buildRankMergeQuery } from '../../scripts/coordinator-backlog-rank.mjs';
+import { buildClearReviewQuery } from '../../lib/coordinator/clear-coordinator-review.js';
+
+describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: buildRankPatch/buildRankMergeQuery', () => {
+  it('buildRankPatch returns exactly the 3 dispatch_rank* keys (mirrors stripDispatchRank\'s key set)', () => {
+    const patch = buildRankPatch(3, '2026-07-01T00:00:00.000Z', 'session-abc');
+    expect(Object.keys(patch).sort()).toEqual(['dispatch_rank', 'dispatch_rank_at', 'dispatch_rank_by'].sort());
+    expect(patch).toEqual({ dispatch_rank: 3, dispatch_rank_at: '2026-07-01T00:00:00.000Z', dispatch_rank_by: 'session-abc' });
+  });
+
+  it('buildRankMergeQuery uses a JSONB || merge, not a full-column overwrite', () => {
+    const { sql, params } = buildRankMergeQuery({ dispatch_rank: 1, dispatch_rank_at: 'now', dispatch_rank_by: 'x' }, 'SD-TEST-001');
+    expect(sql).toMatch(/metadata\s*\|\|\s*\$1::jsonb/);
+    expect(sql).not.toMatch(/SET metadata = \$1/); // guards against regressing to a full-blob SET
+    expect(params[0]).toBe(JSON.stringify({ dispatch_rank: 1, dispatch_rank_at: 'now', dispatch_rank_by: 'x' }));
+    expect(params[1]).toBe('SD-TEST-001');
+  });
+});
+
+describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: TS-3 concurrency-safety (structural proof)', () => {
+  it('a rank-write patch and a clear-review patch touch disjoint metadata keys', () => {
+    const rankPatch = buildRankPatch(5, '2026-07-01T00:00:00.000Z', 'coordinator');
+    const clearPatch = { needs_coordinator_review: false };
+    const overlap = Object.keys(rankPatch).filter((k) => k in clearPatch);
+    expect(overlap).toEqual([]); // no shared key -> `||` merges from either writer can never clobber the other
+  });
+
+  it('applying both patches via JSONB || semantics survives regardless of interleaving order', () => {
+    // Simulates Postgres `metadata || patch` semantics (shallow merge, patch keys win) — this is
+    // exactly what buildRankMergeQuery / buildClearReviewQuery issue server-side. Because the two
+    // patches touch disjoint keys (proven above), applying them in EITHER order yields the same
+    // final object with both writers' output intact — the read-spread-write race this SD closes
+    // is structurally impossible once every writer uses `||`-merge instead of a full blob rewrite.
+    const base = { needs_coordinator_review: true, some_other_key: 'untouched', dispatch_rank: 9 };
+    const rankPatch = buildRankPatch(1, '2026-07-01T00:05:00.000Z', 'coordinator');
+    const clearPatch = { needs_coordinator_review: false };
+
+    const rankThenClear = { ...base, ...rankPatch, ...clearPatch };
+    const clearThenRank = { ...base, ...clearPatch, ...rankPatch };
+
+    for (const merged of [rankThenClear, clearThenRank]) {
+      expect(merged.needs_coordinator_review).toBe(false); // clear survives
+      expect(merged.dispatch_rank).toBe(1); // rank survives
+      expect(merged.dispatch_rank_at).toBe('2026-07-01T00:05:00.000Z');
+      expect(merged.some_other_key).toBe('untouched'); // unrelated concurrent metadata is never clobbered
+    }
+  });
+
+  it('buildClearReviewQuery uses the same `||`-merge shape (no full-blob overwrite)', () => {
+    const { sql, params } = buildClearReviewQuery('SD-TEST-002');
+    expect(sql).toMatch(/metadata\s*\|\|\s*'\{"needs_coordinator_review":\s*false\}'::jsonb/);
+    expect(params).toEqual(['SD-TEST-002']);
+  });
+});

--- a/tests/unit/coordinator-backlog-rank-merge-write.test.js
+++ b/tests/unit/coordinator-backlog-rank-merge-write.test.js
@@ -21,10 +21,20 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: buildRankPatch/build
 
   it('buildRankMergeQuery uses a JSONB || merge, not a full-column overwrite', () => {
     const { sql, params } = buildRankMergeQuery({ dispatch_rank: 1, dispatch_rank_at: 'now', dispatch_rank_by: 'x' }, 'SD-TEST-001');
-    expect(sql).toMatch(/metadata\s*\|\|\s*\$1::jsonb/);
+    expect(sql).toMatch(/\|\|\s*\$1::jsonb/);
     expect(sql).not.toMatch(/SET metadata = \$1/); // guards against regressing to a full-blob SET
     expect(params[0]).toBe(JSON.stringify({ dispatch_rank: 1, dispatch_rank_at: 'now', dispatch_rank_by: 'x' }));
     expect(params[1]).toBe('SD-TEST-001');
+  });
+
+  // Adversarial review (ship gate): NULL::jsonb || '{...}'::jsonb evaluates to NULL in real
+  // Postgres, verified live — an unguarded merge on a NULL-metadata row would silently WIPE
+  // the whole blob while reporting success. This asserts the SQL TEXT carries the COALESCE
+  // guard; a plain-JS spread simulation (as used below for the disjoint-key proof) would NOT
+  // have caught this, since `{...null, ...patch}` silently no-ops instead of nulling out.
+  it('buildRankMergeQuery guards against NULL metadata via COALESCE (Postgres NULL || jsonb = NULL)', () => {
+    const { sql } = buildRankMergeQuery({ dispatch_rank: 1, dispatch_rank_at: 'now', dispatch_rank_by: 'x' }, 'SD-TEST-001');
+    expect(sql).toMatch(/COALESCE\(metadata,\s*'\{\}'::jsonb\)\s*\|\|/);
   });
 });
 
@@ -59,7 +69,27 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: TS-3 concurrency-saf
 
   it('buildClearReviewQuery uses the same `||`-merge shape (no full-blob overwrite)', () => {
     const { sql, params } = buildClearReviewQuery('SD-TEST-002');
-    expect(sql).toMatch(/metadata\s*\|\|\s*'\{"needs_coordinator_review":\s*false\}'::jsonb/);
+    expect(sql).toMatch(/\|\|\s*'\{"needs_coordinator_review":\s*false\}'::jsonb/);
     expect(params).toEqual(['SD-TEST-002']);
+  });
+
+  it('buildClearReviewQuery also guards against NULL metadata via COALESCE', () => {
+    const { sql } = buildClearReviewQuery('SD-TEST-002');
+    expect(sql).toMatch(/COALESCE\(metadata,\s*'\{\}'::jsonb\)\s*\|\|/);
+  });
+
+  // Adversarial review (ship gate): documents exactly why the "applying both patches via
+  // JSONB || semantics" test above cannot substitute for a NULL-safety check. JS object
+  // spread on a null base silently no-ops (the spread is just skipped) — Postgres
+  // `NULL::jsonb || '{...}'::jsonb` instead evaluates the WHOLE expression to NULL, wiping
+  // the row. The two are NOT equivalent, which is why NULL-safety is asserted against the
+  // SQL TEXT (COALESCE) above rather than via a JS-level merge simulation.
+  it('documents the JS-spread-vs-Postgres-NULL semantics gap that motivated the COALESCE fix', () => {
+    const patch = { needs_coordinator_review: false };
+    const jsSimulatedResult = { ...null, ...patch }; // JS: silently ignores the null base
+    expect(jsSimulatedResult).toEqual(patch); // looks "safe" in JS...
+    // ...but real Postgres `NULL::jsonb || '{"needs_coordinator_review":false}'::jsonb` is NULL,
+    // not `{"needs_coordinator_review":false}` — a JS-only proof would have missed this class
+    // of bug entirely, which is exactly what the adversarial review flagged.
   });
 });

--- a/tests/unit/coordinator/clear-coordinator-review.test.js
+++ b/tests/unit/coordinator/clear-coordinator-review.test.js
@@ -1,0 +1,98 @@
+/**
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-2): lib/coordinator/clear-coordinator-review.js
+ *
+ * The FIRST canonical write-site for metadata.needs_coordinator_review. Covers: the atomic
+ * merge query shape (no read-spread-write), that a successful clear triggers a rank pass
+ * (and a failed/no-op clear does NOT), and fail-soft behavior on connection/query errors.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { clearCoordinatorReview, buildClearReviewQuery } from '../../../lib/coordinator/clear-coordinator-review.js';
+
+function fakeClient({ rowCount = 1, queryError = null } = {}) {
+  const queries = [];
+  return {
+    queries,
+    query: vi.fn(async (sql, params) => {
+      queries.push({ sql, params });
+      if (queryError) throw queryError;
+      return { rowCount };
+    }),
+    end: vi.fn(async () => {}),
+  };
+}
+
+describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: clearCoordinatorReview', () => {
+  it('throws synchronously on a missing sdKey (programmer error, not a fail-soft path)', async () => {
+    await expect(clearCoordinatorReview()).rejects.toThrow('sdKey is required');
+  });
+
+  it('issues an atomic || merge (not a read-then-full-write) and closes the connection', async () => {
+    const client = fakeClient({ rowCount: 1 });
+    const createClientFn = vi.fn(async () => client);
+    const triggerFn = vi.fn();
+
+    const result = await clearCoordinatorReview('SD-TEST-001', { createClientFn, triggerFn });
+
+    expect(result).toEqual({ cleared: true, sdKey: 'SD-TEST-001' });
+    expect(client.queries).toHaveLength(1);
+    expect(client.queries[0].sql).toMatch(/metadata\s*\|\|/);
+    expect(client.queries[0].sql).not.toMatch(/SELECT/i); // no read-then-write round trip
+    expect(client.queries[0].params).toEqual(['SD-TEST-001']);
+    expect(client.end).toHaveBeenCalledOnce();
+  });
+
+  it('uses a service-role client via createDatabaseClient(\'engineer\', ...), matching the ranker\'s convention', async () => {
+    const client = fakeClient({ rowCount: 1 });
+    const createClientFn = vi.fn(async () => client);
+    await clearCoordinatorReview('SD-TEST-001', { createClientFn, triggerFn: vi.fn() });
+    expect(createClientFn).toHaveBeenCalledWith('engineer', { verify: false });
+  });
+
+  it('triggers a rank pass ONLY after a successful clear', async () => {
+    const client = fakeClient({ rowCount: 1 });
+    const triggerFn = vi.fn();
+    await clearCoordinatorReview('SD-TEST-001', { createClientFn: async () => client, triggerFn });
+    expect(triggerFn).toHaveBeenCalledWith({ reason: 'clear_coordinator_review', sdKey: 'SD-TEST-001' });
+  });
+
+  it('does NOT trigger a rank pass when no row matched (sdKey not found)', async () => {
+    const client = fakeClient({ rowCount: 0 });
+    const triggerFn = vi.fn();
+    const result = await clearCoordinatorReview('SD-DOES-NOT-EXIST', { createClientFn: async () => client, triggerFn });
+    expect(result).toEqual({ cleared: false, sdKey: 'SD-DOES-NOT-EXIST', error: 'no_matching_row' });
+    expect(triggerFn).not.toHaveBeenCalled();
+  });
+
+  it('is fail-soft on a DB connection failure (never throws, returns a structured error)', async () => {
+    const createClientFn = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
+    const triggerFn = vi.fn();
+    const result = await clearCoordinatorReview('SD-TEST-001', { createClientFn, triggerFn });
+    expect(result.cleared).toBe(false);
+    expect(result.error).toMatch(/db_connect_failed/);
+    expect(triggerFn).not.toHaveBeenCalled();
+  });
+
+  it('is fail-soft on a query error and still closes the connection', async () => {
+    const client = fakeClient({ queryError: new Error('constraint violation') });
+    const triggerFn = vi.fn();
+    const result = await clearCoordinatorReview('SD-TEST-001', { createClientFn: async () => client, triggerFn });
+    expect(result.cleared).toBe(false);
+    expect(result.error).toMatch(/constraint violation/);
+    expect(client.end).toHaveBeenCalledOnce();
+    expect(triggerFn).not.toHaveBeenCalled();
+  });
+
+  it('closes the connection even when the query throws (finally-block guarantee)', async () => {
+    const client = fakeClient({ queryError: new Error('boom') });
+    await clearCoordinatorReview('SD-TEST-001', { createClientFn: async () => client, triggerFn: vi.fn() });
+    expect(client.end).toHaveBeenCalledOnce();
+  });
+});
+
+describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: buildClearReviewQuery', () => {
+  it('is a pure function returning the exact atomic-merge SQL/params', () => {
+    const { sql, params } = buildClearReviewQuery('SD-ABC-001');
+    expect(sql).toBe("UPDATE strategic_directives_v2 SET metadata = metadata || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1");
+    expect(params).toEqual(['SD-ABC-001']);
+  });
+});

--- a/tests/unit/coordinator/clear-coordinator-review.test.js
+++ b/tests/unit/coordinator/clear-coordinator-review.test.js
@@ -35,7 +35,7 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: clearCoordinatorRevi
 
     expect(result).toEqual({ cleared: true, sdKey: 'SD-TEST-001' });
     expect(client.queries).toHaveLength(1);
-    expect(client.queries[0].sql).toMatch(/metadata\s*\|\|/);
+    expect(client.queries[0].sql).toMatch(/\|\|/);
     expect(client.queries[0].sql).not.toMatch(/SELECT/i); // no read-then-write round trip
     expect(client.queries[0].params).toEqual(['SD-TEST-001']);
     expect(client.end).toHaveBeenCalledOnce();
@@ -92,7 +92,12 @@ describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: clearCoordinatorRevi
 describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: buildClearReviewQuery', () => {
   it('is a pure function returning the exact atomic-merge SQL/params', () => {
     const { sql, params } = buildClearReviewQuery('SD-ABC-001');
-    expect(sql).toBe("UPDATE strategic_directives_v2 SET metadata = metadata || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1");
+    expect(sql).toBe("UPDATE strategic_directives_v2 SET metadata = COALESCE(metadata, '{}'::jsonb) || '{\"needs_coordinator_review\": false}'::jsonb WHERE sd_key = $1");
     expect(params).toEqual(['SD-ABC-001']);
+  });
+
+  it('guards against NULL metadata via COALESCE (Postgres NULL || jsonb = NULL, verified live in adversarial review)', () => {
+    const { sql } = buildClearReviewQuery('SD-ABC-001');
+    expect(sql).toMatch(/COALESCE\(metadata,\s*'\{\}'::jsonb\)\s*\|\|/);
   });
 });

--- a/tests/unit/coordinator/trigger-rank-pass.test.js
+++ b/tests/unit/coordinator/trigger-rank-pass.test.js
@@ -1,0 +1,120 @@
+/**
+ * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (FR-4): lib/coordinator/trigger-rank-pass.mjs
+ *
+ * Covers: the filesystem-lockfile debounce (thundering-herd suppression across separate OS
+ * processes, TS-5), the child-scoped RANK_EVENT_TRIGGER env var (TS-6 — must never leak into
+ * the calling process's own process.env), and fail-soft behavior on spawn error (TR-3).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import { triggerRankPass, acquireDebounceLock, DEBOUNCE_MS } from '../../../lib/coordinator/trigger-rank-pass.mjs';
+
+function makeLockPath() {
+  return path.join(os.tmpdir(), `rank-pass-trigger-test-${process.pid}-${Math.random().toString(36).slice(2)}.lock`);
+}
+
+function fakeSpawn(calls) {
+  return (cmd, args, options) => {
+    const child = new EventEmitter();
+    child.unref = () => {};
+    calls.push({ cmd, args, options, child });
+    return child;
+  };
+}
+
+describe('SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C: trigger-rank-pass', () => {
+  let lockPath;
+
+  beforeEach(() => {
+    lockPath = makeLockPath();
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(lockPath); } catch { /* best-effort cleanup */ }
+  });
+
+  describe('acquireDebounceLock', () => {
+    it('acquires when no lock file exists', () => {
+      expect(acquireDebounceLock(lockPath)).toBe(true);
+      expect(fs.existsSync(lockPath)).toBe(true);
+    });
+
+    it('debounces a fresh lock held by a live process (this test process itself)', () => {
+      expect(acquireDebounceLock(lockPath)).toBe(true);
+      expect(acquireDebounceLock(lockPath)).toBe(false); // fresh + pid=self (alive) -> debounced
+    });
+
+    it('re-acquires once a stale lock (older than DEBOUNCE_MS) is present', () => {
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, timestamp: Date.now() - (DEBOUNCE_MS + 1000) }), { flag: 'wx' });
+      expect(acquireDebounceLock(lockPath)).toBe(true);
+    });
+
+    it('re-acquires when the lock holder pid is dead (simulated with an unrealistic pid)', () => {
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999999, timestamp: Date.now() }), { flag: 'wx' });
+      expect(acquireDebounceLock(lockPath)).toBe(true);
+    });
+
+    it('re-acquires past a corrupt lock file', () => {
+      fs.writeFileSync(lockPath, 'not json', { flag: 'wx' });
+      expect(acquireDebounceLock(lockPath)).toBe(true);
+    });
+  });
+
+  describe('triggerRankPass — debounce (TS-5)', () => {
+    it('5 rapid calls within the debounce window spawn at most 1 subprocess', () => {
+      const calls = [];
+      const spawnFn = fakeSpawn(calls);
+      for (let i = 0; i < 5; i++) {
+        triggerRankPass({ reason: 'burst', spawnFn, lockPath });
+      }
+      expect(calls.length).toBe(1);
+    });
+  });
+
+  describe('triggerRankPass — RANK_EVENT_TRIGGER child-scoping (TS-6)', () => {
+    it('sets RANK_EVENT_TRIGGER=1 only in the spawned child env, never on the calling process', () => {
+      const calls = [];
+      const spawnFn = fakeSpawn(calls);
+      const before = process.env.RANK_EVENT_TRIGGER;
+      const result = triggerRankPass({ reason: 'sd_created', sdKey: 'SD-TEST-001', spawnFn, lockPath });
+
+      expect(result.triggered).toBe(true);
+      expect(calls[0].options.env.RANK_EVENT_TRIGGER).toBe('1');
+      expect(process.env.RANK_EVENT_TRIGGER).toBe(before); // unchanged (undefined before -> still undefined)
+    });
+
+    it('spawns the ranker as a detached, stdio-ignored child', () => {
+      const calls = [];
+      const spawnFn = fakeSpawn(calls);
+      triggerRankPass({ spawnFn, lockPath });
+      expect(calls[0].options.detached).toBe(true);
+      expect(calls[0].options.stdio).toBe('ignore');
+      expect(calls[0].args[0]).toMatch(/coordinator-backlog-rank\.mjs$/);
+    });
+  });
+
+  describe('triggerRankPass — fail-soft (TR-3)', () => {
+    it('does not throw when spawnFn itself throws', () => {
+      const spawnFn = () => { throw new Error('ENOENT: node not found'); };
+      expect(() => triggerRankPass({ spawnFn, lockPath })).not.toThrow();
+      const result = triggerRankPass({ spawnFn, lockPath: makeLockPath() });
+      expect(result.triggered).toBe(false);
+    });
+
+    it('does not throw when the spawned child emits an error event', () => {
+      const calls = [];
+      const spawnFn = fakeSpawn(calls);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = triggerRankPass({ reason: 'sd_created', sdKey: 'SD-X', spawnFn, lockPath });
+      expect(result.triggered).toBe(true);
+
+      // Simulate the child failing post-spawn (e.g. ENOENT) — must be swallowed, not rethrown.
+      expect(() => calls[0].child.emit('error', new Error('spawn ENOENT'))).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SD-X'));
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Stamp `metadata.dispatch_rank` synchronously at 3 transition points (SD creation, `needs_coordinator_review` clearance, predecessor completion) so a freshly-claimable SD is never invisible to a parked worker for up to the 15-min `coordinator-backlog-rank.mjs` cron gap. FR-1 of parent SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-001.
- New `lib/coordinator/trigger-rank-pass.mjs`: shared debounced (filesystem lockfile) fire-and-forget spawn of the existing ranker, with `RANK_EVENT_TRIGGER=1` scoped only to the child's env.
- New `lib/coordinator/clear-coordinator-review.js`: first canonical write-site for `metadata.needs_coordinator_review`, using an atomic JSONB `||` merge (not read-spread-write) to avoid a lost-update race against concurrent ranker writes.
- `coordinator-backlog-rank.mjs`: `RANK_EVENT_TRIGGER` guard-bypass (the coordinator-mutation-guard otherwise blocks event-triggered writes whenever any coordinator is live — the normal fleet state), plus its own write loop converted to the same atomic merge pattern, closing the race from both directions. Ranking algorithm itself is untouched.
- New `lead-final-approval` completion hook triggers a rank pass for newly-unblocked dependents.

Both the guard-inversion and the metadata read-modify-write race were caught by prospective testing-agent and PLAN-phase design/database sub-agent review before implementation, not discovered post-hoc — see PRD `PRD-SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C`.

## Test plan
- [x] 24 new unit tests across `trigger-rank-pass.test.js`, `clear-coordinator-review.test.js`, `coordinator-backlog-rank-merge-write.test.js`
- [x] 230 pre-existing tests across all touched surfaces (coordinator-backlog-rank, leo-create-sd, lead-final-approval) re-run clean, no regressions
- [x] Live dogfood: `RANK_EVENT_TRIGGER=1 node scripts/coordinator-backlog-rank.mjs` against production DB — guard bypass fired, atomic merge write landed, verified via direct query
- [x] Live dogfood: `triggerRankPass()` real spawn + debounce (2nd rapid call correctly suppressed)
- [x] Full ~22k-test suite run: 8 pre-existing failures across 4 unrelated files, all confirmed zero-diff vs `origin/main` (not caused by this change) — logged as harness bugs, not blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)