### PR TITLE
fix(QF-20260702-976): operating layer for singleton-relaunch scheduler

### DIFF
--- a/lib/coordinator/singleton-relaunch-trigger.js
+++ b/lib/coordinator/singleton-relaunch-trigger.js
@@ -24,6 +24,23 @@ const { getActiveAdamId } = require('./adam-identity.cjs');
 const { getActiveSolomonId } = require('./solomon-identity.cjs');
 const { getActiveCoordinatorId } = require('./resolve.cjs');
 
+/**
+ * QF-20260702-976: this module (trigger + scheduling) is now periodically INVOKED (see
+ * coordinator-startup-check.mjs STANDARD_LOOPS key 'singleton-relaunch'), so a
+ * singleton_relaunch_scheduled record can actually be written when conditions are met. Two
+ * downstream gaps remain KNOWN and DEFERRED (documented here per QF-20260702-976's guardrails —
+ * explicitly out of scope to fix in that QF; verified this module's own decision logic is
+ * otherwise correct):
+ *   (a) target-idle predicate handling of loop_state='awaiting_tick': a PARKED coordinator
+ *       acting as the relaunch target may report 'awaiting_tick' the same as a genuinely idle
+ *       one, so decideRelaunchSchedule() could treat a merely-parked (not truly safe-to-relaunch)
+ *       target as idle. SAFE_LOOP_STATES does not currently distinguish the two cases.
+ *   (b) the actual fresh-checkout relaunch (spawning a new CC session) remains HUMAN-GATED —
+ *       writing a singleton_relaunch_scheduled record only SURFACES the need; nothing in this
+ *       codebase today autonomously spawns the replacement session from that record.
+ * If either gap needs fixing, size it as its own QF/SD rather than folding into this scheduler.
+ */
+
 /** loop_state values documented as safe-to-relaunch (never mid-consult). Anything else — including
  * 'active', 'unknown', or no recorded state — fails CLOSED (no relaunch). See docs/protocol/
  * fleet-hibernation.md + .claude/commands/coordinator.md for the loop_state contract. */

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -97,6 +97,19 @@ export const STANDARD_LOOPS = [
   // always observes a just-refreshed rank rather than racing it.
   { key: 'unranked-gauge', label: 'Eligible-but-unranked-leaf-count invariant gauge', script: 'gauge-unranked-claimable-leaves.mjs', cron: '9,24,39,54 * * * *',
     prompt: 'node scripts/gauge-unranked-claimable-leaves.mjs' },
+  // QF-20260702-976: the OPERATING layer for SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A.
+  // The trigger + scheduler logic (lib/coordinator/singleton-relaunch-trigger.js, scripts/
+  // singleton-relaunch-scheduler.mjs, npm-wired as singleton-relaunch:run) shipped but nothing
+  // periodically invoked it — first live test 2026-07-02 DID-NOT-FIRE (0 singleton_relaunch_scheduled
+  // records despite a coordinator behind-59 + fleet-quiescent trigger window). This loop makes
+  // DETECTION + SCHEDULING operate (a durable singleton_relaunch_scheduled record + surfacing when
+  // behind-N + quiescent + target-idle) — it does NOT itself perform an end-to-end autonomous
+  // relaunch; the fresh-checkout spawn remains human-gated (see singleton-relaunch-trigger.js header
+  // for the two explicitly-deferred downstream gaps: target-idle awaiting_tick predicate handling,
+  // and the human-gated spawn step). Cheap (git + a few DB reads); offset from the other */15-ish
+  // loops so it doesn't cluster.
+  { key: 'singleton-relaunch', label: 'Singleton-relaunch quiescent-window scheduler (detection + scheduling only)', script: 'singleton-relaunch-scheduler.mjs', cron: '7,22,37,52 * * * *',
+    prompt: 'npm run singleton-relaunch:run' },
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-1/FR-2: drains
   // the tracked relay-request queue deliberately (never processed inline in the active
   // thread) and writes the CONFIRM-ON-RELAY receipt. Frequent — a queued relay-request is

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -29,9 +29,14 @@ test('STANDARD_LOOPS has the expected standard loops with the expected keys', ()
   // SD-MAN-INFRA-RETENTION-OPS-FINISHER-001 added 'retention' (this pin had drifted — it was never added here).
   // SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001 added the durable charter-compliance self-audit (after 'audit').
   // SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D added the unranked-claimable-leaf-count gauge (after 'backlog-rank').
-  assert.equal(STANDARD_LOOPS.length, 17);
+  // QF-20260702-976 added the singleton-relaunch quiescent-window scheduler (after 'unranked-gauge').
+  // NOTE: this assertion had drifted (previously pinned at 17, missing 'relay-drain' and
+  // 'relay-drop-gauge' from SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001,
+  // which were already live in STANDARD_LOOPS but never reflected here) — corrected to the
+  // actual 20-entry array while adding 'singleton-relaunch'.
+  assert.equal(STANDARD_LOOPS.length, 20);
   const keys = STANDARD_LOOPS.map((l) => l.key);
-  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention']);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention']);
 });
 
 test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
@@ -99,7 +104,7 @@ test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboa
 test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
   const none = parseArmedSet([], {});
   const out = renderLoops(none);
-  assert.match(out, /STANDARD CRON LOOPS \(17\)/);
+  assert.match(out, /STANDARD CRON LOOPS \(20\)/);
   // All prompts emitted as CronCreate specs when nothing is armed
   for (const loop of STANDARD_LOOPS) {
     assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
@@ -117,7 +122,7 @@ test('renderLoops reports all-armed cleanly when every loop is armed', () => {
   ];
   const armed = parseArmedSet(['--armed', armedTokens.join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 17 standard loops armed/);
+  assert.match(out, /All 20 standard loops armed/);
 });
 
 test('buildReport combines responsibilities + loop sections', () => {


### PR DESCRIPTION
## Summary
- SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A shipped the trigger + scheduler logic (`lib/coordinator/singleton-relaunch-trigger.js`, `scripts/singleton-relaunch-scheduler.mjs`, npm-wired as `singleton-relaunch:run`) but nothing periodically invoked it — first live test 2026-07-02 DID-NOT-FIRE (0 `singleton_relaunch_scheduled` records) despite a coordinator behind-59 + fleet-quiescent trigger window.
- Registers `singleton-relaunch` in `coordinator-startup-check.mjs` `STANDARD_LOOPS` (cron `7,22,37,52 * * * *`) so it arms on the next `/coordinator start` and survives reboots — this is the established periodic-invoker pattern every other coordinator loop uses (declarative spec + harness CronCreate arming), not a new bespoke mechanism.
- Enables `SINGLETON_RELAUNCH_SCHEDULING_ENABLED=true` (out-of-band `.env` change on the shared tree, Adam-authorized per the QF) so scheduling actually **writes** a durable record instead of dry-run-only evaluating.
- Per the QF's explicit guardrails, documents (does **not** fix) two known downstream gaps in `singleton-relaunch-trigger.js`: (a) the target-idle predicate may mis-evaluate a merely-parked coordinator as safe-to-relaunch under `loop_state=awaiting_tick`; (b) the actual relaunch spawn remains human-gated. This QF makes detection+scheduling **operate** — it does not implement end-to-end autonomous relaunch.
- Corrected a pre-existing, unrelated `STANDARD_LOOPS` test-count drift while touching the test file (was pinned at 17, missing `relay-drain` + `relay-drop-gauge` which were already live in the array but never reflected in the test).

## Test plan
- [x] `node --test tests/unit/coordinator-startup-check.test.mjs` — 12/12 passing (updated for the new loop + corrected count)
- [x] `npx vitest run tests/unit/coordinator/singleton-relaunch-trigger.test.js` — 13/13 passing (untouched trigger logic, verified unaffected)
- [x] Manually ran `SINGLETON_RELAUNCH_SCHEDULING_ENABLED=true node scripts/singleton-relaunch-scheduler.mjs` against the live DB — correctly evaluates all 3 singleton roles (adam/solomon/coordinator) and declines to schedule now that the coordinator's tree is fresh (0 behind, post an unrelated merge-conflict fix earlier today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)