### PR TITLE
fix(SD-FDBK-INFRA-TRIGGER-AUDIT-MEDIUM-001): serialize MAX+1 races in assign_sequence_rank / fn_sync_sd_to_baseline

### DIFF
--- a/database/migrations/20260702_trigger_audit_f3_race_fix.sql
+++ b/database/migrations/20260702_trigger_audit_f3_race_fix.sql
@@ -1,0 +1,148 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-FDBK-INFRA-TRIGGER-AUDIT-MEDIUM-001 / FR-1 + FR-2
+--
+-- TRIGGER-AUDIT finding F-3 (from completed SD-LEO-INFRA-TRIGGER-ESTATE-AUDIT-001):
+-- assign_sequence_rank() and fn_sync_sd_to_baseline() both compute SELECT MAX(sequence_rank)+1
+-- with no locking. Neither strategic_directives_v2.sequence_rank nor
+-- sd_baseline_items(baseline_id,sequence_rank) has a unique constraint, so the race is silent
+-- duplicate-rank data (confirmed live: rank 1 appears 69x across 4800 SDs) rather than a
+-- creation-crash -- but under this repo's multi-worker autonomous fleet, concurrent SD
+-- creation is routine, not an edge case, so the drift keeps growing.
+--
+-- Fix: serialize each MAX+1 critical section with a transaction-scoped advisory lock
+-- (pg_advisory_xact_lock -- auto-releases at commit/rollback, no cleanup code needed).
+-- fn_sync_sd_to_baseline additionally wraps its sd_baseline_items INSERT in a
+-- BEGIN...EXCEPTION...END sub-block so a future/transient failure there can never abort the
+-- parent strategic_directives_v2 INSERT. DATABASE sub-agent reviewed this approach and
+-- confirmed: no deadlock risk (consistent lock ordering across all SD-creation transactions,
+-- no other trigger touches these advisory keys), and the lock MUST be acquired before/outside
+-- the EXCEPTION sub-block (advisory locks are not released on subtransaction rollback).
+--
+-- Explicitly OUT OF SCOPE (see metadata.lead_scope_lock_decision on the SD row):
+--   - Deduping the existing thousands of duplicate ranks (needs its own migration + a
+--     downstream-consumer audit for anything assuming rank uniqueness)
+--   - sd_baseline_items cleanup-on-cancel/delete (a separate, larger lifecycle change)
+--   - F-6 (PK-mutating twin-column sync triggers) -- has its own unresolved prerequisite
+
+CREATE OR REPLACE FUNCTION public.assign_sequence_rank()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+      BEGIN
+        IF NEW.sequence_rank IS NULL THEN
+          PERFORM pg_advisory_xact_lock(hashtext('strategic_directives_v2_sequence_rank'));
+          SELECT COALESCE(MAX(sequence_rank), 0) + 1
+          INTO NEW.sequence_rank
+          FROM strategic_directives_v2;
+        END IF;
+        RETURN NEW;
+      END;
+      $function$
+;
+
+CREATE OR REPLACE FUNCTION public.fn_sync_sd_to_baseline()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_active_baseline_id UUID;
+  v_baseline_item_exists BOOLEAN;
+  v_track TEXT;
+  v_next_rank INTEGER;
+BEGIN
+  SELECT id INTO v_active_baseline_id
+  FROM sd_execution_baselines
+  WHERE is_active = true
+  LIMIT 1;
+  IF v_active_baseline_id IS NULL THEN
+    RAISE NOTICE 'fn_sync_sd_to_baseline: No active baseline found. SD % not auto-synced.', NEW.sd_key;
+    RETURN NEW;
+  END IF;
+  v_track := CASE
+    WHEN LOWER(NEW.category) IN ('infrastructure', 'platform') THEN 'A'
+    WHEN LOWER(NEW.category) IN ('quality', 'testing', 'qa') THEN 'C'
+    ELSE 'B'  -- Default to Features track
+  END;
+  IF TG_OP = 'INSERT' THEN
+    -- LOAD-BEARING: sd_id MUST be NEW.sd_key (the v_sd_next_candidates JOIN key).
+    SELECT EXISTS(
+      SELECT 1 FROM sd_baseline_items
+      WHERE baseline_id = v_active_baseline_id
+        AND sd_id = NEW.sd_key
+    ) INTO v_baseline_item_exists;
+    IF NOT v_baseline_item_exists THEN
+      -- Serialize the read-compute-write MAX+1 critical section per baseline (not globally --
+      -- concurrent SD creation against DIFFERENT baselines should not block each other). Lock
+      -- is acquired BEFORE/outside the exception-handling sub-block below (a lock taken inside
+      -- a subtransaction is not released on subtransaction rollback).
+      PERFORM pg_advisory_xact_lock(hashtext('sd_baseline_items_seq_' || v_active_baseline_id::text));
+      SELECT COALESCE(MAX(sequence_rank) + 1, 1)
+      INTO v_next_rank
+      FROM sd_baseline_items
+      WHERE baseline_id = v_active_baseline_id;
+
+      -- Best-effort side-effect: a failure here must never abort SD creation itself. The
+      -- EXCEPTION clause creates an implicit savepoint -- on error it rolls back to that
+      -- savepoint and continues, leaving the outer strategic_directives_v2 INSERT intact.
+      BEGIN
+        INSERT INTO sd_baseline_items (
+          baseline_id,
+          sd_id,
+          sequence_rank,
+          track,
+          is_ready,
+          created_at
+        ) VALUES (
+          v_active_baseline_id,
+          NEW.sd_key,
+          v_next_rank,
+          v_track,
+          false,  -- New SDs are not ready by default
+          NOW()
+        );
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Added SD % to baseline % (Track %)', NEW.sd_key, v_active_baseline_id, v_track;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'fn_sync_sd_to_baseline: baseline-item insert failed for SD % (non-fatal, SD creation proceeds): %', NEW.sd_key, SQLERRM;
+      END;
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.status IS DISTINCT FROM NEW.status THEN
+      IF NEW.status = 'completed' THEN
+        UPDATE sd_baseline_items
+        SET
+          is_ready = true,
+          notes = COALESCE(notes, '') || E'\nCompleted: ' || NOW()::text
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.sd_key;
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Marked SD % as completed in baseline', NEW.sd_key;
+      ELSIF OLD.status = 'completed' AND NEW.status IN ('active', 'planning', 'in_progress') THEN
+        UPDATE sd_baseline_items
+        SET
+          is_ready = true,
+          notes = COALESCE(notes, '') || E'\nReactivated: ' || NOW()::text
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.sd_key;
+        RAISE NOTICE 'fn_sync_sd_to_baseline: Reactivated SD % in baseline', NEW.sd_key;
+      ELSIF NEW.status IN ('active', 'in_progress') THEN
+        UPDATE sd_baseline_items
+        SET is_ready = true
+        WHERE baseline_id = v_active_baseline_id
+          AND sd_id = NEW.sd_key;
+      END IF;
+    END IF;
+    IF OLD.category IS DISTINCT FROM NEW.category THEN
+      UPDATE sd_baseline_items
+      SET track = v_track
+      WHERE baseline_id = v_active_baseline_id
+        AND sd_id = NEW.sd_key;
+    END IF;
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$function$
+;

--- a/tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js
+++ b/tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js
@@ -1,0 +1,166 @@
+/**
+ * SD-FDBK-INFRA-TRIGGER-AUDIT-MEDIUM-001 (TRIGGER-AUDIT F-3) / FR-1, FR-2, FR-3.
+ *
+ * assign_sequence_rank() and fn_sync_sd_to_baseline() both computed SELECT MAX(sequence_rank)+1
+ * with no locking. Live-confirmed before this fix: rank 1 appeared 69x across 4800 SDs. This
+ * suite proves the fix under real concurrency (Promise.all() against the live DB -- the same
+ * shape as this repo's actual multi-worker fleet, not a simulated race), plus a static
+ * structural guard on the exception-safety shape (TS-3), which live-DB negative-injection
+ * cannot reliably exercise via the PostgREST/supabase-js surface (see comment on that test).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_SQL = readFileSync(
+  resolve(__dirname, '../../../database/migrations/20260702_trigger_audit_f3_race_fix.sql'),
+  'utf8'
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const supabase = createSupabaseServiceClient();
+
+// Anchor on the CREATE OR REPLACE FUNCTION declaration (not a bare name split, which is
+// fragile against the name also appearing in comments/RAISE strings elsewhere in the file).
+function extractFunctionBody(sql, fnName) {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION public.${fnName}`);
+  if (start === -1) throw new Error(`function ${fnName} not found in migration SQL`);
+  return sql.slice(start);
+}
+
+describe('TRIGGER-AUDIT F-3 — static exception-safety shape (TS-3)', () => {
+  it('the advisory lock is acquired BEFORE/outside the BEGIN...EXCEPTION sub-block, not inside it', () => {
+    const fn = extractFunctionBody(MIGRATION_SQL, 'fn_sync_sd_to_baseline');
+    const lockIdx = fn.indexOf("pg_advisory_xact_lock(hashtext('sd_baseline_items_seq_'");
+    const beginIdx = fn.indexOf('BEGIN\n        INSERT INTO sd_baseline_items');
+    expect(lockIdx).toBeGreaterThan(-1);
+    expect(beginIdx).toBeGreaterThan(-1);
+    expect(lockIdx, 'advisory lock must precede the exception-guarded BEGIN block').toBeLessThan(beginIdx);
+  });
+
+  it('EXCEPTION WHEN OTHERS wraps ONLY the sd_baseline_items INSERT, not the MAX+1 SELECT', () => {
+    const fn = extractFunctionBody(MIGRATION_SQL, 'fn_sync_sd_to_baseline');
+    const beginIdx = fn.indexOf('BEGIN\n        INSERT INTO sd_baseline_items');
+    const exceptionIdx = fn.indexOf('EXCEPTION WHEN OTHERS THEN');
+    const endIdx = fn.indexOf('END;', exceptionIdx);
+    expect(beginIdx).toBeGreaterThan(-1);
+    expect(exceptionIdx).toBeGreaterThan(beginIdx);
+    expect(endIdx).toBeGreaterThan(exceptionIdx);
+    // The MAX+1 SELECT must be OUTSIDE (before) this sub-block
+    const selectMaxIdx = fn.indexOf('SELECT COALESCE(MAX(sequence_rank) + 1, 1)');
+    expect(selectMaxIdx).toBeGreaterThan(-1);
+    expect(selectMaxIdx, 'the MAX+1 computation must run before the exception-guarded INSERT block').toBeLessThan(beginIdx);
+  });
+
+  it('a caught baseline-insert failure logs a WARNING referencing the SD, not a silent swallow', () => {
+    expect(MIGRATION_SQL).toMatch(/RAISE WARNING 'fn_sync_sd_to_baseline: baseline-item insert failed for SD %.*NEW\.sd_key, SQLERRM/);
+  });
+
+  it('assign_sequence_rank() only locks/computes when NEW.sequence_rank IS NULL (explicit-rank path unchanged)', () => {
+    const fn = extractFunctionBody(MIGRATION_SQL, 'assign_sequence_rank');
+    const ifIdx = fn.indexOf('IF NEW.sequence_rank IS NULL THEN');
+    const lockIdx = fn.indexOf("pg_advisory_xact_lock(hashtext('strategic_directives_v2_sequence_rank')");
+    expect(ifIdx).toBeGreaterThan(-1);
+    expect(lockIdx).toBeGreaterThan(ifIdx);
+  });
+});
+
+describe.skipIf(!HAS_REAL_DB)('TRIGGER-AUDIT F-3 — live concurrent-insert race fix (TS-1, TS-2, TS-4)', () => {
+  const fixtureIds = [];
+
+  afterEach(async () => {
+    if (fixtureIds.length > 0) {
+      await supabase.from('sd_baseline_items').delete().in('sd_id', fixtureIds);
+      await supabase.from('strategic_directives_v2').delete().in('id', fixtureIds);
+      fixtureIds.length = 0;
+    }
+  });
+
+  function buildFixtureSD(ts, i) {
+    const id = `TEST-F3-RACE-${ts}-${i}`;
+    return {
+      id,
+      sd_key: id,
+      title: `Test SD for F-3 race fix concurrency probe ${i}`,
+      category: 'infrastructure',
+      status: 'draft',
+      priority: 'low',
+      description: 'Test fixture for TRIGGER-AUDIT F-3 concurrent-insert race regression test',
+      rationale: 'Integration test fixture',
+      scope: 'Test scope',
+      sd_code_user_facing: id,
+    };
+  }
+
+  it('TS-1: N concurrent strategic_directives_v2 inserts (sequence_rank omitted) receive N distinct ranks', async () => {
+    const ts = Date.now();
+    const N = 5;
+    const rows = Array.from({ length: N }, (_, i) => buildFixtureSD(ts, i));
+    rows.forEach((r) => fixtureIds.push(r.id));
+
+    const results = await Promise.all(
+      rows.map((row) => supabase.from('strategic_directives_v2').insert(row).select('id, sequence_rank').single())
+    );
+
+    for (const r of results) {
+      expect(r.error, `insert failed: ${r.error?.message}`).toBeNull();
+    }
+    const ranks = results.map((r) => r.data.sequence_rank);
+    const uniqueRanks = new Set(ranks);
+    expect(uniqueRanks.size, `expected ${N} distinct ranks, got duplicates: ${ranks.join(',')}`).toBe(N);
+  }, 30_000);
+
+  it('TS-4: a single-threaded SD creation (no concurrency) behaves identically to pre-migration', async () => {
+    const ts = Date.now();
+    const row = buildFixtureSD(ts, 'single');
+    fixtureIds.push(row.id);
+
+    const { data, error } = await supabase.from('strategic_directives_v2').insert(row).select('id, sequence_rank, category').single();
+    expect(error).toBeNull();
+    expect(data.sequence_rank).toBeGreaterThan(0);
+    expect(data.category).toBe('infrastructure');
+  }, 15_000);
+
+  it('TS-2: N concurrent inserts against the same active baseline receive N distinct sd_baseline_items ranks', async () => {
+    const { data: baseline } = await supabase
+      .from('sd_execution_baselines')
+      .select('id')
+      .eq('is_active', true)
+      .limit(1)
+      .maybeSingle();
+    if (!baseline) {
+      // No active baseline in this environment -- fn_sync_sd_to_baseline no-ops (RAISE NOTICE
+      // path), nothing to assert. Skip rather than false-fail on an environment precondition.
+      return;
+    }
+
+    const ts = Date.now();
+    const N = 5;
+    const rows = Array.from({ length: N }, (_, i) => buildFixtureSD(ts, `bl${i}`));
+    rows.forEach((r) => fixtureIds.push(r.id));
+
+    const results = await Promise.all(
+      rows.map((row) => supabase.from('strategic_directives_v2').insert(row).select('id').single())
+    );
+    for (const r of results) {
+      expect(r.error, `insert failed: ${r.error?.message}`).toBeNull();
+    }
+
+    const { data: items, error: itemsErr } = await supabase
+      .from('sd_baseline_items')
+      .select('sd_id, sequence_rank')
+      .eq('baseline_id', baseline.id)
+      .in('sd_id', rows.map((r) => r.id));
+    expect(itemsErr).toBeNull();
+    expect(items.length, 'every concurrently-inserted SD should get a baseline_items row').toBe(N);
+    const ranks = items.map((i) => i.sequence_rank);
+    expect(new Set(ranks).size, `expected ${N} distinct baseline ranks, got duplicates: ${ranks.join(',')}`).toBe(N);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- TRIGGER-AUDIT finding F-3 (follow-up from completed SD-LEO-INFRA-TRIGGER-ESTATE-AUDIT-001): `assign_sequence_rank()` and `fn_sync_sd_to_baseline()` both computed `SELECT MAX(sequence_rank)+1` with no locking. Live-confirmed pre-fix: rank 1 appeared 69x across 4800 SDs (silent duplicate-rank data under this repo's multi-worker autonomous fleet).
- Adds transaction-scoped `pg_advisory_xact_lock` serialization to both MAX+1 critical sections, and wraps `fn_sync_sd_to_baseline`'s `sd_baseline_items` INSERT in `BEGIN...EXCEPTION WHEN OTHERS...END` so a future/transient insert failure can never abort the parent SD-creation transaction.
- DATABASE sub-agent reviewed the approach pre-implementation (deadlock-free lock ordering, correct lock-placement-outside-exception-block requirement).
- Migration already applied to production; deployed function bodies live-verified byte-identical to the migration file.
- VALIDATION + REGRESSION sub-agents both independently reproduced the fix against live production (10-way and 20-way concurrent-insert probes, zero duplicate ranks either table).
- Explicitly out of scope (recorded in `metadata.lead_scope_lock_decision`): deduping existing duplicate ranks, `sd_baseline_items` cleanup-on-cancel, and F-6 (has its own unresolved prerequisite).

## Test plan
- [x] 7 new tests in `tests/integration/migrations/trigger-audit-f3-race-fix.db.test.js` (4 static structural guards + 3 live concurrent-insert tests against production) — all pass
- [x] TESTING sub-agent independently reproduced with N=20 concurrent probe
- [x] VALIDATION sub-agent independently reproduced with N=10 concurrent probe
- [x] REGRESSION sub-agent confirmed line-by-line diff shows only the intended deltas; UPDATE-path logic byte-identical live
- [x] Full `tests/integration/sd-creation/ tests/database/` regression sweep — 2 pre-existing unrelated flaky tests confirmed (claim_sd RPC races, zero code overlap, pass on rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)