### PR TITLE
fix(QF-20260703-314): checkin model/effort merge-write no longer clobbers concurrent metadata

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1155,10 +1155,18 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
   // call further down reads sessionMetadata, so this call's own fresh values must land here first).
   // Fail-open: a persist error never blocks the check-in itself.
   try {
-    const { metadata: mergedMetadata, changed } = mergeCheckinModelEffort(sessionMetadata, { model: cliModel, effort: cliEffort });
+    const { changed } = mergeCheckinModelEffort(sessionMetadata, { model: cliModel, effort: cliEffort });
     if (changed) {
-      sessionMetadata = mergedMetadata;
-      await sb.from('claude_sessions').update({ metadata: mergedMetadata }).eq('session_id', sessionId);
+      // QF-20260703-314: re-read metadata FRESH immediately before writing instead of persisting
+      // the whole step-2 snapshot merged in-memory -- a concurrent writer (e.g.
+      // assign-fleet-identities.cjs setting fleet_identity) landing between step 2's read and this
+      // write was otherwise silently clobbered by this whole-object update (mechanism (c) of the
+      // callsign-collision chain, backlog cfea31a7: worker 3c40949b lost Charlie/red within 9min).
+      const { data: freshRow } = await sb.from('claude_sessions').select('metadata').eq('session_id', sessionId).maybeSingle();
+      const freshBase = (freshRow && freshRow.metadata) || sessionMetadata || {};
+      const { metadata: freshMerged } = mergeCheckinModelEffort(freshBase, { model: cliModel, effort: cliEffort });
+      sessionMetadata = freshMerged;
+      await sb.from('claude_sessions').update({ metadata: freshMerged }).eq('session_id', sessionId);
     }
   } catch { /* fail-open: check-in proceeds with whatever metadata was already read */ }
 

--- a/tests/unit/worker-checkin-metadata-race.test.js
+++ b/tests/unit/worker-checkin-metadata-race.test.js
@@ -1,0 +1,67 @@
+/**
+ * QF-20260703-314: resolveCheckin's --model/--effort merge-write (step 2c) must not clobber
+ * a concurrent writer (e.g. scripts/assign-fleet-identities.cjs setting metadata.fleet_identity)
+ * that lands between step 2's initial read and the merge-write. Root cause: the write persisted
+ * a metadata object built from the step-2 snapshot instead of re-reading fresh immediately
+ * before writing -- backlog cfea31a7 (worker 3c40949b lost its Charlie/red identity within 9min
+ * of assignment).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { resolveCheckin } = require('../../scripts/worker-checkin.cjs');
+
+function fakeSbWithConcurrentIdentityWrite() {
+  let claudeSessionsReads = 0;
+  const updates = [];
+  return {
+    updates,
+    rpc: () => Promise.resolve({ data: { success: true }, error: null }),
+    from(table) {
+      return {
+        select() { return this; }, eq() { return this; }, gte() { return this; },
+        order() { return this; }, limit() { return this; },
+        maybeSingle() {
+          if (table === 'claude_sessions') {
+            claudeSessionsReads++;
+            if (claudeSessionsReads === 1) {
+              // step-2 read: no model/effort, no fleet_identity yet
+              return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: null }, error: null });
+            }
+            // step-2c fresh re-read: a concurrent writer set fleet_identity since step 2
+            return Promise.resolve({
+              data: { metadata: { role: 'worker', fleet_identity: { callsign: 'Charlie', color: 'red' } }, sd_key: null },
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert() { return Promise.resolve({ error: null }); },
+        update(payload) {
+          return { eq() { updates.push({ table, payload }); return Promise.resolve({ error: null }); } };
+        },
+      };
+    },
+  };
+}
+
+describe('resolveCheckin — model/effort merge-write re-reads fresh before writing (QF-20260703-314)', () => {
+  it('preserves a fleet_identity set concurrently between the step-2 read and the merge-write', async () => {
+    const sb = fakeSbWithConcurrentIdentityWrite();
+    const ws = require('../../lib/fleet/worker-status.cjs');
+    const orig = ws.getMessagesForSession;
+    ws.getMessagesForSession = async () => [];
+    try {
+      await resolveCheckin(sb, 'sess-race', { getCoordinator: async () => null, model: 'sonnet', effort: 'high' });
+      const metaUpdate = sb.updates.find(
+        (u) => u.table === 'claude_sessions' && u.payload.metadata && u.payload.metadata.model === 'sonnet'
+      );
+      expect(metaUpdate).toBeTruthy();
+      // The bug: this would be undefined (clobbered) because the write used the step-2
+      // snapshot, which predates the concurrent fleet_identity assignment.
+      expect(metaUpdate.payload.metadata.fleet_identity).toEqual({ callsign: 'Charlie', color: 'red' });
+    } finally {
+      ws.getMessagesForSession = orig;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `resolveCheckin`'s step 2c (`--model`/`--effort` self-report merge in `scripts/worker-checkin.cjs`) built its written metadata object from the **stale step-2 snapshot** — read at the top of the function, several `await`s earlier — then whole-object-overwrote `claude_sessions.metadata` whenever the merge changed anything.
- Any key a concurrent writer set on the same row in that window (e.g. `scripts/assign-fleet-identities.cjs`'s `metadata.fleet_identity`) was silently wiped.
- Live-hit (backlog `cfea31a7`): worker `3c40949b` lost its Charlie/red identity within 9 minutes of assignment — mechanism (c) of the callsign-collision chain.

## Fix
- When the merge actually changes something, re-read `claude_sessions.metadata` **fresh** immediately before writing and merge the CLI-derived model/effort into that fresh copy instead of the step-2 snapshot.
- Matches the existing "re-read, never clobber" convention already documented and used by `assignFleetIdentityAtCheckin` a few lines down in the same file.

## Test plan
- [x] New regression test (`tests/unit/worker-checkin-metadata-race.test.js`): a concurrent `fleet_identity` write landing between the step-2 read and the merge-write must survive the metadata update
- [x] Confirmed the new test **fails** against the pre-fix code (`git stash` the fix, re-run — assertion fails as expected) and **passes** with the fix
- [x] `npx vitest run tests/unit/worker-checkin*.test.js tests/unit/fleet/` — 318 passed
- [x] `node -c scripts/worker-checkin.cjs` syntax check passes

QF-20260703-314

🤖 Generated with [Claude Code](https://claude.com/claude-code)