### PR TITLE
fix(SD-LEO-FIX-COVERAGE-BASELINE-REGRESSION-001): register wire-check entry points for the new shared lib modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "test:integration:cross-sd-gate": "vitest run tests/integration/cross-sd-overlap-gate/",
     "test:pipeline": "vitest run tests/integration/pipeline-s0-s17.test.js --testTimeout 1200000",
     "test:coverage": "vitest run --coverage",
+    "coverage:compare-baseline": "node scripts/compare-to-main-snapshot.mjs",
+    "coverage:audit-failures": "node scripts/audit-test-failures.mjs",
     "test:watch": "vitest watch",
     "test:e2e": "playwright test --config=playwright.config.js",
     "test:e2e:accessibility": "npm run test:e2e -- tests/e2e/accessibility/",


### PR DESCRIPTION
## Summary
Small follow-up to PR #5349. `WIRE_CHECK_GATE` (LEAD-FINAL-APPROVAL) flagged `scripts/lib/baseline-regression-check.mjs` and `scripts/lib/vitest-report-parser.mjs` as unreachable — its entry-point discovery only walks `package.json` `scripts` (plus a small hardcoded list), not GitHub Actions workflow YAML, and neither of the two CLI scripts that actually import these new lib modules (`scripts/compare-to-main-snapshot.mjs`, `scripts/audit-test-failures.mjs`) was ever registered as a package.json script. This registers both, so the gate's static import-graph walk finds the new modules via their real, already-wired call sites.

No behavior change — both scripts already ran the same way via direct `node scripts/...mjs` invocation in CI (`.github/workflows/test-coverage.yml`) and local developer use.

## Test plan
- [x] Verified via `discoverEntryPoints()` (wire-check-gate.js, run directly) that both scripts now register as entry points and the import chain resolves to the two new lib modules.
- [x] No functional change — pure package.json addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)