### PR TITLE
fix(QF-20260703-369): wire deriveConditionalPassEvidence into orchestrated storeSubAgentResult writer

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-394",
+  "sdKey": "QF-20260703-369",
   "workType": "QF",
-  "workKey": "QF-20260703-394",
-  "expectedBranch": "qf/QF-20260703-394",
-  "createdAt": "2026-07-03T06:06:08.704Z",
+  "workKey": "QF-20260703-369",
+  "expectedBranch": "qf/QF-20260703-369",
+  "createdAt": "2026-07-03T11:17:37.986Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/phase-subagent-orchestrator/execution.js
+++ b/scripts/modules/phase-subagent-orchestrator/execution.js
@@ -8,6 +8,12 @@ import { safeInsert, generateUUID } from '../safe-insert.js';
 import { createHash } from 'crypto';
 // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
 import { normalizeSDId } from '../sd-id-normalizer.js';
+// QF-20260703-369: Import the QF-20260603-485 evidence synthesizer — this writer is the
+// second (orchestrated) insert path for sub_agent_execution_results and was never wired
+// to it, so CONDITIONAL_PASS producers that don't self-populate conditions/justification
+// (e.g. DESIGN) violated check_conditions_required here even though the sibling writer
+// in lib/sub-agent-executor/results-storage.js already handles the same case.
+import { deriveConditionalPassEvidence } from '../../../lib/sub-agent-executor/results-storage.js';
 
 /**
  * Generate deterministic idempotency key for sub-agent execution
@@ -217,6 +223,10 @@ async function storeSubAgentResult(supabase, sdId, result, options = {}) {
     }
   }
 
+  // QF-20260703-369: synthesize conditions/justification for a CONDITIONAL_PASS verdict
+  // that didn't self-populate them, mirroring the sibling writer's QF-20260603-485 fix.
+  const conditionalPassEvidence = deriveConditionalPassEvidence(result, result.sub_agent_code);
+
   const insertData = {
     id: generateUUID(),
     sd_id: normalizedSdId,  // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Use normalized UUID
@@ -237,8 +247,8 @@ async function storeSubAgentResult(supabase, sdId, result, options = {}) {
     },
     created_at: new Date().toISOString(),
     validation_mode: result.validation_mode || null,
-    justification: result.justification || null,
-    conditions: result.conditions || null
+    justification: conditionalPassEvidence.justification,
+    conditions: conditionalPassEvidence.conditions
   };
 
   const insertResult = await safeInsert(supabase, 'sub_agent_execution_results', insertData, {

--- a/tests/unit/phase-subagent-orchestrator-conditional-pass-evidence.test.js
+++ b/tests/unit/phase-subagent-orchestrator-conditional-pass-evidence.test.js
@@ -1,0 +1,105 @@
+/**
+ * QF-20260703-369: the orchestrated writer (scripts/modules/phase-subagent-orchestrator/
+ * execution.js::storeSubAgentResult) is a SECOND, independent insert path for
+ * sub_agent_execution_results, parallel to lib/sub-agent-executor/results-storage.js.
+ * QF-20260603-485 fixed the CONDITIONAL_PASS-without-evidence case (check_conditions_required /
+ * check_justification_required DB constraints) only in the latter. Any producer that downgrades
+ * to CONDITIONAL_PASS without self-populating conditions/justification (e.g. DESIGN via
+ * applyRepoResolutionVerdict) still crashed the orchestrated path with Postgres 23514.
+ *
+ * These tests pin that the orchestrated writer now derives the same evidence before insert.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('storeSubAgentResult (orchestrated writer): CONDITIONAL_PASS evidence synthesis (QF-20260703-369)', () => {
+  const capture = {};
+
+  beforeEach(() => {
+    capture.insertData = null;
+
+    vi.doMock('../../scripts/modules/safe-insert.js', () => ({
+      safeInsert: async (_supabase, _table, data) => {
+        capture.insertData = data;
+        return { success: true, data: { id: data.id, ...data }, warnings: [], error: null };
+      },
+      generateUUID: () => 'mock-uuid-0000'
+    }));
+
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_supabase, sdId) => sdId
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../../scripts/modules/safe-insert.js');
+    vi.doUnmock('../../scripts/modules/sd-id-normalizer.js');
+  });
+
+  function makeFakeSupabase() {
+    return {
+      from() {
+        return {
+          select() { return this; },
+          contains() { return this; },
+          eq() { return this; },
+          single: async () => ({ data: { id: 'mock-uuid-0000' }, error: null })
+        };
+      }
+    };
+  }
+
+  it('synthesizes non-empty conditions + justification>=50 for a bare CONDITIONAL_PASS (DESIGN-shaped, no self-populated evidence)', async () => {
+    const { storeSubAgentResult } = await import('../../scripts/modules/phase-subagent-orchestrator/execution.js');
+
+    await storeSubAgentResult(makeFakeSupabase(), 'SD-TEST-001', {
+      sub_agent_code: 'DESIGN',
+      sub_agent_name: 'Senior Design Sub-Agent',
+      verdict: 'CONDITIONAL_PASS',
+      confidence: 60,
+      critical_issues: [{ severity: 'LOW', issue: '1 accessibility violations', recommendation: 'Fix WCAG 2.1 AA violations before deployment' }],
+      warnings: [],
+      recommendations: []
+      // justification / conditions deliberately omitted, matching design/index.js's actual shape
+    }, { skipIdempotency: true });
+
+    expect(capture.insertData).not.toBeNull();
+    expect(Array.isArray(capture.insertData.conditions)).toBe(true);
+    expect(capture.insertData.conditions.length).toBeGreaterThan(0);
+    expect(typeof capture.insertData.justification).toBe('string');
+    expect(capture.insertData.justification.length).toBeGreaterThanOrEqual(50);
+  });
+
+  it('leaves an already-self-populated CONDITIONAL_PASS (e.g. VALIDATION) untouched', async () => {
+    const { storeSubAgentResult } = await import('../../scripts/modules/phase-subagent-orchestrator/execution.js');
+
+    const ownConditions = [{ action: 'Resolve X before merge', priority: 'high', blocking: true }];
+    const ownJustification = 'A'.repeat(60);
+
+    await storeSubAgentResult(makeFakeSupabase(), 'SD-TEST-001', {
+      sub_agent_code: 'VALIDATION',
+      sub_agent_name: 'Principal Systems Analyst',
+      verdict: 'CONDITIONAL_PASS',
+      confidence: 100,
+      conditions: ownConditions,
+      justification: ownJustification
+    }, { skipIdempotency: true });
+
+    expect(capture.insertData.conditions).toEqual(ownConditions);
+    expect(capture.insertData.justification).toBe(ownJustification);
+  });
+
+  it('leaves conditions/justification null for a non-CONDITIONAL_PASS verdict (no constraint applies)', async () => {
+    const { storeSubAgentResult } = await import('../../scripts/modules/phase-subagent-orchestrator/execution.js');
+
+    await storeSubAgentResult(makeFakeSupabase(), 'SD-TEST-001', {
+      sub_agent_code: 'SECURITY',
+      sub_agent_name: 'Chief Security Architect',
+      verdict: 'PASS',
+      confidence: 100
+    }, { skipIdempotency: true });
+
+    expect(capture.insertData.conditions).toBeNull();
+    expect(capture.insertData.justification).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/modules/phase-subagent-orchestrator/execution.js::storeSubAgentResult` is a second, parallel insert path for `sub_agent_execution_results`. QF-20260603-485 fixed the CONDITIONAL_PASS-without-self-populated-evidence case in the sibling writer (`lib/sub-agent-executor/results-storage.js`) only — this path still inserted `justification: result.justification || null` / `conditions: result.conditions || null` verbatim, so any producer that downgrades to CONDITIONAL_PASS without self-populating those fields (e.g. DESIGN via `applyRepoResolutionVerdict`) crashed with Postgres 23514 `check_conditions_required`, aborting the entire evidence-collection batch fleet-wide.
- Fix: call the already-exported, already-unit-tested `deriveConditionalPassEvidence()` before the insert, mirroring the sibling writer exactly.

## Test plan
- [x] `npx vitest run tests/unit/phase-subagent-orchestrator-conditional-pass-evidence.test.js` — 3/3 passing (new, mocks `safeInsert` to capture the actual insert payload without a live DB): bare CONDITIONAL_PASS synthesizes non-empty conditions + ≥50-char justification; an already-self-populated CONDITIONAL_PASS is left untouched; a non-CONDITIONAL_PASS verdict stays null
- [x] `npx vitest run tests/unit/sub-agent-executor/derive-conditional-pass-evidence.test.js` — 6/6 passing, zero regression on the reused derivation logic
- [x] Live sanity check reproducing the exact DESIGN bug scenario: `deriveConditionalPassEvidence({verdict:'CONDITIONAL_PASS', conditions:null, justification:null, warnings:['repo path mismatch, medium risk']}, 'DESIGN')` → non-empty conditions, 212-char justification

🤖 Generated with [Claude Code](https://claude.com/claude-code)