### PR TITLE
fix(QF-20260703-672): worker-checkin falls back to payload.body when top-level body is null

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -305,7 +305,10 @@ async function surfaceCoordinatorMessages(sb, sessionId, { role = null } = {}) {
     // so isDirective is true → it is NEVER auto-acked here (waits for the per-role ack via
     // scripts/ack-chairman-directive.cjs). Surface a first-class flag so the checkin JSON marks it.
     const isChairmanDirective = kind === 'chairman_directive';
-    out.push({ id: m.id, message_type: m.message_type, kind, chairman_directive: isChairmanDirective, subject: m.subject || null, body: m.body || null, created_at: m.created_at });
+    // QF-20260703-672: coordinator_reply/work_assignment writers put content in payload.body only —
+    // the top-level body column stays null for those kinds. Fall back to payload so /checkin's JSON
+    // (the worker's actual decision input) carries the real text instead of forcing a side DB query.
+    out.push({ id: m.id, message_type: m.message_type, kind, chairman_directive: isChairmanDirective, subject: m.subject || p.subject || null, body: m.body || p.body || null, created_at: m.created_at });
     try {
       if (!m.read_at) {
         // first authoritative delivery — mark DELIVERED, leave unacked so it re-surfaces once

--- a/tests/unit/worker-inbox-push-delivery.test.js
+++ b/tests/unit/worker-inbox-push-delivery.test.js
@@ -59,7 +59,7 @@ function recordingSb({ setIdentityRow = null, sessionMeta = { role: 'worker' }, 
         update(patch) { return { eq: (col, val) => { updates.push({ id: col === 'id' ? val : _eqId, patch }); return Promise.resolve({ error: null }); } }; },
       };
       // registerRollCall uses .insert().select().single()
-      api.insert = (row) => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 'rc-1' }, error: null }) }) });
+      api.insert = (_row) => ({ select: () => ({ single: () => Promise.resolve({ data: { id: 'rc-1' }, error: null }) }) });
       return api;
     },
   };
@@ -155,6 +155,40 @@ describe('surfaceCoordinatorMessages — non-draining bounded delivery (FR-1/FR-
     ws.getMessagesForSession = async () => { throw new Error('db down'); };
     try {
       expect(await surfaceCoordinatorMessages(sb, 'sess-1', {})).toEqual([]);
+    } finally { ws.getMessagesForSession = orig; }
+  });
+
+  it('QF-20260703-672: a coordinator_reply row with body:null falls back to payload.body (the real content)', async () => {
+    const sb = recordingSb();
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [
+      {
+        id: 'cr1', message_type: 'COACHING', body: null,
+        payload: { kind: 'coordinator_reply', body: 'the actual reply text lives here' },
+        created_at: '2026-07-03T00:00:00Z', read_at: null,
+      },
+    ];
+    try {
+      const out = await surfaceCoordinatorMessages(sb, 'sess-1', { role: 'worker' });
+      expect(out).toHaveLength(1);
+      expect(out[0].body).toBe('the actual reply text lives here'); // NOT null
+    } finally { ws.getMessagesForSession = orig; }
+  });
+
+  it('a populated top-level body still wins over payload.body (no regression on the common case)', async () => {
+    const sb = recordingSb();
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [
+      {
+        id: 'c1', message_type: 'COACHING', subject: 'top subject', body: 'top-level body',
+        payload: { subject: 'payload subject', body: 'payload body' },
+        created_at: '2026-07-03T00:00:00Z', read_at: null,
+      },
+    ];
+    try {
+      const out = await surfaceCoordinatorMessages(sb, 'sess-1', { role: 'worker' });
+      expect(out[0].subject).toBe('top subject');
+      expect(out[0].body).toBe('top-level body');
     } finally { ws.getMessagesForSession = orig; }
   });
 });


### PR DESCRIPTION
## Summary
- `surfaceCoordinatorMessages()` in `scripts/worker-checkin.cjs` was surfacing `body: null` / `subject: null` for `coordinator_reply` and `work_assignment` messages, because those writers only populate `payload.body`/`payload.subject`, never the top-level `body`/`subject` columns.
- Workers receiving these messages via `/checkin` had to manually run a side Supabase query against `payload.body` to read their own directive -- this is the exact friction previously signaled (id 2ba94f47) and re-raised in FLEET-RETRO feedback b5a6650f.
- Fix: fall back to `payload.subject`/`payload.body` when the top-level column is empty. A populated top-level `body`/`subject` still wins (no behavior change for the common case).

## Test plan
- [x] Added regression test: a `coordinator_reply` row with `body:null` now surfaces `payload.body`'s real text
- [x] Added regression test: a populated top-level `body`/`subject` still wins over `payload.body`/`payload.subject`
- [x] `tests/unit/worker-inbox-push-delivery.test.js` + `tests/unit/worker-checkin-assignment-surfacing.test.js`: 38/38 pass
- [x] Full worker-checkin regression sweep (13 files, 193 tests): all pass
- [x] `node --check scripts/worker-checkin.cjs`: syntax OK
- [x] `eslint` on both changed files: clean (also fixed one pre-existing unrelated unused-arg error in the test file, exposed while linting the touched file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)