### PR TITLE
fix(QF-20260703-234): restore lost WIRE_CHECK_GATE fixes for lib/vision/north-star.js

### DIFF
--- a/lib/vision/north-star.js
+++ b/lib/vision/north-star.js
@@ -8,6 +8,12 @@
  * Cardinal honesty invariant: getNorthStar() is FAIL-SOFT and NEVER fabricates a target.
  * When no chairman_ratified record exists (or on any DB/error), it returns { status: 'unset' }
  * with NO target — downstream gauges must show "no target set", never a made-up number.
+ *
+ * @wire-check-exempt: consumer-side integration (the ord 2/3/4 cockpit gauges importing this
+ * read API instead of self-deriving their own target) is a follow-up SD; until then this
+ * library has no static importer. The companion data-population CLI, exposed as the
+ * `north-star:populate` npm script, writes the underlying row directly and does not import
+ * this file either.
  */
 
 const UNSET = Object.freeze({ status: 'unset', target: null });

--- a/package.json
+++ b/package.json
@@ -588,6 +588,7 @@
     "schema:lint": "node scripts/lint/schema-reference-lint.mjs --diff",
     "schema:lint:all": "node scripts/lint/schema-reference-lint.mjs --all",
     "retro-migrations:diff-scope": "node scripts/lint/compute-changed-retro-migrations.mjs",
+    "north-star:populate": "node scripts/populate-north-star.mjs",
     "schema:snapshot:lint": "node scripts/lint/schema-reference-snapshot.mjs",
     "canary:probe": "node scripts/canary/run-canary-probe.mjs",
     "test:quarantine": "node scripts/unit-tier-quarantine.mjs report .claude-unit-run.log",


### PR DESCRIPTION
## Summary
- Adds an `@wire-check-exempt` docstring comment to `lib/vision/north-star.js` — no static importer exists yet; consumer-side cockpit-gauge (ord 2/3/4) integration is a follow-up SD, and the companion `scripts/populate-north-star.mjs` writes the underlying row directly rather than importing this module.
- Adds a `north-star:populate` npm script alias for `scripts/populate-north-star.mjs`, mirroring the `schema:lint` / `retro-migrations:diff-scope` precedent.

These two edits were originally drafted in the root tree, then reverted (`git restore`) to avoid working directly on the shared tree, and are being restored here in an isolated worktree per QF-20260703-234.

## Test plan
- [x] `node --check scripts/populate-north-star.mjs` — target script parses
- [x] `node -e "JSON.parse(...)"` — package.json remains valid JSON after edit
- [x] No logic changed — docstring comment + npm alias only, no unit test regression risk