### PR TITLE
fix(SD-LEO-FIX-POST-CRASH-FLEET-001): post-crash fleet roll-call + multi-signal liveness probe

### DIFF
--- a/scripts/fleet-rollcall.cjs
+++ b/scripts/fleet-rollcall.cjs
@@ -77,11 +77,15 @@ async function main() {
   if (error) { console.error('ERROR:', error.message); process.exit(1); }
 
   const ids = (sessions || []).map(s => s.session_id);
-  const { data: msgs } = await supabase
+  const { data: msgs, error: msgsError } = await supabase
     .from('session_coordination')
     .select('sender_session, created_at')
     .in('sender_session', ids)
     .order('created_at', { ascending: false });
+  // Fail-open (don't abort the whole roll-call over the coordination-signal query alone) but
+  // VISIBLE: silently swallowing this would degrade every verdict back to updated_at/heartbeat_at
+  // only — reintroducing the exact Specimen-2 blind spot this signal exists to close.
+  if (msgsError) console.error(`WARNING: session_coordination lookup failed (${msgsError.message}) — recent-send liveness signal is unavailable this run`);
   const lastSent = new Map();
   for (const m of msgs || []) if (!lastSent.has(m.sender_session)) lastSent.set(m.sender_session, m.created_at);
 

--- a/scripts/fleet-rollcall.cjs
+++ b/scripts/fleet-rollcall.cjs
@@ -43,6 +43,22 @@ function fmtAge(ts, nowMs) {
   return `${Math.round(ms / 3_600_000)}h ago`;
 }
 
+/**
+ * Multi-signal verdict for one session: ALIVE (via the shared isSessionAlive SSOT, or a
+ * recent outbound session_coordination send — the Specimen-2 signal that SSOT doesn't cover),
+ * STALE (updated recently but no live signal fired), or DEAD.
+ * Pure — takes the already-fetched isSessionAlive result + lastSentAt so it's unit-testable
+ * without a live DB/heartbeat clock.
+ */
+function computeVerdict(session, { nowMs, lastSentAt, liveResult }) {
+  const live = liveResult || isSessionAlive(session, { nowMs });
+  if (live.alive) return { v: 'ALIVE', reason: live.reason };
+  if (lastSentAt && nowMs - Date.parse(lastSentAt) < RECENT_SEND_MS) return { v: 'ALIVE', reason: 'recent_coordination_send' };
+  const lastSeenMs = nowMs - Date.parse(session.updated_at || session.heartbeat_at || 0);
+  if (Number.isFinite(lastSeenMs) && lastSeenMs < STALE_WINDOW_MS) return { v: 'STALE', reason: 'no_live_signal' };
+  return { v: 'DEAD', reason: null };
+}
+
 const LOOKBACK_MS = 72 * 60 * 60 * 1000; // roll-call is about "who's here now" — bound out ancient history
 
 async function main() {
@@ -70,13 +86,7 @@ async function main() {
   for (const m of msgs || []) if (!lastSent.has(m.sender_session)) lastSent.set(m.sender_session, m.created_at);
 
   function verdict(s) {
-    const live = isSessionAlive(s, { nowMs });
-    if (live.alive) return { v: 'ALIVE', reason: live.reason };
-    const sentAt = lastSent.get(s.session_id);
-    if (sentAt && nowMs - Date.parse(sentAt) < RECENT_SEND_MS) return { v: 'ALIVE', reason: 'recent_coordination_send' };
-    const lastSeenMs = nowMs - Date.parse(s.updated_at || s.heartbeat_at || 0);
-    if (Number.isFinite(lastSeenMs) && lastSeenMs < STALE_WINDOW_MS) return { v: 'STALE', reason: 'no_live_signal' };
-    return { v: 'DEAD', reason: null };
+    return computeVerdict(s, { nowMs, lastSentAt: lastSent.get(s.session_id) });
   }
 
   console.log(`\nFLEET ROLL-CALL — ${new Date(nowMs).toISOString()} (considering activity since ${cutoff})\n`);
@@ -117,4 +127,8 @@ async function main() {
   console.log(`\nSUMMARY: workers alive=${tally.ALIVE} stale=${tally.STALE} dead=${tally.DEAD}${orphanPids.length ? `, unregistered=${orphanPids.length}` : ''}\n`);
 }
 
-main().catch(err => { console.error('fleet-rollcall failed:', err.message); process.exit(1); });
+module.exports = { fmtAge, computeVerdict, ROLE_SINGLETONS, RECENT_SEND_MS, STALE_WINDOW_MS };
+
+if (require.main === module) {
+  main().catch(err => { console.error('fleet-rollcall failed:', err.message); process.exit(1); });
+}

--- a/scripts/fleet-rollcall.cjs
+++ b/scripts/fleet-rollcall.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Fleet roll-call — QF-20260703-958.
+ *
+ * One command to answer, after a crash/restart: did every role singleton
+ * (coordinator/adam/solomon/reasoners) come back, and is each session ACTUALLY
+ * alive (not just recently-updated)?
+ *
+ * Specimen 1 (no roll-call): after the 2026-07-03 Cursor crash the chairman
+ * hand-relaunched terminals with no way to verify every role-session returned.
+ * Specimen 2 (liveness false-negative): Adam probed the coordinator via a stale
+ * claude_sessions.updated_at + a 90s reply-timeout and concluded DOWN while it
+ * was provably ONLINE (it sent a session_coordination message minutes earlier
+ * from the same session_id). Reuses the existing multi-signal isSessionAlive
+ * SSOT (lib/fleet/session-liveness.cjs) instead of a duplicate/divergent check,
+ * plus adds the one signal that SSOT doesn't cover: recent outbound
+ * session_coordination activity — the exact proof-of-life Specimen 2 missed.
+ *
+ * Usage: node scripts/fleet-rollcall.cjs
+ */
+require('dotenv').config();
+const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
+const { isSessionAlive } = require('../lib/fleet/session-liveness.cjs');
+const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const { getMarkerSessionIds } = require('../lib/fleet/cc-pid-liveness.cjs');
+
+const RECENT_SEND_MS = 5 * 60 * 1000; // an outbound message this fresh proves liveness
+const STALE_WINDOW_MS = 30 * 60 * 1000; // updated recently but no live signal -> STALE, not DEAD
+
+const ROLE_SINGLETONS = [
+  { key: 'coordinator', strict: true, match: (s, coordId) => s.metadata?.is_coordinator === true || s.session_id === coordId },
+  { key: 'adam', strict: true, match: (s) => s.metadata?.role === 'adam' },
+  { key: 'solomon', strict: true, match: (s) => s.metadata?.role === 'solomon' },
+  // role is 'sprint-reasoner-A' / '-B' etc — non_fleet alone is too broad (adam/solomon also carry it).
+  { key: 'reasoner', strict: false, match: (s) => typeof s.metadata?.role === 'string' && s.metadata.role.startsWith('sprint-reasoner') },
+];
+
+function fmtAge(ts, nowMs) {
+  const ms = ts ? nowMs - Date.parse(ts) : NaN;
+  if (!Number.isFinite(ms)) return 'never';
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  return `${Math.round(ms / 3_600_000)}h ago`;
+}
+
+const LOOKBACK_MS = 72 * 60 * 60 * 1000; // roll-call is about "who's here now" — bound out ancient history
+
+async function main() {
+  const supabase = createSupabaseServiceClient();
+  const nowMs = Date.now();
+  const coordinatorId = await getActiveCoordinatorId(supabase).catch(() => null);
+  const cutoff = new Date(nowMs - LOOKBACK_MS).toISOString();
+
+  // OR across BOTH timestamp columns: Specimen 2 is exactly a session whose updated_at
+  // was stale despite being alive — bounding on updated_at alone would repeat that bug.
+  const { data: sessions, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_key, updated_at, heartbeat_at, is_alive, terminal_id, process_alive_at, expected_silence_until, metadata')
+    .neq('status', 'terminated')
+    .or(`updated_at.gte.${cutoff},heartbeat_at.gte.${cutoff}`);
+  if (error) { console.error('ERROR:', error.message); process.exit(1); }
+
+  const ids = (sessions || []).map(s => s.session_id);
+  const { data: msgs } = await supabase
+    .from('session_coordination')
+    .select('sender_session, created_at')
+    .in('sender_session', ids)
+    .order('created_at', { ascending: false });
+  const lastSent = new Map();
+  for (const m of msgs || []) if (!lastSent.has(m.sender_session)) lastSent.set(m.sender_session, m.created_at);
+
+  function verdict(s) {
+    const live = isSessionAlive(s, { nowMs });
+    if (live.alive) return { v: 'ALIVE', reason: live.reason };
+    const sentAt = lastSent.get(s.session_id);
+    if (sentAt && nowMs - Date.parse(sentAt) < RECENT_SEND_MS) return { v: 'ALIVE', reason: 'recent_coordination_send' };
+    const lastSeenMs = nowMs - Date.parse(s.updated_at || s.heartbeat_at || 0);
+    if (Number.isFinite(lastSeenMs) && lastSeenMs < STALE_WINDOW_MS) return { v: 'STALE', reason: 'no_live_signal' };
+    return { v: 'DEAD', reason: null };
+  }
+
+  console.log(`\nFLEET ROLL-CALL — ${new Date(nowMs).toISOString()} (considering activity since ${cutoff})\n`);
+  console.log('ROLE SINGLETONS');
+  const roleSessionIds = new Set();
+  for (const role of ROLE_SINGLETONS) {
+    const matches = (sessions || []).filter(s => role.match(s, coordinatorId));
+    matches.forEach(s => roleSessionIds.add(s.session_id));
+    if (matches.length === 0) {
+      console.log(`  ${role.key.padEnd(12)} ${role.strict ? 'MISSING' : 'none active'}`);
+      continue;
+    }
+    for (const s of matches) {
+      const { v, reason } = verdict(s);
+      console.log(`  ${role.key.padEnd(12)} ${v.padEnd(6)} ${s.session_id.slice(0, 8)}  last_seen=${fmtAge(s.updated_at || s.heartbeat_at, nowMs)}  reason=${reason || '-'}`);
+    }
+    if (role.strict && matches.length > 1) console.log(`  ⚠ ${matches.length} sessions claim '${role.key}' — expected exactly 1`);
+  }
+
+  const { isDispatchableFleetMember } = await import('../lib/fleet/session-predicates.mjs');
+  const workers = (sessions || []).filter(s => !roleSessionIds.has(s.session_id) && isDispatchableFleetMember(s, coordinatorId));
+  const tally = { ALIVE: 0, STALE: 0, DEAD: 0 };
+  console.log(`\nWORKERS (${workers.length} registered)`);
+  for (const s of workers) {
+    const { v, reason } = verdict(s);
+    tally[v]++;
+    const callsign = s.metadata?.fleet_identity?.callsign || '(unnamed)';
+    console.log(`  ${v.padEnd(6)} ${callsign.padEnd(12)} ${s.session_id.slice(0, 8)}  sd=${s.sd_key || 'idle'}  last_seen=${fmtAge(s.updated_at || s.heartbeat_at, nowMs)}  reason=${reason || '-'}`);
+  }
+
+  const registered = new Set(ids);
+  const orphanPids = Object.entries(getMarkerSessionIds()).filter(([sid, info]) => info.alive && !registered.has(sid));
+  if (orphanPids.length > 0) {
+    console.log('\nUNREGISTERED (PID alive, no active claude_sessions row)');
+    for (const [sid, info] of orphanPids) console.log(`  pid=${info.pid}  session_id=${sid.slice(0, 12)}`);
+  }
+
+  console.log(`\nSUMMARY: workers alive=${tally.ALIVE} stale=${tally.STALE} dead=${tally.DEAD}${orphanPids.length ? `, unregistered=${orphanPids.length}` : ''}\n`);
+}
+
+main().catch(err => { console.error('fleet-rollcall failed:', err.message); process.exit(1); });

--- a/tests/unit/fleet/fleet-rollcall.test.js
+++ b/tests/unit/fleet/fleet-rollcall.test.js
@@ -1,0 +1,101 @@
+// SD-LEO-FIX-POST-CRASH-FLEET-001 (from QF-20260703-958).
+// Regression coverage for the two live specimens: (1) role-singleton matchers must not
+// conflate adam/solomon with 'reasoner' just because all three carry metadata.non_fleet=true,
+// and (2) a session with a stale updated_at but a recent outbound session_coordination send
+// must verdict ALIVE, not DEAD/STALE (the exact false-negative that fooled Adam's coordinator
+// liveness probe on 2026-07-03).
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { fmtAge, computeVerdict, ROLE_SINGLETONS, RECENT_SEND_MS, STALE_WINDOW_MS } =
+  require('../../../scripts/fleet-rollcall.cjs');
+
+describe('fleet-rollcall fmtAge', () => {
+  const now = Date.parse('2026-07-03T20:00:00Z');
+  it('returns "never" for a missing timestamp', () => {
+    expect(fmtAge(null, now)).toBe('never');
+  });
+  it('formats sub-minute ages in seconds', () => {
+    expect(fmtAge(new Date(now - 30_000).toISOString(), now)).toBe('30s ago');
+  });
+  it('formats sub-hour ages in minutes', () => {
+    expect(fmtAge(new Date(now - 5 * 60_000).toISOString(), now)).toBe('5m ago');
+  });
+  it('formats multi-hour ages in hours', () => {
+    expect(fmtAge(new Date(now - 3 * 3_600_000).toISOString(), now)).toBe('3h ago');
+  });
+});
+
+describe('fleet-rollcall computeVerdict', () => {
+  const now = Date.parse('2026-07-03T20:00:00Z');
+  const staleSession = { updated_at: new Date(now - 45 * 60_000).toISOString() };
+
+  it('trusts an ALIVE isSessionAlive result as-is', () => {
+    const result = computeVerdict(staleSession, { nowMs: now, liveResult: { alive: true, reason: 'fresh_heartbeat' } });
+    expect(result).toEqual({ v: 'ALIVE', reason: 'fresh_heartbeat' });
+  });
+
+  it('Specimen 2 regression: a recent outbound coordination send overrides a dead isSessionAlive verdict', () => {
+    const sentAt = new Date(now - 60_000).toISOString(); // 1 min ago, well within RECENT_SEND_MS
+    const result = computeVerdict(staleSession, { nowMs: now, liveResult: { alive: false }, lastSentAt: sentAt });
+    expect(result).toEqual({ v: 'ALIVE', reason: 'recent_coordination_send' });
+  });
+
+  it('does not credit a coordination send older than RECENT_SEND_MS', () => {
+    const sentAt = new Date(now - RECENT_SEND_MS - 1000).toISOString();
+    const result = computeVerdict(staleSession, { nowMs: now, liveResult: { alive: false }, lastSentAt: sentAt });
+    expect(result.v).not.toBe('ALIVE');
+  });
+
+  it('falls to STALE when updated recently but no live signal fired', () => {
+    const recentlyUpdated = { updated_at: new Date(now - 10 * 60_000).toISOString() }; // within STALE_WINDOW_MS
+    const result = computeVerdict(recentlyUpdated, { nowMs: now, liveResult: { alive: false } });
+    expect(result).toEqual({ v: 'STALE', reason: 'no_live_signal' });
+  });
+
+  it('falls to DEAD when outside the stale window with no live signal', () => {
+    const oldSession = { updated_at: new Date(now - STALE_WINDOW_MS - 1000).toISOString() };
+    const result = computeVerdict(oldSession, { nowMs: now, liveResult: { alive: false } });
+    expect(result).toEqual({ v: 'DEAD', reason: null });
+  });
+});
+
+describe('fleet-rollcall ROLE_SINGLETONS matchers', () => {
+  const byKey = Object.fromEntries(ROLE_SINGLETONS.map(r => [r.key, r]));
+  const adam = { session_id: 'a1', metadata: { role: 'adam', non_fleet: true } };
+  const solomon = { session_id: 's1', metadata: { role: 'solomon', non_fleet: true } };
+  const reasonerA = { session_id: 'r1', metadata: { role: 'sprint-reasoner-A', non_fleet: true } };
+  const reasonerB = { session_id: 'r2', metadata: { role: 'sprint-reasoner-B', non_fleet: true } };
+  const coordinator = { session_id: 'c1', metadata: { is_coordinator: true } };
+  const worker = { session_id: 'w1', metadata: { fleet_identity: { callsign: 'Echo' } } };
+
+  it('regression: reasoner does NOT match adam or solomon despite shared non_fleet=true', () => {
+    expect(byKey.reasoner.match(adam)).toBe(false);
+    expect(byKey.reasoner.match(solomon)).toBe(false);
+  });
+
+  it('reasoner matches sprint-reasoner-A/-B by role prefix', () => {
+    expect(byKey.reasoner.match(reasonerA)).toBe(true);
+    expect(byKey.reasoner.match(reasonerB)).toBe(true);
+  });
+
+  it('adam/solomon match only their own role, not each other or a plain worker', () => {
+    expect(byKey.adam.match(adam)).toBe(true);
+    expect(byKey.adam.match(solomon)).toBe(false);
+    expect(byKey.solomon.match(solomon)).toBe(true);
+    expect(byKey.solomon.match(worker)).toBe(false);
+  });
+
+  it('coordinator matches via metadata.is_coordinator or a session_id equal to the resolved coordinator id', () => {
+    expect(byKey.coordinator.match(coordinator, 'someone-else')).toBe(true);
+    expect(byKey.coordinator.match(worker, 'w1')).toBe(true);
+    expect(byKey.coordinator.match(worker, 'someone-else')).toBe(false);
+  });
+
+  it('coordinator/adam/solomon are strict singletons; reasoner is not', () => {
+    expect(byKey.coordinator.strict).toBe(true);
+    expect(byKey.adam.strict).toBe(true);
+    expect(byKey.solomon.strict).toBe(true);
+    expect(byKey.reasoner.strict).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/fleet-rollcall.cjs`: a post-crash diagnostic reporting coordinator/adam/solomon/reasoner presence and an ALIVE/STALE/DEAD verdict per session
- Reuses the existing `lib/fleet/session-liveness.cjs` `isSessionAlive` multi-signal SSOT instead of a new divergent liveness check, plus adds a "recent outbound session_coordination send" signal that SSOT doesn't cover
- Fixes two live 2026-07-03 specimens: (1) no single command existed to verify every role-session returned after a crash, and (2) the coordinator's `updated_at` read stale despite it being provably online (it had sent a `session_coordination` message minutes earlier), producing a false "DOWN" verdict
- Escalated from QF-20260703-958 (implementation came in at 120 LOC, over the 75-LOC quick-fix cap) via `leo-create-sd.js --from-qf`
- Adds `tests/unit/fleet/fleet-rollcall.test.js` (14 tests) covering both specimens as regressions

## Test plan
- [x] `npx vitest run --project unit tests/unit/fleet/fleet-rollcall.test.js` — 14/14 pass
- [x] `npx vitest run --project unit lib/fleet lib/coordinator/resolve.test.js tests/unit/fleet/fleet-rollcall.test.js` — 73/73 pass (zero regression, confirmed by REGRESSION sub-agent)
- [x] Live smoke test: `node scripts/fleet-rollcall.cjs` against production — coordinator/adam/solomon correctly ALIVE, reasoners correctly separated (confirmed by TESTING sub-agent, PASS/confidence 92)
- [x] Diff confirmed purely additive (2 new files, 0 modified) via three-dot diff against origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)