### PR TITLE
docs: singleton relaunch pipeline (A->B->C) + handoff_memory pattern

### DIFF
--- a/docs/06_deployment/singleton-relaunch.md
+++ b/docs/06_deployment/singleton-relaunch.md
@@ -1,0 +1,65 @@
+---
+category: deployment
+status: approved
+version: 1.0.0
+author: Claude (SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001)
+last_updated: 2026-07-02
+tags: [deployment, singleton, relaunch, adam, solomon, coordinator]
+---
+# Singleton Relaunch Pipeline (A → B → C)
+
+A singleton role-session (Adam, Solomon, the coordinator) can accumulate a stale git
+checkout over a long-lived run. This pipeline lets a singleton relaunch itself onto a
+fresh checkout without a double-registration window or losing in-flight reasoning
+context. Delivered across three children of
+`SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001`.
+
+## Pipeline
+
+1. **001-A — Trigger + scheduler.** Consumes the `checkoutFreshness` stale-tree gauge
+   (`lib/governance/checkout-freshness.js`). Gates on fleet-quiescence and the target
+   singleton's own `loop_state` (fail-closed unless `awaiting_tick`/`exited`), then
+   persists an idempotent, flag-gated schedule row to `session_coordination` for B/C to
+   pick up.
+2. **001-B — Fresh-checkout relaunch + handoff memory** (this doc's primary subject).
+   - `lib/singleton-relaunch.js` (`relaunchOntoFreshCheckout`) creates a fresh `ADHOC`
+     worktree via `createWorkTypeWorktree` and verifies it against `origin/main` via
+     `checkoutFreshness`, throwing on `STALE-CRITICAL`. Scope boundary: this module never
+     touches registration/retirement/removal — that's 001-C.
+   - `lib/coordinator/handoff-memory.cjs` + `handoff-memory-store.cjs` let a relaunching
+     singleton persist in-flight state that isn't already DB-backed (a reply it owed, a
+     mid-reasoning consult) before it hands off, and the successor read it back. Same
+     shape as the existing `working_context` RPC pattern — see
+     `docs/protocol/coordinator-adam-comms.md` for the sibling-key convention.
+   - `scripts/singleton-relaunch-restore.cjs` — CLI a fresh session runs after relaunch:
+     `node scripts/singleton-relaunch-restore.cjs --predecessor-session-id <id>` prints the
+     predecessor's normalized `handoff_memory`. Never throws (exits 0 always) so it's safe
+     to shell out to during startup.
+   - `scripts/adam-restart.cjs` gained an optional **RELAUNCH** step (`deps.relaunch`)
+     between the existing FRESHNESS and REGENERATE steps — a no-op when `deps.relaunch` is
+     absent, so the extension is fully backward compatible.
+3. **001-C — Register-then-retire sequencer.**
+   `lib/coordinator/singleton-refresh-sequencer.cjs` (`sequenceSingletonRefresh`) enforces
+   new-session-healthy-before-old-session-retired: the new session must register and pass
+   a health check before the old one is retired, so there is never a zero-singleton
+   window or a double-registration window. Reuses `worktree-manager.js`'s guarded removal
+   and the existing `released_at`/`released_reason` columns. Deliberately unconsumed by
+   001-B — 001-B builds the relaunch mechanism; wiring `sequenceSingletonRefresh()` as the
+   caller is a separate, explicit integration step.
+
+## Persistence
+
+- `set_session_handoff_memory(p_session_id, p_hm)` — chairman-gated migration
+  (`database/migrations/20260702_set_session_handoff_memory.sql`), atomic
+  `metadata || jsonb_build_object('handoff_memory', p_hm)`, `EXECUTE` revoked from
+  `PUBLIC, anon, authenticated` (server callers use `service_role`, unaffected). Fail-soft:
+  when unapplied, the JS writer returns `{persisted:false, reason:'rpc_absent'}` and never
+  falls back to an unsafe read-modify-write.
+
+## Operational notes
+
+- The RELAUNCH step in `adam-restart.cjs` is fail-soft — a `deps.relaunch` throw is
+  recorded (`warn: fail-soft: ...`) but does not abort the restart sequence.
+- `relaunchOntoFreshCheckout` throwing on `STALE-CRITICAL` is intentional: relaunching
+  onto a checkout that's already critically behind `origin/main` defeats the purpose of
+  the relaunch.

--- a/docs/protocol/coordinator-adam-comms.md
+++ b/docs/protocol/coordinator-adam-comms.md
@@ -209,6 +209,13 @@ RECEIPT LATENCY; this fixes PRESENCE/ACKNOWLEDGMENT/BACKCHANNEL.
   `working_context` RPC already fixed once for this table). Fail-soft: if the chairman-gated
   migration is unapplied, the writer reports `rpc_absent` and does nothing — never an unsafe RMW
   fallback.
+- **Handoff memory** — a sibling pattern to `working_context`, but scoped to a singleton
+  *relaunching* onto a fresh checkout rather than an active session's rolling state:
+  `lib/coordinator/handoff-memory.cjs` normalizes items (`consult`/`directive`/`reply_owed`/
+  `reasoning_context`); `lib/coordinator/handoff-memory-store.cjs` persists them via the same
+  atomic-merge RPC shape (`set_session_handoff_memory`, `metadata || jsonb_build_object(...)`),
+  never a JS read-modify-write. The successor session reads the predecessor's row via
+  `scripts/singleton-relaunch-restore.cjs`. See `docs/06_deployment/singleton-relaunch.md`.
 
 **Wired consumers:** `scripts/adam-advisory.cjs status` and `scripts/solomon-advisory.cjs status`
 (identical subcommand, same shared helper — no per-role reimplementation) print the target's

--- a/docs/protocol/coordinator-solomon-comms.md
+++ b/docs/protocol/coordinator-solomon-comms.md
@@ -36,6 +36,8 @@ The consult is routed by the Phase-B/D triage SSOT (`lib/coordinator/solomon-tri
 
 Solomon is a singleton role-session (like the coordinator and Adam). `solomon-register.cjs` enforces single-Solomon (refuse-new-on-fresh-prior; retire only a STALE prior) and re-targets a retired prior's unread inbound to the new session (`drainSolomonOutbound`, idempotent). Identity is keyed on `metadata.role='solomon'` + `metadata.solomon_since` via the atomic `set_solomon_flag`/`clear_solomon_flag` RPCs.
 
+For the fresh-checkout relaunch pipeline (stale-tree trigger → fresh worktree + handoff-memory restore → register-then-retire sequencing), see `docs/06_deployment/singleton-relaunch.md`.
+
 ## Presence + grounding signals
 
 Solomon's `status` verb (`node scripts/solomon-advisory.cjs status [--working "<body>" [--eta <ms>]]`)


### PR DESCRIPTION
## Summary
- Post-completion `/document` pass for SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001 (children A/B/C).
- Adds `docs/06_deployment/singleton-relaunch.md` describing the trigger → fresh-checkout relaunch + handoff-memory → register-then-retire sequencer pipeline.
- Cross-references from `docs/protocol/coordinator-adam-comms.md` (handoff_memory as a sibling of the existing `working_context` RPC pattern) and `docs/protocol/coordinator-solomon-comms.md` ("Singleton + handoff" section).

Docs-only change, zero code/behavior impact.

## Test plan
- [x] N/A — documentation only, no executable code changed
- [x] Cross-referenced file paths/function names verified against the actual shipped code (PR #5395)

🤖 Generated with [Claude Code](https://claude.com/claude-code)