### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-001): VALIDATION sub-agent checks PRD existence by sd_id, not directive_id

### DIFF
--- a/lib/sub-agents/validation.js
+++ b/lib/sub-agents/validation.js
@@ -356,11 +356,17 @@ async function querySDMetadata(sdId) {
 /**
  * Step 2: Check for Existing PRD
  */
-async function checkExistingPRD(sdId) {
-  const { data: prd, error } = await supabase
+export async function checkExistingPRD(sdId, client = supabase) {
+  // SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-001: sdId here is the SD's UUID (executor
+  // passes sdUUID, matching how Step 1's querySDMetadata resolves it against
+  // strategic_directives_v2.id). product_requirements_v2.directive_id intentionally
+  // stores the SD KEY STRING (see scripts/prd/index.js), not the UUID -- sd_id is
+  // the UUID-bearing column. Filtering on directive_id here always missed, producing
+  // a false "no PRD" recommendation for every SD that actually has one.
+  const { data: prd, error } = await client
     .from('product_requirements_v2')
     .select('id, title, status, functional_requirements, non_functional_requirements, acceptance_criteria')
-    .eq('directive_id', sdId)
+    .eq('sd_id', sdId)
     .single();
 
   if (error || !prd) {

--- a/tests/unit/sub-agents/validation-check-existing-prd.test.js
+++ b/tests/unit/sub-agents/validation-check-existing-prd.test.js
@@ -1,0 +1,82 @@
+/**
+ * SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-001 — checkExistingPRD() UUID-column fix.
+ *
+ * ROOT CAUSE: checkExistingPRD(sdId) queried product_requirements_v2 by
+ * `.eq('directive_id', sdId)`, but sdId at this call site is the SD's UUID
+ * (lib/sub-agent-executor/executor.js passes sdUUID) while directive_id
+ * intentionally stores the SD KEY STRING (scripts/prd/index.js). The UUID-
+ * bearing column is sd_id. The mismatch produced a false "no PRD" result
+ * (and the recurring "PLAN agent should create PRD before EXEC phase
+ * begins" recommendation) for essentially every SD that actually has one.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { checkExistingPRD } from '../../../lib/sub-agents/validation.js';
+
+function fakeSupabaseFor(expectedColumn, expectedValue, row) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      calls.push({ table });
+      return {
+        select: (cols) => {
+          calls[calls.length - 1].select = cols;
+          return {
+            eq: (col, value) => {
+              calls[calls.length - 1].eq = { col, value };
+              return {
+                single: async () => {
+                  if (col === expectedColumn && value === expectedValue) {
+                    return { data: row, error: null };
+                  }
+                  return { data: null, error: { message: 'Not found' } };
+                }
+              };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+describe('checkExistingPRD queries by sd_id (UUID), not directive_id (key string)', () => {
+  const sdUUID = 'b89a7682-b171-42b5-992c-a47a43acec6f';
+  const prdRow = {
+    id: 'PRD-SD-LEO-INFRA-LLM-FACTORY-TIER-LADDER-001',
+    title: 'Product Requirements for SD-LEO-INFRA-LLM-FACTORY-TIER-LADDER-001',
+    status: 'in_progress',
+    functional_requirements: [{ id: 'FR-1' }],
+    non_functional_requirements: [],
+    acceptance_criteria: ['a', 'b']
+  };
+
+  it('finds the PRD when the fixture has sd_id = the SD UUID (real-world shape)', async () => {
+    const client = fakeSupabaseFor('sd_id', sdUUID, prdRow);
+
+    const result = await checkExistingPRD(sdUUID, client);
+
+    expect(result.found).toBe(true);
+    expect(result.prd.title).toBe(prdRow.title);
+    expect(client.calls[0].eq).toEqual({ col: 'sd_id', value: sdUUID });
+  });
+
+  it('regression guard: querying by directive_id (the pre-fix column) would NOT find this PRD', async () => {
+    // Simulates the exact bug: directive_id holds the SD KEY STRING, not the UUID,
+    // so a client that only matches on directive_id never returns this row for a UUID.
+    const client = fakeSupabaseFor('directive_id', 'SD-LEO-INFRA-LLM-FACTORY-TIER-LADDER-001', prdRow);
+
+    const result = await checkExistingPRD(sdUUID, client);
+
+    expect(result.found).toBe(false);
+  });
+
+  it('returns found:false without throwing when no PRD exists for this SD', async () => {
+    const client = fakeSupabaseFor('sd_id', 'some-other-uuid', prdRow);
+
+    const result = await checkExistingPRD(sdUUID, client);
+
+    expect(result.found).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a confirmed root-cause bug in `lib/sub-agents/validation.js`'s `checkExistingPRD()`: it queried `product_requirements_v2` by `.eq('directive_id', sdId)`, but `sdId` here is always the SD's UUID (the executor passes `sdUUID`) while `directive_id` intentionally stores the SD **key string** (per `scripts/prd/index.js`'s documented convention). The UUID-bearing column is `sd_id`.
- The mismatch produced a false "no PRD found" result — and the recurring `"PLAN agent should create PRD before EXEC phase begins"` recommendation — for essentially every SD that actually has a PRD. Tracked 3x as issue pattern `SAL-VALIDATION-REC`, auto-escalated into this SD via `/learn`.
- `checkExistingPRD` is now exported with an injectable `client` param (defaults to the existing module-level client) for unit testability; zero behavior change for the sole existing caller.
- Cross-checked against two other call sites (`HandoffOrchestrator.js`, `PlanToExecVerifier.js`) that already correctly query `product_requirements_v2` by `sd_id` — confirming this is the established correct column, not a novel fix.

## Test plan
- [x] `npx vitest run tests/unit/sub-agents/validation-check-existing-prd.test.js` — 3/3 pass, including an explicit regression guard proving the pre-fix column would have missed
- [x] `npx vitest run tests/unit/sub-agents/` — 139/139 pass, no regressions
- [x] Dogfooded the fix: re-ran VALIDATION against its own SD (SD-LEARN-FIX-ADDRESS-SAL-VALIDATION-001) on-branch — Step 2 correctly reports "PRD exists"
- [x] Live-verified against SD-LEO-INFRA-LLM-FACTORY-TIER-LADDER-001 — false recommendation no longer appears
- [x] TESTING/VALIDATION/REGRESSION sub-agent evidence captured (PASS, 95-100% confidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)