### PR TITLE
fix(QF-20260702-414): Adam inbox orphan-kind drain: type producer kinds + consume the recirculating orphan rows

### DIFF
--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -326,6 +326,15 @@ const ADAM_INBOX_KINDS = Object.freeze([
   // orphan/visibility-recovery fallback. A coordinator->Adam directive-to-action (sibling of
   // coordinator_advisory / coordinator_adam_feedback), so it belongs here, NOT in EXCLUDED_KINDS.
   'coordinator_source_request',
+  // QF-20260702-414: coordinator_review (the periodic every-N-SDs candid-feedback ask) and
+  // adam_advisory (reused directionally: PAYLOAD_KINDS.ADAM_ADVISORY is Adam's OWN outbound kind
+  // to the coordinator, but sprint-reasoner/worker/Solomon senders also address Adam directly with
+  // this same kind — target_session scoping in drainInbox's query already guarantees only rows
+  // TARGETING Adam match here, so widening this never causes Adam to self-consume its own sent
+  // advisories, which target the coordinator, not itself) were recirculating through the degraded
+  // orphan/visibility fallback (28 rows unchanged across 6+ drains) instead of the normal lane.
+  'coordinator_review',
+  'adam_advisory',
 ]);
 
 /**
@@ -419,16 +428,25 @@ async function drainInbox(supabase, sessionId, { quiet = false } = {}) {
   // minus the handler-owned EXCLUDED_KINDS. These are real deliveries (live 2026-06-20: untyped enforcer
   // verdicts left Adam 40m blind). WARN keeps them VISIBLE without consuming, preserving the deliberate
   // non-consume invariant (read_at stays NULL → recoverable; pinned by adam-inbox-all-classes.test.js).
+  // QF-20260702-414: an orphan that no producer ever fixes recirculates FOREVER (28 rows re-printed
+  // ~50KB every tick, unchanged across 6+ drains, risking burial of new lane traffic). Print each
+  // orphan row ONCE — payload.orphan_seen_at (a visibility marker, NEVER read_at) is stamped after
+  // the first warn so a re-run stays silent about it while it remains genuinely recoverable/unread.
   const orphaned = (allRows || []).filter(isOrphanedAdamRow);
-  if (orphaned.length > 0) {
-    console.warn(`⚠ ${orphaned.length} unread Adam-directed row${orphaned.length === 1 ? '' : 's'} with unrecognized/untyped kind NOT auto-drained (visibility — NOT consumed, still recoverable):`);
-    for (const r of orphaned) {
+  const freshOrphans = orphaned.filter((r) => !(r.payload && r.payload.orphan_seen_at));
+  if (freshOrphans.length > 0) {
+    console.warn(`⚠ ${freshOrphans.length} unread Adam-directed row${freshOrphans.length === 1 ? '' : 's'} with unrecognized/untyped kind NOT auto-drained (visibility — NOT consumed, still recoverable):`);
+    for (const r of freshOrphans) {
       const kind = (r.payload && r.payload.kind) || '(untyped)';
       const text = (r.payload && r.payload.body) || r.body || r.subject || '(empty)';
       const ageMin = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
       console.warn(`  ⚠ [orphan/${kind}] id=${r.id} (${ageMin}m) ${text}`);
     }
     console.warn('  → these target the Adam session but match no drain lane; fix the producer to use a typed ADAM_INBOX_KINDS kind, or read via the durable reader.');
+    const seenAt = new Date().toISOString();
+    for (const r of freshOrphans) {
+      await supabase.from('session_coordination').update({ payload: { ...(r.payload || {}), orphan_seen_at: seenAt } }).eq('id', r.id);
+    }
   }
 
   // SD-REFILL-00YJS6VB: the recurring inbox-monitor tick fires every few minutes and was a

--- a/tests/unit/adam-inbox-orphan-recirculation-fix.test.js
+++ b/tests/unit/adam-inbox-orphan-recirculation-fix.test.js
@@ -1,0 +1,39 @@
+/**
+ * QF-20260702-414 — coordinator_review and adam_advisory (from non-Adam senders addressing Adam
+ * directly) must drain through the NORMAL Adam inbox lane, not the degraded orphan/visibility
+ * fallback. Live data: 28 rows recirculated unchanged across 6+ drains before this fix. Mirrors
+ * tests/unit/adam-inbox-coordinator-source-request.test.js's pinning pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import pkg from '../../scripts/adam-advisory.cjs';
+
+const { isAdamInboxRow, isOrphanedAdamRow, ADAM_INBOX_KINDS } = pkg;
+
+const row = (kind) => (kind === undefined ? { payload: {} } : { payload: { kind } });
+
+describe('Adam inbox drains coordinator_review + adam_advisory (recirculation fix)', () => {
+  it('both kinds are in the Adam-scoped allowlist', () => {
+    expect(ADAM_INBOX_KINDS).toContain('coordinator_review');
+    expect(ADAM_INBOX_KINDS).toContain('adam_advisory');
+  });
+
+  it('isAdamInboxRow classifies both as drainable (typed lane)', () => {
+    expect(isAdamInboxRow(row('coordinator_review'))).toBe(true);
+    expect(isAdamInboxRow(row('adam_advisory'))).toBe(true);
+  });
+
+  it('isOrphanedAdamRow is FALSE for both (consumed by the normal drain, not the orphan fallback)', () => {
+    expect(isOrphanedAdamRow(row('coordinator_review'))).toBe(false);
+    expect(isOrphanedAdamRow(row('adam_advisory'))).toBe(false);
+  });
+
+  it('an unrelated unknown kind is still orphaned (the fix is scoped to these two kinds)', () => {
+    expect(isAdamInboxRow(row('some_other_unregistered_kind'))).toBe(false);
+    expect(isOrphanedAdamRow(row('some_other_unregistered_kind'))).toBe(true);
+  });
+
+  it('still drains the sibling Adam-directed kinds (regression)', () => {
+    expect(isAdamInboxRow(row('coordinator_advisory'))).toBe(true);
+    expect(isAdamInboxRow(row('coordinator_source_request'))).toBe(true);
+  });
+});

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -424,7 +424,10 @@ describe('full-lane: drainInbox surfaces BOTH lanes + two-stage ACK', () => {
     const rows = [
       { id: 'dir-1', payload: { kind: 'coordinator_directive', body: 'do X' }, created_at: iso(NOW) },
       { id: 'rep-1', payload: { kind: 'coordinator_reply', reply_to: 'C-9', body: 'ack' }, created_at: iso(NOW) },
-      { id: 'noise', payload: { kind: 'adam_advisory', body: 'fyi' }, created_at: iso(NOW) }, // neither lane
+      // canary_request is handler-owned (EXCLUDED_KINDS) — never surfaced by the Adam inbox, in
+      // ANY lane, regardless of future ADAM_INBOX_KINDS widening (QF-20260702-414: adam_advisory
+      // itself is NOT "noise" any more — it drains via the normal lane when addressed to Adam).
+      { id: 'noise', payload: { kind: 'canary_request', body: 'fyi' }, created_at: iso(NOW) }, // neither lane
     ];
     const captured = {};
     await drainInbox(mockInboxSb(rows, captured), UUID_A);
@@ -436,7 +439,7 @@ describe('full-lane: drainInbox surfaces BOTH lanes + two-stage ACK', () => {
 
   it('no surfaced rows (only non-lane noise) → no DB update (idempotent / quiet)', async () => {
     const captured = {};
-    await drainInbox(mockInboxSb([{ id: 'x', payload: { kind: 'adam_advisory' }, created_at: iso(NOW) }], captured), UUID_A);
+    await drainInbox(mockInboxSb([{ id: 'x', payload: { kind: 'canary_request' }, created_at: iso(NOW) }], captured), UUID_A);
     expect(captured.ids).toBeUndefined();
     expect(captured.update).toBeUndefined();
   });

--- a/tests/unit/coordination/adam-inbox-all-classes.test.js
+++ b/tests/unit/coordination/adam-inbox-all-classes.test.js
@@ -60,6 +60,7 @@ function stub(rows) {
     update() { return updateChain; },
     in(_col, ids) { captured.updatedIds = ids; return updateChain; },
     is() { return Promise.resolve({ error: null }); },
+    eq() { return Promise.resolve({ error: null }); }, // QF-20260702-414: orphan_seen_at per-row stamp
   };
   const supabase = { from() { return new Proxy({}, { get(_t, p) { return (p in selectChain) ? selectChain[p] : updateChain[p]; } }); } };
   return { supabase, captured };

--- a/tests/unit/coordination/adam-inbox-orphan-warn.test.js
+++ b/tests/unit/coordination/adam-inbox-orphan-warn.test.js
@@ -9,7 +9,7 @@ const { drainInbox, isOrphanedAdamRow, EXCLUDED_KINDS } = require('../../../scri
 
 // AND-only fetch + JS-filter stub (mirrors adam-inbox-all-classes.test.js).
 function stub(rows) {
-  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false };
+  const captured = { eq: {}, isNull: [], updatedIds: null, usedOr: false, orphanSeenUpdates: [] };
   const selectChain = {
     select() { return selectChain; },
     eq(col, val) { captured.eq[col] = val; return selectChain; },
@@ -19,9 +19,14 @@ function stub(rows) {
     limit() { return Promise.resolve({ data: rows, error: null }); },
   };
   const updateChain = {
-    update() { return updateChain; },
+    _payload: null,
+    update(body) { updateChain._payload = body; return updateChain; },
     in(_col, ids) { captured.updatedIds = ids; return updateChain; },
     is() { return Promise.resolve({ error: null }); },
+    eq(_col, id) {
+      captured.orphanSeenUpdates.push({ id, payload: updateChain._payload && updateChain._payload.payload });
+      return Promise.resolve({ error: null });
+    },
   };
   const supabase = { from() { return new Proxy({}, { get(_t, p) { return (p in selectChain) ? selectChain[p] : updateChain[p]; } }); } };
   return { supabase, captured };
@@ -82,6 +87,37 @@ describe('drainInbox orphan WARN lane', () => {
     await drainInbox(supabase, 'adam-session');
     expect(warnSpy.mock.calls.length).toBe(0); // no orphan warning
     expect(captured.updatedIds).toBeNull();    // nothing consumed
+    warnSpy.mockRestore(); logSpy.mockRestore();
+  });
+
+  // QF-20260702-414: an orphan recirculated on EVERY tick before this fix (28 rows unchanged
+  // across 6+ drains). Each orphan must WARN once, stamp orphan_seen_at, then stay silent.
+  it('WARNs a fresh orphan once and stamps orphan_seen_at (not read_at)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const now = new Date().toISOString();
+    const { supabase, captured } = stub([
+      { id: 'fresh', payload: { kind: 'coordinator_alert', body: 'first sighting' }, created_at: now },
+    ]);
+    await drainInbox(supabase, 'adam-session');
+    expect(warnSpy.mock.calls.map(c => c.join(' ')).join('\n')).toContain('fresh');
+    expect(captured.orphanSeenUpdates).toHaveLength(1);
+    expect(captured.orphanSeenUpdates[0].id).toBe('fresh');
+    expect(captured.orphanSeenUpdates[0].payload.orphan_seen_at).toBeTruthy();
+    expect(captured.updatedIds).toBeNull(); // read_at NEVER stamped — still recoverable
+    warnSpy.mockRestore(); logSpy.mockRestore();
+  });
+
+  it('stays SILENT on an orphan already stamped orphan_seen_at (no re-print)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const now = new Date().toISOString();
+    const { supabase, captured } = stub([
+      { id: 'already-seen', payload: { kind: 'coordinator_alert', orphan_seen_at: now }, created_at: now },
+    ]);
+    await drainInbox(supabase, 'adam-session');
+    expect(warnSpy.mock.calls.length).toBe(0);
+    expect(captured.orphanSeenUpdates).toHaveLength(0); // no re-stamp of an already-seen row
     warnSpy.mockRestore(); logSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260702-414

**Type:** bug
**Severity:** medium

### Issue Description
28 Adam-directed session_coordination rows recirculate as 'orphan/untyped kind NOT auto-drained' on EVERY adam-advisory.cjs inbox tick — they are read visually but never consumed (read_at never stamped), so every drain re-prints ~50KB and real new messages risk burial (a chairman-approved coordinator message nearly drowned in them 2026-07-02). Producers (sprint-reasoner sessions, Solomon direct sends, coordinator_review emitters) send payload.kind values (adam_advisory from non-coordinator senders, coordinator_review, solomon_adherence_drift, etc.) that are NOT in the ADAM_INBOX_KINDS allowlist in scripts/adam-advisory.cjs, so drainInbox refuses to consume them. FIX (two-sided, keep AND-only query semantics per the file's lane-separation comments): (1) widen ADAM_INBOX_KINDS (or add an ORPHAN_CONSUMABLE_KINDS set) to cover the observed legit kinds — coordinator_review, adam_advisory-from-reasoners, solomon direct kinds — so drainInbox stamps read_at on them after printing ONCE; (2) keep the orphan-visibility warning for genuinely unknown kinds but print each orphan row ONCE (stamp a metadata.orphan_seen_at) instead of re-printing forever. Evidence: 28 rows listed every tick in session 5d0ea5e1 (ids 33978195..., 8b4f8b2d..., etc.), unchanged across 6+ drains.


### Expected Behavior
Each Adam-directed row prints once and is consumed (or once-flagged); drain output stays small; new messages are immediately visible

### Actual Behavior
28 orphan rows re-print on every tick (~50KB), never consumed, burying new lane traffic

### Changes
- **Files Changed:** 5
  - scripts/adam-advisory.cjs
  - tests/unit/adam-inbox-orphan-recirculation-fix.test.js
  - tests/unit/coord-adam-comms-resilient.test.js
  - tests/unit/coordination/adam-inbox-all-classes.test.js
  - tests/unit/coordination/adam-inbox-orphan-warn.test.js
- **LOC:** 115 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
85 relevant unit tests pass across 8 files + full unit suite run shows only 7 pre-existing unrelated failures (worktree-hygiene hooks, solomon-consult messaging, stage-config DB drift) none touching adam-advisory.cjs. Verified live orphan data (session 5d0ea5e1, 28 rows) resolves to exactly coordinator_review + adam_advisory before widening ADAM_INBOX_KINDS.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol