### PR TITLE
fix(QF-20260703-744): P4 witness rung authoritatively probes exact-repo branch protection

### DIFF
--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -82,6 +82,21 @@ export function detectEnforceAdmins(repoOwner, repoName, runner = defaultRunner)
   return r.stdout.trim() === 'true';
 }
 
+/**
+ * QF-20260703-744: authoritative branch-protection presence check that never
+ * collapses "cannot read" into "disabled" (the bug detectEnforceAdmins's
+ * merge-flow fallback intentionally accepts but a WITNESS rung must not).
+ * @returns {true|false|null} true=confirmed enabled, false=confirmed absent
+ *   (genuine 404 "Branch not protected"), null=not_evaluable (403/scope/network).
+ */
+export function detectBranchProtectionEnabled(repoOwner, repoName, branch = 'main', runner = defaultRunner) {
+  const r = runner(['api', `repos/${repoOwner}/${repoName}/branches/${branch}/protection`]);
+  if (r.code === 0) return true;
+  const stderr = (r.stderr || '').toLowerCase();
+  if (stderr.includes('branch not protected') || stderr.includes('404')) return false;
+  return null;
+}
+
 /** Build the gh pr merge argv. Exported for unit tests. */
 export function buildMergeArgs(prNumber, { admin } = {}) {
   const args = ['pr', 'merge', String(prNumber), '--merge', '--delete-branch'];

--- a/lib/ship/merge-witness-ladder.mjs
+++ b/lib/ship/merge-witness-ladder.mjs
@@ -109,13 +109,27 @@ export function evaluateP3CI({ statusCheckRollup }) {
 }
 
 /**
- * P4 PROTECTION INTEGRITY: always not_applicable until GitHub branch
- * protection (P0) has landed on the platform repos — there is nothing to
- * enforce integrity of yet, and the escapeAuth audit table this rung would
- * eventually check is a separate out-of-scope chairman-gated migration.
+ * P4 PROTECTION INTEGRITY: reports NOT_APPLICABLE (the pre-P0 stub) when no
+ * repo/checker is supplied, preserving every existing caller's behavior.
+ * QF-20260703-744: given {repoOwner, repoName, checkProtection}, probes the
+ * EXACT repo authoritatively instead of a hardcoded platform-wide assumption.
+ * checkProtection(repoOwner, repoName) => true|false|null (null=not_evaluable,
+ * e.g. detectBranchProtectionEnabled from lib/ship/auto-merge.mjs) — a read
+ * failure is NEVER folded into "disabled" (the false-negative this QF closes).
  */
-export function evaluateP4ProtectionIntegrity() {
-  return rung('P4', RUNG_STATUS.NOT_APPLICABLE, 'pre-P0: GitHub branch protection not yet enabled on this repo');
+export function evaluateP4ProtectionIntegrity({ repoOwner, repoName, checkProtection } = {}) {
+  if (!repoOwner || !repoName || typeof checkProtection !== 'function') {
+    return rung('P4', RUNG_STATUS.NOT_APPLICABLE, 'pre-P0: GitHub branch protection not yet enabled on this repo');
+  }
+  let enabled;
+  try {
+    enabled = checkProtection(repoOwner, repoName);
+  } catch (e) {
+    return rung('P4', RUNG_STATUS.NOT_EVALUABLE, `protection check threw: ${e?.message || e}`);
+  }
+  if (enabled === true) return rung('P4', RUNG_STATUS.PASS, `branch protection confirmed enabled on ${repoOwner}/${repoName}`);
+  if (enabled === false) return rung('P4', RUNG_STATUS.FAIL, `branch protection confirmed NOT enabled on ${repoOwner}/${repoName}`);
+  return rung('P4', RUNG_STATUS.NOT_EVALUABLE, `could not read protection state for ${repoOwner}/${repoName} (403/scope/network)`);
 }
 
 /**
@@ -146,6 +160,7 @@ export function evaluateP5PostVerify({ merged, verifyResult }) {
  *   lookupWorkKeyReal?: (workKey: string) => Promise<boolean|null>,
  *   fetchReviewFinding?: (prNumber: number|string) => Promise<{verdict:string}|null>,
  *   statusCheckRollup?: Array, merged?: boolean, verifyResult?: {ok:boolean},
+ *   checkProtection?: (repoOwner: string, repoName: string) => (true|false|null),
  * }} params
  */
 export async function evaluateMergeWorkLadder({
@@ -157,11 +172,14 @@ export async function evaluateMergeWorkLadder({
   statusCheckRollup = [],
   merged = false,
   verifyResult = null,
+  repoOwner,
+  repoName,
+  checkProtection,
 }) {
   const p1 = await evaluateP1Admission({ workKey, lookupWorkKeyReal });
   const p2 = await evaluateP2Witness({ prNumber, tier, fetchReviewFinding });
   const p3 = evaluateP3CI({ statusCheckRollup });
-  const p4 = evaluateP4ProtectionIntegrity();
+  const p4 = evaluateP4ProtectionIntegrity({ repoOwner, repoName, checkProtection });
   const p5 = evaluateP5PostVerify({ merged, verifyResult });
 
   return {

--- a/scripts/ship-witness-retroactive.mjs
+++ b/scripts/ship-witness-retroactive.mjs
@@ -24,7 +24,7 @@ import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { evaluateMergeWorkLadder } from '../lib/ship/merge-witness-ladder.mjs';
 import { writeMergeWitnessTelemetry } from '../lib/ship/merge-witness-telemetry.mjs';
-import { verifyMerged, fetchStatusCheckRollup } from '../lib/ship/auto-merge.mjs';
+import { verifyMerged, fetchStatusCheckRollup, detectBranchProtectionEnabled } from '../lib/ship/auto-merge.mjs';
 import { defaultLookupWorkKeyReal, defaultFetchReviewFinding } from '../lib/ship/venture-trust-gate.mjs';
 
 function parseArgs(argv) {
@@ -57,6 +57,11 @@ export async function runRetroactiveEvaluation({ repo, pr, workKey, tier, reason
     statusCheckRollup,
     merged,
     verifyResult,
+    // QF-20260703-744: probe the EXACT repo's live protection state instead of
+    // leaving P4 as the always-not_applicable pre-P0 stub.
+    repoOwner,
+    repoName,
+    checkProtection: detectBranchProtectionEnabled,
   });
 
   verdict.rungs = [

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -11,6 +11,7 @@ import {
   attemptAutoMerge,
   detectDraftState,
   detectEnforceAdmins,
+  detectBranchProtectionEnabled,
   buildMergeArgs,
   verifyMerged,
   verifyBranchDeleted,
@@ -122,6 +123,31 @@ describe('detectEnforceAdmins', () => {
   it('defaults to false (safer fallback) on API lookup failure', () => {
     const runner = () => ({ code: 1, stdout: '', stderr: 'token scope' });
     expect(detectEnforceAdmins('o', 'r', runner)).toBe(false);
+  });
+});
+
+// QF-20260703-744: the retro witness evaluator's P4 rung needs a check that never
+// collapses a read failure into "disabled" — the false-negative that under-reported
+// coverage on rickfelix/marketlens (protection live, P4 wrongly reported NOT-ENABLED).
+describe('detectBranchProtectionEnabled', () => {
+  it('returns true (enabled) — marketlens-shaped fixture with protection live', () => {
+    const runner = () => ({ code: 0, stdout: '{"required_status_checks":{}}', stderr: '' });
+    expect(detectBranchProtectionEnabled('rickfelix', 'marketlens', 'main', runner)).toBe(true);
+  });
+
+  it('returns false (confirmed disabled) on a genuine 404 "Branch not protected"', () => {
+    const runner = () => ({ code: 1, stdout: '', stderr: 'GraphQL: Branch not protected (branch)' });
+    expect(detectBranchProtectionEnabled('o', 'r', 'main', runner)).toBe(false);
+  });
+
+  it('returns null (not_evaluable) on 403/scope failure — never folded into disabled', () => {
+    const runner = () => ({ code: 1, stdout: '', stderr: 'HTTP 403: Resource not accessible by integration' });
+    expect(detectBranchProtectionEnabled('o', 'r', 'main', runner)).toBeNull();
+  });
+
+  it('returns null (not_evaluable) on a network/unknown failure', () => {
+    const runner = () => ({ code: 1, stdout: '', stderr: 'connection reset' });
+    expect(detectBranchProtectionEnabled('o', 'r', 'main', runner)).toBeNull();
   });
 });
 

--- a/tests/unit/ship/merge-witness-ladder.test.js
+++ b/tests/unit/ship/merge-witness-ladder.test.js
@@ -90,8 +90,31 @@ describe('evaluateP3CI', () => {
 });
 
 describe('evaluateP4ProtectionIntegrity', () => {
-  it('always not_applicable pre-P0', () => {
+  it('not_applicable when no repo/checker is supplied (backward-compat, pre-P0 stub)', () => {
     expect(evaluateP4ProtectionIntegrity().status).toBe(RUNG_STATUS.NOT_APPLICABLE);
+  });
+
+  // QF-20260703-744: regression fixture reproducing the exact false-negative —
+  // protection genuinely live on the repo must report PASS, never a fail/stub.
+  it('pass/enabled — marketlens-shaped fixture with protection confirmed live', () => {
+    const r = evaluateP4ProtectionIntegrity({
+      repoOwner: 'rickfelix', repoName: 'marketlens', checkProtection: () => true,
+    });
+    expect(r.status).toBe(RUNG_STATUS.PASS);
+  });
+
+  it('fail — checker authoritatively confirms protection is NOT enabled', () => {
+    const r = evaluateP4ProtectionIntegrity({
+      repoOwner: 'o', repoName: 'r', checkProtection: () => false,
+    });
+    expect(r.status).toBe(RUNG_STATUS.FAIL);
+  });
+
+  it('not_evaluable — checker returns null (403/scope/network), never reported as disabled', () => {
+    const r = evaluateP4ProtectionIntegrity({
+      repoOwner: 'o', repoName: 'r', checkProtection: () => null,
+    });
+    expect(r.status).toBe(RUNG_STATUS.NOT_EVALUABLE);
   });
 });
 


### PR DESCRIPTION
## Summary
- `evaluateP4ProtectionIntegrity()` was a hardcoded stub that always returned `not_applicable` with a platform-wide "pre-P0" assumption — it never made a live GitHub API call for any specific repo.
- The retroactive witness run for `rickfelix/marketlens` (PR #7) surfaced this as a false NOT-ENABLED report even though branch protection had been live since 15:28Z, under-reporting coverage for the enforce-adoption-readiness gauge and delaying the enforce-flip on stale evidence.
- New `detectBranchProtectionEnabled()` makes an authoritative, repo-scoped `gh api .../protection` call that distinguishes a genuine 404 ("Branch not protected" → disabled) from any other failure (403/scope/network → `not_evaluable`) — a read failure is never folded into "disabled".
- `evaluateP4ProtectionIntegrity()` now accepts an optional `{repoOwner, repoName, checkProtection}`; called with no args (every existing caller) it stays byte-identical to before.
- `scripts/ship-witness-retroactive.mjs` now injects the real checker with the repo it already has in scope.

## Test plan
- [x] New regression fixture reproducing the QF's own required case: a marketlens-shaped repo with protection confirmed live now reports P4 pass/enabled
- [x] `not_evaluable` case (403/network) never reported as `disabled` (the false-negative this closes)
- [x] Backward-compat: `evaluateP4ProtectionIntegrity()` with no args stays `not_applicable`
- [x] Full `tests/unit/ship/` suite passes (140/140, no regressions)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>