### PR TITLE
fix(QF-20260703-229): stop Adam PM stall detector flooding chairman queue on finished work

### DIFF
--- a/lib/adam/stall-alert.js
+++ b/lib/adam/stall-alert.js
@@ -12,6 +12,28 @@
 
 import { classifyStaleness } from './stall-detector.js';
 import { recordPendingDecision } from '../chairman/record-pending-decision.mjs';
+import { setStatus } from './task-ledger.js';
+
+const SD_TERMINAL_STATUSES = ['completed', 'cancelled'];
+
+/**
+ * QF-20260703-229: a sourced_sd board node stalls-out FOREVER once its linked SD finishes
+ * (completed work stops moving, by definition). Reads the SD's LIVE status via source_ref so a
+ * finished thread self-heals (closes) instead of maturing into a false "genuine stall". Fail-soft
+ * (a query error is NOT terminal — never silently swallow a possibly-real stall).
+ */
+async function isSdTerminal(supabase, sdKey) {
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('status')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    return !!data && SD_TERMINAL_STATUSES.includes(data.status);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Pure: bump (or reset) the ticks-since-movement counter for a node given its current
@@ -42,9 +64,11 @@ export function bumpMovementTicks(node, prevSnapshot) {
  */
 export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, opts = {}) {
   const snapshot = {};
-  const alerted = [];
+  const stalls = [];
   for (const node of Array.isArray(parents) ? parents : []) {
     if (!node || !node.id) continue;
+    // Terminal board statuses never stall — they've stopped moving BY DEFINITION.
+    if (node.status === 'done' || node.status === 'cancelled') continue;
     const ticks = bumpMovementTicks(node, prevSnapshot);
     snapshot[node.id] = { updated_at: node.updated_at, ticks };
 
@@ -54,14 +78,33 @@ export async function checkAndAlertStalls(supabase, parents, prevSnapshot = {}, 
     );
     if (status !== 'genuine_stall') continue;
 
+    // Self-heal: a sourced_sd node whose linked SD already finished is a stale board row,
+    // not a genuine stall — close it instead of escalating.
+    if (node.source_kind === 'sourced_sd' && node.source_ref && await isSdTerminal(supabase, node.source_ref)) {
+      await setStatus(supabase, node.id, 'done').catch(() => {});
+      continue;
+    }
+    stalls.push({ ...node, ticks });
+  }
+
+  // Cap escalation at ONE digest decision per tick — never per-node — so N stalls never flood
+  // the chairman queue with N blocking rows.
+  const alerted = [];
+  if (stalls.length > 0) {
+    const title = stalls.length === 1
+      ? `Adam PM stall: ${stalls[0].title || stalls[0].id}`
+      : `Adam PM stall: ${stalls.length} threads stalled`;
     const res = await recordPendingDecision(supabase, {
-      title: `Adam PM stall: ${node.title || node.id}`,
+      title,
       decisionType: 'session_question',
-      context: { node_id: node.id, ticks_since_movement: ticks },
+      context: {
+        node_ids: stalls.map((n) => n.id),
+        ticks_since_movement: Object.fromEntries(stalls.map((n) => [n.id, n.ticks])),
+      },
       blocking: true,
       raisedBy: 'adam',
     });
-    alerted.push({ id: node.id, title: node.title || node.id, escalated: res.escalated === true });
+    for (const n of stalls) alerted.push({ id: n.id, title: n.title || n.id, escalated: res.escalated === true });
   }
   return { snapshot, alerted };
 }

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -98,7 +98,15 @@ export async function reconcileBoard(sb) {
 // ambiguous, per stall-detector.js's classifyStaleness contract).
 export async function readCriticalPathParents(sb) {
   try {
-    const { data } = await sb.from(TASK_LEDGER_TABLE).select('id, title, updated_at, status').eq('tier', 'parent');
+    // QF-20260703-229: pre-filter to OPEN nodes at the query — a done/cancelled parent has
+    // stopped moving BY DEFINITION and is never a stall candidate. source_kind/source_ref are
+    // read here too so checkAndAlertStalls can self-heal a sourced_sd node whose linked SD
+    // already finished, instead of escalating a stale board row.
+    const { data } = await sb
+      .from(TASK_LEDGER_TABLE)
+      .select('id, title, updated_at, status, source_kind, source_ref')
+      .eq('tier', 'parent')
+      .in('status', ['open', 'in_progress', 'blocked']);
     return (data || []).map((row) => ({ ...row, inFlightNextStep: row.status === 'in_progress' }));
   } catch {
     return [];

--- a/tests/unit/adam/adam-quiet-tick-reconcile.test.js
+++ b/tests/unit/adam/adam-quiet-tick-reconcile.test.js
@@ -94,7 +94,7 @@ describe('reconcileBoard', () => {
  */
 describe('readCriticalPathParents', () => {
   function ledgerSelect(rows) {
-    const b = { select: () => b, eq: () => b, then: (resolve, reject) => Promise.resolve({ data: rows, error: null }).then(resolve, reject) };
+    const b = { select: () => b, eq: () => b, in: () => b, then: (resolve, reject) => Promise.resolve({ data: rows, error: null }).then(resolve, reject) };
     return b;
   }
 

--- a/tests/unit/adam/stall-alert.test.js
+++ b/tests/unit/adam/stall-alert.test.js
@@ -17,7 +17,26 @@ vi.mock('../../../lib/chairman/record-pending-decision.mjs', () => ({
 }));
 import { recordPendingDecision } from '../../../lib/chairman/record-pending-decision.mjs';
 
-beforeEach(() => { recordPendingDecision.mockClear(); });
+vi.mock('../../../lib/adam/task-ledger.js', () => ({ setStatus: vi.fn(async () => ({})) }));
+import { setStatus } from '../../../lib/adam/task-ledger.js';
+
+beforeEach(() => { recordPendingDecision.mockClear(); setStatus.mockClear(); });
+
+/** Minimal supabase stub for strategic_directives_v2 status lookups (isSdTerminal). */
+function sbWithSdStatus(statusBySdKey) {
+  return {
+    from: (table) => {
+      if (table !== 'strategic_directives_v2') return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }) };
+      return {
+        select: () => ({
+          eq: (_col, val) => ({
+            maybeSingle: async () => ({ data: val in statusBySdKey ? { status: statusBySdKey[val] } : null }),
+          }),
+        }),
+      };
+    },
+  };
+}
 
 describe('bumpMovementTicks', () => {
   it('resets to 0 when updated_at differs from the snapshot (real movement)', () => {
@@ -75,5 +94,70 @@ describe('checkAndAlertStalls', () => {
     const parents = [{ id: 'p4', title: 'x', updated_at: 'v1', inFlightNextStep: false }];
     const { snapshot } = await checkAndAlertStalls(sb, parents, {});
     expect(snapshot.p4).toEqual({ updated_at: 'v1', ticks: 0 });
+  });
+});
+
+describe('QF-20260703-229: false-stall flood fix', () => {
+  const sb = {};
+
+  it('skips a node whose board status is already terminal (done/cancelled) — never a stall', async () => {
+    const parents = [
+      { id: 'd1', title: 'Done thread', updated_at: 'fixed', status: 'done', inFlightNextStep: false },
+      { id: 'c1', title: 'Cancelled thread', updated_at: 'fixed', status: 'cancelled', inFlightNextStep: false },
+    ];
+    const prevSnapshot = {
+      d1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 },
+      c1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 },
+    };
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('self-heals a sourced_sd node whose linked SD already completed — closes it, does not alert', async () => {
+    const stubSb = sbWithSdStatus({ 'SD-DONE-001': 'completed' });
+    const parents = [{
+      id: 'sd1', title: 'Ship SD-DONE-001', updated_at: 'fixed',
+      source_kind: 'sourced_sd', source_ref: 'SD-DONE-001', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { sd1: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(setStatus).toHaveBeenCalledWith(stubSb, 'sd1', 'done');
+    expect(recordPendingDecision).not.toHaveBeenCalled();
+    expect(alerted).toEqual([]);
+  });
+
+  it('still alerts a sourced_sd node whose linked SD is genuinely still open', async () => {
+    const stubSb = sbWithSdStatus({ 'SD-OPEN-001': 'in_progress' });
+    const parents = [{
+      id: 'sd2', title: 'Ship SD-OPEN-001', updated_at: 'fixed',
+      source_kind: 'sourced_sd', source_ref: 'SD-OPEN-001', inFlightNextStep: false,
+    }];
+    const prevSnapshot = { sd2: { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 } };
+
+    const { alerted } = await checkAndAlertStalls(stubSb, parents, prevSnapshot);
+
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    expect(alerted).toEqual([{ id: 'sd2', title: 'Ship SD-OPEN-001', escalated: true }]);
+  });
+
+  it('caps escalation at ONE digest decision for multiple genuine stalls — never per-node (the 82-row flood)', async () => {
+    const parents = [
+      { id: 'a', title: 'Thread A', updated_at: 'fixed', inFlightNextStep: false },
+      { id: 'b', title: 'Thread B', updated_at: 'fixed', inFlightNextStep: false },
+      { id: 'c', title: 'Thread C', updated_at: 'fixed', inFlightNextStep: false },
+    ];
+    const prevSnapshot = Object.fromEntries(parents.map((p) => [p.id, { updated_at: 'fixed', ticks: DEFAULT_STALE_TICKS - 1 }]));
+
+    const { alerted } = await checkAndAlertStalls(sb, parents, prevSnapshot);
+
+    expect(recordPendingDecision).toHaveBeenCalledTimes(1);
+    const call = recordPendingDecision.mock.calls[0][1];
+    expect(call.context.node_ids).toEqual(['a', 'b', 'c']);
+    expect(alerted).toHaveLength(3);
+    expect(alerted.every((a) => a.escalated === true)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a live incident: 82 blocking `chairman_decisions` rows flooded in one tick, nearly all for SDs completed since 2026-07-02. `checkAndAlertStalls` classified staleness purely on ticks-since-movement, never checking whether the node or its linked SD had already finished — completed work stops moving by definition, so every finished thread eventually matures into a false "genuine stall".
- `readCriticalPathParents` now pre-filters to `open`/`in_progress`/`blocked` nodes at the query, and also selects `source_kind`/`source_ref`.
- `checkAndAlertStalls` skips any node already at a terminal board status (`done`/`cancelled`).
- For `source_kind='sourced_sd'` nodes, reads the linked SD's LIVE status; if `completed`/`cancelled`, self-heals (closes the board node via `setStatus`) instead of escalating.
- Escalation is capped at ONE digest decision per tick across all genuine stalls, never one blocking row per node — closes the flood vector even for a future batch of real stalls.

## Test plan
- [x] New unit tests (`tests/unit/adam/stall-alert.test.js`): terminal-status skip, sourced_sd self-heal (completed → closes, no alert), sourced_sd still-open (alerts normally), multi-stall single-digest cap — 4/4 new, 16/16 total in file
- [x] Existing `adam-quiet-tick-reconcile.test.js` updated for the new `.in()` query filter — 12/12 passing
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)