### PR TITLE
fix(QF-20260703-195): chairman email quiet window 23:00-05:00 ET at shared send choke point

### DIFF
--- a/lib/notifications/resend-adapter.js
+++ b/lib/notifications/resend-adapter.js
@@ -6,8 +6,6 @@
  * Handles timeout, retry, and error mapping to internal status codes.
  */
 
-import { createClient } from '@supabase/supabase-js';
-
 const RESEND_API_URL = 'https://api.resend.com/emails';
 const DEFAULT_TIMEOUT_MS = 10000;
 const MAX_RETRIES = 2;

--- a/lib/notifications/resend-adapter.js
+++ b/lib/notifications/resend-adapter.js
@@ -11,6 +11,20 @@ import { createClient } from '@supabase/supabase-js';
 const RESEND_API_URL = 'https://api.resend.com/emails';
 const DEFAULT_TIMEOUT_MS = 10000;
 const MAX_RETRIES = 2;
+const QUIET_WINDOW_TZ = 'America/New_York';
+const QUIET_START_HOUR = 23; // 11:00 PM ET
+const QUIET_END_HOUR = 5;    // 5:00 AM ET
+
+/**
+ * QF-20260703-195: chairman quiet window (23:00-05:00 America/New_York) — a hard floor at the
+ * lowest shared send choke point so every caller (adam-heartbeat-email.mjs, adam-decision-email.mjs,
+ * coordinator-*, fleet-down-alert.mjs) inherits it. Intl-based (DST-aware; never hand-offset).
+ * Exported so callers can detect quiet-window edges (e.g. a post-resume note) and for unit tests.
+ */
+export function isWithinChairmanQuietWindow(now = new Date()) {
+  const hour = Number(now.toLocaleTimeString('en-US', { timeZone: QUIET_WINDOW_TZ, hour12: false, hour: '2-digit' }));
+  return hour >= QUIET_START_HOUR || hour < QUIET_END_HOUR;
+}
 
 /**
  * @typedef {Object} EmailPayload
@@ -32,9 +46,19 @@ const MAX_RETRIES = 2;
 /**
  * Send an email via Resend API with retry and timeout.
  * @param {EmailPayload} payload
+ * @param {{ now?: Date }} [opts] - opts.now overrides the clock (unit tests only)
  * @returns {Promise<SendResult>}
  */
-export async function sendEmail(payload) {
+export async function sendEmail(payload, { now = new Date() } = {}) {
+  if (isWithinChairmanQuietWindow(now)) {
+    return {
+      success: true,
+      suppressed: true,
+      errorCode: 'SUPPRESSED_QUIET_WINDOW',
+      errorMessage: 'Chairman quiet window (23:00-05:00 America/New_York); send skipped to preserve quota.'
+    };
+  }
+
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     return {

--- a/scripts/adam-heartbeat-email.mjs
+++ b/scripts/adam-heartbeat-email.mjs
@@ -32,18 +32,23 @@ const when = new Date().toLocaleString('en-US', { timeZone: 'America/New_York', 
 // (lib/chairman/decision-layman.mjs). His Gmail alerting keys on these literal strings —
 // never change either token without chairman sign-off.
 const subject = `[ALL GOOD - ADAM] heartbeat ${when} ET`;
-const text = `${body.trim()}\n\nas of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor`;
+const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
+// QF-20260703-195: stateless quiet-window-resume note — if the previous ~30min tick would have
+// been suppressed but now isn't, this is the first heartbeat back after 23:00-05:00 ET.
+const thirtyMinAgo = new Date(Date.now() - 30 * 60_000);
+const resumeNote = mod.isWithinChairmanQuietWindow(thirtyMinAgo) && !mod.isWithinChairmanQuietWindow()
+  ? 'Resuming after the overnight quiet window (23:00-05:00 ET). ' : '';
+const text = `${resumeNote}${body.trim()}\n\nas of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor`;
 
 const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 const html = '<div style="font-family:system-ui,Arial,sans-serif;max-width:640px">' +
-  `<p style="font-size:14px;margin:0 0 8px">${esc(body.trim())}</p>` +
+  `<p style="font-size:14px;margin:0 0 8px">${esc(resumeNote)}${esc(body.trim())}</p>` +
   `<p style="font-size:11px;color:#999;margin:14px 0 0">as of ${when} ET ${EM} Adam ${EM} LEO Fleet Advisor</p></div>`;
 
 if (DRY) {
   console.log('=== [ADAM HEARTBEAT EMAIL — DRY RUN] no email sent ===\nSUBJECT: ' + subject + '\n---\n' + text + '\n---');
 } else {
   try {
-    const mod = await import(pathToFileURL(resolve('lib/notifications/resend-adapter.js')).href);
     const r = await mod.sendEmail({ from: 'Adam ' + EM + ' LEO Fleet Advisor <onboarding@resend.dev>', to: process.env.CLAUDE_NOTIFY_EMAIL, subject, html, text });
     console.log('ADAM-HEARTBEAT-EMAIL', JSON.stringify(r));
   } catch (e) {

--- a/tests/unit/notifications/resend-adapter.test.js
+++ b/tests/unit/notifications/resend-adapter.test.js
@@ -25,11 +25,16 @@ afterEach(() => {
   delete process.env.RESEND_FROM_EMAIL;
 });
 
-// Dynamic import to re-evaluate env vars each test
+// Dynamic import to re-evaluate env vars each test.
+// QF-20260703-195: sendEmail now suppresses sends during the 23:00-05:00 ET chairman quiet
+// window. These pre-existing tests are not testing that behavior, so pin `now` to a fixed
+// daytime instant (safely outside the window in any DST state) instead of letting it default
+// to the real ambient clock — otherwise every test here would flake if run overnight ET.
+const SAFE_DAYTIME_NOW = new Date('2026-01-01T18:00:00Z'); // 1pm ET (Jan = EST, unambiguous)
 async function importSendEmail() {
   // Clear the module cache so env vars are re-evaluated
   const mod = await import('../../../lib/notifications/resend-adapter.js');
-  return mod.sendEmail;
+  return (payload, opts) => mod.sendEmail(payload, { now: SAFE_DAYTIME_NOW, ...opts });
 }
 
 describe('resend-adapter', () => {
@@ -272,6 +277,60 @@ describe('resend-adapter', () => {
       expect(result.success).toBe(false);
       expect(result.errorCode).toBe('TIMEOUT');
       expect(result.errorMessage).toContain('timed out');
+    });
+  });
+
+  describe('sendEmail - chairman quiet window (QF-20260703-195)', () => {
+    it('suppresses the send at 2:00 AM ET — no provider call, SUPPRESSED_QUIET_WINDOW result', async () => {
+      const sendEmail = await importSendEmail();
+      // 2026-01-02T07:00:00Z = 2:00 AM EST (Jan = EST, unambiguous DST state)
+      const twoAmEt = new Date('2026-01-02T07:00:00Z');
+      const result = await sendEmail(basePayload, { now: twoAmEt });
+
+      expect(result.success).toBe(true);
+      expect(result.suppressed).toBe(true);
+      expect(result.errorCode).toBe('SUPPRESSED_QUIET_WINDOW');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends normally at 6:00 AM ET (just past the window)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'msg-6am' })
+      });
+      const sendEmail = await importSendEmail();
+      // 2026-01-02T11:00:00Z = 6:00 AM EST
+      const sixAmEt = new Date('2026-01-02T11:00:00Z');
+      const result = await sendEmail(basePayload, { now: sixAmEt });
+
+      expect(result.success).toBe(true);
+      expect(result.suppressed).toBeUndefined();
+      expect(result.providerMessageId).toBe('msg-6am');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses at exactly 23:00 ET (window start, inclusive)', async () => {
+      const sendEmail = await importSendEmail();
+      // 2026-01-02T04:00:00Z = 11:00 PM EST on 2026-01-01
+      const elevenPmEt = new Date('2026-01-02T04:00:00Z');
+      const result = await sendEmail(basePayload, { now: elevenPmEt });
+
+      expect(result.suppressed).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends normally at exactly 22:59 ET (just before the window)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'msg-before' })
+      });
+      const sendEmail = await importSendEmail();
+      // 2026-01-02T03:59:00Z = 10:59 PM EST
+      const beforeWindow = new Date('2026-01-02T03:59:00Z');
+      const result = await sendEmail(basePayload, { now: beforeWindow });
+
+      expect(result.suppressed).toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- The half-hourly Adam heartbeat email + the on-demand decision email fire around the clock, burning the daily Resend quota overnight (HTTP 429 at ~20:20Z 2026-07-03) and killing both the heartbeat AND alert channels for the rest of the day.
- Fix: hard quiet-window guard at `lib/notifications/resend-adapter.js`'s `sendEmail()` — the lowest shared choke point every chairman-email caller (adam-heartbeat-email, adam-decision-email, coordinator-email-summary, coordinator-escalate-question, fleet-down-alert) already funnels through.
- Between 23:00-05:00 America/New_York (Intl-based, DST-aware, never hand-offset), `sendEmail()` skips the provider call and returns `{ success: true, suppressed: true, errorCode: 'SUPPRESSED_QUIET_WINDOW' }`. Both existing callers already `console.log(JSON.stringify(result))` unconditionally, so the suppression is visible with **zero caller-side changes**, and neither script ever calls `process.exit(1)` on this path (exit 0, not an error).
- `adam-heartbeat-email.mjs` additionally detects the quiet-window edge (stateless — was suppressed 30 min ago, isn't now) and prepends a "Resuming after the overnight quiet window" note to the first heartbeat back after 5 AM.
- Genuine emergencies still reach the chairman via the separate Todoist phone-notify channel, unaffected by this guard.

## Test plan
- [x] New regression tests: mocked 2:00 AM ET (suppressed, no provider call, `SUPPRESSED_QUIET_WINDOW`), 6:00 AM ET (normal send), and the 23:00/22:59 window boundary
- [x] Fixed the pre-existing `resend-adapter.test.js` suite's `now` to a pinned safe daytime instant instead of the real ambient clock, so it won't flake if CI runs overnight ET now that suppression exists
- [x] `npx vitest run tests/unit/notifications/` — 87 passed (includes `orchestrator.test.js`, which fully mocks `resend-adapter.js` and is unaffected)
- [x] Manual dry-run smoke test of `adam-heartbeat-email.mjs --dry-run`

QF-20260703-195

🤖 Generated with [Claude Code](https://claude.com/claude-code)