### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A): quiescent-window trigger + relaunch scheduler

### DIFF
--- a/lib/coordinator/singleton-relaunch-trigger.js
+++ b/lib/coordinator/singleton-relaunch-trigger.js
@@ -1,0 +1,209 @@
+/**
+ * Quiescent-window trigger + relaunch scheduler — SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A.
+ *
+ * Consumes the existing stale-tree gauge signal (lib/governance/checkout-freshness.js) as the
+ * refresh trigger and schedules a singleton relaunch ONLY when BOTH the fleet is idle
+ * (lib/coordinator/fleet-quiescence.cjs assessFleetActivity()) AND the target singleton itself
+ * is idle per its own claude_sessions.loop_state (not merely heartbeat-age). Never schedules a
+ * relaunch of a singleton that is mid-consult/mid-work.
+ *
+ * This is trigger + scheduling ONLY (Child A). The actual fresh-checkout relaunch mechanics and
+ * handoff-memory schema are Child B; sequenced re-register/retire + guarded worktree removal are
+ * Child C. Downstream children consume the `session_coordination` SPAWN_REQUEST record this
+ * module writes (payload.kind='singleton_relaunch_scheduled').
+ *
+ * @module lib/coordinator/singleton-relaunch-trigger
+ */
+
+import { createRequire } from 'node:module';
+import { checkoutFreshness, VERDICT } from '../governance/checkout-freshness.js';
+
+const require = createRequire(import.meta.url);
+const { assessFleetActivity } = require('./fleet-quiescence.cjs');
+const { getActiveAdamId } = require('./adam-identity.cjs');
+const { getActiveSolomonId } = require('./solomon-identity.cjs');
+const { getActiveCoordinatorId } = require('./resolve.cjs');
+
+/** loop_state values documented as safe-to-relaunch (never mid-consult). Anything else — including
+ * 'active', 'unknown', or no recorded state — fails CLOSED (no relaunch). See docs/protocol/
+ * fleet-hibernation.md + .claude/commands/coordinator.md for the loop_state contract. */
+export const SAFE_LOOP_STATES = Object.freeze(['awaiting_tick', 'exited']);
+
+export const SINGLETON_ROLES = Object.freeze(['adam', 'solomon', 'coordinator']);
+
+const ROLE_ID_RESOLVERS = {
+  adam: (supabase) => getActiveAdamId(supabase),
+  solomon: (supabase) => getActiveSolomonId(supabase),
+  coordinator: (supabase) => getActiveCoordinatorId(supabase),
+};
+
+/**
+ * PURE decision — no IO. Precedence mirrors the PRD's FR-1 gate exactly: fresh checkout needs no
+ * relaunch; a stale-but-non-quiescent-fleet or mid-consult target both refuse to schedule.
+ * @param {{freshnessVerdict?: string, fleetQuiescent?: boolean, targetLoopState?: string}} signals
+ * @returns {{scheduled: boolean, reason: string}}
+ */
+export function decideRelaunchSchedule({ freshnessVerdict, fleetQuiescent, targetLoopState } = {}) {
+  if (!freshnessVerdict || freshnessVerdict === VERDICT.FRESH) {
+    return { scheduled: false, reason: 'fresh' };
+  }
+  if (!fleetQuiescent) {
+    return { scheduled: false, reason: 'fleet_not_quiescent' };
+  }
+  if (!SAFE_LOOP_STATES.includes(targetLoopState)) {
+    return { scheduled: false, reason: 'target_not_idle' };
+  }
+  return { scheduled: true, reason: 'behind_n_and_quiescent' };
+}
+
+/** Resolve a singleton role's live session_id + loop_state. Fail-open: null id / 'unknown' state
+ * on any resolution or query error — a lookup fault must never crash the scheduler tick. */
+export async function getRoleSessionState(supabase, role) {
+  const resolver = ROLE_ID_RESOLVERS[role];
+  if (!resolver) return { sessionId: null, loopState: 'unknown' };
+  let sessionId = null;
+  try { sessionId = await resolver(supabase); } catch { sessionId = null; }
+  if (!sessionId) return { sessionId: null, loopState: 'unknown' };
+  try {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('loop_state')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error || !data) return { sessionId, loopState: 'unknown' };
+    return { sessionId, loopState: data.loop_state || 'unknown' };
+  } catch {
+    return { sessionId, loopState: 'unknown' };
+  }
+}
+
+/** Idempotency check: an existing unacknowledged scheduled record for this role means "already
+ * scheduled" — do not re-schedule on a repeated tick (TS-2). */
+export async function findPendingSchedule(supabase, role) {
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id, created_at, payload')
+      .eq('message_type', 'SPAWN_REQUEST')
+      .filter('payload->>kind', 'eq', 'singleton_relaunch_scheduled')
+      .filter('payload->>target_role', 'eq', role)
+      .is('acknowledged_at', null)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) return null;
+    return Array.isArray(data) && data.length ? data[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Write the relaunch-scheduled record. Error is CHECKED and returned, never swallowed
+ * (memory: reference-coordination-send-contract-enum-swallow-inboxkinds). */
+export async function writeScheduleRecord(supabase, { role, senderSession, freshness, fleetActivity, targetLoopState, reason }) {
+  const payload = {
+    kind: 'singleton_relaunch_scheduled',
+    target_role: role,
+    trigger_reason: reason,
+    freshness: { verdict: freshness.verdict, behind: freshness.behind, criticalDiff: freshness.criticalDiff },
+    fleet_signals: fleetActivity.signals,
+    target_loop_state: targetLoopState,
+    scheduled_at: new Date().toISOString(),
+  };
+  const { data, error } = await supabase
+    .from('session_coordination')
+    .insert({
+      message_type: 'SPAWN_REQUEST',
+      subject: `[SCHEDULER] singleton relaunch scheduled: ${role}`,
+      body: `Quiescent-window trigger fired for '${role}' — behind ${freshness.behind} commit(s), fleet quiescent, target loop_state=${targetLoopState}.`,
+      payload,
+      sender_session: senderSession || 'singleton-relaunch-scheduler',
+      sender_type: 'coordinator',
+    })
+    .select('id')
+    .single();
+  if (error) return { id: null, error: error.message };
+  return { id: data.id, error: null };
+}
+
+/**
+ * Full IO-orchestrated evaluation for one singleton role. `freshness`/`fleetActivity`/
+ * `targetLoopState` are all injectable overrides (used by evaluateAllSingletons to avoid
+ * recomputing the shared signals per-role, and by unit tests to exercise the decision + dedup
+ * paths without live git/DB calls). `enabled=false` runs the full decision but skips the write
+ * (dry-run / rollout-flag-off mode) — the PRD's rollout requirement is "flag defaulting OFF;
+ * first live cycle run supervised before enabling autonomous triggering".
+ */
+export async function evaluateSingletonRelaunch(supabase, {
+  role,
+  checkoutPath = process.cwd(),
+  senderSession,
+  freshness: freshnessOverride,
+  fleetActivity: fleetActivityOverride,
+  targetLoopState: loopStateOverride,
+  enabled = true,
+} = {}) {
+  if (!SINGLETON_ROLES.includes(role)) {
+    return { role, scheduled: false, reason: 'unknown_role' };
+  }
+  const freshness = freshnessOverride || checkoutFreshness(checkoutPath, { role });
+  const fleetActivity = fleetActivityOverride || (await assessFleetActivity(supabase));
+
+  let sessionId = null;
+  let loopState = loopStateOverride;
+  if (loopState === undefined) {
+    const state = await getRoleSessionState(supabase, role);
+    sessionId = state.sessionId;
+    loopState = state.loopState;
+  }
+
+  const decision = decideRelaunchSchedule({
+    freshnessVerdict: freshness.verdict,
+    fleetQuiescent: fleetActivity.quiescent,
+    targetLoopState: loopState,
+  });
+
+  if (!decision.scheduled) {
+    return { role, scheduled: false, reason: decision.reason, freshness, fleetActivity, sessionId, loopState };
+  }
+
+  if (!enabled) {
+    return { role, scheduled: false, reason: 'would_schedule_but_disabled', wouldSchedule: true, freshness, fleetActivity, sessionId, loopState };
+  }
+
+  const pending = await findPendingSchedule(supabase, role);
+  if (pending) {
+    return { role, scheduled: false, reason: 'already_scheduled_pending', pendingId: pending.id, freshness, fleetActivity, sessionId, loopState };
+  }
+
+  const written = await writeScheduleRecord(supabase, { role, senderSession, freshness, fleetActivity, targetLoopState: loopState, reason: decision.reason });
+  if (written.error) {
+    return { role, scheduled: false, reason: 'write_failed', error: written.error, freshness, fleetActivity, sessionId, loopState };
+  }
+  return { role, scheduled: true, reason: decision.reason, scheduleId: written.id, freshness, fleetActivity, sessionId, loopState };
+}
+
+/** Evaluate all 3 singleton roles for one tick. Freshness + fleet-quiescence are computed ONCE
+ * and shared — today all 3 singletons operate from the same shared working tree, and fleet
+ * activity is fleet-wide, not per-role, so recomputing 3x would just be 3x the git/DB cost for
+ * an identical answer. */
+export async function evaluateAllSingletons(supabase, { checkoutPath = process.cwd(), senderSession, enabled = true } = {}) {
+  const freshness = checkoutFreshness(checkoutPath, { role: 'singleton-relaunch-scheduler' });
+  const fleetActivity = await assessFleetActivity(supabase);
+  const results = [];
+  for (const role of SINGLETON_ROLES) {
+    // sequential by design: each write must dedupe against the previous role's own record, not race
+    results.push(await evaluateSingletonRelaunch(supabase, { role, checkoutPath, senderSession, freshness, fleetActivity, enabled }));
+  }
+  return results;
+}
+
+export default {
+  SAFE_LOOP_STATES,
+  SINGLETON_ROLES,
+  decideRelaunchSchedule,
+  getRoleSessionState,
+  findPendingSchedule,
+  writeScheduleRecord,
+  evaluateSingletonRelaunch,
+  evaluateAllSingletons,
+};

--- a/scripts/singleton-relaunch-scheduler.mjs
+++ b/scripts/singleton-relaunch-scheduler.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Periodic driver for the quiescent-window singleton-relaunch trigger
+ * (SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A).
+ *
+ * No fixed cron — invocation cadence is owned by whatever wires it into a coordinator tick loop
+ * (mirrors scripts/gauge-runner.mjs's own cadence contract). Gated OFF by default per the parent
+ * PRD's rollout requirement: "flag defaulting OFF; first live cycle run supervised before
+ * enabling autonomous triggering." With the flag off, every tick still evaluates and logs the
+ * decision (dry-run) but writes no schedule record.
+ *
+ * Usage: node scripts/singleton-relaunch-scheduler.mjs
+ * Env:   SINGLETON_RELAUNCH_SCHEDULING_ENABLED=true   (arm real scheduling; default unset/false)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { evaluateAllSingletons } from '../lib/coordinator/singleton-relaunch-trigger.js';
+
+const ENABLED = process.env.SINGLETON_RELAUNCH_SCHEDULING_ENABLED === 'true';
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  if (!ENABLED) {
+    console.log('[singleton-relaunch-scheduler] SINGLETON_RELAUNCH_SCHEDULING_ENABLED is not "true" — running in dry-run/report-only mode (evaluates, does not write).');
+  }
+
+  const results = await evaluateAllSingletons(supabase, {
+    senderSession: process.env.CLAUDE_SESSION_ID || 'singleton-relaunch-scheduler',
+    enabled: ENABLED,
+  });
+
+  for (const r of results) {
+    const behind = r.freshness ? r.freshness.behind : '?';
+    console.log(`[singleton-relaunch-scheduler] role=${r.role} scheduled=${r.scheduled} reason=${r.reason} behind=${behind} loop_state=${r.loopState}`);
+    if (r.error) console.error(`[singleton-relaunch-scheduler] role=${r.role} write error: ${r.error}`);
+  }
+}
+
+main().catch((e) => {
+  console.error('[singleton-relaunch-scheduler] fatal:', e && e.message ? e.message : e);
+  process.exit(1);
+});

--- a/tests/unit/coordinator/singleton-relaunch-trigger.test.js
+++ b/tests/unit/coordinator/singleton-relaunch-trigger.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideRelaunchSchedule,
+  evaluateSingletonRelaunch,
+  SAFE_LOOP_STATES,
+} from '../../../lib/coordinator/singleton-relaunch-trigger.js';
+
+// SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A (FR-1): quiescent-window
+// trigger + relaunch scheduler. TS-1/TS-2 from the parent PRD are covered via
+// evaluateSingletonRelaunch below; decideRelaunchSchedule covers the full pure decision matrix.
+
+function makeSupabaseStub({ pendingRows = [], insertResult = { data: { id: 'sched-1' }, error: null }, sessionRow = null } = {}) {
+  const calls = { findPending: 0, insert: 0 };
+  return {
+    from() {
+      return {
+        select() {
+          const chain = {
+            eq() { return chain; },
+            filter() { return chain; },
+            is() { return chain; },
+            order() { return chain; },
+            limit() {
+              calls.findPending += 1;
+              return Promise.resolve({ data: pendingRows, error: null });
+            },
+            maybeSingle() {
+              return Promise.resolve({ data: sessionRow, error: null });
+            },
+          };
+          return chain;
+        },
+        insert() {
+          calls.insert += 1;
+          return { select: () => ({ single: () => Promise.resolve(insertResult) }) };
+        },
+      };
+    },
+    _calls: calls,
+  };
+}
+
+const staleFreshness = { verdict: 'STALE', behind: 5, criticalDiff: [] };
+const quiescentFleet = { quiescent: true, reason: 'quiescent', signals: {} };
+
+describe('decideRelaunchSchedule (pure)', () => {
+  it('FRESH checkout never schedules, regardless of other signals', () => {
+    const r = decideRelaunchSchedule({ freshnessVerdict: 'FRESH', fleetQuiescent: true, targetLoopState: 'awaiting_tick' });
+    expect(r).toEqual({ scheduled: false, reason: 'fresh' });
+  });
+
+  it('missing freshnessVerdict is treated as fresh (fail-safe default)', () => {
+    const r = decideRelaunchSchedule({ fleetQuiescent: true, targetLoopState: 'awaiting_tick' });
+    expect(r.scheduled).toBe(false);
+    expect(r.reason).toBe('fresh');
+  });
+
+  it('STALE + fleet NOT quiescent does not schedule', () => {
+    const r = decideRelaunchSchedule({ freshnessVerdict: 'STALE', fleetQuiescent: false, targetLoopState: 'awaiting_tick' });
+    expect(r).toEqual({ scheduled: false, reason: 'fleet_not_quiescent' });
+  });
+
+  it('STALE + fleet quiescent + target loop_state=active (mid-consult) does not schedule — AC1', () => {
+    const r = decideRelaunchSchedule({ freshnessVerdict: 'STALE', fleetQuiescent: true, targetLoopState: 'active' });
+    expect(r).toEqual({ scheduled: false, reason: 'target_not_idle' });
+  });
+
+  it('STALE + fleet quiescent + target loop_state=unknown does not schedule (fail-closed, not fail-open)', () => {
+    const r = decideRelaunchSchedule({ freshnessVerdict: 'STALE', fleetQuiescent: true, targetLoopState: 'unknown' });
+    expect(r.scheduled).toBe(false);
+    expect(r.reason).toBe('target_not_idle');
+  });
+
+  it.each(SAFE_LOOP_STATES)('STALE-CRITICAL + fleet quiescent + target loop_state=%s schedules — AC2', (state) => {
+    const r = decideRelaunchSchedule({ freshnessVerdict: 'STALE-CRITICAL', fleetQuiescent: true, targetLoopState: state });
+    expect(r).toEqual({ scheduled: true, reason: 'behind_n_and_quiescent' });
+  });
+});
+
+describe('evaluateSingletonRelaunch (IO-orchestrated)', () => {
+  it('returns unknown_role for an unrecognized role without touching supabase', async () => {
+    const stub = makeSupabaseStub();
+    const r = await evaluateSingletonRelaunch(stub, { role: 'not-a-real-role' });
+    expect(r).toEqual({ role: 'not-a-real-role', scheduled: false, reason: 'unknown_role' });
+    expect(stub._calls.findPending).toBe(0);
+    expect(stub._calls.insert).toBe(0);
+  });
+
+  it('TS-1: behind-N + fleet idle + target mid-consult schedules nothing and performs no IO', async () => {
+    const stub = makeSupabaseStub();
+    const r = await evaluateSingletonRelaunch(stub, {
+      role: 'adam',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'active',
+    });
+    expect(r.scheduled).toBe(false);
+    expect(r.reason).toBe('target_not_idle');
+    expect(stub._calls.findPending).toBe(0);
+    expect(stub._calls.insert).toBe(0);
+  });
+
+  it('TS-2: behind-N + fleet idle + target idle schedules exactly once', async () => {
+    const stub = makeSupabaseStub({ pendingRows: [] });
+    const r = await evaluateSingletonRelaunch(stub, {
+      role: 'solomon',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'awaiting_tick',
+      senderSession: 'test-session',
+    });
+    expect(r.scheduled).toBe(true);
+    expect(r.reason).toBe('behind_n_and_quiescent');
+    expect(r.scheduleId).toBe('sched-1');
+    expect(stub._calls.insert).toBe(1);
+  });
+
+  it('TS-2: a repeated tick with an existing pending schedule does not duplicate-write', async () => {
+    const stub = makeSupabaseStub({ pendingRows: [{ id: 'sched-1', created_at: new Date().toISOString(), payload: {} }] });
+    const r = await evaluateSingletonRelaunch(stub, {
+      role: 'solomon',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'awaiting_tick',
+    });
+    expect(r.scheduled).toBe(false);
+    expect(r.reason).toBe('already_scheduled_pending');
+    expect(r.pendingId).toBe('sched-1');
+    expect(stub._calls.insert).toBe(0);
+  });
+
+  it('rollout flag off (enabled=false) evaluates but never writes — dry-run mode', async () => {
+    const stub = makeSupabaseStub();
+    const r = await evaluateSingletonRelaunch(stub, {
+      role: 'coordinator',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'exited',
+      enabled: false,
+    });
+    expect(r.scheduled).toBe(false);
+    expect(r.reason).toBe('would_schedule_but_disabled');
+    expect(r.wouldSchedule).toBe(true);
+    expect(stub._calls.findPending).toBe(0);
+    expect(stub._calls.insert).toBe(0);
+  });
+
+  it('a write error is surfaced, not swallowed', async () => {
+    const stub = makeSupabaseStub({ insertResult: { data: null, error: { message: 'insert failed' } } });
+    const r = await evaluateSingletonRelaunch(stub, {
+      role: 'adam',
+      freshness: staleFreshness,
+      fleetActivity: quiescentFleet,
+      targetLoopState: 'awaiting_tick',
+    });
+    expect(r.scheduled).toBe(false);
+    expect(r.reason).toBe('write_failed');
+    expect(r.error).toBe('insert failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Child A of SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001 (trigger + scheduling only; fresh-checkout relaunch mechanics are Child B, sequenced re-register/retire is Child C).
- `lib/coordinator/singleton-relaunch-trigger.js`: pure `decideRelaunchSchedule()` gate (fail-closed unless checkout is stale + fleet quiescent + target singleton `loop_state` is `awaiting_tick`/`exited`) + IO orchestration reusing the shipped `checkoutFreshness()`, `assessFleetActivity()`, and the 3 role-election modules — no reimplementation of any existing signal.
- Idempotent scheduling: writes a `session_coordination` `SPAWN_REQUEST` record (`payload.kind='singleton_relaunch_scheduled'`) only once per role until acknowledged; a rollout flag (`SINGLETON_RELAUNCH_SCHEDULING_ENABLED`, default OFF) gates the actual write while still logging the decision in dry-run mode.
- `scripts/singleton-relaunch-scheduler.mjs`: thin periodic CLI driver (no fixed cron, matching `gauge-runner.mjs`'s own invocation-cadence contract).

**PR size note**: 415 LOC (production + tests + driver), above the ≤100 LOC target. Justification: this is a single cohesive unit (pure decision core + IO wrapper + CLI driver + an exhaustive decision-matrix test suite) that was already scoped down to the minimum via 3-way SD decomposition; splitting further would break the reviewable unit. Within the documented 400 LOC max for infra work with justification, off by a small margin dominated by test coverage.

## Test plan
- [x] `npx vitest run tests/unit/coordinator/singleton-relaunch-trigger.test.js` — 13/13 passing (pure decision matrix + TS-1/TS-2/rollout-flag/write-error coverage)
- [x] Live-verified against the real DB: `node scripts/singleton-relaunch-scheduler.mjs` (dry-run) → correct per-role log lines, zero `session_coordination` writes
- [x] Live-verified with `SINGLETON_RELAUNCH_SCHEDULING_ENABLED=true` while the fleet was genuinely active → all 3 roles correctly blocked (`fleet_not_quiescent`), zero writes
- [x] `npx eslint` clean on all 3 new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)