### PR TITLE
docs(SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-C): cite probePmBoard in ADKAR Reinforcement section

### DIFF
--- a/docs/protocol/adkar-change-adoption-framework.md
+++ b/docs/protocol/adkar-change-adoption-framework.md
@@ -93,6 +93,17 @@ the natural home for a new adoption's regression check. Reinforcement evidence f
 `requires_adoption` change points at (or extends) one of these three, not a new
 standalone checker.
 
+**Worked example**: `probePmBoard` (`lib/adam/adherence-probes.js`,
+SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-C) extends
+`adam-self-adherence-review.mjs` to catch regression-to-non-use of Adam's PM board —
+open work items exist, but none have progressed since the prior check. It is a
+snapshot-diff against the probe's own last recorded ledger row, not an
+`updated_at`-freshness threshold — a threshold was found (prospective sub-agent review)
+to be silently inert against a table whose timestamp is bumped by routine, no-op
+rehydrate upserts. Any future Reinforcement check facing the same "the obvious
+timestamp signal is noisy" problem should consider the same before/after
+snapshot-comparison pattern rather than a freshness threshold.
+
 ## Out of scope (this framework)
 
 - Non-adoption changes (a pure bugfix has no adoption need — `requires_adoption` stays


### PR DESCRIPTION
## Summary
- Adds a worked-example paragraph to the ADKAR Reinforcement section citing `probePmBoard` (lib/adam/adherence-probes.js, SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-C) as a concrete instance of the snapshot-diff-vs-freshness-threshold pattern.
- Post-completion `/document` step for SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-C (already merged via PR #5354).
- Confirmed `docs/protocol/adkar-pilot-worked-example.md` already cites `probePmBoard` correctly; no change needed there.

## Test plan
- [x] Doc-only change, no code/test impact
- [x] Verified adjacent doc (adkar-pilot-worked-example.md) already references probePmBoard accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)