### PR TITLE
fix(QF-20260703-394): Retro generator analyzeHandoffs joins sd_phase_handoffs on sd_key vs UUID column - always-empty, boilerplate retros

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "SD-LEO-INFRA-CLOSE-ADAM-SOLOMON-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-CLOSE-ADAM-SOLOMON-001",
-  "createdAt": "2026-07-03T05:38:27.235Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
-  "baseRef": "origin/main"
+  "sdKey": "QF-20260703-394",
+  "workType": "QF",
+  "workKey": "QF-20260703-394",
+  "expectedBranch": "qf/QF-20260703-394",
+  "createdAt": "2026-07-03T06:06:08.704Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/generate-comprehensive-retrospective.js
+++ b/scripts/generate-comprehensive-retrospective.js
@@ -60,7 +60,7 @@ const supabase = createClient(supabaseUrl, supabaseKey);
  * Extract insights from handoff records in sd_phase_handoffs table
  * (SD-LEARN-FIX-ADDRESS-PAT-AUTO-010: Replaced markdown file reading with database queries)
  */
-async function analyzeHandoffs(sdKey) {
+async function analyzeHandoffs(sdUuid) {
   const insights = {
     achievements: [],
     challenges: [],
@@ -70,10 +70,13 @@ async function analyzeHandoffs(sdKey) {
   };
 
   try {
+    // QF-20260703-394: sd_phase_handoffs.sd_id is a UUID column that joins on
+    // strategic_directives_v2.id, NOT sd_key (reference_sd_phase_handoffs_joins_on_id_not_uuid_id) —
+    // passing the text sd_key here always silently returned zero rows.
     const { data: handoffs, error } = await supabase
       .from('sd_phase_handoffs')
       .select('from_phase, to_phase, handoff_type, status, executive_summary, deliverables_manifest, key_decisions, known_issues, action_items, validation_score, validation_details')
-      .eq('sd_id', sdKey)
+      .eq('sd_id', sdUuid)
       .order('created_at', { ascending: true });
 
     if (error || !handoffs || handoffs.length === 0) {
@@ -395,7 +398,7 @@ async function generateComprehensiveRetrospective(sdId) {
   // Gather comprehensive data
   console.log('\n📊 Analyzing implementation artifacts...');
 
-  const handoffInsights = await analyzeHandoffs(sd.sd_key);
+  const handoffInsights = await analyzeHandoffs(sdId);
   console.log(`   ✅ Analyzed handoff records (${handoffInsights.achievements.length} achievements, ${handoffInsights.learnings.length} learnings)`);
 
   // Secondary content source: SD metadata fields


### PR DESCRIPTION
## Quick-Fix: QF-20260703-394

**Type:** bug
**Severity:** medium

### Issue Description
KNOWN class (banked memory reference_retro_generator_analyzeHandoffs_sdkey_vs_id_bug), 3 fresh hits tonight (coordinator/Bravo signal 2026-07-03): SHIP-WITNESS-APPLICATIONS-001, SHIP-WITNESS-ENFORCE-001, CLOSE-ADAM-SOLOMON-001 all produced boilerplate retros. ROOT: scripts/generate-comprehensive-retrospective.js analyzeHandoffs() queries sd_phase_handoffs .eq('sd_id', sd.sd_key) — passes the TEXT key into the UUID column — silent empty result -> handoff analysis always empty -> retro falls back to boilerplate. FIX (~5-10 LOC): resolve the SD's UUID (strategic_directives_v2.id via sd_key; note sd_phase_handoffs joins on id NOT uuid_id per reference_sd_phase_handoffs_joins_on_id_not_uuid_id) BEFORE the handoffs query, and use it. Verify with a regenerated retro for one of the 3 named SDs showing real handoff content.


### Expected Behavior
analyzeHandoffs returns the SD's real handoff rows; retros carry actual handoff analysis

### Actual Behavior
UUID column compared to text key; always empty; boilerplate retros on every SD

### Changes
- **Files Changed:** 2
  - .worktree.json
  - scripts/generate-comprehensive-retrospective.js
- **LOC:** 6 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol