### PR TITLE
fix(QF-20260703-130): resolve-sd-workdir.js worktree branch resolver matches a descendant's branch via unanchored prefix glob

### DIFF
--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -280,50 +280,25 @@ function recoverOrphanWorktree(sdKey, worktreePath, repoRoot, worktreesDir, opts
   return { path: worktreePath, branch, created: true, recovered: 'force-add' };
 }
 
-/**
- * Resolve an already-existing feature branch for sdKey, or null if none exists.
- * Exact match FIRST: SD-key namespaces are hierarchical (a child key like "-F1" is
- * an alphanumeric continuation of a parent key like "-F"), so an unanchored
- * `feat/${sdKey}*` glob can match a DESCENDANT's branch instead of the SD's own,
- * stealing its worktree. QF-20260703-130. The variant-discovery fallback (kept for
- * branches with a non-alphanumeric suffix, e.g. renamed variants) is anchored on a
- * separator so an alphanumeric continuation can never match.
- */
+// Exact-ref match first: an unanchored glob can match a DESCENDANT's branch
+// (e.g. "-F1") instead of the SD's own ("-F"). QF-20260703-130.
 function resolveExistingBranch(sdKey, repoRoot) {
+  const opts = { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' };
   try {
-    execSync(`git show-ref --verify --quiet refs/heads/feat/${sdKey}`, {
-      cwd: repoRoot, stdio: 'pipe'
-    });
+    execSync(`git show-ref --verify --quiet refs/heads/feat/${sdKey}`, { cwd: repoRoot, stdio: 'pipe' });
     return `feat/${sdKey}`;
   } catch { /* no exact local branch */ }
-
   try {
-    const branches = execSync('git branch --list "feat/' + sdKey + '[-._]*"', {
-      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
-    }).trim();
-    if (branches) {
-      return branches.split('\n')[0].replace(/^[*+]?\s*/, '').trim();
-    }
+    const branches = execSync(`git branch --list "feat/${sdKey}[-._]*"`, opts).trim();
+    if (branches) return branches.split('\n')[0].replace(/^[*+]?\s*/, '').trim();
   } catch { /* no match */ }
-
   try {
-    const remoteExact = execSync(`git ls-remote --heads origin "feat/${sdKey}"`, {
-      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
-    }).trim();
-    if (remoteExact) {
-      return `feat/${sdKey}`;
-    }
+    if (execSync(`git ls-remote --heads origin "feat/${sdKey}"`, opts).trim()) return `feat/${sdKey}`;
   } catch { /* no exact remote branch */ }
-
   try {
-    const remote = execSync('git ls-remote --heads origin "feat/' + sdKey + '[-._]*"', {
-      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
-    }).trim();
-    if (remote) {
-      return remote.split('\n')[0].split('\t')[1].replace('refs/heads/', '');
-    }
+    const remote = execSync(`git ls-remote --heads origin "feat/${sdKey}[-._]*"`, opts).trim();
+    if (remote) return remote.split('\n')[0].split('\t')[1].replace('refs/heads/', '');
   } catch { /* no match */ }
-
   return null;
 }
 

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -281,6 +281,53 @@ function recoverOrphanWorktree(sdKey, worktreePath, repoRoot, worktreesDir, opts
 }
 
 /**
+ * Resolve an already-existing feature branch for sdKey, or null if none exists.
+ * Exact match FIRST: SD-key namespaces are hierarchical (a child key like "-F1" is
+ * an alphanumeric continuation of a parent key like "-F"), so an unanchored
+ * `feat/${sdKey}*` glob can match a DESCENDANT's branch instead of the SD's own,
+ * stealing its worktree. QF-20260703-130. The variant-discovery fallback (kept for
+ * branches with a non-alphanumeric suffix, e.g. renamed variants) is anchored on a
+ * separator so an alphanumeric continuation can never match.
+ */
+function resolveExistingBranch(sdKey, repoRoot) {
+  try {
+    execSync(`git show-ref --verify --quiet refs/heads/feat/${sdKey}`, {
+      cwd: repoRoot, stdio: 'pipe'
+    });
+    return `feat/${sdKey}`;
+  } catch { /* no exact local branch */ }
+
+  try {
+    const branches = execSync('git branch --list "feat/' + sdKey + '[-._]*"', {
+      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
+    }).trim();
+    if (branches) {
+      return branches.split('\n')[0].replace(/^[*+]?\s*/, '').trim();
+    }
+  } catch { /* no match */ }
+
+  try {
+    const remoteExact = execSync(`git ls-remote --heads origin "feat/${sdKey}"`, {
+      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
+    }).trim();
+    if (remoteExact) {
+      return `feat/${sdKey}`;
+    }
+  } catch { /* no exact remote branch */ }
+
+  try {
+    const remote = execSync('git ls-remote --heads origin "feat/' + sdKey + '[-._]*"', {
+      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
+    }).trim();
+    if (remote) {
+      return remote.split('\n')[0].split('\t')[1].replace('refs/heads/', '');
+    }
+  } catch { /* no match */ }
+
+  return null;
+}
+
+/**
  * Create a new worktree for the SD
  */
 function createWorktree(sdKey, repoRoot, opts = {}) {
@@ -331,34 +378,8 @@ function createWorktree(sdKey, repoRoot, opts = {}) {
   // preserved by `createQuotaExceededError` inside the helper.
   enforceWorktreeQuota(repoRoot, worktreesDir);
 
-  // Look for an existing feature branch
-  const _branchPrefix = `feat/${sdKey}`;
-  let branch = null;
-
-  try {
-    const branches = execSync('git branch --list "feat/' + sdKey + '*"', {
-      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
-    }).trim();
-    if (branches) {
-      branch = branches.split('\n')[0].replace(/^[*+]?\s*/, '').trim();
-    }
-  } catch { /* no match */ }
-
-  if (!branch) {
-    // Check remote
-    try {
-      const remote = execSync('git ls-remote --heads origin "feat/' + sdKey + '*"', {
-        cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
-      }).trim();
-      if (remote) {
-        branch = remote.split('\n')[0].split('\t')[1].replace('refs/heads/', '');
-      }
-    } catch { /* no match */ }
-  }
-
-  if (!branch) {
-    branch = `feat/${sdKey}`;
-  }
+  // Look for an existing feature branch (exact match first — QF-20260703-130).
+  const branch = resolveExistingBranch(sdKey, repoRoot) || `feat/${sdKey}`;
 
   // Sanitize branch name before git operations (SD-LEO-INFRA-AUTO-WORKTREE-START-001 US-004)
   const branchCheck = sanitizeBranchName(branch);
@@ -753,4 +774,4 @@ if (isMainScript) {
   });
 }
 
-export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot };
+export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot, resolveExistingBranch };

--- a/tests/unit/resolve-sd-workdir/branch-resolution-prefix-collision.test.js
+++ b/tests/unit/resolve-sd-workdir/branch-resolution-prefix-collision.test.js
@@ -1,0 +1,64 @@
+/**
+ * Regression test for QF-20260703-130: the worktree branch resolver used an
+ * unanchored `feat/${sdKey}*` glob, so a parent SD key that is a strict alphanumeric
+ * prefix of a descendant's key (e.g. "-F" vs "-F1") could resolve to the descendant's
+ * branch instead of its own.
+ *
+ * Uses os.tmpdir + git init for fixture repos — no main-repo mutations.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { resolveExistingBranch } from '../../../scripts/resolve-sd-workdir.js';
+
+function createFixtureRepo() {
+  const dir = join(tmpdir(), `wt-prefix-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+  writeFileSync(join(dir, 'README.md'), '# test');
+  execSync('git add . && git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+  return dir;
+}
+
+describe('resolveExistingBranch — prefix-collision safety (QF-20260703-130)', () => {
+  it('does not match a descendant\'s branch when only the descendant exists', () => {
+    const repo = createFixtureRepo();
+    try {
+      // Only the CHILD's branch exists — the parent's own branch was never created.
+      execSync('git branch feat/SD-TEST-F1', { cwd: repo, stdio: 'pipe' });
+
+      const resolved = resolveExistingBranch('SD-TEST-F', repo);
+
+      expect(resolved, 'parent should get a fresh branch, not match the descendant').toBeNull();
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('finds an exact-match branch even when a descendant branch also exists', () => {
+    const repo = createFixtureRepo();
+    try {
+      execSync('git branch feat/SD-TEST-G', { cwd: repo, stdio: 'pipe' });
+      execSync('git branch feat/SD-TEST-G1', { cwd: repo, stdio: 'pipe' });
+
+      expect(resolveExistingBranch('SD-TEST-G', repo)).toBe('feat/SD-TEST-G');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('still finds a separator-suffixed variant branch', () => {
+    const repo = createFixtureRepo();
+    try {
+      execSync('git branch feat/SD-TEST-H.retry', { cwd: repo, stdio: 'pipe' });
+
+      expect(resolveExistingBranch('SD-TEST-H', repo)).toBe('feat/SD-TEST-H.retry');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260703-130

**Type:** bug
**Severity:** high

### Issue Description
git branch --list "feat/${sdKey}*" at resolve-sd-workdir.js:339,350 is an unanchored prefix glob. When claiming a mid-hierarchy SD whose key is a strict prefix of a descendant's key (e.g. -F vs -F1) and the parent's own branch doesn't exist yet while the child's does, the glob matches the child's branch and git worktree add tries to check out a branch already in use by the child's own worktree, failing worktree creation. Confirmed live on SD-MARKETLENS-LEO-ORCH-SPRINT-2026-001-F (glob returned only feat/SD-MARKETLENS-LEO-ORCH-SPRINT-2026-001-F1). Fix: resolve by exact ref match first (git show-ref --verify refs/heads/feat/${sdKey} and origin equivalent); only fall through to fresh-branch creation (feat/${sdKey}) if no exact match. If variant discovery must remain, anchor it with a non-alphanumeric separator (feat/${sdKey}[-._]*) so alphanumeric continuations like -F1 cannot match -F. RCA agent aad309476f047cee8 confirmed root cause empirically (5-Whys, confidence 0.97).

### Steps to Reproduce
Claim a draft SD whose key is a strict alphanumeric prefix of an already-claimed/in-flight descendant SD's key (e.g. parent -F, child -F1 with an existing checked-out branch), via node scripts/sd-start.js <parent-key>

### Expected Behavior
Worktree created on the parent's own branch feat/<parent-key> (fresh branch since parent was never worked before)

### Actual Behavior
git worktree add attempts to check out feat/<child-key> (e.g. -F1's branch) because of the unanchored glob match, fails since that branch is already checked out in the child's own worktree, and sd-start.js releases the claim

### Changes
- **Files Changed:** 2
  - scripts/resolve-sd-workdir.js
  - tests/unit/resolve-sd-workdir/branch-resolution-prefix-collision.test.js
- **LOC:** 93 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Fixed unanchored prefix glob in resolveExistingBranch (extracted from createWorktree) per RCA aad309476f047cee8: exact-ref match now checked first via git show-ref/ls-remote before falling back to a separator-anchored variant glob, so an alphanumeric child key (e.g. -F1) can never match a shorter parent key (-F). Added 3-case vitest regression suite.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol