### PR TITLE
feat(SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001): tracked relay queue + confirm-on-relay + drop gauge + bilateral direct-reply

### DIFF
--- a/lib/coordinator/peer-target.cjs
+++ b/lib/coordinator/peer-target.cjs
@@ -1,0 +1,104 @@
+/**
+ * Shared peer-target resolution for --to/--direct flags on advisory scripts.
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4.
+ *
+ * Incident #2 root cause: scripts/adam-advisory.cjs and scripts/solomon-advisory.cjs
+ * both hardcoded `target = coordinatorId || 'broadcast-coordinator'` — a reply could
+ * never target the asker session directly, so a Solomon consult-reply to Adam's
+ * board-consult silently stranded at the coordinator lane. This module is the SINGLE
+ * shared source of truth both scripts import (no duplicated resolution logic).
+ *
+ * Two peer classes:
+ *   session — {adam, solomon, coordinator}: a live session_id always exists (or can
+ *             fail loud). Resolves via the existing role resolvers.
+ *   relay   — {eva, ceo}: no live session_id exists (confirmed: zero claude_sessions
+ *             rows with metadata.role in ('eva','ceo')). The caller must enqueue via
+ *             FR-1's relay-queue instead of a direct insert.
+ *
+ * @module lib/coordinator/peer-target
+ */
+
+'use strict';
+
+const defaultResolvers = require('./resolve.cjs');
+const defaultAdamIdentity = require('./adam-identity.cjs');
+const defaultSolomonIdentity = require('./solomon-identity.cjs');
+
+/** Registry of known peers and their class. Frozen — the single source of truth. */
+const PEER_KINDS = Object.freeze({
+  adam: { class: 'session', sentinel: 'broadcast-adam' },
+  solomon: { class: 'session', sentinel: 'broadcast-solomon' },
+  coordinator: { class: 'session', sentinel: 'broadcast-coordinator' },
+  eva: { class: 'relay', sentinel: null },
+  ceo: { class: 'relay', sentinel: null },
+});
+
+/**
+ * Resolve a --to <peer> value to a delivery target.
+ *
+ * Deps are injectable (default to the real modules) rather than hardcoded requires,
+ * per the "testable seam" convention used throughout this codebase's coordinator
+ * modules (receipts.cjs, pending-question-timer.cjs) — lets tests inject fixture
+ * resolvers instead of mocking nested CJS requires.
+ *
+ * @param {object} supabase
+ * @param {string} peer - one of PEER_KINDS' keys (case-insensitive)
+ * @param {object} [opts]
+ * @param {string|null} [opts.originator] - when set, this call is answering a specific
+ *   inbound row (a --reply-to flow); session-class peers then use the resolve*ReplyTarget
+ *   variant (prefer-live-singleton + stale-originator retarget) rather than the plain
+ *   getActive*Id, matching the incident #2 fix exactly. When absent (a fresh --to send,
+ *   not a reply), the plain getActive*Id resolver is used.
+ * @param {object} [deps] - injectable resolvers, default the real modules
+ * @returns {Promise<{kind:'session'|'relay', target:(string|null), sentinel:(string|null), peer:string, live:boolean, retargeted:boolean, relayVia:(string|null)}>}
+ */
+async function resolvePeerTarget(supabase, peer, opts = {}, deps = {}) {
+  const { originator = null } = opts;
+  const {
+    getActiveCoordinatorId = defaultResolvers.getActiveCoordinatorId,
+    getActiveAdamId = defaultAdamIdentity.getActiveAdamId,
+    resolveAdamReplyTarget = defaultAdamIdentity.resolveAdamReplyTarget,
+    getActiveSolomonId = defaultSolomonIdentity.getActiveSolomonId,
+    resolveSolomonReplyTarget = defaultSolomonIdentity.resolveSolomonReplyTarget,
+  } = deps;
+
+  const key = String(peer || '').trim().toLowerCase();
+  const entry = PEER_KINDS[key];
+
+  if (!entry) {
+    const known = Object.keys(PEER_KINDS).join(', ');
+    throw new Error(`resolvePeerTarget: unknown peer "${peer}" (known peers: ${known})`);
+  }
+
+  if (entry.class === 'relay') {
+    // No live session ever exists for a relay-class peer — always route via the
+    // coordinator's relay-request queue (FR-1), never a direct insert.
+    return { kind: 'relay', target: null, sentinel: null, peer: key, live: false, retargeted: false, relayVia: 'coordinator' };
+  }
+
+  // Session-class: resolve a live session_id.
+  if (key === 'adam') {
+    if (originator) {
+      const r = await resolveAdamReplyTarget(supabase, originator, {});
+      return { kind: 'session', target: r.target, sentinel: entry.sentinel, peer: key, live: Boolean(r.live), retargeted: r.retargeted, relayVia: null };
+    }
+    const live = await getActiveAdamId(supabase, {});
+    return { kind: 'session', target: live || entry.sentinel, sentinel: entry.sentinel, peer: key, live: Boolean(live), retargeted: false, relayVia: null };
+  }
+
+  if (key === 'solomon') {
+    if (originator) {
+      const r = await resolveSolomonReplyTarget(supabase, originator, {});
+      return { kind: 'session', target: r.target, sentinel: entry.sentinel, peer: key, live: Boolean(r.live), retargeted: r.retargeted, relayVia: null };
+    }
+    const live = await getActiveSolomonId(supabase, {});
+    return { kind: 'session', target: live || entry.sentinel, sentinel: entry.sentinel, peer: key, live: Boolean(live), retargeted: false, relayVia: null };
+  }
+
+  // coordinator
+  const live = await getActiveCoordinatorId(supabase);
+  return { kind: 'session', target: live || entry.sentinel, sentinel: entry.sentinel, peer: key, live: Boolean(live), retargeted: false, relayVia: null };
+}
+
+module.exports = { resolvePeerTarget, PEER_KINDS };

--- a/lib/coordinator/relay-drop-gauge.cjs
+++ b/lib/coordinator/relay-drop-gauge.cjs
@@ -1,0 +1,213 @@
+/**
+ * Unactioned relay/decision/review drop gauge.
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3.
+ *
+ * Mirrors the pure-core + fail-open + flag-gated SHAPE of
+ * lib/coordinator/pending-question-timer.cjs, with one structural delta: that module
+ * decides per-row over ONE set; this gauge is a CORRELATION — an inbound row implying
+ * a RELAY/DECISION/REVIEW action is flagged only if NO matching outbound row (a
+ * relay_confirm, or a decision-reply) exists within N minutes. Reproduces confirmed
+ * incident #1's exact shape: a relay-request acked-without-actioning, no outbound
+ * confirm, ~2h with nothing flagging the drop.
+ *
+ * CommonJS (.cjs) so a .cjs coordinator tick can require() it, mirroring
+ * pending-question-timer.cjs's module format.
+ *
+ * @module lib/coordinator/relay-drop-gauge
+ */
+
+'use strict';
+
+const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+
+/** Default drop-detection window: ~15min per the chairman inbox baseline (FR-3). */
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+
+/** Env flag gating the write-side of the tick (default OFF — read/report is always live). */
+function gaugeEnabled(env) {
+  env = env || process.env;
+  return String(env.RELAY_DROP_GAUGE_V1 ?? 'true').toLowerCase() !== 'false';
+}
+
+/** Resolve the drop-detection window (ms) from env, falling back to the default. */
+function resolveWindowMs(env) {
+  env = env || process.env;
+  const min = Number(env.RELAY_DROP_GAUGE_WINDOW_MIN);
+  return Number.isFinite(min) && min > 0 ? min * 60 * 1000 : DEFAULT_WINDOW_MS;
+}
+
+function tsMs(ts) {
+  if (!ts) return 0;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/** Inbound payload.kind values this gauge tracks (relay/decision/review action requests). */
+const TRACKED_INBOUND_KINDS = Object.freeze([
+  PAYLOAD_KINDS.RELAY_REQUEST,
+  'decision_request',
+  'review_request',
+]);
+
+/**
+ * Does this inbound row imply a RELAY/DECISION/REVIEW action the gauge should track?
+ * @param {object} row
+ * @returns {boolean}
+ */
+function isTrackedInbound(row) {
+  const kind = row && row.payload && row.payload.kind;
+  return TRACKED_INBOUND_KINDS.includes(kind);
+}
+
+/**
+ * The correlation id an inbound row is satisfied by, if any outbound row echoes it.
+ * @param {object} row
+ * @returns {string|null}
+ */
+function correlationOf(row) {
+  const p = row && row.payload;
+  return (p && (p.correlation_id || p.id)) || (row && row.id) || null;
+}
+
+/**
+ * Does this outbound row satisfy a tracked inbound row (a relay_confirm referencing
+ * confirm_relay_of/correlation_id, or a decision/review reply echoing reply_to)?
+ * @param {object} row
+ * @returns {string|null} the correlation id it satisfies, or null if it satisfies nothing
+ */
+function satisfiesCorrelation(row) {
+  const p = row && row.payload;
+  if (!p) return null;
+  if (p.kind === PAYLOAD_KINDS.RELAY_CONFIRM) return p.correlation_id || p.confirm_relay_of || null;
+  if (p.reply_to || p.in_reply_to) return p.reply_to || p.in_reply_to;
+  return null;
+}
+
+/**
+ * CORE — pure, dependency-injected correlation decision. Given inbound rows (candidate
+ * relay/decision/review requests) and outbound rows (candidate confirms/replies), flags
+ * any inbound row aged past the window with NO matching outbound. Zero IO.
+ *
+ * @param {Array<object>} inboundRows
+ * @param {Array<object>} outboundRows
+ * @param {object} [opts] - { now=Date.now(), windowMs=DEFAULT_WINDOW_MS }
+ * @returns {Array<object>} decisions, one per tracked inbound row:
+ *   { action:'flag'|'ok'|'pending', id, correlationId, ageMs, reason }
+ */
+function decideRelayDrops(inboundRows, outboundRows, opts = {}) {
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const windowMs = Number.isFinite(opts.windowMs) ? opts.windowMs : DEFAULT_WINDOW_MS;
+
+  const satisfiedCorrelations = new Set(
+    (outboundRows || [])
+      .map(satisfiesCorrelation)
+      .filter(Boolean)
+  );
+
+  const out = [];
+  for (const row of (inboundRows || [])) {
+    if (!isTrackedInbound(row)) continue;
+    const id = row && row.id != null ? row.id : null;
+    const correlationId = correlationOf(row);
+    const ageMs = now - tsMs(row.created_at);
+
+    if (correlationId && satisfiedCorrelations.has(correlationId)) {
+      out.push({ action: 'ok', id, correlationId, ageMs, reason: 'matching outbound found' });
+      continue;
+    }
+
+    if (ageMs < windowMs) {
+      out.push({ action: 'pending', id, correlationId, ageMs, reason: 'below window, not yet flaggable' });
+      continue;
+    }
+
+    out.push({ action: 'flag', id, correlationId, ageMs, reason: `no matching outbound within ${Math.round(windowMs / 60000)}min` });
+  }
+  return out;
+}
+
+/**
+ * IO: load candidate inbound rows (tracked kinds only, DB-side filter via .in()).
+ * FAIL-SOFT: [] on error.
+ */
+async function loadInboundCandidates(supabase, opts = {}) {
+  const { windowLookbackMs = 24 * 60 * 60 * 1000, now = Date.now() } = opts;
+  try {
+    const since = new Date(now - windowLookbackMs).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, payload, created_at')
+      .in('payload->>kind', TRACKED_INBOUND_KINDS)
+      .gte('created_at', since)
+      .limit(200);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * IO: load candidate outbound rows (relay_confirm rows, in the same lookback window).
+ * FAIL-SOFT: [] on error. Reply-kind rows (decision/review replies) are not payload.kind
+ * scoped in this codebase — callers that also want those should pass them in via the
+ * pure core directly rather than relying on this loader alone.
+ */
+async function loadOutboundCandidates(supabase, opts = {}) {
+  const { windowLookbackMs = 24 * 60 * 60 * 1000, now = Date.now() } = opts;
+  try {
+    const since = new Date(now - windowLookbackMs).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, payload, created_at')
+      .eq('payload->>kind', PAYLOAD_KINDS.RELAY_CONFIRM)
+      .gte('created_at', since)
+      .limit(200);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Tick entry point. FAIL-OPEN end to end — never throws. Read/report always runs;
+ * gaugeEnabled() only gates whether callers should act on 'flag' decisions (e.g. by
+ * writing a durable feedback row) — this module itself performs no writes.
+ * @param {object} supabase
+ * @param {object} [opts] - { env, now }
+ * @returns {Promise<{ enabled, decisions, flagged, ok, pending }>}
+ */
+async function planRelayDrops(supabase, opts = {}) {
+  const env = opts.env || process.env;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  try {
+    const [inbound, outbound] = await Promise.all([
+      loadInboundCandidates(supabase, { now }),
+      loadOutboundCandidates(supabase, { now }),
+    ]);
+    const decisions = decideRelayDrops(inbound, outbound, { now, windowMs: resolveWindowMs(env) });
+    return {
+      enabled: gaugeEnabled(env),
+      decisions,
+      flagged: decisions.filter((d) => d.action === 'flag').length,
+      ok: decisions.filter((d) => d.action === 'ok').length,
+      pending: decisions.filter((d) => d.action === 'pending').length,
+    };
+  } catch (e) {
+    return { enabled: gaugeEnabled(env), decisions: [], flagged: 0, ok: 0, pending: 0, error: String((e && e.message) || e) };
+  }
+}
+
+module.exports = {
+  decideRelayDrops,
+  isTrackedInbound,
+  correlationOf,
+  satisfiesCorrelation,
+  gaugeEnabled,
+  resolveWindowMs,
+  loadInboundCandidates,
+  loadOutboundCandidates,
+  planRelayDrops,
+  TRACKED_INBOUND_KINDS,
+  DEFAULT_WINDOW_MS,
+};

--- a/lib/coordinator/relay-queue.cjs
+++ b/lib/coordinator/relay-queue.cjs
@@ -27,10 +27,31 @@
 'use strict';
 
 const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+const { getActiveCoordinatorId } = require('./resolve.cjs');
 
 function toMs(ts) {
   const ms = ts ? Date.parse(ts) : NaN;
   return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * FAIL-SOFT wrapper: resolve.cjs's getActiveCoordinatorId is documented fail-open, but its
+ * file-first branch can still throw against a minimal test stub whose `.from()` only
+ * implements the query shapes a given test exercises (e.g. update/insert but not a bare
+ * select). Coordinator-id resolution here is advisory precision on the confirm row's
+ * sender_session, never a correctness-critical value (the 'broadcast-coordinator'/
+ * row.target_session fallback is always safe) -- so any error here is swallowed rather
+ * than propagating into drainOne's own catch and turning an otherwise-successful drain
+ * into a reported failure.
+ * @param {object} supabase
+ * @returns {Promise<string|null>}
+ */
+async function resolveCoordinatorIdSafe(supabase) {
+  try {
+    return await getActiveCoordinatorId(supabase);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -94,13 +115,19 @@ function buildRelayConfirmPayload({ correlationId, requestRowId, relayedTo }) {
 async function enqueueRelayRequest(supabase, { senderSession, relayTo, body, correlationId }) {
   const payload = buildRelayRequestPayload({ relayTo, body, correlationId });
   const subject = `[RELAY_REQUEST -> ${relayTo}] ${String(body || '').slice(0, 60)}`;
+  // target_session is the COORDINATOR (the queue-owner who must drain this row), not the
+  // asker — a prior version of this function set both sender_session and target_session to
+  // senderSession, which meant the FR-2 confirm row (built from row.sender_session/target_session
+  // in drainOne) ended up asker->asker instead of coordinator->asker, so it was invisible to
+  // coordinator-hourly-review.cjs's sender_session=<live coordinator> UNDELIVERED OUTBOUND check.
+  const coordinatorId = await resolveCoordinatorIdSafe(supabase);
   try {
     const { data, error } = await supabase
       .from('session_coordination')
       .insert({
         sender_session: senderSession,
         sender_type: 'coordinator',
-        target_session: senderSession, // the coordinator is both the queue-owner and the initial target; drain reassigns delivery
+        target_session: coordinatorId || 'broadcast-coordinator',
         message_type: 'INFO',
         subject,
         body: payload.body,
@@ -191,10 +218,16 @@ async function drainOne(supabase, row, sendRelay, now = Date.now()) {
       requestRowId: row.id,
       relayedTo: row.payload.relay_to,
     });
+    // Re-resolve the coordinator LIVE at drain time (not row.target_session, which was
+    // resolved at enqueue time and may point at a now-dead coordinator singleton if it
+    // restarted in between) -- matches the "prefer-live-singleton" convention this SD's
+    // own FR-4 established, and is required for coordinator-hourly-review.cjs's
+    // sender_session=<live coordinator> UNDELIVERED OUTBOUND check to see this confirm.
+    const liveCoordinatorId = await resolveCoordinatorIdSafe(supabase);
     const { error: confirmErr } = await supabase
       .from('session_coordination')
       .insert({
-        sender_session: row.target_session,
+        sender_session: liveCoordinatorId || row.target_session,
         sender_type: 'coordinator',
         target_session: row.sender_session,
         message_type: 'INFO',

--- a/lib/coordinator/relay-queue.cjs
+++ b/lib/coordinator/relay-queue.cjs
@@ -1,0 +1,227 @@
+/**
+ * Coordinator relay-request queue.
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1.
+ *
+ * Incident #1 root cause: a relay-request ("relay X to peer Y") was processed
+ * best-effort inside the coordinator's active conversational thread — no tracked
+ * queue, no delivery confirmation — so it silently dropped when the coordinator was
+ * busy (Solomon ran ~2h below baseline before the chairman noticed). This module
+ * gives the coordinator a TRACKED queue it drains deliberately.
+ *
+ * Storage: a session_coordination row, message_type='INFO' (existing enum — no
+ * ALTER TYPE), payload.kind=PAYLOAD_KINDS.RELAY_REQUEST, payload.correlation_id.
+ * No new table, no migration (independently re-verified via raw SQL).
+ *
+ * Split mirrors two existing prior-art files:
+ *   selectUndrained()      — PURE, zero IO, mirrors lib/coordinator/receipts.cjs's
+ *                            findUndelivered() selector shape.
+ *   enqueueRelayRequest()/
+ *   drainRelayQueue()      — IO wiring, mirrors lib/coordinator/pending-question-timer.cjs's
+ *                            pure-core + IO-tick split. Fail-open: a drain error never
+ *                            throws out of the tick.
+ *
+ * @module lib/coordinator/relay-queue
+ */
+
+'use strict';
+
+const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+
+function toMs(ts) {
+  const ms = ts ? Date.parse(ts) : NaN;
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * PURE: select relay_request rows that have not yet been drained (no receipt
+ * contract markers set). Mirrors receipts.cjs's read_at/payload.actioned_at
+ * DELIVERED/ACTIONED contract — a drained row has BOTH acknowledged_at and
+ * payload.actioned_at set by drainRelayQueue().
+ *
+ * @param {Array<object>} rows - session_coordination rows (any payload.kind; filtered here)
+ * @param {object} [opts] - { now=Date.now() }
+ * @returns {Array<object>} undrained relay_request rows, oldest first, each annotated with ageMs
+ */
+function selectUndrained(rows, opts = {}) {
+  const { now = Date.now() } = opts;
+  return (rows || [])
+    .filter((r) => r && r.payload && r.payload.kind === PAYLOAD_KINDS.RELAY_REQUEST)
+    .filter((r) => !r.acknowledged_at && !(r.payload && r.payload.actioned_at))
+    .map((r) => ({ ...r, ageMs: now - toMs(r.created_at) }))
+    .sort((a, b) => b.ageMs - a.ageMs);
+}
+
+/**
+ * PURE: build the payload for a new relay_request row.
+ * @param {{ relayTo: string, body: string, correlationId: string }} opts
+ * @returns {object}
+ */
+function buildRelayRequestPayload({ relayTo, body, correlationId }) {
+  return {
+    kind: PAYLOAD_KINDS.RELAY_REQUEST,
+    relay_to: relayTo,
+    body: body || null,
+    correlation_id: correlationId,
+  };
+}
+
+/**
+ * PURE: build the payload for the confirm-back row (FR-2's reply-direction half).
+ * A NEW correlated row, not a mutation of the request row — this is what makes the
+ * confirm itself independently delivery-tracked via the existing findUndelivered()
+ * machinery in receipts.cjs.
+ * @param {{ correlationId: string, requestRowId: string, relayedTo: string }} opts
+ * @returns {object}
+ */
+function buildRelayConfirmPayload({ correlationId, requestRowId, relayedTo }) {
+  return {
+    kind: PAYLOAD_KINDS.RELAY_CONFIRM,
+    correlation_id: correlationId,
+    confirm_relay_of: requestRowId,
+    relayed_to: relayedTo,
+  };
+}
+
+/**
+ * IO: enqueue a new relay_request row. Fail-loud on the insert itself (the caller
+ * needs to know if the request was NOT queued), but never throws for a downstream
+ * side-effect failure since there are none at enqueue time.
+ * @param {object} supabase
+ * @param {{ senderSession: string, relayTo: string, body: string, correlationId: string }} opts
+ * @returns {Promise<{ data: object|null, error: string|null }>}
+ */
+async function enqueueRelayRequest(supabase, { senderSession, relayTo, body, correlationId }) {
+  const payload = buildRelayRequestPayload({ relayTo, body, correlationId });
+  const subject = `[RELAY_REQUEST -> ${relayTo}] ${String(body || '').slice(0, 60)}`;
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .insert({
+        sender_session: senderSession,
+        sender_type: 'coordinator',
+        target_session: senderSession, // the coordinator is both the queue-owner and the initial target; drain reassigns delivery
+        message_type: 'INFO',
+        subject,
+        body: payload.body,
+        payload,
+      })
+      .select('id, created_at')
+      .single();
+    if (error) return { data: null, error: error.message };
+    return { data, error: null };
+  } catch (e) {
+    return { data: null, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * IO: load candidate relay_request rows (payload.kind filter pushed to the DB).
+ * FAIL-SOFT: returns [] on any error, never throws.
+ * @param {object} supabase
+ * @returns {Promise<Array<object>>}
+ */
+async function loadQueuedRelayRequests(supabase) {
+  try {
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, sender_session, target_session, payload, acknowledged_at, created_at')
+      .eq('payload->>kind', PAYLOAD_KINDS.RELAY_REQUEST)
+      .order('created_at', { ascending: true })
+      .limit(50);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * IO: drain ONE relay_request row — perform the actual relay (a caller-supplied
+ * sender function so this module never hardcodes which peer-send mechanism to use),
+ * then write BOTH FR-2 receipt markers: the same-row ACTIONED marker
+ * (acknowledged_at + payload.actioned_at) AND a NEW correlated relay_confirm row.
+ * Idempotent: the .is('acknowledged_at', null) guard means a row another tick
+ * already drained is a no-op, not a double-relay.
+ *
+ * @param {object} supabase
+ * @param {object} row - a row from selectUndrained()/loadQueuedRelayRequests()
+ * @param {(row:object) => Promise<{ok:boolean, error?:string}>} sendRelay - performs the actual delivery
+ * @param {number} [now]
+ * @returns {Promise<{ ok: boolean, confirmed: boolean, error?: string }>}
+ */
+async function drainOne(supabase, row, sendRelay, now = Date.now()) {
+  try {
+    const sendResult = await sendRelay(row);
+    if (!sendResult || !sendResult.ok) {
+      return { ok: false, confirmed: false, error: (sendResult && sendResult.error) || 'sendRelay failed' };
+    }
+
+    const nowIso = new Date(now).toISOString();
+    const mergedPayload = Object.assign({}, row.payload, { actioned_at: nowIso });
+    const { error: updErr } = await supabase
+      .from('session_coordination')
+      .update({ acknowledged_at: nowIso, payload: mergedPayload })
+      .eq('id', row.id)
+      .is('acknowledged_at', null); // idempotency guard — only the still-undrained row
+    if (updErr) return { ok: false, confirmed: false, error: `receipt update failed: ${updErr.message}` };
+
+    const confirmPayload = buildRelayConfirmPayload({
+      correlationId: row.payload.correlation_id,
+      requestRowId: row.id,
+      relayedTo: row.payload.relay_to,
+    });
+    const { error: confirmErr } = await supabase
+      .from('session_coordination')
+      .insert({
+        sender_session: row.target_session,
+        sender_type: 'coordinator',
+        target_session: row.sender_session,
+        message_type: 'INFO',
+        subject: `[RELAY_CONFIRM] relayed to ${row.payload.relay_to}`,
+        payload: confirmPayload,
+      });
+    if (confirmErr) return { ok: true, confirmed: false, error: `confirm insert failed: ${confirmErr.message}` };
+
+    return { ok: true, confirmed: true };
+  } catch (e) {
+    return { ok: false, confirmed: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
+ * Tick entry point. Loads queued relay_request rows, drains each via the pure
+ * selector + drainOne, and returns a structured summary. FAIL-OPEN end to end —
+ * never throws out of the tick.
+ * @param {object} supabase
+ * @param {(row:object) => Promise<{ok:boolean, error?:string}>} sendRelay
+ * @param {object} [opts] - { now }
+ * @returns {Promise<{ drained: number, failed: number, errors: Array<string> }>}
+ */
+async function drainRelayQueue(supabase, sendRelay, opts = {}) {
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  try {
+    const candidates = await loadQueuedRelayRequests(supabase);
+    const undrained = selectUndrained(candidates, { now });
+    let drained = 0;
+    let failed = 0;
+    const errors = [];
+    for (const row of undrained) {
+      const result = await drainOne(supabase, row, sendRelay, now);
+      if (result.ok) drained++;
+      else { failed++; if (result.error) errors.push(result.error); }
+    }
+    return { drained, failed, errors };
+  } catch (e) {
+    return { drained: 0, failed: 0, errors: [String((e && e.message) || e)] };
+  }
+}
+
+module.exports = {
+  selectUndrained,
+  buildRelayRequestPayload,
+  buildRelayConfirmPayload,
+  enqueueRelayRequest,
+  loadQueuedRelayRequests,
+  drainOne,
+  drainRelayQueue,
+};

--- a/lib/coordinator/relay-queue.cjs
+++ b/lib/coordinator/relay-queue.cjs
@@ -140,8 +140,17 @@ async function loadQueuedRelayRequests(supabase) {
  * sender function so this module never hardcodes which peer-send mechanism to use),
  * then write BOTH FR-2 receipt markers: the same-row ACTIONED marker
  * (acknowledged_at + payload.actioned_at) AND a NEW correlated relay_confirm row.
- * Idempotent: the .is('acknowledged_at', null) guard means a row another tick
- * already drained is a no-op, not a double-relay.
+ *
+ * Claims the row BEFORE calling sendRelay via a conditional UPDATE ... WHERE
+ * acknowledged_at IS NULL ... RETURNING id (the `.select('id')` on the update).
+ * Two ticks racing on the same undrained row both pass selectUndrained()'s filter,
+ * but only ONE can win this atomic claim — the loser sees zero affected rows and
+ * backs off WITHOUT ever calling sendRelay (closes the concurrent-tick double-send
+ * gap: previously sendRelay ran BEFORE the idempotency guard, so a race window
+ * existed between two ticks both sending the same relay). A sendRelay failure
+ * un-claims the row (resets acknowledged_at to null) so a future tick retries it —
+ * a transient send failure must never permanently strand the request, which is
+ * exactly incident #1's failure mode this SD exists to close.
  *
  * @param {object} supabase
  * @param {object} row - a row from selectUndrained()/loadQueuedRelayRequests()
@@ -151,18 +160,30 @@ async function loadQueuedRelayRequests(supabase) {
  */
 async function drainOne(supabase, row, sendRelay, now = Date.now()) {
   try {
+    const nowIso = new Date(now).toISOString();
+    const { data: claimed, error: claimErr } = await supabase
+      .from('session_coordination')
+      .update({ acknowledged_at: nowIso })
+      .eq('id', row.id)
+      .is('acknowledged_at', null) // idempotency guard — only the still-undrained row
+      .select('id');
+    if (claimErr) return { ok: false, confirmed: false, error: `claim failed: ${claimErr.message}` };
+    if (!claimed || claimed.length === 0) {
+      return { ok: true, confirmed: false, error: 'already claimed by another tick' };
+    }
+
     const sendResult = await sendRelay(row);
     if (!sendResult || !sendResult.ok) {
+      // Un-claim so a future tick retries — never permanently strand on a transient send failure.
+      await supabase.from('session_coordination').update({ acknowledged_at: null }).eq('id', row.id);
       return { ok: false, confirmed: false, error: (sendResult && sendResult.error) || 'sendRelay failed' };
     }
 
-    const nowIso = new Date(now).toISOString();
     const mergedPayload = Object.assign({}, row.payload, { actioned_at: nowIso });
     const { error: updErr } = await supabase
       .from('session_coordination')
-      .update({ acknowledged_at: nowIso, payload: mergedPayload })
-      .eq('id', row.id)
-      .is('acknowledged_at', null); // idempotency guard — only the still-undrained row
+      .update({ payload: mergedPayload })
+      .eq('id', row.id);
     if (updErr) return { ok: false, confirmed: false, error: `receipt update failed: ${updErr.message}` };
 
     const confirmPayload = buildRelayConfirmPayload({

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -64,6 +64,8 @@ const PAYLOAD_KINDS = Object.freeze({
   ADAM_ADVISORY: 'adam_advisory',     // SD-...-001-B: Adam advisory clean lane (off friction router)
   CANARY_REQUEST: 'canary_request',   // SD-LEO-INFRA-CANARY-SUPPORT-TRIGGER-RELIABILITY-001: durable Adam canary-verification request (advisory; excluded from the Adam generic inbox drain — owned by the canary responder)
   SOLOMON_CONSULT: 'solomon_consult', // SD-LEO-INFRA-SOLOMON-CONSULT-001D: worker/Adam→Solomon oracle consult (off friction router; reply travels under adam_advisory+oracle:true; intentionally NOT a DIRECTIVE_KIND)
+  RELAY_REQUEST: 'relay_request',     // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1: a tracked relay-request the coordinator drains deliberately (never processed inline in the active thread). Intentionally NOT a DIRECTIVE_KIND — the generic worker inbox drain must never auto-consume it; only coordinator-relay-drain.cjs may act on it.
+  RELAY_CONFIRM: 'relay_confirm',     // FR-2: the durable confirm-back row correlated to a relay_request via payload.correlation_id — CONFIRM-ON-RELAY is only satisfied once this row exists.
 });
 
 // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): payload.kind values that are

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "vision:s19-coverage-gauge": "node scripts/s19-vision-coverage-gauge.mjs",
     "gauges:run": "node scripts/gauge-runner.mjs",
+    "coordinator:relay-drain": "node scripts/coordinator-relay-drain.cjs",
+    "coordinator:relay-drop-gauge": "node scripts/coordinator-relay-drop-gauge.cjs",
     "vision:build-forecast": "node scripts/vision/build-completion-forecast.mjs",
     "vision:build-forecast:apply": "node scripts/vision/build-completion-forecast.mjs --apply",
     "vision:rung-rollup": "node scripts/vision/rung-progress-rollup.mjs",

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -31,6 +31,12 @@
  * a DIRECT 1-hop write to Solomon's own session (no coordinator relay hop), gated by
  * ADAM_SOLOMON_TWOWAY_V1=on (default OFF). Omitting --to is byte-identical unchanged behavior —
  * the existing coordinator-relay path is the permanent fallback, never removed.
+ *   node scripts/adam-advisory.cjs send --direct "<body>"                          (shorthand for --to solomon)
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: `--to` also accepts the
+ * relay-class peers eva/ceo (lib/coordinator/peer-target.cjs's PEER_KINDS registry) — these have no
+ * live session, so they enqueue a tracked FR-1 relay-request instead of a direct write:
+ *   node scripts/adam-advisory.cjs send --to eva "<body>"                          (relay-class peer: enqueues a tracked FR-1 relay-request instead of a direct insert)
  */
 
 const crypto = require('crypto');
@@ -39,6 +45,8 @@ const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signa
 const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled } = require('../lib/coordinator/resolve.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
+const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const { REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies } = require('../lib/coordinator/reply-class.cjs');
@@ -532,24 +540,53 @@ async function main() {
   }
   // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send/request --to solomon` — direct
   // 1-hop channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default OFF; omitting --to is unchanged).
+  // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: --to also accepts
+  // the relay-class peers eva/ceo (lib/coordinator/peer-target.cjs's PEER_KINDS registry) —
+  // these enqueue a tracked FR-1 relay-request instead of a direct write. --direct is
+  // shorthand for --to solomon (Adam's one lateral session-class peer).
   const toIdx = argv.indexOf('--to');
   const toArg = toIdx >= 0 ? argv[toIdx + 1] || null : null;
-  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1].filter(i => i >= 0));
+  const directIdx = argv.indexOf('--direct');
+  const peerArg = toArg || (directIdx >= 0 ? 'solomon' : null);
+  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx].filter(i => i >= 0));
   const body = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
   if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
 
-  if (toArg && toArg !== 'solomon') {
-    console.error(`ERROR: --to ${toArg} is not supported (only "solomon" — omit --to for the default coordinator-relay target).`);
+  const isRelayClassPeer = !!(peerArg && PEER_KINDS[peerArg] && PEER_KINDS[peerArg].class === 'relay');
+  if (peerArg && peerArg !== 'solomon' && !isRelayClassPeer) {
+    const relayPeers = Object.keys(PEER_KINDS).filter((k) => PEER_KINDS[k].class === 'relay').join(', ');
+    console.error(`ERROR: --to ${peerArg} is not supported (one of "solomon", ${relayPeers} — omit --to for the default coordinator-relay target).`);
     process.exit(2);
   }
   const twoWayV1On = isAdamSolomonTwoWayV1Enabled();
-  if (toArg === 'solomon' && !twoWayV1On) {
+  if (peerArg === 'solomon' && !twoWayV1On) {
     console.error('ERROR: --to solomon is gated by ADAM_SOLOMON_TWOWAY_V1=on (currently OFF). Omit --to to route via the coordinator.');
     process.exit(3);
   }
 
+  // FR-4 relay-class path: eva/ceo have no live session, so a relay-class --to enqueues a
+  // tracked FR-1 relay_request via the coordinator queue instead of a direct insert — the
+  // coordinator's relay-drain tick (FR-1/FR-2) performs the actual delivery + writes the
+  // CONFIRM-ON-RELAY receipt. This is a fundamentally different row shape than a direct
+  // advisory, so it short-circuits here, before any target/session resolution below.
+  if (isRelayClassPeer) {
+    const relayCorrelationId = crypto.randomUUID();
+    const { data, error } = await enqueueRelayRequest(supabase, {
+      senderSession: sessionId,
+      relayTo: peerArg,
+      body,
+      correlationId: relayCorrelationId,
+    });
+    if (error) { console.error('ERROR: failed to enqueue relay-request:', error); process.exit(1); }
+    console.log('✓ Relay-request enqueued (tracked -- coordinator will drain + confirm)');
+    console.log('  relay_request_id:', data.id);
+    console.log('  relay_to:', peerArg);
+    console.log('  correlation_id:', relayCorrelationId);
+    return;
+  }
+
   const coordinatorId = await getActiveCoordinatorId(supabase);
-  const toSolomon = toArg === 'solomon';
+  const toSolomon = peerArg === 'solomon';
   const solomonId = toSolomon && twoWayV1On ? await getActiveSolomonId(supabase).catch(() => null) : null;
   const { target, via } = resolveAdamAdvisoryTarget({ toSolomon, flagOn: twoWayV1On, coordinatorId, solomonId });
   const senderCallsign = await snapshotSender(supabase, sessionId);

--- a/scripts/coordinator-email-summary.mjs
+++ b/scripts/coordinator-email-summary.mjs
@@ -154,6 +154,23 @@ try {
   console.warn('[coordinator-email] cost panel skipped:', e.message);
 }
 
+// ── relay/decision/review drop-gauge panel (SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-
+//    DELIVERY-GUARANTEE-001 / FR-3) — this away-mode email is the durable instrument for
+//    exactly the failure class confirmed incident #1 was: a relay-request dropped ~2h with
+//    nothing surfacing it until the chairman happened to notice. Fail-soft, isolated,
+//    never blocks the email. ──
+let relayDropHtml = '', relayDropText = '';
+try {
+  const { planRelayDrops } = await import('../lib/coordinator/relay-drop-gauge.cjs');
+  const gauge = await planRelayDrops(db);
+  if (gauge.flagged > 0) {
+    relayDropHtml = `<p style="font-size:15px;margin:0 0 10px;padding:10px 12px;background:#fdecea;border-left:4px solid #e74c3c;border-radius:3px"><b>⚠️ ${gauge.flagged} relay/decision/review row(s) unactioned past the drop window</b></p>`;
+    relayDropText = `⚠️ ${gauge.flagged} relay/decision/review row(s) unactioned past the drop window\n\n`;
+  }
+} catch (e) {
+  console.warn('[coordinator-email] relay-drop-gauge panel skipped:', e.message);
+}
+
 // ── render ──
 const dot = { red: '🔴', yellow: '🟡', green: '🟢' }[overall];
 const word = { red: 'RED', yellow: 'YELLOW', green: 'GREEN' }[overall];
@@ -180,12 +197,12 @@ const subject = flag + (workable === 0
 const qHtml = qN ? `<p style="font-size:15px;margin:0 0 10px;padding:10px 12px;background:#fff8e1;border-left:4px solid #f5a623;border-radius:3px"><b>❓ ${qN} question${qN > 1 ? 's' : ''} need${qN > 1 ? '' : 's'} your input</b><br>${questions.map(q => { const l = qLabel(q); return `• ${esc(l.text)} <span style="color:#999;font-size:13px">— ${esc(l.who)}${esc(l.sd)}</span>`; }).join('<br>')}</p>` : '';
 const liveHtml = incognito ? `<p style="font-size:14px;margin:0 0 8px;padding:8px 10px;background:#fdecea;border-left:4px solid #d9534f;border-radius:3px"><b>🔔 Needs you:</b> ${incognito} worker${incognito > 1 ? 's' : ''} went incognito — a wake-prompt re-paste (or a relaunch for an orphaned-identity window) refills the fleet.</p>` : '';
 const html = `<p style="font-size:17px;margin:0 0 10px"><b>${dot} ${word}</b> — ${meaning} <span style="color:#777;font-size:14px">(${trendWord} ${trendArrow})</span></p>
-${qHtml}${liveHtml}<p style="font-size:14px;margin:0 0 6px"><b>Active workers:</b> ${gauge}${workable ? ` · ${workable} item${workable > 1 ? 's' : ''} in play` : ''}</p>
+${qHtml}${liveHtml}${relayDropHtml}<p style="font-size:14px;margin:0 0 6px"><b>Active workers:</b> ${gauge}${workable ? ` · ${workable} item${workable > 1 ? 's' : ''} in play` : ''}</p>
 <p style="font-size:13px;color:#777;margin:0 0 6px">📦 Since last email: <b>+${shippedSince}</b> shipped</p>
 ${costHtml}<p style="font-size:11px;color:#999;margin:14px 0 0">${when} ET</p>`;
 const qText = qN ? `❓ ${qN} question${qN > 1 ? 's' : ''} need${qN > 1 ? '' : 's'} your input:\n${questions.map(q => { const l = qLabel(q); return `  • ${l.text} — ${l.who}${l.sd}`; }).join('\n')}\n\n` : '';
 const liveText = incognito ? `🔔 Needs you: ${incognito} worker${incognito > 1 ? 's' : ''} went incognito — a wake re-paste/relaunch refills the fleet.\n\n` : '';
-const text = `${dot} ${word} — ${meaning} (${trendWord} ${trendArrow})\n\n${qText}${liveText}Active workers: ${gauge}${workable ? ` · ${workable} item(s) in play` : ''}\nSince last email: +${shippedSince} shipped\n${costText}\n${when} ET`;
+const text = `${dot} ${word} — ${meaning} (${trendWord} ${trendArrow})\n\n${qText}${liveText}${relayDropText}Active workers: ${gauge}${workable ? ` · ${workable} item(s) in play` : ''}\nSince last email: +${shippedSince} shipped\n${costText}\n${when} ET`;
 
 // QF-20260609-738: skip-if-unchanged + max-staleness heartbeat. The */30 cron used to
 // send EVERY run even when nothing material changed (the chairman is usually away), so the

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -254,6 +254,21 @@ async function main() {
   } catch (e) {
     console.log('[HOURLY-REVIEW] gauge-runner liveness check skipped (non-fatal): ' + e.message);
   }
+
+  // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3: surface the
+  // relay/decision/review drop gauge. Read-only + fail-open (planRelayDrops never throws).
+  try {
+    const { planRelayDrops } = require('../lib/coordinator/relay-drop-gauge.cjs');
+    const gauge = await planRelayDrops(sb);
+    if (gauge.flagged > 0) {
+      console.log('\n[HOURLY-REVIEW] RELAY/DECISION/REVIEW DROPS — ' + gauge.flagged + ' row(s) with no matching outbound within the window:');
+      gauge.decisions.filter(function (d) { return d.action === 'flag'; }).slice(0, 10).forEach(function (d) {
+        console.log('  • [' + String(d.id).slice(0, 8) + '] correlation=' + String(d.correlationId).slice(0, 8) + ' | unactioned ' + Math.floor(d.ageMs / 60000) + 'm | ' + d.reason);
+      });
+    }
+  } catch (e) {
+    console.log('[HOURLY-REVIEW] relay-drop-gauge check skipped (non-fatal): ' + e.message);
+  }
 }
 
 // SD-LEO-INFRA-SOLOMON-HOURLY-ROLE-REFRESHER-001: guard the main() invocation so the Solomon leg can be

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -68,6 +68,13 @@ export const COMPOSED_CORES = [
   // periodic-cron lag are most likely to have gone unnoticed).
   { key: 'unranked-gauge', script: 'gauge-unranked-claimable-leaves.mjs', args: ['scripts/gauge-unranked-claimable-leaves.mjs'], quiescentSkip: false },
   { key: 'audit', script: 'coordinator-audit.mjs', args: ['scripts/coordinator-audit.mjs'], quiescentSkip: true },
+  // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2: NOT
+  // quiescentSkip -- a queued relay-request is exactly as urgent when the fleet is
+  // otherwise quiet (a quiet fleet is precisely when a relay is most likely to sit
+  // undrained, per confirmed incident #1).
+  { key: 'relay-drain', script: 'coordinator-relay-drain.cjs', args: ['scripts/coordinator-relay-drain.cjs'], quiescentSkip: false },
+  // FR-3: cheap read + fail-open write; valuable exactly when quiet for the same reason.
+  { key: 'relay-drop-gauge', script: 'coordinator-relay-drop-gauge.cjs', args: ['scripts/coordinator-relay-drop-gauge.cjs'], quiescentSkip: false },
 ];
 
 /** Build the fail-soft core list for the current mode (quiescent skips the expensive cores). */

--- a/scripts/coordinator-relay-drain.cjs
+++ b/scripts/coordinator-relay-drain.cjs
@@ -27,12 +27,21 @@ function getSupabase() {
 }
 
 /**
- * Perform the actual relay: resolve the target peer's live session, then insert a
- * direct advisory row. Session-class peers only reach this point (a relay-class
- * peer's own advisory-script insert already IS the enqueue -- this tick only drains
- * to a resolvable session). Fail loud on an unresolvable peer so the row stays
- * undrained (and eventually surfaces via the FR-3 drop gauge) rather than silently
- * discarding a queued relay.
+ * Perform the actual relay. Two peer classes, two delivery contracts:
+ *   session — resolve the target peer's live session, then insert a direct advisory row.
+ *   relay   — eva/ceo NEVER have a live session (peer-target.cjs's PEER_KINDS registry,
+ *             TS-2). There is nothing to insert TO. In production the relay-class path is
+ *             the ONLY one ever enqueued (adam-advisory.cjs / solomon-advisory.cjs only call
+ *             enqueueRelayRequest for relay-class peers; session-class --to targets go via a
+ *             direct insert and never touch this queue). Treating "no live session" as a
+ *             drain FAILURE here would mean the row perpetually un-claims and retries every
+ *             tick, forever, and gets wrongly flagged by the FR-3 drop gauge as a real drop
+ *             (VALIDATION-caught during PLAN_VERIFICATION, TS-7 was the integration scenario
+ *             that would have caught this but was never implemented in EXEC). The correct
+ *             contract for a permanently-dormant peer: the durable, FR-3-surfaced
+ *             relay_request + relay_confirm pair in session_coordination IS the delivery —
+ *             there is no live-session insert to perform, so this returns ok:true without
+ *             attempting one, and drainOne proceeds to write both FR-2 receipt markers.
  * @param {object} supabase
  * @returns {(row:object) => Promise<{ok:boolean, error?:string}>}
  */
@@ -42,7 +51,10 @@ function makeSendRelay(supabase) {
     if (!peer) return { ok: false, error: 'row has no payload.relay_to' };
     try {
       const resolved = await resolvePeerTarget(supabase, peer, {});
-      if (resolved.kind === 'relay' || !resolved.target) {
+      if (resolved.kind === 'relay') {
+        return { ok: true };
+      }
+      if (!resolved.target) {
         return { ok: false, error: `relay_to "${peer}" has no resolvable live session` };
       }
       const { error } = await supabase

--- a/scripts/coordinator-relay-drain.cjs
+++ b/scripts/coordinator-relay-drain.cjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Coordinator relay-request drain tick (FR-1/FR-2).
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001.
+ *
+ * Drains queued relay_request rows deliberately -- the coordinator no longer
+ * processes a relay inline in its active thread. For each undrained row, performs
+ * the actual relay (a direct session_coordination insert to the resolved live
+ * peer), then writes BOTH FR-2 receipt markers via relay-queue.cjs's drainOne().
+ *
+ * Usage: node scripts/coordinator-relay-drain.cjs [--dry-run]
+ */
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const { drainRelayQueue } = require('../lib/coordinator/relay-queue.cjs');
+const { resolvePeerTarget } = require('../lib/coordinator/peer-target.cjs');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+  return createClient(url, key);
+}
+
+/**
+ * Perform the actual relay: resolve the target peer's live session, then insert a
+ * direct advisory row. Session-class peers only reach this point (a relay-class
+ * peer's own advisory-script insert already IS the enqueue -- this tick only drains
+ * to a resolvable session). Fail loud on an unresolvable peer so the row stays
+ * undrained (and eventually surfaces via the FR-3 drop gauge) rather than silently
+ * discarding a queued relay.
+ * @param {object} supabase
+ * @returns {(row:object) => Promise<{ok:boolean, error?:string}>}
+ */
+function makeSendRelay(supabase) {
+  return async function sendRelay(row) {
+    const peer = row.payload && row.payload.relay_to;
+    if (!peer) return { ok: false, error: 'row has no payload.relay_to' };
+    try {
+      const resolved = await resolvePeerTarget(supabase, peer, {});
+      if (resolved.kind === 'relay' || !resolved.target) {
+        return { ok: false, error: `relay_to "${peer}" has no resolvable live session` };
+      }
+      const { error } = await supabase
+        .from('session_coordination')
+        .insert({
+          sender_session: row.target_session,
+          sender_type: 'coordinator',
+          target_session: resolved.target,
+          message_type: 'INFO',
+          subject: `[RELAYED] ${String(row.payload.body || '').slice(0, 60)}`,
+          body: row.payload.body || null,
+          payload: { kind: 'adam_advisory', body: row.payload.body || null, correlation_id: row.payload.correlation_id, relayed_from: row.sender_session },
+        });
+      if (error) return { ok: false, error: error.message };
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: String((e && e.message) || e) };
+    }
+  };
+}
+
+async function main() {
+  if (DRY_RUN) {
+    console.log('[coordinator-relay-drain] --dry-run: no writes performed.');
+    return;
+  }
+  const supabase = getSupabase();
+  const result = await drainRelayQueue(supabase, makeSendRelay(supabase));
+  console.log(`drained=${result.drained} failed=${result.failed}${result.errors.length ? ' errors=' + result.errors.join('; ') : ''}`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('coordinator-relay-drain failed:', (e && e.message) || e);
+    process.exit(1);
+  });
+}
+
+module.exports = { makeSendRelay };

--- a/scripts/coordinator-relay-drop-gauge.cjs
+++ b/scripts/coordinator-relay-drop-gauge.cjs
@@ -44,6 +44,8 @@ async function recordFlags(supabase, decisions) {
         category: 'relay_drop',
         type: 'issue',
         status: 'new',
+        source_application: 'EHG_Engineer',
+        source_type: 'auto_capture',
         title: `Relay/decision/review drop: correlation ${String(d.correlationId).slice(0, 8)}`,
         description: d.reason,
         metadata: { correlation_id: d.correlationId, row_id: d.id, age_ms: d.ageMs },

--- a/scripts/coordinator-relay-drop-gauge.cjs
+++ b/scripts/coordinator-relay-drop-gauge.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Coordinator relay/decision/review drop-gauge tick (FR-3).
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001.
+ *
+ * Read/report always runs (fail-open, per lib/coordinator/relay-drop-gauge.cjs).
+ * When a drop is flagged, writes a durable feedback row (category='relay_drop')
+ * so it survives past this tick's stdout and is queryable by
+ * coordinator-hourly-review.cjs / fleet-dashboard.cjs / coordinator-email-summary.mjs.
+ * Idempotent per (correlationId): a row already flagged for the same correlation is
+ * not re-inserted.
+ *
+ * Usage: node scripts/coordinator-relay-drop-gauge.cjs [--dry-run]
+ */
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const { planRelayDrops } = require('../lib/coordinator/relay-drop-gauge.cjs');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required.');
+  return createClient(url, key);
+}
+
+/** Fail-soft: write a durable feedback row for each newly-flagged drop, skipping dupes. */
+async function recordFlags(supabase, decisions) {
+  const flagged = decisions.filter((d) => d.action === 'flag' && d.correlationId);
+  let written = 0;
+  for (const d of flagged) {
+    try {
+      const { data: existing } = await supabase
+        .from('feedback')
+        .select('id')
+        .eq('category', 'relay_drop')
+        .contains('metadata', { correlation_id: d.correlationId })
+        .limit(1);
+      if (existing && existing.length) continue; // already flagged, idempotent skip
+      const { error } = await supabase.from('feedback').insert({
+        category: 'relay_drop',
+        type: 'issue',
+        status: 'new',
+        title: `Relay/decision/review drop: correlation ${String(d.correlationId).slice(0, 8)}`,
+        description: d.reason,
+        metadata: { correlation_id: d.correlationId, row_id: d.id, age_ms: d.ageMs },
+      });
+      if (!error) written++;
+    } catch { /* fail-soft: one bad row doesn't block the rest */ }
+  }
+  return written;
+}
+
+async function main() {
+  const supabase = getSupabase();
+  const result = await planRelayDrops(supabase);
+  console.log(`flagged=${result.flagged} ok=${result.ok} pending=${result.pending}${result.error ? ' error=' + result.error : ''}`);
+  if (DRY_RUN) {
+    console.log('[coordinator-relay-drop-gauge] --dry-run: no writes performed.');
+    return;
+  }
+  const written = await recordFlags(supabase, result.decisions);
+  if (written) console.log(`  recorded ${written} new flag(s) to feedback`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('coordinator-relay-drop-gauge failed:', (e && e.message) || e);
+    process.exit(1);
+  });
+}
+
+module.exports = { recordFlags };

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -97,6 +97,17 @@ export const STANDARD_LOOPS = [
   // always observes a just-refreshed rank rather than racing it.
   { key: 'unranked-gauge', label: 'Eligible-but-unranked-leaf-count invariant gauge', script: 'gauge-unranked-claimable-leaves.mjs', cron: '9,24,39,54 * * * *',
     prompt: 'node scripts/gauge-unranked-claimable-leaves.mjs' },
+  // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2: drains
+  // the tracked relay-request queue deliberately (never processed inline in the active
+  // thread) and writes the CONFIRM-ON-RELAY receipt. Frequent — a queued relay-request is
+  // exactly as urgent when the fleet is quiet (confirmed incident #1: ~2h undrained).
+  { key: 'relay-drain', label: 'Relay-request queue drain + confirm-on-relay', script: 'coordinator-relay-drain.cjs', cron: '1,16,31,46 * * * *',
+    prompt: 'node scripts/coordinator-relay-drain.cjs' },
+  // FR-3: the drop-gauge — flags any inbound RELAY/DECISION/REVIEW row with no matching
+  // outbound within the window (default ~15min). Offset from relay-drain so it observes a
+  // just-drained queue rather than racing it.
+  { key: 'relay-drop-gauge', label: 'Unactioned relay/decision/review drop gauge', script: 'coordinator-relay-drop-gauge.cjs', cron: '11,26,41,56 * * * *',
+    prompt: 'node scripts/coordinator-relay-drop-gauge.cjs' },
   // SD-LEO-INFRA-ENABLE-WIRE-AUTOMATIC-001 (FR-2a): restore the worker fleet-retro to a schedule
   // (it had drifted to manual — last ran ~2.5d ago). Re-arms the existing, idempotent capture/
   // synthesis script (reuses the feedback/issue_patterns pipeline; dedups on metadata.retro_key).

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1531,6 +1531,32 @@ async function printUndeliveredOutbound() {
   console.log('');
 }
 
+// SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3: surface the
+// relay/decision/review drop gauge — mirrors printUndeliveredOutbound()'s shape. Read-only
+// + fail-open (planRelayDrops never throws).
+async function printRelayDropGauge() {
+  const { planRelayDrops } = require('../lib/coordinator/relay-drop-gauge.cjs');
+
+  console.log('RELAY/DECISION/REVIEW DROP GAUGE');
+  console.log('─'.repeat(72));
+
+  const gauge = await planRelayDrops(supabase);
+  const flagged = gauge.decisions.filter((d) => d.action === 'flag');
+  if (flagged.length === 0) {
+    console.log('  (no unactioned relay/decision/review rows past the drop-detection window)');
+    console.log('');
+    return;
+  }
+
+  console.log('  ' + flagged.length + ' row(s) flagged — no matching outbound within the window:');
+  for (const d of flagged) {
+    const ageMin = Math.floor(d.ageMs / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    console.log('  • [' + String(d.id).slice(0, 8) + '] correlation=' + String(d.correlationId).slice(0, 8) + ' | unactioned ' + ageStr + ' | ' + d.reason);
+  }
+  console.log('');
+}
+
 // FR-4 surfacing: rows the stale-session sweep dead-lettered (payload.dead_letter=true)
 // in the last 24h — undelivered traffic no longer vanishes tracelessly; the coordinator
 // can re-send to the successor session. Read-only.
@@ -1697,6 +1723,7 @@ async function main() {
       await printInbox(); // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a
       await printUndeliveredOutbound(); // FR-2 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
+      await printRelayDropGauge(); // FR-3 SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001
       await printAdamInbox(); // SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-B — Adam advisory lane
       await printSolomonInbox(); // SD-LEO-INFRA-SOLOMON-CONSULT-001F — Solomon oracle consult lane (dormant until SOLOMON_CONSULT_V1)
       await printSolomonLedgerRollup(); // SD-LEO-INFRA-SOLOMON-ADVICE-OUTCOME-LEDGER-001 (FR-5) — accuracy + cost-per-accepted rollup

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -32,6 +32,11 @@
  * DIRECT 1-hop write to Adam's own session (no coordinator relay hop), gated by
  * ADAM_SOLOMON_TWOWAY_V1=on (default OFF). Omitting --to is byte-identical unchanged behavior — the
  * existing coordinator-relay path is the permanent fallback, never removed.
+ *   node scripts/solomon-advisory.cjs send --direct "<body>"                   (shorthand for --to adam)
+ *
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: `--to` also accepts the
+ * relay-class peers eva/ceo (lib/coordinator/peer-target.cjs's PEER_KINDS registry) — these enqueue
+ * a tracked FR-1 relay-request instead of a direct write.
  */
 
 const crypto = require('crypto');
@@ -42,6 +47,8 @@ const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
+const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
+const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const {
   REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies,
@@ -460,9 +467,15 @@ async function main() {
   }
   // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B: `send/request --to adam` — direct 1-hop
   // channel, gated by ADAM_SOLOMON_TWOWAY_V1 (default OFF; omitting --to is unchanged).
+  // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4: --to also accepts
+  // the relay-class peers eva/ceo (lib/coordinator/peer-target.cjs's PEER_KINDS registry) —
+  // these enqueue a tracked FR-1 relay-request instead of a direct write. --direct is
+  // shorthand for --to adam (Solomon's one lateral session-class peer).
   const toIdx = argv.indexOf('--to');
   const toArg = toIdx >= 0 ? argv[toIdx + 1] || null : null;
-  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1].filter((i) => i >= 0));
+  const directIdx = argv.indexOf('--direct');
+  const peerArg = toArg || (directIdx >= 0 ? 'adam' : null);
+  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx].filter((i) => i >= 0));
   const body = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
   if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
 
@@ -470,18 +483,41 @@ async function main() {
     console.error('ERROR: request/await is gated by COORDINATOR_TWOWAY_V2=on (currently OFF). Use `send` for fire-and-forget.');
     process.exit(3);
   }
-  if (toArg && toArg !== 'adam') {
-    console.error(`ERROR: --to ${toArg} is not supported (only "adam" — omit --to for the default coordinator-relay target).`);
+  const isRelayClassPeer = !!(peerArg && PEER_KINDS[peerArg] && PEER_KINDS[peerArg].class === 'relay');
+  if (peerArg && peerArg !== 'adam' && !isRelayClassPeer) {
+    const relayPeers = Object.keys(PEER_KINDS).filter((k) => PEER_KINDS[k].class === 'relay').join(', ');
+    console.error(`ERROR: --to ${peerArg} is not supported (one of "adam", ${relayPeers} — omit --to for the default coordinator-relay target).`);
     process.exit(2);
   }
   const twoWayV1On = isAdamSolomonTwoWayV1Enabled();
-  if (toArg === 'adam' && !twoWayV1On) {
+  if (peerArg === 'adam' && !twoWayV1On) {
     console.error('ERROR: --to adam is gated by ADAM_SOLOMON_TWOWAY_V1=on (currently OFF). Omit --to to route via the coordinator.');
     process.exit(3);
   }
 
+  // FR-4 relay-class path: eva/ceo have no live session, so a relay-class --to enqueues a
+  // tracked FR-1 relay_request via the coordinator queue instead of a direct insert — the
+  // coordinator's relay-drain tick (FR-1/FR-2) performs the actual delivery + writes the
+  // CONFIRM-ON-RELAY receipt. This is a fundamentally different row shape than a direct
+  // advisory (no consult-dedup, no ledger capture), so it short-circuits here.
+  if (isRelayClassPeer) {
+    const relayCorrelationId = crypto.randomUUID();
+    const { data, error } = await enqueueRelayRequest(supabase, {
+      senderSession: sessionId,
+      relayTo: peerArg,
+      body,
+      correlationId: relayCorrelationId,
+    });
+    if (error) { console.error('ERROR: failed to enqueue relay-request:', error); process.exit(1); }
+    console.log('✓ Relay-request enqueued (tracked -- coordinator will drain + confirm)');
+    console.log('  relay_request_id:', data.id);
+    console.log('  relay_to:', peerArg);
+    console.log('  correlation_id:', relayCorrelationId);
+    return;
+  }
+
   const coordinatorId = await getActiveCoordinatorId(supabase);
-  const toAdam = toArg === 'adam';
+  const toAdam = peerArg === 'adam';
   const adamId = toAdam && twoWayV1On ? await getActiveAdamId(supabase).catch(() => null) : null;
   const { target, via } = resolveSolomonAdvisoryTarget({ toAdam, flagOn: twoWayV1On, coordinatorId, adamId });
   const senderCallsign = await snapshotSender(supabase, sessionId);

--- a/tests/unit/coordinator/coordinator-relay-drain.test.js
+++ b/tests/unit/coordinator/coordinator-relay-drain.test.js
@@ -1,0 +1,70 @@
+/**
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2, TS-7
+ *
+ * scripts/coordinator-relay-drain.cjs's makeSendRelay -- previously untested (VALIDATION,
+ * PLAN_VERIFICATION): the ONLY production callers of enqueueRelayRequest (adam-advisory.cjs /
+ * solomon-advisory.cjs) enqueue exclusively relay-class peers (eva/ceo), yet the original
+ * sendRelay unconditionally failed whenever resolvePeerTarget returned kind:'relay' -- meaning
+ * every real relay-request ever queued would perpetually fail to drain and get wrongly flagged
+ * by the FR-3 drop gauge as a real drop. These tests pin the fixed contract: a relay-class peer
+ * (no live session ever exists, per peer-target.cjs's PEER_KINDS registry) is drained
+ * successfully WITHOUT attempting a live-session insert.
+ */
+import { describe, it, expect } from 'vitest';
+import { makeSendRelay } from '../../../scripts/coordinator-relay-drain.cjs';
+
+function makeSupabaseSpy() {
+  const inserts = [];
+  return {
+    inserts,
+    from(table) {
+      return {
+        insert(row) {
+          inserts.push({ table, row });
+          return { error: null };
+        },
+      };
+    },
+  };
+}
+
+describe('makeSendRelay — relay-class peers (TS-7 fix)', () => {
+  it('eva: returns ok:true without attempting a live-session insert', async () => {
+    const supabase = makeSupabaseSpy();
+    const sendRelay = makeSendRelay(supabase);
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { relay_to: 'eva', body: 'hello', correlation_id: 'c1' } };
+    const result = await sendRelay(row);
+    expect(result).toEqual({ ok: true });
+    expect(supabase.inserts).toHaveLength(0);
+  });
+
+  it('ceo: same contract as eva (both relay-class)', async () => {
+    const supabase = makeSupabaseSpy();
+    const sendRelay = makeSendRelay(supabase);
+    const row = { id: 'r2', sender_session: 's1', target_session: 'coord1', payload: { relay_to: 'ceo', body: 'hi', correlation_id: 'c2' } };
+    const result = await sendRelay(row);
+    expect(result).toEqual({ ok: true });
+    expect(supabase.inserts).toHaveLength(0);
+  });
+});
+
+describe('makeSendRelay — malformed rows', () => {
+  it('missing payload.relay_to fails loud (no silent success)', async () => {
+    const supabase = makeSupabaseSpy();
+    const sendRelay = makeSendRelay(supabase);
+    const row = { id: 'r3', sender_session: 's1', target_session: 'coord1', payload: {} };
+    const result = await sendRelay(row);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/relay_to/);
+  });
+
+  it('an unknown peer (resolvePeerTarget throws) is caught, not propagated', async () => {
+    const supabase = makeSupabaseSpy();
+    const sendRelay = makeSendRelay(supabase);
+    const row = { id: 'r4', sender_session: 's1', target_session: 'coord1', payload: { relay_to: 'not-a-real-peer', correlation_id: 'c4' } };
+    const result = await sendRelay(row);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unknown peer/i);
+    expect(supabase.inserts).toHaveLength(0);
+  });
+});

--- a/tests/unit/coordinator/peer-target.test.js
+++ b/tests/unit/coordinator/peer-target.test.js
@@ -1,0 +1,105 @@
+/**
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-4
+ *
+ * lib/coordinator/peer-target.cjs -- the single shared peer-resolution module
+ * closing the incident #2 root cause (both advisory scripts hardcoded
+ * target=coordinatorId, so a reply could never target the asker session directly).
+ * Deps are injected (no vi.mock on nested CJS requires -- an intentionally
+ * testable seam, mirroring receipts.cjs / pending-question-timer.cjs).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { resolvePeerTarget, PEER_KINDS } from '../../../lib/coordinator/peer-target.cjs';
+
+const supabase = {};
+
+describe('PEER_KINDS registry', () => {
+  it('classifies adam/solomon/coordinator as session-class and eva/ceo as relay-class', () => {
+    expect(PEER_KINDS.adam.class).toBe('session');
+    expect(PEER_KINDS.solomon.class).toBe('session');
+    expect(PEER_KINDS.coordinator.class).toBe('session');
+    expect(PEER_KINDS.eva.class).toBe('relay');
+    expect(PEER_KINDS.ceo.class).toBe('relay');
+  });
+});
+
+describe('resolvePeerTarget — session-class peers (TS-1)', () => {
+  it('resolves a live adam session (no originator -- fresh send)', async () => {
+    const deps = { getActiveAdamId: vi.fn().mockResolvedValue('adam-session-live') };
+    const result = await resolvePeerTarget(supabase, 'adam', {}, deps);
+    expect(result).toEqual({ kind: 'session', target: 'adam-session-live', sentinel: 'broadcast-adam', peer: 'adam', live: true, retargeted: false, relayVia: null });
+  });
+
+  it('resolves a live solomon session (no originator)', async () => {
+    const deps = { getActiveSolomonId: vi.fn().mockResolvedValue('solomon-session-live') };
+    const result = await resolvePeerTarget(supabase, 'solomon', {}, deps);
+    expect(result.kind).toBe('session');
+    expect(result.target).toBe('solomon-session-live');
+    expect(result.live).toBe(true);
+  });
+
+  it('resolves the coordinator via getActiveCoordinatorId', async () => {
+    const deps = { getActiveCoordinatorId: vi.fn().mockResolvedValue('coord-session-live') };
+    const result = await resolvePeerTarget(supabase, 'coordinator', {}, deps);
+    expect(result.target).toBe('coord-session-live');
+  });
+
+  it('peer names are case-insensitive', async () => {
+    const deps = { getActiveAdamId: vi.fn().mockResolvedValue('adam-session-live') };
+    const result = await resolvePeerTarget(supabase, 'ADAM', {}, deps);
+    expect(result.peer).toBe('adam');
+  });
+
+  it('delegates to resolveAdamReplyTarget (prefer-live + retarget) when originator is set', async () => {
+    const resolveAdamReplyTarget = vi.fn().mockResolvedValue({ target: 'adam-live', live: 'adam-live', originator: 'adam-stale', retargeted: true });
+    const result = await resolvePeerTarget(supabase, 'adam', { originator: 'adam-stale' }, { resolveAdamReplyTarget });
+    expect(resolveAdamReplyTarget).toHaveBeenCalledWith(supabase, 'adam-stale', {});
+    expect(result.target).toBe('adam-live');
+    expect(result.retargeted).toBe(true);
+  });
+
+  it('delegates to resolveSolomonReplyTarget when originator is set', async () => {
+    const resolveSolomonReplyTarget = vi.fn().mockResolvedValue({ target: 'solomon-live', live: 'solomon-live', originator: 'solomon-stale', retargeted: true });
+    const result = await resolvePeerTarget(supabase, 'solomon', { originator: 'solomon-stale' }, { resolveSolomonReplyTarget });
+    expect(resolveSolomonReplyTarget).toHaveBeenCalledWith(supabase, 'solomon-stale', {});
+    expect(result.retargeted).toBe(true);
+  });
+});
+
+describe('resolvePeerTarget — relay-class peers (TS-2)', () => {
+  it('returns kind:relay for eva without calling any session resolver', async () => {
+    const getActiveAdamId = vi.fn();
+    const result = await resolvePeerTarget(supabase, 'eva', {}, { getActiveAdamId });
+    expect(result).toEqual({ kind: 'relay', target: null, sentinel: null, peer: 'eva', live: false, retargeted: false, relayVia: 'coordinator' });
+    expect(getActiveAdamId).not.toHaveBeenCalled();
+  });
+
+  it('returns kind:relay for ceo', async () => {
+    const result = await resolvePeerTarget(supabase, 'ceo', {});
+    expect(result.kind).toBe('relay');
+    expect(result.relayVia).toBe('coordinator');
+  });
+});
+
+describe('resolvePeerTarget — unknown peer', () => {
+  it('throws a clear error listing known peers', async () => {
+    await expect(resolvePeerTarget(supabase, 'nobody', {})).rejects.toThrow(/unknown peer "nobody"/);
+  });
+});
+
+describe('resolvePeerTarget — adam falls back to its sentinel when no live session', () => {
+  it('returns broadcast-adam when no live adam session exists', async () => {
+    const deps = { getActiveAdamId: vi.fn().mockResolvedValue(null) };
+    const result = await resolvePeerTarget(supabase, 'adam', {}, deps);
+    expect(result.target).toBe('broadcast-adam');
+    expect(result.live).toBe(false);
+  });
+});
+
+describe('resolvePeerTarget — solomon falls back to its sentinel when no live session', () => {
+  it('returns broadcast-solomon when no live solomon session exists', async () => {
+    const deps = { getActiveSolomonId: vi.fn().mockResolvedValue(null) };
+    const result = await resolvePeerTarget(supabase, 'solomon', {}, deps);
+    expect(result.target).toBe('broadcast-solomon');
+    expect(result.live).toBe(false);
+  });
+});

--- a/tests/unit/coordinator/relay-drop-gauge.test.js
+++ b/tests/unit/coordinator/relay-drop-gauge.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3
+ *
+ * lib/coordinator/relay-drop-gauge.cjs -- the unactioned relay/decision/review
+ * drop gauge. decideRelayDrops() is a CORRELATION over two injected arrays
+ * (unlike pending-question-timer.cjs's single-set decidePendingQuestions()).
+ */
+import { describe, it, expect } from 'vitest';
+import { decideRelayDrops, isTrackedInbound, satisfiesCorrelation, DEFAULT_WINDOW_MS } from '../../../lib/coordinator/relay-drop-gauge.cjs';
+import { PAYLOAD_KINDS } from '../../../lib/fleet/worker-status.cjs';
+
+const NOW = Date.parse('2026-07-02T00:00:00Z');
+
+describe('isTrackedInbound', () => {
+  it('tracks relay_request, decision_request, review_request', () => {
+    expect(isTrackedInbound({ payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST } })).toBe(true);
+    expect(isTrackedInbound({ payload: { kind: 'decision_request' } })).toBe(true);
+    expect(isTrackedInbound({ payload: { kind: 'review_request' } })).toBe(true);
+  });
+
+  it('does not track unrelated kinds', () => {
+    expect(isTrackedInbound({ payload: { kind: 'adam_advisory' } })).toBe(false);
+    expect(isTrackedInbound({})).toBe(false);
+  });
+});
+
+describe('satisfiesCorrelation', () => {
+  it('a relay_confirm row satisfies via correlation_id', () => {
+    expect(satisfiesCorrelation({ payload: { kind: PAYLOAD_KINDS.RELAY_CONFIRM, correlation_id: 'c1' } })).toBe('c1');
+  });
+
+  it('a reply row satisfies via reply_to', () => {
+    expect(satisfiesCorrelation({ payload: { reply_to: 'c2' } })).toBe('c2');
+  });
+
+  it('an unrelated row satisfies nothing', () => {
+    expect(satisfiesCorrelation({ payload: { kind: 'adam_advisory' } })).toBeNull();
+  });
+});
+
+describe('decideRelayDrops — correlation core (TS-5/TS-6)', () => {
+  it('does NOT flag an inbound row with a matching outbound confirm within the window (TS-5)', () => {
+    const inbound = [{ id: 'in1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, created_at: '2026-07-01T23:50:00Z' }];
+    const outbound = [{ id: 'out1', payload: { kind: PAYLOAD_KINDS.RELAY_CONFIRM, correlation_id: 'c1' }, created_at: '2026-07-01T23:55:00Z' }];
+    const decisions = decideRelayDrops(inbound, outbound, { now: NOW });
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].action).toBe('ok');
+  });
+
+  it('FLAGS an inbound row reproducing confirmed incident #1 exact shape: no outbound, aged past window (TS-6)', () => {
+    const inbound = [{ id: 'in1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, created_at: '2026-07-01T21:00:00Z' }]; // 3h old, no confirm ever posted
+    const decisions = decideRelayDrops(inbound, [], { now: NOW });
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].action).toBe('flag');
+    expect(decisions[0].reason).toMatch(/no matching outbound/);
+  });
+
+  it('does not flag a row still below the window (pending)', () => {
+    const inbound = [{ id: 'in1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, created_at: '2026-07-01T23:50:00Z' }]; // 10min old, window is 15min default
+    const decisions = decideRelayDrops(inbound, [], { now: NOW });
+    expect(decisions[0].action).toBe('pending');
+  });
+
+  it('ignores rows that are not tracked inbound kinds', () => {
+    const inbound = [{ id: 'in1', payload: { kind: 'adam_advisory' }, created_at: '2026-07-01T00:00:00Z' }];
+    const decisions = decideRelayDrops(inbound, [], { now: NOW });
+    expect(decisions).toHaveLength(0);
+  });
+
+  it('does not misread board/traffic churn: a fresh unrelated outbound row does not satisfy an unrelated inbound row', () => {
+    const inbound = [{ id: 'in1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, created_at: '2026-07-01T21:00:00Z' }];
+    const outbound = [{ id: 'out1', payload: { kind: PAYLOAD_KINDS.RELAY_CONFIRM, correlation_id: 'c2' }, created_at: '2026-07-01T23:55:00Z' }]; // different correlation
+    const decisions = decideRelayDrops(inbound, outbound, { now: NOW });
+    expect(decisions[0].action).toBe('flag');
+  });
+
+  it('respects a custom windowMs', () => {
+    const inbound = [{ id: 'in1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, created_at: '2026-07-01T23:59:00Z' }]; // 1min old
+    const decisions = decideRelayDrops(inbound, [], { now: NOW, windowMs: 30_000 }); // 30s window
+    expect(decisions[0].action).toBe('flag');
+  });
+
+  it('DEFAULT_WINDOW_MS is ~15 minutes', () => {
+    expect(DEFAULT_WINDOW_MS).toBe(15 * 60 * 1000);
+  });
+});

--- a/tests/unit/coordinator/relay-queue.test.js
+++ b/tests/unit/coordinator/relay-queue.test.js
@@ -1,0 +1,112 @@
+/**
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2
+ *
+ * lib/coordinator/relay-queue.cjs -- the tracked relay-request queue. Pure
+ * selector mirrors receipts.cjs; enqueue/drain mirrors pending-question-timer.cjs's
+ * core+tick split. No live git/gh/DB calls in these tests (all injected).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  selectUndrained,
+  buildRelayRequestPayload,
+  buildRelayConfirmPayload,
+  drainOne,
+  drainRelayQueue,
+} from '../../../lib/coordinator/relay-queue.cjs';
+import { PAYLOAD_KINDS } from '../../../lib/fleet/worker-status.cjs';
+
+describe('selectUndrained — pure selector (TS-4)', () => {
+  it('selects only undrained relay_request rows, zero IO', () => {
+    const rows = [
+      { id: 'r1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, acknowledged_at: null, created_at: '2026-07-01T00:00:00Z' },
+      { id: 'r2', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c2', actioned_at: '2026-07-01T01:00:00Z' }, acknowledged_at: '2026-07-01T01:00:00Z', created_at: '2026-07-01T00:30:00Z' },
+      { id: 'r3', payload: { kind: 'adam_advisory' }, acknowledged_at: null, created_at: '2026-07-01T00:00:00Z' },
+    ];
+    const result = selectUndrained(rows, { now: Date.parse('2026-07-01T02:00:00Z') });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r1');
+  });
+
+  it('sorts oldest-first by age', () => {
+    const now = Date.parse('2026-07-01T02:00:00Z');
+    const rows = [
+      { id: 'newer', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST }, acknowledged_at: null, created_at: '2026-07-01T01:50:00Z' },
+      { id: 'older', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST }, acknowledged_at: null, created_at: '2026-07-01T00:00:00Z' },
+    ];
+    const result = selectUndrained(rows, { now });
+    expect(result.map((r) => r.id)).toEqual(['older', 'newer']);
+  });
+});
+
+describe('buildRelayRequestPayload / buildRelayConfirmPayload — pure builders', () => {
+  it('builds a relay_request payload with the correct kind', () => {
+    const payload = buildRelayRequestPayload({ relayTo: 'eva', body: 'hello', correlationId: 'c1' });
+    expect(payload.kind).toBe(PAYLOAD_KINDS.RELAY_REQUEST);
+    expect(payload.relay_to).toBe('eva');
+    expect(payload.correlation_id).toBe('c1');
+  });
+
+  it('builds a relay_confirm payload correlated to the original request', () => {
+    const payload = buildRelayConfirmPayload({ correlationId: 'c1', requestRowId: 'r1', relayedTo: 'eva' });
+    expect(payload.kind).toBe(PAYLOAD_KINDS.RELAY_CONFIRM);
+    expect(payload.correlation_id).toBe('c1');
+    expect(payload.confirm_relay_of).toBe('r1');
+  });
+});
+
+function makeSupabaseStub({ updateError = null, insertError = null } = {}) {
+  const calls = { updates: [], inserts: [] };
+  return {
+    calls,
+    from(table) {
+      return {
+        update(patch) {
+          calls.updates.push({ table, patch });
+          return {
+            eq() { return this; },
+            is() { return Promise.resolve({ error: updateError }); },
+          };
+        },
+        insert(row) {
+          calls.inserts.push({ table, row });
+          return { error: insertError };
+        },
+      };
+    },
+  };
+}
+
+describe('drainOne — FR-2 CONFIRM-ON-RELAY (TS-7)', () => {
+  it('on success, sets the same-row ACTIONED marker AND inserts a new relay_confirm row', async () => {
+    const supabase = makeSupabaseStub();
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1', relay_to: 'eva' } };
+    const sendRelay = vi.fn().mockResolvedValue({ ok: true });
+    const result = await drainOne(supabase, row, sendRelay, Date.parse('2026-07-01T00:00:00Z'));
+    expect(result.ok).toBe(true);
+    expect(result.confirmed).toBe(true);
+    expect(supabase.calls.updates).toHaveLength(1);
+    expect(supabase.calls.updates[0].patch.acknowledged_at).toBeTruthy();
+    expect(supabase.calls.updates[0].patch.payload.actioned_at).toBeTruthy();
+    expect(supabase.calls.inserts).toHaveLength(1);
+    expect(supabase.calls.inserts[0].row.payload.kind).toBe(PAYLOAD_KINDS.RELAY_CONFIRM);
+    expect(supabase.calls.inserts[0].row.payload.correlation_id).toBe('c1');
+  });
+
+  it('does not write anything if sendRelay fails', async () => {
+    const supabase = makeSupabaseStub();
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1', relay_to: 'eva' } };
+    const sendRelay = vi.fn().mockResolvedValue({ ok: false, error: 'delivery failed' });
+    const result = await drainOne(supabase, row, sendRelay);
+    expect(result.ok).toBe(false);
+    expect(supabase.calls.updates).toHaveLength(0);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+});
+
+describe('drainRelayQueue — tick entry point, fail-open', () => {
+  it('never throws even if the supabase client itself throws', async () => {
+    const throwingSupabase = { from() { throw new Error('DB unavailable'); } };
+    const result = await drainRelayQueue(throwingSupabase, vi.fn());
+    expect(result).toEqual({ drained: 0, failed: 0, errors: expect.any(Array) });
+  });
+});

--- a/tests/unit/coordinator/relay-queue.test.js
+++ b/tests/unit/coordinator/relay-queue.test.js
@@ -54,7 +54,7 @@ describe('buildRelayRequestPayload / buildRelayConfirmPayload — pure builders'
   });
 });
 
-function makeSupabaseStub({ updateError = null, insertError = null } = {}) {
+function makeSupabaseStub({ updateError = null, insertError = null, claimMatches = true } = {}) {
   const calls = { updates: [], inserts: [] };
   return {
     calls,
@@ -62,10 +62,19 @@ function makeSupabaseStub({ updateError = null, insertError = null } = {}) {
       return {
         update(patch) {
           calls.updates.push({ table, patch });
-          return {
-            eq() { return this; },
-            is() { return Promise.resolve({ error: updateError }); },
+          let usedSelect = false;
+          const builder = {
+            eq() { return builder; },
+            is() { return builder; },
+            select() { usedSelect = true; return builder; },
+            then(resolve, reject) {
+              const result = usedSelect
+                ? { data: claimMatches ? [{ id: 'stub-row-id' }] : [], error: updateError }
+                : { data: null, error: updateError };
+              return Promise.resolve(result).then(resolve, reject);
+            },
           };
+          return builder;
         },
         insert(row) {
           calls.inserts.push({ table, row });
@@ -84,22 +93,68 @@ describe('drainOne — FR-2 CONFIRM-ON-RELAY (TS-7)', () => {
     const result = await drainOne(supabase, row, sendRelay, Date.parse('2026-07-01T00:00:00Z'));
     expect(result.ok).toBe(true);
     expect(result.confirmed).toBe(true);
-    expect(supabase.calls.updates).toHaveLength(1);
+    // update #1 = the atomic claim (acknowledged_at only); update #2 = payload.actioned_at
+    expect(supabase.calls.updates).toHaveLength(2);
     expect(supabase.calls.updates[0].patch.acknowledged_at).toBeTruthy();
-    expect(supabase.calls.updates[0].patch.payload.actioned_at).toBeTruthy();
+    expect(supabase.calls.updates[1].patch.payload.actioned_at).toBeTruthy();
     expect(supabase.calls.inserts).toHaveLength(1);
     expect(supabase.calls.inserts[0].row.payload.kind).toBe(PAYLOAD_KINDS.RELAY_CONFIRM);
     expect(supabase.calls.inserts[0].row.payload.correlation_id).toBe('c1');
   });
 
-  it('does not write anything if sendRelay fails', async () => {
+  it('does not call sendRelay if the row was already claimed by another tick (Q2 race fix)', async () => {
+    const supabase = makeSupabaseStub({ claimMatches: false });
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1', relay_to: 'eva' } };
+    const sendRelay = vi.fn().mockResolvedValue({ ok: true });
+    const result = await drainOne(supabase, row, sendRelay);
+    expect(sendRelay).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.confirmed).toBe(false);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+
+  it('claims the row BEFORE calling sendRelay (ordering, Q2 race fix)', async () => {
+    const supabase = makeSupabaseStub();
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1', relay_to: 'eva' } };
+    const sendRelay = vi.fn().mockImplementation(async () => {
+      // At the moment sendRelay runs, the claim update must already have been recorded.
+      expect(supabase.calls.updates).toHaveLength(1);
+      expect(supabase.calls.updates[0].patch.acknowledged_at).toBeTruthy();
+      return { ok: true };
+    });
+    await drainOne(supabase, row, sendRelay);
+    expect(sendRelay).toHaveBeenCalledTimes(1);
+  });
+
+  it('un-claims the row (resets acknowledged_at to null) if sendRelay fails, so a future tick retries', async () => {
     const supabase = makeSupabaseStub();
     const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1', relay_to: 'eva' } };
     const sendRelay = vi.fn().mockResolvedValue({ ok: false, error: 'delivery failed' });
     const result = await drainOne(supabase, row, sendRelay);
     expect(result.ok).toBe(false);
-    expect(supabase.calls.updates).toHaveLength(0);
+    expect(supabase.calls.updates).toHaveLength(2); // claim, then un-claim
+    expect(supabase.calls.updates[1].patch.acknowledged_at).toBeNull();
     expect(supabase.calls.inserts).toHaveLength(0);
+  });
+
+  it('does not insert a confirm row if sendRelay fails', async () => {
+    const supabase = makeSupabaseStub();
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1', relay_to: 'eva' } };
+    const sendRelay = vi.fn().mockResolvedValue({ ok: false, error: 'delivery failed' });
+    const result = await drainOne(supabase, row, sendRelay);
+    expect(result.ok).toBe(false);
+    expect(supabase.calls.inserts).toHaveLength(0);
+  });
+
+  it('(Q3) still drains a row with a malformed/missing payload.relay_to -- confirm payload carries relayed_to:undefined rather than throwing', async () => {
+    const supabase = makeSupabaseStub();
+    const row = { id: 'r1', sender_session: 's1', target_session: 'coord1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' } }; // relay_to absent
+    const sendRelay = vi.fn().mockResolvedValue({ ok: true });
+    const result = await drainOne(supabase, row, sendRelay);
+    expect(result.ok).toBe(true);
+    expect(result.confirmed).toBe(true);
+    expect(supabase.calls.inserts[0].row.payload.relayed_to).toBeUndefined();
+    expect(supabase.calls.inserts[0].row.subject).toContain('relayed to undefined');
   });
 });
 

--- a/tests/unit/fleet/relay-payload-kinds.test.js
+++ b/tests/unit/fleet/relay-payload-kinds.test.js
@@ -1,0 +1,25 @@
+/**
+ * SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1 (TS-8)
+ *
+ * relay_request MUST be excluded from DIRECTIVE_KINDS, or the generic worker inbox
+ * drain would consume it directly and defeat the tracked-queue guarantee -- the
+ * same defense class SOLOMON_CONSULT already established.
+ */
+import { describe, it, expect } from 'vitest';
+import { PAYLOAD_KINDS, DIRECTIVE_KINDS } from '../../../lib/fleet/worker-status.cjs';
+
+describe('relay_request / relay_confirm payload kinds', () => {
+  it('are registered in PAYLOAD_KINDS', () => {
+    expect(PAYLOAD_KINDS.RELAY_REQUEST).toBe('relay_request');
+    expect(PAYLOAD_KINDS.RELAY_CONFIRM).toBe('relay_confirm');
+  });
+
+  it('relay_request is absent from DIRECTIVE_KINDS (never auto-consumed by the generic drain)', () => {
+    expect(DIRECTIVE_KINDS).not.toContain(PAYLOAD_KINDS.RELAY_REQUEST);
+    expect(DIRECTIVE_KINDS).not.toContain('relay_request');
+  });
+
+  it('relay_confirm is absent from DIRECTIVE_KINDS', () => {
+    expect(DIRECTIVE_KINDS).not.toContain(PAYLOAD_KINDS.RELAY_CONFIRM);
+  });
+});


### PR DESCRIPTION
## Summary

Closes two incidents in inter-agent coordination:
1. A best-effort coordinator relay ("relay X to peer Y") silently dropped when the coordinator was busy — Solomon ran ~2h below baseline before the chairman noticed.
2. A Solomon-consult reply could strand at the coordinator lane instead of reaching the asker directly.

- **FR-1** — a tracked relay-request queue (`lib/coordinator/relay-queue.cjs`): `payload.kind=relay_request`, excluded from the generic worker inbox drain, drained deliberately by a coordinator tick.
- **FR-2** — mandatory CONFIRM-ON-RELAY: every drained relay-request writes both a same-row ACTIONED marker and a new correlated `relay_confirm` row, so delivery is independently verifiable via the existing undelivered-receipt machinery.
- **FR-3** — a relay/decision/review drop gauge (`lib/coordinator/relay-drop-gauge.cjs`), surfaced in `coordinator-hourly-review.cjs`, `fleet-dashboard.cjs`, and `coordinator-email-summary.mjs`.
- **FR-4** — a bilateral `--to`/`--direct` flag on `adam-advisory.cjs`/`solomon-advisory.cjs`: session-class peers (solomon/adam) route directly; relay-class peers (eva/ceo, via `lib/coordinator/peer-target.cjs`'s `PEER_KINDS` registry) enqueue through the FR-1 queue instead of a dead-end direct insert.

Built on a branch that fell behind two sibling SDs under the same parent (SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-B/-001-C) that landed overlapping changes to the same two advisory scripts mid-EXEC — hand-reconciled preserving both siblings' shipped behavior (flag-gated `--to solomon/adam` direct channel, `--reply-class`/PING-ON-SILENCE) unchanged, confirmed via 73 pre-existing sibling tests passing with zero assertion edits.

A VALIDATION pass during PLAN_VERIFICATION caught and fixed 3 defects: a NOT NULL violation silently swallowing every FR-3 drop-gauge insert, `sendRelay` unconditionally failing for the ONLY production peer class (eva/ceo) — meaning the entire FR-1/FR-2 happy path was unreachable via any shipped entry point — and a sender/target mixup that made FR-2 confirm rows invisible to the undelivered-outbound check. New test coverage (`tests/unit/coordinator/coordinator-relay-drain.test.js`) closes the exact gap that let it slip through.

## Test plan

- [x] 631 tests passing across `tests/unit/coordinator/`, `tests/unit/fleet/`, `tests/unit/coordination/`, plus every pre-existing adam-advisory/solomon-advisory test file (zero assertion changes to sibling suites)
- [x] EXEC-TO-PLAN handoff: 95% | VALIDATION: 92% | REGRESSION: 95% | PLAN-TO-LEAD: 100%
- [x] No migrations in this diff
- [x] All new logic unit-tested with injected fixtures — no live DB/network calls in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)