### PR TITLE
chore(SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001): register gauges:run entry point + wire-check-exempt liveness module

### DIFF
--- a/lib/governance/gauge-runner-liveness.js
+++ b/lib/governance/gauge-runner-liveness.js
@@ -1,3 +1,6 @@
+// @wire-check-exempt: loaded via a dynamic `await import(...)` (a string-literal path) from
+// scripts/coordinator-hourly-review.cjs's invariant#0 check block -- the static wire-check tracer
+// does not follow dynamic import() calls, even with a literal specifier.
 /**
  * gauge-runner liveness check (SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001 FR-4, invariant #0).
  *

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "vision:seed-v2-autonomous-marketing": "node scripts/okr/seed-v2-autonomous-marketing-criteria.mjs",
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "vision:s19-coverage-gauge": "node scripts/s19-vision-coverage-gauge.mjs",
+    "gauges:run": "node scripts/gauge-runner.mjs",
     "vision:build-forecast": "node scripts/vision/build-completion-forecast.mjs",
     "vision:build-forecast:apply": "node scripts/vision/build-completion-forecast.mjs --apply",
     "vision:rung-rollup": "node scripts/vision/rung-progress-rollup.mjs",


### PR DESCRIPTION
## Summary
Follow-up to #5369 — closes 3 WIRE_CHECK_GATE findings at LEAD-FINAL-APPROVAL:
- Registers \`gauges:run\` as an npm script entry point for \`scripts/gauge-runner.mjs\` (mirrors \`vision:gauge\`/\`vision:s19-coverage-gauge\`) — also makes \`lib/governance/gauge-registry.js\` reachable transitively.
- Adds a \`// @wire-check-exempt\` comment to \`lib/governance/gauge-runner-liveness.js\`, which is loaded via a dynamic \`await import(...)\` from \`coordinator-hourly-review.cjs\` — the static tracer doesn't follow dynamic imports even with a literal specifier.

## Test plan
- [x] \`node scripts/handoff.js precheck LEAD-FINAL-APPROVAL SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001\` — WIRE_CHECK_GATE now 100%, all 29 gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)