### PR TITLE
fix(QF-20260703-258): cash-burn-substrate withholds runway instead of fabricating 0 when cash value is null but fresh

### DIFF
--- a/lib/operator/cash-burn-substrate.js
+++ b/lib/operator/cash-burn-substrate.js
@@ -67,7 +67,13 @@ function inputPartial(valueUsd, lastSyncedAt, windowMs, nowMs, extra = {}) {
     ...extra,
   };
   if (f.status === 'live') {
-    return { ...base, value_usd: valueUsd == null ? null : Number(valueUsd), label: null };
+    if (valueUsd == null) {
+      // Fresh sync timestamp but no value was ever recorded — withhold as unattested rather
+      // than reporting status:'live' with value_usd:null, which lets downstream arithmetic
+      // (null coerced to 0) fabricate a numeric result. See core contract in the file header.
+      return { ...base, status: 'unattested', value_usd: null, label: 'not yet measured' };
+    }
+    return { ...base, value_usd: Number(valueUsd), label: null };
   }
   if (f.status === 'stale') {
     // Suppress the stale value — do NOT present it as live.

--- a/tests/unit/operator/cash-burn-substrate.test.js
+++ b/tests/unit/operator/cash-burn-substrate.test.js
@@ -138,6 +138,24 @@ describe('computeRunway — honest degrade', () => {
     expect(attestedZero.partials.cash.value_usd).toBe(0);
   });
 
+  it('a fresh sync timestamp with a null value withholds runway rather than fabricating 0 (regression)', () => {
+    // cash_last_synced_at is fresh, but cash_usd was never actually recorded (null) -- this must
+    // NOT be treated as a live $0 cash balance, since null/burn would otherwise coerce to 0 and
+    // produce a fabricated "0 months of runway" headline.
+    const row = {
+      cash_usd: null, cash_last_synced_at: fresh(1),
+      ai_burn_usd: 800, ai_burn_last_synced_at: fresh(1), ai_burn_is_lower_bound: true,
+      other_burn_usd: null, other_burn_last_synced_at: null,
+      revenue_usd: null, revenue_last_synced_at: null,
+    };
+    const v = computeRunway(row, { nowMs: NOW });
+    expect(v.partials.cash.status).toBe('unattested');
+    expect(v.partials.cash.value_usd).toBeNull();
+    expect(v.partials.cash.label).toBe('not yet measured');
+    expect(v.months_of_runway).toBeNull();
+    expect(v.headline).toBe('awaiting cash source');
+  });
+
   it('exposes per-input liveness windows (ai_burn/revenue hourly-tight, cash generous)', () => {
     expect(LIVENESS_WINDOWS_MS.ai_burn).toBeLessThan(LIVENESS_WINDOWS_MS.cash);
     expect(LIVENESS_WINDOWS_MS.revenue).toBe(LIVENESS_WINDOWS_MS.ai_burn);


### PR DESCRIPTION
## Summary
- \`inputPartial()\` in \`lib/operator/cash-burn-substrate.js\` determined an input's \`status\` purely from timestamp freshness, independent of whether the value itself was null.
- When \`cash_last_synced_at\` is fresh but \`cash_usd\` is null (a sync happened, but no value was ever recorded), this returned \`{status:'live', value_usd:null}\`.
- \`computeRunway\`'s \`cash.status !== 'live'\` check didn't catch this, so execution proceeded to \`cash.value_usd / netBurn.value_usd\` where \`null\` coerced to \`0\`, fabricating a "0 months of runway" headline instead of withholding it — directly violating the file's own documented core contract ("a missing input is NULL, never 0").
- Fix applies to \`inputPartial()\`'s shared logic, so it also protects \`ai_burn\`/\`other_burn\`/\`revenue\` from the same class of bug, not just cash.

## Test plan
- [x] \`npx vitest run tests/unit/operator/cash-burn-substrate.test.js\` — 15/15 passing (14 existing + 1 new regression test pinning the exact fresh-timestamp-null-value scenario)
- [x] Verified the existing "NULL-not-zero" test (attested \`cash_usd: 0\` with a fresh timestamp) still correctly reports \`status:'live', value_usd:0\` — the fix only intervenes on \`null\`, never on a real attested zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)