### PR TITLE
feat(SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B): FR-1 chairman-directive durability (broadcast + per-role ack gauge + SUPERSEDES)

### DIFF
--- a/lib/coordinator/__tests__/chairman-directive-gauge.test.js
+++ b/lib/coordinator/__tests__/chairman-directive-gauge.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1
+ *
+ * lib/coordinator/chairman-directive-gauge.cjs — the per-role chairman-directive ack/compliance gauge.
+ * decideChairmanDirectiveCompliance() is a PURE core (zero IO, injected now/windowMs) that, per
+ * directive_id, keeps only the latest issued_at (SUPERSEDES) and reports each applies_to role as
+ * ACKED (has a chairman_directive_ack with actioned_at) vs OUTSTANDING.
+ */
+import { describe, it, expect } from 'vitest';
+import { decideChairmanDirectiveCompliance } from '../chairman-directive-gauge.cjs';
+
+const NOW = Date.parse('2026-07-02T00:00:00Z');
+
+function directive({ id, issuedAt, roles }) {
+  return { payload: { kind: 'chairman_directive', directive_id: id, issued_at: issuedAt, applies_to: roles } };
+}
+function ack({ id, role, actionedAt }) {
+  return { payload: { kind: 'chairman_directive_ack', directive_id: id, role, actioned_at: actionedAt } };
+}
+
+describe('decideChairmanDirectiveCompliance', () => {
+  it('(a) all applies_to roles OUTSTANDING when there are no acks', () => {
+    const directives = [directive({ id: 'd1', issuedAt: '2026-07-01T23:55:00Z', roles: ['adam', 'coordinator', 'solomon'] })];
+    const rows = decideChairmanDirectiveCompliance({ directives, acks: [], now: NOW });
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.status === 'outstanding')).toBe(true);
+    expect(rows.map((r) => r.role).sort()).toEqual(['adam', 'coordinator', 'solomon']);
+    // ageMs is measured from issued_at
+    expect(rows[0].ageMs).toBe(NOW - Date.parse('2026-07-01T23:55:00Z'));
+  });
+
+  it('(b) a role flips ACKED after an ack row carrying actioned_at; the others stay OUTSTANDING', () => {
+    const directives = [directive({ id: 'd1', issuedAt: '2026-07-01T23:55:00Z', roles: ['adam', 'coordinator', 'solomon'] })];
+    const acks = [ack({ id: 'd1', role: 'solomon', actionedAt: '2026-07-01T23:58:00Z' })];
+    const rows = decideChairmanDirectiveCompliance({ directives, acks, now: NOW });
+    const byRole = Object.fromEntries(rows.map((r) => [r.role, r]));
+    expect(byRole.solomon.status).toBe('acked');
+    expect(byRole.solomon.ackedAt).toBe('2026-07-01T23:58:00Z');
+    expect(byRole.adam.status).toBe('outstanding');
+    expect(byRole.coordinator.status).toBe('outstanding');
+  });
+
+  it('an ack row WITHOUT actioned_at does NOT flip the role to ACKED (two-stage: DELIVERED != ACTIONED)', () => {
+    const directives = [directive({ id: 'd1', issuedAt: '2026-07-01T23:55:00Z', roles: ['adam'] })];
+    const acks = [{ payload: { kind: 'chairman_directive_ack', directive_id: 'd1', role: 'adam' } }]; // no actioned_at
+    const rows = decideChairmanDirectiveCompliance({ directives, acks, now: NOW });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('outstanding');
+  });
+
+  it('(c) SUPERSEDES — the NEWER issued_at directive for the same directive_id is tracked; the stale one is not counted', () => {
+    // Chairman reversed effort low->high->low: same directive_id, three issuances, newest is 'solomon'-only.
+    const directives = [
+      directive({ id: 'baseline', issuedAt: '2026-07-01T22:00:00Z', roles: ['adam', 'coordinator', 'solomon'] }), // stale low
+      directive({ id: 'baseline', issuedAt: '2026-07-01T22:30:00Z', roles: ['adam', 'coordinator', 'solomon'] }), // stale high
+      directive({ id: 'baseline', issuedAt: '2026-07-01T23:00:00Z', roles: ['solomon'] }),                        // NEWEST low
+    ];
+    const rows = decideChairmanDirectiveCompliance({ directives, acks: [], now: NOW });
+    // Only the newest directive is tracked → exactly its applies_to (['solomon']), not the stale ['adam','coordinator','solomon'].
+    expect(rows).toHaveLength(1);
+    expect(rows[0].role).toBe('solomon');
+    expect(rows[0].issuedAt).toBe('2026-07-01T23:00:00Z');
+    expect(rows[0].status).toBe('outstanding');
+  });
+
+  it('SUPERSEDES is directive_id-scoped: two distinct directive_ids are both tracked independently', () => {
+    const directives = [
+      directive({ id: 'd1', issuedAt: '2026-07-01T23:00:00Z', roles: ['adam'] }),
+      directive({ id: 'd2', issuedAt: '2026-07-01T23:10:00Z', roles: ['solomon'] }),
+    ];
+    const rows = decideChairmanDirectiveCompliance({ directives, acks: [], now: NOW });
+    expect(rows.map((r) => r.directiveId).sort()).toEqual(['d1', 'd2']);
+  });
+});

--- a/lib/coordinator/chairman-directive-gauge.cjs
+++ b/lib/coordinator/chairman-directive-gauge.cjs
@@ -1,0 +1,205 @@
+/**
+ * Chairman-directive per-role ack/compliance gauge.
+ *
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1.
+ *
+ * Mirrors the pure-core + fail-open + flag-gated SHAPE of lib/coordinator/relay-drop-gauge.cjs
+ * EXACTLY. Where that gauge correlates one inbound row to one outbound confirm, this gauge tracks,
+ * per directive_id and per applies_to ROLE, whether a chairman_directive_ack (with actioned_at)
+ * exists. Reproduces the confirmed incident shape: a chairman directive that no role acked, ~2h with
+ * nothing flagging that a role was non-compliant.
+ *
+ * SUPERSEDES semantics: for a given directive_id, only the LATEST issued_at directive is tracked (the
+ * chairman reversed effort low->high->low; the stale earlier directive must not out-rank the newer one
+ * and must not be counted OUTSTANDING).
+ *
+ * CommonJS (.cjs) so a .cjs coordinator tick / the fleet dashboard can require() it, mirroring
+ * relay-drop-gauge.cjs's module format.
+ *
+ * @module lib/coordinator/chairman-directive-gauge
+ */
+
+'use strict';
+
+const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+
+const CHAIRMAN_DIRECTIVE_KIND = PAYLOAD_KINDS.CHAIRMAN_DIRECTIVE; // 'chairman_directive'
+const CHAIRMAN_DIRECTIVE_ACK_KIND = 'chairman_directive_ack';
+
+/** Default compliance window: 5 min — the chairman-baseline cadence the incident silently missed. */
+const DEFAULT_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Env flag gating the write-side of any tick (default ON — read/report is always live). Callers MUST
+ * check the returned `enabled` before writing; this function only computes the flag (mirrors
+ * relay-drop-gauge.gaugeEnabled).
+ */
+function gaugeEnabled(env) {
+  env = env || process.env;
+  return String(env.CHAIRMAN_DIRECTIVE_GAUGE_V1 ?? 'true').toLowerCase() !== 'false';
+}
+
+/** Resolve the compliance window (ms) from env, falling back to the default. */
+function resolveWindowMs(env) {
+  env = env || process.env;
+  const min = Number(env.CHAIRMAN_DIRECTIVE_GAUGE_WINDOW_MIN);
+  return Number.isFinite(min) && min > 0 ? min * 60 * 1000 : DEFAULT_WINDOW_MS;
+}
+
+function tsMs(ts) {
+  if (!ts) return 0;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * CORE — pure, dependency-injected per-role compliance decision. Zero IO. Given chairman_directive
+ * rows and chairman_directive_ack rows, for each directive_id keeps ONLY the latest issued_at
+ * (SUPERSEDES), then per applies_to role reports ACKED (an ack row with actioned_at) vs OUTSTANDING.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.directives - session_coordination rows, payload.kind='chairman_directive'
+ * @param {Array<object>} args.acks       - rows, payload.kind='chairman_directive_ack'
+ * @param {number} [args.now=Date.now()]
+ * @param {number} [args.windowMs=DEFAULT_WINDOW_MS]
+ * @returns {Array<object>} one row per (directive_id × applies_to role):
+ *   { directiveId, role, status:'acked'|'outstanding', issuedAt, ageMs, ackedAt }
+ */
+function decideChairmanDirectiveCompliance({ directives, acks, now, windowMs } = {}) {
+  now = Number.isFinite(now) ? now : Date.now();
+  windowMs = Number.isFinite(windowMs) ? windowMs : DEFAULT_WINDOW_MS;
+
+  // SUPERSEDES: per directive_id keep the row with the greatest issued_at (latest wins).
+  const latestByDir = new Map();
+  for (const d of (directives || [])) {
+    const p = d && d.payload;
+    if (!p || p.kind !== CHAIRMAN_DIRECTIVE_KIND || !p.directive_id) continue;
+    const prev = latestByDir.get(p.directive_id);
+    if (!prev || tsMs(p.issued_at) >= tsMs(prev.payload.issued_at)) latestByDir.set(p.directive_id, d);
+  }
+
+  // Index acks by directive_id -> role -> latest actioned_at.
+  const ackByDir = new Map();
+  for (const a of (acks || [])) {
+    const p = a && a.payload;
+    if (!p || p.kind !== CHAIRMAN_DIRECTIVE_ACK_KIND || !p.directive_id || !p.actioned_at) continue;
+    if (!ackByDir.has(p.directive_id)) ackByDir.set(p.directive_id, new Map());
+    const roleMap = ackByDir.get(p.directive_id);
+    const role = String(p.role || '');
+    const prev = roleMap.get(role);
+    if (!prev || tsMs(p.actioned_at) >= tsMs(prev)) roleMap.set(role, p.actioned_at);
+  }
+
+  const out = [];
+  for (const [directiveId, d] of latestByDir) {
+    const p = d.payload;
+    const roles = Array.isArray(p.applies_to) ? p.applies_to : [];
+    const roleMap = ackByDir.get(directiveId) || new Map();
+    const ageMs = now - tsMs(p.issued_at);
+    for (const role of roles) {
+      const ackedAt = roleMap.get(String(role)) || null;
+      out.push({
+        directiveId,
+        role: String(role),
+        status: ackedAt ? 'acked' : 'outstanding',
+        issuedAt: p.issued_at || null,
+        ageMs,
+        ackedAt,
+      });
+    }
+  }
+  return out;
+}
+
+/** IO: load recent chairman_directive rows. FAIL-SOFT: [] on error. */
+async function loadDirectives(supabase, opts = {}) {
+  const { windowLookbackMs = 24 * 60 * 60 * 1000, now = Date.now() } = opts;
+  try {
+    const since = new Date(now - windowLookbackMs).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, payload, created_at')
+      .eq('payload->>kind', CHAIRMAN_DIRECTIVE_KIND)
+      .gte('created_at', since)
+      .limit(200);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/** IO: load recent chairman_directive_ack rows. FAIL-SOFT: [] on error. */
+async function loadAcks(supabase, opts = {}) {
+  const { windowLookbackMs = 24 * 60 * 60 * 1000, now = Date.now() } = opts;
+  try {
+    const since = new Date(now - windowLookbackMs).toISOString();
+    const { data } = await supabase
+      .from('session_coordination')
+      .select('id, payload, created_at')
+      .eq('payload->>kind', CHAIRMAN_DIRECTIVE_ACK_KIND)
+      .gte('created_at', since)
+      .limit(400);
+    return data || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Convenience for a ROLE inbox (adam/coordinator/solomon): compute this role's per-directive
+ * compliance rows (latest issued_at per directive_id, this role's ack status). READ-ONLY / non-
+ * consuming (never mutates target_session — a broadcast chairman_directive must survive so every role
+ * surfaces it). FAIL-OPEN: returns [] on any error. Rendered first-class by each role's inbox.
+ * @returns {Promise<Array<object>>} rows for `role`: { directiveId, role, status, issuedAt, ageMs, ackedAt }
+ */
+async function loadRoleDirectiveStatus(supabase, role, opts = {}) {
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  try {
+    const [directives, acks] = await Promise.all([
+      loadDirectives(supabase, { now }),
+      loadAcks(supabase, { now }),
+    ]);
+    const rows = decideChairmanDirectiveCompliance({ directives, acks, now, windowMs: resolveWindowMs(opts.env || process.env) });
+    return rows.filter((r) => r.role === String(role));
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Tick entry point. FAIL-OPEN end to end — never throws. Read/report always runs; gaugeEnabled() only
+ * gates whether callers should act on 'outstanding' rows — this module performs no writes.
+ * @returns {Promise<{ enabled, rows, outstanding, acked }>}
+ */
+async function planChairmanDirectiveCompliance(supabase, opts = {}) {
+  const env = opts.env || process.env;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  try {
+    const [directives, acks] = await Promise.all([
+      loadDirectives(supabase, { now }),
+      loadAcks(supabase, { now }),
+    ]);
+    const rows = decideChairmanDirectiveCompliance({ directives, acks, now, windowMs: resolveWindowMs(env) });
+    return {
+      enabled: gaugeEnabled(env),
+      rows,
+      outstanding: rows.filter((r) => r.status === 'outstanding').length,
+      acked: rows.filter((r) => r.status === 'acked').length,
+    };
+  } catch (e) {
+    return { enabled: gaugeEnabled(env), rows: [], outstanding: 0, acked: 0, error: String((e && e.message) || e) };
+  }
+}
+
+module.exports = {
+  decideChairmanDirectiveCompliance, // pure core (unit-testable in isolation)
+  gaugeEnabled,
+  resolveWindowMs,
+  loadDirectives,
+  loadAcks,
+  loadRoleDirectiveStatus,
+  planChairmanDirectiveCompliance,
+  CHAIRMAN_DIRECTIVE_KIND,
+  CHAIRMAN_DIRECTIVE_ACK_KIND,
+  DEFAULT_WINDOW_MS,
+};

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -66,6 +66,7 @@ const PAYLOAD_KINDS = Object.freeze({
   SOLOMON_CONSULT: 'solomon_consult', // SD-LEO-INFRA-SOLOMON-CONSULT-001D: worker/Adam→Solomon oracle consult (off friction router; reply travels under adam_advisory+oracle:true; intentionally NOT a DIRECTIVE_KIND)
   RELAY_REQUEST: 'relay_request',     // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1: a tracked relay-request the coordinator drains deliberately (never processed inline in the active thread). Intentionally NOT a DIRECTIVE_KIND — the generic worker inbox drain must never auto-consume it; only coordinator-relay-drain.cjs may act on it.
   RELAY_CONFIRM: 'relay_confirm',     // FR-2: the durable confirm-back row correlated to a relay_request via payload.correlation_id — CONFIRM-ON-RELAY is only satisfied once this row exists.
+  CHAIRMAN_DIRECTIVE: 'chairman_directive', // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1: a durable BROADCAST chairman directive all 3 roles (Adam/coordinator/Solomon) surface FIRST-CLASS with per-role ack-tracking. Intentionally a DIRECTIVE_KIND (below) so the generic inbox drain NEVER auto-acks/consumes it (the last-hop silent-death root cause). Its ack REPLY carries payload.kind='chairman_directive_ack' (NOT a directive — a terminal reply, so it is deliberately NOT in DIRECTIVE_KINDS).
 });
 
 // FR-3 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): payload.kind values that are
@@ -87,6 +88,14 @@ const DIRECTIVE_KINDS = Object.freeze([
   // for Adam (two-stage no-auto-ack, same as the rest of this allowlist) — without it the
   // full-lane inbox drain would silently drop a directive carrying this kind.
   'coordinator_directive',
+  // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1 (THE HIGHEST-LEVERAGE FIX): a
+  // chairman_directive is a BROADCAST directive all 3 roles must genuinely action. Without it
+  // here, the generic inbox drain auto-acked/consumed it before any role acted — the exact
+  // last-hop silent death that let a 5-min-baseline directive die (Solomon ran 2h
+  // non-compliant). As a DIRECTIVE_KIND it is deliver-not-consume (read_at=DELIVERED only;
+  // payload.actioned_at=ACTIONED reserved for the acting role). The ack reply
+  // (chairman_directive_ack) is a terminal reply, NOT a directive — deliberately absent here.
+  'chairman_directive',
 ]);
 
 const FLEET_ACTIVE_WINDOW_MS = 15 * 60 * 1000;

--- a/scripts/ack-chairman-directive.cjs
+++ b/scripts/ack-chairman-directive.cjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Per-role ACK of a CHAIRMAN DIRECTIVE — SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1.
+ *
+ * A role (adam / coordinator / solomon) records that it has GENUINELY ACTIONED a chairman_directive
+ * by writing a chairman_directive_ack reply row. Mirrors lib/coordinator/adam-action-ack.cjs's
+ * two-stage-ACK shape VERBATIM: read_at = DELIVERED is stamped by the transport/inbox drain (the
+ * directive was surfaced); payload.actioned_at = ACTIONED is stamped HERE (the role genuinely acted).
+ * A directive stays OUTSTANDING for a role until this ack row exists — non-compliance is VISIBLE, not
+ * silent (that visibility is computed by lib/coordinator/chairman-directive-gauge.cjs).
+ *
+ * Ack is keyed by directive_id (NOT topic_id) so this child is dependency-free.
+ *
+ * Usage:
+ *   node scripts/ack-chairman-directive.cjs --id <directive_id> --role <adam|coordinator|solomon> [--note "<text>"]
+ */
+'use strict';
+
+const { getServiceClient } = require('../lib/fleet/worker-status.cjs');
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+
+const CHAIRMAN_DIRECTIVE_ACK_KIND = 'chairman_directive_ack';
+
+function argVal(argv, flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const directiveId = argVal(argv, '--id');
+  const role = argVal(argv, '--role');
+  const note = argVal(argv, '--note');
+  if (!directiveId || !role) {
+    console.error('Usage: node scripts/ack-chairman-directive.cjs --id <directive_id> --role <adam|coordinator|solomon> [--note "<text>"]');
+    process.exit(2);
+  }
+  const actionedAt = new Date().toISOString();
+
+  const payload = {
+    kind: CHAIRMAN_DIRECTIVE_ACK_KIND, // a terminal reply — deliberately NOT a DIRECTIVE_KIND
+    directive_id: directiveId,         // ack keyed by directive_id (dependency-free; no topic_id)
+    role: String(role),
+    actioned_at: actionedAt,           // ACTIONED marker (mirrors adam-action-ack payload.actioned_at)
+    reply_to: directiveId,             // correlation echo (reply-lane convention)
+  };
+  if (note) payload.note = String(note);
+
+  const supabase = getServiceClient();
+  await insertCoordinationRow(supabase, {
+    sender_session: role,
+    sender_type: role,
+    target_session: 'broadcast',       // broadcast so the per-role gauge reads every role's ack
+    message_type: 'INFO',
+    subject: `[CHAIRMAN_DIRECTIVE_ACK ${directiveId}] role=${role}`,
+    body: note || `${role} actioned chairman_directive ${directiveId}`,
+    payload,
+  });
+
+  console.log(`✓ chairman_directive_ack recorded: id=${directiveId} role=${role} actioned_at=${actionedAt}`);
+}
+
+main().catch((e) => { console.error('ack-chairman-directive failed:', (e && e.message) || e); process.exit(1); });

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -302,6 +302,10 @@ function isDirectiveRow(r) {
  */
 const ADAM_INBOX_KINDS = Object.freeze([
   ...DIRECTIVE_KINDS,
+  // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1: chairman_directive is ALSO a shared
+  // DIRECTIVE_KIND (spread above) — Adam drains it via the shared allowlist. It is intentionally
+  // NOT re-listed here (avoids a misleading duplicate); its FIRST-CLASS render partition below
+  // surfaces it ABOVE normal advisories so Adam actions it first.
   'chairman_heads_up',
   'chairman_handoff',
   'coordinator_advisory',
@@ -356,6 +360,25 @@ function isOrphanedAdamRow(r) {
   const k = r.payload && r.payload.kind;
   if (k != null && EXCLUDED_KINDS.includes(k)) return false; // handler-owned → never touch
   return true; // untyped, or an unknown typed kind targeting Adam → orphaned delivery
+}
+
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1 — FIRST-CLASS chairman-directive partition.
+ * Surfaces broadcast chairman_directive rows ABOVE the normal advisory drain, with Adam's per-directive
+ * OUTSTANDING/ACKED status (latest issued_at per directive_id — SUPERSEDES). READ-ONLY / non-consuming
+ * (the broadcast row must survive so coordinator + Solomon also surface it). Adam acks a directive it
+ * has actioned via scripts/ack-chairman-directive.cjs --role adam. Fail-open (renders nothing on error).
+ */
+async function renderChairmanDirectives(supabase, role, { quiet = false } = {}) {
+  const { loadRoleDirectiveStatus } = require('../lib/coordinator/chairman-directive-gauge.cjs');
+  const rows = await loadRoleDirectiveStatus(supabase, role);
+  if (rows.length === 0) { if (!quiet) console.log('(no chairman directives outstanding for this role)'); return; }
+  const outstanding = rows.filter((r) => r.status === 'outstanding');
+  console.log(`★ ${rows.length} CHAIRMAN DIRECTIVE(s) for ${role} — ${outstanding.length} OUTSTANDING (ack via scripts/ack-chairman-directive.cjs --role ${role}):`);
+  for (const r of rows) {
+    const ageMin = Math.floor((r.ageMs || 0) / 60_000);
+    console.log(`  ★ [${r.status.toUpperCase()}] ${r.directiveId} (issued ${ageMin}m ago)`);
+  }
 }
 
 /**
@@ -503,6 +526,9 @@ async function main() {
   // if the env var didn't propagate; falls back to the env sessionId.
   if (mode === 'inbox') {
     const adamId = (await resolveAdamSessionId(supabase)) || sessionId;
+    // FR-1: surface broadcast chairman directives FIRST-CLASS (above normal advisories) with Adam's
+    // per-directive ack status, BEFORE the normal target_session-scoped drain.
+    await renderChairmanDirectives(supabase, 'adam', { quiet: argv.includes('--quiet') });
     await drainInbox(supabase, adamId, { quiet: argv.includes('--quiet') });
     // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: PING-ON-SILENCE — check MY OWN sent
     // reply-needed advisories for ones left unanswered past their window. Never suppressed by

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1557,6 +1557,38 @@ async function printRelayDropGauge() {
   console.log('');
 }
 
+// ── Section: Chairman-directive compliance lane (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1) ──
+// Surfaces broadcast chairman_directive rows FIRST (a chairman baseline directive must never silently
+// die at any role's last hop — the incident had Solomon run 2h non-compliant). This lane BYPASSES the
+// printInbox signal_type gate (which filters .not('payload->>signal_type','is',null)): a chairman_directive
+// carries NO signal_type, so printInbox would never show it. It reads the broadcast lane directly via the
+// gauge's pure core, applies SUPERSEDES (latest issued_at per directive_id), and reports per-role
+// OUTSTANDING vs ACKED so non-compliance is VISIBLE. READ-ONLY (never mutates target_session — the
+// broadcast row must survive for every role).
+async function printChairmanDirectives() {
+  const { planChairmanDirectiveCompliance } = require('../lib/coordinator/chairman-directive-gauge.cjs');
+
+  console.log('CHAIRMAN DIRECTIVE COMPLIANCE');
+  console.log('─'.repeat(72));
+
+  const gauge = await planChairmanDirectiveCompliance(supabase);
+  if (gauge.rows.length === 0) {
+    console.log('  (no chairman directives in the last 24h)');
+    console.log('');
+    return;
+  }
+
+  const outstanding = gauge.rows.filter((r) => r.status === 'outstanding');
+  console.log('  ' + gauge.rows.length + ' (directive × role) tracked — ' + outstanding.length + ' OUTSTANDING, ' + gauge.acked + ' ACKED:');
+  for (const r of gauge.rows) {
+    const ageMin = Math.floor((r.ageMs || 0) / 60_000);
+    const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
+    const mark = r.status === 'outstanding' ? '⚠ OUTSTANDING' : '✓ acked';
+    console.log('  • [' + String(r.directiveId).slice(0, 16) + '] role=' + pad(r.role, 12) + mark + ' | issued ' + ageStr + ' ago');
+  }
+  console.log('');
+}
+
 // FR-4 surfacing: rows the stale-session sweep dead-lettered (payload.dead_letter=true)
 // in the last 24h — undelivered traffic no longer vanishes tracelessly; the coordinator
 // can re-send to the successor session. Read-only.
@@ -1696,6 +1728,9 @@ async function main() {
     predictions:   async () => await printPredictions(d),
     drain:         () => printDrainAgents(d),
     inbox:         async () => {
+      // FR-1 (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B): chairman directives surface FIRST —
+      // bypasses the printInbox signal_type gate (chairman_directive carries no signal_type).
+      await printChairmanDirectives();
       await printInbox();
       // FR-2/FR-4 (SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001): sender-side receipts.
       await printUndeliveredOutbound();
@@ -1720,6 +1755,7 @@ async function main() {
       printQuickFixes(d); // QF-20260525-836
       printRevivalPending(d); // SD-LEO-INFRA-COORDINATOR-WORKER-REVIVAL-001
       printCoordination(d);
+      await printChairmanDirectives(); // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1 — chairman-directive compliance FIRST (bypasses the printInbox signal_type gate)
       await printInbox(); // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3a
       await printUndeliveredOutbound(); // FR-2 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001
       await printDeadLetters(); // FR-4 SD-LEO-INFRA-COORD-ADAM-COMMS-RESILIENT-001

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -589,6 +589,14 @@ async function main() {
         'INFO': 'INFO'
       }[msg.message_type] || msg.message_type;
 
+      // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1: a chairman_directive rides on INFO but is
+      // FIRST-CLASS — relabel it (by payload.kind) so it never hides behind the generic 'INFO' banner.
+      // Classification (deliver-not-consume) is already handled by the DIRECTIVE_KINDS branch in
+      // classifyInboxMessage above (chairman_directive is in the imported allowlist). This is render-only.
+      const typeLabelFinal = (msg.payload && msg.payload.kind === 'chairman_directive')
+        ? '★ CHAIRMAN DIRECTIVE' + (msg.payload.directive_id ? ' ' + msg.payload.directive_id : '')
+        : typeLabel;
+
       // Handle SET_IDENTITY: write per-session identity file for statusline integration
       if (msg.message_type === 'SET_IDENTITY' && msg.payload) {
         try {
@@ -602,10 +610,14 @@ async function main() {
       }
 
       console.log('');
-      console.log('=== COORDINATION: ' + typeLabel + ' ===');
+      console.log('=== COORDINATION: ' + typeLabelFinal + ' ===');
       console.log('From: ' + (msg.sender_type || 'orchestrator'));
       console.log('Subject: ' + msg.subject);
       if (msg.body) console.log('Details: ' + msg.body);
+      // FR-1: for a chairman_directive, surface how to ACK it (per-role, keyed by directive_id).
+      if (msg.payload && msg.payload.kind === 'chairman_directive' && msg.payload.directive_id) {
+        console.log('ACK when actioned: node scripts/ack-chairman-directive.cjs --id ' + msg.payload.directive_id + ' --role <your-role>');
+      }
       if (msg.payload?.suggested_sd) {
         console.log('Suggested next SD: ' + msg.payload.suggested_sd);
       }

--- a/scripts/issue-chairman-directive.cjs
+++ b/scripts/issue-chairman-directive.cjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Issue a durable, queryable CHAIRMAN DIRECTIVE (broadcast) — SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1.
+ *
+ * Chairman intent enters via ONE agent and propagates by RELAY (the weakest rail). The last hop
+ * silently died once (a 5-min-baseline directive; Solomon ran 2h non-compliant) because
+ * 'chairman_directive' was not in the DIRECTIVE_KINDS no-auto-ack allowlist, so the generic inbox
+ * drain auto-acked/consumed it before any role acted. This CLI writes a FIRST-CLASS broadcast row
+ * all 3 roles (Adam / coordinator / Solomon) surface deliberately, with per-role ack-tracking so
+ * non-compliance is VISIBLE not silent.
+ *
+ * SUPERSEDES: latest issued_at wins (keyed on directive_id) — a stale earlier directive never
+ * out-ranks a newer one for the same directive_id (the chairman reversed effort low->high->low).
+ *
+ * The ack is keyed by directive_id (NOT topic_id), so this child is dependency-free.
+ *
+ * Insert routes through lib/coordinator/dispatch.cjs insertCoordinationRow with
+ * target_session='broadcast' + message_type='INFO' (assertSdDispatchable only fires for
+ * WORK_ASSIGNMENT, so an INFO broadcast passes the dispatch guard).
+ *
+ * Usage:
+ *   node scripts/issue-chairman-directive.cjs --directive "<text>" [--id <slug>] [--roles adam,coordinator,solomon]
+ */
+'use strict';
+
+const crypto = require('crypto');
+const { getServiceClient, PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+
+const DEFAULT_ROLES = Object.freeze(['adam', 'coordinator', 'solomon']);
+
+function argVal(argv, flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const directive = argVal(argv, '--directive') || argVal(argv, '-d');
+  if (!directive) {
+    console.error('Usage: node scripts/issue-chairman-directive.cjs --directive "<text>" [--id <slug>] [--roles adam,coordinator,solomon]');
+    process.exit(2);
+  }
+  const directiveId = argVal(argv, '--id') || `cd-${crypto.randomUUID()}`;
+  const rolesArg = argVal(argv, '--roles');
+  const appliesTo = rolesArg ? rolesArg.split(',').map((s) => s.trim()).filter(Boolean) : [...DEFAULT_ROLES];
+  const issuedAt = new Date().toISOString();
+
+  const payload = {
+    kind: PAYLOAD_KINDS.CHAIRMAN_DIRECTIVE,
+    directive_id: directiveId,
+    issued_at: issuedAt,           // SUPERSEDES key: latest issued_at wins per directive_id
+    applies_to: appliesTo,         // which roles must ack
+    directive: String(directive),
+    request_ack: true,             // reuse the DELIVERED transport-ack layer for read confirmation
+    body: String(directive),       // rendered by the role inbox partitions
+  };
+
+  const supabase = getServiceClient();
+  await insertCoordinationRow(supabase, {
+    sender_session: 'chairman',
+    sender_type: 'chairman',
+    target_session: 'broadcast',   // broadcast sentinel — dispatch short-circuits the live-session lookup
+    message_type: 'INFO',          // assertSdDispatchable only fires for WORK_ASSIGNMENT → INFO passes
+    subject: `[CHAIRMAN_DIRECTIVE ${directiveId}]`,
+    body: String(directive),
+    payload,
+  });
+
+  console.log(`✓ chairman_directive issued: id=${directiveId} applies_to=[${appliesTo.join(', ')}] issued_at=${issuedAt}`);
+  console.log(`  Each role acks via: node scripts/ack-chairman-directive.cjs --id ${directiveId} --role <adam|coordinator|solomon>`);
+}
+
+main().catch((e) => { console.error('issue-chairman-directive failed:', (e && e.message) || e); process.exit(1); });

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -135,6 +135,10 @@ function isReplyRow(r) {
 }
 
 // A Solomon-inbox row = a consult OR any shared coordinator DIRECTIVE kind, directed at the Solomon session.
+// SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1: chairman_directive is already a shared
+// DIRECTIVE_KIND (spread below) — Solomon drains it via the shared allowlist (no re-list). Its FIRST-CLASS
+// render partition (renderChairmanDirectives, wired into the inbox mode) surfaces it above consults so a
+// chairman baseline directive can never silently die at Solomon's last hop (the 2h-non-compliant incident).
 const SOLOMON_INBOX_KINDS = Object.freeze([...DIRECTIVE_KINDS, SOLOMON_CONSULT_KIND]);
 function isSolomonInboxRow(r) {
   const k = r && r.payload && r.payload.kind;
@@ -225,6 +229,26 @@ async function checkConsultQuota(supabase, { sdKey = null, perSdMax = SOLOMON_PE
  * (WARN, not consumed); surfaced rows stamped read_at = DELIVERED (two-stage ACK — acknowledged_at
  * withheld so a delivered-but-unactioned consult stays recoverable). Mirrors drainInbox in adam-advisory.
  */
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1 — FIRST-CLASS chairman-directive partition for
+ * Solomon. Surfaces broadcast chairman_directive rows ABOVE consults, with Solomon's per-directive
+ * OUTSTANDING/ACKED status (latest issued_at per directive_id — SUPERSEDES). READ-ONLY / non-consuming
+ * (the broadcast row must survive for Adam + coordinator too). Solomon acks via
+ * scripts/ack-chairman-directive.cjs --role solomon. Fail-open. Mirrors renderChairmanDirectives in
+ * adam-advisory. This is the SOLOMON-LAST-HOP fix: the incident had Solomon run 2h non-compliant.
+ */
+async function renderChairmanDirectives(supabase, { quiet = false } = {}) {
+  const { loadRoleDirectiveStatus } = require('../lib/coordinator/chairman-directive-gauge.cjs');
+  const rows = await loadRoleDirectiveStatus(supabase, 'solomon');
+  if (rows.length === 0) { if (!quiet) console.log('(no chairman directives outstanding for solomon)'); return; }
+  const outstanding = rows.filter((r) => r.status === 'outstanding');
+  console.log(`★ ${rows.length} CHAIRMAN DIRECTIVE(s) for solomon — ${outstanding.length} OUTSTANDING (ack via scripts/ack-chairman-directive.cjs --role solomon):`);
+  for (const r of rows) {
+    const ageMin = Math.floor((r.ageMs || 0) / 60_000);
+    console.log(`  ★ [${r.status.toUpperCase()}] ${r.directiveId} (issued ${ageMin}m ago)`);
+  }
+}
+
 async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
   const { data: allRows, error } = await supabase
     .from('session_coordination')
@@ -433,6 +457,9 @@ async function main() {
     if (!ledgerHealth.healthy) {
       console.error(`WARN: solomon_advice_outcome_ledger capture gauge UNHEALTHY — ${ledgerHealth.reason} (advisories are NOT being captured; QF-20260701-289)`);
     }
+    // FR-1: surface broadcast chairman directives FIRST-CLASS (above consults) with Solomon's per-directive
+    // ack status, BEFORE the normal target_session-scoped drain — the Solomon-last-hop compliance fix.
+    await renderChairmanDirectives(supabase, { quiet: argv.includes('--quiet') });
     await drainInbox(supabase, solomonId, { quiet: argv.includes('--quiet') });
     // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: PING-ON-SILENCE — check MY OWN sent
     // reply-needed advisories for ones left unanswered past their window. Never suppressed by

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -301,7 +301,11 @@ async function surfaceCoordinatorMessages(sb, sessionId, { role = null } = {}) {
     const p = m.payload || {};
     const kind = p.kind || null;
     const isDirective = !!(kind && ws.DIRECTIVE_KINDS.includes(kind));
-    out.push({ id: m.id, message_type: m.message_type, kind, subject: m.subject || null, body: m.body || null, created_at: m.created_at });
+    // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1: chairman_directive is in DIRECTIVE_KINDS,
+    // so isDirective is true → it is NEVER auto-acked here (waits for the per-role ack via
+    // scripts/ack-chairman-directive.cjs). Surface a first-class flag so the checkin JSON marks it.
+    const isChairmanDirective = kind === 'chairman_directive';
+    out.push({ id: m.id, message_type: m.message_type, kind, chairman_directive: isChairmanDirective, subject: m.subject || null, body: m.body || null, created_at: m.created_at });
     try {
       if (!m.read_at) {
         // first authoritative delivery — mark DELIVERED, leave unacked so it re-surfaces once

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -43,6 +43,7 @@ describe('FR-3: DIRECTIVE_KINDS allowlist', () => {
       'coordinator_reminder',
       'coordinator_to_adam',
       'coordinator_directive', // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001
+      'chairman_directive', // SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-B / FR-1 (broadcast chairman directive, no-auto-ack)
     ]);
     expect(Object.isFrozen(ws.DIRECTIVE_KINDS)).toBe(true);
   });


### PR DESCRIPTION
Child -B (FR-1, fix-first) of the chairman-prioritized orchestrator SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001.

**Problem:** Chairman intent enters via ONE agent and propagates by RELAY (weakest rail). The 5-min-baseline directive silently died at the last hop (Solomon ran 2h non-compliant, found only when the chairman said to look). **Root cause:** `chairman_directive` was not in the `DIRECTIVE_KINDS` no-auto-ack allowlist, so the generic inbox drain auto-acked/consumed it before any role acted.

**Fix (broadcast `payload.kind='chairman_directive'`, NO migration):**
- `lib/fleet/worker-status.cjs`: add `CHAIRMAN_DIRECTIVE` to `PAYLOAD_KINDS` + `'chairman_directive'` to `DIRECTIVE_KINDS` — highest-leverage (stops the auto-ack).
- `scripts/issue-chairman-directive.cjs` / `scripts/ack-chairman-directive.cjs`: issue + per-role ack CLIs (two-stage ACK: `read_at`=DELIVERED vs `payload.actioned_at`=ACTIONED, `directive_id`-keyed).
- `lib/coordinator/chairman-directive-gauge.cjs`: per-role compliance gauge — pure `decideChairmanDirectiveCompliance` core with **SUPERSEDES** (latest `issued_at` wins) + ACKED/OUTSTANDING, mirroring `relay-drop-gauge`.
- First-class surfacing in all 3 role inboxes via a **non-consuming** `renderChairmanDirectives()` (the bare `broadcast` sentinel is invisible to the `target_session`-scoped `drainInbox`, so a dedicated non-consuming reader is required).

Ack keyed by `directive_id` (not `topic_id`) → dependency-free child. Additive-only (verified). **TESTING PASS** (40/40) + **REGRESSION PASS** (no behavior change to existing kinds). LEAD/EXEC sub-agent evidence recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)