### PR TITLE
fix(QF-20260702-806): WIRE_CHECK_GATE: lib/ship/ is markdown-invoked (via /ship's import() snippet), not statically traceable

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001",
-  "createdAt": "2026-07-03T00:33:29.205Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
-  "baseRef": "origin/main"
+  "sdKey": "QF-20260702-806",
+  "workType": "QF",
+  "workKey": "QF-20260702-806",
+  "expectedBranch": "qf/QF-20260702-806",
+  "createdAt": "2026-07-03T02:48:31.286Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
@@ -143,7 +143,17 @@ export const KNOWN_DYNAMIC_PATTERNS = [
   // sub-agents exemptions (config-registered, not require-reachable).
   // SD-FDBK-ENH-FLEET-WORKER-ATTRITION-001 (stop-loop-wakeup-reminder.cjs was the first new
   // hook to hit this false-positive at LEAD-FINAL).
-  /(^|\/)scripts\/hooks\//
+  /(^|\/)scripts\/hooks\//,
+  // lib/ship/ — auto-merge.mjs (and its helper modules) is invoked exclusively via a
+  // dynamic `import('./lib/ship/auto-merge.mjs')` embedded in .claude/commands/ship.md
+  // prose (the /ship Step 6 hardened auto-merge sequence), never from a package.json
+  // script or any static JS entry point. Same architectural shape as the eva-support /
+  // sub-agents / hooks exemptions above (markdown-invoked, no static reachability from
+  // the current entry-point set). Predates SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001
+  // (auto-merge.mjs itself shipped via SD-LEO-INFRA-SHIP-AUTO-MERGE-001) but no SD had
+  // added a NEW file to lib/ship/ since WIRE_CHECK_GATE went required:true until then.
+  // QF-20260702-806.
+  /(^|\/)lib\/ship\//
 ];
 
 /**

--- a/tests/unit/handoff/wire-check-gate.test.js
+++ b/tests/unit/handoff/wire-check-gate.test.js
@@ -189,6 +189,24 @@ describe('EXCLUSION_PATTERNS (FR-1)', () => {
       expect(isExcludedFromWireCheck('lib/agents/auto-selector.js')).toBe(false);
     });
   });
+
+  // QF-20260702-806: lib/ship/auto-merge.mjs (and its helper modules) is loaded ONLY via
+  // a dynamic `import('./lib/ship/auto-merge.mjs')` embedded in .claude/commands/ship.md
+  // prose, which static AST cannot trace, so every newly-added lib/ship/ module appears
+  // unreachable to WIRE_CHECK.
+  describe('KNOWN_DYNAMIC_PATTERNS — lib/ship markdown-invoked tree (QF-20260702-806)', () => {
+    it('excludes lib/ship/** modules', () => {
+      expect(isExcludedFromWireCheck('lib/ship/auto-merge.mjs')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/ship/ci-status.mjs')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/ship/merge-witness-ladder.mjs')).toBe(true);
+      expect(isExcludedFromWireCheck('lib/ship/merge-witness-telemetry.mjs')).toBe(true);
+    });
+
+    it('does NOT over-match lookalike paths (boundary-safe)', () => {
+      expect(isExcludedFromWireCheck('lib/shipping/x.js')).toBe(false);
+      expect(isExcludedFromWireCheck('scripts/ship/x.js')).toBe(false);
+    });
+  });
 });
 
 describe('call-graph-builder barrel re-export resolution (FR-2 AC-1)', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260702-806

**Type:** bug
**Severity:** medium

### Issue Description
lib/ship/auto-merge.mjs is invoked exclusively via a dynamic import() embedded in .claude/commands/ship.md prose (line ~496), never from a package.json script or any static JS entry point -- same architectural shape as the existing lib/eva-support/, scripts/eva-support/, lib/sub-agents/, and scripts/hooks/ entries in KNOWN_DYNAMIC_PATTERNS. Predates SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (lib/ship/auto-merge.mjs shipped via SD-LEO-INFRA-SHIP-AUTO-MERGE-001) but no SD ever added a NEW file to lib/ship/ before, so WIRE_CHECK_GATE never tripped on it until now.

### Steps to Reproduce
Add any new .mjs file under lib/ship/ that is imported only by auto-merge.mjs, then run LEAD-FINAL-APPROVAL for that SD

### Expected Behavior
WIRE_CHECK_GATE passes, recognizing lib/ship/ as markdown-invoked (same class as lib/eva-support/)

### Actual Behavior
WIRE_CHECK_GATE_FAILED: new file(s) not reachable from any entry point

### Changes
- **Files Changed:** 3
  - .worktree.json
  - scripts/modules/handoff/executors/lead-final-approval/gates/wire-check-gate.js
  - tests/unit/handoff/wire-check-gate.test.js
- **LOC:** 30 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol