### PR TITLE
chore(SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A): wire singleton-relaunch-scheduler.mjs into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vision:gauge": "node scripts/vision-gauge-refresh.mjs",
     "vision:s19-coverage-gauge": "node scripts/s19-vision-coverage-gauge.mjs",
     "gauges:run": "node scripts/gauge-runner.mjs",
+    "singleton-relaunch:run": "node scripts/singleton-relaunch-scheduler.mjs",
     "coordinator:relay-drain": "node scripts/coordinator-relay-drain.cjs",
     "coordinator:relay-drop-gauge": "node scripts/coordinator-relay-drop-gauge.cjs",
     "vision:build-forecast": "node scripts/vision/build-completion-forecast.mjs",


### PR DESCRIPTION
## Summary
- Follow-up to PR #5385 (merged): the LEAD-FINAL-APPROVAL `WIRE_CHECK_GATE` flagged `scripts/singleton-relaunch-scheduler.mjs` and `lib/coordinator/singleton-relaunch-trigger.js` as unreachable from any entry point.
- Adds an npm script entry (`singleton-relaunch:run`), matching the existing `gauges:run` precedent for the same no-fixed-cron CLI pattern — the lib module becomes reachable transitively via the script's own import.

## Test plan
- [x] `grep -n "singleton-relaunch:run" package.json` confirms the entry
- [x] No functional code changed — package.json only

🤖 Generated with [Claude Code](https://claude.com/claude-code)