### PR TITLE
feat(SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001): mergeWork() P1-P5 precondition ladder, OBSERVE-ONLY + telemetry sink

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C",
-  "expectedBranch": "feat/SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-C",
-  "createdAt": "2026-07-02T10:34:06.891Z",
+  "sdKey": "SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001",
+  "createdAt": "2026-07-03T00:33:29.205Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/database/migrations/20260703_merge_witness_telemetry.sql
+++ b/database/migrations/20260703_merge_witness_telemetry.sql
@@ -1,0 +1,45 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- Migration: merge_witness_telemetry — OBSERVE-ONLY audit of the mergeWork() P1-P5 precondition ladder.
+-- SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (FR-3). One row per ladder evaluation, every PR merge attempt, all lanes.
+-- Additive (new table) — no change to any existing table. Chairman-gated apply (requires_chairman_apply).
+-- Written server-side only from lib/ship/auto-merge.mjs via the service-role client; RLS mirrors solomon_advice_outcome_ledger.
+-- DATABASE sub-agent pre-implementation review: sub_agent_execution_results row 44085d71-b5c4-4201-9da3-37b15a0c62d7 (CONDITIONAL_PASS, confidence 92).
+
+CREATE TABLE IF NOT EXISTS merge_witness_telemetry (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pr_number     INTEGER NOT NULL,
+  repo          TEXT,
+  work_key      TEXT,
+  tier          TEXT,
+  lane          TEXT NOT NULL,
+  via_mergework BOOLEAN NOT NULL DEFAULT true,
+  overall       TEXT NOT NULL DEFAULT 'observe-only',
+  rungs         JSONB NOT NULL,          -- [{id:'P1',status,reason}, ... x5]
+  evaluated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_merge_witness_telemetry_pr ON merge_witness_telemetry(pr_number);
+CREATE INDEX IF NOT EXISTS idx_merge_witness_telemetry_evaluated_at ON merge_witness_telemetry(evaluated_at DESC);
+-- Serves the Ship-witness D adoption gauge: GROUP BY lane WHERE evaluated_at >= now()-interval '7 days'.
+CREATE INDEX IF NOT EXISTS idx_merge_witness_telemetry_lane_evaluated_at ON merge_witness_telemetry(lane, evaluated_at DESC);
+
+ALTER TABLE merge_witness_telemetry ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS merge_witness_telemetry_read ON merge_witness_telemetry;
+CREATE POLICY merge_witness_telemetry_read ON merge_witness_telemetry
+  FOR SELECT USING (auth.role() = 'authenticated' OR auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS merge_witness_telemetry_service_write ON merge_witness_telemetry;
+CREATE POLICY merge_witness_telemetry_service_write ON merge_witness_telemetry
+  FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+
+COMMENT ON TABLE merge_witness_telemetry IS 'OBSERVE-ONLY audit of the mergeWork() P1-P5 precondition ladder (SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001). One row per evaluation; never changes any lane merge decision. rungs=[{id,status,reason}] with status IN (pass|fail|not_applicable|not_evaluable). Powers the Ship-witness D adoption gauge.';
+
+-- Rollback:
+-- DROP POLICY IF EXISTS merge_witness_telemetry_service_write ON merge_witness_telemetry;
+-- DROP POLICY IF EXISTS merge_witness_telemetry_read ON merge_witness_telemetry;
+-- DROP INDEX IF EXISTS idx_merge_witness_telemetry_lane_evaluated_at;
+-- DROP INDEX IF EXISTS idx_merge_witness_telemetry_evaluated_at;
+-- DROP INDEX IF EXISTS idx_merge_witness_telemetry_pr;
+-- DROP TABLE IF EXISTS merge_witness_telemetry;

--- a/database/schema-reference-snapshot.json
+++ b/database/schema-reference-snapshot.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-02T01:11:18.893Z",
+ "generated_at": "2026-07-03T02:18:31.866Z",
  "source": "scripts/lint/schema-reference-snapshot.mjs (pg_attribute/pg_class, schema public)",
- "table_count": 758,
+ "table_count": 759,
  "view_count": 170,
  "tables": {
   "_migration_metadata": "{key,value}",
@@ -394,6 +394,7 @@
   "mental_model_archetype_affinity": "{id,model_id,archetype,path,affinity_score,sample_size,confidence_level,updated_at}",
   "mental_model_effectiveness": "{id,model_id,stage_number,path,strategy,venture_archetype,application_count,avg_evaluation_score,avg_operator_rating,stage_progression_correlation,revenue_correlation,composite_effectiveness_score,last_calculated_at}",
   "mental_models": "{id,name,slug,category,description,core_concept,applicable_stages,applicable_paths,applicable_strategies,applicable_archetypes,difficulty_level,exercise_template,evaluation_rubric,artifact_template,prompt_context_block,is_active,created_at,updated_at}",
+  "merge_witness_telemetry": "{id,pr_number,repo,work_key,tier,lane,via_mergework,overall,rungs,evaluated_at,created_at}",
   "missions": "{id,venture_id,mission_text,version,status,proposed_by,approved_by,reasoning,created_at,updated_at}",
   "model_usage_log": "{id,session_id,sd_id,phase,subagent_type,subagent_configured_model,reported_model_name,reported_model_id,config_matches_reported,captured_at,metadata,provider_source}",
   "modeling_requests": "{id,subject,request_type,time_horizon_months,data_sources,input_parameters,status,projections,confidence_interval,actual_outcome,prediction_accuracy,venture_id,brief_id,nursery_id,requested_by,created_at,completed_at}",
@@ -583,7 +584,7 @@
   "service_tasks": "{id,venture_id,service_id,task_type,status,priority,artifacts,confidence_score,input_params,claimed_at,completed_at,error_message,metadata,created_at,updated_at}",
   "service_telemetry": "{id,task_id,venture_id,service_id,pr_url,pr_status,outcomes,venture_agent_version,reported_at,outcome,agent_version,processing_time_ms,feedback,service_key,event_type,confidence_score,routing_decision,metadata,created_at}",
   "service_versions": "{id,service_id,version,artifact_schema,changelog,deprecated_at,created_at}",
-  "session_coordination": "{id,target_session,target_sd,message_type,subject,body,payload,sender_session,sender_type,created_at,expires_at,read_at,acknowledged_at}",
+  "session_coordination": "{id,target_session,target_sd,message_type,subject,body,payload,sender_session,sender_type,created_at,expires_at,read_at,acknowledged_at,correlation_id}",
   "session_lifecycle_events": "{id,event_type,session_id,machine_id,terminal_id,pid,reason,latency_ms,metadata,created_at}",
   "ship_review_findings": "{id,pr_number,review_tier,risk_score,finding_count,finding_categories,verdict,sd_key,branch,multi_agent,reviewed_at,created_at,synthesized_at}",
   "shipping_decisions": "{id,sd_id,handoff_type,decision_type,decision,confidence,confidence_score,reasoning,context_snapshot,executed_at,execution_result,execution_duration_ms,escalated_to_human,human_decision,human_decision_at,human_notes,model,tokens_used,cost_usd,created_at,updated_at}",

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -16,6 +16,8 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { evaluateMergeWorkLadder } from './merge-witness-ladder.mjs';
+import { writeMergeWitnessTelemetry } from './merge-witness-telemetry.mjs';
 
 /**
  * C2 (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-2): platform repos
@@ -130,6 +132,50 @@ export function verifyMerged(prNumber, runner = defaultRunner) {
  *
  * @returns {true|false|null}
  */
+/**
+ * Fetch a PR's statusCheckRollup for the P3 rung of the mergeWork() ladder.
+ * Returns [] on lookup failure (evaluateP3CI reports not_evaluable for an
+ * empty rollup — never a false pass/fail).
+ */
+function fetchStatusCheckRollup(prNumber, runner = defaultRunner) {
+  const r = runner(['pr', 'view', String(prNumber), '--json', 'statusCheckRollup', '--jq', '.statusCheckRollup']);
+  if (r.code !== 0) return [];
+  try {
+    const parsed = JSON.parse(r.stdout.trim() || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (Ship-witness A) FR-4: evaluate the
+ * mergeWork() P1-P5 ladder and persist telemetry in SHADOW MODE for this merge
+ * attempt. This function's return value is discarded by callers — it exists
+ * purely to observe. Never throws: any failure inside is caught and logged so
+ * it can NEVER alter attemptAutoMerge()'s actual merge/no-merge outcome.
+ */
+async function observeMergeWorkLadder({
+  prNumber, repoOwner, repoName, workKey, tier, runner, merged, verifyResult,
+  lookupWorkKeyReal, fetchReviewFinding, supabase, lane, logger,
+}) {
+  try {
+    const statusCheckRollup = fetchStatusCheckRollup(prNumber, runner);
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, merged, verifyResult,
+    });
+    if (supabase) {
+      await writeMergeWitnessTelemetry(supabase, verdict, {
+        repo: repoOwner && repoName ? `${repoOwner}/${repoName}` : null,
+        lane: lane || 'ship-auto-merge',
+        logger,
+      });
+    }
+  } catch (e) {
+    logger?.warn?.(`⚠️  mergeWork() ladder observation failed (non-fatal, observe-only): ${e?.message || e}`);
+  }
+}
+
 export function verifyBranchDeleted(prNumber, repoOwner, repoName, runner = defaultRunner) {
   if (!repoOwner || !repoName) return null;
   const view = runner(['pr', 'view', String(prNumber), '--json', 'headRefName', '--jq', '.headRefName']);
@@ -161,6 +207,17 @@ export async function attemptAutoMerge({
   // override for the rare case a caller has a human already in the loop.
   isTrustedRepo = isPlatformRepo,
   allowExternalMerge = false,
+  // SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (Ship-witness A) FR-4: OBSERVE-ONLY
+  // mergeWork() P1-P5 ladder inputs. All optional and additive — omitting them
+  // (as every pre-existing caller does) still runs the ladder in shadow mode,
+  // just with more rungs reporting not_evaluable. Never affects the return
+  // value or control flow above this comment.
+  workKey = null,
+  tier = 'standard',
+  lane = 'ship-auto-merge',
+  lookupWorkKeyReal,
+  fetchReviewFinding,
+  witnessSupabase = null,
 }) {
   if (!prNumber) {
     return { ok: false, reason: 'prNumber required', exitCode: 2 };
@@ -221,6 +278,10 @@ export async function attemptAutoMerge({
       } else {
         logger.info(`✅ PR #${prNumber} merged (branch deletion not verified)`);
       }
+      await observeMergeWorkLadder({
+        prNumber, repoOwner, repoName, workKey, tier, runner, merged: true, verifyResult: { ok: true },
+        lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger,
+      });
       return { ok: true, action: 'merged', adminUsed: enforceAdmins };
     }
     // QF-20260504-195: gh pr merge exited 0 but mergedAt is null — the
@@ -239,6 +300,10 @@ export async function attemptAutoMerge({
     logger.info(
       `ℹ️  gh pr merge returned ${merge.code} but PR is already MERGED (concurrent-merge race) — continuing`,
     );
+    await observeMergeWorkLadder({
+      prNumber, repoOwner, repoName, workKey, tier, runner, merged: true, verifyResult: { ok: true },
+      lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger,
+    });
     return { ok: true, action: 'already-merged', adminUsed: enforceAdmins };
   }
 
@@ -254,6 +319,10 @@ export async function attemptAutoMerge({
   logger.error(
     `   Manual recovery: gh pr ready ${prNumber} && gh pr merge ${prNumber} --merge --delete-branch --admin`,
   );
+  await observeMergeWorkLadder({
+    prNumber, repoOwner, repoName, workKey, tier, runner, merged: false, verifyResult: { ok: false },
+    lookupWorkKeyReal, fetchReviewFinding, supabase: witnessSupabase, lane, logger,
+  });
   return {
     ok: false,
     reason,

--- a/lib/ship/ci-status.mjs
+++ b/lib/ship/ci-status.mjs
@@ -1,0 +1,40 @@
+/**
+ * Shared pure CI-status helpers for every merge lane.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 FR-1: extracted from
+ * scripts/modules/complete-quick-fix/git-operations.js (QF-20260702-515), which
+ * previously defined these functions locally for the quick-fix lane only. /ship's
+ * lib/ship/auto-merge.mjs attemptAutoMerge() had no CI precondition at all. Pulling
+ * these into a shared module lets both lanes (and the mergeWork() P1-P5 ladder,
+ * lib/ship/merge-witness-ladder.mjs) use the same CI-status logic instead of each
+ * lane reimplementing it independently.
+ *
+ * git-operations.js re-exports these three functions from here so the quick-fix
+ * lane's existing imports and behavior are unchanged.
+ */
+
+/**
+ * Classify a single statusCheckRollup entry as pending.
+ * Handles both CheckRun shape ({status,conclusion}) and legacy StatusContext shape ({state}).
+ */
+export function isCheckPending(check) {
+  if (check.status !== undefined) return check.status !== 'COMPLETED';
+  if (check.state !== undefined) return check.state === 'PENDING' || check.state === 'EXPECTED';
+  return false;
+}
+
+/** Classify a COMPLETED/non-pending check as failed. */
+export function isCheckFailed(check) {
+  if (check.conclusion != null) return ['FAILURE', 'TIMED_OUT', 'CANCELLED'].includes(check.conclusion);
+  if (check.state !== undefined) return check.state === 'FAILURE' || check.state === 'ERROR';
+  return false;
+}
+
+/** Pure summary of a PR's statusCheckRollup — no IO, fully unit-testable. */
+export function summarizeCIStatus(statusCheckRollup) {
+  const checks = Array.isArray(statusCheckRollup) ? statusCheckRollup : [];
+  const pending = checks.filter(isCheckPending);
+  const failed = checks.filter(c => !isCheckPending(c) && isCheckFailed(c));
+  return { total: checks.length, pending: pending.length, failed: failed.length,
+    isPending: pending.length > 0, hasFailed: failed.length > 0 };
+}

--- a/lib/ship/merge-witness-ladder.mjs
+++ b/lib/ship/merge-witness-ladder.mjs
@@ -1,0 +1,174 @@
+/**
+ * mergeWork() P1-P5 precondition ladder — OBSERVE-ONLY evaluator.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (Ship-witness A). Grounded in Solomon
+ * advisory solomon_advice_outcome_ledger id=879a6826 (correlation_id
+ * sprintC-B-finding-006-unified-ship-witness): every merge lane in this repo
+ * currently reinvents its own safety checks. This module evaluates a shared
+ * precondition ladder for a single merge attempt and returns a structured
+ * verdict — it NEVER blocks or alters the caller's merge decision. That is
+ * Ship-witness D's (SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001) job, once the
+ * telemetry this substrate produces shows 100% lane adoption for 7 days.
+ *
+ * Each rung reports one of four statuses (never a bare boolean, so "not yet
+ * checkable" is never silently folded into "pass" — mirrors the existing
+ * verifyBranchDeleted() true|false|null idiom in lib/ship/auto-merge.mjs):
+ *   pass          — precondition evaluated and satisfied
+ *   fail          — precondition evaluated and NOT satisfied
+ *   not_applicable — precondition does not apply yet (e.g. P4 pre-P0)
+ *   not_evaluable — cannot currently be checked (e.g. P2's actor-separation
+ *                    dimension has no supporting columns yet)
+ *
+ * P1 (admission) and P2 (witness) need a DB lookup; the lookups are injected
+ * (lookupWorkKeyReal, fetchReviewFinding) rather than hard-wired to a specific
+ * client, so this module has no direct Supabase dependency and every rung is
+ * unit-testable in isolation. P3 reuses the shared summarizeCIStatus helper
+ * (lib/ship/ci-status.mjs, FR-1). P5 reuses verifyMerged/verifyBranchDeleted
+ * from lib/ship/auto-merge.mjs rather than reimplementing verification.
+ */
+
+import { summarizeCIStatus } from './ci-status.mjs';
+
+export const RUNG_STATUS = Object.freeze({
+  PASS: 'pass',
+  FAIL: 'fail',
+  NOT_APPLICABLE: 'not_applicable',
+  NOT_EVALUABLE: 'not_evaluable',
+});
+
+function rung(id, status, reason) {
+  return { id, status, reason };
+}
+
+/**
+ * P1 ADMISSION: workKey must resolve to a real SD or QF row, not a
+ * synthetic/test fixture. lookupWorkKeyReal(workKey) => Promise<boolean|null>
+ * (null = lookup itself failed — recorded as not_evaluable, not a false fail).
+ */
+export async function evaluateP1Admission({ workKey, lookupWorkKeyReal }) {
+  if (!workKey) return rung('P1', RUNG_STATUS.FAIL, 'no workKey supplied');
+  if (typeof lookupWorkKeyReal !== 'function') {
+    return rung('P1', RUNG_STATUS.NOT_EVALUABLE, 'no lookupWorkKeyReal injected');
+  }
+  let isReal;
+  try {
+    isReal = await lookupWorkKeyReal(workKey);
+  } catch (e) {
+    return rung('P1', RUNG_STATUS.NOT_EVALUABLE, `lookup threw: ${e?.message || e}`);
+  }
+  if (isReal === null || isReal === undefined) {
+    return rung('P1', RUNG_STATUS.NOT_EVALUABLE, 'lookup could not determine workKey origin');
+  }
+  return isReal
+    ? rung('P1', RUNG_STATUS.PASS, `workKey ${workKey} resolves to a real SD/QF row`)
+    : rung('P1', RUNG_STATUS.FAIL, `workKey ${workKey} does not resolve to a real SD/QF row`);
+}
+
+/**
+ * P2 WITNESS: a ship_review_findings row must exist for this PR with
+ * verdict='pass'. Reviewer/author actor-separation (tier>=standard) is NOT
+ * evaluable today — ship_review_findings has no actor columns (confirmed
+ * against database/migrations/20260408_create_ship_review_findings.sql) — so
+ * that dimension is reported separately and never folded into a false pass.
+ * fetchReviewFinding(prNumber) => Promise<{verdict}|null>.
+ */
+export async function evaluateP2Witness({ prNumber, tier, fetchReviewFinding }) {
+  if (typeof fetchReviewFinding !== 'function') {
+    return rung('P2', RUNG_STATUS.NOT_EVALUABLE, 'no fetchReviewFinding injected');
+  }
+  let finding;
+  try {
+    finding = await fetchReviewFinding(prNumber);
+  } catch (e) {
+    return rung('P2', RUNG_STATUS.NOT_EVALUABLE, `lookup threw: ${e?.message || e}`);
+  }
+  if (!finding) {
+    return rung('P2', RUNG_STATUS.FAIL, `no ship_review_findings row for PR #${prNumber}`);
+  }
+  const verdictPass = finding.verdict === 'pass';
+  const actorNote = tier === 'light'
+    ? 'actor-separation not required at tier=light'
+    : 'actor-separation dimension not_evaluable — ship_review_findings has no actor columns yet';
+  return verdictPass
+    ? rung('P2', RUNG_STATUS.PASS, `verdict=pass for PR #${prNumber}; ${actorNote}`)
+    : rung('P2', RUNG_STATUS.FAIL, `verdict=${finding.verdict} for PR #${prNumber}`);
+}
+
+/** P3 CI: statusCheckRollup via the shared summarizeCIStatus helper. Pure — no IO. */
+export function evaluateP3CI({ statusCheckRollup }) {
+  const summary = summarizeCIStatus(statusCheckRollup);
+  if (summary.total === 0) {
+    return rung('P3', RUNG_STATUS.NOT_EVALUABLE, 'no CI checks reported for this PR');
+  }
+  if (summary.isPending) {
+    return rung('P3', RUNG_STATUS.NOT_EVALUABLE, `${summary.pending}/${summary.total} check(s) still pending`);
+  }
+  return summary.hasFailed
+    ? rung('P3', RUNG_STATUS.FAIL, `${summary.failed}/${summary.total} check(s) failed`)
+    : rung('P3', RUNG_STATUS.PASS, `all ${summary.total} check(s) passed`);
+}
+
+/**
+ * P4 PROTECTION INTEGRITY: always not_applicable until GitHub branch
+ * protection (P0) has landed on the platform repos — there is nothing to
+ * enforce integrity of yet, and the escapeAuth audit table this rung would
+ * eventually check is a separate out-of-scope chairman-gated migration.
+ */
+export function evaluateP4ProtectionIntegrity() {
+  return rung('P4', RUNG_STATUS.NOT_APPLICABLE, 'pre-P0: GitHub branch protection not yet enabled on this repo');
+}
+
+/**
+ * P5 POST-VERIFY: delegates to the EXISTING verifyMerged/verifyBranchDeleted
+ * from lib/ship/auto-merge.mjs. Only meaningful after a merge attempt has
+ * actually completed; not_applicable beforehand.
+ */
+export function evaluateP5PostVerify({ merged, verifyResult }) {
+  if (!merged) {
+    return rung('P5', RUNG_STATUS.NOT_APPLICABLE, 'merge attempt has not completed yet');
+  }
+  if (!verifyResult) {
+    return rung('P5', RUNG_STATUS.NOT_EVALUABLE, 'no verify result supplied');
+  }
+  return verifyResult.ok
+    ? rung('P5', RUNG_STATUS.PASS, 'verifyMerged confirmed post-merge state')
+    : rung('P5', RUNG_STATUS.FAIL, 'verifyMerged could not confirm post-merge state');
+}
+
+/**
+ * Top-level orchestrator: evaluates P1-P5 in fixed order and returns a
+ * structured, OBSERVE-ONLY verdict. Never throws for a rung-level failure —
+ * every evaluator above degrades to a rung status, never an exception.
+ *
+ * @param {{
+ *   prNumber: number|string, repoOwner?: string, repoName?: string,
+ *   workKey?: string, tier?: string,
+ *   lookupWorkKeyReal?: (workKey: string) => Promise<boolean|null>,
+ *   fetchReviewFinding?: (prNumber: number|string) => Promise<{verdict:string}|null>,
+ *   statusCheckRollup?: Array, merged?: boolean, verifyResult?: {ok:boolean},
+ * }} params
+ */
+export async function evaluateMergeWorkLadder({
+  prNumber,
+  workKey,
+  tier = 'standard',
+  lookupWorkKeyReal,
+  fetchReviewFinding,
+  statusCheckRollup = [],
+  merged = false,
+  verifyResult = null,
+}) {
+  const p1 = await evaluateP1Admission({ workKey, lookupWorkKeyReal });
+  const p2 = await evaluateP2Witness({ prNumber, tier, fetchReviewFinding });
+  const p3 = evaluateP3CI({ statusCheckRollup });
+  const p4 = evaluateP4ProtectionIntegrity();
+  const p5 = evaluateP5PostVerify({ merged, verifyResult });
+
+  return {
+    overall: 'observe-only',
+    prNumber,
+    workKey: workKey ?? null,
+    tier,
+    rungs: [p1, p2, p3, p4, p5],
+  };
+}

--- a/lib/ship/merge-witness-telemetry.mjs
+++ b/lib/ship/merge-witness-telemetry.mjs
@@ -1,0 +1,42 @@
+/**
+ * Telemetry writer for the mergeWork() P1-P5 precondition ladder.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 FR-3. Persists one row per
+ * evaluateMergeWorkLadder() result into the additive merge_witness_telemetry
+ * table (database/migrations/20260703_merge_witness_telemetry.sql).
+ *
+ * Best-effort by design: a telemetry write failure must NEVER propagate into
+ * a merge lane's control flow (FR-4's whole premise is that this substrate is
+ * observe-only and cannot make a merge attempt behave differently than it did
+ * before this SD). Callers should not await-and-throw on this; writeTelemetry
+ * itself swallows and logs instead of rejecting.
+ */
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ overall: string, prNumber: number|string, workKey: string|null, tier: string, rungs: Array }} verdict
+ * @param {{ repo?: string, lane: string, logger?: { warn: Function } }} p
+ * @returns {Promise<{ ok: boolean, error: string|null }>}
+ */
+export async function writeMergeWitnessTelemetry(supabase, verdict, { repo = null, lane, logger = console }) {
+  try {
+    const { error } = await supabase.from('merge_witness_telemetry').insert({
+      pr_number: Number(verdict.prNumber),
+      repo,
+      work_key: verdict.workKey ?? null,
+      tier: verdict.tier ?? null,
+      lane,
+      via_mergework: true,
+      overall: verdict.overall,
+      rungs: verdict.rungs,
+    });
+    if (error) {
+      logger.warn?.(`⚠️  merge_witness_telemetry insert failed (non-fatal, observe-only): ${error.message}`);
+      return { ok: false, error: error.message };
+    }
+    return { ok: true, error: null };
+  } catch (e) {
+    logger.warn?.(`⚠️  merge_witness_telemetry insert threw (non-fatal, observe-only): ${e?.message || e}`);
+    return { ok: false, error: e?.message || String(e) };
+  }
+}

--- a/scripts/modules/complete-quick-fix/git-operations.js
+++ b/scripts/modules/complete-quick-fix/git-operations.js
@@ -922,31 +922,12 @@ function displayManualCommitInstructions(qf, currentBranch) {
   console.log(`      git push -u origin ${currentBranch}\n`);
 }
 
-/**
- * Classify one entry from `gh pr view --json statusCheckRollup` as pending or not.
- * Handles both CheckRun shape ({status,conclusion}) and legacy StatusContext shape ({state}).
- */
-export function isCheckPending(check) {
-  if (check.status !== undefined) return check.status !== 'COMPLETED';
-  if (check.state !== undefined) return check.state === 'PENDING' || check.state === 'EXPECTED';
-  return false;
-}
-
-/** Classify a COMPLETED/non-pending check as failed. */
-export function isCheckFailed(check) {
-  if (check.conclusion != null) return ['FAILURE', 'TIMED_OUT', 'CANCELLED'].includes(check.conclusion);
-  if (check.state !== undefined) return check.state === 'FAILURE' || check.state === 'ERROR';
-  return false;
-}
-
-/** Pure summary of a PR's statusCheckRollup — no IO, fully unit-testable. */
-export function summarizeCIStatus(statusCheckRollup) {
-  const checks = Array.isArray(statusCheckRollup) ? statusCheckRollup : [];
-  const pending = checks.filter(isCheckPending);
-  const failed = checks.filter(c => !isCheckPending(c) && isCheckFailed(c));
-  return { total: checks.length, pending: pending.length, failed: failed.length,
-    isPending: pending.length > 0, hasFailed: failed.length > 0 };
-}
+// SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 FR-1: isCheckPending/isCheckFailed/
+// summarizeCIStatus moved to lib/ship/ci-status.mjs so every merge lane (not just
+// quick-fix) shares one CI-status implementation. Re-exported here so existing
+// imports of this module are unaffected.
+export { isCheckPending, isCheckFailed, summarizeCIStatus } from '../../../lib/ship/ci-status.mjs';
+import { summarizeCIStatus } from '../../../lib/ship/ci-status.mjs';
 
 const CI_POLL_INTERVAL_MS = 15_000;
 const CI_POLL_TIMEOUT_MS = 20 * 60_000;

--- a/tests/integration/ship/merge-witness-telemetry-live.db.test.js
+++ b/tests/integration/ship/merge-witness-telemetry-live.db.test.js
@@ -1,0 +1,88 @@
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 — live smoke-write against the real
+ * merge_witness_telemetry table (database/migrations/20260703_merge_witness_telemetry.sql).
+ * Closes the mock-only DB-write coverage gap flagged by TESTING sub-agent
+ * evidence row 83d6c6c0 before Ship-witness D depends on this data existing.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { createSupabaseServiceClient } from '../../../lib/supabase-client.js';
+import { evaluateMergeWorkLadder } from '../../../lib/ship/merge-witness-ladder.mjs';
+import { writeMergeWitnessTelemetry } from '../../../lib/ship/merge-witness-telemetry.mjs';
+
+const HAS_REAL_DB = process.env.SUPABASE_URL
+  && !process.env.SUPABASE_URL.includes('test.invalid.local')
+  && process.env.SUPABASE_SERVICE_ROLE_KEY
+  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+
+const supabase = createSupabaseServiceClient();
+const insertedIds = [];
+
+afterEach(async () => {
+  if (insertedIds.length) {
+    await supabase.from('merge_witness_telemetry').delete().in('id', insertedIds);
+    insertedIds.length = 0;
+  }
+});
+
+describe.skipIf(!HAS_REAL_DB)('merge_witness_telemetry — live smoke-write', () => {
+  it('writeMergeWitnessTelemetry persists a real row matching evaluateMergeWorkLadder\'s output', async () => {
+    const prNumber = 900000 + Math.floor(Math.random() * 99999);
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber,
+      workKey: 'SD-TEST-LIVE-WITNESS-001',
+      tier: 'standard',
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      merged: true,
+      verifyResult: { ok: true },
+    });
+
+    const result = await writeMergeWitnessTelemetry(supabase, verdict, {
+      repo: 'rickfelix/EHG_Engineer',
+      lane: 'test-smoke-write',
+    });
+    expect(result.ok).toBe(true);
+
+    const { data, error } = await supabase
+      .from('merge_witness_telemetry')
+      .select('*')
+      .eq('pr_number', prNumber)
+      .eq('lane', 'test-smoke-write')
+      .maybeSingle();
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    insertedIds.push(data.id);
+
+    expect(data.work_key).toBe('SD-TEST-LIVE-WITNESS-001');
+    expect(data.tier).toBe('standard');
+    expect(data.via_mergework).toBe(true);
+    expect(data.overall).toBe('observe-only');
+    expect(data.rungs).toHaveLength(5);
+    const p3 = data.rungs.find((r) => r.id === 'P3');
+    expect(p3.status).toBe('pass');
+  }, 15_000);
+
+  it('a telemetry write failure (bad table target simulation via null pr_number) is reported non-fatally', async () => {
+    const badVerdict = { overall: 'observe-only', prNumber: null, workKey: null, tier: 'standard', rungs: [] };
+    const result = await writeMergeWitnessTelemetry(supabase, badVerdict, {
+      repo: 'rickfelix/EHG_Engineer',
+      lane: 'test-smoke-write-failure',
+    });
+    // pr_number is NOT NULL in the schema -- Number(null) is 0, which the DB
+    // constraint accepts (0 is a valid integer), so this actually succeeds.
+    // The real non-fatal-failure guarantee is proven by the throwing/erroring
+    // mock-supabase cases in auto-merge-witness-integration.test.js; this test
+    // instead confirms writeMergeWitnessTelemetry's return contract ({ok,error})
+    // is well-formed against the LIVE client for both outcomes.
+    expect(typeof result.ok).toBe('boolean');
+    if (result.ok) {
+      const { data } = await supabase
+        .from('merge_witness_telemetry')
+        .select('id')
+        .eq('lane', 'test-smoke-write-failure')
+        .maybeSingle();
+      if (data) insertedIds.push(data.id);
+    }
+  }, 15_000);
+});

--- a/tests/unit/ship/auto-merge-witness-integration.test.js
+++ b/tests/unit/ship/auto-merge-witness-integration.test.js
@@ -1,0 +1,114 @@
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 FR-4
+ * TS-4: a telemetry write failure never alters attemptAutoMerge()'s outcome.
+ * Also proves the happy path DOES persist a telemetry row when a supabase
+ * client is supplied, with the expected shape.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { attemptAutoMerge } from '../../../lib/ship/auto-merge.mjs';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+function makeRunner(responses) {
+  const runner = (args) => {
+    for (const { match, result } of responses) {
+      if (match(args)) return { code: 0, stdout: '', stderr: '', ...result };
+    }
+    return { code: 1, stdout: '', stderr: 'unmatched gh call' };
+  };
+  return runner;
+}
+
+const argvMatchers = {
+  prViewIsDraft: (args) => args[0] === 'pr' && args[1] === 'view' && args.includes('isDraft'),
+  prViewMergedAt: (args) => args[0] === 'pr' && args[1] === 'view' && args.includes('mergedAt'),
+  prViewState: (args) => args[0] === 'pr' && args[1] === 'view' && args.includes('state'),
+  apiProtection: (args) => args[0] === 'api' && args[1]?.includes('/protection'),
+  prMerge: (args) => args[0] === 'pr' && args[1] === 'merge',
+};
+
+function makeHappyPathRunner() {
+  return makeRunner([
+    { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+    { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+    { match: argvMatchers.prMerge, result: { stdout: '' } },
+    { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-07-03T00:00:00Z\n' } },
+    { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+  ]);
+}
+
+function makeThrowingSupabase() {
+  return {
+    from: () => ({
+      insert: async () => { throw new Error('connection reset'); },
+    }),
+  };
+}
+
+function makeRecordingSupabase() {
+  const inserts = [];
+  return {
+    inserts,
+    from: (table) => ({
+      insert: async (row) => { inserts.push({ table, row }); return { error: null }; },
+    }),
+  };
+}
+
+describe('attemptAutoMerge — mergeWork() ladder shadow-mode integration (FR-4)', () => {
+  it('TS-4: a telemetry write that throws does not alter the merge result', async () => {
+    const runner = makeHappyPathRunner();
+    const r = await attemptAutoMerge({
+      prNumber: 99,
+      repoOwner: 'rickfelix',
+      repoName: 'EHG_Engineer',
+      runner,
+      logger: silentLogger,
+      witnessSupabase: makeThrowingSupabase(),
+    });
+    expect(r).toEqual({ ok: true, action: 'merged', adminUsed: false });
+  });
+
+  it('happy path persists exactly one telemetry row with the expected shape', async () => {
+    const runner = makeHappyPathRunner();
+    const supabase = makeRecordingSupabase();
+    const r = await attemptAutoMerge({
+      prNumber: 100,
+      repoOwner: 'rickfelix',
+      repoName: 'EHG_Engineer',
+      runner,
+      logger: silentLogger,
+      workKey: 'SD-TEST-001',
+      tier: 'standard',
+      witnessSupabase: supabase,
+    });
+
+    expect(r.ok).toBe(true);
+    expect(supabase.inserts).toHaveLength(1);
+    expect(supabase.inserts[0].table).toBe('merge_witness_telemetry');
+    const row = supabase.inserts[0].row;
+    expect(row.pr_number).toBe(100);
+    expect(row.repo).toBe('rickfelix/EHG_Engineer');
+    expect(row.work_key).toBe('SD-TEST-001');
+    expect(row.lane).toBe('ship-auto-merge');
+    expect(row.via_mergework).toBe(true);
+    expect(row.overall).toBe('observe-only');
+    expect(row.rungs).toHaveLength(5);
+  });
+
+  it('a telemetry insert() DB error (not a throw) also does not alter the merge result', async () => {
+    const runner = makeHappyPathRunner();
+    const erroringSupabase = {
+      from: () => ({ insert: async () => ({ error: { message: 'unique violation' } }) }),
+    };
+    const r = await attemptAutoMerge({
+      prNumber: 101,
+      repoOwner: 'rickfelix',
+      repoName: 'EHG_Engineer',
+      runner,
+      logger: silentLogger,
+      witnessSupabase: erroringSupabase,
+    });
+    expect(r).toEqual({ ok: true, action: 'merged', adminUsed: false });
+  });
+});

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -145,11 +145,16 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
     // additional gh api call is made when the headRefName lookup fails.
     // QF-20260516-082: verifyMerged cross-checks state==='MERGED' after
     // mergedAt, adding one more pr-view call to the happy path.
+    // SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 FR-4: the mergeWork() P1-P5
+    // ladder observes every merge attempt in shadow mode, adding one final
+    // read-only pr-view (statusCheckRollup, for the P3 rung) after the merge
+    // succeeds. It never affects `r` above — only appends to the call log.
     expect(calls.map((c) => c.slice(0, 2))).toEqual([
       ['pr', 'view'],
       ['pr', 'ready'],
       ['api', 'repos/rickfelix/EHG_Engineer/branches/main/protection'],
       ['pr', 'merge'],
+      ['pr', 'view'],
       ['pr', 'view'],
       ['pr', 'view'],
       ['pr', 'view'],

--- a/tests/unit/ship/merge-witness-ladder.test.js
+++ b/tests/unit/ship/merge-witness-ladder.test.js
@@ -1,0 +1,160 @@
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001
+ * TS-1, TS-2, TS-3: mergeWork() P1-P5 precondition ladder — OBSERVE-ONLY.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  RUNG_STATUS,
+  evaluateP1Admission,
+  evaluateP2Witness,
+  evaluateP3CI,
+  evaluateP4ProtectionIntegrity,
+  evaluateP5PostVerify,
+  evaluateMergeWorkLadder,
+} from '../../../lib/ship/merge-witness-ladder.mjs';
+
+function rungFor(verdict, id) {
+  return verdict.rungs.find((r) => r.id === id);
+}
+
+describe('evaluateP1Admission', () => {
+  it('pass: workKey resolves to a real SD/QF row', async () => {
+    const r = await evaluateP1Admission({ workKey: 'SD-XXX-001', lookupWorkKeyReal: async () => true });
+    expect(r.status).toBe(RUNG_STATUS.PASS);
+  });
+
+  it('fail: workKey does not resolve to a real row', async () => {
+    const r = await evaluateP1Admission({ workKey: 'SD-FAKE-001', lookupWorkKeyReal: async () => false });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+
+  it('fail: no workKey supplied', async () => {
+    const r = await evaluateP1Admission({ workKey: null, lookupWorkKeyReal: async () => true });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+
+  it('not_evaluable: no lookup injected', async () => {
+    const r = await evaluateP1Admission({ workKey: 'SD-XXX-001' });
+    expect(r.status).toBe(RUNG_STATUS.NOT_EVALUABLE);
+  });
+
+  it('not_evaluable: lookup throws', async () => {
+    const r = await evaluateP1Admission({ workKey: 'SD-XXX-001', lookupWorkKeyReal: async () => { throw new Error('db down'); } });
+    expect(r.status).toBe(RUNG_STATUS.NOT_EVALUABLE);
+  });
+});
+
+describe('evaluateP2Witness', () => {
+  it('pass: verdict=pass row exists (standard tier — actor-separation flagged not_evaluable in reason, not folded into pass)', async () => {
+    const r = await evaluateP2Witness({ prNumber: 123, tier: 'standard', fetchReviewFinding: async () => ({ verdict: 'pass' }) });
+    expect(r.status).toBe(RUNG_STATUS.PASS);
+    expect(r.reason).toMatch(/not_evaluable/);
+  });
+
+  it('fail: verdict=block', async () => {
+    const r = await evaluateP2Witness({ prNumber: 123, tier: 'standard', fetchReviewFinding: async () => ({ verdict: 'block' }) });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+
+  it('fail: no row found', async () => {
+    const r = await evaluateP2Witness({ prNumber: 123, tier: 'standard', fetchReviewFinding: async () => null });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+
+  it('not_evaluable: no fetch injected', async () => {
+    const r = await evaluateP2Witness({ prNumber: 123, tier: 'standard' });
+    expect(r.status).toBe(RUNG_STATUS.NOT_EVALUABLE);
+  });
+});
+
+describe('evaluateP3CI', () => {
+  it('pass: all checks succeeded', () => {
+    const r = evaluateP3CI({ statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }] });
+    expect(r.status).toBe(RUNG_STATUS.PASS);
+  });
+
+  it('fail: a check failed', () => {
+    const r = evaluateP3CI({ statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }] });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+
+  it('not_evaluable: checks still pending', () => {
+    const r = evaluateP3CI({ statusCheckRollup: [{ status: 'IN_PROGRESS' }] });
+    expect(r.status).toBe(RUNG_STATUS.NOT_EVALUABLE);
+  });
+
+  it('not_evaluable: no checks reported', () => {
+    const r = evaluateP3CI({ statusCheckRollup: [] });
+    expect(r.status).toBe(RUNG_STATUS.NOT_EVALUABLE);
+  });
+});
+
+describe('evaluateP4ProtectionIntegrity', () => {
+  it('always not_applicable pre-P0', () => {
+    expect(evaluateP4ProtectionIntegrity().status).toBe(RUNG_STATUS.NOT_APPLICABLE);
+  });
+});
+
+describe('evaluateP5PostVerify', () => {
+  it('not_applicable before a merge attempt completes', () => {
+    const r = evaluateP5PostVerify({ merged: false, verifyResult: null });
+    expect(r.status).toBe(RUNG_STATUS.NOT_APPLICABLE);
+  });
+
+  it('pass when verifyResult.ok is true', () => {
+    const r = evaluateP5PostVerify({ merged: true, verifyResult: { ok: true } });
+    expect(r.status).toBe(RUNG_STATUS.PASS);
+  });
+
+  it('fail when verifyResult.ok is false', () => {
+    const r = evaluateP5PostVerify({ merged: true, verifyResult: { ok: false } });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+});
+
+describe('evaluateMergeWorkLadder — full ladder (TS-1, TS-2, TS-3)', () => {
+  it('TS-1: green CI, real workKey, passing review finding — all rungs evaluate cleanly, overall observe-only', async () => {
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber: 42,
+      workKey: 'SD-REAL-001',
+      tier: 'standard',
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      merged: false,
+    });
+    expect(verdict.overall).toBe('observe-only');
+    expect(rungFor(verdict, 'P1').status).toBe(RUNG_STATUS.PASS);
+    expect(rungFor(verdict, 'P2').status).toBe(RUNG_STATUS.PASS);
+    expect(rungFor(verdict, 'P3').status).toBe(RUNG_STATUS.PASS);
+    expect(rungFor(verdict, 'P4').status).toBe(RUNG_STATUS.NOT_APPLICABLE);
+    expect(rungFor(verdict, 'P5').status).toBe(RUNG_STATUS.NOT_APPLICABLE);
+    expect(verdict.rungs).toHaveLength(5);
+  });
+
+  it('TS-2: failed CI check is recorded in the verdict without the ladder throwing or blocking anything itself', async () => {
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber: 43,
+      workKey: 'SD-REAL-001',
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }],
+    });
+    expect(rungFor(verdict, 'P3').status).toBe(RUNG_STATUS.FAIL);
+    // the ladder itself never has an "enforce" concept — overall stays observe-only
+    expect(verdict.overall).toBe('observe-only');
+  });
+
+  it('TS-3: workKey does not resolve to a real row — P1 fails, ladder still completes (observe-only)', async () => {
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber: 44,
+      workKey: 'SCRATCH-TEST-001',
+      lookupWorkKeyReal: async () => false,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    });
+    expect(rungFor(verdict, 'P1').status).toBe(RUNG_STATUS.FAIL);
+    expect(verdict.overall).toBe('observe-only');
+    expect(verdict.rungs).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts shared CI-status helpers (`lib/ship/ci-status.mjs`) from the quick-fix lane's git-operations module so both lanes share one implementation
- Adds `lib/ship/merge-witness-ladder.mjs`: a pure P1-P5 precondition evaluator (admission, witness/review, CI status, protection integrity, post-verify) using a 4-state `pass|fail|not_applicable|not_evaluable` model — never folds "not yet checkable" into a false pass
- Adds an additive, RLS-enabled `merge_witness_telemetry` table (already applied to production, chairman-gated) and a best-effort writer that can never throw into a merge lane's control flow
- Wires `/ship`'s `attemptAutoMerge()` to observe (not enforce) every merge attempt via the ladder — OBSERVE-ONLY because P0 (branch protection) hasn't landed yet, so there's nothing safe to enforce against yet

Grounded in Solomon advisory `solomon_advice_outcome_ledger` id=879a6826 (`sprintC-B-finding-006-unified-ship-witness`).

## Test plan
- [x] `tests/unit/ship/merge-witness-ladder.test.js` — 20 tests covering every rung's pass/fail/not_applicable/not_evaluable path + 3 full-ladder scenarios
- [x] `tests/unit/ship/auto-merge.test.js` — 39 tests, all passing (1 call-sequence assertion updated for the new shadow-mode read, confirmed by REGRESSION sub-agent as non-masking)
- [x] `tests/unit/ship/auto-merge-witness-integration.test.js` — 3 tests, including TS-4 (telemetry write throws → merge result unaffected)
- [x] `tests/integration/ship/merge-witness-telemetry-live.db.test.js` — live smoke-write against the real production table, closes a TESTING-flagged mock-only coverage gap
- [x] `tests/unit/complete-quick-fix/skip-ci-wait-gate.test.js` — 12/12 pass unchanged, confirms zero regression from the CI-status extraction

SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)