### PR TITLE
fix(QF-20260702-433): Adam heartbeat-email sender + durable loop registration

### DIFF
--- a/scripts/adam-heartbeat-email.mjs
+++ b/scripts/adam-heartbeat-email.mjs
@@ -1,0 +1,48 @@
+// adam-heartbeat-email.mjs — QF-20260702-433
+//
+// Chairman directive 2026-07-02: Adam sends a half-hourly reassurance email whose SUBJECT
+// alone signals all-is-well ("All good - Adam heartbeat <time> ET"), so silence never reads
+// as stuck. Caller (the recurring tick prompt) composes ONE fresh, honest status line and
+// passes it via --body; this script never fabricates a status of its own. If something is
+// actually wrong, the caller sends the decision/alert email instead (adam-decision-email.mjs)
+// rather than invoking this script — this script itself does no "is everything ok" judgment.
+//
+// Fail-soft; --dry-run prints only. No emojis (chairman directive, mirrors adam-decision-email.mjs).
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { resolve } from 'path';
+
+const DRY = !!process.env.ADAM_EMAIL_DRYRUN || process.argv.includes('--dry-run');
+const EM = '—';
+
+function argValue(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
+}
+const body = argValue('--body');
+
+if (!body || !body.trim()) {
+  console.warn('[adam-heartbeat-email] --body "<line>" is required — nothing sent');
+  process.exit(0);
+}
+
+const when = new Date().toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
+const subject = `All good - Adam heartbeat ${when} ET`;
+const text = `${body.trim()}\n\nas of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor`;
+
+const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
+  `<p style="font-size:14px;margin:0 0 8px">${esc(body.trim())}</p>` +
+  `<p style="font-size:11px;color:#999;margin:14px 0 0">as of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor</p></div>`;
+
+if (DRY) {
+  console.log('=== [ADAM HEARTBEAT EMAIL — DRY RUN] no email sent ===\nSUBJECT: ' + subject + '\n---\n' + text + '\n---');
+} else {
+  try {
+    const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
+    const r = await mod.sendEmail({ from: 'Adam ' + EM + ' LEO Fleet Advisor <onboarding@resend.dev>', to: process.env.CLAUDE_NOTIFY_EMAIL, subject, html, text });
+    console.log('ADAM-HEARTBEAT-EMAIL', JSON.stringify(r));
+  } catch (e) {
+    console.warn('[adam-heartbeat-email] send failed (fail-soft): ' + (e?.message || e));
+  }
+}

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -127,6 +127,18 @@ export const ADAM_LOOPS = [
     cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *',
     prompt: 'node scripts/adam-quiet-tick.mjs',
   },
+  {
+    // QF-20260702-433 (Chairman directive 2026-07-02): a half-hourly reassurance email whose
+    // SUBJECT alone signals all-is-well ("All good - Adam heartbeat <time> ET"), so silence never
+    // reads as stuck. Was SESSION-ONLY (armed ad hoc, cadence 14,44 * * * *) — the exact
+    // session-fragility class the belt-countdown duty already fixed; registering here so it
+    // survives session restarts.
+    key: 'heartbeat-email',
+    label: 'Half-hourly all-good reassurance email (subject-only signal, never a false all-good)',
+    script: 'adam-heartbeat-email.mjs',
+    cron: '14,44 * * * *',
+    prompt: 'Adam heartbeat-email tick: compose ONE fresh, honest status line, then run node scripts/adam-heartbeat-email.mjs --body "<line>" — never send a false all-good; if something is actually wrong, send the decision/alert email instead (node scripts/adam-decision-email.mjs) rather than this heartbeat.',
+  },
 ];
 
 // Parse the armed-cron basenames/prompts the agent passes from its CronList output.

--- a/tests/unit/adam-startup-check.test.mjs
+++ b/tests/unit/adam-startup-check.test.mjs
@@ -24,13 +24,14 @@ import { CRITICAL_PROTOCOL_FILES } from '../../lib/governance/checkout-freshness
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-test('ADAM_LOOPS has the 8 expected tick loops with the expected keys', () => {
+test('ADAM_LOOPS has the 9 expected tick loops with the expected keys', () => {
   // self-adherence added by SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001 (child E);
   // belt-countdown added by SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001 (FR2 — durable contract duty);
   // doc-drift + github-assessment added by SD-LEO-INFRA-REGISTER-TWO-EVERY-001 (every-3-day propose-only duties);
-  // board-reconcile added by SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (durable contract duty).
-  assert.equal(ADAM_LOOPS.length, 8);
-  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile']);
+  // board-reconcile added by SD-LEO-INFRA-UPSCALE-ADAM-PROJECT-MANAGEMENT-DISCIPLINE-001-B (durable contract duty);
+  // heartbeat-email added by QF-20260702-433 (chairman directive 2026-07-02 — half-hourly all-good reassurance email).
+  assert.equal(ADAM_LOOPS.length, 9);
+  assert.deepEqual(ADAM_LOOPS.map((l) => l.key), ['governance-scan', 'inbox-monitor', 'offer-help', 'self-adherence', 'belt-countdown', 'doc-drift', 'github-assessment', 'board-reconcile', 'heartbeat-email']);
   ADAM_LOOPS.forEach((l) => {
     assert.ok(l.cron && typeof l.cron === 'string', `${l.key} has a cron`);
     assert.ok(l.prompt && typeof l.prompt === 'string', `${l.key} has a prompt`);
@@ -133,16 +134,16 @@ test('loopStatus: armed on key, prompt or script match, MISSING when provided-bu
   assert.equal(loopStatus(offer, { provided: true, set: new Set([offer.prompt]) }), 'armed');
 });
 
-test('end-to-end CSV verdict: --armed with all 8 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
+test('end-to-end CSV verdict: --armed with all 9 loop KEYS → nothing to arm (no duplicate re-arm)', () => {
   const armed = parseArmedSet(['--armed', ADAM_LOOPS.map((l) => l.key).join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 8 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 9 Adam tick loops armed\. Nothing to arm\./);
   assert.doesNotMatch(out, /MISSING/);
 });
 
 test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent note)', () => {
   const out = renderLoops(parseArmedSet([], {}));
-  assert.match(out, /ADAM RECURRING TICK \(8 loops\)/);
+  assert.match(out, /ADAM RECURRING TICK \(9 loops\)/);
   assert.match(out, /CronCreate\(\{ cron: "0 13 \* \* \*"/); // governance-scan spec emitted
   assert.match(out, /idempotent/i);
 });
@@ -150,7 +151,7 @@ test('renderLoops emits CronCreate specs for the not-yet-armed loops (idempotent
 test('renderLoops reports "Nothing to arm" when all loops are in the armed set', () => {
   const armedSet = new Set(ADAM_LOOPS.map((l) => l.prompt));
   const out = renderLoops({ provided: true, set: armedSet });
-  assert.match(out, /All 8 Adam tick loops armed\. Nothing to arm\./);
+  assert.match(out, /All 9 Adam tick loops armed\. Nothing to arm\./);
 });
 
 test('renderResponsibilities is fail-open (bad repoRoot → fallback, never throws)', () => {


### PR DESCRIPTION
## Summary
- Chairman directive 2026-07-02: a half-hourly reassurance email whose SUBJECT alone signals all-is-well ("All good - Adam heartbeat \<time\> ET"), so silence never reads as stuck.
- **The QF's premise was inaccurate**: it claimed `scripts/adam-heartbeat-email.mjs` was "already shipped this session," but the script never existed anywhere in git history, on origin/main, or on any branch/PR (verified). Rather than leave this chairman-directed work stranded on a dependency that was never sourced, built the sender script per the QF's own complete spec (subject format, `--body` flag, fail-soft, no emojis — mirrors `scripts/adam-decision-email.mjs`'s existing convention exactly).
- Registered `heartbeat-email` in `scripts/adam-startup-check.mjs`'s `ADAM_LOOPS` (30-min cadence, `14,44 * * * *`, matching the previously session-only cadence) so `/adam startup` re-arms it idempotently and it survives session restarts — the same session-fragility class the belt-countdown duty already fixed.

## Test plan
- [x] `node scripts/adam-heartbeat-email.mjs --dry-run --body "..."` — renders the correct subject/body, no send attempted
- [x] `node scripts/adam-heartbeat-email.mjs --dry-run` (no `--body`) — warns and exits 0 cleanly, no crash
- [x] `node --test tests/unit/adam-startup-check.test.mjs` — 18/18 passing (updated loop count 8→9, including the FR2 contract↔tooling parity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)