### PR TITLE
feat(SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B): reconcile + anti-slip + chairman stall-alert + role-contract wiring

### DIFF
--- a/lib/adam/stall-alert.js
+++ b/lib/adam/stall-alert.js
@@ -1,0 +1,67 @@
+/**
+ * Adam stall-alert — wires stall-detector.js's genuine-stall classification to the
+ * EXISTING chairman escalation-email channel (lib/chairman/record-pending-decision.mjs).
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-3).
+ *
+ * No new email machinery: this module is pure wiring of a new trigger condition
+ * (genuine stall on a critical-path parent) onto the already-verified
+ * recordPendingDecision -> shouldAutoEscalate -> escalateChairmanDecision channel.
+ * An intended hold never calls recordPendingDecision, so intended/quiet holds
+ * generate zero escalation noise.
+ */
+
+import { classifyStaleness } from './stall-detector.js';
+import { recordPendingDecision } from '../chairman/record-pending-decision.mjs';
+
+/**
+ * Pure: bump (or reset) the ticks-since-movement counter for a node given its current
+ * updated_at and the previous tick's snapshot for that node. No movement recorded yet
+ * (or the timestamp changed) resets the counter to 0; an unchanged timestamp increments it.
+ * @param {{id: string, updated_at?: string}} node
+ * @param {Object<string, {updated_at?: string, ticks?: number}>} prevSnapshot
+ * @returns {number}
+ */
+export function bumpMovementTicks(node, prevSnapshot) {
+  const prev = prevSnapshot && node && prevSnapshot[node.id];
+  if (prev && node.updated_at && prev.updated_at === node.updated_at) {
+    return (prev.ticks || 0) + 1;
+  }
+  return 0;
+}
+
+/**
+ * Check a set of chairman-parent nodes for genuine stalls and alert the chairman via
+ * the existing recordPendingDecision escalation channel. Classification (pure,
+ * stall-detector.js) is kept separate from the IO (recordPendingDecision) — only nodes
+ * classified as a genuine stall ever reach the escalation call.
+ * @param {object} supabase
+ * @param {Array<{id: string, title: string, updated_at?: string, inFlightNextStep?: boolean}>} parents
+ * @param {Object<string, {updated_at?: string, ticks?: number}>} [prevSnapshot]
+ * @param {{staleTicks?: number}} [opts]
+ * @returns {Promise<{snapshot: object, alerted: Array<{id: string, title: string, escalated: boolean}>}>}
+ */
+export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, opts = {}) {
+  const snapshot = {};
+  const alerted = [];
+  for (const node of Array.isArray(parents) ? parents : []) {
+    if (!node || !node.id) continue;
+    const ticks = bumpMovementTicks(node, prevSnapshot);
+    snapshot[node.id] = { updated_at: node.updated_at, ticks };
+
+    const status = classifyStaleness(
+      { ticksSinceMovement: ticks, inFlightNextStep: !!node.inFlightNextStep },
+      opts
+    );
+    if (status !== 'genuine_stall') continue;
+
+    const res = await recordPendingDecision(supabase, {
+      title: `Adam PM stall: ${node.title || node.id}`,
+      decisionType: 'session_question',
+      context: { node_id: node.id, ticks_since_movement: ticks },
+      blocking: true,
+      raisedBy: 'adam',
+    });
+    alerted.push({ id: node.id, title: node.title || node.id, escalated: res.escalated === true });
+  }
+  return { snapshot, alerted };
+}

--- a/lib/adam/stall-detector.js
+++ b/lib/adam/stall-detector.js
@@ -1,0 +1,37 @@
+/**
+ * Adam stall-detector — PURE intended-hold vs genuine-stall classifier.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-2).
+ *
+ * Distinguishes an INTENDED HOLD (a known next-step is itself progressing — e.g. a
+ * dependency SD still in_progress, or a coordinator daemon-reswap in flight) from a
+ * genuine STALL (the thing that should move is not moving AND no self-unblock path
+ * exists), per the chairman's locked anti-slip scope (adam_stall_alert): alert ONLY on
+ * genuine stall, never on every quiet/hold period — noise is the failure mode this
+ * guards against. Age/stall-detection ONLY (v1_BUILD) — no rigid ETAs/Gantt.
+ *
+ * Pure: no DB/network I/O, so it is independently unit-testable without a live client.
+ */
+
+/** Ticks of no movement before a node is even considered for stall/hold classification. */
+export const DEFAULT_STALE_TICKS = 8;
+
+/**
+ * Classify a chairman-parent node's staleness.
+ * @param {{ticksSinceMovement?: number, inFlightNextStep?: boolean}} node
+ * @param {{staleTicks?: number}} [opts]
+ * @returns {'fresh'|'intended_hold'|'genuine_stall'}
+ */
+export function classifyStaleness(node, { staleTicks = DEFAULT_STALE_TICKS } = {}) {
+  const ticks = Number(node && node.ticksSinceMovement) || 0;
+  if (ticks < staleTicks) return 'fresh';
+  return node && node.inFlightNextStep ? 'intended_hold' : 'genuine_stall';
+}
+
+/**
+ * @param {{ticksSinceMovement?: number, inFlightNextStep?: boolean}} node
+ * @param {{staleTicks?: number}} [opts]
+ * @returns {boolean}
+ */
+export function isGenuineStall(node, opts) {
+  return classifyStaleness(node, opts) === 'genuine_stall';
+}

--- a/scripts/adam-pm-board.mjs
+++ b/scripts/adam-pm-board.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * adam-pm-board.mjs — the chairman-curated PM board view.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-4).
+ *
+ * LIGHT chairman-curated view (per the chairman's locked adam_v1_scope_LOCKED): parents +
+ * rolled-up status (task-ledger.js rollupParentStatus) + bubbled blockers (bubbleBlockers)
+ * + a one-line benefit/risk per parent + a coarse token-cost rollup (sumTokenCost).
+ * Modeled on scripts/fleet-dashboard.cjs's modular CLI-panel pattern. No per-subtask cost
+ * attribution, no formal probability x impact risk scoring (v2_DEFERRED).
+ *
+ * Usage: node scripts/adam-pm-board.mjs [--json]
+ */
+import { createRequire } from 'node:module';
+import 'dotenv/config';
+import { TABLE, rollupParentStatus, bubbleBlockers, sumTokenCost } from '../lib/adam/task-ledger.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+const require = createRequire(import.meta.url);
+const { createClient } = require('@supabase/supabase-js');
+
+function makeClient() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+  return createClient(url, key);
+}
+
+/**
+ * Group a flat list of ledger rows into { parent, children[] } pairs.
+ * @param {Array<object>} rows
+ * @returns {Array<{parent: object, children: object[]}>}
+ */
+export function groupByParent(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const parents = list.filter((r) => r.tier === 'parent');
+  return parents.map((parent) => ({
+    parent,
+    children: list.filter((r) => r.tier === 'child' && r.parent_id === parent.id),
+  }));
+}
+
+/**
+ * Build the curated board view from a flat list of adam_task_ledger rows. PURE — no I/O — so
+ * it is unit-testable against a fixture without a live client.
+ * @param {Array<object>} rows
+ * @returns {{ panels: Array<{id, title, status, benefit, risk, blockers, tokenCost}>, totalTokenCost: number }}
+ */
+export function buildBoardView(rows) {
+  const groups = groupByParent(rows);
+  const panels = groups.map(({ parent, children }) => ({
+    id: parent.id,
+    title: parent.title,
+    status: rollupParentStatus(children),
+    benefit: parent.benefit || null,
+    risk: parent.risk || null,
+    blockers: bubbleBlockers(children),
+    tokenCost: sumTokenCost(children),
+  }));
+  return { panels, totalTokenCost: panels.reduce((sum, p) => sum + (p.tokenCost || 0), 0) };
+}
+
+function renderPanel(p) {
+  const lines = [`  [${p.status.toUpperCase()}] ${p.title}`];
+  if (p.benefit) lines.push(`    benefit: ${p.benefit}`);
+  if (p.risk) lines.push(`    risk: ${p.risk}`);
+  for (const b of p.blockers) lines.push(`    blocked: ${b.title || b.id} — ${b.blocker}`);
+  lines.push(`    token cost: ${p.tokenCost}`);
+  return lines.join('\n');
+}
+
+async function fetchLedgerRows(sb) {
+  const { data, error } = await sb.from(TABLE).select('*');
+  if (error) throw new Error(error.message);
+  return Array.isArray(data) ? data : [];
+}
+
+async function main() {
+  const asJson = process.argv.includes('--json');
+  const sb = makeClient();
+
+  let rows = [];
+  let fetchError = null;
+  try {
+    rows = await fetchLedgerRows(sb);
+  } catch (e) {
+    fetchError = e && e.message ? e.message : String(e);
+  }
+
+  const view = buildBoardView(rows);
+
+  if (asJson) {
+    console.log(JSON.stringify({ ...view, error: fetchError }));
+    return;
+  }
+
+  console.log('═══ ADAM PM BOARD (chairman-curated) ═══');
+  if (fetchError) {
+    console.log(`  (unavailable: ${fetchError})`);
+  } else if (view.panels.length === 0) {
+    console.log('  (no parent nodes on the board)');
+  } else {
+    for (const p of view.panels) console.log(renderPanel(p));
+    console.log(`  ─── total token cost: ${view.totalTokenCost} ───`);
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  main().then(() => process.exit(0)).catch((e) => {
+    console.error('ADAM_PM_BOARD_ERROR', e && e.message ? e.message : e);
+    process.exit(1);
+  });
+}

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -22,6 +22,8 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
 import 'dotenv/config';
+import { rehydrateBoard } from '../lib/adam/task-rehydrate.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
 const { createClient } = require('@supabase/supabase-js');
@@ -71,6 +73,19 @@ function scriptCore(key, args, { skip = false } = {}) {
   };
 }
 
+// FR-1 (Child B): board<->reality RECONCILE on every tick, not only at /adam cold start
+// (scripts/adam-startup-check.mjs's renderBoardRehydrate() calls rehydrateBoard() once, on cold
+// start only). Reuses Child A's rehydrateBoard() as-is — no new upsert logic. rehydrateBoard()
+// is already fail-soft per source internally; this wrapper adds an outer fail-soft layer so a
+// synchronous throw (e.g. a malformed client) never aborts the tick.
+export async function reconcileBoard(sb) {
+  try {
+    return await rehydrateBoard(sb);
+  } catch (e) {
+    return { threads: 0, parents: 0, sds: 0, awaited: 0, errors: [`reconcile failed: ${e && e.message}`] };
+  }
+}
+
 async function readSalientState(sb) {
   const state = { beltZero: true, openSignalCount: 0, venture1State: null };
   try {
@@ -110,6 +125,9 @@ async function main() {
   // is delta-gated below, so only the inbox core needs composing here.
   const tick = await runCoresFailSoft(buildCores());
 
+  // Child B FR-1: reconcile the durable task board against live reality every tick.
+  const boardReconcile = await reconcileBoard(sb);
+
   // FR-4: belt-countdown + offer-help collapse to a salient-delta check — Adam only
   // reaches the coordinator on a real belt/venture delta, never a "still idle" status.
   const salient = await readSalientState(sb);
@@ -124,6 +142,7 @@ async function main() {
     modeReason,
     cores: tick.summary,
     failedCount: tick.failedCount,
+    boardReconcile,
     crossPartyPing: delta.changed,
     pingFields: delta.fields,
     nextWakeSeconds: delaySeconds,
@@ -135,6 +154,7 @@ async function main() {
     console.log(
       `QUIET_TICK=adam mode=${result.mode} cores=[${tick.summary}] ` +
       `fail=${tick.failedCount} ` +
+      `reconcile=parents:${boardReconcile.parents},errors:${boardReconcile.errors.length} ` +
       `ping=${delta.changed ? delta.fields.join(',') : 'suppressed'} ` +
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
@@ -145,7 +165,14 @@ async function main() {
   return result;
 }
 
-main().then(() => process.exit(0)).catch((e) => {
-  console.error('QUIET_TICK_ERROR=adam', e && e.message ? e.message : e);
-  process.exit(1);
-});
+// SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-1): main() previously
+// ran unconditionally at import time (no entry-point guard) — importing this module for its exports
+// (reconcileBoard, buildCores, COMPOSED_CORES) would trigger a full tick execution, including a real
+// subprocess spawn and process.exit(0), corrupting any importer/test. Guarded to match the established
+// pattern (lib/utils/is-main-module.js) already used by sibling scripts.
+if (isMainModule(import.meta.url)) {
+  main().then(() => process.exit(0)).catch((e) => {
+    console.error('QUIET_TICK_ERROR=adam', e && e.message ? e.message : e);
+    process.exit(1);
+  });
+}

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -37,6 +37,7 @@ export const RESPONSIBILITIES = [
   'Daily deep governance-scan (one scope per tick, weighted round-robin); gated on ADAM_GOVERNANCE_HEARTBEAT_V1.',
   'Drain coordinator replies/reminders (the inbox); offer the coordinator concise analysis when it helps.',
   'Recurring SELF-adherence audit: probe own role-contract duties, ledger findings, source propose-only remediation on drift (never build — CONST-002).',
+  'Reconcile the durable PM board against live reality every tick; alert the chairman ONLY on a genuine critical-path stall (never on an intended hold) via the verified escalation-email channel.',
 ];
 
 // Adam's recurring tick. Each loop is one CronCreate spec the /adam agent arms idempotently.
@@ -114,6 +115,17 @@ export const ADAM_LOOPS = [
     script: 'adam-github-assessment.mjs',
     cron: '30 9 */3 * *',
     prompt: 'node scripts/adam-github-assessment.mjs',
+  },
+  {
+    // SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-1+FR-5): the
+    // contract-named BOARD RECONCILE DUTY. Reconciles the durable task ledger against live reality
+    // every recurring tick (scripts/adam-quiet-tick.mjs's reconcileBoard()), not only at /adam cold
+    // start — closing the same "durable but session-fragile" gap the belt-countdown duty closed.
+    key: 'board-reconcile',
+    label: 'Board<->reality reconcile every tick (adam_task_ledger via rehydrateBoard)',
+    script: 'adam-quiet-tick.mjs',
+    cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *',
+    prompt: 'node scripts/adam-quiet-tick.mjs',
   },
 ];
 

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -21,12 +21,13 @@ import {
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('ADAM_LOOPS has the 7 expected tick loops with the expected keys', () => {
+test('ADAM_LOOPS has the 8 expected tick loops with the expected keys', () => {
   // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
   // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty);
-  // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties).
-  assert.equal(ADAM_LOOPS.length, 7);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown', 'doc-drift', 'github-assessment']);
+  // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties);
+  // board-reconcile added by SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (durable contract duty).
+  assert.equal(ADAM_LOOPS.length, 8);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);
@@ -129,16 +130,16 @@ test('loopStatus: armed on key, prompt or script match, MISSING when provided-bu
   assert.equal(loopStatus(offer, { provided: true, set: new Set([offer.prompt]) }), 'armed');
 });
 
-test('end-to-end CSV verdict: --armed with all 7 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
+test('end-to-end CSV verdict: --armed with all 8 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
   const armed = parseArmedSet(['--armed', ADAM_LOOPS.map((l) => l.key).join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 7 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 8 Adam tick loops armed\. Nothing to arm\./);
   assert.doesNotMatch(out, /MISSING/);
 });
 
 test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent note)', () => {
   const out = renderLoops(parseArmedSet([], {}));
-  assert.match(out, /ADAM RECURRING TICK \(7 loops\)/);
+  assert.match(out, /ADAM RECURRING TICK \(8 loops\)/);
   assert.match(out, /CronCreate\(\{ cron: "0 13 \* \* \*"/); // governance-scan spec emitted
   assert.match(out, /idempotent/i);
 });
@@ -146,7 +147,7 @@ test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent
 test('renderLoops reports "Nothing to arm" when all loops are in the armed set', () => {
   const armedSet = new Set(ADAM_LOOPS.map((l) => l.prompt));
   const out = renderLoops({ provided: true, set: armedSet });
-  assert.match(out, /All 7 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 8 Adam tick loops armed\. Nothing to arm\./);
 });
 
 test('renderResponsibilities is fail-open (bad repoRoot → fallback, never throws)', () => {

--- a/tests/unit/adam/adam-pm-board.test.js
+++ b/tests/unit/adam/adam-pm-board.test.js
@@ -1,0 +1,61 @@
+/**
+ * Unit pins for the chairman-curated PM board view's pure fixture-to-panel logic.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-4).
+ */
+import { describe, it, expect } from 'vitest';
+import { groupByParent, buildBoardView } from '../../../scripts/adam-pm-board.mjs';
+
+function fixtureRows() {
+  return [
+    { id: 'parent-1', tier: 'parent', title: 'Run#5 -> candidate#2', benefit: 'unblocks next venture cycle', risk: 'daemon reswap flaky', status: 'in_progress' },
+    { id: 'child-1', tier: 'child', parent_id: 'parent-1', title: 'get-daemon-reswap', status: 'blocked', blocker: 'awaiting coordinator reswap', token_cost: 120 },
+    { id: 'child-2', tier: 'child', parent_id: 'parent-1', title: 'launch-subject', status: 'done', token_cost: 80 },
+    { id: 'parent-2', tier: 'parent', title: 'Adam-sourced SD-X', benefit: 'closes a gap', risk: null, status: 'open' },
+  ];
+}
+
+describe('groupByParent', () => {
+  it('TS-6: groups children under their parent by parent_id', () => {
+    const groups = groupByParent(fixtureRows());
+    expect(groups).toHaveLength(2);
+    const p1 = groups.find((g) => g.parent.id === 'parent-1');
+    expect(p1.children.map((c) => c.id)).toEqual(['child-1', 'child-2']);
+    const p2 = groups.find((g) => g.parent.id === 'parent-2');
+    expect(p2.children).toEqual([]);
+  });
+
+  it('handles an empty/non-array input without throwing', () => {
+    expect(groupByParent([])).toEqual([]);
+    expect(groupByParent(undefined)).toEqual([]);
+  });
+});
+
+describe('buildBoardView', () => {
+  it('TS-6: renders parents with rolled-up status, bubbled blockers, benefit/risk, and token-cost rollup', () => {
+    const view = buildBoardView(fixtureRows());
+    expect(view.panels).toHaveLength(2);
+
+    const p1 = view.panels.find((p) => p.id === 'parent-1');
+    expect(p1.status).toBe('blocked'); // rollupParentStatus: one blocked child -> blocked
+    expect(p1.benefit).toBe('unblocks next venture cycle');
+    expect(p1.risk).toBe('daemon reswap flaky');
+    expect(p1.blockers).toEqual([{ id: 'child-1', title: 'get-daemon-reswap', blocker: 'awaiting coordinator reswap' }]);
+    expect(p1.tokenCost).toBe(200); // sumTokenCost: 120 + 80
+
+    const p2 = view.panels.find((p) => p.id === 'parent-2');
+    expect(p2.status).toBe('open'); // no children -> open
+    expect(p2.blockers).toEqual([]);
+    expect(p2.tokenCost).toBe(0);
+  });
+
+  it('sums total token cost across all parents', () => {
+    const view = buildBoardView(fixtureRows());
+    expect(view.totalTokenCost).toBe(200);
+  });
+
+  it('handles an empty ledger without throwing', () => {
+    const view = buildBoardView([]);
+    expect(view.panels).toEqual([]);
+    expect(view.totalTokenCost).toBe(0);
+  });
+});

--- a/tests/unit/adam/adam-quiet-tick-reconcile.test.js
+++ b/tests/unit/adam/adam-quiet-tick-reconcile.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit pins for Child B FR-1: board<->reality reconcile wired into the recurring
+ * Adam tick (scripts/adam-quiet-tick.mjs's reconcileBoard()), not only at cold start.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B.
+ *
+ * Mocks supabase (no live DB), mirroring tests/unit/adam/task-rehydrate.test.js's stub
+ * pattern, so the reconcile step's actual tick-flow wiring is proven without hitting a
+ * real database or spawning a real subprocess. Importing this module is safe because
+ * adam-quiet-tick.mjs now guards its main() call behind isMainModule() (fixed alongside
+ * this FR — the module previously ran main() unconditionally at import time).
+ */
+import { describe, it, expect } from 'vitest';
+import { reconcileBoard } from '../../../scripts/adam-quiet-tick.mjs';
+
+/** Read builder: chainable no-op filters, thenable to the seeded rows. */
+function readBuilder(data) {
+  const b = {
+    select: () => b, eq: () => b, in: () => b, is: () => b, not: () => b,
+    order: () => b, limit: () => b,
+    then: (resolve, reject) => Promise.resolve({ data, error: null }).then(resolve, reject),
+  };
+  return b;
+}
+
+function makeSupabase({ coordination = [], sds = [] } = {}) {
+  const ledger = [];
+  const keyOf = (r) => `${r.source_kind}|${r.source_ref}`;
+  function from(table) {
+    if (table === 'adam_task_ledger') {
+      return {
+        upsert(row) {
+          return {
+            select() {
+              return {
+                single: async () => {
+                  const existing = ledger.find((r) => keyOf(r) === keyOf(row));
+                  if (existing) { Object.assign(existing, row); return { data: existing, error: null }; }
+                  const created = { id: `id-${ledger.length + 1}`, status: 'open', ...row };
+                  ledger.push(created);
+                  return { data: created, error: null };
+                },
+              };
+            },
+          };
+        },
+      };
+    }
+    if (table === 'session_coordination') return readBuilder(coordination);
+    if (table === 'strategic_directives_v2') return readBuilder(sds);
+    return readBuilder([]);
+  }
+  return { from, _ledger: ledger };
+}
+
+describe('reconcileBoard', () => {
+  it('TS-1: reconciles an open advisory thread into the board, same shape rehydrateBoard() already produces', async () => {
+    const sb = makeSupabase({
+      coordination: [
+        { id: 'sc1', sender_type: 'adam', payload: { correlation_id: 'corr-open', subject: 'Decision needed' } },
+      ],
+    });
+    const result = await reconcileBoard(sb);
+    expect(result.errors).toEqual([]);
+    expect(result.threads).toBe(1);
+    expect(result.parents).toBe(1);
+    expect(sb._ledger).toHaveLength(1);
+    expect(sb._ledger[0]).toMatchObject({ source_kind: 'advisory_thread', source_ref: 'corr-open' });
+  });
+
+  it('is fail-soft: a malformed/missing client never throws, always returns a summary', async () => {
+    const result = await reconcileBoard(null);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.threads).toBe(0);
+  });
+
+  it('is idempotent: running twice against the same source data does not duplicate nodes', async () => {
+    const sb = makeSupabase({
+      coordination: [
+        { id: 'sc1', sender_type: 'adam', payload: { correlation_id: 'corr-open', subject: 'Decision needed' } },
+      ],
+    });
+    await reconcileBoard(sb);
+    await reconcileBoard(sb);
+    expect(sb._ledger).toHaveLength(1);
+  });
+});

--- a/tests/unit/adam/stall-alert.test.js
+++ b/tests/unit/adam/stall-alert.test.js
@@ -1,0 +1,79 @@
+/**
+ * Unit pins for wiring genuine-stall detection to the EXISTING chairman escalation
+ * channel (lib/chairman/record-pending-decision.mjs). SD-LEO-INFRA-UPSCALE-ADAM-
+ * PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-3).
+ *
+ * recordPendingDecision already has its own dedicated test coverage
+ * (tests/unit/chairman/record-pending-decision-escalation.test.js) — this suite tests
+ * ONLY the wiring: does a genuine stall call it with the right args, does an intended
+ * hold correctly NOT call it at all.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { bumpMovementTicks, checkAndAlertStalls } from '../../../lib/adam/stall-alert.js';
+import { DEFAULT_STALE_TICKS } from '../../../lib/adam/stall-detector.js';
+
+vi.mock('../../../lib/chairman/record-pending-decision.mjs', () => ({
+  recordPendingDecision: vi.fn(async () => ({ recorded: true, id: 'dec-1', escalated: true })),
+}));
+import { recordPendingDecision } from '../../../lib/chairman/record-pending-decision.mjs';
+
+beforeEach(() => { recordPendingDecision.mockClear(); });
+
+describe('bumpMovementTicks', () => {
+  it('resets to 0 when updated_at differs from the snapshot (real movement)', () => {
+    const node = { id: 'p1', updated_at: '2026-07-01T12:00:00Z' };
+    const prev = { p1: { updated_at: '2026-07-01T11:00:00Z', ticks: 5 } };
+    expect(bumpMovementTicks(node, prev)).toBe(0);
+  });
+
+  it('increments when updated_at is unchanged (no movement)', () => {
+    const node = { id: 'p1', updated_at: '2026-07-01T11:00:00Z' };
+    const prev = { p1: { updated_at: '2026-07-01T11:00:00Z', ticks: 5 } };
+    expect(bumpMovementTicks(node, prev)).toBe(6);
+  });
+
+  it('starts at 0 for a node with no prior snapshot entry', () => {
+    expect(bumpMovementTicks({ id: 'new', updated_at: 'x' }, {})).toBe(0);
+  });
+});
+
+describe('checkAndAlertStalls', () => {
+  const sb = {}; // never touched directly — recordPendingDecision is mocked
+
+  it('TS-4: a genuine stall on a critical-path parent calls recordPendingDecision(raisedBy:adam, blocking:true)', async () => {
+    const parents = [{ id: 'p1', title: 'Run#5 GO', updated_at: 'fixed', inFlightNextStep: false }];
+    // pre-seed the snapshot so this node is already at the stale threshold
+    const prevSnapshot = { p1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    const call = recordPendingDecision.mock.calls[0][1];
+    expect(call.raisedBy).toBe('adam');
+    expect(call.blocking).toBe(true);
+    expect(alerted).toEqual([{ id: 'p1', title: 'Run#5 GO', escalated: true }]);
+  });
+
+  it('TS-5: an intended hold does NOT call recordPendingDecision — no escalation noise', async () => {
+    const parents = [{ id: 'p2', title: 'Daemon reswap in flight', updated_at: 'fixed', inFlightNextStep: true }];
+    const prevSnapshot = { p2: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('a fresh node (below the stale threshold) does not escalate', async () => {
+    const parents = [{ id: 'p3', title: 'Just started', updated_at: 'x', inFlightNextStep: false }];
+    const { alerted } = await checkAndAlertStalls(sb, parents, {});
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('returns an updated snapshot for every parent processed', async () => {
+    const parents = [{ id: 'p4', title: 'x', updated_at: 'v1', inFlightNextStep: false }];
+    const { snapshot } = await checkAndAlertStalls(sb, parents, {});
+    expect(snapshot.p4).toEqual({ updated_at: 'v1', ticks: 0 });
+  });
+});

--- a/tests/unit/adam/stall-detector.test.js
+++ b/tests/unit/adam/stall-detector.test.js
@@ -1,0 +1,39 @@
+/**
+ * Unit pins for the PURE intended-hold vs genuine-stall classifier.
+ * SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (Child B / FR-2).
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyStaleness, isGenuineStall, DEFAULT_STALE_TICKS } from '../../../lib/adam/stall-detector.js';
+
+describe('classifyStaleness', () => {
+  it('is fresh below the stale-ticks threshold, regardless of in-flight flag', () => {
+    expect(classifyStaleness({ ticksSinceMovement: DEFAULT_STALE_TICKS - 1, inFlightNextStep: false })).toBe('fresh');
+    expect(classifyStaleness({ ticksSinceMovement: 0, inFlightNextStep: true })).toBe('fresh');
+  });
+
+  it('TS-2: N stale ticks + no in-flight next-step -> genuine stall', () => {
+    expect(classifyStaleness({ ticksSinceMovement: DEFAULT_STALE_TICKS, inFlightNextStep: false })).toBe('genuine_stall');
+  });
+
+  it('TS-3: N stale ticks + a known in-flight next-step -> intended hold, NOT a stall', () => {
+    expect(classifyStaleness({ ticksSinceMovement: DEFAULT_STALE_TICKS, inFlightNextStep: true })).toBe('intended_hold');
+  });
+
+  it('respects a custom staleTicks threshold', () => {
+    expect(classifyStaleness({ ticksSinceMovement: 3, inFlightNextStep: false }, { staleTicks: 3 })).toBe('genuine_stall');
+    expect(classifyStaleness({ ticksSinceMovement: 2, inFlightNextStep: false }, { staleTicks: 3 })).toBe('fresh');
+  });
+
+  it('handles missing/undefined fields without throwing', () => {
+    expect(classifyStaleness({})).toBe('fresh');
+    expect(classifyStaleness(undefined)).toBe('fresh');
+  });
+});
+
+describe('isGenuineStall', () => {
+  it('is true only for the genuine_stall classification', () => {
+    expect(isGenuineStall({ ticksSinceMovement: DEFAULT_STALE_TICKS, inFlightNextStep: false })).toBe(true);
+    expect(isGenuineStall({ ticksSinceMovement: DEFAULT_STALE_TICKS, inFlightNextStep: true })).toBe(false);
+    expect(isGenuineStall({ ticksSinceMovement: 0 })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Child B of the Adam PM-discipline orchestrator (depends on Child A's `adam_task_ledger` foundation, already merged and now chairman-applied/live):
- **FR-1**: `reconcileBoard()` wires Child A's `rehydrateBoard()` into the recurring Adam tick (`adam-quiet-tick.mjs`), not only at `/adam` cold start.
- **FR-2**: `lib/adam/stall-detector.js` — pure intended-hold vs genuine-stall classifier.
- **FR-3**: `lib/adam/stall-alert.js` wires a genuine stall on a critical-path parent to the existing `recordPendingDecision`/`shouldAutoEscalate` escalation-email channel; an intended hold never escalates (no new email machinery).
- **FR-4**: `scripts/adam-pm-board.mjs` — the chairman-curated view (rolled-up status, bubbled blockers, one-line benefit/risk, coarse token-cost rollup), modeled on `fleet-dashboard.cjs`'s modular pattern.
- **FR-5**: a new `ADAM_LOOPS` entry (`board-reconcile`) + a matching `CLAUDE_ADAM.md` durable-duty marker land atomically in this PR, verified by the existing `missingDurableDuties()` CI guard (stays green, 0 missing).

Also fixes a pre-existing gap surfaced while testing FR-1: `adam-quiet-tick.mjs` ran `main()` unconditionally at import time (no entry-point guard) — importing it for `reconcileBoard` would have spawned a real subprocess and called `process.exit(0)`, corrupting any importer/test. Added the standard `isMainModule()` guard already used by sibling scripts (`adam-pm-board.mjs`, `gauge-unranked-claimable-leaves.mjs`).

**LOC note**: ~263 production LOC across 5 files, ~282 test LOC. Exceeds the ≤100 LOC target; justified per CLAUDE.md's tiered guidance — the PRD's own FR-5 acceptance criterion requires the loop-registry entry and role-contract marker to land atomically (enforced by `missingDurableDuties()`), and FR-1/FR-2/FR-3 are a tightly-coupled reconcile→classify→escalate chain from one chairman-approved locked scope (`adam_v1_scope_LOCKED`/`adam_stall_alert`). Splitting would either break the atomicity guard or add pure process overhead with no review-quality benefit.

## Test plan
- [x] 21 new unit tests across 4 files (stall-detector, stall-alert, adam-pm-board, adam-quiet-tick-reconcile) — all passing via `npx vitest run`
- [x] `tests/unit/adam-startup-check.test.mjs` (16 tests, `node --test`) — updated 3 hardcoded loop-count pins (7→8), all green, `missingDurableDuties()` reports 0 missing
- [x] Full regression sweep: `tests/unit/adam/`, `tests/unit/chairman/`, `tests/unit/governance/` — 428+234 tests, all green
- [x] `npx eslint` on all touched files — clean
- [x] Manually ran `node scripts/adam-quiet-tick.mjs --dry-run --json` against the live (now chairman-applied) `adam_task_ledger` table — reconcile executed correctly, idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)