### PR TITLE
chore(SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-C): register npm entry point for s19-vision-coverage-gauge.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vision:wire-v1-caplayer": "node scripts/okr/wire-v1-caplayer-criteria.mjs",
     "vision:seed-v2-autonomous-marketing": "node scripts/okr/seed-v2-autonomous-marketing-criteria.mjs",
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
+    "vision:s19-coverage-gauge": "node scripts/s19-vision-coverage-gauge.mjs",
     "vision:build-forecast": "node scripts/vision/build-completion-forecast.mjs",
     "vision:build-forecast:apply": "node scripts/vision/build-completion-forecast.mjs --apply",
     "vision:rung-rollup": "node scripts/vision/rung-progress-rollup.mjs",


### PR DESCRIPTION
## Summary
Follow-up to #5358 — registers \`vision:s19-coverage-gauge\` as an npm script entry point for \`scripts/s19-vision-coverage-gauge.mjs\` (mirrors the existing \`vision:gauge\` entry for its sibling). Closes a WIRE_CHECK_GATE finding at LEAD-FINAL-APPROVAL (a standalone CLI script with no other importer needs a registered entry point to count as reachable).

## Test plan
- [x] \`npm run vision:s19-coverage-gauge -- --dry-run\` runs the script correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)