### PR TITLE
fix(SD-LEO-FIX-DIFF-SCOPE-LAYER-001): diff-scope Layer 4.3 Migration File Validation CI job

### DIFF
--- a/.github/workflows/retrospective-quality-gates.yml
+++ b/.github/workflows/retrospective-quality-gates.yml
@@ -210,16 +210,39 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # SD-LEO-FIX-DIFF-SCOPE-LAYER-001: diff-scope to files changed in THIS PR/push,
+      # not a repo-wide sweep — see scripts/lint/compute-changed-retro-migrations.mjs
+      # for the fail-safe fallback (unresolvable diff base -> full repo-wide sweep,
+      # never a silent skip).
+      - name: Determine changed retrospective migration files (diff-scoped)
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$GITHUB_BASE_REF" --depth=1 || true
+          fi
+          node scripts/lint/compute-changed-retro-migrations.mjs > /tmp/changed-retro-migrations.txt
+          echo "--- diff-scoping decision (see stderr above for reason) ---"
+          cat /tmp/changed-retro-migrations.txt
 
       - name: Validate retrospective migration files
         run: |
-          echo "🔍 Validating retrospective migration SQL files..."
+          echo "🔍 Validating retrospective migration SQL files (diff-scoped)..."
 
-          # Find all retrospective-related migrations
-          migrations=$(find database/migrations -name "*retrospective*.sql" 2>/dev/null || true)
+          migrations=$(cat /tmp/changed-retro-migrations.txt)
 
           if [ -z "$migrations" ]; then
-            echo "⚠️  No retrospective migrations found (this may be expected)"
+            echo "✅ No retrospective migration files changed in this diff — nothing to validate (pre-existing files grandfathered)."
             exit 0
           fi
 

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,7 @@
 {
-  "sdKey": "QF-20260703-369",
-  "workType": "QF",
-  "workKey": "QF-20260703-369",
-  "expectedBranch": "qf/QF-20260703-369",
-  "createdAt": "2026-07-03T11:17:37.986Z",
-  "hostname": "Legion-Laptop",
-  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
+  "sdKey": "SD-LEO-FIX-DIFF-SCOPE-LAYER-001",
+  "expectedBranch": "feat/SD-LEO-FIX-DIFF-SCOPE-LAYER-001",
+  "createdAt": "2026-07-03T10:52:54.533Z",
+  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "baseRef": "origin/main"
 }

--- a/scripts/hooks/check-retro-migrations-wrapped.cjs
+++ b/scripts/hooks/check-retro-migrations-wrapped.cjs
@@ -81,7 +81,7 @@ if (violations.length > 0) {
   console.error('');
   console.error('   The Layer 4.3 retrospective-quality-gates CI workflow grep contract requires');
   console.error('   line-leading ^BEGIN; and ^COMMIT; in every database/migrations/*retrospective*.sql file.');
-  console.error('   See: .github/workflows/retrospective-quality-gates.yml lines 232,237');
+  console.error('   See: .github/workflows/retrospective-quality-gates.yml lines 255,260');
   console.error('');
   for (const { file, missing } of violations) {
     console.error('   File: ' + file);

--- a/scripts/lint/compute-changed-retro-migrations.mjs
+++ b/scripts/lint/compute-changed-retro-migrations.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Diff-scoping decision for the Layer 4.3 "Migration File Validation" CI job
+ * (.github/workflows/retrospective-quality-gates.yml). SD-LEO-FIX-DIFF-SCOPE-LAYER-001.
+ *
+ * Before this, the job ran `find database/migrations -name "*retrospective*.sql"` —
+ * repo-wide and diff-independent — so it false-flagged on any pre-existing migration
+ * missing BEGIN;/COMMIT; (e.g. 20260528_retrospective_type_default_null.sql, merged
+ * months ago), failing EVERY future PR regardless of what it actually touched.
+ *
+ * This module's pure functions decide WHICH files to check; the git/find calls that
+ * produce their inputs happen in main() below and in the workflow YAML. Modeled on
+ * scripts/lint/schema-lint-exit.mjs (pure decision, tested; execSync glue, untested).
+ *
+ * Fail-safe design: when the diff base can't be resolved (fetch failure, or a push
+ * event's `before` SHA is the all-zeros sentinel for a new branch/force-push), this
+ * falls back to the full repo-wide file set — i.e. the ORIGINAL pre-fix behavior —
+ * rather than silently skipping validation. This is a hard-blocking correctness gate,
+ * not an advisory lint, so "can't tell what changed" must never mean "check nothing."
+ */
+import { execSync } from 'node:child_process';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+const ALL_ZEROS_SHA = '0000000000000000000000000000000000000000';
+const RETRO_MIGRATION_PATHSPEC = 'database/migrations/*retrospective*.sql';
+
+/**
+ * Resolve what to diff against for a given GitHub Actions event. Pure — takes
+ * only the event fields, makes no git calls.
+ * @param {{eventName: string, baseRef?: string, before?: string}} params
+ * @returns {{range: string[]|null, resolvable: boolean, reason: string}}
+ */
+export function resolveDiffBase({ eventName, baseRef, before }) {
+  if (eventName === 'pull_request') {
+    if (!baseRef) {
+      return { range: null, resolvable: false, reason: 'pull_request event missing base_ref' };
+    }
+    return { range: [`origin/${baseRef}...HEAD`], resolvable: true, reason: `diffing against origin/${baseRef}` };
+  }
+  if (eventName === 'push') {
+    if (!before || before === ALL_ZEROS_SHA) {
+      return {
+        range: null,
+        resolvable: false,
+        reason: 'push event.before is empty/all-zeros (new branch or force-push) — no prior state to diff against',
+      };
+    }
+    return { range: [before, 'HEAD'], resolvable: true, reason: `diffing against pre-push SHA ${before}` };
+  }
+  return { range: null, resolvable: false, reason: `unrecognized event "${eventName}"` };
+}
+
+/**
+ * Decide the final file set to validate. Pure — takes already-computed file lists.
+ * @param {{diffResolvable: boolean, changedFiles?: string[], allRetroMigrationFiles?: string[]}} params
+ * @returns {{filesToCheck: string[], scoped: boolean, reason: string}}
+ */
+export function computeFilesToCheck({ diffResolvable, changedFiles = [], allRetroMigrationFiles = [] }) {
+  if (!diffResolvable) {
+    return {
+      filesToCheck: allRetroMigrationFiles,
+      scoped: false,
+      reason: 'diff base unresolvable — falling back to the full repo-wide file set (fail-safe; matches pre-fix behavior)',
+    };
+  }
+  if (changedFiles.length === 0) {
+    return {
+      filesToCheck: [],
+      scoped: true,
+      reason: 'no retrospective migration files changed in this diff — nothing to validate (pre-existing files grandfathered)',
+    };
+  }
+  return {
+    filesToCheck: changedFiles,
+    scoped: true,
+    reason: `${changedFiles.length} retrospective migration file(s) changed in this diff`,
+  };
+}
+
+function gitDiffChangedFiles(range) {
+  const out = execSync(`git diff --name-only --diff-filter=ACMR ${range.join(' ')} -- '${RETRO_MIGRATION_PATHSPEC}'`, {
+    encoding: 'utf8',
+  });
+  return out.split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+function findAllRetroMigrations() {
+  const out = execSync('find database/migrations -name "*retrospective*.sql"', { encoding: 'utf8' });
+  return out.split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+function main() {
+  const eventName = process.env.GITHUB_EVENT_NAME || '';
+  const baseRef = process.env.GITHUB_BASE_REF || '';
+  const before = process.env.GITHUB_EVENT_BEFORE || '';
+
+  const base = resolveDiffBase({ eventName, baseRef, before });
+
+  let result;
+  if (base.resolvable) {
+    let changedFiles;
+    try {
+      changedFiles = gitDiffChangedFiles(base.range);
+    } catch (err) {
+      // git diff itself failed (e.g. base ref not actually fetched) — fail-safe to full sweep.
+      result = computeFilesToCheck({ diffResolvable: false, allRetroMigrationFiles: findAllRetroMigrations() });
+      console.error(`[compute-changed-retro-migrations] git diff failed (${err.message.split('\n')[0]}); ${result.reason}`);
+      process.stdout.write(result.filesToCheck.join('\n') + (result.filesToCheck.length ? '\n' : ''));
+      return;
+    }
+    result = computeFilesToCheck({ diffResolvable: true, changedFiles });
+  } else {
+    result = computeFilesToCheck({ diffResolvable: false, allRetroMigrationFiles: findAllRetroMigrations() });
+  }
+
+  console.error(`[compute-changed-retro-migrations] ${base.reason}; ${result.reason}`);
+  process.stdout.write(result.filesToCheck.join('\n') + (result.filesToCheck.length ? '\n' : ''));
+}
+
+if (isMainModule(import.meta.url)) {
+  main();
+}

--- a/scripts/lint/compute-changed-retro-migrations.mjs
+++ b/scripts/lint/compute-changed-retro-migrations.mjs
@@ -117,6 +117,8 @@ function main() {
   process.stdout.write(result.filesToCheck.join('\n') + (result.filesToCheck.length ? '\n' : ''));
 }
 
+export { main };
+
 if (isMainModule(import.meta.url)) {
   main();
 }

--- a/tests/unit/compute-changed-retro-migrations.test.js
+++ b/tests/unit/compute-changed-retro-migrations.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-FIX-DIFF-SCOPE-LAYER-001
+ * Pins the diff-scoping decision for the Layer 4.3 "Migration File Validation" CI job.
+ * Before this fix, the job ran `find database/migrations -name "*retrospective*.sql"`
+ * repo-wide and diff-independent, false-flagging on any pre-existing migration missing
+ * BEGIN;/COMMIT; (e.g. 20260528_retrospective_type_default_null.sql) on EVERY PR/push.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveDiffBase, computeFilesToCheck } from '../../scripts/lint/compute-changed-retro-migrations.mjs';
+
+describe('resolveDiffBase', () => {
+  it('TS-1: pull_request with a base_ref resolves against origin/<base>...HEAD', () => {
+    const r = resolveDiffBase({ eventName: 'pull_request', baseRef: 'main' });
+    expect(r).toEqual({ range: ['origin/main...HEAD'], resolvable: true, reason: 'diffing against origin/main' });
+  });
+
+  it('TS-2: pull_request missing base_ref is unresolvable', () => {
+    const r = resolveDiffBase({ eventName: 'pull_request', baseRef: '' });
+    expect(r.resolvable).toBe(false);
+  });
+
+  it('TS-3: push with a real before SHA resolves against [before, HEAD]', () => {
+    const r = resolveDiffBase({ eventName: 'push', before: 'abc1234' });
+    expect(r).toEqual({ range: ['abc1234', 'HEAD'], resolvable: true, reason: 'diffing against pre-push SHA abc1234' });
+  });
+
+  it('TS-4: push with the all-zeros sentinel before (new branch/force-push) is unresolvable', () => {
+    const r = resolveDiffBase({ eventName: 'push', before: '0000000000000000000000000000000000000000' });
+    expect(r.resolvable).toBe(false);
+  });
+
+  it('push with a missing/empty before is unresolvable', () => {
+    const r = resolveDiffBase({ eventName: 'push', before: '' });
+    expect(r.resolvable).toBe(false);
+  });
+
+  it('an unrecognized event is unresolvable', () => {
+    const r = resolveDiffBase({ eventName: 'workflow_dispatch' });
+    expect(r.resolvable).toBe(false);
+  });
+});
+
+describe('computeFilesToCheck', () => {
+  it('TS-5: diffResolvable=false falls back to the full repo-wide file set (fail-safe)', () => {
+    const r = computeFilesToCheck({
+      diffResolvable: false,
+      allRetroMigrationFiles: ['database/migrations/20260528_retrospective_type_default_null.sql', 'database/migrations/20251015_add_retrospective_quality_score_constraint.sql'],
+    });
+    expect(r.filesToCheck).toEqual([
+      'database/migrations/20260528_retrospective_type_default_null.sql',
+      'database/migrations/20251015_add_retrospective_quality_score_constraint.sql',
+    ]);
+    expect(r.scoped).toBe(false);
+  });
+
+  it('TS-6: diffResolvable=true with zero changed files is a clean skip (grandfathers pre-existing files)', () => {
+    const r = computeFilesToCheck({ diffResolvable: true, changedFiles: [] });
+    expect(r.filesToCheck).toEqual([]);
+    expect(r.scoped).toBe(true);
+    expect(r.reason).toMatch(/nothing to validate/);
+  });
+
+  it('TS-7: diffResolvable=true with N changed files checks exactly those N (not the whole repo)', () => {
+    const r = computeFilesToCheck({
+      diffResolvable: true,
+      changedFiles: ['database/migrations/20260703_new_retrospective_thing.sql'],
+      allRetroMigrationFiles: ['database/migrations/20260528_retrospective_type_default_null.sql', 'database/migrations/20260703_new_retrospective_thing.sql'],
+    });
+    expect(r.filesToCheck).toEqual(['database/migrations/20260703_new_retrospective_thing.sql']);
+    expect(r.scoped).toBe(true);
+  });
+
+  it('a grandfathered pre-existing file (not in the diff) is never re-checked even though it exists repo-wide', () => {
+    const r = computeFilesToCheck({
+      diffResolvable: true,
+      changedFiles: ['database/migrations/20260703_unrelated_change.sql'],
+      allRetroMigrationFiles: ['database/migrations/20260528_retrospective_type_default_null.sql', 'database/migrations/20260703_unrelated_change.sql'],
+    });
+    expect(r.filesToCheck).not.toContain('database/migrations/20260528_retrospective_type_default_null.sql');
+  });
+
+  it('defaults changedFiles/allRetroMigrationFiles to empty arrays when omitted', () => {
+    expect(computeFilesToCheck({ diffResolvable: true }).filesToCheck).toEqual([]);
+    expect(computeFilesToCheck({ diffResolvable: false }).filesToCheck).toEqual([]);
+  });
+});

--- a/tests/unit/compute-changed-retro-migrations.test.js
+++ b/tests/unit/compute-changed-retro-migrations.test.js
@@ -5,7 +5,7 @@
  * repo-wide and diff-independent, false-flagging on any pre-existing migration missing
  * BEGIN;/COMMIT; (e.g. 20260528_retrospective_type_default_null.sql) on EVERY PR/push.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveDiffBase, computeFilesToCheck } from '../../scripts/lint/compute-changed-retro-migrations.mjs';
 
 describe('resolveDiffBase', () => {
@@ -82,5 +82,82 @@ describe('computeFilesToCheck', () => {
   it('defaults changedFiles/allRetroMigrationFiles to empty arrays when omitted', () => {
     expect(computeFilesToCheck({ diffResolvable: true }).filesToCheck).toEqual([]);
     expect(computeFilesToCheck({ diffResolvable: false }).filesToCheck).toEqual([]);
+  });
+});
+
+describe('main() wiring (mocked execSync — pins the git/find glue, not just the pure decisions)', () => {
+  const ORIGINAL_ENV = { ...process.env };
+  let execSyncMock;
+  let stdoutSpy;
+  let stderrSpy;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    execSyncMock = vi.fn();
+    vi.doMock('node:child_process', () => ({ execSync: execSyncMock }));
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.doUnmock('node:child_process');
+    vi.restoreAllMocks();
+  });
+
+  it('pull_request with changed files: calls git diff once, prints the file list', async () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_BASE_REF = 'main';
+    delete process.env.GITHUB_EVENT_BEFORE;
+    execSyncMock.mockReturnValue('database/migrations/20260703_new_retrospective.sql\n');
+
+    const { main } = await import('../../scripts/lint/compute-changed-retro-migrations.mjs');
+    main();
+
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    expect(execSyncMock.mock.calls[0][0]).toContain('git diff --name-only --diff-filter=ACMR origin/main...HEAD');
+    expect(stdoutSpy).toHaveBeenCalledWith('database/migrations/20260703_new_retrospective.sql\n');
+  });
+
+  it('push with all-zeros before: falls back to find (no git diff call)', async () => {
+    process.env.GITHUB_EVENT_NAME = 'push';
+    process.env.GITHUB_EVENT_BEFORE = '0000000000000000000000000000000000000000';
+    delete process.env.GITHUB_BASE_REF;
+    execSyncMock.mockReturnValue('database/migrations/20260528_retrospective_type_default_null.sql\n');
+
+    const { main } = await import('../../scripts/lint/compute-changed-retro-migrations.mjs');
+    main();
+
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    expect(execSyncMock.mock.calls[0][0]).toContain('find database/migrations -name "*retrospective*.sql"');
+    expect(stdoutSpy).toHaveBeenCalledWith('database/migrations/20260528_retrospective_type_default_null.sql\n');
+  });
+
+  it('git diff throws (e.g. base not actually fetched): fails safe to the full find sweep, not a crash', async () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_BASE_REF = 'main';
+    delete process.env.GITHUB_EVENT_BEFORE;
+    execSyncMock
+      .mockImplementationOnce(() => { throw new Error('fatal: bad revision'); })
+      .mockReturnValueOnce('database/migrations/20260528_retrospective_type_default_null.sql\n');
+
+    const { main } = await import('../../scripts/lint/compute-changed-retro-migrations.mjs');
+    expect(() => main()).not.toThrow();
+
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+    expect(execSyncMock.mock.calls[1][0]).toContain('find database/migrations');
+    expect(stdoutSpy).toHaveBeenCalledWith('database/migrations/20260528_retrospective_type_default_null.sql\n');
+  });
+
+  it('pull_request with zero changed files: prints nothing to stdout (clean skip)', async () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_BASE_REF = 'main';
+    delete process.env.GITHUB_EVENT_BEFORE;
+    execSyncMock.mockReturnValue('');
+
+    const { main } = await import('../../scripts/lint/compute-changed-retro-migrations.mjs');
+    main();
+
+    expect(stdoutSpy).toHaveBeenCalledWith('');
   });
 });


### PR DESCRIPTION
## Summary
- The Layer 4.3 "Migration File Validation" CI job ran `find database/migrations -name "*retrospective*.sql"` repo-wide and diff-independent, so it false-flagged EVERY future PR/push on `database/migrations/20260528_retrospective_type_default_null.sql` (a months-old already-merged migration missing BEGIN;/COMMIT;).
- Adds `scripts/lint/compute-changed-retro-migrations.mjs` (pure, unit-tested `resolveDiffBase`/`computeFilesToCheck` decision functions) mirroring the existing `schema-reference-lint.yml` diff-scoping pattern for `pull_request`, and designing the `push`-trigger case net-new since no repo precedent existed.
- Fail-safe: an unresolvable diff base (fetch failure, `push` with the all-zeros `before` SHA on a new branch/force-push) falls back to the original full repo-wide sweep rather than silently skipping validation, since this is a hard-blocking correctness gate, not an advisory lint.
- Updates the workflow to `fetch-depth:0` + `setup-node` + call the new script instead of the repo-wide `find`; the BEGIN/COMMIT/verification/rollback grep checks themselves are unchanged.
- Fixes a stale CI line-number reference in `check-retro-migrations-wrapped.cjs` (232,237 -> 255,260).

## Test plan
- [x] `npx vitest run tests/unit/compute-changed-retro-migrations.test.js` — 15/15 passing, 97.43% statement coverage
- [x] Live reproduction: `grep -n "BEGIN;\|COMMIT;" database/migrations/20260528_retrospective_type_default_null.sql` — confirmed 0 matches (the false-flag condition is real) and confirmed the new script correctly grandfathers it when not in the diff
- [x] Live smoke test of all 3 real event paths: `pull_request` vs `origin/main` (empty, correct), `push` with a real `before` SHA (empty, correct), `push` with all-zeros `before` (falls back to full sweep, correct)
- [x] `node scripts/check-workflow-yaml.mjs .github/workflows/retrospective-quality-gates.yml` — YAML parses OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)