### PR TITLE
feat(SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A): crew-comms routing protocol doc + role-contract references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 1578e8514241b25a -->
+<!-- file_content_hash: 5d1f7001d4898e84 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-07-01 7:34:56 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-07-02 8:26:21 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: f03ff96593d095f1 -->
+<!-- file_content_hash: 92177eea35ba55fe -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -76,6 +76,7 @@
 
 **2026-06-11 (handoff-drill fixes — durable encoding of session-fragile duties)**:
 - **BELT COUNTDOWN DUTY (durable)**: while the fleet is active, Adam posts a belt-countdown one-liner every 15 minutes — ONE line, Eastern time in 12-hour format, with a rolling ETA to belt-dry (claimable-SD depth vs current fleet burn). This duty previously lived only in session-scoped crons and DIED with every Adam session (confirmed by the 2026-06-11 handoff drill). Every `/adam` startup must RE-ARM it alongside the three canonical tick loops; countdown timestamps derive from DB rows — never hand-converted ET↔UTC.
+- **BOARD RECONCILE DUTY (durable)**: every recurring Adam tick, reconcile the durable `adam_task_ledger` board against live reality (open advisory threads, sourced SDs, awaited replies) via `lib/adam/task-rehydrate.js` `rehydrateBoard()`, wired into `scripts/adam-quiet-tick.mjs` (not only at `/adam` cold start, which already ran it once via `adam-startup-check.mjs`). SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B. This closes the same "durable but session-fragile" gap class the belt-countdown duty above closed.
 - **FULL-INBOX SWEEP (sharpened — never trust ack state)**: the known auto-ack bug stamps read_at/acknowledged_at on rows Adam never processed (QF-20260610-623, sender_type-allowlist class). Sweep the coordination lane by created_at + payload.kind over the recent window (e.g. 24h) REGARDLESS of read/ack stamps; acknowledged_at-IS-NULL filtering alone provably hides chairman/coordinator directives.
 - **LIVE STATE LIVES IN THE DB, NOT MEMORY (handoff rule)**: experiment arm state (e.g. effort-tier `metadata.arms_log`), open-watch lists, and queue state must be re-read LIVE at session start; memory files are point-in-time and go stale within hours on an active fleet. A fresh Adam asserting experiment/queue state from memory without a live DB read is a D4 (verify-before-certainty) failure.
 
@@ -143,6 +144,10 @@ Distinguish **serious** from **needs-his-decision**: a governance breach (e.g. a
 
 (Chairman-directed 2026-06-25. Enforcement probe tracked as SD-LEO-INFRA-ADAM-DECISION-RUBRIC-ENFORCE-001 so the self-adherence loop auto-flags over-asking, not just documents the rule.)
 
+
+## Crew-comms routing protocol (organizing layer)
+
+Adam operates under the canonical crew-comms routing protocol: `docs/protocol/crew-comms-routing-protocol.md`. It defines the 5 bounding rules that keep 3-party (Adam/Solomon/coordinator) comms from growing chaotically: (1) defined lanes, not full mesh; (2) hop-minimization (the direct Adam<->Solomon channel); (3) sender-stamped reply-class {fire-and-forget | reply-needed | live-handshake}; (4) silence-by-default + one-advisory-per-tick; (5) escalation ladder Adam->Solomon->Chairman. See `docs/protocol/coordinator-adam-comms.md` for this role's wire-level lane contracts, and the organizing doc for the cross-role picture, the cross-check protocol, sync-request rules, and PID-cross-check.
 
 ## SOURCING SSOT — order of operations
 
@@ -278,6 +283,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: ffd551923a42571f -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: 8ca793a57ccca10b -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 
@@ -36,6 +36,10 @@
 - **Proactivity is PROPOSE, not auto-execute (operator-canonical 2026-06-08)**: When idle, Adam **scans, identifies options, and PRESENTS them to the active coordinator with rationale**, then lets the **coordinator decide** which (if any) Adam works on. Adam does **NOT** autonomously *begin* self-generated proactive work — launching investigations, building — without the coordinator's confirmation. **Sourcing/filing DRAFT SDs is EXEMPT — a DRAFT row is a CONST-002-safe proposal, not a dispatch — and runs CONTINUOUSLY per NEVER HOLD SOURCING (below); only *claiming/worktreeing/driving/dispatching* an SD requires the coordinator's go.** Surfacing findings, canary observations
 
 *...truncated. Read full file for complete section.*
+
+## Crew-comms routing protocol (organizing layer)
+
+Adam operates under the canonical crew-comms routing protocol: `docs/protocol/crew-comms-routing-protocol.md`. It defines the 5 bounding rules that keep 3-party (Adam/Solomon/coordinator) comms from growing chaotically: (1) defined lanes, not full mesh; (2) hop-minimization (the direct Adam<->Solomon channel); (3) sender-stamped reply-class {fire-and-forget | reply-needed | live-handshake}; (4) silence-by-default + one-advisory-per-tick; (5) escalation ladder Adam->Solomon->Chairman. See `docs/protocol/coordinator-adam-comms.md` for this role's wire-level lane contracts, and the organizing doc for the cross-role picture, the cross-check protocol, sync-request rules, and PID-cross-check.
 
 ## SOURCING SSOT — order of operations
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 223d035d954912dd -->
+<!-- file_content_hash: a084c69768b28ace -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -69,6 +69,10 @@ When sending ANY Adam-directed message (a session_coordination row targeting the
 - INITIATE a coordinator→Adam directive: use a recognized directive kind (e.g. coordinator_advisory).
 - NEVER raw-insert an untyped (kind=null) session_coordination row to the Adam session — it will be invisible.
 
+## Crew-comms routing protocol (organizing layer)
+
+The coordinator operates under the canonical crew-comms routing protocol: `docs/protocol/crew-comms-routing-protocol.md`. It defines the 5 bounding rules that keep 3-party (Adam/Solomon/coordinator) comms from growing chaotically: (1) defined lanes, not full mesh; (2) hop-minimization (the direct Adam<->Solomon channel); (3) sender-stamped reply-class {fire-and-forget | reply-needed | live-handshake}; (4) silence-by-default + one-advisory-per-tick; (5) escalation ladder Adam->Solomon->Chairman. See `docs/protocol/coordinator-adam-comms.md and docs/protocol/coordinator-solomon-comms.md` for this role's wire-level lane contracts, and the organizing doc for the cross-role picture, the cross-check protocol, sync-request rules, and PID-cross-check.
+
 ## Coordinator ↔ Adam Autonomous Partnership (shared role contract)
 
 **Coordinator ↔ Adam autonomous partnership (shared)** — On harness/sourcing work the COORDINATOR is the decider/manager for work-shaping, scope, tiering, dedup, and dispatch; ADAM authors the DRAFT SDs/QFs (DOC-001 — sourcing is Adam's lane) and routes shaping/scope/dispatch decisions to the coordinator, NOT up to the chairman. The two form a JOINT RATIONALE and PROCEED autonomously — operational calls are never bounced to the operator. Escalate to the chairman/operator ONLY for genuine AUTHORITY (vision, revenue, policy) or IRREVERSIBLE/destructive actions. (Unchanged: the chairman may direct either role directly.) Role-agnostic — a future role-session (e.g. Solomon) inherits this posture by inclusion.
@@ -77,6 +81,6 @@ _Single governed source of truth (section_type=role_partnership_contract), inclu
 
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: b653e4ec79b4675a -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: 0337c0dc55c41047 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 
@@ -45,6 +45,10 @@ When sending ANY Adam-directed message (a session_coordination row targeting the
 - REPLY to an Adam message: payload = { kind: "coordinator_reply", reply_to: <Adam correlation_id or the Adam row id> }.
 - INITIATE a coordinator→Adam directive: use a recognized directive kind (e.g. coordinator_advisory).
 - NEVER raw-insert an untyped (kind=null) session_coordination row to the Adam session — it will be invisible.
+
+## Crew-comms routing protocol (organizing layer)
+
+The coordinator operates under the canonical crew-comms routing protocol: `docs/protocol/crew-comms-routing-protocol.md`. It defines the 5 bounding rules that keep 3-party (Adam/Solomon/coordinator) comms from growing chaotically: (1) defined lanes, not full mesh; (2) hop-minimization (the direct Adam<->Solomon channel); (3) sender-stamped reply-class {fire-and-forget | reply-needed | live-handshake}; (4) silence-by-default + one-advisory-per-tick; (5) escalation ladder Adam->Solomon->Chairman. See `docs/protocol/coordinator-adam-comms.md and docs/protocol/coordinator-solomon-comms.md` for this role's wire-level lane contracts, and the organizing doc for the cross-role picture, the cross-check protocol, sync-request rules, and PID-cross-check.
 
 ---
 *The coordinator is NOT a worker and NOT Adam. Full contract in CLAUDE_COORDINATOR.md.*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 81b2d13c8fb82364 -->
+<!-- file_content_hash: a29a19efc7dcc71e -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1708,7 +1708,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: 1ad130743043d8d9 -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: ee3024533c1b4e53 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-07-01 7:34:56 PM*
+*DIGEST generated: 2026-07-02 8:26:21 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: 8248cbf65c27e61f -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: 479ee6bb55457dbd -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-07-01 7:34:56 PM*
+*DIGEST generated: 2026-07-02 8:26:21 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 63fd880003fc132b -->
+<!-- file_content_hash: 77c6d75dd64170f4 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2120,6 +2120,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: c946c176d57c45eb -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: adf97b35572fe0cf -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-07-01 7:34:56 PM*
+*DIGEST generated: 2026-07-02 8:26:21 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 82b6317e181fcdbd -->
+<!-- file_content_hash: 44f81c5b731862a3 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1584,6 +1584,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: 3180d14101714f62 -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: b73cb016c95d3a55 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-07-01 7:34:56 PM*
+*DIGEST generated: 2026-07-02 8:26:21 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 416a46e305a15917 -->
+<!-- file_content_hash: 026f24c7b4482849 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -2443,6 +2443,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: 56ded987df548165 -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: e6c75cfee54cf996 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-07-01 7:34:56 PM*
+*DIGEST generated: 2026-07-02 8:26:21 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 34f01b13bec3bd3f -->
+<!-- file_content_hash: 0288b805167f4467 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-07-01 7:34:56 PM
+**Generated**: 2026-07-02 8:26:21 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -257,8 +257,12 @@ The self-rubric (§"Self-assessment rubric") scores whether Solomon *behaved*; t
 
 A cluster that is consistently declined or inaccurate, or whose cost-per-accepted-proposal is unjustifiable, is a candidate to **drop** — Solomon earns his scope empirically, cluster by cluster, rather than by assumption.
 
+## Crew-comms routing protocol (organizing layer)
+
+Solomon operates under the canonical crew-comms routing protocol: `docs/protocol/crew-comms-routing-protocol.md`. It defines the 5 bounding rules that keep 3-party (Adam/Solomon/coordinator) comms from growing chaotically: (1) defined lanes, not full mesh; (2) hop-minimization (the direct Adam<->Solomon channel); (3) sender-stamped reply-class {fire-and-forget | reply-needed | live-handshake}; (4) silence-by-default + one-advisory-per-tick; (5) escalation ladder Adam->Solomon->Chairman. See `docs/protocol/coordinator-solomon-comms.md` for this role's wire-level lane contracts, and the organizing doc for the cross-role picture, the cross-check protocol, sync-request rules, and PID-cross-check.
+
 ---
 
-*Generated from database: 2026-07-01*
+*Generated from database: 2026-07-02*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-01T23:34:55.992Z -->
-<!-- git_commit: fe3bbdc1 -->
-<!-- db_snapshot_hash: d38407bccd2a4670 -->
-<!-- file_content_hash: 0f31ef790ab90cca -->
+<!-- generated_at: 2026-07-02T00:26:21.321Z -->
+<!-- git_commit: 0a7a703f -->
+<!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
+<!-- file_content_hash: c9e3fdf9b8ad15b4 -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 
@@ -39,6 +39,10 @@
 A Solomon session self-sc
 
 *...truncated. Read full file for complete section.*
+
+## Crew-comms routing protocol (organizing layer)
+
+Solomon operates under the canonical crew-comms routing protocol: `docs/protocol/crew-comms-routing-protocol.md`. It defines the 5 bounding rules that keep 3-party (Adam/Solomon/coordinator) comms from growing chaotically: (1) defined lanes, not full mesh; (2) hop-minimization (the direct Adam<->Solomon channel); (3) sender-stamped reply-class {fire-and-forget | reply-needed | live-handshake}; (4) silence-by-default + one-advisory-per-tick; (5) escalation ladder Adam->Solomon->Chairman. See `docs/protocol/coordinator-solomon-comms.md` for this role's wire-level lane contracts, and the organizing doc for the cross-role picture, the cross-check protocol, sync-request rules, and PID-cross-check.
 
 ---
 *Solomon is NOT a worker and NOT the coordinator. Full contract in CLAUDE_SOLOMON.md.*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,123 +1,123 @@
 {
-  "generated_at": "2026-07-01T23:34:55.992Z",
-  "git_commit": "fe3bbdc1",
-  "db_snapshot_hash": "d38407bccd2a4670",
+  "generated_at": "2026-07-02T00:26:21.321Z",
+  "git_commit": "0a7a703f",
+  "db_snapshot_hash": "8eb2912b9dff05a2",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19368,
       "estimated_tokens": 4842,
-      "content_hash": "8e0f584affac240d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
+      "content_hash": "fe524d6234f9fd45",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 86703,
       "estimated_tokens": 21676,
-      "content_hash": "2cd6c5c1af462ee4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
+      "content_hash": "0a4c70ad684628b2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 65401,
       "estimated_tokens": 16351,
-      "content_hash": "ac9a92809a886705",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
+      "content_hash": "8a77138e5f17e5be",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 91103,
       "estimated_tokens": 22776,
-      "content_hash": "aaf61e87dab472bc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
+      "content_hash": "fabf2c15190e0ad0",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 86566,
       "estimated_tokens": 21642,
-      "content_hash": "32638a1e465c9e16",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
+      "content_hash": "eaf76fd504cae816",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 52999,
-      "estimated_tokens": 13250,
-      "content_hash": "90f871da57fe32dd",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM.md"
+      "chars": 54280,
+      "estimated_tokens": 13570,
+      "content_hash": "32f68af91433a676",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 20929,
-      "estimated_tokens": 5233,
-      "content_hash": "81fa7d0534df7438",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR.md"
+      "chars": 21735,
+      "estimated_tokens": 5434,
+      "content_hash": "9e8af0f3366d526d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
-      "chars": 44108,
-      "estimated_tokens": 11027,
-      "content_hash": "9a021faeae58e94f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON.md"
+      "chars": 44862,
+      "estimated_tokens": 11216,
+      "content_hash": "4725ff2a8748c883",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "7bfd9905f2d2f723",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
+      "content_hash": "10e6f0c1643ad22b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11664,
       "estimated_tokens": 2916,
-      "content_hash": "4a8fa586a27e5d03",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "eaa746407a216c7c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5551,
       "estimated_tokens": 1388,
-      "content_hash": "11cde85b19a1c17c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "fac465e491ae6684",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8541,
       "estimated_tokens": 2136,
-      "content_hash": "661b6905ee197026",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "9301627bc4f6619c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10964,
       "estimated_tokens": 2741,
-      "content_hash": "0d200c103e8e0b47",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "b40d2d1a3eab9be5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
-      "chars": 12320,
-      "estimated_tokens": 3080,
-      "content_hash": "00bbab1cb26915b6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_ADAM_DIGEST.md"
+      "chars": 13068,
+      "estimated_tokens": 3267,
+      "content_hash": "88878b3b45f0613d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
-      "chars": 5270,
-      "estimated_tokens": 1318,
-      "content_hash": "8be2af36d85882e3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_COORDINATOR_DIGEST.md"
+      "chars": 6076,
+      "estimated_tokens": 1519,
+      "content_hash": "9cb2dd242215b64a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
-      "chars": 3951,
-      "estimated_tokens": 988,
-      "content_hash": "f4440c4100692f46",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_SOLOMON_DIGEST.md"
+      "chars": 4705,
+      "estimated_tokens": 1177,
+      "content_hash": "e248da694c6acf83",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "b7d95fe4ec1fa07d",
+    "global": "105af1849ea00016",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -371,7 +371,7 @@
       "596": "0251044882a17550",
       "597": "ca5efc991922f3b8",
       "599": "7ddd3e2178799aa8",
-      "601": "a405cbac19ca1d0e",
+      "601": "f5b7cffd22ce1f0e",
       "602": "ad0aecae8cdc6cb3",
       "603": "ea1eddc2cef94c83",
       "604": "a35e66b64599f81d",
@@ -383,7 +383,10 @@
       "610": "fb3813fc42f32f3a",
       "611": "8807ed27ea29e908",
       "612": "13e03eddf5300bcc",
-      "613": "1e1de64689c1ad82"
+      "613": "1e1de64689c1ad82",
+      "614": "a4d5064f0ffbe97c",
+      "615": "1ac30c8d7046c470",
+      "616": "cf03793e285951bf"
     },
     "meta": {
       "94": {
@@ -1710,6 +1713,21 @@
         "section_type": "governance",
         "target_file": "docs/protocol/adkar-change-adoption-framework.md",
         "title": "ADKAR Change-Adoption Framework"
+      },
+      "614": {
+        "section_type": "adam_role_contract",
+        "target_file": "CLAUDE_ADAM.md",
+        "title": "Crew-comms routing protocol (organizing layer)"
+      },
+      "615": {
+        "section_type": "coordinator_role_contract",
+        "target_file": "CLAUDE_COORDINATOR.md",
+        "title": "Crew-comms routing protocol (organizing layer)"
+      },
+      "616": {
+        "section_type": "solomon_role_contract",
+        "target_file": "CLAUDE_SOLOMON.md",
+        "title": "Crew-comms routing protocol (organizing layer)"
       }
     }
   }

--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -13,6 +13,12 @@ tags: [documentation, protocol]
 > print a summary of this lane (FR-7), so neither side has to reverse-engineer it.
 > SD-LEO-INFRA-RESILIENT-SYMMETRIC-ADAM-001.
 
+> This lane is one of the canonical channels organized under
+> `docs/protocol/crew-comms-routing-protocol.md` (the 5 bounding rules: defined lanes,
+> hop-minimization, sender-stamped reply-class, silence-by-default, escalation ladder).
+> Read that doc first for the cross-role picture; this doc is the Adam↔coordinator
+> wire-level contract.
+
 ## What this lane is
 
 A **symmetric, resilient** advisory channel over `session_coordination` `INFO` rows, kept
@@ -214,3 +220,42 @@ ONE batched `getFleetPresence()` call per render (not a per-row query).
 **Preserves silence-by-default**: none of the three signals send a new `session_coordination`
 message — they augment existing renders/queries only. Presence/working signals are ambient/
 on-demand, not new chat spam.
+
+## Cross-check protocol (SEE-SOMETHING / CONFIRM-ON-RELAY / PING-ON-SILENCE)
+
+Exception-triggered mutual verification on this lane — not every message, only on these
+triggers. Full rationale + live evidence: `docs/protocol/crew-comms-routing-protocol.md`
+§ "Cross-check protocol".
+
+- **SEE-SOMETHING** — if either side notices a claim from the other contradicts a stale
+  read, a snapshot, or ground truth, flag it immediately rather than acting on it.
+- **CONFIRM-ON-RELAY** — when the coordinator relays a message to/from Adam on behalf of a
+  third party, it confirms back to the origin that the relay landed.
+- **PING-ON-SILENCE** — a `reply-needed` message (see Reply-class below) left unanswered
+  past its expected window is pinged, not silently assumed disagreed-with.
+
+## Reply-class (sender-stamped)
+
+Every message on this lane is sender-stamped with a reply-class: `fire-and-forget`
+(no reply expected), `reply-needed` (async, PING-ON-SILENCE applies), or
+`live-handshake` (sync-request eligible — see below). See
+`docs/protocol/crew-comms-routing-protocol.md` § "Rule 3 — Sender-stamped reply-class"
+for the full contract.
+
+## Sync-request (live-handshake only)
+
+`node scripts/adam-advisory.cjs request "<question>" --timeout <ms>` is this lane's
+synchronous, bounded-timeout request mode — reserved for genuine `live-handshake`
+exchanges, never for `reply-needed`/`fire-and-forget` traffic (those stay async via
+`send`). On timeout, fall back to async rather than re-blocking — a sync-request against
+a dormant/invocation-driven peer will time out by construction, since that peer cannot
+answer until its next tick. **Never** issue a sync-request while already blocked on one
+(mutual sync-requests deadlock). Full rules:
+`docs/protocol/crew-comms-routing-protocol.md` § "Sync-request semantics".
+
+## PID-cross-check (liveness-dispute resolution)
+
+When the coordinator and Adam disagree on which session legitimately holds a role (a
+`session_id` is a label, not ground truth), resolve via OS process enumeration and
+on-disk session markers, not another DB read. Full protocol:
+`docs/protocol/crew-comms-routing-protocol.md` § "PID-cross-check".

--- a/docs/protocol/coordinator-solomon-comms.md
+++ b/docs/protocol/coordinator-solomon-comms.md
@@ -2,6 +2,13 @@
 
 **Status:** Active (ships dormant until `SOLOMON_CONSULT_V1`) · **SD:** SD-LEO-INFRA-SOLOMON-CONSULT-001 (Phase E) · Modeled on `docs/protocol/coordinator-adam-comms.md` + `docs/architecture/solomon-oracle.md`.
 
+> This lane is one of the canonical channels organized under
+> `docs/protocol/crew-comms-routing-protocol.md` (the 5 bounding rules: defined lanes,
+> hop-minimization — including the direct Adam↔Solomon channel this lane's traffic
+> partially graduates to — sender-stamped reply-class, silence-by-default, escalation
+> ladder). Read that doc first for the cross-role picture; this doc is the
+> Solomon↔coordinator wire-level contract.
+
 Solomon is the deep-reasoning **oracle** — the session the fleet escalates its hardest reasoning problems to. This doc defines how a `solomon_consult` reaches Solomon and how Solomon's answer reaches the asker. Solomon **proposes, never executes** (it never claims an SD or drives a build).
 
 ## Channels & kinds
@@ -40,3 +47,44 @@ indicator, ephemeral working-signal). No per-role reimplementation.
 ## Self-adherence
 
 Every 12 h, `solomon-self-adherence-review.mjs` checks that each durable duty declared in `CLAUDE_SOLOMON.md` is present in `SOLOMON_LOOPS`; drift is surfaced as a propose-only remediation (Solomon never builds the fix). The same parity check (`renderContractParity`) prints at every `/solomon` startup.
+
+## Cross-check protocol (SEE-SOMETHING / CONFIRM-ON-RELAY / PING-ON-SILENCE)
+
+Exception-triggered mutual verification on this lane — not every message, only on these
+triggers. Full rationale + live evidence: `docs/protocol/crew-comms-routing-protocol.md`
+§ "Cross-check protocol".
+
+- **SEE-SOMETHING** — if either side notices a claim from the other contradicts a stale
+  read, a snapshot, or ground truth, flag it immediately rather than acting on it.
+- **CONFIRM-ON-RELAY** — when the coordinator relays a message to/from Solomon on behalf
+  of a third party, it confirms back to the origin that the relay landed.
+- **PING-ON-SILENCE** — a `reply-needed` consult (see Reply-class below) left unanswered
+  past its expected window is pinged, not silently assumed disagreed-with.
+
+## Reply-class (sender-stamped)
+
+Every message on this lane is sender-stamped with a reply-class: `fire-and-forget`
+(no reply expected), `reply-needed` (async, PING-ON-SILENCE applies), or
+`live-handshake` (sync-request eligible — see below). See
+`docs/protocol/crew-comms-routing-protocol.md` § "Rule 3 — Sender-stamped reply-class"
+for the full contract.
+
+## Sync-request (live-handshake only)
+
+`node scripts/solomon-advisory.cjs request "<question>" --timeout <ms>` is this lane's
+synchronous, bounded-timeout request mode — reserved for genuine `live-handshake`
+exchanges, never for `reply-needed`/`fire-and-forget` traffic (those stay async via
+`send`/`solomon_consult`). On timeout, fall back to async rather than re-blocking — Solomon
+runs scheduled sweeps and drain ticks rather than a continuous listener, so a sync-request
+against it can time out by construction between ticks; prefer async in that case. **Never**
+issue a sync-request while already blocked on one (mutual sync-requests deadlock). Full
+rules: `docs/protocol/crew-comms-routing-protocol.md` § "Sync-request semantics".
+
+## PID-cross-check (liveness-dispute resolution)
+
+When two sessions disagree on which session is the live canonical Solomon (a
+`session_id` is a label, not ground truth — Solomon's own singleton-handoff guard above
+exists for exactly this), resolve via OS process enumeration and on-disk session markers,
+not another DB read. This settled a real Solomon session-identity dispute live on
+2026-07-01. Full protocol: `docs/protocol/crew-comms-routing-protocol.md`
+§ "PID-cross-check".

--- a/docs/protocol/crew-comms-routing-protocol.md
+++ b/docs/protocol/crew-comms-routing-protocol.md
@@ -1,0 +1,191 @@
+---
+category: Protocol
+status: Approved
+version: 1.0.0
+author: coordinator + Claude Code
+last_updated: 2026-07-02
+tags: [protocol, comms, crew, adam, solomon, coordinator, chairman]
+---
+
+# Crew-comms routing protocol (canonical)
+
+> The ORGANIZING layer the tactical comms mechanisms plug into. Chairman-directed
+> 2026-07-01: "a documented method that we adhere to that makes sense given the roles
+> of each individual" so 3-party comms does not grow chaotically. Per
+> SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001.
+
+## Why this doc exists
+
+Pairwise comms (Adam↔coordinator) stays a clean back-and-forth. Adding a third
+role-session (Solomon) expands touch-points combinatorially — pairwise channels grow
+O(N²) with the number of participants. The individual tactical mechanisms that bound
+chatter already existed and were proven live on 2026-07-01 (cross-check protocol,
+sender-stamped reply-class, sync-request rules, PID-cross-check, adaptive cadence,
+presence-grounding), but lived scattered across sessions with **no single documented
+method on top**. This doc is that method: 5 bounding rules, each cutting chatter at a
+different point, with the existing tactical mechanisms as their concrete implementation.
+
+## The unified 3-way crew topology
+
+Three long-lived singleton role-sessions, plus the chairman:
+
+| Role | Function |
+|------|----------|
+| **Chairman** | Drives priority via cron-pasted directives. Works **through Adam** — never double-surfaced to Solomon or the coordinator directly. |
+| **Adam** | SD sourcing + the chairman's funnel. Silence-by-default; sources and diagnoses, never claims/builds. |
+| **Solomon** | Deep-reasoning oracle. Silence-by-default; proactive Mode-B backlog sweeps on a cron. Consulted for hard analysis/verdicts. Proposes, never executes. |
+| **Coordinator** | Fleet dispatch, ranking, monitoring, worker-signal routing, QA/sweeps. |
+
+All inter-role comms go over the `session_coordination` table (async by default). The
+coordinator and Adam are invocation-driven (see Rule 2 below); Solomon runs a mix of
+scheduled sweeps and drain ticks. See `docs/protocol/coordinator-adam-comms.md` and
+`docs/protocol/coordinator-solomon-comms.md` for the pairwise wire-level contracts this
+doc organizes.
+
+## The 5 bounding rules
+
+### Rule 1 — Defined lanes, not full mesh
+
+Canonical role-based channels, each with a stated purpose — no improvised any-to-any
+paths:
+
+- **Chairman ↔ Adam** — the single chairman interface/funnel.
+- **Adam ↔ coordinator** — dispatch/mechanics/fleet.
+- **Adam ↔ Solomon** — deep-reasoning consult/advisory.
+
+A session that needs to reach a role outside its defined lane routes through the lane
+owner rather than improvising a new path.
+
+### Rule 2 — Hop-minimization (the direct Adam↔Solomon channel)
+
+The single biggest lever: an Adam↔Solomon exchange relayed through the coordinator is 2
+hops plus a confirm-on-relay — roughly 3× the messages of a direct exchange, and it
+carries a relay-drop risk (an ack-without-relay bug observed live). The direct
+Adam↔Solomon channel graduates this from spec-only to built (see
+SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B). **The coordinator stays a relay
+only for messages that genuinely concern it** — dispatch, fleet mechanics, ranking — not
+as a default hop for every cross-role exchange.
+
+### Rule 3 — Sender-stamped reply-class
+
+Every message is stamped by its sender with one of:
+
+| Class | Meaning | Blocking? |
+|-------|---------|-----------|
+| `fire-and-forget` | No reply expected or chased | No |
+| `reply-needed` | A reply is expected within a window; unanswered past it triggers PING-ON-SILENCE | No (async) |
+| `live-handshake` | A synchronous, bounded-timeout reply is needed NOW | Yes (see Sync-Request below) |
+
+This bounds the back-and-forth at the **source** — most messages need no reply at all —
+and drives PING-ON-SILENCE deterministically instead of an ad-hoc guess (see
+SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C).
+
+### Rule 4 — Silence-by-default + one-advisory-per-tick
+
+Already encoded in each role's contract (CLAUDE_ADAM.md, CLAUDE_SOLOMON.md,
+CLAUDE_COORDINATOR.md): a role-session only speaks when it has something that clears its
+rationale bar, and surfaces at most one advisory per tick. This bounds volume
+independently of the other 4 rules.
+
+### Rule 5 — Escalation ladder
+
+Adam → Solomon → Chairman. The three role-sessions absorb the mesh; the chairman
+receives only the funnel (through Adam), never the raw N² chatter between the other
+roles.
+
+## Tactical layer (mechanisms this protocol organizes)
+
+These already exist and implement one or more of the 5 rules above:
+
+- **Cross-check protocol** (SEE-SOMETHING / CONFIRM-ON-RELAY / PING-ON-SILENCE) —
+  implements Rule 3 (PING-ON-SILENCE keys off reply-class) and is a safety net across
+  every lane in Rule 1.
+- **Sync-request semantics** — implements the `live-handshake` reply-class in Rule 3.
+- **PID-cross-check** — a reliability discipline supporting Rule 1 (settles which
+  session legitimately holds a lane when two async reads disagree).
+- **Adaptive comms cadence** (`lib/coordinator/adaptive-comms-cadence.cjs`) — bounds
+  volume/latency under Rule 4 without violating silence-by-default.
+- **Presence + grounding signals** (`lib/coordinator/presence-grounding-signals.cjs`) —
+  resolves the disruption of ambiguous silence under Rule 4.
+
+### Cross-check protocol (SEE-SOMETHING / CONFIRM-ON-RELAY / PING-ON-SILENCE)
+
+Exception-triggered mutual verification between peers — not every message, only on
+these triggers:
+
+- **SEE-SOMETHING** — when you notice a peer's claim contradicts a stale read, a
+  snapshot, or ground truth, flag it immediately rather than acting on it. (Caught live:
+  a peer describing an active venture as "abandoned" off a stale vision timestamp; a
+  "stuck/redundant" worker that had actually completed and added value.)
+- **CONFIRM-ON-RELAY** — when you relay A→B on behalf of a peer, confirm back to the
+  origin that the relay landed (closes the loop; the historical gap here was the
+  ack-without-relay bug Rule 2's direct channel also removes for the Adam↔Solomon pair).
+- **PING-ON-SILENCE** — if a `reply-needed` message goes unanswered past its expected
+  window, ping. The async lane plus inbox-drain lag mean silence is not disagreement.
+
+This protocol caught three real errors before they reached the chairman on 2026-07-01: a
+shared-tree data-loss risk, a flapping-REST false-positive, and a jumped-the-gun
+take-upstream false-positive.
+
+### Sync-request semantics (live-handshake only; disengage-to-async against a dormant peer)
+
+A blocking synchronous request (`request "<question>" --timeout`) is a **shared tool**
+all three role-sessions may use — powerful but costly, since it blocks the sender
+awaiting a reply.
+
+- **When to use** — only for a genuine `live-handshake` (time-sensitive, need-a-reply-now
+  coordination where blocking is worth it). Never for `reply-needed` /
+  `fire-and-forget` — those stay async.
+- **How** — always a bounded timeout; the sender is blocked meanwhile, so keep timeouts
+  tight and purposeful; one open sync-request at a time per session.
+- **When to disengage** — on timeout, fall back to async (post the message, drain the
+  reply later). Do not re-block or retry-spin. A sync-request against an
+  invocation-driven / dormant peer (one with no live listener between ticks — it only
+  wakes on a chairman cron-paste or its own `ScheduleWakeup`) **will** time out, because
+  such a session cannot answer until its next tick — prefer async to it. Proven
+  2026-07-01: repeated 90s sync-requests from Adam to the coordinator timed out until the
+  exchange moved to async with a tightened drain cadence.
+- **Deadlock guard (critical)** — a session already blocked in a sync-wait cannot service
+  an inbound sync-request (it is blocked). Never issue mutual sync-requests: do not open
+  a sync-request while you are the target of one, or while already blocked on one. If
+  both sides sync-request each other, they deadlock.
+
+Mapping to Rule 3: `live-handshake` ⇒ sync-request-eligible; `reply-needed` /
+`fire-and-forget` ⇒ async only.
+
+### PID-cross-check (two-session liveness-dispute resolution)
+
+A `session_id` is a **label**; the running PID plus an on-disk marker are **ground
+truth**. When two sessions get different DB answers for "which session is live",
+resolve via OS/disk, not the DB:
+
+1. A filtered role query (`metadata->>role`, ordered by heartbeat desc) plus an explicit
+   ID lookup.
+2. OS process enumeration (e.g. `Get-Process claude`) — is the candidate's `cc_pid`
+   actually running?
+3. On-disk markers (`.claude/session-identity/<id>.json`, `.claude/pids/tick-<id>.json`).
+
+No obtainable live PID, no on-disk marker, and no process started near the row's alleged
+birth ⇒ a **dead phantom row**. This settled a real Solomon session-identity dispute live
+on 2026-07-01 (one candidate was a phantom; the other, with a running PID, was the real
+live Solomon).
+
+### Reliability disciplines (verify the authoritative signal)
+
+- **Schema/existence checks use the SQL layer** — `information_schema` / `to_regclass`,
+  never a PostgREST REST head-count (`.select(count, head)`). The REST head-count
+  false-positives on a missing table and flaps under PostgREST schema-cache lag /
+  read-replica divergence. (Bit the coordinator live: a "table exists" REST read that
+  flipped to `PGRST205` seconds later; the SQL layer showed it genuinely absent.)
+- **Per-connection read-divergence is real** — the same query has returned different
+  single rows to two different sessions (read-replica / pooler-snapshot / row-cap paging
+  per connection). Do not stake a load-bearing decision on a single REST read.
+- **OS/on-disk marker is the authoritative tiebreaker** whenever DB liveness/existence is
+  ambiguous. A `heartbeat_at` timestamp in a row is not proof of a live process.
+
+## Provenance
+
+The 5 bounding rules were designed to organize protocols and reliability disciplines
+battle-tested live on 2026-07-01 during the Solomon Mode-B activation, a gate-bug sweep,
+and S19 vision triage — this document describes AS-IS current practice, not an
+aspirational target.


### PR DESCRIPTION
## Summary
Child A of the `SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001` orchestrator (chairman-directed, coordinator-reviewed). Documentation-only, no dependency on the parallel protocol-build children (B/C/D).

- **New**: `docs/protocol/crew-comms-routing-protocol.md` — the canonical organizing doc stating the 5 bounding rules (defined lanes, hop-minimization, sender-stamped reply-class, silence-by-default, escalation ladder) and the unified 3-way topology, built from the coordinator's pre-authored AS-IS source material.
- **Updated**: `docs/protocol/coordinator-adam-comms.md` and `docs/protocol/coordinator-solomon-comms.md` — added the 3 protocols proven live on 2026-07-01 but previously undocumented: the cross-check protocol (SEE-SOMETHING/CONFIRM-ON-RELAY/PING-ON-SILENCE), sync-request semantics (live-handshake-only + disengage-to-async against a dormant peer + the mutual-sync deadlock guard), and PID-cross-check for liveness disputes.
- **`leo_protocol_sections`**: new adam/coordinator/solomon role-contract rows referencing the organizing doc; regenerated `CLAUDE_ADAM.md` / `CLAUDE_SOLOMON.md` / `CLAUDE_COORDINATOR.md` pick it up.

## Test plan
- [x] Read `docs/protocol/crew-comms-routing-protocol.md` — states all 5 bounding rules + the 3-way topology
- [x] Read the updated `coordinator-adam-comms.md` / `coordinator-solomon-comms.md` — both document cross-check, sync-request, and PID-cross-check
- [x] Regenerated `CLAUDE_*.md` and confirmed the organizing-doc reference appears in `CLAUDE_ADAM.md`, `CLAUDE_SOLOMON.md`, and `CLAUDE_COORDINATOR.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)