### PR TITLE
fix(SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B): wire stall-alert + adam-pm-board to live entry points (WIRE_CHECK_GATE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -386,6 +386,8 @@
     "coordinator:cold-recovery": "node scripts/coordinator-cold-recovery.cjs",
     "coordinator:reply": "node scripts/coordinator-reply.cjs",
     "adam:startup-check": "node scripts/adam-startup-check.mjs",
+    "adam:quiet-tick": "node scripts/adam-quiet-tick.mjs",
+    "adam:board": "node scripts/adam-pm-board.mjs",
     "coordinator:startup-check": "node scripts/coordinator-startup-check.mjs",
     "test:cold-recovery": "vitest run tests/unit/coordinator-cold-recovery.test.js --project unit",
     "coordinator:teardown": "node scripts/coordinator-teardown.cjs",

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -23,6 +23,8 @@ import { dirname, resolve, join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
 import 'dotenv/config';
 import { rehydrateBoard } from '../lib/adam/task-rehydrate.js';
+import { checkAndAlertStalls } from '../lib/adam/stall-alert.js';
+import { TABLE as TASK_LEDGER_TABLE } from '../lib/adam/task-ledger.js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
@@ -86,6 +88,23 @@ export async function reconcileBoard(sb) {
   }
 }
 
+// FR-2/FR-3 (Child B): critical-path (chairman-parent) task_ledger rows, fail-soft — a read
+// error must never abort the tick. inFlightNextStep is derived from the row's OWN rolled-up
+// status (lib/adam/task-ledger.js rollupParentStatus already writes 'in_progress' onto a parent
+// while any child is still moving): status==='in_progress' -> treated as an intended hold (a
+// known next step is itself progressing) so it never escalates even if this exact row's
+// updated_at hasn't changed this tick; status==='blocked' (or anything else) is a genuine-stall
+// candidate, matching the locked scope's noise-avoidance bias (default to NOT escalating when
+// ambiguous, per stall-detector.js's classifyStaleness contract).
+export async function readCriticalPathParents(sb) {
+  try {
+    const { data } = await sb.from(TASK_LEDGER_TABLE).select('id, title, updated_at, status').eq('tier', 'parent');
+    return (data || []).map((row) => ({ ...row, inFlightNextStep: row.status === 'in_progress' }));
+  } catch {
+    return [];
+  }
+}
+
 async function readSalientState(sb) {
   const state = { beltZero: true, openSignalCount: 0, venture1State: null };
   try {
@@ -128,11 +147,28 @@ async function main() {
   // Child B FR-1: reconcile the durable task board against live reality every tick.
   const boardReconcile = await reconcileBoard(sb);
 
+  const priorState = loadLastState() || {};
+  // Back-compat: a state file written before this SD is a flat salient object, not
+  // {salient, stallSnapshot} — treat it as the salient half and start with no stall snapshot.
+  const priorSalient = priorState.salient !== undefined ? priorState.salient : priorState;
+  const priorStallSnapshot = priorState.stallSnapshot || {};
+
+  // Child B FR-2/FR-3: intended-hold-vs-genuine-stall check on critical-path parents every
+  // tick. Only a genuine stall (per stall-detector.js's classifier) ever calls
+  // recordPendingDecision — an intended hold or a quiet/hold period generates zero escalation.
+  let stall = { snapshot: priorStallSnapshot, alerted: [] };
+  try {
+    const parents = await readCriticalPathParents(sb);
+    stall = await checkAndAlertStalls(sb, parents, priorStallSnapshot, {});
+  } catch (e) {
+    stall = { snapshot: priorStallSnapshot, alerted: [], error: e && e.message };
+  }
+
   // FR-4: belt-countdown + offer-help collapse to a salient-delta check — Adam only
   // reaches the coordinator on a real belt/venture delta, never a "still idle" status.
   const salient = await readSalientState(sb);
-  const delta = detectSalientDelta(loadLastState(), salient);
-  saveLastState(salient);
+  const delta = detectSalientDelta(priorSalient, salient);
+  saveLastState({ salient, stallSnapshot: stall.snapshot });
 
   const delaySeconds = decideCadence({ quiescent, partyOffsetS: ADAM_PARTY_OFFSET_S });
 
@@ -143,6 +179,7 @@ async function main() {
     cores: tick.summary,
     failedCount: tick.failedCount,
     boardReconcile,
+    stallAlerted: stall.alerted,
     crossPartyPing: delta.changed,
     pingFields: delta.fields,
     nextWakeSeconds: delaySeconds,
@@ -155,11 +192,15 @@ async function main() {
       `QUIET_TICK=adam mode=${result.mode} cores=[${tick.summary}] ` +
       `fail=${tick.failedCount} ` +
       `reconcile=parents:${boardReconcile.parents},errors:${boardReconcile.errors.length} ` +
+      `stalls=${stall.alerted.length} ` +
       `ping=${delta.changed ? delta.fields.join(',') : 'suppressed'} ` +
       `nextWakeSeconds=${delaySeconds} :: ${modeReason}`
     );
     if (delta.changed) {
       console.log(`QUIET_TICK_PING=adam->coordinator reason=${delta.fields.join(',')} (real delta — offer help / sourcing)`);
+    }
+    for (const a of stall.alerted) {
+      console.log(`QUIET_TICK_STALL_ALERT=adam node=${a.id} title="${a.title}" escalated=${a.escalated}`);
     }
   }
   return result;

--- a/tests/unit/adam/adam-quiet-tick-reconcile.test.js
+++ b/tests/unit/adam/adam-quiet-tick-reconcile.test.js
@@ -10,7 +10,7 @@
  * this FR — the module previously ran main() unconditionally at import time).
  */
 import { describe, it, expect } from 'vitest';
-import { reconcileBoard } from '../../../scripts/adam-quiet-tick.mjs';
+import { reconcileBoard, readCriticalPathParents } from '../../../scripts/adam-quiet-tick.mjs';
 
 /** Read builder: chainable no-op filters, thenable to the seeded rows. */
 function readBuilder(data) {
@@ -82,5 +82,37 @@ describe('reconcileBoard', () => {
     await reconcileBoard(sb);
     await reconcileBoard(sb);
     expect(sb._ledger).toHaveLength(1);
+  });
+});
+
+/**
+ * Unit pins for Child B FR-2/FR-3's tick-side wiring: readCriticalPathParents() is the
+ * function main() now calls (SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B)
+ * to feed lib/adam/stall-alert.js's checkAndAlertStalls(). Proves the inFlightNextStep
+ * derivation (status==='in_progress' -> intended hold, everything else -> stall candidate)
+ * and the fail-soft contract, independent of stall-alert.js's own (already-covered) logic.
+ */
+describe('readCriticalPathParents', () => {
+  function ledgerSelect(rows) {
+    const b = { select: () => b, eq: () => b, then: (resolve, reject) => Promise.resolve({ data: rows, error: null }).then(resolve, reject) };
+    return b;
+  }
+
+  it('derives inFlightNextStep=true only for status==="in_progress"', async () => {
+    const rows = [
+      { id: 'p1', title: 'A', updated_at: 'x', status: 'in_progress' },
+      { id: 'p2', title: 'B', updated_at: 'x', status: 'blocked' },
+      { id: 'p3', title: 'C', updated_at: 'x', status: 'open' },
+    ];
+    const sb = { from: (table) => (table === 'adam_task_ledger' ? ledgerSelect(rows) : ledgerSelect([])) };
+    const parents = await readCriticalPathParents(sb);
+    expect(parents.find((p) => p.id === 'p1').inFlightNextStep).toBe(true);
+    expect(parents.find((p) => p.id === 'p2').inFlightNextStep).toBe(false);
+    expect(parents.find((p) => p.id === 'p3').inFlightNextStep).toBe(false);
+  });
+
+  it('is fail-soft: a throwing/malformed client returns an empty array, never throws', async () => {
+    const sb = { from: () => { throw new Error('boom'); } };
+    await expect(readCriticalPathParents(sb)).resolves.toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up fix to already-merged PR #5350 for this SD: `WIRE_CHECK_GATE` (AST call-graph reachability) blocked LEAD-FINAL-APPROVAL — `lib/adam/stall-alert.js`, `lib/adam/stall-detector.js`, and `scripts/adam-pm-board.mjs` were built with green unit tests but never wired to any production entry point.
- RCA'd root cause (see PR discussion / sub-agent evidence): "authored + unit-tested in isolation" was conflated with "delivered". `stall-alert.js`'s own test mocks `recordPendingDecision`, proving `fn->mock` but nothing about `tick->fn` reachability.
- Fix: register `"adam:quiet-tick"` and `"adam:board"` package.json scripts (makes `adam-quiet-tick.mjs` a call-graph traversal root, which makes `stall-alert.js`/`stall-detector.js` reachable through it; `adam-pm-board.mjs` becomes self-reachable + discoverable). Wire `checkAndAlertStalls()` into `adam-quiet-tick.mjs`'s `main()` right after `reconcileBoard()`, fed by a new `readCriticalPathParents()` that derives `inFlightNextStep` from the ledger row's own rolled-up status.

## Sub-agent evidence
- RCA sub-agent: root-caused the unwired-but-tested pattern, produced a precise per-file wiring plan (implemented as described above).
- Local verification: `WIRE_CHECK_GATE` precheck now reports `Reachable: 3/3` (was `0/3`).

## Test plan
- [x] `tests/unit/adam/` + `tests/unit/adam-startup-check.test.mjs` — 249/249 pass (2 new tests added for `readCriticalPathParents`)
- [x] `tests/unit/coordinator/quiet-tick*` — 19/19 pass (no regression to the shared quiet-tick core)
- [x] `node scripts/handoff.js precheck LEAD-FINAL-APPROVAL SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B` — PRECHECK PASSED, WIRE_CHECK_GATE 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)