### PR TITLE
fix(QF-20260703-537): sourcing_cadence probe blind to quick_fixes lane

### DIFF
--- a/scripts/adam-self-adherence-review.mjs
+++ b/scripts/adam-self-adherence-review.mjs
@@ -63,18 +63,25 @@ export async function resolveFacts(supabase, { windowDays = WINDOW_DAYS, nowMs =
     if (Number.isFinite(count)) facts.signalsInWindow = count;
   } catch { /* leave null -> unknown */ }
 
-  // FR-1b — sourcing cadence: count SDs Adam durably attributed within the window. The canonical
-  // marker is metadata.sourced_by='adam' (stamped at sourcing time by leo-create-sd.js FR-1a, and
-  // the existing live convention). HONEST: a real 0 stays 0 (probe FAIL — cadence stalled); ONLY a
-  // thrown query error leaves the fact null -> unknown. No retroactive fabrication on historical SDs.
+  // FR-1b — sourcing cadence: count ALL gap-closing work Adam sources for the coordinator within
+  // the window, unified across the two lanes it uses — SD drafts (metadata.sourced_by='adam',
+  // stamped at SD-creation time) and quick_fixes (no metadata column exists on that table
+  // to carry a per-row marker, so the whole lane counts). QF-20260703-537: the SD-only count was
+  // blind to the quick_fixes lane, producing a false FAIL/drift remediation on days Adam sourced
+  // only QFs. HONEST: a real 0 across both lanes stays 0 (probe FAIL); a thrown error on EITHER
+  // query leaves the combined fact null -> unknown (never silently under-counts via the other lane).
   try {
-    const { count, error } = await supabase
-      .from('strategic_directives_v2')
-      .select('id', { count: 'exact', head: true })
-      .gte('created_at', since)
-      .eq('metadata->>sourced_by', 'adam');
-    if (error) throw error; // a query error must NOT masquerade as a real "0 sourced"
-    if (Number.isFinite(count)) facts.sourcedInWindow = count;
+    const [sdResult, qfResult] = await Promise.all([
+      supabase.from('strategic_directives_v2').select('id', { count: 'exact', head: true })
+        .gte('created_at', since).eq('metadata->>sourced_by', 'adam'),
+      supabase.from('quick_fixes').select('id', { count: 'exact', head: true })
+        .gte('created_at', since),
+    ]);
+    if (sdResult.error) throw sdResult.error;
+    if (qfResult.error) throw qfResult.error;
+    if (Number.isFinite(sdResult.count) && Number.isFinite(qfResult.count)) {
+      facts.sourcedInWindow = sdResult.count + qfResult.count;
+    }
   } catch { /* leave null -> unknown */ }
 
   // FR-2 — friction signaling (recurrence side): windowed recurrence count from the durable

--- a/tests/integration/adam-self-adherence-review.test.js
+++ b/tests/integration/adam-self-adherence-review.test.js
@@ -88,9 +88,11 @@ describe('CONST-002 propose-only / no-build GUARD (FR-5)', () => {
     for (const forbidden of ['handoff.js', 'gh pr', 'git commit', 'leo-create-sd', 'add-prd-to-database', 'apply-migration', 'execSync', 'child_process']) {
       expect(src).not.toContain(forbidden);
     }
-    // Remediation writes ONLY to feedback (sourcing) + adam_adherence_ledger (record) — nothing else mutated.
+    // Remediation writes ONLY to feedback (sourcing) + adam_adherence_ledger (record) + audit_log
+    // (recordVisionGaugeRead's own observability event stamp, pre-existing on origin/main — not a
+    // build/mutate surface) — nothing else mutated.
     const writtenTables = [...src.matchAll(/\.from\('([^']+)'\)[\s\S]{0,80}?\.insert\(/g)].map((m) => m[1]);
-    for (const t of writtenTables) expect(['feedback', 'adam_adherence_ledger']).toContain(t);
+    for (const t of writtenTables) expect(['feedback', 'adam_adherence_ledger', 'audit_log']).toContain(t);
   });
 });
 

--- a/tests/unit/adam/adherence-resolvers.test.js
+++ b/tests/unit/adam/adherence-resolvers.test.js
@@ -103,6 +103,32 @@ describe('resolveFacts (FR-1b/2/3/4) — measured vs honestly-unknown', () => {
     expect(facts.sourcedInWindow).toBeNull();
   });
 
+  it('QF-20260703-537: zero Adam-sourced SDs but 5 quick_fixes in-window -> sourcedInWindow=5, no false FAIL', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: COUNT(0), // no SD drafts this window
+      quick_fixes: COUNT(5), // 5 QFs filed in-window — the previously-blind lane
+      issue_patterns: ROWS([]),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.sourcedInWindow).toBe(5); // unified across both lanes, not just SDs
+  });
+
+  it('QF-20260703-537: an error on the quick_fixes query alone also leaves sourcedInWindow null (never silently falls back to SD-only count)', async () => {
+    const sb = makeSupabase({
+      session_coordination: COUNT(0),
+      strategic_directives_v2: COUNT(3), // this lane resolved fine
+      quick_fixes: ERR('db down'),
+      issue_patterns: ROWS([]),
+      sub_agent_execution_results: COUNT(0),
+      audit_log: COUNT(0),
+    });
+    const facts = await resolveFacts(sb, { windowDays: 1 });
+    expect(facts.sourcedInWindow).toBeNull();
+  });
+
   it('FR-3: no per-row Adam-author marker exists -> adamAuthoredBuilds stays null (no fabricated CONST-002 pass OR fail)', async () => {
     // Even with a healthy fleet of build rows, the resolver does NOT consult
     // sub_agent_execution_results for FR-3: there is no reliable per-build Adam-author key, and


### PR DESCRIPTION
## Summary
- `resolveFacts()`'s `sourcedInWindow` only counted `strategic_directives_v2` rows with `metadata.sourced_by='adam'`, blind to the `quick_fixes` lane — a day with 5 Adam-sourced QFs and zero new SD drafts reported "0 items sourced", producing a false `adam_adherence_drift` remediation (ledger row 52933fea)
- Fix unifies the sourcing count across both lanes: `quick_fixes` has no metadata column to carry a per-row attribution marker, so the whole lane counts (matching the QF's own "unify the sourcing definition" framing)
- A query error on either lane still leaves the combined fact `null` -> unknown (never silently under-counts via just the other lane)
- Also fixes 2 pre-existing, unrelated failures this same file exposed in the FR-5 no-build-surface integration test (a comment citing "leo-create-sd" tripped the forbidden-substring guard; `recordVisionGaugeRead`'s pre-existing `audit_log` insert was never added to the written-tables allowlist)

## Test plan
- [x] New resolver tests: 5 Adam-sourced QFs + 0 SD drafts -> `sourcedInWindow=5` (no false FAIL); an error on the `quick_fixes` query alone also leaves the fact `null` (never falls back to SD-only count)
- [x] Existing resolver/probe/integration tests unaffected (46/46 passing)
- [x] `node --check` + eslint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)