### PR TITLE
fix(QF-20260703-076): session-independent dormancy watchdog closes FLEET-WAKE-UNDER-001 reachability gap

### DIFF
--- a/lib/fleet/dormancy-watchdog.cjs
+++ b/lib/fleet/dormancy-watchdog.cjs
@@ -1,0 +1,40 @@
+/**
+ * Fleet worker dormancy detector — QF-20260703-076.
+ *
+ * RCA: prior backstops (loop directive Step-6, stop-loop-wakeup-reminder.cjs) run INSIDE
+ * a turn, so none can observe a worker that armed a ScheduleWakeup and then never got
+ * another turn. This is the missing session-independent detector.
+ *
+ * Keys on process_alive_at, NOT heartbeat_at — heartbeat_at is rewritten by multiple
+ * writers independently of real work (verified live: session cb2bfe72 showed a fresh
+ * heartbeat_at while process_alive_at was 24+ hours stale). Detector-only: does NOT
+ * revive workers (worker-spawn-executor.cjs stays behind its own operator gate).
+ */
+'use strict';
+
+const { SILENCE_HARD_CAP_MS } = require('./silence-cap.cjs');
+
+// Avoid flagging a worker that just woke up and is mid-tick, racing the detector.
+const ELAPSED_GRACE_MS = 3 * 60 * 1000;
+// process_alive_at older than this (or absent) counts as stale.
+const PROCESS_ALIVE_STALE_MS = 5 * 60 * 1000;
+const DORMANT_LOOP_STATES = new Set(['awaiting_tick', 'active']);
+
+/** Pure: is a single session dormant per the corrected reachability predicate? */
+function isDormant(session, nowMs) {
+  if (!session || !DORMANT_LOOP_STATES.has(session.loop_state)) return false;
+  const esu = session.expected_silence_until ? Date.parse(session.expected_silence_until) : NaN;
+  if (Number.isNaN(esu) || nowMs - esu < ELAPSED_GRACE_MS) return false;
+  const paa = session.process_alive_at ? Date.parse(session.process_alive_at) : NaN;
+  if (!Number.isNaN(paa) && nowMs - paa < PROCESS_ALIVE_STALE_MS) return false;
+  return true;
+}
+
+/** Pure: detect dormant workers across a session list. */
+function detectDormantWorkers(sessions, nowMs) {
+  return (sessions || [])
+    .filter((s) => isDormant(s, nowMs))
+    .map((s) => ({ session_id: s.session_id, elapsed_ms: nowMs - Date.parse(s.expected_silence_until) }));
+}
+
+module.exports = { detectDormantWorkers, isDormant, ELAPSED_GRACE_MS, PROCESS_ALIVE_STALE_MS, SILENCE_HARD_CAP_MS };

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -40,6 +40,7 @@ const { assertSdDispatchable, isFullUuid } = require('../lib/coordinator/dispatc
 // they cannot drift. Absorbs QF-20260526-577.
 const { CLAIM_HOLDING_STATUSES, computeClaimedSdKeys } = require('../lib/claim/holding-statuses.cjs');
 const { SILENCE_HARD_CAP_MS } = require('../lib/fleet/silence-cap.cjs'); // FR-4: shared writer<=reader cap
+const { detectDormantWorkers } = require('../lib/fleet/dormancy-watchdog.cjs'); // QF-20260703-076
 // SD-LEO-INFRA-STALE-SWEEP-PID-LIVENESS-GUARD-001: PID-liveness guard for the conflict-eviction path.
 const { shouldHoldClaim } = require('../lib/fleet/claim-release-guard.cjs');
 // SD-LEO-INFRA-TWO-WAY-COORDINATOR-001 / FR-3b — top-level require so wire-check
@@ -672,6 +673,33 @@ async function main() {
   // QF-20260525-211 (early-exit gap): reap orphaned QF claims BEFORE the early-return below,
   // so a stale QF claim is cleared even when zero SD-claiming sessions remain (fleet wound down).
   await clearStaleQfClaims(supabase, now, actions, warnings);
+
+  // QF-20260703-076: session-independent dormancy watchdog -- prior backstops run INSIDE
+  // a turn and can't observe a worker whose armed wakeup never fired. Detector-only.
+  try {
+    const { data: allTracked } = await supabase
+      .from('claude_sessions')
+      .select('session_id, loop_state, expected_silence_until, process_alive_at')
+      .eq('status', 'active');
+    const dormant = detectDormantWorkers(allTracked || [], now.getTime());
+    const DORMANCY_ALERT_THRESHOLD = 2;
+    if (dormant.length >= DORMANCY_ALERT_THRESHOLD) {
+      const { emitFeedback } = await import('../lib/governance/emit-feedback.js');
+      const hourBucket = now.toISOString().slice(0, 13);
+      await emitFeedback({
+        supabase,
+        title: `Fleet dormancy: ${dormant.length} worker(s) armed a wakeup that never fired`,
+        description: `Dormant session_ids: ${dormant.map((d) => d.session_id).join(', ')}. Each has an elapsed expected_silence_until and a stale/absent process_alive_at -- the native ScheduleWakeup did not re-invoke the loop. See QF-20260703-076 RCA.`,
+        category: 'fleet_dormancy',
+        severity: 'high',
+        dedup_key: `dormancy:${hourBucket}`,
+      });
+    }
+  } catch (watchdogErr) {
+    if (process.env.LEO_TELEMETRY_DEBUG === '1') {
+      console.error('[sweep] dormancy watchdog swallowed: ' + watchdogErr.message);
+    }
+  }
 
   if (!sessions || sessions.length === 0) {
     if (actions.length > 0) {

--- a/tests/unit/fleet/dormancy-watchdog.test.js
+++ b/tests/unit/fleet/dormancy-watchdog.test.js
@@ -1,0 +1,109 @@
+/**
+ * QF-20260703-076 — dormancy-watchdog.cjs pure detector.
+ *
+ * Verification cases mirror the RCA's own reachability findings, notably the
+ * heartbeat-masking trap: session cb2bfe72 showed a FRESH heartbeat_at while
+ * process_alive_at was ~24.8h stale, so the detector must key on process_alive_at
+ * and must never be influenced by heartbeat_at (the detector doesn't even accept it).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  detectDormantWorkers,
+  isDormant,
+  ELAPSED_GRACE_MS,
+  PROCESS_ALIVE_STALE_MS,
+} = require('../../../lib/fleet/dormancy-watchdog.cjs');
+
+const NOW = Date.parse('2026-07-03T14:00:00Z');
+
+function isoMinutesAgo(mins, from = NOW) {
+  return new Date(from - mins * 60 * 1000).toISOString();
+}
+
+describe('isDormant', () => {
+  it('(a) awaiting_tick with expected_silence_until still in the future — NOT dormant', () => {
+    const s = { loop_state: 'awaiting_tick', expected_silence_until: isoMinutesAgo(-5), process_alive_at: null };
+    expect(isDormant(s, NOW)).toBe(false);
+  });
+
+  it('(b) awaiting_tick, elapsed silence window, stale process_alive_at — DORMANT', () => {
+    const s = {
+      loop_state: 'awaiting_tick',
+      expected_silence_until: isoMinutesAgo(10),
+      process_alive_at: isoMinutesAgo(60 * 24), // ~24h stale, matches cb2bfe72 specimen
+    };
+    expect(isDormant(s, NOW)).toBe(true);
+  });
+
+  it('(c) heartbeat-masking trap: a fresh heartbeat_at must not prevent detection — detector ignores heartbeat_at entirely', () => {
+    const s = {
+      loop_state: 'awaiting_tick',
+      expected_silence_until: isoMinutesAgo(10),
+      process_alive_at: isoMinutesAgo(60 * 24),
+      heartbeat_at: isoMinutesAgo(0.01), // fresh — must have zero effect
+    };
+    expect(isDormant(s, NOW)).toBe(true);
+  });
+
+  it('(d) loop_state=active with a long-elapsed silence window — DORMANT', () => {
+    const s = { loop_state: 'active', expected_silence_until: isoMinutesAgo(41 * 60), process_alive_at: null };
+    expect(isDormant(s, NOW)).toBe(true);
+  });
+
+  it('a recently-ticked worker (process_alive_at fresh) past its silence window is NOT dormant — still working', () => {
+    const s = { loop_state: 'awaiting_tick', expected_silence_until: isoMinutesAgo(10), process_alive_at: isoMinutesAgo(1) };
+    expect(isDormant(s, NOW)).toBe(false);
+  });
+
+  it('elapsed but within the grace margin is NOT yet dormant (avoids a wake-race false positive)', () => {
+    const s = { loop_state: 'awaiting_tick', expected_silence_until: isoMinutesAgo(ELAPSED_GRACE_MS / 60000 / 2), process_alive_at: null };
+    expect(isDormant(s, NOW)).toBe(false);
+  });
+
+  it('process_alive_at exactly at the stale boundary is NOT flagged (boundary is exclusive on the alive side)', () => {
+    const s = {
+      loop_state: 'awaiting_tick',
+      expected_silence_until: isoMinutesAgo(10),
+      process_alive_at: isoMinutesAgo(PROCESS_ALIVE_STALE_MS / 60000 - 0.001),
+    };
+    expect(isDormant(s, NOW)).toBe(false);
+  });
+
+  it('loop_state exited or unknown is never flagged, regardless of other fields', () => {
+    const base = { expected_silence_until: isoMinutesAgo(60), process_alive_at: isoMinutesAgo(60) };
+    expect(isDormant({ ...base, loop_state: 'exited' }, NOW)).toBe(false);
+    expect(isDormant({ ...base, loop_state: 'unknown' }, NOW)).toBe(false);
+    expect(isDormant({ ...base, loop_state: null }, NOW)).toBe(false);
+  });
+
+  it('no expected_silence_until at all (never armed) is not this detector\'s concern', () => {
+    const s = { loop_state: 'active', expected_silence_until: null, process_alive_at: isoMinutesAgo(60) };
+    expect(isDormant(s, NOW)).toBe(false);
+  });
+
+  it('null/undefined session is never flagged', () => {
+    expect(isDormant(null, NOW)).toBe(false);
+    expect(isDormant(undefined, NOW)).toBe(false);
+  });
+});
+
+describe('detectDormantWorkers', () => {
+  it('returns only the dormant subset with session_id + elapsed_ms', () => {
+    const sessions = [
+      { session_id: 'alive-1', loop_state: 'awaiting_tick', expected_silence_until: isoMinutesAgo(-5), process_alive_at: null },
+      { session_id: 'dormant-1', loop_state: 'awaiting_tick', expected_silence_until: isoMinutesAgo(10), process_alive_at: isoMinutesAgo(60 * 24) },
+      { session_id: 'dormant-2', loop_state: 'active', expected_silence_until: isoMinutesAgo(41 * 60), process_alive_at: null },
+    ];
+    const result = detectDormantWorkers(sessions, NOW);
+    expect(result.map((r) => r.session_id).sort()).toEqual(['dormant-1', 'dormant-2']);
+    expect(result[0].elapsed_ms).toBeGreaterThan(0);
+  });
+
+  it('empty/missing input returns an empty array, never throws', () => {
+    expect(detectDormantWorkers([], NOW)).toEqual([]);
+    expect(detectDormantWorkers(null, NOW)).toEqual([]);
+    expect(detectDormantWorkers(undefined, NOW)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- **REACHABILITY VERDICT** (RCA-verified via direct DB query on specimen session cb2bfe72): both of SD-LEO-INFRA-FLEET-WAKE-UNDER-001's shipped backstops (the Step-6 re-arm mandate, `stop-loop-wakeup-reminder.cjs`) are reachable and working correctly, but both run *inside a turn / at turn-end* — neither can observe a worker that armed a `ScheduleWakeup` and then never got another turn (the native wakeup silently failed to re-invoke the loop). That's why 5 of 7 workers went dormant today despite the "resolved" fix.
- **False-liveness trap confirmed**: cb2bfe72 showed `heartbeat_at` reading fresh while `process_alive_at` was ~24.8h stale (multiple writers refresh `heartbeat_at` independently of real work) — any dormancy detector must key on `process_alive_at`, never `heartbeat_at`.
- Adds `lib/fleet/dormancy-watchdog.cjs`: a pure, session-independent detector. Wired into `scripts/stale-session-sweep.cjs`'s existing coordinator-tick cadence to emit a loud `feedback` signal (`category=fleet_dormancy`, `severity=high`) when ≥2 workers are simultaneously dormant.
- Deliberately does **not** activate autonomous worker respawn (`scripts/fleet/worker-spawn-executor.cjs`) — it stays behind its own explicit operator gate per the file's own header; flipping it on is an operational decision outside this QF's scope. This closes the "silently undetected" half of the gap (loud alarm); autonomous revival needs explicit operator sign-off.

## Test plan
- [x] `npx vitest run tests/unit/fleet/dormancy-watchdog.test.js` — 12/12 pass, including the exact heartbeat-masking-trap regression case
- [x] `npx vitest run tests/unit/fleet/` (full directory) + existing `stale-session-sweep` test suites — 243/243 pass, no regressions
- [x] `node -c` syntax check on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)