### PR TITLE
fix(QF-20260703-281): exempt worker-signal.cjs feedback/wakeup-armed from LEARN-129

### DIFF
--- a/scripts/hooks/retry-state-manager.cjs
+++ b/scripts/hooks/retry-state-manager.cjs
@@ -59,6 +59,13 @@ const EXEMPT_PATTERNS = [
   /\bscripts[/\\]adam-advisory\.cjs\b[^\n]*\binbox\b/,
   /\bscripts[/\\]solomon-advisory\.cjs\b[^\n]*\binbox\b/, // SOLOMON_LOOPS inbox-monitor (*/15) — mutating-but-idempotent tick (SD-LEO-INFRA-SOLOMON-CONSULT-001E-C); answer path (send/request) NOT exempt
   /\bscripts[/\\]worker-checkin\.cjs\b/,
+  // QF-20260703-281: the mandated per-tick fleet-worker heartbeat (`worker-signal.cjs feedback
+  // "wakeup-armed ..."`) is a side-effect-free notification re-run every ScheduleWakeup cycle
+  // (~150-200s) -- its only "varying" content is often inside a $(date ...) substitution the
+  // hook hashes BEFORE shell expansion, so 3 ticks collapse to one signature and trip LEARN-129.
+  // Scoped to feedback+wakeup-armed ONLY: worker-signal.cjs's other paths (stuck, harness-bug,
+  // request, solomon-consult) are NOT idempotent standing cadences and must keep the 3-strikes teeth.
+  /\bscripts[/\\]worker-signal\.cjs\s+feedback\b[^\n]*wakeup-armed/,
   /\bscripts[/\\]coordinator-backlog-rank\.mjs\b/,
   /\bscripts[/\\]coordinator-capacity-forecast\.mjs\b/,
   // SD-LEO-INFRA-RCA-ENFORCEMENT-PROGRESS-STALL-NOT-REPETITION-001: apply-migration.js is one

--- a/tests/unit/retry-state-exempt-worker-signal-wakeup-armed.test.js
+++ b/tests/unit/retry-state-exempt-worker-signal-wakeup-armed.test.js
@@ -1,0 +1,59 @@
+/**
+ * QF-20260703-281 — exempt the mandated per-tick worker-signal.cjs feedback/wakeup-armed
+ * heartbeat from LEARN-129's 3-strikes guard.
+ *
+ * RCA (confirmed twice independently, same root cause): signatureFor() hashes the RAW,
+ * pre-shell-expansion Bash command. The heartbeat's only "varying" content is often inside a
+ * $(date ...) substitution the hook never sees expanded, so 3 ticks (~150-200s apart) collapse
+ * to one signature and trip the block on a side-effect-free, idempotent notification.
+ * Scoped narrowly to feedback+wakeup-armed so worker-signal.cjs's other paths (stuck,
+ * harness-bug, request, solomon-consult) keep the 3-strikes teeth.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const require = createRequire(import.meta.url);
+const { isExempt, recordAndCount } = require('../../scripts/hooks/retry-state-manager.cjs');
+
+describe('isExempt — worker-signal.cjs feedback/wakeup-armed heartbeat', () => {
+  it('exempts the wakeup-armed heartbeat regardless of the embedded timestamp/message', () => {
+    expect(isExempt('node scripts/worker-signal.cjs feedback "wakeup-armed +150s at 2026-07-03T18:26:24Z -- idle"')).toBe(true);
+    expect(isExempt('node scripts/worker-signal.cjs feedback "wakeup-armed +150s at $(date -u \'+%Y-%m-%dT%H:%M:%SZ\')"')).toBe(true);
+    expect(isExempt('node scripts\\worker-signal.cjs feedback "wakeup-armed +150s at 2026-07-03T18:26:24Z"')).toBe(true); // windows path sep
+  });
+
+  it('does NOT exempt other worker-signal.cjs paths (scoped match — teeth preserved)', () => {
+    expect(isExempt('node scripts/worker-signal.cjs stuck "blocked on gate X"')).toBe(false);
+    expect(isExempt('node scripts/worker-signal.cjs harness-bug "found a bug"')).toBe(false);
+    expect(isExempt('node scripts/worker-signal.cjs feedback "comms-check ack -- read you"')).toBe(false); // feedback, but not wakeup-armed
+    expect(isExempt('node scripts/worker-signal.cjs request "need review"')).toBe(false);
+  });
+});
+
+describe('recordAndCount honors the wakeup-armed exemption across ticks with a static (unrotated) body', () => {
+  let tmpDir;
+  const SESSION = 'sess-exempt-wakeup-armed';
+  const noReset = async () => null;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'retry-exempt-wakeup-armed-'));
+    process.env.LEO_RETRY_STATE_DIR = tmpDir;
+  });
+  afterEach(() => {
+    delete process.env.LEO_RETRY_STATE_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('4 identical-signature heartbeat ticks (the $(date) collapse case) never accumulate', async () => {
+    // Byte-identical command every tick -- exactly the collapse the RCA reproduced: the
+    // $(date ...) substitution is invisible to the pre-expansion hash, so pre-fix this would
+    // trip LEARN-129 on tick 3. Post-fix, isExempt short-circuits before the counter accrues.
+    const cmd = 'node scripts/worker-signal.cjs feedback "wakeup-armed +150s at $(date -u \'+%Y-%m-%dT%H:%M:%SZ\') -- idle"';
+    for (let i = 0; i < 4; i++) {
+      const r = await recordAndCount(SESSION, null, 'Bash', { command: cmd }, { rcaCheck: noReset, now: 1000 + i * 150_000 });
+      expect(r.attempts).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The mandated per-tick fleet-worker heartbeat (`worker-signal.cjs feedback "wakeup-armed +<N>s at <time>"`) is a side-effect-free notification re-run every ScheduleWakeup cycle (~150-200s).
- `signatureFor()` hashes the RAW, pre-shell-expansion Bash command. When the heartbeat's only varying content is inside a `$(date ...)` substitution, the hook never sees it expanded — 3 ticks collapse to one signature, tripping LEARN-129's 3-strikes guard on an otherwise idempotent standing cadence.
- Confirmed via two independent RCA runs today (same root cause, verified by matching `sha256(raw_command)` byte-for-byte to the blocked signature — this session and a peer session hit it separately).
- Fix: add a narrowly-scoped `EXEMPT_PATTERNS` entry matching `feedback` + `wakeup-armed` specifically, mirroring the existing `worker-checkin.cjs` / `apply-migration.js` precedents for known-idempotent mutating scripts. Scoped narrowly so `worker-signal.cjs`'s other paths (`stuck`, `harness-bug`, `request`, `solomon-consult`) keep the 3-strikes teeth.

## Test plan
- [x] 3 new unit tests in `tests/unit/retry-state-exempt-worker-signal-wakeup-armed.test.js`: exempts wakeup-armed regardless of embedded timestamp (literal or `$(date...)`), does NOT exempt other worker-signal.cjs message types (scoped match), `recordAndCount` never accumulates across 4 identical-signature ticks
- [x] Negative control: reverted the source change, confirmed both new `isExempt`/`recordAndCount` tests fail (exactly reproducing the live block); restored, confirmed green
- [x] Full file + 2 sibling exemption test files (`apply-migration`, `recurring-ticks`): 15/15 passing, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)