### PR TITLE
fix(QF-20260702-262): stage-17 generateDocs writes a DRAFT vision (approved:false), not active+approved

### DIFF
--- a/lib/eva/__tests__/stage-17-doc-generation.test.js
+++ b/lib/eva/__tests__/stage-17-doc-generation.test.js
@@ -10,7 +10,9 @@ const silentLogger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
 
 // Build mock supabase with realistic responses
 function mockSupabase({ artifacts = [], visionUpsertData = null, visionUpsertErr = null, archUpsertData = null, archUpsertErr = null, existingVisions = [] } = {}) {
+  const visionUpsertCalls = [];
   return {
+    _visionUpsertCalls: visionUpsertCalls,
     from: vi.fn((table) => {
       if (table === 'venture_artifacts') {
         return {
@@ -35,14 +37,17 @@ function mockSupabase({ artifacts = [], visionUpsertData = null, visionUpsertErr
             })),
             like: vi.fn(async () => ({ data: existingVisions, error: null })),
           })),
-          upsert: vi.fn(() => ({
-            select: vi.fn(() => ({
-              single: vi.fn(async () => ({
-                data: visionUpsertData,
-                error: visionUpsertErr,
+          upsert: vi.fn((record) => {
+            visionUpsertCalls.push(record);
+            return {
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: visionUpsertData,
+                  error: visionUpsertErr,
+                })),
               })),
-            })),
-          })),
+            };
+          }),
         };
       }
       if (table === 'eva_architecture_plans') {
@@ -158,6 +163,32 @@ describe('generateDocs', () => {
 
     // If the upsert was called, the content was processed through sanitizeForPrompt
     // which wraps content in [USER_INPUT]...[/USER_INPUT] delimiters
+    expect(result.errors.length).toBe(0);
+  });
+
+  // QF-20260702-262 (SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-C):
+  // generateDocs must write a quality-repairable DRAFT, never active+chairman_approved. This is
+  // the fix for the shipped FR-3 BEFORE INSERT gate (migration 20260702) hard-erroring sparse
+  // real-venture L2 vision creation. Guards against regressing back to upsertVision's implicit
+  // approved=true default (which wrote status='active', chairman_approved=true).
+  test('writes a DRAFT vision (approved:false) — never active/chairman_approved [QF-262 regression guard]', async () => {
+    const visionData = {
+      id: 'v-uuid', vision_key: 'VISION-TEST-L2-002', level: 'L2',
+      version: 1, status: 'draft', quality_checked: true, quality_issues: null,
+    };
+    const supabase = mockSupabase({ artifacts: [], visionUpsertData: visionData });
+
+    const result = await generateDocs({ ventureId: 'v-1', ventureName: 'Test Venture', supabase, logger: silentLogger });
+
+    // The record upsertVision built from generateDocs' args must be a draft — proves approved:false
+    // reached upsertVision (approved:false -> status='draft', chairman_approved=false).
+    expect(supabase._visionUpsertCalls.length).toBeGreaterThan(0);
+    const rec = supabase._visionUpsertCalls[0];
+    expect(rec.status).toBe('draft');
+    expect(rec.status).not.toBe('active');
+    expect(rec.chairman_approved).toBe(false);
+    // And the vision is still produced (not hard-errored).
+    expect(result.vision).not.toBeNull();
     expect(result.errors.length).toBe(0);
   });
 });

--- a/lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js
@@ -270,6 +270,18 @@ export async function generateDocs({
     ventureId,
     brainstormId,
     createdBy: 'stage-17-doc-generation',
+    // QF-20260702-262 (SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-C):
+    // write a quality-repairable DRAFT, never active+approved. This is a FRESH vision_key
+    // (next-number), so upsertVision has no existing row to carry dims from -> dims=null. An
+    // active/approved insert on that shape is rejected by trg_enforce_vision_quality_insert
+    // (sparse venture: quality_checked=false; migration 20260702) AND by the pre-existing
+    // eva_vision_documents_active_rich_check (dims null; 20260527) — either way upsertVision
+    // returned {data:null,error}, the visionData!=null-gated repair loop below never ran, and
+    // no L2/arch doc was produced for real ventures. approved:false -> status='draft' passes
+    // both gates vacuously; the repair loop then runs. Activation stays the deliberate
+    // downstream gate: chairman-manual for real ventures, _autoApproveCloneVision
+    // (eligibility-gated) for clones/convergence off the enriched eager-synthesis L2.
+    approved: false,
   });
 
   if (visionErr) {


### PR DESCRIPTION
## QF-20260702-262 — stage-17 `generateDocs` writes a DRAFT vision, not active+approved

Fixes a **confirmed, live** regression introduced by `SD-LEO-INFRA-REAL-VENTURE-VISION-ENRICH-UNDERPRODUCTION-S19-001-C` (PR #5358, merged). Coordinator-assigned fast-follow QF (deconfliction: QF, not Child B).

### The regression
PR #5358 shipped `trg_enforce_vision_quality_insert` (BEFORE INSERT on `eva_vision_documents`, migration `20260702_vision_quality_insert_coverage.sql`, **live + enabled** on the DB). It blocks any INSERT with `status='active'` / `chairman_approved=true` when `quality_checked=false`.

`generateDocs()` (`lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js:264`) called `upsertVision(...)` with **no `approved` arg** → `vision-upsert.js` defaults `approved=true` → writes `status='active', chairman_approved=true`. For a **sparse real venture** (`<8` standard sections → `auto_validate` sets `quality_checked=false` — the parent SD's whole premise) the INSERT RAISEs, `upsertVision` returns `{data:null,error}` (no try/catch/fallback), the `visionData!=null`-gated repair loop never runs, and **the L2 vision is never created** — breaking real-venture S19 doc generation.

Latent only because the S19 pipeline is currently held (no ventures walking), but it is **a landmine directly in the path of the pending chairman dam-break** — the moment ventures walk, sparse real ventures hard-fail.

### The fix (surgical — 1 functional line)
Pass `approved: false` so the vision lands as a repairable **DRAFT** (`status='draft'`), which passes both the FR-3 gate **and** the pre-existing `eva_vision_documents_active_rich_check` (`20260527`) vacuously. The `visionData!=null`-gated repair loop then runs. Activation stays the deliberate downstream gate:
- **Real ventures** → chairman-manual (stay draft — the invariant the parent SD enforces).
- **Clones / convergence subjects** → `_autoApproveCloneVision` (eligibility-gated, runs at the top of `_runS19Bridge` on every S19 entry path) promotes the enriched **eager-synthesis `-001`** L2.

Mirrors `repairVision`'s deliberate `approved:false` (no-force-approve).

### Design analysis (why this is complete, not just the visible symptom)
- **Paradox resolved:** `generateDocs` always mints a *fresh* `vision_key` (eager-synthesis already made `-001`), so `upsertVision` has no existing row to carry dims from → `extracted_dimensions=null`. A `status='active'` write with null dims has **failed `active_rich_check` for every venture since 20260527** — so the stage-17 row was never the promotable vision. The promotable L2 is the eager-synthesis `-001` (written *with* dims). Changing stage-17 to `approved:false` therefore **strands no venture type**.
- **Per-type end state:** real → quality-passed draft (chairman-manual) ✅; clone/convergence → promoted off `-001` ✅.

### Residual fragility flagged for reviewer (coordinator decision)
Bare `approved:false` makes the previously-*failing* `-002` write now *succeed* as a second `draft` row, which competes in `_autoApproveCloneVision` Case B's `limit(1) order updated_at` selection. It is **unreachable under live freshness ordering** (S18/S19 artifact writes keep `-001` fresher than the one-shot S17 `-002`), so this QF ships the minimal fix. If you want the race eliminated *deterministically*, the follow-up is an idempotency guard in `generateDocs` (skip the redundant write when an L2 already exists, à la `seedDraftL2Vision`; ~15–20 LOC, still QF-tier). Happy to add it here or as a separate QF — your call.

### Tests
`lib/eva/__tests__/stage-17-doc-generation.test.js` — added a regression guard asserting the record `generateDocs` passes to `upsertVision` is a **draft** (`status='draft'`, `chairman_approved=false`), never active/approved. **13/13 pass.**

### Provenance
Pre-merge LEAD-validation blast-radius flag (raised before #5358 merged, not honored when another session completed the SD after a worktree-prune/TTL-claim-loss): `sub_agent_execution_results` row `5bb9d405`. Design verified against **origin/main** (not local HEAD) + **live DB** (`pg_trigger`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
