### PR TITLE
docs(SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C): reply-class is now implemented

### DIFF
--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -238,9 +238,12 @@ triggers. Full rationale + live evidence: `docs/protocol/crew-comms-routing-prot
 
 Every message on this lane is sender-stamped with a reply-class: `fire-and-forget`
 (no reply expected), `reply-needed` (async, PING-ON-SILENCE applies), or
-`live-handshake` (sync-request eligible — see below). See
+`live-handshake` (sync-request eligible — see below). **Implemented**
+(SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C) — Adam opts a `send` into
+`reply-needed` via `node scripts/adam-advisory.cjs send "<body>" --reply-class reply-needed
+[--reply-window-ms <ms>]`; `request` mode is always `live-handshake`. See
 `docs/protocol/crew-comms-routing-protocol.md` § "Rule 3 — Sender-stamped reply-class"
-for the full contract.
+for the full contract and `lib/coordinator/reply-class.cjs` for the implementation.
 
 ## Sync-request (live-handshake only)
 

--- a/docs/protocol/coordinator-solomon-comms.md
+++ b/docs/protocol/coordinator-solomon-comms.md
@@ -65,9 +65,14 @@ triggers. Full rationale + live evidence: `docs/protocol/crew-comms-routing-prot
 
 Every message on this lane is sender-stamped with a reply-class: `fire-and-forget`
 (no reply expected), `reply-needed` (async, PING-ON-SILENCE applies), or
-`live-handshake` (sync-request eligible — see below). See
-`docs/protocol/crew-comms-routing-protocol.md` § "Rule 3 — Sender-stamped reply-class"
-for the full contract.
+`live-handshake` (sync-request eligible — see below). **Implemented**
+(SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C) — Solomon opts a `send` into
+`reply-needed` via `node scripts/solomon-advisory.cjs send "<body>" --reply-class
+reply-needed [--reply-window-ms <ms>]`; `request` mode and a `solomon-consult` answer with
+`--await` are always `live-handshake`; a consult without `--await` defaults to
+`reply-needed`. See `docs/protocol/crew-comms-routing-protocol.md` § "Rule 3 —
+Sender-stamped reply-class" for the full contract and `lib/coordinator/reply-class.cjs`
+for the implementation.
 
 ## Sync-request (live-handshake only)
 

--- a/docs/protocol/crew-comms-routing-protocol.md
+++ b/docs/protocol/crew-comms-routing-protocol.md
@@ -77,8 +77,28 @@ Every message is stamped by its sender with one of:
 | `live-handshake` | A synchronous, bounded-timeout reply is needed NOW | Yes (see Sync-Request below) |
 
 This bounds the back-and-forth at the **source** — most messages need no reply at all —
-and drives PING-ON-SILENCE deterministically instead of an ad-hoc guess (see
-SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C).
+and drives PING-ON-SILENCE deterministically instead of an ad-hoc guess.
+
+**Implemented** (SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C). The taxonomy is a
+frozen SSOT (`REPLY_CLASSES`) in `lib/coordinator/reply-class.cjs`, imported by every
+payload builder that sends an inter-role message: `buildRequestPayload` /
+`buildSolomonConsultPayload` / `buildIntentPayload` (`scripts/worker-signal.cjs`),
+`buildAdvisoryPayload` (`scripts/adam-advisory.cjs`, `scripts/solomon-advisory.cjs`), and
+`buildReplyPayload` (`scripts/coordinator-reply.cjs`). Each stamps `payload.reply_class`
+from its existing mode/flag semantics (e.g. a synchronous `request`/`--await` call is
+always `live-handshake`; a reply is always `fire-and-forget`; a coordinator-relay
+broadcast is always `fire-and-forget`). Senders opt into `reply-needed` explicitly via
+`adam-advisory.cjs send "<body>" --reply-class reply-needed [--reply-window-ms <ms>]`
+(same flag on `solomon-advisory.cjs`; default window 2h, `DEFAULT_REPLY_WINDOW_MS`).
+PING-ON-SILENCE is a single-fire sweep (`findOverdueReplyNeeded` +
+`checkAndPingOverdueReplies`, same module) wired into the existing `adam-advisory.cjs
+inbox` / `solomon-advisory.cjs inbox` recurring ticks: each tick checks the sender's own
+outbound `reply-needed` rows for ones past `reply_expected_by` with no answering row yet,
+sends exactly one threaded ping (`payload.kind=ping_on_silence`, itself
+`fire-and-forget`), and stamps `payload.ping_sent_at` on the original row so it is never
+re-pinged. No schema migration — all fields ride the existing
+`session_coordination.payload` JSONB column; a legacy row with no `reply_class` reads as
+`fire-and-forget` (never retroactively chased).
 
 ### Rule 4 — Silence-by-default + one-advisory-per-tick
 


### PR DESCRIPTION
## Summary
- Doc-only follow-up to PR #5368: updates Rule 3 in `docs/protocol/crew-comms-routing-protocol.md` and the "Reply-class (sender-stamped)" sections in `coordinator-adam-comms.md` / `coordinator-solomon-comms.md` to reflect that the taxonomy is now **implemented**, not just documented as intent.
- Points readers at `lib/coordinator/reply-class.cjs` and the concrete `--reply-class`/`--reply-window-ms` CLI usage.

## Test plan
- [x] Doc-only change, no code touched