### PR TITLE
fix(QF-20260703-440): adam-exec-summary.mjs: remove dead session_question decision_type check (unreachable via chairman_pending_decisions)

### DIFF
--- a/scripts/adam-exec-summary.mjs
+++ b/scripts/adam-exec-summary.mjs
@@ -276,13 +276,19 @@ const visSubj = subjectNeedle
 // '(hr avg)' tag only for a CONFIDENT (non-sparse) hourly average — keep the subject honest too.
 const workerSubj = pulseSource === 'unavailable' ? 'workers n/a' : `${avgActive} active${(pulseSource === 'hourly avg' && !wc.sparse) ? ' (hr avg)' : ''}`;
 const actionsSubj = nActions ? `${nActions} ${nActions === 1 ? 'action' : 'actions'} for you` : 'all clear';
-// QF-20260627-338: when an ADAM ESCALATION is present (a routed stuck-question — decision_type
-// 'session_question' — OR an Adam-flagged blocking decision), the SUBJECT must STAND OUT from the
-// routine hourly digest so the chairman instantly distinguishes it. FR-1 standout subject leading
-// with a distinct token; FR-2 routine subject unchanged otherwise. No emojis (in-file directive).
-// FR-3: escalations are pending actions (nActions>0) so they already bypass the quiescence gate, and
-// --force still triggers an immediate send. Chairman may refine the standout token.
-const escalations = rows.filter((r) => r.decision_type === 'session_question' || r.blocking === true);
+// QF-20260627-338: when an ADAM ESCALATION is present (an Adam-flagged blocking decision), the
+// SUBJECT must STAND OUT from the routine hourly digest so the chairman instantly distinguishes it.
+// FR-1 standout subject leading with a distinct token; FR-2 routine subject unchanged otherwise.
+// No emojis (in-file directive). FR-3: escalations are pending actions (nActions>0) so they already
+// bypass the quiescence gate, and --force still triggers an immediate send. Chairman may refine the
+// standout token.
+// QF-20260703-440: dropped the decision_type==='session_question' disjunct — chairman_pending_decisions'
+// base view (chairman_unified_decisions) hardcodes decision_type to one of 'escalation' | 'gate_decision'
+// | 'chairman_approval' | 'flag_review' | 'flag_enablement' | 'okr_acceptance' across all 7 UNION arms;
+// 'session_question' can never appear in `rows` here. A routed stuck-question's standout-subject
+// escalation is already handled independently and immediately at creation time by
+// lib/chairman/record-pending-decision.mjs's own send path — this hourly digest never re-derives it.
+const escalations = rows.filter((r) => r.blocking === true);
 const escalationLine = escalations.length
   ? String(escalations[0].title || escalations[0].details || 'chairman decision needed').replace(/\s+/g, ' ').trim().slice(0, 80)
   : '';


### PR DESCRIPTION
## Quick-Fix: QF-20260703-440

**Type:** bug
**Severity:** low

### Issue Description
Completion-flag 106eb504 (SD-LEO-INFRA-LEAN-DECISION-EMAIL-001): the escalation-subject arm at adam-exec-summary.mjs L285 keys on r.decision_type === 'session_question', but chairman_pending_decisions' chairman_decisions UNION arm hardcodes decision_type to the literal 'chairman_approval' for every row sourced from that table -- so this disjunct can never be true for any row this array can contain (verified: none of the view's 7 UNION arms ever emit 'session_question'). Session-question escalation is already handled independently and immediately at creation time by lib/chairman/record-pending-decision.mjs's own send path. Fixing the view's decision_type passthrough is out of scope for a quick-fix: it is load-bearing for a DIFFERENT consumer in the same file (the dead-venture filter at L63 also matches on the hardcoded 'chairman_approval' literal), so a real fix requires a schema/view change reviewed against that dependency -- Tier 3 per the schema-keyword routing rule, not this QF.

### Steps to Reproduce
Read scripts/adam-exec-summary.mjs L279-285; read database view def for chairman_pending_decisions and chairman_unified_decisions via pg_get_viewdef; confirm no UNION arm emits decision_type='session_question'.

### Expected Behavior
The escalations filter only checks a signal that can actually be true for chairman_pending_decisions rows (blocking), with a comment documenting why decision_type is dead here and pointing to the real (creation-time) session_question escalation path.

### Actual Behavior
escalations = rows.filter(r => r.decision_type === 'session_question' || r.blocking === true) -- first disjunct is unreachable dead code, silently misleading about how hourly-digest escalation actually works.

### Changes
- **Files Changed:** 1
  - scripts/adam-exec-summary.mjs
- **LOC:** 21 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol