### PR TITLE
fix(QF-20260703-906): PLAN-TO-LEAD PREREQUISITE_HANDOFF_CHECK gate false-fails parent orchestrators (ctx.sd.id resolves to uuid_id, not id)

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -25,7 +25,24 @@ export function createPrerequisiteCheckGate(supabase) {
       console.log('-'.repeat(50));
 
       // Use UUID (ctx.sd.id) not legacy_id (ctx.sdId) - handoffs are stored by UUID
-      const sdUuid = ctx.sd?.id || ctx.sdId;
+      let sdUuid = ctx.sd?.id || ctx.sdId;
+
+      // QF-20260703-906: ctx.sd.id has been observed carrying the SD's legacy
+      // uuid_id column instead of its canonical id, making every .eq(sdUuid) below
+      // come back clean-empty (valid UUID, zero matches) rather than erroring —
+      // which silently downgraded a parent-orchestrator WAIT into a hard FAIL.
+      // Re-resolve via sd_key (unaffected by the id/uuid_id ambiguity) whenever available.
+      if (ctx.sd?.sd_key) {
+        const { data: canonical } = await supabase
+          .from('strategic_directives_v2')
+          .select('id')
+          .eq('sd_key', ctx.sd.sd_key)
+          .maybeSingle();
+        if (canonical?.id && canonical.id !== sdUuid) {
+          console.log(`   ⚠️  sdUuid mismatch (${sdUuid} vs canonical ${canonical.id}) — using canonical id`);
+          sdUuid = canonical.id;
+        }
+      }
 
       // Auto-resolve previous failed PLAN-TO-LEAD attempts on retry
       const resolveResult = await autoResolveFailedHandoffs(supabase, sdUuid, 'PLAN-TO-LEAD');

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -197,7 +197,15 @@ async function checkParentOrchestrator(supabase, sdUuid, _ctx) {
     .select('id, sd_key, status')
     .eq('parent_sd_id', sdUuid);
 
-  if (!childError && childSDs && childSDs.length > 0) {
+  // QF-20260703-906 (fix 1/2): a genuine query error must never be treated the same as
+  // "zero children" — both previously fell through silently to "not a parent," hiding a
+  // DB/connectivity problem behind a misleading EXEC-TO-PLAN-required failure.
+  if (childError) {
+    console.log(`   ⚠️  Parent-detection query failed: ${childError.message} — cannot determine parent status`);
+    return null;
+  }
+
+  if (childSDs && childSDs.length > 0) {
     console.log(`   ℹ️  Parent SD detected with ${childSDs.length} children`);
 
     const terminalStatuses = ['completed', 'cancelled'];

--- a/tests/unit/handoff/executors/plan-to-lead/prerequisite-check-id-mismatch.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/prerequisite-check-id-mismatch.test.js
@@ -1,0 +1,70 @@
+/**
+ * Regression test for QF-20260703-906: PREREQUISITE_HANDOFF_CHECK (PLAN-TO-LEAD)
+ * silently downgraded a parent-orchestrator WAIT into a hard FAIL when ctx.sd.id
+ * carried a stale/mismatched value instead of the SD's canonical id -- every
+ * .eq(sdUuid) query then came back clean-empty (valid UUID, zero matches) rather
+ * than erroring, so checkParentOrchestrator treated it as "not a parent."
+ */
+import { describe, it, expect } from 'vitest';
+import { createPrerequisiteCheckGate } from '../../../../../scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js';
+
+// Simulates a real Supabase client: the sd_key->id lookup returns the CANONICAL
+// id, while any query keyed on the (wrong) ctx.sd.id comes back empty -- exactly
+// the "clean-empty, not an error" shape a valid-but-unmatched UUID produces.
+function makeMismatchedSupabase({ canonicalId, children }) {
+  return {
+    from(table) {
+      return {
+        select() {
+          return {
+            eq(column, value) {
+              const chain = {
+                async maybeSingle() {
+                  if (table === 'strategic_directives_v2' && column === 'sd_key') {
+                    return { data: { id: canonicalId }, error: null };
+                  }
+                  return { data: null, error: null };
+                },
+                eq(column2, value2) {
+                  return {
+                    eq() { return { order() { return { limit: async () => ({ data: [], error: null }) }; } }; },
+                    order() { return { limit: async () => ({ data: [], error: null }) }; },
+                  };
+                },
+                async then(resolve) {
+                  // parent_sd_id lookup: only matches on the CANONICAL id
+                  if (table === 'strategic_directives_v2' && column === 'parent_sd_id' && value === canonicalId) {
+                    resolve({ data: children, error: null });
+                  } else {
+                    resolve({ data: [], error: null });
+                  }
+                  return Promise.resolve();
+                },
+              };
+              return chain;
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('QF-20260703-906: PREREQUISITE_HANDOFF_CHECK id-mismatch resilience', () => {
+  it('re-resolves via sd_key and returns WAIT (not a hard FAIL) when ctx.sd.id is stale', async () => {
+    const canonicalId = 'real-canonical-uuid';
+    const staleId = 'stale-uuid-id-value';
+    const children = [{ id: 'child-1', sd_key: 'SD-CHILD-J1', status: 'pending_approval' }];
+
+    const supabase = makeMismatchedSupabase({ canonicalId, children });
+    const gate = createPrerequisiteCheckGate(supabase);
+
+    const ctx = { sd: { id: staleId, sd_key: 'SD-PARENT-J' }, sdId: staleId };
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(false);
+    expect(result.wait).toBe(true);
+    expect(result.wait_reason).toContain('1 child SD');
+    expect(result.issues).toEqual([]);
+  });
+});

--- a/tests/unit/handoff/executors/plan-to-lead/prerequisite-check-id-mismatch.test.js
+++ b/tests/unit/handoff/executors/plan-to-lead/prerequisite-check-id-mismatch.test.js
@@ -5,7 +5,7 @@
  * .eq(sdUuid) query then came back clean-empty (valid UUID, zero matches) rather
  * than erroring, so checkParentOrchestrator treated it as "not a parent."
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createPrerequisiteCheckGate } from '../../../../../scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js';
 
 // Simulates a real Supabase client: the sd_key->id lookup returns the CANONICAL
@@ -66,5 +66,56 @@ describe('QF-20260703-906: PREREQUISITE_HANDOFF_CHECK id-mismatch resilience', (
     expect(result.wait).toBe(true);
     expect(result.wait_reason).toContain('1 child SD');
     expect(result.issues).toEqual([]);
+  });
+});
+
+// Simulates a genuine DB error on the parent_sd_id lookup (e.g. connectivity blip) — must
+// be surfaced distinctly, NOT silently treated the same as "zero children" (QF-20260703-906
+// fix 1/2). Falls through to the standard EXEC-TO-PLAN check like a real not-a-parent SD;
+// with no accepted handoff seeded, the gate correctly hard-fails on the actual missing
+// prerequisite rather than misreporting a parent-detection outage as that failure.
+function makeChildErrorSupabase() {
+  // A chainable eq()...eq().order().limit() tail that always resolves clean-empty
+  // (used for every query except the one under test — the parent_sd_id lookup).
+  const emptyTail = {
+    eq: () => emptyTail,
+    order: () => ({ limit: async () => ({ data: [], error: null }) }),
+  };
+  return {
+    from(table) {
+      return {
+        select() {
+          return {
+            eq(column, value) {
+              if (table === 'strategic_directives_v2' && column === 'parent_sd_id') {
+                return { async then(resolve) { resolve({ data: null, error: { message: 'connection reset' } }); return Promise.resolve(); } };
+              }
+              return { async maybeSingle() { return { data: null, error: null }; }, ...emptyTail };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('QF-20260703-906: checkParentOrchestrator surfaces childError distinctly', () => {
+  let logSpy;
+  beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+  afterEach(() => { logSpy.mockRestore(); });
+
+  it('logs the DB error and falls through (not a silent "not a parent")', async () => {
+    const supabase = makeChildErrorSupabase();
+    const gate = createPrerequisiteCheckGate(supabase);
+    const ctx = { sd: { id: 'some-id', sd_key: 'SD-NO-SDKEY-QUERY' }, sdId: 'some-id' };
+
+    const result = await gate.validator(ctx);
+
+    const loggedWarning = logSpy.mock.calls.flat().some((a) => String(a).includes('Parent-detection query failed'));
+    expect(loggedWarning).toBe(true);
+    // Falls through to the standard prerequisite path (no accepted handoff seeded -> hard fail),
+    // proving the error was surfaced rather than masked as a false pass.
+    expect(result.passed).toBe(false);
+    expect(result.issues[0]).toContain('No accepted EXEC-TO-PLAN handoff found');
   });
 });


### PR DESCRIPTION
## Quick-Fix: QF-20260703-906

**Type:** bug
**Severity:** high

### Issue Description
prerequisite-check.js (plan-to-lead) derives sdUuid from ctx.sd?.id at gate-invocation time; on SD-MARKETLENS-LEO-ORCH-SPRINT-2026-001-J this resolved to the SD's uuid_id column instead of its canonical id, so both checkParentOrchestrator's parent_sd_id child-lookup AND the EXEC-TO-PLAN handoff lookup returned clean-empty (valid UUID, zero matches, not a query error). checkParentOrchestrator treats a childError/empty result as 'not a parent' and returns null, so the gate falls through to the standard EXEC-TO-PLAN-required path and hard-fails at 0% ('BLOCKING: No accepted EXEC-TO-PLAN handoff found') instead of returning the correct WAIT verdict for a parent orchestrator with an incomplete child (J1 was pending_approval/LEAD_FINAL at the time, confirmed parent_sd_id=J.id via direct DB query). A sibling gate in the same precheck run (CHILDREN_STRUCTURE_VALID, plan-to-exec) correctly detected the same child using its own id resolution, proving this is gate-local, not a DB data issue. RCA agent afde6eef6d1b0036a confirmed root cause empirically (confidence 0.75), verdict-cache exonerated (gate not in GATE_INPUT_EXTRACTORS). Fix: (1) checkParentOrchestrator must not silently return null on a childError -- surface it distinctly from a genuine zero-children case; (2) assert sdUuid is the canonical id (regex/shape-check against uuid_id) before querying, re-resolving via the same canonical loader CHILDREN_STRUCTURE_VALID (plan-to-exec/index.js) uses, so parent-detection can't diverge by id source within the same precheck run.

### Steps to Reproduce
Run PLAN-TO-LEAD precheck/execute on a parent orchestrator SD with exactly one non-terminal child, in a session/context where ctx.sd.id ends up populated from uuid_id rather than id

### Expected Behavior
Gate returns a WAIT verdict (blocked_wait, not a hard failure) citing the incomplete child

### Actual Behavior
Gate hard-fails at 0% claiming no EXEC-TO-PLAN handoff exists, even though one was just accepted moments earlier

### Changes
- **Files Changed:** 2
  - scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
  - tests/unit/handoff/executors/plan-to-lead/prerequisite-check-id-mismatch.test.js
- **LOC:** 92 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
Confirmed via sanity-check: test fails without the fix (result.wait undefined -> hard FAIL) and passes with it (result.wait=true -> correct WAIT verdict). 16/16 tests pass across the new regression test + 2 pre-existing parent-lifecycle test files (no regression). RCA agent afde6eef6d1b0036a confirmed root cause empirically.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol