### PR TITLE
fix(QF-20260703-806): widen assignment pull fallback for ack-before-claim race

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1283,12 +1283,19 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   // consumed-but-unactioned row (read_at set, acknowledged_at NULL, no claim recorded) must still
   // reach the claim step instead of being permanently hidden by an unreadOnly filter.
   let assignment = null;
+  const assignmentSinceIso = new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString();
   try {
-    const msgs = await ws.getMessagesForSession(sb, sessionId, {
-      unackedOnly: true,
-      sinceIso: new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString(),
-    });
+    const msgs = await ws.getMessagesForSession(sb, sessionId, { unackedOnly: true, sinceIso: assignmentSinceIso });
     assignment = (msgs || []).find(m => m.message_type === 'WORK_ASSIGNMENT');
+    if (!assignment) {
+      // QF-20260703-806: the unacked pull can miss a row whose acknowledged_at got stamped by a
+      // path OTHER than a genuine claim outcome (the ack-before-claim race). Claim outcome, not
+      // ack, is the terminal state -- widen to the same bounded window WITHOUT the ack filter.
+      // The terminal/ineligible/tryClaim checks below already re-verify the target SD's LIVE
+      // state and are idempotent, so resurrecting an already-genuinely-resolved row is harmless.
+      const wider = await ws.getMessagesForSession(sb, sessionId, { sinceIso: assignmentSinceIso });
+      assignment = (wider || []).find(m => m.message_type === 'WORK_ASSIGNMENT');
+    }
   } catch { /* fail-open */ }
   if (assignment) {
     const sdKey = extractSdFromAssignment(assignment);

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -289,3 +289,34 @@ describe('resolveCheckin — a stamped-but-unclaimed assignment still reaches th
     }
   });
 });
+
+// QF-20260703-806: live forensics showed a WORK_ASSIGNMENT with BOTH read_at AND acknowledged_at
+// already stamped (the ack-before-claim race QF-476 did not fully close) -- the unackedOnly pull
+// alone excludes it, orphaning the directive. Reproduces the QF's own required sequence: insert a
+// WA already acked by "the checkin generic message pass", run the assignment pull, assert it is
+// CLAIMED, not orphaned. makeFilteringStub's unconditional final branch simulates the widened
+// (no-ack-filter) fallback query the fix adds.
+describe('resolveCheckin — QF-20260703-806: acked-but-never-claimed assignment reaches the claim step', () => {
+  it('no held claim: an already read_at+acknowledged_at-stamped WA is still claimed via the widened fallback pull', async () => {
+    const assignmentSd = 'SD-EHG-ENGINEER-ACKRACE-006';
+    const sb = fakeSb({
+      heldSd: null,
+      sdRow: { status: 'draft', sd_type: 'feature', sd_key: assignmentSd, metadata: {}, target_application: null },
+    });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    // unackedOnly (the primary pull) finds nothing -- this row is already acked; the widened
+    // fallback (neither unackedOnly nor unreadOnly set) is what must resurrect it.
+    ws.getMessagesForSession = makeFilteringStub({
+      id: 'msg-ackraced', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd },
+      read_at: '2026-07-03T16:05:28.000Z', acknowledged_at: '2026-07-03T16:05:28.000Z',
+    });
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).toBe('claimed_assignment');
+      expect(res.sd).toBe(assignmentSd);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- QF-476 fixed the `unreadOnly`→`unackedOnly` gap, but live forensics (2026-07-03 16:03-16:14Z) showed the hole persists: a directed WORK_ASSIGNMENT can get both `read_at` and `acknowledged_at` stamped by a path other than a genuine claim outcome, permanently hiding it from the `unackedOnly` pull.
- Claim outcome, not ack, is the terminal state. When the primary (unacked) pull finds nothing, fall back to the same 24h-bounded window with no ack filter. The existing terminal/ineligible/tryClaim checks downstream are idempotent and re-verify the target SD's live state, so resurrecting an already-genuinely-resolved row is harmless.

## Test plan
- [x] New regression test reproduces the QF's required sequence: a WA with both `read_at` and `acknowledged_at` pre-stamped is still claimed via the widened fallback (`resolveCheckin — QF-20260703-806`)
- [x] Full `worker-checkin-assignment-surfacing.test.js` suite passes (22/22)
- [x] Broader `tests/unit/worker-checkin*` + `tests/unit/fleet/` sweep passes (310/310, no regressions)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>