### PR TITLE
fix(SD-LEO-INFRA-CLOSE-ADAM-SOLOMON-001): close ADAM_SOLOMON_TWOWAY_V1 sentinel-target bypass in adam-advisory.cjs --to

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,7 @@
 {
-  "sdKey": "QF-20260703-964",
-  "workType": "QF",
-  "workKey": "QF-20260703-964",
-  "expectedBranch": "qf/QF-20260703-964",
-  "createdAt": "2026-07-03T04:32:06.879Z",
-  "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
+  "sdKey": "SD-LEO-INFRA-CLOSE-ADAM-SOLOMON-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-CLOSE-ADAM-SOLOMON-001",
+  "createdAt": "2026-07-03T05:38:27.235Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "baseRef": "origin/main"
 }

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -44,7 +44,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { redact, BODY_HARD_CAP, awaitCoordinatorReply } = require('./worker-signal.cjs');
 const { getActiveCoordinatorId, isTwoWayV2Enabled, isAdamSolomonTwoWayV1Enabled } = require('../lib/coordinator/resolve.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
-const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
+const { insertCoordinationRow, isSentinelTarget } = require('../lib/coordinator/dispatch.cjs');
 const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
@@ -112,6 +112,25 @@ function resolveAdamAdvisoryTarget({ toSolomon, flagOn, coordinatorId, solomonId
     return { target: solomonId || 'broadcast-solomon', via: 'direct' };
   }
   return { target: coordinatorId || 'broadcast-coordinator', via: null };
+}
+
+/**
+ * R1 (QF-20260703-964): pure --to <peerArg> classification for the direct-target path. No I/O.
+ * Exported for testing — adversarial-review finding, deep-tier PR review: this exact decision
+ * shipped un-unit-tested and silently admitted a SENTINEL_TARGETS value (e.g. broadcast-solomon)
+ * as a "direct target", completely bypassing the ADAM_SOLOMON_TWOWAY_V1 gate that --to solomon is
+ * deliberately subject to. Sentinels are NOT raw session_ids — isSentinelTarget() short-circuits
+ * dispatch.cjs's live-session check, so they get the SAME hard-error treatment as
+ * RESERVED_PEER_WORDS (role/sentinel resolution is out of R1 scope, raw session_id targets only).
+ * @param {string|null} peerArg
+ * @param {boolean} isRelayClassPeer
+ * @returns {{isDirectTarget: boolean, isBlockedPeerWord: boolean}}
+ */
+function classifyDirectTarget(peerArg, isRelayClassPeer) {
+  const RESERVED_PEER_WORDS = new Set(['coordinator', 'adam']);
+  const isBlockedPeerWord = !!(peerArg && (RESERVED_PEER_WORDS.has(peerArg) || isSentinelTarget(peerArg)));
+  const isDirectTarget = !!(peerArg && peerArg !== 'solomon' && !isRelayClassPeer && !isBlockedPeerWord);
+  return { isDirectTarget, isBlockedPeerWord };
 }
 
 function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass, replyWindowMs, now, addressee }) {
@@ -608,19 +627,18 @@ async function main() {
   if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
 
   const isRelayClassPeer = !!(peerArg && PEER_KINDS[peerArg] && PEER_KINDS[peerArg].class === 'relay');
-  // R1 (QF-20260703-964, crew-comms audit finding-008): 'coordinator'/'adam' need proper
+  // R1 (QF-20260703-964, crew-comms audit finding-008): 'coordinator'/'adam'/sentinels need proper
   // role-alias resolution (out of R1 scope — no live-lookup wiring here); any OTHER --to value
   // (e.g. a reasoner's raw session_id) is now accepted as a DIRECT target instead of hard-erroring
   // — the root incident: Adam had no way to address a specific reasoner/Solomon-bound session
   // directly, so those messages silently misrouted to the coordinator via the old hardcoded default.
   // insertCoordinationRow already REFUSES a non-UUID/non-sentinel target_session (DISPATCH_TARGET_INVALID),
-  // so a mistyped nickname fails loud rather than dead-lettering silently.
-  const RESERVED_PEER_WORDS = new Set(['coordinator', 'adam']);
-  if (peerArg && peerArg !== 'solomon' && !isRelayClassPeer && RESERVED_PEER_WORDS.has(peerArg)) {
+  // so a mistyped nickname fails loud rather than dead-lettering silently. See classifyDirectTarget.
+  const { isDirectTarget, isBlockedPeerWord } = classifyDirectTarget(peerArg, isRelayClassPeer);
+  if (peerArg && peerArg !== 'solomon' && !isRelayClassPeer && isBlockedPeerWord) {
     console.error(`ERROR: --to ${peerArg} needs role-alias resolution not yet supported (R1 scope: raw session_id targets only). Omit --to for the default coordinator relay.`);
     process.exit(2);
   }
-  const isDirectTarget = !!(peerArg && peerArg !== 'solomon' && !isRelayClassPeer && !RESERVED_PEER_WORDS.has(peerArg));
   const twoWayV1On = isAdamSolomonTwoWayV1Enabled();
   if (peerArg === 'solomon' && !twoWayV1On) {
     console.error('ERROR: --to solomon is gated by ADAM_SOLOMON_TWOWAY_V1=on (currently OFF). Omit --to to route via the coordinator.');
@@ -778,7 +796,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget };
+module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/tests/unit/adam-solomon-direct-channel.test.js
+++ b/tests/unit/adam-solomon-direct-channel.test.js
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { resolveAdamAdvisoryTarget, buildAdvisoryPayload: buildAdamPayload } = require('../../scripts/adam-advisory.cjs');
+const { resolveAdamAdvisoryTarget, buildAdvisoryPayload: buildAdamPayload, classifyDirectTarget } = require('../../scripts/adam-advisory.cjs');
 const { resolveSolomonAdvisoryTarget, buildAdvisoryPayload: buildSolomonPayload } = require('../../scripts/solomon-advisory.cjs');
 const { isAdamSolomonTwoWayV1Enabled } = require('../../lib/coordinator/resolve.cjs');
 const { assertValidTarget } = require('../../lib/coordinator/dispatch.cjs');
@@ -122,5 +122,52 @@ describe('payload.addressee is additive-only (QF-20260703-964)', () => {
   it('buildAdvisoryPayload (Adam) stamps the written addressee when passed', () => {
     const p = buildAdamPayload({ body: 'hi', senderCallsign: 'Delta', repo: '/x', correlationId: 'c1', addressee: 'solomon' });
     expect(p.addressee).toBe('solomon');
+  });
+});
+
+// SD-LEO-INFRA-CLOSE-ADAM-SOLOMON-001: adversarial-review finding, deep-tier PR review
+// (QF-20260703-964). This exact decision shipped un-unit-tested and silently admitted a
+// SENTINEL_TARGETS value (broadcast-solomon) as a "direct target", completely bypassing the
+// ADAM_SOLOMON_TWOWAY_V1 gate --to solomon is deliberately subject to. This test would have
+// caught it.
+describe('classifyDirectTarget — sentinels and reserved words are NEVER a direct target', () => {
+  it('a SENTINEL_TARGETS value (broadcast-solomon) is blocked, not admitted as direct', () => {
+    const r = classifyDirectTarget('broadcast-solomon', false);
+    expect(r.isBlockedPeerWord).toBe(true);
+    expect(r.isDirectTarget).toBe(false);
+  });
+  it('every SENTINEL_TARGETS value is blocked (broadcast, broadcast-coordinator, broadcast-adam)', () => {
+    for (const s of ['broadcast', 'broadcast-coordinator', 'broadcast-adam']) {
+      const r = classifyDirectTarget(s, false);
+      expect(r.isBlockedPeerWord).toBe(true);
+      expect(r.isDirectTarget).toBe(false);
+    }
+  });
+  it('RESERVED_PEER_WORDS (coordinator, adam) are still blocked (regression)', () => {
+    for (const w of ['coordinator', 'adam']) {
+      const r = classifyDirectTarget(w, false);
+      expect(r.isBlockedPeerWord).toBe(true);
+      expect(r.isDirectTarget).toBe(false);
+    }
+  });
+  it('a raw session_id (not a keyword, not a sentinel) IS a direct target', () => {
+    const r = classifyDirectTarget('0f8d45d8-9531-4ab8-a1b9-6961c405e1ec', false);
+    expect(r.isBlockedPeerWord).toBe(false);
+    expect(r.isDirectTarget).toBe(true);
+  });
+  it('"solomon" itself is neither blocked nor a direct target (handled by its own dedicated gate)', () => {
+    const r = classifyDirectTarget('solomon', false);
+    expect(r.isBlockedPeerWord).toBe(false);
+    expect(r.isDirectTarget).toBe(false);
+  });
+  it('a relay-class peer is neither blocked nor a direct target (handled by its own enqueue path)', () => {
+    const r = classifyDirectTarget('eva', true);
+    expect(r.isBlockedPeerWord).toBe(false);
+    expect(r.isDirectTarget).toBe(false);
+  });
+  it('null peerArg (no --to flag) is neither blocked nor a direct target', () => {
+    const r = classifyDirectTarget(null, false);
+    expect(r.isBlockedPeerWord).toBe(false);
+    expect(r.isDirectTarget).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- **Security-relevant regression fix.** QF-20260703-964 (PR #5420) merged with a live bug: the `--to <peerArg>` direct-target classification only excluded `RESERVED_PEER_WORDS` ('coordinator', 'adam'), not `dispatch.cjs`'s `SENTINEL_TARGETS` ('broadcast', 'broadcast-coordinator', 'broadcast-solomon', 'broadcast-adam'). `--to broadcast-solomon` was silently admitted as a direct target and inserted with `target_session='broadcast-solomon'` — completely bypassing the `ADAM_SOLOMON_TWOWAY_V1` feature flag (currently OFF) that the dedicated `--to solomon` path is deliberately gated behind. Solomon's inbox drain has no independent flag check on the receiving side, so the message was genuinely delivered.
- Extracts `classifyDirectTarget()` as a pure, exported function (the root cause of why this exact decision shipped un-unit-tested) and adds `isSentinelTarget()` to the block-list alongside `RESERVED_PEER_WORDS`.
- Found by a deep-tier adversarial review dispatched during the original QF's completion flow; the PR merged (by a concurrent process, not this repo's own `complete-quick-fix.js`, which explicitly declined to merge) before the fix landed. Independently re-verified against current `origin/main` before implementing (not blindly reused from the stray local worktree that already had this fix uncommitted).

## Test plan
- [x] `npx vitest run tests/unit/adam-solomon-direct-channel.test.js` — 24/24 passing (17 pre-existing + 7 new)
- [x] `npx vitest run --project unit` across all 20 test files that import `adam-advisory.cjs` — 194/194 passing (zero regression)
- [x] Live sanity check: `classifyDirectTarget('broadcast-solomon', false)` → blocked; `classifyDirectTarget('<raw-uuid>', false)` → still a valid direct target (R1 scope preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)