### PR TITLE
fix(QF-20260703-388): multi-repo scan can't hang preflight past 60s

### DIFF
--- a/scripts/modules/shipping/MultiRepoCoordinator.js
+++ b/scripts/modules/shipping/MultiRepoCoordinator.js
@@ -13,12 +13,19 @@
  * @version 2.0.0 - Uses centralized lib/multi-repo module
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import {
   discoverRepos as discoverReposFromLib,
   getPrimaryRepos
 } from '../../../lib/multi-repo/index.js';
+
+// QF-20260703-388: per-repo git/gh calls use execFileSync (no shell) so a timeout's
+// kill signal reaches the real process directly -- execSync's shell:true default wraps
+// the command in cmd.exe on Windows, and killing that wrapper on timeout leaves the
+// actual git/gh child running, which is why preflight survived SIGTERM at 60s/180s.
+const PER_REPO_TIMEOUT_MS = 15000;
+const SCAN_DEADLINE_MS = 60000;
 
 export class MultiRepoCoordinator {
   /**
@@ -65,6 +72,8 @@ export class MultiRepoCoordinator {
     // Discover repos
     this.repos = this.discoverRepos();
     console.log(`   Found ${Object.keys(this.repos).length} repositories`);
+    this._deadlineAt = Date.now() + SCAN_DEADLINE_MS;
+    this.partial = false;
 
     // Find SD branches in all repos
     await this.findSDBranches();
@@ -80,6 +89,7 @@ export class MultiRepoCoordinator {
 
     return {
       passed: this.branchStatus.filter(b => b.needsAction).length === 0,
+      partial: this.partial,
       repos: this.repos,
       branches: this.branchStatus,
       coordinationPlan
@@ -100,23 +110,28 @@ export class MultiRepoCoordinator {
     ];
 
     for (const [repoName, repoInfo] of Object.entries(this.repos)) {
+      if (Date.now() > this._deadlineAt) {
+        console.log(`   ⚠️  PREFLIGHT_PARTIAL: multi-repo scan deadline (${SCAN_DEADLINE_MS / 1000}s) exceeded, skipping remaining repos`);
+        this.partial = true;
+        break;
+      }
       if (!existsSync(repoInfo.path)) {
         continue;
       }
 
       try {
         // Fetch latest
-        execSync('git fetch --prune', {
+        execFileSync('git', ['fetch', '--prune'], {
           cwd: repoInfo.path,
-          timeout: 30000,
+          timeout: PER_REPO_TIMEOUT_MS,
           stdio: 'pipe'
         });
 
         // Get remote branches
-        const branchList = execSync('git branch -r', {
+        const branchList = execFileSync('git', ['branch', '-r'], {
           encoding: 'utf8',
           cwd: repoInfo.path,
-          timeout: 10000
+          timeout: PER_REPO_TIMEOUT_MS
         });
 
         for (const pattern of branchPatterns) {
@@ -133,9 +148,9 @@ export class MultiRepoCoordinator {
             // Get commit count ahead of main
             let commitsAhead = 0;
             try {
-              const count = execSync(
-                `git rev-list --count origin/main..${branch}`,
-                { encoding: 'utf8', cwd: repoInfo.path, timeout: 10000 }
+              const count = execFileSync(
+                'git', ['rev-list', '--count', `origin/main..${branch}`],
+                { encoding: 'utf8', cwd: repoInfo.path, timeout: PER_REPO_TIMEOUT_MS }
               ).trim();
               commitsAhead = parseInt(count);
             } catch {
@@ -145,9 +160,9 @@ export class MultiRepoCoordinator {
             // Check if branch is fully merged
             let isMerged = false;
             try {
-              execSync(`git merge-base --is-ancestor ${branch} origin/main`, {
+              execFileSync('git', ['merge-base', '--is-ancestor', branch, 'origin/main'], {
                 cwd: repoInfo.path,
-                timeout: 10000,
+                timeout: PER_REPO_TIMEOUT_MS,
                 stdio: 'pipe'
               });
               isMerged = true;
@@ -181,11 +196,16 @@ export class MultiRepoCoordinator {
   async checkPRStatus() {
     for (const branch of this.branchStatus) {
       if (!branch.needsAction) continue;
+      if (Date.now() > this._deadlineAt) {
+        console.log(`   ⚠️  PREFLIGHT_PARTIAL: multi-repo scan deadline (${SCAN_DEADLINE_MS / 1000}s) exceeded, skipping remaining PR checks`);
+        this.partial = true;
+        break;
+      }
 
       try {
-        const result = execSync(
-          `gh pr list --repo ${branch.repoInfo.github} --head ${branch.branch} --state all --json number,state,url --limit 1`,
-          { encoding: 'utf8', timeout: 30000 }
+        const result = execFileSync(
+          'gh', ['pr', 'list', '--repo', branch.repoInfo.github, '--head', branch.branch, '--state', 'all', '--json', 'number,state,url', '--limit', '1'],
+          { encoding: 'utf8', timeout: PER_REPO_TIMEOUT_MS }
         );
 
         const prs = JSON.parse(result || '[]');

--- a/tests/unit/multi-repo-coordinator-scan-deadline.test.js
+++ b/tests/unit/multi-repo-coordinator-scan-deadline.test.js
@@ -1,0 +1,69 @@
+/**
+ * QF-20260703-388: multi-repo scan must never block the ship path indefinitely.
+ * Verifies the global scan deadline skips remaining repos/branches and marks
+ * the result partial, and that git/gh calls go through execFileSync (no shell)
+ * so a timeout's kill signal reaches the real process.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn()
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, existsSync: vi.fn(() => true) };
+});
+
+import { execFileSync } from 'child_process';
+import { MultiRepoCoordinator } from '../../scripts/modules/shipping/MultiRepoCoordinator.js';
+
+function makeRepos() {
+  return {
+    EHG_Engineer: { name: 'EHG_Engineer', path: '/repos/EHG_Engineer', github: 'org/EHG_Engineer', priority: 1 },
+    ehg: { name: 'ehg', path: '/repos/ehg', github: 'org/ehg', priority: 2 }
+  };
+}
+
+describe('MultiRepoCoordinator scan deadline (QF-20260703-388)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips remaining repos and marks partial once the scan deadline has passed', async () => {
+    const coordinator = new MultiRepoCoordinator('SD-TEST-001');
+    coordinator.repos = makeRepos();
+    coordinator._deadlineAt = Date.now() - 1; // already expired
+    coordinator.partial = false;
+
+    await coordinator.findSDBranches();
+
+    expect(coordinator.partial).toBe(true);
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(coordinator.branchStatus).toHaveLength(0);
+  });
+
+  it('scans normally via execFileSync (no shell) when the deadline has not passed', async () => {
+    execFileSync.mockImplementation((file, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'branch') return '  origin/fix/SD-TEST-001\n';
+      if (args[0] === 'rev-list') return '2\n';
+      if (args[0] === 'merge-base') return '';
+      return '';
+    });
+
+    const coordinator = new MultiRepoCoordinator('SD-TEST-001');
+    coordinator.repos = { EHG_Engineer: makeRepos().EHG_Engineer };
+    coordinator._deadlineAt = Date.now() + 60000;
+    coordinator.partial = false;
+
+    await coordinator.findSDBranches();
+
+    expect(coordinator.partial).toBe(false);
+    expect(execFileSync).toHaveBeenCalledWith('git', ['fetch', '--prune'], expect.any(Object));
+    expect(coordinator.branchStatus).toHaveLength(1);
+    expect(coordinator.branchStatus[0].commitsAhead).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- ship-preflight.js hung indefinitely (survived SIGTERM at 60s and 180s) when run from a worktree.
- Root cause: `MultiRepoCoordinator`'s git/gh calls used `execSync` (shell:true → cmd.exe wrapper on Windows). Killing that wrapper on timeout leaves the real git/gh child process running, so an advisory check blocked the ship path instead of degrading.
- Fix: switch the per-repo scan's git/gh calls to `execFileSync` (no shell, so a timeout kill reaches the real process) and add a 60s global scan deadline that skips remaining repos/branches and marks the result `partial` instead of hanging.

## Test plan
- [x] New regression test (`tests/unit/multi-repo-coordinator-scan-deadline.test.js`) confirmed to FAIL against pre-fix code via `git stash`, PASS against the fix.
- [x] `npx tsc --noEmit` passes.
- [x] Unit test suite scoped to this change passes (2/2).

QF-20260703-388