### PR TITLE
fix(QF-20260703-885): writer-side lint requires WORK_ASSIGNMENT type for payload.kind=work_assignment

### DIFF
--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -319,6 +319,21 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
     row.payload = { ...payload, topic_id: topicId };
   }
+  // QF-20260703-885: payload.kind='work_assignment' REQUIRES message_type='WORK_ASSIGNMENT'.
+  // The claim path (worker-checkin.cjs) surfaces pending assignments ONLY on top-level
+  // message_type==='WORK_ASSIGNMENT' — a dispatch typed message_type=INFO with
+  // payload.kind='work_assignment' is invisible to it and also silently bypasses the
+  // WORK-DOWN-NEVER-UP tier guard in assertWorkerTierAllowed below. Fail-closed (refuse,
+  // don't auto-correct) so a mistyped dispatch is caught at write time, not discovered as a
+  // worker sitting idle on addressed-but-invisible work.
+  if (row.payload && typeof row.payload === 'object' && row.payload.kind === 'work_assignment'
+      && row.message_type !== 'WORK_ASSIGNMENT') {
+    const e = new Error(
+      `[dispatch] payload.kind='work_assignment' requires message_type='WORK_ASSIGNMENT' (got '${row.message_type}') — refusing mistyped assignment dispatch.`
+    );
+    e.code = 'DISPATCH_WORK_ASSIGNMENT_TYPE_MISMATCH';
+    throw e;
+  }
   await assertValidTarget(supabase, row.target_session, logger);
   // SD-LEO-FEAT-CLAIM-ASSIGNMENT-PATH-001: refuse to dispatch a terminal/non-existent SD before the
   // insert (mirrors claim_sd's terminal guard — fails CLOSED on terminal/not-found, open on a DB hiccup).

--- a/tests/unit/coordinator-dispatch-work-assignment-type-lint.test.js
+++ b/tests/unit/coordinator-dispatch-work-assignment-type-lint.test.js
@@ -1,0 +1,66 @@
+/**
+ * QF-20260703-885 — insertCoordinationRow (the choke point) must refuse a dispatch typed
+ * message_type=INFO with payload.kind='work_assignment'. The claim path (worker-checkin.cjs)
+ * surfaces pending assignments ONLY on top-level message_type==='WORK_ASSIGNMENT', so an
+ * INFO-typed assignment is invisible to workers — every coordinator dispatch on 2026-07-03
+ * morning was mistyped this way, leaving addressed work invisible to its target worker.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { insertCoordinationRow } = require('../../lib/coordinator/dispatch.cjs');
+
+const LIVE_TARGET = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const silentLog = { warn() {}, error() {}, log() {} };
+
+function stubSupabase() {
+  return {
+    from(table) {
+      const chain = {
+        select() { return chain; },
+        eq(_col, val) { chain._eq = val; return chain; },
+        limit() { return chain; },
+        maybeSingle() {
+          if (table === 'claude_sessions') {
+            return Promise.resolve({ data: chain._eq === LIVE_TARGET ? { session_id: LIVE_TARGET, status: 'active' } : null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(r) { chain._inserted = r; return chain; },
+        then(res, rej) { return Promise.resolve({ data: chain._inserted || null, error: null }).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('insertCoordinationRow: work_assignment writer-side type lint (QF-20260703-885)', () => {
+  it('refuses an INFO-typed row carrying payload.kind=work_assignment', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'INFO', target_session: LIVE_TARGET, payload: { kind: 'work_assignment', body: 'do the thing' } };
+    await expect(insertCoordinationRow(sb, row, { logger: silentLog })).rejects.toMatchObject({
+      code: 'DISPATCH_WORK_ASSIGNMENT_TYPE_MISMATCH',
+    });
+  });
+
+  it('allows a correctly-typed WORK_ASSIGNMENT row carrying payload.kind=work_assignment', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'WORK_ASSIGNMENT', target_session: LIVE_TARGET, payload: { kind: 'work_assignment', body: 'do the thing' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.kind).toBe('work_assignment');
+  });
+
+  it('does not touch rows with an unrelated payload.kind', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'INFO', target_session: LIVE_TARGET, payload: { kind: 'coordinator_reply', body: 'hi' } };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload.kind).toBe('coordinator_reply');
+  });
+
+  it('does not touch payload-less rows', async () => {
+    const sb = stubSupabase();
+    const row = { message_type: 'INFO', target_session: LIVE_TARGET, body: 'no payload here' };
+    const res = await insertCoordinationRow(sb, row, { logger: silentLog });
+    expect(res.data.payload).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- The claim path (`worker-checkin.cjs`) surfaces pending assignments ONLY on top-level `message_type==='WORK_ASSIGNMENT'` — a dispatch written as `message_type=INFO` with `payload.kind='work_assignment'` is invisible to it, and also silently bypasses the WORK-DOWN-NEVER-UP tier guard in `assertWorkerTierAllowed`. Every coordinator dispatch this morning was mistyped this way; a worker only saw its assignment by reading the advisory text, not via the claim path.
- Extends the `insertCoordinationRow` choke point (same seam as THREE-WAY-COMMS FR-3 / the existing addressee-mismatch lint) to refuse (fail-closed) any row where `payload.kind='work_assignment'` but `message_type` is not `'WORK_ASSIGNMENT'`.
- Confirmed no existing scripted caller relies on the old (buggy) combination — searched `scripts/` and `lib/` for any literal `payload.kind='work_assignment'` usage; only `dispatch.cjs` itself and `worker-status.cjs`'s read-side `DIRECTIVE_KINDS` classification constant reference it.

## Test plan
- [x] Added `tests/unit/coordinator-dispatch-work-assignment-type-lint.test.js` (4 cases: rejects INFO+work_assignment, allows WORK_ASSIGNMENT+work_assignment, leaves unrelated kinds untouched, leaves payload-less rows untouched)
- [x] Verified all 4 scenarios manually via a direct Node script against the actual production `insertCoordinationRow` function (vitest excludes `.worktrees/**`, so this worktree's own test can't run locally — CI runs it for real against the merged branch checkout)
- [x] Re-verified the existing `protocol-comms-version` stamping regression still passes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)