### PR TITLE
feat(SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001): Ship-witness C — venture-build observe-only merge-witness

### DIFF
--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -50,6 +50,9 @@ import { execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join, dirname, relative, resolve as resolvePath, sep } from 'path';
 import { resolveRepoPathDbFirst, normalizeAppName, ENGINEER_ROOT } from '../../repo-paths.js';
+// SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001 (Ship-witness C): OBSERVE-ONLY merge-witness at leaf
+// completion (done=SHIPPED). Fully injectable; NEVER alters control flow or advances a stage.
+import { observeLeafMergeWitness } from './venture-build-merge-witness.js';
 
 export const S19 = 19;
 export const NON_TERMINAL = ['draft', 'active'];
@@ -72,6 +75,15 @@ export function isDependencyOrderedExecutionEnabled() {
   if (v === undefined || v === '') return true;
   const s = String(v).toLowerCase();
   return s !== 'false' && s !== '0' && s !== 'off' && s !== 'no';
+}
+
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001: kill-switch for the observe-only leaf merge-witness.
+ * Default ON; ONLY an explicit VENTURE_BUILD_MERGE_WITNESS=off disables it (instant rollback of a
+ * purely additive, observe-only telemetry path — the walk is byte-identical either way).
+ */
+export function isVentureBuildMergeWitnessEnabled() {
+  return String(process.env.VENTURE_BUILD_MERGE_WITNESS || '').toLowerCase() !== 'off';
 }
 
 export function parseArgs(argv) {
@@ -361,7 +373,7 @@ export async function maybeIdleNudge(supabase, ventureId, { dryRun = false } = {
  * through its full LEO cycle to LEAD-FINAL-APPROVAL; unit tests inject a mock. The consumer NEVER
  * advances the venture — the existing worker does that once the tree completes.
  */
-export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFAULT_BOUNDS, dryRun = false, logger = console, now = () => Date.now() }) {
+export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFAULT_BOUNDS, dryRun = false, logger = console, now = () => Date.now(), witness = observeLeafMergeWitness }) {
   const result = { ventureId, drivenLeaves: [], completed: false, held: false, skipped: false, reason: null, dryRun };
 
   const elig = await ventureEligibility(supabase, ventureId);
@@ -437,6 +449,14 @@ export async function runConsume({ supabase, ventureId, driveLeaf, bounds = DEFA
     const ok = !!(driven && driven.completed);
     result.drivenLeaves.push({ sd_key: leaf.sd_key, attempt: prior + 1, completed: ok });
     await emitEvent(supabase, ok ? 'LEO_BUILD_LEAF_DRIVEN' : 'LEO_BUILD_LEAF_ATTEMPT_FAILED', { leaf: leaf.sd_key, attempt: prior + 1 }, { ventureId, sdId: leaf.id, dryRun, logger });
+    // SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001: OBSERVE-ONLY merge-witness at the leaf completion point
+    // (done=SHIPPED := PR merged). Records telemetry only; MUST NOT alter ok / drivenLeaves / loop
+    // termination and NEVER advances a stage. Wrapped defensively so even a misbehaving witness can
+    // never perturb the walk (the default witness is itself fail-soft and never throws).
+    if (ok && !dryRun && isVentureBuildMergeWitnessEnabled()) {
+      try { await witness({ supabase, leaf, ventureId, dryRun, logger }); }
+      catch (e) { logger.error?.(`[venture-build-consumer] merge-witness threw (non-fatal, observe-only): ${e?.message || e}`); }
+    }
     // On failure the outer loop re-selects the same leaf until its attempt cap, then fail-closed HOLD.
   }
 

--- a/lib/eva/bridge/venture-build-merge-witness.js
+++ b/lib/eva/bridge/venture-build-merge-witness.js
@@ -1,0 +1,141 @@
+/**
+ * venture-build-merge-witness — OBSERVE-ONLY merge-witness for a venture-build leaf at completion.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001 (Ship-witness C). Reuses the Ship-witness A substrate
+ * (lib/ship/merge-witness-ladder.mjs + merge-witness-telemetry.mjs, PR #5412): when the outer
+ * tree-walker (venture-build-consumer.runConsume) reports a leaf driven to LEAD-FINAL-APPROVAL,
+ * this helper records whether that leaf's PR actually merged (done=SHIPPED) — WITHOUT changing
+ * control flow and WITHOUT advancing any stage. The fail-CLOSED flip (block completion on an
+ * unmerged leaf) is a SEPARATE downstream SD (Ship-witness D, SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-*);
+ * this module NEVER blocks and NEVER returns anything the caller acts on for control flow.
+ *
+ * Fail-soft by design: the ENTIRE body is wrapped so nothing escapes into the walk. Every IO seam
+ * (prLookup, verifyMerged, writeTelemetry, evaluateLadder, emitEvent) is injectable via `deps`,
+ * each defaulting to the REAL implementation, so the witness is deterministically unit-testable
+ * with NO live gh/DB.
+ */
+import { spawnSync } from 'node:child_process';
+import { evaluateMergeWorkLadder } from '../../ship/merge-witness-ladder.mjs';
+import { writeMergeWitnessTelemetry } from '../../ship/merge-witness-telemetry.mjs';
+import { verifyMerged } from '../../ship/auto-merge.mjs';
+// emitEvent is a hoisted `export async function` in the consumer, so this cyclic import is
+// runtime-safe (the binding is live and only ever dereferenced at call time).
+import { emitEvent } from './venture-build-consumer.js';
+
+export const LANE = 'venture-build';
+const GH_TIMEOUT_MS = 15000;
+
+/** Under a test runner we never shell out — hermetic + deterministic (real gh/DB is injected in tests). */
+function underTest() {
+  return !!(process.env.VITEST || process.env.NODE_ENV === 'test');
+}
+
+/**
+ * Bounded gh runner that THROWS on spawn failure / non-zero exit. Passed to verifyMerged so its
+ * false-on-lookup-failure branch instead surfaces as a THROW here → mergedState='not_evaluable',
+ * never a false 'not_merged' (a gh outage must not positively flag a leaf as unshipped).
+ */
+function boundedThrowingRunner(args) {
+  const r = spawnSync('gh', args, { encoding: 'utf8', timeout: GH_TIMEOUT_MS });
+  if (r.error) throw r.error;
+  if ((r.status ?? 1) !== 0) throw new Error(`gh exited ${r.status}: ${(r.stderr || '').trim()}`);
+  return { code: 0, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+/**
+ * Default PR resolver: canonical ship_review_findings(sd_key) most-recent row, else the
+ * `gh pr list --head feat/<sd_key>` merged-PR fallback. Fail-soft — returns null on any error / no PR.
+ */
+async function defaultPrLookup(supabase, sdKey) {
+  try {
+    const { data, error } = await supabase
+      .from('ship_review_findings')
+      .select('pr_number, branch')
+      .eq('sd_key', sdKey)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (!error && data && data.pr_number != null) return { pr_number: data.pr_number, branch: data.branch };
+  } catch { /* fall through to gh fallback */ }
+  if (underTest()) return null; // never shell out under a test runner
+  try {
+    const r = boundedThrowingRunner(['pr', 'list', '--state', 'merged', '--head', `feat/${sdKey}`, '--json', 'number', '--jq', '.[0].number // empty']);
+    const n = parseInt(String(r.stdout || '').trim(), 10);
+    return Number.isInteger(n) ? { pr_number: n, branch: `feat/${sdKey}` } : null;
+  } catch { return null; }
+}
+
+/** Default merged-check: reuse the existing verifyMerged with a bounded/throwing runner (true|false; throw⇒not_evaluable). */
+async function defaultVerifyMerged(prNumber) {
+  if (underTest()) return null; // never shell out under a test runner → not_evaluable
+  return verifyMerged(prNumber, boundedThrowingRunner);
+}
+
+/**
+ * OBSERVE-ONLY witness for one COMPLETED leaf. Returns a small summary object for logging only —
+ * the caller MUST NOT branch on it. Never throws.
+ */
+export async function observeLeafMergeWitness({ supabase, leaf, ventureId, dryRun = false, logger = console, deps = {} }) {
+  const {
+    prLookup = defaultPrLookup,
+    verifyMerged: verifyMergedDep = defaultVerifyMerged,
+    writeTelemetry = writeMergeWitnessTelemetry,
+    evaluateLadder = evaluateMergeWorkLadder,
+    emitEvent: emit = emitEvent,
+  } = deps;
+  const summary = { workKey: leaf?.sd_key ?? null, prNumber: null, mergedState: 'not_evaluable', telemetryWritten: false, readBack: false, unmergedEmitted: false };
+  try {
+    // (a) resolve the leaf's PR — fail-soft: any error or no PR ⇒ mergedState stays 'not_evaluable'
+    let pr = null;
+    try { pr = await prLookup(supabase, leaf.sd_key); }
+    catch (e) { logger.error?.(`[venture-build-merge-witness] prLookup threw for ${leaf?.sd_key}: ${e?.message || e}`); }
+    const prNumber = pr && pr.pr_number != null ? pr.pr_number : null;
+    summary.prNumber = prNumber;
+
+    // (b) merged state — throw/timeout ⇒ not_evaluable (never a false not_merged)
+    let mergedState = 'not_evaluable';
+    if (prNumber != null) {
+      try {
+        const m = await verifyMergedDep(prNumber);
+        mergedState = m === true ? 'merged' : (m === false ? 'not_merged' : 'not_evaluable');
+      } catch (e) { logger.error?.(`[venture-build-merge-witness] verifyMerged threw for PR #${prNumber}: ${e?.message || e}`); }
+    }
+    summary.mergedState = mergedState;
+
+    // (c) build the observe-only verdict via the Ship-witness A ladder
+    const verdict = await evaluateLadder({
+      prNumber, workKey: leaf.sd_key, merged: mergedState === 'merged', verifyResult: { ok: mergedState === 'merged' },
+    });
+
+    // (d) persist telemetry, then READ IT BACK to confirm persistence (write-then-read-back)
+    if (prNumber != null) {
+      const w = await writeTelemetry(supabase, verdict, { repo: 'venture-build-consumer', lane: LANE, logger });
+      summary.telemetryWritten = !!(w && w.ok);
+      try {
+        const { data } = await supabase
+          .from('merge_witness_telemetry')
+          .select('id, pr_number, lane, work_key, overall, rungs')
+          .eq('pr_number', Number(prNumber))
+          .eq('lane', LANE)
+          .eq('work_key', leaf.sd_key)
+          .order('evaluated_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        summary.readBack = !!(data && Number(data.pr_number) === Number(prNumber) && data.lane === LANE && data.work_key === leaf.sd_key);
+        if (!summary.readBack) logger.warn?.(`[venture-build-merge-witness] telemetry read-back missed for PR #${prNumber} ${leaf.sd_key}`);
+      } catch (e) { logger.error?.(`[venture-build-merge-witness] telemetry read-back threw: ${e?.message || e}`); }
+    }
+
+    // (e) POSITIVE not-merged ONLY ⇒ emit observe event; NEVER on not_evaluable or merged (no false-flag)
+    if (mergedState === 'not_merged') {
+      await emit(supabase, 'LEO_BUILD_LEAF_COMPLETED_UNMERGED',
+        { leaf: leaf.sd_key, pr_number: prNumber, merged_state: mergedState },
+        { ventureId, sdId: leaf.id, dryRun, logger });
+      summary.unmergedEmitted = true;
+    }
+    return summary;
+  } catch (e) {
+    logger.error?.(`[venture-build-merge-witness] observe failed (non-fatal, observe-only) for ${leaf?.sd_key}: ${e?.message || e}`);
+    return { ...summary, error: e?.message || String(e) };
+  }
+}

--- a/tests/unit/eva/bridge/venture-build-merge-witness.test.js
+++ b/tests/unit/eva/bridge/venture-build-merge-witness.test.js
@@ -1,0 +1,258 @@
+// Tests for the OBSERVE-ONLY venture-build leaf merge-witness (SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001,
+// Ship-witness C). TS-1..TS-7 use deterministic INJECTED mocks — NO live gh/DB. The witness runs at
+// the leaf completion point inside runConsume and must NEVER change the walk or advance a stage.
+import { describe, it, expect } from 'vitest';
+import {
+  runConsume, TERMINAL,
+} from '../../../../lib/eva/bridge/venture-build-consumer.js';
+import { observeLeafMergeWitness } from '../../../../lib/eva/bridge/venture-build-merge-witness.js';
+
+// ---- Minimal mutable mock of the supabase query builder (mirrors the consumer suite's MockSB) ----
+class MockQuery {
+  constructor(sb, table) { this.sb = sb; this.table = table; this._op = 'select'; this._filters = []; this._payload = null; this._limit = null; this._single = false; this._returnData = false; }
+  select() { if (this._op === 'update') { this._returnData = true; return this; } this._op = 'select'; return this; }
+  insert(obj) { this._op = 'insert'; this._payload = obj; return this; }
+  update(obj) { this._op = 'update'; this._payload = obj; return this; }
+  eq(c, v) { this._filters.push(['eq', c, v]); return this; }
+  is(c, v) { this._filters.push(['is', c, v]); return this; }
+  in(c, arr) { this._filters.push(['in', c, arr]); return this; }
+  order() { return this; }
+  limit(n) { this._limit = n; return this; }
+  maybeSingle() { this._single = true; return this._exec(); }
+  then(res, rej) { return this._exec().then(res, rej); }
+  _match(row) {
+    return this._filters.every(([op, c, v]) => {
+      if (op === 'eq') return row[c] === v;
+      if (op === 'is') return v === null ? (row[c] === null || row[c] === undefined) : row[c] === v;
+      if (op === 'in') return v.includes(row[c]);
+      return true;
+    });
+  }
+  async _exec() {
+    const rows = this.sb.tables[this.table] || (this.sb.tables[this.table] = []);
+    if (this._op === 'insert') {
+      const items = Array.isArray(this._payload) ? this._payload : [this._payload];
+      for (const it of items) { rows.push({ ...it }); this.sb.inserts.push({ table: this.table, row: it }); }
+      return { data: items, error: null };
+    }
+    const matched = rows.filter((r) => this._match(r));
+    if (this._op === 'update') {
+      for (const r of matched) Object.assign(r, this._payload);
+      this.sb.updates.push({ table: this.table, payload: this._payload, count: matched.length });
+      return { data: this._returnData ? matched.map((r) => ({ ...r })) : null, error: null };
+    }
+    let out = matched.map((r) => ({ ...r }));
+    if (this._limit != null) out = out.slice(0, this._limit);
+    if (this._single) return { data: out[0] || null, error: null };
+    return { data: out, error: null };
+  }
+}
+class MockSB {
+  constructor(tables) { this.tables = tables; this.inserts = []; this.updates = []; }
+  from(name) { return new MockQuery(this, name); }
+}
+
+const VID = 'venture-1';
+function eligibleTables(extra = {}) {
+  return {
+    ventures: [{ id: VID, build_model: 'leo_bridge', status: 'active', current_lifecycle_stage: 19, deleted_at: null, orchestrator_state: 'blocked' }],
+    eva_vision_documents: [{ venture_id: VID, level: 'L2', status: 'active', chairman_approved: true, vision_key: 'V-1' }],
+    strategic_directives_v2: [],
+    system_events: [],
+    venture_artifacts: [{ venture_id: VID, is_current: true, artifact_type: 'blueprint_technical_architecture', content: 'Auth via Clerk (@clerk/tanstack-react-start). Data on Replit Postgres via DATABASE_URL.', artifact_data: null }],
+    ...extra,
+  };
+}
+
+function nestedTree({ children = 5, grandkidsEach = 4 } = {}) {
+  const sds = [{ id: 'orch-top', sd_key: 'ORCH-TOP', venture_id: VID, sd_type: 'orchestrator', parent_sd_id: null, status: 'draft', sequence_rank: 0, metadata: {} }];
+  for (let c = 0; c < children; c++) {
+    const cid = `orch-${c}`;
+    sds.push({ id: cid, sd_key: `ORCH-${c}`, venture_id: VID, sd_type: 'orchestrator', parent_sd_id: 'orch-top', status: 'draft', sequence_rank: c });
+    for (let g = 0; g < grandkidsEach; g++) {
+      sds.push({ id: `leaf-${c}-${g}`, sd_key: `LEAF-${c}-${g}`, venture_id: VID, sd_type: 'feature', parent_sd_id: cid, status: 'draft', sequence_rank: g });
+    }
+  }
+  return sds;
+}
+
+function makeDriveLeaf(tables, { failKeys = new Set() } = {}) {
+  return async (leaf) => {
+    if (failKeys.has(leaf.sd_key)) return { completed: false };
+    const all = tables.strategic_directives_v2;
+    const row = all.find((r) => r.sd_key === leaf.sd_key);
+    if (!row) return { completed: false };
+    row.status = 'completed';
+    let pid = row.parent_sd_id;
+    while (pid) {
+      const parent = all.find((r) => r.id === pid);
+      if (!parent) break;
+      const kids = all.filter((r) => r.parent_sd_id === parent.id);
+      if (kids.length && kids.every((k) => TERMINAL.includes(k.status))) { parent.status = 'completed'; pid = parent.parent_sd_id; }
+      else break;
+    }
+    return { completed: true };
+  };
+}
+
+// A witness wrapper that delegates to the REAL observeLeafMergeWitness with injected deps, and
+// (optionally) records each invocation's leaf key so tests can assert how often the witness fired.
+function witnessWith(deps, calls) {
+  return async (args) => { if (calls) calls.push(args.leaf.sd_key); return observeLeafMergeWitness({ ...args, deps }); };
+}
+const prFor = (sdKey) => ({ pr_number: 500 + sdKey.split('-').slice(1).reduce((a, n) => a * 10 + Number(n), 0), branch: `feat/${sdKey}` });
+const BOUNDS = { maxLeaves: 100, wallClockMs: 1e9, maxAttemptsPerLeaf: 2 };
+
+describe('TS-1 — merged leaf writes venture-build telemetry + read-back matches; result unchanged', () => {
+  it('records observe-only telemetry with lane=venture-build and no COMPLETED_UNMERGED event', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 1 }) });
+    const sb = new MockSB(tables);
+    const deps = { prLookup: async (_s, k) => prFor(k), verifyMerged: async () => true };
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), witness: witnessWith(deps), bounds: BOUNDS });
+    expect(res.completed).toBe(true);
+    expect(res.held).toBe(false);
+    expect(res.drivenLeaves.length).toBe(1);
+    const tele = tables.merge_witness_telemetry || [];
+    expect(tele.length).toBe(1);
+    expect(tele[0].lane).toBe('venture-build');
+    expect(tele[0].overall).toBe('observe-only');
+    expect(tele[0].work_key).toBe('LEAF-0-0');
+    expect(tele[0].pr_number).toBe(prFor('LEAF-0-0').pr_number);
+    const unmerged = (tables.system_events || []).filter((e) => e.event_type === 'LEO_BUILD_LEAF_COMPLETED_UNMERGED');
+    expect(unmerged.length).toBe(0); // merged ⇒ never flagged
+  });
+
+  it('write-then-read-back: the just-written row is read back and matches (evidence confirmed)', async () => {
+    const sb = new MockSB({});
+    const deps = { prLookup: async () => ({ pr_number: 777 }), verifyMerged: async () => true };
+    const summary = await observeLeafMergeWitness({ supabase: sb, leaf: { id: 'leaf-x', sd_key: 'LEAF-X' }, ventureId: VID, deps });
+    expect(summary.mergedState).toBe('merged');
+    expect(summary.telemetryWritten).toBe(true);
+    expect(summary.readBack).toBe(true);
+    const row = (sb.tables.merge_witness_telemetry || [])[0];
+    expect(row.pr_number).toBe(777);
+    expect(row.work_key).toBe('LEAF-X');
+    expect(row.overall).toBe('observe-only');
+  });
+});
+
+describe('TS-2 — positively not_merged leaf emits COMPLETED_UNMERGED and NEVER advances', () => {
+  it('emits the event, keeps ok=true, and writes no stage/orchestrator_state (held tree)', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 2 }) });
+    const sb = new MockSB(tables);
+    const deps = { prLookup: async (_s, k) => prFor(k), verifyMerged: async () => false }; // positively not merged
+    // LEAF-0-1 never completes ⇒ tree stays incomplete ⇒ HELD ⇒ no finalize (no idle-nudge / no marker).
+    const driveLeaf = makeDriveLeaf(tables, { failKeys: new Set(['LEAF-0-1']) });
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf, witness: witnessWith(deps), bounds: BOUNDS });
+    expect(res.completed).toBe(false);
+    expect(res.held).toBe(true);
+    // the completed leaf stayed completed (ok=true recorded) and was witnessed
+    expect(res.drivenLeaves.find((d) => d.sd_key === 'LEAF-0-0').completed).toBe(true);
+    const ev = (tables.system_events || []).filter((e) => e.event_type === 'LEO_BUILD_LEAF_COMPLETED_UNMERGED');
+    expect(ev.length).toBe(1);
+    expect(ev[0].sd_id).toBe('leaf-0-0');
+    // concrete never-advance DB state:
+    expect(tables.strategic_directives_v2.find((r) => r.id === 'leaf-0-0').status).toBe('completed');
+    expect(tables.ventures[0].current_lifecycle_stage).toBe(19);      // stage untouched
+    expect(tables.ventures[0].orchestrator_state).toBe('blocked');    // no idle-nudge
+    expect(sb.updates.filter((u) => 'current_lifecycle_stage' in (u.payload || {})).length).toBe(0);
+    expect(sb.updates.filter((u) => u.table === 'ventures').length).toBe(0);
+  });
+});
+
+describe('TS-3 — any injected IO throw is swallowed, logged, never rethrown; result byte-identical', () => {
+  async function runOnce(deps, logger) {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 1 }) });
+    const sb = new MockSB(tables);
+    return runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), witness: witnessWith(deps), bounds: BOUNDS, logger });
+  }
+  it('prLookup / verifyMerged / writeTelemetry throwing yields the same runConsume result + logger.error', async () => {
+    const clean = await runOnce({ prLookup: async (_s, k) => prFor(k), verifyMerged: async () => true }, { log() {}, warn() {}, error() {} });
+    const cleanJson = JSON.stringify(clean);
+    const throwing = [
+      { prLookup: async () => { throw new Error('prLookup boom'); }, verifyMerged: async () => true },
+      { prLookup: async (_s, k) => prFor(k), verifyMerged: async () => { throw new Error('verify boom'); } },
+      { prLookup: async (_s, k) => prFor(k), verifyMerged: async () => true, writeTelemetry: async () => { throw new Error('telemetry boom'); } },
+    ];
+    for (const deps of throwing) {
+      const errors = [];
+      const logger = { log() {}, warn() {}, error(m) { errors.push(m); } };
+      const res = await runOnce(deps, logger);
+      expect(JSON.stringify(res)).toBe(cleanJson);           // returned result byte-identical
+      expect(res.completed).toBe(true);                       // walk unaffected
+      expect(errors.length).toBeGreaterThan(0);               // swallowed + logged via logger.error
+    }
+  });
+});
+
+describe('TS-4 — unresolvable PR ⇒ not_evaluable, no telemetry, no COMPLETED_UNMERGED', () => {
+  it('does not flag or write anything when no PR resolves', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 1 }) });
+    const sb = new MockSB(tables);
+    const deps = { prLookup: async () => null, verifyMerged: async () => { throw new Error('should not be called'); } };
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), witness: witnessWith(deps), bounds: BOUNDS });
+    expect(res.completed).toBe(true);
+    expect((tables.merge_witness_telemetry || []).length).toBe(0);
+    expect((tables.system_events || []).filter((e) => e.event_type === 'LEO_BUILD_LEAF_COMPLETED_UNMERGED').length).toBe(0);
+    // direct: not_evaluable and nothing emitted/written
+    const summary = await observeLeafMergeWitness({ supabase: new MockSB({}), leaf: { id: 'l', sd_key: 'LEAF-Q' }, ventureId: VID, deps });
+    expect(summary.mergedState).toBe('not_evaluable');
+    expect(summary.telemetryWritten).toBe(false);
+    expect(summary.unmergedEmitted).toBe(false);
+  });
+});
+
+describe('TS-5 — witness ON vs OFF: returned runConsume result is byte-identical', () => {
+  it('the kill-switch changes only side-effect telemetry, never the returned result', async () => {
+    const deps = { prLookup: async (_s, k) => prFor(k), verifyMerged: async () => true };
+    const prev = process.env.VENTURE_BUILD_MERGE_WITNESS;
+    try {
+      process.env.VENTURE_BUILD_MERGE_WITNESS = 'on';
+      const onTables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 2 }) });
+      const onSb = new MockSB(onTables);
+      const resOn = await runConsume({ supabase: onSb, ventureId: VID, driveLeaf: makeDriveLeaf(onTables), witness: witnessWith(deps), bounds: BOUNDS });
+
+      process.env.VENTURE_BUILD_MERGE_WITNESS = 'off';
+      const offTables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 2 }) });
+      const offSb = new MockSB(offTables);
+      const resOff = await runConsume({ supabase: offSb, ventureId: VID, driveLeaf: makeDriveLeaf(offTables), witness: witnessWith(deps), bounds: BOUNDS });
+
+      expect(JSON.stringify(resOn)).toBe(JSON.stringify(resOff));   // scope equality: returned result ONLY
+      expect((onTables.merge_witness_telemetry || []).length).toBe(2);  // ON wrote telemetry
+      expect(offTables.merge_witness_telemetry === undefined || offTables.merge_witness_telemetry.length === 0).toBe(true); // OFF did not
+    } finally {
+      if (prev === undefined) delete process.env.VENTURE_BUILD_MERGE_WITNESS; else process.env.VENTURE_BUILD_MERGE_WITNESS = prev;
+    }
+  });
+});
+
+describe('TS-6 — nested 5x4 tree: witness fires ~20x, stays observe-only, walk unperturbed', () => {
+  it('fires once per completed leaf without perturbing drive order or completion count', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 5, grandkidsEach: 4 }) });
+    const sb = new MockSB(tables);
+    const deps = { prLookup: async (_s, k) => prFor(k), verifyMerged: async () => true };
+    const calls = [];
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), witness: witnessWith(deps, calls), bounds: BOUNDS });
+    expect(res.completed).toBe(true);
+    expect(res.drivenLeaves.length).toBe(20);
+    expect(calls.length).toBe(20);                                  // witnessed every completed leaf
+    expect(new Set(res.drivenLeaves.map((d) => d.sd_key.split('-')[1])).size).toBe(5); // crossed all 5 child-orchs
+    const tele = tables.merge_witness_telemetry || [];
+    expect(tele.length).toBe(20);
+    expect(tele.every((t) => t.overall === 'observe-only')).toBe(true);
+    expect(tele.every((t) => t.lane === 'venture-build')).toBe(true);
+  });
+});
+
+describe('TS-7 — dryRun=true ⇒ the witness never runs (no telemetry)', () => {
+  it('does not invoke the witness or write any telemetry on the dry-run path', async () => {
+    const tables = eligibleTables({ strategic_directives_v2: nestedTree({ children: 1, grandkidsEach: 2 }) });
+    const sb = new MockSB(tables);
+    const calls = [];
+    const deps = { prLookup: async () => ({ pr_number: 1 }), verifyMerged: async () => true };
+    const res = await runConsume({ supabase: sb, ventureId: VID, driveLeaf: makeDriveLeaf(tables), dryRun: true, witness: witnessWith(deps, calls), bounds: BOUNDS });
+    expect(res.dryRun).toBe(true);
+    expect(calls.length).toBe(0);
+    expect((tables.merge_witness_telemetry || []).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## What / Why
Adds an **observe-only** merge-witness to the venture-build tree-walker so each leaf is witnessed for **done=SHIPPED** (its PR actually merged) at its completion point — without changing control flow and without advancing any stage.

New module `lib/eva/bridge/venture-build-merge-witness.js` (`observeLeafMergeWitness`) is called inside `runConsume`'s `if (ok)` block, after the existing `LEO_BUILD_LEAF_DRIVEN` emit, guarded by `!dryRun` + a kill-switch. It:
- resolves the leaf's PR (canonical `ship_review_findings` by `sd_key`; `gh pr list --head feat/<sd_key>` fallback),
- determines merged state via the existing `verifyMerged` (throw/timeout ⇒ `not_evaluable`, never a false `not_merged`),
- builds the Ship-witness A P1–P5 verdict (`evaluateMergeWorkLadder`),
- writes `merge_witness_telemetry` (`lane='venture-build'`) then **reads it back** to confirm persistence,
- emits `LEO_BUILD_LEAF_COMPLETED_UNMERGED` **only** on a positive not-merged (never on `not_evaluable`/`merged`).

## Observe-only / never-advance
Return value is discarded by the caller; the witness never alters `ok`, `drivenLeaves`, loop termination, and never writes a lifecycle stage / governance decision / vision flag. Reuses the Ship-witness A substrate (PR #5412) — **no edits to `lib/ship/*`**, no new schema (reuses `merge_witness_telemetry`).

## Rollback
`VENTURE_BUILD_MERGE_WITNESS=off` (default ON). The walk is byte-identical either way.

## Deferred
Fail-**closed** enforcement (blocking completion on an unmerged leaf) is a separate downstream SD — **Ship-witness D** (`SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-*`). This PR is telemetry-only.

## Tests
`tests/unit/eva/bridge/venture-build-merge-witness.test.js` — 8 new tests (TS-1..TS-7), fully injected mocks (no live gh/DB): merged→telemetry+read-back+result unchanged; positive not_merged→event emitted + concrete never-advance DB state; injected IO throws→swallowed/logged/byte-identical result; unresolvable PR→not_evaluable/no event; witness ON vs OFF→identical returned result; nested 5×4 tree→witness fires 20× observe-only, walk unperturbed; dryRun→witness skipped. **All 34 baseline + 8 new = 42 green.**

+102 production code LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)