### PR TITLE
fix(SD-LEO-FIX-DIFF-SCOPE-LAYER-001): wire-check follow-up for compute-changed-retro-migrations.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -587,6 +587,7 @@
     "dr:dump": "node scripts/dr/governance-dump.mjs",
     "schema:lint": "node scripts/lint/schema-reference-lint.mjs --diff",
     "schema:lint:all": "node scripts/lint/schema-reference-lint.mjs --all",
+    "retro-migrations:diff-scope": "node scripts/lint/compute-changed-retro-migrations.mjs",
     "schema:snapshot:lint": "node scripts/lint/schema-reference-snapshot.mjs",
     "canary:probe": "node scripts/canary/run-canary-probe.mjs",
     "test:quarantine": "node scripts/unit-tier-quarantine.mjs report .claude-unit-run.log",


### PR DESCRIPTION
## Summary
- Follow-up to #5433 (already merged): LEAD-FINAL-APPROVAL's WIRE_CHECK_GATE correctly flagged `scripts/lint/compute-changed-retro-migrations.mjs` as unreachable from any static import graph, since it's invoked only from `.github/workflows/retrospective-quality-gates.yml`'s `run:` shell block, not a JS import.
- Adds a `package.json` scripts entry (`retro-migrations:diff-scope`) exposing it as an entry point, following the exact precedent already used for `scripts/lint/schema-reference-lint.mjs` (`schema:lint` / `schema:lint:all`).

## Test plan
- [x] WIRE_CHECK_GATE will re-scan on the next LEAD-FINAL-APPROVAL attempt for SD-LEO-FIX-DIFF-SCOPE-LAYER-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)