### PR TITLE
fix(QF-20260703-401): retroactive ship-witness CLI + fetchStatusCheckRollup repo-scope fix

### DIFF
--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -145,9 +145,18 @@ export function verifyMerged(prNumber, repoOwner, repoName, runner = defaultRunn
  * empty rollup — never a false pass/fail). Exported (SD-LEO-INFRA-SHIP-
  * WITNESS-APPLICATIONS-001) so lib/ship/venture-trust-gate.mjs can reuse the
  * same gh CLI fetch path instead of reimplementing it.
+ *
+ * QF-20260703-401: repoOwner/repoName are optional but SHOULD always be
+ * passed by cross-repo callers — an unscoped `gh pr view` resolves against
+ * the process's ambient cwd repo (mirrors the exact class of bug fixed in
+ * verifyMerged by QF-20260703-197), so an unscoped call from EHG_Engineer's
+ * own cwd for a venture-repo PR silently reads the wrong repo's checks.
  */
-export function fetchStatusCheckRollup(prNumber, runner = defaultRunner) {
-  const r = runner(['pr', 'view', String(prNumber), '--json', 'statusCheckRollup', '--jq', '.statusCheckRollup']);
+export function fetchStatusCheckRollup(prNumber, repoOwner, repoName, runner = defaultRunner) {
+  const args = ['pr', 'view', String(prNumber)];
+  if (repoOwner && repoName) args.push('-R', `${repoOwner}/${repoName}`);
+  args.push('--json', 'statusCheckRollup', '--jq', '.statusCheckRollup');
+  const r = runner(args);
   if (r.code !== 0) return [];
   try {
     const parsed = JSON.parse(r.stdout.trim() || '[]');
@@ -169,7 +178,7 @@ async function observeMergeWorkLadder({
   lookupWorkKeyReal, fetchReviewFinding, supabase, lane, logger,
 }) {
   try {
-    const statusCheckRollup = fetchStatusCheckRollup(prNumber, runner);
+    const statusCheckRollup = fetchStatusCheckRollup(prNumber, repoOwner, repoName, runner);
     const verdict = await evaluateMergeWorkLadder({
       prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, merged, verifyResult,
     });
@@ -266,7 +275,7 @@ export async function attemptAutoMerge({
   // Only runs when a caller explicitly supplies enforcementDecision — every existing caller
   // (undefined) skips this block entirely, zero behavior change.
   if (enforcementDecision) {
-    const statusCheckRollup = fetchStatusCheckRollup(prNumber, runner);
+    const statusCheckRollup = fetchStatusCheckRollup(prNumber, repoOwner, repoName, runner);
     const verdict = await evaluateMergeWorkLadder({
       prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
     });

--- a/lib/ship/venture-trust-gate.mjs
+++ b/lib/ship/venture-trust-gate.mjs
@@ -133,7 +133,7 @@ export function createVentureTrustGate({
     const trustTier = await fetchTrustTier(repoOwner, repoName, supabase);
     if (trustTier !== 'trusted') return false;
 
-    const statusCheckRollup = fetchStatusCheckRollup ? await fetchStatusCheckRollup(prNumber) : [];
+    const statusCheckRollup = fetchStatusCheckRollup ? await fetchStatusCheckRollup(prNumber, repoOwner, repoName) : [];
     return evaluateVenturePrWitness({
       prNumber,
       workKey,

--- a/scripts/ship-witness-retroactive.mjs
+++ b/scripts/ship-witness-retroactive.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Retroactive mergeWork() P1-P5 witness evaluation for a PR that merged
+ * through a lane outside ship-auto-merge (no telemetry row was ever written).
+ *
+ * QF-20260703-401 (Adam disposition 487dde59). Runs the SAME canonical
+ * evaluator (evaluateMergeWorkLadder) and canonical writer
+ * (writeMergeWitnessTelemetry) that every live lane uses — never a
+ * hand-rolled insert. The row is explicitly marked retroactive via a
+ * distinct `lane` value plus a synthetic META rung carrying the reason, so
+ * it stays honest about being a late, after-the-fact evaluation rather than
+ * a same-day merge-time observation.
+ *
+ * No existing readiness/adoption gauge (scripts/ship-witness-enforce-readiness.mjs,
+ * scripts/gauge-runner.mjs) currently spans venture repos — both are scoped to
+ * PLATFORM_REPOS (rickfelix/ehg, rickfelix/ehg_engineer) only, so a retroactive
+ * venture-repo row is invisible to them today. If a venture-scoped readiness
+ * gauge is built later, it should exclude lane='ship-witness-retroactive-cli'
+ * from same-day-as-merge coverage counts (conservative default).
+ *
+ * Usage: node scripts/ship-witness-retroactive.mjs --repo owner/name --pr N --work-key KEY [--tier standard] [--reason "why"]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { evaluateMergeWorkLadder } from '../lib/ship/merge-witness-ladder.mjs';
+import { writeMergeWitnessTelemetry } from '../lib/ship/merge-witness-telemetry.mjs';
+import { verifyMerged, fetchStatusCheckRollup } from '../lib/ship/auto-merge.mjs';
+import { defaultLookupWorkKeyReal, defaultFetchReviewFinding } from '../lib/ship/venture-trust-gate.mjs';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--repo') out.repo = argv[++i];
+    else if (a === '--pr') out.pr = argv[++i];
+    else if (a === '--work-key') out.workKey = argv[++i];
+    else if (a === '--tier') out.tier = argv[++i];
+    else if (a === '--reason') out.reason = argv[++i];
+  }
+  return out;
+}
+
+export async function runRetroactiveEvaluation({ repo, pr, workKey, tier, reason, supabase }) {
+  const [repoOwner, repoName] = repo.split('/');
+  const prNumber = Number(pr);
+
+  const merged = verifyMerged(prNumber, repoOwner, repoName);
+  const verifyResult = { ok: merged };
+  const statusCheckRollup = fetchStatusCheckRollup(prNumber, repoOwner, repoName);
+
+  const verdict = await evaluateMergeWorkLadder({
+    prNumber,
+    workKey: workKey ?? null,
+    tier: tier || 'standard',
+    lookupWorkKeyReal: (wk) => defaultLookupWorkKeyReal(wk, supabase),
+    fetchReviewFinding: (n) => defaultFetchReviewFinding(n, supabase),
+    statusCheckRollup,
+    merged,
+    verifyResult,
+  });
+
+  verdict.rungs = [
+    ...verdict.rungs,
+    { id: 'META', status: 'retroactive', reason: reason || 'retroactive evaluation via ship-witness-retroactive.mjs CLI (merged outside ship-auto-merge)' },
+  ];
+
+  const written = await writeMergeWitnessTelemetry(supabase, verdict, {
+    repo,
+    lane: 'ship-witness-retroactive-cli',
+  });
+
+  const byId = Object.fromEntries(verdict.rungs.map((r) => [r.id, r.status]));
+  const witnessPass = byId.P1 === 'pass' && byId.P2 === 'pass' && byId.P3 === 'pass';
+
+  return { prNumber, repo, workKey: workKey ?? null, merged, witnessPass, rungs: verdict.rungs, telemetryWritten: written.ok };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.repo || !args.pr) {
+    console.error('Usage: node scripts/ship-witness-retroactive.mjs --repo owner/name --pr N --work-key KEY [--tier standard] [--reason "why"]');
+    process.exit(2);
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const result = await runRetroactiveEvaluation({ ...args, supabase });
+  console.log(JSON.stringify(result, null, 2));
+
+  if (!result.witnessPass) {
+    console.error('VERDICT: witness FAIL — escalate (the merge may be bad on merits).');
+    process.exit(1);
+  }
+  console.log('VERDICT: witness PASS — record healed with an honest retroactive row.');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `scripts/ship-witness-retroactive.mjs`: a CLI that runs the canonical mergeWork() P1-P5 evaluator against current GitHub state for a PR merged outside ship-auto-merge, and writes an honest telemetry row explicitly marked retroactive (distinct `lane` + synthetic META rung) via the canonical `writeMergeWitnessTelemetry` writer — never a hand-rolled insert
- Fixed a discovered bug: `fetchStatusCheckRollup()` had no repo-scoping, so an unscoped `gh pr view` silently reads the ambient-cwd repo's checks instead of the target repo's (same bug class as QF-20260703-197's `verifyMerged` fix). This function backs the real `createVentureTrustGate` gating decision, not just telemetry, so fixed the root cause (repoOwner/repoName params + `-R` flag) and its 3 call sites rather than working around it locally in the new script
- Ran the CLI for `rickfelix/marketlens` PR #6 (SD-MARKETLENS-LEO-ORCH-SPRINT-2026-001-E1): retroactive verdict is **FAIL** — P2 (no `ship_review_findings` row for the PR) is the real gap; P1/P3/P5 all pass. Escalating per Adam disposition 487dde59.

## Test plan
- [x] `npx vitest run tests/unit/ship/auto-merge.test.js tests/unit/ship/auto-merge-witness-integration.test.js tests/unit/ship/venture-trust-gate.test.js` — 74/74 passing, no regressions from the signature change (all existing callers/mocks unaffected)
- [x] Independently verified marketlens PR #6's real CI status via `gh pr view --json statusCheckRollup` (2/2 SUCCESS) before and after the fix, confirming the pre-fix run's "15/21 failed" P3 read was the wrong-repo bug, not a real CI failure
- [x] Deleted the erroneous pre-fix telemetry row and re-ran to write the corrected one

🤖 Generated with [Claude Code](https://claude.com/claude-code)