### PR TITLE
fix(QF-20260703-065): raise UserPromptSubmit hook timeouts 2-3s to 10s

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -245,27 +245,27 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/session-cleanup.js",
-            "timeout": 5
+            "timeout": 10
           },
           {
             "type": "command",
             "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${CLAUDE_PROJECT_DIR}/.claude/set-activity-state.ps1 -State running",
-            "timeout": 2
+            "timeout": 10
           },
           {
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/autonomous-checkpoint.js",
-            "timeout": 3
+            "timeout": 10
           },
           {
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/auto-proceed-resume.js",
-            "timeout": 3
+            "timeout": 10
           },
           {
             "type": "command",
             "command": "node ${CLAUDE_PROJECT_DIR}/scripts/hooks/context-compact-nudge.js",
-            "timeout": 3
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Raises timeout from 2-3s to 10s on all five UserPromptSubmit hooks (session-cleanup, set-activity-state, autonomous-checkpoint, auto-proceed-resume, context-compact-nudge) in `.claude/settings.json`
- Chairman-reported: constant "hook timed out, output discarded" noise on a loaded host, silently no-oping the checkpoint/auto-proceed/compact-nudge hooks
- Matches the fix already applied locally on the shared root (needs upstream commit so resync doesn't revert it) — same pattern as QF-20260703-524

## Test plan
- [x] `node -e "JSON.parse(...)"` — settings.json is valid JSON
- [x] `tests/unit/settings-claude-project-dir.test.js` passes
- [x] `tests/unit/enforcement-hook-registration.test.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)