### PR TITLE
feat(SD-LEO-INFRA-UPSCALE-ADAM-PM-001-A): foundation — hierarchical adam_task_ledger + CRUD/rollup + rehydration + startup hook

### DIFF
--- a/database/migrations/20260701_adam_task_ledger.sql
+++ b/database/migrations/20260701_adam_task_ledger.sql
@@ -1,0 +1,75 @@
+-- adam_task_ledger — durable HIERARCHICAL task board backing Adam's project-management discipline.
+-- SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A (Child A / FR-1 — the FOUNDATION).
+--
+-- A single task TREE: chairman-visible PARENT nodes (milestone / decision / blocker) and Adam-
+-- operational CHILD subtasks, related by parent_id (self-FK) with status + blocker ROLLUP child->parent.
+-- The harness TaskCreate list is session-ephemeral; this backs the board in the DB so a restarted /
+-- compacted Adam reconstructs its open items. UNIQUE(source_kind, source_ref) makes rehydrateBoard a
+-- safe idempotent upsert.
+--
+-- Additive (new table) — no change to any existing table. Mirrors the adam_adherence_ledger +
+-- solomon_advice_outcome_ledger RLS pattern (service_role write / authenticated+service_role read)
+-- and the solomon updated_at trigger.
+--
+-- @chairman-gated
+-- @approved-by: codestreetlabs@gmail.com
+-- Chairman-gated apply (requires_chairman_apply). Do NOT self-apply — this stages for chairman apply
+-- (check-migration-readiness downgrades to PASS_CHAIRMAN_GATED_PENDING; it does not hard-block).
+
+CREATE TABLE IF NOT EXISTS adam_task_ledger (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_id    uuid REFERENCES adam_task_ledger(id) ON DELETE CASCADE,   -- self-FK: the task TREE
+  tier         text NOT NULL CHECK (tier IN ('parent','child')),         -- parent=chairman-visible, child=Adam-operational
+  status       text NOT NULL DEFAULT 'open'
+                 CHECK (status IN ('open','in_progress','blocked','done','cancelled')),
+  title        text NOT NULL,
+  source_kind  text NOT NULL
+                 CHECK (source_kind IN ('advisory_thread','sourced_sd','awaited_reply','manual')),
+  source_ref   text NOT NULL,                     -- idempotent rehydrate key (with source_kind)
+  blocker      text,                              -- materialized blocker/issue that bubbles child->parent
+  benefit      text,                              -- one-line what-it-delivers (chairman-parent)
+  risk         text,                              -- risks + mitigation note
+  token_cost   numeric,                           -- coarse per-parent rollup (light; NOT per-subtask accounting)
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (source_kind, source_ref)                -- idempotent rehydrate-upsert key
+);
+
+CREATE INDEX IF NOT EXISTS idx_adam_task_ledger_parent ON adam_task_ledger (parent_id);
+CREATE INDEX IF NOT EXISTS idx_adam_task_ledger_status ON adam_task_ledger (status);
+CREATE INDEX IF NOT EXISTS idx_adam_task_ledger_source ON adam_task_ledger (source_kind, source_ref);
+
+-- RLS: authenticated read; service_role full write (mirrors the governance-table convention).
+ALTER TABLE adam_task_ledger ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS adam_task_ledger_read ON adam_task_ledger;
+CREATE POLICY adam_task_ledger_read ON adam_task_ledger
+  FOR SELECT
+  USING (auth.role() = 'authenticated' OR auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS adam_task_ledger_service_write ON adam_task_ledger;
+CREATE POLICY adam_task_ledger_service_write ON adam_task_ledger
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- updated_at trigger (mirrors the solomon_advice_outcome_ledger template).
+CREATE OR REPLACE FUNCTION trg_adam_task_ledger_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_adam_task_ledger_updated ON adam_task_ledger;
+CREATE TRIGGER trg_adam_task_ledger_updated BEFORE UPDATE ON adam_task_ledger
+  FOR EACH ROW EXECUTE FUNCTION trg_adam_task_ledger_updated_at();
+
+COMMENT ON TABLE adam_task_ledger IS 'Durable HIERARCHICAL task board for Adam project-management discipline (SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A / Child A). One task TREE via parent_id (self-FK): chairman-visible PARENT nodes + Adam-operational CHILD subtasks, with status + blocker rollup child->parent. Survives compaction/role-handoff; rehydrated idempotently from live sources via UNIQUE(source_kind, source_ref).';
+COMMENT ON COLUMN adam_task_ledger.parent_id IS 'Self-FK to the parent node (NULL for a root/parent-tier node). ON DELETE CASCADE removes the subtree.';
+COMMENT ON COLUMN adam_task_ledger.tier IS 'parent = chairman-visible milestone/decision/blocker; child = Adam-operational subtask.';
+COMMENT ON COLUMN adam_task_ledger.source_kind IS 'Rehydrate provenance: advisory_thread | sourced_sd | awaited_reply | manual. With source_ref forms the idempotent rehydrate key.';
+COMMENT ON COLUMN adam_task_ledger.source_ref IS 'Stable natural key for the source (correlation_id / sd_key / …). UNIQUE with source_kind so rehydrateBoard is an upsert, not a duplicate.';
+COMMENT ON COLUMN adam_task_ledger.blocker IS 'Materialized blocker/issue text; bubbleBlockers() surfaces a child blocker onto its parent for the chairman-curated view.';
+COMMENT ON COLUMN adam_task_ledger.token_cost IS 'Coarse per-parent token rollup (light; a simple sum — NOT per-subtask accounting).';

--- a/lib/adam/task-ledger.js
+++ b/lib/adam/task-ledger.js
@@ -1,0 +1,137 @@
+/**
+ * Adam task-ledger CRUD + PURE status/blocker rollup helpers.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A (Child A / FR-2).
+ *
+ * The durable backing for Adam's hierarchical task board (adam_task_ledger). The board is a single
+ * task TREE — chairman-visible PARENT nodes and Adam-operational CHILD subtasks, related by
+ * parent_id — that survives compaction + role-handoff (the harness TaskCreate list is ephemeral).
+ *
+ * Two layers, kept deliberately separate so the derivations are unit-testable WITHOUT a DB:
+ *   - IO helpers (take a supabase client): createOrUpsertNode / setStatus / setBlocker.
+ *   - PURE derivations (take plain arrays of children): rollupParentStatus / bubbleBlockers /
+ *     sumTokenCost. These are a single-tree derivation (NOT a promotion-copy between two lists).
+ */
+
+export const TABLE = 'adam_task_ledger';
+
+export const STATUSES = Object.freeze(['open', 'in_progress', 'blocked', 'done', 'cancelled']);
+export const TIERS = Object.freeze(['parent', 'child']);
+export const SOURCE_KINDS = Object.freeze(['advisory_thread', 'sourced_sd', 'awaited_reply', 'manual']);
+
+/** Build the persisted row from node input, dropping undefined so the upsert stays sparse. */
+function buildRow({ source_kind, source_ref, tier, title, parent_id, blocker, benefit, risk, token_cost, status } = {}) {
+  const row = { source_kind, source_ref, tier, title };
+  if (parent_id !== undefined) row.parent_id = parent_id;
+  if (blocker !== undefined) row.blocker = blocker;
+  if (benefit !== undefined) row.benefit = benefit;
+  if (risk !== undefined) row.risk = risk;
+  if (token_cost !== undefined) row.token_cost = token_cost;
+  if (status !== undefined) row.status = status;
+  return row;
+}
+
+/**
+ * Idempotent UPSERT of a board node on the natural key (source_kind, source_ref). Re-running with
+ * the same key updates the existing row instead of duplicating it (the rehydrate safety net).
+ * @param {object} supabase - a supabase client
+ * @param {object} node - { source_kind, source_ref, tier, title, parent_id?, blocker?, benefit?, risk?, token_cost?, status? }
+ * @returns {Promise<object>} the upserted row
+ */
+export async function createOrUpsertNode(supabase, node) {
+  if (!node || !node.source_kind || !node.source_ref) {
+    throw new Error('createOrUpsertNode: source_kind + source_ref are required (the idempotency key)');
+  }
+  if (!node.tier || !TIERS.includes(node.tier)) {
+    throw new Error(`createOrUpsertNode: tier must be one of ${TIERS.join('|')} (got ${node.tier})`);
+  }
+  if (!node.title) throw new Error('createOrUpsertNode: title is required');
+  const row = buildRow(node);
+  const { data, error } = await supabase
+    .from(TABLE)
+    .upsert(row, { onConflict: 'source_kind,source_ref' })
+    .select()
+    .single();
+  if (error) throw new Error(`createOrUpsertNode upsert failed: ${error.message}`);
+  return data;
+}
+
+/**
+ * Set a node's status (validated against the CHECK enum).
+ * @param {object} supabase @param {string} id @param {string} status
+ */
+export async function setStatus(supabase, id, status) {
+  if (!STATUSES.includes(status)) {
+    throw new Error(`setStatus: status must be one of ${STATUSES.join('|')} (got ${status})`);
+  }
+  const { data, error } = await supabase.from(TABLE).update({ status }).eq('id', id).select().maybeSingle();
+  if (error) throw new Error(`setStatus failed: ${error.message}`);
+  return data;
+}
+
+/**
+ * Set (or clear, with null) a node's materialized blocker text.
+ * @param {object} supabase @param {string} id @param {string|null} blocker
+ */
+export async function setBlocker(supabase, id, blocker) {
+  const { data, error } = await supabase.from(TABLE).update({ blocker: blocker ?? null }).eq('id', id).select().maybeSingle();
+  if (error) throw new Error(`setBlocker failed: ${error.message}`);
+  return data;
+}
+
+// ── PURE derivations (take plain arrays — no client, no IO — so they unit-test without a DB) ──
+
+/** Coerce a children argument into a safe array of node-ish objects. */
+function asChildren(children) {
+  return Array.isArray(children) ? children.filter((c) => c && typeof c === 'object') : [];
+}
+
+/**
+ * Derive a parent's rolled-up status from its children. Single-tree derivation:
+ *   - cancelled children are IGNORED (they don't count toward the rollup);
+ *   - if any (non-cancelled) child is 'blocked'  -> 'blocked';
+ *   - if there are non-cancelled children and they are ALL 'done' -> 'done';
+ *   - if there are no non-cancelled children -> 'open';
+ *   - otherwise -> 'in_progress'.
+ * @param {Array<{status?:string}>} children
+ * @returns {'open'|'in_progress'|'blocked'|'done'}
+ */
+export function rollupParentStatus(children) {
+  const effective = asChildren(children).filter((c) => c.status !== 'cancelled');
+  if (effective.length === 0) return 'open';
+  if (effective.some((c) => c.status === 'blocked')) return 'blocked';
+  if (effective.every((c) => c.status === 'done')) return 'done';
+  return 'in_progress';
+}
+
+/**
+ * Surface child blockers onto the parent for the chairman-curated view. Returns the ACTIVE child
+ * blockers (a truthy blocker on a child that is not done/cancelled). PURE.
+ * @param {Array<{id?:string,title?:string,status?:string,blocker?:string}>} children
+ * @returns {Array<{id:string|null,title:string|null,blocker:string}>}
+ */
+export function bubbleBlockers(children) {
+  return asChildren(children)
+    .filter((c) => c.blocker && String(c.blocker).trim() && c.status !== 'done' && c.status !== 'cancelled')
+    .map((c) => ({ id: c.id ?? null, title: c.title ?? null, blocker: String(c.blocker) }));
+}
+
+/**
+ * Coarse per-parent token rollup — a simple sum of children's numeric token_cost (cancelled ignored,
+ * null/undefined/non-numeric skipped). Light; NOT per-subtask accounting.
+ * @param {Array<{status?:string,token_cost?:number}>} children
+ * @returns {number}
+ */
+export function sumTokenCost(children) {
+  return asChildren(children)
+    .filter((c) => c.status !== 'cancelled')
+    .reduce((sum, c) => {
+      const n = Number(c.token_cost);
+      return Number.isFinite(n) ? sum + n : sum;
+    }, 0);
+}
+
+export default {
+  TABLE, STATUSES, TIERS, SOURCE_KINDS,
+  createOrUpsertNode, setStatus, setBlocker,
+  rollupParentStatus, bubbleBlockers, sumTokenCost,
+};

--- a/lib/adam/task-rehydrate.js
+++ b/lib/adam/task-rehydrate.js
@@ -1,0 +1,147 @@
+/**
+ * Adam task-board REHYDRATION — reconstruct open threads from the live sources on a cold /adam start.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A (Child A / FR-3).
+ *
+ * The harness TaskCreate list is session-ephemeral; a restarted / compacted Adam otherwise loses its
+ * open items. rehydrateBoard() UPSERTs durable board nodes (via FR-2's createOrUpsertNode, keyed on
+ * UNIQUE(source_kind, source_ref)) from three live sources, so a thread already on the board is
+ * DEDUPED, not duplicated:
+ *   (a) advisory_thread — OPEN Adam advisory threads: session_coordination rows sent by Adam
+ *       (sender_type='adam') carrying a correlation_id (or reply_requested) that have NO reply row
+ *       (a row whose payload.reply_to matches the correlation_id). source_ref = correlation_id.
+ *   (b) sourced_sd     — Adam-sourced SDs still open: strategic_directives_v2 where
+ *       metadata.sourced_by='adam' AND status IN ('draft','in_progress'). source_ref = sd_key.
+ *   (c) awaited_reply  — the awaited-reply markers for the open threads that explicitly requested a
+ *       reply (payload.reply_requested truthy). source_ref = correlation_id.
+ *
+ * Every write goes through the idempotent upsert, so re-running is a safe no-op (dedup). Each source
+ * block is wrapped fail-soft: a failing source logs a warning and contributes nothing, so a partial
+ * outage still rehydrates the healthy sources (the /adam startup hook is additionally fail-soft).
+ */
+
+import { createOrUpsertNode } from './task-ledger.js';
+
+const COORDINATION_TABLE = 'session_coordination';
+const SD_TABLE = 'strategic_directives_v2';
+const OPEN_SD_STATUSES = new Set(['draft', 'in_progress']);
+
+const truthy = (v) => v === true || v === 'true';
+const corrId = (row) => (row && row.payload && row.payload.correlation_id) || null;
+const replyTo = (row) => (row && row.payload && row.payload.reply_to) || null;
+
+/** A short human title for a thread node (subject/body-derived, bounded). */
+function threadTitle(row) {
+  const p = (row && row.payload) || {};
+  const t = p.subject || row.subject || p.body || row.body || `thread ${corrId(row)}`;
+  return String(t).replace(/\s+/g, ' ').trim().slice(0, 160) || `thread ${corrId(row)}`;
+}
+
+/**
+ * Rehydrate the durable Adam task board from the three live sources. Idempotent (upsert on
+ * (source_kind, source_ref)). Never throws — each source is fail-soft.
+ * @param {object} supabase - a supabase client
+ * @returns {Promise<{threads:number, parents:number, sds:number, awaited:number, errors:string[]}>}
+ */
+export async function rehydrateBoard(supabase) {
+  const summary = { threads: 0, parents: 0, sds: 0, awaited: 0, errors: [] };
+  if (!supabase || typeof supabase.from !== 'function') {
+    summary.errors.push('no supabase client supplied');
+    return summary;
+  }
+
+  // ── (a)+(c) advisory threads / awaited replies ─────────────────────────────
+  // One fetch of the coordination lane; classify open threads + replies in JS (so the reply rows,
+  // which are NOT sent by Adam, are visible in the same result set).
+  let rows = [];
+  try {
+    const { data, error } = await supabase
+      .from(COORDINATION_TABLE)
+      .select('id, sender_type, subject, body, payload, created_at')
+      .order('created_at', { ascending: false })
+      .limit(500);
+    if (error) throw new Error(error.message);
+    rows = Array.isArray(data) ? data : [];
+  } catch (e) {
+    summary.errors.push(`advisory-thread source failed: ${e?.message ?? e}`);
+    rows = [];
+  }
+
+  // Every correlation_id that already has a reply → that thread is resolved (closed).
+  const repliedCorr = new Set(rows.map(replyTo).filter(Boolean));
+  // Candidate Adam-sent threads that carry a correlation_id and are still open.
+  const openThreads = rows.filter(
+    (r) => r && r.sender_type === 'adam' && corrId(r) && !repliedCorr.has(corrId(r))
+  );
+
+  for (const t of openThreads) {
+    const ref = corrId(t);
+    const title = threadTitle(t);
+    // (a) the thread/topic node
+    try {
+      await createOrUpsertNode(supabase, {
+        source_kind: 'advisory_thread',
+        source_ref: ref,
+        tier: 'parent',
+        title,
+      });
+      summary.threads += 1;
+      summary.parents += 1;
+    } catch (e) {
+      summary.errors.push(`advisory_thread upsert failed (${ref}): ${e?.message ?? e}`);
+    }
+    // (c) the awaited-reply marker for threads that explicitly requested a reply
+    if (truthy(t.payload && t.payload.reply_requested)) {
+      try {
+        await createOrUpsertNode(supabase, {
+          source_kind: 'awaited_reply',
+          source_ref: ref,
+          tier: 'parent',
+          title: `awaiting reply: ${title}`,
+          blocker: `awaiting reply on ${ref}`,
+        });
+        summary.awaited += 1;
+        summary.parents += 1;
+      } catch (e) {
+        summary.errors.push(`awaited_reply upsert failed (${ref}): ${e?.message ?? e}`);
+      }
+    }
+  }
+
+  // ── (b) Adam-sourced open SDs ──────────────────────────────────────────────
+  let sds = [];
+  try {
+    const { data, error } = await supabase
+      .from(SD_TABLE)
+      .select('sd_key, title, status, metadata')
+      .eq('metadata->>sourced_by', 'adam')
+      .in('status', ['draft', 'in_progress']);
+    if (error) throw new Error(error.message);
+    sds = Array.isArray(data) ? data : [];
+  } catch (e) {
+    summary.errors.push(`sourced_sd source failed: ${e?.message ?? e}`);
+    sds = [];
+  }
+
+  // Authoritative JS-side filter (the stub's server filters are no-ops; the live query mirrors this).
+  const openSds = sds.filter(
+    (s) => s && s.metadata && s.metadata.sourced_by === 'adam' && s.sd_key && OPEN_SD_STATUSES.has(s.status)
+  );
+  for (const sd of openSds) {
+    try {
+      await createOrUpsertNode(supabase, {
+        source_kind: 'sourced_sd',
+        source_ref: sd.sd_key,
+        tier: 'parent',
+        title: sd.title ? String(sd.title).slice(0, 160) : sd.sd_key,
+      });
+      summary.sds += 1;
+      summary.parents += 1;
+    } catch (e) {
+      summary.errors.push(`sourced_sd upsert failed (${sd.sd_key}): ${e?.message ?? e}`);
+    }
+  }
+
+  return summary;
+}
+
+export default { rehydrateBoard };

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -372,6 +372,34 @@ export async function renderSourcingState({ supabase = null, env = process.env }
 }
 
 // ── Main (fail-open: always exit 0) ──
+/**
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A (Child A / FR-4): rehydrate the
+ * durable Adam task board (adam_task_ledger) on a cold /adam start (and post-compaction), BEFORE
+ * Adam works its threads, so the session reconstructs its open items from the live sources. FAIL-SOFT
+ * -- a rehydrate error (or missing DB creds / not-yet-applied migration) never blocks startup; it
+ * degrades to a skip line. Surfaces a one-line 'board: N open threads (M parents)' summary.
+ * Accepts an injected supabase client for tests; otherwise builds one from env creds.
+ */
+export async function renderBoardRehydrate({ supabase = null, env = process.env } = {}) {
+  const head = '═══ ADAM TASK BOARD (rehydrate) ═══\n  ';
+  try {
+    let client = supabase;
+    if (!client) {
+      const url = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+      const key = env.SUPABASE_SERVICE_ROLE_KEY;
+      if (!url || !key) return head + 'rehydrate skipped (no DB creds, fail-open)';
+      const { createClient } = await import('@supabase/supabase-js');
+      client = createClient(url, key);
+    }
+    const { rehydrateBoard } = await import('../lib/adam/task-rehydrate.js');
+    const summary = await rehydrateBoard(client);
+    const note = summary.errors && summary.errors.length ? ` (${summary.errors.length} source issue(s), fail-soft)` : '';
+    return head + `board: ${summary.threads} open threads (${summary.parents} parents)${note}`;
+  } catch (err) {
+    return head + 'rehydrate skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 async function main() {
   try {
     console.log('[ADAM-STARTUP] ' + (process.env.CLAUDE_SESSION_ID ? 'session=' + process.env.CLAUDE_SESSION_ID : 'session=unknown'));
@@ -379,6 +407,9 @@ async function main() {
     // FR-2: the read-only Sourcing SSOT state probe (DB-backed, fail-open).
     console.log('');
     console.log(await renderSourcingState({ env: process.env }));
+    // FR-4: rehydrate the durable Adam task board (fail-soft -- never blocks startup).
+    console.log('');
+    console.log(await renderBoardRehydrate({ env: process.env }));
   } catch (err) {
     console.warn('⚠️  adam-startup-check hiccup (non-blocking, fail-open): ' + (err && err.message ? err.message : String(err)));
   }

--- a/tests/unit/adam/task-ledger.test.js
+++ b/tests/unit/adam/task-ledger.test.js
@@ -1,0 +1,161 @@
+/**
+ * Unit pins for the Adam task-ledger CRUD + PURE rollup helpers.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A (Child A / FR-5).
+ *
+ * Mocks supabase (no live DB), mirroring the adam test-stub pattern: a table-keyed chainable
+ * builder whose .upsert(...).select().single() dedups on the natural key (source_kind, source_ref),
+ * so the idempotency contract is exercised without a database.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createOrUpsertNode, setStatus, setBlocker,
+  rollupParentStatus, bubbleBlockers, sumTokenCost,
+  STATUSES, TIERS, SOURCE_KINDS,
+} from '../../../lib/adam/task-ledger.js';
+
+/** In-memory adam_task_ledger stub. upsert dedups on (source_kind, source_ref) like the UNIQUE key. */
+function makeSupabase() {
+  const ledger = [];
+  const keyOf = (r) => `${r.source_kind}|${r.source_ref}`;
+  function from(table) {
+    if (table !== 'adam_task_ledger') throw new Error(`unexpected table: ${table}`);
+    return {
+      upsert(row /* , opts */) {
+        return {
+          select() {
+            return {
+              single: async () => {
+                const existing = ledger.find((r) => keyOf(r) === keyOf(row));
+                if (existing) { Object.assign(existing, row); return { data: existing, error: null }; }
+                const created = { id: `id-${ledger.length + 1}`, status: 'open', ...row };
+                ledger.push(created);
+                return { data: created, error: null };
+              },
+            };
+          },
+        };
+      },
+      update(patch) {
+        return {
+          eq(_col, id) {
+            return {
+              select() {
+                return {
+                  maybeSingle: async () => {
+                    const row = ledger.find((r) => r.id === id);
+                    if (row) Object.assign(row, patch);
+                    return { data: row ?? null, error: null };
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+  return { from, _ledger: ledger };
+}
+
+describe('exported enums', () => {
+  it('carry the CHECK-constraint domains', () => {
+    expect(STATUSES).toEqual(['open', 'in_progress', 'blocked', 'done', 'cancelled']);
+    expect(TIERS).toEqual(['parent', 'child']);
+    expect(SOURCE_KINDS).toEqual(['advisory_thread', 'sourced_sd', 'awaited_reply', 'manual']);
+  });
+});
+
+describe('createOrUpsertNode — idempotent on (source_kind, source_ref)', () => {
+  it('two upserts with the same key yield exactly one node (dedup)', async () => {
+    const sb = makeSupabase();
+    const node = { source_kind: 'advisory_thread', source_ref: 'corr-1', tier: 'parent', title: 'Thread 1' };
+    const a = await createOrUpsertNode(sb, node);
+    const b = await createOrUpsertNode(sb, { ...node, title: 'Thread 1 (updated)' });
+    expect(sb._ledger).toHaveLength(1);
+    expect(b.id).toBe(a.id);               // same row, not a duplicate
+    expect(sb._ledger[0].title).toBe('Thread 1 (updated)'); // upsert updated in place
+  });
+
+  it('distinct (source_kind, source_ref) pairs create distinct nodes', async () => {
+    const sb = makeSupabase();
+    await createOrUpsertNode(sb, { source_kind: 'advisory_thread', source_ref: 'c1', tier: 'parent', title: 'A' });
+    await createOrUpsertNode(sb, { source_kind: 'awaited_reply', source_ref: 'c1', tier: 'parent', title: 'B' }); // same ref, other kind
+    await createOrUpsertNode(sb, { source_kind: 'sourced_sd', source_ref: 'SD-1', tier: 'parent', title: 'C' });
+    expect(sb._ledger).toHaveLength(3);
+  });
+
+  it('rejects a missing idempotency key or an invalid tier/title (fail-loud)', async () => {
+    const sb = makeSupabase();
+    await expect(createOrUpsertNode(sb, { source_kind: 'manual', tier: 'parent', title: 'x' })).rejects.toThrow(/source_ref/);
+    await expect(createOrUpsertNode(sb, { source_kind: 'manual', source_ref: 'r', tier: 'bogus', title: 'x' })).rejects.toThrow(/tier/);
+    await expect(createOrUpsertNode(sb, { source_kind: 'manual', source_ref: 'r', tier: 'child' })).rejects.toThrow(/title/);
+  });
+});
+
+describe('setStatus / setBlocker', () => {
+  it('setStatus updates the node and rejects a non-enum status', async () => {
+    const sb = makeSupabase();
+    const n = await createOrUpsertNode(sb, { source_kind: 'manual', source_ref: 'r1', tier: 'child', title: 'sub' });
+    await setStatus(sb, n.id, 'in_progress');
+    expect(sb._ledger[0].status).toBe('in_progress');
+    await expect(setStatus(sb, n.id, 'nope')).rejects.toThrow(/status/);
+  });
+  it('setBlocker materializes and clears a blocker', async () => {
+    const sb = makeSupabase();
+    const n = await createOrUpsertNode(sb, { source_kind: 'manual', source_ref: 'r2', tier: 'child', title: 'sub' });
+    await setBlocker(sb, n.id, 'waiting on API key');
+    expect(sb._ledger[0].blocker).toBe('waiting on API key');
+    await setBlocker(sb, n.id, null);
+    expect(sb._ledger[0].blocker).toBeNull();
+  });
+});
+
+describe('rollupParentStatus (PURE) — single-tree derivation', () => {
+  it('blocked when ANY non-cancelled child is blocked', () => {
+    expect(rollupParentStatus([{ status: 'in_progress' }, { status: 'blocked' }, { status: 'done' }])).toBe('blocked');
+  });
+  it('done when ALL non-cancelled children are done', () => {
+    expect(rollupParentStatus([{ status: 'done' }, { status: 'done' }])).toBe('done');
+  });
+  it('cancelled children are IGNORED (all-done-among-the-rest => done)', () => {
+    expect(rollupParentStatus([{ status: 'done' }, { status: 'cancelled' }])).toBe('done');
+  });
+  it('in_progress for a mixed open/in_progress set', () => {
+    expect(rollupParentStatus([{ status: 'open' }, { status: 'in_progress' }])).toBe('in_progress');
+    expect(rollupParentStatus([{ status: 'open' }, { status: 'done' }])).toBe('in_progress');
+  });
+  it('open when there are no effective (non-cancelled) children', () => {
+    expect(rollupParentStatus([])).toBe('open');
+    expect(rollupParentStatus([{ status: 'cancelled' }])).toBe('open');
+    expect(rollupParentStatus(null)).toBe('open');
+  });
+});
+
+describe('bubbleBlockers (PURE)', () => {
+  it('surfaces an active child blocker onto the parent', () => {
+    const out = bubbleBlockers([
+      { id: 'k1', title: 'child A', status: 'blocked', blocker: 'awaiting chairman decision' },
+      { id: 'k2', title: 'child B', status: 'in_progress' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ id: 'k1', blocker: 'awaiting chairman decision' });
+  });
+  it('ignores done/cancelled children and empty blockers', () => {
+    const out = bubbleBlockers([
+      { id: 'a', status: 'done', blocker: 'stale — resolved' },
+      { id: 'b', status: 'cancelled', blocker: 'no longer relevant' },
+      { id: 'c', status: 'blocked', blocker: '   ' },
+      { id: 'd', status: 'blocked', blocker: 'REAL blocker' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].blocker).toBe('REAL blocker');
+  });
+});
+
+describe('sumTokenCost (PURE) — coarse per-parent rollup', () => {
+  it('sums numeric token_cost, ignoring cancelled + non-numeric', () => {
+    expect(sumTokenCost([{ token_cost: 100 }, { token_cost: 250 }, { token_cost: null }])).toBe(350);
+    expect(sumTokenCost([{ token_cost: 100 }, { token_cost: 999, status: 'cancelled' }])).toBe(100);
+    expect(sumTokenCost([])).toBe(0);
+  });
+});

--- a/tests/unit/adam/task-rehydrate.test.js
+++ b/tests/unit/adam/task-rehydrate.test.js
@@ -1,0 +1,118 @@
+/**
+ * Unit pins for the Adam task-board REHYDRATION from the three live sources.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-A (Child A / FR-5).
+ *
+ * Mocks supabase (no live DB): a table-keyed stub serves the coordination + SD sources and an
+ * in-memory ledger whose upsert dedups on (source_kind, source_ref). Asserts each source produces
+ * exactly one board node and that a second run is a no-op (dedup).
+ */
+import { describe, it, expect } from 'vitest';
+import { rehydrateBoard } from '../../../lib/adam/task-rehydrate.js';
+
+/** Read builder: chainable no-op filters, thenable to the seeded rows. */
+function readBuilder(data) {
+  const b = {
+    select: () => b, eq: () => b, in: () => b, is: () => b, not: () => b,
+    order: () => b, limit: () => b,
+    then: (resolve, reject) => Promise.resolve({ data, error: null }).then(resolve, reject),
+  };
+  return b;
+}
+
+function makeSupabase({ coordination = [], sds = [] } = {}) {
+  const ledger = [];
+  const keyOf = (r) => `${r.source_kind}|${r.source_ref}`;
+  function from(table) {
+    if (table === 'adam_task_ledger') {
+      return {
+        upsert(row) {
+          return {
+            select() {
+              return {
+                single: async () => {
+                  const existing = ledger.find((r) => keyOf(r) === keyOf(row));
+                  if (existing) { Object.assign(existing, row); return { data: existing, error: null }; }
+                  const created = { id: `id-${ledger.length + 1}`, status: 'open', ...row };
+                  ledger.push(created);
+                  return { data: created, error: null };
+                },
+              };
+            },
+          };
+        },
+      };
+    }
+    if (table === 'session_coordination') return readBuilder(coordination);
+    if (table === 'strategic_directives_v2') return readBuilder(sds);
+    return readBuilder([]);
+  }
+  return { from, _ledger: ledger };
+}
+
+/** The 3-source fixture: 1 OPEN reply-requested thread, 1 RESOLVED thread, 1 adam-sourced SD, 1 other SD. */
+function fixture() {
+  return {
+    coordination: [
+      // (a)+(c) OPEN Adam thread that explicitly requested a reply, no reply yet
+      { id: 'sc1', sender_type: 'adam', payload: { correlation_id: 'corr-open', reply_requested: true, subject: 'Decision needed on X' } },
+      // RESOLVED Adam thread (corr-done) — a coordinator reply row closes it => must be EXCLUDED
+      { id: 'sc2', sender_type: 'adam', payload: { correlation_id: 'corr-done', subject: 'Old question' } },
+      { id: 'sc3', sender_type: 'coordinator', payload: { reply_to: 'corr-done', body: 'answered' } },
+    ],
+    sds: [
+      // (b) open Adam-sourced SD => included
+      { sd_key: 'SD-ADAM-OPEN', title: 'Adam-sourced open work', status: 'draft', metadata: { sourced_by: 'adam' } },
+      // non-matching SD (not adam-sourced / not open) => excluded
+      { sd_key: 'SD-OTHER', title: 'Coordinator work', status: 'completed', metadata: { sourced_by: 'coordinator' } },
+    ],
+  };
+}
+
+describe('rehydrateBoard — reconstruct from the 3 live sources', () => {
+  it('an unresolved advisory thread + an open adam-sourced SD + an awaited-reply marker each produce exactly one node', async () => {
+    const sb = makeSupabase(fixture());
+    const summary = await rehydrateBoard(sb);
+
+    // Exactly 3 nodes — one per source kind.
+    expect(sb._ledger).toHaveLength(3);
+    const byKind = Object.fromEntries(sb._ledger.map((r) => [r.source_kind, r]));
+    expect(byKind.advisory_thread.source_ref).toBe('corr-open');
+    expect(byKind.awaited_reply.source_ref).toBe('corr-open');
+    expect(byKind.awaited_reply.blocker).toMatch(/awaiting reply/i);
+    expect(byKind.sourced_sd.source_ref).toBe('SD-ADAM-OPEN');
+    // all rehydrated nodes are chairman-visible parents
+    expect(sb._ledger.every((r) => r.tier === 'parent')).toBe(true);
+
+    // Summary counts
+    expect(summary.threads).toBe(1);
+    expect(summary.awaited).toBe(1);
+    expect(summary.sds).toBe(1);
+    expect(summary.parents).toBe(3);
+    expect(summary.errors).toHaveLength(0);
+  });
+
+  it('excludes a resolved thread (a reply matched its correlation_id) and a non-adam / closed SD', async () => {
+    const sb = makeSupabase(fixture());
+    await rehydrateBoard(sb);
+    const refs = sb._ledger.map((r) => r.source_ref);
+    expect(refs).not.toContain('corr-done');   // resolved thread excluded
+    expect(refs).not.toContain('SD-OTHER');    // non-adam, completed SD excluded
+  });
+
+  it('is idempotent — a second run is a no-op (dedup via the natural key)', async () => {
+    const sb = makeSupabase(fixture());
+    await rehydrateBoard(sb);
+    expect(sb._ledger).toHaveLength(3);
+    const idsAfterFirst = sb._ledger.map((r) => r.id).sort();
+    const summary2 = await rehydrateBoard(sb);
+    expect(sb._ledger).toHaveLength(3);                       // no duplicates added
+    expect(sb._ledger.map((r) => r.id).sort()).toEqual(idsAfterFirst); // same rows reused
+    expect(summary2.parents).toBe(3);
+  });
+
+  it('is fail-soft — a bad client returns a summary with an error, never throws', async () => {
+    const summary = await rehydrateBoard(null);
+    expect(summary.threads).toBe(0);
+    expect(summary.errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Child A — foundation of the Adam PM-discipline orchestrator

Child A of the chairman-directed **SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001** ("upscale Adam with durable PM discipline"). Delivers the **durable, hierarchical task board** that survives compaction + role-handoff — the foundation Children B (reconcile/anti-slip/stall-alert/role-wiring) and C (self-adherence PM probe) build on.

### What shipped (+669 LOC, additive)
- **FR-1** `database/migrations/20260701_adam_task_ledger.sql` — a **hierarchical** task tree: `parent_id` self-FK (ON DELETE CASCADE), `tier` (parent=chairman-visible / child=Adam-operational), `status`/`source_kind` CHECK enums, `UNIQUE(source_kind, source_ref)` for idempotent rehydrate-upsert, light `benefit`/`risk`/`token_cost` cols, RLS + `updated_at` trigger. **Chairman-gated** (`-- @chairman-gated` + `@approved-by` markers, `requires_chairman_apply=true`) — **staged, NOT self-applied** (RLS is chairman-only). check-migration-readiness → `PASS_CHAIRMAN_GATED_PENDING`.
- **FR-2** `lib/adam/task-ledger.js` — CRUD + **pure** `rollupParentStatus`/`bubbleBlockers` (single-tree rollup child→parent per the chairman's `adam_scope_hierarchy`, not promotion-copy) + idempotent upsert.
- **FR-3** `lib/adam/task-rehydrate.js` — `rehydrateBoard()` reconstructs the board on a cold `/adam` start from 3 live sources (open advisory threads, adam-sourced draft/in_progress SDs, awaited-reply markers), idempotent.
- **FR-4** `scripts/adam-startup-check.mjs` — **fail-soft** rehydrate hook (never blocks startup).
- **FR-5** tests (18 green; +16 startup-check regression green = 34 total).

### Verification
- DATABASE + TESTING (EXEC) PASS; VALIDATION (90) + REGRESSION (95) + retro (PLAN_VERIFICATION) PASS — purely additive, no existing file broken except the fail-soft startup hook.
- Tests mock supabase (the table isn't applied yet). LOW notes: live-DB integration smoke deferred to chairman apply; rehydrate uses a 500-row window.

### ⚠️ Chairman action required post-merge
The chairman must apply `database/migrations/20260701_adam_task_ledger.sql` (RLS). Until then the startup hook fail-soft-skips. Children B/C build against the frozen ledger contract with mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)