### PR TITLE
fix(QF-20260703-262): lead-aging-detector honors requires_human_action defer flag

### DIFF
--- a/lib/coordinator/lead-aging-detector.mjs
+++ b/lib/coordinator/lead-aging-detector.mjs
@@ -62,9 +62,24 @@ function isUnclaimed(row) {
 }
 
 /**
+ * A row is DURABLY DEFERRED iff it carries metadata.requires_human_action===true or a
+ * metadata.not_worker_claimable_reason — e.g. a chairman-parked SD (mission scope-hold, dependency
+ * defer). Flagging these as a dispatch gap would produce a remediation ("dispatch to a worker") that
+ * directly contradicts the chairman/human directive that parked it. Same class as
+ * reference_gauge_action_divergent_flag_ssot — a gauge must honor the same defer flags the actions do.
+ */
+function isDeferred(row) {
+  const m = row && row.metadata;
+  if (!m) return false;
+  if (m.requires_human_action === true) return true;
+  if (m.not_worker_claimable_reason) return true;
+  return false;
+}
+
+/**
  * A LEAD-aging CANDIDATE iff: status==='draft' AND current_phase==='LEAD' AND it is an Adam-sourced
  * vision-loop proposal (metadata.source==='proposal') AND it IS scored (disjoint from findStalledDrafts)
- * AND it is UNCLAIMED (disjoint from the claimed progress-stall DUTY).
+ * AND it is UNCLAIMED (disjoint from the claimed progress-stall DUTY) AND it is NOT durably deferred.
  * @param {object} row
  * @param {{has:(k:string)=>boolean}|null} scoredKeys
  */
@@ -75,6 +90,7 @@ function isLeadAgingCandidate(row, scoredKeys) {
   if (source !== 'proposal') return false;     // only Adam-sourced vision-loop drafts
   if (!isScored(row, scoredKeys)) return false; // DISJOINT from findStalledDrafts (which flags unscored)
   if (!isUnclaimed(row)) return false;          // DISJOINT from the claimed progress-stall DUTY
+  if (isDeferred(row)) return false;            // honor chairman-park / human-action defer flags
   return true;
 }
 

--- a/tests/unit/lead-aging-detector.test.js
+++ b/tests/unit/lead-aging-detector.test.js
@@ -72,6 +72,20 @@ describe('findLeadAgingDrafts — DISJOINTNESS (never double-reports with the si
     ];
     expect(findLeadAgingDrafts(rows, NOW).violation).toBe(false);
   });
+
+  it('does NOT flag a durably-deferred draft (metadata.requires_human_action=true — e.g. chairman-parked)', () => {
+    const parked = agingDraft('SD-PARKED', 30, {
+      metadata: { source: 'proposal', requires_human_action: true },
+    });
+    expect(findLeadAgingDrafts([parked], NOW).violation).toBe(false);
+  });
+
+  it('does NOT flag a durably-deferred draft (metadata.not_worker_claimable_reason set)', () => {
+    const deferred = agingDraft('SD-NOT-CLAIMABLE', 30, {
+      metadata: { source: 'proposal', not_worker_claimable_reason: 'dependency-hold' },
+    });
+    expect(findLeadAgingDrafts([deferred], NOW).violation).toBe(false);
+  });
 });
 
 describe('findLeadAgingDrafts — authoritative scored signal (scoredKeys / eva-row)', () => {


### PR DESCRIPTION
## Summary
- `lib/coordinator/lead-aging-detector.mjs`: `isLeadAgingCandidate()` flagged scored, unclaimed Adam-sourced drafts at LEAD >7d without checking for a durable defer flag. Live specimen: `SD-EHG-VENTURE1-MARKET-MODELING-SAAS-001` is chairman-parked (mission = prove ONE venture end-to-end; other ventures deferred-with-reopen-note) with `metadata.requires_human_action=true`, yet charter-audit DUTY-9 fired every 15min demanding it be dispatched — a remediation that directly contradicts the chairman's park directive.
- Added `isDeferred(row)` helper (matches the existing `isScored`/`isUnclaimed` style) that skips rows carrying `metadata.requires_human_action===true` or a `metadata.not_worker_claimable_reason`.
- Same class as the gauge-vs-action divergent-flag family (3rd occurrence this codebase) — a gauge must honor the same defer flags the actions already do.

## Test plan
- [x] Added 2 new unit tests in the existing DISJOINTNESS block: one for `requires_human_action=true`, one for `not_worker_claimable_reason`
- [x] Full test file green: 18/18 (16 original + 2 new)
- [x] Confirmed no unrelated behavior change — the new check is an early-return added alongside the existing scored/unclaimed guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)