### PR TITLE
Add ADKAR adoption completion gate (LEAD-FINAL-APPROVAL)

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -45,6 +45,10 @@ import { createPhantomTestAuditGate } from './gates/phantom-test-audit-gate.js';
 export { createPhantomTestAuditGate };
 import { createLearningOrBypassResolvedGate } from './gates/learning-or-bypass-resolved-gate.js';
 export { createLearningOrBypassResolvedGate };
+// SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-B: block completion of a
+// metadata.requires_adoption=true SD until all 5 ADKAR stages are evidenced or waived.
+import { createAdkarAdoptionGate } from './gates/adkar-adoption-gate.js';
+export { createAdkarAdoptionGate };
 // SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001: block completion when declared deferred
 // follow-up work has no live home SD (stop deferred scope from evaporating).
 import { createDeferredFollowupsGate } from './gates/deferred-followups-gate.js';
@@ -1223,6 +1227,12 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   // set ENFORCE_LEARNING_GATE=true to block.
   gates.push(createLearningOrBypassResolvedGate(supabase));
 
+  // ADKAR Adoption Gate — completion safeguard (SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-B)
+  // No-op for any SD without metadata.requires_adoption=true. Blocks/warns (per
+  // ENFORCE_ADKAR_GATE) on missing ADKAR stage evidence-or-waiver for SDs that set it.
+  // Default warn-only; set ENFORCE_ADKAR_GATE=true to block.
+  gates.push(createAdkarAdoptionGate(supabase));
+
   // Deferred-Followups Home — SD-LEO-INFRA-COMPLETION-GATE-DEFERRED-HOME-001
   // Blocks completion when metadata.deferred_followups[] references a follow-up SD that does
   // not exist (or is cancelled). Heuristic-warns on unstructured deferral phrases. Blocking by
@@ -1263,6 +1273,7 @@ export default {
   createWireCheckGate,
   createPhantomTestAuditGate,
   createLearningOrBypassResolvedGate,
+  createAdkarAdoptionGate,
   createDeferredFollowupsGate,
   createCrossSdFileOverlapTemporalShipGate,
   createActivationInvariantGate,

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/adkar-adoption-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/adkar-adoption-gate.js
@@ -1,0 +1,100 @@
+/**
+ * ADKAR_ADOPTION_GATE — LEAD-FINAL-APPROVAL completion safeguard
+ * SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-B (FR-2)
+ *
+ * At LEAD-FINAL-APPROVAL, an SD flagged metadata.requires_adoption=true (a change that
+ * requires role/agent adoption — a new tool, a protocol change, a role-contract change)
+ * must have all 5 ADKAR (Prosci) stages — Awareness, Desire, Knowledge, Ability,
+ * Reinforcement — evidenced or explicitly waived-with-reason in metadata.adkar_checklist
+ * before it can complete. This is a no-op for every SD that does not set that flag (the
+ * overwhelming majority of SDs).
+ *
+ * Structurally mirrors learning-or-bypass-resolved-gate.js: same gate-object shape, same
+ * feature-flag rollout convention (ENFORCE_ADKAR_GATE, default false/warn-only), same
+ * warn-vs-block score split (60 on warn, 0 on block).
+ *
+ * Phase: LEAD-FINAL-APPROVAL
+ */
+
+const GATE_NAME = 'ADKAR_ADOPTION';
+const ADKAR_STAGES = ['awareness', 'desire', 'knowledge', 'ability', 'reinforcement'];
+
+/**
+ * Is this ADKAR checklist stage entry satisfied (evidenced or waived-with-reason)?
+ *
+ * @param {*} entry
+ * @returns {boolean}
+ */
+function isStageSatisfied(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  const hasEvidence = typeof entry.evidence === 'string' && entry.evidence.trim().length > 0;
+  const hasWaiver = entry.waived === true && typeof entry.reason === 'string' && entry.reason.trim().length > 0;
+  return hasEvidence || hasWaiver;
+}
+
+/**
+ * Create the ADKAR adoption completion gate.
+ *
+ * @param {object} _supabase - Unused; accepted for call-site consistency with sibling
+ *   gate factories (gates.js calls every factory as createXGate(supabase)). This gate
+ *   reads only ctx.sd.metadata, no DB queries needed.
+ * @returns {Object} Gate definition
+ */
+export function createAdkarAdoptionGate(_supabase) {
+  return {
+    name: GATE_NAME,
+    validator: async (ctx) => {
+      console.log('\n📋 GATE: ADKAR Adoption Completion');
+      console.log('-'.repeat(50));
+
+      const requiresAdoption = ctx?.sd?.metadata?.requires_adoption === true;
+
+      if (!requiresAdoption) {
+        console.log('   metadata.requires_adoption is not set — gate not applicable');
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [],
+          details: { requires_adoption: false },
+        };
+      }
+
+      const checklist = ctx?.sd?.metadata?.adkar_checklist || {};
+      const missingStages = ADKAR_STAGES.filter((stage) => !isStageSatisfied(checklist[stage]));
+
+      if (missingStages.length === 0) {
+        console.log('   All 5 ADKAR stages evidenced or waived — gate passes');
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [],
+          details: { requires_adoption: true, missing_stages: [] },
+        };
+      }
+
+      const enforceFlag = process.env.ENFORCE_ADKAR_GATE === 'true';
+      const warnOnly = !enforceFlag;
+      const message = `metadata.requires_adoption=true but the following ADKAR stage(s) are missing evidence or a waiver: ${missingStages.join(', ')}. Resolve via metadata.adkar_checklist.<stage> = { evidence: '<citation>' } or { waived: true, reason: '<reason>' } for each.`;
+
+      console.log(`   ${warnOnly ? '⚠️  WARN' : '❌ BLOCK'}: ${message}`);
+
+      return {
+        passed: warnOnly,
+        score: warnOnly ? 60 : 0,
+        max_score: 100,
+        issues: warnOnly ? [] : [message],
+        warnings: warnOnly ? [message] : [],
+        details: {
+          requires_adoption: true,
+          missing_stages: missingStages,
+          enforce_flag: enforceFlag,
+        },
+      };
+    },
+    required: true, // Registered as blocking; feature flag controls actual enforcement
+  };
+}

--- a/tests/unit/handoff/adkar-adoption-gate.test.js
+++ b/tests/unit/handoff/adkar-adoption-gate.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for ADKAR_ADOPTION gate (SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-B).
+ *
+ * Covers:
+ *  - No metadata.requires_adoption → no-op pass (score 100)
+ *  - requires_adoption=true, incomplete adkar_checklist + ENFORCE_ADKAR_GATE=true → BLOCKS (score 0)
+ *  - requires_adoption=true, incomplete adkar_checklist + ENFORCE_ADKAR_GATE unset/false → WARNS (score 60, passed=true)
+ *  - requires_adoption=true, all 5 stages evidenced-or-waived → passes (score 100) regardless of the flag
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createAdkarAdoptionGate } from '../../../scripts/modules/handoff/executors/lead-final-approval/gates/adkar-adoption-gate.js';
+
+describe('ADKAR_ADOPTION gate (SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-B)', () => {
+  const originalFlag = process.env.ENFORCE_ADKAR_GATE;
+  const gate = createAdkarAdoptionGate();
+
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env.ENFORCE_ADKAR_GATE;
+    else process.env.ENFORCE_ADKAR_GATE = originalFlag;
+  });
+
+  it('passes with score 100 as a no-op when metadata.requires_adoption is not set', async () => {
+    const result = await gate.validator({ sd: { id: 'sd-fixture-1', metadata: {} } });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.issues).toEqual([]);
+    expect(result.details.requires_adoption).toBe(false);
+  });
+
+  it('passes with score 100 as a no-op when metadata is entirely absent', async () => {
+    const result = await gate.validator({ sd: { id: 'sd-fixture-2' } });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('BLOCKS (score 0) when requires_adoption=true, stages missing, ENFORCE_ADKAR_GATE=true', async () => {
+    process.env.ENFORCE_ADKAR_GATE = 'true';
+    const result = await gate.validator({
+      sd: {
+        id: 'sd-fixture-3',
+        metadata: {
+          requires_adoption: true,
+          adkar_checklist: {
+            awareness: { evidence: 'role-contract wired at CLAUDE_ADAM.md' },
+            desire: { evidence: 'Why: rationale present in the rollout PR' },
+            // knowledge, ability, reinforcement missing
+          },
+        },
+      },
+    });
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.issues.length).toBe(1);
+    expect(result.issues[0]).toContain('knowledge');
+    expect(result.issues[0]).toContain('ability');
+    expect(result.issues[0]).toContain('reinforcement');
+    expect(result.details.missing_stages).toEqual(['knowledge', 'ability', 'reinforcement']);
+  });
+
+  it('WARNS (score 60, passed=true) when requires_adoption=true, stages missing, ENFORCE_ADKAR_GATE unset', async () => {
+    delete process.env.ENFORCE_ADKAR_GATE;
+    const result = await gate.validator({
+      sd: {
+        id: 'sd-fixture-4',
+        metadata: {
+          requires_adoption: true,
+          adkar_checklist: {},
+        },
+      },
+    });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(60);
+    expect(result.issues).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.details.missing_stages).toEqual(['awareness', 'desire', 'knowledge', 'ability', 'reinforcement']);
+  });
+
+  it('passes (score 100) with all 5 stages evidenced or waived, even with ENFORCE_ADKAR_GATE=true', async () => {
+    process.env.ENFORCE_ADKAR_GATE = 'true';
+    const result = await gate.validator({
+      sd: {
+        id: 'sd-fixture-5',
+        metadata: {
+          requires_adoption: true,
+          adkar_checklist: {
+            awareness: { evidence: 'role-contract wired at CLAUDE_ADAM.md' },
+            desire: { evidence: 'Why: rationale present in the rollout PR' },
+            knowledge: { evidence: 'docs/protocol/adkar-change-adoption-framework.md' },
+            ability: { evidence: 'coordinator_reminder payload.kind mechanism dispatches hourly' },
+            reinforcement: { waived: true, reason: 'self-adherence probe scheduled for a follow-up SD' },
+          },
+        },
+      },
+    });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.details.missing_stages).toEqual([]);
+  });
+
+  it('treats a stage entry with neither evidence nor a valid waiver as missing', async () => {
+    const result = await gate.validator({
+      sd: {
+        id: 'sd-fixture-6',
+        metadata: {
+          requires_adoption: true,
+          adkar_checklist: {
+            awareness: { waived: true }, // waived but no reason string — should NOT count as satisfied
+            desire: { evidence: '' }, // empty string — should NOT count as satisfied
+          },
+        },
+      },
+    });
+    expect(result.details.missing_stages).toEqual(['awareness', 'desire', 'knowledge', 'ability', 'reinforcement']);
+  });
+});


### PR DESCRIPTION
## Summary
- New `scripts/modules/handoff/executors/lead-final-approval/gates/adkar-adoption-gate.js` — mirrors `learning-or-bypass-resolved-gate.js`'s structure exactly (no-op / evidence-or-waiver / feature-flag warn-vs-block)
- No-op for any SD without `metadata.requires_adoption=true`
- For SDs that set it, requires each of the 5 ADKAR stages (awareness/desire/knowledge/ability/reinforcement) evidenced or waived-with-reason in `metadata.adkar_checklist`, else fails/warns naming exactly the missing stages
- Feature-flag-gated via `ENFORCE_ADKAR_GATE` (default `false`/warn-only), matching the `ENFORCE_LEARNING_GATE` rollout precedent
- Registered in `gates.js` (import + push + default export)

Child B of SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001 (Child A defines the metadata shape + protocol docs this gate consumes; Child C pilots the flag on a live orchestrator SD).

## Test plan
- [x] 6 new unit tests: no-op (no flag), no-op (no metadata), block on incomplete checklist + `ENFORCE_ADKAR_GATE=true`, warn on incomplete checklist + flag unset, pass with all 5 stages evidenced/waived, entries with neither evidence nor a valid waiver correctly counted as missing
- [x] Full `tests/unit/handoff/` suite (72 files): 742 passed, 1 pre-existing skip, 0 failed
- [x] Verified `getRequiredGates()` output includes the new gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)