### PR TITLE
fix(QF-20260703-040): re-affirm SET_IDENTITY on drift, not just new assignment

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -224,6 +224,20 @@ function reserveParkedIdentities(usedCallsigns, usedColors, recentSessions, acti
   return { usedCallsigns, usedColors };
 }
 
+// QF-20260703-040: SET_IDENTITY was only ever sent to a NEWLY-assigning worker, so a session whose
+// identity changed via some OTHER path (e.g. dedupeAssignedCallsigns demoting it but the resulting
+// message never being consumed by a dead/dormant session) kept a stale local statusline file
+// forever — the chairman saw 3x "Charlie". Compares the CURRENTLY-desired identity against the
+// last one actually broadcast (metadata.fleet_identity_last_sent, distinct from fleet_identity
+// itself so a partially-failed send is retried next tick) — true means re-send is due.
+function identityNeedsRebroadcast(worker, expectedIdentity) {
+  const lastSent = worker?.metadata?.fleet_identity_last_sent;
+  if (!lastSent) return true;
+  return lastSent.callsign !== expectedIdentity.callsign
+    || lastSent.color !== expectedIdentity.color
+    || lastSent.display_name !== expectedIdentity.display_name;
+}
+
 const ANSI = {
   red: '\x1b[31m', blue: '\x1b[34m', green: '\x1b[32m', yellow: '\x1b[33m',
   purple: '\x1b[35m', orange: '\x1b[38;5;208m', pink: '\x1b[38;5;213m', cyan: '\x1b[36m',
@@ -407,15 +421,20 @@ async function main() {
 
   // nextAvailable is now module-scoped (hoisted above) and shared with worker-checkin.cjs.
 
-  // Refresh display_name for assigned workers whose SD changed
+  // Refresh display_name for assigned workers whose SD changed, AND re-affirm SET_IDENTITY to
+  // ANY assigned worker whose current identity differs from what was last actually broadcast
+  // (QF-20260703-040) — covers the case where fleet_identity changed via a path other than this
+  // loop (e.g. a dedupe demotion) but the worker never consumed that SET_IDENTITY message.
   let refreshed = 0;
   for (const w of assigned) {
     const id = w.metadata.fleet_identity;
     const currentSdLabel = w.sd_id || 'idle';
     const expectedDisplayName = `${id.callsign} | ${currentSdLabel}`;
-    if (id.display_name !== expectedDisplayName) {
+    const expectedIdentity = { callsign: id.callsign, color: id.color, display_name: expectedDisplayName };
+    if (identityNeedsRebroadcast(w, expectedIdentity)) {
       const metadata = { ...(w.metadata || {}) };
       metadata.fleet_identity = { ...id, display_name: expectedDisplayName };
+      metadata.fleet_identity_last_sent = expectedIdentity;
       await supabase
         .from('claude_sessions')
         .update({ metadata })
@@ -494,6 +513,8 @@ async function main() {
       display_name: displayName,
       assigned_at: new Date().toISOString()
     };
+    // QF-20260703-040: stamp what we're about to broadcast so a later tick can detect drift.
+    metadata.fleet_identity_last_sent = { callsign, color, display_name: displayName };
 
     const { error: updateErr } = await supabase
       .from('claude_sessions')
@@ -534,7 +555,7 @@ async function main() {
   console.log('');
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, identityNeedsRebroadcast };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/assign-fleet-identities-rebroadcast.test.js
+++ b/tests/unit/assign-fleet-identities-rebroadcast.test.js
@@ -1,0 +1,40 @@
+// QF-20260703-040: SET_IDENTITY was only ever sent to a NEWLY-assigning worker, so a session
+// whose identity changed via some OTHER path (e.g. a dedupeAssignedCallsigns demotion whose
+// resulting message a dead/dormant session never consumed) kept a stale local statusline file
+// forever — the chairman saw 3x "Charlie" on live windows. identityNeedsRebroadcast compares the
+// CURRENTLY-desired identity against metadata.fleet_identity_last_sent (what was actually
+// broadcast last), so a re-affirm is due whenever they drift, regardless of the cause.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { identityNeedsRebroadcast } = require('../../scripts/assign-fleet-identities.cjs');
+
+describe('QF-20260703-040: identityNeedsRebroadcast', () => {
+  it('is true when no identity has ever been broadcast', () => {
+    const worker = { metadata: {} };
+    expect(identityNeedsRebroadcast(worker, { callsign: 'Charlie', color: 'blue', display_name: 'Charlie | idle' })).toBe(true);
+  });
+
+  it('is false when the last-sent identity matches exactly', () => {
+    const identity = { callsign: 'Charlie', color: 'blue', display_name: 'Charlie | idle' };
+    const worker = { metadata: { fleet_identity_last_sent: identity } };
+    expect(identityNeedsRebroadcast(worker, identity)).toBe(false);
+  });
+
+  it('is true when the callsign drifted since the last broadcast (the stranded-window case)', () => {
+    const worker = { metadata: { fleet_identity_last_sent: { callsign: 'Charlie', color: 'blue', display_name: 'Charlie | idle' } } };
+    expect(identityNeedsRebroadcast(worker, { callsign: 'Hotel-5', color: 'blue', display_name: 'Hotel-5 | idle' })).toBe(true);
+  });
+
+  it('is true when only display_name (SD label) changed', () => {
+    const worker = { metadata: { fleet_identity_last_sent: { callsign: 'Charlie', color: 'blue', display_name: 'Charlie | idle' } } };
+    expect(identityNeedsRebroadcast(worker, { callsign: 'Charlie', color: 'blue', display_name: 'Charlie | SD-FOO-001' })).toBe(true);
+  });
+
+  it('is true when only color changed', () => {
+    const worker = { metadata: { fleet_identity_last_sent: { callsign: 'Charlie', color: 'blue', display_name: 'Charlie | idle' } } };
+    expect(identityNeedsRebroadcast(worker, { callsign: 'Charlie', color: 'purple', display_name: 'Charlie | idle' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the "stale statusline callsign" mechanism (backlog row c895ed33, sibling of QF-20260703-665): SET_IDENTITY was only sent to a NEWLY-assigning worker, so a session whose identity drifted via another path (e.g. a `dedupeAssignedCallsigns` demotion whose message a dead/dormant session never consumed) kept displaying a stale callsign until a manual `--force` rebroadcast.
- Adds `identityNeedsRebroadcast(worker, expectedIdentity)`: compares the currently-desired identity against `metadata.fleet_identity_last_sent` (what was actually broadcast, tracked separately from the desired `fleet_identity`), so ANY drift (callsign, color, or display_name) triggers a re-send on the next identity tick — not just an SD-label change.

## Test plan
- [x] New unit tests (`tests/unit/assign-fleet-identities-rebroadcast.test.js`): no-prior-broadcast, exact-match no-op, callsign drift, display_name drift, color drift — 5/5 passing
- [x] Full existing fleet-identity suite still green (43/43)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)