### PR TITLE
fix(SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001): verify already-shipped cancel reasons against origin/main

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-C",
-  "expectedBranch": "feat/SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-C",
-  "createdAt": "2026-07-02T00:10:01.645Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "sdKey": "SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001",
+  "createdAt": "2026-07-02T00:29:39.515Z",
+  "repoRoot": "C:\Users\rickf\Projects\_EHG\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -26,8 +26,12 @@ dotenv.config();
 
 const supabase = createSupabaseServiceClient();
 
-function parseArgs() {
-  const args = process.argv.slice(2);
+// SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001 (PLAN_VERIFICATION
+// regression fix): exported + argv-injectable so the sdInput-resolution regression
+// (see consumedIdx fix below) is directly testable without mutating process.argv or
+// spawning a subprocess.
+export function parseArgs(argv = process.argv.slice(2)) {
+  const args = argv;
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     console.log(`Usage: node scripts/cancel-sd.js <SD-KEY-or-UUID> --reason "<reason>" [--pr <number>] [--evidence-file <path>]
 
@@ -49,7 +53,8 @@ Optional (REQUIRED when --reason indicates already-shipped/superseded/duplicate-
    neither flag, or whose evidence fails verification, is REFUSED and the SD is left unchanged.)
 
 Examples:
-  node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "Superseded by SD-BAR-001"
+  node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "deprioritized, no longer needed"
+  node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "Superseded by SD-BAR-001" --pr 999
   node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "already shipped via PR #999" --pr 999
   node scripts/cancel-sd.js --help
 `);
@@ -63,7 +68,15 @@ Examples:
   const evidenceFiles = [];
   args.forEach((a, i) => { if (a === '--evidence-file' && args[i + 1]) evidenceFiles.push(args[i + 1]); });
 
-  const consumedIdx = new Set([reasonIdx, reasonIdx + 1, prIdx, prIdx + 1]);
+  // REGRESSION FIX (PLAN_VERIFICATION, independently caught by VALIDATION + REGRESSION
+  // sub-agents): an ABSENT flag's indexOf() is -1, so its "+1" companion is index 0 —
+  // exactly where the SD key conventionally sits (`cancel-sd.js <SD-KEY> --reason ...`).
+  // Unconditionally seeding the Set with reasonIdx/prIdx (even when -1) poisoned index 0
+  // whenever --pr was omitted, breaking the primary documented invocation form. Only add
+  // an index pair for a flag that was ACTUALLY found.
+  const consumedIdx = new Set();
+  if (reasonIdx !== -1) { consumedIdx.add(reasonIdx); consumedIdx.add(reasonIdx + 1); }
+  if (prIdx !== -1) { consumedIdx.add(prIdx); consumedIdx.add(prIdx + 1); }
   args.forEach((a, i) => { if (a === '--evidence-file') { consumedIdx.add(i); consumedIdx.add(i + 1); } });
   const sdInput = args.find((a, i) => !a.startsWith('-') && !consumedIdx.has(i));
 

--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -19,6 +19,7 @@
  */
 
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { execFileSync } from 'node:child_process';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -28,7 +29,7 @@ const supabase = createSupabaseServiceClient();
 function parseArgs() {
   const args = process.argv.slice(2);
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
-    console.log(`Usage: node scripts/cancel-sd.js <SD-KEY-or-UUID> --reason "<reason>"
+    console.log(`Usage: node scripts/cancel-sd.js <SD-KEY-or-UUID> --reason "<reason>" [--pr <number>] [--evidence-file <path>]
 
 Atomically cancels an SD:
   - status='cancelled', current_phase='CANCELLED'
@@ -41,8 +42,15 @@ Atomically cancels an SD:
 Required:
   --reason "<text>"   Cancellation reason (cannot be empty)
 
+Optional (REQUIRED when --reason indicates already-shipped/superseded/duplicate-of-merged):
+  --pr <number>            PR claimed to supersede/ship the fix — verified MERGED (mergedAt set) on origin, not merely open
+  --evidence-file <path>   File claimed present on origin/main (repeatable) — verified via origin/main, never a local branch HEAD
+  (SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001: an already-shipped-style cancel with
+   neither flag, or whose evidence fails verification, is REFUSED and the SD is left unchanged.)
+
 Examples:
   node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "Superseded by SD-BAR-001"
+  node scripts/cancel-sd.js SD-LEO-FIX-FOO-001 --reason "already shipped via PR #999" --pr 999
   node scripts/cancel-sd.js --help
 `);
     process.exit(args.includes('--help') || args.includes('-h') ? 0 : 1);
@@ -50,7 +58,14 @@ Examples:
 
   const reasonIdx = args.indexOf('--reason');
   const reason = reasonIdx !== -1 ? args[reasonIdx + 1] : null;
-  const sdInput = args.find(a => !a.startsWith('-') && (reasonIdx === -1 || args.indexOf(a) !== reasonIdx + 1));
+  const prIdx = args.indexOf('--pr');
+  const pr = prIdx !== -1 ? args[prIdx + 1] : null;
+  const evidenceFiles = [];
+  args.forEach((a, i) => { if (a === '--evidence-file' && args[i + 1]) evidenceFiles.push(args[i + 1]); });
+
+  const consumedIdx = new Set([reasonIdx, reasonIdx + 1, prIdx, prIdx + 1]);
+  args.forEach((a, i) => { if (a === '--evidence-file') { consumedIdx.add(i); consumedIdx.add(i + 1); } });
+  const sdInput = args.find((a, i) => !a.startsWith('-') && !consumedIdx.has(i));
 
   if (!sdInput) {
     console.error('❌ Missing SD identifier (sd_key or UUID)');
@@ -61,7 +76,108 @@ Examples:
     process.exit(1);
   }
 
-  return { sdInput, reason: reason.trim() };
+  return { sdInput, reason: reason.trim(), pr: pr ? pr.trim() : null, evidenceFiles };
+}
+
+/**
+ * SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001 (FR-1)
+ * Pure classifier: does this cancellation reason claim the SD is
+ * already-shipped/superseded/duplicate-of-merged (and therefore requires
+ * origin/main verification before cancelling)?
+ * @param {string} reason
+ * @returns {boolean}
+ */
+export function classifyShipReason(reason) {
+  return /already[\s-]?(shipped|merged)|superseded|duplicate[\s-]?of[\s-]?merged/i.test(reason || '');
+}
+
+/**
+ * SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001 (FR-3)
+ * Verify an already-shipped claim against ORIGIN/MAIN — never a local/branch
+ * HEAD. Injectable runners (mirrors lib/worktree-reaper/detectors.js's
+ * isPatchEquivalentToMain pattern) so tests never touch live git/gh.
+ * Fails CLOSED: any runner error counts as verification failure, not
+ * fail-open — the entire point is not trusting an unverifiable claim.
+ *
+ * @param {{pr?: string|null, evidenceFiles?: string[]}} evidence
+ * @param {{runGit: Function, runGh: Function, repoRoot?: string}} runners
+ * @returns {{verified: boolean, reasons: string[]}}
+ */
+export function verifyShippedOnOriginMain({ pr, evidenceFiles = [] } = {}, { runGit, runGh, repoRoot } = {}) {
+  const reasons = [];
+  let anyCheckRan = false;
+
+  if (pr) {
+    anyCheckRan = true;
+    try {
+      const out = runGh(['pr', 'view', String(pr), '--json', 'state,mergedAt'], { cwd: repoRoot });
+      if (out.code !== 0) {
+        reasons.push(`--pr ${pr}: gh pr view failed (exit ${out.code}): ${(out.stderr || '').trim()}`);
+      } else {
+        const parsed = JSON.parse(out.stdout || '{}');
+        if (parsed.state === 'MERGED' && parsed.mergedAt) {
+          // verified
+        } else {
+          reasons.push(`--pr ${pr}: not merged (state=${parsed.state || 'unknown'}, mergedAt=${parsed.mergedAt || 'null'}) — a local/open PR head does not count as shipped`);
+        }
+      }
+    } catch (err) {
+      reasons.push(`--pr ${pr}: gh pr view threw: ${err?.message || err}`);
+    }
+  }
+
+  for (const file of evidenceFiles) {
+    anyCheckRan = true;
+    try {
+      const out = runGit(['cat-file', '-e', `origin/main:${file}`], { cwd: repoRoot });
+      if (out.code !== 0) {
+        reasons.push(`--evidence-file ${file}: not found on origin/main`);
+      }
+    } catch (err) {
+      reasons.push(`--evidence-file ${file}: git cat-file threw: ${err?.message || err}`);
+    }
+  }
+
+  if (!anyCheckRan) {
+    reasons.push('no evidence supplied (--pr or --evidence-file required for an already-shipped/superseded/duplicate-of-merged cancellation)');
+  }
+
+  return { verified: anyCheckRan && reasons.length === 0, reasons };
+}
+
+/**
+ * SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001 (FR-4, TS-7)
+ * Pure decision composing classifyShipReason + verifyShippedOnOriginMain: should
+ * this cancellation be refused before touching the SD? A reason that doesn't
+ * classify as ship-style is never refused here (FR-5 backward-compat path) —
+ * cancelSD() proceeds unchanged for kill/deprioritize/duplicate-of-open reasons.
+ * @param {string} reason
+ * @param {{pr?: string|null, evidenceFiles?: string[]}} evidence
+ * @param {{runGit: Function, runGh: Function, repoRoot?: string}} runners
+ * @returns {{refuse: boolean, reasons: string[]}}
+ */
+export function decideCancelRefusal(reason, evidence, runners) {
+  if (!classifyShipReason(reason)) return { refuse: false, reasons: [] };
+  const { verified, reasons } = verifyShippedOnOriginMain(evidence, runners);
+  return { refuse: !verified, reasons };
+}
+
+function defaultRunGit(args, opts = {}) {
+  try {
+    const stdout = execFileSync('git', args, { encoding: 'utf-8', cwd: opts.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    return { stdout, stderr: '', code: 0 };
+  } catch (err) {
+    return { stdout: err.stdout ? String(err.stdout) : '', stderr: err.stderr ? String(err.stderr) : String(err.message || err), code: typeof err.status === 'number' ? err.status : 1 };
+  }
+}
+
+function defaultRunGh(args, opts = {}) {
+  try {
+    const stdout = execFileSync('gh', args, { encoding: 'utf-8', cwd: opts.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    return { stdout, stderr: '', code: 0 };
+  } catch (err) {
+    return { stdout: err.stdout ? String(err.stdout) : '', stderr: err.stderr ? String(err.stderr) : String(err.message || err), code: typeof err.status === 'number' ? err.status : 1 };
+  }
 }
 
 async function resolveSD(input) {
@@ -235,8 +351,8 @@ async function cancelSD(sd, reason) {
   return true;
 }
 
-(async () => {
-  const { sdInput, reason } = parseArgs();
+async function main() {
+  const { sdInput, reason, pr, evidenceFiles } = parseArgs();
   const sd = await resolveSD(sdInput);
 
   console.log(`SD: ${sd.sd_key} — ${sd.title?.slice(0, 80)}`);
@@ -245,11 +361,38 @@ async function cancelSD(sd, reason) {
   console.log(`  Reason: ${reason}`);
   console.log('');
 
+  // SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001 (FR-2/FR-3/FR-4):
+  // an already-shipped/superseded/duplicate-of-merged reason must verify against
+  // ORIGIN/MAIN before the SD is touched — never trust a local/branch HEAD.
+  if (classifyShipReason(reason)) {
+    const { refuse, reasons } = decideCancelRefusal(
+      reason,
+      { pr, evidenceFiles },
+      { runGit: defaultRunGit, runGh: defaultRunGh }
+    );
+    if (refuse) {
+      console.error('❌ REFUSED: cancellation reason claims already-shipped/superseded/duplicate-of-merged, but verification against origin/main failed:');
+      for (const r of reasons) console.error(`   - ${r}`);
+      console.error('\nSupply --pr <merged-PR-number> and/or --evidence-file <path-present-on-origin/main>. The SD is unchanged.');
+      process.exit(1);
+    }
+    console.log('✓ Ship verification passed against origin/main (not a local/branch HEAD)');
+  }
+
   const changed = await cancelSD(sd, reason);
   if (changed) {
     console.log('\n✅ Cancellation complete.');
   }
-})().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+}
+
+// SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001: guard so the pure
+// exports (classifyShipReason, verifyShippedOnOriginMain) can be imported for unit
+// testing without triggering main()'s process.exit() side effects — mirrors
+// scripts/ci/red-merge-detector.mjs's isMain pattern.
+const isMain = process.argv[1] && import.meta.url.endsWith('cancel-sd.js') && process.argv[1].endsWith('cancel-sd.js');
+if (isMain) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -113,7 +113,13 @@ Examples:
 export function classifyShipReason(reason) {
   const text = reason || '';
   if (/superseded|duplicate[\s-]?of[\s-]?merged/i.test(text)) return true;
-  const hasShipVerb = /\b(shipped|merged|fixed|resolved|closed|landed)\b/i.test(text);
+  // Deep-tier adversarial review finding: the original 6-verb list missed
+  // extremely common non-git-jargon ways to claim "this is already done
+  // elsewhere" ("already implemented in PR #999", "already done in #999",
+  // "already completed and deployed via PR #123") — arguably MORE natural
+  // phrasing than "merged", and this classifier is the SOLE enforcement
+  // point (no second gate), so a miss here is a full bypass of the guardrail.
+  const hasShipVerb = /\b(shipped|merged|fixed|resolved|closed|landed|implemented|completed|delivered|done|built|handled|addressed|covered)\b/i.test(text);
   if (!hasShipVerb) return false;
   if (/\balready\b/i.test(text)) return true;
   return /#\d+|\bPR\s*\d+\b/i.test(text);

--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -84,11 +84,26 @@ Examples:
  * Pure classifier: does this cancellation reason claim the SD is
  * already-shipped/superseded/duplicate-of-merged (and therefore requires
  * origin/main verification before cancelling)?
+ *
+ * Deliberately broad (UAT finding, EXEC phase): the original adjacent-phrase-only
+ * regex missed realistic rephrasings of the same underlying claim ("merged in
+ * #999", "fixed in #999", "resolved by PR 999", "already fixed and merged
+ * upstream" — "already" and the verb non-adjacent). Over-classifying is the SAFE
+ * direction here (it only asks for --pr/--evidence-file that then must verify;
+ * it can never let an unverified already-shipped claim through), so this
+ * matches "already" + a ship-style verb ANYWHERE in the text, or a ship-style
+ * verb co-occurring with a PR/issue reference (#123 / "PR 123") even without
+ * the word "already".
  * @param {string} reason
  * @returns {boolean}
  */
 export function classifyShipReason(reason) {
-  return /already[\s-]?(shipped|merged)|superseded|duplicate[\s-]?of[\s-]?merged/i.test(reason || '');
+  const text = reason || '';
+  if (/superseded|duplicate[\s-]?of[\s-]?merged/i.test(text)) return true;
+  const hasShipVerb = /\b(shipped|merged|fixed|resolved|closed|landed)\b/i.test(text);
+  if (!hasShipVerb) return false;
+  if (/\balready\b/i.test(text)) return true;
+  return /#\d+|\bPR\s*\d+\b/i.test(text);
 }
 
 /**
@@ -109,29 +124,49 @@ export function verifyShippedOnOriginMain({ pr, evidenceFiles = [] } = {}, { run
 
   if (pr) {
     anyCheckRan = true;
-    try {
-      const out = runGh(['pr', 'view', String(pr), '--json', 'state,mergedAt'], { cwd: repoRoot });
-      if (out.code !== 0) {
-        reasons.push(`--pr ${pr}: gh pr view failed (exit ${out.code}): ${(out.stderr || '').trim()}`);
-      } else {
-        const parsed = JSON.parse(out.stdout || '{}');
-        if (parsed.state === 'MERGED' && parsed.mergedAt) {
-          // verified
+    // SECURITY (SEC-F1): a bare-digits PR number only — rejects URLs / branch
+    // names / anything gh's <number>|<url>|<branch> selector would also accept,
+    // which would let a MERGED PR from an unrelated repo satisfy this guardrail.
+    if (!/^\d+$/.test(String(pr))) {
+      reasons.push(`--pr ${pr}: must be a bare PR number (not a URL or branch name)`);
+    } else {
+      try {
+        const out = runGh(['pr', 'view', String(pr), '--json', 'state,mergedAt'], { cwd: repoRoot });
+        if (out.code !== 0) {
+          reasons.push(`--pr ${pr}: gh pr view failed (exit ${out.code}): ${(out.stderr || '').trim()}`);
         } else {
-          reasons.push(`--pr ${pr}: not merged (state=${parsed.state || 'unknown'}, mergedAt=${parsed.mergedAt || 'null'}) — a local/open PR head does not count as shipped`);
+          const parsed = JSON.parse(out.stdout || '{}');
+          if (parsed.state === 'MERGED' && parsed.mergedAt) {
+            // verified
+          } else {
+            reasons.push(`--pr ${pr}: not merged (state=${parsed.state || 'unknown'}, mergedAt=${parsed.mergedAt || 'null'}) — a local/open PR head does not count as shipped`);
+          }
         }
+      } catch (err) {
+        reasons.push(`--pr ${pr}: gh pr view threw: ${err?.message || err}`);
       }
-    } catch (err) {
-      reasons.push(`--pr ${pr}: gh pr view threw: ${err?.message || err}`);
     }
   }
 
   for (const file of evidenceFiles) {
     anyCheckRan = true;
+    // SECURITY (SEC-F2): reject empty/whitespace paths here too (defense in
+    // depth vs. the CLI parser) — an empty path resolves to the root TREE,
+    // which `cat-file -t` below would otherwise happily confirm as present.
+    if (!file || !file.trim()) {
+      reasons.push('--evidence-file: empty path is not valid evidence');
+      continue;
+    }
     try {
-      const out = runGit(['cat-file', '-e', `origin/main:${file}`], { cwd: repoRoot });
+      // SECURITY (SEC-F2): `-t` + require 'blob', not `-e` (which exit-0s for
+      // trees/directories too) — "this FILE shipped" must mean a blob, not
+      // "some path exists", or any always-present directory (e.g. "scripts")
+      // would pass as evidence.
+      const out = runGit(['cat-file', '-t', `origin/main:${file}`], { cwd: repoRoot });
       if (out.code !== 0) {
         reasons.push(`--evidence-file ${file}: not found on origin/main`);
+      } else if (out.stdout.trim() !== 'blob') {
+        reasons.push(`--evidence-file ${file}: not a file on origin/main (type=${out.stdout.trim() || 'unknown'})`);
       }
     } catch (err) {
       reasons.push(`--evidence-file ${file}: git cat-file threw: ${err?.message || err}`);
@@ -162,9 +197,15 @@ export function decideCancelRefusal(reason, evidence, runners) {
   return { refuse: !verified, reasons };
 }
 
+// SECURITY (SEC-F3): a bounded timeout/maxBuffer so a hung/misbehaving git/gh
+// process (network stall on `gh pr view`, a huge repo response) can't hang this
+// otherwise-synchronous CLI indefinitely.
+const RUNNER_TIMEOUT_MS = 15000;
+const RUNNER_MAX_BUFFER = 1024 * 1024;
+
 function defaultRunGit(args, opts = {}) {
   try {
-    const stdout = execFileSync('git', args, { encoding: 'utf-8', cwd: opts.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdout = execFileSync('git', args, { encoding: 'utf-8', cwd: opts.cwd, stdio: ['ignore', 'pipe', 'pipe'], timeout: RUNNER_TIMEOUT_MS, maxBuffer: RUNNER_MAX_BUFFER });
     return { stdout, stderr: '', code: 0 };
   } catch (err) {
     return { stdout: err.stdout ? String(err.stdout) : '', stderr: err.stderr ? String(err.stderr) : String(err.message || err), code: typeof err.status === 'number' ? err.status : 1 };
@@ -173,7 +214,7 @@ function defaultRunGit(args, opts = {}) {
 
 function defaultRunGh(args, opts = {}) {
   try {
-    const stdout = execFileSync('gh', args, { encoding: 'utf-8', cwd: opts.cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdout = execFileSync('gh', args, { encoding: 'utf-8', cwd: opts.cwd, stdio: ['ignore', 'pipe', 'pipe'], timeout: RUNNER_TIMEOUT_MS, maxBuffer: RUNNER_MAX_BUFFER });
     return { stdout, stderr: '', code: 0 };
   } catch (err) {
     return { stdout: err.stdout ? String(err.stdout) : '', stderr: err.stderr ? String(err.stderr) : String(err.message || err), code: typeof err.status === 'number' ? err.status : 1 };

--- a/tests/unit/cancel-sd-ship-verification.test.js
+++ b/tests/unit/cancel-sd-ship-verification.test.js
@@ -1,0 +1,131 @@
+/**
+ * SD-LEO-INFRA-CANCEL-SD-VERIFY-ORIGIN-MAIN-NOT-LOCAL-HEAD-001
+ *
+ * cancel-sd.js's "superseded / already-shipped" cancellation path must verify
+ * against ORIGIN/MAIN (PR mergedAt + file diff), never a local/branch HEAD.
+ * Incident: a worker cancelled a live SD as "already merged" after checking a
+ * LOCAL commit that was actually an UNMERGED PR head. These tests cover the
+ * pure classifier and the injectable-runner verification function — no live
+ * git/gh calls, mirroring lib/worktree-reaper/detectors.js's
+ * isPatchEquivalentToMain pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyShipReason, verifyShippedOnOriginMain, decideCancelRefusal } from '../../scripts/cancel-sd.js';
+
+describe('classifyShipReason', () => {
+  it('classifies already-shipped/superseded/duplicate-of-merged phrasing as requiring verification', () => {
+    expect(classifyShipReason('already shipped via PR #999')).toBe(true);
+    expect(classifyShipReason('Already Merged in #123')).toBe(true);
+    expect(classifyShipReason('Superseded by SD-BAR-001')).toBe(true);
+    expect(classifyShipReason('duplicate of merged fix in SD-FOO')).toBe(true);
+    expect(classifyShipReason('duplicate-of-merged')).toBe(true);
+  });
+
+  it('does NOT classify ordinary kill/deprioritize/duplicate-of-open reasons as requiring verification', () => {
+    expect(classifyShipReason('duplicate work, killing this one')).toBe(false);
+    expect(classifyShipReason('deprioritized')).toBe(false);
+    expect(classifyShipReason('duplicate of open work in SD-BAZ')).toBe(false);
+    expect(classifyShipReason('')).toBe(false);
+    expect(classifyShipReason(undefined)).toBe(false);
+  });
+});
+
+describe('verifyShippedOnOriginMain — PR verification', () => {
+  it('passes when the PR is MERGED with mergedAt set', () => {
+    const runGh = () => ({ code: 0, stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-07-01T00:00:00Z' }), stderr: '' });
+    const runGit = () => ({ code: 0, stdout: '', stderr: '' });
+    const result = verifyShippedOnOriginMain({ pr: '999' }, { runGit, runGh });
+    expect(result.verified).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('fails when the PR is OPEN (not merged) — the exact incident scenario', () => {
+    const runGh = () => ({ code: 0, stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }), stderr: '' });
+    const runGit = () => ({ code: 0, stdout: '', stderr: '' });
+    const result = verifyShippedOnOriginMain({ pr: '999' }, { runGit, runGh });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/not merged/);
+  });
+
+  it('fails when gh pr view errors', () => {
+    const runGh = () => ({ code: 1, stdout: '', stderr: 'not found' });
+    const runGit = () => ({ code: 0, stdout: '', stderr: '' });
+    const result = verifyShippedOnOriginMain({ pr: '999' }, { runGit, runGh });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/gh pr view failed/);
+  });
+});
+
+describe('verifyShippedOnOriginMain — file verification', () => {
+  it('passes when the file is present on origin/main', () => {
+    const runGit = (args) => {
+      expect(args).toEqual(['cat-file', '-e', 'origin/main:scripts/foo.js']);
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    const result = verifyShippedOnOriginMain({ evidenceFiles: ['scripts/foo.js'] }, { runGit, runGh: () => ({ code: 1 }) });
+    expect(result.verified).toBe(true);
+  });
+
+  it('fails when the file is absent from origin/main', () => {
+    const runGit = () => ({ code: 128, stdout: '', stderr: 'fatal: path not found' });
+    const result = verifyShippedOnOriginMain({ evidenceFiles: ['scripts/missing.js'] }, { runGit, runGh: () => ({ code: 1 }) });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/not found on origin\/main/);
+  });
+
+  it('checks against origin/main explicitly, never a bare branch ref', () => {
+    let capturedArgs = null;
+    const runGit = (args) => { capturedArgs = args; return { code: 0, stdout: '', stderr: '' }; };
+    verifyShippedOnOriginMain({ evidenceFiles: ['x.js'] }, { runGit, runGh: () => ({ code: 1 }) });
+    expect(capturedArgs.join(' ')).toContain('origin/main:');
+  });
+});
+
+describe('verifyShippedOnOriginMain — no evidence supplied', () => {
+  it('fails closed when neither --pr nor --evidence-file is given', () => {
+    const result = verifyShippedOnOriginMain({}, { runGit: () => ({ code: 0 }), runGh: () => ({ code: 0 }) });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/no evidence supplied/);
+  });
+});
+
+describe('verifyShippedOnOriginMain — both PR and file required to pass together', () => {
+  it('fails overall if PR is merged but the evidence file is missing', () => {
+    const runGh = () => ({ code: 0, stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-07-01T00:00:00Z' }), stderr: '' });
+    const runGit = () => ({ code: 1, stdout: '', stderr: 'not found' });
+    const result = verifyShippedOnOriginMain({ pr: '1', evidenceFiles: ['x.js'] }, { runGit, runGh });
+    expect(result.verified).toBe(false);
+    expect(result.reasons.length).toBe(1);
+  });
+});
+
+// TS-7: the CLI refuse path. main() gates its call to cancelSD() on this exact
+// decision — asserting refuse:true here proves the SD update is never reached
+// for a ship-classified reason with no (or failing) evidence, without touching
+// resolveSD/cancelSD/Supabase (FR-6 AC: no live network calls in tests).
+describe('decideCancelRefusal — CLI refuse-path decision (FR-4, TS-7)', () => {
+  it('refuses when no evidence flags are given on a ship-classified reason', () => {
+    const result = decideCancelRefusal('already shipped via PR #999', {}, { runGit: () => ({ code: 0 }), runGh: () => ({ code: 0 }) });
+    expect(result.refuse).toBe(true);
+    expect(result.reasons[0]).toMatch(/no evidence supplied/);
+  });
+
+  it('refuses when the supplied evidence fails verification', () => {
+    const runGh = () => ({ code: 0, stdout: JSON.stringify({ state: 'OPEN', mergedAt: null }), stderr: '' });
+    const result = decideCancelRefusal('already merged in #999', { pr: '999' }, { runGit: () => ({ code: 0 }), runGh });
+    expect(result.refuse).toBe(true);
+  });
+
+  it('does not refuse when the supplied evidence verifies', () => {
+    const runGh = () => ({ code: 0, stdout: JSON.stringify({ state: 'MERGED', mergedAt: '2026-07-01T00:00:00Z' }), stderr: '' });
+    const result = decideCancelRefusal('already shipped via PR #999', { pr: '999' }, { runGit: () => ({ code: 0 }), runGh });
+    expect(result.refuse).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('never refuses a non-ship-classified reason (FR-5 backward compat), even with zero evidence', () => {
+    const result = decideCancelRefusal('duplicate work, killing this one', {}, { runGit: () => ({ code: 0 }), runGh: () => ({ code: 0 }) });
+    expect(result.refuse).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+});

--- a/tests/unit/cancel-sd-ship-verification.test.js
+++ b/tests/unit/cancel-sd-ship-verification.test.js
@@ -32,6 +32,15 @@ describe('classifyShipReason', () => {
     expect(classifyShipReason('closed by #42')).toBe(true);
   });
 
+  // Deep-tier adversarial review finding: non-git-jargon ways of claiming "already
+  // done elsewhere" (arguably MORE natural than "merged") bypassed the classifier
+  // entirely, since it's the SOLE enforcement point with no second gate.
+  it('classifies non-git-jargon "already done elsewhere" claims (adversarial review pin)', () => {
+    expect(classifyShipReason('already implemented in PR #999')).toBe(true);
+    expect(classifyShipReason('already done in #999')).toBe(true);
+    expect(classifyShipReason('already completed and deployed via PR #123')).toBe(true);
+  });
+
   it('does NOT classify ordinary kill/deprioritize/duplicate-of-open reasons as requiring verification', () => {
     expect(classifyShipReason('duplicate work, killing this one')).toBe(false);
     expect(classifyShipReason('deprioritized')).toBe(false);

--- a/tests/unit/cancel-sd-ship-verification.test.js
+++ b/tests/unit/cancel-sd-ship-verification.test.js
@@ -10,7 +10,7 @@
  * isPatchEquivalentToMain pattern.
  */
 import { describe, it, expect } from 'vitest';
-import { classifyShipReason, verifyShippedOnOriginMain, decideCancelRefusal } from '../../scripts/cancel-sd.js';
+import { classifyShipReason, verifyShippedOnOriginMain, decideCancelRefusal, parseArgs } from '../../scripts/cancel-sd.js';
 
 describe('classifyShipReason', () => {
   it('classifies already-shipped/superseded/duplicate-of-merged phrasing as requiring verification', () => {
@@ -175,5 +175,42 @@ describe('decideCancelRefusal — CLI refuse-path decision (FR-4, TS-7)', () => 
     const result = decideCancelRefusal('duplicate work, killing this one', {}, { runGit: () => ({ code: 0 }), runGh: () => ({ code: 0 }) });
     expect(result.refuse).toBe(false);
     expect(result.reasons).toEqual([]);
+  });
+});
+
+// PLAN_VERIFICATION regression (independently caught by VALIDATION + REGRESSION
+// sub-agents): consumedIdx unconditionally seeded reasonIdx/prIdx even when a flag
+// was absent (indexOf() = -1, so "+1" = index 0) — poisoning the SD-key position in
+// the primary documented invocation form and breaking a real production caller
+// (scripts/eva/retire-pilot-ventures.mjs, which calls with the SD key first and no
+// --pr). These tests pin the exact regressed shapes.
+describe('parseArgs — sdInput resolution (PLAN_VERIFICATION regression fix)', () => {
+  it('resolves the SD key when it is first and --pr is absent (the documented common form)', () => {
+    const result = parseArgs(['SD-LEO-FIX-FOO-001', '--reason', 'deprioritized, no longer needed']);
+    expect(result.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(result.reason).toBe('deprioritized, no longer needed');
+    expect(result.pr).toBeNull();
+  });
+
+  it('resolves the SD key when it is first, matching the real retire-pilot-ventures.mjs caller shape', () => {
+    const result = parseArgs(['SD-LEO-INFRA-PILOT-VENTURE-GUARD-001', '--reason', 'pilot/test-fixture venture build-out gated']);
+    expect(result.sdInput).toBe('SD-LEO-INFRA-PILOT-VENTURE-GUARD-001');
+  });
+
+  it('still resolves the SD key when it is first AND --pr is present', () => {
+    const result = parseArgs(['SD-LEO-FIX-FOO-001', '--reason', 'already shipped via PR #999', '--pr', '999']);
+    expect(result.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(result.pr).toBe('999');
+  });
+
+  it('still resolves the SD key when it is last', () => {
+    const result = parseArgs(['--reason', 'deprioritized', 'SD-LEO-FIX-FOO-001']);
+    expect(result.sdInput).toBe('SD-LEO-FIX-FOO-001');
+  });
+
+  it('resolves the SD key alongside a repeated --evidence-file, --pr absent', () => {
+    const result = parseArgs(['SD-LEO-FIX-FOO-001', '--reason', 'duplicate of merged fix', '--evidence-file', 'a.js', '--evidence-file', 'b.js']);
+    expect(result.sdInput).toBe('SD-LEO-FIX-FOO-001');
+    expect(result.evidenceFiles).toEqual(['a.js', 'b.js']);
   });
 });

--- a/tests/unit/cancel-sd-ship-verification.test.js
+++ b/tests/unit/cancel-sd-ship-verification.test.js
@@ -21,12 +21,32 @@ describe('classifyShipReason', () => {
     expect(classifyShipReason('duplicate-of-merged')).toBe(true);
   });
 
+  // UAT finding (EXEC phase): the original adjacent-phrase-only regex missed realistic
+  // rephrasings of the same underlying "this is already shipped elsewhere" claim.
+  it('classifies realistic rephrasings that do not use the literal "already <verb>" adjacency', () => {
+    expect(classifyShipReason('merged in #999')).toBe(true);
+    expect(classifyShipReason('fixed in #999')).toBe(true);
+    expect(classifyShipReason('resolved by PR 999')).toBe(true);
+    expect(classifyShipReason('PR #999 merged this already')).toBe(true);
+    expect(classifyShipReason('this was already fixed and merged upstream')).toBe(true);
+    expect(classifyShipReason('closed by #42')).toBe(true);
+  });
+
   it('does NOT classify ordinary kill/deprioritize/duplicate-of-open reasons as requiring verification', () => {
     expect(classifyShipReason('duplicate work, killing this one')).toBe(false);
     expect(classifyShipReason('deprioritized')).toBe(false);
     expect(classifyShipReason('duplicate of open work in SD-BAZ')).toBe(false);
     expect(classifyShipReason('')).toBe(false);
     expect(classifyShipReason(undefined)).toBe(false);
+  });
+
+  it('does NOT classify a ship-verb-free reason merely because it references a PR/issue number', () => {
+    expect(classifyShipReason('duplicate of PR 123, that one has more context')).toBe(false);
+    expect(classifyShipReason('see #42 for the real tracking issue')).toBe(false);
+  });
+
+  it('does NOT classify a ship verb with no "already" and no PR/issue reference', () => {
+    expect(classifyShipReason('closed as wontfix')).toBe(false);
   });
 });
 
@@ -54,13 +74,24 @@ describe('verifyShippedOnOriginMain — PR verification', () => {
     expect(result.verified).toBe(false);
     expect(result.reasons[0]).toMatch(/gh pr view failed/);
   });
+
+  // SEC-F1 (security review, EXEC phase): a URL/branch value would otherwise let
+  // gh pr view resolve a MERGED PR in an UNRELATED repo, satisfying this
+  // guardrail with evidence that has nothing to do with this repo's origin/main.
+  it('rejects a non-bare-digits --pr value (URL/branch) without calling gh at all', () => {
+    const runGh = () => { throw new Error('should not be called'); };
+    const runGit = () => ({ code: 0, stdout: '', stderr: '' });
+    const result = verifyShippedOnOriginMain({ pr: 'https://github.com/other/repo/pull/999' }, { runGit, runGh });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/must be a bare PR number/);
+  });
 });
 
 describe('verifyShippedOnOriginMain — file verification', () => {
-  it('passes when the file is present on origin/main', () => {
+  it('passes when the file is present on origin/main as a blob', () => {
     const runGit = (args) => {
-      expect(args).toEqual(['cat-file', '-e', 'origin/main:scripts/foo.js']);
-      return { code: 0, stdout: '', stderr: '' };
+      expect(args).toEqual(['cat-file', '-t', 'origin/main:scripts/foo.js']);
+      return { code: 0, stdout: 'blob\n', stderr: '' };
     };
     const result = verifyShippedOnOriginMain({ evidenceFiles: ['scripts/foo.js'] }, { runGit, runGh: () => ({ code: 1 }) });
     expect(result.verified).toBe(true);
@@ -73,9 +104,26 @@ describe('verifyShippedOnOriginMain — file verification', () => {
     expect(result.reasons[0]).toMatch(/not found on origin\/main/);
   });
 
+  // SEC-F2 (security review, EXEC phase): `cat-file -e` exit-0s for trees/
+  // directories too, so an always-present directory would pass as "evidence
+  // this file shipped". `-t` + requiring 'blob' closes that gap.
+  it('fails when the path resolves to a directory/tree, not a file', () => {
+    const runGit = () => ({ code: 0, stdout: 'tree\n', stderr: '' });
+    const result = verifyShippedOnOriginMain({ evidenceFiles: ['scripts'] }, { runGit, runGh: () => ({ code: 1 }) });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/not a file on origin\/main/);
+  });
+
+  it('fails closed on an empty evidence-file path without calling the runner', () => {
+    const runGit = () => { throw new Error('should not be called'); };
+    const result = verifyShippedOnOriginMain({ evidenceFiles: [''] }, { runGit, runGh: () => ({ code: 1 }) });
+    expect(result.verified).toBe(false);
+    expect(result.reasons[0]).toMatch(/empty path is not valid evidence/);
+  });
+
   it('checks against origin/main explicitly, never a bare branch ref', () => {
     let capturedArgs = null;
-    const runGit = (args) => { capturedArgs = args; return { code: 0, stdout: '', stderr: '' }; };
+    const runGit = (args) => { capturedArgs = args; return { code: 0, stdout: 'blob\n', stderr: '' }; };
     verifyShippedOnOriginMain({ evidenceFiles: ['x.js'] }, { runGit, runGh: () => ({ code: 1 }) });
     expect(capturedArgs.join(' ')).toContain('origin/main:');
   });


### PR DESCRIPTION
## Summary
- `cancel-sd.js`'s "superseded / already-shipped" cancellation path now verifies against **origin/main** (PR mergedAt + file diff), never a local/branch HEAD. Incident: a worker cancelled a live SD as "already merged" after checking a LOCAL commit that was actually an UNMERGED PR head.
- `classifyShipReason()` — pure classifier for already-shipped/superseded/duplicate-of-merged phrasing (widened during EXEC-phase review to catch realistic rephrasings, not just adjacent "already <verb>").
- `verifyShippedOnOriginMain()` — injectable-runner verification: `gh pr view` must show `state=MERGED && mergedAt`, `git cat-file -t origin/main:<path>` must be `blob`. Fails CLOSED on any error.
- `decideCancelRefusal()` — gates `main()`'s call to `cancelSD()`; a ship-classified reason with missing/failing evidence refuses (exit 1) before the SD is touched.
- New `--pr <number>` / `--evidence-file <path>` CLI flags.
- **Security hardening** (from EXEC-phase security-agent review): `--pr` requires bare digits (was accepting a URL/branch, letting an unrelated repo's merged PR satisfy the guardrail); evidence-file check requires blob type, not just "path exists" (was accepting directories); added timeout/maxBuffer to the git/gh subprocess calls.
- **Regression fix** (from PLAN_VERIFICATION — validation-agent and regression-agent independently converged on the same bug): `parseArgs()`'s consumed-index tracking unconditionally poisoned index 0 (the SD-key position) whenever `--pr` was omitted, breaking the primary documented invocation form and a real caller (`scripts/eva/retire-pilot-ventures.mjs`). Fixed and pinned with regression tests.

## Test plan
- [x] 25 unit tests in `tests/unit/cancel-sd-ship-verification.test.js`, all passing
- [x] Full regression sweep across 6 related test files: 91/91 passing
- [x] Live-verified `cat-file -t` blob/tree/missing behavior against the real repo
- [x] Live-reproduced and fixed the parseArgs regression against the actual CLI
- [x] TESTING, UAT, SECURITY sub-agent evidence (EXEC phase) + VALIDATION, REGRESSION sub-agent evidence (PLAN_VERIFICATION phase, re-verified PASS after the parseArgs fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)