### PR TITLE
fix(SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-B): real ventures reach vision section-completion repair, still never auto-approved

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -3439,10 +3439,14 @@ export class StageExecutionWorker {
    * (never upsertVision, which writes extracted_dimensions: dimensions||null and would NULL-clobber the
    * enriched dims, violating eva_vision_documents_active_rich_check).
    *
-   * REAL ventures (seeded_from_venture_id IS NULL) are NEVER auto-approved — chairman-manual approval is
-   * preserved and assertVentureVisionReady/shouldHoldAtS19 are untouched. Idempotent (no-op once approved),
-   * constraint-safe (only promotes a row already passing active_rich_check; respects the active-L2 partial
-   * unique index), and fail-soft (never throws into the S19 gate).
+   * REAL ventures (seeded_from_venture_id IS NULL, non-convergence) are NEVER auto-approved — chairman-manual
+   * approval is preserved and assertVentureVisionReady/shouldHoldAtS19 are untouched. SD-LEO-INFRA-REAL-VENTURE-
+   * VISION-ENRICH-UNDERPRODUCTION-S19-001-B (FR-1/FR-2/FR-3): a real venture DOES still reach the Case B
+   * section-completion repair loop (reason='repaired_not_promoted' on success/already-quality_checked, or an
+   * existing active L2 short-circuits with reason='real_venture_active_present') — only the two write points
+   * that would flip status/chairman_approved are gated on eligibility, not the read/repair path. Idempotent
+   * (no-op once approved), constraint-safe (only promotes a row already passing active_rich_check; respects
+   * the active-L2 partial unique index), and fail-soft (never throws into the S19 gate).
    *
    * @param {string} ventureId
    * @returns {Promise<{ promoted: boolean, reason?: string, vision_key?: string, mode?: string, error?: string }>}
@@ -3455,14 +3459,28 @@ export class StageExecutionWorker {
       const { data: venture } = await this._supabase
         .from('ventures').select('id, seeded_from_venture_id').eq('id', ventureId).maybeSingle();
       if (!venture) return { promoted: false, reason: 'venture_not_found' };
-      // Carve-out: only an AUTO-APPROVE-ELIGIBLE venture is auto-approved (a REAL venture stays
-      // chairman-manual). Eligible = a CLONE (seeded_from_venture_id) OR a non-clone CONVERGENCE SUBJECT
-      // (SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001 — marked by launchNonCloneDummy). The
-      // convergence-subject read runs ONLY for non-clones (the clone fast-path is unchanged).
+      // Carve-out: only an AUTO-APPROVE-ELIGIBLE venture is auto-approved/auto-activated (a REAL venture
+      // stays chairman-manual for promotion). Eligible = a CLONE (seeded_from_venture_id) OR a non-clone
+      // CONVERGENCE SUBJECT (SD-LEO-INFRA-NONCLONE-VISION-S19-ACTIVATION-BLOCK-001 — marked by
+      // launchNonCloneDummy). The convergence-subject read runs ONLY for non-clones (the clone fast-path
+      // is unchanged).
+      //
+      // SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-B (FR-1): autoApproveEligible no
+      // longer early-returns here. A real venture is NEVER auto-approved (that invariant is unchanged —
+      // see the two autoApproveEligible checks below, immediately before each write point), but it MUST
+      // still reach the section-completion repair path in Case B — otherwise its L2 vision is permanently
+      // capped at the base writer's 3-4/10 structural ceiling and can never satisfy
+      // trg_enforce_vision_quality_advancement even under an explicit chairman approval later. Safe now
+      // that Child A (SD-...-S19-001-A) makes repeated repair writes clobber-safe.
+      let autoApproveEligible = true;
       if (!venture.seeded_from_venture_id) {
         const convergenceSubject = await isConvergenceSubject(this._supabase, ventureId);
-        if (!convergenceSubject) return { promoted: false, reason: 'real_venture' };
-        this._logger?.log?.(`[Worker] S19: non-clone CONVERGENCE SUBJECT ${ventureId} is auto-approve-eligible (convergence_subject marker) — activating its quality-passed vision on the normal path`);
+        autoApproveEligible = convergenceSubject;
+        if (convergenceSubject) {
+          this._logger?.log?.(`[Worker] S19: non-clone CONVERGENCE SUBJECT ${ventureId} is auto-approve-eligible (convergence_subject marker) — activating its quality-passed vision on the normal path`);
+        } else {
+          this._logger?.log?.(`[Worker] S19: REAL venture ${ventureId} is not auto-approve-eligible — running section-completion repair only (chairman-manual approval preserved)`);
+        }
       }
 
       // Case A — an ACTIVE L2 already exists (eager-synthesis going-forward shape).
@@ -3472,6 +3490,9 @@ export class StageExecutionWorker {
         .eq('venture_id', ventureId).eq('level', 'L2').eq('status', 'active')
         .limit(1).maybeSingle();
       if (active) {
+        // FR-2: a real venture with an existing active L2 is never touched by this function — chairman
+        // approval of an already-active doc remains a fully manual, explicit action.
+        if (!autoApproveEligible) return { promoted: false, reason: 'real_venture_active_present' };
         if (active.chairman_approved === true) return { promoted: false, reason: 'already_approved' };
         // Flip approval ONLY — no status churn (no unique-index collision), dims/content untouched.
         const { error } = await this._supabase
@@ -3549,6 +3570,13 @@ export class StageExecutionWorker {
         this._logger?.log?.(`[Worker] S19: clone vision repaired to quality_checked (attempts=${repair?.attempts}) for venture ${ventureId} ${seed.vision_key}`);
       }
 
+      // FR-3: the seed is now quality_checked=true (either it already was, or the repair loop above just
+      // got it there) — but a real venture stops HERE. Its sections/content were repaired in place via
+      // upsertVision inside repairVision (status/chairman_approved untouched by that call), so the vision
+      // is no longer capped below the quality-advancement trigger's threshold; an explicit chairman
+      // approval can now succeed without this function ever performing the activation itself.
+      if (!autoApproveEligible) return { promoted: false, reason: 'repaired_not_promoted', vision_key: seed.vision_key };
+
       const { error } = await this._supabase
         .from('eva_vision_documents')
         .update({ status: 'active', chairman_approved: true, chairman_approved_at: new Date().toISOString(), created_by: 'testing-agent-clone-autoapprove' })
@@ -3582,10 +3610,11 @@ export class StageExecutionWorker {
     // inherits it: the S19 hard-gate run-then-recheck (~L690), the sync-gate fast-path/primary
     // (~L1479/L1500), and the fire-and-forget _postStageHook_S19_Bridge (~L3424). The prior
     // single call site (the sync entry gate only) left a clone arriving via the hard-gate or
-    // post-hook path un-promoted → it blocked on vision_missing. No-op + fail-soft for REAL
-    // ventures (early-returns 'real_venture' on seeded_from_venture_id IS NULL); idempotent once
-    // approved. Does NOT change the promote's internals — the #5237 isRepairLoopEnabled
-    // kill-switch and #5235 force-approve-backdoor closure are preserved.
+    // post-hook path un-promoted → it blocked on vision_missing. Fail-soft for REAL ventures; never
+    // auto-promotes them (SD-...-S19-001-B: reason='repaired_not_promoted' / 'real_venture_active_present'
+    // on the non-eligible paths, no status/chairman_approved write either way); idempotent once approved.
+    // Does NOT change the promote's internals — the #5237 isRepairLoopEnabled kill-switch and #5235
+    // force-approve-backdoor closure are preserved.
     await this._autoApproveCloneVision(ventureId);
 
     const { data: ventureRow } = await this._supabase

--- a/tests/unit/eva/clone-vision-autoapprove.test.js
+++ b/tests/unit/eva/clone-vision-autoapprove.test.js
@@ -96,10 +96,11 @@ describe('_autoApproveCloneVision (FR-1/FR-2)', () => {
     expect(repairMocks.repairVision).not.toHaveBeenCalled();
   });
 
-  it('REAL venture (seeded_from_venture_id NULL) -> NO update, NO repair', async () => {
-    const sb = makeSb({ venture: { id: 'venture-1', seeded_from_venture_id: null }, draftSeed: enrichedSeed() });
+  it('REAL venture (seeded_from_venture_id NULL), seed already quality_checked -> NO update, NO repair, NOT promoted (SD-...-S19-001-B)', async () => {
+    const sb = makeSb({ venture: { id: 'venture-1', seeded_from_venture_id: null }, draftSeed: enrichedSeed({ quality_checked: true }) });
     const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-1');
-    expect(r.reason).toBe('real_venture');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('repaired_not_promoted');
     expect(sb.updates).toHaveLength(0);
     expect(repairMocks.repairVision).not.toHaveBeenCalled();
   });
@@ -139,6 +140,50 @@ describe('_autoApproveCloneVision (QUALITY-REPAIR FR-1): repair-then-promote', (
   });
 });
 
+describe('SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-B (FR-1/FR-2/FR-3): real ventures reach repair, never promotion', () => {
+  const realVenture = { id: 'venture-real', seeded_from_venture_id: null };
+
+  it('REAL venture, quality_checked=false + repair flag ON + repair succeeds -> repairVision called once, NO writes, reason=repaired_not_promoted', async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(true);
+    repairMocks.repairVision.mockResolvedValue({ finalQualityChecked: true, attempts: 1, exitReason: 'quality_ok' });
+    const sb = makeSb({ venture: realVenture, activeL2: null, draftSeed: enrichedSeed({ quality_checked: false, quality_issues: [{ check: 'section_coverage', message: '3/10' }], sections: {} }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-real');
+    expect(repairMocks.repairVision).toHaveBeenCalledTimes(1);
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('repaired_not_promoted');
+    expect(sb.updates).toHaveLength(0); // repair writes via upsertVision inside repairVision, not this function's own .update()
+  });
+
+  it('REAL venture, quality_checked=false + repair EXHAUSTS -> reason=repair_exhausted_quality (unchanged)', async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(true);
+    repairMocks.repairVision.mockResolvedValue({ finalQualityChecked: false, attempts: 2, exitReason: 'attempt_cap' });
+    const sb = makeSb({ venture: realVenture, activeL2: null, draftSeed: enrichedSeed({ quality_checked: false, quality_issues: [{ check: 'section_coverage' }], sections: {} }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-real');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('repair_exhausted_quality');
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('REAL venture, repair flag OFF -> reason=quality_not_checked (unchanged)', async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(false);
+    const sb = makeSb({ venture: realVenture, activeL2: null, draftSeed: enrichedSeed({ quality_checked: false, quality_issues: [{ check: 'section_coverage' }], sections: {} }) });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-real');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('quality_not_checked');
+    expect(repairMocks.repairVision).not.toHaveBeenCalled();
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('REAL venture with an EXISTING active L2 -> NO writes, reason=real_venture_active_present (Case A short-circuit)', async () => {
+    const sb = makeSb({ venture: realVenture, activeL2: { vision_key: 'V-real', chairman_approved: false } });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-real');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('real_venture_active_present');
+    expect(sb.updates).toHaveLength(0);
+    expect(repairMocks.repairVision).not.toHaveBeenCalled();
+  });
+});
+
 describe('SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001: the non-clone convergence subject draft doc-shape', () => {
   // The from-scratch pipeline produces a NON-CLONE convergence subject's L2 as status='draft' (not
   // draft_seed). Before this fix, Case B queried only draft_seed -> the draft doc fell through to
@@ -166,12 +211,13 @@ describe('SD-LEO-INFRA-NONCLONE-VISION-S19-DRAFT-DOC-SHAPE-001: the non-clone co
     expect(r.promoted).toBe(true);
   });
 
-  it("a REAL venture's status='draft' L2 still returns real_venture (chairman-manual preserved; no marker)", async () => {
+  it("a REAL venture's status='draft' L2, already quality_checked -> repaired_not_promoted (chairman-manual promotion preserved; no marker) (SD-...-S19-001-B)", async () => {
     const sb = makeSb({ venture: { id: 'venture-real', seeded_from_venture_id: null }, convergenceMarker: false, activeL2: null, draftDoc: draftDoc({ quality_checked: true }) });
     const r = await autoApprove.call({ _supabase: sb, _logger: silentLogger }, 'venture-real');
-    expect(r.reason).toBe('real_venture');       // NOT reached Case B — the real_venture gate holds
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('repaired_not_promoted'); // Case B IS reached (the doc-shape match + repair path), but promotion is still withheld
     expect(sb.updates).toHaveLength(0);
-    expect(repairMocks.repairVision).not.toHaveBeenCalled();
+    expect(repairMocks.repairVision).not.toHaveBeenCalled(); // already quality_checked -> no repair call needed
   });
 
   it("repair EXHAUSTS on a 'draft' doc -> NO promote, falls through (no force-approve backdoor)", async () => {

--- a/tests/unit/eva/convergence-non-clone-subject.test.js
+++ b/tests/unit/eva/convergence-non-clone-subject.test.js
@@ -101,7 +101,7 @@ describe('FR-2: S19-gate verification — a non-clone subject blocks at S19 visi
   const subject = { seeded_from_venture_id: null, is_demo: false, is_scaffolding: false }; // the convergence dummy
 
   it('the subject is NOT a clone (so the clone auto-promote does NOT apply to it)', () => {
-    expect(isCloneVenture(subject)).toBe(false);            // not a clone -> _autoApproveCloneVision returns real_venture
+    expect(isCloneVenture(subject)).toBe(false);            // not a clone -> _autoApproveCloneVision never auto-promotes it (SD-...-S19-001-B: it may still reach the repair-only path)
     expect(isCloneVenture({ seeded_from_venture_id: 'x' })).toBe(true); // a real clone WOULD be auto-promoted
   });
 

--- a/tests/unit/eva/nonclone-vision-s19-activation.test.js
+++ b/tests/unit/eva/nonclone-vision-s19-activation.test.js
@@ -109,11 +109,27 @@ describe('(B) S19 auto-approve carve-out ADMITS a convergence-subject non-clone'
     expect(r.promoted).toBe(true);               // repaired (quality) then promoted (activation)
   });
 
-  it('non-clone WITHOUT the marker (a REAL venture) -> real_venture, chairman-manual preserved', async () => {
+  it('non-clone WITHOUT the marker (a REAL venture), no L2 doc at all -> no_l2_vision, chairman-manual preserved (SD-...-S19-001-B: real ventures now reach Case B, but this fixture has no doc to find)', async () => {
     const sb = makeSb({ venture: { id: 'v-real', seeded_from_venture_id: null }, convergenceMarker: false });
     const r = await autoApprove.call({ _supabase: sb, _logger: silent }, 'v-real');
-    expect(r.reason).toBe('real_venture');
+    expect(r.promoted).toBe(false);
+    expect(r.reason).toBe('no_l2_vision');
     expect(repairMocks.repairVision).not.toHaveBeenCalled();
+  });
+
+  it('non-clone WITHOUT the marker (a REAL venture), with an under-quality L2 doc -> repair fires but promotion still withheld (SD-...-S19-001-B)', async () => {
+    repairMocks.isRepairLoopEnabled.mockResolvedValue(true);
+    repairMocks.repairVision.mockResolvedValue({ finalQualityChecked: true, attempts: 1 });
+    const sb = makeSb({
+      venture: { id: 'v-real', seeded_from_venture_id: null },
+      convergenceMarker: false,
+      activeL2: null,
+      draftSeed: { vision_key: 'V-real', extracted_dimensions: { a: 1 }, content: 'x'.repeat(600), quality_checked: false, quality_issues: [{ check: 'section_coverage' }], sections: {} },
+    });
+    const r = await autoApprove.call({ _supabase: sb, _logger: silent }, 'v-real');
+    expect(repairMocks.repairVision).toHaveBeenCalledTimes(1); // real venture now reaches the repair loop
+    expect(r.promoted).toBe(false);                            // but is never auto-activated
+    expect(r.reason).toBe('repaired_not_promoted');
   });
 
   it('a CLONE still works unchanged (no convergence read needed on the clone fast-path)', async () => {

--- a/tests/unit/eva/stage-execution-worker-s19-clone-vision-flow.test.js
+++ b/tests/unit/eva/stage-execution-worker-s19-clone-vision-flow.test.js
@@ -50,6 +50,7 @@ function makeBridgeSb({ calls, venture, activeL2 = null, draftSeed = null, updat
         select() { ctx.op = 'select'; return builder; },
         update(payload) { ctx.op = 'update'; ctx.payload = payload; return builder; },
         eq(col, val) { ctx.filters[col] = val; return builder; },
+        in(col, arr) { ctx.filters[col] = arr; return builder; },
         order() { return builder; },
         limit() { return builder; },
         async upsert() { return { error: null }; },
@@ -72,6 +73,7 @@ function makeBridgeSb({ calls, venture, activeL2 = null, draftSeed = null, updat
     if (ctx.table === 'eva_vision_documents') {
       if (ctx.filters.status === 'active') return activeL2;
       if (ctx.filters.status === 'draft_seed') return draftSeed;
+      if (Array.isArray(ctx.filters.status) && (ctx.filters.status.includes('draft_seed') || ctx.filters.status.includes('draft'))) return draftSeed;
     }
     return null;
   }
@@ -133,7 +135,9 @@ describe('FR-1/FR-2: _runS19Bridge promotes a clone vision at the TOP (before an
 
     const result = await runS19Bridge.call(ctx, 'real-1');
 
-    // The real promote was reached (it runs for every venture) but early-returned real_venture:
+    // The real promote was reached (it runs for every venture); this fixture has no L2 doc at all,
+    // so it stops at no_l2_vision (SD-...-S19-001-B: a real venture WITH a doc would now reach the
+    // repair loop, covered by clone-vision-autoapprove.test.js and nonclone-vision-s19-activation.test.js) —
     // no eva_vision_documents UPDATE, and the bridge proceeded unchanged.
     const visionUpdates = updates.filter((u) => u.table === 'eva_vision_documents');
     expect(visionUpdates).toHaveLength(0);


### PR DESCRIPTION
## Summary
- `_autoApproveCloneVision`'s early return for real (non-clone, non-convergence-subject) ventures skipped the entire section-completion repair path, permanently capping a real venture's L2 vision at the base eager-synthesis writer's 3-4/10 structural ceiling.
- Replaces the umbrella early-return with an `autoApproveEligible` flag that gates only the two activation-write points (Case A's `chairman_approved` flip, Case B's `status=active` promote) — not the read/repair path — so a real venture now reaches the same bounded repair loop clones/convergence-subjects use.
- The "REAL ventures are NEVER auto-approved" invariant is unchanged: `repairVision`→`upsertVision` itself writes `chairman_approved:false`/`status:draft`, so repair cannot activate a venture even in principle (traced and confirmed by the VALIDATION sub-agent, not just asserted).
- Depends on Child A (`SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-A`, already merged) for clobber-safe repeated repair writes on real ventures.

## Sub-agent evidence
- VALIDATION: PASS, 96% confidence — traced both activation write points, confirmed reason-string changes have no external consumers, independently reproduced the negative control (8 assertions fail pre-fix, pass post-fix).
- REGRESSION: PASS, 95% confidence — full `tests/unit/eva/` suite 5603 passed / 19 skipped / 0 failed; confirmed Child A's `mergeVisionSections` protects the now-more-frequent repair writes on real ventures from clobber regression.

## Test plan
- [x] `tests/unit/eva/clone-vision-autoapprove.test.js`, `nonclone-vision-s19-activation.test.js`, `stage-execution-worker-s19-clone-vision-flow.test.js`, `convergence-non-clone-subject.test.js` — 38/38 pass
- [x] Full `tests/unit/eva/` suite — 5603/5603 pass, 0 failures
- [x] Negative control: reverted the source fix only, confirmed 8 new/updated assertions fail with `real_venture` (pre-fix) instead of the new reason strings, restored fix, confirmed 38/38 pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)