### PR TITLE
feat(SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-A): ADKAR change-adoption framework shape + protocol docs

### DIFF
--- a/docs/protocol/adkar-change-adoption-framework.md
+++ b/docs/protocol/adkar-change-adoption-framework.md
@@ -1,0 +1,109 @@
+# ADKAR change-adoption framework
+
+**Status**: Framework definition (this doc) + shape module shipped by
+`SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-A`. The completion gate that
+enforces this shape is owned by sibling child `-B`; pilot-tagging a real SD is owned by
+sibling child `-C`. This document does not itself gate anything.
+
+## Why
+
+A change flagged `metadata.requires_adoption = true` (a new tool, a protocol change, a
+role-contract change, a new process) is only actually adopted once agents are
+**aware** of it, **want** to follow it, **know how**, **can** use it, and the fleet
+**keeps** using it. ADKAR (Prosci) names those five stages. This framework maps each
+stage to the **agent** context — not human emotion — and, critically, does **not**
+invent new machinery: every stage below cites a mechanism that already exists in this
+codebase today. ADKAR formalizes and completes those pieces into an explicit
+evidence-or-waived checklist; it does not replace them.
+
+## The shape
+
+`lib/governance/adkar-checklist.js` is the single source of truth for the checklist
+shape. A `requires_adoption` SD carries `metadata.adkar_checklist`, an array of five
+entries — one per stage, in this order:
+
+```js
+{
+  stage: 'awareness' | 'desire' | 'knowledge' | 'ability' | 'reinforcement',
+  evidence: { kind: string, ref: string } | null,
+  waived: boolean,
+  waived_reason: string | null,
+}
+```
+
+An entry is valid iff it carries **either** real evidence (a non-empty `evidence.kind`)
+**or** a waiver with a non-empty `waived_reason` — an empty waiver is not a waiver.
+
+## The five stages
+
+### Awareness — the change is surfaced to affected roles
+
+**Evidence type**: a role-contract/CLAUDE update landed, or a `coordinator_reminder`
+was dispatched to the affected live sessions.
+
+**Existing mechanism reused**: `scripts/coordinator-hourly-review.cjs` already
+dispatches `session_coordination` rows with `payload.kind = coordinator_reminder` on an
+hourly cadence; these are consumed at `scripts/adam-advisory.cjs` and
+`scripts/solomon-startup-check.mjs`. Awareness evidence for a `requires_adoption`
+change is a reminder dispatched through this same channel — no new dispatch mechanism
+is needed.
+
+### Desire — the WHY is present so agents act on the rationale
+
+**Evidence type**: the change artifact (CLAUDE.md section, PRD, role contract) contains
+a `> Why:` line explaining the benefit, per the existing convention.
+
+**Existing mechanism reused**: CLAUDE.md's pervasive `> Why:` rationale convention
+(CONST-010: factual and non-manipulative — the rationale states a real cause/effect, it
+does not persuade). Desire evidence is simply confirming the `> Why:` line exists on the
+change artifact; ADKAR does not add a second explanation mechanism.
+
+### Knowledge — the HOW is documented
+
+**Evidence type**: a role-contract, CLAUDE file section, or protocol doc documents how
+to actually perform the new behavior.
+
+**Existing mechanism reused**: the same role-contract/CLAUDE-file documentation surface
+already used for every other protocol convention in this codebase (see this very file
+as an instance of that pattern).
+
+### Ability — the change is wired in and verifiably usable
+
+**Evidence type**: the *adoption-is-acceptance* gate — the standing routine that is
+supposed to consume the change actually consumes it, verified by exercising the real
+path (not a mock of the seam).
+
+**Existing mechanism reused**: none dedicated yet — this is the stage sibling child
+`-B`'s completion gate enforces directly, and the one stage most likely to require real
+evidence rather than a waiver, since "wired in but unverified" is exactly the drift this
+framework exists to catch.
+
+### Reinforcement — the change sustains and regression-to-non-use is caught
+
+**Evidence type**: a recurring, already-scheduled self-adherence check that would flag
+if the fleet stopped following the change.
+
+**Existing mechanism reused**: the three live self-adherence scripts —
+`scripts/adam-self-adherence-review.mjs`, `scripts/coordinator-self-review.mjs`, and
+`scripts/solomon-self-adherence-review.mjs` — already run on recurring cadences and are
+the natural home for a new adoption's regression check. Reinforcement evidence for a
+`requires_adoption` change points at (or extends) one of these three, not a new
+standalone checker.
+
+## Out of scope (this framework)
+
+- Non-adoption changes (a pure bugfix has no adoption need — `requires_adoption` stays
+  `false`/unset and the checklist is never evaluated).
+- Heavy change-ceremony or human-org-change tooling — this is a lightweight,
+  agent-context checklist, not a Prosci human-change program.
+- The completion gate implementation (sibling child `-B`) and pilot tagging (sibling
+  child `-C`).
+
+## Related
+
+- `lib/governance/adkar-checklist.js` — the shape module (`ADKAR_STAGES`,
+  `validateAdkarChecklist`, `isValidAdkarEntry`).
+- `scripts/modules/handoff/executors/lead-final-approval/gates/learning-or-bypass-resolved-gate.js`
+  — the structural template the future ADKAR completion gate mirrors
+  (evidence-or-resolved-bypass, feature-flag-gated rollout, central `gates.js`
+  registration).

--- a/lib/governance/adkar-checklist.js
+++ b/lib/governance/adkar-checklist.js
@@ -1,0 +1,57 @@
+/**
+ * Shared frozen contract for the ADKAR change-adoption checklist shape.
+ *
+ * SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-A / FR-1.
+ *
+ * ADKAR (Prosci) mapped to the AGENT context (not human emotion): a change flagged
+ * metadata.requires_adoption=true must evidence-or-waive each of the 5 stages before it
+ * can pass LEAD-FINAL-APPROVAL. See docs/protocol/adkar-change-adoption-framework.md for
+ * what each stage means and which existing codebase mechanism already serves it.
+ *
+ * Imported by BOTH the future completion gate (sibling Child B,
+ * lead-final-approval/gates/adkar-adoption-gate.js) and any pilot-tagging work (sibling
+ * Child C) so the checklist shape cannot drift across files — mirrors
+ * lib/governance/completion-flag-keys.js's shared-frozen-contract pattern.
+ *
+ * @module lib/governance/adkar-checklist
+ */
+
+/** The 5 ADKAR stages, in their canonical order. Frozen — never reorder or rename. */
+export const ADKAR_STAGES = Object.freeze(['awareness', 'desire', 'knowledge', 'ability', 'reinforcement']);
+
+/** The SD metadata field names this convention uses. */
+export const REQUIRES_ADOPTION_KEY = 'requires_adoption';
+export const ADKAR_CHECKLIST_KEY = 'adkar_checklist';
+
+/**
+ * Is a single checklist entry valid? Valid iff it names a real ADKAR stage AND carries
+ * EITHER real evidence (a non-empty evidence.kind) OR a waiver with a non-empty reason —
+ * a waiver with no reason does not satisfy the shape (an empty excuse is not a waiver).
+ * @param {{ stage?: string, evidence?: { kind?: string, ref?: string }|null, waived?: boolean, waived_reason?: string|null }} entry
+ * @returns {boolean}
+ */
+export function isValidAdkarEntry(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (!ADKAR_STAGES.includes(entry.stage)) return false;
+  const hasEvidence = !!(entry.evidence && typeof entry.evidence === 'object'
+    && typeof entry.evidence.kind === 'string' && entry.evidence.kind.trim().length > 0);
+  const hasWaiver = entry.waived === true
+    && typeof entry.waived_reason === 'string' && entry.waived_reason.trim().length > 0;
+  return hasEvidence || hasWaiver;
+}
+
+/**
+ * Validate a full checklist against the 5-stage shape. Pure/synchronous — no DB access,
+ * so the future completion gate can call this on an already-fetched SD row.
+ * @param {Array<object>} checklist
+ * @returns {{ valid: boolean, missingStages: string[], invalidEntries: string[] }}
+ */
+export function validateAdkarChecklist(checklist) {
+  if (!Array.isArray(checklist)) {
+    return { valid: false, missingStages: [...ADKAR_STAGES], invalidEntries: [] };
+  }
+  const byStage = new Map(checklist.filter((e) => e && typeof e === 'object').map((e) => [e.stage, e]));
+  const missingStages = ADKAR_STAGES.filter((stage) => !byStage.has(stage));
+  const invalidEntries = ADKAR_STAGES.filter((stage) => byStage.has(stage) && !isValidAdkarEntry(byStage.get(stage)));
+  return { valid: missingStages.length === 0 && invalidEntries.length === 0, missingStages, invalidEntries };
+}

--- a/tests/unit/governance/adkar-checklist.test.js
+++ b/tests/unit/governance/adkar-checklist.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-LEO-INFRA-ADKAR-CHANGE-ADOPTION-FRAMEWORK-001-A (FR-1)
+ *
+ * The ADKAR checklist shape module: the single source of truth sibling Child B's future
+ * completion gate will import to evaluate metadata.adkar_checklist. This SD ships the shape
+ * only — no gate, no enforcement.
+ */
+import { describe, it, expect } from 'vitest';
+import { ADKAR_STAGES, REQUIRES_ADOPTION_KEY, ADKAR_CHECKLIST_KEY, isValidAdkarEntry, validateAdkarChecklist } from '../../../lib/governance/adkar-checklist.js';
+
+const evidenced = (stage, kind = 'doc', ref = 'x') => ({ stage, evidence: { kind, ref } });
+const waived = (stage, reason) => ({ stage, waived: true, waived_reason: reason });
+const completeChecklist = () => ADKAR_STAGES.map((stage) => evidenced(stage));
+
+describe('ADKAR_STAGES / key constants', () => {
+  it('is the 5 canonical stages in order, frozen', () => {
+    expect(ADKAR_STAGES).toEqual(['awareness', 'desire', 'knowledge', 'ability', 'reinforcement']);
+    expect(Object.isFrozen(ADKAR_STAGES)).toBe(true);
+  });
+
+  it('exposes the metadata field name constants', () => {
+    expect(REQUIRES_ADOPTION_KEY).toBe('requires_adoption');
+    expect(ADKAR_CHECKLIST_KEY).toBe('adkar_checklist');
+  });
+});
+
+describe('isValidAdkarEntry', () => {
+  it('is valid with real evidence (non-empty evidence.kind)', () => {
+    expect(isValidAdkarEntry(evidenced('awareness'))).toBe(true);
+  });
+
+  it('is valid with a waiver carrying a non-empty reason (no evidence needed)', () => {
+    expect(isValidAdkarEntry(waived('reinforcement', 'not applicable to this SD class'))).toBe(true);
+  });
+
+  it('is invalid with an empty evidence.kind', () => {
+    expect(isValidAdkarEntry({ stage: 'ability', evidence: { kind: '' } })).toBe(false);
+  });
+
+  it('is invalid when waived:true but waived_reason is empty — an empty waiver is not a waiver', () => {
+    expect(isValidAdkarEntry({ stage: 'desire', waived: true, waived_reason: '' })).toBe(false);
+    expect(isValidAdkarEntry({ stage: 'desire', waived: true })).toBe(false);
+  });
+
+  it('is invalid when neither evidence nor a waiver is present', () => {
+    expect(isValidAdkarEntry({ stage: 'knowledge' })).toBe(false);
+  });
+
+  it('is invalid for an unrecognized stage name', () => {
+    expect(isValidAdkarEntry(evidenced('enthusiasm'))).toBe(false);
+  });
+
+  it('handles null/non-object input without throwing', () => {
+    expect(isValidAdkarEntry(null)).toBe(false);
+    expect(isValidAdkarEntry(undefined)).toBe(false);
+    expect(isValidAdkarEntry('not-an-object')).toBe(false);
+  });
+});
+
+describe('validateAdkarChecklist', () => {
+  it('TS-1: a complete 5-stage checklist with evidence on every stage is valid', () => {
+    expect(validateAdkarChecklist(completeChecklist())).toEqual({ valid: true, missingStages: [], invalidEntries: [] });
+  });
+
+  it('TS-2: a checklist missing the reinforcement stage names it in missingStages', () => {
+    const missing = completeChecklist().filter((e) => e.stage !== 'reinforcement');
+    const result = validateAdkarChecklist(missing);
+    expect(result.valid).toBe(false);
+    expect(result.missingStages).toEqual(['reinforcement']);
+    expect(result.invalidEntries).toEqual([]);
+  });
+
+  it('TS-3: an entry with an empty evidence.kind is reported as an invalid entry, not missing', () => {
+    const checklist = [...completeChecklist().filter((e) => e.stage !== 'reinforcement'), { stage: 'reinforcement', evidence: { kind: '' } }];
+    const result = validateAdkarChecklist(checklist);
+    expect(result.valid).toBe(false);
+    expect(result.missingStages).toEqual([]);
+    expect(result.invalidEntries).toEqual(['reinforcement']);
+  });
+
+  it('TS-4: a stage waived:true with no waived_reason is invalid', () => {
+    const checklist = [...completeChecklist().filter((e) => e.stage !== 'ability'), { stage: 'ability', waived: true, waived_reason: '' }];
+    const result = validateAdkarChecklist(checklist);
+    expect(result.valid).toBe(false);
+    expect(result.invalidEntries).toEqual(['ability']);
+  });
+
+  it('TS-5: a valid waiver (waived:true + non-empty reason, no evidence) satisfies the shape', () => {
+    const checklist = [...completeChecklist().filter((e) => e.stage !== 'ability'), waived('ability', 'not applicable to this SD class')];
+    expect(validateAdkarChecklist(checklist)).toEqual({ valid: true, missingStages: [], invalidEntries: [] });
+  });
+
+  it('reports multiple missing stages together', () => {
+    const partial = completeChecklist().slice(0, 2); // awareness, desire only
+    const result = validateAdkarChecklist(partial);
+    expect(result.missingStages).toEqual(['knowledge', 'ability', 'reinforcement']);
+  });
+
+  it('handles a non-array checklist (undefined/null/object) by reporting every stage missing', () => {
+    expect(validateAdkarChecklist(undefined).missingStages).toEqual([...ADKAR_STAGES]);
+    expect(validateAdkarChecklist(null).missingStages).toEqual([...ADKAR_STAGES]);
+    expect(validateAdkarChecklist({}).missingStages).toEqual([...ADKAR_STAGES]);
+  });
+});


### PR DESCRIPTION
## Summary
- Defines `metadata.requires_adoption` convention + the 5-stage (Awareness/Desire/Knowledge/Ability/Reinforcement) agent-context checklist shape (`lib/governance/adkar-checklist.js`) for LEO changes needing role/agent adoption.
- Adds `docs/protocol/adkar-change-adoption-framework.md` mapping each stage to a concrete evidence type and an EXISTING, verified-real codebase mechanism (coordinator_reminder dispatch, `> Why:` convention, role-contract docs, self-adherence scripts) — no new machinery invented.
- Registers a `leo_protocol_sections` row (database-first) pointing at the doc.
- Ships shape + docs + tests only — the LEAD-FINAL-APPROVAL completion gate that enforces this shape is sibling child `-B`; pilot-tagging a real SD is sibling child `-C`.

## Test plan
- [x] `npx vitest run tests/unit/governance/adkar-checklist.test.js` — 16/16 passing (all TS-1..TS-5 boundary scenarios from the PRD + additional edge cases)
- [x] `npx eslint lib/governance/adkar-checklist.js tests/unit/governance/adkar-checklist.test.js` — clean
- [x] Every file path cited in the protocol doc verified to exist via `test -f` before/after writing
- [x] `leo_protocol_sections` row inserted and confirmed via select

🤖 Generated with [Claude Code](https://claude.com/claude-code)