### PR TITLE
fix(QF-20260703-758): resync-before-claim freshness check on the claim-gate script

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,8 @@
 {
-  "sdKey": "QF-20260703-347",
-  "expectedBranch": "qf/QF-20260703-347",
-  "createdAt": "2026-07-03T21:07:34.571Z",
-  "repoRoot": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer",
+  "sdKey": "QF-20260703-758",
+  "expectedBranch": "qf/QF-20260703-758",
+  "createdAt": "2026-07-03T23:39:18.605Z",
+  "hostname": "Legion-Laptop",
+  "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
   "baseRef": "origin/main"
 }

--- a/lib/claim/gate-freshness-check.mjs
+++ b/lib/claim/gate-freshness-check.mjs
@@ -1,0 +1,36 @@
+import { execFileSync } from 'child_process';
+
+/**
+ * QF-20260703-758 stopgap: claim eligibility is enforced client-side (in the gate files
+ * themselves), so a session running a checkout from BEFORE a gate fix was merged claims
+ * straight through it. Refuses the claim when origin/main has commits touching a gate
+ * file that HEAD does not have — i.e. this checkout is missing an upstream gate fix.
+ *
+ * Fail-open on any git error (network hiccup, no remote, etc.) — never blocks a
+ * legitimate claim on a tooling failure.
+ *
+ * @param {string} repoRoot - main repo root (git cwd)
+ * @param {string[]} gateFiles - repo-relative paths of the files enforcing claim gates
+ * @returns {{stale: boolean, file?: string, missingCommitCount?: number, skipped?: boolean}}
+ */
+export function checkClaimGateFreshness(repoRoot, gateFiles) {
+  try {
+    execFileSync('git', ['fetch', 'origin', 'main', '--quiet'], { cwd: repoRoot, stdio: 'ignore', timeout: 15000 });
+  } catch (e) {
+    return { stale: false, skipped: true, reason: e.message };
+  }
+  for (const file of gateFiles) {
+    try {
+      const missing = execFileSync(
+        'git', ['log', '--oneline', 'HEAD..origin/main', '--', file],
+        { cwd: repoRoot, encoding: 'utf8', timeout: 5000 }
+      ).trim();
+      if (missing) {
+        return { stale: true, file, missingCommitCount: missing.split('\n').length };
+      }
+    } catch {
+      // fail-open per file — a git error here must not block a legitimate claim
+    }
+  }
+  return { stale: false };
+}

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -34,6 +34,7 @@ import { hasRecentClaimReleased, formatClaimReleasedAbort, detectSdKeyDrift } fr
 import sessionIdentitySot from '../lib/session-identity-sot.js';
 import { findClaudeCodePid } from '../lib/terminal-identity.js';
 import { claimGuard, formatClaimFailure } from '../lib/claim-guard.mjs';
+import { checkClaimGateFreshness } from '../lib/claim/gate-freshness-check.mjs';
 // SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001 — pre-claim multi-signal evidence-of-life gate.
 // Wraps claimGuard's heartbeat/inactive auto-release to prevent hostile reclaim
 // when the prior session has been released but its CC conversation is still active
@@ -767,6 +768,18 @@ async function main() {
     console.log(`\n  ${colors.cyan}cd ${worktreeGuard.repoRoot}${colors.reset}`);
     console.log(`  ${colors.cyan}node scripts/sd-start.js ${sdId}${colors.reset}`);
     console.log(`\n  ${colors.dim}(No claim changes made — safe to retry.)${colors.reset}`);
+    process.exit(1);
+  }
+
+  // QF-20260703-758: refuse a claim from a checkout missing an upstream fix to this
+  // very gate script — closes the window where yesterday's code claims through
+  // a gate that was fixed hours earlier on origin/main.
+  const gateFreshness = checkClaimGateFreshness(worktreeGuard.repoRoot, ['scripts/sd-start.js']);
+  if (gateFreshness.stale) {
+    console.log(`\n${colors.red}${colors.bold}🚫 RESYNC_REQUIRED${colors.reset}`);
+    console.log(`   Your checkout is ${gateFreshness.missingCommitCount} commit(s) behind origin/main for ${gateFreshness.file}.`);
+    console.log('   Claiming now risks bypassing a claim-gate fix merged upstream.');
+    console.log(`   ${colors.cyan}git pull${colors.reset} in the main repo root, then retry.`);
     process.exit(1);
   }
 

--- a/tests/unit/claim-gate-freshness-check.test.js
+++ b/tests/unit/claim-gate-freshness-check.test.js
@@ -1,0 +1,77 @@
+// QF-20260703-758: a stale checkout (running an old copy of the gate script itself)
+// bypasses any gate fix merged upstream since it last synced. checkClaimGateFreshness
+// refuses the claim when origin/main has commits touching a gate file that HEAD lacks.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileSyncMock = vi.fn();
+vi.mock('child_process', () => ({ execFileSync: (...args) => execFileSyncMock(...args) }));
+
+const { checkClaimGateFreshness } = await import('../../lib/claim/gate-freshness-check.mjs');
+
+describe('checkClaimGateFreshness (QF-20260703-758)', () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it('is NOT stale when origin/main has no commits missing from HEAD for the gate file', () => {
+    execFileSyncMock.mockImplementation((cmd, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'log') return '';
+      throw new Error(`unexpected call: ${cmd} ${args.join(' ')}`);
+    });
+    const result = checkClaimGateFreshness('/repo', ['scripts/sd-start.js']);
+    expect(result).toEqual({ stale: false });
+  });
+
+  it('is stale when origin/main has commits touching the gate file that HEAD is missing', () => {
+    execFileSyncMock.mockImplementation((cmd, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args[0] === 'log') return 'abc1234 fix(QF-X): close a claim-gate hole\ndef5678 fix(QF-Y): another fix\n';
+      throw new Error(`unexpected call: ${cmd} ${args.join(' ')}`);
+    });
+    const result = checkClaimGateFreshness('/repo', ['scripts/sd-start.js']);
+    expect(result).toEqual({ stale: true, file: 'scripts/sd-start.js', missingCommitCount: 2 });
+  });
+
+  it('checks multiple gate files and stops at the first stale one', () => {
+    execFileSyncMock.mockImplementation((cmd, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args.includes('lib/claim-guard.mjs')) return 'abc1234 fix\n';
+      if (args.includes('scripts/sd-start.js')) return '';
+      throw new Error(`unexpected call: ${cmd} ${args.join(' ')}`);
+    });
+    const result = checkClaimGateFreshness('/repo', ['scripts/sd-start.js', 'lib/claim-guard.mjs']);
+    expect(result).toEqual({ stale: true, file: 'lib/claim-guard.mjs', missingCommitCount: 1 });
+  });
+
+  it('fails open (not stale) when the fetch itself errors — never blocks on a tooling failure', () => {
+    execFileSyncMock.mockImplementation((cmd, args) => {
+      if (args[0] === 'fetch') throw new Error('network unreachable');
+      throw new Error(`unexpected call: ${cmd} ${args.join(' ')}`);
+    });
+    const result = checkClaimGateFreshness('/repo', ['scripts/sd-start.js']);
+    expect(result.stale).toBe(false);
+    expect(result.skipped).toBe(true);
+  });
+
+  it('fails open per-file when a git log call errors for one file', () => {
+    execFileSyncMock.mockImplementation((cmd, args) => {
+      if (args[0] === 'fetch') return '';
+      if (args.includes('scripts/sd-start.js')) throw new Error('bad path spec');
+      throw new Error(`unexpected call: ${cmd} ${args.join(' ')}`);
+    });
+    const result = checkClaimGateFreshness('/repo', ['scripts/sd-start.js']);
+    expect(result).toEqual({ stale: false });
+  });
+
+  it('passes the pathspec as a separate argv entry, never shell-interpolated', () => {
+    execFileSyncMock.mockImplementation((cmd, args) => {
+      if (args[0] === 'fetch') return '';
+      expect(cmd).toBe('git');
+      expect(args).toEqual(['log', '--oneline', 'HEAD..origin/main', '--', 'scripts/sd-start.js; rm -rf /']);
+      return '';
+    });
+    const result = checkClaimGateFreshness('/repo', ['scripts/sd-start.js; rm -rf /']);
+    expect(result).toEqual({ stale: false });
+  });
+});


### PR DESCRIPTION
## Summary
- Claim eligibility is enforced client-side in `scripts/sd-start.js` itself, so a session running a checkout from before a gate fix was merged (e.g. QF-295's HELD-SD gate, QF-151's orchestrator-parent gate) claims straight through it. Verified live: session `3c40949b` claimed an rha-held SD on pre-QF-295 code at 18:54Z; session `e2791f5b` claimed an orchestrator parent on pre-QF-151 code at 21:02Z.
- Stopgap: `checkClaimGateFreshness()` (`lib/claim/gate-freshness-check.mjs`) fetches `origin/main` and checks for commits touching `scripts/sd-start.js` that `HEAD` doesn't have. If any exist, `sd-start.js` refuses the claim with a `RESYNC_REQUIRED` message instead of proceeding on stale gate logic.
- Fail-open by design: any git error (network hiccup, no remote) never blocks a legitimate claim.
- The DB-side chokepoint (making eligibility unspoofable regardless of client code version) is a separate, SD-sized item — this is the QF-sized client-side stopgap only.

## Test plan
- [x] `npx vitest run tests/unit/claim-gate-freshness-check.test.js` — 6 new cases: fresh, stale (single + multi-file), fetch-error fail-open, per-file-error fail-open, and an execFileSync argv-injection regression check
- [x] `npx vitest run tests/unit/sd-start-*.test.js tests/unit/multi-session-claim-gate.test.js tests/unit/handoff-claim-gate.test.js tests/unit/qf-claim-routing.test.js` — 86 tests total, all passing (no regressions on the claim path)
- [x] `node --check` on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)