### PR TITLE
fix(SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A): Windows-safe isMainModule + convert 21 live sites

### DIFF
--- a/lib/utils/is-main-module.js
+++ b/lib/utils/is-main-module.js
@@ -1,9 +1,14 @@
+import { pathToFileURL } from 'node:url';
+
 /**
  * Cross-platform ESM entry-point guard.
  * Replaces the duplicated pattern: import.meta.url === `file://${process.argv[1]}`
  *
- * Handles: null argv, Unix paths, Windows backslash paths, triple-slash variant.
- * SD-LEO-INFRA-CENTRALIZE-ESM-ENTRY-001
+ * Handles: null argv, Unix paths, Windows backslash paths, and paths with characters
+ * (spaces, #, unicode) that a manual string-replace normalization mis-encodes —
+ * pathToFileURL applies Node's own URL percent-encoding, the same encoding
+ * import.meta.url itself uses.
+ * SD-LEO-INFRA-CENTRALIZE-ESM-ENTRY-001 / SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A
  *
  * @param {string} importMetaUrl - The calling module's import.meta.url
  * @returns {boolean} true if the script was invoked directly via node
@@ -11,6 +16,5 @@
 export function isMainModule(importMetaUrl) {
   const arg = process.argv[1];
   if (!arg) return false;
-  const normalized = `file:///${arg.replace(/\\/g, '/')}`;
-  return importMetaUrl === `file://${arg}` || importMetaUrl === normalized;
+  return importMetaUrl === pathToFileURL(arg).href;
 }

--- a/scripts/backfill-chairman-decisions-missing-rows.mjs
+++ b/scripts/backfill-chairman-decisions-missing-rows.mjs
@@ -22,6 +22,7 @@
  */
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const APPLY = process.argv.includes('--apply');
 
@@ -164,7 +165,7 @@ async function main() {
 }
 
 // Only run main() when invoked directly — allows tests to import deriveDecisionType
-if (import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'))) {
+if (isMainModule(import.meta.url)) {
   main().catch(err => {
     console.error('Backfill failed:', err);
     process.exit(1);

--- a/scripts/breakage/active-breakage-canary.mjs
+++ b/scripts/breakage/active-breakage-canary.mjs
@@ -18,6 +18,7 @@
  */
 import { createRequire } from 'node:module';
 import { detectFromDb as detectLlmDegradation } from '../continuity/llm-degradation-detector.mjs';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
 const {
@@ -136,6 +137,6 @@ export async function run(deps = {}) {
   return summary;
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || (process.argv[1] && process.argv[1].endsWith('active-breakage-canary.mjs'))) {
+if (isMainModule(import.meta.url)) {
   run().then(() => process.exit(0)).catch((e) => { console.error(`[canary] FAILED (fail-loud): ${e.message}`); process.exit(1); });
 }

--- a/scripts/claim-orchestrator-for-rollup.mjs
+++ b/scripts/claim-orchestrator-for-rollup.mjs
@@ -19,6 +19,8 @@
  * Sequence: claim → (caller) run the orchestrator completion / rollup handoff → --release.
  */
 
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
 const LIVE_SESSION_THRESHOLD_MS = 15 * 60 * 1000; // mirrors the claim TTL
 
 /**
@@ -95,7 +97,7 @@ export async function claimOrchestratorForRollup(supabase, { sdKey, sessionId, r
 
 // ── CLI ────────────────────────────────────────────────────────────────────
 const isMain = (() => {
-  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/')); }
+  try { return isMainModule(import.meta.url); }
   catch { return false; }
 })();
 

--- a/scripts/continuity/spike-rehearsal.mjs
+++ b/scripts/continuity/spike-rehearsal.mjs
@@ -16,6 +16,7 @@
  * Usage: node scripts/continuity/spike-rehearsal.mjs   (dry-run; prints PASS/FAIL JSON)
  */
 import { evaluateDegradationRung, isDegradedSafeMode, RUNG } from './llm-degradation-detector.mjs';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 /** A pre-registered chairman touch-count ceiling for a single away-spike incident. */
 export const DEFAULT_TOUCH_CEILING = 1; // degraded-safe-mode should require exactly ONE surface (no per-item touches)
@@ -74,7 +75,7 @@ export function runRehearsal(cfg = {}) {
 }
 
 // CLI (dry-run): runs the rehearsal against the default seeded fixtures and prints PASS/FAIL.
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('spike-rehearsal.mjs')) {
+if (isMainModule(import.meta.url)) {
   const result = runRehearsal({ seededIntakeCount: 5, breakageState: breakageCanaryState(), touchCeiling: DEFAULT_TOUCH_CEILING, nowMs: Date.parse('2026-06-13T00:00:00Z') });
   console.log(JSON.stringify(result, null, 2));
   console.log(result.passed ? '[spike-rehearsal] PASS — degraded-safe-mode reached within the touch ceiling' : '[spike-rehearsal] FAIL — ' + result.failures.join('; '));

--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -24,6 +24,7 @@ import {
   parsePhases,
   withTargetRepos,
 } from '../lib/eva/create-orchestrator-from-plan.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 dotenv.config();
 
@@ -207,9 +208,7 @@ async function main() {
   }
 }
 
-const _isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-                     import.meta.url === `file:///${process.argv[1]?.replace(/\\\\/g, '/')}` ||
-                      import.meta.url === `file:///${process.argv[1]?.replace(/\\/g, '/')}`;
+const _isMainModule = isMainModule(import.meta.url);
 if (_isMainModule) {
   main().catch(err => { console.error('Fatal error:', err); process.exit(1); });
 }

--- a/scripts/glide-path/add-income-dimension.mjs
+++ b/scripts/glide-path/add-income-dimension.mjs
@@ -23,6 +23,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
 import { INCOME_DIMENSION_KEY, DEFAULT_INCOME_WEIGHTS } from './replacement-net.js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 /** Tunable default weight for the income dimension (additive; existing weights untouched). */
 export const DEFAULT_INCOME_DIMENSION_WEIGHT = 0.18;
@@ -87,6 +88,6 @@ async function main() {
 }
 
 // Run only as a script (not on import — keeps withIncomeDimension unit-testable).
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('add-income-dimension.mjs')) {
+if (isMainModule(import.meta.url)) {
   main().catch((e) => { console.error('[add-income-dimension] threw:', e.message); process.exit(1); });
 }

--- a/scripts/lineage/backfill-vision-key.mjs
+++ b/scripts/lineage/backfill-vision-key.mjs
@@ -25,6 +25,7 @@ import {
   BACKFILL_TARGET_CAP,
   APP_CONFIG_KEYS,
 } from './constants.mjs';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 config();
 
@@ -160,7 +161,7 @@ export async function backfillVisionKey({ supabase, target = BACKFILL_TARGET_CAP
   return { protocol_pre_registered: true, results, cap_reached: results.length >= target };
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('backfill-vision-key.mjs')) {
+if (isMainModule(import.meta.url)) {
   const args = process.argv.slice(2);
   const targetIdx = args.indexOf('--target');
   const target = targetIdx >= 0 ? parseInt(args[targetIdx + 1], 10) : BACKFILL_TARGET_CAP;

--- a/scripts/lint/alter-default-override-lint.mjs
+++ b/scripts/lint/alter-default-override-lint.mjs
@@ -43,6 +43,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -395,6 +396,6 @@ function main() {
   process.exit(failing.length > 0 || allowErrors.length > 0 ? 1 : 0);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/'))) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/scripts/lint/alter-default-override-lint.mjs
+++ b/scripts/lint/alter-default-override-lint.mjs
@@ -25,7 +25,7 @@
  *
  * Writer→table attribution (the precision/recall tradeoff, made explicit):
  *   STRONG  — an enclosing `INSERT INTO t (...)` (SQL) or a nearest-preceding
- *             `.from('t')` (JS) whose table actually carries the column.
+ *             `.from('t')` (JS) whose table actually carries the column. (schema-lint-disable-line: 't' here is a doc placeholder, not a real table)
  *   NAME    — for a DISTINCTIVE column (in-class on exactly one table and not in
  *             COMMON_COLUMNS), a literal write of that column name is attributed
  *             to that single table even without a .from()/INSERT (covers the
@@ -68,7 +68,7 @@ export const COMMON_COLUMNS = new Set([
   'category', 'role', 'level', 'mode', 'source', 'priority', 'title', 'label',
 ]);
 
-const JS_FROM_WINDOW = 800; // chars to look back for a governing .from('t')
+const JS_FROM_WINDOW = 800; // chars to look back for a governing .from('t') (schema-lint-disable-line: doc placeholder)
 
 // ── Comment stripping (doc/example mentions never count as code) ──────────────
 export function stripComments(src, ext) {
@@ -191,7 +191,7 @@ export function extractSqlWriters(src, columnNames) {
   return out;
 }
 
-/** Nearest preceding `.from('t')` within JS_FROM_WINDOW chars of `idx`. */
+/** Nearest preceding `.from('t')` within JS_FROM_WINDOW chars of `idx`. (schema-lint-disable-line: doc placeholder) */
 function nearestFrom(code, idx) {
   const start = Math.max(0, idx - JS_FROM_WINDOW);
   const slice = code.slice(start, idx);

--- a/scripts/lint/metadata-flag-lint.mjs
+++ b/scripts/lint/metadata-flag-lint.mjs
@@ -28,6 +28,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -251,6 +252,6 @@ function main() {
   process.exit(failing.length > 0 || allowErrors.length > 0 ? 1 : 0);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/'))) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/scripts/modules/memory/reindex.mjs
+++ b/scripts/modules/memory/reindex.mjs
@@ -5,6 +5,7 @@ import process from 'node:process';
 import { parseMemoryFrontmatter } from './frontmatter.js';
 import { clusterByPrefix, buildTopicFilename, buildTopicContent } from './clustering.mjs';
 import { atomicWriteFileSync, withMemoryIndexLock } from '../../../lib/memory/atomic-write.mjs';
+import { isMainModule } from '../../../lib/utils/is-main-module.js';
 
 const INDEX_FILENAME = 'MEMORY.md';
 const TOPIC_PREFIX = 'topic_';
@@ -163,8 +164,7 @@ function indexFileLineCount(indexPath) {
   }
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}` ||
-               import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/'));
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--preview') || args.includes('--dry-run');

--- a/scripts/modules/scope/scope-gate.js
+++ b/scripts/modules/scope/scope-gate.js
@@ -23,6 +23,7 @@ import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { minimatch } from 'minimatch';
+import { isMainModule } from '../../../lib/utils/is-main-module.js';
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 
@@ -265,7 +266,7 @@ export async function main(argv = process.argv.slice(2)) {
 // Use process.exitCode (not process.exit) to avoid Windows libuv UV_HANDLE_CLOSING
 // assertion when Supabase HTTP keep-alive sockets are still open during teardown.
 // Setting exitCode lets Node finish cleanup naturally before exiting.
-const isDirectRun = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('scope-gate.js');
+const isDirectRun = isMainModule(import.meta.url);
 if (isDirectRun) {
   main().then(code => { process.exitCode = code; }).catch(err => {
     process.stderr.write(`[scope-gate] ERROR: ${err.message}\n`);

--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -33,6 +33,7 @@
 import 'dotenv/config';
 import { execSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const SAFETY_WINDOW_MINUTES = Number(process.env.ORPHAN_QF_REAPER_SAFETY_WINDOW_MINUTES || 5);
 const DRY_RUN = process.env.ORPHAN_QF_REAPER_DRY_RUN === 'true';
@@ -288,7 +289,7 @@ export async function main() {
   process.exit(0);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     console.error('orphan-qf-reaper: unhandled error:', err.message);
     console.error(err.stack);

--- a/scripts/promote-child-0-2.mjs
+++ b/scripts/promote-child-0-2.mjs
@@ -10,6 +10,7 @@
 import { config } from 'dotenv';
 import { createClient } from '@supabase/supabase-js';
 import { APP_CONFIG_KEYS, KILL_SWITCH_ACCURACY_THRESHOLD } from './lineage/constants.mjs';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 config();
 
@@ -28,7 +29,7 @@ export async function checkKillSwitch(supabase) {
   return { active, source: 'app_config', payload: v };
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('promote-child-0-2.mjs')) {
+if (isMainModule(import.meta.url)) {
   const supabase = createClient(
     process.env.SUPABASE_URL,
     process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY

--- a/scripts/repo-cleanup.js
+++ b/scripts/repo-cleanup.js
@@ -19,6 +19,7 @@ import { groupReviewItems } from './modules/cleanup/group-review.js';
 import { deriveRulesFromGitLog } from './modules/cleanup/derive-rules.js';
 import { appendAuditEntry } from './modules/cleanup/audit-log.js';
 import { parseCliFlags as parseAutoProceedCli, parseEnvVar as parseAutoProceedEnv } from './modules/handoff/auto-proceed-resolver.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -378,8 +379,7 @@ async function main() {
   }
 }
 
-const isMain = import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}` ||
-               import.meta.url === `file://${process.argv[1]}`;
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
   main().catch(e => { console.error(e.message); process.exit(1); });
 }

--- a/scripts/solomon-self-adherence-review.mjs
+++ b/scripts/solomon-self-adherence-review.mjs
@@ -12,6 +12,7 @@ import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { SOLOMON_LOOPS, ROLE_CONTEXT_DOC, missingDurableDuties } from './solomon-startup-check.mjs';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -47,6 +48,6 @@ function main() {
   process.exit(0);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('solomon-self-adherence-review.mjs')) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/scripts/solomon-startup-check.mjs
+++ b/scripts/solomon-startup-check.mjs
@@ -22,6 +22,7 @@ import { getClaudeModel } from '../lib/config/model-config.js';
 // SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001: Solomon previously had NO checkout-freshness
 // check at all (Adam and the coordinator already did) — this closes that gap.
 import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -280,6 +281,6 @@ function main() {
   process.exit(0);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('solomon-startup-check.mjs')) {
+if (isMainModule(import.meta.url)) {
   main();
 }

--- a/scripts/sourcing-engine-deferred-watcher-sweep.mjs
+++ b/scripts/sourcing-engine-deferred-watcher-sweep.mjs
@@ -18,6 +18,7 @@
  */
 import { reEvaluateBlockedCandidate, isWatcherFlagEnabled } from '../lib/sourcing-engine/deferred-watcher.js';
 import { ledgerLaneColumnExists } from '../lib/sourcing-engine/dedup-autostamp.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 /**
  * Run the sweep. Pure-DI (supabase + env injected) so it unit-tests without a live DB.
@@ -90,7 +91,7 @@ export async function runDeferredWatcherSweep({ supabase, env = process.env, dry
 
 // CLI tail (FR-2): default-off, prints SUPPRESSED_FLAG_OFF + exits 0 when the flag is off.
 const isMain = (() => {
-  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/')); }
+  try { return isMainModule(import.meta.url); }
   catch { return false; }
 })();
 

--- a/scripts/sourcing-engine/gauge-gap-miner-sweep.mjs
+++ b/scripts/sourcing-engine/gauge-gap-miner-sweep.mjs
@@ -19,9 +19,10 @@
  */
 import 'dotenv/config';
 import { mineGaugeGaps, isGaugeGapMinerFlagEnabled } from '../../lib/sourcing-engine/gauge-gap-miner.js';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const isMain = (() => {
-  try { return import.meta.url === `file://${process.argv[1]}` || import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, '/')); }
+  try { return isMainModule(import.meta.url); }
   catch { return false; }
 })();
 

--- a/scripts/vision/rung-progress-rollup.mjs
+++ b/scripts/vision/rung-progress-rollup.mjs
@@ -14,6 +14,7 @@ import { createClient } from '@supabase/supabase-js';
 import { computeBuildGauge } from '../../lib/vision/vdr-registry.js';
 import { makeDefaultGrepSeam } from '../../lib/vision/vdr-grep-seam.js';
 import { runRollup } from '../../lib/vision/rung-progress-rollup.mjs';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 async function main() {
   const apply = process.argv.includes('--apply');
@@ -36,7 +37,6 @@ async function main() {
   process.exit(0);
 }
 
-const isDirect = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
-if (isDirect || import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('rung-progress-rollup.mjs')) {
+if (isMainModule(import.meta.url)) {
   main().catch((e) => { console.error('[rung-rollup] fatal:', e?.message || e); process.exit(1); });
 }

--- a/scripts/wiring-validators/orphan-detector.js
+++ b/scripts/wiring-validators/orphan-detector.js
@@ -26,6 +26,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { resolve, relative, join, extname, sep, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT_DEFAULT = resolve(__filename, '..', '..', '..');
@@ -291,7 +292,7 @@ export async function persistResults(supabase, result) {
 // ---------------------------------------------------------------------------
 // CLI entry
 // ---------------------------------------------------------------------------
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('orphan-detector.js')) {
+if (isMainModule(import.meta.url)) {
   const opts = parseArgs(process.argv);
   const results = runDetector(opts);
   process.stdout.write(JSON.stringify(results, null, 2) + '\n');

--- a/scripts/wiring-validators/vision-traceability-checker.js
+++ b/scripts/wiring-validators/vision-traceability-checker.js
@@ -26,6 +26,7 @@
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve, extname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT_DEFAULT = resolve(__filename, '..', '..', '..');
@@ -377,7 +378,7 @@ async function main() {
   process.exit(anyFail ? 1 : 0);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('vision-traceability-checker.js')) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     process.stderr.write(`[vision-traceability-checker] fatal: ${err.message}\n`);
     process.exit(2);

--- a/tests/unit/utils/is-main-module.test.js
+++ b/tests/unit/utils/is-main-module.test.js
@@ -1,0 +1,51 @@
+/**
+ * SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A (FR-1/FR-2).
+ * The raw `import.meta.url === \`file://${process.argv[1]}\`` guard never matches on
+ * Windows (backslash paths, no percent-encoding) — isMainModule() uses pathToFileURL
+ * instead, which is what previously had zero dedicated unit coverage.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { pathToFileURL } from 'node:url';
+import { isMainModule } from '../../../lib/utils/is-main-module.js';
+
+describe('isMainModule', () => {
+  const originalArgv1 = process.argv[1];
+
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+  });
+
+  it('detects a Windows backslash-path argv[1] as the main module (the bug this SD fixes)', () => {
+    process.argv[1] = 'C:\\repo\\scripts\\foo.mjs';
+    const url = pathToFileURL(process.argv[1]).href;
+    expect(isMainModule(url)).toBe(true);
+    // the raw broken pattern this helper replaces would have failed here:
+    expect(url === `file://${process.argv[1]}`).toBe(false);
+  });
+
+  it('detects a Unix-path argv[1] as the main module', () => {
+    process.argv[1] = '/repo/scripts/foo.mjs';
+    const url = pathToFileURL(process.argv[1]).href;
+    expect(isMainModule(url)).toBe(true);
+  });
+
+  it('returns false when importMetaUrl does not match argv[1]', () => {
+    process.argv[1] = '/repo/scripts/foo.mjs';
+    expect(isMainModule('file:///repo/scripts/other.mjs')).toBe(false);
+  });
+
+  beforeEach(() => {
+    process.argv[1] = originalArgv1;
+  });
+
+  it('returns false defensively when argv[1] is missing', () => {
+    process.argv[1] = undefined;
+    expect(isMainModule('file:///anything.mjs')).toBe(false);
+  });
+
+  it('handles a path with spaces correctly (manual string-replace normalization would mis-encode this)', () => {
+    process.argv[1] = 'C:\\Program Files\\repo\\foo.mjs';
+    const url = pathToFileURL(process.argv[1]).href;
+    expect(isMainModule(url)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- The ESM direct-execution guard `import.meta.url === \`file://${process.argv[1]}\`` never matches on Windows (backslash paths, no percent-encoding), so `main()` silently no-ops on local win32 invocation.
- Upgrades `lib/utils/is-main-module.js` to a `pathToFileURL`-based comparison, keeping its exported signature unchanged so the 2 pre-existing live callers (`add-prd-to-database.js`, `adam-quiet-tick.mjs`) are unaffected.
- Converts all 21 confirmed-live raw-pattern sites to `isMainModule(import.meta.url)`, including `scripts/orphan-qf-reaper.mjs`'s zero-fallback bare comparison (previously reported symptom QF-533).
- Adds `tests/unit/utils/is-main-module.test.js` — the helper had zero dedicated unit coverage before this.
- Child -A of orchestrator SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001 (sibling child -B adds a lint guard preventing regression).

## Test plan
- [x] `npx vitest run tests/unit/utils/is-main-module.test.js` — 5/5 passing (Windows backslash-path, Unix, mismatch, missing argv, spaces-in-path)
- [x] `npx vitest run tests/unit/inbox/auto-resolve-recovered.test.js` — 31/31 passing (existing mock-based regression check)
- [x] Live smoke test on this Windows machine: `node scripts/orphan-qf-reaper.mjs` now executes `main()` (previously silently no-op'd)
- [x] `grep -rn 'file://\${process.argv\[1\]}' scripts/ --include=*.mjs --include=*.js | grep -v archive | grep -v one-time` — zero matches (all live sites converted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)