### PR TITLE
feat(SD-LEO-INFRA-QF-SD-ESCALATION-LINK-CANONICAL-TRACK-001): bidirectional QF<->SD escalation link + hardened retirement

### DIFF
--- a/scripts/__tests__/leo-create-sd-claim-pin.test.js
+++ b/scripts/__tests__/leo-create-sd-claim-pin.test.js
@@ -15,11 +15,17 @@
 //
 // Test approach: static-source assertions (mirrors leo-create-sd-smoke-detector.test.js
 // FR-3 regression guard). Assertions:
-//   1. Single occurrence of `claiming_session_id` in the file (the QF-table NULL escalation).
-//   2. That single occurrence sets the value to literal `null`.
-//   3. No occurrence of `claiming_session_id` adjacent to (within ~200 chars of)
-//      `strategic_directives_v2` to rule out stealth writes.
-//   4. No `process.env.CLAUDE_SESSION_ID` -> `claiming_session_id` propagation pattern.
+//   1. Exactly two occurrences of `claiming_session_id` in the file: the QF-table NULL
+//      escalation write, and (SD-LEO-INFRA-QF-SD-ESCALATION-LINK-CANONICAL-TRACK-001) a
+//      manual-recovery SQL snippet inside a thrown Error's message — descriptive text for
+//      a human operator, not a second programmatic write site.
+//   2. BOTH occurrences set the value to literal `null`/`NULL` (NOT a session/process
+//      expression) — the recovery text must stay consistent with the real write, since an
+//      operator may copy-paste it verbatim.
+//   3. Neither occurrence appears within ~200 chars of `strategic_directives_v2`, to rule
+//      out stealth writes (or recovery instructions implying a write) to that table.
+//   4. No `process.env.CLAUDE_SESSION_ID` -> `claiming_session_id` propagation pattern at
+//      either occurrence.
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
@@ -30,59 +36,72 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const SOURCE_PATH = path.resolve(__dirname, '../leo-create-sd.js');
 const SOURCE = fs.readFileSync(SOURCE_PATH, 'utf8');
 
+function allIndicesOf(haystack, needle) {
+  const indices = [];
+  let i = 0;
+  while ((i = haystack.indexOf(needle, i)) !== -1) {
+    indices.push(i);
+    i += needle.length;
+  }
+  return indices;
+}
+
 describe('QF-20260509-LEO-CREATE-CLAIM-PIN: leo-create-sd.js never writes non-null claiming_session_id', () => {
-  it('TS-1: source contains exactly one occurrence of `claiming_session_id`', () => {
+  it('TS-1: source contains exactly two occurrences of `claiming_session_id` (the QF-row write + its recovery-text echo)', () => {
     const matches = SOURCE.match(/claiming_session_id/g) || [];
-    // The single allowed occurrence is the QF-row NULL escalation (current line ~509).
-    // If this count grows, FR-2/3/4 below must be updated to bracket the new sites.
-    expect(matches.length).toBe(1);
+    // Occurrence 1: the QF-row NULL escalation write (inside the withRetry-wrapped update).
+    // Occurrence 2: the manual-recovery SQL text inside createFromQF's thrown Error message
+    // (SD-LEO-INFRA-QF-SD-ESCALATION-LINK-CANONICAL-TRACK-001 FR-2) — a string literal
+    // describing recovery for a human, not code that writes to the DB.
+    // If this count grows further, TS-2/3/4 below must be updated to bracket the new sites.
+    expect(matches.length).toBe(2);
   });
 
-  it('TS-2: the single occurrence sets the value to literal `null` (NOT a session/process expression)', () => {
-    // Match `claiming_session_id` followed by `:` and (optionally whitespace) then `null`
-    // within the next ~50 chars. Anything else (e.g. `: sessionId`, `: process.env.X`,
-    // `: getSessionId()`, etc.) fails this assertion.
-    const idx = SOURCE.indexOf('claiming_session_id');
-    expect(idx).toBeGreaterThan(-1);
-    const window = SOURCE.slice(idx, idx + 60);
-    // Must be `claiming_session_id: null` (allowing whitespace variants).
-    expect(window).toMatch(/^claiming_session_id\s*:\s*null\b/);
+  it('TS-2: every occurrence sets the value to literal `null`/`NULL` (NOT a session/process expression)', () => {
+    // Match `claiming_session_id` followed by `:` or `=` and (optionally whitespace) then
+    // null/NULL within the next ~50 chars. Anything else (e.g. `: sessionId`,
+    // `: process.env.X`, `: getSessionId()`, etc.) fails this assertion.
+    const indices = allIndicesOf(SOURCE, 'claiming_session_id');
+    expect(indices.length).toBe(2);
+    for (const idx of indices) {
+      const window = SOURCE.slice(idx, idx + 60);
+      expect(window).toMatch(/^claiming_session_id\s*[:=]\s*null\b/i);
+    }
   });
 
   it('TS-3: no `claiming_session_id` reference appears within 200 chars of `strategic_directives_v2`', () => {
     // Defense-in-depth: rule out any stealth INSERT/UPDATE to strategic_directives_v2
-    // that includes claiming_session_id. The current single occurrence is in the QF
-    // path (quick_fixes table), nowhere near strategic_directives_v2.
-    const sdvIndices = [];
-    let i = 0;
-    while ((i = SOURCE.indexOf('strategic_directives_v2', i)) !== -1) {
-      sdvIndices.push(i);
-      i += 'strategic_directives_v2'.length;
-    }
+    // that includes claiming_session_id (or recovery text implying one). Both occurrences
+    // are in the QF path (quick_fixes table), nowhere near strategic_directives_v2.
+    const sdvIndices = allIndicesOf(SOURCE, 'strategic_directives_v2');
     expect(sdvIndices.length).toBeGreaterThan(0); // sanity — file does reference the table
 
-    const claimIdx = SOURCE.indexOf('claiming_session_id');
-    expect(claimIdx).toBeGreaterThan(-1);
+    const claimIndices = allIndicesOf(SOURCE, 'claiming_session_id');
+    expect(claimIndices.length).toBe(2);
 
-    // Check distance from each strategic_directives_v2 reference to the claim site
+    // Check distance from each strategic_directives_v2 reference to each claim site
     for (const sdvIdx of sdvIndices) {
-      const distance = Math.abs(sdvIdx - claimIdx);
-      expect(distance).toBeGreaterThan(200);
+      for (const claimIdx of claimIndices) {
+        const distance = Math.abs(sdvIdx - claimIdx);
+        expect(distance).toBeGreaterThan(200);
+      }
     }
   });
 
-  it('TS-4: no propagation pattern from CLAUDE_SESSION_ID env into claiming_session_id', () => {
+  it('TS-4: no propagation pattern from CLAUDE_SESSION_ID env into claiming_session_id (either occurrence)', () => {
     // Pattern catches `claiming_session_id: process.env.CLAUDE_SESSION_ID`,
     // `claiming_session_id: ... CLAUDE_SESSION_ID`, etc.
     // This is the literal pattern called out by feedback 4c2b2e1a (sub-process node
     // identity bleeds into the SD claim).
-    const claimIdx = SOURCE.indexOf('claiming_session_id');
-    if (claimIdx === -1) return; // already covered by TS-1
-    const window = SOURCE.slice(claimIdx, claimIdx + 200);
-    expect(window).not.toMatch(/CLAUDE_SESSION_ID/);
-    expect(window).not.toMatch(/process\.env/);
-    expect(window).not.toMatch(/sessionId/);
-    expect(window).not.toMatch(/getSession/);
+    const claimIndices = allIndicesOf(SOURCE, 'claiming_session_id');
+    if (claimIndices.length === 0) return; // already covered by TS-1
+    for (const claimIdx of claimIndices) {
+      const window = SOURCE.slice(claimIdx, claimIdx + 200);
+      expect(window).not.toMatch(/CLAUDE_SESSION_ID/);
+      expect(window).not.toMatch(/process\.env/);
+      expect(window).not.toMatch(/sessionId/);
+      expect(window).not.toMatch(/getSession/);
+    }
   });
 
   it('TS-5: source does not import a session-claim helper that could write claiming_session_id', () => {

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -52,6 +52,7 @@ import {
 } from './modules/plan-archiver.js';
 import { runTriageGate } from './modules/triage-gate.js';
 import { evaluateVisionReadiness, formatRubricResult } from './modules/vision-readiness-rubric.js';
+import { withRetry } from '../lib/eva/stage-zero/data-pollers/retry.js';
 import { scoreSD } from './eva/vision-scorer.js';
 import { trackWriteSource } from '../lib/eva/cli-write-gate.js';
 // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 (FR-5) + SD-FDBK-INFRA-KEY-GENERATOR-LEAKS-001:
@@ -731,6 +732,7 @@ async function createFromQF(qfId, opts = {}) {
     metadata: {
       source: 'quick_fix',
       source_qf_id: qf.id,
+      escalated_from_qf: qf.id,
       qf_type: qf.type,
       qf_severity: qf.severity,
       qf_estimated_loc: qf.estimated_loc,
@@ -739,23 +741,32 @@ async function createFromQF(qfId, opts = {}) {
     }
   });
 
-  // Mark the QF as escalated and release any active claim so the queue/parallel sessions
-  // see the new state. Failure here is non-fatal — the SD exists and operator can reconcile.
-  const { error: updErr } = await supabase
-    .from('quick_fixes')
-    .update({
-      status: 'escalated',
-      escalated_to_sd_id: sd.id,
-      escalation_reason: `Escalated to ${sdKey} via leo-create-sd.js --from-qf`,
-      claiming_session_id: null
-    })
-    .eq('id', qf.id);
+  // Retire the QF so it stops being independently claimable now that the SD is the
+  // canonical track. supabase-js does not throw on a write error, so the wrapped fn
+  // must throw explicitly for withRetry's catch to see it. A transient failure here
+  // (after the SD already exists) would otherwise leave the QF silently claimable
+  // alongside an unlinked SD — fail loud with recovery instructions instead.
+  try {
+    await withRetry(async () => {
+      const { error: updErr } = await supabase
+        .from('quick_fixes')
+        .update({
+          status: 'escalated',
+          escalated_to_sd_id: sd.id,
+          escalation_reason: `Escalated to ${sdKey} via leo-create-sd.js --from-qf`,
+          claiming_session_id: null
+        })
+        .eq('id', qf.id);
+      if (updErr) throw new Error(updErr.message);
+    }, { maxRetries: 2, baseDelayMs: 250, timeoutMs: 5000, label: `retire QF ${qf.id}` });
 
-  if (updErr) {
-    console.warn(`   ⚠️  SD created but QF row update failed: ${updErr.message}`);
-    console.warn(`      Manually run: UPDATE quick_fixes SET status='escalated', escalated_to_sd_id='${sd.id}' WHERE id='${qf.id}';`);
-  } else {
     console.log(`   ✓ Quick-fix ${qf.id} → status='escalated', escalated_to_sd_id=${sd.id}`);
+  } catch (updErr) {
+    throw new Error(
+      `SD ${sdKey} (${sd.id}) was created, but retiring quick-fix ${qf.id} failed after 3 attempts: ${updErr.message}\n` +
+      'The QF is still claimable and NOT linked back to the SD. Manual recovery — run:\n' +
+      `  UPDATE quick_fixes SET status='escalated', escalated_to_sd_id='${sd.id}', escalation_reason='Escalated to ${sdKey} via leo-create-sd.js --from-qf (manual recovery)', claiming_session_id=NULL WHERE id='${qf.id}';`
+    );
   }
 
   return sd;

--- a/tests/rank-items.test.js
+++ b/tests/rank-items.test.js
@@ -339,6 +339,22 @@ describe('rankItems — Phase 3 Quick Fix interleaving', () => {
     const allIds = [...tracks.A, ...tracks.B, ...tracks.C, ...tracks.STANDALONE].map(x => x.id);
     assert.deepEqual(allIds, ['QF-OPEN']);
   });
+
+  // SD-LEO-INFRA-QF-SD-ESCALATION-LINK-CANONICAL-TRACK-001 FR-3: named regression case —
+  // a QF escalated to a companion SD (status='escalated') must never be ranked alongside
+  // that SD, so the same fix can't end up on two independently-claimable belt tracks.
+  it('QF escalated to a companion SD (status=escalated) is filtered out; only the SD remains ranked', () => {
+    const items = [
+      qf({ id: 'QF-ESCALATED', status: 'escalated' }),
+      qf({ id: 'QF-IN-PROGRESS', status: 'in_progress' }),
+      sd({ id: 'SD-CANONICAL', status: 'draft' }),
+    ];
+    const { tracks } = rankItems(items, { now: NOW });
+    const allIds = [...tracks.A, ...tracks.B, ...tracks.C, ...tracks.STANDALONE].map(x => x.id);
+    assert.ok(!allIds.includes('QF-ESCALATED'), 'escalated QF must not appear on any track');
+    assert.ok(allIds.includes('QF-IN-PROGRESS'), 'in_progress QF should still be ranked');
+    assert.ok(allIds.includes('SD-CANONICAL'), 'the canonical SD should still be ranked');
+  });
 });
 
 // SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 FR-5: venture-build queue isolation.

--- a/tests/unit/eva/qf-sd-escalation-retry.test.js
+++ b/tests/unit/eva/qf-sd-escalation-retry.test.js
@@ -1,0 +1,56 @@
+// SD-LEO-INFRA-QF-SD-ESCALATION-LINK-CANONICAL-TRACK-001 (FR-2)
+// createFromQF() in scripts/leo-create-sd.js is unexported, so its retry wiring
+// is verified via source-text assertions in
+// tests/unit/harness/leo-create-flags-parity.test.js. This file behaviorally
+// verifies the underlying withRetry() primitive it composes: a transient
+// failure recovers, and an exhausted retry budget propagates the last error
+// (the exact two behaviors FR-2 depends on).
+
+import { describe, it, expect, vi } from 'vitest';
+import { withRetry } from '../../../lib/eva/stage-zero/data-pollers/retry.js';
+
+describe('withRetry — QF retirement hardening primitive (FR-2)', () => {
+  it('recovers when the wrapped fn fails on the first attempts and succeeds later', async () => {
+    let attempts = 0;
+    const fn = vi.fn(async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error(`transient failure #${attempts}`);
+      return { ok: true };
+    });
+
+    const result = await withRetry(fn, { maxRetries: 2, baseDelayMs: 1, timeoutMs: 1000, logger: { log: () => {} } });
+
+    expect(result).toEqual({ ok: true });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the last error once the retry budget is exhausted, without retrying a 4th time', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('permanent failure');
+    });
+
+    await expect(
+      withRetry(fn, { maxRetries: 2, baseDelayMs: 1, timeoutMs: 1000, logger: { log: () => {} } })
+    ).rejects.toThrow('permanent failure');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('a Supabase-style {error} response must be thrown explicitly to be retried (supabase-js does not throw on its own)', async () => {
+    let attempts = 0;
+    const fakeSupabaseUpdate = async () => {
+      attempts += 1;
+      if (attempts < 2) return { error: { message: 'connection reset' } };
+      return { error: null };
+    };
+
+    const wrapped = async () => {
+      const { error } = await fakeSupabaseUpdate();
+      if (error) throw new Error(error.message);
+    };
+
+    await expect(
+      withRetry(wrapped, { maxRetries: 2, baseDelayMs: 1, timeoutMs: 1000, logger: { log: () => {} } })
+    ).resolves.toBeUndefined();
+    expect(attempts).toBe(2);
+  });
+});

--- a/tests/unit/harness/leo-create-flags-parity.test.js
+++ b/tests/unit/harness/leo-create-flags-parity.test.js
@@ -73,6 +73,52 @@ describe('QF-20260509-LEO-CREATE-FLAGS: review flags sibling parity across creat
     });
   });
 
+  describe('--from-qf bidirectional link + hardened retirement (SD-LEO-INFRA-QF-SD-ESCALATION-LINK-CANONICAL-TRACK-001)', () => {
+    it('createFromQF metadata includes escalated_from_qf pointing back at the source QF id', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const body = src.slice(idx, idx + 3000);
+      expect(body).toMatch(/escalated_from_qf:\s*qf\.id/);
+    });
+
+    it('createFromQF never writes a metadata field on quick_fixes (no metadata column exists on that table)', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const end = src.indexOf('\nasync function', idx + 1);
+      const body = src.slice(idx, end > 0 ? end : idx + 4000);
+      const qfUpdateIdx = body.indexOf("status: 'escalated',");
+      expect(qfUpdateIdx).toBeGreaterThan(-1);
+      const updateBlock = body.slice(qfUpdateIdx, qfUpdateIdx + 200);
+      expect(updateBlock).not.toMatch(/metadata:/);
+    });
+
+    it('the QF retirement write is wrapped in withRetry rather than a single best-effort attempt', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const body = src.slice(idx, idx + 4000);
+      expect(body).toMatch(/await withRetry\(async \(\) => \{/);
+      expect(body).toMatch(/maxRetries:\s*2/);
+    });
+
+    it('withRetry is imported from the shared retry utility', () => {
+      expect(src).toMatch(/import \{ withRetry \} from ['"]\.\.\/lib\/eva\/stage-zero\/data-pollers\/retry\.js['"]/);
+    });
+
+    it('exhausted retries throw an Error naming the already-created SD key and a manual recovery UPDATE', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const body = src.slice(idx, idx + 4500);
+      const catchIdx = body.indexOf('} catch (updErr) {');
+      expect(catchIdx).toBeGreaterThan(-1);
+      const catchBlock = body.slice(catchIdx, catchIdx + 700);
+      expect(catchBlock).toMatch(/throw new Error\(/);
+      expect(catchBlock).toMatch(/SD \$\{sdKey\}/);
+      expect(catchBlock).toMatch(/UPDATE quick_fixes SET status='escalated'/);
+    });
+
+    it('the wrapped update fn throws explicitly on a Supabase error (supabase-js does not throw on its own)', () => {
+      const idx = src.indexOf('async function createFromQF');
+      const body = src.slice(idx, idx + 4000);
+      expect(body).toMatch(/if\s*\(updErr\)\s*throw new Error\(updErr\.message\);/);
+    });
+  });
+
   describe('direct-args mode', () => {
     it('knownDirectFlags Set includes --migration-reviewed / --security-reviewed / --yes / -y', () => {
       const idx = src.indexOf('const knownDirectFlags = new Set');


### PR DESCRIPTION
## Summary
- `leo-create-sd.js --from-qf` now writes `metadata.escalated_from_qf` on the new SD (the existing `source_qf_id` key was write-only and never read anywhere)
- The QF-side retirement write is wrapped in `withRetry` (3 attempts, short backoff) and throws loudly with the SD key + a manual-recovery `UPDATE` on exhausted retries, instead of a silent `console.warn` — closes a live race where a transient DB error left an escalated QF still fully claimable alongside its own unlinked SD
- Deliberately does NOT add `QF.metadata.superseded_by_sd` as originally proposed: `quick_fixes` has no `metadata` column (schema-verified; PR #3606 already reverted an identical mistake on this exact table) — the existing, already-consumed `escalated_to_sd_id` FK column is the correct QF-side pointer
- Adds a named regression case (`status='escalated'`) locking in that an escalated QF is excluded from every belt/claim track — this already worked generically via the existing status filter, but nothing named the case explicitly

## Test plan
- [x] `node --test tests/rank-items.test.js` — 28/28 passing, including new FR-3 case
- [x] `npx vitest run tests/unit/eva/qf-sd-escalation-retry.test.js tests/unit/harness/leo-create-flags-parity.test.js` — 19/19 passing
- [x] Representative sample of 5 other `leo-create-sd.js` consumer test files — 47/47 passing, no regressions from the new top-level import
- [x] `node --check scripts/leo-create-sd.js` — syntax OK
- [x] `npx eslint` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)