### PR TITLE
feat(SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001): staleness gauge for Adam/coordinator/Solomon singleton sessions

### DIFF
--- a/docs/protocol/singleton-stale-tree-remediation-policy.md
+++ b/docs/protocol/singleton-stale-tree-remediation-policy.md
@@ -1,0 +1,62 @@
+# Singleton Stale-Tree Remediation Policy
+
+**Category**: Protocol
+**Status**: Approved
+**Version**: 1.0.0
+**Author**: SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001
+**Last Updated**: 2026-07-02
+**Tags**: singleton-sessions, staleness, remediation, adam, solomon, coordinator
+
+## Scope
+
+This doc records the **default remediation policy** for a long-lived singleton
+role-session (Adam, Solomon, coordinator) whose `renderFreshness()` check
+(see `lib/governance/checkout-freshness.js`, wired into `scripts/adam-startup-check.mjs`,
+`scripts/coordinator-startup-check.mjs`, `scripts/solomon-startup-check.mjs`) reports
+`STALE-CRITICAL` — meaning the session's own role contract (`CLAUDE_ADAM.md` /
+`CLAUDE_SOLOMON.md` / the coordinator's contract doc) or a tick script has drifted
+behind `origin/main`.
+
+**This SD is measure/surface only.** No remediation automation is implemented here —
+that is deferred to a future SD, per the coordinator co-review's "measure first" guidance.
+
+## Default: SUPERVISED RELAUNCH, not in-place sync
+
+The default remediation for a detected `STALE-CRITICAL` singleton session is
+**supervised relaunch** (tear the session down, restart it fresh against the current
+`origin/main`) — **not** an in-place `git pull`/checkout while the session keeps running.
+
+### Why in-place sync is unsafe in a shared working tree
+
+`scripts/hooks/concurrent-session-worktree.cjs` (SD-LEO-INFRA-AUTO-INVOKE-WORKTREE-001 /
+SD-LEO-INFRA-EXTEND-WORKTREE-ISOLATION-001) exists specifically because two live sessions
+sharing one working tree + branch is unsafe: it detects concurrent sessions on the same
+repo+branch and auto-isolates the newer one into its own worktree rather than letting them
+share and sync one tree. The same hazard applies to a single long-lived session syncing
+itself in place — an in-place `git pull`/checkout while the session is mid-tick risks:
+
+- Corrupting the session's own in-flight state (dirty index, a file mid-read by the
+  session's tooling, a partially-applied diff).
+- Colliding with a sibling session that has since been auto-isolated into a separate
+  worktree off the same shared tree (per the concurrent-session-worktree hook), if the
+  stale session and the isolated one still reference overlapping paths.
+
+Supervised relaunch avoids both: the session stops ticking, a human/coordinator confirms
+the relaunch, and the new session starts clean against current `origin/main` with no
+mid-flight state to corrupt.
+
+## Deferred to a future SD
+
+- Automated relaunch triggering (who/what initiates it, and under what confirmation gate).
+- In-place sync tooling for cases where a full relaunch is judged unnecessary (e.g. a
+  drift confined to a non-critical file).
+- Escalation/notification wiring beyond the existing `renderFreshness()` advisory badge
+  printed at each singleton's own startup/tick.
+
+## Related
+
+- `lib/governance/checkout-freshness.js` — the underlying freshness gauge (behind-count +
+  critical-path diff), from the completed `SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001`.
+- `scripts/gauge-unranked-claimable-leaves.mjs` — the standalone-gauge shipping precedent
+  this SD follows (the shared invariant-gauges registry+runner,
+  `SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001`, has no shipped code yet).

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -23,7 +23,7 @@ import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
-import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-freshness.js';
+import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -226,10 +226,16 @@ export function renderLoops(armed) {
   return lines.join('\n');
 }
 
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001 (framework-seed candidate for
+// SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001, still code-free — shipped standalone per the
+// scripts/gauge-unranked-claimable-leaves.mjs precedent): Adam's own contract + tick script,
+// so drift there surfaces as STALE-CRITICAL, not just a generic behind-count.
+export const ADAM_CRITICAL_PATHS = Object.freeze([...CRITICAL_PROTOCOL_FILES, ROLE_CONTEXT_DOC, 'scripts/adam-quiet-tick.mjs']);
+
 /** Advisory checkout-freshness badge (fail-open — never throws, never blocks startup). */
 export function renderFreshness(repoRoot = REPO_ROOT) {
   try {
-    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'adam' }));
+    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'adam', criticalPaths: ADAM_CRITICAL_PATHS }));
   } catch (err) {
     return '═══ CHECKOUT FRESHNESS ═══\n  ✅ freshness check skipped (fail-open): ' + (err?.message || String(err));
   }

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -20,7 +20,7 @@ import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
-import { checkoutFreshness, freshnessBadge } from '../lib/governance/checkout-freshness.js';
+import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -228,10 +228,18 @@ export function renderLoops(armed) {
   return lines.join('\n');
 }
 
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001 (framework-seed candidate for
+// SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001, still code-free — shipped standalone per the
+// scripts/gauge-unranked-claimable-leaves.mjs precedent): the coordinator's own contract doc,
+// so drift there surfaces as STALE-CRITICAL. Unlike Adam (single adam-quiet-tick.mjs) the
+// coordinator has no single canonical "tick" script — STANDARD_LOOPS lists 15+ periodic
+// scripts — so no tick-script path is added here to avoid an arbitrary/incomplete pick.
+export const COORDINATOR_CRITICAL_PATHS = Object.freeze([...CRITICAL_PROTOCOL_FILES, ROLE_CONTEXT_DOC]);
+
 /** Advisory checkout-freshness badge (fail-open — never throws, never blocks startup). */
 export function renderFreshness(repoRoot = REPO_ROOT) {
   try {
-    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'coordinator' }));
+    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'coordinator', criticalPaths: COORDINATOR_CRITICAL_PATHS }));
   } catch (err) {
     return '═══ CHECKOUT FRESHNESS ═══\n  ✅ freshness check skipped (fail-open): ' + (err?.message || String(err));
   }

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -19,6 +19,9 @@ import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { getClaudeModel } from '../lib/config/model-config.js';
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001: Solomon previously had NO checkout-freshness
+// check at all (Adam and the coordinator already did) — this closes that gap.
+import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -250,9 +253,25 @@ export function renderContractParity(repoRoot = REPO_ROOT) {
   }
 }
 
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001 (framework-seed candidate for
+// SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001, still code-free — shipped standalone per the
+// scripts/gauge-unranked-claimable-leaves.mjs precedent): Solomon's own contract doc, so drift
+// there surfaces as STALE-CRITICAL. Solomon's deep-sweep tick has no dedicated script (it's
+// agent-judgment, script:null in SOLOMON_LOOPS above) — no tick-script path to add here.
+export const SOLOMON_CRITICAL_PATHS = Object.freeze([...CRITICAL_PROTOCOL_FILES, ROLE_CONTEXT_DOC]);
+
+/** Advisory checkout-freshness badge (fail-open — never throws, never blocks startup). */
+export function renderFreshness(repoRoot = REPO_ROOT) {
+  try {
+    return '═══ CHECKOUT FRESHNESS ═══\n  ' + freshnessBadge(checkoutFreshness(repoRoot, { role: 'solomon', criticalPaths: SOLOMON_CRITICAL_PATHS }));
+  } catch (err) {
+    return '═══ CHECKOUT FRESHNESS ═══\n  ✅ freshness check skipped (fail-open): ' + (err?.message || String(err));
+  }
+}
+
 export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   const armed = parseArmedSet(argv, env);
-  return [renderResponsibilities(repoRoot), '', renderLoops(armed), '', renderContractParity(repoRoot)].join('\n');
+  return [renderResponsibilities(repoRoot), '', renderLoops(armed), '', renderContractParity(repoRoot), '', renderFreshness(repoRoot)].join('\n');
 }
 
 // Fail-open entry: always exit 0; a hiccup never blocks /solomon startup.

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -17,7 +17,10 @@ import {
   parseDurableDutyMarkers,
   missingDurableDuties,
   renderContractParity,
+  renderFreshness,
+  ADAM_CRITICAL_PATHS,
 } from '../../scripts/adam-startup-check.mjs';
+import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -162,4 +165,17 @@ test('buildReport composes responsibilities + the tick loops', () => {
   assert.match(report, /ADAM ROLE/);
   assert.match(report, /ADAM RECURRING TICK/);
   assert.ok(RESPONSIBILITIES.length >= 3);
+});
+
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001 (FR-2)
+test('ADAM_CRITICAL_PATHS extends the base protocol files with the Adam contract + tick script', () => {
+  CRITICAL_PROTOCOL_FILES.forEach((p) => assert.ok(ADAM_CRITICAL_PATHS.includes(p), `missing base path ${p}`));
+  assert.ok(ADAM_CRITICAL_PATHS.includes(ROLE_CONTEXT_DOC));
+  assert.ok(ADAM_CRITICAL_PATHS.includes('scripts/adam-quiet-tick.mjs'));
+});
+
+test('renderFreshness is fail-open and reports a CHECKOUT FRESHNESS section', () => {
+  assert.doesNotThrow(() => renderFreshness('/no/such/path'));
+  const out = renderFreshness(process.cwd());
+  assert.match(out, /CHECKOUT FRESHNESS/);
 });

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -11,7 +11,10 @@ import {
   renderLoops,
   buildReport,
   ROLE_CONTEXT_DOC,
+  renderFreshness,
+  COORDINATOR_CRITICAL_PATHS,
 } from '../../scripts/coordinator-startup-check.mjs';
+import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness.js';
 
 test('STANDARD_LOOPS has the expected standard loops with the expected keys', () => {
   // SD-LEO-INFRA-ACTIVATE-FEATURE-FLAG-001 (FR-5) added the daily flag-review loop.
@@ -121,4 +124,16 @@ test('buildReport combines responsibilities + loop sections', () => {
   const report = buildReport([], {});
   assert.match(report, /COORDINATOR ROLE/);
   assert.match(report, /STANDARD CRON LOOPS/);
+});
+
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001 (FR-2)
+test('COORDINATOR_CRITICAL_PATHS extends the base protocol files with the coordinator contract doc', () => {
+  CRITICAL_PROTOCOL_FILES.forEach((p) => assert.ok(COORDINATOR_CRITICAL_PATHS.includes(p), `missing base path ${p}`));
+  assert.ok(COORDINATOR_CRITICAL_PATHS.includes(ROLE_CONTEXT_DOC));
+});
+
+test('renderFreshness is fail-open and reports a CHECKOUT FRESHNESS section', () => {
+  assert.doesNotThrow(() => renderFreshness('/no/such/path'));
+  const out = renderFreshness(process.cwd());
+  assert.match(out, /CHECKOUT FRESHNESS/);
 });

--- a/tests/unit/solomon-startup-check.test.js
+++ b/tests/unit/solomon-startup-check.test.js
@@ -10,8 +10,10 @@ import {
   SOLOMON_LOOPS, ROLE_CONTEXT_DOC, parseDurableDutyMarkers, missingDurableDuties,
   loopStatus, parseArmedSet, renderContractParity, slugifyDuty, wiredDutySlugs,
   solomonSweepMode, isProactiveSweepEnabled,
+  renderFreshness, buildReport, SOLOMON_CRITICAL_PATHS,
 } from '../../scripts/solomon-startup-check.mjs';
 import { buildSelfAdherenceVerdict } from '../../scripts/solomon-self-adherence-review.mjs';
+import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness.js';
 
 describe('SOLOMON_LOOPS shape', () => {
   it('declares inbox-monitor (solomon-advisory.cjs inbox, 5min) + self-adherence (*/12h) + deep-sweep', () => {
@@ -158,5 +160,25 @@ describe('SD-LEO-INFRA-SOLOMON-MODEB-FABLE-PIN-TRIGGER-001: solomonSweepMode Fab
     expect(solomonSweepMode('claude-fable-5', { SOLOMON_SWEEP_MODE: 'consult' })).toBe('consult');
     expect(solomonSweepMode('claude-opus-4-8', { SOLOMON_SWEEP_MODE: 'PROACTIVE' })).toBe('proactive'); // case-insensitive
     expect(solomonSweepMode('claude-fable-5', { SOLOMON_SWEEP_MODE: 'garbage' })).toBe('proactive'); // invalid override ignored
+  });
+});
+
+// SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001: Solomon previously had NO checkout-freshness
+// check at all (Adam and the coordinator already did) — this closes that gap (FR-1/FR-2).
+describe('SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001: checkout freshness (Solomon gains parity)', () => {
+  it('SOLOMON_CRITICAL_PATHS extends the base protocol files with CLAUDE_SOLOMON.md', () => {
+    CRITICAL_PROTOCOL_FILES.forEach((p) => expect(SOLOMON_CRITICAL_PATHS).toContain(p));
+    expect(SOLOMON_CRITICAL_PATHS).toContain(ROLE_CONTEXT_DOC);
+  });
+
+  it('renderFreshness is fail-open and reports a CHECKOUT FRESHNESS section', () => {
+    expect(() => renderFreshness('/no/such/path')).not.toThrow();
+    const out = renderFreshness(process.cwd());
+    expect(out).toMatch(/CHECKOUT FRESHNESS/);
+  });
+
+  it('buildReport now includes the freshness section (previously absent)', () => {
+    const report = buildReport([], {});
+    expect(report).toMatch(/CHECKOUT FRESHNESS/);
   });
 });


### PR DESCRIPTION
## Summary
- Extends the existing `checkoutFreshness()` (`lib/governance/checkout-freshness.js`) with role-specific `criticalPaths` for Adam and the coordinator (own contract doc + tick script where one canonically exists), so drift in their own protocol contract surfaces as STALE-CRITICAL, not just a generic behind-count.
- Closes Solomon's freshness-check gap — Solomon previously had NO checkout-freshness integration at all (Adam and the coordinator already did).
- Documents the default remediation policy (supervised relaunch, not in-place sync, citing the `concurrent-session-worktree.cjs` hazard) — remediation execution is explicitly deferred to a future SD per the coordinator co-review's measure-first guidance.
- Shipped standalone (matching the `gauge-unranked-claimable-leaves.mjs` precedent) since `SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001` has no shipped registry/runner code yet; flagged as a framework-seed candidate in-line.

## Test plan
- [x] `node --test tests/unit/adam-startup-check.test.mjs tests/unit/coordinator-startup-check.test.mjs` — 30/30 passing
- [x] `npx vitest run tests/unit/solomon-startup-check.test.js` — 21/21 passing
- [x] `npx vitest run tests/unit/checkout-freshness.test.js tests/integration/checkout-freshness-realgit.test.js` — 20/20 passing (shared module regression check)
- [x] Live smoke test: ran all 3 `*-startup-check.mjs` scripts in this worktree (genuinely 4 commits behind origin/main) — Adam correctly reported STALE-CRITICAL naming `scripts/adam-quiet-tick.mjs`; Solomon now reports a freshness line for the first time; coordinator reported STALE (no critical-file drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)