### PR TITLE
fix(QF-20260703-433): Skills drift X-2: remove/repoint 4 dead script references

### DIFF
--- a/.claude/commands/gate-debug.md
+++ b/.claude/commands/gate-debug.md
@@ -130,9 +130,6 @@ npm run handoff:compliance SD-ID
 
 ```bash
 # View all handoffs for an SD
-node scripts/check-handoff-chain.js SD-XXX-001
-
-# Or query directly
 node -e "
 import { createSupabaseClient } from './lib/supabase-client.js';
 const supabase = createSupabaseClient();
@@ -236,7 +233,7 @@ ORDER BY bypass_count DESC;
 
 ### Reference
 - Emergency bypass docs: CLAUDE_CORE.md (Emergency Bypass section)
-- Rate limit enforcement: `scripts/modules/handoff/validation/bypass-limiter.js`
+- Rate limit enforcement: `scripts/modules/handoff/cli/execution-helpers.js` (`checkBypassRateLimits`)
 - Audit log table: `database/schema/audit_log`
 
 ---

--- a/.claude/skills/eva-research.skill.md
+++ b/.claude/skills/eva-research.skill.md
@@ -162,18 +162,10 @@ Display the research skill output directly, prefixed with:
 
 ### Step 6: Save Research Session
 
-Save the session to `brainstorm_sessions` with vision linkage metadata:
-
-```bash
-node scripts/eva/save-research-session.mjs \
-  --topic "<question>" \
-  --tier <L1|L2|L3> \
-  --summary "<one-sentence summary of findings>" \
-  [--vision-key <key>]
-```
-
-The script will print the session ID on success. If it fails, show a warning but do not block the
-user — research results are already displayed.
+No automated persistence is currently available — `scripts/eva/save-research-session.mjs` was
+retired (archived) with no direct successor. Do not attempt to run it. Research results are
+already displayed to the user in Step 5; if durable tracking is needed, note the finding via
+the normal SD/feedback channels instead.
 
 ---
 

--- a/.claude/skills/eva.skill.md
+++ b/.claude/skills/eva.skill.md
@@ -21,7 +21,6 @@ Entry point for all EVA governance commands. Routes `/eva <subcommand>` to the a
 /eva score [options]          Vision alignment scoring
 /eva research [question]      Tiered research queries
 /eva review [options]         Post-creation vision/arch review
-/eva dashboard                Aggregated EVA metrics
 ```
 
 ## Instructions for Claude
@@ -34,7 +33,6 @@ From `$ARGUMENTS`, extract the first word as the subcommand. Everything after it
 - `/eva` → subcommand = none (show help)
 - `/eva mission view` → subcommand = `mission`, args = `view`
 - `/eva score --sd-id SD-XXX` → subcommand = `score`, args = `--sd-id SD-XXX`
-- `/eva dashboard` → subcommand = `dashboard`, args = none
 
 ---
 
@@ -72,8 +70,6 @@ EVA Governance CLI
 
   /eva research       Tiered research queries
                       Options: <question> [--tier L1|L2|L3]
-
-  /eva dashboard      Aggregated EVA governance metrics
 ```
 
 ---
@@ -93,22 +89,9 @@ Use the Skill tool to invoke the corresponding individual skill:
 | `score` | `eva-score` | Yes |
 | `review` | `review-vision` | Yes |
 | `research` | `eva-research` | Yes |
-| `dashboard` | `eva-dashboard` | Yes |
 
 **Delegation example:**
 If user runs `/eva mission view`, invoke the `eva-mission` skill with args `view`.
-
----
-
-### If subcommand is "dashboard":
-
-Run the dashboard command directly:
-
-```bash
-node scripts/eva/dashboard-command.mjs
-```
-
-Display the output directly to the user.
 
 ---
 


### PR DESCRIPTION
## Summary
Skills-audit S2 drift-sweep (ledger corr `adam-skills-audit-001-drift-sweep`, reasoner-A) found 4 script references in `.claude/commands/*` / `.claude/skills/*` that no longer exist on origin/main. Each was independently re-verified missing before editing (verify-before-amplify — the ledger row is 5 hours old, re-checked live via `git cat-file` against `origin/main`).

- `gate-debug.md:133` `scripts/check-handoff-chain.js` → removed; the doc already has a working direct-DB-query fallback immediately below it
- `gate-debug.md:236` `scripts/modules/handoff/validation/bypass-limiter.js` → repointed to `scripts/modules/handoff/cli/execution-helpers.js` (`checkBypassRateLimits`), the actual live rate-limit enforcement function
- `eva.skill.md` `scripts/eva/dashboard-command.mjs` → duty fully retired (no `eva-dashboard` skill file exists either, script is archived); removed all `/eva dashboard` references (usage line, help menu, delegation table, implementation block) for internal consistency rather than leaving a half-dead advertised subcommand
- `eva-research.skill.md` `scripts/eva/save-research-session.mjs` → archived with no direct successor; converted Step 6 into an honest stub instead of deleting it outright, since Step 7's "Link to vision" flow references it ("re-run Step 6") — full deletion would have just relocated the dangling-reference bug

Text-only edits, no behavior code.

## Test plan
- [x] All 4 refs independently re-verified MISSING on origin/main via `git cat-file -e`
- [x] Successor for the rate-limiter ref confirmed live on origin/main (`checkBypassRateLimits` in `execution-helpers.js`)
- [x] Confirmed no `eva-dashboard` skill exists before fully retiring the dashboard duty
- [x] Confirmed the Step 6/Step 7 cross-reference in eva-research.skill.md still resolves after the edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)