### PR TITLE
fix(SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001): DB trigger + backfill + template fix for sub-agent evidence path corruption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 5d1f7001d4898e84 -->
+<!-- file_content_hash: 11782329cecd1686 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-07-02 8:26:21 PM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-07-02 9:46:58 AM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 92177eea35ba55fe -->
+<!-- file_content_hash: 7e3c5a729fe09aa1 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: 8ca793a57ccca10b -->
+<!-- file_content_hash: dbf9fdb6e7594312 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: a084c69768b28ace -->
+<!-- file_content_hash: cdd2703764071638 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: 0337c0dc55c41047 -->
+<!-- file_content_hash: de4246932c7cbb54 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: a29a19efc7dcc71e -->
+<!-- file_content_hash: b70bc7299aacf8c2 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: ee3024533c1b4e53 -->
+<!-- file_content_hash: 283b3f3b7c47726a -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-07-02 8:26:21 PM*
+*DIGEST generated: 2026-07-02 9:46:58 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: 479ee6bb55457dbd -->
+<!-- file_content_hash: 76ec714210bb0c0d -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -160,5 +160,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-07-02 8:26:21 PM*
+*DIGEST generated: 2026-07-02 9:46:58 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 77c6d75dd64170f4 -->
+<!-- file_content_hash: b9984f4bf6a39c1a -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: adf97b35572fe0cf -->
+<!-- file_content_hash: 35fc9f16564575fc -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-07-02 8:26:21 PM*
+*DIGEST generated: 2026-07-02 9:46:58 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 44f81c5b731862a3 -->
+<!-- file_content_hash: 711c9059fd9186a0 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -147,6 +147,8 @@ Claude: "Found existing user preferences in the EHG app. Let me now run formal v
 
 Task(subagent_type="validation-agent", prompt="Execute VALIDATION analysis for SD-XXX...")
 ```
+
+> **Evidence persistence**: sub-agents MUST persist `sub_agent_execution_results` rows via `node scripts/store-sub-agent-repo-evidence.js <SD-ID> <SUB-AGENT-CODE> --content @results.json` (QF-20260702-679) or the canonical `lib/sub-agents/resolve-repo.js` helpers — NEVER hand-type a Windows path literal inside an inline `node -e`/heredoc INSERT statement. The JS string-escape parser silently corrupts backslash sequences before the value ever reaches the database (e.g. `\U`, `\P`, `\_`, `\E` are dropped as unrecognized escapes; `\r` becomes a literal embedded carriage-return control byte).
 
 ## SD to Quick Fix Reverse Rubric (LEO v4.3.3)
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: b73cb016c95d3a55 -->
+<!-- file_content_hash: f392734caa68f2c2 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-07-02 8:26:21 PM*
+*DIGEST generated: 2026-07-02 9:46:58 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 026f24c7b4482849 -->
+<!-- file_content_hash: 75379ccbaeb2a5a1 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -137,6 +137,8 @@ Launch 1-3 Plan agents based on complexity:
 
 Do NOT launch 3 agents for every task—that wastes time on simple decisions.
 > Why: Three perspectives costs 3× the context. For a decision where the answer is clear, the extra agents produce noise without signal. Match the number of perspectives to the actual uncertainty in the decision.
+
+> **Evidence persistence**: sub-agents MUST persist `sub_agent_execution_results` rows via `node scripts/store-sub-agent-repo-evidence.js <SD-ID> <SUB-AGENT-CODE> --content @results.json` (QF-20260702-679) or the canonical `lib/sub-agents/resolve-repo.js` helpers — NEVER hand-type a Windows path literal inside an inline `node -e`/heredoc INSERT statement. The JS string-escape parser silently corrupts backslash sequences before the value ever reaches the database (e.g. `\U`, `\P`, `\_`, `\E` are dropped as unrecognized escapes; `\r` becomes a literal embedded carriage-return control byte).
 
 ## Friction signaling
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: e6c75cfee54cf996 -->
+<!-- file_content_hash: 604294b224e018b7 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-07-02 8:26:21 PM*
+*DIGEST generated: 2026-07-02 9:46:58 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 0288b805167f4467 -->
+<!-- file_content_hash: f6d719c429268072 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-07-02 8:26:21 PM
+**Generated**: 2026-07-02 9:46:58 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-02T00:26:21.321Z -->
-<!-- git_commit: 0a7a703f -->
+<!-- generated_at: 2026-07-02T13:46:58.449Z -->
+<!-- git_commit: 6541c213 -->
 <!-- db_snapshot_hash: 8eb2912b9dff05a2 -->
-<!-- file_content_hash: c9e3fdf9b8ad15b4 -->
+<!-- file_content_hash: f4eea194e552aec9 -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,123 +1,123 @@
 {
-  "generated_at": "2026-07-02T00:26:21.321Z",
-  "git_commit": "0a7a703f",
+  "generated_at": "2026-07-02T13:46:58.449Z",
+  "git_commit": "6541c213",
   "db_snapshot_hash": "8eb2912b9dff05a2",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 19368,
       "estimated_tokens": 4842,
-      "content_hash": "fe524d6234f9fd45",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE.md"
+      "content_hash": "71cae0605084f3b3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 86703,
       "estimated_tokens": 21676,
-      "content_hash": "0a4c70ad684628b2",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_CORE.md"
+      "content_hash": "917ed70f6e94c4ad",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 65401,
-      "estimated_tokens": 16351,
-      "content_hash": "8a77138e5f17e5be",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_LEAD.md"
+      "chars": 65998,
+      "estimated_tokens": 16500,
+      "content_hash": "003d77824ad67372",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 91103,
-      "estimated_tokens": 22776,
-      "content_hash": "fabf2c15190e0ad0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_PLAN.md"
+      "chars": 91700,
+      "estimated_tokens": 22925,
+      "content_hash": "33b38381fefbbe97",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 86566,
       "estimated_tokens": 21642,
-      "content_hash": "eaf76fd504cae816",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_EXEC.md"
+      "content_hash": "d9bf368da6531394",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
       "chars": 54280,
       "estimated_tokens": 13570,
-      "content_hash": "32f68af91433a676",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_ADAM.md"
+      "content_hash": "3634cc3252d1834e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
       "chars": 21735,
       "estimated_tokens": 5434,
-      "content_hash": "9e8af0f3366d526d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_COORDINATOR.md"
+      "content_hash": "50a107ca12c6ebfa",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
       "chars": 44862,
       "estimated_tokens": 11216,
-      "content_hash": "4725ff2a8748c883",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_SOLOMON.md"
+      "content_hash": "db8faa25718f8d00",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 9611,
       "estimated_tokens": 2403,
-      "content_hash": "10e6f0c1643ad22b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_DIGEST.md"
+      "content_hash": "a7c5cd04f78daef4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 11664,
       "estimated_tokens": 2916,
-      "content_hash": "eaa746407a216c7c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "5339238c989e5665",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 5551,
       "estimated_tokens": 1388,
-      "content_hash": "fac465e491ae6684",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "d0a0035900d9a7f2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 8541,
       "estimated_tokens": 2136,
-      "content_hash": "9301627bc4f6619c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "fb650cebe0174e84",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 10964,
       "estimated_tokens": 2741,
-      "content_hash": "b40d2d1a3eab9be5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "2058e4cff92be2d4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 13068,
       "estimated_tokens": 3267,
-      "content_hash": "88878b3b45f0613d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "759ca4aa05a8098f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 6076,
       "estimated_tokens": 1519,
-      "content_hash": "9cb2dd242215b64a",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "d3d1f80900ac415f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
       "chars": 4705,
       "estimated_tokens": 1177,
-      "content_hash": "e248da694c6acf83",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-A\\CLAUDE_SOLOMON_DIGEST.md"
+      "content_hash": "7476ceb4db2e949d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "105af1849ea00016",
+    "global": "780f36abe5cf5047",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -200,8 +200,8 @@
       "287": "9cd7f602ff4fecd8",
       "288": "c7f7324a8090c87e",
       "289": "38e17ba9d7a8d144",
-      "290": "ecc81495351e7611",
-      "291": "12e28b9bffda36db",
+      "290": "1185719c66c3e85c",
+      "291": "4ca45c0da7371419",
       "292": "3af0fb5d3a3e5774",
       "293": "8a5a7eb0b9a694f9",
       "294": "9bfc656114c59db0",

--- a/database/migrations/20260702_subagent_evidence_control_char_trigger.sql
+++ b/database/migrations/20260702_subagent_evidence_control_char_trigger.sql
@@ -1,0 +1,79 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 (FR-2)
+--
+-- BLOCKING (RAISE EXCEPTION) before-insert-or-update trigger on
+-- sub_agent_execution_results. Unlike the advisory-only precedent in
+-- 20260702_session_coordination_insert_lint.sql (RAISE NOTICE, never rejects),
+-- this trigger REJECTS the write outright when a control character is found in
+-- any of:
+--   1. NEW.metadata->>'repo_path'
+--   2. NEW.metadata->>'executed_from_cwd'
+--   3. NEW.executed_from_cwd (top-level column, distinct from metadata.executed_from_cwd)
+--
+-- Rationale: Windows path literals (e.g. C:\Users\rickf\Projects\_EHG\...) get
+-- hand-typed inline into JS/shell INSERT scripts. When that literal passes through
+-- JS string-escape parsing before ever reaching the DB, backslash sequences like
+-- \U, \P, \_, \E are silently DROPPED because they are not recognized JS escapes
+-- (the backslash disappears, corrupting the path) -- while \r IS a recognized JS
+-- escape and gets converted into a literal embedded carriage-return control byte.
+-- Both failure modes produce a path string that looks superficially plausible but
+-- is silently wrong, and the corrupted evidence row then fails (or worse, falsely
+-- passes) the SUB_AGENT_REPO_RESOLUTION gate's repo_path comparison. Rejecting at
+-- the DB layer catches every producer regardless of code path, rather than relying
+-- on each caller to sanitize correctly.
+--
+-- Tab (\x09) is intentionally excluded from the reject class (all other C0 control
+-- characters, including newline \x0A and carriage-return \x0D, ARE rejected): reject
+-- class = [\x00-\x08\x0A-\x1F]. Windows paths never legitimately contain any control
+-- character, so this is a strict reject with no false-positive risk for valid evidence.
+-- QF-review fix: an earlier draft of this regex ([\x00-\x08\x0B-\x1F]) accidentally
+-- excluded \x0A (newline) alongside tab, which would have let a `\node_modules`-style
+-- corrupted path (\n JS-escaped into a literal LF) bypass this "BLOCKING" guard --
+-- exactly the class of silent corruption this trigger exists to catch.
+
+CREATE OR REPLACE FUNCTION reject_control_chars_in_subagent_evidence()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.metadata->>'repo_path' ~ '[\x00-\x08\x0A-\x1F]' THEN
+    RAISE EXCEPTION
+      'reject_control_chars_in_subagent_evidence: control character detected in metadata.repo_path (id=%). '
+      'Windows path literals hand-typed into JS/shell INSERT scripts get silently corrupted by JS '
+      'string-escape parsing before reaching the DB (\U/\P/\_/\E dropped, \r becomes a literal CR byte).',
+      NEW.id;
+  END IF;
+
+  IF NEW.metadata->>'executed_from_cwd' ~ '[\x00-\x08\x0A-\x1F]' THEN
+    RAISE EXCEPTION
+      'reject_control_chars_in_subagent_evidence: control character detected in metadata.executed_from_cwd (id=%). '
+      'Windows path literals hand-typed into JS/shell INSERT scripts get silently corrupted by JS '
+      'string-escape parsing before reaching the DB (\U/\P/\_/\E dropped, \r becomes a literal CR byte).',
+      NEW.id;
+  END IF;
+
+  IF NEW.executed_from_cwd ~ '[\x00-\x08\x0A-\x1F]' THEN
+    RAISE EXCEPTION
+      'reject_control_chars_in_subagent_evidence: control character detected in executed_from_cwd (id=%). '
+      'Windows path literals hand-typed into JS/shell INSERT scripts get silently corrupted by JS '
+      'string-escape parsing before reaching the DB (\U/\P/\_/\E dropped, \r becomes a literal CR byte).',
+      NEW.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION reject_control_chars_in_subagent_evidence() IS
+  'BLOCKING (RAISE EXCEPTION) guard on sub_agent_execution_results: rejects inserts/updates '
+  'where metadata.repo_path, metadata.executed_from_cwd, or the top-level executed_from_cwd '
+  'column contains a C0 control character other than tab ([\x00-\x08\x0A-\x1F]). Exists '
+  'because Windows path literals hand-typed inline in JS/shell INSERT scripts get silently '
+  'corrupted by JS string-escape parsing before ever reaching the DB: \U, \P, \_, \E are '
+  'dropped since they are not recognized JS escapes, while \r IS a recognized JS escape and '
+  'becomes a literal embedded carriage-return control byte in the stored path. '
+  'SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 (FR-2).';
+
+DROP TRIGGER IF EXISTS trg_subagent_evidence_reject_control_chars ON sub_agent_execution_results;
+CREATE TRIGGER trg_subagent_evidence_reject_control_chars
+  BEFORE INSERT OR UPDATE ON sub_agent_execution_results
+  FOR EACH ROW
+  EXECUTE FUNCTION reject_control_chars_in_subagent_evidence();

--- a/docs/reference/infrastructure-hardening-patterns.md
+++ b/docs/reference/infrastructure-hardening-patterns.md
@@ -804,6 +804,80 @@ unrelated `import.meta.url`/`process.argv[1]` usage):
 
 ---
 
+## Pattern: Sub-agent evidence rows must never hand-type Windows path literals in inline shell/JS INSERT scripts (SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001)
+
+**Symptom**: `sub_agent_execution_results.metadata->>'repo_path'`, `metadata->>'executed_from_cwd'`, and
+the separate top-level `executed_from_cwd` column intermittently contain silently-corrupted Windows
+paths — some fields corrupted while sibling fields in the SAME row stay clean, proving independent
+per-write typing rather than a deterministic code bug. Corrupted `repo_path` values silently fail the
+`SUB_AGENT_REPO_RESOLUTION` gate's exact-match comparison against `applications.local_path`, producing
+confusing gate-failure investigations (this exact bug blocked
+`SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-B` EXEC-TO-PLAN on 2026-07-02, requiring a
+manual DB fix). A live full-table scan found 63 corrupted rows out of 34,246, dated across a multi-week
+range including the day of authoring — an active, ongoing corruption class, not a historical one-off.
+
+**Root cause**: sub-agents spawned via the Task tool are told (by `leo_protocol_sections` rows that
+generate `CLAUDE_PLAN.md`'s Task-tool prompt templates) to "Store results in sub_agent_execution_results
+table" with ZERO guidance on HOW — so each spawned agent freelances its own approach, and several
+hand-typed inline `node -e "..."`/heredoc `INSERT` scripts containing literal Windows path strings (e.g.
+`"C:\Users\rickf\..."` written directly into a JS/shell string). The literal passes through JS
+string-escape parsing at PARSE TIME, before the value ever reaches the database or the canonical
+`lib/sub-agents/resolve-repo.js` writer (confirmed correct and unmodified by this SD): `\U`, `\P`, `\_`,
+`\E` are not recognized JS escapes, so the backslash is silently dropped while the letter survives; `\r`
+IS a recognized escape and becomes a literal embedded carriage-return control byte (`0x0D`) in the stored
+string. The same mechanism corrupts `\n` (embedded LF, `0x0A`) in any path containing a directory name
+starting with `n` (e.g. `\node_modules`) — a related instance this SD's own trigger regex initially
+missed (caught by an independent TESTING-perspective verification pass before the migration was applied;
+see the Files list below for the fixed version, not a since-superseded draft).
+
+**Fix**: prevention + repair, not a single patch:
+1. **A deterministic evidence-writer CLI already exists** (`scripts/store-sub-agent-repo-evidence.js`,
+   QF-20260702-679, shipped independently and reused as-is here) — it chains
+   `resolveSubAgentRepo → applySubAgentRepoVerdict → storeSubAgentResults` so evidence content comes from
+   `--content @<file>|-`, never an inline path literal. This SD does not reimplement it.
+2. **Point the leak-vector templates at it**: `leo_protocol_sections` rows `id=290`
+   (`lead_explore_integration`) and `id=291` (`plan_multi_perspective`) — the only two rows in the table
+   containing the bare "Store results in sub_agent_execution_results table" phrase — now explicitly
+   instruct agents to use the CLI and forbid hand-typed path literals. Regenerated via
+   `node scripts/generate-claude-md-from-db.js`, verified zero-drift via `check-claude-md-drift.cjs`.
+3. **DB-level BLOCKING guard** (fail-closed at the source, unlike the advisory-only
+   `session_coordination_insert_lint` precedent): `trg_subagent_evidence_reject_control_chars`
+   `RAISE EXCEPTION`s on any C0 control character except tab (`[\x00-\x08\x0A-\x1F]`) in
+   `metadata->>'repo_path'`, `metadata->>'executed_from_cwd'`, or the top-level `executed_from_cwd`
+   column — catches every producer regardless of code path, not just the ones updated in step 2.
+4. **Historical backfill**: `scripts/backfill-corrupted-subagent-repo-paths.mjs` — `repo_path` is
+   deterministically recovered via `sd_id → strategic_directives_v2.target_application →
+   applications.local_path` (the corrupted string itself is NOT algorithmically un-corruptible —
+   information is destructively lost — so recovery is a DB join, not string repair); `executed_from_cwd`
+   in both locations is set to `NULL` rather than fabricated, since the exact original worktree path is
+   unrecoverable. `--dry-run` by default; `--apply` required to write.
+
+**Verification lesson**: the migration's first draft used reject-class `[\x00-\x08\x0B-\x1F]`, intending
+to exclude only tab (`\x09`) — but the range skip from `\x08` to `\x0B` also silently excluded newline
+(`\x0A`), undermining the "BLOCKING" guarantee for exactly the corruption pattern this SD exists to catch.
+An independent TESTING-perspective verification pass (re-deriving the regex behavior live against
+Postgres rather than trusting the implementer's report) caught this before the migration was applied to
+production. Fixed to `[\x00-\x08\x0A-\x1F]` in both the SQL trigger and the JS `detectCorruption()`
+before deployment; a regression test for the newline case was added to the test suite.
+
+### PR-review checklist line
+
+> When a sub-agent (or a Task-tool prompt template) needs to persist evidence to
+> `sub_agent_execution_results`, verify it routes through `scripts/store-sub-agent-repo-evidence.js` or
+> `lib/sub-agents/resolve-repo.js` — never a hand-typed Windows path literal inside an inline
+> `node -e`/heredoc `INSERT` script. The JS string-escape parser silently corrupts backslash sequences
+> before the value ever reaches the database.
+
+### Files Modified/Created
+`database/migrations/20260702_subagent_evidence_control_char_trigger.sql` (new),
+`scripts/backfill-corrupted-subagent-repo-paths.mjs` (new),
+`tests/database/subagent-evidence-control-char-trigger.test.js` (new),
+`tests/unit/scripts/backfill-corrupted-subagent-repo-paths.test.js` (new),
+`leo_protocol_sections` rows `id=290`, `id=291` (DB content update, not a file),
+`CLAUDE_PLAN.md`, `CLAUDE_LEAD.md` (regenerated)
+
+---
+
 ## Cross-References
 
 - **Database Patterns**: [database-agent-patterns.md](./database-agent-patterns.md)
@@ -820,3 +894,4 @@ unrelated `import.meta.url`/`process.argv[1]` usage):
 | 1.1.0 | 2026-07-01 | Added Realtime subscribe-teardown class-guard pattern from SD-LEO-INFRA-REALTIME-REMOVECHANNEL-RECURSION-CLASSGUARD-001 |
 | 1.2.0 | 2026-07-01 | Added Count-delta-vs-identity-diff gate class-guard pattern from SD-LEO-INFRA-COUNT-VS-IDENTITY-GATE-CLASSGUARD-001 |
 | 1.3.0 | 2026-07-02 | Added isMainModule raw-pattern class-guard from SD-LEO-INFRA-ISMAINMODULE-WINDOWS-GUARD-CLASSFIX-001-B |
+| 1.4.0 | 2026-07-02 | Added sub-agent evidence control-character corruption pattern from SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 |

--- a/scripts/backfill-corrupted-subagent-repo-paths.mjs
+++ b/scripts/backfill-corrupted-subagent-repo-paths.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// @wire-check-exempt: one-off, human-reviewed data-repair backfill CLI — dry-run by
+// default, --apply is run manually under human/coordinator review (no production
+// caller by design). The pure logic (detectCorruption, recoverRepoPath) is unit-tested.
+/**
+ * Backfill corrupted sub_agent_execution_results.{metadata.repo_path,
+ * metadata.executed_from_cwd, executed_from_cwd} rows.
+ * SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 (FR-3).
+ *
+ * ROOT CAUSE (see the sibling FR-2 migration
+ * database/migrations/20260702_subagent_evidence_control_char_trigger.sql for the
+ * forward-fix that now REJECTS new writes): Windows path literals
+ * (e.g. C:\Users\rickf\Projects\_EHG\EHG_Engineer) hand-typed inline into a
+ * JS/shell INSERT script get corrupted when that literal passes through JS
+ * string-escape parsing before reaching the DB. Backslash sequences like \U, \P,
+ * \_, \E are silently DROPPED because they are not recognized JS escapes (the
+ * backslash disappears, e.g. "C:\Users\..." -> "C:Users..."), while \r IS a
+ * recognized JS escape and gets converted into a literal embedded
+ * carriage-return control byte (0x0D) in the stored string. Both failure modes
+ * produce a path that looks superficially plausible but is silently wrong, and
+ * corrupted evidence rows can falsely pass/fail the SUB_AGENT_REPO_RESOLUTION
+ * gate's exact-string repo_path comparison.
+ *
+ * REMEDIATION:
+ *   - metadata.repo_path IS recoverable: it must equal applications.local_path
+ *     for the SD's target_application (the same DB-first SSOT the canonical
+ *     writer `lib/sub-agents/resolve-repo.js` `applySubAgentRepoVerdict` uses),
+ *     so a fresh DB join reconstructs the correct value. recoverRepoPath() is
+ *     therefore a trivial passthrough — the real "recovery" is the join in
+ *     main(), not string manipulation, because the corrupted string has
+ *     genuinely lost information (dropped separators can't be un-dropped).
+ *   - metadata.executed_from_cwd and the top-level executed_from_cwd column are
+ *     NOT recoverable: they capture the exact worktree cwd the sub-agent ran
+ *     from, which is not derivable from any other row/column. Fabricating a
+ *     value (e.g. guessing it equals repo_path) would produce false evidence
+ *     that is indistinguishable from a genuine reading, so both are set to
+ *     NULL instead — an honest "unknown" rather than a plausible-looking lie.
+ *
+ * Only the specific field(s) that are actually flagged corrupted on a given row
+ * are touched; clean fields are left byte-identical. This also keeps every
+ * UPDATE compatible with the FR-2 BEFORE-trigger, which rejects the whole write
+ * if ANY of the three fields still contains a control character in NEW.
+ *
+ * Idempotent: re-running (including --apply twice) only ever touches rows that
+ * still fail detectCorruption(); a clean row is never re-written.
+ *
+ * Usage:
+ *   node scripts/backfill-corrupted-subagent-repo-paths.mjs           # dry-run (default, zero writes)
+ *   node scripts/backfill-corrupted-subagent-repo-paths.mjs --apply   # perform the UPDATEs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+const PAGE_SIZE = 1000;
+// C0 control characters except tab (\x09) — mirrors the FR-2 trigger's reject
+// class exactly, so "clean per this backfill" == "clean per the DB trigger".
+// (Fixed from an earlier draft that also excluded \x0A/newline by accident —
+// that gap let a `\node_modules`-style corrupted path go undetected.)
+const CONTROL_CHAR_RE = /[\x00-\x08\x0A-\x1F]/;
+
+/**
+ * Pure: does `value` contain a control character consistent with the
+ * JS-string-escape corruption described above? Non-strings (null/undefined/
+ * numbers/etc.) are never corrupted by definition and must not throw.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function detectCorruption(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return CONTROL_CHAR_RE.test(value);
+}
+
+/**
+ * Pure: "recover" a repo path. Trivial passthrough by design — the corrupted
+ * string has lost information (dropped path separators, embedded control
+ * bytes) that cannot be algorithmically un-corrupted. The actual recovery
+ * mechanism is the sd_id -> strategic_directives_v2.target_application ->
+ * applications.local_path DB join performed by main(); this function just
+ * names that final step so callers/tests have a stable seam.
+ *
+ * @param {string} correctLocalPath - applications.local_path for the row's target_application
+ * @returns {string}
+ */
+export function recoverRepoPath(correctLocalPath) {
+  return correctLocalPath;
+}
+
+/**
+ * Paginate through ALL rows of sub_agent_execution_results (no default
+ * row-limit reliance) and return only rows with a control character in
+ * metadata.repo_path, metadata.executed_from_cwd, or the top-level
+ * executed_from_cwd column, annotated with which field(s) triggered it.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} sb
+ * @returns {Promise<Array<{id:string, sd_id:string|null, metadata:object|null, executed_from_cwd:string|null, repoBad:boolean, metaCwdBad:boolean, topCwdBad:boolean}>>}
+ */
+async function scanCorruptedRows(sb) {
+  const corrupted = [];
+  let from = 0;
+  let examined = 0;
+  for (;;) {
+    const { data, error } = await sb
+      .from('sub_agent_execution_results')
+      .select('id, sd_id, metadata, executed_from_cwd')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+    if (error) throw new Error(`sub_agent_execution_results scan failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    examined += data.length;
+    for (const row of data) {
+      const repoBad = detectCorruption(row.metadata?.repo_path);
+      const metaCwdBad = detectCorruption(row.metadata?.executed_from_cwd);
+      const topCwdBad = detectCorruption(row.executed_from_cwd);
+      if (repoBad || metaCwdBad || topCwdBad) {
+        corrupted.push({ ...row, repoBad, metaCwdBad, topCwdBad });
+      }
+    }
+    if (data.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+  return { corrupted, examined };
+}
+
+/**
+ * Resolve applications.local_path for a set of sd_ids via
+ * strategic_directives_v2.target_application, batched (no N+1 per row).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} sb
+ * @param {string[]} sdIds
+ * @returns {Promise<Map<string,string>>} sd_id -> local_path (only resolvable entries)
+ */
+async function resolveLocalPathsBySdId(sb, sdIds) {
+  const result = new Map();
+  const uniqueSdIds = [...new Set(sdIds.filter(Boolean))];
+  if (uniqueSdIds.length === 0) return result;
+
+  const { data: sds, error: sdErr } = await sb
+    .from('strategic_directives_v2')
+    .select('id, target_application')
+    .in('id', uniqueSdIds);
+  if (sdErr) throw new Error(`strategic_directives_v2 lookup failed: ${sdErr.message}`);
+
+  const targetApps = [...new Set((sds || []).map((s) => s.target_application).filter(Boolean))];
+  if (targetApps.length === 0) return result;
+
+  const { data: apps, error: appErr } = await sb
+    .from('applications')
+    .select('name, local_path')
+    .in('name', targetApps);
+  if (appErr) throw new Error(`applications lookup failed: ${appErr.message}`);
+
+  const localPathByApp = new Map((apps || []).filter((a) => a.local_path).map((a) => [a.name, a.local_path]));
+  for (const sd of sds || []) {
+    const localPath = sd.target_application && localPathByApp.get(sd.target_application);
+    if (localPath) result.set(sd.id, localPath);
+  }
+  return result;
+}
+
+export async function main({ apply = false } = {}) {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[backfill-corrupted-subagent-repo-paths] SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required');
+    process.exitCode = 1;
+    return;
+  }
+  const sb = createClient(url, key);
+
+  const { corrupted, examined } = await scanCorruptedRows(sb);
+  console.log(`[backfill-corrupted-subagent-repo-paths] examined=${examined} corrupted=${corrupted.length} mode=${apply ? 'APPLY' : 'DRY-RUN'}`);
+
+  if (corrupted.length === 0) {
+    console.log('[backfill-corrupted-subagent-repo-paths] no corrupted rows found — nothing to do.');
+    return { examined, corruptedCount: 0, updated: 0, skipped: 0, failed: 0 };
+  }
+
+  const localPathBySdId = await resolveLocalPathsBySdId(sb, corrupted.map((r) => r.sd_id));
+
+  let wouldUpdate = 0;
+  let skippedUnresolvable = 0;
+  const plan = [];
+  for (const row of corrupted) {
+    const needsRepoFix = row.repoBad;
+    let newRepoPath;
+    if (needsRepoFix) {
+      const localPath = localPathBySdId.get(row.sd_id);
+      if (!localPath) {
+        // Unresolvable (missing sd_id / target_application / applications.local_path):
+        // never fabricate a repo_path. Skip the WHOLE row — a partial fix that
+        // leaves repo_path corrupted would still be rejected by the FR-2 trigger.
+        skippedUnresolvable++;
+        continue;
+      }
+      newRepoPath = recoverRepoPath(localPath);
+    }
+
+    // Only touch the columns that actually need to change — an untouched
+    // metadata/executed_from_cwd is sent as `undefined` and omitted from the
+    // update payload entirely, so a genuinely-NULL metadata column (or an
+    // already-clean cwd value) is never rewritten to `{}`/overwritten.
+    const updatePayload = {};
+    if (needsRepoFix || row.metaCwdBad) {
+      const newMetadata = { ...(row.metadata || {}) };
+      if (needsRepoFix) newMetadata.repo_path = newRepoPath;
+      if (row.metaCwdBad) newMetadata.executed_from_cwd = null;
+      updatePayload.metadata = newMetadata;
+    }
+    if (row.topCwdBad) updatePayload.executed_from_cwd = null;
+
+    wouldUpdate++;
+    plan.push({ id: row.id, sd_id: row.sd_id, updatePayload });
+  }
+
+  console.log(`[backfill-corrupted-subagent-repo-paths] resolvable=${wouldUpdate} skipped_unresolvable=${skippedUnresolvable}`);
+  console.log('[backfill-corrupted-subagent-repo-paths] sample (up to 5):');
+  for (const p of plan.slice(0, 5)) {
+    console.log(`  id=${p.id} sd_id=${p.sd_id} update=${JSON.stringify(p.updatePayload)}`);
+  }
+
+  if (!apply) {
+    console.log('\nDRY RUN — zero writes made. Re-run with --apply to perform the UPDATEs.');
+    return { examined, corruptedCount: corrupted.length, updated: 0, skipped: skippedUnresolvable, failed: 0, wouldUpdate };
+  }
+
+  let updated = 0;
+  let failed = 0;
+  for (const p of plan) {
+    const { error } = await sb
+      .from('sub_agent_execution_results')
+      .update(p.updatePayload)
+      .eq('id', p.id);
+    if (error) {
+      failed++;
+      console.error(`  ✗ id=${p.id} update failed: ${error.message}`);
+    } else {
+      updated++;
+    }
+  }
+  console.log(`[backfill-corrupted-subagent-repo-paths] APPLIED: updated=${updated} skipped_unresolvable=${skippedUnresolvable} failed=${failed}`);
+  return { examined, corruptedCount: corrupted.length, updated, skipped: skippedUnresolvable, failed };
+}
+
+if (isMainModule(import.meta.url)) {
+  const apply = process.argv.includes('--apply');
+  main({ apply }).catch((err) => {
+    console.error('[backfill-corrupted-subagent-repo-paths] fatal:', err.message);
+    process.exitCode = 1;
+  });
+}

--- a/tests/database/subagent-evidence-control-char-trigger.test.js
+++ b/tests/database/subagent-evidence-control-char-trigger.test.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 (FR-4) — trg_subagent_evidence_reject_control_chars
+ * must BLOCK (not just document) control-character corruption in sub_agent_execution_results.
+ *
+ * Live-DB integration test, gated like the other tests/database suites so CI skips cleanly
+ * without service-role creds. Every inserted row (rejected attempts never persist; the one
+ * accepted row is hard-deleted in afterAll) is a disposable fixture row this suite owns —
+ * no shared/live row is ever touched, matching the hermetic-fixture precedent established
+ * for tests/database/switch-sd-claim-guards.test.js (QF-20260702-290).
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const SUB_AGENT_CODE = 'TEST_TRIGGER_PROBE_SD_LEO_INFRA_FIX_SYSTEMIC_WINDOWS_001';
+const acceptedRowIds = [];
+
+describe.skipIf(!HAS_REAL_DB)('trg_subagent_evidence_reject_control_chars (SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 FR-2/FR-4)', () => {
+  afterAll(async () => {
+    if (acceptedRowIds.length) {
+      await supabase.from('sub_agent_execution_results').delete().in('id', acceptedRowIds);
+    }
+  });
+
+  it('rejects an INSERT with a control-char-corrupted metadata.repo_path', async () => {
+    const corrupted = 'C:/Users/rickf' + String.fromCharCode(0x0D) + 'ickf/Projects';
+    const { data, error } = await supabase.from('sub_agent_execution_results').insert({
+      sub_agent_code: SUB_AGENT_CODE, sub_agent_name: SUB_AGENT_CODE, verdict: 'PASS', confidence: 100,
+      metadata: { repo_path: corrupted },
+    }).select();
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/reject_control_chars_in_subagent_evidence/);
+    expect(error.message).toMatch(/metadata\.repo_path/);
+  });
+
+  it('rejects an INSERT with a control-char-corrupted metadata.executed_from_cwd', async () => {
+    const corrupted = 'C:/Users/rickf' + String.fromCharCode(0x01) + '/Projects';
+    const { data, error } = await supabase.from('sub_agent_execution_results').insert({
+      sub_agent_code: SUB_AGENT_CODE, sub_agent_name: SUB_AGENT_CODE, verdict: 'PASS', confidence: 100,
+      metadata: { repo_path: 'C:/Users/rickf/Projects', executed_from_cwd: corrupted },
+    }).select();
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/metadata\.executed_from_cwd/);
+  });
+
+  it('rejects an INSERT with a control-char-corrupted TOP-LEVEL executed_from_cwd column', async () => {
+    // Regression coverage: the top-level executed_from_cwd column is a SEPARATE field from
+    // metadata.executed_from_cwd, populated directly by several hand-typed one-off scripts
+    // that bypass lib/sub-agents/resolve-repo.js entirely — must be covered independently.
+    const corrupted = 'C:/Users/rickf' + String.fromCharCode(0x0A) + 'ode_modules';
+    const { data, error } = await supabase.from('sub_agent_execution_results').insert({
+      sub_agent_code: SUB_AGENT_CODE, sub_agent_name: SUB_AGENT_CODE, verdict: 'PASS', confidence: 100,
+      executed_from_cwd: corrupted,
+    }).select();
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/(?<!metadata\.)executed_from_cwd/);
+  });
+
+  it('accepts a clean INSERT with control-char-free forward-slash paths in all 3 fields', async () => {
+    const { data, error } = await supabase.from('sub_agent_execution_results').insert({
+      sub_agent_code: SUB_AGENT_CODE, sub_agent_name: SUB_AGENT_CODE, verdict: 'PASS', confidence: 100,
+      metadata: { repo_path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer', executed_from_cwd: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer' },
+      executed_from_cwd: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer',
+    }).select();
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    acceptedRowIds.push(data[0].id);
+  });
+
+  it('accepts a clean INSERT that omits metadata/executed_from_cwd entirely (no false-positive on absent fields)', async () => {
+    const { data, error } = await supabase.from('sub_agent_execution_results').insert({
+      sub_agent_code: SUB_AGENT_CODE, sub_agent_name: SUB_AGENT_CODE, verdict: 'PASS', confidence: 100,
+    }).select();
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    acceptedRowIds.push(data[0].id);
+  });
+});

--- a/tests/unit/scripts/backfill-corrupted-subagent-repo-paths.test.js
+++ b/tests/unit/scripts/backfill-corrupted-subagent-repo-paths.test.js
@@ -1,0 +1,67 @@
+/**
+ * tests/unit/scripts/backfill-corrupted-subagent-repo-paths.test.js
+ *
+ * SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 (FR-3). Coverage: the pure
+ * detectCorruption() seam only — the DB-backed main()/scan logic is exercised
+ * live via --dry-run, not unit-mocked, per this repo's convention for one-off
+ * backfill CLIs (see tests/unit/backfill-canonical-lfa.test.js for the sibling
+ * pattern: only the pure helpers get unit coverage).
+ *
+ * Named `.test.js` (not `.test.mjs`) so it is actually collected by vitest —
+ * vitest.config.js's `unit` project include is `**\/*.test.js` only; a sibling
+ * `.test.mjs` file would silently never run under `npm test`.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectCorruption } from '../../../scripts/backfill-corrupted-subagent-repo-paths.mjs';
+
+describe('detectCorruption (SD-LEO-INFRA-FIX-SYSTEMIC-WINDOWS-001 FR-3)', () => {
+  it('flags the known-corrupted sample: dropped separators + literal embedded CR byte', () => {
+    // "C:\Users\rickf\Projects\_EHG\EHG_Engineer" after JS string-escape
+    // corruption: \U \P \_ \E dropped (backslash disappears, letters stay),
+    // \r IS a recognized JS escape and becomes a literal 0x0D control byte —
+    // the `\r` below is a REAL embedded carriage-return, not the two chars
+    // backslash+r (this is the exact corrupted value observed live in
+    // sub_agent_execution_results.metadata.repo_path).
+    const corrupted = 'C:Users\rickfProjects_EHGEHG_Engineer';
+    expect(corrupted).toBe('C:Users' + String.fromCharCode(0x0D) + 'ickfProjects_EHGEHG_Engineer');
+    expect(detectCorruption(corrupted)).toBe(true);
+  });
+
+  it('does not flag a clean forward-slash path', () => {
+    expect(detectCorruption('C:/Users/rickf/Projects/_EHG/EHG_Engineer')).toBe(false);
+  });
+
+  it('does not flag a clean Windows backslash path (backslash itself is not a control char)', () => {
+    expect(detectCorruption('C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer')).toBe(false);
+  });
+
+  it('does not flag or throw on null/undefined/empty-string input', () => {
+    expect(detectCorruption(null)).toBe(false);
+    expect(detectCorruption(undefined)).toBe(false);
+    expect(detectCorruption('')).toBe(false);
+  });
+
+  it('does not throw on non-string input (number/object)', () => {
+    expect(detectCorruption(42)).toBe(false);
+    expect(detectCorruption({ not: 'a string' })).toBe(false);
+  });
+
+  it('tab (\\x09) is intentionally NOT in the reject class', () => {
+    expect(detectCorruption('C:/Users/rickf\t/Projects')).toBe(false);
+  });
+
+  it('flags any other C0 control character (e.g. \\x01)', () => {
+    expect(detectCorruption('C:/Users/\x01rickf')).toBe(true);
+  });
+
+  it('flags a literal embedded newline (\\x0A) — regression test for a reject-class range bug', () => {
+    // An earlier draft's regex was [\x00-\x08\x0B-\x1F], which silently excluded
+    // \x0A (newline) alongside tab (\x09). A path containing "\node_modules"
+    // (a directory name that appears throughout this repo) has its \n JS-escaped
+    // into a literal embedded LF byte during hand-typed inline INSERT corruption,
+    // exactly analogous to the \r -> CR case this whole SD exists to catch. Must
+    // stay flagged.
+    const corrupted = 'C:/Users/rickf' + String.fromCharCode(0x0A) + 'ode_modules';
+    expect(detectCorruption(corrupted)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Windows path literals hand-typed inline in JS/shell INSERT scripts get silently corrupted by JS string-escape parsing before ever reaching the DB (`\U`/`\P`/`\_`/`\E` dropped as unrecognized escapes, `\r` becomes a literal embedded CR byte) — an active, ongoing corruption class (63 corrupted rows found live across `metadata.repo_path`, `metadata.executed_from_cwd`, and the top-level `executed_from_cwd` column on `sub_agent_execution_results`).
- **FR-1**: `leo_protocol_sections` rows 290/291 (the only rows leaking the unguided "Store results in sub_agent_execution_results table" Task-tool template text) now point agents at `scripts/store-sub-agent-repo-evidence.js` (QF-20260702-679, already merged, reused as-is) instead. Regenerated `CLAUDE_PLAN.md`/`CLAUDE_LEAD.md`, zero drift confirmed.
- **FR-2**: `trg_subagent_evidence_reject_control_chars` — a BLOCKING trigger (RAISE EXCEPTION, not advisory) rejecting C0 control characters except tab across all 3 corruption-prone fields. Already applied to production via the sanctioned `apply-migration.js` 3-factor flow.
- **FR-3**: `scripts/backfill-corrupted-subagent-repo-paths.mjs` — repaired all 63 corrupted rows live (`repo_path` recovered via `sd_id → target_application → applications.local_path`; unrecoverable `executed_from_cwd` nulled, never fabricated). Idempotent — post-apply re-scan confirms 0 corrupted rows remain.
- **FR-4/5**: live-DB trigger tests, backfill unit tests, and a new pattern entry in `docs/reference/infrastructure-hardening-patterns.md`.

An independent TESTING-perspective verification pass caught a real off-by-range bug in the trigger's reject regex (`[\x00-\x08\x0B-\x1F]` accidentally excluded newline alongside tab, exactly the corruption class this SD exists to catch) **before** the migration was applied to production — fixed to `[\x00-\x08\x0A-\x1F]` in both the SQL trigger and the JS detector, covered by a regression test.

## Test plan
- [x] `npx vitest run tests/unit/scripts/backfill-corrupted-subagent-repo-paths.test.js` — 8/8 passing (includes the newline regression case)
- [x] `npx vitest run tests/database/subagent-evidence-control-char-trigger.test.js` — 5/5 passing against the live DB (rejects corrupted repo_path, metadata.executed_from_cwd, top-level executed_from_cwd; accepts clean rows)
- [x] Migration applied to production; live-verified the trigger rejects a real newline-corrupted insert
- [x] Backfill run with `--apply`: `updated=63 skipped_unresolvable=0 failed=0`; re-scan confirms `corrupted=0`
- [x] `node scripts/generate-claude-md-from-db.js && node scripts/check-claude-md-drift.cjs` — zero drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)