### PR TITLE
fix(QF-20260703-563): register gauge-runner in coordinator STANDARD_LOOPS

### DIFF
--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -165,6 +165,15 @@ export const STANDARD_LOOPS = [
   // self-review; coordinator itself requested this as sourceable candidate #1 (advisory 444cdd65 ref).
   { key: 'roles-review', label: 'Coordinator roles/duties self-review (twice-daily, durable)', script: 'coordinator-startup-check.mjs', cron: '41 6,18 * * *',
     prompt: 'Re-read the coordinator role contract (leo_protocol_sections id=605 + docs/protocol/fleet-coordinator-and-worker-behavior.md, rendered by `node scripts/coordinator-startup-check.mjs`) and self-audit duty execution against RESPONSIBILITIES: for each duty, confirm evidence of recent execution and REMEDIATE any drift found (e.g. idle workers with claimable work, a stale sourcing gap) rather than observe-only.' },
+  // QF-20260703-563: the gauge-runner (SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001, the
+  // invariant-gauges execution surface) had NO scheduled venue anywhere — 29h stale until an
+  // interim session-only cron was hand-armed. Session crons die with sessions, the same
+  // fragility class already fixed for Adam's belt-countdown and this coordinator's own
+  // roles-review duty (QF-433/QF-272). Class 6b for the ledger: the instrument that watches
+  // for unwired machinery was itself unwired. Hourly cadence — cheap, and the gauges'
+  // detector functions are internally due-gated/idempotent, so an extra run is a no-op.
+  { key: 'gauge-runner', label: 'Invariant-gauges execution surface (hourly, durable)', script: 'gauge-runner.mjs', cron: '0 * * * *',
+    prompt: 'node scripts/gauge-runner.mjs --json' },
 ];
 
 // Parse the armed-cron basenames the agent passes from its CronList output.

--- a/tests/unit/coordinator-startup-check.test.mjs
+++ b/tests/unit/coordinator-startup-check.test.mjs
@@ -35,9 +35,11 @@ test('STANDARD_LOOPS has the expected standard loops with the expected keys', ()
   // which were already live in STANDARD_LOOPS but never reflected here) — corrected to the
   // actual 20-entry array while adding 'singleton-relaunch'.
   // QF-20260702-272 added the durable twice-daily 'roles-review' self-audit (after 'retention').
-  assert.equal(STANDARD_LOOPS.length, 21);
+  // QF-20260703-563 added the durable hourly 'gauge-runner' loop (after 'roles-review') — the
+  // invariant-gauges execution surface had no scheduled venue anywhere and went 29h stale.
+  assert.equal(STANDARD_LOOPS.length, 22);
   const keys = STANDARD_LOOPS.map((l) => l.key);
-  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention', 'roles-review']);
+  assert.deepEqual(keys, ['sweep', 'dashboard', 'identity', 'inbox', 'audit', 'charter-audit', 'flag-review', 'self-review', 'hourly-review', 'capacity-forecast', 'backlog-rank', 'unranked-gauge', 'singleton-relaunch', 'relay-drain', 'relay-drop-gauge', 'fleet-retro', 'row-growth', 'review-rotation', 'scripts-reachability', 'retention', 'roles-review', 'gauge-runner']);
 });
 
 test('every loop carries a non-empty label, script, cron, and CronCreate prompt', () => {
@@ -105,7 +107,7 @@ test('loopStatus marks armed|MISSING|unverified, distinguishing inbox vs dashboa
 test('renderLoops emits CronCreate spec for missing/unverified loops', () => {
   const none = parseArmedSet([], {});
   const out = renderLoops(none);
-  assert.match(out, /STANDARD CRON LOOPS \(21\)/);
+  assert.match(out, /STANDARD CRON LOOPS \(22\)/);
   // All prompts emitted as CronCreate specs when nothing is armed
   for (const loop of STANDARD_LOOPS) {
     assert.ok(out.includes(loop.prompt), `expected CronCreate prompt for ${loop.key}`);
@@ -123,7 +125,7 @@ test('renderLoops reports all-armed cleanly when every loop is armed', () => {
   ];
   const armed = parseArmedSet(['--armed', armedTokens.join(',')], {});
   const out = renderLoops(armed);
-  assert.match(out, /All 21 standard loops armed/);
+  assert.match(out, /All 22 standard loops armed/);
 });
 
 test('buildReport combines responsibilities + loop sections', () => {


### PR DESCRIPTION
## Summary
- The invariant-gauges execution surface (`scripts/gauge-runner.mjs`) had no scheduled venue anywhere — 29h stale until an interim session-only cron was hand-armed. Session crons die with sessions, the same fragility class already fixed for Adam's belt-countdown and the coordinator's own roles-review duty (QF-433/QF-272).
- Registers `gauge-runner` in `STANDARD_LOOPS` at hourly cadence, so every coordinator boot re-arms it idempotently (`node scripts/gauge-runner.mjs --json`).
- Updates the 3 hardcoded count/keys assertions in the test file (21 → 22 loops).

## Test plan
- [x] `node --test tests/unit/coordinator-startup-check.test.mjs` — 12/12 pass (vitest excludes `.worktrees/**`, so run via node's built-in test runner, matching how these tests are already written — `node:test`/`node:assert`)
- [x] Confirmed the new entry follows the exact established pattern/style of the other durable loop entries
- [x] Confirmed the gauge-runner script's own `--json` CLI flag exists and matches the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)