### PR TITLE
fix(QF-20260703-810): Skills drift X-1: fix stale 15-min cadence text in adam.md + solomon.md

### DIFF
--- a/.claude/commands/adam.md
+++ b/.claude/commands/adam.md
@@ -58,7 +58,7 @@ node scripts/adam-startup-check.mjs
 
 `CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Adam's tick is **seven loops**, silence-by-default + propose-only (CONST-002):
 1. **governance-scan** (daily) — the read-only opportunity-scan (`node scripts/adam-opportunity-scan.cjs --scan --scope auto`); runs only when `ADAM_GOVERNANCE_HEARTBEAT_V1=on` (else it prints `SUPPRESSED_FLAG_OFF`).
-2. **inbox-monitor** (every 15 min) — drain ALL coordinator-directed kinds, replies + directives (`node scripts/adam-advisory.cjs inbox`).
+2. **inbox-monitor** (every 5 min) — drain ALL coordinator-directed kinds, replies + directives (`node scripts/adam-advisory.cjs inbox`).
 3. **offer-help** (every 2 h) — an agent-judgment tick: offer the coordinator concise analysis when it helps, else stay silent.
 4. **self-adherence** (every 6 h) — Adam audits its OWN role-contract adherence (`node scripts/adam-self-adherence-review.mjs`): probes → `adam_adherence_ledger` → propose-only remediation for the coordinator on drift (never builds — CONST-002). SD-LEO-INFRA-AUTOMATED-RECURRING-ADAM-001.
 5. **belt-countdown** (every 15 min) — an agent-judgment tick: while the fleet is active, post ONE belt-countdown line (ET 12-hour, rolling ETA to belt-dry from DB rows via `node scripts/fleet-dashboard.cjs`); stay silent when the fleet is idle. The contract-named BELT COUNTDOWN DUTY (durable) — previously session-scoped and died every Adam session. SD-LEO-INFRA-ADAM-MACHINERY-CONSUMER-001.

--- a/.claude/commands/solomon.md
+++ b/.claude/commands/solomon.md
@@ -61,7 +61,7 @@ node scripts/solomon-startup-check.mjs
 ```
 
 `CronCreate`/`CronList` are **HARNESS tools** (not Node-callable), so the script only EMITS specs — YOU arm them. Solomon's tick is **three loops**:
-1. **inbox-monitor** (every 15 min) — drain `solomon_consult` + coordinator-directed kinds (`node scripts/solomon-advisory.cjs inbox --quiet`).
+1. **inbox-monitor** (every 5 min) — drain `solomon_consult` + coordinator-directed kinds (`node scripts/solomon-advisory.cjs inbox --quiet`).
 2. **self-adherence** (every 12 h) — Solomon audits its OWN role-contract adherence (`node scripts/solomon-self-adherence-review.mjs`): contract-duty parity → propose-only remediation on drift (never builds).
 3. **deep-sweep** (every 6 h) — an agent-judgment Mode-B deep-reasoning tick: enforce the `task_budget` at ENTRY first, then answer the highest-value open consult; stay silent if over budget or nothing pending.
 


### PR DESCRIPTION
## Summary
- `.claude/commands/adam.md` line 61: inbox-monitor cadence text corrected from 15-min to 5-min (chairman set the 5-min baseline 2026-07-01 via QF-20260701-062, which fixed the `.mjs` spec but not this skill doc)
- `.claude/commands/solomon.md` line 64: same class of drift, same fix
- belt-countdown's separate 15-min duty (adam.md line 64) is a different duty and is untouched, per skills-audit ledger confirmation

Source: Skills-audit S2 drift-sweep (ledger corr `adam-skills-audit-001-drift-sweep`, reasoner-A, origin/main-verified). Pure text edits, no behavior code — a fresh `/adam` or `/solomon` session was booting believing 15-min was still current.

## Test plan
- [x] Docs-only change, no code paths affected
- [x] Confirmed no other stale 15-min inbox-monitor references remain in either file
- [x] Confirmed belt-countdown's separate 15-min duty left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)