### PR TITLE
fix(QF-20260703-363): auto-merge lane P4 rung wired to live branch-protection probe

### DIFF
--- a/lib/ship/auto-merge.mjs
+++ b/lib/ship/auto-merge.mjs
@@ -196,6 +196,11 @@ async function observeMergeWorkLadder({
     const statusCheckRollup = fetchStatusCheckRollup(prNumber, repoOwner, repoName, runner);
     const verdict = await evaluateMergeWorkLadder({
       prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup, merged, verifyResult,
+      // QF-20260703-363: same live P4 probe QF-744 wired into the retro CLI —
+      // this lane must not fall back to the always-not_applicable stub.
+      repoOwner,
+      repoName,
+      checkProtection: (ro, rn) => detectBranchProtectionEnabled(ro, rn, 'main', runner),
     });
     if (supabase) {
       await writeMergeWitnessTelemetry(supabase, verdict, {
@@ -293,6 +298,11 @@ export async function attemptAutoMerge({
     const statusCheckRollup = fetchStatusCheckRollup(prNumber, repoOwner, repoName, runner);
     const verdict = await evaluateMergeWorkLadder({
       prNumber, workKey, tier, lookupWorkKeyReal, fetchReviewFinding, statusCheckRollup,
+      // QF-20260703-363: same live P4 probe as observeMergeWorkLadder below —
+      // the pre-merge enforcement path must see the same authoritative P4 rung.
+      repoOwner,
+      repoName,
+      checkProtection: (ro, rn) => detectBranchProtectionEnabled(ro, rn, 'main', runner),
     });
     const decision = await enforcementDecision({ verdict });
     if (decision?.action === 'block') {

--- a/tests/unit/ship/auto-merge.test.js
+++ b/tests/unit/ship/auto-merge.test.js
@@ -183,6 +183,9 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
     // ladder observes every merge attempt in shadow mode, adding one final
     // read-only pr-view (statusCheckRollup, for the P3 rung) after the merge
     // succeeds. It never affects `r` above — only appends to the call log.
+    // QF-20260703-363: the ladder's P4 rung now also probes live branch
+    // protection (same endpoint detectEnforceAdmins already reads above),
+    // appending one more `api .../protection` call at the end.
     expect(calls.map((c) => c.slice(0, 2))).toEqual([
       ['pr', 'view'],
       ['pr', 'ready'],
@@ -191,6 +194,7 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
       ['pr', 'view'],
       ['pr', 'view'],
       ['pr', 'view'],
+      ['api', 'repos/rickfelix/EHG_Engineer/branches/main/protection'],
     ]);
     const mergeCall = calls.find(argvMatchers.prMerge);
     expect(mergeCall).toContain('--admin');
@@ -239,6 +243,42 @@ describe('attemptAutoMerge — happy path (FR-1, FR-2)', () => {
     expect(r).toEqual({ ok: true, action: 'merged', adminUsed: false });
     const mergeCall = calls.find(argvMatchers.prMerge);
     expect(mergeCall).not.toContain('--admin');
+  });
+});
+
+describe('attemptAutoMerge — mergeWork() P4 rung shares the live probe (QF-20260703-363)', () => {
+  it('reports P4 pass via the SAME detectBranchProtectionEnabled probe the retro CLI uses, not the not_applicable stub', async () => {
+    const { runner } = makeRunner([
+      { match: argvMatchers.prViewIsDraft, result: { stdout: 'false\n' } },
+      { match: argvMatchers.apiProtection, result: { stdout: 'true\n' } },
+      { match: argvMatchers.prMerge, result: { stdout: '' } },
+      { match: argvMatchers.prViewMergedAt, result: { stdout: mergedJson('2026-07-03T18:29:39Z') } },
+      { match: argvMatchers.prViewState, result: { stdout: 'MERGED\n' } },
+    ]);
+    let capturedRungs = null;
+    const witnessSupabase = {
+      from: () => ({
+        insert: (row) => {
+          capturedRungs = row.rungs;
+          return Promise.resolve({ error: null });
+        },
+      }),
+    };
+
+    await attemptAutoMerge({
+      prNumber: 9,
+      repoOwner: 'rickfelix',
+      repoName: 'marketlens',
+      allowExternalMerge: true, // mechanic test — not exercising the C2 trust gate
+      runner,
+      logger: silentLogger,
+      witnessSupabase,
+      lane: 'ship-auto-merge',
+    });
+
+    const p4 = capturedRungs.find((r) => r.id === 'P4');
+    expect(p4.status).toBe('pass');
+    expect(p4.reason).toContain('rickfelix/marketlens');
   });
 });
 


### PR DESCRIPTION
## Summary
- QF-744 added `detectBranchProtectionEnabled()` and wired it into the retroactive witness CLI (`scripts/ship-witness-retroactive.mjs`) but never threaded `checkProtection` through the PRIMARY `ship-auto-merge` lane's own `evaluateMergeWorkLadder()` calls in `lib/ship/auto-merge.mjs`.
- Result: the live auto-merge lane kept reporting P4 `not_applicable` even after branch protection went live on a repo (evidence: PR #9 rickfelix/marketlens, merged 2026-07-03T18:29:39Z, protection live since ~15:28Z).
- Fix: pass `repoOwner`, `repoName`, `checkProtection: detectBranchProtectionEnabled` at both `evaluateMergeWorkLadder()` call sites in `auto-merge.mjs` (shadow-mode observation + optional pre-merge enforcement path) — one shared probe implementation, matching the retro CLI.

## Test plan
- [x] `npx vitest run tests/unit/ship/auto-merge.test.js tests/unit/ship/merge-witness-ladder.test.js` — 72 passed
- [x] `npx vitest run tests/unit/ship/` — 141 passed
- [x] New regression test asserts the live auto-merge lane's P4 rung reports `pass` via the same probe/endpoint the retro CLI uses
- [x] `tsc --noEmit` passes

QF-20260703-363

🤖 Generated with [Claude Code](https://claude.com/claude-code)