### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C): singleton refresh register-then-retire sequencer

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001",
-  "createdAt": "2026-07-02T03:12:00.114Z",
+  "sdKey": "SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C",
+  "expectedBranch": "feat/SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C",
+  "createdAt": "2026-07-02T10:34:06.891Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/coordinator/singleton-refresh-sequencer.cjs
+++ b/lib/coordinator/singleton-refresh-sequencer.cjs
@@ -1,0 +1,193 @@
+/**
+ * Singleton refresh register-then-retire sequencer.
+ *
+ * SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C
+ *
+ * Child C of the coordinator-orchestrated singleton refresh pipeline: after Child B
+ * relaunches a long-lived singleton (coordinator / Adam / Solomon) onto a fresh checkout,
+ * this module resolves the register-vs-retire ordering so there is never a window where
+ * BOTH the new and old session are simultaneously the "live" holder of the role (double
+ * registration) nor a window where NEITHER is (zero-singleton). The rule is strict:
+ * verify the new session's registration is healthy FIRST; only then retire the old one.
+ *
+ * This mirrors the decision-function shape already proven for coordinator/Adam role
+ * handoff (lib/coordinator/adam-identity.cjs decideSingleAdamGuard) rather than
+ * inventing a new pattern, and reuses the EXISTING guarded worktree-removal path
+ * (lib/worktree-manager.js removeWorktreeViaGit) instead of a raw `git worktree
+ * remove --force` / `rm -rf` — a raw removal is confirmed able to wipe a node_modules
+ * junction TARGET in the main working tree, not just the removed worktree.
+ *
+ * Retirement reuses the EXISTING claude_sessions.released_at / released_reason columns
+ * (the same chokepoint scripts/stale-session-sweep.cjs already writes through) rather
+ * than adding a new "retired" column.
+ */
+
+const LOOP_STATE_EXITED = 'exited';
+const VALID_LOOP_STATES = Object.freeze(['active', 'awaiting_tick', 'exited', 'unknown']);
+
+const DEFAULT_FRESH_MS = 5 * 60 * 1000; // 5 minutes, matches the sweep's heartbeat-freshness convention
+const RETIRED_REASON = 'ROLE_TRANSFER_RETIRED';
+
+/**
+ * @param {string|null|undefined} heartbeatAt
+ * @param {number} nowMs
+ * @param {number} freshMs
+ */
+function isFreshHeartbeat(heartbeatAt, nowMs, freshMs) {
+  if (!heartbeatAt) return false;
+  const t = new Date(heartbeatAt).getTime();
+  if (Number.isNaN(t)) return false;
+  return (nowMs - t) <= freshMs;
+}
+
+/**
+ * PURE health check for a newly-registered session. Healthy requires BOTH a fresh
+ * heartbeat AND a loop_state that is reachable/queryable (not 'exited', not missing).
+ * @param {{ heartbeat_at?: string|null, loop_state?: string|null }} session
+ * @param {{ nowMs?: number, freshMs?: number }} [opts]
+ * @returns {{ healthy: boolean, reason: string }}
+ */
+function checkNewSessionHealth(session, { nowMs = Date.now(), freshMs = DEFAULT_FRESH_MS } = {}) {
+  if (!session) {
+    return { healthy: false, reason: 'new session not found in claude_sessions' };
+  }
+  if (!isFreshHeartbeat(session.heartbeat_at, nowMs, freshMs)) {
+    return { healthy: false, reason: 'new session heartbeat is stale or missing' };
+  }
+  const loopState = session.loop_state;
+  if (!loopState || !VALID_LOOP_STATES.includes(loopState)) {
+    return { healthy: false, reason: `new session loop_state is not queryable (got: ${String(loopState)})` };
+  }
+  if (loopState === LOOP_STATE_EXITED) {
+    return { healthy: false, reason: 'new session loop_state is exited' };
+  }
+  return { healthy: true, reason: 'fresh heartbeat and reachable loop_state' };
+}
+
+/**
+ * PURE sequencing decision. This is the mutex: retirement of the old session is NEVER
+ * decided except as a function of a positive new-session health check. Structurally,
+ * callers must call this before retireOldSession — there is no path that retires first.
+ * @param {{ newSessionHealthy: boolean }} p
+ * @returns {{ action: 'retire_old' | 'hold_old', reason: string }}
+ */
+function decideRefreshSequencing({ newSessionHealthy }) {
+  if (newSessionHealthy) {
+    return { action: 'retire_old', reason: 'new session verified healthy — safe to retire old session' };
+  }
+  return { action: 'hold_old', reason: 'new session not yet healthy — old session held active, not retired' };
+}
+
+/**
+ * Fetch the minimal fields needed for a health check.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} sessionId
+ */
+async function fetchSessionForHealthCheck(supabase, sessionId) {
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, heartbeat_at, loop_state')
+    .eq('session_id', sessionId)
+    .maybeSingle();
+  if (error) throw new Error(`fetchSessionForHealthCheck(${sessionId}): ${error.message}`);
+  return data;
+}
+
+/**
+ * Retire the old session: mark it released via the EXISTING released_at/released_reason
+ * chokepoint (same columns scripts/stale-session-sweep.cjs already writes), then remove
+ * its worktree via the EXISTING guarded removal path. Never call this without first
+ * confirming decideRefreshSequencing({newSessionHealthy}).action === 'retire_old'.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ oldSessionId: string, oldWorktreePath?: string|null, repoRoot?: string, reason?: string }} p
+ * @returns {Promise<{ ok: boolean, sessionUpdateError: string|null, worktreeResult: object|null }>}
+ */
+async function retireOldSession(supabase, { oldSessionId, oldWorktreePath = null, repoRoot = null, reason = RETIRED_REASON } = {}) {
+  if (!oldSessionId) throw new Error('retireOldSession: oldSessionId is required');
+
+  const nowIso = new Date().toISOString();
+  const { error: updateError } = await supabase
+    .from('claude_sessions')
+    .update({
+      status: 'released',
+      released_at: nowIso,
+      released_reason: reason,
+      sd_key: null,
+      worktree_path: null,
+      worktree_branch: null,
+      has_uncommitted_changes: false,
+      current_branch: null,
+    })
+    .eq('session_id', oldSessionId);
+
+  let worktreeResult = null;
+  if (oldWorktreePath) {
+    // Dynamic import: lib/worktree-manager.js is ESM, this module is CJS.
+    const { removeWorktreeViaGit, getRepoRoot } = await import('../worktree-manager.js');
+    const root = repoRoot || getRepoRoot();
+    worktreeResult = removeWorktreeViaGit(oldWorktreePath, root, {
+      guard: true, // re-verifies the worktree is not owned by another live session before removing
+      allowFail: true,
+      logger: console.warn.bind(console), // removeWorktreeViaGit calls logger(...) as a function
+    });
+  }
+
+  return {
+    ok: !updateError && (worktreeResult ? worktreeResult.ok !== false || Boolean(worktreeResult.skipped) : true),
+    sessionUpdateError: updateError ? updateError.message : null,
+    worktreeResult,
+  };
+}
+
+/**
+ * Full orchestration: verify new session health, decide, and only retire the old
+ * session if the decision says so. This is the single entry point callers should use.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ newSessionId: string, oldSessionId: string, oldWorktreePath?: string|null, repoRoot?: string, freshMs?: number, reason?: string }} p
+ */
+async function sequenceSingletonRefresh(supabase, {
+  newSessionId,
+  oldSessionId,
+  oldWorktreePath = null,
+  repoRoot = null,
+  freshMs = DEFAULT_FRESH_MS,
+  reason = RETIRED_REASON,
+} = {}) {
+  if (!newSessionId) throw new Error('sequenceSingletonRefresh: newSessionId is required');
+  if (!oldSessionId) throw new Error('sequenceSingletonRefresh: oldSessionId is required');
+
+  const newSession = await fetchSessionForHealthCheck(supabase, newSessionId);
+  const health = checkNewSessionHealth(newSession, { freshMs });
+  const decision = decideRefreshSequencing({ newSessionHealthy: health.healthy });
+
+  if (decision.action === 'hold_old') {
+    return {
+      action: 'hold_old',
+      retired: false,
+      healthReason: health.reason,
+      decisionReason: decision.reason,
+    };
+  }
+
+  const retireResult = await retireOldSession(supabase, { oldSessionId, oldWorktreePath, repoRoot, reason });
+  return {
+    action: 'retire_old',
+    retired: retireResult.ok,
+    healthReason: health.reason,
+    decisionReason: decision.reason,
+    ...retireResult,
+  };
+}
+
+module.exports = {
+  DEFAULT_FRESH_MS,
+  RETIRED_REASON,
+  isFreshHeartbeat,
+  checkNewSessionHealth,
+  decideRefreshSequencing,
+  fetchSessionForHealthCheck,
+  retireOldSession,
+  sequenceSingletonRefresh,
+};

--- a/lib/coordinator/singleton-refresh-sequencer.cjs
+++ b/lib/coordinator/singleton-refresh-sequencer.cjs
@@ -1,3 +1,9 @@
+// @wire-check-exempt: Child C of a 3-way sequenced decomposition (parent
+// SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001, TR-3: children build
+// bottom-up, later children wire earlier ones together). This is a real, tested library
+// with no standalone CLI mode (its functions take live sessionId/worktreePath args, not
+// sensible CLI defaults) — it is intentionally unconsumed until Child B's relaunch
+// orchestrator (not yet built) calls sequenceSingletonRefresh() as its final step.
 /**
  * Singleton refresh register-then-retire sequencer.
  *

--- a/tests/integration/coordinator/singleton-refresh-worktree-junction-survives.test.js
+++ b/tests/integration/coordinator/singleton-refresh-worktree-junction-survives.test.js
@@ -1,0 +1,91 @@
+/**
+ * SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C
+ * TS-4: retireOldSession's worktree cleanup goes through the EXISTING guarded
+ * removal path (lib/worktree-manager.js removeWorktreeViaGit -> preUnlinkWorktreeNodeModules),
+ * so a node_modules junction inside the retired worktree does not let removal
+ * follow the link and wipe the shared store it points at. Mirrors the fixture
+ * pattern in tests/integration/worktree-remove-junction-survives.test.js, but
+ * exercises retireOldSession end-to-end against a REAL git-registered worktree
+ * (removeWorktreeViaGit shells `git worktree remove --force`, which requires one).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { retireOldSession } from '../../../lib/coordinator/singleton-refresh-sequencer.cjs';
+
+let repoRoot, store, sentinel, wtPath;
+
+function sh(cmd, cwd) {
+  execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+beforeEach(() => {
+  repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'singleton-refresh-repo-'));
+  sh('git init -q', repoRoot);
+  sh('git config user.email test@example.com', repoRoot);
+  sh('git config user.name test', repoRoot);
+  fs.writeFileSync(path.join(repoRoot, 'README.md'), 'x');
+  // node_modules must be gitignored (as it is in every real checkout of this repo) so the
+  // worktree's node_modules junction is NOT reported as an untracked/dirty-tree change --
+  // isReapable's guard would otherwise (correctly) refuse to remove a dirty worktree.
+  fs.writeFileSync(path.join(repoRoot, '.gitignore'), 'node_modules/\n');
+  sh('git add -A', repoRoot);
+  sh('git commit -q -m init', repoRoot);
+
+  store = path.join(repoRoot, '..', `${path.basename(repoRoot)}-store`);
+  fs.mkdirSync(store, { recursive: true });
+  sentinel = path.join(store, 'SENTINEL.txt');
+  fs.writeFileSync(sentinel, 'do-not-delete');
+
+  wtPath = path.join(repoRoot, '..', `${path.basename(repoRoot)}-wt`);
+  sh(`git worktree add -q -b singleton-refresh-test-branch "${wtPath}"`, repoRoot);
+
+  // Simulate a shared node_modules store: node_modules INSIDE the worktree is a
+  // junction/symlink pointing at the sentinel store, as it would be for a worker
+  // worktree sharing the main tree's install.
+  fs.symlinkSync(store, path.join(wtPath, 'node_modules'), 'junction');
+});
+
+afterEach(() => {
+  for (const p of [repoRoot, store, wtPath]) {
+    try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+function makeNoopSupabase() {
+  return {
+    from() {
+      return { update: () => ({ eq: async () => ({ error: null }) }) };
+    },
+  };
+}
+
+describe('retireOldSession — worktree removal survives a node_modules junction (TS-4)', () => {
+  it('removes the worktree but the shared store the junction pointed at is untouched', async () => {
+    expect(fs.existsSync(sentinel)).toBe(true);
+
+    const result = await retireOldSession(makeNoopSupabase(), {
+      oldSessionId: 'old-session-under-test',
+      oldWorktreePath: wtPath,
+      repoRoot,
+    });
+
+    expect(result.worktreeResult).toBeTruthy();
+    expect(result.worktreeResult.ok).toBe(true);
+    expect(fs.existsSync(wtPath)).toBe(false);   // worktree itself is gone
+    expect(fs.existsSync(sentinel)).toBe(true);  // shared store SURVIVES
+    expect(fs.existsSync(store)).toBe(true);
+  });
+
+  it('session-only retirement (no worktree path) still marks the session released without touching the filesystem', async () => {
+    const result = await retireOldSession(makeNoopSupabase(), {
+      oldSessionId: 'old-session-no-worktree',
+      oldWorktreePath: null,
+      repoRoot,
+    });
+    expect(result.worktreeResult).toBeNull();
+    expect(result.sessionUpdateError).toBeNull();
+  });
+});

--- a/tests/unit/coordinator/singleton-refresh-sequencer.test.js
+++ b/tests/unit/coordinator/singleton-refresh-sequencer.test.js
@@ -1,0 +1,147 @@
+/**
+ * SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C
+ * TS-1, TS-2, TS-3: register-then-retire sequencing decision logic.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  checkNewSessionHealth,
+  decideRefreshSequencing,
+  sequenceSingletonRefresh,
+  RETIRED_REASON,
+} from '../../../lib/coordinator/singleton-refresh-sequencer.cjs';
+
+const NOW = 1_800_000_000_000; // fixed reference instant
+
+describe('checkNewSessionHealth', () => {
+  it('healthy: fresh heartbeat + active loop_state', () => {
+    const result = checkNewSessionHealth(
+      { heartbeat_at: new Date(NOW - 10_000).toISOString(), loop_state: 'active' },
+      { nowMs: NOW, freshMs: 5 * 60 * 1000 },
+    );
+    expect(result.healthy).toBe(true);
+  });
+
+  it('healthy: fresh heartbeat + unknown loop_state (freshly-booted default)', () => {
+    const result = checkNewSessionHealth(
+      { heartbeat_at: new Date(NOW - 10_000).toISOString(), loop_state: 'unknown' },
+      { nowMs: NOW, freshMs: 5 * 60 * 1000 },
+    );
+    expect(result.healthy).toBe(true);
+  });
+
+  it('unhealthy: stale heartbeat', () => {
+    const result = checkNewSessionHealth(
+      { heartbeat_at: new Date(NOW - 60 * 60 * 1000).toISOString(), loop_state: 'active' },
+      { nowMs: NOW, freshMs: 5 * 60 * 1000 },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/stale/);
+  });
+
+  it('unhealthy: missing heartbeat', () => {
+    const result = checkNewSessionHealth({ heartbeat_at: null, loop_state: 'active' }, { nowMs: NOW });
+    expect(result.healthy).toBe(false);
+  });
+
+  it('unhealthy: exited loop_state even with a fresh heartbeat', () => {
+    const result = checkNewSessionHealth(
+      { heartbeat_at: new Date(NOW - 1_000).toISOString(), loop_state: 'exited' },
+      { nowMs: NOW },
+    );
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/exited/);
+  });
+
+  it('unhealthy: session row not found', () => {
+    const result = checkNewSessionHealth(null, { nowMs: NOW });
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/not found/);
+  });
+});
+
+describe('decideRefreshSequencing', () => {
+  it('retire_old when the new session is healthy', () => {
+    expect(decideRefreshSequencing({ newSessionHealthy: true }).action).toBe('retire_old');
+  });
+
+  it('hold_old when the new session is NOT healthy', () => {
+    expect(decideRefreshSequencing({ newSessionHealthy: false }).action).toBe('hold_old');
+  });
+});
+
+/** In-memory fake of the tiny supabase surface sequenceSingletonRefresh touches. */
+function makeFakeSupabase({ newSession, updateOldSpy }) {
+  return {
+    from(table) {
+      expect(table).toBe('claude_sessions');
+      return {
+        select() {
+          return {
+            eq: (_col, val) => ({
+              maybeSingle: async () => ({ data: newSession, error: null }),
+            }),
+          };
+        },
+        update(patch) {
+          return {
+            eq: async (_col, val) => {
+              updateOldSpy(patch, val);
+              return { error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('sequenceSingletonRefresh — ordering guarantee (TS-1, TS-2, TS-3)', () => {
+  it('TS-2: unhealthy new session -> old session update is NEVER called (no premature retire)', async () => {
+    const updateOldSpy = vi.fn();
+    const supabase = makeFakeSupabase({
+      newSession: { session_id: 'new-1', heartbeat_at: null, loop_state: 'unknown' },
+      updateOldSpy,
+    });
+
+    const result = await sequenceSingletonRefresh(supabase, {
+      newSessionId: 'new-1',
+      oldSessionId: 'old-1',
+    });
+
+    expect(result.action).toBe('hold_old');
+    expect(result.retired).toBe(false);
+    expect(updateOldSpy).not.toHaveBeenCalled();
+  });
+
+  it('TS-1: healthy new session -> old session retire IS called with released_at/released_reason set (register-then-retire order)', async () => {
+    const updateOldSpy = vi.fn();
+    const supabase = makeFakeSupabase({
+      newSession: { session_id: 'new-1', heartbeat_at: new Date().toISOString(), loop_state: 'active' },
+      updateOldSpy,
+    });
+
+    const result = await sequenceSingletonRefresh(supabase, {
+      newSessionId: 'new-1',
+      oldSessionId: 'old-1',
+      oldWorktreePath: null, // no worktree cleanup in this case — session-only retirement
+    });
+
+    expect(result.action).toBe('retire_old');
+    expect(updateOldSpy).toHaveBeenCalledTimes(1);
+    const [patch, eqVal] = updateOldSpy.mock.calls[0];
+    expect(eqVal).toBe('old-1');
+    expect(patch.released_reason).toBe(RETIRED_REASON);
+    expect(patch.status).toBe('released');
+    expect(typeof patch.released_at).toBe('string');
+  });
+
+  it('TS-3: never observes both retire_old for an unhealthy session and hold_old for a healthy one (decision matrix is exhaustive/exclusive)', async () => {
+    const cases = [
+      { healthy: true, expected: 'retire_old' },
+      { healthy: false, expected: 'hold_old' },
+    ];
+    for (const c of cases) {
+      expect(decideRefreshSequencing({ newSessionHealthy: c.healthy }).action).toBe(c.expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/coordinator/singleton-refresh-sequencer.cjs`: register-verify-retire mutex for the coordinator-orchestrated singleton refresh pipeline (Child C of SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001).
- A new session must register and pass a health check (fresh heartbeat + reachable `loop_state`) before the old session is retired — no double-registration, no zero-singleton window.
- Old-worktree retirement reuses the existing guarded removal path (`lib/worktree-manager.js` `removeWorktreeViaGit`) instead of a raw `git worktree remove --force`, avoiding a confirmed prior incident where raw removal wiped a `node_modules` junction target in the main working tree.
- Session retirement reuses the existing `claude_sessions.released_at` / `released_reason` columns (already written by `stale-session-sweep.cjs`), no new schema.

## Test plan
- [x] `npx vitest run tests/unit/coordinator/singleton-refresh-sequencer.test.js tests/integration/coordinator/singleton-refresh-worktree-junction-survives.test.js` — 13/13 passed
- [x] Integration test proves a real git worktree with a `node_modules` junction survives removal (junction target/shared store untouched)
- [x] TESTING sub-agent: CONDITIONAL_PASS, no regressions (pre-existing/unrelated flakes independently confirmed on main)
- [x] VALIDATION sub-agent: PASS (95% confidence), independently re-ran tests, confirmed column reuse, confirmed no duplicate/overlapping SDs
- [x] REGRESSION sub-agent: PASS (95% confidence), diff is additive-only, `worktree-manager.js` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)