### PR TITLE
feat(SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001): class-guard the count-delta-gate anti-pattern

### DIFF
--- a/.github/workflows/count-delta-gate-lint.yml
+++ b/.github/workflows/count-delta-gate-lint.yml
@@ -1,0 +1,41 @@
+name: Count-Delta Gate Assertion Lint
+
+# SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001
+#
+# Blocks any PR that (re)introduces the proven, recurring "count-delta gate" anti-pattern: a
+# gate flagging on a raw failure-COUNT delta (e.g. "failures rose 105 -> 107") rather than an
+# identity-set diff of WHICH specific tests/files changed. A count-delta gate false-positives on
+# unrelated flaky / CI-secret / shared-DB-drift noise. Proven instances: scripts/ci/
+# red-merge-detector.mjs, scripts/compare-to-main-snapshot.mjs (BASELINE_REGRESSION), and —
+# converted in this SD — scripts/hooks/compare-test-baseline.cjs.
+#
+# GENUINELY BLOCKING (no continue-on-error): this repo's `npm run lint` (eslint.config.js
+# flat-config run) is not invoked by any other CI workflow, so registering the rule only in
+# eslint.config.js would not actually enforce anything — this dedicated workflow is the real
+# enforcement mechanism (same posture as realtime-subscribe-teardown-recursion-lint.yml).
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/ci/**/*.{js,mjs,cjs,ts,tsx}'
+      - 'scripts/hooks/**/*.{js,mjs,cjs,ts,tsx}'
+      - 'scripts/modules/**/*.{js,mjs,cjs,ts,tsx}'
+      - 'eslint-rules/no-count-delta-gate-assertion.js'
+      - 'scripts/lint/count-delta-gate-lint.mjs'
+      - '.github/workflows/count-delta-gate-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  count-delta-gate-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Detect raw count-delta gate assertions
+        run: node scripts/lint/count-delta-gate-lint.mjs

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-FIX-LEO-CREATE-ROUTE-001",
-  "expectedBranch": "feat/SD-LEO-FIX-LEO-CREATE-ROUTE-001",
-  "createdAt": "2026-07-01T23:12:29.140Z",
+  "sdKey": "SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001",
+  "createdAt": "2026-07-01T23:07:49.526Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/docs/reference/infrastructure-hardening-patterns.md
+++ b/docs/reference/infrastructure-hardening-patterns.md
@@ -668,6 +668,67 @@ to start and the test could not fail.
 
 ---
 
+## Pattern: Count-delta gate should be identity-diff (+ diff-reachability), not a raw count comparison (SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001)
+
+**Symptom**: A gate compares a raw failure COUNT main-vs-PR or baseline-vs-current ("failures rose
+105 -> 107") and flags a regression on any rise — even when the delta is unrelated flaky / CI-secret /
+shared-prod-DB-drift noise that has nothing to do with the change under test. This false-blocks PRs,
+false-files QFs (wasting worker cycles), and trains workers to override/ignore the gate — eroding gate
+trust, adjacent to the test-masking anti-pattern.
+
+**Root cause**: comparing two SCALARS (a count) discards WHICH specific identities (test names, files)
+changed. The same failing tests can produce a higher raw count on a re-run with no change under test
+(retries, shared-DB drift, CI-secret expiry) — a count-delta gate cannot distinguish that from a
+genuine regression.
+
+**Audit — every count-delta gate instance found** (grep/AST sweep of `scripts/ci/`, `scripts/hooks/`,
+`scripts/modules/`, `scripts/gate-health-check.js`, plus a manual read of borderline candidates):
+
+| Class | File | Disposition |
+|-------|------|-------------|
+| GATE-THAT-FLAGS (in-scope anti-pattern) | `scripts/hooks/compare-test-baseline.cjs` `compareTestCounts()` | **CONVERTED** in this SD — see Fix below |
+| GATE-THAT-FLAGS | `scripts/compare-to-main-snapshot.mjs` BASELINE_REGRESSION | **Deliberately deferred** — unmerged branch `qf/QF-20260701-833` (commit `b65b18e2c8`) already prototypes an identity-diff conversion for it; follow-up consolidation SD should have it adopt `lib/gates/identity-diff-gate.cjs` |
+| GATE-THAT-FLAGS | `scripts/ci/red-merge-detector.mjs` `decide()` + `detectBaselineRot()` | **Deliberately deferred** — a separate durable fix is sourced elsewhere; same follow-up-consolidation note. Underlying `codebase_health_snapshots` rows carry only a scalar `failed_count` today (no per-test identity), so converting this instance also needs a snapshot-schema extension, not just a comparator swap |
+| COUNT READER (not a gate, out of scope) | `scripts/hooks/capture-baseline-test-state.cjs`, `lib/sub-agents/regression.js`, `lib/eva/bridge/build-feedback-collector.js` | Reads/reports a count, does not flag on a delta |
+| ABSOLUTE-THRESHOLD (not the anti-pattern, out of scope) | `scripts/modules/shipping/TestExecutionVerifier.js` (`failed>0`), `lib/sub-agents/github.js:575` (`failed_count>0`) | No main-vs-PR/expected-vs-actual delta semantics — an existence/cap check |
+| CONTRASTIVE (already identity-scoped, reference shape) | `scripts/row-growth-snapshot.cjs` (table-name-scoped), `scripts/lib/ci-recurrence-detector.mjs` (classSignature-clustered) | Good examples of the target shape for future conversions |
+
+**Fix**: a structural class-guard, mirroring the shipped `SD-LEO-INFRA-REALTIME-REMOVECHANNEL-
+RECURSION-CLASSGUARD-001` shape exactly, not another per-instance patch:
+1. **Shared comparator**: `lib/gates/identity-diff-gate.cjs` — `computeIdentityRegression(currentIds,
+   priorFailingIds)` (a SET diff of failing identities, not a count subtraction), `extractFailingIds(raw)`
+   (parses a vitest JSON report into `file::fullName` identities), `filterReachable(newIds, changedFiles)`
+   (the diff-reachability half). Shaped as a drop-in superset of QF-20260701-833's inline primitive so
+   the two deferred instances above can adopt it later with zero behavior change.
+2. **One instance actually converted**: `scripts/hooks/compare-test-baseline.cjs` now diffs
+   `failing_ids` (captured additively by `scripts/hooks/capture-baseline-test-state.cjs`) instead of
+   subtracting `current_failed - baseline_failed` — proving the pattern end-to-end.
+3. **Lint rule**: `eslint-rules/no-count-delta-gate-assertion.js` — NAME-ANCHORED (matches a
+   failure-count lexicon: `numFailedTests`, `failed_count`, `baseline_failed`, `current_failed`,
+   `new_failures`, or `/(^|_)(failed|failing|failure)_?(count|tests|total)?$/i`), not a general
+   count-comparison AST match (which would false-positive on every ordinary numeric threshold check —
+   confirmed empirically: an initial general pass over `scripts/modules/**` flagged 9 false positives,
+   all existence checks (`failed > 0`) or absolute-cap checks (`< MIN_FAILURES_FOR_PATTERN`); refining
+   to skip relational comparisons against a numeric literal or an ALL_CAPS constant brought it to zero).
+   Reused via ESLint's programmatic `Linter` API by `scripts/lint/count-delta-gate-lint.mjs`, wired into
+   a dedicated, genuinely blocking GitHub Actions workflow (same "`npm run lint` is never invoked by any
+   CI workflow" rationale as the sibling class-guard).
+
+### PR-review checklist line
+
+> When a gate compares main-vs-PR or baseline-vs-current, verify it diffs a SET of identities (test
+> names, file paths) rather than a raw scalar count — a count-delta comparison cannot distinguish a
+> genuine regression from unrelated flaky/CI-secret/shared-DB-drift noise. Use
+> `lib/gates/identity-diff-gate.cjs`'s `computeIdentityRegression`, not `currentCount - baselineCount`.
+
+### Files Modified/Created
+`lib/gates/identity-diff-gate.cjs` (new), `eslint-rules/no-count-delta-gate-assertion.js` (new),
+`scripts/lint/count-delta-gate-lint.mjs` (new), `.github/workflows/count-delta-gate-lint.yml` (new),
+`scripts/hooks/compare-test-baseline.cjs`, `scripts/hooks/capture-baseline-test-state.cjs`,
+`scripts/modules/qa/test-output-parser.js` (pragma-exempted parsing-loop bound), `package.json`
+
+---
+
 ## Cross-References
 
 - **Database Patterns**: [database-agent-patterns.md](./database-agent-patterns.md)
@@ -682,3 +743,4 @@ to start and the test could not fail.
 |---------|------|---------|
 | 1.0.0 | 2026-01-30 | Initial documentation from SD-LEO-INFRA-HARDENING-001 |
 | 1.1.0 | 2026-07-01 | Added Realtime subscribe-teardown class-guard pattern from SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001 |
+| 1.2.0 | 2026-07-01 | Added Count-delta-vs-identity-diff gate class-guard pattern from SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 |

--- a/eslint-rules/no-count-delta-gate-assertion.js
+++ b/eslint-rules/no-count-delta-gate-assertion.js
@@ -1,0 +1,229 @@
+/**
+ * ESLint Rule: no-count-delta-gate-assertion
+ *
+ * Flags a raw numeric comparison (subtraction or relational: -, >, >=, <, <=, !==) where at
+ * least one operand is a failure-COUNT-lexicon identifier/property (numFailedTests, failed_count,
+ * baseline_failed, current_failed, new_failures, or the pattern /(^|_)(failed|failing|failure)_?
+ * (count|tests|total)?$/i) AND no identity-set operation (new Set(...), .has(, .filter(...=>...has(,
+ * computeIdentityRegression(, extractFailingIds() is present anywhere in the enclosing function.
+ *
+ * This is the recurring "count-delta gate" anti-pattern: a gate that flags on "failures rose N ->
+ * M" rather than checking WHICH specific test/file identities changed. A count-delta gate
+ * false-positives on unrelated flaky / CI-secret / shared-DB-drift noise — the SAME failing tests
+ * can produce a higher count on a re-run with no change under test.
+ *
+ * Proven instances: scripts/ci/red-merge-detector.mjs (decide()/detectBaselineRot()),
+ * scripts/compare-to-main-snapshot.mjs (BASELINE_REGRESSION), and — the instance this SD converted
+ * — scripts/hooks/compare-test-baseline.cjs's original `current_failed - baseline_failed`.
+ * SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 — this rule is the structural guard against
+ * a 4th instance being (re)introduced.
+ *
+ * Correct pattern: use lib/gates/identity-diff-gate.cjs's computeIdentityRegression(currentIds,
+ * priorFailingIds) — a SET diff of failing identities, not a raw count comparison.
+ *
+ * NAME-ANCHORED BY DESIGN (not a general count-comparison match): the anti-pattern is semantic,
+ * not syntactic — there is no crisp AST marker like a method name. A general "compare two numbers
+ * in an if" rule would false-positive on every ordinary threshold check. This rule instead matches
+ * by NAME (the failure-count lexicon), mirroring the proven match-by-NAME philosophy of
+ * eslint-rules/no-realtime-teardown-in-subscribe-callback.js.
+ *
+ * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
+ *
+ *   // eslint-disable-next-line no-count-delta-gate-assertion -- <REASON>
+ *   const delta = failed_count - baseline_failed;
+ *
+ * @module eslint-rules/no-count-delta-gate-assertion
+ */
+
+const RULE_NAME = 'no-count-delta-gate-assertion';
+const DELTA_OPERATORS = new Set(['-', '>', '>=', '<', '<=', '!==', '!=']);
+const EXACT_LEXICON = new Set([
+  'numFailedTests', 'failed_count', 'baseline_failed', 'current_failed', 'new_failures',
+  'priorFailedCount', 'failedCount', 'baselineFailed', 'currentFailed', 'newFailures',
+]);
+const LEXICON_PATTERN = /(^|_)(failed|failing|failure)_?(count|tests|total)?$/i;
+const IDENTITY_MARKERS = [/\bnew\s+Set\s*\(/, /\.has\s*\(/, /computeIdentityRegression\s*\(/, /extractFailingIds\s*\(/];
+
+// Detects `eslint-disable-next-line [<prefix>/]no-count-delta-gate-assertion` and captures the
+// trailing text on the same line, mirroring the pragma contract established by the sibling rules.
+const PRAGMA_DETECT_RE = new RegExp(
+  String.raw`eslint-disable-next-line\s+(?:[^,\n]*,\s*)*(?:[\w@-]+(?:[/][\w@-]+)*/)?` +
+    RULE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+    String.raw`(?:\s*,[^\n]*)?(.*)$`
+);
+
+/**
+ * Is this identifier/property name a failure-count-lexicon match?
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isCountLexiconName(name) {
+  if (!name) return false;
+  return EXACT_LEXICON.has(name) || LEXICON_PATTERN.test(name);
+}
+
+/**
+ * Does this operand reference a failure-count-lexicon name — an Identifier, or a
+ * MemberExpression whose non-computed property matches?
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function referencesCountLexicon(node) {
+  if (!node) return false;
+  if (node.type === 'Identifier') return isCountLexiconName(node.name);
+  if (node.type === 'MemberExpression' && !node.computed && node.property && node.property.type === 'Identifier') {
+    return isCountLexiconName(node.property.name);
+  }
+  return false;
+}
+
+/**
+ * Is this operand an ABSOLUTE-THRESHOLD reference (a numeric literal, or an ALL_CAPS constant
+ * identifier) rather than another baseline/prior/current COUNT variable? A relational comparison
+ * of a count against an absolute threshold (`failed > 0`, `failureCount < MIN_FAILURES`) is an
+ * existence/cap check, NOT the main-vs-PR/expected-vs-actual count-delta anti-pattern — VALIDATION
+ * (LEAD phase) explicitly classified this as out of scope (it would create noise if flagged).
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isAbsoluteThresholdOperand(node) {
+  if (!node) return false;
+  if (node.type === 'Literal' && typeof node.value === 'number') return true;
+  if (node.type === 'UnaryExpression' && node.operator === '-' && node.argument && node.argument.type === 'Literal') return true;
+  if (node.type === 'Identifier' && /^[A-Z][A-Z0-9_]*$/.test(node.name)) return true;
+  return false;
+}
+
+/**
+ * Classify a pragma comment targeting this rule.
+ * @param {string} commentValue
+ * @returns {{ targets: false } | { targets: true, hasMarker: boolean, reason: string }}
+ */
+function classifyPragma(commentValue) {
+  if (!commentValue) return { targets: false };
+  const match = commentValue.match(PRAGMA_DETECT_RE);
+  if (!match) return { targets: false };
+  const suffix = match[1] || '';
+  const markerIdx = suffix.indexOf('--');
+  if (markerIdx === -1) return { targets: true, hasMarker: false, reason: '' };
+  const reason = suffix.slice(markerIdx + 2).trim();
+  return { targets: true, hasMarker: true, reason };
+}
+
+const STATEMENT_TYPES = new Set([
+  'ExpressionStatement', 'VariableDeclaration', 'IfStatement', 'WhileStatement', 'DoWhileStatement',
+  'ForStatement', 'ForInStatement', 'ForOfStatement', 'ReturnStatement', 'SwitchStatement',
+  'ThrowStatement', 'BlockStatement', 'FunctionDeclaration',
+]);
+
+/**
+ * The pragma convention is line-oriented ("disable the violation on the NEXT line"), which is
+ * inherently statement-level — a BinaryExpression nested deep inside a `while (...)` condition (or
+ * any other sub-expression) does not itself have the comment immediately before IT in the token
+ * stream (the preceding token is often `&&`/`(` etc., not the comment). Walk up to the nearest
+ * enclosing statement first, then look for the pragma comment above THAT.
+ * @param {import('eslint').SourceCode} sourceCode @param {import('estree').Node} node
+ */
+function getDisablePragmaCommentAbove(sourceCode, node) {
+  let stmt = node;
+  while (stmt && stmt.parent && !STATEMENT_TYPES.has(stmt.type)) stmt = stmt.parent;
+  for (const candidate of [node, stmt]) {
+    const comments = sourceCode.getCommentsBefore(candidate);
+    if (!comments || comments.length === 0) continue;
+    const last = comments[comments.length - 1];
+    if (!last || (last.type !== 'Line' && last.type !== 'Block')) continue;
+    if (last.loc && candidate.loc && last.loc.end.line < candidate.loc.start.line - 1) continue;
+    const verdict = classifyPragma(last.value);
+    if (verdict.targets) return last;
+  }
+  return null;
+}
+
+/**
+ * Walk up from `node` to the nearest enclosing function (or Program) and return its source text.
+ * @param {import('estree').Node} node
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {string}
+ */
+function enclosingScopeText(node, sourceCode) {
+  let cur = node;
+  while (cur && cur.type !== 'FunctionDeclaration' && cur.type !== 'FunctionExpression' &&
+         cur.type !== 'ArrowFunctionExpression' && cur.type !== 'Program') {
+    cur = cur.parent;
+  }
+  return cur ? sourceCode.getText(cur) : sourceCode.getText();
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a raw count-delta comparison (subtraction/relational) on a failure-count-lexicon identifier without a nearby identity-set diff — gates on WHICH identities changed, not a raw count',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/rickfelix/EHG_Engineer/blob/main/eslint-rules/no-count-delta-gate-assertion.js',
+    },
+    messages: {
+      noCountDeltaGate:
+        'Raw count-delta comparison on "{{name}}" without a nearby identity-set diff (new Set/.has/computeIdentityRegression/extractFailingIds) — false-positives on unrelated flaky/CI-secret/shared-DB-drift noise. ' +
+        'Use lib/gates/identity-diff-gate.cjs computeIdentityRegression(currentIds, priorFailingIds) instead. ' +
+        'To override: // eslint-disable-next-line no-count-delta-gate-assertion -- <reason>',
+      pragmaMissingReason:
+        'eslint-disable-next-line no-count-delta-gate-assertion requires a non-empty REASON after `--`. ' +
+        'Example: // eslint-disable-next-line no-count-delta-gate-assertion -- absolute hard-cap check, no main-vs-PR delta semantics',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    const pragmaHandled = new Set();
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments();
+        for (const comment of comments) {
+          if (comment.type !== 'Line' && comment.type !== 'Block') continue;
+          const verdict = classifyPragma(comment.value);
+          if (!verdict.targets) continue;
+
+          pragmaHandled.add(comment.range && comment.range[0]);
+
+          if (!verdict.hasMarker) {
+            context.report({ loc: comment.loc, messageId: 'noCountDeltaGate', data: { name: 'count' } });
+          } else if (verdict.reason.length === 0) {
+            context.report({ loc: comment.loc, messageId: 'pragmaMissingReason' });
+          }
+        }
+      },
+
+      BinaryExpression(node) {
+        if (!DELTA_OPERATORS.has(node.operator)) return;
+        const leftMatch = referencesCountLexicon(node.left);
+        const rightMatch = referencesCountLexicon(node.right);
+        if (!leftMatch && !rightMatch) return;
+
+        // A relational comparison (not subtraction) against an absolute threshold — a numeric
+        // literal or an ALL_CAPS constant — is an existence/cap check, not a main-vs-PR delta.
+        // Subtraction ('-') is always the delta anti-pattern regardless of the other operand.
+        if (node.operator !== '-') {
+          const otherOperand = leftMatch ? node.right : node.left;
+          if (isAbsoluteThresholdOperand(otherOperand)) return;
+        }
+
+        const scopeText = enclosingScopeText(node, sourceCode);
+        if (IDENTITY_MARKERS.some((re) => re.test(scopeText))) return;
+
+        const above = getDisablePragmaCommentAbove(sourceCode, node);
+        if (above && pragmaHandled.has(above.range && above.range[0])) return;
+
+        const name = leftMatch
+          ? (node.left.type === 'Identifier' ? node.left.name : node.left.property.name)
+          : (node.right.type === 'Identifier' ? node.right.name : node.right.property.name);
+
+        context.report({ node, messageId: 'noCountDeltaGate', data: { name } });
+      },
+    };
+  },
+};

--- a/lib/gates/identity-diff-gate.cjs
+++ b/lib/gates/identity-diff-gate.cjs
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Shared identity-diff comparator — SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001.
+ *
+ * Class-guards the recurring "count-delta gate" anti-pattern: a gate that flags on a raw
+ * numeric delta (e.g. "failures rose 105 -> 107") rather than checking WHICH specific
+ * identities changed. A count-delta gate false-positives on unrelated flaky / CI-secret /
+ * shared-DB-drift noise — the SAME test set can produce a higher count on a re-run with no
+ * change under test. Instances already confirmed: scripts/ci/red-merge-detector.mjs,
+ * scripts/compare-to-main-snapshot.mjs (BASELINE_REGRESSION), scripts/hooks/compare-test-baseline.cjs.
+ *
+ * Shaped as a DROP-IN SUPERSET of QF-20260701-833's inline primitive (compare-to-main-snapshot.mjs,
+ * unmerged branch qf/QF-20260701-833) so that gate and red-merge-detector.mjs can adopt this shared
+ * module later with zero behavior change, instead of drifting as separate reimplementations.
+ */
+
+/**
+ * PURE. Decide whether a regression occurred, comparing the SET of currently-failing identities
+ * against the SET of identities that were already failing at the baseline — not the raw counts.
+ * Only identities present in currentIds but ABSENT from priorFailingIds are a genuine regression.
+ *
+ * Falls back to a count-only comparison ONLY when priorFailingIds is unavailable (a base snapshot
+ * predating identity capture) — the same graceful-degradation QF-833 uses, so an older baseline
+ * never silently stops being checked.
+ *
+ * @param {string[]} currentIds - failing identities on the current run (see extractFailingIds)
+ * @param {string[]|null|undefined} priorFailingIds - failing identities recorded at the baseline
+ * @param {{failed?:number, priorFailedCount?:number}} [counts] - only used for the fallback mode
+ * @returns {{regression:boolean, newIds:string[], mode:'identity'|'count_fallback'}}
+ */
+function computeIdentityRegression(currentIds, priorFailingIds, counts = {}) {
+  const current = Array.isArray(currentIds) ? currentIds : [];
+  if (!Array.isArray(priorFailingIds)) {
+    const failed = Number.isFinite(counts.failed) ? counts.failed : current.length;
+    const priorFailedCount = Number.isFinite(counts.priorFailedCount) ? counts.priorFailedCount : 0;
+    const regression = failed > priorFailedCount;
+    return { regression, newIds: regression ? current : [], mode: 'count_fallback' };
+  }
+  const priorSet = new Set(priorFailingIds);
+  const newIds = current.filter((id) => !priorSet.has(id));
+  return { regression: newIds.length > 0, newIds, mode: 'identity' };
+}
+
+/**
+ * PURE. Walks a vitest JSON report's testResults[].assertionResults[] and returns a stable
+ * file::fullName identity per failing test. Matches QF-20260701-833's extractFailingIds shape.
+ * @param {object} raw - a parsed vitest --reporter=json output object
+ * @returns {string[]}
+ */
+function extractFailingIds(raw) {
+  const testResults = (raw && Array.isArray(raw.testResults)) ? raw.testResults : [];
+  const ids = [];
+  for (const file of testResults) {
+    const assertions = Array.isArray(file.assertionResults) ? file.assertionResults : [];
+    for (const a of assertions) {
+      if (a.status !== 'failed') continue;
+      const filePath = file.name || file.file || '';
+      const fullName = a.fullName || a.title || '';
+      ids.push(`${filePath}::${fullName}`);
+    }
+  }
+  return ids;
+}
+
+/**
+ * PURE. The diff-reachability half QF-833 does NOT implement: narrows newIds to only those
+ * whose file:: prefix is present in changedFiles — a genuinely new failure that isn't even in a
+ * file the current diff touches is very unlikely to be caused by the change under test.
+ * @param {string[]} newIds - identities from computeIdentityRegression's newIds
+ * @param {string[]} changedFiles - file paths touched by the current diff
+ * @returns {string[]}
+ */
+function filterReachable(newIds, changedFiles) {
+  const ids = Array.isArray(newIds) ? newIds : [];
+  const changed = new Set(Array.isArray(changedFiles) ? changedFiles : []);
+  if (changed.size === 0) return ids;
+  return ids.filter((id) => {
+    const filePath = id.split('::')[0];
+    return changed.has(filePath);
+  });
+}
+
+module.exports = { computeIdentityRegression, extractFailingIds, filterReachable };

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "lint:alter-defaults": "node scripts/lint/alter-default-override-lint.mjs",
     "lint:venture-artifacts": "node scripts/lint/venture-artifacts-write-lint.mjs",
     "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
+    "lint:count-delta-gate": "node scripts/lint/count-delta-gate-lint.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",

--- a/scripts/hooks/capture-baseline-test-state.cjs
+++ b/scripts/hooks/capture-baseline-test-state.cjs
@@ -17,6 +17,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execSync } = require('child_process');
+// SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 (FR-2): capture WHICH tests failed, not just
+// how many, so compare-test-baseline.cjs can diff identities instead of a raw count delta.
+const { extractFailingIds } = require('../../lib/gates/identity-diff-gate.cjs');
 
 const SESSION_STATE_FILE = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
 const ENGINEER_DIR = '.';
@@ -92,6 +95,9 @@ function captureUnitTestState(workingDir, testScript = 'test') {
       total: json.numTotalTests ?? 0,
       test_files_failed: json.numFailedTestSuites ?? 0,
       project: testScript,
+      // FR-2: additive alongside the existing counts (backward-compatible) — the identity set
+      // compare-test-baseline.cjs diffs against, instead of a raw failed-count subtraction.
+      failing_ids: extractFailingIds(json),
     };
   } catch (error) {
     try { fs.unlinkSync(outFile); } catch { /* best-effort cleanup */ }

--- a/scripts/hooks/compare-test-baseline.cjs
+++ b/scripts/hooks/compare-test-baseline.cjs
@@ -24,6 +24,9 @@ const path = require('path');
 // since the local gate's skip-awareness can't run until the module loads.
 const { captureBaseline, captureUnitTestState, captureTypeCheckState } = require('./capture-baseline-test-state.cjs');
 const { skipDriftStatus } = require('../lib/skip-drift.cjs');
+// SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 (FR-2): identity-set diff instead of a raw
+// failed-count subtraction — a count rise from the SAME flaky identities is not a regression.
+const { computeIdentityRegression } = require('../../lib/gates/identity-diff-gate.cjs');
 
 const SESSION_STATE_FILE = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
 
@@ -65,10 +68,18 @@ function compareTestCounts(baseline, current, label) {
     status: 'UNKNOWN'
   };
 
-  result.new_failures = Math.max(0, result.current_failed - result.baseline_failed);
+  // FR-2: identity-set diff (which specific tests are newly failing), not a raw count subtraction
+  // — the same flaky identities repeating across runs must never read as a regression.
+  const idResult = computeIdentityRegression(current?.failing_ids, baseline?.failing_ids, {
+    failed: result.current_failed,
+    priorFailedCount: result.baseline_failed,
+  });
+  result.new_failures = idResult.newIds.length;
+  result.new_failing_ids = idResult.newIds;
+  result.regression_mode = idResult.mode;
   result.fixed = Math.max(0, result.baseline_failed - result.current_failed);
 
-  if (result.new_failures > 0) {
+  if (idResult.regression) {
     result.status = 'REGRESSION';
   } else if (result.fixed > 0) {
     result.status = 'IMPROVED';
@@ -216,6 +227,9 @@ function printReport(report) {
 
     if (comparison.new_failures > 0) {
       console.log(`   NEW FAILURES: ${comparison.new_failures}`);
+      if (Array.isArray(comparison.new_failing_ids)) {
+        for (const id of comparison.new_failing_ids) console.log(`     - ${id}`);
+      }
     }
     if (comparison.new_errors > 0) {
       console.log(`   NEW ERRORS: ${comparison.new_errors}`);

--- a/scripts/lint/count-delta-gate-lint.mjs
+++ b/scripts/lint/count-delta-gate-lint.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Count-Delta Gate Assertion Lint
+ * SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 FR-4 / FR-5
+ *
+ * Scans scripts/ci/**, scripts/hooks/**, scripts/modules/** for the proven, recurring
+ * false-positive class: a gate flagging on a raw failure-COUNT delta (e.g. "failures rose
+ * 105 -> 107") rather than an identity-set diff of WHICH tests/files changed. Reuses the SAME
+ * detection logic as eslint-rules/no-count-delta-gate-assertion.js (via ESLint's Linter API) so
+ * there is exactly one implementation of the anti-pattern shape, not a second grep/regex
+ * detector that could drift out of sync.
+ *
+ * Usage:
+ *   node scripts/lint/count-delta-gate-lint.mjs [--json] [--root <dir>]
+ *   npm run lint:count-delta-gate
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Linter } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import rule from '../../eslint-rules/no-count-delta-gate-assertion.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const SCAN_DIRS = ['scripts/ci', 'scripts/hooks', 'scripts/modules'];
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx']);
+const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage'];
+const EXCLUDE_FILE_RE = /(\.test\.|\.spec\.|\.d\.ts$|\.min\.js$)/i;
+
+const RULE_ID = 'count-delta-gate/no-count-delta-gate-assertion';
+
+const FLAT_CONFIG = {
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: {
+      console: 'readonly', process: 'readonly', require: 'readonly', module: 'readonly',
+      exports: 'readonly', __dirname: 'readonly', __filename: 'readonly', Buffer: 'readonly',
+      setTimeout: 'readonly', setInterval: 'readonly', clearTimeout: 'readonly', clearInterval: 'readonly',
+    },
+  },
+  plugins: {
+    'count-delta-gate': { rules: { 'no-count-delta-gate-assertion': rule } },
+  },
+  rules: {
+    [RULE_ID]: 'error',
+  },
+};
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (EXCLUDE_DIR_SEGMENTS.includes(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name)) && !EXCLUDE_FILE_RE.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+function lintFile(linter, absPath) {
+  const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+  let code;
+  try {
+    code = fs.readFileSync(absPath, 'utf8');
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Could not read file: ${err.message}` }];
+  }
+  const isTypeScript = path.extname(absPath) === '.ts' || path.extname(absPath) === '.tsx';
+  const config = {
+    ...FLAT_CONFIG,
+    languageOptions: {
+      ...FLAT_CONFIG.languageOptions,
+      ...(isTypeScript ? { parser: typescriptParser } : {}),
+    },
+  };
+  let messages;
+  try {
+    messages = linter.verify(code, config, { filename: absPath });
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Parse error: ${err.message}` }];
+  }
+  return messages
+    .filter((m) => m.ruleId === RULE_ID)
+    .map((m) => ({ filePath: relPath, line: m.line, column: m.column, message: m.message }));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const rootIdx = args.indexOf('--root');
+  const scanRoot = rootIdx !== -1 && args[rootIdx + 1] ? path.resolve(args[rootIdx + 1]) : REPO_ROOT;
+
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(scanRoot, dir), files);
+  }
+
+  // Flat-config ESLint requires an explicit cwd to resolve absolute filenames passed to
+  // verify() — see the sibling realtime-subscribe-teardown-recursion-lint.mjs for the empirical
+  // basis of this requirement.
+  const linter = new Linter({ cwd: scanRoot });
+  const violations = files.flatMap((f) => lintFile(linter, f));
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ scanned: files.length, violations }, null, 2));
+  } else if (violations.length === 0) {
+    console.log(`✅ count-delta-gate-lint: 0 violations across ${files.length} file(s) scanned (scripts/ci/**, scripts/hooks/**, scripts/modules/**)`);
+  } else {
+    console.error(`❌ count-delta-gate-lint: ${violations.length} violation(s) across ${files.length} file(s) scanned\n`);
+    for (const v of violations) {
+      console.error(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+    }
+    console.error('\nFix: use lib/gates/identity-diff-gate.cjs computeIdentityRegression(currentIds, priorFailingIds) — a SET diff of failing identities, not a raw count comparison.');
+  }
+
+  process.exit(violations.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/modules/qa/test-output-parser.js
+++ b/scripts/modules/qa/test-output-parser.js
@@ -158,6 +158,7 @@ export function parsePlaywrightOutput(output) {
       if (results.failures.length === 0) {
         const simpleFailRegex = /Error:\s*(.+?)(?:\n|$)/g;
         let errorCount = 0;
+        // eslint-disable-next-line no-count-delta-gate-assertion -- parsing-loop bound, not a regression gate
         while ((match = simpleFailRegex.exec(output)) !== null && errorCount < results.failed) {
           results.failures.push({
             error_message: match[1].trim().substring(0, 200)

--- a/scripts/one-off/insert-retro-count-vs-identity-gate-classguard-001.cjs
+++ b/scripts/one-off/insert-retro-count-vs-identity-gate-classguard-001.cjs
@@ -1,0 +1,128 @@
+// @wire-check-exempt
+// One-off SD-completion retrospective insert for
+// SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001.
+//
+// Written directly (not via generate-comprehensive-retrospective.js) because that
+// script's analyzeHandoffs() looks up sd_phase_handoffs by sd.sd_key (string) but
+// rows store sd_id as a UUID -- the lookup 0-matches and produces boilerplate-only
+// content (already flagged 4x this session, feedback id
+// 5fe083a2-f6b3-480d-837e-ad59961761a2). See scripts/modules/handoff/retro-filters.js
+// for the retro_type/retrospective_type/created_at filter invariants this row must
+// satisfy (getFilteredRetrospective) -- mirrors the pattern used in
+// insert-retro-adaptive-comms-cadence-001.cjs and
+// insert-retro-comms-presence-grounding-signals-001.cjs.
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const SD_UUID = 'e0d589d2-9a63-4b77-b195-c3a84e62e2e7';
+const SD_KEY = 'SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001';
+
+(async () => {
+  const row = {
+    sd_id: SD_UUID,
+    target_application: 'EHG_Engineer',
+    learning_category: 'PROCESS_IMPROVEMENT',
+    retro_type: 'SD_COMPLETION',
+    // retrospective_type left NULL (canonical generate-retrospective.js convention) --
+    // handoff-time retros tag this with a PHASE (this SD already has one:
+    // retro_type='HANDOFF', retrospective_type='LEAD_TO_PLAN'), so NULL here plus
+    // retro_type='SD_COMPLETION' cleanly distinguishes this as the genuine
+    // completion retro per getFilteredRetrospective's OR filter.
+    retrospective_type: null,
+    project_name: 'Class-guard the COUNT-based-should-be-IDENTITY-based gate anti-pattern',
+    title: 'SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 — identity-set diff gate + lint guard against count-delta gate assertions',
+    description: 'A gate that flags on a raw failure-COUNT delta (e.g. "failures rose 105->107") false-positives on unrelated flaky/CI-secret/shared-DB-drift noise unrelated to the change under test -- 2 confirmed real-world instances (scripts/ci/red-merge-detector.mjs, scripts/compare-to-main-snapshot.mjs BASELINE_REGRESSION, the latter having false-blocked PR #5330). This SD is the CLASS-GUARD (not a per-instance fix), mirroring the shipped sibling SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001\'s exact shape: (1) a reusable identity-diff primitive, (2) convert the one genuinely-in-scope live gate to identity-based, (3) a name-anchored ESLint rule banning the anti-pattern going forward, (4) a blocking CI lint workflow, (5) an audit doc distinguishing the flagged class from adjacent classes that must NOT be flagged. Built: NEW lib/gates/identity-diff-gate.cjs (computeIdentityRegression: a SET diff of failing identities rather than a raw count subtraction, flags only identities present in current-failing but absent from baseline-failing; extractFailingIds parses vitest JSON into file::fullName identities; filterReachable is the diff-reachability half) shaped as a drop-in superset of QF-20260701-833\'s inline primitive (which independently prototyped the same identity-diff conversion for compare-to-main-snapshot.mjs and has since merged to main as commit 6f1c74a81c) so the two deliberately-deferred instances can adopt the shared module later with zero behavior change. Converted scripts/hooks/compare-test-baseline.cjs to identity-based -- a genuinely-discovered 3rd count-delta instance found via an Explore sweep during PLAN, confirmed by LEAD-phase VALIDATION as not already carved out by any other in-flight fix -- additive/backward-compatible (all legacy fields preserved, new_failures now derived from the identity-set diff instead of a raw subtraction); scripts/hooks/capture-baseline-test-state.cjs additively captures failing_ids alongside existing counts. NEW name-anchored ESLint rule eslint-rules/no-count-delta-gate-assertion.js, NEW scripts/lint/count-delta-gate-lint.mjs production scanner (reuses the rule via ESLint\'s Linter API) + NEW .github/workflows/count-delta-gate-lint.yml (genuinely blocking, mirrors the sibling class-guard\'s exact posture since npm run lint is never invoked by any CI workflow in this repo) + package.json lint:count-delta-gate script. Audit doc added to docs/reference/infrastructure-hardening-patterns.md (v1.1.0->1.2.0) -- a 6-row table separating GATE-THAT-FLAGS (compare-test-baseline.cjs converted; compare-to-main-snapshot.mjs and red-merge-detector.mjs deliberately deferred with a named follow-up consolidation item) from COUNT-READER and ABSOLUTE-THRESHOLD classes (explicitly NOT flagged, would create noise) and contrastive already-identity-scoped examples (row-growth-snapshot.cjs, ci-recurrence-detector.mjs). 29 new/updated unit tests across 3 test files (identity-diff-gate.test.js, compare-test-baseline-identity.test.js, no-count-delta-gate-assertion.test.js), all passing, zero regressions. Net commit 533baef941, branch feat/SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001.',
+    affected_components: [
+      'lib/gates/identity-diff-gate.cjs',
+      'scripts/hooks/compare-test-baseline.cjs',
+      'scripts/hooks/capture-baseline-test-state.cjs',
+      'eslint-rules/no-count-delta-gate-assertion.js',
+      'scripts/lint/count-delta-gate-lint.mjs',
+      '.github/workflows/count-delta-gate-lint.yml',
+      'docs/reference/infrastructure-hardening-patterns.md'
+    ],
+    what_went_well: [
+      'Shaping computeIdentityRegression(currentIds, priorFailingIds) as a deliberate drop-in superset of QF-20260701-833\'s already-merged inline primitive (commit 6f1c74a81c) means the two deliberately-deferred instances (red-merge-detector.mjs, compare-to-main-snapshot.mjs) can adopt the shared module later with zero behavior change -- avoids a second, subtly-different identity-diff implementation drifting from the one QF already proved out in production.',
+      'Keeping scripts/hooks/compare-test-baseline.cjs\'s conversion strictly additive/backward-compatible (all legacy fields -- baseline_failed, current_failed, new_failures, fixed, status -- preserved on the return shape, new_failures now DERIVED from the identity-set diff instead of a raw subtraction) meant REGRESSION sub-agent could verify zero behavior change for every existing consumer of the hook without needing to audit every call site.',
+      'LEAD-phase VALIDATION caught two real risks BEFORE EXEC started: it required the identity-diff primitive be name-anchored/superset-shaped for QF-833 consolidation (not a second independent implementation), and it confirmed compare-test-baseline.cjs was a genuinely new 3rd instance rather than something another in-flight branch was already touching -- both corrections were incorporated pre-build, avoiding rework.',
+      'Building the audit doc as an explicit 6-row table that separates the flagged class (GATE-THAT-FLAGS on a raw count delta) from two adjacent classes that must NOT be flagged (COUNT-READER: just reports a number; ABSOLUTE-THRESHOLD: compares against a fixed cap, not a delta) turned what could have been a vague "count math is bad" rule into a precise, defensible boundary -- directly informed the ESLint rule\'s exclusion logic.'
+    ],
+    what_needs_improvement: [
+      'The initial general count-comparison AST match in eslint-rules/no-count-delta-gate-assertion.js produced 9 false positives when run against the real repo (scripts/modules/auto-trigger-stories.mjs, test-runner.js, failure-pattern-capture.js, test-output-parser.js) -- all were existence checks (failed > 0) or absolute-cap checks (< MIN_FAILURES_FOR_PATTERN), exactly the COUNT-READER/ABSOLUTE-THRESHOLD classes LEAD-phase VALIDATION had predicted as out-of-scope noise. Fixed by excluding relational comparisons against a numeric literal or an ALL_CAPS constant identifier, bringing false positives to zero across a 690-file scan. Lesson: a "ban this pattern" AST rule needs its exclusion set derived from a real full-repo dry run, not just the motivating examples, before it can be trusted as a blocking gate.',
+      'A second bug surfaced during pragma-testing: the pragma-comment detector in the ESLint rule only checked comments immediately preceding the flagged AST node, but a comment placed above a `while` statement does not directly precede the BinaryExpression nested deep inside the loop\'s condition -- the token immediately preceding the flagged node is `&&`, not the comment. Fixed by walking up to the nearest enclosing STATEMENT first, then checking for the pragma comment there. Lesson: pragma-suppression comment lookups in custom ESLint rules must anchor on the nearest enclosing statement, not the specific flagged sub-expression node, or legitimate suppressions silently fail to apply on nested conditions.',
+      'Two of the three known count-delta gate instances (scripts/ci/red-merge-detector.mjs and scripts/compare-to-main-snapshot.mjs -- the latter the one that actually false-blocked PR #5330) remain deliberately UNCONVERTED in this SD, tracked only as a named follow-up in the audit doc. The class-guard (lint rule + CI workflow) now prevents NEW instances, but the two known offenders that motivated the SD keep running count-delta logic until a follow-up SD lands the conversion using the shared identity-diff-gate.cjs module.',
+      'REGRESSION flagged one non-blocking transitional gap: a stale pre-SD baseline lacking failing_ids falls back to count-only comparison in compare-test-baseline.cjs, so the identity-based behavior only fully activates once a fresh baseline (captured via the additively-updated capture-baseline-test-state.cjs) has run at least once -- self-resolving, but worth noting for anyone debugging why an immediate post-merge comparison still looks count-based.'
+    ],
+    action_items: [
+      { item: 'Convert scripts/compare-to-main-snapshot.mjs (BASELINE_REGRESSION check that false-blocked PR #5330) to use lib/gates/identity-diff-gate.cjs, consolidating with QF-20260701-833\'s already-merged inline primitive (commit 6f1c74a81c) rather than maintaining two separate identity-diff implementations', owner: 'TBD', priority: 'high' },
+      { item: 'Convert scripts/ci/red-merge-detector.mjs to use lib/gates/identity-diff-gate.cjs -- the second of the two deliberately-deferred instances named in the audit doc', owner: 'TBD', priority: 'medium' },
+      { item: 'Re-run the eslint-rules/no-count-delta-gate-assertion.js dry run periodically (e.g. quarterly or on major scripts/ additions) since the false-positive exclusion set (numeric-literal / ALL_CAPS-constant comparisons) was tuned against a single point-in-time 690-file scan and new count-reader/absolute-threshold code could reintroduce false positives as the codebase grows', owner: 'TBD', priority: 'low' },
+      { item: 'When writing a future custom ESLint rule with pragma-comment suppression, default to anchoring the comment lookup on the nearest enclosing STATEMENT (not the flagged sub-expression) from the start, based on the walk-up fix required here', owner: 'protocol/EXEC', priority: 'low' }
+    ],
+    key_learnings: [
+      'A "ban this pattern" custom AST lint rule needs its false-positive exclusion set derived from a full-repo dry run against the REAL codebase, not just the motivating examples -- the initial general count-comparison match in no-count-delta-gate-assertion.js flagged 9 false positives (existence checks like `failed > 0`, absolute-cap checks like `< MIN_FAILURES_FOR_PATTERN`) that were exactly the COUNT-READER/ABSOLUTE-THRESHOLD classes the audit doc had already named as out-of-scope. The fix (exclude relational comparisons against a numeric literal or an ALL_CAPS constant identifier) took the false-positive count from 9 to 0 across 690 scanned files -- a class-guard rule is only trustworthy as a BLOCKING CI gate once it has been proven against the actual repo, not just unit-test fixtures.',
+      'Pragma-suppression comment lookups in custom ESLint rules must walk up to the nearest enclosing STATEMENT before checking for a preceding comment, not check immediately before the specific flagged AST node -- a comment placed above a `while` statement does not directly precede a BinaryExpression nested inside the loop\'s condition (the immediately-preceding token is `&&`, not the comment), so a naive "check the token right before this node" pragma detector silently fails to honor legitimate suppressions on nested conditions.',
+      'Shaping a new shared primitive (computeIdentityRegression) as a deliberate drop-in SUPERSET of an already-merged, independently-prototyped inline implementation (QF-20260701-833\'s conversion for compare-to-main-snapshot.mjs, commit 6f1c74a81c) rather than building a second competing identity-diff implementation is the right sequencing when a QF and an SD converge on the same fix shape -- it lets the QF\'s proven-in-production logic and the SD\'s reusable module consolidate later with zero behavior change, instead of the codebase accumulating two subtly different identity-diff comparators.',
+      'A class-guard SD (lint rule + blocking CI workflow) can ship fully and correctly WITHOUT converting every known instance of the anti-pattern it targets -- this SD prevents new count-delta gate assertions from entering the codebase while deliberately deferring the two instances that motivated it (red-merge-detector.mjs, compare-to-main-snapshot.mjs) to a named follow-up, because converting live production gates carries its own regression risk that shouldn\'t block the guardrail from landing. The guardrail and the cleanup are separable deliverables.',
+      'Since npm run lint is never invoked by any CI workflow in this repo, a genuinely blocking lint guard for a new anti-pattern rule requires its OWN dedicated GitHub Actions workflow (not just adding the rule to .eslintrc and assuming it runs) -- mirrored exactly from the sibling class-guard SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001\'s posture, confirming this is now the established pattern for shipping a lint-based class-guard in this repo.'
+    ],
+    quality_score: 90,
+    status: 'PUBLISHED',
+    generated_by: 'MANUAL',
+    conducted_date: new Date().toISOString().slice(0, 10),
+    agents_involved: ['LEAD', 'PLAN', 'EXEC'],
+    sub_agents_involved: ['VALIDATION', 'REGRESSION'],
+    related_files: [
+      'lib/gates/identity-diff-gate.cjs',
+      'scripts/hooks/compare-test-baseline.cjs',
+      'scripts/hooks/capture-baseline-test-state.cjs',
+      'eslint-rules/no-count-delta-gate-assertion.js',
+      'scripts/lint/count-delta-gate-lint.mjs',
+      '.github/workflows/count-delta-gate-lint.yml',
+      'docs/reference/infrastructure-hardening-patterns.md',
+      'tests/unit/gates/identity-diff-gate.test.js',
+      'tests/unit/hooks/compare-test-baseline-identity.test.js',
+      'tests/unit/eslint-rules/no-count-delta-gate-assertion.test.js'
+    ],
+    related_commits: ['533baef941'],
+    business_value_delivered: 'Stops gates from false-blocking PRs and false-filing QFs on unrelated count-drift noise (flaky tests, CI-secret rotation, shared-DB drift) by converting raw failure-COUNT delta assertions to identity-set diffs that only flag genuinely new failing identities. Directly targets the exact class of defect that false-blocked PR #5330 via compare-to-main-snapshot.mjs BASELINE_REGRESSION, and installs a permanent, CI-enforced lint guard (0 violations across 690 files) so the anti-pattern cannot silently re-enter the codebase going forward, mirroring the shipped sibling class-guard SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001.',
+    on_schedule: true,
+    within_scope: true,
+    objectives_met: true,
+    metadata: {
+      sd_key: SD_KEY,
+      target_application: 'EHG_Engineer',
+      sd_type: 'infrastructure',
+      commit_sha: '533baef941',
+      branch: 'feat/SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001',
+      worktree_path: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001',
+      sibling_sd: 'SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001',
+      related_qf: 'QF-20260701-833 (independently prototyped identity-diff conversion for compare-to-main-snapshot.mjs; merged to main as commit 6f1c74a81c; computeIdentityRegression built as a drop-in superset)',
+      false_block_evidence: 'scripts/compare-to-main-snapshot.mjs BASELINE_REGRESSION false-blocked PR #5330 on unrelated count-drift noise',
+      test_results: {
+        new_tests: 29,
+        test_files: [
+          'identity-diff-gate.test.js',
+          'compare-test-baseline-identity.test.js',
+          'no-count-delta-gate-assertion.test.js'
+        ],
+        lint_scan: '0 violations across 690 scanned files (initial general match had 9 false positives, fixed by excluding relational comparisons against a numeric literal or ALL_CAPS constant identifier)'
+      },
+      sub_agent_verdicts: {
+        LEAD_VALIDATION: { verdict: 'CONDITIONAL_PASS', confidence: 0.88, notes: 'Confirmed no duplicate comparator existed pre-build; confirmed compare-test-baseline.cjs not already covered by any other in-flight branch; REQUIRED name-anchoring correction (not general count-comparison match) and REQUIRED computeIdentityRegression be shaped as a drop-in superset of QF-833\'s signature -- both incorporated before EXEC started.' },
+        EXEC_VALIDATION: { verdict: 'PASS', confidence: 0.95, notes: 'All 7 FRs traced to file:line; confirmed red-merge-detector.mjs and compare-to-main-snapshot.mjs genuinely untouched (deliberately deferred); confirmed the lint rule is truly name-anchored; confirmed 0 violations across 690 scanned files; confirmed no duplicate comparator introduced.' },
+        REGRESSION: { verdict: 'PASS', confidence: null, notes: 'Confirmed backward-compatible return shapes on both modified hooks; confirmed the test-output-parser.js change is comment-only; confirmed no package.json/workflow-name collisions; noted one non-blocking transitional observation -- a stale pre-SD baseline lacking failing_ids falls back to count-only comparison, self-resolving once a fresh baseline is captured.' }
+      },
+      known_gap: 'The two known count-delta instances that motivated this SD (scripts/ci/red-merge-detector.mjs, scripts/compare-to-main-snapshot.mjs) remain unconverted, deliberately deferred with a named follow-up in docs/reference/infrastructure-hardening-patterns.md -- the class-guard (lint rule + CI workflow) prevents new instances but does not retroactively fix the two known offenders.'
+    }
+  };
+
+  const { data, error } = await supabase
+    .from('retrospectives')
+    .insert(row)
+    .select('id, sd_id, retro_type, retrospective_type, quality_score, status, created_at')
+    .single();
+  if (error) { console.error('INS_ERR:', error); process.exit(1); }
+  console.log('INSERTED retro:', JSON.stringify(data, null, 2));
+})();

--- a/tests/unit/eslint-rules/no-count-delta-gate-assertion.test.js
+++ b/tests/unit/eslint-rules/no-count-delta-gate-assertion.test.js
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for ESLint rule `no-count-delta-gate-assertion`.
+ *
+ * SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 FR-4/FR-6.
+ *
+ * Covers: correct pattern (identity-set diff nearby — computeIdentityRegression/new Set/.has),
+ * the anti-pattern (raw subtraction/relational comparison on a failure-count-lexicon name with
+ * no nearby identity-set op), each failure-count-lexicon variable name, and the escape-hatch
+ * pragma contract (mirrors no-realtime-teardown-in-subscribe-callback.js).
+ *
+ * @module tests/unit/eslint-rules/no-count-delta-gate-assertion.test.js
+ */
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../../../eslint-rules/no-count-delta-gate-assertion.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const RULE_ID = 'rule-to-test/no-count-delta-gate-assertion';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-count-delta-gate-assertion', rule, {
+  valid: [
+    // TS-1: the converted compare-test-baseline.cjs pattern — computeIdentityRegression nearby.
+    {
+      code: `
+        function compareTestCounts(baseline, current) {
+          const idResult = computeIdentityRegression(current.failing_ids, baseline.failing_ids, {
+            failed: current.failed,
+            priorFailedCount: baseline.failed,
+          });
+          return idResult.regression;
+        }
+      `,
+    },
+    // TS-2: row-growth-snapshot.cjs-style table-scoped comparison — no failure-count lexicon name.
+    {
+      code: `
+        function detectRowGrowthAnomalies(prevRaw, currRaw) {
+          const delta = currRaw - prevRaw;
+          return delta >= absSpike;
+        }
+      `,
+    },
+    // TS-3: an identity-set diff via new Set()/.has() elsewhere in the same function.
+    {
+      code: `
+        function check(current_failed, baseline_failed, currentIds, priorIds) {
+          const priorSet = new Set(priorIds);
+          const newIds = currentIds.filter((id) => !priorSet.has(id));
+          const rose = current_failed > baseline_failed;
+          return newIds.length > 0;
+        }
+      `,
+    },
+    // TS-4: an ordinary, unrelated numeric threshold check (not a failure-count lexicon name).
+    {
+      code: `
+        function checkPassRate(passRate, threshold) {
+          return passRate < threshold;
+        }
+      `,
+    },
+    // TS-4b: an existence check (count > 0) — not a main-vs-PR delta, just "are there any".
+    {
+      code: `
+        function report(failed) {
+          if (failed > 0) { console.log('has failures'); }
+        }
+      `,
+    },
+    // TS-4c: an absolute-cap check against an ALL_CAPS constant, not a baseline/prior count.
+    {
+      code: `
+        const MIN_FAILURES_FOR_PATTERN = 3;
+        function shouldCreatePattern(failureCount) {
+          return failureCount < MIN_FAILURES_FOR_PATTERN;
+        }
+      `,
+    },
+    // Pragma present with a non-empty reason.
+    {
+      code: `
+        function absoluteCap(failed_count) {
+          // eslint-disable-next-line ${RULE_ID} -- absolute hard cap, no main-vs-PR delta semantics
+          return failed_count > 100;
+        }
+      `,
+    },
+    // TS-10: pragma above a WHILE statement whose comparison is nested deep inside the condition
+    // (right operand of &&) — the pragma detector must walk up to the enclosing statement, not
+    // just check the immediately-preceding token of the nested BinaryExpression itself.
+    {
+      code: `
+        function parse(errorCount, results, match) {
+          // eslint-disable-next-line ${RULE_ID} -- parsing-loop bound, not a regression gate
+          while (match !== null && errorCount < results.failed) {
+            errorCount++;
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // TS-5: the pre-conversion compare-test-baseline.cjs pattern — raw subtraction, no identity op.
+    {
+      code: `
+        function compareTestCounts(baseline, current) {
+          const new_failures = Math.max(0, current.current_failed - baseline.baseline_failed);
+          return new_failures;
+        }
+      `,
+      errors: [{ messageId: 'noCountDeltaGate' }],
+    },
+    // TS-6: relational comparison on numFailedTests.
+    {
+      code: `
+        function decide(numFailedTests, priorFailedCount) {
+          return numFailedTests > priorFailedCount;
+        }
+      `,
+      errors: [{ messageId: 'noCountDeltaGate' }],
+    },
+    // TS-7: each failure-count-lexicon variable name, one violation each.
+    {
+      code: `function a(failed_count, x) { return failed_count > x; }`,
+      errors: [{ messageId: 'noCountDeltaGate' }],
+    },
+    {
+      code: `function b(x, new_failures) { return x >= new_failures; }`,
+      errors: [{ messageId: 'noCountDeltaGate' }],
+    },
+    // TS-8: pragma present but missing the `--` REASON marker entirely (no marker at all is
+    // treated the same as no pragma — the violation still reports, mirroring the sibling rule).
+    {
+      code: `
+        function decide(failed_count, x) {
+          // eslint-disable-next-line ${RULE_ID}
+          return failed_count - x;
+        }
+      `,
+      errors: [{ messageId: 'noCountDeltaGate' }],
+    },
+    // TS-9: pragma present with a whitespace-only (effectively empty) reason after `--`.
+    {
+      code: `
+        function decide(failed_count, x) {
+          // eslint-disable-next-line ${RULE_ID} --   \n          return failed_count - x;
+        }
+      `,
+      errors: [{ messageId: 'pragmaMissingReason' }],
+    },
+  ],
+});

--- a/tests/unit/gates/identity-diff-gate.test.js
+++ b/tests/unit/gates/identity-diff-gate.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 — lib/gates/identity-diff-gate.cjs.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { computeIdentityRegression, extractFailingIds, filterReachable } = require('../../../lib/gates/identity-diff-gate.cjs');
+
+describe('computeIdentityRegression', () => {
+  it('does NOT flag when the raw count rises but failing identities are identical to baseline', () => {
+    // The shared-flake false-positive class: same test flakes on both runs, count is the same,
+    // but any FRESH run could re-order/re-count depending on retries — identity is what matters.
+    const prior = ['a.test.js::flaky test'];
+    const current = ['a.test.js::flaky test'];
+    const r = computeIdentityRegression(current, prior);
+    expect(r.regression).toBe(false);
+    expect(r.newIds).toEqual([]);
+    expect(r.mode).toBe('identity');
+  });
+
+  it('flags when a new identity fails that passed on baseline', () => {
+    const prior = ['a.test.js::flaky test'];
+    const current = ['a.test.js::flaky test', 'b.test.js::new regression'];
+    const r = computeIdentityRegression(current, prior);
+    expect(r.regression).toBe(true);
+    expect(r.newIds).toEqual(['b.test.js::new regression']);
+    expect(r.mode).toBe('identity');
+  });
+
+  it('does not flag when current has fewer failures than prior (improvement)', () => {
+    const prior = ['a.test.js::t1', 'b.test.js::t2'];
+    const current = ['a.test.js::t1'];
+    const r = computeIdentityRegression(current, prior);
+    expect(r.regression).toBe(false);
+    expect(r.newIds).toEqual([]);
+  });
+
+  it('falls back to count_fallback mode when priorFailingIds is absent (older baseline)', () => {
+    const r = computeIdentityRegression(['a.test.js::t1', 'b.test.js::t2'], null, { failed: 2, priorFailedCount: 1 });
+    expect(r.mode).toBe('count_fallback');
+    expect(r.regression).toBe(true);
+    expect(r.newIds).toEqual(['a.test.js::t1', 'b.test.js::t2']);
+  });
+
+  it('count_fallback does not flag when failed count did not rise', () => {
+    const r = computeIdentityRegression(['a.test.js::t1'], undefined, { failed: 1, priorFailedCount: 1 });
+    expect(r.mode).toBe('count_fallback');
+    expect(r.regression).toBe(false);
+  });
+
+  it('handles empty/missing current gracefully', () => {
+    const r = computeIdentityRegression(null, ['a.test.js::t1']);
+    expect(r.regression).toBe(false);
+    expect(r.newIds).toEqual([]);
+  });
+});
+
+describe('extractFailingIds', () => {
+  it('parses a representative vitest JSON shape into file::fullName identities', () => {
+    const raw = {
+      testResults: [
+        {
+          name: 'tests/unit/a.test.js',
+          assertionResults: [
+            { status: 'passed', fullName: 'a suite > passes' },
+            { status: 'failed', fullName: 'a suite > fails' },
+          ],
+        },
+        {
+          name: 'tests/unit/b.test.js',
+          assertionResults: [{ status: 'failed', fullName: 'b suite > also fails' }],
+        },
+      ],
+    };
+    expect(extractFailingIds(raw)).toEqual([
+      'tests/unit/a.test.js::a suite > fails',
+      'tests/unit/b.test.js::b suite > also fails',
+    ]);
+  });
+
+  it('returns [] for missing/malformed input', () => {
+    expect(extractFailingIds(null)).toEqual([]);
+    expect(extractFailingIds({})).toEqual([]);
+    expect(extractFailingIds({ testResults: [] })).toEqual([]);
+  });
+});
+
+describe('filterReachable', () => {
+  it('narrows newIds to only those whose file is in the changed-files set', () => {
+    const newIds = ['a.test.js::t1', 'b.test.js::t2', 'c.test.js::t3'];
+    const changed = ['a.test.js', 'c.test.js'];
+    expect(filterReachable(newIds, changed)).toEqual(['a.test.js::t1', 'c.test.js::t3']);
+  });
+
+  it('passes through unfiltered when changedFiles is empty (no diff-scoping info available)', () => {
+    const newIds = ['a.test.js::t1'];
+    expect(filterReachable(newIds, [])).toEqual(newIds);
+    expect(filterReachable(newIds, undefined)).toEqual(newIds);
+  });
+
+  it('returns [] when none of newIds are reachable', () => {
+    expect(filterReachable(['a.test.js::t1'], ['z.test.js'])).toEqual([]);
+  });
+});

--- a/tests/unit/hooks/compare-test-baseline-identity.test.js
+++ b/tests/unit/hooks/compare-test-baseline-identity.test.js
@@ -1,0 +1,46 @@
+/**
+ * SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 (FR-2) — locks in the identity-based
+ * conversion of scripts/hooks/compare-test-baseline.cjs's compareTestCounts.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { compareTestCounts } = require('../../../scripts/hooks/compare-test-baseline.cjs');
+
+describe('compareTestCounts (identity-based, FR-2)', () => {
+  it('does NOT report REGRESSION when the raw count rises but failing identities are identical', () => {
+    // Same shared-flake test failed on both runs; a re-run bumped the raw count via an unrelated
+    // retry artifact, but the identity SET is unchanged — this is the exact false-positive class
+    // red-merge-detector.mjs / compare-to-main-snapshot.mjs are separately being fixed for.
+    const baseline = { failed: 1, failing_ids: ['a.test.js::flaky'] };
+    const current = { failed: 2, failing_ids: ['a.test.js::flaky'] };
+    const r = compareTestCounts(baseline, current, 'Test');
+    expect(r.status).not.toBe('REGRESSION');
+    expect(r.new_failures).toBe(0);
+    expect(r.regression_mode).toBe('identity');
+  });
+
+  it('reports REGRESSION and names the new identity when a genuinely new test fails', () => {
+    const baseline = { failed: 1, failing_ids: ['a.test.js::flaky'] };
+    const current = { failed: 2, failing_ids: ['a.test.js::flaky', 'b.test.js::new break'] };
+    const r = compareTestCounts(baseline, current, 'Test');
+    expect(r.status).toBe('REGRESSION');
+    expect(r.new_failures).toBe(1);
+    expect(r.new_failing_ids).toEqual(['b.test.js::new break']);
+  });
+
+  it('falls back to count comparison when baseline has no failing_ids (pre-conversion baseline)', () => {
+    const baseline = { failed: 1 };
+    const current = { failed: 2, failing_ids: ['a.test.js::x', 'b.test.js::y'] };
+    const r = compareTestCounts(baseline, current, 'Test');
+    expect(r.regression_mode).toBe('count_fallback');
+    expect(r.status).toBe('REGRESSION');
+  });
+
+  it('reports CLEAN when current has zero failures', () => {
+    const baseline = { failed: 0, failing_ids: [] };
+    const current = { failed: 0, failing_ids: [] };
+    const r = compareTestCounts(baseline, current, 'Test');
+    expect(r.status).toBe('CLEAN');
+  });
+});


### PR DESCRIPTION
## Summary
- Class-guard (not per-instance patch) for the "count-delta gate" anti-pattern: gates that flag on a raw failure-COUNT delta rather than an identity-set diff of WHICH tests/files actually changed, causing false-positives on unrelated flaky/CI-secret/shared-DB-drift noise.
- New shared primitive `lib/gates/identity-diff-gate.cjs` (`computeIdentityRegression`, `extractFailingIds`, `filterReachable`) shaped as a drop-in superset of QF-20260701-833's already-merged inline prototype, for future consolidation.
- Converts a genuinely-discovered 3rd instance (`scripts/hooks/compare-test-baseline.cjs`) end-to-end, backward-compatible.
- New name-anchored ESLint rule `no-count-delta-gate-assertion` + dedicated blocking lint workflow, structurally preventing a 4th instance from being reintroduced. Deliberately defers the two already-known/separately-owned instances (`red-merge-detector.mjs`, `compare-to-main-snapshot.mjs`) per LEAD-phase VALIDATION scoping.
- Audit doc added to `docs/reference/infrastructure-hardening-patterns.md`.

## Test plan
- [x] 29 new/updated unit tests pass (`identity-diff-gate`, `compare-test-baseline-identity`, `no-count-delta-gate-assertion`)
- [x] `node scripts/lint/count-delta-gate-lint.mjs` — 0 violations across 692 files
- [x] LEAD-phase VALIDATION: CONDITIONAL_PASS (88%), corrections incorporated
- [x] EXEC-phase VALIDATION: PASS (95%), REGRESSION: PASS
- [x] Re-verified post main-sync merge (origin/main moved substantially, including QF-20260701-833)

🤖 Generated with [Claude Code](https://claude.com/claude-code)