### PR TITLE
docs(SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C): event-driven dispatch_rank trigger + coordinator-review clear path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: ba86693764690e2c -->
+<!-- file_content_hash: 1578e8514241b25a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-06-30 2:51:16 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-07-01 7:34:56 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 4e9d7884c1a41f89 -->
+<!-- file_content_hash: f03ff96593d095f1 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-06-30 2:51:16 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -106,7 +106,7 @@ After sourcing a DRAFT SD, route it for a PRE-BUILD review when its correctness 
 
 **SOURCE-AND-GO (default — no pre-review)** when NONE of the above: small / self-contained (Tier 1/2), no deps, no fleet impact, clear / routine scope, low priority. Normal LEAD-approval + dispatch review already covers it. Silence-by-default: never manufacture a review for a routine SD.
 
-**HOLD MECHANIC (enforced, not advisory):** a review-pending SD is sourced with `metadata.needs_coordinator_review=true`, wired into `classifyDispatchIneligibility` (the shared claim gate) so it is LITERALLY un-claimable until the coordinator clears the flag — that clear IS the coordinator's dispatch authorization. Rejected alternatives: a holding-tier (abuses tiering) and advisory-only (drifts). Make the gate authoritative (same class as the self-claim-window fix). [Implementation follow-on: the gate wiring is itself a dispatch-MECHANISM SD -> coordinator-reviewed.]
+**HOLD MECHANIC (enforced, not advisory):** a review-pending SD is sourced with `metadata.needs_coordinator_review=true`, wired into `classifyDispatchIneligibility` (the shared claim gate) so it is LITERALLY un-claimable until the coordinator clears the flag — that clear IS the coordinator's dispatch authorization. Rejected alternatives: a holding-tier (abuses tiering) and advisory-only (drifts). Make the gate authoritative (same class as the self-claim-window fix). [Implementation follow-on: the gate wiring is itself a dispatch-MECHANISM SD -> coordinator-reviewed.] **Clear path (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C):** `node scripts/clear-coordinator-review.mjs <SD-KEY>` clears the flag via an atomic write (`lib/coordinator/clear-coordinator-review.js`) and immediately triggers a rank-pass refresh so the newly-authorized SD is claimable within seconds, not the next ~15min cron tick.
 
 **Why:** coordinator pre-dispatch review earns its round-trip exactly where dispatch-correctness depends on coordinator-owned state — the gauge-vs-action failure class where a source-time assumption silently diverges from dispatch reality (tiering defaults, window exclusion, wrong-repo). Solomon earns its consult where reasoning-correctness is at risk. Proven on first use (2026-06-30): the Solomon-consult SD review CAUGHT + deliberately set its tiering before any worker touched it.
 
@@ -278,6 +278,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: 66e32dd503a5f577 -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: ffd551923a42571f -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: f3348c98825b0178 -->
+<!-- file_content_hash: 223d035d954912dd -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-06-30 2:51:16 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -77,6 +77,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: d17b5294d5d4d56d -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: b653e4ec79b4675a -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 5daa01fb2c84e762 -->
+<!-- file_content_hash: 81b2d13c8fb82364 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-06-30 3:18:12 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1708,7 +1708,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: 0f5d93436845dd4b -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: 1ad130743043d8d9 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-06-30 2:51:16 PM*
+*DIGEST generated: 2026-07-01 7:34:56 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: 05d018fc951d45d5 -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: 8248cbf65c27e61f -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-06-30 2:51:16 PM*
+*DIGEST generated: 2026-07-01 7:34:56 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 570ca66e1267fcab -->
+<!-- file_content_hash: 63fd880003fc132b -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-06-30 2:51:16 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2120,6 +2120,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: bcf5cd28fdeebda2 -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: c946c176d57c45eb -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-06-30 2:51:16 PM*
+*DIGEST generated: 2026-07-01 7:34:56 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 7b16e7ea5356830e -->
+<!-- file_content_hash: 82b6317e181fcdbd -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-06-30 2:51:16 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1584,6 +1584,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: a7bec272455e0434 -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: 3180d14101714f62 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-06-30 2:51:16 PM*
+*DIGEST generated: 2026-07-01 7:34:56 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 44af24593585864b -->
+<!-- file_content_hash: 416a46e305a15917 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-06-30 2:51:16 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2443,6 +2443,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: 37bde37e2745db95 -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: 56ded987df548165 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-06-30 2:51:16 PM*
+*DIGEST generated: 2026-07-01 7:34:56 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 14544092f1eaefc3 -->
+<!-- file_content_hash: 34f01b13bec3bd3f -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-06-30 2:51:16 PM
+**Generated**: 2026-07-01 7:34:56 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -259,6 +259,6 @@ A cluster that is consistently declined or inaccurate, or whose cost-per-accepte
 
 ---
 
-*Generated from database: 2026-06-30*
+*Generated from database: 2026-07-01*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-06-30T18:51:16.835Z -->
-<!-- git_commit: 1039ba83 -->
-<!-- db_snapshot_hash: a46d688d59366c69 -->
-<!-- file_content_hash: 659df43e2819773e -->
+<!-- generated_at: 2026-07-01T23:34:55.992Z -->
+<!-- git_commit: fe3bbdc1 -->
+<!-- db_snapshot_hash: d38407bccd2a4670 -->
+<!-- file_content_hash: 0f31ef790ab90cca -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,123 +1,123 @@
 {
-  "generated_at": "2026-06-30T18:51:16.835Z",
-  "git_commit": "1039ba83",
-  "db_snapshot_hash": "a46d688d59366c69",
+  "generated_at": "2026-07-01T23:34:55.992Z",
+  "git_commit": "fe3bbdc1",
+  "db_snapshot_hash": "d38407bccd2a4670",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19368,
       "estimated_tokens": 4842,
-      "content_hash": "56f99db3b204174d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE.md"
+      "content_hash": "8e0f584affac240d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 86703,
       "estimated_tokens": 21676,
-      "content_hash": "d5865159254ff5c3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_CORE.md"
+      "content_hash": "2cd6c5c1af462ee4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65401,
       "estimated_tokens": 16351,
-      "content_hash": "2d98c089db950a94",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_LEAD.md"
+      "content_hash": "ac9a92809a886705",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 91103,
       "estimated_tokens": 22776,
-      "content_hash": "afcfa804e0e5b105",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_PLAN.md"
+      "content_hash": "aaf61e87dab472bc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 86566,
       "estimated_tokens": 21642,
-      "content_hash": "02acfe9bc66d110a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_EXEC.md"
+      "content_hash": "32638a1e465c9e16",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 52663,
-      "estimated_tokens": 13166,
-      "content_hash": "5ddad31ffd41e740",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_ADAM.md"
+      "chars": 52999,
+      "estimated_tokens": 13250,
+      "content_hash": "90f871da57fe32dd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
       "chars": 20929,
       "estimated_tokens": 5233,
-      "content_hash": "abe46b199def7c4e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_COORDINATOR.md"
+      "content_hash": "81fa7d0534df7438",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
       "chars": 44108,
       "estimated_tokens": 11027,
-      "content_hash": "a996742d42000830",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_SOLOMON.md"
+      "content_hash": "9a021faeae58e94f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "9e0f443312630eef",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_DIGEST.md"
+      "content_hash": "7bfd9905f2d2f723",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11664,
       "estimated_tokens": 2916,
-      "content_hash": "9ba34b3b6e653481",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "4a8fa586a27e5d03",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5551,
       "estimated_tokens": 1388,
-      "content_hash": "a94bcad08a210c31",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "11cde85b19a1c17c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8541,
       "estimated_tokens": 2136,
-      "content_hash": "50e7bbc4f31dffa9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "661b6905ee197026",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10964,
       "estimated_tokens": 2741,
-      "content_hash": "d401174299477d6f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "0d200c103e8e0b47",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 12320,
       "estimated_tokens": 3080,
-      "content_hash": "c103909cf18986a2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "00bbab1cb26915b6",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 5270,
       "estimated_tokens": 1318,
-      "content_hash": "d8138f72f8053a0f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "8be2af36d85882e3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
       "chars": 3951,
       "estimated_tokens": 988,
-      "content_hash": "64a1ae472fb5b5fa",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-SOLOMON-CONSULT-001E-B\\CLAUDE_SOLOMON_DIGEST.md"
+      "content_hash": "f4440c4100692f46",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "a277118e3d04d5b3",
+    "global": "b7d95fe4ec1fa07d",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -371,7 +371,7 @@
       "596": "0251044882a17550",
       "597": "ca5efc991922f3b8",
       "599": "7ddd3e2178799aa8",
-      "601": "280e0a6b3f84e430",
+      "601": "a405cbac19ca1d0e",
       "602": "ad0aecae8cdc6cb3",
       "603": "ea1eddc2cef94c83",
       "604": "a35e66b64599f81d",
@@ -382,7 +382,8 @@
       "609": "9790a74a362ff0ca",
       "610": "fb3813fc42f32f3a",
       "611": "8807ed27ea29e908",
-      "612": "13e03eddf5300bcc"
+      "612": "13e03eddf5300bcc",
+      "613": "1e1de64689c1ad82"
     },
     "meta": {
       "94": {
@@ -1704,6 +1705,11 @@
         "section_type": "signaling_friction",
         "target_file": "CLAUDE_CORE.md",
         "title": "Solomon Consultation Protocol"
+      },
+      "613": {
+        "section_type": "governance",
+        "target_file": "docs/protocol/adkar-change-adoption-framework.md",
+        "title": "ADKAR Change-Adoption Framework"
       }
     }
   }

--- a/docs/protocol/fleet-coordinator-and-worker-behavior.md
+++ b/docs/protocol/fleet-coordinator-and-worker-behavior.md
@@ -157,7 +157,7 @@ There is a SEPARATE failure mode (feedback `34113d39`, `category='harness_backlo
 | Chairman email (post-cutover 2026-06-10: Adam exec-summary, NOT the retired coordinator email) | `.github/workflows/adam-exec-email-cron.yml` → `scripts/adam-exec-summary.mjs` |
 | Recurring 3-source audit | `scripts/coordinator-audit.mjs` |
 | Capacity forecasting + predictive belt refill (duty 5) | `scripts/coordinator-capacity-forecast.mjs` (armed cron `3,13,…`, `--dispatch`) |
-| Backlog prioritization + dispatch ordering (duty 6) | `scripts/coordinator-backlog-rank.mjs` (armed cron `6,21,…`) → `metadata.dispatch_rank`, honored by `scripts/worker-checkin.cjs` `sortByDispatchRank` |
+| Backlog prioritization + dispatch ordering (duty 6) | `scripts/coordinator-backlog-rank.mjs` (armed cron `9,24,39,54 * * * *`, ~15min) → `metadata.dispatch_rank`, honored by `scripts/worker-checkin.cjs` `sortByDispatchRank`. Event-driven refresh (SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C) also fires on SD creation, `needs_coordinator_review` clearance (`lib/coordinator/clear-coordinator-review.js` / `scripts/clear-coordinator-review.mjs`), and predecessor SD completion, via `lib/coordinator/trigger-rank-pass.mjs` — so a freshly-claimable SD is ranked within seconds instead of waiting for the next cron tick |
 | Question→operator escalation (durable row; rendered by the Adam exec email / operator conversation) | `scripts/coordinator-escalate-question.mjs` (writes `operator_question` row) |
 | Teardown ordering / flag | `lib/coordinator/teardown-coordinator.cjs` (`COORD_TEARDOWN_SAFETY_V2`) |
 


### PR DESCRIPTION
## Summary
Post-completion documentation for SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-C (already merged via #5339).
- `docs/protocol/fleet-coordinator-and-worker-behavior.md`: note the new event-driven rank-pass trigger (SD creation, review clearance, predecessor completion) alongside the existing 15-min cron, and correct the cron cadence to its current schedule.
- `leo_protocol_sections` id=601 (Adam role contract): document the new `clear-coordinator-review` CLI path, closing a gap where the HOLD MECHANIC was documented but no callable clear path existed.
- Regenerated `CLAUDE*.md` files from the updated DB section.

## Test plan
- [x] `node scripts/generate-claude-md-from-db.js` ran clean, all 16 files regenerated
- [x] `grep clear-coordinator-review CLAUDE_ADAM.md` confirms the new content landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)