### PR TITLE
chore(SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001): register venture-build-consumer CLI (WIRE_CHECK)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "build:loader": "tsc -p tsconfig.json",
     "test:loader:dry": "node dist/services/database-loader/index.js --dry-run",
     "venture:prove": "node scripts/venture-proving-companion.js",
+    "venture:build:consume": "node lib/eva/bridge/venture-build-consumer.js",
     "test": "vitest run --project unit",
     "resync:safe": "node scripts/safe-root-resync.mjs",
     "protocol:lint": "node scripts/protocol-lint/cli.mjs audit",


### PR DESCRIPTION
Registers the venture-build walker CLI as `venture:build:consume` (package.json). This makes venture-build-consumer.js a discoverable entry point, transitively wiring the SD's new `lib/eva/bridge/venture-build-merge-witness.js` (statically imported by the consumer) so WIRE_CHECK_GATE passes at LEAD-FINAL-APPROVAL. Follow-up to merged PR #5416. Scripts-only, additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)