### PR TITLE
fix(QF-20260703-883): adam-register.cjs stale-prior retirement + comms drain silently INERT when set/clear_adam_flag RPCs are unapplied

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-486",
+  "sdKey": "QF-20260703-883",
   "workType": "QF",
-  "workKey": "QF-20260703-486",
-  "expectedBranch": "qf/QF-20260703-486",
-  "createdAt": "2026-07-03T18:33:04.382Z",
+  "workKey": "QF-20260703-883",
+  "expectedBranch": "qf/QF-20260703-883",
+  "createdAt": "2026-07-03T19:12:16.217Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -131,26 +131,41 @@ async function registerAdam(supabase, sessionId, opts = {}) {
     // holds even under a race). Residual: two simultaneous STALE restarts can both register briefly
     // — surfaced by the MULTIPLE_ADAMS detector + refused on the next register (eventual convergence).
     const retired = [];
+    const retireFallbackUsed = []; // QF-20260703-883: priors retired via JS-merge (clear_adam_flag RPC absent)
+    let retireBlocked = false;
     if (decision.retire.length) {
       const nowMs2 = Date.now();
       const current = await fetchAllAdams(supabase);
+      const bySessionId = new Map(current.map((a) => [a.session_id, a]));
       const freshNow = new Set(current.filter((a) => isFresh(a.heartbeat_at, nowMs2)).map((a) => a.session_id));
       for (const sid of decision.retire) {
         if (freshNow.has(sid)) continue; // became fresh since the decision — do NOT clear a restarting Adam
         const r = await supabase.rpc('clear_adam_flag', { p_session_id: sid }).then((x) => x, (e) => ({ error: e }));
-        if (!(r && r.error)) retired.push(sid); // best-effort: a failed stale-clear is swept later
+        if (!(r && r.error)) { retired.push(sid); continue; }
+        if (!isMissingFunctionError(r.error)) { retireBlocked = true; continue; } // real error — swept later
+        // RPC absent (migration unapplied) — fall back to the same JS-merge tagging uses, so the prior
+        // is actually retired instead of silently staying role=adam forever (QF-20260703-883).
+        const priorMeta = (bySessionId.get(sid) || {}).metadata || {};
+        const { error: mergeErr } = await supabase.from('claude_sessions')
+          .update({ metadata: { ...priorMeta, role: 'adam_retired', non_fleet: true } }).eq('session_id', sid);
+        if (mergeErr) { retireBlocked = true; continue; }
+        retired.push(sid);
+        retireFallbackUsed.push(sid);
       }
     }
     if (retired.length) action = action === 'tagged_fallback' ? 'tagged_after_retire_fallback' : 'tagged_after_retire';
     // FR-4: re-target the retired prior Adam(s)' unread inbound to this new session (comms survive
-    // the handoff). Fail-open + idempotent; a drain error never fails the registration.
+    // the handoff) — including priors retired via the JS-merge fallback above. Fail-open + idempotent;
+    // a drain error never fails the registration.
     let drained = 0;
     if (retired.length) {
       const d = await drainAdamOutbound(supabase, { newSessionId: sessionId, oldSessionIds: retired });
       drained = (d && d.moved) || 0;
     }
     return { ok: true, action, session_id: sessionId, role: ADAM_ROLE, non_fleet: true, retired, drained,
-      message: `Registered as the single Adam${retired.length ? ` (retired stale prior(s): ${retired.join(', ')}; re-targeted ${drained} inbound row(s))` : ''}${fallbackReason ? ` — fail-soft JS merge (set_adam_flag RPC ${fallbackReason}; apply the chairman-gated migration for atomic writes)` : ' via atomic set_adam_flag'}.` };
+      retire_fallback_used: retireFallbackUsed.length ? retireFallbackUsed : undefined,
+      retire_blocked: retireBlocked || undefined,
+      message: `Registered as the single Adam${retired.length ? ` (retired stale prior(s): ${retired.join(', ')}; re-targeted ${drained} inbound row(s))` : ''}${retireFallbackUsed.length ? ` [clear_adam_flag RPC absent — retired via JS-merge fallback; apply the chairman-gated migration for atomic clears]` : ''}${retireBlocked ? ' — WARNING: a stale prior could NOT be retired (see retire_blocked)' : ''}${fallbackReason ? ` — fail-soft JS merge (set_adam_flag RPC ${fallbackReason}; apply the chairman-gated migration for atomic writes)` : ' via atomic set_adam_flag'}.` };
   }
 
   const { alreadyTagged, merged } = computeAdamTag(row.metadata);

--- a/scripts/adam-register.test.js
+++ b/scripts/adam-register.test.js
@@ -1,9 +1,19 @@
 // Tests for SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-A
 // scripts/adam-register.cjs — idempotent verify-first Adam role tagger.
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const { computeAdamTag, registerAdam, ADAM_ROLE } = require('./adam-register.cjs');
+
+// These tests exercise the legacy (flag-OFF) registerAdam path, but the real .env sets
+// ROLE_HANDOFF_ADAM_V1=on for the FR-3 single-Adam guard — force it off here so the suite
+// isn't at the mercy of ambient env (mirrors tests/unit/coordination/adam-singleton.test.js).
+const PRIOR_ROLE_HANDOFF_ADAM_V1 = process.env.ROLE_HANDOFF_ADAM_V1;
+beforeEach(() => { delete process.env.ROLE_HANDOFF_ADAM_V1; });
+afterEach(() => {
+  if (PRIOR_ROLE_HANDOFF_ADAM_V1 === undefined) delete process.env.ROLE_HANDOFF_ADAM_V1;
+  else process.env.ROLE_HANDOFF_ADAM_V1 = PRIOR_ROLE_HANDOFF_ADAM_V1;
+});
 
 describe('computeAdamTag (pure)', () => {
   it('tags an untagged metadata and preserves existing keys', () => {

--- a/scripts/adam-register.test.js
+++ b/scripts/adam-register.test.js
@@ -1,7 +1,7 @@
 // Tests for SD-LEO-INFRA-ADAM-ROLE-FORMALIZATION-001-A
 // scripts/adam-register.cjs — idempotent verify-first Adam role tagger.
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 const { computeAdamTag, registerAdam, ADAM_ROLE } = require('./adam-register.cjs');
 

--- a/tests/unit/coordination/adam-singleton.test.js
+++ b/tests/unit/coordination/adam-singleton.test.js
@@ -228,6 +228,24 @@ describe('registerAdam (FR-3 flag-gated single-Adam guard)', () => {
     expect(calls.rpc.map((c) => c.fn)).toEqual(expect.arrayContaining(['clear_adam_flag', 'set_adam_flag']));
     expect(calls.drainSelect).toBe(1); // FR-4 drain ran (re-targeted old->new)
   });
+
+  // QF-20260703-883: clear_adam_flag RPC absent (migration unapplied) must NOT silently leave
+  // retired:[] forever — falls back to the JS-merge used for tagging, and still drains the prior's
+  // stranded inbound. Loud reporting via retire_fallback_used (no more silent no-op).
+  it('flag ON: RPC absent + STALE prior => JS-merge retire fallback (no silent retired:[])', async () => {
+    process.env.ROLE_HANDOFF_ADAM_V1 = 'on';
+    const { supabase, calls } = regStub({
+      allAdams: [{ session_id: 'staleprior', heartbeat_at: fresh(999), metadata: { role: 'adam', non_fleet: true } }],
+      rpcError: { code: 'PGRST202', message: 'Could not find the function' },
+      drainRows: [{ id: 'm1' }],
+    });
+    const r = await registerAdam(supabase, 'self', { nowMs: NOW });
+    expect(r).toMatchObject({ ok: true, action: 'tagged_after_retire_fallback', drained: 1 });
+    expect(r.retired).toEqual(['staleprior']);
+    expect(r.retire_fallback_used).toEqual(['staleprior']);
+    expect(r.retire_blocked).toBeUndefined();
+    expect(calls.drainSelect).toBe(1); // FR-4 drain still ran for the JS-merge-retired prior
+  });
 });
 
 describe('drainAdamOutbound (FR-4 idempotent re-target)', () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260703-883

**Type:** bug
**Severity:** medium

### Issue Description
adam-register.cjs retires stale prior Adam sessions via the clear_adam_flag RPC best-effort (line ~140); with the chairman-gated migration unapplied the rpc fails silently, so retired:[] ALWAYS, the output still says 'Registered as the single Adam', stale adam tags accumulate (one sat from 06-24 to 07-03), and drainAdamOutbound never runs - 1020 unacked inbound rows were found stranded on the dead prior Adam session on 2026-07-03 and had to be re-targeted by hand. Fix (code-only, no schema): (a) when the RPC path is unavailable AND stale priors exist, fall back to the same JS-merge used for tagging to retire them (role=adam_retired, non_fleet preserved) instead of skipping; (b) run drainAdamOutbound for JS-merge-retired priors too; (c) report loudly in the JSON output (retire_blocked/fallback_used fields) instead of silent retired:[]. The RPC migration itself is a SEPARATE chairman-gated item - do not bundle DDL here.


### Expected Behavior
Register retires stale priors and drains their inbound even without the RPCs, and says so explicitly

### Actual Behavior
retired:[] always; stale tags + stranded messages accumulate silently

### Changes
- **Files Changed:** 4
  - .worktree.json
  - scripts/adam-register.cjs
  - scripts/adam-register.test.js
  - tests/unit/coordination/adam-singleton.test.js
- **LOC:** 51 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol