### PR TITLE
fix(QF-20260703-311): Worker commits unattributable across sessions - stamp a per-session trailer (callsign + session id) on fleet commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -21,6 +21,9 @@ if [ "$SKIP_STRUNKIAN" = "1" ]; then
   exit 0
 fi
 
+# Stamp a fleet attribution trailer (QF-20260703-311) — fail-open, never blocks
+node scripts/append-fleet-commit-trailer.js "$1"
+
 # Run EXEC commit gate
 node scripts/exec-commit-gate.js "$1"
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -21,8 +21,12 @@ if [ "$SKIP_STRUNKIAN" = "1" ]; then
   exit 0
 fi
 
-# Stamp a fleet attribution trailer (QF-20260703-311) — fail-open, never blocks
-node scripts/append-fleet-commit-trailer.js "$1"
+# Stamp a fleet attribution trailer (QF-20260703-311) — fail-open, never blocks.
+# `|| true` is load-bearing: this hook runs under `sh -e` (husky's shim), so ANY
+# non-zero exit here would abort the rest of commit-msg (including the Strunkian
+# check below). A known Node/libuv-on-Windows quirk can make a script exit
+# non-zero on shutdown even after process.exit(0) if it opened a network client.
+node scripts/append-fleet-commit-trailer.js "$1" || true
 
 # Run EXEC commit gate
 node scripts/exec-commit-gate.js "$1"

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,7 +1,9 @@
 {
-  "sdKey": "QF-20260703-758",
-  "expectedBranch": "qf/QF-20260703-758",
-  "createdAt": "2026-07-03T23:39:18.605Z",
+  "sdKey": "QF-20260703-311",
+  "workType": "QF",
+  "workKey": "QF-20260703-311",
+  "expectedBranch": "qf/QF-20260703-311",
+  "createdAt": "2026-07-03T22:33:05.293Z",
   "hostname": "Legion-Laptop",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer",
   "baseRef": "origin/main"

--- a/lib/worktree-provision.js
+++ b/lib/worktree-provision.js
@@ -71,6 +71,24 @@ function defaultWriteMarker(worktreePath, modeStr) {
   try { fs.writeFileSync(path.join(worktreePath, MARKER_FILE), modeStr + '\n'); } catch { /* best-effort */ }
 }
 
+/**
+ * Re-link husky's git hook shims (`.husky/_`) in the worktree. Both provisioning
+ * strategies below (junction, and isolate's `--ignore-scripts` install) skip
+ * npm's "prepare" lifecycle script, so `.husky/_` — which core.hooksPath points
+ * at — never gets created and EVERY git hook (commit-msg Strunkian check,
+ * pre-commit secret scanning) silently never fires in a fresh worktree.
+ * `npx husky` alone (no full install) recreates just the shims, in ~2s.
+ * Fail-open: a hook-provisioning failure must never make a worktree unusable.
+ */
+export function defaultEnsureHuskyHooks(worktreePath, { execSyncImpl = execSync } = {}) {
+  try {
+    execSyncImpl('npx husky', { cwd: worktreePath, stdio: 'pipe', timeout: 15000 });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
 /** Read the isolation-mode marker for teardown decisions. Returns 'isolated' | 'junction' | null. */
 export function readWorktreeNmMode(worktreePath, fsImpl = fs) {
   try { return fsImpl.readFileSync(path.join(worktreePath, MARKER_FILE), 'utf8').trim() || null; }
@@ -90,6 +108,7 @@ export function provisionWorktreeNodeModules(worktreePath, options = {}) {
     runInstall = defaultRunInstall,
     writeMarker = defaultWriteMarker,
     rm = safeRecursiveRmWithRetry,
+    ensureHuskyHooks = defaultEnsureHuskyHooks,
     log = (msg) => console.log(msg),
   } = deps;
 
@@ -98,6 +117,8 @@ export function provisionWorktreeNodeModules(worktreePath, options = {}) {
   if (decision.strategy === 'junction') {
     symlink(worktreePath, repoRoot);
     writeMarker(worktreePath, 'junction');
+    const hooks = ensureHuskyHooks(worktreePath);
+    if (!hooks.ok) log(`[worktree-provision] husky hook re-link failed (non-fatal): ${hooks.error}`);
     log(`[worktree-provision] junction (${decision.reason}): ${worktreePath}`);
     return { strategy: 'junction', reason: decision.reason };
   }
@@ -106,6 +127,8 @@ export function provisionWorktreeNodeModules(worktreePath, options = {}) {
   try {
     runInstall(worktreePath);
     writeMarker(worktreePath, 'isolated');
+    const hooks = ensureHuskyHooks(worktreePath);
+    if (!hooks.ok) log(`[worktree-provision] husky hook re-link failed (non-fatal): ${hooks.error}`);
     log(`[worktree-provision] isolated (${decision.reason}): ${worktreePath}`);
     return { strategy: 'isolate', reason: decision.reason };
   } catch (err) {

--- a/scripts/append-fleet-commit-trailer.js
+++ b/scripts/append-fleet-commit-trailer.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Fleet Commit Trailer (QF-20260703-311)
+ *
+ * All fleet worker sessions commit under the same git author identity, so a
+ * worker seeing a peer's commit on a shared/moved-claim branch reads it as an
+ * unattributed background actor. Appends a trailer identifying the current
+ * session's fleet callsign so peer commits are attributable at a glance.
+ * Author identity is left unchanged for GitHub attribution — trailer-only.
+ *
+ * Usage: node scripts/append-fleet-commit-trailer.js <commit-msg-file>
+ *
+ * Fail-open: any missing env var, DB error, or timeout exits 0 silently —
+ * this is cosmetic metadata, never a reason to block a commit.
+ */
+
+import fs from 'fs';
+
+async function main() {
+  const msgFile = process.argv[2];
+  const sessionId = process.env.CLAUDE_SESSION_ID;
+  if (!msgFile || !sessionId) process.exit(0);
+
+  try {
+    const { createSupabaseServiceClient } = await import('../lib/supabase-client.js');
+    const supabase = createSupabaseServiceClient();
+
+    const timeoutMs = 2000;
+    const result = await Promise.race([
+      supabase
+        .from('claude_sessions')
+        .select('metadata')
+        .eq('session_id', sessionId)
+        .maybeSingle(),
+      new Promise((resolve) => setTimeout(() => resolve({ data: null, timedOut: true }), timeoutMs)),
+    ]);
+
+    const callsign = result?.data?.metadata?.fleet_identity?.callsign;
+    if (!callsign) process.exit(0);
+
+    const message = fs.readFileSync(msgFile, 'utf8');
+    const trailer = `Fleet-Worker: ${callsign}\nClaude-Session: ${sessionId}`;
+    if (message.includes('Fleet-Worker:')) process.exit(0); // already stamped (amend/retry)
+    fs.writeFileSync(msgFile, `${message.replace(/\s*$/, '')}\n\n${trailer}\n`);
+  } catch {
+    // Fail-open — never block a commit over attribution metadata.
+  }
+  process.exit(0);
+}
+
+main();

--- a/tests/unit/append-fleet-commit-trailer.test.js
+++ b/tests/unit/append-fleet-commit-trailer.test.js
@@ -1,0 +1,51 @@
+/**
+ * Regression test for QF-20260703-311: fleet commits are unattributable because
+ * every session shares the same git author identity. This script appends a
+ * Fleet-Worker/Claude-Session trailer to the commit message so peer commits are
+ * attributable without changing the author identity GitHub uses.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT = join(process.cwd(), 'scripts', 'append-fleet-commit-trailer.js');
+
+describe('append-fleet-commit-trailer.js (QF-20260703-311)', () => {
+  let dir;
+  let msgFile;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fleet-trailer-test-'));
+    msgFile = join(dir, 'COMMIT_EDITMSG');
+    writeFileSync(msgFile, 'test commit message\n');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('leaves the message unchanged when CLAUDE_SESSION_ID is unset (fail-open)', () => {
+    const env = { ...process.env };
+    delete env.CLAUDE_SESSION_ID;
+    execFileSync('node', [SCRIPT, msgFile], { env });
+    const result = readFileSync(msgFile, 'utf8');
+    expect(result).toBe('test commit message\n');
+  });
+
+  it('leaves the message unchanged when the session lookup finds nothing (fail-open, bad session id)', () => {
+    const env = { ...process.env, CLAUDE_SESSION_ID: 'nonexistent-session-id-00000000' };
+    execFileSync('node', [SCRIPT, msgFile], { env });
+    const result = readFileSync(msgFile, 'utf8');
+    expect(result).toBe('test commit message\n');
+  });
+
+  it('is idempotent: running twice never double-stamps', () => {
+    writeFileSync(msgFile, 'test commit message\n\nFleet-Worker: Alpha\nClaude-Session: abc-123\n');
+    const env = { ...process.env, CLAUDE_SESSION_ID: 'abc-123' };
+    execFileSync('node', [SCRIPT, msgFile], { env });
+    const result = readFileSync(msgFile, 'utf8');
+    expect(result.match(/Fleet-Worker:/g).length).toBe(1);
+  });
+});

--- a/tests/unit/worktree-provision-husky-hooks.test.js
+++ b/tests/unit/worktree-provision-husky-hooks.test.js
@@ -1,0 +1,48 @@
+/**
+ * Regression test for QF-20260703-311 (fix 2/2): both worktree node_modules
+ * provisioning strategies (junction, and isolate's `--ignore-scripts` install)
+ * skip npm's "prepare" lifecycle script, so `.husky/_` — which core.hooksPath
+ * points at — never gets created and every git hook silently never fires in a
+ * fresh worktree. provisionWorktreeNodeModules must always call an injectable
+ * ensureHuskyHooks step, for both strategies, without ever failing the
+ * worktree provisioning itself if hook re-linking fails.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { provisionWorktreeNodeModules } from '../../lib/worktree-provision.js';
+
+function makeDeps(overrides = {}) {
+  return {
+    decide: vi.fn(() => ({ strategy: 'junction', reason: 'test' })),
+    symlink: vi.fn(),
+    runInstall: vi.fn(),
+    writeMarker: vi.fn(),
+    rm: vi.fn(),
+    ensureHuskyHooks: vi.fn(() => ({ ok: true })),
+    log: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('provisionWorktreeNodeModules — husky hook re-link (QF-20260703-311)', () => {
+  it('calls ensureHuskyHooks on the junction path', () => {
+    const deps = makeDeps({ decide: vi.fn(() => ({ strategy: 'junction', reason: 'auto_solo' })) });
+    provisionWorktreeNodeModules('/fake/wt', { deps });
+    expect(deps.ensureHuskyHooks).toHaveBeenCalledWith('/fake/wt');
+  });
+
+  it('calls ensureHuskyHooks on the isolate path', () => {
+    const deps = makeDeps({ decide: vi.fn(() => ({ strategy: 'isolate', reason: 'auto_concurrent' })) });
+    provisionWorktreeNodeModules('/fake/wt', { deps });
+    expect(deps.ensureHuskyHooks).toHaveBeenCalledWith('/fake/wt');
+  });
+
+  it('does not throw and still returns success when hook re-linking fails', () => {
+    const deps = makeDeps({
+      decide: vi.fn(() => ({ strategy: 'junction', reason: 'auto_solo' })),
+      ensureHuskyHooks: vi.fn(() => ({ ok: false, error: 'npx husky failed' })),
+    });
+    const result = provisionWorktreeNodeModules('/fake/wt', { deps });
+    expect(result.strategy).toBe('junction');
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('husky hook re-link failed'));
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260703-311

**Type:** bug
**Severity:** medium

### Issue Description
Feedback 74d73c2f (verified live): all fleet sessions commit as the same git identity, so a worker seeing a peer's commit on a shared/moved-claim branch reads it as an unattributed background actor - 2 false-alarm harness-bug signals today (Delta 19:03Z reaper-pull suspicion + one more). Fix: the fleet commit path appends a trailer to every commit message - Fleet-Worker: <callsign> / Claude-Session: <session-id> (or sets GIT_COMMITTER_NAME to 'callsign (fleet)') so peer commits are attributable at a glance. Keep author identity unchanged for GitHub attribution; trailer-only is the low-risk shape.


### Expected Behavior
Any fleet commit is attributable to its worker session from the commit message

### Actual Behavior
All commits look identical; workers file false background-actor alarms

### Changes
- **Files Changed:** 6
  - .husky/commit-msg
  - .worktree.json
  - lib/worktree-provision.js
  - scripts/append-fleet-commit-trailer.js
  - tests/unit/append-fleet-commit-trailer.test.js
  - tests/unit/worktree-provision-husky-hooks.test.js
- **LOC:** 186 lines
- **Tests:** ❌ Failed
- **UAT:** ✅ Verified

### Verification
Verified: (1) npx husky recreates .husky/_ shims in a fresh worktree in ~2s on both junction and isolate provisioning paths, unit-tested with injectable deps; (2) reproduced the libuv exit-crash directly via sh -e .husky/commit-msg, confirmed the || true fix yields exit 0 with the Fleet-Worker/Claude-Session trailer correctly stamped and the Strunkian check still running after it; (3) full git commit in this worktree now succeeds end-to-end with hooks firing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol