### PR TITLE
docs(SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-D): wire adaptive-cadence + presence-grounding to organizing comms protocol

### DIFF
--- a/lib/coordinator/adaptive-comms-cadence.cjs
+++ b/lib/coordinator/adaptive-comms-cadence.cjs
@@ -15,6 +15,10 @@
  * happens via SELF-SCHEDULED RE-CHECK (each caller reads the recommendation and re-arms its own
  * next wakeup) — a CronCreate-armed cadence can't be retuned mid-flight from Node, so this is
  * layered on top of the baseline-armed cron, not a replacement for it.
+ *
+ * SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-D: this is one of the TACTICAL mechanisms
+ * organized under docs/protocol/crew-comms-routing-protocol.md (Rule 4, silence-by-default) —
+ * see that doc's "Tactical layer" section for the full hierarchy.
  */
 
 const DEFAULT_TIGHT_MS = 150000; // 2.5 min

--- a/lib/coordinator/presence-grounding-signals.cjs
+++ b/lib/coordinator/presence-grounding-signals.cjs
@@ -20,6 +20,10 @@
  *
  * Both I/O helpers are FAIL-OPEN: any query error or thrown exception resolves to an empty/absent
  * result — never blocks the caller's tick, never throws.
+ *
+ * SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-D: this is one of the TACTICAL mechanisms
+ * organized under docs/protocol/crew-comms-routing-protocol.md (Rule 4, silence-by-default) —
+ * see that doc's "Tactical layer" section for the full hierarchy.
  */
 
 const { isSessionAlive, hasExpectedSilence } = require('../fleet/session-liveness.cjs');


### PR DESCRIPTION
## Summary
- Adds the missing code→doc back-reference for the 2 tactical comms mechanisms with a real code artifact (`lib/coordinator/adaptive-comms-cadence.cjs`, `lib/coordinator/presence-grounding-signals.cjs`) — both already cited by file path in sibling Child A's `docs/protocol/crew-comms-routing-protocol.md` "Tactical layer" section, completing a genuine two-way link.
- The other 2 named mechanisms (cross-check protocol, invariant-gauges) have no code artifact to wire against (confirmed via repo-wide grep) and are explicitly descoped in the PRD (FR-3, FR-4) with recorded reasoning rather than force-fitting a misleading reference.
- Comment-only change — zero behavior/logic modification.

## Sub-agent evidence
- VALIDATION: PASS, 97% confidence — independently re-verified the diff (comment-only) and re-ran the descope reasoning's own greps rather than trusting the PRD's claim.
- REGRESSION: PASS — 35/35 tests pass; confirmed no consumer of either file is sensitive to line-position/byte-offset changes.

## Test plan
- [x] `tests/unit/adaptive-comms-cadence.test.js` + `tests/unit/presence-grounding-signals.test.js` — 35/35 pass, unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)