### PR TITLE
fix(SD-LEO-FIX-LEO-CREATE-ROUTE-001): honor --security-reviewed on the --from-qf escalation route

### DIFF
--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-05-06T02:21:56.375Z"
+  "last_scan": "2026-07-01T23:16:44.644Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001",
-  "createdAt": "2026-07-01T11:15:34.967Z",
+  "sdKey": "SD-LEO-FIX-LEO-CREATE-ROUTE-001",
+  "expectedBranch": "feat/SD-LEO-FIX-LEO-CREATE-ROUTE-001",
+  "createdAt": "2026-07-01T23:12:29.140Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -682,7 +682,7 @@ async function createFromRoadmapItem(itemId, options = {}) {
  * Mirrors createFromFeedback contract; updates the source quick_fixes row with
  * status='escalated' + escalated_to_sd_id so the queue stops recommending it.
  */
-async function createFromQF(qfId) {
+async function createFromQF(qfId, opts = {}) {
   console.log(`\n📋 Creating SD from quick-fix: ${qfId}`);
 
   if (!qfId) {
@@ -734,7 +734,8 @@ async function createFromQF(qfId) {
       qf_type: qf.type,
       qf_severity: qf.severity,
       qf_estimated_loc: qf.estimated_loc,
-      qf_target_application: qf.target_application
+      qf_target_application: qf.target_application,
+      ...(opts.securityReviewed ? { security_reviewed: true } : {})
     }
   });
 
@@ -2891,7 +2892,12 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         targetRepos: riTargetReposIdx !== -1 ? parseTargetReposArg(args[riTargetReposIdx + 1]) : null,
       });
     } else if (args[0] === '--from-qf') {
-      await createFromQF(args[1]);
+      // QF-20260701-833 follow-up: honor --security-reviewed on this route too (was
+      // previously silently ignored here, unlike --from-feedback/--from-roadmap-item/
+      // --child/--from-proposal), so a QF whose DESCRIPTION merely mentions security-
+      // adjacent keywords (e.g. "CI DB secrets") isn't unescapably blocked by
+      // GR-SECURITY-BASELINE when the actual code change touches no security-sensitive scope.
+      await createFromQF(args[1], { securityReviewed: args.includes('--security-reviewed') });
     } else if (args[0] === '--from-proposal') {
       // SD-LEO-INFRA-FROM-PROPOSAL-INGEST-001: materialize PROPOSAL-*.json into DRAFT SDs.
       // path/glob = first non-flag positional after --from-proposal; --dry-run = no writes.

--- a/tests/e2e/story-test-mapping.json
+++ b/tests/e2e/story-test-mapping.json
@@ -79,10 +79,10 @@
     }
   ],
   "statistics": {
-    "totalTestFiles": 36,
+    "totalTestFiles": 63,
     "mappedFiles": 5,
-    "unmappedFiles": 31,
-    "coveragePercentage": 13.9,
-    "lastValidated": "2025-12-22T05:18:28.636Z"
+    "unmappedFiles": 58,
+    "coveragePercentage": 7.9,
+    "lastValidated": "2026-07-01T23:25:39.880Z"
   }
 }

--- a/tests/unit/harness/leo-create-flags-parity.test.js
+++ b/tests/unit/harness/leo-create-flags-parity.test.js
@@ -51,6 +51,28 @@ describe('QF-20260509-LEO-CREATE-FLAGS: review flags sibling parity across creat
     });
   });
 
+  describe('--from-qf path (SD-LEO-FIX-LEO-CREATE-ROUTE-001)', () => {
+    it('createFromQF accepts an opts param and destructures securityReviewed', () => {
+      const idx = src.indexOf('async function createFromQF');
+      expect(idx).toBeGreaterThan(0);
+      const header = src.slice(idx, idx + 100);
+      expect(header).toMatch(/async function createFromQF\(qfId,\s*opts\s*=\s*\{\}\)/);
+    });
+
+    it('createFromQF metadata propagates security_reviewed=true when the flag is set', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const body = src.slice(idx, idx + 3000);
+      expect(body).toMatch(/opts\.securityReviewed\s*\?\s*\{\s*security_reviewed:\s*true\s*\}/);
+    });
+
+    it('CLI passes args.includes(--security-reviewed) to createFromQF', () => {
+      const idx = src.indexOf("args[0] === '--from-qf'");
+      expect(idx).toBeGreaterThan(0);
+      const block = src.slice(idx, idx + 900);
+      expect(block).toMatch(/await createFromQF\(args\[1\],\s*\{\s*securityReviewed:\s*args\.includes\(['"]--security-reviewed['"]\)\s*\}\)/);
+    });
+  });
+
   describe('direct-args mode', () => {
     it('knownDirectFlags Set includes --migration-reviewed / --security-reviewed / --yes / -y', () => {
       const idx = src.indexOf('const knownDirectFlags = new Set');


### PR DESCRIPTION
## Summary
- `createFromQF()` (scripts/leo-create-sd.js's QF-to-SD Tier 3 escalation route) never accepted a `securityReviewed` override, unlike `--from-feedback`/`--from-roadmap-item`/`--child`/`--from-proposal`, all of which honor `--security-reviewed` to satisfy the GR-SECURITY-BASELINE guardrail.
- A QF whose DESCRIPTION merely mentions security-adjacent keywords (e.g. "CI DB secrets" in a root-cause narrative) trips the guardrail even when the actual code change touches no security-sensitive scope, and `--from-qf` had no escape hatch. Discovered while escalating QF-20260701-833 (a pure CI-comparator test-infra fix) to SD-LEO-FIX-COVERAGE-BASELINE-REGRESSION-001.
- Mirrors the exact `--from-feedback` pattern already proven in the same file: `createFromQF(qfId, opts = {})` destructures `opts.securityReviewed` and spreads `{ security_reviewed: true }` into the SD metadata only when truthy; the CLI's `--from-qf` branch now passes `{ securityReviewed: args.includes('--security-reviewed') }`.
- Adds a `--from-qf path` block to the existing sibling-parity harness test (`tests/unit/harness/leo-create-flags-parity.test.js`, QF-20260509-LEO-CREATE-FLAGS), following that file's own source-inspection assertion style.

## Test plan
- [x] `npx vitest run tests/unit/harness/leo-create-flags-parity.test.js` — 10/10 pass (7 pre-existing + 3 new)
- [x] `node -c scripts/leo-create-sd.js` — syntax valid
- [x] `node scripts/leo-create-sd.js --help` — CLI entrypoint unaffected
- [x] Live-verified: successfully escalated a second real QF (QF-20260701-409) using `--from-qf --security-reviewed` after this fix landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)