### PR TITLE
feat(SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001): hook applications.trust_tier into isTrustedRepo for witness-gated venture auto-merge

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -493,14 +493,26 @@ The bare `gh pr merge <PR#> --merge --delete-branch` call silently failed for mo
 
 ```bash
 node -e "
-import('./lib/ship/auto-merge.mjs').then(async ({ attemptAutoMerge }) => {
+require('dotenv').config();
+Promise.all([
+  import('./lib/ship/auto-merge.mjs'),
+  import('./lib/ship/venture-trust-gate.mjs'),
+  import('@supabase/supabase-js'),
+]).then(async ([{ attemptAutoMerge, fetchStatusCheckRollup }, { createVentureTrustGate }, { createClient }]) => {
   const owner = (await import('node:child_process')).execSync('gh repo view --json owner --jq .owner.login').toString().trim();
   const name = (await import('node:child_process')).execSync('gh repo view --json name --jq .name').toString().trim();
-  const result = await attemptAutoMerge({ prNumber: <PR#>, repoOwner: owner, repoName: name });
+  const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const isTrustedRepo = createVentureTrustGate({ supabase, fetchStatusCheckRollup });
+  const result = await attemptAutoMerge({
+    prNumber: <PR#>, repoOwner: owner, repoName: name,
+    isTrustedRepo, witnessSupabase: supabase, workKey: '<SD-KEY or null>',
+  });
   if (!result.ok) process.exit(result.exitCode || 1);
 });
 "
 ```
+
+SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B): `isTrustedRepo` here now also admits a venture repo whose `applications.trust_tier='trusted'` AND whose PR has independently passed the P1 admission + P2 witness + P3 CI subset of the mergeWork() ladder (`lib/ship/venture-trust-gate.mjs`) — platform repos (EHG/EHG_Engineer) are unaffected, still fast-pathed with zero DB lookup. `<SD-KEY or null>` is the same value passed to Step 5's `logFindings` call.
 
 If the call exits non-zero, `/ship` MUST hard-fail and skip Step 6.3 / Step 6.5 / `/learn` / next-SD selection. Do NOT rescue the exit code.
 

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,7 @@
 {
-  "sdKey": "QF-20260702-806",
-  "workType": "QF",
-  "workKey": "QF-20260702-806",
-  "expectedBranch": "qf/QF-20260702-806",
-  "createdAt": "2026-07-03T02:48:31.286Z",
-  "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
+  "sdKey": "SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001",
+  "createdAt": "2026-07-03T03:04:13.870Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "baseRef": "origin/main"
 }

--- a/docs/reference/ship-witness-venture-trust-tier.md
+++ b/docs/reference/ship-witness-venture-trust-tier.md
@@ -1,0 +1,99 @@
+# Ship-witness: `applications.trust_tier` and venture auto-merge eligibility
+
+**SD**: SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B)
+**Status**: Approved
+**Category**: Protocol
+**Version**: 1.0.0
+**Last Updated**: 2026-07-03
+
+## What this is
+
+`lib/ship/auto-merge.mjs`'s `attemptAutoMerge()` refuses to auto-merge any
+repo that isn't on the hardcoded `AUTO_MERGE_PLATFORM_REPOS` allowlist
+(`rickfelix/ehg`, `rickfelix/ehg_engineer`) — every venture/external repo
+requires a human merge. This SD adds a second, narrower eligibility path:
+`lib/ship/venture-trust-gate.mjs`'s `createVentureTrustGate()` predicate,
+which admits a venture repo when **both**:
+
+1. `applications.trust_tier = 'trusted'` for that repo's registry row, **and**
+2. the specific PR being merged has independently passed the
+   `P1` admission + `P2` witness + `P3` CI subset of the mergeWork() P1-P5
+   ladder (`lib/ship/merge-witness-ladder.mjs`, SD-LEO-INFRA-SHIP-WITNESS-
+   MERGEWORK-001 — consumed read-only by this SD).
+
+Registry promotion alone grants nothing. Every PR is still evaluated
+independently — a `trusted`-tier repo with a PR lacking a passing
+`ship_review_findings` row, or with red/pending CI, is still refused.
+
+Platform repos (EHG / EHG_Engineer) are unaffected: `isPlatformRepo()` is
+checked first and short-circuits with zero DB lookup, exactly as before this
+SD.
+
+## The trust_tier SSOT
+
+`applications.trust_tier` (existing column; `ck_applications_trust_tier`
+already permits `'platform' | 'trusted' | 'external'` — no migration was
+needed for this SD). As of this SD's delivery, **zero rows use `'trusted'`**
+— promoting a specific venture repo is a separate, deliberate, chairman-gated
+operational decision, not something this SD's code performs.
+
+To promote a venture repo, issue a direct, reviewed SQL statement (there is
+no self-service script by design — see "Why no promotion script" below):
+
+```sql
+UPDATE applications
+SET trust_tier = 'trusted'
+WHERE github_repo = '<owner>/<repo>.git'; -- must have a non-null github_repo
+```
+
+A repo whose `applications.github_repo` is `NULL` can never resolve to
+`'trusted'` via `fetchTrustTier()` (fail-closed) until that registry row is
+backfilled — as of this SD, 8 of the 11 non-platform application rows have
+`github_repo = NULL`.
+
+## Why no promotion script
+
+The chairman's ratification of the ship-witness family (`chairman_decisions`
+id `dd09d62b-4eb5-419b-90f3-25ac8f3c4eae`) defines the witness composition as
+**"CI-green + a second-session check + our-own-fleet-authored"** — a
+per-PR runtime check, not a one-time registry flip that then bypasses future
+scrutiny. Building a convenience script to set `trust_tier='trusted'` would
+make registry promotion feel like the whole gate, when it is only the first
+of two independent conditions. Keeping promotion manual keeps the weight of
+that decision visible.
+
+## Mapping the ratification language to the P1/P2/P3 witness
+
+| Ratification term | Ladder rung | What it checks |
+|---|---|---|
+| "our-own-fleet-authored" | P1 admission | `workKey` resolves to a real `strategic_directives_v2`/`quick_fixes` row (not a synthetic/test key) |
+| "a second-session check" | P2 witness | A `ship_review_findings` row exists for the PR with `verdict='pass'` (produced by the review gate — actor-separation beyond that is `not_evaluable` today, per the ladder module's own docs) |
+| "CI-green" | P3 CI | `statusCheckRollup` shows all checks succeeded (pending/empty is `not_evaluable`, never a false pass) |
+
+P2's actor-separation dimension and P4 (branch protection, pre-P0) are never
+required for a pass — they aren't evaluable yet at all (see
+`lib/ship/merge-witness-ladder.mjs`).
+
+## Where it's wired in
+
+- `lib/ship/venture-trust-gate.mjs` — the predicate + default lookups (new).
+- `lib/ship/auto-merge.mjs` — `attemptAutoMerge()`'s `isTrustedRepo` call now
+  threads `prNumber` and `{workKey, tier}` so a per-PR predicate can be
+  evaluated (additive; the default `isPlatformRepo` predicate ignores the
+  extra args).
+- `.claude/commands/ship.md` Step 6 — the real `/ship` merge sequence
+  constructs `createVentureTrustGate({ supabase, fetchStatusCheckRollup })`
+  and passes it as `isTrustedRepo`. Without this wiring, the gate exists as
+  library code but is never actually consulted for a real merge decision.
+
+## Family status
+
+- **A** — SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (completed): the P1-P5
+  observe-only ladder + `merge_witness_telemetry` substrate this SD reads.
+- **B** — SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (this SD): the
+  `trust_tier` hook described here.
+- **C** — SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001 (draft): venture-build walker
+  completion gates on a merged PR.
+- **D** — SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (draft): flips the ladder's
+  `overall` field from observe-to-fail-closed once telemetry shows 100% lane
+  adoption for 7 days.

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -135,9 +135,11 @@ export function verifyMerged(prNumber, runner = defaultRunner) {
 /**
  * Fetch a PR's statusCheckRollup for the P3 rung of the mergeWork() ladder.
  * Returns [] on lookup failure (evaluateP3CI reports not_evaluable for an
- * empty rollup — never a false pass/fail).
+ * empty rollup — never a false pass/fail). Exported (SD-LEO-INFRA-SHIP-
+ * WITNESS-APPLICATIONS-001) so lib/ship/venture-trust-gate.mjs can reuse the
+ * same gh CLI fetch path instead of reimplementing it.
  */
-function fetchStatusCheckRollup(prNumber, runner = defaultRunner) {
+export function fetchStatusCheckRollup(prNumber, runner = defaultRunner) {
   const r = runner(['pr', 'view', String(prNumber), '--json', 'statusCheckRollup', '--jq', '.statusCheckRollup']);
   if (r.code !== 0) return [];
   try {
@@ -228,7 +230,12 @@ export async function attemptAutoMerge({
   // build PRs at external repos; unattended auto-merge there would let the harness merge
   // untrusted code without human review. Refuse unless the repo is platform-trusted (or
   // an explicit allowExternalMerge override is passed). Unknown/unresolvable repo => refuse.
-  if (!allowExternalMerge && !isTrustedRepo(repoOwner, repoName)) {
+  // SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001: thread prNumber + workKey/tier
+  // through so an injected predicate can evaluate a per-PR witness (not just a
+  // repo-level allowlist check). isPlatformRepo (the default) ignores the
+  // extra args, so this is additive — existing 2-arg predicates are unaffected.
+  const trusted = await isTrustedRepo(repoOwner, repoName, prNumber, { workKey, tier });
+  if (!allowExternalMerge && !trusted) {
     logger.warn(
       `⛔ Auto-merge refused for PR #${prNumber}: ${repoOwner || '?'}/${repoName || '?'} is not a platform repo. `
       + `External/venture repos require a human merge (SD-LEO-INFRA-RECONCILE-VENTURE-BUILD-001 / SECURITY VB-2).`

--- a/lib/ship/venture-trust-gate.mjs
+++ b/lib/ship/venture-trust-gate.mjs
@@ -1,0 +1,146 @@
+/**
+ * applications.trust_tier SSOT hook + pre-merge witness evaluator for venture repos.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B). Extends the
+ * platform-only auto-merge trust gate (lib/ship/auto-merge.mjs isPlatformRepo)
+ * with a second, narrower path: a venture repo explicitly opted in via
+ * applications.trust_tier='trusted' (already permitted by the live
+ * ck_applications_trust_tier CHECK constraint — no migration needed) is
+ * eligible for auto-merge ONLY when its specific PR has independently passed
+ * the currently-evaluable subset of the mergeWork() P1-P5 ladder
+ * (lib/ship/merge-witness-ladder.mjs, Ship-witness A, consumed read-only
+ * here): P1 admission, P2 witness verdict, P3 CI. P2's actor-separation
+ * dimension and P4 (pre-P0 branch protection) are not evaluable yet and are
+ * never required for a pass — see the ladder module's own docs. Registry
+ * promotion to 'trusted' grants nothing by itself; every PR is still
+ * evaluated independently.
+ *
+ * Sibling A shipped the ladder's lookupWorkKeyReal/fetchReviewFinding as
+ * injectable interfaces with no concrete default (its own ladder is
+ * observe-only and never needed real values to be useful telemetry). This
+ * module's gating IS real, so it ships default implementations of both.
+ */
+
+import { evaluateMergeWorkLadder, RUNG_STATUS } from './merge-witness-ladder.mjs';
+import { isPlatformRepo } from './auto-merge.mjs';
+
+/** Normalize a github_repo field ('owner/name.git' or 'owner/name') to 'owner/name' lowercase. */
+export function normalizeGithubRepo(githubRepo) {
+  if (!githubRepo) return null;
+  return githubRepo.replace(/\.git$/i, '').toLowerCase();
+}
+
+/**
+ * Look up applications.trust_tier for a repoOwner/repoName pair by matching
+ * against every non-null github_repo. Returns the trust_tier string, or null
+ * (fail-closed) when no row's github_repo resolves to this repo.
+ */
+export async function fetchTrustTier(repoOwner, repoName, supabase) {
+  if (!supabase || !repoOwner || !repoName) return null;
+  const target = `${repoOwner}/${repoName}`.toLowerCase();
+  const { data, error } = await supabase
+    .from('applications')
+    .select('trust_tier, github_repo')
+    .not('github_repo', 'is', null);
+  if (error || !data) return null;
+  const match = data.find((row) => normalizeGithubRepo(row.github_repo) === target);
+  return match ? match.trust_tier : null;
+}
+
+/**
+ * P1 admission default: workKey starting with 'QF-' resolves against
+ * quick_fixes.id; anything else resolves against strategic_directives_v2.sd_key.
+ * Returns true/false/null (null on query error — mirrors evaluateP1Admission's
+ * not_evaluable contract, never a false pass).
+ */
+export async function defaultLookupWorkKeyReal(workKey, supabase) {
+  if (!supabase || !workKey) return null;
+  try {
+    if (workKey.startsWith('QF-')) {
+      const { data, error } = await supabase.from('quick_fixes').select('id').eq('id', workKey).maybeSingle();
+      if (error) return null;
+      return !!data;
+    }
+    const { data, error } = await supabase.from('strategic_directives_v2').select('sd_key').eq('sd_key', workKey).maybeSingle();
+    if (error) return null;
+    return !!data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * P2 witness default: most recent ship_review_findings row for this PR.
+ * Returns { verdict } or null (no row / query error).
+ */
+export async function defaultFetchReviewFinding(prNumber, supabase) {
+  if (!supabase || !prNumber) return null;
+  try {
+    const { data, error } = await supabase
+      .from('ship_review_findings')
+      .select('verdict')
+      .eq('pr_number', prNumber)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error || !data) return null;
+    return { verdict: data.verdict };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evaluate whether a venture PR has passed the pre-merge-evaluable witness
+ * subset (P1 admission, P2 witness verdict, P3 CI) — all three must report
+ * 'pass'. Never throws; any internal failure degrades to false (fail-closed).
+ */
+export async function evaluateVenturePrWitness({
+  prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
+}) {
+  try {
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
+    });
+    const byId = Object.fromEntries(verdict.rungs.map((r) => [r.id, r.status]));
+    return byId.P1 === RUNG_STATUS.PASS && byId.P2 === RUNG_STATUS.PASS && byId.P3 === RUNG_STATUS.PASS;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build an isTrustedRepo-compatible predicate for attemptAutoMerge():
+ * isTrustedRepoOrWitnessPassed(repoOwner, repoName, prNumber, {workKey, tier}).
+ * isPlatformRepo fast path (no DB call) preserves today's behavior exactly;
+ * otherwise requires trust_tier==='trusted' AND a passing per-PR witness.
+ * Extra args beyond (repoOwner, repoName) are simply unused by isPlatformRepo,
+ * so this predicate is a drop-in replacement for attemptAutoMerge's default.
+ */
+export function createVentureTrustGate({
+  supabase,
+  fetchStatusCheckRollup,
+  lookupWorkKeyReal,
+  fetchReviewFinding,
+} = {}) {
+  const lookupWork = lookupWorkKeyReal || ((workKey) => defaultLookupWorkKeyReal(workKey, supabase));
+  const fetchFinding = fetchReviewFinding || ((prNumber) => defaultFetchReviewFinding(prNumber, supabase));
+
+  return async function isTrustedRepoOrWitnessPassed(repoOwner, repoName, prNumber, { workKey, tier } = {}) {
+    if (isPlatformRepo(repoOwner, repoName)) return true;
+    if (!prNumber) return false;
+
+    const trustTier = await fetchTrustTier(repoOwner, repoName, supabase);
+    if (trustTier !== 'trusted') return false;
+
+    const statusCheckRollup = fetchStatusCheckRollup ? await fetchStatusCheckRollup(prNumber) : [];
+    return evaluateVenturePrWitness({
+      prNumber,
+      workKey,
+      tier,
+      lookupWorkKeyReal: lookupWork,
+      fetchReviewFinding: fetchFinding,
+      statusCheckRollup,
+    });
+  };
+}

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -609,4 +609,31 @@ describe('attemptAutoMerge — C2 external-repo merge-gate (SECURITY VB-2)', () 
     });
     expect(r.ok).toBe(true);
   });
+
+  // SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (FR-2, FR-4): isTrustedRepo must
+  // receive prNumber + {workKey, tier} so a per-PR witness predicate can be
+  // evaluated, not just a repo-level allowlist check.
+  it('invokes a custom isTrustedRepo predicate with (repoOwner, repoName, prNumber, {workKey, tier})', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+      { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-07-03T00:00:00Z\n' } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+      { match: argvMatchers.prViewHeadRef, result: { stdout: 'feat/x\n' } },
+      { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'Not Found (404)' } },
+    ]);
+    const calls = [];
+    const isTrustedRepo = (...args) => { calls.push(args); return true; };
+    const r = await attemptAutoMerge({
+      prNumber: 42, repoOwner: 'rickfelix', repoName: 'marketlens', runner, logger: silentLogger,
+      isTrustedRepo, workKey: 'SD-XXX-001', tier: 'standard',
+    });
+    expect(r.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('rickfelix');
+    expect(calls[0][1]).toBe('marketlens');
+    expect(calls[0][2]).toBe(42);
+    expect(calls[0][3]).toEqual({ workKey: 'SD-XXX-001', tier: 'standard' });
+  });
 });

--- a/tests/unit/ship/venture-trust-gate.test.js
+++ b/tests/unit/ship/venture-trust-gate.test.js
@@ -1,0 +1,269 @@
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (Ship-witness B)
+ * FR-1, FR-4: venture-trust-gate.mjs — applications.trust_tier SSOT hook +
+ * pre-merge witness evaluator. Pure unit tests against fake Supabase/runner
+ * stubs — no live DB.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeGithubRepo,
+  fetchTrustTier,
+  defaultLookupWorkKeyReal,
+  defaultFetchReviewFinding,
+  evaluateVenturePrWitness,
+  createVentureTrustGate,
+} from '../../../lib/ship/venture-trust-gate.mjs';
+
+const GREEN_ROLLUP = [{ status: 'COMPLETED', conclusion: 'SUCCESS' }];
+
+function makeApplicationsSupabase(rows) {
+  return {
+    from: (table) => {
+      if (table !== 'applications') throw new Error(`unexpected table ${table}`);
+      return {
+        select: () => ({
+          not: () => Promise.resolve({ data: rows, error: null }),
+        }),
+      };
+    },
+  };
+}
+
+function makeThrowingSupabase() {
+  return {
+    from: () => {
+      throw new Error('supabase should not have been called (fast-path expected)');
+    },
+  };
+}
+
+describe('normalizeGithubRepo', () => {
+  it('strips .git suffix and lowercases', () => {
+    expect(normalizeGithubRepo('rickfelix/MarketLens.GIT')).toBe('rickfelix/marketlens');
+  });
+  it('handles no .git suffix', () => {
+    expect(normalizeGithubRepo('rickfelix/marketlens')).toBe('rickfelix/marketlens');
+  });
+  it('null in, null out', () => {
+    expect(normalizeGithubRepo(null)).toBeNull();
+  });
+});
+
+describe('fetchTrustTier', () => {
+  it('matches a repo whose github_repo is owner/Name.git (case + suffix insensitive)', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/MarketLens.git' }]);
+    const tier = await fetchTrustTier('rickfelix', 'marketlens', supabase);
+    expect(tier).toBe('trusted');
+  });
+
+  it('returns null (fail-closed) when no row matches', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/other-repo' }]);
+    const tier = await fetchTrustTier('rickfelix', 'marketlens', supabase);
+    expect(tier).toBeNull();
+  });
+
+  it('returns null when supabase/repoOwner/repoName missing', async () => {
+    expect(await fetchTrustTier(null, 'marketlens', {})).toBeNull();
+    expect(await fetchTrustTier('rickfelix', null, {})).toBeNull();
+    expect(await fetchTrustTier('rickfelix', 'marketlens', null)).toBeNull();
+  });
+
+  it('returns null on query error', async () => {
+    const supabase = { from: () => ({ select: () => ({ not: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) };
+    expect(await fetchTrustTier('rickfelix', 'marketlens', supabase)).toBeNull();
+  });
+});
+
+describe('defaultLookupWorkKeyReal', () => {
+  it('routes QF- prefixed keys to quick_fixes', async () => {
+    const supabase = {
+      from: (table) => {
+        expect(table).toBe('quick_fixes');
+        return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { id: 'QF-20260703-001' }, error: null }) }) }) };
+      },
+    };
+    expect(await defaultLookupWorkKeyReal('QF-20260703-001', supabase)).toBe(true);
+  });
+
+  it('routes non-QF keys to strategic_directives_v2.sd_key', async () => {
+    const supabase = {
+      from: (table) => {
+        expect(table).toBe('strategic_directives_v2');
+        return { select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { sd_key: 'SD-XXX-001' }, error: null }) }) }) };
+      },
+    };
+    expect(await defaultLookupWorkKeyReal('SD-XXX-001', supabase)).toBe(true);
+  });
+
+  it('returns false when no row found', async () => {
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }) }) };
+    expect(await defaultLookupWorkKeyReal('SD-FAKE-001', supabase)).toBe(false);
+  });
+
+  it('returns null on query error (not_evaluable, never a false pass)', async () => {
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) };
+    expect(await defaultLookupWorkKeyReal('SD-XXX-001', supabase)).toBeNull();
+  });
+
+  it('returns null when workKey/supabase missing', async () => {
+    expect(await defaultLookupWorkKeyReal(null, {})).toBeNull();
+    expect(await defaultLookupWorkKeyReal('SD-XXX-001', null)).toBeNull();
+  });
+});
+
+describe('defaultFetchReviewFinding', () => {
+  function makeFindingSupabase(row) {
+    return {
+      from: (table) => {
+        expect(table).toBe('ship_review_findings');
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => ({
+                limit: () => ({
+                  maybeSingle: () => Promise.resolve({ data: row, error: null }),
+                }),
+              }),
+            }),
+          }),
+        };
+      },
+    };
+  }
+
+  it('returns the most recent verdict', async () => {
+    const supabase = makeFindingSupabase({ verdict: 'pass' });
+    expect(await defaultFetchReviewFinding(42, supabase)).toEqual({ verdict: 'pass' });
+  });
+
+  it('returns null when no row found', async () => {
+    const supabase = makeFindingSupabase(null);
+    expect(await defaultFetchReviewFinding(42, supabase)).toBeNull();
+  });
+
+  it('returns null on query error', async () => {
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ order: () => ({ limit: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: { message: 'boom' } }) }) }) }) }) }) };
+    expect(await defaultFetchReviewFinding(42, supabase)).toBeNull();
+  });
+});
+
+describe('evaluateVenturePrWitness', () => {
+  const base = {
+    prNumber: 7,
+    workKey: 'SD-XXX-001',
+    tier: 'standard',
+    statusCheckRollup: GREEN_ROLLUP,
+  };
+
+  it('passes when P1 + P2 + P3 all pass', async () => {
+    const ok = await evaluateVenturePrWitness({
+      ...base,
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+    });
+    expect(ok).toBe(true);
+  });
+
+  it('fails when P1 admission fails (workKey not real)', async () => {
+    const ok = await evaluateVenturePrWitness({
+      ...base,
+      lookupWorkKeyReal: async () => false,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('fails when P2 witness fails (no review finding)', async () => {
+    const ok = await evaluateVenturePrWitness({
+      ...base,
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => null,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('fails when P3 CI is pending (not_evaluable, not a pass)', async () => {
+    const ok = await evaluateVenturePrWitness({
+      ...base,
+      statusCheckRollup: [{ status: 'IN_PROGRESS' }],
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('fails when P3 CI has failed', async () => {
+    const ok = await evaluateVenturePrWitness({
+      ...base,
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }],
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('degrades to false (never throws) when the ladder call throws', async () => {
+    const ok = await evaluateVenturePrWitness({
+      ...base,
+      lookupWorkKeyReal: async () => { throw new Error('db down'); },
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe('createVentureTrustGate', () => {
+  it('platform repo returns true with ZERO supabase calls (fast path)', async () => {
+    const gate = createVentureTrustGate({ supabase: makeThrowingSupabase() });
+    await expect(gate('rickfelix', 'ehg', 7, {})).resolves.toBe(true);
+    await expect(gate('rickfelix', 'ehg_engineer', 7, {})).resolves.toBe(true);
+  });
+
+  it('trust_tier=trusted repo with a passing witness returns true', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/marketlens' }]);
+    const gate = createVentureTrustGate({
+      supabase,
+      fetchStatusCheckRollup: async () => GREEN_ROLLUP,
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => ({ verdict: 'pass' }),
+    });
+    const result = await gate('rickfelix', 'marketlens', 99, { workKey: 'SD-XXX-001', tier: 'standard' });
+    expect(result).toBe(true);
+  });
+
+  it('trust_tier=trusted repo with a failing/absent witness returns false', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/marketlens' }]);
+    const gate = createVentureTrustGate({
+      supabase,
+      fetchStatusCheckRollup: async () => GREEN_ROLLUP,
+      lookupWorkKeyReal: async () => true,
+      fetchReviewFinding: async () => null,
+    });
+    const result = await gate('rickfelix', 'marketlens', 99, { workKey: 'SD-XXX-001', tier: 'standard' });
+    expect(result).toBe(false);
+  });
+
+  it('trust_tier=external returns false without needing to evaluate the witness', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'external', github_repo: 'rickfelix/crongenius' }]);
+    const gate = createVentureTrustGate({
+      supabase,
+      fetchStatusCheckRollup: async () => { throw new Error('should not be called'); },
+    });
+    const result = await gate('rickfelix', 'crongenius', 99, { workKey: 'SD-XXX-001' });
+    expect(result).toBe(false);
+  });
+
+  it('unresolvable repo (no matching applications row) returns false', async () => {
+    const supabase = makeApplicationsSupabase([]);
+    const gate = createVentureTrustGate({ supabase });
+    const result = await gate('someorg', 'unknown-repo', 99, {});
+    expect(result).toBe(false);
+  });
+
+  it('returns false when no prNumber supplied for a non-platform repo', async () => {
+    const supabase = makeApplicationsSupabase([{ trust_tier: 'trusted', github_repo: 'rickfelix/marketlens' }]);
+    const gate = createVentureTrustGate({ supabase });
+    const result = await gate('rickfelix', 'marketlens', undefined, {});
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/ship/venture-trust-gate.mjs`: a venture repo opted into `applications.trust_tier='trusted'` is auto-merge eligible only when its specific PR independently passes the P1 admission + P2 witness + P3 CI subset of sibling A's mergeWork() ladder (`SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001`, consumed read-only).
- Platform repos (EHG / EHG_Engineer) are unaffected — `isPlatformRepo()` fast-paths with zero DB lookup, exactly as before.
- Threads `prNumber` + `{workKey, tier}` into `attemptAutoMerge()`'s `isTrustedRepo` call (additive; default predicate ignores the extra args) and wires `createVentureTrustGate()` into the real `/ship` Step 6 merge sequence — without that wiring the gate is inert library code.
- No migration needed: `ck_applications_trust_tier` already permits `'trusted'`. Zero rows are promoted by this PR — promotion is a separate, chairman-gated manual SQL step (documented).

## Test plan
- [x] `npx vitest run tests/unit/ship/venture-trust-gate.test.js tests/unit/ship/auto-merge.test.js tests/unit/ship/auto-merge-witness-integration.test.js tests/unit/ship/merge-witness-ladder.test.js` — 90/90 passing
- [x] `npx vitest run --project unit tests/unit/ship/` — 103/103 passing (zero regression on existing lib/ship tests)
- [x] New tests cover: trust_tier normalization/lookup, default P1/P2 lookup implementations (QF vs SD routing), witness pass/fail combinations, platform fast-path with zero DB calls, and the auto-merge call-site threading

🤖 Generated with [Claude Code](https://claude.com/claude-code)