### PR TITLE
fix(QF-20260703-780): worker-checkin: terminal-class claim rejection (sd_terminal_status/sd_not_found) never acks a directed WORK_ASSIGNMENT, causing infinite per-tick re-fire

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -84,6 +84,16 @@ const DEFAULT_IDLE_WAKEUP_SECONDS = 600;      // ~10m, matches the tightened fle
 // truly ancient, abandoned assignment while covering the observed hours-long stuck window.
 const ASSIGNMENT_RECENCY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+// QF-20260703-780: closed allowlist of claim_sd RPC errors that mean "this target is
+// PERMANENTLY unclaimable" (as opposed to a transient/retryable conflict like
+// claimed_by_live_peer). The terminal/fitness pre-checks above only resolve
+// strategic_directives_v2, so a QF-keyed or phantom/typo'd-SD-keyed WORK_ASSIGNMENT skips
+// both purge branches and falls through here -- if the RPC itself then reports a terminal
+// verdict, the message must still be acked or it re-fires every tick forever. CLOSED
+// allowlist (never a denylist): claim_sd has gained new transient codes across recent
+// migrations, and an unrecognized error must fail safe to "retry", not "silently purge".
+const TERMINAL_CLAIM_ERRORS = new Set(['sd_terminal_status', 'sd_not_found']);
+
 // SD-LEO-INFRA-WORKER-ANTI-PREMATURE-WINDDOWN-001 (Mode B, the DOMINANT wind-down failure 3/4):
 // the enforceable lever. When a worker holds/just-claimed RANKED claimable work, this directive
 // rides the check-in payload to kill the false "drained" feeling with data and to surface — AT the
@@ -1341,8 +1351,18 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
             ...(effortRec ? { effort_recommendation: effortRec, effort_recommendation_reason: assignment.payload?.effort_recommendation_reason || null } : {}),
             message: `Claimed assigned ${sdKey} via claim_sd.${effortRec ? ` Recommended effort: ${effortRec} (advisory).` : ''} Run: node scripts/sd-start.js ${sdKey}. ${antiWinddownDirective(base.belt_ranked_claimable)}` };
         }
-        // could not claim the assigned SD -> fall through to self-claim
-        base.assignment_claim_error = claimed.error;
+        // QF-20260703-780: a terminal-class RPC verdict means this assignment can NEVER
+        // succeed (unlike e.g. claimed_by_live_peer, which may resolve next tick) -- ack it
+        // now so it stops being re-selected, mirroring the stale_assignment_purged /
+        // assignment_ineligible_purged branches above. Distinct breadcrumb so callers can
+        // tell "permanently resolved" apart from assignment_claim_error's "retryable" meaning.
+        if (TERMINAL_CLAIM_ERRORS.has(claimed.error)) {
+          await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+          base.assignment_claim_terminal_purged = { sd: sdKey, error: claimed.error };
+        } else {
+          // could not claim the assigned SD -> fall through to self-claim
+          base.assignment_claim_error = claimed.error;
+        }
       }
     }
   }

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -68,7 +68,9 @@ function fakeSb({ heldSd, assignmentSd, windDown, sdRow }) {
         order() { return this; }, limit() { return this; },
         maybeSingle() {
           if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker', ...(windDown ? { wind_down: windDown } : {}) }, sd_key: heldSd }, error: null });
-          if (table === 'strategic_directives_v2') return Promise.resolve({ data: sdRow || { status: 'in_progress' }, error: null });
+          // QF-20260703-780: sdRow === null must mean "genuinely no row" (a QF-keyed or
+          // phantom/typo'd-SD-keyed lookup), distinct from sdRow left unspecified (undefined).
+          if (table === 'strategic_directives_v2') return Promise.resolve({ data: sdRow === undefined ? { status: 'in_progress' } : sdRow, error: null });
           return Promise.resolve({ data: null, error: null });
         },
         insert() { return Promise.resolve({ error: null }); },
@@ -347,6 +349,67 @@ describe('resolveCheckin — QF-20260703-806: acked-but-never-claimed assignment
       const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
       expect(res.action).toBe('claimed_assignment');
       expect(res.sd).toBe(assignmentSd);
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});
+
+// QF-20260703-780: a WORK_ASSIGNMENT whose key resolves to zero rows in strategic_directives_v2
+// (a QF key, or a typo'd/deleted SD key) skips both the terminal-purge and ineligibility-purge
+// branches (assignedSdRow is null) and falls to tryClaim(). If the RPC itself then reports a
+// terminal verdict, the message must still be acked -- else it re-fires every tick forever, which
+// is exactly what was observed live (session cb2bfe72, 30+ min / 5+ ticks against a completed QF).
+describe('resolveCheckin — QF-20260703-780: terminal-class claim rejection acks the message', () => {
+  it('a QF-keyed assignment whose target is now completed (sd_terminal_status) is ACKed and purged', async () => {
+    const assignmentSd = 'QF-20260703-197';
+    const sb = fakeSb({ heldSd: null, sdRow: null }); // no strategic_directives_v2 row for a QF key
+    sb.rpc = () => Promise.resolve({ data: { success: false, error: 'sd_terminal_status' }, error: null });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-qf-terminal', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.assignment_claim_terminal_purged).toEqual({ sd: assignmentSd, error: 'sd_terminal_status' });
+      expect(res.assignment_claim_error).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('a phantom/typo\'d SD key whose claim RPC reports sd_not_found is ACKed and purged', async () => {
+    const assignmentSd = 'SD-DOES-NOT-EXIST-999';
+    const sb = fakeSb({ heldSd: null, sdRow: null }); // no strategic_directives_v2 row
+    sb.rpc = () => Promise.resolve({ data: { success: false, error: 'sd_not_found' }, error: null });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-phantom', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.assignment_claim_terminal_purged).toEqual({ sd: assignmentSd, error: 'sd_not_found' });
+      expect(res.assignment_claim_error).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+
+  it('a TRANSIENT claim rejection (claimed_by_live_peer) is NOT acked -- stays retryable', async () => {
+    const assignmentSd = 'SD-EHG-ENGINEER-LIVEPEER-007';
+    const sb = fakeSb({
+      heldSd: null,
+      sdRow: { status: 'draft', sd_type: 'feature', sd_key: assignmentSd, metadata: {}, target_application: null },
+    });
+    sb.rpc = () => Promise.resolve({ data: { success: false, error: 'claimed_by_live_peer', claimed_by: 'other-session' }, error: null });
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-livepeer', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.assignment_claim_error).toBe('claimed_by_live_peer');
+      expect(res.assignment_claim_terminal_purged).toBeUndefined();
     } finally {
       ws.getMessagesForSession = orig;
     }


### PR DESCRIPTION
## Quick-Fix: QF-20260703-780

**Type:** bug
**Severity:** high

### Issue Description
RCA-confirmed (2026-07-03, session cb2bfe72). worker-checkin.cjs's directed-assignment terminal/fitness pre-checks (branch 1: stale_assignment_purged, branch 2: assignment_ineligible_purged, ~line 1312-1332) query strategic_directives_v2 ONLY. A WORK_ASSIGNMENT whose payload.assigned_sd resolves to a QF key (or a typo'd/deleted SD key) gets assignedSdRow=null, so BOTH purge branches are structurally unreachable -- it falls through to branch 3 (tryClaim). If tryClaim's underlying claim_sd RPC correctly refuses because the target is terminal (sd_terminal_status for a completed/deferred SD or completed/cancelled QF; sd_not_found for a phantom key), branch 3 records assignment_claim_error but does NOT ack the message (only acks on claim SUCCESS, line 1335-1336). The unacked message is then re-selected by getMessagesForSession(unackedOnly:true) on every subsequent checkin, re-attempting and re-failing identically forever -- observed live: 30+ minutes, 5+ consecutive ~150s ticks, for a FINISHER assignment (session_coordination id 1aa08b0c) targeting QF-20260703-197, which was in_progress at dispatch time and completed via a different path before this worker's next checkin.

### Steps to Reproduce
1. Coordinator dispatches a directed WORK_ASSIGNMENT whose payload.assigned_sd is a QF key (or a since-deleted/typo'd SD key). 2. Before the target worker claims it, the QF/SD independently reaches a terminal state (completed/cancelled/deferred) via another path (e.g. a FINISHER assignment where CI goes green and a different session merges it). 3. Target worker runs worker-checkin.cjs repeatedly.

### Expected Behavior
A terminal-class claim rejection (claimed.error in {sd_terminal_status, sd_not_found}) should ack+purge the message exactly once, mirroring the existing stale_assignment_purged / assignment_ineligible_purged branches, and record a distinct breadcrumb (e.g. assignment_claim_terminal_purged) so downstream tooling can tell 'permanently resolved' apart from 'retryable'.

### Actual Behavior
assignment_claim_error: sd_terminal_status (or sd_not_found) returned on every checkin call indefinitely; message never leaves the unacked queue; worker silently burns a claim-attempt round-trip every tick with no forward progress, and the recurring error is easily misread as evidence of an unrelated bug (it was initially misattributed to a repo-mismatch on a different, already-acked assignment during this session's investigation).

### Changes
- **Files Changed:** 2
  - scripts/worker-checkin.cjs
  - tests/unit/worker-checkin-assignment-surfacing.test.js
- **LOC:** 94 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol