### PR TITLE
fix(SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-A): additive-only vision section writes close the clobber race

### DIFF
--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -778,6 +778,38 @@ function deriveContent(artifactData) {
 
 // ── EVA Eager Synthesis ──
 
+// SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-A: a standard section counts as
+// "substantive" once it clears the SAME 50-char floor trg_auto_validate_vision_quality uses to flag
+// stub sections (database/migrations/20260314_quality_validation_vision_docs.sql) — reusing the
+// gate's own threshold keeps this merge and that trigger's section_coverage count in agreement.
+const SUBSTANTIVE_SECTION_MIN_CHARS = 50;
+
+/**
+ * Merge freshly-synthesized sections into the existing sections JSONB, additively. An existing
+ * key with a substantive (>=50 char) value is NEVER overwritten — eager-synthesis re-fires on every
+ * artifact write and previously produced only ~3/10 standard keys from a sparse source, so a naive
+ * wholesale replace clobbers any section a prior repair pass (or a richer artifact set) had filled
+ * in. A missing or stub (<50 char) key IS replaced/filled from the new synthesis, so coverage still
+ * improves over time — this only prevents regression, it doesn't cap growth.
+ *
+ * @param {Record<string, string>|null} existingSections
+ * @param {Record<string, string>|null} newSections
+ * @returns {Record<string, string>|null}
+ */
+export function mergeVisionSections(existingSections, newSections) {
+  const existing = existingSections && typeof existingSections === 'object' ? existingSections : {};
+  const incoming = newSections && typeof newSections === 'object' ? newSections : {};
+  const merged = { ...existing };
+  for (const [key, value] of Object.entries(incoming)) {
+    const existingValue = existing[key];
+    const existingIsSubstantive = typeof existingValue === 'string' && existingValue.length >= SUBSTANTIVE_SECTION_MIN_CHARS;
+    if (!existingIsSubstantive) {
+      merged[key] = value;
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : null;
+}
+
 /**
  * Upsert eva_vision_documents by synthesizing content from all linked artifacts.
  * Fetches all current artifacts with matching supports_vision_key, synthesizes
@@ -799,7 +831,7 @@ export async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureI
 
   const { data: existing } = await supabase
     .from('eva_vision_documents')
-    .select('id, version, addendums, extracted_dimensions, status, chairman_approved')
+    .select('id, version, addendums, extracted_dimensions, status, chairman_approved, sections')
     .eq('vision_key', visionKey)
     .single();
 
@@ -814,6 +846,13 @@ export async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureI
   if (existing && existing.status === 'active' && existing.chairman_approved === true) {
     return;
   }
+  // FR-2 decision record (SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-A): this
+  // freeze is intentionally LEFT AS-IS rather than widened to also cover a repaired-but-unpromoted
+  // (quality_checked=true, still draft) vision. FR-1's mergeVisionSections makes the write below
+  // additive, so a repair-then-resynthesize on a not-yet-promoted vision is now a safe no-op on
+  // every already-substantive section regardless of freeze state — widening the freeze would be
+  // redundant defense, not a required fix. The freeze's actual job (skip active+approved ticks
+  // entirely, including the addendum-growth avoidance) is unrelated to the clobber race and stays.
 
   // SD-LEO-INFRA-EAGER-SYNTHESIS-VISION-DIMS-EXTRACT-001: populate sections (deterministic, always)
   // and extracted_dimensions (LLM, extract-once + fail-soft) so the vision passes the active-rich
@@ -849,11 +888,16 @@ export async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureI
       evidence_count: artifacts.length,
       timestamp: new Date().toISOString(),
     });
+    // FR-1 (SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-A): merge, don't
+    // overwrite. A raw `sections` replace clobbers any standard key a prior repair/richer artifact
+    // pass had already filled — mergeVisionSections keeps every existing substantive (>=50 char)
+    // section and only fills genuinely missing/stub ones from this tick's synthesis.
+    const mergedSections = sections ? mergeVisionSections(existing.sections, sections) : existing.sections;
     const { error: updateError } = await supabase.from('eva_vision_documents').update({
       content: synthesized,
       version: newVersion,
       addendums,
-      ...(sections ? { sections } : {}),
+      ...(mergedSections ? { sections: mergedSections } : {}),
       // Only write dims when we newly extracted them (existing lacked them); never clobber with null.
       ...(extractedDimensions ? { extracted_dimensions: extractedDimensions } : {}),
       updated_at: new Date().toISOString(),

--- a/tests/unit/eva/eager-synthesis-vision-dims.test.js
+++ b/tests/unit/eva/eager-synthesis-vision-dims.test.js
@@ -18,6 +18,7 @@ vi.mock('../../../lib/eva/vision-dimensions-extractor.js', () => ({
 import {
   upsertEvaVisionFromArtifacts,
   synthesizeFromArtifacts,
+  mergeVisionSections,
 } from '../../../lib/eva/artifact-persistence-service.js';
 import { extractDimensions, MAX_LLM_CONTENT_CHARS } from '../../../lib/eva/vision-dimensions-extractor.js';
 
@@ -129,5 +130,71 @@ describe('SD-LEO-INFRA-S19-HELD-STATE-NOT-IDEMPOTENT-CLOBBER-001: idempotency gu
     const u = makeSupabase({ id: 'x', version: 3, addendums: [], extracted_dimensions: DIMS, status: 'active', chairman_approved: false });
     await upsertEvaVisionFromArtifacts(u.client, 'VISION-TEST-L2-001', 'v-1', 17);
     expect(u.updates).toHaveLength(1);   // active+UNapproved is not yet the frozen final state
+  });
+});
+
+describe('mergeVisionSections (pure function)', () => {
+  it('keeps an existing substantive (>=50 char) section untouched even when new synthesis offers a different value for the same key', () => {
+    const existing = { problem_statement: 'A'.repeat(200) };
+    const incoming = { problem_statement: 'a much shorter replacement that would be a regression' };
+    const merged = mergeVisionSections(existing, incoming);
+    expect(merged.problem_statement).toBe(existing.problem_statement);
+  });
+
+  it('fills a genuinely missing key from the new synthesis', () => {
+    const existing = { problem_statement: 'A'.repeat(200) };
+    const incoming = { personas: 'B'.repeat(200) };
+    const merged = mergeVisionSections(existing, incoming);
+    expect(merged.problem_statement).toBe(existing.problem_statement);
+    expect(merged.personas).toBe(incoming.personas);
+  });
+
+  it('replaces a stub (<50 char) existing key with a substantive new one', () => {
+    const existing = { personas: 'stub' }; // 4 chars, well under the 50-char floor
+    const incoming = { personas: 'C'.repeat(200) };
+    const merged = mergeVisionSections(existing, incoming);
+    expect(merged.personas).toBe(incoming.personas);
+  });
+
+  it('handles null/undefined existing (insert-shaped call) by returning the new sections as-is', () => {
+    const incoming = { problem_statement: 'D'.repeat(200) };
+    expect(mergeVisionSections(null, incoming)).toEqual(incoming);
+    expect(mergeVisionSections(undefined, incoming)).toEqual(incoming);
+  });
+
+  it('returns null when both sides are empty/absent', () => {
+    expect(mergeVisionSections(null, null)).toBeNull();
+    expect(mergeVisionSections({}, {})).toBeNull();
+  });
+});
+
+describe('SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-A: repaired-but-unpromoted vision survives a subsequent eager-synthesis tick', () => {
+  beforeEach(() => extractSpy.mockReset());
+
+  it('a repaired draft vision with substantive sections is NOT clobbered by the next eager-synthesis write (the Resilient AI thrash)', async () => {
+    extractSpy.mockResolvedValue(DIMS);
+    // Reproduces the real Resilient AI shape: draft, repaired to several substantive standard
+    // sections, but not yet promoted to active+approved (so the freeze at L846 does not apply).
+    const repairedSections = {
+      executive_summary: 'E'.repeat(200),
+      problem_statement: 'F'.repeat(200),
+      success_criteria: 'G'.repeat(200),
+      personas: 'H'.repeat(200),
+      out_of_scope: 'I'.repeat(200),
+      evolution_plan: 'J'.repeat(200),
+      information_architecture: 'K'.repeat(200),
+      key_decision_points: 'L'.repeat(200),
+    };
+    const stuck = makeSupabase({
+      id: 'resilient-ai', version: 38, addendums: [], extracted_dimensions: DIMS,
+      status: 'draft', chairman_approved: false, sections: repairedSections,
+    });
+    await upsertEvaVisionFromArtifacts(stuck.client, 'VISION-RESILIENT-AI-L2-001', 'v-resilient-ai', 19);
+    expect(stuck.updates).toHaveLength(1);
+    // Every repaired section survives byte-identical — this is the assertion that would FAIL
+    // against the pre-fix wholesale-replace write (verified via negative-control revert-and-retest).
+    for (const [key, value] of Object.entries(repairedSections)) {
+      expect(stuck.updates[0].sections[key]).toBe(value);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- RCA-confirmed root cause (rca-agent): `upsertEvaVisionFromArtifacts`'s clobber-freeze only protects a vision once `status=active AND chairman_approved=true`. A vision repaired to `quality_checked=true` but not yet promoted is NOT frozen, so the next eager-synthesis re-fire (every artifact write) wholesale-replaced `sections`, clobbering any previously-filled standard section. Live evidence: venture "Resilient AI" sits at vision version 38, never promoted.
- New `mergeVisionSections(existing, new)`: keeps every existing substantive (>=50 char, matching the DB trigger's own stub threshold) section untouched; only fills genuinely missing/stub keys from the latest synthesis.
- Decision record added explaining the freeze itself is intentionally left as-is — this fix makes the write idempotent regardless of freeze state, so widening the freeze would be redundant.

Child of SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001 (parent orchestrator, FR-1). Ships first — sibling Child B (extending repair to real ventures) has a real, DB-enforced dependency on this landing before it.

## Test plan
- [x] New unit tests for the pure `mergeVisionSections` function (5 cases: existing-preserved, missing-filled, stub-replaced, null-existing, both-empty)
- [x] New integration test reproducing the exact Resilient AI thrash shape (repaired draft vision + subsequent eager-synthesis tick) — verified to **fail** against the pre-fix wholesale-replace write via a negative-control revert-and-retest before shipping
- [x] `npx vitest run tests/unit/eva/eager-synthesis-vision-dims.test.js tests/unit/eva/artifact-persistence-dual-write.test.js tests/unit/eva/artifact-persistence-advance-reset.test.js` — 32/32 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)