### PR TITLE
fix(QF-20260703-524): Commit the chairman Gmail-filter subject tokens in adam-heartbeat-email.mjs upstream (uncommitted shared-root edit)

### DIFF
--- a/scripts/adam-heartbeat-email.mjs
+++ b/scripts/adam-heartbeat-email.mjs
@@ -27,7 +27,11 @@ if (!body || !body.trim()) {
 }
 
 const when = new Date().toLocaleString('en-US', { timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit', month: 'short', day: 'numeric' });
-const subject = `All good - Adam heartbeat ${when} ET`;
+// Chairman Gmail-filter contract (2026-07-03): heartbeat subjects ALWAYS start with the exact
+// token "[ALL GOOD - ADAM]"; decision/action emails ALWAYS start with "[ACTION NEEDED - ADAM]"
+// (lib/chairman/decision-layman.mjs). His Gmail alerting keys on these literal strings —
+// never change either token without chairman sign-off.
+const subject = `[ALL GOOD - ADAM] heartbeat ${when} ET`;
 const text = `${body.trim()}\n\nas of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor`;
 
 const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');


### PR DESCRIPTION
## Quick-Fix: QF-20260703-524

**Type:** bug
**Severity:** medium

### Issue Description
Same class as QF-20260703-374 (registry, now merged): scripts/adam-heartbeat-email.mjs carries an UNCOMMITTED shared-root edit (Adam live edit 2026-07-03) implementing the chairman's Gmail-filter contract — heartbeat subjects start with the literal token '[ALL GOOD - ADAM]' (was 'All good - Adam heartbeat'), plus a code comment stating the paired '[ACTION NEEDED - ADAM]' token (lib/chairman/decision-layman.mjs, already upstream) and warning that the chairman's Gmail alerting keys on these LITERAL strings — never change either without his sign-off. A future resync/reset silently reverts his filters to missing heartbeats. FIX: commit the subject-token block upstream via QF branch/PR (diff = the subject line + comment block only; verify no other local noise rides along), confirm shared-root copy converges post-merge. The chairman has already built (or is building) Gmail filters on these exact strings — treat the tokens as a frozen contract.


### Expected Behavior
The [ALL GOOD - ADAM] token lives on origin/main; resyncs cannot revert the chairman's filter contract

### Actual Behavior
Token exists only as an uncommitted working-tree edit; any resync silently breaks his Gmail alerting

### Changes
- **Files Changed:** 1
  - scripts/adam-heartbeat-email.mjs
- **LOC:** 9 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol