### PR TITLE
fix(QF-20260701-833): coverage BASELINE_REGRESSION check is IDENTITY-based, not COUNT-based

### DIFF
--- a/docs/reference/test-coverage-baseline-ratchet.md
+++ b/docs/reference/test-coverage-baseline-ratchet.md
@@ -39,7 +39,7 @@ After the existing `Run tests with coverage` step parses `test-results.json`, a 
 
 1. Reads `numFailedTests` from `test-results.json`.
 2. On `push` events: INSERTs a row into `codebase_health_snapshots` with the current count and a `trend_direction` derived from the prior snapshot (`improving` / `stable` / `declining` / `new`).
-3. On `pull_request` events: SELECTs the most recent snapshot for the PR's base branch where `dimension='ci_test_failure_count' AND target_application='EHG_Engineer'`. If the current PR's failure count exceeds the baseline by ≥ 1, the step exits 1 with three GitHub Actions annotations:
+3. On `pull_request` events: SELECTs the most recent snapshot for the PR's base branch where `dimension='ci_test_failure_count' AND target_application='EHG_Engineer'`. **QF-20260701-833 (identity-based, not count-based):** the check compares the SET of failing-test identities (`file::fullName`) in the PR run against the set recorded in the base snapshot — a test that was already failing on main never blocks the PR, regardless of the raw count. Only a genuinely NEW failing identity (not present in the base snapshot's set) trips the gate. (A base snapshot written before this shipped has no recorded identity set — that one comparison falls back to the old raw-count delta until the next push to that branch records a full baseline.) On a regression, the step exits 1 with GitHub Actions annotations:
    - `::error::BASELINE_REGRESSION: N new test failure(s) vs main snapshot.`
    - `Reproduce locally: node scripts/audit-test-failures.mjs --pr-only --format=json | jq .new_failures`
    - `See docs/reference/test-coverage-baseline-ratchet.md for triage steps.`
@@ -59,7 +59,7 @@ The ratchet uses only the `ci_test_failure_count` dimension. Conventions for tha
 - `dimension`: literal string `ci_test_failure_count`
 - `target_application`: literal string `EHG_Engineer`
 - `score`: pass-rate as `0–100` (computed as `(passed / total) * 100`, NUMERIC(5,2))
-- `findings`: JSONB **array with exactly one element** — `[{failed_count, branch, commit_sha}]`. The single-element-array shape matches existing `dead_code` and `complexity` dimension consumers; bare-object shape is incompatible.
+- `findings`: JSONB **array with exactly one element** — `[{failed_count, skipped_count, failing_test_ids, branch, commit_sha}]`. `failing_test_ids` (QF-20260701-833) is the array of `file::fullName` identities for that run's failures — the input to the identity-based regression diff. The single-element-array shape matches existing `dead_code` and `complexity` dimension consumers; bare-object shape is incompatible.
 - `trend_direction`: one of `improving` | `stable` | `declining` | `new` per the table CHECK constraint
 - `metadata.workflow_run_id`: GitHub Actions run id for traceability
 - `scanned_at` and `created_at`: defaults to `now()`
@@ -84,6 +84,10 @@ SELECT findings->0->>'failed_count' AS baseline_failed
 2. Run `node scripts/audit-test-failures.mjs --results test-results.json --summary` to see the bucket counts.
 3. Diff against the previous run on main to identify the new failures (use `--by-category=<bucket>` to narrow scope).
 4. Either fix the new failure (preferred), gate it behind `it.skipIf(...)` with a one-line rationale, or — if the failure was already present on main and the snapshot is stale — push an empty commit to main to regenerate the snapshot.
+
+### `BASELINE_REGRESSION` fires with the SAME failing test(s) as a prior unrelated PR
+
+Before QF-20260701-833, the check was count-based: any rise in the raw failed-test count blocked the PR, even when the "new" failures were unrelated flaky tests already failing on main (or a live-DB/CI-secret hiccup). Symptom: the `New failing test(s) not present on main:` list in the annotation is empty or lists tests clearly unrelated to your diff — that means the base snapshot predates identity tracking and the check degraded to the old count-based comparison (see Schema Reference). Push an empty commit to main (or wait for the next push) to record a fresh baseline with `failing_test_ids`, which resolves it going forward.
 
 ### Workflow exits 1 with no failure count printed
 

--- a/scripts/compare-to-main-snapshot.mjs
+++ b/scripts/compare-to-main-snapshot.mjs
@@ -11,14 +11,20 @@
  *                  current failed_tests + skipped_tests counts and trend_direction
  *                  relative to the prior snapshot.
  *   pull_request → SELECT the most recent snapshot for the PR's base branch.
- *                  If current failed_tests > baseline by ≥1, write
+ *                  QF-20260701-833: the regression check is IDENTITY-based, not
+ *                  count-based — a failing test only counts as a regression if its
+ *                  identity (file::fullName) is NOT already in the base branch's
+ *                  recorded failing set, so an unrelated flaky/pre-existing failure
+ *                  never false-blocks the PR. If any NEW identity is found, write
  *                  test-failures-pr.json (for the upload-artifact step) and
  *                  exit 1 with ::error:: annotations on stderr. Otherwise, if the
  *                  skipped-test count has drifted outside the baseline's ±10% band
  *                  (FR-5 vacuous-green guard), exit 1 with a SKIP_DRIFT annotation.
  *
  * Cold start (no prior snapshot for base branch, or a snapshot predating the
- * skipped_count field): pass — the next push to that branch records the baseline.
+ * skipped_count/failing_test_ids fields): pass, or fall back to the old
+ * count-based comparison for failing_test_ids specifically — the next push to
+ * that branch records the full baseline.
  *
  * Env vars required:
  *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
@@ -105,6 +111,60 @@ function detectContext() {
   return { mode: 'push', branch, sha, runId };
 }
 
+/**
+ * Extract the SET of failing-test identities (file::fullName) from a vitest JSON
+ * reporter payload. Pure. Shared by insertSnapshot() (records the baseline's
+ * failing set) and decideRegression() (diffs it against the PR's failing set).
+ */
+export function extractFailingIds(raw) {
+  const ids = [];
+  for (const file of (raw?.testResults || [])) {
+    for (const test of (file.assertionResults || [])) {
+      if (test.status === 'failed') ids.push(`${file.name || file.testFilePath}::${test.fullName}`);
+    }
+  }
+  return ids;
+}
+
+/**
+ * QF-20260701-833: IDENTITY-based regression decision, not COUNT-based.
+ *
+ * compare-to-main-snapshot.mjs previously flagged BASELINE_REGRESSION on ANY rise
+ * in the raw failed-test COUNT vs the base-branch snapshot — so an unrelated flaky
+ * test bouncing (or a live-DB/CI-secret hiccup) on a PR run false-blocks the PR even
+ * though the diff introduced no new failure. Evidenced on PR #5330 (worker 1d49c728):
+ * the same 107 failures, byte-identical across reruns, in 29 files unrelated to the
+ * diff. Recurred on PR #5334 and #5337 this session — same 2 unrelated tests both
+ * times (tests/unit/gates/consumer-impact-gate.test.js TS-6, a worker-crash artifact).
+ *
+ * Fix: compare the SET of failing test identities. Only a test that is NOT in the
+ * base branch's recorded failing set counts as a regression — a pre-existing/flaky
+ * failure that was already red on main never blocks the PR, regardless of the raw
+ * count. Pure (no I/O) for unit-testability, mirrors red-merge-detector.mjs's
+ * decide() pattern.
+ *
+ * Graceful degradation: `priorFailingIds` is null for a snapshot written before this
+ * shipped (identity list wasn't recorded yet) — fall back to the old count-based
+ * comparison for that single comparison, matching the existing skipped_count
+ * cold-start pattern in fetchPriorSnapshot().
+ *
+ * @param {string[]} currentIds - failing-test identities in this run (PR or push)
+ * @param {string[]|null} priorFailingIds - failing-test identities recorded in the
+ *   base branch's snapshot, or null if that snapshot predates identity tracking
+ * @param {{failed: number, priorFailedCount: number}} counts - fallback inputs for
+ *   the degraded count-based path
+ * @returns {{regression: boolean, newIds: string[], mode: 'identity'|'count-fallback'}}
+ */
+export function decideRegression(currentIds, priorFailingIds, { failed, priorFailedCount }) {
+  if (Array.isArray(priorFailingIds)) {
+    const priorSet = new Set(priorFailingIds);
+    const newIds = currentIds.filter((id) => !priorSet.has(id));
+    return { regression: newIds.length > 0, newIds, mode: 'identity' };
+  }
+  const newFailures = failed - priorFailedCount;
+  return { regression: newFailures >= 1, newIds: [], mode: 'count-fallback' };
+}
+
 function trendFor(currentFailed, priorFailed) {
   if (priorFailed == null) return 'new';
   if (currentFailed < priorFailed) return 'improving';
@@ -129,9 +189,13 @@ async function fetchPriorSnapshot(supabase, branch) {
       // leave it null so the skip-drift check cold-starts (passes) until the
       // next push to this branch records it.
       const rawSkipped = row.findings[0].skipped_count;
+      // QF-20260701-833: absent on a snapshot written before this shipped — null
+      // signals decideRegression() to fall back to the count-based comparison.
+      const rawFailingIds = row.findings[0].failing_test_ids;
       return {
         failed_count: Number(row.findings[0].failed_count),
         skipped_count: rawSkipped == null ? null : Number(rawSkipped),
+        failing_test_ids: Array.isArray(rawFailingIds) ? rawFailingIds : null,
         scanned_at: row.scanned_at,
       };
     }
@@ -139,7 +203,7 @@ async function fetchPriorSnapshot(supabase, branch) {
   return null;
 }
 
-async function insertSnapshot(supabase, { failed, total, skipped, branch, sha, runId, priorFailed }) {
+async function insertSnapshot(supabase, { failed, total, skipped, branch, sha, runId, priorFailed, failingIds }) {
   const score = total === 0 ? 0 : Number(((total - failed) / total * 100).toFixed(2));
   const trend = trendFor(failed, priorFailed);
   const row = {
@@ -148,7 +212,9 @@ async function insertSnapshot(supabase, { failed, total, skipped, branch, sha, r
     score,
     // FR-5: skipped_count is recorded alongside failed_count so the next PR's
     // skip-drift band has a baseline (the ratchet rewrites it on every push).
-    findings: [{ failed_count: failed, skipped_count: skipped, branch, commit_sha: sha }],
+    // QF-20260701-833: failing_test_ids recorded alongside so the next PR's
+    // regression check can diff by identity, not just raw count.
+    findings: [{ failed_count: failed, skipped_count: skipped, failing_test_ids: failingIds, branch, commit_sha: sha }],
     trend_direction: trend,
     metadata: { workflow_run_id: runId },
   };
@@ -173,8 +239,13 @@ function writePrFailuresArtifact(path, raw, failed) {
   writeFileSync(path, JSON.stringify({ summary: { numFailed: failed }, failures }, null, 2));
 }
 
-function annotateRegression(newFailures) {
+function annotateRegression(newFailures, newIds = []) {
   stderr.write(`::error::BASELINE_REGRESSION: ${newFailures} new test failure(s) vs main snapshot.\n`);
+  if (newIds.length > 0) {
+    stderr.write(`New failing test(s) not present on main:\n`);
+    for (const id of newIds.slice(0, 10)) stderr.write(`  - ${id}\n`);
+    if (newIds.length > 10) stderr.write(`  ... and ${newIds.length - 10} more\n`);
+  }
   stderr.write(`Reproduce locally: node scripts/audit-test-failures.mjs --pr-only --format=json | jq .new_failures\n`);
   stderr.write(`See docs/reference/test-coverage-baseline-ratchet.md for triage steps.\n`);
 }
@@ -203,6 +274,7 @@ async function main() {
     await insertSnapshot(supabase, {
       failed, total, skipped, branch: ctx.branch, sha: ctx.sha, runId: ctx.runId,
       priorFailed: prior?.failed_count,
+      failingIds: extractFailingIds(raw),
     });
     return 0;
   }
@@ -213,10 +285,14 @@ async function main() {
     stdout.write(`No prior snapshot for base branch '${ctx.baseBranch}' — cold start, passing.\n`);
     return 0;
   }
-  const newFailures = failed - prior.failed_count;
-  if (newFailures >= 1) {
+  // QF-20260701-833: identity-based (falls back to count-based only for a
+  // pre-QF baseline snapshot that never recorded failing_test_ids).
+  const decision = decideRegression(extractFailingIds(raw), prior.failing_test_ids, {
+    failed, priorFailedCount: prior.failed_count,
+  });
+  if (decision.regression) {
     writePrFailuresArtifact(args.prFailuresPath, raw, failed);
-    annotateRegression(newFailures);
+    annotateRegression(decision.mode === 'identity' ? decision.newIds.length : failed - prior.failed_count, decision.newIds);
     return 1;
   }
   // FR-5: failure count is stable — now guard against a vacuous green where the
@@ -229,8 +305,12 @@ async function main() {
   const skipNote = skip.status === 'NEW'
     ? 'skip baseline not yet recorded (cold start)'
     : `skipped=${skipped} within band ${skip.lowerBound}–${skip.upperBound}`;
-  stdout.write(`Snapshot baseline=${prior.failed_count}, current=${failed}, delta=${newFailures}; ${skipNote} — passing.\n`);
+  stdout.write(`Snapshot baseline=${prior.failed_count}, current=${failed}, delta=${failed - prior.failed_count} (${decision.mode}, 0 new failing identities); ${skipNote} — passing.\n`);
   return 0;
 }
 
-main().then(code => exit(code)).catch(e => die(`unhandled error: ${e.stack || e.message}`));
+// QF-20260701-833: guard so the pure exports (extractFailingIds, decideRegression)
+// can be imported for unit testing without triggering main()'s process.exit() side
+// effects — mirrors scripts/ci/red-merge-detector.mjs's isMain pattern.
+const isMain = process.argv[1] && import.meta.url.endsWith('compare-to-main-snapshot.mjs') && process.argv[1].endsWith('compare-to-main-snapshot.mjs');
+if (isMain) main().then(code => exit(code)).catch(e => die(`unhandled error: ${e.stack || e.message}`));

--- a/tests/unit/compare-to-main-snapshot-identity.test.js
+++ b/tests/unit/compare-to-main-snapshot-identity.test.js
@@ -1,0 +1,96 @@
+/**
+ * QF-20260701-833 — compare-to-main-snapshot.mjs's BASELINE_REGRESSION check must be
+ * IDENTITY-based, not COUNT-based. The old check flagged a regression on ANY rise in
+ * the raw failed-test count vs the base-branch snapshot, so an unrelated flaky test
+ * bouncing (or a live-DB/CI-secret hiccup) false-blocked PRs whose diff introduced no
+ * new failure. Evidenced on PR #5330 (byte-identical 107 failures across reruns, all
+ * in files unrelated to the diff) and recurred on PR #5334 / #5337 (same 2 unrelated
+ * tests both times). Pure-function coverage, no DB/env required.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractFailingIds, decideRegression } from '../../scripts/compare-to-main-snapshot.mjs';
+
+describe('extractFailingIds', () => {
+  it('extracts file::fullName identities for failed assertions only', () => {
+    const raw = {
+      testResults: [
+        {
+          name: 'tests/a.test.js',
+          assertionResults: [
+            { fullName: 'a passes', status: 'passed' },
+            { fullName: 'a fails', status: 'failed' },
+          ],
+        },
+        {
+          name: 'tests/b.test.js',
+          assertionResults: [{ fullName: 'b fails too', status: 'failed' }],
+        },
+      ],
+    };
+    expect(extractFailingIds(raw)).toEqual([
+      'tests/a.test.js::a fails',
+      'tests/b.test.js::b fails too',
+    ]);
+  });
+
+  it('returns an empty array for a fully-passing run or missing testResults', () => {
+    expect(extractFailingIds({ testResults: [] })).toEqual([]);
+    expect(extractFailingIds({})).toEqual([]);
+  });
+});
+
+describe('decideRegression — identity mode', () => {
+  it('is NOT a regression when the PR failing set is a subset of the base failing set (unrelated pre-existing flakes)', () => {
+    const currentIds = ['tests/consumer-impact-gate.test.js::TS-6 a', 'tests/consumer-impact-gate.test.js::TS-6 b'];
+    const priorFailingIds = [
+      'tests/consumer-impact-gate.test.js::TS-6 a',
+      'tests/consumer-impact-gate.test.js::TS-6 b',
+      'tests/other.test.js::unrelated',
+    ];
+    const decision = decideRegression(currentIds, priorFailingIds, { failed: 2, priorFailedCount: 105 });
+    expect(decision).toEqual({ regression: false, newIds: [], mode: 'identity' });
+  });
+
+  it('IS a regression when the PR introduces a failing test identity not present on main', () => {
+    const currentIds = ['tests/consumer-impact-gate.test.js::TS-6 a', 'tests/new-broken.test.js::oops'];
+    const priorFailingIds = ['tests/consumer-impact-gate.test.js::TS-6 a'];
+    const decision = decideRegression(currentIds, priorFailingIds, { failed: 2, priorFailedCount: 1 });
+    expect(decision.regression).toBe(true);
+    expect(decision.newIds).toEqual(['tests/new-broken.test.js::oops']);
+    expect(decision.mode).toBe('identity');
+  });
+
+  it('is NOT a regression even if the raw count rises, as long as no NEW identity appears (the exact false-positive class this QF fixes)', () => {
+    // Simulates PR #5334/#5337: main baseline=105, PR run=107, but the 2 "extra"
+    // failures are identities already known-flaky and present in the base set too.
+    const priorFailingIds = Array.from({ length: 105 }, (_, i) => `tests/f${i}.test.js::t`).concat([
+      'tests/unit/gates/consumer-impact-gate.test.js::TS-6 a',
+      'tests/unit/gates/consumer-impact-gate.test.js::TS-6 b',
+    ]);
+    const currentIds = priorFailingIds; // identical set, count "107" either way
+    const decision = decideRegression(currentIds, priorFailingIds, { failed: 107, priorFailedCount: 105 });
+    expect(decision.regression).toBe(false);
+  });
+
+  it('IS a regression when the count goes DOWN but a genuinely new failure was introduced (count-based would have missed this)', () => {
+    const priorFailingIds = ['tests/a.test.js::x', 'tests/b.test.js::y', 'tests/c.test.js::z'];
+    // Two old flakes got fixed, but a new one was introduced — net count drops 3 -> 2.
+    const currentIds = ['tests/a.test.js::x', 'tests/new.test.js::regression'];
+    const decision = decideRegression(currentIds, priorFailingIds, { failed: 2, priorFailedCount: 3 });
+    expect(decision.regression).toBe(true);
+    expect(decision.newIds).toEqual(['tests/new.test.js::regression']);
+  });
+});
+
+describe('decideRegression — count-fallback mode (pre-QF baseline snapshot)', () => {
+  it('falls back to count-based comparison when priorFailingIds is null (graceful degradation)', () => {
+    const decision = decideRegression(['tests/x.test.js::x'], null, { failed: 107, priorFailedCount: 105 });
+    expect(decision).toEqual({ regression: true, newIds: [], mode: 'count-fallback' });
+  });
+
+  it('count-fallback passes when the count has not risen', () => {
+    const decision = decideRegression(['tests/x.test.js::x'], null, { failed: 105, priorFailedCount: 105 });
+    expect(decision.regression).toBe(false);
+    expect(decision.mode).toBe('count-fallback');
+  });
+});


### PR DESCRIPTION
## Summary
- `compare-to-main-snapshot.mjs` (the coverage workflow's `Compare to main snapshot` step) previously flagged `BASELINE_REGRESSION` on ANY rise in the raw failed-test COUNT vs the base-branch snapshot, so an unrelated flaky test bouncing (or a live-DB/CI-secret hiccup) false-blocked PRs whose diff introduced no new failure.
- **Evidence**: PR #5330 (worker 1d49c728) — 107 failures byte-identical across reruns, all in 29 files unrelated to the diff, root-caused to missing CI DB secrets. Recurred on PR #5334 and #5337 this session — same 2 unrelated tests both times (`tests/unit/gates/consumer-impact-gate.test.js` TS-6, a vitest worker-crash artifact).
- **Fix**: record the SET of failing-test identities (`file::fullName`) alongside `failed_count` in every push-to-main snapshot, and diff that set against the PR run's failing set. Only a test NOT in the base branch's recorded failing set counts as a regression — a pre-existing/flaky failure already red on main never blocks the PR, regardless of raw count. Also catches a class the old check MISSED: a net-count *drop* that still hides one genuinely new failure.
- Graceful degradation: a base snapshot written before this shipped has no recorded `failing_test_ids` — falls back to the old count-based comparison for that one comparison (mirrors the existing `skipped_count` cold-start pattern) until the next push records a full identity baseline.
- Added an `isMain` guard (mirrors `scripts/ci/red-merge-detector.mjs`) so the new pure exports (`extractFailingIds`, `decideRegression`) are unit-testable without triggering `main()`'s `process.exit()`.
- Updated `docs/reference/test-coverage-baseline-ratchet.md` (the doc cited directly in the error annotation) to describe the new mechanics.

## Deliberate scope boundary
This does NOT attempt "reachable from the diff" correlation (mapping failing test files back to changed source files via a dependency graph) — the identity-diff alone fully resolves the reported false-positive class (byte-identical unrelated failures = zero new identities = no false block). Adding diff-reachability would be meaningfully more complex and is not needed to fix the evidenced bug.

## Test plan
- [x] New `tests/unit/compare-to-main-snapshot-identity.test.js` — 8/8 pass, covering: identity extraction, subset-of-base-set (not a regression), genuinely new identity (is a regression), same-raw-count-rise-but-no-new-identity (the exact PR #5334/#5337 false-positive class), count-drop-hiding-a-new-failure (a class the old check missed), and count-fallback graceful degradation.
- [x] Adjacent `tests/unit/red-merge-baseline-rot.test.js` — 10/10 pass (confirmed no hidden breakage in the sibling detector)
- [x] `node scripts/compare-to-main-snapshot.mjs --help` — CLI entrypoint still works after adding the `isMain` guard
- [x] `schema-reference-lint --diff` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)