### PR TITLE
fix(QF-20260703-905): rate-cap chairman-escalation emails (3/hour + 1 digest)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,9 +1,9 @@
 {
-  "sdKey": "QF-20260703-295",
+  "sdKey": "QF-20260703-905",
   "workType": "QF",
-  "workKey": "QF-20260703-295",
-  "expectedBranch": "qf/QF-20260703-295",
-  "createdAt": "2026-07-03T19:09:27.089Z",
+  "workKey": "QF-20260703-905",
+  "expectedBranch": "qf/QF-20260703-905",
+  "createdAt": "2026-07-03T20:41:24.159Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -112,7 +112,11 @@ export async function escalateChairmanDecision(supabase, decisionId, { spawn = d
         return { escalated: false, suppressed: 'rate_cap' };
       }
       spawn(decisionId); // ONE digest for the whole rolling window, in place of another standout email
-      const merged = { ...(live?.brief_data || {}), digest_sent_at: new Date().toISOString() };
+      // Stamp BOTH markers: digest_sent_at for observability, escalation_email_sent_at so the
+      // top-of-function dedup check still treats this decision as handled on any future re-call
+      // (the function's own documented contract — see docstring above).
+      const now = new Date().toISOString();
+      const merged = { ...(live?.brief_data || {}), digest_sent_at: now, escalation_email_sent_at: now };
       await supabase.from('chairman_decisions').update({ brief_data: merged }).eq('id', decisionId);
       return { escalated: true, digest: true };
     }

--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -60,6 +60,27 @@ function defaultSpawnEscalationEmail(decisionId) {
   if (typeof child.unref === 'function') child.unref();
 }
 
+// QF-20260703-905: escalation rate cap. The 165-decision flood specimen (QF-20260703-229's stall-
+// detector defect) sent ~165 standout emails in 20 minutes and burned the entire daily Resend quota,
+// killing both the heartbeat and alert channels for the rest of the day. Decision ROWS are always
+// recorded regardless (recordPendingDecision inserts unconditionally) — only the EMAIL amplification
+// is capped here: at most RATE_CAP_MAX_EMAILS standout emails per rolling hour, the rest fold into
+// ONE digest email per window (further suppressions in the same window are logged, not re-sent).
+const RATE_CAP_WINDOW_MS = 60 * 60 * 1000;
+const RATE_CAP_MAX_EMAILS = 3;
+
+/** Counts standout/digest emails already sent within the rolling rate-cap window. Fail-open (treats
+ *  a read error as an empty window) to match this file's existing fail-soft escalation philosophy. */
+async function getEscalationWindowCounts(supabase) {
+  const since = new Date(Date.now() - RATE_CAP_WINDOW_MS).toISOString();
+  const { data } = await supabase.from('chairman_decisions').select('brief_data').gte('created_at', since);
+  const rows = data || [];
+  return {
+    emails: rows.filter(r => r.brief_data?.escalation_email_sent_at).length,
+    digests: rows.filter(r => r.brief_data?.digest_sent_at).length,
+  };
+}
+
 /**
  * FR-2/FR-3 — escalate a recorded chairman decision: fire the standout email ONCE (dedup on
  * brief_data.escalation_email_sent_at), then stamp the marker so a re-call is a no-op. Fail-soft:
@@ -69,7 +90,7 @@ function defaultSpawnEscalationEmail(decisionId) {
  * @param {Object} supabase
  * @param {string} decisionId
  * @param {{spawn?:Function}} [opts] - inject spawn for tests
- * @returns {Promise<{escalated:boolean, deduped?:boolean, error?:string}>}
+ * @returns {Promise<{escalated:boolean, deduped?:boolean, digest?:boolean, suppressed?:string, error?:string}>}
  */
 export async function escalateChairmanDecision(supabase, decisionId, { spawn = defaultSpawnEscalationEmail } = {}) {
   if (!supabase || !decisionId) return { escalated: false, error: 'supabase and decisionId required' };
@@ -83,6 +104,19 @@ export async function escalateChairmanDecision(supabase, decisionId, { spawn = d
     if (live?.brief_data?.escalation_email_sent_at) {
       return { escalated: false, deduped: true };
     }
+
+    const { emails, digests } = await getEscalationWindowCounts(supabase);
+    if (emails >= RATE_CAP_MAX_EMAILS) {
+      if (digests > 0) {
+        console.log(`SUPPRESSED_RATE_CAP decision=${decisionId} emails_this_hour=${emails}`);
+        return { escalated: false, suppressed: 'rate_cap' };
+      }
+      spawn(decisionId); // ONE digest for the whole rolling window, in place of another standout email
+      const merged = { ...(live?.brief_data || {}), digest_sent_at: new Date().toISOString() };
+      await supabase.from('chairman_decisions').update({ brief_data: merged }).eq('id', decisionId);
+      return { escalated: true, digest: true };
+    }
+
     spawn(decisionId); // fire-and-forget standout LEAN decision email (leads with this decision)
     const merged = { ...(live?.brief_data || {}), escalation_email_sent_at: new Date().toISOString() };
     await supabase.from('chairman_decisions').update({ brief_data: merged }).eq('id', decisionId);

--- a/tests/unit/chairman/record-pending-decision-escalation.test.js
+++ b/tests/unit/chairman/record-pending-decision-escalation.test.js
@@ -197,9 +197,11 @@ describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)'
     }
     expect(sb.rows.length).toBe(20); // decision rows are NEVER affected by the rate cap
     expect(spawn).toHaveBeenCalledTimes(4); // 3 standout emails + exactly 1 digest
-    const standoutCount = sb.rows.filter(r => r.brief_data?.escalation_email_sent_at).length;
     const digestCount = sb.rows.filter(r => r.brief_data?.digest_sent_at).length;
-    expect(standoutCount).toBe(3);
+    // The digest row also carries escalation_email_sent_at (dedup-contract parity — see
+    // escalateChairmanDecision), so "pure standout" excludes it from the escalation_email_sent_at count.
+    const pureStandoutCount = sb.rows.filter(r => r.brief_data?.escalation_email_sent_at && !r.brief_data?.digest_sent_at).length;
+    expect(pureStandoutCount).toBe(3);
     expect(digestCount).toBe(1);
   });
 });

--- a/tests/unit/chairman/record-pending-decision-escalation.test.js
+++ b/tests/unit/chairman/record-pending-decision-escalation.test.js
@@ -2,6 +2,11 @@
  * SD-LEO-INFRA-ADAM-ESCALATION-DETERMINISM-001 — the chairman-escalation email is now DETERMINISTIC:
  * an Adam session_question/blocking decision fires the standout email immediately on creation, with no
  * in-session gate, deduped to one email per decision, fail-soft.
+ *
+ * QF-20260703-905 — the escalation choke point now carries a rolling-hour RATE CAP (max 3 standout
+ * emails/hour; the rest fold into ONE digest per window) so a decision flood (the 165-email specimen
+ * from QF-20260703-229) can no longer burn the entire daily provider quota. Decision rows are always
+ * recorded regardless of the cap — only the email amplification is capped.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -10,26 +15,55 @@ import {
   recordPendingDecision,
 } from '../../../lib/chairman/record-pending-decision.mjs';
 
-/** Minimal supabase stub: insert returns an id; select reads back a row's brief_data; update records. */
-function makeSupabase({ briefData = null } = {}) {
-  const state = { briefData, updates: [] };
+/** Minimal in-memory chairman_decisions table backing insert/select/eq/gte/update/maybeSingle —
+ *  enough surface for record-pending-decision.mjs's query shapes, nothing more. */
+function makeFakeTable() {
+  let seq = 0;
+  const rows = [];
+  function matches(row, filters) {
+    return filters.every(([col, op, val]) => (op === '>=' ? row[col] >= val : row[col] === val));
+  }
   return {
-    state,
+    rows,
     from() {
-      const ctx = {};
+      const ctx = { filters: [] };
       const api = {
-        insert() { ctx.op = 'insert'; return api; },
-        update(vals) { ctx.op = 'update'; state.updates.push(vals); return api; },
-        select() { ctx.op = ctx.op || 'select'; return api; },
-        eq() { return api; },
-        async maybeSingle() { return { data: state.briefData === null ? null : { brief_data: state.briefData } }; },
-        then(resolve) { // insert(...).select('id') is awaited directly
-          resolve({ data: [{ id: 'dec-1' }], error: null });
+        insert(row) {
+          ctx.op = 'insert';
+          ctx.row = { id: `dec-${++seq}`, created_at: new Date().toISOString(), ...row };
+          return api;
+        },
+        select() { if (!ctx.op) ctx.op = 'select'; return api; },
+        eq(col, val) { ctx.filters.push([col, '=', val]); return api; },
+        gte(col, val) { ctx.filters.push([col, '>=', val]); return api; },
+        update(vals) { ctx.op = 'update'; ctx.vals = vals; return api; },
+        async maybeSingle() {
+          const row = rows.find(r => matches(r, ctx.filters));
+          return { data: row ? { brief_data: row.brief_data } : null };
+        },
+        then(resolve) {
+          if (ctx.op === 'insert') {
+            rows.push(ctx.row);
+            resolve({ data: [{ id: ctx.row.id }], error: null });
+          } else if (ctx.op === 'update') {
+            const row = rows.find(r => matches(r, ctx.filters));
+            if (row) Object.assign(row, ctx.vals);
+            resolve({ data: null, error: null });
+          } else {
+            resolve({ data: rows.filter(r => matches(r, ctx.filters)).map(r => ({ brief_data: r.brief_data })), error: null });
+          }
         },
       };
       return api;
     },
   };
+}
+
+/** Back-compat single-row helper for the direct escalateChairmanDecision(sb, 'dec-1', ...) tests. */
+function makeSupabase({ briefData = null } = {}) {
+  const sb = makeFakeTable();
+  if (briefData !== null) sb.rows.push({ id: 'dec-1', created_at: new Date().toISOString(), brief_data: briefData });
+  return sb;
 }
 
 describe('shouldAutoEscalate (FR-1)', () => {
@@ -59,7 +93,7 @@ describe('escalateChairmanDecision (FR-2/FR-3)', () => {
     const r = await escalateChairmanDecision(sb, 'dec-1', { spawn });
     expect(r.escalated).toBe(true);
     expect(spawn).toHaveBeenCalledTimes(1);
-    expect(sb.state.updates[0].brief_data.escalation_email_sent_at).toBeTruthy();
+    expect(sb.rows[0].brief_data.escalation_email_sent_at).toBeTruthy();
   });
 
   it('dedup: a row already stamped does NOT spawn again', async () => {
@@ -79,9 +113,53 @@ describe('escalateChairmanDecision (FR-2/FR-3)', () => {
   });
 });
 
+describe('escalateChairmanDecision — rate cap (QF-20260703-905)', () => {
+  it('the 4th escalation in a rolling hour folds into ONE digest, not another standout email', async () => {
+    const sb = makeFakeTable();
+    const spawn = vi.fn();
+    for (let i = 0; i < 3; i++) {
+      sb.rows.push({ id: `seed-${i}`, created_at: new Date().toISOString(), brief_data: { escalation_email_sent_at: new Date().toISOString() } });
+    }
+    sb.rows.push({ id: 'dec-4', created_at: new Date().toISOString(), brief_data: { title: 'q4' } });
+
+    const r = await escalateChairmanDecision(sb, 'dec-4', { spawn });
+    expect(r.escalated).toBe(true);
+    expect(r.digest).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(sb.rows.find(row => row.id === 'dec-4').brief_data.digest_sent_at).toBeTruthy();
+  });
+
+  it('a 5th escalation in the same window is suppressed once the digest is already sent (no re-send)', async () => {
+    const sb = makeFakeTable();
+    const spawn = vi.fn();
+    for (let i = 0; i < 3; i++) {
+      sb.rows.push({ id: `seed-${i}`, created_at: new Date().toISOString(), brief_data: { escalation_email_sent_at: new Date().toISOString() } });
+    }
+    sb.rows.push({ id: 'dec-4', created_at: new Date().toISOString(), brief_data: {} });
+    await escalateChairmanDecision(sb, 'dec-4', { spawn }); // sends the ONE digest
+
+    sb.rows.push({ id: 'dec-5', created_at: new Date().toISOString(), brief_data: { title: 'q5' } });
+    const r = await escalateChairmanDecision(sb, 'dec-5', { spawn });
+    expect(r.escalated).toBe(false);
+    expect(r.suppressed).toBe('rate_cap');
+    expect(spawn).toHaveBeenCalledTimes(1); // still just the one digest — never a 2nd
+  });
+
+  it('under the cap (< 3 emails this hour) still sends a normal standout email', async () => {
+    const sb = makeFakeTable();
+    const spawn = vi.fn();
+    sb.rows.push({ id: 'seed-0', created_at: new Date().toISOString(), brief_data: { escalation_email_sent_at: new Date().toISOString() } });
+    sb.rows.push({ id: 'dec-2', created_at: new Date().toISOString(), brief_data: { title: 'q2' } });
+    const r = await escalateChairmanDecision(sb, 'dec-2', { spawn });
+    expect(r.escalated).toBe(true);
+    expect(r.digest).toBeUndefined();
+    expect(sb.rows.find(row => row.id === 'dec-2').brief_data.escalation_email_sent_at).toBeTruthy();
+  });
+});
+
 describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)', () => {
   it('an adam session_question record fires exactly one email spawn, no in-session gate', async () => {
-    const sb = makeSupabase({ briefData: { title: 'Adam needs a call' } });
+    const sb = makeFakeTable();
     const spawn = vi.fn();
     const r = await recordPendingDecision(sb, { title: 'Adam needs a call', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: spawn });
     expect(r.recorded).toBe(true);
@@ -90,7 +168,7 @@ describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)'
   });
 
   it('a non-adam record does NOT fire the email', async () => {
-    const sb = makeSupabase({ briefData: { title: 'routine' } });
+    const sb = makeFakeTable();
     const spawn = vi.fn();
     const r = await recordPendingDecision(sb, { title: 'routine', raisedBy: 'coordinator', decisionType: 'session_question', _spawnEscalation: spawn });
     expect(r.recorded).toBe(true);
@@ -99,9 +177,29 @@ describe('recordPendingDecision — deterministic escalation wiring (FR-2/FR-5)'
   });
 
   it('persists raised_by in brief_data for escalation provenance', async () => {
-    // The insert path builds brief_data with raised_by; assert recordPendingDecision still records.
-    const sb = makeSupabase({ briefData: { title: 'q' } });
+    const sb = makeFakeTable();
     const r = await recordPendingDecision(sb, { title: 'q', raisedBy: 'adam', decisionType: 'session_question', _spawnEscalation: vi.fn() });
     expect(r.recorded).toBe(true);
+  });
+
+  it('QF-20260703-905 acceptance: 20 blocking decisions in a burst => <=3 standout + 1 digest, 20 durable rows', async () => {
+    const sb = makeFakeTable();
+    const spawn = vi.fn();
+    for (let i = 0; i < 20; i++) {
+      const r = await recordPendingDecision(sb, {
+        title: `flood ${i}`,
+        raisedBy: 'adam',
+        decisionType: 'stage_gate',
+        blocking: true,
+        _spawnEscalation: spawn,
+      });
+      expect(r.recorded).toBe(true);
+    }
+    expect(sb.rows.length).toBe(20); // decision rows are NEVER affected by the rate cap
+    expect(spawn).toHaveBeenCalledTimes(4); // 3 standout emails + exactly 1 digest
+    const standoutCount = sb.rows.filter(r => r.brief_data?.escalation_email_sent_at).length;
+    const digestCount = sb.rows.filter(r => r.brief_data?.digest_sent_at).length;
+    expect(standoutCount).toBe(3);
+    expect(digestCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- The 165-decision flood specimen (QF-20260703-229's stall-detector defect) sent ~165 standout escalation emails in 20 minutes, burning the entire daily Resend quota and killing both the heartbeat and alert channels for the rest of the day.
- Adds a rolling-hour rate cap in `escalateChairmanDecision`: at most 3 standout emails/hour; further escalations in the same window fold into ONE digest email (subsequent ones are logged `SUPPRESSED_RATE_CAP`, never re-sent).
- Decision rows are always recorded regardless of the cap (`recordPendingDecision` inserts unconditionally) — only the email amplification is capped.
- Known scope limitation: the "digest" currently reuses the same single-decision email helper (tagged via `digest_sent_at` rather than `escalation_email_sent_at`) rather than composing a true multi-decision summary body — sufficient to satisfy the quota-protection goal within this quick-fix's scope.

## Test plan
- [x] `npx vitest run tests/unit/chairman/record-pending-decision-escalation.test.js` — 15 passed, including the exact acceptance scenario: 20 blocking decisions in a burst → exactly 3 standout + 1 digest spawn calls, 20 durable rows preserved
- [x] `npx vitest run` across related decision-queue/stall-alert tests — 78 passed, no regressions
- [x] `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)