### PR TITLE
feat(SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D): choke-point coverage + multi-party thread primitive

### DIFF
--- a/.github/workflows/session-coordination-insert-classguard-lint.yml
+++ b/.github/workflows/session-coordination-insert-classguard-lint.yml
@@ -1,0 +1,38 @@
+name: Session-Coordination Raw-Insert Class-Guard Lint
+
+# SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3b)
+#
+# Blocks any PR that introduces a raw `<supabase>.from('session_coordination').insert(...)` call
+# outside the canonical choke point (insertCoordinationRow() in lib/coordinator/dispatch.cjs).
+# A DB-level advisory trigger already covers existing raw producers (see database/migrations/
+# 20260702_session_coordination_insert_lint.sql) -- this lint's job is to stop NEW raw sites.
+#
+# GENUINELY BLOCKING (no continue-on-error): this repo's `npm run lint` (eslint.config.js
+# flat-config run) is not invoked by any other CI workflow, so registering the rule only in
+# eslint.config.js would not actually enforce anything -- this dedicated workflow is the real
+# enforcement mechanism (same posture as count-delta-gate-lint.yml).
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**/*.{js,mjs,cjs}'
+      - 'lib/**/*.{js,mjs,cjs}'
+      - 'eslint-rules/no-raw-session-coordination-insert.js'
+      - 'scripts/lint/session-coordination-insert-classguard-lint.mjs'
+      - '.github/workflows/session-coordination-insert-classguard-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  session-coordination-insert-classguard-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Detect raw session_coordination inserts outside the choke point
+        run: node scripts/lint/session-coordination-insert-classguard-lint.mjs

--- a/database/migrations/20260702_session_coordination_insert_lint.sql
+++ b/database/migrations/20260702_session_coordination_insert_lint.sql
@@ -1,0 +1,60 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3a)
+--
+-- Advisory (non-blocking) insert-time lint for session_coordination, plus a nullable
+-- correlation_id column. No backfill of historical rows. RAISE NOTICE only -- never
+-- rejects an insert (matches the bypass_ledger_advisory_vocab_trigger precedent
+-- in 20260516130001_add_bypass_ledger.sql, not the blocking sd_type_change_governance
+-- precedent in 20260202_sd_type_change_governance_fixed.sql).
+--
+-- Rationale: rather than converting all ~19 raw session_coordination producers to
+-- route through insertCoordinationRow() (large, risky, still-incomplete coverage for
+-- any future raw-insert site), this trigger catches every producer automatically
+-- regardless of code path. Paired with a CI-enforced ESLint rule (separate change)
+-- that blocks NEW raw inserts from being written going forward.
+
+ALTER TABLE session_coordination ADD COLUMN IF NOT EXISTS correlation_id text;
+
+COMMENT ON COLUMN session_coordination.correlation_id IS
+  'Optional message id this row replies to / correlates with. Nullable -- no backfill '
+  'for historical rows. SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D';
+
+CREATE OR REPLACE FUNCTION session_coordination_insert_lint()
+RETURNS TRIGGER AS $$
+DECLARE
+  known_sender_types text[] := ARRAY['orchestrator','worker','coordinator','sweep','manual','adam','solomon'];
+  dup_count integer;
+BEGIN
+  IF NEW.sender_type IS NOT NULL AND NOT (NEW.sender_type = ANY(known_sender_types)) THEN
+    RAISE NOTICE 'session_coordination_insert_lint: unrecognized sender_type "%" (id=%)', NEW.sender_type, NEW.id;
+  END IF;
+
+  IF NEW.correlation_id IS NULL THEN
+    RAISE NOTICE 'session_coordination_insert_lint: missing correlation_id (id=%, subject=%)', NEW.id, NEW.subject;
+  END IF;
+
+  IF NEW.sender_session IS NOT NULL AND NEW.body IS NOT NULL THEN
+    SELECT COUNT(*) INTO dup_count
+    FROM session_coordination
+    WHERE sender_session = NEW.sender_session
+      AND body = NEW.body
+      AND created_at > now() - interval '60 seconds';
+    IF dup_count > 0 THEN
+      RAISE NOTICE 'session_coordination_insert_lint: duplicate body from sender_session=% within 60s (id=%)', NEW.sender_session, NEW.id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION session_coordination_insert_lint() IS
+  'Advisory (non-blocking, RAISE NOTICE only) insert-time lint for session_coordination: '
+  'unrecognized sender_type, missing correlation_id, duplicate body within 60s. Never '
+  'rejects an insert. SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D';
+
+DROP TRIGGER IF EXISTS trg_session_coordination_insert_lint ON session_coordination;
+CREATE TRIGGER trg_session_coordination_insert_lint
+  BEFORE INSERT ON session_coordination
+  FOR EACH ROW
+  EXECUTE FUNCTION session_coordination_insert_lint();

--- a/eslint-rules/no-raw-session-coordination-insert.js
+++ b/eslint-rules/no-raw-session-coordination-insert.js
@@ -1,0 +1,146 @@
+/**
+ * ESLint Rule: no-raw-session-coordination-insert
+ *
+ * Flags a raw `<supabase>.from('session_coordination').insert(...)` call site. The canonical
+ * choke point for writing session_coordination rows is insertCoordinationRow() in
+ * lib/coordinator/dispatch.cjs, which validates the target (assertValidTarget), refuses
+ * terminal/unknown SD targets (assertSdDispatchable), and enforces worker-tier dispatch rules
+ * (assertWorkerTierAllowed) before inserting. A raw insert bypasses ALL of that.
+ *
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3b) — same 3-part class-guard shape as
+ * no-count-delta-gate-assertion.js / no-realtime-teardown-in-subscribe-callback.js: an ESLint
+ * rule + a driver script (scripts/lint/session-coordination-insert-classguard-lint.mjs) + a
+ * dedicated blocking CI workflow. The driver script excludes lib/coordinator/dispatch.cjs (the
+ * choke point's own definition) and test/fixture files (which legitimately seed rows directly
+ * for setup) from the scan; this rule itself has no file-path awareness.
+ *
+ * Note: a DB-level advisory (non-blocking) insert-time trigger already covers every existing
+ * raw producer regardless of code path (see database/migrations/
+ * 20260702_session_coordination_insert_lint.sql) — this rule's job is to stop NEW raw sites
+ * from being written, not to retroactively convert everything.
+ *
+ * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
+ *
+ *   // eslint-disable-next-line no-raw-session-coordination-insert -- <REASON>
+ *   await supabase.from('session_coordination').insert(row);
+ *
+ * @module eslint-rules/no-raw-session-coordination-insert
+ */
+
+const RULE_NAME = 'no-raw-session-coordination-insert';
+const TARGET_TABLE = 'session_coordination';
+
+const PRAGMA_DETECT_RE = new RegExp(
+  String.raw`eslint-disable-next-line\s+(?:[^,\n]*,\s*)*(?:[\w@-]+(?:[/][\w@-]+)*/)?` +
+    RULE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+    String.raw`(?:\s*,[^\n]*)?(.*)$`
+);
+
+/**
+ * Is this call `X.from('session_coordination')`?
+ * @param {import('estree').Node} node
+ */
+function isFromSessionCoordinationCall(node) {
+  if (!node || node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  if (!callee || callee.type !== 'MemberExpression' || callee.computed) return false;
+  if (!callee.property || callee.property.type !== 'Identifier' || callee.property.name !== 'from') return false;
+  const arg = node.arguments && node.arguments[0];
+  return !!arg && arg.type === 'Literal' && arg.value === TARGET_TABLE;
+}
+
+/**
+ * Is this call `<fromCall>.insert(...)` where fromCall matches session_coordination?
+ * @param {import('estree').Node} node
+ */
+function isRawInsertOnSessionCoordination(node) {
+  if (!node || node.type !== 'CallExpression') return false;
+  const callee = node.callee;
+  if (!callee || callee.type !== 'MemberExpression' || callee.computed) return false;
+  if (!callee.property || callee.property.type !== 'Identifier' || callee.property.name !== 'insert') return false;
+  return isFromSessionCoordinationCall(callee.object);
+}
+
+function classifyPragma(commentValue) {
+  if (!commentValue) return { targets: false };
+  const match = commentValue.match(PRAGMA_DETECT_RE);
+  if (!match) return { targets: false };
+  const suffix = match[1] || '';
+  const markerIdx = suffix.indexOf('--');
+  if (markerIdx === -1) return { targets: true, hasMarker: false, reason: '' };
+  const reason = suffix.slice(markerIdx + 2).trim();
+  return { targets: true, hasMarker: true, reason };
+}
+
+const STATEMENT_TYPES = new Set([
+  'ExpressionStatement', 'VariableDeclaration', 'IfStatement', 'ReturnStatement',
+  'AwaitExpression', 'BlockStatement',
+]);
+
+function getDisablePragmaCommentAbove(sourceCode, node) {
+  let stmt = node;
+  while (stmt && stmt.parent && !STATEMENT_TYPES.has(stmt.type)) stmt = stmt.parent;
+  for (const candidate of [node, stmt]) {
+    const comments = sourceCode.getCommentsBefore(candidate);
+    if (!comments || comments.length === 0) continue;
+    const last = comments[comments.length - 1];
+    if (!last || (last.type !== 'Line' && last.type !== 'Block')) continue;
+    if (last.loc && candidate.loc && last.loc.end.line < candidate.loc.start.line - 1) continue;
+    const verdict = classifyPragma(last.value);
+    if (verdict.targets) return last;
+  }
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a raw <supabase>.from(\'session_coordination\').insert(...) call outside the canonical insertCoordinationRow() choke point',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/rickfelix/EHG_Engineer/blob/main/eslint-rules/no-raw-session-coordination-insert.js',
+    },
+    messages: {
+      noRawInsert:
+        'Raw .from(\'session_coordination\').insert(...) bypasses the canonical choke point (insertCoordinationRow() in lib/coordinator/dispatch.cjs), which validates the target and enforces dispatch rules. ' +
+        'To override: // eslint-disable-next-line no-raw-session-coordination-insert -- <reason>',
+      pragmaMissingReason:
+        'eslint-disable-next-line no-raw-session-coordination-insert requires a non-empty REASON after `--`. ' +
+        'Example: // eslint-disable-next-line no-raw-session-coordination-insert -- test fixture seed, not a real producer',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    const pragmaHandled = new Set();
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments();
+        for (const comment of comments) {
+          if (comment.type !== 'Line' && comment.type !== 'Block') continue;
+          const verdict = classifyPragma(comment.value);
+          if (!verdict.targets) continue;
+          pragmaHandled.add(comment.range && comment.range[0]);
+          if (!verdict.hasMarker) {
+            context.report({ loc: comment.loc, messageId: 'noRawInsert' });
+          } else if (verdict.reason.length === 0) {
+            context.report({ loc: comment.loc, messageId: 'pragmaMissingReason' });
+          }
+        }
+      },
+
+      CallExpression(node) {
+        if (!isRawInsertOnSessionCoordination(node)) return;
+
+        const above = getDisablePragmaCommentAbove(sourceCode, node);
+        if (above && pragmaHandled.has(above.range && above.range[0])) return;
+
+        context.report({ node, messageId: 'noRawInsert' });
+      },
+    };
+  },
+};

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -301,15 +301,23 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
  * @param {object} [opts.logger=console]
  * @param {string} [opts.select] - optional columns to .select() after insert (e.g. 'id')
  * @param {boolean} [opts.single] - if true with select, append .single()
+ * @param {string} [opts.topicId] - SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-4): when present,
+ *   stamped into row.payload.topic_id before the insert so multi-party threads can be grouped later via
+ *   getThreadByTopicId. Merges into any existing payload (never clobbers other payload keys). Omitting
+ *   opts.topicId leaves row.payload byte-identical to before — fully backward-compatible.
  * @returns {Promise<{data:any,error:any}>} the Supabase insert result
  * @throws {Error} with err.code DISPATCH_TARGET_INVALID|DISPATCH_TARGET_UNKNOWN|DISPATCH_LOOKUP_FAILED on refusal
  */
 async function insertCoordinationRow(supabase, row, opts = {}) {
-  const { logger = console, select = null, single = false } = opts;
+  const { logger = console, select = null, single = false, topicId = null } = opts;
   if (!row || typeof row !== 'object') {
     const e = new Error('[dispatch] row must be an object');
     e.code = 'DISPATCH_BAD_ROW';
     throw e;
+  }
+  if (topicId) {
+    const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
+    row.payload = { ...payload, topic_id: topicId };
   }
   await assertValidTarget(supabase, row.target_session, logger);
   // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a terminal/non-existent SD before the
@@ -335,6 +343,26 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
 }
 
 /**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-4): fetch a whole multi-party thread by its
+ * topic_id (stamped via insertCoordinationRow's opts.topicId), ordered oldest-first so callers can
+ * replay the conversation in send order. Uses .eq() on the JSONB ->> text-extraction path
+ * ('payload->>topic_id') — the same syntax already used throughout lib/coordinator (e.g.
+ * adam-advisory-store.cjs, relay-drop-gauge.cjs, reply-class.cjs) to filter on a JSONB field; supabase-js
+ * passes the column string straight through to PostgREST, so ->> works with .eq() same as .filter().
+ *
+ * @param {object} supabase - Supabase client
+ * @param {string} topicId
+ * @returns {Promise<{data:any[],error:any}>}
+ */
+async function getThreadByTopicId(supabase, topicId) {
+  return await supabase
+    .from('session_coordination')
+    .select('*')
+    .eq('payload->>topic_id', topicId)
+    .order('created_at');
+}
+
+/**
  * Thin convenience wrapper for coordinator→worker dispatch. Same guarantees as
  * insertCoordinationRow; exists so call sites read intentionally.
  */
@@ -349,6 +377,7 @@ module.exports = {
   isSentinelTarget,
   assertValidTarget,
   insertCoordinationRow,
+  getThreadByTopicId,
   dispatchToWorker,
   stampEffortRecommendation,
   isTerminalSdStatus,

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
     "lint:count-delta-gate": "node scripts/lint/count-delta-gate-lint.mjs",
     "lint:ismainmodule-classguard": "node scripts/lint/ismainmodule-classguard-lint.mjs",
+    "lint:session-coordination-insert": "node scripts/lint/session-coordination-insert-classguard-lint.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",

--- a/scripts/lint/session-coordination-insert-classguard-lint.mjs
+++ b/scripts/lint/session-coordination-insert-classguard-lint.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Raw session_coordination Insert Class-Guard Lint
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3b)
+ *
+ * Scans scripts/ and lib/ for the raw `.from('session_coordination').insert(...)` pattern that
+ * bypasses the canonical choke point (insertCoordinationRow() in lib/coordinator/dispatch.cjs).
+ * Reuses the SAME detection logic as eslint-rules/no-raw-session-coordination-insert.js (via
+ * ESLint's Linter API) so there is exactly one implementation of the pattern, not a second
+ * grep/regex detector that could drift out of sync.
+ *
+ * lib/coordinator/dispatch.cjs itself (the choke point's own definition) and test/fixture files
+ * (which legitimately seed rows directly for setup) are excluded from the scan.
+ *
+ * Modes (mirrors scripts/lint/schema-reference-lint.mjs's precedent — a pre-existing backlog
+ * must never block a PR that didn't introduce it):
+ *   --diff (default in CI): lint ONLY files changed vs the merge base with origin/main — the
+ *       ~28-site existing phantom backlog (this SD deliberately converts only 2 flagship
+ *       producers; the DB-level advisory trigger in database/migrations/
+ *       20260702_session_coordination_insert_lint.sql already covers the rest regardless of
+ *       conversion status) never blocks an unrelated PR.
+ *   --all: advisory full sweep of scripts/ + lib/.
+ *
+ * Usage:
+ *   node scripts/lint/session-coordination-insert-classguard-lint.mjs [--diff|--all] [--json] [--root <dir>]
+ *   npm run lint:session-coordination-insert-classguard
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { Linter } from 'eslint';
+import rule from '../../eslint-rules/no-raw-session-coordination-insert.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const SCAN_DIRS = ['scripts', 'lib'];
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
+const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive', 'one-time', 'temp'];
+const EXCLUDE_FILE_RE = /(\.test\.|\.spec\.|\.d\.ts$|\.min\.js$)/i;
+const EXCLUDE_PATHS = new Set(['lib/coordinator/dispatch.cjs']);
+const EXCLUDE_DIR_PREFIXES = ['tests/'];
+
+const RULE_ID = 'session-coordination-insert-classguard/no-raw-session-coordination-insert';
+
+const FLAT_CONFIG = {
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: {
+      console: 'readonly', process: 'readonly', require: 'readonly', module: 'readonly',
+      exports: 'readonly', __dirname: 'readonly', __filename: 'readonly', Buffer: 'readonly',
+      setTimeout: 'readonly', setInterval: 'readonly', clearTimeout: 'readonly', clearInterval: 'readonly',
+    },
+  },
+  plugins: {
+    'session-coordination-insert-classguard': { rules: { 'no-raw-session-coordination-insert': rule } },
+  },
+  rules: {
+    [RULE_ID]: 'error',
+  },
+};
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (EXCLUDE_DIR_SEGMENTS.includes(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry.name)) && !EXCLUDE_FILE_RE.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+function isExcluded(relPath) {
+  if (EXCLUDE_PATHS.has(relPath)) return true;
+  return EXCLUDE_DIR_PREFIXES.some((prefix) => relPath.startsWith(prefix));
+}
+
+/** Files changed vs the merge base (+ staged/working-tree, empty in CI) — --diff mode candidates. */
+function candidateFilesDiff(repoRoot) {
+  const base = process.env.SESSION_COORD_LINT_BASE || 'origin/main';
+  const out = [
+    execSync(`git diff --name-only --diff-filter=ACMR ${base}...HEAD`, { encoding: 'utf8', timeout: 30000, cwd: repoRoot }),
+    execSync('git diff --name-only --diff-filter=ACMR --cached', { encoding: 'utf8', timeout: 30000, cwd: repoRoot }),
+    execSync('git diff --name-only --diff-filter=ACMR', { encoding: 'utf8', timeout: 30000, cwd: repoRoot }),
+    execSync('git ls-files --others --exclude-standard', { encoding: 'utf8', timeout: 30000, cwd: repoRoot }),
+  ].join('\n');
+  return [...new Set(out.split('\n').map((s) => s.trim()).filter(Boolean))]
+    .filter((f) => SCAN_EXTENSIONS.has(path.extname(f)))
+    .filter((f) => f.split('/')[0] === 'scripts' || f.split('/')[0] === 'lib')
+    .filter((f) => !EXCLUDE_FILE_RE.test(path.basename(f)))
+    .filter((f) => !isExcluded(f))
+    .map((f) => path.join(repoRoot, f));
+}
+
+function lintFile(linter, absPath) {
+  const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+  let code;
+  try {
+    code = fs.readFileSync(absPath, 'utf8');
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Could not read file: ${err.message}` }];
+  }
+  let messages;
+  try {
+    messages = linter.verify(code, FLAT_CONFIG, { filename: absPath });
+  } catch (err) {
+    return [{ filePath: relPath, line: 0, column: 0, message: `Parse error: ${err.message}` }];
+  }
+  return messages
+    .filter((m) => m.ruleId === RULE_ID)
+    .map((m) => ({ filePath: relPath, line: m.line, column: m.column, message: m.message }));
+}
+
+function candidateFilesAll(scanRoot) {
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    walk(path.join(scanRoot, dir), files);
+  }
+  return files.filter((f) => !isExcluded(path.relative(REPO_ROOT, f).split(path.sep).join('/')));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes('--json');
+  const allMode = args.includes('--all');
+  const rootIdx = args.indexOf('--root');
+  const scanRoot = rootIdx !== -1 && args[rootIdx + 1] ? path.resolve(args[rootIdx + 1]) : REPO_ROOT;
+
+  let scanned;
+  let mode = 'diff';
+  if (allMode) {
+    mode = 'all';
+    scanned = candidateFilesAll(scanRoot);
+  } else {
+    try {
+      scanned = candidateFilesDiff(scanRoot);
+    } catch (e) {
+      // Fail-soft: no diff base resolvable -> advisory full sweep instead of a false block.
+      console.warn(`⚠️  diff base unavailable (${e.message.split('\n')[0]}) — falling back to --all (advisory)`);
+      mode = 'all (degraded)';
+      scanned = candidateFilesAll(scanRoot);
+    }
+  }
+
+  const linter = new Linter({ cwd: scanRoot });
+  const violations = scanned.flatMap((f) => lintFile(linter, f));
+  // Only true diff mode blocks. Both explicit --all (advisory full sweep, per this file's own
+  // docstring) and a degraded diff->all fallback (re-surfaces the pre-existing backlog, not new
+  // drift introduced by this PR) must never fire a false block.
+  const blocking = mode === 'diff';
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ mode, scanned: scanned.length, violations, blocking }, null, 2));
+  } else if (violations.length === 0) {
+    console.log(`✅ session-coordination-insert-classguard-lint (${mode}): 0 violations across ${scanned.length} file(s) scanned`);
+  } else if (!blocking) {
+    console.warn(`⚠️  session-coordination-insert-classguard-lint (${mode}, advisory): ${violations.length} violation(s) across ${scanned.length} file(s) scanned — not blocking\n`);
+    for (const v of violations) console.warn(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+  } else {
+    console.error(`❌ session-coordination-insert-classguard-lint (${mode}): ${violations.length} violation(s) across ${scanned.length} file(s) scanned\n`);
+    for (const v of violations) {
+      console.error(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+    }
+    console.error('\nFix: route through insertCoordinationRow(supabase, row, opts) in lib/coordinator/dispatch.cjs.');
+  }
+
+  process.exit(violations.length > 0 && blocking ? 1 : 0);
+}
+
+main();

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -33,6 +33,10 @@
 
 const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
 const { getCommsActivitySignals, computeAdaptiveCadence } = require('../lib/coordinator/adaptive-comms-cadence.cjs');
+// SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3c): canonical session_coordination insert
+// choke point — routes both raw insert call sites below through the same validated path the
+// coordinator's dispatch code uses (target-session validation; no-op for non-WORK_ASSIGNMENT rows).
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 const ws = require('../lib/fleet/worker-status.cjs');
 const { stampClaim } = require('../lib/fleet/claim-stamp.cjs');
 // SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001: acquisition-time guard so a propose-only
@@ -221,20 +225,16 @@ async function registerRollCall(sb, { sessionId, coordinatorId, callsign, mySd }
       available: !mySd,
       repo: process.cwd(),
     };
-    const { data, error } = await sb
-      .from('session_coordination')
-      .insert({
-        sender_session: sessionId,
-        sender_type: 'worker',
-        target_session: coordinatorId || 'broadcast-coordinator',
-        message_type: 'INFO',
-        subject: `[ROLL_CALL] ${callsign || 'unassigned'} ${mySd ? 'working ' + mySd : 'available'}`,
-        body: null,
-        payload,
-        expires_at: new Date(Date.now() + ROLL_CALL_TTL_MS).toISOString(),
-      })
-      .select('id')
-      .single();
+    const { data, error } = await insertCoordinationRow(sb, {
+      sender_session: sessionId,
+      sender_type: 'worker',
+      target_session: coordinatorId || 'broadcast-coordinator',
+      message_type: 'INFO',
+      subject: `[ROLL_CALL] ${callsign || 'unassigned'} ${mySd ? 'working ' + mySd : 'available'}`,
+      body: null,
+      payload,
+      expires_at: new Date(Date.now() + ROLL_CALL_TTL_MS).toISOString(),
+    }, { select: 'id', single: true });
     if (error) return { id: null, error: error.message };
     return { id: data && data.id, deduped: false };
   } catch (e) {
@@ -1016,7 +1016,7 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
     // the mechanism that makes the name VISIBLE; still fail-open — a message failure leaves the DB
     // identity authoritative and the next cron refresh re-emits the message.
     try {
-      await sb.from('session_coordination').insert({
+      await insertCoordinationRow(sb, {
         target_session: sessionId,
         target_sd: claimSd || null,
         message_type: 'SET_IDENTITY',

--- a/scripts/worker-signal.cjs
+++ b/scripts/worker-signal.cjs
@@ -19,6 +19,9 @@ require('dotenv').config();
 const crypto = require('crypto');
 const { createClient } = require('@supabase/supabase-js');
 const { getActiveCoordinatorId, isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
+// SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3c): route all session_coordination inserts
+// through the validated dispatch choke point instead of raw .from().insert().
+const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 // SD-LEO-INFRA-SOLOMON-CONSULT-001D: Solomon oracle consult lane (flag-gated, dormant by default).
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
 const { evaluateSolomonTriage } = require('../lib/coordinator/solomon-triage.cjs');
@@ -233,25 +236,32 @@ async function intentMain(flags, positional) {
   const subjBody = payload.body || '';
   const subject = `[INTENT:${action.toUpperCase()}] ${(targetSdKey || targetTree || '')} ${subjBody.slice(0, 60)}`.trim();
 
-  const { data: inserted, error } = await supabase
-    .from('session_coordination')
-    .insert({
-      sender_session: sessionId,
-      sender_type: 'worker',
-      // INFO is an existing coordination_message_type enum value — no new type, no ALTER.
-      // FR-2 disambiguates INTENT from FR-3a signals via payload.intent_action.
-      target_session: 'broadcast-coordinator',
-      message_type: 'INFO',
-      subject,
-      body: payload.body || null,
-      payload,
-      expires_at: expiresAt
-    })
-    .select('id, created_at')
-    .single();
-
-  if (error) {
-    console.error('ERROR: failed to insert intent:', error.message);
+  let inserted;
+  try {
+    const { data, error } = await insertCoordinationRow(
+      supabase,
+      {
+        sender_session: sessionId,
+        sender_type: 'worker',
+        // INFO is an existing coordination_message_type enum value — no new type, no ALTER.
+        // FR-2 disambiguates INTENT from FR-3a signals via payload.intent_action.
+        target_session: 'broadcast-coordinator',
+        message_type: 'INFO',
+        subject,
+        body: payload.body || null,
+        payload,
+        expires_at: expiresAt
+      },
+      { select: 'id, created_at', single: true }
+    );
+    if (error) {
+      console.error('ERROR: failed to insert intent:', error.message);
+      process.exit(1);
+    }
+    inserted = data;
+  } catch (e) {
+    const code = e && e.code ? `${e.code}: ` : '';
+    console.error(`ERROR: failed to insert intent: ${code}${(e && e.message) || e}`);
     process.exit(1);
   }
 
@@ -383,9 +393,8 @@ async function requestMain(flags, positional) {
   // Request expiry guards the coordinator's reply window (request + reply margin).
   const expiresAt = new Date(Date.now() + timeoutMs + 5 * 60_000).toISOString();
 
-  const { error: insErr } = await supabase
-    .from('session_coordination')
-    .insert({
+  try {
+    const { error: insErr } = await insertCoordinationRow(supabase, {
       sender_session: sessionId,
       sender_type: 'worker',
       target_session: coordinatorId,
@@ -395,8 +404,13 @@ async function requestMain(flags, positional) {
       payload,
       expires_at: expiresAt
     });
-  if (insErr) {
-    console.error('ERROR: failed to insert request:', insErr.message);
+    if (insErr) {
+      console.error('ERROR: failed to insert request:', insErr.message);
+      process.exit(1);
+    }
+  } catch (e) {
+    const code = e && e.code ? `${e.code}: ` : '';
+    console.error(`ERROR: failed to insert request: ${code}${(e && e.message) || e}`);
     process.exit(1);
   }
 
@@ -541,9 +555,8 @@ async function solomonConsultMain(flags, positional) {
   const subject = `[SOLOMON_CONSULT] ${payload.body.slice(0, 80)}`;
   const expiresAt = new Date(Date.now() + timeoutMs + 5 * 60_000).toISOString();
 
-  const { error: insErr } = await supabase
-    .from('session_coordination')
-    .insert({
+  try {
+    const { error: insErr } = await insertCoordinationRow(supabase, {
       sender_session: sessionId,
       sender_type: 'worker',
       target_session: target,
@@ -553,8 +566,13 @@ async function solomonConsultMain(flags, positional) {
       payload,
       expires_at: expiresAt
     });
-  if (insErr) {
-    console.error('ERROR: failed to insert solomon-consult:', insErr.message);
+    if (insErr) {
+      console.error('ERROR: failed to insert solomon-consult:', insErr.message);
+      process.exit(1);
+    }
+  } catch (e) {
+    const code = e && e.code ? `${e.code}: ` : '';
+    console.error(`ERROR: failed to insert solomon-consult: ${code}${(e && e.message) || e}`);
     process.exit(1);
   }
 
@@ -692,23 +710,30 @@ async function main() {
 
   const expiresAt = new Date(Date.now() + 24 * 60 * 60_000).toISOString();
 
-  const { data: inserted, error } = await supabase
-    .from('session_coordination')
-    .insert({
-      sender_session: sessionId,
-      sender_type: 'worker',
-      target_session: target,
-      message_type: 'INFO',
-      subject,
-      body,
-      payload,
-      expires_at: expiresAt
-    })
-    .select('id, created_at')
-    .single();
-
-  if (error) {
-    console.error('ERROR: failed to insert signal:', error.message);
+  let inserted;
+  try {
+    const { data, error } = await insertCoordinationRow(
+      supabase,
+      {
+        sender_session: sessionId,
+        sender_type: 'worker',
+        target_session: target,
+        message_type: 'INFO',
+        subject,
+        body,
+        payload,
+        expires_at: expiresAt
+      },
+      { select: 'id, created_at', single: true }
+    );
+    if (error) {
+      console.error('ERROR: failed to insert signal:', error.message);
+      process.exit(1);
+    }
+    inserted = data;
+  } catch (e) {
+    const code = e && e.code ? `${e.code}: ` : '';
+    console.error(`ERROR: failed to insert signal: ${code}${(e && e.message) || e}`);
     process.exit(1);
   }
 

--- a/tests/unit/coordinator/dispatch-topic-id.test.js
+++ b/tests/unit/coordinator/dispatch-topic-id.test.js
@@ -1,0 +1,145 @@
+/**
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-4) — topic_id multi-party thread primitive.
+ *
+ * insertCoordinationRow(supabase, row, { topicId }) stamps row.payload.topic_id before insert
+ * (merging into any existing payload, never clobbering other keys); getThreadByTopicId(supabase,
+ * topicId) reads the thread back grouped + ordered by created_at ASC. Follows the same lightweight
+ * chain-stub mocking convention as tests/unit/coordinator-dispatch-terminal-guard.test.js (which
+ * covers the same lib/coordinator/dispatch.cjs choke point).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow, getThreadByTopicId } = require('../../../lib/coordinator/dispatch.cjs');
+
+const silentLog = { warn() {}, error() {}, log() {} };
+// Sentinel target short-circuits assertValidTarget (no claude_sessions lookup needed), and a
+// non-WORK_ASSIGNMENT message_type short-circuits assertSdDispatchable / assertWorkerTierAllowed /
+// stampEffortRecommendation (each bails at message_type !== 'WORK_ASSIGNMENT') — so the fake below
+// only needs to model the 'session_coordination' table itself.
+const TARGET = 'broadcast-coordinator';
+
+/** Minimal fake supabase client modeling only session_coordination insert + select/eq/order reads. */
+function createFakeSupabase() {
+  const rows = [];
+  let counter = 0;
+  return {
+    _rows: rows,
+    from(table) {
+      if (table !== 'session_coordination') {
+        // Not expected to be hit given TARGET is a sentinel + message_type is not WORK_ASSIGNMENT,
+        // but stub defensively so an unexpected call fails loudly instead of throwing on undefined.
+        const generic = {
+          select() { return generic; },
+          eq() { return generic; },
+          limit() { return generic; },
+          maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+        };
+        return generic;
+      }
+      const chain = {
+        _mode: null,
+        _filters: [],
+        _order: null,
+        insert(row) {
+          chain._mode = 'insert';
+          const stored = {
+            id: `row-${++counter}`,
+            created_at: row.created_at || new Date().toISOString(),
+            ...row,
+          };
+          rows.push(stored);
+          chain._result = stored;
+          return chain;
+        },
+        select() {
+          if (chain._mode !== 'insert') chain._mode = 'select';
+          return chain;
+        },
+        eq(col, val) {
+          chain._filters.push([col, val]);
+          return chain;
+        },
+        order(col) {
+          chain._order = col;
+          return chain;
+        },
+        then(resolve, reject) {
+          let result;
+          if (chain._mode === 'insert') {
+            result = { data: chain._result, error: null };
+          } else {
+            let data = rows.slice();
+            for (const [col, val] of chain._filters) {
+              if (col === 'payload->>topic_id') {
+                data = data.filter((r) => r.payload && r.payload.topic_id === val);
+              } else {
+                data = data.filter((r) => r[col] === val);
+              }
+            }
+            if (chain._order) {
+              data.sort((a, b) => new Date(a[chain._order]) - new Date(b[chain._order]));
+            }
+            result = { data, error: null };
+          }
+          return Promise.resolve(result).then(resolve, reject);
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('insertCoordinationRow + getThreadByTopicId: topic_id thread primitive', () => {
+  it('groups 3 messages sharing a topic_id and returns them ordered by created_at ASC', async () => {
+    const sb = createFakeSupabase();
+    const topicId = 'topic-abc-123';
+
+    // Insert out of chronological order to prove getThreadByTopicId re-sorts, not just echoes insert order.
+    await insertCoordinationRow(sb, {
+      message_type: 'INFO', target_session: TARGET, sender_type: 'coordinator',
+      created_at: '2026-07-02T10:02:00.000Z', payload: { body: 'third' },
+    }, { logger: silentLog, topicId });
+    await insertCoordinationRow(sb, {
+      message_type: 'INFO', target_session: TARGET, sender_type: 'adam',
+      created_at: '2026-07-02T10:00:00.000Z', payload: { body: 'first' },
+    }, { logger: silentLog, topicId });
+    await insertCoordinationRow(sb, {
+      message_type: 'INFO', target_session: TARGET, sender_type: 'solomon',
+      created_at: '2026-07-02T10:01:00.000Z', payload: { body: 'second' },
+    }, { logger: silentLog, topicId });
+
+    // An unrelated message (different topic_id) must NOT show up in the thread.
+    await insertCoordinationRow(sb, {
+      message_type: 'INFO', target_session: TARGET, sender_type: 'coordinator',
+      created_at: '2026-07-02T10:03:00.000Z', payload: { body: 'unrelated' },
+    }, { logger: silentLog, topicId: 'topic-other' });
+
+    const { data, error } = await getThreadByTopicId(sb, topicId);
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(3);
+    expect(data.map((r) => r.payload.body)).toEqual(['first', 'second', 'third']);
+    expect(data.every((r) => r.payload.topic_id === topicId)).toBe(true);
+  });
+
+  it('backward-compat: insertCoordinationRow WITHOUT opts.topicId does not add a topic_id key at all', async () => {
+    const sb = createFakeSupabase();
+
+    // Case 1: row.payload already has keys — those must survive unchanged, and no topic_id key added.
+    await insertCoordinationRow(sb, {
+      message_type: 'INFO', target_session: TARGET, sender_type: 'coordinator',
+      payload: { body: 'no topic here', foo: 'bar' },
+    }, { logger: silentLog });
+
+    // Case 2: row.payload is undefined entirely — must not throw, and no payload.topic_id materializes.
+    await insertCoordinationRow(sb, {
+      message_type: 'INFO', target_session: TARGET, sender_type: 'coordinator',
+    }, { logger: silentLog });
+
+    expect(sb._rows).toHaveLength(2);
+    expect(sb._rows[0].payload).toEqual({ body: 'no topic here', foo: 'bar' });
+    expect(Object.prototype.hasOwnProperty.call(sb._rows[0].payload, 'topic_id')).toBe(false);
+    expect(sb._rows[1].payload).toBeUndefined();
+  });
+});

--- a/tests/unit/coordinator/dispatch-topic-id.test.js
+++ b/tests/unit/coordinator/dispatch-topic-id.test.js
@@ -138,8 +138,15 @@ describe('insertCoordinationRow + getThreadByTopicId: topic_id thread primitive'
     }, { logger: silentLog });
 
     expect(sb._rows).toHaveLength(2);
-    expect(sb._rows[0].payload).toEqual({ body: 'no topic here', foo: 'bar' });
+    // Original payload keys survive unchanged; no topic_id key is added. protocol_comms_version is
+    // a SEPARATE, unrelated stamp from sibling SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C (FR-2)
+    // that insertCoordinationRow also applies to any row with a payload object -- not this test's
+    // concern, so assert its presence rather than pretending it doesn't exist.
+    expect(sb._rows[0].payload).toMatchObject({ body: 'no topic here', foo: 'bar' });
     expect(Object.prototype.hasOwnProperty.call(sb._rows[0].payload, 'topic_id')).toBe(false);
+    expect(sb._rows[0].payload).toHaveProperty('protocol_comms_version');
+    // A payload-less row stays payload-less -- protocol_comms_version stamping only stamps INTO an
+    // existing payload object, never invents one (some rows are payload-less by design).
     expect(sb._rows[1].payload).toBeUndefined();
   });
 });

--- a/tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js
+++ b/tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js
@@ -29,15 +29,15 @@ ruleTester.run('no-raw-session-coordination-insert', rule, {
   valid: [
     // TS-1: routed through the canonical choke point.
     {
-      code: `await insertCoordinationRow(supabase, { target_session: 'x', subject: 'y' });`,
+      code: 'await insertCoordinationRow(supabase, { target_session: \'x\', subject: \'y\' });',
     },
     // TS-2: .insert() on a different table entirely.
     {
-      code: `await supabase.from('feedback').insert({ category: 'harness_backlog' });`,
+      code: 'await supabase.from(\'feedback\').insert({ category: \'harness_backlog\' });',
     },
     // TS-3: .from('session_coordination') without a chained .insert() (e.g. a .select() read).
     {
-      code: `await supabase.from('session_coordination').select('*').eq('target_session', sid);`,
+      code: 'await supabase.from(\'session_coordination\').select(\'*\').eq(\'target_session\', sid);',
     },
     // TS-4: escape-hatch pragma with a non-empty reason.
     {
@@ -50,12 +50,12 @@ ruleTester.run('no-raw-session-coordination-insert', rule, {
   invalid: [
     // TS-5: the raw anti-pattern this rule exists to catch.
     {
-      code: `await supabase.from('session_coordination').insert(row);`,
+      code: 'await supabase.from(\'session_coordination\').insert(row);',
       errors: [{ messageId: 'noRawInsert' }],
     },
     // TS-6: same anti-pattern via a differently-named client variable.
     {
-      code: `await sb.from('session_coordination').insert({ target_sd: sdKey, subject: 'x' });`,
+      code: 'await sb.from(\'session_coordination\').insert({ target_sd: sdKey, subject: \'x\' });',
       errors: [{ messageId: 'noRawInsert' }],
     },
     // TS-7: pragma present but missing the `--` REASON marker entirely -- ESLint's native

--- a/tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js
+++ b/tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for ESLint rule `no-raw-session-coordination-insert`.
+ *
+ * SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-D (FR-3b).
+ *
+ * Covers: the anti-pattern (raw .from('session_coordination').insert(...)), the correct pattern
+ * (insertCoordinationRow(...) call, or .from() on a different table), and the escape-hatch
+ * pragma contract (mirrors no-count-delta-gate-assertion.js / no-realtime-teardown-in-
+ * subscribe-callback.js).
+ *
+ * @module tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js
+ */
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../../../eslint-rules/no-raw-session-coordination-insert.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const RULE_ID = 'rule-to-test/no-raw-session-coordination-insert';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-raw-session-coordination-insert', rule, {
+  valid: [
+    // TS-1: routed through the canonical choke point.
+    {
+      code: `await insertCoordinationRow(supabase, { target_session: 'x', subject: 'y' });`,
+    },
+    // TS-2: .insert() on a different table entirely.
+    {
+      code: `await supabase.from('feedback').insert({ category: 'harness_backlog' });`,
+    },
+    // TS-3: .from('session_coordination') without a chained .insert() (e.g. a .select() read).
+    {
+      code: `await supabase.from('session_coordination').select('*').eq('target_session', sid);`,
+    },
+    // TS-4: escape-hatch pragma with a non-empty reason.
+    {
+      code: `
+        // eslint-disable-next-line ${RULE_ID} -- test fixture seed, not a real producer
+        await supabase.from('session_coordination').insert(row);
+      `,
+    },
+  ],
+  invalid: [
+    // TS-5: the raw anti-pattern this rule exists to catch.
+    {
+      code: `await supabase.from('session_coordination').insert(row);`,
+      errors: [{ messageId: 'noRawInsert' }],
+    },
+    // TS-6: same anti-pattern via a differently-named client variable.
+    {
+      code: `await sb.from('session_coordination').insert({ target_sd: sdKey, subject: 'x' });`,
+      errors: [{ messageId: 'noRawInsert' }],
+    },
+    // TS-7: pragma present but missing the `--` REASON marker entirely -- ESLint's native
+    // directive parser still suppresses the CallExpression's own report (no `--` required for a
+    // directive to be syntactically valid), so only this rule's OWN Program-level pragma check
+    // fires (mirrors the no-raw-ismainmodule-comparison.js sibling's identical TS).
+    {
+      code: `
+        // eslint-disable-next-line ${RULE_ID}
+        await supabase.from('session_coordination').insert(row);
+      `,
+      errors: [{ messageId: 'noRawInsert' }],
+    },
+    // TS-8: pragma present with the `--` marker but a whitespace-only (effectively empty) reason.
+    {
+      code: `// eslint-disable-next-line ${RULE_ID} --   \nawait supabase.from('session_coordination').insert(row);`,
+      errors: [{ messageId: 'pragmaMissingReason' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- **FR-3a**: `session_coordination` gains a nullable `correlation_id` column plus an **advisory** (non-blocking, `RAISE NOTICE` only) insert-time trigger warning on unrecognized `sender_type`, missing `correlation_id`, and same-sender duplicate bodies within 60s. Already live-applied to prod via the 3-factor `apply-migration.js --prod-deploy` guard.
- **FR-3b**: a CI-blocking (diff-mode, matching `schema-reference-lint.mjs`'s precedent) ESLint class-guard bans NEW raw `.from('session_coordination').insert(...)` call sites outside the canonical choke point (`insertCoordinationRow` in `lib/coordinator/dispatch.cjs`). The ~28-36-site pre-existing backlog is deliberately deferred — the DB trigger already covers it regardless of conversion status.
- **FR-3c**: converts the 2 highest-traffic raw producers (`worker-checkin.cjs`, `worker-signal.cjs` — 6 call sites) to route through `insertCoordinationRow`.
- **FR-4**: `insertCoordinationRow` gains an optional `opts.topicId`, stamped into `payload.topic_id` (zero-migration JSONB convention); a new `getThreadByTopicId()` helper groups a multi-party conversation instead of only pairwise-correlating.
- Rebased onto `origin/main` to compose cleanly with sibling SDs 001-B (chairman-directive durability) and 001-C (protocol-version-skew detection), both of which also touch `insertCoordinationRow` — verified both features coexist correctly (independent payload stamps, no clobbering).

## Test plan
- [x] `tests/unit/eslint-rules/no-raw-session-coordination-insert.test.js` — 8/8 passing
- [x] `tests/unit/coordinator/dispatch-topic-id.test.js` — 2/2 passing
- [x] 12 `worker-checkin.cjs` test files — 172/172 passing
- [x] `worker-signal.cjs`-adjacent test files — 108/109 passing (1 pre-existing, unrelated failure confirmed via `git stash` reproduction on unmodified code)
- [x] 10 files importing `lib/coordinator/dispatch.cjs` — 153/153 passing
- [x] Live smoke test: `node scripts/worker-checkin.cjs` and `node scripts/worker-signal.cjs feedback ...` both invoked against the live fleet DB with expected output shape
- [x] Live DB verification: `correlation_id` column + `trg_session_coordination_insert_lint` trigger confirmed live; a deliberate insert with an unrecognized `sender_type` succeeded (advisory-not-blocking confirmed)
- [x] `session-coordination-insert-classguard-lint.mjs` (diff mode): 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)