### PR TITLE
feat(SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001): ship-witness adoption gauge + gated enforce-flip capability

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,7 @@
 {
-  "sdKey": "SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001",
-  "createdAt": "2026-07-03T03:04:13.870Z",
+  "sdKey": "SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001",
+  "createdAt": "2026-07-03T04:16:47.255Z",
   "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/docs/reference/ship-witness-enforce-flip-readiness.md
+++ b/docs/reference/ship-witness-enforce-flip-readiness.md
@@ -1,0 +1,112 @@
+# Ship-witness: enforce-flip readiness (Ship-witness D)
+
+**SD**: SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D)
+**Status**: Approved
+**Category**: Protocol
+**Version**: 1.0.0
+**Last Updated**: 2026-07-03
+
+## What this is
+
+Sibling A's mergeWork() P1-P5 ladder (`lib/ship/merge-witness-ladder.mjs`) is
+strictly OBSERVE-ONLY — its `overall` field is hardcoded to the literal
+string `'observe-only'` and never blocks a real merge. This SD builds the
+**capability** to compute a real pass/fail verdict and refuse a merge on it,
+but does **not** activate that capability in production. Activation is a
+separate, future decision gated on real adoption evidence.
+
+Two new modules:
+
+- `lib/ship/witness-adoption.mjs` — measures adoption. `detectUnwitnessedMerges()`
+  finds platform-repo merges with **zero** `merge_witness_telemetry` row at
+  all (a WATCH-HOLE — observe was skipped entirely, not merely
+  recorded-and-allowed). `computeAdoptionReadiness()` answers "has adoption
+  been 100%-via-witness for N consecutive days?"
+- `lib/ship/ship-witness-enforcement.mjs` — `evaluateEnforcementDecision()`
+  computes a real `observe`/`allow`/`block` decision, but **only** when
+  `SHIP_WITNESS_ENFORCE_MODE=enforce` **and** `computeAdoptionReadiness()`
+  independently reports `ready: true`. Neither condition alone is sufficient.
+
+`lib/ship/auto-merge.mjs`'s `attemptAutoMerge()` gained one new optional
+param, `enforcementDecision`. Every existing caller (including the real
+`/ship` Step 6 snippet) omits it, so behavior is byte-identical to before
+this SD. Only a caller that explicitly supplies
+`evaluateEnforcementDecision` can ever cause a real pre-merge refusal.
+
+## The readiness bar
+
+`computeAdoptionReadiness()` requires **7 consecutive evidenced days at
+100%-via-witness** (the design spec's own threshold — see Family status
+below). Semantics:
+
+- A day counts toward the streak only if it had **at least one merge** and
+  **all** of that day's merges were witnessed.
+- A day with **zero merges** is skipped — it neither breaks nor extends the
+  streak. Readiness requires actual evidence, not silence.
+- A day with **any** unwitnessed merge resets the streak; days before the gap
+  do not count.
+
+Run `node scripts/ship-witness-enforce-readiness.mjs` at any time to check
+current readiness. It only reports — it never flips anything.
+
+**As of this SD's delivery, readiness is false.** `merge_witness_telemetry`
+has exactly one row (from PR #5415, the merge that first wired the
+substrate into production). The 7-day bar cannot possibly be met yet.
+
+## Cutover timestamp
+
+`WITNESS_CUTOVER_ISO = '2026-07-03T03:37:35Z'` (`lib/ship/witness-adoption.mjs`)
+— the instant PR #5415 (SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001) merged
+and `merge_witness_telemetry` wiring went live in the real `/ship` Step 6
+flow. Merges before this point are excluded from adoption scoring entirely
+— the substrate did not exist to observe them, and counting them as
+unwitnessed would produce a permanent false floor, not a real signal.
+
+## The WATCH-HOLE contract
+
+Any merge with **no** `merge_witness_telemetry` row at all means observe was
+skipped entirely — a blind spot, distinct from a merge that has a telemetry
+row showing a failed/bypassed rung (which means the witness caught it and is
+working as designed). `lib/governance/gauge-registry.js`'s new
+`ship-witness-unwitnessed-merge` entry runs on the existing
+`scripts/gauge-runner.mjs` cadence and escalates any WATCH-HOLE via the
+framework's existing `feedback` table pipeline — no new alerting mechanism
+was built.
+
+Two specimens are already banked as the rationale for this contract
+(recorded in the SD's own description, chairman/coordinator/Adam triage
+2026-07-03):
+
+1. **Self-attested authority** — a worker self-authored the chairman
+   `@approved-by` attestation in the witness-A migration itself (PR #5412,
+   permanent git history).
+2. **Observe-phase catch** — QF-20260702-806 force-completed with
+   `merge_witness` telemetry logging `verified:false`; the witness recorded
+   the exact bypass class on day 0 (observe worked as designed — this is
+   the class D's enforce-flip would eventually convert from record to
+   block).
+
+## Deliberately NOT delivered by this SD
+
+- **P4 (protection integrity) / escapeAuth**: sibling A's ladder still
+  reports P4 as `not_applicable` unconditionally, even though branch
+  protection (N1/P0) is now live on both platform repos. A real P4 check
+  needs a dual-key audited escapeAuth table that does not exist yet — that
+  is a separate, future SD's scope, not this one's.
+- **Wiring `evaluateEnforcementDecision` into the real `/ship` Step 6
+  snippet.** This SD ships the capability and the readiness measurement, not
+  the activation. Wiring it live today would exercise dead code against zero
+  real decisions (readiness is provably false) and would pre-empt the
+  explicit human/chairman decision that should gate a fail-closed flip on a
+  shared merge path.
+
+## Family status
+
+- **A** — SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (completed): the P1-P5
+  observe-only ladder + `merge_witness_telemetry` substrate.
+- **B** — SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (completed): the
+  `applications.trust_tier` hook (see `ship-witness-venture-trust-tier.md`).
+- **C** — SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001 (completed): venture-build
+  walker completion gates on a merged PR.
+- **D** — SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (this SD): adoption
+  measurement + gated, currently-inert enforce-flip capability.

--- a/docs/reference/ship-witness-venture-trust-tier.md
+++ b/docs/reference/ship-witness-venture-trust-tier.md
@@ -90,10 +90,11 @@ required for a pass — they aren't evaluable yet at all (see
 
 - **A** — SD-LEO-INFRA-SHIP-WITNESS-MERGEWORK-001 (completed): the P1-P5
   observe-only ladder + `merge_witness_telemetry` substrate this SD reads.
-- **B** — SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (this SD): the
+- **B** — SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001 (completed): the
   `trust_tier` hook described here.
-- **C** — SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001 (draft): venture-build walker
-  completion gates on a merged PR.
-- **D** — SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (draft): flips the ladder's
-  `overall` field from observe-to-fail-closed once telemetry shows 100% lane
-  adoption for 7 days.
+- **C** — SD-LEO-INFRA-SHIP-WITNESS-VENTURE-001 (completed): venture-build
+  walker completion gates on a merged PR.
+- **D** — SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (completed): the
+  adoption-readiness gauge + gated enforce-flip capability. See
+  `docs/reference/ship-witness-enforce-flip-readiness.md` for the readiness
+  bar and what D deliberately did NOT activate.

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -63,4 +63,14 @@ export const GAUGE_REGISTRY = [
     prevent: 'SD-LEO-INFRA-SINGLETON-STALE-TREE-STALENESS-GAUGE-001 FR-1 (behind-N staleness gauge on singleton startup + periodic tick).',
     enabled: true,
   },
+  {
+    id: 'ship-witness-unwitnessed-merge',
+    name: 'Platform-repo merge with zero merge_witness_telemetry row (WATCH-HOLE)',
+    detectorFn: 'ship-witness-unwitnessed-merge',
+    thresholdConfig: { tripWhen: (result) => (result?.count || 0) > 0 },
+    ownerRole: 'coordinator',
+    remediation: 'A merge landed with observe skipped entirely (not just recorded-and-allowed) — escalate immediately per the WATCH-HOLE contract; identify which merge lane bypassed telemetry writing and file a fix.',
+    prevent: 'SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D) — this gauge itself is the durable detection; a genuine fix retires individual watch-holes as merge lanes finish migrating to mergeWork(), not this gauge.',
+    enabled: true,
+  },
 ];

--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -220,6 +220,13 @@ export async function attemptAutoMerge({
   lookupWorkKeyReal,
   fetchReviewFinding,
   witnessSupabase = null,
+  // SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D): optional pre-merge enforcement
+  // hook. undefined (every pre-existing caller, including today's real /ship Step 6 snippet)
+  // means this block never runs — byte-identical behavior to before this SD. Only a caller
+  // that explicitly supplies lib/ship/ship-witness-enforcement.mjs's evaluateEnforcementDecision
+  // (itself gated on SHIP_WITNESS_ENFORCE_MODE=enforce AND independently-computed readiness)
+  // can ever cause a real pre-merge refusal here.
+  enforcementDecision,
 }) {
   if (!prNumber) {
     return { ok: false, reason: 'prNumber required', exitCode: 2 };
@@ -246,6 +253,26 @@ export async function attemptAutoMerge({
       reason: `non-platform repo ${repoOwner || '?'}/${repoName || '?'} requires human merge (auto-merge gated per SECURITY VB-2)`,
       exitCode: 0,
     };
+  }
+
+  // SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D): optional pre-merge enforcement gate.
+  // Only runs when a caller explicitly supplies enforcementDecision — every existing caller
+  // (undefined) skips this block entirely, zero behavior change.
+  if (enforcementDecision) {
+    const statusCheckRollup = fetchStatusCheckRollup(prNumber, runner);
+    const verdict = await evaluateMergeWorkLadder({
+      prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
+    });
+    const decision = await enforcementDecision({ verdict });
+    if (decision?.action === 'block') {
+      logger.warn(`⛔ Auto-merge refused for PR #${prNumber}: ship-witness enforcement — ${decision.reason}`);
+      return {
+        ok: false,
+        requiresHumanMerge: true,
+        reason: `ship-witness enforcement blocked: ${decision.reason}`,
+        exitCode: 0,
+      };
+    }
   }
 
   // 1. Detect + handle draft state.

--- a/lib/ship/ship-witness-enforcement.mjs
+++ b/lib/ship/ship-witness-enforcement.mjs
@@ -1,0 +1,43 @@
+/**
+ * Enforce-flip capability: a gated, currently-inert wrapper computing a REAL pass/fail from
+ * sibling A's mergeWork() ladder, ONLY when explicitly enabled (SHIP_WITNESS_ENFORCE_MODE=enforce)
+ * AND adoption readiness (lib/ship/witness-adoption.mjs computeAdoptionReadiness) independently
+ * confirms it. Neither condition alone is sufficient — belt-and-suspenders, matching Ship-witness
+ * B's own "registry promotion alone grants nothing" precedent. lib/ship/merge-witness-ladder.mjs
+ * itself is untouched: its evaluateMergeWorkLadder() "observe-only" contract and existing
+ * tests/callers are unaffected by this module's existence.
+ *
+ * Only P1 admission + P2 witness + P3 CI are required to pass — the same three-rung composition
+ * Ship-witness B already established for venture PRs, applied here to the general lane. P4
+ * (protection integrity) stays not_applicable pre-escapeAuth infra (not built by this SD); P5
+ * (post-verify) is post-merge-only and inapplicable to a pre-merge gate decision.
+ *
+ * NOT wired into the real /ship Step 6 flow by this SD — that activation is deliberately deferred
+ * to a future SD, once scripts/ship-witness-enforce-readiness.mjs reports ready=true for real.
+ */
+
+import { RUNG_STATUS } from './merge-witness-ladder.mjs';
+
+/** Resolves the current enforce mode from the environment. 'enforce' only on an exact match. */
+export function resolveEnforceMode(env = process.env) {
+  return env.SHIP_WITNESS_ENFORCE_MODE === 'enforce' ? 'enforce' : 'observe';
+}
+
+/**
+ * @param {{ verdict: {rungs: Array}, enforceMode?: string, readiness?: {ready: boolean} }} params
+ * @returns {{ action: 'observe'|'allow'|'block', reason: string }}
+ */
+export function evaluateEnforcementDecision({ verdict, enforceMode = resolveEnforceMode(), readiness } = {}) {
+  if (enforceMode !== 'enforce') {
+    return { action: 'observe', reason: 'SHIP_WITNESS_ENFORCE_MODE is not "enforce" — observe-only (today\'s default)' };
+  }
+  if (!readiness?.ready) {
+    return { action: 'observe', reason: 'adoption readiness not yet met — observe-only regardless of enforce mode' };
+  }
+
+  const byId = Object.fromEntries((verdict?.rungs || []).map((r) => [r.id, r.status]));
+  const pass = byId.P1 === RUNG_STATUS.PASS && byId.P2 === RUNG_STATUS.PASS && byId.P3 === RUNG_STATUS.PASS;
+  return pass
+    ? { action: 'allow', reason: 'P1 admission + P2 witness + P3 CI all pass' }
+    : { action: 'block', reason: `enforcement active and ready — P1/P2/P3 not all pass (P1=${byId.P1}, P2=${byId.P2}, P3=${byId.P3})` };
+}

--- a/lib/ship/witness-adoption.mjs
+++ b/lib/ship/witness-adoption.mjs
@@ -1,0 +1,117 @@
+/**
+ * Ship-witness adoption: identity-matched unwitnessed-merge detection + N-day readiness gauge.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D). Consumes merge_witness_telemetry
+ * (Ship-witness A, read-only) to answer two questions: (1) did any platform-repo merge since the
+ * witness substrate went live have ZERO telemetry row at all — a WATCH-HOLE, observe skipped
+ * entirely, not merely recorded-and-allowed (SD description's own contract)? (2) has adoption
+ * been 100%-via-witness for enough consecutive days to make an eventual enforce-flip safe?
+ * Neither function here flips anything — this module only measures. Matching uses (repo,
+ * pr_number) IDENTITY, never a raw count comparison (the red-merge-detector count-vs-identity
+ * lesson, scripts/ci/red-merge-detector.mjs).
+ */
+
+// merge_witness_telemetry wiring went live in production /ship at PR #5415's merge
+// (SD-LEO-INFRA-SHIP-WITNESS-APPLICATIONS-001, 2026-07-03T03:37:35Z). Merges before this instant
+// were never observable — counting them as unwitnessed would produce a permanent false floor, not
+// a real signal, so they are excluded rather than penalized.
+export const WITNESS_CUTOVER_ISO = '2026-07-03T03:37:35Z';
+
+export const PLATFORM_REPOS = [
+  { owner: 'rickfelix', name: 'ehg' },
+  { owner: 'rickfelix', name: 'EHG_Engineer' },
+];
+
+/**
+ * Default evidence-fetch: merged PRs for a platform repo since a given ISO timestamp, via gh CLI.
+ * Injectable — every caller in this module accepts a fetch override for deterministic tests.
+ */
+export function defaultFetchMergedPlatformPRs(repoOwner, repoName, sinceIso, runner) {
+  const search = `merged:>=${sinceIso.slice(0, 10)}`;
+  const r = runner(['pr', 'list', '--repo', `${repoOwner}/${repoName}`, '--state', 'merged', '--search', search, '--json', 'number,mergedAt', '--limit', '200']);
+  if (r.code !== 0) return [];
+  try {
+    const parsed = JSON.parse(r.stdout.trim() || '[]');
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((p) => ({ repo: `${repoOwner}/${repoName}`.toLowerCase(), prNumber: p.number, mergedAt: p.mergedAt }))
+      .filter((m) => m.mergedAt >= sinceIso);
+  } catch {
+    return [];
+  }
+}
+
+/** Pure: IDENTITY-match (repo, prNumber) merges against telemetry rows. Never a raw count diff. */
+export function classifyMerges(merges, telemetryRows) {
+  const witnessedKeys = new Set((telemetryRows || []).map((t) => `${(t.repo || '').toLowerCase()}#${t.pr_number}`));
+  return (merges || []).map((m) => ({
+    ...m,
+    witnessed: witnessedKeys.has(`${m.repo.toLowerCase()}#${m.prNumber}`),
+  }));
+}
+
+/** Pure: WATCH-HOLE detector shaped for gauge-registry's {count,...} convention. */
+export function detectUnwitnessedMerges(merges, telemetryRows) {
+  const classified = classifyMerges(merges, telemetryRows);
+  const unwitnessed = classified.filter((m) => !m.witnessed);
+  return { count: unwitnessed.length, total: classified.length, unwitnessed };
+}
+
+/** Pure: groups classified merges by UTC calendar day (YYYY-MM-DD). */
+function groupByDay(classifiedMerges) {
+  const byDay = new Map();
+  for (const m of classifiedMerges) {
+    const day = m.mergedAt.slice(0, 10);
+    if (!byDay.has(day)) byDay.set(day, []);
+    byDay.get(day).push(m);
+  }
+  return byDay;
+}
+
+/**
+ * Pure: N-consecutive-day 100%-via-witness readiness. Walks backward from `today` (an injectable
+ * YYYY-MM-DD, real Date.now() only as the default). A day with zero merges is SKIPPED — it
+ * neither breaks nor extends the streak, since readiness requires actual evidence, not silence.
+ * A day with any unwitnessed merge resets the streak (stops the walk). ready=true only once
+ * requiredConsecutiveDays evidenced days have accumulated with no reset in between.
+ *
+ * @param {{merges: Array, telemetryRows: Array, requiredConsecutiveDays?: number, today?: string, lookbackDays?: number}} params
+ */
+export function computeAdoptionReadiness({
+  merges,
+  telemetryRows,
+  requiredConsecutiveDays = 7,
+  today = new Date().toISOString().slice(0, 10),
+  lookbackDays = 60,
+}) {
+  const classified = classifyMerges(merges, telemetryRows);
+  const byDay = groupByDay(classified);
+  const dailyBreakdown = [];
+  let consecutiveDays = 0;
+  let ready = false;
+
+  const todayDate = new Date(`${today}T00:00:00Z`);
+  for (let i = 0; i < lookbackDays; i++) {
+    const d = new Date(todayDate);
+    d.setUTCDate(d.getUTCDate() - i);
+    const dayStr = d.toISOString().slice(0, 10);
+    const dayMerges = byDay.get(dayStr) || [];
+    if (dayMerges.length === 0) continue; // skip: no evidence either way, doesn't affect streak
+
+    const dayUnwitnessed = dayMerges.filter((m) => !m.witnessed).length;
+    dailyBreakdown.push({ day: dayStr, total: dayMerges.length, unwitnessed: dayUnwitnessed });
+    if (dayUnwitnessed > 0) break; // a real gap — stop walking, streak resets to what we've counted so far minus this
+
+    consecutiveDays += 1;
+    if (consecutiveDays >= requiredConsecutiveDays) { ready = true; break; }
+  }
+
+  return {
+    ready,
+    consecutiveDays,
+    dailyBreakdown,
+    reason: ready
+      ? `${consecutiveDays} consecutive evidenced day(s) at 100%-via-witness`
+      : `only ${consecutiveDays}/${requiredConsecutiveDays} consecutive evidenced day(s) at 100%-via-witness`,
+  };
+}

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -25,6 +25,13 @@ import { GAUGE_REGISTRY } from '../lib/governance/gauge-registry.js';
 import { computeClaimableLeaves } from './coordinator-backlog-rank.mjs';
 import { countUnrankedClaimableLeaves } from './gauge-unranked-claimable-leaves.mjs';
 import { checkoutFreshness } from '../lib/governance/checkout-freshness.js';
+import {
+  PLATFORM_REPOS,
+  WITNESS_CUTOVER_ISO,
+  defaultFetchMergedPlatformPRs,
+  detectUnwitnessedMerges,
+} from '../lib/ship/witness-adoption.mjs';
+import { spawnSync } from 'node:child_process';
 
 // relay-drop-gauge.cjs is CommonJS -- createRequire is this codebase's established ESM-import-CJS
 // seam (mirrors gauge-unranked-claimable-leaves.mjs's own worker-checkin.cjs import).
@@ -72,6 +79,16 @@ function buildDetectorResolvers(supabase) {
     },
     'relay-drop': async () => shapeRelayDropResult(await planRelayDrops(supabase)),
     'stale-tree': async () => shapeStaleTreeResult(checkoutFreshness(process.cwd(), { role: 'fleet-gauge-runner' })),
+    'ship-witness-unwitnessed-merge': async () => {
+      const ghRunner = (args) => {
+        const r = spawnSync('gh', args, { encoding: 'utf8' });
+        return { code: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
+      };
+      const merges = PLATFORM_REPOS.flatMap((r) => defaultFetchMergedPlatformPRs(r.owner, r.name, WITNESS_CUTOVER_ISO, ghRunner));
+      const { data: telemetryRows, error } = await supabase.from('merge_witness_telemetry').select('repo, pr_number');
+      if (error) throw new Error('merge_witness_telemetry query failed: ' + error.message);
+      return detectUnwitnessedMerges(merges, telemetryRows);
+    },
   };
 }
 

--- a/scripts/ship-witness-enforce-readiness.mjs
+++ b/scripts/ship-witness-enforce-readiness.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * On-demand adoption-readiness report for the Ship-witness enforce-flip.
+ *
+ * SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D) FR-2. This script only REPORTS — it
+ * never flips SHIP_WITNESS_ENFORCE_MODE or writes anything. A human/Adam consults it before
+ * deciding whether activating enforcement (a separate, future SD) is safe.
+ *
+ * Usage: node scripts/ship-witness-enforce-readiness.mjs [--json]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import {
+  PLATFORM_REPOS,
+  WITNESS_CUTOVER_ISO,
+  defaultFetchMergedPlatformPRs,
+  computeAdoptionReadiness,
+} from '../lib/ship/witness-adoption.mjs';
+
+const JSON_MODE = process.argv.includes('--json');
+
+function ghRunner(args) {
+  const r = spawnSync('gh', args, { encoding: 'utf8' });
+  return { code: r.status ?? 1, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required'); process.exit(1); }
+  const supabase = createClient(url, key);
+
+  const merges = PLATFORM_REPOS.flatMap((r) => defaultFetchMergedPlatformPRs(r.owner, r.name, WITNESS_CUTOVER_ISO, ghRunner));
+  const { data: telemetryRows, error } = await supabase.from('merge_witness_telemetry').select('repo, pr_number');
+  if (error) { console.error('merge_witness_telemetry query failed: ' + error.message); process.exit(1); }
+
+  const readiness = computeAdoptionReadiness({ merges, telemetryRows });
+
+  if (JSON_MODE) {
+    console.log(JSON.stringify(readiness));
+  } else {
+    console.log(`Ship-witness enforce-flip readiness: ${readiness.ready ? 'READY' : 'NOT READY'}`);
+    console.log(`  ${readiness.reason}`);
+    console.log(`  Cutover: ${WITNESS_CUTOVER_ISO}`);
+    for (const day of readiness.dailyBreakdown) {
+      console.log(`  ${day.day}: ${day.total} merge(s), ${day.unwitnessed} unwitnessed`);
+    }
+  }
+  process.exit(0);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  main().catch((e) => { console.error('UNHANDLED: ' + (e?.message || e)); process.exit(1); });
+}

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -19,14 +19,14 @@ import {
 const VALID_FEEDBACK_TYPES = ['issue', 'enhancement'];
 
 describe('GAUGE_REGISTRY shape', () => {
-  it('exports exactly 3 seed entries', () => {
-    expect(GAUGE_REGISTRY).toHaveLength(3);
+  it('exports exactly 4 seed entries (3 original + ship-witness-unwitnessed-merge, SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001)', () => {
+    expect(GAUGE_REGISTRY).toHaveLength(4);
   });
 
-  it('all 3 entries are activated — both former stubs adopted their sibling SDs\' detectors (QF-20260702-222)', () => {
+  it('all 4 entries are activated — no stub entries remain', () => {
     const live = GAUGE_REGISTRY.filter((e) => e.enabled === true);
     const stubs = GAUGE_REGISTRY.filter((e) => e.enabled === false);
-    expect(live).toHaveLength(3);
+    expect(live).toHaveLength(4);
     expect(stubs).toHaveLength(0);
   });
 
@@ -84,10 +84,18 @@ describe('selectEnabledEntries (TS-1/TS-2)', () => {
     expect(selectEnabledEntries(undefined)).toEqual([]);
   });
 
-  it('the real GAUGE_REGISTRY selects all 3 entries now that every stub is activated', () => {
+  it('the real GAUGE_REGISTRY selects all 4 entries now that every stub is activated', () => {
     const selected = selectEnabledEntries(GAUGE_REGISTRY);
-    expect(selected).toHaveLength(3);
-    expect(selected.map((e) => e.id).sort()).toEqual(['relay-drop', 'stale-tree', 'unranked-claimable-leaves']);
+    expect(selected).toHaveLength(4);
+    expect(selected.map((e) => e.id).sort()).toEqual(['relay-drop', 'ship-witness-unwitnessed-merge', 'stale-tree', 'unranked-claimable-leaves']);
+  });
+
+  it('SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001: the new entry has a resolvable detectorFn and the >0-count tripWhen convention', () => {
+    const entry = GAUGE_REGISTRY.find((e) => e.id === 'ship-witness-unwitnessed-merge');
+    expect(entry).toBeTruthy();
+    expect(entry.detectorFn).toBe('ship-witness-unwitnessed-merge');
+    expect(entry.thresholdConfig.tripWhen({ count: 1 })).toBe(true);
+    expect(entry.thresholdConfig.tripWhen({ count: 0 })).toBe(false);
   });
 });
 

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -636,4 +636,61 @@ describe('attemptAutoMerge — C2 external-repo merge-gate (SECURITY VB-2)', () 
     expect(calls[0][2]).toBe(42);
     expect(calls[0][3]).toEqual({ workKey: 'SD-XXX-001', tier: 'standard' });
   });
+
+  // SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (FR-3, FR-4): the optional enforcementDecision hook
+  // must be a true no-op when omitted (regression guard) and must refuse the merge BEFORE any
+  // gh pr merge call when a caller-supplied decision returns action='block'.
+  describe('enforcementDecision (Ship-witness D, optional pre-merge gate)', () => {
+    it('omitting enforcementDecision behaves byte-identical to before this SD (no extra gh calls, merge proceeds)', async () => {
+      const { runner, calls } = makeRunner([
+        { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+        { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+        { match: argvMatchers.prMerge, result: { stdout: '' } },
+        { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-07-03T00:00:00Z\n' } },
+        { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+        { match: argvMatchers.prViewHeadRef, result: { stdout: 'feat/x\n' } },
+        { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'Not Found (404)' } },
+      ]);
+      const r = await attemptAutoMerge({ prNumber: 55, repoOwner: 'rickfelix', repoName: 'ehg', runner, logger: silentLogger });
+      expect(r.ok).toBe(true);
+      // Sibling A's post-merge shadow-mode observe still fetches statusCheckRollup once
+      // (pre-existing, unrelated to this SD) — the D pre-merge gate must NOT add a second
+      // fetch when enforcementDecision is omitted.
+      const rollupCalls = calls.filter((c) => c[0] === 'pr' && c.includes('statusCheckRollup'));
+      expect(rollupCalls).toHaveLength(1);
+    });
+
+    it('refuses the merge BEFORE calling gh pr merge when enforcementDecision returns action=block', async () => {
+      const { runner, calls } = makeRunner([
+        { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+        { match: (a) => a[0] === 'pr' && a.includes('statusCheckRollup'), result: { stdout: '[]\n' } },
+      ]);
+      const enforcementDecision = async () => ({ action: 'block', reason: 'fixture block' });
+      const r = await attemptAutoMerge({
+        prNumber: 56, repoOwner: 'rickfelix', repoName: 'ehg', runner, logger: silentLogger, enforcementDecision,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.requiresHumanMerge).toBe(true);
+      expect(r.reason).toMatch(/fixture block/);
+      expect(calls.some((c) => c[0] === 'pr' && c[1] === 'merge')).toBe(false);
+    });
+
+    it('proceeds to merge when enforcementDecision returns action=observe or action=allow', async () => {
+      const { runner } = makeRunner([
+        { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+        { match: (a) => a[0] === 'pr' && a.includes('statusCheckRollup'), result: { stdout: '[]\n' } },
+        { match: argvMatchers.apiProtection, result: { stdout: 'false\n' } },
+        { match: argvMatchers.prMerge, result: { stdout: '' } },
+        { match: argvMatchers.prViewMergedAt, result: { stdout: '2026-07-03T00:00:00Z\n' } },
+        { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+        { match: argvMatchers.prViewHeadRef, result: { stdout: 'feat/x\n' } },
+        { match: argvMatchers.apiRefHead, result: { code: 1, stderr: 'Not Found (404)' } },
+      ]);
+      const enforcementDecision = async () => ({ action: 'observe' });
+      const r = await attemptAutoMerge({
+        prNumber: 57, repoOwner: 'rickfelix', repoName: 'ehg', runner, logger: silentLogger, enforcementDecision,
+      });
+      expect(r.ok).toBe(true);
+    });
+  });
 });

--- a/tests/unit/ship/ship-witness-enforcement.test.js
+++ b/tests/unit/ship/ship-witness-enforcement.test.js
@@ -1,0 +1,71 @@
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D)
+ * FR-3, FR-4: ship-witness-enforcement.mjs — gated, currently-inert enforce-flip decision.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveEnforceMode, evaluateEnforcementDecision } from '../../../lib/ship/ship-witness-enforcement.mjs';
+import { RUNG_STATUS } from '../../../lib/ship/merge-witness-ladder.mjs';
+
+function rung(id, status) {
+  return { id, status, reason: 'fixture' };
+}
+
+const ALL_PASS_VERDICT = {
+  rungs: [rung('P1', RUNG_STATUS.PASS), rung('P2', RUNG_STATUS.PASS), rung('P3', RUNG_STATUS.PASS), rung('P4', RUNG_STATUS.NOT_APPLICABLE), rung('P5', RUNG_STATUS.NOT_APPLICABLE)],
+};
+const P2_FAIL_VERDICT = {
+  rungs: [rung('P1', RUNG_STATUS.PASS), rung('P2', RUNG_STATUS.FAIL), rung('P3', RUNG_STATUS.PASS), rung('P4', RUNG_STATUS.NOT_APPLICABLE), rung('P5', RUNG_STATUS.NOT_APPLICABLE)],
+};
+
+describe('resolveEnforceMode', () => {
+  it('returns "enforce" only on an exact env match', () => {
+    expect(resolveEnforceMode({ SHIP_WITNESS_ENFORCE_MODE: 'enforce' })).toBe('enforce');
+    expect(resolveEnforceMode({ SHIP_WITNESS_ENFORCE_MODE: 'Enforce' })).toBe('observe');
+    expect(resolveEnforceMode({ SHIP_WITNESS_ENFORCE_MODE: 'true' })).toBe('observe');
+  });
+
+  it('defaults to "observe" when unset — today\'s real production state', () => {
+    expect(resolveEnforceMode({})).toBe('observe');
+  });
+});
+
+describe('evaluateEnforcementDecision', () => {
+  it('returns observe when enforceMode is unset (default) — regardless of verdict', () => {
+    const decision = evaluateEnforcementDecision({ verdict: P2_FAIL_VERDICT, readiness: { ready: true } });
+    expect(decision.action).toBe('observe');
+  });
+
+  it('returns observe when enforceMode=enforce but readiness.ready=false (today\'s real readiness)', () => {
+    const decision = evaluateEnforcementDecision({
+      verdict: P2_FAIL_VERDICT, enforceMode: 'enforce', readiness: { ready: false },
+    });
+    expect(decision.action).toBe('observe');
+  });
+
+  it('returns observe when enforceMode=enforce and readiness is entirely absent', () => {
+    const decision = evaluateEnforcementDecision({ verdict: P2_FAIL_VERDICT, enforceMode: 'enforce' });
+    expect(decision.action).toBe('observe');
+  });
+
+  it('returns block only when BOTH enforceMode=enforce AND readiness.ready=true AND rungs fail', () => {
+    const decision = evaluateEnforcementDecision({
+      verdict: P2_FAIL_VERDICT, enforceMode: 'enforce', readiness: { ready: true },
+    });
+    expect(decision.action).toBe('block');
+    expect(decision.reason).toMatch(/P2=fail/);
+  });
+
+  it('returns allow when both conditions hold and P1/P2/P3 all pass', () => {
+    const decision = evaluateEnforcementDecision({
+      verdict: ALL_PASS_VERDICT, enforceMode: 'enforce', readiness: { ready: true },
+    });
+    expect(decision.action).toBe('allow');
+  });
+
+  it('P4/P5 not_applicable never affect the decision — only P1/P2/P3 matter', () => {
+    const decision = evaluateEnforcementDecision({
+      verdict: ALL_PASS_VERDICT, enforceMode: 'enforce', readiness: { ready: true },
+    });
+    expect(decision.action).toBe('allow');
+  });
+});

--- a/tests/unit/ship/witness-adoption.test.js
+++ b/tests/unit/ship/witness-adoption.test.js
@@ -1,0 +1,143 @@
+/**
+ * SD-LEO-INFRA-SHIP-WITNESS-ENFORCE-001 (Ship-witness D)
+ * FR-1, FR-2, FR-4: witness-adoption.mjs — identity-matched WATCH-HOLE detection +
+ * N-consecutive-day adoption readiness. Pure unit tests, no live DB/gh calls.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  WITNESS_CUTOVER_ISO,
+  defaultFetchMergedPlatformPRs,
+  classifyMerges,
+  detectUnwitnessedMerges,
+  computeAdoptionReadiness,
+} from '../../../lib/ship/witness-adoption.mjs';
+
+function isoDay(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function dayOffset(todayIso, offsetDays) {
+  const d = new Date(`${todayIso}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - offsetDays);
+  return isoDay(d);
+}
+
+describe('defaultFetchMergedPlatformPRs', () => {
+  function makeRunner(stdout, code = 0) {
+    return () => ({ code, stdout, stderr: '' });
+  }
+
+  it('maps gh CLI output to {repo, prNumber, mergedAt} and lowercases repo', () => {
+    const runner = makeRunner(JSON.stringify([{ number: 42, mergedAt: '2026-07-04T00:00:00Z' }]));
+    const merges = defaultFetchMergedPlatformPRs('rickfelix', 'EHG_Engineer', '2026-07-03T00:00:00Z', runner);
+    expect(merges).toEqual([{ repo: 'rickfelix/ehg_engineer', prNumber: 42, mergedAt: '2026-07-04T00:00:00Z' }]);
+  });
+
+  it('filters out merges before sinceIso even if gh returns them', () => {
+    const runner = makeRunner(JSON.stringify([{ number: 1, mergedAt: '2026-07-01T00:00:00Z' }, { number: 2, mergedAt: '2026-07-04T00:00:00Z' }]));
+    const merges = defaultFetchMergedPlatformPRs('rickfelix', 'ehg', '2026-07-03T00:00:00Z', runner);
+    expect(merges.map((m) => m.prNumber)).toEqual([2]);
+  });
+
+  it('returns [] on gh CLI failure', () => {
+    const runner = makeRunner('', 1);
+    expect(defaultFetchMergedPlatformPRs('rickfelix', 'ehg', WITNESS_CUTOVER_ISO, runner)).toEqual([]);
+  });
+
+  it('returns [] on unparseable output', () => {
+    const runner = makeRunner('not json');
+    expect(defaultFetchMergedPlatformPRs('rickfelix', 'ehg', WITNESS_CUTOVER_ISO, runner)).toEqual([]);
+  });
+});
+
+describe('classifyMerges / detectUnwitnessedMerges (identity matching)', () => {
+  it('matches by (repo, prNumber) IDENTITY — a coincidental same-count different-PR row is NOT a match', () => {
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 10, mergedAt: '2026-07-04T00:00:00Z' }];
+    const telemetryRows = [{ repo: 'rickfelix/ehg', pr_number: 99 }]; // different PR, same repo
+    const result = detectUnwitnessedMerges(merges, telemetryRows);
+    expect(result.count).toBe(1);
+    expect(result.unwitnessed[0].prNumber).toBe(10);
+  });
+
+  it('matches case-insensitively on repo', () => {
+    const merges = [{ repo: 'rickfelix/EHG_Engineer', prNumber: 5, mergedAt: '2026-07-04T00:00:00Z' }];
+    const telemetryRows = [{ repo: 'rickfelix/ehg_engineer', pr_number: 5 }];
+    const result = detectUnwitnessedMerges(merges, telemetryRows);
+    expect(result.count).toBe(0);
+  });
+
+  it('a real matching row marks the merge witnessed', () => {
+    const merges = [{ repo: 'rickfelix/ehg', prNumber: 10, mergedAt: '2026-07-04T00:00:00Z' }];
+    const telemetryRows = [{ repo: 'rickfelix/ehg', pr_number: 10 }];
+    const classified = classifyMerges(merges, telemetryRows);
+    expect(classified[0].witnessed).toBe(true);
+  });
+
+  it('empty telemetry rows means every merge is unwitnessed', () => {
+    const merges = [
+      { repo: 'rickfelix/ehg', prNumber: 1, mergedAt: '2026-07-04T00:00:00Z' },
+      { repo: 'rickfelix/ehg', prNumber: 2, mergedAt: '2026-07-04T01:00:00Z' },
+    ];
+    const result = detectUnwitnessedMerges(merges, []);
+    expect(result.count).toBe(2);
+    expect(result.total).toBe(2);
+  });
+});
+
+describe('computeAdoptionReadiness', () => {
+  const TODAY = '2026-08-01';
+
+  function buildClean7DayFixture(today) {
+    const merges = [];
+    const telemetryRows = [];
+    for (let i = 0; i < 7; i++) {
+      const day = dayOffset(today, i);
+      merges.push({ repo: 'rickfelix/ehg', prNumber: 100 + i, mergedAt: `${day}T12:00:00Z` });
+      telemetryRows.push({ repo: 'rickfelix/ehg', pr_number: 100 + i });
+    }
+    return { merges, telemetryRows };
+  }
+
+  it('ready=true, consecutiveDays=7 for a clean 7-day fixture', () => {
+    const { merges, telemetryRows } = buildClean7DayFixture(TODAY);
+    const readiness = computeAdoptionReadiness({ merges, telemetryRows, today: TODAY, requiredConsecutiveDays: 7 });
+    expect(readiness.ready).toBe(true);
+    expect(readiness.consecutiveDays).toBe(7);
+  });
+
+  it('one unwitnessed merge on a recent day resets the streak — ready=false, does not count days before the gap', () => {
+    const { merges, telemetryRows } = buildClean7DayFixture(TODAY);
+    // Remove the telemetry row for the merge 3 days back — that day becomes fully unwitnessed.
+    const gapIndex = telemetryRows.findIndex((t) => t.pr_number === 103);
+    telemetryRows.splice(gapIndex, 1);
+
+    const readiness = computeAdoptionReadiness({ merges, telemetryRows, today: TODAY, requiredConsecutiveDays: 7 });
+    expect(readiness.ready).toBe(false);
+    // Days 0,1,2 (most recent, closer to today) are clean and counted; day 3 breaks the walk.
+    expect(readiness.consecutiveDays).toBe(3);
+  });
+
+  it('a day with zero merges is skipped — does not break or extend the streak', () => {
+    // 7 evidenced days spread across 8 calendar days (one quiet day with zero merges in between).
+    const merges = [];
+    const telemetryRows = [];
+    const offsets = [0, 1, 2, 3, 5, 6, 7]; // day offset 4 is intentionally quiet (no merges at all)
+    offsets.forEach((offset, idx) => {
+      const day = dayOffset(TODAY, offset);
+      merges.push({ repo: 'rickfelix/ehg', prNumber: 200 + idx, mergedAt: `${day}T12:00:00Z` });
+      telemetryRows.push({ repo: 'rickfelix/ehg', pr_number: 200 + idx });
+    });
+
+    const readiness = computeAdoptionReadiness({ merges, telemetryRows, today: TODAY, requiredConsecutiveDays: 7 });
+    expect(readiness.ready).toBe(true);
+    expect(readiness.consecutiveDays).toBe(7);
+  });
+
+  it('reflects real production state: 1 historical telemetry row is far short of 7 days — not ready', () => {
+    const merges = [{ repo: 'rickfelix/ehg_engineer', prNumber: 5415, mergedAt: '2026-07-03T03:37:35Z' }];
+    const telemetryRows = [{ repo: 'rickfelix/ehg_engineer', pr_number: 5415 }];
+    const readiness = computeAdoptionReadiness({ merges, telemetryRows, today: '2026-07-03', requiredConsecutiveDays: 7 });
+    expect(readiness.ready).toBe(false);
+    expect(readiness.consecutiveDays).toBeLessThan(7);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/ship/witness-adoption.mjs`: identity-matched (repo, pr_number) WATCH-HOLE detection (a merge with zero `merge_witness_telemetry` row — observe skipped entirely) and `computeAdoptionReadiness()` (7-consecutive-evidenced-day 100%-via-witness readiness bar).
- Adds `lib/ship/ship-witness-enforcement.mjs`: `evaluateEnforcementDecision()` computes a real `observe`/`allow`/`block` verdict from sibling A's ladder (P1+P2+P3 only), but ONLY when both `SHIP_WITNESS_ENFORCE_MODE=enforce` AND readiness is independently true — neither condition alone is sufficient.
- Registers a new `lib/governance/gauge-registry.js` entry (`ship-witness-unwitnessed-merge`) wired through the existing `scripts/gauge-runner.mjs` escalation pipeline — no new alerting mechanism built.
- Threads an optional `enforcementDecision` param into `attemptAutoMerge()`. Every existing caller (including the real `/ship` Step 6 snippet, unmodified by this PR) omits it — production behavior is byte-identical to before this PR.
- **This SD ships the capability, not the activation.** Readiness is provably false today (`merge_witness_telemetry` has exactly 1 row). `docs/reference/ship-witness-enforce-flip-readiness.md` documents the readiness bar, the WATCH-HOLE contract (with its 2 banked specimens), and what was deliberately deferred (P4/escapeAuth, real `/ship` wiring).

## Test plan
- [x] `npx vitest run tests/unit/ship/ tests/unit/governance/gauge-registry.test.js tests/unit/governance/gauge-runner-liveness.test.js` — 159/159 passing
- [x] `npx vitest run --project unit tests/unit/ship/ tests/unit/governance/` — 566/566 passing (zero regression on siblings A/B and the existing gauge framework)
- [x] New tests cover: identity vs. count matching, readiness streak-reset/zero-merge-day semantics, enforce-mode/readiness double-gating, and `attemptAutoMerge` regression guards (omitted param = byte-identical; block param = refuses before `gh pr merge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)