### PR TITLE
fix(QF-20260703-476): assignment pull reads consumed-but-unactioned rows, not just unread

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -77,6 +77,13 @@ const ROLL_CALL_DEDUP_MS = 5 * 60 * 1000;    // don't re-register within 5m (ide
 // small. NOT applied to the propose-only idle branch below, which keeps its own 1200 literal.
 const DEFAULT_IDLE_WAKEUP_SECONDS = 600;      // ~10m, matches the tightened fleet idle cadence
 
+// QF-20260703-476: bounded lookback for a "consumed but unactioned" WORK_ASSIGNMENT re-pull.
+// A row can get read_at stamped by some other delivery path (poll, prior session) without ever
+// being genuinely actioned (acknowledged_at still NULL, no claim recorded) -- an unreadOnly pull
+// then hides it from the claim step forever. Bounding the re-pull to 24h avoids resurrecting a
+// truly ancient, abandoned assignment while covering the observed hours-long stuck window.
+const ASSIGNMENT_RECENCY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 // SD-LEO-INFRA-WORKER-ANTI-PREMATURE-WINDDOWN-001 (Mode B, the DOMINANT wind-down failure 3/4):
 // the enforceable lever. When a worker holds/just-claimed RANKED claimable work, this directive
 // rides the check-in payload to kill the false "drained" feeling with data and to surface — AT the
@@ -1227,7 +1234,13 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // until actioned. Fail-open: any error preserves today's plain resume.
       let pendingAssignment = null;
       try {
-        const msgs = await ws.getMessagesForSession(sb, sessionId, { unreadOnly: true });
+        // QF-20260703-476: unackedOnly (acknowledged_at IS NULL), not unreadOnly -- a row whose
+        // read_at got stamped by some other delivery path but was never genuinely actioned must
+        // still surface here, bounded to a recency window so an ancient row isn't resurrected.
+        const msgs = await ws.getMessagesForSession(sb, sessionId, {
+          unackedOnly: true,
+          sinceIso: new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString(),
+        });
         // Only a row carrying a STRUCTURED directed field (assigned_sd/sd_key) is a real redirect;
         // selecting on extractDirectedSd also skips past the generic sweep advisory if a directed
         // row exists beneath it (finding #3: subtype-blind newest-wins .find() could otherwise mask
@@ -1266,9 +1279,15 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   }
 
   // 5. pending WORK_ASSIGNMENT -> claim via claim_sd RPC
+  // QF-20260703-476: unackedOnly, not unreadOnly -- see ASSIGNMENT_RECENCY_WINDOW_MS above. A
+  // consumed-but-unactioned row (read_at set, acknowledged_at NULL, no claim recorded) must still
+  // reach the claim step instead of being permanently hidden by an unreadOnly filter.
   let assignment = null;
   try {
-    const msgs = await ws.getMessagesForSession(sb, sessionId, { unreadOnly: true });
+    const msgs = await ws.getMessagesForSession(sb, sessionId, {
+      unackedOnly: true,
+      sinceIso: new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString(),
+    });
     assignment = (msgs || []).find(m => m.message_type === 'WORK_ASSIGNMENT');
   } catch { /* fail-open */ }
   if (assignment) {

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -232,3 +232,60 @@ describe('resolveCheckin — directed WORK_ASSIGNMENT claim path skips an inelig
     }
   });
 });
+
+// QF-20260703-476: a WORK_ASSIGNMENT whose read_at got stamped by some other delivery path
+// (e.g. a stale/legacy poll) but was never genuinely actioned (acknowledged_at still NULL, no
+// claim recorded) must still reach the claim step -- an unreadOnly pull hides it forever.
+// These stubs assert on the OPTIONS resolveCheckin actually passes (unackedOnly, not unreadOnly),
+// simulating real Postgres filter semantics: a row only "exists" in the returned set when the
+// options it was called with are the ones that would truly select it.
+function makeFilteringStub(row) {
+  return async (sb, sessionId, opts = {}) => {
+    if (opts.unackedOnly) return row.acknowledged_at == null ? [row] : [];
+    if (opts.unreadOnly) return row.read_at == null ? [row] : [];
+    return [row];
+  };
+}
+
+describe('resolveCheckin — a stamped-but-unclaimed assignment still reaches the claim step', () => {
+  it('no held claim: a read_at-set/acknowledged_at-null row is still claimed (not hidden by unreadOnly)', async () => {
+    const assignmentSd = 'SD-EHG-ENGINEER-STAMPED-003';
+    const sb = fakeSb({
+      heldSd: null,
+      sdRow: { status: 'draft', sd_type: 'feature', sd_key: assignmentSd, metadata: {}, target_application: null },
+    });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = makeFilteringStub({
+      id: 'msg-stamped', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd },
+      read_at: '2026-07-03T10:00:00.000Z', acknowledged_at: null,
+    });
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).toBe('claimed_assignment');
+      expect(res.sd).toBe(assignmentSd);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('held claim (seam 1): a read_at-set/acknowledged_at-null row still surfaces as pending_work_assignment', async () => {
+    const heldSd = 'SD-CURRENT-004';
+    const assignmentSd = 'SD-REDIRECT-005';
+    const sb = fakeSb({ heldSd, assignmentSd });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = makeFilteringStub({
+      id: 'msg-stamped-busy', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd },
+      read_at: '2026-07-03T10:00:00.000Z', acknowledged_at: null,
+    });
+    try {
+      const res = await resolveCheckin(sb, 'sess-busy', { getCoordinator: async () => null });
+      expect(res.action).toBe('resume');
+      expect(res.sd).toBe(heldSd);
+      expect(res.pending_work_assignment?.sd).toBe(assignmentSd);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause of this morning's apparent worker dormancy: a WORK_ASSIGNMENT whose `read_at` gets stamped by some other delivery path (poll, prior session) without ever being genuinely actioned (`acknowledged_at` still NULL, no claim recorded) became **permanently invisible** to `resolveCheckin`'s claim-attempt logic, which pulled with `{ unreadOnly: true }` — that filter excludes any row with `read_at` set, regardless of `acknowledged_at`. The same gap existed in the seam-1 "surface pending assignment to a busy worker" pull.
- Both pulls now use `{ unackedOnly: true, sinceIso: <24h ago> }` — `acknowledged_at IS NULL` is the true "not yet genuinely actioned" signal (`getMessagesForSession` already documents this read/ack distinction), bounded to a 24h recency window so an ancient abandoned assignment isn't resurrected.

**Deliberately NOT implementing** the QF description's other stated change (role-generalizing `ackMessage`'s Adam-role no-auto-ack guard): traced all 3 `ackMessage` call sites (this file's only callers, all in the step-5 claim-decision branches) and confirmed `isBuildForbiddenSession`'s ACQUISITION GUARD at step 4.5 already blocks `role==='adam'` (and `is_coordinator`/`non_fleet`) sessions before they can ever reach step 5 — the `role==='adam'` branch in `ackMessage` is unreachable dead code for these call sites, not a live bug. Role-generalizing it would risk suppressing the genuine action-taken ack for ordinary worker claims without fixing anything currently broken.

## Test plan
- [x] Extended `tests/unit/worker-checkin-assignment-surfacing.test.js` with 2 new cases: a `read_at`-set/`acknowledged_at`-null row still reaches the claim step with no held claim (claimed normally); the same row still surfaces as `pending_work_assignment` when a claim is already held (seam 1). Both stub `getMessagesForSession` to assert on the actual options passed (`unackedOnly` vs `unreadOnly`), simulating real filter semantics rather than a canned return.
- [x] `npx vitest run tests/unit/worker-checkin-assignment-surfacing.test.js` — 21/21 passing
- [x] `npx vitest run tests/unit/worker-checkin*.test.js` — full family, 93/93 passing, no regressions
- [x] `npx vitest run tests/unit/fleet/ tests/unit/coordination-inbox*.test.js` — 233/233 passing, no regressions