### PR TITLE
feat(SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C): FR-2 protocol-version-skew detection

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -21,6 +21,8 @@
 // the prefix-only isUuidLike in stale-session-sweep.cjs is for the cleanup path.
 const FULL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+const { PROTOCOL_COMMS_VERSION } = require('./protocol-comms-version.cjs');
+
 // Documented non-UUID targets that are intentionally allowed. broadcast =
 // coordinator→all; broadcast-coordinator = worker→coordinator; broadcast-solomon =
 // worker/Adam→Solomon consult lane (SD-LEO-INFRA-SOLOMON-CONSULT-001C — inert until
@@ -317,6 +319,13 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
   // directed dispatch BYPASSES claim-eligibility by design, so WORK-DOWN-NEVER-UP also lives here.
   await assertWorkerTierAllowed(supabase, row, logger);
   await stampEffortRecommendation(supabase, row, logger);
+  // FR-2 (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C): stamp the protocol version on every row
+  // through the choke point so a stale long-lived-singleton reader can detect a skew instead of
+  // silently misreading it. Only stamps INTO an existing payload object — never invents one (some
+  // rows are payload-less by design) — and never overwrites a caller-supplied stamp.
+  if (row.payload && typeof row.payload === 'object' && row.payload.protocol_comms_version == null) {
+    row.payload = { ...row.payload, protocol_comms_version: PROTOCOL_COMMS_VERSION };
+  }
   let q = supabase.from('session_coordination').insert(row);
   if (select) {
     q = q.select(select);

--- a/lib/coordinator/protocol-comms-version.cjs
+++ b/lib/coordinator/protocol-comms-version.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+// SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C (FR-2): protocol-version-skew detection.
+// Long-lived singletons (Adam/coordinator/Solomon) can run boot-time code while payload-shape
+// fixes ship to origin — a stale singleton then silently misreads/drops rows as "mystery orphans"
+// instead of a detectable version mismatch. Bump this only when session_coordination.payload's
+// SHAPE changes in a way a stale reader could misclassify (new required discriminator field,
+// changed classification semantics) — not for routine additive fields.
+const PROTOCOL_COMMS_VERSION = 1;
+
+/**
+ * Returns {senderVersion, receiverVersion} when payload carries a stamped version DIFFERENT from
+ * this process's own PROTOCOL_COMMS_VERSION, else null. An unstamped payload (pre-versioning
+ * producer, or a row with no payload object) is NOT itself treated as skew — absence of the field
+ * is not evidence of a version gap, only an explicit differing stamp is.
+ */
+function detectVersionSkew(payload) {
+  const senderVersion = payload && payload.protocol_comms_version;
+  if (senderVersion == null || senderVersion === PROTOCOL_COMMS_VERSION) return null;
+  return { senderVersion, receiverVersion: PROTOCOL_COMMS_VERSION };
+}
+
+module.exports = { PROTOCOL_COMMS_VERSION, detectVersionSkew };

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -45,6 +45,7 @@ const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signa
 const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled } = require('../lib/coordinator/resolve.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
@@ -421,6 +422,10 @@ async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
     const kind = (r.payload && r.payload.kind) || r.message_type || '?';
     const text = (r.payload && r.payload.body) || r.body || r.subject || '(empty)';
     const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+    // FR-2 (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C): detect a stale-singleton version skew
+    // instead of silently misreading the row — surfaced, not consumed-differently (still drained).
+    const skew = detectVersionSkew(r.payload);
+    if (skew) console.warn(`  ⚠ PROTOCOL VERSION SKEW: sender v${skew.senderVersion}, receiver v${skew.receiverVersion} (id=${r.id})`);
     console.log(`  • [${lane}/${kind}] (${ageMin}m) ${text}`);
     ids.push(r.id);
   }

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -44,6 +44,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signal.cjs');
 const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled } = require('../lib/coordinator/resolve.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
@@ -256,6 +257,10 @@ async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
     const kind = (r.payload && r.payload.kind) || r.message_type || '?';
     const text = (r.payload && r.payload.body) || r.body || r.subject || '(empty)';
     const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+    // FR-2 (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C): Solomon is the named live example of a
+    // long-lived singleton misreading rows from boot-time-stale code — detect, don't silently drop.
+    const skew = detectVersionSkew(r.payload);
+    if (skew) console.warn(`  ⚠ PROTOCOL VERSION SKEW: sender v${skew.senderVersion}, receiver v${skew.receiverVersion} (id=${r.id})`);
     console.log(`  • [${lane}/${kind}] (${ageMin}m) ${text}`);
     ids.push(r.id);
   }

--- a/tests/unit/coordination/protocol-version-skew-surfacing.test.js
+++ b/tests/unit/coordination/protocol-version-skew-surfacing.test.js
@@ -1,0 +1,84 @@
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C (FR-2) — the read side: Adam's and Solomon's
+ * canonical `inbox` reader (drainInbox) must WARN "PROTOCOL VERSION SKEW" when a surfaced row's
+ * stamped payload.protocol_comms_version differs from this process's own, instead of silently
+ * misreading the row like every other kind of unrecognized mismatch.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { drainInbox: drainAdamInbox } = require('../../../scripts/adam-advisory.cjs');
+const { drainInbox: drainSolomonInbox } = require('../../../scripts/solomon-advisory.cjs');
+const { PROTOCOL_COMMS_VERSION } = require('../../../lib/coordinator/protocol-comms-version.cjs');
+
+function stub(rows) {
+  const captured = { updatedIds: null };
+  const selectChain = {
+    select() { return selectChain; },
+    eq() { return selectChain; },
+    is() { return selectChain; },
+    order() { return selectChain; },
+    limit() { return Promise.resolve({ data: rows, error: null }); },
+  };
+  const updateChain = {
+    update() { return updateChain; },
+    in(_col, ids) { captured.updatedIds = ids; return updateChain; },
+    is() { return Promise.resolve({ error: null }); },
+  };
+  const supabase = {
+    from() {
+      return new Proxy({}, {
+        get(_t, prop) {
+          if (prop in selectChain) return selectChain[prop];
+          if (prop in updateChain) return updateChain[prop];
+          return undefined;
+        },
+      });
+    },
+  };
+  return { supabase, captured };
+}
+
+describe('drainInbox (Adam): protocol-version-skew surfacing', () => {
+  it('WARNs on a row stamped with a differing version', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      { id: 'skewed-1', payload: { kind: 'coordinator_directive', body: 'stale singleton read this', protocol_comms_version: PROTOCOL_COMMS_VERSION + 1 }, created_at: new Date().toISOString() },
+    ];
+    const { supabase } = stub(rows);
+    await drainAdamInbox(supabase, 'adam-session');
+    const warned = warnSpy.mock.calls.some((c) => String(c[0]).includes('PROTOCOL VERSION SKEW'));
+    expect(warned).toBe(true);
+    logSpy.mockRestore(); warnSpy.mockRestore();
+  });
+
+  it('does NOT warn on a row with no version stamp or a matching stamp', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      { id: 'unstamped', payload: { kind: 'coordinator_directive', body: 'no stamp' }, created_at: new Date().toISOString() },
+      { id: 'matched', payload: { kind: 'coordinator_directive', body: 'same version', protocol_comms_version: PROTOCOL_COMMS_VERSION }, created_at: new Date().toISOString() },
+    ];
+    const { supabase } = stub(rows);
+    await drainAdamInbox(supabase, 'adam-session');
+    const warned = warnSpy.mock.calls.some((c) => String(c[0]).includes('PROTOCOL VERSION SKEW'));
+    expect(warned).toBe(false);
+    logSpy.mockRestore(); warnSpy.mockRestore();
+  });
+});
+
+describe('drainInbox (Solomon): protocol-version-skew surfacing', () => {
+  it('WARNs on a row stamped with a differing version', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [
+      { id: 'skewed-2', payload: { kind: 'coordinator_directive', body: 'stale Solomon read this', protocol_comms_version: PROTOCOL_COMMS_VERSION + 1 }, created_at: new Date().toISOString() },
+    ];
+    const { supabase } = stub(rows);
+    await drainSolomonInbox(supabase, 'solomon-session');
+    const warned = warnSpy.mock.calls.some((c) => String(c[0]).includes('PROTOCOL VERSION SKEW'));
+    expect(warned).toBe(true);
+    logSpy.mockRestore(); warnSpy.mockRestore();
+  });
+});

--- a/tests/unit/coordinator-dispatch-protocol-version-stamp.test.js
+++ b/tests/unit/coordinator-dispatch-protocol-version-stamp.test.js
@@ -1,0 +1,62 @@
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C (FR-2) — insertCoordinationRow (the choke point)
+ * must stamp payload.protocol_comms_version on every row it inserts, so a stale long-lived-singleton
+ * reader can detect a skew instead of silently misreading the row as a mystery orphan.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow } = require('../../lib/coordinator/dispatch.cjs');
+const { PROTOCOL_COMMS_VERSION } = require('../../lib/coordinator/protocol-comms-version.cjs');
+
+const LIVE_TARGET = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const silentLog = { warn() {}, error() {}, log() {} };
+
+// Minimal stub: no SD/QF terminal-guard fixtures needed (non-WORK_ASSIGNMENT rows fail-open through
+// assertSdDispatchable), and the target session resolves live.
+function stubSupabase() {
+  return {
+    from(table) {
+      const chain = {
+        select() { return chain; },
+        eq(_col, val) { chain._eq = val; return chain; },
+        limit() { return chain; },
+        maybeSingle() {
+          if (table === 'claude_sessions') {
+            return Promise.resolve({ data: chain._eq === LIVE_TARGET ? { session_id: LIVE_TARGET, status: 'active' } : null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(r) { chain._inserted = r; return chain; },
+        then(res, rej) { return Promise.resolve({ data: chain._inserted || null, error: null }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('insertCoordinationRow: protocol-version stamping (FR-2)', () => {
+  it('stamps protocol_comms_version onto a row with an existing payload object', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'INFO', target_session: LIVE_TARGET, payload: { kind: 'coordinator_reply', body: 'hi' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.protocol_comms_version).toBe(PROTOCOL_COMMS_VERSION);
+    // Original fields preserved.
+    expect(res.data.payload.kind).toBe('coordinator_reply');
+    expect(res.data.payload.body).toBe('hi');
+  });
+
+  it('never overwrites a caller-supplied stamp', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'INFO', target_session: LIVE_TARGET, payload: { kind: 'coordinator_reply', protocol_comms_version: 999 } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.protocol_comms_version).toBe(999);
+  });
+
+  it('does not invent a payload object on a payload-less row', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'INFO', target_session: LIVE_TARGET, body: 'no payload here' };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload).toBeUndefined();
+  });
+});

--- a/tests/unit/protocol-comms-version.test.js
+++ b/tests/unit/protocol-comms-version.test.js
@@ -1,0 +1,29 @@
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C (FR-2) — protocol-version-skew detection.
+ * Pure-function tests for lib/coordinator/protocol-comms-version.cjs.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { PROTOCOL_COMMS_VERSION, detectVersionSkew } = require('../../lib/coordinator/protocol-comms-version.cjs');
+
+describe('detectVersionSkew', () => {
+  it('returns null when payload carries no version stamp (pre-versioning producer)', () => {
+    expect(detectVersionSkew({ kind: 'coordinator_reply', body: 'hi' })).toBeNull();
+  });
+  it('returns null when payload is null/undefined', () => {
+    expect(detectVersionSkew(null)).toBeNull();
+    expect(detectVersionSkew(undefined)).toBeNull();
+  });
+  it('returns null when the stamped version matches this process\'s own', () => {
+    expect(detectVersionSkew({ protocol_comms_version: PROTOCOL_COMMS_VERSION })).toBeNull();
+  });
+  it('returns {senderVersion, receiverVersion} when the stamped version differs', () => {
+    const skew = detectVersionSkew({ protocol_comms_version: PROTOCOL_COMMS_VERSION + 1 });
+    expect(skew).toEqual({ senderVersion: PROTOCOL_COMMS_VERSION + 1, receiverVersion: PROTOCOL_COMMS_VERSION });
+  });
+  it('detects a skew from an older sender too (not just newer)', () => {
+    const skew = detectVersionSkew({ protocol_comms_version: 0 });
+    expect(skew).toEqual({ senderVersion: 0, receiverVersion: PROTOCOL_COMMS_VERSION });
+  });
+});


### PR DESCRIPTION
## Summary
- Long-lived singletons (Adam/coordinator/Solomon) can run boot-time code while `session_coordination.payload`'s shape evolves on origin — a stale reader silently misreads a row as a mystery orphan instead of a detectable version gap. Solomon is the parent SD's cited live example (inbound orphans + hand-inserts from a session predating selectable-target/inbound-first-class).
- New `lib/coordinator/protocol-comms-version.cjs`: `PROTOCOL_COMMS_VERSION` constant + `detectVersionSkew(payload)` pure function. An unstamped payload is NOT treated as skew — only an explicit differing stamp is.
- `lib/coordinator/dispatch.cjs`'s `insertCoordinationRow` (the single choke point for `session_coordination` inserts) auto-stamps `payload.protocol_comms_version` on every row with an existing payload object, unless the caller already supplied one. Never invents a payload where none existed.
- `scripts/adam-advisory.cjs` and `scripts/solomon-advisory.cjs`: each role's canonical `inbox` command (`drainInbox`) now WARNs `"PROTOCOL VERSION SKEW: sender vX, receiver vY"` per mismatched row.

## Scope note
- Deliberately excluded (documented, not silently dropped): the coordinator's own inbox reading (no single canonical `drainInbox`-equivalent exists) and `scripts/worker-checkin.cjs`'s fleet-worker inbox surfacing (fleet workers are ephemeral/freshly-spawned and don't suffer the boot-time-drift problem this FR targets).

## Verification
- 3 independent sub-agent passes: LEAD-phase VALIDATION (95%), EXEC-phase TESTING (96%), PLAN_VERIFICATION VALIDATION (97%) + REGRESSION (95%) — all PASS, all re-derived findings from the actual code/PRD rather than trusting prior reports.
- 11/11 new tests pass (pure-function detector, choke-point stamping, read-side skew-warn surfacing with proper negative cases).
- 301/301 broader coordination/coordinator-surface regression tests pass — zero regressions.
- `npx tsc --noEmit` clean.
- No E2E/UI surface (pure backend `.cjs`).

## Test plan
- [x] Unit tests for `detectVersionSkew` (unstamped/matched/differing-older/differing-newer)
- [x] Unit tests for `insertCoordinationRow` stamping (auto-stamp / never-overwrite / never-invent-payload)
- [x] Unit tests for Adam's and Solomon's `drainInbox` skew-warn surfacing
- [x] Full regression sweep of touched modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)