### PR TITLE
fix(QF-20260703-151): directed-assignment claim path fails closed on fitness-fetch error

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1314,16 +1314,25 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       // terminal status (completed/cancelled/deferred) AFTER the assignment was created — the
       // in_progress->terminal race. claim_sd now refuses terminal claims, but a never-ACKed
       // assignment would re-fire every tick (the "retried on every tick" symptom), so ACK it
-      // here and fall through to self-claim. Fail-open: a query error skips the purge and lets
-      // the normal claim path (now guarded by the RPC) handle it.
+      // here and fall through to self-claim.
       let terminalStatus = null;
       let assignedSdRow = null;
+      let assignedSdFetchFailed = false;
       try {
-        const { data: tgt } = await sb.from('strategic_directives_v2')
+        const { data: tgt, error: tgtErr } = await sb.from('strategic_directives_v2')
           .select('status, sd_type, sd_key, metadata, target_application').eq('sd_key', sdKey).maybeSingle();
-        assignedSdRow = tgt || null;
-        if (tgt && ['completed', 'cancelled', 'deferred'].includes(tgt.status)) terminalStatus = tgt.status;
-      } catch { /* fail-open: leave terminalStatus null, attempt the claim below */ }
+        // QF-20260703-151: a query ERROR is distinct from a genuine not-found and must NOT be
+        // silently discarded — the prior code destructured only `data`, so a failed fetch left
+        // assignedSdRow=null, which the ineligibleReason ternary below then treated as "nothing
+        // to check" (fail-open), admitting an orchestrator-parent / repo-mismatched SD straight
+        // through to tryClaim (live-hit: SD-EHG-PRODUCT-UIUX-REMEDIATION-001, audit flag c71c3a54).
+        if (tgtErr) {
+          assignedSdFetchFailed = true;
+        } else {
+          assignedSdRow = tgt || null;
+          if (tgt && ['completed', 'cancelled', 'deferred'].includes(tgt.status)) terminalStatus = tgt.status;
+        }
+      } catch { assignedSdFetchFailed = true; }
       // QF-20260703-091 (RCA-confirmed): mirror the self-claim paths' shared fitness/premise gate
       // (classifyDispatchIneligibility, incl. the repo-match axis) onto this DIRECTED-assignment
       // path too. Previously only sd-start.js caught a repo-mismatched directed assignment, AFTER
@@ -1334,7 +1343,12 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
       const ineligibleReason = (!terminalStatus && assignedSdRow)
         ? classifyDispatchIneligibility(assignedSdRow, { cwd: process.cwd() })
         : null;
-      if (terminalStatus) {
+      if (assignedSdFetchFailed) {
+        // QF-20260703-151: FAIL CLOSED — could not confirm fitness for this assignment. Never
+        // ack (the assignment stays live for a retry once the transient fetch issue clears) and
+        // never fall through to tryClaim on an unconfirmed target.
+        base.assignment_claim_error = 'fitness_check_query_failed';
+      } else if (terminalStatus) {
         await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
         base.stale_assignment_purged = { sd: sdKey, status: terminalStatus };
       } else if (ineligibleReason) {

--- a/tests/unit/worker-checkin-assignment-surfacing.test.js
+++ b/tests/unit/worker-checkin-assignment-surfacing.test.js
@@ -265,6 +265,43 @@ describe('resolveCheckin — directed WORK_ASSIGNMENT claim path skips an inelig
       ws.getMessagesForSession = orig;
     }
   });
+
+  // QF-20260703-151: a query ERROR fetching the assigned SD's fitness row must fail CLOSED —
+  // never silently discard `error` and fall through to tryClaim as if nothing needed checking
+  // (the bug that let an orchestrator-parent / repo-mismatched SD get claimed, live-hit:
+  // SD-EHG-PRODUCT-UIUX-REMEDIATION-001).
+  it('a query error fetching the assignment target fails CLOSED — no claim, no ack, retryable', async () => {
+    const assignmentSd = 'SD-FETCH-ERROR-001';
+    const sb = {
+      rpc: () => Promise.resolve({ data: { success: true }, error: null }),
+      from(table) {
+        return {
+          select() { return this; }, eq() { return this; }, gte() { return this; },
+          order() { return this; }, limit() { return this; },
+          maybeSingle() {
+            if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: null }, error: null });
+            if (table === 'strategic_directives_v2') return Promise.resolve({ data: null, error: { message: 'connection reset' } });
+            return Promise.resolve({ data: null, error: null });
+          },
+          insert() { return Promise.resolve({ error: null }); },
+          update() { return { eq() { return Promise.resolve({ error: null }); } }; },
+        };
+      },
+    };
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [{ id: 'msg-fetch-error', message_type: 'WORK_ASSIGNMENT', payload: { assigned_sd: assignmentSd } }];
+    try {
+      const res = await resolveCheckin(sb, 'sess-idle', { getCoordinator: async () => null });
+      expect(res.action).not.toBe('claimed_assignment');
+      expect(res.sd).not.toBe(assignmentSd);
+      expect(res.assignment_claim_error).toBe('fitness_check_query_failed');
+      expect(res.assignment_ineligible_purged).toBeUndefined();
+      expect(res.stale_assignment_purged).toBeUndefined();
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
 });
 
 // QF-20260703-476: a WORK_ASSIGNMENT whose read_at got stamped by some other delivery path


### PR DESCRIPTION
## Summary
- The DIRECTED WORK_ASSIGNMENT claim path in `scripts/worker-checkin.cjs` destructured only `{ data: tgt }` from the fitness-check query against `strategic_directives_v2`, silently discarding `error`.
- On a query failure, `assignedSdRow` ended up `null`, which the `ineligibleReason` ternary treated as "nothing to check" (fail-open) — so `classifyDispatchIneligibility` (orchestrator-parent / repo-mismatch / terminal-premise) was skipped entirely and the assignment fell straight through to `tryClaim`.
- Live-hit: `SD-EHG-PRODUCT-UIUX-REMEDIATION-001` (target_app=EHG, orchestrator parent) was claimed by an EHG_Engineer-based worker; the worker had to self-signal UNFIT after the fact (audit flag c71c3a54).

## Fix
- Capture the query's `error` explicitly. On error, fail **CLOSED**: don't ack the assignment (stays live for retry once the transient issue clears) and don't fall through to `tryClaim`.
- A genuine not-found (no error, no row) is unaffected — that still reaches `tryClaim` as before, where `claim_sd`'s own existence guard handles it.

## Test plan
- [x] New regression test: a query error on the fitness fetch skips the claim, skips both purge paths, and surfaces a retryable `assignment_claim_error` (not a silent fail-open)
- [x] `npx vitest run tests/unit/worker-checkin-assignment-surfacing.test.js tests/unit/harness/claim-terminal-status-guard.test.js` — 37 passed
- [x] `npx vitest run tests/unit/worker-checkin*.test.js tests/unit/claim-eligibility*.test.js tests/dispatch-eligibility-convergence.test.js tests/unit/fleet/ tests/unit/scripts/claim-lifecycle-hardening.test.js` — 376 passed
- [x] `node -c scripts/worker-checkin.cjs` syntax check passes

QF-20260703-151

🤖 Generated with [Claude Code](https://claude.com/claude-code)