### PR TITLE
fix(QF-20260702-272): bake durable roles-review loop into coordinator STANDARD_LOOPS

### DIFF
--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -157,6 +157,14 @@ export const STANDARD_LOOPS = [
   // (~513k workflow_trace_log + ~484k governance_audit_log) only progresses while this is armed.
   { key: 'retention', label: 'Weekly retention enforcement (archive-not-delete)', script: 'retention-enforce.js', cron: '0 3 * * 0',
     prompt: 'Run `npm run retention:apply` in EHG_Engineer and report the per-table archived/deleted counts; if the command exits non-zero or `npm run retention:check -- --liveness` reports STALE, surface to the coordinator.' },
+  // QF-20260702-272: durable twice-daily roles/duties self-review — replaces a session-only CronCreate
+  // (d5f7e707, 41 6,18 * * *) that DIED with its session, the same session-fragility class as Adam's
+  // belt-countdown duty (already durably encoded). It caught a real live drift (Duty-5 let-workers-idle
+  // miss, chairman-flagged 2026-07-02), so every coordinator startup now re-arms it. Same off-minute
+  // twice-daily cadence as the original. Chairman endorsed each crew member keeping a recurring
+  // self-review; coordinator itself requested this as sourceable candidate #1 (advisory 444cdd65 ref).
+  { key: 'roles-review', label: 'Coordinator roles/duties self-review (twice-daily, durable)', script: 'coordinator-startup-check.mjs', cron: '41 6,18 * * *',
+    prompt: 'Re-read the coordinator role contract (leo_protocol_sections id=605 + docs/protocol/fleet-coordinator-and-worker-behavior.md, rendered by `node scripts/coordinator-startup-check.mjs`) and self-audit duty execution against RESPONSIBILITIES: for each duty, confirm evidence of recent execution and REMEDIATE any drift found (e.g. idle workers with claimable work, a stale sourcing gap) rather than observe-only.' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -34,9 +34,10 @@ test('STANDARD_LOOPS has the expected standard loops with the expected keys', ()
   // 'relay-drop-gauge' from SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001,
   // which were already live in STANDARD_LOOPS but never reflected here) — corrected to the
   // actual 20-entry array while adding 'singleton-relaunch'.
-  assert.equal(STANDARD_LOOPS.length, 20);
+  // QF-20260702-272 added the durable twice-daily 'roles-review' self-audit (after 'retention').
+  assert.equal(STANDARD_LOOPS.length, 21);
   const keys = STANDARD_LOOPS.map((l) => l.key);
-  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention']);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention', 'roles-review']);
 });
 
 test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
@@ -104,7 +105,7 @@ test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboa
 test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
   const none = parseArmedSet([], {});
   const out = renderLoops(none);
-  assert.match(out, /STANDARD CRON LOOPS \(20\)/);
+  assert.match(out, /STANDARD CRON LOOPS \(21\)/);
   // All prompts emitted as CronCreate specs when nothing is armed
   for (const loop of STANDARD_LOOPS) {
     assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
@@ -122,7 +123,7 @@ test('renderLoops reports all-armed cleanly when every loop is armed', () => {
   ];
   const armed = parseArmedSet(['--armed', armedTokens.join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 20 standard loops armed/);
+  assert.match(out, /All 21 standard loops armed/);
 });
 
 test('buildReport combines responsibilities + loop sections', () => {


### PR DESCRIPTION
## Summary
- The coordinator stood up a twice-daily roles-review as a session-only CronCreate job (`d5f7e707`, `41 6,18 * * *`) — it re-reads the durable role contract (`leo_protocol_sections` id=605 + `docs/protocol/fleet-coordinator-and-worker-behavior.md`) and self-audits duty execution; it caught a real drift (Duty-5 let-workers-idle miss, chairman-flagged 2026-07-02). Session-only crons die with the session, the same fragility class as Adam's belt-countdown duty (already durably encoded).
- Adds a `roles-review` entry to `STANDARD_LOOPS` so every coordinator startup re-arms it idempotently, mirroring the pattern's existing self-audit loops (`charter-audit`, `hourly-review`). Same off-minute twice-daily cadence as the original session cron.
- `STANDARD_LOOPS` grows from 20 to 21 entries; updated the pinned-count + keys-array assertions in `tests/unit/coordinator-startup-check.test.mjs` accordingly.

## Test plan
- [x] `coordinator-startup-check.test.mjs` — 12/12 pass (count/keys/armed-status assertions updated for the new entry)
- [x] `retention-loop-parity.test.js`, `quiet-tick-loop-parity.test.js`, `charter-audit-detectors.test.js` — pass, no hardcoded-count assumptions affected
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)