### PR TITLE
fix(QF-20260703-091): apply repo-fitness gate to directed WORK_ASSIGNMENT claim branch

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1281,14 +1281,29 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // here and fall through to self-claim. Fail-open: a query error skips the purge and lets
       // the normal claim path (now guarded by the RPC) handle it.
       let terminalStatus = null;
+      let assignedSdRow = null;
       try {
         const { data: tgt } = await sb.from('strategic_directives_v2')
-          .select('status').eq('sd_key', sdKey).maybeSingle();
+          .select('status, sd_type, sd_key, metadata, target_application').eq('sd_key', sdKey).maybeSingle();
+        assignedSdRow = tgt || null;
         if (tgt && ['completed', 'cancelled', 'deferred'].includes(tgt.status)) terminalStatus = tgt.status;
       } catch { /* fail-open: leave terminalStatus null, attempt the claim below */ }
+      // QF-20260703-091 (RCA-confirmed): mirror the self-claim paths' shared fitness/premise gate
+      // (classifyDispatchIneligibility, incl. the repo-match axis) onto this DIRECTED-assignment
+      // path too. Previously only sd-start.js caught a repo-mismatched directed assignment, AFTER
+      // the claim had already churned (coordinator re-dispatch -> checkin claims unconditionally ->
+      // sd-start releases -> repeats every tick). No tierCtx: an explicit coordinator directive
+      // should not be second-guessed by the WORK-DOWN-NEVER-UP self-claim preference, only the hard
+      // fitness/premise axes (repo mismatch, terminal/superseded premise, orchestrator parent, etc).
+      const ineligibleReason = (!terminalStatus && assignedSdRow)
+        ? classifyDispatchIneligibility(assignedSdRow, { cwd: process.cwd() })
+        : null;
       if (terminalStatus) {
         await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
         base.stale_assignment_purged = { sd: sdKey, status: terminalStatus };
+      } else if (ineligibleReason) {
+        await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+        base.assignment_ineligible_purged = { sd: sdKey, reason: ineligibleReason };
       } else {
         const claimed = await tryClaim(sb, sdKey, sessionId);
         if (claimed.ok) {

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -59,7 +59,7 @@ describe('extractDirectedSd — structured directed fields only (finding #2)', (
 
 // resolveCheckin seam 1 — fake sb: session holds mySd; an unread WORK_ASSIGNMENT targets a
 // different SD. The assignment must surface on the resume result without dropping the claim.
-function fakeSb({ heldSd, assignmentSd, windDown }) {
+function fakeSb({ heldSd, assignmentSd, windDown, sdRow }) {
   return {
     rpc: () => Promise.resolve({ data: { success: true }, error: null }),
     from(table) {
@@ -68,7 +68,7 @@ function fakeSb({ heldSd, assignmentSd, windDown }) {
         order() { return this; }, limit() { return this; },
         maybeSingle() {
           if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker', ...(windDown ? { wind_down: windDown } : {}) }, sd_key: heldSd }, error: null });
-          if (table === 'strategic_directives_v2') return Promise.resolve({ data: { status: 'in_progress' }, error: null });
+          if (table === 'strategic_directives_v2') return Promise.resolve({ data: sdRow || { status: 'in_progress' }, error: null });
           return Promise.resolve({ data: null, error: null });
         },
         insert() { return Promise.resolve({ error: null }); },
@@ -183,6 +183,50 @@ describe('resolveCheckin — surface pending WORK_ASSIGNMENT on resume (seam 1)'
       expect(res.sd).toBe(heldSd);
       expect(res.pending_work_assignment?.sd).toBe('SD-REDIRECT-009');
       expect(res.pending_work_assignment?.message_id).toBe('directed-1');
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});
+
+// QF-20260703-091 (RCA-confirmed): a NO-held-claim session with a directed WORK_ASSIGNMENT must
+// run the same repo-fitness/premise gate (classifyDispatchIneligibility) the self-claim paths use
+// BEFORE calling tryClaim — previously it claimed unconditionally and relied on sd-start.js to
+// catch a repo-mismatched SD one step later, after the claim had already churned.
+describe('resolveCheckin — directed WORK_ASSIGNMENT claim path skips an ineligible SD (no held claim)', () => {
+  it('repo-mismatched directed assignment is ACKed and skipped, NOT claimed (falls through to idle)', async () => {
+    const assignmentSd = 'SD-MARKETLENS-MISMATCH-001';
+    const sb = fakeSb({
+      heldSd: null,
+      sdRow: { status: 'draft', sd_type: 'feature', sd_key: assignmentSd, metadata: {}, target_application: 'MarketLens' },
+    });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-mismatch', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.sd).not.toBe(assignmentSd);
+      expect(res.assignment_ineligible_purged).toEqual({ sd: assignmentSd, reason: 'unfit_repo_mismatch' });
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('a FIT directed assignment still claims normally (regression guard)', async () => {
+    const assignmentSd = 'SD-EHG-ENGINEER-FIT-002';
+    const sb = fakeSb({
+      heldSd: null,
+      sdRow: { status: 'draft', sd_type: 'feature', sd_key: assignmentSd, metadata: {}, target_application: null },
+    });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-fit', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).toBe('claimed_assignment');
+      expect(res.sd).toBe(assignmentSd);
+      expect(res.assignment_ineligible_purged).toBeUndefined();
     } finally {
       ws.getMessagesForSession = orig;
     }


### PR DESCRIPTION
## Summary
- RCA-confirmed (invoked via rca-agent after a 3rd occurrence of the same repo-mismatched SD being re-dispatched to this fleet-worker session): `resolveCheckin`'s no-held-claim WORK_ASSIGNMENT branch in `scripts/worker-checkin.cjs` called `tryClaim()` unconditionally, never running the same `classifyDispatchIneligibility` fitness/premise gate the self-claim paths already apply (lines 660/848).
- A repo-mismatched directed assignment (e.g. `target_application='MarketLens'` assigned to an `EHG_Engineer` checkout) got claimed here and was only caught one step later by `sd-start.js`'s own guard — after the claim had already churned, so the coordinator kept re-dispatching the identical SD on every tick despite an intervening `unfit --block-class repo_mismatch` signal (that signal's lack of a coordinator-side consumer is a separate, larger preventive follow-up flagged by the same RCA, not in this QF's scope).
- Fix: fetch `sd_type`/`metadata`/`target_application` alongside the existing terminal-status lookup, and run `classifyDispatchIneligibility(row, {cwd: process.cwd()})` before `tryClaim()`. On any ineligibility, ACK the assignment and skip it (falls through to self-claim) instead of claiming. No `tierCtx` is passed — an explicit coordinator directive shouldn't be second-guessed by the WORK-DOWN-NEVER-UP self-claim preference, only the hard fitness/premise axes (repo mismatch, terminal/superseded premise, orchestrator parent, etc).

## Test plan
- [x] Extended `tests/unit/worker-checkin-assignment-surfacing.test.js` with 2 new cases: a repo-mismatched directed assignment is ACKed+skipped (not claimed, falls through to idle); a FIT directed assignment still claims normally (regression guard).
- [x] `npx vitest run tests/unit/worker-checkin-assignment-surfacing.test.js` — 19/19 passing
- [x] `npx vitest run tests/unit/worker-checkin*.test.js` — full worker-checkin family, 91/91 passing, no regressions
- [x] `npx vitest run tests/unit/fleet/` — broader fleet suite, 216/216 passing