### PR TITLE
fix(QF-20260702-679): safe heredoc-free evidence writer for sub-agent repo evidence

### DIFF
--- a/scripts/store-sub-agent-repo-evidence.js
+++ b/scripts/store-sub-agent-repo-evidence.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * QF-20260702-679 — safe, heredoc-free evidence writer for Task-tool-invoked sub-agents
+ * (validation-agent, regression-agent, etc). These agents hand-roll their own inline
+ * `node -e "..."` inserts to persist sub_agent_execution_results, which is where a
+ * heredoc/backslash-collapse silently mangles Windows repo paths and drops
+ * metadata.repo_path/executed_from_cwd on the first write attempt.
+ *
+ * This script chains the ALREADY-CORRECT library functions (resolveSubAgentRepo ->
+ * applySubAgentRepoVerdict -> storeSubAgentResults — proven correct by
+ * tests/unit/sub-agent-repo-evidence-persistence.test.js) so repo evidence persists
+ * reliably. Content comes from --content @<file>|- (never inline shell JSON), the same
+ * safe pattern as add-prd-to-database.js.
+ *
+ * Usage:
+ *   node scripts/store-sub-agent-repo-evidence.js <SD-ID> <SUB-AGENT-CODE> --content @results.json [--target-application <app>] [--phase <phase>]
+ */
+import 'dotenv/config';
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../lib/sub-agent-executor/supabase-client.js';
+import { normalizeSDId } from './modules/sd-id-normalizer.js';
+import { loadContentPayload, extractContentArg } from './add-prd-to-database.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+export async function main(argv) {
+  const [sdId, subAgentCode, ...rest] = argv;
+  if (!sdId || !subAgentCode) {
+    throw new Error('Usage: store-sub-agent-repo-evidence.js <SD-ID> <SUB-AGENT-CODE> --content @results.json [--target-application <app>] [--phase <phase>]');
+  }
+  const { value: contentArg, remaining } = extractContentArg(rest);
+  const results = loadContentPayload(contentArg);
+
+  const phaseIdx = remaining.indexOf('--phase');
+  const phase = phaseIdx >= 0 ? remaining[phaseIdx + 1] : undefined;
+  const appIdx = remaining.indexOf('--target-application');
+  let targetApplication = appIdx >= 0 ? remaining[appIdx + 1] : undefined;
+
+  const supabase = await getSupabaseClient();
+  if (!targetApplication) {
+    const normalized = await normalizeSDId(supabase, sdId);
+    const { data: sd } = await supabase.from('strategic_directives_v2').select('target_application').eq('id', normalized).maybeSingle();
+    targetApplication = sd?.target_application || undefined;
+  }
+
+  const resolution = await resolveSubAgentRepo({ sdId, targetApplication, subAgentCode, supabase });
+  const withEvidence = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults(subAgentCode, sdId, null, withEvidence, phase ? { phase } : {});
+  console.log(`Stored ${subAgentCode} evidence for ${sdId}: id=${stored.id}, repo_path=${withEvidence.metadata.repo_path}`);
+  return stored;
+}
+
+if (isMainModule(import.meta.url)) {
+  main(process.argv.slice(2)).catch((err) => { console.error('ERROR:', err.message); process.exit(1); });
+}

--- a/tests/unit/store-sub-agent-repo-evidence.test.js
+++ b/tests/unit/store-sub-agent-repo-evidence.test.js
@@ -1,0 +1,90 @@
+/**
+ * QF-20260702-679 — scripts/store-sub-agent-repo-evidence.js is the new safe, heredoc-free
+ * write path for Task-tool-invoked sub-agents. This exercises `main()` end-to-end (content
+ * loaded from a real temp file, matching --content @<path> usage, never inline shell JSON)
+ * against the same stubbed-network-only supabase pattern as the other results-storage tests.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function makeMockSupabase(captureTarget) {
+  return {
+    from(table) {
+      return {
+        select() { return this; },
+        eq(col, val) {
+          if (table === 'strategic_directives_v2' && col === 'id') captureTarget.sdLookupId = val;
+          return this;
+        },
+        gte() { return this; },
+        order() { return this; },
+        limit() { return Promise.resolve({ data: [], error: null }); },
+        maybeSingle() {
+          if (table === 'strategic_directives_v2') {
+            return Promise.resolve({ data: { target_application: 'EHG_Engineer' }, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(record) {
+          captureTarget.insertedTable = table;
+          captureTarget.inserted = record;
+          const inserted = { id: 'mock-row-id', ...record };
+          return {
+            select() {
+              return { single: async () => ({ data: inserted, error: null }) };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('store-sub-agent-repo-evidence.js main() (QF-20260702-679)', () => {
+  const capture = {};
+  let tmpFile;
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../../lib/sub-agent-executor/supabase-client.js');
+    vi.doUnmock('../../scripts/modules/sd-id-normalizer.js');
+    vi.doUnmock('../../lib/sub-agents/resolve-repo.js');
+    if (tmpFile && fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  });
+
+  it('resolves target_application from the SD when not passed, stamps repo evidence, and persists it', async () => {
+    capture.inserted = null;
+    tmpFile = path.join(os.tmpdir(), `qf-679-results-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify({ verdict: 'PASS', confidence: 91, summary: 'looks good' }));
+
+    vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeMockSupabase(capture),
+    }));
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => v,
+    }));
+    vi.doMock('../../lib/sub-agents/resolve-repo.js', async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        resolveSubAgentRepo: async () => ({ repoPath: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer', repoResolved: true, registrySource: 'db' }),
+      };
+    });
+
+    const { main } = await import('../../scripts/store-sub-agent-repo-evidence.js');
+    const stored = await main(['SD-TEST-001', 'VALIDATION', '--content', `@${tmpFile}`, '--phase', 'PLAN_VERIFICATION']);
+
+    expect(capture.insertedTable).toBe('sub_agent_execution_results');
+    expect(capture.inserted.metadata.repo_path).toBe('C:/Users/rickf/Projects/_EHG/EHG_Engineer');
+    expect(capture.inserted.metadata.repo_resolved).toBe(true);
+    expect(capture.inserted.metadata.executed_from_cwd).toBeTruthy();
+    expect(stored.id).toBe('mock-row-id');
+  });
+
+  it('throws a clear usage error when SD-ID or sub-agent code is missing', async () => {
+    const { main } = await import('../../scripts/store-sub-agent-repo-evidence.js');
+    await expect(main(['SD-ONLY'])).rejects.toThrow(/Usage:/);
+  });
+});

--- a/tests/unit/sub-agent-repo-evidence-persistence.test.js
+++ b/tests/unit/sub-agent-repo-evidence-persistence.test.js
@@ -1,0 +1,100 @@
+/**
+ * QF-20260702-679 — applySubAgentRepoVerdict (lib/sub-agents/resolve-repo.js) mutates
+ * results.metadata.repo_path/executed_from_cwd correctly IN-MEMORY, but the metadata never
+ * reaches sub_agent_execution_results on first attempt (tripped SUB_AGENT_REPO_RESOLUTION /
+ * SUBAGENT_EVIDENCE_MISSING fleet-wide during the comms/refresh hardening sprint).
+ *
+ * This test chains the REAL applySubAgentRepoVerdict into the REAL storeSubAgentResults
+ * (the canonical lib/sub-agent-executor writer) — only the Supabase network call is stubbed,
+ * matching the established convention in sub-agent-execution-results-phase-column.test.js — to
+ * prove where persistence actually breaks against a real (non-mocked-seam) code path.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+function makeMockSupabase(captureTarget) {
+  return {
+    from(table) {
+      return {
+        select() { return this; },
+        eq() { return this; },
+        gte() { return this; },
+        order() { return this; },
+        limit() { return Promise.resolve({ data: [], error: null }); },
+        insert(record) {
+          captureTarget.insertedTable = table;
+          captureTarget.inserted = record;
+          return {
+            select() {
+              return { single: async () => ({ data: { id: 'mock-row-id', ...record }, error: null }) };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('applySubAgentRepoVerdict -> storeSubAgentResults: repo evidence persistence (QF-20260702-679)', () => {
+  const capture = {};
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../../lib/sub-agent-executor/supabase-client.js');
+    vi.doUnmock('../../scripts/modules/sd-id-normalizer.js');
+  });
+
+  it('persists metadata.repo_path + executed_from_cwd to the stored row on the FIRST attempt', async () => {
+    capture.inserted = null;
+    vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeMockSupabase(capture),
+    }));
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => v,
+    }));
+
+    const { applySubAgentRepoVerdict, toCanonicalRepoPath } = await import('../../lib/sub-agents/resolve-repo.js');
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    // Real resolution shape (as resolveSubAgentRepo would return), no filesystem/DB dependency.
+    const resolution = { repoPath: 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer', repoResolved: true, registrySource: 'db' };
+
+    let results = { verdict: 'PASS', confidence: 90, summary: 'ok' };
+    results = applySubAgentRepoVerdict(results, resolution);
+
+    // Sanity: the in-memory mutation happened (this half was never in dispute).
+    expect(results.metadata.repo_path).toBe(toCanonicalRepoPath(resolution.repoPath));
+    expect(results.metadata.executed_from_cwd).toBeTruthy();
+
+    await storeSubAgentResults('VALIDATION', 'SD-TEST-001', null, results, { phase: 'PLAN_VERIFICATION' });
+
+    expect(capture.insertedTable).toBe('sub_agent_execution_results');
+    const row = capture.inserted;
+    expect(row.metadata.repo_path).toBe(toCanonicalRepoPath(resolution.repoPath));
+    expect(row.metadata.repo_resolved).toBe(true);
+    expect(row.metadata.registry_source).toBe('db');
+    expect(row.metadata.executed_from_cwd).toBe(results.metadata.executed_from_cwd);
+  });
+
+  it('preserves the caller-passed results object across the two calls (no stale/copied reference)', async () => {
+    capture.inserted = null;
+    vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeMockSupabase(capture),
+    }));
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => v,
+    }));
+
+    const { applySubAgentRepoVerdict } = await import('../../lib/sub-agents/resolve-repo.js');
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    const results = { verdict: 'PASS', confidence: 88 };
+    const mutated = applySubAgentRepoVerdict(results, { repoPath: '/tmp/repo', repoResolved: true, registrySource: 'registry' });
+
+    // applySubAgentRepoVerdict returns the SAME object it mutated (identity check) — a caller
+    // that discards the return value and re-uses `results` still gets the stamped metadata.
+    expect(mutated).toBe(results);
+
+    await storeSubAgentResults('REGRESSION', 'SD-TEST-001', null, results, {});
+    expect(capture.inserted.metadata.repo_path).toBe('/tmp/repo');
+  });
+});


### PR DESCRIPTION
## Summary
- `applySubAgentRepoVerdict` (`lib/sub-agents/resolve-repo.js`) mutates `results.metadata.repo_path`/`executed_from_cwd` correctly in-memory, and `storeSubAgentResults` (`lib/sub-agent-executor/results-storage.js`) already persists it correctly when the two are chained on the same `results` object — proven by the new `sub-agent-repo-evidence-persistence.test.js`, which found **no bug in either library function**.
- The real seam: Task-tool-invoked sub-agents (validation-agent, regression-agent, etc.) hand-roll their own inline `node -e "..."` inserts instead of using this chain, which is where a heredoc/backslash-collapse mangles Windows repo paths on the write — trips `SUB_AGENT_REPO_RESOLUTION`/`SUBAGENT_EVIDENCE_MISSING` fleet-wide.
- Adds `scripts/store-sub-agent-repo-evidence.js`: a safe, reusable CLI chaining `resolveSubAgentRepo -> applySubAgentRepoVerdict -> storeSubAgentResults`, taking its results payload via `--content @<file>|-` (never inline shell JSON — the same safe pattern already proven by `add-prd-to-database.js`).

## RCA
SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C VALIDATION + REGRESSION sub-agent runs, backlog `cc494032`.

## Test plan
- [x] `sub-agent-repo-evidence-persistence.test.js` — proves the existing library chain persists correctly (2/2)
- [x] `store-sub-agent-repo-evidence.test.js` — end-to-end `main()` test, target_application resolved from SD, repo evidence stamped and persisted, usage-error path (2/2)
- [x] Regression sweep: `sub-agent-execution-results-phase-column`, `resolve-sub-agent-repo`, `gates/sub-agent-repo-resolution*` — 31/31 pass
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)