### PR TITLE
feat(SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B): isMainModule raw-pattern class guard

### DIFF
--- a/.github/workflows/ismainmodule-classguard-lint.yml
+++ b/.github/workflows/ismainmodule-classguard-lint.yml
@@ -6,10 +6,11 @@ name: isMainModule Raw-Pattern Class Guard Lint
 # anti-pattern: `import.meta.url === `file://${process.argv[1]}`` silently no-ops the
 # direct-execution guard on Windows (argv[1] is a backslash path; import.meta.url is a
 # proper file:// URL -- they never match). Use isMainModule(import.meta.url) from
-# lib/utils/is-main-module.js instead. 21 confirmed-live pre-existing instances are
-# grandfathered in scripts/lint/ismainmodule-classguard-allowlist.json pending conversion
-# by sibling child -A (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A) -- this
-# workflow blocks any NEW/unallowlisted instance from day one.
+# lib/utils/is-main-module.js instead. scripts/lint/ismainmodule-classguard-allowlist.json
+# exists for grandfathering pre-existing debt but is currently EMPTY -- sibling child -A
+# (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A, PR #5373) landed before this SD
+# and converted all originally-confirmed-live sites, so this workflow blocks ANY
+# raw-pattern instance in scripts/** from day one, with zero exceptions.
 #
 # GENUINELY BLOCKING (no continue-on-error): matches the posture of
 # count-delta-gate-lint.yml and realtime-subscribe-teardown-recursion-lint.yml, not the

--- a/.github/workflows/ismainmodule-classguard-lint.yml
+++ b/.github/workflows/ismainmodule-classguard-lint.yml
@@ -1,0 +1,41 @@
+name: isMainModule Raw-Pattern Class Guard Lint
+
+# SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B
+#
+# Blocks any PR that (re)introduces the proven, recurring "raw isMainModule comparison"
+# anti-pattern: `import.meta.url === `file://${process.argv[1]}`` silently no-ops the
+# direct-execution guard on Windows (argv[1] is a backslash path; import.meta.url is a
+# proper file:// URL -- they never match). Use isMainModule(import.meta.url) from
+# lib/utils/is-main-module.js instead. 21 confirmed-live pre-existing instances are
+# grandfathered in scripts/lint/ismainmodule-classguard-allowlist.json pending conversion
+# by sibling child -A (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A) -- this
+# workflow blocks any NEW/unallowlisted instance from day one.
+#
+# GENUINELY BLOCKING (no continue-on-error): matches the posture of
+# count-delta-gate-lint.yml and realtime-subscribe-teardown-recursion-lint.yml, not the
+# older continue-on-error advisory scanners (metadata-flag-lint, alter-default-override-lint).
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**/*.{js,mjs,cjs,ts,tsx}'
+      - 'eslint-rules/no-raw-ismainmodule-comparison.js'
+      - 'scripts/lint/ismainmodule-classguard-lint.mjs'
+      - 'scripts/lint/ismainmodule-classguard-allowlist.json'
+      - '.github/workflows/ismainmodule-classguard-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ismainmodule-classguard-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Detect raw isMainModule comparisons
+        run: node scripts/lint/ismainmodule-classguard-lint.mjs

--- a/eslint-rules/no-raw-ismainmodule-comparison.js
+++ b/eslint-rules/no-raw-ismainmodule-comparison.js
@@ -1,0 +1,197 @@
+/**
+ * ESLint Rule: no-raw-ismainmodule-comparison
+ *
+ * Flags the raw, Windows-broken direct-execution guard comparison:
+ * `import.meta.url === \`file://${process.argv[1]}\`` (or the string-concatenation
+ * variant `import.meta.url === 'file://' + process.argv[1]`, either operand order).
+ * On Windows, `process.argv[1]` is a backslash path (e.g. `C:\foo\bar.mjs`) while
+ * `import.meta.url` is a proper `file:///C:/foo/bar.mjs` URL, so the raw string
+ * comparison NEVER matches — every one of the ~20+ instances of this pattern
+ * silently no-ops the direct-execution guard on Windows.
+ *
+ * Proven instance count: 21 live files (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-
+ * CLASSFIX-001, converted by sibling child -A to `isMainModule(import.meta.url)`
+ * from `lib/utils/is-main-module.js`). SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-
+ * CLASSFIX-001-B — this rule is the structural guard against a 21st (re)instance,
+ * mirroring the proven shape of eslint-rules/no-count-delta-gate-assertion.js and
+ * eslint-rules/no-realtime-teardown-in-subscribe-callback.js.
+ *
+ * Correct pattern: `isMainModule(import.meta.url)` (lib/utils/is-main-module.js).
+ *
+ * Deliberately NARROW by design: only the bare `process.argv[1]` MemberExpression
+ * is matched, not a wrapped/transformed variant (`.replace(...)`, `new URL(...)`) —
+ * those are structurally different, unproven-instance shapes out of this SD's scope
+ * (matches the precision philosophy of the sibling rules over broad matching that
+ * risks false positives).
+ *
+ * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
+ *
+ *   // eslint-disable-next-line no-raw-ismainmodule-comparison -- <REASON>
+ *   if (import.meta.url === `file://${process.argv[1]}`) { ... }
+ *
+ * @module eslint-rules/no-raw-ismainmodule-comparison
+ */
+
+const RULE_NAME = 'no-raw-ismainmodule-comparison';
+const COMPARISON_OPERATORS = new Set(['===', '==']);
+
+// Detects `eslint-disable-next-line [<prefix>/]no-raw-ismainmodule-comparison` and captures
+// the trailing text on the same line, mirroring the pragma contract established by the sibling
+// rules (no-count-delta-gate-assertion.js / no-realtime-teardown-in-subscribe-callback.js).
+const PRAGMA_DETECT_RE = new RegExp(
+  String.raw`eslint-disable-next-line\s+(?:[^,\n]*,\s*)*(?:[\w@-]+(?:[/][\w@-]+)*/)?` +
+    RULE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+    String.raw`(?:\s*,[^\n]*)?(.*)$`
+);
+
+/**
+ * Is this node `import.meta.url` — a MemberExpression `.url` on the `import.meta` MetaProperty?
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isImportMetaUrl(node) {
+  if (!node || node.type !== 'MemberExpression' || node.computed) return false;
+  if (!node.property || node.property.type !== 'Identifier' || node.property.name !== 'url') return false;
+  const obj = node.object;
+  return !!obj && obj.type === 'MetaProperty' && obj.meta && obj.meta.name === 'import' && obj.property && obj.property.name === 'meta';
+}
+
+/**
+ * Is this node the bare `process.argv[1]` MemberExpression?
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isProcessArgv1(node) {
+  if (!node || node.type !== 'MemberExpression' || !node.computed) return false;
+  if (!node.property || node.property.type !== 'Literal' || node.property.value !== 1) return false;
+  const obj = node.object;
+  if (!obj || obj.type !== 'MemberExpression' || obj.computed) return false;
+  if (!obj.property || obj.property.type !== 'Identifier' || obj.property.name !== 'argv') return false;
+  return !!obj.object && obj.object.type === 'Identifier' && obj.object.name === 'process';
+}
+
+/**
+ * Is this node's cooked/raw text exactly the literal `file://`?
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isFileUrlLiteral(node) {
+  return !!node && node.type === 'Literal' && node.value === 'file://';
+}
+
+/**
+ * Is this node the banned `file://` + `process.argv[1]` construction — a TemplateLiteral
+ * (`` `file://${process.argv[1]}` ``) or a `+` string concatenation (`'file://' + process.argv[1]`)?
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isFileUrlArgv1Expression(node) {
+  if (!node) return false;
+  if (node.type === 'TemplateLiteral') {
+    if (node.expressions.length !== 1 || node.quasis.length !== 2) return false;
+    const head = node.quasis[0] && node.quasis[0].value && node.quasis[0].value.cooked;
+    const tail = node.quasis[1] && node.quasis[1].value && node.quasis[1].value.cooked;
+    if (head !== 'file://' || tail !== '') return false;
+    return isProcessArgv1(node.expressions[0]);
+  }
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    return (isFileUrlLiteral(node.left) && isProcessArgv1(node.right)) ||
+           (isFileUrlLiteral(node.right) && isProcessArgv1(node.left));
+  }
+  return false;
+}
+
+/**
+ * Classify a pragma comment targeting this rule.
+ * @param {string} commentValue
+ * @returns {{ targets: false } | { targets: true, hasMarker: boolean, reason: string }}
+ */
+function classifyPragma(commentValue) {
+  if (!commentValue) return { targets: false };
+  const match = commentValue.match(PRAGMA_DETECT_RE);
+  if (!match) return { targets: false };
+  const suffix = match[1] || '';
+  const markerIdx = suffix.indexOf('--');
+  if (markerIdx === -1) return { targets: true, hasMarker: false, reason: '' };
+  const reason = suffix.slice(markerIdx + 2).trim();
+  return { targets: true, hasMarker: true, reason };
+}
+
+/**
+ * Return the rule-targeting pragma comment directly above `node`, or null.
+ * @param {import('eslint').SourceCode} sourceCode
+ * @param {import('estree').Node} node
+ * @returns {import('estree').Comment | null}
+ */
+function getDisablePragmaCommentAbove(sourceCode, node) {
+  const comments = sourceCode.getCommentsBefore(node);
+  if (!comments || comments.length === 0) return null;
+  const last = comments[comments.length - 1];
+  if (!last || (last.type !== 'Line' && last.type !== 'Block')) return null;
+  if (last.loc && node.loc && last.loc.end.line < node.loc.start.line - 1) return null;
+  const verdict = classifyPragma(last.value);
+  return verdict.targets ? last : null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow the raw, Windows-broken `import.meta.url === `file://${process.argv[1]}`` direct-execution guard comparison — use isMainModule(import.meta.url) instead',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://github.com/rickfelix/EHG_Engineer/blob/main/eslint-rules/no-raw-ismainmodule-comparison.js',
+    },
+    messages: {
+      noRawComparison:
+        'Raw `import.meta.url === file://+argv[1]` comparison is Windows-broken (argv[1] is a backslash path, import.meta.url is a proper file:// URL — they never match). ' +
+        'Use isMainModule(import.meta.url) from lib/utils/is-main-module.js instead. ' +
+        'To override: // eslint-disable-next-line no-raw-ismainmodule-comparison -- <reason>',
+      pragmaMissingReason:
+        'eslint-disable-next-line no-raw-ismainmodule-comparison requires a non-empty REASON after `--`. ' +
+        'Example: // eslint-disable-next-line no-raw-ismainmodule-comparison -- deliberately testing the broken legacy behavior',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    const pragmaHandled = new Set();
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments();
+        for (const comment of comments) {
+          if (comment.type !== 'Line' && comment.type !== 'Block') continue;
+          const verdict = classifyPragma(comment.value);
+          if (!verdict.targets) continue;
+
+          pragmaHandled.add(comment.range && comment.range[0]);
+
+          if (!verdict.hasMarker) {
+            context.report({ loc: comment.loc, messageId: 'noRawComparison' });
+          } else if (verdict.reason.length === 0) {
+            context.report({ loc: comment.loc, messageId: 'pragmaMissingReason' });
+          }
+        }
+      },
+
+      BinaryExpression(node) {
+        if (!COMPARISON_OPERATORS.has(node.operator)) return;
+
+        const leftIsMeta = isImportMetaUrl(node.left);
+        const rightIsMeta = isImportMetaUrl(node.right);
+        if (!leftIsMeta && !rightIsMeta) return;
+
+        const other = leftIsMeta ? node.right : node.left;
+        if (!isFileUrlArgv1Expression(other)) return;
+
+        const above = getDisablePragmaCommentAbove(sourceCode, node);
+        if (above && pragmaHandled.has(above.range && above.range[0])) return;
+
+        context.report({ node, messageId: 'noRawComparison' });
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lint:venture-artifacts": "node scripts/lint/venture-artifacts-write-lint.mjs",
     "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
     "lint:count-delta-gate": "node scripts/lint/count-delta-gate-lint.mjs",
+    "lint:ismainmodule-classguard": "node scripts/lint/ismainmodule-classguard-lint.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",

--- a/scripts/lint/ismainmodule-classguard-allowlist.json
+++ b/scripts/lint/ismainmodule-classguard-allowlist.json
@@ -1,0 +1,26 @@
+{
+  "_doc": "Grandfather allow-list for ismainmodule-classguard-lint.mjs (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B). Keys are repo-relative file paths (the whole file is exempted, since the raw pattern is the file's own direct-execution guard, one instance per file). Each entry REQUIRES a non-empty reason. These 21 entries are the confirmed-live (non-archived) files still carrying the raw `import.meta.url === `file://${process.argv[1]}`` pattern as of this SD's landing -- conversion to isMainModule(import.meta.url) is sibling child -A's scope (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A), not this SD's. This allowlist is a TEMPORARY grandfather: as -A converts each file, remove its entry here so the guard's coverage tightens back to 100% of scripts/**. Prefer removing an entry (once converted) over leaving it indefinitely.",
+  "allow": {
+    "scripts/wiring-validators/vision-traceability-checker.js": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/wiring-validators/orphan-detector.js": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/vision/rung-progress-rollup.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/sourcing-engine/gauge-gap-miner-sweep.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/sourcing-engine-deferred-watcher-sweep.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/solomon-self-adherence-review.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/solomon-startup-check.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/repo-cleanup.js": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/promote-child-0-2.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/orphan-qf-reaper.mjs": "Pending conversion by sibling child -A (file-conversion SD) -- highest priority (zero fallback, matches QF-533's reported symptom).",
+    "scripts/modules/scope/scope-gate.js": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/modules/memory/reindex.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/lint/metadata-flag-lint.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/lint/alter-default-override-lint.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/lineage/backfill-vision-key.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/glide-path/add-income-dimension.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/create-orchestrator-from-plan.js": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/continuity/spike-rehearsal.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/claim-orchestrator-for-rollup.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/breakage/active-breakage-canary.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
+    "scripts/backfill-chairman-decisions-missing-rows.mjs": "Pending conversion by sibling child -A (file-conversion SD)."
+  }
+}

--- a/scripts/lint/ismainmodule-classguard-allowlist.json
+++ b/scripts/lint/ismainmodule-classguard-allowlist.json
@@ -1,26 +1,4 @@
 {
-  "_doc": "Grandfather allow-list for ismainmodule-classguard-lint.mjs (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B). Keys are repo-relative file paths (the whole file is exempted, since the raw pattern is the file's own direct-execution guard, one instance per file). Each entry REQUIRES a non-empty reason. These 21 entries are the confirmed-live (non-archived) files still carrying the raw `import.meta.url === `file://${process.argv[1]}`` pattern as of this SD's landing -- conversion to isMainModule(import.meta.url) is sibling child -A's scope (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A), not this SD's. This allowlist is a TEMPORARY grandfather: as -A converts each file, remove its entry here so the guard's coverage tightens back to 100% of scripts/**. Prefer removing an entry (once converted) over leaving it indefinitely.",
-  "allow": {
-    "scripts/wiring-validators/vision-traceability-checker.js": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/wiring-validators/orphan-detector.js": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/vision/rung-progress-rollup.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/sourcing-engine/gauge-gap-miner-sweep.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/sourcing-engine-deferred-watcher-sweep.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/solomon-self-adherence-review.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/solomon-startup-check.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/repo-cleanup.js": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/promote-child-0-2.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/orphan-qf-reaper.mjs": "Pending conversion by sibling child -A (file-conversion SD) -- highest priority (zero fallback, matches QF-533's reported symptom).",
-    "scripts/modules/scope/scope-gate.js": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/modules/memory/reindex.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/lint/metadata-flag-lint.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/lint/alter-default-override-lint.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/lineage/backfill-vision-key.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/glide-path/add-income-dimension.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/create-orchestrator-from-plan.js": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/continuity/spike-rehearsal.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/claim-orchestrator-for-rollup.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/breakage/active-breakage-canary.mjs": "Pending conversion by sibling child -A (file-conversion SD).",
-    "scripts/backfill-chairman-decisions-missing-rows.mjs": "Pending conversion by sibling child -A (file-conversion SD)."
-  }
+  "_doc": "Grandfather allow-list for ismainmodule-classguard-lint.mjs (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B). Keys are repo-relative file paths (the whole file is exempted, since the raw pattern is the file's own direct-execution guard, one instance per file). Each entry REQUIRES a non-empty reason. EMPTY as of this SD's landing: sibling child -A (SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-A, PR #5373, commit 714c675f90) merged to main BEFORE this SD did, converting all 21 originally-confirmed-live sites to isMainModule(import.meta.url) -- so the guard needs zero grandfathering and covers 100% of scripts/** (excluding scripts/archive/**) from day one. Kept as an empty, documented allowlist (not deleted) so a future genuinely-legitimate exemption has an established, precedented place to go.",
+  "allow": {}
 }

--- a/scripts/lint/ismainmodule-classguard-lint.mjs
+++ b/scripts/lint/ismainmodule-classguard-lint.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * isMainModule Raw-Pattern Class Guard Lint
+ * SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B
+ *
+ * Scans scripts/** for the proven, recurring false-negative class: the raw, Windows-broken
+ * direct-execution guard `import.meta.url === `file://${process.argv[1]}`` (argv[1] is a
+ * backslash path on Windows; import.meta.url is a proper file:// URL — they never match, so
+ * every instance silently no-ops the guard on Windows). Reuses the SAME detection logic as
+ * eslint-rules/no-raw-ismainmodule-comparison.js (via ESLint's Linter API) so there is exactly
+ * one implementation of the anti-pattern shape, not a second grep/regex detector that could
+ * drift out of sync.
+ *
+ * scripts/archive/** is NEVER scanned — it holds ~140 dead one-time/archived instances that are
+ * explicitly out of scope (per the parent SD and sibling child -A, which convert only confirmed-
+ * live sites). A reason-required allowlist (ismainmodule-classguard-allowlist.json) grandfathers
+ * the 21 confirmed-live files still pending conversion by sibling child -A, so this guard is
+ * genuinely blocking for any NEW/reintroduced instance without red-lining CI on pre-existing,
+ * already-tracked debt that belongs to a different child SD.
+ *
+ * Usage:
+ *   node scripts/lint/ismainmodule-classguard-lint.mjs [--json] [--root <dir>]
+ *   npm run lint:ismainmodule-classguard
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Linter } from 'eslint';
+import typescriptParser from '@typescript-eslint/parser';
+import rule from '../../eslint-rules/no-raw-ismainmodule-comparison.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const ALLOWLIST_PATH = path.resolve(__dirname, 'ismainmodule-classguard-allowlist.json');
+
+const SCAN_DIRS = ['scripts'];
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx']);
+const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive'];
+const EXCLUDE_FILE_RE = /(\.test\.|\.spec\.|\.d\.ts$|\.min\.js$)/i;
+
+const RULE_ID = 'ismainmodule-classguard/no-raw-ismainmodule-comparison';
+
+const FLAT_CONFIG = {
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: {
+      console: 'readonly', process: 'readonly', require: 'readonly', module: 'readonly',
+      exports: 'readonly', __dirname: 'readonly', __filename: 'readonly', Buffer: 'readonly',
+      setTimeout: 'readonly', setInterval: 'readonly', clearTimeout: 'readonly', clearInterval: 'readonly',
+    },
+  },
+  plugins: {
+    'ismainmodule-classguard': { rules: { 'no-raw-ismainmodule-comparison': rule } },
+  },
+  rules: {
+    [RULE_ID]: 'error',
+  },
+};
+
+/**
+ * Load the grandfather allowlist. Every entry MUST carry a non-empty reason string — throws
+ * loud on any malformed entry rather than silently accepting it. Missing file -> empty allowlist
+ * (fail-open on absence, not on malformed content).
+ * @param {string} [allowlistPath]
+ * @returns {Record<string, string>}
+ */
+export function loadAllowlist(allowlistPath = ALLOWLIST_PATH) {
+  let raw;
+  try { raw = fs.readFileSync(allowlistPath, 'utf8'); } catch { return {}; }
+  let json;
+  try { json = JSON.parse(raw); } catch (e) { throw new Error(`Invalid allowlist JSON at ${allowlistPath}: ${e.message}`); }
+  const entries = json.allow || json;
+  for (const [file, reason] of Object.entries(entries)) {
+    if (!reason || typeof reason !== 'string' || !reason.trim()) {
+      throw new Error(`Allowlist entry '${file}' must have a non-empty reason string`);
+    }
+  }
+  return entries;
+}
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (EXCLUDE_DIR_SEGMENTS.includes(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name)) && !EXCLUDE_FILE_RE.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+function lintFile(linter, absPath) {
+  const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+  let code;
+  try {
+    code = fs.readFileSync(absPath, 'utf8');
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Could not read file: ${err.message}` }];
+  }
+  const isTypeScript = path.extname(absPath) === '.ts' || path.extname(absPath) === '.tsx';
+  const config = {
+    ...FLAT_CONFIG,
+    languageOptions: {
+      ...FLAT_CONFIG.languageOptions,
+      ...(isTypeScript ? { parser: typescriptParser } : {}),
+    },
+  };
+  let messages;
+  try {
+    messages = linter.verify(code, config, { filename: absPath });
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Parse error: ${err.message}` }];
+  }
+  return messages
+    .filter((m) => m.ruleId === RULE_ID)
+    .map((m) => ({ filePath: relPath, line: m.line, column: m.column, message: m.message }));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const rootIdx = args.indexOf('--root');
+  const scanRoot = rootIdx !== -1 && args[rootIdx + 1] ? path.resolve(args[rootIdx + 1]) : REPO_ROOT;
+
+  const allow = loadAllowlist();
+
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(scanRoot, dir), files);
+  }
+
+  const linter = new Linter({ cwd: scanRoot });
+  const hits = files.flatMap((f) => lintFile(linter, f));
+  const violations = hits.filter((h) => !(h.filePath in allow));
+  const grandfathered = hits.filter((h) => h.filePath in allow);
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ scanned: files.length, violations, grandfathered: grandfathered.length }, null, 2));
+  } else if (violations.length === 0) {
+    console.log(`✅ ismainmodule-classguard-lint: 0 ungoverned violations across ${files.length} file(s) scanned (scripts/**, excluding scripts/archive/**); ${grandfathered.length} grandfathered.`);
+  } else {
+    console.error(`❌ ismainmodule-classguard-lint: ${violations.length} violation(s) across ${files.length} file(s) scanned\n`);
+    for (const v of violations) {
+      console.error(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+    }
+    console.error('\nFix: use isMainModule(import.meta.url) from lib/utils/is-main-module.js instead of the raw comparison.');
+    console.error('Or, if this file is genuinely pending sibling-SD conversion, add a reason-required entry to scripts/lint/ismainmodule-classguard-allowlist.json.');
+  }
+
+  process.exit(violations.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/lint/ismainmodule-classguard-lint.mjs
+++ b/scripts/lint/ismainmodule-classguard-lint.mjs
@@ -12,11 +12,11 @@
  * drift out of sync.
  *
  * scripts/archive/** is NEVER scanned — it holds ~140 dead one-time/archived instances that are
- * explicitly out of scope (per the parent SD and sibling child -A, which convert only confirmed-
- * live sites). A reason-required allowlist (ismainmodule-classguard-allowlist.json) grandfathers
- * the 21 confirmed-live files still pending conversion by sibling child -A, so this guard is
- * genuinely blocking for any NEW/reintroduced instance without red-lining CI on pre-existing,
- * already-tracked debt that belongs to a different child SD.
+ * explicitly out of scope (per the parent SD and sibling child -A, which converts only confirmed-
+ * live sites). A reason-required allowlist (ismainmodule-classguard-allowlist.json) exists for
+ * grandfathering pre-existing debt without red-lining CI — currently EMPTY, since sibling child -A
+ * (PR #5373) landed before this SD and converted all 21 originally-confirmed-live sites, so this
+ * guard covers 100% of scripts/** (excluding archive/) with zero exceptions from day one.
  *
  * Usage:
  *   node scripts/lint/ismainmodule-classguard-lint.mjs [--json] [--root <dir>]

--- a/tests/unit/eslint-rules/no-raw-ismainmodule-comparison.test.js
+++ b/tests/unit/eslint-rules/no-raw-ismainmodule-comparison.test.js
@@ -40,15 +40,28 @@ ruleTester.run('no-raw-ismainmodule-comparison', rule, {
         }
       `,
     },
-    // lib/utils/is-main-module.js's own internal implementation — compares an ALIASED
-    // variable (arg), not a bare process.argv[1] MemberExpression, against a template
-    // literal. Structurally different from the banned inline pattern.
+    // An ALIASED variable (arg), not a bare process.argv[1] MemberExpression, compared
+    // against a file:// template literal — structurally different from the banned inline
+    // pattern (this was lib/utils/is-main-module.js's own partial-fix-era internal shape).
     {
       code: `
         export function isMainModule(importMetaUrl) {
           const arg = process.argv[1];
           if (!arg) return false;
           return importMetaUrl === \`file://\${arg}\`;
+        }
+      `,
+    },
+    // lib/utils/is-main-module.js's CURRENT implementation (post SD-LEO-INFRA-ISMAINMODULE-
+    // WINDOWS-GUARD-CLASSFIX-001-A): pathToFileURL(arg).href — a CallExpression chain, not a
+    // TemplateLiteral/+-concatenation at all, so trivially out of this rule's match shape.
+    {
+      code: `
+        import { pathToFileURL } from 'node:url';
+        export function isMainModule(importMetaUrl) {
+          const arg = process.argv[1];
+          if (!arg) return false;
+          return importMetaUrl === pathToFileURL(arg).href;
         }
       `,
     },

--- a/tests/unit/eslint-rules/no-raw-ismainmodule-comparison.test.js
+++ b/tests/unit/eslint-rules/no-raw-ismainmodule-comparison.test.js
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for ESLint rule `no-raw-ismainmodule-comparison`.
+ *
+ * SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B FR-1/FR-4.
+ *
+ * Covers: the correct pattern (isMainModule(import.meta.url) call sites), the two
+ * banned raw-comparison forms (template-literal + string-concatenation) in both
+ * operand orders, non-matching import.meta.url usage, and the escape-hatch pragma
+ * contract (mirrors no-realtime-teardown-in-subscribe-callback.test.js).
+ *
+ * @module tests/unit/eslint-rules/no-raw-ismainmodule-comparison.test.js
+ */
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../../../eslint-rules/no-raw-ismainmodule-comparison.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const RULE_ID = 'rule-to-test/no-raw-ismainmodule-comparison';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: { process: 'readonly' },
+  },
+});
+
+ruleTester.run('no-raw-ismainmodule-comparison', rule, {
+  valid: [
+    // TS-1: the correct pattern — the shared helper, not a raw comparison.
+    {
+      code: `
+        import { isMainModule } from './lib/utils/is-main-module.js';
+        if (isMainModule(import.meta.url)) {
+          main();
+        }
+      `,
+    },
+    // lib/utils/is-main-module.js's own internal implementation — compares an ALIASED
+    // variable (arg), not a bare process.argv[1] MemberExpression, against a template
+    // literal. Structurally different from the banned inline pattern.
+    {
+      code: `
+        export function isMainModule(importMetaUrl) {
+          const arg = process.argv[1];
+          if (!arg) return false;
+          return importMetaUrl === \`file://\${arg}\`;
+        }
+      `,
+    },
+    // Unrelated import.meta.url usage (no comparison to a file://+argv[1] construction).
+    {
+      code: `const dir = path.dirname(fileURLToPath(import.meta.url));`,
+    },
+    // import.meta.url compared to something else entirely — not the banned shape.
+    {
+      code: `if (import.meta.url === someOtherUrl) { doThing(); }`,
+    },
+    // Pragma with a full REASON — valid suppression.
+    {
+      code: `
+        // eslint-disable-next-line ${RULE_ID} -- deliberately testing the broken legacy behavior
+        if (import.meta.url === \`file://\${process.argv[1]}\`) { legacy(); }
+      `,
+    },
+  ],
+
+  invalid: [
+    // TS-2: template-literal form, import.meta.url on the left.
+    {
+      code: `if (import.meta.url === \`file://\${process.argv[1]}\`) { main(); }`,
+      errors: [{ messageId: 'noRawComparison' }],
+    },
+    // Template-literal form, import.meta.url on the right (mirrored operand order).
+    {
+      code: `if (\`file://\${process.argv[1]}\` === import.meta.url) { main(); }`,
+      errors: [{ messageId: 'noRawComparison' }],
+    },
+    // TS-2b: string-concatenation variant.
+    {
+      code: `if (import.meta.url === 'file://' + process.argv[1]) { main(); }`,
+      errors: [{ messageId: 'noRawComparison' }],
+    },
+    // String-concatenation variant, mirrored operand order.
+    {
+      code: `if ('file://' + process.argv[1] === import.meta.url) { main(); }`,
+      errors: [{ messageId: 'noRawComparison' }],
+    },
+    // Loose equality (==) variant — still detected.
+    {
+      code: `if (import.meta.url == \`file://\${process.argv[1]}\`) { main(); }`,
+      errors: [{ messageId: 'noRawComparison' }],
+    },
+    // Pragma present but missing the `--` REASON marker entirely.
+    {
+      code: `
+        // eslint-disable-next-line ${RULE_ID}
+        if (import.meta.url === \`file://\${process.argv[1]}\`) { legacy(); }
+      `,
+      errors: [{ messageId: 'noRawComparison' }],
+    },
+    // Pragma present with the `--` marker but a whitespace-only (effectively empty) reason.
+    // Trailing spaces after `--` (not a bare `--`) mirrors the sibling rule's TS-9 convention —
+    // a bare `--` with nothing after it at all trips ESLint's OWN native directive-comment
+    // parser (it fails to split the rule-name from the marker), which is a native-parser
+    // artifact unrelated to this rule's own pragmaMissingReason logic.
+    {
+      code: `// eslint-disable-next-line ${RULE_ID} --   \nif (import.meta.url === \`file://\${process.argv[1]}\`) { legacy(); }`,
+      errors: [{ messageId: 'pragmaMissingReason' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds a static AST-based ESLint class-guard (`eslint-rules/no-raw-ismainmodule-comparison.js`) banning the raw, Windows-broken `` import.meta.url === `file://${process.argv[1]}` `` direct-execution comparison, mirroring the exact shape of two precedent class-guard SDs (`no-count-delta-gate-assertion.js`, `no-realtime-teardown-in-subscribe-callback.js`).
- Driver script (`scripts/lint/ismainmodule-classguard-lint.mjs`) + genuinely-blocking (no `continue-on-error`) CI workflow (`.github/workflows/ismainmodule-classguard-lint.yml`), scoped to `scripts/**` excluding `scripts/archive/**` (~140 dead one-time-script instances, explicitly out of scope).
- Sibling child -A (the file-conversion SD, PR #5373) merged to main before this branch — verified via a fresh merge that all 21 originally-confirmed-live sites are already converted, so the guard ships with **0 grandfathered exceptions**, covering 100% of `scripts/**` from day one. A reason-required allowlist mechanism still exists (currently empty) for any genuinely-legitimate future exemption.

Child B of orchestrator SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001.

## Test plan
- [x] 13 new ESLint RuleTester unit tests (both raw-pattern forms, both operand orders, `isMainModule(...)` call sites and the helper's own current+legacy internal shapes correctly NOT flagged, pragma escape-hatch contract)
- [x] Negative control: disabled core detection logic, confirmed exactly the 5 detection-dependent tests fail, restored
- [x] Live verification against the real codebase: driver script reports 0 violations across 1713 files scanned
- [x] Live negative test: scratch file with the raw pattern correctly triggers exit 1; removed, returns to exit 0
- [x] TESTING (92%), VALIDATION (97%), REGRESSION (95%) sub-agents all PASS — REGRESSION specifically confirmed the rule is NOT double-registered in `eslint.config.js` (would have red-lined the general `npm run lint` pipeline)
- [x] E2E N/A (backend CI/lint tooling, no UI surface) — confirmed by TESTING sub-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)